### PR TITLE
Start MCP anywhere with an exact-checkout local broker

### DIFF
--- a/.orbit/learnings/L-0098/learning.yaml
+++ b/.orbit/learnings/L-0098/learning.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+id: L-0098
+status: active
+scope:
+  paths:
+  - crates/orbit-cli/src/command/mcp/**
+  - crates/orbit-cli/src/command/workspace/**
+  - crates/orbit-store/src/sqlite/task_registry/**
+  tags:
+  - workspace-registry
+  - mcp-bridge
+summary: Treat host-registry checkout IDs and task-registry config.yaml IDs as distinct legacy-compatible authorities until an explicit migration unifies them
+body: Existing installations can have a host-registry logical ID such as ws_orbit while the same checkout .orbit/config.yaml carries a task-registry ID such as orbit-5c61b3. Broker preflight must validate the checkout relationship without assuming these strings are equal, and runtime/audit cache identity must preserve the config.yaml ID. Fresh workspace initialization may converge on the host-registry ID, but compatibility code must remain until a coordinated task-bundle and registry migration is specified.
+evidence:
+- kind: task
+  reference: ORB-10262
+created_at: 2026-07-18T21:29:25.461396321Z
+updated_at: 2026-07-18T21:29:25.461396321Z
+created_by: codex
+priority: 180

--- a/crates/orbit-cli/src/command/mcp/command.rs
+++ b/crates/orbit-cli/src/command/mcp/command.rs
@@ -10,7 +10,7 @@ use orbit_mcp::McpHost;
 
 use crate::command::Execute;
 
-use super::host::{EmptyMcpHost, RuntimeMcpHost};
+use super::host::BrokerMcpHost;
 use super::setup::{InitArgs, RemoveArgs};
 
 #[derive(Args)]
@@ -60,30 +60,22 @@ pub struct ServeArgs {}
 
 impl ServeArgs {
     pub fn execute_without_runtime(self, root_override: Option<&Path>) -> Result<(), OrbitError> {
-        let (host, workspace_id): (Arc<dyn McpHost>, Option<String>) =
-            match OrbitRuntime::try_initialize_existing(root_override)? {
-                Some(runtime) => {
-                    let workspace_id = runtime.workspace_id()?;
-                    (Arc::new(RuntimeMcpHost::new(runtime)), Some(workspace_id))
-                }
-                None => {
-                    let cwd = std::env::current_dir()
-                        .map(|p| p.display().to_string())
-                        .unwrap_or_else(|_| "<unknown>".to_string());
-                    eprintln!(
-                        "orbit mcp serve: no initialized Orbit workspace discovered from {cwd}; serving empty tool surface"
-                    );
-                    (Arc::new(EmptyMcpHost), None)
-                }
-            };
+        if root_override.is_some() {
+            return Err(OrbitError::InvalidInput(
+                "orbit mcp serve does not accept a workspace root override; select a workspace per initialize or tool call"
+                    .to_string(),
+            ));
+        }
+        let global_root = resolve_global_root()?;
+        let host: Arc<dyn McpHost> = Arc::new(BrokerMcpHost::new(global_root.clone()));
 
-        let (machine_id, host_id) = match inspect_host_identity(&resolve_global_root()?)? {
+        let (machine_id, host_id) = match inspect_host_identity(&global_root)? {
             HostIdentityState::Present(identity) => {
                 (Some(identity.machine_id), Some(identity.host_id))
             }
             HostIdentityState::Legacy { .. } | HostIdentityState::Absent => (None, None),
         };
-        let trusted_context = ToolSessionContext::trusted_local(workspace_id, machine_id, host_id);
+        let trusted_context = ToolSessionContext::trusted_local(None, machine_id, host_id);
 
         let tokio_runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()

--- a/crates/orbit-cli/src/command/mcp/host.rs
+++ b/crates/orbit-cli/src/command/mcp/host.rs
@@ -24,6 +24,7 @@ use orbit_core::command::tool::{
     ToolEntryPoint, audit_role_label_for_entry_point, trusted_mcp_audit_context,
 };
 use orbit_core::routines::{HostIdentityState, HostMode, inspect_host_identity};
+use orbit_core::runtime::HubCoordinationExecutor;
 use orbit_core::{
     AuditEventInsertParams, NotFoundKind, OrbitError, OrbitRuntime, redact_sensitive_env_text,
 };
@@ -93,6 +94,7 @@ struct RuntimeCacheKey {
 
 #[derive(Debug, Clone)]
 struct ExactCheckoutBinding {
+    logical_workspace_id: String,
     key: RuntimeCacheKey,
     role: WorkspaceCheckoutRole,
     owner_machine_id: Option<String>,
@@ -217,7 +219,7 @@ impl BrokerMcpHost {
         let path = Path::new(selector);
         if path.is_absolute() {
             let binding = self.resolve_exact_checkout(path)?;
-            return Ok((binding.key.workspace_id.clone(), Some(binding)));
+            return Ok((binding.logical_workspace_id.clone(), Some(binding)));
         }
         if selector.contains('/') || selector == "." || selector == ".." {
             return Err(OrbitError::InvalidInput(format!(
@@ -239,7 +241,7 @@ impl BrokerMcpHost {
                 };
                 if identity.workspace_id == selector {
                     let binding = self.resolve_exact_checkout(&checkout.repo_root)?;
-                    return Ok((binding.key.workspace_id.clone(), Some(binding)));
+                    return Ok((binding.logical_workspace_id.clone(), Some(binding)));
                 }
             }
         }
@@ -263,7 +265,7 @@ impl BrokerMcpHost {
             .find(|checkout| checkout.workspace_id == workspace.id)
             .ok_or_else(|| self.local_checkout_unavailable(&workspace.id))?;
         let binding = self.resolve_exact_checkout(&checkout.repo_root)?;
-        Ok((binding.key.workspace_id.clone(), Some(binding)))
+        Ok((binding.logical_workspace_id.clone(), Some(binding)))
     }
 
     fn local_checkout_unavailable(&self, workspace_id: &str) -> OrbitError {
@@ -363,6 +365,7 @@ impl BrokerMcpHost {
             )));
         }
         Ok(ExactCheckoutBinding {
+            logical_workspace_id: workspace.id.clone(),
             key: RuntimeCacheKey {
                 workspace_id: identity.workspace_id,
                 repo_root: repo_root.clone(),
@@ -461,6 +464,50 @@ impl BrokerMcpHost {
         }
     }
 
+    fn legacy_friction_root(
+        &self,
+        workspace_id: &str,
+        binding: Option<&ExactCheckoutBinding>,
+    ) -> Option<PathBuf> {
+        if let Some(binding) = binding {
+            return Some(binding.key.shared_root.join("frictions"));
+        }
+        let registry_path = orbit_core::workspace_registry::registry_path_for(&self.global_root);
+        let registry = orbit_core::workspace_registry::load_registry_from(&registry_path).ok()?;
+        registry
+            .checkouts
+            .iter()
+            .find(|checkout| checkout.workspace_id == workspace_id)
+            .map(|checkout| checkout.orbit_dir.join("frictions"))
+    }
+
+    fn record_coordination_outcome(
+        &self,
+        name: &str,
+        context: &ToolSessionContext,
+        result: &Result<Value, OrbitError>,
+    ) {
+        let success_placeholder = OrbitError::Execution(String::new());
+        let error = result.as_ref().err().unwrap_or(&success_placeholder);
+        let mut params = mcp_preflight_failure_params(name, context, error);
+        match result {
+            Ok(_) => {
+                params.status = AuditEventStatus::Success;
+                params.exit_code = 0;
+                params.error_message = None;
+            }
+            Err(error) => {
+                params.status = AuditEventStatus::Failure;
+                params.error_message = Some(redact_sensitive_env_text(&error.to_string()));
+            }
+        }
+        if let Err(error) =
+            orbit_core::host_registry::record_global_audit_event_at(&self.global_root, &params)
+        {
+            tracing::warn!(tool = name, error = %error, "failed to persist global MCP coordination audit");
+        }
+    }
+
     fn resolved_call(
         &self,
         name: &str,
@@ -475,7 +522,9 @@ impl BrokerMcpHost {
             return Err(error);
         }
         if definition.policy.scope() == McpToolScope::Global {
-            return self.global_call(name);
+            let result = self.global_call(name);
+            self.record_coordination_outcome(name, &context, &result);
+            return result;
         }
 
         let selector = match Self::selector(&input, &context) {
@@ -488,9 +537,15 @@ impl BrokerMcpHost {
                 return Err(error);
             }
         };
-        let require_local = definition.policy.placement() != McpToolPlacement::Hub;
-        let (mut workspace_id, mut binding) = match self.resolve_workspace(selector, require_local)
-        {
+        let with_context = name == "orbit.task.show"
+            && input
+                .get("with_context")
+                .or_else(|| input.get("withContext"))
+                .or_else(|| input.get("with-context"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+        let require_local = definition.policy.placement() != McpToolPlacement::Hub || with_context;
+        let (workspace_id, binding) = match self.resolve_workspace(selector, require_local) {
             Ok(resolved) => resolved,
             Err(error) => {
                 self.record_preflight_denial(name, &input, &context, &error);
@@ -498,37 +553,6 @@ impl BrokerMcpHost {
             }
         };
 
-        // The current local hub executor still uses a runtime for hub-domain
-        // calls. Resolve an exact checkout only on hosts where the call may
-        // safely short-circuit locally; checkoutless hub execution is handled
-        // by the coordination executor as its individual tool families move
-        // off OrbitRuntime.
-        if binding.is_none() {
-            let identity = match inspect_host_identity(&self.global_root) {
-                Ok(identity) => identity,
-                Err(error) => {
-                    self.record_preflight_denial(name, &input, &context, &error);
-                    return Err(error);
-                }
-            };
-            let mode = match identity {
-                HostIdentityState::Present(identity) => identity.mode,
-                HostIdentityState::Legacy { .. } | HostIdentityState::Absent => {
-                    HostMode::Standalone
-                }
-            };
-            if mode != HostMode::Spoke {
-                let resolved = match self.resolve_workspace(&workspace_id, true) {
-                    Ok(resolved) => resolved,
-                    Err(error) => {
-                        self.record_preflight_denial(name, &input, &context, &error);
-                        return Err(error);
-                    }
-                };
-                workspace_id = resolved.0;
-                binding = resolved.1;
-            }
-        }
         if let Err(error) = self.preflight_placement(
             definition.policy.placement(),
             &workspace_id,
@@ -536,6 +560,20 @@ impl BrokerMcpHost {
         ) {
             self.record_preflight_denial(name, &input, &context, &error);
             return Err(error);
+        }
+        if definition.policy.placement() == McpToolPlacement::Hub && !with_context {
+            context.workspace_id = Some(workspace_id.clone());
+            context.workspace = Some(workspace_id.clone());
+            if let Some(object) = input.as_object_mut()
+                && object.contains_key("workspace")
+            {
+                object.insert("workspace".to_string(), Value::String(workspace_id.clone()));
+            }
+            let legacy_root = self.legacy_friction_root(&workspace_id, binding.as_ref());
+            let result = HubCoordinationExecutor::new(&self.global_root, workspace_id, legacy_root)
+                .and_then(|executor| executor.execute_tool(name, input, context.clone()));
+            self.record_coordination_outcome(name, &context, &result);
+            return result;
         }
         let binding = match binding {
             Some(binding) => binding,

--- a/crates/orbit-cli/src/command/mcp/host.rs
+++ b/crates/orbit-cli/src/command/mcp/host.rs
@@ -9,20 +9,26 @@
 //! that boundary; registry preflight failures are recorded explicitly before
 //! runtime dispatch. Either rejection path produces a failure-status row.
 
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Mutex;
 use std::time::Instant;
 
 use orbit_common::types::{
-    AuditEventStatus, LearningInjectionState, McpCapability, McpToolDefinition, McpToolPolicyError,
-    McpTransport, ToolSessionContext, audit_execution_id, validate_mcp_tool_definitions,
+    AuditEventStatus, McpToolDefinition, McpToolPlacement, McpToolPolicyError, McpToolScope,
+    McpTransport, ToolSessionContext, WorkspaceCheckoutRole, WorkspaceStatus, audit_execution_id,
+    validate_mcp_tool_definitions,
 };
 use orbit_core::command::tool::{
     ToolEntryPoint, audit_role_label_for_entry_point, trusted_mcp_audit_context,
 };
+use orbit_core::routines::{HostIdentityState, HostMode, inspect_host_identity};
 use orbit_core::{
-    AuditEventInsertParams, LearningSearchParams, NotFoundKind, OrbitError, OrbitRuntime,
-    redact_sensitive_env_text,
+    AuditEventInsertParams, NotFoundKind, OrbitError, OrbitRuntime, redact_sensitive_env_text,
 };
 use orbit_mcp::McpHost;
+use serde::Deserialize;
 use serde_json::{Value, json};
 
 pub(crate) const ORBIT_MCP_SERVER_ID: &str = "orbit";
@@ -54,7 +60,7 @@ pub(crate) fn is_mcp_tool_exposed(name: &str) -> bool {
     })
 }
 
-fn ensure_mcp_tool_exposed(name: &str) -> Result<(), OrbitError> {
+pub(super) fn ensure_mcp_tool_exposed(name: &str) -> Result<(), OrbitError> {
     if is_mcp_tool_exposed(name) {
         Ok(())
     } else {
@@ -62,12 +68,11 @@ fn ensure_mcp_tool_exposed(name: &str) -> Result<(), OrbitError> {
     }
 }
 
-fn normalize_trusted_call_context(mut context: ToolSessionContext) -> ToolSessionContext {
+pub(super) fn normalize_trusted_call_context(
+    mut context: ToolSessionContext,
+) -> ToolSessionContext {
     if context.transport.is_none() {
         context.transport = Some(McpTransport::Local);
-    }
-    if context.effective_capabilities.is_empty() {
-        context.effective_capabilities.insert(McpCapability::Agent);
     }
     if context.origin_session_id.is_none() {
         context.origin_session_id = Some(audit_execution_id("mcp-session"));
@@ -78,21 +83,504 @@ fn normalize_trusted_call_context(mut context: ToolSessionContext) -> ToolSessio
     context
 }
 
-/// [`McpHost`] impl that forwards every MCP operation through the full
-/// [`OrbitRuntime`] pipeline.
-pub(super) struct RuntimeMcpHost {
-    pub(super) runtime: OrbitRuntime,
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct RuntimeCacheKey {
+    workspace_id: String,
+    repo_root: PathBuf,
+    shared_root: PathBuf,
+    local_root: PathBuf,
 }
 
-impl RuntimeMcpHost {
-    pub(super) fn new(runtime: OrbitRuntime) -> Self {
-        Self { runtime }
+#[derive(Debug, Clone)]
+struct ExactCheckoutBinding {
+    key: RuntimeCacheKey,
+    role: WorkspaceCheckoutRole,
+    owner_machine_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WorkspaceIdentityDocument {
+    schema_version: u32,
+    workspace_id: String,
+}
+
+/// Checkout-independent local MCP broker.
+///
+/// Listing is sourced exclusively from the canonical schema-plus-policy
+/// registry. A workspace runtime is constructed only after a call has passed
+/// capability, workspace, binding, role, owner, and placement preflight. Cache
+/// entries are keyed by the exact selected checkout and are never authority:
+/// every call re-runs resolution before looking up the cached runtime.
+pub(super) struct BrokerMcpHost {
+    global_root: PathBuf,
+    runtimes: Mutex<BTreeMap<RuntimeCacheKey, OrbitRuntime>>,
+}
+
+impl BrokerMcpHost {
+    pub(super) fn new(global_root: PathBuf) -> Self {
+        Self {
+            global_root,
+            runtimes: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    fn definition(&self, name: &str) -> Result<McpToolDefinition, OrbitError> {
+        canonical_mcp_tool_definitions()
+            .map_err(|error| OrbitError::InvalidInput(error.to_string()))?
+            .into_iter()
+            .find(|definition| definition.schema.name == name)
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Tool, name.to_string()))
+    }
+
+    fn authorize_capability(
+        &self,
+        definition: &McpToolDefinition,
+        context: &ToolSessionContext,
+    ) -> Result<(), OrbitError> {
+        if definition
+            .policy
+            .allowed_capabilities()
+            .iter()
+            .any(|capability| context.effective_capabilities.contains(capability))
+        {
+            return Ok(());
+        }
+        let required = definition
+            .policy
+            .allowed_capabilities()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        Err(OrbitError::InvalidInput(format!(
+            "MCP capability denied for tool '{}': the effective session set must contain one of [{required}]",
+            definition.schema.name
+        )))
+    }
+
+    fn record_preflight_denial(
+        &self,
+        name: &str,
+        input: &Value,
+        session_context: &ToolSessionContext,
+        denial: &OrbitError,
+    ) {
+        let mut context = normalize_trusted_call_context(session_context.clone());
+        if let Some((workspace_id, binding)) = Self::selector(input, &context)
+            .and_then(|selector| self.resolve_workspace(selector, true).ok())
+        {
+            context.workspace_id = Some(workspace_id);
+            if let Some(binding) = binding {
+                context.workspace = Some(binding.key.repo_root.to_string_lossy().into_owned());
+            }
+        }
+        let params = mcp_preflight_failure_params(name, &context, denial);
+        if let Err(error) =
+            orbit_core::host_registry::record_global_audit_event_at(&self.global_root, &params)
+        {
+            tracing::warn!(
+                tool = name,
+                error = %error,
+                "failed to persist global MCP preflight denial"
+            );
+        }
+    }
+
+    fn selector<'a>(input: &'a Value, context: &'a ToolSessionContext) -> Option<&'a str> {
+        input
+            .get("workspace")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .or_else(|| {
+                context
+                    .workspace
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+            })
+            .or_else(|| {
+                context
+                    .workspace_id
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+            })
+    }
+
+    fn resolve_workspace(
+        &self,
+        selector: &str,
+        require_local: bool,
+    ) -> Result<(String, Option<ExactCheckoutBinding>), OrbitError> {
+        let path = Path::new(selector);
+        if path.is_absolute() {
+            let binding = self.resolve_exact_checkout(path)?;
+            return Ok((binding.key.workspace_id.clone(), Some(binding)));
+        }
+        if selector.contains('/') || selector == "." || selector == ".." {
+            return Err(OrbitError::InvalidInput(format!(
+                "workspace path selector '{selector}' must be absolute; the MCP broker never resolves paths from process cwd"
+            )));
+        }
+
+        let registry_path = orbit_core::workspace_registry::registry_path_for(&self.global_root);
+        let registry = orbit_core::workspace_registry::load_registry_from(&registry_path)?;
+        let workspace = registry
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.id == selector);
+        if workspace.is_none() {
+            for checkout in &registry.checkouts {
+                let identity_path = checkout.orbit_dir.join("config.yaml");
+                let Ok(identity) = read_workspace_identity(&identity_path) else {
+                    continue;
+                };
+                if identity.workspace_id == selector {
+                    let binding = self.resolve_exact_checkout(&checkout.repo_root)?;
+                    return Ok((binding.key.workspace_id.clone(), Some(binding)));
+                }
+            }
+        }
+        let workspace = workspace.ok_or_else(|| {
+                OrbitError::InvalidInput(format!(
+                    "unknown logical workspace ID '{selector}'; pass a registered workspace ID or an absolute local checkout path"
+                ))
+            })?;
+        if workspace.status != WorkspaceStatus::Active {
+            return Err(OrbitError::InvalidInput(format!(
+                "logical workspace ID '{}' is not active",
+                workspace.id
+            )));
+        }
+        if !require_local {
+            return Ok((workspace.id.clone(), None));
+        }
+        let checkout = registry
+            .checkouts
+            .iter()
+            .find(|checkout| checkout.workspace_id == workspace.id)
+            .ok_or_else(|| self.local_checkout_unavailable(&workspace.id))?;
+        let binding = self.resolve_exact_checkout(&checkout.repo_root)?;
+        Ok((binding.key.workspace_id.clone(), Some(binding)))
+    }
+
+    fn local_checkout_unavailable(&self, workspace_id: &str) -> OrbitError {
+        OrbitError::InvalidInput(format!(
+            "workspace '{workspace_id}' has no single validated exact local checkout; provide an absolute checkout path as the workspace selector"
+        ))
+    }
+
+    fn resolve_exact_checkout(&self, selected: &Path) -> Result<ExactCheckoutBinding, OrbitError> {
+        let selected = selected.canonicalize().map_err(|error| {
+            OrbitError::InvalidInput(format!(
+                "workspace path '{}' is unavailable: {error}",
+                selected.display()
+            ))
+        })?;
+        if !selected.is_dir() {
+            return Err(OrbitError::InvalidInput(format!(
+                "workspace path '{}' is not a directory",
+                selected.display()
+            )));
+        }
+        let repo_root = git_path(&selected, "--show-toplevel")?;
+        let common_dir = git_path(&selected, "--git-common-dir")?;
+
+        let registry_path = orbit_core::workspace_registry::registry_path_for(&self.global_root);
+        let registry = orbit_core::workspace_registry::load_registry_from(&registry_path)?;
+        let mut matches = Vec::new();
+        for checkout in &registry.checkouts {
+            let Ok(registered_common) = git_path(&checkout.repo_root, "--git-common-dir") else {
+                continue;
+            };
+            if registered_common == common_dir {
+                matches.push(checkout);
+            }
+        }
+        if matches.len() != 1 {
+            return Err(OrbitError::InvalidInput(format!(
+                "workspace path '{}' does not resolve to exactly one registered local checkout (matched {}); register or repair the checkout binding before retrying",
+                repo_root.display(),
+                matches.len()
+            )));
+        }
+        let checkout = matches[0];
+        let workspace = registry
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.id == checkout.workspace_id)
+            .ok_or_else(|| {
+                OrbitError::InvalidInput(format!(
+                    "checkout '{}' names unknown logical workspace ID '{}'",
+                    checkout.repo_root.display(),
+                    checkout.workspace_id
+                ))
+            })?;
+        if workspace.status != WorkspaceStatus::Active {
+            return Err(OrbitError::InvalidInput(format!(
+                "logical workspace ID '{}' is not active",
+                workspace.id
+            )));
+        }
+        let shared_root = checkout.orbit_dir.canonicalize().map_err(|error| {
+            OrbitError::InvalidInput(format!(
+                "workspace '{}' shared Orbit root '{}' is unavailable: {error}",
+                workspace.id,
+                checkout.orbit_dir.display()
+            ))
+        })?;
+        let identity_path = shared_root.join("config.yaml");
+        let identity = read_workspace_identity(&identity_path).map_err(|error| {
+            OrbitError::InvalidInput(format!(
+                "workspace '{}' requires a valid '{}': {error}",
+                workspace.id,
+                identity_path.display()
+            ))
+        })?;
+        if identity.schema_version != 1 {
+            return Err(OrbitError::InvalidInput(format!(
+                "workspace identity '{}' declares schema_version {}, expected schema_version 1",
+                identity_path.display(),
+                identity.schema_version,
+            )));
+        }
+        // L-0098: legacy host-registry and task-registry IDs may differ for
+        // the same validated checkout until their coordinated migration lands.
+        let role = checkout.role.ok_or_else(|| {
+            OrbitError::InvalidInput(format!(
+                "workspace '{}' local checkout is missing its required owner/replica role",
+                workspace.id
+            ))
+        })?;
+        if role == WorkspaceCheckoutRole::Replica
+            && checkout.owner_machine_id.as_deref() != workspace.owner_machine_id.as_deref()
+        {
+            return Err(OrbitError::InvalidInput(format!(
+                "workspace '{}' replica owner identity drifted between logical and local registry records",
+                workspace.id
+            )));
+        }
+        Ok(ExactCheckoutBinding {
+            key: RuntimeCacheKey {
+                workspace_id: identity.workspace_id,
+                repo_root: repo_root.clone(),
+                shared_root,
+                local_root: repo_root.join(".orbit"),
+            },
+            role,
+            owner_machine_id: workspace.owner_machine_id.clone(),
+        })
+    }
+
+    fn preflight_placement(
+        &self,
+        placement: McpToolPlacement,
+        workspace_id: &str,
+        binding: Option<&ExactCheckoutBinding>,
+    ) -> Result<(), OrbitError> {
+        let identity = inspect_host_identity(&self.global_root)?;
+        let (mode, machine_id) = match identity {
+            HostIdentityState::Present(identity) => (identity.mode, Some(identity.machine_id)),
+            HostIdentityState::Legacy { .. } | HostIdentityState::Absent => {
+                (HostMode::Standalone, None)
+            }
+        };
+        match placement {
+            McpToolPlacement::Hub if mode == HostMode::Spoke => {
+                Err(OrbitError::InvalidInput(format!(
+                    "hub placement for workspace '{workspace_id}' is unavailable from this spoke: no MCP hub transport is configured"
+                )))
+            }
+            McpToolPlacement::Hub => Ok(()),
+            McpToolPlacement::LocalDerived => binding
+                .map(|_| ())
+                .ok_or_else(|| self.local_checkout_unavailable(workspace_id)),
+            McpToolPlacement::Owner => {
+                let binding =
+                    binding.ok_or_else(|| self.local_checkout_unavailable(workspace_id))?;
+                if binding.role == WorkspaceCheckoutRole::Replica {
+                    return Err(OrbitError::InvalidInput(format!(
+                        "workspace '{workspace_id}' is a replica on this machine and may not author owner-placed mutations"
+                    )));
+                }
+                if mode != HostMode::Standalone
+                    && binding.owner_machine_id.as_deref() != machine_id.as_deref()
+                {
+                    return Err(OrbitError::InvalidInput(format!(
+                        "workspace '{workspace_id}' is owned by another machine; current owner state is unavailable locally"
+                    )));
+                }
+                Ok(())
+            }
+            McpToolPlacement::Composite => {
+                let binding =
+                    binding.ok_or_else(|| self.local_checkout_unavailable(workspace_id))?;
+                if mode == HostMode::Spoke || binding.role == WorkspaceCheckoutRole::Replica {
+                    return Err(OrbitError::InvalidInput(format!(
+                        "composite placement for workspace '{workspace_id}' cannot collapse every declared route to one validated standalone or hub-owner checkout"
+                    )));
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn runtime_for(&self, binding: &ExactCheckoutBinding) -> Result<OrbitRuntime, OrbitError> {
+        let mut runtimes = self
+            .runtimes
+            .lock()
+            .map_err(|_| OrbitError::Execution("MCP runtime cache lock poisoned".to_string()))?;
+        if let Some(runtime) = runtimes.get(&binding.key) {
+            return Ok(runtime.clone());
+        }
+        let runtime = OrbitRuntime::from_resolved_roots(
+            &self.global_root,
+            &binding.key.shared_root,
+            &binding.key.local_root,
+        )?;
+        runtimes.insert(binding.key.clone(), runtime.clone());
+        Ok(runtime)
+    }
+
+    fn global_call(&self, name: &str) -> Result<Value, OrbitError> {
+        let snapshot = orbit_core::host_registry::registry_snapshot_at(&self.global_root)?;
+        match name {
+            "orbit.host.list" => Ok(json!({
+                "hub_machine_id": snapshot.hub_machine_id,
+                "registry_revision": snapshot.registry_revision,
+                "hosts": snapshot.hosts,
+            })),
+            "orbit.workspace.list" => Ok(json!({
+                "hub_machine_id": snapshot.hub_machine_id,
+                "registry_revision": snapshot.registry_revision,
+                "workspaces": snapshot.workspaces,
+            })),
+            _ => Err(OrbitError::not_found(NotFoundKind::Tool, name.to_string())),
+        }
+    }
+
+    fn resolved_call(
+        &self,
+        name: &str,
+        mut input: Value,
+        context: ToolSessionContext,
+        in_process: Option<&mut dyn FnMut(Value, ToolSessionContext) -> Result<Value, OrbitError>>,
+    ) -> Result<Value, OrbitError> {
+        let mut context = normalize_trusted_call_context(context);
+        let definition = self.definition(name)?;
+        if let Err(error) = self.authorize_capability(&definition, &context) {
+            self.record_preflight_denial(name, &input, &context, &error);
+            return Err(error);
+        }
+        if definition.policy.scope() == McpToolScope::Global {
+            return self.global_call(name);
+        }
+
+        let selector = match Self::selector(&input, &context) {
+            Some(selector) => selector,
+            None => {
+                let error = OrbitError::InvalidInput(format!(
+                    "tool '{name}' requires a workspace selector; pass a non-empty `workspace` argument or initialize with `_meta.orbit.workspace`"
+                ));
+                self.record_preflight_denial(name, &input, &context, &error);
+                return Err(error);
+            }
+        };
+        let require_local = definition.policy.placement() != McpToolPlacement::Hub;
+        let (mut workspace_id, mut binding) = match self.resolve_workspace(selector, require_local)
+        {
+            Ok(resolved) => resolved,
+            Err(error) => {
+                self.record_preflight_denial(name, &input, &context, &error);
+                return Err(error);
+            }
+        };
+
+        // The current local hub executor still uses a runtime for hub-domain
+        // calls. Resolve an exact checkout only on hosts where the call may
+        // safely short-circuit locally; checkoutless hub execution is handled
+        // by the coordination executor as its individual tool families move
+        // off OrbitRuntime.
+        if binding.is_none() {
+            let identity = match inspect_host_identity(&self.global_root) {
+                Ok(identity) => identity,
+                Err(error) => {
+                    self.record_preflight_denial(name, &input, &context, &error);
+                    return Err(error);
+                }
+            };
+            let mode = match identity {
+                HostIdentityState::Present(identity) => identity.mode,
+                HostIdentityState::Legacy { .. } | HostIdentityState::Absent => {
+                    HostMode::Standalone
+                }
+            };
+            if mode != HostMode::Spoke {
+                let resolved = match self.resolve_workspace(&workspace_id, true) {
+                    Ok(resolved) => resolved,
+                    Err(error) => {
+                        self.record_preflight_denial(name, &input, &context, &error);
+                        return Err(error);
+                    }
+                };
+                workspace_id = resolved.0;
+                binding = resolved.1;
+            }
+        }
+        if let Err(error) = self.preflight_placement(
+            definition.policy.placement(),
+            &workspace_id,
+            binding.as_ref(),
+        ) {
+            self.record_preflight_denial(name, &input, &context, &error);
+            return Err(error);
+        }
+        let binding = match binding {
+            Some(binding) => binding,
+            None => {
+                let error = self.local_checkout_unavailable(&workspace_id);
+                self.record_preflight_denial(name, &input, &context, &error);
+                return Err(error);
+            }
+        };
+        context.workspace_id = Some(workspace_id);
+        context.workspace = Some(binding.key.repo_root.to_string_lossy().into_owned());
+        if let Some(object) = input.as_object_mut()
+            && object.contains_key("workspace")
+        {
+            object.insert(
+                "workspace".to_string(),
+                Value::String(binding.key.repo_root.to_string_lossy().into_owned()),
+            );
+        }
+        let runtime = match self.runtime_for(&binding) {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                self.record_preflight_denial(name, &input, &context, &error);
+                return Err(error);
+            }
+        };
+        match in_process {
+            Some(dispatch) => runtime
+                .execute_in_process_tool_dispatch(
+                    name,
+                    input,
+                    ToolEntryPoint::Mcp,
+                    context.clone(),
+                    |input| dispatch(input, context),
+                )
+                .map(|outcome| outcome.value),
+            None => audited_mcp_call_with_session_context(&runtime, name, input, context),
+        }
     }
 }
 
-impl McpHost for RuntimeMcpHost {
+impl McpHost for BrokerMcpHost {
     fn list_mcp_tool_definitions(&self) -> Result<Vec<McpToolDefinition>, OrbitError> {
-        self.runtime.list_mcp_tool_definitions()
+        canonical_mcp_tool_definitions()
+            .map_err(|error| OrbitError::InvalidInput(error.to_string()))
     }
 
     fn call_tool(
@@ -101,12 +589,22 @@ impl McpHost for RuntimeMcpHost {
         input: Value,
         session_context: ToolSessionContext,
     ) -> Result<Value, OrbitError> {
-        audited_mcp_call_with_session_context(
-            &self.runtime,
-            name,
-            input,
-            normalize_trusted_call_context(session_context),
-        )
+        if let Err(error) = self.definition(name) {
+            self.record_preflight_denial(name, &input, &session_context, &error);
+            return Err(error);
+        }
+        self.resolved_call(name, input, session_context, None)
+    }
+
+    fn reject_tool_call(
+        &self,
+        name: &str,
+        input: &Value,
+        session_context: &ToolSessionContext,
+        denial: OrbitError,
+    ) -> OrbitError {
+        self.record_preflight_denial(name, input, session_context, &denial);
+        denial
     }
 
     fn call_in_process_tool(
@@ -116,63 +614,47 @@ impl McpHost for RuntimeMcpHost {
         session_context: ToolSessionContext,
         dispatch: &mut dyn FnMut(Value, ToolSessionContext) -> Result<Value, OrbitError>,
     ) -> Result<Value, OrbitError> {
-        let session_context = normalize_trusted_call_context(session_context);
-        let dispatch_context = session_context.clone();
-        self.runtime
-            .execute_in_process_tool_dispatch(
-                name,
-                input,
-                ToolEntryPoint::Mcp,
-                session_context,
-                |input| {
-                    ensure_mcp_tool_exposed(name)?;
-                    dispatch(input, dispatch_context)
-                },
-            )
-            .map(|outcome| outcome.value)
+        self.resolved_call(name, input, session_context, Some(dispatch))
     }
+}
 
-    fn learning_candidates_for_path(
-        &self,
-        path: &str,
-        _session_context: ToolSessionContext,
-    ) -> Result<Value, OrbitError> {
-        // L-0043: this is adapter-internal lookup, not a client MCP tool call.
-        let rows = self.runtime.search_learnings(LearningSearchParams {
-            path: Some(path.to_string()),
-            tag: None,
-            query: None,
-            limit: None,
+fn git_path(start: &Path, argument: &str) -> Result<PathBuf, OrbitError> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(start)
+        .args(["rev-parse", "--path-format=absolute", argument])
+        .output()
+        .map_err(|error| {
+            OrbitError::Execution(format!("run git for '{}': {error}", start.display()))
         })?;
-        Ok(Value::Array(
-            rows.into_iter()
-                .map(|row| {
-                    json!({
-                        "id": row.learning.id,
-                        "summary": row.learning.summary,
-                        "priority": row.learning.priority,
-                        "updated_at": row.learning.updated_at.to_rfc3339(),
-                    })
-                })
-                .collect(),
+    if !output.status.success() {
+        return Err(OrbitError::InvalidInput(format!(
+            "workspace path '{}' is not a valid Git checkout: {}",
+            start.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    let raw = String::from_utf8(output.stdout).map_err(|error| {
+        OrbitError::InvalidInput(format!("git returned a non-UTF-8 path: {error}"))
+    })?;
+    let path = PathBuf::from(raw.trim());
+    path.canonicalize().map_err(|error| {
+        OrbitError::InvalidInput(format!(
+            "git resolved '{}' to unavailable path '{}': {error}",
+            start.display(),
+            path.display()
         ))
-    }
+    })
+}
 
-    fn get_session_learning_state(
-        &self,
-        session_id: &str,
-    ) -> Result<Option<LearningInjectionState>, OrbitError> {
-        self.runtime.get_session_learning_state(session_id)
-    }
-
-    fn upsert_session_learning_state(
-        &self,
-        session_id: &str,
-        state: &LearningInjectionState,
-    ) -> Result<(), OrbitError> {
-        self.runtime
-            .upsert_session_learning_state(session_id, state)
-    }
+fn read_workspace_identity(path: &Path) -> Result<WorkspaceIdentityDocument, OrbitError> {
+    let raw = std::fs::read_to_string(path).map_err(|error| OrbitError::Io(error.to_string()))?;
+    serde_yaml::from_str(&raw).map_err(|error| {
+        OrbitError::InvalidInput(format!(
+            "invalid workspace identity '{}': {error}",
+            path.display()
+        ))
+    })
 }
 
 /// Bracket the MCP `tools/call` preflight + dispatch with a single audit
@@ -195,7 +677,7 @@ pub(super) fn audited_mcp_call(
         runtime,
         name,
         input,
-        normalize_trusted_call_context(ToolSessionContext::default()),
+        normalize_trusted_call_context(ToolSessionContext::trusted_local(None, None, None)),
     )
 }
 
@@ -229,6 +711,17 @@ fn record_mcp_preflight_failure(
     session_context: &ToolSessionContext,
     err: &OrbitError,
 ) {
+    let params = mcp_preflight_failure_params(name, session_context, err);
+    if let Err(write_err) = runtime.record_audit_event(&params) {
+        eprintln!("warning: failed to persist MCP preflight audit event: {write_err}");
+    }
+}
+
+fn mcp_preflight_failure_params(
+    name: &str,
+    session_context: &ToolSessionContext,
+    err: &OrbitError,
+) -> AuditEventInsertParams {
     let start = Instant::now();
     let role = audit_role_label_for_entry_point(&Value::Null, None, None, ToolEntryPoint::Mcp);
     let (audit_context, correlation_error) = trusted_mcp_audit_context(session_context);
@@ -237,7 +730,7 @@ fn record_mcp_preflight_failure(
         .map(|path| path.to_string_lossy().into_owned())
         .unwrap_or_else(|_| ".".to_string());
 
-    let params = AuditEventInsertParams {
+    AuditEventInsertParams {
         execution_id: audit_execution_id("exec"),
         command: "tool".to_string(),
         subcommand: Some(ToolEntryPoint::Mcp.audit_subcommand().to_string()),
@@ -275,29 +768,5 @@ fn record_mcp_preflight_failure(
         job_run_id: audit_context.job_run_id,
         activity_id: audit_context.activity_id,
         step_index: audit_context.step_index,
-    };
-
-    if let Err(write_err) = runtime.record_audit_event(&params) {
-        eprintln!("warning: failed to persist MCP preflight audit event: {write_err}");
-    }
-}
-
-/// MCP host returned when no initialized Orbit workspace is discoverable.
-/// Keeps the stdio transport alive so clients see an empty `tools/list`
-/// instead of a connection error.
-pub(super) struct EmptyMcpHost;
-
-impl McpHost for EmptyMcpHost {
-    fn list_mcp_tool_definitions(&self) -> Result<Vec<McpToolDefinition>, OrbitError> {
-        Ok(Vec::new())
-    }
-
-    fn call_tool(
-        &self,
-        name: &str,
-        _input: Value,
-        _session_context: ToolSessionContext,
-    ) -> Result<Value, OrbitError> {
-        Err(OrbitError::not_found(NotFoundKind::Tool, name.to_string()))
     }
 }

--- a/crates/orbit-cli/src/command/mcp/tests/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/tests/mod.rs
@@ -16,9 +16,270 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use super::host::{
-    audited_mcp_call_with_session_context, canonical_mcp_tool_definitions, ensure_mcp_tool_exposed,
-    is_mcp_tool_exposed, normalize_trusted_call_context, safe_mcp_tool_names,
+    BrokerMcpHost, audited_mcp_call_with_session_context, canonical_mcp_tool_definitions,
+    ensure_mcp_tool_exposed, is_mcp_tool_exposed, normalize_trusted_call_context,
+    safe_mcp_tool_names,
 };
+
+#[test]
+fn broker_checkoutless_task_call_uses_stable_id_and_one_trusted_audit() {
+    use chrono::Utc;
+    use orbit_common::types::{AuditEventStatus, Workspace, WorkspaceRegistry, WorkspaceStatus};
+
+    let root = tempfile::tempdir().expect("global root");
+    let workspace = Workspace {
+        id: "ws_checkoutless".to_string(),
+        name: "Checkoutless".to_string(),
+        owner_machine_id: None,
+        git_remote: None,
+        ship_mode: None,
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    orbit_core::workspace_registry::save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![workspace],
+            ..Default::default()
+        },
+        &orbit_core::workspace_registry::registry_path_for(root.path()),
+    )
+    .expect("workspace registry");
+    orbit_core::runtime::HubCoordinationExecutor::register_workspace(
+        root.path(),
+        "ws_checkoutless",
+        "checkoutless",
+    )
+    .expect("task workspace");
+
+    let host = BrokerMcpHost::new(root.path().to_path_buf());
+    let mut context = ToolSessionContext::trusted_local(
+        Some("ws_checkoutless".to_string()),
+        Some("hm_hub".to_string()),
+        Some("hub".to_string()),
+    );
+    context.origin_session_id = Some("mcp-session-checkoutless".to_string());
+    context.mcp_call_id = Some("mcall-checkoutless-add".to_string());
+    let task = host
+        .call_tool(
+            "orbit.task.add",
+            json!({
+                "workspace": "ws_checkoutless",
+                "title": "No checkout",
+                "description": "Coordinate at hub",
+                "model": "codex"
+            }),
+            context,
+        )
+        .expect("checkoutless task add");
+    assert_eq!(task["title"], "No checkout");
+    let id = task["id"].as_str().expect("task id");
+    let mut update_context = ToolSessionContext::trusted_local(
+        Some("ws_checkoutless".to_string()),
+        Some("hm_hub".to_string()),
+        Some("hub".to_string()),
+    );
+    update_context.mcp_call_id = Some("mcall-checkoutless-update".to_string());
+    host.call_tool(
+        "orbit.task.update",
+        json!({"workspace": "ws_checkoutless", "id": id, "description": "Updated at hub", "model": "codex"}),
+        update_context,
+    )
+    .expect("checkoutless task update");
+    let mut show_context = ToolSessionContext::trusted_local(
+        Some("ws_checkoutless".to_string()),
+        Some("hm_hub".to_string()),
+        Some("hub".to_string()),
+    );
+    show_context.mcp_call_id = Some("mcall-checkoutless-show".to_string());
+    let shown = host
+        .call_tool(
+            "orbit.task.show",
+            json!({"workspace": "ws_checkoutless", "id": id}),
+            show_context,
+        )
+        .expect("checkoutless task show");
+    assert_eq!(shown["description"], "Updated at hub");
+    assert!(!root.path().join(".orbit").exists());
+
+    let audit_path =
+        orbit_core::config::resolved_audit_db_path(root.path(), root.path()).expect("audit path");
+    let connection = rusqlite::Connection::open(audit_path).expect("audit store");
+    let rows = connection
+        .query_row(
+            "SELECT COUNT(*), status, workspace_id, transport, mcp_call_id
+             FROM audit_events WHERE tool_name = ?1 AND mcp_call_id = ?2",
+            rusqlite::params!["orbit.task.add", "mcall-checkoutless-add"],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                ))
+            },
+        )
+        .expect("audit row");
+    assert_eq!(rows.0, 1);
+    assert_eq!(rows.1, AuditEventStatus::Success.to_string());
+    assert_eq!(rows.2.as_deref(), Some("ws_checkoutless"));
+    assert_eq!(rows.3.as_deref(), Some("local"));
+    assert_eq!(rows.4.as_deref(), Some("mcall-checkoutless-add"));
+}
+
+#[test]
+fn broker_with_context_requires_local_checkout_before_dispatch() {
+    use chrono::Utc;
+    use orbit_common::types::{Workspace, WorkspaceRegistry, WorkspaceStatus};
+
+    let root = tempfile::tempdir().expect("global root");
+    orbit_core::workspace_registry::save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![Workspace {
+                id: "ws_checkoutless".to_string(),
+                name: "Checkoutless".to_string(),
+                owner_machine_id: None,
+                git_remote: None,
+                ship_mode: None,
+                base_branch: "agent-main".to_string(),
+                status: WorkspaceStatus::Active,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            }],
+            ..Default::default()
+        },
+        &orbit_core::workspace_registry::registry_path_for(root.path()),
+    )
+    .expect("workspace registry");
+    let host = BrokerMcpHost::new(root.path().to_path_buf());
+    let error = host
+        .call_tool(
+            "orbit.task.show",
+            json!({"workspace": "ws_checkoutless", "id": "ORB-00001", "with_context": true}),
+            ToolSessionContext::trusted_local(
+                Some("ws_checkoutless".to_string()),
+                Some("hm_hub".to_string()),
+                Some("hub".to_string()),
+            ),
+        )
+        .expect_err("local-derived enrichment requires checkout");
+    assert!(
+        error
+            .to_string()
+            .contains("no single validated exact local checkout")
+    );
+    assert!(
+        !root
+            .path()
+            .join("tasks/workspaces/ws_checkoutless/ORB-00001")
+            .exists()
+    );
+}
+
+#[test]
+fn broker_spoke_hub_denial_writes_no_local_coordination_state() {
+    use chrono::Utc;
+    use orbit_common::types::{Workspace, WorkspaceRegistry, WorkspaceStatus};
+    use orbit_core::routines::{HostMode, NewHostIdentity, ensure_host_identity};
+
+    let root = tempfile::tempdir().expect("global root");
+    ensure_host_identity(root.path(), || {
+        Ok(NewHostIdentity {
+            host_id: "spoke".to_string(),
+            mode: HostMode::Spoke,
+        })
+    })
+    .expect("spoke identity");
+    orbit_core::workspace_registry::save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![Workspace {
+                id: "ws_remote".to_string(),
+                name: "Remote".to_string(),
+                owner_machine_id: Some("hm_remote_owner".to_string()),
+                git_remote: None,
+                ship_mode: None,
+                base_branch: "agent-main".to_string(),
+                status: WorkspaceStatus::Active,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            }],
+            ..Default::default()
+        },
+        &orbit_core::workspace_registry::registry_path_for(root.path()),
+    )
+    .expect("workspace registry");
+    let host = BrokerMcpHost::new(root.path().to_path_buf());
+    let mut context = ToolSessionContext::trusted_local(
+        Some("ws_remote".to_string()),
+        Some("hm_spoke".to_string()),
+        Some("spoke".to_string()),
+    );
+    context.mcp_call_id = Some("mcall-spoke-denied".to_string());
+    let error = host
+        .call_tool(
+            "orbit.task.add",
+            json!({
+                "workspace": "ws_remote",
+                "title": "Must not land locally",
+                "description": "Denied on spoke",
+                "model": "codex"
+            }),
+            context,
+        )
+        .expect_err("spoke has no hub transport");
+    assert!(error.to_string().contains("no MCP hub transport"));
+    assert!(!root.path().join("tasks").exists());
+    assert!(!root.path().join("frictions").exists());
+}
+
+#[test]
+fn broker_capability_denial_precedes_coordination_store_open() {
+    use chrono::Utc;
+    use orbit_common::types::{McpCapability, Workspace, WorkspaceRegistry, WorkspaceStatus};
+
+    let root = tempfile::tempdir().expect("global root");
+    orbit_core::workspace_registry::save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![Workspace {
+                id: "ws_checkoutless".to_string(),
+                name: "Checkoutless".to_string(),
+                owner_machine_id: None,
+                git_remote: None,
+                ship_mode: None,
+                base_branch: "agent-main".to_string(),
+                status: WorkspaceStatus::Active,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            }],
+            ..Default::default()
+        },
+        &orbit_core::workspace_registry::registry_path_for(root.path()),
+    )
+    .expect("workspace registry");
+    let host = BrokerMcpHost::new(root.path().to_path_buf());
+    let mut context = ToolSessionContext::trusted_local(
+        Some("ws_checkoutless".to_string()),
+        Some("hm_hub".to_string()),
+        Some("hub".to_string()),
+    );
+    context.effective_capabilities = BTreeSet::from([McpCapability::Runner]);
+    let error = host
+        .call_tool(
+            "orbit.task.add",
+            json!({
+                "workspace": "ws_checkoutless",
+                "title": "Denied",
+                "description": "Must not write",
+                "model": "codex"
+            }),
+            context,
+        )
+        .expect_err("runner capability is not task-authority");
+    assert!(error.to_string().contains("MCP capability denied"));
+    assert!(!root.path().join("tasks").exists());
+}
 
 struct RuntimeMcpHost {
     runtime: OrbitRuntime,

--- a/crates/orbit-cli/src/command/mcp/tests/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/tests/mod.rs
@@ -5,17 +5,108 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use orbit_common::types::{
-    McpCapability, McpToolDefinition, McpToolPlacement, McpToolPolicy, McpToolPolicyError,
-    McpToolScope, mcp_advertised_tool_name, mcp_capability_placement_matrix,
-    validate_mcp_tool_definitions,
+    LearningInjectionState, McpCapability, McpToolDefinition, McpToolPlacement, McpToolPolicy,
+    McpToolPolicyError, McpToolScope, ToolSessionContext, mcp_advertised_tool_name,
+    mcp_capability_placement_matrix, validate_mcp_tool_definitions,
 };
-use orbit_core::OrbitRuntime;
+use orbit_core::command::tool::ToolEntryPoint;
+use orbit_core::{LearningSearchParams, OrbitError, OrbitRuntime};
 use orbit_mcp::McpHost;
 use serde::Deserialize;
+use serde_json::{Value, json};
 
 use super::host::{
-    RuntimeMcpHost, canonical_mcp_tool_definitions, is_mcp_tool_exposed, safe_mcp_tool_names,
+    audited_mcp_call_with_session_context, canonical_mcp_tool_definitions, ensure_mcp_tool_exposed,
+    is_mcp_tool_exposed, normalize_trusted_call_context, safe_mcp_tool_names,
 };
+
+struct RuntimeMcpHost {
+    runtime: OrbitRuntime,
+}
+
+impl McpHost for RuntimeMcpHost {
+    fn list_mcp_tool_definitions(&self) -> Result<Vec<McpToolDefinition>, OrbitError> {
+        self.runtime.list_mcp_tool_definitions()
+    }
+
+    fn call_tool(
+        &self,
+        name: &str,
+        input: Value,
+        session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
+        audited_mcp_call_with_session_context(
+            &self.runtime,
+            name,
+            input,
+            normalize_trusted_call_context(session_context),
+        )
+    }
+
+    fn call_in_process_tool(
+        &self,
+        name: &str,
+        input: Value,
+        session_context: ToolSessionContext,
+        dispatch: &mut dyn FnMut(Value, ToolSessionContext) -> Result<Value, OrbitError>,
+    ) -> Result<Value, OrbitError> {
+        let session_context = normalize_trusted_call_context(session_context);
+        let dispatch_context = session_context.clone();
+        self.runtime
+            .execute_in_process_tool_dispatch(
+                name,
+                input,
+                ToolEntryPoint::Mcp,
+                session_context,
+                |input| {
+                    ensure_mcp_tool_exposed(name)?;
+                    dispatch(input, dispatch_context)
+                },
+            )
+            .map(|outcome| outcome.value)
+    }
+
+    fn learning_candidates_for_path(
+        &self,
+        path: &str,
+        _session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
+        let rows = self.runtime.search_learnings(LearningSearchParams {
+            path: Some(path.to_string()),
+            tag: None,
+            query: None,
+            limit: None,
+        })?;
+        Ok(Value::Array(
+            rows.into_iter()
+                .map(|row| {
+                    json!({
+                        "id": row.learning.id,
+                        "summary": row.learning.summary,
+                        "priority": row.learning.priority,
+                        "updated_at": row.learning.updated_at.to_rfc3339(),
+                    })
+                })
+                .collect(),
+        ))
+    }
+
+    fn get_session_learning_state(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<LearningInjectionState>, OrbitError> {
+        self.runtime.get_session_learning_state(session_id)
+    }
+
+    fn upsert_session_learning_state(
+        &self,
+        session_id: &str,
+        state: &LearningInjectionState,
+    ) -> Result<(), OrbitError> {
+        self.runtime
+            .upsert_session_learning_state(session_id, state)
+    }
+}
 
 const EXPECTED_INACTIVE_TOOL_NAMES: &[&str] = &[
     "orbit.docs.index",
@@ -457,7 +548,8 @@ mod audited_mcp_call_tests {
     use orbit_mcp::McpHost;
     use serde_json::json;
 
-    use super::super::host::{RuntimeMcpHost, audited_mcp_call};
+    use super::super::host::audited_mcp_call;
+    use super::RuntimeMcpHost;
 
     // ORB-00289: the previous `create_task` helper + the three
     // `task_delete_*_over_mcp` tests asserted that `orbit.task.delete` was

--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -6,10 +6,12 @@ use orbit_cmd::agent_rules::{InjectionAction, inject_agent_rules};
 use orbit_common::types::{
     Workspace, WorkspaceCheckout, WorkspaceCheckoutRole, WorkspaceStatus, validate_machine_id,
 };
+use orbit_common::utility::fs::atomic_write_text;
 use orbit_core::command::init::{InitOptions, init_workspace_at_root, seed_default_orbitignore};
 use orbit_core::routines::{HostIdentityState, HostMode, inspect_host_identity};
 use orbit_core::workspace_registry;
 use orbit_core::{OrbitError, OrbitRuntime};
+use serde::Serialize;
 
 use super::role::CliCheckoutRole;
 use super::support::{detect_git_remote, dir_name_or_fallback, ensure_orbit_gitignore_entry};
@@ -263,6 +265,7 @@ impl WorkspaceInitArgs {
             )?;
         }
         workspace_registry::save_registry_to(&registry, registry_path)?;
+        write_workspace_identity(orbit_dir, &id)?;
 
         Ok(WorkspaceInitResult {
             id,
@@ -271,6 +274,21 @@ impl WorkspaceInitArgs {
             orbit_dir: orbit_dir.to_path_buf(),
         })
     }
+}
+
+#[derive(Serialize)]
+struct WorkspaceIdentityDocument<'a> {
+    schema_version: u32,
+    workspace_id: &'a str,
+}
+
+fn write_workspace_identity(orbit_dir: &Path, workspace_id: &str) -> Result<(), OrbitError> {
+    let content = serde_yaml::to_string(&WorkspaceIdentityDocument {
+        schema_version: 1,
+        workspace_id,
+    })
+    .map_err(|error| OrbitError::Store(format!("serialize workspace identity: {error}")))?;
+    atomic_write_text(&orbit_dir.join("config.yaml"), &content).map_err(OrbitError::from)
 }
 
 fn unassigned_checkout(

--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -202,7 +202,7 @@ impl WorkspaceInitArgs {
 
         let name = self.name.unwrap_or_else(|| dir_name_or_fallback(cwd));
 
-        let id = format!("ws_{name}");
+        let id = canonical_workspace_id(&name);
         let git_remote = detect_git_remote(cwd);
 
         let mut registry = workspace_registry::load_registry_from(registry_path)?;
@@ -266,6 +266,7 @@ impl WorkspaceInitArgs {
         }
         workspace_registry::save_registry_to(&registry, registry_path)?;
         write_workspace_identity(orbit_dir, &id)?;
+        orbit_core::runtime::HubCoordinationExecutor::register_workspace(global_root, &id, &name)?;
 
         Ok(WorkspaceInitResult {
             id,
@@ -274,6 +275,30 @@ impl WorkspaceInitArgs {
             orbit_dir: orbit_dir.to_path_buf(),
         })
     }
+}
+
+pub(super) fn canonical_workspace_id(name: &str) -> String {
+    let mut canonical = String::new();
+    let mut separator = false;
+    for character in name.chars().flat_map(char::to_lowercase) {
+        if character.is_ascii_alphanumeric() || character == '_' {
+            canonical.push(character);
+            separator = false;
+        } else if !canonical.is_empty() {
+            separator = true;
+        }
+        if separator && !canonical.ends_with('-') {
+            canonical.push('-');
+            separator = false;
+        }
+    }
+    while canonical.ends_with('-') {
+        canonical.pop();
+    }
+    if canonical.is_empty() {
+        canonical.push_str("workspace");
+    }
+    format!("ws_{canonical}")
 }
 
 #[derive(Serialize)]

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -10,7 +10,7 @@ use orbit_core::workspace_registry;
 
 use crate::tests::env_isolation::EnvGuard;
 
-use super::super::init::WorkspaceInitArgs;
+use super::super::init::{WorkspaceInitArgs, canonical_workspace_id};
 use super::super::list::format_workspace_list;
 use super::super::role::CliCheckoutRole;
 use super::super::show::format_workspace_show;
@@ -837,7 +837,7 @@ fn nameless_tmp_workspace_registers_only_in_isolated_registry() {
         registry
             .workspaces
             .iter()
-            .any(|w| w.id == format!("ws_{workspace_name}")),
+            .any(|w| w.id == canonical_workspace_id(&workspace_name)),
         "nameless workspace must register in the isolated fixture registry"
     );
 

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -44,6 +44,13 @@ impl McpWorkspace {
         std::fs::create_dir_all(&home).expect("create home");
         std::fs::create_dir_all(&work).expect("create work");
 
+        let output = Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&work)
+            .output()
+            .expect("initialize Git checkout");
+        assert!(output.status.success(), "git init failed: {output:?}");
+
         let output = Self::orbit_command(&work, &home)
             .args([
                 "init",
@@ -280,8 +287,8 @@ fn mcp_serve_tools_list_matches_production_snapshot() {
         assert!(!names.contains(&hidden), "{hidden} leaked into: {names:?}");
     }
     assert!(
-        names.contains(&"orbit_friction_update"),
-        "D2 policy metadata must not narrow the current MCP surface: {names:?}"
+        !names.contains(&"orbit_friction_update"),
+        "operator-only tool leaked onto the default agent surface: {names:?}"
     );
 
     // Snapshot guard for the full production agent surface: names AND input
@@ -312,6 +319,47 @@ fn mcp_serve_tools_list_matches_production_snapshot() {
          with `ORBIT_MCP_UPDATE_SNAPSHOT=1 cargo test -p orbit-cli --test mcp_roundtrip` and \
          call the release breaking."
     );
+}
+
+#[test]
+fn mcp_serve_lists_canonical_agent_surface_outside_any_checkout() {
+    let workspace = McpWorkspace::init();
+    let scratch = workspace.home.join("scratch");
+    std::fs::create_dir_all(&scratch).expect("create non-workspace launch dir");
+    let child = McpWorkspace::orbit_command(&scratch, &workspace.home)
+        .args(["mcp", "serve"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn checkout-independent MCP server");
+    let mut client = McpClient::new(child);
+    client.request(
+        "initialize",
+        json!({
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": { "name": "outside-checkout", "version": "0" }
+        }),
+    );
+    client.notify("notifications/initialized");
+
+    let listed = client.request("tools/list", Value::Null);
+    let names = listed["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .filter_map(|tool| tool["name"].as_str())
+        .collect::<Vec<_>>();
+    assert!(names.contains(&"orbit_task_show"));
+    assert!(names.contains(&"orbit_graph_search"));
+    assert!(!names.contains(&"orbit_host_list"));
+
+    let missing = client.call_tool_err("orbit_task_show", json!({ "id": "ORB-00001" }));
+    assert!(missing["message"].as_str().is_some_and(|message| {
+        message.contains("requires a workspace selector")
+            && message.contains("_meta.orbit.workspace")
+    }));
 }
 
 #[test]
@@ -347,20 +395,30 @@ fn mcp_serve_round_trips_records_against_a_temp_workspace() {
         items.iter().any(|task| task["id"] == json!(task_id)),
         "created task missing from list: {items:?}"
     );
+    let listed_by_stable_id = client.call_tool_ok(
+        "orbit_task_list",
+        json!({ "workspace": "ws_mcp-roundtrip" }),
+    );
+    assert!(listed_by_stable_id["items"].as_array().is_some());
 
-    // D2 constructs and propagates capability membership but does not yet
-    // enforce policy metadata. Preserve the currently callable surface until
-    // the D3/E1 broker enforcement boundary lands.
+    // D3 enforces the non-hierarchical default agent capability. The agent may
+    // create friction, but the operator-only triage mutation stays hidden and
+    // returns the same typed denial when called by its canonical alias.
     let friction = client.call_tool_ok(
         "orbit_friction_add",
         json!({ "body": "MCP D2 exposure regression", "model": "codex" }),
     );
     let friction_id = friction["id"].as_str().expect("friction id").to_string();
-    let updated = client.call_tool_ok(
+    let denied = client.call_tool_err(
         "orbit_friction_update",
         json!({ "id": friction_id, "status": "triaged", "model": "codex" }),
     );
-    assert_eq!(updated["status"], "triaged");
+    assert_eq!(denied["code"], "invalid_input");
+    assert!(
+        denied["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("capability denied"))
+    );
 
     // Learning create → show → lexical federated search (no embedding
     // companion installed, so `orbit.search` must serve the lexical path).

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -489,45 +489,6 @@
     "name": "orbit_friction_tags"
   },
   {
-    "description": "Update triage metadata for an Orbit friction record",
-    "inputSchema": {
-      "additionalProperties": true,
-      "properties": {
-        "body": {
-          "description": "Optional replacement markdown body",
-          "type": "string"
-        },
-        "id": {
-          "description": "Friction record id, e.g. F2026-05-001",
-          "type": "string"
-        },
-        "status": {
-          "description": "Optional status: open, triaged, or resolved",
-          "type": "string"
-        },
-        "tags": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "string"
-            }
-          ],
-          "description": "Optional replacement taxonomy tags as a string or array; valid tags: build | docs | lifecycle | naming | other | policy | skill-guidance | tooling"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "name": "orbit_friction_update"
-  },
-  {
     "description": "Find outbound calls from an orbit-graph symbol selector.",
     "inputSchema": {
       "additionalProperties": true,
@@ -834,15 +795,6 @@
       "type": "object"
     },
     "name": "orbit_graph_trace"
-  },
-  {
-    "description": "List registered hub hosts with sanitized lifecycle, aliases, and workspace-presence freshness (operator, hub placement).",
-    "inputSchema": {
-      "additionalProperties": true,
-      "properties": {},
-      "type": "object"
-    },
-    "name": "orbit_host_list"
   },
   {
     "description": "Create an active project learning. Returns `{ id, created_at }` plus the full record.",
@@ -1768,14 +1720,5 @@
       "type": "object"
     },
     "name": "orbit_task_update"
-  },
-  {
-    "description": "List workspaces with declared owner and sanitized execution-profile freshness (operator, hub placement).",
-    "inputSchema": {
-      "additionalProperties": true,
-      "properties": {},
-      "type": "object"
-    },
-    "name": "orbit_workspace_list"
   }
 ]

--- a/crates/orbit-core/src/host_registry.rs
+++ b/crates/orbit-core/src/host_registry.rs
@@ -15,9 +15,10 @@ use orbit_common::types::activity_job::{
 };
 use orbit_common::types::{
     ActivityV2, Crew, CrewRoleAssignment, EXECUTION_PROFILE_SCHEMA_VERSION, ExecutionProfileCrewV1,
-    ExecutionProfileShipV1, ExecutionProfileV1, JobV2, OrbitError, Workspace,
+    ExecutionProfileShipV1, ExecutionProfileV1, JobV2, OrbitError, RegistrySnapshotV1, Workspace,
 };
 use orbit_engine::{dispatch_error_to_orbit, resolve_job_catalog_refs_for_execution, validate_job};
+use orbit_store::Store;
 use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -39,6 +40,27 @@ const UNSUPPORTED_PROFILE_ENV_OVERRIDES: [&str; 5] = [
     "ORBIT_V2_CATALOG_DIR",
     "ORBIT_BACKEND",
 ];
+
+/// Read the path-free coordination registry without constructing a workspace
+/// runtime. Long-running brokers use this for global discovery tools and must
+/// not manufacture a checkout merely to open the hub registry.
+pub fn registry_snapshot_at(
+    global_root: &std::path::Path,
+) -> Result<RegistrySnapshotV1, OrbitError> {
+    let database = crate::config::resolved_audit_db_path(global_root, global_root)?;
+    HostRegistryService::new(Store::open(&database)?).snapshot()
+}
+
+/// Persist a broker denial into the global coordination audit database when a
+/// workspace runtime is deliberately unavailable (for example a global tool
+/// or a checkoutless preflight denial).
+pub fn record_global_audit_event_at(
+    global_root: &std::path::Path,
+    params: &orbit_store::AuditEventInsertParams,
+) -> Result<(), OrbitError> {
+    let database = crate::config::resolved_audit_db_path(global_root, global_root)?;
+    Store::open(&database)?.insert_audit_event_record(params)
+}
 
 impl OrbitRuntime {
     /// Build the frozen owner payload from the exact runtime/config/catalog

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -45,6 +45,7 @@ use crate::context::ActorIdentity;
 use crate::context::OrbitContext;
 use crate::context::OrbitStores;
 
+pub use orbit_tool_host::HubCoordinationExecutor;
 pub(crate) use orbit_tool_host::build_orbit_tool_host;
 pub(crate) use resolve::{resolve_bootstrap_roots, resolve_initialize_roots};
 // `pub` for the runtime-less `orbit migrate --dry-run` inspection that moved

--- a/crates/orbit-core/src/runtime/orbit_tool_host/host.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/host.rs
@@ -1,8 +1,34 @@
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::Arc;
 
-use orbit_common::types::OrbitError;
-use orbit_tools::{OrbitBuiltinAction, OrbitTaskScope, OrbitToolHost, ReservationOwnerContext};
-use serde_json::Value;
+use chrono::Utc;
+use orbit_common::types::{
+    FrictionStatus, NotFoundKind, OrbitError, ReviewMessage, ReviewThread, ReviewThreadStatus,
+    Task, TaskComment, TaskPriority, TaskStatus, TaskType, ToolSessionContext,
+    is_valid_friction_id, normalize_optional_attribution_label, normalize_task_dependencies,
+    normalize_task_tags, optional_csv_or_string_list_alias, optional_raw_string, optional_string,
+    optional_string_alias, required_string, resolve_task_dependencies, task_dependencies_ready,
+    task_matches_tags, validate_task_dependencies,
+};
+use orbit_common::utility::redaction::redact_all;
+use orbit_common::utility::selector::canonical_selector;
+use orbit_store::friction_store::{
+    FrictionAddParams, FrictionUpdateParams, add_friction, friction_tags,
+    prepare_hub_friction_root, resolve_friction_by_task, update_friction,
+};
+use orbit_store::sqlite::task_registry::{
+    RegisterWorkspaceParams, TaskRegistryStore, task_registry_path,
+};
+use orbit_store::{
+    TaskArtifactUpdateParams, TaskCreateParams, TaskDocumentUpdateParams, TaskHistoryUpdateParams,
+    TaskReviewUpdateParams, WorkspaceTaskBackends, coordination_task_backends,
+};
+use orbit_tools::{
+    OrbitBuiltinAction, OrbitTaskScope, OrbitToolHost, ReservationOwnerContext, ToolContext,
+    ToolRegistry,
+};
+use serde_json::{Map, Value, json};
 
 use crate::OrbitRuntime;
 
@@ -25,6 +51,832 @@ pub(crate) fn build_orbit_tool_host(
 struct RuntimeOrbitToolHost {
     runtime: OrbitRuntime,
     task_scope: OrbitTaskScope,
+}
+
+/// Checkout-independent executor for coordination-authoritative hub tools.
+///
+/// It deliberately has no `OrbitRuntime`, `WorkspacePaths`, local configuration,
+/// owner store, or fabricated checkout. The stable logical workspace ID is the
+/// sole task/friction partition key.
+#[derive(Clone)]
+pub struct HubCoordinationExecutor {
+    inner: Arc<HubCoordinationState>,
+}
+
+struct HubCoordinationState {
+    global_root: PathBuf,
+    workspace_id: String,
+    legacy_friction_root: Option<PathBuf>,
+    tasks: WorkspaceTaskBackends,
+}
+
+impl HubCoordinationExecutor {
+    /// Registers the path-free task-registry partition for a logical workspace.
+    /// Workspace initialization calls this once; identical repeats are safe.
+    pub fn register_workspace(
+        global_root: &Path,
+        workspace_id: impl Into<String>,
+        slug: impl Into<String>,
+    ) -> Result<(), OrbitError> {
+        let registry = TaskRegistryStore::open(&task_registry_path(global_root))?;
+        registry.register_workspace(RegisterWorkspaceParams {
+            workspace_id: workspace_id.into(),
+            slug: slug.into(),
+            repo_fingerprint: None,
+        })?;
+        Ok(())
+    }
+
+    pub fn new(
+        global_root: &Path,
+        workspace_id: impl Into<String>,
+        legacy_friction_root: Option<PathBuf>,
+    ) -> Result<Self, OrbitError> {
+        let workspace_id = workspace_id.into();
+        let registry = TaskRegistryStore::open(&task_registry_path(global_root))?;
+        let tasks = coordination_task_backends(registry, workspace_id.clone());
+        Ok(Self {
+            inner: Arc::new(HubCoordinationState {
+                global_root: global_root.to_path_buf(),
+                workspace_id,
+                legacy_friction_root,
+                tasks,
+            }),
+        })
+    }
+
+    pub fn execute_tool(
+        &self,
+        name: &str,
+        input: Value,
+        session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
+        let mut registry = ToolRegistry::new();
+        registry.register_builtins();
+        let context = ToolContext {
+            cwd: std::env::current_dir()
+                .ok()
+                .map(|path| path.to_string_lossy().into_owned()),
+            session_context,
+            orbit_host: Some(Arc::new(self.clone())),
+            ..Default::default()
+        };
+        registry.execute(name, &context, input)
+    }
+
+    fn actor(agent: Option<&str>, model: Option<&str>) -> String {
+        normalize_optional_attribution_label(model.or(agent), model)
+            .unwrap_or_else(|| "unknown".to_string())
+    }
+
+    fn task(&self, id: &str) -> Result<Task, OrbitError> {
+        self.inner
+            .tasks
+            .task
+            .get_task(id)?
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, id.to_string()))
+    }
+
+    fn task_json(&self, task: &Task) -> Result<Value, OrbitError> {
+        let status = self.inner.tasks.task.task_status_index()?;
+        let mut value = super::json::task_to_json(task, &status);
+        let object = value.as_object_mut().ok_or_else(|| {
+            OrbitError::Execution("task JSON projection did not produce an object".to_string())
+        })?;
+        object.insert(
+            "comments".to_string(),
+            serde_json::to_value(
+                self.inner
+                    .tasks
+                    .history
+                    .get_task_comments(&task.id)?
+                    .unwrap_or_default(),
+            )
+            .map_err(|error| OrbitError::Execution(format!("serialize comments: {error}")))?,
+        );
+        object.insert(
+            "history".to_string(),
+            serde_json::to_value(
+                self.inner
+                    .tasks
+                    .history
+                    .get_task_history(&task.id)?
+                    .unwrap_or_default(),
+            )
+            .map_err(|error| OrbitError::Execution(format!("serialize history: {error}")))?,
+        );
+        object.insert(
+            "review_threads".to_string(),
+            serde_json::to_value(
+                self.inner
+                    .tasks
+                    .review
+                    .get_task_review_threads(&task.id)?
+                    .unwrap_or_default(),
+            )
+            .map_err(|error| OrbitError::Execution(format!("serialize review threads: {error}")))?,
+        );
+        Ok(value)
+    }
+
+    fn add_task(
+        &self,
+        input: Value,
+        agent: Option<String>,
+        model: Option<String>,
+    ) -> Result<Value, OrbitError> {
+        let actor = Self::actor(agent.as_deref(), model.as_deref());
+        let context_files = optional_csv_or_string_list_alias(&input, &["context_files"])?
+            .unwrap_or_default()
+            .into_iter()
+            .map(|entry| {
+                canonical_selector(&entry)
+                    .map_err(|error| OrbitError::InvalidInput(error.to_string()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let relations = super::input::parse_relations(&input)?.unwrap_or_default();
+        let task_type = optional_string_alias(&input, &["type", "task_type", "taskType"])?
+            .map(|value| super::input::parse_task_type("type", &value))
+            .transpose()?
+            .unwrap_or(TaskType::Feature);
+        let title = redact_all(&required_string(&input, &["title"], "title")?);
+        let description = redact_all(&required_string(&input, &["description"], "description")?);
+        let acceptance_criteria = optional_csv_or_string_list_alias(
+            &input,
+            &[
+                "acceptance_criteria",
+                "acceptanceCriteria",
+                "acceptance-criteria",
+            ],
+        )?
+        .unwrap_or_default()
+        .into_iter()
+        .map(|criterion| redact_all(&criterion))
+        .collect();
+        let task = self.inner.tasks.task.create_task(TaskCreateParams {
+            actor: actor.clone(),
+            parent_id: None,
+            title,
+            description,
+            acceptance_criteria,
+            dependencies: Vec::new(),
+            relations,
+            tags: normalize_task_tags(
+                optional_csv_or_string_list_alias(&input, &["tags", "tag"])?.unwrap_or_default(),
+            ),
+            plan: String::new(),
+            execution_summary: String::new(),
+            context_files,
+            workspace_path: None,
+            repo_root: None,
+            created_by: Some(actor),
+            planned_by: None,
+            implemented_by: None,
+            status: TaskStatus::Proposed,
+            priority: optional_string(&input, "priority")?
+                .map(|value| super::input::parse_task_priority("priority", &value))
+                .transpose()?
+                .unwrap_or(TaskPriority::Medium),
+            complexity: optional_string(&input, "complexity")?
+                .map(|value| super::input::parse_task_complexity("complexity", &value))
+                .transpose()?,
+            task_type,
+            external_refs: Vec::new(),
+            source_task_id: None,
+            crew: optional_string(&input, "crew")?,
+            comments: Vec::new(),
+        })?;
+        self.task_json(&task)
+    }
+
+    fn update_task(
+        &self,
+        input: Value,
+        agent: Option<String>,
+        model: Option<String>,
+    ) -> Result<Value, OrbitError> {
+        let id = required_string(&input, &["id"], "id")?;
+        let current = self.task(&id)?;
+        let actor = Self::actor(agent.as_deref(), model.as_deref());
+        let status = optional_string(&input, "status")?
+            .map(|value| super::input::parse_task_status("status", &value))
+            .transpose()?;
+        let has_non_status_mutation = [
+            "title",
+            "description",
+            "acceptance_criteria",
+            "dependencies",
+            "relations",
+            "tags",
+            "plan",
+            "execution_summary",
+            "type",
+            "source_task_id",
+            "planned_by",
+            "implemented_by",
+            "pr_status",
+            "job_run_id",
+            "crew",
+            "context_files",
+            "context",
+            "artifacts",
+            "artifact",
+        ]
+        .iter()
+        .any(|field| input.get(*field).is_some());
+        let unarchiving = current.status == TaskStatus::Archived
+            && status == Some(TaskStatus::Backlog)
+            && !has_non_status_mutation;
+        if current.status == TaskStatus::Archived && !unarchiving {
+            return Err(OrbitError::InvalidInput(format!(
+                "task {id} is archived and cannot be modified; restore it to backlog first"
+            )));
+        }
+        if current.status == TaskStatus::Done && (status.is_some() || has_non_status_mutation) {
+            return Err(OrbitError::InvalidInput(format!(
+                "task {id} is done and cannot be modified; done is terminal"
+            )));
+        }
+        if let Some(target) = status {
+            current
+                .status
+                .validate_transition(target)
+                .map_err(OrbitError::TaskStatusTransition)?;
+            if target == TaskStatus::InProgress
+                && current.status != TaskStatus::InProgress
+                && input
+                    .get("plan")
+                    .and_then(Value::as_str)
+                    .unwrap_or(&current.plan)
+                    .trim()
+                    .is_empty()
+            {
+                return Err(OrbitError::InvalidInput(format!(
+                    "task '{id}' requires a non-empty plan before entering in-progress"
+                )));
+            }
+            if current.status == TaskStatus::InProgress
+                && target == TaskStatus::Review
+                && optional_raw_string(&input, "execution_summary")?
+                    .as_deref()
+                    .unwrap_or(&current.execution_summary)
+                    .trim()
+                    .is_empty()
+            {
+                return Err(OrbitError::InvalidInput(format!(
+                    "task '{id}' requires non-empty execution_summary before transitioning in-progress -> review"
+                )));
+            }
+        }
+        let dependencies = optional_csv_or_string_list_alias(&input, &["dependencies"])?
+            .map(normalize_task_dependencies)
+            .transpose()?;
+        if let Some(dependencies) = dependencies.as_ref() {
+            validate_task_dependencies(
+                &self.inner.tasks.task.list_tasks()?,
+                Some(&id),
+                dependencies,
+            )?;
+        }
+        let context_files =
+            optional_csv_or_string_list_alias(&input, &["context_files", "context"])?
+                .map(|entries| {
+                    entries
+                        .into_iter()
+                        .map(|entry| {
+                            canonical_selector(&entry)
+                                .map_err(|error| OrbitError::InvalidInput(error.to_string()))
+                        })
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .transpose()?;
+        let artifacts = super::input::parse_artifacts(&input)?;
+        let relations = super::input::parse_relations(&input)?;
+        let comment = optional_string(&input, "comment")?;
+        let task_type = optional_string_alias(&input, &["type", "task_type", "taskType"])?
+            .map(|value| super::input::parse_task_type("type", &value))
+            .transpose()?;
+        let description = input
+            .get("description")
+            .map(|value| {
+                value.as_str().map(redact_all).ok_or_else(|| {
+                    OrbitError::InvalidInput("`description` must be a string".to_string())
+                })
+            })
+            .transpose()?;
+        let plan = input
+            .get("plan")
+            .map(|value| {
+                value
+                    .as_str()
+                    .map(redact_all)
+                    .ok_or_else(|| OrbitError::InvalidInput("`plan` must be a string".to_string()))
+            })
+            .transpose()?;
+        let explicit_planned_by = raw_clearable(&input, "planned_by")?;
+        let explicit_implemented_by = raw_clearable(&input, "implemented_by")?;
+        self.inner.tasks.document.update_task_document(
+            &id,
+            TaskDocumentUpdateParams {
+                actor: actor.clone(),
+                title: optional_string(&input, "title")?.map(|value| redact_all(&value)),
+                description,
+                acceptance_criteria: optional_csv_or_string_list_alias(
+                    &input,
+                    &[
+                        "acceptance_criteria",
+                        "acceptanceCriteria",
+                        "acceptance-criteria",
+                    ],
+                )?
+                .map(|values| values.into_iter().map(|value| redact_all(&value)).collect()),
+                dependencies,
+                relations,
+                tags: optional_csv_or_string_list_alias(&input, &["tags", "tag"])?
+                    .map(normalize_task_tags),
+                plan,
+                execution_summary: optional_raw_string(&input, "execution_summary")?
+                    .map(|value| redact_all(&value)),
+                context_files,
+                planned_by: explicit_planned_by
+                    .or_else(|| input.get("plan").is_some().then(|| Some(actor.clone()))),
+                implemented_by: explicit_implemented_by.or_else(|| {
+                    status
+                        .is_some_and(|value| matches!(value, TaskStatus::Review | TaskStatus::Done))
+                        .then(|| Some(actor.clone()))
+                }),
+                priority: None,
+                complexity: None,
+                task_type,
+                external_refs: None,
+                pr_status: raw_clearable(&input, "pr_status")?,
+                source_task_id: raw_clearable(&input, "source_task_id")?,
+                job_run_id: raw_clearable(&input, "job_run_id")?,
+                crew: raw_clearable(&input, "crew")?,
+                created_by: None,
+            },
+        )?;
+        if !artifacts.is_empty() {
+            self.inner.tasks.artifact.upsert_task_artifacts(
+                &id,
+                TaskArtifactUpdateParams {
+                    actor: actor.clone(),
+                    upsert_artifacts: artifacts,
+                },
+            )?;
+        }
+        if status.is_some() || comment.is_some() {
+            let append_comments = comment
+                .map(|message| TaskComment {
+                    at: Utc::now(),
+                    by: actor.clone(),
+                    message: redact_all(message.trim()),
+                })
+                .into_iter()
+                .collect();
+            self.inner.tasks.history.update_task_history(
+                &id,
+                TaskHistoryUpdateParams {
+                    actor,
+                    status,
+                    status_event: status.map(|_| "updated".to_string()),
+                    status_note: None,
+                    append_history: Vec::new(),
+                    append_comments,
+                },
+            )?;
+        }
+        let updated = self.task(&id)?;
+        if updated.status == TaskStatus::Done
+            && current.status != TaskStatus::Done
+            && let Ok(root) = self.friction_root()
+        {
+            for relation in &updated.relations {
+                if relation.relation_type == orbit_common::types::TaskRelationType::Resolves
+                    && is_valid_friction_id(&relation.target)
+                    && let Err(error) =
+                        resolve_friction_by_task(&root, &relation.target, &id, Utc::now())
+                {
+                    tracing::warn!(
+                        task_id = id,
+                        friction_id = relation.target,
+                        error = %error,
+                        "checkoutless task completion could not apply friction side effect"
+                    );
+                }
+            }
+        }
+        self.task_json(&updated)
+    }
+
+    fn transition(
+        &self,
+        input: Value,
+        agent: Option<String>,
+        model: Option<String>,
+        start: bool,
+    ) -> Result<Value, OrbitError> {
+        let id = required_string(&input, &["id"], "id")?;
+        let task = self.task(&id)?;
+        let target = if start {
+            if !matches!(
+                task.status,
+                TaskStatus::Proposed
+                    | TaskStatus::Backlog
+                    | TaskStatus::Someday
+                    | TaskStatus::Blocked
+            ) {
+                return Err(OrbitError::InvalidInput(format!(
+                    "task '{id}' is in status '{}'; start requires proposed, backlog, someday, or blocked",
+                    task.status
+                )));
+            }
+            if task.plan.trim().is_empty() {
+                return Err(OrbitError::InvalidInput(format!(
+                    "task '{id}' requires a non-empty plan before entering in-progress"
+                )));
+            }
+            TaskStatus::InProgress
+        } else {
+            match task.status {
+                TaskStatus::Proposed => TaskStatus::Backlog,
+                TaskStatus::Review => TaskStatus::Done,
+                other => {
+                    return Err(OrbitError::InvalidInput(format!(
+                        "task '{id}' is in status '{other}'; approve requires proposed or review"
+                    )));
+                }
+            }
+        };
+        let mut update = Map::new();
+        update.insert("id".to_string(), Value::String(id));
+        update.insert("status".to_string(), Value::String(target.to_string()));
+        if let Some(note) = optional_string(&input, "note")? {
+            update.insert("comment".to_string(), Value::String(note));
+        } else if let Some(comment) = optional_string(&input, "comment")? {
+            update.insert("comment".to_string(), Value::String(comment));
+        }
+        if let Some(crew) = optional_string(&input, "crew")? {
+            update.insert("crew".to_string(), Value::String(crew));
+        }
+        self.update_task(Value::Object(update), agent, model)
+    }
+
+    fn show_task(&self, input: Value) -> Result<Value, OrbitError> {
+        if input
+            .get("with_context")
+            .or_else(|| input.get("withContext"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            return Err(OrbitError::InvalidInput(
+                "checkoutless hub execution cannot provide `with_context` local-derived enrichment"
+                    .to_string(),
+            ));
+        }
+        let id = required_string(&input, &["id"], "id")?;
+        let task = self.task(&id)?;
+        let Some(fields) = optional_csv_or_string_list_alias(&input, &["fields", "field"])? else {
+            return self.task_json(&task);
+        };
+        let status = self.inner.tasks.task.task_status_index()?;
+        let one = |field: &str| -> Result<Value, OrbitError> {
+            match field {
+                "comments" => serde_json::to_value(
+                    self.inner
+                        .tasks
+                        .history
+                        .get_task_comments(&id)?
+                        .unwrap_or_default(),
+                )
+                .map_err(|error| OrbitError::Execution(error.to_string())),
+                "history" => serde_json::to_value(
+                    self.inner
+                        .tasks
+                        .history
+                        .get_task_history(&id)?
+                        .unwrap_or_default(),
+                )
+                .map_err(|error| OrbitError::Execution(error.to_string())),
+                "artifacts" => Ok(super::json::serialize_task_artifacts(
+                    &self
+                        .inner
+                        .tasks
+                        .artifact
+                        .get_task_artifacts(&id)?
+                        .unwrap_or_default(),
+                )),
+                "plan" => Ok(json!(task.plan)),
+                "execution_summary" => Ok(json!(task.execution_summary)),
+                "description" => Ok(json!(task.description)),
+                "acceptance_criteria" => Ok(json!(task.acceptance_criteria)),
+                "dependencies" => Ok(json!(task.dependencies())),
+                "resolved_dependencies" => Ok(json!(
+                    resolve_task_dependencies(&task, &status)
+                        .into_iter()
+                        .map(|entry| entry.label())
+                        .collect::<Vec<_>>()
+                )),
+                "tags" => Ok(json!(task.tags)),
+                "context_files" => Ok(json!(task.context_files)),
+                other => Err(OrbitError::InvalidInput(format!(
+                    "unknown field selector `{other}`"
+                ))),
+            }
+        };
+        if fields.len() == 1 {
+            return one(&fields[0]);
+        }
+        let mut object = Map::new();
+        for field in fields {
+            object.insert(field.clone(), one(&field)?);
+        }
+        Ok(Value::Object(object))
+    }
+
+    fn list_tasks(&self, input: Value) -> Result<Value, OrbitError> {
+        let status_filter = optional_string(&input, "status")?
+            .map(|value| super::input::parse_task_status("status", &value))
+            .transpose()?;
+        let type_filter = optional_string_alias(&input, &["type", "task_type", "taskType"])?
+            .map(|value| super::input::parse_task_type("type", &value))
+            .transpose()?;
+        let tags = optional_csv_or_string_list_alias(&input, &["tags", "tag"])?.unwrap_or_default();
+        let ready = super::input::optional_bool_alias(&input, &["ready"])?;
+        let status = self.inner.tasks.task.task_status_index()?;
+        let tasks = self
+            .inner
+            .tasks
+            .task
+            .list_tasks()?
+            .into_iter()
+            .filter(|task| status_filter.is_none_or(|value| task.status == value))
+            .filter(|task| type_filter.is_none_or(|value| task.task_type == value))
+            .filter(|task| task_matches_tags(task, &tags))
+            .filter(|task| ready != Some(true) || task_dependencies_ready(task, &status))
+            .map(|task| super::json::task_to_json(&task, &status))
+            .collect();
+        Ok(Value::Array(tasks))
+    }
+
+    fn review(
+        &self,
+        action: OrbitBuiltinAction,
+        input: Value,
+        agent: Option<String>,
+        model: Option<String>,
+    ) -> Result<Value, OrbitError> {
+        let id = required_string(&input, &["id", "task_id"], "id")?;
+        let actor = Self::actor(agent.as_deref(), model.as_deref());
+        let mut threads = self
+            .inner
+            .tasks
+            .review
+            .get_task_review_threads(&id)?
+            .unwrap_or_default();
+        match action {
+            OrbitBuiltinAction::ReviewThreadList => {
+                let filter = optional_string(&input, "status")?
+                    .map(|value| {
+                        ReviewThreadStatus::from_str(&value).map_err(OrbitError::InvalidInput)
+                    })
+                    .transpose()?;
+                threads.retain(|thread| filter.is_none_or(|status| thread.status == status));
+                return serde_json::to_value(threads)
+                    .map_err(|error| OrbitError::Execution(error.to_string()));
+            }
+            OrbitBuiltinAction::ReviewThreadAdd => {
+                if model.as_deref().is_none_or(|value| value.trim().is_empty()) {
+                    return Err(OrbitError::InvalidInput(
+                        "orbit.task.review_thread.add requires `model`".to_string(),
+                    ));
+                }
+                let now = Utc::now();
+                let suffix = now.timestamp_subsec_nanos();
+                let path = optional_string(&input, "path")?;
+                let line = optional_string(&input, "line")?
+                    .map(|value| {
+                        value.parse::<u64>().map_err(|error| {
+                            OrbitError::InvalidInput(format!(
+                                "`line` must be an unsigned integer: {error}"
+                            ))
+                        })
+                    })
+                    .transpose()?;
+                self.inner.tasks.review.update_task_reviews(
+                    &id,
+                    TaskReviewUpdateParams {
+                        append_review_threads: vec![ReviewThread {
+                            thread_id: format!("rt-{}-{suffix:09}", now.format("%Y%m%d-%H%M%S")),
+                            path,
+                            line,
+                            status: ReviewThreadStatus::Open,
+                            messages: vec![ReviewMessage {
+                                message_id: format!(
+                                    "rm-{}-{suffix:09}",
+                                    now.format("%Y%m%d-%H%M%S")
+                                ),
+                                at: now,
+                                by: actor,
+                                body: redact_all(&required_string(&input, &["body"], "body")?),
+                                github_comment_id: None,
+                            }],
+                            github_thread_id: None,
+                        }],
+                        replace_review_threads: None,
+                    },
+                )?;
+            }
+            OrbitBuiltinAction::ReviewThreadReply => {
+                if model.as_deref().is_none_or(|value| value.trim().is_empty()) {
+                    return Err(OrbitError::InvalidInput(
+                        "orbit.task.review_thread.reply requires `model`".to_string(),
+                    ));
+                }
+                let thread_id = required_string(&input, &["thread_id"], "thread_id")?;
+                if !threads.iter().any(|thread| thread.thread_id == thread_id) {
+                    return Err(OrbitError::InvalidInput(format!(
+                        "review thread '{thread_id}' not found on task '{id}'"
+                    )));
+                }
+                let now = Utc::now();
+                self.inner.tasks.review.update_task_reviews(
+                    &id,
+                    TaskReviewUpdateParams {
+                        append_review_threads: vec![ReviewThread {
+                            thread_id,
+                            path: None,
+                            line: None,
+                            status: ReviewThreadStatus::Open,
+                            messages: vec![ReviewMessage {
+                                message_id: format!(
+                                    "rm-{}-{:09}",
+                                    now.format("%Y%m%d-%H%M%S"),
+                                    now.timestamp_subsec_nanos()
+                                ),
+                                at: now,
+                                by: actor,
+                                body: redact_all(&required_string(&input, &["body"], "body")?),
+                                github_comment_id: None,
+                            }],
+                            github_thread_id: None,
+                        }],
+                        replace_review_threads: None,
+                    },
+                )?;
+            }
+            OrbitBuiltinAction::ReviewThreadResolve => {
+                let thread_id = required_string(&input, &["thread_id"], "thread_id")?;
+                if !threads.iter().any(|thread| thread.thread_id == thread_id) {
+                    return Err(OrbitError::InvalidInput(format!(
+                        "review thread '{thread_id}' not found on task '{id}'"
+                    )));
+                }
+                self.inner.tasks.review.update_task_reviews(
+                    &id,
+                    TaskReviewUpdateParams {
+                        append_review_threads: vec![ReviewThread {
+                            thread_id,
+                            path: None,
+                            line: None,
+                            status: ReviewThreadStatus::Resolved,
+                            messages: Vec::new(),
+                            github_thread_id: None,
+                        }],
+                        replace_review_threads: None,
+                    },
+                )?;
+            }
+            _ => unreachable!(),
+        }
+        self.task_json(&self.task(&id)?)
+    }
+
+    fn friction_root(&self) -> Result<PathBuf, OrbitError> {
+        prepare_hub_friction_root(
+            &self.inner.global_root,
+            &self.inner.workspace_id,
+            self.inner.legacy_friction_root.as_deref(),
+        )
+    }
+
+    fn friction(
+        &self,
+        action: OrbitBuiltinAction,
+        input: Value,
+        model: Option<String>,
+    ) -> Result<Value, OrbitError> {
+        let root = self.friction_root()?;
+        match action {
+            OrbitBuiltinAction::FrictionTags => Ok(json!(friction_tags(&root)?)),
+            OrbitBuiltinAction::FrictionAdd => {
+                let model = model
+                    .filter(|value| !value.trim().is_empty())
+                    .ok_or_else(|| {
+                        OrbitError::InvalidInput("orbit.friction.add requires `model`".to_string())
+                    })?;
+                let stored = add_friction(
+                    &root,
+                    FrictionAddParams {
+                        model,
+                        body: redact_all(&required_string(
+                            &input,
+                            &["body", "description"],
+                            "body",
+                        )?),
+                        tags: optional_csv_or_string_list_alias(&input, &["tags", "tag"])?
+                            .unwrap_or_default(),
+                        during_task: optional_string(&input, "during_task")?
+                            .or(optional_string(&input, "task_id")?),
+                        created_at: Utc::now(),
+                    },
+                )?;
+                friction_json(stored)
+            }
+            OrbitBuiltinAction::FrictionUpdate => {
+                let id = required_string(&input, &["id"], "id")?;
+                let status = optional_string(&input, "status")?
+                    .map(|value| {
+                        FrictionStatus::from_str(&value)
+                            .map_err(|error| OrbitError::InvalidInput(format!("`status` {error}")))
+                    })
+                    .transpose()?;
+                let tags = optional_csv_or_string_list_alias(&input, &["tags", "tag"])?;
+                let body = optional_string(&input, "body")?.map(|value| redact_all(&value));
+                if status.is_none() && tags.is_none() && body.is_none() {
+                    return Err(OrbitError::InvalidInput(
+                        "orbit.friction.update requires `status`, `tags`, or `body`".to_string(),
+                    ));
+                }
+                friction_json(update_friction(
+                    &root,
+                    &id,
+                    FrictionUpdateParams {
+                        status,
+                        tags,
+                        body,
+                        resolved_by_task: None,
+                        updated_at: Utc::now(),
+                    },
+                )?)
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl OrbitToolHost for HubCoordinationExecutor {
+    fn execute(
+        &self,
+        action: OrbitBuiltinAction,
+        input: Value,
+        agent: Option<String>,
+        model: Option<String>,
+        _reservation_owner: Option<ReservationOwnerContext>,
+    ) -> Result<Value, OrbitError> {
+        let (input, _redaction_report) =
+            super::artifact_redaction::sanitize_tool_input(action, input)?;
+        match action {
+            OrbitBuiltinAction::TaskAdd => self.add_task(input, agent, model),
+            OrbitBuiltinAction::TaskApprove => self.transition(input, agent, model, false),
+            OrbitBuiltinAction::TaskStart => self.transition(input, agent, model, true),
+            OrbitBuiltinAction::TaskShow => self.show_task(input),
+            OrbitBuiltinAction::TaskList => self.list_tasks(input),
+            OrbitBuiltinAction::TaskUpdate => self.update_task(input, agent, model),
+            OrbitBuiltinAction::ReviewThreadAdd
+            | OrbitBuiltinAction::ReviewThreadList
+            | OrbitBuiltinAction::ReviewThreadReply
+            | OrbitBuiltinAction::ReviewThreadResolve => self.review(action, input, agent, model),
+            OrbitBuiltinAction::FrictionAdd
+            | OrbitBuiltinAction::FrictionTags
+            | OrbitBuiltinAction::FrictionUpdate => self.friction(action, input, model),
+            _ => Err(OrbitError::InvalidInput(format!(
+                "action {action:?} is outside the checkoutless hub coordination executor"
+            ))),
+        }
+    }
+
+    fn task_scope(&self) -> OrbitTaskScope {
+        OrbitTaskScope::default()
+    }
+}
+
+fn raw_clearable(input: &Value, field: &str) -> Result<Option<Option<String>>, OrbitError> {
+    Ok(optional_raw_string(input, field)?.map(|value| {
+        let value = value.trim();
+        (!value.is_empty()).then(|| value.to_string())
+    }))
+}
+
+fn friction_json(
+    stored: orbit_store::friction_store::StoredFrictionRecord,
+) -> Result<Value, OrbitError> {
+    let mut value = serde_json::to_value(&stored.record)
+        .map_err(|error| OrbitError::Store(format!("serialize friction record: {error}")))?;
+    if let Some(object) = value.as_object_mut() {
+        object.insert("path".to_string(), json!(stored.path.to_string_lossy()));
+    }
+    Ok(value)
 }
 
 impl OrbitToolHost for RuntimeOrbitToolHost {
@@ -66,4 +918,140 @@ fn trusted_env_run_id() -> Option<String> {
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod checkoutless_hub_tests {
+    use super::*;
+
+    fn executor() -> (
+        tempfile::TempDir,
+        HubCoordinationExecutor,
+        ToolSessionContext,
+    ) {
+        let root = tempfile::tempdir().expect("global root");
+        HubCoordinationExecutor::register_workspace(root.path(), "ws_checkoutless", "checkoutless")
+            .expect("register workspace");
+        let executor = HubCoordinationExecutor::new(root.path(), "ws_checkoutless", None)
+            .expect("coordination executor");
+        let context = ToolSessionContext::trusted_local(
+            Some("ws_checkoutless".to_string()),
+            Some("hm_hub".to_string()),
+            Some("hub".to_string()),
+        );
+        (root, executor, context)
+    }
+
+    #[test]
+    fn task_artifact_review_and_verdict_persist_without_checkout() {
+        let (root, executor, context) = executor();
+        let created = executor
+            .execute_tool(
+                "orbit.task.add",
+                json!({
+                    "workspace": "ws_checkoutless",
+                    "title": "Coordinate from hub",
+                    "description": "No checkout required",
+                    "context_files": ["future/new.rs", "symbol:src/lib.rs#Host:struct"],
+                    "model": "codex"
+                }),
+                context.clone(),
+            )
+            .expect("add checkoutless task");
+        let id = created["id"].as_str().expect("task id");
+        assert_eq!(created["context_files"][0], "file:future/new.rs");
+        assert!(created.get("resolved_crew").is_none());
+
+        executor
+            .execute_tool(
+                "orbit.task.update",
+                json!({
+                    "id": id,
+                    "plan": "1. Execute",
+                    "status": "in_progress",
+                    "execution_summary": "Outcome: success",
+                    "model": "codex"
+                }),
+                context.clone(),
+            )
+            .expect("persist verdict fields");
+
+        let source = root.path().join("caller.txt");
+        std::fs::write(&source, "payload").expect("caller artifact");
+        let with_artifact = executor
+            .execute_tool(
+                "orbit.task.artifact.put",
+                json!({
+                    "id": id,
+                    "source_path": source,
+                    "path": "reports/result.txt",
+                    "model": "codex"
+                }),
+                context.clone(),
+            )
+            .expect("put artifact bytes");
+        assert_eq!(with_artifact["execution_summary"], "Outcome: success");
+
+        let reviewed = executor
+            .execute_tool(
+                "orbit.task.review_thread.add",
+                json!({"id": id, "body": "Looks good", "model": "codex"}),
+                context.clone(),
+            )
+            .expect("create review thread");
+        assert_eq!(reviewed["review_threads"].as_array().unwrap().len(), 1);
+        let thread_id = reviewed["review_threads"][0]["thread_id"]
+            .as_str()
+            .expect("thread id");
+        executor
+            .execute_tool(
+                "orbit.task.review_thread.reply",
+                json!({"id": id, "thread_id": thread_id, "body": "Confirmed", "model": "codex"}),
+                context.clone(),
+            )
+            .expect("reply without local scoring config");
+        let resolved = executor
+            .execute_tool(
+                "orbit.task.review_thread.resolve",
+                json!({"id": id, "thread_id": thread_id, "model": "codex"}),
+                context.clone(),
+            )
+            .expect("resolve review thread");
+        assert_eq!(resolved["review_threads"][0]["status"], "resolved");
+        assert_eq!(
+            resolved["review_threads"][0]["messages"]
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+
+        let artifact = executor
+            .execute_tool(
+                "orbit.task.show",
+                json!({"id": id, "fields": "artifacts"}),
+                context,
+            )
+            .expect("show artifact");
+        assert_eq!(artifact[0]["path"], "reports/result.txt");
+        assert_eq!(artifact[0]["content"], "payload");
+        assert!(
+            !root.path().join(".orbit").exists(),
+            "no fabricated checkout"
+        );
+    }
+
+    #[test]
+    fn friction_writes_use_canonical_workspace_partition() {
+        let (root, executor, context) = executor();
+        let result = executor
+            .execute_tool(
+                "orbit.friction.add",
+                json!({"body": "Hub friction", "tags": ["tooling"], "model": "codex"}),
+                context,
+            )
+            .expect("add friction");
+        let path = PathBuf::from(result["path"].as_str().expect("friction path"));
+        assert!(path.starts_with(root.path().join("frictions/workspaces/ws_checkoutless")));
+    }
 }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/mod.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/mod.rs
@@ -23,6 +23,7 @@ mod tests;
 #[cfg(test)]
 pub(crate) mod test_support;
 
+pub use host::HubCoordinationExecutor;
 pub(crate) use host::build_orbit_tool_host;
 pub(crate) use task_locks::{
     emit_expired_reservation_events, emit_task_lock_release_event, merge_task_lock_conflicts,

--- a/crates/orbit-mcp/src/adapter/dispatch.rs
+++ b/crates/orbit-mcp/src/adapter/dispatch.rs
@@ -37,10 +37,35 @@ impl OrbitToolServer {
         Ok(definitions)
     }
 
+    #[cfg(test)]
     pub(super) fn combined_tool_schemas(&self) -> Result<Vec<ToolSchema>, OrbitError> {
         Ok(self
             .combined_tool_definitions()?
             .into_iter()
+            .map(|definition| definition.schema)
+            .collect())
+    }
+
+    /// Return the advertised subset for the trusted effective session grants.
+    ///
+    /// Capability sets are deliberately non-hierarchical. An empty set is a
+    /// hard denial, and a definition is visible only when at least one of its
+    /// adjacent allowed capabilities is present in the session set. Canonical
+    /// name resolution still uses the unfiltered registry so a call to a
+    /// hidden tool reaches the host's audited denial path instead of being
+    /// misclassified as an unknown name.
+    pub(super) fn visible_tool_schemas(&self) -> Result<Vec<ToolSchema>, OrbitError> {
+        let context = self.session_context();
+        Ok(self
+            .combined_tool_definitions()?
+            .into_iter()
+            .filter(|definition| {
+                definition
+                    .policy
+                    .allowed_capabilities()
+                    .iter()
+                    .any(|capability| context.effective_capabilities.contains(capability))
+            })
             .map(|definition| definition.schema)
             .collect())
     }
@@ -127,6 +152,34 @@ impl OrbitToolServer {
             .arguments
             .map(Value::Object)
             .unwrap_or_else(|| Value::Object(Map::new()));
+
+        let definition = self
+            .combined_tool_definitions()
+            .map_err(invalid_definitions_mcp_error)?
+            .into_iter()
+            .find(|definition| definition.schema.name == canonical);
+        if let Some(definition) = definition
+            && !definition
+                .policy
+                .allowed_capabilities()
+                .iter()
+                .any(|capability| session_context.effective_capabilities.contains(capability))
+        {
+            let allowed = definition
+                .policy
+                .allowed_capabilities()
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            let denial = OrbitError::InvalidInput(format!(
+                "MCP capability denied for tool '{canonical}': the effective session set must contain one of [{allowed}]"
+            ));
+            let denial = self
+                .host
+                .reject_tool_call(&canonical, &input, &session_context, denial);
+            return Ok(tool_error_result(&denial));
+        }
 
         let host = Arc::clone(&self.host);
         let graph_tools = Arc::clone(&self.graph_tools);
@@ -215,7 +268,7 @@ impl ServerHandler for OrbitToolServer {
         _ctx: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
         let mut schemas = self
-            .combined_tool_schemas()
+            .visible_tool_schemas()
             .map_err(invalid_definitions_mcp_error)?;
         schemas.sort_by(|a, b| a.name.cmp(&b.name));
         self.refresh_name_map(&schemas)

--- a/crates/orbit-mcp/src/adapter/graph.rs
+++ b/crates/orbit-mcp/src/adapter/graph.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::env;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -499,21 +498,25 @@ fn resolve_worktree(
         None => optional_string(input, "workspace")?,
     };
 
-    // Anchor root for containment: the announced session workspace if present,
-    // otherwise the process working directory. A client-supplied path is ALWAYS
-    // scoped against this root, even when no session workspace was announced —
-    // otherwise an unannounced session lets a client open/read an arbitrary
-    // directory (CWE-22, ORB-00361).
-    let anchor_root = match session_context.workspace.as_deref() {
-        Some(workspace) => canonicalize_dir(absolutize(workspace)?.as_path(), "workspace")?,
-        None => canonicalize_dir(
-            env::current_dir().map_err(OrbitError::from)?.as_path(),
-            "workspace",
-        )?,
-    };
+    // The broker announces the validated exact checkout. Graph dispatch never
+    // falls back to process cwd: doing so aliases worktrees and turns a missing
+    // workspace selector into ambient filesystem authority.
+    let announced = session_context.workspace.as_deref().ok_or_else(|| {
+        OrbitError::InvalidInput(
+            "graph operation requires a validated exact checkout workspace selector; initialize with `_meta.orbit.workspace` or pass `workspace`"
+                .to_string(),
+        )
+    })?;
+    let announced_path = Path::new(announced);
+    if !announced_path.is_absolute() {
+        return Err(OrbitError::InvalidInput(format!(
+            "announced workspace path must be absolute; process cwd is never consulted: {announced}"
+        )));
+    }
+    let anchor_root = canonicalize_dir(announced_path, "workspace")?;
 
     let candidate = match requested.as_deref() {
-        Some(raw) => absolutize(raw)?,
+        Some(raw) => absolutize_against(raw, &anchor_root),
         None => anchor_root.clone(),
     };
     let canonical = canonicalize_dir(candidate.as_path(), "worktree")?;
@@ -528,12 +531,12 @@ fn resolve_worktree(
     Ok(canonical)
 }
 
-fn absolutize(raw: &str) -> Result<PathBuf, OrbitError> {
+fn absolutize_against(raw: &str, anchor: &Path) -> PathBuf {
     let path = Path::new(raw);
     if path.is_absolute() {
-        Ok(path.to_path_buf())
+        path.to_path_buf()
     } else {
-        Ok(env::current_dir().map_err(OrbitError::from)?.join(path))
+        anchor.join(path)
     }
 }
 

--- a/crates/orbit-mcp/src/adapter/tests/dispatch.rs
+++ b/crates/orbit-mcp/src/adapter/tests/dispatch.rs
@@ -92,26 +92,26 @@ async fn missing_policy_is_excluded_and_rejected_before_dispatch() {
 }
 
 #[tokio::test]
-async fn d2_context_membership_does_not_filter_tool_list_or_call() {
+async fn d3_context_membership_filters_tool_list_and_call() {
     let agent_server = OrbitToolServer::new(Arc::new(CapabilityHost));
     let agent_context = agent_server.session_context();
     assert!(agent_context.has_capability(McpCapability::Agent));
     assert!(!agent_context.has_capability(McpCapability::Operator));
     let agent_names = agent_server
-        .combined_tool_schemas()
+        .visible_tool_schemas()
         .expect("agent tool list")
         .into_iter()
         .map(|schema| schema.name)
         .collect::<Vec<_>>();
-    for expected in ["demo.agent", "demo.operator", "demo.runner"] {
-        assert!(agent_names.iter().any(|name| name == expected));
-    }
+    assert!(agent_names.iter().any(|name| name == "demo.agent"));
+    assert!(!agent_names.iter().any(|name| name == "demo.operator"));
+    assert!(!agent_names.iter().any(|name| name == "demo.runner"));
 
     let called = agent_server
         .call_tool_request(CallToolRequestParams::new("demo_operator"))
         .await
-        .expect("D2 does not reject calls from policy metadata");
-    assert_eq!(called.is_error, Some(false));
+        .expect("capability denial is a structured tool error");
+    assert_eq!(called.is_error, Some(true));
 
     let mut operator_context = ToolSessionContext::trusted_local(None, None, None);
     operator_context.effective_capabilities = [McpCapability::Operator].into_iter().collect();
@@ -120,12 +120,37 @@ async fn d2_context_membership_does_not_filter_tool_list_or_call() {
     let operator_server =
         OrbitToolServer::new_with_context(Arc::new(CapabilityHost), operator_context);
     let operator_names = operator_server
-        .combined_tool_schemas()
+        .visible_tool_schemas()
         .expect("operator tool list")
         .into_iter()
         .map(|schema| schema.name)
         .collect::<Vec<_>>();
-    assert_eq!(operator_names, agent_names);
+    assert!(operator_names.iter().any(|name| name == "demo.operator"));
+    assert!(!operator_names.iter().any(|name| name == "demo.agent"));
+    assert!(!operator_names.iter().any(|name| name == "demo.runner"));
+}
+
+#[tokio::test]
+async fn managed_empty_capability_set_is_never_upgraded_and_runner_is_non_hierarchical() {
+    let empty =
+        OrbitToolServer::new_with_context(Arc::new(CapabilityHost), ToolSessionContext::default());
+    assert!(empty.visible_tool_schemas().expect("empty list").is_empty());
+    let denied = empty
+        .call_tool_request(CallToolRequestParams::new("demo_agent"))
+        .await
+        .expect("empty capability denial is structured");
+    assert_eq!(denied.is_error, Some(true));
+
+    let mut runner_context = ToolSessionContext::default();
+    runner_context.effective_capabilities = [McpCapability::Runner].into_iter().collect();
+    let runner = OrbitToolServer::new_with_context(Arc::new(CapabilityHost), runner_context);
+    let names = runner
+        .visible_tool_schemas()
+        .expect("runner list")
+        .into_iter()
+        .map(|schema| schema.name)
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec!["demo.runner"]);
 }
 
 #[tokio::test]

--- a/crates/orbit-mcp/src/adapter/tests/graph.rs
+++ b/crates/orbit-mcp/src/adapter/tests/graph.rs
@@ -190,9 +190,7 @@ async fn graph_tools_invoke_in_process_fixture() {
     });
     let server = OrbitToolServer::new(host);
     // L-0053: graph MCP tests must pin the worktree to their temp fixture.
-    server.replace_session_context(ToolSessionContext::with_workspace(
-        worktree.path().display().to_string(),
-    ));
+    server.replace_session_context(agent_workspace_context(worktree.path()));
 
     let sync = call_json(
         &server,
@@ -334,9 +332,7 @@ async fn graph_tool_errors_are_structured_mcp_tool_errors() {
     });
     let server = OrbitToolServer::new(host);
     // L-0053: graph MCP tests must pin the worktree to their temp fixture.
-    server.replace_session_context(ToolSessionContext::with_workspace(
-        worktree.path().display().to_string(),
-    ));
+    server.replace_session_context(agent_workspace_context(worktree.path()));
 
     let result = server
         .call_tool_request(request_with_args(
@@ -370,9 +366,7 @@ async fn graph_show_returns_labeled_byte_fallback_for_non_utf8_source() {
     });
     let server = OrbitToolServer::new(host);
     // L-0053: graph MCP tests must pin the worktree to their temp fixture.
-    server.replace_session_context(ToolSessionContext::with_workspace(
-        worktree.path().display().to_string(),
-    ));
+    server.replace_session_context(agent_workspace_context(worktree.path()));
 
     call_json(
         &server,
@@ -437,7 +431,7 @@ async fn graph_show_rejects_out_of_workspace_path_without_session_workspace() {
         payload["message"]
             .as_str()
             .expect("message")
-            .contains("must stay within initialized workspace"),
+            .contains("requires a validated exact checkout workspace selector"),
         "unexpected error message: {payload}"
     );
     // No source bytes were returned and no graph was opened/indexed for the
@@ -473,6 +467,12 @@ fn assert_param_names(schema: &orbit_common::types::ToolSchema, expected: &[&str
         .map(|param| param.name.as_str())
         .collect();
     assert_eq!(names, expected);
+}
+
+fn agent_workspace_context(path: &Path) -> ToolSessionContext {
+    let mut context = ToolSessionContext::trusted_local(None, None, None);
+    context.workspace = Some(path.display().to_string());
+    context
 }
 
 fn with_workspace_params(base: &[&'static str]) -> Vec<&'static str> {

--- a/crates/orbit-mcp/src/lib.rs
+++ b/crates/orbit-mcp/src/lib.rs
@@ -77,6 +77,19 @@ pub trait McpHost: Send + Sync + 'static {
         session_context: ToolSessionContext,
     ) -> Result<Value, OrbitError>;
 
+    /// Observe a transport-level capability denial. The default preserves the
+    /// denial unchanged; audited brokers may record it without executing the
+    /// tool or constructing a workspace runtime.
+    fn reject_tool_call(
+        &self,
+        _name: &str,
+        _input: &Value,
+        _session_context: &ToolSessionContext,
+        denial: OrbitError,
+    ) -> OrbitError {
+        denial
+    }
+
     /// Apply host policy and auditing around a tool implemented inside this
     /// adapter. The secure default rejects the call; hosts must explicitly
     /// admit adapter-owned tools and invoke `dispatch` inside their boundary.

--- a/crates/orbit-mcp/tests/mcp_wire_roundtrip.rs
+++ b/crates/orbit-mcp/tests/mcp_wire_roundtrip.rs
@@ -403,8 +403,8 @@ async fn tools_list_matches_wire_snapshot() {
         .map(|tool| tool["name"].as_str().expect("tool name"))
         .collect();
     assert!(names.contains(&"orbit_task_add"), "names: {names:?}");
-    assert!(names.contains(&"orbit_host_list"), "names: {names:?}");
-    assert!(names.contains(&"orbit_workspace_list"), "names: {names:?}");
+    assert!(!names.contains(&"orbit_host_list"), "names: {names:?}");
+    assert!(!names.contains(&"orbit_workspace_list"), "names: {names:?}");
     assert!(names.contains(&"orbit_graph_search"), "names: {names:?}");
     let mut sorted = names.clone();
     sorted.sort_unstable();
@@ -444,7 +444,11 @@ async fn tools_list_matches_wire_snapshot() {
 
 #[tokio::test]
 async fn global_registry_discovery_executes_without_a_workspace() {
-    let (mut client, host, _workspace) = start_fixture().await;
+    let workspace = TempDir::new().expect("temp workspace");
+    let host = std::sync::Arc::new(FileStoreHost::new(workspace.path().to_path_buf()));
+    let mut operator = ToolSessionContext::trusted_local(None, None, None);
+    operator.effective_capabilities = [McpCapability::Operator].into_iter().collect();
+    let mut client = WireClient::start(OrbitToolServer::new_with_context(host.clone(), operator));
     client.initialize(None).await;
 
     let hosts = client.call_tool("orbit_host_list", json!({})).await;

--- a/crates/orbit-mcp/tests/snapshots/wire_tools_list.json
+++ b/crates/orbit-mcp/tests/snapshots/wire_tools_list.json
@@ -308,15 +308,6 @@
     "name": "orbit_graph_trace"
   },
   {
-    "description": "List registered hub hosts with sanitized lifecycle, aliases, and workspace-presence freshness (operator, hub placement).",
-    "inputSchema": {
-      "additionalProperties": true,
-      "properties": {},
-      "type": "object"
-    },
-    "name": "orbit_host_list"
-  },
-  {
     "description": "Create a task record in the fixture store.",
     "inputSchema": {
       "additionalProperties": true,
@@ -382,14 +373,5 @@
       "type": "object"
     },
     "name": "orbit_task_show"
-  },
-  {
-    "description": "List workspaces with declared owner and sanitized execution-profile freshness (operator, hub placement).",
-    "inputSchema": {
-      "additionalProperties": true,
-      "properties": {},
-      "type": "object"
-    },
-    "name": "orbit_workspace_list"
   }
 ]

--- a/crates/orbit-store/src/file/friction_store/mod.rs
+++ b/crates/orbit-store/src/file/friction_store/mod.rs
@@ -14,6 +14,192 @@ use serde_json::{Value, json};
 pub use orbit_common::types::validate_friction_id;
 
 const TAGS_FILENAME: &str = "tags.yaml";
+const HUB_FRICTION_MIGRATION_MARKERS: &str = ".migration-markers";
+
+/// Canonical checkout-independent friction state for a logical workspace.
+pub fn canonical_hub_friction_root(
+    global_root: &Path,
+    workspace_id: &str,
+) -> Result<PathBuf, OrbitError> {
+    let workspace_id = workspace_id.trim();
+    if workspace_id.is_empty()
+        || workspace_id == "."
+        || workspace_id == ".."
+        || workspace_id.contains(['/', '\\'])
+    {
+        return Err(OrbitError::InvalidInput(format!(
+            "invalid logical workspace ID '{workspace_id}' for hub friction state"
+        )));
+    }
+    Ok(global_root
+        .join("frictions")
+        .join("workspaces")
+        .join(workspace_id))
+}
+
+/// Publishes legacy checkout-local friction state into the canonical hub root.
+///
+/// The destination directory is renamed into place only after a complete copy.
+/// The separate marker is the commit record: reads continue using `legacy_root`
+/// until it exists. Identical interrupted/repeated publishes are idempotent;
+/// differing source and destination trees fail closed.
+pub fn prepare_hub_friction_root(
+    global_root: &Path,
+    workspace_id: &str,
+    legacy_root: Option<&Path>,
+) -> Result<PathBuf, OrbitError> {
+    let canonical = canonical_hub_friction_root(global_root, workspace_id)?;
+    let parent = canonical.parent().ok_or_else(|| {
+        OrbitError::Store("canonical hub friction root has no parent".to_string())
+    })?;
+    let marker = parent
+        .join(HUB_FRICTION_MIGRATION_MARKERS)
+        .join(format!("{workspace_id}.complete"));
+    let lock = parent
+        .join(HUB_FRICTION_MIGRATION_MARKERS)
+        .join(format!("{workspace_id}.migration"));
+    with_exclusive_file_lock(&lock, "hub friction migration", || {
+        fs::create_dir_all(parent).map_err(|error| OrbitError::Io(error.to_string()))?;
+        if marker.exists() {
+            if !canonical.is_dir() {
+                return Err(OrbitError::Store(format!(
+                    "hub friction migration marker for workspace '{workspace_id}' exists but canonical root '{}' is unavailable",
+                    canonical.display()
+                )));
+            }
+            return Ok(canonical.clone());
+        }
+
+        let source = legacy_root.filter(|path| path.exists());
+        if canonical.exists() {
+            if let Some(source) = source
+                && !directory_trees_identical(source, &canonical)?
+            {
+                return Err(OrbitError::Store(format!(
+                    "hub friction migration conflict for workspace '{workspace_id}': legacy '{}' differs from uncommitted canonical '{}'",
+                    source.display(),
+                    canonical.display()
+                )));
+            }
+        } else if let Some(source) = source {
+            let staging = parent.join(format!(
+                ".{workspace_id}.migration-{}-{}",
+                std::process::id(),
+                Utc::now().timestamp_nanos_opt().unwrap_or_default()
+            ));
+            if staging.exists() {
+                fs::remove_dir_all(&staging).map_err(|error| OrbitError::Io(error.to_string()))?;
+            }
+            if let Err(error) = copy_directory_tree(source, &staging) {
+                let _ = fs::remove_dir_all(&staging);
+                return Err(error);
+            }
+            fs::rename(&staging, &canonical).map_err(|error| {
+                let _ = fs::remove_dir_all(&staging);
+                OrbitError::Io(format!(
+                    "publish hub friction migration '{}': {error}",
+                    canonical.display()
+                ))
+            })?;
+        } else {
+            fs::create_dir_all(&canonical).map_err(|error| OrbitError::Io(error.to_string()))?;
+        }
+
+        atomic_write_text(&marker, "schema_version: 1\nstate: complete\n")?;
+        Ok(canonical.clone())
+    })
+}
+
+/// Resolves the readable root without treating an unmarked publish as committed.
+pub fn readable_hub_friction_root(
+    global_root: &Path,
+    workspace_id: &str,
+    legacy_root: Option<&Path>,
+) -> Result<PathBuf, OrbitError> {
+    let canonical = canonical_hub_friction_root(global_root, workspace_id)?;
+    let parent = canonical.parent().ok_or_else(|| {
+        OrbitError::Store("canonical hub friction root has no parent".to_string())
+    })?;
+    let marker = parent
+        .join(HUB_FRICTION_MIGRATION_MARKERS)
+        .join(format!("{workspace_id}.complete"));
+    if !marker.exists()
+        && let Some(legacy) = legacy_root.filter(|path| path.exists())
+    {
+        return Ok(legacy.to_path_buf());
+    }
+    Ok(canonical)
+}
+
+fn copy_directory_tree(source: &Path, destination: &Path) -> Result<(), OrbitError> {
+    fs::create_dir_all(destination).map_err(|error| OrbitError::Io(error.to_string()))?;
+    for entry in fs::read_dir(source).map_err(|error| OrbitError::Io(error.to_string()))? {
+        let entry = entry.map_err(|error| OrbitError::Io(error.to_string()))?;
+        let file_type = entry
+            .file_type()
+            .map_err(|error| OrbitError::Io(error.to_string()))?;
+        let target = destination.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_directory_tree(&entry.path(), &target)?;
+        } else if file_type.is_file() {
+            fs::copy(entry.path(), target).map_err(|error| OrbitError::Io(error.to_string()))?;
+        } else {
+            return Err(OrbitError::Store(format!(
+                "hub friction migration refuses non-file entry '{}'",
+                entry.path().display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn directory_trees_identical(left: &Path, right: &Path) -> Result<bool, OrbitError> {
+    fn snapshot(
+        root: &Path,
+        current: &Path,
+        directories: &mut BTreeSet<PathBuf>,
+        files: &mut BTreeMap<PathBuf, Vec<u8>>,
+    ) -> Result<(), OrbitError> {
+        for entry in fs::read_dir(current).map_err(|error| OrbitError::Io(error.to_string()))? {
+            let entry = entry.map_err(|error| OrbitError::Io(error.to_string()))?;
+            let file_type = entry
+                .file_type()
+                .map_err(|error| OrbitError::Io(error.to_string()))?;
+            if file_type.is_dir() {
+                let relative = entry
+                    .path()
+                    .strip_prefix(root)
+                    .map_err(|error| OrbitError::Store(error.to_string()))?
+                    .to_path_buf();
+                directories.insert(relative);
+                snapshot(root, &entry.path(), directories, files)?;
+            } else if file_type.is_file() {
+                let relative = entry
+                    .path()
+                    .strip_prefix(root)
+                    .map_err(|error| OrbitError::Store(error.to_string()))?
+                    .to_path_buf();
+                files.insert(
+                    relative,
+                    fs::read(entry.path()).map_err(|error| OrbitError::Io(error.to_string()))?,
+                );
+            } else {
+                return Err(OrbitError::Store(format!(
+                    "hub friction migration refuses non-file entry '{}'",
+                    entry.path().display()
+                )));
+            }
+        }
+        Ok(())
+    }
+    let mut left_directories = BTreeSet::new();
+    let mut right_directories = BTreeSet::new();
+    let mut left_files = BTreeMap::new();
+    let mut right_files = BTreeMap::new();
+    snapshot(left, left, &mut left_directories, &mut left_files)?;
+    snapshot(right, right, &mut right_directories, &mut right_files)?;
+    Ok(left_directories == right_directories && left_files == right_files)
+}
 
 #[derive(Debug, Clone)]
 pub struct FrictionAddParams {

--- a/crates/orbit-store/src/file/friction_store/tests/friction_store.rs
+++ b/crates/orbit-store/src/file/friction_store/tests/friction_store.rs
@@ -5,6 +5,74 @@ use orbit_common::test_fixtures::TEST_CODEX_MODEL;
 use orbit_common::types::{TaskPriority, TaskType};
 
 #[test]
+fn hub_migration_publishes_complete_tree_and_is_idempotent() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let legacy = temp.path().join("legacy");
+    fs::create_dir_all(legacy.join("2026-07")).expect("legacy month");
+    fs::write(legacy.join("tags.yaml"), "tooling: Tools\n").expect("taxonomy");
+    fs::write(legacy.join("2026-07/F001.md"), "record\n").expect("record");
+
+    let canonical = prepare_hub_friction_root(temp.path(), "ws_test", Some(&legacy))
+        .expect("publish migration");
+    assert_eq!(
+        fs::read(canonical.join("2026-07/F001.md")).unwrap(),
+        b"record\n"
+    );
+    assert_eq!(
+        prepare_hub_friction_root(temp.path(), "ws_test", Some(&legacy)).unwrap(),
+        canonical
+    );
+    assert_eq!(
+        readable_hub_friction_root(temp.path(), "ws_test", Some(&legacy)).unwrap(),
+        canonical
+    );
+}
+
+#[test]
+fn hub_migration_accepts_identical_interrupted_publish_and_commits_marker() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let legacy = temp.path().join("legacy");
+    let canonical = canonical_hub_friction_root(temp.path(), "ws_test").unwrap();
+    fs::create_dir_all(&legacy).unwrap();
+    fs::create_dir_all(&canonical).unwrap();
+    fs::write(legacy.join("tags.yaml"), "same\n").unwrap();
+    fs::write(canonical.join("tags.yaml"), "same\n").unwrap();
+
+    assert_eq!(
+        readable_hub_friction_root(temp.path(), "ws_test", Some(&legacy)).unwrap(),
+        legacy
+    );
+    prepare_hub_friction_root(temp.path(), "ws_test", Some(&legacy)).unwrap();
+    assert_eq!(
+        readable_hub_friction_root(temp.path(), "ws_test", Some(&legacy)).unwrap(),
+        canonical
+    );
+}
+
+#[test]
+fn hub_migration_conflict_fails_closed_and_preserves_legacy_reads() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let legacy = temp.path().join("legacy");
+    let canonical = canonical_hub_friction_root(temp.path(), "ws_test").unwrap();
+    fs::create_dir_all(&legacy).unwrap();
+    fs::create_dir_all(&canonical).unwrap();
+    fs::write(legacy.join("tags.yaml"), "legacy\n").unwrap();
+    fs::write(canonical.join("tags.yaml"), "different\n").unwrap();
+
+    let error = prepare_hub_friction_root(temp.path(), "ws_test", Some(&legacy))
+        .expect_err("conflict must fail");
+    assert!(error.to_string().contains("migration conflict"));
+    assert_eq!(
+        readable_hub_friction_root(temp.path(), "ws_test", Some(&legacy)).unwrap(),
+        legacy
+    );
+    assert_eq!(
+        fs::read(canonical.join("tags.yaml")).unwrap(),
+        b"different\n"
+    );
+}
+
+#[test]
 fn id_allocation_resets_across_month_boundary() {
     let temp = tempfile::tempdir().expect("tempdir");
     let root = temp.path();

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -50,7 +50,8 @@ pub mod skill_store {
 pub mod friction_store {
     pub use crate::file::friction_store::{
         FrictionAddParams, FrictionListFilter, FrictionUpdateParams, StoredFrictionRecord,
-        add_friction, ensure_default_tag_taxonomy, friction_stats, friction_tags, list_frictions,
+        add_friction, canonical_hub_friction_root, ensure_default_tag_taxonomy, friction_stats,
+        friction_tags, list_frictions, prepare_hub_friction_root, readable_hub_friction_root,
         resolve_friction, resolve_friction_by_task, show_friction, update_friction,
         validate_friction_id,
     };

--- a/crates/orbit-store/src/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/tests/mod.rs
@@ -904,6 +904,25 @@ fn workspace_id_for_orbit_dir_returns_id_from_config() {
 }
 
 #[test]
+fn workspace_id_for_orbit_dir_accepts_canonical_logical_registry_id() {
+    let temp = TempDir::new().expect("tempdir");
+    let orbit_dir = temp.path().join(".orbit");
+    write_workspace_config(
+        &orbit_dir,
+        &WorkspaceConfig {
+            schema_version: 1,
+            workspace_id: "ws_orbit-main".into(),
+        },
+    )
+    .expect("write config");
+
+    assert_eq!(
+        workspace_id_for_orbit_dir(&orbit_dir).expect("workspace id"),
+        "ws_orbit-main"
+    );
+}
+
+#[test]
 fn workspace_id_for_orbit_dir_missing_file_names_path_and_key() {
     let temp = TempDir::new().expect("tempdir");
     let orbit_dir = temp.path().join(".orbit");

--- a/crates/orbit-store/src/sqlite/task_registry/workspace_id.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/workspace_id.rs
@@ -52,9 +52,12 @@ pub(super) fn sanitize_slug(raw: &str) -> String {
 
 pub(super) fn validate_workspace_id(raw: &str) -> Result<String, OrbitError> {
     let trimmed = raw.trim();
+    if is_valid_logical_workspace_id(trimmed) {
+        return Ok(trimmed.to_string());
+    }
     let Some((slug, suffix)) = trimmed.rsplit_once('-') else {
         return Err(OrbitError::InvalidInput(format!(
-            "workspace_id '{trimmed}' must use <slug>-<6char> form"
+            "workspace_id '{trimmed}' must use canonical ws_<name> or legacy <slug>-<6char> form"
         )));
     };
     if !is_valid_workspace_slug(slug)
@@ -65,10 +68,21 @@ pub(super) fn validate_workspace_id(raw: &str) -> Result<String, OrbitError> {
             .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
     {
         return Err(OrbitError::InvalidInput(format!(
-            "workspace_id '{trimmed}' must use <slug>-<6char> form"
+            "workspace_id '{trimmed}' must use canonical ws_<name> or legacy <slug>-<6char> form"
         )));
     }
     Ok(trimmed.to_string())
+}
+
+fn is_valid_logical_workspace_id(value: &str) -> bool {
+    let Some(name) = value.strip_prefix("ws_") else {
+        return false;
+    };
+    !name.is_empty()
+        && name
+            .as_bytes()
+            .iter()
+            .all(|byte| matches!(byte, b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_'))
 }
 
 fn is_valid_workspace_slug(slug: &str) -> bool {

--- a/crates/orbit-tools/src/builtin/orbit/task/artifact_put.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/artifact_put.rs
@@ -1,4 +1,6 @@
-use std::path::PathBuf;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 
 use orbit_common::types::{OrbitError, TaskArtifact, ToolParam, ToolSchema};
 use serde_json::{Map, Value, json};
@@ -6,6 +8,10 @@ use serde_json::{Map, Value, json};
 use crate::{OrbitBuiltinAction, Tool, ToolContext};
 
 pub struct OrbitTaskArtifactPutTool;
+
+/// Keep caller-local artifact reads bounded before the byte payload crosses
+/// the coordination boundary. The hub never receives a caller-local path.
+pub(crate) const MAX_ARTIFACT_CONTENT_BYTES: u64 = 1_048_576;
 
 impl Tool for OrbitTaskArtifactPutTool {
     fn schema(&self) -> ToolSchema {
@@ -49,8 +55,7 @@ impl Tool for OrbitTaskArtifactPutTool {
             &["path", "artifact_path", "artifactPath"],
         )?;
         let resolved_source_path = resolve_source_path(ctx, &source_path);
-        let artifact =
-            TaskArtifact::from_source_file(&resolved_source_path, artifact_path.as_deref())?;
+        let artifact = read_bounded_artifact(&resolved_source_path, artifact_path.as_deref())?;
 
         let mut update_input = input.as_object().cloned().unwrap_or_else(Map::new);
         update_input.insert("id".to_string(), Value::String(id));
@@ -75,6 +80,57 @@ impl Tool for OrbitTaskArtifactPutTool {
             OrbitBuiltinAction::TaskUpdate,
         )
     }
+}
+
+fn read_bounded_artifact(
+    source_path: &Path,
+    artifact_path: Option<&str>,
+) -> Result<TaskArtifact, OrbitError> {
+    let mut file = File::open(source_path).map_err(|error| {
+        OrbitError::Io(format!(
+            "read artifact source '{}': {error}",
+            source_path.display()
+        ))
+    })?;
+    let mut content = Vec::new();
+    file.by_ref()
+        .take(MAX_ARTIFACT_CONTENT_BYTES + 1)
+        .read_to_end(&mut content)
+        .map_err(|error| {
+            OrbitError::Io(format!(
+                "read artifact source '{}': {error}",
+                source_path.display()
+            ))
+        })?;
+    if content.len() as u64 > MAX_ARTIFACT_CONTENT_BYTES {
+        return Err(OrbitError::InvalidInput(format!(
+            "artifact source '{}' exceeds the {} byte content limit",
+            source_path.display(),
+            MAX_ARTIFACT_CONTENT_BYTES
+        )));
+    }
+
+    let path = artifact_path
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            source_path
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+        })
+        .ok_or_else(|| {
+            OrbitError::InvalidInput(format!(
+                "artifact source '{}' has no file name; provide `path`",
+                source_path.display()
+            ))
+        })?;
+    Ok(TaskArtifact {
+        media_type: orbit_common::types::media_type_for_artifact_path(&path).to_string(),
+        path,
+        content,
+        created_by: None,
+    })
 }
 
 fn resolve_source_path(ctx: &ToolContext, source_path: &str) -> PathBuf {

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/artifact_put.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/artifact_put.rs
@@ -103,3 +103,43 @@ fn artifact_put_rejects_agent_identity_field() {
 
     assert!(error.to_string().contains("use `model`"));
 }
+
+#[test]
+fn artifact_put_read_failure_never_calls_host() {
+    let host = RecordingHost::default();
+    let ctx = ToolContext {
+        orbit_host: Some(Arc::new(host.clone())),
+        ..Default::default()
+    };
+    let error = OrbitTaskArtifactPutTool
+        .execute(
+            &ctx,
+            json!({"id": "ORB-00001", "source_path": "/definitely/missing"}),
+        )
+        .expect_err("missing source must fail locally");
+
+    assert!(error.to_string().contains("read artifact source"));
+    assert!(host.call.lock().expect("host call").is_none());
+}
+
+#[test]
+fn artifact_put_size_failure_never_calls_host() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let source = dir.path().join("large.bin");
+    std::fs::write(
+        &source,
+        vec![0_u8; (MAX_ARTIFACT_CONTENT_BYTES + 1) as usize],
+    )
+    .expect("write oversized source");
+    let host = RecordingHost::default();
+    let ctx = ToolContext {
+        orbit_host: Some(Arc::new(host.clone())),
+        ..Default::default()
+    };
+    let error = OrbitTaskArtifactPutTool
+        .execute(&ctx, json!({"id": "ORB-00001", "source_path": source}))
+        .expect_err("oversized source must fail locally");
+
+    assert!(error.to_string().contains("content limit"));
+    assert!(host.call.lock().expect("host call").is_none());
+}

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -182,5 +182,6 @@ Each record contains timestamp, level, target, and structured fields. After [T20
 - **[ORB-10200]** — Derive CLI audit metadata and the other cross-cutting command policies from one exhaustive command-operation registry.
 - **[ORB-10225]** — Route in-process graph MCP calls through the safe-surface allowlist and shared runtime audit boundary.
 - **[ORB-10228]** — Add trusted MCP context, anti-spoofing, full capability-set audit, per-call correlation, and additive audit migration v7.
+- **[ORB-10262]** — Enforce MCP capability and exact-checkout placement preflight, retaining one trusted call ID and one denial row before runtime/store mutation, including global checkoutless denials.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/auditability/specs/coverage-matrix.md
+++ b/docs/design/auditability/specs/coverage-matrix.md
@@ -36,6 +36,7 @@ Every Orbit operation that touches code, task state, persistent runtime state, e
 - New operation classes must update this matrix in the same PR that introduces the operation.
 - Registry-backed and in-process MCP tools must have parity for preflight denial, runtime success, and tool failure, with one trusted call context across the path.
 - MCP initialize/tool JSON cannot become trusted audit identity, capability, transport, or correlation; malicious-payload wire tests must pin this boundary.
+- MCP capability, workspace, binding, role, owner, placement, and unknown-name denials produce exactly one row with D2's call ID before runtime/store mutation; checkoutless/global denials use the global coordination audit database.
 
 ## Known Gaps
 
@@ -57,4 +58,4 @@ When reviewing a change that mutates code or state, ask:
 
 ## Agent Signature
 
-Last revised by codex / gpt-5.5 for [T20260427-0023].
+Last revised by codex for [ORB-10262].

--- a/docs/design/mcp-bridge/2_design.md
+++ b/docs/design/mcp-bridge/2_design.md
@@ -10,7 +10,7 @@ summary: Target design for a local Orbit MCP broker with one SSH hub link, hub-o
 tags: [mcp, remote-access, host-registry, bridge, ssh, routing]
 paths: ["crates/orbit-mcp/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-registry/**", "crates/orbit-core/src/command/tool.rs", "crates/orbit-common/src/types/tool.rs"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access, orbit-search, orbit-graph, project-learnings]
-related_artifacts: [ORB-00424, ORB-10257, ORB-10267, ORB-10302, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235]
+related_artifacts: [ORB-00424, ORB-10257, ORB-10262, ORB-10267, ORB-10302, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235]
 ---
 
 # Orbit MCP Bridge — Design
@@ -19,8 +19,9 @@ This document specifies the **target** design. The host-registry identity,
 workspace, registry core/projections, C3 discovery tools, and typed placement,
 capability, scope, and trusted-session metadata they depend on have landed. C4
 places identity, catalog, cache, and the store-backed registry service in the
-dedicated `orbit-registry` domain crate ([ORB-10302], [ADR-0235]); the
-checkout-aware broker and transport surfaces here remain pending. It replaces both
+dedicated `orbit-registry` domain crate ([ORB-10302], [ADR-0235]). The local
+checkout-aware broker, exact-worktree runtime cache, and effective-capability
+filtering landed in [ORB-10262]; remote transport remains pending. It replaces both
 Bridge's HTTP parity layer and the earlier
 per-workspace-authority draft with a local broker that has one remote destination:
 the coordination hub. It covers client→hub transport and local tool placement. The
@@ -641,10 +642,11 @@ schemas.
 
 ### Phase 2 — placement-aware local broker
 
-- Add `hub`, `owner`, `local-derived`, and `composite` metadata.
-- Preserve exact session checkout/worktree paths for graph/docs.
-- Enforce owner and replica-mode preflight without spoke-to-spoke discovery.
-- Add capability filtering independent of placement.
+- Implemented by [ORB-10262]: consume canonical `hub`, `owner`, `local-derived`,
+  and `composite` metadata; preserve exact session checkout/worktree paths for
+  graph dispatch and runtime-cache identity; enforce owner/replica preflight
+  without spoke-to-spoke discovery; and filter `tools/list`/`tools/call` by the
+  non-hierarchical effective capability set.
 
 ### Phase 3 — singular hub link
 

--- a/docs/design/mcp-bridge/2_design.md
+++ b/docs/design/mcp-bridge/2_design.md
@@ -141,9 +141,12 @@ the fixed remote command; `mcp.toml` cannot inject arbitrary shell text.
 ### 2.3 Hub-local short circuit
 
 When the current machine's role is hub, hub-class calls dispatch directly through
-the local `OrbitRuntime`/global coordination runtime. The broker does not SSH to
-itself or add a second MCP serialization boundary. Placement and capability
-preflight remain identical to the remote path.
+the checkout-independent coordination executor keyed by stable `workspace_id`.
+That executor opens only global task/friction coordination stores: it does not
+construct `OrbitRuntime`, `WorkspacePaths`, a checkout, owner stores, or local
+model/scoreboard configuration. The broker does not SSH to itself or add a
+second MCP serialization boundary. Placement and capability preflight remain
+identical to the remote path.
 
 ## 3. Workspace, Role, and Session Resolution
 
@@ -382,6 +385,17 @@ through the hub. Current knowledge does **not** flow across owners in v1: the hu
 serves it only when the hub owns that workspace, and never proxies to a spoke owner.
 Every other machine reads a pulled Git replica explicitly or routes actionable work
 as a task to the owner. Graph/docs remain local.
+
+Hub friction state is partitioned at
+`<global_root>/frictions/workspaces/<workspace_id>`. Legacy checkout-local state
+is copied to a staging tree and atomically published before a separate completion
+marker commits the migration. Identical repeats are idempotent, differing trees
+fail closed, and reads remain on the legacy tree until the marker exists.
+
+`orbit.task.artifact.put` completes capability, workspace, and placement
+preflight before opening the caller-local source. It reads at most the typed
+content limit and sends `{path, media_type, content}` bytes to hub execution;
+caller-local paths never cross the coordination boundary.
 
 ### 6.2 Knowledge creation
 
@@ -646,7 +660,9 @@ schemas.
   and `composite` metadata; preserve exact session checkout/worktree paths for
   graph dispatch and runtime-cache identity; enforce owner/replica preflight
   without spoke-to-spoke discovery; and filter `tools/list`/`tools/call` by the
-  non-hierarchical effective capability set.
+  non-hierarchical effective capability set. Hub task, artifact, review-thread,
+  verdict, and friction calls use the stable-ID checkoutless coordination
+  executor; `task.show(with_context=true)` remains explicitly local-derived.
 
 ### Phase 3 — singular hub link
 

--- a/docs/design/mcp-bridge/4_decisions.md
+++ b/docs/design/mcp-bridge/4_decisions.md
@@ -10,7 +10,7 @@ summary: Accepted ADR log for the coupled MCP Bridge and Host Registry v1 contra
 tags: [mcp, remote-access, host-registry, bridge]
 paths: ["crates/orbit-mcp/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-registry/**", "crates/orbit-core/src/command/tool.rs"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access]
-related_artifacts: [ORB-00424, ORB-10245, ORB-10267, ORB-10302, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235]
+related_artifacts: [ORB-00424, ORB-10245, ORB-10262, ORB-10267, ORB-10302, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235]
 ---
 
 # Orbit MCP Bridge — Decisions
@@ -62,7 +62,7 @@ and pin the one hub `machine_id` out of band in machine-local `mcp.toml`.
 
 ## ADR-0228 — Local placement broker with capability-set filtering
 
-**Status:** Accepted · 2026-07 · [ORB-10245] froze tool routing and authorization; [ORB-10267] registered the first operator-only, hub-placement canonical discovery tools (`orbit.host.list`, `orbit.workspace.list`) in the canonical registry and the versioned conformance fixture.
+**Status:** Accepted · 2026-07 · [ORB-10245] froze tool routing and authorization; [ORB-10267] registered the first operator-only, hub-placement canonical discovery tools (`orbit.host.list`, `orbit.workspace.list`) in the canonical registry and the versioned conformance fixture; [ORB-10262] implemented the local exact-checkout broker and capability enforcement.
 
 ### Context
 
@@ -189,8 +189,10 @@ adapter, runtime profile/ship construction in `orbit-core`, persistence in
   canonical builtin registry and the versioned conformance fixture, with every pre-existing tool
   defaulting to typed `workspace-required`. Each discovery tool is backed by one sanitized,
   path-free registry snapshot. C3 proves the real runtime/store action path with no session
-  workspace or checkout binding for the enumerated workspace; D3 still owns construction of the
-  checkoutless broker plus effective-session `tools/list` omission and `tools/call` denial.
+  workspace or checkout binding for the enumerated workspace.
+- [ORB-10262] — replaced startup cwd discovery and `EmptyMcpHost` with the canonical
+  schema-listing broker, exact-checkout resolution/cache identity, placement preflight, and
+  effective-session `tools/list` omission plus hidden-name `tools/call` denial.
 - [ORB-10302] — moved the coupled registry domain into `orbit-registry` and retained
   MCP ownership of serialization/dispatch only ([ADR-0235]).
 

--- a/docs/design/mcp-bridge/4_decisions.md
+++ b/docs/design/mcp-bridge/4_decisions.md
@@ -192,7 +192,11 @@ adapter, runtime profile/ship construction in `orbit-core`, persistence in
   workspace or checkout binding for the enumerated workspace.
 - [ORB-10262] — replaced startup cwd discovery and `EmptyMcpHost` with the canonical
   schema-listing broker, exact-checkout resolution/cache identity, placement preflight, and
-  effective-session `tools/list` omission plus hidden-name `tools/call` denial.
+  effective-session `tools/list` omission plus hidden-name `tools/call` denial. Hub coordination
+  calls now execute by stable workspace ID without `OrbitRuntime` or a fabricated checkout;
+  task artifacts cross the hub boundary as bounded bytes, review persistence is independent of
+  local scoreboard/model configuration, and canonical friction state uses marker-committed
+  migration under the global workspace partition.
 - [ORB-10302] — moved the coupled registry domain into `orbit-registry` and retained
   MCP ownership of serialization/dispatch only ([ADR-0235]).
 

--- a/docs/design/mcp-session-context/2_design.md
+++ b/docs/design/mcp-session-context/2_design.md
@@ -10,7 +10,7 @@ doc_role: design
 tags: ["mcp-session-context", "mcp", "workspace"]
 paths: ["crates/orbit-mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool.rs", "crates/orbit-cli/src/command/mcp/**"]
 related_features: ["mcp-session-context", "task-artifacts"]
-related_artifacts: ["ORB-00256", "ORB-10228", "ADR-0181", "ADR-0149"]
+related_artifacts: ["ORB-00256", "ORB-10228", "ORB-10262", "ADR-0181", "ADR-0199", "ADR-0149"]
 ---
 
 # MCP Session Context — Design
@@ -39,7 +39,7 @@ Clients announce workspace with:
 
 `OrbitToolServer` stores a `ToolSessionContext` in an `RwLock` for the lifetime of the stdio session. Each `tools/call` snapshots that context, generates exactly one unique `mcp_call_id` before name/exposure preflight, and passes the same snapshot through registry-backed or graph dispatch.
 
-The CLI `RuntimeMcpHost` forwards the context into `OrbitRuntime::execute_tool_command_dispatch_with_session_context`, which places it on `ToolContext` and audit. Unknown/unexposed denial, runtime success/failure, and graph success/failure retain the same per-call context.
+The CLI `BrokerMcpHost` resolves and validates the logical workspace plus any exact local checkout before constructing or selecting an `OrbitRuntime`, then forwards the trusted context into `OrbitRuntime::execute_tool_command_dispatch_with_session_context`, which places it on `ToolContext` and audit. Unknown/unexposed denial, runtime success/failure, and graph success/failure retain the same per-call context.
 
 The trusted fields are `workspace_id`, caller/process `machine_id` and display `host_id`, `transport`, the complete sorted `effective_capabilities` set, `origin_session_id`, `mcp_call_id`, and optional typed `leased_run {run_id, lease_id}`. A standalone stdio session is always `transport=local`, has exactly `{agent}`, and audits as `role=unverified`. Ambient `ORBIT_*` identity/correlation is ignored unless `ORBIT_MANAGED_RUN_CONTEXT` authenticates the existing managed envelope.
 
@@ -63,17 +63,18 @@ This means existing explicit-workspace clients continue to work, while MCP clien
 
 Legacy audit `host` remains the executing process hostname and `session_id` retains its old meaning. Caller/process machine and display-host fields are additive. `origin_session_id` does not replace `session_id`. `job_run_id` remains the only run column: a trusted lease run populates it when empty or must match it; `lease_id` is additive. Migration v7 adds nullable columns and capability-set JSON without rewriting v1-v6 rows.
 
-The trusted context carries the entire effective capability set so later authorization and `tools/list` filtering can test membership directly. [ORB-10228] propagates and audits the set but deliberately leaves enforcement to the placement/capability broker units; no arbitrary member, ordinal, maximum, or scalar ceiling represents authority.
+The trusted context carries the entire effective capability set. [ORB-10262] tests membership directly for both `tools/list` and `tools/call`; an empty set is denial and no arbitrary member, ordinal, maximum, or scalar ceiling represents authority.
 
 ## 6. Concerns & Honest Limitations
 
 The session context currently covers stdio sessions; future HTTP or multi-session transports must preserve the same per-session isolation rather than promoting the value to process-global state.
 
-The external channel carries a workspace address, not a trusted workspace ID. The local adapter may validate that address and separately populate `workspace_id`; explicit resolution, broker routing, and hub negotiation remain later MCP Bridge units.
+The external channel carries a workspace address, not a trusted workspace ID. The local broker validates an absolute path against Git common-directory identity, `.orbit/config.yaml`, the logical registry, local role, and owner before separately populating `workspace_id`. Process cwd and `ORBIT_ROOT` are not fallbacks. Hub-link negotiation remains a later MCP Bridge unit.
 
 ## Task References
 
 - [ORB-00256] implemented the initial session context channel and workspace resolver.
 - [ORB-10228] implemented trusted provenance, anti-spoofing, capability-set propagation and audit, call correlation, and audit migration v7.
+- [ORB-10262] implemented exact-checkout workspace resolution, placement preflight, capability enforcement, and runtime caching by exact binding.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-session-context/4_decisions.md
+++ b/docs/design/mcp-session-context/4_decisions.md
@@ -10,7 +10,7 @@ doc_role: decisions
 tags: ["mcp-session-context", "mcp", "workspace"]
 paths: ["crates/orbit-mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool.rs", "crates/orbit-cli/src/command/mcp/**"]
 related_features: ["mcp-session-context", "task-artifacts"]
-related_artifacts: ["ORB-00256", "ORB-00406", "ORB-10228", "ADR-0181", "ADR-0199", "ADR-0149"]
+related_artifacts: ["ORB-00256", "ORB-00406", "ORB-10228", "ORB-10262", "ADR-0181", "ADR-0199", "ADR-0149"]
 ---
 
 # MCP Session Context — Decisions
@@ -39,16 +39,16 @@ ADR log for MCP session context. Format follows [docs/design/CONVENTIONS.md §4]
 
 ## ADR-0199 — Workspace_path-addressable MCP host tools with surface-scoped containment
 
-**Status:** Proposed · 2026-06 · [ORB-00406]
+**Status:** Accepted · 2026-07 · [ORB-00406], implemented by [ORB-10262]
 
 **Context.** MCP host tools (`orbit.task.*`, `orbit.adr.*`, `orbit.learning.*`, `orbit.friction.*`, `orbit.search`) bind to a single `OrbitRuntime` resolved at `serve` launch from cwd discovery; when none is found the server installs `EmptyMcpHost` and advertises an empty `tools/list`, so clients that launch the server without the repo as cwd lose the entire host surface (e.g. Cowork, which launches with cwd / `CLAUDE_PROJECT_DIR` set to an internal scratchpad; see [ORB-00405] and learning L-0065). [ADR-0181] already routes workspace *addressing* per-call → session-context, but tool *registration* still gates on launch discovery. The real alternatives were to keep launch-gated registration and require every client to fix cwd, or to advertise host tools unconditionally and resolve the runtime per call.
 
-**Decision.** Advertise the host tool schemas unconditionally and resolve the target `OrbitRuntime` per call via the [ADR-0181] chain (explicit `workspace_path` → session context → clear missing-workspace error), reusing `OrbitRuntime::try_initialize_existing`. Containment is scoped by surface by design: the graph adapter keeps its strict anchor containment ([2_design.md] / [ORB-00361]) because it indexes the entire worktree and is therefore a path-traversal (CWE-22) read surface; host tools, which only operate on a structured `.orbit/` store, validate only that the resolved path is an initialized Orbit workspace and honor the [ADR-0149] `workspace_id` binding — no traversal anchor is imposed on them.
+**Decision.** Advertise canonical schema-plus-policy definitions unconditionally and resolve the target route per call via the [ADR-0181] chain (non-empty explicit `workspace` → session context → clear missing-workspace error). Absolute local paths are validated against the logical registry, Git common directory, and `.orbit/config.yaml`; relative paths, process cwd, and `ORBIT_ROOT` are never routing inputs. Exact checkout identity is retained for graph containment and runtime caching.
 
 **Consequences.**
 - `tools/list` returns the full host surface even when launch discovery finds nothing; execution binds to the caller-supplied workspace, making Orbit usable from any MCP client regardless of launch cwd / `CLAUDE_PROJECT_DIR` and removing the per-user `--root` workaround (L-0065).
 - The graph adapter's strict containment is retained and explicitly justified as tree-indexing-specific, so the asymmetry between graph and host surfaces is intentional rather than an oversight.
-- Omitting `workspace_path` preserves current CLI behavior (resolve from cwd / `--root`).
+- Omitting workspace selection is an actionable error; MCP never inherits CLI cwd/`--root` discovery.
 - Cost: the host runtime stops being a single process-lifetime singleton — the server must resolve and cache a runtime per workspace and keep the [ADR-0181] session thread-through correct across that cache, adding per-call resolution state that every future host tool must respect.
 
 ## Task References
@@ -56,5 +56,6 @@ ADR log for MCP session context. Format follows [docs/design/CONVENTIONS.md §4]
 - [ORB-00256] implemented MCP ambient workspace session context.
 - [ORB-00406] proposes workspace_path-addressable host tools ([ADR-0199]).
 - [ORB-10228] accepted and implemented the trusted-provenance amendment to [ADR-0181].
+- [ORB-10262] accepted and implemented ADR-0199 through the exact-checkout local broker.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10262](https://orbit-cli.com/tasks/ORB-10262) — Start MCP anywhere with an exact-checkout local broker

### Description

## Problem

Orbit's MCP host is still constructed from a workspace-local runtime and current checkout assumptions. The accepted Host Registry + MCP Bridge contract requires `orbit mcp serve` to start outside any checkout, advertise the canonical schema+policy surface before a workspace is selected, and route each call only after resolving an explicit logical workspace and any required exact local checkout binding. Cwd-based guessing would misroute multi-worktree calls and hub coordination tools; constructing an OrbitRuntime merely to list schemas would reintroduce the same coupling.

This is Unit D3 of implementation umbrella ORB-10246. It follows the path-free logical catalog/task binding (B2/B3), canonical schema-adjacent MCP policy (D1), and trusted session/audit context (D2).

## Required outcome

Introduce a local `BrokerMcpHost`/equivalent seam that:

- can start outside a repository and enumerate canonical schemas plus placement/capability policy without constructing a workspace runtime;
- resolves workspace selection in the fixed order explicit request selector -> trusted initialize/session workspace metadata -> actionable error, never cwd;
- distinguishes stable logical workspace IDs from path selectors, validating a path by its `.orbit/config.yaml` identity and retaining the exact worktree root;
- caches local runtimes by exact checkout binding so two worktrees for one logical workspace never alias;
- executes hub/local short-circuit routes through the same placement/capability preflight and trusted session context;
- lets hub-only coordination tools operate for a registered logical workspace with no local checkout;
- requires an explicit local checkout for `local_derived` work and fails before mutation on missing or ambiguous bindings; and
- represents an owner route to another machine as unavailable until the later transport units rather than fabricating a local or spoke-to-spoke path.

## Boundaries

- Local startup, resolution, caching, placement/capability preflight, and hub/local dispatch only.
- No `[hub]` config, SSH child process, initialize negotiation across a link, registration choreography, owner connector, runner polling, lease state, or network retry.
- Do not broaden accepted placement semantics or add a fallback to cwd, hostname, workspace-name prefixes, or guessed checkout paths.
- Preserve standalone behavior and existing MCP schema/result shapes when started inside a single initialized workspace.
- If D1 cannot expose canonical schema+policy definitions without a workspace runtime, fix D1 before starting this task rather than creating a third registry here.

### Acceptance Criteria

- `orbit mcp serve` starts outside any repository and enumerates the complete canonical schema-plus-policy registry without constructing an `OrbitRuntime` or opening a workspace checkout; `tools/list` advertises only the effective capability-filtered subset.
- Workspace resolution precedence is a non-empty explicit `workspace` selector (stable registered ID or local path), then `initialize.params._meta.orbit.workspace`, then an actionable missing-workspace error; process cwd is never consulted for startup, listing, dispatch, or graph-path resolution.
- External initialize metadata may supply only the workspace selector. Stable `workspace_id`, caller/process host identity, transport, effective capability, origin session, `mcp_call_id`, and optional lease identity come only from the trusted D2 seams and cannot be overridden by ordinary tool input or untrusted initialize metadata.
- A path selector is accepted only at the local broker, must identify a checkout containing a valid `.orbit/config.yaml`, must resolve to the matching stable logical workspace, and preserves that exact selected checkout/worktree root for local execution; hub/coordination dispatch receives only the stable workspace ID.
- An ID-only selector permits hub-placement calls for an active logical workspace with no local checkout. `local-derived` and locally executing `owner` calls require one validated exact local checkout; missing or ambiguous bindings fail before runtime construction or mutation, name the workspace ID, and instruct the caller to provide a path.
- The runtime cache is keyed by the resolved exact checkout/worktree binding rather than logical workspace ID: repeated calls for one exact root reuse its entry, while deterministic two-worktree fixtures for one logical workspace receive distinct runtime and derived-index entries.
- `tools/list` and `tools/call` enforce the same effective session capability independently of placement. Table-driven tests cover `hub`, `owner`, `local-derived`, and `composite` policies across `agent`, `operator`, and `runner`, prove the capability sets are non-hierarchical, and prove `composite` is never treated as an unconditional local route.
- Owner preflight resolves the declared owner and local role: a local owner uses its validated exact checkout; a hub owner uses the same hub-local short circuit only when its canonical owner checkout exists; another spoke owner returns current-state-unavailable before mutation; a replica never authors locally; and no hub-to-owner or spoke-to-spoke route is invented.
- Standalone and hub-local hub calls pass through the same canonical placement/capability preflight and trusted D2 session/audit context, with no SSH-to-self path. In spoke mode, a hub call with no configured transport returns an actionable unavailable error with zero local coordination-domain writes.
- Existing single-workspace, in-checkout MCP behavior remains compatible: the default agent surface retains its advertised names, input schemas, descriptions, and result shapes, while graph operations use the announced exact checkout instead of process cwd.
- The broker consumes C3's canonical workspace-unscoped marker rather than matching tool-name prefixes: an operator can list and call orbit.host.list and orbit.workspace.list without a workspace selector or checkout, while agent and runner sessions neither advertise nor execute those exact tools.
- A checkoutless hub-coordination executor routes the current hub-policy task, artifact, review-thread, and friction tools from stable workspace_id through the global coordination registry/audit context without constructing WorkspacePaths, manufacturing a checkout, or opening owner/local-derived stores.
- Hub friction execution uses one canonical per-workspace coordination root with an additive idempotent migration from the legacy checkout-derived location; tests prove no duplicate or split friction history and zero spoke-local coordination writes.
- Exact-checkout resolution ignores both process cwd and ORBIT_ROOT, validates .orbit/config.yaml against the stable logical workspace, retains the exact matched override or linked-worktree shared/local roots, and never collapses two worktrees to one runtime.
- Composite preflight establishes every required placement/capability route before executing any component; failure leaves every component side-effect free. Route composition is schema/policy driven and does not add F/G knowledge or search semantics.
- Targeted `orbit-core` runtime/workspace-registry tests, `orbit-mcp` dispatch/graph tests, `orbit-cli` broker and stdio round-trip tests, `git diff --check`, and `make ci-fast` pass.
- A declared worktree/path route never disables protection or authority checks on Git discovery failure: missing/non-Git roots, mismatched common directories, stale bindings, malformed config, and identity/role drift are typed fail-closed errors before runtime construction or provider/tool dispatch.
- Checkoutless hub task add/update performs only canonical syntactic selector normalization and preserves every supplied selector without filesystem pruning; it stores an explicit crew value without consulting a checkout-local config, and execution-profile validation remains deferred to H1/H3. Hub task serialization never derives crew from a local runtime.
- For orbit.task.show with_context=true, D3 treats the local context branch as a required local-derived component: it succeeds only when hub/task and exact-checkout routes safely collapse on the standalone or hub-owner machine, otherwise returns a typed local-derived-unavailable error before any branch runs. Ordinary checkoutless task.show remains hub-only and path-free.
- An empty trusted effective-capability set is a hard denial. Only the standalone session constructor may deliberately create exactly {agent}; normalization of a managed/brokered empty set never upgrades it. tools/call resolves canonical and advertised aliases against the unfiltered registry, then returns a typed capability denial for hidden names while tools/list omits them.
- Every capability, workspace, binding, role, owner, placement, and composite preflight denial retains D2's one mcp_call_id and produces exactly one audit row before any runtime/store mutation.
- Before every runtime-cache lookup, the broker revalidates stable workspace identity, local role, declared owner, exact repo/shared/local roots, and .orbit/config.yaml. Cache identity includes workspace ID plus canonical exact roots; cached runtimes are convenience only and never preserve stale authority after role/config/binding changes.
- D3's temporary composite rule is explicit: until F/G provide tool-specific composition, a composite call is allowed only when every required component is known from canonical policy and all routes safely collapse to the same validated standalone or hub-owner exact checkout; otherwise preflight fails closed. No component or placement is inferred from a tool-name prefix.
- Hub friction state uses the canonical path <global_root>/frictions/workspaces/<workspace_id>, never runtime.data_root(). Legacy checkout-local friction migration atomically publishes a complete destination plus per-workspace marker; byte-identical repeats are idempotent, differing source/destination records fail closed without overwrite or merge, and an uncommitted migration continues reading the legacy source so one active history is visible at a time.
- `orbit.task.artifact.put` keeps its public caller-local `source_path` input, but the broker completes capability/workspace/placement authorization before reading it, materializes a bounded typed content payload locally, and sends content plus metadata—not the path—to the hub coordination executor. The hub never opens or interprets the caller path; read/preflight/size failures leave zero hub mutation.
- Hub review-thread create/reply/resolve and verdict persistence do not require checkout-local scoreboard or model configuration. The canonical coordination record commits from trusted hub/session data alone; any local scoring/enrichment is non-authoritative, requires an independently validated exact checkout route, and cannot make a checkoutless coordination write fail after mutation.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Completed the checkoutless hub coordination executor for hub-policy task, artifact, review-thread, verdict, and friction operations keyed by stable workspace ID, without constructing OrbitRuntime, WorkspacePaths, or a fabricated checkout.
- Added canonical workspace friction state under `<global_root>/frictions/workspaces/<workspace_id>` with staged atomic publication, marker commit, legacy read continuity, identical-repeat idempotence, and conflict fail-closed behavior.
- Made `orbit.task.artifact.put` authorize before caller-local I/O, enforce a typed 1 MiB content bound, and transfer bytes plus metadata rather than a caller path; preflight/read/size failures do not call the hub executor.
- Made checkoutless review-thread create/reply/resolve and verdict persistence independent of checkout-local scoreboard/model configuration.
- Added deterministic broker placement/capability/audit, coordination, friction migration, artifact failure, and stable workspace-ID initialization coverage. Updated the accepted MCP Bridge design/decision records.
- Preserved D3 boundaries: no hub config, SSH/link worker, owner connector, F/G composition, runner/lease work, or multi-hub/HA scaffold.

Validation:
- `cargo test -p orbit-cli command::mcp::tests -- --nocapture` — 18 passed
- `cargo test -p orbit-core checkoutless_hub_tests -- --nocapture` — 2 passed
- `cargo test -p orbit-store hub_migration -- --nocapture` — 3 passed
- `cargo test -p orbit-tools artifact_put -- --nocapture` — 4 passed
- `cargo test -p orbit-cli workspace_init_ -- --nocapture` — 13 passed
- `cargo test -p orbit-cli nameless_tmp_workspace -- --nocapture` — 1 passed
- `cargo clippy -p orbit-cli -p orbit-core -p orbit-store -p orbit-tools` — passed with one pre-existing `too_many_arguments` warning in `orbit-core/src/command/tool.rs`
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- `make ci-fast` — passed

Remaining risk:
- The PR head is four disjoint commits behind current `origin/agent-main`. They concern resident-orchestrator documentation and an automation delivery gate; rebasing this already-published branch would require rewriting history, so the branch was left intact for Daniel's review.
- PR remains draft. No review was requested and no merge was attempted.

</details>

## Validation

- Reported in the execution summary above.

## Branch Freshness

- Base ref: `origin/agent-main`
- Base SHA: `849670c024180ed0911aadff25f546f6cecb0b8d`
- Head ref: `orbit/ORB-10262-6a5bea14`
- Head SHA: `0a9ff51d294e8861205a5a5a7fe9f8fa7d88aab2`
- Behind base: 4
- Ahead of base: 2
