### PR TITLE
Delete the six dead host-trait methods spanning orbit-engine/core/store

### DIFF
--- a/crates/orbit-core/src/runtime/engine/job_run_host.rs
+++ b/crates/orbit-core/src/runtime/engine/job_run_host.rs
@@ -1,23 +1,11 @@
 use chrono::{DateTime, Utc};
-use orbit_common::types::{JobRun, JobRunState, KnowledgeRunMetrics, NotFoundKind, OrbitError};
+use orbit_common::types::{JobRun, JobRunState, NotFoundKind, OrbitError};
 use orbit_engine::JobRunHost;
 use orbit_store::{JobRunStepParams, TaskReservationReleaseReason};
 
 use crate::OrbitRuntime;
 
 impl JobRunHost for OrbitRuntime {
-    fn list_all_pending_or_running_runs(&self) -> Result<Vec<JobRun>, OrbitError> {
-        self.reconcile_stale_job_runs(None)?;
-        self.stores().jobs().list_all_pending_or_running_runs()
-    }
-
-    fn list_pending_or_running_job_runs(&self, job_id: &str) -> Result<Vec<JobRun>, OrbitError> {
-        self.reconcile_stale_job_runs(Some(job_id))?;
-        self.stores()
-            .jobs()
-            .list_pending_or_running_job_runs(job_id)
-    }
-
     fn insert_job_run(
         &self,
         job_id: &str,
@@ -46,47 +34,12 @@ impl JobRunHost for OrbitRuntime {
             .mark_job_run_running(run_id, started_at, pid)
     }
 
-    fn take_over_running_job_run(
-        &self,
-        run_id: &str,
-        expected_pid: Option<u32>,
-        expected_pid_start_time: Option<String>,
-        started_at: DateTime<Utc>,
-        pid: u32,
-    ) -> Result<bool, OrbitError> {
-        self.stores().jobs().take_over_running_job_run(
-            run_id,
-            expected_pid,
-            expected_pid_start_time,
-            started_at,
-            pid,
-        )
-    }
-
-    fn abandon_job_run(
-        &self,
-        run_id: &str,
-        finished_at: DateTime<Utc>,
-    ) -> Result<bool, OrbitError> {
-        self.stores().jobs().abandon_job_run(run_id, finished_at)
-    }
-
     fn complete_job_run_step(
         &self,
         run_id: &str,
         params: &JobRunStepParams,
     ) -> Result<bool, OrbitError> {
         self.stores().jobs().complete_job_run_step(run_id, params)
-    }
-
-    fn record_job_run_knowledge_metrics(
-        &self,
-        run_id: &str,
-        metrics: KnowledgeRunMetrics,
-    ) -> Result<bool, OrbitError> {
-        self.stores()
-            .jobs()
-            .record_job_run_knowledge_metrics(run_id, metrics)
     }
 
     fn finalize_job_run(

--- a/crates/orbit-engine/src/context/hosts.rs
+++ b/crates/orbit-engine/src/context/hosts.rs
@@ -6,8 +6,8 @@ use orbit_agent::AgentConfig;
 use orbit_common::types::InvocationTrace;
 use orbit_common::types::activity_job::{AgentRole, Backend, Provider};
 use orbit_common::types::{
-    ActivityV2, AgentModelPair, ExecutorDef, ExternalRef, JobRun, JobRunState, KnowledgeRunMetrics,
-    OrbitError, OrbitEvent, PipelineState, Role, Task, TaskArtifact, TaskComment, TaskHistoryEntry,
+    ActivityV2, AgentModelPair, ExecutorDef, ExternalRef, JobRun, JobRunState, OrbitError,
+    OrbitEvent, PipelineState, Role, Task, TaskArtifact, TaskComment, TaskHistoryEntry,
     TaskPriority, TaskStatus, all_agent_families,
 };
 use orbit_exec::EnvironmentMode;
@@ -52,8 +52,6 @@ pub struct TaskActivityUpdate {
 }
 
 pub trait JobRunHost {
-    fn list_all_pending_or_running_runs(&self) -> Result<Vec<JobRun>, OrbitError>;
-    fn list_pending_or_running_job_runs(&self, job_id: &str) -> Result<Vec<JobRun>, OrbitError>;
     fn insert_job_run(
         &self,
         job_id: &str,
@@ -68,28 +66,10 @@ pub trait JobRunHost {
         started_at: chrono::DateTime<chrono::Utc>,
         pid: u32,
     ) -> Result<bool, OrbitError>;
-    fn take_over_running_job_run(
-        &self,
-        run_id: &str,
-        expected_pid: Option<u32>,
-        expected_pid_start_time: Option<String>,
-        started_at: chrono::DateTime<chrono::Utc>,
-        pid: u32,
-    ) -> Result<bool, OrbitError>;
-    fn abandon_job_run(
-        &self,
-        run_id: &str,
-        finished_at: chrono::DateTime<chrono::Utc>,
-    ) -> Result<bool, OrbitError>;
     fn complete_job_run_step(
         &self,
         run_id: &str,
         params: &JobRunStepParams,
-    ) -> Result<bool, OrbitError>;
-    fn record_job_run_knowledge_metrics(
-        &self,
-        run_id: &str,
-        metrics: KnowledgeRunMetrics,
     ) -> Result<bool, OrbitError>;
     fn finalize_job_run(
         &self,
@@ -278,18 +258,6 @@ pub trait RuntimeHost {
         _query: InvocationQuery,
     ) -> Result<Vec<InvocationRecord>, OrbitError> {
         Ok(Vec::new())
-    }
-    fn invocation_records_for_job_run_and_activity(
-        &self,
-        job_run_id: &str,
-        activity_id: &str,
-    ) -> Result<Vec<InvocationRecord>, OrbitError> {
-        self.invocation_records(InvocationQuery {
-            job_run_id: Some(job_run_id.to_string()),
-            activity_id: Some(activity_id.to_string()),
-            limit: 1_000_000,
-            ..InvocationQuery::default()
-        })
     }
     fn activity_implementer_identity(
         &self,

--- a/crates/orbit-store/src/backend/contracts/traits.rs
+++ b/crates/orbit-store/src/backend/contracts/traits.rs
@@ -197,21 +197,11 @@ pub trait JobRunStoreBackend: Send + Sync {
         started_at: DateTime<Utc>,
         pid: u32,
     ) -> Result<bool, OrbitError>;
-    fn take_over_running_job_run(
-        &self,
-        run_id: &str,
-        expected_pid: Option<u32>,
-        expected_pid_start_time: Option<String>,
-        started_at: DateTime<Utc>,
-        pid: u32,
-    ) -> Result<bool, OrbitError>;
     /// [ORB-10070] Record `pid` (+ its start-time identity token) as the owner
     /// of a still-`pending` run so orphan reconciliation can distinguish a
     /// queued run with a live worker from one whose worker died. Returns
     /// `false` without writing when the run is missing or no longer pending.
     fn claim_pending_job_run_owner(&self, run_id: &str, pid: u32) -> Result<bool, OrbitError>;
-    fn abandon_job_run(&self, run_id: &str, finished_at: DateTime<Utc>)
-    -> Result<bool, OrbitError>;
     fn complete_job_run_step(
         &self,
         run_id: &str,

--- a/crates/orbit-store/src/sqlite/job_run_store/mod.rs
+++ b/crates/orbit-store/src/sqlite/job_run_store/mod.rs
@@ -152,36 +152,6 @@ impl JobRunStoreBackend for SqliteJobRunStore {
         })
     }
 
-    fn take_over_running_job_run(
-        &self,
-        run_id: &str,
-        expected_pid: Option<u32>,
-        expected_pid_start_time: Option<String>,
-        started_at: DateTime<Utc>,
-        pid: u32,
-    ) -> Result<bool, OrbitError> {
-        self.update_run(run_id, |run| {
-            if run.state != JobRunState::Running
-                || run.pid != expected_pid
-                || run.pid_start_time != expected_pid_start_time
-            {
-                return Err(OrbitError::InvalidInput(
-                    "job run takeover mismatch".to_string(),
-                ));
-            }
-            run.started_at = run.started_at.or(Some(started_at));
-            run.pid = Some(pid);
-            run.pid_start_time = process_start_identity_token(pid);
-            Ok(())
-        })
-        .or_else(|err| match err {
-            OrbitError::InvalidInput(message) if message == "job run takeover mismatch" => {
-                Ok(false)
-            }
-            other => Err(other),
-        })
-    }
-
     fn claim_pending_job_run_owner(&self, run_id: &str, pid: u32) -> Result<bool, OrbitError> {
         let mut claimed = false;
         let found = self.update_run(run_id, |run| {
@@ -194,24 +164,6 @@ impl JobRunStoreBackend for SqliteJobRunStore {
             Ok(())
         })?;
         Ok(found && claimed)
-    }
-
-    fn abandon_job_run(
-        &self,
-        run_id: &str,
-        finished_at: DateTime<Utc>,
-    ) -> Result<bool, OrbitError> {
-        self.update_run(run_id, |run| {
-            if run.state.is_terminal() {
-                return Ok(());
-            }
-            run.state = run
-                .state
-                .try_transition(RunEvent::Abandon)
-                .map_err(OrbitError::JobRunStateTransition)?;
-            run.finished_at = Some(finished_at);
-            Ok(())
-        })
     }
 
     fn complete_job_run_step(


### PR DESCRIPTION
## Task

[ORB-10412](https://orbit-cli.com/tasks/ORB-10412) — Delete the six dead host-trait methods spanning orbit-engine/core/store

### Description

RE-SCOPED 2026-07-26 after terra's valid block (see execution summary + comment): the original spec over-claimed. Three of the five store-backend methods have LIVE direct orbit-core callers via self.stores().jobs() — list_pending_or_running_job_runs (command/job/pipeline.rs:226,368; command/job/run/reconcile.rs:77), list_all_pending_or_running_runs (reconcile.rs:51,64,79), record_job_run_knowledge_metrics (runtime/v2_host/mod.rs:260) — verified by orchestrator against origin/agent-main. Those store methods and their sqlite impls STAY.

What is actually dead (from orbit-engine cleanup audit §8, corrected):
1. The ENGINE-side trait declarations of the five methods (list_all_pending_or_running_runs, list_pending_or_running_job_runs, take_over_running_job_run, abandon_job_run, record_job_run_knowledge_metrics) on JobRunHost/RuntimeHost in orbit-engine/src/context/hosts.rs — the engine never calls them; that is the only reason those trait members exist.
2. The orbit-core impls in runtime/engine/job_run_host.rs for those five — pure delegation shims satisfying the now-dead trait members. (Core's live callers go straight to stores().jobs(), not through these.)
3. The defaulted, never-overridden, never-called invocation_records_for_job_run_and_activity (hosts.rs:293).
4. take_over_running_job_run and abandon_job_run ONLY: re-verify with the compiler that no caller exists outside the deleted rungs; if confirmed, also delete their store backend trait entries (orbit-store backend contracts traits) and sqlite impls (sqlite/job_run_store/). If any live caller surfaces, leave the store rung and note it in the execution summary.

No behavior change; every deletion compiler-confirmed. Original audit context: knowledgebase/polaris/design/orbit-cleanup/orbitenginecleanup.md §8.

### Acceptance Criteria

- Engine trait decls for the five methods and the defaulted sixth are gone from hosts.rs; the corresponding job_run_host.rs delegation impls are gone; the three live store methods (list_pending_or_running_job_runs, list_all_pending_or_running_runs, record_job_run_knowledge_metrics) and their sqlite impls remain untouched with their callers compiling unchanged; take_over/abandon store rungs deleted only if compiler-confirmed dead, otherwise documented; cargo check --workspace + full tests pass; no behavior change.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Removed the five unused JobRunHost trait members and their OrbitRuntime delegation shims.
- Removed the unused RuntimeHost invocation_records_for_job_run_and_activity default helper.
- Compiler/reference-confirmed take_over_running_job_run and abandon_job_run had no callers, then removed their JobRunStoreBackend contracts and SQLite implementations.
- Preserved the three live store methods and direct orbit-core callers unchanged.
- Added file:crates/orbit-store/src/backend/contracts/traits.rs to context_files before modifying it because it is the tightly coupled backend contract needed for the confirmed-dead store rungs.
Assessment: mechanical deletion only; no behavior change.
Validation:
- cargo fmt --check: passed.
- git diff --check: passed.
- cargo check --workspace: passed (pre-existing orbit-core warnings only).
- cargo test -p orbit-engine -p orbit-store -p orbit-core --lib --quiet: passed (run with managed-run attribution variables unset per L-0068).
- cargo test --workspace --quiet: blocked by an unrelated existing orbit-cli MCP tools-list snapshot drift in mcp_serve_tools_list_matches_production_snapshot; all preceding suites passed.
- make ci-fast: blocked by unrelated pre-existing orphan-module reports in orbit-engine automation files (knowledge.rs, snapshot.rs, check_review_decision.rs, and and_pr.rs).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10412-6a657729`
- Behind base: 0
- Ahead of base: 1