### PR TITLE
Plumb state/job_id/since from the query string into list_job_runs [ORB-10377]

### DIFF
--- a/crates/orbit-core/src/command/job/catalog.rs
+++ b/crates/orbit-core/src/command/job/catalog.rs
@@ -117,6 +117,7 @@ impl OrbitRuntime {
                 .list_runs_filtered(&JobRunQuery {
                     job_id: Some(job_id.to_string()),
                     state: None,
+                    terminal_only: false,
                     created_since: None,
                     limit: Some(1),
                 })

--- a/crates/orbit-core/src/command/job/run/query.rs
+++ b/crates/orbit-core/src/command/job/run/query.rs
@@ -37,6 +37,7 @@ impl OrbitRuntime {
         let query = JobRunQuery {
             job_id: params.job_id,
             state: params.state,
+            terminal_only: params.terminal_only,
             created_since: params.since,
             limit: params.limit,
         };

--- a/crates/orbit-core/src/command/job/run/types.rs
+++ b/crates/orbit-core/src/command/job/run/types.rs
@@ -7,6 +7,11 @@ use serde::Serialize;
 pub struct JobRunListParams {
     pub job_id: Option<String>,
     pub state: Option<JobRunState>,
+    /// Restrict results to every state considered terminal by `JobRunState`.
+    ///
+    /// This is independent from `state` so existing callers can continue to
+    /// request one concrete state without changing their query semantics.
+    pub terminal_only: bool,
     pub since: Option<DateTime<Utc>>,
     pub limit: Option<usize>,
 }

--- a/crates/orbit-dashboard/src/api/audit.rs
+++ b/crates/orbit-dashboard/src/api/audit.rs
@@ -436,6 +436,7 @@ fn count_failed_runs(
         let runs = runtime.list_job_runs(JobRunListParams {
             job_id: None,
             state: Some(state),
+            terminal_only: false,
             since: Some(since),
             limit: Some(HISTORY_MAX_LIMIT),
         })?;
@@ -464,6 +465,7 @@ fn count_active_long_runs(
         let runs = runtime.list_job_runs(JobRunListParams {
             job_id: None,
             state: Some(state),
+            terminal_only: false,
             since: Some(since),
             limit: Some(HISTORY_MAX_LIMIT),
         })?;
@@ -485,6 +487,7 @@ fn count_active_long_runs(
     let running = runtime.list_job_runs(JobRunListParams {
         job_id: None,
         state: Some(JobRunState::Running),
+        terminal_only: false,
         since: None,
         limit: Some(HISTORY_MAX_LIMIT),
     })?;

--- a/crates/orbit-dashboard/src/api/jobs.rs
+++ b/crates/orbit-dashboard/src/api/jobs.rs
@@ -3,13 +3,44 @@
 use crate::state::Ws;
 use axum::extract::Query;
 use axum::response::{IntoResponse, Json, Response};
+use chrono::{DateTime, Utc};
+use orbit_core::JobRunState;
 use orbit_core::command::job::JobRunListParams;
+use serde::Deserialize;
 use serde_json::Value;
 
-use super::{LimitQuery, bounded_limit, server_error};
+use super::{bad_request, bounded_limit, server_error};
 use crate::projections::{job_catalog_to_json_with_last_run, job_run_to_json};
 
 const JOB_RUN_DEFAULT_LIMIT: usize = 25;
+
+#[derive(Deserialize, Default)]
+pub(super) struct JobRunListQuery {
+    #[serde(default)]
+    limit: Option<usize>,
+    #[serde(default)]
+    job_id: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    since: Option<DateTime<Utc>>,
+}
+
+enum JobRunListState {
+    Concrete(JobRunState),
+    Terminal,
+}
+
+impl JobRunListState {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "pending" => Ok(Self::Concrete(JobRunState::Pending)),
+            "running" => Ok(Self::Concrete(JobRunState::Running)),
+            "terminal" => Ok(Self::Terminal),
+            _ => Err("invalid state; expected one of: pending, running, terminal".to_string()),
+        }
+    }
+}
 
 pub(super) async fn list_jobs(Ws(runtime): Ws) -> Response {
     use orbit_core::command::job::JobCatalogFilter;
@@ -27,12 +58,20 @@ pub(super) async fn list_jobs(Ws(runtime): Ws) -> Response {
     }
 }
 
-pub(super) async fn list_job_runs(Ws(runtime): Ws, Query(q): Query<LimitQuery>) -> Response {
+pub(super) async fn list_job_runs(Ws(runtime): Ws, Query(q): Query<JobRunListQuery>) -> Response {
     let limit = bounded_limit(q.limit, JOB_RUN_DEFAULT_LIMIT);
+    let state = match q.state.as_deref().map(JobRunListState::parse).transpose() {
+        Ok(state) => state,
+        Err(message) => return bad_request(message),
+    };
     let params = JobRunListParams {
-        job_id: None,
-        state: None,
-        since: None,
+        job_id: q.job_id,
+        state: state.as_ref().and_then(|state| match state {
+            JobRunListState::Concrete(state) => Some(*state),
+            JobRunListState::Terminal => None,
+        }),
+        terminal_only: matches!(state, Some(JobRunListState::Terminal)),
+        since: q.since,
         limit: Some(limit),
     };
     match runtime.list_job_runs(params) {

--- a/crates/orbit-dashboard/src/api/tests/handlers.rs
+++ b/crates/orbit-dashboard/src/api/tests/handlers.rs
@@ -2,13 +2,14 @@ use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode, header};
+use chrono::{Duration, Utc};
 use orbit_core::command::task::TaskAddParams;
 use orbit_core::{JobRunState, OrbitRuntime, TaskStatus};
 use serde_json::json;
 use tower::ServiceExt;
 
 use super::super::*;
-use super::test_support::{body_json, seed_run};
+use super::test_support::{body_json, seed_run, write_seeded_run};
 
 async fn request_cancel(runtime: OrbitRuntime, run_id: &str, origin: Option<&str>) -> Response {
     let mut builder = Request::builder()
@@ -31,6 +32,20 @@ async fn request_tasks(runtime: OrbitRuntime) -> Response {
             Request::builder()
                 .method(Method::GET)
                 .uri("/tasks")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response")
+}
+
+async fn request_job_runs(runtime: OrbitRuntime, query: &str) -> Response {
+    router()
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(format!("/job-runs?{query}"))
                 .body(Body::empty())
                 .expect("request"),
         )
@@ -174,6 +189,92 @@ fn seed_task(
             ..Default::default()
         })
         .expect("create task")
+}
+
+#[tokio::test]
+async fn job_run_filters_apply_before_limit_and_validate_state() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let since = Utc::now();
+    let mut running = seed_run(
+        &runtime,
+        "jrun-job-runs-running",
+        "job_runs_filter",
+        JobRunState::Running,
+    );
+    running.pid = Some(std::process::id());
+    write_seeded_run(&runtime, &running);
+    for state in [
+        JobRunState::Success,
+        JobRunState::Failed,
+        JobRunState::Cancelled,
+        JobRunState::Interrupted,
+        JobRunState::Timeout,
+    ] {
+        seed_run(
+            &runtime,
+            &format!("jrun-job-runs-terminal-{state}"),
+            "job_runs_filter",
+            state,
+        );
+    }
+    let mut old_terminal = seed_run(
+        &runtime,
+        "jrun-job-runs-terminal-old",
+        "job_runs_filter",
+        JobRunState::Success,
+    );
+    old_terminal.created_at = since - Duration::days(1);
+    write_seeded_run(&runtime, &old_terminal);
+    seed_run(
+        &runtime,
+        "jrun-job-runs-terminal-other-job",
+        "other_job",
+        JobRunState::Success,
+    );
+
+    let response = request_job_runs(runtime.clone(), "state=running&limit=1").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let rows = body_json(response).await;
+    assert_eq!(rows.as_array().expect("runs array").len(), 1);
+    assert_eq!(rows[0]["run_id"], json!(running.run_id));
+
+    let response = request_job_runs(runtime.clone(), "state=terminal&limit=10").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let rows = body_json(response).await;
+    let states = rows
+        .as_array()
+        .expect("runs array")
+        .iter()
+        .map(|run| run["state"].as_str().expect("state"))
+        .collect::<Vec<_>>();
+    for state in ["success", "failed", "cancelled", "interrupted", "timeout"] {
+        assert!(states.contains(&state), "missing terminal state {state}");
+    }
+
+    let since = since.to_rfc3339().replace('+', "%2B");
+    let response = request_job_runs(
+        runtime.clone(),
+        &format!("job_id=job_runs_filter&state=terminal&since={since}&limit=10"),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let rows = body_json(response).await;
+    let run_ids = rows
+        .as_array()
+        .expect("runs array")
+        .iter()
+        .map(|run| run["run_id"].as_str().expect("run id"))
+        .collect::<Vec<_>>();
+    assert!(!run_ids.contains(&old_terminal.run_id.as_str()));
+    assert!(!run_ids.contains(&"jrun-job-runs-terminal-other-job"));
+
+    let response = request_job_runs(runtime, "state=unknown").await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let error = body_json(response).await;
+    assert_eq!(
+        error["error"],
+        json!("invalid state; expected one of: pending, running, terminal")
+    );
 }
 
 #[tokio::test]

--- a/crates/orbit-store/src/backend/contracts.rs
+++ b/crates/orbit-store/src/backend/contracts.rs
@@ -346,6 +346,9 @@ pub struct TaskReservationOwnedConflictsResult {
 pub struct JobRunQuery {
     pub job_id: Option<String>,
     pub state: Option<JobRunState>,
+    /// Whether to include only states for which `JobRunState::is_terminal()`
+    /// returns true. Applied before ordering and limiting.
+    pub terminal_only: bool,
     pub created_since: Option<DateTime<Utc>>,
     pub limit: Option<usize>,
 }

--- a/crates/orbit-store/src/file/job_store/api.rs
+++ b/crates/orbit-store/src/file/job_store/api.rs
@@ -42,6 +42,9 @@ impl JobFileStore {
         if let Some(state) = query.state {
             runs.retain(|run| run.state == state);
         }
+        if query.terminal_only {
+            runs.retain(|run| run.state.is_terminal());
+        }
         if let Some(created_since) = query.created_since {
             runs.retain(|run| run.created_at >= created_since);
         }

--- a/crates/orbit-store/src/sqlite/job_run_store/mod.rs
+++ b/crates/orbit-store/src/sqlite/job_run_store/mod.rs
@@ -448,6 +448,11 @@ impl Store {
             conditions.push(format!("state = ?{}", params.len() + 1));
             params.push(Box::new(state.to_string()));
         }
+        if query.terminal_only {
+            conditions.push(
+                "state IN ('success', 'failed', 'timeout', 'cancelled', 'interrupted')".to_string(),
+            );
+        }
         if let Some(created_since) = query.created_since {
             conditions.push(format!("created_at >= ?{}", params.len() + 1));
             params.push(Box::new(created_since.to_rfc3339()));


### PR DESCRIPTION
## Rescue of stranded, already-validated work

This PR carries work that was implemented and validated in run `jrun-20260725-1656-3`
(crew `terra`) but never reached a branch on origin. It is **not** a re-implementation —
the diff is the run's own output, recovered verbatim from its worktree and rebased onto
current `agent-main`.

### Why it was stranded

The run's implement step succeeded and its execution summary records `Outcome: success`.
The deterministic `git_commit` step then failed with:

```
commit_batch_changes: no staged changes to commit for task 'ORB-10377' ...
the implement step produced an empty diff
```

The diff was not empty. Root cause is recorded in **ORB-10380**: `existing_batch_commits()`
re-resolves `base_ref` (`origin/agent-main` — a moving name) at commit time. A merge to
`agent-main` mid-run makes the recorded base a non-ancestor, and the failed ancestor check
raises the misleading empty-diff error **before** `git add --all` ever runs. The work
survives intact in the worktree; only the commit is lost. Sibling tasks from the same wave
were recovered the same way in #696, #697, #698.

### The change

Fix for **F2026-07-111** (orbit's half). `GET /api/job-runs` extracted only `LimitQuery`
and hardcoded `job_id`, `state`, and `since` to `None`, so it returned the N most recent
runs unconditionally — forcing Bridge's `workflow_run_list` to post-filter client-side over
an already-truncated window, which silently under-reports.

- New job-run-specific `JobRunListQuery` extractor for optional `limit`, `job_id`, `state`,
  and RFC 3339 `since`; the shared `LimitQuery` is left unchanged rather than widened.
- `state` accepts `pending`, `running`, `terminal`; anything else is a JSON 400 naming the
  accepted values.
- `terminal` was inexpressible as one correctly limited query (`state` is an
  `Option<JobRunState>` exact-equality filter), so a separate `terminal_only` flag is
  threaded through the core/store boundary. Both the SQLite and file stores apply it before
  ordering and `limit`. Existing concrete-state callers keep `terminal_only: false`.
- Endpoint coverage includes the case the old handler failed: terminal rows ahead of a live
  running row at `limit=1`.

All three filters stay optional; omitting them preserves current behaviour exactly.

### Validation

Recorded by the implementing run: `cargo fmt --check`, `cargo test -p orbit-dashboard`,
`cargo clippy --workspace --all-targets -- -D warnings`, `make ci`.

Re-verified during the rescue, after rebasing onto `agent-main` (`b17d8d2c`):

- `make ci-fast` — clean
- `git diff --check` — clean
- `cargo test -p orbit-dashboard` — **198 passed, 0 failed**

Rebase was textually clean: diff-of-diffs against the pre-rebase patch differs only in a
blob-hash line and one hunk offset (`catalog.rs`, +4 lines); every added and removed content
line is byte-identical.

No ADRs and no learning records are included in this diff.

**Do not merge without Daniel's review** — this is a rescue, not an approval.
