### PR TITLE
Guardrails: orphan-module check + asset→action reachability test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ ci-fast:
 	./scripts/check-artifact-redaction-guardrail.sh
 	./scripts/check-changelog-style.sh
 	./scripts/check-error-translation.sh
+	./scripts/check-orphan-modules.sh
 
 # Verify every workspace crate declares its stability tier
 stability:

--- a/crates/orbit-core/src/runtime/v2_host/tests/dispatch.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/dispatch.rs
@@ -3,13 +3,15 @@ use crate::OrbitRuntime;
 use crate::command::task::{TaskAddParams, TaskUpdateParams};
 use crate::{ShipMode, WorkspaceRuntimeBinding};
 use chrono::Utc;
+use orbit_common::types::activity_job::V2ActivityCatalog;
 use orbit_common::types::{
-    NO_DIFF_EXPECTED_TAG, PipelineState, TaskPriority, TaskStatus, TaskType,
+    ActivityV2Spec, NO_DIFF_EXPECTED_TAG, PipelineState, TaskPriority, TaskStatus, TaskType,
 };
 use orbit_engine::DispatchError;
 use orbit_engine::V2RuntimeHost;
 use orbit_tools::ToolContext;
 use serde_json::json;
+use std::path::{Path, PathBuf};
 use tempfile::tempdir;
 
 fn seed_task(
@@ -346,5 +348,65 @@ fn waiting_locks_from_reserve_output_extracts_unique_conflict_files() {
             "dir:crates/orbit-core/src".to_string(),
             "file:src/lib.rs".to_string()
         ]
+    );
+}
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR points at <repo>/crates/orbit-core. Walk up two
+    // levels to reach the workspace root.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("orbit-core has a parent (crates/)")
+        .parent()
+        .expect("crates/ has a parent (repo root)")
+        .to_path_buf()
+}
+
+/// Loads every activity asset under `dir` through the same catalog loader
+/// `OrbitRuntime::v2_activity_catalog` uses at runtime, and returns the
+/// deterministic actions it names that this dispatcher does not register.
+/// A missing `dir` is not itself a failure — callers assert on the
+/// unregistered-actions list, so an empty (or absent) tree just yields none.
+fn unregistered_deterministic_actions(dir: &Path) -> Vec<String> {
+    if !dir.is_dir() {
+        return Vec::new();
+    }
+    let mut catalog = V2ActivityCatalog::new();
+    catalog
+        .load_dir_skipping_retired(dir)
+        .unwrap_or_else(|error| panic!("load activity assets from {}: {error}", dir.display()));
+
+    catalog
+        .names()
+        .filter_map(|name| {
+            let ActivityV2Spec::Deterministic(spec) = &catalog.get(name).expect("just listed").spec
+            else {
+                return None;
+            };
+            (!is_deterministic_action_registered(&spec.action))
+                .then(|| format!("{name} (action: {})", spec.action))
+        })
+        .collect()
+}
+
+/// [ORB-10415] Guardrail for orbit-engine cleanup audit §2/§11: a shipped
+/// activity asset naming a deterministic action this dispatcher does not
+/// register is exactly the live defect that silently broke the PR failure
+/// handoff (`pr_failure_handoff`) and the worktree GC routine (`worktree_gc`)
+/// until ORB-10410. Load through the real catalog loader (not grep) so any
+/// future asset drift fails a test instead of a production run.
+#[test]
+fn shipped_activity_assets_only_name_registered_deterministic_actions() {
+    let root = repo_root();
+    let mut unregistered =
+        unregistered_deterministic_actions(&root.join("crates/orbit-core/assets/activities"));
+    unregistered.extend(unregistered_deterministic_actions(
+        &root.join(".orbit/resources/activities"),
+    ));
+
+    assert!(
+        unregistered.is_empty(),
+        "shipped activity assets name deterministic actions missing from \
+         REGISTERED_DETERMINISTIC_ACTIONS: {unregistered:?}"
     );
 }

--- a/scripts/check-orphan-modules.sh
+++ b/scripts/check-orphan-modules.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Every src/**/*.rs file (excluding mod.rs/lib.rs/main.rs and anything under a
+# tests/ dir) must be reachable from the module tree: declared as `mod <stem>`
+# in its directory's owning file (mod.rs, lib.rs, or main.rs), in the sibling
+# file that owns the directory as a module (`foo.rs` next to `foo/`), or
+# referenced by a `#[path = "...stem.rs"]` attribute anywhere in the crate.
+# Otherwise the file is never compiled, linted, or tested — see
+# docs/design/orbit-cleanup/orbitenginecleanup.md §1/§11.
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "check-orphan-modules: ripgrep (rg) is required; install it before running" >&2
+  exit 1
+fi
+
+fail=0
+
+is_declared() {
+  local stem="$1"
+  local dir="$2"
+  local file="$3"
+
+  local owner
+  for owner in \
+    "$dir/mod.rs" \
+    "$dir/lib.rs" \
+    "$dir/main.rs" \
+    "$(dirname "$dir")/$(basename "$dir").rs"; do
+    if [[ -f "$owner" ]] && rg -q "\\bmod[[:space:]]+${stem}\\b[[:space:]]*[;{]" "$owner"; then
+      return 0
+    fi
+  done
+
+  local crate_src="${file%%/src/*}/src"
+  local base
+  base="$(basename "$file")"
+  if rg -q "#\\[path[[:space:]]*=[[:space:]]*\"[^\"]*${base}\"" --glob '*.rs' "$crate_src" 2>/dev/null; then
+    return 0
+  fi
+
+  return 1
+}
+
+while IFS= read -r -d '' file; do
+  case "$file" in
+    # Sibling unit-test trees (docs/design-patterns/test_layout.md).
+    */tests/*) continue ;;
+    # Cargo auto-discovers every file directly under src/bin/ as its own
+    # binary crate root ([[bin]] path or implicit) — no `mod` needed.
+    */src/bin/*) continue ;;
+  esac
+
+  dir="$(dirname "$file")"
+  base="$(basename "$file")"
+  stem="${base%.rs}"
+
+  if ! is_declared "$stem" "$dir" "$file"; then
+    echo "orphan module: ${file} — no mod ${stem}; declaration and no matching #[path] attribute"
+    fail=1
+  fi
+done < <(find crates/*/src -type f -name '*.rs' \
+  ! -name 'mod.rs' ! -name 'lib.rs' ! -name 'main.rs' -print0)
+
+if [[ "$fail" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "orphan module guard passed"

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -48,3 +48,4 @@ fi
 "$repo_root/scripts/check-artifact-redaction-guardrail.sh"
 "$repo_root/scripts/check-changelog-style.sh"
 "$repo_root/scripts/check-error-translation.sh"
+"$repo_root/scripts/check-orphan-modules.sh"


### PR DESCRIPTION
## Task

[ORB-10415](https://orbit-cli.com/tasks/ORB-10415) — Guardrails: orphan-module check + asset→action reachability test

### Description

From the orbit-engine cleanup audit §11 (design doc: ~/workspace/constellation/knowledgebase/polaris/design/orbit-cleanup/orbitenginecleanup.md). Two cheap checks for failure modes that have each now recurred independently across crates:

1. Orphan-module detection — scripts/check-orphan-modules.sh in the ci-fast list: for every src/**/*.rs that is not mod.rs, lib.rs/main.rs, or under a tests/ dir, assert its stem is declared in the sibling mod.rs / parent .rs or matched by a #[path] attribute. Would have caught orbit-engine §1 (4 files / 171 LOC) and orbit-store §1 (763 LOC job_store orphan). Follow the existing guardrail-script pattern (Makefile:117-128: dependency direction, CLI imports, stability tiers, learning layout, error translation).
2. Asset→action reachability — a Rust test in orbit-core (not shell/grep, so it uses the real asset loader): every action: in crates/*/assets/** and .orbit/resources/** must be matched by an arm in runtime/v2_host/dispatch.rs. Would have caught the §2 live defects (pr_failure_handoff, worktree_gc).

Depends on ORB-10410 — the reachability test must land against the fixed allowlist or it is born failing. Keep both checks fail-closed and fast; the shell check must be portable to CI's environment.

### Acceptance Criteria

- check-orphan-modules.sh wired into ci-fast and passing; seeding a throwaway undeclared .rs file makes it fail (demonstrated in the PR); the reachability test enumerates shipped assets via the real loader and fails when an asset names an unregistered action (demonstrated with a fixture); both green on the current tree.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `scripts/check-orphan-modules.sh`: for every `crates/*/src/**/*.rs` file
  that isn't `mod.rs`/`lib.rs`/`main.rs`, under a sibling `tests/` dir, or under
  `src/bin/` (Cargo auto-discovered binary roots), asserts its stem is declared
  via `mod <stem>` in the directory's owning file (`mod.rs`/`lib.rs`/`main.rs`
  or the sibling `foo.rs` that owns a `foo/` dir) or matched by a `#[path]`
  attribute anywhere in the crate. Wired into `Makefile`'s `ci-fast` target and
  into `scripts/ci-guardrails.sh` (the full `make ci` / CI merge gate), next to
  the other `check-*.sh` guardrails.
- Added a Rust test,
  `runtime::v2_host::tests::dispatch::shipped_activity_assets_only_name_registered_deterministic_actions`,
  in the sibling test file for `runtime/v2_host/dispatch.rs`. It loads every
  activity asset under `crates/orbit-core/assets/activities` and
  `.orbit/resources/activities` through `orbit_common::types::activity_job::V2ActivityCatalog`
  (the same catalog loader `OrbitRuntime::v2_activity_catalog` uses at runtime,
  not grep or a hand-maintained file list) and asserts every `deterministic`
  activity's `action` is in `dispatch::REGISTERED_DETERMINISTIC_ACTIONS` via
  `is_deterministic_action_registered`.

Validation performed:
- Orphan script: seeded a throwaway
  `crates/orbit-core/assets/activities/zzz_fixture_orphan_action.yaml`-style
  `.rs` fixture is not how this check triggers — instead validated by seeding
  an undeclared `.rs` file directly (via ad hoc run) and confirming non-zero
  exit; also ran unmodified against the current tree, which correctly flagged
  the exact 4 orphaned files documented in the orbit-engine cleanup audit
  (`executor/automation/knowledge.rs`, `batch/snapshot.rs`,
  `duel/check_review_decision.rs`, `vcs/commit/and_pr.rs`) and nothing else —
  positive proof the detection logic is correct. Also caught and fixed a false
  positive on `src/bin/*.rs` (Cargo-auto-discovered binary crate roots), which
  needed no `mod` declaration.
- Reachability test: ran green against the current tree
  (`cargo test -p orbit-core --lib ... dispatch::`, 9/9 passing). Seeded a
  throwaway `zzz_fixture_orphan_action.yaml` activity asset naming an
  unregistered action under `crates/orbit-core/assets/activities/`, confirmed
  the test fails closed with a clear message naming the offending asset and
  action, then removed the fixture and reconfirmed green.
- `cargo fmt --all -- --check` passes on the full workspace.
- `cargo clippy -p orbit-core --all-targets -- -D warnings`: fails, but on 8
  pre-existing `dead_code` violations unrelated to this change (verified via
  `git stash` — identical failures on the unmodified tree). Not introduced by
  this task.

Known gap vs. acceptance criteria ("both green on the current tree"): the
orphan-module script is NOT green on the current tree — it correctly reports
the 4 pre-existing orphaned files from the cleanup audit's §1. Their deletion
is already scoped to a separate, larger, still-`proposed` task, ORB-10411
("orbit-engine mechanical sweep: orphans, unreachable action branches, dead
executor impls, stale allows, job_runner fold, re-export narrowing"), which
was not listed as a dependency of this task. Deleting those 4 files here would
duplicate/conflict with ORB-10411's declared scope, so I left them untouched
per the "deletions of unrelated artifacts are scope drift" rule and filed
friction F2026-07-135 recommending a dependency edge (or acceptance-criteria
adjustment) for this task-graph shape. The reachability test and its fixture
demonstration are fully green; the orphan script's logic is validated
correct — the remaining non-green state is pre-existing, tracked, unrelated
work.

context_files appended (via orbit.task.update): file:scripts/check-orphan-modules.sh
(new script), file:scripts/ci-guardrails.sh (wired the new script into the
full CI gate alongside ci-fast), and
file:crates/orbit-core/src/runtime/v2_host/tests/dispatch.rs (sibling test
file for the already-listed dispatch.rs, per the repo's test-layout
convention).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10415-6a656f9a`
- Behind base: 0
- Ahead of base: 1