### PR TITLE
Remove stale task, learning, and ADR lock files reported by orbit doctor

### DIFF
--- a/crates/orbit-cli/src/command/doctor.rs
+++ b/crates/orbit-cli/src/command/doctor.rs
@@ -12,10 +12,20 @@ pub struct DoctorCommand {
     /// Emit machine-readable JSON instead of the table.
     #[arg(long)]
     pub json: bool,
+
+    /// Remove lock files whose recorded holder process is dead before diagnosing the workspace.
+    #[arg(long)]
+    pub fix_stale_locks: bool,
 }
 
 impl Execute for DoctorCommand {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        if self.fix_stale_locks {
+            let removed = runtime.remove_stale_lock_files()?;
+            if !self.json {
+                println!("Removed {removed} stale lock file(s).");
+            }
+        }
         let results = runtime.doctor_workspace()?;
         let failures = results
             .iter()

--- a/crates/orbit-cli/src/command/tests/mod.rs
+++ b/crates/orbit-cli/src/command/tests/mod.rs
@@ -33,6 +33,18 @@ fn assert_cli_rejects(args: &[&str], kind: ErrorKind, expected: &str) {
 }
 
 #[test]
+fn cli_parses_doctor_stale_lock_cleanup() {
+    let cli = Cli::parse_from(["orbit", "doctor", "--fix-stale-locks", "--json"]);
+    match cli.command {
+        Commands::Doctor(command) => {
+            assert!(command.fix_stale_locks);
+            assert!(command.json);
+        }
+        _ => panic!("expected top-level doctor command"),
+    }
+}
+
+#[test]
 fn cli_parses_mcp_init() {
     let cli = Cli::parse_from(["orbit", "mcp", "init"]);
     match cli.command {

--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -15,8 +15,10 @@
 //! `/healthz?detailed=true` ([`DoctorCommands::health_check_store_writable`],
 //! [`DoctorCommands::health_check_graph_index`]) also live here.
 
+use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 
+use fs2::FileExt;
 use orbit_common::types::{OrbitError, WorkspacePaths};
 use orbit_core::OrbitRuntime;
 use orbit_store::sqlite::migration::SUPPORTED_SCHEMA_VERSION;
@@ -73,6 +75,10 @@ pub trait DoctorCommands {
     /// absent subsystems as `Skipped`.
     fn doctor_workspace(&self) -> Result<Vec<WorkspaceDoctorResult>, OrbitError>;
 
+    /// Remove lock files left by dead holders, without disturbing a lock that
+    /// is currently held by another process.
+    fn remove_stale_lock_files(&self) -> Result<usize, OrbitError>;
+
     /// Cheap store write probe for health endpoints: open the store and
     /// acquire + roll back the write lock without mutating anything.
     fn health_check_store_writable(&self) -> Result<String, OrbitError>;
@@ -98,6 +104,16 @@ impl DoctorCommands for OrbitRuntime {
             doctor_check_job_runs(self),
             doctor_check_task_relations(self),
         ])
+    }
+
+    fn remove_stale_lock_files(&self) -> Result<usize, OrbitError> {
+        let mut removed = 0;
+        for path in collect_lock_files(self.paths()) {
+            if remove_stale_lock_file(&path)? {
+                removed += 1;
+            }
+        }
+        Ok(removed)
     }
 
     fn health_check_store_writable(&self) -> Result<String, OrbitError> {
@@ -283,6 +299,55 @@ fn doctor_check_stale_locks(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {
             ),
         )
     }
+}
+
+/// Delete one dead-holder lock only after acquiring its advisory lock. A
+/// fresh holder can win the race between the initial scan and this cleanup;
+/// in that case `try_lock_exclusive` reports contention and the file remains.
+fn remove_stale_lock_file(path: &Path) -> Result<bool, OrbitError> {
+    let Some(holder) = orbit_store::read_lock_holder(path) else {
+        return Ok(false);
+    };
+    if process_is_alive(holder.pid) {
+        return Ok(false);
+    }
+
+    let file = match OpenOptions::new().read(true).write(true).open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "open stale lock candidate {}: {error}",
+                path.display()
+            )));
+        }
+    };
+    match file.try_lock_exclusive() {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => return Ok(false),
+        Err(error) => {
+            return Err(OrbitError::Store(format!(
+                "acquire stale lock candidate {}: {error}",
+                path.display()
+            )));
+        }
+    }
+
+    // Re-read after acquiring the advisory lock so a holder that appeared
+    // after the first liveness probe is never removed.
+    let should_remove = orbit_store::read_lock_holder(path)
+        .is_some_and(|current_holder| !process_is_alive(current_holder.pid));
+    if !should_remove {
+        return Ok(false);
+    }
+
+    std::fs::remove_file(path).map_err(|error| {
+        OrbitError::Io(format!(
+            "remove stale lock candidate {}: {error}",
+            path.display()
+        ))
+    })?;
+    Ok(true)
 }
 
 /// `running`/`pending` job runs with no live worker process — dead recorded

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::path::Path;
 
 use chrono::Utc;
+use fs2::FileExt;
 use orbit_common::types::{JobRun, JobRunState};
 
 use orbit_core::OrbitRuntime;
@@ -170,6 +171,64 @@ fn dead_holder_lock_file_is_reported_stale() {
         "message names the stale lock and its op: {}",
         locks.message
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn stale_task_learning_and_adr_lock_files_are_removed() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let paths = runtime.paths();
+    let stale_locks = [
+        paths.tasks_dir.join(".ORB-00001.lock"),
+        paths.learnings_dir.join(".L-0001.lock"),
+        paths.adrs_dir.join(".locks").join("adr-0001.lock"),
+    ];
+
+    let dead_pid = reaped_child_pid();
+    for path in &stale_locks {
+        write_holder_lock(path, dead_pid, "crashed op");
+    }
+
+    assert_eq!(
+        runtime
+            .remove_stale_lock_files()
+            .expect("remove stale locks"),
+        stale_locks.len()
+    );
+    assert!(
+        stale_locks.iter().all(|path| !path.exists()),
+        "all dead-holder files must be removed: {stale_locks:?}"
+    );
+    assert_eq!(
+        status_of(&runtime.doctor_workspace().expect("doctor"), "stale-locks").status,
+        WorkspaceDoctorStatus::Ok
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn cleanup_preserves_a_lock_held_by_a_live_process() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let lock_path = runtime.paths().tasks_dir.join(".ORB-00001.lock");
+    write_holder_lock(&lock_path, reaped_child_pid(), "stale metadata");
+
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .expect("open lock file");
+    file.lock_exclusive().expect("hold lock");
+
+    assert_eq!(
+        runtime
+            .remove_stale_lock_files()
+            .expect("clean stale locks"),
+        0
+    );
+    assert!(lock_path.exists(), "a held lock file must remain");
+    file.unlock().expect("unlock lock file");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Task

[ORB-10423](https://orbit-cli.com/tasks/ORB-10423) — Remove stale task, learning, and ADR lock files reported by orbit doctor

### Description

## Problem

`orbit doctor --json` reports 13 stale lock files whose recorded holder PIDs are dead. The OS has released their advisory locks, but the files remain in the workspace state, leaving a persistent health warning and requiring a manual cleanup path.

## Evidence

On commit `4dddd94f3cee78846e8e8c1507ed7e7595a815d5` (after recent ORB-10411 and ORB-10412 cleanup changes), the built CLI reported `stale-locks` as `warning` with 13 dead-holder files under `.orbit/learnings/` and `.orbit/adrs/.locks/`. No existing open task tagged `qa-sweep` described stale lock-file cleanup; ORB-10396 concerns code organization for task locks, not this cleanup behavior.

## Reproduction

1. Build the CLI: `cargo build -p orbit-cli --quiet`.
2. In the affected workspace, run `./target/debug/orbit doctor --json`.
3. Observe the `stale-locks` warning listing 13 files with dead PIDs, despite the report saying they are safe to delete.

## Expected

Orbit provides a supported cleanup path (or safely removes stale locks during the appropriate lifecycle) so a healthy workspace does not retain these warnings.

### Acceptance Criteria

- A supported, documented command or lifecycle path removes stale dead-holder lock files without deleting locks held by live processes.
- After applying that path to a workspace containing the reproduced stale locks, `orbit doctor --json` no longer reports those files under `stale-locks`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added the documented orbit doctor --fix-stale-locks lifecycle path. It removes stale lock metadata before running the normal health report; --json therefore reports the post-cleanup stale-locks result.
- Implemented cleanup in orbit-cmd: it only considers dead recorded PIDs, takes a non-blocking advisory lock, then rechecks holder metadata before unlinking. Contended/live locks are left intact.
- Added regression coverage for task, learning, and ADR stale locks; a held lock is preserved; and the CLI flag parses.
Assessment: Meets both acceptance criteria with no new dependency or crate edge.
Validation:
- cargo fmt --all -- --check
- cargo test -p orbit-cmd stale_task_learning_and_adr_lock_files_are_removed --lib
- cargo test -p orbit-cmd cleanup_preserves_a_lock_held_by_a_live_process --lib
- cargo test -p orbit-cli cli_parses_doctor_stale_lock_cleanup
- target/debug/orbit doctor --help confirms --fix-stale-locks
- make ci-fast
Scope additions: added crates/orbit-cli/src/command/tests/mod.rs to context_files for the focused CLI parser regression test; no other unlisted files were modified.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10423-6a658104`
- Behind base: 0
- Ahead of base: 1