### PR TITLE
Auto-task: recurring learning-deprecation review reporting stale candidates via execution_summary

### DIFF
--- a/.orbit/auto_tasks/learning-deprecation-review.yaml
+++ b/.orbit/auto_tasks/learning-deprecation-review.yaml
@@ -1,0 +1,69 @@
+schemaVersion: 1
+name: learning-deprecation-review
+description: Recurring report-only review that surfaces potentially stale learnings via execution_summary
+enabled: true
+schedule:
+  cron: 0 5 * * 1
+template:
+  title: Review the learning corpus for deprecation candidates
+  description: |
+    Review this workspace's project learnings and surface the ones that look
+    stale. This is a REPORT-ONLY review: the entire deliverable is a ranked
+    list of candidate learnings, each with evidence, written into this task's
+    `execution_summary`. Do NOT deprecate, delete, supersede, archive, or
+    otherwise change any learning, and do NOT introduce any new learning state
+    — curation decisions are applied separately by a human or the orchestrator
+    through the existing `orbit learning update` / archival surface.
+
+    Gather evidence from two sources and reason from them; there are no
+    hard-coded staleness thresholds, so use judgment.
+
+    1. Usage rollups — run `orbit learning stats --json` (falls back to
+       `orbit tool run orbit.learning.stats` where the CLI is unavailable).
+       Each row carries `injected_count`, `shown_count`, `shown_ratio`,
+       `last_injected_at`, and `last_shown_at`. Combine with each learning's
+       age from `orbit learning list --json` (`created_at` / `updated_at`).
+       A learning that is old and has never been injected or shown, or that is
+       injected but never shown (agents ignore it), is a candidate.
+    2. Anchor health — from `orbit learning list --json`, inspect each active
+       learning's `scope.paths`. Flag:
+         * empty path scopes (`scope.paths == []`) — the injection hook keys on
+           path globs, so an empty scope can never inject on tool use;
+         * path globs that match nothing in the current tree (the anchored
+           file/dir no longer exists, or the glob was written for a different
+           repo layout) — these silently never fire.
+
+    Cross-reference the two signals, then write into `execution_summary` a
+    ranked list of the potentially stale learnings. For each, cite the concrete
+    evidence (counts, ratios, timestamps, the offending glob) and a one-line
+    rationale. Rank by leverage: over-broad or dead globs and never-useful
+    injections first. Note learnings you considered but are keeping, and why.
+
+    Fail open. If `orbit learning stats` reports no events (empty rollup), or
+    the usage/anchor data is otherwise missing or empty, report that nothing
+    looks stale rather than erroring — an empty corpus or a fresh workspace
+    with no audit history is a valid "nothing to deprecate" outcome, not a
+    failure.
+
+    Calibration: the 2026-07-18 learning-hook relevancy audit
+    (`operations/reports/2026-07-18-learning-hook-relevancy-audit.md`) flagged
+    L-0074, L-0077, L-0068, and L-0041 (over-broad / layout-mismatched globs)
+    plus the six empty-path learnings. The first cycle should reproduce that
+    candidate set, or explain in the summary why any candidate now differs
+    (e.g. a glob was already narrowed, or a learning was superseded).
+  acceptance_criteria:
+  - Potentially stale learnings are listed in execution_summary, each with concrete evidence (usage counts/ratios/timestamps and/or anchor-health findings).
+  - No learning was deprecated, deleted, superseded, archived, or given a new state — the run is report-only.
+  - An empty or missing usage rollup produced a "nothing stale" report rather than an error.
+  task_type: chore
+  tags:
+  - learning-deprecation
+  - no-diff-expected
+  priority: medium
+  crew: opus
+  status: backlog
+dedupe: skip_if_open
+created_by: system
+created_at: 2026-07-19T00:00:00Z
+updated_by: claude
+updated_at: 2026-07-19T00:00:00Z

--- a/crates/orbit-core/src/auto_tasks/tests/mod.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/mod.rs
@@ -7,6 +7,7 @@ use crate::auto_tasks::crud::AutoTaskAddParams;
 mod crud;
 mod schedule;
 mod scheduler;
+mod shipped;
 
 /// A minimal, valid template for tests.
 pub(super) fn template(title: &str) -> AutoTaskTemplate {

--- a/crates/orbit-core/src/auto_tasks/tests/shipped.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/shipped.rs
@@ -1,0 +1,90 @@
+//! Shipped-definition tests [ORB-10318]: every git-tracked auto-task
+//! definition under the repo's `.orbit/auto_tasks/` must parse and validate
+//! fail-closed, and the learning-deprecation review definition must stay
+//! report-only. This is the "mechanism covered by tests" guard for the
+//! definitions that travel with the repo — a malformed definition would
+//! otherwise only surface at scheduler-fire time.
+
+use std::path::PathBuf;
+
+use orbit_common::types::{AutoTaskSchedule, parse_auto_task_yaml};
+
+/// The repo's git-tracked auto-task definition directory, resolved relative to
+/// this crate's manifest (`crates/orbit-core` → repo root → `.orbit/auto_tasks`).
+fn shipped_auto_tasks_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(".orbit/auto_tasks")
+}
+
+/// Every shipped `.yaml` definition parses and validates. Fail-closed parsing
+/// means any malformed record is an error here, not a silent skip at fire time.
+#[test]
+fn shipped_definitions_all_parse() {
+    let dir = shipped_auto_tasks_dir();
+    let entries =
+        std::fs::read_dir(&dir).unwrap_or_else(|error| panic!("read {}: {error}", dir.display()));
+    let mut count = 0usize;
+    for entry in entries {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("yaml") {
+            continue;
+        }
+        let yaml = std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+        let definition = parse_auto_task_yaml(&yaml)
+            .unwrap_or_else(|error| panic!("parse {}: {error}", path.display()));
+        // The file stem is the definition's identity.
+        let stem = path.file_stem().and_then(|s| s.to_str()).expect("stem");
+        assert_eq!(
+            definition.name, stem,
+            "name must match file stem for {stem}"
+        );
+        count += 1;
+    }
+    assert!(
+        count > 0,
+        "expected at least one shipped auto-task definition"
+    );
+}
+
+/// The learning-deprecation review definition ships enabled, on a cron cadence,
+/// and stays report-only: it carries the `no-diff-expected` and
+/// `learning-deprecation` tags and its template never asks to mutate learnings.
+#[test]
+fn learning_deprecation_review_is_report_only() {
+    let path = shipped_auto_tasks_dir().join("learning-deprecation-review.yaml");
+    let yaml = std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    let definition = parse_auto_task_yaml(&yaml).expect("parse learning-deprecation-review");
+
+    assert_eq!(definition.name, "learning-deprecation-review");
+    assert!(definition.enabled, "definition must ship enabled");
+    assert!(
+        matches!(definition.schedule, AutoTaskSchedule::Cron { .. }),
+        "deprecation review runs on a cron cadence"
+    );
+
+    let tags = &definition.template.tags;
+    assert!(
+        tags.iter().any(|t| t == "no-diff-expected"),
+        "report-only run must be tagged no-diff-expected"
+    );
+    assert!(
+        tags.iter().any(|t| t == "learning-deprecation"),
+        "definition must be tagged learning-deprecation"
+    );
+
+    // Report-only: the prompt must not direct the agent to mutate learnings.
+    let body = definition.template.description.to_lowercase();
+    assert!(
+        body.contains("report-only") || body.contains("report only"),
+        "template must state the run is report-only"
+    );
+    for forbidden in ["execution_summary", "learning stats", "fail open"] {
+        assert!(
+            body.contains(forbidden),
+            "template should reference '{forbidden}'"
+        );
+    }
+}

--- a/docs/design/auto-tasks/1_overview.md
+++ b/docs/design/auto-tasks/1_overview.md
@@ -1,7 +1,7 @@
 ---
 title: Auto-tasks — Overview
 owner: claude
-last_updated: 2026-07-12
+last_updated: 2026-07-19
 status: Accepted
 feature: auto-tasks
 doc_role: overview
@@ -10,7 +10,7 @@ summary: Dynamically-defined recurring task templates minted by one generic sche
 tags: [auto-tasks]
 paths: ["crates/orbit-core/src/auto_tasks/**"]
 related_features: [auto-tasks]
-related_artifacts: [ORB-10149, ADR-0218, ADR-0217]
+related_artifacts: [ORB-10149, ORB-10318, ADR-0218, ADR-0217]
 ---
 
 # Auto-tasks — Overview
@@ -36,8 +36,11 @@ becomes just the first definition.
 - **Definition** — a `.orbit/auto_tasks/<name>.yaml` record; `name` is identity.
   Modeled on the file-backed routine convention (directory scan, fail-closed
   parse, `deny_unknown_fields`), not the SQLite-indexed learning/ADR convention.
-- **Schedule** — a 5-field `cron` or an `every_minutes` interval. Catch-up
-  always collapses: a downtime gap mints one make-up task, not one per slot.
+- **Schedule (cadence)** — a 5-field `cron` or an `every_minutes` interval, in
+  the definition's `schedule` field. Catch-up always collapses: a downtime gap
+  mints one make-up task, not one per slot. Cadence is per-definition data, not
+  a knob in the identity `config.yaml` ([L-0014] keeps runtime config out of
+  `config.yaml`).
 - **Cursor** — per-definition last-fired state, host-local at
   `<orbit_dir>/state/auto-tasks.json`, so the git-versioned definition is never
   churned by a scheduler fire.
@@ -61,9 +64,17 @@ becomes just the first definition.
 | Deterministic action | `crates/orbit-core/src/runtime/v2_host/dispatch.rs` | ORB-10149 |
 | Seeded assets | `crates/orbit-core/assets/{activities,jobs,routines}/…` | ORB-10149 |
 
+## Definitions shipped in this repo
+
+- `qa-sweep` — hands-on validation of recent changes (ORB-10148).
+- `learning-deprecation-review` — report-only weekly review that lists stale
+  learning candidates (usage rollups + anchor health) via `execution_summary`;
+  never mutates learnings (ORB-10318, [project-learnings §7.6](../project-learnings/2_design.md#76-recurring-deprecation-review-auto-task)).
+
 ## Task References
 
 - ORB-10149 — Auto-task primitive.
 - ORB-10148 — qa-sweep V1 (first definition; depends on this).
+- ORB-10318 — learning-deprecation-review definition (report-only stale-learning review).
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/project-learnings/2_design.md
+++ b/docs/design/project-learnings/2_design.md
@@ -404,6 +404,20 @@ Two agents (or two humans) may author overlapping learnings concurrently. Phase 
 
 When a duplicate concern is already covered by an active learning, the agent should upvote the existing record instead of creating a near-duplicate. The vote says "this learning is still load-bearing in a new task context" and improves search ranking without changing the learning body or `updated_at`.
 
+### 7.6 Recurring deprecation review (auto-task)
+
+`orbit learning prune` ([§7.3](#73-staleness-detection)) is mechanical and anchor-only: it flags a learning stale purely on dead paths / evidence, and it is opportunistic — nothing schedules it. The teaser-injection instrumentation ([ORB-10316], [§5.5](#55-usage-instrumentation-and-feedback)) adds a second, softer signal — *whether a learning is ever injected or shown* — that `prune` does not consider. A learning can be perfectly anchored (its globs still resolve) yet be dead weight: never injected, injected-but-never-opened, or scoped so broadly it only ever matches tangentially.
+
+To surface that class continuously without hard-coding thresholds, orbit ships a **report-only recurring review** as an auto-task ([docs/design/auto-tasks/](../auto-tasks/), [ORB-10318]) — `.orbit/auto_tasks/learning-deprecation-review.yaml`. On its cadence the generic scheduler mints a normal task whose prompt directs the assigned agent to:
+
+1. Read the usage rollups (`orbit learning stats --json`: `injected_count`, `shown_count`, `shown_ratio`, `last_injected_at`, `last_shown_at`) and each learning's age (`orbit learning list --json`).
+2. Inspect **anchor health** from `scope.paths`: empty path scopes (can never inject) and globs that match nothing in the current tree.
+3. Write a ranked list of the potentially stale learnings, each with evidence, into the task's `execution_summary` — that is the entire deliverable.
+
+The run **never** deprecates, deletes, supersedes, archives, or adds a learning state; curation stays human/orchestrator-owned and is applied afterwards through the existing `orbit learning update` / archival surface. It **fails open**: an empty or missing rollup (a fresh workspace with no audit history) reports "nothing stale" rather than erroring. Agent judgment replaces the fixed thresholds a bespoke staleness-scoring engine would have hard-coded — the deliberate choice ([ORB-10318]) not to build one, given the small corpus and the audit's finding that no learning is a proven chronic offender.
+
+The definition is ordinary workspace data (`no-diff-expected` + `learning-deprecation` tags, `skip_if_open` dedupe); its cadence lives in the definition's `schedule` field, not in the identity `config.yaml` ([L-0014] keeps runtime config out of `config.yaml`). First-cycle calibration reproduces the 2026-07-18 hook-relevancy audit's candidate set (L-0074, L-0077, L-0068, L-0041, and the six empty-path learnings) or documents why any now differs.
+
 ---
 
 ## 8. Concerns & Honest Limitations
@@ -451,5 +465,6 @@ Learnings are workspace-scoped and checked into the repo. They travel exactly wh
 - [ORB-00061] — Add Knowledge tab and Learnings subtab to dashboard.
 - [ORB-00090] — Aligned learning identity examples with the agent-family convention.
 - [ORB-10316] — Teaser injection (id + summary + tags), `learning_shown` usage signal on `orbit learning show`, `learning_injected`/`learning_shown` rollup via `orbit learning stats`, payload-derived session dedup ([§4.3](#43-layer-3--claude-code-pretooluse-hook-optional), [§4.5](#45-what-gets-injected), [§5.5](#55-usage-instrumentation-and-feedback); [ADR-0242]).
+- [ORB-10318] — Report-only recurring learning-deprecation review as an auto-task; surfaces stale candidates via `execution_summary` from usage rollups + anchor health, no bespoke sweep engine ([§7.6](#76-recurring-deprecation-review-auto-task)).
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -87,9 +87,12 @@ orbit routine list
 orbit sweep --json
 ```
 
-The dashboard also exposes `GET /api/routines`. The `qa-sweep` auto-task definition is
-ordinary workspace data under `.orbit/auto_tasks/`, processed by the generic auto-task
-scheduler routine.
+The dashboard also exposes `GET /api/routines`. Auto-task definitions such as
+`qa-sweep` and `learning-deprecation-review` are ordinary workspace data under
+`.orbit/auto_tasks/`, processed by the generic auto-task scheduler routine.
+`learning-deprecation-review` is report-only — it mints a task that lists stale
+learning candidates via `execution_summary` and never mutates learnings
+(ORB-10318).
 
 ## Verification and escalation
 


### PR DESCRIPTION
## Task

[ORB-10318](https://orbit-cli.com/tasks/ORB-10318) — Auto-task: recurring learning-deprecation review reporting stale candidates via execution_summary

### Description

Second leg of the 2026-07-18 learning-system redesign (audit: `operations/reports/2026-07-18-learning-hook-relevancy-audit.md`; F2026-07-092). Scope revised 2026-07-19 (again): drop the bespoke sweep engine — no dedicated `orbit learning sweep` command, no staleness-scoring rules in code, no `stale-candidate` state, no report artifacts. This is now **just an auto-task feature**.

Implement auto-task support in Orbit: a recurring task that re-instantiates on a configurable cadence (cadence in `.orbit/config.toml` per L-0014 — config.yaml is identity-only). The first consumer is the learning-deprecation review:

1. Each cycle, the auto-task spawns as a normal task whose prompt directs the assigned agent to review the learning corpus using the `learning stats` rollups from ORB-10316 (injection count, shown count, shown ratio, last-injected/last-shown timestamps, age) plus anchor health (path globs matching nothing in the current tree, empty path scopes).
2. The agent **lists the potentially stale learning artifacts, with evidence, in the task's `execution_summary`** — that is the entire deliverable. Agent judgment replaces hard-coded thresholds.
3. The run never deprecates anything. Curation stays human/orchestrator-owned: decisions are applied afterwards via existing `learning update` / deletion, outside this task's scope.

Dependency: ORB-10316 (teaser injection + show signal + stats). First cycle should surface the audit's candidates (L-0074, L-0077, L-0068, L-0041, the 6 empty-path learnings) — validate the run reproduces them or documents why any differ.

Out of scope: changing injection selection or show/stats mechanics (ORB-10316), tag-vocabulary machinery (rejected with ORB-10317), any new learning lifecycle states, sweep CLI commands, scoring config, or report files.

### Acceptance Criteria

- Orbit supports auto-tasks: a recurring task definition that re-instantiates as a normal task on a configurable cadence (cadence in .orbit/config.toml, not config.yaml); mechanism covered by tests and documented
- A learning-deprecation auto-task is defined whose prompt directs the agent to review learning stats rollups (ORB-10316) and anchor health, and to list potentially stale learnings with evidence in the task's execution_summary
- The run is report-only: no state transitions, no deletions, no new learning states — curation decisions applied separately by human/orchestrator via existing learning update
- First cycle's execution_summary surfaces the 2026-07-18 audit candidate set (L-0074, L-0077, L-0068, L-0041, empty-path learnings) or documents why any differ
- Fail open: missing/empty rollup data or missing cadence config produces a run that reports nothing stale rather than crashing; covered by tests
- Docs updated (auto-task mechanism, cadence config, deprecation-review flow); make ci-fast passes

## Execution Summary

<details>
<summary>Click to expand</summary>

ORB-10318 — Auto-task: recurring learning-deprecation review (report-only).

Scope (revised 2026-07-19): no bespoke sweep engine — no `orbit learning sweep`
command, no staleness-scoring rules in code, no `stale-candidate` state, no
report artifacts. Deliverable is a single recurring auto-task definition plus
docs + a shipped-definition test guard. The auto-task *mechanism* was already
shipped by ORB-10149 (crates/orbit-core/src/auto_tasks/*, schema in
orbit-common/src/types/auto_task.rs); this task is its first learning-review
consumer.

Changes:
- `.orbit/auto_tasks/learning-deprecation-review.yaml` — new report-only
  auto-task. schemaVersion 1, enabled, weekly cron (`0 5 * * 1`),
  `dedupe: skip_if_open`, crew opus, status backlog, tags
  [learning-deprecation, no-diff-expected]. Prompt directs the agent to gather
  two evidence signals — usage rollups (`orbit learning stats --json`:
  injected_count / shown_count / shown_ratio / last_injected_at / last_shown_at,
  plus age from `orbit learning list --json`) and anchor health (empty
  `scope.paths`; globs matching nothing in the tree) — then write a ranked list
  of stale candidates with evidence into `execution_summary`. Explicitly
  report-only (never deprecate/delete/supersede/archive/add-state) and
  fail-open (empty/missing rollup => "nothing stale", not an error). Carries a
  calibration note: first cycle should reproduce the 2026-07-18 hook-relevancy
  audit set (L-0074, L-0077, L-0068, L-0041, six empty-path learnings) or
  explain any divergence.
- `crates/orbit-core/src/auto_tasks/tests/shipped.rs` (+ registered in
  tests/mod.rs) — guards every git-tracked `.orbit/auto_tasks/*.yaml` parses
  fail-closed (name == file stem) and that learning-deprecation-review ships
  enabled, cron-scheduled, tagged no-diff-expected + learning-deprecation, and
  its prompt stays report-only (contains report-only / execution_summary /
  learning stats / fail open). Malformed definitions surface at test time, not
  at scheduler-fire time.
- Docs: auto-tasks/1_overview.md (cadence-is-definition-data per L-0014,
  shipped-definitions list, ORB-10318 refs), project-learnings/2_design.md new
  §7.6 (recurring deprecation review: usage-signal complement to the
  anchor-only `orbit learning prune`, report-only, fail-open, judgment over
  hard-coded thresholds) + changelog line, runbooks/health-checks.md
  (learning-deprecation-review is report-only).

Acceptance criteria: all six met. Cadence lives in the definition's `schedule`
field (not the identity config.yaml, per L-0014); report-only enforced by prompt
+ test; fail-open stated in prompt and asserted by the report-only test, with
the loader already treating a malformed/absent definition as absent (no crash,
ORB-10149 coverage); first-cycle calibration set encoded in the prompt.

Validation: `cargo test -p orbit-core --lib auto_tasks::tests::shipped` — 2/2
pass. `make ci-fast` — exit 0 (fmt-check + all guardrail scripts).
Cross-references verified factual: `orbit learning stats` / `orbit learning
prune` subcommands exist; design §7.3 exists; ORB-10316 dependency (stats
rollups) is merged. No code behavior changed outside the new definition + test;
report-only by construction (no-diff-expected).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10318-6a5d4400`
- Behind base: 0
- Ahead of base: 1