### PR TITLE
orbit-core Tier 1 sweep: delete dead fns, dead root re-exports, narrow command/ module visibility

### DIFF
--- a/crates/orbit-core/src/command/init.rs
+++ b/crates/orbit-core/src/command/init.rs
@@ -66,10 +66,6 @@ pub struct InitOptions {
 }
 
 impl OrbitRuntime {
-    pub fn init_workspace(&self) -> Result<InitResult, OrbitError> {
-        self.init_workspace_with_options(InitOptions::default())
-    }
-
     pub fn init_workspace_with_options(
         &self,
         options: InitOptions,
@@ -114,21 +110,6 @@ pub fn init_global(
         InitOptions {
             global_only: true,
             link_global_skills: true,
-            ..options
-        },
-    )
-}
-
-pub fn init_workspace_from_root_override(
-    root_override: Option<&Path>,
-    options: InitOptions,
-) -> Result<InitResult, OrbitError> {
-    let cwd = std::env::current_dir().map_err(|e| OrbitError::Io(e.to_string()))?;
-    let roots = OrbitRuntime::resolve_bootstrap_roots_for_cwd(&cwd, root_override)?;
-    init_workspace_at_root(
-        &roots.shared_root,
-        InitOptions {
-            global_root_override: Some(roots.global_root),
             ..options
         },
     )

--- a/crates/orbit-core/src/command/mod.rs
+++ b/crates/orbit-core/src/command/mod.rs
@@ -15,26 +15,26 @@
 /// [ORB-10016] and stamps the same identity.
 pub const SYSTEM_AUDIT_IDENTITY: &str = "system";
 
-pub mod activity;
+pub(crate) mod activity;
 pub mod audit_event;
 pub mod backend_resolver;
-pub mod docs;
-pub mod executor;
+pub(crate) mod docs;
+pub(crate) mod executor;
 pub mod gc;
 pub mod init;
 pub mod job;
 pub mod learning;
-pub mod learning_authoring;
-pub mod pipeline_run;
-pub mod policy;
-pub mod routine;
-pub mod search;
+pub(crate) mod learning_authoring;
+pub(crate) mod pipeline_run;
+pub(crate) mod policy;
+pub(crate) mod routine;
+pub(crate) mod search;
 pub mod semantic;
 pub mod skill;
 pub mod task;
 pub mod task_migration;
 pub mod tool;
-pub mod workflow;
+pub(crate) mod workflow;
 
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-core/src/command/task/transitions.rs
+++ b/crates/orbit-core/src/command/task/transitions.rs
@@ -180,17 +180,6 @@ impl OrbitRuntime {
         )
     }
 
-    pub fn start_task_with_identity(
-        &self,
-        id: &str,
-        note: Option<String>,
-        comment: Option<String>,
-        agent: Option<String>,
-        model: Option<String>,
-    ) -> Result<Task, OrbitError> {
-        self.start_task_with_identity_and_crew(id, note, comment, agent, model, None)
-    }
-
     pub fn start_task_with_identity_and_crew(
         &self,
         id: &str,

--- a/crates/orbit-core/src/command/workflow.rs
+++ b/crates/orbit-core/src/command/workflow.rs
@@ -202,43 +202,6 @@ pub struct WorkflowInput {
     pub pr_number: Option<String>,
 }
 
-pub fn validate_workflow_flags(
-    workflow: &Workflow,
-    input: &WorkflowInput,
-) -> Result<(), OrbitError> {
-    if !workflow.supports_tasks && input.tasks.is_some() {
-        return Err(OrbitError::InvalidInput(format!(
-            "explicit task selection is not supported by workflow '{}'",
-            workflow.alias
-        )));
-    }
-    if !workflow.supports_parallelism && input.parallelism.is_some() {
-        return Err(OrbitError::InvalidInput(format!(
-            "--parallelism is not supported by workflow '{}'",
-            workflow.alias
-        )));
-    }
-    if !workflow.supports_base && input.base.is_some() {
-        return Err(OrbitError::InvalidInput(format!(
-            "--base is not supported by workflow '{}'",
-            workflow.alias
-        )));
-    }
-    if !workflow.supports_pr_number && input.pr_number.is_some() {
-        return Err(OrbitError::InvalidInput(format!(
-            "--pr-number is not supported by workflow '{}'",
-            workflow.alias
-        )));
-    }
-    if workflow.requires_pr_number && input.pr_number.is_none() {
-        return Err(OrbitError::InvalidInput(format!(
-            "--pr-number is required for workflow '{}'",
-            workflow.alias
-        )));
-    }
-    Ok(())
-}
-
 pub fn build_workflow_input(input: &WorkflowInput) -> Result<Value, OrbitError> {
     build_workflow_input_for(None, input)
 }

--- a/crates/orbit-core/src/config/store.rs
+++ b/crates/orbit-core/src/config/store.rs
@@ -123,10 +123,6 @@ impl ConfigStore {
         &self.path
     }
 
-    pub fn exists_on_disk(&self) -> bool {
-        self.path.exists()
-    }
-
     /// The fully resolved (defaulted) view of this document, as if it were
     /// loaded as the effective `config.toml`. Used by both `orbit config
     /// show` and `orbit config get` so they report identical values for the

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -67,10 +67,6 @@ pub use orbit_tools::prepare_remote_task_artifact_put;
 // Command-layer types the CLI names in its clap surfaces.
 pub use command::docs::{DocType, TaskRelatedDoc};
 pub use command::learning::migrate_learning_layout_at;
-pub use command::learning_authoring::{
-    LEARNING_AUTHOR_OPT_IN_ENV, LearningAuthorRole, LearningWriteAttempt,
-    ensure_learning_write_allowed, learning_author_role,
-};
 pub use command::search::{
     GlobalSearchHit, GlobalSearchKind, GlobalSearchParams, task_selectors_contain_path,
 };
@@ -88,8 +84,8 @@ pub use orbit_common::types::{
     JobRunState, JobRunStep, JobTargetType, Learning, LearningEvidence, LearningScope,
     LearningStatus, ProjectionFreshness, SanitizedExecutionProfile, SanitizedWorkspacePresence,
     StoredExecutionProfile, Task, TaskComplexity, TaskCreateStatus, TaskPriority, TaskStatus,
-    TaskType, WorkspaceOwnership, WorkspacePresenceDeclaration, build_task_status_index,
-    resolve_task_dependencies, task_dependencies_ready,
+    TaskType, WorkspaceOwnership, WorkspacePresenceDeclaration, resolve_task_dependencies,
+    task_dependencies_ready,
 };
 pub use orbit_common::types::{MissedRunPolicy, NotFoundKind, OrbitError, OverlapPolicy};
 pub use orbit_common::utility::redaction::redact_sensitive_env_text;

--- a/crates/orbit-core/src/runtime/engine/summary.rs
+++ b/crates/orbit-core/src/runtime/engine/summary.rs
@@ -70,17 +70,4 @@ impl OrbitRuntime {
             orbit_store::scoreboard_summary::write_summary(&self.paths().scoreboard_dir, &summary)?;
         Ok(summary)
     }
-
-    pub fn scoreboard_summary_path(&self) -> std::path::PathBuf {
-        orbit_store::scoreboard_summary::summary_path(&self.paths().scoreboard_dir)
-    }
-
-    /// Read the append-only duel scoreboard log. The CLI's
-    /// `orbit duel scoreboard` command aggregates the returned runs in
-    /// memory via `orbit_store::duel_scoreboard::aggregate`. Returns an
-    /// empty vector when the file does not yet exist — an unrun
-    /// scoreboard is not an error condition.
-    pub fn load_duel_runs(&self) -> Result<Vec<orbit_common::types::DuelRun>, OrbitError> {
-        orbit_store::duel_scoreboard::load_runs(&self.paths().scoreboard_dir)
-    }
 }

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -135,28 +135,6 @@ impl OrbitRuntime {
         }
     }
 
-    /// Initialize a runtime against an already-initialized workspace, returning
-    /// `Ok(None)` when no initialized workspace is discovered from cwd.
-    ///
-    /// Unlike [`Self::initialize_with_root_override`], this does not bootstrap
-    /// a new `.orbit/` directory. Intended for long-running services like
-    /// `orbit mcp serve` that may be invoked from arbitrary directories and
-    /// must not silently materialize workspace state.
-    pub fn try_initialize_existing(
-        root_override: Option<&Path>,
-    ) -> Result<Option<Self>, OrbitError> {
-        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        let Some(resolved) = try_resolve_initialized_roots(&cwd, root_override)? else {
-            return Ok(None);
-        };
-        let global_root = resolve_global_root()?;
-        Ok(Some(Self::from_resolved_roots(
-            &global_root,
-            &resolved.shared_root,
-            &resolved.local_root,
-        )?))
-    }
-
     pub fn resolve_roots_for_cwd(
         cwd: &Path,
         root_override: Option<&Path>,
@@ -213,10 +191,6 @@ impl OrbitRuntime {
             resolve_global_root()?
         };
         Ok(OrbitRuntimeRoots::new(global_root, resolved))
-    }
-
-    pub fn from_data_root(data_root: &Path) -> Result<Self, OrbitError> {
-        Self::from_resolved_roots(data_root, data_root, data_root)
     }
 
     pub fn from_roots(global_root: &Path, workspace_root: &Path) -> Result<Self, OrbitError> {
@@ -306,11 +280,6 @@ impl OrbitRuntime {
         &self.layout_report
     }
 
-    pub fn with_policy(mut self, policy: orbit_policy::PolicyEngine) -> Self {
-        self.context.set_policy(policy);
-        self
-    }
-
     pub fn with_actor(mut self, actor: ActorIdentity) -> Self {
         self.context.set_actor(actor);
         self
@@ -335,23 +304,6 @@ impl OrbitRuntime {
         Err(OrbitError::Execution(format!(
             "v1 job lookup is retired; refusing to resolve job '{job_id}' through OrbitRuntime::get_job. Use schemaVersion: 2 job assets with `orbit job run` or `orbit run` instead."
         )))
-    }
-
-    pub fn execution_env_config(&self) -> (bool, Vec<String>) {
-        (
-            self.context.execution_env_policy().inherit(),
-            self.context.execution_env_policy().pass().to_vec(),
-        )
-    }
-
-    pub fn codex_execution_config(&self) -> (String, Option<String>) {
-        (
-            self.context.codex_execution_policy().sandbox().to_string(),
-            self.context
-                .codex_execution_policy()
-                .approval_policy()
-                .map(ToString::to_string),
-        )
     }
 
     pub fn shared_root(&self) -> PathBuf {


### PR DESCRIPTION
## Task

[ORB-10386](https://orbit-cli.com/tasks/ORB-10386) — orbit-core Tier 1 sweep: delete dead fns, dead root re-exports, narrow command/ module visibility

### Description

Wave 1 of the orbit-core cleanup (design doc: ~/workspace/constellation/knowledgebase/polaris/design/orbit-cleanup/orbit-core-cleanup.md §1–3; line refs @ agent-main 6a2b767 — re-verify with the compiler before deleting).

Scope (pure refactor, no behavior change):
1. Delete the 12 dead public functions listed in §1 (each has exactly one workspace-wide occurrence — its own definition). Confirm each with cargo check before removal; several are pub on OrbitRuntime, so note the public-surface removal in the PR description.
2. Delete the 6 dead root re-exports from lib.rs (§2): the learning_authoring cluster (LEARNING_AUTHOR_OPT_IN_ENV, LearningAuthorRole, LearningWriteAttempt, ensure_learning_write_allowed, learning_author_role) and build_task_status_index. Items stay where they are; only re-exports go.
3. Narrow the 9 command/ modules with zero external path refs to pub(crate) per the §3 table; keep root pub use for docs/search/workflow; drop learning_authoring's re-export first per §2. The other 10 consumed modules stay pub.

Dispatch gate: hold until ORB-10358 lands and the rebuild is verified.

### Acceptance Criteria

- cargo check --workspace and cargo test pass with no #[allow] additions; every deletion confirmed dead by the compiler (not just the static audit); no behavior change; PR notes the OrbitRuntime public-surface removals; lib.rs re-export policy comment remains accurate afterward.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Removed all 12 compiler-confirmed dead functions from orbit-core, including the obsolete OrbitRuntime public methods.
- Removed the six unused root re-exports (the learning-authoring cluster and build_task_status_index).
- Narrowed the nine unconsumed command modules to pub(crate), preserving the root facade exports for docs, search, and workflow.
- The lib.rs root re-export policy comment remains accurate: remaining root exports have consumers.

Public surface note: OrbitRuntime no longer exposes try_initialize_existing, from_data_root, with_policy, execution_env_config, codex_execution_config, scoreboard_summary_path, or load_duel_runs; this is an intentional removal of unused API.

Assessment: Pure visibility and dead-code cleanup; no behavior changes. ORB-10358 is present in the admitted HEAD (merge 7e16ede0).

Validation: cargo fmt --all -- --check; cargo check --workspace; cargo test --workspace (with managed-agent identity variables unset per L-0068); make ci-fast; git diff --check.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10386-6a656134`
- Behind base: 0
- Ahead of base: 1