### PR TITLE
agent_implement: record discovered modification targets in context_files, not a task comment

### DIFF
--- a/.orbit/resources/activities/agent_implement.yaml
+++ b/.orbit/resources/activities/agent_implement.yaml
@@ -68,9 +68,12 @@ spec:
        unlisted file that must change to make the scoped edits compile, preserve
        an existing caller/API after a deletion or refactor, update tightly
        coupled registration/dispatch/audit metadata, update a directly affected
-       test or snapshot, or satisfy a stated acceptance criterion, add a task
-       comment with `orbit.task.update` naming the file and reason, then make
-       the smallest compatible change and include it in your summary.
+       test or snapshot, or satisfy a stated acceptance criterion, append it to
+       the task's `context_files` via `orbit.task.update` before proceeding.
+       Append only real modification targets, expressed as canonical `file:`,
+       `dir:`, or `symbol:` selectors, each resolving inside the workspace root.
+       Note the reason in your execution summary, then make the smallest
+       compatible change and include it in your summary.
        Stop after commenting instead of continuing when the unlisted file would
        introduce a new dependency edge, change behavior outside the task intent,
        require a broad refactor, or remain ambiguous after a quick local

--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -68,9 +68,12 @@ spec:
        unlisted file that must change to make the scoped edits compile, preserve
        an existing caller/API after a deletion or refactor, update tightly
        coupled registration/dispatch/audit metadata, update a directly affected
-       test or snapshot, or satisfy a stated acceptance criterion, add a task
-       comment with `orbit.task.update` naming the file and reason, then make
-       the smallest compatible change and include it in your summary.
+       test or snapshot, or satisfy a stated acceptance criterion, append it to
+       the task's `context_files` via `orbit.task.update` before proceeding.
+       Append only real modification targets, expressed as canonical `file:`,
+       `dir:`, or `symbol:` selectors, each resolving inside the workspace root.
+       Note the reason in your execution summary, then make the smallest
+       compatible change and include it in your summary.
        Stop after commenting instead of continuing when the unlisted file would
        introduce a new dependency edge, change behavior outside the task intent,
        require a broad refactor, or remain ambiguous after a quick local


### PR DESCRIPTION
## Task

[ORB-10402](https://orbit-cli.com/tasks/ORB-10402) — agent_implement: record discovered modification targets in context_files, not a task comment

### Description

## Problem

`agent_implement`'s instruction item 5 tells the implementer that when it discovers an unlisted file it must change, it should "add a task comment with `orbit.task.update` naming the file and reason, then make the smallest compatible change".

Routing the discovery into a **comment** has three costs:

1. **The durable field stays wrong.** `context_files` is the task's record of its modification surface. Recording the correction in prose leaves the field permanently understating the real surface, so every later reader — reviewer, rescue run, retry, dependency analysis, anything that reasons over `context_files` — sees a stale boundary.
2. **It produces enormous low-signal history.** An implementer that discovers a large mechanical fan-out emits one comment containing the entire file list. A recent run on a refactor task posted a single comment naming roughly fifty files as "scope expansion required". That is exactly the low-signal-history problem already filed as a separate concern in this workspace.
3. **It reads as a request for permission.** Item 5 already authorizes the implementer to proceed for the enumerated cases (make it compile, preserve a caller after a deletion/refactor, update tightly coupled registration/dispatch/audit metadata, update a directly affected test or snapshot, satisfy a stated acceptance criterion). Phrasing the record-keeping as "comment, then change" invites executors to comment and stall instead of proceeding.

## Change

In `agent_implement`'s instruction item 5, for the **proceed** cases only: the implementer adds the discovered paths to the task's `context_files` via `orbit.task.update` — appending to the existing list, as canonical selectors (`file:`/`dir:`/`symbol:`), each resolving inside the workspace root — and notes the reason in its execution summary rather than as a standalone comment. Then it makes the smallest compatible change, as today.

Keep unchanged:

- The **stop** conditions and their behaviour: a new dependency edge, behaviour change outside task intent, a required broad refactor, or ambiguity remaining after a quick local inspection. Those still stop, and for those a comment explaining the stop is still the right channel.
- The rule that deletions of unrelated artifacts (learnings, ADRs, design docs, fixtures) are always scope drift.
- Every other numbered item.

Also make item 5 state the `context_files` contract explicitly, so the implementer appends conformant entries: only real modification targets, canonical selectors, resolving inside the workspace root. A path outside the workspace root fails pipeline admission outright, so an implementer that appends one would strand its own retry.

## Files

Both copies must change and stay byte-identical (they are identical today): the shipped asset `crates/orbit-core/assets/activities/agent_implement.yaml` and the workspace mirror `.orbit/resources/activities/agent_implement.yaml`.

## Portability constraint — read before editing

`crates/orbit-core/assets/**` seeds **every** workspace this tool is used in. The instruction text must stay entirely project-agnostic: no task ids, no friction/learning/ADR ids, no personal names, no references to this repository's layout, history, or contributors. Describe the rule, never the incident that motivated it.

Instruction-only change: no schema, tool-allowlist, timeout, or code changes.

### Acceptance Criteria

- agent_implement item 5 directs the implementer, in the proceed cases, to append discovered modification targets to the task's context_files via orbit.task.update rather than recording them in a standalone task comment.
- Item 5 states the context_files contract the appended entries must satisfy: real modification targets only, canonical selectors (file:/dir:/symbol:), each resolving inside the workspace root.
- The stop conditions (new dependency edge, behavior change outside task intent, broad refactor required, ambiguity after local inspection) are preserved with unchanged meaning, and a comment remains the channel for a stop.
- The unrelated-artifact-deletion scope-drift rule and all other numbered items are unchanged.
- crates/orbit-core/assets/activities/agent_implement.yaml and .orbit/resources/activities/agent_implement.yaml are updated identically and remain byte-identical to each other (verify with diff).
- The changed instruction text contains no task ids, friction/learning/ADR ids, personal names, or references specific to this repository — verified by the shipped-surface portability checker.
- No schema, tools allowlist, proc_allowed_programs, role, or timeout fields are modified; the diff is confined to the instruction block.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated both mirrored agent_implement activity instructions so allowed discovered modification targets are appended to context_files through orbit.task.update as canonical in-workspace selectors, with the reason recorded in the execution summary.
- Preserved the comment-based stop conditions and unrelated-artifact-deletion scope-drift rule.
Assessment: Instruction-only change confined to item 5; the shipped and workspace copies are byte-identical.
Validation: git diff --check; cmp -s crates/orbit-core/assets/activities/agent_implement.yaml .orbit/resources/activities/agent_implement.yaml; cargo test -p orbit-core embedded_assets_are_repository_agnostic --lib; make ci-fast.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10402-6a655035`
- Behind base: 0
- Ahead of base: 1