### PR TITLE
Make GET /api/tasks filter before limit and report truncation

### DIFF
--- a/crates/orbit-dashboard/assets/dashboard/app.js
+++ b/crates/orbit-dashboard/assets/dashboard/app.js
@@ -1,7 +1,7 @@
 // Orbit dashboard — terminal-dark, manually refreshed SPA.
 // Pure vanilla JS, split into ES modules with no build step.
 
-import { el, statusPill, stateCell, fetchJson, requestJson, postJson, patchJson, syncNodes, positiveIntParam, getWorkspace, setWorkspace, setMultiWorkspace, isAggregateView, renderPanelPlaceholder } from './common.js';
+import { el, statusPill, stateCell, fetchJson, listItems, requestJson, postJson, patchJson, syncNodes, positiveIntParam, getWorkspace, setWorkspace, setMultiWorkspace, isAggregateView, renderPanelPlaceholder } from './common.js';
 import { buildChips, cacheCrewPayload, copyTaskIdWithNotice, hasCrewOptions, openVisibleTask, renderTasks, setPinnedExternalTask, wireSearch } from './tasks.js';
 import { applyAuditHashQuery, buildAuditChips, buildAuditHash, fetchAndRenderAudit, fetchAndRenderPolicy, getActiveAuditSubtab, navigateToAuditExecution, renderAuditSummary, setActiveAuditSubtabFromButton, setAuditSubtab, syncAuditControls, wireAuditSearch, } from './audit.js';
 import { renderScoreboard } from './scoreboard.js';
@@ -1243,7 +1243,9 @@ function fetchAndRenderTasks() {
   return Promise.all([
     fetchJson(path),
     crews,
-  ]).then(([tasks]) => {
+  ]).then(([payload]) => {
+    // /api/tasks answers `{ items, ... }` (ORB-10400); /api/tasks/all a bare array.
+    const tasks = listItems(payload);
     lastTasks = tasks;
     renderTasks(tasks, taskContext());
   });

--- a/crates/orbit-dashboard/assets/dashboard/common.js
+++ b/crates/orbit-dashboard/assets/dashboard/common.js
@@ -99,6 +99,16 @@ export function fetchJson(path) {
     });
 }
 
+// ORB-10400: /api/tasks answers a paginated envelope
+// `{ items, total, limit, truncated }` so a client can tell an empty result from
+// a truncated window, while the /api/tasks/all aggregate still answers a bare
+// array. Accept either shape rather than teaching each call site the difference.
+export function listItems(payload) {
+  if (Array.isArray(payload)) return payload;
+  if (payload && Array.isArray(payload.items)) return payload.items;
+  return [];
+}
+
 export function requestJson(path, method, body) {
   const headers = { accept: "application/json" };
   const opts = {

--- a/crates/orbit-dashboard/src/api/tasks.rs
+++ b/crates/orbit-dashboard/src/api/tasks.rs
@@ -2,7 +2,7 @@
 
 use crate::state::Ws;
 use axum::body::Body;
-use axum::extract::Path;
+use axum::extract::{Path, RawQuery};
 use axum::http::{HeaderName, HeaderValue, header};
 use axum::response::{IntoResponse, Json, Response};
 use orbit_common::types::task_artifacts::TaskRelation;
@@ -135,19 +135,178 @@ where
     Option::<String>::deserialize(deserializer).map(Some)
 }
 
-pub(super) async fn list_tasks(Ws(runtime): Ws) -> Response {
-    match list_tasks_json(&runtime) {
-        Ok(values) => Json(Value::Array(values)).into_response(),
+/// `GET /api/tasks` — the request workspace's tasks, filtered server-side.
+///
+/// ## Query parameters
+///
+/// - `status` — repeatable and/or comma-separated (`?status=proposed,backlog`).
+///   OR semantics across values; omitted means every lifecycle status.
+/// - `tag` (alias `tags`) — repeatable and/or comma-separated. AND semantics:
+///   a task must carry every requested tag. Values go through Orbit's own
+///   [`normalize_task_tags`](orbit_common::types::normalize_task_tags) /
+///   `task_matches_tags`, so a colon is ordinary tag content and
+///   `auto-task:qa-sweep` matches that whole tag rather than being split.
+/// - `type` (alias `task_type`) — a single task type (`feature`/`bug`/
+///   `refactor`/`chore`).
+/// - `limit` — positive integer, defaulting to [`DEFAULT_TASK_LIST_LIMIT`].
+///
+/// Unknown keys (including the `?workspace=<id>` selector consumed by the
+/// [`Ws`] extractor) are ignored; an unparseable value is a 400 rather than a
+/// silently-dropped filter.
+///
+/// ## Response contract (ORB-10400, consumed by bridge ORB-10398)
+///
+/// ```json
+/// { "items": [ /* task objects, newest first */ ],
+///   "total": 137, "limit": 50, "truncated": true }
+/// ```
+///
+/// **Every predicate is applied before the limit**, so `items` holds the newest
+/// *matching* tasks — a match older than the newest `limit` unfiltered tasks is
+/// still reachable by passing its filters. `total` is the pre-limit match count
+/// and `truncated` is `total > items.len()`, which is what lets a client tell a
+/// genuinely empty result (`total: 0`) from a filter whose matches fell outside
+/// the window (previously indistinguishable, because the handler answered a bare
+/// truncated array with no metadata).
+///
+/// The cross-workspace `/api/tasks/all` aggregate still answers a bare array; it
+/// takes no filters and is bounded by the same default limit.
+pub(super) async fn list_tasks(Ws(runtime): Ws, RawQuery(query): RawQuery) -> Response {
+    let query = match TaskListQuery::parse(query.as_deref()) {
+        Ok(query) => query,
+        Err(message) => return bad_request(message),
+    };
+    match task_list_page_json(&runtime, &query) {
+        Ok(value) => Json(value).into_response(),
         Err(e) => server_error(e),
     }
 }
 
-/// Build the dashboard task list as JSON values (shared by `list_tasks` and the
-/// cross-workspace `/api/tasks/all` aggregate).
+/// Server-side filters for `GET /api/tasks`, mirroring `orbit task list`
+/// semantics (ORB-10400).
+struct TaskListQuery {
+    /// Accepted statuses; empty means status-neutral (every lifecycle status).
+    statuses: Vec<TaskStatus>,
+    /// Required tags, AND-combined. Passed verbatim to `list_tasks_by_tags`,
+    /// which normalizes them.
+    tags: Vec<String>,
+    task_type: Option<TaskType>,
+    limit: usize,
+}
+
+impl Default for TaskListQuery {
+    fn default() -> Self {
+        Self {
+            statuses: Vec::new(),
+            tags: Vec::new(),
+            task_type: None,
+            limit: DEFAULT_TASK_LIST_LIMIT,
+        }
+    }
+}
+
+impl TaskListQuery {
+    /// Parse the raw (still percent-encoded) query string.
+    ///
+    /// Repeated keys accumulate and each value may itself be comma-separated,
+    /// matching the CLI's `--status a,b` / repeated `--tag`. Empty values are
+    /// ignored so `?status=` behaves like an omitted filter, and unknown keys
+    /// are skipped because this endpoint shares its query string with the `Ws`
+    /// workspace selector.
+    fn parse(raw_query: Option<&str>) -> Result<Self, String> {
+        let mut parsed = Self::default();
+        let Some(raw_query) = raw_query else {
+            return Ok(parsed);
+        };
+        for (key, value) in url::form_urlencoded::parse(raw_query.as_bytes()) {
+            match key.as_ref() {
+                "status" => {
+                    for raw in split_filter_values(&value) {
+                        let status = raw
+                            .to_ascii_lowercase()
+                            .parse::<TaskStatus>()
+                            .map_err(|error| format!("invalid `status` value `{raw}`: {error}"))?;
+                        if !parsed.statuses.contains(&status) {
+                            parsed.statuses.push(status);
+                        }
+                    }
+                }
+                // A tag is matched whole: only `,` separates values, so a
+                // colon-bearing tag (`auto-task:qa-sweep`) stays intact.
+                "tag" | "tags" => parsed
+                    .tags
+                    .extend(split_filter_values(&value).map(str::to_string)),
+                "type" | "task_type" => {
+                    for raw in split_filter_values(&value) {
+                        parsed.task_type =
+                            Some(raw.to_ascii_lowercase().parse::<TaskType>().map_err(
+                                |error| format!("invalid `type` value `{raw}`: {error}"),
+                            )?);
+                    }
+                }
+                "limit" => {
+                    if let Some(raw) = split_filter_values(&value).next_back() {
+                        parsed.limit = parse_limit(raw)?;
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(parsed)
+    }
+}
+
+/// Split one query value into its comma-separated parts, trimming each and
+/// dropping empties.
+fn split_filter_values(value: &str) -> impl DoubleEndedIterator<Item = &str> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+}
+
+/// Parse `?limit=`, rejecting zero (which would return nothing) the same way the
+/// CLI's `--limit` does.
+fn parse_limit(raw: &str) -> Result<usize, String> {
+    let value: usize = raw
+        .parse()
+        .map_err(|_| format!("invalid `limit` value `{raw}` (expected a positive integer)"))?;
+    if value == 0 {
+        return Err("`limit` must be at least 1".to_string());
+    }
+    Ok(value)
+}
+
+/// Build the `{ items, total, limit, truncated }` page for `GET /api/tasks`.
+fn task_list_page_json(
+    runtime: &OrbitRuntime,
+    query: &TaskListQuery,
+) -> Result<Value, orbit_core::OrbitError> {
+    let (tasks, total) = filtered_dashboard_tasks(runtime, query)?;
+    let items = task_values(runtime, &tasks)?;
+    let truncated = total > items.len();
+    Ok(json!({
+        "items": items,
+        "total": total,
+        "limit": query.limit,
+        "truncated": truncated,
+    }))
+}
+
+/// Build the dashboard task list as JSON values for the cross-workspace
+/// `/api/tasks/all` aggregate: unfiltered and bounded by the default limit,
+/// exactly as `GET /api/tasks` was before it grew query filters.
 pub(super) fn list_tasks_json(
     runtime: &OrbitRuntime,
 ) -> Result<Vec<Value>, orbit_core::OrbitError> {
-    let tasks = list_dashboard_tasks(runtime)?;
+    let (tasks, _total) = filtered_dashboard_tasks(runtime, &TaskListQuery::default())?;
+    task_values(runtime, &tasks)
+}
+
+fn task_values(
+    runtime: &OrbitRuntime,
+    tasks: &[Task],
+) -> Result<Vec<Value>, orbit_core::OrbitError> {
     let status_by_id = dashboard_status_index(runtime)?;
     tasks
         .iter()
@@ -162,14 +321,31 @@ pub(super) async fn list_task_locks(Ws(runtime): Ws) -> Response {
     }
 }
 
-/// The dashboard task list: status-neutral, newest-first, and bounded
-/// (ORB-10310). `list_tasks` already orders by `created_at DESC` with task ID
-/// ascending for ties, so truncating keeps the newest matching tasks and no
-/// lifecycle status (including `done`/`archived`) is excluded by default.
-fn list_dashboard_tasks(runtime: &OrbitRuntime) -> Result<Vec<Task>, orbit_core::OrbitError> {
-    let mut tasks = runtime.list_tasks()?;
-    tasks.truncate(DEFAULT_TASK_LIST_LIMIT);
-    Ok(tasks)
+/// The dashboard task list: status-neutral by default, newest-first, and
+/// bounded (ORB-10310). Returns the page plus the **pre-limit** match count.
+///
+/// `list_tasks_by_tags` orders by `created_at DESC` with task ID ascending for
+/// ties and applies Orbit's own `normalize_task_tags`/`task_matches_tags`, so
+/// tag matching here is identical to `orbit task list --tag` (a colon is
+/// ordinary tag content). The remaining predicates preserve that order, and —
+/// the point of ORB-10400 — every predicate runs *before* the truncation, so
+/// the page holds the newest tasks matching the filter rather than whatever
+/// survives a truncation of the unfiltered set. With no filters this is exactly
+/// the previous behavior: the newest `DEFAULT_TASK_LIST_LIMIT` tasks of any
+/// lifecycle status, `done`/`archived` included.
+fn filtered_dashboard_tasks(
+    runtime: &OrbitRuntime,
+    query: &TaskListQuery,
+) -> Result<(Vec<Task>, usize), orbit_core::OrbitError> {
+    let mut matching = runtime
+        .list_tasks_by_tags(&query.tags)?
+        .into_iter()
+        .filter(|task| query.statuses.is_empty() || query.statuses.contains(&task.status))
+        .filter(|task| query.task_type.is_none_or(|kind| task.task_type == kind))
+        .collect::<Vec<_>>();
+    let total = matching.len();
+    matching.truncate(query.limit);
+    Ok((matching, total))
 }
 
 /// Dependency-status projection for dashboard task serialization.

--- a/crates/orbit-dashboard/src/api/tests/handlers.rs
+++ b/crates/orbit-dashboard/src/api/tests/handlers.rs
@@ -285,7 +285,8 @@ async fn tasks_with_stale_explicit_crew_fall_back_to_default_projection() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let body = body_json(response).await;
-    let rows = body.as_array().expect("tasks response array");
+    // ORB-10400: GET /tasks answers `{ items, total, limit, truncated }`.
+    let rows = body["items"].as_array().expect("tasks response items");
     let task = rows
         .iter()
         .find(|task| task["id"].as_str() == Some(task_id.as_str()))
@@ -388,7 +389,8 @@ async fn tasks_resolve_dependency_statuses_from_all_tasks() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let body = body_json(response).await;
-    let rows = body.as_array().expect("tasks response array");
+    // ORB-10400: GET /tasks answers `{ items, total, limit, truncated }`.
+    let rows = body["items"].as_array().expect("tasks response items");
     assert!(
         rows.iter()
             .any(|task| task["id"].as_str() == Some(&visible.id))

--- a/crates/orbit-dashboard/src/api/tests/tasks.rs
+++ b/crates/orbit-dashboard/src/api/tests/tasks.rs
@@ -9,7 +9,7 @@ use orbit_common::test_fixtures::TEST_CODEX_MODEL;
 use orbit_common::types::TaskArtifact;
 use orbit_common::types::task_artifacts::{TaskRelation, TaskRelationType};
 use orbit_core::command::task::{TaskAddParams, TaskUpdateParams};
-use orbit_core::{OrbitRuntime, TaskComplexity, TaskStatus};
+use orbit_core::{OrbitRuntime, TaskComplexity, TaskStatus, TaskType};
 use serde_json::{Value, json};
 use tower::ServiceExt;
 
@@ -138,8 +138,14 @@ fn seed_lock_task(
 }
 
 async fn request(runtime: OrbitRuntime, uri: &str) -> axum::response::Response {
+    request_shared(Arc::new(runtime), uri).await
+}
+
+/// `request` against an already-shared runtime, so one fixture can serve several
+/// query variants without reseeding (ORB-10400's filter matrix).
+async fn request_shared(runtime: Arc<OrbitRuntime>, uri: &str) -> axum::response::Response {
     router()
-        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
+        .with_state(crate::state::DashboardState::single(runtime))
         .oneshot(
             Request::builder()
                 .method(Method::GET)
@@ -851,7 +857,7 @@ async fn list_tasks_includes_complexity_when_set() {
     let response = request(runtime, "/tasks").await;
     assert_eq!(response.status(), StatusCode::OK);
     let body = body_json(response).await;
-    let arr = body.as_array().expect("tasks list is array");
+    let arr = task_items(&body);
     let found = arr
         .iter()
         .find(|t| t["id"] == serde_json::json!(with_complexity.id))
@@ -868,15 +874,41 @@ fn seed_task_with_status(
     title: &str,
     status: TaskStatus,
 ) -> orbit_core::Task {
+    seed_filterable_task(runtime, title, status, Vec::new(), None)
+}
+
+/// Seed a task with the attributes `GET /tasks` can filter on (ORB-10400).
+fn seed_filterable_task(
+    runtime: &OrbitRuntime,
+    title: &str,
+    status: TaskStatus,
+    tags: Vec<&str>,
+    task_type: Option<TaskType>,
+) -> orbit_core::Task {
     runtime
         .add_task(TaskAddParams {
             title: title.to_string(),
             description: format!("Fixture task: {title}."),
             status: Some(status),
             workspace_path: Some(".".to_string()),
+            tags: tags.into_iter().map(str::to_string).collect(),
+            task_type,
             ..Default::default()
         })
         .expect("seed task")
+}
+
+/// `GET /tasks` answers the ORB-10400 page envelope
+/// `{ items, total, limit, truncated }`; unwrap `items` for row assertions.
+fn task_items(body: &Value) -> &Vec<Value> {
+    body["items"].as_array().expect("items is an array")
+}
+
+fn task_ids(body: &Value) -> Vec<&str> {
+    task_items(body)
+        .iter()
+        .map(|row| row["id"].as_str().expect("task id"))
+        .collect()
 }
 
 /// ORB-10310: `GET /tasks` is status-neutral — `done` and `archived` tasks
@@ -893,7 +925,7 @@ async fn list_tasks_includes_done_and_archived_statuses_newest_first() {
     let response = request(runtime, "/tasks").await;
     assert_eq!(response.status(), StatusCode::OK);
     let body = body_json(response).await;
-    let rows = body.as_array().expect("tasks list is array");
+    let rows = task_items(&body);
 
     for expected in [&proposed.id, &done.id, &to_archive.id] {
         assert!(
@@ -939,7 +971,7 @@ async fn list_tasks_is_bounded_to_default_limit() {
     let response = request(runtime, "/tasks").await;
     assert_eq!(response.status(), StatusCode::OK);
     let body = body_json(response).await;
-    let rows = body.as_array().expect("tasks list is array");
+    let rows = task_items(&body);
     assert_eq!(rows.len(), 50, "default limit bounds the response to 50");
     let oldest = oldest.expect("seeded at least one task");
     assert!(
@@ -948,6 +980,229 @@ async fn list_tasks_is_bounded_to_default_limit() {
             .any(|row| row["id"].as_str() == Some(oldest.as_str())),
         "the oldest task must fall outside the newest 50"
     );
+    // ORB-10400: the page metadata is what tells a client the window is partial.
+    assert_eq!(
+        body["total"],
+        json!(55),
+        "total counts every match pre-limit"
+    );
+    assert_eq!(body["limit"], json!(50));
+    assert_eq!(body["truncated"], json!(true));
+}
+
+/// ORB-10400: every filter predicate is applied *before* the limit. The
+/// regression fixture puts the only matching task beyond the first
+/// `DEFAULT_TASK_LIST_LIMIT` unfiltered rows — the exact shape that made
+/// matches unrecoverable to bridge, which could only filter the already
+/// truncated array client-side.
+#[tokio::test]
+async fn list_tasks_filters_before_limit() {
+    let runtime = Arc::new(OrbitRuntime::in_memory().expect("build runtime"));
+    let buried = seed_filterable_task(
+        &runtime,
+        "Buried proposed task",
+        TaskStatus::Proposed,
+        vec!["auto-task:qa-sweep"],
+        None,
+    );
+    // 60 newer tasks bury it well outside the unfiltered 50-row window.
+    for index in 0..60 {
+        seed_task_with_status(
+            &runtime,
+            &format!("Newer backlog task {index:02}"),
+            TaskStatus::Backlog,
+        );
+    }
+
+    let unfiltered = body_json(request_shared(runtime.clone(), "/tasks").await).await;
+    assert!(
+        !task_ids(&unfiltered).contains(&buried.id.as_str()),
+        "fixture must bury the match outside the unfiltered window"
+    );
+
+    for uri in [
+        "/tasks?status=proposed",
+        "/tasks?tag=auto-task:qa-sweep",
+        "/tasks?status=proposed&tag=auto-task:qa-sweep",
+    ] {
+        let response = request_shared(runtime.clone(), uri).await;
+        assert_eq!(response.status(), StatusCode::OK, "{uri}");
+        let body = body_json(response).await;
+        assert_eq!(
+            task_ids(&body),
+            vec![buried.id.as_str()],
+            "{uri} must return the buried match"
+        );
+        assert_eq!(body["total"], json!(1), "{uri}");
+        assert_eq!(
+            body["truncated"],
+            json!(false),
+            "{uri} is a complete result, not a truncated window"
+        );
+    }
+}
+
+/// ORB-10400: a colon-bearing tag is matched as one whole tag through Orbit's
+/// `normalize_task_tags`/`task_matches_tags` semantics — never split on `:` into
+/// `auto-task` + `qa-sweep`. Only `,` separates values.
+#[tokio::test]
+async fn list_tasks_matches_colon_bearing_tag_exactly() {
+    let runtime = Arc::new(OrbitRuntime::in_memory().expect("build runtime"));
+    let sweep = seed_filterable_task(
+        &runtime,
+        "Sweep task",
+        TaskStatus::Backlog,
+        vec!["auto-task:qa-sweep"],
+        None,
+    );
+    // Decoys that would match if the tag were split on `:` or matched by prefix.
+    seed_filterable_task(
+        &runtime,
+        "Other auto task",
+        TaskStatus::Backlog,
+        vec!["auto-task"],
+        None,
+    );
+    seed_filterable_task(
+        &runtime,
+        "Other sweep task",
+        TaskStatus::Backlog,
+        vec!["qa-sweep"],
+        None,
+    );
+    seed_filterable_task(
+        &runtime,
+        "Longer sweep tag",
+        TaskStatus::Backlog,
+        vec!["auto-task:qa-sweep-extended"],
+        None,
+    );
+
+    let body =
+        body_json(request_shared(runtime.clone(), "/tasks?tag=auto-task:qa-sweep").await).await;
+    assert_eq!(task_ids(&body), vec![sweep.id.as_str()]);
+    assert_eq!(body["total"], json!(1));
+
+    // Percent-encoded `%3A` is the same tag, and tags are normalized (trimmed,
+    // lowercased) exactly as the CLI normalizes `--tag`.
+    let encoded =
+        body_json(request_shared(runtime.clone(), "/tasks?tag=%20AUTO-TASK%3Aqa-sweep").await)
+            .await;
+    assert_eq!(task_ids(&encoded), vec![sweep.id.as_str()]);
+
+    // Repeated `tag` is AND, so a tag the task lacks yields a complete empty
+    // result — distinguishable from truncation by `total: 0`.
+    let anded =
+        body_json(request_shared(runtime, "/tasks?tag=auto-task:qa-sweep&tag=qa-sweep").await)
+            .await;
+    assert!(task_items(&anded).is_empty());
+    assert_eq!(anded["total"], json!(0));
+    assert_eq!(anded["truncated"], json!(false));
+}
+
+/// ORB-10400: status is OR across values (repeated and/or comma-separated),
+/// type is an equality filter, and `limit` overrides the default — matching
+/// `orbit task list` semantics for the same flags.
+#[tokio::test]
+async fn list_tasks_honors_status_type_and_limit_filters() {
+    let runtime = Arc::new(OrbitRuntime::in_memory().expect("build runtime"));
+    let bug = seed_filterable_task(
+        &runtime,
+        "Bug task",
+        TaskStatus::Proposed,
+        Vec::new(),
+        Some(TaskType::Bug),
+    );
+    let feature = seed_filterable_task(
+        &runtime,
+        "Feature task",
+        TaskStatus::Review,
+        Vec::new(),
+        Some(TaskType::Feature),
+    );
+    let chore = seed_filterable_task(
+        &runtime,
+        "Chore task",
+        TaskStatus::Backlog,
+        Vec::new(),
+        Some(TaskType::Chore),
+    );
+
+    let csv =
+        body_json(request_shared(runtime.clone(), "/tasks?status=proposed,review").await).await;
+    let mut ids = task_ids(&csv);
+    ids.sort_unstable();
+    let mut expected = vec![bug.id.as_str(), feature.id.as_str()];
+    expected.sort_unstable();
+    assert_eq!(ids, expected, "status is OR across values");
+
+    let repeated =
+        body_json(request_shared(runtime.clone(), "/tasks?status=proposed&status=review").await)
+            .await;
+    assert_eq!(
+        task_items(&repeated).len(),
+        2,
+        "repeated status accumulates"
+    );
+
+    let typed = body_json(request_shared(runtime.clone(), "/tasks?type=chore").await).await;
+    assert_eq!(task_ids(&typed), vec![chore.id.as_str()]);
+
+    // Filters compose: a type that no `proposed` task carries is empty.
+    let composed =
+        body_json(request_shared(runtime.clone(), "/tasks?status=proposed&type=chore").await).await;
+    assert!(task_items(&composed).is_empty());
+    assert_eq!(composed["total"], json!(0));
+
+    // `limit` truncates the filtered set and is reported back with `truncated`.
+    let limited = body_json(request_shared(runtime, "/tasks?limit=1").await).await;
+    assert_eq!(task_items(&limited).len(), 1);
+    assert_eq!(limited["limit"], json!(1));
+    assert_eq!(limited["total"], json!(3));
+    assert_eq!(limited["truncated"], json!(true));
+}
+
+/// ORB-10400: an unparseable filter is a loud 400. Silently dropping it would
+/// answer an unfiltered page that a client cannot distinguish from a real match
+/// set — the failure mode this task exists to remove.
+#[tokio::test]
+async fn list_tasks_rejects_invalid_filter_values() {
+    for uri in [
+        "/tasks?status=nonsense",
+        "/tasks?type=nonsense",
+        "/tasks?limit=0",
+        "/tasks?limit=many",
+    ] {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let response = request(runtime, uri).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{uri}");
+        let body = body_json(response).await;
+        assert!(
+            body["error"].as_str().is_some_and(|msg| !msg.is_empty()),
+            "{uri} must explain the rejected value: {body:?}"
+        );
+    }
+}
+
+/// ORB-10400: empty filter values behave like an omitted filter (matching the
+/// `?workspace=` convention), and the `?workspace=` selector itself — which
+/// shares this query string — is never mistaken for a task filter.
+#[tokio::test]
+async fn list_tasks_ignores_empty_values_and_the_workspace_selector() {
+    let runtime = Arc::new(OrbitRuntime::in_memory().expect("build runtime"));
+    seed_task_with_status(&runtime, "Only task", TaskStatus::Backlog);
+
+    for uri in [
+        "/tasks?status=&tag=&type=&limit=",
+        "/tasks?workspace=default",
+    ] {
+        let response = request_shared(runtime.clone(), uri).await;
+        assert_eq!(response.status(), StatusCode::OK, "{uri}");
+        let body = body_json(response).await;
+        assert_eq!(task_items(&body).len(), 1, "{uri}");
+        assert_eq!(body["limit"], json!(50), "{uri} keeps the default limit");
+        assert_eq!(body["truncated"], json!(false), "{uri}");
+    }
 }
 
 /// ORB-00042: `workspace` is a selector and lives in the query string, never

--- a/crates/orbit-dashboard/src/api/tests/workspaces.rs
+++ b/crates/orbit-dashboard/src/api/tests/workspaces.rs
@@ -336,7 +336,8 @@ async fn cross_workspace_dependency_resolves_global_status_not_missing() {
         .expect("response");
     assert_eq!(response.status(), StatusCode::OK);
     let body = body_json(response).await;
-    let tasks = body.as_array().expect("array");
+    // ORB-10400: GET /tasks answers `{ items, total, limit, truncated }`.
+    let tasks = body["items"].as_array().expect("items");
     assert_eq!(
         tasks.len(),
         1,
@@ -418,10 +419,10 @@ async fn task_titles(state: &DashboardState, workspace: &str) -> Vec<String> {
         .await
         .expect("response");
     assert_eq!(response.status(), StatusCode::OK);
-    body_json(response)
-        .await
+    // ORB-10400: GET /tasks answers `{ items, total, limit, truncated }`.
+    body_json(response).await["items"]
         .as_array()
-        .expect("array")
+        .expect("items")
         .iter()
         .map(|t| t["title"].as_str().expect("title").to_string())
         .collect()

--- a/docs/design/remote-access/1_overview.md
+++ b/docs/design/remote-access/1_overview.md
@@ -1,7 +1,7 @@
 ---
 title: "Remote Access — Overview"
 owner: claude
-last_updated: 2026-07-18
+last_updated: 2026-07-26
 status: Accepted
 feature: remote-access
 doc_role: overview
@@ -10,7 +10,7 @@ summary: "How an operator views Orbit across every local workspace and across ma
 tags: [remote-access]
 paths: ["crates/orbit-dashboard/**", "crates/orbit-remote/src/runtime.rs", "crates/orbit-remote/src/workspace_registry.rs", "crates/orbit-cli/src/command/web.rs", "crates/orbit-cli/src/command/operation.rs"]
 related_features: [remote-access, user-interface, host-registry]
-related_artifacts: [ORB-00029, ORB-00030, ORB-00360, ORB-10029, ORB-10200, ORB-10319, ADR-0200, ADR-0201]
+related_artifacts: [ORB-00029, ORB-00030, ORB-00360, ORB-10029, ORB-10200, ORB-10310, ORB-10319, ORB-10400, ADR-0200, ADR-0201]
 ---
 
 # Remote Access — Overview
@@ -60,6 +60,7 @@ Remote access shows what already exists on a machine that is online and reachabl
 | Workspace-keyed runtime map + `Ws` extractor | [crates/orbit-dashboard/src/state.rs](../../../crates/orbit-dashboard/src/state.rs) | [ORB-00030] |
 | Logical-workspace catalog + registered-checkout runtime construction | [crates/orbit-remote/src/workspace_registry.rs](../../../crates/orbit-remote/src/workspace_registry.rs), [crates/orbit-remote/src/runtime.rs](../../../crates/orbit-remote/src/runtime.rs) | [ORB-10319] |
 | Aggregate endpoints (`/api/workspaces`, `/api/tasks/all`) | [crates/orbit-dashboard/src/api/workspaces.rs](../../../crates/orbit-dashboard/src/api/workspaces.rs) | [ORB-00030] |
+| Task-list filters + page envelope (`GET /api/tasks`) | [crates/orbit-dashboard/src/api/tasks.rs](../../../crates/orbit-dashboard/src/api/tasks.rs) | [ORB-10310], [ORB-10400] |
 | SSH tunnel, port selection, teardown | [crates/orbit-dashboard/src/connect.rs](../../../crates/orbit-dashboard/src/connect.rs) | [ORB-00029] |
 | CLI runtime-free operation policy (dispatch before eager runtime init) | [crates/orbit-cli/src/command/operation.rs](../../../crates/orbit-cli/src/command/operation.rs) | [ORB-00029], [ORB-00030], [ORB-10200] |
 | `web` subcommand wiring | [crates/orbit-cli/src/command/web.rs](../../../crates/orbit-cli/src/command/web.rs) | [ORB-00029] |
@@ -77,5 +78,7 @@ Remote access shows what already exists on a machine that is online and reachabl
 - [ORB-10029] — Made global mode the default and only mode for `orbit web serve`; `--global` is now a deprecated no-op retained for `connect` passthrough.
 - [ORB-10200] — Moved runtime-free web dispatch into the exhaustive command-operation registry.
 - [ORB-10319] — Made the dashboard consume the Remote-owned workspace catalog and runtime factory instead of Core-owned registry composition.
+- [ORB-10310] — Made task listing status-neutral and bounded by a default limit across the CLI, MCP, and dashboard surfaces.
+- [ORB-10400] — Gave `GET /api/tasks` server-side status/tag/type filters applied before the limit, plus `{ items, total, limit, truncated }` page metadata. See [2_design.md §2.2](./2_design.md).
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/remote-access/2_design.md
+++ b/docs/design/remote-access/2_design.md
@@ -1,16 +1,16 @@
 ---
 title: "Remote Access — Design"
 owner: claude
-last_updated: 2026-07-18
+last_updated: 2026-07-26
 status: Accepted
 feature: remote-access
 doc_role: design
 type: design
-summary: "The two shipped surfaces — global multi-workspace serve (the only mode since ORB-10029) and SSH-tunnel connect — their state model, and how they compose."
+summary: "The two shipped surfaces — global multi-workspace serve (the only mode since ORB-10029) and SSH-tunnel connect — their state model, the dashboard task-list endpoint contract, and how they compose."
 tags: [remote-access]
 paths: ["crates/orbit-dashboard/**", "crates/orbit-remote/src/runtime.rs", "crates/orbit-remote/src/workspace_registry.rs", "crates/orbit-cli/src/command/web.rs", "crates/orbit-cli/src/command/operation.rs"]
 related_features: [remote-access, user-interface, host-registry]
-related_artifacts: [ORB-00029, ORB-00030, ORB-00360, ORB-10029, ORB-10200, ORB-10294, ORB-10319, ADR-0200, ADR-0201, ADR-0234]
+related_artifacts: [ORB-00029, ORB-00030, ORB-00360, ORB-10029, ORB-10200, ORB-10294, ORB-10310, ORB-10319, ORB-10400, ADR-0200, ADR-0201, ADR-0234]
 ---
 
 # Remote Access — Design
@@ -55,6 +55,32 @@ Two aggregate endpoints expose the machine-wide surface:
 
 The frontend adds a header workspace selector and an "All workspaces" aggregate task view. `common.js` wraps every fetch in `withWorkspace()` (appending `?workspace=` unless already present); `app.js` uses `/api/tasks/all` when more than one workspace exists and none is selected.
 
+### 2.2 `GET /api/tasks` — server-side filters and page metadata ([ORB-10400])
+
+The workspace-scoped task list is the endpoint programmatic clients (notably Bridge's `orbit_task_list`) read, so it carries the native `orbit task list` filters rather than making each client re-derive them:
+
+| Query parameter | Semantics |
+|---|---|
+| `status` | Repeatable and/or comma-separated. **OR** across values; omitted is status-neutral (every lifecycle status, `done`/`archived` included — [ORB-10310]). |
+| `tag` (alias `tags`) | Repeatable and/or comma-separated. **AND** across values, normalized by `normalize_task_tags`/`task_matches_tags` — the same predicate `orbit task list --tag` uses. Only `,` separates values, so a colon is ordinary tag content and `auto-task:qa-sweep` matches that whole tag. |
+| `type` (alias `task_type`) | A single `feature`/`bug`/`refactor`/`chore`. |
+| `limit` | Positive integer; defaults to `DEFAULT_TASK_LIST_LIMIT` (50). |
+
+Unknown keys are ignored — the `?workspace=<id>` selector consumed by the `Ws` extractor shares this query string — but an *unparseable* value for a recognized key is a `400`, never a silently dropped filter that would return an unfiltered page a client cannot distinguish from a real match set.
+
+The response is a page envelope rather than a bare array:
+
+```json
+{ "items": [ /* task objects, newest first */ ], "total": 137, "limit": 50, "truncated": true }
+```
+
+Two properties make this usable as a provider contract:
+
+- **Every predicate is applied before the limit.** `items` holds the newest *matching* tasks, so a match older than the newest `limit` unfiltered tasks is still reachable by passing its filters. Before [ORB-10400] the handler truncated the unfiltered set to 50 and offered no filters at all, so any client filtering the response client-side simply lost every older match — Bridge saw one `auto-task:qa-sweep` task where the CLI saw seven, and 13 `proposed` where the CLI saw 14.
+- **`total` and `truncated` distinguish empty from truncated.** `total` is the pre-limit match count and `truncated` is `total > items.len()`, so `{"items": [], "total": 0}` is a genuinely empty result while a partial window announces itself.
+
+Consumers accept either shape (`items` when present, else the array) — the `/api/tasks/all` aggregate is still a bare array, takes no filters, and is bounded by the same default limit. `common.js` exposes `listItems(payload)` for the frontend; Bridge's `_as_items` already had the same tolerance.
+
 ## 3. SSH-tunnel connect
 
 [`connect`](../../../crates/orbit-dashboard/src/connect.rs) automates the manual `ssh -L 7878:localhost:7878 <host> "orbit web serve --no-open"` dance and nothing more. Given `orbit web connect <ssh-host>`:
@@ -93,6 +119,8 @@ Neither surface touches the loopback-only bind guard from [ORB-00360]: `check_bi
 - [ORB-10029] — Made global mode the only mode for `orbit web serve`; `--global` is now a deprecated no-op kept for `connect` passthrough compatibility.
 - [ORB-10200] — Moved runtime-free web dispatch into the exhaustive command-operation registry.
 - [ORB-10294] — Live per-request registry refresh (§2.1): native workspace add/remove/rebind is honored without a restart, with atomic snapshot swap, runtime eviction, keep-last-valid on malformed reads, and no auto-delete. See [ADR-0234](./4_decisions.md).
+- [ORB-10310] — Made every task-listing surface status-neutral and bounded by `DEFAULT_TASK_LIST_LIMIT`.
 - [ORB-10319] — Moved logical-workspace catalog and registered-checkout runtime construction into `orbit-remote`; dashboard behavior is unchanged.
+- [ORB-10400] — Gave `GET /api/tasks` server-side status/tag/type filters applied before the limit, plus the `{ items, total, limit, truncated }` page envelope (§2.2). Prerequisite for Bridge's `orbit_task_list` (ws_bridge ORB-10398), which could previously only filter an already-truncated array client-side.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10400](https://orbit-cli.com/tasks/ORB-10400) — Make GET /api/tasks filter before limit and report truncation

### Description

## Problem

Bridge orbit_task_list can only fetch Orbit dashboard GET /api/tasks and then filter client-side. The HTTP handler currently accepts no filter query, calls runtime.list_tasks(), and truncates the unfiltered newest-first set to DEFAULT_TASK_LIST_LIMIT=50. Matches older than that window are therefore unrecoverable to Bridge.

## Boundary evidence captured from ORB-10398 on 2026-07-25

- GET /api/tasks?workspace=ws_orbit returned a bare array of exactly 50 rows, ending at ORB-10338, with no total, limit, or truncated signal. ORB-10309 was absent.
- The HTTP window contained only ORB-10399 for tag auto-task:qa-sweep, while on-box orbit task list --tag auto-task:qa-sweep returned seven rows: ORB-10399, ORB-10309, ORB-10250, ORB-10244, ORB-10239, ORB-10219, and ORB-10154. This proves colon-bearing tags work when the row is inside the HTTP window; the apparent colon failure is pre-filter truncation.
- GET /api/tasks contained 13 proposed rows, while orbit task list --status proposed returned 14, additionally including ORB-10243 beyond the HTTP window.
- Bridge source sends only the workspace query and applies status/tag/type after receiving the already-truncated array, so it cannot repair this loss locally.

## Required change

Give GET /api/tasks query-level status, tag, and type filters matching the native task-list semantics, apply all predicates before the requested/default limit, and return pagination metadata that distinguishes an empty complete result from an empty/truncated window. Keep dashboard compatibility and document the response contract needed by Bridge ORB-10398. Reuse normalize_task_tags/task_matches_tags semantics so colon is treated as ordinary tag content.

## Coordination

This is the Orbit-side prerequisite discovered while executing ws_bridge ORB-10398. Once it lands, ORB-10398 can forward filters and expose the endpoint metadata without inventing a second provider/filtering contract.

### Acceptance Criteria

- GET /api/tasks accepts workspace routing plus status, tag, and type filters and returns the same task IDs/order as on-box orbit task list for the same filters and limit.
- All status/tag/type predicates are applied before limit; a regression fixture places a matching task beyond the first unfiltered DEFAULT_TASK_LIST_LIMIT rows and still returns it.
- A colon-bearing tag such as auto-task:qa-sweep matches exactly using Orbit tag normalization; regression coverage proves it is not split on colon.
- The JSON response includes enough metadata to distinguish complete empty results from truncation, such as items plus total, limit, and truncated, and dashboard consumers remain compatible.
- Live reproduction in ws_orbit returns all seven current auto-task:qa-sweep tasks and all proposed tasks visible to the CLI when queried with the same default limit.

## Execution Summary

<details>
<summary>Click to expand</summary>

GET /api/tasks now filters server-side before the limit and reports page metadata.

## Change

`crates/orbit-dashboard/src/api/tasks.rs`:
- New `TaskListQuery` parsed from the raw query string with `url::form_urlencoded` (same mechanism the `Ws` extractor uses, so the shared `?workspace=` selector and any other unknown key are simply ignored). Supported: `status` (repeatable and/or comma-separated, OR semantics), `tag`/`tags` (repeatable and/or comma-separated, AND semantics), `type`/`task_type`, `limit`. Empty values behave like an omitted filter; an unparseable value is a 400 with the offending value named, never a silently dropped filter.
- `list_dashboard_tasks` became `filtered_dashboard_tasks`, which lists through `runtime.list_tasks_by_tags(&tags)` — the same call `orbit task list` makes, so tag matching reuses `normalize_task_tags`/`task_matches_tags` and a colon is ordinary tag content — then applies status and type predicates, records the pre-limit match count, and only then truncates. Every predicate runs before the limit.
- `GET /api/tasks` answers `{ items, total, limit, truncated }` (`truncated = total > items.len()`), so an empty complete result (`total: 0`) is distinguishable from a window whose matches fell outside it. `list_tasks_json` (the `/api/tasks/all` aggregate) keeps its previous exact behavior: unfiltered, default limit, bare array.

Dashboard consumer: `common.js` gained a shared `listItems(payload)` that accepts the envelope or a bare array; `app.js` unwraps through it at the single task-list call site. Bridge's existing `_as_items` helper already had the same tolerance, so bridge does not break before ORB-10398 lands.

Docs: `docs/design/remote-access/2_design.md` §2.2 documents the query parameters, the envelope, and the two properties bridge needs; `1_overview.md` gained an At a Glance row. Both frontmatter blocks bumped.

## Validation

- `cargo test -p orbit-dashboard` — 207 passed, 0 failed.
- `cargo clippy -p orbit-dashboard --all-targets` — clean.
- `make ci-fast` — exit 0.
- `node --check` on both changed JS modules.

New regression tests in `crates/orbit-dashboard/src/api/tests/tasks.rs`:
- `list_tasks_filters_before_limit` — the only matching task is buried behind 60 newer ones (outside the unfiltered 50-row window); asserts it is absent unfiltered and returned by `?status=proposed`, `?tag=auto-task:qa-sweep`, and both combined.
- `list_tasks_matches_colon_bearing_tag_exactly` — `auto-task:qa-sweep` matches only the whole tag, with `auto-task`, `qa-sweep`, and `auto-task:qa-sweep-extended` decoys present; also covers `%3A` encoding, normalization, and repeated-tag AND.
- `list_tasks_honors_status_type_and_limit_filters`, `list_tasks_rejects_invalid_filter_values`, `list_tasks_ignores_empty_values_and_the_workspace_selector`.
- `list_tasks_is_bounded_to_default_limit` extended to assert `total`/`limit`/`truncated`.

## Live reproduction (ws_orbit, this branch's binary on port 7979)

Unfiltered: `items=50, total=622, truncated=true`, window bottoming out at ORB-10358.
- `?tag=auto-task:qa-sweep` -> 8 items, `total=8`, `truncated=false`: ORB-10403, 10399, 10309, 10250, 10244, 10239, 10219, 10154 — byte-identical to `orbit task list --tag auto-task:qa-sweep` (the task description's seven, plus ORB-10403 filed since it was written). All but ORB-10403/10399 sit outside the unfiltered window.
- `?status=proposed` -> 26 items, `total=26`, `truncated=false` — identical ID set and order to `orbit task list --status proposed`, including ORB-10243 which is far outside the window.
- `?status=proposed&tag=auto-task:qa-sweep` -> [ORB-10403]; `?type=feature&tag=auto-task:qa-sweep` -> `items=[], total=0, truncated=false` (complete empty, not truncation); `?status=nonsense` -> 400 with a naming message; `?limit=200` -> `items=200, total=622, truncated=true`; `/api/tasks/all` still a bare 50-element array.

## Not done

No ADR record: this activity's tool allowlist has no `orbit.adr.*`, so the global ID could not be allocated and CONVENTIONS.md §4 forbids hand-authored `## ADR-` headings. The decision and its rejected alternative live in 2_design.md §2.2 prose; see the task comment.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10400-6a655ade`
- Behind base: 0
- Ahead of base: 1