### PR TITLE
Release runbook mislabels agent-main as the release branch and omits promotion to main

### DIFF
--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -84,9 +84,11 @@ Each step names the exact file or command. Do them in order.
    exactly the previous version — anything else means an unrelated regression
    in one of the files the check inspects.
 
-4. **Commit the version bumps** and merge to the release branch
-   (`agent-main`). One commit, one PR, one bump set — do not let the two
-   plugin manifests or the npm package drift across commits.
+4. **Commit the version bumps** and merge to `agent-main`, the development
+   integration branch. One commit, one PR, one bump set — do not let the two
+   plugin manifests or the npm package drift across commits. This is not the
+   final release landing: after the tag and release CI, step 6 directs the
+   required promotion to `main`.
 
 5. **Push the matching tag.** From the merge commit:
 
@@ -118,7 +120,11 @@ Each step names the exact file or command. Do them in order.
    receives a CLI asset, but semantic search is unsupported because the
    companion has no x86_64-apple-darwin ONNX Runtime prebuilt.
 
-   All five must be green before step 7.
+   All five must be green before step 7. At that point, follow
+   [`RELEASING.md` §10b](../../RELEASING.md#10b-promote-to-main) to promote
+   `agent-main` to the production release branch (`main`), then follow
+   [`RELEASING.md` §10c](../../RELEASING.md#10c-post-merge-back-merge-to-agent-main)
+   to back-merge `main` to `agent-main` in the same session.
 
 7. **Publish to npm manually.** From the merged commit on your laptop:
 


### PR DESCRIPTION
## Task

[ORB-10431](https://orbit-cli.com/tasks/ORB-10431) — Release runbook mislabels agent-main as the release branch and omits promotion to main

### Description

## Problem

`docs/runbooks/release.md` step 4 reads:

> **Commit the version bumps** and merge to the release branch (`agent-main`).

`agent-main` is not the release branch. It is the universal landing/default branch where work accumulates. `main` is the release branch — the production branch a release is promoted to.

The two authorities agree with each other and disagree with this runbook:

- `RELEASING.md` §10b: opens a PR `agent-main → main` "so the release reaches the production branch", merged with a **merge commit** (never squash or rebase) so the release tag stays reachable from `main`'s history; §10c then back-merges `main → agent-main` in the same session.
- The repo router (`CLAUDE.md` in the constellation parent): `orbit` and `sextant` land via PR into `agent-main`; "their `main` is the release branch."

Confirmed against history: `v0.9.2` (`b50f73981`, "chore: prepare v0.9.2 release") is reachable from `main`, and `main` currently sits 569 commits behind `agent-main` — exactly the shape the promote-on-release flow produces.

## Why it matters

This is the operational runbook someone follows while cutting a release. Its step list ends at "publish to npm / verify" and never mentions promotion or back-merge, so a drafter working from this file alone tags, publishes to npm and Homebrew, and leaves `main` stale — with no step that would reveal the omission. The mislabel is what makes the omission invisible: if `agent-main` is believed to be the release branch, there is nothing left to promote.

## Constraints

- **`RELEASING.md` is the authority for the branch/tag/promotion sequence — do not restate it here.** This runbook's own preamble already defers to it ("See also RELEASING.md for the higher-level release runbook and versioning policy"). Correct the label and route the reader to the promotion steps; do not duplicate the command blocks into a second place that can drift.
- Do not renumber or restructure the existing steps beyond what the correction requires. Steps 1–8 are cross-referenced from the "What `make release-check` enforces" section and from step 3's expected-failure note.
- Do not change any of the npm, signing-key, or smoke-test content — none of it is implicated.
- Verify the claim before writing it, rather than trusting this description: confirm which branch `v0.9.2` is reachable from and what `RELEASING.md` §10b/§10c actually say.
- PR mode — `orbit` is PR+CI gated. Branch off `agent-main`, land via PR.

## Out of scope

- Any change to `RELEASING.md` itself — it is correct.
- Reconciling the separate CHANGELOG policy conflict (`RELEASING.md` step 2 and `CLAUDE.md` say the release section is compiled at release time; `## Unreleased` has 64 accumulated bullets). Tracked elsewhere.
- Changing the actual release process, branch protection, or CI.

### Acceptance Criteria

- `docs/runbooks/release.md` no longer describes `agent-main` as the release branch anywhere; a reader of step 4 alone cannot conclude that tagging and publishing completes a release.
- The runbook routes the reader to `RELEASING.md` §10b (promote `agent-main → main`) and §10c (back-merge) at the point in the sequence where they apply, without copying those command blocks into this file.
- Existing step numbering is preserved, and the cross-references from step 3's expected-failure note and the "What `make release-check` enforces" section still resolve to the steps they name.
- The execution summary quotes the evidence checked: which branch `v0.9.2` is reachable from, and the relevant lines of `RELEASING.md` §10b/§10c.
- No change to `RELEASING.md`, to npm/signing/smoke content in this runbook, or to any code, workflow, or CI configuration.
- `make ci-fast` passes; CI green on the PR.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated docs/runbooks/release.md step 4 to identify agent-main as the development integration branch, state that promotion to main remains required, and preserve the existing 1–8 numbering.
- Added the release-sequence handoff after step 6: readers follow RELEASING.md §10b for agent-main → main promotion and §10c for the same-session main → agent-main back-merge; no command blocks were duplicated.
Evidence checked:
- v0.9.2 (b50f73981f20a725c2905120934e33d723218717) is reachable from main (and agent-main), verified with git merge-base --is-ancestor.
- RELEASING.md §10b states that after the tag and green release CI, a PR agent-main → main brings the release to the production branch and must merge with a merge commit; §10c requires a same-session main → agent-main back-merge.
Validation:
- git diff --check passed.
- make ci-fast passed (format, documentation index, installer/security, dependency-direction, import, stability, learning-layout, artifact-redaction, changelog-style, error-translation, and orphan-module guards).
Assessment: Scoped documentation-only correction; RELEASING.md, npm/signing/smoke content, code, workflows, and CI configuration remain unchanged.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10431-6a659da1`
- Behind base: 0
- Ahead of base: 1