### PR TITLE
gc worktrees reclaims nothing: run-input key mismatch makes every worktree unrecognized

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/gc.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/gc.rs
@@ -4,21 +4,19 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use chrono::{DateTime, Utc};
-use orbit_common::types::{JobRun, JobRunState, OrbitError, TaskStatus};
+use orbit_common::types::{JobRun, JobRunState, OrbitError, Task, TaskStatus};
 use serde::Serialize;
 use serde_json::Value;
 
 use crate::context::TaskReadHost;
 
 use super::cleanup::remove_worktree;
-use super::{resolve_shared_worktree_path, resolve_worktree_path_from_prefix};
-
-const DEFAULT_BRANCH_PREFIX: &str = "orbit";
+use super::{WorktreeIdentity, resolve_shared_worktree_path};
 
 /// Task statuses that settle the work as done — the only statuses that
 /// license discarding a run's worktree and branch. Every other status
 /// (including `blocked` and `review`) retains it, and an unresolvable or
-/// missing task_id retains it as well: the collector fails closed.
+/// missing task id retains it as well: the collector fails closed.
 fn task_status_permits_deletion(status: TaskStatus) -> bool {
     matches!(
         status,
@@ -60,8 +58,9 @@ pub fn collect_worktrees<H: TaskReadHost + ?Sized>(
 ) -> Result<WorktreeGcResult, OrbitError> {
     let mut known_paths = BTreeMap::<PathBuf, Vec<&JobRun>>::new();
     for run in runs {
-        let path = expected_path(repo_root, run)?;
-        known_paths.entry(path).or_default().push(run);
+        for path in expected_paths(repo_root, run)? {
+            known_paths.entry(path).or_default().push(run);
+        }
     }
 
     let mut reports = Vec::new();
@@ -142,19 +141,22 @@ fn classify_known<H: TaskReadHost + ?Sized>(
     task_host: &H,
     options: &WorktreeGcOptions,
 ) -> Result<WorktreeGcReport, OrbitError> {
-    let task_id =
-        string_field(run.input.as_ref().unwrap_or(&Value::Null), "task_id").map(ToOwned::to_owned);
-    let task = task_id
-        .as_deref()
-        .and_then(|task_id| task_host.get_task(task_id).ok());
+    let task_ids = attributed_task_ids(run);
+    let resolved = task_ids
+        .iter()
+        .map(|task_id| (task_id.clone(), task_host.get_task(task_id).ok()))
+        .collect::<Vec<(String, Option<Task>)>>();
+    let first_task = resolved.first().and_then(|(_, task)| task.as_ref());
 
     let mut report = WorktreeGcReport {
         path: path.to_path_buf(),
         run_id: Some(run.run_id.clone()),
         run_state: Some(run.state),
-        task_id: task_id.clone(),
-        task_status: task.as_ref().map(|task| task.status),
-        pr_status: task.as_ref().and_then(|task| task.pr_status.clone()),
+        // A bundle worktree serves several tasks; name all of them until a
+        // single one is identified as the reason it is retained.
+        task_id: (!task_ids.is_empty()).then(|| task_ids.join(",")),
+        task_status: first_task.map(|task| task.status),
+        pr_status: first_task.and_then(|task| task.pr_status.clone()),
         action: String::new(),
         bytes_reclaimed: 0,
     };
@@ -192,17 +194,30 @@ fn classify_known<H: TaskReadHost + ?Sized>(
     // whether the work it produced is settled — a run with no associated
     // task, or one whose task can't be resolved, is retained rather than
     // treated as eligible.
-    if task_id.is_none() {
+    //
+    // Bundle rule (ORB-10427): a worktree that serves several tasks is
+    // eligible only when *every* task it serves is settled, so a bundle is
+    // never easier to discard than its least-settled member. The first
+    // member that blocks deletion becomes the reported task.
+    if resolved.is_empty() {
         report.action = "skipped:unattributed".to_string();
         return Ok(report);
     }
-    let Some(status) = report.task_status else {
-        report.action = "skipped:task_unresolved".to_string();
-        return Ok(report);
-    };
-    if !task_status_permits_deletion(status) {
-        report.action = "skipped:task_status_ineligible".to_string();
-        return Ok(report);
+    for (task_id, task) in &resolved {
+        let Some(task) = task else {
+            report.task_id = Some(task_id.clone());
+            report.task_status = None;
+            report.pr_status = None;
+            report.action = "skipped:task_unresolved".to_string();
+            return Ok(report);
+        };
+        if !task_status_permits_deletion(task.status) {
+            report.task_id = Some(task_id.clone());
+            report.task_status = Some(task.status);
+            report.pr_status = task.pr_status.clone();
+            report.action = "skipped:task_status_ineligible".to_string();
+            return Ok(report);
+        }
     }
 
     // Reported safety net, not a deletion gate: a task can be settled with
@@ -226,6 +241,9 @@ fn classify_known<H: TaskReadHost + ?Sized>(
     let estimated_bytes = directory_bytes(path)?;
     if !options.delete {
         report.action = "would_remove".to_string();
+        // In dry-run mode this is the estimate of what `--yes` would reclaim;
+        // the result's `dry_run` flag says nothing was actually freed.
+        report.bytes_reclaimed = estimated_bytes;
         return Ok(report);
     }
 
@@ -238,23 +256,30 @@ fn classify_known<H: TaskReadHost + ?Sized>(
     Ok(report)
 }
 
-fn expected_path(repo_root: &Path, run: &JobRun) -> Result<PathBuf, OrbitError> {
+/// Every directory this run could have left behind.
+///
+/// The identity is re-derived with the same rule `setup_worktree` used
+/// (ORB-10427) — never re-spelled here. A run whose input names no task never
+/// reached `setup_worktree`; its worktree, if any, is the shared batch
+/// worktree keyed by run id.
+fn expected_paths(repo_root: &Path, run: &JobRun) -> Result<Vec<PathBuf>, OrbitError> {
     let input = run.input.as_ref().unwrap_or(&Value::Null);
-    if let Some(prefix) = string_field(input, "branch_prefix") {
-        resolve_worktree_path_from_prefix(repo_root, prefix, &run.run_id)
-    } else if string_field(input, "task_id").is_some() {
-        resolve_worktree_path_from_prefix(repo_root, DEFAULT_BRANCH_PREFIX, &run.run_id)
-    } else {
-        resolve_shared_worktree_path(repo_root, &run.run_id)
-    }
+    let Ok(identity) = WorktreeIdentity::from_input(input, Some(&run.run_id)) else {
+        return Ok(vec![resolve_shared_worktree_path(repo_root, &run.run_id)?]);
+    };
+    let mut paths = vec![identity.path(repo_root)?];
+    paths.extend(identity.fallback_path(repo_root)?);
+    Ok(paths)
 }
 
-fn string_field<'a>(input: &'a Value, key: &str) -> Option<&'a str> {
-    input
-        .get(key)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
+/// The tasks a run's worktree serves, empty when the run names none.
+fn attributed_task_ids(run: &JobRun) -> Vec<String> {
+    WorktreeIdentity::from_input(
+        run.input.as_ref().unwrap_or(&Value::Null),
+        Some(&run.run_id),
+    )
+    .map(|identity| identity.task_ids)
+    .unwrap_or_default()
 }
 
 fn on_disk_worktrees(repo_root: &Path) -> Result<Vec<PathBuf>, OrbitError> {

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/mod.rs
@@ -7,12 +7,132 @@ use std::path::{Path, PathBuf};
 
 use orbit_common::types::OrbitError;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::executor::automation::input::{input_string_field, required_input_string};
 
 pub use gc::{WorktreeGcOptions, WorktreeGcResult, collect_worktrees};
 pub(in crate::executor::automation) use merge::merge_batch_worktree_into_base;
 pub(in crate::executor::automation) use setup::setup_worktree;
 
 const SHARED_WORKTREE_NAME_PREFIX: &str = "parallel-batch";
+const DEFAULT_BRANCH_PREFIX: &str = "orbit";
+
+/// What a run's worktree is: the tasks it serves, the branch prefix that
+/// names it, and the run token that makes its directory unique.
+///
+/// `setup_worktree` creates a worktree from this identity; the garbage
+/// collector re-derives the same identity from the stored run record to
+/// recognise the directory on disk. The two sites used to spell the rule out
+/// independently and silently drifted — gc probed a singular `task_id` while
+/// `task_pr_pipeline` emits a `task_ids` array — so gc matched no real
+/// directory, classified every worktree `skipped:unrecognized`, and reclaimed
+/// nothing (ORB-10427). This type is the single derivation; add new inputs
+/// here rather than at either call site.
+pub(in crate::executor::automation) struct WorktreeIdentity {
+    /// Every task the worktree serves, in input order. Non-empty.
+    pub(in crate::executor::automation) task_ids: Vec<String>,
+    /// The branch (and directory) prefix, `orbit` unless overridden.
+    pub(in crate::executor::automation) branch_prefix: String,
+    /// The token that names the directory alongside the prefix.
+    pub(in crate::executor::automation) run_id: String,
+}
+
+impl WorktreeIdentity {
+    /// Derive the identity from a `setup_worktree`-shaped input.
+    ///
+    /// `engine_run_id` is the id the engine knows the run by, consulted when
+    /// the input itself carries no `run_id`. `setup_worktree` passes `None`:
+    /// it only ever sees its own input, and falls back to a task-derived
+    /// token. gc passes the run record's id, because a stored `initial_input`
+    /// does not carry the `run_id` the engine injected at dispatch.
+    ///
+    /// Fails when the input names no task at all — such a run never went
+    /// through `setup_worktree`.
+    pub(in crate::executor::automation) fn from_input(
+        input: &Value,
+        engine_run_id: Option<&str>,
+    ) -> Result<Self, OrbitError> {
+        let task_ids = task_ids_from_input(input)?;
+        let run_id = input_string_field(input, "run_id")
+            .or_else(|| {
+                engine_run_id
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToOwned::to_owned)
+            })
+            .unwrap_or_else(|| fallback_run_id_for_tasks(&task_ids));
+        let branch_prefix = input_string_field(input, "branch_prefix")
+            .unwrap_or_else(|| DEFAULT_BRANCH_PREFIX.to_string());
+        Ok(Self {
+            task_ids,
+            branch_prefix,
+            run_id,
+        })
+    }
+
+    /// The worktree directory this identity resolves to.
+    pub(in crate::executor::automation) fn path(
+        &self,
+        repo_root: &Path,
+    ) -> Result<PathBuf, OrbitError> {
+        resolve_worktree_path_from_prefix(repo_root, &self.branch_prefix, &self.run_id)
+    }
+
+    /// The directory setup would have chosen had no `run_id` reached it, when
+    /// that differs from [`Self::path`].
+    ///
+    /// gc consults this as a second candidate so a worktree created under the
+    /// task-derived fallback token is still recognised: setup prefers
+    /// `input.run_id` and falls back to `task-<id>` / `bundle-<hash>`, and gc
+    /// cannot tell after the fact which branch setup took.
+    pub(in crate::executor::automation) fn fallback_path(
+        &self,
+        repo_root: &Path,
+    ) -> Result<Option<PathBuf>, OrbitError> {
+        let fallback = fallback_run_id_for_tasks(&self.task_ids);
+        if fallback == self.run_id {
+            return Ok(None);
+        }
+        resolve_worktree_path_from_prefix(repo_root, &self.branch_prefix, &fallback).map(Some)
+    }
+}
+
+fn task_ids_from_input(input: &Value) -> Result<Vec<String>, OrbitError> {
+    if let Some(items) = input.get("task_ids").and_then(Value::as_array) {
+        let task_ids = items
+            .iter()
+            .map(|item| {
+                item.as_str()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToOwned::to_owned)
+                    .ok_or_else(|| {
+                        OrbitError::InvalidInput(
+                            "setup_worktree input.task_ids entries must be non-empty strings"
+                                .to_string(),
+                        )
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if !task_ids.is_empty() {
+            return Ok(task_ids);
+        }
+    }
+
+    Ok(vec![required_input_string(input, "task_id")?.to_string()])
+}
+
+fn fallback_run_id_for_tasks(task_ids: &[String]) -> String {
+    if task_ids.len() == 1 {
+        return format!("task-{}", task_ids[0]);
+    }
+
+    let mut sorted_ids = task_ids.to_vec();
+    sorted_ids.sort();
+    let digest = Sha256::digest(sorted_ids.join(","));
+    format!("bundle-{}", &format!("{digest:x}")[..8])
+}
 
 /// Extract the `run_id` from an activity input value, returning a trimmed
 /// non-empty string. Used by activities that need to resolve the shared

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
@@ -5,16 +5,15 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
 use crate::context::{RuntimeHost, TaskAutomationUpdate, TaskHost, ensure_task_can_enter_workflow};
-use crate::executor::automation::input::{input_string_field, required_input_string};
+use crate::executor::automation::input::input_string_field;
 
 use super::super::git::{
     base_sync_mode_from_input, git_command_success, git_output, git_success,
     resolve_worktree_start_point,
 };
-use super::resolve_worktree_path_from_prefix;
+use super::WorktreeIdentity;
 
 const DEFAULT_BASE: &str = "main";
-const DEFAULT_BRANCH_PREFIX: &str = "orbit";
 
 /// Create a worktree and branch for a single task or task bundle, stamp
 /// `job_run_id` and `workspace_path` on every task in scope, and move them to
@@ -26,21 +25,20 @@ pub(in crate::executor::automation) fn setup_worktree<H: RuntimeHost + TaskHost 
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {
-    let task_ids = task_ids_from_input(input)?;
-    let run_id = input_string_field(input, "run_id")
-        .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| fallback_run_id_for_tasks(&task_ids));
+    // The worktree's identity is derived once, here and in gc, from the same
+    // rule (ORB-10427) — never re-spelled per call site.
+    let identity = WorktreeIdentity::from_input(input, None)?;
+    let task_ids = &identity.task_ids;
+    let run_id = &identity.run_id;
     let base = input_string_field(input, "base")
         .or_else(|| input_string_field(input, "base_branch"))
         .unwrap_or_else(|| DEFAULT_BASE.to_string());
     let base_sync_mode = base_sync_mode_from_input(input)?;
-    let branch_prefix = input_string_field(input, "branch_prefix")
-        .unwrap_or_else(|| DEFAULT_BRANCH_PREFIX.to_string());
 
     let repo_root_str = host.repo_root()?;
     let repo_root = Path::new(&repo_root_str);
 
-    for task_id in &task_ids {
+    for task_id in task_ids {
         ensure_task_can_enter_workflow(host, task_id, "worktree_setup")?;
     }
 
@@ -58,15 +56,15 @@ pub(in crate::executor::automation) fn setup_worktree<H: RuntimeHost + TaskHost 
         ],
     )?;
 
-    let branch_name = branch_name_for_tasks(&branch_prefix, &task_ids);
+    let branch_name = branch_name_for_tasks(&identity.branch_prefix, task_ids);
 
-    let worktree_path = resolve_worktree_path_from_prefix(repo_root, &branch_prefix, &run_id)?;
+    let worktree_path = identity.path(repo_root)?;
 
     ensure_worktree(repo_root, &worktree_path, &base_sha, &branch_name)?;
 
     let workspace_path_str = worktree_path.to_string_lossy().to_string();
 
-    for task_id in &task_ids {
+    for task_id in task_ids {
         host.admit_task_for_workflow(task_id, "worktree_setup")?;
         host.apply_task_automation_update(
             task_id,
@@ -78,7 +76,7 @@ pub(in crate::executor::automation) fn setup_worktree<H: RuntimeHost + TaskHost 
     }
 
     Ok(worktree_setup_output(
-        &run_id,
+        run_id,
         workspace_path_str,
         branch_name,
         start_point,
@@ -196,31 +194,6 @@ fn is_empty_dir(path: &Path) -> Result<bool, OrbitError> {
     Ok(entries.next().is_none())
 }
 
-fn task_ids_from_input(input: &Value) -> Result<Vec<String>, OrbitError> {
-    if let Some(items) = input.get("task_ids").and_then(Value::as_array) {
-        let task_ids = items
-            .iter()
-            .map(|item| {
-                item.as_str()
-                    .map(str::trim)
-                    .filter(|value| !value.is_empty())
-                    .map(ToOwned::to_owned)
-                    .ok_or_else(|| {
-                        OrbitError::InvalidInput(
-                            "setup_worktree input.task_ids entries must be non-empty strings"
-                                .to_string(),
-                        )
-                    })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        if !task_ids.is_empty() {
-            return Ok(task_ids);
-        }
-    }
-
-    Ok(vec![required_input_string(input, "task_id")?.to_string()])
-}
-
 fn branch_name_for_tasks(branch_prefix: &str, task_ids: &[String]) -> String {
     if task_ids.len() == 1 {
         let short_ts = format!(
@@ -238,15 +211,4 @@ fn branch_name_for_tasks(branch_prefix: &str, task_ids: &[String]) -> String {
     let digest = Sha256::digest(sorted_ids.join(","));
     let bundle_hash = format!("{digest:x}");
     format!("{branch_prefix}/bundle-{}", &bundle_hash[..8])
-}
-
-fn fallback_run_id_for_tasks(task_ids: &[String]) -> String {
-    if task_ids.len() == 1 {
-        return format!("task-{}", task_ids[0]);
-    }
-
-    let mut sorted_ids = task_ids.to_vec();
-    sorted_ids.sort();
-    let digest = Sha256::digest(sorted_ids.join(","));
-    format!("bundle-{}", &format!("{digest:x}")[..8])
 }

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/gc.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/gc.rs
@@ -6,18 +6,21 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Mutex;
 
-use chrono::Utc;
+use chrono::{Duration, Utc};
 use orbit_common::types::{
     ExternalRef, JobRun, JobRunState, NotFoundKind, OrbitError, Task, TaskArtifact, TaskPriority,
     TaskStatus, TaskType,
 };
-use serde_json::json;
+use serde_json::{Value, json};
 use tempfile::tempdir;
 
 use crate::context::TaskReadHost;
 
+use super::super::cleanup::remove_worktree;
 use super::super::gc::{WorktreeGcOptions, collect_worktrees};
-use super::super::{resolve_shared_worktree_path, resolve_worktree_path_from_prefix};
+use super::super::{
+    WorktreeIdentity, resolve_shared_worktree_path, resolve_worktree_path_from_prefix,
+};
 
 static WORKTREE_ROOT_ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -127,7 +130,7 @@ fn terminal_dirty_worktree_is_a_rescue_candidate() {
     let temp = tempdir().unwrap();
     let repo = temp.path().join("repo");
     init_repo(&repo);
-    let run = run("jrun-dirty", JobRunState::Failed, Some("ORB-DIRTY"));
+    let run = pipeline_run("jrun-dirty", JobRunState::Failed, &["ORB-DIRTY"]);
     let worktree = resolved_task_worktree(&repo, &run);
     add_worktree(&repo, &worktree, "orbit/dirty");
     fs::write(worktree.join("uncommitted.txt"), "valuable").unwrap();
@@ -155,7 +158,7 @@ fn dry_run_and_yes_share_eligibility_but_only_yes_removes() {
     let temp = tempdir().unwrap();
     let repo = temp.path().join("repo");
     init_repo(&repo);
-    let run = run("jrun-clean", JobRunState::Success, Some("ORB-CLEAN"));
+    let run = pipeline_run("jrun-clean", JobRunState::Success, &["ORB-CLEAN"]);
     let worktree = resolved_task_worktree(&repo, &run);
     add_worktree(&repo, &worktree, "orbit/clean");
     fs::write(worktree.join("bytes.bin"), [1_u8; 32]).unwrap();
@@ -194,16 +197,8 @@ fn colliding_sanitized_run_ids_are_ambiguous_and_never_removed() {
     let temp = tempdir().unwrap();
     let repo = temp.path().join("repo");
     init_repo(&repo);
-    let first = run(
-        "jrun:collision",
-        JobRunState::Success,
-        Some("ORB-COLLISION"),
-    );
-    let second = run(
-        "jrun-collision",
-        JobRunState::Success,
-        Some("ORB-COLLISION"),
-    );
+    let first = pipeline_run("jrun:collision", JobRunState::Success, &["ORB-COLLISION"]);
+    let second = pipeline_run("jrun-collision", JobRunState::Success, &["ORB-COLLISION"]);
     let worktree = resolved_task_worktree(&repo, &first);
     assert_eq!(worktree, resolved_task_worktree(&repo, &second));
     add_worktree(&repo, &worktree, "orbit/collision");
@@ -235,7 +230,7 @@ fn terminal_run_with_blocked_task_is_retained() {
     let temp = tempdir().unwrap();
     let repo = temp.path().join("repo");
     init_repo(&repo);
-    let run = run("jrun-blocked", JobRunState::Success, Some("ORB-BLOCKED"));
+    let run = pipeline_run("jrun-blocked", JobRunState::Success, &["ORB-BLOCKED"]);
     let worktree = resolved_task_worktree(&repo, &run);
     add_worktree(&repo, &worktree, "orbit/blocked");
     let host = FakeTaskHost::new(vec![task_fixture("ORB-BLOCKED", TaskStatus::Blocked)]);
@@ -262,7 +257,7 @@ fn terminal_run_with_review_task_is_retained() {
     let temp = tempdir().unwrap();
     let repo = temp.path().join("repo");
     init_repo(&repo);
-    let run = run("jrun-review", JobRunState::Success, Some("ORB-REVIEW"));
+    let run = pipeline_run("jrun-review", JobRunState::Success, &["ORB-REVIEW"]);
     let worktree = resolved_task_worktree(&repo, &run);
     add_worktree(&repo, &worktree, "orbit/review");
     let host = FakeTaskHost::new(vec![task_fixture("ORB-REVIEW", TaskStatus::Review)]);
@@ -288,7 +283,7 @@ fn unattributed_run_is_retained_and_reported() {
     let temp = tempdir().unwrap();
     let repo = temp.path().join("repo");
     init_repo(&repo);
-    let run = run("jrun-unattributed", JobRunState::Success, None);
+    let run = unattributed_run("jrun-unattributed", JobRunState::Success);
     let worktree = resolve_shared_worktree_path(&repo, &run.run_id).unwrap();
     add_worktree(&repo, &worktree, "orbit/unattributed");
     let host = FakeTaskHost::new(Vec::new());
@@ -339,7 +334,430 @@ fn resolver_uses_external_root_and_repository_name_when_configured() {
     restore_worktree_root(old);
 }
 
-fn run(id: &str, state: JobRunState, task_id: Option<&str>) -> JobRun {
+/// ORB-10427: the collector reclaimed nothing in production because it probed
+/// a singular `task_id` that `task_pr_pipeline` never writes, derived a
+/// `parallel-batch-*` path no worktree occupied, and reported every real
+/// worktree `skipped:unrecognized`. Nothing about this worktree is
+/// unrecognizable: the run record is complete and terminal and its task is
+/// settled.
+#[test]
+fn pipeline_shaped_run_is_recognized_and_reported_in_full() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo);
+    let run = pipeline_run("jrun-20260726-0305-2", JobRunState::Success, &["ORB-10419"]);
+    let worktree = resolved_task_worktree(&repo, &run);
+    add_worktree(&repo, &worktree, "orbit/ORB-10419-6a657983");
+    let host = FakeTaskHost::new(vec![task_fixture("ORB-10419", TaskStatus::Done)]);
+
+    let result = collect_worktrees(
+        &repo,
+        std::slice::from_ref(&run),
+        &host,
+        &WorktreeGcOptions::default(),
+    )
+    .unwrap();
+
+    let report = result
+        .reports
+        .iter()
+        .find(|report| report.path == worktree)
+        .expect("the worktree the pipeline created must appear in the report");
+    assert!(
+        !report.action.starts_with("skipped:"),
+        "an attributable worktree must not be skipped, got {}",
+        report.action
+    );
+    assert_eq!(report.action, "would_remove");
+    assert_eq!(report.run_id.as_deref(), Some("jrun-20260726-0305-2"));
+    assert_eq!(report.run_state, Some(JobRunState::Success));
+    assert_eq!(report.task_id.as_deref(), Some("ORB-10419"));
+    assert_eq!(report.task_status, Some(TaskStatus::Done));
+    assert!(
+        report.bytes_reclaimed > 0,
+        "a dry run still estimates what --yes would reclaim"
+    );
+    assert!(result.dry_run);
+    assert!(worktree.exists(), "a dry run never removes anything");
+}
+
+/// The bug was a silent divergence between two independent spellings of one
+/// rule: `setup_worktree` created `orbit-<run_id>` and gc looked for
+/// `parallel-batch-<run_id>`. Both now derive through [`WorktreeIdentity`].
+#[test]
+fn setup_and_gc_derive_the_same_worktree_path() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    let run = pipeline_run("jrun-derivation", JobRunState::Success, &["ORB-DERIVE"]);
+    let input = run.input.clone().unwrap();
+
+    let identity = WorktreeIdentity::from_input(&input, Some(&run.run_id)).unwrap();
+
+    assert_eq!(identity.task_ids, vec!["ORB-DERIVE".to_string()]);
+    assert_eq!(identity.branch_prefix, "orbit");
+    assert_eq!(identity.run_id, "jrun-derivation");
+    assert_eq!(
+        identity.path(&repo).unwrap(),
+        resolved_task_worktree(&repo, &run)
+    );
+}
+
+/// Stored runs from before `task_ids` existed still carry the singular key.
+#[test]
+fn legacy_singular_task_id_run_is_still_recognized() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo);
+    let run = legacy_task_id_run("jrun-legacy", JobRunState::Success, "ORB-LEGACY");
+    let worktree = resolved_task_worktree(&repo, &run);
+    add_worktree(&repo, &worktree, "orbit/legacy");
+    let host = FakeTaskHost::new(vec![task_fixture("ORB-LEGACY", TaskStatus::Done)]);
+
+    let result = collect_worktrees(&repo, &[run], &host, &WorktreeGcOptions::default()).unwrap();
+
+    assert_eq!(result.reports[0].action, "would_remove");
+    assert_eq!(result.reports[0].task_id.as_deref(), Some("ORB-LEGACY"));
+}
+
+/// The second divergence of the same shape: `setup_worktree` falls back to a
+/// task-derived token when no `run_id` reaches it, while gc only ever knew the
+/// run record's id. gc now considers both candidates.
+#[test]
+fn worktree_created_under_the_task_derived_fallback_is_recognized() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo);
+    let run = pipeline_run("jrun-fallback", JobRunState::Success, &["ORB-FALLBACK"]);
+    let fallback = resolve_worktree_path_from_prefix(&repo, "orbit", "task-ORB-FALLBACK").unwrap();
+    assert_ne!(fallback, resolved_task_worktree(&repo, &run));
+    add_worktree(&repo, &fallback, "orbit/fallback");
+    let host = FakeTaskHost::new(vec![task_fixture("ORB-FALLBACK", TaskStatus::Blocked)]);
+
+    let result = collect_worktrees(
+        &repo,
+        &[run],
+        &host,
+        &WorktreeGcOptions {
+            delete: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let report = result
+        .reports
+        .iter()
+        .find(|report| report.path == fallback)
+        .expect("the fallback-named worktree must be attributed to its run");
+    assert_eq!(report.action, "skipped:task_status_ineligible");
+    assert_eq!(report.run_id.as_deref(), Some("jrun-fallback"));
+    assert!(fallback.exists());
+}
+
+/// Bundle rule: a worktree serving several tasks is only eligible when every
+/// task it serves is settled, and the report names the member that blocked it.
+/// A bundle is never easier to discard than its least-settled member.
+#[test]
+fn bundle_worktree_is_retained_until_every_member_settles() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo);
+    let run = pipeline_run(
+        "jrun-bundle",
+        JobRunState::Success,
+        &["ORB-BUNDLE-A", "ORB-BUNDLE-B"],
+    );
+    let worktree = resolved_task_worktree(&repo, &run);
+    add_worktree(&repo, &worktree, "orbit/bundle-0badc0de");
+    let host = FakeTaskHost::new(vec![
+        task_fixture("ORB-BUNDLE-A", TaskStatus::Done),
+        task_fixture("ORB-BUNDLE-B", TaskStatus::Review),
+    ]);
+
+    let result = collect_worktrees(
+        &repo,
+        &[run],
+        &host,
+        &WorktreeGcOptions {
+            delete: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(worktree.exists());
+    assert_eq!(result.reports[0].action, "skipped:task_status_ineligible");
+    assert_eq!(
+        result.reports[0].task_id.as_deref(),
+        Some("ORB-BUNDLE-B"),
+        "the report names the member that blocked the bundle"
+    );
+    assert_eq!(result.reports[0].task_status, Some(TaskStatus::Review));
+}
+
+#[test]
+fn bundle_worktree_with_every_member_settled_is_eligible() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo);
+    let run = pipeline_run(
+        "jrun-bundle-settled",
+        JobRunState::Success,
+        &["ORB-BUNDLE-A", "ORB-BUNDLE-B"],
+    );
+    let worktree = resolved_task_worktree(&repo, &run);
+    add_worktree(&repo, &worktree, "orbit/bundle-5ettled");
+    let host = FakeTaskHost::new(vec![
+        task_fixture("ORB-BUNDLE-A", TaskStatus::Done),
+        task_fixture("ORB-BUNDLE-B", TaskStatus::Archived),
+    ]);
+
+    let result = collect_worktrees(&repo, &[run], &host, &WorktreeGcOptions::default()).unwrap();
+
+    assert_eq!(result.reports[0].action, "would_remove");
+    assert_eq!(
+        result.reports[0].task_id.as_deref(),
+        Some("ORB-BUNDLE-A,ORB-BUNDLE-B"),
+        "an eligible bundle names every task it serves"
+    );
+}
+
+/// Safety gate: a worktree may still back a live process.
+#[test]
+fn non_terminal_run_is_retained() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo);
+    let run = pipeline_run("jrun-running", JobRunState::Running, &["ORB-RUNNING"]);
+    let worktree = resolved_task_worktree(&repo, &run);
+    add_worktree(&repo, &worktree, "orbit/running");
+    let host = FakeTaskHost::new(vec![task_fixture("ORB-RUNNING", TaskStatus::Done)]);
+
+    let result = collect_worktrees(
+        &repo,
+        &[run],
+        &host,
+        &WorktreeGcOptions {
+            delete: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(worktree.exists());
+    assert_eq!(result.reports[0].action, "skipped:run_not_terminal");
+}
+
+/// Safety gate: `--older-than-hours` holds back recently finished runs.
+#[test]
+fn run_finished_after_the_cutoff_is_retained() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo);
+    let run = pipeline_run("jrun-recent", JobRunState::Success, &["ORB-RECENT"]);
+    let worktree = resolved_task_worktree(&repo, &run);
+    add_worktree(&repo, &worktree, "orbit/recent");
+    let host = FakeTaskHost::new(vec![task_fixture("ORB-RECENT", TaskStatus::Done)]);
+
+    let result = collect_worktrees(
+        &repo,
+        &[run],
+        &host,
+        &WorktreeGcOptions {
+            delete: true,
+            older_than: Some(Utc::now() - Duration::hours(1)),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(worktree.exists());
+    assert_eq!(result.reports[0].action, "skipped:too_recent");
+}
+
+/// Safety gate: the collector never follows a symlink standing where a
+/// worktree should be.
+#[cfg(unix)]
+#[test]
+fn symlink_at_a_known_worktree_path_is_never_followed() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo);
+    let run = pipeline_run("jrun-symlink", JobRunState::Success, &["ORB-SYMLINK"]);
+    let worktree = resolved_task_worktree(&repo, &run);
+    let elsewhere = temp.path().join("elsewhere");
+    fs::create_dir_all(&elsewhere).unwrap();
+    fs::write(elsewhere.join("precious.txt"), "keep me").unwrap();
+    fs::create_dir_all(worktree.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(&elsewhere, &worktree).unwrap();
+    let host = FakeTaskHost::new(vec![task_fixture("ORB-SYMLINK", TaskStatus::Done)]);
+
+    let result = collect_worktrees(
+        &repo,
+        &[run],
+        &host,
+        &WorktreeGcOptions {
+            delete: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(elsewhere.join("precious.txt").exists());
+    assert_eq!(result.reports[0].action, "skipped:not_a_real_directory");
+}
+
+/// Safety gate: a directory Git does not know as a worktree is left alone,
+/// even at a path a run record claims.
+#[test]
+fn unregistered_directory_at_a_known_path_is_retained() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo);
+    let run = pipeline_run("jrun-unregistered", JobRunState::Success, &["ORB-UNREG"]);
+    let worktree = resolved_task_worktree(&repo, &run);
+    fs::create_dir_all(&worktree).unwrap();
+    fs::write(worktree.join("rescue.txt"), "keep me").unwrap();
+    let host = FakeTaskHost::new(vec![task_fixture("ORB-UNREG", TaskStatus::Done)]);
+
+    let result = collect_worktrees(
+        &repo,
+        &[run],
+        &host,
+        &WorktreeGcOptions {
+            delete: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(worktree.join("rescue.txt").exists());
+    assert_eq!(result.reports[0].action, "skipped:not_registered_worktree");
+}
+
+/// Safety gate: a task the store cannot resolve says nothing about whether
+/// the work settled, so the worktree is retained.
+#[test]
+fn run_whose_task_cannot_be_resolved_is_retained() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo);
+    let run = pipeline_run("jrun-missing", JobRunState::Success, &["ORB-MISSING"]);
+    let worktree = resolved_task_worktree(&repo, &run);
+    add_worktree(&repo, &worktree, "orbit/missing");
+    let host = FakeTaskHost::new(Vec::new());
+
+    let result = collect_worktrees(
+        &repo,
+        &[run],
+        &host,
+        &WorktreeGcOptions {
+            delete: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(worktree.exists());
+    assert_eq!(result.reports[0].action, "skipped:task_unresolved");
+    assert_eq!(result.reports[0].task_id.as_deref(), Some("ORB-MISSING"));
+    assert_eq!(result.reports[0].task_status, None);
+}
+
+/// Safety gate: a detached worktree has no branch to reason about, so it is
+/// never collected.
+#[test]
+fn detached_worktree_with_no_branch_is_retained() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo);
+    let run = pipeline_run("jrun-detached", JobRunState::Success, &["ORB-DETACHED"]);
+    let worktree = resolved_task_worktree(&repo, &run);
+    git(
+        &repo,
+        &[
+            "worktree",
+            "add",
+            "--detach",
+            worktree.to_str().unwrap(),
+            "HEAD",
+        ],
+    );
+    let host = FakeTaskHost::new(vec![task_fixture("ORB-DETACHED", TaskStatus::Done)]);
+
+    let result = collect_worktrees(
+        &repo,
+        &[run],
+        &host,
+        &WorktreeGcOptions {
+            delete: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(worktree.exists());
+    assert_eq!(result.reports[0].action, "skipped:branch_unknown");
+}
+
+/// The removal itself is the last gate: gc calls `remove_worktree` without
+/// `--force`, so a worktree dirtied after the status check makes Git refuse.
+/// Never replace this with a recursive delete.
+#[test]
+fn removal_without_force_fails_closed_on_a_dirty_worktree() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo);
+    let worktree = repo.join(".orbit/state/worktrees/orbit-jrun-noforce");
+    add_worktree(&repo, &worktree, "orbit/noforce");
+    fs::write(worktree.join("uncommitted.txt"), "valuable").unwrap();
+
+    let error = remove_worktree(&repo, &worktree, Some("orbit/noforce"), false)
+        .expect_err("git must refuse to remove a dirty worktree without --force");
+
+    assert!(worktree.join("uncommitted.txt").exists());
+    assert!(
+        format!("{error}").contains("worktree remove"),
+        "unexpected error: {error}"
+    );
+}
+
+/// A run record shaped exactly like a real `task_pr_pipeline` run: `task_ids`
+/// as an array, no `branch_prefix`, and no singular `task_id`. Also no
+/// `run_id` — the engine injects that into the activity input at dispatch, so
+/// the stored `initial_input` never carries it.
+///
+/// Copied from run `jrun-20260726-0305-2` on dk-server-1 (ORB-10427). GC
+/// probed the singular `task_id` against this shape, missed, derived a
+/// `parallel-batch-*` path that no worktree ever occupied, and so classified
+/// every real worktree `skipped:unrecognized`.
+fn pipeline_run(id: &str, state: JobRunState, task_ids: &[&str]) -> JobRun {
+    job_run(
+        id,
+        state,
+        json!({
+            "auto_push": true,
+            "base_branch": "agent-main",
+            "base_sync": "remote",
+            "review": false,
+            "review_crew": null,
+            "task_ids": task_ids,
+        }),
+    )
+}
+
+/// A pre-`task_ids` run record. Stored runs from older pipelines still carry
+/// the singular key, and gc must keep recognizing them.
+fn legacy_task_id_run(id: &str, state: JobRunState, task_id: &str) -> JobRun {
+    job_run(id, state, json!({ "task_id": task_id }))
+}
+
+/// A run that names no task at all — it never went through `setup_worktree`.
+fn unattributed_run(id: &str, state: JobRunState) -> JobRun {
+    job_run(id, state, json!({}))
+}
+
+fn job_run(id: &str, state: JobRunState, input: Value) -> JobRun {
     let now = Utc::now();
     JobRun {
         run_id: id.to_string(),
@@ -353,10 +771,7 @@ fn run(id: &str, state: JobRunState, task_id: Option<&str>) -> JobRun {
         created_at: now,
         pid: None,
         pid_start_time: None,
-        input: Some(match task_id {
-            Some(task_id) => json!({"task_id": task_id}),
-            None => json!({}),
-        }),
+        input: Some(input),
         retry_source_run_id: None,
         knowledge_metrics: None,
         resolved_crew: None,
@@ -365,6 +780,10 @@ fn run(id: &str, state: JobRunState, task_id: Option<&str>) -> JobRun {
     }
 }
 
+/// The directory `setup_worktree` creates for a run with no `branch_prefix`
+/// override, spelled out independently of the production derivation so these
+/// tests pin the on-disk outcome rather than restating the code under test.
+/// [`setup_and_gc_derive_the_same_worktree_path`] ties the two together.
 fn resolved_task_worktree(repo: &Path, run: &JobRun) -> PathBuf {
     resolve_worktree_path_from_prefix(repo, "orbit", &run.run_id).unwrap()
 }

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Decisions"
 type: design
 title: "Activity / Job — Decisions"
 owner: codex
-last_updated: 2026-07-25
+last_updated: 2026-07-26
 status: Draft
 feature: activity-job
 doc_role: decisions
@@ -728,8 +728,28 @@ Commits found above the pinned base are adopted with a loud `warn` naming the sh
 
 ---
 
+## ADR-0253 — A worktree's identity is derived once, and a bundle is only collectable when every member has settled
+
+**Status:** Accepted · 2026-07 · [ORB-10427]
+
+**Context.** `orbit gc worktrees` had never reclaimed a byte. `setup_worktree` derived the worktree directory from `task_ids_from_input` (array-first, singular fallback) and named it `orbit-<run_id>`; the collector spelled the same rule out a second time, probing only the singular `task_id` that `task_pr_pipeline` does not emit, missing, and deriving the shared `parallel-batch-<run_id>` path instead. No entry in the collector's known-path map ever matched a real directory, so every worktree fell through to the on-disk sweep and was reported `skipped:unrecognized` — a terminal classification no flag can act on, which reads as "nothing to do" rather than "the collector is broken". Measured on dk-server-1 (binary `0.9.2`, gc source current): 6/6 worktrees in `codebases/orbit`, 4/4 in `knowledgebase/polaris`, 3/3 in `constellation`, `total_bytes_reclaimed=0` in each. The same singular probe attributed the worktree to a task, so repairing only the path derivation would have moved every worktree from `skipped:unrecognized` to `skipped:unattributed` and still reclaimed nothing. Two independent spellings of one rule is the defect; fixing the key probe at both sites would have left the shape intact, and a third site would drift the same way.
+
+**Decision.** One derivation, `WorktreeIdentity::from_input`, owns the task ids, the branch prefix, and the run token; `setup_worktree` creates from it and gc re-derives from it. The token resolves as `input.run_id`, then the engine's run id, then the task-derived fallback (`task-<id>` / `bundle-<hash>`) — setup passes no engine id because it only sees its own input, gc passes the run record's id because a stored `initial_input` never carries the one the engine injected at dispatch. That precedence closes the first divergence; gc also probes the fallback-token path as a second candidate, closing the second (a worktree setup named `task-<id>` was previously invisible to gc). Attribution reads the whole `task_ids` array, and the **bundle rule is unanimity**: a worktree serving several tasks is eligible only when *every* member resolves and is settled to `rejected`/`archived`/`done`, so a bundle is never easier to discard than its least-settled member. The first member that blocks becomes the reported `task_id`/`task_status`; an eligible bundle names all of them.
+
+Recognition is the entire change: no safety gate moved. Non-terminal run, `--older-than-hours`, symlink-or-not-a-directory, unregistered-with-Git, unresolvable task, ineligible status, dirty-rescue, and unknown-branch each still return their own `skipped:*` action, each now pinned by a test that fails if the gate is deleted, and `remove_worktree` is still called without `--force` so a last-moment dirtying makes Git fail closed. `skipped:unrecognized` is preserved for the case it was meant for — a directory matching no run record at all — and is still never deleted.
+
+**Consequences.**
+- gc works. Same three repos, dry run, branch build: zero `skipped:unrecognized`, every worktree attributed with a real `run_id`/`run_state`/`task_id`/`task_status`, `would_remove` on 10 of 12 with the other two correctly held by the non-terminal gate — 3.29 GB in `codebases/orbit` alone.
+- A dry run now reports the byte estimate per report and in the total, so `--dry-run` answers "how much would this reclaim" instead of always `0`. The envelope's `dry_run: true` remains the statement that nothing was freed.
+- Regression fixtures use the shape `task_pr_pipeline` actually emits (`task_ids` array, no `branch_prefix`, no `run_id`), captured from run `jrun-20260726-0305-2`. A fixture hand-built with a singular `task_id` passes against the broken code and proves nothing.
+- Cost: gc considers up to two candidate paths per run, so two runs over the same task both claiming the fallback name collide into `skipped:ambiguous_run_path` rather than either being collected. That is the fail-closed direction.
+- Out of scope, deliberately: no `--force`/`--include-unrecognized` reap flag for genuinely orphaned directories. Widening what gc will delete is a separate decision from making it see.
+
+---
+
 ## Task References
 
+- **[ORB-10427]** — Share one worktree-path derivation between `setup_worktree` and gc; collect bundles only when every member has settled.
 - **[ORB-10393]** — Port planning-duel planner and arbiter legs to seeded v2
   assets with per-slot model overrides and retire `RuntimeHost::invoke_activity`.
 - **[ORB-10385]** — Gate job admission on the runtime's deterministic-action registry; register `pr_failure_handoff` and `worktree_gc`.


### PR DESCRIPTION
## Task

[ORB-10427](https://orbit-cli.com/tasks/ORB-10427) — gc worktrees reclaims nothing: run-input key mismatch makes every worktree unrecognized

### Description

## Problem

`orbit gc worktrees` classifies **every** worktree it finds as `skipped:unrecognized` and reclaims zero bytes. The command is completely non-functional in production — it has never reclaimed anything.

Reproduced on dk-server-1 (binary `orbit 0.9.2` at `~/.orbit/bin/orbit`, verified byte-identical to a build of `4dddd94f`, an ancestor of current `agent-main` — the gc source in the running binary is current, this is not a stale-binary artifact; `ORBIT_WORKTREE_ROOT` unset):

```
$ orbit gc worktrees
path=.../.orbit/state/worktrees/orbit-jrun-20260726-0305-2 run_id=- run_state=- task_id=- task_status=- pr_status=- action=skipped:unrecognized bytes_reclaimed=0
```

**Scope — systemic, not repo-specific.** Every worktree in every repo checked:

| Repo | Worktrees | `skipped:unrecognized` | Disk |
|---|---|---|---|
| `codebases/orbit` | 6 | 6 | **~44 GB** |
| `knowledgebase/polaris` | 4 | 4 | 6.3 MB |
| `constellation` (root) | 3 | 3 | 2.3 MB |

## Evidence

The worktree above is healthy and fully attributable by hand: it is a real directory, registered in `git worktree list --porcelain`, on branch `orbit/ORB-10419-6a657983`, produced by run `jrun-20260726-0305-2` (job `task_pr_pipeline`, terminal, task ORB-10419, PR #738). Its run record exists and is complete. Nothing about it is actually unrecognizable.

Its `initial_input` verbatim:

```json
{"auto_push":true,"base_branch":"agent-main","base_sync":"remote","review":false,"review_crew":null,"task_ids":["ORB-10419"]}
```

The pipeline writes **`task_ids`** (plural, array). `gc.rs::expected_path` probes `string_field(input, "task_id")` — **singular, string**. It misses, so the run falls through to the shared-worktree branch and derives `parallel-batch-jrun-20260726-0305-2`, while `setup_worktree` (which reads `task_ids` correctly, via `task_ids_from_input`) created `orbit-jrun-20260726-0305-2`. No path in `known_paths` ever matches a real directory, so the on-disk sweep reports all of them as unrecognized.

## Why It Matters

~44 GB of reclaimable disk on the box is unreachable, and growing with every pipeline run. Worse, the failure is silent-by-design: `skipped:unrecognized` is a terminal classification with no flag that can act on it, so the command reports a wall of skips and exits 0. It reads as "nothing to do" rather than "the collector is broken."

## Constraints / Notes

- **The singular `task_id` probe appears at more than one decision site in `gc.rs`.** Besides path derivation in `expected_path`, `classify_known` reads the same singular key to attribute a worktree to a task, and retains anything it cannot attribute (`skipped:unattributed`). A change that only repairs path derivation will move every worktree from one skip bucket to another and still reclaim nothing — verify the whole classification path end to end, not just the first mismatch.
- **A run can carry multiple task ids.** `task_ids` is an array and bundle runs populate it with more than one. Deletion eligibility for a multi-task worktree needs a defined rule, and it must preserve the existing fail-closed posture: the current gate deletes only for `rejected`/`archived`/`done` and retains on anything unresolvable. Whatever rule is chosen must not make a bundle *easier* to delete than its least-settled member. State the rule explicitly in the execution summary.
- **`setup_worktree` and `expected_path` derive the same path independently from the same input**, which is what allowed them to drift apart silently. There is a second latent divergence in the same shape: setup falls back to `fallback_run_id_for_tasks` (yielding `task-<id>` / `bundle-<hash>`) when `input.run_id` is absent, while gc always uses `run.run_id`. Consider whether the two sites should share one derivation rather than fixing the key probe twice.
- **The deletion path is safety-critical and currently correct — do not loosen it.** `remove_worktree` is deliberately called without `--force` so a last-moment dirty worktree makes Git fail closed; the dirty check, the registered-worktree check, the symlink/not-a-dir check, and the non-terminal-run check are all deliberate. This task makes gc *recognize* worktrees; it must not widen what gc is willing to delete. Never introduce raw recursive deletion.
- Regression coverage must fail against the current code. A test that exercises a hand-built input with a singular `task_id` will pass today and prove nothing — fixtures must use the input shape the pipeline actually emits (`task_ids` array, no `branch_prefix`), ideally captured from a real `task_pr_pipeline` run record.
- Existing tests in `crates/orbit-engine/src/executor/automation/vcs/worktree/tests/gc.rs` assert `skipped:unrecognized` for a case that is presumably genuinely unrecognizable. Distinguish that legitimate case from this bug rather than deleting the assertion.
- PR mode — `orbit` is PR+CI gated. Branch off `agent-main`, land via PR.

## Out of scope

- Adding a `--force`/`--include-unrecognized` reap flag for genuinely unattributable directories. If the fix leaves a residue of truly orphaned worktrees, file a follow-up rather than inlining a new deletion surface into this change.
- Actually reaping the ~44 GB on dk-server-1. That is an operational step for Daniel after this lands and is verified in dry-run.

### Acceptance Criteria

- A regression test in `crates/orbit-engine/src/executor/automation/vcs/worktree/tests/gc.rs` builds a `JobRun` whose `input` matches the shape a real `task_pr_pipeline` run emits (`task_ids` as a one-element array, no `branch_prefix`, no singular `task_id`) alongside a worktree created by `setup_worktree`'s own derivation, and asserts the resulting report is NOT a `skipped:*` action. This test fails on the parent commit and passes on the branch — paste both outcomes in the execution summary.
- A second regression test covers the multi-element `task_ids` (bundle) case and pins the chosen eligibility rule: a bundle worktree whose tasks are not all settled to rejected/archived/done is retained, and the report names which task blocked it.
- The report for an attributable worktree populates `run_id`, `run_state`, `task_id`, and `task_status` with real values instead of `-`; a settled task yields `would_remove` in dry-run mode and a non-zero `bytes_reclaimed` estimate.
- Tests still assert that a genuinely unattributable on-disk directory (one matching no run record at all) is reported `skipped:unrecognized` and is never deleted — the existing legitimate case is preserved, not deleted from the suite.
- Every pre-existing safety gate in `classify_known` still returns its own distinct `skipped:*` action, each covered by a test that fails if the gate is removed: non-terminal run, too recent, symlink or non-directory, unregistered worktree, unresolvable task, ineligible task status, dirty worktree, unknown branch. `remove_worktree` is still invoked without `--force`.
- `cargo test -p orbit-engine` and `cargo clippy --all-targets -- -D warnings` both pass; CI is green on the PR.
- Verified against real state on dk-server-1: with the rebuilt binary, `orbit gc worktrees` (DRY RUN, no `--yes`) in `codebases/orbit`, `knowledgebase/polaris`, and the `constellation` root reports zero `skipped:unrecognized` entries for worktrees that have a resolvable run record, and the per-repo before/after action counts are pasted into the execution summary. Do not run with `--yes`.

## Execution Summary

<details>
<summary>Click to expand</summary>

## What was wrong

`setup_worktree` and `gc` each spelled out the worktree-path rule independently. Setup read `task_ids` (array-first) and created `orbit-<run_id>`; `gc.rs::expected_path` probed the singular `task_id` that `task_pr_pipeline` never emits, missed, and derived `parallel-batch-<run_id>`. No entry in gc's known-path map ever matched a real directory, so every worktree fell through to the on-disk sweep as `skipped:unrecognized`. `classify_known` read the same singular key, so repairing only the path derivation would have moved every worktree to `skipped:unattributed` and still reclaimed nothing.

## Fix

**One derivation, not two.** `WorktreeIdentity::from_input` (in `worktree/mod.rs`) now owns task ids, branch prefix, and run token; `setup_worktree` creates from it and gc re-derives from it. `task_ids_from_input` and `fallback_run_id_for_tasks` moved out of `setup.rs` into `mod.rs` — no logic duplicated.

**Run-token precedence:** `input.run_id` -> engine run id -> task-derived fallback (`task-<id>` / `bundle-<hash>`). Setup passes `None` for the engine id (it only sees its own input, so its behaviour is byte-identical to before); gc passes `run.run_id`, because a stored `initial_input` never carries the id the engine injected at dispatch. This closes the first divergence. gc also probes the fallback-token path as a second candidate, closing the second latent divergence named in the task: a worktree setup named `orbit-task-<id>` was previously invisible to gc.

**Bundle eligibility rule (stated explicitly, as required): unanimity.** A worktree serving several tasks is eligible only when *every* member resolves AND every member is settled to `rejected`/`archived`/`done`. The first member that is unresolvable or unsettled blocks the whole worktree and becomes the reported `task_id`/`task_status`; an eligible bundle reports all its ids. A bundle is therefore never easier to discard than its least-settled member, and the fail-closed posture is unchanged.

**Nothing about deletion was widened.** Every pre-existing gate returns its own distinct `skipped:*` action: `run_not_terminal`, `too_recent`, `not_a_real_directory`, `not_registered_worktree`, `unattributed`, `task_unresolved`, `task_status_ineligible`, `dirty_rescue_candidate`, `branch_unknown`. `remove_worktree` is still invoked without `--force`. No recursive deletion. `skipped:unrecognized` is preserved for the case it was meant for (a directory matching no run record) and is still never deleted.

One behaviour addition, required by AC3: a dry run now populates `bytes_reclaimed` with the estimate rather than `0`, so `--dry-run` answers "how much would this reclaim". `dry_run: true` in the envelope remains the statement that nothing was freed.

## AC1 — regression test fails on parent, passes on branch

Test: `pipeline_shaped_run_is_recognized_and_reported_in_full`. Fixture is the verbatim input shape from run `jrun-20260726-0305-2` (`task_ids` array, no `branch_prefix`, no singular `task_id`, no `run_id`).

On the parent commit (666dc70e, source files reverted, test file kept):
```
test ...gc::pipeline_shaped_run_is_recognized_and_reported_in_full ... FAILED
panicked at .../tests/gc.rs:364:5:
an attributable worktree must not be skipped, got skipped:unrecognized
```

On the branch:
```
test ...gc::pipeline_shaped_run_is_recognized_and_reported_in_full ... ok
```

Whole-suite comparison, same test file against parent vs branch implementation: parent `FAILED. 6 passed; 15 failed`; branch `ok. 22 passed; 0 failed`. The 6 that pass on both are the ones that must: `unrecognized_hand_made_worktree_survives_collection` (AC4 — the legitimate case, preserved not deleted), `legacy_singular_task_id_run_is_still_recognized`, `unattributed_run_is_retained_and_reported`, `removal_without_force_fails_closed_on_a_dirty_worktree`, and the two path-resolver tests. (The parent run excludes `setup_and_gc_derive_the_same_worktree_path`, which names a type that does not exist on the parent commit.)

## AC2 / AC5 — coverage

New: `pipeline_shaped_run_is_recognized_and_reported_in_full`, `setup_and_gc_derive_the_same_worktree_path`, `legacy_singular_task_id_run_is_still_recognized`, `worktree_created_under_the_task_derived_fallback_is_recognized`, `bundle_worktree_is_retained_until_every_member_settles` (asserts the report names `ORB-BUNDLE-B`, the Review member), `bundle_worktree_with_every_member_settled_is_eligible`, `non_terminal_run_is_retained`, `run_finished_after_the_cutoff_is_retained`, `symlink_at_a_known_worktree_path_is_never_followed`, `unregistered_directory_at_a_known_path_is_retained`, `run_whose_task_cannot_be_resolved_is_retained`, `detached_worktree_with_no_branch_is_retained`, `removal_without_force_fails_closed_on_a_dirty_worktree`. Existing tests were retargeted to the pipeline input shape rather than replaced; the legacy singular-`task_id` shape keeps its own test.

## AC6 — validation

- `cargo test -p orbit-engine`: **305 passed, 0 failed** (22 in the gc module).
- `cargo fmt --check`: clean. `make ci-fast`: passes.
- `cargo clippy -p orbit-engine --all-targets`: no warning from any file this task touches.
- `cargo clippy --all-targets -- -D warnings`: fails, but **pre-existing and unrelated** — `too many arguments (8/7)` at `crates/orbit-engine/src/executor/automation/duel/planning_duel/runner.rs:29`, a file this task does not touch. Verified by running the identical command against an untouched HEAD checkout: same single failure. Left alone as out of scope; CI is the arbiter.

## AC7 — verified against real state on dk-server-1 (DRY RUN, no `--yes`)

Before = installed `~/.orbit/bin/orbit` 0.9.2. After = binary built from this branch. Per-repo action counts:

| Repo | Before | After |
|---|---|---|
| `codebases/orbit` | 5x `skipped:unrecognized`, total 0 B | 3x `would_remove`, 2x `skipped:run_not_terminal`, total **3,290,511,682 B** |
| `knowledgebase/polaris` | 4x `skipped:unrecognized`, total 0 B | 4x `would_remove`, total **4,752,875 B** |
| `constellation` (root) | 3x `skipped:unrecognized`, total 0 B | 3x `would_remove`, total **1,651,296 B** |

Zero `skipped:unrecognized` remain in any of the three repos — every worktree has a resolvable run record and is now attributed with real values, e.g.
```
orbit-jrun-20260726-0443-3 run_id=jrun-20260726-0443-3 run_state=success task_id=ORB-10396 task_status=done action=would_remove bytes_reclaimed=2939687308
```
The two `skipped:run_not_terminal` entries are the live runs (`jrun-20260726-0439-3` = this run, and `jrun-20260726-0443-6`), correctly held back by the non-terminal gate. Nothing was run with `--yes`; the actual reap is Daniel's operational step.

## Scope notes

- `context_files` extended with `file:...worktree/setup.rs` (the shared derivation had to move out of it) and `file:docs/design/activity-job/4_decisions.md` (repo convention requires an ADR in the same PR).
- Added **ADR-0253** to `docs/design/activity-job/4_decisions.md` recording the single-derivation decision and the bundle unanimity rule, and bumped the doc's `last_updated`.
- No new dependency, no new crate edge, no `#[allow(...)]` added. No `--force`/`--include-unrecognized` reap flag (explicitly out of scope).
- Filed a friction report: `refs/stash` is shared across linked worktrees, so a `git stash pop` in a pipeline worktree can silently restore and destroy another session's WIP. It happened during this run (an unrelated 2026-07-18 stash was popped and dropped); fully recovered via `git checkout --` plus `git stash store <sha>`, and the baseline comparison was redone with file copies instead.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10427-6a658f9a`
- Behind base: 0
- Ahead of base: 1