### PR TITLE
feat: audit grandfathered unresolved task relation targets [ORB-10305]

### DIFF
--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -4,7 +4,9 @@
 //! surfaces with whole-workspace checks: config validity, store database
 //! integrity and schema-ledger version, free disk space on the volume
 //! holding `.orbit`, semantic/graph index staleness, leftover lock files
-//! from crashed holders, and orphaned `running`/`pending` job runs.
+//! from crashed holders, orphaned `running`/`pending` job runs, and task
+//! relation/dependency targets that no longer resolve in the registry
+//! (grandfathered relations that block index rebuilds — ORB-10305).
 //!
 //! Every check degrades rather than errors: subsystems that are absent in a
 //! fresh workspace report [`WorkspaceDoctorStatus::Skipped`], and probe
@@ -94,6 +96,7 @@ impl DoctorCommands for OrbitRuntime {
             doctor_check_graph_index(self),
             doctor_check_stale_locks(self),
             doctor_check_job_runs(self),
+            doctor_check_task_relations(self),
         ])
     }
 
@@ -334,6 +337,58 @@ fn doctor_check_job_runs(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {
         WorkspaceDoctorStatus::Warning,
         segments.join("; "),
     )
+}
+
+/// Task relation/dependency targets that no longer resolve to a registered
+/// task bundle — the "grandfathered" relations that make a generated task
+/// index fail to rebuild against its relation validator, forcing an unbounded
+/// bundle-scan fallback (ORB-10305 / ORB-10246). Scoped to the current
+/// workspace; surfacing them here lets an operator fix or remove the offending
+/// relation before the validator trips over it at rebuild time.
+fn doctor_check_task_relations(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {
+    let workspace_id = match runtime.workspace_id() {
+        Ok(id) => id,
+        Err(error) => {
+            return check(
+                "task-relations",
+                WorkspaceDoctorStatus::Warning,
+                format!("cannot resolve workspace id to audit relations: {error}"),
+            );
+        }
+    };
+    match runtime.audit_dangling_relations(Some(&workspace_id)) {
+        Err(error) => check(
+            "task-relations",
+            WorkspaceDoctorStatus::Warning,
+            format!("cannot audit task relations: {error}"),
+        ),
+        Ok(dangling) if dangling.is_empty() => check(
+            "task-relations",
+            WorkspaceDoctorStatus::Ok,
+            "no unresolved relation/dependency targets".to_string(),
+        ),
+        Ok(dangling) => {
+            let detail = dangling
+                .iter()
+                .map(|target| {
+                    format!(
+                        "{} ({}) -> {}",
+                        target.source_task_id, target.relation_type, target.target_task_id
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("; ");
+            check(
+                "task-relations",
+                WorkspaceDoctorStatus::Warning,
+                format!(
+                    "{} unresolved relation/dependency target(s) will block index rebuild \
+                     until fixed or removed: {detail}",
+                    dangling.len()
+                ),
+            )
+        }
+    }
 }
 
 /// Free/total space thresholds for the volume containing `path`.

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -33,7 +33,7 @@ fn healthy_fresh_workspace_has_no_failures() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     let results = runtime.doctor_workspace().expect("doctor");
 
-    assert_eq!(results.len(), 7, "one row per check: {results:?}");
+    assert_eq!(results.len(), 8, "one row per check: {results:?}");
     assert!(
         results
             .iter()
@@ -63,6 +63,11 @@ fn healthy_fresh_workspace_has_no_failures() {
     );
     assert_eq!(
         status_of(&results, "job-runs").status,
+        WorkspaceDoctorStatus::Ok
+    );
+    // No tasks yet → no unresolved relation/dependency targets.
+    assert_eq!(
+        status_of(&results, "task-relations").status,
         WorkspaceDoctorStatus::Ok
     );
 }

--- a/crates/orbit-core/src/command/task_migration.rs
+++ b/crates/orbit-core/src/command/task_migration.rs
@@ -20,6 +20,7 @@ use crate::OrbitRuntime;
 // Re-export the engine's public types so `orbit-cli` (which depends on
 // orbit-core, not orbit-store) can name them without crossing the crate
 // boundary.
+pub use orbit_store::sqlite::task_registry::DanglingRelationTarget;
 pub use orbit_store::task_migration::{
     ExportOutcome, ExportSelection, ImportAction, ImportConflictPolicy, ImportOutcome,
     ImportedTask, ReindexOutcome,
@@ -71,6 +72,19 @@ impl OrbitRuntime {
         let registry = self.open_task_registry()?;
         let workspace_id = self.resolve_migration_workspace(workspace_id)?;
         reindex_workspace(&registry, &workspace_id)
+    }
+
+    /// Audit task relation/dependency targets that no longer resolve to a
+    /// registered task bundle — the grandfathered relations that make an index
+    /// rebuild fail its validator (ORB-10305). Pass `Some(workspace_id)` to
+    /// scope the sweep to one workspace, or `None` to audit the whole
+    /// coordination registry.
+    pub fn audit_dangling_relations(
+        &self,
+        workspace_id: Option<&str>,
+    ) -> Result<Vec<DanglingRelationTarget>, OrbitError> {
+        let registry = self.open_task_registry()?;
+        registry.dangling_relation_targets(workspace_id)
     }
 }
 

--- a/crates/orbit-store/src/sqlite/task_registry/mod.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/mod.rs
@@ -25,9 +25,9 @@ const REGISTRY_SCHEMA_VERSION: u32 = 4;
 pub use store::TaskRegistryStore;
 pub(crate) use store::parse_orb_task_number;
 pub use types::{
-    AllocatorSeedOutcome, BindWorkspaceParams, ProjectionRebuildResult, RegisterWorkspaceParams,
-    TaskBundleBinding, TaskIndexFilter, WorkspaceBinding, WorkspaceCheckoutBinding,
-    WorkspaceConfig,
+    AllocatorSeedOutcome, BindWorkspaceParams, DanglingRelationTarget, ProjectionRebuildResult,
+    RegisterWorkspaceParams, TaskBundleBinding, TaskIndexFilter, WorkspaceBinding,
+    WorkspaceCheckoutBinding, WorkspaceConfig,
 };
 pub use workspace_config::{
     assign_workspace_id, home_task_workspace_dir, read_workspace_config,

--- a/crates/orbit-store/src/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/store.rs
@@ -20,8 +20,9 @@ use super::schema::{
     apply_schema, assert_registry_user_version, reject_unsupported_registry_schema,
 };
 use super::types::{
-    AllocatorSeedOutcome, BindWorkspaceParams, ProjectionRebuildResult, RegisterWorkspaceParams,
-    TaskBundleBinding, TaskIndexFilter, WorkspaceBinding, WorkspaceCheckoutBinding,
+    AllocatorSeedOutcome, BindWorkspaceParams, DanglingRelationTarget, ProjectionRebuildResult,
+    RegisterWorkspaceParams, TaskBundleBinding, TaskIndexFilter, WorkspaceBinding,
+    WorkspaceCheckoutBinding,
 };
 use super::util::{
     normalize_path, now_string, parse_relation_type_name, path_to_string, relation_type_name,
@@ -580,6 +581,75 @@ impl TaskRegistryStore {
             .lock()
             .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
         validate_relation_targets_exist(&conn, &workspace_id, None, relations)
+    }
+
+    /// Audit the coordination registry for relation edges whose target is a
+    /// valid `ORB-` task id with no registered task bundle — the "grandfathered"
+    /// relations that make [`validate_relation_targets_exist`] reject an index
+    /// rebuild (ORB-10305). Scans indexed relation rows across the whole
+    /// registry, or a single workspace when `workspace_id` is set, so these
+    /// targets can be surfaced (and cleaned) proactively instead of only when a
+    /// rebuild trips over them.
+    ///
+    /// Mirrors the validator's resolution semantics: only `ORB-` targets can be
+    /// unresolved; friction / learning / ADR targets that `produces`/`resolves`
+    /// edges legitimately allow to dangle are excluded.
+    pub fn dangling_relation_targets(
+        &self,
+        workspace_id: Option<&str>,
+    ) -> Result<Vec<DanglingRelationTarget>, OrbitError> {
+        let workspace_id = workspace_id.map(validate_workspace_id).transpose()?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+
+        let mut sql = String::from(
+            "SELECT r.workspace_id, r.source_task_id, r.relation_type, r.target_task_id
+             FROM task_bundle_relations r
+             LEFT JOIN task_bundle_bindings b ON b.task_id = r.target_task_id
+             WHERE b.task_id IS NULL",
+        );
+        let mut values: Vec<String> = Vec::new();
+        if let Some(workspace_id) = &workspace_id {
+            sql.push_str(" AND r.workspace_id = ?1");
+            values.push(workspace_id.clone());
+        }
+        sql.push_str(
+            " ORDER BY r.workspace_id, r.source_task_id, r.relation_type, r.target_task_id",
+        );
+
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let rows = stmt
+            .query_map(params_from_iter(values.iter()), |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                ))
+            })
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        let mut dangling = Vec::new();
+        for row in rows {
+            let (workspace_id, source_task_id, relation_type, target_task_id) =
+                row.map_err(|e| OrbitError::Store(e.to_string()))?;
+            // The validator only rejects `ORB-` targets; non-`ORB-` targets
+            // (friction / learning / ADR) are allowed to dangle, so skip them.
+            if !is_valid_orb_task_id(&target_task_id) {
+                continue;
+            }
+            dangling.push(DanglingRelationTarget {
+                workspace_id,
+                source_task_id,
+                relation_type,
+                target_task_id,
+            });
+        }
+        Ok(dangling)
     }
 
     pub fn indexed_task_ids_filtered(

--- a/crates/orbit-store/src/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/tests/mod.rs
@@ -598,6 +598,176 @@ fn checkoutless_workspaces_coordinate_cross_workspace_relations_without_paths() 
 }
 
 #[test]
+fn dangling_relation_targets_reports_only_grandfathered_orb_targets() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let workspace = bind(&store, temp.path());
+
+    // A resolvable target and the source both exist in the registry.
+    let target_id = store
+        .allocate_task_id(&workspace.workspace_id)
+        .expect("allocate target");
+    let source_id = store
+        .allocate_task_id(&workspace.workspace_id)
+        .expect("allocate source");
+    for task_id in [target_id.as_str(), source_id.as_str()] {
+        let path = store
+            .canonical_task_bundle_path(&workspace.workspace_id, task_id)
+            .expect("canonical bundle path");
+        fs::create_dir_all(&path).expect("create canonical bundle");
+        store
+            .register_task_bundle(task_id, &workspace.workspace_id, &path)
+            .expect("register bundle");
+    }
+    store
+        .replace_task_index(
+            &workspace.workspace_id,
+            &envelope(&target_id, TaskStatus::Done, Vec::new(), Vec::new()),
+        )
+        .expect("index target");
+    // Source carries a resolvable ORB relation plus a non-ORB `resolves`
+    // target; the audit must flag neither.
+    store
+        .replace_task_index(
+            &workspace.workspace_id,
+            &envelope(
+                &source_id,
+                TaskStatus::Backlog,
+                Vec::new(),
+                vec![
+                    TaskRelation {
+                        relation_type: TaskRelationType::RelatedTo,
+                        target: target_id.clone(),
+                    },
+                    TaskRelation {
+                        relation_type: TaskRelationType::Resolves,
+                        target: "F2026-05-001".into(),
+                    },
+                ],
+            ),
+        )
+        .expect("index source relations");
+
+    assert!(
+        store
+            .dangling_relation_targets(None)
+            .expect("audit clean")
+            .is_empty(),
+        "resolvable + non-ORB targets must not be flagged"
+    );
+
+    // Grandfather a dangling ORB target. The public API forbids adding one (the
+    // validator rejects it at index time), so these only exist as legacy rows —
+    // inject one directly to reproduce that state.
+    let missing_target = "ORB-09999";
+    {
+        let conn = store.conn.lock().expect("lock registry");
+        conn.execute(
+            "INSERT INTO task_bundle_relations(
+                source_task_id, workspace_id, relation_type, target_task_id
+            ) VALUES (?1, ?2, ?3, ?4)",
+            params![
+                source_id,
+                workspace.workspace_id,
+                "related_to",
+                missing_target
+            ],
+        )
+        .expect("seed grandfathered relation");
+    }
+
+    let dangling = store
+        .dangling_relation_targets(None)
+        .expect("audit dangling");
+    assert_eq!(
+        dangling.len(),
+        1,
+        "only the missing ORB target dangles: {dangling:?}"
+    );
+    assert_eq!(dangling[0].source_task_id, source_id);
+    assert_eq!(dangling[0].target_task_id, missing_target);
+    assert_eq!(dangling[0].relation_type, "related_to");
+    assert_eq!(dangling[0].workspace_id, workspace.workspace_id);
+    assert_eq!(
+        store
+            .dangling_relation_targets(Some(&workspace.workspace_id))
+            .expect("scoped audit")
+            .len(),
+        1
+    );
+
+    // A second workspace with its own grandfathered target: the unscoped audit
+    // spans both, each scoped audit sees exactly its own.
+    let repo_two = temp.path().join("repo-two");
+    let orbit_two = repo_two.join(".orbit");
+    fs::create_dir_all(&orbit_two).expect("create second orbit dir");
+    let workspace_two = store
+        .bind_workspace(BindWorkspaceParams {
+            workspace_id: Some("orbit-two-654321".into()),
+            slug: "Orbit Two".into(),
+            repo_root: repo_two.clone(),
+            workspace_path: repo_two.clone(),
+            orbit_dir: orbit_two,
+            repo_fingerprint: None,
+        })
+        .expect("bind second workspace");
+    let source_two = store
+        .allocate_task_id(&workspace_two.workspace_id)
+        .expect("allocate second source");
+    let path_two = store
+        .canonical_task_bundle_path(&workspace_two.workspace_id, &source_two)
+        .expect("second canonical path");
+    fs::create_dir_all(&path_two).expect("create second bundle");
+    store
+        .register_task_bundle(&source_two, &workspace_two.workspace_id, &path_two)
+        .expect("register second source");
+    store
+        .replace_task_index(
+            &workspace_two.workspace_id,
+            &envelope(&source_two, TaskStatus::Backlog, Vec::new(), Vec::new()),
+        )
+        .expect("index second source");
+    {
+        let conn = store.conn.lock().expect("lock registry");
+        conn.execute(
+            "INSERT INTO task_bundle_relations(
+                source_task_id, workspace_id, relation_type, target_task_id
+            ) VALUES (?1, ?2, ?3, ?4)",
+            params![
+                source_two,
+                workspace_two.workspace_id,
+                "blocked_by",
+                "ORB-08888"
+            ],
+        )
+        .expect("seed second grandfathered relation");
+    }
+
+    assert_eq!(
+        store
+            .dangling_relation_targets(None)
+            .expect("audit both")
+            .len(),
+        2,
+        "unscoped audit spans workspaces"
+    );
+    assert_eq!(
+        store
+            .dangling_relation_targets(Some(&workspace_two.workspace_id))
+            .expect("scoped to second")
+            .len(),
+        1
+    );
+    assert_eq!(
+        store
+            .dangling_relation_targets(Some(&workspace.workspace_id))
+            .expect("scoped to first")
+            .len(),
+        1
+    );
+}
+
+#[test]
 fn allocator_reports_exhaustion() {
     let temp = TempDir::new().expect("tempdir");
     let store = store(&temp);

--- a/crates/orbit-store/src/sqlite/task_registry/types.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/types.rs
@@ -64,6 +64,26 @@ pub struct TaskIndexFilter {
     pub tags: Vec<String>,
 }
 
+/// A relation edge whose target is a valid `ORB-` task id that does not
+/// resolve to any registered task bundle in the coordination registry — the
+/// exact condition
+/// [`validate_relation_targets_exist`](crate::sqlite::task_registry::TaskRegistryStore)
+/// rejects at index-rebuild time. These are the "grandfathered" relations that
+/// make an index rebuild fail its validator and fall back to a full bundle
+/// scan (see ORB-10305 / ORB-10246).
+///
+/// `relation_type` carries the canonical snake_case name as stored in the
+/// registry (`related_to`, `blocked_by`, …); non-`ORB-` targets (friction /
+/// learning / ADR ids that `produces`/`resolves` edges legitimately allow to
+/// dangle) are never reported here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DanglingRelationTarget {
+    pub workspace_id: String,
+    pub source_task_id: String,
+    pub relation_type: String,
+    pub target_task_id: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProjectionRebuildResult {
     pub projected: usize,


### PR DESCRIPTION
## Task
[ORB-10305] — grandfathered-relation **audit** half. The defensive half (retry-suppression + attributable rebuild warning + hot-loop regression tests) is split into ORB-10307.

## Problem
A task relation/dependency whose target is a valid `ORB-` id but resolves to no registered task (grandfathered — created before the relation validator existed, or orphaned by a target deletion) makes the generated task index fail its rebuild validator on every stale read, falling back to an unbounded bundle scan. In the ORB-10246 incident the warning repeated ~4,817 times and one dashboard request drove ~17,997 bundle assemblies. The validator only discovers these at rebuild time — there was no way to find them proactively.

## Change
A repeatable sweep of the coordination registry that surfaces these targets before a rebuild trips over them.

- **orbit-store** — `TaskRegistryStore::dangling_relation_targets(workspace_id: Option<&str>)`: `task_bundle_relations LEFT JOIN task_bundle_bindings`, keeping only rows whose target has no binding **and** is a valid `ORB-` id (mirrors `validate_relation_targets_exist`; non-`ORB-` friction/learning/ADR targets that `produces`/`resolves` edges legitimately dangle are excluded). The registry opens from `global_root`, so the sweep is inherently cross-workspace; `Some(id)` scopes it. New exported `DanglingRelationTarget` type.
- **orbit-core** — `OrbitRuntime::audit_dangling_relations(...)` facade next to `reindex_tasks`.
- **orbit-cmd** — new `orbit doctor` **`task-relations`** check (scoped to the current workspace): `Ok` when clean, `Warning` naming each `source (relation_type) -> target`.

## Validation
- `cargo test -p orbit-store task_registry` (29 pass, incl. new `dangling_relation_targets_reports_only_grandfathered_orb_targets`), `cargo test -p orbit-cmd doctor` (12 pass), `cargo build -p orbit-cli`, `make ci-fast` green, fmt/clippy clean on touched crates.
- **Read-only run of the exact audit SQL against the live registry** surfaced precisely the reported instance: `bridge-c02d47: ORB-10259 (related_to) -> ORB-99999`. Of 43 no-binding candidate rows, only that 1 is a valid ORB target — the other 42 are non-ORB targets correctly excluded, validating the filter on real data. That relation has since been cleared (ORB-10259 is a rejected scratch task; `ORB-99999` was a deliberate invalid-target fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
