### PR TITLE
Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design-patterns/command.md
+++ b/docs/design-patterns/command.md
@@ -1,10 +1,11 @@
 ---
 type: pattern
 summary: "Command Pattern"
+last_validated: 2026-07-26
 ---
 # Command Pattern
 
-In this codebase, Command = the `Tool` trait at `crates/orbit-tools/src/lib.rs:225`:
+In this codebase, Command = the `Tool` trait at `crates/orbit-tools/src/lib.rs:243`:
 
 ```rust
 pub trait Tool: Send + Sync {
@@ -13,7 +14,7 @@ pub trait Tool: Send + Sync {
 }
 ```
 
-The registry at `crates/orbit-tools/src/registry.rs:10` stores `Arc<dyn Tool>` keyed by `ToolSchema::name`. Adding a tool means: writing a struct, `impl Tool`, registering in `builtin::register_builtins`. The dispatcher never changes.
+The registry at `crates/orbit-tools/src/registry.rs:31` stores `Arc<dyn Tool>` keyed by `ToolSchema::name`. Adding a tool means: writing a struct, `impl Tool`, registering in `builtin::register_builtins`. The dispatcher never changes.
 
 Two codebase-specific shapes carry non-obvious lessons; everything else is straightforward `impl Tool`.
 
@@ -33,7 +34,7 @@ impl Tool for OrbitPipelineInvokeTool {
 }
 ```
 
-`execute_host_action` (`orbit/mod.rs:204`) resolves the caller's identity, requires a host on the context, and forwards `(action, input, agent, model, reservation_owner)` into the runtime.
+`execute_host_action` (`orbit/mod.rs:275`) resolves the caller's identity, requires a host on the context, and forwards `(action, input, agent, model, reservation_owner)` into the runtime.
 
 Patterns to copy:
 
@@ -41,29 +42,10 @@ Patterns to copy:
 - **Schema in `orbit-tools`; logic in `orbit-core`.** This is the rule that keeps `orbit-tools` free of runtime / store dependencies per the architecture diagram in `CLAUDE.md`. If your tool needs the task store, the activity-job engine, or sandboxed exec, it must dispatch through the host — don't pull those deps into `orbit-tools`.
 - **Remote MCP-only adapters stay in `orbit-remote`.** Global host/workspace discovery and local-derived graph definitions are not generic `ToolRegistry` commands. Their schema, policy, and execution live together in Remote and are composed over the generic MCP kernel; adding one does not add an `OrbitBuiltinAction` or Core `run_tool` arm.
 
-## Reference: compatibility shim (`OrbitGraphHistoryTool`)
+## Former compatibility shim: `graph.history`
 
-A tool whose entire `execute()` is a structured deprecation error. Used when a tool is removed but the name should still resolve to an actionable redirect rather than "tool not found." From `crates/orbit-tools/src/builtin/orbit/graph_history.rs:10`:
-
-```rust
-impl Tool for OrbitGraphHistoryTool {
-    fn schema(&self) -> ToolSchema { /* keeps the old name + params */ }
-
-    fn execute(&self, _ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
-        let selector_str = super::required_string(&input, &["selector"], "selector")?;
-        let _: Selector = selector_str.parse()
-            .map_err(|error| OrbitError::InvalidInput(format!("{error}")))?;
-        Err(OrbitError::InvalidInput(REMOVED_GRAPH_HISTORY_MESSAGE.to_string()))
-    }
-}
-```
-
-Patterns to copy:
-
-- **Keep the schema; replace the body.** Agents discover tools by name. A tool that vanishes leaves a worse trail than one that returns a redirect.
-- **Validate inputs before returning the deprecation error.** Malformed callers get "invalid selector"; correct callers get the redirect message. Easier to diagnose.
-- **Redirect text in a `pub const` next to its replacement.** `REMOVED_GRAPH_HISTORY_MESSAGE` lives in `orbit-knowledge::workflows::observe` — alongside whatever still implements the underlying capability — and the shim imports it. Don't inline the message in the tool body; the replacement guidance rots if it's not near the replacement.
+The former `OrbitGraphHistoryTool` compatibility stub is no longer present. The registry records that ORB-00391 removed the v1 `orbit-knowledge` graph builtins and `graph.history` stub, while ORB-10325 keeps v2 graph access exclusively on `orbit graph` (`crates/orbit-tools/src/builtin/orbit/mod.rs:120`). Do not use the retired shim shape as a template for new tools.
 
 ---
 
-**Not Command — same code shape, different role.** The codebase also uses `Box<dyn Trait>` + registry where every `impl` is a parallel algorithm for *the same* operation (parse Rust vs parse Python). That's Strategy, not Command — selection is by input-derived key, not by caller naming the operation. If that's what you're building, the load-bearing example is `FileExtractor` (`crates/orbit-knowledge/src/extract/mod.rs:53`, `Vec<Box<dyn _>>` + `applies_to()` predicate). The engine's `ActivityExecutor` + `ActivityExecutorRegistry` (`HashMap<String, Box<dyn _>>` keyed by `spec_type`) used to be the second example; [ORB-10395] deleted it — v2 dispatch selects a handler from a typed spec enum instead, so don't reach for a string-keyed executor registry in the engine.
+**Not Command — same code shape, different role.** The codebase also uses `Box<dyn Trait>` + registry where every `impl` is a parallel algorithm for *the same* operation (parse Rust vs parse Python). That's Strategy, not Command — selection is by input-derived key, not by caller naming the operation. The current load-bearing example is `ExtractorRegistry` (`crates/orbit-graph/src/sync/scanner.rs:183`, `Vec<Box<dyn Extractor>>` + `supports()` predicate). The engine's `ActivityExecutor` + `ActivityExecutorRegistry` (`HashMap<String, Box<dyn _>>` keyed by `spec_type`) used to be the second example; [ORB-10395] deleted it — v2 dispatch selects a handler from a typed spec enum instead, so don't reach for a string-keyed executor registry in the engine.

--- a/docs/design-patterns/error_translation.md
+++ b/docs/design-patterns/error_translation.md
@@ -1,6 +1,7 @@
 ---
 type: pattern
 summary: "Crate-Boundary Error Translation"
+last_validated: 2026-07-26
 ---
 # Crate-Boundary Error Translation
 
@@ -72,13 +73,9 @@ pub fn graph_error_to_orbit(error: GraphError) -> OrbitError {
 }
 ```
 
-Used at every cross-crate edge — e.g. `crates/orbit-remote/src/mcp/graph.rs`:
+The graph crate currently has no workspace dependents, so there is no live cross-crate call site for this translator; `graph_error_to_orbit` remains at the graph crate root for any future boundary. The former `crates/orbit-remote/src/mcp/graph.rs` adapter was removed when graph access was consolidated and removed from MCP.
 
-```rust
-to_json(graph.search(&query).map_err(graph_error_to_orbit)?)
-```
-
-Other live translators in the same shape: `selector_error_to_orbit` (`orbit-common::utility::selector`, re-exported through `orbit-graph::extract` for graph consumers), `rpc_error_to_orbit` (`orbit-search::rpc`), and `dispatch_error_to_orbit` (`orbit-engine`, dispatcher module).
+Other live translators in the same shape: `selector_error_to_orbit` (`orbit-common::utility::selector`; `Selector` and `SelectorParseError` are re-exported through `orbit-graph::extract` for graph consumers), `rpc_error_to_orbit` (`orbit-search::rpc`), and `dispatch_error_to_orbit` (`orbit-engine`, dispatcher module).
 
 Patterns to copy:
 

--- a/docs/design-patterns/newtype.md
+++ b/docs/design-patterns/newtype.md
@@ -1,6 +1,7 @@
 ---
 type: pattern
 summary: "Newtype Wrapper"
+last_validated: 2026-07-26
 ---
 # Newtype Wrapper
 
@@ -32,47 +33,7 @@ Sometimes phrased as "parse, don't validate": validate once at construction so n
 - **The "primitive" is already typed.** `PathBuf`, `Uuid`, `chrono::DateTime` already wear their domain.
 - **The primitive really is free-form.** A user-facing note, comment, or description has no contract to enforce.
 
-## Reference: `RefName`
-
-A git-ref-name wrapper around `String`. From `crates/orbit-knowledge/src/graph/object_store.rs:27`:
-
-```rust
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct RefName(String);
-
-impl RefName {
-    pub fn new(value: impl Into<String>) -> Result<Self, KnowledgeError> {
-        let value = value.into();
-        validate_ref_name(&value)?;
-        Ok(Self(value))
-    }
-
-    pub fn as_str(&self) -> &str { &self.0 }
-}
-
-impl fmt::Display for RefName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.0.fmt(f) }
-}
-
-fn validate_ref_name(value: &str) -> Result<(), KnowledgeError> {
-    if value.trim().is_empty() { /* ... */ }
-    if value.starts_with('-') { /* ... */ }
-    if value.starts_with('/') || value.ends_with('/') || value.contains("//") { /* ... */ }
-    // ...remaining git ref-name grammar checks...
-    Ok(())
-}
-```
-
-Downstream code accepts `&RefName` or `RefName` and never re-checks.
-
-Patterns to copy:
-
-- **Tuple struct with a non-`pub` inner field.** `pub struct RefName(String)` lets you derive `Debug`/`Clone`/`Hash`/`PartialEq`/`Eq` for free while keeping outside callers from constructing `RefName("--bad".into())` directly.
-- **`new(impl Into<String>) -> Result<Self, _>` as the only constructor.** Accepts `&str`, `String`, anything string-like; returns the typed error if invalid. Don't add a `From<&str>` impl (it would have to panic) or `pub const` constructors.
-- **`as_str(&self) -> &str` for read-only access.** Callers needing the raw form (display, serialization, passing to APIs that take `&str`) get it cheaply, without enabling mutation.
-- **Validation in a private free function next to the type.** Not a `validate()` method on the wrapper — the wrapper *carries* the proof of validation; it doesn't re-offer it.
-
-Use this shape whenever a primitive has a protocol contract worth enforcing once at the boundary.
+The former `RefName` example was removed with the `orbit-knowledge` crate; no current production private-inner validated newtype is present in the workspace. The generic shape above remains the guidance for introducing one when a primitive has a protocol contract worth enforcing once at the boundary.
 
 ---
 

--- a/docs/design-patterns/raii_guard.md
+++ b/docs/design-patterns/raii_guard.md
@@ -1,6 +1,7 @@
 ---
 type: pattern
 summary: "RAII Guard Pattern"
+last_validated: 2026-07-26
 ---
 # RAII Guard Pattern
 
@@ -22,7 +23,7 @@ Four shapes in the codebase carry distinct lessons.
 
 ## Reference: `AuditGuard` — record the scope's outcome once
 
-From `crates/orbit-cli/src/audit_middleware.rs:39`:
+From `crates/orbit-cli/src/audit_middleware.rs:28`:
 
 ```rust
 pub struct AuditGuard<'a> {
@@ -59,7 +60,7 @@ Patterns to copy:
 
 ## Reference: `StagedTextFile` — `Drop` as rollback
 
-From `crates/orbit-common/src/utility/fs.rs:74`:
+From `crates/orbit-common/src/utility/fs.rs:112`:
 
 ```rust
 pub struct StagedTextFile {
@@ -137,41 +138,29 @@ Patterns to copy:
 - **Hold a `'static` mutex as a field.** `_lock: MutexGuard<'static, ()>` makes "one guard at a time, process-wide" structurally impossible to violate.
 - **Hand-rollback on partial install.** `Drop` only runs on values that successfully return; mid-construction failures must unwind their own work before returning `Err`.
 
-## Reference: `GraphLockGuard` — explicit release with `Drop` fallback
+## Reference: `DbLockGuard` — resource held until `Drop`
 
-From `crates/orbit-knowledge/src/lock.rs:209`:
+From `crates/orbit-graph/src/sync/scanner.rs:150`:
 
 ```rust
-pub struct GraphLockGuard {
-    /* ...selectors, owner, paths... */
-    released: bool,
+pub(crate) struct DbLockGuard {
+    _file: File,
 }
 
-impl GraphLockGuard {
-    pub fn release(&mut self) -> Result<(), KnowledgeError> {
-        if self.released { return Ok(()); }
-        /* ...unlock each selector, persist store... */
-        self.released = true;
-        Ok(())
-    }
-}
-
-impl Drop for GraphLockGuard {
-    fn drop(&mut self) {
-        if self.released { return; }
-        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            if let Err(error) = self.release() {
-                tracing::warn!(target: "orbit.knowledge.lock", error = %error, "...");
-            }
-        }));
+impl DbLockGuard {
+    pub(crate) fn acquire(db_path: &Path) -> Result<Self, GraphError> {
+        let lock_path = lock_path_for(db_path);
+        let file = /* open the sidecar and acquire an exclusive lock */;
+        Ok(Self { _file: file })
     }
 }
 ```
 
 Patterns to copy:
 
-- **`released: bool` for idempotency.** `release()` followed by scope exit is a no-op, not a double-release.
-- **Explicit `release()` returns `Result`; `Drop` only logs.** Callers that can react to a release error get a real error path. Callers that can't (or whose scope just ended) get the Drop fallback.
+- **Hold the resource in a field.** `DbLockGuard` keeps the locked sidecar `File` alive in `_file`; dropping the file releases the OS lock. There is no separate explicit release path to call or duplicate.
+
+The live implementation is `crates/orbit-graph/src/sync/scanner.rs:150`. The former `GraphLockGuard` reference belonged to the retired `orbit-knowledge` lock store.
 
 ---
 

--- a/docs/design-patterns/test_layout.md
+++ b/docs/design-patterns/test_layout.md
@@ -1,6 +1,7 @@
 ---
 type: pattern
 summary: "Per-Module Sibling tests/ Directory"
+last_validated: 2026-07-26
 ---
 # Per-Module Sibling tests/ Directory
 


### PR DESCRIPTION
## Task

[ORB-10430](https://orbit-cli.com/tasks/ORB-10430) — Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Docs that have no frontmatter block at all are **out of the rotation**: do
not invent a frontmatter block for them, because `type` and `summary` are
required fields and guessing them corrupts the docs corpus. List them in
your execution summary instead so a human can decide.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**` and `CHANGELOG.md` (historical records — a
citation that was accurate when written is provenance, not staleness),
`docs/design/_archive/**`, `.orbit/tasks/`, `.orbit/graph/`, and any other
generated or stored state. Do not author new documents or new sections; if
you find a real documentation gap, report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and the docs you found with no frontmatter block.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/design/_archive/, or generated state was modified.
- No frontmatter block was created for a doc that lacked one; such docs are listed instead.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Exact batch selection: docs/design-patterns/command.md, error_translation.md, newtype.md, raii_guard.md, test_layout.md, then docs/design/CONVENTIONS.md (the five patterns were the oldest missing-validation docs after excluding no-frontmatter prose and generated/template/archive content; CONVENTIONS was the sixth).
- command.md: refreshed verified Tool/registry/dispatch paths, removed the deleted OrbitGraphHistoryTool example, and pointed the Strategy example at the live ExtractorRegistry.
- error_translation.md: refreshed selector re-export wording and removed the deleted orbit-remote graph adapter example.
- newtype.md: removed the deleted orbit-knowledge RefName example while retaining the generic guidance.
- raii_guard.md: refreshed live source paths and replaced the retired GraphLockGuard example with orbit-graph DbLockGuard.
- test_layout.md: verified and stamped only.
- CONVENTIONS.md was inspected but left unstamped and unmodified because its recommendation-only claims were not fully objectively verifiable in this bounded run.
- No-frontmatter docs left untouched: docs/CONFIG.md, docs/LESSONS.md, docs/POSITIONING.md, docs/design/_templates/references/glossary.md, docs/design/_templates/specs/_mechanism.md, docs/design/activity-job/references/glossary.md, docs/design/activity-job/specs/audit-envelope.md, docs/design/activity-job/specs/backend-resolution.md, docs/design/agent-families/references/glossary.md, docs/design/auditability/references/glossary.md, docs/design/auditability/specs/artifact-redaction.md, docs/design/auditability/specs/coverage-matrix.md, docs/design/auditability/specs/event-schema.md, docs/design/auditability/specs/redaction-retention.md, docs/design/host-registry/references/glossary.md, docs/design/mcp-bridge/references/glossary.md, docs/design/orbit-docs-plugin/1_scope.md, docs/design/orbit-graph/specs/GRAPH_SPEC.md, docs/design/policy-sandbox/references/glossary.md, docs/design/policy-sandbox/specs/fs-profile-resolution.md, docs/design/policy-sandbox/specs/sandbox-exec-contract.md, docs/design/project-learnings/references/glossary.md, docs/design/project-learnings/references/injection-layers.md, docs/design/remote-access/references/glossary.md, docs/design/remote-access/specs/ssh-tunnel.md, docs/design/task-artifacts/references/glossary.md, docs/design/task-artifacts/specs/task-bundle-v2.md, docs/design/user-interface/specs/theme.md.
Assessment: Minimal documentation-only diff; no new document or section, no prose reflow, and no protected/generated state changes.
Validation:
- rg/test -e checks verified stamped paths and symbols and confirmed retired examples are absent.
- orbit activity --help, orbit job --help, and orbit run --help verified current command surfaces.
- git diff --check and forbidden-path checks passed.
- make ci-fast passed.
- Existing friction checkpoint: F2026-07-145.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10430-6a659950`
- Behind base: 0
- Ahead of base: 1