### PR TITLE
Remove orbit.learning writes from executor activities; redirect the learning checkpoint to frictions

### DIFF
--- a/.orbit/resources/activities/agent_implement.yaml
+++ b/.orbit/resources/activities/agent_implement.yaml
@@ -31,14 +31,18 @@ spec:
     You are implementing an Orbit task from plan to validated code.
 
     Tool access: whenever an instruction below says to call an `orbit.*` tool
-    (e.g. `orbit.task.update`, `orbit.task.show`, `orbit.search`), use that tool
-    when it is present in your tool surface. When it is NOT — some executors run
-    without the Orbit MCP tools wired in — run the equivalent Orbit CLI in the
-    terminal instead: `orbit tool run <tool.name> --input '<json>'` (use
-    `--input-file <path>` for large or multi-line values). State you persist
-    through Orbit (via the MCP tool OR the CLI) is durable; the structured
-    result object you return at the end is NOT persisted, so never treat it as
-    the system of record.
+    that is present in this activity's `tools:` allowlist (e.g. `orbit.task.update`,
+    `orbit.task.show`, `orbit.search`), use that tool when it is present in your
+    tool surface. When it is NOT wired into your tool surface — some executors
+    run without the Orbit MCP tools wired in — run the equivalent Orbit CLI in
+    the terminal instead: `orbit tool run <tool.name> --input '<json>'` (use
+    `--input-file <path>` for large or multi-line values). Only do this for a
+    tool this activity actually grants; the CLI routes through the same runtime
+    gates as the MCP tool, so falling back to the CLI for a tool outside your
+    allowlist (or one the runtime gates by caller role, like the `orbit.learning.*`
+    writes) just trades one refusal for another. State you persist through Orbit
+    (via the MCP tool OR the CLI) is durable; the structured result object you
+    return at the end is NOT persisted, so never treat it as the system of record.
 
     1. Start with the injected `task` object when present. Treat it as the
        authoritative task context for title, description, acceptance criteria,
@@ -112,13 +116,15 @@ spec:
         reason) rather than leaving it silently in `in-progress`. This is
         distinct from item 10: a blocker means the work cannot be completed, not
         merely that a check could not run in this environment.
-    12. Before handoff, run the learning checkpoint: if this task surfaced a
+    12. Before handoff, run the friction checkpoint: if this task surfaced a
         contradicted assumption, recurring failure mode, non-obvious gotcha that
-        took more than 10 minutes to debug, or incident-style root cause, follow
-        the `orbit-knowledge` skill and call the `add` action on
-        `orbit.learning` (or use that skill's update/supersede flow when it
-        points to existing guidance).
-        Skip if none apply.
+        took more than 10 minutes to debug, or incident-style root cause, file
+        it with `orbit.friction.add`, describing what happened and the evidence
+        behind it. Project learnings are authored by the orchestrator or by
+        Daniel, not by task executors — the runtime gate (ADR-0250) refuses
+        `orbit.learning.add`/`update`/`supersede` calls made from executor
+        context, so attempting one here is a wasted call, not a judgment call.
+        Skip if none of the trigger conditions apply.
     13. The task is already in `in-progress` status when this activity fires
         (the engine performed workflow admission via `admit_task_for_workflow`
         during worktree setup, before dispatching the implement step). Do **not**
@@ -145,9 +151,6 @@ spec:
     - orbit.friction.*
     - orbit.search
     - orbit.learning.show
-    - orbit.learning.add
-    - orbit.learning.update
-    - orbit.learning.supersede
     - fs.read
     - fs.delete
     - proc.spawn

--- a/.orbit/resources/activities/agent_review.yaml
+++ b/.orbit/resources/activities/agent_review.yaml
@@ -76,13 +76,15 @@ spec:
        acceptance-criteria miss, obvious regression — note the most relevant
        task, file, and line in your verdict response. Cite `path:line` when the
        issue is file-specific. Skip stylistic nits.
-    4. Before stopping, run the learning checkpoint: if this review surfaced a
+    4. Before stopping, run the friction checkpoint: if this review surfaced a
        contradicted assumption, recurring failure mode, non-obvious gotcha that
-       took more than 10 minutes to debug, or incident-style root cause, follow
-       the `orbit-knowledge` skill and call the `add` action on
-       `orbit.learning` (or use that skill's update/supersede flow when it
-       points to existing guidance).
-       Skip if none apply.
+       took more than 10 minutes to debug, or incident-style root cause, file
+       it with `orbit.friction.add`, describing what happened and the evidence
+       behind it. Project learnings are authored by the orchestrator or by
+       Daniel, not by task executors — the runtime gate (ADR-0250) refuses
+       `orbit.learning.add`/`update`/`supersede` calls made from executor
+       context, so attempting one here is a wasted call, not a judgment call.
+       Skip if none of the trigger conditions apply.
     5. Return exactly one Orbit response envelope. Use status `success`, set
        `result.verdict` to `approve` only when no blocking issue remains, or
        `request_changes` when at least one blocking issue remains, and set
@@ -91,11 +93,9 @@ spec:
        {"schemaVersion":1,"status":"success","result":{"verdict":"approve|request_changes","reviewed_head_sha":"<sha>"},"error":null}
   tools:
     - orbit.task.show
+    - orbit.friction.add
     - orbit.search
     - orbit.learning.show
-    - orbit.learning.add
-    - orbit.learning.update
-    - orbit.learning.supersede
     - fs.read
     - proc.spawn
   proc_allowed_programs:

--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -31,14 +31,18 @@ spec:
     You are implementing an Orbit task from plan to validated code.
 
     Tool access: whenever an instruction below says to call an `orbit.*` tool
-    (e.g. `orbit.task.update`, `orbit.task.show`, `orbit.search`), use that tool
-    when it is present in your tool surface. When it is NOT — some executors run
-    without the Orbit MCP tools wired in — run the equivalent Orbit CLI in the
-    terminal instead: `orbit tool run <tool.name> --input '<json>'` (use
-    `--input-file <path>` for large or multi-line values). State you persist
-    through Orbit (via the MCP tool OR the CLI) is durable; the structured
-    result object you return at the end is NOT persisted, so never treat it as
-    the system of record.
+    that is present in this activity's `tools:` allowlist (e.g. `orbit.task.update`,
+    `orbit.task.show`, `orbit.search`), use that tool when it is present in your
+    tool surface. When it is NOT wired into your tool surface — some executors
+    run without the Orbit MCP tools wired in — run the equivalent Orbit CLI in
+    the terminal instead: `orbit tool run <tool.name> --input '<json>'` (use
+    `--input-file <path>` for large or multi-line values). Only do this for a
+    tool this activity actually grants; the CLI routes through the same runtime
+    gates as the MCP tool, so falling back to the CLI for a tool outside your
+    allowlist (or one the runtime gates by caller role, like the `orbit.learning.*`
+    writes) just trades one refusal for another. State you persist through Orbit
+    (via the MCP tool OR the CLI) is durable; the structured result object you
+    return at the end is NOT persisted, so never treat it as the system of record.
 
     1. Start with the injected `task` object when present. Treat it as the
        authoritative task context for title, description, acceptance criteria,
@@ -112,13 +116,15 @@ spec:
         reason) rather than leaving it silently in `in-progress`. This is
         distinct from item 10: a blocker means the work cannot be completed, not
         merely that a check could not run in this environment.
-    12. Before handoff, run the learning checkpoint: if this task surfaced a
+    12. Before handoff, run the friction checkpoint: if this task surfaced a
         contradicted assumption, recurring failure mode, non-obvious gotcha that
-        took more than 10 minutes to debug, or incident-style root cause, follow
-        the `orbit-knowledge` skill and call the `add` action on
-        `orbit.learning` (or use that skill's update/supersede flow when it
-        points to existing guidance).
-        Skip if none apply.
+        took more than 10 minutes to debug, or incident-style root cause, file
+        it with `orbit.friction.add`, describing what happened and the evidence
+        behind it. Project learnings are authored by the orchestrator or by
+        Daniel, not by task executors — the runtime gate (ADR-0250) refuses
+        `orbit.learning.add`/`update`/`supersede` calls made from executor
+        context, so attempting one here is a wasted call, not a judgment call.
+        Skip if none of the trigger conditions apply.
     13. The task is already in `in-progress` status when this activity fires
         (the engine performed workflow admission via `admit_task_for_workflow`
         during worktree setup, before dispatching the implement step). Do **not**
@@ -145,9 +151,6 @@ spec:
     - orbit.friction.*
     - orbit.search
     - orbit.learning.show
-    - orbit.learning.add
-    - orbit.learning.update
-    - orbit.learning.supersede
     - fs.read
     - fs.delete
     - proc.spawn

--- a/crates/orbit-core/assets/activities/agent_review.yaml
+++ b/crates/orbit-core/assets/activities/agent_review.yaml
@@ -76,13 +76,15 @@ spec:
        acceptance-criteria miss, obvious regression — note the most relevant
        task, file, and line in your verdict response. Cite `path:line` when the
        issue is file-specific. Skip stylistic nits.
-    4. Before stopping, run the learning checkpoint: if this review surfaced a
+    4. Before stopping, run the friction checkpoint: if this review surfaced a
        contradicted assumption, recurring failure mode, non-obvious gotcha that
-       took more than 10 minutes to debug, or incident-style root cause, follow
-       the `orbit-knowledge` skill and call the `add` action on
-       `orbit.learning` (or use that skill's update/supersede flow when it
-       points to existing guidance).
-       Skip if none apply.
+       took more than 10 minutes to debug, or incident-style root cause, file
+       it with `orbit.friction.add`, describing what happened and the evidence
+       behind it. Project learnings are authored by the orchestrator or by
+       Daniel, not by task executors — the runtime gate (ADR-0250) refuses
+       `orbit.learning.add`/`update`/`supersede` calls made from executor
+       context, so attempting one here is a wasted call, not a judgment call.
+       Skip if none of the trigger conditions apply.
     5. Return exactly one Orbit response envelope. Use status `success`, set
        `result.verdict` to `approve` only when no blocking issue remains, or
        `request_changes` when at least one blocking issue remains, and set
@@ -91,11 +93,9 @@ spec:
        {"schemaVersion":1,"status":"success","result":{"verdict":"approve|request_changes","reviewed_head_sha":"<sha>"},"error":null}
   tools:
     - orbit.task.show
+    - orbit.friction.add
     - orbit.search
     - orbit.learning.show
-    - orbit.learning.add
-    - orbit.learning.update
-    - orbit.learning.supersede
     - fs.read
     - proc.spawn
   proc_allowed_programs:

--- a/crates/orbit-core/assets/skills/orbit-task/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-task/SKILL.md
@@ -66,7 +66,7 @@ Carry a task (or human request, once created above) from intent to verified impl
 
 **Step 4 — Implement and validate.** Follow the plan; use the CLI-only `orbit graph` surface when shell access is available, otherwise inspect files directly. Verify transitive impact during implementation/review with `orbit graph` or `rg`; run the repo-approved verification commands (honor repo instructions if tests are forbidden).
 
-**Step 5 — Summarize and hand off.** Persist `execution_summary` via `orbit.task.update` first (template below). Learning checkpoint: if the task surfaced a contradicted assumption, recurring failure mode, non-obvious gotcha, or incident root cause, follow `orbit-knowledge` and call `orbit.learning.add`; skip otherwise. Then:
+**Step 5 — Summarize and hand off.** Persist `execution_summary` via `orbit.task.update` first (template below). Friction checkpoint: if the task surfaced a contradicted assumption, recurring failure mode, non-obvious gotcha, or incident root cause, file it with `orbit.friction.add` (see §4). Project learnings are authored by the orchestrator or by Daniel, not by task executors — the runtime gate (ADR-0250) refuses `orbit.learning.add`/`update`/`supersede` from executor context, so calling `orbit-knowledge`'s `add` action here is a wasted call, not a judgment call. Skip filing if none of the trigger conditions apply. Then:
 - **Under an activity envelope** (e.g. `agent_implement`): persist the summary only — the pipeline owns the `review` transition after commit/merge/PR steps succeed.
 - **Direct execution** (no envelope): persist the summary and move to `review` via `orbit.task.update`.
 
@@ -83,7 +83,7 @@ Include when relevant: `Strategic decisions:`, `Design weaknesses / risks:` (wit
 
 **Lifecycle rules:** one task per activity invocation — no multiplexing. Ask clarifying questions before implementing if material ambiguity remains. If `proposed`-work approval can't be obtained, stop after recording that state. Don't skip lifecycle updates. Direct execution must persist a non-empty `execution_summary` before/with the review transition.
 
-Exit: task started via `orbit.task.start`; execution summary persisted; learning checkpoint considered; direct execution advanced to `review` (envelope-driven execution leaves that to the pipeline).
+Exit: task started via `orbit.task.start`; execution summary persisted; friction checkpoint considered; direct execution advanced to `review` (envelope-driven execution leaves that to the pipeline).
 
 ## 3. Review
 

--- a/plugin/skills/orbit-task/SKILL.md
+++ b/plugin/skills/orbit-task/SKILL.md
@@ -66,7 +66,7 @@ Carry a task (or human request, once created above) from intent to verified impl
 
 **Step 4 — Implement and validate.** Follow the plan; use the CLI-only `orbit graph` surface when shell access is available, otherwise inspect files directly. Verify transitive impact during implementation/review with `orbit graph` or `rg`; run the repo-approved verification commands (honor repo instructions if tests are forbidden).
 
-**Step 5 — Summarize and hand off.** Persist `execution_summary` via `orbit.task.update` first (template below). Learning checkpoint: if the task surfaced a contradicted assumption, recurring failure mode, non-obvious gotcha, or incident root cause, follow `orbit-knowledge` and call `orbit.learning.add`; skip otherwise. Then:
+**Step 5 — Summarize and hand off.** Persist `execution_summary` via `orbit.task.update` first (template below). Friction checkpoint: if the task surfaced a contradicted assumption, recurring failure mode, non-obvious gotcha, or incident root cause, file it with `orbit.friction.add` (see §4). Project learnings are authored by the orchestrator or by Daniel, not by task executors — the runtime gate (ADR-0250) refuses `orbit.learning.add`/`update`/`supersede` from executor context, so calling `orbit-knowledge`'s `add` action here is a wasted call, not a judgment call. Skip filing if none of the trigger conditions apply. Then:
 - **Under an activity envelope** (e.g. `agent_implement`): persist the summary only — the pipeline owns the `review` transition after commit/merge/PR steps succeed.
 - **Direct execution** (no envelope): persist the summary and move to `review` via `orbit.task.update`.
 
@@ -83,7 +83,7 @@ Include when relevant: `Strategic decisions:`, `Design weaknesses / risks:` (wit
 
 **Lifecycle rules:** one task per activity invocation — no multiplexing. Ask clarifying questions before implementing if material ambiguity remains. If `proposed`-work approval can't be obtained, stop after recording that state. Don't skip lifecycle updates. Direct execution must persist a non-empty `execution_summary` before/with the review transition.
 
-Exit: task started via `orbit.task.start`; execution summary persisted; learning checkpoint considered; direct execution advanced to `review` (envelope-driven execution leaves that to the pipeline).
+Exit: task started via `orbit.task.start`; execution summary persisted; friction checkpoint considered; direct execution advanced to `review` (envelope-driven execution leaves that to the pipeline).
 
 ## 3. Review
 


### PR DESCRIPTION
## Task

[ORB-10381](https://orbit-cli.com/tasks/ORB-10381) — Remove orbit.learning writes from executor activities; redirect the learning checkpoint to frictions

### Description

**Reframed again 2026-07-25 18:10Z — Daniel merged PR #698, so the ORB-10364 runtime gate IS on `agent-main`** (*"I merged it - its cleaner anyways"*). This task reverts to its original purpose: **align the executor activity contract with the now-live gate.** Ignore the previous version's "no runtime gate exists / do not add one" framing; the gate exists, is wanted, and is not to be touched.

## Why this is urgent

The moment the orbit binary is next rebuilt and services restarted, the gate is live in production while `agent_implement.yaml` step 12 still **instructs** every executor to call `orbit.learning.add` and its allowlist still grants the write tools. Every implement run will then hit `OrbitError::PolicyDenied` on an instructed step. The refusal message is self-teaching (it names `orbit friction add` and echoes the attempted payload), so runs degrade noisily rather than die — but that is a contradiction burning tokens and attention on every single task run. **This should land before the next binary rebuild.**

## The defect

- **Step 12**: *"Before handoff, run the learning checkpoint: … call the `add` action on `orbit.learning`…"* — now instructs a refused operation.
- **`tools:` allowlist** grants `orbit.learning.add`, `orbit.learning.update`, `orbit.learning.supersede` — tools the gate will refuse for executor-context callers.

All four incident learnings today (L-0108, L-0109, L-0082, L-0112) were executors complying with step 12.

## Scope

1. **Step 12** — replace the learning checkpoint with friction filing. Keep the trigger conditions (contradicted assumption, recurring failure mode, non-obvious gotcha over ~10 minutes, incident-style root cause); change the channel to `orbit.friction.add`; state plainly that learnings are authored by the orchestrator or Daniel, and that the runtime gate (ADR-0250) will refuse learning writes from executor context — so attempting one is a wasted call, not a judgment call.
2. **Tools allowlist** — remove `orbit.learning.add/update/supersede`. **Keep `orbit.learning.show`** — reads stay open in every context under the gate, and the learning store drives PreToolUse scope injection.
3. **Scope the CLI-fallback sentence** in the activity preamble (*"run the equivalent Orbit CLI: `orbit tool run <tool.name>`"*) to the tools the activity actually grants. The gate covers the CLI path too (`orbit learning add` routes through the gated runtime methods), so this is hygiene rather than enforcement — the instruction should not send executors into a refusal.
4. **Sweep ALL agent_loop activities** in `.orbit/resources/activities/` and `crates/orbit-core/assets/activities/` (`agent_review.yaml`, `step_failure_recovery.yaml`, qa, and any others): remove learning write tools from allowlists, fix any instruction directing an executor to author a learning. Full list of affected activities in the execution summary.
5. **Check the skills** — `orbit-knowledge`, `orbit-task`, `orbit-workflow` under `crates/orbit-core/assets/skills/`. Fix executor-facing learning-authoring guidance; orchestrator/human guidance stays — the orchestrator legitimately authors learnings via the `ORBIT_LEARNING_AUTHOR=1` opt-in.
6. Both copies of every touched YAML stay identical; validate by loading, not by eye.

## Non-goals

- **Do not touch the gate** (`learning_authoring.rs`), ADR-0250, or any `orbit.learning.*` code path. Merged and accepted.
- Do not delete or edit existing learning artifacts, including quarantined L-0108 / L-0112 — disposition is Daniel's.

## Guards

PR-gated repo: worktree off `agent-main`, PR + CI. `make ci` is the merge gate — `make ci-fast` does not run clippy, so run `cargo clippy --workspace --all-targets -- -D warnings` explicitly. Activity YAML loads fail-closed; a malformed edit breaks every pipeline run.

### Acceptance Criteria

- `agent_implement.yaml` step 12 directs the implementer to `orbit.friction.add`, states learnings are orchestrator/Daniel-authored, and notes the runtime gate refuses executor learning writes
- `orbit.learning.add/update/supersede` are removed from every executor activity's tools allowlist; `orbit.learning.show` is retained; the full list of affected activities is in the execution summary
- The CLI-fallback instruction is scoped to granted tools and no longer directs executors toward a gated operation
- No change to `learning_authoring.rs`, ADR-0250, or any `orbit.learning.*` code path
- Both copies of every touched YAML are identical and every touched activity loads successfully
- `orbit-knowledge` / `orbit-task` / `orbit-workflow` skills checked; executor-facing guidance fixed, orchestrator/human guidance untouched
- No learning artifact created, edited, or deleted
- `make ci` passes, including `cargo clippy --workspace --all-targets -- -D warnings` run explicitly

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `agent_implement.yaml` (both `.orbit/resources/activities/` and `crates/orbit-core/assets/activities/` copies, kept byte-identical): step 12 now instructs `orbit.friction.add` for the checkpoint, states learnings are authored by the orchestrator/Daniel, and notes the ADR-0250 runtime gate refuses `orbit.learning.add/update/supersede` from executor context; the preamble's CLI-fallback sentence is scoped to tools this activity's `tools:` allowlist actually grants, so it no longer implies a blanket CLI fallback that could hit a gated write; `tools:` list drops `orbit.learning.add/update/supersede`, keeps `orbit.learning.show`.
- `agent_review.yaml` (both copies, kept identical): step 4's learning checkpoint replaced the same way; `tools:` drops the three learning-write tools, keeps `orbit.learning.show`, and adds `orbit.friction.add` (needed since the instruction now calls it and the activity previously had no friction tool granted).
- Swept every other `agent_loop`-typed activity (`dispatch_agent.yaml`, `step_failure_recovery.yaml`, `triage_failed_runs.yaml`) and `.orbit/auto_tasks/qa-sweep.yaml`: none reference `orbit.learning.*` or instruct learning authorship, so none needed changes. Confirmed via grep across both activities directories — only `agent_implement.yaml` and `agent_review.yaml` mentioned "learning".
- `orbit-task` skill (`crates/orbit-core/assets/skills/orbit-task/SKILL.md` and its `plugin/skills/orbit-task/SKILL.md` mirror, kept identical): Step 5's learning checkpoint and the Execute-section exit criterion updated to file friction instead, with the same ADR-0250 rationale. `orbit-knowledge` and `orbit-workflow` skills were checked; their content is generic tool reference / orchestrator-facing material (or unrelated sandbox-troubleshooting text in `orbit-workflow/references/common_failures.md`), not an executor-directed instruction to author a learning, so left untouched.
- No changes to `learning_authoring.rs`, ADR-0250, any `orbit.learning.*` code path, or any learning artifact.

Validation:
- `cargo run -p orbit-common --example v2_asset_smoke`: "activities loaded: 39, jobs loaded: 13, all assets loaded without error" — every touched YAML (and every other activity/job asset) parses via the real asset loader, not by eye.
- `cargo clippy --workspace --all-targets -- -D warnings`: ran explicitly per the task's guard (make ci-fast doesn't cover clippy); exited 0 with no warnings.
- Diffed both copies of `agent_implement.yaml`, `agent_review.yaml`, and `orbit-task/SKILL.md` after edits to confirm they remain byte-identical.

Assessment: Scope matched the task exactly — only the two activities that actually referenced learnings, plus their skill counterpart, were touched; the gate, ADR, and learning code/artifacts are untouched as required.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10381-6a6504b8`
- Behind base: 0
- Ahead of base: 1