### PR TITLE
Widen the shipped-asset portability guard to activities, ADR ids, and personal names [ORB-10381]

### DIFF
--- a/.orbit/learnings/L-0114/learning.yaml
+++ b/.orbit/learnings/L-0114/learning.yaml
@@ -1,0 +1,100 @@
+schema_version: 1
+id: L-0114
+status: active
+scope:
+  paths:
+  - crates/orbit-core/assets/**
+  - .orbit/resources/**
+  - plugin/skills/**
+  - crates/*/assets/**
+  tags:
+  - skills
+  - activities
+  - boundaries
+  - distribution
+  - portability
+summary: 'Shipped surfaces — crates/orbit-core/assets/**, its .orbit/resources/** mirrors, anything include_str!''d or seeded by `orbit init` — must be repository-agnostic: state policy as roles and mechanisms, never personal names or workspace-local ids (ORB-/L-/ADR-/F-).'
+body: |
+  # Shipped surfaces state policy as roles and mechanisms, never as named people or artifact ids
+
+  ## Rule
+
+  Everything that leaves this checkout is a **portable surface** and must read the
+  same way in a workspace that has never heard of this repository:
+
+  - `crates/orbit-core/assets/**` — activities, skills, jobs, executors, clock units
+  - the mirrored `.orbit/resources/**` copies of those assets
+  - anything `include_str!`'d into the binary or seeded into a workspace by `orbit init`
+
+  In those files, never write:
+
+  - **personal names** — the workspace owner, a teammate, any human
+  - **workspace-local artifact ids** — `ORB-NNNNN`, `L-NNNN`, `ADR-NNNN`, `F2026-NN-NNN`
+  - **workspace layout assumptions** — private repo/host names, a fixed directory tree
+  - **hardcoded crew or model names** where the choice should stay configurable
+
+  Express a policy by the **role** that holds it and the **mechanism** that enforces
+  it, not by the person who happens to hold the role or the decision record that
+  happens to document it. "Project learnings are curated by the workspace's
+  orchestrator or owner, not by task executors — the learning authoring gate refuses
+  executor-context writes" carries the full force of the rule and stays true in every
+  consumer workspace. "…authored by <person>, and ADR-NNNN refuses…" carries the same
+  instruction but names a stranger and cites a decision record the reader cannot
+  resolve.
+
+  ## Why
+
+  The audience for a shipped asset is an **end user's agent**, not a contributor to
+  this repo. A name that is authoritative here is an unresolvable stranger there, and
+  an artifact id is a dangling pointer the moment the file is seeded elsewhere — there
+  is no `ADR-NNNN` in *their* `.orbit/adrs/`. Worse than being merely confusing, a
+  named person reads as an *instruction* to defer to someone the reader has no way to
+  contact, so the policy quietly stops being actionable.
+
+  The failure mode is not carelessness. It comes from upstream: a task description
+  dictates the exact prose to write, in wording that is perfectly correct for a
+  workspace-local record, without flagging that the destination file is portable. The
+  executor complies faithfully and the leak lands. So the check has to live at the
+  surface, not in the author's intent.
+
+  ## Evidence
+
+  PR #702 rewrote the executor learning-checkpoint guidance — a correct and wanted
+  change — and in doing so wrote a personal name and a concrete `ADR-NNNN` reference
+  into `crates/orbit-core/assets/activities/agent_implement.yaml`,
+  `assets/activities/agent_review.yaml`, `assets/skills/orbit-task/SKILL.md`, their
+  `.orbit/resources/**` mirrors, and the `plugin/skills/**` copy. Both strings came
+  verbatim from the task description and its acceptance criteria.
+
+  The existing portability regression did not catch it, for two independent reasons:
+  it scoped only to `assets/skills/`, so `assets/activities/**` was never scanned at
+  all; and its pattern list covered `ORB-`/`L-`/`F2026-` artifact ids but neither
+  `ADR-NNNN` nor personal names.
+
+  ## How to apply
+
+  - **Before editing any file under `assets/**` or `.orbit/resources/**`**, ask who
+    reads it. If the answer is "an agent in someone else's workspace", phrase every
+    policy portably — role plus mechanism.
+  - **A task description is not a style guide for the destination.** When a task
+    dictates prose, keep its *meaning* and re-phrase for the surface. De-specify;
+    never weaken the instruction.
+  - **Run the portability checker** over shipped assets before pushing. It is the
+    enforcement point precisely because intent-based review keeps missing this.
+  - **Know where the line is.** Workspace-local surfaces — task records, ADRs,
+    frictions, run records, `.orbit/` knowledge artifacts, and Rust source comments —
+    *may* name people and cite artifact ids freely, and should, because that is where
+    provenance belongs. The boundary is the shipped-asset line, not the repository.
+
+  ## Related
+
+  Extends the shipped-asset artifact-id rule to policy prose and to the `activities`
+  tree; the id half of this rule is the same boundary that learning documents for
+  plugin assets.
+evidence:
+- kind: task
+  reference: ORB-10381
+- kind: external
+  reference: https://github.com/danieljhkim/orbit/pull/702
+created_at: 2026-07-25T19:15:11.592653963Z
+updated_at: 2026-07-25T19:15:11.592653963Z

--- a/crates/orbit-core/assets/activities/examples/agent_loop_cli_reference.yaml
+++ b/crates/orbit-core/assets/activities/examples/agent_loop_cli_reference.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   type: agent_loop
   description: >
-    Phase T20260419-0104 reference for the `backend: cli` dispatch path. This
+    Reference for the `backend: cli` dispatch path. This
     activity is executed through `orbit-agent`'s retained `claude_cli.rs`
     runtime (or a substitutable CLI in smoke runs) with Orbit emitting §7.6
     `cli.invocation.*` envelope events and the §6

--- a/crates/orbit-core/assets/activities/examples/agent_review_diff.yaml
+++ b/crates/orbit-core/assets/activities/examples/agent_review_diff.yaml
@@ -9,7 +9,7 @@ spec:
     current diff plus the reviewer's accumulated Session history and emits a
     structured verdict. Designed to sit inside a `loop:` body with a named
     `session: reviewer` binding so conversation state persists across
-    iterations — a precondition for T20260418-0421 Option B adversarial
+    iterations — a precondition for Option B adversarial
     independence. Phase 4 preserves that guarantee by pinning `backend: http`
     explicitly (§3.2 item 1: cross-iteration `session:` binding is HTTP-only).
 

--- a/crates/orbit-core/assets/skills/orbit-knowledge/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-knowledge/SKILL.md
@@ -54,7 +54,7 @@ Listing is **not** on the agent MCP surface — use `orbit search --kind adr` fo
 **Workflow:** (1) inspect nearby decisions first (`orbit search "<concept>" --kind adr`, `orbit.adr.show`, `legacy_id` lookup for migrated per-feature refs). (2) new decision → `add`; body/metadata correction → `update`; reversal of an accepted ADR → create the replacement, accept it with a related task, then `supersede`. (3) body needs exactly `## Context`, `## Decision`, `## Consequences`, with ≥1 consequences bullet starting `Cost:`. (4) `related_features` = feature/area names; `tags` = free-form cross-artifact labels; `paths` = repo-relative globs the decision constrains. (5) `related_tasks` may be empty for a speculative proposed ADR — don't invent a task just to satisfy one; **acceptance requires a real related task**. (6) verify with `.show` or `orbit search --kind adr`.
 
 Propose an ADR only when both hold: a real alternative was on the table, and the choice is meaningfully costly to reverse. Treat "surprising without context" as a strong signal, not a third hard requirement — lock-in can be real without being surprising (e.g. a Postgres or monorepo pick), so weigh it as a tiebreaker rather than a filter. Qualifies:
-- A deliberate deviation from the obvious path (e.g. ADR-0217's turn-knobs-out-of-specs).
+- A deliberate deviation from the obvious path (e.g. deliberately keeping tuning knobs out of specs).
 - A constraint not visible in the code itself.
 - A non-obvious rejected alternative worth recording.
 - A technology/architecture choice with real lock-in.

--- a/crates/orbit-core/src/command/skill.rs
+++ b/crates/orbit-core/src/command/skill.rs
@@ -192,10 +192,11 @@ mod tests {
     //! router skill's enumeration. The next agent who adds a skill folder
     //! must update all four; these tests fail loudly if any catalog lags.
     //!
-    //! Plus a portability regression (`embedded_skills_are_repository_agnostic`)
-    //! guarding the shipped skill tree against leaking Orbit-source paths,
-    //! private Constellation names, workspace-local artifact IDs, and fixed
-    //! consumer design-doc filenames into public consumer workspaces.
+    //! Plus a portability regression (`embedded_assets_are_repository_agnostic`)
+    //! guarding the shipped skill *and* activity trees against leaking
+    //! Orbit-source paths, private Constellation names, maintainers' personal
+    //! names, workspace-local artifact IDs (task/friction/learning/ADR), and
+    //! fixed consumer design-doc filenames into public consumer workspaces.
 
     use super::*;
     use std::collections::BTreeSet;
@@ -203,6 +204,10 @@ mod tests {
 
     fn assets_skills_dir() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets/skills")
+    }
+
+    fn assets_activities_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets/activities")
     }
 
     fn repo_root() -> PathBuf {
@@ -567,10 +572,10 @@ mod tests {
     // paths (`.orbit/...`, `~/.orbit/...`) and placeholder IDs (`ORB-NNNN`,
     // `L-NNNN`, `<task-id>`).
 
-    /// Concrete workspace-local artifact IDs (task/friction/learning) that would
-    /// become dangling references in a consumer workspace. Placeholder forms
-    /// (`ORB-NNNN`, `L-NNNN`, `<task-id>`) use non-digit stand-ins and are
-    /// intentionally *not* matched.
+    /// Concrete workspace-local artifact IDs (task/friction/learning/decision)
+    /// that would become dangling references in a consumer workspace. Placeholder
+    /// forms (`ORB-NNNN`, `L-NNNN`, `ADR-NNNN`, `<task-id>`) use non-digit
+    /// stand-ins and are intentionally *not* matched.
     fn find_artifact_ids(content: &str) -> Vec<String> {
         let b = content.as_bytes();
         let n = b.len();
@@ -592,6 +597,15 @@ mod tests {
                 // ORB-<digit...> (task ids). ORB-NNNN / ORB-NNNNN placeholders
                 // have a non-digit after the dash and are skipped.
                 if starts(i, b"ORB-") && is_digit(i + 4) {
+                    let d = digit_run(i + 4);
+                    out.push(String::from_utf8_lossy(&b[i..i + 4 + d]).into_owned());
+                }
+                // ADR-<digit...> (decision-record ids). ADR ids are allocated
+                // per workspace, so a concrete one resolves to a different
+                // decision — or to nothing — in a consumer's `.orbit/adrs/`.
+                // The ADR-NNNN placeholder has a non-digit after the dash and
+                // is skipped.
+                if starts(i, b"ADR-") && is_digit(i + 4) {
                     let d = digit_run(i + 4);
                     out.push(String::from_utf8_lossy(&b[i..i + 4 + d]).into_owned());
                 }
@@ -650,6 +664,11 @@ mod tests {
         None
     }
 
+    /// Given names of this repository's maintainers. Shipped assets address an
+    /// arbitrary consumer's agent, so naming a maintainer turns an enforceable
+    /// policy into a referral to someone the reader cannot reach.
+    const PRIVATE_PERSONAL_NAMES: &[&str] = &["Daniel"];
+
     /// Every reason `content` is not repository-agnostic. Empty == portable.
     fn portability_violations(content: &str) -> Vec<String> {
         let mut hits = Vec::new();
@@ -663,6 +682,18 @@ mod tests {
         for needle in ["almanac", "dk-mac", "dk-server", "Constellation"] {
             if content.contains(needle) {
                 hits.push(format!("private name `{needle}`"));
+            }
+        }
+
+        // Personal names. A shipped asset is read by an agent in someone else's
+        // workspace, where a maintainer's given name is an unreachable stranger
+        // rather than an authority — so policy must be stated by the *role* that
+        // holds it ("the workspace's orchestrator or owner"), never by person.
+        for needle in PRIVATE_PERSONAL_NAMES {
+            if content.contains(needle) {
+                hits.push(format!(
+                    "personal name `{needle}` (state the role, not the person)"
+                ));
             }
         }
 
@@ -700,6 +731,8 @@ mod tests {
             r#"{"model": "codex"}"#,
             "migrated by ORB-00200",
             "see learning L-0065",
+            "the runtime gate (ADR-0250) refuses the call",
+            "learnings are authored by the orchestrator or by Daniel",
             "silently drops it (F2026-05-024)",
             "--evidence task:T20260514-3",
             "docs/design/<feature>/4_decisions.md",
@@ -718,6 +751,8 @@ mod tests {
             "evidence under `.orbit/state/job-runs/`",
             "dependencies: [\"ORB-NNNN\", ...] require ORB-NNNNN targets",
             "drop a `// L-NNNN: <rationale>` citation",
+            "record the choice as ADR-NNNN once `orbit.adr.add` allocates it",
+            "learnings are curated by the workspace's orchestrator or owner",
             "recommended layout: `docs/design/<feature>/`",
             "resolve `context_files` selectors, then `fs.read` a `<task-id>`",
             "run `orbit search --kind adr`",
@@ -730,27 +765,46 @@ mod tests {
         }
     }
 
-    #[test]
-    fn embedded_skills_are_repository_agnostic() {
-        let root = assets_skills_dir();
-        let files = collect_relative_files(&root)
+    /// Every portability violation in `root`, each prefixed with its path
+    /// relative to `crates/orbit-core/assets/` for a readable failure report.
+    fn portability_failures_under(label: &str, root: &Path) -> Vec<String> {
+        let files = collect_relative_files(root)
             .unwrap_or_else(|e| panic!("collect_relative_files({}): {e}", root.display()));
 
-        let mut failures: Vec<String> = Vec::new();
+        let mut failures = Vec::new();
         for relative in files {
             let path = root.join(&relative);
             let content = std::fs::read_to_string(&path)
                 .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
             for violation in portability_violations(&content) {
-                failures.push(format!("  {}: {violation}", relative.display()));
+                failures.push(format!("  {label}/{}: {violation}", relative.display()));
             }
         }
+        failures
+    }
+
+    #[test]
+    fn embedded_assets_are_repository_agnostic() {
+        // Both trees ship: skills are embedded and mirrored into the public
+        // plugin package, and activities are `include_str!`'d by
+        // `command::activity` and seeded into every workspace on `orbit init`
+        // (with a byte-identical copy under `.orbit/resources/activities/`).
+        // Activities were outside this check until a task description's own
+        // wording — a maintainer's name plus a concrete ADR id — was copied
+        // verbatim into `agent_implement.yaml` (PR #702).
+        let mut failures = portability_failures_under("skills", &assets_skills_dir());
+        failures.extend(portability_failures_under(
+            "activities",
+            &assets_activities_dir(),
+        ));
 
         assert!(
             failures.is_empty(),
-            "embedded skill assets under crates/orbit-core/assets/skills/ are not repository-agnostic \
-             ({} leak(s)) — generalize, remove, or guard as explicitly source-only/client-specific \
-             guidance (ORB-10208):\n{}",
+            "embedded assets under crates/orbit-core/assets/{{skills,activities}}/ are not \
+             repository-agnostic ({} leak(s)) — generalize, remove, or guard as explicitly \
+             source-only/client-specific guidance. State a policy by the role that holds it and \
+             the mechanism that enforces it, never by a person's name or a workspace-local \
+             artifact id (ORB-10208):\n{}",
             failures.len(),
             failures.join("\n"),
         );

--- a/plugin/skills/orbit-knowledge/SKILL.md
+++ b/plugin/skills/orbit-knowledge/SKILL.md
@@ -54,7 +54,7 @@ Listing is **not** on the agent MCP surface — use `orbit search --kind adr` fo
 **Workflow:** (1) inspect nearby decisions first (`orbit search "<concept>" --kind adr`, `orbit.adr.show`, `legacy_id` lookup for migrated per-feature refs). (2) new decision → `add`; body/metadata correction → `update`; reversal of an accepted ADR → create the replacement, accept it with a related task, then `supersede`. (3) body needs exactly `## Context`, `## Decision`, `## Consequences`, with ≥1 consequences bullet starting `Cost:`. (4) `related_features` = feature/area names; `tags` = free-form cross-artifact labels; `paths` = repo-relative globs the decision constrains. (5) `related_tasks` may be empty for a speculative proposed ADR — don't invent a task just to satisfy one; **acceptance requires a real related task**. (6) verify with `.show` or `orbit search --kind adr`.
 
 Propose an ADR only when both hold: a real alternative was on the table, and the choice is meaningfully costly to reverse. Treat "surprising without context" as a strong signal, not a third hard requirement — lock-in can be real without being surprising (e.g. a Postgres or monorepo pick), so weigh it as a tiebreaker rather than a filter. Qualifies:
-- A deliberate deviation from the obvious path (e.g. ADR-0217's turn-knobs-out-of-specs).
+- A deliberate deviation from the obvious path (e.g. deliberately keeping tuning knobs out of specs).
 - A constraint not visible in the code itself.
 - A non-obvious rejected alternative worth recording.
 - A technology/architecture choice with real lock-in.


### PR DESCRIPTION
Follow-up to **ORB-10381 / PR #702**. Widens the guard that keeps project-specifics out of shipped assets, so this class of leak fails CI instead of relying on a review catch.

**DO NOT MERGE without Daniel's approval.** See the sequencing note at the bottom — #702 is still open.

## What went wrong

PR #702's change (redirect executor learning-writes to frictions) is correct, but its wording is wrong for the surface. It writes a maintainer's given name and the literal `ADR-0250` into:

- `crates/orbit-core/assets/activities/agent_implement.yaml`
- `crates/orbit-core/assets/activities/agent_review.yaml`
- `crates/orbit-core/assets/skills/orbit-task/SKILL.md`
- the `.orbit/resources/**` mirrors and the `plugin/skills/**` copy

Those files are `include_str!`'d into the binary and seeded into every workspace on `orbit init`. A consumer's agent can resolve neither reference — the name is an unreachable stranger, the ADR id is a dangling pointer into a `.orbit/adrs/` that has no such record.

The wording came verbatim from the ORB-10381 task description and its acceptance criteria, so this is an upstream-authoring issue, not executor error. That is precisely why the fix belongs in a test rather than in reviewer attention.

## Why the existing guard missed it

`embedded_skills_are_repository_agnostic` had two independent gaps:

1. It scanned only `assets/skills/` — `assets/activities/**` was never checked at all.
2. Its pattern list covered `ORB-`/`L-`/`F2026-`/`T<date>` artifact ids but neither `ADR-NNNN` nor personal names.

#702 went through both at once.

## Changes

- **Scope** — scan `assets/activities/**` alongside `assets/skills/**`. Activities ship the same way skills do (`command::activity::DEFAULT_ACTIVITY_FILES`, plus the byte-identical `.orbit/resources/activities/` mirror). Renamed to `embedded_assets_are_repository_agnostic`; failures are labelled by tree.
- **`ADR-<digits>`** — matched in `find_artifact_ids`, following the existing `ORB-` shape. ADR ids are allocated per workspace. The `ADR-NNNN` placeholder keeps its non-digit stand-in and is still skipped.
- **Personal names** — new `PRIVATE_PERSONAL_NAMES` needle list. Policy in a shipped asset must be stated by the **role** that holds it and the **mechanism** that enforces it, never by a person.
- Representative bad/good cases added to `portability_checker_flags_and_allows_representative_inputs`, using #702's actual strings.

## Verification

Checked out #702's asset content into this tree and ran the widened guard — it reports **all six** leaks:

```
skills/orbit-task/SKILL.md: personal name `Daniel` (state the role, not the person)
skills/orbit-task/SKILL.md: workspace-local artifact id `ADR-0250`
activities/agent_implement.yaml: personal name `Daniel` (state the role, not the person)
activities/agent_implement.yaml: workspace-local artifact id `ADR-0250`
activities/agent_review.yaml: personal name `Daniel` (state the role, not the person)
activities/agent_review.yaml: workspace-local artifact id `ADR-0250`
```

Then restored. Also green: `cargo test -p orbit-core --lib` (612 passed), `cargo clippy --workspace --all-targets -- -D warnings`, `make ci-fast`, `cargo run -p orbit-common --example v2_asset_smoke` (39 activities / 13 jobs load).

## Pre-existing violations surfaced

All three were stale citations whose removal costs no meaning, so they are fixed here:

- `assets/skills/orbit-knowledge/SKILL.md` cited `ADR-0217` as an example of a deliberate deviation.
- `assets/activities/examples/agent_review_diff.yaml` and `agent_loop_cli_reference.yaml` carried legacy `T<date>` task ids in prose descriptions.

`plugin/skills/orbit-knowledge/SKILL.md` is a materialized copy (not a symlink), updated in lockstep to hold the package-parity test.

**Left as-is, out of this guard's scope:** `ADR-` references under `assets/jobs/task_pr_pipeline.yaml`, `assets/executors/external.example.yaml`, and `assets/clock/*`. Widening to all of `assets/**` is a bigger call than this change should make — flagged for follow-up. ADR citations in Rust source are correct and untouched.

## Sequencing — needs a decision

**#702 has not merged**, so there is nothing to scrub on `agent-main`; this PR only installs the guard. Two orderings:

1. **Merge this first.** #702 then goes red on rebase and must scrub its wording before it can land — the guard does the enforcing.
2. **Scrub #702 on its own branch first**, then merge this.

Either works; (1) needs no trust. The scrub itself was not done here because #702's text lives only on its own branch, and pushing to another task's open PR was outside this mandate.

Recorded as learning **L-0114**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)