### PR TITLE
Derive dashboard ADR write attribution from the request, not server env [ORB-10352]

### DIFF
--- a/crates/orbit-dashboard/src/api/adrs.rs
+++ b/crates/orbit-dashboard/src/api/adrs.rs
@@ -11,6 +11,7 @@ use serde_json::{Map, Value, json};
 use super::{bad_request, bounded_limit, map_runtime_error, non_empty_string};
 
 const ADRS_DEFAULT_LIMIT: usize = 100;
+const HUMAN_ACTOR_LABEL: &str = "human";
 
 #[derive(Deserialize, Default)]
 pub(super) struct AdrsQuery {
@@ -32,8 +33,8 @@ pub(super) struct AdrsQuery {
 /// empty. Status is not a field — the tool always creates a Proposed ADR.
 /// `model` carries caller-supplied attribution (the canonical agent family,
 /// e.g. `codex`/`claude`, or `human`) and is forwarded to the tool host
-/// unchanged; when absent, the tool host attributes the write to the human
-/// actor label rather than defaulting to a model constant. `orbit.adr.add`
+/// unchanged; when absent, the HTTP route supplies the human actor label so
+/// the server process's ambient identity cannot become the actor. `orbit.adr.add`
 /// rejects a separate `agent` field (attribution was consolidated to
 /// `model`-only), so this body does not accept one.
 #[derive(Deserialize, Default)]
@@ -185,6 +186,7 @@ pub(super) async fn create_adr_action(
     let mut input = json!({
         "title": title,
         "body": adr_body,
+        "model": model_attribution(body.model.as_deref()),
         "related_features": body.related_features,
         "related_tasks": body.related_tasks,
         "tags": body.tags,
@@ -195,12 +197,6 @@ pub(super) async fn create_adr_action(
     {
         object.insert("owner".to_string(), Value::String(owner));
     }
-    if let Some(model) = body.model.as_deref().and_then(non_empty_string)
-        && let Some(object) = input.as_object_mut()
-    {
-        object.insert("model".to_string(), Value::String(model));
-    }
-
     match runtime.run_tool("orbit.adr.add", input) {
         Ok(adr) => match adr.get("id").and_then(Value::as_str) {
             Some(id) => match adr_show(&runtime, id) {
@@ -221,6 +217,7 @@ pub(super) async fn accept_adr_action(Ws(runtime): Ws, Path(id): Path<String>) -
         json!({
             "id": id.clone(),
             "status": "accepted",
+            "model": HUMAN_ACTOR_LABEL,
         }),
     );
     match result {
@@ -253,6 +250,7 @@ pub(super) async fn update_adr_action(
         legacy_ids,
         model,
     } = body;
+    let model = model.as_deref().and_then(non_empty_string);
 
     let mut input = Map::new();
     insert_optional_string(&mut input, "title", title);
@@ -265,11 +263,14 @@ pub(super) async fn update_adr_action(
     insert_optional_list(&mut input, "paths", paths);
     insert_optional_list(&mut input, "supersedes", supersedes);
     insert_optional_list(&mut input, "legacy_ids", legacy_ids);
-    insert_optional_string(&mut input, "model", model);
-    if input.is_empty() {
+    if input.is_empty() && model.is_none() {
         return bad_request("request body must include at least one updatable field".to_string());
     }
     input.insert("id".to_string(), Value::String(id.clone()));
+    input.insert(
+        "model".to_string(),
+        Value::String(model_attribution(model.as_deref())),
+    );
 
     match runtime.run_tool("orbit.adr.update", Value::Object(input)) {
         Ok(_) => match adr_show(&runtime, &id) {
@@ -293,15 +294,11 @@ pub(super) async fn supersede_adr_action(
     };
     let _reason = body.reason.as_deref().and_then(non_empty_string);
 
-    let mut input = json!({
+    let input = json!({
         "old_id": id.clone(),
         "new_id": by.clone(),
+        "model": model_attribution(body.model.as_deref()),
     });
-    if let Some(object) = input.as_object_mut()
-        && let Some(model) = body.model.as_deref().and_then(non_empty_string)
-    {
-        object.insert("model".to_string(), Value::String(model));
-    }
 
     let result = runtime.run_tool("orbit.adr.supersede", input);
 
@@ -339,6 +336,12 @@ fn insert_optional_list(input: &mut Map<String, Value>, key: &str, value: Option
     if let Some(value) = value {
         input.insert(key.to_string(), json!(value));
     }
+}
+
+fn model_attribution(model: Option<&str>) -> String {
+    model
+        .and_then(non_empty_string)
+        .unwrap_or_else(|| HUMAN_ACTOR_LABEL.to_string())
 }
 
 fn adr_list(runtime: &OrbitRuntime, input: Map<String, Value>) -> Result<Vec<Value>, OrbitError> {

--- a/crates/orbit-dashboard/src/api/tests/adrs.rs
+++ b/crates/orbit-dashboard/src/api/tests/adrs.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode, header};
 use orbit_common::test_fixtures::TEST_CODEX_MODEL;
-use orbit_core::OrbitRuntime;
+use orbit_core::{ActorIdentity, OrbitRuntime};
 use serde_json::{Value, json};
 use tower::ServiceExt;
 
@@ -28,6 +28,19 @@ fn runtime_without_agent_identity() -> OrbitRuntime {
     let _env =
         orbit_common::test_env::unset(orbit_common::test_env::AGENT_IDENTITY_ENV.iter().copied());
     OrbitRuntime::in_memory().expect("build runtime")
+}
+
+/// A runtime carrying an explicit ambient *agent* actor — what a dashboard
+/// server process looks like when it runs inside a managed Orbit run.
+///
+/// Built on [`runtime_without_agent_identity`] so the injected actor is the
+/// only agent identity in play however the suite was launched (ORB-10350),
+/// then given one deterministically (ORB-10352). The no-attribution
+/// assertions below are strongest against this runtime: the ADR HTTP routes
+/// now derive attribution from the request, so an identity-less write must
+/// still record the human actor even though the runtime itself is an agent.
+fn runtime_with_ambient_agent_identity() -> OrbitRuntime {
+    runtime_without_agent_identity().with_actor(ActorIdentity::agent("ambient-server-model"))
 }
 
 fn seed_adr(runtime: &OrbitRuntime, title: &str, related_tasks: Vec<&str>) -> Value {
@@ -201,7 +214,7 @@ async fn create_persists_proposed_adr_and_reads_back() {
 
 #[tokio::test]
 async fn create_without_attribution_defaults_owner_to_human() {
-    let runtime = runtime_without_agent_identity();
+    let runtime = runtime_with_ambient_agent_identity();
 
     let response = request_create(
         runtime,
@@ -662,7 +675,7 @@ fn transition_audit_actor(runtime: &OrbitRuntime, adr_id: &str) -> String {
 
 #[tokio::test]
 async fn update_without_attribution_records_human_actor_in_audit() {
-    let runtime = runtime_without_agent_identity();
+    let runtime = runtime_with_ambient_agent_identity();
     let adr = seed_adr(&runtime, "No attribution transition", vec!["ORB-00063"]);
 
     let response = request_update(


### PR DESCRIPTION
## Summary

Identity-less dashboard ADR HTTP writes were attributing to the server process's ambient agent
identity instead of `human`. `ActorContext::from_env()` reads `ORBIT_AGENT_MODEL`, so any
orbit-managed run environment leaked its model into writes that carried no attribution of their
own — observed as the two `api::tests::adrs` failures inside managed envs (they pass in GitHub CI,
where the var is unset).

- `crates/orbit-dashboard/src/api/adrs.rs` — every ADR HTTP mutation (create, accept, update,
  supersede) now forwards the request-supplied non-empty `model`, or an explicit `human` actor
  label when absent, via a new `model_attribution` helper. The tool host can no longer fall back
  to process identity on these routes. `update` also no longer rejects a body whose only field is
  `model`.
- `crates/orbit-dashboard/src/api/tests/adrs.rs` — the two no-attribution tests build the runtime
  with `.with_actor(ActorIdentity::agent("ambient-server-model"))`, so they fail if the ambient
  identity leaks into create ownership or the update audit actor. No process-env mutation, no lock
  held across await (workspace `await_holding_lock=deny`).

CLI/tool-host env-based attribution is untouched.

## ⚠️ This is a rescue PR — please read before merging

The implementation is the original work of job run `jrun-20260725-0217-3` (crew `sol`), recovered
**verbatim**. Nothing was re-implemented, reviewed, or modified by the rescuing agent.

That run's `implement_one` **succeeded** — `cargo test -p orbit-dashboard` passed on both targeted
tests, `make ci-fast` passed, `git diff --check` clean — and the pipeline then died downstream at
`persist invocation trace: store error: table invocations has no column named
cache_create_1h_tokens` (the v10-schema defect, since fixed by ORB-10367). It never reached commit,
push, or PR, so the work sat uncommitted in its worktree.

**The rebase onto `origin/agent-main` conflicts and was deliberately aborted, not resolved.**
This branch is based on `dfcd3576`, which is 16 commits behind `origin/agent-main` (`bb94f032`).
The conflict is in `crates/orbit-dashboard/src/api/tests/adrs.rs`, against **`1944458e`
(`fix(test): Isolate tests from ambient env and umask` [ORB-10350])** — which touched the very same
no-attribution tests, from the same angle. That overlap wants a human judgement call, not an
automated merge: **ORB-10350 and this change may be partly redundant.**

Consequences:
- CI here runs against a 16-commit-stale base.
- The branch is **not mergeable as-is** and needs a conflict resolution before merge.
- ORB-10352 stays in `backlog`; its status was not changed.

Pre-existing unrelated CI red on `agent-main`: `cargo deny` fails on a yanked `spin` crate.

Task: ORB-10352
Recovered from: `jrun-20260725-0217-3`
