### PR TITLE
v1 phase-out Stage 2: port planning duel to the v2 pipeline

### DIFF
--- a/.orbit/resources/activities/arbitrate_duel_plan.yaml
+++ b/.orbit/resources/activities/arbitrate_duel_plan.yaml
@@ -1,0 +1,74 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: arbitrate_duel_plan
+spec:
+  type: agent_loop
+  description: >
+    Choose the better of two planning-duel task artifacts for a single task
+    and persist the winner marker.
+  input_schema_json:
+    type: object
+    required: [task_id, planning_duel_slot]
+    properties:
+      task_id:
+        type: string
+        description: Orbit task ID for the planning duel.
+      planning_duel_slot:
+        type: string
+        enum: [arbiter]
+  output_schema_json: {}
+  instruction: |
+    Only use skills listed in this activity's skill_refs. Ignore all others.
+    You are the ARBITER in an Orbit planning duel. Your job is to compare the
+    two submitted planner artifacts, choose the better one, and persist the
+    winning decision to the task artifact bundle.
+
+    Steps:
+    1. Load the task:
+       - Call orbit.task.show with input: {"id": "<task_id>"} to fetch the task title,
+         description, plan, acceptance_criteria, and context_files.
+
+    2. Load only the planner artifacts:
+       - Call orbit.task.show with input: {"id":"<task_id>","field":"artifacts"} to fetch only the task artifacts.
+       - From that response, inspect planner markdown artifacts under `planning-duel/` and ignore `planning-duel/winner.json`.
+       - There must be exactly two planner markdown artifacts for this duel. If there are not exactly two, fail instead of guessing.
+       - Treat both planner artifacts as read-only inputs. Do not invent a third plan.
+
+    3. Infer planner identity from the artifact signatures:
+       - The first line of each planner artifact must be `*authored by: <family> / <slot>*`.
+       - Parse those lines to recover each planner's family and slot.
+       - The artifact signature is the canonical planner identity source.
+
+    4. Verify claims against the codebase:
+       - Use `fs.read` to spot-check the winning proposal's named symbols, files,
+         and directly visible integration points. Use `orbit.search` when related
+         tasks or indexed decisions can resolve ambiguity.
+       - Treat exhaustive caller and blast-radius verification as an
+         implementation/review gate. Require the proposal to name exact
+         `rg` commands for that later verification instead of
+         rejecting a plan because the shell-less arbiter cannot prove it now.
+
+    5. Decide the winner:
+       - Choose the artifact proposal that is more feasible, complete, scoped, and aligned
+         with the current codebase.
+       - Keep a short `arbiter_rationale` that explains why the winning proposal is better.
+
+    6. Persist the winner marker:
+       - Use orbit.duel.plan.winner to write `planning-duel/winner.json`.
+       - Exact example:
+         {"id":"<task_id>","winner_slot":"planner_a","arbiter_rationale":"More concrete writeback and test coverage."}
+
+    7. Stay narrowly scoped:
+       - Do not edit source files, update task.plan directly, or open PRs.
+       - The only permitted mutation is writing `planning-duel/winner.json` via orbit.duel.plan.winner.
+  tools:
+    - orbit.task.show
+    - orbit.duel.plan.winner
+    - orbit.search
+    - fs.read
+  skill_refs:
+    - orbit
+  backend: cli
+  wall_clock_timeout_seconds: 900
+  on_denial: terminate

--- a/.orbit/resources/activities/propose_duel_plan.yaml
+++ b/.orbit/resources/activities/propose_duel_plan.yaml
@@ -1,0 +1,101 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: propose_duel_plan
+spec:
+  type: agent_loop
+  description: >
+    Draft one planning-duel proposal, then persist it as a task artifact.
+  input_schema_json:
+    type: object
+    required: [task_id, planning_duel_slot]
+    properties:
+      task_id:
+        type: string
+        description: Orbit task ID for the planning duel.
+      planning_duel_slot:
+        type: string
+        enum: [planner_a, planner_b]
+  output_schema_json: {}
+  instruction: |
+    Only use skills listed in this activity's skill_refs. Ignore all others.
+    You are a PLANNER in an Orbit planning duel. Inspect the task and surrounding
+    code, draft one implementation-ready proposal, and persist it to the task's
+    `artifacts/` directory. Do not edit source files, open PRs, or rely on your
+    structured response as the workflow handoff.
+
+    Steps:
+    1. Load the task:
+       - Call orbit.task.show with input: {"id": "<task_id>"} to fetch the task title,
+         description, plan, acceptance_criteria, context_files, and workspace_path.
+
+    2. Determine your artifact path from the active slot:
+       - Your active agent family is `{{agent_family}}`.
+       - Your active planning-duel slot is in input.planning_duel_slot.
+       - Your plan artifact path must be `planning-duel/<slot>.md`.
+
+    3. Gather plan-level context BEFORE drafting. Start from the task's directories
+       and each task.context_files entry. Use `orbit.search` for related tasks,
+       decisions, and indexed docs, and use `fs.read` for the named source files,
+       nearby module roots, and manifests. Establish enough breadth to:
+       - Name the files, modules, and symbols the proposal will change.
+       - Identify directly visible consumers, imports, and integration points in
+         the inspected files without claiming exhaustive caller coverage.
+       - Read the full body of every symbol you intend to change.
+       - Map an unfamiliar area before you draft against it.
+       - Mark transitive blast-radius claims that need implementation/review
+         verification as risks, with exact `rg` commands that will verify them
+         later.
+       - If you discover pub(crate) imports, helper coupling, call sites, or
+         dependency edges not reflected in the task description, treat them as
+         hidden coupling — they belong in step 1 of your plan body.
+
+    4. Draft exactly one proposal as markdown:
+       - Include these sections:
+         ## Plan
+         ## Context Files
+         ## Risks
+       - Ignore any existing planner artifact for the other role. Your proposal must
+         be independently reasoned.
+       - The plan MUST:
+         - Name every symbol being moved, renamed, removed, or added (functions,
+           types, modules, constants) BY IDENTIFIER, not by category.
+         - Name the directly visible consumers and integration points established
+           by the inspected files. Treat unverified transitive consumers as an
+           implementation/review risk rather than inventing exhaustive coverage.
+         - Specify exact verification commands the implementer should run — e.g.
+           `cargo build -p <crate>`, `cargo test -p <crate> <test_name>`,
+           `make ci-fast`, `rg '<symbol>' <path>`, or
+           `curl -s http://localhost:<port>/<route>` — that prove the change works.
+         - If hidden coupling exists (imports, helpers, call sites the task
+           description did not name), open the plan with step 1 enumerating it.
+       - The plan MUST NOT:
+         - Use hedge language: "this should just work", "should compile", "verify
+           it continues to compile", "we must verify", "this just works", or
+           similar. Replace each with the exact command above that proves it.
+         - Defer evidence to the implementer ("the implementer will discover X")
+           when inspecting the code now could have surfaced X.
+       - Length is not the goal. Named identifiers, grounded integration points,
+         and exact verification commands are.
+
+    5. Persist the proposal as a task artifact:
+       - Use orbit.duel.plan.add to write the artifact under the slot-derived path. Orbit stamps the signature line.
+       - Exact example:
+         {"id":"<task_id>","planning_duel_slot":"planner_a","content":"## Plan\n..."}
+
+    6. Stay narrowly scoped:
+       - Do not edit source files, update task.plan, or touch PR state.
+       - The only permitted mutation is writing your own planner artifact via orbit.duel.plan.add.
+
+    7. Structured output is optional:
+       - The workflow does not depend on your response payload. Persist the artifact correctly even if you return null.
+  tools:
+    - orbit.task.show
+    - orbit.duel.plan.add
+    - orbit.search
+    - fs.read
+  skill_refs:
+    - orbit
+  backend: cli
+  wall_clock_timeout_seconds: 1800
+  on_denial: terminate

--- a/crates/orbit-cmd/src/activity_v2.rs
+++ b/crates/orbit-cmd/src/activity_v2.rs
@@ -128,6 +128,7 @@ impl ActivityV2Commands for OrbitRuntime {
             input,
             audit: writer.clone(),
             run_id: &run_id,
+            agent_override: None,
             host: Some(self),
         });
 

--- a/crates/orbit-core/assets/activities/arbitrate_duel_plan.yaml
+++ b/crates/orbit-core/assets/activities/arbitrate_duel_plan.yaml
@@ -1,0 +1,74 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: arbitrate_duel_plan
+spec:
+  type: agent_loop
+  description: >
+    Choose the better of two planning-duel task artifacts for a single task
+    and persist the winner marker.
+  input_schema_json:
+    type: object
+    required: [task_id, planning_duel_slot]
+    properties:
+      task_id:
+        type: string
+        description: Orbit task ID for the planning duel.
+      planning_duel_slot:
+        type: string
+        enum: [arbiter]
+  output_schema_json: {}
+  instruction: |
+    Only use skills listed in this activity's skill_refs. Ignore all others.
+    You are the ARBITER in an Orbit planning duel. Your job is to compare the
+    two submitted planner artifacts, choose the better one, and persist the
+    winning decision to the task artifact bundle.
+
+    Steps:
+    1. Load the task:
+       - Call orbit.task.show with input: {"id": "<task_id>"} to fetch the task title,
+         description, plan, acceptance_criteria, and context_files.
+
+    2. Load only the planner artifacts:
+       - Call orbit.task.show with input: {"id":"<task_id>","field":"artifacts"} to fetch only the task artifacts.
+       - From that response, inspect planner markdown artifacts under `planning-duel/` and ignore `planning-duel/winner.json`.
+       - There must be exactly two planner markdown artifacts for this duel. If there are not exactly two, fail instead of guessing.
+       - Treat both planner artifacts as read-only inputs. Do not invent a third plan.
+
+    3. Infer planner identity from the artifact signatures:
+       - The first line of each planner artifact must be `*authored by: <family> / <slot>*`.
+       - Parse those lines to recover each planner's family and slot.
+       - The artifact signature is the canonical planner identity source.
+
+    4. Verify claims against the codebase:
+       - Use `fs.read` to spot-check the winning proposal's named symbols, files,
+         and directly visible integration points. Use `orbit.search` when related
+         tasks or indexed decisions can resolve ambiguity.
+       - Treat exhaustive caller and blast-radius verification as an
+         implementation/review gate. Require the proposal to name exact
+         `rg` commands for that later verification instead of
+         rejecting a plan because the shell-less arbiter cannot prove it now.
+
+    5. Decide the winner:
+       - Choose the artifact proposal that is more feasible, complete, scoped, and aligned
+         with the current codebase.
+       - Keep a short `arbiter_rationale` that explains why the winning proposal is better.
+
+    6. Persist the winner marker:
+       - Use orbit.duel.plan.winner to write `planning-duel/winner.json`.
+       - Exact example:
+         {"id":"<task_id>","winner_slot":"planner_a","arbiter_rationale":"More concrete writeback and test coverage."}
+
+    7. Stay narrowly scoped:
+       - Do not edit source files, update task.plan directly, or open PRs.
+       - The only permitted mutation is writing `planning-duel/winner.json` via orbit.duel.plan.winner.
+  tools:
+    - orbit.task.show
+    - orbit.duel.plan.winner
+    - orbit.search
+    - fs.read
+  skill_refs:
+    - orbit
+  backend: cli
+  wall_clock_timeout_seconds: 900
+  on_denial: terminate

--- a/crates/orbit-core/assets/activities/propose_duel_plan.yaml
+++ b/crates/orbit-core/assets/activities/propose_duel_plan.yaml
@@ -1,0 +1,101 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: propose_duel_plan
+spec:
+  type: agent_loop
+  description: >
+    Draft one planning-duel proposal, then persist it as a task artifact.
+  input_schema_json:
+    type: object
+    required: [task_id, planning_duel_slot]
+    properties:
+      task_id:
+        type: string
+        description: Orbit task ID for the planning duel.
+      planning_duel_slot:
+        type: string
+        enum: [planner_a, planner_b]
+  output_schema_json: {}
+  instruction: |
+    Only use skills listed in this activity's skill_refs. Ignore all others.
+    You are a PLANNER in an Orbit planning duel. Inspect the task and surrounding
+    code, draft one implementation-ready proposal, and persist it to the task's
+    `artifacts/` directory. Do not edit source files, open PRs, or rely on your
+    structured response as the workflow handoff.
+
+    Steps:
+    1. Load the task:
+       - Call orbit.task.show with input: {"id": "<task_id>"} to fetch the task title,
+         description, plan, acceptance_criteria, context_files, and workspace_path.
+
+    2. Determine your artifact path from the active slot:
+       - Your active agent family is `{{agent_family}}`.
+       - Your active planning-duel slot is in input.planning_duel_slot.
+       - Your plan artifact path must be `planning-duel/<slot>.md`.
+
+    3. Gather plan-level context BEFORE drafting. Start from the task's directories
+       and each task.context_files entry. Use `orbit.search` for related tasks,
+       decisions, and indexed docs, and use `fs.read` for the named source files,
+       nearby module roots, and manifests. Establish enough breadth to:
+       - Name the files, modules, and symbols the proposal will change.
+       - Identify directly visible consumers, imports, and integration points in
+         the inspected files without claiming exhaustive caller coverage.
+       - Read the full body of every symbol you intend to change.
+       - Map an unfamiliar area before you draft against it.
+       - Mark transitive blast-radius claims that need implementation/review
+         verification as risks, with exact `rg` commands that will verify them
+         later.
+       - If you discover pub(crate) imports, helper coupling, call sites, or
+         dependency edges not reflected in the task description, treat them as
+         hidden coupling — they belong in step 1 of your plan body.
+
+    4. Draft exactly one proposal as markdown:
+       - Include these sections:
+         ## Plan
+         ## Context Files
+         ## Risks
+       - Ignore any existing planner artifact for the other role. Your proposal must
+         be independently reasoned.
+       - The plan MUST:
+         - Name every symbol being moved, renamed, removed, or added (functions,
+           types, modules, constants) BY IDENTIFIER, not by category.
+         - Name the directly visible consumers and integration points established
+           by the inspected files. Treat unverified transitive consumers as an
+           implementation/review risk rather than inventing exhaustive coverage.
+         - Specify exact verification commands the implementer should run — e.g.
+           `cargo build -p <crate>`, `cargo test -p <crate> <test_name>`,
+           `make ci-fast`, `rg '<symbol>' <path>`, or
+           `curl -s http://localhost:<port>/<route>` — that prove the change works.
+         - If hidden coupling exists (imports, helpers, call sites the task
+           description did not name), open the plan with step 1 enumerating it.
+       - The plan MUST NOT:
+         - Use hedge language: "this should just work", "should compile", "verify
+           it continues to compile", "we must verify", "this just works", or
+           similar. Replace each with the exact command above that proves it.
+         - Defer evidence to the implementer ("the implementer will discover X")
+           when inspecting the code now could have surfaced X.
+       - Length is not the goal. Named identifiers, grounded integration points,
+         and exact verification commands are.
+
+    5. Persist the proposal as a task artifact:
+       - Use orbit.duel.plan.add to write the artifact under the slot-derived path. Orbit stamps the signature line.
+       - Exact example:
+         {"id":"<task_id>","planning_duel_slot":"planner_a","content":"## Plan\n..."}
+
+    6. Stay narrowly scoped:
+       - Do not edit source files, update task.plan, or touch PR state.
+       - The only permitted mutation is writing your own planner artifact via orbit.duel.plan.add.
+
+    7. Structured output is optional:
+       - The workflow does not depend on your response payload. Persist the artifact correctly even if you return null.
+  tools:
+    - orbit.task.show
+    - orbit.duel.plan.add
+    - orbit.search
+    - fs.read
+  skill_refs:
+    - orbit
+  backend: cli
+  wall_clock_timeout_seconds: 1800
+  on_denial: terminate

--- a/crates/orbit-core/src/command/activity.rs
+++ b/crates/orbit-core/src/command/activity.rs
@@ -15,6 +15,10 @@ use super::seed_embedded_assets;
 /// runtime defaults.
 pub(crate) const DEFAULT_ACTIVITY_FILES: &[(&str, &str)] = &[
     (
+        "arbitrate_duel_plan",
+        include_str!("../../assets/activities/arbitrate_duel_plan.yaml"),
+    ),
+    (
         "agent_implement",
         include_str!("../../assets/activities/agent_implement.yaml"),
     ),
@@ -89,6 +93,10 @@ pub(crate) const DEFAULT_ACTIVITY_FILES: &[(&str, &str)] = &[
     (
         "pr_promote",
         include_str!("../../assets/activities/pr_promote.yaml"),
+    ),
+    (
+        "propose_duel_plan",
+        include_str!("../../assets/activities/propose_duel_plan.yaml"),
     ),
     (
         "reserve_locks",
@@ -198,6 +206,36 @@ mod tests {
                     assert_eq!(spec.action, action);
                 }
                 other => panic!("expected deterministic {name} activity, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn seeded_planning_duel_agent_activities_preserve_v1_contracts() {
+        let root = tempdir().expect("create tempdir");
+        let activities_dir = root.path().join("resources/activities");
+        seed_default_activities(&activities_dir, true).expect("seed default activities");
+
+        for (name, timeout, required_tool) in [
+            ("propose_duel_plan", 1_800, "orbit.duel.plan.add"),
+            ("arbitrate_duel_plan", 900, "orbit.duel.plan.winner"),
+        ] {
+            let yaml = std::fs::read_to_string(activities_dir.join(format!("{name}.yaml")))
+                .expect("read seeded planning-duel activity");
+            let asset = load_activity_asset(&yaml).expect("parse planning-duel activity");
+            match asset.spec.spec {
+                ActivityV2Spec::AgentLoop(spec) => {
+                    assert_eq!(
+                        spec.backend,
+                        orbit_common::types::activity_job::Backend::Cli
+                    );
+                    assert_eq!(spec.wall_clock_timeout_seconds, timeout);
+                    assert!(spec.tools.iter().any(|tool| tool == required_tool));
+                    assert!(spec.tools.iter().any(|tool| tool == "orbit.task.show"));
+                    assert!(spec.tools.iter().any(|tool| tool == "orbit.search"));
+                    assert!(spec.tools.iter().any(|tool| tool == "fs.read"));
+                }
+                other => panic!("expected agent_loop activity, got {other:?}"),
             }
         }
     }

--- a/crates/orbit-core/src/runtime/engine/runtime_host.rs
+++ b/crates/orbit-core/src/runtime/engine/runtime_host.rs
@@ -1,10 +1,9 @@
-use std::collections::HashMap;
+use std::sync::Arc;
 
 use orbit_common::types::{
-    Activity, AgentModelPair, InvocationTrace, JobRun, JobRunState, OrbitError, OrbitEvent, Role,
-    RoleSlot,
+    ActivityV2, AgentModelPair, InvocationTrace, JobRun, OrbitError, OrbitEvent, Role, RoleSlot,
 };
-use orbit_engine::{ActivityInvocationResult, ExecutionContext, ExecutorHost, RuntimeHost};
+use orbit_engine::{ExecutionContext, RuntimeHost, V2AuditWriter, V2RuntimeHost};
 use orbit_store::{InvocationInsertParams, InvocationQuery, InvocationRecord, token_scoreboard};
 use orbit_tools::ToolContext;
 use serde_json::Value;
@@ -94,62 +93,30 @@ impl RuntimeHost for OrbitRuntime {
         OrbitRuntime::run_tool_with_context_and_role(self, name, input, role, tool_context)
     }
 
-    fn invoke_activity(
-        &self,
-        activity: Activity,
-        agent_cli: &str,
-        model: Option<&str>,
-        input: Value,
-        timeout_seconds: u64,
-        debug: bool,
-    ) -> Result<ActivityInvocationResult, OrbitError> {
-        if !is_planning_duel_agent_activity(&activity.id) {
-            return Err(retired_invoke_activity_error(&activity.id));
-        }
+    fn v2_runtime_host(&self) -> Result<&dyn V2RuntimeHost, OrbitError> {
+        Ok(self)
+    }
 
-        let executor = self
-            .activity_executor_registry()
-            .get(agent_cli)
-            .ok_or_else(|| {
-                OrbitError::Execution(format!(
-                    "planning duel activity '{}' requires direct-agent executor '{}'",
-                    activity.id, agent_cli
-                ))
-            })?;
-        let execution = ExecutionContext {
-            activity,
-            job: None,
-            agent_cli: agent_cli.to_string(),
-            model: model.map(ToOwned::to_owned),
-            timeout_seconds,
-            env_extra: Vec::new(),
-            env_set: HashMap::new(),
-            input,
-            debug,
-            steps_outputs: HashMap::new(),
-            run_id: None,
-            step_index: None,
-            state_dir: None,
-        };
-        let outcome = executor.execute(ExecutorHost::new(self), &execution);
-        if outcome.state != JobRunState::Success {
-            return Err(OrbitError::Execution(outcome.error_message.unwrap_or_else(
-                || {
-                    format!(
-                        "planning duel activity '{}' failed with state {}",
-                        execution.activity.id, outcome.state
-                    )
-                },
-            )));
-        }
-        Ok(ActivityInvocationResult {
-            response_json: outcome.response_json,
-            invocation_trace: outcome.invocation_trace.clone(),
-            exit_code: outcome.exit_code,
-            duration_ms: outcome
-                .duration_ms
-                .unwrap_or(outcome.invocation_trace.duration_ms),
-        })
+    fn v2_activity(&self, name: &str) -> Result<ActivityV2, OrbitError> {
+        self.v2_activity_catalog()
+            .map_err(|error| {
+                OrbitError::InvalidInput(format!("build v2 activity catalog: {error}"))
+            })?
+            .get(name)
+            .cloned()
+            .ok_or_else(|| OrbitError::InvalidInput(format!("v2 activity '{name}' not found")))
+    }
+
+    fn v2_audit_writer(&self, run_id: &str) -> Result<Arc<V2AuditWriter>, OrbitError> {
+        V2AuditWriter::with_disk_sinks(
+            &self.paths().audit_dir,
+            self.sqlite_store()?,
+            self.workspace_id()?,
+            run_id,
+            "system",
+            Some(self.paths().repo_root.as_path()),
+        )
+        .map_err(|error| OrbitError::Execution(format!("v2 audit sinks: {error}")))
     }
 
     fn maybe_create_failure_task(
@@ -233,14 +200,4 @@ fn role_slot_from_input(input: &Value) -> Option<RoleSlot> {
         .or_else(|| input.get("slot"))
         .and_then(Value::as_str)
         .and_then(|value| value.parse().ok())
-}
-
-fn is_planning_duel_agent_activity(activity_id: &str) -> bool {
-    matches!(activity_id, "propose_duel_plan" | "arbitrate_duel_plan")
-}
-
-fn retired_invoke_activity_error(activity_id: &str) -> OrbitError {
-    OrbitError::Execution(format!(
-        "v1 invoke_activity is retired; activity '{activity_id}' cannot be dispatched via RuntimeHost"
-    ))
 }

--- a/crates/orbit-core/src/runtime/engine/tests/runtime_host.rs
+++ b/crates/orbit-core/src/runtime/engine/tests/runtime_host.rs
@@ -3,107 +3,171 @@
 use std::collections::HashMap;
 
 use chrono::Utc;
-use orbit_common::types::{Activity, ExecutorDef, ExecutorType};
-use orbit_engine::RuntimeHost;
+use orbit_common::types::{ExecutorDef, ExecutorType};
+use orbit_engine::{
+    RuntimeHost, V2AgentDispatchOverride, V2DispatchInput, V2RuntimeHost, dispatch_v2_activity,
+};
+use orbit_store::InvocationQuery;
 use serde_json::json;
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
 use crate::OrbitRuntime;
+use crate::command::activity::seed_default_activities;
+use crate::command::task::{TaskAddParams, TaskUpdateParams};
 
 #[test]
-fn planning_duel_invoke_activity_uses_direct_agent_bridge() {
-    let seed_runtime = OrbitRuntime::in_memory().expect("build runtime");
-    let root = seed_runtime.data_root();
-    let fake_agent = root.join("fake-agent.sh");
-    std::fs::write(
-        &fake_agent,
-        "#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"ok\":true},\"error\":null}'\n",
-    )
-    .expect("write fake agent");
-    #[cfg(unix)]
-    {
-        let mut permissions = std::fs::metadata(&fake_agent)
-            .expect("fake agent metadata")
-            .permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(&fake_agent, permissions).expect("chmod fake agent");
+fn planning_duel_v2_dispatch_preserves_slot_model_and_task_attribution() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    seed_default_activities(&runtime.data_root().join("resources/activities"), true)
+        .expect("seed v2 activities");
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "v2 planning duel dispatch".to_string(),
+            description: "Exercise a real task through the planner v2 activity.".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("add task");
+    runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                plan: Some("Use the v2 path.".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("give task a plan");
+
+    let now = Utc::now();
+    for provider in ["codex", "claude", "gemini"] {
+        let fake_agent = runtime.data_root().join(provider);
+        std::fs::write(
+            &fake_agent,
+            "#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"ok\":true},\"error\":null}'\n",
+        )
+        .expect("write fake agent");
+        #[cfg(unix)]
+        {
+            let mut permissions = std::fs::metadata(&fake_agent)
+                .expect("fake agent metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&fake_agent, permissions).expect("chmod fake agent");
+        }
+        runtime
+            .upsert_executor_def(&ExecutorDef {
+                name: provider.to_string(),
+                executor_type: ExecutorType::DirectAgent,
+                command: Some(fake_agent.display().to_string()),
+                args: Vec::new(),
+                stdout_format: None,
+                model_pair_override: None,
+                model_flag: None,
+                timeout_seconds: None,
+                env: HashMap::new(),
+                sandbox: None,
+                allow_fallback: false,
+                created_at: now,
+                updated_at: now,
+            })
+            .expect("seed fake direct-agent executor");
     }
 
-    let now = Utc::now();
-    seed_runtime
-        .upsert_executor_def(&ExecutorDef {
-            name: "codex".to_string(),
-            executor_type: ExecutorType::DirectAgent,
-            command: Some(fake_agent.display().to_string()),
-            args: Vec::new(),
-            stdout_format: None,
-            model_pair_override: None,
-            model_flag: None,
-            timeout_seconds: None,
-            env: HashMap::new(),
-            sandbox: None,
-            allow_fallback: false,
-            created_at: now,
-            updated_at: now,
+    let run_id = "planning-duel-v2-test";
+    let audit = RuntimeHost::v2_audit_writer(&runtime, run_id).expect("v2 audit writer");
+    for (activity_name, slot, provider, model) in [
+        (
+            "propose_duel_plan",
+            "planner_a",
+            "codex",
+            "duel-planner-a-model",
+        ),
+        (
+            "propose_duel_plan",
+            "planner_b",
+            "claude",
+            "duel-planner-b-model",
+        ),
+        (
+            "arbitrate_duel_plan",
+            "arbiter",
+            "gemini",
+            "duel-arbiter-model",
+        ),
+    ] {
+        let activity =
+            RuntimeHost::v2_activity(&runtime, activity_name).expect("load seeded duel activity");
+        let input = json!({
+            "task_id": task.id,
+            "planning_duel_slot": slot,
+        });
+        let outcome = dispatch_v2_activity(V2DispatchInput {
+            activity_name,
+            spec: &activity.spec,
+            fs_profile: activity.fs_profile.as_deref(),
+            input: input.clone(),
+            audit: audit.clone(),
+            run_id,
+            agent_override: Some(V2AgentDispatchOverride {
+                provider,
+                model: Some(model),
+            }),
+            host: Some(&runtime),
         })
-        .expect("seed fake direct-agent executor");
-    let runtime = OrbitRuntime::from_roots(&root, &root).expect("reload runtime");
+        .expect("dispatch duel v2 activity");
 
-    let result = runtime
-        .invoke_activity(
-            planning_duel_activity("propose_duel_plan"),
-            "codex",
-            Some("test-model"),
-            json!({}),
-            5,
-            false,
+        assert!(outcome.success, "{:?}", outcome.message);
+        let invocation = outcome.invocation.expect("duel invocation trace");
+        assert_eq!(invocation.provider, provider);
+        assert_eq!(invocation.model.as_deref(), Some(model));
+        V2RuntimeHost::persist_invocation_trace(
+            &runtime,
+            run_id,
+            activity_name,
+            &invocation.provider,
+            invocation.model.as_deref(),
+            &input,
+            &invocation.trace,
         )
-        .expect("planning duel activity should invoke through bridge");
+        .expect("persist v2 invocation trace");
+    }
 
-    assert_eq!(result.exit_code, Some(0));
-    assert_eq!(result.response_json, None);
-}
-
-#[test]
-fn invoke_activity_still_rejects_non_planning_duel_v1_activities() {
-    let runtime = OrbitRuntime::in_memory().expect("build runtime");
-    let err = runtime
-        .invoke_activity(
-            planning_duel_activity("legacy_activity"),
+    let rows = runtime
+        .invocation_records(InvocationQuery {
+            job_run_id: Some(run_id.to_string()),
+            ..InvocationQuery::default()
+        })
+        .expect("read invocation telemetry");
+    assert_eq!(rows.len(), 3);
+    for (slot, agent, model, activity_id) in [
+        (
+            "planner_a",
             "codex",
-            None,
-            json!({}),
-            5,
-            false,
-        )
-        .expect_err("unrelated v1 activity should remain retired");
-
-    assert!(
-        err.to_string().contains("v1 invoke_activity is retired"),
-        "unexpected error: {err}"
-    );
-}
-
-fn planning_duel_activity(id: &str) -> Activity {
-    let now = Utc::now();
-    Activity {
-        id: id.to_string(),
-        spec_type: "agent_invoke".to_string(),
-        description: "test planning duel activity".to_string(),
-        input_schema_json: json!({}),
-        output_schema_json: json!({}),
-        spec_config: json!({
-            "instruction": "Return a success envelope."
-        }),
-        tools: Vec::new(),
-        proc_allowed_programs: Vec::new(),
-        executor: None,
-        workspace_path: None,
-        created_by: Some("test".to_string()),
-        is_active: true,
-        created_at: now,
-        updated_at: now,
+            "duel-planner-a-model",
+            "propose_duel_plan",
+        ),
+        (
+            "planner_b",
+            "claude",
+            "duel-planner-b-model",
+            "propose_duel_plan",
+        ),
+        (
+            "arbiter",
+            "gemini",
+            "duel-arbiter-model",
+            "arbitrate_duel_plan",
+        ),
+    ] {
+        let row = rows
+            .iter()
+            .find(|row| row.slot.map(|row_slot| row_slot.as_str()) == Some(slot))
+            .expect("slot telemetry row");
+        assert_eq!(row.agent, agent);
+        assert_eq!(row.model.as_deref(), Some(model));
+        assert_eq!(row.activity_id, activity_id);
+        assert_eq!(row.task_ids, [task.id.clone()]);
     }
 }

--- a/crates/orbit-core/src/runtime/engine/tests/task_host.rs
+++ b/crates/orbit-core/src/runtime/engine/tests/task_host.rs
@@ -94,6 +94,7 @@ fn run_update_task_v2_activity(runtime: &OrbitRuntime, run_id: &str, input: Valu
         input,
         audit,
         run_id,
+        agent_override: None,
         host: Some(runtime),
     })
     .expect("dispatch update_task activity")

--- a/crates/orbit-core/tests/grok_cli_backend_smoke.rs
+++ b/crates/orbit-core/tests/grok_cli_backend_smoke.rs
@@ -87,6 +87,7 @@ fn installed_grok_cli_backend_smoke_captures_stdout_artifact() {
         }),
         audit: audit.clone(),
         run_id: "grok-installed-smoke",
+        agent_override: None,
         host: Some(&runtime),
     })
     .expect("dispatch grok cli backend");

--- a/crates/orbit-engine/examples/v2_cli_backend_smoke.rs
+++ b/crates/orbit-engine/examples/v2_cli_backend_smoke.rs
@@ -83,6 +83,7 @@ fn scenario_a_cli_dispatch_emits_envelope_events() -> Result<(), Box<dyn std::er
         input: serde_json::json!({ "prompt": "hello" }),
         audit: writer.clone(),
         run_id: "smoke-cli-a",
+        agent_override: None,
         host: Some(&host),
     })?;
 
@@ -122,6 +123,7 @@ fn scenario_b_argv_redaction() -> Result<(), Box<dyn std::error::Error>> {
         input: serde_json::json!({ "prompt": "redact me" }),
         audit: writer.clone(),
         run_id: "smoke-cli-b",
+        agent_override: None,
         host: Some(&host),
     })?;
 
@@ -165,6 +167,7 @@ fn scenario_c_wall_clock_timeout() -> Result<(), Box<dyn std::error::Error>> {
         input: serde_json::json!({ "prompt": "ignored" }),
         audit: writer.clone(),
         run_id: "smoke-cli-c",
+        agent_override: None,
         host: Some(&host),
     })?;
     let elapsed = started.elapsed();
@@ -205,6 +208,7 @@ fn scenario_d_no_silent_fallback_unwired_http() -> Result<(), Box<dyn std::error
         input: serde_json::json!({ "prompt": "ignored" }),
         audit: writer.clone(),
         run_id: "smoke-cli-d",
+        agent_override: None,
         host: Some(&host),
     })
     .expect_err("expected UnwiredHttpTransport");
@@ -273,6 +277,7 @@ fn scenario_g_auto_backend_unresolved_is_structural_error() -> Result<(), Box<dy
         input: serde_json::json!({ "prompt": "ignored" }),
         audit: writer.clone(),
         run_id: "smoke-cli-g",
+        agent_override: None,
         host: Some(&host),
     })
     .expect_err("expected UnresolvedAutoBackend");
@@ -322,6 +327,7 @@ fn scenario_h_cli_reference_asset_round_trip() -> Result<(), Box<dyn std::error:
         input: serde_json::json!({ "prompt": "hello from the yaml round-trip" }),
         audit: writer.clone(),
         run_id: "smoke-cli-h",
+        agent_override: None,
         host: Some(&host),
     })?;
     assert!(outcome.success);
@@ -381,6 +387,7 @@ fn scenario_j_cli_executor_static_args_are_audited() -> Result<(), Box<dyn std::
         input: serde_json::json!({ "prompt": "hello" }),
         audit: writer.clone(),
         run_id: "smoke-cli-j",
+        agent_override: None,
         host: Some(&host),
     })?;
 

--- a/crates/orbit-engine/examples/v2_name_resolution_smoke.rs
+++ b/crates/orbit-engine/examples/v2_name_resolution_smoke.rs
@@ -267,6 +267,7 @@ fn scenario_f_deterministic_activities_dispatch() -> Result<(), Box<dyn std::err
             input,
             audit: writer.clone(),
             run_id: &format!("smoke-f-{name}"),
+            agent_override: None,
             host: Some(&host),
         })?;
         assert!(outcome.success, "`{}` dispatch should succeed", name);

--- a/crates/orbit-engine/examples/v2_runtime_smoke.rs
+++ b/crates/orbit-engine/examples/v2_runtime_smoke.rs
@@ -86,6 +86,7 @@ fn smoke_dispatch_deterministic(
         input: Value::Null,
         audit: writer.clone(),
         run_id,
+        agent_override: None,
         host: Some(&host),
     })
     .map_err(|e| format!("dispatch: {e}"))?;

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use orbit_common::types::activity_job::V2AuditEventKind;
 use orbit_common::types::activity_job::{
-    ActivityV2Spec, AgentLoopSpec, AgentRole, Backend, DeterministicSpec,
+    ActivityV2Spec, AgentLoopSpec, AgentRole, Backend, DeterministicSpec, Provider,
 };
 
 use crate::context::AgentRoleConfig;
@@ -244,10 +244,20 @@ pub struct V2DispatchInput<'a> {
     pub input: Value,
     pub audit: Arc<V2AuditWriter>,
     pub run_id: &'a str,
+    /// Optional caller-selected provider/model for this invocation. This is
+    /// applied to a cloned agent-loop spec, so catalog assets remain immutable
+    /// and concurrent dispatches can select different duel roles safely.
+    pub agent_override: Option<V2AgentDispatchOverride<'a>>,
     /// Runtime host for agent_loop + deterministic paths. A `None` host is only
     /// valid for callers that never dispatch a host-backed activity; host-backed
     /// specs return `DispatchError::HostRequired` when it is absent.
     pub host: Option<&'a dyn V2RuntimeHost>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct V2AgentDispatchOverride<'a> {
+    pub provider: &'a str,
+    pub model: Option<&'a str>,
 }
 
 /// Outcome of a v2 dispatch attempt. Kept separate from v1's AttemptOutcome
@@ -431,7 +441,9 @@ fn dispatch_v2_activity_inner(
     } else {
         input.input.clone()
     };
-    let activity_type = match input.spec {
+    let overridden_spec = overridden_agent_spec(input.spec, input.agent_override)?;
+    let spec = overridden_spec.as_ref().unwrap_or(input.spec);
+    let activity_type = match spec {
         ActivityV2Spec::AgentLoop(_) => "agent_loop",
         ActivityV2Spec::Deterministic(_) => "deterministic",
     };
@@ -447,7 +459,7 @@ fn dispatch_v2_activity_inner(
         .map_err(|err| DispatchError::AuditFailed(format!("{err:?}")))?;
     input.audit.push_parent_lossy(activity_event_id);
 
-    let result = match input.spec {
+    let result = match spec {
         ActivityV2Spec::AgentLoop(spec) => match input.host {
             Some(host) => run_agent_loop_activity(
                 host,
@@ -487,6 +499,29 @@ fn dispatch_v2_activity_inner(
     );
 
     result
+}
+
+pub(crate) fn overridden_agent_spec(
+    spec: &ActivityV2Spec,
+    agent_override: Option<V2AgentDispatchOverride<'_>>,
+) -> Result<Option<ActivityV2Spec>, DispatchError> {
+    let Some(agent_override) = agent_override else {
+        return Ok(None);
+    };
+    let ActivityV2Spec::AgentLoop(agent_spec) = spec else {
+        return Err(DispatchError::JobValidation(
+            "agent override requires an agent_loop activity".to_string(),
+        ));
+    };
+    let provider = Provider::parse(agent_override.provider)
+        .map_err(|error| DispatchError::JobValidation(error.to_string()))?;
+    let mut overridden = agent_spec.clone();
+    overridden.provider = provider;
+    overridden.model = agent_override.model.map(ToOwned::to_owned);
+    overridden.instruction = overridden
+        .instruction
+        .replace("{{agent_family}}", provider.as_str());
+    Ok(Some(ActivityV2Spec::AgentLoop(overridden)))
 }
 
 fn inject_run_id(input: &Value, run_id: &str) -> Value {

--- a/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
@@ -62,6 +62,7 @@ pub(super) fn attempt_recovery_activity(
         input: input.clone(),
         audit: ctx.audit.clone(),
         run_id: &ctx.run_id,
+        agent_override: None,
         host: Some(ctx.host),
     });
 
@@ -135,6 +136,7 @@ pub(super) fn attempt_failure_activity(
         input: input.clone(),
         audit: ctx.audit.clone(),
         run_id: &ctx.run_id,
+        agent_override: None,
         host: Some(ctx.host),
     });
     match dispatch {

--- a/crates/orbit-engine/src/activity_job/job_executor/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/target.rs
@@ -81,6 +81,7 @@ pub(super) fn run_target(
                 input: rendered_input.clone(),
                 audit: ctx.audit.clone(),
                 run_id: &ctx.run_id,
+                agent_override: None,
                 host: Some(ctx.host),
             })?;
             persist_dispatch_invocation(ctx, &step.id, &rendered_input, &dispatch);
@@ -102,6 +103,7 @@ pub(super) fn run_target(
                 input: rendered_input.clone(),
                 audit: ctx.audit.clone(),
                 run_id: &ctx.run_id,
+                agent_override: None,
                 host: Some(ctx.host),
             })?;
             persist_dispatch_invocation(ctx, &step.id, &rendered_input, &dispatch);

--- a/crates/orbit-engine/src/activity_job/mod.rs
+++ b/crates/orbit-engine/src/activity_job/mod.rs
@@ -26,8 +26,8 @@ pub use agent_role::{ResolvedAgentSettings, apply_resolved_settings, resolve_age
 pub use audit_writer::{V2AuditWriter, WriteError};
 pub use cli_runner::run_cli_backend;
 pub use dispatcher::{
-    DispatchError, DispatchOutcome, ResolvedCliExecutor, ResolvedSandbox, V2DispatchInput,
-    V2RuntimeHost, dispatch_error_to_orbit, dispatch_v2_activity,
+    DispatchError, DispatchOutcome, ResolvedCliExecutor, ResolvedSandbox, V2AgentDispatchOverride,
+    V2DispatchInput, V2RuntimeHost, dispatch_error_to_orbit, dispatch_v2_activity,
 };
 pub use job_executor::{
     JobOutcome, execute_job, execute_job_with_resume, resolve_job_catalog_refs_for_execution,

--- a/crates/orbit-engine/src/activity_job/tests/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/tests/dispatcher.rs
@@ -3,6 +3,7 @@
 use serde_json::{Map, Value, json};
 
 use super::super::dispatcher::agent_loop_output_from_final_message;
+use super::super::dispatcher::{V2AgentDispatchOverride, overridden_agent_spec};
 
 #[test]
 fn agent_loop_output_exposes_structured_final_message_fields() {
@@ -102,4 +103,48 @@ fn dispatch_error_to_orbit_keeps_validation_variant_and_buckets_the_rest() {
         dispatch_error_to_orbit(other),
         OrbitError::InvalidInput(m) if m == expected
     ));
+}
+
+#[test]
+fn per_dispatch_agent_override_sets_provider_model_and_renders_family() {
+    use orbit_common::types::activity_job::{
+        ActivityV2Spec, AgentLoopSpec, Backend, OnDenial, Provider,
+    };
+
+    let spec = ActivityV2Spec::AgentLoop(AgentLoopSpec {
+        instruction: "family={{agent_family}}".to_string(),
+        backend: Backend::Cli,
+        provider: Provider::Claude,
+        model: Some("asset-default".to_string()),
+        tools: Vec::new(),
+        on_denial: OnDenial::Terminate,
+        max_iterations: 20,
+        wall_clock_timeout_seconds: 300,
+        require_response_envelope: false,
+        role: None,
+        proc_allowed_programs: None,
+    });
+    let overridden = overridden_agent_spec(
+        &spec,
+        Some(V2AgentDispatchOverride {
+            provider: "codex",
+            model: Some("gpt-duel-a"),
+        }),
+    )
+    .expect("apply override")
+    .expect("overridden spec");
+
+    let ActivityV2Spec::AgentLoop(agent) = overridden else {
+        panic!("expected agent-loop override");
+    };
+    assert_eq!(agent.provider, Provider::Codex);
+    assert_eq!(agent.model.as_deref(), Some("gpt-duel-a"));
+    assert_eq!(agent.instruction, "family=codex");
+
+    let ActivityV2Spec::AgentLoop(original) = spec else {
+        panic!("expected original agent-loop spec");
+    };
+    assert_eq!(original.provider, Provider::Claude);
+    assert_eq!(original.model.as_deref(), Some("asset-default"));
+    assert_eq!(original.instruction, "family={{agent_family}}");
 }

--- a/crates/orbit-engine/src/context/executor_host.rs
+++ b/crates/orbit-engine/src/context/executor_host.rs
@@ -6,7 +6,7 @@
 use crate::executor::registry::ActivityExecutorRegistry;
 use orbit_common::types::activity_job::AgentRole;
 use orbit_common::types::{
-    Activity, AgentModelPair, ExecutorDef, ExternalRef, InvocationTrace, JobRun, OrbitError,
+    ActivityV2, AgentModelPair, ExecutorDef, ExternalRef, InvocationTrace, JobRun, OrbitError,
     OrbitEvent, Role, Task, TaskArtifact, TaskComment, TaskHistoryEntry, TaskPriority, TaskStatus,
 };
 use orbit_store::{InvocationQuery, InvocationRecord};
@@ -14,13 +14,14 @@ use orbit_tools::ToolContext;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::Arc;
 
 use super::execution::ExecutionContext;
 use super::hosts::{
     AgentProtocolHost, AgentRoleConfig, EnvironmentHost, ExecutorLookupHost, RuntimeHost,
     TaskActivityUpdate, TaskAutomationUpdate, TaskHost, TaskReadHost, TaskWriteHost,
 };
-use super::outcome::ActivityInvocationResult;
+use crate::activity_job::{V2AuditWriter, V2RuntimeHost};
 
 #[derive(Clone, Copy)]
 pub struct ExecutorHost<'a> {
@@ -401,17 +402,16 @@ impl RuntimeHost for AutomationExecutorHost<'_> {
             .run_tool_with_context_and_role(name, input, role, tool_context)
     }
 
-    fn invoke_activity(
-        &self,
-        activity: Activity,
-        agent_cli: &str,
-        model: Option<&str>,
-        input: Value,
-        timeout_seconds: u64,
-        debug: bool,
-    ) -> Result<ActivityInvocationResult, OrbitError> {
-        self.runtime
-            .invoke_activity(activity, agent_cli, model, input, timeout_seconds, debug)
+    fn v2_runtime_host(&self) -> Result<&dyn V2RuntimeHost, OrbitError> {
+        self.runtime.v2_runtime_host()
+    }
+
+    fn v2_activity(&self, name: &str) -> Result<ActivityV2, OrbitError> {
+        self.runtime.v2_activity(name)
+    }
+
+    fn v2_audit_writer(&self, run_id: &str) -> Result<Arc<V2AuditWriter>, OrbitError> {
+        self.runtime.v2_audit_writer(run_id)
     }
 
     fn maybe_create_failure_task(

--- a/crates/orbit-engine/src/context/hosts.rs
+++ b/crates/orbit-engine/src/context/hosts.rs
@@ -6,7 +6,7 @@ use orbit_agent::AgentConfig;
 use orbit_common::types::InvocationTrace;
 use orbit_common::types::activity_job::{AgentRole, Backend, Provider};
 use orbit_common::types::{
-    Activity, AgentModelPair, ExecutorDef, ExternalRef, JobRun, JobRunState, KnowledgeRunMetrics,
+    ActivityV2, AgentModelPair, ExecutorDef, ExternalRef, JobRun, JobRunState, KnowledgeRunMetrics,
     OrbitError, OrbitEvent, PipelineState, Role, Task, TaskArtifact, TaskComment, TaskHistoryEntry,
     TaskPriority, TaskStatus, all_agent_families,
 };
@@ -17,9 +17,10 @@ use orbit_tools::ToolContext;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::Arc;
 
 use super::execution::ExecutionContext;
-use super::outcome::ActivityInvocationResult;
+use crate::activity_job::{V2AuditWriter, V2RuntimeHost};
 
 #[derive(Debug, Clone, Default)]
 pub struct TaskAutomationUpdate {
@@ -309,18 +310,20 @@ pub trait RuntimeHost {
         role: Role,
         tool_context: ToolContext,
     ) -> Result<Value, OrbitError>;
-    fn invoke_activity(
-        &self,
-        _activity: Activity,
-        _agent_cli: &str,
-        _model: Option<&str>,
-        _input: Value,
-        _timeout_seconds: u64,
-        _debug: bool,
-    ) -> Result<ActivityInvocationResult, OrbitError> {
+    fn v2_runtime_host(&self) -> Result<&dyn V2RuntimeHost, OrbitError> {
         Err(OrbitError::Execution(
-            "invoke_activity is not implemented for this host".to_string(),
+            "v2 runtime host is not available on this host".to_string(),
         ))
+    }
+    fn v2_activity(&self, name: &str) -> Result<ActivityV2, OrbitError> {
+        Err(OrbitError::Execution(format!(
+            "v2 activity '{name}' is not available on this host"
+        )))
+    }
+    fn v2_audit_writer(&self, run_id: &str) -> Result<Arc<V2AuditWriter>, OrbitError> {
+        Err(OrbitError::Execution(format!(
+            "v2 audit writer is not available for run '{run_id}'"
+        )))
     }
     /// Create a task capturing a job run failure, skipping creation if an open
     /// task for the same `job_id` + `error_code` combination already exists.

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs
@@ -4,7 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::Utc;
 use orbit_common::types::{
-    Activity, AgentFamily, OrbitError, PlanningRoleAssignment, PlanningRoles, RoleSlot,
+    AgentFamily, OrbitError, PlanningRoleAssignment, PlanningRoles, RoleSlot,
 };
 use serde_json::{Value, json};
 
@@ -16,123 +16,6 @@ use super::super::{role_permutation_at, validate_role_permutation};
 
 pub(super) const PLANNER_ACTIVITY_ID: &str = "propose_duel_plan";
 pub(super) const ARBITER_ACTIVITY_ID: &str = "arbitrate_duel_plan";
-pub(super) const PLANNER_TIMEOUT_SECONDS: u64 = 1800;
-pub(super) const ARBITER_TIMEOUT_SECONDS: u64 = 900;
-
-const PLANNING_DUEL_INSTRUCTION: &str = r###"Only use skills listed in this activity's skill_refs. Ignore all others.
-You are a PLANNER in an Orbit planning duel. Inspect the task and surrounding
-code, draft one implementation-ready proposal, and persist it to the task's
-`artifacts/` directory. Do not edit source files, open PRs, or rely on your
-structured response as the workflow handoff.
-
-Steps:
-1. Load the task:
-   - Call orbit.task.show with input: {"id": "<task_id>"} to fetch the task title,
-     description, plan, acceptance_criteria, context_files, and workspace_path.
-
-2. Determine your artifact path from the active slot:
-   - Your active agent family is `{{agent_family}}`.
-   - Your active planning-duel slot is in input.planning_duel_slot.
-   - Your plan artifact path must be `planning-duel/<slot>.md`.
-
-3. Gather plan-level context BEFORE drafting. Start from the task's directories
-   and each task.context_files entry. Use `orbit.search` for related tasks,
-   decisions, and indexed docs, and use `fs.read` for the named source files,
-   nearby module roots, and manifests. Establish enough breadth to:
-   - Name the files, modules, and symbols the proposal will change.
-   - Identify directly visible consumers, imports, and integration points in
-     the inspected files without claiming exhaustive caller coverage.
-   - Read the full body of every symbol you intend to change.
-   - Map an unfamiliar area before you draft against it.
-   - Mark transitive blast-radius claims that need implementation/review
-     verification as risks, with exact `rg` commands that will verify them
-     later.
-   - If you discover pub(crate) imports, helper coupling, call sites, or
-     dependency edges not reflected in the task description, treat them as
-     hidden coupling — they belong in step 1 of your plan body.
-
-4. Draft exactly one proposal as markdown:
-   - Include these sections:
-     ## Plan
-     ## Context Files
-     ## Risks
-   - Ignore any existing planner artifact for the other role. Your proposal must
-     be independently reasoned.
-   - The plan MUST:
-     - Name every symbol being moved, renamed, removed, or added (functions,
-       types, modules, constants) BY IDENTIFIER, not by category.
-     - Name the directly visible consumers and integration points established
-       by the inspected files. Treat unverified transitive consumers as an
-       implementation/review risk rather than inventing exhaustive coverage.
-     - Specify exact verification commands the implementer should run — e.g.
-       `cargo build -p <crate>`, `cargo test -p <crate> <test_name>`,
-       `make ci-fast`, `rg '<symbol>' <path>`, or
-       `curl -s http://localhost:<port>/<route>` — that prove the change works.
-     - If hidden coupling exists (imports, helpers, call sites the task
-       description did not name), open the plan with step 1 enumerating it.
-   - The plan MUST NOT:
-     - Use hedge language: "this should just work", "should compile", "verify
-       it continues to compile", "we must verify", "this just works", or
-       similar. Replace each with the exact command above that proves it.
-     - Defer evidence to the implementer ("the implementer will discover X")
-       when inspecting the code now could have surfaced X.
-   - Length is not the goal. Named identifiers, grounded integration points,
-     and exact verification commands are.
-
-5. Persist the proposal as a task artifact:
-   - Use orbit.duel.plan.add to write the artifact under the slot-derived path. Orbit stamps the signature line.
-   - Exact example:
-     {"id":"<task_id>","planning_duel_slot":"planner_a","content":"## Plan\n..."}
-
-6. Stay narrowly scoped:
-   - Do not edit source files, update task.plan, or touch PR state.
-   - The only permitted mutation is writing your own planner artifact via orbit.duel.plan.add.
-
-7. Structured output is optional:
-   - The workflow does not depend on your response payload. Persist the artifact correctly even if you return null."###;
-const ARBITER_INSTRUCTION: &str = r#"Only use skills listed in this activity's skill_refs. Ignore all others.
-You are the ARBITER in an Orbit planning duel. Your job is to compare the
-two submitted planner artifacts, choose the better one, and persist the
-winning decision to the task artifact bundle.
-
-Steps:
-1. Load the task:
-   - Call orbit.task.show with input: {"id": "<task_id>"} to fetch the task title,
-     description, plan, acceptance_criteria, and context_files.
-
-2. Load only the planner artifacts:
-   - Call orbit.task.show with input: {"id":"<task_id>","field":"artifacts"} to fetch only the task artifacts.
-   - From that response, inspect planner markdown artifacts under `planning-duel/` and ignore `planning-duel/winner.json`.
-   - There must be exactly two planner markdown artifacts for this duel. If there are not exactly two, fail instead of guessing.
-   - Treat both planner artifacts as read-only inputs. Do not invent a third plan.
-
-3. Infer planner identity from the artifact signatures:
-   - The first line of each planner artifact must be `*authored by: <family> / <slot>*`.
-   - Parse those lines to recover each planner's family and slot.
-   - The artifact signature is the canonical planner identity source.
-
-4. Verify claims against the codebase:
-   - Use `fs.read` to spot-check the winning proposal's named symbols, files,
-     and directly visible integration points. Use `orbit.search` when related
-     tasks or indexed decisions can resolve ambiguity.
-   - Treat exhaustive caller and blast-radius verification as an
-     implementation/review gate. Require the proposal to name exact
-     `rg` commands for that later verification instead of
-     rejecting a plan because the shell-less arbiter cannot prove it now.
-
-5. Decide the winner:
-   - Choose the artifact proposal that is more feasible, complete, scoped, and aligned
-     with the current codebase.
-   - Keep a short `arbiter_rationale` that explains why the winning proposal is better.
-
-6. Persist the winner marker:
-   - Use orbit.duel.plan.winner to write `planning-duel/winner.json`.
-   - Exact example:
-     {"id":"<task_id>","winner_slot":"planner_a","arbiter_rationale":"More concrete writeback and test coverage."}
-
-7. Stay narrowly scoped:
-   - Do not edit source files, update task.plan directly, or open PRs.
-   - The only permitted mutation is writing `planning-duel/winner.json` via orbit.duel.plan.winner."#;
 
 thread_local! {
     static TEST_PERMUTATION_QUEUE: RefCell<VecDeque<[usize; 3]>> =
@@ -206,71 +89,6 @@ pub(crate) fn build_roles_output<H: RuntimeHost + ?Sized>(
             "arbiter": build_role_assignment(host, arbiter)?,
         }
     }))
-}
-
-fn planning_duel_agent_activity(
-    id: &str,
-    description: &str,
-    instruction: &str,
-    tools: &[&str],
-) -> Activity {
-    let now = Utc::now();
-    Activity {
-        id: id.to_string(),
-        spec_type: "agent_invoke".to_string(),
-        description: description.to_string(),
-        input_schema_json: json!({
-            "type": "object",
-            "required": ["task_id"],
-            "properties": {
-                "task_id": {
-                    "type": "string",
-                    "description": "Orbit task ID for the planning duel."
-                }
-            }
-        }),
-        output_schema_json: json!({}),
-        spec_config: json!({
-            "instruction": instruction,
-            "skill_refs": ["orbit"],
-        }),
-        tools: tools.iter().map(|tool| (*tool).to_string()).collect(),
-        proc_allowed_programs: Vec::new(),
-        executor: None,
-        workspace_path: None,
-        created_by: Some("system".to_string()),
-        is_active: true,
-        created_at: now,
-        updated_at: now,
-    }
-}
-
-pub(super) fn planner_activity() -> Activity {
-    planning_duel_agent_activity(
-        PLANNER_ACTIVITY_ID,
-        "Draft one planning-duel proposal, then persist it as a task artifact.",
-        PLANNING_DUEL_INSTRUCTION,
-        &[
-            "orbit.task.show",
-            "orbit.duel.plan.add",
-            "orbit.search",
-            "fs.read",
-        ],
-    )
-}
-
-pub(super) fn arbiter_activity() -> Activity {
-    planning_duel_agent_activity(
-        ARBITER_ACTIVITY_ID,
-        "Choose the better of two planning-duel task artifacts for a single task and persist the winner marker.",
-        ARBITER_INSTRUCTION,
-        &[
-            "orbit.task.show",
-            "orbit.duel.plan.winner",
-            "orbit.search",
-            "fs.read",
-        ],
-    )
 }
 
 pub(super) fn planner_input_for_slot(task_id: &str, slot: RoleSlot) -> Value {

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/runner.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/runner.rs
@@ -1,6 +1,12 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
-use orbit_common::types::{OrbitError, PlanningRoleAssignment, RoleSlot};
+use crate::activity_job::{
+    V2AgentDispatchOverride, V2AuditWriter, V2DispatchInput, dispatch_v2_activity,
+};
+use orbit_common::types::{
+    ActivityV2, InvocationTrace, OrbitError, PlanningRoleAssignment, RoleSlot,
+};
 use serde_json::{Value, json};
 
 use super::types::PlanningDuelPlanArtifact;
@@ -18,6 +24,82 @@ fn join_activity_result(
             "{label} activity thread panicked"
         ))),
     }
+}
+
+fn dispatch_duel_agent_activity<H: RuntimeHost + ?Sized>(
+    host: &H,
+    activity_name: &str,
+    activity: &ActivityV2,
+    provider: &str,
+    model: &str,
+    input: Value,
+    run_id: &str,
+    audit: Arc<V2AuditWriter>,
+) -> Result<ActivityInvocationResult, OrbitError> {
+    let v2_host = host.v2_runtime_host()?;
+    let outcome = dispatch_v2_activity(V2DispatchInput {
+        activity_name,
+        spec: &activity.spec,
+        fs_profile: activity.fs_profile.as_deref(),
+        input: input.clone(),
+        audit: audit.clone(),
+        run_id,
+        agent_override: Some(V2AgentDispatchOverride {
+            provider,
+            model: Some(model),
+        }),
+        host: Some(v2_host),
+    })
+    .map_err(|error| {
+        OrbitError::Execution(format!(
+            "planning duel v2 activity '{}' dispatch failed: {error}",
+            activity_name
+        ))
+    })?;
+
+    if !outcome.success {
+        return Err(OrbitError::Execution(format!(
+            "planning duel v2 activity '{}' failed: {}",
+            activity_name,
+            outcome
+                .message
+                .unwrap_or_else(|| "agent invocation did not succeed".to_string())
+        )));
+    }
+
+    let (trace, duration_ms) = match outcome.invocation.as_ref() {
+        Some(invocation) => {
+            if let Err(error) = v2_host.persist_invocation_trace(
+                run_id,
+                activity_name,
+                &invocation.provider,
+                invocation.model.as_deref(),
+                &input,
+                &invocation.trace,
+            ) {
+                audit.note_telemetry_failure("invocation_trace", Some(activity_name), &error);
+            }
+            (invocation.trace.clone(), invocation.trace.duration_ms)
+        }
+        None => (InvocationTrace::default(), 0),
+    };
+    let exit_code = outcome
+        .output
+        .get("exit_code")
+        .and_then(Value::as_i64)
+        .and_then(|code| i32::try_from(code).ok());
+    let duration_ms = outcome
+        .output
+        .get("duration_ms")
+        .and_then(Value::as_u64)
+        .unwrap_or(duration_ms);
+
+    Ok(ActivityInvocationResult {
+        response_json: Some(outcome.output),
+        invocation_trace: trace,
+        exit_code,
+        duration_ms,
+    })
 }
 
 fn require_plan_artifact_for_assignment<'a>(
@@ -96,12 +178,13 @@ fn compact_diagnostic_text(value: &str) -> String {
 pub(crate) fn run_planning_duel<H: RuntimeHost + TaskHost + Sync + ?Sized>(
     host: &H,
     input: &Value,
-    debug: bool,
+    _debug: bool,
 ) -> Result<Value, OrbitError> {
     let task_id = required_input_string(input, "task_id")?;
     let job_run_id = input_string_field(input, "job_run_id")
         .or_else(|| input_string_field(input, "run_id"))
         .ok_or_else(|| OrbitError::InvalidInput("missing required input.run_id".to_string()))?;
+    let run_id = job_run_id.as_str();
 
     let _ = host.get_task(task_id)?;
 
@@ -124,7 +207,8 @@ pub(crate) fn run_planning_duel<H: RuntimeHost + TaskHost + Sync + ?Sized>(
     let roles_output = roles::select_planning_duel_roles(host, &roles_input)?;
     let planning_roles = roles::parse_planning_duel_roles(&roles_output)?;
 
-    let planner_activity = roles::planner_activity();
+    let planner_activity = host.v2_activity(roles::PLANNER_ACTIVITY_ID)?;
+    let audit = host.v2_audit_writer(run_id)?;
     let planner_a_input = roles::planner_input_for_slot(task_id, RoleSlot::PlannerA);
     let planner_b_input = roles::planner_input_for_slot(task_id, RoleSlot::PlannerB);
     let planner_a_model = roles_output["planner_a_model"]
@@ -140,24 +224,30 @@ pub(crate) fn run_planning_duel<H: RuntimeHost + TaskHost + Sync + ?Sized>(
         let planner_b = planning_roles.planner_b.clone();
         let planner_activity_a = planner_activity.clone();
         let planner_activity_b = planner_activity.clone();
+        let audit_a = audit.clone();
+        let audit_b = audit.clone();
         let handle_a = scope.spawn(move || {
-            host.invoke_activity(
-                planner_activity_a,
+            dispatch_duel_agent_activity(
+                host,
+                roles::PLANNER_ACTIVITY_ID,
+                &planner_activity_a,
                 planner_a.family.as_str(),
-                Some(planner_a_model.as_str()),
+                planner_a_model.as_str(),
                 planner_a_input,
-                roles::PLANNER_TIMEOUT_SECONDS,
-                debug,
+                run_id,
+                audit_a,
             )
         });
         let handle_b = scope.spawn(move || {
-            host.invoke_activity(
-                planner_activity_b,
+            dispatch_duel_agent_activity(
+                host,
+                roles::PLANNER_ACTIVITY_ID,
+                &planner_activity_b,
                 planner_b.family.as_str(),
-                Some(planner_b_model.as_str()),
+                planner_b_model.as_str(),
                 planner_b_input,
-                roles::PLANNER_TIMEOUT_SECONDS,
-                debug,
+                run_id,
+                audit_b,
             )
         });
         (
@@ -187,13 +277,16 @@ pub(crate) fn run_planning_duel<H: RuntimeHost + TaskHost + Sync + ?Sized>(
         .ok_or_else(|| OrbitError::Execution("missing arbiter_model".to_string()))?
         .to_string();
 
-    let arbiter_result = host.invoke_activity(
-        roles::arbiter_activity(),
+    let arbiter_activity = host.v2_activity(roles::ARBITER_ACTIVITY_ID)?;
+    let arbiter_result = dispatch_duel_agent_activity(
+        host,
+        roles::ARBITER_ACTIVITY_ID,
+        &arbiter_activity,
         planning_roles.arbiter.family.as_str(),
-        Some(arbiter_model.as_str()),
+        arbiter_model.as_str(),
         roles::arbiter_input(task_id),
-        roles::ARBITER_TIMEOUT_SECONDS,
-        debug,
+        run_id,
+        audit,
     )?;
 
     let artifacts_after_arbiter = host.get_task_artifacts(task_id)?;

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/tests/roles.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/tests/roles.rs
@@ -1,35 +1,17 @@
-use super::super::roles::{arbiter_activity, planner_activity};
+use orbit_common::types::RoleSlot;
+
+use super::super::roles::{arbiter_input, planner_input_for_slot};
 
 #[test]
-fn planning_duel_roles_do_not_require_graph_mcp_tools() {
-    for activity in [planner_activity(), arbiter_activity()] {
-        assert!(
-            activity
-                .tools
-                .iter()
-                .all(|tool| !tool.starts_with("orbit.graph.")),
-            "{} must not grant removed graph MCP tools: {:?}",
-            activity.id,
-            activity.tools
-        );
-        assert!(activity.tools.iter().any(|tool| tool == "orbit.search"));
-        assert!(activity.tools.iter().any(|tool| tool == "fs.read"));
-        assert!(activity.proc_allowed_programs.is_empty());
+fn planning_duel_inputs_thread_the_active_role_slot() {
+    let planner_a = planner_input_for_slot("ORB-10393", RoleSlot::PlannerA);
+    let planner_b = planner_input_for_slot("ORB-10393", RoleSlot::PlannerB);
+    let arbiter = arbiter_input("ORB-10393");
 
-        let instruction = activity.spec_config["instruction"]
-            .as_str()
-            .expect("planning-duel instruction");
-        for removed_mandate in [
-            "orbit.graph.",
-            "map the call and import graph",
-            "enumerate its callers and consumers BY NAME",
-            "Reading symbol bodies alone is not enough",
-        ] {
-            assert!(
-                !instruction.contains(removed_mandate),
-                "{} still carries removed graph mandate {removed_mandate:?}",
-                activity.id
-            );
-        }
+    assert_eq!(planner_a["planning_duel_slot"], "planner_a");
+    assert_eq!(planner_b["planning_duel_slot"], "planner_b");
+    assert_eq!(arbiter["planning_duel_slot"], "arbiter");
+    for input in [planner_a, planner_b, arbiter] {
+        assert_eq!(input["task_id"], "ORB-10393");
     }
 }

--- a/crates/orbit-engine/src/lib.rs
+++ b/crates/orbit-engine/src/lib.rs
@@ -40,10 +40,10 @@ mod template;
 pub use activity_job::{
     DispatchError, DispatchOutcome, EnforcedAuditSink, EnforcementDecision, JobOutcome,
     OrbitToolCallExecutor, ResolvedAgentSettings, ResolvedCliExecutor, ResolvedSandbox,
-    V2AuditWriter, V2DispatchInput, V2RuntimeHost, V2SqliteSink, WriteError,
-    apply_resolved_settings, dispatch_error_to_orbit, dispatch_v2_activity, drive_agent_loop,
-    drive_agent_loop_with_session, drive_agent_loop_with_tool_context, execute_job,
-    execute_job_with_resume, reset_replay_transport, resolve_agent_settings,
+    V2AgentDispatchOverride, V2AuditWriter, V2DispatchInput, V2RuntimeHost, V2SqliteSink,
+    WriteError, apply_resolved_settings, dispatch_error_to_orbit, dispatch_v2_activity,
+    drive_agent_loop, drive_agent_loop_with_session, drive_agent_loop_with_tool_context,
+    execute_job, execute_job_with_resume, reset_replay_transport, resolve_agent_settings,
     resolve_job_catalog_refs_for_execution, resolve_subprocess_cwd, run_cli_backend, validate_job,
     validate_job_deterministic_actions,
 };

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -54,11 +54,17 @@ Folded instances:
 
 ## ADR-002 — Host boundaries and agent dispatch stay explicit
 
-**Status:** Accepted · 2026-05 · [T20260419-2014], [T20260418-2210], [T20260419-0104], [T20260423-0114], [T20260427-48], [T20260430-15], [T20260418-2018], [T20260419-0623-2], [T20260420-0510-2], [T20260428-9], [T20260428-12], [T20260506-16], [T20260506-17], [T20260505-22], [T20260506-18]
+**Status:** Accepted · 2026-05 · [T20260419-2014], [T20260418-2210], [T20260419-0104], [T20260423-0114], [T20260427-48], [T20260430-15], [T20260418-2018], [T20260419-0623-2], [T20260420-0510-2], [T20260428-9], [T20260428-12], [T20260506-16], [T20260506-17], [T20260505-22], [T20260506-18], [ORB-10393]
 
 **Context.** The agent-loop path is where activity/job can most easily leak provider implementation details, mutable sessions, or role configuration across crate boundaries. The split ADRs all defended the same shape: shared types live low, orbit-core hosts primitive services, the engine dispatches concrete activity specs, and provider/backends remain explicit choices.
 
 **Decision.** Keep activity/job types in `orbit-common`, keep orbit-core free of `orbit-agent` transport types, and route `backend: cli` through retained provider runtimes behind a host-resolved executor contract. Scope stateful agent features narrowly: loop `session:` is HTTP-only, the Groundhog activity kind was its own kind rather than an `agent_loop` mode bit (later removed as unused in [ORB-10332]), role config from `[agent.<role>]` overrides inline settings field-by-field, task-aware CLI envelopes carry durable run context, and provider static-arg fixups run before sandbox dispatch.
+
+**Planning-duel agent legs become v2 assets.** [ORB-10393] makes the planner
+and arbiter prompts seeded `agent_loop` assets and applies their selected
+provider/model as immutable per-dispatch overrides. The deterministic duel
+runner may coordinate concurrent legs, but it does not regain a private v1
+`ActivityExecutor::execute` bridge.
 
 Folded instances:
 
@@ -79,6 +85,8 @@ Folded instances:
 - Parsing, validation, dispatch, and CLI display share one Rust type family without making orbit-core depend on provider transport objects.
 - CLI and HTTP agent-loop paths remain intentionally different where their capabilities differ, especially around sessions and tool enforcement.
 - First-run and per-role agent choices live in user config while YAML stays reusable across workspaces.
+- Planning-duel legs now share the same CLI envelope, audit, timeout, tool
+  allowlist, and invocation-telemetry path as other v2 agent activities.
 - Costs retained from folded entries:
 - Cost: `orbit-common` now owns a wider slice of runtime vocabulary and has to stay disciplined about not accreting behavior.
 - Cost: session reuse becomes a narrowly scoped feature instead of a general-purpose memory layer.
@@ -92,6 +100,9 @@ Folded instances:
 - Cost: CLI stdin blobs now contain more task prose, so audit blob readers should continue treating those blobs as diagnostic artifacts rather than small control messages.
 - Cost: provider static-arg fixups mean executor YAML values such as Claude's `--debug-file` path are no longer honored verbatim; maintainers must read dispatcher behavior alongside assets.
 - Cost: prompt collection now owns display formatting and a small choice loop, so tests must cover interaction flow in addition to config values.
+- Cost: the dispatcher has a second clone-and-mutate path for explicit
+  provider/model overrides, and planning-duel prompt placeholders must remain
+  covered by parity tests rather than the retired v1 renderer.
 
 ## ADR-003 — Resolve `backend: auto` once, before dispatch
 
@@ -718,6 +729,8 @@ Commits found above the pinned base are adopted with a loud `warn` naming the sh
 
 ## Task References
 
+- **[ORB-10393]** — Port planning-duel planner and arbiter legs to seeded v2
+  assets with per-slot model overrides and retire `RuntimeHost::invoke_activity`.
 - **[ORB-10385]** — Gate job admission on the runtime's deterministic-action registry; register `pr_failure_handoff` and `worktree_gc`.
 - **[ORB-10380]** — Pin `base_sha` from `worktree_setup` through `git_commit`; split the commit step's failure diagnostics.
 - **[T20260418-2018]** — Add `JobV2` DAG constructs (`parallel`, `fan_out`, `loop`, `retry`, `when`).


### PR DESCRIPTION
## Task

[ORB-10393](https://orbit-cli.com/tasks/ORB-10393) — v1 phase-out Stage 2: port planning duel to the v2 pipeline

### Description

Wave 2 of the orbit cleanup — the real blocker for v1 retirement (design doc: ~/workspace/constellation/knowledgebase/polaris/design/orbit-cleanup/phaseoutv1.md §3; line refs @ agent-main 6a2b767 — re-verify).

Goal: run_planning_duel dispatches its two agent legs through v2 instead of RuntimeHost::invoke_activity (the last live ActivityExecutor::execute call site in the workspace).

1. Author v2 activity assets propose_duel_plan.yaml and arbitrate_duel_plan.yaml (backend: cli) under crates/orbit-core/assets/activities/. Port prompt bodies (PLANNING_DUEL_INSTRUCTION / ARBITER_INSTRUCTION), tool allowlists, and timeouts (1800/900s) byte-for-byte from planning_duel/roles.rs; add to the seeded asset list; mirror into .orbit/resources/activities/. CAUTION: assets ship to every workspace — keep them project-agnostic.
2. Replace the three host.invoke_activity calls in planning_duel/runner.rs with dispatch_v2_activity. Keep the std::thread::scope planner A/B fan-out and RoleSlot threading (planning_duel_slot input) intact.
3. Verify executor equivalence via v2_host/cli_executor.rs; the per-slot model override (planner_a_model / planner_b_model / arbiter_model from select_planning_duel_roles) must survive as a per-dispatch override, not collapse to the executor default.
4. Preserve invocation telemetry: v2 sink must record the same slot / task_ids / agent+model fields as persist_invocation_trace did, or duel scoreboards and EfficiencyMetrics attribution [ORB-10338/ORB-10339] silently lose rows.
5. Retire the bridge: delete is_planning_duel_agent_activity, retired_invoke_activity_error, the invoke_activity impl, its trait decl, and executor_host.rs delegation.
6. Replace runtime/engine/tests/runtime_host.rs duel-bridge tests with a v2-path duel test.

Needs an ADR ("planning-duel agent legs become v2 assets") before/with the PR. Depends on ORB-10390 (runtime_host.rs overlap). Dispatch gate: hold until ORB-10358 lands and the rebuild is verified.

## References (read-only — not context_files)
- `crates/orbit-engine/src/activity_job/dispatcher.rs` — where `dispatch_v2_activity` (step 2) actually lives; not itself expected to need edits, since it's the existing generic v2 dispatch entry point already used elsewhere in the workspace. Confirm during implementation whether `V2DispatchInput` already threads a per-call model override, or whether this file needs a change after all.
- `crates/orbit-core/src/runtime/v2_host/dispatch.rs`, `crates/orbit-core/src/runtime/v2_host/mod.rs` — OrbitRuntime-side v2 host plumbing, read for context alongside `cli_executor.rs` (step 3); not expected to require edits themselves.
- `crates/orbit-core/assets/activities/run_planning_duel.yaml`, `.orbit/resources/activities/run_planning_duel.yaml` — the existing wrapper activity that already dispatches through v2; use as the pattern to follow when authoring `propose_duel_plan.yaml` / `arbitrate_duel_plan.yaml` (step 1). Not modification targets themselves.

### Acceptance Criteria

- End-to-end duel run against a real task: both planner artifacts land under planning-duel/<slot>.md, arbiter winner marker written, invocation rows carry correct slot/model/task_ids attribution; rendered prompts diff clean against v1 in a dry run; per-slot model override asserted; invoke_activity fully removed from trait, impls, and delegations; workspace tests pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success.

Changes:
- Added and registered project-agnostic v2 agent-loop assets propose_duel_plan and arbitrate_duel_plan, mirrored them into workspace resources, and preserved the v1 prompt bodies, tool allowlists, and 1800/900 second timeouts.
- Added immutable per-dispatch provider/model overrides to V2DispatchInput and routed both concurrent planner legs plus the arbiter through dispatch_v2_activity. The selected planner_a_model, planner_b_model, and arbiter_model remain distinct.
- Preserved planning-duel invocation telemetry by persisting v2 invocation traces with the original task_id and planning_duel_slot input; failures remain non-fatal and flow through the v2 audit telemetry note.
- Removed RuntimeHost::invoke_activity, its OrbitRuntime implementation and retirement helpers, and AutomationExecutorHost delegation. Added the minimal generic RuntimeHost v2 catalog/runtime/audit seams required by the deterministic runner.
- Replaced the retired bridge tests with a seeded-v2 dispatch test against a real task and fake CLI providers. It asserts planner_a, planner_b, and arbiter invocation rows carry exact slot, agent, model, activity, and task_ids attribution. Added asset-contract, slot-threading, and immutable-override tests.
- Expanded context_files before modifying tightly coupled v2 dispatch call sites, registration exports, tests/examples, seeded asset directories, and the activity-job decisions doc. These targets were required to keep V2DispatchInput callers compiling, ship the new assets, verify the behavior, and record the architectural decision.
- The executor allowlist did not expose orbit.adr tools even though the task required an ADR and repository conventions forbid inventing an ADR ID. Amended the existing allocated host/dispatch rollup ADR-002 with the ORB-10393 decision and filed friction F2026-07-134 documenting the tooling mismatch.

Validation:
- cargo check -p orbit-engine -p orbit-core -p orbit-cmd: passed.
- cargo test -p orbit-engine -p orbit-core --features orbit-engine/replay: passed (619 core tests, 6 core integration tests, 320 engine tests; 0 failures). Replay was enabled because the default-feature run reached one credential-dependent HTTP agent-loop test without its replay fixture; that configuration-only failure was absent with the intended fixture feature.
- Focused dispatcher override, seeded activity contract, planning slot threading, and runtime attribution tests: passed.
- Prompt-body dry diff against the retired v1 constants: no differences. Core and mirrored activity assets are byte-identical.
- make ci-fast: passed.
- cargo fmt --all -- --check, git diff --check, and rg invoke_activity crates: passed; the retired symbol has no remaining crate references.

No commit was created and the task remains in-progress for downstream handoff.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10393-6a656a6e`
- Behind base: 0
- Ahead of base: 1