### PR TITLE
Telemetry v1 step 5: populate duel EfficiencyMetrics.token_usage from run telemetry

### DIFF
--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/metrics.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/metrics.rs
@@ -1,8 +1,8 @@
 use orbit_common::types::{
     OrbitError, PlanningDuelRun, PlanningEfficiency, PlanningOutcome, PlanningRoleAssignment,
-    PlanningRoles, RoleSlot,
+    PlanningRoles, RoleSlot, TokenUsage,
 };
-use orbit_store::planning_duel_scoreboard;
+use orbit_store::{InvocationQuery, InvocationRecord, planning_duel_scoreboard};
 use serde_json::{Value, json};
 
 use crate::context::{ActivityInvocationResult, RuntimeHost, TaskHost};
@@ -22,18 +22,49 @@ fn efficiency_from_invocation(invocation: &ActivityInvocationResult) -> Planning
         // wall clock separately from the invocation trace payload.
         wall_clock_ms: invocation.duration_ms,
         tool_call_count: trace.tool_calls.len() as u64,
-        input_tokens: trace.usage.input,
-        cache_read_tokens: trace.usage.cache_read,
-        cache_create_tokens: trace.usage.cache_create,
-        output_tokens: trace.usage.output,
-        total_tokens: trace
-            .usage
-            .input
-            .saturating_add(trace.usage.cache_read)
-            .saturating_add(trace.usage.cache_create)
-            .saturating_add(trace.usage.output),
+        // Token usage is taken from the persisted invocation telemetry below.
+        // The direct activity result is not the durable telemetry source.
+        token_usage: None,
         byte_proxy_total: trace.tool_calls.iter().map(|call| call.result_bytes).sum(),
     }
+}
+
+pub(super) fn aggregate_token_usage(records: &[InvocationRecord]) -> TokenUsage {
+    records
+        .iter()
+        .fold(TokenUsage::default(), |mut usage, record| {
+            usage.input = usage.input.saturating_add(record.input_tokens);
+            usage.cache_read = usage.cache_read.saturating_add(record.cache_read_tokens);
+            usage.cache_create = usage
+                .cache_create
+                .saturating_add(record.cache_create_tokens);
+            usage.output = usage.output.saturating_add(record.output_tokens);
+            usage
+        })
+}
+
+fn token_usage_from_run_telemetry<H: RuntimeHost + ?Sized>(
+    host: &H,
+    job_run_id: &str,
+    task_id: &str,
+    activity_id: &str,
+    slot: RoleSlot,
+) -> Result<TokenUsage, OrbitError> {
+    let records = host.invocation_records(InvocationQuery {
+        job_run_id: Some(job_run_id.to_string()),
+        activity_id: Some(activity_id.to_string()),
+        task_id: Some(task_id.to_string()),
+        slot: Some(slot),
+        limit: 1_000_000,
+        ..InvocationQuery::default()
+    })?;
+    if records.is_empty() {
+        return Err(OrbitError::Execution(format!(
+            "missing invocation telemetry for planning-duel {slot} in job run '{job_run_id}'"
+        )));
+    }
+
+    Ok(aggregate_token_usage(&records))
 }
 
 pub(super) fn role_metrics_from_invocation(
@@ -92,22 +123,52 @@ pub(super) fn record_planning_duel_scores<H: RuntimeHost + TaskHost + ?Sized>(
 
     let PlanningDuelRoleMetrics {
         family: planner_a_family,
-        slot: _,
-        activity_id: _,
-        efficiency: planner_a_efficiency,
+        slot: planner_a_slot,
+        activity_id: planner_a_activity_id,
+        efficiency: mut planner_a_efficiency,
     } = planner_a_role;
     let PlanningDuelRoleMetrics {
         family: planner_b_family,
-        slot: _,
-        activity_id: _,
-        efficiency: planner_b_efficiency,
+        slot: planner_b_slot,
+        activity_id: planner_b_activity_id,
+        efficiency: mut planner_b_efficiency,
     } = planner_b_role;
     let PlanningDuelRoleMetrics {
         family: arbiter_family,
-        slot: _,
-        activity_id: _,
-        efficiency: arbiter_efficiency,
+        slot: arbiter_slot,
+        activity_id: arbiter_activity_id,
+        efficiency: mut arbiter_efficiency,
     } = arbiter_role;
+    if planner_a_slot != RoleSlot::PlannerA
+        || planner_b_slot != RoleSlot::PlannerB
+        || arbiter_slot != RoleSlot::Arbiter
+    {
+        return Err(OrbitError::InvalidInput(
+            "planning-duel role metrics must use planner_a, planner_b, and arbiter slots"
+                .to_string(),
+        ));
+    }
+    planner_a_efficiency.token_usage = Some(token_usage_from_run_telemetry(
+        host,
+        &job_run_id,
+        task_id,
+        &planner_a_activity_id,
+        planner_a_slot,
+    )?);
+    planner_b_efficiency.token_usage = Some(token_usage_from_run_telemetry(
+        host,
+        &job_run_id,
+        task_id,
+        &planner_b_activity_id,
+        planner_b_slot,
+    )?);
+    arbiter_efficiency.token_usage = Some(token_usage_from_run_telemetry(
+        host,
+        &job_run_id,
+        task_id,
+        &arbiter_activity_id,
+        arbiter_slot,
+    )?);
     let roles = PlanningRoles {
         planner_a: PlanningRoleAssignment {
             family: planner_a_family,

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/tests/metrics.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/tests/metrics.rs
@@ -1,0 +1,61 @@
+use chrono::Utc;
+use orbit_common::types::{RoleSlot, TokenUsage};
+use orbit_store::InvocationRecord;
+
+use super::super::metrics::aggregate_token_usage;
+use super::super::types::{PlanningDuelEfficiency, into_efficiency_metrics};
+
+fn invocation_record(
+    input_tokens: u64,
+    cache_read_tokens: u64,
+    cache_create_tokens: u64,
+    output_tokens: u64,
+) -> InvocationRecord {
+    InvocationRecord {
+        id: 1,
+        ts: Utc::now(),
+        job_run_id: "jrun-1".to_string(),
+        activity_id: "propose_duel_plan".to_string(),
+        agent: "codex".to_string(),
+        model: Some("gpt-5.6".to_string()),
+        slot: Some(RoleSlot::PlannerA),
+        duration_ms: 10,
+        input_tokens,
+        cache_read_tokens,
+        cache_create_tokens,
+        output_tokens,
+        total_tokens: input_tokens
+            .saturating_add(cache_read_tokens)
+            .saturating_add(cache_create_tokens)
+            .saturating_add(output_tokens),
+        tool_call_count: 0,
+        task_ids: vec!["ORB-10339".to_string()],
+        tool_calls: Vec::new(),
+    }
+}
+
+#[test]
+fn aggregate_token_usage_preserves_all_telemetry_splits() {
+    let usage = aggregate_token_usage(&[
+        invocation_record(100, 20, 30, 40),
+        invocation_record(7, 8, 9, 10),
+    ]);
+
+    assert_eq!(usage.input, 107);
+    assert_eq!(usage.cache_read, 28);
+    assert_eq!(usage.cache_create, 39);
+    assert_eq!(usage.output, 50);
+}
+
+#[test]
+fn efficiency_metrics_preserve_reported_zero_token_usage() {
+    let token_usage = TokenUsage::default();
+    let metrics = into_efficiency_metrics(PlanningDuelEfficiency {
+        token_usage: Some(token_usage.clone()),
+        byte_proxy_total: 42,
+        ..PlanningDuelEfficiency::default()
+    });
+
+    assert_eq!(metrics.token_usage, Some(token_usage));
+    assert_eq!(metrics.byte_proxy_total, None);
+}

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/tests/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/tests/mod.rs
@@ -2,5 +2,6 @@
 
 mod artifacts;
 mod context_files;
+mod metrics;
 mod roles;
 // runner folded content not yet consolidated in this pass (old nested removed to eliminate anti-pattern); tests coverage for that module temporarily reduced but structure cleaned. See ORB-00240.

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/types.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/types.rs
@@ -1,4 +1,6 @@
-use orbit_common::types::{AgentFamily, EfficiencyMetrics, PlanningRoleAssignment, RoleSlot};
+use orbit_common::types::{
+    AgentFamily, EfficiencyMetrics, PlanningRoleAssignment, RoleSlot, TokenUsage,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -14,11 +16,7 @@ pub(super) struct PlanningDuelEfficiency {
     pub invocation_count: u64,
     pub wall_clock_ms: u64,
     pub tool_call_count: u64,
-    pub input_tokens: u64,
-    pub cache_read_tokens: u64,
-    pub cache_create_tokens: u64,
-    pub output_tokens: u64,
-    pub total_tokens: u64,
+    pub token_usage: Option<TokenUsage>,
     pub byte_proxy_total: u64,
 }
 
@@ -59,22 +57,13 @@ pub(super) struct PlanningDuelPlanArtifact {
 }
 
 pub(super) fn into_efficiency_metrics(value: PlanningDuelEfficiency) -> EfficiencyMetrics {
-    let token_usage = orbit_common::types::TokenUsage {
-        input: value.input_tokens,
-        cache_read: value.cache_read_tokens,
-        cache_create: value.cache_create_tokens,
-        output: value.output_tokens,
-    };
-    let has_exact_tokens = token_usage.input > 0
-        || token_usage.cache_read > 0
-        || token_usage.cache_create > 0
-        || token_usage.output > 0;
+    let has_token_usage = value.token_usage.is_some();
 
     EfficiencyMetrics {
         wall_clock_ms: value.wall_clock_ms,
         tool_call_count: value.tool_call_count.min(u32::MAX as u64) as u32,
-        token_usage: has_exact_tokens.then_some(token_usage),
-        byte_proxy_total: (!has_exact_tokens && value.byte_proxy_total > 0)
+        token_usage: value.token_usage,
+        byte_proxy_total: (!has_token_usage && value.byte_proxy_total > 0)
             .then_some(value.byte_proxy_total),
     }
 }


### PR DESCRIPTION
## Task

[ORB-10339](https://orbit-cli.com/tasks/ORB-10339) — Telemetry v1 step 5: populate duel EfficiencyMetrics.token_usage from run telemetry

### Description

Per `knowledgebase/polaris/design/agent-telemetry.md` (execution plan #5). `duel.rs` already has per-side model, winner, scores, and `EfficiencyMetrics.token_usage` reserved as `None` "until the agent runtime starts reporting them end-to-end". Wire the per-side token usage from the now-captured run telemetry (worker step 1 typed usage, ingested via step 3). No new store.

Scope change from the design doc: effort is NOT captured in v1 (Daniel 2026-07-20), so populate token_usage only — leave any effort field untouched.

Depends on the worker step 1 and orbit step 3 tasks. PR-gated repo: dedicated worktree off `agent-main`, land via PR + CI.

### Acceptance Criteria

- Duel records populate EfficiencyMetrics.token_usage per side from real run telemetry
- No new storage introduced; effort fields left unpopulated
- A completed duel shows non-None token usage for both sides

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Planning-duel score recording now reads persisted invocation telemetry by job run, task, activity, and role slot, then writes exact token splits into each role’s EfficiencyMetrics.token_usage.
- Missing per-slot telemetry now prevents a completed score record with absent token usage; no storage was added and existing duration/tool/byte metrics remain unchanged.
- Added focused coverage for token-split aggregation and preserving a reported zero-token usage payload.
Assessment: Scoped telemetry wiring is complete; effort is untouched.
Validation:
- cargo test -p orbit-engine planning_duel::tests::metrics
- make ci-fast

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10339-6a5d8dfa`
- Behind base: 0
- Ahead of base: 1