### PR TITLE
Support comma-separated status filters in orbit.task.list tool input

### DIFF
--- a/crates/orbit-core/src/runtime/orbit_tool_host/host.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/host.rs
@@ -585,8 +585,13 @@ impl HubCoordinationExecutor {
     }
 
     fn list_tasks(&self, input: Value) -> Result<Value, OrbitError> {
-        let status_filter = optional_string(&input, "status")?
-            .map(|value| super::input::parse_task_status("status", &value))
+        let status_filter = optional_csv_or_string_list_alias(&input, &["status"])?
+            .map(|values| {
+                values
+                    .into_iter()
+                    .map(|value| super::input::parse_task_status("status", &value))
+                    .collect::<Result<Vec<_>, _>>()
+            })
             .transpose()?;
         let type_filter = optional_string_alias(&input, &["type", "task_type", "taskType"])?
             .map(|value| super::input::parse_task_type("type", &value))
@@ -604,7 +609,11 @@ impl HubCoordinationExecutor {
             .task
             .list_tasks()?
             .into_iter()
-            .filter(|task| status_filter.is_none_or(|value| task.status == value))
+            .filter(|task| {
+                status_filter
+                    .as_ref()
+                    .is_none_or(|values| values.contains(&task.status))
+            })
             .filter(|task| type_filter.is_none_or(|value| task.task_type == value))
             .filter(|task| task_matches_tags(task, &tags))
             .filter(|task| ready != Some(true) || task_dependencies_ready(task, &status))
@@ -920,5 +929,57 @@ mod checkoutless_hub_tests {
                 .any(|entry| entry.path().extension().is_some_and(|ext| ext == "md")),
             "friction persisted in the canonical workspace partition"
         );
+    }
+
+    #[test]
+    fn task_list_accepts_multi_status_filters_without_checkout() {
+        let (_root, executor, context) = executor();
+        for (title, status) in [
+            ("Backlog hub task", "backlog"),
+            ("In-progress hub task", "in-progress"),
+            ("Review hub task", "review"),
+            ("Done hub task", "done"),
+        ] {
+            let created = executor
+                .execute_tool(
+                    "orbit.task.add",
+                    json!({
+                        "workspace": "ws_checkoutless",
+                        "title": title,
+                        "description": "multi-status fixture",
+                        "model": "codex"
+                    }),
+                    context.clone(),
+                )
+                .expect("add checkoutless task");
+            executor
+                .execute_tool(
+                    "orbit.task.update",
+                    json!({
+                        "id": created["id"],
+                        "status": status,
+                        "plan": "Multi-status filter fixture.",
+                        "model": "codex"
+                    }),
+                    context.clone(),
+                )
+                .expect("set checkoutless task status");
+        }
+
+        for input in [
+            json!({ "status": "backlog,in-progress,review" }),
+            json!({ "status": ["backlog", "in-progress", "review"] }),
+        ] {
+            let output = executor
+                .execute_tool("orbit.task.list", input, context.clone())
+                .expect("multi-status filter succeeds");
+            let statuses = output
+                .as_array()
+                .expect("task array")
+                .iter()
+                .map(|task| task["status"].as_str().expect("task status"))
+                .collect::<std::collections::HashSet<_>>();
+            assert_eq!(statuses, ["backlog", "in-progress", "review"].into());
+        }
     }
 }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
@@ -116,8 +116,13 @@ pub(super) fn lint(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
 }
 
 pub(super) fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
-    let status = optional_string(&input, "status")?
-        .map(|value| parse_task_status("status", &value))
+    let statuses = optional_csv_or_string_list_alias(&input, &["status"])?
+        .map(|values| {
+            values
+                .into_iter()
+                .map(|value| parse_task_status("status", &value))
+                .collect::<Result<Vec<_>, _>>()
+        })
         .transpose()?;
     let task_type = optional_string_alias(&input, &["type", "task_type", "taskType"])?
         .map(|value| parse_task_type("type", &value))
@@ -132,7 +137,7 @@ pub(super) fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
     // ID ascending for ties); the filters below preserve that order, so the
     // trailing `take(limit)` yields the newest matching tasks (ORB-10310).
     let all_tasks = runtime.list_tasks_filtered(
-        status,
+        None,
         None,
         parent_id.as_deref(),
         job_run_id.as_deref(),
@@ -143,6 +148,11 @@ pub(super) fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
     Ok(Value::Array(
         all_tasks
             .into_iter()
+            .filter(|task| {
+                statuses
+                    .as_ref()
+                    .is_none_or(|values| values.contains(&task.status))
+            })
             .filter(|task| orbit_common::types::task_matches_tags(task, &tags))
             .filter(|task| ready != Some(true) || task_dependencies_ready(task, &status_by_id))
             .filter(|task| {

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
@@ -1605,6 +1605,73 @@ fn task_list_tool_applies_status_filter_before_limit() {
 }
 
 #[test]
+fn task_list_tool_accepts_comma_delimited_and_array_status_filters() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let backlog = create_task(
+        &runtime,
+        &repo_root,
+        "Backlog status task",
+        "multi-status fixture",
+        TaskStatus::Backlog,
+        &[],
+    );
+    let in_progress = create_task(
+        &runtime,
+        &repo_root,
+        "In-progress status task",
+        "multi-status fixture",
+        TaskStatus::InProgress,
+        &[],
+    );
+    let review = create_task(
+        &runtime,
+        &repo_root,
+        "Review status task",
+        "multi-status fixture",
+        TaskStatus::Review,
+        &[],
+    );
+    create_task(
+        &runtime,
+        &repo_root,
+        "Done status task",
+        "multi-status fixture",
+        TaskStatus::Done,
+        &[],
+    );
+
+    let comma_delimited = runtime
+        .execute_tool_command(
+            "orbit.task.list",
+            json!({ "status": "backlog,in-progress,review" }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("comma-delimited statuses succeed");
+    let array = runtime
+        .execute_tool_command(
+            "orbit.task.list",
+            json!({ "status": ["backlog", "in-progress", "review"] }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("status array succeeds");
+
+    for output in [&comma_delimited, &array] {
+        let ids = output
+            .as_array()
+            .expect("task array")
+            .iter()
+            .map(|task| task["id"].as_str().expect("task id"))
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(ids.len(), 3);
+        assert!(ids.contains(backlog.id.as_str()));
+        assert!(ids.contains(in_progress.id.as_str()));
+        assert!(ids.contains(review.id.as_str()));
+    }
+}
+
+#[test]
 fn task_update_tool_recovers_mcp_encoded_acceptance_array() {
     let (_root, runtime, repo_root) = test_runtime();
     let task = create_task(

--- a/crates/orbit-tools/src/builtin/orbit/task/list.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/list.rs
@@ -10,8 +10,10 @@ impl Tool for OrbitTaskListTool {
         let mut parameters = vec![
             ToolParam {
                 name: "status".to_string(),
-                description: "Optional task status filter".to_string(),
-                param_type: "string".to_string(),
+                description:
+                    "Optional task status filter. Pass a comma-separated string or an array of status names."
+                        .to_string(),
+                param_type: "string_list".to_string(),
                 required: false,
             },
             ToolParam {

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/list.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/list.rs
@@ -1,0 +1,22 @@
+//! Schema tests for `orbit.task.list`.
+
+use super::super::list::OrbitTaskListTool;
+use crate::Tool;
+
+#[test]
+fn schema_exposes_multi_status_filter() {
+    let schema = OrbitTaskListTool.schema();
+    let status = schema
+        .parameters
+        .iter()
+        .find(|parameter| parameter.name == "status")
+        .expect("status parameter");
+
+    assert_eq!(status.param_type, "string_list");
+    assert!(!status.required);
+    assert!(
+        status
+            .description
+            .contains("comma-separated string or an array")
+    );
+}

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/mod.rs
@@ -2,4 +2,5 @@
 
 mod add;
 mod artifact_put;
+mod list;
 mod update;


### PR DESCRIPTION
## Task

[ORB-10401](https://orbit-cli.com/tasks/ORB-10401) — Support comma-separated status filters in orbit.task.list tool input

### Description

## Problem
The documented `orbit.task.list` status filter accepts comma-separated statuses in the CLI, but the tool JSON adapter accepts only one status.

## Evidence
On commit `949c1f70cfedd68f27aaad0b9730c06c5f85fe0f`, both of these tool invocations fail:

```json
{"status":"backlog,in-progress,review","tag":["qa-sweep"],"limit":100}
```
returns `invalid input: status unknown task status: backlog,in-progress,review`; and

```json
{"status":["backlog","in-progress","review"]}
```
returns `invalid input: status must be a string`.

This conflicts with `crates/orbit-cli/src/command/task/list.rs`, which documents `--status backlog,in-progress,review` and defines a repeatable comma-delimited status filter.

## Reproduction
1. From an initialized Orbit workspace, run `orbit tool run orbit.task.list --input '{"status":"backlog,in-progress,review","tag":["qa-sweep"],"limit":100,"model":"codex"}'`.
2. Observe the `invalid_input` error rather than a union of the selected statuses.
3. Repeat with a JSON array for `status`; observe `status must be a string`.

## Expected behavior
The tool should accept the documented comma-separated statuses (and ideally its JSON-schema-native array form) and apply the same union filter as the user-facing CLI.

### Acceptance Criteria

- `orbit.task.list` accepts `status: "backlog,in-progress,review"` through the tool surface and returns matching tasks.
- Tool-schema and adapter behavior are covered for multi-status filtering without breaking the single-status form.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `orbit.task.list` now parses status as a comma-delimited string or JSON string array in both the standard runtime adapter and checkoutless hub adapter, applying union semantics before the result limit.
- The tool schema now advertises `status` as `string_list`; focused schema and adapter regression tests cover CSV, array, and existing single-status behavior.
Assessment: Scoped, backward-compatible change; no new dependencies.
Validation:
- `cargo fmt`
- `cargo test -p orbit-core task_list_accepts_multi_status_filters_without_checkout --lib`
- `cargo test -p orbit-core task_list_tool_accepts_comma_delimited_and_array_status_filters --lib`
- `cargo test -p orbit-tools schema_exposes_multi_status_filter --lib`
- `make ci-fast`

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10401-6a655afa`
- Behind base: 0
- Ahead of base: 1