### PR TITLE
Teaser learning injection + show-as-usage-signal + session-dedup fix

### DIFF
--- a/.orbit/adrs/accepted/ADR-0242/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0242/adr.yaml
@@ -1,0 +1,26 @@
+schema_version: 2
+id: ADR-0242
+title: Teaser learning injection + show-as-usage-signal (replaces rejected ack design)
+status: accepted
+owner: claude
+created_at: 2026-07-19T21:16:29.039388312Z
+accepted_at: 2026-07-19T21:16:34.909096658Z
+last_updated: 2026-07-19T21:16:34.909096658Z
+related_features:
+- project-learnings
+related_tasks:
+- ORB-10316
+tags:
+- learnings
+- hooks
+- observability
+- deprecation
+paths:
+- crates/orbit-cmd/src/learning_hook.rs
+- crates/orbit-core/src/command/learning.rs
+- crates/orbit-store/src/sqlite/audit_event_store/mod.rs
+- crates/orbit-common/src/types/learning.rs
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0242/body.md
+++ b/.orbit/adrs/accepted/ADR-0242/body.md
@@ -1,0 +1,36 @@
+## Context
+
+The 2026-07-18 relevancy audit (friction F2026-07-092) found the learning PreToolUse hook fired 2,374 times over two weeks with 13 injections (0.55%) and **zero usage signal**: nothing recorded whether an injected learning shaped the receiving agent's work, so nothing could drive deprecation of stale learnings. ADR-0210 removed the vote/comment feedback surfaces for lack of real usage, ending with an explicit reopening clause: a scoped feedback primitive can return "with real usage data behind it." The audit is that data.
+
+A first attempt (PR #657, closed unmerged) added an explicit `orbit learning ack` CLI/MCP surface with ignored-by-default semantics. Daniel rejected it: an ack is an active, gameable step the agent must remember to take, it costs a reminder-block footer line and a new MCP tool in the frozen conformance surface, and "unacked = ignored" biases every silent session toward deprecation regardless of whether the learning was actually useless.
+
+Separately, per-session injection dedup was dead in interactive sessions — `ORBIT_SESSION_ID` was exported on 0/2,374 observed fires, and the ppid-tmpfile fallback re-keys per invocation because every hook fire runs under a fresh parent shell (L-0077 injected 10× in one session).
+
+Alternatives considered:
+
+| Approach | Profile |
+|----------|---------|
+| **Explicit `learning ack` surface (PR #657)** | Active, gameable, adds an MCP tool to the frozen conformance fixture and a reminder footer line; silence forced to mean "ignored." Rejected by Daniel. |
+| **Full-content injection + no signal (status quo)** | High token cost per fire, no usage data, no deprecation input. |
+| **Teaser injection + show-as-signal (this ADR)** | Injection carries only id + summary + tags; opening the full body via `orbit learning show` is the passive, ungameable usage signal. Lower token cost, no new agent action, no new MCP tool. |
+
+## Decision
+
+1. **Teaser injection.** The injection layers project only the learning id, one-line summary, and scope tags into agent context (`render_reminder_block`). The full body is retrieved on demand via `orbit learning show <id>` — the reminder block already tells the agent how. This drops per-fire injection token cost and makes "read the full learning" an explicit, observable act.
+
+2. **Show-as-usage-signal.** `orbit learning show` (CLI and `orbit.learning.show` MCP tool) records a `learning_shown` audit event in the host-global `~/.orbit/orbit.db`, keyed by learning id + session, alongside the existing `learning_injected` events. It is the passive signal: an agent that opens a learning found the teaser worth expanding. No ack, no new tool, no schema change — `orbit.learning.show` already exists.
+
+3. **Aggregation.** `orbit learning stats` folds `learning_injected` + `learning_shown` per learning into injected count, shown count, shown ratio, and last-injected/last-shown timestamps (CLI + `learning_usage_stats` runtime API). This rollup is the designed input for the downstream deprecation sweep (ORB-10318); a low shown ratio (injected often, never read) is the deprecation-candidate signal. No deprecation logic lives here.
+
+4. **Fail-open instrumentation.** An unavailable audit backend logs a warning and injection still renders; `learning show` logs a warning and still returns the learning when the `learning_shown` emit fails. The signal is best-effort observability and must never break the read or injection path.
+
+5. **Session dedup** keys on the first resolvable anchor: `ORBIT_SESSION_ID` env (engine-managed runs export it, pre-seeded with layer-1 injections) → the `session_id` field the hook payload itself carries (Claude Code sends it on every hook event) → ppid-tmpfile last resort.
+
+**No ack surface.** There is deliberately no `orbit learning ack` CLI, no `orbit.learning.ack` MCP tool, and no ack instruction in the injected block.
+
+## Consequences
+
+- The rollup is the designed input for downstream deprecation policy (ORB-10318); decay/TTL is deliberately follow-up work, not implemented here.
+- The `learning_shown` / `learning_injected` contract lives in audit-event conventions (`target_type` + `arguments_json`) enforced by store-level fold tests, not a schema migration — consistent with the injection events it joins against.
+- Signal quality depends on agents actually opening learnings they use, but `show` is far harder to game than an ack and costs the agent nothing extra to emit; the ratio is directional input for a human/automated sweep, not an automated gate.
+- Cost: one audit row per `show`, plus scope tags added to each teaser line. No change to the MCP conformance surface (no new tool), unlike the rejected ack design.

--- a/crates/orbit-cli/src/command/hook/tests/render.rs
+++ b/crates/orbit-cli/src/command/hook/tests/render.rs
@@ -28,6 +28,7 @@ fn core_renderer_combines_learning_and_review_thread_output_for_cli_formats() {
     let learnings = vec![LearningReminder {
         id: "L-0017".to_string(),
         summary: "learning reminder".to_string(),
+        tags: Vec::new(),
     }];
     let review_threads = reminders_from_threads(
         "ORB-00001",

--- a/crates/orbit-cli/src/command/learning/command.rs
+++ b/crates/orbit-cli/src/command/learning/command.rs
@@ -8,6 +8,7 @@ use super::list::LearningListArgs;
 use super::migrate_layout::LearningMigrateLayoutArgs;
 use super::prune::LearningPruneArgs;
 use super::show::LearningShowArgs;
+use super::stats::LearningStatsArgs;
 use super::supersede::LearningSupersedeArgs;
 use super::sync::LearningSyncArgs;
 use super::update::LearningUpdateArgs;
@@ -33,6 +34,8 @@ pub enum LearningSubcommand {
     List(LearningListArgs),
     /// Show a single learning by ID
     Show(LearningShowArgs),
+    /// Per-learning usage rollup from injection and show audit events
+    Stats(LearningStatsArgs),
     /// Update an existing active learning
     Update(LearningUpdateArgs),
     /// Mark a learning as superseded by another
@@ -51,6 +54,7 @@ impl Execute for LearningSubcommand {
             LearningSubcommand::Add(args) => args.execute(runtime),
             LearningSubcommand::List(args) => args.execute(runtime),
             LearningSubcommand::Show(args) => args.execute(runtime),
+            LearningSubcommand::Stats(args) => args.execute(runtime),
             LearningSubcommand::Update(args) => args.execute(runtime),
             LearningSubcommand::Supersede(args) => args.execute(runtime),
             LearningSubcommand::Sync(args) => args.execute(runtime),

--- a/crates/orbit-cli/src/command/learning/mod.rs
+++ b/crates/orbit-cli/src/command/learning/mod.rs
@@ -5,6 +5,7 @@ mod migrate_layout;
 pub(crate) mod output;
 mod prune;
 mod show;
+mod stats;
 mod supersede;
 mod sync;
 mod update;

--- a/crates/orbit-cli/src/command/learning/show.rs
+++ b/crates/orbit-cli/src/command/learning/show.rs
@@ -17,6 +17,8 @@ pub struct LearningShowArgs {
 impl Execute for LearningShowArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         let learning = runtime.get_learning(&self.id)?;
+        // Opening the full body is the passive usage signal for this learning.
+        runtime.record_learning_shown(&learning.id)?;
         if self.json {
             crate::output::json::print_pretty(&learning_show_to_json(&learning))
         } else {

--- a/crates/orbit-cli/src/command/learning/stats.rs
+++ b/crates/orbit-cli/src/command/learning/stats.rs
@@ -1,0 +1,63 @@
+use clap::Args;
+use orbit_core::{LearningUsageStat, OrbitError, OrbitRuntime};
+use serde_json::Value;
+
+use crate::command::Execute;
+use crate::parse::parse_since;
+
+#[derive(Args)]
+pub struct LearningStatsArgs {
+    /// Restrict the rollup to events since a duration or timestamp (e.g. "30d", RFC3339)
+    #[arg(long)]
+    pub since: Option<String>,
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for LearningStatsArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let since = self.since.map(|s| parse_since(&s)).transpose()?;
+        let stats = runtime.learning_usage_stats(since)?;
+
+        if self.json {
+            let array = Value::Array(stats.iter().map(usage_stat_to_json).collect());
+            return crate::output::json::print_pretty(&array);
+        }
+
+        if stats.is_empty() {
+            println!("no learning injection or show events recorded");
+            return Ok(());
+        }
+        println!("ID\tINJECTED\tSHOWN\tSHOWN_RATIO\tLAST_INJECTED\tLAST_SHOWN");
+        for stat in &stats {
+            println!(
+                "{}\t{}\t{}\t{}\t{}\t{}",
+                stat.learning_id,
+                stat.injected_count,
+                stat.shown_count,
+                stat.shown_ratio()
+                    .map(|ratio| format!("{ratio:.2}"))
+                    .unwrap_or_else(|| "-".to_string()),
+                stat.last_injected_at
+                    .map(|ts| ts.to_rfc3339())
+                    .unwrap_or_else(|| "-".to_string()),
+                stat.last_shown_at
+                    .map(|ts| ts.to_rfc3339())
+                    .unwrap_or_else(|| "-".to_string()),
+            );
+        }
+        Ok(())
+    }
+}
+
+fn usage_stat_to_json(stat: &LearningUsageStat) -> Value {
+    serde_json::json!({
+        "learning_id": stat.learning_id,
+        "injected_count": stat.injected_count,
+        "shown_count": stat.shown_count,
+        "shown_ratio": stat.shown_ratio(),
+        "last_injected_at": stat.last_injected_at.map(|ts| ts.to_rfc3339()),
+        "last_shown_at": stat.last_shown_at.map(|ts| ts.to_rfc3339()),
+    })
+}

--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -487,6 +487,7 @@ impl Commands {
                     LearningSubcommand::Add(_) => ("add", RuntimeNeed::Required),
                     LearningSubcommand::List(_) => ("list", RuntimeNeed::Required),
                     LearningSubcommand::Show(_) => ("show", RuntimeNeed::Required),
+                    LearningSubcommand::Stats(_) => ("stats", RuntimeNeed::Required),
                     LearningSubcommand::Update(_) => ("update", RuntimeNeed::Required),
                     LearningSubcommand::Supersede(_) => ("supersede", RuntimeNeed::Required),
                     LearningSubcommand::Sync(_) => ("sync", RuntimeNeed::Required),

--- a/crates/orbit-cli/tests/hook_pretooluse.rs
+++ b/crates/orbit-cli/tests/hook_pretooluse.rs
@@ -382,6 +382,147 @@ fn missing_session_uses_tmpdir_parent_pid_state_file() {
     );
 }
 
+#[test]
+fn payload_session_id_keys_dedup_without_env_var() {
+    let workspace = TestWorkspace::new();
+    workspace.add_learning("Payload session id anchors dedup", &["src/**"]);
+    // No ORBIT_SESSION_ID in the environment — the session id rides in the
+    // hook payload itself, as Claude Code sends it on every hook event. This
+    // is the previously-dead path: ORBIT_SESSION_ID was exported on 0/2,374
+    // observed fires, so dedup only engages once the payload anchors it.
+    let payload = r#"{"tool_name":"Edit","tool_input":{"file_path":"src/lib.rs"},"session_id":"payload-session"}"#;
+
+    let first = workspace.run_hook(payload, &[], "payload session first");
+    assert!(!first.stdout.is_empty());
+    let second = workspace.run_hook(payload, &[], "payload session second");
+    assert!(
+        second.stdout.is_empty(),
+        "second stdout: {}",
+        String::from_utf8_lossy(&second.stdout)
+    );
+
+    let state = workspace.session_learning_state("payload-session");
+    assert_eq!(state["count"], 1);
+
+    let events = workspace.run_json(
+        &["audit", "list", "--kind", "learning_injected", "--json"],
+        "audit list",
+    );
+    let rows = events.as_array().expect("audit rows");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["session_id"], "payload-session");
+}
+
+#[test]
+fn env_session_id_takes_priority_over_payload_session_id() {
+    let workspace = TestWorkspace::new();
+    workspace.add_learning("Env session id wins over payload", &["src/**"]);
+    let payload = r#"{"tool_name":"Edit","tool_input":{"file_path":"src/lib.rs"},"session_id":"payload-session"}"#;
+
+    let output = workspace.run_hook(
+        payload,
+        &[("ORBIT_SESSION_ID", "env-session")],
+        "env-priority hook",
+    );
+    assert!(!output.stdout.is_empty());
+
+    // Engine-managed runs pre-seed dedup state under the env session id, so
+    // the env var must key the state even when the payload carries its own.
+    let state = workspace.session_learning_state("env-session");
+    assert_eq!(state["count"], 1);
+}
+
+#[test]
+fn unavailable_audit_backend_fails_open_and_still_injects() {
+    let workspace = TestWorkspace::new();
+    workspace.add_learning("Injection survives a dead audit backend", &["src/**"]);
+    workspace.break_audit_event_inserts();
+
+    let output = workspace.run_hook(
+        r#"{"tool_name":"Edit","tool_input":{"file_path":"src/lib.rs"},"session_id":"failopen-session"}"#,
+        &[],
+        "fail-open hook",
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Injection survives a dead audit backend"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn show_emits_learning_shown_event_and_stats_roll_up() {
+    let workspace = TestWorkspace::new();
+    let shown = workspace.add_learning("Shown learning gets read", &["src/**"]);
+    let shown_id = shown["id"].as_str().expect("shown learning id").to_string();
+    let unshown = workspace.add_learning("Unshown learning stays cold", &["src/**"]);
+    let unshown_id = unshown["id"]
+        .as_str()
+        .expect("unshown learning id")
+        .to_string();
+
+    // Inject both learnings in one hook fire.
+    let output = workspace.run_hook(
+        r#"{"tool_name":"Edit","tool_input":{"file_path":"src/lib.rs"},"session_id":"show-session"}"#,
+        &[],
+        "show rollup hook",
+    );
+    assert!(!output.stdout.is_empty());
+
+    // Opening the full body is the passive usage signal.
+    let shown_view =
+        workspace.run_json(&["learning", "show", &shown_id, "--json"], "learning show");
+    assert_eq!(shown_view["id"], shown_id);
+
+    let shown_events = workspace.run_json(
+        &["audit", "list", "--kind", "learning_shown", "--json"],
+        "audit list shown",
+    );
+    let shown_rows = shown_events.as_array().expect("shown rows");
+    assert_eq!(shown_rows.len(), 1, "shown rows: {shown_events}");
+    assert_eq!(shown_rows[0]["target_id"], shown_id);
+
+    let stats = workspace.run_json(&["learning", "stats", "--json"], "learning stats");
+    let rows = stats.as_array().expect("stats rows");
+    assert_eq!(rows.len(), 2, "stats rows: {stats}");
+    let row_for = |id: &str| {
+        rows.iter()
+            .find(|row| row["learning_id"] == *id)
+            .unwrap_or_else(|| panic!("no stats row for {id}: {stats}"))
+    };
+
+    let shown_row = row_for(&shown_id);
+    assert_eq!(shown_row["injected_count"], 1);
+    assert_eq!(shown_row["shown_count"], 1);
+    assert_eq!(shown_row["shown_ratio"], 1.0);
+    assert!(shown_row["last_shown_at"].is_string());
+
+    let unshown_row = row_for(&unshown_id);
+    assert_eq!(unshown_row["injected_count"], 1);
+    assert_eq!(unshown_row["shown_count"], 0);
+    assert_eq!(unshown_row["shown_ratio"], 0.0);
+    assert!(unshown_row["last_shown_at"].is_null());
+}
+
+#[test]
+fn show_fails_open_when_audit_backend_unavailable() {
+    let workspace = TestWorkspace::new();
+    let learning = workspace.add_learning("Show survives a dead audit backend", &["src/**"]);
+    let learning_id = learning["id"].as_str().expect("learning id").to_string();
+
+    workspace.break_audit_event_inserts();
+    // Showing still works — the learning_shown emission is instrumentation
+    // and must not break the read surface when the audit backend is down.
+    let output = workspace.run(
+        &["learning", "show", &learning_id, "--json"],
+        None,
+        &[],
+        "show with dead audit backend",
+    );
+    let view: Value = serde_json::from_slice(&output.stdout).expect("show JSON stdout");
+    assert_eq!(view["id"], learning_id);
+}
+
 struct TestWorkspace {
     _temp: TempDir,
     home: PathBuf,
@@ -494,6 +635,18 @@ impl TestWorkspace {
             .as_str()
             .expect("thread id")
             .to_string()
+    }
+
+    /// Simulate an unavailable audit/log backend: reads (learning search,
+    /// session state) keep working, but every `audit_events` insert fails.
+    fn break_audit_event_inserts(&self) {
+        let conn = rusqlite::Connection::open(self.home.join(".orbit").join("orbit.db"))
+            .expect("open orbit db");
+        conn.execute_batch(
+            "CREATE TRIGGER break_audit_inserts BEFORE INSERT ON audit_events \
+             BEGIN SELECT RAISE(ABORT, 'audit backend unavailable'); END;",
+        )
+        .expect("install audit insert trigger");
     }
 
     fn session_learning_state(&self, session_id: &str) -> Value {

--- a/crates/orbit-cmd/src/learning_hook.rs
+++ b/crates/orbit-cmd/src/learning_hook.rs
@@ -7,7 +7,7 @@ use fs2::FileExt;
 use orbit_common::types::{
     AuditEventStatus, LearningInjectionCaps, LearningInjectionState, LearningReminder, OrbitError,
 };
-use orbit_store::{AuditEventInsertParams, LearningSearchParams};
+use orbit_store::{AuditEventInsertParams, LEARNING_INJECTED_TARGET_TYPE, LearningSearchParams};
 use serde_json::Value;
 use serde_json::json;
 
@@ -28,6 +28,12 @@ pub type SessionLearningState = LearningInjectionState;
 pub struct HookPayload {
     pub tool_name: String,
     pub target_path: String,
+    /// Session id carried by the hook payload itself (Claude Code sends
+    /// `session_id` on every hook event). Used as the dedup anchor when
+    /// `ORBIT_SESSION_ID` is not exported — interactive sessions spawn a
+    /// fresh shell per hook fire, so the ppid-tmpfile fallback re-keys per
+    /// invocation and never dedups (L-0077 injected 10× in one session).
+    pub session_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -151,9 +157,12 @@ pub fn parse_payload_with_tools(stdin: &str, accepted_tools: &[&str]) -> Option<
                 .and_then(path_from_shell_command)
         })?;
 
+    let session_id = string_field(&value, &["session_id", "sessionId"]).map(ToOwned::to_owned);
+
     Some(HookPayload {
         tool_name: tool_name.to_string(),
         target_path: target_path.to_string(),
+        session_id,
     })
 }
 
@@ -226,6 +235,7 @@ pub fn reminders_from_search_results(
         .map(|result| LearningReminder {
             id: result.learning.id,
             summary: result.learning.summary,
+            tags: result.learning.scope.tags,
         })
         .collect()
 }
@@ -346,9 +356,13 @@ pub fn run_pretooluse_input(
     };
 
     let caps = caps_from_env();
+    // Engine-managed runs export `ORBIT_SESSION_ID` (pre-seeded with layer-1
+    // injections), so the env var wins; interactive sessions never export it
+    // and fall back to the session id the hook payload itself carries.
     let session_id = std::env::var(ORBIT_SESSION_ID_ENV)
         .ok()
-        .filter(|value| !value.trim().is_empty());
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| payload.session_id.clone());
     let tmpdir = learning_hook_tmpdir();
     let ppid = parent_process_id();
 
@@ -384,25 +398,33 @@ pub fn run_pretooluse_input(
         return Ok(None);
     }
 
-    if !admitted.is_empty() {
-        emit_learning_injected_audit(
+    // Audit instrumentation fails open: an unavailable audit backend must
+    // not suppress reminders that were already admitted for injection.
+    if !admitted.is_empty()
+        && let Err(error) = emit_learning_injected_audit(
             runtime,
             &payload.tool_name,
             &payload.target_path,
             session_id.as_deref(),
             &admitted,
             start.elapsed(),
-        )?;
+        )
+    {
+        tracing::warn!(error = %redact_sensitive_env_text(&error), "learning hook audit emit failed open");
     }
     for reminder in &review_thread_admitted {
-        orbit_core::command::review_thread_hook::emit_review_thread_surfaced_audit(
-            runtime,
-            &payload.tool_name,
-            &payload.target_path,
-            session_id.as_deref(),
-            reminder,
-            start.elapsed(),
-        )?;
+        if let Err(error) =
+            orbit_core::command::review_thread_hook::emit_review_thread_surfaced_audit(
+                runtime,
+                &payload.tool_name,
+                &payload.target_path,
+                session_id.as_deref(),
+                reminder,
+                start.elapsed(),
+            )
+        {
+            tracing::warn!(error = %redact_sensitive_env_text(&error), "review-thread hook audit emit failed open");
+        }
     }
 
     render_hook_reminders(format, &admitted, &review_thread_admitted)
@@ -706,7 +728,7 @@ fn emit_learning_injected_audit(
         command: "hook".to_string(),
         subcommand: Some("pretooluse".to_string()),
         tool_name: Some(tool_name.to_string()),
-        target_type: Some("learning_injected".to_string()),
+        target_type: Some(LEARNING_INJECTED_TARGET_TYPE.to_string()),
         target_id: Some(target_path.to_string()),
         role: "hook".to_string(),
         status: AuditEventStatus::Success,

--- a/crates/orbit-cmd/src/tests/learning_hook.rs
+++ b/crates/orbit-cmd/src/tests/learning_hook.rs
@@ -35,6 +35,29 @@ fn parse_payload_accepts_tool_and_path_variants() {
 }
 
 #[test]
+fn parse_payload_extracts_session_id_when_present() {
+    let with_session = parse_payload(
+        r#"{"tool_name":"Edit","tool_input":{"file_path":"src/lib.rs"},"session_id":" sess-123 "}"#,
+    )
+    .expect("payload with session id");
+    assert_eq!(with_session.session_id.as_deref(), Some("sess-123"));
+
+    let camel = parse_payload(
+        r#"{"toolName":"Write","toolInput":{"filePath":"README.md"},"sessionId":"sess-camel"}"#,
+    )
+    .expect("payload with camelCase session id");
+    assert_eq!(camel.session_id.as_deref(), Some("sess-camel"));
+
+    let without = parse_payload(r#"{"tool_name":"Read","path":"Cargo.toml"}"#)
+        .expect("payload without session id");
+    assert_eq!(without.session_id, None);
+
+    let blank = parse_payload(r#"{"tool_name":"Read","path":"Cargo.toml","session_id":"  "}"#)
+        .expect("payload with blank session id");
+    assert_eq!(blank.session_id, None);
+}
+
+#[test]
 fn parse_payload_rejects_malformed_irrelevant_or_pathless_payloads() {
     assert!(parse_payload("").is_none());
     assert!(parse_payload("not-json").is_none());
@@ -351,6 +374,7 @@ fn reminders(ids: &[&str]) -> Vec<LearningReminder> {
         .map(|id| LearningReminder {
             id: (*id).to_string(),
             summary: format!("summary {id}"),
+            tags: Vec::new(),
         })
         .collect()
 }

--- a/crates/orbit-common/src/types/learning.rs
+++ b/crates/orbit-common/src/types/learning.rs
@@ -167,12 +167,18 @@ pub const DEFAULT_LEARNING_REMINDER_PER_CALL_CAP: usize = 5;
 pub const DEFAULT_LEARNING_REMINDER_SESSION_CAP: usize = 20;
 
 /// Envelope projected into agent context by the project-learnings injection
-/// layers. The learning itself carries only the summary; agents open the full
-/// body via `orbit.learning.show` when they need the details.
+/// layers. The teaser carries only the id, one-line summary, and scope tags;
+/// agents open the full body via `orbit.learning.show` when they need the
+/// details — that show is the passive usage signal ([ORB-10316]).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LearningReminder {
     pub id: OrbitId,
     pub summary: String,
+    /// Scope tags for the learning, rendered inline in the teaser. Empty when
+    /// the learning is path-scoped only; `#[serde(default)]` keeps older
+    /// persisted dedup state readable.
+    #[serde(default)]
+    pub tags: Vec<String>,
 }
 
 /// Budget controls for project-learning injection.
@@ -280,7 +286,16 @@ pub fn render_reminder_block(reminders: &[LearningReminder]) -> String {
     let mut out = String::from("<system-reminder>\n");
     out.push_str("Project learnings relevant to this task:\n\n");
     for reminder in reminders {
-        out.push_str(&format!("- [{}] {}\n", reminder.id, reminder.summary));
+        if reminder.tags.is_empty() {
+            out.push_str(&format!("- [{}] {}\n", reminder.id, reminder.summary));
+        } else {
+            out.push_str(&format!(
+                "- [{}] {} [tags: {}]\n",
+                reminder.id,
+                reminder.summary,
+                reminder.tags.join(", ")
+            ));
+        }
     }
     out.push('\n');
     out.push_str("Read full body via `orbit.learning.show <id>` if needed.\n");

--- a/crates/orbit-common/src/types/tests/learning.rs
+++ b/crates/orbit-common/src/types/tests/learning.rs
@@ -28,6 +28,7 @@ mod admission {
             .map(|idx| LearningReminder {
                 id: format!("L{idx}"),
                 summary: format!("summary {idx}"),
+                tags: Vec::new(),
             })
             .collect();
 
@@ -115,6 +116,7 @@ mod reminders {
         let block = render_reminder_block(&[LearningReminder {
             id: "L-0001".to_string(),
             summary: "Verify output equivalence before freezing a result.".to_string(),
+            tags: Vec::new(),
         }]);
 
         assert_eq!(
@@ -122,6 +124,24 @@ mod reminders {
             "<system-reminder>\n\
 Project learnings relevant to this task:\n\n\
 - [L-0001] Verify output equivalence before freezing a result.\n\n\
+Read full body via `orbit.learning.show <id>` if needed.\n\
+</system-reminder>"
+        );
+    }
+
+    #[test]
+    fn render_reminder_block_includes_scope_tags_in_teaser() {
+        let block = render_reminder_block(&[LearningReminder {
+            id: "L-0002".to_string(),
+            summary: "Scope tags ride in the teaser.".to_string(),
+            tags: vec!["hooks".to_string(), "observability".to_string()],
+        }]);
+
+        assert_eq!(
+            block,
+            "<system-reminder>\n\
+Project learnings relevant to this task:\n\n\
+- [L-0002] Scope tags ride in the teaser. [tags: hooks, observability]\n\n\
 Read full body via `orbit.learning.show <id>` if needed.\n\
 </system-reminder>"
         );

--- a/crates/orbit-core/src/command/learning.rs
+++ b/crates/orbit-core/src/command/learning.rs
@@ -8,10 +8,14 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use orbit_common::types::{EvidenceKind, Learning, LearningStatus, NotFoundKind, OrbitError};
+use orbit_common::types::{
+    AuditEventStatus, EvidenceKind, Learning, LearningStatus, NotFoundKind, OrbitError,
+    audit_execution_id,
+};
 use orbit_store::{
-    LearningCreateParams, LearningListEntry, LearningSearchParams, LearningSearchResult,
-    LearningUpdateParams, RemoteArtifactStub, learning_layout::LearningLayoutMigrationReport,
+    AuditEventInsertParams, LEARNING_SHOWN_TARGET_TYPE, LearningCreateParams, LearningListEntry,
+    LearningSearchParams, LearningSearchResult, LearningUpdateParams, LearningUsageStat,
+    RemoteArtifactStub, learning_layout::LearningLayoutMigrationReport,
 };
 use serde::Deserialize;
 
@@ -94,6 +98,83 @@ impl OrbitRuntime {
 
     pub fn learning_search_config(&self) -> Result<LearningSearchConfig, OrbitError> {
         read_learning_search_config_from_config_path(&self.config_path())
+    }
+
+    /// Record a `learning_shown` audit event — the passive, ungameable usage
+    /// signal emitted when an agent opens a learning's full body via
+    /// `orbit learning show` (CLI or MCP). Keyed by learning ID + session.
+    ///
+    /// Fails open: an unavailable audit backend logs a warning and returns
+    /// `Ok(())` so the show surface keeps working. The session id resolves
+    /// from `ORBIT_SESSION_ID` (the injecting session exports it); an absent
+    /// session records a `None`, which the rollup still counts per learning.
+    pub fn record_learning_shown(&self, learning_id: &str) -> Result<(), OrbitError> {
+        let session_id = std::env::var("ORBIT_SESSION_ID")
+            .ok()
+            .filter(|value| !value.trim().is_empty());
+        let working_directory = std::env::current_dir()
+            .map(|path| path.to_string_lossy().to_string())
+            .unwrap_or_else(|_| ".".to_string());
+        let params = AuditEventInsertParams {
+            execution_id: audit_execution_id("learning"),
+            command: "learning".to_string(),
+            subcommand: Some("show".to_string()),
+            tool_name: None,
+            target_type: Some(LEARNING_SHOWN_TARGET_TYPE.to_string()),
+            target_id: Some(learning_id.to_string()),
+            role: "agent".to_string(),
+            status: AuditEventStatus::Success,
+            exit_code: 0,
+            duration_ms: 0,
+            working_directory,
+            arguments_json: None,
+            stdout_truncated: None,
+            stderr_truncated: None,
+            error_message: None,
+            host: std::env::var("HOSTNAME").ok(),
+            pid: std::process::id(),
+            session_id,
+            workspace_id: None,
+            caller_machine_id: None,
+            caller_host_id: None,
+            process_machine_id: None,
+            process_host_id: None,
+            transport: None,
+            effective_capabilities: Default::default(),
+            origin_session_id: None,
+            mcp_call_id: None,
+            lease_id: None,
+            task_id: std::env::var("ORBIT_TASK_ID")
+                .ok()
+                .filter(|value| !value.is_empty()),
+            job_run_id: std::env::var("ORBIT_RUN_ID")
+                .ok()
+                .filter(|value| !value.is_empty()),
+            activity_id: std::env::var("ORBIT_ACTIVITY_ID")
+                .ok()
+                .filter(|value| !value.is_empty()),
+            step_index: std::env::var("ORBIT_STEP_INDEX")
+                .ok()
+                .and_then(|value| value.parse().ok()),
+        };
+        if let Err(error) = self.record_audit_event(&params) {
+            tracing::warn!(
+                learning_id,
+                error = %error,
+                "learning_shown audit emit failed open"
+            );
+        }
+        Ok(())
+    }
+
+    /// Per-learning usage rollup over the global audit store: injection
+    /// counts from `learning_injected` events, show counts from
+    /// `learning_shown` events. Input for the deprecation sweep (ORB-10318).
+    pub fn learning_usage_stats(
+        &self,
+        since: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<Vec<LearningUsageStat>, OrbitError> {
+        self.stores().audit_events().learning_usage(since.as_ref())
     }
 
     pub fn update_learning(

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -96,6 +96,7 @@ pub use orbit_store::{
 };
 pub use orbit_store::{
     LearningCreateParams, LearningListEntry, LearningSearchParams, LearningUpdateParams,
+    LearningUsageStat,
 };
 // Routine fire records surfaced by the dashboard's routine-health JSON API.
 pub use orbit_store::{RoutineFireRecord, RoutineFireState};

--- a/crates/orbit-core/src/runtime/orbit_tool_host/learning_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/learning_tools.rs
@@ -53,6 +53,8 @@ pub(super) fn add(
 pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
     let id = required_string(&input, &["id"], "id")?;
     let learning = runtime.get_learning(&id)?;
+    // Opening the full body is the passive usage signal for this learning.
+    runtime.record_learning_shown(&learning.id)?;
     Ok(learning_show_to_json(&learning))
 }
 

--- a/crates/orbit-core/src/runtime/store_delegates.rs
+++ b/crates/orbit-core/src/runtime/store_delegates.rs
@@ -611,6 +611,13 @@ impl AuditEventRecords<'_> {
         self.store.get_audit_event_stats(since, tool)
     }
 
+    pub(crate) fn learning_usage(
+        &self,
+        since: Option<&chrono::DateTime<chrono::Utc>>,
+    ) -> Result<Vec<orbit_store::LearningUsageStat>, OrbitError> {
+        self.store.get_learning_usage_stats(since)
+    }
+
     pub(crate) fn durations(
         &self,
         since: Option<&chrono::DateTime<chrono::Utc>>,

--- a/crates/orbit-core/src/runtime/v2_host/learning_reminders.rs
+++ b/crates/orbit-core/src/runtime/v2_host/learning_reminders.rs
@@ -76,6 +76,7 @@ fn learning_reminders_for_task_snapshot(
         reminders.push(LearningReminder {
             id,
             summary: result.learning.summary,
+            tags: result.learning.scope.tags,
         });
     }
     Ok(reminders)

--- a/crates/orbit-engine/src/activity_job/tests/agent_loop_driver.rs
+++ b/crates/orbit-engine/src/activity_job/tests/agent_loop_driver.rs
@@ -280,6 +280,7 @@ fn l1_learning_reminder_prepends_prompt_for_matching_task() {
         reminders: vec![LearningReminder {
             id: "L-0001".to_string(),
             summary: "Remember to validate the output.".to_string(),
+            tags: Vec::new(),
         }],
     };
     let mut session = Session::new("replay", "test-model", "test", None);
@@ -342,6 +343,7 @@ fn l1_learning_reminder_applies_default_per_call_cap() {
             .map(|idx| LearningReminder {
                 id: format!("L-{idx:04}"),
                 summary: format!("Learning {idx}"),
+                tags: Vec::new(),
             })
             .collect(),
     };

--- a/crates/orbit-remote/src/mcp/learning.rs
+++ b/crates/orbit-remote/src/mcp/learning.rs
@@ -339,6 +339,19 @@ fn parse_learning_list_candidates(value: &Value) -> Vec<ReminderCandidate> {
         .filter_map(|item| {
             let id = item.get("id").and_then(Value::as_str)?.to_string();
             let summary = item.get("summary").and_then(Value::as_str)?.to_string();
+            // Tags may ride at the top level or under `scope`; absent tags
+            // render as a path-only teaser.
+            let tags = item
+                .get("tags")
+                .or_else(|| item.get("scope").and_then(|scope| scope.get("tags")))
+                .and_then(Value::as_array)
+                .map(|values| {
+                    values
+                        .iter()
+                        .filter_map(|value| value.as_str().map(ToOwned::to_owned))
+                        .collect()
+                })
+                .unwrap_or_default();
             let priority = item
                 .get("priority")
                 .and_then(Value::as_u64)
@@ -349,7 +362,7 @@ fn parse_learning_list_candidates(value: &Value) -> Vec<ReminderCandidate> {
                 .unwrap_or_default()
                 .to_string();
             Some(ReminderCandidate {
-                reminder: LearningReminder { id, summary },
+                reminder: LearningReminder { id, summary, tags },
                 priority,
                 updated_at,
             })

--- a/crates/orbit-remote/src/mcp/tests/mod.rs
+++ b/crates/orbit-remote/src/mcp/tests/mod.rs
@@ -1414,6 +1414,7 @@ mod audited_mcp_call_tests {
                     .and_then(serde_json::Value::as_str)
                     .expect("candidate summary")
                     .to_string(),
+                tags: Vec::new(),
             })
             .collect::<Vec<_>>();
         assert_eq!(

--- a/crates/orbit-store/src/backend/contracts.rs
+++ b/crates/orbit-store/src/backend/contracts.rs
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 use crate::sqlite::audit_event_store::{
     AuditEventFilter, AuditEventInsertParams, AuditRoleAggregate, AuditToolAggregate,
     AuditToolCallCountsByRole, AuditToolCallCountsBySurfaceAndRole, AuditTopToolCall,
+    LearningUsageStat,
 };
 use crate::sqlite::v2_audit_store::{
     V2AuditEventFilter, V2AuditEventInsertParams, V2AuditEventRow,
@@ -655,6 +656,10 @@ pub trait AuditEventStoreBackend: Send + Sync {
         &self,
         since: &DateTime<Utc>,
     ) -> Result<Vec<AuditRoleAggregate>, OrbitError>;
+    fn get_learning_usage_stats(
+        &self,
+        since: Option<&DateTime<Utc>>,
+    ) -> Result<Vec<LearningUsageStat>, OrbitError>;
     fn prune_audit_events(&self, older_than: &DateTime<Utc>) -> Result<usize, OrbitError>;
 }
 

--- a/crates/orbit-store/src/backend/sqlite_backends.rs
+++ b/crates/orbit-store/src/backend/sqlite_backends.rs
@@ -139,6 +139,13 @@ impl AuditEventStoreBackend for SqliteAuditEventStoreBackend {
         self.store.get_audit_event_aggregates_by_role(since)
     }
 
+    fn get_learning_usage_stats(
+        &self,
+        since: Option<&DateTime<Utc>>,
+    ) -> Result<Vec<crate::LearningUsageStat>, OrbitError> {
+        self.store.get_learning_usage_stats(since)
+    }
+
     fn prune_audit_events(&self, older_than: &DateTime<Utc>) -> Result<usize, OrbitError> {
         self.store.prune_audit_events(older_than)
     }

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -145,6 +145,7 @@ pub use json_schema::{validate_instance_against_schema, validate_schema_document
 pub use sqlite::audit_event_store::{
     AuditEventFilter, AuditEventInsertParams, AuditRoleAggregate, AuditToolAggregate,
     AuditToolCallCountsByRole, AuditToolCallCountsBySurfaceAndRole, AuditTopToolCall,
+    LEARNING_INJECTED_TARGET_TYPE, LEARNING_SHOWN_TARGET_TYPE, LearningUsageStat,
 };
 pub use sqlite::connection::{Store, StoreTx};
 pub use sqlite::id_allocator::{

--- a/crates/orbit-store/src/sqlite/audit_event_store/mod.rs
+++ b/crates/orbit-store/src/sqlite/audit_event_store/mod.rs
@@ -123,6 +123,47 @@ pub struct AuditRoleAggregate {
     pub cli: i64,
 }
 
+/// `target_type` of the per-fire injection audit event emitted by the
+/// learning PreToolUse hook.
+pub const LEARNING_INJECTED_TARGET_TYPE: &str = "learning_injected";
+/// `target_type` of the passive usage-signal audit event recorded when a
+/// learning's full body is opened via `orbit learning show`.
+pub const LEARNING_SHOWN_TARGET_TYPE: &str = "learning_shown";
+
+/// Per-learning rollup of injection and show audit events. Raw counts only;
+/// the derived shown ratio lives on an accessor so the "shown is the passive
+/// usage signal" semantics stay in one place.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LearningUsageStat {
+    pub learning_id: String,
+    /// Number of `learning_injected` events that included this learning.
+    pub injected_count: u64,
+    /// Number of `learning_shown` events for this learning (full body opened
+    /// via `orbit learning show`). The ungameable usage signal.
+    pub shown_count: u64,
+    pub last_injected_at: Option<DateTime<Utc>>,
+    pub last_shown_at: Option<DateTime<Utc>>,
+}
+
+impl LearningUsageStat {
+    fn new(learning_id: String) -> Self {
+        Self {
+            learning_id,
+            injected_count: 0,
+            shown_count: 0,
+            last_injected_at: None,
+            last_shown_at: None,
+        }
+    }
+
+    /// `shown_count / injected_count`, or `None` when nothing was injected.
+    /// A low ratio is the deprecation-candidate signal: injected often, never
+    /// read.
+    pub fn shown_ratio(&self) -> Option<f64> {
+        (self.injected_count > 0).then(|| self.shown_count as f64 / self.injected_count as f64)
+    }
+}
+
 fn audit_event_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AuditEvent> {
     let ts_raw: String = row.get(2)?;
     let status_raw: String = row.get(9)?;
@@ -878,6 +919,92 @@ impl Store {
 
         rows.collect::<Result<Vec<_>, _>>()
             .map_err(|e| OrbitError::Store(e.to_string()))
+    }
+
+    /// Fold `learning_injected` and `learning_shown` audit events into a
+    /// per-learning usage rollup. Malformed `arguments_json` payloads are
+    /// skipped rather than failing the whole aggregation — the rollup is an
+    /// observability surface over best-effort instrumentation.
+    pub fn get_learning_usage_stats(
+        &self,
+        since: Option<&DateTime<Utc>>,
+    ) -> Result<Vec<LearningUsageStat>, OrbitError> {
+        let conn = self.read()?;
+
+        let (since_clause, since_params) = match since {
+            Some(since) => (
+                " AND timestamp >= ?1",
+                vec![Box::new(since.to_rfc3339()) as Box<dyn rusqlite::types::ToSql>],
+            ),
+            None => ("", Vec::new()),
+        };
+        let sql = format!(
+            "SELECT timestamp, target_type, target_id, arguments_json \
+             FROM audit_events \
+             WHERE target_type IN ('{LEARNING_INJECTED_TARGET_TYPE}', '{LEARNING_SHOWN_TARGET_TYPE}') \
+             AND status = 'success'{since_clause} ORDER BY id ASC"
+        );
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            since_params.iter().map(|b| b.as_ref()).collect();
+        let rows = stmt
+            .query_map(param_refs.as_slice(), |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                ))
+            })
+            .map_err(|e| OrbitError::Store(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        let mut stats = std::collections::BTreeMap::<String, LearningUsageStat>::new();
+        for (ts_raw, target_type, target_id, arguments_json) in rows {
+            let Ok(timestamp) = parse_timestamp(&ts_raw) else {
+                continue;
+            };
+            if target_type == LEARNING_INJECTED_TARGET_TYPE {
+                let arguments = arguments_json
+                    .as_deref()
+                    .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok());
+                let Some(learning_ids) = arguments
+                    .as_ref()
+                    .and_then(|value| value.get("learning_ids"))
+                    .and_then(serde_json::Value::as_array)
+                else {
+                    continue;
+                };
+                for learning_id in learning_ids.iter().filter_map(serde_json::Value::as_str) {
+                    let stat = stats
+                        .entry(learning_id.to_string())
+                        .or_insert_with(|| LearningUsageStat::new(learning_id.to_string()));
+                    stat.injected_count += 1;
+                    stat.last_injected_at = Some(timestamp);
+                }
+            } else {
+                // `learning_shown` keys the learning ID directly on target_id.
+                let Some(learning_id) = target_id.as_deref().filter(|id| !id.is_empty()) else {
+                    continue;
+                };
+                let stat = stats
+                    .entry(learning_id.to_string())
+                    .or_insert_with(|| LearningUsageStat::new(learning_id.to_string()));
+                stat.shown_count += 1;
+                stat.last_shown_at = Some(timestamp);
+            }
+        }
+
+        let mut stats = stats.into_values().collect::<Vec<_>>();
+        stats.sort_by(|a, b| {
+            b.injected_count
+                .cmp(&a.injected_count)
+                .then_with(|| a.learning_id.cmp(&b.learning_id))
+        });
+        Ok(stats)
     }
 
     pub fn prune_audit_events(&self, older_than: &DateTime<Utc>) -> Result<usize, OrbitError> {

--- a/crates/orbit-store/src/sqlite/audit_event_store/tests/audit_event_store.rs
+++ b/crates/orbit-store/src/sqlite/audit_event_store/tests/audit_event_store.rs
@@ -187,6 +187,93 @@ fn list_audit_events_filters_by_target_type_kind() {
     assert_eq!(events[0].execution_id, "exec-hook");
 }
 
+fn learning_injected_params(execution_id: &str, learning_ids: &[&str]) -> AuditEventInsertParams {
+    AuditEventInsertParams {
+        execution_id: execution_id.to_string(),
+        command: "hook".to_string(),
+        subcommand: Some("pretooluse".to_string()),
+        target_type: Some(LEARNING_INJECTED_TARGET_TYPE.to_string()),
+        target_id: Some("src/lib.rs".to_string()),
+        arguments_json: Some(serde_json::json!({ "learning_ids": learning_ids }).to_string()),
+        ..sample_params()
+    }
+}
+
+fn learning_shown_params(execution_id: &str, learning_id: &str) -> AuditEventInsertParams {
+    AuditEventInsertParams {
+        execution_id: execution_id.to_string(),
+        command: "learning".to_string(),
+        subcommand: Some("show".to_string()),
+        target_type: Some(LEARNING_SHOWN_TARGET_TYPE.to_string()),
+        target_id: Some(learning_id.to_string()),
+        arguments_json: None,
+        ..sample_params()
+    }
+}
+
+#[test]
+fn learning_usage_stats_fold_injections_and_shows_per_learning() {
+    let store = Store::open_in_memory().expect("open store");
+    for (execution_id, ids) in [
+        ("exec-inject-1", vec!["L-0001", "L-0002"]),
+        ("exec-inject-2", vec!["L-0001"]),
+        ("exec-inject-3", vec!["L-0001"]),
+    ] {
+        store
+            .insert_audit_event_record(&learning_injected_params(execution_id, &ids))
+            .expect("insert injection event");
+    }
+    store
+        .insert_audit_event_record(&learning_shown_params("exec-show-1", "L-0001"))
+        .expect("insert show event");
+
+    let stats = store
+        .get_learning_usage_stats(None)
+        .expect("learning usage stats");
+    assert_eq!(stats.len(), 2);
+
+    // Sorted by injected_count DESC: L-0001 (3) before L-0002 (1).
+    let first = &stats[0];
+    assert_eq!(first.learning_id, "L-0001");
+    assert_eq!(first.injected_count, 3);
+    assert_eq!(first.shown_count, 1);
+    assert_eq!(first.shown_ratio(), Some(1.0 / 3.0));
+    assert!(first.last_injected_at.is_some());
+    assert!(first.last_shown_at.is_some());
+
+    let second = &stats[1];
+    assert_eq!(second.learning_id, "L-0002");
+    assert_eq!(second.injected_count, 1);
+    assert_eq!(second.shown_count, 0);
+    assert_eq!(second.shown_ratio(), Some(0.0));
+    assert!(second.last_shown_at.is_none());
+}
+
+#[test]
+fn learning_usage_stats_skip_malformed_arguments_and_respect_since() {
+    let store = Store::open_in_memory().expect("open store");
+    let mut malformed = learning_injected_params("exec-malformed", &["L-0001"]);
+    malformed.arguments_json = Some("not-json".to_string());
+    store
+        .insert_audit_event_record(&malformed)
+        .expect("insert malformed event");
+    store
+        .insert_audit_event_record(&learning_injected_params("exec-ok", &["L-0002"]))
+        .expect("insert valid event");
+
+    let stats = store
+        .get_learning_usage_stats(None)
+        .expect("learning usage stats");
+    assert_eq!(stats.len(), 1);
+    assert_eq!(stats[0].learning_id, "L-0002");
+
+    let future = chrono::Utc::now() + chrono::Duration::days(1);
+    let stats = store
+        .get_learning_usage_stats(Some(&future))
+        .expect("learning usage stats since future");
+    assert!(stats.is_empty());
+}
+
 #[test]
 fn migration_adds_correlation_columns_to_legacy_table() {
     let conn = rusqlite::Connection::open_in_memory().expect("open in-memory connection");

--- a/docs/design/project-learnings/2_design.md
+++ b/docs/design/project-learnings/2_design.md
@@ -224,6 +224,10 @@ This is the only layer that surfaces learnings on Claude Code's built-in editor 
 
 The hook is shipped as part of the design, but it is **layered on top of** layers 1 and 2, not a replacement. Other agent vendors that gain analogous hook capabilities can plug in equivalent layers without touching the Orbit-side store.
 
+Every hook fire that admits at least one learning records a `learning_injected` audit event in the host-global `~/.orbit/orbit.db` (`arguments_json.learning_ids`, target path, session id). The instrumentation **fails open**: an unavailable audit backend logs a warning and the reminder still renders — injection never depends on the observability write ([ORB-10316]). The per-learning rollup over these events is described in [§5.5](#55-usage-instrumentation-and-feedback).
+
+The hook resolves its session identity in priority order: `ORBIT_SESSION_ID` from the environment (engine-managed runs export it, pre-seeded with layer-1 injections) → the `session_id` field carried by the hook payload itself (Claude Code sends it on every hook event) → a tmpdir file keyed by parent pid as the last resort. The payload fallback matters: interactive sessions never export `ORBIT_SESSION_ID`, and each hook fire runs under a fresh shell, so the ppid fallback re-keys per invocation and cannot dedup (the 2026-07-18 relevancy audit observed one learning injected 10× in a single session; F2026-07-092).
+
 ### 4.4 Deduplication and budget
 
 A naive implementation injects the same learning multiple times across layers (e.g. once at layer 1, once at layer 2 for a tool call referencing the same file, once at layer 3 for the eventual edit). To prevent this:
@@ -234,13 +238,13 @@ A naive implementation injects the same learning multiple times across layers (e
 
 Implementation note: the per-session set lives in the agent's working memory. The Orbit-side store does not need to track session state; it just provides idempotent search. Layers consult the set; the store is stateless.
 
-Cross-process deduplication is best-effort via `ORBIT_SESSION_ID` plus `.orbit/state/sessions/<id>/learnings.json`. In-process Layer 1 + Layer 2 dedup is exact; when Layer 2 or Layer 3 runs without `ORBIT_SESSION_ID` (for example, an `orbit-mcp` server started outside an engine-spawned session, or a Claude session not initiated through Orbit), they fall back to per-process state and may double-emit. The dedup layer is belt-and-braces; the agent's own context window remains the practical backstop.
+Cross-process deduplication is best-effort and keyed on a session id: `ORBIT_SESSION_ID` when exported, else (for Layer 3) the `session_id` field the hook payload carries ([ORB-10316]). With a session id, dedup state lives in the `session_learning_state` table of the host-global `orbit.db`; without one, Layer 3 falls back to a tmpdir state file keyed by parent pid, which cannot dedup across fires from an interactive agent (each fire gets a fresh parent shell). In-process Layer 1 + Layer 2 dedup is exact; an `orbit-mcp` server started outside an engine-spawned session still falls back to per-process state and may double-emit. The dedup layer is belt-and-braces; the agent's own context window remains the practical backstop.
 
 ### 4.5 What gets injected
 
-`summary` is always injected. `body` is **not** — bodies are loaded on demand via `orbit.learning.show`. This keeps per-injection token cost small (a few dozen tokens per learning, not a few hundred), which is what makes the 5-per-call cap workable.
+The injected teaser carries only the learning **id**, one-line **summary**, and scope **tags** (`- [L-0001] summary [tags: a, b]`). `body` is **not** injected — bodies are loaded on demand via `orbit learning show` / `orbit.learning.show`. This keeps per-injection token cost small (a few dozen tokens per learning, not a few hundred), which is what makes the 5-per-call cap workable.
 
-If an agent decides a summary is relevant, it pulls the body explicitly. This separates "alerting the agent that a learning exists" from "spending context on the full content." Most learnings will be summary-only in any given session.
+If an agent decides a teaser is relevant, it pulls the body explicitly — and that `show` is the passive usage signal the deprecation rollup reads (see [§5.5](#55-usage-instrumentation-and-feedback)). This separates "alerting the agent that a learning exists" from "spending context on the full content." Most learnings will be teaser-only in any given session.
 
 ---
 
@@ -251,12 +255,13 @@ If an agent decides a summary is relevant, it pulls the body explicitly. This se
 ```
 orbit learning add --summary <text> --scope paths=... [tags=...] [--body-file FILE] [--evidence task=T... commit=SHA ...]
 orbit learning list [--status active|superseded] [--tag TAG] [--path GLOB]  # --path uses glob-containment
-orbit learning show <id>
+orbit learning show <id>                  # loads the full body; emits a learning_shown usage signal
 orbit learning update <id> [--summary ...] [--body-file ...] [--scope ...]
 orbit learning supersede <id> --with <new-id>
 orbit learning upvote --id <id> --model <agent-family> --task <task-id>
 orbit learning sync                       # reconcile SQLite index from YAML
 orbit learning prune [--stale-only]       # report or delete stale learnings
+orbit learning stats [--since 30d]        # per-learning injected/shown usage rollup (see §5.5)
 
 # Free-text content match (formerly the per-domain `learning` subcommand of `orbit search`) lives on the unified search surface:
 orbit search <text> --kind learning [--tag T] [--all] [--status learning:active] [--limit N]
@@ -322,6 +327,17 @@ Search ranking remains scope-filtered first. Within the matched set, rows sort b
 4. `id` asc.
 
 `ORBIT_LEARNING_VOTE_HALF_LIFE_DAYS=0` disables decay and uses raw vote count. Vote files are scanned at query time in v1; a SQLite vote-summary mirror is a follow-up only if measured matched-set sizes make the per-file scan visible.
+
+### 5.5 Usage instrumentation and feedback
+
+Two audit event kinds in the host-global `~/.orbit/orbit.db` carry the usage signal ([ORB-10316], [ADR-0242]; the scoped reintroduction of a feedback primitive anticipated by [ADR-0210]):
+
+- **`learning_injected`** — one event per hook fire that admitted learnings; `arguments_json.learning_ids` lists the injected IDs, `target_id` is the tool-target path, `session_id` the resolved session.
+- **`learning_shown`** — recorded when an agent opens a learning's full body via `orbit learning show` (CLI) or the `orbit.learning.show` MCP tool: `target_id` is the learning ID, keyed by session. This is the **passive, ungameable usage signal** — an agent that expands a teaser found it worth reading. There is deliberately **no ack surface** (no `orbit learning ack`, no `orbit.learning.ack`): an earlier ack-based design ([ADR-0242] rejected alternatives) added a gameable, agent-remembered step and a new MCP tool; `show` needs neither.
+
+Both emissions **fail open**: an unavailable audit backend logs a warning and the injection/show still completes. The signal is best-effort observability and must never break the read or injection path.
+
+`orbit learning stats [--since ..] [--json]` folds both event kinds into a per-learning rollup: injected count, shown count, shown ratio (`shown / injected`), and last-injected/last-shown timestamps (CLI + the `learning_usage_stats` runtime API). A low shown ratio — injected often, never read — is the deprecation-candidate signal. This rollup is the designed input for downstream deprecation policy (ORB-10318); decay/TTL is deliberately follow-up work, not implemented at this layer.
 
 ---
 
@@ -414,9 +430,9 @@ Phase 2's semantic-similarity ranking from orbit-search may complement or replac
 
 The `PreToolUse` hook covers Claude Code's built-in `Edit | Write | Read`, which are the most frequent agent actions. Other agents that gain comparable hooks can layer in equivalent integrations, but as of phase 1, agents without hook support get only layers 1 and 2 — coarser-grained injection. This is uneven coverage by agent vendor; the design accepts the unevenness because layer 1 is universal and gives a baseline that's strictly better than today.
 
-### 8.5 Per-session deduplication state is agent-local
+### 8.5 Per-session deduplication depends on a resolvable session id
 
-The dedup set lives in the agent's working memory. If an agent's context is compressed or the agent crashes and restarts, the set resets and the same learning may inject twice. Hardening this would require a session-keyed cache in `orbit-store`, which trades complexity for a marginal context-token saving. Not worth it in phase 1.
+Cross-process dedup state is session-keyed in `orbit-store` (`session_learning_state`), but it only engages when a session id resolves — from `ORBIT_SESSION_ID` or, for Layer 3, the hook payload ([ORB-10316]). Agents whose hook payloads carry no session id and that run outside engine management still fall back to the per-invocation ppid state file and may re-inject. Separately, the agent's own in-context dedup set resets on context compression or crash-restart; the store-side state is the backstop for exactly the sessions that can be keyed.
 
 ### 8.6 No write-time validation that learnings are non-obvious
 
@@ -434,5 +450,6 @@ Learnings are workspace-scoped and checked into the repo. They travel exactly wh
 - [T20260510-12] — Add `tags` field to `Task` schema. Hard prerequisite for Layer 1's tag-axis matching ([§4.1](#41-layer-1--engine-pre-prompt-injection-universal)).
 - [ORB-00061] — Add Knowledge tab and Learnings subtab to dashboard.
 - [ORB-00090] — Aligned learning identity examples with the agent-family convention.
+- [ORB-10316] — Teaser injection (id + summary + tags), `learning_shown` usage signal on `orbit learning show`, `learning_injected`/`learning_shown` rollup via `orbit learning stats`, payload-derived session dedup ([§4.3](#43-layer-3--claude-code-pretooluse-hook-optional), [§4.5](#45-what-gets-injected), [§5.5](#55-usage-instrumentation-and-feedback); [ADR-0242]).
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/project-learnings/4_decisions.md
+++ b/docs/design/project-learnings/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Project Learnings — Decisions"
 type: design
 title: "Project Learnings — Decisions"
 owner: claude
-last_updated: 2026-07-18
+last_updated: 2026-07-19
 status: Draft
 feature: project-learnings
 doc_role: decisions
@@ -229,9 +229,34 @@ Alternatives considered:
 
 ---
 
+## ADR-0242 — Teaser learning injection + show-as-usage-signal (replaces rejected ack design)
+
+**Status:** Accepted · 2026-07 · [ORB-10316]
+
+**Context.** The 2026-07-18 relevancy audit (friction F2026-07-092) found the learning PreToolUse hook fired 2,374 times over two weeks with 13 injections (0.55%) and **zero usage signal**: nothing recorded whether an injected learning shaped the receiving agent's work, so nothing could drive deprecation of stale learnings. ADR-0210 removed the vote/comment feedback surfaces for lack of real usage, with an explicit reopening clause: a scoped feedback primitive can return "with real usage data behind it." A first attempt (PR #657, closed unmerged) added an explicit `orbit learning ack` CLI/MCP surface — Daniel rejected it as gameable, agent-remembered, and a new tool in the frozen conformance fixture, with "unacked = ignored" penalizing every silent session. Separately, per-session dedup was dead: `ORBIT_SESSION_ID` was exported on 0/2,374 fires and the ppid-tmpfile fallback re-keys per invocation (L-0077 injected 10× in one session).
+
+Alternatives considered:
+
+| Approach | Profile |
+|----------|---------|
+| **Explicit `learning ack` surface (PR #657)** | Active, gameable, adds an MCP tool to the frozen conformance fixture and a reminder footer line; silence forced to mean "ignored." Rejected. |
+| **Full-content injection, no signal (status quo)** | High per-fire token cost, no usage data, no deprecation input. |
+| **Teaser injection + show-as-signal (this ADR)** | Injection carries only id + summary + tags; opening the body via `orbit learning show` is the passive, ungameable signal. Lower token cost, no new agent action, no new MCP tool. |
+
+**Decision.** Injection projects only the learning id, one-line summary, and scope tags; the full body is retrieved via `orbit learning show <id>`, which records a `learning_shown` audit event (keyed by learning id + session) in the host-global `~/.orbit/orbit.db` — the passive usage signal. `orbit learning stats` folds `learning_injected` + `learning_shown` into a per-learning rollup (injected, shown, shown ratio, last-injected/last-shown). Both emissions **fail open**: an unavailable audit backend logs a warning and the injection/show still completes. Session dedup keys on the first resolvable anchor: `ORBIT_SESSION_ID` env → the `session_id` field the hook payload carries → ppid-tmpfile last resort. **No ack surface** — no `orbit learning ack`, no `orbit.learning.ack`, no ack instruction in the injected block.
+
+**Consequences.**
+- The rollup is the designed input for downstream deprecation policy (ORB-10318); decay/TTL is deliberately follow-up work, not implemented at this layer.
+- The `learning_injected`/`learning_shown` contract lives in audit-event conventions (`target_type` + `arguments_json`), enforced by store-level fold tests, not a schema migration.
+- Signal quality depends on agents opening learnings they use, but `show` is far harder to game than an ack and costs nothing extra to emit; the ratio is directional input for a sweep, not an automated gate.
+- Cost: one audit row per `show`, plus scope tags on each teaser line. **No** change to the MCP conformance surface (no new tool), unlike the rejected ack design.
+
+---
+
 ## Task References
 
 - [T20260510-11] — Design + build project-learnings system as native Orbit primitive. The task that produced this folder.
 - [ORB-10046] — Remove the vote and comment surfaces from the learning subsystem (ADR-0210 supersedes ADR-0157).
+- [ORB-10316] — Teaser injection + `learning_shown` usage signal + `orbit learning stats` rollup + payload-derived session dedup (ADR-0242).
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10316](https://orbit-cli.com/tasks/ORB-10316) — Teaser learning injection + show-as-usage-signal + session-dedup fix

### Description

Re-scoped 2026-07-19 after Daniel rejected the ack-based design (PR #657 closed unmerged). Revised design: **teaser injection + show-as-signal**. Injections carry only learning id + one-line summary; reading the full learning requires `orbit learning show`, which becomes the passive, ungameable usage signal — and injection token cost drops. **No ack surface**: do not add `orbit learning ack` / `orbit.learning.ack` (PR #657 built one; it was rejected — do not resurrect it).

Implement:

1. **Teaser injection payload.** The PreToolUse hook (and, once ORB-10317 lands, the upfront job-run surface) injects id + one-line summary (+ tags) per learning instead of full content. Full content is retrieved via `orbit learning show <id>`.
2. **Show-as-usage-signal.** `orbit learning show` (CLI and MCP) emits a durable audit event (e.g. `learning_shown`) into the global `~/.orbit/orbit.db`, keyed by learning id + session, alongside the existing `learning_injected` events.
3. **Aggregation surface.** `orbit learning stats`: per-learning rollup over injected + shown events — injected count, shown count, shown ratio, last-injected/last-shown timestamps — via CLI/API. Input for the deprecation sweep (ORB-10318); no deprecation logic here.
4. **Session-dedup fix** (unchanged from original scope): `ORBIT_SESSION_ID` is exported on 0/2,374 observed fires; the ppid-tmpfile fallback re-keys per invocation (L-0077 injected 10× in one session). Resolution order env → hook payload `session_id` → ppid fallback.

Note: closed PR #657 (branch `orbit/ORB-10316-6a5c1cc3`) contains reusable pieces — the session-dedup fix, fail-open audit emission, and stats fold plumbing — but its ack CLI/MCP surface, conformance fixture addition, and injected ack instruction must not be carried over. ADR-0238 (ack design) is rejected; file a fresh ADR for teaser+show.

Audit baseline: 2,374 fires 2026-07-04→18, 13 injections (0.55%), DIRECT 0 / TANGENTIAL 12 / NOISE 1 — `operations/reports/2026-07-18-learning-hook-relevancy-audit.md`; F2026-07-092.

Out of scope: deprecation logic (ORB-10318), selection/ranking changes, injection budget changes, any ack mechanism.

### Acceptance Criteria

- Injected learning payload is teaser-only (id + one-line summary + tags); full content is not injected and is retrievable via orbit learning show
- learning show (CLI and MCP) emits a durable learning_shown audit event keyed by learning id and session into the global orbit.db; showing works and warns without failing when the audit backend is unavailable (fail open)
- orbit learning stats reports per-learning injected count, shown count, shown ratio, last-injected and last-shown timestamps over learning_injected + learning_shown events, via CLI and API
- Per-session injection dedup works via stable session id (env, then hook payload session_id, then fallback); regression test covers the previously dead ORBIT_SESSION_ID path
- No ack surface exists: no orbit learning ack CLI, no orbit.learning.ack MCP tool, no ack instruction in the injected block
- Success and failure paths tested including audit backend unavailable during injection and during show; docs updated (teaser format, show signal, stats, session-id resolution); ADR filed for teaser+show replacing the rejected ack design; make ci-fast passes

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented teaser injection + show-as-usage-signal + session-dedup fix (ADR-0242 filed; supersedes the rejected ack design from closed PR #657). No ack surface added.

1. Teaser injection: LearningReminder now carries id + summary + scope tags (crates/orbit-common/src/types/learning.rs); render_reminder_block renders `- [id] summary [tags: a, b]` (tags omitted when empty, so path-only fixtures are byte-identical). Tags threaded through all three construction sites (hook reminders_from_search_results, v2_host/learning_reminders.rs, orbit-remote/mcp/learning.rs). Full body still only via `orbit learning show`.

2. Show-as-signal: new OrbitRuntime::record_learning_shown (crates/orbit-core/src/command/learning.rs) emits a durable `learning_shown` audit event (target_id = learning id, session from ORBIT_SESSION_ID) into global orbit.db; fails open (tracing::warn, returns Ok) when the audit backend is down. Called from CLI show (command/learning/show.rs) and MCP orbit.learning.show (orbit_tool_host/learning_tools.rs). No MCP schema change -> no conformance/snapshot churn.

3. Stats: OrbitRuntime::learning_usage_stats + store Store::get_learning_usage_stats fold `learning_injected` (arguments_json.learning_ids) + `learning_shown` (target_id) into LearningUsageStat{injected_count, shown_count, shown_ratio(), last_injected_at, last_shown_at}. New `orbit learning stats [--since] [--json]` CLI (command/learning/stats.rs, wired in command.rs/mod.rs/operation.rs). Plumbed through AuditEventStoreBackend contract + sqlite_backends + store_delegates. Constants LEARNING_INJECTED_TARGET_TYPE / LEARNING_SHOWN_TARGET_TYPE in orbit-store.

4. Session-dedup fix: HookPayload gains session_id (parsed from session_id/sessionId); run_pretooluse_input resolves ORBIT_SESSION_ID env -> payload.session_id -> ppid fallback (crates/orbit-cmd/src/learning_hook.rs). Injection + review-thread audit emission made fail-open.

Reused from closed PR #657: session-dedup fix, fail-open emission, stats fold plumbing. NOT carried over: ack CLI/MCP tool, ack instruction, conformance fixture entry, LearningAckOutcome, ADR-0238 (rejected).

Docs: docs/design/project-learnings/2_design.md (§4.3/4.4/4.5/5.1, new §5.5 usage instrumentation, §8.5, task refs) and 4_decisions.md (ADR-0242 entry). ADR-0242 filed + accepted via orbit.adr.add/update.

Context_files was empty; the scope boundary is the task description. All touched files are directly required for the scoped work (teaser field threading, show emission wiring, stats plumbing, session-id resolution) or are their tests.

Validation: make ci-fast passes; cargo clippy clean on orbit-store/core/cli/cmd/common/remote --all-targets; unit tests pass (orbit-store learning_usage fold x2, orbit-common reminder incl. tags render, orbit-cmd learning_hook incl. session_id parse); orbit-cli hook_pretooluse integration suite 16/16 including 5 new tests (payload-session dedup, env priority, fail-open injection, show->stats rollup, show fail-open); MCP canaries (mcp_definitions count, mcp_tools_list snapshot) pass unchanged confirming no ack tool added. Not run locally: full `make ci` (canonical merge gate on PR).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10316-6a5d3a98`
- Behind base: 0
- Ahead of base: 1

*authored by: claude*