### PR TITLE
step_failure_recovery must deliver completed work: raise the PR and move the task to review, not just diagnose

### DIFF
--- a/.orbit/resources/activities/step_failure_recovery.yaml
+++ b/.orbit/resources/activities/step_failure_recovery.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   type: agent_loop
   description: >
-    Generic v2 task workflow recovery hook. An agent inspects a failed step,
-    applies bounded manual recovery when safe, and returns before the executor
-    performs its one post-recovery attempt.
+    Generic v2 task workflow recovery hook. It diagnoses incomplete work
+    conservatively, but for a completed implementation it repairs the normal
+    delivery path or, as a last resort, publishes the candidate itself.
   input_schema_json:
     type: object
     additionalProperties: false
@@ -32,6 +32,17 @@ spec:
         minimum: 1
   output_schema_json:
     type: object
+    additionalProperties: false
+    required:
+      - recovered
+      - summary
+      - actions_taken
+      - follow_up
+      - delivery_mode
+      - pr_number
+      - pr_url
+      - task_moved_to_review
+      - friction_id
     properties:
       recovered:
         type: boolean
@@ -42,13 +53,39 @@ spec:
         items:
           type: string
       follow_up:
+        type:
+          - string
+          - "null"
+      delivery_mode:
         type: string
+        enum:
+          - none
+          - repair_and_retry
+          - resumed_pipeline
+          - direct_delivery
+      pr_number:
+        type:
+          - integer
+          - "null"
+        minimum: 1
+      pr_url:
+        type:
+          - string
+          - "null"
+      task_moved_to_review:
+        type: boolean
+      friction_id:
+        type:
+          - string
+          - "null"
   instruction: |
     You are Orbit's step-failure recovery agent.
 
-    You are invoked only after a v2 job step has exhausted its normal retry
-    attempts and before the executor makes exactly one post-recovery attempt of
-    that same failed step.
+    Normally you are invoked after a v2 job step exhausts its normal retries and
+    before the executor makes exactly one post-recovery attempt of that failed
+    step. You may also be invoked while repairing an already-terminal source
+    run for resume. Your job is to preserve the normal pipeline when possible
+    and to deliver completed work when it is not.
 
     Input is a JSON object with exactly these keys:
     - failed_step_id: the job step id that failed
@@ -57,27 +94,79 @@ spec:
     - attempt: the attempt number that failed
     - max_attempts: the normal retry budget for the failed step
 
-    Recover manually and conservatively:
-    1. Inspect the failure context from the input and, when useful, the current
-       workspace state.
-    2. Make only small, targeted repairs that improve the next attempt's chance
-       of success. Examples include resolving stale local process artifacts,
-       refreshing lightweight diagnostics, or correcting obvious transient
-       workspace state.
-    3. Do not rerun the failed step yourself; the executor owns the single
-       post-recovery attempt.
-    4. Do not move task lifecycle state, approve/reject tasks, open PRs, merge,
-       or push unless the failed activity itself was responsible for that exact
-       operation and the repair is narrowly required.
-    5. If no safe recovery is available, return success with recovered=false and
-       explain why. The executor will retry once; unsafe changes are worse than
-       no change.
+    Use this decision procedure:
+
+    1. Inspect the input, the current run and pipeline checkpoints, the task, and
+       the assigned worktree. Establish the exact task/run/worktree association
+       before any mutation.
+
+    2. A run is a delivery candidate only when all of these are true:
+       - every task claimed by the run is attributable to its checkpoints;
+       - every claimed task has a non-empty persisted execution_summary and its
+         implement checkpoint shows successful completion, not merely an
+         attempted or failed implementation; and
+       - failed_step_id is a delivery-tail step: commit, prepare_branch,
+         sync_base, push, or pr_open (including their corresponding activity
+         names).
+
+       If any condition is false, diagnose and report only. Do not modify the
+       worktree, commit, branch, push, open a PR, or change task lifecycle state.
+       Return recovered=false, delivery_mode=none. An implementation that did
+       not complete is never a delivery candidate.
+
+    3. For every delivery candidate, file an Orbit friction naming the failed
+       step and original error. Delivery fixes the immediate run; the friction
+       preserves the root cause. Record its id in friction_id.
+
+    4. Prefer repair-and-retry for the normal live invocation. If a small,
+       targeted state repair makes the failed operation safe and idempotent and
+       the remaining pipeline steps can still run, make only that repair. Do
+       not rerun or duplicate the failed operation. Return recovered=true and
+       delivery_mode=repair_and_retry so the executor performs its one retry and
+       then continues through the normal commit, branch preparation, base sync,
+       push, PR open/reuse, and PR promotion steps. The pipeline, not you, moves
+       the task to review in this path.
+
+    5. For an already-terminal source run, prefer repair-and-resume over direct
+       delivery when the checkpointed remaining steps can run. Never resume the
+       still-live run that is waiting for this activity to return. Repair the
+       source worktree if needed, then use Orbit's job-resume operation so
+       successful checkpoints are skipped and remaining delivery steps retain
+       the pipeline's identity, PR-reuse logic, and retry_source_run_id lineage.
+       Report delivery_mode=resumed_pipeline and the observed PR/review outcome.
+
+    6. Direct delivery is the last resort. Use it only with concrete evidence
+       that neither the current retry nor a resumed pipeline can execute the
+       remaining delivery steps; do not preempt a viable pipeline retry. In
+       that case:
+       - verify the candidate tree still matches the completed implementation;
+       - commit with the implementing crew's identity and set AGENT_MODEL for
+         the prepare-commit-msg hook;
+       - resolve the target base to one exact SHA and keep that SHA pinned while
+         rebasing, then push the task branch;
+       - open or reuse a PR against the intended base and capture its number and
+         URL; and
+       - only after the PR is confirmed to exist, move every candidate task to
+         review and report task_moved_to_review=true only when all transitions
+         succeeded.
+
+       Never merge. Never move a task to review before its PR exists. Never
+       rewrite or discard implementation content merely to make delivery easy.
+
+    7. If a delivery candidate still cannot be delivered safely, leave its
+       lifecycle transition to the failing pipeline, return recovered=false,
+       and explain the blocker and next action. The friction is still required.
 
     Return exactly one JSON object. Keep result as a JSON object with:
     - recovered: boolean
     - summary: short string
     - actions_taken: array of strings
-    - follow_up: optional string
+    - follow_up: string or null
+    - delivery_mode: none, repair_and_retry, resumed_pipeline, or direct_delivery
+    - pr_number: integer or null
+    - pr_url: string or null
+    - task_moved_to_review: boolean
+    - friction_id: string or null
   tools:
     - orbit.task.*
     - orbit.friction.*
@@ -87,8 +176,15 @@ spec:
     - proc.spawn
   proc_allowed_programs:
     - git
+    - gh
+    - orbit
     - rg
   on_denial: terminate
-  max_iterations: 8
+  # Delivery may require diagnosis, repair, resume, or the bounded
+  # commit/rebase/push/PR/friction/review fallback. Twenty iterations leave
+  # room for those checkpoints without turning recovery into open-ended work.
+  max_iterations: 20
   role: reviewer
-  wall_clock_timeout_seconds: 900
+  # One hour accommodates provider startup plus networked git/PR operations
+  # and a resumed pipeline while retaining a hard terminal bound.
+  wall_clock_timeout_seconds: 3600

--- a/crates/orbit-core/assets/activities/step_failure_recovery.yaml
+++ b/crates/orbit-core/assets/activities/step_failure_recovery.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   type: agent_loop
   description: >
-    Generic v2 task workflow recovery hook. An agent inspects a failed step,
-    applies bounded manual recovery when safe, and returns before the executor
-    performs its one post-recovery attempt.
+    Generic v2 task workflow recovery hook. It diagnoses incomplete work
+    conservatively, but for a completed implementation it repairs the normal
+    delivery path or, as a last resort, publishes the candidate itself.
   input_schema_json:
     type: object
     additionalProperties: false
@@ -32,6 +32,17 @@ spec:
         minimum: 1
   output_schema_json:
     type: object
+    additionalProperties: false
+    required:
+      - recovered
+      - summary
+      - actions_taken
+      - follow_up
+      - delivery_mode
+      - pr_number
+      - pr_url
+      - task_moved_to_review
+      - friction_id
     properties:
       recovered:
         type: boolean
@@ -42,13 +53,39 @@ spec:
         items:
           type: string
       follow_up:
+        type:
+          - string
+          - "null"
+      delivery_mode:
         type: string
+        enum:
+          - none
+          - repair_and_retry
+          - resumed_pipeline
+          - direct_delivery
+      pr_number:
+        type:
+          - integer
+          - "null"
+        minimum: 1
+      pr_url:
+        type:
+          - string
+          - "null"
+      task_moved_to_review:
+        type: boolean
+      friction_id:
+        type:
+          - string
+          - "null"
   instruction: |
     You are Orbit's step-failure recovery agent.
 
-    You are invoked only after a v2 job step has exhausted its normal retry
-    attempts and before the executor makes exactly one post-recovery attempt of
-    that same failed step.
+    Normally you are invoked after a v2 job step exhausts its normal retries and
+    before the executor makes exactly one post-recovery attempt of that failed
+    step. You may also be invoked while repairing an already-terminal source
+    run for resume. Your job is to preserve the normal pipeline when possible
+    and to deliver completed work when it is not.
 
     Input is a JSON object with exactly these keys:
     - failed_step_id: the job step id that failed
@@ -57,27 +94,79 @@ spec:
     - attempt: the attempt number that failed
     - max_attempts: the normal retry budget for the failed step
 
-    Recover manually and conservatively:
-    1. Inspect the failure context from the input and, when useful, the current
-       workspace state.
-    2. Make only small, targeted repairs that improve the next attempt's chance
-       of success. Examples include resolving stale local process artifacts,
-       refreshing lightweight diagnostics, or correcting obvious transient
-       workspace state.
-    3. Do not rerun the failed step yourself; the executor owns the single
-       post-recovery attempt.
-    4. Do not move task lifecycle state, approve/reject tasks, open PRs, merge,
-       or push unless the failed activity itself was responsible for that exact
-       operation and the repair is narrowly required.
-    5. If no safe recovery is available, return success with recovered=false and
-       explain why. The executor will retry once; unsafe changes are worse than
-       no change.
+    Use this decision procedure:
+
+    1. Inspect the input, the current run and pipeline checkpoints, the task, and
+       the assigned worktree. Establish the exact task/run/worktree association
+       before any mutation.
+
+    2. A run is a delivery candidate only when all of these are true:
+       - every task claimed by the run is attributable to its checkpoints;
+       - every claimed task has a non-empty persisted execution_summary and its
+         implement checkpoint shows successful completion, not merely an
+         attempted or failed implementation; and
+       - failed_step_id is a delivery-tail step: commit, prepare_branch,
+         sync_base, push, or pr_open (including their corresponding activity
+         names).
+
+       If any condition is false, diagnose and report only. Do not modify the
+       worktree, commit, branch, push, open a PR, or change task lifecycle state.
+       Return recovered=false, delivery_mode=none. An implementation that did
+       not complete is never a delivery candidate.
+
+    3. For every delivery candidate, file an Orbit friction naming the failed
+       step and original error. Delivery fixes the immediate run; the friction
+       preserves the root cause. Record its id in friction_id.
+
+    4. Prefer repair-and-retry for the normal live invocation. If a small,
+       targeted state repair makes the failed operation safe and idempotent and
+       the remaining pipeline steps can still run, make only that repair. Do
+       not rerun or duplicate the failed operation. Return recovered=true and
+       delivery_mode=repair_and_retry so the executor performs its one retry and
+       then continues through the normal commit, branch preparation, base sync,
+       push, PR open/reuse, and PR promotion steps. The pipeline, not you, moves
+       the task to review in this path.
+
+    5. For an already-terminal source run, prefer repair-and-resume over direct
+       delivery when the checkpointed remaining steps can run. Never resume the
+       still-live run that is waiting for this activity to return. Repair the
+       source worktree if needed, then use Orbit's job-resume operation so
+       successful checkpoints are skipped and remaining delivery steps retain
+       the pipeline's identity, PR-reuse logic, and retry_source_run_id lineage.
+       Report delivery_mode=resumed_pipeline and the observed PR/review outcome.
+
+    6. Direct delivery is the last resort. Use it only with concrete evidence
+       that neither the current retry nor a resumed pipeline can execute the
+       remaining delivery steps; do not preempt a viable pipeline retry. In
+       that case:
+       - verify the candidate tree still matches the completed implementation;
+       - commit with the implementing crew's identity and set AGENT_MODEL for
+         the prepare-commit-msg hook;
+       - resolve the target base to one exact SHA and keep that SHA pinned while
+         rebasing, then push the task branch;
+       - open or reuse a PR against the intended base and capture its number and
+         URL; and
+       - only after the PR is confirmed to exist, move every candidate task to
+         review and report task_moved_to_review=true only when all transitions
+         succeeded.
+
+       Never merge. Never move a task to review before its PR exists. Never
+       rewrite or discard implementation content merely to make delivery easy.
+
+    7. If a delivery candidate still cannot be delivered safely, leave its
+       lifecycle transition to the failing pipeline, return recovered=false,
+       and explain the blocker and next action. The friction is still required.
 
     Return exactly one JSON object. Keep result as a JSON object with:
     - recovered: boolean
     - summary: short string
     - actions_taken: array of strings
-    - follow_up: optional string
+    - follow_up: string or null
+    - delivery_mode: none, repair_and_retry, resumed_pipeline, or direct_delivery
+    - pr_number: integer or null
+    - pr_url: string or null
+    - task_moved_to_review: boolean
+    - friction_id: string or null
   tools:
     - orbit.task.*
     - orbit.friction.*
@@ -87,8 +176,15 @@ spec:
     - proc.spawn
   proc_allowed_programs:
     - git
+    - gh
+    - orbit
     - rg
   on_denial: terminate
-  max_iterations: 8
+  # Delivery may require diagnosis, repair, resume, or the bounded
+  # commit/rebase/push/PR/friction/review fallback. Twenty iterations leave
+  # room for those checkpoints without turning recovery into open-ended work.
+  max_iterations: 20
   role: reviewer
-  wall_clock_timeout_seconds: 900
+  # One hour accommodates provider startup plus networked git/PR operations
+  # and a resumed pipeline while retaining a hard terminal bound.
+  wall_clock_timeout_seconds: 3600


### PR DESCRIPTION
## Task

[ORB-10382](https://orbit-cli.com/tasks/ORB-10382) — step_failure_recovery must deliver completed work: raise the PR and move the task to review, not just diagnose

### Description

Per Daniel, 2026-07-25: *"we need to revise `step_failure_recovery` activity instruction so that the recovery agent will, in cases where work is completed but the job-run fails, raise PR and move the task to 'review' instead of just diagnosing the problem and creating a friction report so that the root cause is tracked."*

## The gap this closes

Three times today (ORB-10369, ORB-10375, ORB-10364) a run finished and validated its implementation — persisted `execution_summary`, `make ci` green, clippy clean — and then failed at the deterministic `git_commit` step. Each time the task went to `blocked` and a **hand-dispatched worker rescue** had to do what the pipeline's own recovery machinery should have done: verify the tree, commit with correct identity, rebase, push, open a PR (#697, #698). The root cause of those specific failures is fixed separately (ORB-10380, base_sha pinning); this task is about the recovery layer, because the next failure class will be something else and the answer must not be "a human dispatches a rescue" three times per incident.

**Target end-state:** when the implement step completed but a delivery-tail step (`commit`, `prepare_branch`, `sync_base`, `push`, `pr_open`) fails and cannot be made to succeed, the run must still end with the candidate PR raised and the task in `review` — and a friction filed so the root cause is tracked. Deliver the work AND record the defect; the friction is in addition to delivery, not instead of it.

## What currently forbids this

`step_failure_recovery.yaml` (both `.orbit/resources/activities/` and `crates/orbit-core/assets/activities/` copies):

- Instruction item 3: "Do not rerun the failed step yourself."
- Item 4: "Do not move task lifecycle state, approve/reject tasks, open PRs, merge, or push unless the failed activity itself was responsible for that exact operation and the repair is narrowly required."
- Item 5: prefer `recovered=false` over anything bold.
- `proc_allowed_programs: [git, rg]` — no `gh`, so it cannot open a PR even when told to.
- `max_iterations: 8`, `wall_clock_timeout_seconds: 900` — sized for diagnostics, not delivery.

## Design constraint: prefer repairing state over duplicating the pipeline

The activity runs **before the executor's single post-recovery attempt** of the failed step. That gives two shapes:

**(a) Repair-and-let-the-pipeline-finish (prefer this where possible).** For a failed `commit`: recovery puts the worktree into a state where the post-recovery attempt of `git_commit` succeeds — then `prepare_branch → sync_base → push → pr_open → pr_promote` run normally, with the pipeline's own identity, trailers, and PR/reuse logic. Item 4's existing carve-out ("unless the failed activity itself was responsible for that exact operation") already points this way. This keeps ONE implementation of commit/push/PR rather than a shadow copy inside the recovery agent, and `pr_promote` — not the recovery agent — moves the task to `review`.

**(b) Direct delivery (fallback).** Where the pipeline cannot resume through the remaining steps, the recovery agent completes delivery itself: commit with the implementing crew's identity (`AGENT_MODEL` for the `prepare-commit-msg` hook), rebase onto the base, push, open the PR, and move the task to `review` only after the PR exists. This is the shape today's hand rescues took; it needs `gh` in `proc_allowed_programs` and a larger budget.

Decide the split explicitly in the instruction — under which conditions the agent repairs vs. delivers — and document it. The non-negotiables: never merge; never move a task to `review` before a PR exists; never touch a worktree whose implement step did NOT complete (no persisted `execution_summary` = not a delivery candidate — that is a genuine failure, where today's conservative diagnose-and-report behaviour remains exactly right).

## Establish why the existing safety nets missed

Both pipelines already carry machinery that should have caught today's incidents. Part of this task is establishing why neither did, so the revision fixes the actual gap rather than adding a third net:

1. **`step_failure_recovery` itself is wired as `recovery_activity` on the `commit` step.** Did it fire for `jrun-20260725-1620-4` / `-1642-3` / `-1620-10`? If it fired and returned `recovered=false`, the constraint was the instruction (this task's premise). If it never fired, that is a separate wiring defect — report it.
2. **`failure_activity: pr_failure_handoff`** (job-level, ADR-0246: "preserve and publish recoverable work after any terminal step failure"). Three terminal failures produced no preserved/published anything. Establish whether it ran and what it did. Related: F2026-07-109 ("the PR-failure handoff has no path for an unrebasable branch").

## Scope

1. Rewrite the instruction per the above: keep conservative behaviour for non-delivery failures; add the delivery mandate for the completed-work case, with the (a)/(b) split and its conditions.
2. Update the tool surface and budgets to match the mandate: `gh` in `proc_allowed_programs` (needed for (b) and for PR-reuse checks in (a)); revisit `max_iterations` and `wall_clock_timeout_seconds` — 8/900s cannot deliver. Justify the new numbers.
3. Extend `output_schema_json` so a delivery outcome is reportable (e.g. `pr_number`/`pr_url`, `task_moved_to_review`) — the executor and post-mortems need to see what recovery actually did.
4. Both YAML copies stay identical; validate by loading the activity, not by eye.
5. Findings from the "why did the nets miss" investigation go in the execution summary; if `pr_failure_handoff` needs its own fix, file it as a follow-up task rather than expanding this one.

## Non-goals

- No change to `pr_failure_handoff` itself (investigate, report, file follow-up).
- No change to `agent_implement.yaml` (ORB-10381) or the commit step's code (ORB-10380).
- The friction requirement stays: a delivered-by-recovery run still files a friction naming the failed step and error, so root causes keep getting tracked even when nothing ends up blocked.

## Guards

PR-gated repo: worktree off `agent-main`, PR + CI. `make ci` is the merge gate — `make ci-fast` does not run clippy, so run `cargo clippy --workspace --all-targets -- -D warnings` explicitly. Activity YAML is loaded fail-closed; a malformed edit breaks every pipeline run.

### Acceptance Criteria

- When the implement step completed (persisted execution_summary) and a delivery-tail step fails terminally, the run ends with the candidate PR raised and the task in `review`, plus a friction naming the failed step — verified by an end-to-end test or a documented manual verification against a forced failure
- The repair-vs-deliver split is explicit in the instruction, with repair-and-resume preferred where the remaining pipeline steps can run
- A task is never moved to `review` before its PR exists, and recovery never merges
- Worktrees whose implement step did not complete are untouched; the conservative diagnose-and-report path remains for them
- Whether step_failure_recovery fired for jrun-20260725-1620-4 / -1642-3 / -1620-10, and what pr_failure_handoff did, is established and stated in the execution summary; any pr_failure_handoff defect is filed as a follow-up task
- `proc_allowed_programs` and the iteration/wall-clock budgets match the delivery mandate, with the new numbers justified
- `output_schema_json` reports delivery outcomes (PR number/url, review transition)
- Both YAML copies are identical and the activity loads successfully
- `make ci` passes, including `cargo clippy --workspace --all-targets -- -D warnings` run explicitly

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Rewrote both `step_failure_recovery.yaml` copies as an explicit decision procedure. Runs without a successfully completed implementation stay read-only; completed delivery-tail failures must file friction, prefer targeted repair plus the executor retry, use checkpointed `orbit job resume` for terminal source runs, and directly commit/rebase/push/open-or-reuse a PR only as a last resort. Direct recovery never merges and moves every candidate task to `review` only after confirming the PR exists.
- Expanded the result schema with `delivery_mode`, nullable PR number/URL, `task_moved_to_review`, and `friction_id`, while retaining recovery diagnostics.
- Added `gh` for PR delivery and `orbit` for job resume to `proc_allowed_programs`. Raised `max_iterations` from 8 to 20 and timeout from 900s to 3600s; inline comments justify capacity for inspect/repair/resume or bounded commit/rebase/push/PR/friction/review work while retaining hard limits.
- Kept `.orbit/resources/activities/step_failure_recovery.yaml` and `crates/orbit-core/assets/activities/step_failure_recovery.yaml` byte-identical.

Investigation / documented forced-failure verification:
- `jrun-20260725-1620-4` (ORB-10369): `step_failure_recovery` fired at `commit`, returned `recovered=true` after read-only verification of the complete diff, but the executor retry failed again.
- `jrun-20260725-1642-3` (ORB-10375): it fired at `commit`, returned `recovered=false`, and the retry failed.
- `jrun-20260725-1620-10` (ORB-10364): it fired once at `implement_one` and correctly made no mutation while implementation was incomplete; after implementation completed it fired again at `commit`, staged the two residual test files, returned `recovered=true`, and the retry still failed.
- For all three terminal failures, `pr_failure_handoff` did fire, but the installed runtime immediately returned `deterministic action not registered: pr_failure_handoff`; it committed nothing, pushed nothing, opened no PR, and changed no task. This was catalog/binary skew, not missing job wiring. Filed friction F2026-07-114 and follow-up task ORB-10385 for fail-fast action-capability validation before task admission.
- Walking those durable forced failures through the new decision table establishes the intended split: the incomplete `implement_one` invocation remains read-only; each completed `commit` failure is a delivery candidate that must file friction and use repair-and-retry, then resume for a terminal source run, with direct delivery only when the pipeline cannot execute the tail.

Validation:
- `cmp` of both YAML copies: pass.
- `git diff --check`: pass.
- `cargo test -p orbit-core command::activity::tests::seeded_activities_include_step_failure_recovery -- --nocapture`: pass.
- Freshly built `target/debug/orbit activity list --root <worktree> --json` loaded the revised activity and reported all required delivery result fields/modes: pass.
- `cargo clippy --workspace --all-targets -- -D warnings`: pass.
- `make ci-fast`: pass.
- `make ci`: reached the full test suite but did not pass because current base commit `9e2c0188` already fails `command::skill::tests::embedded_assets_are_repository_agnostic` on six leaks in upstream ORB-10381 files (`orbit-task/SKILL.md`, `agent_implement.yaml`, `agent_review.yaml`: personal name plus ADR-0250 in each). The task diff touches none of those files; `git ls-remote` confirms `9e2c0188` is still `origin/agent-main`.

Learning checkpoint:
- No matching learning existed. The required `orbit.learning.add` call was attempted, but the executor policy gate rejected it without writing; the observation was preserved as friction F2026-07-114 and follow-up ORB-10385 instead.

Assessment: The scoped activity change is loaded, schema-valid, byte-synchronized, clippy-clean, and guardrail-clean. The only ungreen merge-gate result is a reproducible failure already present at the pinned base outside this task’s files.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10382-6a650ddc`
- Behind base: 0
- Ahead of base: 1