### PR TITLE
Collapse the four-hop config accessor chain via OrbitContext::settings()

### DIFF
--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -409,45 +409,8 @@ impl OrbitContext {
         self.runtime.graph_editing
     }
 
-    pub(crate) fn pr_config(&self) -> &PrConfig {
-        self.runtime.pr_config()
-    }
-
-    /// Persisted default for the v2 `agent_loop` execution backend (§3.1
-    /// resolution precedence step 3). `None` means "not configured".
-    pub(crate) fn v2_backend(&self) -> Option<&str> {
-        self.runtime.v2_backend()
-    }
-
-    /// Default base branch for ship/duel-plan workflows. Sourced
-    /// from `[workflow] base_branch` in `config.toml`; falls back to
-    /// `"main"` when the key is absent.
-    pub(crate) fn workflow_base_branch(&self) -> &str {
-        self.runtime.workflow_base_branch()
-    }
-
-    /// Whether this workspace opted into unattended ship dispatch
-    /// (`[workflow] auto_ship` in `config.toml`, default `false`).
-    pub(crate) fn workflow_auto_ship(&self) -> bool {
-        self.runtime.workflow_auto_ship()
-    }
-
-    /// Whether this workspace is a routine source
-    /// (`[routines] role = "source"` in `config.toml`, default `false`).
-    pub(crate) fn routines_source(&self) -> bool {
-        self.runtime.routines_source()
-    }
-
-    pub(crate) fn crews(&self) -> &std::collections::BTreeMap<String, Crew> {
-        self.runtime.crews()
-    }
-
-    pub(crate) fn default_crew(&self) -> Option<&str> {
-        self.runtime.default_crew()
-    }
-
-    pub(crate) fn duel_config(&self) -> &DuelConfig {
-        self.runtime.duel_config()
+    pub(crate) fn settings(&self) -> &OrbitRuntimeSettings {
+        &self.runtime
     }
 }
 

--- a/crates/orbit-core/src/runtime/engine/crew.rs
+++ b/crates/orbit-core/src/runtime/engine/crew.rs
@@ -94,9 +94,14 @@ impl ResolvedCrewProjection {
 
 impl OrbitRuntime {
     pub fn configured_crew_registry_projection(&self) -> ConfiguredCrewRegistryProjection {
-        let default_crew = self.context.default_crew().map(ToString::to_string);
+        let default_crew = self
+            .context
+            .settings()
+            .default_crew()
+            .map(ToString::to_string);
         let mut crews = self
             .context
+            .settings()
             .crews()
             .values()
             .map(|crew| {
@@ -117,7 +122,7 @@ impl OrbitRuntime {
         let Some(crew) = crew.map(str::trim).filter(|value| !value.is_empty()) else {
             return Ok(());
         };
-        resolve_crew(crew, self.context.crews()).map(|_| ())
+        resolve_crew(crew, self.context.settings().crews()).map(|_| ())
     }
 
     pub fn resolve_crew_for_task(
@@ -132,7 +137,7 @@ impl OrbitRuntime {
         let selection = select_crew_name(
             cli_override,
             task_crew,
-            self.context.default_crew(),
+            self.context.settings().default_crew(),
             None,
             None,
         );
@@ -143,7 +148,7 @@ impl OrbitRuntime {
                     .to_string(),
             ));
         };
-        resolve_crew(selected, self.context.crews())
+        resolve_crew(selected, self.context.settings().crews())
     }
 
     pub(crate) fn resolve_crew_for_run_input(&self, input: &Value) -> Result<Crew, OrbitError> {
@@ -184,7 +189,8 @@ impl OrbitRuntime {
             }));
         }
 
-        let has_resolvable_name = task.crew.is_some() || self.context.default_crew().is_some();
+        let has_resolvable_name =
+            task.crew.is_some() || self.context.settings().default_crew().is_some();
         if !has_resolvable_name {
             return Ok(None);
         }
@@ -233,7 +239,7 @@ impl OrbitRuntime {
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
-            && let Ok(crew) = resolve_crew(crew_name, self.context.crews())
+            && let Ok(crew) = resolve_crew(crew_name, self.context.settings().crews())
             && let Some(family) = family_from_assignment(&crew.assignment)
         {
             return Ok((Some(family.clone()), Some(family)));

--- a/crates/orbit-core/src/runtime/engine/environment_host.rs
+++ b/crates/orbit-core/src/runtime/engine/environment_host.rs
@@ -55,8 +55,9 @@ impl EnvironmentHost for OrbitRuntime {
     fn agent_role_config(&self, role: AgentRole) -> Option<AgentRoleConfig> {
         let crew = self
             .context
+            .settings()
             .default_crew()
-            .and_then(|name| self.context.crews().get(name))?;
+            .and_then(|name| self.context.settings().crews().get(name))?;
         let raw = crew.role(role.as_str())?;
         Some(typed_role_config_from_assignment(role, raw))
     }

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -398,20 +398,20 @@ impl OrbitRuntime {
     }
 
     pub fn pr_config(&self) -> &orbit_engine::PrConfig {
-        self.context.pr_config()
+        self.context.settings().pr_config()
     }
 
     /// Configured default for the v2 `agent_loop` execution backend (§3.1
     /// precedence step 3). Returns `None` when not set.
     pub fn v2_backend_config(&self) -> Option<&str> {
-        self.context.v2_backend()
+        self.context.settings().v2_backend()
     }
 
     /// Default base branch for ship/duel-plan workflows. Sourced
     /// from `[workflow] base_branch` in the active `config.toml`; defaults
     /// to `"main"` when no key is present.
     pub fn workflow_base_branch(&self) -> &str {
-        self.context.workflow_base_branch()
+        self.context.settings().workflow_base_branch()
     }
 
     /// Whether this workspace opted into unattended ship dispatch
@@ -419,7 +419,7 @@ impl OrbitRuntime {
     /// `false`). Consulted by `orbit run ship-sweep` and other schedulers
     /// before dispatching ship runs nobody explicitly asked for.
     pub fn workflow_auto_ship(&self) -> bool {
-        self.context.workflow_auto_ship()
+        self.context.settings().workflow_auto_ship()
     }
 
     /// Whether this workspace declared itself a routine source
@@ -427,17 +427,17 @@ impl OrbitRuntime {
     /// to `false`). Consulted by `orbit sweep` before loading routine
     /// definitions nobody registered explicitly.
     pub fn routines_source(&self) -> bool {
-        self.context.routines_source()
+        self.context.settings().routines_source()
     }
 
     /// Returns the configured `[duel] candidates` list (e.g. ["codex", "claude", "gemini", "grok"]).
     /// Used by `orbit run duel-plan --planner-a ...` overrides to validate explicit families.
     pub fn duel_candidate_families(&self) -> Vec<String> {
-        self.context.duel_config().candidates.clone()
+        self.context.settings().duel_config().candidates.clone()
     }
 
     pub(crate) fn duel_config(&self) -> &crate::config::DuelConfig {
-        self.context.duel_config()
+        self.context.settings().duel_config()
     }
 
     /// Build the activity catalog for `target: activity:<name>` resolution


### PR DESCRIPTION
## Task

[ORB-10394](https://orbit-cli.com/tasks/ORB-10394) — Collapse the four-hop config accessor chain via OrbitContext::settings()

### Description

Wave 2 of the orbit-core cleanup (design doc: ~/workspace/constellation/knowledgebase/polaris/design/orbit-cleanup/orbit-core-cleanup.md §7). Encapsulation question resolved by Daniel 2026-07-25: the OrbitRuntimeSettings indirection is not load-bearing (OrbitContext is pub(crate)-only) — proceed with the collapse.

Eight config accessors (pr_config, v2_backend, workflow_base_branch, workflow_auto_ship, routines_source, crews, default_crew, duel_config) are hand-written four times each across config/runtime.rs, context.rs (OrbitRuntimeSettings + OrbitContext), and runtime/mod.rs. OrbitContext re-delegates all eight verbatim.

Expose OrbitContext::settings() -> &OrbitRuntimeSettings, delete the OrbitContext re-delegation layer, and update call sites. Adding a config key drops from four edits to two. Pure refactor, no behavior change.

Depends on ORB-10390 (runtime/mod.rs overlap). Dispatch gate: hold until ORB-10358 lands and the rebuild is verified.

### Acceptance Criteria

- OrbitContext no longer re-delegates the eight accessors; settings() accessor in place and used at former call sites; no pub leakage of OrbitRuntimeSettings beyond crate boundary; full test suite passes; no behavior change.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added crate-private `OrbitContext::settings()` and removed its eight verbatim runtime-settings forwarding accessors.
- Updated OrbitRuntime and its crew/environment call sites to access the existing `OrbitRuntimeSettings` accessors through `context.settings()`, preserving the public OrbitRuntime API and behavior.
- Expanded `context_files` with `runtime/engine/crew.rs` and `runtime/engine/environment_host.rs` because they were direct former OrbitContext accessor call sites.
Assessment: Pure encapsulation refactor; `OrbitRuntimeSettings` and `settings()` remain crate-private, so no public API leakage.
Validation:
- `cargo fmt --all -- --check`
- `make ci-fast`
- `cargo test -p orbit-core -q`
- Verified no direct calls remain to the removed OrbitContext config accessors and `git diff --check` passes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10394-6a656d76`
- Behind base: 0
- Ahead of base: 1