### PR TITLE
Accept `complexity` on the task-update path (CLI, core, dashboard API) [ORB-10375]

### DIFF
--- a/crates/orbit-cli/src/command/task/tests/update.rs
+++ b/crates/orbit-cli/src/command/task/tests/update.rs
@@ -31,3 +31,27 @@ fn task_update_accepts_context_files_alias() {
     );
     assert!(args.json);
 }
+
+#[test]
+fn task_update_complexity_uses_add_spellings() {
+    for complexity in ["low", "medium", "hard"] {
+        let cli = Cli::try_parse_from([
+            "orbit",
+            "task",
+            "update",
+            "ORB-00001",
+            "--complexity",
+            complexity,
+        ])
+        .expect("parse task update complexity");
+
+        let Commands::Task(task) = cli.command else {
+            panic!("expected task command");
+        };
+        let TaskSubcommand::Update(args) = task.command else {
+            panic!("expected task update command");
+        };
+
+        assert_eq!(args.complexity.expect("complexity").to_string(), complexity);
+    }
+}

--- a/crates/orbit-cli/src/command/task/update.rs
+++ b/crates/orbit-cli/src/command/task/update.rs
@@ -1,7 +1,7 @@
 use clap::{ArgAction, Args};
 use orbit_common::types::TaskArtifact;
 use orbit_core::command::task::TaskUpdateParams;
-use orbit_core::{OrbitError, OrbitRuntime, TaskStatus, TaskType};
+use orbit_core::{OrbitError, OrbitRuntime, TaskComplexity, TaskStatus, TaskType};
 
 use crate::command::Execute;
 
@@ -41,6 +41,9 @@ pub struct TaskUpdateArgs {
     /// New task type
     #[arg(long = "type", value_enum)]
     pub task_type: Option<TaskType>,
+    /// Task complexity
+    #[arg(long, value_enum)]
+    pub complexity: Option<TaskComplexity>,
     /// Explicit planning attribution label (empty string clears)
     #[arg(long)]
     pub planned_by: Option<String>,
@@ -85,6 +88,7 @@ impl Execute for TaskUpdateArgs {
             comment,
             status,
             task_type,
+            complexity,
             planned_by,
             implemented_by,
             pr_status,
@@ -150,6 +154,7 @@ impl Execute for TaskUpdateArgs {
                 comment,
                 status: status.map(Into::into),
                 task_type,
+                complexity,
                 planned_by,
                 implemented_by,
                 pr_status,

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -1107,6 +1107,10 @@
           "description": "Task comment to append",
           "type": "string"
         },
+        "complexity": {
+          "description": "Optional task complexity level (low, medium, or hard)",
+          "type": "string"
+        },
         "context": {
           "description": "Legacy alias for `context_files`. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files that are only relevant background context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`.",
           "type": "string"

--- a/crates/orbit-cli/tests/task_trimmed_surface.rs
+++ b/crates/orbit-cli/tests/task_trimmed_surface.rs
@@ -61,6 +61,18 @@ fn update_status_performs_approve_and_reject_transitions() {
 }
 
 #[test]
+fn task_update_complexity_roundtrips_through_a_real_task_record() {
+    let workspace = TestWorkspace::new();
+    let id = workspace.add_task("Complexity update");
+
+    let updated = workspace.task_json(&["task", "update", &id, "--complexity", "medium", "--json"]);
+    assert_eq!(updated["complexity"], json!("medium"));
+
+    let shown = workspace.task_json(&["task", "show", &id, "--json"]);
+    assert_eq!(shown["complexity"], json!("medium"));
+}
+
+#[test]
 fn locks_list_projects_files_held_by_active_tasks() {
     let workspace = TestWorkspace::new();
     fs::write(workspace.work.join("held.rs"), "// held\n").expect("write held file");

--- a/crates/orbit-core/src/command/task/params.rs
+++ b/crates/orbit-core/src/command/task/params.rs
@@ -68,6 +68,7 @@ pub struct TaskUpdateParams {
     pub execution_summary: Option<String>,
     pub comment: Option<String>,
     pub status: Option<TaskStatus>,
+    pub complexity: Option<TaskComplexity>,
     pub task_type: Option<TaskType>,
     pub source_task_id: Option<Option<String>>,
     pub planned_by: Option<Option<String>>,
@@ -94,6 +95,7 @@ impl TaskUpdateParams {
             || self.plan.is_some()
             || self.execution_summary.is_some()
             || self.status.is_some()
+            || self.complexity.is_some()
             || self.task_type.is_some()
             || self.source_task_id.is_some()
             || self.planned_by.is_some()
@@ -122,6 +124,7 @@ impl From<TaskUpdateParams> for TaskRecordUpdateParams {
             plan: p.plan,
             execution_summary: p.execution_summary,
             status: p.status,
+            complexity: p.complexity,
             task_type: p.task_type,
             source_task_id: p.source_task_id,
             planned_by: p.planned_by,

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
@@ -294,6 +294,9 @@ pub(super) fn update(
             status: optional_string(&input, "status")?
                 .map(|value| parse_task_status("status", &value))
                 .transpose()?,
+            complexity: optional_string(&input, "complexity")?
+                .map(|value| parse_task_complexity("complexity", &value))
+                .transpose()?,
             task_type: optional_string_alias(&input, &["type", "task_type", "taskType"])?
                 .map(|value| parse_task_type("type", &value))
                 .transpose()?,

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
@@ -553,6 +553,79 @@ fn task_add_and_show_tools_roundtrip_crew() {
 }
 
 #[test]
+fn task_update_tool_persists_complexity_without_adding_history() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let added = runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Complexity update task",
+                "description": "Starts without complexity and receives one on update.",
+                "workspace": ".",
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task add tool succeeds");
+    let task_id = added["id"].as_str().expect("task id");
+    assert_eq!(added.get("complexity"), Some(&Value::Null));
+    let history_before = runtime.get_task_history(task_id).expect("initial history");
+
+    runtime
+        .execute_tool_command(
+            "orbit.task.update",
+            json!({ "id": task_id, "crew": "sol" }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("crew update succeeds");
+    let history_after_crew = runtime
+        .get_task_history(task_id)
+        .expect("history after crew update");
+    assert_eq!(
+        history_after_crew, history_before,
+        "crew update adds no history"
+    );
+
+    let updated = runtime
+        .execute_tool_command(
+            "orbit.task.update",
+            json!({ "id": task_id, "complexity": "medium" }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("complexity update succeeds");
+    assert_eq!(updated.get("complexity"), Some(&json!("medium")));
+    assert_eq!(
+        runtime
+            .get_task_history(task_id)
+            .expect("history after complexity update"),
+        history_after_crew,
+        "complexity update must match crew's no-history behavior"
+    );
+
+    let shown = runtime
+        .execute_tool_command(
+            "orbit.task.show",
+            json!({ "id": task_id }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task show succeeds");
+    assert_eq!(shown.get("complexity"), Some(&json!("medium")));
+
+    let omitted = runtime
+        .execute_tool_command(
+            "orbit.task.update",
+            json!({ "id": task_id, "title": "Complexity remains set" }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("update omitting complexity succeeds");
+    assert_eq!(omitted.get("complexity"), Some(&json!("medium")));
+}
+
+#[test]
 fn task_add_tool_rejects_unknown_crew() {
     // Un-retiring crew also means it is validated: an unknown crew is now
     // rejected rather than silently ignored.

--- a/crates/orbit-dashboard/src/api/tasks.rs
+++ b/crates/orbit-dashboard/src/api/tasks.rs
@@ -115,6 +115,8 @@ pub(super) struct UpdateTaskBody {
     #[serde(default)]
     status: Option<TaskStatus>,
     #[serde(default)]
+    complexity: Option<TaskComplexity>,
+    #[serde(default)]
     task_type: Option<TaskType>,
     #[serde(default, deserialize_with = "deserialize_nullable_string_patch_field")]
     pr_status: Option<Option<String>>,
@@ -351,6 +353,7 @@ pub(super) async fn update_task_action(
         execution_summary: body.execution_summary,
         comment: body.comment,
         status: body.status,
+        complexity: body.complexity,
         task_type: body.task_type,
         source_task_id: None,
         planned_by: None,

--- a/crates/orbit-dashboard/src/api/tests/tasks.rs
+++ b/crates/orbit-dashboard/src/api/tests/tasks.rs
@@ -759,6 +759,68 @@ async fn patch_api_persists_pr_status_with_status_and_execution_summary() {
     assert_eq!(persisted.status, TaskStatus::Review);
 }
 
+#[tokio::test]
+async fn patch_api_persists_complexity_and_omission_preserves_it() {
+    use axum::http::{Method, Request, header};
+
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let task = seed_backlog_task(&runtime, "Dashboard complexity update");
+    let app = router().with_state(crate::state::DashboardState::single(Arc::new(
+        runtime.clone(),
+    )));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::PATCH)
+                .uri(format!("/tasks/{}", task.id))
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::ORIGIN, "http://localhost:7878")
+                .body(Body::from(json!({ "complexity": "medium" }).to_string()))
+                .expect("build complexity patch request"),
+        )
+        .await
+        .expect("complexity patch response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body_json(response).await["complexity"], json!("medium"));
+    assert_eq!(
+        runtime
+            .get_task(&task.id)
+            .expect("read updated task")
+            .complexity,
+        Some(TaskComplexity::Medium)
+    );
+
+    let response = router()
+        .with_state(crate::state::DashboardState::single(Arc::new(
+            runtime.clone(),
+        )))
+        .oneshot(
+            Request::builder()
+                .method(Method::PATCH)
+                .uri(format!("/tasks/{}", task.id))
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::ORIGIN, "http://localhost:7878")
+                .body(Body::from(
+                    json!({ "title": "Retitled without complexity" }).to_string(),
+                ))
+                .expect("build omitted complexity patch request"),
+        )
+        .await
+        .expect("omitted complexity patch response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body_json(response).await["complexity"], json!("medium"));
+    assert_eq!(
+        runtime
+            .get_task(&task.id)
+            .expect("read preserved complexity")
+            .complexity,
+        Some(TaskComplexity::Medium)
+    );
+}
+
 /// Contract test: /tasks projection (and /tasks/:id) must include `complexity` string
 /// when TaskComplexity is set on the task (low/medium/hard). Null complexity omits the key
 /// or yields null (per current projection); this test asserts presence for a hard task.

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/update.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/update.rs
@@ -124,6 +124,21 @@ fn schema_exposes_source_task_id() {
 }
 
 #[test]
+fn schema_exposes_complexity() {
+    let schema = OrbitTaskUpdateTool.schema();
+
+    let param = schema
+        .parameters
+        .iter()
+        .find(|param| param.name == "complexity")
+        .expect("complexity param");
+
+    assert_eq!(param.param_type, "string");
+    assert!(!param.required);
+    assert!(param.description.contains("low, medium, or hard"));
+}
+
+#[test]
 fn schema_and_handler_exclude_inline_artifacts() {
     let schema = OrbitTaskUpdateTool.schema();
     assert!(

--- a/crates/orbit-tools/src/builtin/orbit/task/update.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/update.rs
@@ -61,6 +61,12 @@ impl Tool for OrbitTaskUpdateTool {
                 required: false,
             },
             ToolParam {
+                name: "complexity".to_string(),
+                description: "Optional task complexity level (low, medium, or hard)".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
                 name: "type".to_string(),
                 description: "New task type".to_string(),
                 param_type: "string".to_string(),


### PR DESCRIPTION
## Rescue of stranded, already-validated work

This PR carries the completed output of orbit run **`jrun-20260725-1642-3`** (crew `terra`, task **ORB-10375**). That run implemented and validated the change in full, then died at the deterministic `git_commit` step at 2026-07-25T17:00:36Z with:

```
commit_batch_changes: no staged changes to commit for task 'ORB-10375' ...
the implement step produced an empty diff
```

**That message was wrong about the cause.** The diff was never empty — the worktree held all 11 modifications the entire time. The failure came from `existing_batch_commits()` (`crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs:287-295`), which re-resolves `base_ref` at commit time and requires `merge-base --is-ancestor <base> HEAD`. `worktree_setup` emits `base_ref` as the *moving symbolic ref name* `origin/agent-main`, not a pinned SHA, so once PR #695 merged into `agent-main` at 16:58:10Z — mid-run — the freshly-resolved base stopped being an ancestor of this worktree's HEAD and the check failed. On failure it returns `outside_worktree_or_empty_diff_error`, the same error text used for a genuinely empty diff. It returns at line 190, *before* the `git add --all` at line 191, which is exactly why the index was empty and the work survived untouched in the worktree.

The code here is **unmodified** from what the `terra` run produced. `Agent-Model` is set to `gpt-5.6-terra` to credit the crew that wrote it, not the rescuing agent.

## Recorded validation (from the run's execution summary, `Outcome: success`)

- Added `--complexity <low|medium|hard>` to `orbit task update`, using the same `TaskComplexity` clap value enum as `task add`, threaded through core persistence alongside `crew`.
- Added `complexity` to the dashboard PATCH body/handler and to the registered `orbit.task.update` MCP schema and runtime handler; regenerated the production MCP tools-list snapshot.
- Coverage added at CLI, real-record round-trip, core tool, MCP schema, and dashboard PATCH layers. Core coverage verifies a complexity change adds **no** task-history entry (matching an actual `crew` update) and that omission preserves an existing value.
- Strategic decision recorded: clearing `complexity` is intentionally **not** expressible on update — the CLI accepts only a concrete enum value, and MCP/dashboard JSON `null` is treated like omission. This preserves the existing `Option<TaskComplexity>` partial-update contract rather than expanding it to a tri-state API.
- Non-goals honoured: no `deny_unknown_fields` on `UpdateTaskBody`; `TaskComplexity`'s variants and parsing unchanged.

## Verification performed during the rescue

- `make ci-fast` — pass (run in the worktree, exit 0).
- `git diff --check` — clean.
- Rebased onto `origin/agent-main` (`6d43661`); the patch was proven byte-identical pre- and post-rebase, and the committed tree hash matched the staged tree hash exactly. No conflicts.
- Full `make ci` was **not** run locally — it is the PR merge gate per the repo's `CLAUDE.md`. CI on this PR is the authoritative check, including the explicit `cargo clippy --workspace --all-targets -- -D warnings` the task calls for.

Task ORB-10375 is deliberately left at **`blocked`** — status is Daniel's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
