### PR TITLE
Wire the Claude CLI ephemeral_1h/5m cache-write split through usage ingest [ORB-10353]

### DIFF
--- a/crates/orbit-agent/src/types/response/usage.rs
+++ b/crates/orbit-agent/src/types/response/usage.rs
@@ -147,17 +147,35 @@ fn usage_from_map(map: &JsonMap, key_mode: UsageKeyMode) -> Option<TokenUsage> {
         }
     };
 
-    input.or(cache_read).or(cache_create).or(output)?;
+    let cache_creation_split = match key_mode {
+        UsageKeyMode::Standard => cache_creation_split(map),
+        UsageKeyMode::TokenBlock => None,
+    };
+
+    if input.is_none()
+        && cache_read.is_none()
+        && cache_create.is_none()
+        && cache_creation_split.is_none()
+        && output.is_none()
+    {
+        return None;
+    }
+
+    let (cache_create, cache_create_1h) = match cache_creation_split {
+        // Claude CLI reports the aggregate cache-creation count as well as a
+        // TTL split. Prefer the split whenever it is present so 1h writes can
+        // be priced at their premium rate rather than being folded into 5m.
+        Some((five_minutes, one_hour)) => (five_minutes, one_hour),
+        // Older Claude CLI output and providers without a TTL split retain the
+        // historical aggregate-as-5m interpretation.
+        None => (cache_create.unwrap_or(0), 0),
+    };
 
     Some(TokenUsage {
         input: input.unwrap_or(0),
         cache_read: cache_read.unwrap_or(0),
-        cache_create: cache_create.unwrap_or(0),
-        // The generic usage flattener reads a single cache-creation counter; the
-        // Anthropic ephemeral_1h/ephemeral_5m split isn't parsed here yet, so
-        // cache_create_1h stays zero and all cache-creation tokens price at the
-        // standard (5m) rate downstream (ORB-10338 follow-up).
-        cache_create_1h: 0,
+        cache_create,
+        cache_create_1h,
         output: output.unwrap_or(0),
     })
 }
@@ -212,6 +230,10 @@ const STANDARD_CACHE_CREATE_KEYS: &[&str] = &[
     "cacheCreateTokens",
 ];
 
+const CACHE_CREATION_KEY: &str = "cache_creation";
+const EPHEMERAL_5M_INPUT_TOKENS_KEY: &str = "ephemeral_5m_input_tokens";
+const EPHEMERAL_1H_INPUT_TOKENS_KEY: &str = "ephemeral_1h_input_tokens";
+
 const STANDARD_OUTPUT_KEYS: &[&str] = &[
     "output_tokens",
     "outputTokens",
@@ -236,6 +258,23 @@ const TOKEN_BLOCK_THOUGHT_KEYS: &[&str] =
     &["thoughts", "thoughtsTokenCount", "thoughts_token_count"];
 
 const TOKEN_BLOCK_TOOL_KEYS: &[&str] = &["tool", "toolTokenCount", "tool_token_count"];
+
+/// Returns Claude CLI's cache-creation TTL split when either split field is
+/// present. A missing counterpart is zero: the provider has explicitly chosen
+/// the split format, so the aggregate is not a reliable 5m-only fallback.
+fn cache_creation_split(map: &JsonMap) -> Option<(u64, u64)> {
+    let cache_creation = map.get(CACHE_CREATION_KEY)?.as_object()?;
+    let five_minutes = cache_creation
+        .get(EPHEMERAL_5M_INPUT_TOKENS_KEY)
+        .and_then(value_as_u64);
+    let one_hour = cache_creation
+        .get(EPHEMERAL_1H_INPUT_TOKENS_KEY)
+        .and_then(value_as_u64);
+
+    five_minutes
+        .or(one_hour)
+        .map(|_| (five_minutes.unwrap_or(0), one_hour.unwrap_or(0)))
+}
 
 fn first_u64(map: &JsonMap, keys: &[&str]) -> Option<u64> {
     keys.iter().find_map(|key| value_as_u64(map.get(*key)?))

--- a/crates/orbit-agent/src/types/tests/response.rs
+++ b/crates/orbit-agent/src/types/tests/response.rs
@@ -172,6 +172,50 @@ mod sum {
     use super::super::super::response::usage::*;
 
     #[test]
+    fn claude_cli_cache_creation_ttl_split_maps_each_ttl() {
+        let documents = vec![json!({
+            "usage": {
+                "input_tokens": 36,
+                "output_tokens": 8_265,
+                "cache_read_input_tokens": 858_526,
+                "cache_creation_input_tokens": 37_846,
+                "cache_creation": {
+                    "ephemeral_5m_input_tokens": 51,
+                    "ephemeral_1h_input_tokens": 37_795,
+                }
+            }
+        })];
+
+        assert_eq!(
+            sum_usage(&documents),
+            TokenUsage {
+                input: 36,
+                cache_read: 858_526,
+                cache_create: 51,
+                cache_create_1h: 37_795,
+                output: 8_265,
+            }
+        );
+    }
+
+    #[test]
+    fn cache_creation_without_a_ttl_split_remains_five_minute_usage() {
+        let documents = vec![json!({
+            "usage": {
+                "cache_creation_input_tokens": 100,
+            }
+        })];
+
+        assert_eq!(
+            sum_usage(&documents),
+            TokenUsage {
+                cache_create: 100,
+                ..TokenUsage::default()
+            }
+        );
+    }
+
+    #[test]
     fn gemini_cli_model_token_blocks_are_summed_once_per_model() {
         let documents = vec![json!({
             "stats": {

--- a/crates/orbit-common/src/types/invocation.rs
+++ b/crates/orbit-common/src/types/invocation.rs
@@ -16,8 +16,7 @@ pub struct TokenUsage {
     /// (Anthropic `ephemeral_1h_input_tokens`). Kept separate from
     /// [`Self::cache_create`] so the price table can charge the 1h rate (2x
     /// input) distinctly from the 5m rate (1.25x input). Zero when the provider
-    /// doesn't split TTLs, or until the ingest path learns to populate it
-    /// (ORB-10338 follow-up).
+    /// doesn't split TTLs.
     #[serde(default)]
     pub cache_create_1h: u64,
     #[serde(default)]

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/envelope.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/envelope.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use orbit_common::types::TokenUsage;
+use orbit_store::{InvocationInsertParams, InvocationQuery, Store};
 use serde_json::Value;
 
 use super::super::envelope::{
@@ -141,6 +142,61 @@ fn parse_cli_invocation_trace_extracts_gemini_cli_stats_tokens() {
             cache_create_1h: 0,
             output: 4,
         })
+    );
+}
+
+#[test]
+fn claude_cache_creation_ttl_split_ingests_at_the_one_hour_rate() {
+    // Ground truth from worker run 91d7ef01. This exercises the production
+    // Claude CLI wrapper parser and then persists its trace through the
+    // invocation store, rather than constructing a pre-split TokenUsage.
+    let stdout = serde_json::json!({
+        "type": "result",
+        "subtype": "success",
+        "result": "{\"schemaVersion\":1,\"status\":\"success\",\"result\":{}}",
+        "usage": {
+            "input_tokens": 36,
+            "output_tokens": 8_265,
+            "cache_read_input_tokens": 858_526,
+            "cache_creation_input_tokens": 37_795,
+            "cache_creation": {
+                "ephemeral_5m_input_tokens": 0,
+                "ephemeral_1h_input_tokens": 37_795,
+            }
+        }
+    })
+    .to_string();
+    let trace = parse_cli_invocation_trace(stdout.as_bytes(), b"", Some(0), 99, true)
+        .expect("Claude CLI envelope parses");
+    let store = Store::open_in_memory().expect("open store");
+
+    store
+        .insert_invocation_trace_record(&InvocationInsertParams {
+            job_run_id: "jrun-91d7ef01".to_string(),
+            activity_id: "implement_one".to_string(),
+            agent: "claude".to_string(),
+            model: Some("claude-opus-4-8[1m]".to_string()),
+            slot: None,
+            task_ids: vec!["ORB-10353".to_string()],
+            trace,
+        })
+        .expect("persist parsed trace");
+
+    let records = store
+        .list_invocation_records(&InvocationQuery {
+            job_run_id: Some("jrun-91d7ef01".to_string()),
+            limit: 1,
+            ..InvocationQuery::default()
+        })
+        .expect("read persisted trace");
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].cache_create_tokens, 0);
+    assert_eq!(records[0].cache_create_1h_tokens, 37_795);
+    let derived = records[0].derived_cost_usd.expect("priced Claude model");
+    assert!(
+        (derived - 1.014_018).abs() < 1e-6,
+        "derived cost was {derived}, expected ~1.014018"
     );
 }
 


### PR DESCRIPTION
## What

`usage_from_map` (orbit-agent) read a single aggregate cache-creation counter and hardcoded `cache_create_1h: 0`, so every Anthropic 1h cache write was priced at the 5m rate (1.25x input) instead of the 1h rate (2x input).

- Parse Claude CLI's `usage.cache_creation` object (`ephemeral_5m_input_tokens` / `ephemeral_1h_input_tokens`) into `TokenUsage::cache_create` / `cache_create_1h`. The split wins whenever either field is present; a missing counterpart is treated as zero rather than falling back to the aggregate, because the provider has explicitly chosen the split format.
- Providers with no TTL split (and the `TokenBlock` key mode) keep the historical aggregate-as-5m interpretation, so Gemini/Grok ingest is unchanged.
- Drop the now-stale ORB-10338-follow-up caveat from the `cache_create_1h` doc comment on orbit-common's `TokenUsage`.

## Tests

- orbit-agent unit coverage for both split and no-split usage maps.
- An orbit-engine test that runs real Claude CLI stdout (ground truth from worker run `91d7ef01`) through `parse_cli_invocation_trace` and persists it through the invocation store, asserting `cache_create_1h_tokens` and the derived 1h-rate cost — rather than constructing a pre-split `TokenUsage`.

Reported green by the implementing run: `cargo test -p orbit-agent --lib`, `cargo test -p orbit-engine --lib activity_job::cli_runner::tests::envelope`, `cargo test -p orbit-common --lib pricing`, `cargo test -p orbit-store --lib invocation`, and `make ci-fast`.

## Provenance — this is a rescue PR

This work was implemented by job run `jrun-20260725-0217-6` (crew terra / gpt-5.6-terra), which completed the implementation successfully and then died **before** commit/push/PR at:

```
persist invocation trace: store error: table invocations has no column named cache_create_1h_tokens
```

That is the v10-schema defect (since fixed and redeployed), not a defect in this change. The work sat uncommitted in the run's worktree with no PR; this PR recovers it verbatim.

Verification performed during recovery:

- The diff touches **no** migration or schema file, so there is no collision with the `cache_create_1h_tokens` migration that shipped since. (`crates/orbit-store/src/sqlite/migration/mod.rs` already carries the column at the merge base.)
- Nothing under `.orbit/learnings/` and no ADR appears in the diff — nothing was quarantined.
- Rebased cleanly onto `origin/agent-main` (`bb94f032`); diffstat unchanged by the rebase.

`agent-main` currently has a pre-existing, unrelated CI red: `cargo deny` fails on a yanked `spin` crate.

Recovered by agent run `c7587435-5532-4e34-8023-d6627eec29e1`. Not merged — merge is Daniel's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
