### PR TITLE
commit_batch_changes fails on implement steps that author their own commits

### DIFF
--- a/.orbit/resources/activities/git_commit.yaml
+++ b/.orbit/resources/activities/git_commit.yaml
@@ -19,6 +19,9 @@ spec:
         enum: [all, per_task, per_task_finalize]
       workspace_path:
         type: string
+      base_ref:
+        type: string
+        description: Worktree setup start-point ref used to identify commits authored during implementation.
   output_schema_json:
     type: object
     properties:
@@ -28,7 +31,17 @@ spec:
         type: string
       committed:
         type: boolean
+      adopted_commits:
+        type: boolean
+      base_sha:
+        type: string
       commit_sha:
+        type: string
+      commit_shas:
+        type: array
+        items:
+          type: string
+      job_run_id:
         type: string
       skipped_no_diff_expected:
         type: boolean

--- a/.orbit/resources/jobs/task_local_pipeline.yaml
+++ b/.orbit/resources/jobs/task_local_pipeline.yaml
@@ -70,6 +70,7 @@ spec:
         job_run_id: "{{ steps.worktree.output.job_run_id }}"
         scope: all
         workspace_path: "{{ steps.worktree.output.workspace_path }}"
+        base_ref: "{{ steps.worktree.output.base_ref }}"
 
     - id: merge
       recovery_activity: step_failure_recovery

--- a/.orbit/resources/jobs/task_pr_pipeline.yaml
+++ b/.orbit/resources/jobs/task_pr_pipeline.yaml
@@ -72,6 +72,7 @@ spec:
         job_run_id: "{{ steps.worktree.output.job_run_id }}"
         scope: all
         workspace_path: "{{ steps.worktree.output.workspace_path }}"
+        base_ref: "{{ steps.worktree.output.base_ref }}"
 
     - id: prepare_branch
       when: "{{ steps.commit.output.skipped_no_diff_expected }} != true"

--- a/crates/orbit-core/assets/activities/git_commit.yaml
+++ b/crates/orbit-core/assets/activities/git_commit.yaml
@@ -19,6 +19,9 @@ spec:
         enum: [all, per_task, per_task_finalize]
       workspace_path:
         type: string
+      base_ref:
+        type: string
+        description: Worktree setup start-point ref used to identify commits authored during implementation.
   output_schema_json:
     type: object
     properties:
@@ -28,7 +31,17 @@ spec:
         type: string
       committed:
         type: boolean
+      adopted_commits:
+        type: boolean
+      base_sha:
+        type: string
       commit_sha:
+        type: string
+      commit_shas:
+        type: array
+        items:
+          type: string
+      job_run_id:
         type: string
       skipped_no_diff_expected:
         type: boolean

--- a/crates/orbit-core/assets/jobs/task_local_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_local_pipeline.yaml
@@ -70,6 +70,7 @@ spec:
         job_run_id: "{{ steps.worktree.output.job_run_id }}"
         scope: all
         workspace_path: "{{ steps.worktree.output.workspace_path }}"
+        base_ref: "{{ steps.worktree.output.base_ref }}"
 
     - id: merge
       recovery_activity: step_failure_recovery

--- a/crates/orbit-core/assets/jobs/task_pr_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_pr_pipeline.yaml
@@ -72,6 +72,7 @@ spec:
         job_run_id: "{{ steps.worktree.output.job_run_id }}"
         scope: all
         workspace_path: "{{ steps.worktree.output.workspace_path }}"
+        base_ref: "{{ steps.worktree.output.base_ref }}"
 
     - id: prepare_branch
       when: "{{ steps.commit.output.skipped_no_diff_expected }} != true"

--- a/crates/orbit-core/src/command/job/catalog.rs
+++ b/crates/orbit-core/src/command/job/catalog.rs
@@ -675,6 +675,32 @@ spec:
     }
 
     #[test]
+    fn task_shipment_commit_steps_use_the_worktree_base_checkpoint() {
+        for job_name in ["task_local_pipeline", "task_pr_pipeline"] {
+            let yaml = DEFAULT_JOB_FILES
+                .iter()
+                .find_map(|(name, yaml)| (*name == job_name).then_some(*yaml))
+                .unwrap_or_else(|| panic!("default job {job_name} exists"));
+            let asset =
+                load_job_asset(yaml).unwrap_or_else(|error| panic!("parse {job_name}: {error}"));
+            let commit = asset
+                .spec
+                .steps
+                .iter()
+                .find(|step| step.id == "commit")
+                .expect("commit step");
+            let JobV2StepBody::TargetRef(commit) = &commit.body else {
+                panic!("{job_name} commit step must reference git_commit");
+            };
+            let input = commit.default_input.as_ref().expect("commit input");
+            assert_eq!(
+                input["base_ref"], "{{ steps.worktree.output.base_ref }}",
+                "{job_name} must pass the exact worktree start-point ref"
+            );
+        }
+    }
+
+    #[test]
     fn independent_review_job_requires_structured_exact_head_verdict() {
         let yaml = DEFAULT_JOB_FILES
             .iter()

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
@@ -12,7 +12,7 @@ use serde_json::{Value, json};
 use crate::context::{RuntimeHost, TaskHost};
 
 use super::super::input::{canonicalize_existing_dir, input_string_field, required_job_run_id};
-use super::git::{git_output, git_success};
+use super::git::{git_command_success, git_output, git_success};
 use super::handoff::reject_failed_delivery;
 use author::{append_co_author_trailers, commit_author_for_tasks, git_author_for_task};
 use git_ops::{
@@ -186,10 +186,30 @@ pub(super) fn commit_batch_changes<H: TaskHost + RuntimeHost + ?Sized>(
     ensure_named_branch(&workspace_path)?;
 
     ensure_no_unmerged_changes(&workspace_path)?;
+    let (base_sha, mut commit_shas) = existing_batch_commits(&workspace_path, input, &task.id)?;
     git_success(&workspace_path, &["add", "--all", "--", "."])?;
 
     let changed_files = staged_changed_files(&workspace_path)?;
     if changed_files.is_empty() {
+        if !commit_shas.is_empty() {
+            let commit_sha = git_output(&workspace_path, &["rev-parse", "HEAD"])?;
+            let mut result = json!({
+                "phase": "commit",
+                "decision": "adopted_existing_commits",
+                "committed": false,
+                "adopted_commits": true,
+                "commit_sha": commit_sha.trim(),
+                "commit_shas": commit_shas,
+                "job_run_id": batch_id,
+                "skipped_no_diff_expected": false,
+                "task_id": task.id,
+            });
+            if let Some(base_sha) = base_sha {
+                result["base_sha"] = json!(base_sha);
+            }
+            return Ok(result);
+        }
+
         git_success(&workspace_path, &["reset", "HEAD"])?;
         // ADR-0219: explicit side-effect-only tasks bypass the empty-diff gate.
         if task.tags.iter().any(|tag| tag == NO_DIFF_EXPECTED_TAG) {
@@ -201,14 +221,10 @@ pub(super) fn commit_batch_changes<H: TaskHost + RuntimeHost + ?Sized>(
                 "task_id": task.id,
             }));
         }
-        return Err(OrbitError::Execution(format!(
-            "commit_batch_changes: no staged changes to commit for task '{}' in worktree '{}'; \
-             the implement step produced an empty diff. Changes may have been written outside \
-             the assigned worktree, or attribution may be unknown; Orbit did not inspect, stage, \
-             reset, or reconcile any other checkout",
-            task.id,
-            workspace_path.display()
-        )));
+        return Err(outside_worktree_or_empty_diff_error(
+            &task.id,
+            &workspace_path,
+        ));
     }
 
     let message = batch_commit_message(task);
@@ -216,14 +232,63 @@ pub(super) fn commit_batch_changes<H: TaskHost + RuntimeHost + ?Sized>(
 
     git_commit_with_identity(&workspace_path, &message, author.as_ref())?;
     let commit_sha = git_output(&workspace_path, &["rev-parse", "HEAD"])?;
-    Ok(json!({
+    commit_shas.push(commit_sha.trim().to_string());
+    let mut result = json!({
         "phase": "commit",
         "decision": "performed",
         "committed": true,
+        "adopted_commits": commit_shas.len() > 1,
         "commit_sha": commit_sha.trim(),
+        "commit_shas": commit_shas,
+        "job_run_id": batch_id,
         "skipped_no_diff_expected": false,
         "task_id": task.id,
-    }))
+    });
+    if let Some(base_sha) = base_sha {
+        result["base_sha"] = json!(base_sha);
+    }
+    Ok(result)
+}
+
+fn existing_batch_commits(
+    workspace_path: &Path,
+    input: &Value,
+    task_id: &str,
+) -> Result<(Option<String>, Vec<String>), OrbitError> {
+    let Some(base_ref) = input_string_field(input, "base_ref") else {
+        return Ok((None, Vec::new()));
+    };
+
+    let base_commit = format!("{base_ref}^{{commit}}");
+    let base_sha = git_output(workspace_path, &["rev-parse", "--verify", &base_commit])?;
+    if !git_command_success(
+        workspace_path,
+        &["merge-base", "--is-ancestor", &base_sha, "HEAD"],
+    )? {
+        return Err(outside_worktree_or_empty_diff_error(
+            task_id,
+            workspace_path,
+        ));
+    }
+
+    let range = format!("{base_sha}..HEAD");
+    let commit_shas = git_output(workspace_path, &["rev-list", "--reverse", &range])?
+        .lines()
+        .map(str::trim)
+        .filter(|sha| !sha.is_empty())
+        .map(ToOwned::to_owned)
+        .collect();
+    Ok((Some(base_sha), commit_shas))
+}
+
+fn outside_worktree_or_empty_diff_error(task_id: &str, workspace_path: &Path) -> OrbitError {
+    OrbitError::Execution(format!(
+        "commit_batch_changes: no staged changes to commit for task '{task_id}' in worktree '{}'; \
+         the implement step produced an empty diff. Changes may have been written outside \
+         the assigned worktree, or attribution may be unknown; Orbit did not inspect, stage, \
+         reset, or reconcile any other checkout",
+        workspace_path.display()
+    ))
 }
 
 fn resolve_workspace_path<H: RuntimeHost + ?Sized>(

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/author.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/author.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use orbit_common::types::TaskType;
+use orbit_common::types::{OrbitError, TaskType};
 use serde_json::json;
 
 use super::super::git_commit;
@@ -182,22 +182,252 @@ fn git_commit_batch_errors_on_empty_stage() {
         "claude-opus-4-7",
     )];
     let host = CommitTestHost::new(tasks, workspace.to_path_buf());
+    let base_sha = git_output(workspace, &["rev-parse", "HEAD"]).expect("read base checkpoint");
     let input = json!({
         "scope": "all",
         "job_run_id": "batch-1",
         "workspace_path": workspace.to_string_lossy().to_string(),
+        "base_ref": base_sha,
     });
 
     let error = git_commit(&host, &input).expect_err("empty stage must error");
-    assert!(
-        error.to_string().contains("no staged changes to commit"),
-        "expected empty-diff error, got: {error}"
+    let OrbitError::Execution(message) = error else {
+        panic!("expected execution error, got: {error}");
+    };
+    assert_eq!(
+        message,
+        format!(
+            "commit_batch_changes: no staged changes to commit for task 'T1' in worktree '{}'; \
+             the implement step produced an empty diff. Changes may have been written outside \
+             the assigned worktree, or attribution may be unknown; Orbit did not inspect, stage, \
+             reset, or reconcile any other checkout",
+            workspace.display()
+        ),
+        "the existing empty-diff diagnostic must remain unchanged"
     );
 
     // The index is left clean (the staging reset ran before erroring), so no
     // commit was created beyond the repo's initial commit.
     let log = git_output(workspace, &["rev-list", "--count", "HEAD"]).expect("count commits");
     assert_eq!(log.trim(), "1", "no commit should have been created");
+}
+
+#[test]
+fn git_commit_batch_adopts_implement_authored_commits_without_rewriting_them() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+    let base_sha = git_output(workspace, &["rev-parse", "HEAD"]).expect("read base checkpoint");
+
+    fs::write(workspace.join("README.md"), "reverted\n").unwrap();
+    git_success(workspace, &["add", "README.md"]).expect("stage revert");
+    git_success(
+        workspace,
+        &[
+            "-c",
+            "user.name=Implement Agent",
+            "-c",
+            "user.email=implement@example.test",
+            "commit",
+            "-m",
+            "revert prior change",
+        ],
+    )
+    .expect("author revert commit");
+    fs::write(workspace.join("README.md"), "replacement\n").unwrap();
+    git_success(workspace, &["add", "README.md"]).expect("stage replacement");
+    git_success(
+        workspace,
+        &[
+            "-c",
+            "user.name=Implement Agent",
+            "-c",
+            "user.email=implement@example.test",
+            "commit",
+            "-m",
+            "cherry-pick replacement",
+        ],
+    )
+    .expect("author replacement commit");
+
+    let head_before = git_output(workspace, &["rev-parse", "HEAD"]).expect("read authored head");
+    let authored_shas = git_output(
+        workspace,
+        &["rev-list", "--reverse", &format!("{base_sha}..HEAD")],
+    )
+    .expect("read authored commits")
+    .lines()
+    .map(ToOwned::to_owned)
+    .collect::<Vec<_>>();
+    let task = task_with_file("T1", "History surgery", "README.md", "codex");
+    let host = CommitTestHost::new(vec![task], workspace.to_path_buf());
+    let input = json!({
+        "scope": "all",
+        "job_run_id": "batch-1",
+        "workspace_path": workspace.to_string_lossy().to_string(),
+        "base_ref": base_sha,
+    });
+
+    let result = git_commit(&host, &input).expect("commit-only batch succeeds");
+
+    assert_eq!(result["decision"], "adopted_existing_commits");
+    assert_eq!(result["committed"], false);
+    assert_eq!(result["adopted_commits"], true);
+    assert_eq!(result["task_id"], "T1");
+    assert_eq!(result["job_run_id"], "batch-1");
+    assert_eq!(result["commit_shas"], json!(authored_shas));
+    assert_eq!(result["commit_sha"], head_before);
+    assert_eq!(
+        git_output(workspace, &["rev-parse", "HEAD"]).expect("read final head"),
+        head_before,
+        "the pipeline must not create or amend a commit"
+    );
+    assert_eq!(
+        git_output(workspace, &["log", "-2", "--format=%an <%ae>"]).expect("read retained authors"),
+        "Implement Agent <implement@example.test>\nImplement Agent <implement@example.test>"
+    );
+}
+
+#[test]
+fn git_commit_batch_commits_dirty_residue_above_implement_authored_commits() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+    let base_sha = git_output(workspace, &["rev-parse", "HEAD"]).expect("read base checkpoint");
+
+    fs::write(workspace.join("README.md"), "implement commit\n").unwrap();
+    git_success(workspace, &["add", "README.md"]).expect("stage implement commit");
+    git_success(
+        workspace,
+        &[
+            "-c",
+            "user.name=Implement Agent",
+            "-c",
+            "user.email=implement@example.test",
+            "commit",
+            "-m",
+            "implement authored",
+        ],
+    )
+    .expect("author implement commit");
+    let authored_sha =
+        git_output(workspace, &["rev-parse", "HEAD"]).expect("read implement commit");
+    fs::write(workspace.join("residue.txt"), "dirty residue\n").unwrap();
+
+    let task = task_with_file("T1", "Mixed history", "residue.txt", "codex");
+    let host = CommitTestHost::new(vec![task], workspace.to_path_buf());
+    let input = json!({
+        "scope": "all",
+        "job_run_id": "batch-1",
+        "workspace_path": workspace.to_string_lossy().to_string(),
+        "base_ref": base_sha,
+    });
+
+    let result = git_commit(&host, &input).expect("mixed batch succeeds");
+
+    assert_eq!(result["decision"], "performed");
+    assert_eq!(result["committed"], true);
+    assert_eq!(result["adopted_commits"], true);
+    assert_eq!(result["commit_shas"][0], authored_sha);
+    assert_eq!(result["commit_shas"].as_array().map(Vec::len), Some(2));
+    assert_eq!(
+        git_output(workspace, &["log", "-1", "--format=%P"]).expect("read residue parent"),
+        authored_sha
+    );
+    assert_eq!(
+        git_output(
+            workspace,
+            &["show", "-s", "--format=%an <%ae>", &authored_sha]
+        )
+        .expect("read retained implement author"),
+        "Implement Agent <implement@example.test>"
+    );
+    assert_eq!(
+        git_output(workspace, &["log", "-1", "--format=%an <%ae>"]).expect("read residue author"),
+        "codex <codex@orbit.local>"
+    );
+}
+
+#[test]
+fn git_commit_batch_does_not_adopt_commits_reachable_only_from_another_branch() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+    let base_sha = git_output(workspace, &["rev-parse", "HEAD"]).expect("read base checkpoint");
+
+    git_success(workspace, &["checkout", "-b", "other-worktree-branch"])
+        .expect("create other branch");
+    fs::write(workspace.join("other.txt"), "other branch work\n").unwrap();
+    git_success(workspace, &["add", "other.txt"]).expect("stage other branch work");
+    git_success(workspace, &["commit", "-m", "other branch commit"])
+        .expect("commit other branch work");
+    git_success(
+        workspace,
+        &["checkout", "-b", "assigned-task-branch", &base_sha],
+    )
+    .expect("restore assigned branch at checkpoint");
+
+    let task = task_with_file("T1", "Assigned task", "src/missing.txt", "codex");
+    let host = CommitTestHost::new(vec![task], workspace.to_path_buf());
+    let input = json!({
+        "scope": "all",
+        "job_run_id": "batch-1",
+        "workspace_path": workspace.to_string_lossy().to_string(),
+        "base_ref": base_sha,
+    });
+
+    let error = git_commit(&host, &input).expect_err("other branch commit is not adopted");
+    let message = error.to_string();
+    assert!(message.contains("no staged changes to commit"), "{message}");
+    assert!(
+        message.contains("outside the assigned worktree"),
+        "{message}"
+    );
+    assert_eq!(
+        git_output(workspace, &["rev-list", "--count", "HEAD"]).expect("count assigned commits"),
+        "1"
+    );
+}
+
+#[test]
+fn git_commit_batch_rejects_head_that_is_not_a_descendant_of_the_base_checkpoint() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+    let root_sha = git_output(workspace, &["rev-parse", "HEAD"]).expect("read root");
+
+    fs::write(workspace.join("base.txt"), "recorded base\n").unwrap();
+    git_success(workspace, &["add", "base.txt"]).expect("stage base");
+    git_success(workspace, &["commit", "-m", "recorded base checkpoint"])
+        .expect("commit recorded base");
+    let base_sha = git_output(workspace, &["rev-parse", "HEAD"]).expect("read base checkpoint");
+    git_success(workspace, &["reset", "--hard", &root_sha]).expect("rewind task branch");
+    fs::write(workspace.join("divergent.txt"), "divergent task history\n").unwrap();
+    git_success(workspace, &["add", "divergent.txt"]).expect("stage divergent work");
+    git_success(workspace, &["commit", "-m", "divergent task commit"])
+        .expect("commit divergent history");
+    let divergent_head =
+        git_output(workspace, &["rev-parse", "HEAD"]).expect("read divergent head");
+
+    let task = task_with_file("T1", "Divergent task", "divergent.txt", "codex");
+    let host = CommitTestHost::new(vec![task], workspace.to_path_buf());
+    let input = json!({
+        "scope": "all",
+        "job_run_id": "batch-1",
+        "workspace_path": workspace.to_string_lossy().to_string(),
+        "base_ref": base_sha,
+    });
+
+    let error = git_commit(&host, &input).expect_err("non-descendant history is rejected");
+    let message = error.to_string();
+    assert!(
+        message.contains("outside the assigned worktree"),
+        "{message}"
+    );
+    assert!(
+        message.contains("Orbit did not inspect, stage, reset, or reconcile any other checkout"),
+        "{message}"
+    );
+    assert_eq!(
+        git_output(workspace, &["rev-parse", "HEAD"]).expect("read final divergent head"),
+        divergent_head
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-10331](https://orbit-cli.com/tasks/ORB-10331) — commit_batch_changes fails on implement steps that author their own commits

### Description

## Problem

The task_pr_pipeline's deterministic `git_commit` action (`commit_batch_changes`) assumes the implement step leaves *uncommitted* changes in the assigned worktree, then stages and commits them as the batch. When the deliverable is inherently commit-producing — `git revert`, `git cherry-pick`, or any task whose instructions require authoring commits directly — the implement step finishes with a clean tree, and `commit_batch_changes` fails with "no staged changes to commit ... the implement step produced an empty diff" even though the work exists as commits on the branch.

Observed on jrun-20260719-2301-3 (ORB-10330, revert-and-land): the implement step correctly produced two commits (revert 191b3ccf + cherry-pick e16db787, 26 files, validation green), the pipeline failed at git_commit, the task went to `blocked`, and triage classified it task_defect. Publication required a manual out-of-pipeline recovery run (b9a03871) to push the branch and open PR #670. Any future revert, cherry-pick, or history-surgery task will hit the same wall.

## Required behavior

- After the implement step, `commit_batch_changes` detects commits authored in the assigned worktree since the recorded base checkpoint (commits ahead of the checkpoint on the task branch) in addition to staged/unstaged changes.
- If such commits exist and the tree is clean, accept them as the batch: skip the staging commit and proceed to the later handoff phases (rebase, push, PR) unchanged. Mixed state (commits plus dirty tree) commits the residue on top, preserving current attribution rules.
- The genuine failure mode is preserved: no commits beyond the checkpoint AND an empty diff still fails exactly as today.
- Scope guardrails are unchanged: only the assigned worktree and task branch are inspected; commits are validated to be descendants of the base checkpoint on that branch; Orbit still never inspects, stages, resets, or reconciles any other checkout. No force-push semantics are introduced.
- Attribution: implement-step-authored commits retain their recorded author; the pipeline's batch metadata (task id, run id) is still captured for handoff (e.g. via the existing commit-message/task-annotation mechanism or run journal, without amending the agent's commits unless that is already the pipeline's convention).

## Boundaries

- task_pr_pipeline / commit_batch_changes and its tests only; no change to worktree_setup, rebase, push, or PR phases beyond consuming the new batch source.
- No change to local-mode pipeline semantics beyond the same detection rule if it shares the action.
- Do not weaken the "changes written outside the assigned worktree" rejection.

## Evidence

- Run jrun-20260719-2301-3 error text and ORB-10330 history (triage_diagnosis at 2026-07-19T23:17Z classified task_defect with exact commit shas).
- Recovery run b9a03871 shows the manual steps the pipeline should have performed.

### Acceptance Criteria

- A fixture where the implement step produces only commits (clean tree, e.g. a revert plus a cherry-pick ahead of the base checkpoint) passes commit_batch_changes and proceeds to the handoff phases with those commits as the batch; no synthetic empty commit is created.
- A fixture with commits plus a dirty tree commits the residue on top under existing attribution rules and hands off all commits together.
- A fixture with no commits beyond the checkpoint and an empty diff still fails with the current 'no staged changes / empty diff' error unchanged.
- Commits reachable only from another worktree or branch, or not descendants of the recorded base checkpoint, are not adopted; the existing outside-the-worktree rejection message is preserved and tested.
- Batch metadata (task id, run id) is captured for implement-authored commits without amending or re-authoring them, and the PR handoff phases (rebase, push, PR creation) consume the batch unchanged.
- Regression: existing task_pr_pipeline and local-mode commit tests remain green; targeted orbit-engine/orbit-core pipeline tests, task-scoped clippy -D warnings, cargo fmt --all --check, and make ci-fast pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- commit_batch_changes now resolves the worktree setup base ref, verifies it is an ancestor of the assigned branch HEAD, and adopts the ordered HEAD-only commit range when implementation leaves a clean tree.
- Mixed commit-plus-dirty batches preserve implement-authored history and attribution, then create one existing-attribution residue commit on top; action checkpoints persist base/head SHA lists plus task and run metadata without amending prior commits.
- PR and local shipment jobs pass the recorded worktree base ref into git_commit; embedded activity/job assets and deployed resource mirrors remain synchronized.
- Added exact regressions for commit-only, mixed residue, true empty diff, another-branch-only commits, non-descendant history, preserved authorship, no synthetic commit, and shipment wiring.
Assessment: Scoped implementation preserves the genuine empty-diff and outside-worktree diagnostic verbatim, keeps later rebase/push/PR behavior branch-based and unchanged, and adds no force-push or cross-checkout behavior.
Validation:
- 26 orbit-engine commit tests passed (with the runner global provenance hook disabled for hermetic temporary-repo assertions).
- 25 orbit-core job catalog/pipeline tests passed.
- Existing provider worktree shipment integration test and local base-resolution regression passed.
- cargo clippy -p orbit-engine -p orbit-core --all-targets -- -D warnings passed.
- cargo fmt --all --check, git diff --check, and make ci-fast passed.
Deviations from original plan:
- None.
Recommended follow-ups:
- F2026-07-099 records the MCP worktree-routing mismatch encountered while persisting this task.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10331-6a641217`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*