### PR TITLE
Telemetry v1 step 6b: orbit engine sets AGENT_RUN_ID/AGENT_MODEL/AGENT_TASK when spawning provider CLIs

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -203,6 +203,17 @@ pub fn run_cli_backend(
         child_env.push(("ORBIT_TASK_ID".to_string(), task_id.to_string()));
         child_env.push(("ORBIT_ACTIVE_TASK_ID".to_string(), task_id.to_string()));
     }
+    // Telemetry trailers (ORB-10342, mirrors ORB-10340's worker-side spawn):
+    // the shared prepare-commit-msg injector reads these to stamp
+    // Agent-Run/Agent-Model/Agent-Task on every commit a pipeline-gate
+    // provider CLI makes. Omitted (not empty) when unknown.
+    child_env.push(("AGENT_RUN_ID".to_string(), run_id.to_string()));
+    if let Some(model_name) = model.as_deref() {
+        child_env.push(("AGENT_MODEL".to_string(), model_name.to_string()));
+    }
+    if let Some(task_id) = task_id_from_input(input) {
+        child_env.push(("AGENT_TASK".to_string(), task_id.to_string()));
+    }
     let spawn_result = spawn_with_timeout(SpawnWithTimeoutRequest {
         program: &invocation.program,
         args: &subprocess_args,

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -1649,6 +1649,110 @@ fi
     assert_eq!(outcome.output["provider"], "grok");
 }
 
+/// ORB-10342: pipeline-gate provider spawns must carry the same
+/// AGENT_RUN_ID/AGENT_MODEL/AGENT_TASK trio the worker path sets
+/// (ORB-10340), so the shared prepare-commit-msg injector can stamp commit
+/// trailers regardless of which spawner produced the commit.
+#[test]
+fn run_cli_backend_sets_agent_telemetry_env_vars_for_commit_trailers() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("grok");
+    write_executable(
+        &script,
+        r#"#!/bin/sh
+cat > /dev/null
+if [ "$AGENT_RUN_ID" = "job-grok-telemetry" ] && [ "$AGENT_MODEL" = "grok-build" ] && [ "$AGENT_TASK" = "ORB-10342" ]; then
+  printf '%s\n' '{"schemaVersion":1,"status":"success","result":{"identity":"ok"},"error":null}'
+else
+  printf '%s\n' '{"schemaVersion":1,"status":"failed","error":{"code":"telemetry_env_missing","message":"agent telemetry env was not propagated","details":null}}'
+  exit 1
+fi
+"#,
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-grok-telemetry",
+        "grok:grok-build",
+        sink_for_writer,
+    ));
+    let host = TestHost {
+        command: script.display().to_string(),
+        executor_args: Vec::new(),
+        provider_config: HashMap::new(),
+        sandbox: None,
+        task_context: None,
+        workspace_root: None,
+    };
+    let mut spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
+    spec.model = Some("grok-build".to_string());
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-grok-telemetry",
+        audit,
+        &serde_json::json!({"prompt": "hi", "task_id": "ORB-10342"}),
+        None,
+    )
+    .expect("run succeeds");
+
+    assert!(outcome.success);
+    assert_eq!(outcome.output["provider"], "grok");
+}
+
+/// AGENT_MODEL/AGENT_TASK must be omitted (unset), not set to an empty
+/// string, when the model or task id is unknown — mirrors ORB-10340's
+/// worker-side semantics. AGENT_RUN_ID is always known for a dispatched run.
+#[test]
+fn run_cli_backend_omits_agent_model_and_task_env_vars_when_unknown() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("grok");
+    write_executable(
+        &script,
+        r#"#!/bin/sh
+cat > /dev/null
+if [ "$AGENT_RUN_ID" = "job-grok-telemetry-unknown" ] && [ -z "${AGENT_MODEL+x}" ] && [ -z "${AGENT_TASK+x}" ]; then
+  printf '%s\n' '{"schemaVersion":1,"status":"success","result":{"identity":"ok"},"error":null}'
+else
+  printf '%s\n' '{"schemaVersion":1,"status":"failed","error":{"code":"telemetry_env_unexpected","message":"agent telemetry env should be unset when unknown","details":null}}'
+  exit 1
+fi
+"#,
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-grok-telemetry-unknown",
+        "grok",
+        sink_for_writer,
+    ));
+    let host = TestHost {
+        command: script.display().to_string(),
+        executor_args: Vec::new(),
+        provider_config: HashMap::new(),
+        sandbox: None,
+        task_context: None,
+        workspace_root: None,
+    };
+    let spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-grok-telemetry-unknown",
+        audit,
+        &serde_json::json!({"prompt": "hi"}),
+        None,
+    )
+    .expect("run succeeds");
+
+    assert!(outcome.success);
+    assert_eq!(outcome.output["provider"], "grok");
+}
+
 struct EnvVarGuard {
     key: &'static str,
     previous: Option<OsString>,


### PR DESCRIPTION
## Task

[ORB-10342](https://orbit-cli.com/tasks/ORB-10342) — Telemetry v1 step 6b: orbit engine sets AGENT_RUN_ID/AGENT_MODEL/AGENT_TASK when spawning provider CLIs

### Description

Follow-up to ORB-10340 (ws_constellation), per `knowledgebase/polaris/design/agent-telemetry.md` step 6. ORB-10340 wired the WORKER spawn path to set `AGENT_RUN_ID`/`AGENT_MODEL`/`AGENT_TASK` on provider CLI child envs, but the orbit engine is the second spawner: pipeline gate runs (task_auto_pipeline / task_gate_pipeline / task_local_pipeline children) exec provider CLIs directly, and those are exactly the runs that produce worktree/PR-branch commits. Set the same three env vars at orbit's provider-spawn site(s): AGENT_RUN_ID = the jrun id (e.g. jrun-20260720-0248-3), AGENT_MODEL = resolved crew_model/exact model string, AGENT_TASK = the task id. Mirror ORB-10340's semantics: vars omitted (not empty) when unknown; works for env-allowlisting providers (codex) too — see AgentTelemetryEnvTests in the worker repo for the reference behavior.

DEPLOY PRECONDITION (sequencing, do not skip): git-guard Rule 3 blocks agent commits when AGENT_* vars are set but the effective prepare-commit-msg hook is missing. The box-wide hook install (`git config --global core.hooksPath ~/workspace/constellation/operations/scripts/git-hooks`, Daniel's action after ORB-10340's constellation side merges) must be in place BEFORE this change deploys, or every pipeline run will start failing at commit. State this loudly in the PR description.

PR-gated repo: dedicated worktree off `agent-main`, land via PR + CI.

### Acceptance Criteria

- Orbit-spawned provider CLI processes receive AGENT_RUN_ID, AGENT_MODEL, AGENT_TASK matching the run's jrun id, resolved model, and task id
- Vars are omitted (not set empty) when a value is unknown
- Covered by tests at the spawn site; existing pipeline tests pass
- PR description documents the hooks-install deploy precondition (git-guard Rule 3 interaction)

## Execution Summary

<details>
<summary>Click to expand</summary>

Set AGENT_RUN_ID/AGENT_MODEL/AGENT_TASK on the orbit engine's provider-CLI spawn site (crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs, run_cli_backend's child_env build, ~line 187-216) — the single place where task_auto_pipeline/task_gate_pipeline/task_local_pipeline children exec provider CLIs. Mirrors ORB-10340's worker-side semantics: AGENT_RUN_ID is always set from the run's jrun id (always known for a dispatched run); AGENT_MODEL is set from `agent.model_name()` (the resolved exact model string, already computed earlier in the function) only when Some; AGENT_TASK is set from `task_id_from_input(input)` only when Some. Vars are omitted, not set empty, when unknown — same convention as the worker path (agentbase/worker/server/worker/driver.py:129-143) and its AgentTelemetryEnvTests reference.

Tests added in crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs: `run_cli_backend_sets_agent_telemetry_env_vars_for_commit_trailers` (all three vars present and correct when model + task_id are known) and `run_cli_backend_omits_agent_model_and_task_env_vars_when_unknown` (AGENT_MODEL/AGENT_TASK unset via `${VAR+x}` check, AGENT_RUN_ID still present, when spec.model is None and no task_id is in the input) — both spawn a real shell script subprocess and assert on env as seen by the child, following the existing `run_cli_backend_exports_runtime_identity_for_subprocess_tools` pattern.

Validation: `cargo test -p orbit-engine` (281 passed, 0 failed, includes the 2 new tests) and `make ci-fast` (fmt-check + guardrail scripts) both pass. No new dependencies, no schema/API changes.

DEPLOY PRECONDITION — must be called out loudly in the PR description: git-guard Rule 3 blocks agent commits when AGENT_* env vars are set but the effective prepare-commit-msg hook is missing. Daniel's box-wide hook install (`git config --global core.hooksPath ~/workspace/constellation/operations/scripts/git-hooks`, action item from ORB-10340's constellation-side merge) MUST already be in place before this change deploys, or every orbit-engine pipeline run will start failing at commit time. This PR should not merge/deploy until that hook install is confirmed done.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10342-6a5d98a9`
- Behind base: 0
- Ahead of base: 1