### PR TITLE
fix: Carry invocation telemetry columns to existing stores; never fail a run on a telemetry write [ORB-10367]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Telemetry no longer discards completed runs**: the `invocations` insert-bound columns (`cache_create_1h_tokens`, `provider_cost_usd`) reach existing databases through a new `invocation_telemetry_columns` migration (schema v10) instead of only the v1 baseline, and a failed invocation-trace write is now logged and recorded as a `telemetry.persist_failed` event on the run rather than failing the job. ([ORB-10367])
 - **PR review status clearing is documented**: `orbit.task.update` now describes its empty-string clear convention, with tool-host coverage for the persisted null result. ([ORB-10229])
 - **Task PR status updates persist in v2 storage**: local tool and dashboard PATCH updates now retain `pr_status` alongside status and execution-summary changes. ([ORB-10223])
 - **Bundled skills are repository-agnostic**: the embedded skill tree drops Orbit-source paths, private Constellation names, workspace-local artifact IDs, and fixed design-doc filenames; a portability regression test and byte-aligned plugin mirrors guard against reintroduction. ([ORB-10208])

--- a/crates/orbit-common/src/types/activity_job/audit_envelope.rs
+++ b/crates/orbit-common/src/types/activity_job/audit_envelope.rs
@@ -184,6 +184,16 @@ pub enum V2AuditEventKind {
         harness_version: Option<String>,
         timed_out: bool,
     },
+    /// [ORB-10367] A telemetry write failed (e.g. persisting an invocation
+    /// trace). The run continues — telemetry is observability, not
+    /// correctness — but the failure is recorded on the run so the gap in
+    /// the telemetry is visible rather than silent.
+    TelemetryPersistFailed {
+        component: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        step_id: Option<String>,
+        error: String,
+    },
 }
 
 impl V2AuditEventKind {
@@ -215,6 +225,7 @@ impl V2AuditEventKind {
             }
             V2AuditEventKind::CliInvocationStarted { .. } => "cli.invocation.started",
             V2AuditEventKind::CliInvocationFinished { .. } => "cli.invocation.finished",
+            V2AuditEventKind::TelemetryPersistFailed { .. } => "telemetry.persist_failed",
         }
     }
 }

--- a/crates/orbit-engine/src/activity_job/audit_writer.rs
+++ b/crates/orbit-engine/src/activity_job/audit_writer.rs
@@ -51,6 +51,10 @@ pub struct V2AuditWriter {
     /// [ORB-00414] Count of audit-write failures observed this run. Non-fatal
     /// to the run, but recorded so consumers know the trail is incomplete.
     audit_failures: AtomicU64,
+    /// [ORB-10367] Count of telemetry-persistence failures observed this run
+    /// (invocation traces). Non-fatal to the run — its success is decided by
+    /// its work — but recorded so the telemetry gap is visible.
+    telemetry_failures: AtomicU64,
 }
 
 /// Restores the calling thread's previous parent stack on drop.
@@ -82,6 +86,7 @@ impl V2AuditWriter {
             event_counter: Mutex::new(0),
             parent_stacks: Mutex::new(HashMap::new()),
             audit_failures: AtomicU64::new(0),
+            telemetry_failures: AtomicU64::new(0),
         }
     }
 
@@ -203,6 +208,46 @@ impl V2AuditWriter {
     /// True when at least one audit write failed — the trail is incomplete.
     pub fn degraded_audit(&self) -> bool {
         self.audit_failure_count() > 0
+    }
+
+    /// [ORB-10367] Record a non-fatal telemetry-persistence failure: bump the
+    /// per-run counter, emit a `tracing::error!`, and put a
+    /// `telemetry.persist_failed` event on the run record so the gap is
+    /// visible to run-history consumers. The run's own success is never
+    /// decided by this — completed agent work must not be discarded because a
+    /// telemetry row could not be written.
+    pub fn note_telemetry_failure(
+        &self,
+        component: &str,
+        step_id: Option<&str>,
+        error: &dyn std::fmt::Display,
+    ) {
+        self.telemetry_failures.fetch_add(1, Ordering::Relaxed);
+        let error = error.to_string();
+        tracing::error!(
+            target: "orbit.engine.telemetry",
+            run_id = %self.run_id,
+            component,
+            step_id = step_id.unwrap_or_default(),
+            error = %error,
+            "telemetry persist failed; run continuing with degraded telemetry",
+        );
+        self.emit_lossy(V2AuditEventKind::TelemetryPersistFailed {
+            component: component.to_string(),
+            step_id: step_id.map(ToOwned::to_owned),
+            error,
+        });
+    }
+
+    /// Number of telemetry-persistence failures observed this run.
+    pub fn telemetry_failure_count(&self) -> u64 {
+        self.telemetry_failures.load(Ordering::Relaxed)
+    }
+
+    /// True when at least one telemetry write failed — invocation traces for
+    /// this run are incomplete.
+    pub fn degraded_telemetry(&self) -> bool {
+        self.telemetry_failure_count() > 0
     }
 
     /// [ORB-00414] Emit an envelope event, recording (not discarding) a write

--- a/crates/orbit-engine/src/activity_job/job_executor/mod.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/mod.rs
@@ -93,6 +93,12 @@ pub struct JobOutcome {
     /// [ORB-00414] True when any audit write failed — retry/recovery/debugging
     /// consumers should treat the trail as incomplete.
     pub degraded_audit: bool,
+    /// [ORB-10367] Number of telemetry-persistence failures (invocation
+    /// traces) observed during the run. Never affects `success`.
+    pub telemetry_failures: u64,
+    /// [ORB-10367] True when any telemetry write failed — the run's
+    /// invocation/token accounting is incomplete, but its work is not.
+    pub degraded_telemetry: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -209,6 +215,8 @@ pub fn execute_job_with_resume(
         message: (!overall_ok).then_some(overall_message).flatten(),
         audit_failures: audit.audit_failure_count(),
         degraded_audit: audit.degraded_audit(),
+        telemetry_failures: audit.telemetry_failure_count(),
+        degraded_telemetry: audit.degraded_telemetry(),
     })
 }
 

--- a/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
@@ -71,12 +71,12 @@ pub(super) fn attempt_recovery_activity(
             // record, not an audit-envelope write); a failure here is
             // intentionally non-fatal and does not affect recovery outcome. The
             // audit trail of the recovery attempt is emitted separately below.
-            let _ = persist_dispatch_invocation(ctx, &recovery.name, &input, &dispatch);
+            persist_dispatch_invocation(ctx, &recovery.name, &input, &dispatch);
             true
         }
         Ok(dispatch) => {
             // [ORB-00414] See above: non-audit DB persistence, non-fatal.
-            let _ = persist_dispatch_invocation(ctx, &recovery.name, &input, &dispatch);
+            persist_dispatch_invocation(ctx, &recovery.name, &input, &dispatch);
             false
         }
         Err(_) => false,

--- a/crates/orbit-engine/src/activity_job/job_executor/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/target.rs
@@ -77,7 +77,7 @@ pub(super) fn run_target(
                 run_id: &ctx.run_id,
                 host: Some(ctx.host),
             })?;
-            persist_dispatch_invocation(ctx, &step.id, &rendered_input, &dispatch)?;
+            persist_dispatch_invocation(ctx, &step.id, &rendered_input, &dispatch);
             let out = dispatch.output.clone();
             record_pipeline(ctx, &step.id, out.clone());
             Ok(StepOutcome {
@@ -98,7 +98,7 @@ pub(super) fn run_target(
                 run_id: &ctx.run_id,
                 host: Some(ctx.host),
             })?;
-            persist_dispatch_invocation(ctx, &step.id, &rendered_input, &dispatch)?;
+            persist_dispatch_invocation(ctx, &step.id, &rendered_input, &dispatch);
             let out = dispatch.output.clone();
             record_pipeline(ctx, &step.id, out.clone());
             Ok(StepOutcome {
@@ -111,24 +111,34 @@ pub(super) fn run_target(
     }
 }
 
+/// Persist the invocation trace for a dispatched step.
+///
+/// [ORB-10367] **Non-fatal by contract.** This is telemetry: a failed write
+/// (schema drift, a locked or unwritable database, a full disk) must never
+/// discard agent work that already completed. The failure is logged loudly
+/// and surfaced on the run record as `telemetry.persist_failed`; the step's
+/// success stays decided solely by its own work.
 pub(super) fn persist_dispatch_invocation(
     ctx: &ExecCtx<'_>,
     step_id: &str,
     input: &Value,
     dispatch: &super::super::dispatcher::DispatchOutcome,
-) -> Result<(), DispatchError> {
+) {
     let Some(invocation) = dispatch.invocation.as_ref() else {
-        return Ok(());
+        return;
     };
 
-    ctx.host.persist_invocation_trace(
+    if let Err(error) = ctx.host.persist_invocation_trace(
         &ctx.run_id,
         step_id,
         &invocation.provider,
         invocation.model.as_deref(),
         input,
         &invocation.trace,
-    )
+    ) {
+        ctx.audit
+            .note_telemetry_failure("invocation_trace", Some(step_id), &error);
+    }
 }
 
 pub(super) fn run_agent_loop_outcome(
@@ -155,14 +165,19 @@ pub(super) fn run_agent_loop_outcome(
         &outcome,
         started.elapsed().as_millis() as u64,
     );
-    ctx.host.persist_invocation_trace(
+    // [ORB-10367] Telemetry, not correctness: the agent loop already ran to
+    // completion, so a failed trace write is recorded, never propagated.
+    if let Err(error) = ctx.host.persist_invocation_trace(
         &ctx.run_id,
         &step.id,
         spec.provider.as_str(),
         spec.model.as_deref(),
         input,
         &trace,
-    )?;
+    ) {
+        ctx.audit
+            .note_telemetry_failure("invocation_trace", Some(&step.id), &error);
+    }
     let mut metadata = serde_json::Map::new();
     metadata.insert(
         "final_message".to_string(),

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
@@ -345,3 +345,130 @@ fn role_override_does_not_disable_replay_short_circuit() {
     // Replay short-circuit still triggers — independent of the override.
     assert!(super::replay_active());
 }
+
+// ----- Telemetry persistence is non-fatal (ORB-10367) -----------------
+
+/// Host whose invocation-trace persistence always fails, standing in for the
+/// production failure mode where the store's `invocations` table lacks a
+/// column the insert binds.
+struct FailingTelemetryHost;
+
+impl V2RuntimeHost for FailingTelemetryHost {
+    fn run_deterministic(
+        &self,
+        _action: &str,
+        _config: &Value,
+        _input: &Value,
+        _tool_context: orbit_tools::ToolContext,
+    ) -> Result<Value, DispatchError> {
+        Err(DispatchError::DeterministicActionNotRegistered(
+            "failing telemetry host: not used".into(),
+        ))
+    }
+
+    fn api_key_for(&self, _provider: &str) -> Result<String, DispatchError> {
+        Err(DispatchError::AgentLoopFailed(
+            "failing telemetry host: no credentials".into(),
+        ))
+    }
+
+    fn resolve_cli_executor(
+        &self,
+        _provider: &str,
+    ) -> Result<super::super::super::dispatcher::ResolvedCliExecutor, DispatchError> {
+        Err(DispatchError::CliInvocationFailed(
+            "failing telemetry host: no CLI mapping".into(),
+        ))
+    }
+
+    fn tool_context_for_activity(
+        &self,
+        _run_id: Option<&str>,
+        _fs_profile: Option<&str>,
+        _fs_audit: Option<std::sync::Arc<dyn orbit_tools::FsAuditLogger>>,
+        _proc_allowed_programs: Option<&[String]>,
+    ) -> orbit_tools::ToolContext {
+        orbit_tools::ToolContext::default()
+    }
+
+    fn persist_invocation_trace(
+        &self,
+        _job_run_id: &str,
+        _activity_id: &str,
+        _provider: &str,
+        _model: Option<&str>,
+        _input: &Value,
+        _trace: &orbit_common::types::InvocationTrace,
+    ) -> Result<(), DispatchError> {
+        Err(DispatchError::JobExecution(
+            "persist invocation trace: store error: table invocations has no column named \
+             cache_create_1h_tokens"
+                .to_string(),
+        ))
+    }
+}
+
+fn dispatch_with_invocation() -> super::super::super::dispatcher::DispatchOutcome {
+    super::super::super::dispatcher::DispatchOutcome {
+        success: true,
+        output: json!({ "implemented": true }),
+        message: None,
+        invocation: Some(super::super::super::dispatcher::DispatchInvocationTrace {
+            provider: "claude".to_string(),
+            model: Some(TEST_CLAUDE_MODEL.to_string()),
+            trace: orbit_common::types::InvocationTrace::default(),
+        }),
+    }
+}
+
+/// [ORB-10367] A failed telemetry write must not discard completed agent
+/// work. `persist_dispatch_invocation` returns `()` — there is no error path
+/// left to propagate into the step outcome — and records the failure instead.
+#[test]
+fn failed_invocation_trace_persist_does_not_fail_the_step() {
+    let host = FailingTelemetryHost;
+    let ctx = exec_ctx(&host);
+    let dispatch = dispatch_with_invocation();
+
+    let trace = capture(|| {
+        super::persist_dispatch_invocation(&ctx, "implement_one", &ctx.input, &dispatch);
+    });
+
+    // Logged loudly: an ERROR naming the run, the step, and the store error.
+    let logged = trace
+        .events
+        .iter()
+        .find(|event| event.target == "orbit.engine.telemetry")
+        .expect("telemetry failure logged");
+    assert_eq!(logged.level, Level::ERROR);
+    assert_eq!(logged.field("step_id"), Some("implement_one"));
+    assert!(
+        logged
+            .field("error")
+            .expect("error field")
+            .contains("cache_create_1h_tokens"),
+        "unexpected error field: {:?}",
+        logged.field("error")
+    );
+
+    // ...and surfaced on the run record as a telemetry.persist_failed event.
+    assert_eq!(ctx.audit.telemetry_failure_count(), 1);
+    assert!(ctx.audit.degraded_telemetry());
+    let events = ctx.audit.events_snapshot().expect("events snapshot");
+    let recorded = events
+        .iter()
+        .find(|event| event.envelope.event_type == "telemetry.persist_failed")
+        .expect("telemetry.persist_failed recorded on the run");
+    match &recorded.kind {
+        V2AuditEventKind::TelemetryPersistFailed {
+            component, step_id, ..
+        } => {
+            assert_eq!(component, "invocation_trace");
+            assert_eq!(step_id.as_deref(), Some("implement_one"));
+        }
+        other => panic!("unexpected event kind: {other:?}"),
+    }
+
+    // The audit trail itself is undamaged — this is a telemetry gap only.
+    assert_eq!(ctx.audit.audit_failure_count(), 0);
+}

--- a/crates/orbit-store/src/sqlite/invocation_store.rs
+++ b/crates/orbit-store/src/sqlite/invocation_store.rs
@@ -5,6 +5,10 @@ mod records;
 #[path = "invocation_store/types.rs"]
 mod types;
 
+/// [ORB-10367] Insert-bound invocation columns, re-exported for the schema
+/// drift regression test in `sqlite::migration::tests`.
+#[cfg(test)]
+pub(crate) use records::INVOCATION_INSERT_COLUMNS;
 pub use types::{
     ActivityInvocationMetrics, AgentInvocationMetrics, InvocationInsertParams, InvocationQuery,
     InvocationRecord, InvocationToolCallRecord, TaskInvocationMetrics, ToolInvocationMetrics,

--- a/crates/orbit-store/src/sqlite/invocation_store/records/mod.rs
+++ b/crates/orbit-store/src/sqlite/invocation_store/records/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 use chrono::{DateTime, Utc};
 use rusqlite::{params, types::ToSql};
@@ -11,6 +12,42 @@ use crate::{Store, now_string};
 use super::types::{
     InvocationInsertParams, InvocationQuery, InvocationRecord, InvocationToolCallRecord,
 };
+
+/// Every column the invocation-trace insert binds, in bind order.
+///
+/// [ORB-10367] This list is the single source of truth for both the INSERT
+/// statement below and the migration regression test that asserts a migrated
+/// legacy database carries each column. Adding a column here without a
+/// matching schema migration fails that test instead of failing a live job
+/// run at the telemetry-persistence boundary.
+pub(crate) const INVOCATION_INSERT_COLUMNS: &[&str] = &[
+    "ts",
+    "job_run_id",
+    "activity_id",
+    "agent",
+    "model",
+    "slot",
+    "duration_ms",
+    "input_tokens",
+    "cache_read_tokens",
+    "cache_create_tokens",
+    "cache_create_1h_tokens",
+    "output_tokens",
+    "tool_call_count",
+    "provider_cost_usd",
+];
+
+/// `INSERT INTO invocations(...) VALUES (?1, ...)` rendered from
+/// [`INVOCATION_INSERT_COLUMNS`] so the column list and the bind arity can
+/// never drift from each other.
+static INVOCATION_INSERT_SQL: LazyLock<String> = LazyLock::new(|| {
+    let columns = INVOCATION_INSERT_COLUMNS.join(", ");
+    let placeholders = (1..=INVOCATION_INSERT_COLUMNS.len())
+        .map(|index| format!("?{index}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("INSERT INTO invocations({columns}) VALUES ({placeholders})")
+});
 
 impl Store {
     pub fn insert_invocation_trace_record(
@@ -26,12 +63,7 @@ impl Store {
             .map_err(|e| OrbitError::Store(e.to_string()))?;
 
         tx.execute(
-            r#"INSERT INTO invocations(
-                ts, job_run_id, activity_id, agent, model, slot, duration_ms,
-                input_tokens, cache_read_tokens, cache_create_tokens,
-                cache_create_1h_tokens, output_tokens, tool_call_count,
-                provider_cost_usd
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)"#,
+            INVOCATION_INSERT_SQL.as_str(),
             params![
                 now_string(),
                 params.job_run_id,

--- a/crates/orbit-store/src/sqlite/migration/ledger.rs
+++ b/crates/orbit-store/src/sqlite/migration/ledger.rs
@@ -78,12 +78,20 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "feature_schema_ledger",
         apply: super::apply_feature_schema_ledger,
     },
+    // ORB-10367: carries the invocation telemetry columns
+    // (`cache_create_1h_tokens`, `provider_cost_usd`) to databases that
+    // recorded the v1 baseline before those columns were added to it.
+    Migration {
+        version: 10,
+        name: "invocation_telemetry_columns",
+        apply: super::apply_invocation_telemetry_columns,
+    },
 ];
 
 /// Highest schema version this binary knows how to produce. Public for
 /// the future `orbit migrate` surface (P3.4), alongside
 /// [`AppliedMigration`] and the `Store` version accessors.
-pub const SUPPORTED_SCHEMA_VERSION: u32 = 9;
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 10;
 
 const LEDGER_KEY_PREFIX: &str = "migration.v";
 

--- a/crates/orbit-store/src/sqlite/migration/mod.rs
+++ b/crates/orbit-store/src/sqlite/migration/mod.rs
@@ -585,6 +585,32 @@ fn ensure_audit_events_schema(conn: &Connection) -> Result<(), OrbitError> {
     Ok(())
 }
 
+/// v10 `invocation_telemetry_columns` migration (ORB-10367): re-run the
+/// idempotent invocation-schema step against databases that already recorded
+/// the v1 baseline.
+///
+/// The 5m/1h cache split (`cache_create_1h_tokens`) and the token-derived
+/// cost column (`provider_cost_usd`) were added to
+/// [`ensure_invocation_schema`], which only ever runs as part of the v1
+/// `baseline` migration. Every database created before those columns landed
+/// is already at v1 or newer, so `run_migrations` skips baseline and the
+/// `ALTER`s never reach it — the insert then binds columns the table lacks
+/// and every agent-dispatching run dies at the telemetry write. Registering
+/// the same idempotent step under its own version is what carries it to
+/// existing databases.
+fn apply_invocation_telemetry_columns(conn: &Connection) -> Result<(), OrbitError> {
+    // The `ALTER`s below address tables the v1 baseline creates. A database
+    // without them has nothing to repair (and `ALTER TABLE` on a missing
+    // table is an error, not a no-op), so skip rather than fail the open.
+    if !table_exists(conn, "invocations")?
+        || !table_exists(conn, "invocation_tasks")?
+        || !table_exists(conn, "tool_calls")?
+    {
+        return Ok(());
+    }
+    ensure_invocation_schema(conn)
+}
+
 fn ensure_invocation_schema(conn: &Connection) -> Result<(), OrbitError> {
     add_column_if_missing(conn, "ALTER TABLE invocations ADD COLUMN slot TEXT")?;
     add_column_if_missing(

--- a/crates/orbit-store/src/sqlite/migration/tests/ledger.rs
+++ b/crates/orbit-store/src/sqlite/migration/tests/ledger.rs
@@ -58,6 +58,9 @@ fn fresh_db_applies_baseline_and_records_ledger() {
     assert_eq!(applied[8].version, 9);
     assert_eq!(applied[8].name, "feature_schema_ledger");
     assert!(!applied[8].applied_at.is_empty());
+    assert_eq!(applied[9].version, 10);
+    assert_eq!(applied[9].name, "invocation_telemetry_columns");
+    assert!(!applied[9].applied_at.is_empty());
 }
 
 #[test]
@@ -194,6 +197,10 @@ fn legacy_db_adopts_versioned_ledger() {
                 "migration.v0009".to_string(),
                 "feature_schema_ledger".to_string()
             ),
+            (
+                "migration.v0010".to_string(),
+                "invocation_telemetry_columns".to_string()
+            ),
         ]
     );
 }
@@ -205,7 +212,7 @@ fn refuses_db_from_a_newer_binary() {
 
     conn.execute(
         "INSERT INTO schema_meta(key, value, updated_at)
-         VALUES ('migration.v0010', 'from-the-future', '2099-01-01T00:00:00Z')",
+         VALUES ('migration.v0011', 'from-the-future', '2099-01-01T00:00:00Z')",
         [],
     )
     .expect("record future migration");
@@ -274,12 +281,18 @@ fn store_reopens_database_at_shipped_schema_v4_and_applies_through_latest() {
     drop(conn);
 
     let store = crate::Store::open(&path).expect("reopen shipped v4 store");
-    assert_eq!(store.schema_version().expect("schema version"), 9);
+    assert_eq!(
+        store.schema_version().expect("schema version"),
+        SUPPORTED_SCHEMA_VERSION
+    );
     let applied = store.applied_migrations().expect("applied migrations");
-    assert_eq!(applied.last().map(|migration| migration.version), Some(9));
+    assert_eq!(
+        applied.last().map(|migration| migration.version),
+        Some(SUPPORTED_SCHEMA_VERSION)
+    );
     assert_eq!(
         applied.last().map(|migration| migration.name.as_str()),
-        Some("feature_schema_ledger")
+        Some("invocation_telemetry_columns")
     );
     let connection = store.connection();
     let conn = connection.lock().expect("connection");
@@ -356,7 +369,10 @@ fn store_reopens_shipped_v6_audit_rows_and_applies_v7_additively() {
     drop(conn);
 
     let store = crate::Store::open(&path).expect("open and migrate v6 store");
-    assert_eq!(store.schema_version().expect("schema version"), 9);
+    assert_eq!(
+        store.schema_version().expect("schema version"),
+        SUPPORTED_SCHEMA_VERSION
+    );
     let rows = store
         .list_audit_events(&crate::AuditEventFilter::default())
         .expect("read migrated audit rows");
@@ -370,7 +386,10 @@ fn store_reopens_shipped_v6_audit_rows_and_applies_v7_additively() {
     drop(store);
 
     let reopened = crate::Store::open(&path).expect("reopen migrated store");
-    assert_eq!(reopened.schema_version().expect("schema version"), 9);
+    assert_eq!(
+        reopened.schema_version().expect("schema version"),
+        SUPPORTED_SCHEMA_VERSION
+    );
     assert_eq!(
         reopened
             .list_audit_events(&crate::AuditEventFilter::default())
@@ -488,4 +507,116 @@ fn rejects_non_increasing_registry() {
 
     let err = ledger::run_migrations(&conn, &registry).expect_err("must reject registry");
     assert!(matches!(err, OrbitError::Migration(_)), "got {err:?}");
+}
+
+/// [ORB-10367] Schema/insert skew regression: a database that recorded the v1
+/// baseline *before* a column was added to it never re-runs baseline, so any
+/// column added there alone silently never reaches it. This models the
+/// dk-server-1 store — pre-telemetry `invocations` table, ledger stamped
+/// through the newest pre-fix version — and asserts that after migration
+/// every column the insert binds exists and a real insert lands.
+///
+/// Against the broken state (no v10 registry entry) the store opens at v9 and
+/// the insert fails with `table invocations has no column named
+/// cache_create_1h_tokens` — the exact production failure.
+#[test]
+fn migrated_legacy_db_carries_every_invocation_insert_column() {
+    use orbit_common::types::{InvocationTrace, TokenUsage};
+
+    use crate::sqlite::invocation_store::{INVOCATION_INSERT_COLUMNS, InvocationInsertParams};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("orbit.db");
+    let conn = Connection::open(&path).expect("open raw store connection");
+    conn.execute_batch(
+        r#"
+            CREATE TABLE schema_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            INSERT INTO schema_meta VALUES
+                ('migration.v0001', 'baseline', '2026-07-01T00:00:00Z'),
+                ('migration.v0002', 'learnings_index_workspace_scope', '2026-07-02T00:00:00Z'),
+                ('migration.v0003', 'flat_crew_model', '2026-07-03T00:00:00Z'),
+                ('migration.v0004', 'job_run_archive_stage', '2026-07-04T00:00:00Z'),
+                ('migration.v0005', 'host_registry_core', '2026-07-05T00:00:00Z'),
+                ('migration.v0006', 'workspace_coordination_projections', '2026-07-06T00:00:00Z'),
+                ('migration.v0007', 'trusted_mcp_audit_provenance', '2026-07-07T00:00:00Z'),
+                ('migration.v0008', 'hub_registry_metadata', '2026-07-08T00:00:00Z'),
+                ('migration.v0009', 'feature_schema_ledger', '2026-07-09T00:00:00Z');
+
+            -- `invocations` as the baseline created it before the 5m/1h cache
+            -- split and the token-derived cost column were added.
+            CREATE TABLE invocations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts TEXT NOT NULL,
+                job_run_id TEXT NOT NULL,
+                activity_id TEXT NOT NULL,
+                agent TEXT NOT NULL,
+                model TEXT,
+                slot TEXT,
+                duration_ms INTEGER NOT NULL DEFAULT 0,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_create_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                tool_call_count INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE invocation_tasks (
+                invocation_id INTEGER NOT NULL,
+                task_id TEXT NOT NULL,
+                PRIMARY KEY(invocation_id, task_id),
+                FOREIGN KEY(invocation_id) REFERENCES invocations(id) ON DELETE CASCADE
+            );
+            CREATE TABLE tool_calls (
+                invocation_id INTEGER NOT NULL,
+                seq INTEGER NOT NULL,
+                tool_name TEXT NOT NULL,
+                result_bytes INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY(invocation_id, seq),
+                FOREIGN KEY(invocation_id) REFERENCES invocations(id) ON DELETE CASCADE
+            );
+        "#,
+    )
+    .expect("seed pre-telemetry database");
+    drop(conn);
+
+    let store = crate::Store::open(&path).expect("open and migrate legacy store");
+    assert_eq!(
+        store.schema_version().expect("schema version"),
+        SUPPORTED_SCHEMA_VERSION
+    );
+
+    {
+        let connection = store.connection();
+        let conn = connection.lock().expect("connection");
+        for column in INVOCATION_INSERT_COLUMNS {
+            assert!(
+                table_has_column(&conn, "invocations", column).expect("read invocations columns"),
+                "migrated database is missing insert-bound column `{column}`",
+            );
+        }
+    }
+
+    // The structural assertion above is what catches skew early; this proves
+    // the production write path itself works against a migrated database.
+    store
+        .insert_invocation_trace_record(&InvocationInsertParams {
+            job_run_id: "jrun-legacy".to_string(),
+            activity_id: "implement_one".to_string(),
+            agent: "claude".to_string(),
+            model: Some("claude-opus-4-7".to_string()),
+            slot: None,
+            task_ids: vec!["ORB-10367".to_string()],
+            trace: InvocationTrace {
+                usage: TokenUsage {
+                    cache_create_1h: 37_795,
+                    ..TokenUsage::default()
+                },
+                provider_cost_usd: Some(1.25),
+                ..InvocationTrace::default()
+            },
+        })
+        .expect("insert invocation trace into migrated legacy database");
 }

--- a/crates/orbit-store/src/sqlite/migration/tests/migration.rs
+++ b/crates/orbit-store/src/sqlite/migration/tests/migration.rs
@@ -187,7 +187,10 @@ fn coordination_migrations_create_typed_tables_without_touching_existing_records
         )
         .expect("existing row");
     assert_eq!(preserved, "unchanged");
-    assert_eq!(current_schema_version(&conn).expect("version"), 9);
+    assert_eq!(
+        current_schema_version(&conn).expect("version"),
+        SUPPORTED_SCHEMA_VERSION
+    );
     for table in [
         "workspace_ownership",
         "host_workspace_presence",


### PR DESCRIPTION
Fixes **ORB-10367** / friction **F2026-07-105** — the incident that killed every agent-dispatching pipeline run on dk-server-1 tonight.

## Root cause: migration exists, but never runs on existing databases

Not a missing migration, and not a wrong database path.

`ensure_invocation_schema` holds the `ALTER TABLE invocations ADD COLUMN` steps for `cache_create_1h_tokens` and `provider_cost_usd`, and it is only called from `apply_baseline_schema` — migration **v1**. `run_migrations` applies entries with `version > current`, so any database that already recorded v1 skips baseline forever. Both columns were added to baseline on 2026-07-20; `~/.orbit/orbit.db` recorded `migration.v0001` on 2026-07-04. The ALTERs never reached it, the insert bound columns the table lacked, and the run died at the telemetry write — after the agent work had finished.

Distinguishing evidence: `provider_cost_usd` (same function, added the same day) is **missing from every live database on the box** while the insert binds it. Nothing has ever applied that ALTER anywhere. Path is not the variable — `audit_db` is `global_dir/orbit.db` and `Store::open` migrates the very handle it writes through, so the migrated database and the written database are the same file by construction.

## Changes

**1. Schema (`orbit-store`)** — register the idempotent invocation-schema step as migration **v10** `invocation_telemetry_columns`, guarded on the tables existing. `SUPPORTED_SCHEMA_VERSION` → 10. Both drifted columns are fixed together, not just the one the error named.

**2. Telemetry is non-fatal (`orbit-engine`)** — the durable half. `persist_dispatch_invocation` no longer returns a `Result`: there is no error path left to propagate into a step outcome. Both engine call sites (dispatcher path and HTTP agent-loop path) record the failure through the new `V2AuditWriter::note_telemetry_failure`, mirroring the ORB-00414 audit-failure pattern:
- `tracing::error!` on `orbit.engine.telemetry` naming run, step, and error;
- a `telemetry.persist_failed` audit event on the run record;
- `JobOutcome::{telemetry_failures, degraded_telemetry}`.

A run's success stays decided solely by its work. Had this been in place, four runs' completed work would not have been thrown away.

**3. Structural regression test** — the insert is rendered from one `INVOCATION_INSERT_COLUMNS` list. The new test stamps a database at the newest pre-fix ledger version with the pre-telemetry `invocations` shape (the live dk-server-1 shape), migrates it, and asserts every insert-bound column exists *and* that a real `insert_invocation_trace_record` lands. Verified to fail against the broken state with the exact production message: \`migrated database is missing insert-bound column \`cache_create_1h_tokens\`\`. A fresh-database test cannot catch this class.

## Deployment notes

- **No manual database step is needed** once this ships: v10 applies on the next `Store::open`. Restart `orbit-web.service` after the binary swap.
- **Sequencing vs ORB-10361 (redeploy):** a redeploy alone does *not* fix this and makes it worse — the current live binary already binds `provider_cost_usd`, which is missing from every database on the box, so redeploying without this change just moves the fatal error to the next column. Land this first.
- **Downgrade guard:** databases migrated to v10 are refused by older orbit binaries, as with every prior schema bump.

## Validation

`cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, workspace tests, doc tests, `cargo doc -D warnings`, `cargo deny`, and every guardrail script pass. Two failures on the box are environmental and reproduce on a pristine `agent-main` checkout: `direct_search_semantic_command_surfaces_companion_stderr` (verified against stashed baseline) and `git_commit_batch_uses_templated_single_task_message` (fails only because the worker run exports `AGENT_RUN_ID`/`AGENT_MODEL`/`AGENT_TASK`, which the commit-trailer feature picks up; 285/285 pass with those unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)