### PR TITLE
Expose an HTTP search route on Orbit's API so Bridge can proxy hybrid/vector search

### DIFF
--- a/.orbit/adrs/accepted/ADR-0244/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0244/adr.yaml
@@ -1,0 +1,23 @@
+schema_version: 2
+id: ADR-0244
+title: Expose unified search through a thin HTTP adapter
+status: accepted
+owner: codex
+created_at: 2026-07-20T02:13:36.199351021Z
+accepted_at: 2026-07-20T02:13:41.746781451Z
+last_updated: 2026-07-20T02:13:41.746781451Z
+related_features:
+- orbit-search
+related_tasks:
+- ORB-10304
+tags:
+- search
+- http-api
+- parity
+paths:
+- crates/orbit-dashboard/src/api/**
+- crates/orbit-core/src/command/search/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0244/body.md
+++ b/.orbit/adrs/accepted/ADR-0244/body.md
@@ -1,0 +1,10 @@
+## Context
+Bridge needs hybrid Orbit search but can only proxy the dashboard HTTP surface. The alternatives were to keep reconstructing lexical results in Bridge, expose a generic tool-execution HTTP endpoint, or add a narrow search endpoint backed by the same runtime pipeline as the CLI.
+
+## Decision
+Expose GET /api/search as a thin transport adapter over OrbitRuntime::global_search. The endpoint accepts the unified query, kind, status, tag, path, hybrid, and semantic parameters and returns the runtime response unchanged, including the effective mode and per-hit retriever rank breakdown. If hybrid infrastructure is unavailable, the shared runtime pipeline degrades to lexical so CLI and HTTP callers observe the same behavior.
+
+## Consequences
+- Bridge can proxy one authoritative endpoint instead of owning a second search implementation.
+- CLI, tool, and HTTP search share filtering, ranking, result ordering, and fallback semantics.
+- Cost: the unified search parameter names and serialized result shape become an HTTP compatibility contract; future search changes must preserve or deliberately version that surface.

--- a/crates/orbit-core/src/command/search/convert.rs
+++ b/crates/orbit-core/src/command/search/convert.rs
@@ -12,6 +12,7 @@ pub(super) fn lexical_task_hit(task: &orbit_common::types::Task) -> GlobalSearch
         best_field: None,
         snippet: None,
         score: None,
+        score_breakdown: None,
         matched_by: None,
     }
 }
@@ -28,6 +29,7 @@ pub(super) fn semantic_hit_to_global(hit: orbit_search::SemanticHit) -> GlobalSe
         best_field: Some(hit.best_field),
         snippet: Some(hit.snippet),
         score: Some(hit.score),
+        score_breakdown: Some(hit.score_breakdown),
         matched_by: None,
     }
 }
@@ -48,6 +50,7 @@ pub(super) fn doc_result_to_global(
         best_field: None,
         snippet: None,
         score,
+        score_breakdown: None,
         matched_by: Some(result.matched_by),
     }
 }
@@ -67,6 +70,7 @@ pub(super) fn adr_result_to_global(
         best_field: None,
         snippet: None,
         score: Some(result.score as f32),
+        score_breakdown: None,
         matched_by: Some(result.matched_by),
     }
 }
@@ -99,6 +103,7 @@ pub(super) fn adr_to_global_hit_with_source(
         best_field: None,
         snippet: None,
         score: None,
+        score_breakdown: None,
         matched_by,
     }
 }

--- a/crates/orbit-core/src/command/search/hybrid.rs
+++ b/crates/orbit-core/src/command/search/hybrid.rs
@@ -6,7 +6,7 @@ use super::convert::doc_result_to_global;
 use super::types::GlobalSearchHit;
 use super::{
     ADR_HYBRID_FALLBACK_NOTE, DOC_HYBRID_FALLBACK_NOTE, DOC_SEARCH_MIN_CANDIDATES,
-    DOC_SEARCH_OVERFETCH, LEARNING_HYBRID_FALLBACK_NOTE,
+    DOC_SEARCH_OVERFETCH, LEARNING_HYBRID_FALLBACK_NOTE, TASK_HYBRID_FALLBACK_NOTE,
 };
 
 pub(super) fn doc_search_candidate_limit(limit: usize) -> usize {
@@ -271,6 +271,19 @@ pub(super) fn warn_learning_hybrid_fallback(notes: &mut Vec<String>, reason: &st
         notes,
         "learning hybrid vector",
         &format!("{LEARNING_HYBRID_FALLBACK_NOTE}: {reason}"),
+    );
+}
+
+pub(super) fn warn_task_hybrid_fallback(notes: &mut Vec<String>, reason: &str) {
+    orbit_common::tracing::warn!(
+        target: "orbit.search.tasks",
+        reason,
+        "falling back to lexical task search"
+    );
+    push_skip_note(
+        notes,
+        "task hybrid vector",
+        &format!("{TASK_HYBRID_FALLBACK_NOTE}: {reason}"),
     );
 }
 

--- a/crates/orbit-core/src/command/search/mod.rs
+++ b/crates/orbit-core/src/command/search/mod.rs
@@ -47,6 +47,7 @@ const DOC_SEARCH_OVERFETCH: usize = 4;
 const DOC_HYBRID_FALLBACK_NOTE: &str = "falling back to lexical doc search";
 const ADR_HYBRID_FALLBACK_NOTE: &str = "falling back to lexical ADR search";
 const LEARNING_HYBRID_FALLBACK_NOTE: &str = "falling back to lexical learning search";
+const TASK_HYBRID_FALLBACK_NOTE: &str = "falling back to lexical task search";
 const DOC_SEARCH_MIN_CANDIDATES: usize = DEFAULT_LIMIT * DOC_SEARCH_OVERFETCH;
 
 #[cfg(test)]
@@ -59,6 +60,9 @@ thread_local! {
         const { std::cell::RefCell::new(None) };
     static LEARNING_SEMANTIC_SEARCH_OVERRIDE:
         std::cell::RefCell<Option<Result<Vec<LearningSemanticHit>, String>>> =
+        const { std::cell::RefCell::new(None) };
+    static TASK_SEMANTIC_SEARCH_OVERRIDE:
+        std::cell::RefCell<Option<Result<Vec<orbit_search::SemanticHit>, String>>> =
         const { std::cell::RefCell::new(None) };
 }
 
@@ -132,12 +136,6 @@ impl OrbitRuntime {
             ));
         }
 
-        let mode = if params.hybrid {
-            GlobalSearchMode::Hybrid
-        } else {
-            GlobalSearchMode::Lexical
-        };
-
         let mut branches = Vec::new();
 
         if params.kind.includes_tasks() {
@@ -147,6 +145,7 @@ impl OrbitRuntime {
                 query_owned.as_deref(),
                 &tag_filter,
                 limit,
+                &mut notes,
             )?);
         }
 
@@ -192,6 +191,15 @@ impl OrbitRuntime {
         }
 
         let results = merge_round_robin(branches, limit);
+        let mode = if params.hybrid
+            && results
+                .iter()
+                .any(|hit| matches!(hit.source.as_str(), "hybrid" | "semantic"))
+        {
+            GlobalSearchMode::Hybrid
+        } else {
+            GlobalSearchMode::Lexical
+        };
         Ok(GlobalSearchResponse {
             mode,
             kind: params.kind,
@@ -207,33 +215,33 @@ impl OrbitRuntime {
         query: Option<&str>,
         tag_filter: &[String],
         limit: usize,
+        notes: &mut Vec<String>,
     ) -> Result<Vec<GlobalSearchHit>, OrbitError> {
         let statuses = resolve_task_statuses(params, status_filters);
 
         let candidates = if params.hybrid
             && let Some(query) = query
         {
-            let search = self.semantic_search(SemanticSearchParams {
-                query: query.to_string(),
-                limit: limit.saturating_mul(2).max(limit),
-                field: None,
-                kind: Some("task".to_string()),
-                model: None,
-            })?;
-            // Resolve task records so we can apply the post-filters.
-            let mut hits: Vec<(GlobalSearchHit, Option<orbit_common::types::Task>)> = Vec::new();
-            for hit in search.results.into_iter() {
-                let task = self.get_task(&hit.source_id).ok();
-                hits.push((semantic_hit_to_global(hit), task));
+            let semantic = self.task_semantic_hits(query, limit.saturating_mul(2).max(limit));
+            match semantic {
+                Ok(hits) if !hits.is_empty() => hits
+                    .into_iter()
+                    .map(|hit| {
+                        let task = self.get_task(&hit.source_id).ok();
+                        (semantic_hit_to_global(hit), task)
+                    })
+                    .collect(),
+                Ok(_) => {
+                    hybrid::warn_task_hybrid_fallback(notes, "no task embeddings found");
+                    self.lexical_task_candidates(query, limit)?
+                }
+                Err(error) => {
+                    hybrid::warn_task_hybrid_fallback(notes, &error.to_string());
+                    self.lexical_task_candidates(query, limit)?
+                }
             }
-            hits
         } else if let Some(query) = query {
-            let mut tasks = self.search_tasks_filtered(query, &[])?;
-            tasks.truncate(limit.saturating_mul(2).max(limit));
-            tasks
-                .into_iter()
-                .map(|task| (lexical_task_hit(&task), Some(task)))
-                .collect()
+            self.lexical_task_candidates(query, limit)?
         } else {
             // No query → enumerate tasks (used by `--path` and `--tag`).
             let tasks = self.list_tasks()?;
@@ -265,6 +273,40 @@ impl OrbitRuntime {
         }
         out.truncate(limit);
         Ok(out)
+    }
+
+    fn lexical_task_candidates(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<(GlobalSearchHit, Option<orbit_common::types::Task>)>, OrbitError> {
+        let mut tasks = self.search_tasks_filtered(query, &[])?;
+        tasks.truncate(limit.saturating_mul(2).max(limit));
+        Ok(tasks
+            .into_iter()
+            .map(|task| (lexical_task_hit(&task), Some(task)))
+            .collect())
+    }
+
+    fn task_semantic_hits(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<orbit_search::SemanticHit>, OrbitError> {
+        #[cfg(test)]
+        if let Some(result) = TASK_SEMANTIC_SEARCH_OVERRIDE.with(|cell| cell.borrow().clone()) {
+            return result.map_err(OrbitError::Execution);
+        }
+
+        Ok(self
+            .semantic_search(SemanticSearchParams {
+                query: query.to_string(),
+                limit,
+                field: None,
+                kind: Some("task".to_string()),
+                model: None,
+            })?
+            .results)
     }
 
     fn doc_branch(
@@ -299,6 +341,7 @@ impl OrbitRuntime {
                     best_field: None,
                     snippet: None,
                     score: None,
+                    score_breakdown: None,
                     matched_by: Some(tag_filter.iter().map(|tag| format!("tag:{tag}")).collect()),
                 });
             }
@@ -454,6 +497,7 @@ impl OrbitRuntime {
                         best_field: None,
                         snippet: None,
                         score: None,
+                        score_breakdown: None,
                         matched_by: None,
                     },
                     lexical_score: None,
@@ -764,6 +808,7 @@ impl OrbitRuntime {
                     best_field: None,
                     snippet: None,
                     score: None,
+                    score_breakdown: None,
                     matched_by: Some(result.matched_by),
                 });
             }
@@ -805,6 +850,7 @@ impl OrbitRuntime {
                     best_field: None,
                     snippet: None,
                     score: None,
+                    score_breakdown: None,
                     matched_by: None,
                 });
             }
@@ -892,6 +938,7 @@ impl OrbitRuntime {
                         best_field: None,
                         snippet: None,
                         score: None,
+                        score_breakdown: None,
                         matched_by: None,
                     },
                     lexical_score: None,

--- a/crates/orbit-core/src/command/search/tests/hybrid.rs
+++ b/crates/orbit-core/src/command/search/tests/hybrid.rs
@@ -2,6 +2,68 @@ use super::*;
 use serde_json::json;
 
 #[test]
+fn global_search_task_hybrid_preserves_retriever_breakdown() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    let id = add_task_with_status(&runtime, "task hybrid breakdown", TaskStatus::Backlog);
+
+    let response = with_task_semantic_override(Ok(vec![task_semantic_hit(&id, 0.75)]), || {
+        runtime
+            .global_search(GlobalSearchParams {
+                query: Some("task hybrid breakdown".to_string()),
+                hybrid: true,
+                kind: GlobalSearchKind::Task,
+                limit: 3,
+                ..Default::default()
+            })
+            .expect("task hybrid search")
+    });
+
+    assert_eq!(response.mode, GlobalSearchMode::Hybrid);
+    assert_eq!(
+        serde_json::to_value(&response.results[0]).expect("serialize hit"),
+        json!({
+            "kind": "task",
+            "source": "semantic",
+            "id": id,
+            "status": "backlog",
+            "best_field": "title",
+            "snippet": "semantic task snippet",
+            "score": 0.75,
+            "score_breakdown": {
+                "rrf": 0.75,
+                "bm25_rank": 2,
+                "cosine_rank": 1
+            }
+        })
+    );
+}
+
+#[test]
+fn global_search_task_hybrid_falls_back_to_lexical_on_semantic_error() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    let id = add_task_with_status(&runtime, "task fallback needle", TaskStatus::Backlog);
+
+    let response = with_task_semantic_override(Err("companion missing".to_string()), || {
+        runtime
+            .global_search(GlobalSearchParams {
+                query: Some("task fallback needle".to_string()),
+                hybrid: true,
+                kind: GlobalSearchKind::Task,
+                limit: 3,
+                ..Default::default()
+            })
+            .expect("task lexical fallback")
+    });
+
+    assert_eq!(response.mode, GlobalSearchMode::Lexical);
+    assert!(response.notes.iter().any(|note| {
+        note.contains("falling back to lexical task search") && note.contains("companion missing")
+    }));
+    assert_eq!(response.results[0].source, "lexical");
+    assert_eq!(response.results[0].id.as_deref(), Some(id.as_str()));
+}
+
+#[test]
 fn global_search_doc_hybrid_uses_docs_semantic_weight() {
     let runtime = OrbitRuntime::in_memory().expect("runtime");
     add_doc_with_tags(&runtime, "docs/z-lexical.md", "Literal primary", &["foo"]);
@@ -375,6 +437,7 @@ fn adr_hybrid_handles_single_candidate_side() {
         best_field: None,
         snippet: None,
         score: None,
+        score_breakdown: None,
         matched_by: None,
     };
     let out = blend_adr_hybrid_candidates(
@@ -403,6 +466,7 @@ fn hybrid_handles_single_candidate_side() {
         best_field: None,
         snippet: None,
         score: None,
+        score_breakdown: None,
         matched_by: None,
     };
     let out = blend_doc_hybrid_candidates(
@@ -605,6 +669,7 @@ fn learning_hybrid_handles_single_candidate_side() {
         best_field: None,
         snippet: None,
         score: None,
+        score_breakdown: None,
         matched_by: None,
     };
     let out = blend_learning_hybrid_candidates(

--- a/crates/orbit-core/src/command/search/tests/mod.rs
+++ b/crates/orbit-core/src/command/search/tests/mod.rs
@@ -1,7 +1,9 @@
 use std::fs;
 
 use orbit_common::types::{AdrStatus, LearningScope, TaskPriority, TaskStatus, TaskType};
-use orbit_search::{AdrSemanticHit, DocSemanticHit, LearningSemanticHit};
+use orbit_search::{
+    AdrSemanticHit, DocSemanticHit, LearningSemanticHit, ScoreBreakdown, SemanticHit,
+};
 use orbit_store::{AdrCreateParams, LearningCreateParams, TaskCreateParams};
 
 use super::*;
@@ -179,6 +181,21 @@ fn learning_semantic_hit(id: &str, score: f32) -> LearningSemanticHit {
     }
 }
 
+fn task_semantic_hit(id: &str, score: f32) -> SemanticHit {
+    SemanticHit {
+        source_kind: "task".to_string(),
+        source_id: id.to_string(),
+        best_field: "title".to_string(),
+        snippet: "semantic task snippet".to_string(),
+        score,
+        score_breakdown: ScoreBreakdown {
+            rrf: Some(score),
+            bm25_rank: Some(2),
+            cosine_rank: Some(1),
+        },
+    }
+}
+
 fn with_doc_semantic_override<T>(
     result: Result<Vec<DocSemanticHit>, String>,
     f: impl FnOnce() -> T,
@@ -216,6 +233,20 @@ fn with_learning_semantic_override<T>(
     });
     let out = f();
     LEARNING_SEMANTIC_SEARCH_OVERRIDE.with(|cell| {
+        *cell.borrow_mut() = None;
+    });
+    out
+}
+
+fn with_task_semantic_override<T>(
+    result: Result<Vec<SemanticHit>, String>,
+    f: impl FnOnce() -> T,
+) -> T {
+    TASK_SEMANTIC_SEARCH_OVERRIDE.with(|cell| {
+        *cell.borrow_mut() = Some(result);
+    });
+    let out = f();
+    TASK_SEMANTIC_SEARCH_OVERRIDE.with(|cell| {
         *cell.borrow_mut() = None;
     });
     out

--- a/crates/orbit-core/src/command/search/types.rs
+++ b/crates/orbit-core/src/command/search/types.rs
@@ -2,6 +2,8 @@ use std::str::FromStr;
 
 use serde::Serialize;
 
+use orbit_search::ScoreBreakdown;
+
 use super::DEFAULT_LIMIT;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
@@ -129,6 +131,8 @@ pub struct GlobalSearchHit {
     pub snippet: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub score: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub score_breakdown: Option<ScoreBreakdown>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub matched_by: Option<Vec<String>>,
 }

--- a/crates/orbit-dashboard/src/api/mod.rs
+++ b/crates/orbit-dashboard/src/api/mod.rs
@@ -33,6 +33,7 @@ mod review_threads;
 mod routines;
 mod runs;
 mod scoreboard;
+mod search;
 mod tasks;
 mod workspaces;
 
@@ -331,6 +332,7 @@ async fn require_localhost_origin(request: Request<Body>, next: Next) -> Respons
 
 pub(super) fn router() -> Router<crate::state::DashboardState> {
     Router::new()
+        .route("/search", get(search::search))
         .route(
             "/tasks",
             get(tasks::list_tasks).post(tasks::create_task_action),

--- a/crates/orbit-dashboard/src/api/search.rs
+++ b/crates/orbit-dashboard/src/api/search.rs
@@ -1,0 +1,92 @@
+//! Unified lexical, hybrid, and neighbor search over the dashboard HTTP API.
+
+use std::str::FromStr;
+
+use axum::extract::RawQuery;
+use axum::response::{IntoResponse, Json, Response};
+use orbit_core::{GlobalSearchKind, GlobalSearchParams};
+
+use crate::state::Ws;
+
+use super::{bad_request, map_runtime_error, non_empty_string};
+
+pub(super) async fn search(Ws(runtime): Ws, RawQuery(raw): RawQuery) -> Response {
+    let params = match parse_search_query(raw.as_deref()) {
+        Ok(params) => params,
+        Err(message) => return bad_request(message),
+    };
+    match runtime.global_search(params) {
+        Ok(response) => Json(response).into_response(),
+        Err(error) => map_runtime_error(error),
+    }
+}
+
+fn parse_search_query(raw: Option<&str>) -> Result<GlobalSearchParams, String> {
+    let mut params = GlobalSearchParams::default();
+    params.limit = 10;
+
+    for (key, value) in url::form_urlencoded::parse(raw.unwrap_or_default().as_bytes()) {
+        match key.as_ref() {
+            "query" | "q" => params.query = non_empty_string(&value),
+            "hybrid" => params.hybrid = parse_bool("hybrid", &value)?,
+            "semantic" => params.semantic = non_empty_string(&value),
+            "kind" => {
+                params.kind = GlobalSearchKind::from_str(&value)?;
+            }
+            "limit" => {
+                params.limit = value.parse::<usize>().map_err(|_| {
+                    format!("invalid limit `{value}`; expected a non-negative integer")
+                })?;
+            }
+            "tag" | "tags" => append_csv(&mut params.tags, &value),
+            "all" => params.all = parse_bool("all", &value)?,
+            "status" | "statuses" => append_csv(&mut params.status, &value),
+            "path" => params.path = non_empty_string(&value),
+            // `workspace` is consumed by the Ws extractor. Ignore unknown
+            // query keys like the other dashboard GET endpoints do.
+            _ => {}
+        }
+    }
+
+    Ok(params)
+}
+
+fn append_csv(target: &mut Vec<String>, raw: &str) {
+    target.extend(
+        raw.split(',')
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned),
+    );
+}
+
+fn parse_bool(field: &str, raw: &str) -> Result<bool, String> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" => Ok(true),
+        "false" | "0" => Ok(false),
+        _ => Err(format!(
+            "invalid {field} `{raw}`; expected true, false, 1, or 0"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod query_tests {
+    use super::*;
+
+    #[test]
+    fn query_parser_accepts_repeated_and_csv_filters() {
+        let params = parse_search_query(Some(
+            "query=agent+loop&kind=task&hybrid=true&tag=rust,search&tag=api&status=task%3Aopen&path=src%2Flib.rs&limit=7",
+        ))
+        .expect("parse query");
+
+        assert_eq!(params.query.as_deref(), Some("agent loop"));
+        assert_eq!(params.kind, GlobalSearchKind::Task);
+        assert!(params.hybrid);
+        assert_eq!(params.tags, ["rust", "search", "api"]);
+        assert_eq!(params.status, ["task:open"]);
+        assert_eq!(params.path.as_deref(), Some("src/lib.rs"));
+        assert_eq!(params.limit, 7);
+    }
+}

--- a/crates/orbit-dashboard/src/api/tests/mod.rs
+++ b/crates/orbit-dashboard/src/api/tests/mod.rs
@@ -17,5 +17,6 @@ mod review_threads;
 mod routines;
 mod runs;
 mod scoreboard;
+mod search;
 mod tasks;
 mod workspaces;

--- a/crates/orbit-dashboard/src/api/tests/search.rs
+++ b/crates/orbit-dashboard/src/api/tests/search.rs
@@ -1,0 +1,119 @@
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use orbit_core::command::task::TaskAddParams;
+use orbit_core::{GlobalSearchKind, GlobalSearchParams, OrbitRuntime, TaskStatus};
+use serde_json::Value;
+use tower::ServiceExt;
+
+use super::super::*;
+use super::test_support::body_json;
+
+async fn request_search(runtime: OrbitRuntime, query: &str) -> (StatusCode, Value) {
+    let response = router()
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
+        .oneshot(
+            Request::builder()
+                .uri(format!("/search?{query}"))
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    (response.status(), body_json(response).await)
+}
+
+fn seed_search_task(runtime: &OrbitRuntime) {
+    runtime
+        .add_task(TaskAddParams {
+            title: "Bridge hybrid search parity".to_string(),
+            description: "Expose ranked search through the HTTP API.".to_string(),
+            status: Some(TaskStatus::Backlog),
+            tags: vec!["search".to_string(), "api".to_string()],
+            context_files: vec!["file:crates/orbit-dashboard/src/api/search.rs".to_string()],
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("seed task");
+}
+
+#[tokio::test]
+async fn search_route_matches_unified_lexical_pipeline() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    seed_search_task(&runtime);
+    let params = GlobalSearchParams {
+        query: Some("Bridge hybrid".to_string()),
+        kind: GlobalSearchKind::Task,
+        limit: 5,
+        tags: vec!["search".to_string(), "api".to_string()],
+        ..Default::default()
+    };
+    let expected = serde_json::to_value(runtime.global_search(params).expect("direct search"))
+        .expect("serialize direct search");
+
+    let (status, actual) = request_search(
+        runtime,
+        "query=Bridge+hybrid&kind=task&limit=5&tag=search&tag=api",
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(actual, expected);
+}
+
+#[tokio::test]
+async fn search_route_matches_hybrid_fallback_and_reports_lexical_mode() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    let params = GlobalSearchParams {
+        query: Some("no indexed vectors".to_string()),
+        hybrid: true,
+        kind: GlobalSearchKind::Task,
+        limit: 5,
+        ..Default::default()
+    };
+    let expected = serde_json::to_value(runtime.global_search(params).expect("direct search"))
+        .expect("serialize direct search");
+
+    let (status, actual) = request_search(
+        runtime,
+        "query=no+indexed+vectors&kind=task&limit=5&hybrid=true",
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(actual, expected);
+    assert_eq!(actual["mode"], "lexical");
+}
+
+#[tokio::test]
+async fn search_route_rejects_invalid_filters_as_bad_requests() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+
+    let (status, body) = request_search(runtime, "query=x&kind=unknown").await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        body["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("invalid search kind"))
+    );
+}
+
+#[tokio::test]
+async fn search_route_forwards_semantic_neighbor_mode() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+
+    let (status, body) = request_search(
+        runtime,
+        "query=mutually+exclusive&semantic=ORB-00001&kind=task",
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        body["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("`query` and `semantic` are mutually exclusive"))
+    );
+}

--- a/docs/design/orbit-search/4_decisions.md
+++ b/docs/design/orbit-search/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Semantic Search — Decisions"
 type: design
 title: "Semantic Search — Decisions"
 owner: claude
-last_updated: 2026-05-21
+last_updated: 2026-07-20
 status: Accepted
 feature: orbit-search
 doc_role: decisions
@@ -286,6 +286,21 @@ Compare to the analogous knowledge-graph crate: `orbit-knowledge` owns its data 
 
 ---
 
+## ADR-0244 — Expose unified search through a thin HTTP adapter
+
+**Status:** Accepted · 2026-07-20 · [ORB-10304]
+
+**Context.** Bridge needs hybrid Orbit search but can only proxy the dashboard HTTP surface. The alternatives were to keep reconstructing lexical results in Bridge, expose a generic tool-execution HTTP endpoint, or add a narrow search endpoint backed by the same runtime pipeline as the CLI.
+
+**Decision.** Expose `GET /api/search` as a thin transport adapter over `OrbitRuntime::global_search`. The endpoint accepts the unified query, kind, status, tag, path, hybrid, and semantic parameters and returns the runtime response unchanged, including the effective mode and per-hit retriever rank breakdown. If hybrid infrastructure is unavailable, the shared runtime pipeline degrades to lexical so CLI and HTTP callers observe the same behavior.
+
+**Consequences.**
+- Bridge can proxy one authoritative endpoint instead of owning a second search implementation.
+- CLI, tool, and HTTP search share filtering, ranking, result ordering, and fallback semantics.
+- Cost: the unified search parameter names and serialized result shape become an HTTP compatibility contract; future search changes must preserve or deliberately version that surface.
+
+---
+
 ## Task References
 
 - [T20260510-3] — Design semantic search over task artifacts and graph (v2). The task that produced this folder.
@@ -298,5 +313,6 @@ Compare to the analogous knowledge-graph crate: `orbit-knowledge` owns its data 
 - [ORB-00203] — Add ADR envelope `tags` and `paths` so ADRs participate in cross-kind `--tag` / `--path` search filters.
 - [ORB-00205] — Split `orbit search` into query / similar / path forms and require per-kind `--status` syntax. The task that accepted and implemented ADR-0179.
 - [ORB-00206] — Add doc-corpus embeddings through `orbit docs index` and `orbit search --kind doc --hybrid`. The task that accepted and implemented ADR-0180.
+- [ORB-10304] — Expose unified lexical, hybrid, and neighbor search through `GET /api/search`.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10304](https://orbit-cli.com/tasks/ORB-10304) — Expose an HTTP search route on Orbit's API so Bridge can proxy hybrid/vector search

### Description

## Problem

Bridge's `orbit_search` / `search_query` cannot serve hybrid (BM25 + cosine vector) ranking. When a caller passes `hybrid: true`, Bridge silently downgrades to lexical and appends this note:

> hybrid vector ranking unavailable through bridge (orbit's HTTP API exposes no search route); falling back to lexical matching

Source: `bridge/src/bridge/domains/orbit_parity.py:1061-1067`.

## Root cause

Orbit's HTTP API (the `orbit-dashboard` crate) exposes **no search route**. The router in `crates/orbit-dashboard/src/api/mod.rs` registers `/tasks`, `/learnings`, `/adrs`, `/frictions`, `/metrics`, `/runs`, etc. — but nothing that runs the unified search pipeline. Because Bridge owns no data and only proxies Orbit's HTTP surface, it reassembles search itself by pulling `/api/tasks` (and friends) and token-matching locally, which is lexical-only by construction. The hybrid pipeline (embeddings + RRF fusion) lives in the `orbit-search` crate (`commands/search.rs`, `vector/query/{bm25,fuse}.rs`) and is unreachable over HTTP.

This is a genuine parity gap, not a deliberate "hybrid is too noisy" disable — hybrid still works fine via the `orbit search --hybrid` CLI on-box.

## Proposed direction

Add an HTTP endpoint (e.g. `GET /api/search`) that runs the same unified search pipeline as `orbit search` — kind / status / tag / path filters and `hybrid` / `semantic` modes — returning ranked results with `mode`, `matched_by`, and the score breakdown (`bm25_rank` / `cosine_rank`) already exposed by the CLI. Bridge can then proxy the route instead of reimplementing lexical matching, and hybrid becomes reachable through Bridge.

**Companion change (separate, `ws_bridge`):** once the route exists, replace Bridge's local lexical reassembly in `orbit_parity.py` with a proxied call to the new route and drop the fallback note. Flagged here so the two stay contract-integrated per the coupled-system rule.

## Notes

- ADRs stay lexical-only by existing design; hybrid applies to tasks, docs, and learnings.
- The embedder companion is opt-in — the route must degrade to lexical (with an honest `mode`) when vectors are absent, matching current CLI behavior.

### Acceptance Criteria

- GET /api/search exists on the orbit-dashboard router and runs the unified orbit-search pipeline, honoring kind/status/tag/path filters
- The route supports hybrid and semantic modes and returns `mode` plus the per-hit score breakdown (bm25_rank/cosine_rank) so callers can tell which retriever drove each hit
- When the embedder companion or vectors are absent, the route falls back to lexical and reports mode: "lexical" without erroring
- Route results match `orbit search` for the same query/flags (parity test covering a lexical and a hybrid case)
- orbit-search design docs updated in the same PR (flip/add ADR for the new HTTP surface, bump Last updated) and `make ci-fast` passes

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added GET /api/search and mapped query/q, kind, repeated or CSV tag/status filters, path, limit, all, hybrid, and semantic parameters directly onto OrbitRuntime::global_search.
- Preserved orbit-search ScoreBreakdown on unified task hits and made task hybrid failures/empty vector results degrade to lexical with mode: lexical and a fallback note; effective mode is now based on the retriever that produced returned hits.
- Added HTTP/direct-runtime parity coverage for lexical and hybrid-fallback cases, semantic parameter forwarding, filter parsing, invalid inputs, and core coverage for bm25_rank/cosine_rank serialization.
- Allocated and accepted ADR-0244, added its worktree artifact, and updated docs/design/orbit-search/4_decisions.md with the HTTP contract and 2026-07-20 last_updated.
Assessment: The route is a thin transport adapter with no new crate dependency edge or duplicate search implementation. CLI/tool/HTTP share one runtime pipeline and serialized response.
Validation:
- make ci-fast: passed.
- cargo check -p orbit-core -p orbit-dashboard --tests: passed.
- cargo test -p orbit-core command::search::tests: 38 passed.
- cargo test -p orbit-dashboard search: 5 passed.
- cargo test -p orbit-cli command::search: compiled and passed (no matching unit tests).
- Full cargo test -p orbit-dashboard: 202 passed; 2 unrelated pre-existing attribution assertions failed because OrbitRuntime::in_memory inherited the executor model gpt-5.6-sol while those tests expect human. The modified search tests all passed, and the required repository gate make ci-fast passed.
Deviations from original plan:
- Added tightly coupled orbit-core search files after recording the scope expansion because the existing global projection discarded ScoreBreakdown and lacked task hybrid fallback; implementing those in the HTTP handler would have duplicated and diverged from the CLI pipeline.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10304-6a5d83b3`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*