### PR TITLE
Narrow the linked-worktree integrity guard and publish blocked PR candidates [ORB-10363]

### DIFF
--- a/.orbit/adrs/accepted/ADR-0246/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0246/adr.yaml
@@ -1,0 +1,25 @@
+schema_version: 2
+id: ADR-0246
+title: Terminal PR shipment uses a job-level failure handoff
+status: accepted
+owner: codex
+created_at: 2026-07-25T02:24:31.464115803Z
+accepted_at: 2026-07-25T02:34:08.643735005Z
+last_updated: 2026-07-25T02:34:08.643735005Z
+related_features:
+- activity-job
+related_tasks:
+- ORB-10363
+tags:
+- pipeline
+- recovery
+- git
+paths:
+- crates/orbit-common/src/types/activity_job/**
+- crates/orbit-engine/src/activity_job/**
+- crates/orbit-engine/src/executor/automation/vcs/**
+- crates/orbit-core/assets/jobs/task_pr_pipeline.yaml
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0246/body.md
+++ b/.orbit/adrs/accepted/ADR-0246/body.md
@@ -1,0 +1,11 @@
+## Context
+A task shipment can fail after an agent has produced coherent work but before the normal commit, rebase, push, and PR checkpoints finish. The real alternatives are to overload per-step recovery so it replays or impersonates later checkpoints, or give the workflow one explicit terminal failure hook that preserves the original failure while publishing any recoverable candidate.
+
+## Decision
+Add an optional job-level failure activity that runs once after a terminal step failure with the job input, completed pipeline checkpoints, failing step, and structured error. `task_pr_pipeline` binds it to a deterministic PR failure handoff which restores the pre-rebase candidate, commits dirty work, pushes without rewriting unknown remote history, opens or reuses a blocked/manual-resolution PR, and blocks the task while the original run still terminalizes as failed.
+
+## Consequences
+- Normal success and retry checkpoints remain unchanged; the failure handoff is an explicit, auditable last-chance side effect.
+- A conflict-blocked run is distinguishable through its task status event, PR body, and failure-activity audit even though the original step failure remains authoritative.
+- Cost: JobV2 gains another lifecycle hook and task shipment maintains a dedicated deterministic recovery action with conservative Git/remote rules.
+- Cost: External push or PR service outages can still prevent publication, but dirty work is committed locally before those fallible operations so terminal runs do not strand uncommitted changes.

--- a/.orbit/resources/activities/pr_failure_handoff.yaml
+++ b/.orbit/resources/activities/pr_failure_handoff.yaml
@@ -1,0 +1,71 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: pr_failure_handoff
+spec:
+  type: deterministic
+  description: >
+    Terminal task-PR recovery hook. Commits any dirty candidate, restores and
+    pushes the pre-rebase branch, opens or reuses a blocked PR, and records
+    manual conflict resolution details without replacing the original failure.
+  input_schema_json:
+    type: object
+    additionalProperties: false
+    required:
+      - failed_step_id
+      - activity_name
+      - error_code
+      - error_message
+      - job_input
+      - pipeline
+      - run_id
+    properties:
+      failed_step_id:
+        type: string
+      activity_name:
+        type: string
+      error_code:
+        type: string
+      error_message:
+        type: string
+      job_input:
+        type: object
+      pipeline:
+        type: object
+      run_id:
+        type: string
+  output_schema_json:
+    type: object
+    required:
+      - phase
+      - decision
+    properties:
+      phase:
+        type: string
+      decision:
+        type: string
+      branch:
+        type: string
+      head_sha:
+        type: string
+      original_base_sha:
+        type: string
+      target_base_sha:
+        type: string
+      conflicting_paths:
+        type: array
+        items:
+          type: string
+      committed_files:
+        type: array
+        items:
+          type: string
+      pr_number:
+        type: string
+      pr_url:
+        type:
+          - string
+          - "null"
+      task_status:
+        type: string
+  action: pr_failure_handoff

--- a/.orbit/resources/jobs/task_pr_pipeline.yaml
+++ b/.orbit/resources/jobs/task_pr_pipeline.yaml
@@ -30,6 +30,9 @@ spec:
   state: enabled
   kind: workflow
   max_active_runs: 10
+  # ADR-0246: preserve and publish recoverable work after any terminal step
+  # failure while keeping the original failure authoritative.
+  failure_activity: pr_failure_handoff
   default_input:
     task_ids: []
     base_branch: main

--- a/crates/orbit-common/src/types/activity_job/catalog.rs
+++ b/crates/orbit-common/src/types/activity_job/catalog.rs
@@ -139,6 +139,8 @@ pub enum ResolveError {
     ActivityNotInCatalog { step_id: String, name: String },
     #[error("job recovery_activity `{name}` not found in catalog")]
     RecoveryActivityNotInCatalog { name: String },
+    #[error("job failure_activity `{name}` not found in catalog")]
+    FailureActivityNotInCatalog { name: String },
     #[error("step `{step_id}`: recovery_activity `{name}` not found in catalog")]
     StepRecoveryActivityNotInCatalog { step_id: String, name: String },
 }
@@ -494,6 +496,14 @@ pub fn resolve_job_target_refs(
     job.resolved_recovery_activity = match job.recovery_activity.as_deref() {
         Some(name) => Some(catalog.get(name).cloned().ok_or_else(|| {
             ResolveError::RecoveryActivityNotInCatalog {
+                name: name.to_string(),
+            }
+        })?),
+        None => None,
+    };
+    job.resolved_failure_activity = match job.failure_activity.as_deref() {
+        Some(name) => Some(catalog.get(name).cloned().ok_or_else(|| {
+            ResolveError::FailureActivityNotInCatalog {
                 name: name.to_string(),
             }
         })?),

--- a/crates/orbit-common/src/types/activity_job/job_v2.rs
+++ b/crates/orbit-common/src/types/activity_job/job_v2.rs
@@ -36,6 +36,12 @@ pub struct JobV2 {
     pub recovery_activity: Option<String>,
     #[serde(skip)]
     pub resolved_recovery_activity: Option<ActivityV2>,
+    /// Best-effort terminal hook invoked once after a step failure. Unlike
+    /// `recovery_activity`, it does not retry or replace the failed step.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_activity: Option<String>,
+    #[serde(skip)]
+    pub resolved_failure_activity: Option<ActivityV2>,
     #[serde(default = "default_max_active_runs")]
     pub max_active_runs: u32,
     #[serde(default)]

--- a/crates/orbit-core/assets/activities/pr_failure_handoff.yaml
+++ b/crates/orbit-core/assets/activities/pr_failure_handoff.yaml
@@ -1,0 +1,71 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: pr_failure_handoff
+spec:
+  type: deterministic
+  description: >
+    Terminal task-PR recovery hook. Commits any dirty candidate, restores and
+    pushes the pre-rebase branch, opens or reuses a blocked PR, and records
+    manual conflict resolution details without replacing the original failure.
+  input_schema_json:
+    type: object
+    additionalProperties: false
+    required:
+      - failed_step_id
+      - activity_name
+      - error_code
+      - error_message
+      - job_input
+      - pipeline
+      - run_id
+    properties:
+      failed_step_id:
+        type: string
+      activity_name:
+        type: string
+      error_code:
+        type: string
+      error_message:
+        type: string
+      job_input:
+        type: object
+      pipeline:
+        type: object
+      run_id:
+        type: string
+  output_schema_json:
+    type: object
+    required:
+      - phase
+      - decision
+    properties:
+      phase:
+        type: string
+      decision:
+        type: string
+      branch:
+        type: string
+      head_sha:
+        type: string
+      original_base_sha:
+        type: string
+      target_base_sha:
+        type: string
+      conflicting_paths:
+        type: array
+        items:
+          type: string
+      committed_files:
+        type: array
+        items:
+          type: string
+      pr_number:
+        type: string
+      pr_url:
+        type:
+          - string
+          - "null"
+      task_status:
+        type: string
+  action: pr_failure_handoff

--- a/crates/orbit-core/assets/jobs/task_pr_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_pr_pipeline.yaml
@@ -30,6 +30,9 @@ spec:
   state: enabled
   kind: workflow
   max_active_runs: 10
+  # ADR-0246: preserve and publish recoverable work after any terminal step
+  # failure while keeping the original failure authoritative.
+  failure_activity: pr_failure_handoff
   default_input:
     task_ids: []
     base_branch: main

--- a/crates/orbit-core/src/command/activity.rs
+++ b/crates/orbit-core/src/command/activity.rs
@@ -77,6 +77,10 @@ pub(crate) const DEFAULT_ACTIVITY_FILES: &[(&str, &str)] = &[
         include_str!("../../assets/activities/pr_open.yaml"),
     ),
     (
+        "pr_failure_handoff",
+        include_str!("../../assets/activities/pr_failure_handoff.yaml"),
+    ),
+    (
         "pr_prepare",
         include_str!("../../assets/activities/pr_prepare.yaml"),
     ),
@@ -174,6 +178,7 @@ mod tests {
             ("git_commit", "git_commit"),
             ("git_rebase", "git_rebase"),
             ("pr_prepare", "pr_prepare"),
+            ("pr_failure_handoff", "pr_failure_handoff"),
             ("pr_promote", "pr_promote"),
             ("release_locks", "release_locks"),
             ("independent_review_guard", "independent_review_guard"),

--- a/crates/orbit-core/src/command/job/catalog.rs
+++ b/crates/orbit-core/src/command/job/catalog.rs
@@ -1205,6 +1205,18 @@ spec:
             assert_eq!(asset.spec.recovery_activity.as_deref(), None);
             resolve_job_target_refs(&mut asset.spec, &catalog)
                 .unwrap_or_else(|err| panic!("default job {job_name} refs resolve: {err}"));
+            if job_name == "task_pr_pipeline" {
+                assert_eq!(
+                    asset.spec.failure_activity.as_deref(),
+                    Some("pr_failure_handoff")
+                );
+                assert!(
+                    asset.spec.resolved_failure_activity.is_some(),
+                    "task PR terminal failure handoff must resolve from the shipped catalog"
+                );
+            } else {
+                assert_eq!(asset.spec.failure_activity, None);
+            }
             let recovery_steps = step_recovery_activities(&asset.spec);
             assert!(
                 !recovery_steps.is_empty(),

--- a/crates/orbit-engine/examples/v2_cli_backend_smoke.rs
+++ b/crates/orbit-engine/examples/v2_cli_backend_smoke.rs
@@ -545,6 +545,8 @@ fn synthetic_loop_session_cli_job() -> JobV2 {
         default_input: None,
         recovery_activity: None,
         resolved_recovery_activity: None,
+        failure_activity: None,
+        resolved_failure_activity: None,
         max_active_runs: 1,
         kind: JobKind::Workflow,
         steps: vec![loop_step],

--- a/crates/orbit-engine/examples/v2_name_resolution_smoke.rs
+++ b/crates/orbit-engine/examples/v2_name_resolution_smoke.rs
@@ -406,6 +406,8 @@ fn synthetic_job_using_ref(target_name: &str) -> JobV2 {
         default_input: None,
         recovery_activity: None,
         resolved_recovery_activity: None,
+        failure_activity: None,
+        resolved_failure_activity: None,
         max_active_runs: 1,
         kind: JobKind::Workflow,
         steps: vec![JobV2Step {
@@ -445,6 +447,8 @@ fn pipeline_with_reviewer_loop() -> JobV2 {
         default_input: None,
         recovery_activity: None,
         resolved_recovery_activity: None,
+        failure_activity: None,
+        resolved_failure_activity: None,
         max_active_runs: 1,
         kind: JobKind::Workflow,
         steps: vec![JobV2Step {

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -23,6 +23,7 @@ use super::super::super::agent_role::{apply_resolved_settings, resolve_agent_set
 use super::super::super::audit_writer::V2AuditWriter;
 use super::super::super::dispatcher::DispatchError;
 use super::super::super::sqlite_sink::V2SqliteSink;
+use super::super::super::workspace::{WorktreeBoundaryGuard, validate_declared_worktree_pair};
 use super::super::run_cli_backend;
 use super::test_support::{
     RecordingSink, TestHost, capture_events, test_agent_loop_spec, test_agent_loop_spec_for,
@@ -957,6 +958,121 @@ fn unchanged_pre_dirty_primary_does_not_block_valid_worktree_implementation() {
 }
 
 #[test]
+fn concurrent_primary_fast_forward_does_not_block_disjoint_worktree_changes() {
+    let fixture = linked_worktree_fixture();
+    let script = fixture.root().join("codex");
+    write_executable(
+        &script,
+        &format!(
+            "#!/bin/sh\ncat > /dev/null\nprintf 'assigned\\n' > assigned.txt\nprintf 'concurrent\\n' > '{}/concurrent.txt'\ngit -C '{}' add -- concurrent.txt\ngit -C '{}' commit -m concurrent-base\nprintf '%s\\n' '{{\"schemaVersion\":1,\"status\":\"success\",\"result\":{{}},\"error\":null}}'\n",
+            fixture.primary.display(),
+            fixture.primary.display(),
+            fixture.primary.display(),
+        ),
+    );
+    let mut host = TestHost::with_command(script.display().to_string());
+    host.workspace_root = Some(fixture.primary.clone());
+
+    let outcome = run_cli_backend(
+        &host,
+        &test_agent_loop_spec(Duration::from_secs(5)),
+        "run-concurrent-fast-forward",
+        test_audit("run-concurrent-fast-forward", "codex"),
+        &worktree_input(&fixture, "ORB-CONCURRENT-FF"),
+        None,
+    )
+    .expect("a disjoint same-branch primary fast-forward is benign");
+
+    assert!(outcome.success);
+    assert!(fixture.assigned.join("assigned.txt").exists());
+    assert!(fixture.primary.join("concurrent.txt").exists());
+}
+
+#[test]
+fn two_in_flight_worktrees_survive_one_primary_merge_advance() {
+    let fixture = linked_worktree_fixture();
+    let assigned_two = fixture.root().join("assigned-two");
+    git_ok(
+        &fixture.primary,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "orbit-integrity-test-two",
+            assigned_two.to_str().expect("utf8 second worktree"),
+        ],
+    );
+    let assigned_two = assigned_two
+        .canonicalize()
+        .expect("canonical second worktree");
+    let input_one = worktree_input(&fixture, "ORB-CONCURRENT-ONE");
+    let input_two = serde_json::json!({
+        "prompt": "implement",
+        "task_id": "ORB-CONCURRENT-TWO",
+        "workspace_path": assigned_two,
+        "repo_root": assigned_two,
+    });
+    let pair_one = validate_declared_worktree_pair(
+        &input_one,
+        None,
+        "run-concurrent-one",
+        "codex",
+        Some(&fixture.primary),
+    )
+    .expect("validate first pair")
+    .expect("first linked pair");
+    let pair_two = validate_declared_worktree_pair(
+        &input_two,
+        None,
+        "run-concurrent-two",
+        "codex",
+        Some(&fixture.primary),
+    )
+    .expect("validate second pair")
+    .expect("second linked pair");
+    let guard_one = WorktreeBoundaryGuard::capture(
+        &input_one,
+        None,
+        "run-concurrent-one",
+        "codex",
+        Some(&fixture.assigned),
+        Some(&fixture.primary),
+        Some(&pair_one),
+    )
+    .expect("capture first guard")
+    .expect("first guard enabled");
+    let guard_two = WorktreeBoundaryGuard::capture(
+        &input_two,
+        None,
+        "run-concurrent-two",
+        "codex",
+        Some(&assigned_two),
+        Some(&fixture.primary),
+        Some(&pair_two),
+    )
+    .expect("capture second guard")
+    .expect("second guard enabled");
+
+    fs::write(fixture.assigned.join("candidate-one.txt"), "candidate\n")
+        .expect("write first candidate");
+    fs::write(assigned_two.join("candidate-two.txt"), "candidate\n")
+        .expect("write second candidate");
+    fs::write(fixture.primary.join("merged-pr.txt"), "merged\n").expect("write merged PR");
+    git_ok(&fixture.primary, &["add", "merged-pr.txt"]);
+    git_ok(&fixture.primary, &["commit", "-m", "merge concurrent PR"]);
+
+    guard_one
+        .verify()
+        .expect("first in-flight pipeline accepts the shared base advance");
+    guard_two
+        .verify()
+        .expect("second in-flight pipeline accepts the shared base advance");
+
+    assert!(fixture.assigned.join("candidate-one.txt").exists());
+    assert!(assigned_two.join("candidate-two.txt").exists());
+}
+
+#[test]
 fn unchanged_pre_dirty_path_is_excluded_from_escape_diagnostic() {
     let fixture = linked_worktree_fixture();
     fs::write(
@@ -1075,7 +1191,7 @@ fn primary_escape_is_typed_non_retryable_and_preserves_both_checkouts() {
 
     assert_worktree_integrity_error(
         &error,
-        "worktree_escape",
+        "primary_checkout_drift",
         ("ORB-ESCAPE", "run-deliberate-escape", "claude"),
         &fixture,
         "escaped.txt",
@@ -1110,7 +1226,7 @@ fn primary_escape_is_typed_non_retryable_and_preserves_both_checkouts() {
 }
 
 #[test]
-fn changes_in_both_checkouts_report_ambiguous_integrity_violation() {
+fn primary_content_mutation_is_typed_even_when_assigned_content_also_changes() {
     let fixture = linked_worktree_fixture();
     let escaped = fixture.primary.join("ambiguous-primary.txt");
     let script = fixture.root().join("codex");
@@ -1136,13 +1252,94 @@ fn changes_in_both_checkouts_report_ambiguous_integrity_violation() {
 
     assert_worktree_integrity_error(
         &error,
-        "worktree_integrity_ambiguous",
+        "primary_checkout_drift",
         ("ORB-AMBIGUOUS", "run-ambiguous-integrity", "codex"),
         &fixture,
         "ambiguous-primary.txt",
     );
     assert!(fixture.assigned.join("ambiguous-assigned.txt").exists());
     assert!(escaped.exists());
+}
+
+#[test]
+fn assigned_history_divergence_is_a_typed_worktree_content_conflict() {
+    let fixture = linked_worktree_fixture();
+    let script = fixture.root().join("codex");
+    write_executable(
+        &script,
+        "#!/bin/sh\ncat > /dev/null\nprintf 'committed by provider\\n' > assigned-commit.txt\ngit add -- assigned-commit.txt\ngit commit -m assigned-history-change\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\n",
+    );
+    let mut host = TestHost::with_command(script.display().to_string());
+    host.workspace_root = Some(fixture.primary.clone());
+
+    let error = run_cli_backend(
+        &host,
+        &test_agent_loop_spec(Duration::from_secs(5)),
+        "run-assigned-history-change",
+        test_audit("run-assigned-history-change", "codex"),
+        &worktree_input(&fixture, "ORB-ASSIGNED-HISTORY"),
+        None,
+    )
+    .expect_err("provider-created worktree history must fail closed");
+
+    assert_worktree_integrity_error(
+        &error,
+        "worktree_content_conflict",
+        (
+            "ORB-ASSIGNED-HISTORY",
+            "run-assigned-history-change",
+            "codex",
+        ),
+        &fixture,
+        "assigned-commit.txt",
+    );
+    let diagnostic = worktree_integrity_diagnostic(&error);
+    assert_eq!(
+        diagnostic["changed_paths"],
+        serde_json::json!(["assigned-commit.txt"]),
+        "worktree conflicts report the run's paths, not primary checkout paths"
+    );
+}
+
+#[test]
+fn non_fast_forward_primary_move_remains_a_typed_drift_failure() {
+    let fixture = linked_worktree_fixture();
+    fs::write(fixture.primary.join("before-reset.txt"), "before reset\n")
+        .expect("write primary commit");
+    git_ok(&fixture.primary, &["add", "before-reset.txt"]);
+    git_ok(&fixture.primary, &["commit", "-m", "primary before reset"]);
+    let script = fixture.root().join("codex");
+    write_executable(
+        &script,
+        &format!(
+            "#!/bin/sh\ncat > /dev/null\nprintf 'assigned survives\\n' > assigned-survives.txt\ngit -C '{}' reset --hard HEAD^\nprintf '%s\\n' '{{\"schemaVersion\":1,\"status\":\"success\",\"result\":{{}},\"error\":null}}'\n",
+            fixture.primary.display(),
+        ),
+    );
+    let mut host = TestHost::with_command(script.display().to_string());
+    host.workspace_root = Some(fixture.primary.clone());
+
+    let error = run_cli_backend(
+        &host,
+        &test_agent_loop_spec(Duration::from_secs(5)),
+        "run-primary-reset",
+        test_audit("run-primary-reset", "codex"),
+        &worktree_input(&fixture, "ORB-PRIMARY-RESET"),
+        None,
+    )
+    .expect_err("a primary reset must remain fail closed");
+
+    assert_worktree_integrity_error(
+        &error,
+        "primary_checkout_drift",
+        ("ORB-PRIMARY-RESET", "run-primary-reset", "codex"),
+        &fixture,
+        "before-reset.txt",
+    );
+    assert!(
+        fixture.assigned.join("assigned-survives.txt").exists(),
+        "the guard diagnoses without discarding the run candidate"
+    );
 }
 
 #[test]
@@ -1179,7 +1376,7 @@ fn primary_escape_is_checked_after_nonzero_exit_and_timeout() {
 
         assert_worktree_integrity_error(
             &error,
-            "worktree_escape",
+            "primary_checkout_drift",
             (&task_id, &run_id, "codex"),
             &fixture,
             &escaped_name,

--- a/crates/orbit-engine/src/activity_job/job_executor/exec_ctx.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/exec_ctx.rs
@@ -14,6 +14,7 @@ pub(super) struct ExecCtx<'a> {
     pub(super) pipeline: Arc<Mutex<HashMap<String, Value>>>,
     pub(super) sessions: Arc<Mutex<HashMap<String, Session>>>,
     pub(super) recovery_activity: Option<ResolvedRecoveryActivity>,
+    pub(super) failure_activity: Option<ResolvedRecoveryActivity>,
     /// `Some(value)` inside a fan-out worker. Rendered into template context
     /// as `{{ item }}`.
     pub(super) item: Option<Value>,

--- a/crates/orbit-engine/src/activity_job/job_executor/fan_out.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/fan_out.rs
@@ -97,6 +97,7 @@ pub(super) fn run_fan_out(
                     pipeline: Arc::new(Mutex::new(pipeline_snapshot)),
                     sessions: Arc::new(Mutex::new(HashMap::new())),
                     recovery_activity: ctx.recovery_activity.clone(),
+                    failure_activity: ctx.failure_activity.clone(),
                     item: Some(item),
                     iteration: Some(idx),
                 };

--- a/crates/orbit-engine/src/activity_job/job_executor/loop_block.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/loop_block.rs
@@ -48,6 +48,7 @@ pub(super) fn run_loop(
             pipeline: ctx.pipeline.clone(),
             sessions: ctx.sessions.clone(),
             recovery_activity: ctx.recovery_activity.clone(),
+            failure_activity: ctx.failure_activity.clone(),
             item: loop_items
                 .as_ref()
                 .and_then(|items| items.get(iteration_index as usize).cloned()),

--- a/crates/orbit-engine/src/activity_job/job_executor/mod.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/mod.rs
@@ -157,6 +157,13 @@ pub fn execute_job_with_resume(
         }),
         _ => None,
     };
+    let failure_activity = match (&job.failure_activity, &job.resolved_failure_activity) {
+        (Some(name), Some(activity)) => Some(ResolvedRecoveryActivity {
+            name: name.clone(),
+            spec: activity.spec.clone(),
+        }),
+        _ => None,
+    };
 
     let ctx = ExecCtx {
         run_id: run_id.to_string(),
@@ -166,6 +173,7 @@ pub fn execute_job_with_resume(
         pipeline: Arc::new(Mutex::new(seed_pipeline_from_resume(job, resume))),
         sessions: Arc::new(Mutex::new(HashMap::new())),
         recovery_activity,
+        failure_activity,
         item: None,
         iteration: None,
     };
@@ -187,7 +195,13 @@ pub fn execute_job_with_resume(
             );
             continue;
         }
-        let outcome = run_step(step, &ctx)?;
+        let outcome = match run_step(step, &ctx) {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                attempt_failure_activity(step, &ctx, &error);
+                return Err(error);
+            }
+        };
         if !outcome.success {
             overall_ok = false;
             overall_message = Some(
@@ -195,6 +209,12 @@ pub fn execute_job_with_resume(
                     .message
                     .unwrap_or_else(|| format!("step `{}` completed with success=false", step.id)),
             );
+            let error = DispatchError::JobExecution(
+                overall_message
+                    .clone()
+                    .unwrap_or_else(|| format!("step `{}` failed", step.id)),
+            );
+            attempt_failure_activity(step, &ctx, &error);
             break;
         }
         checkpoint_completed_step(&ctx, step_index, &step.id, &outcome.output);

--- a/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
@@ -95,6 +95,72 @@ pub(super) fn attempt_recovery_activity(
     recovery_succeeded
 }
 
+/// Invoke the job's terminal failure hook once, preserving the original step
+/// error regardless of the hook outcome. ADR-0246 keeps this separate from
+/// retry recovery: the hook may publish a recoverable candidate, but it never
+/// claims that the failed step succeeded.
+pub(super) fn attempt_failure_activity(
+    step: &JobV2Step,
+    ctx: &ExecCtx<'_>,
+    original_err: &DispatchError,
+) {
+    let Some(failure) = &ctx.failure_activity else {
+        return;
+    };
+    let pipeline = Value::Object(
+        ctx.pipeline
+            .lock()
+            .expect("pipeline poisoned")
+            .clone()
+            .into_iter()
+            .collect(),
+    );
+    let error_code = match original_err {
+        DispatchError::WorktreeIntegrity { code, .. } => *code,
+        _ => "pipeline_step_failed",
+    };
+    let input = serde_json::json!({
+        "failed_step_id": step.id,
+        "activity_name": step_activity_name(step),
+        "error_code": error_code,
+        "error_message": original_err.to_string(),
+        "job_input": ctx.input,
+        "pipeline": pipeline,
+        "run_id": ctx.run_id,
+    });
+    let dispatch = dispatch_v2_activity_without_run_id_injection(V2DispatchInput {
+        activity_name: &failure.name,
+        spec: &failure.spec,
+        fs_profile: step_fs_profile(step),
+        input: input.clone(),
+        audit: ctx.audit.clone(),
+        run_id: &ctx.run_id,
+        host: Some(ctx.host),
+    });
+    match dispatch {
+        Ok(dispatch) => {
+            let _ = persist_dispatch_invocation(ctx, &failure.name, &input, &dispatch);
+            if !dispatch.success {
+                tracing::warn!(
+                    target: "orbit.engine.job_executor",
+                    run_id = %ctx.run_id,
+                    failed_step_id = %step.id,
+                    failure_activity = %failure.name,
+                    "terminal failure activity completed without success"
+                );
+            }
+        }
+        Err(error) => tracing::warn!(
+            target: "orbit.engine.job_executor",
+            run_id = %ctx.run_id,
+            failed_step_id = %step.id,
+            failure_activity = %failure.name,
+            error = %error,
+            "terminal failure activity failed; preserving original step error"
+        ),
+    }
+}
+
 pub(super) fn role_overridden_recovery_spec(
     recovery: &ResolvedRecoveryActivity,
     ctx: &ExecCtx<'_>,

--- a/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
@@ -139,7 +139,7 @@ pub(super) fn attempt_failure_activity(
     });
     match dispatch {
         Ok(dispatch) => {
-            let _ = persist_dispatch_invocation(ctx, &failure.name, &input, &dispatch);
+            persist_dispatch_invocation(ctx, &failure.name, &input, &dispatch);
             if !dispatch.success {
                 tracing::warn!(
                     target: "orbit.engine.job_executor",

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/mod.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/mod.rs
@@ -354,6 +354,8 @@ pub(super) fn job_with_steps(steps: Vec<JobV2Step>) -> JobV2 {
         default_input: None,
         recovery_activity: None,
         resolved_recovery_activity: None,
+        failure_activity: None,
+        resolved_failure_activity: None,
         max_active_runs: 1,
         kind: JobKind::Workflow,
         steps,

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
@@ -528,6 +528,39 @@ fn no_recovery_activity_preserves_success_and_failure_paths() {
 }
 
 #[test]
+fn terminal_failure_activity_runs_once_and_preserves_original_error() {
+    let host = ScriptedHost::new([
+        (
+            "build",
+            vec![Action::Err(retryable_error("build", "compile failed"))],
+        ),
+        (
+            "publish_failure",
+            vec![Action::Ok(json!({"published": true}))],
+        ),
+    ]);
+    let mut job = recovery_job(None, None, "build", None, 1);
+    job.failure_activity = Some("publish_failure".to_string());
+    job.resolved_failure_activity = Some(deterministic_activity("publish_failure", None));
+
+    let error = execute_job(
+        &job,
+        json!({"task_id": "ORB-FAILURE-HOOK"}),
+        "run-failure-hook",
+        Arc::new(test_writer("run-failure-hook")),
+        &host,
+    )
+    .expect_err("the failure hook must not replace the original step failure");
+
+    assert!(
+        error.to_string().contains("compile failed"),
+        "original error remains authoritative: {error}"
+    );
+    assert_eq!(host.call_count("build"), 1);
+    assert_eq!(host.call_count("publish_failure"), 1);
+}
+
+#[test]
 fn unknown_recovery_activity_name_is_job_validation_during_catalog_resolution() {
     let yaml = r#"
 schemaVersion: 2
@@ -569,6 +602,8 @@ fn recovery_job(
         recovery_activity: recovery_name.map(str::to_string),
         resolved_recovery_activity: recovery_name
             .map(|name| deterministic_activity(name, recovery_fs_profile)),
+        failure_activity: None,
+        resolved_failure_activity: None,
         max_active_runs: 1,
         kind: JobKind::Workflow,
         steps: vec![JobV2Step {
@@ -645,6 +680,7 @@ fn recovery_exec_ctx<'a>(host: &'a dyn V2RuntimeHost) -> ExecCtx<'a> {
         pipeline: std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
         sessions: std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
         recovery_activity: None,
+        failure_activity: None,
         item: None,
         iteration: None,
     }

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
@@ -145,6 +145,7 @@ fn exec_ctx<'a>(host: &'a dyn V2RuntimeHost) -> super::ExecCtx<'a> {
         pipeline: std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
         sessions: std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
         recovery_activity: None,
+        failure_activity: None,
         item: None,
         iteration: None,
     }

--- a/crates/orbit-engine/src/activity_job/job_executor/validate.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/validate.rs
@@ -9,6 +9,14 @@ pub fn validate_job(job: &JobV2) -> Result<(), DispatchError> {
              `resolve_job_catalog_refs_for_execution` at load time before dispatch"
         )));
     }
+    if let Some(name) = &job.failure_activity
+        && job.resolved_failure_activity.is_none()
+    {
+        return Err(DispatchError::JobValidation(format!(
+            "job failure_activity `{name}` was not resolved — caller must run \
+             `resolve_job_catalog_refs_for_execution` at load time before dispatch"
+        )));
+    }
     for step in &job.steps {
         validate_step(step)?;
     }

--- a/crates/orbit-engine/src/activity_job/workspace.rs
+++ b/crates/orbit-engine/src/activity_job/workspace.rs
@@ -562,25 +562,81 @@ impl WorktreeBoundaryGuard {
     }
 
     /// Compare both monitored checkouts after the provider reaches any
-    /// terminal outcome. A primary delta always fails closed. When the
-    /// assigned checkout changed too, attribution is ambiguous rather than an
-    /// automatic escape/reconciliation claim.
+    /// terminal outcome. An externally advanced primary branch is benign when
+    /// it is a clean fast-forward: linked worktrees keep their own HEAD, and
+    /// the shipment rebase checkpoint owns reconciliation with the new base.
+    /// Primary rewrites/content mutation and history changes in the assigned
+    /// worktree remain typed, fail-closed violations.
     pub(crate) fn verify(self) -> Result<(), DispatchError> {
         let assigned_after = git_fingerprint(&self.assigned_root)?;
         let primary_after = git_fingerprint(&self.primary_root)?;
+        let assigned_history_changed = assigned_after.head != self.assigned_before.head
+            || assigned_after.branch != self.assigned_before.branch;
+        let run_changed_paths =
+            changed_paths(&self.assigned_root, &self.assigned_before, &assigned_after);
+        let primary_changed_paths =
+            changed_paths(&self.primary_root, &self.primary_before, &primary_after);
+        let conflicting_paths = run_changed_paths
+            .iter()
+            .filter(|path| primary_changed_paths.contains(path))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        if assigned_history_changed {
+            return Err(self.integrity_error(
+                "worktree_content_conflict",
+                &assigned_after,
+                &primary_after,
+                &run_changed_paths,
+                &primary_changed_paths,
+                &conflicting_paths,
+                "the assigned worktree history or branch changed during implementation",
+            ));
+        }
+
         if primary_after == self.primary_before {
             return Ok(());
         }
 
-        let assigned_changed = assigned_after != self.assigned_before;
-        let code = if assigned_changed {
-            "worktree_integrity_ambiguous"
-        } else {
-            "worktree_escape"
-        };
-        let changed_paths = changed_paths(&self.primary_root, &self.primary_before, &primary_after);
+        if primary_fast_forward_is_benign(&self.primary_root, &self.primary_before, &primary_after)?
+        {
+            tracing::info!(
+                target: "orbit.engine.cli_runner",
+                task_id = %self.task_id,
+                run_id = %self.run_id,
+                primary_before = %self.primary_before.head,
+                primary_after = %primary_after.head,
+                conflicting_paths = ?conflicting_paths,
+                "accepted concurrent primary fast-forward; shipment base synchronization owns reconciliation"
+            );
+            return Ok(());
+        }
+
+        Err(self.integrity_error(
+            "primary_checkout_drift",
+            &assigned_after,
+            &primary_after,
+            &primary_changed_paths,
+            &primary_changed_paths,
+            &conflicting_paths,
+            "the registered primary checkout changed without a clean same-branch fast-forward",
+        ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn integrity_error(
+        &self,
+        code: &'static str,
+        assigned_after: &GitWorktreeFingerprint,
+        primary_after: &GitWorktreeFingerprint,
+        reported_paths: &[String],
+        primary_changed_paths: &[String],
+        conflicting_paths: &[String],
+        reason: &str,
+    ) -> DispatchError {
         let diagnostic = json!({
             "code": code,
+            "reason": reason,
             "task_id": self.task_id,
             "run_id": self.run_id,
             "provider": self.provider,
@@ -588,19 +644,46 @@ impl WorktreeBoundaryGuard {
             "requested_repo_root": self.requested_repo_root,
             "resolved_assigned_root": self.assigned_root,
             "registered_primary_root": self.primary_root,
-            "changed_paths": changed_paths,
-            "assigned_changed": assigned_changed,
+            "changed_paths": reported_paths,
+            "run_changed_paths": changed_paths(&self.assigned_root, &self.assigned_before, assigned_after),
+            "primary_changed_paths": primary_changed_paths,
+            "conflicting_paths": conflicting_paths,
+            "assigned_changed": assigned_after != &self.assigned_before,
             "assigned_before": self.assigned_before,
             "assigned_after": assigned_after,
             "primary_before": self.primary_before,
             "primary_after": primary_after,
             "automatic_reconciliation": false,
         });
-        Err(DispatchError::WorktreeIntegrity {
+        DispatchError::WorktreeIntegrity {
             code,
             diagnostic: diagnostic.to_string(),
-        })
+        }
     }
+}
+
+fn primary_fast_forward_is_benign(
+    root: &Path,
+    before: &GitWorktreeFingerprint,
+    after: &GitWorktreeFingerprint,
+) -> Result<bool, DispatchError> {
+    // L-0110: linked-worktree shipment owns clean base fast-forwards; the
+    // provider boundary still rejects primary content/history drift.
+    if before.head == after.head
+        || before.branch != after.branch
+        || before.dirty_paths != after.dirty_paths
+        || before.path_states != after.path_states
+        || before.tracked_patch_sha256 != after.tracked_patch_sha256
+        || before.untracked_content != after.untracked_content
+    {
+        return Ok(false);
+    }
+    Ok(git_output_raw(
+        root,
+        &["merge-base", "--is-ancestor", &before.head, &after.head],
+    )?
+    .status
+    .success())
 }
 
 fn declared_workspace_path(input: &Value, task_ctx: Option<&Value>) -> Option<String> {

--- a/crates/orbit-engine/src/executor/automation/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/mod.rs
@@ -28,6 +28,7 @@ const RUN_PLANNING_DUEL_ACTION: &str = "run_planning_duel";
 // ---- generic built-in automation actions ----
 const GIT_COMMIT_ACTION: &str = "git_commit";
 const GIT_REBASE_ACTION: &str = "git_rebase";
+const PR_FAILURE_HANDOFF_ACTION: &str = "pr_failure_handoff";
 const GIT_PUSH_ACTION: &str = "git_push";
 const GIT_PULL_ACTION: &str = "git_pull";
 const GIT_MERGE_ACTION: &str = "git_merge";
@@ -170,6 +171,7 @@ pub fn execute_action<
         // ---- generic built-in actions ----
         GIT_COMMIT_ACTION => vcs::git_commit(host, input),
         GIT_REBASE_ACTION => vcs::rebase_pr_branch(host, input),
+        PR_FAILURE_HANDOFF_ACTION => vcs::pr_failure_handoff(host, input),
         GIT_PUSH_ACTION => vcs::push_batch_changes(host, input),
         GIT_PULL_ACTION => vcs::pull_batch_changes(host, input),
         GIT_MERGE_ACTION => vcs::git_merge(host, input),

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
@@ -250,6 +250,26 @@ pub(super) fn commit_batch_changes<H: TaskHost + RuntimeHost + ?Sized>(
     Ok(result)
 }
 
+/// Commit a terminally-failed shipment's dirty candidate without consulting
+/// the normal success-summary delivery gate. ADR-0246 confines this bypass to
+/// the failure handoff, which blocks rather than promotes the task.
+pub(super) fn commit_failure_candidate(
+    workspace_path: &Path,
+    task: &orbit_common::types::Task,
+) -> Result<(String, Vec<String>), OrbitError> {
+    ensure_named_branch(workspace_path)?;
+    ensure_no_unmerged_changes(workspace_path)?;
+    git_success(workspace_path, &["add", "--all", "--", "."])?;
+    let changed_files = staged_changed_files(workspace_path)?;
+    if !changed_files.is_empty() {
+        let message = batch_commit_message(task);
+        let author = git_author_for_task(task);
+        git_commit_with_identity(workspace_path, &message, author.as_ref())?;
+    }
+    let head_sha = git_output(workspace_path, &["rev-parse", "--verify", "HEAD^{commit}"])?;
+    Ok((head_sha.trim().to_string(), changed_files))
+}
+
 fn existing_batch_commits(
     workspace_path: &Path,
     input: &Value,

--- a/crates/orbit-engine/src/executor/automation/vcs/failure.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/failure.rs
@@ -1,0 +1,286 @@
+use std::path::Path;
+
+use chrono::Utc;
+use orbit_common::types::{ExternalRef, OrbitError, TaskComment, TaskStatus};
+use serde_json::{Value, json};
+
+use crate::context::{RuntimeHost, TaskAutomationUpdate, TaskHost};
+use crate::executor::automation::input::{
+    canonicalize_existing_dir, input_string_field, required_input_string,
+};
+
+use super::commit::commit_failure_candidate;
+use super::freshness::commit_sha;
+use super::git::{
+    base_sync_mode_from_input, git_command_success, git_output, resolve_worktree_start_point,
+};
+use super::pr::open_or_reuse_unchecked;
+use super::push::push_batch_changes_inner;
+
+const CONFLICT_BLOCKED_EVENT: &str = "pr_conflict_blocked";
+const FAILURE_HANDOFF_EVENT: &str = "pr_failure_handoff";
+
+/// ADR-0246 terminal hook for `task_pr_pipeline`.
+///
+/// The original job error remains authoritative. This action only makes the
+/// candidate recoverable: restore the pre-rebase branch, commit dirtiness,
+/// push without rewriting unknown remote history, publish a blocked PR, and
+/// leave the task in `blocked` rather than `review`.
+pub(in crate::executor::automation) fn pr_failure_handoff<
+    H: RuntimeHost + TaskHost + Sync + ?Sized,
+>(
+    host: &H,
+    input: &Value,
+) -> Result<Value, OrbitError> {
+    let failed_step_id = required_input_string(input, "failed_step_id")?;
+    let error_code = required_input_string(input, "error_code")?;
+    let error_message = required_input_string(input, "error_message")?;
+    let run_id = required_input_string(input, "run_id")?;
+    let job_input = input
+        .get("job_input")
+        .ok_or_else(|| OrbitError::InvalidInput("missing required input.job_input".to_string()))?;
+    let worktree = pipeline_step(input, "worktree")?;
+    let workspace_path = canonicalize_existing_dir(
+        required_input_string(worktree, "workspace_path")?,
+        "pipeline.worktree.workspace_path",
+    )?;
+
+    let mut conflicting_paths = unmerged_paths(&workspace_path)?;
+    let rebase_aborted = git_command_success(&workspace_path, &["rebase", "--abort"])?;
+    if !conflicting_paths.is_empty() && !rebase_aborted {
+        return Err(OrbitError::Execution(
+            "pr_failure_handoff: conflicts exist but the in-progress rebase could not be aborted"
+                .to_string(),
+        ));
+    }
+    if conflicting_paths.is_empty() {
+        conflicting_paths = conflicts_from_error(error_message);
+    }
+
+    let task_ids = job_input
+        .get("task_ids")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            OrbitError::InvalidInput(
+                "pr_failure_handoff: job_input.task_ids must be an array".to_string(),
+            )
+        })?;
+    let [task_id] = task_ids.as_slice() else {
+        return Err(OrbitError::InvalidInput(format!(
+            "pr_failure_handoff expected exactly one task id, got {}",
+            task_ids.len()
+        )));
+    };
+    let task_id = task_id.as_str().ok_or_else(|| {
+        OrbitError::InvalidInput(
+            "pr_failure_handoff: task id must be a non-empty string".to_string(),
+        )
+    })?;
+    let task = host.get_task(task_id)?;
+    if task.job_run_id.as_deref() != Some(run_id) {
+        return Err(OrbitError::Execution(format!(
+            "pr_failure_handoff: task '{}' no longer belongs to run '{}'",
+            task.id, run_id
+        )));
+    }
+
+    let (head_sha, committed_files) = commit_failure_candidate(&workspace_path, &task)?;
+    let head = git_output(&workspace_path, &["rev-parse", "--abbrev-ref", "HEAD"])?
+        .trim()
+        .to_string();
+    if head == "HEAD" {
+        return Err(OrbitError::Execution(
+            "pr_failure_handoff: recovery candidate is detached".to_string(),
+        ));
+    }
+
+    let base = input_string_field(job_input, "base_branch").unwrap_or_else(|| "main".to_string());
+    let target_base_sha = match prepared_base_sha(input) {
+        Some(base_sha) => base_sha,
+        None => {
+            let sync_mode = base_sync_mode_from_input(job_input)?;
+            let target_base_ref = resolve_worktree_start_point(&workspace_path, &base, sync_mode)?;
+            commit_sha(&workspace_path, &target_base_ref)?
+        }
+    };
+    let original_base_sha = original_base_sha(&workspace_path, &head_sha, &target_base_sha)?;
+
+    if committed_files.is_empty() && head_sha == original_base_sha {
+        return Ok(json!({
+            "phase": "failure_handoff",
+            "decision": "no_candidate",
+            "failed_step_id": failed_step_id,
+            "workspace_path": workspace_path,
+        }));
+    }
+
+    let pushed = push_batch_changes_inner(
+        host,
+        &json!({
+            "branch": head,
+            "workspace_path": workspace_path,
+        }),
+        &workspace_path,
+    )?;
+    let title = input_string_field(job_input, "title")
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| format!("[BLOCKED] {}", task.title.trim()));
+    let body = blocked_pr_body(
+        &task.id,
+        run_id,
+        failed_step_id,
+        error_code,
+        error_message,
+        &original_base_sha,
+        &target_base_sha,
+        &conflicting_paths,
+    );
+    let (pr_number, pr_url, pr_created) =
+        open_or_reuse_unchecked(host, &workspace_path, &head, &base, &title, &body)?;
+
+    let conflict_blocked = !conflicting_paths.is_empty();
+    let event = if conflict_blocked {
+        CONFLICT_BLOCKED_EVENT
+    } else {
+        FAILURE_HANDOFF_EVENT
+    };
+    let paths = if conflicting_paths.is_empty() {
+        "none reported".to_string()
+    } else {
+        conflicting_paths.join(", ")
+    };
+    let note = format!(
+        "failure handoff published PR #{pr_number}: run={run_id}, failed_step={failed_step_id}, \
+         original_base={original_base_sha}, target_base={target_base_sha}, conflicts={paths}"
+    );
+    host.apply_task_automation_update(
+        &task.id,
+        TaskAutomationUpdate {
+            status: Some(TaskStatus::Blocked),
+            status_event: Some(event.to_string()),
+            status_note: Some(note.clone()),
+            external_refs: vec![ExternalRef::github_pr(pr_number.clone())?],
+            append_comments: vec![TaskComment {
+                at: Utc::now(),
+                by: "system".to_string(),
+                message: format!("{note}\n\n{body}"),
+            }],
+            ..TaskAutomationUpdate::default()
+        },
+    )?;
+
+    Ok(json!({
+        "phase": "failure_handoff",
+        "decision": if conflict_blocked { "blocked_conflict_pr" } else { "blocked_failure_pr" },
+        "failed_step_id": failed_step_id,
+        "branch": head,
+        "head_sha": head_sha,
+        "original_base_sha": original_base_sha,
+        "target_base_sha": target_base_sha,
+        "conflicting_paths": conflicting_paths,
+        "committed_files": committed_files,
+        "push": pushed,
+        "pr_number": pr_number,
+        "pr_url": pr_url,
+        "pr_created": pr_created,
+        "task_status": "blocked",
+    }))
+}
+
+fn pipeline_step<'a>(input: &'a Value, step: &str) -> Result<&'a Value, OrbitError> {
+    input
+        .get("pipeline")
+        .and_then(|pipeline| pipeline.get(step))
+        .ok_or_else(|| {
+            OrbitError::InvalidInput(format!(
+                "pr_failure_handoff: missing pipeline.{step} checkpoint"
+            ))
+        })
+}
+
+fn prepared_base_sha(input: &Value) -> Option<String> {
+    input
+        .get("pipeline")
+        .and_then(|pipeline| pipeline.get("prepare_branch"))
+        .and_then(|prepare| prepare.get("base_sha"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|sha| !sha.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn unmerged_paths(workspace_path: &Path) -> Result<Vec<String>, OrbitError> {
+    Ok(
+        git_output(workspace_path, &["diff", "--name-only", "--diff-filter=U"])?
+            .lines()
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+            .map(ToOwned::to_owned)
+            .collect(),
+    )
+}
+
+fn original_base_sha(
+    workspace_path: &Path,
+    head_sha: &str,
+    target_base_sha: &str,
+) -> Result<String, OrbitError> {
+    match git_output(workspace_path, &["merge-base", head_sha, target_base_sha]) {
+        Ok(sha) if !sha.trim().is_empty() => Ok(sha.trim().to_string()),
+        _ => Ok(
+            git_output(workspace_path, &["rev-parse", &format!("{head_sha}^")])?
+                .trim()
+                .to_string(),
+        ),
+    }
+}
+
+fn conflicts_from_error(error: &str) -> Vec<String> {
+    let Some((_, paths)) = error.split_once("conflicting paths: ") else {
+        return Vec::new();
+    };
+    paths
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .split(", ")
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn blocked_pr_body(
+    task_id: &str,
+    run_id: &str,
+    failed_step_id: &str,
+    error_code: &str,
+    error_message: &str,
+    original_base_sha: &str,
+    target_base_sha: &str,
+    conflicting_paths: &[String],
+) -> String {
+    let conflicts = if conflicting_paths.is_empty() {
+        "- None reported; inspect the failed pipeline step before merging.".to_string()
+    } else {
+        conflicting_paths
+            .iter()
+            .map(|path| format!("- `{path}`"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    format!(
+        "## Manual resolution required\n\n\
+         Orbit preserved and pushed this task's pre-rebase candidate after the shipment pipeline \
+         stopped. This PR is intentionally blocked and must be reconciled manually before merge.\n\n\
+         - Task: `{task_id}`\n\
+         - Run: `{run_id}`\n\
+         - Failed step: `{failed_step_id}`\n\
+         - Error code: `{error_code}`\n\
+         - Original base: `{original_base_sha}`\n\
+         - Target base: `{target_base_sha}`\n\n\
+         ## Conflicting paths\n\n{conflicts}\n\n\
+         ## Failure\n\n```text\n{error_message}\n```"
+    )
+}

--- a/crates/orbit-engine/src/executor/automation/vcs/freshness.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/freshness.rs
@@ -140,10 +140,10 @@ fn rebase_pr_branch_inner(input: &Value, context: &HandoffContext) -> Result<Val
         &context.workspace_path,
         &["diff", "--quiet", "--diff-filter=U"],
     )? {
-        return Err(OrbitError::Execution(
-            "git_rebase: unresolved merge conflicts remain; recovery must resolve and continue the recorded rebase"
-                .to_string(),
-        ));
+        return Err(rebase_conflict_error(
+            &context.workspace_path,
+            "unresolved merge conflicts remain",
+        )?);
     }
 
     let current_sha = commit_sha(&context.workspace_path, head)?;
@@ -172,9 +172,10 @@ fn rebase_pr_branch_inner(input: &Value, context: &HandoffContext) -> Result<Val
             ));
         }
         if !git_command_success(&context.workspace_path, &["rebase", base_sha])? {
-            return Err(OrbitError::Execution(format!(
-                "git_rebase: rebase of '{head}' onto checkpoint '{base_sha}' stopped with conflicts; resolve them and continue the rebase before recovery retries this step"
-            )));
+            return Err(rebase_conflict_error(
+                &context.workspace_path,
+                &format!("rebase of '{head}' onto checkpoint '{base_sha}' stopped with conflicts"),
+            )?);
         }
         let after =
             branch_freshness_against_ref(&context.workspace_path, head, base_ref, base_sha)?;
@@ -202,6 +203,18 @@ fn rebase_pr_branch_inner(input: &Value, context: &HandoffContext) -> Result<Val
         "remote_sha_before": input_string_field(input, "remote_sha"),
         "rewritten": rewritten,
     }))
+}
+
+fn rebase_conflict_error(repo_root: &Path, context: &str) -> Result<OrbitError, OrbitError> {
+    let paths = git_output(repo_root, &["diff", "--name-only", "--diff-filter=U"])?
+        .lines()
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .collect::<Vec<_>>()
+        .join(", ");
+    Ok(OrbitError::Execution(format!(
+        "git_rebase: {context}; conflicting paths: {paths}"
+    )))
 }
 
 pub(super) fn ensure_branch_fresh_against_base(

--- a/crates/orbit-engine/src/executor/automation/vcs/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/mod.rs
@@ -1,4 +1,5 @@
 mod commit;
+mod failure;
 mod freshness;
 pub(crate) mod git;
 mod handoff;
@@ -8,6 +9,7 @@ mod push;
 mod worktree;
 
 pub(super) use commit::git_commit;
+pub(super) use failure::pr_failure_handoff;
 pub(super) use freshness::{prepare_pr_handoff, rebase_pr_branch};
 pub(super) use pr::{git_merge, pr_open, pr_promote};
 pub(super) use pull::pull_batch_changes;

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/mod.rs
@@ -14,5 +14,6 @@ mod tests;
 
 pub(in crate::executor::automation::vcs) use body::meaningful_execution_summary;
 pub(in crate::executor::automation) use merge::git_merge;
+pub(in crate::executor::automation::vcs) use open::open_or_reuse_unchecked;
 pub(in crate::executor::automation) use open::pr_open;
 pub(in crate::executor::automation) use promote::pr_promote;

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/open.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/open.rs
@@ -153,6 +153,48 @@ fn open_or_reuse_pr<H: RuntimeHost + TaskHost + ?Sized>(
     }
 }
 
+/// Create or reuse a PR for an already-pushed recovery branch without the
+/// normal freshness/success gate. The caller owns candidate validation and
+/// must block, never promote, the associated task.
+pub(in crate::executor::automation::vcs) fn open_or_reuse_unchecked<H: RuntimeHost + ?Sized>(
+    host: &H,
+    workspace_path: &std::path::Path,
+    head: &str,
+    base: &str,
+    title: &str,
+    body: &str,
+) -> Result<(String, Option<String>, bool), OrbitError> {
+    let tool_context = ToolContext {
+        cwd: Some(workspace_path.to_string_lossy().to_string()),
+        allowed_tools: vec![],
+        ..Default::default()
+    };
+    if let Some((number, url)) = find_pr_by_head(host, head, tool_context.clone())? {
+        return Ok((number, url, false));
+    }
+    let created = host.run_tool_with_context_and_role(
+        "github.pr.create",
+        json!({
+            "title": title,
+            "body": body,
+            "base": base,
+            "head": head,
+        }),
+        Role::Admin,
+        tool_context.clone(),
+    )?;
+    let url = created
+        .get("url")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            OrbitError::Execution("github.pr.create did not return a PR url".to_string())
+        })?;
+    let (number, viewed_url) = view_pr(host, url, tool_context)?;
+    Ok((number, viewed_url.or_else(|| Some(url.to_string())), true))
+}
+
 fn invalid_prepare(error: OrbitError) -> (FailedHandoffPhase, OrbitError) {
     (FailedHandoffPhase::PrLookup, error)
 }

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/handoff.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/handoff.rs
@@ -7,6 +7,7 @@ use super::super::open::pr_open;
 use super::super::promote::pr_promote;
 use super::test_support::*;
 use crate::context::TaskReadHost;
+use crate::executor::automation::vcs::failure::pr_failure_handoff;
 use crate::executor::automation::vcs::freshness::{prepare_pr_handoff, rebase_pr_branch};
 use crate::executor::automation::vcs::push::push_batch_changes;
 use orbit_common::types::TaskStatus;
@@ -197,6 +198,205 @@ fn recovered_rebase_continues_remaining_handoff_phases_without_replay() {
     let task = host.get_task(task_id).expect("task");
     assert_eq!(task.status, TaskStatus::Review);
     assert_eq!(task.github_pr_number(), Some("42"));
+}
+
+#[test]
+fn base_advance_with_mergeable_changes_rebases_cleanly_and_continues() {
+    let workspace = pr_workspace();
+    git(&workspace.repo, &["checkout", "agent-main"]);
+    fs::write(workspace.repo.join("BASE_ADVANCE.md"), "new base\n").expect("write base advance");
+    git(&workspace.repo, &["add", "BASE_ADVANCE.md"]);
+    git(&workspace.repo, &["commit", "-m", "advance base"]);
+    git(&workspace.repo, &["checkout", "orbit/test-batch"]);
+    let task_id = "ORB-CLEAN-REBASE";
+    let host = PrOpenTestHost::new(
+        vec![batch_task(
+            task_id,
+            "Clean base synchronization",
+            "Outcome: success\nChanges:\n- Candidate remains mergeable.",
+        )],
+        workspace.repo.clone(),
+    );
+    let input = json!({
+        "workspace_path": workspace.repo,
+        "job_run_id": "batch-1",
+        "completed_task_ids": [task_id],
+        "base": "agent-main",
+        "base_sync": "local",
+    });
+
+    let prepared = prepare_pr_handoff(&host, &input).expect("detect advanced base");
+    assert_eq!(prepared["decision"], json!("rebase_required"));
+    let synced =
+        rebase_pr_branch(&host, &rebase_input(&input, &prepared)).expect("clean rebase succeeds");
+
+    assert_eq!(synced["decision"], json!("performed"));
+    assert_eq!(synced["rewritten"], json!(true));
+    assert!(
+        workspace.repo.join("BASE_ADVANCE.md").exists(),
+        "rebased candidate contains the new base commit"
+    );
+}
+
+#[test]
+fn conflicting_rebase_publishes_clean_pre_rebase_branch_and_blocks_task() {
+    let workspace = rebase_conflict_pr_workspace();
+    let task_id = "ORB-CONFLICT-HANDOFF";
+    let host = PrOpenTestHost::new(
+        vec![batch_task(
+            task_id,
+            "Preserve conflicting candidate",
+            "Outcome: success\nChanges:\n- Candidate is complete.",
+        )],
+        workspace.repo.clone(),
+    );
+    let common = json!({
+        "workspace_path": workspace.repo,
+        "job_run_id": "batch-1",
+        "completed_task_ids": [task_id],
+        "base": "agent-main",
+        "base_sync": "local",
+    });
+    let prepared = prepare_pr_handoff(&host, &common).expect("prepare conflict checkpoint");
+    let pre_rebase_sha = git(&workspace.repo, &["rev-parse", "HEAD"]);
+    let error = rebase_pr_branch(&host, &rebase_input(&common, &prepared))
+        .expect_err("rebase must stop on the fixture conflict");
+
+    let recovered = pr_failure_handoff(
+        &host,
+        &json!({
+            "failed_step_id": "sync_base",
+            "activity_name": "git_rebase",
+            "error_code": "pipeline_step_failed",
+            "error_message": error.to_string(),
+            "run_id": "batch-1",
+            "job_input": {
+                "task_ids": [task_id],
+                "base_branch": "agent-main",
+                "base_sync": "local",
+            },
+            "pipeline": {
+                "worktree": {
+                    "workspace_path": workspace.repo,
+                    "job_run_id": "batch-1",
+                    "base_ref": "agent-main",
+                },
+                "prepare_branch": prepared,
+            },
+        }),
+    )
+    .expect("terminal handoff publishes the pre-rebase candidate");
+
+    assert_eq!(recovered["decision"], json!("blocked_conflict_pr"));
+    assert_eq!(
+        recovered["conflicting_paths"],
+        json!(["src/lib.rs"]),
+        "diagnostics name only the run's true conflict"
+    );
+    assert_eq!(
+        recovered["target_base_sha"], prepared["base_sha"],
+        "the blocked handoff names the exact prepared base that rejected the rebase"
+    );
+    assert_eq!(git(&workspace.repo, &["rev-parse", "HEAD"]), pre_rebase_sha);
+    assert!(
+        git(&workspace.repo, &["status", "--porcelain"]).is_empty(),
+        "terminal handoff must not leave uncommitted or conflict-marked work"
+    );
+    let body = host.pr_create_body();
+    for expected in [
+        "Manual resolution required",
+        "Original base:",
+        "Target base:",
+        "`src/lib.rs`",
+    ] {
+        assert!(
+            body.contains(expected),
+            "blocked PR body missing {expected:?}: {body}"
+        );
+    }
+    let task = host.get_task(task_id).expect("blocked task");
+    assert_eq!(task.status, TaskStatus::Blocked);
+    assert_eq!(task.github_pr_number(), Some("42"));
+    let update = host
+        .automation_updates()
+        .into_iter()
+        .find(|(_, update)| update.status == Some(TaskStatus::Blocked))
+        .expect("blocked failure-handoff update");
+    assert_eq!(
+        update.1.status_event.as_deref(),
+        Some("pr_conflict_blocked")
+    );
+}
+
+#[test]
+fn non_fast_forward_drift_handoff_commits_dirty_work_and_raises_pr() {
+    let workspace = no_diff_pr_workspace();
+    fs::create_dir_all(workspace.repo.join("src")).expect("create source dir");
+    fs::write(
+        workspace.repo.join("src/recovered.rs"),
+        "pub fn recovered() {}\n",
+    )
+    .expect("write uncommitted candidate");
+    let task_id = "ORB-DIRTY-HANDOFF";
+    let host = PrOpenTestHost::new(
+        vec![batch_task(
+            task_id,
+            "Preserve dirty candidate",
+            "Outcome: failed\nChanges:\n- Agent stopped after writing code.",
+        )],
+        workspace.repo.clone(),
+    );
+
+    let recovered = pr_failure_handoff(
+        &host,
+        &json!({
+            "failed_step_id": "implement_bundle",
+            "activity_name": "agent_implement",
+            "error_code": "primary_checkout_drift",
+            "error_message": "registered primary moved non-fast-forward after work was persisted",
+            "run_id": "batch-1",
+            "job_input": {
+                "task_ids": [task_id],
+                "base_branch": "agent-main",
+                "base_sync": "local",
+            },
+            "pipeline": {
+                "worktree": {
+                    "workspace_path": workspace.repo,
+                    "job_run_id": "batch-1",
+                    "base_ref": "agent-main",
+                },
+            },
+        }),
+    )
+    .expect("dirty work is committed and published");
+
+    assert_eq!(recovered["decision"], json!("blocked_failure_pr"));
+    assert_eq!(recovered["committed_files"], json!(["src/recovered.rs"]));
+    assert!(
+        git(&workspace.repo, &["status", "--porcelain"]).is_empty(),
+        "failure handoff must leave a clean worktree"
+    );
+    assert_eq!(
+        git(&workspace.repo, &["log", "-1", "--format=%s"]),
+        "chore: Preserve dirty candidate [ORB-DIRTY-HANDOFF]"
+    );
+    assert!(
+        host.tool_calls().iter().any(|call| call.name == "git.push"),
+        "the recovery branch is pushed before PR creation"
+    );
+    assert!(
+        host.pr_create_body().contains("primary_checkout_drift"),
+        "the blocked PR preserves the typed primary-drift classification"
+    );
+    let calls = host.tool_calls();
+    assert!(
+        calls.iter().position(|call| call.name == "git.push")
+            < calls
+                .iter()
+                .position(|call| call.name == "github.pr.create"),
+        "push precedes PR creation"
+    );
 }
 
 /// ORB-10313: every resumable PR checkpoint reloads durable state through

--- a/crates/orbit-engine/src/executor/automation/vcs/push.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/push.rs
@@ -37,7 +37,7 @@ pub(in crate::executor::automation) fn push_batch_changes<H: RuntimeHost + TaskH
     }
 }
 
-fn push_batch_changes_inner<H: RuntimeHost + ?Sized>(
+pub(super) fn push_batch_changes_inner<H: RuntimeHost + ?Sized>(
     host: &H,
     input: &Value,
     workspace_path: &Path,

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Design"
 type: design
 title: "Activity / Job — Design"
 owner: codex
-last_updated: 2026-07-20
+last_updated: 2026-07-25
 status: Draft
 feature: activity-job
 doc_role: design
@@ -142,6 +142,10 @@ After [ORB-10306], retry classification and recovery eligibility are separate de
 After [ORB-10232], `task_pr_pipeline` exposes the PR handoff as ordered durable checkpoints: `commit` (`git_commit`), `prepare_branch` (`pr_prepare`), `sync_base` (`git_rebase`), `push` (`git_push`), `pr_open`, and `promote_tasks` (`pr_promote`). The no-diff-expected path skips the remote phases and uses its own promotion checkpoint. Each performed activity returns a `phase` and `decision`, so persisted step output distinguishes work performed on the first attempt from a current/skipped phase or a recovered/reused phase; job recovery audit records the recovery decision around the one retried step. `pr_open` no longer commits, rebases, pushes, or mutates task lifecycle state.
 
 `pr_prepare` is the pre-rewrite authority boundary. It records the exact head SHA, base SHA, and observed remote task-branch SHA before `git_rebase` may rewrite history. `git_push` classifies the remote ref as missing, current, fast-forwardable, remote-ahead, or diverged. Missing and fast-forwardable refs use normal push; current refs are reused; remote-ahead refs fail closed. Divergence may use force-with-lease only when the persisted preparation SHA still exactly matches the observed remote SHA and `git_rebase` reports a performed or recovery-reused rewrite. The underlying tool emits a branch-scoped `--force-with-lease=refs/heads/<branch>:<expected-sha>`, so a concurrent remote update rejects the push instead of overwriting it. This is [ADR-0225].
+
+After [ORB-10363], `JobV2.failure_activity` is a terminal, best-effort hook distinct from retry recovery. It receives the merged job input, all completed pipeline checkpoints, the failing step/action, and the structured error; it runs once and never replaces the original failure. `task_pr_pipeline` binds this hook to `pr_failure_handoff` ([ADR-0246]). That deterministic action aborts an active conflicting rebase back to the prepared branch, commits any remaining dirty candidate without passing through the normal success-only promotion gate, performs the existing non-overwriting push classification, and opens or reuses a blocked PR. A conflict PR body names the original and target base SHAs plus the conflicting paths, and the task moves to `blocked` with `pr_conflict_blocked` rather than `review`.
+
+The linked-worktree boundary guard now treats a clean same-branch primary fast-forward as concurrent base movement, not provider escape. The assigned checkout retains its own HEAD, so the later `pr_prepare`/`git_rebase` checkpoints reconcile that movement. Primary resets, force-moves, branch switches, or working-content mutations surface as `primary_checkout_drift`; history or branch movement inside the assigned worktree surfaces as `worktree_content_conflict`. Conflict diagnostics report `run_changed_paths`, `primary_changed_paths`, and their `conflicting_paths` separately instead of presenting the primary's entire moved set as the task's conflict.
 
 PR creation is restartable within its own checkpoint. `pr_open` first looks up the open PR by head branch; only the explicit no-PR result permits `github.pr.create`. If creation succeeds but PR view or local step-output persistence fails, the retry finds that same external PR and returns it as reused. `pr_promote` then idempotently applies the GitHub PR external ref and the per-task implementation attribution before moving tasks to `review`.
 

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Decisions"
 type: design
 title: "Activity / Job — Decisions"
 owner: codex
-last_updated: 2026-07-20
+last_updated: 2026-07-25
 status: Draft
 feature: activity-job
 doc_role: decisions
@@ -662,6 +662,22 @@ Rejected alternatives: reconciling by parent linkage (no parent run id is persis
 
 ---
 
+## ADR-0246 — Terminal PR shipment uses a job-level failure handoff
+
+**Status:** Accepted · 2026-07 · [ORB-10363]
+
+**Context.** A task shipment can fail after an agent has produced coherent work but before the normal commit, rebase, push, and PR checkpoints finish. The real alternatives are to overload per-step recovery so it replays or impersonates later checkpoints, or give the workflow one explicit terminal failure hook that preserves the original failure while publishing any recoverable candidate.
+
+**Decision.** Add an optional job-level failure activity that runs once after a terminal step failure with the job input, completed pipeline checkpoints, failing step, and structured error. `task_pr_pipeline` binds it to a deterministic PR failure handoff which restores the pre-rebase candidate, commits dirty work, pushes without rewriting unknown remote history, opens or reuses a blocked/manual-resolution PR, and blocks the task while the original run still terminalizes as failed.
+
+**Consequences.**
+- Normal success and retry checkpoints remain unchanged; the failure handoff is an explicit, auditable last-chance side effect.
+- A conflict-blocked run is distinguishable through its task status event, PR body, and failure-activity audit even though the original step failure remains authoritative.
+- Cost: JobV2 gains another lifecycle hook and task shipment maintains a dedicated deterministic recovery action with conservative Git/remote rules.
+- Cost: External push or PR service outages can still prevent publication, but dirty work is committed locally before those fallible operations so terminal runs do not strand uncommitted changes.
+
+---
+
 ## Task References
 
 - **[T20260418-2018]** — Add `JobV2` DAG constructs (`parallel`, `fan_out`, `loop`, `retry`, `when`).
@@ -734,6 +750,7 @@ Rejected alternatives: reconciling by parent linkage (no parent run id is persis
 - **[ORB-10232]** — Model recoverable PR handoff as checkpointed job activities with exact-SHA force-push provenance.
 - **[ORB-10266]** — Materialize independent review as a durable exact-head child Run or fail before implementation.
 - **[ORB-10313]** — Fail delivery before Git mutation when the durable execution outcome is not `Outcome: success`.
+- **[ORB-10363]** — Rebase task candidates after concurrent base advances and publish blocked PRs instead of stranding failed work.
 - **[ORB-10332]** — Remove the unused Groundhog activity kind and the epic/parallel pipeline layer (`task_epic_pipeline`, `epic_orchestrator`, `pipeline_wait`, legacy parallel-batch executor).
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## What this is

**A hand-dispatched rescue of finished work stranded by a `worktree_integrity_ambiguous` abort.**

The original job run (`jrun-20260725-0220-3`, task ORB-10363) completed its implementation and
then aborted at the very last step on the linked-worktree integrity guard, because the primary
checkout's HEAD advanced (`dfcd3576` → `66f848a3`) mid-run. Triage confirmed those changed paths
were entirely the unrelated ORB-10346 / ORB-10344 merges — they do not intersect this run's diff.
The abort left 35 modified/untracked paths uncommitted in the worktree: nothing committed,
nothing pushed, no PR. This PR recovers that work verbatim.

**The irony worth stating: this PR is the fix for the very guard that blocked it** — friction
F2026-07-101. A fresh pipeline run would have discarded the finished work and very likely aborted
identically, which is why it was recovered by hand instead of re-run.

## Validation

Already validated in the original run, before the abort (the abort was in the shipment tail, not
in the build or tests):

- `make ci-fast` — passed
- `cargo test -p orbit-engine --lib` — **288 passed**
- `cargo test -p orbit-common --lib` — **256 passed**

Not re-run in the rescue; CI on this PR is the independent check.

## Rebase

**Succeeded cleanly.** The branch was rebased onto `origin/agent-main` (`ce8e7053`) with no
conflicts; the commit's tree and its 34-file diff are unchanged from the recovered state.

## What's in the change

- **Narrowed linked-worktree integrity guard** (`crates/orbit-engine/src/activity_job/workspace.rs`) —
  accept a concurrent primary advance when it is a clean same-branch fast-forward with unchanged
  dirty/path/content state; the shipment rebase checkpoint owns base reconciliation. Real drift
  stays fail-closed and typed: `primary_checkout_drift` (primary reset / branch switch / content
  mutation) and `worktree_content_conflict` (history or branch movement in the assigned worktree).
  Run-changed, primary-changed, and intersecting paths are now reported separately.
- **JobV2 terminal-failure activity** — optional job-level `failure_activity` hook invoked once
  after a terminal step failure. Unlike `recovery_activity` it never retries or replaces the failed
  step; the original failure remains authoritative.
- **`pr_failure_handoff` deterministic action** — bound from `task_pr_pipeline`: restores the
  pre-rebase candidate, commits dirty work *before* any fallible remote call, pushes without
  rewriting unknown remote history, opens or reuses a blocked/manual-resolution PR, and blocks the
  task while the run still terminalizes as failed. `git_rebase` conflict errors now name the
  conflicting paths.

## Two things that need your disposition

1. **ADR-0246 is included in this diff** (`.orbit/adrs/accepted/ADR-0246/`) and **needs review** —
   it records the terminal-failure-handoff decision. It was deliberately left in the PR rather than
   pulled out, because an ADR belongs where it can be reviewed.

2. **Two executor-authored learning artifacts were withheld and quarantined**, per the standing
   policy that executors file frictions only and learning artifacts are human/orchestrator-authored:
   - new `.orbit/learnings/L-0110/learning.yaml` (blob `2eb32751`)
   - the edit marking `.orbit/learnings/L-0095/learning.yaml` superseded (`ab5e18e6` → `02bf450b`)

   Both are preserved verbatim (the L-0095 edit as a patch) under
   `~/.orbit/quarantine/2026-07-25-ORB-10363-executor-authored-learning/`, with a README. No learning
   was created, modified, or deleted in any Orbit store. `L-0095` was restored to its committed
   version with `git checkout --`. Note: the code comment in `workspace.rs` still cites `L-0110`
   by id — left as-is rather than edited, since you may still author that learning.

## Task status

**ORB-10363 remains `blocked`** and was deliberately not advanced — it is awaiting merge of this PR.
