### PR TITLE
Add last_validated to the design-doc frontmatter templates

### DIFF
--- a/docs/design/_templates/1_overview.md
+++ b/docs/design/_templates/1_overview.md
@@ -2,6 +2,7 @@
 title: <Feature> — Overview
 owner: <agent family: codex | claude | grok | gemini>
 last_updated: YYYY-MM-DD
+last_validated: YYYY-MM-DD
 status: Draft
 feature: <feature-slug>
 doc_role: overview

--- a/docs/design/_templates/2_design.md
+++ b/docs/design/_templates/2_design.md
@@ -2,6 +2,7 @@
 title: <Feature> — Design
 owner: <agent family: codex | claude | grok | gemini>
 last_updated: YYYY-MM-DD
+last_validated: YYYY-MM-DD
 status: Draft
 feature: <feature-slug>
 doc_role: design

--- a/docs/design/_templates/3_vision.md
+++ b/docs/design/_templates/3_vision.md
@@ -2,6 +2,7 @@
 title: <Feature> — Vision
 owner: <agent family: codex | claude | grok | gemini>
 last_updated: YYYY-MM-DD
+last_validated: YYYY-MM-DD
 status: Draft
 feature: <feature-slug>
 doc_role: vision

--- a/docs/design/_templates/4_decisions.md
+++ b/docs/design/_templates/4_decisions.md
@@ -2,6 +2,7 @@
 title: <Feature> — Decisions
 owner: <agent family: codex | claude | grok | gemini>
 last_updated: YYYY-MM-DD
+last_validated: YYYY-MM-DD
 status: Draft
 feature: <feature-slug>
 doc_role: decisions


### PR DESCRIPTION
## Task

[ORB-10421](https://orbit-cli.com/tasks/ORB-10421) — Add last_validated to the design-doc frontmatter templates

### Description

The `doc-duties` auto-task keeps this repo's documentation honest by cycling through docs oldest-first and re-checking their claims against the code. It tracks that with a `last_validated` frontmatter key, and treats a doc with no such key as never-validated — front of the queue.

That works for the existing corpus, but every new doc created from a template starts without the key. Add it to the templates so docs are born into the rotation with the right shape.

## The distinction the key encodes

`last_updated` answers "when did this text last change". `last_validated` answers "when did someone last confirm this is still true". They are different events: a typo fix bumps `last_updated` and should not bump `last_validated`; confirming a design doc's cited paths still resolve bumps `last_validated` and changes no prose at all. Whatever you write into the templates should make that distinction obvious to whoever fills the template in, without turning the frontmatter into an essay.

## The job

Find the doc templates in this repo, decide which of them actually define a document with a frontmatter block (some may be fragments, spec stubs, or partials rather than whole documents — judge, don't assume), and add the key to those.

Match each template's own conventions: placeholder style, key ordering, and where the existing recency keys sit. The new key belongs next to them, not appended at the end as an afterthought.

## Constraints

- **Templates only.** Do not add `last_validated` to any existing document — populating the corpus is `doc-duties`' job, and a date you did not earn is worse than no date.
- **No code changes.** The docs frontmatter parser tolerates keys beyond the ones it models, so this needs no Rust change. Do not modify the frontmatter structs, the docs command, or any test to "support" the new key — whether the parser should model it is a separate decision that is not yours to make here.
- Confirm the templates still parse under the repo's strict doc-frontmatter rules after your change (`type` and `summary` remain required and untouched).
- Do not restructure, reorder, or otherwise improve the templates while you are in there. One key added, nothing else.
- Do not create new templates.
- Report in the commit description which templates you changed, and which you examined and deliberately left alone, with the reason.

### Acceptance Criteria

- Every template in this repo that defines a document with a frontmatter block carries a `last_validated` key, placed with the other recency keys and using that template's placeholder convention.
- Templates that are fragments or partials rather than whole documents are left unchanged, and the commit description says which and why.
- No file under crates/** is modified — no parser, struct, or test changes.
- No existing document outside the templates directories was modified.
- The templates still satisfy the strict doc-frontmatter rules, with `type` and `summary` unchanged.
- The diff adds the key and nothing else — no reordering, rewording, or restructuring of template content.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `last_validated: YYYY-MM-DD` immediately after `last_updated` in the four whole-document frontmatter templates: `1_overview.md`, `2_design.md`, `3_vision.md`, and `4_decisions.md`.
- Examined and deliberately left `references/glossary.md` and `specs/_mechanism.md` unchanged because they are body-only fragments/spec stubs without a frontmatter block.
- No files under `crates/**` or outside the templates directory were modified; `type` and `summary` remain unchanged.
Assessment: The diff is exactly four added frontmatter lines, using the existing date placeholder convention and recency-key placement. `orbit docs show --json` successfully parsed all four templates under the strict frontmatter path, `git diff --check` passed, and `make ci-fast` passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10421-6a659017`
- Behind base: 0
- Ahead of base: 1