### PR TITLE
orbit-store: fan yaml_doc.rs helpers out to the 14 hand-rolled call sites

### DIFF
--- a/crates/orbit-store/src/file/adr_store/bundle/mod.rs
+++ b/crates/orbit-store/src/file/adr_store/bundle/mod.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use orbit_common::types::{Adr, NotFoundKind, OrbitError};
 use orbit_common::utility::fs::atomic_write_text_volatile as write_atomic;
 
-use super::doc::{AdrFileDocument, serialize_adr_doc_yaml};
+use super::doc::AdrFileDocument;
 use super::layout::{adr_doc_path, body_path, validate_adr_id};
 use crate::file::yaml_doc::{read_yaml_with, write_yaml_atomic_with};
 
@@ -18,7 +18,9 @@ pub(super) fn write_bundle_at(adr_dir: &Path, bundle: &AdrBundle) -> Result<(), 
     validate_bundle(bundle)?;
     fs::create_dir_all(adr_dir).map_err(|e| OrbitError::Io(e.to_string()))?;
 
-    write_yaml_atomic_with(&adr_doc_path(adr_dir), &bundle.doc, serialize_adr_doc_yaml)?;
+    write_yaml_atomic_with(&adr_doc_path(adr_dir), &bundle.doc, |error| {
+        OrbitError::Store(error.to_string())
+    })?;
     write_atomic(&body_path(adr_dir), &bundle.body).map_err(|e| OrbitError::Io(e.to_string()))?;
     Ok(())
 }

--- a/crates/orbit-store/src/file/adr_store/bundle/tests/bundle.rs
+++ b/crates/orbit-store/src/file/adr_store/bundle/tests/bundle.rs
@@ -53,8 +53,10 @@ fn read_bundle_rejects_missing_body_md() {
     let dir = tempdir.path().join("ADR-0001");
     fs::create_dir_all(&dir).expect("create adr dir");
     let bundle = sample_bundle("ADR-0001");
-    write_yaml_atomic_with(&adr_doc_path(&dir), &bundle.doc, serialize_adr_doc_yaml)
-        .expect("write doc only");
+    write_yaml_atomic_with(&adr_doc_path(&dir), &bundle.doc, |error| {
+        OrbitError::Store(error.to_string())
+    })
+    .expect("write doc only");
 
     let error = read_bundle_at(&dir).expect_err("missing body must fail");
 

--- a/crates/orbit-store/src/file/adr_store/doc/mod.rs
+++ b/crates/orbit-store/src/file/adr_store/doc/mod.rs
@@ -1,4 +1,4 @@
-use orbit_common::types::{Adr, OrbitError};
+use orbit_common::types::Adr;
 use serde::{Deserialize, Serialize};
 
 /// On-disk shape of an ADR record (the contents of `adr.yaml`).
@@ -11,10 +11,6 @@ pub(super) struct AdrFileDocument {
     pub(super) schema_version: u8,
     #[serde(flatten)]
     pub(super) adr: Adr,
-}
-
-pub(super) fn serialize_adr_doc_yaml(doc: &AdrFileDocument) -> Result<String, OrbitError> {
-    serde_yaml::to_string(doc).map_err(|e| OrbitError::Store(e.to_string()))
 }
 
 #[cfg(test)]

--- a/crates/orbit-store/src/file/adr_store/doc/tests/serialization.rs
+++ b/crates/orbit-store/src/file/adr_store/doc/tests/serialization.rs
@@ -1,9 +1,10 @@
 use chrono::TimeZone;
 use chrono::Utc;
-use orbit_common::types::{AdrStatus, LegacyValidation};
+use orbit_common::types::{AdrStatus, LegacyValidation, OrbitError};
 
 use super::super::super::constants::ADR_SCHEMA_VERSION;
 use super::super::*;
+use crate::file::yaml_doc::serialize_yaml_with;
 
 fn sample_doc() -> AdrFileDocument {
     let ts = Utc.with_ymd_and_hms(2026, 5, 11, 0, 0, 0).unwrap();
@@ -35,7 +36,8 @@ fn round_trip_through_yaml_preserves_schema_version() {
     let mut doc = sample_doc();
     doc.adr.tags = vec!["adr-schema".to_string(), "cross-cutting".to_string()];
     doc.adr.paths = vec!["crates/orbit-store/**".to_string()];
-    let yaml = serialize_adr_doc_yaml(&doc).expect("serialize");
+    let yaml =
+        serialize_yaml_with(&doc, |error| OrbitError::Store(error.to_string())).expect("serialize");
     assert!(
         yaml.contains("schema_version: 2"),
         "yaml should contain schema_version: 2; got:\n{yaml}"

--- a/crates/orbit-store/src/file/executor_def_store/mod.rs
+++ b/crates/orbit-store/src/file/executor_def_store/mod.rs
@@ -6,7 +6,7 @@ use orbit_common::types::{
     OrbitError, ResourceKind, ResourceMetadata, validate_resource_name,
 };
 
-use orbit_common::utility::fs::atomic_write_text_volatile as write_atomic;
+use crate::file::yaml_doc::{parse_yaml_with, write_yaml_atomic_with};
 
 pub struct ExecutorDefFileStore {
     root: PathBuf,
@@ -61,33 +61,36 @@ impl ExecutorDefFileStore {
         let path = self.executor_path(&def.name)?;
         let dir = self.executors_dir();
         fs::create_dir_all(&dir).map_err(|e| OrbitError::Io(e.to_string()))?;
-        let content = serde_yaml::to_string(&ExecutorResource {
-            schema_version: EXECUTOR_RESOURCE_SCHEMA_VERSION,
-            kind: ResourceKind::Executor,
-            metadata: ResourceMetadata::named(def.name.clone()),
-            spec: ExecutorResourceSpec {
-                executor_type: def.executor_type,
-                command: def.command.clone(),
-                args: def.args.clone(),
-                stdout_format: def.stdout_format,
-                model_pair_override: def.model_pair_override.clone(),
-                model_flag: def.model_flag.clone(),
-                timeout_seconds: def.timeout_seconds,
-                env: def.env.clone(),
-                sandbox: def.sandbox,
-                allow_fallback: def.allow_fallback,
-                created_at: def.created_at,
-                updated_at: def.updated_at,
+        write_yaml_atomic_with(
+            &path,
+            &ExecutorResource {
+                schema_version: EXECUTOR_RESOURCE_SCHEMA_VERSION,
+                kind: ResourceKind::Executor,
+                metadata: ResourceMetadata::named(def.name.clone()),
+                spec: ExecutorResourceSpec {
+                    executor_type: def.executor_type,
+                    command: def.command.clone(),
+                    args: def.args.clone(),
+                    stdout_format: def.stdout_format,
+                    model_pair_override: def.model_pair_override.clone(),
+                    model_flag: def.model_flag.clone(),
+                    timeout_seconds: def.timeout_seconds,
+                    env: def.env.clone(),
+                    sandbox: def.sandbox,
+                    allow_fallback: def.allow_fallback,
+                    created_at: def.created_at,
+                    updated_at: def.updated_at,
+                },
             },
-        })
-        .map_err(|e| OrbitError::Execution(format!("failed to serialize executor def: {e}")))?;
-        write_atomic(&path, &content).map_err(Into::into)
+            |e| OrbitError::Execution(format!("failed to serialize executor def: {e}")),
+        )
     }
 }
 
 fn parse_executor_def(content: &str, label: String) -> Result<ExecutorDef, OrbitError> {
-    let doc: ExecutorResource = serde_yaml::from_str(content)
-        .map_err(|e| OrbitError::InvalidInput(format!("invalid executor def at {}: {e}", label)))?;
+    let doc: ExecutorResource = parse_yaml_with(content, std::path::Path::new(&label), |_, e| {
+        OrbitError::InvalidInput(format!("invalid executor def at {}: {e}", label))
+    })?;
     if doc.kind != ResourceKind::Executor {
         return Err(OrbitError::InvalidInput(format!(
             "invalid executor def at {}: expected kind Executor, found {}",

--- a/crates/orbit-store/src/file/friction_store/mod.rs
+++ b/crates/orbit-store/src/file/friction_store/mod.rs
@@ -11,6 +11,8 @@ use orbit_common::types::{
 use orbit_common::utility::fs::{atomic_write_text, with_exclusive_file_lock};
 use serde_json::{Value, json};
 
+use crate::file::yaml_doc::{parse_yaml_with, serialize_yaml_with};
+
 pub use orbit_common::types::validate_friction_id;
 
 const TAGS_FILENAME: &str = "tags.yaml";
@@ -569,8 +571,9 @@ fn load_tag_taxonomy(frictions_root: &Path) -> Result<BTreeSet<String>, OrbitErr
     let path = ensure_default_tag_taxonomy(frictions_root)?;
     let raw = fs::read_to_string(&path)
         .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
-    let value: serde_yaml::Value = serde_yaml::from_str(&raw)
-        .map_err(|error| OrbitError::InvalidInput(format!("parse {}: {error}", path.display())))?;
+    let value: serde_yaml::Value = parse_yaml_with(&raw, &path, |_, error| {
+        OrbitError::InvalidInput(format!("parse {}: {error}", path.display()))
+    })?;
     let mut tags = BTreeSet::new();
     collect_tags_from_yaml(&value, &mut tags);
     if tags.is_empty() {
@@ -703,8 +706,9 @@ fn write_record_at(
         during_task: record.during_task.clone(),
         resolved_by_task: record.resolved_by_task.clone(),
     };
-    let yaml = serde_yaml::to_string(&frontmatter)
-        .map_err(|error| OrbitError::Store(format!("serialize friction frontmatter: {error}")))?;
+    let yaml = serialize_yaml_with(&frontmatter, |error| {
+        OrbitError::Store(format!("serialize friction frontmatter: {error}"))
+    })?;
     let content = format!("---\n{}---\n{}\n", yaml, record.body.trim_end());
     atomic_write_text(path, &content).map_err(|error| OrbitError::Io(error.to_string()))?;
     Ok(StoredFrictionRecord {
@@ -722,7 +726,7 @@ fn read_record_at(path: &Path) -> Result<StoredFrictionRecord, OrbitError> {
             path.display()
         ))
     })?;
-    let frontmatter: FrictionFrontmatter = serde_yaml::from_str(yaml).map_err(|error| {
+    let frontmatter: FrictionFrontmatter = parse_yaml_with(yaml, path, |_, error| {
         OrbitError::Store(format!(
             "parse friction frontmatter {}: {error}",
             path.display()

--- a/crates/orbit-store/src/file/learning_store/doc.rs
+++ b/crates/orbit-store/src/file/learning_store/doc.rs
@@ -81,9 +81,3 @@ fn default_schema_version() -> u8 {
 fn default_status() -> LearningStatus {
     LearningStatus::Active
 }
-
-pub(super) fn serialize_learning_doc_yaml(
-    doc: &LearningFileDocument,
-) -> Result<String, orbit_common::types::OrbitError> {
-    serde_yaml::to_string(doc).map_err(|e| orbit_common::types::OrbitError::Store(e.to_string()))
-}

--- a/crates/orbit-store/src/file/learning_store/record.rs
+++ b/crates/orbit-store/src/file/learning_store/record.rs
@@ -6,9 +6,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use orbit_common::types::{Learning, LearningStatus, NotFoundKind, OrbitError};
 
 use super::constants::LEARNING_SCHEMA_VERSION;
-use super::doc::{LearningFileDocument, serialize_learning_doc_yaml};
+use super::doc::LearningFileDocument;
 use super::layout::validate_learning_id;
-use crate::file::yaml_doc::{read_yaml_with, write_yaml_atomic_with};
+use crate::file::yaml_doc::{read_yaml_with, serialize_yaml_with, write_yaml_atomic_with};
 
 static LEARNING_CREATE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -55,7 +55,7 @@ pub(super) fn write_learning_file(
         schema_version: LEARNING_SCHEMA_VERSION,
         learning: learning.clone(),
     };
-    write_yaml_atomic_with(path, &doc, serialize_learning_doc_yaml)
+    write_yaml_atomic_with(path, &doc, |error| OrbitError::Store(error.to_string()))
 }
 
 /// Create a learning record at `path` without clobbering an existing body.
@@ -87,7 +87,7 @@ pub(super) fn create_learning_file_exclusive(
         schema_version: LEARNING_SCHEMA_VERSION,
         learning: learning.clone(),
     };
-    let yaml = serialize_learning_doc_yaml(&doc)?;
+    let yaml = serialize_yaml_with(&doc, |error| OrbitError::Store(error.to_string()))?;
     let temp_path = exclusive_temp_path(path);
     let mut file = OpenOptions::new()
         .create_new(true)

--- a/crates/orbit-store/src/file/policy_def_store/mod.rs
+++ b/crates/orbit-store/src/file/policy_def_store/mod.rs
@@ -6,7 +6,7 @@ use orbit_common::types::{
     ResourceKind, ResourceMetadata, parse_policy_resource, validate_resource_name,
 };
 
-use orbit_common::utility::fs::atomic_write_text_volatile as write_atomic;
+use crate::file::yaml_doc::write_yaml_atomic_with;
 
 pub(crate) struct PolicyDefFileStore {
     root: PathBuf,
@@ -69,23 +69,23 @@ impl PolicyDefFileStore {
         def.validate()?;
         let path = self.policy_path(&def.name)?;
         self.ensure_layout()?;
-        let content = serde_yaml::to_string(&PolicyResource {
-            schema_version: POLICY_RESOURCE_SCHEMA_VERSION,
-            kind: ResourceKind::Policy,
-            metadata: ResourceMetadata::named(def.name.clone()),
-            spec: PolicyResourceSpec {
-                description: def.description.clone(),
-                deny_read: def.deny_read.clone(),
-                deny_modify: def.deny_modify.clone(),
-                fs_profiles: def.fs_profiles.clone(),
-                created_at: def.created_at,
-                updated_at: def.updated_at,
+        write_yaml_atomic_with(
+            &path,
+            &PolicyResource {
+                schema_version: POLICY_RESOURCE_SCHEMA_VERSION,
+                kind: ResourceKind::Policy,
+                metadata: ResourceMetadata::named(def.name.clone()),
+                spec: PolicyResourceSpec {
+                    description: def.description.clone(),
+                    deny_read: def.deny_read.clone(),
+                    deny_modify: def.deny_modify.clone(),
+                    fs_profiles: def.fs_profiles.clone(),
+                    created_at: def.created_at,
+                    updated_at: def.updated_at,
+                },
             },
-        })
-        .map_err(|e| {
-            OrbitError::InvalidInput(format!("failed to serialize policy {}: {e}", def.name))
-        })?;
-        write_atomic(&path, &content).map_err(Into::into)
+            |e| OrbitError::InvalidInput(format!("failed to serialize policy {}: {e}", def.name)),
+        )
     }
 }
 

--- a/crates/orbit-store/src/file/skill_store/mod.rs
+++ b/crates/orbit-store/src/file/skill_store/mod.rs
@@ -9,6 +9,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 
+use crate::file::yaml_doc::parse_yaml_with;
+
 const PURPOSE_SECTION: &str = "Purpose";
 const META_NAME: &str = "name";
 const META_SUMMARY: &str = "summary";
@@ -386,8 +388,9 @@ fn parse_frontmatter(raw: &str) -> Result<SkillFrontmatter, OrbitError> {
     }
 
     let fm_raw = fm_lines.join("\n");
-    serde_yaml::from_str::<SkillFrontmatter>(&fm_raw)
-        .map_err(|e| OrbitError::SkillValidation(format!("invalid skill frontmatter: {e}")))
+    parse_yaml_with(&fm_raw, Path::new("<skill frontmatter>"), |_, e| {
+        OrbitError::SkillValidation(format!("invalid skill frontmatter: {e}"))
+    })
 }
 
 fn parse_section_heading(raw: &str) -> Option<String> {

--- a/crates/orbit-store/src/file/task_store/v2_bundle.rs
+++ b/crates/orbit-store/src/file/task_store/v2_bundle.rs
@@ -13,6 +13,7 @@ use orbit_common::types::{
 };
 use orbit_common::utility::fs::{atomic_write_text, sync_parent_dir, with_exclusive_file_lock};
 
+use crate::file::yaml_doc::write_yaml_atomic_with;
 use crate::sqlite::task_registry::{ProjectionRebuildResult, TaskRegistryStore};
 
 pub(crate) mod bundle_io;
@@ -21,7 +22,7 @@ pub(crate) mod task_bundle_types;
 
 pub(crate) use bundle_io::{
     append_jsonl_row, cleanup_partial_bundle_best_effort, copy_artifact_blobs, read_bundle_at,
-    write_bundle_at, write_yaml_file,
+    write_bundle_at,
 };
 pub(crate) use lock::{
     ensure_projection_entry_removable, remove_projection_entry, remove_task_bundle_lock_sentinel,
@@ -233,9 +234,10 @@ impl TaskBundleStoreV2 {
             )));
         }
         envelope.validate()?;
-        write_yaml_file(
+        write_yaml_atomic_with(
             &self.bundle_path(task_id)?.join(TASK_ENVELOPE_FILE_NAME),
             envelope,
+            |err| OrbitError::Store(err.to_string()),
         )
     }
 
@@ -245,12 +247,13 @@ impl TaskBundleStoreV2 {
         manifest: &ArtifactManifestV2,
     ) -> Result<(), OrbitError> {
         manifest.validate()?;
-        write_yaml_file(
+        write_yaml_atomic_with(
             &self
                 .bundle_path(task_id)?
                 .join(TASK_ARTIFACTS_DIR_NAME)
                 .join(TASK_ARTIFACT_MANIFEST_FILE_NAME),
             manifest,
+            |err| OrbitError::Store(err.to_string()),
         )
     }
 

--- a/crates/orbit-store/src/file/task_store/v2_bundle/bundle_io/mod.rs
+++ b/crates/orbit-store/src/file/task_store/v2_bundle/bundle_io/mod.rs
@@ -16,6 +16,7 @@ use sha2::{Digest, Sha256};
 
 use super::task_bundle_types::TaskBundleV2;
 use crate::file::task_store::task_migrations;
+use crate::file::yaml_doc::{parse_yaml_with, write_yaml_atomic_with};
 
 /// Write a new v2 bundle at `bundle_dir`.
 ///
@@ -32,7 +33,11 @@ pub(crate) fn write_bundle_at(bundle_dir: &Path, bundle: &TaskBundleV2) -> Resul
     validate_bundle(bundle)?;
     ensure_bundle_dirs(bundle_dir)?;
 
-    write_yaml_file(&bundle_dir.join(TASK_ENVELOPE_FILE_NAME), &bundle.envelope)?;
+    write_yaml_atomic_with(
+        &bundle_dir.join(TASK_ENVELOPE_FILE_NAME),
+        &bundle.envelope,
+        |err| OrbitError::Store(err.to_string()),
+    )?;
     atomic_write_text(
         &bundle_dir.join(TASK_DESCRIPTION_FILE_NAME),
         &bundle.description,
@@ -54,11 +59,12 @@ pub(crate) fn write_bundle_at(bundle_dir: &Path, bundle: &TaskBundleV2) -> Resul
     write_jsonl_file(&bundle_dir.join(TASK_EVENTS_FILE_NAME), &bundle.events)?;
     write_jsonl_file(&bundle_dir.join(TASK_COMMENTS_FILE_NAME), &bundle.comments)?;
     if let Some(manifest) = &bundle.artifact_manifest {
-        write_yaml_file(
+        write_yaml_atomic_with(
             &bundle_dir
                 .join(TASK_ARTIFACTS_DIR_NAME)
                 .join(TASK_ARTIFACT_MANIFEST_FILE_NAME),
             manifest,
+            |err| OrbitError::Store(err.to_string()),
         )?;
     }
 
@@ -149,21 +155,14 @@ fn task_id_from_bundle_dir(bundle_dir: &Path) -> Result<String, OrbitError> {
         })
 }
 
-pub(crate) fn write_yaml_file<T>(path: &Path, value: &T) -> Result<(), OrbitError>
-where
-    T: serde::Serialize,
-{
-    let yaml = serde_yaml::to_string(value).map_err(|err| OrbitError::Store(err.to_string()))?;
-    atomic_write_text(path, &yaml).map_err(|err| OrbitError::Io(err.to_string()))
-}
-
 fn read_migrated_yaml_file<T>(path: &Path, plan: &Plan) -> Result<T, OrbitError>
 where
     T: DeserializeOwned,
 {
     let raw = read_required_text(path)?;
-    let value: serde_yaml::Value = serde_yaml::from_str(&raw)
-        .map_err(|err| OrbitError::Store(format!("invalid YAML at {}: {err}", path.display())))?;
+    let value: serde_yaml::Value = parse_yaml_with(&raw, path, |_, err| {
+        OrbitError::Store(format!("invalid YAML at {}: {err}", path.display()))
+    })?;
     let migrated = plan.migrate(value).map_err(|err| match err {
         OrbitError::Migration(msg) => {
             OrbitError::Migration(format!("{} ({})", msg, path.display()))
@@ -336,7 +335,7 @@ fn read_artifact_manifest(bundle_dir: &Path) -> Result<Option<ArtifactManifestV2
     let manifest_path = artifact_dir.join(TASK_ARTIFACT_MANIFEST_FILE_NAME);
     match fs::read_to_string(&manifest_path) {
         Ok(raw) => {
-            let manifest: ArtifactManifestV2 = serde_yaml::from_str(&raw).map_err(|err| {
+            let manifest: ArtifactManifestV2 = parse_yaml_with(&raw, &manifest_path, |_, err| {
                 OrbitError::Store(format!(
                     "invalid artifact manifest {}: {err}",
                     manifest_path.display()

--- a/crates/orbit-store/src/file/yaml_doc.rs
+++ b/crates/orbit-store/src/file/yaml_doc.rs
@@ -12,17 +12,38 @@ where
     F: FnOnce(&Path, serde_yaml::Error) -> OrbitError,
 {
     let raw = fs::read_to_string(path).map_err(|e| OrbitError::Io(e.to_string()))?;
-    serde_yaml::from_str(&raw).map_err(|err| invalid(path, err))
+    parse_yaml_with(&raw, path, invalid)
 }
 
-pub(crate) fn write_yaml_atomic_with<T, F>(
+pub(crate) fn parse_yaml_with<T: serde::de::DeserializeOwned, F>(
+    raw: &str,
+    path: &Path,
+    invalid: F,
+) -> Result<T, OrbitError>
+where
+    F: FnOnce(&Path, serde_yaml::Error) -> OrbitError,
+{
+    serde_yaml::from_str(raw).map_err(|err| invalid(path, err))
+}
+
+pub(crate) fn serialize_yaml_with<T: serde::Serialize, F>(
+    value: &T,
+    invalid: F,
+) -> Result<String, OrbitError>
+where
+    F: FnOnce(serde_yaml::Error) -> OrbitError,
+{
+    serde_yaml::to_string(value).map_err(invalid)
+}
+
+pub(crate) fn write_yaml_atomic_with<T: serde::Serialize, F>(
     path: &Path,
     value: &T,
-    serialize: F,
+    invalid: F,
 ) -> Result<(), OrbitError>
 where
-    F: FnOnce(&T) -> Result<String, OrbitError>,
+    F: FnOnce(serde_yaml::Error) -> OrbitError,
 {
-    let yaml = serialize(value)?;
+    let yaml = serialize_yaml_with(value, invalid)?;
     write_atomic(path, &yaml).map_err(Into::into)
 }

--- a/crates/orbit-store/src/sqlite/id_allocator/mod.rs
+++ b/crates/orbit-store/src/sqlite/id_allocator/mod.rs
@@ -11,6 +11,8 @@ use rusqlite::{Connection, Transaction, TransactionBehavior, params, types::Type
 use serde::{Deserialize, Serialize};
 use serde_yaml::{Mapping, Value};
 
+use crate::file::yaml_doc::{parse_yaml_with, serialize_yaml_with};
+
 const KIND_ADR: &str = "adr";
 const KIND_LEARNING: &str = "learning";
 const STATUS_ABANDONED: &str = "abandoned";
@@ -435,8 +437,8 @@ impl IdAllocator {
 
             let mut value = read_yaml_value(yaml_path)?;
             rewrite_learning_yaml(&mut value, old_id, &rename.new_id, &rename_map)?;
-            let rendered = serde_yaml::to_string(&value)
-                .map_err(|error| OrbitError::Migration(error.to_string()))?;
+            let rendered =
+                serialize_yaml_with(&value, |error| OrbitError::Migration(error.to_string()))?;
             atomic_write_text(yaml_path, &rendered).map_err(|error| {
                 OrbitError::Io(format!("write {}: {error}", yaml_path.display()))
             })?;
@@ -875,8 +877,9 @@ fn yaml_epoch(path: &Path) -> Result<i64, OrbitError> {
 fn read_yaml_value(path: &Path) -> Result<Value, OrbitError> {
     let raw = fs::read_to_string(path)
         .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
-    serde_yaml::from_str(&raw)
-        .map_err(|error| OrbitError::Migration(format!("parse {}: {error}", path.display())))
+    parse_yaml_with(&raw, path, |_, error| {
+        OrbitError::Migration(format!("parse {}: {error}", path.display()))
+    })
 }
 
 fn rewrite_learning_yaml(

--- a/crates/orbit-store/src/sqlite/task_registry/workspace_config.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/workspace_config.rs
@@ -2,8 +2,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use orbit_common::types::OrbitError;
-use orbit_common::utility::fs::atomic_write_text;
 use serde::{Deserialize, Serialize};
+
+use crate::file::yaml_doc::{parse_yaml_with, write_yaml_atomic_with};
 
 use super::CONFIG_SCHEMA_VERSION;
 use super::types::WorkspaceConfig;
@@ -52,7 +53,7 @@ pub fn read_workspace_config_optional(
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(err) => return Err(OrbitError::Io(err.to_string())),
     };
-    let doc: WorkspaceConfigDoc = serde_yaml::from_str(&raw).map_err(|e| {
+    let doc: WorkspaceConfigDoc = parse_yaml_with(&raw, &path, |_, e| {
         OrbitError::InvalidInput(format!(
             "invalid workspace config '{}': {e}",
             path.display()
@@ -77,9 +78,9 @@ pub fn write_workspace_config(
         schema_version: CONFIG_SCHEMA_VERSION,
         workspace_id,
     };
-    let content = serde_yaml::to_string(&doc).map_err(|e| OrbitError::Store(e.to_string()))?;
-    atomic_write_text(&workspace_config_path(orbit_dir), &content)
-        .map_err(|e| OrbitError::Io(e.to_string()))
+    write_yaml_atomic_with(&workspace_config_path(orbit_dir), &doc, |e| {
+        OrbitError::Store(e.to_string())
+    })
 }
 
 fn validate_workspace_config_doc(doc: WorkspaceConfigDoc) -> Result<WorkspaceConfig, OrbitError> {


### PR DESCRIPTION
## Task

[ORB-10406](https://orbit-cli.com/tasks/ORB-10406) — orbit-store: fan yaml_doc.rs helpers out to the 14 hand-rolled call sites

### Description

Tier 2 of the orbit-store cleanup (design doc: ~/workspace/constellation/knowledgebase/polaris/design/orbit-cleanup/orbitstorecleanup.md §7).

file/yaml_doc.rs provides read_yaml_with / write_yaml_atomic_with with pluggable error mapping, but only two call sites use it (learning_store/record.rs, adr_store/bundle/mod.rs). Fourteen other sites hand-roll serde_yaml + their own error mapping: policy_def_store:72, executor_def_store:64,89, learning_store/doc.rs:88, friction_store:572,706,725, skill_store:389, adr_store/doc:17, task_store/v2_bundle/bundle_io:156,165,339 (incl. its private write_yaml_file), id_allocator:438,878, task_registry/workspace_config:62,87.

Migrate all fourteen to the shared helpers. The real payoff is removing error-mapping drift (some map to OrbitError::Store, others OrbitError::Io for the same failure class) — preserve each site's CURRENT error variant exactly in this pass; normalizing variants would be a behavior change and is out of scope. Pure refactor.

Depends on ORB-10404 (workspace_config.rs overlap — dead fn deletions land first). Dispatch gate: hold until ORB-10358 lands and the rebuild is verified.

### Acceptance Criteria

- All fourteen sites route through yaml_doc helpers; bundle_io's private write_yaml_file removed; each site's existing error variant preserved (no error-type changes); no remaining direct serde_yaml::from_str/to_string in the migrated files; full test suite passes; no behavior change.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Expanded file::yaml_doc with shared parse/serialize helpers and made atomic writes use the centralized serializer.
- Migrated all scoped policy, executor, learning, friction, skill, ADR, task-bundle, ID-allocation, and workspace-config YAML operations while preserving each existing OrbitError variant and message shape.
- Removed bundle_io::write_yaml_file and updated directly affected ADR serialization tests.
Assessment: Pure refactor; scoped files contain no direct serde_yaml::from_str/to_string calls outside yaml_doc.
Validation:
- cargo test -p orbit-store --lib --quiet (297 passed, 3 ignored)
- make ci-fast
- git diff --check
- Scoped direct-serde/write_yaml_file audit passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10406-6a65672a`
- Behind base: 0
- Ahead of base: 1