### PR TITLE
Finalize hub-preallocated knowledge in the exact owner checkout

### DIFF
--- a/crates/orbit-core/src/command/learning.rs
+++ b/crates/orbit-core/src/command/learning.rs
@@ -50,6 +50,51 @@ struct LearningSearchConfigSection {
 }
 
 impl OrbitRuntime {
+    /// Verify that a multi-host owner finalizer is operating through the exact
+    /// checkout-bound runtime capability selected by the broker. The caller
+    /// supplies only the stable runtime workspace ID; checkout paths come from
+    /// the trusted runtime binding, never from public request data or cwd.
+    pub fn verify_preallocated_owner_runtime(
+        &self,
+        expected_runtime_workspace_id: &str,
+    ) -> Result<(), OrbitError> {
+        let binding = self.workspace_runtime_binding().ok_or_else(|| {
+            OrbitError::InvalidInput(
+                "preallocated knowledge finalization requires a registered exact-checkout runtime binding"
+                    .to_string(),
+            )
+        })?;
+        let persisted_workspace_id = self.workspace_id()?;
+        if binding.workspace_id != expected_runtime_workspace_id
+            || persisted_workspace_id != expected_runtime_workspace_id
+        {
+            return Err(OrbitError::InvalidInput(format!(
+                "preallocated knowledge workspace mismatch: expected '{expected_runtime_workspace_id}', runtime binding is '{}', persisted checkout identity is '{persisted_workspace_id}'",
+                binding.workspace_id
+            )));
+        }
+        let bound_repo = binding.repo_root.canonicalize().map_err(|error| {
+            OrbitError::InvalidInput(format!(
+                "preallocated owner checkout '{}' is unavailable: {error}",
+                binding.repo_root.display()
+            ))
+        })?;
+        let runtime_repo = self.paths().repo_root.canonicalize().map_err(|error| {
+            OrbitError::InvalidInput(format!(
+                "runtime checkout '{}' is unavailable: {error}",
+                self.paths().repo_root.display()
+            ))
+        })?;
+        if bound_repo != runtime_repo {
+            return Err(OrbitError::InvalidInput(format!(
+                "preallocated owner checkout binding drifted: bound '{}', runtime '{}'",
+                bound_repo.display(),
+                runtime_repo.display()
+            )));
+        }
+        Ok(())
+    }
+
     pub fn create_learning(&self, params: LearningCreateParams) -> Result<Learning, OrbitError> {
         let learning = self.stores().learnings().add(params)?;
         self.record_id_allocation_audit("learning", &learning.id)?;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs
@@ -14,6 +14,7 @@ use orbit_store::{
     AdrArtifact, AdrArtifactResolution, AdrCreateParams, AdrDocumentUpdateParams, AdrListEntry,
     RemoteArtifactStub,
 };
+use orbit_tools::OrbitBuiltinAction;
 use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
@@ -24,20 +25,64 @@ pub(super) fn add(
     agent: Option<String>,
     model: Option<String>,
 ) -> Result<Value, OrbitError> {
-    let title = required_string(&input, &["title"], "title")?;
-    let owner = match optional_string(&input, "owner")? {
-        Some(value) => value,
-        None => actor_label(runtime, agent.as_deref(), model.as_deref()),
-    };
-    let body = required_string(&input, &["body"], "body")?;
-    let related_features =
-        optional_string_list_alias(&input, &["related_features", "features"])?.unwrap_or_default();
-    let related_tasks =
-        optional_string_list_alias(&input, &["related_tasks", "tasks"])?.unwrap_or_default();
-    let tags = optional_string_list_alias(&input, &["tags"])?.unwrap_or_default();
-    let paths = optional_string_list_alias(&input, &["paths"])?.unwrap_or_default();
+    let params = adr_create_params(runtime, &input, agent.as_deref(), model.as_deref())?;
+    let adr = runtime.stores().adrs().add(params)?;
+    runtime.record_id_allocation_audit("adr", &adr.id)?;
+    Ok(adr_to_json(&adr))
+}
 
-    let adr = runtime.stores().adrs().add(AdrCreateParams {
+impl OrbitRuntime {
+    /// Complete one hub-issued ADR ID in this exact runtime binding while
+    /// preserving the public `orbit.adr.add` parser and result shape.
+    pub fn finalize_preallocated_adr_tool(
+        &self,
+        expected_runtime_workspace_id: &str,
+        id: &str,
+        input: Value,
+        model: Option<String>,
+    ) -> Result<Value, OrbitError> {
+        self.verify_preallocated_owner_runtime(expected_runtime_workspace_id)?;
+        let (input, redaction_report) =
+            super::artifact_redaction::sanitize_tool_input(OrbitBuiltinAction::AdrAdd, input)?;
+        let params = adr_create_params(self, &input, None, model.as_deref())?;
+        let adr = self.stores().adrs().finalize_preallocated(id, params)?;
+        let mut response = adr_to_json(&adr);
+        super::artifact_redaction::finish_tool_response(
+            self,
+            OrbitBuiltinAction::AdrAdd,
+            &mut response,
+            &redaction_report,
+            None,
+            model.as_deref(),
+        )?;
+        Ok(response)
+    }
+
+    pub fn rollback_preallocated_adr(&self, id: &str) -> Result<bool, OrbitError> {
+        self.stores().adrs().rollback_preallocated(id)
+    }
+}
+
+fn adr_create_params(
+    runtime: &OrbitRuntime,
+    input: &Value,
+    agent: Option<&str>,
+    model: Option<&str>,
+) -> Result<AdrCreateParams, OrbitError> {
+    let title = required_string(input, &["title"], "title")?;
+    let owner = match optional_string(input, "owner")? {
+        Some(value) => value,
+        None => actor_label(runtime, agent, model),
+    };
+    let body = required_string(input, &["body"], "body")?;
+    let related_features =
+        optional_string_list_alias(input, &["related_features", "features"])?.unwrap_or_default();
+    let related_tasks =
+        optional_string_list_alias(input, &["related_tasks", "tasks"])?.unwrap_or_default();
+    let tags = optional_string_list_alias(input, &["tags"])?.unwrap_or_default();
+    let paths = optional_string_list_alias(input, &["paths"])?.unwrap_or_default();
+
+    Ok(AdrCreateParams {
         title,
         owner,
         related_features,
@@ -45,9 +90,7 @@ pub(super) fn add(
         tags,
         paths,
         body,
-    })?;
-    runtime.record_id_allocation_audit("adr", &adr.id)?;
-    Ok(adr_to_json(&adr))
+    })
 }
 
 pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
@@ -449,6 +492,7 @@ mod tests {
     use super::*;
     use crate::OrbitRuntime;
     use crate::runtime::orbit_tool_host::test_support::test_runtime;
+    use crate::{ShipMode, WorkspaceRuntimeBinding};
     use orbit_common::types::{LearningScope, NotFoundKind};
     use orbit_store::LearningCreateParams;
     use std::path::Path;
@@ -479,6 +523,72 @@ mod tests {
         assert_adr_field(&response, "id", "ADR-0001");
         assert_adr_field(&response, "status", "proposed");
         assert_adr_field(&response, "owner", "claude");
+    }
+
+    #[test]
+    fn exact_bound_runtime_finalizes_supplied_adr_and_learning_ids() {
+        let root = tempdir().expect("tempdir");
+        let global_root = root.path().join("global");
+        let repo_root = root.path().join("selected-checkout");
+        let orbit_root = repo_root.join(".orbit");
+        std::fs::create_dir_all(&global_root).expect("global root");
+        std::fs::create_dir_all(&orbit_root).expect("Orbit root");
+        let runtime = OrbitRuntime::from_roots_with_binding(
+            &global_root,
+            &orbit_root,
+            WorkspaceRuntimeBinding {
+                workspace_id: "ws_exact".to_string(),
+                repo_root: repo_root.clone(),
+                ship_mode: ShipMode::Local,
+            },
+        )
+        .expect("bound runtime");
+
+        let adr = runtime
+            .finalize_preallocated_adr_tool(
+                "ws_exact",
+                "ADR-9000",
+                json!({"title": "Exact", "owner": "codex", "body": "Body"}),
+                Some("codex".to_string()),
+            )
+            .expect("ADR finalization");
+        let learning = runtime
+            .finalize_preallocated_learning_tool(
+                "ws_exact",
+                "L-9000",
+                json!({
+                    "summary": "Exact checkout learning",
+                    "scope": {"paths": ["src/**"], "tags": ["exact"]},
+                    "body": "Body"
+                }),
+                Some("codex".to_string()),
+            )
+            .expect("learning finalization");
+
+        assert_eq!(adr["id"], "ADR-9000");
+        assert_eq!(learning["id"], "L-9000");
+        assert!(
+            repo_root
+                .join(".orbit/adrs/proposed/ADR-9000/adr.yaml")
+                .is_file()
+        );
+        assert!(
+            repo_root
+                .join(".orbit/learnings/L-9000/learning.yaml")
+                .is_file()
+        );
+
+        let error = runtime
+            .finalize_preallocated_adr_tool(
+                "ws_other",
+                "ADR-9001",
+                json!({"title": "Wrong", "owner": "codex", "body": "Body"}),
+                None,
+            )
+            .expect_err("workspace mismatch")
+            .to_string();
+        assert!(error.contains("workspace mismatch"), "{error}");
+        assert!(!repo_root.join(".orbit/adrs/proposed/ADR-9001").exists());
     }
 
     #[test]

--- a/crates/orbit-core/src/runtime/orbit_tool_host/learning_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/learning_tools.rs
@@ -15,6 +15,7 @@ use orbit_common::types::{
 use orbit_store::{
     LearningCreateParams, LearningListEntry, LearningUpdateParams, RemoteArtifactStub,
 };
+use orbit_tools::OrbitBuiltinAction;
 use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
@@ -28,26 +29,69 @@ pub(super) fn add(
     _agent: Option<String>,
     model: Option<String>,
 ) -> Result<Value, OrbitError> {
-    let summary = required_string(&input, &["summary"], "summary")?;
+    let params = learning_create_params(&input, model)?;
+    let learning = runtime.create_learning(params)?;
+    Ok(learning_to_json(&learning))
+}
+
+impl OrbitRuntime {
+    /// Complete one hub-issued learning ID in this exact runtime binding while
+    /// preserving the public `orbit.learning.add` parser and result shape.
+    pub fn finalize_preallocated_learning_tool(
+        &self,
+        expected_runtime_workspace_id: &str,
+        id: &str,
+        input: Value,
+        model: Option<String>,
+    ) -> Result<Value, OrbitError> {
+        self.verify_preallocated_owner_runtime(expected_runtime_workspace_id)?;
+        let (input, redaction_report) =
+            super::artifact_redaction::sanitize_tool_input(OrbitBuiltinAction::LearningAdd, input)?;
+        let params = learning_create_params(&input, model.clone())?;
+        let learning = self
+            .stores()
+            .learnings()
+            .finalize_preallocated(id, params)?;
+        let mut response = learning_to_json(&learning);
+        super::artifact_redaction::finish_tool_response(
+            self,
+            OrbitBuiltinAction::LearningAdd,
+            &mut response,
+            &redaction_report,
+            None,
+            model.as_deref(),
+        )?;
+        Ok(response)
+    }
+
+    pub fn rollback_preallocated_learning(&self, id: &str) -> Result<bool, OrbitError> {
+        self.stores().learnings().rollback_preallocated(id)
+    }
+}
+
+fn learning_create_params(
+    input: &Value,
+    model: Option<String>,
+) -> Result<LearningCreateParams, OrbitError> {
+    let summary = required_string(input, &["summary"], "summary")?;
     let scope_value = input
         .get("scope")
         .cloned()
         .unwrap_or(Value::Object(Default::default()));
     let scope = parse_scope_value(scope_value)?;
-    let body = optional_string(&input, "body")?.unwrap_or_default();
+    let body = optional_string(input, "body")?.unwrap_or_default();
     let evidence = parse_evidence_value(input.get("evidence"))?;
-    let priority = parse_optional_priority(&input)?;
-    let created_by = optional_string_alias(&input, &["created_by", "createdBy"])?.or(model);
+    let priority = parse_optional_priority(input)?;
+    let created_by = optional_string_alias(input, &["created_by", "createdBy"])?.or(model);
 
-    let learning = runtime.create_learning(LearningCreateParams {
+    Ok(LearningCreateParams {
         summary,
         scope,
         body,
         evidence,
         created_by,
         priority,
-    })?;
-    Ok(learning_to_json(&learning))
+    })
 }
 
 pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {

--- a/crates/orbit-core/src/runtime/store_delegates.rs
+++ b/crates/orbit-core/src/runtime/store_delegates.rs
@@ -734,6 +734,18 @@ impl AdrRecords<'_> {
         self.store.add_adr(params)
     }
 
+    pub(crate) fn finalize_preallocated(
+        &self,
+        id: &str,
+        params: AdrCreateParams,
+    ) -> Result<Adr, OrbitError> {
+        self.store.finalize_preallocated_adr(id, params)
+    }
+
+    pub(crate) fn rollback_preallocated(&self, id: &str) -> Result<bool, OrbitError> {
+        self.store.rollback_preallocated_adr(id)
+    }
+
     pub(crate) fn get(&self, id: &str) -> Result<Option<Adr>, OrbitError> {
         self.store.get_adr(id)
     }
@@ -825,6 +837,18 @@ pub(crate) struct LearningRecords<'a> {
 impl LearningRecords<'_> {
     pub(crate) fn add(&self, params: LearningCreateParams) -> Result<Learning, OrbitError> {
         self.store.create_learning(params)
+    }
+
+    pub(crate) fn finalize_preallocated(
+        &self,
+        id: &str,
+        params: LearningCreateParams,
+    ) -> Result<Learning, OrbitError> {
+        self.store.finalize_preallocated_learning(id, params)
+    }
+
+    pub(crate) fn rollback_preallocated(&self, id: &str) -> Result<bool, OrbitError> {
+        self.store.rollback_preallocated_learning(id)
     }
 
     pub(crate) fn get(&self, id: &str) -> Result<Option<Learning>, OrbitError> {

--- a/crates/orbit-remote/src/mcp/host.rs
+++ b/crates/orbit-remote/src/mcp/host.rs
@@ -16,9 +16,10 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use orbit_common::types::{
-    AuditEventStatus, McpToolDefinition, McpToolPlacement, McpToolPolicyError, McpToolScope,
-    McpTransport, ToolSessionContext, WorkspaceCheckoutRole, WorkspaceStatus, audit_execution_id,
-    validate_mcp_tool_definitions,
+    AuditEventStatus, HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION, HubKnowledgeAllocationRequestV1,
+    HubKnowledgeAllocationV1, KnowledgeIdKind, McpToolDefinition, McpToolPlacement,
+    McpToolPolicyError, McpToolScope, McpTransport, ToolSessionContext, WorkspaceCheckoutRole,
+    WorkspaceStatus, audit_execution_id, validate_mcp_tool_definitions,
 };
 use orbit_core::command::tool::{
     ToolEntryPoint, audit_role_label_for_entry_point, trusted_mcp_audit_context,
@@ -30,12 +31,16 @@ use orbit_core::{
 };
 use orbit_mcp::McpHost;
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use crate::runtime::RemoteRuntimeFactory;
-use crate::{HostIdentityState, HostMode, inspect_host_identity};
+use crate::{HostIdentityState, HostMode, HubKnowledgeSequenceService, inspect_host_identity};
 
 use super::hub_link::HubLinkPool;
+
+/// F2 composes and validates the forward-only path without switching public
+/// authoring. F3 owns the atomic cutover of every legacy caller.
+pub(super) const PREALLOCATED_KNOWLEDGE_CUTOVER_ENABLED: bool = false;
 
 pub fn canonical_mcp_tool_definitions() -> Result<Vec<McpToolDefinition>, McpToolPolicyError> {
     let mut definitions = orbit_tools::canonical_builtin_mcp_tool_definitions()?;
@@ -102,6 +107,11 @@ struct ExactCheckoutBinding {
     key: RuntimeCacheKey,
     role: WorkspaceCheckoutRole,
     owner_machine_id: Option<String>,
+}
+
+enum KnowledgeOwnerRoute {
+    Local(ExactCheckoutBinding),
+    Hub,
 }
 
 #[derive(Debug, Deserialize)]
@@ -493,6 +503,203 @@ impl BrokerMcpHost {
         }
     }
 
+    fn preflight_knowledge_owner(
+        &self,
+        selector: &str,
+    ) -> Result<(String, KnowledgeOwnerRoute), OrbitError> {
+        let (workspace_id, selected_binding) = self.resolve_workspace(selector, false)?;
+        let registry_path = crate::workspace_registry::registry_path_for(&self.global_root);
+        let registry = crate::workspace_registry::load_registry_from(&registry_path)?;
+        let workspace = registry
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.id == workspace_id)
+            .ok_or_else(|| {
+                OrbitError::InvalidInput(format!(
+                    "unknown logical workspace ID '{workspace_id}' during knowledge owner preflight"
+                ))
+            })?;
+        let owner_machine_id = workspace.owner_machine_id.as_deref().ok_or_else(|| {
+            OrbitError::InvalidInput(format!(
+                "workspace '{workspace_id}' has no declared knowledge owner; refusing allocation"
+            ))
+        })?;
+        let identity = inspect_host_identity(&self.global_root)?;
+        let HostIdentityState::Present(identity) = identity else {
+            return Err(OrbitError::InvalidInput(format!(
+                "workspace '{workspace_id}' requires managed hub/spoke ownership before global knowledge allocation"
+            )));
+        };
+
+        if owner_machine_id == identity.machine_id {
+            let binding = match selected_binding {
+                Some(binding) => binding,
+                None => self
+                    .resolve_workspace(&workspace_id, true)?
+                    .1
+                    .ok_or_else(|| self.local_checkout_unavailable(&workspace_id))?,
+            };
+            self.preflight_placement(McpToolPlacement::Owner, &workspace_id, Some(&binding))?;
+            return Ok((workspace_id, KnowledgeOwnerRoute::Local(binding)));
+        }
+
+        if identity.mode == HostMode::Spoke
+            && self
+                .hub_links
+                .as_ref()
+                .is_some_and(|pool| pool.hub_machine_id() == owner_machine_id)
+        {
+            return Ok((workspace_id, KnowledgeOwnerRoute::Hub));
+        }
+
+        let local_role = selected_binding
+            .as_ref()
+            .map(|binding| match binding.role {
+                WorkspaceCheckoutRole::Owner => "owner",
+                WorkspaceCheckoutRole::Replica => "replica",
+            })
+            .unwrap_or("absent");
+        Err(OrbitError::InvalidInput(format!(
+            "workspace '{workspace_id}' is owned by machine '{owner_machine_id}'; local role is '{local_role}', so this host cannot finalize knowledge and no owner/spoke connection was opened"
+        )))
+    }
+
+    /// Dormant F2 composition seam. Public dispatch reaches this only after F3
+    /// flips the atomic cutover gate; focused tests exercise it directly.
+    pub(super) fn preallocated_knowledge_call(
+        &self,
+        name: &str,
+        input: Value,
+        context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
+        let kind = preallocated_knowledge_kind(name).ok_or_else(|| {
+            OrbitError::InvalidInput(format!(
+                "tool '{name}' is not a preallocated knowledge mutation"
+            ))
+        })?;
+        let definition = self.definition(name)?;
+        let mut context = normalize_trusted_call_context(context);
+        self.authorize_capability(&definition, &context)?;
+        let selector = Self::selector(&input, &context)
+            .ok_or_else(|| {
+                OrbitError::InvalidInput(format!(
+                    "tool '{name}' requires a workspace selector before knowledge allocation"
+                ))
+            })?
+            .to_string();
+        let (workspace_id, route) = self.preflight_knowledge_owner(&selector)?;
+
+        context.workspace_id = Some(workspace_id.clone());
+        let model = input
+            .get("model")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        match route {
+            KnowledgeOwnerRoute::Hub => {
+                context.workspace = Some(workspace_id.clone());
+                self.remote_hub_call(name, input, context, Some(&workspace_id))
+            }
+            KnowledgeOwnerRoute::Local(binding) => {
+                // Runtime construction is part of owner-binding preflight and
+                // must finish before a forward-only hub allocation is consumed.
+                let runtime = self.runtime_for(&binding)?;
+                let allocation_request = HubKnowledgeAllocationRequestV1 {
+                    schema_version: HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION,
+                    workspace_id: workspace_id.clone(),
+                    kind,
+                    model: model.clone(),
+                };
+                let allocation = if self.is_spoke()? {
+                    let pool = self.hub_links.as_ref().ok_or_else(|| {
+                        OrbitError::HubUnavailable(
+                            "local owner cannot allocate a global knowledge ID because no hub link is configured"
+                                .to_string(),
+                        )
+                    })?;
+                    let capability = Self::scalar_capability(&context)?;
+                    let mut allocation_context = context.clone();
+                    allocation_context.workspace = Some(workspace_id.clone());
+                    allocation_context.transport = Some(McpTransport::SshMcp);
+                    allocation_context.process_machine_id = None;
+                    allocation_context.process_host_id = None;
+                    pool.allocate_knowledge_id(capability, allocation_request, allocation_context)?
+                } else {
+                    context.workspace = Some(workspace_id.clone());
+                    HubKnowledgeSequenceService::at(&self.global_root)?
+                        .allocate(&allocation_request, &context)?
+                };
+                validate_preallocated_correlation(&allocation, &context, &workspace_id, kind)?;
+                self.finalize_owner_knowledge(
+                    &runtime,
+                    &binding,
+                    name,
+                    input,
+                    context,
+                    model,
+                    &allocation,
+                )
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn finalize_owner_knowledge(
+        &self,
+        runtime: &OrbitRuntime,
+        binding: &ExactCheckoutBinding,
+        name: &str,
+        input: Value,
+        context: ToolSessionContext,
+        model: Option<String>,
+        allocation: &HubKnowledgeAllocationV1,
+    ) -> Result<Value, OrbitError> {
+        let result = match allocation.kind {
+            KnowledgeIdKind::Adr => runtime.finalize_preallocated_adr_tool(
+                &binding.key.workspace_id,
+                &allocation.id,
+                input,
+                model,
+            ),
+            KnowledgeIdKind::Learning => runtime.finalize_preallocated_learning_tool(
+                &binding.key.workspace_id,
+                &allocation.id,
+                input,
+                model,
+            ),
+        };
+        let audit = record_owner_finalization_audit(runtime, name, &context, allocation, &result);
+        match (result, audit) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Ok(_), Err(audit_error)) => {
+                let rollback = match allocation.kind {
+                    KnowledgeIdKind::Adr => runtime.rollback_preallocated_adr(&allocation.id),
+                    KnowledgeIdKind::Learning => {
+                        runtime.rollback_preallocated_learning(&allocation.id)
+                    }
+                };
+                match rollback {
+                    Ok(true) => Err(audit_error),
+                    Ok(false) => Err(OrbitError::Store(format!(
+                        "owner audit failed for consumed {} {} and no projection was available to roll back: {audit_error}",
+                        allocation.kind.as_str(),
+                        allocation.id
+                    ))),
+                    Err(cleanup_error) => Err(OrbitError::Store(format!(
+                        "owner audit failed for consumed {} {}: {audit_error}; local cleanup failed: {cleanup_error}",
+                        allocation.kind.as_str(),
+                        allocation.id
+                    ))),
+                }
+            }
+            (Err(error), _) => Err(OrbitError::Execution(format!(
+                "hub allocated {} {} for workspace '{}', but owner finalization failed and the allocation remains consumed: {error}",
+                allocation.kind.as_str(),
+                allocation.id,
+                allocation.workspace_id
+            ))),
+        }
+    }
+
     fn runtime_for(&self, binding: &ExactCheckoutBinding) -> Result<OrbitRuntime, OrbitError> {
         let mut runtimes = self
             .runtimes
@@ -583,6 +790,9 @@ impl BrokerMcpHost {
         if let Err(error) = self.authorize_capability(&definition, &context) {
             self.record_preflight_denial(name, &input, &context, &error);
             return Err(error);
+        }
+        if PREALLOCATED_KNOWLEDGE_CUTOVER_ENABLED && preallocated_knowledge_kind(name).is_some() {
+            return self.preallocated_knowledge_call(name, input, context);
         }
         if definition.policy.scope() == McpToolScope::Global {
             if self.is_spoke()? {
@@ -758,6 +968,102 @@ impl McpHost for BrokerMcpHost {
 }
 
 impl super::learning::LearningSidecarHost for BrokerMcpHost {}
+
+pub(super) fn preallocated_knowledge_kind(name: &str) -> Option<KnowledgeIdKind> {
+    match name {
+        "orbit.adr.add" => Some(KnowledgeIdKind::Adr),
+        "orbit.learning.add" => Some(KnowledgeIdKind::Learning),
+        _ => None,
+    }
+}
+
+fn validate_preallocated_correlation(
+    allocation: &HubKnowledgeAllocationV1,
+    context: &ToolSessionContext,
+    workspace_id: &str,
+    kind: KnowledgeIdKind,
+) -> Result<(), OrbitError> {
+    allocation.validate()?;
+    if allocation.workspace_id != workspace_id
+        || allocation.kind != kind
+        || context.mcp_call_id.as_deref() != Some(allocation.mcp_call_id.as_str())
+    {
+        return Err(OrbitError::InvalidInput(format!(
+            "hub allocation correlation mismatch for workspace '{workspace_id}', kind '{}', mcp_call_id '{}'",
+            kind.as_str(),
+            context.mcp_call_id.as_deref().unwrap_or("<missing>")
+        )));
+    }
+    Ok(())
+}
+
+fn record_owner_finalization_audit(
+    runtime: &OrbitRuntime,
+    name: &str,
+    context: &ToolSessionContext,
+    allocation: &HubKnowledgeAllocationV1,
+    result: &Result<Value, OrbitError>,
+) -> Result<(), OrbitError> {
+    let (audit_context, correlation_error) = trusted_mcp_audit_context(context);
+    if let Some(error) = correlation_error {
+        return Err(error);
+    }
+    let arguments_json = serde_json::to_string(&json!({
+        "workspace_id": allocation.workspace_id,
+        "kind": allocation.kind.as_str(),
+        "allocated_id": allocation.id,
+        "mcp_call_id": allocation.mcp_call_id,
+        "allocation_remains_consumed": true,
+    }))
+    .map_err(|error| {
+        OrbitError::Execution(format!("serialize owner finalization audit: {error}"))
+    })?;
+    let (status, exit_code, error_message) = match result {
+        Ok(_) => (AuditEventStatus::Success, 0, None),
+        Err(error) => (
+            AuditEventStatus::Failure,
+            1,
+            Some(redact_sensitive_env_text(&error.to_string())),
+        ),
+    };
+    runtime.record_audit_event(&AuditEventInsertParams {
+        execution_id: audit_execution_id("audit-owner-knowledge-finalization"),
+        command: "knowledge".to_string(),
+        subcommand: Some("finalize-preallocated".to_string()),
+        tool_name: Some(name.to_string()),
+        target_type: Some("knowledge_finalization".to_string()),
+        target_id: Some(allocation.id.clone()),
+        role: audit_role_label_for_entry_point(&Value::Null, None, None, ToolEntryPoint::Mcp),
+        status,
+        exit_code,
+        duration_ms: 1,
+        working_directory: runtime.paths().repo_root.to_string_lossy().into_owned(),
+        arguments_json: Some(arguments_json),
+        stdout_truncated: None,
+        stderr_truncated: None,
+        error_message,
+        host: std::env::var("HOSTNAME").ok(),
+        pid: std::process::id(),
+        session_id: None,
+        workspace_id: Some(allocation.workspace_id.clone()),
+        caller_machine_id: context.caller_machine_id.clone(),
+        caller_host_id: context.caller_host_id.clone(),
+        process_machine_id: context.process_machine_id.clone(),
+        process_host_id: context.process_host_id.clone(),
+        transport: context.transport,
+        effective_capabilities: context.effective_capabilities.clone(),
+        origin_session_id: context.origin_session_id.clone(),
+        mcp_call_id: Some(allocation.mcp_call_id.clone()),
+        lease_id: context
+            .leased_run
+            .as_ref()
+            .map(|leased_run| leased_run.lease_id.clone()),
+        task_id: audit_context.task_id,
+        job_run_id: audit_context.job_run_id,
+        activity_id: audit_context.activity_id,
+        step_index: audit_context.step_index,
+    })
+}
 
 fn git_path(start: &Path, argument: &str) -> Result<PathBuf, OrbitError> {
     let output = Command::new("git")

--- a/crates/orbit-remote/src/mcp/hub.rs
+++ b/crates/orbit-remote/src/mcp/hub.rs
@@ -21,17 +21,31 @@ use super::contract::{
     CANONICAL_MCP_REGISTRY_REVISION, HubServerContractV1, MCP_CONTRACT_REVISION, hub_schema_digest,
 };
 use super::host::{
-    canonical_mcp_tool_definitions, mcp_preflight_failure_params, normalize_trusted_call_context,
+    BrokerMcpHost, PREALLOCATED_KNOWLEDGE_CUTOVER_ENABLED, canonical_mcp_tool_definitions,
+    mcp_preflight_failure_params, normalize_trusted_call_context, preallocated_knowledge_kind,
 };
 
-/// A fixed hub-only host. It owns no broker, runtime cache, connector, owner
-/// resolver, or transport factory.
-#[derive(Debug)]
+/// A fixed hub-only host. Its local broker has no connector or transport
+/// factory, so composed knowledge writes can terminate only in a validated
+/// hub-owned checkout and cannot recurse back through the hub link.
 pub(super) struct HubMcpHost {
     global_root: PathBuf,
     identity: HostIdentity,
     capability: McpCapability,
     private_instructions: String,
+    knowledge_broker: BrokerMcpHost,
+}
+
+impl std::fmt::Debug for HubMcpHost {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("HubMcpHost")
+            .field("global_root", &self.global_root)
+            .field("identity", &self.identity)
+            .field("capability", &self.capability)
+            .field("private_instructions", &self.private_instructions)
+            .finish_non_exhaustive()
+    }
 }
 
 impl HubMcpHost {
@@ -53,11 +67,13 @@ impl HubMcpHost {
             hub_schema_digest: hub_schema_digest(&definitions, capability)?,
         };
         let private_instructions = contract.instructions()?;
+        let knowledge_broker = BrokerMcpHost::new(global_root.clone());
         let host = Self {
             global_root,
             identity,
             capability,
             private_instructions,
+            knowledge_broker,
         };
         // Fail before stdio is opened. Listing and every call repeat this
         // check so a long-lived server cannot outlive an authority change.
@@ -176,11 +192,32 @@ impl HubMcpHost {
     }
 
     fn admitted(&self, definition: &McpToolDefinition) -> bool {
-        definition.policy.placement() == McpToolPlacement::Hub
+        (definition.policy.placement() == McpToolPlacement::Hub
+            || (PREALLOCATED_KNOWLEDGE_CUTOVER_ENABLED
+                && definition.policy.placement() == McpToolPlacement::Composite
+                && preallocated_knowledge_kind(&definition.schema.name).is_some()))
             && definition
                 .policy
                 .allowed_capabilities()
                 .contains(&self.capability)
+    }
+
+    pub(super) fn compose_preallocated_knowledge_add(
+        &self,
+        name: &str,
+        input: Value,
+        session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
+        let (identity, snapshot) = self.verify_authority()?;
+        let context = self.normalize_context(session_context, &identity);
+        Self::require_active_remote_caller(&context, &snapshot)?;
+        if preallocated_knowledge_kind(name).is_none() {
+            return Err(OrbitError::InvalidInput(format!(
+                "tool '{name}' is not a preallocated knowledge add"
+            )));
+        }
+        self.knowledge_broker
+            .preallocated_knowledge_call(name, input, context)
     }
 
     fn definition(&self, inbound: &str) -> Result<McpToolDefinition, OrbitError> {
@@ -457,6 +494,9 @@ impl HubMcpHost {
         {
             self.record_denial(name, &context, &error);
             return Err(error);
+        }
+        if PREALLOCATED_KNOWLEDGE_CUTOVER_ENABLED && preallocated_knowledge_kind(name).is_some() {
+            return self.compose_preallocated_knowledge_add(name, input, context);
         }
         let result = HubCoordinationExecutor::new(&self.global_root, workspace_id, None)
             .and_then(|executor| executor.execute_tool(name, input, context.clone()));

--- a/crates/orbit-remote/src/mcp/hub_link.rs
+++ b/crates/orbit-remote/src/mcp/hub_link.rs
@@ -320,7 +320,6 @@ pub(super) enum WorkerMessage {
     Register(RegistrationRequest),
     // Dormant until the F3 caller-path cutover; F1 freezes and tests the
     // connector-private seam without routing ordinary agent tools through it.
-    #[allow(dead_code)]
     Allocate(KnowledgeAllocationRequest),
     Shutdown,
 }
@@ -333,6 +332,7 @@ struct CachedPeer {
 /// Synchronous [`orbit_mcp::McpHost`] seam backed by one dedicated runtime
 /// thread and at most one live peer for each scalar capability.
 pub(super) struct HubLinkPool {
+    hub_machine_id: String,
     pub(super) tx: Option<mpsc::SyncSender<WorkerMessage>>,
     worker: Option<JoinHandle<()>>,
 }
@@ -363,13 +363,14 @@ impl HubLinkPool {
     ) -> Result<Self, OrbitError> {
         let (tx, rx) = mpsc::sync_channel(limits.queue_capacity);
         let worker_clock = Arc::clone(&clock);
+        let worker_hub_machine_id = hub_machine_id.clone();
         let worker = std::thread::Builder::new()
             .name("orbit-hub-link".to_string())
             .spawn(move || {
                 run_worker(
                     rx,
                     ssh_alias,
-                    hub_machine_id,
+                    worker_hub_machine_id,
                     schema_digests,
                     factory,
                     limits,
@@ -380,9 +381,14 @@ impl HubLinkPool {
                 OrbitError::HubUnavailable(format!("start hub link worker: {error}"))
             })?;
         Ok(Self {
+            hub_machine_id,
             tx: Some(tx),
             worker: Some(worker),
         })
+    }
+
+    pub(super) fn hub_machine_id(&self) -> &str {
+        &self.hub_machine_id
     }
 
     pub(super) fn call(
@@ -483,7 +489,6 @@ impl HubLinkPool {
             })?
     }
 
-    #[allow(dead_code)]
     pub(super) fn allocate_knowledge_id(
         &self,
         capability: McpCapability,

--- a/crates/orbit-remote/src/mcp/tests/knowledge_allocation.rs
+++ b/crates/orbit-remote/src/mcp/tests/knowledge_allocation.rs
@@ -1,14 +1,16 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use chrono::Utc;
 use orbit_common::types::{
-    HUB_KNOWLEDGE_ALLOCATION_METHOD_V1, HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION,
+    AuditEventStatus, HUB_KNOWLEDGE_ALLOCATION_METHOD_V1, HUB_KNOWLEDGE_ALLOCATION_SCHEMA_VERSION,
     HubKnowledgeAllocationRequestV1, HubKnowledgeAllocationV1, KnowledgeIdKind, McpCapability,
     McpTransport, OrbitError, SpokeRegistrationRequestV1, SpokeRegistrationResultV1,
-    ToolSessionContext, Workspace, WorkspaceRegistry, WorkspaceStatus,
+    ToolSessionContext, Workspace, WorkspaceCheckout, WorkspaceCheckoutRole, WorkspaceRegistry,
+    WorkspaceStatus,
 };
 use orbit_mcp::{McpCustomRequestError, McpCustomRequestHandler, McpHost, OrbitToolServer};
 use rmcp::ServiceExt;
@@ -21,7 +23,7 @@ use crate::{
 };
 
 use super::super::contract::hub_schema_digest;
-use super::super::host::canonical_mcp_tool_definitions;
+use super::super::host::{BrokerMcpHost, canonical_mcp_tool_definitions};
 use super::super::hub::HubMcpHost;
 use super::super::hub_client::OrbitMcpClient;
 use super::super::hub_link::{
@@ -119,12 +121,143 @@ fn context(workspace_id: &str, call_id: &str) -> ToolSessionContext {
     }
 }
 
+fn local_context(
+    selector: &str,
+    call_id: &str,
+    machine_id: &str,
+    host_id: &str,
+) -> ToolSessionContext {
+    let mut context = ToolSessionContext::trusted_local(
+        None,
+        Some(machine_id.to_string()),
+        Some(host_id.to_string()),
+    );
+    context.workspace = Some(selector.to_string());
+    context.origin_session_id = Some(format!("session-{machine_id}"));
+    context.mcp_call_id = Some(call_id.to_string());
+    context
+}
+
 fn schema_digests() -> BTreeMap<McpCapability, String> {
     let definitions = canonical_mcp_tool_definitions().expect("definitions");
     BTreeMap::from([(
         McpCapability::Agent,
         hub_schema_digest(&definitions, McpCapability::Agent).expect("schema digest"),
     )])
+}
+
+fn workspace_record(workspace_id: &str, owner_machine_id: &str) -> Workspace {
+    Workspace {
+        id: workspace_id.to_string(),
+        name: workspace_id.to_string(),
+        owner_machine_id: Some(owner_machine_id.to_string()),
+        git_remote: None,
+        ship_mode: Some("local".to_string()),
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+fn init_owner_checkout(base: &Path, workspace_id: &str) -> WorkspaceCheckout {
+    let repo_root = base.join(format!("{workspace_id}-checkout"));
+    std::fs::create_dir_all(&repo_root).expect("checkout root");
+    let status = Command::new("git")
+        .args(["init", "-b", "agent-main"])
+        .arg(&repo_root)
+        .status()
+        .expect("git init");
+    assert!(status.success());
+    for (key, value) in [
+        ("user.name", "Orbit Test"),
+        ("user.email", "orbit@example.invalid"),
+    ] {
+        assert!(
+            Command::new("git")
+                .arg("-C")
+                .arg(&repo_root)
+                .args(["config", key, value])
+                .status()
+                .expect("git config")
+                .success()
+        );
+    }
+    std::fs::write(repo_root.join("README.md"), b"fixture\n").expect("README");
+    assert!(
+        Command::new("git")
+            .arg("-C")
+            .arg(&repo_root)
+            .args(["add", "README.md"])
+            .status()
+            .expect("git add")
+            .success()
+    );
+    assert!(
+        Command::new("git")
+            .arg("-C")
+            .arg(&repo_root)
+            .args(["commit", "-m", "fixture"])
+            .status()
+            .expect("git commit")
+            .success()
+    );
+    let orbit_dir = repo_root.join(".orbit");
+    std::fs::create_dir_all(&orbit_dir).expect("Orbit root");
+    std::fs::write(
+        orbit_dir.join("config.yaml"),
+        format!("schema_version: 1\nworkspace_id: {workspace_id}\n"),
+    )
+    .expect("workspace identity");
+    WorkspaceCheckout::owner(workspace_id.to_string(), repo_root, orbit_dir)
+}
+
+fn add_linked_worktree(checkout: &WorkspaceCheckout, destination: &Path) {
+    assert!(
+        Command::new("git")
+            .arg("-C")
+            .arg(&checkout.repo_root)
+            .args(["worktree", "add", "-b", "selected-owner"])
+            .arg(destination)
+            .status()
+            .expect("git worktree add")
+            .success()
+    );
+}
+
+fn save_workspace_registry(
+    global_root: &Path,
+    workspace: Workspace,
+    checkout: Option<WorkspaceCheckout>,
+) {
+    crate::workspace_registry::save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![workspace],
+            checkouts: checkout.into_iter().collect(),
+            ..WorkspaceRegistry::default()
+        },
+        &crate::workspace_registry::registry_path_for(global_root),
+    )
+    .expect("workspace registry");
+}
+
+fn add_hub_owned_workspace(hub_root: &Path, workspace_id: &str, checkout: WorkspaceCheckout) {
+    let registry_path = crate::workspace_registry::registry_path_for(hub_root);
+    let mut registry =
+        crate::workspace_registry::load_registry_from(&registry_path).expect("load hub registry");
+    registry
+        .workspaces
+        .push(workspace_record(workspace_id, "hm_hub"));
+    registry.checkouts.push(checkout);
+    crate::workspace_registry::save_registry_to(&registry, &registry_path)
+        .expect("save hub registry");
+    HubKnowledgeSequenceService::at(hub_root)
+        .expect("hub allocator")
+        .reconcile_workspace(KnowledgeWorkspaceInventory {
+            workspace_id: workspace_id.to_string(),
+            ids: Vec::new(),
+        })
+        .expect("reconcile hub workspace");
 }
 
 fn limits() -> HubLinkLimits {
@@ -136,6 +269,28 @@ fn limits() -> HubLinkLimits {
         idle_poll: Duration::from_millis(10),
         close: Duration::from_secs(1),
     }
+}
+
+fn wire_pool(
+    hub_root: &Path,
+    allocations: Arc<Mutex<Vec<(HubKnowledgeAllocationRequestV1, ToolSessionContext)>>>,
+    tool_calls: Arc<Mutex<Vec<(String, serde_json::Value, ToolSessionContext)>>>,
+    connects: Arc<Mutex<usize>>,
+) -> HubLinkPool {
+    HubLinkPool::with_factory(
+        "hub-alias".to_string(),
+        "hm_hub".to_string(),
+        schema_digests(),
+        Arc::new(WireFactory {
+            hub_root: hub_root.to_path_buf(),
+            allocations,
+            tool_calls,
+            connects,
+        }),
+        limits(),
+        Arc::new(MonotonicClock::default()) as Arc<dyn HubClock>,
+    )
+    .expect("link pool")
 }
 
 fn snapshot_files(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
@@ -168,6 +323,8 @@ fn snapshot_files(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
 struct WireFactory {
     hub_root: PathBuf,
     allocations: Arc<Mutex<Vec<(HubKnowledgeAllocationRequestV1, ToolSessionContext)>>>,
+    tool_calls: Arc<Mutex<Vec<(String, serde_json::Value, ToolSessionContext)>>>,
+    connects: Arc<Mutex<usize>>,
 }
 
 impl HubPeerFactory for WireFactory {
@@ -176,9 +333,11 @@ impl HubPeerFactory for WireFactory {
         spec: &'a HubSpawnSpec,
         limits: HubLinkLimits,
     ) -> BoxFuture<'a, Result<Box<dyn HubPeer>, OrbitError>> {
+        *self.connects.lock().expect("connect count") += 1;
         let hub_root = self.hub_root.clone();
         let spec = spec.clone();
         let allocations = Arc::clone(&self.allocations);
+        let tool_calls = Arc::clone(&self.tool_calls);
         Box::pin(async move {
             let host = Arc::new(HubMcpHost::new(hub_root, spec.capability)?);
             let mut trusted = ToolSessionContext::trusted_local(
@@ -190,7 +349,7 @@ impl HubPeerFactory for WireFactory {
             let server = OrbitToolServer::new_with_context_and_composition(
                 Arc::clone(&host) as Arc<dyn McpHost>,
                 trusted,
-                hub_server_composition(host),
+                hub_server_composition(Arc::clone(&host)),
             );
             let (server_io, client_io) = tokio::io::duplex(256 * 1024);
             let server_task = tokio::spawn(async move {
@@ -205,7 +364,9 @@ impl HubPeerFactory for WireFactory {
             Ok(Box::new(WirePeer {
                 client,
                 server_task,
+                host,
                 allocations,
+                tool_calls,
                 request_timeout: limits.request,
                 close_timeout: limits.close,
             }) as Box<dyn HubPeer>)
@@ -216,7 +377,9 @@ impl HubPeerFactory for WireFactory {
 struct WirePeer {
     client: OrbitMcpClient,
     server_task: tokio::task::JoinHandle<()>,
+    host: Arc<HubMcpHost>,
     allocations: Arc<Mutex<Vec<(HubKnowledgeAllocationRequestV1, ToolSessionContext)>>>,
+    tool_calls: Arc<Mutex<Vec<(String, serde_json::Value, ToolSessionContext)>>>,
     request_timeout: Duration,
     close_timeout: Duration,
 }
@@ -228,11 +391,19 @@ impl HubPeer for WirePeer {
 
     fn call<'a>(
         &'a mut self,
-        _name: &'a str,
-        _input: serde_json::Value,
-        _context: &'a ToolSessionContext,
+        name: &'a str,
+        input: serde_json::Value,
+        context: &'a ToolSessionContext,
     ) -> BoxFuture<'a, Result<serde_json::Value, OrbitError>> {
-        Box::pin(async { Err(OrbitError::InvalidInput("unexpected tool call".to_string())) })
+        self.tool_calls.lock().expect("tool calls").push((
+            name.to_string(),
+            input.clone(),
+            context.clone(),
+        ));
+        let result = self
+            .host
+            .compose_preallocated_knowledge_add(name, input, context.clone());
+        Box::pin(async move { result })
     }
 
     fn register_spoke<'a>(
@@ -354,6 +525,8 @@ fn connector_private_two_root_allocation_is_path_free_checkoutless_and_not_adver
     std::fs::write(spoke_root.path().join("marker"), b"unchanged").expect("spoke marker");
     let spoke_before = snapshot_files(spoke_root.path());
     let allocations = Arc::new(Mutex::new(Vec::new()));
+    let tool_calls = Arc::new(Mutex::new(Vec::new()));
+    let connects = Arc::new(Mutex::new(0));
     let pool = HubLinkPool::with_factory(
         "hub-alias".to_string(),
         "hm_hub".to_string(),
@@ -361,6 +534,8 @@ fn connector_private_two_root_allocation_is_path_free_checkoutless_and_not_adver
         Arc::new(WireFactory {
             hub_root: hub_root.path().to_path_buf(),
             allocations: Arc::clone(&allocations),
+            tool_calls: Arc::clone(&tool_calls),
+            connects: Arc::clone(&connects),
         }),
         limits(),
         Arc::new(MonotonicClock::default()) as Arc<dyn HubClock>,
@@ -386,6 +561,8 @@ fn connector_private_two_root_allocation_is_path_free_checkoutless_and_not_adver
     assert_eq!(snapshot_files(spoke_root.path()), spoke_before);
     let captured = allocations.lock().expect("allocations");
     assert_eq!(captured.len(), 2, "connector replayed allocation");
+    assert!(tool_calls.lock().expect("tool calls").is_empty());
+    assert_eq!(*connects.lock().expect("connects"), 1);
     assert_eq!(captured[0].0.workspace_id, "ws_alpha");
     assert_eq!(captured[1].0.workspace_id, "ws_beta");
     let encoded = serde_json::to_value(&captured[0].0).expect("request json");
@@ -455,9 +632,648 @@ fn connector_private_two_root_allocation_is_path_free_checkoutless_and_not_adver
 }
 
 #[test]
+fn local_owner_allocates_once_then_finalizes_both_kinds_in_exact_selected_worktree() {
+    let hub_root = tempfile::tempdir().expect("hub root");
+    let spoke_root = tempfile::tempdir().expect("spoke root");
+    setup_hub(hub_root.path());
+    write_identity(spoke_root.path(), "spoke", "hm_spoke", "spoke");
+    let workspace = workspace_record("ws_alpha", "hm_spoke");
+    let checkout = init_owner_checkout(spoke_root.path(), "ws_alpha");
+    let selected = spoke_root.path().join("selected-worktree");
+    add_linked_worktree(&checkout, &selected);
+    save_workspace_registry(spoke_root.path(), workspace.clone(), Some(checkout.clone()));
+
+    let allocations = Arc::new(Mutex::new(Vec::new()));
+    let tool_calls = Arc::new(Mutex::new(Vec::new()));
+    let connects = Arc::new(Mutex::new(0));
+    let pool = wire_pool(
+        hub_root.path(),
+        Arc::clone(&allocations),
+        Arc::clone(&tool_calls),
+        Arc::clone(&connects),
+    );
+    let broker = BrokerMcpHost::new_with_hub_link(spoke_root.path().to_path_buf(), pool);
+    let selector = selected.to_string_lossy().into_owned();
+
+    let adr = broker
+        .preallocated_knowledge_call(
+            "orbit.adr.add",
+            json!({
+                "workspace": selector,
+                "title": "Global ID",
+                "owner": "codex",
+                "body": "Body",
+                "model": "codex"
+            }),
+            local_context(&selector, "mcall-owner-adr", "hm_spoke", "spoke"),
+        )
+        .expect("ADR add");
+    let learning = broker
+        .preallocated_knowledge_call(
+            "orbit.learning.add",
+            json!({
+                "workspace": selector,
+                "summary": "Global learning ID",
+                "scope": {"paths": ["src/**"], "tags": ["global"]},
+                "body": "Body",
+                "model": "codex"
+            }),
+            local_context(&selector, "mcall-owner-learning", "hm_spoke", "spoke"),
+        )
+        .expect("learning add");
+
+    assert_eq!(adr["id"], "ADR-0001");
+    assert_eq!(learning["id"], "L-0001");
+    assert!(
+        selected
+            .join(".orbit/adrs/proposed/ADR-0001/adr.yaml")
+            .is_file()
+    );
+    assert!(
+        selected
+            .join(".orbit/learnings/L-0001/learning.yaml")
+            .is_file()
+    );
+    assert!(
+        !checkout
+            .repo_root
+            .join(".orbit/adrs/proposed/ADR-0001")
+            .exists()
+    );
+    assert!(!checkout.repo_root.join(".orbit/learnings/L-0001").exists());
+
+    drop(broker);
+    let captured = allocations.lock().expect("allocations");
+    assert_eq!(captured.len(), 2);
+    assert!(tool_calls.lock().expect("tool calls").is_empty());
+    assert_eq!(*connects.lock().expect("connects"), 1);
+    for (request, context) in captured.iter() {
+        assert_eq!(request.workspace_id, "ws_alpha");
+        assert_eq!(
+            request.kind.as_str(),
+            if request.kind == KnowledgeIdKind::Adr {
+                "adr"
+            } else {
+                "learning"
+            }
+        );
+        assert_eq!(context.workspace_id.as_deref(), Some("ws_alpha"));
+        let encoded = serde_json::to_string(request).expect("request JSON");
+        assert!(!encoded.contains(selected.to_string_lossy().as_ref()));
+        assert!(!encoded.contains(checkout.repo_root.to_string_lossy().as_ref()));
+    }
+
+    let runtime = crate::runtime::RemoteRuntimeFactory::open_registered_checkout(
+        spoke_root.path(),
+        &workspace,
+        &checkout,
+    )
+    .expect("reopen owner runtime");
+    let audits = runtime
+        .list_audit_events_with_kind(
+            None,
+            None,
+            Some("knowledge_finalization".to_string()),
+            None,
+            None,
+            10,
+        )
+        .expect("owner audits");
+    assert_eq!(audits.len(), 2);
+    for audit in audits {
+        assert_eq!(audit.workspace_id.as_deref(), Some("ws_alpha"));
+        assert_eq!(audit.caller_machine_id.as_deref(), Some("hm_spoke"));
+        assert_eq!(audit.process_machine_id.as_deref(), Some("hm_spoke"));
+        let (expected_kind, expected_id) = match audit.mcp_call_id.as_deref() {
+            Some("mcall-owner-adr") => ("adr", "ADR-0001"),
+            Some("mcall-owner-learning") => ("learning", "L-0001"),
+            correlation => panic!("unexpected correlation: {correlation:?}"),
+        };
+        assert_eq!(audit.status, AuditEventStatus::Success);
+        assert_eq!(audit.target_id.as_deref(), Some(expected_id));
+        let arguments: serde_json::Value = serde_json::from_str(
+            audit
+                .arguments_json
+                .as_deref()
+                .expect("finalization arguments"),
+        )
+        .expect("finalization arguments JSON");
+        assert_eq!(arguments["workspace_id"], "ws_alpha");
+        assert_eq!(arguments["kind"], expected_kind);
+        assert_eq!(arguments["allocated_id"], expected_id);
+        assert_eq!(
+            arguments["mcp_call_id"],
+            audit.mcp_call_id.as_deref().expect("correlation")
+        );
+    }
+}
+
+#[test]
+fn supplied_id_collisions_preserve_owner_artifacts_and_leave_consumed_hub_gaps() {
+    let hub_root = tempfile::tempdir().expect("hub root");
+    let spoke_root = tempfile::tempdir().expect("spoke root");
+    setup_hub(hub_root.path());
+    write_identity(spoke_root.path(), "spoke", "hm_spoke", "spoke");
+    let checkout = init_owner_checkout(spoke_root.path(), "ws_alpha");
+    let workspace = workspace_record("ws_alpha", "hm_spoke");
+    save_workspace_registry(spoke_root.path(), workspace.clone(), Some(checkout.clone()));
+
+    let allocations = Arc::new(Mutex::new(Vec::new()));
+    let tool_calls = Arc::new(Mutex::new(Vec::new()));
+    let connects = Arc::new(Mutex::new(0));
+    let broker = BrokerMcpHost::new_with_hub_link(
+        spoke_root.path().to_path_buf(),
+        wire_pool(
+            hub_root.path(),
+            Arc::clone(&allocations),
+            Arc::clone(&tool_calls),
+            Arc::clone(&connects),
+        ),
+    );
+    let selector = checkout.repo_root.to_string_lossy().into_owned();
+
+    let compatibility_runtime = crate::runtime::RemoteRuntimeFactory::open_registered_checkout(
+        spoke_root.path(),
+        &workspace,
+        &checkout,
+    )
+    .expect("compatibility runtime");
+    let existing_adr = compatibility_runtime
+        .run_tool(
+            "orbit.adr.add",
+            json!({
+                "title": "Compatibility ADR",
+                "owner": "codex",
+                "body": "original ADR body"
+            }),
+        )
+        .expect("compatibility ADR");
+    let existing_learning = compatibility_runtime
+        .run_tool(
+            "orbit.learning.add",
+            json!({
+                "summary": "Compatibility learning",
+                "scope": {},
+                "body": "original learning body"
+            }),
+        )
+        .expect("compatibility learning");
+    assert_eq!(existing_adr["id"], "ADR-0001");
+    assert_eq!(existing_learning["id"], "L-0001");
+    let adr_dir = checkout.repo_root.join(".orbit/adrs/proposed/ADR-0001");
+    let learning_dir = checkout.repo_root.join(".orbit/learnings/L-0001");
+    let adr_before = snapshot_files(&adr_dir);
+    let learning_before = snapshot_files(&learning_dir);
+
+    let adr_error = broker
+        .preallocated_knowledge_call(
+            "orbit.adr.add",
+            json!({
+                "workspace": selector,
+                "title": "Must not overwrite",
+                "owner": "codex",
+                "body": "replacement",
+                "model": "codex"
+            }),
+            local_context(&selector, "mcall-collision-adr", "hm_spoke", "spoke"),
+        )
+        .expect_err("ADR collision")
+        .to_string();
+    assert!(adr_error.contains("ADR-0001"), "{adr_error}");
+    assert!(adr_error.contains("remains consumed"), "{adr_error}");
+    assert_eq!(snapshot_files(&adr_dir), adr_before);
+
+    let learning_error = broker
+        .preallocated_knowledge_call(
+            "orbit.learning.add",
+            json!({
+                "workspace": selector,
+                "summary": "Must not overwrite",
+                "scope": {},
+                "body": "replacement",
+                "model": "codex"
+            }),
+            local_context(&selector, "mcall-collision-learning", "hm_spoke", "spoke"),
+        )
+        .expect_err("learning collision")
+        .to_string();
+    assert!(learning_error.contains("L-0001"), "{learning_error}");
+    assert!(
+        learning_error.contains("remains consumed"),
+        "{learning_error}"
+    );
+    assert_eq!(snapshot_files(&learning_dir), learning_before);
+
+    let next_adr = broker
+        .preallocated_knowledge_call(
+            "orbit.adr.add",
+            json!({
+                "workspace": selector,
+                "title": "After the gap",
+                "owner": "codex",
+                "body": "new body",
+                "model": "codex"
+            }),
+            local_context(&selector, "mcall-next-adr", "hm_spoke", "spoke"),
+        )
+        .expect("next ADR");
+    let next_learning = broker
+        .preallocated_knowledge_call(
+            "orbit.learning.add",
+            json!({
+                "workspace": selector,
+                "summary": "After the gap",
+                "scope": {},
+                "body": "new body",
+                "model": "codex"
+            }),
+            local_context(&selector, "mcall-next-learning", "hm_spoke", "spoke"),
+        )
+        .expect("next learning");
+    assert_eq!(next_adr["id"], "ADR-0002");
+    assert_eq!(next_learning["id"], "L-0002");
+    drop(broker);
+
+    let service = HubKnowledgeSequenceService::at(hub_root.path()).expect("hub service");
+    for (call_id, kind, id) in [
+        ("mcall-collision-adr", KnowledgeIdKind::Adr, "ADR-0001"),
+        (
+            "mcall-collision-learning",
+            KnowledgeIdKind::Learning,
+            "L-0001",
+        ),
+        ("mcall-next-adr", KnowledgeIdKind::Adr, "ADR-0002"),
+        ("mcall-next-learning", KnowledgeIdKind::Learning, "L-0002"),
+    ] {
+        let allocation = service
+            .allocation_by_call(call_id)
+            .expect("allocation lookup")
+            .expect("consumed allocation");
+        assert_eq!(allocation.workspace_id, "ws_alpha");
+        assert_eq!(allocation.kind, kind);
+        assert_eq!(allocation.id, id);
+        assert_eq!(allocation.mcp_call_id, call_id);
+    }
+    assert_eq!(allocations.lock().expect("allocations").len(), 4);
+    assert!(tool_calls.lock().expect("tool calls").is_empty());
+    assert_eq!(*connects.lock().expect("connects"), 1);
+}
+
+#[test]
+fn post_allocation_index_failures_clean_owner_state_and_consume_gap_ids() {
+    let hub_root = tempfile::tempdir().expect("hub root");
+    let spoke_root = tempfile::tempdir().expect("spoke root");
+    setup_hub(hub_root.path());
+    write_identity(spoke_root.path(), "spoke", "hm_spoke", "spoke");
+    let checkout = init_owner_checkout(spoke_root.path(), "ws_alpha");
+    let workspace = workspace_record("ws_alpha", "hm_spoke");
+    save_workspace_registry(spoke_root.path(), workspace.clone(), Some(checkout.clone()));
+    let runtime = crate::runtime::RemoteRuntimeFactory::open_registered_checkout(
+        spoke_root.path(),
+        &workspace,
+        &checkout,
+    )
+    .expect("initialize owner stores");
+    drop(runtime);
+    let owner_index =
+        rusqlite::Connection::open(spoke_root.path().join("orbit.db")).expect("owner index");
+    owner_index
+        .execute_batch(
+            "CREATE TRIGGER fail_f2_adr_index
+             BEFORE INSERT ON adrs WHEN NEW.id = 'ADR-0001'
+             BEGIN SELECT RAISE(ABORT, 'injected F2 ADR index failure'); END;
+             CREATE TRIGGER fail_f2_learning_index
+             BEFORE INSERT ON learnings_index WHEN NEW.id = 'L-0001'
+             BEGIN SELECT RAISE(ABORT, 'injected F2 learning index failure'); END;",
+        )
+        .expect("failure triggers");
+
+    let allocations = Arc::new(Mutex::new(Vec::new()));
+    let tool_calls = Arc::new(Mutex::new(Vec::new()));
+    let connects = Arc::new(Mutex::new(0));
+    let broker = BrokerMcpHost::new_with_hub_link(
+        spoke_root.path().to_path_buf(),
+        wire_pool(
+            hub_root.path(),
+            Arc::clone(&allocations),
+            Arc::clone(&tool_calls),
+            Arc::clone(&connects),
+        ),
+    );
+    let selector = checkout.repo_root.to_string_lossy().into_owned();
+
+    let adr_error = broker
+        .preallocated_knowledge_call(
+            "orbit.adr.add",
+            json!({
+                "workspace": selector,
+                "title": "Injected failure",
+                "owner": "codex",
+                "body": "must be removed",
+                "model": "codex"
+            }),
+            local_context(&selector, "mcall-fail-adr", "hm_spoke", "spoke"),
+        )
+        .expect_err("ADR index failure")
+        .to_string();
+    let learning_error = broker
+        .preallocated_knowledge_call(
+            "orbit.learning.add",
+            json!({
+                "workspace": selector,
+                "summary": "Injected failure",
+                "scope": {},
+                "body": "must be removed",
+                "model": "codex"
+            }),
+            local_context(&selector, "mcall-fail-learning", "hm_spoke", "spoke"),
+        )
+        .expect_err("learning index failure")
+        .to_string();
+    assert!(adr_error.contains("ADR-0001"), "{adr_error}");
+    assert!(adr_error.contains("remains consumed"), "{adr_error}");
+    assert!(learning_error.contains("L-0001"), "{learning_error}");
+    assert!(
+        learning_error.contains("remains consumed"),
+        "{learning_error}"
+    );
+    assert!(
+        !checkout
+            .repo_root
+            .join(".orbit/adrs/proposed/ADR-0001")
+            .exists()
+    );
+    assert!(!checkout.repo_root.join(".orbit/learnings/L-0001").exists());
+    let projection_db = rusqlite::Connection::open(checkout.orbit_dir.join("state/semantic.db"))
+        .expect("projection database");
+    let projection_count: i64 = projection_db
+        .query_row(
+            "SELECT COUNT(*) FROM id_allocations WHERE id IN ('ADR-0001', 'L-0001')",
+            [],
+            |row| row.get(0),
+        )
+        .expect("projection count");
+    assert_eq!(projection_count, 0);
+    let adr_index_count: i64 = owner_index
+        .query_row(
+            "SELECT COUNT(*) FROM adrs WHERE id = 'ADR-0001'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("ADR index count");
+    let learning_index_count: i64 = owner_index
+        .query_row(
+            "SELECT COUNT(*) FROM learnings_index WHERE id = 'L-0001'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("learning index count");
+    assert_eq!((adr_index_count, learning_index_count), (0, 0));
+
+    owner_index
+        .execute_batch("DROP TRIGGER fail_f2_adr_index; DROP TRIGGER fail_f2_learning_index;")
+        .expect("remove failure triggers");
+    let next_adr = broker
+        .preallocated_knowledge_call(
+            "orbit.adr.add",
+            json!({
+                "workspace": selector,
+                "title": "After failure",
+                "owner": "codex",
+                "body": "persists",
+                "model": "codex"
+            }),
+            local_context(&selector, "mcall-after-fail-adr", "hm_spoke", "spoke"),
+        )
+        .expect("ADR after gap");
+    let next_learning = broker
+        .preallocated_knowledge_call(
+            "orbit.learning.add",
+            json!({
+                "workspace": selector,
+                "summary": "After failure",
+                "scope": {},
+                "body": "persists",
+                "model": "codex"
+            }),
+            local_context(&selector, "mcall-after-fail-learning", "hm_spoke", "spoke"),
+        )
+        .expect("learning after gap");
+    assert_eq!(next_adr["id"], "ADR-0002");
+    assert_eq!(next_learning["id"], "L-0002");
+    drop(broker);
+
+    let audit_runtime = crate::runtime::RemoteRuntimeFactory::open_registered_checkout(
+        spoke_root.path(),
+        &workspace,
+        &checkout,
+    )
+    .expect("audit runtime");
+    let audits = audit_runtime
+        .list_audit_events_with_kind(
+            None,
+            None,
+            Some("knowledge_finalization".to_string()),
+            None,
+            None,
+            10,
+        )
+        .expect("finalization audits");
+    for (call_id, kind, id) in [
+        ("mcall-fail-adr", "adr", "ADR-0001"),
+        ("mcall-fail-learning", "learning", "L-0001"),
+    ] {
+        let audit = audits
+            .iter()
+            .find(|audit| audit.mcp_call_id.as_deref() == Some(call_id))
+            .expect("failure audit");
+        assert_eq!(audit.status, AuditEventStatus::Failure);
+        assert_eq!(audit.workspace_id.as_deref(), Some("ws_alpha"));
+        assert_eq!(audit.caller_machine_id.as_deref(), Some("hm_spoke"));
+        assert_eq!(audit.process_machine_id.as_deref(), Some("hm_spoke"));
+        assert_eq!(audit.target_id.as_deref(), Some(id));
+        let arguments: serde_json::Value = serde_json::from_str(
+            audit
+                .arguments_json
+                .as_deref()
+                .expect("finalization arguments"),
+        )
+        .expect("finalization arguments JSON");
+        assert_eq!(arguments["workspace_id"], "ws_alpha");
+        assert_eq!(arguments["kind"], kind);
+        assert_eq!(arguments["allocated_id"], id);
+        assert_eq!(arguments["mcp_call_id"], call_id);
+    }
+
+    let service = HubKnowledgeSequenceService::at(hub_root.path()).expect("hub service");
+    for (call_id, expected_id) in [
+        ("mcall-fail-adr", "ADR-0001"),
+        ("mcall-fail-learning", "L-0001"),
+        ("mcall-after-fail-adr", "ADR-0002"),
+        ("mcall-after-fail-learning", "L-0002"),
+    ] {
+        assert_eq!(
+            service
+                .allocation_by_call(call_id)
+                .expect("allocation lookup")
+                .expect("consumed allocation")
+                .id,
+            expected_id
+        );
+    }
+    assert_eq!(allocations.lock().expect("allocations").len(), 4);
+    assert!(tool_calls.lock().expect("tool calls").is_empty());
+    assert_eq!(*connects.lock().expect("connects"), 1);
+}
+
+#[test]
+fn hub_owned_add_dispatches_once_and_finalizes_only_in_hub_checkout() {
+    let hub_root = tempfile::tempdir().expect("hub root");
+    let spoke_root = tempfile::tempdir().expect("spoke root");
+    setup_hub(hub_root.path());
+    let hub_checkout = init_owner_checkout(hub_root.path(), "ws_hub");
+    add_hub_owned_workspace(hub_root.path(), "ws_hub", hub_checkout.clone());
+    write_identity(spoke_root.path(), "spoke", "hm_spoke", "spoke");
+    save_workspace_registry(
+        spoke_root.path(),
+        workspace_record("ws_hub", "hm_hub"),
+        None,
+    );
+
+    let allocations = Arc::new(Mutex::new(Vec::new()));
+    let tool_calls = Arc::new(Mutex::new(Vec::new()));
+    let connects = Arc::new(Mutex::new(0));
+    let pool = wire_pool(
+        hub_root.path(),
+        Arc::clone(&allocations),
+        Arc::clone(&tool_calls),
+        Arc::clone(&connects),
+    );
+    let broker = BrokerMcpHost::new_with_hub_link(spoke_root.path().to_path_buf(), pool);
+
+    let compatibility_error = broker
+        .call_tool(
+            "orbit.adr.add",
+            json!({
+                "workspace": "ws_hub",
+                "title": "Compatibility stays inactive",
+                "owner": "codex",
+                "body": "Body"
+            }),
+            local_context("ws_hub", "mcall-public-compat", "hm_spoke", "spoke"),
+        )
+        .expect_err("F2 gate remains inactive")
+        .to_string();
+    assert!(
+        compatibility_error.contains("exact local checkout"),
+        "{compatibility_error}"
+    );
+    assert!(
+        HubKnowledgeSequenceService::at(hub_root.path())
+            .expect("allocator")
+            .allocation_by_call("mcall-public-compat")
+            .expect("lookup")
+            .is_none()
+    );
+
+    let response = broker
+        .preallocated_knowledge_call(
+            "orbit.adr.add",
+            json!({
+                "workspace": "ws_hub",
+                "title": "Hub owned",
+                "owner": "codex",
+                "body": "Body",
+                "model": "codex"
+            }),
+            local_context("ws_hub", "mcall-hub-owned", "hm_spoke", "spoke"),
+        )
+        .expect("hub-owned add");
+    assert_eq!(response["id"], "ADR-0001");
+    drop(broker);
+
+    assert!(allocations.lock().expect("allocations").is_empty());
+    let calls = tool_calls.lock().expect("tool calls");
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].0, "orbit.adr.add");
+    assert_eq!(calls[0].1["workspace"], "ws_hub");
+    assert_eq!(calls[0].2.workspace_id.as_deref(), Some("ws_hub"));
+    assert!(
+        !calls[0]
+            .1
+            .to_string()
+            .contains(hub_checkout.repo_root.to_string_lossy().as_ref())
+    );
+    assert_eq!(*connects.lock().expect("connects"), 1);
+    assert!(
+        hub_checkout
+            .repo_root
+            .join(".orbit/adrs/proposed/ADR-0001/adr.yaml")
+            .is_file()
+    );
+    assert!(!spoke_root.path().join(".orbit/adrs").exists());
+}
+
+#[test]
+fn replica_or_other_spoke_owner_is_rejected_before_allocation_or_connection() {
+    let hub_root = tempfile::tempdir().expect("hub root");
+    let spoke_root = tempfile::tempdir().expect("spoke root");
+    setup_hub(hub_root.path());
+    write_identity(spoke_root.path(), "spoke", "hm_spoke", "spoke");
+    let mut checkout = init_owner_checkout(spoke_root.path(), "ws_other");
+    checkout.role = Some(WorkspaceCheckoutRole::Replica);
+    checkout.owner_machine_id = Some("hm_other".to_string());
+    save_workspace_registry(
+        spoke_root.path(),
+        workspace_record("ws_other", "hm_other"),
+        Some(checkout.clone()),
+    );
+    let allocations = Arc::new(Mutex::new(Vec::new()));
+    let tool_calls = Arc::new(Mutex::new(Vec::new()));
+    let connects = Arc::new(Mutex::new(0));
+    let pool = wire_pool(
+        hub_root.path(),
+        Arc::clone(&allocations),
+        Arc::clone(&tool_calls),
+        Arc::clone(&connects),
+    );
+    let broker = BrokerMcpHost::new_with_hub_link(spoke_root.path().to_path_buf(), pool);
+    let selector = checkout.repo_root.to_string_lossy().into_owned();
+
+    let error = broker
+        .preallocated_knowledge_call(
+            "orbit.learning.add",
+            json!({
+                "workspace": selector,
+                "summary": "Must refuse",
+                "scope": {},
+                "model": "codex"
+            }),
+            local_context(&selector, "mcall-replica-denied", "hm_spoke", "spoke"),
+        )
+        .expect_err("replica refusal")
+        .to_string();
+    assert!(error.contains("hm_other"), "{error}");
+    assert!(error.contains("replica"), "{error}");
+    drop(broker);
+    assert!(allocations.lock().expect("allocations").is_empty());
+    assert!(tool_calls.lock().expect("tool calls").is_empty());
+    assert_eq!(*connects.lock().expect("connects"), 0);
+    assert!(!checkout.repo_root.join(".orbit/learnings/L-0001").exists());
+}
+
+#[test]
 fn outcome_unknown_is_not_replayed_and_is_resolved_by_internal_lookup() {
     let hub_root = tempfile::tempdir().expect("hub root");
+    let spoke_root = tempfile::tempdir().expect("spoke root");
     setup_hub(hub_root.path());
+    write_identity(spoke_root.path(), "spoke", "hm_spoke", "spoke");
+    let checkout = init_owner_checkout(spoke_root.path(), "ws_alpha");
+    save_workspace_registry(
+        spoke_root.path(),
+        workspace_record("ws_alpha", "hm_spoke"),
+        Some(checkout.clone()),
+    );
     let calls = Arc::new(Mutex::new(0));
     let pool = HubLinkPool::with_factory(
         "hub-alias".to_string(),
@@ -471,17 +1287,35 @@ fn outcome_unknown_is_not_replayed_and_is_resolved_by_internal_lookup() {
         Arc::new(MonotonicClock::default()) as Arc<dyn HubClock>,
     )
     .expect("link pool");
-    let error = pool
-        .allocate_knowledge_id(
-            McpCapability::Agent,
-            request("ws_alpha", KnowledgeIdKind::Learning),
-            context("ws_alpha", "mcall-lost-allocation"),
+    let broker = BrokerMcpHost::new_with_hub_link(spoke_root.path().to_path_buf(), pool);
+    let selector = checkout.repo_root.to_string_lossy().into_owned();
+    let error = broker
+        .preallocated_knowledge_call(
+            "orbit.learning.add",
+            json!({
+                "workspace": selector,
+                "summary": "Response will be lost",
+                "scope": {},
+                "model": "codex"
+            }),
+            local_context(&selector, "mcall-lost-allocation", "hm_spoke", "spoke"),
         )
         .expect_err("response loss")
         .to_string();
     assert!(error.contains("outcome unknown"), "{error}");
     assert_eq!(*calls.lock().expect("calls"), 1, "link replayed request");
-    drop(pool);
+    assert!(!checkout.repo_root.join(".orbit/learnings/L-0001").exists());
+    let local_db = rusqlite::Connection::open(checkout.orbit_dir.join("state/semantic.db"))
+        .expect("local semantic database");
+    let projection_count: i64 = local_db
+        .query_row(
+            "SELECT COUNT(*) FROM id_allocations WHERE kind = 'learning' AND id = 'L-0001'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("projection count");
+    assert_eq!(projection_count, 0, "response loss finalized locally");
+    drop(broker);
 
     let allocation = HubKnowledgeSequenceService::at(hub_root.path())
         .expect("service")

--- a/crates/orbit-store/src/backend/contracts.rs
+++ b/crates/orbit-store/src/backend/contracts.rs
@@ -402,6 +402,12 @@ pub trait TaskStoreBackend: Send + Sync {
 
 pub trait AdrStoreBackend: Send + Sync {
     fn add_adr(&self, params: AdrCreateParams) -> Result<Adr, OrbitError>;
+    fn finalize_preallocated_adr(
+        &self,
+        id: &str,
+        params: AdrCreateParams,
+    ) -> Result<Adr, OrbitError>;
+    fn rollback_preallocated_adr(&self, id: &str) -> Result<bool, OrbitError>;
     fn get_adr(&self, id: &str) -> Result<Option<Adr>, OrbitError>;
     fn resolve_adr_artifact(&self, id: &str) -> Result<AdrArtifactResolution, OrbitError>;
     fn list_adrs(&self) -> Result<Vec<Adr>, OrbitError>;
@@ -752,6 +758,12 @@ pub struct LearningSearchResult {
 
 pub trait LearningStoreBackend: Send + Sync {
     fn create_learning(&self, params: LearningCreateParams) -> Result<Learning, OrbitError>;
+    fn finalize_preallocated_learning(
+        &self,
+        id: &str,
+        params: LearningCreateParams,
+    ) -> Result<Learning, OrbitError>;
+    fn rollback_preallocated_learning(&self, id: &str) -> Result<bool, OrbitError>;
     fn get_learning(&self, id: &str) -> Result<Option<Learning>, OrbitError>;
     fn get_learning_federated(&self, id: &str) -> Result<Option<Learning>, OrbitError>;
     fn list_learnings(

--- a/crates/orbit-store/src/backend/file_backends/mod.rs
+++ b/crates/orbit-store/src/backend/file_backends/mod.rs
@@ -190,6 +190,18 @@ impl AdrStoreBackend for AdrFileStore {
         self.add_adr(params)
     }
 
+    fn finalize_preallocated_adr(
+        &self,
+        id: &str,
+        params: AdrCreateParams,
+    ) -> Result<Adr, OrbitError> {
+        self.finalize_preallocated_adr(id, params)
+    }
+
+    fn rollback_preallocated_adr(&self, id: &str) -> Result<bool, OrbitError> {
+        self.rollback_preallocated_adr(id)
+    }
+
     fn get_adr(&self, id: &str) -> Result<Option<Adr>, OrbitError> {
         // ADRs use the WorkspaceOnly strategy per `CLAUDE.md`.
         resolve::<Adr, _>(self, id)
@@ -247,6 +259,18 @@ impl AdrStoreBackend for AdrFileStore {
 impl LearningStoreBackend for LearningFileStore {
     fn create_learning(&self, params: LearningCreateParams) -> Result<Learning, OrbitError> {
         self.create_learning(params)
+    }
+
+    fn finalize_preallocated_learning(
+        &self,
+        id: &str,
+        params: LearningCreateParams,
+    ) -> Result<Learning, OrbitError> {
+        self.finalize_preallocated_learning(id, params)
+    }
+
+    fn rollback_preallocated_learning(&self, id: &str) -> Result<bool, OrbitError> {
+        self.rollback_preallocated_learning(id)
     }
 
     fn get_learning(&self, id: &str) -> Result<Option<Learning>, OrbitError> {

--- a/crates/orbit-store/src/file/adr_store/api/mod.rs
+++ b/crates/orbit-store/src/file/adr_store/api/mod.rs
@@ -14,7 +14,10 @@ use orbit_common::utility::glob::{compile_glob_regex, normalize_glob_path};
 use orbit_common::utility::redaction::credential_safe_location;
 use rusqlite::params;
 
-use super::bundle::{AdrBundle, bundle_to_adr, read_bundle_at, validate_bundle, write_bundle_at};
+use super::bundle::{
+    AdrBundle, bundle_to_adr, create_bundle_exclusive, read_bundle_at, validate_bundle,
+    write_bundle_at,
+};
 use super::constants::ADR_SCHEMA_VERSION;
 use super::doc::AdrFileDocument;
 use super::layout::{AdrStateDir, adr_dir, state_dir_path, validate_adr_id};
@@ -72,45 +75,8 @@ impl AdrFileStore {
     /// back the filesystem: the filesystem is the source of truth and the index
     /// can be rebuilt from it.
     pub(crate) fn add_adr(&self, params: AdrCreateParams) -> Result<Adr, OrbitError> {
-        if params.title.trim().is_empty() {
-            return Err(OrbitError::InvalidInput(
-                "ADR title must not be empty".to_string(),
-            ));
-        }
-        if params.owner.trim().is_empty() {
-            return Err(OrbitError::InvalidInput(
-                "ADR owner must not be empty".to_string(),
-            ));
-        }
-
         let id = self.id_allocator.allocate_adr()?.id;
-        let now = Utc::now();
-        let adr = Adr {
-            id: id.clone(),
-            title: params.title,
-            status: AdrStatus::Proposed,
-            owner: params.owner,
-            created_at: now,
-            accepted_at: None,
-            last_updated: now,
-            related_features: params.related_features,
-            related_tasks: params.related_tasks,
-            tags: normalize_adr_tags(params.tags),
-            paths: normalize_adr_paths(params.paths),
-            supersedes: Vec::new(),
-            superseded_by: None,
-            legacy_ids: Vec::new(),
-            validation_warnings: Vec::new(),
-            legacy_validation: LegacyValidation::None,
-        };
-        let bundle = AdrBundle {
-            doc: AdrFileDocument {
-                schema_version: ADR_SCHEMA_VERSION,
-                adr,
-            },
-            body: params.body,
-        };
-        validate_bundle(&bundle)?;
+        let bundle = new_adr_bundle(id.clone(), params, Utc::now())?;
 
         let target_dir = adr_dir(&self.root, AdrStateDir::Proposed, &id);
         if let Err(error) = write_bundle_at(&target_dir, &bundle) {
@@ -128,6 +94,77 @@ impl AdrFileStore {
         let adr = bundle_to_adr(bundle);
         self.upsert_index_row(&adr);
         Ok(adr)
+    }
+
+    /// Finalize one caller-supplied hub allocation in this store's already
+    /// bound checkout. This path never selects, abandons, adopts, retries, or
+    /// replaces an ID.
+    pub(crate) fn finalize_preallocated_adr(
+        &self,
+        id: &str,
+        params: AdrCreateParams,
+    ) -> Result<Adr, OrbitError> {
+        let bundle = new_adr_bundle(id.to_string(), params, Utc::now())?;
+        let _lock = acquire_adr_lock(&self.root, id)?;
+        if self.locate_adr(id)?.is_some() {
+            return Err(preallocated_adr_collision(id));
+        }
+
+        let target_dir = adr_dir(&self.root, AdrStateDir::Proposed, id);
+        if !create_bundle_exclusive(&target_dir, &bundle)? {
+            return Err(preallocated_adr_collision(id));
+        }
+        let body_path = super::layout::body_path(&target_dir);
+        if let Err(error) = self
+            .id_allocator
+            .install_preallocated_adr_projection(id, &body_path)
+        {
+            let _ = fs::remove_dir_all(&target_dir);
+            return Err(OrbitError::Store(format!(
+                "finalize preallocated ADR {id}: {error}"
+            )));
+        }
+        if let Err(error) = self.upsert_index_row_strict(&bundle.doc.adr) {
+            let cleanup = self.cleanup_preallocated_adr(id, &target_dir);
+            return match cleanup {
+                Ok(()) => Err(error),
+                Err(cleanup_error) => Err(OrbitError::Store(format!(
+                    "finalize preallocated ADR {id} failed: {error}; cleanup failed: {cleanup_error}"
+                ))),
+            };
+        }
+        Ok(bundle_to_adr(bundle))
+    }
+
+    /// Remove a just-finalized preallocated ADR when a later composition step
+    /// fails. Compatibility rows and ordinary ADRs are never eligible.
+    pub(crate) fn rollback_preallocated_adr(&self, id: &str) -> Result<bool, OrbitError> {
+        validate_adr_id(id)?;
+        let _lock = acquire_adr_lock(&self.root, id)?;
+        let Some(record) = self.id_allocator.adr_allocation(id)? else {
+            return Ok(false);
+        };
+        if !record.is_projection || record.worktree_root != self.id_allocator.worktree_root() {
+            return Err(OrbitError::Store(format!(
+                "refusing to roll back non-projection ADR {id}"
+            )));
+        }
+        let target_dir = adr_dir(&self.root, AdrStateDir::Proposed, id);
+        self.cleanup_preallocated_adr(id, &target_dir)?;
+        Ok(true)
+    }
+
+    fn cleanup_preallocated_adr(&self, id: &str, target_dir: &Path) -> Result<(), OrbitError> {
+        self.delete_index_row_strict(id)?;
+        if target_dir.exists() {
+            fs::remove_dir_all(target_dir).map_err(|error| OrbitError::Io(error.to_string()))?;
+        }
+        if !self.id_allocator.remove_preallocated_adr_projection(id)? {
+            return Err(OrbitError::Store(format!(
+                "owner-local ADR projection missing during cleanup for {id}"
+            )));
+        }
+        Ok(())
     }
 
     /// [ORB-00413] Best-effort rollback of a partially-created ADR: remove the
@@ -623,17 +660,7 @@ impl AdrFileStore {
     }
 
     fn upsert_index_row(&self, adr: &Adr) {
-        let Some(index) = &self.index else {
-            return;
-        };
-        let result = index.with_transaction(|tx| {
-            tx.tx
-                .execute("DELETE FROM adrs WHERE id = ?1", params![adr.id])
-                .map_err(|e| OrbitError::Store(e.to_string()))?;
-            insert_adr_row(&tx.tx, adr)?;
-            Ok(())
-        });
-        if let Err(err) = result {
+        if let Err(err) = self.upsert_index_row_strict(adr) {
             orbit_common::tracing::warn!(
                 target: "orbit.store.adr",
                 adr_id = adr.id.as_str(),
@@ -643,17 +670,21 @@ impl AdrFileStore {
         }
     }
 
-    fn delete_index_row(&self, id: &str) {
+    fn upsert_index_row_strict(&self, adr: &Adr) -> Result<(), OrbitError> {
         let Some(index) = &self.index else {
-            return;
+            return Ok(());
         };
-        let result = index.with_transaction(|tx| {
+        index.with_transaction(|tx| {
             tx.tx
-                .execute("DELETE FROM adrs WHERE id = ?1", params![id])
+                .execute("DELETE FROM adrs WHERE id = ?1", params![adr.id])
                 .map_err(|e| OrbitError::Store(e.to_string()))?;
+            insert_adr_row(&tx.tx, adr)?;
             Ok(())
-        });
-        if let Err(err) = result {
+        })
+    }
+
+    fn delete_index_row(&self, id: &str) {
+        if let Err(err) = self.delete_index_row_strict(id) {
             orbit_common::tracing::warn!(
                 target: "orbit.store.adr",
                 adr_id = id,
@@ -661,6 +692,18 @@ impl AdrFileStore {
                 "failed to delete ADR envelope from index; filesystem is source of truth",
             );
         }
+    }
+
+    fn delete_index_row_strict(&self, id: &str) -> Result<(), OrbitError> {
+        let Some(index) = &self.index else {
+            return Ok(());
+        };
+        index.with_transaction(|tx| {
+            tx.tx
+                .execute("DELETE FROM adrs WHERE id = ?1", params![id])
+                .map_err(|e| OrbitError::Store(e.to_string()))?;
+            Ok(())
+        })
     }
 
     fn query_filtered_ids(&self, filter: AdrListFilter<'_>) -> Result<Vec<String>, OrbitError> {
@@ -724,6 +767,55 @@ impl AdrFileStore {
         }
         Ok(ids)
     }
+}
+
+fn new_adr_bundle(
+    id: String,
+    params: AdrCreateParams,
+    now: chrono::DateTime<Utc>,
+) -> Result<AdrBundle, OrbitError> {
+    if params.title.trim().is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "ADR title must not be empty".to_string(),
+        ));
+    }
+    if params.owner.trim().is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "ADR owner must not be empty".to_string(),
+        ));
+    }
+    let bundle = AdrBundle {
+        doc: AdrFileDocument {
+            schema_version: ADR_SCHEMA_VERSION,
+            adr: Adr {
+                id,
+                title: params.title,
+                status: AdrStatus::Proposed,
+                owner: params.owner,
+                created_at: now,
+                accepted_at: None,
+                last_updated: now,
+                related_features: params.related_features,
+                related_tasks: params.related_tasks,
+                tags: normalize_adr_tags(params.tags),
+                paths: normalize_adr_paths(params.paths),
+                supersedes: Vec::new(),
+                superseded_by: None,
+                legacy_ids: Vec::new(),
+                validation_warnings: Vec::new(),
+                legacy_validation: LegacyValidation::None,
+            },
+        },
+        body: params.body,
+    };
+    validate_bundle(&bundle)?;
+    Ok(bundle)
+}
+
+fn preallocated_adr_collision(id: &str) -> OrbitError {
+    OrbitError::Store(format!(
+        "preallocated ADR {id} already has an owner-local artifact or allocation projection; refusing overwrite, adoption, or replacement ID"
+    ))
 }
 
 fn read_complete_bundle(dir: &Path, expected_id: &str) -> Result<AdrBundle, OrbitError> {

--- a/crates/orbit-store/src/file/adr_store/api/tests/api.rs
+++ b/crates/orbit-store/src/file/adr_store/api/tests/api.rs
@@ -393,6 +393,133 @@ fn add_adr_twice_allocates_sequential_ids() {
 }
 
 #[test]
+fn finalize_preallocated_adr_installs_projection_without_advancing_allocator() {
+    let (_dir, store) = store_with_index();
+    let adr = store
+        .finalize_preallocated_adr("ADR-9000", create_params("Hub ID", "Body"))
+        .expect("finalize supplied ID");
+
+    assert_eq!(adr.id, "ADR-9000");
+    let projection = store
+        .id_allocator
+        .adr_allocation(&adr.id)
+        .expect("projection lookup")
+        .expect("projection exists");
+    assert!(projection.is_projection);
+    assert_eq!(count_index_rows(&store), 1);
+    assert_eq!(
+        store
+            .list_adr_entries_filtered(AdrListFilter::default(), false)
+            .expect("list")
+            .len(),
+        1
+    );
+
+    store
+        .update_adr_status(&adr.id, AdrStatus::Accepted)
+        .expect("lifecycle uses projection");
+    let compatibility = store
+        .add_adr(create_params("Compatibility", "Body"))
+        .expect("compatibility allocation");
+    assert_eq!(compatibility.id, "ADR-0001");
+}
+
+#[test]
+fn finalize_preallocated_adr_collision_preserves_original_without_replacement() {
+    let (_dir, store) = store_with_index();
+    let original = store
+        .finalize_preallocated_adr("ADR-7000", create_params("Original", "Original body"))
+        .expect("original");
+    let original_dir = store.root.join("proposed").join(&original.id);
+    let before = (
+        fs::read(original_dir.join("adr.yaml")).expect("original yaml"),
+        fs::read(original_dir.join("body.md")).expect("original body"),
+    );
+
+    let error = store
+        .finalize_preallocated_adr("ADR-7000", create_params("Replacement", "Replacement body"))
+        .expect_err("collision")
+        .to_string();
+    assert!(error.contains("refusing overwrite"), "{error}");
+    assert_eq!(
+        (
+            fs::read(original_dir.join("adr.yaml")).expect("unchanged yaml"),
+            fs::read(original_dir.join("body.md")).expect("unchanged body"),
+        ),
+        before
+    );
+    assert_eq!(store.id_allocator.adr_allocations().expect("rows").len(), 1);
+    assert_eq!(
+        store.id_allocator.allocate_adr().expect("next").id,
+        "ADR-0001"
+    );
+}
+
+#[test]
+fn finalize_preallocated_adr_index_failure_removes_body_projection_and_index() {
+    let (dir, store) = store_with_index();
+    let index = store.index.as_ref().expect("index");
+    index
+        .connection()
+        .lock()
+        .expect("lock")
+        .execute_batch(
+            "CREATE TRIGGER fail_preallocated_adr_index
+             BEFORE INSERT ON adrs WHEN NEW.id = 'ADR-6000'
+             BEGIN SELECT RAISE(ABORT, 'injected ADR index failure'); END;",
+        )
+        .expect("failure trigger");
+
+    let error = store
+        .finalize_preallocated_adr("ADR-6000", create_params("Fails", "Body"))
+        .expect_err("injected failure")
+        .to_string();
+    assert!(error.contains("injected ADR index failure"), "{error}");
+    assert!(!dir.path().join("proposed/ADR-6000").exists());
+    assert!(
+        store
+            .id_allocator
+            .adr_allocation("ADR-6000")
+            .expect("projection lookup")
+            .is_none()
+    );
+    assert_eq!(count_index_rows(&store), 0);
+    assert_eq!(
+        store.id_allocator.allocate_adr().expect("next").id,
+        "ADR-0001"
+    );
+}
+
+#[test]
+fn preallocated_adr_finalizes_only_in_selected_worktree_store() {
+    let fixture = TwoWorktreeFixture::new();
+    let adr = fixture
+        .local
+        .finalize_preallocated_adr("ADR-5000", create_params("Selected", "Local only"))
+        .expect("local finalization");
+
+    assert!(
+        fixture
+            .local_root
+            .join(".orbit/adrs/proposed/ADR-5000/adr.yaml")
+            .is_file()
+    );
+    assert!(
+        !fixture
+            .sibling_root
+            .join(".orbit/adrs/proposed/ADR-5000")
+            .exists()
+    );
+    assert!(
+        fixture
+            .sibling
+            .get_adr(&adr.id)
+            .expect("sibling read")
+            .is_none()
+    );
+}
+
+#[test]
 fn update_adr_status_proposed_to_accepted_moves_dir_and_sets_accepted_at() {
     let tempdir = tempdir().expect("tempdir");
     let store = AdrFileStore::new(tempdir.path().to_path_buf());

--- a/crates/orbit-store/src/file/adr_store/bundle/mod.rs
+++ b/crates/orbit-store/src/file/adr_store/bundle/mod.rs
@@ -23,6 +23,34 @@ pub(super) fn write_bundle_at(adr_dir: &Path, bundle: &AdrBundle) -> Result<(), 
     Ok(())
 }
 
+/// Create a complete ADR bundle without adopting or clobbering an existing
+/// supplied-ID directory. The directory creation is the exclusive publish
+/// boundary; any later write failure removes only the directory created by
+/// this call.
+pub(super) fn create_bundle_exclusive(
+    adr_dir: &Path,
+    bundle: &AdrBundle,
+) -> Result<bool, OrbitError> {
+    validate_bundle(bundle)?;
+    let parent = adr_dir.parent().ok_or_else(|| {
+        OrbitError::Store(format!(
+            "cannot determine ADR state directory for '{}'",
+            adr_dir.display()
+        ))
+    })?;
+    fs::create_dir_all(parent).map_err(|error| OrbitError::Io(error.to_string()))?;
+    match fs::create_dir(adr_dir) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => return Ok(false),
+        Err(error) => return Err(OrbitError::Io(error.to_string())),
+    }
+    if let Err(error) = write_bundle_at(adr_dir, bundle) {
+        let _ = fs::remove_dir_all(adr_dir);
+        return Err(error);
+    }
+    Ok(true)
+}
+
 pub(super) fn read_bundle_at(adr_dir: &Path) -> Result<AdrBundle, OrbitError> {
     let doc_path = adr_doc_path(adr_dir);
     if !doc_path.exists() {

--- a/crates/orbit-store/src/file/learning_store/api/crud.rs
+++ b/crates/orbit-store/src/file/learning_store/api/crud.rs
@@ -30,39 +30,11 @@ impl LearningFileStore {
         params: LearningCreateParams,
         now: DateTime<Utc>,
     ) -> Result<Learning, OrbitError> {
-        if params.summary.trim().is_empty() {
-            return Err(OrbitError::InvalidInput(
-                "learning summary must not be empty".to_string(),
-            ));
-        }
-        if params.summary.chars().count() > 280 {
-            return Err(OrbitError::InvalidInput(format!(
-                "learning summary must be at most 280 characters (got {})",
-                params.summary.chars().count()
-            )));
-        }
-
-        let mut scope = params.scope;
-        scope.paths = normalize_learning_paths(scope.paths);
-        scope.tags = normalize_learning_tags(scope.tags);
+        let params = normalize_learning_create_params(params)?;
 
         loop {
             let id = self.id_allocator.allocate_learning()?.id;
-            let learning = Learning {
-                id: id.clone(),
-                status: LearningStatus::Active,
-                scope: scope.clone(),
-                summary: params.summary.clone(),
-                body: params.body.clone(),
-                evidence: params.evidence.clone(),
-                supersedes: None,
-                superseded_by: None,
-                legacy_ids: Vec::new(),
-                created_at: now,
-                updated_at: now,
-                created_by: params.created_by.clone(),
-                priority: params.priority,
-            };
+            let learning = new_learning(id.clone(), &params, now);
 
             let path = learning_doc_path(&self.root, &id);
 
@@ -97,6 +69,82 @@ impl LearningFileStore {
                 }
             }
         }
+    }
+
+    /// Finalize exactly one learning ID allocated by the hub in this store's
+    /// already-bound checkout. Supplied-ID collisions are deterministic
+    /// failures; this path never adopts, abandons, retries, or allocates.
+    pub(crate) fn finalize_preallocated_learning(
+        &self,
+        id: &str,
+        params: LearningCreateParams,
+    ) -> Result<Learning, OrbitError> {
+        validate_learning_id(id)?;
+        let params = normalize_learning_create_params(params)?;
+        let learning = new_learning(id.to_string(), &params, Utc::now());
+        let _lock = super::super::lock::acquire_learning_lock(&self.root, id)?;
+        let path = learning_doc_path(&self.root, id);
+        if path.exists() || self.id_allocator.learning_allocation(id)?.is_some() {
+            return Err(preallocated_learning_collision(id));
+        }
+        if !create_learning_file_exclusive(&path, &learning, LearningStatus::Active)? {
+            return Err(preallocated_learning_collision(id));
+        }
+        if let Err(error) = self
+            .id_allocator
+            .install_preallocated_learning_projection(id, &path)
+        {
+            remove_learning_body(&path);
+            return Err(OrbitError::Store(format!(
+                "finalize preallocated learning {id}: {error}"
+            )));
+        }
+        if let Err(error) = self.upsert_index_row_strict(&learning) {
+            let cleanup = self.cleanup_preallocated_learning(id, &path);
+            return match cleanup {
+                Ok(()) => Err(error),
+                Err(cleanup_error) => Err(OrbitError::Store(format!(
+                    "finalize preallocated learning {id} failed: {error}; cleanup failed: {cleanup_error}"
+                ))),
+            };
+        }
+        self.invalidate_envelope_cache();
+        Ok(learning)
+    }
+
+    pub(crate) fn rollback_preallocated_learning(&self, id: &str) -> Result<bool, OrbitError> {
+        validate_learning_id(id)?;
+        let _lock = super::super::lock::acquire_learning_lock(&self.root, id)?;
+        let Some(record) = self.id_allocator.learning_allocation(id)? else {
+            return Ok(false);
+        };
+        if !record.is_projection || record.worktree_root != self.id_allocator.worktree_root() {
+            return Err(OrbitError::Store(format!(
+                "refusing to roll back non-projection learning {id}"
+            )));
+        }
+        let path = learning_doc_path(&self.root, id);
+        self.cleanup_preallocated_learning(id, &path)?;
+        Ok(true)
+    }
+
+    fn cleanup_preallocated_learning(
+        &self,
+        id: &str,
+        path: &std::path::Path,
+    ) -> Result<(), OrbitError> {
+        self.delete_index_row_strict(id)?;
+        remove_learning_body(path);
+        if !self
+            .id_allocator
+            .remove_preallocated_learning_projection(id)?
+        {
+            return Err(OrbitError::Store(format!(
+                "owner-local learning projection missing during cleanup for {id}"
+            )));
+        }
+        self.invalidate_envelope_cache();
+        Ok(())
     }
 
     /// Finalize a freshly-created learning body: write its empty sidecars,
@@ -341,6 +389,56 @@ impl LearningFileStore {
         self.upsert_index_row(&existing);
         self.invalidate_envelope_cache();
         Ok(())
+    }
+}
+
+fn normalize_learning_create_params(
+    mut params: LearningCreateParams,
+) -> Result<LearningCreateParams, OrbitError> {
+    if params.summary.trim().is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "learning summary must not be empty".to_string(),
+        ));
+    }
+    if params.summary.chars().count() > 280 {
+        return Err(OrbitError::InvalidInput(format!(
+            "learning summary must be at most 280 characters (got {})",
+            params.summary.chars().count()
+        )));
+    }
+    params.scope.paths = normalize_learning_paths(params.scope.paths);
+    params.scope.tags = normalize_learning_tags(params.scope.tags);
+    Ok(params)
+}
+
+fn new_learning(id: String, params: &LearningCreateParams, now: DateTime<Utc>) -> Learning {
+    Learning {
+        id,
+        status: LearningStatus::Active,
+        scope: params.scope.clone(),
+        summary: params.summary.clone(),
+        body: params.body.clone(),
+        evidence: params.evidence.clone(),
+        supersedes: None,
+        superseded_by: None,
+        legacy_ids: Vec::new(),
+        created_at: now,
+        updated_at: now,
+        created_by: params.created_by.clone(),
+        priority: params.priority,
+    }
+}
+
+fn preallocated_learning_collision(id: &str) -> OrbitError {
+    OrbitError::Store(format!(
+        "preallocated learning {id} already has an owner-local artifact or allocation projection; refusing overwrite, adoption, or replacement ID"
+    ))
+}
+
+fn remove_learning_body(path: &std::path::Path) {
+    let _ = std::fs::remove_file(path);
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::remove_dir(dir);
     }
 }
 

--- a/crates/orbit-store/src/file/learning_store/api/search_index.rs
+++ b/crates/orbit-store/src/file/learning_store/api/search_index.rs
@@ -281,10 +281,7 @@ impl LearningFileStore {
     }
 
     pub(super) fn upsert_index_row(&self, learning: &Learning) {
-        let Some(index) = &self.index else {
-            return;
-        };
-        if let Err(err) = index.upsert_learning_index_row(&self.workspace_id, learning) {
+        if let Err(err) = self.upsert_index_row_strict(learning) {
             orbit_common::tracing::warn!(
                 target: "orbit.store.learning",
                 learning_id = learning.id.as_str(),
@@ -292,6 +289,20 @@ impl LearningFileStore {
                 "failed to upsert learning envelope into index; filesystem is source of truth",
             );
         }
+    }
+
+    pub(super) fn upsert_index_row_strict(&self, learning: &Learning) -> Result<(), OrbitError> {
+        let Some(index) = &self.index else {
+            return Ok(());
+        };
+        index.upsert_learning_index_row(&self.workspace_id, learning)
+    }
+
+    pub(super) fn delete_index_row_strict(&self, id: &str) -> Result<(), OrbitError> {
+        let Some(index) = &self.index else {
+            return Ok(());
+        };
+        index.delete_learning_index_row(&self.workspace_id, id)
     }
 }
 

--- a/crates/orbit-store/src/file/learning_store/api/tests/crud.rs
+++ b/crates/orbit-store/src/file/learning_store/api/tests/crud.rs
@@ -136,6 +136,117 @@ fn id_format_increments_within_a_day() {
 }
 
 #[test]
+fn finalize_preallocated_learning_installs_projection_without_advancing_allocator() {
+    let (_dir, store) = store_with_index();
+    let learning = store
+        .finalize_preallocated_learning(
+            "L-9000",
+            create_params("Hub supplied", vec!["src/**"], vec!["knowledge"]),
+        )
+        .expect("finalize supplied ID");
+
+    assert_eq!(learning.id, "L-9000");
+    let projection = store
+        .id_allocator
+        .learning_allocation(&learning.id)
+        .expect("projection lookup")
+        .expect("projection exists");
+    assert!(projection.is_projection);
+    assert_eq!(store.list_learnings(None).expect("list"), vec![learning]);
+    let updated = store
+        .update_learning(
+            "L-9000",
+            LearningUpdateParams {
+                body: Some("updated through the normal lifecycle".to_string()),
+                ..LearningUpdateParams::default()
+            },
+        )
+        .expect("update projected learning");
+    assert_eq!(updated.body, "updated through the normal lifecycle");
+
+    let compatibility = store
+        .create_learning(create_params("Compatibility", vec![], vec![]))
+        .expect("compatibility allocation");
+    assert_eq!(compatibility.id, "L-0001");
+}
+
+#[test]
+fn finalize_preallocated_learning_collision_preserves_original_without_replacement() {
+    let (dir, store) = store_with_index();
+    store
+        .finalize_preallocated_learning(
+            "L-7000",
+            create_params("Original", vec!["src/**"], vec!["original"]),
+        )
+        .expect("original");
+    let path = dir.path().join("L-7000/learning.yaml");
+    let before = std::fs::read(&path).expect("original bytes");
+
+    let error = store
+        .finalize_preallocated_learning("L-7000", create_params("Replacement", vec![], vec![]))
+        .expect_err("collision")
+        .to_string();
+    assert!(error.contains("refusing overwrite"), "{error}");
+    assert_eq!(std::fs::read(&path).expect("unchanged bytes"), before);
+    assert_eq!(
+        store
+            .id_allocator
+            .learning_allocations()
+            .expect("rows")
+            .len(),
+        1
+    );
+    assert_eq!(
+        store.id_allocator.allocate_learning().expect("next").id,
+        "L-0001"
+    );
+}
+
+#[test]
+fn finalize_preallocated_learning_index_failure_removes_all_local_visibility() {
+    let (dir, store) = store_with_index();
+    let index = store.index.as_ref().expect("index");
+    index
+        .connection()
+        .lock()
+        .expect("lock")
+        .execute_batch(
+            "CREATE TRIGGER fail_preallocated_learning_index
+             BEFORE INSERT ON learnings_index WHEN NEW.id = 'L-6000'
+             BEGIN SELECT RAISE(ABORT, 'injected learning index failure'); END;",
+        )
+        .expect("failure trigger");
+
+    let error = store
+        .finalize_preallocated_learning(
+            "L-6000",
+            create_params("Fails", vec!["src/**"], vec!["failure"]),
+        )
+        .expect_err("injected failure")
+        .to_string();
+    assert!(error.contains("injected learning index failure"), "{error}");
+    assert!(!dir.path().join("L-6000").exists());
+    assert!(
+        store
+            .id_allocator
+            .learning_allocation("L-6000")
+            .expect("projection lookup")
+            .is_none()
+    );
+    assert!(store.get_learning("L-6000").expect("get").is_none());
+    assert!(
+        store
+            .search_learnings(LearningSearchParams::default())
+            .expect("search")
+            .is_empty()
+    );
+    assert_eq!(
+        store.id_allocator.allocate_learning().expect("next").id,
+        "L-0001"
+    );
+}
+
+#[test]
 fn create_learning_retries_after_adopting_existing_local_path_collision() {
     let dir = tempdir().expect("tempdir");
     let store = LearningFileStore::new(dir.path().to_path_buf());

--- a/crates/orbit-store/src/sqlite/id_allocator/mod.rs
+++ b/crates/orbit-store/src/sqlite/id_allocator/mod.rs
@@ -49,6 +49,11 @@ pub struct IdAllocationRecord {
     pub branch: Option<String>,
     pub status: String,
     pub body_path: Option<PathBuf>,
+    /// True for an owner-local visibility projection of an ID allocated by
+    /// the singular hub. Projection rows never participate in compatibility
+    /// ID selection and are removable only through the preallocated cleanup
+    /// path.
+    pub is_projection: bool,
 }
 
 impl IdAllocationRecord {
@@ -194,6 +199,30 @@ impl IdAllocator {
 
     pub fn record_learning_body_path(&self, id: &str, body_path: &Path) -> Result<(), OrbitError> {
         self.record_body_path(IdAllocationKind::Learning, id, body_path)
+    }
+
+    pub fn install_preallocated_adr_projection(
+        &self,
+        id: &str,
+        body_path: &Path,
+    ) -> Result<(), OrbitError> {
+        self.install_preallocated_projection(IdAllocationKind::Adr, id, body_path)
+    }
+
+    pub fn install_preallocated_learning_projection(
+        &self,
+        id: &str,
+        body_path: &Path,
+    ) -> Result<(), OrbitError> {
+        self.install_preallocated_projection(IdAllocationKind::Learning, id, body_path)
+    }
+
+    pub fn remove_preallocated_adr_projection(&self, id: &str) -> Result<bool, OrbitError> {
+        self.remove_preallocated_projection(IdAllocationKind::Adr, id)
+    }
+
+    pub fn remove_preallocated_learning_projection(&self, id: &str) -> Result<bool, OrbitError> {
+        self.remove_preallocated_projection(IdAllocationKind::Learning, id)
     }
 
     pub fn abandon_learning(&self, id: &str) -> Result<(), OrbitError> {
@@ -480,6 +509,80 @@ impl IdAllocator {
         Ok(())
     }
 
+    /// Install the owner-local lookup projection for an ID already allocated
+    /// by the hub. This deliberately does not call `allocate`, inspect a
+    /// sequence, or mutate a compatibility reservation.
+    fn install_preallocated_projection(
+        &self,
+        kind: IdAllocationKind,
+        id: &str,
+        body_path: &Path,
+    ) -> Result<(), OrbitError> {
+        let valid = match kind {
+            IdAllocationKind::Adr => parse_adr_sequence(id).is_some(),
+            IdAllocationKind::Learning => parse_learning_sequence(id).is_some(),
+        };
+        if !valid {
+            return Err(OrbitError::InvalidInput(format!(
+                "invalid preallocated {} id '{id}'",
+                kind.as_str()
+            )));
+        }
+
+        let relative_body_path = relative_to(body_path, &self.inner.worktree_root);
+        let branch = best_effort_branch(&self.inner.worktree_root);
+        let _lock = self.acquire_lock()?;
+        let mut conn = self.lock_conn()?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        tx.execute(
+            "INSERT INTO id_allocations(
+                kind, id, allocated_at, worktree_root, branch, status, body_path, is_projection
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 1)",
+            params![
+                kind.as_str(),
+                id,
+                Utc::now().timestamp(),
+                self.inner.worktree_root.to_string_lossy(),
+                branch,
+                STATUS_MERGED,
+                relative_body_path.to_string_lossy(),
+            ],
+        )
+        .map_err(|error| {
+            OrbitError::Store(format!(
+                "install owner-local projection for {} {id}: {error}",
+                kind.as_str()
+            ))
+        })?;
+        tx.commit()
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        Ok(())
+    }
+
+    fn remove_preallocated_projection(
+        &self,
+        kind: IdAllocationKind,
+        id: &str,
+    ) -> Result<bool, OrbitError> {
+        let _lock = self.acquire_lock()?;
+        let mut conn = self.lock_conn()?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let removed = tx
+            .execute(
+                "DELETE FROM id_allocations
+                 WHERE kind = ?1 AND id = ?2 AND is_projection = 1",
+                params![kind.as_str(), id],
+            )
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        tx.commit()
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        Ok(removed == 1)
+    }
+
     fn abandon(&self, kind: IdAllocationKind, id: &str) -> Result<(), OrbitError> {
         let _lock = self.acquire_lock()?;
         let mut conn = self.lock_conn()?;
@@ -516,7 +619,8 @@ impl IdAllocator {
         let conn = self.lock_conn()?;
         let mut stmt = conn
             .prepare(
-                "SELECT kind, id, allocated_at, worktree_root, branch, status, body_path
+                "SELECT kind, id, allocated_at, worktree_root, branch, status, body_path,
+                        is_projection
                  FROM id_allocations
                  WHERE kind = ?1 AND id = ?2 AND status != ?3",
             )
@@ -539,7 +643,8 @@ impl IdAllocator {
         let conn = self.lock_conn()?;
         let mut stmt = conn
             .prepare(
-                "SELECT kind, id, allocated_at, worktree_root, branch, status, body_path
+                "SELECT kind, id, allocated_at, worktree_root, branch, status, body_path,
+                        is_projection
                  FROM id_allocations
                  WHERE kind = ?1 AND status != ?2
                  ORDER BY id DESC",
@@ -584,6 +689,7 @@ pub fn ensure_id_allocation_schema(conn: &Connection) -> Result<(), OrbitError> 
                 branch TEXT,
                 status TEXT NOT NULL,
                 body_path TEXT,
+                is_projection INTEGER NOT NULL DEFAULT 0 CHECK (is_projection IN (0, 1)),
                 PRIMARY KEY (kind, id),
                 CHECK (kind IN ('adr', 'learning')),
                 CHECK (status IN ('reserved', 'merged', 'abandoned'))
@@ -598,6 +704,12 @@ pub fn ensure_id_allocation_schema(conn: &Connection) -> Result<(), OrbitError> 
     )
     .map_err(|error| OrbitError::Store(error.to_string()))?;
     add_column_if_missing(conn, "id_allocations", "body_path", "TEXT")?;
+    add_column_if_missing(
+        conn,
+        "id_allocations",
+        "is_projection",
+        "INTEGER NOT NULL DEFAULT 0 CHECK (is_projection IN (0, 1))",
+    )?;
     Ok(())
 }
 
@@ -613,7 +725,7 @@ fn next_id_for_kind(tx: &Transaction<'_>, kind: IdAllocationKind) -> Result<Stri
 
 fn max_sequence(tx: &Transaction<'_>, kind: IdAllocationKind) -> Result<u32, OrbitError> {
     let mut stmt = tx
-        .prepare("SELECT id FROM id_allocations WHERE kind = ?1")
+        .prepare("SELECT id FROM id_allocations WHERE kind = ?1 AND is_projection = 0")
         .map_err(|error| OrbitError::Store(error.to_string()))?;
     let rows = stmt
         .query_map([kind.as_str()], |row| row.get::<_, String>(0))
@@ -752,6 +864,7 @@ fn allocation_record_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<IdAll
         branch: row.get(4)?,
         status: row.get(5)?,
         body_path: body_path.map(PathBuf::from),
+        is_projection: row.get::<_, i64>(7)? != 0,
     })
 }
 

--- a/crates/orbit-store/src/sqlite/id_allocator/tests/id_allocator.rs
+++ b/crates/orbit-store/src/sqlite/id_allocator/tests/id_allocator.rs
@@ -26,6 +26,7 @@ fn schema_is_idempotent_for_preexisting_semantic_db() {
         .expect("table exists");
     assert_eq!(exists, 1);
     assert!(id_allocations_has_column(&conn, "body_path"));
+    assert!(id_allocations_has_column(&conn, "is_projection"));
 }
 
 #[test]
@@ -96,6 +97,69 @@ fn allocates_dense_adr_and_learning_ids() {
     assert_eq!(
         allocator.allocate_learning().expect("learning").id,
         "L-0002"
+    );
+}
+
+#[test]
+fn preallocated_projection_is_visible_without_advancing_compatibility_sequences() {
+    let temp = TempDir::new().expect("tempdir");
+    let allocator = IdAllocator::open(allocator_config(temp.path())).expect("allocator");
+    let adr_body = temp.path().join(".orbit/adrs/proposed/ADR-9000/body.md");
+    let learning_body = temp.path().join(".orbit/learnings/L-8000/learning.yaml");
+
+    allocator
+        .install_preallocated_adr_projection("ADR-9000", &adr_body)
+        .expect("ADR projection");
+    allocator
+        .install_preallocated_learning_projection("L-8000", &learning_body)
+        .expect("learning projection");
+
+    let adr = allocator
+        .adr_allocation("ADR-9000")
+        .expect("ADR lookup")
+        .expect("ADR projection row");
+    let learning = allocator
+        .learning_allocation("L-8000")
+        .expect("learning lookup")
+        .expect("learning projection row");
+    assert!(adr.is_projection);
+    assert!(learning.is_projection);
+    assert_eq!(
+        adr.resolved_body_path().as_deref(),
+        Some(adr_body.as_path())
+    );
+    assert_eq!(
+        learning.resolved_body_path().as_deref(),
+        Some(learning_body.as_path())
+    );
+
+    assert_eq!(allocator.allocate_adr().expect("compat ADR").id, "ADR-0001");
+    assert_eq!(
+        allocator.allocate_learning().expect("compat learning").id,
+        "L-0001"
+    );
+
+    assert!(
+        allocator
+            .remove_preallocated_adr_projection("ADR-9000")
+            .expect("remove ADR projection")
+    );
+    assert!(
+        allocator
+            .remove_preallocated_learning_projection("L-8000")
+            .expect("remove learning projection")
+    );
+    assert!(
+        allocator
+            .adr_allocation("ADR-9000")
+            .expect("removed ADR lookup")
+            .is_none()
+    );
+    assert!(
+        allocator
+            .learning_allocation("L-8000")
+            .expect("removed learning lookup")
+            .is_none()
     );
 }
 

--- a/docs/design/host-registry/2_design.md
+++ b/docs/design/host-registry/2_design.md
@@ -10,7 +10,7 @@ summary: Target mechanisms for host identity, the main-host registry, the coordi
 tags: [host-registry, multi-host, dispatch, routines, data-placement]
 paths: ["crates/orbit-remote/**", "crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**", "crates/orbit-common/**"]
 related_features: [host-registry, mcp-bridge, routines, remote-access, mcp-session-context]
-related_artifacts: [ORB-00424, ORB-10247, ORB-10248, ORB-10249, ORB-10255, ORB-10257, ORB-10258, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10302, ORB-10319, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
+related_artifacts: [ORB-00424, ORB-10247, ORB-10248, ORB-10249, ORB-10255, ORB-10257, ORB-10258, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10273, ORB-10302, ORB-10319, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
 ---
 
 # Host Registry — Design
@@ -23,9 +23,10 @@ private registration plus first remote coordination slice have landed
 [ORB-10268, ORB-10269, ORB-10271]. [ORB-10319] then consolidated those coupled
 pieces into the vertical `orbit-remote` feature crate described by [ADR-0240],
 superseding the earlier horizontal boundary in [ADR-0235]. [ORB-10272] adds the
-dormant hub-global ADR/learning sequence substrate inside that boundary; public
-knowledge creation remains on the standalone compatibility path until the F3
-cutover. Run
+dormant hub-global ADR/learning sequence substrate inside that boundary, and
+[ORB-10273] adds exact-owner preallocated finalizers plus dormant broker
+composition. Public knowledge creation remains on the standalone compatibility
+path until the F3 cutover. Run
 placement, polling, and later phases remain pending. The folder is Accepted. It
 covers host identity, the registry, the
 coordination-plane/workspace-ownership split, execution placement (including the
@@ -508,6 +509,22 @@ Notes:
   abandon, expiry, reuse, or remote-finalize API. Owner finalization may fail after
   allocation and leave a valid unused ID. That gap is deliberate and does not
   grant the hub a route to a spoke owner.
+- **F2 validates the exact owner checkout before allocation.** [ORB-10273]
+  resolves one active, unambiguous D3 owner binding and constructs its bound
+  runtime before requesting an ID. Local replicas, another-spoke ownership, and
+  missing/stale/ambiguous/unavailable bindings fail before allocation and before
+  any owner/spoke connection. A local owner makes one path-free hub allocation and
+  finalizes that exact ID locally; a hub owner receives one public hub mutation
+  whose hub-local broker performs both steps. No route proxies from the hub to a
+  spoke owner.
+- **Owner finalization cannot choose or return an ID.** The supplied-ID ADR and
+  learning finalizers exclusively create the body, sidecars, index rows, and a
+  non-authoritative owner-local lookup projection. They never advance the local
+  compatibility sequence, allocate, abandon, retry, adopt a collision, or select
+  a replacement. Failure removes their partial local state while the immutable
+  hub allocation remains consumed; response loss is `outcome_unknown` and is not
+  retried automatically. The original `mcp_call_id`, stable workspace ID, kind,
+  allocated ID, and D2 provenance correlate the hub and owner audits.
 
 - **Knowledge is one-writer per workspace — the owner.** The owner authors the file
   in its own checkout and commits there; the global ID comes from the hub in a
@@ -655,5 +672,8 @@ of that routine.** Consequences:
   forward-only activation, replay-safe immutable correlation ledger, atomic audit,
   and explicit late-workspace ineligibility without changing standalone creation
   or activating the F3 cutover.
+- [ORB-10273] — adds exact-checkout supplied-ID owner finalizers, owner-local
+  projections and cleanup, and the preflighted local-owner/hub-owner composite
+  broker behind an inactive F2 gate; F3 still owns the atomic public cutover.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/host-registry/4_decisions.md
+++ b/docs/design/host-registry/4_decisions.md
@@ -10,7 +10,7 @@ summary: ADR log for the coupled Host Registry and MCP Bridge v1 contract and it
 tags: [host-registry, mcp-bridge, multi-host, placement]
 paths: ["crates/orbit-remote/**", "crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**"]
 related_features: [host-registry, mcp-bridge]
-related_artifacts: [ORB-00424, ORB-10245, ORB-10248, ORB-10249, ORB-10255, ORB-10257, ORB-10267, ORB-10258, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
+related_artifacts: [ORB-00424, ORB-10245, ORB-10248, ORB-10249, ORB-10255, ORB-10257, ORB-10267, ORB-10258, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10273, ORB-10276, ORB-10302, ORB-10319, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
 ---
 
 # Host Registry — Decisions
@@ -91,7 +91,7 @@ filtered non-empty capability set.
 
 ## ADR-0229 — Owner-authored knowledge with hub-global IDs and explicit replicas
 
-**Status:** Accepted · 2026-07 · [ORB-10245] fixed the one-writer knowledge rule; [ORB-10272] implemented its dormant hub-global sequence, validated reconciliation, and immutable allocation-ledger substrate without activating public issuance.
+**Status:** Accepted · 2026-07 · [ORB-10245] fixed the one-writer knowledge rule; [ORB-10272] implemented its dormant hub-global sequence, validated reconciliation, and immutable allocation-ledger substrate; [ORB-10273] implemented exact-owner supplied-ID finalization and dormant broker composition without activating public issuance.
 
 ### Context
 
@@ -106,6 +106,9 @@ Hub activation first reconciles every registered workspace's complete hub-local
 legacy file/allocation inventory; missing sources and cross-workspace duplicate IDs
 fail before mutation. A later workspace stays knowledge-ineligible until the same
 reconciliation succeeds under the allocator lock.
+Before allocation, the broker selects one validated owner checkout. The owner then
+finalizes only the supplied ID and installs a non-authoritative local projection;
+the hub neither supplies a checkout path nor proxies to a spoke owner.
 
 ### Consequences
 
@@ -114,6 +117,8 @@ reconciliation succeeds under the allocator lock.
   sequence advance, immutable ledger append, and canonical hub audit commit atomically.
 - Standalone/worktree allocation remains the compatibility path until F3 performs
   the explicit activation and caller cutover.
+- Collision or partial-write failure removes only F2's local state; allocation is
+  never abandoned, retried, or replaced, so the resulting gap remains valid.
 - Cost: finalize failure consumes a valid unused ID, and current spoke-owned knowledge is unavailable off-owner.
 
 ## ADR-0230 — Pull-based leases with immutable placement and explicit recovery
@@ -302,3 +307,8 @@ crate.
   resolved crew, generation, config digest, ship-closure digest). Standalone and
   owner-local auto-task CRUD keep their local crew validation. Task `host`/claims
   (H2), workflow ship/placement (H3), and run lineage/leasing (I1) stay out of scope.
+- [ORB-10273] — implements ADR-0229's exact-checkout supplied-ID finalizers,
+  non-authoritative local projections, correlated owner audit, and dormant
+  local-owner/hub-owner composition without adding an owner proxy or public cutover.
+
+> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-bridge/2_design.md
+++ b/docs/design/mcp-bridge/2_design.md
@@ -10,7 +10,7 @@ summary: Target design for a local Orbit MCP broker with one SSH hub link, hub-o
 tags: [mcp, remote-access, host-registry, bridge, ssh, routing]
 paths: ["crates/orbit-remote/**", "crates/orbit-mcp/**", "crates/orbit-core/**", "crates/orbit-tools/**", "crates/orbit-store/**", "crates/orbit-common/**"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access, orbit-search, orbit-graph, project-learnings]
-related_artifacts: [ORB-00424, ORB-10257, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
+related_artifacts: [ORB-00424, ORB-10257, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10273, ORB-10276, ORB-10302, ORB-10319, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
 ---
 
 # Orbit MCP Bridge — Design
@@ -525,10 +525,11 @@ Invalid workspace/kind/correlation, ineligible workspace, and overflow also leav
 both sequences unchanged. Requests and results contain no checkout or owner path.
 
 F1 exposes no public agent allocation tool, no reservation/finalize/release API,
-and no owner proxy. F3 alone activates public issuance and cuts the following
-composite create flow over to the hub sequence.
+and no owner proxy. F2 [ORB-10273] adds internal supplied-ID owner finalizers and
+the following broker composition behind an inactive cutover gate. F3 alone
+activates public issuance and atomically cuts every create caller over.
 
-#### F3 composite creation target
+#### F2 dormant composite creation
 
 `orbit.learning.add` and `orbit.adr.add` are composite owner operations:
 
@@ -540,8 +541,20 @@ composite create flow over to the hub sequence.
 4. if another spoke owns the workspace, reject before allocation; and
 5. correlate allocation/finalize audit with one `mcp_call_id`.
 
+Before either allocation, D3 preflight must resolve one active, available,
+unambiguous exact owner checkout and construct its bound runtime. Missing, stale,
+ambiguous, unavailable, another-spoke, and replica cases fail before allocation;
+the latter two also open no owner/spoke connection. Neither request data nor the
+hub allocation request carries a checkout path.
+
 Both successful paths reuse the existing local file/index atomicity and rollback
-boundary on the machine that owns the checkout.
+boundary on the machine that owns the checkout. A non-authoritative local
+projection makes the supplied body visible to ordinary list and lifecycle paths,
+but it cannot select an ID or advance the compatibility allocator. Exclusive
+creation refuses to overwrite or adopt a supplied-ID collision. Any partial body,
+sidecar, index row, or projection is removed on failure; only the hub ledger and
+correlated canonical/owner audit retain the consumed allocation. Allocation
+response loss is `outcome_unknown`, with no local finalization or automatic retry.
 
 This is not a reservation protocol. The allocator advances once and returns an ID;
 there is no pending reservation row, lease, expiry, abandon, or remote finalize.
@@ -950,5 +963,8 @@ Required validation:
   correlation-safe immutable ledger and atomic audit, plus contract revision 3's
   private path-free request/result used by the two-workspace canary. Public
   issuance/caller cutover remains F3, and standalone creation is unchanged.
+- [ORB-10273] — adds exact-checkout supplied-ID ADR/learning finalizers,
+  owner-local projections and cleanup, correlated owner audit, and the dormant
+  local-owner/hub-owner broker seam; its gate remains inactive until F3.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-bridge/4_decisions.md
+++ b/docs/design/mcp-bridge/4_decisions.md
@@ -10,7 +10,7 @@ summary: ADR log for the coupled MCP Bridge and Host Registry v1 contract and it
 tags: [mcp, remote-access, host-registry, bridge]
 paths: ["crates/orbit-remote/**", "crates/orbit-mcp/**", "crates/orbit-core/**", "crates/orbit-tools/**", "crates/orbit-store/**"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access]
-related_artifacts: [ORB-00424, ORB-10245, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
+related_artifacts: [ORB-00424, ORB-10245, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10273, ORB-10276, ORB-10302, ORB-10319, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
 ---
 
 # Orbit MCP Bridge — Decisions
@@ -87,7 +87,7 @@ filtered non-empty capability set.
 
 ## ADR-0229 — Owner-authored knowledge with hub-global IDs and explicit replicas
 
-**Status:** Accepted · 2026-07 · [ORB-10245] fixed the one-writer knowledge rule; [ORB-10272] implemented the dormant Remote-v2 hub sequence, reconciliation, immutable-ledger, and atomic-audit substrate without activating the F3 public cutover.
+**Status:** Accepted · 2026-07 · [ORB-10245] fixed the one-writer knowledge rule; [ORB-10272] implemented the dormant Remote-v2 hub sequence, reconciliation, immutable-ledger, and atomic-audit substrate; [ORB-10273] implemented exact-owner supplied-ID finalization and dormant composition without activating the F3 public cutover.
 
 ### Context
 
@@ -101,6 +101,9 @@ replicas are opt-in reads marked as replicas. The hub never proxies to a spoke o
 Activation validates every registered workspace's complete hub-local legacy
 inventory before mutation; missing sources or cross-workspace duplicate IDs fail
 closed, and a late workspace remains ineligible until reconciled under the hub lock.
+Owner preflight selects one exact checkout before allocation. Finalization consumes
+only the hub-supplied ID, installs a non-authoritative local projection, and never
+turns a checkout path into request data or a hub-to-owner route.
 
 ### Consequences
 
@@ -109,6 +112,8 @@ closed, and a late workspace remains ineligible until reconciled under the hub l
   one transaction; exact request-identity replay is idempotent.
 - Standalone/worktree allocation remains unchanged until F3 activates and cuts over
   public knowledge creation.
+- Finalization cleanup cannot abandon or replace the immutable hub allocation;
+  collision, partial-write failure, and unknown response outcomes preserve allowed gaps.
 - Cost: finalize failure consumes a valid unused ID, and current spoke-owned knowledge is unavailable off-owner.
 
 ## ADR-0230 — Pull-based leases with immutable placement and explicit recovery
@@ -284,5 +289,8 @@ Remote database or a separate broker crate.
   and mutate nothing. Standalone and owner-local auto-task CRUD keep their local
   crew validation. Task `host`/claims (H2), workflow ship/placement (H3), and run
   lineage/leasing (I1) remain out of scope.
+- [ORB-10273] — implements ADR-0229's path-free exact-owner finalizers,
+  non-authoritative projections, correlated owner audit, and dormant broker
+  composition without weakening the one-writer or no-proxy boundary.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/worktree-artifacts/2_design.md
+++ b/docs/design/worktree-artifacts/2_design.md
@@ -10,7 +10,7 @@ doc_role: design
 tags: ["worktree-artifacts"]
 paths: ["crates/orbit-remote/**", "crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-cli/**"]
 related_features: ["worktree-artifacts", "host-registry", "mcp-bridge"]
-related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10272", "ORB-10297", "ADR-0177", "ADR-0229"]
+related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10272", "ORB-10273", "ORB-10297", "ADR-0177", "ADR-0229"]
 ---
 
 # Worktree Artifacts - Design
@@ -63,6 +63,16 @@ reservation, release, reuse, or remote-finalize protocol.
 F1 leaves the substrate dormant and exposes no public allocation tool. F3 alone
 activates public issuance and cuts owner creation over; standalone hosts cannot
 enter hub authority.
+
+F2 [ORB-10273] adds an owner-local projection row for a successfully finalized
+hub ID. The row is explicitly non-authoritative: it records the selected
+checkout/body path for ordinary list and lifecycle operations but is excluded from
+compatibility sequence selection. The supplied-ID finalizers write only under the
+D3-selected `local_root`, never infer placement from process cwd, and never accept
+an absolute checkout path as request data. Collision refuses overwrite/adoption;
+failure removes every partial body, sidecar, index entry, and projection while the
+hub allocation remains a valid consumed gap. The public create paths still use the
+compatibility allocator until F3 enables the dormant broker atomically.
 
 ## 3. Write Path
 
@@ -118,5 +128,8 @@ The `worktree_root` column preserves historical rows from earlier phases, so old
 - [ORB-10272] added the dormant, path-free Remote-v2 hub sequence and reconciliation
   substrate while preserving the standalone shared-root allocator and owner-local
   body/federation semantics; F3 owns activation and caller cutover.
+- [ORB-10273] added exact-checkout supplied-ID body finalization and removable,
+  non-authoritative owner-local projections without advancing or replacing the
+  compatibility allocator; the public F2 gate stays inactive.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/worktree-artifacts/4_decisions.md
+++ b/docs/design/worktree-artifacts/4_decisions.md
@@ -10,7 +10,7 @@ doc_role: decisions
 tags: ["worktree-artifacts"]
 paths: ["crates/orbit-remote/**", "crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-cli/**"]
 related_features: ["worktree-artifacts", "host-registry", "mcp-bridge"]
-related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10272", "ORB-10297", "ADR-0177", "ADR-0229"]
+related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10272", "ORB-10273", "ORB-10297", "ADR-0177", "ADR-0229"]
 ---
 
 # Worktree Artifacts - Decisions
@@ -19,7 +19,7 @@ ADR-style log for worktree artifact storage. Entries use globally allocated ADR 
 
 ## ADR-0177 - Worktree-local ADR and learning bodies with shared ID allocation
 
-**Status:** Accepted - 2026-05 - [ORB-00201]; amended 2026-07 by [ORB-10297] and [ORB-10272]
+**Status:** Accepted - 2026-05 - [ORB-00201]; amended 2026-07 by [ORB-10297], [ORB-10272], and [ORB-10273]
 
 **Context.** Linked worktrees need ADR and learning bodies committed with the code branch that created them, but IDs must remain collision-free across all worktrees. [ORB-00199] introduced shared/local root resolution and [ORB-00200] introduced the shared SQLite allocator. The remaining choice was whether body files follow the allocator into `shared_root` or follow the editing branch into `local_root`.
 
@@ -33,6 +33,11 @@ advance, ledger append, and audit are atomic; owner-local body creation remains 
 separate step and may leave a valid gap. F1 preserves every existing allocator and
 create caller. F3 alone activates and cuts public issuance over. The hub never
 proxies to or reads a spoke owner's worktree.
+[ORB-10273] adds supplied-ID finalization in one D3-selected owner checkout and a
+non-authoritative local projection for ordinary reads/lifecycle operations. The
+projection records placement but cannot advance or choose from the compatibility
+sequence; failed finalization removes it and every partial local artifact without
+releasing or replacing the consumed hub ID.
 
 **Consequences.**
 - ADR and learning files can be staged in the same PR as the implementation that created them.
@@ -42,6 +47,8 @@ proxies to or reads a spoke owner's worktree.
 - A late workspace is explicitly ineligible until its complete hub-local inventory
   reconciles; missing sources and duplicate IDs fail before mutation.
 - Standalone/worktree allocation remains unchanged until the explicit F3 cutover.
+- Owner finalization is independent of process cwd, refuses supplied-ID collision,
+  and leaves the sibling-worktree projection/index unchanged.
 - Readers get predictable defaults without failing on missing sibling-worktree files.
 - Readable sibling ADRs preserve their exact body, while unavailable allocations and unknown IDs remain distinct typed failures.
 - Rejected sibling-only mutations leave bundles, allocation metadata, lifecycle timestamps, and audit state unchanged.
@@ -57,5 +64,7 @@ proxies to or reads a spoke owner's worktree.
 - [ORB-10272] amended the allocation boundary with the dormant Remote-v2 hub-global
   sequence, full legacy reconciliation, immutable correlation ledger and atomic
   audit while retaining standalone compatibility and owner-local bodies.
+- [ORB-10273] amended finalization with exact-checkout supplied IDs and removable
+  non-authoritative projections while preserving allowed gaps and no owner proxy.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10273](https://orbit-cli.com/tasks/ORB-10273) — Finalize hub-preallocated knowledge in the exact owner checkout

### Description

## Problem

Orbit's ADR and learning file stores currently choose IDs internally through the workspace-scoped compatibility `IdAllocator`. Their partial-create rollback can abandon that local reservation, and learning creation may retry with another ID after a path collision.

That behavior cannot be used for the multi-host path. ORB-10272 makes the singular hub the only authority that chooses a global ADR or learning ID. Once allocated, the declared workspace owner must finalize exactly that ID in the exact owner checkout selected by ORB-10262. A failed finalization consumes the hub allocation and creates a valid gap; it must never choose, abandon, release, or reuse another global ID.

This is Unit F2, preallocated owner finalizers, from the accepted Sol execution plan under ORB-10246. It depends directly on ORB-10262 and ORB-10272.

## Required behavior

- Split both owner file stores into the existing standalone compatibility creation path and an internal `finalize_preallocated(id, payload, exact_checkout)` path that never selects another ID.
- Preserve existing validation, exclusive-file creation, sidecar/index updates, and local partial-write cleanup for ADRs and learnings.
- The exact checkout comes from ORB-10262's validated owner binding. Finalization must not inspect process cwd, choose another worktree, or accept a remote absolute path.
- Compose `orbit.learning.add` and `orbit.adr.add` on the multi-host broker path:
  - local owner: allocate once through ORB-10272, then finalize in the selected local owner checkout;
  - hub owner: send one public hub mutation whose hub-local broker allocates and finalizes in the hub's canonical owner checkout;
  - another-spoke owner or local replica: reuse D3 owner preflight and reject before allocation.
- Allocation and finalization success or failure remain correlated by the original trusted `mcp_call_id`, workspace ID, knowledge kind, and allocated ID.
- A finalization failure reports the allocated ID and that it remains consumed. Local cleanup may remove only partial owner artifacts/index state; it must never roll back or abandon the hub allocation.
- A supplied-ID collision preserves the existing artifact, fails deterministically, and never adopts it, overwrites it, loops, or requests another ID.
- Keep the public `orbit.learning.add` and `orbit.adr.add` schemas and successful result shapes compatible.

## Boundaries

- Composite knowledge creation and exact-checkout owner finalization only.
- F3 owns direct CLI/lifecycle owner enforcement, the human CLI-only allocation command, and post-merge sync/reindex.
- Do not add a generic agent-visible allocation or finalization MCP tool.
- Do not add reservation, lease, expiry, abandon, release, reuse, distributed commit, or remote-finalize state.
- Do not add a hub-to-owner connector, spoke-to-spoke route, owner proxy, or checkout path to the hub request.
- Do not implement replica reads, search composition, learning-sidecar consistency, or ownership migration.
- Preserve standalone creation behavior and its compatibility allocator until F3 completes the multi-host cutover.
- Add no new crate or dependency edge.

## Rollback

The store and broker changes remain additive until the multi-host knowledge path is enabled. Once ORB-10272 has issued a production ID, rollback is roll-forward only: never restore per-workspace allocation for that path, renumber an artifact, or reuse a consumed ID.

### Acceptance Criteria

- Deterministic ADR and learning tests finalize caller-supplied canonical IDs into requested owner roots, create expected body/sidecars/index entries, and prove neither finalizer invokes allocation, abandon, retry, or second-ID selection.
- A two-worktree fixture for one logical workspace finalizes only in the exact checkout selected by ORB-10262; the sibling worktree and derived index remain unchanged, and process cwd has no effect.
- For a spoke-local owner, one learning.add and one adr.add each produce exactly one ORB-10272 hub allocation followed by one local finalization of that same ID; the request carries kind, workspace ID, and mcp_call_id but no checkout path.
- For a hub-owned workspace called from a spoke, each public add dispatches once to the hub and the hub allocates/finalizes in its validated owner checkout; no spoke-local knowledge or compatibility-allocation state is written.
- For another-spoke ownership or a local replica, D3 preflight rejects before allocation or owner-store mutation, names the owner, and opens no owner/spoke connection.
- Injected ADR and learning failures after hub allocation leave no partial body, sidecar, or local index visibility; the immutable hub allocation stays consumed and the next allocation is higher, demonstrating a valid gap.
- A pre-existing artifact at the supplied ID is never overwritten or adopted. Finalization fails without requesting a replacement ID, and both original artifact and consumed allocation remain inspectable.
- Success and injected-failure fixtures correlate allocation and owner-finalization audit with one mcp_call_id, workspace ID, kind, and allocated ID, with correct D2 caller/process provenance.
- A simulated lost allocation response produces outcome_unknown with mcp_call_id, performs no local finalization and no automatic retry, and correlation lookup observes exactly one consumed allocation.
- Existing standalone ADR/learning creation, worktree-local placement, public MCP schema/result, and compatibility allocator regression suites remain green.
- Host Registry, MCP Bridge, and worktree-artifact docs cite this task and distinguish hub allocation from owner-local finalization without weakening one-writer, no-proxy, or allowed-gap semantics.
- Targeted orbit-store/orbit-core/orbit-cli and MCP round-trip tests, task-scoped clippy, cargo fmt --all --check, git diff --check, and make ci-fast pass.
- finalize_preallocated consumes a D3-selected checkout-bound owner store/runtime capability and verifies the same stable workspace ID; no caller-supplied absolute path is request data.
- Successful preallocated finalization installs a non-authoritative owner-local projection for the supplied ID and body path so ADR/learning list and lifecycle operations work. It never chooses an ID, advances a local sequence, or represents the projection as canonical allocation authority.
- Injected failure removes every partial local projection or stub as well as body, sidecars, and index rows. The only durable residue is the consumed hub allocation plus correlated canonical/local audits.
- F2 adds/tests preallocated finalizers and broker composition behind an inactive cutover gate. Public add remains on compatibility behavior until F3 atomically disables/reroutes all legacy authoring paths and enables global issuance.
- Before requesting a hub allocation, broker preflight must resolve one exact validated owner checkout for both hub-owner and local-owner cases. Missing, stale, ambiguous, inactive, or unavailable owner bindings fail before allocation, so avoidable gaps are not consumed; another-spoke and replica cases remain explicit pre-allocation refusals.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented F2 behind an inactive public cutover gate. Store now has collision-safe ADR and learning finalize_preallocated paths that consume a caller-supplied ID, exclusively create owner-local artifacts, install removable non-authoritative projections, update indexes strictly, and clean body/index/projection state on failure without allocation, abandon, retry, or replacement-ID selection. Core verifies the same stable workspace against an exact checkout-bound runtime and reuses the public add parsers/results. Remote now preflights an exact D3 owner checkout before allocation, composes one local-owner hub allocation plus finalization or one hub-owner public dispatch, rejects replicas/other-spoke owners before allocation/connection, correlates canonical and owner audits, preserves outcome_unknown no-replay behavior, and leaves public add on compatibility behavior until F3. Updated Host Registry, MCP Bridge, and Worktree Artifacts design/decision docs for ORB-10273. Added store/core/remote fixtures covering projections and lifecycle visibility, selected two-worktree placement, local and hub ownership, replica refusal, path-free requests, supplied-ID collision, injected post-allocation index failures and valid gaps, consumed-ledger inspection, correlated success/failure audits, and lost-response no-finalization. Scope-expanded tightly coupled Remote broker/link tests and learning index files were named in the earlier task comment. Validation passed: cargo test -p orbit-store (297 passed, 3 ignored); cargo test -p orbit-core (610 passed, 2 ignored across targets); cargo test -p orbit-remote (169 unit plus 3 boundary passed); cargo test -p orbit-cli --test mcp_roundtrip (6 passed); cargo clippy for orbit-store/orbit-core/orbit-remote/orbit-cli all targets with -D warnings; cargo fmt --all --check; git diff --check; and make ci-fast. No commit was created and task remains in-progress for downstream handoff.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10273-6a5d368f`
- Behind base: 0
- Ahead of base: 1