### PR TITLE
Expose resume_job_run: dashboard API endpoint + Resume button on the runs page

### DIFF
--- a/crates/orbit-dashboard/assets/dashboard/dashboard.css
+++ b/crates/orbit-dashboard/assets/dashboard/dashboard.css
@@ -1022,6 +1022,31 @@
         transition: color 0.15s ease;
       }
       .runs-row .run-id:hover { color: var(--accent); }
+      .runs-row .run-id-cell {
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+        gap: 2px;
+      }
+      .runs-row .run-lineage {
+        width: fit-content;
+        max-width: 100%;
+        overflow: hidden;
+        padding: 0;
+        border: 0;
+        background: transparent;
+        color: var(--fg-dim);
+        font: inherit;
+        font-size: 9px;
+        text-align: left;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        cursor: pointer;
+      }
+      .runs-row .run-lineage:hover,
+      .runs-row .run-lineage.resumed-as {
+        color: var(--accent-hover);
+      }
       .runs-row .duration { color: var(--fg-dim); text-align: right; }
       .runs-row .num { text-align: right; color: var(--fg-dim); }
       .runs-row .num.hot { color: var(--state-failed); }
@@ -1036,6 +1061,7 @@
       }
       .runs-row .run-actions {
         display: flex;
+        gap: 4px;
         justify-content: flex-end;
         min-height: 26px;
       }
@@ -3543,5 +3569,4 @@
           max-height: none;
         }
       }
-
 

--- a/crates/orbit-dashboard/assets/dashboard/runs.js
+++ b/crates/orbit-dashboard/assets/dashboard/runs.js
@@ -4,7 +4,7 @@
 // Extracted from app.js (ORB-00180). Owns the runSort state, all friction-row
 // classification helpers (coerce*, first*, frictionRow*, empty*, add*), merge*,
 // sort*, header/cell renderers, and the table renderer.
-// Also owns the action button builders and cancel/replay fns (used by both the
+// Also owns the action button builders and cancel/replay/resume fns (used by both the
 // runs table and the run-detail meta in app.js).
 //
 // Receives one-time context via initRuns(runsContext()) containing the
@@ -16,6 +16,7 @@ import { el, stateCell, syncNodes, postJson } from './common.js';
 const $ = (id) => document.getElementById(id);
 
 const CANCELLABLE_RUN_STATES = new Set(["pending", "running"]);
+const RESUMABLE_RUN_STATES = new Set(["failed", "interrupted", "timeout"]);
 
 const RUN_SORT_DEFAULT_DIR = {
   when: "desc",
@@ -28,6 +29,7 @@ const RUN_SORT_DEFAULT_DIR = {
 };
 
 let runSort = { key: "when", dir: "desc" };
+const resumedRunIdsBySource = new Map();
 
 let _runsCtx = null;
 
@@ -83,6 +85,10 @@ function runIsCancellable(run) {
   return CANCELLABLE_RUN_STATES.has(run && run.state);
 }
 
+function runIsResumable(run) {
+  return RESUMABLE_RUN_STATES.has(run && run.state);
+}
+
 function buildCancelRunButton(run, host) {
   const btn = el("button", {
     class: "action reject run-cancel",
@@ -106,6 +112,19 @@ function buildReplayRunButton(run, host) {
   btn.addEventListener("click", (e) => {
     e.stopPropagation();
     replayRun(run, btn, host);
+  });
+  return btn;
+}
+
+function buildResumeRunButton(run, host) {
+  const btn = el("button", {
+    class: "action approve run-resume",
+    text: "Resume",
+    title: `Resume ${run.run_id} from its first non-successful step`,
+  });
+  btn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    resumeRun(run, btn, host);
   });
   return btn;
 }
@@ -154,6 +173,33 @@ async function replayRun(run, btn, host) {
   } catch (e) {
     if (host) {
       host.appendChild(el("div", { class: "action-error", text: e.message || "replay failed" }));
+    }
+    console.error(e);
+  } finally {
+    btn.disabled = false;
+    btn.textContent = old;
+  }
+}
+
+async function resumeRun(run, btn, host) {
+  const runId = run && run.run_id;
+  if (!runId) return;
+  const message = `Resume ${runId}? This creates a new run that re-runs the failed step and all subsequent steps. It succeeds only if the underlying cause is resolved.`;
+  if (!window.confirm(message)) return;
+  const old = btn.textContent;
+  btn.disabled = true;
+  btn.innerHTML = `<span class="spinner"></span>Resume`;
+  if (host) {
+    for (const node of host.querySelectorAll(".action-error")) node.remove();
+  }
+  try {
+    const payload = await postJson(`/api/job-runs/${encodeURIComponent(runId)}/resume`);
+    if (!payload.run_id) throw new Error("resume response did not include run_id");
+    resumedRunIdsBySource.set(runId, payload.run_id);
+    await doFetchAndRenderRuns();
+  } catch (e) {
+    if (host) {
+      host.appendChild(el("div", { class: "action-error", text: e.message || "resume failed" }));
     }
     console.error(e);
   } finally {
@@ -438,18 +484,48 @@ export function renderRuns(runs) {
         runIdSpan.style.color = "";
       }, 1000);
     });
+    const runIdCell = el("span", { class: "run-id-cell" }, [runIdSpan]);
+    if (r.retry_source_run_id) {
+      const sourceId = r.retry_source_run_id;
+      const lineage = el("button", {
+        class: "run-lineage",
+        text: `from ${sourceId}`,
+        title: `Open source run ${sourceId}`,
+      });
+      lineage.addEventListener("click", (e) => {
+        e.stopPropagation();
+        doNavigateToRun(sourceId);
+      });
+      runIdCell.appendChild(lineage);
+    }
+    const resumedAsId = resumedRunIdsBySource.get(r.run_id);
+    if (resumedAsId) {
+      const lineage = el("button", {
+        class: "run-lineage resumed-as",
+        text: `resumed as ${resumedAsId}`,
+        title: `Open resumed run ${resumedAsId}`,
+      });
+      lineage.addEventListener("click", (e) => {
+        e.stopPropagation();
+        doNavigateToRun(resumedAsId);
+      });
+      runIdCell.appendChild(lineage);
+    }
     const row = el("div", { class: "runs-row", title: `${r.run_id} (click to inspect)` }, [
       el("span", { class: "when", text: fmtTimestampValue(ts) }),
       el("span", { class: "id", text: r.job_id }),
-      runIdSpan,
+      runIdCell,
       runCountCell(friction.denials),
       runCountCell(friction.toolFails),
       runDurationCell(r),
       el("span", { class: "state" }, [stateCell(r.state)]),
-      el("span", { class: "run-actions" }, runIsCancellable(r) ? [buildCancelRunButton(r, body)] : []),
+      el("span", { class: "run-actions" }, [
+        runIsCancellable(r) ? buildCancelRunButton(r, body) : null,
+        runIsResumable(r) ? buildResumeRunButton(r, body) : null,
+      ]),
     ]);
     row.dataset.key = `run-${r.run_id}`;
-    row.dataset.hash = `${r.run_id}-${ts}-${r.duration_ms}-${r.state}-${friction.denials}-${friction.toolFails}-${friction.durationMs}-${friction.longRun}`;
+    row.dataset.hash = `${r.run_id}-${ts}-${r.duration_ms}-${r.state}-${r.retry_source_run_id || ""}-${resumedAsId || ""}-${friction.denials}-${friction.toolFails}-${friction.durationMs}-${friction.longRun}`;
     row.style.cursor = "pointer";
     row.addEventListener("click", () => doNavigateToRun(r.run_id));
     frag.appendChild(row);
@@ -459,6 +535,8 @@ export function renderRuns(runs) {
 
 export {
   runIsCancellable,
+  runIsResumable,
   buildCancelRunButton,
   buildReplayRunButton,
+  buildResumeRunButton,
 };

--- a/crates/orbit-dashboard/src/api/jobs.rs
+++ b/crates/orbit-dashboard/src/api/jobs.rs
@@ -1,15 +1,16 @@
 //! Job catalog and job-run listing handlers.
 
 use crate::state::Ws;
-use axum::extract::Query;
+use axum::extract::{Path, Query};
+use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
 use chrono::{DateTime, Utc};
 use orbit_core::JobRunState;
 use orbit_core::command::job::JobRunListParams;
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{Value, json};
 
-use super::{bad_request, bounded_limit, server_error};
+use super::{bad_request, bounded_limit, map_runtime_error, server_error, validate_id};
 use crate::projections::{job_catalog_to_json_with_last_run, job_run_to_json};
 
 const JOB_RUN_DEFAULT_LIMIT: usize = 25;
@@ -80,5 +81,26 @@ pub(super) async fn list_job_runs(Ws(runtime): Ws, Query(q): Query<JobRunListQue
             Json(Value::Array(values)).into_response()
         }
         Err(e) => server_error(e),
+    }
+}
+
+/// Resume a terminal resumable run as a new linked run.
+///
+/// Resume re-runs the first non-successful step and every subsequent step; it
+/// succeeds only when the underlying cause of the source failure is resolved.
+pub(super) async fn resume_job_run_action(Ws(runtime): Ws, Path(id): Path<String>) -> Response {
+    let id = match validate_id(&id) {
+        Ok(id) => id,
+        Err(message) => return bad_request(message),
+    };
+    match runtime.resume_job_run(id) {
+        Ok(result) => match runtime.show_job_run(&result.run_id) {
+            Ok(run) => Json(job_run_to_json(&run)).into_response(),
+            Err(e) => map_runtime_error(e),
+        },
+        Err(orbit_core::OrbitError::JobValidation(message)) => {
+            (StatusCode::CONFLICT, Json(json!({ "error": message }))).into_response()
+        }
+        Err(e) => map_runtime_error(e),
     }
 }

--- a/crates/orbit-dashboard/src/api/mod.rs
+++ b/crates/orbit-dashboard/src/api/mod.rs
@@ -379,6 +379,7 @@ pub(super) fn router() -> Router<crate::state::DashboardState> {
         )
         .route("/jobs", get(jobs::list_jobs))
         .route("/job-runs", get(jobs::list_job_runs))
+        .route("/job-runs/:id/resume", post(jobs::resume_job_run_action))
         .route("/workflows/ship", post(runs::ship_workflow_action))
         .route("/runs/:id", get(runs::get_run))
         .route("/runs/:id/cancel", post(runs::cancel_run_action))

--- a/crates/orbit-dashboard/src/api/tests/runs.rs
+++ b/crates/orbit-dashboard/src/api/tests/runs.rs
@@ -18,7 +18,9 @@ use tower::ServiceExt;
 
 use super::super::router;
 use super::super::runs::*;
-use super::test_support::{body_json, seed_run, write_replay_job, write_replay_job_under};
+use super::test_support::{
+    body_json, seed_run, write_replay_job, write_replay_job_under, write_seeded_run,
+};
 
 async fn request_cancel(runtime: OrbitRuntime, run_id: &str, origin: Option<&str>) -> Response {
     let mut builder = Request::builder()
@@ -38,6 +40,20 @@ async fn request_replay(runtime: OrbitRuntime, run_id: &str, origin: Option<&str
     let mut builder = Request::builder()
         .method(Method::POST)
         .uri(format!("/runs/{run_id}/replay"));
+    if let Some(origin) = origin {
+        builder = builder.header(header::ORIGIN, origin);
+    }
+    router()
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
+        .oneshot(builder.body(Body::empty()).expect("request"))
+        .await
+        .expect("response")
+}
+
+async fn request_resume(runtime: OrbitRuntime, run_id: &str, origin: Option<&str>) -> Response {
+    let mut builder = Request::builder()
+        .method(Method::POST)
+        .uri(format!("/job-runs/{run_id}/resume"));
     if let Some(origin) = origin {
         builder = builder.header(header::ORIGIN, origin);
     }
@@ -531,6 +547,85 @@ async fn replay_run_endpoint_returns_4xx_when_current_job_is_deleted() {
             .as_str()
             .is_some_and(|message| message.contains("job not found"))
     );
+}
+
+#[tokio::test]
+async fn resume_job_run_endpoint_returns_new_run_summary_and_lineage() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    write_replay_job(&runtime, "web_resume_success");
+    let mut source = seed_run(
+        &runtime,
+        "jrun-web-resume-failed",
+        "web_resume_success",
+        JobRunState::Failed,
+    );
+    source.input = Some(json!({ "seconds": 0 }));
+    write_seeded_run(&runtime, &source);
+
+    let response = request_resume(
+        runtime.clone(),
+        &source.run_id,
+        Some("http://localhost:3000"),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = body_json(response).await;
+    let new_run_id = payload["run_id"].as_str().expect("new run id");
+    assert_ne!(new_run_id, source.run_id);
+    assert_eq!(payload["state"], "success");
+    assert_eq!(
+        payload["retry_source_run_id"].as_str(),
+        Some(source.run_id.as_str())
+    );
+    let stored = runtime.show_job_run(new_run_id).expect("show resumed run");
+    assert_eq!(stored.state, JobRunState::Success);
+    assert_eq!(
+        stored.retry_source_run_id.as_deref(),
+        Some(source.run_id.as_str())
+    );
+}
+
+#[tokio::test]
+async fn resume_job_run_endpoint_rejects_non_terminal_run_with_guard_reason() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let source = seed_run(
+        &runtime,
+        "jrun-web-resume-pending",
+        "web_resume_pending",
+        JobRunState::Pending,
+    );
+
+    let response = request_resume(runtime, &source.run_id, Some("http://localhost:3000")).await;
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let payload = body_json(response).await;
+    assert!(
+        payload["error"]
+            .as_str()
+            .is_some_and(|message| message.contains("is pending"))
+    );
+    assert!(
+        payload["error"]
+            .as_str()
+            .is_some_and(|message| message.contains("interrupted, failed, or timed-out"))
+    );
+}
+
+#[tokio::test]
+async fn resume_job_run_endpoint_returns_not_found_for_unknown_run() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    let response = request_resume(
+        runtime,
+        "jrun-web-resume-missing",
+        Some("http://localhost:3000"),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let payload = body_json(response).await;
+    assert_eq!(payload["error"], "run not found: jrun-web-resume-missing");
 }
 
 #[test]

--- a/crates/orbit-dashboard/src/tests/dashboard_assets.rs
+++ b/crates/orbit-dashboard/src/tests/dashboard_assets.rs
@@ -122,6 +122,36 @@ fn dashboard_task_actions_route_to_selected_workspace() {
 }
 
 #[test]
+fn dashboard_run_resume_matches_runtime_guard_and_surfaces_lineage_and_errors() {
+    let runs = include_str!("../../assets/dashboard/runs.js");
+
+    assert!(
+        runs.contains(
+            r#"const RESUMABLE_RUN_STATES = new Set(["failed", "interrupted", "timeout"])"#
+        ),
+        "Resume must only be offered for states accepted by resume_job_run"
+    );
+    assert!(
+        runs.contains("/api/job-runs/${encodeURIComponent(runId)}/resume"),
+        "Resume must POST to the job-run action route"
+    );
+    assert!(
+        runs.contains("re-runs the failed step and all subsequent steps")
+            && runs.contains("underlying cause is resolved"),
+        "the confirmation must explain checkpoint resume semantics honestly"
+    );
+    assert!(
+        runs.contains("text: `resumed as ${resumedAsId}`")
+            && runs.contains("text: `from ${sourceId}`"),
+        "the runs table must expose both directions of resumed-run lineage"
+    );
+    assert!(
+        runs.contains(r#"class: "action-error", text: e.message || "resume failed""#),
+        "Resume failures must display the server-provided error text"
+    );
+}
+
+#[test]
 fn dashboard_guards_per_workspace_panels_in_aggregate_view() {
     // ORB-00039: in the aggregate "All workspaces" view there is no concrete
     // workspace, so the per-workspace endpoints (/api/crews, /api/tasks/locks,


### PR DESCRIPTION
## Task

[ORB-10383](https://orbit-cli.com/tasks/ORB-10383) — Expose resume_job_run: dashboard API endpoint + Resume button on the runs page

### Description

Per Daniel, 2026-07-25: *"we need to be able to resume a job-run from a specific step, i.e. a failed step"* — plus a Resume button in the orbit dashboard.

## The capability already exists; only exposure is missing

**Do not build new resume semantics.** ORB-10002's `resume_job_run(source_run_id)` (`crates/orbit-core/src/command/job/exec.rs:78`) already does the right thing: creates a new run linked via `retry_source_run_id`, seeds `PipelineState` from the source run's persisted step checkpoints, skips every top-level step recorded `success` while feeding their recorded outputs forward (so a resumed `commit` sees the original `workspace_path`/`job_run_id`), and degrades to full replay when no checkpoints exist. Its state guard reconciles a stale `Running` owner to `Interrupted` before checking, so SIGKILL-orphaned runs are resumable. `orbit run job` already drives it from the CLI (`crates/orbit-cli/src/command/run/job.rs:181`).

What is missing is reach: the dashboard HTTP API has only `GET /job-runs` (`api/mod.rs:381`), so neither the dashboard UI nor Bridge can trigger a resume. Today that gap turned five recoverable commit-step failures into five hand-dispatched worker rescues (PRs #696–#700).

## Deliverable 1 — HTTP endpoint

`POST /api/job-runs/:id/resume` on the dashboard API, following the existing action-route conventions exactly (`/tasks/:id/approve` → `tasks::approve_task_action` at `api/mod.rs:348-350` is the closest precedent — same handler naming, same response shaping).

- Handler calls `runtime.resume_job_run(&id)` and returns the new run's summary (the same projection `GET /job-runs` uses), so the caller immediately has the new `run_id` to poll.
- A non-terminal source run must produce a clean 4xx with the state that was found, not a 500 — surface the existing state-guard error legibly.
- Unknown run id → 404, consistent with the other `:id` routes.
- **This endpoint is what a Bridge `workflow_run_resume` tool will call** — a companion ws_bridge task follows once this merges and the binary is rebuilt. Keep the response shape stable and boring.

## Deliverable 2 — Resume button on the runs page

The dashboard UI is vanilla JS under `crates/orbit-dashboard/assets/dashboard/` — the runs page is `runs.js` (it already handles `cancel`, which is the interaction precedent to mirror: same confirm/feedback pattern, same styling in `dashboard.css`).

- Show **Resume** only for runs in a resumable state (terminal-failed / interrupted / cancelled / timeout — match whatever the state guard actually accepts; establish that set by reading the guard, not by assumption, and record it in the execution summary).
- On click: confirm, POST to the endpoint, then surface the **new** run id and refresh the list — the resumed run is a distinct row linked by `retry_source_run_id`, and the UI must make that lineage visible rather than implying the old run restarted in place. If the runs page already renders any lineage/relationship affordance, reuse it; if not, showing "resumed as `<new-id>`" on the source row is enough.
- Failure of the POST surfaces the server's error text (e.g. the not-terminal message), not a generic toast.

## Semantics caveat to carry into the UI copy and endpoint docs

Resume **replays the failed step; it does not fix why it failed.** Today's five strandings would each have re-failed on resume until ORB-10380 (base pinning) lands, because the failed `commit` would re-resolve the moved base. That is not an argument against the button — it is an argument for honest copy: "re-runs the failed step and all subsequent steps; succeeds only if the underlying cause is resolved."

## Non-goals

- No change to `resume_job_run` itself, its state guard, or checkpoint semantics.
- No step-picker ("resume from step N"): the checkpoint mechanism already resumes from the first non-success step, which is the failed step. A picker adds a foot-gun (skipping a failed step fabricates its outputs) with no present need.
- No Bridge tool in this task — separate ws_bridge follow-up.
- No auto-resume-on-failure policy. Resumption stays a deliberate human/orchestrator act.

## Guards

PR-gated repo: worktree off `agent-main`, PR + CI. `make ci` is the merge gate — `make ci-fast` does not run clippy, so run `cargo clippy --workspace --all-targets -- -D warnings` explicitly.

### Acceptance Criteria

- `POST /api/job-runs/:id/resume` exists, follows the `/tasks/:id/approve` action-route conventions, and returns the new run's summary including its `run_id` and `retry_source_run_id`
- Resuming a non-terminal run returns a clean 4xx carrying the state-guard's reason; unknown id returns 404
- The runs page shows Resume only for states the guard actually accepts — that set is established by reading the guard and recorded in the execution summary
- Clicking Resume confirms, POSTs, surfaces the new run id, and refreshes; the lineage (resumed-as) is visible rather than implying an in-place restart
- A POST failure surfaces the server's error text in the UI
- UI copy states that resume re-runs the failed step and subsequent steps, succeeding only if the underlying cause is resolved
- No change to `resume_job_run`, its state guard, or checkpoint semantics; no step-picker; no auto-resume
- Endpoint covered by dashboard API tests (success, non-terminal 4xx, 404); UI behaviour verified against a real failed run, not only by reading the diff
- `make ci` passes, including `cargo clippy --workspace --all-targets -- -D warnings` run explicitly

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `POST /api/job-runs/:id/resume`, validating the id, returning the standard job-run summary projection, mapping the existing resume state guard to HTTP 409 with its legible reason, and preserving 404 for unknown runs.
- Added dashboard Resume behavior with confirmation copy explaining that the failed step and all subsequent steps re-run and only succeed after the underlying cause is resolved. The new run id is surfaced as `resumed as`, refreshed rows expose reverse `from` lineage, and server error text is rendered inline.
- Read the unchanged runtime guard and matched the UI to exactly `failed`, `interrupted`, and `timeout`; `cancelled` is not accepted by `resume_job_run` and is therefore intentionally excluded.
- Added dashboard API coverage for success/summary lineage, non-terminal 409 guard text, and unknown-run 404, plus asset contract checks for state gating, endpoint path, semantics copy, lineage, and server-error display.
Assessment: The endpoint is a thin exposure of existing checkpoint semantics with no changes to `resume_job_run`, its guard, checkpoint behavior, step selection, or automation policy. Temporary UI-smoke fixtures were removed after validation.
Validation:
- `cargo test -p orbit-dashboard` passed: 202 tests.
- `make ci-fast` passed after the final edit.
- `cargo clippy --workspace --all-targets -- -D warnings` passed explicitly.
- `make ci` passed, including the full workspace test/doc/guardrail suite.
- Real UI smoke against deliberate failed run `jrun-20260725-2033`: the built dashboard rendered Resume only on the failed source; an unresolved-cause attempt surfaced the server error, and after resolving the fixture cause a confirmed click POSTed, refreshed, created successful linked run `jrun-20260725-2038`, showed `resumed as jrun-20260725-2038` on the source, and `from jrun-20260725-2033` on the new row.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10383-6a651c3a`
- Behind base: 0
- Ahead of base: 1