### PR TITLE
Rename RuntimeHost to reflect its post-v1 role (DeterministicActionHost)

### DIFF
--- a/.orbit/adrs/accepted/ADR-0155/body.md
+++ b/.orbit/adrs/accepted/ADR-0155/body.md
@@ -4,7 +4,7 @@ Duel-plan previously walked the full `all_agent_families()` registry and used th
 
 ## Decision
 
-Add a workspace `[duel]` section with `candidates` as a normalized subset of `all_agent_families()` and `[duel.models]` as flat orchestrator-only per-family overrides. Duel role selection reads those values through `RuntimeHost`; non-duel callers continue to use executor overrides and builtin model pairs.
+Add a workspace `[duel]` section with `candidates` as a normalized subset of `all_agent_families()` and `[duel.models]` as flat orchestrator-only per-family overrides. Duel role selection reads those values through `DeterministicActionHost`; non-duel callers continue to use executor overrides and builtin model pairs.
 
 ## Consequences
 

--- a/crates/orbit-core/src/runtime/engine/deterministic_action_host.rs
+++ b/crates/orbit-core/src/runtime/engine/deterministic_action_host.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use orbit_common::types::{ActivityV2, AgentModelPair, JobRun, OrbitError, OrbitEvent, Role};
-use orbit_engine::{RuntimeHost, V2AuditWriter, V2RuntimeHost};
+use orbit_engine::{DeterministicActionHost, V2AuditWriter, V2RuntimeHost};
 use orbit_store::{InvocationQuery, InvocationRecord};
 use orbit_tools::ToolContext;
 use serde_json::Value;
@@ -9,7 +9,7 @@ use serde_json::Value;
 use super::paths::current_repo_root;
 use crate::OrbitRuntime;
 
-impl RuntimeHost for OrbitRuntime {
+impl DeterministicActionHost for OrbitRuntime {
     fn record_event(&self, event: OrbitEvent) -> Result<(), OrbitError> {
         OrbitRuntime::record_event(self, event)
     }

--- a/crates/orbit-core/src/runtime/engine/mod.rs
+++ b/crates/orbit-core/src/runtime/engine/mod.rs
@@ -1,10 +1,10 @@
 mod crew;
+mod deterministic_action_host;
 pub(crate) mod environment_host;
 mod identity;
 mod invocation;
 mod job_run_host;
 mod paths;
-mod runtime_host;
 mod summary;
 mod task_host;
 

--- a/crates/orbit-core/src/runtime/engine/task_host.rs
+++ b/crates/orbit-core/src/runtime/engine/task_host.rs
@@ -3,7 +3,7 @@ use orbit_common::types::{
     TaskStatus, push_external_ref_if_missing,
 };
 use orbit_engine::{
-    RuntimeHost, TaskActivityUpdate, TaskAutomationUpdate, TaskReadHost, TaskWriteHost,
+    DeterministicActionHost, TaskActivityUpdate, TaskAutomationUpdate, TaskReadHost, TaskWriteHost,
 };
 
 use crate::OrbitRuntime;
@@ -91,7 +91,7 @@ impl TaskWriteHost for OrbitRuntime {
         }
         let (agent, model) = self
             .try_canonical_agent_model_identity(update.agent.as_deref(), update.model.as_deref())?;
-        let runtime_model_identity = <Self as RuntimeHost>::actor_model_identity(self);
+        let runtime_model_identity = <Self as DeterministicActionHost>::actor_model_identity(self);
         let attribution = assemble_task_attribution(
             &existing_task,
             TaskAttributionInput {

--- a/crates/orbit-core/src/runtime/engine/tests/deterministic_action_host.rs
+++ b/crates/orbit-core/src/runtime/engine/tests/deterministic_action_host.rs
@@ -1,11 +1,12 @@
-//! Sibling tests for `runtime_host.rs` (migrated per ORB-00246 / docs/design-patterns/test_layout.md).
+//! Sibling tests for `deterministic_action_host.rs` (migrated per ORB-00246 / docs/design-patterns/test_layout.md).
 
 use std::collections::HashMap;
 
 use chrono::Utc;
 use orbit_common::types::{ExecutorDef, ExecutorType};
 use orbit_engine::{
-    RuntimeHost, V2AgentDispatchOverride, V2DispatchInput, V2RuntimeHost, dispatch_v2_activity,
+    DeterministicActionHost, V2AgentDispatchOverride, V2DispatchInput, V2RuntimeHost,
+    dispatch_v2_activity,
 };
 use orbit_store::InvocationQuery;
 use serde_json::json;
@@ -76,7 +77,8 @@ fn planning_duel_v2_dispatch_preserves_slot_model_and_task_attribution() {
     }
 
     let run_id = "planning-duel-v2-test";
-    let audit = RuntimeHost::v2_audit_writer(&runtime, run_id).expect("v2 audit writer");
+    let audit =
+        DeterministicActionHost::v2_audit_writer(&runtime, run_id).expect("v2 audit writer");
     for (activity_name, slot, provider, model) in [
         (
             "propose_duel_plan",
@@ -97,8 +99,8 @@ fn planning_duel_v2_dispatch_preserves_slot_model_and_task_attribution() {
             "duel-arbiter-model",
         ),
     ] {
-        let activity =
-            RuntimeHost::v2_activity(&runtime, activity_name).expect("load seeded duel activity");
+        let activity = DeterministicActionHost::v2_activity(&runtime, activity_name)
+            .expect("load seeded duel activity");
         let input = json!({
             "task_id": task.id,
             "planning_duel_slot": slot,

--- a/crates/orbit-core/src/runtime/engine/tests/identity.rs
+++ b/crates/orbit-core/src/runtime/engine/tests/identity.rs
@@ -4,13 +4,13 @@
 //! `ActivityExecutorRegistry`. [ORB-10395] deleted that registry, so the lookup
 //! now reads the executor def store directly. These tests pin that wiring: a
 //! `model_pair_override` seeded into the store must be observable through the
-//! public `RuntimeHost::resolved_agent_model_pair` surface.
+//! public `DeterministicActionHost::resolved_agent_model_pair` surface.
 
 use std::collections::HashMap;
 
 use chrono::Utc;
 use orbit_common::types::{AgentModelPair, ExecutorDef, ExecutorType, ModelPairOverride};
-use orbit_engine::RuntimeHost;
+use orbit_engine::DeterministicActionHost;
 
 use crate::OrbitRuntime;
 
@@ -47,7 +47,7 @@ fn resolved_agent_model_pair_reads_the_executor_def_store() {
         .expect("seed executor def");
 
     assert_eq!(
-        RuntimeHost::resolved_agent_model_pair(&runtime, "claude"),
+        DeterministicActionHost::resolved_agent_model_pair(&runtime, "claude"),
         Some(AgentModelPair::new("claude-orchestrator", "claude-helper"))
     );
 }
@@ -60,7 +60,7 @@ fn resolved_agent_model_pair_is_none_without_an_override() {
         .expect("seed executor def");
 
     assert_eq!(
-        RuntimeHost::resolved_agent_model_pair(&runtime, "codex"),
+        DeterministicActionHost::resolved_agent_model_pair(&runtime, "codex"),
         None
     );
 }
@@ -70,7 +70,7 @@ fn resolved_agent_model_pair_is_none_for_an_unregistered_executor() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
 
     assert_eq!(
-        RuntimeHost::resolved_agent_model_pair(&runtime, "not-registered"),
+        DeterministicActionHost::resolved_agent_model_pair(&runtime, "not-registered"),
         None
     );
 }

--- a/crates/orbit-core/src/runtime/engine/tests/mod.rs
+++ b/crates/orbit-core/src/runtime/engine/tests/mod.rs
@@ -1,4 +1,4 @@
 mod crew;
+mod deterministic_action_host;
 mod identity;
-mod runtime_host;
 mod task_host;

--- a/crates/orbit-engine/src/context/hosts.rs
+++ b/crates/orbit-engine/src/context/hosts.rs
@@ -224,7 +224,7 @@ pub trait EnvironmentHost {
     }
 }
 
-pub trait RuntimeHost {
+pub trait DeterministicActionHost {
     fn record_event(&self, event: OrbitEvent) -> Result<(), OrbitError>;
     fn repo_root(&self) -> Result<String, OrbitError>;
     fn list_job_runs_for_gc(&self) -> Result<Vec<JobRun>, OrbitError> {

--- a/crates/orbit-engine/src/context/mod.rs
+++ b/crates/orbit-engine/src/context/mod.rs
@@ -5,7 +5,7 @@
 //! - [`outcome`] — run outcome types, error-code constants, and
 //!   workflow-failure helpers.
 //! - [`hosts`] — the host trait boundary (`JobRunHost`, `TaskHost`,
-//!   `EnvironmentHost`, `RuntimeHost`, ...) and the task-update param types.
+//!   `EnvironmentHost`, `DeterministicActionHost`, ...) and the task-update param types.
 //! - [`env`] — subprocess provenance environment variables shared by every
 //!   engine spawn path.
 
@@ -18,8 +18,9 @@ mod tests;
 
 pub(crate) use env::{ProvenanceEnv, provenance_env};
 pub use hosts::{
-    AgentRoleConfig, EnvironmentHost, JobRunHost, PrConfig, RuntimeHost, TaskActivityUpdate,
-    TaskAutomationUpdate, TaskHost, TaskReadHost, TaskWriteHost, ensure_task_can_enter_workflow,
+    AgentRoleConfig, DeterministicActionHost, EnvironmentHost, JobRunHost, PrConfig,
+    TaskActivityUpdate, TaskAutomationUpdate, TaskHost, TaskReadHost, TaskWriteHost,
+    ensure_task_can_enter_workflow,
 };
 pub use outcome::{
     AGENT_INVOCATION_FAILED, AGENT_TIMEOUT, ActivityInvocationResult, WORKFLOW_RUN_FAILED_EVENT,

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/artifacts.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/artifacts.rs
@@ -9,7 +9,7 @@ use orbit_common::types::{
 use orbit_tools::ToolContext;
 use serde_json::{Value, json};
 
-use crate::context::{RuntimeHost, TaskAutomationUpdate, TaskHost};
+use crate::context::{DeterministicActionHost, TaskAutomationUpdate, TaskHost};
 use crate::executor::automation::input::required_input_string;
 
 use super::context_files::extract_context_files_from_plan;
@@ -535,7 +535,9 @@ fn find_task_dir(tasks_root: &Path, task_id: &str) -> Result<Option<PathBuf>, Or
     }
 }
 
-pub(super) fn cleanup_stale_planning_duel_artifacts<H: RuntimeHost + TaskHost + ?Sized>(
+pub(super) fn cleanup_stale_planning_duel_artifacts<
+    H: DeterministicActionHost + TaskHost + ?Sized,
+>(
     host: &H,
     task_id: &str,
 ) -> Result<(), OrbitError> {
@@ -581,7 +583,7 @@ pub(super) fn cleanup_stale_planning_duel_artifacts<H: RuntimeHost + TaskHost + 
     Ok(())
 }
 
-pub(super) fn writeback_planning_duel_task<H: TaskHost + RuntimeHost + ?Sized>(
+pub(super) fn writeback_planning_duel_task<H: TaskHost + DeterministicActionHost + ?Sized>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/metrics.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/metrics.rs
@@ -5,7 +5,7 @@ use orbit_common::types::{
 use orbit_store::{InvocationQuery, InvocationRecord, planning_duel_scoreboard};
 use serde_json::{Value, json};
 
-use crate::context::{ActivityInvocationResult, RuntimeHost, TaskHost};
+use crate::context::{ActivityInvocationResult, DeterministicActionHost, TaskHost};
 use crate::executor::automation::input::{input_string_field, required_input_string};
 
 use super::artifacts::{
@@ -46,7 +46,7 @@ pub(super) fn aggregate_token_usage(records: &[InvocationRecord]) -> TokenUsage 
         })
 }
 
-fn token_usage_from_run_telemetry<H: RuntimeHost + ?Sized>(
+fn token_usage_from_run_telemetry<H: DeterministicActionHost + ?Sized>(
     host: &H,
     job_run_id: &str,
     task_id: &str,
@@ -84,7 +84,7 @@ pub(super) fn role_metrics_from_invocation(
     }
 }
 
-pub(super) fn record_planning_duel_scores<H: RuntimeHost + TaskHost + ?Sized>(
+pub(super) fn record_planning_duel_scores<H: DeterministicActionHost + TaskHost + ?Sized>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs
@@ -8,7 +8,7 @@ use orbit_common::types::{
 };
 use serde_json::{Value, json};
 
-use crate::context::RuntimeHost;
+use crate::context::DeterministicActionHost;
 
 use crate::executor::automation::input::{input_string_field, required_input_string};
 
@@ -22,7 +22,9 @@ thread_local! {
         const { RefCell::new(VecDeque::new()) };
 }
 
-fn next_permutation<H: RuntimeHost + ?Sized>(host: &H) -> Result<[usize; 3], OrbitError> {
+fn next_permutation<H: DeterministicActionHost + ?Sized>(
+    host: &H,
+) -> Result<[usize; 3], OrbitError> {
     let family_count = host.duel_candidate_families().len();
     let from_test = TEST_PERMUTATION_QUEUE.with(|cell| cell.borrow_mut().pop_front());
     if let Some(perm) = from_test {
@@ -36,7 +38,7 @@ fn next_permutation<H: RuntimeHost + ?Sized>(host: &H) -> Result<[usize; 3], Orb
     role_permutation_at(family_count, nanos as usize)
 }
 
-fn orchestrator_model_for<H: RuntimeHost + ?Sized>(
+fn orchestrator_model_for<H: DeterministicActionHost + ?Sized>(
     host: &H,
     family: &str,
 ) -> Result<String, OrbitError> {
@@ -52,7 +54,7 @@ fn orchestrator_model_for<H: RuntimeHost + ?Sized>(
         })
 }
 
-fn build_role_assignment<H: RuntimeHost + ?Sized>(
+fn build_role_assignment<H: DeterministicActionHost + ?Sized>(
     host: &H,
     family: &str,
 ) -> Result<PlanningRoleAssignment, OrbitError> {
@@ -63,7 +65,7 @@ fn build_role_assignment<H: RuntimeHost + ?Sized>(
 }
 
 // pub(crate) widened for tests/ layout under ORB-00225; test reaches via exposed surface.
-pub(crate) fn build_roles_output<H: RuntimeHost + ?Sized>(
+pub(crate) fn build_roles_output<H: DeterministicActionHost + ?Sized>(
     host: &H,
     perm: [usize; 3],
 ) -> Result<Value, OrbitError> {
@@ -106,7 +108,7 @@ pub(super) fn parse_planning_duel_roles(input: &Value) -> Result<PlanningRoles, 
     .map_err(|err| OrbitError::InvalidInput(format!("invalid planning_duel_roles payload: {err}")))
 }
 
-pub(super) fn select_planning_duel_roles<H: RuntimeHost + ?Sized>(
+pub(super) fn select_planning_duel_roles<H: DeterministicActionHost + ?Sized>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/runner.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/runner.rs
@@ -11,7 +11,7 @@ use serde_json::{Value, json};
 
 use super::types::PlanningDuelPlanArtifact;
 use super::{artifacts, metrics, roles};
-use crate::context::{ActivityInvocationResult, RuntimeHost, TaskHost};
+use crate::context::{ActivityInvocationResult, DeterministicActionHost, TaskHost};
 use crate::executor::automation::input::{input_string_field, required_input_string};
 
 fn join_activity_result(
@@ -36,7 +36,7 @@ struct DuelAgentDispatch<'a> {
     audit: Arc<V2AuditWriter>,
 }
 
-fn dispatch_duel_agent_activity<H: RuntimeHost + ?Sized>(
+fn dispatch_duel_agent_activity<H: DeterministicActionHost + ?Sized>(
     host: &H,
     dispatch: DuelAgentDispatch<'_>,
 ) -> Result<ActivityInvocationResult, OrbitError> {
@@ -188,7 +188,7 @@ fn compact_diagnostic_text(value: &str) -> String {
     }
 }
 
-pub(crate) fn run_planning_duel<H: RuntimeHost + TaskHost + Sync + ?Sized>(
+pub(crate) fn run_planning_duel<H: DeterministicActionHost + TaskHost + Sync + ?Sized>(
     host: &H,
     input: &Value,
     _debug: bool,

--- a/crates/orbit-engine/src/executor/automation/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/mod.rs
@@ -36,7 +36,7 @@ pub struct StateExecutionContext {
 }
 
 pub fn execute_action<
-    H: crate::context::RuntimeHost
+    H: crate::context::DeterministicActionHost
         + crate::context::TaskHost
         + crate::context::EnvironmentHost
         + Sync

--- a/crates/orbit-engine/src/executor/automation/task_update/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/task_update/mod.rs
@@ -1,12 +1,12 @@
 use orbit_common::types::{OrbitError, TaskStatus};
 use serde_json::{Value, json};
 
-use crate::context::{RuntimeHost, TaskActivityUpdate, TaskHost};
+use crate::context::{DeterministicActionHost, TaskActivityUpdate, TaskHost};
 
 use super::StateExecutionContext;
 use super::input::{input_string_field, required_input_string};
 
-pub(super) fn update_task<H: RuntimeHost + TaskHost + ?Sized>(
+pub(super) fn update_task<H: DeterministicActionHost + TaskHost + ?Sized>(
     host: &H,
     input: &Value,
     state_context: Option<&StateExecutionContext>,
@@ -47,7 +47,7 @@ pub(super) fn update_task<H: RuntimeHost + TaskHost + ?Sized>(
     Ok(json!({}))
 }
 
-fn activity_identity<H: RuntimeHost + ?Sized>(
+fn activity_identity<H: DeterministicActionHost + ?Sized>(
     host: &H,
     input: &Value,
     state_context: Option<&StateExecutionContext>,

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use orbit_common::types::{NO_DIFF_EXPECTED_TAG, OrbitError};
 use serde_json::{Value, json};
 
-use crate::context::{RuntimeHost, TaskHost};
+use crate::context::{DeterministicActionHost, TaskHost};
 
 use super::super::input::{canonicalize_existing_dir, input_string_field, required_job_run_id};
 use super::git::{git_command_success, git_output, git_success};
@@ -22,7 +22,9 @@ use git_ops::{
 use message::{batch_commit_message, finalize_commit_message, task_commit_message};
 use scope::{changed_files_for_task, collect_worktree_changes, filter_changed_files_for_task};
 
-pub(in crate::executor::automation) fn git_commit<H: TaskHost + RuntimeHost + ?Sized>(
+pub(in crate::executor::automation) fn git_commit<
+    H: TaskHost + DeterministicActionHost + ?Sized,
+>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {
@@ -37,7 +39,7 @@ pub(in crate::executor::automation) fn git_commit<H: TaskHost + RuntimeHost + ?S
     }
 }
 
-pub(super) fn commit_task_artifact_changes<H: TaskHost + RuntimeHost + ?Sized>(
+pub(super) fn commit_task_artifact_changes<H: TaskHost + DeterministicActionHost + ?Sized>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {
@@ -112,7 +114,7 @@ pub(super) fn commit_task_artifact_changes<H: TaskHost + RuntimeHost + ?Sized>(
     }))
 }
 
-pub(super) fn commit_finalize_artifact_changes<H: TaskHost + RuntimeHost + ?Sized>(
+pub(super) fn commit_finalize_artifact_changes<H: TaskHost + DeterministicActionHost + ?Sized>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {
@@ -166,7 +168,7 @@ pub(super) fn commit_finalize_artifact_changes<H: TaskHost + RuntimeHost + ?Size
     }))
 }
 
-pub(super) fn commit_batch_changes<H: TaskHost + RuntimeHost + ?Sized>(
+pub(super) fn commit_batch_changes<H: TaskHost + DeterministicActionHost + ?Sized>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {
@@ -279,7 +281,7 @@ pub(super) fn commit_batch_changes<H: TaskHost + RuntimeHost + ?Sized>(
 /// Commit a terminally-failed shipment's dirty candidate without consulting
 /// the normal success-summary delivery gate. ADR-0246 confines this bypass to
 /// the failure handoff, which blocks rather than promotes the task.
-pub(super) fn commit_failure_candidate<H: RuntimeHost + ?Sized>(
+pub(super) fn commit_failure_candidate<H: DeterministicActionHost + ?Sized>(
     host: &H,
     run_id: &str,
     workspace_path: &Path,
@@ -528,7 +530,7 @@ fn worktree_status_counts(workspace_path: &Path) -> Result<WorktreeStatusCounts,
     Ok(counts)
 }
 
-fn resolve_workspace_path<H: RuntimeHost + ?Sized>(
+fn resolve_workspace_path<H: DeterministicActionHost + ?Sized>(
     host: &H,
     input: &Value,
     batch_id: &str,

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/test_support.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/test_support.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 use tempfile::tempdir;
 
 use crate::context::{
-    RuntimeHost, TaskActivityUpdate, TaskAutomationUpdate, TaskReadHost, TaskWriteHost,
+    DeterministicActionHost, TaskActivityUpdate, TaskAutomationUpdate, TaskReadHost, TaskWriteHost,
 };
 
 use super::super::super::git::git_success;
@@ -133,7 +133,7 @@ impl TaskWriteHost for CommitTestHost {
     }
 }
 
-impl RuntimeHost for CommitTestHost {
+impl DeterministicActionHost for CommitTestHost {
     fn record_event(&self, _event: OrbitEvent) -> Result<(), OrbitError> {
         Ok(())
     }

--- a/crates/orbit-engine/src/executor/automation/vcs/failure.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/failure.rs
@@ -4,7 +4,7 @@ use chrono::Utc;
 use orbit_common::types::{ExternalRef, OrbitError, TaskComment, TaskStatus};
 use serde_json::{Value, json};
 
-use crate::context::{RuntimeHost, TaskAutomationUpdate, TaskHost};
+use crate::context::{DeterministicActionHost, TaskAutomationUpdate, TaskHost};
 use crate::executor::automation::input::{
     canonicalize_existing_dir, input_string_field, required_input_string,
 };
@@ -27,7 +27,7 @@ const FAILURE_HANDOFF_EVENT: &str = "pr_failure_handoff";
 /// push without rewriting unknown remote history, publish a blocked PR, and
 /// leave the task in `blocked` rather than `review`.
 pub(in crate::executor::automation) fn pr_failure_handoff<
-    H: RuntimeHost + TaskHost + Sync + ?Sized,
+    H: DeterministicActionHost + TaskHost + Sync + ?Sized,
 >(
     host: &H,
     input: &Value,

--- a/crates/orbit-engine/src/executor/automation/vcs/freshness.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/freshness.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use orbit_common::types::OrbitError;
 use serde_json::{Value, json};
 
-use crate::context::{RuntimeHost, TaskHost};
+use crate::context::{DeterministicActionHost, TaskHost};
 
 use super::super::input::{input_string_field, required_input_string};
 use super::git::{BaseSyncMode, git_command_success, git_output, resolve_worktree_start_point};
@@ -19,7 +19,9 @@ pub(super) struct BranchFreshness {
     pub(super) commits_ahead: u64,
 }
 
-pub(in crate::executor::automation) fn prepare_pr_handoff<H: RuntimeHost + TaskHost + ?Sized>(
+pub(in crate::executor::automation) fn prepare_pr_handoff<
+    H: DeterministicActionHost + TaskHost + ?Sized,
+>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {
@@ -88,7 +90,9 @@ fn prepare_error(error: OrbitError) -> (FailedHandoffPhase, OrbitError) {
     (FailedHandoffPhase::Prepare, error)
 }
 
-pub(in crate::executor::automation) fn rebase_pr_branch<H: RuntimeHost + TaskHost + ?Sized>(
+pub(in crate::executor::automation) fn rebase_pr_branch<
+    H: DeterministicActionHost + TaskHost + ?Sized,
+>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/attribution.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/attribution.rs
@@ -1,7 +1,7 @@
 use orbit_common::types::{OrbitError, Task, normalize_optional_attribution_label};
 use serde_json::json;
 
-use crate::context::RuntimeHost;
+use crate::context::DeterministicActionHost;
 
 pub(super) fn ship_done_attribution(task: &Task) -> Option<String> {
     normalize_optional_attribution_label(
@@ -12,7 +12,7 @@ pub(super) fn ship_done_attribution(task: &Task) -> Option<String> {
     )
 }
 
-pub(super) fn pr_review_attribution<H: RuntimeHost + ?Sized>(
+pub(super) fn pr_review_attribution<H: DeterministicActionHost + ?Sized>(
     host: &H,
     task: &Task,
     batch_id: &str,

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/merge.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/merge.rs
@@ -5,7 +5,7 @@ use orbit_store::pr_scoreboard;
 use orbit_tools::ToolContext;
 use serde_json::{Value, json};
 
-use crate::context::{RuntimeHost, TaskAutomationUpdate, TaskHost};
+use crate::context::{DeterministicActionHost, TaskAutomationUpdate, TaskHost};
 
 use super::super::super::input::{
     canonicalize_existing_dir, input_string_field, required_job_run_id,
@@ -14,7 +14,9 @@ use super::super::freshness::ensure_branch_fresh_against_base;
 use super::super::git::{base_sync_mode_from_input, git_command_success, git_output};
 use super::attribution::ship_done_attribution;
 
-pub(in crate::executor::automation) fn git_merge<H: RuntimeHost + TaskHost + Sync + ?Sized>(
+pub(in crate::executor::automation) fn git_merge<
+    H: DeterministicActionHost + TaskHost + Sync + ?Sized,
+>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {
@@ -39,7 +41,7 @@ pub(in crate::executor::automation) fn git_merge<H: RuntimeHost + TaskHost + Syn
     }
 }
 
-pub(super) fn merge_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
+pub(super) fn merge_batch_pr<H: DeterministicActionHost + TaskHost + ?Sized>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {
@@ -161,7 +163,7 @@ pub(super) fn merge_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
     Ok(json!({ "merged": true }))
 }
 
-fn resolve_batch_workspace_path<H: RuntimeHost + ?Sized>(
+fn resolve_batch_workspace_path<H: DeterministicActionHost + ?Sized>(
     host: &H,
     input: &Value,
     batch_id: &str,

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/open.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/open.rs
@@ -2,7 +2,7 @@ use orbit_common::types::{OrbitError, Role};
 use orbit_tools::ToolContext;
 use serde_json::{Value, json};
 
-use crate::context::{RuntimeHost, TaskHost};
+use crate::context::{DeterministicActionHost, TaskHost};
 
 use super::super::super::input::{
     input_string_field, json_number_to_string, required_input_string,
@@ -14,7 +14,9 @@ use super::super::handoff::{
 };
 use super::body::{build_batch_pr_body, default_pr_title};
 
-pub(in crate::executor::automation) fn pr_open<H: RuntimeHost + TaskHost + Sync + ?Sized>(
+pub(in crate::executor::automation) fn pr_open<
+    H: DeterministicActionHost + TaskHost + Sync + ?Sized,
+>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {
@@ -28,7 +30,7 @@ pub(in crate::executor::automation) fn pr_open<H: RuntimeHost + TaskHost + Sync 
     }
 }
 
-fn open_or_reuse_pr<H: RuntimeHost + TaskHost + ?Sized>(
+fn open_or_reuse_pr<H: DeterministicActionHost + TaskHost + ?Sized>(
     host: &H,
     input: &Value,
     context: &HandoffContext,
@@ -156,7 +158,9 @@ fn open_or_reuse_pr<H: RuntimeHost + TaskHost + ?Sized>(
 /// Create or reuse a PR for an already-pushed recovery branch without the
 /// normal freshness/success gate. The caller owns candidate validation and
 /// must block, never promote, the associated task.
-pub(in crate::executor::automation::vcs) fn open_or_reuse_unchecked<H: RuntimeHost + ?Sized>(
+pub(in crate::executor::automation::vcs) fn open_or_reuse_unchecked<
+    H: DeterministicActionHost + ?Sized,
+>(
     host: &H,
     workspace_path: &std::path::Path,
     head: &str,
@@ -199,7 +203,7 @@ fn invalid_prepare(error: OrbitError) -> (FailedHandoffPhase, OrbitError) {
     (FailedHandoffPhase::PrLookup, error)
 }
 
-fn view_pr<H: RuntimeHost + ?Sized>(
+fn view_pr<H: DeterministicActionHost + ?Sized>(
     host: &H,
     selector: &str,
     tool_context: ToolContext,
@@ -228,7 +232,7 @@ fn view_pr<H: RuntimeHost + ?Sized>(
     Ok((pr_number, pr_url))
 }
 
-fn find_pr_by_head<H: RuntimeHost + ?Sized>(
+fn find_pr_by_head<H: DeterministicActionHost + ?Sized>(
     host: &H,
     head: &str,
     tool_context: ToolContext,

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/promote.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/promote.rs
@@ -1,13 +1,15 @@
 use orbit_common::types::{ExternalRef, NO_DIFF_EXPECTED_TAG, OrbitError, TaskStatus};
 use serde_json::{Value, json};
 
-use crate::context::{RuntimeHost, TaskAutomationUpdate, TaskHost};
+use crate::context::{DeterministicActionHost, TaskAutomationUpdate, TaskHost};
 
 use super::super::super::input::{input_string_field, required_input_string};
 use super::super::handoff::{FailedHandoffPhase, load_handoff_context, record_failed_handoff};
 use super::attribution::pr_review_attribution;
 
-pub(in crate::executor::automation) fn pr_promote<H: RuntimeHost + TaskHost + ?Sized>(
+pub(in crate::executor::automation) fn pr_promote<
+    H: DeterministicActionHost + TaskHost + ?Sized,
+>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
@@ -15,7 +15,8 @@ use serde_json::{Value, json};
 use tempfile::{TempDir, tempdir};
 
 use crate::context::{
-    PrConfig, RuntimeHost, TaskActivityUpdate, TaskAutomationUpdate, TaskReadHost, TaskWriteHost,
+    DeterministicActionHost, PrConfig, TaskActivityUpdate, TaskAutomationUpdate, TaskReadHost,
+    TaskWriteHost,
 };
 
 use super::super::super::freshness::BranchFreshness;
@@ -263,7 +264,7 @@ impl TaskWriteHost for PrOpenTestHost {
     }
 }
 
-impl RuntimeHost for PrOpenTestHost {
+impl DeterministicActionHost for PrOpenTestHost {
     fn record_event(&self, _event: OrbitEvent) -> Result<(), OrbitError> {
         Ok(())
     }

--- a/crates/orbit-engine/src/executor/automation/vcs/push.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/push.rs
@@ -4,14 +4,16 @@ use orbit_common::types::{OrbitError, Role};
 use orbit_tools::ToolContext;
 use serde_json::{Value, json};
 
-use crate::context::{RuntimeHost, TaskHost};
+use crate::context::{DeterministicActionHost, TaskHost};
 
 use super::super::input::{canonicalize_existing_dir, input_string_field, required_job_run_id};
 use super::freshness::{commit_sha, remote_branch_sha};
 use super::git::{git_command_success, git_output, git_success};
 use super::handoff::{FailedHandoffPhase, load_handoff_context, record_failed_handoff};
 
-pub(in crate::executor::automation) fn push_batch_changes<H: RuntimeHost + TaskHost + ?Sized>(
+pub(in crate::executor::automation) fn push_batch_changes<
+    H: DeterministicActionHost + TaskHost + ?Sized,
+>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {
@@ -37,7 +39,7 @@ pub(in crate::executor::automation) fn push_batch_changes<H: RuntimeHost + TaskH
     }
 }
 
-pub(super) fn push_batch_changes_inner<H: RuntimeHost + ?Sized>(
+pub(super) fn push_batch_changes_inner<H: DeterministicActionHost + ?Sized>(
     host: &H,
     input: &Value,
     workspace_path: &Path,
@@ -106,7 +108,7 @@ pub(super) fn push_batch_changes_inner<H: RuntimeHost + ?Sized>(
     ))
 }
 
-fn resolve_workspace_path<H: RuntimeHost + ?Sized>(
+fn resolve_workspace_path<H: DeterministicActionHost + ?Sized>(
     host: &H,
     input: &Value,
 ) -> Result<PathBuf, OrbitError> {

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/merge.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/merge.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use orbit_common::types::OrbitError;
 use serde_json::{Value, json};
 
-use crate::context::RuntimeHost;
+use crate::context::DeterministicActionHost;
 use crate::executor::automation::input::{canonicalize_existing_dir, input_string_field};
 
 use super::super::git::{
@@ -15,7 +15,9 @@ use super::resolve_shared_worktree_path;
 const DEFAULT_BASE: &str = "main";
 const MAX_REBASE_RETRY_ATTEMPTS: usize = 2;
 
-pub(in crate::executor::automation) fn merge_batch_worktree_into_base<H: RuntimeHost + ?Sized>(
+pub(in crate::executor::automation) fn merge_batch_worktree_into_base<
+    H: DeterministicActionHost + ?Sized,
+>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
@@ -4,7 +4,9 @@ use orbit_common::types::OrbitError;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
-use crate::context::{RuntimeHost, TaskAutomationUpdate, TaskHost, ensure_task_can_enter_workflow};
+use crate::context::{
+    DeterministicActionHost, TaskAutomationUpdate, TaskHost, ensure_task_can_enter_workflow,
+};
 use crate::executor::automation::input::input_string_field;
 
 use super::super::git::{
@@ -21,7 +23,9 @@ const DEFAULT_BASE: &str = "main";
 ///
 /// Generic automation — not tied to duel or any specific workflow. Any
 /// pipeline can reuse this by passing a `branch_prefix`.
-pub(in crate::executor::automation) fn setup_worktree<H: RuntimeHost + TaskHost + ?Sized>(
+pub(in crate::executor::automation) fn setup_worktree<
+    H: DeterministicActionHost + TaskHost + ?Sized,
+>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {

--- a/crates/orbit-engine/src/lib.rs
+++ b/crates/orbit-engine/src/lib.rs
@@ -21,7 +21,7 @@
 //! # Key exports
 //! - v2 dispatcher, job executor, and audit writer types re-exported at the
 //!   crate root
-//! - [`RuntimeHost`] / [`TaskHost`] / [`EnvironmentHost`] / [`JobRunHost`] —
+//! - [`DeterministicActionHost`] / [`TaskHost`] / [`EnvironmentHost`] / [`JobRunHost`] —
 //!   the host trait boundary v2's deterministic actions dispatch against
 //! - [`execute_deterministic_action`] — the built-in automation actions
 //!   (git/PR/worktree/task-update) v2 job steps invoke
@@ -48,8 +48,8 @@ pub use activity_job::{
 };
 pub use context::{
     AGENT_INVOCATION_FAILED, AGENT_TIMEOUT, ActivityInvocationResult, AgentRoleConfig,
-    EnvironmentHost, JobRunHost, PrConfig, RuntimeHost, TaskActivityUpdate, TaskAutomationUpdate,
-    TaskHost, TaskReadHost, TaskWriteHost, WORKFLOW_RUN_FAILED_EVENT,
+    DeterministicActionHost, EnvironmentHost, JobRunHost, PrConfig, TaskActivityUpdate,
+    TaskAutomationUpdate, TaskHost, TaskReadHost, TaskWriteHost, WORKFLOW_RUN_FAILED_EVENT,
     blocked_workflow_failure_update, ensure_task_can_enter_workflow,
 };
 pub use executor::automation::vcs::{WorktreeGcOptions, WorktreeGcResult, collect_worktrees};

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -751,7 +751,7 @@ Recognition is the entire change: no safety gate moved. Non-terminal run, `--old
 
 - **[ORB-10427]** — Share one worktree-path derivation between `setup_worktree` and gc; collect bundles only when every member has settled.
 - **[ORB-10393]** — Port planning-duel planner and arbiter legs to seeded v2
-  assets with per-slot model overrides and retire `RuntimeHost::invoke_activity`.
+  assets with per-slot model overrides and retire `DeterministicActionHost::invoke_activity`.
 - **[ORB-10385]** — Gate job admission on the runtime's deterministic-action registry; register `pr_failure_handoff` and `worktree_gc`.
 - **[ORB-10380]** — Pin `base_sha` from `worktree_setup` through `git_commit`; split the commit step's failure diagnostics.
 - **[T20260418-2018]** — Add `JobV2` DAG constructs (`parallel`, `fan_out`, `loop`, `retry`, `when`).

--- a/docs/design/agent-families/2_design.md
+++ b/docs/design/agent-families/2_design.md
@@ -58,7 +58,7 @@ The duel model precedence is:
 2. `.orbit/executors/<family>.yaml::model_pair_override`
 3. `resolve_agent_model_pair()` builtin defaults
 
-This precedence is scoped to duel role selection through `RuntimeHost::duel_orchestrator_model`; non-duel model identity, envelope rendering, review sync, and task-review scoring continue to start at executor overrides and builtin defaults.
+This precedence is scoped to duel role selection through `DeterministicActionHost::duel_orchestrator_model`; non-duel model identity, envelope rendering, review sync, and task-review scoring continue to start at executor overrides and builtin defaults.
 
 ## 6. Concerns & Honest Limitations
 

--- a/docs/design/agent-families/4_decisions.md
+++ b/docs/design/agent-families/4_decisions.md
@@ -51,7 +51,7 @@ See full ADR-0151 for context, alternatives considered, and cost analysis.
 
 **Context.** Duel-plan previously walked the full `all_agent_families()` registry and used the same model-pair resolution chain as non-duel callers. That made local CLI availability load-bearing for every supported family and made reproducible planning-duel scoreboards depend on executor YAML state.
 
-**Decision.** Add a workspace `[duel]` section with `candidates` as a normalized subset of `all_agent_families()` and `[duel.models]` as flat orchestrator-only per-family overrides. Duel role selection reads those values through `RuntimeHost`; non-duel callers continue to use executor overrides and builtin model pairs.
+**Decision.** Add a workspace `[duel]` section with `candidates` as a normalized subset of `all_agent_families()` and `[duel.models]` as flat orchestrator-only per-family overrides. Duel role selection reads those values through `DeterministicActionHost`; non-duel callers continue to use executor overrides and builtin model pairs.
 
 **Consequences.**
 - Duel permutations remain dynamic but require at least three distinct configured families.


### PR DESCRIPTION
## Task

[ORB-10397](https://orbit-cli.com/tasks/ORB-10397) — Rename RuntimeHost to reflect its post-v1 role (DeterministicActionHost)

### Description

Wave 3 of the orbit cleanup (design doc: ~/workspace/constellation/knowledgebase/polaris/design/orbit-cleanup/phaseoutv1.md §4, trait carve-down note). After Stage 3, RuntimeHost holds only what v2 deterministic dispatch needs; the name implies a retired era.

Rename the trait (suggested: DeterministicActionHost — confirm naming against docs/design/activity-job/2_design.md vocabulary before committing) and update all impls, bounds (execute_action's H: RuntimeHost + TaskHost + EnvironmentHost), test mocks, and docs. Large but purely mechanical diff; no signature or behavior changes beyond the rename.

Depends on Stage 3 (the carve-down defines the final surface being renamed). Dispatch gate: hold until ORB-10358 lands and the rebuild is verified.

### Acceptance Criteria

- No references to RuntimeHost remain (code, tests, docs); trait surface unchanged modulo the name; cargo check --workspace + full tests pass; rename rationale noted in the PR.

## Execution Summary

<details>
<summary>Click to expand</summary>

Verified and validated the RuntimeHost -> DeterministicActionHost rename that was already fully implemented (uncommitted) in this worktree at run start: the trait definition and its file (crates/orbit-core/src/runtime/engine/runtime_host.rs -> deterministic_action_host.rs, plus its sibling tests file), all impls, the execute_action bound (H: DeterministicActionHost + TaskHost + EnvironmentHost), duel/vcs/task_update call sites, orbit-engine's public re-exports (context/mod.rs, lib.rs), and the four docs/ADR mentions (ADR-0155, docs/design/activity-job/4_decisions.md, docs/design/agent-families/2_design.md and 4_decisions.md) were all renamed consistently. Confirmed no remaining references to the old RuntimeHost trait name anywhere in the repo (all surviving 'RuntimeHost' hits are the unrelated V2RuntimeHost trait, out of scope). Ran cargo check --workspace (clean) and cargo test --workspace --no-fail-fast (616 passed / 1 pre-existing failure in orbit-core::runtime::v2_host::tests::v2_host::http_agent_loop_tool_update_persists_runtime_identity_family — reproduced identically by stashing this task's changes and testing the unmodified base tree, confirming it's an environment credential-availability issue unrelated to this rename, not a regression). make ci-fast passed clean (fmt-check + all guardrail scripts). No unlisted files needed touching beyond what was already in context_files. Trait surface and behavior unchanged; this is a pure mechanical rename.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10397-6a659532`
- Behind base: 0
- Ahead of base: 1