### PR TITLE
Repoint `orbit gc worktrees` onto the task-status gate [ORB-10378]

### DIFF
--- a/crates/orbit-cli/src/command/gc.rs
+++ b/crates/orbit-cli/src/command/gc.rs
@@ -22,7 +22,7 @@ impl Execute for GcCommand {
 /// or execution contract.
 #[derive(Subcommand)]
 pub enum GcTarget {
-    /// Reap clean, finished, merged-or-closed job-run worktrees
+    /// Reap job-run worktrees whose associated task has settled to rejected, archived, or done
     Worktrees(WorktreeGcArgs),
 }
 
@@ -76,7 +76,7 @@ impl Execute for WorktreeGcArgs {
         }
         for report in &result.reports {
             println!(
-                "path={} run_id={} run_state={} action={} bytes_reclaimed={}",
+                "path={} run_id={} run_state={} task_id={} task_status={} pr_status={} action={} bytes_reclaimed={}",
                 report.path.display(),
                 report.run_id.as_deref().unwrap_or("-"),
                 report
@@ -84,6 +84,13 @@ impl Execute for WorktreeGcArgs {
                     .map(|state| state.to_string())
                     .as_deref()
                     .unwrap_or("-"),
+                report.task_id.as_deref().unwrap_or("-"),
+                report
+                    .task_status
+                    .map(|status| status.to_string())
+                    .as_deref()
+                    .unwrap_or("-"),
+                report.pr_status.as_deref().unwrap_or("-"),
                 report.action,
                 report.bytes_reclaimed
             );

--- a/crates/orbit-core/assets/activities/worktree_gc.yaml
+++ b/crates/orbit-core/assets/activities/worktree_gc.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   type: deterministic
   description: >
-    Reap clean worktrees belonging to terminal job runs after confirming that
-    their branches are merged or their pull requests are closed. Unknown and
-    dirty worktrees are always retained and reported.
+    Reap worktrees whose associated task has settled to rejected, archived,
+    or done. A run that is not yet terminal, has no resolvable associated
+    task, or still has a dirty tree is always retained and reported.
   input_schema_json:
     type: object
     properties:
@@ -28,6 +28,7 @@ spec:
         type: array
         items:
           type: object
-          required: [path, run_id, run_state, action, bytes_reclaimed]
+          required:
+            [path, run_id, run_state, task_id, task_status, action, bytes_reclaimed]
   action: worktree_gc
   config: {}

--- a/crates/orbit-core/assets/routines/worktree_gc.yaml
+++ b/crates/orbit-core/assets/routines/worktree_gc.yaml
@@ -3,8 +3,8 @@
 schemaVersion: 1
 name: __ORBIT_ROUTINE_NAME__
 description: >
-  Hourly reclamation of clean worktrees from terminal job runs whose branch is
-  merged or whose pull request is closed.
+  Hourly reclamation of worktrees whose associated task has settled to
+  rejected, archived, or done.
 enabled: false
 hosts:
   - __ORBIT_HOST_ID__

--- a/crates/orbit-core/src/command/gc.rs
+++ b/crates/orbit-core/src/command/gc.rs
@@ -26,6 +26,7 @@ impl OrbitRuntime {
         collect_worktrees(
             &self.paths().repo_root,
             &runs,
+            self,
             &WorktreeGcOptions {
                 delete,
                 run_id,

--- a/crates/orbit-engine/src/executor/automation/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/mod.rs
@@ -198,6 +198,7 @@ pub fn execute_action<
             let result = vcs::collect_worktrees(
                 std::path::Path::new(&repo_root),
                 &runs,
+                host,
                 &vcs::WorktreeGcOptions {
                     delete: true,
                     run_id: input

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/gc.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/gc.rs
@@ -4,14 +4,27 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use chrono::{DateTime, Utc};
-use orbit_common::types::{JobRun, JobRunState, OrbitError};
+use orbit_common::types::{JobRun, JobRunState, OrbitError, TaskStatus};
 use serde::Serialize;
 use serde_json::Value;
+
+use crate::context::TaskReadHost;
 
 use super::cleanup::remove_worktree;
 use super::{resolve_shared_worktree_path, resolve_worktree_path_from_prefix};
 
 const DEFAULT_BRANCH_PREFIX: &str = "orbit";
+
+/// Task statuses that settle the work as done — the only statuses that
+/// license discarding a run's worktree and branch. Every other status
+/// (including `blocked` and `review`) retains it, and an unresolvable or
+/// missing task_id retains it as well: the collector fails closed.
+fn task_status_permits_deletion(status: TaskStatus) -> bool {
+    matches!(
+        status,
+        TaskStatus::Rejected | TaskStatus::Archived | TaskStatus::Done
+    )
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct WorktreeGcOptions {
@@ -25,6 +38,9 @@ pub struct WorktreeGcReport {
     pub path: PathBuf,
     pub run_id: Option<String>,
     pub run_state: Option<JobRunState>,
+    pub task_id: Option<String>,
+    pub task_status: Option<TaskStatus>,
+    pub pr_status: Option<String>,
     pub action: String,
     pub bytes_reclaimed: u64,
 }
@@ -36,9 +52,10 @@ pub struct WorktreeGcResult {
     pub reports: Vec<WorktreeGcReport>,
 }
 
-pub fn collect_worktrees(
+pub fn collect_worktrees<H: TaskReadHost + ?Sized>(
     repo_root: &Path,
     runs: &[JobRun],
+    task_host: &H,
     options: &WorktreeGcOptions,
 ) -> Result<WorktreeGcResult, OrbitError> {
     let mut known_paths = BTreeMap::<PathBuf, Vec<&JobRun>>::new();
@@ -70,12 +87,21 @@ pub fn collect_worktrees(
                 path: path.clone(),
                 run_id: Some(run.run_id.clone()),
                 run_state: Some(run.state),
+                task_id: None,
+                task_status: None,
+                pr_status: None,
                 action: "skipped:ambiguous_run_path".to_string(),
                 bytes_reclaimed: 0,
             }));
             continue;
         }
-        reports.push(classify_known(repo_root, path, selected_runs[0], options)?);
+        reports.push(classify_known(
+            repo_root,
+            path,
+            selected_runs[0],
+            task_host,
+            options,
+        )?);
     }
 
     if options.run_id.is_none() {
@@ -86,6 +112,9 @@ pub fn collect_worktrees(
                     path: entry,
                     run_id: None,
                     run_state: None,
+                    task_id: None,
+                    task_status: None,
+                    pr_status: None,
                     action: "skipped:unrecognized".to_string(),
                     bytes_reclaimed: 0,
                 });
@@ -106,19 +135,32 @@ pub fn collect_worktrees(
     })
 }
 
-fn classify_known(
+fn classify_known<H: TaskReadHost + ?Sized>(
     repo_root: &Path,
     path: &Path,
     run: &JobRun,
+    task_host: &H,
     options: &WorktreeGcOptions,
 ) -> Result<WorktreeGcReport, OrbitError> {
+    let task_id =
+        string_field(run.input.as_ref().unwrap_or(&Value::Null), "task_id").map(ToOwned::to_owned);
+    let task = task_id
+        .as_deref()
+        .and_then(|task_id| task_host.get_task(task_id).ok());
+
     let mut report = WorktreeGcReport {
         path: path.to_path_buf(),
         run_id: Some(run.run_id.clone()),
         run_state: Some(run.state),
+        task_id: task_id.clone(),
+        task_status: task.as_ref().map(|task| task.status),
+        pr_status: task.as_ref().and_then(|task| task.pr_status.clone()),
         action: String::new(),
         bytes_reclaimed: 0,
     };
+
+    // Secondary gate: never disturb a worktree that may still back a live
+    // process, regardless of what the associated task's status says.
     if !run.state.is_terminal() {
         report.action = "skipped:run_not_terminal".to_string();
         return Ok(report);
@@ -144,6 +186,27 @@ fn classify_known(
         report.action = "skipped:not_registered_worktree".to_string();
         return Ok(report);
     }
+
+    // Primary gate: only a task settled to rejected, archived, or done
+    // licenses deletion. A run's process finishing says nothing about
+    // whether the work it produced is settled — a run with no associated
+    // task, or one whose task can't be resolved, is retained rather than
+    // treated as eligible.
+    if task_id.is_none() {
+        report.action = "skipped:unattributed".to_string();
+        return Ok(report);
+    }
+    let Some(status) = report.task_status else {
+        report.action = "skipped:task_unresolved".to_string();
+        return Ok(report);
+    };
+    if !task_status_permits_deletion(status) {
+        report.action = "skipped:task_status_ineligible".to_string();
+        return Ok(report);
+    }
+
+    // Reported safety net, not a deletion gate: a task can be settled with
+    // uncommitted content still sitting in the worktree.
     if !git_output(path, &["status", "--porcelain", "--untracked-files=all"])?
         .trim()
         .is_empty()
@@ -159,10 +222,6 @@ fn classify_known(
             return Ok(report);
         }
     };
-    if !branch_is_merged(repo_root, &branch) && !branch_pr_is_closed(repo_root, &branch) {
-        report.action = "skipped:branch_not_merged_or_pr_closed".to_string();
-        return Ok(report);
-    }
 
     let estimated_bytes = directory_bytes(path)?;
     if !options.delete {
@@ -254,28 +313,6 @@ fn is_registered_worktree(repo_root: &Path, path: &Path) -> Result<bool, OrbitEr
         .lines()
         .filter_map(|line| line.strip_prefix("worktree "))
         .any(|registered| registered == expected))
-}
-
-fn branch_is_merged(repo_root: &Path, branch: &str) -> bool {
-    Command::new("git")
-        .current_dir(repo_root)
-        .args(["merge-base", "--is-ancestor", branch, "HEAD"])
-        .status()
-        .is_ok_and(|status| status.success())
-}
-
-fn branch_pr_is_closed(repo_root: &Path, branch: &str) -> bool {
-    let output = Command::new("gh")
-        .current_dir(repo_root)
-        .args([
-            "pr", "list", "--head", branch, "--state", "closed", "--limit", "1", "--json", "number",
-        ])
-        .output();
-    output
-        .ok()
-        .filter(|output| output.status.success())
-        .and_then(|output| serde_json::from_slice::<Vec<Value>>(&output.stdout).ok())
-        .is_some_and(|items| !items.is_empty())
 }
 
 fn branch_exists(repo_root: &Path, branch: &str) -> bool {

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/gc.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/gc.rs
@@ -1,19 +1,93 @@
 #![allow(missing_docs)]
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Mutex;
 
 use chrono::Utc;
-use orbit_common::types::{JobRun, JobRunState};
+use orbit_common::types::{
+    ExternalRef, JobRun, JobRunState, NotFoundKind, OrbitError, Task, TaskArtifact, TaskPriority,
+    TaskStatus, TaskType,
+};
 use serde_json::json;
 use tempfile::tempdir;
 
+use crate::context::TaskReadHost;
+
 use super::super::gc::{WorktreeGcOptions, collect_worktrees};
-use super::super::resolve_worktree_path_from_prefix;
+use super::super::{resolve_shared_worktree_path, resolve_worktree_path_from_prefix};
 
 static WORKTREE_ROOT_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+struct FakeTaskHost {
+    tasks: BTreeMap<String, Task>,
+}
+
+impl FakeTaskHost {
+    fn new(tasks: Vec<Task>) -> Self {
+        Self {
+            tasks: tasks
+                .into_iter()
+                .map(|task| (task.id.clone(), task))
+                .collect(),
+        }
+    }
+}
+
+impl TaskReadHost for FakeTaskHost {
+    fn get_task(&self, task_id: &str) -> Result<Task, OrbitError> {
+        self.tasks
+            .get(task_id)
+            .cloned()
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, task_id.to_string()))
+    }
+
+    fn get_task_artifacts(&self, _task_id: &str) -> Result<Vec<TaskArtifact>, OrbitError> {
+        Ok(Vec::new())
+    }
+
+    fn list_tasks_filtered(
+        &self,
+        _status: Option<TaskStatus>,
+        _priority: Option<TaskPriority>,
+        _parent_id: Option<&str>,
+        _job_run_id: Option<&str>,
+        _external_ref: Option<&ExternalRef>,
+        _has_external_ref_system: Option<&str>,
+    ) -> Result<Vec<Task>, OrbitError> {
+        Ok(self.tasks.values().cloned().collect())
+    }
+}
+
+fn task_fixture(id: &str, status: TaskStatus) -> Task {
+    let now = Utc::now();
+    Task {
+        id: id.to_string(),
+        title: "fixture task".to_string(),
+        description: String::new(),
+        acceptance_criteria: Vec::new(),
+        tags: Vec::new(),
+        plan: String::new(),
+        execution_summary: String::new(),
+        context_files: Vec::new(),
+        created_by: None,
+        planned_by: None,
+        implemented_by: None,
+        status,
+        priority: TaskPriority::Medium,
+        complexity: None,
+        task_type: TaskType::Chore,
+        pr_status: None,
+        external_refs: Vec::new(),
+        relations: Vec::new(),
+        job_run_id: None,
+        crew: None,
+        created_at: now,
+        updated_at: now,
+    }
+}
 
 #[test]
 fn unrecognized_hand_made_worktree_survives_collection() {
@@ -26,9 +100,11 @@ fn unrecognized_hand_made_worktree_survives_collection() {
     fs::create_dir_all(&hand_made).unwrap();
     fs::write(hand_made.join("rescue.txt"), "keep me").unwrap();
 
+    let host = FakeTaskHost::new(Vec::new());
     let result = collect_worktrees(
         &repo,
         &[],
+        &host,
         &WorktreeGcOptions {
             delete: true,
             ..Default::default()
@@ -51,14 +127,16 @@ fn terminal_dirty_worktree_is_a_rescue_candidate() {
     let temp = tempdir().unwrap();
     let repo = temp.path().join("repo");
     init_repo(&repo);
-    let run = run("jrun-dirty", JobRunState::Failed);
+    let run = run("jrun-dirty", JobRunState::Failed, Some("ORB-DIRTY"));
     let worktree = resolved_task_worktree(&repo, &run);
     add_worktree(&repo, &worktree, "orbit/dirty");
     fs::write(worktree.join("uncommitted.txt"), "valuable").unwrap();
+    let host = FakeTaskHost::new(vec![task_fixture("ORB-DIRTY", TaskStatus::Done)]);
 
     let result = collect_worktrees(
         &repo,
         &[run],
+        &host,
         &WorktreeGcOptions {
             delete: true,
             ..Default::default()
@@ -69,6 +147,7 @@ fn terminal_dirty_worktree_is_a_rescue_candidate() {
     assert!(worktree.exists());
     assert_eq!(result.reports[0].action, "skipped:dirty_rescue_candidate");
     assert_eq!(result.reports[0].bytes_reclaimed, 0);
+    assert_eq!(result.reports[0].task_status, Some(TaskStatus::Done));
 }
 
 #[test]
@@ -76,26 +155,29 @@ fn dry_run_and_yes_share_eligibility_but_only_yes_removes() {
     let temp = tempdir().unwrap();
     let repo = temp.path().join("repo");
     init_repo(&repo);
-    let run = run("jrun-clean", JobRunState::Success);
+    let run = run("jrun-clean", JobRunState::Success, Some("ORB-CLEAN"));
     let worktree = resolved_task_worktree(&repo, &run);
     add_worktree(&repo, &worktree, "orbit/clean");
     fs::write(worktree.join("bytes.bin"), [1_u8; 32]).unwrap();
     git(&worktree, &["add", "bytes.bin"]);
     git(&worktree, &["commit", "-m", "worktree content"]);
-    git(&repo, &["merge", "--ff-only", "orbit/clean"]);
+    let host = FakeTaskHost::new(vec![task_fixture("ORB-CLEAN", TaskStatus::Done)]);
 
     let dry = collect_worktrees(
         &repo,
         std::slice::from_ref(&run),
+        &host,
         &WorktreeGcOptions::default(),
     )
     .unwrap();
     assert!(worktree.exists());
     assert_eq!(dry.reports[0].action, "would_remove");
+    assert_eq!(dry.reports[0].task_id.as_deref(), Some("ORB-CLEAN"));
 
     let applied = collect_worktrees(
         &repo,
         &[run],
+        &host,
         &WorktreeGcOptions {
             delete: true,
             ..Default::default()
@@ -112,15 +194,25 @@ fn colliding_sanitized_run_ids_are_ambiguous_and_never_removed() {
     let temp = tempdir().unwrap();
     let repo = temp.path().join("repo");
     init_repo(&repo);
-    let first = run("jrun:collision", JobRunState::Success);
-    let second = run("jrun-collision", JobRunState::Success);
+    let first = run(
+        "jrun:collision",
+        JobRunState::Success,
+        Some("ORB-COLLISION"),
+    );
+    let second = run(
+        "jrun-collision",
+        JobRunState::Success,
+        Some("ORB-COLLISION"),
+    );
     let worktree = resolved_task_worktree(&repo, &first);
     assert_eq!(worktree, resolved_task_worktree(&repo, &second));
     add_worktree(&repo, &worktree, "orbit/collision");
+    let host = FakeTaskHost::new(vec![task_fixture("ORB-COLLISION", TaskStatus::Done)]);
 
     let result = collect_worktrees(
         &repo,
         &[first, second],
+        &host,
         &WorktreeGcOptions {
             delete: true,
             ..Default::default()
@@ -136,6 +228,86 @@ fn colliding_sanitized_run_ids_are_ambiguous_and_never_removed() {
             .iter()
             .all(|report| report.action == "skipped:ambiguous_run_path")
     );
+}
+
+#[test]
+fn terminal_run_with_blocked_task_is_retained() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo);
+    let run = run("jrun-blocked", JobRunState::Success, Some("ORB-BLOCKED"));
+    let worktree = resolved_task_worktree(&repo, &run);
+    add_worktree(&repo, &worktree, "orbit/blocked");
+    let host = FakeTaskHost::new(vec![task_fixture("ORB-BLOCKED", TaskStatus::Blocked)]);
+
+    let result = collect_worktrees(
+        &repo,
+        &[run],
+        &host,
+        &WorktreeGcOptions {
+            delete: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(worktree.exists());
+    assert_eq!(result.reports[0].action, "skipped:task_status_ineligible");
+    assert_eq!(result.reports[0].task_id.as_deref(), Some("ORB-BLOCKED"));
+    assert_eq!(result.reports[0].task_status, Some(TaskStatus::Blocked));
+}
+
+#[test]
+fn terminal_run_with_review_task_is_retained() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo);
+    let run = run("jrun-review", JobRunState::Success, Some("ORB-REVIEW"));
+    let worktree = resolved_task_worktree(&repo, &run);
+    add_worktree(&repo, &worktree, "orbit/review");
+    let host = FakeTaskHost::new(vec![task_fixture("ORB-REVIEW", TaskStatus::Review)]);
+
+    let result = collect_worktrees(
+        &repo,
+        &[run],
+        &host,
+        &WorktreeGcOptions {
+            delete: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(worktree.exists());
+    assert_eq!(result.reports[0].action, "skipped:task_status_ineligible");
+    assert_eq!(result.reports[0].task_status, Some(TaskStatus::Review));
+}
+
+#[test]
+fn unattributed_run_is_retained_and_reported() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo);
+    let run = run("jrun-unattributed", JobRunState::Success, None);
+    let worktree = resolve_shared_worktree_path(&repo, &run.run_id).unwrap();
+    add_worktree(&repo, &worktree, "orbit/unattributed");
+    let host = FakeTaskHost::new(Vec::new());
+
+    let result = collect_worktrees(
+        &repo,
+        &[run],
+        &host,
+        &WorktreeGcOptions {
+            delete: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(worktree.exists());
+    assert_eq!(result.reports[0].action, "skipped:unattributed");
+    assert_eq!(result.reports[0].task_id, None);
+    assert_eq!(result.reports[0].task_status, None);
 }
 
 #[test]
@@ -167,7 +339,7 @@ fn resolver_uses_external_root_and_repository_name_when_configured() {
     restore_worktree_root(old);
 }
 
-fn run(id: &str, state: JobRunState) -> JobRun {
+fn run(id: &str, state: JobRunState, task_id: Option<&str>) -> JobRun {
     let now = Utc::now();
     JobRun {
         run_id: id.to_string(),
@@ -181,7 +353,10 @@ fn run(id: &str, state: JobRunState) -> JobRun {
         created_at: now,
         pid: None,
         pid_start_time: None,
-        input: Some(json!({"task_id": "ORB-10374"})),
+        input: Some(match task_id {
+            Some(task_id) => json!({"task_id": task_id}),
+            None => json!({}),
+        }),
         retry_source_run_id: None,
         knowledge_metrics: None,
         resolved_crew: None,


### PR DESCRIPTION
## Rescue of stranded, already-validated work

This PR carries work implemented and validated in run `jrun-20260725-1700-4` (crew
`sonnet`) that never reached a branch on origin. It is **not** a re-implementation — the
diff is the run's own output, recovered verbatim from its worktree and rebased onto current
`agent-main`.

### Why it was stranded

The implement step succeeded; the deterministic `git_commit` step then failed with:

```
commit_batch_changes: no staged changes to commit for task 'ORB-10378' ...
the implement step produced an empty diff
```

The diff was not empty. Root cause is recorded in **ORB-10380**: `existing_batch_commits()`
re-resolves `base_ref` (`origin/agent-main` — a moving name) at commit time. A merge to
`agent-main` mid-run makes the recorded base a non-ancestor, and the failed ancestor check
raises the misleading empty-diff error **before** `git add --all` ever runs. Sibling tasks
from the same wave were recovered the same way in #696, #697, #698.

There is a certain symmetry here: this is the exact scenario the change itself protects
against. ORB-10369's worktree — terminal run, validated work, task `blocked` — survived the
old gate only because it happened to be dirty.

### The change

Follow-up to ORB-10374 (#695). The command, collector, reports, job, activity, routine
asset, and tests all landed and are sound. **One predicate changes.**

Run state says whether a *process* finished; task status says whether the *work* is settled.
Only the second licenses deletion.

- **Primary gate is now task status.** `collect_worktrees`/`classify_known` take a
  `&dyn TaskReadHost`-bound host and resolve each run's task via its `task_id` input field.
  Deletion is licensed only for `rejected`, `archived`, `done`. Every other status —
  including `blocked` and `review` — retains the worktree, as do a missing task_id
  (`skipped:unattributed`) and an unresolvable one (`skipped:task_unresolved`). The collector
  fails closed; "not in the permitted set" is never read as licence to delete.
- **Terminal-run demoted to a secondary gate**, kept for a different reason: don't disturb a
  live process.
- **`dirty_rescue_candidate` preserved exactly as merged**, demoted from gate to reported
  safety net — a task can be settled with uncommitted content still present.
- **The merged-or-closed PR gate is deleted entirely**: `branch_is_merged`,
  `branch_pr_is_closed`, the `gh pr list` subprocess, and the fail-closed branch. Task status
  subsumes all of it. A net simplification that drops a network dependency from a command
  operators run during incidents, when `gh` may be exactly what is not working. `pr_status`
  is still reported, from the already-fetched task rather than queried.
- `WorktreeGcReport` gains `task_id`, `task_status`, `pr_status`, surfaced in both `--json`
  and the human-readable CLI line.
- Both call sites updated with no new cross-crate edges: `orbit-core` passes `self`
  (`OrbitRuntime` already implements `TaskReadHost`); the `WORKTREE_GC_ACTION` handler passes
  its existing `host` (`TaskHost` is a supertrait of `TaskReadHost`).
- Activity and routine assets re-described against the task-status gate;
  `task_id`/`task_status` added to the activity's `output_schema_json` required list.

No regression in: sanitized-run-id collision fail-closed handling; detached/unregistered/
symlinked/ambiguous retention with reasons; never parsing directory names as run ids;
non-forcing `git worktree remove` + `git worktree prune`; no raw recursive deletion; dry-run
default; disabled seeded routine with `policy.overlap: forbid`. Still no free-space check,
dispatch precondition, or `builds` target.

### Validation

Recorded by the implementing run: `cargo build`/`cargo test` across orbit-engine/orbit-core/
orbit-cli, `cargo clippy --workspace --all-targets -- -D warnings`, and `make ci-fast`.
`make ci` was **not** run in that run — the sandbox denied it — so **`make ci` on this PR
gate is the first full run**, which is the intended gate for this repo.

Re-verified during the rescue, after rebasing onto `agent-main` (`b17d8d2c`):

- `cargo test -p orbit-engine worktree::tests::gc` — **9 passed, 0 failed**, including the
  three new cases (blocked-task retained, review-task retained, unattributed retained)
- `cargo test -p orbit-engine -p orbit-core -p orbit-cli` — green
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (this is the check that
  matters most post-rebase: #696 altered the `RuntimeHost` trait in the same crate)
- `make ci-fast` — clean; `git diff --check` — clean

Rebase was byte-for-byte clean: the post-rebase patch is identical to the pre-rebase patch.

#### One flaky test, pre-existing and unrelated

`orbit-core`'s `runtime::engine::tests::task_host::direct_update_task_keeps_default_human_
attribution` failed intermittently (6 failures, then 1, then 0 across runs) with
`left: "grok-build", right: "human"`.

This is an intra-binary environment race that predates this branch and is untouched by it:
`crates/orbit-core/src/command/tool.rs` tests mutate the process-global `ORBIT_AGENT_MODEL`/
`ORBIT_AGENT_NAME` under a mutex that serializes only *among themselves*, while
`ActorIdentity::from_env()` readers in other modules take no such guard. This branch modifies
none of those files. Serialized, `cargo test -p orbit-core --lib -- --test-threads=1` is
**600 passed, 0 failed**, and the test passes in isolation 3/3. Flagging it rather than
fixing it — out of scope for a rescue, and worth its own task.

No ADRs and no learning records are included in this diff.

**Do not merge without Daniel's review** — this is a rescue, not an approval.
