### PR TITLE
Set exact Claude crew model strings in workspace config [ORB-10354]

### DIFF
--- a/.orbit/config.toml
+++ b/.orbit/config.toml
@@ -31,12 +31,12 @@ default_crew = "opus"
 role = "source"
 
 [crews.opus]
-model = "opus"
+model = "claude-opus-5"
 provider = "claude"
 backend = "cli"
 
 [crews.sonnet]
-model = "sonnet"
+model = "claude-sonnet-5"
 provider = "claude"
 backend = "cli"
 


### PR DESCRIPTION
## What

`.orbit/config.toml` (this workspace's crew definitions) had bare self-referential aliases for the two Claude crews:

| Crew | Before | After |
|---|---|---|
| `opus` | `model = "opus"` | `model = "claude-opus-5"` |
| `sonnet` | `model = "sonnet"` | `model = "claude-sonnet-5"` |

Crew names are unchanged; only the `model` value moves.

## Why this file

`ws_orbit` tasks resolve `crew_model` from *this* config, which is why rows like ORB-10352 (`gpt-5.6-sol`), ORB-10353 (`gpt-5.6-terra`) and ORB-10366 (`crew_model: sonnet`) showed a bare alias where the gpt crews showed exact strings. The sibling fix to the (gitignored) constellation-root config does not reach these tasks.

## How the strings were verified

Each string was checked against `provider_metadata.modelUsage.<model>.canonicalModel` in real run records under `~/.local/share/supervisor/runs/`, not against a supplied list:

- `claude-opus-5` → `canonicalModel: "claude-opus-5"` — 13 runs (e.g. `715721ce`)
- `claude-sonnet-5` → `canonicalModel: "claude-sonnet-5"` — run `a6ec3b92`

## Deliberately not changed

- **`[crews.fable]` is left as `model = "fable"`.** The fleet's only fable dispatch (`b41c159e`, 2026-07-18) predates the `canonicalModel` field — its record carries `canonicalModel: None` — so `claude-fable-5` cannot be provider-verified from evidence on this box. An unverified guess is worse than a working alias.
- **The gpt crews (`sol`, `terra`, `luna`) already carry exact strings.**
- **No validation, guard, alias table, or resolver.** Bare aliases must keep working: being able to write `opus`/`sonnet` is more convenient than updating orbit on every model release. This is a config edit only — no Rust change.

## Verification

`make ci-fast` passes. A throwaway probe task created in `ws_orbit` with `--crew opus` resolved `crew_model` to `claude-opus-5`; see the ORB-10354 comment for the probe id and result.

[ORB-10354]