### PR TITLE
Instrument learning PreToolUse hook: per-fire injection log + used/ignored feedback signal

### DIFF
--- a/.orbit/adrs/accepted/ADR-0238/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0238/adr.yaml
@@ -1,0 +1,24 @@
+schema_version: 2
+id: ADR-0238
+title: Learning usage feedback via audit-store acks with ignored-by-default semantics
+status: accepted
+owner: claude
+created_at: 2026-07-19T01:05:30.669601297Z
+accepted_at: 2026-07-19T01:05:36.404311482Z
+last_updated: 2026-07-19T01:05:36.404311482Z
+related_features:
+- project-learnings
+related_tasks:
+- ORB-10316
+tags:
+- learnings
+- hooks
+- observability
+paths:
+- crates/orbit-cmd/src/learning_hook.rs
+- crates/orbit-core/src/command/learning.rs
+- crates/orbit-store/src/sqlite/audit_event_store/mod.rs
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0238/body.md
+++ b/.orbit/adrs/accepted/ADR-0238/body.md
@@ -1,0 +1,19 @@
+## Context
+
+The 2026-07-18 relevancy audit (F2026-07-092) showed the learning PreToolUse hook fired 2,374 times over two weeks with 13 injections and zero usage signal: nothing recorded whether an injected learning shaped the receiving agent's work, so nothing could drive deprecation of stale learnings. ADR-0210 had removed the earlier vote/comment feedback surfaces for lack of real usage, explicitly leaving the door open for 'a scoped feedback primitive ... reintroduced with real usage data behind it.' Separately, per-session injection dedup was dead in interactive sessions: ORBIT_SESSION_ID was exported on 0/2,374 fires and the ppid-tmpfile fallback re-keys per invocation.
+
+## Decision
+
+1. Record the feedback signal as `learning_ack` audit events in the existing host-global audit store (`~/.orbit/orbit.db`), not as a new sidecar or store: `target_id` = learning ID, `arguments_json.outcome` = `used` | `ignored`. Recorded via `orbit learning ack <id>... [--ignored]` or the `orbit.learning.ack` MCP tool (an additive entry in the frozen mcp-bridge conformance-v1 fixture). The injected reminder block documents the ack call inline.
+2. Absent ack counts as **ignored**. The rollup (`orbit learning stats`, folding `learning_injected` + `learning_ack` events per learning) derives ignored = injected − used, so a silent agent population biases learnings toward deprecation, never away from it.
+3. Instrumentation fails open. An unavailable audit backend logs a warning and injection still renders; `orbit learning ack` warns and exits 0 on backend failure (caller mistakes such as unknown IDs still fail closed).
+4. Session dedup keys on the first resolvable anchor: ORBIT_SESSION_ID env (engine-managed runs, pre-seeded with layer-1 injections) → the `session_id` field carried by the hook payload itself (Claude Code sends it on every hook event) → ppid-tmpfile last resort.
+
+Rejected alternatives: a dedicated ack table or per-learning sidecar (disproportionate infrastructure for an observability signal — the exact failure mode ADR-0210 removed); treating absent ack as used (optimistic default would make the rollup useless for deprecation); a session-end Stop-hook auto-ack (cannot know used-ness automatically; a bulk auto-ack would fabricate the signal).
+
+## Consequences
+
+- The rollup is the designed input for downstream deprecation policy; decay/TTL is deliberately follow-up work, not implemented at this layer.
+- The `learning_ack` contract lives in audit-event conventions (target_type + arguments_json), enforced by store-level fold tests rather than a schema migration.
+- Used-ratio data is only as good as agent ack discipline; the ignored-by-default rule makes the failure mode conservative (over-deprecation pressure, surfaced before any automated deprecation exists).
+- Cost: one extra reminder-block line per injection and one audit row per ack; the stats fold scans only learning-targeted audit rows.

--- a/.orbit/learnings/L-0102/learning.yaml
+++ b/.orbit/learnings/L-0102/learning.yaml
@@ -1,0 +1,27 @@
+schema_version: 1
+id: L-0102
+status: active
+scope:
+  paths:
+  - crates/orbit-tools/src/builtin/**
+  - crates/orbit-cli/src/command/mcp/**
+  - docs/design/mcp-bridge/**
+  tags:
+  - mcp
+  - tooling
+summary: 'Adding/removing a builtin MCP tool must update four canaries: the mcp_tools_list.json snapshot (ORBIT_MCP_UPDATE_SNAPSHOT=1), the definition count in orbit-tools mcp_definitions.rs, the name lists in orbit-cli command/mcp/tests, and the mcp-bridge conformance-v1.yaml fixture.'
+body: |-
+  The agent MCP surface is guarded by four independent breaking-change canaries; registering a tool in crates/orbit-tools/src/builtin/orbit/mod.rs alone fails three test suites in non-obvious places:
+
+  1. `crates/orbit-cli/tests/snapshots/mcp_tools_list.json` — full name+schema snapshot; regenerate with `ORBIT_MCP_UPDATE_SNAPSHOT=1 cargo test -p orbit-cli --test mcp_roundtrip mcp_serve_tools_list_matches_production_snapshot`.
+  2. `crates/orbit-tools/tests/mcp_definitions.rs` — asserts the exact builtin definition count (`canonical_builtin_definitions_are_workspace_independent`).
+  3. `crates/orbit-cli/src/command/mcp/tests/mod.rs` — `REQUIRED_AGENT_FACING_TOOL_NAMES` / `EXPECTED_INACTIVE_TOOL_NAMES` (with a length canary), plus `canonical_mcp_policy_conforms_to_frozen_v1_fixture` which compares against the fixture in (4).
+  4. `docs/design/mcp-bridge/references/conformance-v1.yaml` — the frozen mcp-bridge v1 contract fixture; the new tool needs a `placement`/`scope`/`allowed_capabilities` entry matching its registration exactly.
+
+  Discovered in ORB-10316 when adding `orbit.learning.ack` (placement owner): each canary failed in a separate test binary, so a plain `cargo test -p orbit-tools` run looked green while orbit-cli suites failed. Grep for an existing tool name (e.g. `orbit.learning.show`) to find every canary before running tests.
+evidence:
+- kind: task
+  reference: ORB-10316
+created_at: 2026-07-19T01:07:19.030891501Z
+updated_at: 2026-07-19T01:07:19.030891501Z
+created_by: claude

--- a/crates/orbit-cli/src/command/learning/ack.rs
+++ b/crates/orbit-cli/src/command/learning/ack.rs
@@ -1,0 +1,58 @@
+use clap::Args;
+use orbit_core::{LearningAckOutcome, OrbitError, OrbitRuntime};
+
+use crate::command::Execute;
+
+#[derive(Args)]
+pub struct LearningAckArgs {
+    /// Learning IDs to ack (as listed in the injected reminder block)
+    #[arg(required = true)]
+    pub ids: Vec<String>,
+    /// Record an explicit dismissal instead of the default `used` outcome.
+    /// Injections with no ack already count as ignored.
+    #[arg(long)]
+    pub ignored: bool,
+    /// Session the ack belongs to. Defaults to ORBIT_SESSION_ID when exported.
+    #[arg(long)]
+    pub session: Option<String>,
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for LearningAckArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let outcome = if self.ignored {
+            LearningAckOutcome::Ignored
+        } else {
+            LearningAckOutcome::Used
+        };
+        let session_id = self.session.or_else(|| {
+            std::env::var("ORBIT_SESSION_ID")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        });
+
+        match runtime.ack_learnings(&self.ids, outcome, session_id.as_deref()) {
+            Ok(()) => {
+                if self.json {
+                    crate::output::json::print_pretty(&serde_json::json!({
+                        "acked": self.ids,
+                        "outcome": outcome.as_str(),
+                    }))?;
+                } else {
+                    println!("acked {} as {}", self.ids.join(", "), outcome.as_str());
+                }
+                Ok(())
+            }
+            // Caller mistakes (unknown ID, empty input) fail closed; an
+            // unavailable audit backend fails open so a scripted ack (e.g.
+            // in a session-end hook) never breaks the agent's main work.
+            Err(error @ (OrbitError::InvalidInput(_) | OrbitError::NotFound { .. })) => Err(error),
+            Err(error) => {
+                eprintln!("warning: learning ack failed open: {error}");
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/orbit-cli/src/command/learning/command.rs
+++ b/crates/orbit-cli/src/command/learning/command.rs
@@ -3,11 +3,13 @@ use orbit_core::{OrbitError, OrbitRuntime};
 
 use crate::command::Execute;
 
+use super::ack::LearningAckArgs;
 use super::add::LearningAddArgs;
 use super::list::LearningListArgs;
 use super::migrate_layout::LearningMigrateLayoutArgs;
 use super::prune::LearningPruneArgs;
 use super::show::LearningShowArgs;
+use super::stats::LearningStatsArgs;
 use super::supersede::LearningSupersedeArgs;
 use super::sync::LearningSyncArgs;
 use super::update::LearningUpdateArgs;
@@ -27,12 +29,16 @@ impl Execute for LearningCommand {
 
 #[derive(Subcommand)]
 pub enum LearningSubcommand {
+    /// Ack injected learnings as used (default) or explicitly ignored
+    Ack(LearningAckArgs),
     /// Create a new active learning
     Add(LearningAddArgs),
     /// List learnings filtered by status, tag, or path
     List(LearningListArgs),
     /// Show a single learning by ID
     Show(LearningShowArgs),
+    /// Per-learning usage rollup from injection and ack audit events
+    Stats(LearningStatsArgs),
     /// Update an existing active learning
     Update(LearningUpdateArgs),
     /// Mark a learning as superseded by another
@@ -48,9 +54,11 @@ pub enum LearningSubcommand {
 impl Execute for LearningSubcommand {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         match self {
+            LearningSubcommand::Ack(args) => args.execute(runtime),
             LearningSubcommand::Add(args) => args.execute(runtime),
             LearningSubcommand::List(args) => args.execute(runtime),
             LearningSubcommand::Show(args) => args.execute(runtime),
+            LearningSubcommand::Stats(args) => args.execute(runtime),
             LearningSubcommand::Update(args) => args.execute(runtime),
             LearningSubcommand::Supersede(args) => args.execute(runtime),
             LearningSubcommand::Sync(args) => args.execute(runtime),

--- a/crates/orbit-cli/src/command/learning/mod.rs
+++ b/crates/orbit-cli/src/command/learning/mod.rs
@@ -1,3 +1,4 @@
+mod ack;
 mod add;
 mod command;
 mod list;
@@ -5,6 +6,7 @@ mod migrate_layout;
 pub(crate) mod output;
 mod prune;
 mod show;
+mod stats;
 mod supersede;
 mod sync;
 mod update;

--- a/crates/orbit-cli/src/command/learning/stats.rs
+++ b/crates/orbit-cli/src/command/learning/stats.rs
@@ -1,0 +1,66 @@
+use clap::Args;
+use orbit_core::{LearningUsageStat, OrbitError, OrbitRuntime};
+use serde_json::Value;
+
+use crate::command::Execute;
+use crate::parse::parse_since;
+
+#[derive(Args)]
+pub struct LearningStatsArgs {
+    /// Restrict the rollup to events since duration or timestamp (e.g. "30d", RFC3339)
+    #[arg(long)]
+    pub since: Option<String>,
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for LearningStatsArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let since = self.since.map(|s| parse_since(&s)).transpose()?;
+        let stats = runtime.learning_usage_stats(since)?;
+
+        if self.json {
+            let array = Value::Array(stats.iter().map(usage_stat_to_json).collect());
+            return crate::output::json::print_pretty(&array);
+        }
+
+        if stats.is_empty() {
+            println!("no learning injection or ack events recorded");
+            return Ok(());
+        }
+        println!("ID\tINJECTED\tUSED\tIGNORED\tUSED_RATIO\tLAST_INJECTED\tLAST_USED");
+        for stat in &stats {
+            println!(
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                stat.learning_id,
+                stat.injected_count,
+                stat.used_count,
+                stat.ignored_count(),
+                stat.used_ratio()
+                    .map(|ratio| format!("{ratio:.2}"))
+                    .unwrap_or_else(|| "-".to_string()),
+                stat.last_injected_at
+                    .map(|ts| ts.to_rfc3339())
+                    .unwrap_or_else(|| "-".to_string()),
+                stat.last_used_at
+                    .map(|ts| ts.to_rfc3339())
+                    .unwrap_or_else(|| "-".to_string()),
+            );
+        }
+        Ok(())
+    }
+}
+
+fn usage_stat_to_json(stat: &LearningUsageStat) -> Value {
+    serde_json::json!({
+        "learning_id": stat.learning_id,
+        "injected_count": stat.injected_count,
+        "used_count": stat.used_count,
+        "ignored_count": stat.ignored_count(),
+        "ignored_ack_count": stat.ignored_ack_count,
+        "used_ratio": stat.used_ratio(),
+        "last_injected_at": stat.last_injected_at.map(|ts| ts.to_rfc3339()),
+        "last_used_at": stat.last_used_at.map(|ts| ts.to_rfc3339()),
+    })
+}

--- a/crates/orbit-cli/src/command/mcp/tests/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/tests/mod.rs
@@ -423,6 +423,7 @@ const REQUIRED_AGENT_FACING_TOOL_NAMES: &[&str] = &[
     "orbit.adr.show",
     "orbit.adr.supersede",
     "orbit.adr.update",
+    "orbit.learning.ack",
     "orbit.learning.add",
     "orbit.learning.show",
     "orbit.learning.update",

--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -484,9 +484,11 @@ impl Commands {
             Commands::Learning(command) => {
                 use super::learning::LearningSubcommand;
                 let (subcommand, runtime_need) = match &command.command {
+                    LearningSubcommand::Ack(_) => ("ack", RuntimeNeed::Required),
                     LearningSubcommand::Add(_) => ("add", RuntimeNeed::Required),
                     LearningSubcommand::List(_) => ("list", RuntimeNeed::Required),
                     LearningSubcommand::Show(_) => ("show", RuntimeNeed::Required),
+                    LearningSubcommand::Stats(_) => ("stats", RuntimeNeed::Required),
                     LearningSubcommand::Update(_) => ("update", RuntimeNeed::Required),
                     LearningSubcommand::Supersede(_) => ("supersede", RuntimeNeed::Required),
                     LearningSubcommand::Sync(_) => ("sync", RuntimeNeed::Required),

--- a/crates/orbit-cli/tests/hook_pretooluse.rs
+++ b/crates/orbit-cli/tests/hook_pretooluse.rs
@@ -82,6 +82,7 @@ fn matching_payload_emits_reminder_state_and_audit_event() {
 Project learnings relevant to this task:\n\n\
 - [{learning_id}] Always keep hook reminders audited\n\n\
 Read full body via `orbit.learning.show <id>` if needed.\n\
+If a learning shaped your work, ack it: `orbit learning ack <id>` (unacked injections count as ignored).\n\
 </system-reminder>\n"
     );
     assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
@@ -151,6 +152,158 @@ fn repeated_payload_with_same_session_dedups_and_skips_second_audit() {
         "audit list",
     );
     assert_eq!(events.as_array().expect("audit rows").len(), 1);
+}
+
+#[test]
+fn payload_session_id_keys_dedup_without_env_var() {
+    let workspace = TestWorkspace::new();
+    workspace.add_learning("Payload session id anchors dedup", &["src/**"]);
+    // No ORBIT_SESSION_ID in the environment — the session id rides in the
+    // hook payload itself, as Claude Code sends it on every hook event.
+    let payload = r#"{"tool_name":"Edit","tool_input":{"file_path":"src/lib.rs"},"session_id":"payload-session"}"#;
+
+    let first = workspace.run_hook(payload, &[], "payload session first");
+    assert!(!first.stdout.is_empty());
+    let second = workspace.run_hook(payload, &[], "payload session second");
+    assert!(
+        second.stdout.is_empty(),
+        "second stdout: {}",
+        String::from_utf8_lossy(&second.stdout)
+    );
+
+    let state = workspace.session_learning_state("payload-session");
+    assert_eq!(state["count"], 1);
+
+    let events = workspace.run_json(
+        &["audit", "list", "--kind", "learning_injected", "--json"],
+        "audit list",
+    );
+    let rows = events.as_array().expect("audit rows");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["session_id"], "payload-session");
+}
+
+#[test]
+fn env_session_id_takes_priority_over_payload_session_id() {
+    let workspace = TestWorkspace::new();
+    workspace.add_learning("Env session id wins over payload", &["src/**"]);
+    let payload = r#"{"tool_name":"Edit","tool_input":{"file_path":"src/lib.rs"},"session_id":"payload-session"}"#;
+
+    let output = workspace.run_hook(
+        payload,
+        &[("ORBIT_SESSION_ID", "env-session")],
+        "env-priority hook",
+    );
+    assert!(!output.stdout.is_empty());
+
+    // Engine-managed runs pre-seed dedup state under the env session id, so
+    // the env var must key the state even when the payload carries its own.
+    let state = workspace.session_learning_state("env-session");
+    assert_eq!(state["count"], 1);
+}
+
+#[test]
+fn unavailable_audit_backend_fails_open_and_still_injects() {
+    let workspace = TestWorkspace::new();
+    workspace.add_learning("Injection survives a dead audit backend", &["src/**"]);
+    workspace.break_audit_event_inserts();
+
+    let output = workspace.run_hook(
+        r#"{"tool_name":"Edit","tool_input":{"file_path":"src/lib.rs"},"session_id":"failopen-session"}"#,
+        &[],
+        "fail-open hook",
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Injection survives a dead audit backend"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn ack_and_stats_roll_up_used_and_ignored_learnings() {
+    let workspace = TestWorkspace::new();
+    let used = workspace.add_learning("Used learning gets acked", &["src/**"]);
+    let used_id = used["id"].as_str().expect("used learning id").to_string();
+    let ignored = workspace.add_learning("Ignored learning gets no ack", &["src/**"]);
+    let ignored_id = ignored["id"]
+        .as_str()
+        .expect("ignored learning id")
+        .to_string();
+
+    let output = workspace.run_hook(
+        r#"{"tool_name":"Edit","tool_input":{"file_path":"src/lib.rs"},"session_id":"ack-session"}"#,
+        &[],
+        "ack rollup hook",
+    );
+    assert!(!output.stdout.is_empty());
+
+    let ack = workspace.run_json(&["learning", "ack", &used_id, "--json"], "learning ack");
+    assert_eq!(ack["acked"], json!([used_id.clone()]));
+    assert_eq!(ack["outcome"], "used");
+    workspace.run(
+        &["learning", "ack", &ignored_id, "--ignored"],
+        None,
+        &[],
+        "learning ack ignored",
+    );
+
+    let stats = workspace.run_json(&["learning", "stats", "--json"], "learning stats");
+    let rows = stats.as_array().expect("stats rows");
+    assert_eq!(rows.len(), 2, "stats rows: {stats}");
+    let row_for = |id: &str| {
+        rows.iter()
+            .find(|row| row["learning_id"] == *id)
+            .unwrap_or_else(|| panic!("no stats row for {id}: {stats}"))
+    };
+
+    let used_row = row_for(&used_id);
+    assert_eq!(used_row["injected_count"], 1);
+    assert_eq!(used_row["used_count"], 1);
+    assert_eq!(used_row["ignored_count"], 0);
+    assert_eq!(used_row["used_ratio"], 1.0);
+    assert!(used_row["last_used_at"].is_string());
+
+    let ignored_row = row_for(&ignored_id);
+    assert_eq!(ignored_row["injected_count"], 1);
+    assert_eq!(ignored_row["used_count"], 0);
+    assert_eq!(ignored_row["ignored_count"], 1);
+    assert_eq!(ignored_row["ignored_ack_count"], 1);
+    assert_eq!(ignored_row["used_ratio"], 0.0);
+    assert!(ignored_row["last_used_at"].is_null());
+}
+
+#[test]
+fn ack_fails_closed_on_unknown_id_and_open_on_dead_backend() {
+    let workspace = TestWorkspace::new();
+    let learning = workspace.add_learning("Ack validation learning", &["src/**"]);
+    let learning_id = learning["id"].as_str().expect("learning id").to_string();
+
+    let unknown = run_orbit(
+        &workspace.work,
+        &workspace.home,
+        &["learning", "ack", "L-9999"],
+        None,
+        &[],
+    );
+    assert!(
+        !unknown.status.success(),
+        "unknown-id ack unexpectedly succeeded: {}",
+        String::from_utf8_lossy(&unknown.stdout)
+    );
+
+    workspace.break_audit_event_inserts();
+    let output = workspace.run(
+        &["learning", "ack", &learning_id],
+        None,
+        &[],
+        "ack with dead audit backend",
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("learning ack failed open"),
+        "stderr: {stderr}"
+    );
 }
 
 #[test]
@@ -494,6 +647,18 @@ impl TestWorkspace {
             .as_str()
             .expect("thread id")
             .to_string()
+    }
+
+    /// Simulate an unavailable audit/log backend: reads (learning search,
+    /// session state) keep working, but every `audit_events` insert fails.
+    fn break_audit_event_inserts(&self) {
+        let conn = rusqlite::Connection::open(self.home.join(".orbit").join("orbit.db"))
+            .expect("open orbit db");
+        conn.execute_batch(
+            "CREATE TRIGGER break_audit_inserts BEFORE INSERT ON audit_events \
+             BEGIN SELECT RAISE(ABORT, 'audit backend unavailable'); END;",
+        )
+        .expect("install audit insert trigger");
     }
 
     fn session_learning_state(&self, session_id: &str) -> Value {

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -797,6 +797,31 @@
     "name": "orbit_graph_trace"
   },
   {
+    "description": "Record a used/ignored feedback ack for injected learnings. Feeds the per-learning usage rollup (`orbit learning stats`) that drives deprecation decisions.",
+    "inputSchema": {
+      "additionalProperties": true,
+      "properties": {
+        "ids": {
+          "description": "Learning ID or array of learning IDs to ack (e.g. the IDs listed in an injected reminder block).",
+          "type": "array"
+        },
+        "outcome": {
+          "description": "`used` (default) when the learning shaped the work, `ignored` to record an explicit dismissal. Injections with no ack already count as ignored.",
+          "type": "string"
+        },
+        "session_id": {
+          "description": "Session the ack belongs to. Defaults to `ORBIT_SESSION_ID` when exported.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "ids"
+      ],
+      "type": "object"
+    },
+    "name": "orbit_learning_ack"
+  },
+  {
     "description": "Create an active project learning. Returns `{ id, created_at }` plus the full record.",
     "inputSchema": {
       "additionalProperties": true,

--- a/crates/orbit-cmd/src/learning_hook.rs
+++ b/crates/orbit-cmd/src/learning_hook.rs
@@ -28,6 +28,12 @@ pub type SessionLearningState = LearningInjectionState;
 pub struct HookPayload {
     pub tool_name: String,
     pub target_path: String,
+    /// Session id carried by the hook payload itself (Claude Code sends
+    /// `session_id` on every hook event). Used as the dedup anchor when
+    /// `ORBIT_SESSION_ID` is not exported — interactive sessions spawn a
+    /// fresh shell per hook fire, so the ppid-tmpfile fallback re-keys per
+    /// invocation and never dedups.
+    pub session_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -151,9 +157,12 @@ pub fn parse_payload_with_tools(stdin: &str, accepted_tools: &[&str]) -> Option<
                 .and_then(path_from_shell_command)
         })?;
 
+    let session_id = string_field(&value, &["session_id", "sessionId"]).map(ToOwned::to_owned);
+
     Some(HookPayload {
         tool_name: tool_name.to_string(),
         target_path: target_path.to_string(),
+        session_id,
     })
 }
 
@@ -346,9 +355,13 @@ pub fn run_pretooluse_input(
     };
 
     let caps = caps_from_env();
+    // Engine-managed runs export `ORBIT_SESSION_ID` (pre-seeded with layer-1
+    // injections), so the env var wins; interactive sessions never export it
+    // and fall back to the session id the hook payload itself carries.
     let session_id = std::env::var(ORBIT_SESSION_ID_ENV)
         .ok()
-        .filter(|value| !value.trim().is_empty());
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| payload.session_id.clone());
     let tmpdir = learning_hook_tmpdir();
     let ppid = parent_process_id();
 
@@ -384,25 +397,33 @@ pub fn run_pretooluse_input(
         return Ok(None);
     }
 
-    if !admitted.is_empty() {
-        emit_learning_injected_audit(
+    // Audit instrumentation fails open: an unavailable audit backend must
+    // not suppress reminders that were already admitted for injection.
+    if !admitted.is_empty()
+        && let Err(error) = emit_learning_injected_audit(
             runtime,
             &payload.tool_name,
             &payload.target_path,
             session_id.as_deref(),
             &admitted,
             start.elapsed(),
-        )?;
+        )
+    {
+        tracing::warn!(error = %redact_sensitive_env_text(&error), "learning hook audit emit failed open");
     }
     for reminder in &review_thread_admitted {
-        orbit_core::command::review_thread_hook::emit_review_thread_surfaced_audit(
-            runtime,
-            &payload.tool_name,
-            &payload.target_path,
-            session_id.as_deref(),
-            reminder,
-            start.elapsed(),
-        )?;
+        if let Err(error) =
+            orbit_core::command::review_thread_hook::emit_review_thread_surfaced_audit(
+                runtime,
+                &payload.tool_name,
+                &payload.target_path,
+                session_id.as_deref(),
+                reminder,
+                start.elapsed(),
+            )
+        {
+            tracing::warn!(error = %redact_sensitive_env_text(&error), "review-thread hook audit emit failed open");
+        }
     }
 
     render_hook_reminders(format, &admitted, &review_thread_admitted)
@@ -706,7 +727,7 @@ fn emit_learning_injected_audit(
         command: "hook".to_string(),
         subcommand: Some("pretooluse".to_string()),
         tool_name: Some(tool_name.to_string()),
-        target_type: Some("learning_injected".to_string()),
+        target_type: Some(orbit_store::LEARNING_INJECTED_TARGET_TYPE.to_string()),
         target_id: Some(target_path.to_string()),
         role: "hook".to_string(),
         status: AuditEventStatus::Success,

--- a/crates/orbit-cmd/src/tests/learning_hook.rs
+++ b/crates/orbit-cmd/src/tests/learning_hook.rs
@@ -35,6 +35,29 @@ fn parse_payload_accepts_tool_and_path_variants() {
 }
 
 #[test]
+fn parse_payload_extracts_session_id_when_present() {
+    let with_session = parse_payload(
+        r#"{"tool_name":"Edit","tool_input":{"file_path":"src/lib.rs"},"session_id":" sess-123 "}"#,
+    )
+    .expect("payload with session id");
+    assert_eq!(with_session.session_id.as_deref(), Some("sess-123"));
+
+    let camel = parse_payload(
+        r#"{"toolName":"Write","toolInput":{"filePath":"README.md"},"sessionId":"sess-camel"}"#,
+    )
+    .expect("payload with camelCase session id");
+    assert_eq!(camel.session_id.as_deref(), Some("sess-camel"));
+
+    let without = parse_payload(r#"{"tool_name":"Read","path":"Cargo.toml"}"#)
+        .expect("payload without session id");
+    assert_eq!(without.session_id, None);
+
+    let blank = parse_payload(r#"{"tool_name":"Read","path":"Cargo.toml","session_id":"  "}"#)
+        .expect("payload with blank session id");
+    assert_eq!(blank.session_id, None);
+}
+
+#[test]
 fn parse_payload_rejects_malformed_irrelevant_or_pathless_payloads() {
     assert!(parse_payload("").is_none());
     assert!(parse_payload("not-json").is_none());

--- a/crates/orbit-common/src/types/learning.rs
+++ b/crates/orbit-common/src/types/learning.rs
@@ -163,6 +163,43 @@ pub struct Learning {
     pub priority: Option<u8>,
 }
 
+/// Receiving-agent verdict on one injected learning, recorded as a
+/// `learning_ack` audit event. Absent ack degrades safely: an injection with
+/// no `Used` ack counts as ignored in the usage rollup.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LearningAckOutcome {
+    Used,
+    Ignored,
+}
+
+impl LearningAckOutcome {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LearningAckOutcome::Used => "used",
+            LearningAckOutcome::Ignored => "ignored",
+        }
+    }
+}
+
+impl Display for LearningAckOutcome {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for LearningAckOutcome {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "used" => Ok(LearningAckOutcome::Used),
+            "ignored" => Ok(LearningAckOutcome::Ignored),
+            other => Err(format!("unknown learning ack outcome: {other}")),
+        }
+    }
+}
+
 pub const DEFAULT_LEARNING_REMINDER_PER_CALL_CAP: usize = 5;
 pub const DEFAULT_LEARNING_REMINDER_SESSION_CAP: usize = 20;
 
@@ -284,6 +321,10 @@ pub fn render_reminder_block(reminders: &[LearningReminder]) -> String {
     }
     out.push('\n');
     out.push_str("Read full body via `orbit.learning.show <id>` if needed.\n");
+    out.push_str(
+        "If a learning shaped your work, ack it: `orbit learning ack <id>` \
+         (unacked injections count as ignored).\n",
+    );
     out.push_str("</system-reminder>");
     out
 }

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -120,9 +120,9 @@ pub use job::{
 };
 pub use learning::{
     DEFAULT_LEARNING_REMINDER_PER_CALL_CAP, DEFAULT_LEARNING_REMINDER_SESSION_CAP, EvidenceKind,
-    Learning, LearningEvidence, LearningInjectionCaps, LearningInjectionState, LearningReminder,
-    LearningScope, LearningStatus, normalize_learning_paths, normalize_learning_tags,
-    prepend_reminder_block, render_reminder_block,
+    Learning, LearningAckOutcome, LearningEvidence, LearningInjectionCaps, LearningInjectionState,
+    LearningReminder, LearningScope, LearningStatus, normalize_learning_paths,
+    normalize_learning_tags, prepend_reminder_block, render_reminder_block,
 };
 pub use metrics::MetricsEntry;
 pub use policy_decision::PolicyDecision;

--- a/crates/orbit-common/src/types/tests/learning.rs
+++ b/crates/orbit-common/src/types/tests/learning.rs
@@ -123,6 +123,7 @@ mod reminders {
 Project learnings relevant to this task:\n\n\
 - [L-0001] Verify output equivalence before freezing a result.\n\n\
 Read full body via `orbit.learning.show <id>` if needed.\n\
+If a learning shaped your work, ack it: `orbit learning ack <id>` (unacked injections count as ignored).\n\
 </system-reminder>"
         );
     }

--- a/crates/orbit-core/src/command/learning.rs
+++ b/crates/orbit-core/src/command/learning.rs
@@ -8,10 +8,14 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use orbit_common::types::{EvidenceKind, Learning, LearningStatus, NotFoundKind, OrbitError};
+use orbit_common::types::{
+    AuditEventStatus, EvidenceKind, Learning, LearningAckOutcome, LearningStatus, NotFoundKind,
+    OrbitError, audit_execution_id,
+};
 use orbit_store::{
-    LearningCreateParams, LearningListEntry, LearningSearchParams, LearningSearchResult,
-    LearningUpdateParams, RemoteArtifactStub, learning_layout::LearningLayoutMigrationReport,
+    AuditEventInsertParams, LEARNING_ACK_TARGET_TYPE, LearningCreateParams, LearningListEntry,
+    LearningSearchParams, LearningSearchResult, LearningUpdateParams, LearningUsageStat,
+    RemoteArtifactStub, learning_layout::LearningLayoutMigrationReport,
 };
 use serde::Deserialize;
 
@@ -94,6 +98,111 @@ impl OrbitRuntime {
 
     pub fn learning_search_config(&self) -> Result<LearningSearchConfig, OrbitError> {
         read_learning_search_config_from_config_path(&self.config_path())
+    }
+
+    /// Record a used/ignored feedback ack for injected learnings as
+    /// `learning_ack` audit events in the global audit store.
+    ///
+    /// IDs are validated against the learning store when it is readable;
+    /// an unknown ID is a hard `InvalidInput` (typo protection). A store
+    /// that cannot be read skips validation instead of blocking the ack —
+    /// the ack is instrumentation and must not depend on more backends
+    /// than the audit write itself.
+    pub fn ack_learnings(
+        &self,
+        ids: &[String],
+        outcome: LearningAckOutcome,
+        session_id: Option<&str>,
+    ) -> Result<(), OrbitError> {
+        if ids.is_empty() {
+            return Err(OrbitError::InvalidInput(
+                "learning ack requires at least one learning ID".to_string(),
+            ));
+        }
+        for id in ids {
+            if let Ok(None) = self.stores().learnings().get_federated(id) {
+                if self
+                    .stores()
+                    .learnings()
+                    .remote_stub(id)
+                    .ok()
+                    .flatten()
+                    .is_some()
+                {
+                    continue;
+                }
+                return Err(OrbitError::not_found(
+                    NotFoundKind::Learning,
+                    id.to_string(),
+                ));
+            }
+        }
+
+        let working_directory = std::env::current_dir()
+            .map(|path| path.to_string_lossy().to_string())
+            .unwrap_or_else(|_| ".".to_string());
+        for id in ids {
+            let arguments_json = serde_json::to_string(&serde_json::json!({
+                "learning_id": id,
+                "outcome": outcome.as_str(),
+            }))
+            .map_err(|error| {
+                OrbitError::Execution(format!("serialize learning ack arguments: {error}"))
+            })?;
+            self.record_audit_event(&AuditEventInsertParams {
+                execution_id: audit_execution_id("learning"),
+                command: "learning".to_string(),
+                subcommand: Some("ack".to_string()),
+                tool_name: None,
+                target_type: Some(LEARNING_ACK_TARGET_TYPE.to_string()),
+                target_id: Some(id.clone()),
+                role: "agent".to_string(),
+                status: AuditEventStatus::Success,
+                exit_code: 0,
+                duration_ms: 0,
+                working_directory: working_directory.clone(),
+                arguments_json: Some(arguments_json),
+                stdout_truncated: None,
+                stderr_truncated: None,
+                error_message: None,
+                host: std::env::var("HOSTNAME").ok(),
+                pid: std::process::id(),
+                session_id: session_id.map(ToOwned::to_owned),
+                workspace_id: None,
+                caller_machine_id: None,
+                caller_host_id: None,
+                process_machine_id: None,
+                process_host_id: None,
+                transport: None,
+                effective_capabilities: Default::default(),
+                origin_session_id: None,
+                mcp_call_id: None,
+                lease_id: None,
+                task_id: std::env::var("ORBIT_TASK_ID")
+                    .ok()
+                    .filter(|value| !value.is_empty()),
+                job_run_id: std::env::var("ORBIT_RUN_ID")
+                    .ok()
+                    .filter(|value| !value.is_empty()),
+                activity_id: std::env::var("ORBIT_ACTIVITY_ID")
+                    .ok()
+                    .filter(|value| !value.is_empty()),
+                step_index: std::env::var("ORBIT_STEP_INDEX")
+                    .ok()
+                    .and_then(|value| value.parse().ok()),
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Per-learning usage rollup over the global audit store: injection
+    /// counts from `learning_injected` events, used/ignored feedback from
+    /// `learning_ack` events.
+    pub fn learning_usage_stats(
+        &self,
+        since: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<Vec<LearningUsageStat>, OrbitError> {
+        self.stores().audit_events().learning_usage(since.as_ref())
     }
 
     pub fn update_learning(

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -85,11 +85,12 @@ pub use orbit_common::types::{
     AutoTaskTemplate, DEFAULT_TASK_LIST_LIMIT, DedupePolicy, EvidenceKind, ExecutionProfileCrewV1,
     ExecutionProfileShipV1, ExecutionProfileV1, ExecutorDef, ExternalRef, HostAlias,
     HostNameResolution, HostRecord, HostRegistration, HostStatus, HostWorkspacePresence, JobRun,
-    JobRunState, JobRunStep, JobTargetType, Learning, LearningEvidence, LearningScope,
-    LearningStatus, ProjectionFreshness, ReviewThreadStatus, SanitizedExecutionProfile,
-    SanitizedWorkspacePresence, StoredExecutionProfile, Task, TaskComplexity, TaskCreateStatus,
-    TaskPriority, TaskStatus, TaskType, WorkspaceOwnership, WorkspacePresenceDeclaration,
-    build_task_status_index, resolve_task_dependencies, task_dependencies_ready,
+    JobRunState, JobRunStep, JobTargetType, Learning, LearningAckOutcome, LearningEvidence,
+    LearningScope, LearningStatus, ProjectionFreshness, ReviewThreadStatus,
+    SanitizedExecutionProfile, SanitizedWorkspacePresence, StoredExecutionProfile, Task,
+    TaskComplexity, TaskCreateStatus, TaskPriority, TaskStatus, TaskType, WorkspaceOwnership,
+    WorkspacePresenceDeclaration, build_task_status_index, resolve_task_dependencies,
+    task_dependencies_ready,
 };
 pub use orbit_common::types::{MissedRunPolicy, NotFoundKind, OrbitError, OverlapPolicy};
 pub use orbit_common::utility::redaction::redact_sensitive_env_text;
@@ -100,6 +101,7 @@ pub use orbit_store::{
 };
 pub use orbit_store::{
     LearningCreateParams, LearningListEntry, LearningSearchParams, LearningUpdateParams,
+    LearningUsageStat,
 };
 // Routine fire records surfaced by the dashboard's routine-health JSON API.
 pub use orbit_store::{RoutineFireRecord, RoutineFireState};

--- a/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
@@ -42,6 +42,7 @@ pub(super) fn execute(
         OrbitBuiltinAction::FrictionTags => super::friction_tools::tags(runtime),
         OrbitBuiltinAction::FrictionUpdate => super::friction_tools::update(runtime, input),
         OrbitBuiltinAction::HostList => super::registry_tools::host_list(runtime),
+        OrbitBuiltinAction::LearningAck => super::learning_tools::ack(runtime, input),
         OrbitBuiltinAction::LearningAdd => super::learning_tools::add(runtime, input, agent, model),
         OrbitBuiltinAction::LearningList => super::learning_tools::list(runtime, input),
         OrbitBuiltinAction::LearningPrune => super::learning_tools::prune(runtime, input),

--- a/crates/orbit-core/src/runtime/orbit_tool_host/learning_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/learning_tools.rs
@@ -9,8 +9,8 @@
 use std::str::FromStr;
 
 use orbit_common::types::{
-    EvidenceKind, LearningEvidence, LearningScope, LearningStatus, NotFoundKind, OrbitError,
-    optional_string, optional_string_alias, required_string,
+    EvidenceKind, LearningAckOutcome, LearningEvidence, LearningScope, LearningStatus,
+    NotFoundKind, OrbitError, optional_string, optional_string_alias, required_string,
 };
 use orbit_store::{
     LearningCreateParams, LearningListEntry, LearningUpdateParams, RemoteArtifactStub,
@@ -48,6 +48,31 @@ pub(super) fn add(
         priority,
     })?;
     Ok(learning_to_json(&learning))
+}
+
+/// `orbit.learning.ack` — record a used/ignored feedback signal for one or
+/// more injected learnings. `ids` accepts a string or array; `outcome`
+/// defaults to `used` (an absent ack already records as ignored, so the
+/// explicit call is normally the positive signal).
+pub(super) fn ack(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
+    let ids = match input.get("ids").or_else(|| input.get("id")) {
+        Some(value) => parse_string_list("ids", value)?,
+        None => Vec::new(),
+    };
+    let outcome = match optional_string(&input, "outcome")? {
+        Some(raw) => LearningAckOutcome::from_str(&raw).map_err(OrbitError::InvalidInput)?,
+        None => LearningAckOutcome::Used,
+    };
+    let session_id = optional_string_alias(&input, &["session_id", "sessionId"])?.or_else(|| {
+        std::env::var("ORBIT_SESSION_ID")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+    });
+    runtime.ack_learnings(&ids, outcome, session_id.as_deref())?;
+    Ok(json!({
+        "acked": ids,
+        "outcome": outcome.as_str(),
+    }))
 }
 
 pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {

--- a/crates/orbit-core/src/runtime/store_delegates.rs
+++ b/crates/orbit-core/src/runtime/store_delegates.rs
@@ -603,6 +603,13 @@ impl AuditEventRecords<'_> {
         self.store.prune_audit_events(older_than)
     }
 
+    pub(crate) fn learning_usage(
+        &self,
+        since: Option<&chrono::DateTime<chrono::Utc>>,
+    ) -> Result<Vec<orbit_store::LearningUsageStat>, OrbitError> {
+        self.store.get_learning_usage_stats(since)
+    }
+
     pub(crate) fn stats(
         &self,
         since: Option<&chrono::DateTime<chrono::Utc>>,

--- a/crates/orbit-engine/src/activity_job/tests/agent_loop_driver.rs
+++ b/crates/orbit-engine/src/activity_job/tests/agent_loop_driver.rs
@@ -302,6 +302,7 @@ fn l1_learning_reminder_prepends_prompt_for_matching_task() {
 Project learnings relevant to this task:\n\n\
 - [L-0001] Remember to validate the output.\n\n\
 Read full body via `orbit.learning.show <id>` if needed.\n\
+If a learning shaped your work, ack it: `orbit learning ack <id>` (unacked injections count as ignored).\n\
 </system-reminder>\n\n\
 baseline prompt"
     );

--- a/crates/orbit-store/src/backend/contracts.rs
+++ b/crates/orbit-store/src/backend/contracts.rs
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 use crate::sqlite::audit_event_store::{
     AuditEventFilter, AuditEventInsertParams, AuditRoleAggregate, AuditToolAggregate,
     AuditToolCallCountsByRole, AuditToolCallCountsBySurfaceAndRole, AuditTopToolCall,
+    LearningUsageStat,
 };
 use crate::sqlite::v2_audit_store::{
     V2AuditEventFilter, V2AuditEventInsertParams, V2AuditEventRow,
@@ -655,6 +656,10 @@ pub trait AuditEventStoreBackend: Send + Sync {
         &self,
         since: &DateTime<Utc>,
     ) -> Result<Vec<AuditRoleAggregate>, OrbitError>;
+    fn get_learning_usage_stats(
+        &self,
+        since: Option<&DateTime<Utc>>,
+    ) -> Result<Vec<LearningUsageStat>, OrbitError>;
     fn prune_audit_events(&self, older_than: &DateTime<Utc>) -> Result<usize, OrbitError>;
 }
 

--- a/crates/orbit-store/src/backend/sqlite_backends.rs
+++ b/crates/orbit-store/src/backend/sqlite_backends.rs
@@ -139,6 +139,13 @@ impl AuditEventStoreBackend for SqliteAuditEventStoreBackend {
         self.store.get_audit_event_aggregates_by_role(since)
     }
 
+    fn get_learning_usage_stats(
+        &self,
+        since: Option<&DateTime<Utc>>,
+    ) -> Result<Vec<crate::LearningUsageStat>, OrbitError> {
+        self.store.get_learning_usage_stats(since)
+    }
+
     fn prune_audit_events(&self, older_than: &DateTime<Utc>) -> Result<usize, OrbitError> {
         self.store.prune_audit_events(older_than)
     }

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -148,6 +148,7 @@ pub use orbit_common::types::{
 pub use sqlite::audit_event_store::{
     AuditEventFilter, AuditEventInsertParams, AuditRoleAggregate, AuditToolAggregate,
     AuditToolCallCountsByRole, AuditToolCallCountsBySurfaceAndRole, AuditTopToolCall,
+    LEARNING_ACK_TARGET_TYPE, LEARNING_INJECTED_TARGET_TYPE, LearningUsageStat,
 };
 pub use sqlite::connection::{Store, StoreTx};
 pub use sqlite::id_allocator::{

--- a/crates/orbit-store/src/sqlite/audit_event_store/mod.rs
+++ b/crates/orbit-store/src/sqlite/audit_event_store/mod.rs
@@ -123,6 +123,55 @@ pub struct AuditRoleAggregate {
     pub cli: i64,
 }
 
+/// `target_type` of the per-fire injection audit event emitted by the
+/// learning PreToolUse hook.
+pub const LEARNING_INJECTED_TARGET_TYPE: &str = "learning_injected";
+/// `target_type` of the used/ignored feedback audit event recorded by
+/// `orbit learning ack`.
+pub const LEARNING_ACK_TARGET_TYPE: &str = "learning_ack";
+
+/// Per-learning rollup of injection and ack audit events. Raw counts only;
+/// the derived ignored count and used ratio live on the accessor methods so
+/// the "absent ack counts as ignored" semantics stay in one place.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LearningUsageStat {
+    pub learning_id: String,
+    /// Number of `learning_injected` events that included this learning.
+    pub injected_count: u64,
+    /// Number of `learning_ack` events with outcome `used`.
+    pub used_count: u64,
+    /// Number of explicit `learning_ack` events with outcome `ignored`.
+    /// Informational — the derived [`Self::ignored_count`] already counts
+    /// every non-used injection as ignored.
+    pub ignored_ack_count: u64,
+    pub last_injected_at: Option<DateTime<Utc>>,
+    pub last_used_at: Option<DateTime<Utc>>,
+}
+
+impl LearningUsageStat {
+    fn new(learning_id: String) -> Self {
+        Self {
+            learning_id,
+            injected_count: 0,
+            used_count: 0,
+            ignored_ack_count: 0,
+            last_injected_at: None,
+            last_used_at: None,
+        }
+    }
+
+    /// Injections not covered by a `used` ack. Absent ack degrades safely:
+    /// it records as ignored, not as used.
+    pub fn ignored_count(&self) -> u64 {
+        self.injected_count.saturating_sub(self.used_count)
+    }
+
+    /// `used_count / injected_count`, or `None` when nothing was injected.
+    pub fn used_ratio(&self) -> Option<f64> {
+        (self.injected_count > 0).then(|| self.used_count as f64 / self.injected_count as f64)
+    }
+}
+
 fn audit_event_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AuditEvent> {
     let ts_raw: String = row.get(2)?;
     let status_raw: String = row.get(9)?;
@@ -857,6 +906,102 @@ impl Store {
 
         rows.collect::<Result<Vec<_>, _>>()
             .map_err(|e| OrbitError::Store(e.to_string()))
+    }
+
+    /// Fold `learning_injected` and `learning_ack` audit events into a
+    /// per-learning usage rollup. Malformed `arguments_json` payloads are
+    /// skipped rather than failing the whole aggregation — the rollup is an
+    /// observability surface over best-effort instrumentation.
+    pub fn get_learning_usage_stats(
+        &self,
+        since: Option<&DateTime<Utc>>,
+    ) -> Result<Vec<LearningUsageStat>, OrbitError> {
+        let conn = self.read()?;
+
+        let (since_clause, since_params) = match since {
+            Some(since) => (
+                " AND timestamp >= ?1",
+                vec![Box::new(since.to_rfc3339()) as Box<dyn rusqlite::types::ToSql>],
+            ),
+            None => ("", Vec::new()),
+        };
+        let sql = format!(
+            "SELECT timestamp, target_type, target_id, arguments_json \
+             FROM audit_events \
+             WHERE target_type IN ('{LEARNING_INJECTED_TARGET_TYPE}', '{LEARNING_ACK_TARGET_TYPE}') \
+             AND status = 'success'{since_clause} ORDER BY id ASC"
+        );
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            since_params.iter().map(|b| b.as_ref()).collect();
+        let rows = stmt
+            .query_map(param_refs.as_slice(), |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                ))
+            })
+            .map_err(|e| OrbitError::Store(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        let mut stats = std::collections::BTreeMap::<String, LearningUsageStat>::new();
+        for (ts_raw, target_type, target_id, arguments_json) in rows {
+            let Ok(timestamp) = parse_timestamp(&ts_raw) else {
+                continue;
+            };
+            let arguments = arguments_json
+                .as_deref()
+                .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok());
+            if target_type == LEARNING_INJECTED_TARGET_TYPE {
+                let Some(learning_ids) = arguments
+                    .as_ref()
+                    .and_then(|value| value.get("learning_ids"))
+                    .and_then(serde_json::Value::as_array)
+                else {
+                    continue;
+                };
+                for learning_id in learning_ids.iter().filter_map(serde_json::Value::as_str) {
+                    let stat = stats
+                        .entry(learning_id.to_string())
+                        .or_insert_with(|| LearningUsageStat::new(learning_id.to_string()));
+                    stat.injected_count += 1;
+                    stat.last_injected_at = Some(timestamp);
+                }
+            } else {
+                let Some(learning_id) = target_id.as_deref().filter(|id| !id.is_empty()) else {
+                    continue;
+                };
+                let outcome = arguments
+                    .as_ref()
+                    .and_then(|value| value.get("outcome"))
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default();
+                let stat = stats
+                    .entry(learning_id.to_string())
+                    .or_insert_with(|| LearningUsageStat::new(learning_id.to_string()));
+                match outcome {
+                    "used" => {
+                        stat.used_count += 1;
+                        stat.last_used_at = Some(timestamp);
+                    }
+                    "ignored" => stat.ignored_ack_count += 1,
+                    _ => {}
+                }
+            }
+        }
+
+        let mut stats = stats.into_values().collect::<Vec<_>>();
+        stats.sort_by(|a, b| {
+            b.injected_count
+                .cmp(&a.injected_count)
+                .then_with(|| a.learning_id.cmp(&b.learning_id))
+        });
+        Ok(stats)
     }
 
     pub fn prune_audit_events(&self, older_than: &DateTime<Utc>) -> Result<usize, OrbitError> {

--- a/crates/orbit-store/src/sqlite/audit_event_store/tests/audit_event_store.rs
+++ b/crates/orbit-store/src/sqlite/audit_event_store/tests/audit_event_store.rs
@@ -187,6 +187,105 @@ fn list_audit_events_filters_by_target_type_kind() {
     assert_eq!(events[0].execution_id, "exec-hook");
 }
 
+fn learning_injected_params(execution_id: &str, learning_ids: &[&str]) -> AuditEventInsertParams {
+    AuditEventInsertParams {
+        execution_id: execution_id.to_string(),
+        command: "hook".to_string(),
+        subcommand: Some("pretooluse".to_string()),
+        target_type: Some(LEARNING_INJECTED_TARGET_TYPE.to_string()),
+        target_id: Some("src/lib.rs".to_string()),
+        arguments_json: Some(serde_json::json!({ "learning_ids": learning_ids }).to_string()),
+        ..sample_params()
+    }
+}
+
+fn learning_ack_params(
+    execution_id: &str,
+    learning_id: &str,
+    outcome: &str,
+) -> AuditEventInsertParams {
+    AuditEventInsertParams {
+        execution_id: execution_id.to_string(),
+        command: "learning".to_string(),
+        subcommand: Some("ack".to_string()),
+        target_type: Some(LEARNING_ACK_TARGET_TYPE.to_string()),
+        target_id: Some(learning_id.to_string()),
+        arguments_json: Some(
+            serde_json::json!({ "learning_id": learning_id, "outcome": outcome }).to_string(),
+        ),
+        ..sample_params()
+    }
+}
+
+#[test]
+fn learning_usage_stats_fold_injections_and_acks_per_learning() {
+    let store = Store::open_in_memory().expect("open store");
+    for (execution_id, ids) in [
+        ("exec-inject-1", vec!["L-0001", "L-0002"]),
+        ("exec-inject-2", vec!["L-0001"]),
+        ("exec-inject-3", vec!["L-0001"]),
+    ] {
+        store
+            .insert_audit_event_record(&learning_injected_params(execution_id, &ids))
+            .expect("insert injection event");
+    }
+    store
+        .insert_audit_event_record(&learning_ack_params("exec-ack-1", "L-0001", "used"))
+        .expect("insert used ack");
+    store
+        .insert_audit_event_record(&learning_ack_params("exec-ack-2", "L-0002", "ignored"))
+        .expect("insert ignored ack");
+
+    let stats = store
+        .get_learning_usage_stats(None)
+        .expect("learning usage stats");
+    assert_eq!(stats.len(), 2);
+
+    let first = &stats[0];
+    assert_eq!(first.learning_id, "L-0001");
+    assert_eq!(first.injected_count, 3);
+    assert_eq!(first.used_count, 1);
+    assert_eq!(first.ignored_ack_count, 0);
+    assert_eq!(first.ignored_count(), 2);
+    assert_eq!(first.used_ratio(), Some(1.0 / 3.0));
+    assert!(first.last_injected_at.is_some());
+    assert!(first.last_used_at.is_some());
+
+    let second = &stats[1];
+    assert_eq!(second.learning_id, "L-0002");
+    assert_eq!(second.injected_count, 1);
+    assert_eq!(second.used_count, 0);
+    assert_eq!(second.ignored_ack_count, 1);
+    assert_eq!(second.ignored_count(), 1);
+    assert_eq!(second.used_ratio(), Some(0.0));
+    assert!(second.last_used_at.is_none());
+}
+
+#[test]
+fn learning_usage_stats_skip_malformed_arguments_and_respect_since() {
+    let store = Store::open_in_memory().expect("open store");
+    let mut malformed = learning_injected_params("exec-malformed", &["L-0001"]);
+    malformed.arguments_json = Some("not-json".to_string());
+    store
+        .insert_audit_event_record(&malformed)
+        .expect("insert malformed event");
+    store
+        .insert_audit_event_record(&learning_injected_params("exec-ok", &["L-0002"]))
+        .expect("insert valid event");
+
+    let stats = store
+        .get_learning_usage_stats(None)
+        .expect("learning usage stats");
+    assert_eq!(stats.len(), 1);
+    assert_eq!(stats[0].learning_id, "L-0002");
+
+    let future = chrono::Utc::now() + chrono::Duration::days(1);
+    let stats = store
+        .get_learning_usage_stats(Some(&future))
+        .expect("learning usage stats since future");
+    assert!(stats.is_empty());
+}
+
 #[test]
 fn migration_adds_correlation_columns_to_legacy_table() {
     let conn = rusqlite::Connection::open_in_memory().expect("open in-memory connection");

--- a/crates/orbit-tools/src/builtin/orbit/learning/ack.rs
+++ b/crates/orbit-tools/src/builtin/orbit/learning/ack.rs
@@ -1,0 +1,49 @@
+use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
+use serde_json::Value;
+
+use crate::{OrbitBuiltinAction, Tool, ToolContext};
+
+pub struct OrbitLearningAckTool;
+
+impl Tool for OrbitLearningAckTool {
+    fn schema(&self) -> ToolSchema {
+        let parameters = vec![
+            ToolParam {
+                name: "ids".to_string(),
+                description:
+                    "Learning ID or array of learning IDs to ack (e.g. the IDs listed in an injected reminder block)."
+                        .to_string(),
+                param_type: "array".to_string(),
+                required: true,
+            },
+            ToolParam {
+                name: "outcome".to_string(),
+                description:
+                    "`used` (default) when the learning shaped the work, `ignored` to record an explicit dismissal. Injections with no ack already count as ignored."
+                        .to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "session_id".to_string(),
+                description:
+                    "Session the ack belongs to. Defaults to `ORBIT_SESSION_ID` when exported."
+                        .to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+        ];
+        ToolSchema {
+            name: "orbit.learning.ack".to_string(),
+            description:
+                "Record a used/ignored feedback ack for injected learnings. Feeds the per-learning usage rollup (`orbit learning stats`) that drives deprecation decisions."
+                    .to_string(),
+            parameters,
+            builtin: true,
+        }
+    }
+
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        super::super::execute_host_action(ctx, input, OrbitBuiltinAction::LearningAck)
+    }
+}

--- a/crates/orbit-tools/src/builtin/orbit/learning/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/learning/mod.rs
@@ -1,3 +1,4 @@
+pub mod ack;
 pub mod add;
 pub mod list;
 pub mod prune;

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -155,6 +155,10 @@ pub fn register(registry: &mut ToolRegistry) {
     // compatibility stub were decommissioned. The agent graph surface is now
     // served by the in-process orbit-graph (v2) adapter in orbit-mcp.
     registry.register_mcp(
+        learning::ack::OrbitLearningAckTool,
+        agent_operator(McpToolPlacement::Owner),
+    );
+    registry.register_mcp(
         learning::add::OrbitLearningAddTool,
         agent_operator(McpToolPlacement::Composite),
     );

--- a/crates/orbit-tools/src/lib.rs
+++ b/crates/orbit-tools/src/lib.rs
@@ -91,6 +91,7 @@ pub enum OrbitBuiltinAction {
     FrictionTags,
     FrictionUpdate,
     HostList,
+    LearningAck,
     LearningAdd,
     LearningList,
     LearningPrune,

--- a/crates/orbit-tools/tests/mcp_definitions.rs
+++ b/crates/orbit-tools/tests/mcp_definitions.rs
@@ -29,7 +29,7 @@ impl Tool for TestTool {
 fn canonical_builtin_definitions_are_workspace_independent() {
     let definitions =
         canonical_builtin_mcp_tool_definitions().expect("builtin MCP definitions are valid");
-    assert_eq!(definitions.len(), 29);
+    assert_eq!(definitions.len(), 30);
     assert!(
         definitions
             .iter()

--- a/docs/design/mcp-bridge/references/conformance-v1.yaml
+++ b/docs/design/mcp-bridge/references/conformance-v1.yaml
@@ -59,6 +59,7 @@ tools:
   orbit.adr.show: { placement: owner, scope: workspace-required, allowed_capabilities: [agent, operator] }
   orbit.adr.supersede: { placement: owner, scope: workspace-required, allowed_capabilities: [agent, operator] }
   orbit.adr.update: { placement: owner, scope: workspace-required, allowed_capabilities: [agent, operator] }
+  orbit.learning.ack: { placement: owner, scope: workspace-required, allowed_capabilities: [agent, operator] }
   orbit.learning.add: { placement: composite, scope: workspace-required, allowed_capabilities: [agent, operator] }
   orbit.learning.show: { placement: owner, scope: workspace-required, allowed_capabilities: [agent, operator] }
   orbit.learning.update: { placement: owner, scope: workspace-required, allowed_capabilities: [agent, operator] }

--- a/docs/design/project-learnings/2_design.md
+++ b/docs/design/project-learnings/2_design.md
@@ -3,7 +3,7 @@ summary: "Project Learnings — Design"
 type: design
 title: "Project Learnings — Design"
 owner: claude
-last_updated: 2026-05-21
+last_updated: 2026-07-19
 status: Draft
 feature: project-learnings
 doc_role: design
@@ -224,6 +224,10 @@ This is the only layer that surfaces learnings on Claude Code's built-in editor 
 
 The hook is shipped as part of the design, but it is **layered on top of** layers 1 and 2, not a replacement. Other agent vendors that gain analogous hook capabilities can plug in equivalent layers without touching the Orbit-side store.
 
+Every hook fire that admits at least one learning records a `learning_injected` audit event in the host-global `~/.orbit/orbit.db` (`arguments_json.learning_ids`, target path, session id). The instrumentation **fails open**: an unavailable audit backend logs a warning and the reminder still renders — injection never depends on the observability write ([ORB-10316]). The per-learning rollup over these events is described in [§5.5](#55-usage-instrumentation-and-feedback).
+
+The hook resolves its session identity in priority order: `ORBIT_SESSION_ID` from the environment (engine-managed runs export it, pre-seeded with layer-1 injections) → the `session_id` field carried by the hook payload itself (Claude Code sends it on every hook event) → a tmpdir file keyed by parent pid as the last resort. The payload fallback matters: interactive sessions never export `ORBIT_SESSION_ID`, and each hook fire runs under a fresh shell, so the ppid fallback re-keys per invocation and cannot dedup (the 2026-07-18 relevancy audit observed one learning injected 10× in a single session; F2026-07-092).
+
 ### 4.4 Deduplication and budget
 
 A naive implementation injects the same learning multiple times across layers (e.g. once at layer 1, once at layer 2 for a tool call referencing the same file, once at layer 3 for the eventual edit). To prevent this:
@@ -234,7 +238,7 @@ A naive implementation injects the same learning multiple times across layers (e
 
 Implementation note: the per-session set lives in the agent's working memory. The Orbit-side store does not need to track session state; it just provides idempotent search. Layers consult the set; the store is stateless.
 
-Cross-process deduplication is best-effort via `ORBIT_SESSION_ID` plus `.orbit/state/sessions/<id>/learnings.json`. In-process Layer 1 + Layer 2 dedup is exact; when Layer 2 or Layer 3 runs without `ORBIT_SESSION_ID` (for example, an `orbit-mcp` server started outside an engine-spawned session, or a Claude session not initiated through Orbit), they fall back to per-process state and may double-emit. The dedup layer is belt-and-braces; the agent's own context window remains the practical backstop.
+Cross-process deduplication is best-effort and keyed on a session id: `ORBIT_SESSION_ID` when exported, else (for Layer 3) the `session_id` field the hook payload carries ([ORB-10316]). With a session id, dedup state lives in the `session_learning_state` table of the host-global `orbit.db`; without one, Layer 3 falls back to a tmpdir state file keyed by parent pid, which cannot dedup across fires from an interactive agent (each fire gets a fresh parent shell). In-process Layer 1 + Layer 2 dedup is exact; an `orbit-mcp` server started outside an engine-spawned session still falls back to per-process state and may double-emit. The dedup layer is belt-and-braces; the agent's own context window remains the practical backstop.
 
 ### 4.5 What gets injected
 
@@ -257,6 +261,8 @@ orbit learning supersede <id> --with <new-id>
 orbit learning upvote --id <id> --model <agent-family> --task <task-id>
 orbit learning sync                       # reconcile SQLite index from YAML
 orbit learning prune [--stale-only]       # report or delete stale learnings
+orbit learning ack <id>... [--ignored] [--session S]  # used/ignored feedback for injected learnings
+orbit learning stats [--since 30d]        # per-learning usage rollup (see §5.5)
 
 # Free-text content match (formerly the per-domain `learning` subcommand of `orbit search`) lives on the unified search surface:
 orbit search <text> --kind learning [--tag T] [--all] [--status learning:active] [--limit N]
@@ -276,6 +282,7 @@ orbit search path <path> --kind learning [--tag T] [--all] [--status learning:ac
 | `orbit.learning.update` | `id`, fields | updated record |
 | `orbit.learning.supersede` | `id`, `with` | both records updated |
 | `orbit.learning.upvote` | `id`, `model`, `task?` | vote summary |
+| `orbit.learning.ack` | `ids`, `outcome?` (`used`\|`ignored`), `session_id?` | `{ acked, outcome }` |
 
 `orbit.learning.list` and the runtime-side `search_learnings` helper drive the injection-layer hot path; both must stay sub-10ms at expected scale. The standalone per-domain learning-search MCP tool (phase-1 surface) was retired by [ORB-00202] in favor of `orbit.search` with `kind: "learning"`.
 
@@ -322,6 +329,17 @@ Search ranking remains scope-filtered first. Within the matched set, rows sort b
 4. `id` asc.
 
 `ORBIT_LEARNING_VOTE_HALF_LIFE_DAYS=0` disables decay and uses raw vote count. Vote files are scanned at query time in v1; a SQLite vote-summary mirror is a follow-up only if measured matched-set sizes make the per-file scan visible.
+
+### 5.5 Usage instrumentation and feedback
+
+Two audit event kinds in the host-global `~/.orbit/orbit.db` carry the usage signal ([ORB-10316]; the scoped reintroduction of a feedback primitive anticipated by [ADR-0210]):
+
+- **`learning_injected`** — one event per hook fire that admitted learnings; `arguments_json.learning_ids` lists the injected IDs, `target_id` is the tool-target path, `session_id` the resolved session.
+- **`learning_ack`** — the receiving agent's verdict on one learning: `target_id` is the learning ID, `arguments_json.outcome` is `used` or `ignored`. Recorded via `orbit learning ack <id>...` (one CLI call; `--ignored` for an explicit dismissal) or the `orbit.learning.ack` MCP tool. The injected reminder block itself tells the agent how to ack.
+
+**The ack contract degrades safely, not optimistically.** An injection with no `used` ack counts as **ignored** in the rollup — agents that never ack bias learnings toward deprecation, never away from it. Recording an ack fails open on an unavailable audit backend (CLI warns and exits 0) so a scripted ack in a session-end hook can never break the agent's main work; only caller mistakes (unknown ID, empty input) fail closed.
+
+`orbit learning stats [--since ..] [--json]` folds both event kinds into a per-learning rollup: injected count, used count, derived ignored count (`injected − used`, floored at 0), explicit ignored-ack count, used ratio, last-injected and last-used timestamps. This rollup is the designed input for downstream deprecation policy (decay/TTL is follow-up work, deliberately not implemented at this layer).
 
 ---
 
@@ -414,9 +432,9 @@ Phase 2's semantic-similarity ranking from orbit-search may complement or replac
 
 The `PreToolUse` hook covers Claude Code's built-in `Edit | Write | Read`, which are the most frequent agent actions. Other agents that gain comparable hooks can layer in equivalent integrations, but as of phase 1, agents without hook support get only layers 1 and 2 — coarser-grained injection. This is uneven coverage by agent vendor; the design accepts the unevenness because layer 1 is universal and gives a baseline that's strictly better than today.
 
-### 8.5 Per-session deduplication state is agent-local
+### 8.5 Per-session deduplication depends on a resolvable session id
 
-The dedup set lives in the agent's working memory. If an agent's context is compressed or the agent crashes and restarts, the set resets and the same learning may inject twice. Hardening this would require a session-keyed cache in `orbit-store`, which trades complexity for a marginal context-token saving. Not worth it in phase 1.
+Cross-process dedup state is session-keyed in `orbit-store` (`session_learning_state`), but it only engages when a session id resolves — from `ORBIT_SESSION_ID` or, for Layer 3, the hook payload ([ORB-10316]). Agents whose hook payloads carry no session id and that run outside engine management still fall back to the per-invocation ppid state file and may re-inject. Separately, the agent's own in-context dedup set resets on context compression or crash-restart; the store-side state is the backstop for exactly the sessions that can be keyed.
 
 ### 8.6 No write-time validation that learnings are non-obvious
 
@@ -434,5 +452,6 @@ Learnings are workspace-scoped and checked into the repo. They travel exactly wh
 - [T20260510-12] — Add `tags` field to `Task` schema. Hard prerequisite for Layer 1's tag-axis matching ([§4.1](#41-layer-1--engine-pre-prompt-injection-universal)).
 - [ORB-00061] — Add Knowledge tab and Learnings subtab to dashboard.
 - [ORB-00090] — Aligned learning identity examples with the agent-family convention.
+- [ORB-10316] — Learning-hook usage instrumentation: `learning_injected`/`learning_ack` audit events, `orbit learning ack`/`stats`, payload-derived session dedup ([§4.3](#43-layer-3--claude-code-pretooluse-hook-optional), [§5.5](#55-usage-instrumentation-and-feedback)).
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/project-learnings/4_decisions.md
+++ b/docs/design/project-learnings/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Project Learnings — Decisions"
 type: design
 title: "Project Learnings — Decisions"
 owner: claude
-last_updated: 2026-07-11
+last_updated: 2026-07-19
 status: Draft
 feature: project-learnings
 doc_role: decisions
@@ -229,9 +229,35 @@ Alternatives considered:
 
 ---
 
+## ADR-0238 — Learning usage feedback via audit-store acks with ignored-by-default semantics
+
+**Status:** Accepted · 2026-07 · [ORB-10316]
+
+**Context.** The 2026-07-18 relevancy audit (friction F2026-07-092) found the learning PreToolUse hook fired 2,374 times over two weeks with 13 injections and **zero usage signal**: nothing recorded whether an injected learning shaped the receiving agent's work, so nothing could drive deprecation of stale learnings. ADR-0210 had removed the vote/comment feedback surfaces for lack of real usage, ending with an explicit reopening clause: a scoped feedback primitive can return "with real usage data behind it." The audit is that data. Separately, per-session injection dedup was dead in interactive sessions — `ORBIT_SESSION_ID` was exported on 0/2,374 observed fires, and the ppid-tmpfile fallback re-keys per invocation because every hook fire runs under a fresh parent shell (L-0077 injected 10× in one session).
+
+Alternatives considered:
+
+| Approach | Profile |
+|----------|---------|
+| **Dedicated ack table or per-learning sidecar** | Recreates the disproportionate infrastructure ADR-0210 removed; a new durable schema for what is an observability signal. |
+| **Absent ack counts as used** | Optimistic default makes the rollup useless for deprecation — silence would defend stale learnings. |
+| **Session-end Stop-hook auto-ack** | Cannot know used-ness automatically; bulk auto-acks fabricate the signal. |
+| **Audit-store acks, ignored by default (this ADR)** | One audit row per ack in the store that already carries the per-fire injection events; silence biases toward deprecation, never away from it. |
+
+**Decision.** Record the feedback signal as `learning_ack` audit events in the existing host-global audit store (`target_id` = learning ID, `arguments_json.outcome` = `used` \| `ignored`), written by `orbit learning ack <id>... [--ignored]` or the `orbit.learning.ack` MCP tool (an additive entry in the frozen mcp-bridge conformance-v1 fixture). The injected reminder block documents the ack call inline, so the mechanism travels with the injection. `orbit learning stats` folds `learning_injected` + `learning_ack` events into the per-learning rollup (injected, used, derived ignored = injected − used, used ratio, last-injected/last-used). Instrumentation fails open end to end: an unavailable audit backend logs a warning and injection still renders; `ack` warns and exits 0 on backend failure while caller mistakes (unknown IDs) still fail closed. Session dedup keys on the first resolvable anchor: `ORBIT_SESSION_ID` env → the `session_id` field the hook payload itself carries → ppid-tmpfile last resort.
+
+**Consequences.**
+- The rollup is the designed input for downstream deprecation policy; decay/TTL is deliberately follow-up work, not implemented at this layer.
+- The `learning_ack` contract lives in audit-event conventions (`target_type` + `arguments_json`) enforced by store-level fold tests, not a schema migration — consistent with the injection events it joins against.
+- Used-ratio quality depends on agent ack discipline, but the ignored-by-default rule makes the failure mode conservative: a silent agent population produces over-deprecation *pressure*, surfaced in `stats` long before any automated deprecation exists.
+- Cost: one extra reminder-block footer line per injection, one audit row per ack, and one additive tool in the MCP surface canaries (builtin definition count 29 → 30; conformance-v1 gains `orbit.learning.ack`).
+
+---
+
 ## Task References
 
 - [T20260510-11] — Design + build project-learnings system as native Orbit primitive. The task that produced this folder.
 - [ORB-10046] — Remove the vote and comment surfaces from the learning subsystem (ADR-0210 supersedes ADR-0157).
+- [ORB-10316] — Learning-hook usage instrumentation: `learning_ack` events, usage rollup, payload-derived session dedup (ADR-0238).
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10316](https://orbit-cli.com/tasks/ORB-10316) — Instrument learning PreToolUse hook: per-fire injection log + used/ignored feedback signal

### Description

Motivated by the 2026-07-18 relevancy audit (`operations/reports/2026-07-18-learning-hook-relevancy-audit.md`, commit 43b84ce; friction F2026-07-092). The learning PreToolUse hook (`crates/orbit-cmd/src/learning_hook.rs`) already logs per-fire audit events to the **global** `~/.orbit/orbit.db` (`target_type='hook'` per fire, `learning_injected` per injection; per-workspace stores hold 0). What's missing is any usage signal and any aggregation — so nothing can drive deprecation of stale learnings.

Implement:

1. **Used/ignored feedback signal.** Near-zero-cost way for a receiving agent to ack each injected learning as applied vs ignored (e.g. session-end Stop/SessionEnd hook or one-line CLI call). Missing ack defaults to `ignored` — the signal degrades safely, not optimistically.
2. **Aggregation surface.** Per-learning rollup over the existing global-DB audit events plus acks: injection count, used/ignored counts, used ratio, last-used timestamp; queryable via orbit CLI/API. This rollup is the input for downstream deprecation policy (decay/TTL is a follow-up task — do not implement deprecation here).
3. **Session-dedup fix (may be split into its own task if it grows).** `ORBIT_SESSION_ID` is exported on 0/2,374 observed fires, so the DB session-state dedup path is dead code and the ppid-tmpfile fallback re-keys per invocation (L-0077 injected 10× in one session). Propagate a stable session id or re-key dedup on a stable per-session anchor.

Audit baseline for reference: 2,374 fires 2026-07-04→18, 13 injections (0.55%), DIRECT 0 / TANGENTIAL 12 / NOISE 1; selection is pure path-glob scope matching.

Out of scope: building a new injection log (exists), changing selection/ranking semantics, deprecating any learning, injection budget caps.

### Acceptance Criteria

- Receiving agents have a documented, near-zero-cost mechanism to ack each injected learning as used or ignored; absent ack records as ignored
- Per-learning aggregation (injection count, used/ignored ratio, last-used timestamp) over the existing global orbit.db audit events plus acks is queryable via the orbit CLI or HTTP API
- Per-session injection dedup works: a stable session id (or equivalent stable anchor) keys dedup so the same learning is not re-injected within one session; regression test covers the previously dead ORBIT_SESSION_ID path
- Success and failure paths tested, including ack/log backend unavailable (injection still succeeds; instrumentation fails open)
- Docs updated describing the ack contract, aggregation query, and session-id propagation; ADR filed if a new durable contract is introduced
- make ci-fast passes

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented learning-hook usage instrumentation end to end (ADR-0238).

1. Used/ignored feedback signal: new `orbit learning ack <id>... [--ignored] [--session S]` CLI and `orbit.learning.ack` MCP tool record `learning_ack` audit events in the global ~/.orbit/orbit.db (target_id = learning ID, arguments_json.outcome = used|ignored). Absent ack counts as ignored in the rollup. The injected reminder block now carries a one-line ack instruction, so the mechanism travels with the injection. Ack fails open on an unavailable audit backend (warn + exit 0) and fails closed on caller mistakes (unknown ID).

2. Aggregation surface: `orbit learning stats [--since ..] [--json]` backed by Store::get_learning_usage_stats, which folds learning_injected + learning_ack events per learning: injected count, used count, derived ignored (= injected − used, floored at 0), explicit ignored-ack count, used ratio, last-injected/last-used timestamps. Exposed through AuditEventStoreBackend → runtime.learning_usage_stats.

3. Session-dedup fix: HookPayload now parses the `session_id` field Claude Code sends in every hook payload; resolution order is ORBIT_SESSION_ID env (engine runs, pre-seeded with L1 injections) → payload session_id → ppid-tmpfile last resort. Also made the hook's audit emission fail open — previously an audit-write error aborted the already-admitted injection via `?`.

Tests: store fold unit tests (incl. malformed-arguments skip + since filter); orbit-cmd payload-session-id parse tests; CLI integration tests for payload-keyed dedup, env-over-payload priority, ack+stats rollup (used/ignored/ratio), unknown-ID fail-closed, and audit-backend-unavailable fail-open for both hook injection and ack (simulated with a RAISE(ABORT) trigger on audit_events so reads keep working while inserts fail). Regenerated the MCP tools snapshot; bumped the builtin definition count 29→30; added orbit.learning.ack to the frozen mcp-bridge conformance-v1.yaml fixture (additive, schema_version unchanged) and REQUIRED_AGENT_FACING_TOOL_NAMES.

Docs: 2_design.md §4.3/§4.4 (audit + session resolution), new §5.5 (ack contract + rollup), §5.1/§5.2 surface lists, §8.5 limitation rewrite, Task References; 4_decisions.md ADR-0238 (accepted, allocated via orbit.adr.add; references ADR-0210's reopening clause). Learning L-0102 recorded (four MCP surface canaries must move together).

Validation: make ci-fast passes; all touched suites green (orbit-common, orbit-store, orbit-cmd, orbit-tools, orbit-mcp, orbit-engine reminder tests, orbit-cli hook_pretooluse 16/16, mcp_roundtrip 5/5, orbit bin mcp tests). Two orbit-cli bin test failures (config seed-from-global, workspace ship-mode table) reproduce on the clean base tree in this sandbox — pre-existing/environment-sensitive, not from this change; two clippy warnings flagged are in untouched files. Out of scope honored: no deprecation/decay, no selection-semantics change, no injection budget change.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10316-6a5c1cc3`
- Behind base: 0
- Ahead of base: 1