### PR TITLE
Feature-gate ORBIT_V2_REPLAY; de-duplicate replay_active; un-cfg output_capture_limit

### DIFF
--- a/crates/orbit-core/assets/jobs/examples/loop_review_fix.yaml
+++ b/crates/orbit-core/assets/jobs/examples/loop_review_fix.yaml
@@ -15,6 +15,7 @@ spec:
           - id: reviewer
             spec:
               type: agent_loop
+              backend: http
               description: >
                 Iterative reviewer. Under ORBIT_V2_REPLAY_FIXTURE the fixture
                 scripts two iterations: iteration 1 emits a tool_use for

--- a/crates/orbit-core/assets/jobs/examples/tool_denial_no_retry.yaml
+++ b/crates/orbit-core/assets/jobs/examples/tool_denial_no_retry.yaml
@@ -15,6 +15,7 @@ spec:
         backoff_strategy: exponential
       spec:
         type: agent_loop
+        backend: http
         description: >
           Under ORBIT_V2_REPLAY=tool_denial the replay emits a tool_use for
           `fs.delete` while the allowlist is `[fs.read]`. The driver surfaces

--- a/crates/orbit-engine/Cargo.toml
+++ b/crates/orbit-engine/Cargo.toml
@@ -8,6 +8,18 @@ license.workspace = true
 [package.metadata.orbit]
 stability = "internal"
 
+[features]
+default = []
+replay = []
+
+[[example]]
+name = "v2_runtime_smoke"
+required-features = ["replay"]
+
+[[example]]
+name = "v2_job_runtime_smoke"
+required-features = ["replay"]
+
 [lints]
 workspace = true
 

--- a/crates/orbit-engine/examples/v2_job_runtime_smoke.rs
+++ b/crates/orbit-engine/examples/v2_job_runtime_smoke.rs
@@ -17,7 +17,7 @@
 //! (`ORBIT_V2_REPLAY{,_FIXTURE}`).
 //!
 //! Usage:
-//!     cargo run -p orbit-engine --example v2_job_runtime_smoke
+//!     cargo run -p orbit-engine --features replay --example v2_job_runtime_smoke
 
 use std::env;
 use std::path::{Path, PathBuf};
@@ -33,7 +33,7 @@ use orbit_engine::{
 use serde_json::Value;
 
 fn main() -> ExitCode {
-    let samples_dir = workspace_root().join("crates/orbit-core/assets/jobs");
+    let samples_dir = workspace_root().join("crates/orbit-core/assets/jobs/examples");
     let fixtures_dir = samples_dir.join("fixtures");
     let tmp_audit_root = std::env::temp_dir().join("orbit-v2-job-smoke");
     let _ = std::fs::create_dir_all(&tmp_audit_root);

--- a/crates/orbit-engine/examples/v2_runtime_smoke.rs
+++ b/crates/orbit-engine/examples/v2_runtime_smoke.rs
@@ -16,7 +16,7 @@
 //!    `tool.denied` envelope event is present.
 //!
 //! Usage:
-//!     cargo run -p orbit-engine --example v2_runtime_smoke
+//!     cargo run -p orbit-engine --features replay --example v2_runtime_smoke
 
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -36,7 +36,7 @@ use std::env;
 fn main() -> ExitCode {
     let mut failures: Vec<String> = Vec::new();
 
-    let references_dir = workspace_root().join("crates/orbit-core/assets/activities");
+    let references_dir = workspace_root().join("crates/orbit-core/assets/activities/examples");
     let tmp_audit_root = std::env::temp_dir().join("orbit-v2-smoke");
     let _ = std::fs::create_dir_all(&tmp_audit_root);
 

--- a/crates/orbit-engine/src/activity_job/agent_loop_driver.rs
+++ b/crates/orbit-engine/src/activity_job/agent_loop_driver.rs
@@ -7,11 +7,10 @@
 //! `DispatchError` so the DAG retry wrapper can classify denials as
 //! non-retryable.
 //!
-//! Offline replay: `ORBIT_V2_REPLAY=tool_denial` replays a single canned
-//! tool_use on turn 1 (Phase 2 denial smoke). `ORBIT_V2_REPLAY_FIXTURE=<path>`
-//! reads a JSON array of `ReplayTurn`-shaped objects and scripts an arbitrary
-//! multi-turn sequence — used by the Phase 3 loop sample to drive convergence
-//! across iterations without credentials.
+//! With the `replay` cargo feature enabled, `ORBIT_V2_REPLAY=tool_denial`
+//! replays a single canned tool_use on turn 1 (Phase 2 denial smoke), while
+//! `ORBIT_V2_REPLAY_FIXTURE=<path>` scripts an arbitrary multi-turn sequence
+//! from a JSON fixture. Default builds ignore both variables.
 
 // ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
@@ -274,7 +273,10 @@ fn resolve_model(spec: &AgentLoopSpec) -> String {
         .unwrap_or_else(|| ANTHROPIC_HTTP_DEFAULT_MODEL.to_string())
 }
 
-fn replay_active() -> bool {
+pub(crate) fn replay_active() -> bool {
+    if !cfg!(feature = "replay") {
+        return false;
+    }
     std::env::var("ORBIT_V2_REPLAY").is_ok() || std::env::var("ORBIT_V2_REPLAY_FIXTURE").is_ok()
 }
 
@@ -284,7 +286,7 @@ fn replay_active() -> bool {
 /// fixtures). Cleared by `reset_replay_transport` in tests.
 static REPLAY_TRANSPORT: OnceLock<Mutex<Option<Arc<ReplayTransport>>>> = OnceLock::new();
 
-#[cfg(test)]
+#[cfg(all(test, feature = "replay"))]
 pub(crate) static REPLAY_TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
 
 fn acquire_replay_transport(model: &str) -> Result<Arc<ReplayTransport>, DispatchError> {

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -216,7 +216,6 @@ pub fn run_cli_backend(
             task_id: task_id_from_input(input),
             cwd: subprocess_cwd_string.as_deref(),
         },
-        #[cfg(test)]
         output_capture_limit: None,
     });
 

--- a/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
@@ -153,7 +153,6 @@ pub(super) struct SpawnWithTimeoutRequest<'a> {
     pub(super) timeout: Duration,
     pub(super) sandbox: Option<&'a ResolvedSandbox>,
     pub(super) trace: SpawnTraceContext<'a>,
-    #[cfg(test)]
     pub(super) output_capture_limit: Option<usize>,
 }
 
@@ -183,7 +182,6 @@ pub(super) fn spawn_with_timeout(
         timeout,
         sandbox,
         trace,
-        #[cfg(test)]
         output_capture_limit,
     } = request;
 
@@ -206,10 +204,7 @@ pub(super) fn spawn_with_timeout(
         });
     }
 
-    #[cfg(test)]
     let output_limit = output_capture_limit.unwrap_or_else(default_output_capture_limit);
-    #[cfg(not(test))]
-    let output_limit = default_output_capture_limit();
     let stdout_buf = Arc::new(Mutex::new(RollingOutputCapture::new(output_limit)));
     let stderr_buf = Arc::new(Mutex::new(RollingOutputCapture::new(output_limit)));
     let dispatch = tracing::dispatcher::get_default(Clone::clone);

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -561,9 +561,10 @@ fn run_agent_loop_via_driver(
 ) -> Result<DispatchOutcome, DispatchError> {
     // Sourcing only: orbit-core pulls the provider credential from wherever
     // makes sense (env var, config, secrets manager). We treat a sourcing
-    // failure as `None` so `drive_agent_loop` can still honor the offline
-    // replay path (ORBIT_V2_REPLAY) without credentials. When the driver
-    // actually needs a key and none is present, it errors structurally.
+    // failure as `None` so a `replay`-enabled `drive_agent_loop` can still
+    // honor ORBIT_V2_REPLAY without credentials. Default builds ignore replay
+    // variables; when the driver needs a key and none is present, it errors
+    // structurally.
     let api_key = host.api_key_for("anthropic").ok();
     let started = Instant::now();
     let outcome = drive_agent_loop(

--- a/crates/orbit-engine/src/activity_job/job_executor/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/target.rs
@@ -3,6 +3,8 @@
 
 use super::*;
 
+use super::super::agent_loop_driver::replay_active;
+
 pub(super) fn run_target(
     step: &JobV2Step,
     t: &TargetStep,
@@ -47,7 +49,11 @@ pub(super) fn run_target(
                 let provider = agent_spec.provider.as_str();
                 Session::new(provider, model, &agent_spec.instruction, None)
             });
-            let api_key = ctx.host.api_key_for("anthropic").ok();
+            let api_key = if replay_active() {
+                None
+            } else {
+                ctx.host.api_key_for("anthropic").ok()
+            };
             run_agent_loop_outcome(
                 step,
                 agent_spec,
@@ -198,11 +204,6 @@ pub(super) fn run_agent_loop_outcome(
         message: None,
         skipped: false,
     })
-}
-
-#[cfg(test)]
-pub(super) fn replay_active() -> bool {
-    std::env::var("ORBIT_V2_REPLAY").is_ok() || std::env::var("ORBIT_V2_REPLAY_FIXTURE").is_ok()
 }
 
 /// Build a crew-overridden clone of an [`AgentLoopSpec`]. A declared activity

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
@@ -298,11 +298,10 @@ fn role_override_does_not_apply_to_non_agent_loop_specs() {
     assert!(host.observed_lookups().is_empty());
 }
 
-/// Replay short-circuit regression (AC #9). The override is applied
-/// before session creation, so `replay_active()` must continue to see
-/// the env var and return `true` regardless of the override.
+/// Replay short-circuit regression (AC #9). Role resolution must not alter
+/// the shared feature-gated replay predicate.
 #[test]
-fn role_override_does_not_disable_replay_short_circuit() {
+fn role_override_does_not_change_feature_gated_replay_state() {
     // Use a unique env var name to avoid stomping other tests; we restore
     // it on drop.
     struct EnvGuard {
@@ -313,9 +312,7 @@ fn role_override_does_not_disable_replay_short_circuit() {
         fn set(key: &'static str, value: &str) -> Self {
             let prior = std::env::var(key).ok();
             // SAFETY: tests touching env vars must coordinate; we use a
-            // dedicated key and restore on drop, and replay_active() is
-            // a pure read of two specific keys so no other thread races
-            // it for the duration of this test.
+            // dedicated key and restore on drop.
             unsafe {
                 std::env::set_var(key, value);
             }
@@ -343,8 +340,10 @@ fn role_override_does_not_disable_replay_short_circuit() {
         .expect("resolve override")
         .expect("override expected");
     assert_eq!(overridden.provider, Provider::Codex);
-    // Replay short-circuit still triggers — independent of the override.
-    assert!(super::replay_active());
+    assert_eq!(
+        crate::activity_job::agent_loop_driver::replay_active(),
+        cfg!(feature = "replay")
+    );
 }
 
 // ----- Telemetry persistence is non-fatal (ORB-10367) -----------------

--- a/crates/orbit-engine/src/activity_job/tests/agent_loop_driver_default.rs
+++ b/crates/orbit-engine/src/activity_job/tests/agent_loop_driver_default.rs
@@ -1,0 +1,46 @@
+#![allow(missing_docs)]
+
+use super::super::agent_loop_driver::replay_active;
+
+struct ReplayEnvGuard {
+    replay: Option<String>,
+    fixture: Option<String>,
+}
+
+impl ReplayEnvGuard {
+    fn set_both() -> Self {
+        let guard = Self {
+            replay: std::env::var("ORBIT_V2_REPLAY").ok(),
+            fixture: std::env::var("ORBIT_V2_REPLAY_FIXTURE").ok(),
+        };
+        // SAFETY: this test restores both variables before returning. The
+        // default build's predicate returns before reading process state.
+        unsafe {
+            std::env::set_var("ORBIT_V2_REPLAY", "tool_denial");
+            std::env::set_var("ORBIT_V2_REPLAY_FIXTURE", "/tmp/inert-replay-fixture");
+        }
+        guard
+    }
+}
+
+impl Drop for ReplayEnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: restore the process environment captured by `set_both`.
+        unsafe {
+            match &self.replay {
+                Some(value) => std::env::set_var("ORBIT_V2_REPLAY", value),
+                None => std::env::remove_var("ORBIT_V2_REPLAY"),
+            }
+            match &self.fixture {
+                Some(value) => std::env::set_var("ORBIT_V2_REPLAY_FIXTURE", value),
+                None => std::env::remove_var("ORBIT_V2_REPLAY_FIXTURE"),
+            }
+        }
+    }
+}
+
+#[test]
+fn replay_environment_is_inert_without_feature() {
+    let _guard = ReplayEnvGuard::set_both();
+    assert!(!replay_active());
+}

--- a/crates/orbit-engine/src/activity_job/tests/mod.rs
+++ b/crates/orbit-engine/src/activity_job/tests/mod.rs
@@ -1,6 +1,9 @@
 #![allow(missing_docs)]
 
+#[cfg(feature = "replay")]
 mod agent_loop_driver;
+#[cfg(not(feature = "replay"))]
+mod agent_loop_driver_default;
 mod agent_role;
 mod dispatcher;
 mod workspace;

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Design"
 type: design
 title: "Activity / Job — Design"
 owner: codex
-last_updated: 2026-07-25
+last_updated: 2026-07-26
 status: Draft
 feature: activity-job
 doc_role: design
@@ -220,7 +220,7 @@ The HTTP path is driven by `agent_loop_driver.rs`. It:
 - chooses a transport
 - runs `orbit-agent`'s `AgentLoop`
 
-This path is narrower than the schema: `Provider::has_http_transport()` currently returns true only for `claude`, so non-replay uses `AnthropicMessagesTransport`. `ORBIT_V2_REPLAY` and `ORBIT_V2_REPLAY_FIXTURE` provide scripted replay.
+This path is narrower than the schema: `Provider::has_http_transport()` currently returns true only for `claude`, so non-replay uses `AnthropicMessagesTransport`. Default builds ignore `ORBIT_V2_REPLAY` and `ORBIT_V2_REPLAY_FIXTURE`; scripted replay is enabled for explicit smoke and fixture use only when orbit-engine's `replay` cargo feature is selected ([ORB-10414]).
 
 The allowlist is enforced in the loop engine on this path. A denied tool becomes a structural `DispatchError::ToolDenied` so the job retry wrapper can classify it as non-retryable.
 
@@ -572,5 +572,6 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[ORB-00374]** — Remove the `shell` activity variant and `run_shell` dispatch (fail-closed resolution of security bug [ORB-00363]).
 - **[ORB-10232]** — Model recoverable PR handoff as checkpointed job activities with exact-SHA force-push provenance.
 - **[ORB-10332]** — Remove the unused Groundhog activity kind and the epic/parallel pipeline layer (`task_epic_pipeline`, `epic_orchestrator`, `pipeline_wait`, legacy parallel-batch executor).
+- **[ORB-10414]** — Make HTTP replay an explicit default-off cargo feature and keep replay environment variables inert in default builds.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -14,13 +14,19 @@ fi
 
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
-# Keep examples covered by clippy's all-targets pass, but avoid re-running
-# their empty test harnesses in the test phase.
+# The replay smokes require an explicit feature, so the default workspace
+# clippy pass skips them. Keep that opt-in path compiled and linted too.
+cargo clippy -p orbit-engine --all-targets --features replay -- -D warnings
+# Keep examples covered by the clippy passes, but avoid re-running their empty
+# test harnesses in the test phase. Exercise orbit-engine's replay-dependent
+# tests separately so both default and opt-in configurations stay covered.
 if cargo nextest --version >/dev/null 2>&1; then
   cargo nextest run --workspace --lib --bins --tests
+  cargo nextest run -p orbit-engine --features replay --lib --bins --tests
 else
   echo "cargo-nextest not found; falling back to cargo test" >&2
   cargo test --workspace --lib --bins --tests
+  cargo test -p orbit-engine --features replay --lib --bins --tests
 fi
 cargo test --workspace --doc
 RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace


### PR DESCRIPTION
## Task

[ORB-10414](https://orbit-cli.com/tasks/ORB-10414) — Feature-gate ORBIT_V2_REPLAY; de-duplicate replay_active; un-cfg output_capture_limit

### Description

From the orbit-engine cleanup audit §10 (design doc: ~/workspace/constellation/knowledgebase/polaris/design/orbit-cleanup/orbitenginecleanup.md). Hardening — behavior change in release builds.

activity_job/agent_loop_driver.rs:277 replay_active() is NOT cfg(test)-gated: setting ORBIT_V2_REPLAY / ORBIT_V2_REPLAY_FIXTURE in a release build substitutes a ReplayTransport (canned turns from a file) for the real provider call. A byte-identical copy at activity_job/job_executor/target.rs:204 IS #[cfg(test)]-gated — two copies of one predicate with different compilation semantics.

1. Put the production replay path behind a cargo feature (replay), off by default; the capability stays available for the Phase 2 denial smoke path (documented at agent_loop_driver.rs:10) via explicit feature opt-in.
2. target.rs calls the one definition instead of keeping its own copy.
3. While there: cli_runner/supervisor.rs:157 has a #[cfg(test)] output_capture_limit field on a production struct (+ paired cfg'd bodies at :210/:212, None init at orchestrator.rs:220) — inject the limit via a normal constructor parameter so production and test share one code path.

Verify nothing in shipped assets, docs, or CI depends on env-var replay in default builds before gating; if the denial smoke path runs in CI, wire the feature flag there explicitly.

### Acceptance Criteria

- Default release build ignores ORBIT_V2_REPLAY* (test proves the env vars are inert without the feature); replay feature restores the capability; single replay_active definition; output_capture_limit has no cfg(test) conditional compilation; any CI consumer of the replay path updated; full test suite passes under both feature configurations.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a default-off `replay` cargo feature and made the sole `replay_active` predicate return false before reading ORBIT_V2_REPLAY variables unless the feature is selected. The session-bound job target now calls that shared predicate and avoids credential lookup during replay.
- Made CLI `output_capture_limit` unconditional across the production request struct, destructuring, default initialization, and test override so all builds use one capture path.
- Split replay tests by feature configuration: default tests prove both replay variables are inert; feature-enabled tests retain denial, fixture, and learning-injection coverage.
- Marked replay smoke examples as feature-required, corrected their shipped sample paths, pinned replay sample jobs to `backend: http`, updated usage/design documentation, and added explicit replay-feature clippy/test coverage to the canonical CI guardrail script.
Validation:
- `cargo test -p orbit-engine`: 315 passed in the default configuration.
- `cargo test -p orbit-engine --features replay`: 319 passed.
- `cargo clippy -p orbit-engine --all-targets -- -D warnings`: passed.
- `cargo clippy -p orbit-engine --all-targets --features replay -- -D warnings`: passed.
- Both feature-enabled replay smoke examples passed, including loop convergence and non-retryable tool denial.
- `make ci-fast`, `bash -n scripts/ci-guardrails.sh`, `cargo fmt --all --check`, and `git diff --check`: passed.
Assessment: The release-default credential/provider path is preserved while replay now requires explicit build-time opt-in; focused default/feature tests and CI wiring cover both compilation semantics.
Deviations from original plan: Expanded into the shipped replay examples, their two job assets, the activity-job design page, and CI after consumer inspection showed those files directly depend on the replay path. Each extension was recorded in task comments before modification.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10414-6a65614d`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*