### PR TITLE
Seed model-specific crews for available providers during initialization

### DIFF
--- a/.orbit/learnings/L-0100/learning.yaml
+++ b/.orbit/learnings/L-0100/learning.yaml
@@ -1,0 +1,17 @@
+schema_version: 1
+id: L-0100
+status: active
+scope:
+  paths:
+  - crates/orbit-core/src/config/bootstrap.rs
+  - crates/orbit-core/src/config/tests/bootstrap.rs
+  tags: []
+summary: Insert generated TOML keys inside their intended table and assert the parsed path, not only matching text
+body: Orbit's bootstrap template ends in `[runtime]`. Appending a bare `default_crew = ...` string therefore produced `runtime.default_crew`, even though substring assertions passed and runtime fallback masked the mistake. Insert generated keys at the target table header (or render structurally), and make deterministic tests inspect `workflow.default_crew` through parsed TOML.
+evidence:
+- kind: task
+  reference: ORB-10315
+created_at: 2026-07-18T23:39:16.644173807Z
+updated_at: 2026-07-18T23:39:16.644173807Z
+created_by: codex
+priority: 150

--- a/crates/orbit-cli/src/command/init.rs
+++ b/crates/orbit-cli/src/command/init.rs
@@ -224,7 +224,9 @@ pub(crate) fn collect_role_settings_for_init(
         .map_err(|err| OrbitError::Io(format!("agent prompts failed: {err}")))?;
     let qa = collect_qa_crew_setting(detected, &mut prompter)
         .map_err(|err| OrbitError::Io(format!("QA crew prompt failed: {err}")))?;
-    collected.insert("qa".to_string(), qa);
+    if let Some(qa) = qa {
+        collected.insert("qa".to_string(), qa);
+    }
     Ok(Some(collected))
 }
 

--- a/crates/orbit-cli/src/command/tests/init.rs
+++ b/crates/orbit-cli/src/command/tests/init.rs
@@ -124,20 +124,65 @@ fn non_interactive_init_isolates_temporary_root_skill_discovery() {
             "unexpected uncommented agent section: {line}",
         );
     }
-    assert!(contents.contains("[crews.claude]"));
-    assert!(contents.contains("[crews.codex]"));
-    assert!(contents.contains("[crews.gemini]"));
-    assert!(contents.contains("[crews.grok]"));
-    assert!(contents.contains("[crews.qa]"));
     let config = toml::from_str::<toml::Value>(&contents).expect("seeded config parses");
-    let codex = config
-        .get("crews")
-        .and_then(|crews| crews.get("codex"))
-        .expect("codex crew is seeded");
+    let crews = config.get("crews").and_then(toml::Value::as_table);
+    let expected = [
+        ("opus", "claude", "opus"),
+        ("sonnet", "claude", "sonnet"),
+        ("fable", "claude", "fable"),
+        ("sol", "codex", "gpt-5.6-sol"),
+        ("terra", "codex", "gpt-5.6-terra"),
+        ("luna", "codex", "gpt-5.6-luna"),
+        ("gemini", "gemini", "pro"),
+        ("grok", "grok", "grok-build"),
+        ("qa", "", ""),
+    ];
+    if let Some(crews) = crews {
+        assert!(!crews.contains_key("claude"));
+        assert!(!crews.contains_key("codex"));
+        for (name, crew) in crews {
+            let (_, provider, model) = expected
+                .iter()
+                .find(|(expected_name, _, _)| expected_name == name)
+                .unwrap_or_else(|| panic!("unexpected seeded crew {name}"));
+            assert_eq!(
+                crew.get("backend").and_then(toml::Value::as_str),
+                Some("cli"),
+            );
+            if name == "qa" {
+                let (provider, model) = if crews.contains_key("sol") {
+                    ("codex", "gpt-5.6-terra")
+                } else {
+                    ("claude", "sonnet")
+                };
+                assert_eq!(
+                    crew.get("provider").and_then(toml::Value::as_str),
+                    Some(provider),
+                );
+                assert_eq!(crew.get("model").and_then(toml::Value::as_str), Some(model),);
+            } else {
+                assert_eq!(
+                    crew.get("provider").and_then(toml::Value::as_str),
+                    Some(*provider),
+                );
+                assert_eq!(
+                    crew.get("model").and_then(toml::Value::as_str),
+                    Some(*model),
+                );
+            }
+        }
+    }
+    let default_crew = config
+        .get("workflow")
+        .and_then(|workflow| workflow.get("default_crew"))
+        .and_then(toml::Value::as_str);
     assert_eq!(
-        codex.get("model").and_then(toml::Value::as_str),
-        Some("gpt-5.6-terra"),
+        default_crew.is_some(),
+        crews.is_some_and(|crews| !crews.is_empty()),
     );
+    if let Some(default_crew) = default_crew {
+        assert!(crews.is_some_and(|crews| crews.contains_key(default_crew)));
+    }
     drop(validation_root);
     drop(validation_home);
     assert_discovery_sentinel(&agents_link, &agents_target);

--- a/crates/orbit-common/src/model_defaults.rs
+++ b/crates/orbit-common/src/model_defaults.rs
@@ -31,6 +31,9 @@ pub const CLAUDE_DEFAULT_STRONG: &str = "opus";
 /// Default "weak" Claude model: the unversioned `sonnet` CLI alias.
 pub const CLAUDE_DEFAULT_WEAK: &str = "sonnet";
 
+/// Claude CLI alias used by the standard Fable crew.
+pub const CLAUDE_FABLE_MODEL: &str = "fable";
+
 /// Default model for the Anthropic **HTTP Messages API** path.
 ///
 /// Unlike the CLI, the Messages API requires a fully-qualified model id and
@@ -38,8 +41,17 @@ pub const CLAUDE_DEFAULT_WEAK: &str = "sonnet";
 /// pinned. Bump it in lockstep with Anthropic's published API model ids.
 pub const ANTHROPIC_HTTP_DEFAULT_MODEL: &str = "claude-sonnet-4-5";
 
-/// Default codex model (strong role and provider default).
-pub const CODEX_DEFAULT_MODEL: &str = "gpt-5.6-terra";
+/// Codex model used by the standard Sol crew.
+pub const CODEX_SOL_MODEL: &str = "gpt-5.6-sol";
+
+/// Codex model used by the standard Terra crew and provider default.
+pub const CODEX_TERRA_MODEL: &str = "gpt-5.6-terra";
+
+/// Codex model used by the standard Luna crew.
+pub const CODEX_LUNA_MODEL: &str = "gpt-5.6-luna";
+
+/// Default codex model (Terra remains the provider and QA default).
+pub const CODEX_DEFAULT_MODEL: &str = CODEX_TERRA_MODEL;
 
 /// Default codex "weak" model used by the executor model pair.
 pub const CODEX_DEFAULT_WEAK: &str = "gpt-5.4-mini";

--- a/crates/orbit-core/src/command/init.rs
+++ b/crates/orbit-core/src/command/init.rs
@@ -945,11 +945,8 @@ mod tests {
                 "unexpected uncommented agent section: {line}",
             );
         }
-        assert!(contents.contains("[crews.claude]"));
-        assert!(contents.contains("[crews.codex]"));
-        assert!(contents.contains("[crews.gemini]"));
-        assert!(contents.contains("[crews.grok]"));
-        assert!(contents.contains("default_crew = \"codex\""));
+        assert!(!contents.contains("[crews."));
+        assert!(!contents.contains("default_crew"));
     }
 
     fn assert_skill_link_exists(path: PathBuf) {

--- a/crates/orbit-core/src/config/agent_detect.rs
+++ b/crates/orbit-core/src/config/agent_detect.rs
@@ -106,19 +106,21 @@ pub fn detect(probe: &dyn AgentEnvProbe) -> DetectedAgents {
     }
 }
 
-/// Agent families available for crew-backed config seeding.
+/// CLI agent families available for crew-backed config seeding.
 ///
-/// The order intentionally mirrors [`default_provider`] for the overlapping
-/// families, excluding `ollama` because Orbit does not ship an `ollama` crew.
+/// Seeded crews always use the CLI backend, so API-key-only detection is not
+/// sufficient. The order intentionally mirrors [`default_provider`] for the
+/// overlapping families, excluding `ollama` because Orbit does not ship an
+/// `ollama` crew.
 pub fn available_crew_families(detected: &DetectedAgents) -> Vec<&'static str> {
     let mut families = Vec::new();
-    if detected.claude_cli || detected.anthropic_api_key {
+    if detected.claude_cli {
         families.push("claude");
     }
-    if detected.codex_cli || detected.openai_api_key {
+    if detected.codex_cli {
         families.push("codex");
     }
-    if detected.gemini_cli || detected.gemini_api_key {
+    if detected.gemini_cli {
         families.push("gemini");
     }
     if detected.grok_cli {
@@ -127,16 +129,18 @@ pub fn available_crew_families(detected: &DetectedAgents) -> Vec<&'static str> {
     families
 }
 
-/// Default crew name frozen into newly seeded config.
-///
-/// Falling back to `codex` preserves the historical no-detection template
-/// behavior even though [`default_provider`] still falls back to `claude` for
-/// role prompt defaults.
-pub fn default_crew_name(detected: &DetectedAgents) -> &'static str {
+/// Default crew name frozen into newly seeded config, when a supported CLI is
+/// available. The result always names the first emitted crew for that family.
+pub fn default_crew_name(detected: &DetectedAgents) -> Option<&'static str> {
     available_crew_families(detected)
         .first()
-        .copied()
-        .unwrap_or("codex")
+        .map(|family| match *family {
+            "claude" => "opus",
+            "codex" => "sol",
+            "gemini" => "gemini",
+            "grok" => "grok",
+            _ => unreachable!("available crew families are fixed"),
+        })
 }
 
 /// "Latest known good" model per provider. Returned to seed prompt defaults;

--- a/crates/orbit-core/src/config/agent_prompt.rs
+++ b/crates/orbit-core/src/config/agent_prompt.rs
@@ -101,32 +101,28 @@ pub fn collect_role_settings(
 pub fn collect_qa_crew_setting(
     detected: &DetectedAgents,
     prompter: &mut dyn Prompter,
-) -> io::Result<RawAgentRoleConfig> {
+) -> io::Result<Option<RawAgentRoleConfig>> {
     let mut options = Vec::new();
-    if detected.codex_cli || detected.openai_api_key {
+    if detected.codex_cli {
         options.push(RawAgentRoleConfig {
-            provider: Some("codex".to_string()),
-            backend: Some(default_backend("codex", detected).to_string()),
-            model: Some(orbit_common::model_defaults::CODEX_DEFAULT_MODEL.to_string()),
-        });
-    }
-    if detected.claude_cli || detected.anthropic_api_key {
-        options.push(RawAgentRoleConfig {
-            provider: Some("claude".to_string()),
-            backend: Some(default_backend("claude", detected).to_string()),
-            model: Some(orbit_common::model_defaults::CLAUDE_DEFAULT_WEAK.to_string()),
-        });
-    }
-
-    if options.is_empty() {
-        return Ok(RawAgentRoleConfig {
             provider: Some("codex".to_string()),
             backend: Some("cli".to_string()),
             model: Some(orbit_common::model_defaults::CODEX_DEFAULT_MODEL.to_string()),
         });
     }
+    if detected.claude_cli {
+        options.push(RawAgentRoleConfig {
+            provider: Some("claude".to_string()),
+            backend: Some("cli".to_string()),
+            model: Some(orbit_common::model_defaults::CLAUDE_DEFAULT_WEAK.to_string()),
+        });
+    }
+
+    if options.is_empty() {
+        return Ok(None);
+    }
     if options.len() == 1 {
-        return Ok(options.remove(0));
+        return Ok(Some(options.remove(0)));
     }
 
     prompter.message(
@@ -134,8 +130,8 @@ pub fn collect_qa_crew_setting(
     )?;
     loop {
         match prompter.prompt("QA crew [1]: ")?.trim() {
-            "" | "1" => return Ok(options.remove(0)),
-            "2" => return Ok(options.remove(1)),
+            "" | "1" => return Ok(Some(options.remove(0))),
+            "2" => return Ok(Some(options.remove(1))),
             _ => prompter.message("Please enter 1 or 2.")?,
         }
     }

--- a/crates/orbit-core/src/config/bootstrap.rs
+++ b/crates/orbit-core/src/config/bootstrap.rs
@@ -44,7 +44,15 @@ fn render_seeded_config(
     }
 
     // ADR-0193: freeze agent detection at init; runtime config loading never probes PATH/env.
-    body.push_str(&render_workflow_default_crew(detected, role_settings));
+    let workflow_default = render_workflow_default_crew(detected, role_settings);
+    if !workflow_default.is_empty() {
+        // L-0100: generated TOML keys must be inserted inside their intended table.
+        let marker = "[workflow]\n";
+        let insertion = body.find(marker).ok_or_else(|| {
+            OrbitError::InvalidInput("default config template is missing [workflow]".to_string())
+        })? + marker.len();
+        body.insert_str(insertion, &workflow_default);
+    }
     body.push('\n');
     body.push_str(&render_crews(detected, role_settings)?);
     body.push_str(&render_duel(detected)?);
@@ -56,19 +64,21 @@ fn render_workflow_default_crew(
     role_settings: Option<&BTreeMap<String, RawAgentRoleConfig>>,
 ) -> String {
     let default_crew = if role_settings.is_some() {
-        "custom"
+        Some("custom")
     } else {
         default_crew_name(detected)
     };
-    format!("default_crew = \"{default_crew}\"\n")
+    default_crew.map_or_else(String::new, |name| format!("default_crew = \"{name}\"\n"))
 }
 
 fn render_crews(
     detected: &DetectedAgents,
     role_settings: Option<&BTreeMap<String, RawAgentRoleConfig>>,
 ) -> Result<String, OrbitError> {
+    let available_families = available_crew_families(detected);
     let mut crews: BTreeMap<String, RawCrewEntry> = default_crews()
         .into_iter()
+        .filter(|(_, crew)| available_families.contains(&crew.assignment.provider.as_str()))
         .map(|(name, crew)| {
             (
                 name,
@@ -107,55 +117,50 @@ fn render_crews(
         );
     }
 
-    let qa = role_settings
+    if let Some(qa) = role_settings
         .and_then(|roles| roles.get("qa").cloned())
-        .unwrap_or_else(|| default_qa_crew(detected));
-    crews.insert(
-        "qa".to_string(),
-        RawCrewEntry {
-            provider: qa.provider,
-            model: qa.model,
-            backend: qa.backend,
-            description: None,
-            tags: Vec::new(),
-            planner: None,
-            implementer: None,
-            reviewer: None,
-        },
-    );
+        .or_else(|| default_qa_crew(detected))
+    {
+        crews.insert(
+            "qa".to_string(),
+            RawCrewEntry {
+                provider: qa.provider,
+                model: qa.model,
+                backend: qa.backend,
+                description: None,
+                tags: Vec::new(),
+                planner: None,
+                implementer: None,
+                reviewer: None,
+            },
+        );
+    }
 
     let mut rendered = String::new();
     for (name, entry) in crews {
         rendered.push_str(&render_crew_table(&name, &entry)?);
     }
+    if rendered.is_empty() {
+        // Preserve an explicitly empty registry so runtime loading does not
+        // substitute built-in crews for a host where init detected none.
+        rendered.push_str("[crews]\n");
+    }
     Ok(rendered)
 }
 
-fn default_qa_crew(detected: &DetectedAgents) -> RawAgentRoleConfig {
-    let (provider, backend, model) = if detected.codex_cli || detected.openai_api_key {
-        (
-            "codex",
-            super::agent_detect::default_backend("codex", detected),
-            orbit_common::model_defaults::CODEX_DEFAULT_MODEL,
-        )
-    } else if detected.claude_cli || detected.anthropic_api_key {
-        (
-            "claude",
-            super::agent_detect::default_backend("claude", detected),
-            orbit_common::model_defaults::CLAUDE_DEFAULT_WEAK,
-        )
+fn default_qa_crew(detected: &DetectedAgents) -> Option<RawAgentRoleConfig> {
+    let (provider, model) = if detected.codex_cli {
+        ("codex", orbit_common::model_defaults::CODEX_DEFAULT_MODEL)
+    } else if detected.claude_cli {
+        ("claude", orbit_common::model_defaults::CLAUDE_DEFAULT_WEAK)
     } else {
-        (
-            "codex",
-            "cli",
-            orbit_common::model_defaults::CODEX_DEFAULT_MODEL,
-        )
+        return None;
     };
-    RawAgentRoleConfig {
+    Some(RawAgentRoleConfig {
         provider: Some(provider.to_string()),
-        backend: Some(backend.to_string()),
+        backend: Some("cli".to_string()),
         model: Some(model.to_string()),
-    }
+    })
 }
 
 fn render_crew_table(name: &str, entry: &RawCrewEntry) -> Result<String, OrbitError> {

--- a/crates/orbit-core/src/config/registry.rs
+++ b/crates/orbit-core/src/config/registry.rs
@@ -21,7 +21,8 @@ use serde::de::DeserializeOwned;
 use serde_json::{Value as JsonValue, json};
 
 const DEFAULT_WORKFLOW_BASE_BRANCH: &str = "main";
-const DEFAULT_WORKFLOW_CREW: &str = "claude";
+const DEFAULT_WORKFLOW_CREW: &str = "opus";
+const LEGACY_DEFAULT_WORKFLOW_CREW: &str = "claude";
 const CONSTELLATION_DEFAULT_PROVIDER_ENV: &str = "CONSTELLATION_DEFAULT_PROVIDER";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -241,7 +242,7 @@ fn default_admission_crews() -> BTreeMap<String, Crew> {
             name: DEFAULT_WORKFLOW_CREW.to_string(),
             assignment: CrewRoleAssignment {
                 model: String::new(),
-                provider: DEFAULT_WORKFLOW_CREW.to_string(),
+                provider: "claude".to_string(),
                 backend: String::new(),
             },
             description: None,
@@ -425,16 +426,21 @@ pub(super) fn resolve_default_crew(
     let selected = if let Some(configured) = configured.filter(|value| !value.trim().is_empty()) {
         Some(configured)
     } else if let Some(raw_env) = env_default.filter(|value| !value.trim().is_empty()) {
-        Some(
-            Provider::parse(raw_env)
-                .map_err(|error| {
-                    OrbitError::InvalidInput(format!(
-                        "{CONSTELLATION_DEFAULT_PROVIDER_ENV} has invalid value: {error}"
-                    ))
-                })?
-                .as_str()
-                .to_string(),
-        )
+        let provider = Provider::parse(raw_env).map_err(|error| {
+            OrbitError::InvalidInput(format!(
+                "{CONSTELLATION_DEFAULT_PROVIDER_ENV} has invalid value: {error}"
+            ))
+        })?;
+        let preferred = match provider.as_str() {
+            "claude" => "opus",
+            "codex" => "sol",
+            provider => provider,
+        };
+        Some(if crews.contains_key(preferred) {
+            preferred.to_string()
+        } else {
+            provider.as_str().to_string()
+        })
     } else {
         None
     };
@@ -444,6 +450,9 @@ pub(super) fn resolve_default_crew(
     }
     if crews.contains_key(DEFAULT_WORKFLOW_CREW) {
         return Ok(Some(DEFAULT_WORKFLOW_CREW.to_string()));
+    }
+    if crews.contains_key(LEGACY_DEFAULT_WORKFLOW_CREW) {
+        return Ok(Some(LEGACY_DEFAULT_WORKFLOW_CREW.to_string()));
     }
     if crews.is_empty() {
         return Ok(None);

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -3,7 +3,8 @@ use std::fs;
 use std::path::Path;
 
 use orbit_common::model_defaults::{
-    CLAUDE_DEFAULT_WEAK, CODEX_DEFAULT_MODEL, GEMINI_CREW_MODEL, GROK_DEFAULT_MODEL,
+    CLAUDE_DEFAULT_STRONG, CLAUDE_DEFAULT_WEAK, CLAUDE_FABLE_MODEL, CODEX_LUNA_MODEL,
+    CODEX_SOL_MODEL, CODEX_TERRA_MODEL, GEMINI_CREW_MODEL, GROK_DEFAULT_MODEL,
 };
 use orbit_common::types::{Crew, CrewRoleAssignment, OrbitError, all_agent_families};
 use orbit_common::utility::redaction::redact_home_dir;
@@ -251,42 +252,26 @@ impl RuntimeConfig {
 
 pub(crate) fn default_crews() -> BTreeMap<String, Crew> {
     let mut crews = BTreeMap::new();
-    crews.insert(
-        "claude".to_string(),
-        Crew {
-            name: "claude".to_string(),
-            assignment: crew_role(CLAUDE_DEFAULT_WEAK, "claude", "cli"),
-            description: None,
-            tags: Vec::new(),
-        },
-    );
-    crews.insert(
-        "codex".to_string(),
-        Crew {
-            name: "codex".to_string(),
-            assignment: crew_role(CODEX_DEFAULT_MODEL, "codex", "cli"),
-            description: None,
-            tags: Vec::new(),
-        },
-    );
-    crews.insert(
-        "gemini".to_string(),
-        Crew {
-            name: "gemini".to_string(),
-            assignment: crew_role(GEMINI_CREW_MODEL, "gemini", "cli"),
-            description: None,
-            tags: Vec::new(),
-        },
-    );
-    crews.insert(
-        "grok".to_string(),
-        Crew {
-            name: "grok".to_string(),
-            assignment: crew_role(GROK_DEFAULT_MODEL, "grok", "cli"),
-            description: None,
-            tags: Vec::new(),
-        },
-    );
+    for (name, model, provider) in [
+        ("opus", CLAUDE_DEFAULT_STRONG, "claude"),
+        ("sonnet", CLAUDE_DEFAULT_WEAK, "claude"),
+        ("fable", CLAUDE_FABLE_MODEL, "claude"),
+        ("sol", CODEX_SOL_MODEL, "codex"),
+        ("terra", CODEX_TERRA_MODEL, "codex"),
+        ("luna", CODEX_LUNA_MODEL, "codex"),
+        ("gemini", GEMINI_CREW_MODEL, "gemini"),
+        ("grok", GROK_DEFAULT_MODEL, "grok"),
+    ] {
+        crews.insert(
+            name.to_string(),
+            Crew {
+                name: name.to_string(),
+                assignment: crew_role(model, provider, "cli"),
+                description: None,
+                tags: Vec::new(),
+            },
+        );
+    }
     crews
 }
 
@@ -334,11 +319,6 @@ fn crews_from_raw(
                 "[crews] contains duplicate name '{trimmed}' after whitespace normalization"
             )));
         }
-    }
-    if crews.is_empty() {
-        return Err(OrbitError::InvalidInput(
-            "[crews] must define at least one crew".to_string(),
-        ));
     }
     Ok(crews)
 }

--- a/crates/orbit-core/src/config/tests/agent_detect.rs
+++ b/crates/orbit-core/src/config/tests/agent_detect.rs
@@ -25,6 +25,30 @@ fn detect_reflects_probe_results() {
 fn empty_probe_detects_nothing() {
     let probe = MockAgentEnvProbe::new();
     assert_eq!(detect(&probe), DetectedAgents::default());
+    assert!(available_crew_families(&detect(&probe)).is_empty());
+    assert_eq!(default_crew_name(&detect(&probe)), None);
+}
+
+#[test]
+fn seeded_crew_availability_requires_cli_and_maps_defaults() {
+    let api_only = DetectedAgents {
+        anthropic_api_key: true,
+        openai_api_key: true,
+        gemini_api_key: true,
+        ..DetectedAgents::default()
+    };
+    assert!(available_crew_families(&api_only).is_empty());
+
+    for (binary, family, crew) in [
+        ("claude", "claude", "opus"),
+        ("codex", "codex", "sol"),
+        ("gemini", "gemini", "gemini"),
+        ("grok", "grok", "grok"),
+    ] {
+        let detected = detect(&MockAgentEnvProbe::new().with_binary(binary));
+        assert_eq!(available_crew_families(&detected), vec![family]);
+        assert_eq!(default_crew_name(&detected), Some(crew));
+    }
 }
 
 #[test]

--- a/crates/orbit-core/src/config/tests/agent_prompt.rs
+++ b/crates/orbit-core/src/config/tests/agent_prompt.rs
@@ -149,7 +149,9 @@ fn qa_crew_prompt_offers_only_detected_claude_and_codex_defaults() {
         ..DetectedAgents::default()
     };
     let mut prompter = CannedPrompter::new(["2"]);
-    let qa = collect_qa_crew_setting(&detected, &mut prompter).expect("qa choice");
+    let qa = collect_qa_crew_setting(&detected, &mut prompter)
+        .expect("qa choice")
+        .expect("qa is available");
 
     assert_eq!(qa.provider.as_deref(), Some("claude"));
     assert_eq!(
@@ -170,8 +172,25 @@ fn qa_crew_noninteractive_default_prefers_detected_codex() {
         ..DetectedAgents::default()
     };
     let mut prompter = CannedPrompter::new([""]);
-    let qa = collect_qa_crew_setting(&detected, &mut prompter).expect("qa default");
+    let qa = collect_qa_crew_setting(&detected, &mut prompter)
+        .expect("qa default")
+        .expect("qa is available");
 
     assert_eq!(qa.provider.as_deref(), Some("codex"));
     assert_eq!(qa.model.as_deref(), Some(CODEX_DEFAULT_MODEL));
+}
+
+#[test]
+fn qa_crew_is_omitted_without_claude_or_codex_cli() {
+    let detected = DetectedAgents {
+        anthropic_api_key: true,
+        openai_api_key: true,
+        gemini_cli: true,
+        ..DetectedAgents::default()
+    };
+    let mut prompter = CannedPrompter::new([] as [&str; 0]);
+    let qa = collect_qa_crew_setting(&detected, &mut prompter).expect("qa selection");
+
+    assert!(qa.is_none());
+    assert!(prompter.transcript().is_empty());
 }

--- a/crates/orbit-core/src/config/tests/bootstrap.rs
+++ b/crates/orbit-core/src/config/tests/bootstrap.rs
@@ -51,33 +51,80 @@ fn default_template_keeps_agent_dependent_sections_out() {
 }
 
 #[test]
-fn seed_with_claude_detection_writes_all_crews_and_claude_default() {
-    let detected = detect(&MockAgentEnvProbe::new().with_binary("claude"));
-    let contents = seed_contents(&detected, None);
-
-    assert_all_base_crews_present(&contents);
-    assert!(contents.contains("default_crew = \"claude\""));
-    assert_qa_crew(
-        &contents,
-        "claude",
-        orbit_common::model_defaults::CLAUDE_DEFAULT_WEAK,
+fn claude_only_seeds_the_claude_family_and_qa() {
+    let contents = seed_contents(
+        &detect(&MockAgentEnvProbe::new().with_binary("claude")),
+        None,
     );
+    let parsed = parsed_config(&contents);
+
+    assert_eq!(crew_names(&parsed), vec!["fable", "opus", "qa", "sonnet"]);
+    assert_crew(&parsed, "opus", "claude", "opus");
+    assert_crew(&parsed, "sonnet", "claude", "sonnet");
+    assert_crew(&parsed, "fable", "claude", "fable");
+    assert_crew(&parsed, "qa", "claude", "sonnet");
+    assert_default_crew(&parsed, Some("opus"));
     assert!(!contents.contains("[duel"));
 }
 
 #[test]
-fn seed_with_empty_detection_defaults_codex_and_omits_duel() {
-    let detected = DetectedAgents::default();
-    let contents = seed_contents(&detected, None);
-
-    assert_all_base_crews_present(&contents);
-    assert!(contents.contains("default_crew = \"codex\""));
-    assert_qa_crew(
-        &contents,
-        "codex",
-        orbit_common::model_defaults::CODEX_DEFAULT_MODEL,
+fn codex_only_seeds_the_codex_family_and_qa() {
+    let contents = seed_contents(
+        &detect(&MockAgentEnvProbe::new().with_binary("codex")),
+        None,
     );
+    let parsed = parsed_config(&contents);
+
+    assert_eq!(crew_names(&parsed), vec!["luna", "qa", "sol", "terra"]);
+    assert_crew(&parsed, "sol", "codex", "gpt-5.6-sol");
+    assert_crew(&parsed, "terra", "codex", "gpt-5.6-terra");
+    assert_crew(&parsed, "luna", "codex", "gpt-5.6-luna");
+    assert_crew(&parsed, "qa", "codex", "gpt-5.6-terra");
+    assert_default_crew(&parsed, Some("sol"));
+}
+
+#[test]
+fn gemini_only_seeds_gemini_without_qa() {
+    let contents = seed_contents(
+        &detect(&MockAgentEnvProbe::new().with_binary("gemini")),
+        None,
+    );
+    let parsed = parsed_config(&contents);
+
+    assert_eq!(crew_names(&parsed), vec!["gemini"]);
+    assert_crew(&parsed, "gemini", "gemini", "pro");
+    assert_default_crew(&parsed, Some("gemini"));
+}
+
+#[test]
+fn grok_only_seeds_grok_without_qa() {
+    let contents = seed_contents(&detect(&MockAgentEnvProbe::new().with_binary("grok")), None);
+    let parsed = parsed_config(&contents);
+
+    assert_eq!(crew_names(&parsed), vec!["grok"]);
+    assert_crew(&parsed, "grok", "grok", "grok-build");
+    assert_default_crew(&parsed, Some("grok"));
+}
+
+#[test]
+fn no_supported_cli_seeds_no_crews_or_dangling_default() {
+    let detected = detect(
+        &MockAgentEnvProbe::new()
+            .with_binary("ollama")
+            .with_env("ANTHROPIC_API_KEY", "anthropic")
+            .with_env("OPENAI_API_KEY", "openai")
+            .with_env("GEMINI_API_KEY", "gemini"),
+    );
+    let contents = seed_contents(&detected, None);
+    let parsed = parsed_config(&contents);
+
+    assert!(crew_names(&parsed).is_empty());
+    assert_default_crew(&parsed, None);
     assert!(!contents.contains("[duel"));
+    toml::from_str::<RawRuntimeConfig>(&contents).expect("no-provider config parses");
+    let runtime = load_seeded_config(&contents);
+    assert!(runtime.crews.is_empty());
+    assert_eq!(runtime.default_crew, None);
 }
 
 #[test]
@@ -120,6 +167,43 @@ fn seed_with_three_available_families_writes_duel_candidates_and_models() {
         models.get("gemini").and_then(|v| v.as_str()),
         Some(orbit_common::model_defaults::GEMINI_DEFAULT_MODEL)
     );
+}
+
+#[test]
+fn multi_provider_seed_includes_each_available_family_and_excludes_unavailable() {
+    let detected = detect(
+        &MockAgentEnvProbe::new()
+            .with_binary("claude")
+            .with_binary("codex")
+            .with_binary("grok"),
+    );
+    let parsed = parsed_config(&seed_contents(&detected, None));
+
+    assert_eq!(
+        crew_names(&parsed),
+        vec![
+            "fable", "grok", "luna", "opus", "qa", "sol", "sonnet", "terra"
+        ]
+    );
+    assert_default_crew(&parsed, Some("opus"));
+    assert_crew(&parsed, "opus", "claude", "opus");
+    assert_crew(&parsed, "sonnet", "claude", "sonnet");
+    assert_crew(&parsed, "fable", "claude", "fable");
+    assert_crew(&parsed, "sol", "codex", "gpt-5.6-sol");
+    assert_crew(&parsed, "terra", "codex", "gpt-5.6-terra");
+    assert_crew(&parsed, "luna", "codex", "gpt-5.6-luna");
+    assert_crew(&parsed, "grok", "grok", "grok-build");
+    assert_crew(&parsed, "qa", "codex", "gpt-5.6-terra");
+    for crew in crews(&parsed).values() {
+        assert_eq!(
+            crew.get("backend").and_then(toml::Value::as_str),
+            Some("cli")
+        );
+        assert_ne!(
+            crew.get("provider").and_then(toml::Value::as_str),
+            Some("gemini")
+        );
+    }
 }
 
 #[test]
@@ -191,7 +275,7 @@ fn seeded_configs_round_trip_for_detection_permutations() {
 }
 
 #[test]
-fn seed_with_no_role_settings_writes_generated_agent_block() {
+fn seed_with_no_role_settings_keeps_static_template_content() {
     let dir = tempdir().expect("tempdir");
     let path = dir.path().join("config.toml");
     let detected = DetectedAgents::default();
@@ -199,8 +283,8 @@ fn seed_with_no_role_settings_writes_generated_agent_block() {
     assert!(created);
     let contents = std::fs::read_to_string(&path).expect("read");
     assert!(no_active_role_section(&contents));
-    assert_all_base_crews_present(&contents);
-    assert!(contents.contains("default_crew = \"codex\""));
+    assert!(crew_names(&parsed_config(&contents)).is_empty());
+    assert!(!contents.contains("default_crew"));
     assert!(contents.contains("sandbox = \"danger-full-access\""));
 }
 
@@ -221,25 +305,48 @@ fn load_seeded_config(contents: &str) -> RuntimeConfig {
     RuntimeConfig::load_layered(dir.path(), dir.path()).expect("runtime config loads")
 }
 
-fn assert_all_base_crews_present(contents: &str) {
-    assert!(contents.contains("[crews.claude]"));
-    assert!(contents.contains("[crews.codex]"));
-    assert!(contents.contains("[crews.gemini]"));
-    assert!(contents.contains("[crews.grok]"));
-    assert!(contents.contains("[crews.qa]"));
+fn parsed_config(contents: &str) -> toml::Value {
+    toml::from_str(contents).expect("parse seeded config")
 }
 
-fn assert_qa_crew(contents: &str, provider: &str, model: &str) {
-    let parsed: toml::Value = toml::from_str(contents).expect("parse seeded config");
-    let qa = parsed
+fn crews(parsed: &toml::Value) -> &toml::map::Map<String, toml::Value> {
+    parsed
         .get("crews")
-        .and_then(|crews| crews.get("qa"))
-        .expect("qa crew");
+        .and_then(toml::Value::as_table)
+        .unwrap_or_else(|| empty_toml_table())
+}
+
+fn empty_toml_table() -> &'static toml::map::Map<String, toml::Value> {
+    static EMPTY: std::sync::OnceLock<toml::map::Map<String, toml::Value>> =
+        std::sync::OnceLock::new();
+    EMPTY.get_or_init(toml::map::Map::new)
+}
+
+fn crew_names(parsed: &toml::Value) -> Vec<&str> {
+    crews(parsed).keys().map(String::as_str).collect()
+}
+
+fn assert_crew(parsed: &toml::Value, name: &str, provider: &str, model: &str) {
+    let crew = crews(parsed).get(name).expect("expected crew");
     assert_eq!(
-        qa.get("provider").and_then(toml::Value::as_str),
+        crew.get("provider").and_then(toml::Value::as_str),
         Some(provider)
     );
-    assert_eq!(qa.get("model").and_then(toml::Value::as_str), Some(model));
+    assert_eq!(crew.get("model").and_then(toml::Value::as_str), Some(model));
+    assert_eq!(
+        crew.get("backend").and_then(toml::Value::as_str),
+        Some("cli")
+    );
+}
+
+fn assert_default_crew(parsed: &toml::Value, expected: Option<&str>) {
+    assert_eq!(
+        parsed
+            .get("workflow")
+            .and_then(|workflow| workflow.get("default_crew"))
+            .and_then(toml::Value::as_str),
+        expected,
+    );
 }
 
 fn no_active_role_section(contents: &str) -> bool {
@@ -260,9 +367,7 @@ fn seed_with_role_settings_writes_custom_crew() {
 
     assert!(no_active_role_section(&contents));
     assert!(contents.contains("default_crew = \"custom\""));
-    assert_all_base_crews_present(&contents);
     assert!(contents.contains("[crews.custom]"));
-    assert!(contents.contains("provider = \"claude\""));
     assert!(contents.contains("provider = \"codex\""));
     assert!(contents.contains(&format!(
         "model = \"{}\"",
@@ -276,6 +381,7 @@ fn seed_with_role_settings_writes_custom_crew() {
         .expect("crews table")
         .as_table()
         .unwrap();
+    assert_eq!(crews.len(), 1, "custom init must not invent provider crews");
     let custom = crews
         .get("custom")
         .and_then(|v| v.as_table())
@@ -307,7 +413,7 @@ fn seed_with_existing_file_is_noop() {
 }
 
 #[test]
-fn seed_with_empty_role_map_uses_detected_default() {
+fn seed_with_empty_role_map_uses_no_provider_behavior() {
     let dir = tempdir().expect("tempdir");
     let path = dir.path().join("config.toml");
     let roles: BTreeMap<String, RawAgentRoleConfig> = BTreeMap::new();
@@ -315,8 +421,9 @@ fn seed_with_empty_role_map_uses_detected_default() {
     let created = seed_default_config(&path, &detected, Some(&roles)).expect("seed");
     assert!(created);
     let contents = std::fs::read_to_string(&path).expect("read");
-    assert!(contents.contains("default_crew = \"codex\""));
-    assert_all_base_crews_present(&contents);
+    let parsed = parsed_config(&contents);
+    assert!(crew_names(&parsed).is_empty());
+    assert_default_crew(&parsed, None);
 }
 
 #[test]

--- a/crates/orbit-core/src/config/tests/runtime.rs
+++ b/crates/orbit-core/src/config/tests/runtime.rs
@@ -22,6 +22,37 @@ fn single_family_crew(name: &str) -> Crew {
     }
 }
 
+#[test]
+fn built_in_crews_use_standard_model_specific_names() {
+    let crews = default_crews();
+    assert_eq!(
+        crews.keys().map(String::as_str).collect::<Vec<_>>(),
+        vec![
+            "fable", "gemini", "grok", "luna", "opus", "sol", "sonnet", "terra"
+        ]
+    );
+    for (name, provider, model) in [
+        ("opus", "claude", "opus"),
+        ("sonnet", "claude", "sonnet"),
+        ("fable", "claude", "fable"),
+        ("sol", "codex", "gpt-5.6-sol"),
+        ("terra", "codex", "gpt-5.6-terra"),
+        ("luna", "codex", "gpt-5.6-luna"),
+        ("gemini", "gemini", "pro"),
+        ("grok", "grok", "grok-build"),
+    ] {
+        let assignment = &crews.get(name).expect("built-in crew").assignment;
+        assert_eq!(assignment.provider, provider);
+        assert_eq!(assignment.model, model);
+        assert_eq!(assignment.backend, "cli");
+    }
+    assert!(!crews.contains_key("claude"));
+    assert!(!crews.contains_key("codex"));
+
+    let config = RuntimeConfig::default_for_data_root(Path::new(".orbit"));
+    assert_eq!(config.default_crew.as_deref(), Some("opus"));
+}
+
 fn load_config(body: &str) -> Result<RuntimeConfig, OrbitError> {
     let global = tempdir().expect("global tempdir");
     let workspace = tempdir().expect("workspace tempdir");
@@ -392,7 +423,8 @@ fn workflow_default_crew_no_crews_defined_is_noop() {
 fn workflow_default_crew_uses_environment_then_claude_system_default() {
     use super::super::registry::resolve_default_crew;
     let crews = BTreeMap::from([
-        ("claude".to_string(), single_family_crew("claude")),
+        ("opus".to_string(), single_family_crew("claude")),
+        ("sol".to_string(), single_family_crew("codex")),
         ("gemini".to_string(), single_family_crew("gemini")),
     ]);
 
@@ -400,9 +432,13 @@ fn workflow_default_crew_uses_environment_then_claude_system_default() {
         .expect("deprecated environment alias resolves");
     assert_eq!(env.as_deref(), Some("gemini"));
 
+    let codex = resolve_default_crew(None, &crews, Some("codex"))
+        .expect("provider environment maps to standard crew");
+    assert_eq!(codex.as_deref(), Some("sol"));
+
     let system =
         resolve_default_crew(None, &crews, None).expect("canonical system default resolves");
-    assert_eq!(system.as_deref(), Some("claude"));
+    assert_eq!(system.as_deref(), Some("opus"));
 
     let error = resolve_default_crew(None, &crews, Some("bogus"))
         .expect_err("selected invalid environment value must not fall back");

--- a/crates/orbit-core/src/config/tests/store.rs
+++ b/crates/orbit-core/src/config/tests/store.rs
@@ -123,7 +123,7 @@ fn set_validate_and_save_round_trips() {
 fn set_preserves_comments_and_unrelated_formatting() {
     let dir = tempdir().expect("tempdir");
     let path = config_path(dir.path());
-    let original = "# top comment\n[workflow]\n# base branch comment\nbase_branch = \"main\"\ndefault_crew = \"codex\" # inline comment\n";
+    let original = "# top comment\n[workflow]\n# base branch comment\nbase_branch = \"main\"\ndefault_crew = \"sol\" # inline comment\n";
     fs::write(&path, original).expect("write config");
 
     let mut store = ConfigStore::open(ConfigScope::Workspace, &path).expect("open store");
@@ -137,7 +137,7 @@ fn set_preserves_comments_and_unrelated_formatting() {
     assert!(saved.contains("# top comment"), "saved:\n{saved}");
     assert!(saved.contains("# base branch comment"), "saved:\n{saved}");
     assert!(
-        saved.contains("default_crew = \"codex\" # inline comment"),
+        saved.contains("default_crew = \"sol\" # inline comment"),
         "saved:\n{saved}"
     );
     assert!(

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -24,7 +24,7 @@ The workspace identity file `.orbit/config.yaml` is a separate artifact (it stor
 ```toml
 [workflow]
 base_branch = "main"        # default merge-base for ship / duel-plan
-default_crew = "codex"      # fallback crew when a task has no `crew` set
+default_crew = "sol"        # fallback crew when a task has no `crew` set
 ```
 
 - **`base_branch`** — the branch `orbit run ship` and `duel-plan` rebase against and target with PRs. Override per-invocation with `--base <branch>`. If your repo uses a two-branch pattern like this repo does (`main` = release, `agent-main` = dev integration), set `base_branch = "agent-main"`.
@@ -38,22 +38,24 @@ A **crew** is one provider-model-backend assignment. Every activity role (`plann
 
 | Field | Purpose | Values |
 |---|---|---|
-| `model` | Model identifier passed to the provider CLI | Provider-specific (e.g. `opus`, `sonnet`, `gpt-5.5`, `pro`, `grok-build`) |
+| `model` | Model identifier passed to the provider CLI | Provider-specific (e.g. `opus`, `sonnet`, `gpt-5.6-sol`, `pro`, `grok-build`) |
 | `provider` | Agent family | `claude`, `codex`, `gemini`, `grok` (the CLI-executable families; see [Provider identity and resolution](#provider-identity-and-resolution) for the full canonical set) |
 | `backend` | How Orbit dispatches the agent | `cli` (today the only supported value for these roles) |
 | `description` | Optional human-facing crew summary | Any non-empty string after trimming |
 | `tags` | Optional discovery labels | Array of strings; normalized, sorted, and deduplicated |
 
-Example — a Codex crew:
+Example — the standard Codex Sol crew:
 
 ```toml
-[crews.codex]
-model = "gpt-5.5"
+[crews.sol]
+model = "gpt-5.6-sol"
 provider = "codex"
 backend = "cli"
 description = "Systems implementation"
 tags = ["implementation", "review"]
 ```
+
+Fresh `orbit init` configuration advertises only detected provider CLIs. Claude seeds `opus`, `sonnet`, and `fable`; Codex seeds `sol`, `terra`, and `luna`; Gemini seeds `gemini`; and Grok seeds `grok`. When Codex or Claude is available, `qa` uses Terra or Sonnet respectively. Every generated entry uses the CLI backend. If no supported provider CLI is detected, init leaves both the crew registry and `workflow.default_crew` unset instead of writing an unusable provider.
 
 You can define any number of crews. Set the workspace-wide fallback with `workflow.default_crew`; assign a specific crew to individual tasks via the [per-task crew override](#per-task-crew-override). Crews are validated at load time: each crew must have non-empty `model`, `provider`, and `backend`; `workflow.default_crew` must name a defined crew.
 

--- a/docs/design/agent-families/2_design.md
+++ b/docs/design/agent-families/2_design.md
@@ -3,7 +3,7 @@ summary: "Agent Families — Design"
 type: design
 title: "Agent Families — Design"
 owner: human
-last_updated: 2026-07-11
+last_updated: 2026-07-18
 status: Draft
 feature: agent-families
 doc_role: design
@@ -28,7 +28,7 @@ Workspace config defines one concrete assignment under each `[crews.<name>]`: fl
 
 `crates/orbit-core/src/config/raw.rs` owns the TOML shape, and `crates/orbit-core/src/config/runtime.rs` materializes it into `Crew` values from `orbit-common`. Runtime loading rejects incomplete crews and rejects `[workflow].default_crew` when it does not name a defined crew.
 
-The repository default template and `.orbit/config.toml` use `[workflow].default_crew = "codex"` and seed single-family crews named `claude`, `codex`, `gemini`, and `grok`.
+The built-in runtime registry uses model-specific standard crews: Claude provides `opus`, `sonnet`, and `fable`; Codex provides `sol`, `terra`, and `luna`; Gemini provides `gemini`; and Grok provides `grok`. Fresh `orbit init` config filters that registry by detected provider CLIs, always writes `backend = "cli"`, and chooses the first emitted standard crew as `[workflow].default_crew` (`opus`, `sol`, `gemini`, or `grok`). It adds `qa` on Terra when Codex is available, otherwise on Sonnet when Claude is available. With no supported provider CLI, initialization emits neither crews nor a dangling default.
 
 ## 3. Task and Tool Surface
 
@@ -71,5 +71,6 @@ Task-level per-role overrides were deferred; today a task picks an entire crew, 
 - ORB-00042: Onboard Grok (xAI) as a first-class supported agent family.
 - ORB-00058: Introduce per-task crew override for agent model selection.
 - ORB-00072: Make duel-plan agent pool and per-family model configurable via `[duel]`.
+- ORB-10315: Seed model-specific crews only for providers available during initialization.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10315](https://orbit-cli.com/tasks/ORB-10315) — Seed model-specific crews for available providers during initialization

### Description

## Problem
Fresh Orbit initialization currently seeds generic provider-named crews (`claude`, `codex`, `gemini`, and `grok`) plus `qa`. The generated configuration should instead expose the standard model-specific crew names used by Orbit workflows, while never advertising a provider the user cannot run.

## Desired Defaults
When the corresponding CLI provider is detected as available, seed:

- Claude: `opus` → `claude/opus`, `sonnet` → `claude/sonnet`, and `fable` → `claude/fable`.
- Codex: `sol` → `codex/gpt-5.6-sol`, `terra` → `codex/gpt-5.6-terra`, and `luna` → `codex/gpt-5.6-luna`.
- Gemini: `gemini` → `gemini/pro`.
- Grok: `grok` → `grok/grok-build`.
- QA: `qa` → `codex/gpt-5.6-terra` when Codex is available; otherwise `claude/sonnet` when Claude is available. Omit `qa` when neither provider is available.

Every generated entry uses `backend = "cli"`.

## Constraints / Notes
- Use Orbit's existing provider-detection result; initialization must not introduce network calls, authentication prompts, or speculative providers.
- Do not emit any crew backed by an unavailable provider.
- Replace the generic `claude` and `codex` seed entries rather than retaining duplicate aliases. The `gemini` and `grok` names remain because they are the desired standard names.
- The generated `[workflow].default_crew` must always reference a crew that was actually emitted. Map a selected Claude default to `opus`, Codex to `sol`, Gemini to `gemini`, and Grok to `grok`.
- Preserve explicit/custom initialization role settings and never rewrite an existing `.orbit/config.toml`.
- Keep the runtime's built-in defaults and initialization/bootstrap output consistent so commands without a persisted config do not disagree with freshly initialized workspaces.
- Update user-facing initialization documentation or examples if they enumerate the old generic crew set.

### Acceptance Criteria

- A deterministic bootstrap test with only Claude detected emits exactly opus, sonnet, fable, and qa crew tables; qa uses claude/sonnet, default_crew is opus, and no codex, sol, terra, luna, gemini, or grok table is emitted.
- A deterministic bootstrap test with only Codex detected emits exactly sol, terra, luna, and qa crew tables; qa uses codex/gpt-5.6-terra, default_crew is sol, and no claude, opus, sonnet, fable, gemini, or grok table is emitted.
- Tests covering Gemini-only and Grok-only detection emit only the corresponding gemini/pro or grok/grok-build crew, omit qa, and set default_crew to the emitted crew.
- A multi-provider test proves each available provider contributes its full desired crew family, unavailable providers contribute none, qa deterministically prefers Terra when Codex is present, and every generated crew has backend = "cli".
- Initialization with no detected supported provider does not emit an invalid crew or a default_crew that references a missing entry; the command's existing no-provider behavior remains explicit and tested.
- Existing-config and explicit custom-role initialization tests prove the new defaults neither overwrite existing .orbit/config.toml nor replace a caller-supplied custom crew.
- Runtime default crew definitions, bootstrap rendering, and CLI init assertions agree on the new names and model/provider mappings; legacy generic claude and codex seed entries are absent from fresh default initialization.
- The Orbit task-scoped gate `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced generic built-in Claude/Codex crews with the standard model-specific families: opus/sonnet/fable, sol/terra/luna, gemini, and grok, with CLI backends and centralized model constants.
- Fresh initialization now filters crews strictly by detected provider CLIs, selects opus/sol/gemini/grok defaults from emitted entries, prefers Codex Terra for qa then Claude Sonnet, and writes an explicitly empty crew registry with no default when no supported CLI is available.
- Preserved existing config files and caller-supplied custom crews; updated interactive QA collection to omit QA when neither Claude nor Codex CLI is detected.
- Updated runtime fallback/default resolution, deterministic core and CLI init tests, config documentation, and the agent-family design doc. Added learning L-0100 for parsed-table validation after finding the prior bootstrap renderer appended workflow.default_crew under the trailing runtime table.
Validation:
- cargo test -p orbit-core config::tests:: --no-fail-fast (81 passed)
- cargo test -p orbit-core command::init::tests:: --no-fail-fast (5 passed)
- cargo test -p orbit-cli command::tests::init:: --no-fail-fast (7 passed)
- make ci-fast (passed)
Assessment: Acceptance criteria are covered by deterministic single-provider, multi-provider, no-provider, preservation, runtime-default, and CLI initialization tests; no new dependency edge was introduced.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10315-6a5c0c0f`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*