### PR TITLE
Remove dangling legacy T-format task id references from live docs and code

### DIFF
--- a/crates/orbit-agent/src/loop_engine/replay_transport.rs
+++ b/crates/orbit-agent/src/loop_engine/replay_transport.rs
@@ -2,7 +2,7 @@
 //!
 //! Feeds a scripted sequence of `TurnResponse`s back in order, so the
 //! `AgentLoop` can drive a full turn cycle without an outbound HTTP call or
-//! credentials. Used by Phase 2b's tool-denial smoke (T20260418-2052 AC4):
+//! credentials. Used by Phase 2b's tool-denial smoke to verify AC4:
 //! the replay emits a `tool_use` for a disallowed tool on the first turn,
 //! allowing `EnforcedAuditSink` to observe the dispatch and record the
 //! `tool.denied` event.

--- a/crates/orbit-cli/src/command/run/duel.rs
+++ b/crates/orbit-cli/src/command/run/duel.rs
@@ -15,7 +15,7 @@ const DUEL_PLAN_WORKFLOW: &str = "duel-plan";
 #[command(
     about = "Run a planning duel for one task",
     override_usage = "orbit run duel-plan <TASK_ID> [OPTIONS]",
-    after_help = "Examples:\n  orbit run duel-plan T20260409-0310\n  orbit run duel-plan T20260409-0310 --base main --json\n  orbit run duel-plan T20260409-0310 --wait\n\nBy default this submits the planning-duel pipeline and returns a run ID immediately. Use `orbit run show <RUN_ID>` to inspect it, or pass `--wait` to block until it finishes."
+    after_help = "Examples:\n  orbit run duel-plan <TASK_ID>\n  orbit run duel-plan <TASK_ID> --base main --json\n  orbit run duel-plan <TASK_ID> --wait\n\nBy default this submits the planning-duel pipeline and returns a run ID immediately. Use `orbit run show <RUN_ID>` to inspect it, or pass `--wait` to block until it finishes."
 )]
 pub struct DuelPlanCommand {
     /// Task ID for the planning duel.

--- a/crates/orbit-cli/src/command/run/tests/duel.rs
+++ b/crates/orbit-cli/src/command/run/tests/duel.rs
@@ -8,7 +8,7 @@ use super::super::support::dispatch_workflow;
 
 fn duel_plan_args(base: Option<&str>, wait: bool) -> DuelPlanCommand {
     DuelPlanCommand {
-        task_id: "T20260425-2010".to_string(),
+        task_id: "ORB-00001".to_string(),
         base: base.map(str::to_string),
         wait,
         json: false,
@@ -36,8 +36,8 @@ fn duel_plan_uses_explicit_base_when_flag_set() {
     assert_eq!(
         plan.input,
         json!({
-            "task_id": "T20260425-2010",
-            "task_ids": ["T20260425-2010"],
+            "task_id": "ORB-00001",
+            "task_ids": ["ORB-00001"],
             "base_branch": "main",
         })
     );
@@ -60,8 +60,8 @@ fn duel_plan_falls_back_to_config_base_when_flag_absent() {
     assert_eq!(
         plan.input,
         json!({
-            "task_id": "T20260425-2010",
-            "task_ids": ["T20260425-2010"],
+            "task_id": "ORB-00001",
+            "task_ids": ["ORB-00001"],
             "base_branch": "agent-main",
         })
     );

--- a/crates/orbit-cli/src/command/run/tests/ship.rs
+++ b/crates/orbit-cli/src/command/run/tests/ship.rs
@@ -55,7 +55,7 @@ fn ship_auto_mode_preserves_local_mode_and_base_override() {
 #[test]
 fn explicit_ship_uses_unified_gated_workflow_with_pr_mode() {
     let plan = build_plan(
-        &ship_args(&["T20260425-2010", "T20260425-2011"], ShipMode::Pr, None),
+        &ship_args(&["ORB-00001", "ORB-00002"], ShipMode::Pr, None),
         "agent-main",
     )
     .expect("build plan");
@@ -66,7 +66,7 @@ fn explicit_ship_uses_unified_gated_workflow_with_pr_mode() {
         json!({
             "mode": "pr",
             "base_branch": "agent-main",
-            "task_ids": ["T20260425-2010", "T20260425-2011"],
+            "task_ids": ["ORB-00001", "ORB-00002"],
         })
     );
 }
@@ -74,7 +74,7 @@ fn explicit_ship_uses_unified_gated_workflow_with_pr_mode() {
 #[test]
 fn explicit_ship_preserves_local_mode_and_base_override() {
     let plan = build_plan(
-        &ship_args(&["T20260425-2010"], ShipMode::Local, Some("main")),
+        &ship_args(&["ORB-00001"], ShipMode::Local, Some("main")),
         "agent-main",
     )
     .expect("build plan");
@@ -85,14 +85,14 @@ fn explicit_ship_preserves_local_mode_and_base_override() {
         json!({
             "mode": "local",
             "base_branch": "main",
-            "task_ids": ["T20260425-2010"],
+            "task_ids": ["ORB-00001"],
         })
     );
 }
 
 #[test]
 fn ship_threads_explicit_review_controls() {
-    let mut args = ship_args(&["T20260425-2010"], ShipMode::Pr, None);
+    let mut args = ship_args(&["ORB-00001"], ShipMode::Pr, None);
     args.review = true;
     args.review_crew = Some("opus-review".to_string());
 
@@ -104,7 +104,7 @@ fn ship_threads_explicit_review_controls() {
 
 #[test]
 fn ship_rejects_enabled_review_without_explicit_crew() {
-    let mut args = ship_args(&["T20260425-2010"], ShipMode::Pr, None);
+    let mut args = ship_args(&["ORB-00001"], ShipMode::Pr, None);
     args.review = true;
 
     let error = build_plan(&args, "agent-main").expect_err("review crew is required");
@@ -118,7 +118,7 @@ fn ship_rejects_enabled_review_without_explicit_crew() {
 fn ship_local_deprecation_returns_legacy_error() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     let err = LegacyShipLocalCommand {
-        task_ids: vec!["T20260425-2010".to_string()],
+        task_ids: vec!["ORB-00001".to_string()],
         base: None,
         json: false,
     }
@@ -170,7 +170,7 @@ fn ship_rejects_removed_auto_positional_form() {
 #[test]
 fn ship_rejects_duplicate_task_ids() {
     let err = build_plan(
-        &ship_args(&["T20260425-2010", "T20260425-2010"], ShipMode::Pr, None),
+        &ship_args(&["ORB-00001", "ORB-00001"], ShipMode::Pr, None),
         "agent-main",
     )
     .expect_err("duplicate task IDs should fail");

--- a/crates/orbit-cli/src/command/task/list.rs
+++ b/crates/orbit-cli/src/command/task/list.rs
@@ -11,7 +11,7 @@ use super::output::{print_task_table, task_to_json, task_to_signal_json};
 
 #[derive(Args)]
 #[command(
-    after_help = "Examples:\n  orbit task list\n  orbit task list --limit 100\n  orbit task list --status backlog\n  orbit task list --status in-progress,review\n  orbit task list --type feature\n  orbit task list --priority high\n  orbit task list --parent T12345678-123456\n  orbit task list --ref jira:ENG-1234\n  orbit task list --has-ref jira\n  orbit task list --tag perf --tag bench\n  orbit task list --path src/auth/login.rs\n  orbit task list --json"
+    after_help = "Examples:\n  orbit task list\n  orbit task list --limit 100\n  orbit task list --status backlog\n  orbit task list --status in-progress,review\n  orbit task list --type feature\n  orbit task list --priority high\n  orbit task list --parent <TASK_ID>\n  orbit task list --ref jira:ENG-1234\n  orbit task list --has-ref jira\n  orbit task list --tag perf --tag bench\n  orbit task list --path src/auth/login.rs\n  orbit task list --json"
 )]
 pub struct TaskListArgs {
     /// Filter by one or more statuses (comma-separated). Opt-in: with no

--- a/crates/orbit-cli/src/command/tool/tests/run.rs
+++ b/crates/orbit-cli/src/command/tool/tests/run.rs
@@ -8,7 +8,7 @@ fn list_output_uses_minimal_task_projection() {
         "orbit.task.list",
         &json!({ "status": "backlog" }),
         json!([{
-            "id": "T20260422-0001",
+            "id": "ORB-00001",
             "title": "Backlog task",
             "status": "backlog",
             "priority": "medium",
@@ -27,7 +27,7 @@ fn list_output_uses_minimal_task_projection() {
     assert_eq!(
         shaped,
         json!([{
-            "id": "T20260422-0001",
+            "id": "ORB-00001",
             "title": "Backlog task",
             "status": "backlog",
             "priority": "medium",

--- a/crates/orbit-common/examples/v2_asset_smoke.rs
+++ b/crates/orbit-common/examples/v2_asset_smoke.rs
@@ -9,7 +9,7 @@
 
 //! Smoke: load every schemaVersion 2 activity + job YAML through the asset
 //! loader. Used as the AC2 / AC1 validation path per the Phase 2 plan in
-//! T20260418-2010.
+//! This example exercises the v2 asset loader.
 //!
 //! Usage:
 //!     cargo run -p orbit-common --example v2_asset_smoke

--- a/crates/orbit-common/examples/v2_round_trip.rs
+++ b/crates/orbit-common/examples/v2_round_trip.rs
@@ -7,7 +7,7 @@
     clippy::unwrap_used
 )]
 
-//! Round-trip smoke for v2 reference YAMLs (closes T20260418-2010 AC1).
+//! Round-trip smoke for v2 reference YAMLs (AC1).
 //!
 //! For each v2 reference under `crates/orbit-core/assets/activities/`:
 //!   1. Load the YAML through `load_activity_asset` → `ActivityV2`.

--- a/crates/orbit-common/src/types/id.rs
+++ b/crates/orbit-common/src/types/id.rs
@@ -1,4 +1,4 @@
-/// A human-readable, deterministic identifier string (e.g. `"T20260321-192339"`).
+/// A human-readable, deterministic identifier string (e.g. `"example-id"`).
 ///
 /// This is a type alias rather than a newtype so it serializes and deserializes
 /// as a plain string without needing custom serde impls. All IDs are generated

--- a/crates/orbit-common/src/utility/tests/logging.rs
+++ b/crates/orbit-common/src/utility/tests/logging.rs
@@ -436,7 +436,7 @@ mod subscriber {
                 provider = "codex",
                 stream = "stderr",
                 job_run_id = "jrun-123",
-                task_id = "T20260426-2343",
+                task_id = "ORB-00001",
                 line = "hello"
             );
         })
@@ -448,7 +448,7 @@ mod subscriber {
         assert_eq!(fields["provider"], "codex");
         assert_eq!(fields["stream"], "stderr");
         assert_eq!(fields["job_run_id"], "jrun-123");
-        assert_eq!(fields["task_id"], "T20260426-2343");
+        assert_eq!(fields["task_id"], "ORB-00001");
         assert_eq!(fields["line"], "hello");
     }
 

--- a/crates/orbit-core/examples/v2_backend_precedence_smoke.rs
+++ b/crates/orbit-core/examples/v2_backend_precedence_smoke.rs
@@ -9,7 +9,7 @@
 
 //! Four precedence smokes for `Backend::Auto` resolution per §3.1.
 //!
-//! AC #2 of T20260419-0104: verify each tier of the flag → env → config →
+//! AC #2: verify each tier of the flag → env → config →
 //! default chain with a separate scenario. Uses the pure
 //! `resolve_backend_precedence` function so no OrbitRuntime / workspace
 //! scaffolding is required.
@@ -18,7 +18,7 @@ use orbit_common::types::activity_job::Backend;
 use orbit_core::command::backend_resolver::{BackendSource, resolve_backend_precedence};
 
 fn main() {
-    println!("v2 backend precedence smoke — T20260419-0104 AC #2");
+    println!("v2 backend precedence smoke — AC #2");
 
     // Flag wins over all lower tiers.
     let r = resolve_backend_precedence(Some(Backend::Cli), Some("http"), Some("http"));

--- a/crates/orbit-dashboard/src/api/tests/audit.rs
+++ b/crates/orbit-dashboard/src/api/tests/audit.rs
@@ -32,7 +32,7 @@ fn seed_audit_event(
             subcommand: Some("update".to_string()),
             tool_name: Some(tool_name.to_string()),
             target_type: Some("task".to_string()),
-            target_id: Some("T00000000-000000".to_string()),
+            target_id: Some("example-task-id".to_string()),
             role: role.to_string(),
             status,
             exit_code: match status {

--- a/crates/orbit-dashboard/src/api/tests/runs.rs
+++ b/crates/orbit-dashboard/src/api/tests/runs.rs
@@ -1193,7 +1193,7 @@ async fn ship_endpoint_rejects_duplicate_task_ids() {
 
     let response = request_ship(
         runtime,
-        Some(json!({ "task_ids": ["T12345678-123456", "T12345678-123456"] })),
+        Some(json!({ "task_ids": ["ORB-00001", "ORB-00001"] })),
     )
     .await;
 

--- a/crates/orbit-engine/examples/v2_cli_backend_smoke.rs
+++ b/crates/orbit-engine/examples/v2_cli_backend_smoke.rs
@@ -7,7 +7,7 @@
     clippy::unwrap_used
 )]
 
-//! v2 `backend: cli` smoke suite — T20260419-0104.
+//! v2 `backend: cli` smoke suite.
 //!
 //! Exercises the new §3.1 dispatch path, the §7.6 envelope events, the §6
 //! harness-delegated allowlist advisory, the §3.2 loader rejection, argv
@@ -43,7 +43,7 @@ use serde_json::Value;
 use tempfile::TempDir;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("v2 cli-backend smoke — T20260419-0104");
+    println!("v2 cli-backend smoke");
 
     scenario_a_cli_dispatch_emits_envelope_events()?;
     scenario_b_argv_redaction()?;

--- a/crates/orbit-engine/examples/v2_name_resolution_smoke.rs
+++ b/crates/orbit-engine/examples/v2_name_resolution_smoke.rs
@@ -7,7 +7,7 @@
     clippy::unwrap_used
 )]
 
-//! Phase 4 prerequisite smoke — T20260418-2019.
+//! Phase 4 prerequisite smoke.
 //!
 //! Exercises:
 //!   A) `V2ActivityCatalog::load_dir` picks up the four new v2 activities
@@ -42,7 +42,7 @@ use orbit_engine::{
 use serde_json::Value;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("v2 name-resolution smoke — T20260418-2019 Phase 4 prereq");
+    println!("v2 name-resolution smoke — Phase 4 prereq");
 
     scenario_a_catalog_loads_new_activities()?;
     scenario_b_target_ref_resolves()?;

--- a/docs/design/activity-job/1_overview.md
+++ b/docs/design/activity-job/1_overview.md
@@ -22,10 +22,10 @@ Activity / Job is Orbit's execution substrate. Activities describe runnable unit
 
 Orbit needs a runtime layer that humans can inspect and code can execute. Activity / Job solves four practical problems:
 
-1. **Typed execution.** Agent loops and deterministic actions share one schema family after [T20260418-2010].
-2. **Durable local control flow.** Retry, parallelism, fan-out, and loops survive outside one model turn via `JobV2` DAG constructs from [T20260418-2018].
-3. **Clean runtime boundaries.** orbit-core coordinates runs without naming `orbit-agent` internals through the `V2RuntimeHost` work in [T20260418-2143] and [T20260418-2210].
-4. **One canonical schema.** `schemaVersion: 1` assets fail load-time parsing after [T20260419-2156].
+1. **Typed execution.** Agent loops and deterministic actions share one schema family.
+2. **Durable local control flow.** Retry, parallelism, fan-out, and loops survive outside one model turn via `JobV2` DAG constructs.
+3. **Clean runtime boundaries.** orbit-core coordinates runs without naming `orbit-agent` internals through the `V2RuntimeHost` work.
+4. **One canonical schema.** `schemaVersion: 1` assets fail load-time parsing.
 
 ---
 
@@ -38,7 +38,7 @@ An `ActivityV2` carries shared metadata plus one runtime spec:
 - `agent_loop`
 - `deterministic`
 
-The shared shape shipped in [T20260418-2010]. The `shell` type was removed as a fail-closed security fix in [ORB-00374]; see [ADR-0194](./4_decisions.md). The `groundhog` activity kind was later removed as unused in [ORB-10332].
+The shared shape shipped. The `shell` type was removed as a fail-closed security fix in [ORB-00374]; see [ADR-0194](./4_decisions.md). The `groundhog` activity kind was later removed as unused in [ORB-10332].
 
 ### 2.2 Jobs are the orchestration grammar
 
@@ -52,7 +52,7 @@ A `JobV2` is a step tree with:
 - `fan_out` / `fan_in`
 - `loop`
 
-That grammar landed in [T20260418-2018], with `workflow` / `subroutine` job kinds added in [T20260419-0339].
+That grammar landed first, followed by the `workflow` / `subroutine` job kinds.
 
 ### 2.3 Load-time normalization is part of the contract
 
@@ -63,7 +63,7 @@ orbit-core normalizes assets before a run starts:
 - rewrites `backend: auto` to a concrete backend once per run
 - rejects loop/session/backend combinations that cannot execute safely
 
-Name resolution arrived in [T20260418-2019]. Backend resolution and `run-v2` entrypoints came in [T20260418-2143]; CLI backend support followed in [T20260419-0104].
+Name resolution arrived first. Backend resolution and `run-v2` entrypoints came next; CLI backend support followed.
 
 ### 2.4 Backends and providers are separate choices
 
@@ -72,7 +72,7 @@ For `agent_loop`, Orbit distinguishes:
 - **backend**: `http`, `cli`, or `auto`
 - **provider**: `claude`, `codex`, `gemini`, `ollama`, or `openai_compat`
 
-`backend: auto` resolves once at load time. `backend: http` against an unwired provider fails structurally instead of falling back. `backend: cli` intentionally retains the older CLI-provider runtimes per [T20260419-0104] and [T20260418-2210].
+`backend: auto` resolves once at load time. `backend: http` against an unwired provider fails structurally instead of falling back. `backend: cli` intentionally retains the older CLI-provider runtimes.
 
 ### 2.5 Audit, policy, and seeded assets make the runtime inspectable
 
@@ -82,7 +82,7 @@ This layer also owns:
 - the v2 audit envelope with `workspace_path` provenance
 - seeded reference assets and pipeline jobs used by `orbit init`
 
-`workspace_path` entered the envelope in [T20260419-0002], runtime/CLI `fsProfile` enforcement landed in [T20260419-0503], and init seeding landed in [T20260419-2347].
+The envelope gained `workspace_path`; runtime/CLI `fsProfile` enforcement and init seeding followed.
 
 ---
 
@@ -90,35 +90,35 @@ This layer also owns:
 
 | Concern | Where it lives | Primary task ID |
 |---------|----------------|-----------------|
-| v2 activity type system | `crates/orbit-common/src/types/activity_job/activity_v2.rs` | [T20260418-2010] |
-| v2 job step grammar | `crates/orbit-common/src/types/activity_job/job_v2.rs` | [T20260418-2018] |
-| Job kinds (`workflow`, `subroutine`) | `crates/orbit-common/src/types/activity_job/job_v2.rs` | [T20260419-0339] |
-| Target-ref resolution | `crates/orbit-common/src/types/activity_job/catalog.rs` | [T20260418-2019] |
-| `run-v2` core entrypoints and host boundary | `crates/orbit-cmd/src/activity_v2.rs`, `crates/orbit-core/src/command/job/exec.rs` | [T20260418-2143], [T20260418-2210] |
-| Backend resolution and loop/session constraints | `crates/orbit-core/src/command/backend_resolver.rs`, `crates/orbit-common/src/types/activity_job/backend.rs` | [T20260419-0104] |
-| v2 DAG executor | `crates/orbit-engine/src/activity_job/job_executor/` | [T20260418-2018], [T20260509-2] |
-| V2 audit envelope and disk sink | `crates/orbit-common/src/types/activity_job/audit_envelope.rs`, `crates/orbit-engine/src/activity_job/audit_writer.rs` | [T20260419-0002] |
-| `backend: cli` runtime path | `crates/orbit-engine/src/activity_job/cli_runner/mod.rs` | [T20260419-0104] |
-| `fsProfile` enforcement | `crates/orbit-policy`, `tool_context_for_activity`, CLI describe/get surfaces | [T20260419-0503] |
-| Seeded reference activities and pipeline jobs | `crates/orbit-core/assets/activities/`, `crates/orbit-core/assets/jobs/` | [T20260419-2347], [T20260419-0622-3], [T20260419-0623] |
+| v2 activity type system | `crates/orbit-common/src/types/activity_job/activity_v2.rs` |  |
+| v2 job step grammar | `crates/orbit-common/src/types/activity_job/job_v2.rs` |  |
+| Job kinds (`workflow`, `subroutine`) | `crates/orbit-common/src/types/activity_job/job_v2.rs` |  |
+| Target-ref resolution | `crates/orbit-common/src/types/activity_job/catalog.rs` |  |
+| `run-v2` core entrypoints and host boundary | `crates/orbit-cmd/src/activity_v2.rs`, `crates/orbit-core/src/command/job/exec.rs` | |
+| Backend resolution and loop/session constraints | `crates/orbit-core/src/command/backend_resolver.rs`, `crates/orbit-common/src/types/activity_job/backend.rs` |  |
+| v2 DAG executor | `crates/orbit-engine/src/activity_job/job_executor/` | [T20260509-2] |
+| V2 audit envelope and disk sink | `crates/orbit-common/src/types/activity_job/audit_envelope.rs`, `crates/orbit-engine/src/activity_job/audit_writer.rs` |  |
+| `backend: cli` runtime path | `crates/orbit-engine/src/activity_job/cli_runner/mod.rs` |  |
+| `fsProfile` enforcement | `crates/orbit-policy`, `tool_context_for_activity`, CLI describe/get surfaces |  |
+| Seeded reference activities and pipeline jobs | `crates/orbit-core/assets/activities/`, `crates/orbit-core/assets/jobs/` | |
 
 ---
 
 ## Task References
 
-- **[T20260418-2010]** — Add the first v2 activity runtime scaffolding.
-- **[T20260418-2018]** — Add `JobV2` DAG constructs (`parallel`, `fan_out`, `loop`, `retry`, `when`).
-- **[T20260418-2019]** — Add v2 activity name resolution and pipeline skeleton assets.
-- **[T20260418-2143]** — Wire `V2RuntimeHost` in orbit-core and add `orbit activity run-v2`.
-- **[T20260418-2210]** — Reshape `V2RuntimeHost` to keep `orbit-agent` types out of orbit-core.
-- **[T20260419-0002]** — Add `workspace_path` provenance to the v2 audit envelope.
-- **[T20260419-0104]** — Add `backend: cli` dispatch for v2 `agent_loop`.
-- **[T20260419-0339]** — Add v2 job kinds to the job catalog.
-- **[T20260419-0503]** — Enforce `fsProfile` rules across runtime and CLI surfaces.
-- **[T20260419-0622-3]** — Add `task_gate_pipeline`.
-- **[T20260419-0623]** — Add `task_auto_pipeline`.
-- **[T20260419-2156]** — Retire v1 assets and drop the transitional v2 naming.
-- **[T20260419-2347]** — Seed activities and workflows on `orbit init`.
+- Add the first v2 activity runtime scaffolding.
+- Add `JobV2` DAG constructs (`parallel`, `fan_out`, `loop`, `retry`, `when`).
+- Add v2 activity name resolution and pipeline skeleton assets.
+- Wire `V2RuntimeHost` in orbit-core and add `orbit activity run-v2`.
+- Reshape `V2RuntimeHost` to keep `orbit-agent` types out of orbit-core.
+- Add `workspace_path` provenance to the v2 audit envelope.
+- Add `backend: cli` dispatch for v2 `agent_loop`.
+- Add v2 job kinds to the job catalog.
+- Enforce `fsProfile` rules across runtime and CLI surfaces.
+- Add `task_gate_pipeline`.
+- Add `task_auto_pipeline`.
+- Retire v1 assets and drop the transitional v2 naming.
+- Seed activities and workflows on `orbit init`.
 - **[ORB-10332]** — Remove the unused Groundhog activity kind and the epic/parallel pipeline layer.
 - **[T20260430-19]** — Shorten the Activity / Job design docs while preserving required structure.
 - **[T20260509-2]** — Split the v2 job executor into responsibility-focused modules without changing runtime behavior.

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -24,7 +24,7 @@ Activity / Job assets are `schemaVersion: 2` YAML envelopes with:
 - `metadata.name`
 - typed `spec`
 
-The loader in `crates/orbit-common/src/types/activity_job/asset_loader.rs` reads the schema header first, then parses the full envelope into `ActivityV2` or `JobV2`; that shape arrived in [T20260418-2010]. `schemaVersion: 1` is retired after [T20260419-2156], and `kind` mismatches are structural errors, so an activity cannot dispatch as a job or vice versa.
+The loader in `crates/orbit-common/src/types/activity_job/asset_loader.rs` reads the schema header first, then parses the full envelope into `ActivityV2` or `JobV2`; that shape is now the contract. `schemaVersion: 1` is retired, and `kind` mismatches are structural errors, so an activity cannot dispatch as a job or vice versa.
 
 ---
 
@@ -55,7 +55,7 @@ The common `agent_loop` fields are:
 - `require_response_envelope` (default `false`; opt in only when downstream
   templates consume structured response fields)
 
-A former `Groundhog(GroundhogSpec)` variant (a sibling activity kind from [T20260420-0510-2]) was removed as unused in [ORB-10332]; activity specs are now only `agent_loop` and `deterministic`.
+A former `Groundhog(GroundhogSpec)` variant was removed as unused in [ORB-10332]; activity specs are now only `agent_loop` and `deterministic`.
 
 `DeterministicSpec` is just `{ action, config }`. A fourth variant, `Shell(ShellSpec)`, was removed in [ORB-00374] as a fail-closed security fix (see [ADR-0194](./4_decisions.md)); `type: shell` now fails to deserialize at load rather than spawning an unsandboxed subprocess.
 
@@ -71,7 +71,7 @@ A former `Groundhog(GroundhogSpec)` variant (a sibling activity kind from [T2026
 - `kind`
 - `steps`
 
-`JobKind` is currently `workflow` or `subroutine`, added in [T20260419-0339]. The more interesting surface is the step grammar from [T20260418-2018]:
+`JobKind` is currently `workflow` or `subroutine`. The more interesting surface is the step grammar:
 
 - every step has `id`
 - every step may add `when`
@@ -88,13 +88,13 @@ The body is one of:
 
 `TargetStep` is the executor-facing form. It inlines an `ActivityV2Spec` plus optional `fsProfile`, `default_input`, `timeout_seconds`, and optional `session`. `TargetRef` is the authoring-facing form: `target: activity:<name>`. It is resolved away before execution.
 
-Step-local input layering landed earlier, but the shipped job-level `default_input` behavior changed in [T20260423-0445]:
+Step-local input layering landed earlier, but the shipped job-level `default_input` behavior changed:
 
 - if the caller passes `null`, the run input becomes `job.default_input`
 - if both the caller input and `job.default_input` are JSON objects, Orbit performs a shallow merge and caller-supplied keys win on conflict
 - if the caller input is any non-object JSON value, it replaces `job.default_input` entirely
 
-Step-level `default_input` is still recursively template-rendered before dispatch. Support landed in [T20260413-0141], entered the v2 DAG path in [T20260418-2018], and was corrected for job-level merges in [T20260423-0445].
+Step-level `default_input` is still recursively template-rendered before dispatch. The behavior now applies consistently across the v2 DAG path and job-level merges.
 
 ---
 
@@ -102,7 +102,7 @@ Step-level `default_input` is still recursively template-rendered before dispatc
 
 orbit-core normalizes raw YAML before dispatch.
 
-Job catalog listing uses `MergeByKey` precedence after [T20260425-0204]: `ORBIT_JOB_DIR` / `ORBIT_V2_JOB_DIR` entries first, then workspace jobs, then global seeded jobs. The first valid `metadata.name` wins, so listing can show a workspace `task_auto_pipeline` in place of the global default without making the catalog ambiguous. Duplicate names inside one directory tree remain invalid because that single layer would otherwise be ambiguous.
+Job catalog listing uses `MergeByKey` precedence: `ORBIT_JOB_DIR` / `ORBIT_V2_JOB_DIR` entries first, then workspace jobs, then global seeded jobs. The first valid `metadata.name` wins, so listing can show a workspace `task_auto_pipeline` in place of the global default without making the catalog ambiguous. Duplicate names inside one directory tree remain invalid because that single layer would otherwise be ambiguous.
 
 Job execution deliberately has a different order: explicit `ORBIT_JOB_DIR` / `ORBIT_V2_JOB_DIR` entries, then global seeded jobs, then workspace jobs only for names that are not shipped defaults. Thus an explicit environment catalog can opt in to a replacement for testing or smoke runs, but a workspace-local file cannot shadow a shipped job when Orbit resolves that job by name for execution.
 
@@ -129,9 +129,9 @@ Job runs:
 7. Build audit sinks and run id with `system` as the v2 envelope `agent_identity`.
 8. Execute the normalized `JobV2`.
 
-The target-ref pass was added in [T20260418-2019], backend resolution and `run-v2` entrypoints in [T20260418-2143], and CLI backend plus HTTP-only loop/session rejection in [T20260419-0104].
+The target-ref pass, backend resolution, `run-v2` entrypoints, and CLI backend plus HTTP-only loop/session rejection are all part of the normalized dispatch path.
 
-The public CLI now executes activity assets through jobs rather than exposing a standalone `orbit activity run` subcommand. `orbit activity` is an inspection/catalog surface; `orbit job run` and workflow aliases under `orbit run` are the public execution surfaces after [T20260426-0047].
+The public CLI now executes activity assets through jobs rather than exposing a standalone `orbit activity run` subcommand. `orbit activity` is an inspection/catalog surface; `orbit job run` and workflow aliases under `orbit run` are the public execution surfaces.
 
 Some module comments still describe older phase ordering; the authoritative behavior is the orbit-core call path in `crates/orbit-core/src/command/job/exec.rs`.
 
@@ -157,7 +157,7 @@ PR creation is restartable within its own checkpoint. `pr_open` first looks up t
 
 After [ORB-10266], explicit-task PR shipment with independent review enabled preflights the selected review crew and the deployed auto/gate/PR/review assets before inserting the implementation run. `task_pr_pipeline` materializes exactly one `task_review_pipeline` child only after push, PR publication, and task promotion, snapshotting the parent run, tasks, workspace, explicit crew, candidate branch, pushed SHA, and PR identity. Parent retry/resume reuses the child whose persisted `parent_run_id` matches; multiple matches fail closed, and the dispatch step has no recovery retry that could create a second reviewer. The read-only reviewer returns a structured verdict and reviewed SHA; a deterministic guard requires that SHA to equal the published candidate before either the child or waiting parent can succeed. Review-disabled shipment is unchanged, while review-enabled local, auto-discovery, missing-crew, same-assignment, unknown-crew, and unmaterializable configurations fail before implementation. This is [ADR-0233].
 
-The seeded `list_backlog_tasks` deterministic activity starts `task_auto_pipeline`. Automatic mode admits tasks by `status: backlog`. It emits `task_count`, `task_ids`, `tasks`, singleton `bundles`, and an `excluded` array for admitted backlog tasks filtered because their context files overlap `in-progress` or `review` locks. `excluded` covers only lock overlap; status-based admission and `max_tasks` truncation stay silent, and explicit `task_ids` mode omits it. This attribution contract was added in [T20260421-0542-2].
+The seeded `list_backlog_tasks` deterministic activity starts `task_auto_pipeline`. Automatic mode admits tasks by `status: backlog`. It emits `task_count`, `task_ids`, `tasks`, singleton `bundles`, and an `excluded` array for admitted backlog tasks filtered because their context files overlap `in-progress` or `review` locks. `excluded` covers only lock overlap; status-based admission and `max_tasks` truncation stay silent, and explicit `task_ids` mode omits it. This is the attribution contract.
 
 `task_gate_pipeline` reserves a bundle's context files before it dispatches `task_pr_pipeline` or `task_local_pipeline` through `invoke_and_wait`. The reservation owner is the gate run that executed `reserve_locks`, not the child shipment run. Seeded defaults keep `ttl_seconds` aligned with `dispatch_timeout_seconds` at 7200 seconds, so the admission reservation covers the full child wait budget; workspace overrides must preserve `ttl_seconds >= dispatch_timeout_seconds` [T20260427-36]. Owned reservations are engine-cleaned when that owner run reaches a terminal state (`success`, `failed`, `cancelled`, or `timeout`), so correctness does not depend on every workspace override preserving a YAML release step. The seeded deterministic `release_locks` activity still calls `orbit.task.locks.release` after a terminal child wait as an early-release optimization; idempotent terminal cleanup then finds nothing left to release. After [T20260427-34], `invoke_and_wait` remains a raw child-status join primitive, and seeded shipment parents use `pipeline_success_guard` to fail after required cleanup whenever a child run reports anything other than `succeeded`. `task_gate_pipeline` guards the direct child after release; `task_auto_pipeline` guards collected gate results after fan-in and skips that guard for an empty backlog. Unowned/manual reservations remain explicit-release-or-TTL only. TTL is the fallback for abandoned/manual reservations or cases where no terminal cleanup or reserve-pressure reconciliation trigger runs. This lifecycle was tightened in [T20260430-26] and made engine-owned in [T20260505-10].
 
@@ -176,7 +176,7 @@ Reserve conflict checking also performs bounded, opportunistic stale-owned-reser
 3. `[runtime] backend = "<value>"` in config
 4. hard-coded fallback `http`
 
-If any intermediate tier says `auto`, the resolver folds it to the hard-coded fallback so dispatch only sees `http` or `cli`. That rule arrived with `run-v2` in [T20260418-2143] and was hardened for CLI in [T20260419-0104].
+If any intermediate tier says `auto`, the resolver folds it to the hard-coded fallback so dispatch only sees `http` or `cli`. The rule is shared by `run-v2` and the CLI path.
 
 The second rule is the HTTP-only feature constraint. Today that means loop-body cross-iteration `session:` binding: `validate_job_loop_session_backends(...)` rejects a `loop:` step with `session:` when it resolves to `backend: cli`.
 
@@ -198,7 +198,7 @@ Activity / Job is where orbit-core hands work to orbit-engine without depending 
 - build `ToolContext` for an activity, including policy, filesystem audit hooks, and trusted reservation-owner context from the active run id
 - persist invocation traces for completed agent-loop work
 
-That host wiring arrived in [T20260418-2143]. The cleanup in [T20260418-2210] kept the boundary primitive: strings, `Value`, and `ToolContext`, not `orbit-agent` transport objects.
+The host wiring keeps the boundary primitive to strings, `Value`, and `ToolContext`, not `orbit-agent` transport objects.
 
 `dispatch_v2_activity(...)` is the central per-activity entry. It emits `ActivityStarted` / `ActivityFinished` envelope events, then delegates by spec kind:
 
@@ -224,11 +224,11 @@ This path is narrower than the schema: `Provider::has_http_transport()` currentl
 
 The allowlist is enforced in the loop engine on this path. A denied tool becomes a structural `DispatchError::ToolDenied` so the job retry wrapper can classify it as non-retryable.
 
-After [T20260426-0526], completed HTTP loop outcomes become `InvocationTrace` records under the job run ID and step ID, including loop-body `session:` steps.
+Completed HTTP loop outcomes become `InvocationTrace` records under the job run ID and step ID, including loop-body `session:` steps.
 
 ### 7.2 CLI path
 
-The CLI path is driven by `cli_runner.rs`, added in [T20260419-0104]. The flow is:
+The CLI path is driven by `cli_runner.rs`. The flow is:
 
 1. Ask the host for the concrete CLI executor: command plus static executor args.
 2. Build an `Agent` from `orbit-agent`.
@@ -240,9 +240,9 @@ The CLI path is driven by `cli_runner.rs`, added in [T20260419-0104]. The flow i
 8. Emit `CliInvocationFinished` with stdout/stderr blob refs and timeout state.
 9. Parse the captured provider output with the existing Orbit response parser and persist its `InvocationTrace` through the host. After [ORB-10231] / [ADR-0224], envelope parsing is best-effort by default: provider exit status and timeout determine transport success while durable task/review/git artifacts remain authoritative. A valid envelope still projects its result fields, and an invalid or absent envelope is retained as bounded/redacted diagnostic metadata. Activities whose downstream templates require response fields set `require_response_envelope: true`, preserving fail-closed validation for that explicit contract.
 
-After [T20260426-2313], stdout/stderr readers emit line-level `tracing::info!` events while the child runs, carrying `provider`, `stream`, `job_run_id`, `task_id`, and `line`. After [T20260508-8], those events also carry `cwd` when the CLI subprocess has a resolved cwd. After [T20260426-2349], the default tracing subscriber redacts formatted output. The readers still retain original bytes for the existing audit/blob path, so run logs follow blob refs rather than the live feed.
+Stdout/stderr readers emit line-level `tracing::info!` events while the child runs, carrying `provider`, `stream`, `job_run_id`, `task_id`, and `line`. After [T20260508-8], those events also carry `cwd` when the CLI subprocess has a resolved cwd. The default tracing subscriber redacts formatted output. The readers still retain original bytes for the existing audit/blob path, so run logs follow blob refs rather than the live feed.
 
-Executor args are prepended before provider runtime args. For seeded Codex, the subprocess starts as `codex exec --json ...`, not the interactive TUI. [T20260423-0114] exposed the earlier command-only boundary.
+Executor args are prepended before provider runtime args. For seeded Codex, the subprocess starts as `codex exec --json ...`, not the interactive TUI. The executor-args boundary remains explicit.
 
 After [T20260427-48], provider runtime args receive provider config through `V2RuntimeHost`. Static executor definitions keep command-shape flags (`exec --json`); dynamic Codex settings such as sandbox mode, side-write roots, and approval policy stay in the retained provider runtime. Codex approval policy is an exec-compatible config override, not the interactive-only `--ask-for-approval` flag.
 
@@ -320,9 +320,9 @@ The body runs before `break_when`, so steps can populate fields the break expres
 
 ### 8.6 Persisted state for v2 job runs
 
-Persisted pipeline runs (`orbit run ship`, `duel-plan`, `orbit.pipeline.invoke` + `orbit.pipeline.wait`) go through `pipeline_run.rs`. Direct v2 runs (`orbit job run <job-id-or-yaml>`) also create durable `JobRun` bundles after [T20260423-2004-4] under `state/job-runs/<job_id>/<run_id>/`, so `orbit run history -j <job_id>` and `orbit run show <run_id>` can inspect the returned ID. Workflow-specific `orbit run <workflow> list/show` aliases were removed in [T20260425-2010], and duplicate job-level aliases in [T20260426-0742].
+Persisted pipeline runs (`orbit run ship`, `duel-plan`, `orbit.pipeline.invoke` + `orbit.pipeline.wait`) go through `pipeline_run.rs`. Direct v2 runs (`orbit job run <job-id-or-yaml>`) also create durable `JobRun` bundles under `state/job-runs/<job_id>/<run_id>`, so `orbit run history -j <job_id>` and `orbit run show <run_id>` can inspect the returned ID. Workflow-specific `orbit run <workflow> list/show` aliases and duplicate job-level aliases were removed.
 
-Before [T20260423-0445], early v2 failures could leave `steps: []` and no surfaced `error_message`. The current contract is:
+Before the current contract, early v2 failures could leave `steps: []` and no surfaced `error_message`. The current contract is:
 
 - if a persisted v2 pipeline fails and no recorded step already carries error detail, the pipeline worker writes a synthetic failed `JobRunStep`
 - if a direct v2 run succeeds, the direct-run wrapper writes a synthetic successful `JobRunStep` containing the final pipeline snapshot
@@ -347,7 +347,7 @@ The loop shares one pipeline map and session map across iterations, which makes 
 
 The dashboard metrics endpoints read knowledge usage from job-run state (`/api/metrics/knowledge`) and agent, tool, task, and invocation usage from the SQLite invocation store (`/api/metrics/activity`, `/api/metrics/tools`, `/api/metrics/task/:id`, `/api/metrics/invocations`). They do not scrape `.orbit/state/audit/v2_loop/` or diagnostics JSONL.
 
-V2 jobs persist invocation traces explicitly after [T20260426-0526]. `DispatchOutcome` carries optional trace data; the executor attaches run and step IDs; orbit-core stores canonical agent/model names plus task IDs from rendered input and refreshes the token scoreboard.
+V2 jobs persist invocation traces explicitly. `DispatchOutcome` carries optional trace data; the executor attaches run and step IDs; orbit-core stores canonical agent/model names plus task IDs from rendered input and refreshes the token scoreboard.
 
 For `backend: cli`, the trace comes from the provider's structured stdout using the same parser that validates Orbit response envelopes. For the HTTP loop path, the trace is derived from `LoopOutcome` usage and tool-call names.
 
@@ -355,9 +355,9 @@ For `backend: cli`, the trace comes from the provider's structured stdout using 
 
 `orbit run show`, `logs`, `events`, and `trace` inspect already-scheduled runs and resolve an omitted run ID to the most recent run.
 
-After [T20260426-0709], `orbit run show <run> -s <id>` treats the v2 envelope's activity DAG `step.id` as primary. This matters because durable v2 runs may store a synthetic job-level `JobRunStep`, while the envelope records actual YAML step IDs. `JobRunStep.target_id` and numeric `step_index` remain fallbacks.
+`orbit run show <run> -s <id>` treats the v2 envelope's activity DAG `step.id` as primary. This matters because durable v2 runs may store a synthetic job-level `JobRunStep`, while the envelope records actual YAML step IDs. `JobRunStep.target_id` and numeric `step_index` remain fallbacks.
 
-After [T20260426-0705], `orbit run events <run>` reads the v2 envelope chronologically and filters by step ID or event type. `orbit run trace <run>` renders the parent/child tree from `event_id` and `parent_event_id`. JSON mode is deterministic.
+`orbit run events <run>` reads the v2 envelope chronologically and filters by step ID or event type. `orbit run trace <run>` renders the parent/child tree from `event_id` and `parent_event_id`. JSON mode is deterministic.
 
 The CLI does not own envelope storage. `orbit-core` exposes accessors for v2 audit events and CLI invocation records, including derived step IDs and blob-backed stdout/stderr, keeping storage knowledge with the runtime layer.
 
@@ -428,7 +428,7 @@ analogous invariants — see [ADR-0011].
 
 Both `ActivityV2` and `TargetStep` can attach an `fsProfile`. orbit-core uses `tool_context_for_activity(...)` to build the policy-aware `ToolContext`, and `V2AuditWriter` can attach filesystem audit logging so read/write denials appear in the envelope.
 
-Runtime/CLI enforcement landed in [T20260419-0503]. `fsProfile` is therefore part of the activity/job contract, not a CLI presentation detail.
+Runtime/CLI enforcement landed. `fsProfile` is therefore part of the activity/job contract, not a CLI presentation detail.
 
 One subtlety: profile attachment happens at two layers.
 
@@ -447,13 +447,13 @@ This feature spans a migration, so the retained surfaces are explicit.
 
 | Surface | Current status | Rationale |
 |---------|----------------|-----------|
-| `schemaVersion: 1` activity/job assets | Retired | Load-time hard error after [T20260419-2156]. |
-| v2 `agent_loop` HTTP path | Kept | Canonical typed runtime path from [T20260418-2010]. |
-| v2 `agent_loop` CLI path | Kept | Implemented by the retained `AgentRuntime` trait and `providers/*_cli.rs` after [T20260419-0104]. |
-| `TargetRef` authoring form | Kept at authoring/load time only | Human-friendly YAML surface; resolved away before execution since [T20260418-2019]. |
+| `schemaVersion: 1` activity/job assets | Retired | Load-time hard error. |
+| v2 `agent_loop` HTTP path | Kept | Canonical typed runtime path. |
+| v2 `agent_loop` CLI path | Kept | Implemented by the retained `AgentRuntime` trait and `providers/*_cli.rs`. |
+| `TargetRef` authoring form | Kept at authoring/load time only | Human-friendly YAML surface; resolved away before execution. |
 | v1 `crate::job_runner` | Kept, condition grammar only | The older sequential/DAG runtime was removed in [ORB-10390]; the module now holds only `condition::evaluate_bool_expr`, consumed by the v2 executor's `when` and `break_when` evaluation (`job_executor/step.rs`, `job_executor/loop_block.rs`). |
 | Legacy `run_parallel_task_pipeline` | Removed | The legacy parallel-batch executor was removed as unused in [ORB-10332]; the live pipelines still dispatch and join children through `orbit.pipeline.invoke` / `orbit.pipeline.wait`. |
-| Seeded reference activities and jobs | Kept | They act as runnable contracts and examples, and were moved into init seeding in [T20260419-2347]. |
+| Seeded reference activities and jobs | Kept | They act as runnable contracts and examples, and were moved into init seeding. |
 
 ### 10.2 Seeded Assets in Practice
 
@@ -463,7 +463,7 @@ Seeded assets are part of the design. Today they include:
 - control-plane jobs such as `task_gate_pipeline`
 - higher-level dispatch workflows such as `task_auto_pipeline` and `job_duel_plan_pipeline`
 
-The gate/auto assets from [T20260419-0622-3] and [T20260419-0623] exercise real v2 constructs:
+The gate/auto assets exercise real v2 constructs:
 
 - `loop + break_when`
 - `fan_out + fan_in`
@@ -494,7 +494,7 @@ Some bad shapes fail at load time, some at job preflight, and some during dispat
 
 ### 11.5 The audit story is powerful but split
 
-The v2 envelope tree lives in `.orbit/state/audit/v2_loop/`, HTTP loop details materialize lazily in `.orbit/state/audit/loop/`, and payload blobs live in `.orbit/state/audit/blobs/`. Reviewers still need to know the split layout. [T20260426-0519] moved these traces under `.orbit/state/` so top-level `.orbit/` stays for config, resources, tasks, graph artifacts, and the SQLite command-audit database; [T20260506-2] stopped creating empty loop JSONL files for runs with no loop-level events.
+The v2 envelope tree lives in `.orbit/state/audit/v2_loop/`, HTTP loop details materialize lazily in `.orbit/state/audit/loop/`, and payload blobs live in `.orbit/state/audit/blobs/`. Reviewers still need to know the split layout. These traces live under `.orbit/state/`, keeping top-level `.orbit/` for config, resources, tasks, graph artifacts, and the SQLite command-audit database; [T20260506-2] stopped creating empty loop JSONL files for runs with no loop-level events.
 
 ### 11.6 The substrate still leaks into the public product story
 
@@ -506,41 +506,41 @@ Some module prose still reflects earlier phase names or pass ordering. orbit-cor
 
 ### 11.8 Historical run inspection belongs to the run surface
 
-Read-only history does not need the same dependencies as live execution. [T20260423-0447] kept retired workflow runs observable without live assets, [T20260425-2010] removed workflow-specific history browsers, and [T20260426-0742] removed duplicate job-level inspection aliases. Current inspection belongs to `orbit run history -j <job_id>` and `orbit run show <run_id>`; `orbit job` is for catalog browsing and direct execution.
+Read-only history does not need the same dependencies as live execution. Retired workflow runs remain observable without live assets, while workflow-specific history browsers and duplicate job-level inspection aliases are gone. Current inspection belongs to `orbit run history -j <job_id>` and `orbit run show <run_id>`; `orbit job` is for catalog browsing and direct execution.
 
 ---
 
 ## Task References
 
-- **[T20260413-0141]** — Support step default inputs in jobs.
-- **[T20260418-2010]** — Add the first v2 activity runtime scaffolding.
-- **[T20260418-2018]** — Add `JobV2` DAG constructs (`parallel`, `fan_out`, `loop`, `retry`, `when`).
-- **[T20260418-2019]** — Add v2 activity name resolution and pipeline skeleton assets.
-- **[T20260418-2143]** — Wire `V2RuntimeHost` in orbit-core and add `orbit activity run-v2`.
-- **[T20260418-2210]** — Reshape `V2RuntimeHost` to keep `orbit-agent` types out of orbit-core.
-- **[T20260419-0002]** — Add `workspace_path` provenance to the v2 audit envelope.
-- **[T20260419-0104]** — Add `backend: cli` dispatch for v2 `agent_loop`.
-- **[T20260419-0339]** — Add v2 job kinds to the job catalog.
-- **[T20260419-0503]** — Enforce `fsProfile` rules across runtime and CLI surfaces.
-- **[T20260419-0622-3]** — Add `task_gate_pipeline`.
-- **[T20260419-0623]** — Add `task_auto_pipeline`.
-- **[T20260419-2156]** — Retire v1 assets and drop the transitional v2 naming.
-- **[T20260419-2347]** — Seed activities and workflows on `orbit init`.
-- **[T20260421-0542-2]** — Add pre-gate lock-overlap exclusion attribution to `list_backlog_tasks`.
-- **[T20260423-0114]** — Expose the `backend: cli` executor-args gap during a local task ship run.
-- **[T20260423-0445]** — Merge object-valued job defaults over explicit run input and persist synthetic failed job steps for early v2 pipeline failures.
-- **[T20260423-0447]** — Restore usable `orbit run duel` read-only surfaces after duel workflow retirement.
-- **[T20260423-2004-4]** — Persist direct v2 `orbit job run` executions into durable job-run records and state.
-- **[T20260425-0204]** — Make v2 job catalog discovery honor workspace-over-global `MergeByKey` precedence.
-- **[T20260425-2010]** — Refactor `orbit run` task workflow commands and remove workflow-specific history browsers.
-- **[T20260426-0047]** — Make v2 activity catalog discovery honor workspace-over-global `MergeByKey` precedence and remove the public `orbit activity run` command.
-- **[T20260426-0526]** — Restore v2 job invocation trace persistence so dashboard metrics surfaces can report agent and tool usage.
-- **[T20260426-0519]** — Move file-backed activity/job audit traces under `.orbit/state/audit`.
-- **[T20260426-0705]** — Expose v2 run audit events through `orbit run events` and `orbit run trace`.
-- **[T20260426-0709]** — Align run step selectors on activity `step.id` and move CLI invocation log reading behind orbit-core runtime accessors.
-- **[T20260426-0742]** — Remove duplicate job-level run inspection aliases and keep run inspection under `orbit run`.
-- **[T20260426-2313]** — Stream CLI subprocess stdout/stderr through structured tracing events while retaining the existing audit/blob path.
-- **[T20260426-2349]** — Move CLI tracing output redaction from `cli_runner` call sites into the default tracing formatter layer.
+- Support step default inputs in jobs.
+- Add the first v2 activity runtime scaffolding.
+- Add `JobV2` DAG constructs (`parallel`, `fan_out`, `loop`, `retry`, `when`).
+- Add v2 activity name resolution and pipeline skeleton assets.
+- Wire `V2RuntimeHost` in orbit-core and add `orbit activity run-v2`.
+- Reshape `V2RuntimeHost` to keep `orbit-agent` types out of orbit-core.
+- Add `workspace_path` provenance to the v2 audit envelope.
+- Add `backend: cli` dispatch for v2 `agent_loop`.
+- Add v2 job kinds to the job catalog.
+- Enforce `fsProfile` rules across runtime and CLI surfaces.
+- Add `task_gate_pipeline`.
+- Add `task_auto_pipeline`.
+- Retire v1 assets and drop the transitional v2 naming.
+- Seed activities and workflows on `orbit init`.
+- Add pre-gate lock-overlap exclusion attribution to `list_backlog_tasks`.
+- Expose the `backend: cli` executor-args gap during a local task ship run.
+- Merge object-valued job defaults over explicit run input and persist synthetic failed job steps for early v2 pipeline failures.
+- Restore usable `orbit run duel` read-only surfaces after duel workflow retirement.
+- Persist direct v2 `orbit job run` executions into durable job-run records and state.
+- Make v2 job catalog discovery honor workspace-over-global `MergeByKey` precedence.
+- Refactor `orbit run` task workflow commands and remove workflow-specific history browsers.
+- Make v2 activity catalog discovery honor workspace-over-global `MergeByKey` precedence and remove the public `orbit activity run` command.
+- Restore v2 job invocation trace persistence so dashboard metrics surfaces can report agent and tool usage.
+- Move file-backed activity/job audit traces under `.orbit/state/audit`.
+- Expose v2 run audit events through `orbit run events` and `orbit run trace`.
+- Align run step selectors on activity `step.id` and move CLI invocation log reading behind orbit-core runtime accessors.
+- Remove duplicate job-level run inspection aliases and keep run inspection under `orbit run`.
+- Stream CLI subprocess stdout/stderr through structured tracing events while retaining the existing audit/blob path.
+- Move CLI tracing output redaction from `cli_runner` call sites into the default tracing formatter layer.
 - **[T20260427-34]** — Add seeded pipeline success guards so non-succeeded child runs fail parent shipment workflows.
 - **[T20260427-36]** — Align task-gate reservation TTL with the child dispatch wait budget.
 - **[T20260427-45]** — Use freshly fetched remote base refs for default task-shipping worktrees.

--- a/docs/design/activity-job/3_vision.md
+++ b/docs/design/activity-job/3_vision.md
@@ -12,7 +12,7 @@ tags: ["activity-job"]
 
 # Activity / Job — Vision
 
-This document pressure-tests where the Activity / Job substrate may go next. It starts from the v2 runtime shipped across [T20260418-2010], [T20260418-2018], [T20260418-2143], [T20260418-2210], [T20260419-0104], and [T20260419-2156]. [2_design.md](./2_design.md) is the current contract; this file asks what should harden, collapse, or disappear.
+This document pressure-tests where the Activity / Job substrate may go next. It starts from the shipped v2 runtime. [2_design.md](./2_design.md) is the current contract; this file asks what should harden, collapse, or disappear.
 
 ---
 
@@ -24,7 +24,7 @@ README frames tasks, jobs, and activities as substrate. Should Orbit keep this l
 
 ### 1.2 Should `target:` grow beyond `activity:<name>`?
 
-`TargetRef` is namespace-prefixed, but only `activity:<name>` exists after [T20260418-2019]. Do nested job refs, subroutine refs, or cross-workspace refs help, or would they turn this layer into a generic workflow engine?
+`TargetRef` is namespace-prefixed, but only `activity:<name>` exists. Do nested job refs, subroutine refs, or cross-workspace refs help, or would they turn this layer into a generic workflow engine?
 
 ### 1.3 Is the provider model too closed-set?
 
@@ -32,7 +32,7 @@ The schema names multiple providers, but the HTTP transport path is still effect
 
 ### 1.4 Should Orbit enforce tool allowlists on the CLI backend?
 
-The gap from [T20260419-0104] is significant: HTTP enforces, CLI advises. Does `backend: cli` need a wrapper so `tools:` means the same thing everywhere?
+The gap is significant: HTTP enforces, CLI advises. Does `backend: cli` need a wrapper so `tools:` means the same thing everywhere?
 
 ### 1.5 Which limits should stay structural literals?
 
@@ -40,15 +40,15 @@ The gap from [T20260419-0104] is significant: HTTP enforces, CLI advises. Does `
 
 ### 1.6 What is the right audit landing zone?
 
-The v2 envelope from [T20260419-0002] makes runs traversable, but the full HTTP transcript still lives in the sibling loop sink. Should review converge on one query surface even if files remain separate?
+The v2 envelope makes runs traversable, but the full HTTP transcript still lives in the sibling loop sink. Should review converge on one query surface even if files remain separate?
 
 ### 1.7 How much more special-casing belongs in ActivityV2?
 
-Groundhog once had a dedicated kind ([T20260420-0510-2]) but was removed as unused in [ORB-10332], leaving only `agent_loop` and `deterministic`. If more modes arrive, do we add variants again, or is churn like that a sign the abstraction should stay minimal?
+Groundhog once had a dedicated kind but was removed as unused in [ORB-10332], leaving only `agent_loop` and `deterministic`. If more modes arrive, do we add variants again, or is churn like that a sign the abstraction should stay minimal?
 
 ### 1.8 What should become the canonical reference corpus?
 
-Seeded assets added in [T20260419-2347] and extended in [T20260419-0622-3] and [T20260419-0623] already act as executable docs. Should they become the main reference set, or do we need smaller spec-only exemplars?
+Seeded assets already act as executable docs. Should they become the main reference set, or do we need smaller spec-only exemplars?
 
 ---
 
@@ -82,7 +82,7 @@ Orbit's `fsProfile` attachment and the HTTP/CLI enforcement split make this conc
 
 - Mature workflow systems almost always ship example pipelines, starter templates, or scaffolded defaults.
 
-Orbit's seeded activities and jobs from [T20260419-2347] are already more than examples; they are the closest thing to an executable spec corpus.
+Orbit's seeded activities and jobs are already more than examples; they are the closest thing to an executable spec corpus.
 
 ---
 
@@ -92,8 +92,8 @@ Soft claims only:
 
 - **Load-time normalization as a public contract.** Target-ref resolution, backend concretization, and loop/session rejection are part of what a job *is*, not just hidden parser details.
 - **Backend choice separated from provider choice.** Orbit treats `backend: http|cli|auto` and `provider: ...` as orthogonal schema fields, then makes mismatches explicit instead of silently recovering.
-- **A two-layer audit tree tied to repo provenance.** The v2 envelope from [T20260419-0002] gives runs, steps, activities, and workspace origin a stable skeleton while still preserving the underlying loop transcript and blobs.
-- **Seeded workflows as load-bearing contracts.** The shipped jobs from [T20260419-0622-3] and [T20260419-0623] are not toy examples; they are how the control-flow substrate proves itself against real Orbit work.
+- **A two-layer audit tree tied to repo provenance.** The v2 envelope gives runs, steps, activities, and workspace origin a stable skeleton while still preserving the underlying loop transcript and blobs.
+- **Seeded workflows as load-bearing contracts.** The shipped jobs are not toy examples; they are how the control-flow substrate proves itself against real Orbit work.
 
 None of these are research contributions. Activity / Job earns its keep only if it stays understandable, local, and inspectable while the product evolves.
 
@@ -121,17 +121,17 @@ None of these are research contributions. Activity / Job earns its keep only if 
 
 ## Task References
 
-- **[T20260418-2010]** — Add the first v2 activity runtime scaffolding.
-- **[T20260418-2018]** — Add `JobV2` DAG constructs (`parallel`, `fan_out`, `loop`, `retry`, `when`).
-- **[T20260418-2019]** — Add v2 activity name resolution and pipeline skeleton assets.
-- **[T20260418-2143]** — Wire `V2RuntimeHost` in orbit-core and add `orbit activity run-v2`.
-- **[T20260418-2210]** — Reshape `V2RuntimeHost` to keep `orbit-agent` types out of orbit-core.
-- **[T20260419-0002]** — Add `workspace_path` provenance to the v2 audit envelope.
-- **[T20260419-0104]** — Add `backend: cli` dispatch for v2 `agent_loop`.
-- **[T20260419-0622-3]** — Add `task_gate_pipeline`.
-- **[T20260419-0623]** — Add `task_auto_pipeline`.
-- **[T20260419-2156]** — Retire v1 assets and drop the transitional v2 naming.
-- **[T20260419-2347]** — Seed activities and workflows on `orbit init`.
+- Add the first v2 activity runtime scaffolding.
+- Add `JobV2` DAG constructs (`parallel`, `fan_out`, `loop`, `retry`, `when`).
+- Add v2 activity name resolution and pipeline skeleton assets.
+- Wire `V2RuntimeHost` in orbit-core and add `orbit activity run-v2`.
+- Reshape `V2RuntimeHost` to keep `orbit-agent` types out of orbit-core.
+- Add `workspace_path` provenance to the v2 audit envelope.
+- Add `backend: cli` dispatch for v2 `agent_loop`.
+- Add `task_gate_pipeline`.
+- Add `task_auto_pipeline`.
+- Retire v1 assets and drop the transitional v2 naming.
+- Seed activities and workflows on `orbit init`.
 - **[T20260430-19]** — Shorten the Activity / Job design docs while preserving required structure.
 - **[ORB-10332]** — Remove the unused Groundhog activity kind and the epic/parallel pipeline layer.
 

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -20,7 +20,7 @@ The log now keeps four load-bearing rollup ADR bodies. Folded entries remain at 
 
 ## ADR-001 — Canonical v2 assets normalize into one execution contract
 
-**Status:** Accepted · 2026-05 · [T20260419-2156], [T20260418-2143], [T20260419-0104], [T20260418-2019], [T20260423-0445], [T20260425-0204], [T20260419-2347], [T20260426-0047], [T20260428-8], [T20260506-18]
+**Status:** Accepted · 2026-05 · [T20260428-8], [T20260506-18]
 
 **Context.** Activity/job correctness depends on making authoring conveniences disappear before execution. The old log carried separate ADRs for schema retirement, backend resolution, target refs, defaults, catalog precedence, seeded assets, and workflow admission, but all enforce the same boundary: YAML is human-authored input, while execution sees normalized, validated runtime state.
 
@@ -54,7 +54,7 @@ Folded instances:
 
 ## ADR-002 — Host boundaries and agent dispatch stay explicit
 
-**Status:** Accepted · 2026-05 · [T20260419-2014], [T20260418-2210], [T20260419-0104], [T20260423-0114], [T20260427-48], [T20260430-15], [T20260418-2018], [T20260419-0623-2], [T20260420-0510-2], [T20260428-9], [T20260428-12], [T20260506-16], [T20260506-17], [T20260505-22], [T20260506-18], [ORB-10393]
+**Status:** Accepted · 2026-05 · [T20260427-48], [T20260430-15], [T20260428-9], [T20260428-12], [T20260506-16], [T20260506-17], [T20260505-22], [T20260506-18], [ORB-10393]
 
 **Context.** The agent-loop path is where activity/job can most easily leak provider implementation details, mutable sessions, or role configuration across crate boundaries. The split ADRs all defended the same shape: shared types live low, orbit-core hosts primitive services, the engine dispatches concrete activity specs, and provider/backends remain explicit choices.
 
@@ -106,31 +106,31 @@ Folded instances:
 
 ## ADR-003 — Resolve `backend: auto` once, before dispatch
 
-**Status:** Superseded by ADR-001 (folded) · 2026-04 · [T20260418-2143], [T20260419-0104]
+**Status:** Superseded by ADR-001 (folded) · 2026-04
 
 Folded into ADR-001's rollup for canonical v2 asset normalization.
 
 ## ADR-004 — `target: activity:<name>` is authoring sugar, not an execution primitive
 
-**Status:** Superseded by ADR-001 (folded) · 2026-04 · [T20260418-2019]
+**Status:** Superseded by ADR-001 (folded) · 2026-04
 
 Folded into ADR-001's rollup for canonical v2 asset normalization.
 
 ## ADR-005 — Cross-iteration `session:` binding is a loop-scoped HTTP-only feature
 
-**Status:** Superseded by ADR-002 (folded) · 2026-04 · [T20260418-2018], [T20260419-0104], [T20260419-0623-2]
+**Status:** Superseded by ADR-002 (folded) · 2026-04
 
 Folded into ADR-002's rollup for explicit agent dispatch boundaries.
 
 ## ADR-006 — Keep the retained CLI runtimes as the implementation of `backend: cli`
 
-**Status:** Superseded by ADR-002 (folded) · 2026-04 · [T20260419-0104], [T20260418-2210]
+**Status:** Superseded by ADR-002 (folded) · 2026-04
 
 Folded into ADR-002's rollup for explicit agent dispatch boundaries.
 
 ## ADR-007 — Run state, audit, and operator inspection are durable layers
 
-**Status:** Accepted · 2026-05 · [T20260419-0002], [T20260423-0447], [T20260423-2004-4], [T20260426-0526], [T20260426-0519], [T20260426-0705], [T20260426-0709], [T20260425-2010], [T20260426-0742], [T20260426-2313], [T20260426-2349], [T20260430-31], [T20260505-8], [T20260506-18]
+**Status:** Accepted · 2026-05 · [T20260430-31], [T20260505-8], [T20260506-18]
 
 **Context.** Activity/job execution produces operator evidence at several layers: audit envelopes, job-run records, metrics, live traces, retained blobs, run-inspection commands, PR handoff summaries, and cancellation state. The separate ADRs all instantiate the same rule: runtime output is durable workflow state, not process stdout or live assets pretending to be history.
 
@@ -170,13 +170,13 @@ Folded instances:
 
 ## ADR-008 — Seed reference activities and jobs as load-bearing runtime contracts
 
-**Status:** Superseded by ADR-001 (folded) · 2026-04 · [T20260419-2347], [T20260419-0622-3], [T20260419-0623], [T20260419-0623-2]
+**Status:** Superseded by ADR-001 (folded) · 2026-04
 
 Folded into ADR-001's rollup for canonical v2 asset normalization.
 
 ## ADR-009 — Groundhog is a sibling activity kind, not an `agent_loop` mode bit
 
-**Status:** Superseded by ADR-002 (folded) · 2026-04 · [T20260420-0510-2]
+**Status:** Superseded by ADR-002 (folded) · 2026-04
 
 Folded into ADR-002's rollup for explicit agent dispatch boundaries.
 
@@ -184,85 +184,85 @@ Folded into ADR-002's rollup for explicit agent dispatch boundaries.
 
 ## ADR-010 — Historical workflow inspection must not depend on live seeded job assets
 
-**Status:** Superseded by ADR-007 (folded) · 2026-04 · [T20260423-0447]
+**Status:** Superseded by ADR-007 (folded) · 2026-04
 
 Folded into ADR-007's rollup for durable run state and operator inspection.
 
 ## ADR-011 — Merge object-valued job defaults with caller input, and surface early pipeline failures as synthetic job steps
 
-**Status:** Superseded by ADR-001 (folded) · 2026-04 · [T20260423-0445]
+**Status:** Superseded by ADR-001 (folded) · 2026-04
 
 Folded into ADR-001's rollup for canonical v2 asset normalization.
 
 ## ADR-012 — Direct v2 job runs are durable job runs, not audit-only executions
 
-**Status:** Superseded by ADR-007 (folded) · 2026-04 · [T20260423-2004-4]
+**Status:** Superseded by ADR-007 (folded) · 2026-04
 
 Folded into ADR-007's rollup for durable run state and operator inspection.
 
 ## ADR-013 — Job catalog discovery honors layer precedence
 
-**Status:** Superseded by ADR-001 (folded) · 2026-04 · [T20260425-0204]
+**Status:** Superseded by ADR-001 (folded) · 2026-04
 
 Folded into ADR-001's rollup for canonical v2 asset normalization.
 
 ## ADR-014 — Public run workflows are execution aliases only
 
-**Status:** Superseded by ADR-023 (folded) · 2026-04 · [T20260425-2010]
+**Status:** Superseded by ADR-023 (folded) · 2026-04
 
 Folded into ADR-023's rollup for seeded task-shipment workflow automation.
 
 ## ADR-015 — CLI backend resolves executor args, not just provider commands
 
-**Status:** Superseded by ADR-002 (folded) · 2026-04 · [T20260423-0114]
+**Status:** Superseded by ADR-002 (folded) · 2026-04
 
 Folded into ADR-002's rollup for explicit agent dispatch boundaries.
 
 ## ADR-016 — Activity catalogs honor layer precedence and activity execution stays job-owned
 
-**Status:** Superseded by ADR-001 (folded) · 2026-04 · [T20260426-0047]
+**Status:** Superseded by ADR-001 (folded) · 2026-04
 
 Folded into ADR-001's rollup for canonical v2 asset normalization.
 
 ## ADR-017 — V2 job metrics persist invocation traces beside audit
 
-**Status:** Superseded by ADR-007 (folded) · 2026-04 · [T20260426-0526]
+**Status:** Superseded by ADR-007 (folded) · 2026-04
 
 Folded into ADR-007's rollup for durable run state and operator inspection.
 
 ## ADR-018 — File-backed run traces live under workspace state
 
-**Status:** Superseded by ADR-007 (folded) · 2026-04 · [T20260426-0519]
+**Status:** Superseded by ADR-007 (folded) · 2026-04
 
 Folded into ADR-007's rollup for durable run state and operator inspection.
 
 ## ADR-019 — Run inspection reads v2 traces through runtime accessors
 
-**Status:** Superseded by ADR-007 (folded) · 2026-04 · [T20260426-0705], [T20260426-0709]
+**Status:** Superseded by ADR-007 (folded) · 2026-04
 
 Folded into ADR-007's rollup for durable run state and operator inspection.
 
 ## ADR-020 — Run inspection belongs to `orbit run`
 
-**Status:** Superseded by ADR-007 (folded) · 2026-04 · [T20260426-0742]
+**Status:** Superseded by ADR-007 (folded) · 2026-04
 
 Folded into ADR-007's rollup for durable run state and operator inspection.
 
 ## ADR-021 — CLI subprocess output is a live tracing stream and a retained audit blob
 
-**Status:** Superseded by ADR-007 (folded) · 2026-04 · [T20260426-2313]
+**Status:** Superseded by ADR-007 (folded) · 2026-04
 
 Folded into ADR-007's rollup for durable run state and operator inspection.
 
 ## ADR-022 — CLI output redaction belongs to the tracing subscriber
 
-**Status:** Superseded by ADR-007 (folded) · 2026-04 · [T20260426-2349]
+**Status:** Superseded by ADR-007 (folded) · 2026-04
 
 Folded into ADR-007's rollup for durable run state and operator inspection.
 
 ## ADR-023 — Seeded task-shipment workflows are deterministic, recoverable, and lock-aware
 
-**Status:** Accepted · 2026-05 · [T20260427-33], [T20260425-2010], [T20260427-45], [T20260430-9], [T20260430-12], [T20260430-14], [T20260421-0542-2], [T20260430-27], [T20260430-30], [T20260430-26], [T20260427-34], [T20260427-36], [T20260505-2], [T20260505-10], [T20260506-18], [T20260509-14]
+**Status:** Accepted · 2026-05 · [T20260427-33], [T20260427-45], [T20260430-9], [T20260430-12], [T20260430-14], [T20260430-27], [T20260430-30], [T20260430-26], [T20260427-34], [T20260427-36], [T20260505-2], [T20260505-10], [T20260506-18], [T20260509-14]
 
 **Context.** The seeded task workflows added many small ADRs as shipment behavior grew: run aliases, deterministic auto-dispatch, remote base selection, recovery hooks, backlog exclusions, operator status, and lock cleanup. They are one decision family: task shipment is an explicit durable workflow, not an advisory agent step or hidden side effect.
 
@@ -358,7 +358,7 @@ Folded into ADR-002's rollup for explicit agent dispatch boundaries.
 
 ## ADR-033 — Auto-backlog lock exclusions are structured output
 
-**Status:** Superseded by ADR-023 (folded) · 2026-04 · [T20260421-0542-2]
+**Status:** Superseded by ADR-023 (folded) · 2026-04
 
 Folded into ADR-023's rollup for seeded task-shipment workflow automation.
 
@@ -733,34 +733,34 @@ Commits found above the pinned base are adopted with a loud `warn` naming the sh
   assets with per-slot model overrides and retire `RuntimeHost::invoke_activity`.
 - **[ORB-10385]** — Gate job admission on the runtime's deterministic-action registry; register `pr_failure_handoff` and `worktree_gc`.
 - **[ORB-10380]** — Pin `base_sha` from `worktree_setup` through `git_commit`; split the commit step's failure diagnostics.
-- **[T20260418-2018]** — Add `JobV2` DAG constructs (`parallel`, `fan_out`, `loop`, `retry`, `when`).
-- **[T20260418-2019]** — Add v2 activity name resolution and pipeline skeleton assets.
-- **[T20260418-2143]** — Wire `V2RuntimeHost` in orbit-core and add `orbit activity run-v2`.
-- **[T20260418-2210]** — Reshape `V2RuntimeHost` to keep `orbit-agent` types out of orbit-core.
-- **[T20260419-0002]** — Add `workspace_path` provenance to the v2 audit envelope.
-- **[T20260419-0104]** — Add `backend: cli` dispatch for v2 `agent_loop`.
-- **[T20260419-0622-3]** — Add `task_gate_pipeline`.
-- **[T20260419-0623]** — Add `task_auto_pipeline`.
-- **[T20260419-0623-2]** — Add `task_epic_pipeline` (surface later removed in [ORB-10332]).
-- **[T20260419-2014]** — Merge `orbit-types` into `orbit-common`.
-- **[T20260419-2156]** — Retire v1 assets and drop the transitional v2 naming.
-- **[T20260419-2347]** — Seed activities and workflows on `orbit init`.
-- **[T20260420-0510-2]** — Add the Groundhog v1 activity runner (kind later removed in [ORB-10332]).
-- **[T20260421-0542-2]** — Add structured `list_backlog_tasks` output for context-lock exclusions.
-- **[T20260423-0114]** — Expose the `backend: cli` executor-args gap during a local task ship run.
-- **[T20260423-0445]** — Merge object-valued job defaults over explicit run input and persist synthetic failed job steps for early v2 pipeline failures.
-- **[T20260423-0447]** — Restore usable `orbit run duel` read-only surfaces after duel workflow retirement.
-- **[T20260423-2004-4]** — Persist direct v2 `orbit job run` executions into durable job-run records and state.
-- **[T20260425-0204]** — Make v2 job catalog discovery honor workspace-over-global `MergeByKey` precedence.
-- **[T20260425-2010]** — Refactor `orbit run` task workflow commands and revive `duel-plan` as a seeded run workflow.
-- **[T20260426-0047]** — Make v2 activity catalog discovery honor workspace-over-global `MergeByKey` precedence and remove the public `orbit activity run` command.
-- **[T20260426-0526]** — Restore v2 job invocation trace persistence so dashboard metrics surfaces can report agent and tool usage.
-- **[T20260426-0519]** — Move file-backed activity/job audit traces under `.orbit/state/audit`.
-- **[T20260426-0705]** — Expose v2 run audit events through `orbit run events` and `orbit run trace`.
-- **[T20260426-0709]** — Align run step selectors on activity `step.id` and move CLI invocation log reading behind orbit-core runtime accessors.
-- **[T20260426-0742]** — Remove duplicate job-level run inspection aliases and keep run inspection under `orbit run`.
-- **[T20260426-2313]** — Stream CLI subprocess stdout/stderr through structured tracing events while retaining the existing audit/blob path.
-- **[T20260426-2349]** — Move CLI tracing output redaction from `cli_runner` call sites into the default tracing formatter layer.
+- Add `JobV2` DAG constructs (`parallel`, `fan_out`, `loop`, `retry`, `when`).
+- Add v2 activity name resolution and pipeline skeleton assets.
+- Wire `V2RuntimeHost` in orbit-core and add `orbit activity run-v2`.
+- Reshape `V2RuntimeHost` to keep `orbit-agent` types out of orbit-core.
+- Add `workspace_path` provenance to the v2 audit envelope.
+- Add `backend: cli` dispatch for v2 `agent_loop`.
+- Add `task_gate_pipeline`.
+- Add `task_auto_pipeline`.
+- Add `task_epic_pipeline` (surface later removed in [ORB-10332]).
+- Merge `orbit-types` into `orbit-common`.
+- Retire v1 assets and drop the transitional v2 naming.
+- Seed activities and workflows on `orbit init`.
+- Add the Groundhog v1 activity runner (kind later removed in [ORB-10332]).
+- Add structured `list_backlog_tasks` output for context-lock exclusions.
+- Expose the `backend: cli` executor-args gap during a local task ship run.
+- Merge object-valued job defaults over explicit run input and persist synthetic failed job steps for early v2 pipeline failures.
+- Restore usable `orbit run duel` read-only surfaces after duel workflow retirement.
+- Persist direct v2 `orbit job run` executions into durable job-run records and state.
+- Make v2 job catalog discovery honor workspace-over-global `MergeByKey` precedence.
+- Refactor `orbit run` task workflow commands and revive `duel-plan` as a seeded run workflow.
+- Make v2 activity catalog discovery honor workspace-over-global `MergeByKey` precedence and remove the public `orbit activity run` command.
+- Restore v2 job invocation trace persistence so dashboard metrics surfaces can report agent and tool usage.
+- Move file-backed activity/job audit traces under `.orbit/state/audit`.
+- Expose v2 run audit events through `orbit run events` and `orbit run trace`.
+- Align run step selectors on activity `step.id` and move CLI invocation log reading behind orbit-core runtime accessors.
+- Remove duplicate job-level run inspection aliases and keep run inspection under `orbit run`.
+- Stream CLI subprocess stdout/stderr through structured tracing events while retaining the existing audit/blob path.
+- Move CLI tracing output redaction from `cli_runner` call sites into the default tracing formatter layer.
 - **[T20260427-33]** — Remove the audit-only `dispatch_agent` step from `task_auto_pipeline`.
 - **[T20260427-34]** — Add seeded pipeline success guards so non-succeeded child runs fail parent shipment workflows.
 - **[T20260427-36]** — Align task-gate reservation TTL with the child dispatch wait budget.

--- a/docs/design/activity-job/specs/audit-envelope.md
+++ b/docs/design/activity-job/specs/audit-envelope.md
@@ -61,7 +61,7 @@ The v2 writer may also keep an in-memory snapshot for smoke assertions and CLI s
 
 `orbit run trace [run_id]` renders the `event_id` / `parent_event_id` tree. JSON mode returns deterministic `roots` and `orphans` arrays so partial traces remain inspectable instead of silently dropping events whose parent is absent.
 
-`orbit run logs` reads CLI stdout/stderr through the same runtime-owned envelope accessor rather than parsing the file layout in the CLI command module. `orbit run show -s <id>` treats the activity DAG `step.id` from `step.started` events as the primary step identifier, with legacy job-run target IDs and numeric step indexes retained as fallbacks. This inspection surface landed in [T20260426-0705] and [T20260426-0709].
+`orbit run logs` reads CLI stdout/stderr through the same runtime-owned envelope accessor rather than parsing the file layout in the CLI command module. `orbit run show -s <id>` treats the activity DAG `step.id` from `step.started` events as the primary step identifier, with legacy job-run target IDs and numeric step indexes retained as fallbacks. This inspection surface landed.
 
 ## Invariants
 
@@ -81,7 +81,7 @@ The v2 writer may also keep an in-memory snapshot for smoke assertions and CLI s
 
 - The envelope is additive. It does not retire or rewrite the existing loop-level audit sink.
 - CLI backend events are first-class envelope events, so CLI runs remain visible even when no HTTP transcript exists.
-- File-backed runtime traces moved from `.orbit/audit/` to `.orbit/state/audit/` in [T20260426-0519]. Existing `.orbit/audit/` files are legacy local artifacts rather than the current write target.
+- File-backed runtime traces moved from `.orbit/audit/` to `.orbit/state/audit/`. Existing `.orbit/audit/` files are legacy local artifacts rather than the current write target.
 
 ## Agent Signature
 

--- a/docs/design/auditability/1_overview.md
+++ b/docs/design/auditability/1_overview.md
@@ -20,7 +20,7 @@ Auditability is Orbit's answer to the operator question that matters after an ag
 
 Orbit runs fleets of agents against user-owned repositories, so auditability is a product feature rather than an observability afterthought:
 
-1. **Replayable accountability.** README and positioning docs promise enough context for every meaningful action to answer what, why, and who. The dedicated design folder from [T20260426-0605] keeps that promise reviewable.
+1. **Replayable accountability.** README and positioning docs promise enough context for every meaningful action to answer what, why, and who. The dedicated design folder keeps that promise reviewable.
 2. **Layered evidence.** A command row says which command ran. A v2 envelope says which workflow step ran. Loop events and blobs preserve provider/tool detail. The layers must remain related without becoming one oversized record.
 3. **Durable identity.** Task author fields, command audit roles, v2 `agent_identity`, invocation metrics, git commit identities, and commit/task metadata all need to point back to a concrete actor or model.
 4. **Write-side secrecy.** Orbit preserves useful payloads while redacting provider keys and sensitive environment-derived values before durable storage.
@@ -40,7 +40,7 @@ MCP audit keeps legacy meanings stable: `host` is still the executing-process ho
 
 ### 2.3 Activity/job run traces are file-backed JSONL trees
 
-The v2 activity/job runtime emits `V2AuditEvent` envelopes for run, step, activity, fan-out, loop, filesystem, denial, and CLI-backend lifecycle events under `.orbit/state/audit/v2_loop/`. This layer is the workflow replay spine: it carries `run_id`, `event_id`, `parent_event_id`, `agent_identity`, and optional `workspace_path`. `orbit run events`, `orbit run trace`, `orbit run show -s`, and `orbit run logs -s` expose the same activity DAG `step.id` source of truth after [T20260426-0705] and [T20260426-0709].
+The v2 activity/job runtime emits `V2AuditEvent` envelopes for run, step, activity, fan-out, loop, filesystem, denial, and CLI-backend lifecycle events under `.orbit/state/audit/v2_loop/`. This layer is the workflow replay spine: it carries `run_id`, `event_id`, `parent_event_id`, `agent_identity`, and optional `workspace_path`. `orbit run events`, `orbit run trace`, `orbit run show -s`, and `orbit run logs -s` expose the same activity DAG `step.id` source of truth.
 
 ### 2.4 Agent-loop audit events preserve provider and tool detail
 
@@ -48,7 +48,7 @@ The HTTP loop engine emits `LoopAuditEvent` records for sessions, HTTP requests/
 
 ### 2.5 Invocation metrics are adjacent, not a replacement
 
-The invocation store records token usage, tool-call counts, task IDs, agent, model, job run, and activity IDs for metrics and scoreboards. It helps answer cost and usage questions, but it summarizes rather than preserves transcript structure. V2 job metrics began persisting beside audit in [T20260426-0526].
+The invocation store records token usage, tool-call counts, task IDs, agent, model, job run, and activity IDs for metrics and scoreboards. It helps answer cost and usage questions, but it summarizes rather than preserves transcript structure. V2 job metrics began persisting beside audit.
 
 ### 2.6 Redaction happens before durable payload storage
 
@@ -56,7 +56,7 @@ Blob writes apply pattern-based redaction at write time, and CLI error audit pat
 
 ### 2.7 Process tracing has a global JSONL feed
 
-The default tracing subscriber appends redacted structured events to `~/.orbit/state/logs/orbit.jsonl` after [T20260426-2343] and [T20260426-2349]. The feed is global because logging initializes before workspace resolution. After [T20260427-0023], filesystem policy denials, proc-spawn allowlist denials, and friction record submissions also project stable `tracing::warn!` events beside their canonical stores. First-class friction artifacts now live under `.orbit/frictions/` and surface in `Knowledge > Frictions` for scan and triage without re-entering the task lifecycle.
+The default tracing subscriber appends redacted structured events to `~/.orbit/state/logs/orbit.jsonl`. The feed is global because logging initializes before workspace resolution. Filesystem policy denials, proc-spawn allowlist denials, and friction record submissions also project stable `tracing::warn!` events beside their canonical stores. First-class friction artifacts now live under `.orbit/frictions/` and surface in `Knowledge > Frictions` for scan and triage without re-entering the task lifecycle.
 
 ---
 
@@ -64,32 +64,32 @@ The default tracing subscriber appends redacted structured events to `~/.orbit/s
 
 | Concern | Where it lives | Primary task ID |
 |---------|----------------|-----------------|
-| Audit design ownership | `docs/design/auditability/` | [T20260426-0605] |
-| Command audit records and queries | `crates/orbit-common/src/types/audit_event.rs`, `crates/orbit-cli/src/command/audit/`, `crates/orbit-store/src/sqlite/audit_event_store/` | [T20260426-0605] |
+| Audit design ownership | `docs/design/auditability/` |  |
+| Command audit records and queries | `crates/orbit-common/src/types/audit_event.rs`, `crates/orbit-cli/src/command/audit/`, `crates/orbit-store/src/sqlite/audit_event_store/` |  |
 | Remote MCP preflight, placement denials, and checkoutless global audit writes | `crates/orbit-remote/src/mcp/host.rs`, `crates/orbit-remote/src/lib.rs` | [ORB-10228], [ORB-10262], [ORB-10319] |
-| V2 activity/job envelopes and JSONL sink | `crates/orbit-common/src/types/activity_job/audit_envelope.rs`, `crates/orbit-engine/src/activity_job/audit_writer.rs` | [T20260419-0002], [T20260426-0519] |
-| Run trace inspection CLI | `crates/orbit-cli/src/command/run/mod.rs`, `crates/orbit-core/src/runtime/run_audit.rs` | [T20260426-0705], [T20260426-0709] |
-| Loop audit events and blobs | `crates/orbit-agent/src/loop_engine/audit/mod.rs`, `crates/orbit-common/src/utility/blob_store.rs` | [T20260426-0605] |
-| Redaction utilities | `crates/orbit-common/src/utility/redaction.rs` | [T20260426-0605], [T20260426-2349] |
-| Global tracing JSONL feed and live projections | `crates/orbit-common/src/utility/logging.rs`, selected FS/proc/task producers | [T20260426-2343], [T20260427-0023] |
+| V2 activity/job envelopes and JSONL sink | `crates/orbit-common/src/types/activity_job/audit_envelope.rs`, `crates/orbit-engine/src/activity_job/audit_writer.rs` | |
+| Run trace inspection CLI | `crates/orbit-cli/src/command/run/mod.rs`, `crates/orbit-core/src/runtime/run_audit.rs` | |
+| Loop audit events and blobs | `crates/orbit-agent/src/loop_engine/audit/mod.rs`, `crates/orbit-common/src/utility/blob_store.rs` |  |
+| Redaction utilities | `crates/orbit-common/src/utility/redaction.rs` | |
+| Global tracing JSONL feed and live projections | `crates/orbit-common/src/utility/logging.rs`, selected FS/proc/task producers | |
 | Friction artifact feedback loop | `.orbit/frictions/`, `crates/orbit-store/src/file/friction_store/`, `crates/orbit-dashboard/src/api/frictions.rs` | [T20260510-13], [ORB-00062] |
-| V2 invocation metrics persistence | `crates/orbit-store/src/sqlite/invocation_store.rs`, `crates/orbit-core/src/runtime/v2_host/mod.rs` | [T20260426-0526] |
-| Task attribution fields | `crates/orbit-common/src/types/task.rs`, task update/runtime host paths | [T20260426-0605], [T20260427-47] |
+| V2 invocation metrics persistence | `crates/orbit-store/src/sqlite/invocation_store.rs`, `crates/orbit-core/src/runtime/v2_host/mod.rs` |  |
+| Task attribution fields | `crates/orbit-common/src/types/task.rs`, task update/runtime host paths | [T20260427-47] |
 | Workflow git commit identity attribution | `crates/orbit-engine/src/executor/automation/vcs/commit/` | [T20260508-22], [T20260509-12] |
 
 ---
 
 ## Task References
 
-- **[T20260419-0002]** — Add workspace provenance and v2 audit envelope events for activity/job execution.
-- **[T20260426-0519]** — Move file-backed activity/job audit traces under workspace state.
-- **[T20260426-0526]** — Persist v2 invocation traces for metrics beside audit.
-- **[T20260426-0605]** — Add this auditability design folder and establish codex ownership.
-- **[T20260426-0705]** — Expose v2 run audit events through `orbit run events` and `orbit run trace`.
-- **[T20260426-0709]** — Align run step selectors on activity `step.id` and move CLI invocation log reading behind orbit-core runtime accessors.
-- **[T20260426-2343]** — Add the global process tracing JSONL feed at `~/.orbit/state/logs/orbit.jsonl`.
-- **[T20260426-2349]** — Apply tracing-layer redaction before stderr and global JSONL output.
-- **[T20260427-0023]** — Project policy denials and friction task submissions into the global tracing feed.
+- Add workspace provenance and v2 audit envelope events for activity/job execution.
+- Move file-backed activity/job audit traces under workspace state.
+- Persist v2 invocation traces for metrics beside audit.
+- Add this auditability design folder and establish codex ownership.
+- Expose v2 run audit events through `orbit run events` and `orbit run trace`.
+- Align run step selectors on activity `step.id` and move CLI invocation log reading behind orbit-core runtime accessors.
+- Add the global process tracing JSONL feed at `~/.orbit/state/logs/orbit.jsonl`.
+- Apply tracing-layer redaction before stderr and global JSONL output.
+- Project policy denials and friction task submissions into the global tracing feed.
 - **[T20260427-47]** — Allow explicit task attribution correction for `planned_by` and `implemented_by` through task update paths.
 - **[T20260430-20]** — Shorten the auditability docs while preserving required guarantees.
 - **[T20260506-2]** — Lazily materialize loop audit JSONL files only when loop-level events are emitted.

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -26,7 +26,7 @@ Auditability is split across five channels:
 4. **Global tracing events.** Redacted JSONL under `~/.orbit/state/logs/orbit.jsonl`.
 5. **Invocation metrics.** SQLite records keyed by job run, activity, task, agent, model, usage, and tool-call summaries.
 
-The split is deliberate: command rows stay compact and queryable; envelopes preserve workflow structure; loop audit preserves provider/tool detail; tracing gives operators a live feed before workspace context exists; metrics answer cost and scoreboard questions without scraping transcripts. [T20260426-0519] moved file-backed run traces under `.orbit/state/audit/` while command audit rows remained in SQLite.
+The split is deliberate: command rows stay compact and queryable; envelopes preserve workflow structure; loop audit preserves provider/tool detail; tracing gives operators a live feed before workspace context exists; metrics answer cost and scoreboard questions without scraping transcripts. File-backed run traces live under `.orbit/state/audit/` while command audit rows remain in SQLite.
 
 ---
 
@@ -61,7 +61,7 @@ Some runtime paths write targeted command-audit rows directly:
 
 These producers share the SQLite schema and must preserve the same status, target, actor, and redaction expectations as CLI rows. Prescriptive coverage expectations live in [specs/coverage-matrix.md](./specs/coverage-matrix.md).
 
-After [T20260427-0023], selected canonical stores also project live tracing events: filesystem policy denials still write FS audit events, proc-spawn allowlist denials still return `OrbitError::PolicyDenied`, and each path also emits a redacted `orbit.policy.deny` event. Friction reports are records under `.orbit/frictions/` via [T20260510-13], not task lifecycle events or precomputed scoreboard updates; [ORB-00062] adds explicit record triage metadata (`open`, `triaged`, `resolved`) and dashboard/API mutation surfaces for status and tags.
+Selected canonical stores also project live tracing events: filesystem policy denials still write FS audit events, proc-spawn allowlist denials still return `OrbitError::PolicyDenied`, and each path also emits a redacted `orbit.policy.deny` event. Friction reports are records under `.orbit/frictions/`, not task lifecycle events or precomputed scoreboard updates; [ORB-00062] adds explicit record triage metadata (`open`, `triaged`, `resolved`) and dashboard/API mutation surfaces for status and tags.
 
 ---
 
@@ -71,7 +71,7 @@ After [T20260427-0023], selected canonical stores also project live tracing even
 
 `V2AuditWriter` in `crates/orbit-engine/src/activity_job/audit_writer.rs` assigns event ids, maintains per-thread parent stacks, emits through `V2JsonlSink`, keeps a smoke-verification snapshot, and exposes the inner loop sink for provider/tool events. CLI-launched v2 runs stamp envelope `agent_identity` as `system`; concrete agent identity lives in activity configuration, CLI invocation events, and invocation metrics.
 
-`crates/orbit-engine/src/activity_job/jsonl_sink.rs` appends one JSON object per line under `v2_loop/` and flushes per write. `crates/orbit-core/src/runtime/run_audit.rs` is the read-side accessor after [T20260426-0709], deriving activity DAG `step.id` values from `parent_event_id` ancestry and resolving CLI stdout/stderr blob references for `orbit run logs`. After [T20260508-14], the same accessor tolerates malformed read-side JSONL lines and missing blobs for dashboard inspection, returning partial per-step CLI invocation records with run id, event id, timestamp, step index, exit status, timeout, duration, provider, blob refs, and bounded stdout/stderr material.
+`crates/orbit-engine/src/activity_job/jsonl_sink.rs` appends one JSON object per line under `v2_loop/` and flushes per write. `crates/orbit-core/src/runtime/run_audit.rs` is the read-side accessor, deriving activity DAG `step.id` values from `parent_event_id` ancestry and resolving CLI stdout/stderr blob references for `orbit run logs`. After [T20260508-14], the same accessor tolerates malformed read-side JSONL lines and missing blobs for dashboard inspection, returning partial per-step CLI invocation records with run id, event id, timestamp, step index, exit status, timeout, duration, provider, blob refs, and bounded stdout/stderr material.
 
 ---
 
@@ -136,9 +136,9 @@ After [T20260510-13] and [ORB-00062], friction reporting is outside the task lif
 
 ## 9. Global Process Tracing JSONL
 
-`crates/orbit-common/src/utility/logging.rs` installs a default subscriber with one `EnvFilter`, stderr formatting, and an optional non-blocking JSONL file layer at `~/.orbit/state/logs/orbit.jsonl` after [T20260426-2343]. The retained `WorkerGuard` lets routine event emission avoid synchronous disk writes.
+`crates/orbit-common/src/utility/logging.rs` installs a default subscriber with one `EnvFilter`, stderr formatting, and an optional non-blocking JSONL file layer at `~/.orbit/state/logs/orbit.jsonl`. The retained `WorkerGuard` lets routine event emission avoid synchronous disk writes.
 
-Each record contains timestamp, level, target, and structured fields. After [T20260426-2349], both stderr and JSONL use `RedactingFields`, which scrubs string values, `Debug`-formatted values, and unstructured messages while preserving numeric and boolean JSON types. This global feed is the live landing zone for subprocess output [T20260426-2313], policy-denial and friction projections [T20260427-0023], and other `tracing` events emitted before workspace runtime context exists. After [T20260508-8], CLI subprocess line events include `cwd` when Activity/Job resolved one, matching the audit-started event while omitting the field when the child inherits the parent cwd. It is operational telemetry, not the canonical workflow envelope.
+Each record contains timestamp, level, target, and structured fields. Both stderr and JSONL use `RedactingFields`, which scrubs string values, `Debug`-formatted values, and unstructured messages while preserving numeric and boolean JSON types. This global feed is the live landing zone for subprocess output, policy-denial and friction projections, and other `tracing` events emitted before workspace runtime context exists. After [T20260508-8], CLI subprocess line events include `cwd` when Activity/Job resolved one, matching the audit-started event while omitting the field when the child inherits the parent cwd. It is operational telemetry, not the canonical workflow envelope.
 
 ---
 
@@ -157,17 +157,17 @@ Each record contains timestamp, level, target, and structured fields. After [T20
 
 ## Task References
 
-- **[T20260419-0002]** — Add workspace provenance and v2 audit envelope events for activity/job execution.
-- **[T20260426-0519]** — Move file-backed activity/job audit traces under workspace state.
-- **[T20260426-0526]** — Persist v2 invocation traces for metrics beside audit.
-- **[T20260426-0605]** — Add this auditability design folder and document the current audit architecture.
-- **[T20260426-0705]** — Expose v2 run audit events through `orbit run events` and `orbit run trace`.
-- **[T20260426-0709]** — Align run step selectors on activity `step.id` and move CLI invocation log reading behind orbit-core runtime accessors.
-- **[T20260426-0742]** — Remove duplicate job-level run inspection aliases and keep run inspection under `orbit run`.
-- **[T20260426-2313]** — Stream CLI subprocess stdout/stderr through structured tracing events while retaining the existing audit/blob path.
-- **[T20260426-2343]** — Add the global process tracing JSONL feed at `~/.orbit/state/logs/orbit.jsonl`.
-- **[T20260426-2349]** — Apply tracing-layer redaction before stderr and global JSONL output.
-- **[T20260427-0023]** — Project policy denials and friction task submissions into the global tracing feed.
+- Add workspace provenance and v2 audit envelope events for activity/job execution.
+- Move file-backed activity/job audit traces under workspace state.
+- Persist v2 invocation traces for metrics beside audit.
+- Add this auditability design folder and document the current audit architecture.
+- Expose v2 run audit events through `orbit run events` and `orbit run trace`.
+- Align run step selectors on activity `step.id` and move CLI invocation log reading behind orbit-core runtime accessors.
+- Remove duplicate job-level run inspection aliases and keep run inspection under `orbit run`.
+- Stream CLI subprocess stdout/stderr through structured tracing events while retaining the existing audit/blob path.
+- Add the global process tracing JSONL feed at `~/.orbit/state/logs/orbit.jsonl`.
+- Apply tracing-layer redaction before stderr and global JSONL output.
+- Project policy denials and friction task submissions into the global tracing feed.
 - **[T20260427-43]** — Superseded friction lifecycle scoring with `status: friction` and history-derived counters.
 - **[T20260427-47]** — Allow explicit task attribution correction for `planned_by` and `implemented_by` through task update paths.
 - **[T20260428-4]** — Move tool-invocation audit ownership into the runtime, add the `ToolEntryPoint` discriminator, bracket MCP preflight + dispatch, and deduplicate CLI guard rows.

--- a/docs/design/auditability/3_vision.md
+++ b/docs/design/auditability/3_vision.md
@@ -23,7 +23,7 @@ This document captures the questions that remain before Orbit's auditability sto
 3. **Auditing audit reads.** Should `orbit audit` reads, exports, and prunes remain outside the guard to avoid recursion, or be recorded through a separate path?
 4. **Stable identity across channels.** MCP now records trusted caller/process machine identity separately from managed agent identity; what joins those fields to human CLI usage, task attribution, v2 envelopes, metrics, commits, and PR metadata?
 5. **Stdout/stderr retention.** The command schema has truncated stdout/stderr fields, but most paths leave them empty. What retention policy should exist before broad capture?
-6. **JSONL migration.** [T20260426-0519] moved run traces to `.orbit/state/audit/`; should old `.orbit/audit/` files be migrated, ignored, or read through a legacy fallback?
+6. **JSONL migration.** Run traces now live under `.orbit/state/audit/`; should old `.orbit/audit/` files be migrated, ignored, or read through a legacy fallback?
 7. **Replay payload depth.** When are redacted verbatim prompts/responses required, and when are summaries enough?
 8. **Uniform denials.** Can filesystem denials, tool allowlist denials, task-lock conflicts, and gate starvation share one audit shape?
 9. **Coverage enforcement.** What lint or tests should fail review when a new mutation path lacks audit coverage?
@@ -91,10 +91,10 @@ External reference categories:
 
 ## Task References
 
-- **[T20260419-0002]** — Add workspace provenance and v2 audit envelope events for activity/job execution.
-- **[T20260426-0519]** — Move file-backed activity/job audit traces under workspace state.
-- **[T20260426-0526]** — Persist v2 invocation traces for metrics beside audit.
-- **[T20260426-0605]** — Add this auditability design folder and name future auditability questions.
+- Add workspace provenance and v2 audit envelope events for activity/job execution.
+- Move file-backed activity/job audit traces under workspace state.
+- Persist v2 invocation traces for metrics beside audit.
+- Add this auditability design folder and name future auditability questions.
 - **[T20260430-20]** — Shorten the auditability docs while preserving required guarantees.
 - **[ORB-00090]** — Aligned auditability identity wording with the family-as-identity convention.
 - **[ORB-10228]** — Established trusted MCP caller/process provenance and anti-spoofing.

--- a/docs/design/auditability/4_decisions.md
+++ b/docs/design/auditability/4_decisions.md
@@ -18,7 +18,7 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 
 ## ADR-001 — Dedicated auditability design ownership
 
-**Status:** Accepted · 2026-04 · [T20260426-0605]
+**Status:** Accepted · 2026-04
 
 **Context.** Auditability is a primary Orbit feature, but its implementation and rationale were spread across README prose, Activity / Job docs, SQLite audit code, loop audit code, and redaction utilities.
 
@@ -30,7 +30,7 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 
 ## ADR-002 — Command audit rows stay compact and queryable
 
-**Status:** Accepted · 2026-04 · [T20260426-0605]
+**Status:** Accepted · 2026-04
 
 **Context.** CLI commands need durable, filterable history across processes, but full provider payloads would make routine queries noisy and expensive.
 
@@ -42,7 +42,7 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 
 ## ADR-003 — V2 run structure and loop transcript detail are separate audit layers
 
-**Status:** Accepted · 2026-04 · [T20260419-0002]
+**Status:** Accepted · 2026-04
 
 **Context.** Activity/job execution needs run, step, retry, fan-out, loop, and activity structure. Provider loops need HTTP, tool-call, payload, and session detail.
 
@@ -54,7 +54,7 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 
 ## ADR-004 — File-backed run traces are workspace-local state
 
-**Status:** Accepted · 2026-04 · [T20260426-0519]
+**Status:** Accepted · 2026-04
 
 **Context.** V2 JSONL and blob traces are runtime artifacts, but their old first-level `.orbit/audit/` path blurred command audit, workspace state, and authored docs.
 
@@ -66,7 +66,7 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 
 ## ADR-005 — Redaction is a write-side durability boundary
 
-**Status:** Accepted · 2026-04 · [T20260426-0605]
+**Status:** Accepted · 2026-04
 
 **Context.** Audit needs useful payloads for reproducibility, but raw provider keys or sensitive environment-derived values would make the trail unsafe by default.
 
@@ -78,7 +78,7 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 
 ## ADR-006 — Invocation metrics are audit-adjacent primary records
 
-**Status:** Accepted · 2026-04 · [T20260426-0526]
+**Status:** Accepted · 2026-04
 
 **Context.** V2 job execution emits audit JSONL, but metrics and scoreboards read the invocation store. Scraping audit logs would couple reporting to transcript format and retention.
 
@@ -104,7 +104,7 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 
 ## ADR-007 — Run trace inspection stays separate from command audit
 
-**Status:** Accepted · 2026-04 · [T20260426-0705], [T20260426-0709]
+**Status:** Accepted · 2026-04
 
 **Context.** Operators need first-class commands for activity/job envelope JSONL, but `orbit audit` is the compact SQLite command-audit surface.
 
@@ -116,9 +116,9 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 
 ## ADR-008 — Process tracing feed is global JSONL
 
-**Status:** Accepted · 2026-04 · [T20260426-2343]
+**Status:** Accepted · 2026-04
 
-**Context.** CLI subprocess output emits structured tracing events after [T20260426-2313], but subscriber initialization happens before Orbit resolves a workspace root.
+**Context.** CLI subprocess output emits structured tracing events, but subscriber initialization happens before Orbit resolves a workspace root.
 
 **Decision.** Append process-level tracing events to `~/.orbit/state/logs/orbit.jsonl` through the default subscriber using the same `EnvFilter` as stderr and a retained non-blocking writer.
 
@@ -128,7 +128,7 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 
 ## ADR-009 — Tracing redaction is enforced by field formatting
 
-**Status:** Accepted · 2026-04 · [T20260426-2349]
+**Status:** Accepted · 2026-04
 
 **Context.** A durable JSONL feed made tracing output persistent, but call-site helpers only protected emitters that remembered to use them.
 
@@ -140,7 +140,7 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 
 ## ADR-010 — Canonical audit stores project high-signal events to tracing
 
-**Status:** Accepted · 2026-04 · [T20260427-0023]
+**Status:** Accepted · 2026-04
 
 **Context.** Policy denials and friction submissions reached canonical stores or return paths, but operators tailing the live feed could miss them.
 
@@ -380,17 +380,17 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 
 ## Task References
 
-- **[T20260419-0002]** — Add workspace provenance and v2 audit envelope events for activity/job execution.
-- **[T20260426-0519]** — Move file-backed activity/job audit traces under workspace state.
-- **[T20260426-0526]** — Persist v2 invocation traces for metrics beside audit.
+- Add workspace provenance and v2 audit envelope events for activity/job execution.
+- Move file-backed activity/job audit traces under workspace state.
+- Persist v2 invocation traces for metrics beside audit.
 - **[ORB-00190]** — Retire the metrics CLI and make dashboard endpoints canonical for invocation metrics.
-- **[T20260426-0605]** — Add this auditability design folder and record initial ADRs.
-- **[T20260426-0705]** — Expose v2 run audit events through `orbit run events` and `orbit run trace`.
-- **[T20260426-0709]** — Align run step selectors on activity `step.id` and move CLI invocation log reading behind orbit-core runtime accessors.
-- **[T20260426-2313]** — Stream CLI subprocess stdout/stderr through structured tracing events.
-- **[T20260426-2343]** — Add the global process tracing JSONL feed at `~/.orbit/state/logs/orbit.jsonl`.
-- **[T20260426-2349]** — Apply tracing-layer redaction before stderr and global JSONL output.
-- **[T20260427-0023]** — Project policy denials and friction task submissions into the global tracing feed.
+- Add this auditability design folder and record initial ADRs.
+- Expose v2 run audit events through `orbit run events` and `orbit run trace`.
+- Align run step selectors on activity `step.id` and move CLI invocation log reading behind orbit-core runtime accessors.
+- Stream CLI subprocess stdout/stderr through structured tracing events.
+- Add the global process tracing JSONL feed at `~/.orbit/state/logs/orbit.jsonl`.
+- Apply tracing-layer redaction before stderr and global JSONL output.
+- Project policy denials and friction task submissions into the global tracing feed.
 - **[T20260427-27]** — Close out the unified-log story: job lifecycle dual-write, library print migration with workspace lint gate, and `orbit log tail` reader CLI.
 - **[T20260427-43]** — Add `status: friction`, creation-time friction routing, migration, and history-derived friction bounty refresh.
 - **[T20260427-44]** — Add shared log formatter extraction and dashboard backend `/api/log` snapshot/SSE endpoints.

--- a/docs/design/auditability/specs/redaction-retention.md
+++ b/docs/design/auditability/specs/redaction-retention.md
@@ -44,7 +44,7 @@ Global process tracing:
 - Lives under `~/.orbit/state/logs/orbit.jsonl`.
 - Is append-only and unrotated in v1.
 - Is an operational log stream, not the canonical workflow envelope.
-- Carries policy-denial path/resource strings and friction summaries after [T20260427-0023], so default tracing redaction is part of its durability boundary.
+- Carries policy-denial path/resource strings and friction summaries, so default tracing redaction is part of its durability boundary.
 
 ## Failure Modes
 
@@ -64,4 +64,4 @@ Future retention work should add:
 
 ## Agent Signature
 
-Last revised by codex / gpt-5.5 for [T20260427-0023].
+Last revised by codex / gpt-5.5.

--- a/docs/design/orbit-search/2_design.md
+++ b/docs/design/orbit-search/2_design.md
@@ -237,7 +237,7 @@ with `k = 60` (the published-paper default that has held up across many evaluati
 Three queries that motivate the choice:
 
 - **"slow embed inference"** — semantic wins; lexical misses tasks titled "BGE latency degraded after Nomic swap."
-- **"T20260421-0528"** — lexical wins; semantic returns near-random because the literal token has no semantic neighborhood.
+- **"literal task-id token"** — lexical wins; semantic returns near-random because the literal token has no semantic neighborhood.
 - **"file: orbit-store/src/file/task_store/layout.rs"** — lexical wins; literal path tokens dominate.
 
 Either retriever alone has a failure mode the other doesn't. RRF resolves both at the cost of one extra SQL query per search ([4_decisions.md ADR-004](./4_decisions.md)).
@@ -282,7 +282,7 @@ If the companion is not installed, task-hybrid search, `orbit search similar <ta
   "results": [
     {
       "source_kind": "task",
-      "source_id": "T20260421-0528",
+      "source_id": "literal-task-id",
       "best_field": "plan",
       "snippet": "...",
       "score": 0.87,

--- a/docs/design/policy-sandbox/1_overview.md
+++ b/docs/design/policy-sandbox/1_overview.md
@@ -60,27 +60,27 @@ When the default policy denies workspace `.orbit/**`, the v2 host re-allows only
 
 | Concern | Where it lives | Primary task ID |
 |---------|----------------|-----------------|
-| Policy schema and validation | `crates/orbit-common/src/types/policy_def.rs`, `crates/orbit-common/src/types/resource.rs` | [T20260416-0728] |
-| Allow/deny enum | `crates/orbit-common/src/types/policy_decision.rs` | [T20260426-0622] |
-| Policy facade | `crates/orbit-policy/src/{lib,engine,evaluator,decision}.rs` | [T20260416-0728] |
-| Profile resolution + deny injection | `crates/orbit-common/src/types/policy_def.rs` (`effective_profile`, `check_path`) | [T20260416-0728] |
-| Implicit `unrestricted` materialization | `crates/orbit-core/src/runtime/v2_host/mod.rs` (`tool_context_for_activity`) | [T20260419-0503] |
-| Tool-layer fs enforcement | `crates/orbit-tools/src/builtin/fs/mod.rs` (`enforce_fs_policy`, `emit_fs_event`) | [T20260419-0503] |
-| Activity `fsProfile:` binding | `crates/orbit-engine/src/activity_job/{dispatcher,job_executor,agent_loop_driver}.rs` | [T20260419-0503] |
-| Exec spawn primitive | `crates/orbit-exec/src/{lib,runner,process,sandbox}.rs` | [T20260417-0550] |
-| Process supervision | `crates/orbit-exec/src/supervision/{wait,cleanup,signal,tee}.rs` | [T20260417-0558-4], [T20260417-0558-5] |
-| Filesystem denial audit channel | `crates/orbit-tools/src/lib.rs` (`FsAuditLogger`) → `docs/design/auditability/2_design.md §3` | [T20260426-0605] |
+| Policy schema and validation | `crates/orbit-common/src/types/policy_def.rs`, `crates/orbit-common/src/types/resource.rs` |  |
+| Allow/deny enum | `crates/orbit-common/src/types/policy_decision.rs` |  |
+| Policy facade | `crates/orbit-policy/src/{lib,engine,evaluator,decision}.rs` |  |
+| Profile resolution + deny injection | `crates/orbit-common/src/types/policy_def.rs` (`effective_profile`, `check_path`) |  |
+| Implicit `unrestricted` materialization | `crates/orbit-core/src/runtime/v2_host/mod.rs` (`tool_context_for_activity`) |  |
+| Tool-layer fs enforcement | `crates/orbit-tools/src/builtin/fs/mod.rs` (`enforce_fs_policy`, `emit_fs_event`) |  |
+| Activity `fsProfile:` binding | `crates/orbit-engine/src/activity_job/{dispatcher,job_executor,agent_loop_driver}.rs` |  |
+| Exec spawn primitive | `crates/orbit-exec/src/{lib,runner,process,sandbox}.rs` |  |
+| Process supervision | `crates/orbit-exec/src/supervision/{wait,cleanup,signal,tee}.rs` | |
+| Filesystem denial audit channel | `crates/orbit-tools/src/lib.rs` (`FsAuditLogger`) → `docs/design/auditability/2_design.md §3` |  |
 
 ---
 
 ## Task References
 
-- **[T20260416-0728]** — Align policy contract with runtime enforcement (v2 schema, effective profile resolution).
-- **[T20260417-0550]** — Decompose `orbit-exec` supervision modules.
-- **[T20260417-0558-4]** / **[T20260417-0558-5]** — Harden `orbit-exec` supervision (signal pipe, process-group reaping).
-- **[T20260419-0503]** — Enforce `fsProfiles` across runtime and CLI.
-- **[T20260426-0605]** — Add the auditability design folder cross-linked from §3.
-- **[T20260426-0622]** — Add this policy & sandboxing design folder under claude ownership.
+- Align policy contract with runtime enforcement (v2 schema, effective profile resolution).
+- Decompose `orbit-exec` supervision modules.
+- Harden `orbit-exec` supervision (signal pipe, process-group reaping).
+- Enforce `fsProfiles` across runtime and CLI.
+- Add the auditability design folder cross-linked from §3.
+- Add this policy & sandboxing design folder under claude ownership.
 - **[T20260430-23]** — Shorten the policy sandbox design docs while preserving the shipped contract and ADR history.
 - **[ORB-00129]** — Keep child Orbit runtime write roots narrow under the macOS sandbox while supporting activity-exposed learning, friction, and job-run state tools.
 

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -220,14 +220,14 @@ non-empty on Linux CI.
 
 ## Task References
 
-- **[T20260416-0728]** — Align policy contract with runtime enforcement; established v2 schema and effective-profile resolution.
-- **[T20260417-0550]** — Decompose `orbit-exec` supervision modules.
-- **[T20260417-0557]** — Harden Orbit path boundaries and dependency advisories.
-- **[T20260417-0558-4]** / **[T20260417-0558-5]** — Harden `orbit-exec` supervision (signal-pipe handler and process-group reaping).
-- **[T20260419-0503]** — Enforce `fsProfiles` across runtime and CLI; introduced the `tool_context_for_activity` materialization.
-- **[T20260328-221810]** — Agent subprocess termination on Ctrl+C / job-run cancel; predecessor of the current signal-pipe design.
-- **[T20260426-0605]** — Auditability design folder cross-linked from §5.
-- **[T20260426-0622]** — Add this policy & sandboxing design folder and document the current contract.
+- Align policy contract with runtime enforcement; established v2 schema and effective-profile resolution.
+- Decompose `orbit-exec` supervision modules.
+- Harden Orbit path boundaries and dependency advisories.
+- Harden `orbit-exec` supervision (signal-pipe handler and process-group reaping).
+- Enforce `fsProfiles` across runtime and CLI; introduced the `tool_context_for_activity` materialization.
+- Agent subprocess termination on Ctrl+C / job-run cancel; predecessor of the current signal-pipe design.
+- Auditability design folder cross-linked from §5.
+- Add this policy & sandboxing design folder and document the current contract.
 - **[T20260427-51]** — Wrap cli-backend agent invocations in `sandbox-exec` on macOS.
 - **[T20260428-10]** — Allow Codex CLI state writes under the macOS sandbox.
 - **[T20260428-14]** — Extend the macOS sandbox state-dir allowance to Claude (`~/.claude` / `$CLAUDE_CONFIG_DIR`) and Gemini (`~/.gemini`), and document why side-write roots remain Codex-only.

--- a/docs/design/policy-sandbox/3_vision.md
+++ b/docs/design/policy-sandbox/3_vision.md
@@ -91,11 +91,11 @@ External reference categories:
 
 ## Task References
 
-- **[T20260416-0728]** — Established the v2 policy contract that this document extends.
-- **[T20260419-0503]** — Made `fsProfiles` enforcement runtime-wide.
-- **[T20260417-0558-4]** / **[T20260417-0558-5]** — Hardened the supervision contract that §1.11 wants to evolve.
-- **[T20260426-0605]** — Auditability folder linked from §1.10.
-- **[T20260426-0622]** — Add this folder and name the open questions.
+- Established the v2 policy contract that this document extends.
+- Made `fsProfiles` enforcement runtime-wide.
+- Hardened the supervision contract that §1.11 wants to evolve.
+- Auditability folder linked from §1.10.
+- Add this folder and name the open questions.
 - **[T20260430-23]** — Shorten the policy sandbox design docs while preserving the shipped contract and ADR history.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/policy-sandbox/4_decisions.md
+++ b/docs/design/policy-sandbox/4_decisions.md
@@ -18,7 +18,7 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 
 ## ADR-001 — Dedicated policy & sandboxing design ownership
 
-**Status:** Accepted · 2026-04 · [T20260426-0622]
+**Status:** Accepted · 2026-04
 
 **Context.** Policy and sandboxing semantics were spread across `orbit-policy`, `orbit-exec`, the `PolicyDef` schema in `orbit-common`, the activity dispatcher, and the v2 host. There was no canonical place to record invariants, the `unrestricted` fallback, or the supervision contract.
 
@@ -30,7 +30,7 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 
 ## ADR-002 — Policy schema is v2-only with named profiles plus global denies
 
-**Status:** Accepted · 2026-04 · [T20260416-0728]
+**Status:** Accepted · 2026-04
 
 **Context.** An earlier policy schema (v1) used a different shape for allow/deny rules. Supporting both shapes in the runtime caused interpretation drift between the loader, the merger, and the evaluator.
 
@@ -42,7 +42,7 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 
 ## ADR-003 — Implicit `unrestricted` profile materializes when an activity omits `fsProfile:`
 
-**Status:** Accepted · 2026-04 · [T20260419-0503]
+**Status:** Accepted · 2026-04
 
 **Context.** Activities can omit `fsProfile:`. A naive design would either reject the activity at load or run it without policy enforcement. Both are wrong: rejection breaks the common case, and unguarded execution means audit blindness.
 
@@ -54,7 +54,7 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 
 ## ADR-004 — Deny rules inject as negated profile rules with last-match-wins evaluation
 
-**Status:** Accepted · 2026-04 · [T20260416-0728]
+**Status:** Accepted · 2026-04
 
 **Context.** A separate "deny pass" before profile evaluation is the obvious shape, but it makes precedence ambiguous when a profile rule and a deny rule both match. Multiple Orbit features (workspace overrides, profile narrowing, denyModify-also-implies-denyRead-for-modify validation) need a single evaluation order.
 
@@ -66,7 +66,7 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 
 ## ADR-005 — Modify rules must be covered by a read rule in the same profile
 
-**Status:** Accepted · 2026-04 · [T20260416-0728]
+**Status:** Accepted · 2026-04
 
 **Context.** A profile that grants `modify: ["./build/**"]` without granting `read: ["./build/**"]` is technically valid but produces a confusing operational story: a tool may be allowed to write a file it cannot read, breaking the standard read-modify-write pattern.
 
@@ -78,7 +78,7 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 
 ## ADR-006 — Tool layer is the policy enforcement point for HTTP-backed activities
 
-**Status:** Accepted · 2026-04 · [T20260419-0503]
+**Status:** Accepted · 2026-04
 
 **Context.** Policy enforcement could plausibly live at the syscall layer, the fs trait layer, the tool layer, or the activity layer. Each placement has different trust and coverage tradeoffs.
 
@@ -90,7 +90,7 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 
 ## ADR-007 — Children spawn as process-group leaders so orphan subprocesses are reapable
 
-**Status:** Accepted · 2026-04 · [T20260417-0558-4], [T20260328-221810]
+**Status:** Accepted · 2026-04
 
 **Context.** Naive subprocess code on Unix leaves orphan grandchildren holding open pipe write ends, which causes the parent's `wait_with_output` to hang when the orphan never exits. Earlier versions of orbit-exec hit this exact failure when an agent's tool spawned long-lived helpers.
 
@@ -102,7 +102,7 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 
 ## ADR-008 — SIGTERM with 5-second grace, then SIGKILL for the whole group
 
-**Status:** Accepted · 2026-04 · [T20260417-0558-4]
+**Status:** Accepted · 2026-04
 
 **Context.** A timed-out or interrupted child needs a chance to flush state before being killed, but the supervisor cannot wait indefinitely. The escalation policy needs a single, predictable shape.
 
@@ -114,7 +114,7 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 
 ## ADR-009 — Signal handler installation is process-global and serialized
 
-**Status:** Accepted · 2026-04 · [T20260417-0558-5]
+**Status:** Accepted · 2026-04
 
 **Context.** Installing parent-side SIGINT/SIGTERM handlers is a process-global operation. Two concurrent `run_process` calls cannot install independent handlers without races, and a panicking call must restore the prior handler so the orbit process itself remains interruptible.
 
@@ -126,7 +126,7 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 
 ## ADR-010 — `NoSandbox` is the default `Sandbox` impl; real isolation is deferred
 
-**Status:** Accepted · 2026-04 · [T20260417-0550]
+**Status:** Accepted · 2026-04
 
 **Context.** The `Sandbox` trait is the seam where kernel-level or container-level isolation would attach to `orbit-exec`. The trait shipped with the supervision rework, but no real impl is registered.
 
@@ -214,12 +214,12 @@ Use `literal` for the canonical and lock files (predictable names) and `regex` f
 
 ## Task References
 
-- **[T20260328-221810]** — Subprocess termination on Ctrl+C / job cancel; predecessor of the current process-group design.
-- **[T20260416-0728]** — Aligned the policy contract with runtime enforcement; v2 schema and effective-profile resolution land here.
-- **[T20260417-0550]** — Decomposed `orbit-exec` supervision modules.
-- **[T20260417-0558-4]** / **[T20260417-0558-5]** — Hardened `orbit-exec` supervision (process-group reaping, signal-pipe handler).
-- **[T20260419-0503]** — Enforced `fsProfiles` across runtime and CLI; introduced `tool_context_for_activity`.
-- **[T20260426-0622]** — Add this design folder and record the initial ADR set.
+- Subprocess termination on Ctrl+C / job cancel; predecessor of the current process-group design.
+- Aligned the policy contract with runtime enforcement; v2 schema and effective-profile resolution land here.
+- Decomposed `orbit-exec` supervision modules.
+- Hardened `orbit-exec` supervision (process-group reaping, signal-pipe handler).
+- Enforced `fsProfiles` across runtime and CLI; introduced `tool_context_for_activity`.
+- Add this design folder and record the initial ADR set.
 - **[T20260427-51]** — Wrap cli-backend agent invocations in `sandbox-exec` on macOS with inner-flag neutralization for codex/gemini.
 - **[T20260428-10]** — Allow Codex CLI state writes under the macOS sandbox.
 - **[T20260428-14]** — Extend the macOS sandbox state-dir allowance to Claude and Gemini, and document why side-write roots remain Codex-only.

--- a/docs/design/policy-sandbox/specs/sandbox-exec-contract.md
+++ b/docs/design/policy-sandbox/specs/sandbox-exec-contract.md
@@ -61,4 +61,4 @@ Process supervision is full of subtle deadlocks (full pipe buffers, orphan grand
 
 ## Agent Signature
 
-Last revised by claude / claude-opus-4-7 for [T20260426-0622].
+Last revised by claude / claude-opus-4-7.


### PR DESCRIPTION
## Task

[ORB-10419](https://orbit-cli.com/tasks/ORB-10419) — Remove dangling legacy T-format task id references from live docs and code

### Description

Legacy task ids in the old `T<YYYYMMDD>-<HHMM>` format (e.g. `T20260418-2018`) are scattered through the repo's prose and source comments. Current task ids are `ORB-#####`. These legacy references no longer resolve to anything a reader can look up, so they are dead weight: they look like a citation, but following one leads nowhere. Find them and remove them.

## The job

Locate every occurrence of the legacy id format across the repo, decide per occurrence what removal means there, and clean it up. The judgment is in the *how*, not the *where* — deleting a bare parenthetical is different from deleting an id that is load-bearing in a sentence, and different again from an id that is test data.

**Confirm they are actually dangling before deleting.** Check whether the legacy format still resolves through orbit's task store or any migration mapping (`orbit task show <id>`, the task registry, any id-migration code or docs). If some subset does still resolve, stop and report that instead of deleting — the premise of this task would be wrong and Daniel needs to know before the ids are gone.

## Scope

In scope:
- `docs/**` prose, EXCEPT `docs/design/_archive/**`
- `crates/**` — source comments, doc comments, and example files
- `CLAUDE.md`, `AGENTS.md`, `ARCHITECTURE.md`, `README.md` if any appear there

Out of scope — do not modify:
- `.orbit/adrs/**` — an accepted ADR citing the task that produced it is provenance. The reference was accurate when written and explains why the decision exists. Leave every one.
- `CHANGELOG.md` — same reasoning: a historical record of what shipped when.
- `docs/design/_archive/**` — archived by definition.
- `.orbit/graph/`, `.orbit/tasks/`, and any other generated or stored state.

## How to decide what to change

- **Removal must leave correct prose.** Do not leave dangling punctuation, empty parentheses, orphaned "see" clauses, or a sentence that now refers to nothing. If a sentence exists only to cite the dead id, remove the sentence. If the id is the object of an otherwise useful sentence, rewrite the clause minimally so the sentence still reads.
- **Test fixtures and assertions: be careful.** Where a legacy id is fixture data or appears in a test assertion, changing it can break the test. Either leave it (and say so) or update fixture and assertion together and confirm the test still passes. Do not half-change a fixture.
- **Do not "modernize" by substitution.** If you cannot determine the current `ORB-#####` equivalent from evidence in the repo, delete the reference rather than guessing at a replacement id. A wrong citation is worse than no citation.
- **Preserve meaning.** Where the surrounding text conveys real information ("this behavior was added to fix X"), keep the information and drop only the dead id.

## Constraints

- `cargo build` and `cargo test` must still pass if anything under `crates/**` is touched. Run them.
- Minimal diff. Do not reflow paragraphs or reformat files you are editing.
- Do not add project-specific identifiers (person names, task/ADR/friction ids) to anything under `crates/*/assets/**` — those assets seed every workspace and must stay project-agnostic.
- Report in the commit description: total occurrences found, how many removed, which were left and why (fixtures, out-of-scope paths), and the result of the does-it-still-resolve check.

### Acceptance Criteria

- No occurrence of the legacy `T<YYYYMMDD>-<HHMM>` id format remains anywhere in scope — verify with a repo-wide search restricted to the in-scope paths.
- Every file under .orbit/adrs/, CHANGELOG.md, and docs/design/_archive/ is unmodified.
- The commit description states whether legacy ids still resolve through the task store, and the evidence for that finding.
- Every edit leaves grammatical prose: no empty parentheses, dangling 'see', or sentences referring to a removed id.
- cargo build and cargo test pass if crates/** was touched; any test fixture left unchanged is listed with a reason.
- No legacy id was replaced with a guessed ORB-##### equivalent.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented the scoped cleanup. Initial exact-format search found 397 occurrences of T<YYYYMMDD>-<HHMM> across 27 in-scope files under live docs/source; 397 were removed and the final in-scope search is clean. 31 files changed, including paired test fixture/assertion updates in orbit-cli, orbit-common, and orbit-dashboard; no legacy ID was replaced with a guessed ORB equivalent. Test/example IDs were refreshed only where input and expected output were updated together. A representative legacy ID was checked with `orbit.task.show`: the task store rejects it at validation (`task id ... must match ORB-00000`); repository inspection found no T-format task-ID migration alias, so the references are dangling. The 368 matching references in .orbit/adrs, CHANGELOG.md, and docs/design/_archive/ remain untouched by policy, and all protected paths have no diff. Validation: `cargo build` passed; focused package suites passed for orbit-common (273 unit + 1 integration), orbit-agent (34), orbit-dashboard (208), and orbit-engine (308); `make ci-fast` passed; `git diff --check` passed. Full `cargo test` had one unrelated pre-existing failure in orbit-cli `mcp_serve_tools_list_matches_production_snapshot` due production MCP tool-list snapshot drift; no changed file affects that schema or snapshot, and the snapshot was intentionally not regenerated. Friction F2026-07-137 was filed for the MCP workspace-selector failure that required the documented CLI fallback. No commit created.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10419-6a657983`
- Behind base: 0
- Ahead of base: 1