### PR TITLE
Reconcile two stale/mismatched entries in orbit's .orbit/config.toml

### DIFF
--- a/.orbit/config.toml
+++ b/.orbit/config.toml
@@ -72,7 +72,7 @@ backend = "cli"
 
 [crews.qa]
 model = "gpt-5.6-terra"
-provider = "claude"
+provider = "codex"
 backend = "cli"
 
 
@@ -82,9 +82,9 @@ task_url_template = "https://orbit-cli.com/tasks/{task_id}"
 [duel]
 candidates = ["codex", "claude", "grok"]
 
-[duel.models]                             
+[duel.models]
 codex  = "gpt-5.6-terra"
-claude = "claude-opus-4-8"
+claude = "opus"
 grok = "grok-build"
 
 [docs]


### PR DESCRIPTION
## Task

[ORB-10373](https://orbit-cli.com/tasks/ORB-10373) — Reconcile two stale/mismatched entries in orbit's .orbit/config.toml

### Description

Surfaced by the ORB-10354 part-2 executor while fixing self-referential crew model aliases. Both are out of scope for ORB-10354 (neither is a self-referential alias) and were deliberately left untouched there. Filing them here as promised.

## Defect 1 — `[crews.qa]` provider/model mismatch

In `codebases/orbit/.orbit/config.toml`, the `qa` crew is defined as:

```toml
[crews.qa]
provider = "claude"
model = "gpt-5.6-terra"
```

The same crew in the global config (`~/.orbit/config.toml`) is `provider = "codex"`. A `claude` provider cannot serve a `gpt-*` model, so one of the two fields is wrong — and the two config files disagree about which. This cannot be correct in either direction.

Decide which is authoritative and make the two files agree. Worth checking whether any run has ever dispatched on the `qa` crew from the orbit workspace; if one has, its `job_runs` row will show what actually got resolved and that settles it empirically.

## Defect 2 — stale `[duel.models]` entry

```toml
[duel.models]
claude = "claude-opus-4-8"
```

This is a non-crew model string pointing at a prior generation. It is not covered by ORB-10354's alias fix because it is not a crew definition. Either refresh it to a current model string or, if the duel feature is no longer exercised, remove the block.

## Notes

- `.gitignore:71` explicitly un-ignores `codebases/orbit/.orbit/config.toml`, so this file is git-tracked and any change is PR-gated.
- Do NOT change any `[crews.fable]` entry. `claude-fable-5` has never been confirmed against `provider_metadata.modelUsage.<model>.canonicalModel` in any worker run record (it appears once, in run `b41c159e`, with `canonicalModel: null`), so its alias is deliberately left as `model = "fable"`.
- Config changes on a branch have no effect until the PR merges: `orbit config path` from `codebases/orbit` resolves to the primary checkout, not the PR branch.

### Acceptance Criteria

- The `qa` crew's provider and model agree with each other, and the orbit workspace config agrees with the global config on which provider serves that crew
- The rationale for which side was authoritative is recorded in the task record, not just in the diff
- `[duel.models] claude` either names a current model string or the block is removed
- No `[crews.fable]` entry is modified
- `make ci-fast` is green and a PR is raised against agent-main

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed both stale/mismatched entries in codebases/orbit/.orbit/config.toml.

Defect 1 — [crews.qa] provider/model mismatch: changed provider from "claude" to "codex" (model stays "gpt-5.6-terra"). Rationale, backed by empirical evidence from job_runs in ~/.orbit/orbit.db (workspace_id orbit-5c61b3, resolved_crew='qa'): 12 of 15 recorded qa-crew runs (e.g. jrun-20260716-0510, jrun-20260717-0520-4/5) actually dispatched via `codex exec --model gpt-5.6-terra` with pipeline_state_json recording provider="codex" — matching the global ~/.orbit/config.toml, which already has provider="codex" for [crews.qa] and is internally consistent (codex provider serving a gpt-* model, same pin used by [crews.terra]). The workspace-local provider="claude" override was the wrong side: a claude provider cannot serve a gpt-5.6-terra model. Two later runs (jrun-20260718-2032-2/3) resolved qa to model "opus"/provider "claude" instead — consistent with a broken qa resolution silently falling back to the workspace's default_crew ("opus"), which is further evidence the local override was invalid rather than authoritative. Global config left unchanged; only the workspace-local file was corrected to agree with it.

Defect 2 — stale [duel.models] claude entry: refreshed "claude-opus-4-8" to "opus". crates/orbit-common/src/model_defaults.rs is the documented single source of truth for default model names and states duel defaults are seeded from `default_model_for_provider`, where claude resolves to CLAUDE_DEFAULT_STRONG = "opus" (the unversioned CLI alias, chosen there specifically because the Claude CLI resolves it to the current flagship so it never drifts). The sibling duel.models entries already follow this pattern exactly: codex="gpt-5.6-terra" matches CODEX_DEFAULT_MODEL, grok="grok-build" matches GROK_DEFAULT_MODEL. Did not remove the [duel] block: grepped the codebase and confirmed duel is a live, actively maintained feature (dedicated crates/orbit-tools/src/builtin/orbit/duel/*, orbit-common/src/types/duel.rs, CLI `orbit run duel-plan`, tests, multiple docs/ADRs) — the absence of duel job_runs in this workspace's history reflects that no one has run it here yet, not that the feature is retired, so removing its config would be an unrelated behavior change beyond this cleanup task's scope.

[crews.fable] was not touched, per the task's explicit instruction (its `model = "fable"` alias is deliberately left as-is pending confirmation in worker run records).

Validation: `make ci-fast` green (fmt-check, doc index, installer/security checks, dependency-direction, cli-imports, stability tiers, learning-layout, artifact-redaction, error-translation guards all passed) — cargo was found at ~/.cargo/bin after adding it to PATH (not on the default PATH in this sandbox).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10373-6a64e261`
- Behind base: 0
- Ahead of base: 1