### PR TITLE
Telemetry v1 step 3: ingestion entry point into the orbit invocation store for worker runs

### DIFF
--- a/crates/orbit-dashboard/src/api/metrics.rs
+++ b/crates/orbit-dashboard/src/api/metrics.rs
@@ -2,11 +2,12 @@
 
 use crate::state::Ws;
 use axum::extract::{Path, Query};
+use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
 use chrono::{DateTime, Utc};
-use orbit_core::InvocationQuery;
 use orbit_core::command::job::JobRunListParams;
 use orbit_core::metrics::aggregate as aggregate_knowledge_stats;
+use orbit_core::{InvocationInsertParams, InvocationQuery};
 use serde::Deserialize;
 
 use super::{LimitQuery, map_runtime_error, non_empty_string};
@@ -76,6 +77,16 @@ pub(super) async fn invocation_metrics(
     };
     match runtime.invocation_records(query) {
         Ok(rows) => Json(rows).into_response(),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+pub(super) async fn ingest_invocation(
+    Ws(runtime): Ws,
+    Json(params): Json<InvocationInsertParams>,
+) -> Response {
+    match runtime.insert_invocation_trace_record(&params) {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(e) => map_runtime_error(e),
     }
 }

--- a/crates/orbit-dashboard/src/api/mod.rs
+++ b/crates/orbit-dashboard/src/api/mod.rs
@@ -396,7 +396,10 @@ pub(super) fn router() -> Router<crate::state::DashboardState> {
         .route("/metrics/activity", get(metrics::activity_metrics))
         .route("/metrics/tools", get(metrics::tool_metrics))
         .route("/metrics/task/:id", get(metrics::task_metrics))
-        .route("/metrics/invocations", get(metrics::invocation_metrics))
+        .route(
+            "/metrics/invocations",
+            get(metrics::invocation_metrics).post(metrics::ingest_invocation),
+        )
         .route(
             "/diagnostics/metrics",
             get(diagnostics::list_diagnostics_metrics),

--- a/crates/orbit-dashboard/src/api/tests/metrics.rs
+++ b/crates/orbit-dashboard/src/api/tests/metrics.rs
@@ -40,6 +40,25 @@ async fn request_metrics(runtime: OrbitRuntime, uri: &str) -> Response {
         .expect("response")
 }
 
+async fn ingest_metrics(runtime: OrbitRuntime, params: &InvocationInsertParams) -> Response {
+    Router::new()
+        .nest("/api", router())
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/metrics/invocations")
+                .header("content-type", "application/json")
+                .header("origin", "http://localhost")
+                .body(Body::from(
+                    serde_json::to_vec(params).expect("serialize invocation params"),
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("response")
+}
+
 async fn body_bytes(response: Response) -> Vec<u8> {
     to_bytes(response.into_body(), usize::MAX)
         .await
@@ -289,4 +308,112 @@ async fn metrics_invocations_reports_invalid_rfc3339_field() {
     let payload = body_json(response).await;
     let message = payload["error"].as_str().expect("error message");
     assert!(message.contains("invalid since:"));
+}
+
+#[tokio::test]
+async fn metrics_invocation_ingestion_preserves_worker_runs_and_aggregates() {
+    const WORKER_TASK_ID: &str = "ORB-WORKER-COUPLED";
+    const SECONDARY_TASK_ID: &str = "ORB-WORKER-SECONDARY";
+    const MODEL: &str = "openai/gpt-5.6-sol-2026-07-20";
+
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let worker_runs = [
+        InvocationInsertParams {
+            job_run_id: "worker-run-001".to_string(),
+            activity_id: "worker.invoke".to_string(),
+            agent: "codex".to_string(),
+            model: Some(MODEL.to_string()),
+            slot: None,
+            task_ids: vec![WORKER_TASK_ID.to_string(), SECONDARY_TASK_ID.to_string()],
+            trace: InvocationTrace {
+                usage: TokenUsage {
+                    input: 120,
+                    cache_read: 80,
+                    cache_create: 3,
+                    output: 14,
+                },
+                tool_calls: Vec::new(),
+                duration_ms: 1_500,
+            },
+        },
+        InvocationInsertParams {
+            job_run_id: "worker-run-002".to_string(),
+            activity_id: "worker.invoke".to_string(),
+            agent: "codex".to_string(),
+            model: Some(MODEL.to_string()),
+            slot: None,
+            task_ids: vec![WORKER_TASK_ID.to_string()],
+            trace: InvocationTrace {
+                usage: TokenUsage {
+                    input: 70,
+                    cache_read: 5,
+                    cache_create: 1,
+                    output: 9,
+                },
+                tool_calls: Vec::new(),
+                duration_ms: 900,
+            },
+        },
+    ];
+
+    for params in &worker_runs {
+        let response = ingest_metrics(runtime.clone(), params).await;
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        assert!(body_bytes(response).await.is_empty());
+    }
+
+    for expected in &worker_runs {
+        let records = runtime
+            .invocation_records(InvocationQuery {
+                job_run_id: Some(expected.job_run_id.clone()),
+                limit: 10,
+                ..InvocationQuery::default()
+            })
+            .expect("query worker invocation");
+        assert_eq!(records.len(), 1);
+        let record = &records[0];
+        assert_eq!(record.job_run_id, expected.job_run_id);
+        assert_eq!(record.activity_id, expected.activity_id);
+        assert_eq!(record.agent, expected.agent);
+        assert_eq!(record.model, expected.model);
+        assert_eq!(record.task_ids, expected.task_ids);
+        assert_eq!(record.input_tokens, expected.trace.usage.input);
+        assert_eq!(record.cache_read_tokens, expected.trace.usage.cache_read);
+        assert_eq!(
+            record.cache_create_tokens,
+            expected.trace.usage.cache_create
+        );
+        assert_eq!(record.output_tokens, expected.trace.usage.output);
+    }
+
+    let task_records = runtime
+        .invocation_records(InvocationQuery {
+            task_id: Some(WORKER_TASK_ID.to_string()),
+            limit: 10,
+            ..InvocationQuery::default()
+        })
+        .expect("query task invocations");
+    assert_eq!(task_records.len(), 2, "all worker runs remain queryable");
+
+    let task_metrics: TaskInvocationMetrics = runtime
+        .task_invocation_metrics(WORKER_TASK_ID)
+        .expect("task invocation metrics");
+    assert_eq!(task_metrics.invocation_count, 2);
+    assert_eq!(task_metrics.total_input_tokens, 190);
+    assert_eq!(task_metrics.total_cache_read_tokens, 85);
+    assert_eq!(task_metrics.total_cache_create_tokens, 4);
+    assert_eq!(task_metrics.total_output_tokens, 23);
+
+    let agent_metrics = runtime
+        .agent_invocation_metrics()
+        .expect("agent invocation metrics");
+    let worker_metrics = agent_metrics
+        .iter()
+        .find(|row| row.agent == "codex" && row.model.as_deref() == Some(MODEL))
+        .expect("worker agent metrics");
+    assert_eq!(worker_metrics.invocation_count, 2);
+    assert_eq!(worker_metrics.total_input_tokens, 190);
+    assert_eq!(worker_metrics.total_cache_read_tokens, 85);
+    assert_eq!(worker_metrics.total_cache_create_tokens, 4);
+    assert_eq!(worker_metrics.total_output_tokens, 23);
 }

--- a/crates/orbit-store/src/sqlite/invocation_store/types.rs
+++ b/crates/orbit-store/src/sqlite/invocation_store/types.rs
@@ -17,7 +17,7 @@ pub struct InvocationQuery {
     pub limit: usize,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InvocationInsertParams {
     pub job_run_id: String,
     pub activity_id: String,

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -3,7 +3,7 @@ summary: "Auditability — Design"
 type: design
 title: "Auditability — Design"
 owner: codex
-last_updated: 2026-07-19
+last_updated: 2026-07-20
 status: Draft
 feature: auditability
 doc_role: design
@@ -118,6 +118,8 @@ The audit CLI exposes command rows through `orbit audit list`, `show`, `stats`, 
 
 V2 traces are exposed separately: `orbit run events` prints chronological envelopes, `orbit run trace` renders the parent tree, and `orbit run logs` extracts CLI stdout/stderr blobs. `orbit run history` and `orbit run show` expose job-run state rather than the full envelope stream. Metrics and scoreboard commands read invocation records; they summarize cost and usage, not transcript structure.
 
+After [ORB-10337], `POST /api/metrics/invocations` accepts the existing `InvocationInsertParams` shape and writes directly to the invocation store, with no additional schema. Worker bridges use the worker run id as `job_run_id`, pass every task id from run coupling, and preserve the provider's exact model string and input/cache-read/cache-create/output token splits. Each post creates one invocation row, so multiple worker runs coupled to one task remain independently queryable and contribute separately to task and agent aggregates. Like every dashboard mutation, ingestion requires an `Origin` header for `http://localhost` or `http://127.0.0.1`.
+
 The local dashboard exposes two read-only API surfaces for these traces after [T20260508-14]: `GET /api/runs/:id/logs` returns bounded per-step CLI invocation previews, and `GET /api/diagnostics/errors` returns recent process ERROR rows plus structured agent-stderr error rows sorted newest first. Both endpoints use existing dashboard limit conventions and tolerate missing v2 audit files, malformed lines, and missing blobs by returning empty or partial arrays.
 
 After [T20260428-11], compact `summary.json` counts all audited tool-run attempts and failed attempts from command-audit rows where `command: tool`, `subcommand` is `"run"` or `"run-mcp"`, and `tool_name` is present. Token totals still come from invocation/token scoreboards, with legacy tool-call totals used only as a max overlay to avoid obvious double counting.
@@ -178,6 +180,7 @@ Each record contains timestamp, level, target, and structured fields. After [T20
 - **[T20260510-13]** — Move friction reports from task lifecycle state to append-only `.orbit/frictions/` records.
 - **[ORB-00062]** — Surface first-class friction artifacts in the dashboard Knowledge tab and add triage endpoints.
 - **[ORB-00090]** — Aligned agent-facing provenance wording with the family-as-identity convention.
+- **[ORB-10337]** — Added dashboard HTTP ingestion for worker invocation records without changing the invocation schema.
 - **[ORB-00106]** — Preserve per-task implementer attribution when `orbit run ship` moves batch PR tasks from Review to Done.
 - **[ORB-10200]** — Derive CLI audit metadata and the other cross-cutting command policies from one exhaustive command-operation registry.
 - **[ORB-10225]** — Route in-process graph MCP calls through the safe-surface allowlist and shared runtime audit boundary.


### PR DESCRIPTION
## Task

[ORB-10337](https://orbit-cli.com/tasks/ORB-10337) — Telemetry v1 step 3: ingestion entry point into the orbit invocation store for worker runs

### Description

Per `knowledgebase/polaris/design/agent-telemetry.md` (execution plan #3) — the highest-leverage step. Add an ingestion entry point into orbit's existing sqlite invocation store (CLI subcommand or HTTP route accepting `InvocationInsertParams`); the worker/bridge coupling hook posts one `InvocationRecord` per worker run (`job_run_id` = worker run_id, `task_ids` from coupling, exact model + token splits from the typed provider usage of the worker step "parse provider usage into typed ProviderOutcome"). Zero new schema — feed what exists; many-rows-per-task keying fixes the scalar `Task.job_run_id` collapse for metrics purposes and lights up the existing `TaskInvocationMetrics` / `AgentInvocationMetrics` aggregates.

Depends on the worker step 1 task (typed provider usage). Effort capture is out of scope for v1 (Daniel 2026-07-20).

PR-gated repo: work in a dedicated worktree on a branch off `agent-main`, land via PR + CI.

### Acceptance Criteria

- An ingestion entry point (CLI subcommand or HTTP route) accepts InvocationInsertParams and inserts into the existing invocation store with no schema changes
- One InvocationRecord per worker run with job_run_id = worker run_id, task_ids from coupling, exact model string, and token splits
- Existing aggregates (TaskInvocationMetrics, AgentInvocationMetrics) return correct results over ingested worker runs
- A task with multiple runs shows all runs (runs-per-task no longer collapsed)

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `POST /api/metrics/invocations`, accepting the existing `InvocationInsertParams` JSON contract and delegating directly to the existing SQLite invocation store with no schema or dependency changes.
- Made `InvocationInsertParams` serializable/deserializable for the HTTP boundary.
- Added end-to-end coverage that ingests two worker runs coupled to one task, verifies one exact invocation record per worker run (run id, task ids, model, and all token splits), verifies both runs remain queryable for the task, and verifies task/agent aggregate totals.
- Updated the auditability design doc with the ingestion contract and existing localhost-origin requirement.

Assessment: The change is narrowly scoped to the canonical dashboard metrics surface established by ADR-0173 and reuses the existing invocation DTO/store path, so runtime-produced and externally ingested records share identical persistence and aggregate behavior.

Validation:
- `cargo test -p orbit-dashboard api::tests::metrics` (4 passed)
- `cargo test -p orbit-store invocation_store` (3 passed)
- `make ci-fast` (passed)
- `git diff --check` (passed)

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10337-6a5d9445`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*