### PR TITLE
Make task listing status-neutral, recent-first, and bounded

### DIFF
--- a/.orbit/learnings/L-0099/learning.yaml
+++ b/.orbit/learnings/L-0099/learning.yaml
@@ -1,0 +1,27 @@
+schema_version: 1
+id: L-0099
+status: active
+scope:
+  paths:
+  - crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
+  - crates/orbit-core/src/runtime/orbit_tool_host/host.rs
+  - crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
+  tags:
+  - task-lifecycle
+  - mcp
+summary: 'orbit.task.list has two MCP host implementations that must stay in sync: task_tools::list (standard dispatch) and HubCoordinationExecutor::list_tasks (checkoutless hub) in host.rs.'
+body: |-
+  When changing the behavior of the `orbit.task.list` MCP tool (filters, ordering, limit), remember there are **two** OrbitToolHost executor paths that both match `OrbitBuiltinAction::TaskList`:
+
+  1. `dispatch.rs` routes to `super::task_tools::list` — the standard workspace-checkout runtime path used by the CLI's `orbit tool run`, the MCP stdio server, and `execute_tool_command`.
+  2. `host.rs` has `HubCoordinationExecutor::list_tasks` (`OrbitBuiltinAction::TaskList => self.list_tasks(input)`) — the checkoutless hub-coordination broker path (ORB-10262, 'MCP anywhere').
+
+  Editing only one silently diverges the two surfaces. ORB-10310 (status-neutral, newest-first, default-50 limit) had to update both, plus the shared `super::input::task_list_limit` parser and the `orbit-tools` schema in `crates/orbit-tools/src/builtin/orbit/task/list.rs`. There is no single dispatch table; grep `OrbitBuiltinAction::TaskList` and audit every `impl OrbitToolHost` before assuming one edit covers the tool.
+evidence:
+- kind: task
+  reference: ORB-10310
+- kind: task
+  reference: ORB-10262
+created_at: 2026-07-18T23:06:27.835490482Z
+updated_at: 2026-07-18T23:06:27.835490482Z
+created_by: claude

--- a/crates/orbit-cli/src/command/task/list.rs
+++ b/crates/orbit-cli/src/command/task/list.rs
@@ -1,7 +1,7 @@
 use clap::{ArgAction, Args};
 use orbit_core::{
-    ExternalRef, OrbitError, OrbitRuntime, TaskPriority, TaskStatus, TaskType,
-    task_dependencies_ready, task_selectors_contain_path,
+    DEFAULT_TASK_LIST_LIMIT, ExternalRef, OrbitError, OrbitRuntime, TaskPriority, TaskStatus,
+    TaskType, task_dependencies_ready, task_selectors_contain_path,
 };
 use serde_json::Value;
 
@@ -11,15 +11,22 @@ use super::output::{print_task_table, task_to_json, task_to_signal_json};
 
 #[derive(Args)]
 #[command(
-    after_help = "Examples:\n  orbit task list\n  orbit task list --all\n  orbit task list --status backlog\n  orbit task list --status in-progress,review\n  orbit task list --type feature\n  orbit task list --priority high\n  orbit task list --parent T12345678-123456\n  orbit task list --ref jira:ENG-1234\n  orbit task list --has-ref jira\n  orbit task list --tag perf --tag bench\n  orbit task list --path src/auth/login.rs\n  orbit task list --json"
+    after_help = "Examples:\n  orbit task list\n  orbit task list --limit 100\n  orbit task list --status backlog\n  orbit task list --status in-progress,review\n  orbit task list --type feature\n  orbit task list --priority high\n  orbit task list --parent T12345678-123456\n  orbit task list --ref jira:ENG-1234\n  orbit task list --has-ref jira\n  orbit task list --tag perf --tag bench\n  orbit task list --path src/auth/login.rs\n  orbit task list --json"
 )]
 pub struct TaskListArgs {
-    /// Filter by one or more statuses (comma-separated). Defaults to backlog,in-progress.
+    /// Filter by one or more statuses (comma-separated). Opt-in: with no
+    /// `--status`, tasks of every lifecycle status are listed.
     #[arg(long, value_enum, value_delimiter = ',')]
     pub status: Vec<TaskStatus>,
-    /// Show all tasks regardless of status
-    #[arg(long, conflicts_with = "status")]
+    /// Deprecated no-op: task listing is status-neutral by default, so `--all`
+    /// is no longer required to see every lifecycle status. Accepted for
+    /// backward compatibility and ignored.
+    #[arg(long)]
     pub all: bool,
+    /// Maximum number of tasks to return, newest first (default 50). Must be at
+    /// least 1.
+    #[arg(long, default_value_t = DEFAULT_TASK_LIST_LIMIT, value_parser = parse_task_list_limit)]
+    pub limit: usize,
     /// Filter by priority level (low, medium, high)
     #[arg(long, value_enum)]
     pub priority: Option<TaskPriority>,
@@ -63,8 +70,8 @@ pub struct TaskListArgs {
 
 impl Execute for TaskListArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let all = self.all;
         let status = self.status;
+        let limit = self.limit;
         let priority = self.priority;
         let task_type = self.task_type;
         let parent_id = self.parent_id;
@@ -82,15 +89,16 @@ impl Execute for TaskListArgs {
             .transpose()?;
         let ready = self.ready;
 
+        // `list_tasks_by_tags` returns tasks already ordered newest-first
+        // (`created_at DESC`, task ID ascending for ties); the filters below
+        // preserve that order, so a trailing `take(limit)` yields the newest
+        // matching tasks (ORB-10310).
         let tasks_matching_tags = runtime.list_tasks_by_tags(&tags)?;
         let status_by_id = runtime.task_status_index()?;
-        let active_statuses = [TaskStatus::Backlog, TaskStatus::InProgress];
-        let status_filter =
-            default_task_list_status_filter(all, &status, job_run_id.as_deref(), &active_statuses);
 
         let tasks: Vec<_> = tasks_matching_tags
             .into_iter()
-            .filter(|t| status_filter.is_empty() || status_filter.contains(&t.status))
+            .filter(|t| status.is_empty() || status.contains(&t.status))
             .filter(|t| priority.is_none_or(|p| t.priority == p))
             .filter(|t| task_type.is_none_or(|kind| t.task_type == kind))
             .filter(|t| {
@@ -122,6 +130,7 @@ impl Execute for TaskListArgs {
                 path.as_deref()
                     .is_none_or(|p| task_selectors_contain_path(&t.context_files, p))
             })
+            .take(limit)
             .collect();
 
         if self.ops {
@@ -144,19 +153,14 @@ fn validate_external_ref_system(system: &str) -> Result<String, OrbitError> {
     ExternalRef::validate_system(system)
 }
 
-fn default_task_list_status_filter<'a>(
-    all: bool,
-    status: &'a [TaskStatus],
-    job_run_id: Option<&str>,
-    active_statuses: &'a [TaskStatus],
-) -> &'a [TaskStatus] {
-    if all {
-        &[]
-    } else if !status.is_empty() {
-        status
-    } else if job_run_id.is_some() {
-        &[]
-    } else {
-        active_statuses
+/// Parse the `--limit` value, rejecting a zero limit (which would return no
+/// tasks) with a clear input error (ORB-10310).
+fn parse_task_list_limit(raw: &str) -> Result<usize, String> {
+    let value: usize = raw
+        .parse()
+        .map_err(|_| format!("`{raw}` is not a valid limit (expected a positive integer)"))?;
+    if value == 0 {
+        return Err("limit must be at least 1".to_string());
     }
+    Ok(value)
 }

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -1217,7 +1217,7 @@
     "name": "orbit_task_artifact_put"
   },
   {
-    "description": "List Orbit tasks, optionally filtered by status, parent, type, or dependency readiness",
+    "description": "List Orbit tasks newest-first (default limit 50), across every lifecycle status unless a filter is supplied. Optional filters: status, parent, type, tag, dependency readiness, path.",
     "inputSchema": {
       "additionalProperties": true,
       "properties": {
@@ -1228,6 +1228,10 @@
         "job_run_id": {
           "description": "Filter by job run ID",
           "type": "string"
+        },
+        "limit": {
+          "description": "Maximum number of tasks to return, newest first (default 50). Must be at least 1.",
+          "type": "integer"
         },
         "model": {
           "description": "Preferred provenance field. Pass the canonical agent family (`codex`, `claude`, `gemini`, or `grok`); full model strings are accepted and auto-normalized.",

--- a/crates/orbit-cli/tests/task_tags.rs
+++ b/crates/orbit-cli/tests/task_tags.rs
@@ -19,8 +19,10 @@ fn task_cli_roundtrips_filters_and_replaces_tags() {
 
     assert_eq!(both["tags"], json!(["perf", "bench"]));
 
+    // ORB-10310: freshly-added tasks are `proposed`; status-neutral listing must
+    // surface them without `--all` or `--status proposed`.
     let perf_list = workspace.run(
-        &["task", "list", "--all", "--tag", "perf", "--json"],
+        &["task", "list", "--tag", "perf", "--json"],
         None,
         "list perf tasks",
     );
@@ -54,6 +56,52 @@ fn task_cli_roundtrips_filters_and_replaces_tags() {
     );
     let updated: Value = serde_json::from_slice(&updated.stdout).expect("update JSON");
     assert_eq!(updated["tags"], json!(["docs"]));
+}
+
+/// ORB-10310: `orbit task list` is status-neutral and bounded by `--limit`.
+#[test]
+fn task_list_is_status_neutral_and_bounded_by_limit() {
+    let workspace = TestWorkspace::new();
+    // Every task starts in `proposed`; the default listing must include them
+    // all with no `--status`/`--all`.
+    for index in 0..3 {
+        workspace.add_task(&format!("Task {index}"), &[]);
+    }
+
+    let default_list = workspace.run(&["task", "list", "--json"], None, "default list");
+    let default_tasks: Value = serde_json::from_slice(&default_list.stdout).expect("list JSON");
+    assert_eq!(
+        default_tasks.as_array().expect("array").len(),
+        3,
+        "all proposed tasks are listed by default: {default_tasks}"
+    );
+
+    // `--limit` bounds the response.
+    let limited = workspace.run(
+        &["task", "list", "--limit", "2", "--json"],
+        None,
+        "limited list",
+    );
+    let limited_tasks: Value = serde_json::from_slice(&limited.stdout).expect("list JSON");
+    assert_eq!(limited_tasks.as_array().expect("array").len(), 2);
+
+    // A zero limit is a clear input error, not an empty success.
+    let rejected = run_orbit(
+        &workspace.work,
+        &workspace.home,
+        &["task", "list", "--limit", "0"],
+        None,
+    );
+    assert!(
+        !rejected.status.success(),
+        "`--limit 0` must be rejected: {}",
+        String::from_utf8_lossy(&rejected.stdout)
+    );
+    assert!(
+        String::from_utf8_lossy(&rejected.stderr).contains("limit"),
+        "error must mention the limit: {}",
+        String::from_utf8_lossy(&rejected.stderr)
+    );
 }
 
 fn assert_task_titles(output: &Output, expected: &[&str]) {

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -148,13 +148,13 @@ pub use routine::{
 pub use run_state::PipelineState;
 pub use skill::Skill;
 pub use task::{
-    ExternalRef, GITHUB_PR_EXTERNAL_REF_SYSTEM, NO_DIFF_EXPECTED_TAG, ResolvedTaskDependency,
-    ReviewMessage, ReviewThread, ReviewThreadAnchor, ReviewThreadStatus, Task, TaskArtifact,
-    TaskComment, TaskComplexity, TaskCreateStatus, TaskHistoryEntry, TaskPriority, TaskStatus,
-    TaskType, build_task_status_index, media_type_for_artifact_path, normalize_task_dependencies,
-    normalize_task_tags, prune_missing_context_files, push_external_ref_if_missing,
-    resolve_task_dependencies, task_dependencies_ready, task_matches_tags, unmet_task_dependencies,
-    validate_task_dependencies,
+    DEFAULT_TASK_LIST_LIMIT, ExternalRef, GITHUB_PR_EXTERNAL_REF_SYSTEM, NO_DIFF_EXPECTED_TAG,
+    ResolvedTaskDependency, ReviewMessage, ReviewThread, ReviewThreadAnchor, ReviewThreadStatus,
+    Task, TaskArtifact, TaskComment, TaskComplexity, TaskCreateStatus, TaskHistoryEntry,
+    TaskPriority, TaskStatus, TaskType, build_task_status_index, media_type_for_artifact_path,
+    normalize_task_dependencies, normalize_task_tags, prune_missing_context_files,
+    push_external_ref_if_missing, resolve_task_dependencies, task_dependencies_ready,
+    task_matches_tags, unmet_task_dependencies, validate_task_dependencies,
 };
 pub use task_artifacts::{
     ArtifactManifestFileV2, ArtifactManifestV2, ORB_TASK_ID_MAX, ORB_TASK_ID_PREFIX,

--- a/crates/orbit-common/src/types/task.rs
+++ b/crates/orbit-common/src/types/task.rs
@@ -51,6 +51,14 @@ use crate::utility::selector::exists_in_workspace;
 /// QA validation tasks file follow-up Orbit tasks).
 pub const NO_DIFF_EXPECTED_TAG: &str = "no-diff-expected";
 
+/// Default maximum number of tasks a status-neutral task listing returns
+/// (ORB-10310). Every discovery surface — the `orbit task list` CLI, the
+/// `orbit.task.list` MCP tool, and the dashboard HTTP task routes — returns the
+/// newest `DEFAULT_TASK_LIST_LIMIT` matching tasks first rather than filtering
+/// on lifecycle status, matching Orbit's existing recent-history convention
+/// (see `HISTORY_DEFAULT_LIMIT` in orbit-dashboard).
+pub const DEFAULT_TASK_LIST_LIMIT: usize = 50;
+
 /// Current lifecycle state of a task.
 ///
 /// See the module-level doc for the full state transition diagram.

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -82,14 +82,14 @@ pub use registry_cache::{RegistryCacheOutcome, RegistryCacheService, RegistryCac
 pub use auto_tasks::{AutoTaskAddParams, AutoTaskUpdateParams};
 pub use orbit_common::types::{
     AuditEvent, AuditEventStatus, AuditStats, AutoTaskDefinition, AutoTaskSchedule,
-    AutoTaskTemplate, DedupePolicy, EvidenceKind, ExecutionProfileCrewV1, ExecutionProfileShipV1,
-    ExecutionProfileV1, ExecutorDef, ExternalRef, HostAlias, HostNameResolution, HostRecord,
-    HostRegistration, HostStatus, HostWorkspacePresence, JobRun, JobRunState, JobRunStep,
-    JobTargetType, Learning, LearningEvidence, LearningScope, LearningStatus, ProjectionFreshness,
-    ReviewThreadStatus, SanitizedExecutionProfile, SanitizedWorkspacePresence,
-    StoredExecutionProfile, Task, TaskComplexity, TaskCreateStatus, TaskPriority, TaskStatus,
-    TaskType, WorkspaceOwnership, WorkspacePresenceDeclaration, build_task_status_index,
-    resolve_task_dependencies, task_dependencies_ready,
+    AutoTaskTemplate, DEFAULT_TASK_LIST_LIMIT, DedupePolicy, EvidenceKind, ExecutionProfileCrewV1,
+    ExecutionProfileShipV1, ExecutionProfileV1, ExecutorDef, ExternalRef, HostAlias,
+    HostNameResolution, HostRecord, HostRegistration, HostStatus, HostWorkspacePresence, JobRun,
+    JobRunState, JobRunStep, JobTargetType, Learning, LearningEvidence, LearningScope,
+    LearningStatus, ProjectionFreshness, ReviewThreadStatus, SanitizedExecutionProfile,
+    SanitizedWorkspacePresence, StoredExecutionProfile, Task, TaskComplexity, TaskCreateStatus,
+    TaskPriority, TaskStatus, TaskType, WorkspaceOwnership, WorkspacePresenceDeclaration,
+    build_task_status_index, resolve_task_dependencies, task_dependencies_ready,
 };
 pub use orbit_common::types::{MissedRunPolicy, NotFoundKind, OrbitError, OverlapPolicy};
 pub use orbit_common::utility::redaction::redact_sensitive_env_text;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/host.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/host.rs
@@ -603,7 +603,11 @@ impl HubCoordinationExecutor {
             .transpose()?;
         let tags = optional_csv_or_string_list_alias(&input, &["tags", "tag"])?.unwrap_or_default();
         let ready = super::input::optional_bool_alias(&input, &["ready"])?;
+        let limit = super::input::task_list_limit(&input)?;
         let status = self.inner.tasks.task.task_status_index()?;
+        // `list_tasks()` returns tasks newest-first (`created_at DESC`, task ID
+        // ascending for ties); the filters preserve that order, so `take(limit)`
+        // yields the newest matching tasks (ORB-10310).
         let tasks = self
             .inner
             .tasks
@@ -614,6 +618,7 @@ impl HubCoordinationExecutor {
             .filter(|task| type_filter.is_none_or(|value| task.task_type == value))
             .filter(|task| task_matches_tags(task, &tags))
             .filter(|task| ready != Some(true) || task_dependencies_ready(task, &status))
+            .take(limit)
             .map(|task| super::json::task_to_json(&task, &status))
             .collect();
         Ok(Value::Array(tasks))

--- a/crates/orbit-core/src/runtime/orbit_tool_host/input.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/input.rs
@@ -2,9 +2,9 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use orbit_common::types::{
-    NotFoundKind, OrbitError, TaskArtifact, TaskComplexity, TaskPriority, TaskRelation, TaskStatus,
-    TaskType, media_type_for_artifact_path, optional_string, optional_string_alias,
-    optional_u32_alias,
+    DEFAULT_TASK_LIST_LIMIT, NotFoundKind, OrbitError, TaskArtifact, TaskComplexity, TaskPriority,
+    TaskRelation, TaskStatus, TaskType, media_type_for_artifact_path, optional_string,
+    optional_string_alias, optional_u32_alias,
 };
 use orbit_store::state_io;
 use orbit_tools::OrbitTaskScope;
@@ -64,6 +64,42 @@ pub(super) fn resolve_state_dir(
 
     state_io::resolve_active_run_state_dir(&orbit_root, &run_id)?
         .ok_or(OrbitError::not_found(NotFoundKind::JobRun, run_id))
+}
+
+/// Resolve the `limit` for a task listing: the caller-supplied value when
+/// present (accepting a JSON number or numeric string), otherwise the
+/// status-neutral default. A zero limit is rejected with a clear input error
+/// (ORB-10310).
+pub(super) fn task_list_limit(input: &Value) -> Result<usize, OrbitError> {
+    let Some(value) = input.get("limit") else {
+        return Ok(DEFAULT_TASK_LIST_LIMIT);
+    };
+    let limit = match value {
+        Value::Null => return Ok(DEFAULT_TASK_LIST_LIMIT),
+        Value::Number(number) => number
+            .as_u64()
+            .ok_or_else(|| {
+                OrbitError::InvalidInput("`limit` must be a positive integer".to_string())
+            })
+            .and_then(|value| {
+                usize::try_from(value)
+                    .map_err(|_| OrbitError::InvalidInput("`limit` is too large".to_string()))
+            })?,
+        Value::String(raw) => raw.trim().parse::<usize>().map_err(|error| {
+            OrbitError::InvalidInput(format!("`limit` must be a positive integer: {error}"))
+        })?,
+        _ => {
+            return Err(OrbitError::InvalidInput(
+                "`limit` must be a positive integer".to_string(),
+            ));
+        }
+    };
+    if limit == 0 {
+        return Err(OrbitError::InvalidInput(
+            "`limit` must be at least 1".to_string(),
+        ));
+    }
+    Ok(limit)
 }
 
 pub(super) fn resolve_step_index(input: &Value) -> Result<u32, OrbitError> {

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
@@ -127,6 +127,10 @@ pub(super) fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
     let tags = optional_csv_or_string_list_alias(&input, &["tags", "tag"])?.unwrap_or_default();
     let ready = optional_bool_alias(&input, &["ready"])?;
     let path = optional_string(&input, "path")?;
+    let limit = super::input::task_list_limit(&input)?;
+    // `list_tasks_filtered` returns tasks newest-first (`created_at DESC`, task
+    // ID ascending for ties); the filters below preserve that order, so the
+    // trailing `take(limit)` yields the newest matching tasks (ORB-10310).
     let all_tasks = runtime.list_tasks_filtered(
         status,
         None,
@@ -136,19 +140,17 @@ pub(super) fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
         None,
     )?;
     let status_by_id = runtime.task_status_index()?;
-    let tasks = all_tasks
-        .into_iter()
-        .filter(|task| orbit_common::types::task_matches_tags(task, &tags))
-        .filter(|task| ready != Some(true) || task_dependencies_ready(task, &status_by_id))
-        .filter(|task| {
-            path.as_deref()
-                .is_none_or(|p| crate::task_selectors_contain_path(&task.context_files, p))
-        })
-        .collect::<Vec<_>>();
     Ok(Value::Array(
-        tasks
+        all_tasks
             .into_iter()
+            .filter(|task| orbit_common::types::task_matches_tags(task, &tags))
+            .filter(|task| ready != Some(true) || task_dependencies_ready(task, &status_by_id))
+            .filter(|task| {
+                path.as_deref()
+                    .is_none_or(|p| crate::task_selectors_contain_path(&task.context_files, p))
+            })
             .filter(|task| task_type.is_none_or(|kind| task.task_type == kind))
+            .take(limit)
             .map(|task| task_to_json(&task, &status_by_id))
             .collect::<Vec<_>>(),
     ))

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
@@ -1345,6 +1345,193 @@ fn task_list_and_search_tools_filter_by_tags_with_and_semantics() {
 }
 
 #[test]
+fn task_list_tool_is_status_neutral_recent_first_and_bounded() {
+    // ORB-10310: `orbit.task.list` must return every lifecycle status by
+    // default (no hidden `backlog,in-progress` subset), newest-first.
+    let (_root, runtime, repo_root) = test_runtime();
+    let statuses = [
+        TaskStatus::Proposed,
+        TaskStatus::Backlog,
+        TaskStatus::InProgress,
+        TaskStatus::Review,
+        TaskStatus::Done,
+    ];
+    let mut created = Vec::new();
+    for (index, status) in statuses.iter().enumerate() {
+        created.push(create_task(
+            &runtime,
+            &repo_root,
+            &format!("Task {index} in {status}"),
+            "status-neutral listing fixture",
+            *status,
+            &[],
+        ));
+    }
+
+    let output = runtime
+        .execute_tool_command(
+            "orbit.task.list",
+            json!({}),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task list tool succeeds");
+    let listed = output.as_array().expect("task array");
+    assert_eq!(
+        listed.len(),
+        created.len(),
+        "every status must be listed by default: {listed:?}"
+    );
+    for task in &created {
+        assert!(
+            listed.iter().any(|value| value["id"] == json!(task.id)),
+            "task {} ({}) missing from status-neutral list",
+            task.id,
+            task.status
+        );
+    }
+    let created_ats = listed
+        .iter()
+        .map(|value| {
+            value["created_at"]
+                .as_str()
+                .expect("created_at")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    for pair in created_ats.windows(2) {
+        assert!(
+            pair[0] >= pair[1],
+            "list must be newest-first by created_at: {created_ats:?}"
+        );
+    }
+}
+
+#[test]
+fn task_list_tool_default_limit_returns_newest_fifty() {
+    // ORB-10310: the status-neutral default is bounded to the 50 newest tasks.
+    let (_root, runtime, repo_root) = test_runtime();
+    let mut created = Vec::new();
+    for index in 0..55 {
+        created.push(create_task(
+            &runtime,
+            &repo_root,
+            &format!("Bounded task {index:02}"),
+            "default-limit fixture",
+            TaskStatus::Backlog,
+            &[],
+        ));
+    }
+
+    let output = runtime
+        .execute_tool_command(
+            "orbit.task.list",
+            json!({}),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task list tool succeeds");
+    let listed = output.as_array().expect("task array");
+    assert_eq!(
+        listed.len(),
+        50,
+        "default limit must bound the response to 50"
+    );
+    // The 50 returned are the newest; the five oldest are excluded.
+    let listed_ids = listed
+        .iter()
+        .map(|value| value["id"].as_str().expect("id").to_string())
+        .collect::<std::collections::HashSet<_>>();
+    for oldest in &created[..5] {
+        assert!(
+            !listed_ids.contains(&oldest.id),
+            "oldest task {} must fall outside the newest 50",
+            oldest.id
+        );
+    }
+}
+
+#[test]
+fn task_list_tool_limit_override_and_zero_rejection() {
+    let (_root, runtime, repo_root) = test_runtime();
+    for index in 0..3 {
+        create_task(
+            &runtime,
+            &repo_root,
+            &format!("Override task {index}"),
+            "limit-override fixture",
+            TaskStatus::Backlog,
+            &[],
+        );
+    }
+
+    let limited = runtime
+        .execute_tool_command(
+            "orbit.task.list",
+            json!({ "limit": 2 }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task list tool succeeds");
+    assert_eq!(limited.as_array().expect("task array").len(), 2);
+
+    let message = invalid_input_message(runtime.execute_tool_command(
+        "orbit.task.list",
+        json!({ "limit": 0 }),
+        Some("codex".to_string()),
+        Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+    ));
+    assert!(message.contains("at least 1"), "{message}");
+}
+
+#[test]
+fn task_list_tool_applies_status_filter_before_limit() {
+    // ORB-10310: an explicit filter must be applied before ordering + limiting,
+    // so a `limit: 1` on a status filter returns the newest *matching* task,
+    // never a newer non-matching one.
+    let (_root, runtime, repo_root) = test_runtime();
+    create_task(
+        &runtime,
+        &repo_root,
+        "Older review task",
+        "filter-before-limit fixture",
+        TaskStatus::Review,
+        &[],
+    );
+    let newer_review = create_task(
+        &runtime,
+        &repo_root,
+        "Newer review task",
+        "filter-before-limit fixture",
+        TaskStatus::Review,
+        &[],
+    );
+    // Created last, so newest overall — but not a review, so the status filter
+    // must exclude it even though the limit is 1.
+    create_task(
+        &runtime,
+        &repo_root,
+        "Newest backlog task",
+        "filter-before-limit fixture",
+        TaskStatus::Backlog,
+        &[],
+    );
+
+    let output = runtime
+        .execute_tool_command(
+            "orbit.task.list",
+            json!({ "status": "review", "limit": 1 }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task list tool succeeds");
+    let listed = output.as_array().expect("task array");
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0]["id"], json!(newer_review.id));
+    assert_eq!(listed[0]["status"], json!("review"));
+}
+
+#[test]
 fn task_update_tool_recovers_mcp_encoded_acceptance_array() {
     let (_root, runtime, repo_root) = test_runtime();
     let task = create_task(

--- a/crates/orbit-dashboard/src/api/tasks.rs
+++ b/crates/orbit-dashboard/src/api/tasks.rs
@@ -9,24 +9,14 @@ use orbit_common::types::task_artifacts::TaskRelation;
 use orbit_common::types::validate_relative_artifact_path;
 use orbit_core::command::task::{TaskAddParams, TaskUpdateParams};
 use orbit_core::{
-    ExternalRef, OrbitRuntime, Task, TaskComplexity, TaskCreateStatus, TaskPriority, TaskStatus,
-    TaskType,
+    DEFAULT_TASK_LIST_LIMIT, ExternalRef, OrbitRuntime, Task, TaskComplexity, TaskCreateStatus,
+    TaskPriority, TaskStatus, TaskType,
 };
 use serde::{Deserialize, Deserializer};
 use serde_json::{Value, json};
 
 use super::{bad_request, map_runtime_error, server_error, validate_id};
 use crate::projections::{task_locks_json, task_to_json_with_sidecars};
-
-const DASHBOARD_TASK_STATUSES: &[TaskStatus] = &[
-    TaskStatus::InProgress,
-    TaskStatus::Review,
-    TaskStatus::Blocked,
-    TaskStatus::Proposed,
-    TaskStatus::Backlog,
-    TaskStatus::Someday,
-    TaskStatus::Rejected,
-];
 
 struct ArtifactResponsePolicy {
     content_type: &'static str,
@@ -170,11 +160,13 @@ pub(super) async fn list_task_locks(Ws(runtime): Ws) -> Response {
     }
 }
 
+/// The dashboard task list: status-neutral, newest-first, and bounded
+/// (ORB-10310). `list_tasks` already orders by `created_at DESC` with task ID
+/// ascending for ties, so truncating keeps the newest matching tasks and no
+/// lifecycle status (including `done`/`archived`) is excluded by default.
 fn list_dashboard_tasks(runtime: &OrbitRuntime) -> Result<Vec<Task>, orbit_core::OrbitError> {
-    let mut tasks = Vec::new();
-    for status in DASHBOARD_TASK_STATUSES {
-        tasks.extend(runtime.list_tasks_filtered(Some(*status), None, None, None, None, None)?);
-    }
+    let mut tasks = runtime.list_tasks()?;
+    tasks.truncate(DEFAULT_TASK_LIST_LIMIT);
     Ok(tasks)
 }
 

--- a/crates/orbit-dashboard/src/api/tests/handlers.rs
+++ b/crates/orbit-dashboard/src/api/tests/handlers.rs
@@ -296,14 +296,15 @@ async fn tasks_resolve_dependency_statuses_from_all_tasks() {
         rows.iter()
             .any(|task| task["id"].as_str() == Some(&rejected.id))
     );
+    // ORB-10310: task listing is status-neutral, so `done` and `archived`
+    // dependency tasks now appear in the list too. Their status still resolves
+    // from the global index (asserted below), independent of list membership.
     assert!(
-        !rows
-            .iter()
+        rows.iter()
             .any(|task| task["id"].as_str() == Some(&done.id))
     );
     assert!(
-        !rows
-            .iter()
+        rows.iter()
             .any(|task| task["id"].as_str() == Some(&archived.id))
     );
 

--- a/crates/orbit-dashboard/src/api/tests/tasks.rs
+++ b/crates/orbit-dashboard/src/api/tests/tasks.rs
@@ -801,6 +801,93 @@ async fn list_tasks_includes_complexity_when_set() {
     );
 }
 
+fn seed_task_with_status(
+    runtime: &OrbitRuntime,
+    title: &str,
+    status: TaskStatus,
+) -> orbit_core::Task {
+    runtime
+        .add_task(TaskAddParams {
+            title: title.to_string(),
+            description: format!("Fixture task: {title}."),
+            status: Some(status),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("seed task")
+}
+
+/// ORB-10310: `GET /tasks` is status-neutral — `done` and `archived` tasks
+/// (previously excluded by the hard-coded dashboard status subset) are now
+/// discoverable, and the list is ordered newest-first.
+#[tokio::test]
+async fn list_tasks_includes_done_and_archived_statuses_newest_first() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let proposed = seed_task_with_status(&runtime, "Proposed task", TaskStatus::Proposed);
+    let done = seed_task_with_status(&runtime, "Done task", TaskStatus::Done);
+    let to_archive = seed_task_with_status(&runtime, "Archived task", TaskStatus::Backlog);
+    runtime.archive_task(&to_archive.id).expect("archive task");
+
+    let response = request(runtime, "/tasks").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    let rows = body.as_array().expect("tasks list is array");
+
+    for expected in [&proposed.id, &done.id, &to_archive.id] {
+        assert!(
+            rows.iter().any(|row| row["id"].as_str() == Some(expected)),
+            "task {expected} must be discoverable regardless of status: {rows:?}"
+        );
+    }
+    let archived_row = rows
+        .iter()
+        .find(|row| row["id"].as_str() == Some(to_archive.id.as_str()))
+        .expect("archived task present");
+    assert_eq!(archived_row["status"], json!("archived"));
+
+    let created_ats = rows
+        .iter()
+        .map(|row| row["created_at"].as_str().expect("created_at").to_string())
+        .collect::<Vec<_>>();
+    for pair in created_ats.windows(2) {
+        assert!(
+            pair[0] >= pair[1],
+            "tasks must be ordered newest-first: {created_ats:?}"
+        );
+    }
+}
+
+/// ORB-10310: `GET /tasks` bounds the response to the default limit (50),
+/// keeping the newest matching tasks.
+#[tokio::test]
+async fn list_tasks_is_bounded_to_default_limit() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let mut oldest = None;
+    for index in 0..55 {
+        let task = seed_task_with_status(
+            &runtime,
+            &format!("Bounded dashboard task {index:02}"),
+            TaskStatus::Backlog,
+        );
+        if index == 0 {
+            oldest = Some(task.id);
+        }
+    }
+
+    let response = request(runtime, "/tasks").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    let rows = body.as_array().expect("tasks list is array");
+    assert_eq!(rows.len(), 50, "default limit bounds the response to 50");
+    let oldest = oldest.expect("seeded at least one task");
+    assert!(
+        !rows
+            .iter()
+            .any(|row| row["id"].as_str() == Some(oldest.as_str())),
+        "the oldest task must fall outside the newest 50"
+    );
+}
+
 /// ORB-00042: `workspace` is a selector and lives in the query string, never
 /// the body. A stray `workspace` body key (the historical bridge mis-key) must
 /// be a loud 400 pointing at `?workspace=`, not silently dropped.

--- a/crates/orbit-dashboard/src/api/workspaces.rs
+++ b/crates/orbit-dashboard/src/api/workspaces.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 
 use axum::extract::State;
 use axum::response::{IntoResponse, Json, Response};
+use orbit_core::DEFAULT_TASK_LIST_LIMIT;
 use serde_json::{Value, json};
 
 use super::server_error;
@@ -78,6 +79,29 @@ pub(super) async fn list_all_tasks(State(state): State<DashboardState>) -> Respo
             all.push(value);
         }
     }
+    // Each workspace already contributes its newest tasks; re-sort the union so
+    // the aggregate is globally newest-first and bounded to the same default
+    // limit as every other task-listing surface (ORB-10310). `created_at` is a
+    // fixed-format UTC RFC 3339 string, so lexical order is chronological; task
+    // ID breaks timestamp ties ascending.
+    all.sort_by(|a, b| {
+        let created = |value: &Value| {
+            value
+                .get("created_at")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string()
+        };
+        let id = |value: &Value| {
+            value
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string()
+        };
+        created(b).cmp(&created(a)).then_with(|| id(a).cmp(&id(b)))
+    });
+    all.truncate(DEFAULT_TASK_LIST_LIMIT);
     Json(Value::Array(all)).into_response()
 }
 

--- a/crates/orbit-tools/src/builtin/orbit/task/list.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/list.rs
@@ -54,12 +54,20 @@ impl Tool for OrbitTaskListTool {
                 param_type: "string".to_string(),
                 required: false,
             },
+            ToolParam {
+                name: "limit".to_string(),
+                description:
+                    "Maximum number of tasks to return, newest first (default 50). Must be at least 1."
+                        .to_string(),
+                param_type: "integer".to_string(),
+                required: false,
+            },
         ];
         parameters.extend(super::super::identity_params());
         ToolSchema {
             name: "orbit.task.list".to_string(),
             description:
-                "List Orbit tasks, optionally filtered by status, parent, type, or dependency readiness"
+                "List Orbit tasks newest-first (default limit 50), across every lifecycle status unless a filter is supplied. Optional filters: status, parent, type, tag, dependency readiness, path."
                 .to_string(),
             parameters,
             builtin: true,


### PR DESCRIPTION
## Task

[ORB-10310](https://orbit-cli.com/tasks/ORB-10310) — Make task listing status-neutral, recent-first, and bounded

### Description

## Problem

Task-list defaults silently hide records based on lifecycle status, and the behavior differs by surface:

- `orbit task list` injects a default `backlog,in-progress` filter.
- `GET /api/tasks` and `/api/tasks/all` use a different hard-coded status subset and omit `done` and `archived`.
- `orbit.task.list` therefore cannot offer one predictable discovery contract across CLI, MCP, HTTP, and Bridge.

PR #647 exposed the user impact: a newly created `proposed` task with the `qa-sweep` tag was absent from `orbit task list --tag qa-sweep`, which looked like failed tag persistence and can cause duplicate task filing. The finding is recorded in L-0097.

## Desired Contract

Default task listing must not filter on status. Instead, every list surface should return the newest matching tasks first and bound the response size.

Use a default limit of 50, matching Orbit's existing recent-history convention. Keep status filtering available only when the caller explicitly supplies it. Apply all explicit filters before ordering and limiting.

## Reproduction

1. Create a task; it starts in `proposed`.
2. Run `orbit task list --tag <that-task-tag>`.
3. Observe that the task is absent unless `--status proposed` or `--all` is added.

## Constraints / Notes

- Sort deterministically by `created_at DESC`, then task ID ascending for ties.
- Add a caller-controlled `limit` / `--limit` override while retaining a bounded default.
- `--all` must no longer be required to discover any lifecycle status; remove it or retain it only as an explicitly documented compatibility path.
- Preserve explicit status, tag, type, parent, job-run, readiness, path, priority, and reference filters.
- Keep CLI, native MCP tool schema/runtime, HTTP workspace and aggregate routes, and their tests synchronized.

### Acceptance Criteria

- With tasks spanning proposed, backlog, in-progress, review, done, archived, rejected, blocked, and someday, default `orbit task list` returns the 50 newest matching tasks across all statuses, ordered by `created_at DESC` and task ID ascending for timestamp ties.
- `orbit task list --status <status>` remains an opt-in filter, and every explicit filter is applied before the result is ordered and limited.
- `orbit task list --limit N` controls the maximum number of text, `--json`, and `--ops` results; the default is 50 and invalid zero is rejected with a clear input error.
- `orbit.task.list` exposes a `limit` input and applies the same status-neutral, newest-first, default-50 contract as the CLI.
- `GET /api/tasks` and the cross-workspace `/api/tasks/all` route no longer exclude lifecycle statuses by default and return at most the newest 50 matching tasks with deterministic ordering.
- Regression tests cover inclusion of newly created proposed tasks, inclusion of done/archived tasks on HTTP-backed discovery, ordering, limit override, filter-before-limit behavior, and CLI/MCP/HTTP contract parity.
- CLI help and tool-schema descriptions no longer claim or imply a default status filter and document the default limit.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Made task listing status-neutral, recent-first, and bounded (default limit 50) across every discovery surface.

Core change: added `DEFAULT_TASK_LIST_LIMIT = 50` in orbit-common (types/task.rs), re-exported through orbit-common::types and orbit-core::lib. The underlying store already orders `created_at DESC, task_id ASC` in both the sqlite-index path (`indexed_task_ids_filtered` ORDER BY) and the bundle-scan fallback (`sort_by_created_desc_id_asc`), and tag intersection preserves that order, so every surface just applies filters then `take(limit)`.

Surfaces updated (all four kept in sync):
- CLI `orbit task list` (orbit-cli/command/task/list.rs): dropped the default `backlog,in-progress` filter and the `default_task_list_status_filter` helper; `--status` is now opt-in and applied before ordering/limit; added `--limit` (default 50, zero rejected via `parse_task_list_limit`) bounding text/--json/--ops; `--all` retained as a documented deprecated no-op; help text corrected.
- MCP `orbit.task.list` standard path (orbit-core task_tools::list) and the checkoutless hub path (host.rs `HubCoordinationExecutor::list_tasks`) — both apply the shared `input::task_list_limit` parser and `take(limit)`. New shared parser accepts JSON number or numeric string, defaults to 50, rejects 0.
- Tool schema (orbit-tools builtin/orbit/task/list.rs): added `limit` integer param and rewrote the description to drop the default-status-filter claim and document the default limit. mcp_tools_list.json snapshot updated.
- HTTP: `GET /api/tasks` (`list_dashboard_tasks`) now uses `list_tasks()` truncated to 50 instead of the hard-coded 7-status subset that omitted done/archived; `/api/tasks/all` re-sorts the cross-workspace union newest-first and truncates to 50.

Tests added: MCP status-neutral/newest-first/default-50/limit-override+zero-rejection/filter-before-limit; CLI status-neutral + --limit + zero rejection; HTTP done+archived inclusion & newest-first & default-limit; updated handlers.rs dependency test (done/archived now appear in list) and task_tags.rs (dropped `--all`).

Validation: `cargo build` (5 crates) clean; targeted tests green in orbit-core, orbit-cli (task_tags, mcp_roundtrip), orbit-dashboard (api::tests::tasks + handlers); `make ci-fast` PASSES. One pre-existing unrelated failure `orbit-dashboard routines_endpoint_returns_envelope_for_empty_host` (400 vs 200, host global-root resolution) reproduces on the clean base without these changes — out of scope.

Learning L-0099 recorded: `orbit.task.list` has two MCP host executor paths (task_tools::list and HubCoordinationExecutor::list_tasks) that must be edited together.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10310-6a5c00e8`
- Behind base: 0
- Ahead of base: 1