### PR TITLE
Register pr_failure_handoff + worktree_gc in v2 deterministic dispatch (live defect)

### DIFF
--- a/crates/orbit-core/src/command/job/tests/exec.rs
+++ b/crates/orbit-core/src/command/job/tests/exec.rs
@@ -68,13 +68,16 @@ fn seed_gate_task(runtime: &OrbitRuntime, repo_root: &Path, status: TaskStatus) 
         .id
 }
 
-fn resolved_gate_job(runtime: &OrbitRuntime) -> orbit_common::types::activity_job::JobV2 {
+fn resolved_job(
+    runtime: &OrbitRuntime,
+    job_name: &str,
+) -> orbit_common::types::activity_job::JobV2 {
     let (_path, mut job) = runtime
-        .load_v2_job_asset_by_name("task_gate_pipeline")
-        .expect("load task gate pipeline");
+        .load_v2_job_asset_by_name(job_name)
+        .unwrap_or_else(|err| panic!("load {job_name}: {err}"));
     let catalog = runtime.v2_activity_catalog().expect("activity catalog");
     resolve_job_catalog_refs_for_execution(&mut job, &catalog)
-        .expect("resolve task gate activities");
+        .unwrap_or_else(|err| panic!("resolve {job_name} activities: {err}"));
     job
 }
 
@@ -95,7 +98,25 @@ fn try_execute_gate_job(
     input: Value,
     run_id: &str,
 ) -> Result<JobOutcome, DispatchError> {
-    let job = resolved_gate_job(runtime);
+    try_execute_named_job(
+        runtime,
+        repo_root,
+        host,
+        "task_gate_pipeline",
+        input,
+        run_id,
+    )
+}
+
+fn try_execute_named_job(
+    runtime: &OrbitRuntime,
+    repo_root: &Path,
+    host: &dyn V2RuntimeHost,
+    job_name: &str,
+    input: Value,
+    run_id: &str,
+) -> Result<JobOutcome, DispatchError> {
+    let job = resolved_job(runtime, job_name);
     let writer = V2AuditWriter::with_disk_sinks(
         &runtime.paths().audit_dir,
         runtime
@@ -110,6 +131,154 @@ fn try_execute_gate_job(
     )
     .expect("audit writer");
     execute_job_with_resume(&job, input, run_id, writer, host, None)
+}
+
+const WORKTREE_FIXTURE_FAILURE: &str = "fixture: worktree setup exploded";
+
+/// Runs `task_pr_pipeline` against the real runtime dispatch table with a
+/// seeded first-step failure, recording how every deterministic action
+/// resolved so the terminal failure hook's fate is observable — the
+/// executor deliberately swallows that hook's own error.
+struct FailureHandoffHost<'a> {
+    runtime: &'a OrbitRuntime,
+    dispatches: Mutex<Vec<(String, String)>>,
+}
+
+impl FailureHandoffHost<'_> {
+    fn new(runtime: &OrbitRuntime) -> FailureHandoffHost<'_> {
+        FailureHandoffHost {
+            runtime,
+            dispatches: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn record(&self, action: &str, outcome: String) {
+        self.dispatches
+            .lock()
+            .expect("dispatch log")
+            .push((action.to_string(), outcome));
+    }
+
+    fn outcomes(&self, action: &str) -> Vec<String> {
+        self.dispatches
+            .lock()
+            .expect("dispatch log")
+            .iter()
+            .filter(|(recorded, _)| recorded == action)
+            .map(|(_, outcome)| outcome.clone())
+            .collect()
+    }
+}
+
+impl V2RuntimeHost for FailureHandoffHost<'_> {
+    fn run_deterministic(
+        &self,
+        action: &str,
+        config: &Value,
+        input: &Value,
+        tool_context: ToolContext,
+    ) -> Result<Value, DispatchError> {
+        if action == "worktree_setup" {
+            self.record(action, "seeded_failure".to_string());
+            return Err(DispatchError::DeterministicActionFailed {
+                action: action.to_string(),
+                message: WORKTREE_FIXTURE_FAILURE.to_string(),
+            });
+        }
+        let result = <OrbitRuntime as V2RuntimeHost>::run_deterministic(
+            self.runtime,
+            action,
+            config,
+            input,
+            tool_context,
+        );
+        let outcome = match &result {
+            Ok(_) => "ok".to_string(),
+            Err(DispatchError::DeterministicActionNotRegistered(name)) => {
+                format!("not_registered: {name}")
+            }
+            Err(other) => format!("dispatched: {other}"),
+        };
+        self.record(action, outcome);
+        result
+    }
+
+    fn has_deterministic_action(&self, action: &str) -> bool {
+        <OrbitRuntime as V2RuntimeHost>::has_deterministic_action(self.runtime, action)
+    }
+
+    fn api_key_for(&self, provider: &str) -> Result<String, DispatchError> {
+        <OrbitRuntime as V2RuntimeHost>::api_key_for(self.runtime, provider)
+    }
+
+    fn resolve_cli_executor(&self, provider: &str) -> Result<ResolvedCliExecutor, DispatchError> {
+        <OrbitRuntime as V2RuntimeHost>::resolve_cli_executor(self.runtime, provider)
+    }
+
+    fn tool_context_for_activity(
+        &self,
+        run_id: Option<&str>,
+        fs_profile: Option<&str>,
+        fs_audit: Option<Arc<dyn FsAuditLogger>>,
+        proc_allowed_programs: Option<&[String]>,
+    ) -> ToolContext {
+        <OrbitRuntime as V2RuntimeHost>::tool_context_for_activity(
+            self.runtime,
+            run_id,
+            fs_profile,
+            fs_audit,
+            proc_allowed_programs,
+        )
+    }
+}
+
+/// [ORB-10410] `task_pr_pipeline` binds `pr_failure_handoff` as its
+/// terminal `failure_activity`, and that hook resolves through the same v2
+/// deterministic dispatch table as any ordinary step. While the allowlist
+/// omitted the name, every terminal PR-pipeline failure ran the hook as
+/// `DeterministicActionNotRegistered`: the recoverable candidate was never
+/// published, and the registry miss masked the real failure. The hook must
+/// reach its own implementation, and the original step error must stay
+/// authoritative.
+#[test]
+fn failed_pr_pipeline_dispatches_the_failure_handoff_and_keeps_the_original_error() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    let host = FailureHandoffHost::new(&runtime);
+
+    let error = try_execute_named_job(
+        &runtime,
+        &repo_root,
+        &host,
+        "task_pr_pipeline",
+        json!({
+            "task_ids": ["ORB-FAILURE-HANDOFF"],
+            "base_branch": "agent-main",
+            "base_sync": "local",
+            "review": false,
+        }),
+        "run-pr-failure-handoff",
+    )
+    .expect_err("the seeded worktree failure must terminalize the run");
+
+    assert!(
+        error.to_string().contains(WORKTREE_FIXTURE_FAILURE),
+        "the original step error stays authoritative: {error}"
+    );
+
+    let handoff = host.outcomes("pr_failure_handoff");
+    assert_eq!(
+        handoff.len(),
+        1,
+        "the terminal hook runs exactly once: {handoff:?}"
+    );
+    // The hook reached its own input validation — it failed on this run's
+    // missing `worktree` checkpoint, not on the dispatch registry guard.
+    assert!(
+        handoff[0].contains("missing pipeline.worktree checkpoint"),
+        "the handoff must execute its implementation, not be rejected as unregistered: {}",
+        handoff[0]
+    );
 }
 
 struct ReserveThenStatusHost<'a> {

--- a/crates/orbit-core/src/runtime/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/v2_host/dispatch.rs
@@ -27,8 +27,11 @@ use super::{backlog_exclusion, pipeline_actions, triage};
 /// Adding an arm below without adding its name here makes validation reject a
 /// job the runtime could actually run; adding a name here without an arm
 /// reintroduces exactly the skew this list exists to prevent. The seeded-asset
-/// coverage test in `mod.rs` pins the direction that broke in production —
-/// every shipped deterministic activity's action must be registered here.
+/// coverage tests in `command/job/catalog.rs` pin the direction that broke in
+/// production — every shipped deterministic activity's action must be
+/// registered here — and [ORB-10410] adds behavioral cover for the two actions
+/// the skew actually reached: `pr_failure_handoff` (the `task_pr_pipeline`
+/// terminal hook, in `command/job/exec.rs`) and `worktree_gc` (below).
 pub(super) const REGISTERED_DETERMINISTIC_ACTIONS: &[&str] = &[
     "apply_triage_dispositions",
     "context_conflict_check",
@@ -624,6 +627,46 @@ mod tests {
         let diff_task = runtime.get_task(&diff_task).expect("promoted PR task");
         assert_eq!(diff_task.status, TaskStatus::Review);
         assert_eq!(diff_task.github_pr_number(), Some("42"));
+    }
+
+    /// [ORB-10410] `worktree_gc` ships as a deterministic activity reached
+    /// through the seeded (deliberately disabled) `worktree_gc` routine, so
+    /// nothing exercised it until an operator opted in — and by then the v2
+    /// allowlist no longer carried its name. Invoking the action directly must
+    /// reach the engine's reaper and return its structured GC envelope.
+    #[test]
+    fn worktree_gc_is_dispatchable_directly_through_the_v2_host() {
+        let (_root, runtime, repo_root) =
+            super::super::test_support::runtime_with_workspace_layout();
+        let git_init = std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&repo_root)
+            .output()
+            .expect("run git init");
+        assert!(
+            git_init.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&git_init.stderr)
+        );
+
+        let output = runtime
+            .run_deterministic(
+                "worktree_gc",
+                &json!({}),
+                &json!({ "older_than_hours": 24 }),
+                ToolContext::default(),
+            )
+            .expect("worktree_gc must dispatch through the v2 host");
+
+        // This workspace has recorded no job runs, so the reaper considers no
+        // worktrees. The assertion is the envelope itself: only the real
+        // action produces it, and an unregistered name never gets this far.
+        assert_eq!(output["reports"], json!([]));
+        assert_eq!(output["bytes_reclaimed"], json!(0));
+        assert!(
+            output["dry_run"].is_boolean(),
+            "GC envelope reports its deletion mode: {output}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Task

[ORB-10410](https://orbit-cli.com/tasks/ORB-10410) — Register pr_failure_handoff + worktree_gc in v2 deterministic dispatch (live defect)

### Description

From the orbit-engine cleanup audit §2 (design doc: ~/workspace/constellation/knowledgebase/polaris/design/orbit-cleanup/orbitenginecleanup.md; line refs @ agent-main — re-verify). LIVE DEFECT, ships ahead of all cleanup waves.

orbit-core v2_host/dispatch.rs:51 forwards a hard-coded ten-name allowlist to execute_deterministic_action; two actions shipped as activity assets are missing from it:

1. pr_failure_handoff — the failure_activity of task_pr_pipeline (assets/jobs/task_pr_pipeline.yaml:35 → assets/activities/pr_failure_handoff.yaml:71). failure_activity resolves through the same dispatcher, so when the PR pipeline fails, the failure handler itself fails with DeterministicActionNotRegistered, masking the original error. Implementation intact and tested (executor/automation/vcs/failure.rs, vcs/pr/tests/handoff.rs). Add to the allowlist + a regression test that drives the PR pipeline to failure and asserts the handoff runs.

2. worktree_gc — reached via shipped routine worktree_gc.yaml → worktree_gc_pipeline.yaml → activities/worktree_gc.yaml:33. Decision (orchestrator, 2026-07-26, subject to Daniel's review at merge): REGISTER rather than delete — the subsystem was deliberately built with opt-in gating (routine ships enabled: false per ORB-10374, operators must opt in before unattended deletion); the missing allowlist entry is v2-migration fallout, not intent. Registering restores the intended path while the disabled routine remains the safety gate. Do NOT enable the routine. Add a test that the action dispatches when invoked directly.

Scope is the two allowlist arms + regression tests only. The general asset→action reachability guardrail is a separate task.

### Acceptance Criteria

- Both actions dispatch through v2_host; regression test proves a failed task_pr_pipeline run executes pr_failure_handoff and surfaces the ORIGINAL error, not DeterministicActionNotRegistered; worktree_gc routine remains enabled: false; no other allowlist changes; full test suite passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Finding that reshaped the task: the two allowlist arms this task was written to add are ALREADY present on origin/agent-main. `REGISTERED_DETERMINISTIC_ACTIONS` carries `pr_failure_handoff` and `worktree_gc`, and both appear in the `execute_deterministic_action` forwarding arm (dispatch.rs:122-124). ORB-10385 landed the registration edit while ORB-10410 was queued. What was genuinely missing — and is what this branch delivers — is the behavioral regression cover the acceptance criteria demand. The pre-existing coverage in command/job/catalog.rs (`default_deterministic_activities_are_registered_in_the_runtime`) only asserts name-level reachability; nothing drove either action through a real dispatch.

Changes (2 files, test code + one doc comment; zero production behavior change):

1. crates/orbit-core/src/command/job/exec.rs — new test `failed_pr_pipeline_dispatches_the_failure_handoff_and_keeps_the_original_error`. Runs the real `task_pr_pipeline` asset through the real runtime dispatch table behind a `FailureHandoffHost` decorator that seeds a `worktree_setup` failure and records how every deterministic action resolved (the executor deliberately swallows the terminal hook's own error, so the hook's fate is otherwise unobservable). Asserts (a) the original error `fixture: worktree setup exploded` stays authoritative, and (b) `pr_failure_handoff` dispatched exactly once and reached its OWN input validation (`missing pipeline.worktree checkpoint`) rather than the registry guard. Supporting refactor: `resolved_gate_job` generalized to `resolved_job(runtime, job_name)` plus `try_execute_named_job`, so a test can drive a job other than `task_gate_pipeline`; the existing `try_execute_gate_job` is preserved as a thin wrapper, so no existing test changed shape.

2. crates/orbit-core/src/runtime/v2_host/dispatch.rs — new test `worktree_gc_is_dispatchable_directly_through_the_v2_host`. Invokes the action directly against a git-initialized workspace layout and asserts the engine reaper's structured GC envelope (`reports: []`, `bytes_reclaimed: 0`, boolean `dry_run`) — an envelope only the real action can produce. Also corrected the `REGISTERED_DETERMINISTIC_ACTIONS` doc comment: it pointed at a seeded-asset coverage test in `mod.rs` that actually lives in `command/job/catalog.rs`, and now names where the ORB-10410 behavioral cover lives.

Mutation-verified, not just green: temporarily removing both names from the allowlist and the forwarding arm makes both new tests fail, and fail with exactly the production symptom — worktree_gc returns `DeterministicActionNotRegistered("worktree_gc")`, and the PR pipeline terminalizes with the registry-skew message *masking* the seeded original error. Entries restored; tree verified clean.

Acceptance criteria: both actions dispatch through v2_host (proven by the direct-invocation and pipeline tests); the PR-pipeline regression test proves the handoff executes and the ORIGINAL error survives, not DeterministicActionNotRegistered; `crates/orbit-core/assets/routines/worktree_gc.yaml:8` remains `enabled: false` (untouched — registration restores the path, the disabled routine stays the opt-in safety gate per the task's decision); no allowlist changes at all were needed, so a fortiori no others.

Validation: `make ci-fast` passes. `cargo test --workspace` has exactly one failure, and it is PRE-EXISTING ON origin/agent-main, unrelated to this branch: `orbit-cli --test mcp_roundtrip mcp_serve_tools_list_matches_production_snapshot`. ORB-10401 (merged as PR #714) widened the `orbit.task.list` `status` input schema without regenerating `crates/orbit-cli/tests/snapshots/mcp_tools_list.json` — verified at origin/agent-main, where list.rs:14 carries the new description and snapshot line 965 still carries the old one. This branch touches no tool schema and cannot affect that snapshot; regenerating it is ORB-10401's call because the guard exists to force a BREAKING-change release note. Left untouched deliberately and filed as friction F2026-07-128. The full-suite acceptance criterion is met modulo that inherited red.

Scope: no production code changed, no new dependencies, no allowlist edits, no files outside the two named above. The general asset-to-action reachability guardrail remains a separate task.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10410-6a65612f`
- Behind base: 0
- Ahead of base: 1