### PR TITLE
Shared seed_embedded_assets helper for activity/job/routine seeding

### DIFF
--- a/crates/orbit-core/src/command/activity.rs
+++ b/crates/orbit-core/src/command/activity.rs
@@ -1,7 +1,9 @@
+use std::borrow::Cow;
 use std::path::Path;
 
 use orbit_common::types::OrbitError;
-use orbit_common::utility::fs::write_text_with_parent;
+
+use super::seed_embedded_assets;
 
 /// Shippable default activity assets, seeded under
 /// `<orbit_root>/resources/activities/<name>.yaml` on `orbit init`. Keep this
@@ -151,16 +153,12 @@ pub(crate) fn seed_default_activities(
     activities_dir: &Path,
     overwrite: bool,
 ) -> Result<usize, OrbitError> {
-    let mut count = 0usize;
-    for (name, content) in DEFAULT_ACTIVITY_FILES {
-        let path = activities_dir.join(format!("{name}.yaml"));
-        if !overwrite && path.exists() {
-            continue;
-        }
-        write_text_with_parent(&path, content)?;
-        count += 1;
-    }
-    Ok(count)
+    seed_embedded_assets(
+        activities_dir,
+        DEFAULT_ACTIVITY_FILES,
+        overwrite,
+        |_, content| Ok(Cow::Borrowed(content)),
+    )
 }
 
 #[cfg(test)]

--- a/crates/orbit-core/src/command/job/catalog.rs
+++ b/crates/orbit-core/src/command/job/catalog.rs
@@ -1,13 +1,14 @@
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 use orbit_common::types::activity_job::{
     CatalogDirectory, CatalogDirectoryList, V2JobCatalog, catalog_error_to_orbit,
 };
 use orbit_common::types::{JobKind, JobRun, JobScheduleState, JobV2, NotFoundKind, OrbitError};
-use orbit_common::utility::fs::write_text_with_parent;
 use serde_json::Value;
 
 use crate::OrbitRuntime;
+use crate::command::seed_embedded_assets;
 
 /// Shippable default workflow assets, seeded under
 /// `<orbit_root>/resources/jobs/<name>.yaml` on `orbit init`. The entries
@@ -279,14 +280,7 @@ fn matches_job_filter(kind: JobKind, filter: JobCatalogFilter) -> bool {
 /// When `overwrite` is false, existing files are preserved — users who've
 /// edited a previously-seeded workflow won't lose their changes on re-init.
 pub(crate) fn seed_default_jobs(jobs_dir: &Path, overwrite: bool) -> Result<usize, OrbitError> {
-    let mut count = 0usize;
-    for (name, content) in DEFAULT_JOB_FILES {
-        let path = jobs_dir.join(format!("{name}.yaml"));
-        if !overwrite && path.exists() {
-            continue;
-        }
-        write_text_with_parent(&path, content)?;
-        count += 1;
-    }
-    Ok(count)
+    seed_embedded_assets(jobs_dir, DEFAULT_JOB_FILES, overwrite, |_, content| {
+        Ok(Cow::Borrowed(content))
+    })
 }

--- a/crates/orbit-core/src/command/mod.rs
+++ b/crates/orbit-core/src/command/mod.rs
@@ -10,10 +10,40 @@
 //! Default YAML assets (e.g., sample skills, config templates) are embedded
 //! at compile time via `include_str!` and seeded to disk on first `orbit init`.
 
+use std::borrow::Cow;
+use std::path::Path;
+
+use orbit_common::types::OrbitError;
+use orbit_common::utility::fs::write_text_with_parent;
+
 /// Audit identity used for system-initiated (non-agent) mutations.
 /// `pub` because the direct v2 activity runner moved to `orbit-cmd`
 /// [ORB-10016] and stamps the same identity.
 pub const SYSTEM_AUDIT_IDENTITY: &str = "system";
+
+/// Seed every `(name, content)` pair in `files` as `<dir>/<name>.yaml`,
+/// skipping entries that already exist unless `overwrite` is set. `render`
+/// maps each embedded asset's raw content to what actually gets written —
+/// activity and job seeding pass content through unchanged; routine seeding
+/// uses it for placeholder substitution and fail-closed validation.
+pub(crate) fn seed_embedded_assets<'a>(
+    dir: &Path,
+    files: &'a [(&'a str, &'a str)],
+    overwrite: bool,
+    mut render: impl FnMut(&'a str, &'a str) -> Result<Cow<'a, str>, OrbitError>,
+) -> Result<usize, OrbitError> {
+    let mut count = 0usize;
+    for (name, content) in files {
+        let path = dir.join(format!("{name}.yaml"));
+        if !overwrite && path.exists() {
+            continue;
+        }
+        let rendered = render(name, content)?;
+        write_text_with_parent(&path, &rendered)?;
+        count += 1;
+    }
+    Ok(count)
+}
 
 pub(crate) mod activity;
 pub mod audit_event;

--- a/crates/orbit-core/src/command/routine.rs
+++ b/crates/orbit-core/src/command/routine.rs
@@ -16,10 +16,12 @@
 //! `[routines] role = "source"`; they exist so a fresh workspace gets
 //! reviewable, opt-in schedules without silently enabling unattended work.
 
+use std::borrow::Cow;
 use std::path::Path;
 
 use orbit_common::types::{OrbitError, parse_routine_yaml};
-use orbit_common::utility::fs::write_text_with_parent;
+
+use super::seed_embedded_assets;
 
 /// Shippable default routine assets, seeded under
 /// `<workspace>/.orbit/routines/<file>.yaml` on `orbit init`. Every entry
@@ -68,27 +70,25 @@ pub(crate) fn seed_default_routines(
             "cannot seed default routines without a host id".to_string(),
         ));
     }
-    let mut count = 0usize;
-    for (file_stem, template) in DEFAULT_ROUTINE_FILES {
-        let path = routines_dir.join(format!("{file_stem}.yaml"));
-        if !overwrite && path.exists() {
-            continue;
-        }
-        let routine_name = routine_name_for(file_stem, workspace_slug);
-        let rendered = template
-            .replace(ROUTINE_NAME_PLACEHOLDER, &routine_name)
-            .replace(HOST_ID_PLACEHOLDER, host_id);
-        // Fail-closed: never seed a file the routine loader would reject.
-        parse_routine_yaml(&rendered).map_err(|error| {
-            OrbitError::InvalidInput(format!(
-                "default routine `{file_stem}` failed validation after placeholder \
-                 substitution (host `{host_id}`, name `{routine_name}`): {error}"
-            ))
-        })?;
-        write_text_with_parent(&path, &rendered)?;
-        count += 1;
-    }
-    Ok(count)
+    seed_embedded_assets(
+        routines_dir,
+        DEFAULT_ROUTINE_FILES,
+        overwrite,
+        |file_stem, template| {
+            let routine_name = routine_name_for(file_stem, workspace_slug);
+            let rendered = template
+                .replace(ROUTINE_NAME_PLACEHOLDER, &routine_name)
+                .replace(HOST_ID_PLACEHOLDER, host_id);
+            // Fail-closed: never seed a file the routine loader would reject.
+            parse_routine_yaml(&rendered).map_err(|error| {
+                OrbitError::InvalidInput(format!(
+                    "default routine `{file_stem}` failed validation after placeholder \
+                     substitution (host `{host_id}`, name `{routine_name}`): {error}"
+                ))
+            })?;
+            Ok(Cow::Owned(rendered))
+        },
+    )
 }
 
 /// Compose a per-workspace routine name: `<stem>-<workspace-slug>`, using


### PR DESCRIPTION
## Task

[ORB-10392](https://orbit-cli.com/tasks/ORB-10392) — Shared seed_embedded_assets helper for activity/job/routine seeding

### Description

Wave 2 of the orbit-core cleanup (design doc: ~/workspace/constellation/knowledgebase/polaris/design/orbit-cleanup/orbit-core-cleanup.md §8).

seed_default_activities (command/activity.rs) and seed_default_jobs (command/job/catalog.rs) are byte-identical modulo the constant name; seed_default_routines (command/routine.rs) is the same loop plus placeholder substitution and fail-closed validation. Extract one seed_embedded_assets(dir, files, overwrite, render) helper covering all three call sites.

Scope is exactly three call sites: executor seeding writes to the store and skill seeding has a different shape — neither folds in. Pure refactor, no behavior change (identical files written, identical counts returned, routine validation stays fail-closed).

Depends on ORB-10388 (command/job/catalog.rs overlap). Dispatch gate: hold until ORB-10358 lands and the rebuild is verified.

### Acceptance Criteria

- Single shared helper used by all three seeders; executor and skill seeding untouched; seeded output byte-identical before/after (verify on a fresh orbit init); routine placeholder substitution and fail-closed validation preserved; full test suite passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Extracted a single `seed_embedded_assets(dir, files, overwrite, render)` helper in `crates/orbit-core/src/command/mod.rs` and rewired all three call sites to use it:

- `command/activity.rs::seed_default_activities` — render is a no-op passthrough (`Cow::Borrowed(content)`).
- `command/job/catalog.rs::seed_default_jobs` — same no-op passthrough.
- `command/routine.rs::seed_default_routines` — render does the `__ORBIT_ROUTINE_NAME__`/`__ORBIT_HOST_ID__` placeholder substitution and the fail-closed `parse_routine_yaml` validation, then returns `Cow::Owned(rendered)`; the host-id-empty guard stays in `seed_default_routines` itself (runs once, before the per-file loop, not per-file).

Executor seeding (`command/executor.rs`) and skill seeding (`command/skill.rs`) were left untouched, per task scope — different shapes (store-backed / different structure).

Validation:
- `cargo check -p orbit-core` — clean (only pre-existing unrelated warnings).
- `cargo test -p orbit-core --lib` — all activity/job/routine seeding tests pass; whole-crate run is 617 passed / 1 failed, and the one failure (`http_agent_loop_tool_update_persists_runtime_identity_family`) reproduces identically on the unmodified base branch (missing provider credential in this sandbox — unrelated to this change).
- `cargo test --workspace` — one pre-existing failure, `mcp_serve_tools_list_matches_production_snapshot`, reproduced identically on the unmodified base branch (unrelated MCP tool snapshot drift, not touched by this diff).
- Byte-identical output verified directly: built binaries from both the pre-change and post-change trees, ran `orbit init --root <tmp> --non-interactive --host-name test-host` against each, and `diff -rq` the seeded `resources/activities/` and `resources/jobs/` directories — zero differences. Refreshed counts also matched exactly (32 activities, 10 jobs). Routine seeding correctness (placeholder substitution + fail-closed validation + overwrite semantics) is covered directly by its existing unit tests, which pass unchanged.
- `make ci-fast` — passes (had to run `cargo fmt --all` once to satisfy the formatter on the new call-site formatting).

No behavior change; no new dependencies; no public API changes (all touched items stay `pub(crate)`).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10392-6a656632`
- Behind base: 0
- Ahead of base: 1