### PR TITLE
Remove low-signal task history entries and enrich change events

### DIFF
--- a/crates/orbit-cli/src/command/task/output.rs
+++ b/crates/orbit-cli/src/command/task/output.rs
@@ -5,6 +5,13 @@ use orbit_common::types::{ArtifactManifestFileV2, TaskArtifact};
 use orbit_core::{OrbitError, OrbitRuntime, TaskStatus, resolve_task_dependencies};
 use serde_json::{Value, json};
 
+/// Legacy bare `commented` history entries duplicate the authoritative Comments
+/// list, so human-facing history rendering omits them (ORB-10311). Raw JSON/MCP
+/// history projections keep every event for backward compatibility.
+pub(crate) fn is_human_visible_history_event(event: &str) -> bool {
+    event != "commented"
+}
+
 pub(crate) fn task_to_signal_json(task: &orbit_core::Task) -> Value {
     json!({
         "id": task.id,
@@ -320,6 +327,9 @@ pub(super) fn print_single_task_field(
         "history" => {
             use crate::output::color::dimmed;
             for entry in runtime.get_task_history(&task.id)? {
+                if !is_human_visible_history_event(&entry.event) {
+                    continue;
+                }
                 if let Some(note) = &entry.note {
                     println!(
                         "{} {}: {} ({})",

--- a/crates/orbit-cli/src/command/task/show.rs
+++ b/crates/orbit-cli/src/command/task/show.rs
@@ -4,7 +4,10 @@ use serde_json::Value;
 
 use crate::command::Execute;
 
-use super::output::{print_task_fields, task_fields_to_json, task_to_json_for_runtime};
+use super::output::{
+    is_human_visible_history_event, print_task_fields, task_fields_to_json,
+    task_to_json_for_runtime,
+};
 
 #[derive(Args)]
 pub struct TaskShowArgs {
@@ -145,9 +148,13 @@ impl Execute for TaskShowArgs {
                 println!("{} {}", bold("Implemented By:"), implemented_by);
             }
             let history = runtime.get_task_history(&task.id)?;
-            if !history.is_empty() {
+            let visible_history: Vec<_> = history
+                .iter()
+                .filter(|entry| is_human_visible_history_event(&entry.event))
+                .collect();
+            if !visible_history.is_empty() {
                 println!("{}", bold("History:"));
-                for entry in &history {
+                for entry in visible_history {
                     if let Some(note) = &entry.note {
                         println!(
                             "  {} {}: {} ({})",

--- a/crates/orbit-cli/src/command/task/tests/mod.rs
+++ b/crates/orbit-cli/src/command/task/tests/mod.rs
@@ -1,4 +1,5 @@
 mod add;
 mod artifact;
 mod command;
+mod output;
 mod update;

--- a/crates/orbit-cli/src/command/task/tests/output.rs
+++ b/crates/orbit-cli/src/command/task/tests/output.rs
@@ -1,0 +1,55 @@
+//! Sibling tests for `task/output.rs` (docs/design-patterns/test_layout.md).
+
+use orbit_common::types::TaskHistoryEntry;
+
+use crate::command::task::output::is_human_visible_history_event;
+
+fn entry(event: &str) -> TaskHistoryEntry {
+    TaskHistoryEntry {
+        at: chrono::Utc::now(),
+        by: "human".to_string(),
+        event: event.to_string(),
+        note: None,
+        from_status: None,
+        to_status: None,
+    }
+}
+
+#[test]
+fn commented_events_are_suppressed_from_human_history() {
+    // ORB-10311: legacy bare `commented` stubs are hidden from human-facing
+    // history, while every operational lifecycle event stays visible.
+    assert!(!is_human_visible_history_event("commented"));
+    for event in [
+        "status_changed",
+        "renamed",
+        "updated",
+        "started",
+        "context_pruned",
+        "approved",
+        "rejected",
+    ] {
+        assert!(
+            is_human_visible_history_event(event),
+            "operational event `{event}` must remain visible"
+        );
+    }
+}
+
+#[test]
+fn human_history_filter_drops_only_commented_entries_and_preserves_order() {
+    let history = vec![
+        entry("status_changed"),
+        entry("commented"),
+        entry("renamed"),
+        entry("commented"),
+        entry("updated"),
+    ];
+    // Mirror the rendering-site filter: keep everything except legacy stubs.
+    let visible: Vec<&str> = history
+        .iter()
+        .filter(|entry| is_human_visible_history_event(&entry.event))
+        .map(|entry| entry.event.as_str())
+        .collect();
+    assert_eq!(visible, vec!["status_changed", "renamed", "updated"]);
+}

--- a/crates/orbit-core/src/command/task/helpers.rs
+++ b/crates/orbit-core/src/command/task/helpers.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use orbit_common::types::{
-    OrbitError, Task, TaskComment, TaskHistoryEntry, TaskStatus, normalize_attribution_label,
+    OrbitError, Task, TaskComment, TaskStatus, normalize_attribution_label,
     normalize_optional_attribution_label,
 };
 
@@ -94,18 +94,12 @@ pub(super) fn build_task_comments(
     }])
 }
 
-pub(super) fn task_comment_history_entries(comments: &[TaskComment]) -> Vec<TaskHistoryEntry> {
-    comments
-        .iter()
-        .map(|comment| TaskHistoryEntry {
-            at: comment.at,
-            by: comment.by.clone(),
-            event: "commented".to_string(),
-            note: None,
-            from_status: None,
-            to_status: None,
-        })
-        .collect()
+/// Render an optional task field value for a history note, giving unset values a
+/// clear textual marker instead of an empty string (ORB-10311).
+pub(super) fn describe_optional_field_value(value: Option<&str>) -> String {
+    value
+        .map(str::to_string)
+        .unwrap_or_else(|| "(none)".to_string())
 }
 
 pub(super) fn effective_actor_label(

--- a/crates/orbit-core/src/command/task/update.rs
+++ b/crates/orbit-core/src/command/task/update.rs
@@ -9,7 +9,7 @@ use crate::runtime::TaskRecordUpdateParams;
 
 use super::helpers::{
     SYSTEM_ACTOR_LABEL, TaskAttributionInput, assemble_task_attribution, build_task_comments,
-    task_comment_history_entries,
+    describe_optional_field_value,
 };
 use super::params::TaskUpdateParams;
 use super::paths::{
@@ -176,10 +176,13 @@ impl OrbitRuntime {
             .map(ToOwned::to_owned);
         let append_comments =
             build_task_comments(params.comment.clone(), effective_label.as_str())?;
-        let source_task_id_changed = params
+        // ORB-10311: a persisted task comment no longer emits a bare `commented`
+        // history stub; the comment itself (append_comments) is the record.
+        let source_task_id_replacement = params
             .source_task_id
             .as_ref()
-            .is_some_and(|source_task_id| task.source_task_id() != source_task_id.as_deref());
+            .map(|value| value.as_deref())
+            .filter(|replacement| task.source_task_id() != *replacement);
 
         let mut append_history: Vec<TaskHistoryEntry> = if dropped_context_files.is_empty() {
             Vec::new()
@@ -189,13 +192,19 @@ impl OrbitRuntime {
                 &dropped_context_files,
             )]
         };
-        append_history.extend(task_comment_history_entries(&append_comments));
-        if source_task_id_changed {
+        if let Some(replacement) = source_task_id_replacement {
+            // ORB-10311: record the explicit previous and replacement source
+            // ids (with a clear marker for the unset case) so the change is
+            // auditable from history alone.
             append_history.push(TaskHistoryEntry {
                 at: chrono::Utc::now(),
                 by: effective_label.clone(),
                 event: "updated".to_string(),
-                note: Some("source_task_id changed".to_string()),
+                note: Some(format!(
+                    "source_task_id changed: {} → {}",
+                    describe_optional_field_value(task.source_task_id()),
+                    describe_optional_field_value(replacement),
+                )),
                 from_status: None,
                 to_status: None,
             });

--- a/crates/orbit-core/src/runtime/engine/tests/task_host.rs
+++ b/crates/orbit-core/src/runtime/engine/tests/task_host.rs
@@ -653,12 +653,13 @@ fn activity_update_comment_records_comment_as_system() {
         .expect("reload comments");
     let comment = comments.last().expect("activity comment");
     assert_eq!(comment.by, SYSTEM_ACTOR_LABEL);
+    assert_eq!(comment.message, "Automation left a note.");
+    // ORB-10311: the comment persists but no bare `commented` history stub is created.
     let history = runtime.get_task_history(&task.id).expect("reload history");
-    let comment_history = history
-        .iter()
-        .find(|entry| entry.event == "commented")
-        .expect("comment history");
-    assert_eq!(comment_history.by, SYSTEM_ACTOR_LABEL);
+    assert!(
+        !history.iter().any(|entry| entry.event == "commented"),
+        "a persisted comment must not emit a `commented` history entry"
+    );
 }
 
 #[test]
@@ -865,12 +866,78 @@ fn direct_update_task_keeps_default_human_attribution() {
         .expect("reload comments");
     let comment = comments.last().expect("human comment");
     assert_eq!(comment.by, "human");
+    assert_eq!(comment.message, "Human-visible note.");
+    // ORB-10311: the full comment is persisted, but no redundant `commented`
+    // history entry is emitted alongside it.
     let history = runtime.get_task_history(&task.id).expect("reload history");
-    let comment_history = history
-        .iter()
-        .find(|entry| entry.event == "commented")
-        .expect("comment history");
-    assert_eq!(comment_history.by, "human");
+    assert!(
+        !history.iter().any(|entry| entry.event == "commented"),
+        "a persisted comment must not emit a `commented` history entry"
+    );
+}
+
+#[test]
+fn source_task_id_change_history_records_previous_and_replacement() {
+    let (_root, runtime) = test_runtime();
+    let source = runtime
+        .add_task(TaskAddParams {
+            title: "Source of regression".to_string(),
+            description: "Origin task referenced by a regression.".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("add source task");
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Regressed task".to_string(),
+            description: "Exercise source_task_id change history enrichment.".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("add task");
+
+    runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                source_task_id: Some(Some(source.id.clone())),
+                ..Default::default()
+            },
+        )
+        .expect("set source_task_id");
+    let set_note = latest_source_task_id_note(&runtime, &task.id);
+    assert!(set_note.contains("(none)"), "{set_note}");
+    assert!(set_note.contains(&source.id), "{set_note}");
+
+    runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                source_task_id: Some(None),
+                ..Default::default()
+            },
+        )
+        .expect("clear source_task_id");
+    let cleared_note = latest_source_task_id_note(&runtime, &task.id);
+    assert!(cleared_note.contains(&source.id), "{cleared_note}");
+    assert!(cleared_note.contains("(none)"), "{cleared_note}");
+}
+
+fn latest_source_task_id_note(runtime: &OrbitRuntime, id: &str) -> String {
+    runtime
+        .get_task_history(id)
+        .expect("reload history")
+        .into_iter()
+        .rev()
+        .find(|entry| {
+            entry.event == "updated"
+                && entry
+                    .note
+                    .as_deref()
+                    .is_some_and(|note| note.contains("source_task_id changed"))
+        })
+        .and_then(|entry| entry.note)
+        .expect("source_task_id change history entry")
 }
 
 #[test]

--- a/crates/orbit-dashboard/assets/dashboard/tasks.js
+++ b/crates/orbit-dashboard/assets/dashboard/tasks.js
@@ -578,18 +578,24 @@ function buildTaskDetail(task, context) {
   }
 
   if (Array.isArray(task.history) && task.history.length > 0) {
-    const wrap = el("div");
-    const recent = task.history.slice(-5).reverse();
-    for (const h of recent) {
-      const note = h.note ? ` (${h.note})` : "";
-      const line = el("div", { class: "history-line" }, [
-        document.createTextNode(`[${fmtAbsTimeValue(context, h.at)}] `),
-        el("span", { class: "actor", text: h.by || "?" }),
-        document.createTextNode(`: ${h.event}${note}`),
-      ]);
-      wrap.appendChild(line);
+    // ORB-10311: drop legacy bare `commented` stubs *before* the recent-history
+    // limit so meaningful status/workflow events are not displaced by comment
+    // noise (comments render in their own panel below).
+    const meaningful = task.history.filter((h) => h && h.event !== "commented");
+    if (meaningful.length > 0) {
+      const wrap = el("div");
+      const recent = meaningful.slice(-5).reverse();
+      for (const h of recent) {
+        const note = h.note ? ` (${h.note})` : "";
+        const line = el("div", { class: "history-line" }, [
+          document.createTextNode(`[${fmtAbsTimeValue(context, h.at)}] `),
+          el("span", { class: "actor", text: h.by || "?" }),
+          document.createTextNode(`: ${h.event}${note}`),
+        ]);
+        wrap.appendChild(line);
+      }
+      addField(rightCol, "recent history", wrap);
     }
-    addField(rightCol, "recent history", wrap);
   }
 
   if (Array.isArray(task.comments) && task.comments.length > 0) {

--- a/crates/orbit-dashboard/src/tests/dashboard_assets.rs
+++ b/crates/orbit-dashboard/src/tests/dashboard_assets.rs
@@ -392,6 +392,26 @@ fn dashboard_guards_diagnostics_and_detail_panels_in_aggregate_view() {
     }
 }
 
+#[test]
+fn dashboard_recent_history_filters_before_limiting() {
+    // ORB-10311: the recent-history panel must exclude legacy bare `commented`
+    // stubs *before* applying the five-row limit, so meaningful status/workflow
+    // events cannot be displaced by comment noise. Asserted against the embedded
+    // asset source (the dashboard has no JS test runner).
+    let tasks = include_str!("../../assets/dashboard/tasks.js");
+
+    let filter_at = tasks
+        .find(r#".filter((h) => h && h.event !== "commented")"#)
+        .expect("recent history must drop legacy `commented` stubs");
+    let slice_at = tasks
+        .find("meaningful.slice(-5).reverse()")
+        .expect("recent history must apply the five-row limit to the filtered list");
+    assert!(
+        filter_at < slice_at,
+        "the `commented`-stub filter must run before the recent-history slice"
+    );
+}
+
 async fn response_body(response: Response) -> String {
     let bytes = match to_bytes(response.into_body(), usize::MAX).await {
         Ok(bytes) => bytes,

--- a/crates/orbit-store/src/file/task_store/v2/tests/update.rs
+++ b/crates/orbit-store/src/file/task_store/v2/tests/update.rs
@@ -38,14 +38,17 @@ fn document_update_rewrites_v2_documents_and_envelope() {
     assert_eq!(task.execution_summary, "Updated summary");
     assert_eq!(task.priority, TaskPriority::Low);
     assert_eq!(task.pr_status.as_deref(), Some("approved"));
-    assert!(
-        store
-            .get_task_history("ORB-00000")
-            .expect("get history")
-            .expect("task exists")
-            .iter()
-            .any(|entry| entry.event == "renamed")
-    );
+    let renamed = store
+        .get_task_history("ORB-00000")
+        .expect("get history")
+        .expect("task exists")
+        .into_iter()
+        .find(|entry| entry.event == "renamed")
+        .expect("renamed event");
+    // ORB-10311: the rename note carries both the previous and replacement titles.
+    let note = renamed.note.expect("renamed note");
+    assert!(note.contains("Original"), "{note}");
+    assert!(note.contains("Renamed"), "{note}");
     assert_eq!(
         store
             .list_tasks_by_tags(&["task-artifacts".to_string()])

--- a/crates/orbit-store/src/file/task_store/v2/updates.rs
+++ b/crates/orbit-store/src/file/task_store/v2/updates.rs
@@ -16,6 +16,7 @@ impl TaskV2Store {
             let mut bundle = self.read_existing_bundle(id)?;
             let mut envelope_changed = false;
             let mut title_changed = false;
+            let mut previous_title: Option<String> = None;
             let relations_changed = fields.dependencies.is_some()
                 || fields.source_task_id.is_some()
                 || fields.relations.is_some();
@@ -27,6 +28,9 @@ impl TaskV2Store {
                     ));
                 }
                 title_changed = *value != bundle.envelope.title;
+                if title_changed {
+                    previous_title = Some(bundle.envelope.title.clone());
+                }
                 bundle.envelope.title = value.clone();
                 envelope_changed = true;
             }
@@ -135,13 +139,18 @@ impl TaskV2Store {
 
             if title_changed {
                 let now = Utc::now();
+                // ORB-10311: capture both titles so the rename is auditable from
+                // history alone rather than an empty `renamed` marker.
+                let note = previous_title
+                    .as_ref()
+                    .map(|previous| format!("\"{previous}\" → \"{}\"", bundle.envelope.title));
                 let event = TaskEventRowV2 {
                     schema_version: TASK_ARTIFACT_SCHEMA_VERSION,
                     event_id: next_event_id(&bundle.events),
                     at: now,
                     by: fields.actor.clone(),
                     event_type: "renamed".to_string(),
-                    note: None,
+                    note,
                     from_status: None,
                     to_status: None,
                 };


### PR DESCRIPTION
## Task

[ORB-10311](https://orbit-cli.com/tasks/ORB-10311) — Remove low-signal task history entries and enrich change events

### Description

## Problem
Task history emits a bare `commented` event for every separately persisted task comment. Human-facing views render entries such as `human: commented` without the message, duplicating the authoritative Comments list and crowding meaningful status and workflow events out of view.

Two other events preserve too little context: `renamed` omits the old and new title, and the `source_task_id changed` update omits the previous and replacement IDs. The dashboard further amplifies the noise by slicing the last five history rows before excluding low-signal legacy events.

## Why It Matters
Operators need task history to explain meaningful state changes quickly. Empty duplicate events consume attention and can hide load-bearing lifecycle events, while under-specified rename/source changes lose the only useful audit context.

## Constraints / Notes
- Stop creating redundant `commented` history entries; continue persisting full task comments unchanged.
- Suppress already-persisted legacy `commented` stubs only in human-facing CLI/dashboard history views. Do not migrate or destructively rewrite existing event data, and keep raw JSON/MCP compatibility.
- Enrich rather than remove rename and source-task change events.
- Preserve all status, approval/rejection, triage, workflow failure, start, and context-pruning events. Some are consumed by automation.
- Do not broaden this task into changing proposed-to-start transition semantics.

### Acceptance Criteria

- Appending a task comment persists the full TaskComment but creates no new TaskHistoryEntry whose event is `commented`; deterministic tests prove both outcomes.
- Human-readable CLI task history and the dashboard recent-history panel omit legacy bare `commented` entries, while comments remain visible with their full messages and raw JSON/MCP history remains backward-compatible.
- A title change emits `renamed` with a note containing both the previous and replacement title; a store-level test verifies the values.
- A source_task_id change emits an `updated` event whose note contains explicit previous and replacement values, including a clear representation of an unset value; tests cover the changed-value cases.
- The dashboard applies meaningful-event filtering before its recent-history limit so legacy comment stubs cannot displace status or workflow events; an automated asset/rendering test covers the ordering.
- Regression coverage confirms status_changed and other operational lifecycle events remain emitted and available to their existing consumers.
- `make ci-fast` passes from the Orbit repository root.

## Execution Summary

<details>
<summary>Click to expand</summary>

Removed low-signal task history noise and enriched change events (ORB-10311).

Core (orbit-core):
- helpers.rs: deleted task_comment_history_entries (the `commented`-stub factory) and added describe_optional_field_value for note formatting.
- command/task/update.rs: stopped extending append_history with comment stubs — a persisted TaskComment is now the sole record — and enriched the source_task_id change event: the `updated` event note now reads `source_task_id changed: <prev> -> <new>` with `(none)` for unset on either side.

Store (orbit-store):
- v2/updates.rs: the `renamed` event note now carries both titles ("Old" -> "New") instead of being empty; captured previous_title before overwrite.

Human-facing views (raw JSON/MCP history unchanged):
- orbit-cli output.rs: added pub(crate) is_human_visible_history_event(event) (false only for `commented`); applied it in the --fields history renderer.
- orbit-cli show.rs: filtered legacy `commented` stubs from the default task-show History block.
- orbit-dashboard tasks.js: filter out `commented` events BEFORE the recent-history slice(-5) so status/workflow events aren't displaced; skip the panel entirely if nothing meaningful remains.

Tests:
- task_host.rs: updated the two comment-attribution tests to assert the comment persists but no `commented` history entry is emitted; added source_task_id_change_history_records_previous_and_replacement (set + clear cases).
- store v2 tests/update.rs: rename test now asserts the note contains both titles.
- orbit-cli tests/output.rs (new): predicate + filter-order/preservation tests; registered in tests/mod.rs.
- orbit-dashboard dashboard_assets.rs: asserts the `commented` filter precedes the slice in tasks.js (filter-before-limit).
- Existing status_changed/started/context_pruned regression tests preserved.

Validation: targeted tests pass for orbit-store, orbit-core, orbit-cli, orbit-dashboard (identity env unset per L-0068 — two pre-existing attribution tests fail only under inherited ORBIT_AGENT_* env, unrelated to this change). make ci-fast passes (exit 0) from the repo root.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10311-6a5c0c0f`
- Behind base: 0
- Ahead of base: 1