### PR TITLE
Perform QA validation

### DIFF
--- a/.orbit/learnings/L-0097/learning.yaml
+++ b/.orbit/learnings/L-0097/learning.yaml
@@ -1,0 +1,32 @@
+schema_version: 1
+id: L-0097
+status: active
+scope:
+  paths: []
+  tags:
+  - qa-sweep
+  - task-lifecycle
+  - cli
+summary: Default `orbit task list` (incl. `--tag`) hides proposed-status tasks; a tag/dedup check must add `--status proposed` (or query all statuses) before concluding a tag didn't persist or a task doesn't exist.
+body: |-
+  ## Gotcha
+
+  `orbit task list` and `orbit task list --tag <tag>` default to the *open/active* status set and **exclude** `proposed` tasks. On a store with 27 proposed tasks, plain `orbit task list` showed zero of them.
+
+  ## Why it bites (and how it wasted ~10 min during a qa-sweep)
+
+  A freshly filed task lands in `proposed`. Right after creating a `proposed` task via `orbit.task.add` + tagging it, `orbit task list --tag <tag>` did NOT show it, which looked exactly like a **tag-persistence bug** — reinforced because `orbit.task.show` returns a summary subset that omits `tags` entirely, so `show` couldn't confirm the tag either. The tag was in fact correctly written to the durable bundle (`.orbit/tasks/<ID>/task.yaml` had `tags: [qa-sweep]`); the task was simply filtered out by status. Confirming with `orbit task list --tag <tag> --status proposed` returned it immediately.
+
+  ## Guardrail
+
+  - When verifying that a tag/field persisted, check the durable bundle file or use `--status proposed` — do NOT infer 'not persisted' from an unfiltered `task list`.
+  - The qa-sweep dedup step ('search open Orbit tasks tagged qa-sweep' before filing) is directly exposed: an unfiltered/default `task list --tag qa-sweep` will MISS proposed qa-sweep tasks and can cause duplicate filings. Query proposed status too when deduping against previously-filed sweep tasks.
+  - `orbit.task.show` JSON is a summary view (id, title, status, type, priority, deps, timestamps) and does not carry tags/description/acceptance_criteria; don't use it to verify those fields.
+evidence:
+- kind: task
+  reference: ORB-10250
+- kind: task
+  reference: ORB-10308
+created_at: 2026-07-18T20:42:10.954665843Z
+updated_at: 2026-07-18T20:42:10.954665843Z
+created_by: claude


### PR DESCRIPTION
## Task

[ORB-10250](https://orbit-cli.com/tasks/ORB-10250) — Perform QA validation

### Description

Identify recent changes in this workspace and validate them hands-on. Build
and run the changed software, then exercise the affected CLI, API, and
feature paths as a user would; do not treat re-running the existing test
suite as sufficient validation.

Before filing anything, search open Orbit tasks tagged `qa-sweep`. For each
real issue that is not already filed, create an Orbit task yourself through
the Orbit MCP tools or the equivalent `orbit tool run orbit.task.add`
command. Give it severity-appropriate priority, tag it `qa-sweep`, and put
the relevant commits, observed evidence, and exact reproduction steps in
its description. Skip duplicates. Your narrative output is advisory; the
tasks you create are the durable side-effect channel.


### Acceptance Criteria

- Recent changes were exercised through their real user-facing paths.
- Real, non-duplicate issues were filed as Orbit tasks with evidence and reproduction steps.

## Execution Summary

<details>
<summary>Click to expand</summary>

QA sweep of recent Orbit changes (ORB-10267 registry admin, ORB-10297 ADR federation, ORB-10302 orbit-registry extraction, ORB-10305 relation-target audit, ORB-10306 worktree integrity recovery) on agent-main @ a3ff7b29. Built the orbit binary clean (`cargo build --bin orbit`, 52s) and exercised the changed user-facing paths hands-on rather than re-running the suite.

HEALTHY: `orbit doctor` incl. the new `task-relations` check (table + --json well-formed, exits 0 on warnings, 1 on failures); ADR federation tool surface `orbit.adr.{show,add,update,supersede}` returns full body + artifact_origin and clean typed error codes (adr_not_found, adr_invalid_transition, invalid_input for missing/empty fields); task relation-target validation (ORB-10305) correctly rejects unresolved targets with 'does not resolve in the coordination registry'; post-refactor read paths (search --hybrid, task/learning/friction list) all work. `orbit host list` refusing on a standalone machine is intentional v1 hub-local gating, not a defect.

FILED 1 real issue: ORB-10308 (priority low, type bug, tag qa-sweep) — `orbit workspace list` renders a ragged table because the ID column is `{:<12}` while real workspace IDs are >=12 chars (ws_astrolabe=12, ws_constellation=16), overflowing the field and shifting STATUS/SHIP MODE/OWNER/ROLE/ROOT out of alignment. `{:<N}` pads to a minimum and never truncates; the OWNER/ROLE columns added by ORB-10267 made it prominent. Root cause: format_workspace_list in crates/orbit-cli/src/command/workspace/list.rs. No duplicate qa-sweep task existed.

INVESTIGATED-then-cleared a false alarm: a freshly filed proposed task did not appear under `orbit task list --tag qa-sweep`, which looked like a tag-persistence bug. Verified the tag WAS durably written (.orbit/tasks/ORB-10308/task.yaml: tags:[qa-sweep]); the cause is that default `task list` excludes proposed-status tasks (0 of 27 shown) — `--status proposed` returns it. Recorded as learning L-0097 (guardrail for the qa-sweep dedup step + note that orbit.task.show omits tags). No code change; this is a no-diff-expected task and was not moved to review.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10250-6a5be2f9`
- Behind base: 0
- Ahead of base: 1