### PR TITLE
Add claude-opus-5 to model_prices.yaml (+ fleet coverage guard)

### DIFF
--- a/.orbit/learnings/L-0106/learning.yaml
+++ b/.orbit/learnings/L-0106/learning.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+id: L-0106
+status: active
+scope:
+  paths:
+  - crates/orbit-common/assets/model_prices.yaml
+  - crates/orbit-common/src/types/tests/pricing.rs
+  tags:
+  - pricing
+summary: Adding a model_prices.yaml row with a later effective_from can break the fleet coverage test's shared timestamp — bump it, don't touch the row
+body: |
+  When adding a new row to `crates/orbit-common/assets/model_prices.yaml`, check the `every_fleet_model_string_is_priced` test in `crates/orbit-common/src/types/tests/pricing.rs`. That test checks every fleet model string's coverage against one shared fixed timestamp (`let at = dt("...")`), not per-model timestamps. If the new row's `effective_from` is later than that shared timestamp, the guard fails even though the row is present and correct — the fix is to advance the shared `at` to on/after the new row's `effective_from`, not to touch the row itself. Before landing, confirm no other row's `effective_until` falls before the new timestamp (it would silently drop that row's coverage instead).
+
+  Discovered while adding `claude-opus-5` (effective_from 2026-07-24) against a shared `at` of 2026-07-19 — the coverage assertion failed for a real reason (the row exists but doesn't cover that instant), not a missing row.
+evidence:
+- kind: task
+  reference: ORB-10351
+created_at: 2026-07-25T01:51:26.765429602Z
+updated_at: 2026-07-25T01:51:26.765429602Z

--- a/.orbit/learnings/L-0107/learning.yaml
+++ b/.orbit/learnings/L-0107/learning.yaml
@@ -1,0 +1,18 @@
+schema_version: 1
+id: L-0107
+status: active
+scope:
+  paths:
+  - crates/orbit-common/assets/model_prices.yaml
+  tags:
+  - pricing
+summary: A provider's -fast/preview speed variant may not be a distinct model id — verify official docs before adding a suffixed price row
+body: |
+  Don't assume a provider's "-fast" / turbo / research-preview speed variant needs its own row in `crates/orbit-common/assets/model_prices.yaml` just because it has separate published rates. Verify on the provider's official docs whether the variant actually changes the wire model-id string recorded in `InvocationRecord.model`, or whether it's a request-time parameter on the same base model id billed at a multiplier.
+
+  Concretely: Anthropic's Claude Opus 5 "fast mode" (research preview) publishes distinct pricing ($10/$50 per MTok vs. $5/$25 base) but is a `speed: "fast"` request parameter on the *same* `claude-opus-5` model id (per platform.claude.com/docs/en/about-claude/pricing) — it can never appear as a distinct string in the ledger, so a `claude-opus-5-fast` price row would be dead weight the coverage guard can't even validate against real data. Only add a `-fast`-suffixed (or similarly suffixed) row when crew config or ledger records actually reference that literal string.
+evidence:
+- kind: task
+  reference: ORB-10351
+created_at: 2026-07-25T01:51:29.465034712Z
+updated_at: 2026-07-25T01:51:29.465034712Z

--- a/crates/orbit-common/assets/model_prices.yaml
+++ b/crates/orbit-common/assets/model_prices.yaml
@@ -42,6 +42,21 @@
 # current open-ended rate.
 prices:
   # ── Anthropic / Claude (crews: opus, sonnet, fable) ──────────────────────
+  # Opus 5 launched 2026-07-24 at the same rates as Opus 4.8 (verified against
+  # the official platform.claude.com/docs pricing table). No `-fast` row: fast
+  # mode is a `speed: "fast"` request parameter on the *same* `claude-opus-5`
+  # model id, not a distinct string that would ever appear in
+  # `InvocationRecord.model`, and neither crew config nor the ledger reference
+  # a `-fast` string.
+  - model: "claude-opus-5"
+    effective_from: "2026-07-24T00:00:00Z"
+    effective_until: null
+    input_per_million_usd: 5.0
+    cache_read_per_million_usd: 0.5
+    cache_create_per_million_usd: 6.25
+    cache_create_1h_per_million_usd: 10.0
+    output_per_million_usd: 25.0
+
   - model: "claude-opus-4-8"
     effective_from: "2026-07-17T00:00:00Z"
     effective_until: null

--- a/crates/orbit-common/src/types/tests/pricing.rs
+++ b/crates/orbit-common/src/types/tests/pricing.rs
@@ -147,6 +147,7 @@ fn context_window_suffix_falls_back_to_the_base_row() {
 #[test]
 fn every_fleet_model_string_is_priced() {
     const FLEET_MODELS: &[&str] = &[
+        "claude-opus-5",
         "claude-opus-4-8",
         "claude-opus-4-8[1m]",
         "claude-opus-4-7",
@@ -166,7 +167,9 @@ fn every_fleet_model_string_is_priced() {
         output: 1_000,
         ..TokenUsage::default()
     };
-    let at = dt("2026-07-19T00:00:00Z");
+    // 2026-07-24 (not 07-19): must be on/after claude-opus-5's effective_from
+    // so its row is in range too, while still covering every other row below.
+    let at = dt("2026-07-24T00:00:00Z");
     for model in FLEET_MODELS {
         assert!(
             derive_cost_usd(model, at, &usage).is_some(),


### PR DESCRIPTION
## Task

[ORB-10351](https://orbit-cli.com/tasks/ORB-10351) — Add claude-opus-5 to model_prices.yaml (+ fleet coverage guard)

### Description

Claude Opus 5 released 2026-07-24 (API id `claude-opus-5`, no date suffix; 1M context; thinking on by default). Add to `crates/orbit-common/assets/model_prices.yaml` per the file's own learning-header rules (web-verify against Anthropic's official pricing page; cross-check strings against crew config + ledger; append-only rows):

- claude-opus-5: effective_from 2026-07-24, input 5.00, cache_read 0.50, cache_write_5m 6.25, cache_write_1h 10.00, output 25.00 (same rates as opus-4-8 per launch coverage — verify officially)
- claude-opus-5-fast (research preview, 10.00/1.00/12.50/20.00/50.00): add ONLY if crew config or recent ledger records reference it; otherwise note as skipped.

Add `claude-opus-5` to the `every_fleet_model_string_is_priced` coverage-guard list. If crew config still pins opus → claude-opus-4-8, note that switching the opus crew to opus-5 is Daniel's separate decision — this task only makes the price table ready.

Small PR off agent-main; per Daniel's current stance, known-flaky/baseline CI failures don't block the merge, but the pricing tests themselves must pass.

### Acceptance Criteria

- claude-opus-5 row present with officially-verified rates and effective_from 2026-07-24; append-only (no existing rows modified)
- Coverage guard includes claude-opus-5; pricing test suite green
- -fast variant added or explicitly skipped with reason
- YAML learning header conventions followed (verification steps documented in PR description)

## Execution Summary

<details>
<summary>Click to expand</summary>

Added claude-opus-5 to crates/orbit-common/assets/model_prices.yaml with effective_from 2026-07-24T00:00:00Z, effective_until null, and rates input 5.00 / cache_read 0.50 / cache_write_5m 6.25 / cache_write_1h 10.00 / output 25.00 per million tokens (same as claude-opus-4-8). Row is appended before the existing claude-opus-4-8 row (no existing rows modified).

Verification: web-searched and fetched the official pricing table at platform.claude.com/docs/en/about-claude/pricing, which lists Claude Opus 5 at exactly $5/$6.25/$10/$0.50/$25 per MTok (input / 5m cache write / 1h cache write / cache hit / output) -- matching the task's suggested rates exactly. Cross-checked crew config (.orbit/config.toml): opus crew still pins to claude-opus-4-8, so no crew-config change is needed or made -- switching the opus crew to opus-5 remains Daniel's separate decision.

claude-opus-5-fast: SKIPPED, not added. Two independent reasons: (1) grepped the full repo for "opus-5" and found zero references in crew config or any ledger/record files, so the task's own skip condition applies. (2) More importantly, per the official pricing doc, Anthropic's "fast mode" (research preview) is NOT a distinct model id -- it is the *same* `claude-opus-5` string billed at 2x ($10 input / $50 output) via a request-time `speed: "fast"` parameter. It is architecturally impossible for a `claude-opus-5-fast` string to appear in `InvocationRecord.model`, since fast mode never changes the model id on the wire. Documented this reasoning in a YAML comment above the new row.

Coverage guard: added "claude-opus-5" to the FLEET_MODELS list in crates/orbit-common/src/types/tests/pricing.rs (every_fleet_model_string_is_priced). Also had to bump that test's shared timestamp from 2026-07-19 to 2026-07-24 -- the test checks all fleet models at one fixed instant, and 2026-07-19 predates claude-opus-5's effective_from, which would fail coverage for a real reason (the row exists but doesn't cover that instant) rather than a missing row. 2026-07-24 still falls within every other row's effective range (all Anthropic/OpenAI/Gemini/xAI rows are effective_from <= 2026-07-17 with no effective_until before 2026-09-01), so no other row's coverage regressed.

Validation: `cargo test -p orbit-common pricing` -- 11/11 pass (was 10/11 before the timestamp fix, with the new fleet-coverage assertion failing as expected). Full `cargo test -p orbit-common` -- 256/256 pass. `make ci-fast` -- all checks pass (fmt, doc-index, installer, dependency-direction, cli-imports, stability, learning-layout, artifact-redaction, changelog-style, error-translation guards).

No unlisted-file scope drift: context_files was empty on this task; the pricing.rs test-file edit is explicitly required by the acceptance criteria ("Coverage guard includes claude-opus-5; pricing test suite green"), not an out-of-scope touch.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10351-6a6415aa`
- Behind base: 0
- Ahead of base: 1