### PR TITLE
Add projection-backed operator discovery and crew validation

### DIFF
--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -434,6 +434,20 @@
     "name": "orbit_auto_task_update"
   },
   {
+    "description": "List a workspace owner's published execution-profile crews with sanitized profile state, generation, and freshness (agent/operator, hub placement).",
+    "inputSchema": {
+      "additionalProperties": true,
+      "properties": {
+        "workspace": {
+          "description": "Stable logical workspace ID. Defaults to the trusted MCP session workspace; never resolved from process cwd or a checkout path.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "orbit_crew_list"
+  },
+  {
     "description": "Append an Orbit friction report under .orbit/frictions/",
     "inputSchema": {
       "additionalProperties": true,

--- a/crates/orbit-common/src/types/execution_profile.rs
+++ b/crates/orbit-common/src/types/execution_profile.rs
@@ -7,10 +7,15 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use super::activity_job::{Backend, Provider};
+use super::registry_snapshot::RegistryProfileV1;
 use super::{Crew, OrbitError, validate_machine_id};
 
 pub const EXECUTION_PROFILE_SCHEMA_VERSION: u32 = 1;
 pub const EXECUTION_CONFIG_DIGEST_DOMAIN: &[u8] = b"orbit.execution-profile.config.v1\0";
+
+/// Schema version of the sanitized [`CrewDiscoveryV1`] projection returned by
+/// `orbit.crew.list`. Bumped only for a backward-incompatible projection change.
+pub const CREW_DISCOVERY_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkspaceOwnership {
@@ -271,6 +276,44 @@ pub struct SanitizedExecutionProfile {
     pub received_at: Option<DateTime<Utc>>,
     pub age_seconds: Option<u64>,
     pub profile: Option<ExecutionProfileV1>,
+}
+
+/// Sanitized `orbit.crew.list` projection: stable workspace/owner identity, the
+/// shared [`RegistryProfileV1`] freshness/generation envelope (also used by
+/// `orbit.workspace.list`), the default crew, and the sorted effective crew
+/// entries.
+///
+/// It deliberately carries no `config_digest`, ship closure, presence root,
+/// checkout path, raw profile payload, environment name/value, secret,
+/// credential, token, SSH material, command fragment, or repository content:
+/// only the allowlisted name/provider/model/backend/description/tags crew
+/// projection appears. A stale record still returns its crews, but they are
+/// bound to the stale `profile` envelope generation/freshness and never carry a
+/// dispatch-eligible marker.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CrewDiscoveryV1 {
+    pub schema_version: u32,
+    pub workspace_id: String,
+    pub owner_machine_id: Option<String>,
+    pub profile: RegistryProfileV1,
+    pub default_crew: Option<String>,
+    pub crews: Vec<ExecutionProfileCrewV1>,
+}
+
+/// One reusable, immutable typed validation result shared by crew discovery and
+/// explicit task-crew validation. It captures the exact owner profile lineage
+/// that a validated dispatch is bound to — stored profile, resolved crew,
+/// hub-owned generation, config digest, and ship-closure digest — without
+/// persisting any run lineage or leasing state (those belong to H3/I1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatedCrewProfile {
+    pub workspace_id: String,
+    pub owner_machine_id: String,
+    pub generation: u64,
+    pub config_digest: String,
+    pub ship_closure_digest: String,
+    pub resolved_crew: ExecutionProfileCrewV1,
+    pub profile: ExecutionProfileV1,
 }
 
 fn validate_profile_crew(crew: &ExecutionProfileCrewV1) -> Result<(), OrbitError> {

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -99,10 +99,11 @@ pub use duel::{
 pub use error::{ArtifactOrigin, ArtifactOriginMode, NotFoundKind, OrbitError};
 pub use event::OrbitEvent;
 pub use execution_profile::{
-    EXECUTION_CONFIG_DIGEST_DOMAIN, EXECUTION_PROFILE_SCHEMA_VERSION, ExecutionProfileCrewV1,
-    ExecutionProfileShipV1, ExecutionProfileV1, HostWorkspacePresence, ProjectionFreshness,
-    SanitizedExecutionProfile, SanitizedWorkspacePresence, StoredExecutionProfile,
-    WorkspaceOwnership, WorkspacePresenceDeclaration,
+    CREW_DISCOVERY_SCHEMA_VERSION, CrewDiscoveryV1, EXECUTION_CONFIG_DIGEST_DOMAIN,
+    EXECUTION_PROFILE_SCHEMA_VERSION, ExecutionProfileCrewV1, ExecutionProfileShipV1,
+    ExecutionProfileV1, HostWorkspacePresence, ProjectionFreshness, SanitizedExecutionProfile,
+    SanitizedWorkspacePresence, StoredExecutionProfile, ValidatedCrewProfile, WorkspaceOwnership,
+    WorkspacePresenceDeclaration,
 };
 pub use executor_def::{
     ExecutorDef, ExecutorSandboxKind, ExecutorType, ModelPairOverride, StdoutFormat,

--- a/crates/orbit-remote/src/execution_profile_projection.rs
+++ b/crates/orbit-remote/src/execution_profile_projection.rs
@@ -1,0 +1,208 @@
+//! Hub-side projection-backed crew discovery and explicit task-crew validation
+//! [ORB-10276].
+//!
+//! This is the single reusable service that both `orbit.crew.list` discovery
+//! and explicit task-crew validation read through. It consumes C2's stored
+//! owner execution-profile projection (never hub-local crews, the satellite
+//! registry cache, a stale replica, or a synchronous owner call), applies one
+//! service-owned freshness TTL through an injected clock, and returns either a
+//! sanitized [`CrewDiscoveryV1`] or an immutable [`ValidatedCrewProfile`].
+//!
+//! Discovery and validation observe the exact same workspace-specific profile
+//! generation and freshness because they share this one read path: a newer
+//! semantic profile advances the generation for both, and an identically
+//! refreshed profile updates freshness without inventing a generation.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use chrono::{DateTime, Duration, Utc};
+use orbit_common::types::{
+    CREW_DISCOVERY_SCHEMA_VERSION, CrewDiscoveryV1, OrbitError, ProjectionFreshness,
+    RegistryProfileV1, SanitizedExecutionProfile, ValidatedCrewProfile,
+};
+
+use crate::persistence::RemoteStore;
+use crate::service::remote_store_at;
+
+/// The single service-owned execution-profile freshness TTL shared by crew
+/// discovery and task-crew validation. It matches C2's profile-status TTL so a
+/// workspace never reports one freshness through discovery and a different one
+/// through validation.
+pub const CREW_PROFILE_FRESHNESS_TTL: Duration = Duration::minutes(10);
+
+/// Injected, testable wall clock for freshness computation. Production uses
+/// [`SystemProfileClock`]; deterministic fixtures inject a fixed clock so
+/// missing/current/stale transitions are exercised without sleeping.
+pub trait ProfileClock: Send + Sync {
+    fn now(&self) -> DateTime<Utc>;
+}
+
+/// The real wall clock.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemProfileClock;
+
+impl ProfileClock for SystemProfileClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+/// Fixed clock for deterministic tests.
+#[derive(Debug, Clone, Copy)]
+pub struct FixedProfileClock(pub DateTime<Utc>);
+
+impl ProfileClock for FixedProfileClock {
+    fn now(&self) -> DateTime<Utc> {
+        self.0
+    }
+}
+
+/// Projection-backed crew discovery and validation over one owner
+/// execution-profile store.
+#[derive(Clone)]
+pub struct ExecutionProfileProjection {
+    store: RemoteStore,
+    clock: Arc<dyn ProfileClock>,
+    freshness_ttl: Duration,
+}
+
+impl ExecutionProfileProjection {
+    /// Build over an already-opened Remote store using the system clock and the
+    /// shared freshness TTL.
+    pub fn new(store: RemoteStore) -> Self {
+        Self {
+            store,
+            clock: Arc::new(SystemProfileClock),
+            freshness_ttl: CREW_PROFILE_FRESHNESS_TTL,
+        }
+    }
+
+    /// Build over the config-resolved coordination store for a machine-global
+    /// root.
+    pub fn at(global_root: &Path) -> Result<Self, OrbitError> {
+        Ok(Self::new(remote_store_at(global_root)?))
+    }
+
+    /// Test seam: inject a deterministic clock (and TTL).
+    pub fn with_clock(
+        store: RemoteStore,
+        clock: Arc<dyn ProfileClock>,
+        freshness_ttl: Duration,
+    ) -> Self {
+        Self {
+            store,
+            clock,
+            freshness_ttl,
+        }
+    }
+
+    fn status(&self, workspace_id: &str) -> Result<SanitizedExecutionProfile, OrbitError> {
+        self.store
+            .sanitized_execution_profile(workspace_id, self.clock.now(), self.freshness_ttl)
+    }
+
+    /// Sanitized `orbit.crew.list` projection for one workspace. Missing and
+    /// stale profiles remain inspectable discovery states; crews returned from a
+    /// stale record stay bound to that stale generation via the shared profile
+    /// envelope and carry no dispatch-eligible marker.
+    pub fn crew_discovery(&self, workspace_id: &str) -> Result<CrewDiscoveryV1, OrbitError> {
+        Ok(build_crew_discovery(
+            workspace_id,
+            self.status(workspace_id)?,
+        ))
+    }
+
+    /// Validate an explicit, non-empty task crew against the current owner
+    /// profile. A current profile whose effective crews contain `crew` yields
+    /// the immutable [`ValidatedCrewProfile`]; a missing profile, a stale
+    /// profile, or an unknown crew fails with an actionable
+    /// workspace/owner/state/age error and never falls back to any other crew
+    /// source.
+    pub fn validate_task_crew(
+        &self,
+        workspace_id: &str,
+        crew: &str,
+    ) -> Result<ValidatedCrewProfile, OrbitError> {
+        let status = self.status(workspace_id)?;
+        let owner = status.owner_machine_id.clone().unwrap_or_default();
+        match status.freshness {
+            ProjectionFreshness::Missing => Err(OrbitError::InvalidInput(format!(
+                "cannot validate crew '{crew}' for workspace '{workspace_id}': owner '{}' has no published execution profile (state=missing). File the task without a crew, or clear it, until the owner publishes a profile",
+                owner_label(&owner)
+            ))),
+            ProjectionFreshness::Stale => Err(OrbitError::InvalidInput(format!(
+                "cannot validate crew '{crew}' for workspace '{workspace_id}': owner '{}' execution profile is stale (state=stale{}). Refuse dispatch-affecting crew assignment until the owner republishes",
+                owner_label(&owner),
+                age_suffix(status.age_seconds),
+            ))),
+            ProjectionFreshness::Current => {
+                let profile = status.profile.ok_or_else(|| {
+                    OrbitError::Store(format!(
+                        "workspace '{workspace_id}' reports a current execution profile without a payload"
+                    ))
+                })?;
+                let resolved_crew = profile
+                    .crews
+                    .iter()
+                    .find(|entry| entry.name == crew)
+                    .cloned()
+                    .ok_or_else(|| {
+                        OrbitError::InvalidInput(format!(
+                            "crew '{crew}' is not published in owner '{}' execution profile for workspace '{workspace_id}' (state=current, generation={}); known crews: [{}]",
+                            owner_label(&owner),
+                            status.generation.unwrap_or_default(),
+                            profile
+                                .crews
+                                .iter()
+                                .map(|entry| entry.name.as_str())
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        ))
+                    })?;
+                Ok(ValidatedCrewProfile {
+                    workspace_id: workspace_id.to_string(),
+                    owner_machine_id: profile.owner_machine_id.clone(),
+                    generation: status.generation.unwrap_or_default(),
+                    config_digest: profile.config_digest.clone(),
+                    ship_closure_digest: profile.ship.ship_closure_digest.clone(),
+                    resolved_crew,
+                    profile,
+                })
+            }
+        }
+    }
+}
+
+fn build_crew_discovery(workspace_id: &str, status: SanitizedExecutionProfile) -> CrewDiscoveryV1 {
+    let profile = RegistryProfileV1 {
+        freshness: status.freshness,
+        generation: status.generation,
+        observed_at: status.observed_at,
+        received_at: status.received_at,
+        age_seconds: status.age_seconds,
+    };
+    let (default_crew, crews) = match status.profile {
+        Some(profile) => (Some(profile.default_crew), profile.crews),
+        None => (None, Vec::new()),
+    };
+    CrewDiscoveryV1 {
+        schema_version: CREW_DISCOVERY_SCHEMA_VERSION,
+        workspace_id: workspace_id.to_string(),
+        owner_machine_id: status.owner_machine_id,
+        profile,
+        default_crew,
+        crews,
+    }
+}
+
+fn owner_label(owner: &str) -> &str {
+    if owner.is_empty() { "unknown" } else { owner }
+}
+
+fn age_suffix(age_seconds: Option<u64>) -> String {
+    match age_seconds {
+        Some(age) => format!(", age={age}s"),
+        None => String::new(),
+    }
+}

--- a/crates/orbit-remote/src/lib.rs
+++ b/crates/orbit-remote/src/lib.rs
@@ -21,6 +21,7 @@
 //! snapshot queries are encapsulated here over `orbit-store`'s generic SQLite
 //! connection and namespaced migration-ledger infrastructure.
 
+pub mod execution_profile_projection;
 pub mod host_identity;
 pub mod host_registry;
 pub mod knowledge;
@@ -36,6 +37,10 @@ pub mod workspace_registry;
 #[cfg(test)]
 mod tests;
 
+pub use execution_profile_projection::{
+    CREW_PROFILE_FRESHNESS_TTL, ExecutionProfileProjection, FixedProfileClock, ProfileClock,
+    SystemProfileClock,
+};
 pub use host_identity::{
     HOST_IDENTITY_SCHEMA_VERSION, HOST_TOML_FILE, HostIdentity, HostIdentityOutcome,
     HostIdentityState, HostMode, NewHostIdentity, ensure_host_identity, inspect_host_identity,

--- a/crates/orbit-remote/src/mcp/discovery.rs
+++ b/crates/orbit-remote/src/mcp/discovery.rs
@@ -2,7 +2,8 @@
 
 use orbit_common::types::{
     McpToolDefinition, McpToolPlacement, McpToolPolicy, McpToolPolicyError, McpToolScope,
-    NotFoundKind, OrbitError, RegistrySnapshotV1, ToolSchema, validate_mcp_tool_definitions,
+    NotFoundKind, OrbitError, RegistrySnapshotV1, ToolParam, ToolSchema,
+    validate_mcp_tool_definitions,
 };
 use serde_json::{Value, json};
 
@@ -18,6 +19,7 @@ pub(super) fn discovery_tool_definitions() -> Result<Vec<McpToolDefinition>, Mcp
             "List workspaces with declared owner and sanitized execution-profile freshness \
              (operator, hub placement).",
         )?,
+        crew_list_definition()?,
     ];
     validate_mcp_tool_definitions(&definitions)?;
     Ok(definitions)
@@ -37,6 +39,34 @@ fn discovery_definition(
             builtin: true,
         },
         McpToolPolicy::operator_only(McpToolPlacement::Hub).with_scope(McpToolScope::Global),
+    )
+}
+
+/// `orbit.crew.list` completes the hub discovery surface. Unlike the two
+/// registry-wide, operator-only, global tools above, it resolves a stable
+/// workspace and reads that workspace owner's stored execution-profile
+/// projection, so it is workspace-scoped and its accepted read-only crew
+/// discovery contract permits `agent` and `operator` (never `runner`).
+fn crew_list_definition() -> Result<McpToolDefinition, McpToolPolicyError> {
+    McpToolDefinition::new(
+        ToolSchema {
+            name: "orbit.crew.list".to_string(),
+            description:
+                "List a workspace owner's published execution-profile crews with sanitized \
+                 profile state, generation, and freshness (agent/operator, hub placement)."
+                    .to_string(),
+            parameters: vec![ToolParam {
+                name: "workspace".to_string(),
+                description:
+                    "Stable logical workspace ID. Defaults to the trusted MCP session workspace; \
+                     never resolved from process cwd or a checkout path."
+                        .to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            }],
+            builtin: true,
+        },
+        McpToolPolicy::agent_and_operator(McpToolPlacement::Hub),
     )
 }
 

--- a/crates/orbit-remote/src/mcp/host.rs
+++ b/crates/orbit-remote/src/mcp/host.rs
@@ -520,6 +520,15 @@ impl BrokerMcpHost {
         super::discovery::execute_discovery_tool(name, snapshot)
     }
 
+    /// Project the sanitized crew-discovery response for `orbit.crew.list` from
+    /// C2's stored owner execution-profile projection at this hub-local root.
+    fn crew_discovery(&self, workspace_id: &str) -> Result<Value, OrbitError> {
+        let discovery = crate::ExecutionProfileProjection::at(&self.global_root)?
+            .crew_discovery(workspace_id)?;
+        serde_json::to_value(discovery)
+            .map_err(|error| OrbitError::Execution(format!("serialize crew discovery: {error}")))
+    }
+
     fn legacy_friction_root(
         &self,
         workspace_id: &str,
@@ -651,6 +660,15 @@ impl BrokerMcpHost {
                     };
                 }
                 return self.remote_hub_call(name, input, context, Some(&workspace_id));
+            }
+            // Crew discovery is projection-backed and hub-local; it never opens
+            // the coordination task registry. Standalone task validation keeps
+            // its current local-runtime behavior, so crew validation is not
+            // applied on this non-spoke coordination path.
+            if name == "orbit.crew.list" {
+                let result = self.crew_discovery(&workspace_id);
+                self.record_coordination_outcome(name, &context, &result);
+                return result;
             }
             let legacy_root = self.legacy_friction_root(&workspace_id, binding.as_ref());
             let result = HubCoordinationExecutor::new(&self.global_root, workspace_id, legacy_root)

--- a/crates/orbit-remote/src/mcp/hub.rs
+++ b/crates/orbit-remote/src/mcp/hub.rs
@@ -441,10 +441,45 @@ impl HubMcpHost {
         {
             object.insert("workspace".to_string(), Value::String(workspace_id.clone()));
         }
+        // Crew discovery reads the stored owner execution-profile projection at
+        // the hub; it never opens the coordination task registry.
+        if name == "orbit.crew.list" {
+            let result = self.crew_discovery(&workspace_id);
+            self.record_outcome(name, &context, &result);
+            return result;
+        }
+        // Explicit non-empty task-crew assignment is validated against the
+        // owner profile before any allocation/mutation. An omitted or cleared
+        // crew is accepted without a profile, so coordination tasks can still be
+        // filed while an owner is unavailable.
+        if let Some(crew) = explicit_task_crew(name, &input)
+            && let Err(error) = self.validate_task_crew(&workspace_id, &crew)
+        {
+            self.record_denial(name, &context, &error);
+            return Err(error);
+        }
         let result = HubCoordinationExecutor::new(&self.global_root, workspace_id, None)
             .and_then(|executor| executor.execute_tool(name, input, context.clone()));
         self.record_outcome(name, &context, &result);
         result
+    }
+
+    /// Project the sanitized crew-discovery response for `orbit.crew.list` from
+    /// C2's stored owner execution-profile projection.
+    fn crew_discovery(&self, workspace_id: &str) -> Result<Value, OrbitError> {
+        let discovery = crate::ExecutionProfileProjection::at(&self.global_root)?
+            .crew_discovery(workspace_id)?;
+        serde_json::to_value(discovery)
+            .map_err(|error| OrbitError::Execution(format!("serialize crew discovery: {error}")))
+    }
+
+    /// Validate an explicit task crew against the workspace owner's current
+    /// execution profile. Never falls back to hub-local crews, the registry
+    /// cache, a stale replica, or a synchronous owner call.
+    fn validate_task_crew(&self, workspace_id: &str, crew: &str) -> Result<(), OrbitError> {
+        crate::ExecutionProfileProjection::at(&self.global_root)?
+            .validate_task_crew(workspace_id, crew)
+            .map(|_| ())
     }
 
     fn registration_result(
@@ -656,6 +691,20 @@ fn registration_partial(
         "projection_failed",
         error.to_string(),
     )
+}
+
+/// The explicit, non-empty `crew` on a task add/update, or `None` for any other
+/// tool, an omitted crew, or an explicit crew-clearing (empty) value.
+fn explicit_task_crew(name: &str, input: &Value) -> Option<String> {
+    if !matches!(name, "orbit.task.add" | "orbit.task.update") {
+        return None;
+    }
+    input
+        .get("crew")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 fn placement_label(placement: McpToolPlacement) -> &'static str {

--- a/crates/orbit-remote/src/mcp/tests/discovery.rs
+++ b/crates/orbit-remote/src/mcp/tests/discovery.rs
@@ -13,13 +13,13 @@ use super::super::schema::remote_input_schema;
 #[test]
 fn remote_owns_the_exact_global_discovery_definitions() {
     let definitions = discovery_tool_definitions().expect("discovery definitions");
-    assert_eq!(definitions.len(), 2);
+    assert_eq!(definitions.len(), 3);
     assert_eq!(
         definitions
             .iter()
             .map(|definition| definition.schema.name.as_str())
             .collect::<Vec<_>>(),
-        ["orbit.host.list", "orbit.workspace.list"]
+        ["orbit.host.list", "orbit.workspace.list", "orbit.crew.list"]
     );
     assert_eq!(
         definitions[0].schema.description,
@@ -31,7 +31,9 @@ fn remote_owns_the_exact_global_discovery_definitions() {
         "List workspaces with declared owner and sanitized execution-profile freshness \
          (operator, hub placement)."
     );
-    for definition in &definitions {
+    // The two registry-wide tools stay operator-only and global; they do not
+    // treat capability as a hierarchy that the crew tool extends.
+    for definition in &definitions[..2] {
         assert!(definition.schema.builtin);
         assert!(definition.schema.parameters.is_empty());
         assert_eq!(definition.policy.placement(), McpToolPlacement::Hub);
@@ -53,8 +55,26 @@ fn remote_owns_the_exact_global_discovery_definitions() {
         );
     }
 
+    // Crew discovery is workspace-scoped with exactly {agent, operator}; runner
+    // is never in its set.
+    let crew = &definitions[2];
+    assert_eq!(crew.schema.name, "orbit.crew.list");
+    assert!(crew.schema.builtin);
+    assert_eq!(crew.policy.placement(), McpToolPlacement::Hub);
+    assert_eq!(crew.policy.scope(), McpToolScope::WorkspaceRequired);
+    assert_eq!(
+        crew.policy.allowed_capabilities(),
+        &BTreeSet::from([McpCapability::Agent, McpCapability::Operator])
+    );
+    assert!(
+        !crew
+            .policy
+            .allowed_capabilities()
+            .contains(&McpCapability::Runner)
+    );
+
     let canonical = canonical_mcp_tool_definitions().expect("canonical definitions");
-    assert_eq!(canonical.len(), 31, "the frozen production surface changed");
+    assert_eq!(canonical.len(), 32, "the frozen production surface changed");
     assert_eq!(
         canonical
             .iter()

--- a/crates/orbit-remote/src/mcp/tests/e1.rs
+++ b/crates/orbit-remote/src/mcp/tests/e1.rs
@@ -305,6 +305,9 @@ fn hub_listing_uses_one_canonical_placement_and_capability_predicate() {
         .collect::<BTreeSet<_>>();
     assert!(agent_names.contains("orbit.task.add"));
     assert!(!agent_names.contains("orbit.host.list"));
+    // Crew discovery is admitted for agent (unlike the operator-only registry
+    // discovery tools), proving capability is by placement, not a hierarchy.
+    assert!(agent_names.contains("orbit.crew.list"));
     assert!(
         !agent_names
             .iter()
@@ -320,6 +323,7 @@ fn hub_listing_uses_one_canonical_placement_and_capability_predicate() {
         .map(|definition| definition.schema.name)
         .collect::<BTreeSet<_>>();
     assert!(operator_names.contains("orbit.host.list"));
+    assert!(operator_names.contains("orbit.crew.list"));
     assert!(operator_names.contains("orbit.friction.list"));
     assert!(operator_names.contains("orbit.friction.show"));
     assert!(operator_names.contains("orbit.friction.update"));
@@ -337,6 +341,157 @@ fn hub_listing_uses_one_canonical_placement_and_capability_predicate() {
             .expect("runner tools")
             .is_empty(),
         "D1 currently declares no runner-capability hub tools"
+    );
+}
+
+#[test]
+fn hub_crew_discovery_and_task_validation_read_the_owner_execution_profile() {
+    use orbit_common::types::{ExecutionProfileCrewV1, ExecutionProfileShipV1, ExecutionProfileV1};
+
+    use crate::host_identity::{HOST_IDENTITY_SCHEMA_VERSION, HostIdentity, HostMode};
+    use crate::host_registry::HostRegistryService;
+
+    let root = tempfile::tempdir().expect("global root");
+    write_identity(&root, "hub", "hm_hub");
+    // Register + stamp the hub, bind the workspace owner, and publish an owner
+    // execution profile through the same coordination store the hub reads.
+    let service = HostRegistryService::new(crate::remote_store_at(root.path()).expect("store"));
+    service
+        .register_hub_identity(
+            &HostIdentity {
+                schema_version: HOST_IDENTITY_SCHEMA_VERSION,
+                machine_id: "hm_hub".to_string(),
+                host_id: "test-host".to_string(),
+                mode: HostMode::Hub,
+            },
+            BTreeSet::new(),
+        )
+        .expect("register hub");
+    add_checkoutless_workspace(&root, "ws_alpha");
+    let registry = crate::workspace_registry::load_registry_from(
+        &crate::workspace_registry::registry_path_for(root.path()),
+    )
+    .expect("registry");
+    service
+        .bind_workspace_owner(&registry, "ws_alpha", "hm_hub")
+        .expect("bind owner");
+    let observed = Utc::now();
+    let mut profile = ExecutionProfileV1 {
+        schema_version: 1,
+        workspace_id: "ws_alpha".to_string(),
+        owner_machine_id: "hm_hub".to_string(),
+        observed_at: observed,
+        config_digest: String::new(),
+        default_crew: "sol".to_string(),
+        crews: vec![ExecutionProfileCrewV1 {
+            name: "sol".to_string(),
+            provider: "codex".to_string(),
+            model: "gpt-test".to_string(),
+            backend: "cli".to_string(),
+            description: None,
+            tags: Vec::new(),
+        }],
+        ship: ExecutionProfileShipV1 {
+            mode: "pr".to_string(),
+            base_branch: "agent-main".to_string(),
+            ship_closure_digest: "a".repeat(64),
+        },
+    };
+    profile.config_digest = profile.compute_config_digest().expect("config digest");
+    service
+        .publish_execution_profile("hm_hub", 0, &profile)
+        .expect("publish owner profile");
+
+    let host = HubMcpHost::new(root.path().to_path_buf(), McpCapability::Agent).expect("hub host");
+    let workspace_context = |call_id: &str| {
+        let mut context = context(McpCapability::Agent, call_id);
+        context.workspace = Some("ws_alpha".to_string());
+        context.workspace_id = Some("ws_alpha".to_string());
+        context
+    };
+
+    // Crew discovery resolves the session workspace and projects the owner
+    // profile, not the hub's unrelated local configuration.
+    let crews = host
+        .call_tool(
+            "orbit.crew.list",
+            json!({"workspace": "ws_alpha"}),
+            workspace_context("mcall-crew-list"),
+        )
+        .expect("crew list");
+    assert_eq!(crews["workspace_id"], "ws_alpha");
+    assert_eq!(crews["owner_machine_id"], "hm_hub");
+    assert_eq!(crews["profile"]["freshness"], "current");
+    assert_eq!(crews["profile"]["generation"], 1);
+    assert_eq!(crews["default_crew"], "sol");
+    assert_eq!(crews["crews"][0]["name"], "sol");
+    assert_eq!(crews["crews"][0]["model"], "gpt-test");
+    let serialized = serde_json::to_string(&crews).expect("serialize crew list");
+    for forbidden in ["config_digest", "ship_closure_digest", "\"root\""] {
+        assert!(
+            !serialized.contains(forbidden),
+            "crew list leaked {forbidden}"
+        );
+    }
+
+    // A valid explicit crew is accepted and the coordination task lands.
+    let created = host
+        .call_tool(
+            "orbit.task.add",
+            json!({
+                "workspace": "ws_alpha",
+                "title": "Coordinate",
+                "description": "Body",
+                "crew": "sol",
+                "model": "codex"
+            }),
+            workspace_context("mcall-task-valid"),
+        )
+        .expect("valid crew task add");
+    assert_eq!(created["crew"], "sol");
+
+    // An unknown explicit crew is rejected before allocation.
+    let error = host
+        .call_tool(
+            "orbit.task.add",
+            json!({
+                "workspace": "ws_alpha",
+                "title": "Rejected",
+                "description": "Body",
+                "crew": "ghost",
+                "model": "codex"
+            }),
+            workspace_context("mcall-task-bad"),
+        )
+        .expect_err("unknown crew rejected");
+    assert!(error.to_string().contains("ghost"), "unexpected: {error}");
+
+    // Omitting the crew is always accepted, even for coordination filing.
+    host.call_tool(
+        "orbit.task.add",
+        json!({
+            "workspace": "ws_alpha",
+            "title": "No crew",
+            "description": "Body",
+            "model": "codex"
+        }),
+        workspace_context("mcall-task-nocrew"),
+    )
+    .expect("omitted crew task add");
+
+    // The rejected task never entered hub coordination state: exactly the two
+    // accepted tasks exist.
+    let listed = host
+        .call_tool(
+            "orbit.task.list",
+            json!({"workspace": "ws_alpha"}),
+            workspace_context("mcall-task-list"),
+        )
+        .expect("task list");
+    assert_eq!(
+        listed.as_array().expect("task array").len(),
+        2,
+        "unknown-crew add must not mutate the task count"
     );
 }
 

--- a/crates/orbit-remote/src/mcp/tests/mod.rs
+++ b/crates/orbit-remote/src/mcp/tests/mod.rs
@@ -505,7 +505,10 @@ fn is_runtime_mcp_category_tool(name: &str) -> bool {
 }
 
 fn is_remote_owned_non_runtime_tool(name: &str) -> bool {
-    matches!(name, "orbit.host.list" | "orbit.workspace.list")
+    matches!(
+        name,
+        "orbit.host.list" | "orbit.workspace.list" | "orbit.crew.list"
+    )
 }
 
 #[test]
@@ -553,7 +556,7 @@ fn safe_surface_separates_remote_owned_and_runtime_tools() {
         );
     }
 
-    for name in ["orbit.host.list", "orbit.workspace.list"] {
+    for name in ["orbit.host.list", "orbit.workspace.list", "orbit.crew.list"] {
         assert!(safe_names.contains(name));
         assert!(is_mcp_tool_exposed(name));
         assert!(
@@ -675,7 +678,7 @@ fn runtime_mcp_host_lists_only_core_registry_backed_safe_tools() {
             .filter(|name| name.starts_with("orbit.graph."))
             .collect::<Vec<_>>()
     );
-    for name in ["orbit.host.list", "orbit.workspace.list"] {
+    for name in ["orbit.host.list", "orbit.workspace.list", "orbit.crew.list"] {
         assert!(
             !listed.contains(name),
             "Core runtime host must not expose Remote discovery: {name}"

--- a/crates/orbit-remote/src/tests/execution_profile_projection.rs
+++ b/crates/orbit-remote/src/tests/execution_profile_projection.rs
@@ -1,0 +1,332 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use orbit_common::types::{
+    ExecutionProfileCrewV1, ExecutionProfileShipV1, ExecutionProfileV1, ProjectionFreshness,
+    Workspace, WorkspaceRegistry, WorkspaceStatus,
+};
+
+use crate::execution_profile_projection::{ExecutionProfileProjection, FixedProfileClock};
+use crate::host_identity::{HOST_IDENTITY_SCHEMA_VERSION, HostIdentity, HostMode};
+use crate::host_registry::HostRegistryService;
+use crate::persistence::RemoteStore;
+
+const TTL: Duration = Duration::minutes(10);
+
+fn base_time() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 7, 18, 9, 0, 0)
+        .single()
+        .expect("timestamp")
+}
+
+fn identity(machine_id: &str, host_id: &str) -> HostIdentity {
+    HostIdentity {
+        schema_version: HOST_IDENTITY_SCHEMA_VERSION,
+        machine_id: machine_id.to_string(),
+        host_id: host_id.to_string(),
+        mode: HostMode::Hub,
+    }
+}
+
+fn workspace(id: &str, owner_machine_id: &str) -> Workspace {
+    Workspace {
+        id: id.to_string(),
+        name: id.to_string(),
+        owner_machine_id: Some(owner_machine_id.to_string()),
+        git_remote: Some("git@github.com:example/repo.git".to_string()),
+        ship_mode: Some("pr".to_string()),
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: base_time(),
+        updated_at: base_time(),
+    }
+}
+
+fn crew(name: &str, model: &str) -> ExecutionProfileCrewV1 {
+    ExecutionProfileCrewV1 {
+        name: name.to_string(),
+        provider: "codex".to_string(),
+        model: model.to_string(),
+        backend: "cli".to_string(),
+        description: Some(format!("{name} crew")),
+        tags: vec!["execution".to_string()],
+    }
+}
+
+fn profile(
+    workspace_id: &str,
+    owner_machine_id: &str,
+    default_crew: &str,
+    crews: Vec<ExecutionProfileCrewV1>,
+    observed_at: DateTime<Utc>,
+) -> ExecutionProfileV1 {
+    let mut profile = ExecutionProfileV1 {
+        schema_version: 1,
+        workspace_id: workspace_id.to_string(),
+        owner_machine_id: owner_machine_id.to_string(),
+        observed_at,
+        config_digest: String::new(),
+        default_crew: default_crew.to_string(),
+        crews,
+        ship: ExecutionProfileShipV1 {
+            mode: "pr".to_string(),
+            base_branch: "agent-main".to_string(),
+            ship_closure_digest: "a".repeat(64),
+        },
+    };
+    profile.config_digest = profile.compute_config_digest().expect("config digest");
+    profile
+}
+
+/// Build a store with two workspaces whose owner profiles deliberately differ,
+/// plus one owned workspace that never publishes a profile.
+fn two_workspace_store() -> RemoteStore {
+    let store = RemoteStore::open_in_memory().expect("store");
+    let service = HostRegistryService::new(store.clone());
+    for (machine, host) in [
+        ("hm_owner_a", "owner-a"),
+        ("hm_owner_b", "owner-b"),
+        ("hm_owner_c", "owner-c"),
+    ] {
+        service
+            .register_identity(&identity(machine, host), Default::default())
+            .expect("register owner");
+    }
+    let registry = WorkspaceRegistry {
+        schema_version: 1,
+        workspaces: vec![
+            workspace("ws_alpha", "hm_owner_a"),
+            workspace("ws_beta", "hm_owner_b"),
+            workspace("ws_gamma", "hm_owner_c"),
+        ],
+        checkouts: Vec::new(),
+    };
+    for (workspace_id, owner) in [
+        ("ws_alpha", "hm_owner_a"),
+        ("ws_beta", "hm_owner_b"),
+        ("ws_gamma", "hm_owner_c"),
+    ] {
+        service
+            .bind_workspace_owner(&registry, workspace_id, owner)
+            .expect("bind owner");
+    }
+    // ws_alpha owner publishes {sol}; ws_beta owner publishes {qa}. ws_gamma
+    // owner never publishes: it stays a "missing" workspace.
+    service
+        .publish_execution_profile_at(
+            "hm_owner_a",
+            0,
+            &profile(
+                "ws_alpha",
+                "hm_owner_a",
+                "sol",
+                vec![crew("sol", "gpt-alpha")],
+                base_time(),
+            ),
+            base_time(),
+        )
+        .expect("publish alpha");
+    service
+        .publish_execution_profile_at(
+            "hm_owner_b",
+            0,
+            &profile(
+                "ws_beta",
+                "hm_owner_b",
+                "qa",
+                vec![crew("qa", "claude-beta")],
+                base_time(),
+            ),
+            base_time(),
+        )
+        .expect("publish beta");
+    store
+}
+
+fn projection_at(store: RemoteStore, now: DateTime<Utc>) -> ExecutionProfileProjection {
+    ExecutionProfileProjection::with_clock(store, Arc::new(FixedProfileClock(now)), TTL)
+}
+
+#[test]
+fn discovery_and_validation_never_leak_one_workspace_crews_into_another() {
+    let projection = projection_at(two_workspace_store(), base_time());
+
+    let alpha = projection
+        .crew_discovery("ws_alpha")
+        .expect("alpha discovery");
+    assert_eq!(alpha.owner_machine_id.as_deref(), Some("hm_owner_a"));
+    assert_eq!(alpha.default_crew.as_deref(), Some("sol"));
+    assert_eq!(
+        alpha
+            .crews
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>(),
+        ["sol"]
+    );
+
+    let beta = projection
+        .crew_discovery("ws_beta")
+        .expect("beta discovery");
+    assert_eq!(
+        beta.crews
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>(),
+        ["qa"]
+    );
+
+    // A crew valid in one workspace is unknown in the other; validation reads
+    // only the resolved workspace's owner profile.
+    projection
+        .validate_task_crew("ws_alpha", "sol")
+        .expect("sol valid in alpha");
+    let cross = projection
+        .validate_task_crew("ws_alpha", "qa")
+        .expect_err("qa is not published for alpha")
+        .to_string();
+    assert!(cross.contains("qa"), "unexpected: {cross}");
+    assert!(cross.contains("ws_alpha"), "unexpected: {cross}");
+}
+
+#[test]
+fn discovery_and_validation_observe_the_same_generation_and_track_republication() {
+    let store = two_workspace_store();
+    let service = HostRegistryService::new(store.clone());
+    let projection = projection_at(store.clone(), base_time());
+
+    let first = projection.crew_discovery("ws_alpha").expect("discovery");
+    assert_eq!(first.profile.freshness, ProjectionFreshness::Current);
+    assert_eq!(first.profile.generation, Some(1));
+    let validated = projection
+        .validate_task_crew("ws_alpha", "sol")
+        .expect("valid");
+    assert_eq!(validated.generation, 1);
+    assert_eq!(first.profile.generation, Some(validated.generation));
+
+    // Publishing a newer *semantic* profile advances the generation for both
+    // paths together.
+    service
+        .publish_execution_profile_at(
+            "hm_owner_a",
+            1,
+            &profile(
+                "ws_alpha",
+                "hm_owner_a",
+                "sol",
+                vec![crew("sol", "gpt-alpha-2")],
+                base_time() + Duration::minutes(1),
+            ),
+            base_time() + Duration::minutes(1),
+        )
+        .expect("republish semantic change");
+    let after = projection_at(store.clone(), base_time() + Duration::minutes(1));
+    assert_eq!(
+        after
+            .crew_discovery("ws_alpha")
+            .expect("discovery")
+            .profile
+            .generation,
+        Some(2)
+    );
+    assert_eq!(
+        after
+            .validate_task_crew("ws_alpha", "sol")
+            .expect("valid")
+            .generation,
+        2
+    );
+
+    // An identical refresh renews freshness without inventing a generation.
+    service
+        .publish_execution_profile_at(
+            "hm_owner_a",
+            2,
+            &profile(
+                "ws_alpha",
+                "hm_owner_a",
+                "sol",
+                vec![crew("sol", "gpt-alpha-2")],
+                base_time() + Duration::minutes(2),
+            ),
+            base_time() + Duration::minutes(2),
+        )
+        .expect("republish identical");
+    let refreshed = projection_at(store, base_time() + Duration::minutes(2));
+    let discovery = refreshed.crew_discovery("ws_alpha").expect("discovery");
+    assert_eq!(discovery.profile.generation, Some(2));
+    assert_eq!(discovery.profile.freshness, ProjectionFreshness::Current);
+}
+
+#[test]
+fn missing_profile_is_inspectable_discovery_but_blocks_validation() {
+    let projection = projection_at(two_workspace_store(), base_time());
+    let discovery = projection.crew_discovery("ws_gamma").expect("discovery");
+    assert_eq!(discovery.profile.freshness, ProjectionFreshness::Missing);
+    assert_eq!(discovery.profile.generation, None);
+    assert!(discovery.crews.is_empty());
+    assert!(discovery.default_crew.is_none());
+
+    let error = projection
+        .validate_task_crew("ws_gamma", "sol")
+        .expect_err("missing profile blocks crew")
+        .to_string();
+    assert!(error.contains("missing"), "unexpected: {error}");
+    assert!(error.contains("ws_gamma"), "unexpected: {error}");
+    assert!(error.contains("hm_owner_c"), "unexpected: {error}");
+}
+
+#[test]
+fn stale_profile_returns_crews_bound_to_stale_generation_but_never_validates() {
+    // A clock past the TTL makes the alpha profile stale.
+    let projection = projection_at(two_workspace_store(), base_time() + Duration::minutes(11));
+    let discovery = projection.crew_discovery("ws_alpha").expect("discovery");
+    assert_eq!(discovery.profile.freshness, ProjectionFreshness::Stale);
+    // Crews remain inspectable but stay tied to the stale generation.
+    assert_eq!(discovery.profile.generation, Some(1));
+    assert_eq!(
+        discovery
+            .crews
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>(),
+        ["sol"]
+    );
+
+    let error = projection
+        .validate_task_crew("ws_alpha", "sol")
+        .expect_err("stale profile is never dispatch-eligible")
+        .to_string();
+    assert!(error.contains("stale"), "unexpected: {error}");
+    assert!(error.contains("age="), "unexpected: {error}");
+}
+
+#[test]
+fn discovery_is_sanitized_and_exposes_no_config_or_ship_material() {
+    let projection = projection_at(two_workspace_store(), base_time());
+    let discovery = projection.crew_discovery("ws_alpha").expect("discovery");
+    let serialized = serde_json::to_string(&discovery).expect("serialize");
+
+    // The crew projection intentionally exposes model/provider/backend.
+    assert!(serialized.contains("gpt-alpha"));
+    assert!(serialized.contains("\"provider\":\"codex\""));
+
+    for forbidden in [
+        "config_digest",
+        "ship_closure_digest",
+        "ship",
+        "base_branch",
+        "root",
+        "repo_root",
+        "orbit_dir",
+        "secret",
+        "token",
+        "ssh",
+        "observed_at\":\"/", // no path smuggled through a timestamp field
+    ] {
+        assert!(
+            !serialized.contains(forbidden),
+            "crew discovery leaked '{forbidden}': {serialized}"
+        );
+    }
+}

--- a/crates/orbit-remote/src/tests/mod.rs
+++ b/crates/orbit-remote/src/tests/mod.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)]
 
+mod execution_profile_projection;
 mod host_identity;
 mod host_registry;
 mod knowledge;

--- a/docs/design/host-registry/4_decisions.md
+++ b/docs/design/host-registry/4_decisions.md
@@ -10,7 +10,7 @@ summary: ADR log for the coupled Host Registry and MCP Bridge v1 contract and it
 tags: [host-registry, mcp-bridge, multi-host, placement]
 paths: ["crates/orbit-remote/**", "crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**"]
 related_features: [host-registry, mcp-bridge]
-related_artifacts: [ORB-00424, ORB-10245, ORB-10248, ORB-10249, ORB-10255, ORB-10257, ORB-10267, ORB-10258, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10302, ORB-10319, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
+related_artifacts: [ORB-00424, ORB-10245, ORB-10248, ORB-10249, ORB-10255, ORB-10257, ORB-10267, ORB-10258, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
 ---
 
 # Host Registry — Decisions
@@ -71,7 +71,7 @@ and pin the one hub `machine_id` out of band in machine-local `mcp.toml`.
 
 ## ADR-0228 — Local placement broker with capability-set filtering
 
-**Status:** Accepted · 2026-07 · [ORB-10245] froze tool routing and authorization; [ORB-10267] added the `orbit.host.list` and `orbit.workspace.list` canonical discovery tools (hub placement, operator capability, workspace-unscoped) reading one sanitized path-free registry snapshot; [ORB-10268] implemented the fixed checkoutless hub endpoint and exact scalar-capability surface; [ORB-10271] enforced current registered/active caller identity before every ordinary remote call and exposed path-free operator friction list/show; [ORB-10319] colocates MCP-only discovery schema and execution in Remote while retaining dedicated human CLI commands.
+**Status:** Accepted · 2026-07 · [ORB-10245] froze tool routing and authorization; [ORB-10267] added the `orbit.host.list` and `orbit.workspace.list` canonical discovery tools (hub placement, operator capability, workspace-unscoped) reading one sanitized path-free registry snapshot; [ORB-10268] implemented the fixed checkoutless hub endpoint and exact scalar-capability surface; [ORB-10271] enforced current registered/active caller identity before every ordinary remote call and exposed path-free operator friction list/show; [ORB-10319] colocates MCP-only discovery schema and execution in Remote while retaining dedicated human CLI commands; [ORB-10276] added the workspace-scoped, `{agent, operator}` `orbit.crew.list` (never `runner`) beside the two operator-only global registry tools, reading the owner execution-profile projection through one service that also backs explicit task-crew validation.
 
 ### Context
 
@@ -292,5 +292,13 @@ crate.
   sequences, immutable correlation ledger plus atomic audit, replay-safe lookup,
   and late-workspace ineligibility. F3 retains authority over public activation and
   caller cutover; standalone creation remains unchanged.
-
-> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.
+- [ORB-10276] — implemented Unit H1 of ORB-10246: completed host/workspace/crew
+  discovery with the workspace-scoped, `{agent, operator}`, hub-placement
+  `orbit.crew.list` and added the single `orbit-remote` execution-profile projection
+  service (injected clock, one shared freshness TTL) backing both crew discovery and
+  explicit task-crew validation on task add/update. It consumes C2's stored owner
+  projection only — never hub-local crews, the satellite cache, a stale replica, or a
+  synchronous owner call — and returns a `ValidatedCrewProfile` (stored profile,
+  resolved crew, generation, config digest, ship-closure digest). Standalone and
+  owner-local auto-task CRUD keep their local crew validation. Task `host`/claims
+  (H2), workflow ship/placement (H3), and run lineage/leasing (I1) stay out of scope.

--- a/docs/design/mcp-bridge/2_design.md
+++ b/docs/design/mcp-bridge/2_design.md
@@ -10,7 +10,7 @@ summary: Target design for a local Orbit MCP broker with one SSH hub link, hub-o
 tags: [mcp, remote-access, host-registry, bridge, ssh, routing]
 paths: ["crates/orbit-remote/**", "crates/orbit-mcp/**", "crates/orbit-core/**", "crates/orbit-tools/**", "crates/orbit-store/**", "crates/orbit-common/**"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access, orbit-search, orbit-graph, project-learnings]
-related_artifacts: [ORB-00424, ORB-10257, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10302, ORB-10319, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
+related_artifacts: [ORB-00424, ORB-10257, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
 ---
 
 # Orbit MCP Bridge — Design
@@ -683,6 +683,21 @@ This is one-way spoke→hub coordination metadata, not repo content and not a li
 proxy. `orbit.crew.list`, task crew validation, and workflow preflight all read the
 same projection. Missing/stale owner profile fails dispatch with the owner named;
 the hub never asks the owner synchronously.
+
+- Implemented by [ORB-10276] (Unit H1): one `orbit-remote` execution-profile
+  projection service — an injected clock and one service-owned freshness TTL over
+  C2's stored owner projection — backs both `orbit.crew.list` discovery (sanitized
+  workspace/owner identity, the shared `RegistryProfileV1` freshness/generation
+  envelope, default crew, and the sorted name/provider/model/backend/description/tags
+  crew projection; missing and stale profiles stay inspectable but never
+  dispatch-eligible) and explicit task-crew validation. A non-empty `crew` on task
+  add/update requires the resolved owner's current profile and validates against its
+  effective crews before allocation/mutation; an omitted or cleared crew is accepted
+  without a profile. Standalone task validation and owner-local auto-task CRUD keep
+  their local-runtime crew registry. The returned `ValidatedCrewProfile` captures the
+  stored profile, resolved crew, generation, config digest, and ship-closure digest;
+  H3 later persists the immutable dispatch snapshot on run admission and I1 carries
+  and revalidates that lineage during leasing.
 
 The publication/ownership/presence/freshness service, profile construction, and
 registry persistence live in `orbit-remote`. Remote combines the workspace binding

--- a/docs/design/mcp-bridge/4_decisions.md
+++ b/docs/design/mcp-bridge/4_decisions.md
@@ -10,7 +10,7 @@ summary: ADR log for the coupled MCP Bridge and Host Registry v1 contract and it
 tags: [mcp, remote-access, host-registry, bridge]
 paths: ["crates/orbit-remote/**", "crates/orbit-mcp/**", "crates/orbit-core/**", "crates/orbit-tools/**", "crates/orbit-store/**"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access]
-related_artifacts: [ORB-00424, ORB-10245, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10302, ORB-10319, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
+related_artifacts: [ORB-00424, ORB-10245, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
 ---
 
 # Orbit MCP Bridge — Decisions
@@ -25,7 +25,7 @@ The older entry remains intact as design history.
 
 ## ADR-0226 — Singular coordination hub, workspace owner, and per-run placement
 
-**Status:** Accepted · 2026-07 · [ORB-10245] accepted the coupled v1 contract.
+**Status:** Accepted · 2026-07 · [ORB-10245] accepted the coupled v1 contract; [ORB-10276] added the single projection-backed explicit-task-crew validation path: a non-empty `crew` on task add/update is validated against the resolved workspace owner's current stored execution profile (never hub-local crews, the registry cache, a stale replica, or a synchronous owner call), while an omitted or cleared crew still files without a profile and standalone/auto-task CRUD keep their local-runtime crew validation.
 
 ### Context
 
@@ -67,7 +67,7 @@ and pin the one hub `machine_id` out of band in machine-local `mcp.toml`.
 
 ## ADR-0228 — Local placement broker with capability-set filtering
 
-**Status:** Accepted · 2026-07 · [ORB-10245] froze tool routing and authorization; [ORB-10267] registered the first operator-only, hub-placement canonical discovery tools (`orbit.host.list`, `orbit.workspace.list`) in Remote's canonical composition and the versioned conformance fixture; [ORB-10262] implemented the local exact-checkout broker and capability enforcement; [ORB-10268] implemented the fixed checkoutless hub endpoint and exact scalar-capability surface; [ORB-10271] implemented active registered-caller validation, operator-only friction reads, and path-free remote artifacts/responses; [ORB-10319] colocated MCP-only discovery schemas and execution in Remote while retaining the dedicated human CLI commands.
+**Status:** Accepted · 2026-07 · [ORB-10245] froze tool routing and authorization; [ORB-10267] registered the first operator-only, hub-placement canonical discovery tools (`orbit.host.list`, `orbit.workspace.list`) in Remote's canonical composition and the versioned conformance fixture; [ORB-10262] implemented the local exact-checkout broker and capability enforcement; [ORB-10268] implemented the fixed checkoutless hub endpoint and exact scalar-capability surface; [ORB-10271] implemented active registered-caller validation, operator-only friction reads, and path-free remote artifacts/responses; [ORB-10319] colocated MCP-only discovery schemas and execution in Remote while retaining the dedicated human CLI commands; [ORB-10276] completed the discovery surface with the workspace-scoped, `{agent, operator}`, hub-placement `orbit.crew.list` (runner neither advertises nor executes it) beside the two operator-only global registry tools, reading the same profile projection through one service.
 
 ### Context
 
@@ -272,5 +272,17 @@ Remote database or a separate broker crate.
   explicit late-workspace ineligibility. Its private path-free allocation protocol
   advances the connector contract to revision 3. Public issuance remains an F3
   cutover and standalone creation remains unchanged.
+- [ORB-10276] — completed host/workspace/crew discovery and the first
+  projection-backed validation path (Unit H1). Registered the workspace-scoped,
+  `{agent, operator}`, hub-placement `orbit.crew.list` beside the two operator-only
+  global registry tools and in the conformance fixture, and added one reusable
+  `orbit-remote` execution-profile projection service (injected clock, single shared
+  freshness TTL) that both crew discovery and explicit task-crew validation read.
+  A non-empty task crew on add/update now requires the resolved workspace owner's
+  current stored profile and validates against its effective crews; missing/stale
+  profiles and unknown crews fail with actionable workspace/owner/state/age errors
+  and mutate nothing. Standalone and owner-local auto-task CRUD keep their local
+  crew validation. Task `host`/claims (H2), workflow ship/placement (H3), and run
+  lineage/leasing (I1) remain out of scope.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-bridge/references/conformance-v1.yaml
+++ b/docs/design/mcp-bridge/references/conformance-v1.yaml
@@ -69,6 +69,7 @@ tools:
   orbit.friction.update: { placement: hub, scope: workspace-required, allowed_capabilities: [operator] }
   orbit.host.list: { placement: hub, scope: global, allowed_capabilities: [operator] }
   orbit.workspace.list: { placement: hub, scope: global, allowed_capabilities: [operator] }
+  orbit.crew.list: { placement: hub, scope: workspace-required, allowed_capabilities: [agent, operator] }
   orbit.search: { placement: composite, scope: workspace-required, allowed_capabilities: [agent, operator] }
   orbit.adr.add: { placement: composite, scope: workspace-required, allowed_capabilities: [agent, operator] }
   orbit.adr.show: { placement: owner, scope: workspace-required, allowed_capabilities: [agent, operator] }


### PR DESCRIPTION
## Task

[ORB-10276](https://orbit-cli.com/tasks/ORB-10276) — Add projection-backed operator discovery and crew validation

### Description

## Problem

C3/ORB-10267 provides hub-owned host/workspace administration, sanitized discovery, and the registry cache. E3/ORB-10271 proves those discovery calls and ordinary coordination traffic over the verified spoke-to-hub link. C2/ORB-10257 provides owner-published execution profiles and typed freshness/generation reads.

Orbit still has no canonical `orbit.crew.list` tool, and task crew validation currently reads the process runtime's checkout-local crew registry. A checkoutless hub therefore cannot validate a task for a spoke-owned workspace without either using the wrong local configuration or contacting the owner synchronously.

This is Unit H1 of implementation umbrella ORB-10246. It completes host/workspace/crew discovery and introduces exactly one projection-backed validation path: explicit task `crew` assignment. Task host selection and claims belong to H2; workflow submission and placement belong to H3.

## Required outcome

### Canonical crew discovery

Add `orbit.crew.list` as a canonical `hub`-placement tool.

- It resolves the stable workspace through the broker/session contract, never process cwd.
- It reads C2's stored owner execution-profile projection at the hub; it never opens an owner route or reads the hub process's unrelated local workspace configuration.
- Its policy permits `agent` and `operator`, matching the accepted read-only crew-discovery contract. `runner` must neither advertise nor execute it.
- C3's `orbit.host.list` and `orbit.workspace.list` remain `operator`-only. Together, the three tools form the discovery surface without changing their independent capability policies.
- The response is deterministic and sanitized: stable workspace and owner identity, explicit profile state (`missing | current | stale`), hub generation/freshness metadata, default crew, and sorted effective crew entries containing only the normalized name/provider/model/backend/description/tags projection.
- Missing and stale profiles remain inspectable discovery states. Any crew entries returned from a stale record must remain explicitly tied to that stale profile generation and must never be presented as dispatch-eligible.
- Responses expose no presence root, checkout/worktree path, raw profile/config payload, environment name/value, secret, credential, token, SSH material, command fragment, or repository content.

Host, workspace, and crew discovery must read the same hub registry/profile generation and freshness authorities. Do not introduce a second projection, schema registry, capability allowlist, or freshness calculation in individual handlers.

### Projection-backed task crew validation

Add one reusable hub-side validation service backed by C2's owner execution-profile projection, using a single service-owned freshness policy and an injected/testable clock.

Use it only when a non-empty explicit `crew` is set through task add or task update:

- resolve the task's stable logical workspace and declared owner;
- require a current owner profile;
- validate the crew name against that profile's effective crew entries; and
- reject missing/stale profiles or unknown crews before task allocation/update, returning an actionable error with workspace, owner, profile state, and age when available.

An omitted crew or clearing an existing crew remains valid, so owner/profile unavailability does not prevent filing an ordinary coordination task. Default-crew resolution and dispatch eligibility are H3 concerns.

Preserve standalone behavior: an unconfigured standalone installation continues using the current local runtime crew registry. In hub/spoke mode, projection failure must never fall back to hub-local crews, the satellite registry cache, a stale replica, or a synchronous owner call.

Keep auto-task definition validation owner-local; do not globally change the existing local `validate_crew_name` behavior used by owner-placed auto-task CRUD.

### Consistency proof

Use a deterministic hub/spoke fixture with at least two workspaces whose owner profiles deliberately differ from the hub's local crew configuration.

Prove that:

- discovery and task validation observe the same workspace-specific profile generation;
- publishing a newer semantic profile changes both paths together;
- an identically refreshed profile updates freshness without inventing a generation;
- missing, stale, wrong-workspace, and unknown-crew cases cannot mutate a task;
- valid remote task mutations exist only in the hub coordination store; and
- no discovery or validation operation contacts an owner or opens a spoke-to-spoke/hub-to-spoke route.

## Boundaries

- Consume C2/C3/E3 APIs; do not create another registry, profile store, cache, transport, session context, or audit seam.
- H2 owns task `host`, human claim/release, host validation, and explicit ship preflight.
- H3 owns `workflow.ship`, run observation, requested/actual placement, submission/spawn splitting, and new run states.
- I1 and later units own leases, runner tools, profile-digest snapshots, selected-runner recomputation, TTLs, reporting, and recovery.
- Do not add workflow dispatch, run persistence, runner polling, lease behavior, knowledge routing, search composition, Bridge retirement, HA, multiple hubs, per-workspace coordination targets, relays, or owner proxies.
- The satellite registry cache remains offline routine-validation data only; discovery and task validation never read it.
- Preserve standalone and hub-local behavior.
- Update the accepted Host Registry/MCP Bridge design task references and implemented evidence in the same PR; do not reopen the accepted topology.

### Acceptance Criteria

- orbit.crew.list is registered beside its canonical schema with hub placement and exactly {agent, operator} capabilities; runner neither advertises nor executes it.
- orbit.host.list and orbit.workspace.list remain operator-only, and capability/conformance tests cover all three discovery tools without treating capability as a hierarchy.
- Authority remains explicit: C3 is the source for host identity, presence, and host freshness; C2 is the source for owner-published execution profiles; H1 only validates/projects crews from those facts and creates no second authority.
- Crew discovery resolves an explicit/session workspace ID and reads that workspace owner's stored execution-profile projection, not cwd, the hub's unrelated runtime configuration, or a live owner.
- Crew discovery returns deterministic owner/profile freshness metadata and sorted normalized crew entries; missing/current/stale states are explicit and stale data is never marked dispatch-eligible.
- Workspace and crew responses share one profile envelope containing owner, profile generation, receipt time, and freshness. Host responses use C3 registry/presence authority instead of borrowing profile generation, and no handler recomputes freshness independently.
- One reusable typed validation result contains the stored profile, resolved crew, profile generation, config digest, and ship-closure digest; it uses an injected clock and one TTL policy shared by discovery and task mutation.
- Sanitization tests with hostile roots, raw config/profile values, secrets, tokens, and executable-looking strings prove discovery exposes none of them.
- Setting a non-empty explicit task crew through task add or update requires a current owner profile and validates against that profile's crew entries before allocation or mutation.
- Missing or stale profiles and unknown crew names return actionable workspace/owner/state/age errors and leave task count, payload, history, and indexes unchanged.
- Omitted crew and explicit crew clearing remain accepted without a profile, preserving the ability to file coordination tasks while an owner is unavailable.
- Standalone task validation retains current local-runtime behavior. Every hub/spoke validation—including when the hub owns the workspace—uses the stored owner profile and never falls back to hub-local crews, registry cache, replicas, or synchronous owner contact.
- Auto-task CRUD retains its owner-local crew-validation path and is not redirected to hub task-profile validation.
- A deterministic two-workspace fixture proves discovery and validation change atomically with profile generation/freshness and cannot leak one workspace's crews into another.
- A hermetic spoke call proves crew discovery and valid task mutation traverse only the hub link, mutate only hub coordination state, and create no hub-to-spoke or spoke-to-spoke connection.
- H3 persists the immutable validated dispatch-profile snapshot on run admission; I1 later carries and revalidates that exact lineage during leasing. H1 does not persist run lineage or implement leasing.
- Canonical registry tests, capability-by-placement conformance, MCP tool-list/wire snapshots, targeted orbit-common/orbit-store/orbit-core/orbit-tools/orbit-mcp/orbit-cli tests, cargo fmt --all --check, git diff --check, and make ci-fast pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Unit H1 (ORB-10276): projection-backed operator discovery + crew validation.

## Canonical crew discovery
- Added `orbit.crew.list` as a canonical, Remote-owned `hub`-placement tool with exactly `{agent, operator}` (runner neither advertises nor executes it), workspace-scoped (not global). Registered beside its schema in `orbit-remote/src/mcp/discovery.rs`; added to the frozen conformance fixture. `orbit.host.list`/`orbit.workspace.list` stay operator-only + global.
- Execution routes through one new service, `orbit_remote::ExecutionProfileProjection` (`crates/orbit-remote/src/execution_profile_projection.rs`): reads C2's stored owner execution-profile projection (`RemoteStore::sanitized_execution_profile`) via an injected `ProfileClock` and one service-owned freshness TTL (`CREW_PROFILE_FRESHNESS_TTL`, 10m). Wired into both the hub-local `BrokerMcpHost` (standalone) and the `HubMcpHost` (spoke→hub) before the coordination executor; spokes forward over the hub link unchanged.
- Response = new `CrewDiscoveryV1` (orbit-common): stable workspace/owner identity, the shared `RegistryProfileV1` freshness/generation envelope (also used by workspace.list), default crew, and sorted `ExecutionProfileCrewV1` entries (name/provider/model/backend/description/tags only). No config_digest, ship closure, root, secret, token, or path. Missing/stale profiles stay inspectable; stale crews stay bound to the stale generation and are never dispatch-eligible.

## Projection-backed task crew validation
- New `ExecutionProfileProjection::validate_task_crew` returns the immutable typed `ValidatedCrewProfile` (stored profile, resolved crew, generation, config digest, ship-closure digest). Same read path/TTL/clock as discovery → discovery and validation observe the same generation and freshness.
- Wired into `HubMcpHost.resolved_call` only: a non-empty explicit `crew` on `orbit.task.add`/`orbit.task.update` requires the resolved workspace owner's `current` profile and validates against its effective crews before allocation/mutation. Missing/stale/unknown crew → actionable workspace/owner/state/age error, no mutation. Omitted or cleared crew accepted without a profile. Standalone (BrokerMcpHost non-spoke) and owner-local auto-task CRUD keep their local-runtime crew validation — projection failure never falls back to hub-local crews, cache, replica, or a synchronous owner call.

## Tests
- `orbit-remote/src/tests/execution_profile_projection.rs`: deterministic two/three-workspace fixture proving no cross-workspace crew leak; discovery+validation observe the same generation; semantic republish advances generation for both; identical refresh renews freshness without inventing a generation; missing (inspectable, blocks validation), stale (returns crews bound to stale generation, never validates), unknown-crew; sanitization (no config/ship/root/secret; model IS exposed).
- `orbit-remote/src/mcp/tests/e1.rs`: HubMcpHost end-to-end — crew.list projects the owner profile (sanitized), valid crew task.add lands in hub coordination state, unknown crew is rejected before allocation (task count unchanged), omitted crew accepted; crew.list admitted for agent and operator, not runner.
- Updated discovery/capability/conformance tests and regenerated the agent MCP tools/list snapshot (crew.list is agent-visible).

## Validation run locally
cargo fmt --all --check, git diff --check, make ci-fast: pass. cargo clippy (orbit-common, orbit-remote): clean. Tests: orbit-remote (170), orbit-common, orbit-store, orbit-tools, orbit-mcp, orbit-core lib, orbit-cli mcp_roundtrip: pass.

Sandbox-only non-failures (CI arbitrates, per envelope rule 10): `orbit-cli` audit test `tool_run_audit_meta_uses_agent_role_without_identity` expects role "agent" but this managed-agent env sets ORBIT_AGENT_MODEL=opus (passes with env cleared); `orbit-cli --test docs` semantic-companion tests fail because /tmp is world-writable in this sandbox ("override parent must not be group/world writable"). Both are pre-existing environment artifacts unrelated to this change.

Scope boundaries respected: H2 (task host/claims), H3 (workflow ship/placement, run persistence), and I1 (leases, run lineage snapshot) untouched. Design docs (mcp-bridge + host-registry decisions/design) updated with ORB-10276 evidence; accepted topology not reopened.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10276-6a5d379f`
- Behind base: 0
- Ahead of base: 1