### PR TITLE
chore: Consolidate provenance env assembly into a shared builder [ORB-10344]

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -10,6 +10,8 @@ use orbit_common::types::{LearningInjectionCaps, LearningInjectionState, prepend
 use orbit_common::utility::redaction::{PatternRedactor, redact_sensitive_env_text};
 use serde_json::Value;
 
+use crate::context::{ProvenanceEnv, provenance_env};
+
 use super::super::audit_writer::V2AuditWriter;
 use super::super::dispatcher::{
     DispatchError, DispatchInvocationTrace, DispatchOutcome, V2RuntimeHost,
@@ -184,36 +186,22 @@ pub fn run_cli_backend(
         wall_clock_timeout_ms: wall_clock_timeout.as_millis() as u64,
     });
 
-    let mut child_env = vec![
-        ("ORBIT_RUN_ID".to_string(), run_id.to_string()),
-        ("ORBIT_MANAGED_RUN_CONTEXT".to_string(), "1".to_string()),
-    ];
-    if let Some(agent_name) = tool_ctx.agent_name.as_deref() {
-        child_env.push(("ORBIT_AGENT_NAME".to_string(), agent_name.to_string()));
-    }
-    if let Some(model_name) = tool_ctx.model_name.as_deref() {
-        child_env.push(("ORBIT_AGENT_MODEL".to_string(), model_name.to_string()));
-    }
-    if let Some(session_id) = learning_context.session_id {
-        child_env.push(("ORBIT_SESSION_ID".to_string(), session_id));
-    }
-    if let Some(task_id) = task_id_from_input(input) {
-        // ADR-0182: external CLI agents get the same active-task hook binding
-        // as direct-agent executions.
-        child_env.push(("ORBIT_TASK_ID".to_string(), task_id.to_string()));
-        child_env.push(("ORBIT_ACTIVE_TASK_ID".to_string(), task_id.to_string()));
-    }
-    // Telemetry trailers (ORB-10342, mirrors ORB-10340's worker-side spawn):
-    // the shared prepare-commit-msg injector reads these to stamp
-    // Agent-Run/Agent-Model/Agent-Task on every commit a pipeline-gate
-    // provider CLI makes. Omitted (not empty) when unknown.
-    child_env.push(("AGENT_RUN_ID".to_string(), run_id.to_string()));
-    if let Some(model_name) = model.as_deref() {
-        child_env.push(("AGENT_MODEL".to_string(), model_name.to_string()));
-    }
-    if let Some(task_id) = task_id_from_input(input) {
-        child_env.push(("AGENT_TASK".to_string(), task_id.to_string()));
-    }
+    let task_id = task_id_from_input(input);
+    // ADR-0182: external CLI agents get the same active-task hook binding as
+    // direct-agent executions. The AGENT_* fields preserve ORB-10342's
+    // commit-telemetry contract and omit unknown model/task values.
+    let child_env = provenance_env(ProvenanceEnv {
+        orbit_run_id: Some(run_id),
+        orbit_managed_run_context: true,
+        orbit_agent_name: tool_ctx.agent_name.as_deref(),
+        orbit_agent_model: tool_ctx.model_name.as_deref(),
+        orbit_session_id: learning_context.session_id.as_deref(),
+        orbit_task_id: task_id,
+        orbit_active_task: true,
+        agent_run_id: Some(run_id),
+        agent_model: model.as_deref(),
+        agent_task_id: task_id,
+    });
     let spawn_result = spawn_with_timeout(SpawnWithTimeoutRequest {
         program: &invocation.program,
         args: &subprocess_args,

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -16,6 +16,7 @@ use orbit_common::types::activity_job::{
 use orbit_store::Store;
 use tempfile::{TempDir, tempdir};
 
+use crate::context::{ProvenanceEnv, provenance_env};
 use crate::template::{self, TemplateContext};
 
 use super::super::super::agent_role::{apply_resolved_settings, resolve_agent_settings};
@@ -1705,52 +1706,26 @@ fi
 /// AGENT_MODEL/AGENT_TASK must be omitted (unset), not set to an empty
 /// string, when the model or task id is unknown — mirrors ORB-10340's
 /// worker-side semantics. AGENT_RUN_ID is always known for a dispatched run.
+// Asserted at the builder boundary, not through a spawned child: provider spawns seed the
+// cleared environment with `non_sensitive_env_vars()`, so an Orbit-dispatched test run's own
+// AGENT_* telemetry can leak into the child and mask a correct omission. The positive
+// propagation case above still covers the wiring end-to-end.
 #[test]
 fn run_cli_backend_omits_agent_model_and_task_env_vars_when_unknown() {
-    let temp = tempdir().expect("tempdir");
-    let script = temp.path().join("grok");
-    write_executable(
-        &script,
-        r#"#!/bin/sh
-cat > /dev/null
-if [ "$AGENT_RUN_ID" = "job-grok-telemetry-unknown" ] && [ -z "${AGENT_MODEL+x}" ] && [ -z "${AGENT_TASK+x}" ]; then
-  printf '%s\n' '{"schemaVersion":1,"status":"success","result":{"identity":"ok"},"error":null}'
-else
-  printf '%s\n' '{"schemaVersion":1,"status":"failed","error":{"code":"telemetry_env_unexpected","message":"agent telemetry env should be unset when unknown","details":null}}'
-  exit 1
-fi
-"#,
-    );
+    let vars = provenance_env(ProvenanceEnv {
+        orbit_run_id: Some("job-grok-telemetry-unknown"),
+        orbit_managed_run_context: true,
+        orbit_agent_name: Some("grok"),
+        agent_run_id: Some("job-grok-telemetry-unknown"),
+        ..ProvenanceEnv::default()
+    });
 
-    let sink = Arc::new(RecordingSink::default());
-    let sink_for_writer: Arc<dyn AuditSink> = sink;
-    let audit = Arc::new(V2AuditWriter::new(
-        "job-grok-telemetry-unknown",
-        "grok",
-        sink_for_writer,
-    ));
-    let host = TestHost {
-        command: script.display().to_string(),
-        executor_args: Vec::new(),
-        provider_config: HashMap::new(),
-        sandbox: None,
-        task_context: None,
-        workspace_root: None,
-    };
-    let spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
-
-    let outcome = run_cli_backend(
-        &host,
-        &spec,
-        "job-grok-telemetry-unknown",
-        audit,
-        &serde_json::json!({"prompt": "hi"}),
-        None,
-    )
-    .expect("run succeeds");
-
-    assert!(outcome.success);
-    assert_eq!(outcome.output["provider"], "grok");
+    assert!(vars.contains(&(
+        "AGENT_RUN_ID".to_string(),
+        "job-grok-telemetry-unknown".to_string()
+    )));
+    assert!(!vars.iter().any(|(key, _)| key == "AGENT_MODEL"));
+    assert!(!vars.iter().any(|(key, _)| key == "AGENT_TASK"));
 }
 
 struct EnvVarGuard {

--- a/crates/orbit-engine/src/context/env.rs
+++ b/crates/orbit-engine/src/context/env.rs
@@ -6,6 +6,64 @@ use serde_json::Value;
 
 use super::execution::ExecutionContext;
 
+#[derive(Debug, Default)]
+pub(crate) struct ProvenanceEnv<'a> {
+    pub(crate) orbit_run_id: Option<&'a str>,
+    pub(crate) orbit_managed_run_context: bool,
+    pub(crate) orbit_agent_name: Option<&'a str>,
+    pub(crate) orbit_agent_model: Option<&'a str>,
+    pub(crate) orbit_session_id: Option<&'a str>,
+    pub(crate) orbit_task_id: Option<&'a str>,
+    pub(crate) orbit_active_task: bool,
+    pub(crate) agent_run_id: Option<&'a str>,
+    pub(crate) agent_model: Option<&'a str>,
+    pub(crate) agent_task_id: Option<&'a str>,
+}
+
+/// Builds subprocess provenance variables shared by every engine spawn path.
+///
+/// The namespaces deliberately remain separate: `ORBIT_*` is internal
+/// plumbing whose consumers depend on Orbit job-run semantics, while
+/// `AGENT_*` is a spawner-neutral, cross-repository commit-telemetry contract
+/// whose model value must be the exact provider model string. Callers select
+/// only the fields their spawn site historically emitted.
+pub(crate) fn provenance_env(config: ProvenanceEnv<'_>) -> Vec<(String, String)> {
+    let mut vars = Vec::new();
+
+    if let Some(run_id) = config.orbit_run_id {
+        vars.push(("ORBIT_RUN_ID".to_string(), run_id.to_string()));
+    }
+    if config.orbit_managed_run_context {
+        vars.push(("ORBIT_MANAGED_RUN_CONTEXT".to_string(), "1".to_string()));
+    }
+    if let Some(agent_name) = config.orbit_agent_name {
+        vars.push(("ORBIT_AGENT_NAME".to_string(), agent_name.to_string()));
+    }
+    if let Some(model) = config.orbit_agent_model {
+        vars.push(("ORBIT_AGENT_MODEL".to_string(), model.to_string()));
+    }
+    if let Some(session_id) = config.orbit_session_id {
+        vars.push(("ORBIT_SESSION_ID".to_string(), session_id.to_string()));
+    }
+    if let Some(task_id) = config.orbit_task_id {
+        vars.push(("ORBIT_TASK_ID".to_string(), task_id.to_string()));
+        if config.orbit_active_task {
+            vars.push(("ORBIT_ACTIVE_TASK_ID".to_string(), task_id.to_string()));
+        }
+    }
+    if let Some(run_id) = config.agent_run_id {
+        vars.push(("AGENT_RUN_ID".to_string(), run_id.to_string()));
+    }
+    if let Some(model) = config.agent_model {
+        vars.push(("AGENT_MODEL".to_string(), model.to_string()));
+    }
+    if let Some(task_id) = config.agent_task_id {
+        vars.push(("AGENT_TASK".to_string(), task_id.to_string()));
+    }
+
+    vars
+}
+
 /// Resolve `${VAR}` references in a value string from the parent environment.
 /// Returns an empty string and logs a warning when the referenced var is not set.
 /// Previously the literal `${VAR}` was passed through, which caused tools like `gh`
@@ -77,17 +135,18 @@ pub fn state_env_vars(execution: &ExecutionContext) -> Vec<(String, String)> {
 
     // Task ID is sourced from the activity input by convention (see
     // `execution_working_directory_with_task` for the same pattern).
-    if let Some(task_id) = execution
+    let task_id = execution
         .input
         .get("task_id")
         .and_then(Value::as_str)
-        .filter(|s| !s.is_empty())
-    {
-        vars.push(("ORBIT_TASK_ID".to_string(), task_id.to_string()));
-        // ADR-0182: hooks read the explicit active-task binding while older
-        // audit/tool code continues to consume ORBIT_TASK_ID.
-        vars.push(("ORBIT_ACTIVE_TASK_ID".to_string(), task_id.to_string()));
-    }
+        .filter(|s| !s.is_empty());
+    // ADR-0182: hooks read the explicit active-task binding while older
+    // audit/tool code continues to consume ORBIT_TASK_ID.
+    vars.extend(provenance_env(ProvenanceEnv {
+        orbit_task_id: task_id,
+        orbit_active_task: true,
+        ..ProvenanceEnv::default()
+    }));
 
     // Run-state vars only exist for steps inside a real job run, so they
     // share a guarded block.
@@ -96,8 +155,11 @@ pub fn state_env_vars(execution: &ExecutionContext) -> Vec<(String, String)> {
         execution.step_index,
         execution.state_dir.as_ref(),
     ) {
-        vars.push(("ORBIT_RUN_ID".to_string(), run_id.clone()));
-        vars.push(("ORBIT_MANAGED_RUN_CONTEXT".to_string(), "1".to_string()));
+        vars.extend(provenance_env(ProvenanceEnv {
+            orbit_run_id: Some(run_id),
+            orbit_managed_run_context: true,
+            ..ProvenanceEnv::default()
+        }));
         vars.push(("ORBIT_STEP_INDEX".to_string(), step_index.to_string()));
         vars.push((
             "ORBIT_STATE_DIR".to_string(),

--- a/crates/orbit-engine/src/context/mod.rs
+++ b/crates/orbit-engine/src/context/mod.rs
@@ -22,6 +22,7 @@ mod outcome;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use env::{ProvenanceEnv, provenance_env};
 pub use env::{apply_env_set, inject_state_env, state_env_vars};
 pub use execution::{
     ExecutionContext, execution_working_directory, execution_working_directory_with_task,

--- a/crates/orbit-engine/src/context/tests/env.rs
+++ b/crates/orbit-engine/src/context/tests/env.rs
@@ -7,7 +7,7 @@ use chrono::Utc;
 use orbit_common::types::Activity;
 use serde_json::{Value, json};
 
-use super::super::{ExecutionContext, state_env_vars};
+use super::super::{ExecutionContext, ProvenanceEnv, provenance_env, state_env_vars};
 
 fn activity_with_id(id: &str) -> Activity {
     let now = Utc::now();
@@ -45,6 +45,43 @@ fn execution_with(input: Value, run_id: Option<&str>) -> ExecutionContext {
         step_index: run_id.map(|_| 2),
         state_dir: run_id.map(|_| PathBuf::from("/tmp/state")),
     }
+}
+
+#[test]
+fn provenance_env_preserves_both_namespace_contracts() {
+    let vars = provenance_env(ProvenanceEnv {
+        orbit_run_id: Some("jrun-42"),
+        orbit_managed_run_context: true,
+        orbit_agent_name: Some("codex"),
+        orbit_agent_model: Some("gpt-5.6-sol"),
+        orbit_session_id: Some("session-7"),
+        orbit_task_id: Some("ORB-10344"),
+        orbit_active_task: true,
+        agent_run_id: Some("jrun-42"),
+        agent_model: Some("gpt-5.6-sol"),
+        agent_task_id: Some("ORB-10344"),
+    });
+
+    assert_eq!(
+        vars,
+        vec![
+            ("ORBIT_RUN_ID".to_string(), "jrun-42".to_string()),
+            ("ORBIT_MANAGED_RUN_CONTEXT".to_string(), "1".to_string()),
+            ("ORBIT_AGENT_NAME".to_string(), "codex".to_string()),
+            ("ORBIT_AGENT_MODEL".to_string(), "gpt-5.6-sol".to_string()),
+            ("ORBIT_SESSION_ID".to_string(), "session-7".to_string()),
+            ("ORBIT_TASK_ID".to_string(), "ORB-10344".to_string()),
+            ("ORBIT_ACTIVE_TASK_ID".to_string(), "ORB-10344".to_string()),
+            ("AGENT_RUN_ID".to_string(), "jrun-42".to_string()),
+            ("AGENT_MODEL".to_string(), "gpt-5.6-sol".to_string()),
+            ("AGENT_TASK".to_string(), "ORB-10344".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn provenance_env_omits_unknown_fields() {
+    assert!(provenance_env(ProvenanceEnv::default()).is_empty());
 }
 
 #[test]

--- a/crates/orbit-engine/src/executor/automation/command/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/command/mod.rs
@@ -7,7 +7,7 @@ use serde_json::{Value, json};
 use tempfile::tempdir;
 
 use super::StateExecutionContext;
-use crate::context::{EnvironmentHost, RuntimeHost, TaskHost};
+use crate::context::{EnvironmentHost, ProvenanceEnv, RuntimeHost, TaskHost, provenance_env};
 use crate::template::{TemplateContext, render, render_shell_command};
 
 #[derive(Debug, Deserialize)]
@@ -88,8 +88,11 @@ pub(super) fn run_command<H: RuntimeHost + TaskHost + EnvironmentHost + ?Sized>(
             state_context.state_dir.as_ref(),
         )
     {
-        proc_env.insert("ORBIT_RUN_ID".to_string(), run_id.clone());
-        proc_env.insert("ORBIT_MANAGED_RUN_CONTEXT".to_string(), "1".to_string());
+        proc_env.extend(provenance_env(ProvenanceEnv {
+            orbit_run_id: Some(run_id),
+            orbit_managed_run_context: true,
+            ..ProvenanceEnv::default()
+        }));
         proc_env.insert("ORBIT_STEP_INDEX".to_string(), step_index.to_string());
         proc_env.insert(
             "ORBIT_STATE_DIR".to_string(),

--- a/crates/orbit-engine/src/executor/automation/command/tests/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/command/tests/mod.rs
@@ -15,6 +15,7 @@ use crate::context::{
     EnvironmentHost, JobRunResult, RuntimeHost, TaskActivityUpdate, TaskAutomationUpdate,
     TaskReadHost, TaskWriteHost,
 };
+use crate::executor::automation::StateExecutionContext;
 use crate::executor::registry::ActivityExecutorRegistry;
 
 struct CommandTestHost {
@@ -251,6 +252,32 @@ fn single_quoted_template_value_still_substitutes() {
 
     let result =
         super::run_command(&host, &input, &HashMap::new(), None).expect("run_command succeeds");
+
+    assert_eq!(result, json!({ "exit_code": 0 }));
+}
+
+#[test]
+fn managed_command_preserves_site_specific_provenance_env() {
+    let host = CommandTestHost::new();
+    let state_dir = tempfile::tempdir().expect("create state dir");
+    let state_context = StateExecutionContext {
+        run_id: Some("jrun-command".to_string()),
+        step_index: Some(4),
+        state_dir: Some(state_dir.path().to_path_buf()),
+        agent: None,
+        model: None,
+    };
+    let input = json!({
+        "command": concat!(
+            "test \"$ORBIT_RUN_ID\" = jrun-command",
+            " && test \"$ORBIT_MANAGED_RUN_CONTEXT\" = 1",
+            " && test \"$ORBIT_STEP_INDEX\" = 4",
+            " && test -z \"${AGENT_RUN_ID+x}\"",
+        ),
+    });
+
+    let result = super::run_command(&host, &input, &HashMap::new(), Some(&state_context))
+        .expect("managed run_command succeeds");
 
     assert_eq!(result, json!({ "exit_code": 0 }));
 }

--- a/crates/orbit-engine/src/executor/direct_agent.rs
+++ b/crates/orbit-engine/src/executor/direct_agent.rs
@@ -6,7 +6,8 @@ use orbit_exec::EnvironmentMode;
 use super::ActivityExecutor;
 use crate::context::{
     AGENT_INVOCATION_FAILED, AGENT_TIMEOUT, AgentProtocolHost, AttemptOutcome, EnvironmentHost,
-    ExecutionContext, ExecutorHost, apply_env_set, execution_working_directory, inject_state_env,
+    ExecutionContext, ExecutorHost, ProvenanceEnv, apply_env_set, execution_working_directory,
+    inject_state_env, provenance_env,
 };
 
 fn inject_activity_tools(mode: EnvironmentMode, tools: &[String]) -> EnvironmentMode {
@@ -28,15 +29,16 @@ fn inject_agent_identity(
     }
 
     inject_environment(mode, |pairs| {
-        pairs.push(("ORBIT_AGENT_NAME".to_string(), agent.clone()));
-        if let Some(model) = execution
+        let model = execution
             .model
             .as_deref()
             .map(str::trim)
-            .filter(|value| !value.is_empty())
-        {
-            pairs.push(("ORBIT_AGENT_MODEL".to_string(), model.to_string()));
-        }
+            .filter(|value| !value.is_empty());
+        pairs.extend(provenance_env(ProvenanceEnv {
+            orbit_agent_name: Some(&agent),
+            orbit_agent_model: model,
+            ..ProvenanceEnv::default()
+        }));
     })
 }
 

--- a/crates/orbit-engine/src/executor/tests/external.rs
+++ b/crates/orbit-engine/src/executor/tests/external.rs
@@ -12,6 +12,7 @@ use chrono::Utc;
 use orbit_common::types::{
     Activity, ExecutorDef, ExecutorSandboxKind, ExecutorType, JobRunState, OrbitError,
 };
+use orbit_exec::EnvironmentMode;
 use serde_json::json;
 
 use super::super::direct_agent::{build_subprocess_exec_request, run_subprocess_executor};
@@ -224,4 +225,48 @@ fn external_and_direct_agent_build_identical_exec_request() {
     assert_eq!(req_external.stdin_mode, req_direct.stdin_mode);
     assert_eq!(req_external.environment_mode, req_direct.environment_mode);
     assert_eq!(req_external.debug, req_direct.debug);
+}
+
+#[test]
+fn direct_agent_request_preserves_site_specific_provenance_env() {
+    let host = stub_host();
+    let mut def = external_def("acme-harness", &["run"]);
+    def.executor_type = ExecutorType::DirectAgent;
+    let mut execution = execution();
+    execution.model = Some("vendor/model-exact".to_string());
+    execution.run_id = Some("jrun-direct".to_string());
+    execution.step_index = Some(3);
+    execution.state_dir = Some("/tmp/orbit-state".into());
+    execution.input = json!({ "task_id": "ORB-direct" });
+
+    let request =
+        build_subprocess_exec_request(&def, &host, &execution).expect("direct agent request");
+    let EnvironmentMode::ClearAndSet(pairs) = request.environment_mode else {
+        panic!("direct agent request must carry an explicit environment");
+    };
+    let env: HashMap<String, String> = pairs.into_iter().collect();
+
+    assert_eq!(
+        env.get("ORBIT_AGENT_NAME").map(String::as_str),
+        Some("acme-harness")
+    );
+    assert_eq!(
+        env.get("ORBIT_AGENT_MODEL").map(String::as_str),
+        Some("vendor/model-exact")
+    );
+    assert_eq!(
+        env.get("ORBIT_RUN_ID").map(String::as_str),
+        Some("jrun-direct")
+    );
+    assert_eq!(
+        env.get("ORBIT_TASK_ID").map(String::as_str),
+        Some("ORB-direct")
+    );
+    assert_eq!(
+        env.get("ORBIT_ACTIVE_TASK_ID").map(String::as_str),
+        Some("ORB-direct")
+    );
+    assert!(!env.contains_key("AGENT_RUN_ID"));
+    assert!(!env.contains_key("AGENT_MODEL"));
+    assert!(!env.contains_key("AGENT_TASK"));
 }


### PR DESCRIPTION
## What this does

Provenance/attribution env vars were assembled independently at four spawn sites and had
already drifted — ORB-10342 had to patch the middle of `run_cli_backend`. This consolidates
them behind one builder.

- **Adds `ProvenanceEnv` / `provenance_env()`** in `orbit-engine`'s `context::env`: a single
  documented builder owning both contracts, with explicit per-site parameterization so each
  caller selects only the fields it historically emitted.
- **Routes all four spawn sites through it:** `context::env::state_env_vars` (direct agents),
  `executor::direct_agent`, `activity_job::cli_runner::orchestrator`, and
  `executor::automation::command`. Emitted variables, their **order**, and their **omissions**
  are unchanged — including `ORBIT_ACTIVE_TASK_ID` (ADR-0182) and `ORBIT_MANAGED_RUN_CONTEXT`
  at exactly the sites that set them today. The orchestrator's distinction between
  `tool_ctx.model_name` (→ `ORBIT_AGENT_MODEL`) and `model` (→ `AGENT_MODEL`) is preserved.
- **Doc comment records why the two namespaces must stay separate:** `ORBIT_*` is internal
  plumbing whose consumers depend on jrun-id semantics the worker path can't satisfy;
  `AGENT_*` is the cross-repo commit-telemetry contract requiring exact provider model
  strings, omitted (not empty) when unknown.

Pure refactor — no behavioral change to env contents at any site beyond what ORB-10342
already introduced.

## Test note

The `AGENT_*`-omission assertion in `cli_runner/tests/orchestrator.rs` moved from a spawned
child to the builder boundary. Provider spawns seed the cleared environment with
`non_sensitive_env_vars()`, so an Orbit-dispatched test run's own `AGENT_*` telemetry leaks
into the child and masks a correct omission — `[ -z "${AGENT_MODEL+x}" ]` cannot distinguish
"builder omitted it" from "parent supplied it". The **positive** end-to-end propagation test
(`run_cli_backend` → real child sees `AGENT_RUN_ID`/`AGENT_MODEL`/`AGENT_TASK`) is retained,
so the wiring is still covered end-to-end; only the non-hermetic half moved.

## Validation

- `cargo fmt --all --check` — clean
- `cargo clippy -p orbit-engine --all-targets -- -D warnings` — clean
- `cargo test -p orbit-engine` — **284 passed, 0 failed**

Caveat worth knowing for reviewers: running the engine suite from inside an Orbit-dispatched
agent run fails `executor::automation::vcs::commit::tests::author::git_commit_batch_uses_templated_single_task_message`,
because that test inherits the ambient `AGENT_RUN_ID`/`AGENT_MODEL`/`AGENT_TASK` and gets
extra commit trailers. This reproduces identically on unmodified `agent-main` and is
**unrelated to this PR**; the 284/284 run above unsets those three vars. It is the same
class of leak this PR's test note describes, in a file this PR does not touch.

## Note

Landed via rescue after the original pipeline run (`jrun-20260725-0157-3`) failed with
`worktree_integrity_ambiguous` — a concurrent merge of ORB-10351 advanced the primary
checkout mid-run. The implementation itself was complete and untouched; only the landing
step was redone.