### PR TITLE
Extract runtime/task_locks.rs from orbit_tool_host

### DIFF
--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -21,6 +21,7 @@ mod resolve;
 pub mod run_audit;
 pub(crate) mod run_input;
 mod task_block_on_run_failure;
+mod task_locks;
 mod task_records;
 mod task_reservation_cleanup;
 pub(crate) mod tool_exec;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
@@ -68,12 +68,12 @@ pub(super) fn execute(
         OrbitBuiltinAction::TaskDelete => super::task_tools::delete(runtime, input),
         OrbitBuiltinAction::TaskLint => super::task_tools::lint(runtime, input),
         OrbitBuiltinAction::TaskList => super::task_tools::list(runtime, input),
-        OrbitBuiltinAction::TaskLocks => super::task_locks::list(runtime),
+        OrbitBuiltinAction::TaskLocks => crate::runtime::task_locks::list(runtime),
         OrbitBuiltinAction::TaskLocksRelease => {
-            super::task_locks::release(runtime, input, agent, model)
+            crate::runtime::task_locks::release(runtime, input, agent, model)
         }
         OrbitBuiltinAction::TaskLocksReserve => {
-            super::task_locks::reserve(runtime, input, agent, model, reservation_owner)
+            crate::runtime::task_locks::reserve(runtime, input, agent, model, reservation_owner)
         }
         OrbitBuiltinAction::TaskReject => super::task_tools::reject(runtime, input, agent, model),
         OrbitBuiltinAction::TaskShow => super::task_tools::show(runtime, input),

--- a/crates/orbit-core/src/runtime/orbit_tool_host/json.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/json.rs
@@ -92,17 +92,6 @@ pub(super) fn serialize_task(runtime: &OrbitRuntime, task: &Task) -> Result<Valu
     Ok(value)
 }
 
-pub(super) fn task_lock_to_json(task: &Task) -> Value {
-    json!({
-        "id": task.id,
-        "title": task.title,
-        "status": task.status.to_string(),
-        "job_run_id": task.job_run_id,
-        "crew": task.crew,
-        "context_files": task.context_files,
-    })
-}
-
 fn insert_resolved_crew(
     runtime: &OrbitRuntime,
     task: &Task,
@@ -220,14 +209,6 @@ fn serialize_comments(comments: &[TaskComment]) -> Result<Value, OrbitError> {
 
 fn serialize_history(history: &[TaskHistoryEntry]) -> Result<Value, OrbitError> {
     serde_json::to_value(history).map_err(serialize_error("serialize history"))
-}
-
-pub(super) fn task_lock_status_rank(status: TaskStatus) -> u8 {
-    match status {
-        TaskStatus::InProgress => 0,
-        TaskStatus::Review => 1,
-        _ => 2,
-    }
 }
 
 pub(super) fn serialize_error(label: &'static str) -> impl FnOnce(serde_json::Error) -> OrbitError {

--- a/crates/orbit-core/src/runtime/orbit_tool_host/mod.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/mod.rs
@@ -12,7 +12,6 @@ mod pipeline_tools;
 mod search_tools;
 mod semantic_tools;
 mod state_tools;
-mod task_locks;
 mod task_tools;
 
 #[cfg(test)]
@@ -24,8 +23,3 @@ pub(crate) mod test_support;
 pub use host::HubCoordinationExecutor;
 pub(crate) use host::build_orbit_tool_host;
 pub(crate) use learning_tools::update_without_role_gate as update_learning_without_role_gate;
-pub(crate) use task_locks::{
-    emit_expired_reservation_events, emit_task_lock_release_event, merge_task_lock_conflicts,
-    requested_task_files, task_lock_conflicts, workspace_orbit_dir, workspace_task_reservation_id,
-};
-pub(crate) use task_tools::parse_task_ids;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeSet;
-
 use orbit_common::types::{
     OrbitError, TaskPriority, optional_csv_or_string_list_alias, optional_raw_string,
     optional_string, optional_string_alias, optional_string_list_alias, required_string,
@@ -331,22 +329,6 @@ pub(super) fn update(
         model,
     )?;
     serialize_task(runtime, &task)
-}
-
-pub(crate) fn parse_task_ids(input: &Value) -> Result<Vec<String>, OrbitError> {
-    let task_ids = optional_string_list_alias(input, &["task_ids", "taskIds", "task-ids"])?
-        .ok_or_else(|| OrbitError::InvalidInput("missing `task_ids`".to_string()))?;
-    parse_task_id_list(task_ids)
-}
-
-fn parse_task_id_list(task_ids: Vec<String>) -> Result<Vec<String>, OrbitError> {
-    let deduped = task_ids.into_iter().collect::<BTreeSet<_>>();
-    if deduped.is_empty() {
-        return Err(OrbitError::InvalidInput(
-            "`task_ids` must contain at least one task ID".to_string(),
-        ));
-    }
-    Ok(deduped.into_iter().collect())
 }
 
 fn optional_raw_string_alias(input: &Value, keys: &[&str]) -> Result<Option<String>, OrbitError> {

--- a/crates/orbit-core/src/runtime/orbit_tool_host/test_support.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/test_support.rs
@@ -62,7 +62,7 @@ pub(super) fn create_task(
         .expect("create task")
 }
 
-pub(super) fn create_context_task(
+pub(crate) fn create_context_task(
     runtime: &OrbitRuntime,
     workspace_path: &Path,
     status: TaskStatus,
@@ -78,7 +78,7 @@ pub(super) fn create_context_task(
     )
 }
 
-pub(super) fn invalid_input_message<T>(result: Result<T, OrbitError>) -> String {
+pub(crate) fn invalid_input_message<T>(result: Result<T, OrbitError>) -> String {
     match result {
         Err(OrbitError::InvalidInput(message)) => message,
         Err(error) => panic!("expected invalid input, got {error:?}"),
@@ -86,12 +86,12 @@ pub(super) fn invalid_input_message<T>(result: Result<T, OrbitError>) -> String 
     }
 }
 
-pub(super) struct UnmanagedToolEnvGuard {
+pub(crate) struct UnmanagedToolEnvGuard {
     _lock: MutexGuard<'static, ()>,
     vars: Vec<(&'static str, Option<String>)>,
 }
 
-pub(super) fn unmanaged_tool_env_guard() -> UnmanagedToolEnvGuard {
+pub(crate) fn unmanaged_tool_env_guard() -> UnmanagedToolEnvGuard {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     let lock = LOCK
         .get_or_init(|| Mutex::new(()))

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/mod.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/mod.rs
@@ -1,4 +1,3 @@
 mod learning_tools;
 mod state_tools;
-mod task_locks;
 mod task_tools;

--- a/crates/orbit-core/src/runtime/task_locks.rs
+++ b/crates/orbit-core/src/runtime/task_locks.rs
@@ -20,8 +20,6 @@ use serde_json::{Value, json};
 use crate::OrbitRuntime;
 use crate::command::task::canonicalize_context_files_for_read;
 
-use super::json::{task_lock_status_rank, task_lock_to_json};
-
 pub(super) fn list(runtime: &OrbitRuntime) -> Result<Value, OrbitError> {
     let workspace_id = workspace_task_reservation_id(runtime)?;
     let reservation_result = runtime
@@ -307,6 +305,12 @@ pub(super) fn parse_task_lock_reservation_scope(
             parse_file_lock_selectors(files).map(TaskLockReservationScope::Files)
         }
     }
+}
+
+pub(crate) fn parse_task_ids(input: &Value) -> Result<Vec<String>, OrbitError> {
+    let task_ids = optional_string_list_alias(input, &["task_ids", "taskIds", "task-ids"])?
+        .ok_or_else(|| OrbitError::InvalidInput("missing `task_ids`".to_string()))?;
+    parse_task_id_list(task_ids)
 }
 
 fn parse_task_id_list(task_ids: Vec<String>) -> Result<Vec<String>, OrbitError> {
@@ -596,153 +600,21 @@ fn owner_run_id_from_payload(payload: &Value) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use orbit_common::types::{AuditEvent, Role, TaskStatus};
-    use orbit_tools::{ReservationOwnerContext, ToolContext};
-    use serde_json::{Value, json};
+fn task_lock_to_json(task: &Task) -> Value {
+    json!({
+        "id": task.id,
+        "title": task.title,
+        "status": task.status.to_string(),
+        "job_run_id": task.job_run_id,
+        "crew": task.crew,
+        "context_files": task.context_files,
+    })
+}
 
-    use super::super::test_support::{create_context_task, test_runtime, unmanaged_tool_env_guard};
-
-    fn task_lock_audit_event(runtime: &OrbitRuntime, tool_name: &str, command: &str) -> AuditEvent {
-        runtime
-            .list_audit_events(None, Some(tool_name.to_string()), None, None, 16)
-            .expect("list audit events")
-            .into_iter()
-            .find(|event| event.command == command)
-            .expect("task lock audit event")
-    }
-
-    fn reserve_files(runtime: &OrbitRuntime, owner_run_id: Option<&str>) -> String {
-        let input = json!({
-            "files": ["file:src/lib.rs"],
-            "ttl_seconds": 3600,
-            "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
-        });
-        let output = match owner_run_id {
-            Some(owner_run_id) => runtime
-                .run_tool_with_context_and_role(
-                    "orbit.task.locks.reserve",
-                    input,
-                    Role::Admin,
-                    ToolContext {
-                        reservation_owner: Some(ReservationOwnerContext {
-                            owner_run_id: owner_run_id.to_string(),
-                            owner_metadata_json: None,
-                        }),
-                        ..ToolContext::default()
-                    },
-                )
-                .expect("reserve direct file selectors with owner"),
-            None => runtime
-                .run_tool("orbit.task.locks.reserve", input)
-                .expect("reserve direct file selectors"),
-        };
-
-        output
-            .get("reservation_id")
-            .and_then(Value::as_str)
-            .expect("reservation id")
-            .to_string()
-    }
-
-    #[test]
-    fn release_audit_without_owner_has_no_task_or_job_run_id() {
-        let _env = unmanaged_tool_env_guard();
-        let (_root, runtime, repo_root) = test_runtime();
-        std::fs::create_dir_all(repo_root.join("src")).expect("create src dir");
-        std::fs::write(repo_root.join("src/lib.rs"), "pub fn ok() {}\n")
-            .expect("write source file");
-
-        let reservation_id = reserve_files(&runtime, None);
-        let release = runtime
-            .run_tool(
-                "orbit.task.locks.release",
-                json!({
-                    "reservation_id": reservation_id.clone(),
-                    "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
-                }),
-            )
-            .expect("release reservation");
-        assert_eq!(release["released"], true);
-
-        let row = task_lock_audit_event(
-            &runtime,
-            "orbit.task.locks.release",
-            "task.locks.reserve.released",
-        );
-        assert_eq!(row.target_id.as_deref(), Some(reservation_id.as_str()));
-        assert!(row.task_id.is_none());
-        assert!(row.job_run_id.is_none());
-    }
-
-    #[test]
-    fn release_audit_uses_reservation_owner_run_id() {
-        let _env = unmanaged_tool_env_guard();
-        let (_root, runtime, repo_root) = test_runtime();
-        std::fs::create_dir_all(repo_root.join("src")).expect("create src dir");
-        std::fs::write(repo_root.join("src/lib.rs"), "pub fn ok() {}\n")
-            .expect("write source file");
-
-        let reservation_id = reserve_files(&runtime, Some("jrun-owner"));
-        let release = runtime
-            .run_tool(
-                "orbit.task.locks.release",
-                json!({
-                    "reservation_id": reservation_id.clone(),
-                    "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
-                }),
-            )
-            .expect("release reservation");
-        assert_eq!(release["released"], true);
-
-        let row = task_lock_audit_event(
-            &runtime,
-            "orbit.task.locks.release",
-            "task.locks.reserve.released",
-        );
-        assert_eq!(row.target_id.as_deref(), Some(reservation_id.as_str()));
-        assert!(row.task_id.is_none());
-        assert_eq!(row.job_run_id.as_deref(), Some("jrun-owner"));
-    }
-
-    #[test]
-    fn reserve_audit_for_task_scope_records_first_task_id() {
-        let _env = unmanaged_tool_env_guard();
-        let (_root, runtime, repo_root) = test_runtime();
-        std::fs::create_dir_all(repo_root.join("src")).expect("create src dir");
-        std::fs::write(repo_root.join("src/lib.rs"), "pub fn ok() {}\n")
-            .expect("write source file");
-        let task = create_context_task(
-            &runtime,
-            &repo_root,
-            TaskStatus::Backlog,
-            &["file:src/lib.rs"],
-        );
-
-        let reserve = runtime
-            .run_tool(
-                "orbit.task.locks.reserve",
-                json!({
-                    "task_ids": [task.id.clone()],
-                    "ttl_seconds": 3600,
-                    "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
-                }),
-            )
-            .expect("reserve task scope");
-        assert_eq!(reserve["reserved"], true);
-        let reservation_id = reserve["reservation_id"]
-            .as_str()
-            .expect("reservation id")
-            .to_string();
-
-        let row = task_lock_audit_event(
-            &runtime,
-            "orbit.task.locks.reserve",
-            "task.locks.reserve.granted",
-        );
-        assert_eq!(row.target_id.as_deref(), Some(reservation_id.as_str()));
-        assert_eq!(row.task_id.as_deref(), Some(task.id.as_str()));
+fn task_lock_status_rank(status: TaskStatus) -> u8 {
+    match status {
+        TaskStatus::InProgress => 0,
+        TaskStatus::Review => 1,
+        _ => 2,
     }
 }

--- a/crates/orbit-core/src/runtime/task_reservation_cleanup.rs
+++ b/crates/orbit-core/src/runtime/task_reservation_cleanup.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 
 use crate::OrbitRuntime;
 
-use super::orbit_tool_host::{
+use super::task_locks::{
     emit_expired_reservation_events, emit_task_lock_release_event, workspace_orbit_dir,
     workspace_task_reservation_id,
 };

--- a/crates/orbit-core/src/runtime/tests/mod.rs
+++ b/crates/orbit-core/src/runtime/tests/mod.rs
@@ -4,5 +4,6 @@ mod run_audit;
 mod run_input;
 mod runtime;
 mod task_block_on_run_failure;
+mod task_locks;
 mod task_reservation_cleanup;
 mod tool_exec;

--- a/crates/orbit-core/src/runtime/tests/task_locks.rs
+++ b/crates/orbit-core/src/runtime/tests/task_locks.rs
@@ -9,7 +9,7 @@ use super::super::task_locks::{
     TaskLockReservationScope, parse_task_lock_reservation_scope, requested_task_files,
     task_lock_conflicts,
 };
-use super::super::test_support::{
+use crate::runtime::orbit_tool_host::test_support::{
     create_context_task, invalid_input_message, test_runtime, unmanaged_tool_env_guard,
 };
 
@@ -460,4 +460,145 @@ fn files_shape_reservations_conflict_and_release_like_task_reservations() {
         )
         .expect("task reservation succeeds after release");
     assert_eq!(task_reserve["reserved"], true);
+}
+
+use orbit_common::types::{AuditEvent, Role};
+use orbit_tools::{ReservationOwnerContext, ToolContext};
+
+fn task_lock_audit_event(runtime: &OrbitRuntime, tool_name: &str, command: &str) -> AuditEvent {
+    runtime
+        .list_audit_events(None, Some(tool_name.to_string()), None, None, 16)
+        .expect("list audit events")
+        .into_iter()
+        .find(|event| event.command == command)
+        .expect("task lock audit event")
+}
+
+fn reserve_files(runtime: &OrbitRuntime, owner_run_id: Option<&str>) -> String {
+    let input = json!({
+        "files": ["file:src/lib.rs"],
+        "ttl_seconds": 3600,
+        "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+    });
+    let output = match owner_run_id {
+        Some(owner_run_id) => runtime
+            .run_tool_with_context_and_role(
+                "orbit.task.locks.reserve",
+                input,
+                Role::Admin,
+                ToolContext {
+                    reservation_owner: Some(ReservationOwnerContext {
+                        owner_run_id: owner_run_id.to_string(),
+                        owner_metadata_json: None,
+                    }),
+                    ..ToolContext::default()
+                },
+            )
+            .expect("reserve direct file selectors with owner"),
+        None => runtime
+            .run_tool("orbit.task.locks.reserve", input)
+            .expect("reserve direct file selectors"),
+    };
+
+    output
+        .get("reservation_id")
+        .and_then(Value::as_str)
+        .expect("reservation id")
+        .to_string()
+}
+
+#[test]
+fn release_audit_without_owner_has_no_task_or_job_run_id() {
+    let _env = unmanaged_tool_env_guard();
+    let (_root, runtime, repo_root) = test_runtime();
+    std::fs::create_dir_all(repo_root.join("src")).expect("create src dir");
+    std::fs::write(repo_root.join("src/lib.rs"), "pub fn ok() {}\n").expect("write source file");
+
+    let reservation_id = reserve_files(&runtime, None);
+    let release = runtime
+        .run_tool(
+            "orbit.task.locks.release",
+            json!({
+                "reservation_id": reservation_id.clone(),
+                "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+            }),
+        )
+        .expect("release reservation");
+    assert_eq!(release["released"], true);
+
+    let row = task_lock_audit_event(
+        &runtime,
+        "orbit.task.locks.release",
+        "task.locks.reserve.released",
+    );
+    assert_eq!(row.target_id.as_deref(), Some(reservation_id.as_str()));
+    assert!(row.task_id.is_none());
+    assert!(row.job_run_id.is_none());
+}
+
+#[test]
+fn release_audit_uses_reservation_owner_run_id() {
+    let _env = unmanaged_tool_env_guard();
+    let (_root, runtime, repo_root) = test_runtime();
+    std::fs::create_dir_all(repo_root.join("src")).expect("create src dir");
+    std::fs::write(repo_root.join("src/lib.rs"), "pub fn ok() {}\n").expect("write source file");
+
+    let reservation_id = reserve_files(&runtime, Some("jrun-owner"));
+    let release = runtime
+        .run_tool(
+            "orbit.task.locks.release",
+            json!({
+                "reservation_id": reservation_id.clone(),
+                "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+            }),
+        )
+        .expect("release reservation");
+    assert_eq!(release["released"], true);
+
+    let row = task_lock_audit_event(
+        &runtime,
+        "orbit.task.locks.release",
+        "task.locks.reserve.released",
+    );
+    assert_eq!(row.target_id.as_deref(), Some(reservation_id.as_str()));
+    assert!(row.task_id.is_none());
+    assert_eq!(row.job_run_id.as_deref(), Some("jrun-owner"));
+}
+
+#[test]
+fn reserve_audit_for_task_scope_records_first_task_id() {
+    let _env = unmanaged_tool_env_guard();
+    let (_root, runtime, repo_root) = test_runtime();
+    std::fs::create_dir_all(repo_root.join("src")).expect("create src dir");
+    std::fs::write(repo_root.join("src/lib.rs"), "pub fn ok() {}\n").expect("write source file");
+    let task = create_context_task(
+        &runtime,
+        &repo_root,
+        TaskStatus::Backlog,
+        &["file:src/lib.rs"],
+    );
+
+    let reserve = runtime
+        .run_tool(
+            "orbit.task.locks.reserve",
+            json!({
+                "task_ids": [task.id.clone()],
+                "ttl_seconds": 3600,
+                "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+            }),
+        )
+        .expect("reserve task scope");
+    assert_eq!(reserve["reserved"], true);
+    let reservation_id = reserve["reservation_id"]
+        .as_str()
+        .expect("reservation id")
+        .to_string();
+
+    let row = task_lock_audit_event(
+        &runtime,
+        "orbit.task.locks.reserve",
+        "task.locks.reserve.granted",
+    );
+    assert_eq!(row.target_id.as_deref(), Some(reservation_id.as_str()));
+    assert_eq!(row.task_id.as_deref(), Some(task.id.as_str()));
 }

--- a/crates/orbit-core/src/runtime/tests/task_reservation_cleanup.rs
+++ b/crates/orbit-core/src/runtime/tests/task_reservation_cleanup.rs
@@ -6,7 +6,7 @@ use orbit_common::types::JobRunState;
 use orbit_store::TaskReservationReleaseReason;
 use serde_json::json;
 
-use super::super::orbit_tool_host::{workspace_orbit_dir, workspace_task_reservation_id};
+use super::super::task_locks::{workspace_orbit_dir, workspace_task_reservation_id};
 
 use chrono::Duration;
 use orbit_common::types::{AuditEventStatus, Role, TaskPriority, TaskStatus, TaskType};

--- a/crates/orbit-core/src/runtime/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/v2_host/dispatch.rs
@@ -8,7 +8,7 @@ use orbit_tools::ToolContext;
 use serde_json::Value;
 
 use crate::OrbitRuntime;
-use crate::runtime::orbit_tool_host::{
+use crate::runtime::task_locks::{
     emit_expired_reservation_events, merge_task_lock_conflicts, parse_task_ids,
     requested_task_files, task_lock_conflicts, workspace_orbit_dir, workspace_task_reservation_id,
 };

--- a/crates/orbit-core/src/runtime/v2_host/pipeline_actions.rs
+++ b/crates/orbit-core/src/runtime/v2_host/pipeline_actions.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use crate::OrbitRuntime;
 use crate::command::job::JobRunListParams;
-use crate::runtime::orbit_tool_host::parse_task_ids;
+use crate::runtime::task_locks::parse_task_ids;
 
 pub(super) fn validate_bundles(action: &str, input: &Value) -> Result<Value, DispatchError> {
     let bundles_raw = input


### PR DESCRIPTION
## Task

[ORB-10396](https://orbit-cli.com/tasks/ORB-10396) — Extract runtime/task_locks.rs from orbit_tool_host

### Description

Wave 3 of the orbit-core cleanup (design doc: ~/workspace/constellation/knowledgebase/polaris/design/orbit-cleanup/orbit-core-cleanup.md §9). Sequencing per design doc: do this AFTER v1 phase-out Stage 3, when runtime/engine shrinks and runtime/ module boundaries settle.

v2_host/dispatch.rs reaches into orbit_tool_host for seven reservation/lock helpers (emit_expired_reservation_events, merge_task_lock_conflicts, parse_task_ids, requested_task_files, task_lock_conflicts, workspace_orbit_dir, workspace_task_reservation_id), enabled by pub(crate) re-exports in orbit_tool_host/mod.rs. Task reservations are a runtime concern used by both hosts.

Move orbit_tool_host/task_locks.rs (599 production LOC + its tests) to runtime/task_locks.rs; both hosts import from the peer module; drop the cross-host re-exports. Pure refactor, no behavior change.

Dispatch gate: hold until ORB-10358 lands and the rebuild is verified.

### Acceptance Criteria

- task_locks lives at runtime/task_locks.rs with tests in the conforming layout; orbit_tool_host no longer re-exports lock helpers; no host imports from the other host; full test suite passes; no behavior change.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Moved the shared task reservation/lock implementation from `runtime/orbit_tool_host/task_locks.rs` to `runtime/task_locks.rs`, including its JSON projection helpers and the `parse_task_ids` helper.
- Relocated lock tests to the conforming sibling layout at `runtime/tests/task_locks.rs`; widened only the shared test-helper visibility needed by the new sibling test module.
- Updated both hosts and reservation-cleanup code to consume `runtime::task_locks`, removing orbit_tool_host lock-helper re-exports and v2_host imports from orbit_tool_host.
- Expanded context_files before editing to include the tightly coupled v2 pipeline action, reservation cleanup, JSON/parser, and test-support files required to complete the runtime extraction.

Assessment: Pure refactor; task-lock response shape and behavior are preserved.

Validation:
- `cargo fmt --all -- --check` passed.
- `cargo test -p orbit-core task_locks --lib` passed (13 tests).
- `make ci-fast` passed.
- `cargo test -p orbit-core --lib` compiled and ran 621 tests; 619 passed, 1 ignored, and one unrelated existing HTTP agent-loop test failed because no provider credential was available (`host.api_key_for returned an error`).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10396-6a65907a`
- Behind base: 0
- Ahead of base: 1