### PR TITLE
ORB-10272: add hub-global knowledge ID sequences

### DIFF
--- a/crates/orbit-common/src/types/knowledge_allocation.rs
+++ b/crates/orbit-common/src/types/knowledge_allocation.rs
@@ -1,0 +1,114 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::{OrbitError, validate_registry_identifier};
+
+pub const HUB_KNOWLEDGE_ALLOCATION_METHOD_V1: &str = "orbit/private/allocate-knowledge-id/v1";
+pub const HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION: u8 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KnowledgeIdKind {
+    Adr,
+    Learning,
+}
+
+impl KnowledgeIdKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Adr => "adr",
+            Self::Learning => "learning",
+        }
+    }
+
+    pub fn parse_id(self, id: &str) -> Option<u32> {
+        let prefix = match self {
+            Self::Adr => "ADR-",
+            Self::Learning => "L-",
+        };
+        let suffix = id.strip_prefix(prefix)?;
+        if suffix.len() < 4 || !suffix.bytes().all(|byte| byte.is_ascii_digit()) {
+            return None;
+        }
+        suffix.parse().ok()
+    }
+
+    pub fn format_id(self, sequence: u32) -> String {
+        let width = sequence.to_string().len().max(4);
+        match self {
+            Self::Adr => format!("ADR-{sequence:0width$}"),
+            Self::Learning => format!("L-{sequence:0width$}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HubKnowledgeAllocationRequestV1 {
+    pub schema_version: u8,
+    pub workspace_id: String,
+    pub kind: KnowledgeIdKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
+impl HubKnowledgeAllocationRequestV1 {
+    pub fn validate(&self) -> Result<(), OrbitError> {
+        if self.schema_version != HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION {
+            return Err(OrbitError::InvalidInput(format!(
+                "unsupported hub knowledge allocation request schema_version {}; expected {}",
+                self.schema_version, HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION
+            )));
+        }
+        validate_registry_identifier("workspace_id", &self.workspace_id)?;
+        if self
+            .model
+            .as_deref()
+            .is_some_and(|model| model.trim().is_empty() || model.trim() != model)
+        {
+            return Err(OrbitError::InvalidInput(
+                "hub knowledge allocation model must be normalized and non-empty when present"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HubKnowledgeAllocationV1 {
+    pub schema_version: u8,
+    pub workspace_id: String,
+    pub kind: KnowledgeIdKind,
+    pub id: String,
+    pub sequence: u32,
+    pub mcp_call_id: String,
+    pub allocated_at: DateTime<Utc>,
+}
+
+impl HubKnowledgeAllocationV1 {
+    pub fn validate(&self) -> Result<(), OrbitError> {
+        if self.schema_version != HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION {
+            return Err(OrbitError::InvalidInput(format!(
+                "unsupported hub knowledge allocation result schema_version {}; expected {}",
+                self.schema_version, HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION
+            )));
+        }
+        validate_registry_identifier("workspace_id", &self.workspace_id)?;
+        if self.mcp_call_id.trim().is_empty() || self.mcp_call_id.trim() != self.mcp_call_id {
+            return Err(OrbitError::InvalidInput(
+                "hub knowledge allocation result requires a normalized mcp_call_id".to_string(),
+            ));
+        }
+        if self.kind.parse_id(&self.id) != Some(self.sequence) {
+            return Err(OrbitError::InvalidInput(format!(
+                "hub knowledge allocation id '{}' does not match kind '{}' sequence {}",
+                self.id,
+                self.kind.as_str(),
+                self.sequence
+            )));
+        }
+        Ok(())
+    }
+}

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -40,6 +40,7 @@ pub mod host;
 pub mod id;
 pub mod invocation;
 pub mod job;
+pub mod knowledge_allocation;
 pub mod learning;
 pub mod metrics;
 pub mod policy_decision;
@@ -118,6 +119,10 @@ pub use job::{
     AgentCommitRequest, AgentResponseEnvelope, AgentRunError, Job, JobRun, JobRunState, JobRunStep,
     JobScheduleState, JobStep, JobTargetType, KnowledgeRunMetrics, RunEvent, StepCondition,
     default_job_max_active_runs, default_max_iterations, default_retry_backoff_seconds,
+};
+pub use knowledge_allocation::{
+    HUB_KNOWLEDGE_ALLOCATION_METHOD_V1, HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION,
+    HubKnowledgeAllocationRequestV1, HubKnowledgeAllocationV1, KnowledgeIdKind,
 };
 pub use learning::{
     DEFAULT_LEARNING_REMINDER_PER_CALL_CAP, DEFAULT_LEARNING_REMINDER_SESSION_CAP, EvidenceKind,

--- a/crates/orbit-remote/src/knowledge.rs
+++ b/crates/orbit-remote/src/knowledge.rs
@@ -1,0 +1,635 @@
+//! Explicit activation and checkoutless hub knowledge-allocation service.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use orbit_common::types::{
+    AuditEventStatus, HUB_KNOWLEDGE_ALLOCATION_METHOD_V1, HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION,
+    HubKnowledgeAllocationRequestV1, HubKnowledgeAllocationV1, KnowledgeIdKind, OrbitError,
+    ToolSessionContext, WorkspaceRegistry, WorkspaceStatus, audit_execution_id,
+};
+use orbit_core::command::tool::{
+    ToolEntryPoint, audit_role_label_for_entry_point, trusted_mcp_audit_context,
+};
+use orbit_store::AuditEventInsertParams;
+use rusqlite::{Connection, OpenFlags};
+use serde_json::{Value, json};
+
+use crate::persistence::{
+    HubKnowledgeAllocatorState, HubKnowledgeRequestIdentityV1, KnowledgeWorkspaceInventory,
+    LegacyKnowledgeId,
+};
+use crate::{RemoteStore, workspace_registry};
+
+#[derive(Clone)]
+pub struct HubKnowledgeSequenceService {
+    store: RemoteStore,
+    registered_workspace_ids: BTreeSet<String>,
+    global_root: Option<PathBuf>,
+}
+
+impl HubKnowledgeSequenceService {
+    pub fn at(global_root: &Path) -> Result<Self, OrbitError> {
+        let identity = crate::host_registry::require_local_hub_identity(global_root)?;
+        let store = crate::remote_store_at(global_root)?;
+        require_configured_hub_identity(&store, &identity.machine_id)?;
+        let registry = workspace_registry::load_registry_from(
+            &workspace_registry::registry_path_for(global_root),
+        )?;
+        let registered_workspace_ids = registered_workspace_ids(&registry);
+        Ok(Self {
+            store,
+            registered_workspace_ids,
+            global_root: Some(global_root.to_path_buf()),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test(
+        store: RemoteStore,
+        registered_workspace_ids: BTreeSet<String>,
+    ) -> Self {
+        Self {
+            store,
+            registered_workspace_ids,
+            global_root: None,
+        }
+    }
+
+    // F1 deliberately installs a dormant substrate; F3 will call this during cutover.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn activate(
+        &self,
+        inventories: Vec<KnowledgeWorkspaceInventory>,
+    ) -> Result<HubKnowledgeAllocatorState, OrbitError> {
+        self.require_hub_mode()?;
+        self.require_exact_inventory_coverage(
+            &inventories,
+            &self.current_registered_workspace_ids()?,
+        )?;
+        self.store.activate_knowledge_allocator(inventories)
+    }
+
+    // F1 deliberately installs a dormant substrate; F3 will call this for late workspaces.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn reconcile_workspace(
+        &self,
+        inventory: KnowledgeWorkspaceInventory,
+    ) -> Result<HubKnowledgeAllocatorState, OrbitError> {
+        self.require_hub_mode()?;
+        if !self
+            .current_registered_workspace_ids()?
+            .contains(&inventory.workspace_id)
+        {
+            return Err(OrbitError::InvalidInput(format!(
+                "cannot reconcile unregistered workspace '{}'",
+                inventory.workspace_id
+            )));
+        }
+        self.store.reconcile_knowledge_workspace(inventory)
+    }
+
+    pub fn allocate(
+        &self,
+        request: &HubKnowledgeAllocationRequestV1,
+        context: &ToolSessionContext,
+    ) -> Result<HubKnowledgeAllocationV1, OrbitError> {
+        self.require_hub_mode()?;
+        request.validate()?;
+        if context.effective_capabilities.len() != 1
+            || (!context
+                .effective_capabilities
+                .contains(&orbit_common::types::McpCapability::Agent)
+                && !context
+                    .effective_capabilities
+                    .contains(&orbit_common::types::McpCapability::Operator))
+        {
+            return Err(OrbitError::InvalidInput(
+                "private hub knowledge allocation requires exactly one effective capability: agent or operator"
+                    .to_string(),
+            ));
+        }
+        if !self
+            .current_active_workspace_ids()?
+            .contains(&request.workspace_id)
+        {
+            return Err(OrbitError::InvalidInput(format!(
+                "cannot allocate knowledge for unregistered or inactive workspace '{}'",
+                request.workspace_id
+            )));
+        }
+        let identity = request_identity(request, context)?;
+        let audit = allocation_audit(request, context, &identity)?;
+        self.store
+            .allocate_hub_knowledge_id(request, &identity, &audit)
+    }
+
+    pub fn allocation_by_call(
+        &self,
+        mcp_call_id: &str,
+    ) -> Result<Option<HubKnowledgeAllocationV1>, OrbitError> {
+        self.store.hub_knowledge_allocation_by_call(mcp_call_id)
+    }
+
+    pub fn allocation_by_id(
+        &self,
+        workspace_id: &str,
+        kind: KnowledgeIdKind,
+        id: &str,
+    ) -> Result<Option<HubKnowledgeAllocationV1>, OrbitError> {
+        self.store
+            .hub_knowledge_allocation_by_id(workspace_id, kind, id)
+    }
+
+    fn require_exact_inventory_coverage(
+        &self,
+        inventories: &[KnowledgeWorkspaceInventory],
+        registered_workspace_ids: &BTreeSet<String>,
+    ) -> Result<(), OrbitError> {
+        let supplied = inventories
+            .iter()
+            .map(|inventory| inventory.workspace_id.clone())
+            .collect::<BTreeSet<_>>();
+        let missing = registered_workspace_ids
+            .difference(&supplied)
+            .cloned()
+            .collect::<Vec<_>>();
+        let extra = supplied
+            .difference(registered_workspace_ids)
+            .cloned()
+            .collect::<Vec<_>>();
+        if !inventories.is_empty()
+            && missing.is_empty()
+            && extra.is_empty()
+            && supplied.len() == inventories.len()
+        {
+            return Ok(());
+        }
+        Err(OrbitError::Migration(format!(
+            "knowledge activation inventory must be nonempty and cover the registered-workspace set exactly; missing [{}], extra [{}], repeated inputs {}",
+            missing.join(", "),
+            extra.join(", "),
+            inventories.len().saturating_sub(supplied.len())
+        )))
+    }
+
+    fn require_hub_mode(&self) -> Result<(), OrbitError> {
+        if let Some(global_root) = &self.global_root {
+            let identity = crate::host_registry::require_local_hub_identity(global_root)?;
+            require_configured_hub_identity(&self.store, &identity.machine_id)?;
+        }
+        Ok(())
+    }
+
+    fn current_registered_workspace_ids(&self) -> Result<BTreeSet<String>, OrbitError> {
+        if let Some(global_root) = &self.global_root {
+            let registry = workspace_registry::load_registry_from(
+                &workspace_registry::registry_path_for(global_root),
+            )?;
+            return Ok(registered_workspace_ids(&registry));
+        }
+        Ok(self.registered_workspace_ids.clone())
+    }
+
+    fn current_active_workspace_ids(&self) -> Result<BTreeSet<String>, OrbitError> {
+        if let Some(global_root) = &self.global_root {
+            let registry = workspace_registry::load_registry_from(
+                &workspace_registry::registry_path_for(global_root),
+            )?;
+            return Ok(active_workspace_ids(&registry));
+        }
+        Ok(self.registered_workspace_ids.clone())
+    }
+}
+
+pub fn scan_registered_knowledge_inventories(
+    global_root: &Path,
+) -> Result<Vec<KnowledgeWorkspaceInventory>, OrbitError> {
+    let registry = workspace_registry::load_registry_from(&workspace_registry::registry_path_for(
+        global_root,
+    ))?;
+    let mut inventories = BTreeMap::new();
+    for workspace in &registry.workspaces {
+        let checkout = registry
+            .checkouts
+            .iter()
+            .find(|checkout| checkout.workspace_id == workspace.id)
+            .ok_or_else(|| {
+                OrbitError::Migration(format!(
+                    "registered workspace '{}' has no hub-local checkout to scan; supply a validated owner inventory before activation",
+                    workspace.id
+                ))
+            })?;
+        let mut ids = BTreeMap::new();
+        let primary_metadata = fs::symlink_metadata(&checkout.orbit_dir).map_err(|error| {
+            OrbitError::Migration(format!(
+                "registered workspace '{}' has unresolved migration source '{}': its primary hub-local orbit_dir is unavailable because the checkout binding is stale: {error}",
+                workspace.id,
+                checkout.orbit_dir.display()
+            ))
+        })?;
+        if !primary_metadata.file_type().is_dir() {
+            return Err(OrbitError::Migration(format!(
+                "registered workspace '{}' has unresolved migration source '{}': its primary hub-local orbit_dir is not a real directory because the checkout binding is stale",
+                workspace.id,
+                checkout.orbit_dir.display()
+            )));
+        }
+        let mut orbit_roots = BTreeSet::from([checkout.orbit_dir.clone()]);
+        for override_root in &checkout.path_overrides {
+            orbit_roots.insert(override_root.join(".orbit"));
+        }
+        for orbit_root in orbit_roots {
+            scan_adr_files(&orbit_root, &mut ids)?;
+            scan_learning_files(&orbit_root, &mut ids)?;
+            scan_allocation_rows(&orbit_root, &mut ids)?;
+        }
+        inventories.insert(
+            workspace.id.clone(),
+            KnowledgeWorkspaceInventory {
+                workspace_id: workspace.id.clone(),
+                ids: materialize_ids(ids),
+            },
+        );
+    }
+
+    inventories
+        .into_values()
+        .map(KnowledgeWorkspaceInventory::validated)
+        .collect()
+}
+
+fn registered_workspace_ids(registry: &WorkspaceRegistry) -> BTreeSet<String> {
+    registry
+        .workspaces
+        .iter()
+        .map(|workspace| workspace.id.clone())
+        .collect()
+}
+
+fn active_workspace_ids(registry: &WorkspaceRegistry) -> BTreeSet<String> {
+    registry
+        .workspaces
+        .iter()
+        .filter(|workspace| workspace.status == WorkspaceStatus::Active)
+        .map(|workspace| workspace.id.clone())
+        .collect()
+}
+
+fn require_configured_hub_identity(
+    store: &RemoteStore,
+    local_machine_id: &str,
+) -> Result<(), OrbitError> {
+    match store.hub_machine_id()? {
+        Some(configured) if configured == local_machine_id => Ok(()),
+        Some(configured) => Err(OrbitError::InvalidInput(format!(
+            "refusing hub knowledge allocation through a shadow coordination store: local hub machine_id '{local_machine_id}' does not match configured hub_machine_id '{configured}'"
+        ))),
+        None => Err(OrbitError::InvalidInput(
+            "the global coordination store has no configured hub_machine_id; register this hub before activating hub knowledge allocation"
+                .to_string(),
+        )),
+    }
+}
+
+type InventoryMap = BTreeMap<(KnowledgeIdKind, String), BTreeSet<String>>;
+
+fn add_evidence(map: &mut InventoryMap, kind: KnowledgeIdKind, id: String, evidence: String) {
+    map.entry((kind, id)).or_default().insert(evidence);
+}
+
+fn materialize_ids(map: InventoryMap) -> Vec<LegacyKnowledgeId> {
+    map.into_iter()
+        .map(|((kind, id), evidence)| LegacyKnowledgeId { kind, id, evidence })
+        .collect()
+}
+
+fn scan_adr_files(orbit_root: &Path, ids: &mut InventoryMap) -> Result<(), OrbitError> {
+    for state in ["proposed", "accepted", "superseded", "deleted"] {
+        let root = orbit_root.join("adrs").join(state);
+        for directory in child_directories_if_present(&root)? {
+            let directory_id = file_name_utf8(&directory)?;
+            let yaml = directory.join("adr.yaml");
+            if !yaml.is_file() {
+                continue;
+            }
+            let document_id = yaml_id(&yaml)?;
+            if document_id != directory_id {
+                return Err(OrbitError::Migration(format!(
+                    "ADR source '{}' contains id '{}' but directory is '{}'",
+                    yaml.display(),
+                    document_id,
+                    directory_id
+                )));
+            }
+            validate_source_id(KnowledgeIdKind::Adr, &document_id, &yaml)?;
+            add_evidence(
+                ids,
+                KnowledgeIdKind::Adr,
+                document_id,
+                format!("adr-file:{state}"),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn scan_learning_files(orbit_root: &Path, ids: &mut InventoryMap) -> Result<(), OrbitError> {
+    let root = orbit_root.join("learnings");
+    for directory in child_directories_if_present(&root)? {
+        let directory_id = file_name_utf8(&directory)?;
+        let yaml = directory.join("learning.yaml");
+        if !yaml.is_file() {
+            continue;
+        }
+        let value = read_yaml(&yaml)?;
+        let document_id = yaml_string(&value, "id", &yaml)?;
+        if document_id != directory_id {
+            return Err(OrbitError::Migration(format!(
+                "learning source '{}' contains id '{}' but directory is '{}'",
+                yaml.display(),
+                document_id,
+                directory_id
+            )));
+        }
+        let status = value
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("active");
+        if !matches!(status, "active" | "superseded") {
+            return Err(OrbitError::Migration(format!(
+                "learning source '{}' has invalid lifecycle status '{}'",
+                yaml.display(),
+                status
+            )));
+        }
+        validate_source_id(KnowledgeIdKind::Learning, &document_id, &yaml)?;
+        add_evidence(
+            ids,
+            KnowledgeIdKind::Learning,
+            document_id,
+            format!("learning-file:{status}"),
+        );
+    }
+    Ok(())
+}
+
+fn scan_allocation_rows(orbit_root: &Path, ids: &mut InventoryMap) -> Result<(), OrbitError> {
+    let database = orbit_root.join("state").join("semantic.db");
+    let Some(conn) = open_read_only_if_present(&database)? else {
+        return Ok(());
+    };
+    if !table_exists(&conn, "id_allocations").map_err(|error| {
+        OrbitError::Migration(format!("inspect {}: {error}", database.display()))
+    })? {
+        return Ok(());
+    }
+    let mut statement = conn
+        .prepare("SELECT kind, id, status FROM id_allocations ORDER BY kind, id")
+        .map_err(|error| {
+            OrbitError::Migration(format!("inspect {}: {error}", database.display()))
+        })?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .map_err(|error| OrbitError::Migration(format!("read {}: {error}", database.display())))?;
+    for row in rows {
+        let (kind, id, status) = row.map_err(|error| OrbitError::Migration(error.to_string()))?;
+        let kind = match kind.as_str() {
+            "adr" => KnowledgeIdKind::Adr,
+            "learning" => KnowledgeIdKind::Learning,
+            _ => {
+                return Err(OrbitError::Migration(format!(
+                    "{} contains unknown id_allocations kind '{}' for '{}'",
+                    database.display(),
+                    kind,
+                    id
+                )));
+            }
+        };
+        if !matches!(status.as_str(), "reserved" | "merged" | "abandoned") {
+            return Err(OrbitError::Migration(format!(
+                "{} contains unknown id_allocations status '{}' for '{}'",
+                database.display(),
+                status,
+                id
+            )));
+        }
+        validate_source_id(kind, &id, &database)?;
+        add_evidence(ids, kind, id, format!("allocation:{status}"));
+    }
+    Ok(())
+}
+
+fn request_identity(
+    request: &HubKnowledgeAllocationRequestV1,
+    context: &ToolSessionContext,
+) -> Result<HubKnowledgeRequestIdentityV1, OrbitError> {
+    let required = |label: &str, value: &Option<String>| {
+        value
+            .as_deref()
+            .filter(|value| !value.trim().is_empty() && value.trim() == *value)
+            .map(str::to_string)
+            .ok_or_else(|| {
+                OrbitError::InvalidInput(format!(
+                    "private hub knowledge allocation requires trusted {label}"
+                ))
+            })
+    };
+    if context.workspace_id.as_deref() != Some(request.workspace_id.as_str()) {
+        return Err(OrbitError::InvalidInput(
+            "private hub knowledge allocation workspace does not match trusted session context"
+                .to_string(),
+        ));
+    }
+    let transport = context.transport.ok_or_else(|| {
+        OrbitError::InvalidInput(
+            "private hub knowledge allocation requires trusted transport".to_string(),
+        )
+    })?;
+    if context.effective_capabilities.is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "private hub knowledge allocation requires trusted effective capabilities".to_string(),
+        ));
+    }
+    Ok(HubKnowledgeRequestIdentityV1 {
+        schema_version: HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION,
+        workspace_id: request.workspace_id.clone(),
+        kind: request.kind,
+        model: request.model.clone(),
+        caller_machine_id: required("caller_machine_id", &context.caller_machine_id)?,
+        caller_host_id: required("caller_host_id", &context.caller_host_id)?,
+        process_machine_id: required("process_machine_id", &context.process_machine_id)?,
+        process_host_id: required("process_host_id", &context.process_host_id)?,
+        transport,
+        effective_capabilities: context.effective_capabilities.clone(),
+        origin_session_id: required("origin_session_id", &context.origin_session_id)?,
+        mcp_call_id: required("mcp_call_id", &context.mcp_call_id)?,
+        leased_run: context.leased_run.clone(),
+    })
+}
+
+fn allocation_audit(
+    request: &HubKnowledgeAllocationRequestV1,
+    context: &ToolSessionContext,
+    identity: &HubKnowledgeRequestIdentityV1,
+) -> Result<AuditEventInsertParams, OrbitError> {
+    let (correlation, correlation_error) = trusted_mcp_audit_context(context);
+    if let Some(error) = correlation_error {
+        return Err(error);
+    }
+    let arguments_json = serde_json::to_string(&json!({
+        "schema_version": request.schema_version,
+        "kind": request.kind,
+        "model": request.model,
+    }))
+    .map_err(|error| OrbitError::Store(format!("serialize allocation audit: {error}")))?;
+    Ok(AuditEventInsertParams {
+        execution_id: audit_execution_id("audit-hub-knowledge-allocation"),
+        command: "id".to_string(),
+        subcommand: Some("allocate".to_string()),
+        tool_name: Some(HUB_KNOWLEDGE_ALLOCATION_METHOD_V1.to_string()),
+        target_type: Some("id_allocation".to_string()),
+        target_id: None,
+        role: audit_role_label_for_entry_point(
+            &Value::Null,
+            None,
+            request.model.as_deref(),
+            ToolEntryPoint::Mcp,
+        ),
+        status: AuditEventStatus::Success,
+        exit_code: 0,
+        duration_ms: 0,
+        working_directory: ".".to_string(),
+        arguments_json: Some(arguments_json),
+        stdout_truncated: None,
+        stderr_truncated: None,
+        error_message: None,
+        host: std::env::var("HOSTNAME").ok(),
+        pid: std::process::id(),
+        session_id: None,
+        workspace_id: Some(request.workspace_id.clone()),
+        caller_machine_id: Some(identity.caller_machine_id.clone()),
+        caller_host_id: Some(identity.caller_host_id.clone()),
+        process_machine_id: Some(identity.process_machine_id.clone()),
+        process_host_id: Some(identity.process_host_id.clone()),
+        transport: Some(identity.transport),
+        effective_capabilities: identity.effective_capabilities.clone(),
+        origin_session_id: Some(identity.origin_session_id.clone()),
+        mcp_call_id: Some(identity.mcp_call_id.clone()),
+        lease_id: identity.leased_run.as_ref().map(|run| run.lease_id.clone()),
+        task_id: correlation.task_id,
+        job_run_id: correlation.job_run_id,
+        activity_id: correlation.activity_id,
+        step_index: correlation.step_index,
+    })
+}
+
+fn open_read_only_if_present(path: &Path) -> Result<Option<Connection>, OrbitError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => {}
+        Ok(_) => {
+            return Err(OrbitError::Migration(format!(
+                "knowledge allocation source '{}' exists but is not a regular file",
+                path.display()
+            )));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(OrbitError::Migration(format!(
+                "inspect knowledge allocation source '{}': {error}",
+                path.display()
+            )));
+        }
+    }
+    Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map(Some)
+    .map_err(|error| OrbitError::Migration(format!("open {} read-only: {error}", path.display())))
+}
+
+fn table_exists(conn: &Connection, table: &str) -> Result<bool, OrbitError> {
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1)",
+        [table],
+        |row| row.get(0),
+    )
+    .map_err(|error| OrbitError::Migration(error.to_string()))
+}
+
+fn child_directories_if_present(root: &Path) -> Result<Vec<PathBuf>, OrbitError> {
+    if !root.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut directories = fs::read_dir(root)
+        .map_err(|error| OrbitError::Migration(format!("read {}: {error}", root.display())))?
+        .map(|entry| {
+            entry
+                .map_err(|error| OrbitError::Migration(error.to_string()))
+                .and_then(|entry| {
+                    entry
+                        .file_type()
+                        .map_err(|error| OrbitError::Migration(error.to_string()))
+                        .map(|kind| (entry.path(), kind))
+                })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    directories.retain(|(_, kind)| kind.is_dir());
+    let mut paths = directories
+        .into_iter()
+        .map(|(path, _)| path)
+        .collect::<Vec<_>>();
+    paths.sort();
+    Ok(paths)
+}
+
+fn file_name_utf8(path: &Path) -> Result<String, OrbitError> {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            OrbitError::Migration(format!("non-UTF-8 knowledge path '{}'", path.display()))
+        })
+}
+
+fn read_yaml(path: &Path) -> Result<Value, OrbitError> {
+    let raw = fs::read_to_string(path)
+        .map_err(|error| OrbitError::Migration(format!("read {}: {error}", path.display())))?;
+    serde_yaml::from_str(&raw)
+        .map_err(|error| OrbitError::Migration(format!("parse {}: {error}", path.display())))
+}
+
+fn yaml_id(path: &Path) -> Result<String, OrbitError> {
+    let value = read_yaml(path)?;
+    yaml_string(&value, "id", path)
+}
+
+fn yaml_string(value: &Value, key: &str, path: &Path) -> Result<String, OrbitError> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| {
+            OrbitError::Migration(format!("{}: missing string field '{key}'", path.display()))
+        })
+}
+
+fn validate_source_id(kind: KnowledgeIdKind, id: &str, source: &Path) -> Result<(), OrbitError> {
+    if kind.parse_id(id).is_none() {
+        return Err(OrbitError::Migration(format!(
+            "{} contains invalid {} id '{}'",
+            source.display(),
+            kind.as_str(),
+            id
+        )));
+    }
+    Ok(())
+}

--- a/crates/orbit-remote/src/lib.rs
+++ b/crates/orbit-remote/src/lib.rs
@@ -23,6 +23,7 @@
 
 pub mod host_identity;
 pub mod host_registry;
+pub mod knowledge;
 pub mod mcp;
 pub mod persistence;
 pub mod profile;
@@ -41,6 +42,7 @@ pub use host_identity::{
     load_host_identity, os_hostname, rename_current_host_identity,
 };
 pub use host_registry::{HostRegistryService, WorkspaceLink, require_local_hub_identity};
+pub use knowledge::{HubKnowledgeSequenceService, scan_registered_knowledge_inventories};
 pub use mcp::{
     canonical_mcp_tool_definitions, register_local_spoke, safe_mcp_tool_names, serve_mcp_stdio,
 };

--- a/crates/orbit-remote/src/mcp/contract.rs
+++ b/crates/orbit-remote/src/mcp/contract.rs
@@ -10,10 +10,10 @@ use sha2::{Digest, Sha256};
 
 use super::schema::remote_input_schema;
 
-/// Revision 2 adds the strict connector-private spoke-registration method.
-/// Bumping this fact prevents an E3 client from negotiating successfully with
-/// an E2 hub that has the same canonical tool schemas but no bootstrap seam.
-pub const MCP_CONTRACT_REVISION: u32 = 2;
+/// Revision 3 adds the strict connector-private hub knowledge-ID allocator.
+/// Bumping this fact prevents a newer client from negotiating successfully
+/// with a hub that has the same canonical tool schemas but no allocation seam.
+pub const MCP_CONTRACT_REVISION: u32 = 3;
 pub const CANONICAL_MCP_REGISTRY_REVISION: u32 = 1;
 pub const HUB_SCHEMA_DOMAIN: &str = "orbit.mcp.hub-schema.v1";
 pub const HUB_CONTRACT_INSTRUCTIONS_PREFIX: &str = "orbit-hub-contract-v1:";

--- a/crates/orbit-remote/src/mcp/hub.rs
+++ b/crates/orbit-remote/src/mcp/hub.rs
@@ -4,8 +4,9 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use orbit_common::types::{
-    AuditEventStatus, HostRecord, HostStatus, McpCapability, McpToolDefinition, McpToolPlacement,
-    McpToolScope, McpTransport, RegistrySnapshotV1, SPOKE_REGISTRATION_METHOD_V1,
+    AuditEventStatus, HUB_KNOWLEDGE_ALLOCATION_METHOD_V1, HostRecord, HostStatus,
+    HubKnowledgeAllocationRequestV1, HubKnowledgeAllocationV1, McpCapability, McpToolDefinition,
+    McpToolPlacement, McpToolScope, McpTransport, RegistrySnapshotV1, SPOKE_REGISTRATION_METHOD_V1,
     SpokeRegistrationRequestV1, SpokeRegistrationResultV1, SpokeRegistrationStageV1,
     ToolSessionContext, WorkspaceStatus, mcp_advertised_tool_name,
 };
@@ -95,6 +96,55 @@ impl HubMcpHost {
         };
         self.record_outcome(SPOKE_REGISTRATION_METHOD_V1, &context, &audit_result);
         Ok(result)
+    }
+
+    pub(super) fn private_allocate_knowledge_id(
+        &self,
+        request: HubKnowledgeAllocationRequestV1,
+        session_context: ToolSessionContext,
+    ) -> Result<HubKnowledgeAllocationV1, OrbitError> {
+        let (identity, snapshot) = match self.verify_authority() {
+            Ok(authority) => authority,
+            Err(error) => {
+                let context = self.normalize_context(session_context, &self.identity);
+                self.record_denial(HUB_KNOWLEDGE_ALLOCATION_METHOD_V1, &context, &error);
+                return Err(error);
+            }
+        };
+        let context = self.normalize_context(session_context, &identity);
+        let result = (|| {
+            Self::require_active_remote_caller(&context, &snapshot)?;
+            if !matches!(
+                self.capability,
+                McpCapability::Agent | McpCapability::Operator
+            ) {
+                return Err(OrbitError::InvalidInput(
+                    "private hub knowledge allocation requires agent or operator capability"
+                        .to_string(),
+                ));
+            }
+            request.validate()?;
+            let workspace_id = self.resolve_workspace(&request.workspace_id)?;
+            if context.workspace_id.as_deref() != Some(workspace_id.as_str())
+                || context
+                    .workspace
+                    .as_deref()
+                    .is_some_and(|selector| selector != workspace_id)
+            {
+                return Err(OrbitError::InvalidInput(
+                    "private hub knowledge allocation workspace must exactly match the trusted session context"
+                        .to_string(),
+                ));
+            }
+            crate::HubKnowledgeSequenceService::at(&self.global_root)?.allocate(&request, &context)
+        })();
+        if let Err(error) = &result {
+            self.record_denial(HUB_KNOWLEDGE_ALLOCATION_METHOD_V1, &context, error);
+        }
+        // Successful allocation writes its canonical audit row inside the
+        // same SQLite transaction as sequence, occupancy, and ledger state.
+        // Deliberately do not call `record_outcome` here.
+        result
     }
 
     fn verify_authority(&self) -> Result<(HostIdentity, RegistrySnapshotV1), OrbitError> {

--- a/crates/orbit-remote/src/mcp/hub_client.rs
+++ b/crates/orbit-remote/src/mcp/hub_client.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use orbit_common::types::{
+    HUB_KNOWLEDGE_ALLOCATION_METHOD_V1, HubKnowledgeAllocationRequestV1, HubKnowledgeAllocationV1,
     McpCapability, McpTransport, OrbitError, SPOKE_REGISTRATION_METHOD_V1,
     SpokeRegistrationRequestV1, SpokeRegistrationResultV1, ToolSessionContext,
 };
@@ -219,6 +220,103 @@ impl OrbitMcpClient {
                 ),
             })?;
         Ok(result)
+    }
+
+    /// Execute the connector-private hub knowledge allocation exactly once.
+    ///
+    /// The caller retains `mcp_call_id` on every post-handoff failure and must
+    /// use the allocation lookup seam to resolve an outcome-unknown response;
+    /// this client never replays the request automatically.
+    pub(super) async fn allocate_knowledge_id(
+        &self,
+        request: &HubKnowledgeAllocationRequestV1,
+        context: &ToolSessionContext,
+        request_timeout: Duration,
+    ) -> Result<HubKnowledgeAllocationV1, OrbitError> {
+        request.validate()?;
+        validate_remote_call_context(context, self.contract.effective_capability)?;
+        if context.workspace_id.as_deref() != Some(request.workspace_id.as_str()) {
+            return Err(OrbitError::InvalidInput(
+                "private hub knowledge allocation workspace must exactly match the trusted remote context"
+                    .to_string(),
+            ));
+        }
+        let mcp_call_id = context
+            .mcp_call_id
+            .as_deref()
+            .ok_or_else(|| OrbitError::InvalidInput("remote MCP call requires mcp_call_id".into()))?
+            .to_string();
+        let params = serde_json::to_value(request).map_err(|error| {
+            OrbitError::InvalidInput(format!(
+                "serialize private hub knowledge allocation request: {error}"
+            ))
+        })?;
+        let mut meta = Map::new();
+        meta.insert(
+            "orbit".to_string(),
+            json!({ REMOTE_SESSION_META_KEY: context }),
+        );
+        let response = self
+            .raw
+            .custom_request(
+                HUB_KNOWLEDGE_ALLOCATION_METHOD_V1,
+                Some(params),
+                meta,
+                request_timeout,
+            )
+            .await
+            .map_err(|error| match error {
+                McpClientRequestError::PreHandoff { message } => {
+                    OrbitError::HubUnavailable(format!(
+                        "hub allocation request was not handed to the initialized peer: {message}"
+                    ))
+                }
+                McpClientRequestError::Protocol { code, .. }
+                    if code == JSON_RPC_METHOD_NOT_FOUND =>
+                {
+                    OrbitError::HubNegotiation(format!(
+                        "verified hub does not implement {HUB_KNOWLEDGE_ALLOCATION_METHOD_V1}"
+                    ))
+                }
+                McpClientRequestError::Protocol {
+                    code,
+                    message,
+                    data,
+                } if code == JSON_RPC_INVALID_PARAMS => OrbitError::RemoteTool {
+                    code: "invalid_input".to_string(),
+                    message,
+                    payload: data.unwrap_or(Value::Null),
+                },
+                McpClientRequestError::UnexpectedResponse { .. } => OrbitError::OutcomeUnknown {
+                    mcp_call_id: mcp_call_id.clone(),
+                    message: "hub returned a non-allocation result after request handoff"
+                        .to_string(),
+                },
+                error => OrbitError::OutcomeUnknown {
+                    mcp_call_id: mcp_call_id.clone(),
+                    message: format!(
+                        "hub allocation response failed after request handoff: {error}"
+                    ),
+                },
+            })?;
+        let allocation =
+            serde_json::from_value::<HubKnowledgeAllocationV1>(response).map_err(|error| {
+                OrbitError::OutcomeUnknown {
+                    mcp_call_id: mcp_call_id.clone(),
+                    message: format!(
+                        "hub returned a malformed allocation result after request handoff: {error}"
+                    ),
+                }
+            })?;
+        allocation
+            .validate()
+            .map_err(|error| OrbitError::OutcomeUnknown {
+                mcp_call_id,
+                message: format!(
+                    "hub returned an invalid allocation result after request handoff: {error}"
+                ),
+            })?;
+        Ok(allocation)
     }
 
     pub(super) async fn close(&mut self, timeout: Duration) -> Result<(), OrbitError> {

--- a/crates/orbit-remote/src/mcp/hub_link.rs
+++ b/crates/orbit-remote/src/mcp/hub_link.rs
@@ -9,8 +9,8 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use orbit_common::types::{
-    McpCapability, OrbitError, SpokeRegistrationRequestV1, SpokeRegistrationResultV1,
-    ToolSessionContext,
+    HubKnowledgeAllocationRequestV1, HubKnowledgeAllocationV1, McpCapability, OrbitError,
+    SpokeRegistrationRequestV1, SpokeRegistrationResultV1, ToolSessionContext,
 };
 use orbit_common::utility::redaction::redact_sensitive_env_text;
 use serde_json::Value;
@@ -109,6 +109,17 @@ pub(super) trait HubPeer: Send {
         request: &'a SpokeRegistrationRequestV1,
         context: &'a ToolSessionContext,
     ) -> BoxFuture<'a, Result<SpokeRegistrationResultV1, OrbitError>>;
+    fn allocate_knowledge_id<'a>(
+        &'a mut self,
+        _request: &'a HubKnowledgeAllocationRequestV1,
+        _context: &'a ToolSessionContext,
+    ) -> BoxFuture<'a, Result<HubKnowledgeAllocationV1, OrbitError>> {
+        Box::pin(async {
+            Err(OrbitError::HubNegotiation(
+                "hub peer does not implement private knowledge allocation".to_string(),
+            ))
+        })
+    }
     fn close<'a>(&'a mut self) -> BoxFuture<'a, ()>;
 }
 
@@ -243,6 +254,30 @@ impl HubPeer for SshHubPeer {
         })
     }
 
+    fn allocate_knowledge_id<'a>(
+        &'a mut self,
+        request: &'a HubKnowledgeAllocationRequestV1,
+        context: &'a ToolSessionContext,
+    ) -> BoxFuture<'a, Result<HubKnowledgeAllocationV1, OrbitError>> {
+        Box::pin(async move {
+            if self
+                .child
+                .try_wait()
+                .map_err(|error| {
+                    OrbitError::HubUnavailable(format!("inspect SSH hub process: {error}"))
+                })?
+                .is_some()
+            {
+                return Err(OrbitError::HubUnavailable(
+                    "SSH hub process exited before allocation handoff".to_string(),
+                ));
+            }
+            self.client
+                .allocate_knowledge_id(request, context, self.request_timeout)
+                .await
+        })
+    }
+
     fn close<'a>(&'a mut self) -> BoxFuture<'a, ()> {
         Box::pin(async move {
             let _ = self.client.close(self.close_timeout).await;
@@ -273,9 +308,20 @@ pub(super) struct RegistrationRequest {
     response: mpsc::SyncSender<Result<SpokeRegistrationResultV1, OrbitError>>,
 }
 
+pub(super) struct KnowledgeAllocationRequest {
+    capability: McpCapability,
+    request: HubKnowledgeAllocationRequestV1,
+    context: ToolSessionContext,
+    response: mpsc::SyncSender<Result<HubKnowledgeAllocationV1, OrbitError>>,
+}
+
 pub(super) enum WorkerMessage {
     Call(CallRequest),
     Register(RegistrationRequest),
+    // Dormant until the F3 caller-path cutover; F1 freezes and tests the
+    // connector-private seam without routing ordinary agent tools through it.
+    #[allow(dead_code)]
+    Allocate(KnowledgeAllocationRequest),
     Shutdown,
 }
 
@@ -436,6 +482,53 @@ impl HubLinkPool {
                 message: format!("hub link worker disconnected after queue handoff: {error}"),
             })?
     }
+
+    #[allow(dead_code)]
+    pub(super) fn allocate_knowledge_id(
+        &self,
+        capability: McpCapability,
+        request: HubKnowledgeAllocationRequestV1,
+        context: ToolSessionContext,
+    ) -> Result<HubKnowledgeAllocationV1, OrbitError> {
+        request.validate()?;
+        validate_remote_call_context(&context, capability)?;
+        if context.workspace_id.as_deref() != Some(request.workspace_id.as_str()) {
+            return Err(OrbitError::InvalidInput(
+                "private hub knowledge allocation workspace must exactly match the trusted remote context"
+                    .to_string(),
+            ));
+        }
+        let mcp_call_id = context
+            .mcp_call_id
+            .clone()
+            .ok_or_else(|| OrbitError::InvalidInput("remote call ID is missing".to_string()))?;
+        let (response_tx, response_rx) = mpsc::sync_channel(1);
+        self.tx
+            .as_ref()
+            .ok_or_else(|| {
+                OrbitError::HubUnavailable("hub link pool is shutting down".to_string())
+            })?
+            .try_send(WorkerMessage::Allocate(KnowledgeAllocationRequest {
+                capability,
+                request,
+                context,
+                response: response_tx,
+            }))
+            .map_err(|error| match error {
+                mpsc::TrySendError::Full(_) => OrbitError::HubUnavailable(
+                    "hub link request queue is saturated before handoff".to_string(),
+                ),
+                mpsc::TrySendError::Disconnected(_) => OrbitError::HubUnavailable(
+                    "hub link worker is unavailable before handoff".to_string(),
+                ),
+            })?;
+        response_rx
+            .recv()
+            .map_err(|error| OrbitError::OutcomeUnknown {
+                mcp_call_id,
+                message: format!("hub link worker disconnected after queue handoff: {error}"),
+            })?
+    }
 }
 
 impl Drop for HubLinkPool {
@@ -497,6 +590,10 @@ fn run_worker(
             }
             WorkerMessage::Register(request) => {
                 let result = runtime.block_on(process_registration(&mut peers, &worker, &request));
+                let _ = request.response.send(result);
+            }
+            WorkerMessage::Allocate(request) => {
+                let result = runtime.block_on(process_allocation(&mut peers, &worker, &request));
                 let _ = request.response.send(result);
             }
         }
@@ -570,6 +667,45 @@ async fn process_registration(
             mcp_call_id: request.context.mcp_call_id.clone().unwrap_or_default(),
             message: format!(
                 "hub registration response exceeded the {} ms post-handoff deadline",
+                worker.limits.request.as_millis()
+            ),
+        }),
+    };
+    cached.last_used = worker.clock.now();
+    if matches!(
+        result,
+        Err(OrbitError::HubUnavailable(_)) | Err(OrbitError::OutcomeUnknown { .. })
+    ) && let Some(mut failed) = peers.remove(&request.capability)
+    {
+        failed.peer.close().await;
+    }
+    result
+}
+
+async fn process_allocation(
+    peers: &mut BTreeMap<McpCapability, CachedPeer>,
+    worker: &WorkerRuntime<'_>,
+    request: &KnowledgeAllocationRequest,
+) -> Result<HubKnowledgeAllocationV1, OrbitError> {
+    let now = worker.clock.now();
+    reap_idle(peers, now, worker.limits.idle).await;
+    ensure_peer(peers, worker, request.capability).await?;
+    let cached = peers
+        .get_mut(&request.capability)
+        .ok_or_else(|| OrbitError::HubUnavailable("hub peer disappeared".to_string()))?;
+    let result = match tokio::time::timeout(
+        worker.limits.request,
+        cached
+            .peer
+            .allocate_knowledge_id(&request.request, &request.context),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => Err(OrbitError::OutcomeUnknown {
+            mcp_call_id: request.context.mcp_call_id.clone().unwrap_or_default(),
+            message: format!(
+                "hub allocation response exceeded the {} ms post-handoff deadline",
                 worker.limits.request.as_millis()
             ),
         }),

--- a/crates/orbit-remote/src/mcp/mod.rs
+++ b/crates/orbit-remote/src/mcp/mod.rs
@@ -36,7 +36,7 @@ use self::hub::HubMcpHost;
 use self::hub_link::HubLinkPool;
 use self::learning::{LearningSidecarDecorator, LearningSidecarHost};
 use self::schema::RemoteInputSchemaResolver;
-use self::transport::{RemoteCallContextResolver, SpokeRegistrationHandler};
+use self::transport::{PrivateHubRequestHandler, RemoteCallContextResolver};
 
 pub use self::host::{canonical_mcp_tool_definitions, safe_mcp_tool_names};
 pub use self::registration::register_local_spoke;
@@ -150,6 +150,6 @@ fn hub_server_composition(host: Arc<HubMcpHost>) -> McpServerComposition {
         .with_result_decorator(learning)
         .with_call_context_resolver(Arc::new(RemoteCallContextResolver))
         .with_input_schema_resolver(Arc::new(RemoteInputSchemaResolver))
-        .with_custom_request_handler(Arc::new(SpokeRegistrationHandler::new(Arc::clone(&host))))
+        .with_custom_request_handler(Arc::new(PrivateHubRequestHandler::new(Arc::clone(&host))))
         .with_metadata(McpServerMetadata::default().with_instructions(host.private_instructions()))
 }

--- a/crates/orbit-remote/src/mcp/tests/knowledge_allocation.rs
+++ b/crates/orbit-remote/src/mcp/tests/knowledge_allocation.rs
@@ -1,0 +1,588 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use chrono::Utc;
+use orbit_common::types::{
+    HUB_KNOWLEDGE_ALLOCATION_METHOD_V1, HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION,
+    HubKnowledgeAllocationRequestV1, HubKnowledgeAllocationV1, KnowledgeIdKind, McpCapability,
+    McpTransport, OrbitError, SpokeRegistrationRequestV1, SpokeRegistrationResultV1,
+    ToolSessionContext, Workspace, WorkspaceRegistry, WorkspaceStatus,
+};
+use orbit_mcp::{McpCustomRequestError, McpCustomRequestHandler, McpHost, OrbitToolServer};
+use rmcp::ServiceExt;
+use serde_json::json;
+
+use crate::persistence::KnowledgeWorkspaceInventory;
+use crate::{
+    HOST_IDENTITY_SCHEMA_VERSION, HostIdentity, HostMode, HubKnowledgeSequenceService,
+    load_host_identity,
+};
+
+use super::super::contract::hub_schema_digest;
+use super::super::host::canonical_mcp_tool_definitions;
+use super::super::hub::HubMcpHost;
+use super::super::hub_client::OrbitMcpClient;
+use super::super::hub_link::{
+    BoxFuture, HubClock, HubLinkLimits, HubLinkPool, HubPeer, HubPeerFactory, HubSpawnSpec,
+    MonotonicClock,
+};
+use super::super::hub_server_composition;
+use super::super::transport::PrivateHubRequestHandler;
+
+fn write_identity(root: &Path, mode: &str, machine_id: &str, host_id: &str) {
+    std::fs::write(
+        root.join("host.toml"),
+        format!(
+            "schema_version = 1\nmachine_id = \"{machine_id}\"\nhost_id = \"{host_id}\"\nmode = \"{mode}\"\n"
+        ),
+    )
+    .expect("host identity");
+}
+
+fn setup_hub(root: &Path) {
+    write_identity(root, "hub", "hm_hub", "hub");
+    let identity = load_host_identity(root).expect("hub identity");
+    let registry = crate::host_registry_service_at(root).expect("registry service");
+    registry
+        .register_hub_identity(&identity, BTreeSet::new())
+        .expect("register hub");
+    registry
+        .register_identity(
+            &HostIdentity {
+                schema_version: HOST_IDENTITY_SCHEMA_VERSION,
+                machine_id: "hm_spoke".to_string(),
+                host_id: "spoke".to_string(),
+                mode: HostMode::Spoke,
+            },
+            BTreeSet::new(),
+        )
+        .expect("register spoke");
+    crate::workspace_registry::save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: ["ws_alpha", "ws_beta"]
+                .into_iter()
+                .map(|workspace_id| Workspace {
+                    id: workspace_id.to_string(),
+                    name: workspace_id.to_string(),
+                    owner_machine_id: Some("hm_spoke".to_string()),
+                    git_remote: None,
+                    ship_mode: None,
+                    base_branch: "agent-main".to_string(),
+                    status: WorkspaceStatus::Active,
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                })
+                .collect(),
+            ..WorkspaceRegistry::default()
+        },
+        &crate::workspace_registry::registry_path_for(root),
+    )
+    .expect("workspace registry");
+    HubKnowledgeSequenceService::at(root)
+        .expect("allocator service")
+        .activate(
+            ["ws_alpha", "ws_beta"]
+                .into_iter()
+                .map(|workspace_id| KnowledgeWorkspaceInventory {
+                    workspace_id: workspace_id.to_string(),
+                    ids: Vec::new(),
+                })
+                .collect(),
+        )
+        .expect("activate allocator");
+}
+
+fn request(workspace_id: &str, kind: KnowledgeIdKind) -> HubKnowledgeAllocationRequestV1 {
+    HubKnowledgeAllocationRequestV1 {
+        schema_version: HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION,
+        workspace_id: workspace_id.to_string(),
+        kind,
+        model: Some("gpt-test".to_string()),
+    }
+}
+
+fn context(workspace_id: &str, call_id: &str) -> ToolSessionContext {
+    ToolSessionContext {
+        workspace: Some(workspace_id.to_string()),
+        workspace_id: Some(workspace_id.to_string()),
+        caller_machine_id: Some("hm_spoke".to_string()),
+        caller_host_id: Some("spoke".to_string()),
+        process_machine_id: None,
+        process_host_id: None,
+        transport: Some(McpTransport::SshMcp),
+        effective_capabilities: BTreeSet::from([McpCapability::Agent]),
+        origin_session_id: Some("spoke-session".to_string()),
+        mcp_call_id: Some(call_id.to_string()),
+        leased_run: None,
+    }
+}
+
+fn schema_digests() -> BTreeMap<McpCapability, String> {
+    let definitions = canonical_mcp_tool_definitions().expect("definitions");
+    BTreeMap::from([(
+        McpCapability::Agent,
+        hub_schema_digest(&definitions, McpCapability::Agent).expect("schema digest"),
+    )])
+}
+
+fn limits() -> HubLinkLimits {
+    HubLinkLimits {
+        queue_capacity: 4,
+        initialize: Duration::from_secs(3),
+        request: Duration::from_secs(3),
+        idle: Duration::from_secs(30),
+        idle_poll: Duration::from_millis(10),
+        close: Duration::from_secs(1),
+    }
+}
+
+fn snapshot_files(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+    fn visit(root: &Path, directory: &Path, files: &mut BTreeMap<PathBuf, Vec<u8>>) {
+        let mut entries = std::fs::read_dir(directory)
+            .expect("snapshot directory")
+            .map(|entry| entry.expect("snapshot entry"))
+            .collect::<Vec<_>>();
+        entries.sort_by_key(|entry| entry.path());
+        for entry in entries {
+            let path = entry.path();
+            let kind = entry.file_type().expect("file type");
+            if kind.is_dir() {
+                visit(root, &path, files);
+            } else if kind.is_file() {
+                files.insert(
+                    path.strip_prefix(root)
+                        .expect("relative path")
+                        .to_path_buf(),
+                    std::fs::read(path).expect("file bytes"),
+                );
+            }
+        }
+    }
+    let mut files = BTreeMap::new();
+    visit(root, root, &mut files);
+    files
+}
+
+struct WireFactory {
+    hub_root: PathBuf,
+    allocations: Arc<Mutex<Vec<(HubKnowledgeAllocationRequestV1, ToolSessionContext)>>>,
+}
+
+impl HubPeerFactory for WireFactory {
+    fn connect<'a>(
+        &'a self,
+        spec: &'a HubSpawnSpec,
+        limits: HubLinkLimits,
+    ) -> BoxFuture<'a, Result<Box<dyn HubPeer>, OrbitError>> {
+        let hub_root = self.hub_root.clone();
+        let spec = spec.clone();
+        let allocations = Arc::clone(&self.allocations);
+        Box::pin(async move {
+            let host = Arc::new(HubMcpHost::new(hub_root, spec.capability)?);
+            let mut trusted = ToolSessionContext::trusted_local(
+                None,
+                Some(host.identity().machine_id.clone()),
+                Some(host.identity().host_id.clone()),
+            );
+            trusted.effective_capabilities = BTreeSet::from([spec.capability]);
+            let server = OrbitToolServer::new_with_context_and_composition(
+                Arc::clone(&host) as Arc<dyn McpHost>,
+                trusted,
+                hub_server_composition(host),
+            );
+            let (server_io, client_io) = tokio::io::duplex(256 * 1024);
+            let server_task = tokio::spawn(async move {
+                if let Ok(running) = server.serve(server_io).await {
+                    let _ = running.waiting().await;
+                }
+            });
+            let (read, write) = tokio::io::split(client_io);
+            let client =
+                OrbitMcpClient::connect(read, write, &spec.expectation(), limits.initialize)
+                    .await?;
+            Ok(Box::new(WirePeer {
+                client,
+                server_task,
+                allocations,
+                request_timeout: limits.request,
+                close_timeout: limits.close,
+            }) as Box<dyn HubPeer>)
+        })
+    }
+}
+
+struct WirePeer {
+    client: OrbitMcpClient,
+    server_task: tokio::task::JoinHandle<()>,
+    allocations: Arc<Mutex<Vec<(HubKnowledgeAllocationRequestV1, ToolSessionContext)>>>,
+    request_timeout: Duration,
+    close_timeout: Duration,
+}
+
+impl HubPeer for WirePeer {
+    fn is_closed(&self) -> bool {
+        self.client.is_closed()
+    }
+
+    fn call<'a>(
+        &'a mut self,
+        _name: &'a str,
+        _input: serde_json::Value,
+        _context: &'a ToolSessionContext,
+    ) -> BoxFuture<'a, Result<serde_json::Value, OrbitError>> {
+        Box::pin(async { Err(OrbitError::InvalidInput("unexpected tool call".to_string())) })
+    }
+
+    fn register_spoke<'a>(
+        &'a mut self,
+        _request: &'a SpokeRegistrationRequestV1,
+        _context: &'a ToolSessionContext,
+    ) -> BoxFuture<'a, Result<SpokeRegistrationResultV1, OrbitError>> {
+        Box::pin(async {
+            Err(OrbitError::InvalidInput(
+                "unexpected registration".to_string(),
+            ))
+        })
+    }
+
+    fn allocate_knowledge_id<'a>(
+        &'a mut self,
+        request: &'a HubKnowledgeAllocationRequestV1,
+        context: &'a ToolSessionContext,
+    ) -> BoxFuture<'a, Result<HubKnowledgeAllocationV1, OrbitError>> {
+        self.allocations
+            .lock()
+            .expect("allocations")
+            .push((request.clone(), context.clone()));
+        Box::pin(async move {
+            self.client
+                .allocate_knowledge_id(request, context, self.request_timeout)
+                .await
+        })
+    }
+
+    fn close<'a>(&'a mut self) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            let _ = self.client.close(self.close_timeout).await;
+            self.server_task.abort();
+        })
+    }
+}
+
+struct CommitThenLoseFactory {
+    hub_root: PathBuf,
+    calls: Arc<Mutex<usize>>,
+}
+
+impl HubPeerFactory for CommitThenLoseFactory {
+    fn connect<'a>(
+        &'a self,
+        spec: &'a HubSpawnSpec,
+        _limits: HubLinkLimits,
+    ) -> BoxFuture<'a, Result<Box<dyn HubPeer>, OrbitError>> {
+        let host = HubMcpHost::new(self.hub_root.clone(), spec.capability);
+        let calls = Arc::clone(&self.calls);
+        Box::pin(async move {
+            Ok(Box::new(CommitThenLosePeer { host: host?, calls }) as Box<dyn HubPeer>)
+        })
+    }
+}
+
+struct CommitThenLosePeer {
+    host: HubMcpHost,
+    calls: Arc<Mutex<usize>>,
+}
+
+impl HubPeer for CommitThenLosePeer {
+    fn is_closed(&self) -> bool {
+        false
+    }
+
+    fn call<'a>(
+        &'a mut self,
+        _name: &'a str,
+        _input: serde_json::Value,
+        _context: &'a ToolSessionContext,
+    ) -> BoxFuture<'a, Result<serde_json::Value, OrbitError>> {
+        Box::pin(async { Err(OrbitError::InvalidInput("unexpected tool call".to_string())) })
+    }
+
+    fn register_spoke<'a>(
+        &'a mut self,
+        _request: &'a SpokeRegistrationRequestV1,
+        _context: &'a ToolSessionContext,
+    ) -> BoxFuture<'a, Result<SpokeRegistrationResultV1, OrbitError>> {
+        Box::pin(async {
+            Err(OrbitError::InvalidInput(
+                "unexpected registration".to_string(),
+            ))
+        })
+    }
+
+    fn allocate_knowledge_id<'a>(
+        &'a mut self,
+        request: &'a HubKnowledgeAllocationRequestV1,
+        context: &'a ToolSessionContext,
+    ) -> BoxFuture<'a, Result<HubKnowledgeAllocationV1, OrbitError>> {
+        *self.calls.lock().expect("call count") += 1;
+        let committed = self
+            .host
+            .private_allocate_knowledge_id(request.clone(), context.clone());
+        let call_id = context.mcp_call_id.clone().unwrap_or_default();
+        Box::pin(async move {
+            committed?;
+            Err(OrbitError::OutcomeUnknown {
+                mcp_call_id: call_id,
+                message: "injected response loss after commit".to_string(),
+            })
+        })
+    }
+
+    fn close<'a>(&'a mut self) -> BoxFuture<'a, ()> {
+        Box::pin(async {})
+    }
+}
+
+#[test]
+fn connector_private_two_root_allocation_is_path_free_checkoutless_and_not_advertised() {
+    let hub_root = tempfile::tempdir().expect("hub root");
+    let spoke_root = tempfile::tempdir().expect("spoke root");
+    setup_hub(hub_root.path());
+    write_identity(spoke_root.path(), "spoke", "hm_spoke", "spoke");
+    std::fs::write(spoke_root.path().join("marker"), b"unchanged").expect("spoke marker");
+    let spoke_before = snapshot_files(spoke_root.path());
+    let allocations = Arc::new(Mutex::new(Vec::new()));
+    let pool = HubLinkPool::with_factory(
+        "hub-alias".to_string(),
+        "hm_hub".to_string(),
+        schema_digests(),
+        Arc::new(WireFactory {
+            hub_root: hub_root.path().to_path_buf(),
+            allocations: Arc::clone(&allocations),
+        }),
+        limits(),
+        Arc::new(MonotonicClock::default()) as Arc<dyn HubClock>,
+    )
+    .expect("link pool");
+    let alpha = pool
+        .allocate_knowledge_id(
+            McpCapability::Agent,
+            request("ws_alpha", KnowledgeIdKind::Adr),
+            context("ws_alpha", "mcall-wire-alpha"),
+        )
+        .expect("alpha wire allocation");
+    let beta = pool
+        .allocate_knowledge_id(
+            McpCapability::Agent,
+            request("ws_beta", KnowledgeIdKind::Adr),
+            context("ws_beta", "mcall-wire-beta"),
+        )
+        .expect("beta wire allocation");
+    assert_eq!(alpha.id, "ADR-0001");
+    assert_eq!(beta.id, "ADR-0002");
+    drop(pool);
+    assert_eq!(snapshot_files(spoke_root.path()), spoke_before);
+    let captured = allocations.lock().expect("allocations");
+    assert_eq!(captured.len(), 2, "connector replayed allocation");
+    assert_eq!(captured[0].0.workspace_id, "ws_alpha");
+    assert_eq!(captured[1].0.workspace_id, "ws_beta");
+    let encoded = serde_json::to_value(&captured[0].0).expect("request json");
+    assert_eq!(
+        encoded
+            .as_object()
+            .expect("request object")
+            .keys()
+            .cloned()
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([
+            "kind".to_string(),
+            "model".to_string(),
+            "schema_version".to_string(),
+            "workspace_id".to_string(),
+        ])
+    );
+    assert!(
+        !encoded
+            .to_string()
+            .contains(hub_root.path().to_string_lossy().as_ref())
+    );
+    assert!(
+        !encoded
+            .to_string()
+            .contains(spoke_root.path().to_string_lossy().as_ref())
+    );
+    let encoded_result = serde_json::to_value(&alpha).expect("allocation result json");
+    assert_eq!(
+        encoded_result
+            .as_object()
+            .expect("allocation result object")
+            .keys()
+            .cloned()
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([
+            "allocated_at".to_string(),
+            "id".to_string(),
+            "kind".to_string(),
+            "mcp_call_id".to_string(),
+            "schema_version".to_string(),
+            "sequence".to_string(),
+            "workspace_id".to_string(),
+        ])
+    );
+    assert!(
+        !encoded_result
+            .to_string()
+            .contains(hub_root.path().to_string_lossy().as_ref())
+    );
+    assert!(
+        !encoded_result
+            .to_string()
+            .contains(spoke_root.path().to_string_lossy().as_ref())
+    );
+
+    let hub =
+        HubMcpHost::new(hub_root.path().to_path_buf(), McpCapability::Agent).expect("hub host");
+    let names = hub
+        .list_mcp_tool_definitions()
+        .expect("hub definitions")
+        .into_iter()
+        .map(|definition| definition.schema.name)
+        .collect::<BTreeSet<_>>();
+    assert!(!names.contains(HUB_KNOWLEDGE_ALLOCATION_METHOD_V1));
+    assert!(!names.contains("orbit.knowledge.allocation.lookup"));
+}
+
+#[test]
+fn outcome_unknown_is_not_replayed_and_is_resolved_by_internal_lookup() {
+    let hub_root = tempfile::tempdir().expect("hub root");
+    setup_hub(hub_root.path());
+    let calls = Arc::new(Mutex::new(0));
+    let pool = HubLinkPool::with_factory(
+        "hub-alias".to_string(),
+        "hm_hub".to_string(),
+        schema_digests(),
+        Arc::new(CommitThenLoseFactory {
+            hub_root: hub_root.path().to_path_buf(),
+            calls: Arc::clone(&calls),
+        }),
+        limits(),
+        Arc::new(MonotonicClock::default()) as Arc<dyn HubClock>,
+    )
+    .expect("link pool");
+    let error = pool
+        .allocate_knowledge_id(
+            McpCapability::Agent,
+            request("ws_alpha", KnowledgeIdKind::Learning),
+            context("ws_alpha", "mcall-lost-allocation"),
+        )
+        .expect_err("response loss")
+        .to_string();
+    assert!(error.contains("outcome unknown"), "{error}");
+    assert_eq!(*calls.lock().expect("calls"), 1, "link replayed request");
+    drop(pool);
+
+    let allocation = HubKnowledgeSequenceService::at(hub_root.path())
+        .expect("service")
+        .allocation_by_call("mcall-lost-allocation")
+        .expect("lookup")
+        .expect("committed allocation");
+    assert_eq!(allocation.id, "L-0001");
+}
+
+#[test]
+fn runner_private_allocation_is_denied_before_sequence_mutation() {
+    let hub_root = tempfile::tempdir().expect("hub root");
+    setup_hub(hub_root.path());
+    let hub = HubMcpHost::new(hub_root.path().to_path_buf(), McpCapability::Runner)
+        .expect("runner hub host");
+    let mut runner_context = context("ws_alpha", "mcall-runner-denied");
+    runner_context.effective_capabilities = BTreeSet::from([McpCapability::Runner]);
+    let error = hub
+        .private_allocate_knowledge_id(request("ws_alpha", KnowledgeIdKind::Adr), runner_context)
+        .expect_err("runner allocation must fail")
+        .to_string();
+    assert!(error.contains("agent or operator"), "{error}");
+    let state = crate::remote_store_at(hub_root.path())
+        .expect("store")
+        .knowledge_allocator_state()
+        .expect("state");
+    assert_eq!(state.adr_next_sequence, 1);
+    assert!(
+        HubKnowledgeSequenceService::at(hub_root.path())
+            .expect("service")
+            .allocation_by_call("mcall-runner-denied")
+            .expect("lookup")
+            .is_none()
+    );
+}
+
+#[test]
+fn multiple_effective_capabilities_are_denied_before_sequence_mutation() {
+    let hub_root = tempfile::tempdir().expect("hub root");
+    setup_hub(hub_root.path());
+    let service = HubKnowledgeSequenceService::at(hub_root.path()).expect("service");
+    let mut ambiguous_context = context("ws_alpha", "mcall-ambiguous-capability");
+    ambiguous_context.effective_capabilities =
+        BTreeSet::from([McpCapability::Agent, McpCapability::Operator]);
+    let error = service
+        .allocate(
+            &request("ws_alpha", KnowledgeIdKind::Adr),
+            &ambiguous_context,
+        )
+        .expect_err("multi-capability allocation must fail")
+        .to_string();
+    assert!(error.contains("exactly one"), "{error}");
+    let state = crate::remote_store_at(hub_root.path())
+        .expect("store")
+        .knowledge_allocator_state()
+        .expect("state");
+    assert_eq!(state.adr_next_sequence, 1);
+    assert!(
+        service
+            .allocation_by_call("mcall-ambiguous-capability")
+            .expect("lookup")
+            .is_none()
+    );
+}
+
+#[test]
+fn private_handler_rejects_unknown_kind_before_sequence_mutation() {
+    let hub_root = tempfile::tempdir().expect("hub root");
+    setup_hub(hub_root.path());
+    let hub = Arc::new(
+        HubMcpHost::new(hub_root.path().to_path_buf(), McpCapability::Agent)
+            .expect("agent hub host"),
+    );
+    let handler = PrivateHubRequestHandler::new(hub);
+    let error = handler
+        .call(
+            HUB_KNOWLEDGE_ALLOCATION_METHOD_V1,
+            Some(json!({
+                "schema_version": HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION,
+                "workspace_id": "ws_alpha",
+                "kind": "friction",
+                "model": "gpt-test",
+            })),
+            context("ws_alpha", "mcall-invalid-kind"),
+        )
+        .expect_err("unknown kind must fail typed deserialization");
+    assert!(
+        matches!(error, McpCustomRequestError::InvalidParams { .. }),
+        "{error:?}"
+    );
+    let state = crate::remote_store_at(hub_root.path())
+        .expect("store")
+        .knowledge_allocator_state()
+        .expect("state");
+    assert_eq!(state.adr_next_sequence, 1);
+    assert_eq!(state.learning_next_sequence, 1);
+    assert!(
+        HubKnowledgeSequenceService::at(hub_root.path())
+            .expect("service")
+            .allocation_by_call("mcall-invalid-kind")
+            .expect("lookup")
+            .is_none()
+    );
+}

--- a/crates/orbit-remote/src/mcp/tests/mod.rs
+++ b/crates/orbit-remote/src/mcp/tests/mod.rs
@@ -8,6 +8,7 @@ mod e1;
 mod graph;
 mod hub_client;
 mod hub_link;
+mod knowledge_allocation;
 mod learning;
 mod schema;
 mod support;
@@ -713,6 +714,7 @@ struct McpConformanceFixture {
 #[derive(Debug, Deserialize)]
 struct McpConformancePrivateConnector {
     spoke_registration: McpConformanceSpokeRegistration,
+    knowledge_allocation: McpConformanceKnowledgeAllocation,
 }
 
 #[derive(Debug, Deserialize)]
@@ -726,6 +728,19 @@ struct McpConformanceSpokeRegistration {
     ordinary_calls_require_active_registration: bool,
     only_path_bearing_fields: Vec<String>,
     cache_refresh: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct McpConformanceKnowledgeAllocation {
+    method: String,
+    schema_version: u32,
+    advertised: bool,
+    ordinary_tools_call: bool,
+    allowed_capabilities: BTreeSet<McpCapability>,
+    active_caller_required: bool,
+    path_bearing_fields: Vec<String>,
+    automatic_replay: bool,
+    lookup_keys: BTreeSet<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -839,6 +854,34 @@ fn canonical_mcp_policy_conforms_to_frozen_v1_fixture() {
             .tools
             .contains_key(orbit_common::types::SPOKE_REGISTRATION_METHOD_V1),
         "private registration must never enter the canonical tool matrix"
+    );
+    let allocation = fixture.private_connector.knowledge_allocation;
+    assert_eq!(
+        allocation.method,
+        orbit_common::types::HUB_KNOWLEDGE_ALLOCATION_METHOD_V1
+    );
+    assert_eq!(
+        allocation.schema_version,
+        u32::from(orbit_common::types::HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION)
+    );
+    assert!(!allocation.advertised);
+    assert!(!allocation.ordinary_tools_call);
+    assert_eq!(
+        allocation.allowed_capabilities,
+        BTreeSet::from([McpCapability::Agent, McpCapability::Operator])
+    );
+    assert!(allocation.active_caller_required);
+    assert!(allocation.path_bearing_fields.is_empty());
+    assert!(!allocation.automatic_replay);
+    assert_eq!(
+        allocation.lookup_keys,
+        BTreeSet::from(["mcp_call_id".to_string(), "workspace-kind-id".to_string()])
+    );
+    assert!(
+        !fixture
+            .tools
+            .contains_key(orbit_common::types::HUB_KNOWLEDGE_ALLOCATION_METHOD_V1),
+        "private allocation must never enter the canonical tool matrix"
     );
     assert_eq!(
         fixture.hub_schema_digest.domain_tag,

--- a/crates/orbit-remote/src/mcp/transport.rs
+++ b/crates/orbit-remote/src/mcp/transport.rs
@@ -1,8 +1,9 @@
-//! Connector-private MCP context and registration composition.
+//! Connector-private MCP context and request composition.
 
 use std::sync::Arc;
 
 use orbit_common::types::{
+    HUB_KNOWLEDGE_ALLOCATION_METHOD_V1, HubKnowledgeAllocationRequestV1, HubKnowledgeAllocationV1,
     McpTransport, OrbitError, SPOKE_REGISTRATION_METHOD_V1, SpokeRegistrationRequestV1,
     SpokeRegistrationResultV1, ToolSessionContext,
 };
@@ -28,6 +29,11 @@ impl McpCallContextResolver for RemoteCallContextResolver {
             let message = match request {
                 McpRequestKind::Custom { method } if method == SPOKE_REGISTRATION_METHOD_V1 => {
                     "private spoke registration requires connector-owned remote session metadata"
+                }
+                McpRequestKind::Custom { method }
+                    if method == HUB_KNOWLEDGE_ALLOCATION_METHOD_V1 =>
+                {
+                    "private hub knowledge allocation requires connector-owned remote session metadata"
                 }
                 _ => "hub tool calls require connector-owned remote session metadata",
             };
@@ -60,29 +66,48 @@ impl McpCallContextResolver for RemoteCallContextResolver {
     }
 }
 
-/// Typed custom handler for the connector-private spoke bootstrap method.
-pub(super) struct SpokeRegistrationHandler {
+/// Typed custom handler for connector-private hub methods.
+pub(super) struct PrivateHubRequestHandler {
     host: Arc<HubMcpHost>,
 }
 
-impl SpokeRegistrationHandler {
+impl PrivateHubRequestHandler {
     pub(super) fn new(host: Arc<HubMcpHost>) -> Self {
         Self { host }
     }
 }
 
-impl McpCustomRequestHandler for SpokeRegistrationHandler {
+impl McpCustomRequestHandler for PrivateHubRequestHandler {
     fn recognizes(&self, method: &str) -> bool {
-        method == SPOKE_REGISTRATION_METHOD_V1
+        matches!(
+            method,
+            SPOKE_REGISTRATION_METHOD_V1 | HUB_KNOWLEDGE_ALLOCATION_METHOD_V1
+        )
     }
 
     fn worker_label(&self) -> &'static str {
-        "private spoke registration"
+        "private hub request"
     }
 
     fn call(
         &self,
-        _method: &str,
+        method: &str,
+        params: Option<Value>,
+        session_context: ToolSessionContext,
+    ) -> Result<Value, McpCustomRequestError> {
+        match method {
+            SPOKE_REGISTRATION_METHOD_V1 => self.call_registration(params, session_context),
+            HUB_KNOWLEDGE_ALLOCATION_METHOD_V1 => {
+                self.call_knowledge_allocation(params, session_context)
+            }
+            _ => Err(McpCustomRequestError::MethodNotFound),
+        }
+    }
+}
+
+impl PrivateHubRequestHandler {
+    fn call_registration(
+        &self,
         params: Option<Value>,
         session_context: ToolSessionContext,
     ) -> Result<Value, McpCustomRequestError> {
@@ -112,6 +137,35 @@ impl McpCustomRequestHandler for SpokeRegistrationHandler {
         })?;
         serialize_registration_result(result)
     }
+
+    fn call_knowledge_allocation(
+        &self,
+        params: Option<Value>,
+        session_context: ToolSessionContext,
+    ) -> Result<Value, McpCustomRequestError> {
+        let params = params.ok_or_else(|| {
+            McpCustomRequestError::invalid_params(
+                "private hub knowledge allocation requires parameters",
+            )
+        })?;
+        let request: HubKnowledgeAllocationRequestV1 =
+            serde_json::from_value(params).map_err(|error| {
+                McpCustomRequestError::invalid_params(format!(
+                    "invalid private hub knowledge allocation payload: {error}"
+                ))
+            })?;
+        request
+            .validate()
+            .map_err(|error| McpCustomRequestError::invalid_params(error.to_string()))?;
+        let allocation = self
+            .host
+            .private_allocate_knowledge_id(request, session_context)
+            .map_err(|error| match error {
+                OrbitError::InvalidInput(message) => McpCustomRequestError::invalid_params(message),
+                error => McpCustomRequestError::internal(error.to_string()),
+            })?;
+        serialize_allocation(allocation)
+    }
 }
 
 fn serialize_registration_result(
@@ -120,6 +174,16 @@ fn serialize_registration_result(
     serde_json::to_value(result).map_err(|error| {
         McpCustomRequestError::internal(format!(
             "serialize private spoke registration result: {error}"
+        ))
+    })
+}
+
+fn serialize_allocation(
+    allocation: HubKnowledgeAllocationV1,
+) -> Result<Value, McpCustomRequestError> {
+    serde_json::to_value(allocation).map_err(|error| {
+        McpCustomRequestError::internal(format!(
+            "serialize private hub knowledge allocation result: {error}"
         ))
     })
 }

--- a/crates/orbit-remote/src/persistence/knowledge.rs
+++ b/crates/orbit-remote/src/persistence/knowledge.rs
@@ -1,0 +1,824 @@
+//! Dormant hub-global ADR/learning sequence persistence [ORB-10272].
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use chrono::{DateTime, Utc};
+use orbit_common::types::{
+    HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION, HubKnowledgeAllocationRequestV1,
+    HubKnowledgeAllocationV1, KnowledgeIdKind, McpCapability, McpLeasedRun, McpTransport,
+    OrbitError,
+};
+use orbit_store::AuditEventInsertParams;
+use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::RemoteStore;
+
+type KnowledgeSourcesByWorkspace = Vec<(String, BTreeSet<String>)>;
+type GlobalKnowledgeInventory = BTreeMap<(KnowledgeIdKind, String), KnowledgeSourcesByWorkspace>;
+type NormalizedKnowledgeInventory =
+    BTreeMap<(KnowledgeIdKind, u32), Vec<(String, String, BTreeSet<String>)>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HubKnowledgeAllocatorStatus {
+    Dormant,
+    Active,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HubKnowledgeAllocatorState {
+    pub status: HubKnowledgeAllocatorStatus,
+    pub activation_generation: u64,
+    pub activated_at: Option<DateTime<Utc>>,
+    pub adr_next_sequence: u64,
+    pub learning_next_sequence: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct LegacyKnowledgeId {
+    pub kind: KnowledgeIdKind,
+    pub id: String,
+    pub evidence: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KnowledgeWorkspaceInventory {
+    pub workspace_id: String,
+    pub ids: Vec<LegacyKnowledgeId>,
+}
+
+impl KnowledgeWorkspaceInventory {
+    pub fn validated(mut self) -> Result<Self, OrbitError> {
+        orbit_common::types::validate_registry_identifier("workspace_id", &self.workspace_id)?;
+        let mut merged: BTreeMap<(KnowledgeIdKind, String), BTreeSet<String>> = BTreeMap::new();
+        for record in self.ids {
+            let sequence = record.kind.parse_id(&record.id).ok_or_else(|| {
+                OrbitError::Migration(format!(
+                    "workspace '{}' contains invalid {} id '{}' in legacy knowledge inventory",
+                    self.workspace_id,
+                    record.kind.as_str(),
+                    record.id
+                ))
+            })?;
+            if sequence == 0
+                || record.evidence.is_empty()
+                || record
+                    .evidence
+                    .iter()
+                    .any(|value| value.trim().is_empty() || value.trim() != value)
+            {
+                return Err(OrbitError::Migration(format!(
+                    "workspace '{}' {} id '{}' has invalid sequence or source evidence",
+                    self.workspace_id,
+                    record.kind.as_str(),
+                    record.id
+                )));
+            }
+            merged
+                .entry((record.kind, record.id))
+                .or_default()
+                .extend(record.evidence);
+        }
+        let mut normalized_ids = NormalizedKnowledgeInventory::new();
+        for ((kind, id), evidence) in &merged {
+            let sequence = kind.parse_id(id).ok_or_else(|| {
+                OrbitError::Migration(format!(
+                    "workspace '{}' contains invalid {} id '{}' after inventory normalization",
+                    self.workspace_id,
+                    kind.as_str(),
+                    id
+                ))
+            })?;
+            normalized_ids.entry((*kind, sequence)).or_default().push((
+                self.workspace_id.clone(),
+                id.clone(),
+                evidence.clone(),
+            ));
+        }
+        let conflicts = normalized_sequence_conflicts(normalized_ids);
+        if !conflicts.is_empty() {
+            return Err(OrbitError::Migration(format!(
+                "workspace '{}' contains numerically duplicate knowledge identifiers:\n- {}",
+                self.workspace_id,
+                conflicts.join("\n- ")
+            )));
+        }
+        self.ids = merged
+            .into_iter()
+            .map(|((kind, id), evidence)| LegacyKnowledgeId { kind, id, evidence })
+            .collect();
+        Ok(self)
+    }
+
+    fn source_digest(&self) -> Result<String, OrbitError> {
+        let payload = serde_json::to_vec(&self.ids).map_err(|error| {
+            OrbitError::Store(format!("serialize knowledge inventory: {error}"))
+        })?;
+        Ok(format!("sha256:{:x}", Sha256::digest(payload)))
+    }
+
+    fn maximum(&self, kind: KnowledgeIdKind) -> u32 {
+        self.ids
+            .iter()
+            .filter(|record| record.kind == kind)
+            .filter_map(|record| kind.parse_id(&record.id))
+            .max()
+            .unwrap_or(0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct HubKnowledgeRequestIdentityV1 {
+    pub schema_version: u8,
+    pub workspace_id: String,
+    pub kind: KnowledgeIdKind,
+    pub model: Option<String>,
+    pub caller_machine_id: String,
+    pub caller_host_id: String,
+    pub process_machine_id: String,
+    pub process_host_id: String,
+    pub transport: McpTransport,
+    pub effective_capabilities: BTreeSet<McpCapability>,
+    pub origin_session_id: String,
+    pub mcp_call_id: String,
+    pub leased_run: Option<McpLeasedRun>,
+}
+
+impl RemoteStore {
+    pub fn knowledge_allocator_state(&self) -> Result<HubKnowledgeAllocatorState, OrbitError> {
+        self.read(read_allocator_state)
+    }
+
+    // F1 deliberately installs a dormant substrate; F3 will call this during cutover.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn activate_knowledge_allocator(
+        &self,
+        inventories: Vec<KnowledgeWorkspaceInventory>,
+    ) -> Result<HubKnowledgeAllocatorState, OrbitError> {
+        let inventories = validate_inventory_set(inventories)?;
+        self.store
+            .with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+                let current = read_allocator_state(tx.connection())?;
+                if current.status == HubKnowledgeAllocatorStatus::Active {
+                    ensure_inventories_already_reconciled(tx.connection(), &inventories)?;
+                    return read_allocator_state(tx.connection());
+                }
+                let generation = current
+                    .activation_generation
+                    .checked_add(1)
+                    .ok_or_else(|| {
+                        OrbitError::Store("knowledge activation generation overflow".into())
+                    })?;
+                for inventory in &inventories {
+                    apply_inventory(tx.connection(), inventory, generation)?;
+                }
+                seed_sequences_from_ids(tx.connection())?;
+                let now = super::now_string();
+                tx.connection()
+                    .execute(
+                        "UPDATE hub_knowledge_allocator_state
+                         SET status = 'active', activation_generation = ?1,
+                             activated_at = ?2, updated_at = ?2
+                         WHERE id = 0 AND status = 'dormant'",
+                        params![u64_to_i64(generation, "activation generation")?, now],
+                    )
+                    .map_err(|error| {
+                        OrbitError::Store(format!("activate knowledge allocator: {error}"))
+                    })?;
+                read_allocator_state(tx.connection())
+            })
+    }
+
+    // F1 deliberately installs a dormant substrate; F3 will call this for late workspaces.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn reconcile_knowledge_workspace(
+        &self,
+        inventory: KnowledgeWorkspaceInventory,
+    ) -> Result<HubKnowledgeAllocatorState, OrbitError> {
+        let inventory = inventory.validated()?;
+        self.store
+            .with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+                let current = read_allocator_state(tx.connection())?;
+                if current.status != HubKnowledgeAllocatorStatus::Active {
+                    return Err(OrbitError::InvalidInput(
+                        "hub knowledge allocator is dormant; activate it before reconciling a late workspace"
+                            .to_string(),
+                    ));
+                }
+                let generation = current
+                    .activation_generation
+                    .checked_add(1)
+                    .ok_or_else(|| OrbitError::Store("knowledge reconciliation generation overflow".into()))?;
+                apply_inventory(tx.connection(), &inventory, generation)?;
+                seed_sequences_from_ids(tx.connection())?;
+                tx.connection()
+                    .execute(
+                        "UPDATE hub_knowledge_allocator_state
+                         SET activation_generation = ?1, updated_at = ?2 WHERE id = 0",
+                        params![u64_to_i64(generation, "reconciliation generation")?, super::now_string()],
+                    )
+                    .map_err(|error| OrbitError::Store(format!("advance reconciliation generation: {error}")))?;
+                read_allocator_state(tx.connection())
+            })
+    }
+
+    pub(crate) fn allocate_hub_knowledge_id(
+        &self,
+        request: &HubKnowledgeAllocationRequestV1,
+        identity: &HubKnowledgeRequestIdentityV1,
+        audit: &AuditEventInsertParams,
+    ) -> Result<HubKnowledgeAllocationV1, OrbitError> {
+        request.validate()?;
+        validate_request_identity(request, identity, audit)?;
+        let identity_json = serde_json::to_string(identity).map_err(|error| {
+            OrbitError::Store(format!("serialize hub knowledge request identity: {error}"))
+        })?;
+
+        self.store
+            .with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+                if let Some((allocation, stored_identity)) =
+                    allocation_by_call(tx.connection(), &identity.mcp_call_id)?
+                {
+                    if stored_identity == identity_json {
+                        return Ok(allocation);
+                    }
+                    return Err(OrbitError::InvalidInput(format!(
+                        "mcp_call_id '{}' was already used for a different hub knowledge allocation request",
+                        identity.mcp_call_id
+                    )));
+                }
+                if read_allocator_state(tx.connection())?.status
+                    != HubKnowledgeAllocatorStatus::Active
+                {
+                    return Err(OrbitError::InvalidInput(
+                        "hub knowledge allocator is dormant".to_string(),
+                    ));
+                }
+                let eligible: bool = tx
+                    .connection()
+                    .query_row(
+                        "SELECT EXISTS(
+                            SELECT 1 FROM hub_knowledge_workspace_reconciliation
+                            WHERE workspace_id = ?1
+                         )",
+                        [&request.workspace_id],
+                        |row| row.get(0),
+                    )
+                    .map_err(|error| OrbitError::Store(error.to_string()))?;
+                if !eligible {
+                    return Err(OrbitError::InvalidInput(format!(
+                        "workspace '{}' is not eligible for hub knowledge allocation until its legacy sources are reconciled",
+                        request.workspace_id
+                    )));
+                }
+
+                let next_raw: i64 = tx
+                    .connection()
+                    .query_row(
+                        "SELECT next_sequence FROM hub_knowledge_sequences WHERE kind = ?1",
+                        [request.kind.as_str()],
+                        |row| row.get(0),
+                    )
+                    .map_err(|error| OrbitError::Store(error.to_string()))?;
+                let sequence = u32::try_from(next_raw).map_err(|_| {
+                    OrbitError::Execution(format!(
+                        "{} knowledge id sequence is exhausted",
+                        request.kind.as_str()
+                    ))
+                })?;
+                let id = request.kind.format_id(sequence);
+                let allocated_at = Utc::now();
+                tx.connection()
+                    .execute(
+                        "INSERT INTO hub_knowledge_ids(
+                            kind, id, workspace_id, sequence, origin, evidence_json, recorded_at
+                         ) VALUES (?1, ?2, ?3, ?4, 'allocated', '[]', ?5)",
+                        params![
+                            request.kind.as_str(), id, request.workspace_id,
+                            i64::from(sequence), allocated_at.to_rfc3339(),
+                        ],
+                    )
+                    .map_err(|error| OrbitError::Store(format!("record allocated knowledge id: {error}")))?;
+                tx.connection()
+                    .execute(
+                        "INSERT INTO hub_knowledge_allocation_ledger(
+                            mcp_call_id, workspace_id, kind, id, sequence,
+                            request_identity_json, allocated_at
+                         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                        params![
+                            identity.mcp_call_id, request.workspace_id, request.kind.as_str(), id,
+                            i64::from(sequence), identity_json, allocated_at.to_rfc3339(),
+                        ],
+                    )
+                    .map_err(|error| OrbitError::Store(format!("record knowledge allocation ledger: {error}")))?;
+                tx.connection()
+                    .execute(
+                        "UPDATE hub_knowledge_sequences
+                         SET next_sequence = ?2, updated_at = ?3 WHERE kind = ?1",
+                        params![
+                            request.kind.as_str(), i64::from(sequence) + 1,
+                            allocated_at.to_rfc3339(),
+                        ],
+                    )
+                    .map_err(|error| OrbitError::Store(format!("advance knowledge sequence: {error}")))?;
+                let mut audit = audit.clone();
+                audit.target_id = Some(id.clone());
+                tx.insert_audit_event_record(&audit)?;
+                Ok(HubKnowledgeAllocationV1 {
+                    schema_version: HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION,
+                    workspace_id: request.workspace_id.clone(),
+                    kind: request.kind,
+                    id,
+                    sequence,
+                    mcp_call_id: identity.mcp_call_id.clone(),
+                    allocated_at,
+                })
+            })
+    }
+
+    pub(crate) fn hub_knowledge_allocation_by_call(
+        &self,
+        mcp_call_id: &str,
+    ) -> Result<Option<HubKnowledgeAllocationV1>, OrbitError> {
+        validate_correlation(mcp_call_id)?;
+        self.read(|conn| Ok(allocation_by_call(conn, mcp_call_id)?.map(|row| row.0)))
+    }
+
+    pub(crate) fn hub_knowledge_allocation_by_id(
+        &self,
+        workspace_id: &str,
+        kind: KnowledgeIdKind,
+        id: &str,
+    ) -> Result<Option<HubKnowledgeAllocationV1>, OrbitError> {
+        orbit_common::types::validate_registry_identifier("workspace_id", workspace_id)?;
+        if kind.parse_id(id).is_none() {
+            return Err(OrbitError::InvalidInput(format!(
+                "invalid {} id '{id}'",
+                kind.as_str()
+            )));
+        }
+        self.read(|conn| {
+            conn.query_row(
+                "SELECT workspace_id, kind, id, sequence, mcp_call_id, allocated_at
+                 FROM hub_knowledge_allocation_ledger
+                 WHERE workspace_id = ?1 AND kind = ?2 AND id = ?3",
+                params![workspace_id, kind.as_str(), id],
+                allocation_row,
+            )
+            .optional()
+            .map_err(|error| OrbitError::Store(error.to_string()))
+        })
+    }
+}
+
+fn validate_inventory_set(
+    inventories: Vec<KnowledgeWorkspaceInventory>,
+) -> Result<Vec<KnowledgeWorkspaceInventory>, OrbitError> {
+    let mut normalized = Vec::with_capacity(inventories.len());
+    let mut workspaces = BTreeSet::new();
+    let mut global_ids = GlobalKnowledgeInventory::new();
+    let mut normalized_ids = NormalizedKnowledgeInventory::new();
+    for inventory in inventories {
+        let inventory = inventory.validated()?;
+        if !workspaces.insert(inventory.workspace_id.clone()) {
+            return Err(OrbitError::Migration(format!(
+                "knowledge activation inventory repeats workspace '{}'",
+                inventory.workspace_id
+            )));
+        }
+        for record in &inventory.ids {
+            let sequence = record.kind.parse_id(&record.id).ok_or_else(|| {
+                OrbitError::Migration(format!(
+                    "workspace '{}' contains invalid {} id '{}' after inventory validation",
+                    inventory.workspace_id,
+                    record.kind.as_str(),
+                    record.id
+                ))
+            })?;
+            global_ids
+                .entry((record.kind, record.id.clone()))
+                .or_default()
+                .push((inventory.workspace_id.clone(), record.evidence.clone()));
+            normalized_ids
+                .entry((record.kind, sequence))
+                .or_default()
+                .push((
+                    inventory.workspace_id.clone(),
+                    record.id.clone(),
+                    record.evidence.clone(),
+                ));
+        }
+        normalized.push(inventory);
+    }
+    let mut conflicts = global_ids
+        .into_iter()
+        .filter(|(_, sources)| sources.len() > 1)
+        .map(|((kind, id), sources)| {
+            let sources = sources
+                .into_iter()
+                .map(|(workspace, evidence)| {
+                    format!(
+                        "{} [{}]",
+                        workspace,
+                        evidence.into_iter().collect::<Vec<_>>().join(", ")
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("; ");
+            format!("{} {id}: {sources}", kind.as_str())
+        })
+        .collect::<Vec<_>>();
+    conflicts.extend(normalized_sequence_conflicts(normalized_ids));
+    if !conflicts.is_empty() {
+        return Err(OrbitError::Migration(format!(
+            "duplicate global knowledge identifiers were found across registered workspaces:\n- {}",
+            conflicts.join("\n- ")
+        )));
+    }
+    normalized.sort_by(|left, right| left.workspace_id.cmp(&right.workspace_id));
+    Ok(normalized)
+}
+
+fn normalized_sequence_conflicts(inventory: NormalizedKnowledgeInventory) -> Vec<String> {
+    inventory
+        .into_iter()
+        .filter(|(_, sources)| {
+            sources
+                .iter()
+                .map(|(_, id, _)| id)
+                .collect::<BTreeSet<_>>()
+                .len()
+                > 1
+        })
+        .map(|((kind, sequence), sources)| {
+            let sources = sources
+                .into_iter()
+                .map(|(workspace, id, evidence)| {
+                    format!(
+                        "{workspace}/{id} [{}]",
+                        evidence.into_iter().collect::<Vec<_>>().join(", ")
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("; ");
+            format!(
+                "{} sequence {sequence} has multiple textual forms: {sources}",
+                kind.as_str()
+            )
+        })
+        .collect()
+}
+
+fn apply_inventory(
+    conn: &Connection,
+    inventory: &KnowledgeWorkspaceInventory,
+    generation: u64,
+) -> Result<(), OrbitError> {
+    let mut conflicts = Vec::new();
+    for record in &inventory.ids {
+        let sequence = record.kind.parse_id(&record.id).ok_or_else(|| {
+            OrbitError::Migration(format!(
+                "workspace '{}' contains invalid {} id '{}' after inventory validation",
+                inventory.workspace_id,
+                record.kind.as_str(),
+                record.id
+            ))
+        })?;
+        if let Some((existing_id, workspace_id)) = conn
+            .query_row(
+                "SELECT id, workspace_id FROM hub_knowledge_ids
+                 WHERE kind = ?1 AND (id = ?2 OR sequence = ?3)",
+                params![record.kind.as_str(), record.id, i64::from(sequence)],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()
+            .map_err(|error| OrbitError::Store(error.to_string()))?
+            .filter(|(existing_id, workspace_id)| {
+                workspace_id != &inventory.workspace_id || existing_id != &record.id
+            })
+        {
+            conflicts.push(format!(
+                "{} sequence {}: {}/{} [{}]; {}/{} [{}]",
+                record.kind.as_str(),
+                sequence,
+                workspace_id,
+                existing_id,
+                existing_evidence(conn, record.kind, &existing_id)?.join(", "),
+                inventory.workspace_id,
+                record.id,
+                record
+                    .evidence
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+    }
+    if !conflicts.is_empty() {
+        return Err(OrbitError::Migration(format!(
+            "duplicate global knowledge identifiers were found while reconciling workspace '{}':\n- {}",
+            inventory.workspace_id,
+            conflicts.join("\n- ")
+        )));
+    }
+    for record in &inventory.ids {
+        let sequence = record.kind.parse_id(&record.id).ok_or_else(|| {
+            OrbitError::Migration(format!(
+                "invalid {} id '{}'",
+                record.kind.as_str(),
+                record.id
+            ))
+        })?;
+        if let Some((workspace_id, origin)) = conn
+            .query_row(
+                "SELECT workspace_id, origin FROM hub_knowledge_ids WHERE kind = ?1 AND id = ?2",
+                params![record.kind.as_str(), record.id],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()
+            .map_err(|error| OrbitError::Store(error.to_string()))?
+        {
+            if workspace_id != inventory.workspace_id {
+                return Err(OrbitError::Migration(format!(
+                    "duplicate global {} id '{}' appears in reconciled workspace '{}' and workspace '{}'",
+                    record.kind.as_str(),
+                    record.id,
+                    workspace_id,
+                    inventory.workspace_id
+                )));
+            }
+            if origin == "legacy" {
+                let evidence_json = serde_json::to_string(&record.evidence)
+                    .map_err(|error| OrbitError::Store(error.to_string()))?;
+                conn.execute(
+                    "UPDATE hub_knowledge_ids SET evidence_json = ?3
+                     WHERE kind = ?1 AND id = ?2 AND origin = 'legacy'",
+                    params![record.kind.as_str(), record.id, evidence_json],
+                )
+                .map_err(|error| {
+                    OrbitError::Store(format!("refresh legacy knowledge evidence: {error}"))
+                })?;
+            }
+            continue;
+        }
+        let evidence_json = serde_json::to_string(&record.evidence)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        conn.execute(
+            "INSERT INTO hub_knowledge_ids(
+                kind, id, workspace_id, sequence, origin, evidence_json, recorded_at
+             ) VALUES (?1, ?2, ?3, ?4, 'legacy', ?5, ?6)",
+            params![
+                record.kind.as_str(),
+                record.id,
+                inventory.workspace_id,
+                i64::from(sequence),
+                evidence_json,
+                super::now_string(),
+            ],
+        )
+        .map_err(|error| OrbitError::Store(format!("record legacy knowledge id: {error}")))?;
+    }
+    conn.execute(
+        "INSERT INTO hub_knowledge_workspace_reconciliation(
+            workspace_id, source_digest, source_count, adr_max, learning_max,
+            reconciliation_generation, reconciled_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+         ON CONFLICT(workspace_id) DO UPDATE SET
+            source_digest = excluded.source_digest,
+            source_count = excluded.source_count,
+            adr_max = MAX(hub_knowledge_workspace_reconciliation.adr_max, excluded.adr_max),
+            learning_max = MAX(hub_knowledge_workspace_reconciliation.learning_max, excluded.learning_max),
+            reconciliation_generation = excluded.reconciliation_generation,
+            reconciled_at = excluded.reconciled_at",
+        params![
+            inventory.workspace_id, inventory.source_digest()?,
+            i64::try_from(inventory.ids.len()).map_err(|error| OrbitError::Store(error.to_string()))?,
+            i64::from(inventory.maximum(KnowledgeIdKind::Adr)),
+            i64::from(inventory.maximum(KnowledgeIdKind::Learning)),
+            u64_to_i64(generation, "reconciliation generation")?, super::now_string(),
+        ],
+    )
+    .map_err(|error| OrbitError::Store(format!("record workspace knowledge reconciliation: {error}")))?;
+    Ok(())
+}
+
+fn existing_evidence(
+    conn: &Connection,
+    kind: KnowledgeIdKind,
+    id: &str,
+) -> Result<Vec<String>, OrbitError> {
+    let raw: String = conn
+        .query_row(
+            "SELECT evidence_json FROM hub_knowledge_ids WHERE kind = ?1 AND id = ?2",
+            params![kind.as_str(), id],
+            |row| row.get(0),
+        )
+        .map_err(|error| OrbitError::Store(error.to_string()))?;
+    serde_json::from_str::<BTreeSet<String>>(&raw)
+        .map(|evidence| evidence.into_iter().collect())
+        .map_err(|error| OrbitError::Store(format!("decode knowledge evidence: {error}")))
+}
+
+fn seed_sequences_from_ids(conn: &Connection) -> Result<(), OrbitError> {
+    for kind in [KnowledgeIdKind::Adr, KnowledgeIdKind::Learning] {
+        let maximum: i64 = conn
+            .query_row(
+                "SELECT COALESCE(MAX(sequence), 0) FROM hub_knowledge_ids WHERE kind = ?1",
+                [kind.as_str()],
+                |row| row.get(0),
+            )
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let next = maximum.checked_add(1).ok_or_else(|| {
+            OrbitError::Store(format!("{} knowledge sequence overflow", kind.as_str()))
+        })?;
+        conn.execute(
+            "UPDATE hub_knowledge_sequences
+             SET next_sequence = MAX(next_sequence, ?2), updated_at = ?3 WHERE kind = ?1",
+            params![kind.as_str(), next, super::now_string()],
+        )
+        .map_err(|error| {
+            OrbitError::Store(format!(
+                "seed {} knowledge sequence: {error}",
+                kind.as_str()
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+fn ensure_inventories_already_reconciled(
+    conn: &Connection,
+    inventories: &[KnowledgeWorkspaceInventory],
+) -> Result<(), OrbitError> {
+    for inventory in inventories {
+        let digest = inventory.source_digest()?;
+        let stored: Option<String> = conn
+            .query_row(
+                "SELECT source_digest FROM hub_knowledge_workspace_reconciliation
+                 WHERE workspace_id = ?1",
+                [&inventory.workspace_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        if stored.as_deref() != Some(digest.as_str()) {
+            return Err(OrbitError::InvalidInput(format!(
+                "hub knowledge allocator is active and workspace '{}' has unreconciled sources",
+                inventory.workspace_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn read_allocator_state(conn: &Connection) -> Result<HubKnowledgeAllocatorState, OrbitError> {
+    let (status, generation, activated_at): (String, i64, Option<String>) = conn
+        .query_row(
+            "SELECT status, activation_generation, activated_at
+             FROM hub_knowledge_allocator_state WHERE id = 0",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .map_err(|error| OrbitError::Store(format!("read knowledge allocator state: {error}")))?;
+    let status = match status.as_str() {
+        "dormant" => HubKnowledgeAllocatorStatus::Dormant,
+        "active" => HubKnowledgeAllocatorStatus::Active,
+        other => {
+            return Err(OrbitError::Store(format!(
+                "invalid knowledge allocator status '{other}'"
+            )));
+        }
+    };
+    let activated_at = activated_at
+        .as_deref()
+        .map(super::parse_timestamp)
+        .transpose()
+        .map_err(|error| OrbitError::Store(error.to_string()))?;
+    Ok(HubKnowledgeAllocatorState {
+        status,
+        activation_generation: u64::try_from(generation).map_err(|error| {
+            OrbitError::Store(format!("invalid activation generation: {error}"))
+        })?,
+        activated_at,
+        adr_next_sequence: read_next_sequence(conn, KnowledgeIdKind::Adr)?,
+        learning_next_sequence: read_next_sequence(conn, KnowledgeIdKind::Learning)?,
+    })
+}
+
+fn read_next_sequence(conn: &Connection, kind: KnowledgeIdKind) -> Result<u64, OrbitError> {
+    let raw: i64 = conn
+        .query_row(
+            "SELECT next_sequence FROM hub_knowledge_sequences WHERE kind = ?1",
+            [kind.as_str()],
+            |row| row.get(0),
+        )
+        .map_err(|error| OrbitError::Store(error.to_string()))?;
+    u64::try_from(raw).map_err(|error| OrbitError::Store(format!("invalid sequence: {error}")))
+}
+
+fn validate_request_identity(
+    request: &HubKnowledgeAllocationRequestV1,
+    identity: &HubKnowledgeRequestIdentityV1,
+    audit: &AuditEventInsertParams,
+) -> Result<(), OrbitError> {
+    validate_correlation(&identity.mcp_call_id)?;
+    if identity.schema_version != HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION
+        || identity.workspace_id != request.workspace_id
+        || identity.kind != request.kind
+        || identity.model != request.model
+    {
+        return Err(OrbitError::InvalidInput(
+            "hub knowledge allocation request identity does not match the typed request"
+                .to_string(),
+        ));
+    }
+    for (label, value) in [
+        ("caller_machine_id", identity.caller_machine_id.as_str()),
+        ("caller_host_id", identity.caller_host_id.as_str()),
+        ("process_machine_id", identity.process_machine_id.as_str()),
+        ("process_host_id", identity.process_host_id.as_str()),
+        ("origin_session_id", identity.origin_session_id.as_str()),
+    ] {
+        if value.trim().is_empty() || value.trim() != value {
+            return Err(OrbitError::InvalidInput(format!(
+                "hub knowledge allocation requires normalized {label}"
+            )));
+        }
+    }
+    if identity.effective_capabilities.is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "hub knowledge allocation requires a non-empty effective capability set".to_string(),
+        ));
+    }
+    if audit.workspace_id.as_deref() != Some(request.workspace_id.as_str())
+        || audit.mcp_call_id.as_deref() != Some(identity.mcp_call_id.as_str())
+        || audit.caller_machine_id.as_deref() != Some(identity.caller_machine_id.as_str())
+        || audit.caller_host_id.as_deref() != Some(identity.caller_host_id.as_str())
+        || audit.process_machine_id.as_deref() != Some(identity.process_machine_id.as_str())
+        || audit.process_host_id.as_deref() != Some(identity.process_host_id.as_str())
+        || audit.transport != Some(identity.transport)
+        || audit.effective_capabilities != identity.effective_capabilities
+        || audit.origin_session_id.as_deref() != Some(identity.origin_session_id.as_str())
+    {
+        return Err(OrbitError::InvalidInput(
+            "hub knowledge allocation audit provenance does not match the request identity"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_correlation(mcp_call_id: &str) -> Result<(), OrbitError> {
+    if mcp_call_id.trim().is_empty() || mcp_call_id.trim() != mcp_call_id {
+        return Err(OrbitError::InvalidInput(
+            "hub knowledge allocation requires a normalized mcp_call_id".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn allocation_by_call(
+    conn: &Connection,
+    mcp_call_id: &str,
+) -> Result<Option<(HubKnowledgeAllocationV1, String)>, OrbitError> {
+    conn.query_row(
+        "SELECT workspace_id, kind, id, sequence, mcp_call_id, allocated_at,
+                request_identity_json
+         FROM hub_knowledge_allocation_ledger WHERE mcp_call_id = ?1",
+        [mcp_call_id],
+        |row| Ok((allocation_row(row)?, row.get(6)?)),
+    )
+    .optional()
+    .map_err(|error| OrbitError::Store(error.to_string()))
+}
+
+fn allocation_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<HubKnowledgeAllocationV1> {
+    let kind_raw: String = row.get(1)?;
+    let kind = match kind_raw.as_str() {
+        "adr" => KnowledgeIdKind::Adr,
+        "learning" => KnowledgeIdKind::Learning,
+        _ => return Err(rusqlite::Error::InvalidQuery),
+    };
+    let sequence_raw: i64 = row.get(3)?;
+    let allocated_at_raw: String = row.get(5)?;
+    let allocated_at = DateTime::parse_from_rfc3339(&allocated_at_raw)
+        .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?
+        .with_timezone(&Utc);
+    Ok(HubKnowledgeAllocationV1 {
+        schema_version: HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION,
+        workspace_id: row.get(0)?,
+        kind,
+        id: row.get(2)?,
+        sequence: u32::try_from(sequence_raw)
+            .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?,
+        mcp_call_id: row.get(4)?,
+        allocated_at,
+    })
+}
+
+fn u64_to_i64(value: u64, label: &str) -> Result<i64, OrbitError> {
+    i64::try_from(value)
+        .map_err(|error| OrbitError::Store(format!("{label} is too large: {error}")))
+}

--- a/crates/orbit-remote/src/persistence/mod.rs
+++ b/crates/orbit-remote/src/persistence/mod.rs
@@ -13,15 +13,28 @@ use orbit_store::Store;
 use orbit_store::sqlite::migration::{FeatureMigration, FeatureSchemaStatus};
 use rusqlite::{Connection, OptionalExtension};
 
+mod knowledge;
 mod registry;
 mod snapshot;
 
+pub use knowledge::{
+    HubKnowledgeAllocatorState, HubKnowledgeAllocatorStatus, HubKnowledgeRequestIdentityV1,
+    KnowledgeWorkspaceInventory, LegacyKnowledgeId,
+};
+
 const REMOTE_SCHEMA_FEATURE: &str = "orbit-remote";
-const REMOTE_SCHEMA_MIGRATIONS: &[FeatureMigration] = &[FeatureMigration::new(
-    1,
-    "adopt_global_v8_registry_schema",
-    adopt_global_v8_registry_schema,
-)];
+const REMOTE_SCHEMA_MIGRATIONS: &[FeatureMigration] = &[
+    FeatureMigration::new(
+        1,
+        "adopt_global_v8_registry_schema",
+        adopt_global_v8_registry_schema,
+    ),
+    FeatureMigration::new(
+        2,
+        "dormant_hub_knowledge_sequences",
+        apply_dormant_hub_knowledge_sequences,
+    ),
+];
 
 /// Persistence facade for Orbit's remote coordination domain.
 ///
@@ -269,6 +282,109 @@ fn adopt_global_v8_registry_schema(conn: &Connection) -> Result<(), OrbitError> 
         )));
     }
 
+    Ok(())
+}
+
+/// Remote v2 installs the hub-global ADR/learning allocation substrate in a
+/// deliberately dormant state. Source discovery and activation are explicit
+/// service operations: merely opening the Remote facade never scans a
+/// checkout, advances a sequence, or changes an existing caller path.
+fn apply_dormant_hub_knowledge_sequences(conn: &Connection) -> Result<(), OrbitError> {
+    conn.execute_batch(
+        r#"
+        CREATE TABLE hub_knowledge_allocator_state (
+            id                    INTEGER PRIMARY KEY CHECK (id = 0),
+            status                TEXT NOT NULL CHECK (status IN ('dormant', 'active')),
+            activation_generation INTEGER NOT NULL DEFAULT 0
+                                      CHECK (activation_generation >= 0),
+            activated_at          TEXT,
+            updated_at            TEXT NOT NULL,
+            CHECK (
+                (status = 'dormant' AND activated_at IS NULL)
+                OR (status = 'active' AND activated_at IS NOT NULL)
+            )
+        );
+
+        INSERT INTO hub_knowledge_allocator_state(
+            id, status, activation_generation, activated_at, updated_at
+        ) VALUES (0, 'dormant', 0, NULL, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
+
+        CREATE TABLE hub_knowledge_sequences (
+            kind          TEXT PRIMARY KEY CHECK (kind IN ('adr', 'learning')),
+            next_sequence INTEGER NOT NULL
+                          CHECK (next_sequence >= 1 AND next_sequence <= 4294967296),
+            updated_at    TEXT NOT NULL
+        );
+
+        INSERT INTO hub_knowledge_sequences(kind, next_sequence, updated_at) VALUES
+            ('adr', 1, strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            ('learning', 1, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
+
+        CREATE TABLE hub_knowledge_ids (
+            kind          TEXT NOT NULL CHECK (kind IN ('adr', 'learning')),
+            id            TEXT NOT NULL,
+            workspace_id  TEXT NOT NULL CHECK (length(workspace_id) > 0),
+            sequence      INTEGER NOT NULL CHECK (sequence >= 1 AND sequence <= 4294967295),
+            origin        TEXT NOT NULL CHECK (origin IN ('legacy', 'allocated')),
+            evidence_json TEXT NOT NULL
+                          CHECK (json_valid(evidence_json) AND json_type(evidence_json) = 'array'),
+            recorded_at   TEXT NOT NULL,
+            PRIMARY KEY(kind, id),
+            UNIQUE(kind, sequence),
+            UNIQUE(workspace_id, kind, id)
+        );
+
+        CREATE INDEX hub_knowledge_ids_workspace
+            ON hub_knowledge_ids(workspace_id, kind, sequence);
+
+        CREATE TABLE hub_knowledge_workspace_reconciliation (
+            workspace_id          TEXT PRIMARY KEY CHECK (length(workspace_id) > 0),
+            source_digest         TEXT NOT NULL CHECK (length(source_digest) > 0),
+            source_count          INTEGER NOT NULL CHECK (source_count >= 0),
+            adr_max               INTEGER NOT NULL CHECK (adr_max >= 0 AND adr_max <= 4294967295),
+            learning_max          INTEGER NOT NULL
+                                      CHECK (learning_max >= 0 AND learning_max <= 4294967295),
+            reconciliation_generation INTEGER NOT NULL
+                                      CHECK (reconciliation_generation >= 1),
+            reconciled_at         TEXT NOT NULL
+        );
+
+        CREATE TABLE hub_knowledge_allocation_ledger (
+            mcp_call_id          TEXT PRIMARY KEY CHECK (length(mcp_call_id) > 0),
+            workspace_id        TEXT NOT NULL CHECK (length(workspace_id) > 0),
+            kind                TEXT NOT NULL CHECK (kind IN ('adr', 'learning')),
+            id                  TEXT NOT NULL,
+            sequence            INTEGER NOT NULL CHECK (sequence >= 1 AND sequence <= 4294967295),
+            request_identity_json TEXT NOT NULL
+                                CHECK (json_valid(request_identity_json)
+                                       AND json_type(request_identity_json) = 'object'),
+            allocated_at        TEXT NOT NULL,
+            FOREIGN KEY(kind, id) REFERENCES hub_knowledge_ids(kind, id)
+                ON UPDATE RESTRICT ON DELETE RESTRICT,
+            UNIQUE(workspace_id, kind, id)
+        );
+
+        CREATE INDEX hub_knowledge_allocation_lookup
+            ON hub_knowledge_allocation_ledger(workspace_id, kind, id);
+
+        CREATE TRIGGER hub_knowledge_allocation_ledger_immutable_update
+        BEFORE UPDATE ON hub_knowledge_allocation_ledger
+        BEGIN
+            SELECT RAISE(ABORT, 'hub knowledge allocation ledger is immutable');
+        END;
+
+        CREATE TRIGGER hub_knowledge_allocation_ledger_immutable_delete
+        BEFORE DELETE ON hub_knowledge_allocation_ledger
+        BEGIN
+            SELECT RAISE(ABORT, 'hub knowledge allocation ledger is immutable');
+        END;
+        "#,
+    )
+    .map_err(|error| {
+        OrbitError::Migration(format!(
+            "apply orbit-remote dormant hub knowledge sequence schema: {error}"
+        ))
+    })?;
     Ok(())
 }
 

--- a/crates/orbit-remote/src/persistence/tests/adoption.rs
+++ b/crates/orbit-remote/src/persistence/tests/adoption.rs
@@ -4,15 +4,27 @@ use orbit_store::Store;
 use super::super::{REMOTE_SCHEMA_FEATURE, REMOTE_SCHEMA_MIGRATIONS, RemoteStore};
 
 #[test]
-fn remote_store_adopts_shipped_registry_schema_as_feature_v1() {
+fn remote_store_adopts_registry_and_installs_dormant_knowledge_schema_as_feature_v2() {
     let store = RemoteStore::open_in_memory().expect("remote store");
     let status = store.schema_status().expect("remote schema status");
 
     assert_eq!(status.feature, REMOTE_SCHEMA_FEATURE);
-    assert_eq!(status.current_version, 1);
-    assert_eq!(status.applied.len(), 1);
+    assert_eq!(status.current_version, 2);
+    assert_eq!(status.applied.len(), 2);
     assert_eq!(status.applied[0].name, "adopt_global_v8_registry_schema");
+    assert_eq!(status.applied[1].name, "dormant_hub_knowledge_sequences");
     assert!(status.pending.is_empty());
+
+    let allocator = store
+        .knowledge_allocator_state()
+        .expect("dormant allocator state");
+    assert_eq!(
+        allocator.status,
+        super::super::HubKnowledgeAllocatorStatus::Dormant
+    );
+    assert_eq!(allocator.activation_generation, 0);
+    assert_eq!(allocator.adr_next_sequence, 1);
+    assert_eq!(allocator.learning_next_sequence, 1);
 }
 
 #[test]
@@ -66,7 +78,7 @@ fn remote_store_refuses_a_future_remote_feature_version() {
             tx.connection()
                 .execute(
                     "INSERT INTO feature_schema_meta(feature, version, name, applied_at)
-                     VALUES (?1, 2, 'future_remote_schema', '2026-07-19T00:00:00Z')",
+                     VALUES (?1, 3, 'future_remote_schema', '2026-07-19T00:00:00Z')",
                     [REMOTE_SCHEMA_FEATURE],
                 )
                 .map_err(|error| OrbitError::Store(error.to_string()))?;

--- a/crates/orbit-remote/src/persistence/tests/knowledge.rs
+++ b/crates/orbit-remote/src/persistence/tests/knowledge.rs
@@ -1,0 +1,762 @@
+use std::collections::{BTreeSet, HashSet};
+
+use orbit_common::types::{
+    HUB_KNOWLEDGE_ALLOCATION_METHOD_V1, HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION,
+    HubKnowledgeAllocationRequestV1, KnowledgeIdKind, McpCapability, McpLeasedRun, McpTransport,
+    ToolSessionContext,
+};
+use rusqlite::params;
+
+use crate::HubKnowledgeSequenceService;
+
+use super::super::{
+    HubKnowledgeAllocatorStatus, KnowledgeWorkspaceInventory, LegacyKnowledgeId, RemoteStore,
+};
+
+fn evidence(values: &[&str]) -> BTreeSet<String> {
+    values.iter().map(|value| (*value).to_string()).collect()
+}
+
+fn legacy(kind: KnowledgeIdKind, id: &str, sources: &[&str]) -> LegacyKnowledgeId {
+    LegacyKnowledgeId {
+        kind,
+        id: id.to_string(),
+        evidence: evidence(sources),
+    }
+}
+
+fn inventory(workspace_id: &str, ids: Vec<LegacyKnowledgeId>) -> KnowledgeWorkspaceInventory {
+    KnowledgeWorkspaceInventory {
+        workspace_id: workspace_id.to_string(),
+        ids,
+    }
+}
+
+fn service(store: RemoteStore, workspaces: &[&str]) -> HubKnowledgeSequenceService {
+    HubKnowledgeSequenceService::new_for_test(
+        store,
+        workspaces
+            .iter()
+            .map(|workspace| (*workspace).to_string())
+            .collect(),
+    )
+}
+
+fn request(workspace_id: &str, kind: KnowledgeIdKind) -> HubKnowledgeAllocationRequestV1 {
+    HubKnowledgeAllocationRequestV1 {
+        schema_version: HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION,
+        workspace_id: workspace_id.to_string(),
+        kind,
+        model: Some("gpt-test".to_string()),
+    }
+}
+
+fn context(workspace_id: &str, call_id: &str) -> ToolSessionContext {
+    ToolSessionContext {
+        workspace: None,
+        workspace_id: Some(workspace_id.to_string()),
+        caller_machine_id: Some("hm_spoke".to_string()),
+        caller_host_id: Some("spoke".to_string()),
+        process_machine_id: Some("hm_hub".to_string()),
+        process_host_id: Some("hub".to_string()),
+        transport: Some(McpTransport::SshMcp),
+        effective_capabilities: BTreeSet::from([McpCapability::Agent]),
+        origin_session_id: Some("session-knowledge".to_string()),
+        mcp_call_id: Some(call_id.to_string()),
+        leased_run: Some(McpLeasedRun {
+            run_id: "jrun-knowledge".to_string(),
+            lease_id: "lease-knowledge".to_string(),
+        }),
+    }
+}
+
+#[test]
+fn two_workspace_activation_seeds_above_every_legacy_max_and_allocates_with_atomic_audit() {
+    let store = RemoteStore::open_in_memory().expect("store");
+    let service = service(store.clone(), &["ws_alpha", "ws_beta"]);
+    let state = service
+        .activate(vec![
+            inventory(
+                "ws_alpha",
+                vec![
+                    legacy(KnowledgeIdKind::Adr, "ADR-0004", &["adr-file:accepted"]),
+                    legacy(
+                        KnowledgeIdKind::Learning,
+                        "L-0009",
+                        &["allocation:reserved"],
+                    ),
+                ],
+            ),
+            inventory(
+                "ws_beta",
+                vec![
+                    legacy(KnowledgeIdKind::Adr, "ADR-0012", &["adr-file:deleted"]),
+                    legacy(
+                        KnowledgeIdKind::Learning,
+                        "L-0003",
+                        &["allocation:abandoned"],
+                    ),
+                ],
+            ),
+        ])
+        .expect("activate");
+    assert_eq!(state.status, HubKnowledgeAllocatorStatus::Active);
+    assert_eq!(state.adr_next_sequence, 13);
+    assert_eq!(state.learning_next_sequence, 10);
+
+    let adr_request = request("ws_alpha", KnowledgeIdKind::Adr);
+    let adr_context = context("ws_alpha", "mcall-adr-13");
+    let adr = service
+        .allocate(&adr_request, &adr_context)
+        .expect("allocate adr");
+    assert_eq!(adr.id, "ADR-0013");
+    assert_eq!(adr.sequence, 13);
+
+    let learning = service
+        .allocate(
+            &request("ws_beta", KnowledgeIdKind::Learning),
+            &context("ws_beta", "mcall-learning-10"),
+        )
+        .expect("allocate learning");
+    assert_eq!(learning.id, "L-0010");
+    assert_eq!(
+        service
+            .allocation_by_call("mcall-adr-13")
+            .expect("call lookup"),
+        Some(adr.clone())
+    );
+    assert_eq!(
+        service
+            .allocation_by_id("ws_alpha", KnowledgeIdKind::Adr, "ADR-0013")
+            .expect("id lookup"),
+        Some(adr.clone())
+    );
+
+    let replay = service
+        .allocate(&adr_request, &adr_context)
+        .expect("exact replay");
+    assert_eq!(replay, adr);
+    let mut drifted = adr_request;
+    drifted.model = Some("different-model".to_string());
+    let error = service
+        .allocate(&drifted, &adr_context)
+        .expect_err("identity drift must fail")
+        .to_string();
+    assert!(error.contains("already used"), "{error}");
+
+    let connection = store.connection();
+    let connection = connection.lock().expect("connection");
+    let audit: (String, String, String, String, String, String, String) = connection
+        .query_row(
+            "SELECT tool_name, target_id, workspace_id, caller_machine_id,
+                    process_machine_id, mcp_call_id, lease_id
+             FROM audit_events WHERE mcp_call_id = 'mcall-adr-13'",
+            [],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                ))
+            },
+        )
+        .expect("allocation audit");
+    assert_eq!(audit.0, HUB_KNOWLEDGE_ALLOCATION_METHOD_V1);
+    assert_eq!(audit.1, "ADR-0013");
+    assert_eq!(audit.2, "ws_alpha");
+    assert_eq!(audit.3, "hm_spoke");
+    assert_eq!(audit.4, "hm_hub");
+    assert_eq!(audit.5, "mcall-adr-13");
+    assert_eq!(audit.6, "lease-knowledge");
+}
+
+#[test]
+fn activation_reports_every_cross_workspace_duplicate_before_mutation() {
+    let store = RemoteStore::open_in_memory().expect("store");
+    let service = service(store.clone(), &["ws_a", "ws_b", "ws_c"]);
+    let error = service
+        .activate(vec![
+            inventory(
+                "ws_a",
+                vec![
+                    legacy(KnowledgeIdKind::Adr, "ADR-0007", &["adr-file:accepted"]),
+                    legacy(
+                        KnowledgeIdKind::Learning,
+                        "L-0002",
+                        &["learning-file:active"],
+                    ),
+                ],
+            ),
+            inventory(
+                "ws_b",
+                vec![
+                    legacy(KnowledgeIdKind::Adr, "ADR-0007", &["allocation:merged"]),
+                    legacy(
+                        KnowledgeIdKind::Learning,
+                        "L-0002",
+                        &["allocation:reserved"],
+                    ),
+                ],
+            ),
+            inventory(
+                "ws_c",
+                vec![legacy(
+                    KnowledgeIdKind::Adr,
+                    "ADR-0007",
+                    &["adr-file:deleted"],
+                )],
+            ),
+        ])
+        .expect_err("duplicates must block activation")
+        .to_string();
+    for expected in [
+        "ADR-0007",
+        "L-0002",
+        "ws_a",
+        "ws_b",
+        "ws_c",
+        "adr-file:accepted",
+        "allocation:merged",
+        "adr-file:deleted",
+    ] {
+        assert!(error.contains(expected), "missing '{expected}' in {error}");
+    }
+    let state = store.knowledge_allocator_state().expect("state");
+    assert_eq!(state.status, HubKnowledgeAllocatorStatus::Dormant);
+    let count: i64 = store
+        .connection()
+        .lock()
+        .expect("connection")
+        .query_row("SELECT COUNT(*) FROM hub_knowledge_ids", [], |row| {
+            row.get(0)
+        })
+        .expect("id count");
+    assert_eq!(count, 0);
+}
+
+#[test]
+fn activation_reports_numeric_normalization_collisions_before_mutation() {
+    let store = RemoteStore::open_in_memory().expect("store");
+    let service = service(store.clone(), &["ws_a", "ws_b", "ws_c"]);
+    let error = service
+        .activate(vec![
+            inventory(
+                "ws_a",
+                vec![legacy(
+                    KnowledgeIdKind::Adr,
+                    "ADR-0001",
+                    &["adr-file:accepted"],
+                )],
+            ),
+            inventory(
+                "ws_b",
+                vec![legacy(
+                    KnowledgeIdKind::Adr,
+                    "ADR-00001",
+                    &["allocation:merged"],
+                )],
+            ),
+            inventory(
+                "ws_c",
+                vec![legacy(
+                    KnowledgeIdKind::Adr,
+                    "ADR-000001",
+                    &["adr-file:deleted"],
+                )],
+            ),
+        ])
+        .expect_err("numeric duplicate must block activation")
+        .to_string();
+    for expected in [
+        "sequence 1",
+        "ADR-0001",
+        "ADR-00001",
+        "ADR-000001",
+        "ws_a",
+        "ws_b",
+        "ws_c",
+        "adr-file:accepted",
+        "allocation:merged",
+        "adr-file:deleted",
+    ] {
+        assert!(error.contains(expected), "missing '{expected}' in {error}");
+    }
+    let state = store.knowledge_allocator_state().expect("state");
+    assert_eq!(state.status, HubKnowledgeAllocatorStatus::Dormant);
+    let count: i64 = store
+        .connection()
+        .lock()
+        .expect("connection")
+        .query_row("SELECT COUNT(*) FROM hub_knowledge_ids", [], |row| {
+            row.get(0)
+        })
+        .expect("id count");
+    assert_eq!(count, 0);
+}
+
+#[test]
+fn activation_requires_the_exact_nonempty_registered_workspace_inventory_set() {
+    let store = RemoteStore::open_in_memory().expect("store");
+    let allocator = service(store.clone(), &["ws_alpha", "ws_beta"]);
+    let error = allocator
+        .activate(vec![inventory("ws_alpha", Vec::new())])
+        .expect_err("partial inventory must fail")
+        .to_string();
+    assert!(error.contains("ws_beta"), "{error}");
+    assert!(error.contains("missing"), "{error}");
+    let error = allocator
+        .activate(Vec::new())
+        .expect_err("empty inventory must fail")
+        .to_string();
+    assert!(error.contains("ws_alpha"), "{error}");
+    assert!(error.contains("ws_beta"), "{error}");
+    assert_eq!(
+        store.knowledge_allocator_state().expect("state").status,
+        HubKnowledgeAllocatorStatus::Dormant
+    );
+
+    let empty_registry_store = RemoteStore::open_in_memory().expect("empty registry store");
+    let empty_registry_service = service(empty_registry_store.clone(), &[]);
+    let error = empty_registry_service
+        .activate(Vec::new())
+        .expect_err("empty registered-workspace set still cannot establish authority")
+        .to_string();
+    assert!(error.contains("exactly"), "{error}");
+    assert_eq!(
+        empty_registry_store
+            .knowledge_allocator_state()
+            .expect("empty registry state")
+            .status,
+        HubKnowledgeAllocatorStatus::Dormant
+    );
+}
+
+#[test]
+fn audit_failure_rolls_back_sequence_occupancy_and_ledger() {
+    let store = RemoteStore::open_in_memory().expect("store");
+    let service = service(store.clone(), &["ws_alpha"]);
+    service
+        .activate(vec![inventory("ws_alpha", Vec::new())])
+        .expect("activate");
+    store
+        .connection()
+        .lock()
+        .expect("connection")
+        .execute_batch(
+            "CREATE TRIGGER fail_knowledge_allocation_audit
+             BEFORE INSERT ON audit_events
+             WHEN NEW.tool_name = 'orbit/private/allocate-knowledge-id/v1'
+             BEGIN
+                 SELECT RAISE(ABORT, 'injected audit failure');
+             END;",
+        )
+        .expect("failure trigger");
+
+    let request = request("ws_alpha", KnowledgeIdKind::Adr);
+    let context = context("ws_alpha", "mcall-rollback");
+    let error = service
+        .allocate(&request, &context)
+        .expect_err("audit failure")
+        .to_string();
+    assert!(error.contains("injected audit failure"), "{error}");
+    let connection = store.connection();
+    let connection = connection.lock().expect("connection");
+    let (next, ids, ledger, audits): (i64, i64, i64, i64) = connection
+        .query_row(
+            "SELECT
+                (SELECT next_sequence FROM hub_knowledge_sequences WHERE kind = 'adr'),
+                (SELECT COUNT(*) FROM hub_knowledge_ids),
+                (SELECT COUNT(*) FROM hub_knowledge_allocation_ledger),
+                (SELECT COUNT(*) FROM audit_events WHERE mcp_call_id = 'mcall-rollback')",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("rollback state");
+    assert_eq!((next, ids, ledger, audits), (1, 0, 0, 0));
+    connection
+        .execute_batch("DROP TRIGGER fail_knowledge_allocation_audit")
+        .expect("remove trigger");
+    drop(connection);
+
+    let allocation = service
+        .allocate(&request, &context)
+        .expect("retry after definitive rollback");
+    assert_eq!(allocation.id, "ADR-0001");
+}
+
+#[test]
+fn activation_authority_update_failure_rolls_back_inventory_sequences_and_reconciliation() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let database = directory.path().join("remote.db");
+    let store = RemoteStore::open(&database).expect("store");
+    store
+        .connection()
+        .lock()
+        .expect("connection")
+        .execute_batch(
+            "CREATE TRIGGER fail_knowledge_activation_authority
+             BEFORE UPDATE ON hub_knowledge_allocator_state
+             WHEN NEW.status = 'active'
+             BEGIN
+                 SELECT RAISE(ABORT, 'injected activation authority failure');
+             END;",
+        )
+        .expect("failure trigger");
+    let service = service(store.clone(), &["ws_alpha"]);
+    let error = service
+        .activate(vec![inventory(
+            "ws_alpha",
+            vec![
+                legacy(KnowledgeIdKind::Adr, "ADR-0042", &["adr-file:accepted"]),
+                legacy(
+                    KnowledgeIdKind::Learning,
+                    "L-0017",
+                    &["allocation:reserved"],
+                ),
+            ],
+        )])
+        .expect_err("activation authority failure")
+        .to_string();
+    assert!(
+        error.contains("injected activation authority failure"),
+        "{error}"
+    );
+    drop(service);
+    drop(store);
+
+    let reopened = RemoteStore::open(&database).expect("reopen");
+    let state = reopened.knowledge_allocator_state().expect("state");
+    assert_eq!(state.status, HubKnowledgeAllocatorStatus::Dormant);
+    assert_eq!(state.activation_generation, 0);
+    assert_eq!(state.adr_next_sequence, 1);
+    assert_eq!(state.learning_next_sequence, 1);
+    let connection = reopened.connection();
+    let connection = connection.lock().expect("connection");
+    let (occupancy, reconciliations): (i64, i64) = connection
+        .query_row(
+            "SELECT
+                (SELECT COUNT(*) FROM hub_knowledge_ids),
+                (SELECT COUNT(*) FROM hub_knowledge_workspace_reconciliation)",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("rollback rows");
+    assert_eq!((occupancy, reconciliations), (0, 0));
+}
+
+#[test]
+fn concurrent_file_backed_allocations_are_unique_and_monotonic() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let database = directory.path().join("remote.db");
+    let store = RemoteStore::open(&database).expect("store");
+    service(store, &["ws_alpha"])
+        .activate(vec![inventory("ws_alpha", Vec::new())])
+        .expect("activate");
+
+    let handles = (0..24)
+        .map(|index| {
+            let database = database.clone();
+            std::thread::spawn(move || {
+                let store = RemoteStore::open(&database).expect("thread store");
+                service(store, &["ws_alpha"])
+                    .allocate(
+                        &request("ws_alpha", KnowledgeIdKind::Learning),
+                        &context("ws_alpha", &format!("mcall-concurrent-{index}")),
+                    )
+                    .expect("concurrent allocation")
+            })
+        })
+        .collect::<Vec<_>>();
+    let mut allocations = handles
+        .into_iter()
+        .map(|handle| handle.join().expect("allocation thread"))
+        .collect::<Vec<_>>();
+    allocations.sort_by_key(|allocation| allocation.sequence);
+    assert_eq!(
+        allocations
+            .iter()
+            .map(|allocation| allocation.sequence)
+            .collect::<Vec<_>>(),
+        (1..=24).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        allocations
+            .iter()
+            .map(|allocation| allocation.id.clone())
+            .collect::<HashSet<_>>()
+            .len(),
+        24
+    );
+    let reopened = RemoteStore::open(&database).expect("reopen");
+    let audits: i64 = reopened
+        .connection()
+        .lock()
+        .expect("connection")
+        .query_row(
+            "SELECT COUNT(*) FROM audit_events WHERE tool_name = ?1",
+            [HUB_KNOWLEDGE_ALLOCATION_METHOD_V1],
+            |row| row.get(0),
+        )
+        .expect("audit count");
+    assert_eq!(audits, 24);
+}
+
+#[test]
+fn restart_is_idempotent_and_late_workspace_reconciliation_is_required() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let database = directory.path().join("remote.db");
+    let initial = inventory(
+        "ws_alpha",
+        vec![legacy(
+            KnowledgeIdKind::Adr,
+            "ADR-0008",
+            &["adr-file:superseded"],
+        )],
+    );
+    let store = RemoteStore::open(&database).expect("store");
+    let initial_service = service(store, &["ws_alpha"]);
+    initial_service
+        .activate(vec![initial.clone()])
+        .expect("activate");
+    drop(initial_service);
+
+    let reopened = RemoteStore::open(&database).expect("reopen");
+    let restarted = service(reopened.clone(), &["ws_alpha"]);
+    let state = restarted
+        .activate(vec![initial])
+        .expect("idempotent activation");
+    assert_eq!(state.status, HubKnowledgeAllocatorStatus::Active);
+    assert_eq!(state.adr_next_sequence, 9);
+
+    let expanded = service(reopened.clone(), &["ws_alpha", "ws_beta"]);
+    let error = expanded
+        .allocate(
+            &request("ws_beta", KnowledgeIdKind::Adr),
+            &context("ws_beta", "mcall-too-early"),
+        )
+        .expect_err("late workspace is ineligible")
+        .to_string();
+    assert!(error.contains("not eligible"), "{error}");
+    expanded
+        .reconcile_workspace(inventory(
+            "ws_beta",
+            vec![legacy(
+                KnowledgeIdKind::Adr,
+                "ADR-0015",
+                &["allocation:abandoned"],
+            )],
+        ))
+        .expect("late reconciliation");
+    let allocation = expanded
+        .allocate(
+            &request("ws_beta", KnowledgeIdKind::Adr),
+            &context("ws_beta", "mcall-late"),
+        )
+        .expect("late workspace allocation");
+    assert_eq!(allocation.id, "ADR-0016");
+}
+
+#[test]
+fn late_reconciliation_reports_all_collisions_and_ledger_is_immutable() {
+    let store = RemoteStore::open_in_memory().expect("store");
+    let initial = service(store.clone(), &["ws_a"]);
+    initial
+        .activate(vec![inventory(
+            "ws_a",
+            vec![
+                legacy(KnowledgeIdKind::Adr, "ADR-0002", &["adr-file:accepted"]),
+                legacy(
+                    KnowledgeIdKind::Learning,
+                    "L-0005",
+                    &["learning-file:active"],
+                ),
+            ],
+        )])
+        .expect("activate");
+    let expanded = service(store.clone(), &["ws_a", "ws_b"]);
+    let error = expanded
+        .reconcile_workspace(inventory(
+            "ws_b",
+            vec![
+                legacy(KnowledgeIdKind::Adr, "ADR-00002", &["allocation:merged"]),
+                legacy(
+                    KnowledgeIdKind::Learning,
+                    "L-00005",
+                    &["allocation:reserved"],
+                ),
+            ],
+        ))
+        .expect_err("collisions")
+        .to_string();
+    for expected in ["ADR-0002", "ADR-00002", "L-0005", "L-00005", "ws_a", "ws_b"] {
+        assert!(error.contains(expected), "missing '{expected}' in {error}");
+    }
+
+    let allocation = initial
+        .allocate(
+            &request("ws_a", KnowledgeIdKind::Adr),
+            &context("ws_a", "mcall-immutable"),
+        )
+        .expect("allocation");
+    let connection = store.connection();
+    let connection = connection.lock().expect("connection");
+    let update = connection
+        .execute(
+            "UPDATE hub_knowledge_allocation_ledger SET id = 'ADR-9999' WHERE mcp_call_id = ?1",
+            params![allocation.mcp_call_id],
+        )
+        .expect_err("ledger update must fail")
+        .to_string();
+    assert!(update.contains("immutable"), "{update}");
+    let delete = connection
+        .execute(
+            "DELETE FROM hub_knowledge_allocation_ledger WHERE mcp_call_id = ?1",
+            params![allocation.mcp_call_id],
+        )
+        .expect_err("ledger delete must fail")
+        .to_string();
+    assert!(delete.contains("immutable"), "{delete}");
+}
+
+#[test]
+fn overflow_and_invalid_identity_do_not_advance_or_leave_partial_rows() {
+    let store = RemoteStore::open_in_memory().expect("store");
+    let service = service(store.clone(), &["ws_alpha"]);
+    service
+        .activate(vec![inventory("ws_alpha", Vec::new())])
+        .expect("activate");
+    store
+        .connection()
+        .lock()
+        .expect("connection")
+        .execute(
+            "UPDATE hub_knowledge_sequences SET next_sequence = 4294967296 WHERE kind = 'adr'",
+            [],
+        )
+        .expect("seed exhaustion");
+    let error = service
+        .allocate(
+            &request("ws_alpha", KnowledgeIdKind::Adr),
+            &context("ws_alpha", "mcall-overflow"),
+        )
+        .expect_err("overflow must fail")
+        .to_string();
+    assert!(error.contains("exhausted"), "{error}");
+
+    let mut wrong_context = context("ws_other", "mcall-invalid");
+    wrong_context.workspace_id = Some("ws_other".to_string());
+    let error = service
+        .allocate(
+            &request("ws_alpha", KnowledgeIdKind::Learning),
+            &wrong_context,
+        )
+        .expect_err("workspace identity mismatch")
+        .to_string();
+    assert!(error.contains("does not match"), "{error}");
+    for (call_id, label) in [("", "empty"), ("  ", "whitespace")] {
+        let mut invalid_correlation = context("ws_alpha", "placeholder");
+        invalid_correlation.mcp_call_id = Some(call_id.to_string());
+        let error = service
+            .allocate(
+                &request("ws_alpha", KnowledgeIdKind::Learning),
+                &invalid_correlation,
+            )
+            .expect_err("invalid correlation must fail")
+            .to_string();
+        assert!(error.contains("mcp_call_id"), "{label}: {error}");
+    }
+
+    let connection = store.connection();
+    let connection = connection.lock().expect("connection");
+    let (adr_next, learning_next, ids, ledger, audits): (i64, i64, i64, i64, i64) = connection
+        .query_row(
+            "SELECT
+                (SELECT next_sequence FROM hub_knowledge_sequences WHERE kind = 'adr'),
+                (SELECT next_sequence FROM hub_knowledge_sequences WHERE kind = 'learning'),
+                (SELECT COUNT(*) FROM hub_knowledge_ids),
+                (SELECT COUNT(*) FROM hub_knowledge_allocation_ledger),
+                (SELECT COUNT(*) FROM audit_events WHERE tool_name = ?1)",
+            [HUB_KNOWLEDGE_ALLOCATION_METHOD_V1],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            },
+        )
+        .expect("unchanged state");
+    assert_eq!(
+        (adr_next, learning_next, ids, ledger, audits),
+        (4294967296, 1, 0, 0, 0)
+    );
+}
+
+#[test]
+fn adr_and_learning_sequences_interleave_independently_and_allow_legacy_gaps() {
+    let store = RemoteStore::open_in_memory().expect("store");
+    let service = service(store, &["ws_alpha", "ws_beta"]);
+    service
+        .activate(vec![
+            inventory("ws_alpha", Vec::new()),
+            inventory("ws_beta", Vec::new()),
+        ])
+        .expect("activate");
+    let adr_one = service
+        .allocate(
+            &request("ws_alpha", KnowledgeIdKind::Adr),
+            &context("ws_alpha", "mcall-interleave-adr-1"),
+        )
+        .expect("adr one");
+    let learning_one = service
+        .allocate(
+            &request("ws_alpha", KnowledgeIdKind::Learning),
+            &context("ws_alpha", "mcall-interleave-learning-1"),
+        )
+        .expect("learning one");
+    let adr_two = service
+        .allocate(
+            &request("ws_beta", KnowledgeIdKind::Adr),
+            &context("ws_beta", "mcall-interleave-adr-2"),
+        )
+        .expect("adr two");
+    assert_eq!(
+        (
+            adr_one.id.as_str(),
+            learning_one.id.as_str(),
+            adr_two.id.as_str()
+        ),
+        ("ADR-0001", "L-0001", "ADR-0002")
+    );
+
+    service
+        .reconcile_workspace(inventory(
+            "ws_beta",
+            vec![legacy(
+                KnowledgeIdKind::Adr,
+                "ADR-0010",
+                &["allocation:abandoned"],
+            )],
+        ))
+        .expect("reconcile sparse legacy max");
+    let adr_after_gap = service
+        .allocate(
+            &request("ws_alpha", KnowledgeIdKind::Adr),
+            &context("ws_alpha", "mcall-interleave-adr-11"),
+        )
+        .expect("adr after gap");
+    let learning_two = service
+        .allocate(
+            &request("ws_beta", KnowledgeIdKind::Learning),
+            &context("ws_beta", "mcall-interleave-learning-2"),
+        )
+        .expect("learning two");
+    assert_eq!(adr_after_gap.id, "ADR-0011");
+    assert_eq!(learning_two.id, "L-0002");
+}

--- a/crates/orbit-remote/src/persistence/tests/mod.rs
+++ b/crates/orbit-remote/src/persistence/tests/mod.rs
@@ -1,2 +1,3 @@
 mod adoption;
+mod knowledge;
 mod registry;

--- a/crates/orbit-remote/src/tests/knowledge.rs
+++ b/crates/orbit-remote/src/tests/knowledge.rs
@@ -1,0 +1,446 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use orbit_common::types::{
+    HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION, HubKnowledgeAllocationRequestV1, KnowledgeIdKind,
+    McpCapability, McpTransport, ToolSessionContext, Workspace, WorkspaceCheckout,
+    WorkspaceCheckoutRole, WorkspaceRegistry, WorkspaceStatus,
+};
+use rusqlite::Connection;
+
+use crate::{HubKnowledgeSequenceService, scan_registered_knowledge_inventories};
+
+fn write_identity(root: &Path, mode: &str) {
+    fs::write(
+        root.join("host.toml"),
+        format!(
+            "schema_version = 1\nmachine_id = \"hm_hub\"\nhost_id = \"hub\"\nmode = \"{mode}\"\n"
+        ),
+    )
+    .expect("host identity");
+}
+
+fn configure_hub(root: &Path, machine_id: &str) {
+    let service = crate::host_registry_service_at(root).expect("host registry service");
+    service
+        .register_hub_identity(
+            &crate::HostIdentity {
+                schema_version: crate::HOST_IDENTITY_SCHEMA_VERSION,
+                machine_id: machine_id.to_string(),
+                host_id: "configured-hub".to_string(),
+                mode: crate::HostMode::Hub,
+            },
+            BTreeSet::new(),
+        )
+        .expect("configured hub identity");
+}
+
+fn allocation_context(workspace_id: &str, mcp_call_id: &str) -> ToolSessionContext {
+    ToolSessionContext {
+        workspace: None,
+        workspace_id: Some(workspace_id.to_string()),
+        caller_machine_id: Some("hm_hub".to_string()),
+        caller_host_id: Some("hub".to_string()),
+        process_machine_id: Some("hm_hub".to_string()),
+        process_host_id: Some("hub".to_string()),
+        transport: Some(McpTransport::Local),
+        effective_capabilities: BTreeSet::from([McpCapability::Agent]),
+        origin_session_id: Some("knowledge-test".to_string()),
+        mcp_call_id: Some(mcp_call_id.to_string()),
+        leased_run: None,
+    }
+}
+
+fn workspace(root: &Path, id: &str) -> (Workspace, WorkspaceCheckout) {
+    let repo_root = root.join(id);
+    let orbit_dir = repo_root.join(".orbit");
+    fs::create_dir_all(&orbit_dir).expect("orbit dir");
+    (
+        Workspace {
+            id: id.to_string(),
+            name: id.to_string(),
+            owner_machine_id: Some("hm_hub".to_string()),
+            git_remote: None,
+            ship_mode: None,
+            base_branch: "agent-main".to_string(),
+            status: WorkspaceStatus::Active,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        },
+        WorkspaceCheckout {
+            workspace_id: id.to_string(),
+            repo_root,
+            orbit_dir,
+            role: Some(WorkspaceCheckoutRole::Owner),
+            owner_machine_id: None,
+            path_overrides: Vec::new(),
+        },
+    )
+}
+
+fn save_registry(root: &Path, entries: Vec<(Workspace, WorkspaceCheckout)>) {
+    let (workspaces, checkouts): (Vec<_>, Vec<_>) = entries.into_iter().unzip();
+    crate::workspace_registry::save_registry_to(
+        &WorkspaceRegistry {
+            workspaces,
+            checkouts,
+            ..WorkspaceRegistry::default()
+        },
+        &crate::workspace_registry::registry_path_for(root),
+    )
+    .expect("registry");
+}
+
+fn write_adr(orbit_dir: &Path, state: &str, id: &str) {
+    let directory = orbit_dir.join("adrs").join(state).join(id);
+    fs::create_dir_all(&directory).expect("adr directory");
+    fs::write(directory.join("adr.yaml"), format!("id: {id}\n")).expect("adr yaml");
+}
+
+fn write_learning(orbit_dir: &Path, id: &str, status: &str) {
+    let directory = orbit_dir.join("learnings").join(id);
+    fs::create_dir_all(&directory).expect("learning directory");
+    fs::write(
+        directory.join("learning.yaml"),
+        format!("id: {id}\nstatus: {status}\n"),
+    )
+    .expect("learning yaml");
+}
+
+fn write_allocations(orbit_dir: &Path) {
+    let database = orbit_dir.join("state").join("semantic.db");
+    fs::create_dir_all(database.parent().expect("database parent")).expect("state dir");
+    let connection = Connection::open(database).expect("semantic db");
+    connection
+        .execute_batch(
+            "CREATE TABLE id_allocations (
+                 kind TEXT NOT NULL,
+                 id TEXT NOT NULL,
+                 status TEXT NOT NULL,
+                 worktree_root TEXT NOT NULL,
+                 body_path TEXT
+             );
+             INSERT INTO id_allocations VALUES
+                 ('adr', 'ADR-0007', 'reserved', '/outside/hub', '/arbitrary/ADR-9999/body.md'),
+                 ('learning', 'L-0008', 'merged', '/stale/worktree', '../outside.yaml'),
+                 ('adr', 'ADR-0009', 'abandoned', '/deleted/worktree', NULL);",
+        )
+        .expect("allocation rows");
+}
+
+fn snapshot_files(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+    fn visit(root: &Path, directory: &Path, files: &mut BTreeMap<PathBuf, Vec<u8>>) {
+        let mut entries = fs::read_dir(directory)
+            .expect("snapshot directory")
+            .map(|entry| entry.expect("snapshot entry"))
+            .collect::<Vec<_>>();
+        entries.sort_by_key(|entry| entry.path());
+        for entry in entries {
+            let path = entry.path();
+            let kind = entry.file_type().expect("snapshot file type");
+            if kind.is_dir() {
+                visit(root, &path, files);
+            } else if kind.is_file() {
+                files.insert(
+                    path.strip_prefix(root)
+                        .expect("relative snapshot")
+                        .to_path_buf(),
+                    fs::read(path).expect("snapshot file"),
+                );
+            }
+        }
+    }
+    let mut files = BTreeMap::new();
+    visit(root, root, &mut files);
+    files
+}
+
+#[test]
+fn scanner_covers_every_file_lifecycle_and_allocation_status_without_following_row_paths() {
+    let root = tempfile::tempdir().expect("root");
+    write_identity(root.path(), "hub");
+    let (workspace_alpha, checkout_alpha) = workspace(root.path(), "ws_alpha");
+    let (workspace_beta, checkout_beta) = workspace(root.path(), "ws_beta");
+    let orbit_dir = checkout_alpha.orbit_dir.clone();
+    let beta_orbit_dir = checkout_beta.orbit_dir.clone();
+    save_registry(
+        root.path(),
+        vec![
+            (workspace_alpha, checkout_alpha),
+            (workspace_beta, checkout_beta),
+        ],
+    );
+
+    for (state, id) in [
+        ("proposed", "ADR-0001"),
+        ("accepted", "ADR-0002"),
+        ("superseded", "ADR-0003"),
+        ("deleted", "ADR-0004"),
+    ] {
+        write_adr(&orbit_dir, state, id);
+    }
+    write_learning(&orbit_dir, "L-0005", "active");
+    write_learning(&orbit_dir, "L-0006", "superseded");
+    write_allocations(&orbit_dir);
+    write_adr(&beta_orbit_dir, "accepted", "ADR-0010");
+    write_learning(&beta_orbit_dir, "L-0011", "active");
+
+    let before = snapshot_files(root.path());
+    let inventories = scan_registered_knowledge_inventories(root.path()).expect("scan");
+    assert_eq!(
+        snapshot_files(root.path()),
+        before,
+        "scanner mutated source bytes"
+    );
+    assert_eq!(inventories.len(), 2);
+    let alpha = inventories
+        .iter()
+        .find(|inventory| inventory.workspace_id == "ws_alpha")
+        .expect("alpha inventory");
+    let actual = alpha
+        .ids
+        .iter()
+        .map(|record| ((record.kind, record.id.clone()), record.evidence.clone()))
+        .collect::<BTreeMap<_, _>>();
+    for (kind, id, source) in [
+        (KnowledgeIdKind::Adr, "ADR-0001", "adr-file:proposed"),
+        (KnowledgeIdKind::Adr, "ADR-0002", "adr-file:accepted"),
+        (KnowledgeIdKind::Adr, "ADR-0003", "adr-file:superseded"),
+        (KnowledgeIdKind::Adr, "ADR-0004", "adr-file:deleted"),
+        (KnowledgeIdKind::Learning, "L-0005", "learning-file:active"),
+        (
+            KnowledgeIdKind::Learning,
+            "L-0006",
+            "learning-file:superseded",
+        ),
+        (KnowledgeIdKind::Adr, "ADR-0007", "allocation:reserved"),
+        (KnowledgeIdKind::Learning, "L-0008", "allocation:merged"),
+        (KnowledgeIdKind::Adr, "ADR-0009", "allocation:abandoned"),
+    ] {
+        assert_eq!(
+            actual.get(&(kind, id.to_string())),
+            Some(&BTreeSet::from([source.to_string()])),
+            "{kind:?} {id}"
+        );
+    }
+    assert_eq!(actual.len(), 9);
+    let beta = inventories
+        .iter()
+        .find(|inventory| inventory.workspace_id == "ws_beta")
+        .expect("beta inventory");
+    assert_eq!(
+        beta.ids
+            .iter()
+            .map(|record| record.id.as_str())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from(["ADR-0010", "L-0011"])
+    );
+}
+
+#[test]
+fn scanner_ignores_derived_global_indexes_and_accepts_missing_semantic_db_after_file_scan() {
+    let root = tempfile::tempdir().expect("root");
+    write_identity(root.path(), "hub");
+    let (workspace, checkout) = workspace(root.path(), "ws_alpha");
+    let orbit_dir = checkout.orbit_dir.clone();
+    save_registry(root.path(), vec![(workspace, checkout)]);
+    write_adr(&orbit_dir, "accepted", "ADR-0042");
+
+    // A malformed global audit DB would have blocked the old derived-index
+    // scanner. It is not an activation source and must remain irrelevant.
+    fs::write(root.path().join("orbit.db"), b"stale derived cache").expect("stale cache");
+    let inventories = scan_registered_knowledge_inventories(root.path()).expect("scan files");
+    assert_eq!(inventories[0].ids.len(), 1);
+    assert_eq!(inventories[0].ids[0].id, "ADR-0042");
+}
+
+#[test]
+fn scanner_fails_on_present_but_unreadable_or_non_file_semantic_database() {
+    for directory_instead_of_file in [false, true] {
+        let root = tempfile::tempdir().expect("root");
+        write_identity(root.path(), "hub");
+        let (workspace, checkout) = workspace(root.path(), "ws_alpha");
+        let database = checkout.orbit_dir.join("state").join("semantic.db");
+        fs::create_dir_all(database.parent().expect("parent")).expect("state dir");
+        if directory_instead_of_file {
+            fs::create_dir(&database).expect("database directory");
+        } else {
+            fs::write(&database, b"not a sqlite database").expect("malformed database");
+        }
+        save_registry(root.path(), vec![(workspace, checkout)]);
+        let error = scan_registered_knowledge_inventories(root.path())
+            .expect_err("present invalid database must fail")
+            .to_string();
+        assert!(error.contains("semantic.db"), "{error}");
+    }
+}
+
+#[test]
+fn scanner_names_missing_hub_local_source_and_leaves_dormant_store_unchanged() {
+    let root = tempfile::tempdir().expect("root");
+    write_identity(root.path(), "hub");
+    crate::workspace_registry::save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![Workspace {
+                id: "ws_checkoutless".to_string(),
+                name: "Checkoutless".to_string(),
+                owner_machine_id: Some("hm_owner".to_string()),
+                git_remote: None,
+                ship_mode: None,
+                base_branch: "agent-main".to_string(),
+                status: WorkspaceStatus::Active,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            }],
+            ..WorkspaceRegistry::default()
+        },
+        &crate::workspace_registry::registry_path_for(root.path()),
+    )
+    .expect("checkoutless registry");
+    let store = crate::remote_store_at(root.path()).expect("dormant store");
+    let before = snapshot_files(root.path());
+
+    let error = scan_registered_knowledge_inventories(root.path())
+        .expect_err("missing local source must block activation scan")
+        .to_string();
+    assert!(error.contains("ws_checkoutless"), "{error}");
+    assert!(error.contains("hub-local checkout"), "{error}");
+    assert_eq!(
+        snapshot_files(root.path()),
+        before,
+        "failed scan mutated bytes"
+    );
+    let state = store.knowledge_allocator_state().expect("allocator state");
+    assert_eq!(state.activation_generation, 0);
+    assert!(state.activated_at.is_none());
+}
+
+#[test]
+fn scanner_rejects_stale_primary_orbit_dir_without_mutating_dormant_store() {
+    let root = tempfile::tempdir().expect("root");
+    write_identity(root.path(), "hub");
+    let (mut workspace, checkout) = workspace(root.path(), "ws_stale");
+    workspace.status = WorkspaceStatus::Invalid;
+    fs::remove_dir(&checkout.orbit_dir).expect("remove empty orbit dir");
+    let stale_path = checkout.orbit_dir.clone();
+    save_registry(root.path(), vec![(workspace, checkout)]);
+    let store = crate::remote_store_at(root.path()).expect("dormant store");
+    let before = snapshot_files(root.path());
+
+    let error = scan_registered_knowledge_inventories(root.path())
+        .expect_err("stale primary binding must block activation scan")
+        .to_string();
+    for expected in [
+        "ws_stale",
+        stale_path.to_string_lossy().as_ref(),
+        "orbit_dir",
+        "stale",
+        "unresolved migration source",
+    ] {
+        assert!(error.contains(expected), "missing '{expected}' in {error}");
+    }
+    assert_eq!(
+        snapshot_files(root.path()),
+        before,
+        "failed scan mutated bytes"
+    );
+    let state = store.knowledge_allocator_state().expect("allocator state");
+    assert_eq!(state.activation_generation, 0);
+    assert!(state.activated_at.is_none());
+}
+
+#[test]
+fn inactive_registered_workspace_contributes_global_max_but_cannot_allocate() {
+    let root = tempfile::tempdir().expect("root");
+    write_identity(root.path(), "hub");
+    configure_hub(root.path(), "hm_hub");
+    let (active, active_checkout) = workspace(root.path(), "ws_active");
+    let (mut inactive, inactive_checkout) = workspace(root.path(), "ws_inactive");
+    inactive.status = WorkspaceStatus::Invalid;
+    write_adr(&inactive_checkout.orbit_dir, "accepted", "ADR-0099");
+    save_registry(
+        root.path(),
+        vec![(active, active_checkout), (inactive, inactive_checkout)],
+    );
+
+    let inventories =
+        scan_registered_knowledge_inventories(root.path()).expect("scan all registered");
+    assert_eq!(inventories.len(), 2);
+    let service = HubKnowledgeSequenceService::at(root.path()).expect("authoritative service");
+    let state = service.activate(inventories).expect("activate");
+    assert_eq!(state.adr_next_sequence, 100);
+    let allocation = service
+        .allocate(
+            &HubKnowledgeAllocationRequestV1 {
+                schema_version: HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION,
+                workspace_id: "ws_active".to_string(),
+                kind: KnowledgeIdKind::Adr,
+                model: None,
+            },
+            &allocation_context("ws_active", "mcall-inactive-max"),
+        )
+        .expect("allocate above inactive max");
+    assert_eq!(allocation.id, "ADR-0100");
+    let error = service
+        .allocate(
+            &HubKnowledgeAllocationRequestV1 {
+                schema_version: HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION,
+                workspace_id: "ws_inactive".to_string(),
+                kind: KnowledgeIdKind::Adr,
+                model: None,
+            },
+            &allocation_context("ws_inactive", "mcall-inactive-denied"),
+        )
+        .expect_err("inactive workspace must not allocate")
+        .to_string();
+    assert!(error.contains("inactive"), "{error}");
+}
+
+#[test]
+fn production_service_rejects_unstamped_and_shadow_hub_stores() {
+    let unstamped = tempfile::tempdir().expect("unstamped root");
+    write_identity(unstamped.path(), "hub");
+    let error = match HubKnowledgeSequenceService::at(unstamped.path()) {
+        Ok(_) => panic!("unstamped store must not construct allocation authority"),
+        Err(error) => error.to_string(),
+    };
+    assert!(error.contains("no configured hub_machine_id"), "{error}");
+    let state = crate::remote_store_at(unstamped.path())
+        .expect("unstamped store")
+        .knowledge_allocator_state()
+        .expect("unstamped state");
+    assert_eq!(state.activation_generation, 0);
+    assert!(state.activated_at.is_none());
+
+    let shadow = tempfile::tempdir().expect("shadow root");
+    write_identity(shadow.path(), "hub");
+    configure_hub(shadow.path(), "hm_other");
+    let error = match HubKnowledgeSequenceService::at(shadow.path()) {
+        Ok(_) => panic!("shadow store must not construct allocation authority"),
+        Err(error) => error.to_string(),
+    };
+    assert!(error.contains("hm_hub"), "{error}");
+    assert!(error.contains("hm_other"), "{error}");
+    assert!(error.contains("shadow"), "{error}");
+    let state = crate::remote_store_at(shadow.path())
+        .expect("shadow store")
+        .knowledge_allocator_state()
+        .expect("shadow state");
+    assert_eq!(state.activation_generation, 0);
+    assert!(state.activated_at.is_none());
+}
+
+#[test]
+fn production_service_rejects_standalone_before_opening_allocation_authority() {
+    let root = tempfile::tempdir().expect("root");
+    write_identity(root.path(), "standalone");
+    let error = match HubKnowledgeSequenceService::at(root.path()) {
+        Ok(_) => panic!("standalone must not construct hub allocation authority"),
+        Err(error) => error.to_string(),
+    };
+    assert!(error.contains("hub-local"), "{error}");
+    assert!(error.contains("standalone"), "{error}");
+    assert!(!root.path().join("orbit.db").exists());
+}

--- a/crates/orbit-remote/src/tests/mod.rs
+++ b/crates/orbit-remote/src/tests/mod.rs
@@ -2,6 +2,7 @@
 
 mod host_identity;
 mod host_registry;
+mod knowledge;
 mod profile;
 mod registry_cache;
 mod routines;

--- a/crates/orbit-store/src/sqlite/audit_event_store/mod.rs
+++ b/crates/orbit-store/src/sqlite/audit_event_store/mod.rs
@@ -11,7 +11,7 @@ use chrono::{DateTime, Utc};
 use orbit_common::types::{AuditEvent, AuditEventStatus, McpCapability, McpTransport, OrbitError};
 use rusqlite::params;
 
-use crate::{Store, now_string, parse_timestamp};
+use crate::{Store, StoreTx, now_string, parse_timestamp};
 
 #[derive(Debug, Clone)]
 pub struct AuditEventInsertParams {
@@ -209,61 +209,82 @@ impl Store {
             .lock()
             .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
 
-        let capabilities_json = serde_json::to_string(&params.effective_capabilities)
-            .map_err(|error| OrbitError::Store(format!("serialize MCP capability set: {error}")))?;
+        insert_audit_event_record_on_connection(&conn, params)
+    }
+}
 
-        conn.execute(
-            r#"INSERT INTO audit_events(
-                execution_id, timestamp, command, subcommand, tool_name,
-                target_type, target_id, role, status, exit_code,
-                duration_ms, working_directory, arguments_json,
-                stdout_truncated, stderr_truncated, error_message,
-                host, pid, session_id, workspace_id, caller_machine_id,
-                caller_host_id, process_machine_id, process_host_id, transport,
-                capabilities_json, origin_session_id, mcp_call_id, lease_id,
-                task_id, job_run_id, activity_id, step_index
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33)"#,
-            rusqlite::params![
-                params.execution_id,
-                now_string(),
-                params.command,
-                params.subcommand,
-                params.tool_name,
-                params.target_type,
-                params.target_id,
-                params.role,
-                params.status.to_string(),
-                params.exit_code,
-                params.duration_ms,
-                params.working_directory,
-                params.arguments_json,
-                params.stdout_truncated,
-                params.stderr_truncated,
-                params.error_message,
-                params.host,
-                params.pid,
-                params.session_id,
-                params.workspace_id,
-                params.caller_machine_id,
-                params.caller_host_id,
-                params.process_machine_id,
-                params.process_host_id,
-                params.transport.map(|transport| transport.to_string()),
-                capabilities_json,
-                params.origin_session_id,
-                params.mcp_call_id,
-                params.lease_id,
-                params.task_id,
-                params.job_run_id,
-                params.activity_id,
-                params.step_index,
-            ],
-        )
+impl StoreTx<'_> {
+    /// Insert one canonical audit row inside the caller's existing Store
+    /// transaction. Vertical features use this when their domain mutation and
+    /// its audit outcome must commit or roll back together.
+    pub fn insert_audit_event_record(
+        &mut self,
+        params: &AuditEventInsertParams,
+    ) -> Result<(), OrbitError> {
+        insert_audit_event_record_on_connection(self.connection(), params)
+    }
+}
+
+fn insert_audit_event_record_on_connection(
+    conn: &rusqlite::Connection,
+    params: &AuditEventInsertParams,
+) -> Result<(), OrbitError> {
+    let capabilities_json = serde_json::to_string(&params.effective_capabilities)
+        .map_err(|error| OrbitError::Store(format!("serialize MCP capability set: {error}")))?;
+
+    conn.execute(
+        r#"INSERT INTO audit_events(
+            execution_id, timestamp, command, subcommand, tool_name,
+            target_type, target_id, role, status, exit_code,
+            duration_ms, working_directory, arguments_json,
+            stdout_truncated, stderr_truncated, error_message,
+            host, pid, session_id, workspace_id, caller_machine_id,
+            caller_host_id, process_machine_id, process_host_id, transport,
+            capabilities_json, origin_session_id, mcp_call_id, lease_id,
+            task_id, job_run_id, activity_id, step_index
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33)"#,
+        rusqlite::params![
+            params.execution_id,
+            now_string(),
+            params.command,
+            params.subcommand,
+            params.tool_name,
+            params.target_type,
+            params.target_id,
+            params.role,
+            params.status.to_string(),
+            params.exit_code,
+            params.duration_ms,
+            params.working_directory,
+            params.arguments_json,
+            params.stdout_truncated,
+            params.stderr_truncated,
+            params.error_message,
+            params.host,
+            params.pid,
+            params.session_id,
+            params.workspace_id,
+            params.caller_machine_id,
+            params.caller_host_id,
+            params.process_machine_id,
+            params.process_host_id,
+            params.transport.map(|transport| transport.to_string()),
+            capabilities_json,
+            params.origin_session_id,
+            params.mcp_call_id,
+            params.lease_id,
+            params.task_id,
+            params.job_run_id,
+            params.activity_id,
+            params.step_index,
+        ],
+    )
         .map_err(|e| OrbitError::Store(e.to_string()))?;
 
-        Ok(())
-    }
+    Ok(())
+}
 
+impl Store {
     pub fn list_audit_events(
         &self,
         filter: &AuditEventFilter,

--- a/docs/design/host-registry/2_design.md
+++ b/docs/design/host-registry/2_design.md
@@ -1,7 +1,7 @@
 ---
 title: Host Registry — Design
 owner: claude
-last_updated: 2026-07-18
+last_updated: 2026-07-19
 status: Accepted
 feature: host-registry
 doc_role: design
@@ -10,7 +10,7 @@ summary: Target mechanisms for host identity, the main-host registry, the coordi
 tags: [host-registry, multi-host, dispatch, routines, data-placement]
 paths: ["crates/orbit-remote/**", "crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**", "crates/orbit-common/**"]
 related_features: [host-registry, mcp-bridge, routines, remote-access, mcp-session-context]
-related_artifacts: [ORB-00424, ORB-10247, ORB-10248, ORB-10249, ORB-10255, ORB-10257, ORB-10258, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10302, ORB-10319, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
+related_artifacts: [ORB-00424, ORB-10247, ORB-10248, ORB-10249, ORB-10255, ORB-10257, ORB-10258, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10302, ORB-10319, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
 ---
 
 # Host Registry — Design
@@ -20,9 +20,12 @@ catalog, registry core/projections, operator administration, sanitized discovery
 and the satellite-cache format landed through C4. E1's strict hub trust document
 and fixed checkoutless hub MCP endpoint, E2's bounded verified spoke link, and E3's
 private registration plus first remote coordination slice have landed
-[ORB-10268, ORB-10269, ORB-10271]. [ORB-10319] then consolidates those coupled
+[ORB-10268, ORB-10269, ORB-10271]. [ORB-10319] then consolidated those coupled
 pieces into the vertical `orbit-remote` feature crate described by [ADR-0240],
-superseding the earlier horizontal boundary in [ADR-0235] when it lands. Run
+superseding the earlier horizontal boundary in [ADR-0235]. [ORB-10272] adds the
+dormant hub-global ADR/learning sequence substrate inside that boundary; public
+knowledge creation remains on the standalone compatibility path until the F3
+cutover. Run
 placement, polling, and later phases remain pending. The folder is Accepted. It
 covers host identity, the registry, the
 coordination-plane/workspace-ownership split, execution placement (including the
@@ -181,6 +184,13 @@ and namespaced feature-migration machinery; it does not import Remote. Remote v1
 adopts the immutable global v5/v6/v8 registry tables in place and refuses an unknown
 future Remote schema instead of copying rows or creating a second database
 ([ORB-10319], [ADR-0240]).
+
+Remote feature migration v2 adds the dormant hub knowledge-ID tables in that same
+config-resolved database ([ORB-10272]). Opening `RemoteStore` applies only the
+schema: it does not inspect a checkout, reconcile a workspace, advance either
+sequence, or activate hub authority. This preserves standalone creation and makes
+activation an explicit, restart-safe transition rather than a side effect of
+opening the hub.
 
 **Boundary with `~/.orbit/mcp.toml`.** The registry is server-side *inventory*;
 `mcp.toml` is the client's trust policy for its one hub route. They stay separate:
@@ -462,6 +472,43 @@ Per-record placement rules, chosen to dissolve sync rather than implement it:
 
 Notes:
 
+- **F1 installs the hub-global allocator but does not cut callers over.** Remote
+  feature migration v2 creates independent monotonic `adr` and `learning`
+  sequences, a reconciliation projection, an immutable allocation ledger, and a
+  dormant/active authority marker in the hub's shared `orbit.db` [ORB-10272]. The
+  existing standalone/worktree allocator and all current ADR/learning create paths
+  remain unchanged. F3 alone activates public issuance and replaces those callers;
+  a standalone host cannot enter hub authority merely by opening the database.
+- **Activation validates the complete hub-local inventory before mutation.** The
+  hub inventories every registered workspace from locally available migration
+  sources: ADR and learning files in every valid lifecycle state plus every legacy
+  allocation row, including reserved, unfinalized, and abandoned rows. A missing
+  source fails precondition with the workspace named; the hub never contacts or
+  proxies to its owner. The full inventory is validated before a sequence,
+  reconciliation row, ledger row, or audit row changes. Every cross-workspace
+  duplicate `(kind, id)` is reported with all conflicting workspace/source
+  evidence and is never renumbered.
+- **Seeding is forward-only and restart-safe.** Under one hub write lock, a final
+  reseed advances each sequence above its independently computed global maximum,
+  records the reconciled workspace/source digest, and activates authority in one
+  durable transition. Repeating or reopening that transition is idempotent and
+  can never decrease a sequence. A workspace registered after activation is
+  knowledge-ineligible until the same complete local reconciliation succeeds
+  under the allocator lock; registration cannot make an unscanned workspace
+  eligible.
+- **Allocation is one atomic hub transaction.** A successful allocation advances
+  exactly one kind's sequence, appends an immutable row keyed by `mcp_call_id`, and
+  writes one canonical SQLite audit carrying the trusted ORB-10271 caller/process
+  provenance. Exact replay is idempotent only when the full stored request identity
+  matches; reusing a correlation ID for another request fails without advancement.
+  Internal lookup exists by correlation and by `(workspace, kind, id)`. Invalid
+  kind/workspace/correlation, ineligible workspace, and overflow likewise leave
+  both sequences unchanged.
+- **Allocated IDs are final gaps, not reservations.** There is no release,
+  abandon, expiry, reuse, or remote-finalize API. Owner finalization may fail after
+  allocation and leave a valid unused ID. That gap is deliberate and does not
+  grant the hub a route to a spoke owner.
+
 - **Knowledge is one-writer per workspace — the owner.** The owner authors the file
   in its own checkout and commits there; the global ID comes from the hub in a
   single allocation call first (in-process when the owner *is* the hub). Allocation
@@ -603,5 +650,10 @@ of that routine.** Consequences:
   caller validation on every ordinary hub call, staged projection/snapshot results,
   definitive-success cache refresh, operator-only friction list/show, and the
   hermetic two-root coordination/provenance canary.
+- [ORB-10272] — adds Remote feature migration v2 and the dormant hub-global ADR and
+  learning sequence service: complete validated hub-local reconciliation,
+  forward-only activation, replay-safe immutable correlation ledger, atomic audit,
+  and explicit late-workspace ineligibility without changing standalone creation
+  or activating the F3 cutover.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/host-registry/4_decisions.md
+++ b/docs/design/host-registry/4_decisions.md
@@ -1,7 +1,7 @@
 ---
 title: Host Registry — Decisions
 owner: claude
-last_updated: 2026-07-18
+last_updated: 2026-07-19
 status: Accepted
 feature: host-registry
 doc_role: decisions
@@ -10,7 +10,7 @@ summary: ADR log for the coupled Host Registry and MCP Bridge v1 contract and it
 tags: [host-registry, mcp-bridge, multi-host, placement]
 paths: ["crates/orbit-remote/**", "crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**"]
 related_features: [host-registry, mcp-bridge]
-related_artifacts: [ORB-00424, ORB-10245, ORB-10248, ORB-10249, ORB-10255, ORB-10257, ORB-10267, ORB-10258, ORB-10268, ORB-10269, ORB-10271, ORB-10302, ORB-10319, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
+related_artifacts: [ORB-00424, ORB-10245, ORB-10248, ORB-10249, ORB-10255, ORB-10257, ORB-10267, ORB-10258, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10302, ORB-10319, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
 ---
 
 # Host Registry — Decisions
@@ -19,8 +19,8 @@ ADR log for `host-registry`. Entries are append-only and ordered by global ID.
 The Orbit ADR store owns their allocation, status, and task link; this document is
 the long-form feature log. The first seven entries are the consolidated v1
 behavior contract shared with [mcp-bridge](../mcp-bridge/4_decisions.md);
-ADR-0235 records the first registry-only extraction, and proposed ADR-0240 records
-the vertical Remote boundary replacing it in [ORB-10319]. The older entry remains
+ADR-0235 records the first registry-only extraction, and accepted ADR-0240 records
+the vertical Remote boundary that replaced it in [ORB-10319]. The older entry remains
 intact so the reason for the intermediate architecture is not rewritten after the
 fact.
 
@@ -91,7 +91,7 @@ filtered non-empty capability set.
 
 ## ADR-0229 — Owner-authored knowledge with hub-global IDs and explicit replicas
 
-**Status:** Accepted · 2026-07 · [ORB-10245] fixed the one-writer knowledge rule.
+**Status:** Accepted · 2026-07 · [ORB-10245] fixed the one-writer knowledge rule; [ORB-10272] implemented its dormant hub-global sequence, validated reconciliation, and immutable allocation-ledger substrate without activating public issuance.
 
 ### Context
 
@@ -102,10 +102,18 @@ author.
 
 The hub allocates global IDs, the declared owner authors current knowledge, and Git
 replicas are opt-in reads marked as replicas. The hub never proxies to a spoke owner.
+Hub activation first reconciles every registered workspace's complete hub-local
+legacy file/allocation inventory; missing sources and cross-workspace duplicate IDs
+fail before mutation. A later workspace stays knowledge-ineligible until the same
+reconciliation succeeds under the allocator lock.
 
 ### Consequences
 
 - A non-owner agent routes actionable work as a task to the owner.
+- Exact `mcp_call_id` replay is idempotent only for the same full request identity;
+  sequence advance, immutable ledger append, and canonical hub audit commit atomically.
+- Standalone/worktree allocation remains the compatibility path until F3 performs
+  the explicit activation and caller cutover.
 - Cost: finalize failure consumes a valid unused ID, and current spoke-owned knowledge is unavailable off-owner.
 
 ## ADR-0230 — Pull-based leases with immutable placement and explicit recovery
@@ -191,13 +199,13 @@ service. Keep runtime profile/ship construction in `orbit-core`, persistence in
 - Temporary `orbit-core` compatibility re-exports avoid an atomic caller rewrite without retaining duplicate implementations.
 - Cost: `orbit-registry` is no longer a consumer-agnostic leaf and now compiles the store layer; reversing the boundary requires another domain move or a cycle-prone abstraction.
 
-**Planned replacement:** [ADR-0240] proposes superseding this horizontal boundary
-when [ORB-10319] lands. Until that task is approved and merged, ADR-0235 remains the
-accepted historical decision.
+**Replacement:** [ADR-0240] superseded this horizontal boundary when [ORB-10319]
+landed. ADR-0235 remains the accepted historical decision that explains the
+intermediate architecture.
 
 ## ADR-0240 — Consolidate remote coordination in one vertical feature crate
 
-**Status:** Proposed · 2026-07 · [ORB-10319] implements the candidate boundary.
+**Status:** Accepted · 2026-07 · [ORB-10319] implemented the boundary.
 
 ### Context
 
@@ -223,6 +231,9 @@ crate.
   dependencies from Core, Store, MCP, Tools, or Common.
 - Remote v1 adopts the existing global v5/v6/v8 registry tables in place through
   Store's namespaced feature-migration ledger, preserving every row.
+- Remote v2 adds the dormant hub-global knowledge sequence and reconciliation
+  tables in the same database [ORB-10272]; the feature can evolve that transaction
+  without moving knowledge policy into Store.
 - CLI and dashboard remain thin consumers; generic MCP framing and raw client code
   no longer know registry, graph, learning, hub, or placement policy.
 - Cost: `orbit-remote` is intentionally broad and requires internal module
@@ -276,5 +287,10 @@ crate.
   the registry crate into vertical `orbit-remote`, adopting its persistence in
   place, moving profile/routine/MCP composition into the feature, and removing
   Registry/Remote dependencies from Core and MCP.
+- [ORB-10272] — implements ADR-0229's dormant allocation substrate in Remote v2:
+  full pre-mutation legacy reconciliation, independent forward-only ADR/learning
+  sequences, immutable correlation ledger plus atomic audit, replay-safe lookup,
+  and late-workspace ineligibility. F3 retains authority over public activation and
+  caller cutover; standalone creation remains unchanged.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-bridge/2_design.md
+++ b/docs/design/mcp-bridge/2_design.md
@@ -1,7 +1,7 @@
 ---
 title: Orbit MCP Bridge — Design
 owner: codex
-last_updated: 2026-07-18
+last_updated: 2026-07-19
 status: Accepted
 feature: mcp-bridge
 doc_role: design
@@ -10,7 +10,7 @@ summary: Target design for a local Orbit MCP broker with one SSH hub link, hub-o
 tags: [mcp, remote-access, host-registry, bridge, ssh, routing]
 paths: ["crates/orbit-remote/**", "crates/orbit-mcp/**", "crates/orbit-core/**", "crates/orbit-tools/**", "crates/orbit-store/**", "crates/orbit-common/**"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access, orbit-search, orbit-graph, project-learnings]
-related_artifacts: [ORB-00424, ORB-10257, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10302, ORB-10319, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
+related_artifacts: [ORB-00424, ORB-10257, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10302, ORB-10319, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
 ---
 
 # Orbit MCP Bridge — Design
@@ -26,6 +26,9 @@ capability filtering landed in [ORB-10262]. Strict machine-global trust
 configuration and the fixed checkoutless hub endpoint landed in [ORB-10268]. The
 bounded negotiated SSH connector landed in [ORB-10269], and private spoke
 registration plus the first end-to-end coordination slice landed in [ORB-10271].
+[ORB-10272] adds the dormant Remote-v2 hub sequence and connector-private
+allocation substrate for ADR/learning IDs; it deliberately does not cut the public
+knowledge-create paths over before F3.
 It replaces both
 Bridge's HTTP parity layer and the earlier
 per-workspace-authority draft with a local broker that has one remote destination:
@@ -369,6 +372,12 @@ The connector-private registration method is a negotiated protocol input even
 though it is deliberately absent from the canonical tool registry. Adding
 `orbit/private/register-spoke/v1` therefore advanced the MCP contract revision to
 2; an E3 spoke refuses an E2-only hub before any registration mutation [ORB-10271].
+The F1 knowledge allocator follows the same connector-private rule: its typed
+request is absent from the canonical registry and `tools/list`, carries only stable
+workspace/kind/correlation identity, and advances the private connector contract to
+revision 3. A revision-2 peer therefore fails negotiation before allocation, and
+the method becomes reachable from public composite creation only when F3 activates
+and cuts over that path [ORB-10272].
 
 ## 5. Hub Transport and Trusted Configuration
 
@@ -485,6 +494,42 @@ does not accept inline artifacts, so this private form is reachable only through
 backing-file path [ORB-10271].
 
 ### 6.2 Knowledge creation
+
+#### F1 dormant allocation substrate
+
+[ORB-10272] installs Remote feature migration v2 in the hub's config-resolved
+`orbit.db`. It creates independent monotonic ADR and learning sequences, an
+immutable allocation ledger, per-workspace reconciliation state, and a dormant
+authority marker. Merely opening Remote applies the schema but never scans files,
+advances a sequence, or activates authority; standalone/worktree allocators and
+the existing creation paths continue unchanged.
+
+Before activation, the hub validates every registered workspace's complete set of
+hub-local migration sources: all ADR/learning files in valid lifecycle states and
+all legacy allocation rows regardless of reserved, unfinalized, or abandoned
+status. A missing source fails precondition and names its workspace without
+contacting the owner. All cross-workspace `(kind, id)` collisions are collected and
+reported with their workspace/source evidence before any sequence, ledger,
+reconciliation, or audit mutation; no ID is renumbered. The final reseed and
+authority flip run under one hub lock and commit as one forward-only, restart-safe
+transition. A workspace registered afterward remains explicitly
+knowledge-ineligible until its complete local sources reconcile under the same
+lock. A standalone host cannot enter hub authority.
+
+Once active, one successful connector-private allocation transaction advances only
+the requested kind, appends the immutable request-identity ledger row, and writes
+one canonical hub audit with trusted caller/process provenance. `mcp_call_id` is
+unique; an exact replay returns the original result only when the full request
+identity matches, while a mismatch fails without advancing either sequence.
+Internal outcome probes can read by correlation or `(workspace, kind, id)`.
+Invalid workspace/kind/correlation, ineligible workspace, and overflow also leave
+both sequences unchanged. Requests and results contain no checkout or owner path.
+
+F1 exposes no public agent allocation tool, no reservation/finalize/release API,
+and no owner proxy. F3 alone activates public issuance and cuts the following
+composite create flow over to the hub sequence.
+
+#### F3 composite creation target
 
 `orbit.learning.add` and `orbit.adr.add` are composite owner operations:
 
@@ -771,7 +816,12 @@ schemas.
 
 ### Phase 4 — knowledge and search split
 
-- Add hub global-ID allocation consumed by owner learning/ADR creation.
+- [ORB-10272] installs the dormant Remote-v2 hub global-ID sequence, complete
+  reconciliation/activation service, replay-safe ledger, atomic audit, and private
+  path-free allocation request. It does not activate authority or cut over public
+  creation.
+- F3 activates the authority through the final forward-only reseed and cuts owner
+  learning/ADR creation over to hub allocation.
 - Add explicit replica knowledge reads plus reindex/freshness metadata.
 - Implement role-aware search and learning-sidecar availability behavior.
 
@@ -798,26 +848,34 @@ Required validation:
    owner. The separate human ID-plus-PR path does not enable replica-store writes.
 4. Knowledge add allocates globally at the hub and finalizes in the owner's exact
    checkout; finalize failure creates only an allowed ID gap.
-5. Current knowledge for a spoke-owned workspace is never served or proxied by the
+5. Activation validates every registered workspace's complete hub-local files and
+   legacy allocation rows before mutation; missing sources and every duplicate
+   conflict are reported, and late workspaces remain ineligible until reconciled.
+6. Concurrent/interleaved ADR and learning allocations are globally unique and
+   independently increasing; exact correlation replay is idempotent, while
+   mismatched replay, invalid input, and overflow do not advance either sequence.
+7. Allocation commits sequence, immutable ledger, and one canonical hub audit in
+   one transaction; requests/results and audit contain no checkout path.
+8. Current knowledge for a spoke-owned workspace is never served or proxied by the
    hub.
-6. Graph/docs observe the exact session checkout/worktree, never a base or hub
+9. Graph/docs observe the exact session checkout/worktree, never a base or hub
    checkout.
-7. Search requires explicit replica/omit semantics when current knowledge is
+10. Search requires explicit replica/omit semantics when current knowledge is
    unavailable, rejects `kind=doc|all` without a local checkout, and preserves
    current round-robin ranking when branches resolve.
-8. Ordinary routing, session, coordination, response, cache, audit, and lease
+11. Ordinary routing, session, coordination, response, cache, audit, and lease
    frames carry stable IDs, never spoke absolute paths. Authenticated
    registration/poll presence publication is the sole path-bearing exception and
    stores the reporting root only in the hub-private host-keyed projection.
-9. Hub audits distinguish caller and process machine identity; composite knowledge
+12. Hub audits distinguish caller and process machine identity; composite knowledge
    audit events correlate by `mcp_call_id`.
-10. `agent`, `operator`, and `runner` advertise/enforce the intended surfaces across
+13. `agent`, `operator`, and `runner` advertise/enforce the intended surfaces across
     the capability × placement matrix; runner polling and leased-run agent work use
     separate filtered and audited sessions.
-11. Crew/host discovery and task validation read the same fresh hub projections.
-12. Auto-task CRUD stays owner-placed while the scheduler pass reads local
+14. Crew/host discovery and task validation read the same fresh hub projections.
+15. Auto-task CRUD stays owner-placed while the scheduler pass reads local
     definition/cursor state and dedupes/creates tasks only through the hub.
-13. Bridge passes its remaining suite without an Orbit schema snapshot or Orbit
+16. Bridge passes its remaining suite without an Orbit schema snapshot or Orbit
    HTTP dependency.
 
 ## 12. Concerns & Honest Limitations
@@ -872,5 +930,10 @@ Required validation:
 - [ORB-10271] — implemented private staged spoke registration, contract revision 2,
   current active-caller enforcement, definitive-success cache refresh, path-free
   task artifact/friction coordination, and the two-root RMCP canary.
+- [ORB-10272] — adds the dormant Remote-v2 hub-global ADR/learning sequence service,
+  complete pre-mutation hub-local reconciliation, forward-only activation,
+  correlation-safe immutable ledger and atomic audit, plus contract revision 3's
+  private path-free request/result used by the two-workspace canary. Public
+  issuance/caller cutover remains F3, and standalone creation is unchanged.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-bridge/4_decisions.md
+++ b/docs/design/mcp-bridge/4_decisions.md
@@ -1,7 +1,7 @@
 ---
 title: Orbit MCP Bridge — Decisions
 owner: codex
-last_updated: 2026-07-18
+last_updated: 2026-07-19
 status: Accepted
 feature: mcp-bridge
 doc_role: decisions
@@ -10,7 +10,7 @@ summary: ADR log for the coupled MCP Bridge and Host Registry v1 contract and it
 tags: [mcp, remote-access, host-registry, bridge]
 paths: ["crates/orbit-remote/**", "crates/orbit-mcp/**", "crates/orbit-core/**", "crates/orbit-tools/**", "crates/orbit-store/**"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access]
-related_artifacts: [ORB-00424, ORB-10245, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10302, ORB-10319, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
+related_artifacts: [ORB-00424, ORB-10245, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10302, ORB-10319, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
 ---
 
 # Orbit MCP Bridge — Decisions
@@ -20,7 +20,7 @@ Orbit ADR store owns allocation, status, and task links; this log records the
 complete seven-decision v1 behavior contract shared with
 [host-registry](../host-registry/4_decisions.md), plus the crate boundary that
 keeps its implementation singular. ADR-0235 records the intermediate registry-only
-extraction; proposed ADR-0240 records [ORB-10319]'s vertical Remote replacement.
+extraction; accepted ADR-0240 records [ORB-10319]'s vertical Remote replacement.
 The older entry remains intact as design history.
 
 ## ADR-0226 — Singular coordination hub, workspace owner, and per-run placement
@@ -87,7 +87,7 @@ filtered non-empty capability set.
 
 ## ADR-0229 — Owner-authored knowledge with hub-global IDs and explicit replicas
 
-**Status:** Accepted · 2026-07 · [ORB-10245] fixed the one-writer knowledge rule.
+**Status:** Accepted · 2026-07 · [ORB-10245] fixed the one-writer knowledge rule; [ORB-10272] implemented the dormant Remote-v2 hub sequence, reconciliation, immutable-ledger, and atomic-audit substrate without activating the F3 public cutover.
 
 ### Context
 
@@ -98,10 +98,17 @@ author.
 
 The hub allocates global IDs, the declared owner authors current knowledge, and Git
 replicas are opt-in reads marked as replicas. The hub never proxies to a spoke owner.
+Activation validates every registered workspace's complete hub-local legacy
+inventory before mutation; missing sources or cross-workspace duplicate IDs fail
+closed, and a late workspace remains ineligible until reconciled under the hub lock.
 
 ### Consequences
 
 - A non-owner agent routes actionable work as a task to the owner.
+- Sequence advancement, immutable correlation ledger, and canonical hub audit are
+  one transaction; exact request-identity replay is idempotent.
+- Standalone/worktree allocation remains unchanged until F3 activates and cuts over
+  public knowledge creation.
 - Cost: finalize failure consumes a valid unused ID, and current spoke-owned knowledge is unavailable off-owner.
 
 ## ADR-0230 — Pull-based leases with immutable placement and explicit recovery
@@ -186,13 +193,12 @@ adapter, runtime profile/ship construction in `orbit-core`, persistence in
 - The retired replicated-writer API cannot reappear as a second authority beside the singular hub.
 - Cost: `orbit-registry` gains a store dependency and is no longer a consumer-agnostic leaf.
 
-**Planned replacement:** [ADR-0240] proposes superseding this horizontal boundary
-when [ORB-10319] lands. Until that task is approved and merged, ADR-0235 remains the
-accepted historical decision.
+**Replacement:** [ADR-0240] superseded this horizontal boundary when [ORB-10319]
+landed. ADR-0235 remains the accepted historical decision.
 
 ## ADR-0240 — Consolidate remote coordination in one vertical feature crate
 
-**Status:** Proposed · 2026-07 · [ORB-10319] implements the candidate boundary.
+**Status:** Accepted · 2026-07 · [ORB-10319] implemented the boundary.
 
 ### Context
 
@@ -218,6 +224,9 @@ Remote database or a separate broker crate.
   the MCP kernel remains unaware of registry, graph, learning, or routing policy.
 - Remote owns its registry SQL through `RemoteStore`; Store owns generic connection,
   transaction, and namespaced feature-migration infrastructure.
+- Remote feature migration v2 owns the dormant hub-global knowledge sequence and
+  reconciliation transaction [ORB-10272], while Store remains a neutral SQLite
+  kernel.
 - CLI retains command parsing, client setup/removal, and black-box binary tests;
   broker/hub/link/registration behavior evolves inside the feature crate.
 - Cost: `orbit-remote` is intentionally broad and needs disciplined internal seams;
@@ -257,5 +266,11 @@ Remote database or a separate broker crate.
 - [ORB-10319] — implements proposed ADR-0240 by renaming and widening the registry
   crate into vertical `orbit-remote`, adopting registry persistence in place and
   moving MCP composition/broker/hub/link/registration out of CLI and the MCP kernel.
+- [ORB-10272] — implements ADR-0229's dormant Remote-v2 hub allocation substrate:
+  complete validated legacy reconciliation, forward-only activation, independent
+  sequences, immutable correlation ledger plus atomic audit, no owner proxy, and
+  explicit late-workspace ineligibility. Its private path-free allocation protocol
+  advances the connector contract to revision 3. Public issuance remains an F3
+  cutover and standalone creation remains unchanged.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-bridge/references/conformance-v1.yaml
+++ b/docs/design/mcp-bridge/references/conformance-v1.yaml
@@ -42,6 +42,16 @@ private_connector:
     ordinary_calls_require_active_registration: true
     only_path_bearing_fields: ["presence[].root"]
     cache_refresh: definitive-complete-response-only
+  knowledge_allocation:
+    method: orbit/private/allocate-knowledge-id/v1
+    schema_version: 1
+    advertised: false
+    ordinary_tools_call: false
+    allowed_capabilities: [agent, operator]
+    active_caller_required: true
+    path_bearing_fields: []
+    automatic_replay: false
+    lookup_keys: [mcp_call_id, workspace-kind-id]
 
 tools:
   orbit.task.add: { placement: hub, scope: workspace-required, allowed_capabilities: [agent, operator] }
@@ -88,7 +98,7 @@ tools:
 
 hub_schema_digest:
   domain_tag: orbit.mcp.hub-schema.v1
-  contract_revision: 2
+  contract_revision: 3
   canonical_registry_revision: 1
   golden_vector:
     capability: agent
@@ -99,7 +109,7 @@ hub_schema_digest:
     - canonical schema name, description, and input schema for every composite tool's hub step
     - advertised MCP name mapping for each included canonical tool
     - canonical registry revision
-    - private connector protocol revision, including orbit/private/register-spoke/v1
+    - private connector protocol revision, including orbit/private/register-spoke/v1 and orbit/private/allocate-knowledge-id/v1
   mismatch_behavior:
     - Reject hub routing before dispatch when revision or digest differs.
     - Local-derived and locally eligible owner calls may continue without a hub route.

--- a/docs/design/worktree-artifacts/2_design.md
+++ b/docs/design/worktree-artifacts/2_design.md
@@ -3,14 +3,14 @@ summary: "Worktree Artifacts - Design"
 type: design
 title: "Worktree Artifacts - Design"
 owner: codex
-last_updated: 2026-07-18
+last_updated: 2026-07-19
 status: Accepted
 feature: worktree-artifacts
 doc_role: design
 tags: ["worktree-artifacts"]
-paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-cli/**"]
-related_features: ["worktree-artifacts"]
-related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10297", "ADR-0177"]
+paths: ["crates/orbit-remote/**", "crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-cli/**"]
+related_features: ["worktree-artifacts", "host-registry", "mcp-bridge"]
+related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10272", "ORB-10297", "ADR-0177", "ADR-0229"]
 ---
 
 # Worktree Artifacts - Design
@@ -25,13 +25,44 @@ Explicit `--root` and `ORBIT_ROOT` overrides pin both roots to preserve the old 
 
 ## 2. Allocation Metadata
 
-`id_allocations` lives in `shared_root/.orbit/state/semantic.db`. The allocator serializes ID creation with a shared lock, then body writes update the row with:
+In standalone/worktree mode, `id_allocations` lives in
+`shared_root/.orbit/state/semantic.db`. The allocator serializes ID creation with a
+shared lock, then body writes update the row with:
 
 - `worktree_root`: the recorded worktree root for the body.
 - `branch`: best-effort current branch.
 - `body_path`: the body file path relative to `worktree_root`.
 
 Backfilled shared-root artifacts receive `body_path` during allocator initialization so old ADRs and migrated learnings remain readable from any worktree.
+
+This remains the compatibility allocator and every current create path continues to
+use it during F1. [ORB-10272] does not redirect standalone or worktree creation.
+
+### 2.1 Hub-global sequence substrate
+
+Multi-host authority is separate from worktree federation. Remote feature migration
+v2 installs dormant, independent ADR and learning sequences in the hub's
+config-resolved `orbit.db`, together with per-workspace reconciliation state and an
+immutable `mcp_call_id` allocation ledger. Those rows are path-free; they neither
+replace `body_path` nor make the hub a reader of a spoke owner's worktree.
+
+Before hub authority can activate, every registered workspace's complete hub-local
+legacy inventory is validated: all valid lifecycle files and all legacy allocation
+rows in every status. Missing sources and cross-workspace duplicate IDs fail before
+any mutation. The final forward-only reseed and authority flip are one restart-safe
+transition. A late workspace stays knowledge-ineligible until the same complete
+local reconciliation succeeds. The hub never contacts an owner to repair a missing
+source.
+
+After activation, allocation advances one kind's sequence and commits its immutable
+correlation ledger plus canonical audit atomically. It still does not write the
+artifact body: the owner writes the branch-local bundle under `local_root`. A
+finalize failure therefore consumes a valid unused global ID. There is no
+reservation, release, reuse, or remote-finalize protocol.
+
+F1 leaves the substrate dormant and exposes no public allocation tool. F3 alone
+activates public issuance and cuts owner creation over; standalone hosts cannot
+enter hub authority.
 
 ## 3. Write Path
 
@@ -84,5 +115,8 @@ The `worktree_root` column preserves historical rows from earlier phases, so old
 - [ORB-00200] introduced allocation metadata and the learning ID migration.
 - [ORB-00201] implemented local body writes and read federation.
 - [ORB-10297] made ADR federation body-preserving and typed the read/mutation boundary.
+- [ORB-10272] added the dormant, path-free Remote-v2 hub sequence and reconciliation
+  substrate while preserving the standalone shared-root allocator and owner-local
+  body/federation semantics; F3 owns activation and caller cutover.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/worktree-artifacts/4_decisions.md
+++ b/docs/design/worktree-artifacts/4_decisions.md
@@ -3,14 +3,14 @@ summary: "Worktree Artifacts - Decisions"
 type: design
 title: "Worktree Artifacts - Decisions"
 owner: codex
-last_updated: 2026-07-18
+last_updated: 2026-07-19
 status: Accepted
 feature: worktree-artifacts
 doc_role: decisions
 tags: ["worktree-artifacts"]
-paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-cli/**"]
-related_features: ["worktree-artifacts"]
-related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10297", "ADR-0177"]
+paths: ["crates/orbit-remote/**", "crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-cli/**"]
+related_features: ["worktree-artifacts", "host-registry", "mcp-bridge"]
+related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10272", "ORB-10297", "ADR-0177", "ADR-0229"]
 ---
 
 # Worktree Artifacts - Decisions
@@ -19,15 +19,29 @@ ADR-style log for worktree artifact storage. Entries use globally allocated ADR 
 
 ## ADR-0177 - Worktree-local ADR and learning bodies with shared ID allocation
 
-**Status:** Accepted - 2026-05 - [ORB-00201]; amended 2026-07 by [ORB-10297]
+**Status:** Accepted - 2026-05 - [ORB-00201]; amended 2026-07 by [ORB-10297] and [ORB-10272]
 
 **Context.** Linked worktrees need ADR and learning bodies committed with the code branch that created them, but IDs must remain collision-free across all worktrees. [ORB-00199] introduced shared/local root resolution and [ORB-00200] introduced the shared SQLite allocator. The remaining choice was whether body files follow the allocator into `shared_root` or follow the editing branch into `local_root`.
 
-**Decision.** Write ADR and learning body files under the current worktree `local_root` while keeping ID allocation, migration, and allocation metadata in `shared_root/.orbit/state/semantic.db`. Lists read through `id_allocations`: default output includes only locally readable bodies, while `include_remote` returns stubs that name the recorded worktree and branch. ADR show resolves envelope plus body once into `local`, `federated`, `remote_artifact_unavailable`, or `not_found`; a valid current-local bundle wins without rewriting allocation metadata. Successful show includes only the credential-safe `{mode, worktree_root, branch}` origin. ADR update, accept, and both supersede operands must be current-local before the first mutation and otherwise fail as `artifact_not_local`.
+**Decision.** Write ADR and learning body files under the current worktree `local_root` while keeping standalone/worktree ID allocation, migration, and allocation metadata in `shared_root/.orbit/state/semantic.db`. Lists read through `id_allocations`: default output includes only locally readable bodies, while `include_remote` returns stubs that name the recorded worktree and branch. ADR show resolves envelope plus body once into `local`, `federated`, `remote_artifact_unavailable`, or `not_found`; a valid current-local bundle wins without rewriting allocation metadata. Successful show includes only the credential-safe `{mode, worktree_root, branch}` origin. ADR update, accept, and both supersede operands must be current-local before the first mutation and otherwise fail as `artifact_not_local`.
+
+For multi-host mode, ADR-0229 adds a distinct hub-global authority rather than
+stretching `semantic.db` federation across machines. Remote feature migration v2
+installs its dormant, path-free ADR/learning sequences, validated reconciliation
+state, and immutable correlation ledger in the hub `orbit.db` [ORB-10272]. Sequence
+advance, ledger append, and audit are atomic; owner-local body creation remains a
+separate step and may leave a valid gap. F1 preserves every existing allocator and
+create caller. F3 alone activates and cuts public issuance over. The hub never
+proxies to or reads a spoke owner's worktree.
 
 **Consequences.**
 - ADR and learning files can be staged in the same PR as the implementation that created them.
 - Shared ID allocation still prevents cross-worktree collisions and records where each body lives.
+- Hub-global allocation is reconciled above every workspace's complete legacy
+  file/allocation maximum without turning worktree paths into protocol data.
+- A late workspace is explicitly ineligible until its complete hub-local inventory
+  reconciles; missing sources and duplicate IDs fail before mutation.
+- Standalone/worktree allocation remains unchanged until the explicit F3 cutover.
 - Readers get predictable defaults without failing on missing sibling-worktree files.
 - Readable sibling ADRs preserve their exact body, while unavailable allocations and unknown IDs remain distinct typed failures.
 - Rejected sibling-only mutations leave bundles, allocation metadata, lifecycle timestamps, and audit state unchanged.
@@ -40,5 +54,8 @@ ADR-style log for worktree artifact storage. Entries use globally allocated ADR 
 - [ORB-00200] introduced shared ID allocation and `L-NNNN`.
 - [ORB-00201] implemented this decision.
 - [ORB-10297] amended the ADR show and mutation boundary with four-state resolution and typed origin/error payloads.
+- [ORB-10272] amended the allocation boundary with the dormant Remote-v2 hub-global
+  sequence, full legacy reconciliation, immutable correlation ledger and atomic
+  audit while retaining standalone compatibility and owner-local bodies.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Summary

- add the dormant Remote v2 hub-global ADR and learning sequence substrate, complete legacy-source reconciliation, immutable allocation ledger, and atomic allocation/audit transaction
- add the connector-private, path-free MCP allocation contract at revision 3 with trusted agent/operator context, exact replay identity, typed outcome lookup, and no public tool exposure
- synchronize the host-registry, MCP-bridge, worktree-artifacts, decision, and conformance documentation while preserving the F1-dormant / F3-cutover boundary

## Validation

- `make ci-fast`
- `cargo test -p orbit-remote --locked --quiet` (176 unit + 3 dependency-boundary)
- `cargo test -p orbit-store --locked` (289 passed, 3 ignored)
- `cargo test -p orbit-core --locked --quiet` (614 passed, 1 ignored; 6 integration passed)
- `cargo test -p orbit-cli mcp --locked --quiet` (43 unit + 6 integration)
- `cargo clippy -p orbit-common -p orbit-store -p orbit-remote -p orbit-cli --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Boundary

This is F1 only: the allocator remains dormant and existing knowledge-creation paths are unchanged until the later F3 cutover.