### PR TITLE
fix: re-seed dogfood activity resources after graph MCP removal [ORB-10325]

### DIFF
--- a/.orbit/resources/activities/agent_implement.yaml
+++ b/.orbit/resources/activities/agent_implement.yaml
@@ -46,10 +46,11 @@ spec:
     2. If the injected task context is missing or malformed, recover it with
        `orbit.task.show`.
     3. Read the task description, acceptance criteria, and plan first. Treat
-       `context_files` as Orbit graph selectors: prefer `orbit.graph.show`
-       (and `orbit.graph.overview` for `dir:` scopes) to gather context, and
-       fall back to `fs.read` only for selectors that stay unresolved or when
-       the graph is unavailable. If `orbit.search`
+       `context_files` as Orbit graph selectors and use the CLI-only graph
+       surface through `proc.spawn`: prefer `orbit graph show <selector>`
+       (and `orbit graph overview <selector>` for `dir:` scopes) to gather
+       context, and fall back to `fs.read` only for selectors that stay
+       unresolved or when the graph CLI is unavailable. If `orbit.search`
        is available, call it with `semantic: "<task-id>"` to surface prior tasks
        not linked via `context_files` (past decisions, related review threads);
        skip if the companion binary is not installed.
@@ -142,7 +143,6 @@ spec:
   tools:
     - orbit.task.*
     - orbit.friction.*
-    - orbit.graph.*
     - orbit.search
     - orbit.learning.show
     - orbit.learning.add

--- a/.orbit/resources/activities/agent_review.yaml
+++ b/.orbit/resources/activities/agent_review.yaml
@@ -65,10 +65,11 @@ spec:
        different head.
     2. For each task id in `input.task_ids`, call `orbit.task.show` to
        recover its description, acceptance criteria, plan, and context
-       files. Read context selectors via `orbit.graph.show` (and
-       `orbit.graph.overview` for `dir:` scopes), falling back to `fs.read`
-       only when the graph is unavailable or a selector is unresolved. If
-       `orbit.search` is available, optionally call it with
+       files. Use the CLI-only graph surface through `proc.spawn`: read
+       context selectors via `orbit graph show <selector>` (and
+       `orbit graph overview <selector>` for `dir:` scopes), falling back
+       to `fs.read` only when the graph CLI is unavailable or a selector is
+       unresolved. If `orbit.search` is available, optionally call it with
        `semantic: "<task-id>"` to surface prior similar tasks whose review
        threads or decisions may inform this review; skip if the companion
        binary is not installed.
@@ -96,7 +97,6 @@ spec:
     - orbit.task.show
     - orbit.task.review_thread.add
     - orbit.task.review_thread.list
-    - orbit.graph.*
     - orbit.search
     - orbit.learning.show
     - orbit.learning.add
@@ -106,6 +106,7 @@ spec:
     - proc.spawn
   proc_allowed_programs:
     - git
+    - orbit
     - rg
   on_denial: terminate
   max_iterations: 20

--- a/.orbit/resources/activities/dispatch_agent.yaml
+++ b/.orbit/resources/activities/dispatch_agent.yaml
@@ -87,7 +87,6 @@ spec:
   tools:
     - orbit.task.*
     - orbit.friction.*
-    - orbit.graph.*
     - orbit.search
   on_denial: terminate
   max_iterations: 8

--- a/.orbit/resources/activities/epic_orchestrator.yaml
+++ b/.orbit/resources/activities/epic_orchestrator.yaml
@@ -118,7 +118,6 @@ spec:
     - orbit.task.list
     - orbit.task.show
     - orbit.pipeline.invoke
-    - orbit.graph.*
     - orbit.search
   on_denial: terminate
   max_iterations: 8

--- a/.orbit/resources/activities/step_failure_recovery.yaml
+++ b/.orbit/resources/activities/step_failure_recovery.yaml
@@ -82,7 +82,6 @@ spec:
     - orbit.task.*
     - orbit.friction.*
     - orbit.state.*
-    - orbit.graph.*
     - fs.read
     - fs.delete
     - proc.spawn


### PR DESCRIPTION
## Summary

PR #663 (ORB-10325, ADR-0241 2nd amendment) removed the `orbit.graph.*` MCP tool surface and updated the allowlist validator to reject wildcard root grants (`V2_TOOL_WILDCARD_ROOTS`), rewriting the canonical activity templates under `crates/orbit-core/assets/activities/`. The independent review on #663 flagged that this repo's own committed dogfood copies under `.orbit/resources/activities/*.yaml` still grant `orbit.graph.*` and recommended re-seeding post-merge.

After the merge, the current release binary fails to build the activity catalog against this repo's own `.orbit/`:

```
error: store error: v2 activity catalog: parse .../codebases/orbit/.orbit/resources/activities/agent_implement.yaml: activity 'agent_implement' tool allowlist invalid: wildcard root not permitted in allowlist entry 'orbit.graph.*' (see V2_TOOL_WILDCARD_ROOTS)
```

## Changes

Re-seeded the 5 dogfood copies that diverged from their canonical source templates, verbatim, matching #663's rewrite exactly:
- `agent_implement.yaml`, `agent_review.yaml` — drop the `orbit.graph.*` grant; instruction text now points at the CLI-only `orbit graph show`/`orbit graph overview` via `proc.spawn` (`agent_review` also gains `orbit` in `proc_allowed_programs`, matching the source template — no other activity gained `proc.spawn` beyond what #663's source already carried).
- `dispatch_agent.yaml`, `epic_orchestrator.yaml`, `step_failure_recovery.yaml` — drop the vestigial `orbit.graph.*` grant (plan-level activities; no CLI access added, per the source templates).

No source/behavior changes — resource-only, copied from the current `crates/orbit-core/assets/activities/*.yaml` (the same templates `orbit init` seeds).

## Test plan

- [x] Confirmed the failure reproduces on `agent-main` (pre-fix): `orbit activity list --root .orbit` → wildcard-root parse error on `agent_implement.yaml`.
- [x] Confirmed the fix resolves it: `orbit activity list --root .orbit --json` on this branch parses cleanly, all 32 activities returned.
- [x] `git diff --check` clean.
- [x] Resource-only change (no crate source touched) — no `make ci-fast` run needed per task scope; diff verified to exactly match #663's already-CI-validated template rewrite.

Ref: ORB-10325, PR #663 review note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)