### PR TITLE
Regroup the orbit CLI command surface: fold `orbit locks` under `orbit task`, add a Scheduler help group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Breaking Changes
 
+- **Task locks returned to task administration**: `orbit locks` is now `orbit task locks`. This partially reverses ORB-10000: unlike the other removed task verbs, which were consolidated into existing verbs, locks were only relocated to a more prominent top-level surface. Moving them back completes the original surface-reduction intent without changing the MCP tool surface. ([ORB-10428])
 - **Learning vote and comment surfaces removed**: `orbit.learning.upvote` and all `orbit.learning.comment.*` tools and CLI subcommands are gone — use `priority` + search rank for ranking, `update`/`supersede` for corrections, and `evidence` for provenance. ([ORB-10046])
 - **`orbit task` trimmed from 19 to 12 subcommands**: seven state-transition and read-projection verbs removed. `approve`/`reject`/`unarchive`/`delete` → `orbit task update --status …`; `locks` → `orbit locks`; `prune-context` → `orbit task lint --fix`; `templates` dropped. MCP tool surface unchanged. ([ORB-10000])
 

--- a/crates/orbit-cli/src/command/locks.rs
+++ b/crates/orbit-cli/src/command/locks.rs
@@ -1,4 +1,4 @@
-//! `orbit locks ...` — task file-lock administration.
+//! `orbit task locks ...` — task file-lock administration.
 //!
 //! `list` renders the file-lock projection over active (in-progress/review)
 //! tasks. `release` clears a stale reservation by ID.

--- a/crates/orbit-cli/src/command/mod.rs
+++ b/crates/orbit-cli/src/command/mod.rs
@@ -67,10 +67,7 @@ Environment:
 Operate:
   run         Run a workflow (ship, duel-plan, job)
   gc          Inspect and explicitly reap Orbit-managed garbage
-  sweep       Fire due routines on this host (the scheduler pass)
-  routine     Inspect and control scheduled routines on this host
   task        Create, update, and manage tasks
-  locks       Inspect and release task file locks
   docs        Search and manage the indexed docs corpus
   adr         List and inspect Architecture Decision Records
   friction    Report, list, and triage friction records
@@ -83,12 +80,16 @@ Observe:
   doctor      Diagnose workspace health (config, database, disk, indexes)
 
 Definitions:
-  auto-task   Define recurring auto-task templates (the scheduler primitive)
   activity    View activity definitions
   job         View job definitions
   tool        View tool registry
   policy      View filesystem policies
   executor    View executors
+
+Scheduler:
+  sweep       Fire due routines on this host (the scheduler pass)
+  routine     Inspect and control scheduled routines on this host
+  auto-task   Define recurring auto-task templates (the scheduler primitive)
 
 Services:
   mcp         Register MCP client integrations and run the MCP server
@@ -120,29 +121,30 @@ pub enum Commands {
     // ── Operate ──
     Run(run::RunCommand),
     Gc(gc::GcCommand),
-    Sweep(sweep::SweepCommand),
-    Routine(routine::RoutineCommand),
     Task(Box<task::TaskCommand>),
-    Locks(locks::LocksCommand),
-    Search(search::SearchCommand),
     Docs(docs::DocsCommand),
     Adr(adr::AdrCommand),
     Friction(friction::FrictionCommand),
     Learning(learning::LearningCommand),
 
     // ── Observe ──
+    Search(search::SearchCommand),
     Audit(audit::AuditCommand),
     Log(log::LogCommand),
     Doctor(doctor::DoctorCommand),
 
     // ── Definitions ──
-    #[command(name = "auto-task")]
-    AutoTask(auto_task::AutoTaskCommand),
     Activity(activity::ActivityCommand),
     Job(job::JobCommand),
     Tool(tool::ToolCommand),
     Policy(policy::PolicyCommand),
     Executor(executor::ExecutorCommand),
+
+    // ── Scheduler ──
+    Sweep(sweep::SweepCommand),
+    Routine(routine::RoutineCommand),
+    #[command(name = "auto-task")]
+    AutoTask(auto_task::AutoTaskCommand),
 
     // ── Services ──
     Mcp(mcp::McpCommand),

--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -365,6 +365,7 @@ impl Commands {
                 )
             }
             Commands::Task(command) => {
+                use super::locks::LocksSubcommand;
                 use super::task::TaskSubcommand;
                 use super::task::artifact::TaskArtifactSubcommand;
                 let (subcommand, target_type, target_id) = match &command.command {
@@ -373,6 +374,14 @@ impl Commands {
                         TaskArtifactSubcommand::Put(args) => {
                             ("artifact-put", Some("task"), Some(args.id.as_str()))
                         }
+                    },
+                    TaskSubcommand::Locks(command) => match &command.command {
+                        LocksSubcommand::List(_) => ("locks-list", None, None),
+                        LocksSubcommand::Release(args) => (
+                            "locks-release",
+                            Some("reservation"),
+                            Some(args.reservation_id.as_str()),
+                        ),
                     },
                     TaskSubcommand::List(_) => ("list", None, None),
                     TaskSubcommand::Show(args) => ("show", Some("task"), Some(args.id.as_str())),
@@ -398,29 +407,6 @@ impl Commands {
                     None,
                     false,
                     boxed_runtime_dispatch!(Task),
-                )
-            }
-            Commands::Locks(command) => {
-                use super::locks::LocksSubcommand;
-                let (subcommand, target_type, target_id) = match &command.command {
-                    LocksSubcommand::List(_) => ("list", None, None),
-                    LocksSubcommand::Release(args) => (
-                        "release",
-                        Some("reservation"),
-                        Some(args.reservation_id.as_str()),
-                    ),
-                };
-                CommandOperation::new(
-                    RuntimeNeed::Required,
-                    Some(admin_meta(
-                        "locks",
-                        Some(subcommand),
-                        target_type,
-                        target_id,
-                    )),
-                    None,
-                    false,
-                    runtime_dispatch!(Locks),
                 )
             }
             Commands::Search(command) => CommandOperation::new(

--- a/crates/orbit-cli/src/command/task/command.rs
+++ b/crates/orbit-cli/src/command/task/command.rs
@@ -2,6 +2,7 @@ use clap::{Args, Subcommand};
 use orbit_core::{OrbitError, OrbitRuntime};
 
 use crate::command::Execute;
+use crate::command::locks::LocksCommand;
 
 use super::add::TaskAddArgs;
 use super::artifact::TaskArtifactCommand;
@@ -33,6 +34,8 @@ pub enum TaskSubcommand {
     Add(TaskAddArgs),
     /// Manage task artifact files
     Artifact(TaskArtifactCommand),
+    /// Inspect and release task file locks
+    Locks(LocksCommand),
     /// List tasks with optional filters
     List(TaskListArgs),
     /// Show detailed information about a task
@@ -59,6 +62,7 @@ impl Execute for TaskSubcommand {
         match self {
             TaskSubcommand::Add(args) => args.execute(runtime),
             TaskSubcommand::Artifact(cmd) => cmd.execute(runtime),
+            TaskSubcommand::Locks(cmd) => cmd.execute(runtime),
             TaskSubcommand::List(args) => args.execute(runtime),
             TaskSubcommand::Show(args) => args.execute(runtime),
             TaskSubcommand::Lint(args) => args.execute(runtime),

--- a/crates/orbit-cli/src/command/task/tests/command.rs
+++ b/crates/orbit-cli/src/command/task/tests/command.rs
@@ -1,17 +1,15 @@
-use clap::{Parser, error::ErrorKind};
+use clap::{CommandFactory, Parser, error::ErrorKind};
 
 use crate::command::Cli;
 
-/// The trimmed `orbit task` surface (ORB-10000): 11 subcommands. Lock
-/// administration lives under the top-level `orbit locks` command (ORB-00420),
-/// not here.
-const EXPECTED_TASK_SUBCOMMANDS: [&str; 11] = [
-    "add", "artifact", "list", "show", "lint", "update", "start", "archive", "export", "import",
-    "reindex",
+/// The trimmed `orbit task` surface has 12 subcommands. ORB-10428 supersedes
+/// the ORB-00420/ORB-10000 placement and returns lock administration here.
+const EXPECTED_TASK_SUBCOMMANDS: [&str; 12] = [
+    "add", "artifact", "locks", "list", "show", "lint", "update", "start", "archive", "export",
+    "import", "reindex",
 ];
 
-const REMOVED_TASK_SUBCOMMANDS: [&str; 8] = [
-    "locks",
+const REMOVED_TASK_SUBCOMMANDS: [&str; 7] = [
     "approve",
     "reject",
     "unarchive",
@@ -28,6 +26,15 @@ fn task_help() -> String {
     };
     assert_eq!(err.kind(), ErrorKind::DisplayHelp);
     err.to_string()
+}
+
+fn root_help_section<'a>(help: &'a str, heading: &str) -> &'a str {
+    let (_, after_heading) = help
+        .split_once(&format!("{heading}:\n"))
+        .unwrap_or_else(|| panic!("root help missing `{heading}` section:\n{help}"));
+    after_heading
+        .split_once("\n\n")
+        .map_or(after_heading, |(section, _)| section)
 }
 
 #[test]
@@ -75,7 +82,35 @@ fn task_help_describes_update_status_transitions() {
 }
 
 #[test]
-fn lock_administration_lives_under_top_level_locks_command() {
+fn root_help_groups_scheduler_commands_in_layer_order() {
+    let help = Cli::command().render_long_help().to_string();
+    assert_eq!(
+        root_help_section(&help, "Scheduler"),
+        "  sweep       Fire due routines on this host (the scheduler pass)\n  routine     Inspect and control scheduled routines on this host\n  auto-task   Define recurring auto-task templates (the scheduler primitive)",
+        "{help}"
+    );
+    assert!(
+        !root_help_section(&help, "Operate").contains("sweep"),
+        "{help}"
+    );
+    assert!(
+        !root_help_section(&help, "Operate").contains("routine"),
+        "{help}"
+    );
+    assert!(
+        !root_help_section(&help, "Definitions").contains("auto-task"),
+        "{help}"
+    );
+    assert!(
+        !help
+            .lines()
+            .any(|line| line.trim_start().starts_with("locks")),
+        "{help}"
+    );
+}
+
+#[test]
+fn lock_administration_lives_under_task() {
     // `--locked` was removed from `task list` (ORB-00420).
     let err = match Cli::try_parse_from(["orbit", "task", "list", "--locked"]) {
         Ok(_) => panic!("`task list --locked` should no longer parse"),
@@ -83,18 +118,24 @@ fn lock_administration_lives_under_top_level_locks_command() {
     };
     assert_eq!(err.kind(), ErrorKind::UnknownArgument);
 
-    // Lock administration now lives under the top-level `orbit locks` command.
-    Cli::try_parse_from(["orbit", "locks", "list"]).expect("orbit locks list parses");
-    Cli::try_parse_from(["orbit", "locks", "list", "--json"])
-        .expect("orbit locks list --json parses");
-    Cli::try_parse_from(["orbit", "locks", "release", "R-123"])
-        .expect("orbit locks release <id> parses");
+    // ORB-10428 supersedes the ORB-00420/ORB-10000 placement: locks are task administration.
+    Cli::try_parse_from(["orbit", "task", "locks", "list"]).expect("task locks list parses");
+    Cli::try_parse_from(["orbit", "task", "locks", "list", "--json"])
+        .expect("task locks list --json parses");
+    Cli::try_parse_from(["orbit", "task", "locks", "release", "R-123"])
+        .expect("task locks release <id> parses");
 
-    let err = match Cli::try_parse_from(["orbit", "locks", "release"]) {
-        Ok(_) => panic!("`locks release` requires a reservation id"),
+    let err = match Cli::try_parse_from(["orbit", "task", "locks", "release"]) {
+        Ok(_) => panic!("`task locks release` requires a reservation id"),
         Err(err) => err,
     };
     assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
+
+    let err = match Cli::try_parse_from(["orbit", "locks", "list"]) {
+        Ok(_) => panic!("top-level `locks` should not parse"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), ErrorKind::InvalidSubcommand);
 }
 
 #[test]

--- a/crates/orbit-cli/tests/task_trimmed_surface.rs
+++ b/crates/orbit-cli/tests/task_trimmed_surface.rs
@@ -2,10 +2,10 @@
 // ORB-00013: Tests use unwrap/expect to keep fixture setup readable.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
-//! End-to-end coverage for the trimmed `orbit task` surface (ORB-10000):
+//! End-to-end coverage for the task surface after ORB-10428:
 //! approve/reject/unarchive folded into `update --status` and `prune-context`
-//! folded into `lint --fix`. Lock administration lives under the top-level
-//! `orbit locks` command (`list`/`release`, ORB-00420).
+//! folded into `lint --fix`. Lock administration lives under `task locks`
+//! (`list`/`release`).
 
 use std::fs;
 use std::path::Path;
@@ -94,13 +94,13 @@ fn locks_list_projects_files_held_by_active_tasks() {
         "start with context",
     );
 
-    let output = workspace.run(&["locks", "list", "--json"], "locks list");
+    let output = workspace.run(&["task", "locks", "list", "--json"], "task locks list");
     let value: Value = serde_json::from_slice(&output.stdout).expect("locked JSON");
     assert_eq!(value["total_tasks"], json!(1));
     assert_eq!(value["locked_files"], json!(["file:held.rs"]));
     assert_eq!(value["by_task"][0]["id"], json!(id));
 
-    let text = workspace.run(&["locks", "list"], "locks list text");
+    let text = workspace.run(&["task", "locks", "list"], "task locks list text");
     let stdout = String::from_utf8_lossy(&text.stdout);
     assert!(stdout.contains("file:held.rs"), "{stdout}");
 }
@@ -194,12 +194,12 @@ fn locks_release_reaches_admin_tool_bypassing_agent_gate() {
     let workspace = TestWorkspace::new();
 
     // `orbit.task.locks.release` is inactive on the agent tool surface, so
-    // `orbit locks release` must reach it through the admin `runtime.run_tool`
+    // `orbit task locks release` must reach it through the admin `runtime.run_tool`
     // bypass. An unknown reservation yields a structured `released: false`, NOT
     // the `ensure_tool_agent_facing` rejection.
     let output = workspace.run(
-        &["locks", "release", "no-such-reservation"],
-        "locks release",
+        &["task", "locks", "release", "no-such-reservation"],
+        "task locks release",
     );
     let value: Value = serde_json::from_slice(&output.stdout).expect("release JSON");
     assert_eq!(value["released"], json!(false));

--- a/crates/orbit-core/assets/skills/orbit-workflow/references/common_failures.md
+++ b/crates/orbit-core/assets/skills/orbit-workflow/references/common_failures.md
@@ -10,13 +10,13 @@ Symptoms:
 
 - A gate, auto, or task run repeatedly emits `task.locks.reserve.denied`.
 - Conflicts name `held_by: "reservation"` with the same `held_by_id` on each retry.
-- CLI-only `orbit locks list` or reservation-store inspection shows the blocking reservation belongs to a different task that is already `done`, `failed`, or otherwise no longer active.
+- CLI-only `orbit task locks list` or reservation-store inspection shows the blocking reservation belongs to a different task that is already `done`, `failed`, or otherwise no longer active.
 - The reservation has `owner_run_id: null`, so terminal run cleanup cannot release it by owner.
 
 Confirm:
 
 ```bash
-orbit locks list --json
+orbit task locks list --json
 orbit tool run orbit.task.show --full --input '{"id":"<blocking_task_id>","model":"<agent-family>"}'
 rg -n '<reservation_id>|task.locks.reserve.denied|<blocked_task_id>' .orbit/state/audit/v2_loop
 ```
@@ -36,7 +36,7 @@ Solution:
 2. Release through the CLI-only lock admin surface, not by editing SQLite:
 
    ```bash
-   orbit locks release <reservation_id>
+   orbit task locks release <reservation_id>
    ```
 
 3. Re-run or re-check the blocked run. The next reserve attempt should either acquire a fresh reservation with `owner_run_id` set or reveal a different conflict.


### PR DESCRIPTION
## Task

[ORB-10428](https://orbit-cli.com/tasks/ORB-10428) — Regroup the orbit CLI command surface: fold `orbit locks` under `orbit task`, add a Scheduler help group

### Description

## Problem

`orbit --help` groups top-level commands into hand-rolled sections (Environment / Operate / Observe / Definitions / Services) via the `help_template` in `crates/orbit-cli/src/command/mod.rs`. Two placements in that layout misrepresent how the system actually works.

**1. `orbit locks` is presented as a peer subsystem, but it is a projection over tasks.**

`LocksListArgs::execute` calls `runtime.list_tasks()`, filters to `InProgress | Review`, reads `task.context_files`, and renders through `crate::command::task::output::print_task_locks`. It owns no state of its own. The MCP surface already namespaces it correctly as `orbit.task.locks.release`; the CLI is the only surface that treats locks as top-level. `orbit task artifact` already establishes that nested groups under `task` are an accepted shape.

**2. The scheduler is split across three sections despite being one layered chain.**

```
orbit sweep        OS clock pass, host-local, every minute
  └─ fires the seeded auto_task_scheduler routine        (orbit routine)
       └─ target: job:auto_task_scheduler_pipeline
            └─ activity:run_auto_task_scheduler
                 └─ mints tasks from .orbit/auto_tasks/*.yaml   (orbit auto-task)
```

Today `sweep` and `routine` sit in **Operate** while `auto-task` sits in **Definitions**, so the help implies `auto-task` is a peer of `routine` when it is a layer beneath it. Separately, `auto-task` is the only entry in **Definitions** that mutates anything — `activity`, `job`, `tool`, `policy`, `executor` are all read-only catalog views. Moving it out makes Definitions honestly the read-only catalog.

## Prior decision being reversed — read before starting

This task **deliberately reverses part of ORB-10000**, a shipped breaking change. Do not treat the existing layout as drift.

- ORB-00420 created `orbit locks` (`list` / `release`).
- ORB-10000 trimmed `orbit task` from 19 to 12 subcommands and moved `locks` out to top-level. CHANGELOG, under Breaking Changes: "`approve`/`reject`/`unarchive`/`delete` → `orbit task update --status …`; `locks` → `orbit locks`; `prune-context` → `orbit task lint --fix`; `templates` dropped."

The reversal is deliberate and its rationale must be recorded in the commit message and CHANGELOG entry: every other verb ORB-10000 removed was **consolidated** — the same capability stayed reachable through an existing verb, so the surface genuinely shrank. `locks` was the only one **relocated** rather than consolidated: total CLI surface did not shrink, it moved from nested to top-level, i.e. became more prominent. Judged against ORB-10000's own stated goal, that item did not deliver. This task completes the intent of ORB-10000 for `locks`; it does not contradict it. `orbit task` goes 12 → 13 subcommands and that is accepted.

Note this cuts against ORB-10000's headline framing, so the CHANGELOG entry must be explicit rather than quietly re-listing the surface.

## Scope

Both changes rewrite the same `help_template` string and the same `Commands` enum in `crates/orbit-cli/src/command/mod.rs`. They are one edit and must not be split into parallel tasks.

## Constraints

- **Keep the template and variant order in sync.** The comment at the top of `command/mod.rs` states that the hand-rolled template's section order and the `Commands` enum variant order must match, because variant order determines where a command missing from the template would surface. Both must move together.
- **Order the scheduler group by the layering, not alphabetically** — entry point downward: `sweep`, `routine`, `auto-task`. Alphabetical order would reintroduce exactly the misreading this task removes.
- **Name the group `Scheduler`**, matching the codebase's own vocabulary (`routines/mod.rs`: "Orbit as the constellation's single scheduler"; `run_auto_task_scheduler`, `auto_task_scheduler_pipeline`). Not "Scheduled" — every other group heading is a noun or verb, not a bare adjective.
- **`orbit sweep` stays top-level as an invocation path.** Only its *help grouping* changes. It must remain `orbit sweep`, keep running through `execute_without_runtime`, and must not become a subcommand of `routine` — installed launchd/systemd clock units invoke `orbit sweep` literally on every host, and renaming it would silently stop the scheduler wherever a unit was not reinstalled.
- **No compatibility alias for `orbit locks`.** `locks release` is a rarely hand-typed operator escape hatch, not a scripted path. Make the break clean rather than adding a hidden variant.
- **`orbit task locks release` must keep reaching the tool through the admin `runtime.run_tool` bypass.** `orbit.task.locks.release` is inactive on the agent MCP surface; that bypass (mirroring `orbit adr list`, ORB-00289) is load-bearing and must survive the move.
- **MCP tool surface is unchanged.** No tool renames, no `tools/list` snapshot churn. This is CLI-only.

## Known reference sites

Not exhaustive — search for `orbit locks` and confirm before finishing.

- `crates/orbit-cli/src/command/locks.rs` — the command module itself
- `crates/orbit-cli/src/command/mod.rs` — `Locks` variant, module declaration, help template
- `crates/orbit-cli/src/command/task/tests/command.rs:86-91` — **negative test** asserting `orbit locks list` parses and that lock administration is *not* under `task`. This must be inverted, not deleted, and its comment updated to cite this task rather than ORB-00420.
- `crates/orbit-cli/tests/task_trimmed_surface.rs` — module doc-comment describes the ORB-10000 surface, including the locks placement
- `crates/orbit-core/assets/skills/orbit-workflow/references/common_failures.md:13,19,39` — operator runbook with literal `orbit locks list --json` / `orbit locks release <id>` invocations. **Shipped asset seeding every workspace — update the commands but keep the wording project-agnostic; no ORB-/ADR- ids or constellation specifics.**
- `CHANGELOG.md` — new Breaking Changes entry

## Out of scope

- Nesting `sweep` under `routine` (considered and rejected — clock-unit migration cost).
- Any change to `gc`, `run`, or the Observe/Services groups.
- Revisiting the other six verbs ORB-10000 removed.

### Acceptance Criteria

- `orbit task locks list` and `orbit task locks release <id>` parse and behave identically to the previous top-level forms, including `--json` output shape.
- `orbit locks` no longer parses as a top-level command, and no hidden compatibility alias is added for it.
- `orbit task locks release` still reaches `orbit.task.locks.release` through the admin `runtime.run_tool` bypass, with the existing coverage in `crates/orbit-cli/tests/task_trimmed_surface.rs` updated to the new command form and still asserting the bypass.
- `orbit --help` shows a `Scheduler:` group containing exactly `sweep`, `routine`, `auto-task`, listed in that order.
- `sweep` and `routine` no longer appear under `Operate:`; `auto-task` no longer appears under `Definitions:`; `locks` no longer appears as a top-level entry anywhere in the help.
- `orbit sweep` remains invocable as `orbit sweep` and still executes via `execute_without_runtime` — an installed launchd/systemd clock unit calling `orbit sweep` keeps working unchanged.
- The `Commands` enum variant order matches the help template's section order, per the sync requirement documented at the top of `crates/orbit-cli/src/command/mod.rs`.
- The negative parse test at `crates/orbit-cli/src/command/task/tests/command.rs` is inverted rather than deleted, and its comment cites this task as superseding the ORB-00420/ORB-10000 placement.
- `crates/orbit-core/assets/skills/orbit-workflow/references/common_failures.md` uses the new command form, and its wording contains no project-specific names or ORB-/ADR-/L-/F- identifiers.
- A CHANGELOG entry under Breaking Changes records the `orbit locks` → `orbit task locks` move, states that it partially reverses ORB-10000, and gives the relocation-not-consolidation rationale.
- No MCP tool is renamed, added, or removed; the `tools/list` production snapshot test passes without modification.
- `cargo test -p orbit-cli` passes, and a repo-wide search for `orbit locks` returns no stale references outside CHANGELOG history.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Folded the CLI-only locks projection beneath `orbit task locks`, retaining the existing `runtime.run_tool` admin bypass for release and moving corresponding audit metadata under task administration.
- Removed top-level locks parsing and regrouped help/enum order into Environment, Operate, Observe, Definitions, Scheduler, and Services; Scheduler lists sweep, routine, auto-task in execution-layer order while `orbit sweep` remains runtime-free.
- Updated parsing and integration coverage, the portable workflow runbook, and Breaking Changes documentation; no MCP tool surface changed.
Assessment: Scoped CLI surface change with compatibility behavior verified for the new nested commands and release bypass.
Validation:
- `cargo test -p orbit-cli` (pass)
- `make ci-fast` (pass)
- `rg -n --fixed-strings orbit locks --glob !CHANGELOG.md .` (no stale references)

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10428-6a65956d`
- Behind base: 0
- Ahead of base: 1