### PR TITLE
Reconcile MCP tools-list production snapshot with the multi-status task.list schema

### DIFF
--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -962,8 +962,18 @@
           "type": "boolean"
         },
         "status": {
-          "description": "Optional task status filter",
-          "type": "string"
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Optional task status filter. Pass a comma-separated string or an array of status names."
         },
         "tag": {
           "anyOf": [


### PR DESCRIPTION
## Task

[ORB-10425](https://orbit-cli.com/tasks/ORB-10425) — Reconcile MCP tools-list production snapshot with the multi-status task.list schema

### Description

orbit-cli's mcp_serve_tools_list_matches_production_snapshot fails on agent-main. Two independent executor runs hit it tonight (ORB-10412 and ORB-10419 execution summaries, both confirming it pre-existing and unrelated to their diffs).

Likely root cause: ORB-10401 (merged 2026-07-26 ~01:01Z) changed the orbit.task.list tool schema — status now advertises string_list to accept comma-separated/array forms — and the production tools-list snapshot was not regenerated in that PR.

Fix: confirm the snapshot diff is exactly the ORB-10401 schema change (verify against that merge's diff — do not blindly regenerate over an unrelated drift); regenerate/update the snapshot; if anything beyond the task.list status field differs, stop and report what else drifted instead of absorbing it silently. cargo test -p orbit-cli passes afterward.

### Acceptance Criteria

- mcp_serve_tools_list_matches_production_snapshot passes on agent-main; snapshot diff confirmed to consist only of the ORB-10401 schema change (any other drift reported, not absorbed); full orbit-cli suite passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Regenerated `crates/orbit-cli/tests/snapshots/mcp_tools_list.json` through the prescribed `ORBIT_MCP_UPDATE_SNAPSHOT=1` MCP round-trip test.
- Confirmed the regenerated snapshot diff is limited to `orbit_task_list.inputSchema.properties.status`: it now accepts either a string or string array and documents comma-separated/array status names, exactly matching ORB-10401 (`dc4cd172`). No unrelated MCP schema drift was absorbed.

Assessment: The production MCP snapshot now accurately reflects the ORB-10401 multi-status task-list contract.

Validation:
- `cargo test -p orbit-cli --test mcp_roundtrip mcp_serve_tools_list_matches_production_snapshot -- --exact`
- `cargo test -p orbit-cli` (all orbit-cli unit and integration tests passed)
- `git diff --check`

Notes:
- Test builds emitted existing `orbit-core` unused-import/dead-code warnings; they are outside this snapshot-only task and did not affect test success.
- Friction checkpoint: no new executor/tooling friction identified; the initial snapshot failure was the expected task defect.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10425-6a657fd9`
- Behind base: 0
- Ahead of base: 1