### PR TITLE
Revise resident-orchestrator design docs to resolve review findings

### DIFF
--- a/docs/design/resident-orchestrator/1_overview.md
+++ b/docs/design/resident-orchestrator/1_overview.md
@@ -1,7 +1,7 @@
 ---
 title: Resident Orchestrator — Overview
 owner: codex
-last_updated: 2026-07-17
+last_updated: 2026-07-18
 status: Draft
 feature: resident-orchestrator
 doc_role: overview

--- a/docs/design/resident-orchestrator/2_design.md
+++ b/docs/design/resident-orchestrator/2_design.md
@@ -1,7 +1,7 @@
 ---
 title: Resident Orchestrator — Design
 owner: codex
-last_updated: 2026-07-17
+last_updated: 2026-07-18
 status: Draft
 feature: resident-orchestrator
 doc_role: design
@@ -41,6 +41,15 @@ The `epic` tag is deliberately behavioral only at the resident pickup boundary. 
 the task schema or create a new task type. Child tasks are recognized by `parent_id`, not by a
 special child tag.
 
+This differs from the legacy `task_epic_pipeline`, whose `load_epic` path recognizes a root by
+`TaskType::Feature`. During retirement stages 1–3, the two selectors are disjoint by workspace:
+enabling the resident routine marks that workspace resident-owned and must make legacy epic-pipeline
+admission reject runs from the same workspace. A workspace without the resident capability may
+continue using the legacy Feature-typed path. Task type and tag may coexist on one task, but the
+workspace capability chooses exactly one claimant; neither selector may treat the other marker as
+permission to bypass that boundary. The proposed marker choice and coexistence rule are named in
+[4_decisions.md](./4_decisions.md).
+
 ## 2. Workspace-Local Resident Identity
 
 Each participating workspace owns an activity named `resident_orchestrator`. The activity is the
@@ -57,7 +66,6 @@ spec:
   backend: cli
   provider: codex
   model: gpt-5.6-sol
-  max_iterations: 1
   wall_clock_timeout_seconds: 7200
   instruction: |
     Read the resident identity and active rules before acting.
@@ -68,6 +76,11 @@ The example values are illustrative; each workspace chooses its own provider, mo
 instruction. The resolved provider/model must be explicit and must match the named resident's
 identity. Defaults or role overrides that silently change the resolved identity are invalid for a
 resident activity.
+
+`AgentLoopSpec.max_iterations` in `activity_v2.rs` bounds turns in Orbit's HTTP loop. The CLI
+dispatcher launches one provider process and does not apply that field to provider turns, so the
+resident example omits it: a full shepherd cycle is bounded by the 7,200-second wall clock, while
+provider turn knobs remain provider/harness policy rather than Orbit activity configuration.
 
 Identity memory remains outside Orbit's task store. The activity instruction points the CLI agent
 to its versioned memory layer, and the CLI harness loads the workspace's normal repository
@@ -99,15 +112,22 @@ Selection order is deterministic:
 
 1. resume the oldest `in-progress`, root, `epic` task;
 2. otherwise select the highest-priority ready `backlog` root epic, then creation order;
-3. otherwise select a `proposed` root epic only when workspace policy permits the resident to plan
-   and start it; and
-4. otherwise return a successful no-op.
+3. otherwise return a successful no-op.
+
+V1 does not pick up `proposed` epics. A human or upstream authority must approve one into `backlog`
+before the resident can claim it; a future policy surface for proposed pickup remains an open
+question in [3_vision.md](./3_vision.md).
 
 The first version permits one active epic per workspace. The routine uses `overlap: forbid`, pins
 one host, and the selector always resumes active ownership before admitting new work. These three
 constraints avoid a new lease or assignee subsystem. A concurrent manual lifecycle transition is
 resolved by the task store's existing status validation; the losing cycle refreshes instead of
 forcing state.
+
+`overlap: forbid` prevents concurrent fires of this routine, not a manual invocation of the same
+activity. Status validation is the admission backstop: only one contender can transition the
+selected backlog epic to `in-progress`; a loser refreshes, while contenders resuming an already
+active epic are made dispatch-safe by the authoritative task/run lookup in Section 4.
 
 ## 4. Resident Cycle Contract
 
@@ -121,14 +141,29 @@ supervisor. During each cycle it must:
 4. create independently shippable child tasks with `parent_id`, strong acceptance criteria,
    precise `context_files`, dependencies, priority, complexity, and crew;
 5. dispatch only explicit ready child IDs through the workspace's normal shipment workflow;
-6. observe existing child runs before dispatching anything, so a restart never duplicates an
-   in-flight shipment;
+6. query the authoritative run-list projection by each ready child task ID before dispatching;
+   observe any non-terminal matching run instead of submitting another shipment;
 7. obtain and enforce the workspace's independent-review policy;
-8. resolve failures, review findings, merge conflicts, and stale branches within its workspace;
-9. verify landed commits and child lifecycle state rather than trusting agent prose or a PR merge
+8. treat waiting for human review/merge approval as an explicit gate: record the pending PR and
+   required approver evidence, then exit until that evidence exists;
+9. resolve failures, review findings, merge conflicts, and stale branches within its workspace;
+10. verify landed commits and child lifecycle state rather than trusting agent prose or a PR merge
    button; and
-10. complete the parent only after every required child is terminal and the parent-level acceptance
+11. complete the parent only after every required child is terminal and the parent-level acceptance
     criteria have been verified as an integrated outcome.
+
+Shipment submission takes explicit child task IDs. Before a Run becomes dispatchable, the shipment
+path must persist those IDs on the Run in the same transaction as Run creation; the run-list
+projection indexed by task ID is therefore the authoritative run↔task association. Comments,
+execution summaries, and resident checkpoints may point to that association, but are never its
+source of truth. This makes the pre-dispatch query reliable even if the resident crashes immediately
+after submission and before writing its own checkpoint.
+
+For the `ws_orbit` canary, the review gate is Daniel's human merge approval; agent review is off by
+default. Planner, implementer, and reviewer crew labels are activity labels on one resolved
+provider/model/backend assignment and do not establish independent review. The resident may prepare
+and repair the candidate, but it must enter the human-approval wait state rather than approving or
+merging on Daniel's behalf.
 
 The resident may inspect adjacent workspaces to understand an interface, but it must not silently
 edit or dispatch into them. A cross-workspace dependency becomes a separate epic assignment in the
@@ -142,7 +177,7 @@ No correctness may depend on CLI conversation history. The recovery state is the
 - the parent task's status, plan, comments, execution summary, and acceptance criteria;
 - child tasks connected by `parent_id`;
 - child `dependencies` and relations;
-- workflow/run IDs attached to tasks or recorded in artifacts/comments;
+- workflow Runs whose transactionally stored task IDs are exposed by the run-list projection;
 - review threads and structured verdicts; and
 - repository/PR state verified during the cycle.
 
@@ -158,8 +193,9 @@ Crash behavior follows from where the failure occurs:
 | After selection, before start | Parent remains proposed/backlog | Re-evaluate and retry |
 | After parent start | Parent remains `in-progress` | Resume it before new work |
 | After child creation | Children remain attached | Continue decomposition/dispatch |
-| After workflow submit | Run/task link remains authoritative | Observe; do not redispatch |
-| While waiting for review or CI evidence | Parent remains active | Recheck only the required gate |
+| After workflow submit, before resident checkpoint | Run already contains the child task ID and appears in the task-indexed run-list projection | Observe the matching run; do not redispatch |
+| While waiting for agent review or CI evidence | Parent remains active with the pending gate recorded | Recheck only the required gate |
+| While waiting for human review/merge approval | Parent remains active with the PR and required approval evidence recorded | Recheck human approval/merge evidence; do not redispatch or complete |
 | Genuine product-authority blocker | Parent moves to `blocked` with exact question | Stop automatic retries |
 
 ## 6. Routine Contract
@@ -174,7 +210,7 @@ hosts: [dk-server-1]
 trigger: { cron: "*/5 * * * *", missed_run: skip }
 target: job:resident_epic_cycle
 policy:
-  timeout_minutes: 120
+  timeout_minutes: 135
   overlap: forbid
 ```
 
@@ -186,6 +222,12 @@ Routine definitions remain disabled by default when seeded. Enabling a resident 
 workspace decision, and the activity must resolve to a valid CLI provider/model on the pinned host
 before enablement.
 
+The routine timeout must be strictly greater than the resident activity wall clock plus job and
+checkpoint overhead. For the 120-minute activity example, the routine reserves 15 minutes of
+headroom (`135` minutes total), so routine-level expiry cannot preempt the activity supervisor's
+shutdown and final durable checkpoint. Workspaces that change the activity wall clock must increase
+the routine timeout by at least the same delta while retaining explicit headroom.
+
 ## 7. Child Shipment and Completion
 
 The resident reuses existing leaf delivery workflows. It does not implement code inside the epic
@@ -193,15 +235,17 @@ cycle unless the workspace's delivery policy explicitly treats a bounded change 
 Normally it promotes ready children and invokes shipment with explicit task IDs, selected mode,
 crew, base branch, and independent review configuration.
 
-An epic may have sequential and parallel children. Ordering is expressed durably through child
-`dependencies`; disjoint ready children may be shipped concurrently within the workspace's normal
-run and lock limits. Dependency inference that exists only in a model's reasoning is incomplete —
-the resident must write it to the child tasks before dispatch.
+An epic may have sequential and parallel children. Ordering is expressed durably by creating
+`BlockedBy` relations on child tasks; `dependencies` is the read projection of those relations, not
+a stored scalar field. Disjoint ready children may be shipped concurrently within the workspace's
+normal run and lock limits. Dependency inference that exists only in a model's reasoning is
+incomplete — the resident must create the relations before dispatch.
 
 The parent does not become `done` merely because all children reached `review`. Completion requires:
 
 - every required child is `done`, `rejected`, or explicitly accepted as out of scope;
 - no open blocking review thread remains;
+- every required PR has the human review/merge approval evidence required by workspace policy;
 - required PRs are merged and candidate commits are on the integration branch;
 - parent-level integration checks pass; and
 - the parent execution summary contains a structured final verdict and evidence pointers.

--- a/docs/design/resident-orchestrator/3_vision.md
+++ b/docs/design/resident-orchestrator/3_vision.md
@@ -1,7 +1,7 @@
 ---
 title: Resident Orchestrator — Vision
 owner: codex
-last_updated: 2026-07-17
+last_updated: 2026-07-18
 status: Draft
 feature: resident-orchestrator
 doc_role: vision
@@ -39,6 +39,10 @@ durable task state are sufficient before adding routing or coordination machiner
 6. **Should identity be promoted beyond an activity asset?** If many products need resident agents,
    a typed resident profile may become worthwhile. It should be justified by repeated configuration
    drift, not introduced before the activity-based canary.
+7. **Should residents pick up proposed epics?** V1 requires an upstream authority to move an epic
+   to `backlog`; it deliberately has no implicit proposed-work authority. A future version could
+   add an explicit policy block to the routine or workspace configuration, but only once its
+   approval provenance and operator visibility are defined.
 
 ## 2. Prior Work
 

--- a/docs/design/resident-orchestrator/4_decisions.md
+++ b/docs/design/resident-orchestrator/4_decisions.md
@@ -1,7 +1,7 @@
 ---
 title: Resident Orchestrator — Decisions
 owner: codex
-last_updated: 2026-07-17
+last_updated: 2026-07-18
 status: Draft
 feature: resident-orchestrator
 doc_role: decisions
@@ -23,6 +23,21 @@ This folder is still Draft and has no allocated ADR. The candidate choices descr
 [2_design.md](./2_design.md)—workspace-addressed `epic` tasks, bounded CLI ownership cycles, and
 replacement rather than conversion of the HTTP epic pipeline—remain proposals until the design is
 accepted and implementation tasks are allocated.
+
+## Candidate Decision: Epic Marker and Legacy Coexistence
+
+**Proposal.** Resident orchestration selects root tasks by the `epic` tag rather than changing or
+depending on `TaskType`. The legacy `task_epic_pipeline` continues to identify epics by
+`TaskType::Feature` until it is retired.
+
+**Coexistence rule.** The paths are disjoint by workspace capability during retirement stages 1–3.
+Once a workspace enables its resident routine, legacy epic-pipeline admission must reject that
+workspace; workspaces without the resident capability may continue to use the Feature-typed legacy
+path. A task may carry both markers, but may never be claimed by both paths.
+
+**Why this proposal.** A tag is an explicit delegation signal that does not overload the broad
+`feature` type, while workspace-level exclusion provides a fail-closed migration boundary without
+rewriting existing legacy tasks. This remains a candidate decision, not an allocated ADR.
 
 ## Task References
 


### PR DESCRIPTION
## Task

[ORB-10314](https://orbit-cli.com/tasks/ORB-10314) — Revise resident-orchestrator design docs to resolve review findings

### Description

Docs-only revision of `docs/design/resident-orchestrator/` (Draft) to resolve six findings from Daniel's design review (2026-07-18). No code changes; the folder stays `status: Draft` and no ADR is allocated (allocation happens at acceptance).

## Findings to resolve

1. **Duplicate-dispatch prevention gap (§4.6, §5).** Recovery state currently lists run IDs "attached to tasks or recorded in artifacts/comments", relying on the resident to checkpoint the run↔task link. A crash after workflow submission but before the checkpoint makes the in-flight run invisible to the next cycle → redispatch. Revise the design to require an authoritative link that does not depend on agent discipline: either the shipment path writes the run↔task association atomically at submit, or the cycle contract mandates querying workflow runs by task ID (e.g. the run-list projection) before any dispatch. Update the §5 crash table row "After workflow submit" accordingly.

2. **`epic` tag coexistence window (§1, §8).** The `epic` tag is a new convention; the legacy `task_epic_pipeline` recognizes epics by `TaskType::Feature` (see `load_epic` / `epic_orchestrator.yaml`). During retirement stages 1–3 both paths are live. Specify what prevents a Feature-typed root task from being claimed by both paths (e.g. legacy pipeline excluded from resident workspaces, or explicit disjoint selection predicates), and record the tag-vs-task-type choice as a named candidate decision in `4_decisions.md` (as a proposal, not an allocated ADR).

3. **Selection rule 3 policy location (§3).** "Select a `proposed` root epic only when workspace policy permits" names no concrete config surface. Either specify where that policy lives (routine policy block, activity spec, or workspace config) or drop `proposed` pickup from v1 and note it in §10 / vision open questions.

4. **Budget semantics (§2 example, §6).** Verify against `activity_v2.rs` what `max_iterations: 1` means for a CLI `agent_loop` and correct the example if it would cap provider turns (a full shepherd cycle must not be starved; per ADR-0217 turn knobs stay out of orbit specs). Also give the routine `timeout_minutes` explicit headroom above the activity `wall_clock_timeout_seconds` (currently both 7200s) so a routine-level kill cannot truncate the exit checkpoint; state the headroom rule in §6.

5. **Human approval as first-class wait state (§4.7, §5, §7).** The canary policy is human (Daniel) merge approval with no agent review by default, and crew role labels do not create reviewer independence [ORB-10130]. Name "waiting for human review/merge approval" as an explicit gate in the cycle contract and add it to the §5 crash/resume table; §7 completion must reference the human approval evidence, not only merged-PR state.

6. **Minor precision.** (a) §7: `dependencies` is a projection of `BlockedBy` relations, not a stored scalar — note that the write path is relation creation. (b) §3: `overlap: forbid` guards routine fires but not a concurrent manual invocation of the same activity; add one sentence on why status validation is a sufficient backstop.

## Scope

Edit only files under `docs/design/resident-orchestrator/`. Update `last_updated` in frontmatter. Keep the house design-doc style and section numbering; do not renumber existing sections unless required. Do not allocate ADR IDs, create implementation tasks, or touch code/assets.

### Acceptance Criteria

- Each of the six review findings is resolved in the resident-orchestrator docs with the specific sections cited above updated, or explicitly moved to 3_vision.md open questions with rationale (permitted only for finding 3's proposed-pickup option).
- 2_design.md specifies an authoritative run<->task linkage mechanism for duplicate-dispatch prevention that does not depend on the agent remembering to checkpoint, and the crash table reflects it.
- 2_design.md and 4_decisions.md name the epic-tag-vs-TaskType::Feature choice and specify the coexistence rule preventing double-claim while task_epic_pipeline is still live.
- The activity example's max_iterations value is verified against activity_v2.rs semantics and corrected if it would starve a shepherd cycle; the routine example gives timeout_minutes headroom above the activity wall clock and states the rule.
- Human review/merge approval appears as an explicit wait state in the cycle contract, crash table, and completion criteria.
- Docs remain status: Draft, no ADR allocated, no code or asset changes; frontmatter last_updated bumped.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Revised the resident cycle contract to use a transactionally persisted Run-to-task association and task-indexed run lookup before dispatch, including crash-safe resume behavior.
- Made resident and legacy epic selectors disjoint by workspace capability, documented the epic-tag versus TaskType::Feature proposal, and moved proposed-epic pickup out of v1 into a vision open question.
- Verified that max_iterations is not applied to CLI provider turns, removed the misleading example field, and gave the 120-minute activity a 135-minute routine timeout with an explicit headroom rule.
- Added human review/merge approval as a first-class wait gate in the cycle, crash table, canary policy, and completion evidence.
- Clarified BlockedBy relation writes behind the dependencies projection and manual-invocation concurrency behavior.
- Bumped all resident-orchestrator frontmatter dates while preserving Draft status and allocating no ADR.
Assessment: The six review findings are resolved within the docs-only scope, with authoritative recovery and coexistence contracts stated as implementation requirements.
Validation:
- make ci-fast
- git diff --check
- Targeted checks confirmed all four docs remain Draft with last_updated 2026-07-18, no ADR heading was allocated, and only docs/design/resident-orchestrator files changed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10314-6a5bf7dc`
- Behind base: 0
- Ahead of base: 1