### PR TITLE
Remove the --hooks feature from `orbit workspace init`

### DIFF
--- a/.claude/hooks/orbit-learning-reminder
+++ b/.claude/hooks/orbit-learning-reminder
@@ -1,3 +1,0 @@
-#!/bin/sh
-# Orbit project-learning PreToolUse hook.
-exec "${ORBIT_BIN:-orbit}" hook pretooluse "$@"

--- a/.codex/hooks/orbit-learning-reminder
+++ b/.codex/hooks/orbit-learning-reminder
@@ -1,3 +1,0 @@
-#!/bin/sh
-# Orbit project-learning PreToolUse hook.
-exec "${ORBIT_BIN:-orbit}" hook pretooluse --format codex "$@"

--- a/.orbit/adrs/accepted/ADR-0248/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0248/adr.yaml
@@ -1,0 +1,24 @@
+schema_version: 2
+id: ADR-0248
+title: Keep `orbit hook install` opt-in; remove `--hooks` from `workspace init`
+status: accepted
+owner: claude
+created_at: 2026-07-25T05:43:58.112051260Z
+accepted_at: 2026-07-25T05:44:03.377312110Z
+last_updated: 2026-07-25T05:44:03.377312110Z
+related_features: []
+related_tasks:
+- ORB-10366
+- ORB-10346
+tags:
+- cli
+- learnings
+- hooks
+paths:
+- crates/orbit-cli/src/command/workspace/init.rs
+- crates/orbit-cli/src/command/hook/**
+- crates/orbit-cmd/src/hook_install.rs
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0248/body.md
+++ b/.orbit/adrs/accepted/ADR-0248/body.md
@@ -1,0 +1,23 @@
+## Context
+
+[ORB-10346] removed the learning-reminder PreToolUse registrations this repo's own `.claude/settings.json` and `.codex/config.toml` carried, per the pull-discovery direction (ADR-0108/ADR-0112 supersession, ADR-0242 amendment). It deliberately left the writer mechanism itself untouched — `orbit workspace init --hooks` and `orbit hook install` both still silently wrote those registrations back for any repo that invoked them, and the tree still carried two now-inert tracked shim files (`.claude/hooks/orbit-learning-reminder`, `.codex/hooks/orbit-learning-reminder`) left over from before the retirement. [ORB-10366] closes that gap.
+
+Two call sites write the registration via `orbit_cmd::hook_install::install_for_workspace`:
+
+1. `orbit workspace init --hooks` (`crates/orbit-cli/src/command/workspace/init.rs`) — an implicit side effect of the init flow, easy to invoke unintentionally from a script or muscle memory (`orbit init --hooks` from an older doc, a stale redeploy script, etc.).
+2. `orbit hook install` (`crates/orbit-cli/src/command/hook/install.rs`) — a standalone, explicitly human-invoked command with no other purpose.
+
+## Decision
+
+Remove the `--hooks` flag from `orbit workspace init` entirely (clap now rejects it as an unknown argument rather than silently ignoring it) and delete the two tracked inert shim files. Keep `orbit hook install` / `orbit hook uninstall` as an explicit, opt-in, human-invoked escape hatch — do not remove the command.
+
+The distinction that matters is *automatic* vs. *deliberate*. ADR-0108/ADR-0112's problem was learnings being pushed into agent context without anyone choosing that — the failure mode was "agents not knowing they should look," closed by pull discovery instead. An `--hooks` flag riding along on `workspace init` (a command run for unrelated reasons — bootstrapping a new checkout) reproduces exactly that: a side effect nobody asked for in the moment. `orbit hook install` has no such ambiguity — it is the only thing the command does, so running it is itself the deliberate choice, same category as a human explicitly opting back into the old delivery model for a specific reason (e.g. a non-Claude-Code agent runtime that has no other discovery path, or reproducing pre-retirement behavior for comparison). Removing it forecloses that choice for no safety gain, since `orbit hook uninstall` (needed regardless, to clean up pre-ORB-10366 registrations like this repo's own) is already the same shape of explicit command.
+
+## Consequences
+
+- No code path reachable from `orbit init` or `orbit workspace init` writes a learning-reminder registration; a fresh `workspace init` against a temp workspace root leaves `.claude/settings.json` / `.codex/config.toml` untouched (asserted in `crates/orbit-cli/tests/hook_install.rs`).
+- `orbit workspace init --hooks` now fails with a clap "unexpected argument" error instead of silently succeeding — a stale script or doc still passing it breaks loudly at the call site instead of appearing to work.
+- `orbit hook install` / `orbit hook uninstall` are unchanged; `orbit_cmd::hook_install::{install,uninstall}_for_workspace` and the underlying JSON/TOML merge helpers are untouched, so the only diff is at the two CLI call sites plus the flag itself.
+- The independently-registered `scripts/orbit-file-lock` PreToolUse guard and the `orbit hook pretooluse` / `learning_hook::run_pretooluse` runtime path are unrelated to this change and keep working exactly as before.
+- Cost: `orbit hook install` remains capable of re-registering the retired delivery mechanism if a human runs it deliberately. This is accepted as the intended behavior of an opt-in escape hatch, not a gap — the alternative (removing the command) would require touching `orbit-cli`'s audit-metadata match, `operation.rs`'s exhaustive command arm, and the `--help` template for a command with a legitimate use case and no automatic trigger.
+- Cost: the two tracked inert shim files this repo carried are deleted rather than kept as reference examples; `orbit hook install` regenerates them byte-identically if ever re-run, so nothing is lost.

--- a/crates/orbit-cli/src/command/hook/install.rs
+++ b/crates/orbit-cli/src/command/hook/install.rs
@@ -3,6 +3,8 @@ use orbit_core::{OrbitError, OrbitRuntime};
 
 use crate::command::Execute;
 
+// ADR-0248: kept as a deliberate, human-invoked opt-in — `workspace init`
+// no longer wires this up automatically.
 #[derive(Args)]
 pub struct HookInstallArgs;
 

--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -48,9 +48,6 @@ pub struct WorkspaceInitArgs {
     /// Set up MCP client integrations for auto-detected providers.
     #[arg(long)]
     pub mcp: bool,
-    /// Set up PreToolUse learning hooks for auto-detected agent providers.
-    #[arg(long)]
-    pub hooks: bool,
     /// Inject (or refresh) an Orbit workflow-rules block in CLAUDE.md and AGENTS.md at the workspace root.
     #[arg(long)]
     pub inject_agent_rules: bool,
@@ -67,7 +64,6 @@ impl WorkspaceInitArgs {
         let global_root = roots.global_root;
         let registry_path = workspace_registry::registry_path_for(&global_root);
         let mcp = self.mcp;
-        let hooks = self.hooks;
         let inject_rules = self.inject_agent_rules;
         let task_id_start = self.task_id_start;
         let init_result = self.execute_at_path(&cwd, &orbit_dir, &global_root, &registry_path)?;
@@ -102,17 +98,6 @@ impl WorkspaceInitArgs {
             }
         } else {
             println!("  mcp:       skipped (pass --mcp to set up integrations)");
-        }
-
-        if hooks {
-            let providers = orbit_cmd::hook_install::install_for_workspace(&init_result.root)?;
-            if providers.is_empty() {
-                println!("  hooks:     no providers auto-detected");
-            } else {
-                println!("  hooks:     {}", providers.join(", "));
-            }
-        } else {
-            println!("  hooks:     skipped (pass --hooks to set up integrations)");
         }
 
         if inject_rules {

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -40,7 +40,6 @@ fn workspace_reinit_merges_explicit_registration_updates_without_resetting_autho
         owner: None,
         task_id_start: None,
         mcp: false,
-        hooks: false,
         inject_agent_rules: false,
         refresh_defaults: false,
     };
@@ -163,7 +162,6 @@ fn multi_host_workspace_init_persists_an_explicit_local_owner() {
             owner: None,
             task_id_start: None,
             mcp: false,
-            hooks: false,
             inject_agent_rules: false,
             refresh_defaults: false,
         }
@@ -204,7 +202,6 @@ fn spoke_workspace_init_can_atomically_declare_a_remote_owner_replica() {
         owner: Some("hm_owner".to_string()),
         task_id_start: None,
         mcp: false,
-        hooks: false,
         inject_agent_rules: false,
         refresh_defaults: false,
     }
@@ -255,7 +252,6 @@ fn invalid_replica_init_fails_before_workspace_artifacts_or_registry_mutation() 
             owner: Some(rejected_owner.to_string()),
             task_id_start: None,
             mcp: false,
-            hooks: false,
             inject_agent_rules: false,
             refresh_defaults: false,
         }
@@ -330,7 +326,6 @@ fn workspace_init_seeds_disabled_routines_and_reinit_preserves_authored_files() 
         owner: None,
         task_id_start: None,
         mcp: false,
-        hooks: false,
         inject_agent_rules: false,
         refresh_defaults: false,
     };
@@ -426,7 +421,6 @@ fn workspace_init_seeds_auto_detected_mcp_configs() {
         owner: None,
         task_id_start: None,
         mcp: true,
-        hooks: false,
         inject_agent_rules: false,
         refresh_defaults: false,
     }
@@ -476,7 +470,6 @@ fn workspace_init_skips_mcp_by_default() {
         owner: None,
         task_id_start: None,
         mcp: false,
-        hooks: false,
         inject_agent_rules: false,
         refresh_defaults: false,
     }
@@ -518,7 +511,6 @@ fn workspace_init_under_home_with_global_orbit_creates_repo_orbit() {
         owner: None,
         task_id_start: None,
         mcp: false,
-        hooks: false,
         inject_agent_rules: false,
         refresh_defaults: false,
     }
@@ -553,7 +545,6 @@ fn workspace_init_appends_orbit_to_existing_gitignore() {
         owner: None,
         task_id_start: None,
         mcp: false,
-        hooks: false,
         inject_agent_rules: false,
         refresh_defaults: false,
     }
@@ -587,7 +578,6 @@ fn workspace_init_replaces_legacy_bare_orbit_gitignore_line_with_managed_block()
         owner: None,
         task_id_start: None,
         mcp: false,
-        hooks: false,
         inject_agent_rules: false,
         refresh_defaults: false,
     };
@@ -631,7 +621,6 @@ fn workspace_init_from_git_subdir_gitignores_repo_orbit_dir() {
         owner: None,
         task_id_start: None,
         mcp: false,
-        hooks: false,
         inject_agent_rules: false,
         refresh_defaults: false,
     }
@@ -662,7 +651,6 @@ fn workspace_init_with_root_override_uses_custom_registry() {
         owner: None,
         task_id_start: None,
         mcp: false,
-        hooks: false,
         inject_agent_rules: false,
         refresh_defaults: false,
     }
@@ -718,7 +706,6 @@ fn workspace_init_seeds_default_orbitignore_when_missing() {
         owner: None,
         task_id_start: None,
         mcp: false,
-        hooks: false,
         inject_agent_rules: false,
         refresh_defaults: false,
     }
@@ -751,7 +738,6 @@ fn workspace_init_preserves_existing_orbitignore() {
         owner: None,
         task_id_start: None,
         mcp: false,
-        hooks: false,
         inject_agent_rules: false,
         refresh_defaults: false,
     }
@@ -785,7 +771,6 @@ fn workspace_init_with_root_override_does_not_modify_repo_gitignore() {
         owner: None,
         task_id_start: None,
         mcp: false,
-        hooks: false,
         inject_agent_rules: false,
         refresh_defaults: false,
     }
@@ -843,7 +828,6 @@ fn nameless_tmp_workspace_registers_only_in_isolated_registry() {
             owner: None,
             task_id_start: None,
             mcp: false,
-            hooks: false,
             inject_agent_rules: false,
             refresh_defaults: false,
         }

--- a/crates/orbit-cli/tests/hook_install.rs
+++ b/crates/orbit-cli/tests/hook_install.rs
@@ -10,15 +10,40 @@ use assert_cmd::cargo::cargo_bin_cmd;
 use serde_json::{Value, json};
 use tempfile::{TempDir, tempdir};
 
+// ORB-10366: `orbit workspace init` no longer wires up learning-reminder
+// registrations as a side effect. `orbit hook install` remains as an
+// explicit, human-invoked opt-in — see crates/orbit-cli/CLAUDE.md /
+// docs/design/project-learnings/4_decisions.md for the rationale.
+
 #[test]
-fn workspace_init_seeds_hooks_for_detected_agents() {
+fn workspace_init_rejects_hooks_flag() {
+    let workspace = TestWorkspace::new();
+    workspace.seed_agent_dirs(&[".claude"]);
+
+    let output = workspace.run_raw(
+        &["workspace", "init", "--name", "hooks", "--hooks"],
+        "init with removed --hooks flag",
+    );
+
+    assert!(
+        !output.status.success(),
+        "expected --hooks to be rejected by clap, stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--hooks") || stderr.contains("unexpected argument"),
+        "stderr did not mention the rejected flag: {stderr}"
+    );
+}
+
+#[test]
+fn workspace_init_leaves_no_learning_reminder_registrations() {
     let workspace = TestWorkspace::new();
     workspace.seed_agent_dirs(&[".claude", ".codex", ".gemini", ".grok"]);
 
-    workspace.run(
-        &["workspace", "init", "--name", "hooks", "--hooks"],
-        "init hooks",
-    );
+    workspace.run(&["workspace", "init", "--name", "hooks"], "init workspace");
 
     for path in [
         ".claude/hooks/orbit-learning-reminder",
@@ -26,48 +51,23 @@ fn workspace_init_seeds_hooks_for_detected_agents() {
         ".gemini/hooks/orbit-learning-reminder",
         ".grok/hooks/orbit-learning-reminder",
     ] {
-        assert!(workspace.work.join(path).exists(), "missing {path}");
+        assert!(
+            !workspace.work.join(path).exists(),
+            "fresh workspace init must not write shim {path}"
+        );
     }
 
-    assert_json_hook(
-        &workspace.work.join(".claude/settings.json"),
-        "PreToolUse",
-        ".claude/hooks/orbit-learning-reminder",
-    );
-    assert_json_hook(
-        &workspace.work.join(".gemini/settings.json"),
-        "BeforeTool",
-        ".gemini/hooks/orbit-learning-reminder",
-    );
-    assert_toml_hook(
-        &workspace.work.join(".codex/config.toml"),
-        "PreToolUse",
-        ".codex/hooks/orbit-learning-reminder",
-    );
-    assert_toml_hook(
-        &workspace.work.join(".grok/config.toml"),
-        "PreToolUse",
-        ".grok/hooks/orbit-learning-reminder",
-    );
-}
-
-#[test]
-fn workspace_init_hooks_is_idempotent() {
-    let workspace = TestWorkspace::new();
-    workspace.seed_agent_dirs(&[".claude", ".codex", ".gemini", ".grok"]);
-
-    workspace.run(
-        &["workspace", "init", "--name", "hooks", "--hooks"],
-        "init hooks",
-    );
-    let first = workspace.read_configs();
-    workspace.run(
-        &["workspace", "init", "--name", "hooks", "--hooks"],
-        "init hooks again",
-    );
-    let second = workspace.read_configs();
-
-    assert_eq!(first, second);
+    for path in [".claude/settings.json", ".codex/config.toml"] {
+        let full = workspace.work.join(path);
+        if !full.exists() {
+            continue;
+        }
+        let contents = fs::read_to_string(&full).expect("read config");
+        assert!(
+            !contents.contains("orbit-learning-reminder"),
+            "{path} unexpectedly contains a learning-reminder registration:\n{contents}"
+        );
+    }
 }
 
 #[test]
@@ -95,115 +95,6 @@ fn hook_install_command_seeds_hooks_and_is_idempotent() {
 }
 
 #[test]
-fn workspace_init_hooks_preserves_user_entries() {
-    let workspace = TestWorkspace::new();
-    workspace.seed_agent_dirs(&[".claude"]);
-    fs::write(
-        workspace.work.join(".claude/settings.json"),
-        serde_json::to_string_pretty(&json!({
-            "hooks": {
-                "PreToolUse": [{
-                    "matcher": "Write",
-                    "hooks": [{
-                        "type": "command",
-                        "command": ".claude/hooks/user-hook"
-                    }]
-                }]
-            },
-            "theme": "dark"
-        }))
-        .expect("serialize settings"),
-    )
-    .expect("write settings");
-
-    workspace.run(
-        &["workspace", "init", "--name", "hooks", "--hooks"],
-        "init hooks",
-    );
-
-    let settings: Value = serde_json::from_str(
-        &fs::read_to_string(workspace.work.join(".claude/settings.json")).expect("read settings"),
-    )
-    .expect("parse settings");
-    assert_eq!(settings["theme"], "dark");
-    assert_json_value_contains_command(&settings, ".claude/hooks/user-hook");
-    assert_json_value_contains_command(&settings, ".claude/hooks/orbit-learning-reminder");
-}
-
-#[test]
-fn workspace_init_hooks_skips_absent_agent_dirs() {
-    let workspace = TestWorkspace::new();
-    workspace.seed_agent_dirs(&[".claude"]);
-
-    workspace.run(
-        &["workspace", "init", "--name", "hooks", "--hooks"],
-        "init hooks",
-    );
-
-    assert!(
-        workspace
-            .work
-            .join(".claude/hooks/orbit-learning-reminder")
-            .exists()
-    );
-    assert!(
-        !workspace
-            .work
-            .join(".codex/hooks/orbit-learning-reminder")
-            .exists()
-    );
-    assert!(
-        !workspace
-            .work
-            .join(".gemini/hooks/orbit-learning-reminder")
-            .exists()
-    );
-    assert!(
-        !workspace
-            .work
-            .join(".grok/hooks/orbit-learning-reminder")
-            .exists()
-    );
-}
-
-#[test]
-fn workspace_init_hooks_failure_is_warned_not_fatal() {
-    let workspace = TestWorkspace::new();
-    workspace.seed_agent_dirs(&[".claude", ".codex", ".gemini", ".grok"]);
-    fs::write(workspace.work.join(".claude/settings.json"), "{ not json")
-        .expect("write malformed settings");
-
-    workspace.run(
-        &["workspace", "init", "--name", "hooks", "--hooks"],
-        "init hooks",
-    );
-
-    assert!(
-        workspace
-            .work
-            .join(".codex/hooks/orbit-learning-reminder")
-            .exists()
-    );
-    assert!(
-        workspace
-            .work
-            .join(".gemini/hooks/orbit-learning-reminder")
-            .exists()
-    );
-    assert!(
-        workspace
-            .work
-            .join(".grok/hooks/orbit-learning-reminder")
-            .exists()
-    );
-    assert_json_hook(
-        &workspace.work.join(".gemini/settings.json"),
-        "BeforeTool",
-        ".gemini/hooks/orbit-learning-reminder",
-    );
-}
-
-#[test]
 fn workspace_teardown_removes_orbit_hooks_only() {
     let workspace = TestWorkspace::new();
     workspace.seed_agent_dirs(&[".claude"]);
@@ -224,10 +115,8 @@ fn workspace_teardown_removes_orbit_hooks_only() {
     )
     .expect("write settings");
 
-    workspace.run(
-        &["workspace", "init", "--name", "hooks", "--hooks"],
-        "init hooks",
-    );
+    workspace.run(&["workspace", "init", "--name", "hooks"], "init workspace");
+    workspace.run(&["hook", "install"], "install hooks");
     workspace.run(&["workspace", "teardown", "--confirm"], "teardown hooks");
 
     assert!(
@@ -356,16 +245,20 @@ impl TestWorkspace {
         .collect()
     }
 
-    fn run(&self, args: &[&str], label: &str) -> Output {
+    fn run_raw(&self, args: &[&str], _label: &str) -> Output {
         let mut command = cargo_bin_cmd!("orbit");
-        let output = command
+        command
             .current_dir(&self.work)
             .env("HOME", &self.home)
             .env("USERPROFILE", &self.home)
             .env_remove("ORBIT_ROOT")
             .args(args)
             .output()
-            .expect("run orbit");
+            .expect("run orbit")
+    }
+
+    fn run(&self, args: &[&str], label: &str) -> Output {
+        let output = self.run_raw(args, label);
         assert!(
             output.status.success(),
             "{label} failed\nargs: {args:?}\nstdout:\n{}\nstderr:\n{}",

--- a/docs/design/project-learnings/4_decisions.md
+++ b/docs/design/project-learnings/4_decisions.md
@@ -259,11 +259,29 @@ Alternatives considered:
 
 ---
 
+## ADR-0248 — Keep `orbit hook install` opt-in; remove `--hooks` from `workspace init`
+
+**Status:** Accepted · 2026-07 · [ORB-10366]
+
+**Context.** [ORB-10346] removed the learning-reminder registrations this repo's own `.claude/settings.json` and `.codex/config.toml` carried, but deliberately left the writer mechanism untouched: `orbit workspace init --hooks` and `orbit hook install` both still silently wrote those registrations back for any repo that invoked them, and the tree still carried two now-inert tracked shim files left over from before the retirement.
+
+**Decision.** Remove the `--hooks` flag from `orbit workspace init` entirely — clap now rejects it as an unknown argument instead of silently ignoring it — and delete the tracked inert shim files. Keep `orbit hook install` / `orbit hook uninstall` as an explicit, opt-in, human-invoked escape hatch. The distinction is *automatic* vs. *deliberate*: ADR-0108/ADR-0112's failure mode was learnings pushed into context without anyone choosing that. A `--hooks` flag riding along on `workspace init` (run for unrelated reasons — bootstrapping a checkout) reproduces exactly that. `orbit hook install` has no such ambiguity — it is the only thing the command does, so running it is itself the deliberate opt-in choice.
+
+**Consequences.**
+- No code path reachable from `orbit init` or `orbit workspace init` writes a learning-reminder registration; a fresh `workspace init` against a temp workspace root leaves `.claude/settings.json` / `.codex/config.toml` untouched (`crates/orbit-cli/tests/hook_install.rs`).
+- `orbit workspace init --hooks` now fails loudly (clap "unexpected argument") instead of silently succeeding.
+- `orbit hook install` / `orbit hook uninstall`, the underlying `orbit_cmd::hook_install` module, the `orbit hook pretooluse` runtime path, and the independent `scripts/orbit-file-lock` PreToolUse guard are all unchanged.
+- Cost: `orbit hook install` remains capable of re-registering the retired delivery mechanism if a human runs it deliberately — accepted as the intended behavior of an opt-in escape hatch, not a gap.
+- Cost: the two tracked inert shim files this repo carried are deleted; `orbit hook install` regenerates them byte-identically if ever re-run, so nothing is lost.
+
+---
+
 ## Task References
 
 - [T20260510-11] — Design + build project-learnings system as native Orbit primitive. The task that produced this folder.
 - [ORB-10046] — Remove the vote and comment surfaces from the learning subsystem (ADR-0210 supersedes ADR-0157).
 - [ORB-10316] — Teaser injection + `learning_shown` usage signal + `orbit learning stats` rollup + payload-derived session dedup (ADR-0242).
 - [ORB-10346] — Retired automatic learning delivery while retaining pull discovery, `learning_shown`, and historical usage stats.
+- [ORB-10366] — Removed the `--hooks` flag from `orbit workspace init` and the tracked inert shims; kept `orbit hook install` as an opt-in escape hatch (ADR-0248).
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10366](https://orbit-cli.com/tasks/ORB-10366) — Remove the --hooks feature from `orbit workspace init`

### Description

Follow-on to ORB-10346 / PR #682 (Daniel, 2026-07-25). **Description rewritten 2026-07-25 04:47Z — the original targeted `orbit init`, which has never carried a `--hooks` flag. See the premise-correction comment for the full evidence; the corrected target is `orbit workspace init`.**

ORB-10346 removed the project-learning reminder registrations from `.claude/settings.json` and `.codex/config.toml`, per ADR-0001 — knowledge is now delivered by pull discovery (`orbit search` + `orbit learning show`) and point-of-use reference comments, not by PreToolUse injection. The hook implementation itself was deliberately retained, just left unregistered.

`orbit workspace init` still carries a `--hooks` flag that writes those registrations back. Remove it.

### Priority: dropped high → medium

The original urgency claim was that ORB-10361's redeploy runs `orbit init --non-interactive` and would silently re-register the hooks. That claim is void. `orbit init` cannot reach the installer — `init_global` (`crates/orbit-core/src/command/init.rs:104-120`) has zero `hook` occurrences, and `orbit-core` has no dependency on `orbit-cmd`, which owns `hook_install`. It is structurally unreachable, not merely un-passed. Confirmed empirically: `update-orbit.sh` ran on dk-server-1 at 03:58Z on 2026-07-25 and all five settings files were byte-identical afterwards. ORB-10361 shipped and closed without this task. What remains is real cleanup, not a blocker.

### Scope

1. Remove the `--hooks` flag from `orbit workspace init` (`crates/orbit-cli/src/command/workspace/init.rs:53`) and the registration-writing path it gates (`:107-108` — `if hooks { orbit_cmd::hook_install::install_for_workspace(&init_result.root)? }`; else arm at `:115` prints "hooks: skipped"). Reject the flag with a clear message rather than silently accepting and ignoring it, so any script still passing it fails loudly instead of appearing to work.
2. Decide the fate of `orbit hook install` — the tree's only other installer call site (`crates/orbit-cli/src/command/hook/install.rs:11`). It is an explicit, deliberate, human-invoked command, so removing it is a separate judgement from removing an init side-effect. Either remove it too or state explicitly why an opt-in escape hatch is retained after ADR-0001.
3. Sweep for other callers — installer scripts, runbooks, docs, test fixtures, shipped default definitions — and remove or update each. A leftover `--hooks` in an ops script is the same hazard as the flag itself.
4. Leave the hook *implementation* alone. ORB-10346 retained it intentionally; this task removes only the registration-writing surface. The independent file-lock PreToolUse guard (`scripts/orbit-file-lock`) is unrelated and must keep working.
5. Assert in a test that a fresh `orbit workspace init` produces no learning-reminder registration. **The test must use a temp workspace root, not `$HOME`.** All hook paths are workspace-root-relative (`crates/orbit-cmd/src/hook_install.rs:45-51` → `<root>/.claude/settings.json`:47, `<root>/.codex/config.toml`:48, `<root>/.gemini/settings.json`:49, `<root>/.grok/config.toml`:50; shim at `<root>/<agentdir>/hooks/orbit-learning-reminder`, `:54-59`; write sites `:227` shim / `:384` JSON / `:560` TOML). Nothing under `~` is ever a target, so a `$HOME`-based assertion would pass vacuously and prove nothing.
6. **Delete the tracked inert shims, or justify keeping them.** `codebases/orbit/.claude/hooks/orbit-learning-reminder` and `.codex/hooks/orbit-learning-reminder` exist and are git-tracked (mtime 2026-06-27). They are currently unregistered and inert — both settings files register only `scripts/orbit-file-lock` on PreToolUse — but anyone running `orbit workspace init --hooks` in that repo today would wire them up and silently undo ORB-10346. Removing the flag defuses the mechanism; the tracked files are a separate question. ORB-10346 retained the *implementation* deliberately, which is not the same as retaining committed shims in the repo.
7. Update docs describing init's hook behaviour, including the ADR-0001 follow-through and any runbook covering box redeployment.

PR-gated repo: worktree off `agent-main`, PR + CI.

### Acceptance Criteria

- `orbit workspace init` no longer accepts `--hooks`; passing it fails loudly rather than being silently ignored
- No code path in either `orbit init` or `orbit workspace init` writes learning-reminder registrations to any agent settings file
- A fresh `orbit workspace init` against a TEMP workspace root leaves `.claude/settings.json` and `.codex/config.toml` free of learning-reminder registrations, asserted by a test that would fail if the registration returned
- The fate of `orbit hook install` is explicitly decided — removed, or retained with a stated reason
- The tracked inert shims under codebases/orbit/.claude/hooks/ and .codex/hooks/ are either deleted or explicitly justified in the execution summary
- All other callers of `--hooks` (installer/update scripts, runbooks, docs, fixtures, shipped definitions) are removed or updated
- The retained hook implementation and the independent scripts/orbit-file-lock PreToolUse guard are unchanged and still working
- Docs and the redeployment runbook reflect the new behaviour
- make ci green

## Execution Summary

<details>
<summary>Click to expand</summary>

Removed the `--hooks` flag and its registration-writing code path from `orbit workspace init` (crates/orbit-cli/src/command/workspace/init.rs) — clap now rejects `--hooks` as an unknown argument instead of silently accepting and ignoring it, closing the exact gap the corrected task description identified. `orbit init` never carried this flag; only `orbit workspace init` did.

Decided the fate of `orbit hook install`/`orbit hook uninstall`: kept both, deliberately, as ADR-0248 documents. Rationale: ADR-0108/ADR-0112's problem was *automatic* delivery (learnings pushed into context without anyone choosing that); `--hooks` on `workspace init` reproduced that as a side effect of an unrelated command. `orbit hook install` has no such ambiguity — running it is itself the deliberate opt-in choice, same category as `orbit hook uninstall` (already required for cleanup, e.g. of this repo's own now-removed registrations). Removing the command would also have required touching orbit-cli's exhaustive audit-metadata match, the `operation.rs` command arm, and the help template for a command with a legitimate use case and no automatic trigger (L-0013/L-0038 territory) — not warranted absent a reason to remove it.

Deleted the two tracked inert shim files this repo carried (.claude/hooks/orbit-learning-reminder, .codex/hooks/orbit-learning-reminder) — unregistered since ORB-10346, regenerated byte-identically by `orbit hook install` if ever re-run, so nothing is lost.

Swept for other `--hooks` callers: none found outside the removed flag itself — smoke scripts (scripts/smoke-plugin-install.sh, scripts/smoke-claude-mcp.sh) and plugin/hooks/check-workspace.sh only reference `orbit workspace init` without `--hooks`. No redeployment runbook exists inside this repo (the ORB-10361 update-orbit.sh referenced in the task lives outside this repo/worktree and was already confirmed void of `--hooks` usage per the task's own priority-correction note).

Left the hook *implementation* untouched: `orbit hook pretooluse` / `orbit_cmd::learning_hook::run_pretooluse` (the runtime path the shim scripts exec into), the `orbit_cmd::hook_install` module's install/uninstall logic, and the independent `scripts/orbit-file-lock` PreToolUse guard are all unchanged and verified still working via existing and updated tests.

Test coverage (acceptance criterion 3): rewrote crates/orbit-cli/tests/hook_install.rs — `workspace_init_rejects_hooks_flag` asserts clap failure; `workspace_init_leaves_no_learning_reminder_registrations` runs a fresh `workspace init` against a TEMP workspace root (tempdir-backed, never $HOME) and asserts no shim files are written and neither `.claude/settings.json` nor `.codex/config.toml` contain an `orbit-learning-reminder` registration — this test fails if the registration path returns. Removed the now-obsolete `--hooks`-flag CLI tests (idempotency/preserve-user-entries/skip-absent-dirs/failure-is-warned) since that CLI trigger no longer exists; equivalent coverage already existed at the module level in crates/orbit-cmd/src/tests/hook_install.rs (install_preserves_user_json_entries, install_is_idempotent_for_managed_config_files) which is unchanged and still passing. Kept `hook_install_command_seeds_hooks_and_is_idempotent` (now the only CLI-level install test, exercising `orbit hook install` directly) and updated `workspace_teardown_removes_orbit_hooks_only` to seed hooks via `orbit hook install` instead of the removed `--hooks` flag.

Docs: added ADR-0248 (Accepted, related_tasks [ORB-10366, ORB-10346]) to docs/design/project-learnings/4_decisions.md documenting the automatic-vs-deliberate distinction and the decision to keep `hook install` opt-in; referenced from the Task References section. Added a one-line ADR-0248 pointer comment above `HookInstallArgs` in crates/orbit-cli/src/command/hook/install.rs per the project's reference-comment convention.

Unlisted files touched beyond the bare flag removal (all tightly coupled, per envelope rule 5): crates/orbit-cli/src/command/workspace/tests/init.rs (16x `hooks: false,` struct-literal fields removed — required to keep WorkspaceInitArgs construction compiling after the field was deleted); crates/orbit-cli/src/command/hook/install.rs (reference comment only, no behavior change).

Validation: `cargo check -p orbit-cli -p orbit-cmd --tests`, `cargo clippy -p orbit-cli -p orbit-cmd --tests --all-targets -- -D warnings`, `cargo test -p orbit-cmd hook_install` (4 pass), `cargo test -p orbit-cli --test hook_install` (4 pass), `cargo test -p orbit-cli --bin orbit workspace` (38 pass), and `make ci-fast` — all clean/green. Full `make ci` was not run locally per repo convention (CI is the canonical gate).

No cross-crate dependency edges added. No third-party dependencies added. No CHANGELOG.md edit (per repo convention, compiled at release time).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10366-6a644bab`
- Behind base: 0
- Ahead of base: 1