### PR TITLE
ORB-10323: HTTP write attribution — accept caller identity, default to human

### DIFF
--- a/.orbit/learnings/L-0103/learning.yaml
+++ b/.orbit/learnings/L-0103/learning.yaml
@@ -1,0 +1,22 @@
+schema_version: 1
+id: L-0103
+status: active
+scope:
+  paths:
+  - crates/orbit-tools/src/builtin/orbit/**
+  - crates/orbit-dashboard/src/api/**
+  - crates/orbit-core/src/runtime/orbit_tool_host/**
+  tags: []
+summary: orbit.adr.add/update/supersede, orbit.friction.add, and orbit.task.add/update/start reject a top-level `agent` field outright — attribution is `model`-only
+body: |-
+  Since T20260510-15 ("Simplify task attribution to model-only; drop derived agent field", commit e7ba29c9), every mutation-style orbit.* tool that uses `model_identity_params()` also calls `reject_agent_field(&input, "<tool>")` at the top of its `execute()` (crates/orbit-tools/src/builtin/orbit/mod.rs). That function returns `OrbitError::InvalidInput` if the input JSON has an `agent` key at all, even if empty-string. This covers orbit.adr.add/update/supersede, orbit.friction.add, orbit.task.add/update/start, orbit.task.artifact.put. Only read-only tools (list/show) and review_thread add/reply (which use `scored_identity_params()`, a still-deprecated `agent` field) accept `agent`.
+
+  Gotcha: this constraint lives in orbit-tools (the MCP/CLI tool wrapper layer), not in orbit-core's dispatch/*_tools.rs functions that actually implement the tool logic — those still take `agent: Option<String>` as a function parameter for backward-compat plumbing, which makes it look like `agent` is a live, accepted field when reading only orbit-core. A caller building a request that forwards a caller-supplied `agent` value into one of these tools' JSON input will get a hard error the moment `agent` is non-empty, not a silent ignore.
+
+  When a task asks an HTTP/API layer to "forward agent/model attribution" to one of these tools, forward `model` only (canonical agent family, or `human` for identity-less/human-authored writes) and drop `agent` from the request body entirely.
+evidence:
+- kind: task
+  reference: ORB-10323
+created_at: 2026-07-19T08:04:31.813492273Z
+updated_at: 2026-07-19T08:04:31.813492273Z
+created_by: claude

--- a/crates/orbit-dashboard/src/api/adrs.rs
+++ b/crates/orbit-dashboard/src/api/adrs.rs
@@ -11,7 +11,6 @@ use serde_json::{Map, Value, json};
 use super::{bad_request, bounded_limit, map_runtime_error, non_empty_string};
 
 const ADRS_DEFAULT_LIMIT: usize = 100;
-const ADR_TOOL_MODEL: &str = orbit_common::model_defaults::CODEX_DEFAULT_MODEL;
 
 #[derive(Deserialize, Default)]
 pub(super) struct AdrsQuery {
@@ -31,6 +30,12 @@ pub(super) struct AdrsQuery {
 /// `title` and `body` are required (validated in the handler for a structured
 /// 400 rather than serde's default rejection); the remaining fields default to
 /// empty. Status is not a field — the tool always creates a Proposed ADR.
+/// `model` carries caller-supplied attribution (the canonical agent family,
+/// e.g. `codex`/`claude`, or `human`) and is forwarded to the tool host
+/// unchanged; when absent, the tool host attributes the write to the human
+/// actor label rather than defaulting to a model constant. `orbit.adr.add`
+/// rejects a separate `agent` field (attribution was consolidated to
+/// `model`-only), so this body does not accept one.
 #[derive(Deserialize, Default)]
 pub(super) struct CreateAdrBody {
     #[serde(default)]
@@ -39,6 +44,8 @@ pub(super) struct CreateAdrBody {
     body: Option<String>,
     #[serde(default)]
     owner: Option<String>,
+    #[serde(default)]
+    model: Option<String>,
     #[serde(default)]
     related_features: Vec<String>,
     #[serde(default)]
@@ -55,6 +62,8 @@ pub(super) struct SupersedeAdrBody {
     by: Option<String>,
     #[serde(default)]
     reason: Option<String>,
+    #[serde(default)]
+    model: Option<String>,
 }
 
 /// Partial-update payload for `PATCH /adrs/:id`, mirroring the mutable fields
@@ -84,6 +93,8 @@ pub(super) struct AdrPatchBody {
     supersedes: Option<Vec<String>>,
     #[serde(default)]
     legacy_ids: Option<Vec<String>>,
+    #[serde(default)]
+    model: Option<String>,
 }
 
 pub(super) async fn list_adrs(Ws(runtime): Ws, Query(query): Query<AdrsQuery>) -> Response {
@@ -184,8 +195,13 @@ pub(super) async fn create_adr_action(
     {
         object.insert("owner".to_string(), Value::String(owner));
     }
+    if let Some(model) = body.model.as_deref().and_then(non_empty_string)
+        && let Some(object) = input.as_object_mut()
+    {
+        object.insert("model".to_string(), Value::String(model));
+    }
 
-    match run_adr_tool(&runtime, "orbit.adr.add", input) {
+    match runtime.run_tool("orbit.adr.add", input) {
         Ok(adr) => match adr.get("id").and_then(Value::as_str) {
             Some(id) => match adr_show(&runtime, id) {
                 Ok(resolved) => Json(resolved).into_response(),
@@ -200,8 +216,7 @@ pub(super) async fn create_adr_action(
 }
 
 pub(super) async fn accept_adr_action(Ws(runtime): Ws, Path(id): Path<String>) -> Response {
-    let result = run_adr_tool(
-        &runtime,
+    let result = runtime.run_tool(
         "orbit.adr.update",
         json!({
             "id": id.clone(),
@@ -236,6 +251,7 @@ pub(super) async fn update_adr_action(
         paths,
         supersedes,
         legacy_ids,
+        model,
     } = body;
 
     let mut input = Map::new();
@@ -249,12 +265,13 @@ pub(super) async fn update_adr_action(
     insert_optional_list(&mut input, "paths", paths);
     insert_optional_list(&mut input, "supersedes", supersedes);
     insert_optional_list(&mut input, "legacy_ids", legacy_ids);
+    insert_optional_string(&mut input, "model", model);
     if input.is_empty() {
         return bad_request("request body must include at least one updatable field".to_string());
     }
     input.insert("id".to_string(), Value::String(id.clone()));
 
-    match run_adr_tool(&runtime, "orbit.adr.update", Value::Object(input)) {
+    match runtime.run_tool("orbit.adr.update", Value::Object(input)) {
         Ok(_) => match adr_show(&runtime, &id) {
             Ok(adr) => Json(adr).into_response(),
             Err(e) => map_runtime_error(e),
@@ -276,14 +293,17 @@ pub(super) async fn supersede_adr_action(
     };
     let _reason = body.reason.as_deref().and_then(non_empty_string);
 
-    let result = run_adr_tool(
-        &runtime,
-        "orbit.adr.supersede",
-        json!({
-            "old_id": id.clone(),
-            "new_id": by.clone(),
-        }),
-    );
+    let mut input = json!({
+        "old_id": id.clone(),
+        "new_id": by.clone(),
+    });
+    if let Some(object) = input.as_object_mut()
+        && let Some(model) = body.model.as_deref().and_then(non_empty_string)
+    {
+        object.insert("model".to_string(), Value::String(model));
+    }
+
+    let result = runtime.run_tool("orbit.adr.supersede", input);
 
     match result {
         Ok(_) => {
@@ -322,7 +342,7 @@ fn insert_optional_list(input: &mut Map<String, Value>, key: &str, value: Option
 }
 
 fn adr_list(runtime: &OrbitRuntime, input: Map<String, Value>) -> Result<Vec<Value>, OrbitError> {
-    let value = run_adr_tool(runtime, "orbit.adr.list", Value::Object(input))?;
+    let value = runtime.run_tool("orbit.adr.list", Value::Object(input))?;
     match value {
         Value::Array(adrs) => Ok(adrs),
         other => Err(OrbitError::Execution(format!(
@@ -332,16 +352,7 @@ fn adr_list(runtime: &OrbitRuntime, input: Map<String, Value>) -> Result<Vec<Val
 }
 
 fn adr_show(runtime: &OrbitRuntime, id: &str) -> Result<Value, OrbitError> {
-    run_adr_tool(runtime, "orbit.adr.show", json!({ "id": id }))
-}
-
-fn run_adr_tool(runtime: &OrbitRuntime, name: &str, mut input: Value) -> Result<Value, OrbitError> {
-    if let Some(object) = input.as_object_mut() {
-        object
-            .entry("model".to_string())
-            .or_insert_with(|| Value::String(ADR_TOOL_MODEL.to_string()));
-    }
-    runtime.run_tool(name, input)
+    runtime.run_tool("orbit.adr.show", json!({ "id": id }))
 }
 
 fn adr_stats_to_json(adrs: &[Value]) -> Value {

--- a/crates/orbit-dashboard/src/api/frictions.rs
+++ b/crates/orbit-dashboard/src/api/frictions.rs
@@ -11,7 +11,7 @@ use serde_json::{Map, Value, json};
 use super::{bad_request, bounded_limit, map_runtime_error, non_empty_string};
 
 const FRICTIONS_DEFAULT_LIMIT: usize = 100;
-const FRICTION_TOOL_MODEL: &str = orbit_common::model_defaults::CODEX_DEFAULT_MODEL;
+const HUMAN_ACTOR_LABEL: &str = "human";
 
 #[derive(Deserialize, Default)]
 pub(super) struct FrictionsQuery {
@@ -30,12 +30,13 @@ pub(super) struct FrictionsQuery {
 }
 
 /// Create body for `POST /frictions`. Mirrors the `orbit.friction.add` tool
-/// schema: `body` is required, `model` provenance and `tags`/`during_task` are
-/// optional. Field parsing and validation stay in the shared runtime add path
-/// so the wire shape and defaults match the native MCP tool exactly. `model`
-/// falls back to the dashboard default (`FRICTION_TOOL_MODEL`) via
-/// [`run_friction_tool`] when the caller omits it, matching the other friction
-/// routes.
+/// schema: `body` is required, `model` provenance and `tags`/`during_task`
+/// are optional. Field parsing and validation stay in the shared runtime add
+/// path so the wire shape and defaults match the native MCP tool exactly.
+/// `model` falls back to the human actor label via [`run_friction_tool`] when
+/// the caller omits it, matching the ADR routes. `orbit.friction.add` rejects
+/// a separate `agent` field (attribution was consolidated to `model`-only),
+/// so this body does not accept one.
 #[derive(Deserialize, Default)]
 pub(super) struct CreateFrictionBody {
     #[serde(default)]
@@ -209,17 +210,21 @@ fn insert_optional(input: &mut Map<String, Value>, key: &str, value: Option<&str
     }
 }
 
+/// `orbit.friction.add` requires a non-empty `model`; when the caller supplies
+/// no attribution, default to the human actor label rather than a model
+/// constant. No other friction tool consumes `model`, so this only touches
+/// `orbit.friction.add`.
 fn run_friction_tool(
     runtime: &OrbitRuntime,
     name: &str,
     mut input: Value,
 ) -> Result<Value, OrbitError> {
-    if name != "orbit.friction.list"
+    if name == "orbit.friction.add"
         && let Some(object) = input.as_object_mut()
     {
         object
             .entry("model".to_string())
-            .or_insert_with(|| Value::String(FRICTION_TOOL_MODEL.to_string()));
+            .or_insert_with(|| Value::String(HUMAN_ACTOR_LABEL.to_string()));
     }
     runtime.run_tool(name, input)
 }

--- a/crates/orbit-dashboard/src/api/tests/adrs.rs
+++ b/crates/orbit-dashboard/src/api/tests/adrs.rs
@@ -185,6 +185,55 @@ async fn create_persists_proposed_adr_and_reads_back() {
 }
 
 #[tokio::test]
+async fn create_without_attribution_defaults_owner_to_human() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    let response = request_create(
+        runtime,
+        Some("http://localhost:7878"),
+        Some(json!({
+            "title": "No attribution supplied",
+            "body": ADR_BODY,
+            "related_features": ["dashboard"],
+            "related_tasks": ["ORB-00063"],
+        })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let created = body_json(response).await;
+    assert_eq!(
+        created["owner"], "human",
+        "identity-less writes attribute to the human actor label, not a model constant"
+    );
+}
+
+#[tokio::test]
+async fn create_forwards_explicit_model_attribution() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    let response = request_create(
+        runtime,
+        Some("http://localhost:7878"),
+        Some(json!({
+            "title": "Explicit attribution supplied",
+            "body": ADR_BODY,
+            "model": TEST_CODEX_MODEL,
+            "related_features": ["dashboard"],
+            "related_tasks": ["ORB-00063"],
+        })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let created = body_json(response).await;
+    assert_eq!(
+        created["owner"], TEST_CODEX_MODEL,
+        "caller-supplied `model` is forwarded to the tool host unchanged"
+    );
+}
+
+#[tokio::test]
 async fn federated_http_show_and_mutators_preserve_typed_origin_boundary() {
     let root = tempfile::tempdir().expect("tempdir");
     let global_root = root.path().join("global");
@@ -576,6 +625,70 @@ async fn update_sets_status_and_tags() {
         )
         .expect("show adr");
     assert_eq!(stored["status"], "accepted");
+}
+
+fn transition_audit_actor(runtime: &OrbitRuntime, adr_id: &str) -> String {
+    let events = runtime
+        .list_audit_events(None, Some("orbit.adr.update".to_string()), None, None, 20)
+        .expect("audit events");
+    let event = events
+        .iter()
+        .find(|event| {
+            event
+                .arguments_json
+                .as_deref()
+                .is_some_and(|args| args.contains(adr_id))
+        })
+        .expect("transition audit event");
+    let payload: Value = serde_json::from_str(event.arguments_json.as_deref().expect("args"))
+        .expect("audit payload");
+    payload["actor"].as_str().expect("actor field").to_string()
+}
+
+#[tokio::test]
+async fn update_without_attribution_records_human_actor_in_audit() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let adr = seed_adr(&runtime, "No attribution transition", vec!["ORB-00063"]);
+
+    let response = request_update(
+        runtime.clone(),
+        adr_id(&adr),
+        Some("http://localhost:7878"),
+        Some(json!({ "status": "accepted" })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        transition_audit_actor(&runtime, adr_id(&adr)),
+        "human",
+        "identity-less transitions attribute to the human actor label"
+    );
+}
+
+#[tokio::test]
+async fn update_forwards_explicit_model_attribution_to_audit() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let adr = seed_adr(
+        &runtime,
+        "Explicit attribution transition",
+        vec!["ORB-00063"],
+    );
+
+    let response = request_update(
+        runtime.clone(),
+        adr_id(&adr),
+        Some("http://localhost:7878"),
+        Some(json!({ "status": "accepted", "model": TEST_CODEX_MODEL })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        transition_audit_actor(&runtime, adr_id(&adr)),
+        TEST_CODEX_MODEL,
+        "caller-supplied `model` is forwarded to the tool host unchanged"
+    );
 }
 
 #[tokio::test]

--- a/crates/orbit-dashboard/src/api/tests/frictions.rs
+++ b/crates/orbit-dashboard/src/api/tests/frictions.rs
@@ -144,6 +144,53 @@ async fn create_persists_and_echoes_fields() {
 }
 
 #[tokio::test]
+async fn create_without_attribution_defaults_model_to_human() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    let response = request(
+        runtime,
+        Method::POST,
+        "/frictions".to_string(),
+        Some("http://localhost:7878"),
+        Some(json!({
+            "body": "# No attribution supplied\nDetails.",
+        })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let created = body_json(response).await;
+    assert_eq!(
+        created["model"], "human",
+        "identity-less writes attribute to the human actor label, not a model constant"
+    );
+}
+
+#[tokio::test]
+async fn create_forwards_explicit_model_attribution() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    let response = request(
+        runtime,
+        Method::POST,
+        "/frictions".to_string(),
+        Some("http://localhost:7878"),
+        Some(json!({
+            "body": "# Explicit attribution supplied\nDetails.",
+            "model": TEST_CODEX_MODEL,
+        })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let created = body_json(response).await;
+    assert_eq!(
+        created["model"], TEST_CODEX_MODEL,
+        "caller-supplied `model` is forwarded to the tool host unchanged"
+    );
+}
+
+#[tokio::test]
 async fn create_requires_localhost_origin() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
 


### PR DESCRIPTION
## Summary

- `orbit-dashboard`'s ADR (add/update/supersede) and friction (add) HTTP write endpoints now accept an optional `model` attribution field in the request body and forward it verbatim to the tool host, instead of the dashboard silently stamping `gpt-5.6-terra` (`ADR_TOOL_MODEL`/`FRICTION_TOOL_MODEL`) on every identity-less write.
- Removed `ADR_TOOL_MODEL` and `FRICTION_TOOL_MODEL`. For ADR writes, absent attribution now falls through to `orbit-core`'s existing `actor_label()` fallback, which resolves to the dashboard runtime's configured human actor (`orbit-dashboard/src/state.rs` already builds every runtime with `.with_actor(ActorIdentity::human("human"))`) — no dashboard-side default needed. For frictions, `orbit.friction.add` hard-requires a non-empty `model` server-side with no fallback, so `frictions.rs` keeps a narrow default-to-`"human"` fallback scoped to that one call only (list/show/stats/tags/resolve/update are untouched).
- Deliberately did **not** add an `agent` field to the request bodies: `orbit.adr.add/update/supersede` and `orbit.friction.add` call `reject_agent_field()` and hard-error on any `agent` key at all (attribution was consolidated to `model`-only per T20260510-15 / commit `e7ba29c9`). Filed `.orbit/learnings/L-0103` documenting this gotcha, since it's easy to miss reading `orbit-core` alone (the `*_tools.rs` functions still take a legacy `agent: Option<String>` parameter).
- Repo-wide audit (`grep` for `model_defaults::`/`CODEX_DEFAULT_MODEL`/`entry("model")` across `crates/orbit-dashboard/src`) confirms `adrs.rs` and `frictions.rs` were the only two dashboard endpoints injecting a default model constant; no other `api` module does.
- `orbit.friction.update`'s `FrictionPatchBody` is untouched — the underlying tool has no model-mutation capability, so there's nothing to forward there.

## Test plan

- [x] `make ci-fast` — clean
- [x] `cargo test -p orbit-dashboard` — 199 passed, including 19 `adrs::*` and 12 `friction*::*` tests (new coverage: `create_without_attribution_defaults_owner_to_human`, `create_forwards_explicit_model_attribution`, `update_without_attribution_records_human_actor_in_audit`, `update_forwards_explicit_model_attribution_to_audit`, `create_without_attribution_defaults_model_to_human`, `create_forwards_explicit_model_attribution` (frictions))
- [x] `cargo test -p orbit-common` — 244 passed
- [x] `cargo check --workspace --tests` — clean
- [x] `cargo fmt --all -- --check` — clean

Refs ORB-10323.