### PR TITLE
Document the CHANGELOG archive-on-major-release convention and carve docs/changelogs out of the doc-duties sweep

### DIFF
--- a/.orbit/auto_tasks/doc-duties.yaml
+++ b/.orbit/auto_tasks/doc-duties.yaml
@@ -67,11 +67,12 @@ template:
     In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
     `docs/runbooks/**`, and the other prose under `docs/`.
 
-    Never modify: `.orbit/adrs/**` and `CHANGELOG.md` (historical records — a
-    citation that was accurate when written is provenance, not staleness),
-    `docs/design/_archive/**`, `.orbit/tasks/`, `.orbit/graph/`, and any other
-    generated or stored state. Do not author new documents or new sections; if
-    you find a real documentation gap, report it rather than filling it.
+    Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
+    (historical records — a citation that was accurate when written is
+    provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
+    `.orbit/graph/`, and any other generated or stored state. Do not author
+    new documents or new sections; if you find a real documentation gap,
+    report it rather than filling it.
 
     Do not add project-specific identifiers (person names, task/ADR/friction
     ids) to anything under `crates/*/assets/**` — those assets seed every
@@ -87,7 +88,7 @@ template:
   - Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
   - Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
   - Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
-  - No file under .orbit/adrs/, CHANGELOG.md, docs/design/_archive/, or generated state was modified.
+  - No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
   - No frontmatter block was created for a doc that lacked one; such docs are listed instead.
   - No new document or new section was authored.
   - Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -42,6 +42,19 @@ Layout migrations must be **idempotent or staged (write-new-then-swap)**: they a
 
 Such a change is still **breaking** for versioning purposes (bump minor) and must be listed under Breaking Changes; the registry entry is what makes it *survivable*, not what makes it non-breaking.
 
+### CHANGELOG archiving
+
+On a **major** release, the CHANGELOG history released before that version is archived under `docs/changelogs/` and `CHANGELOG.md` starts fresh (the new version's section, plus a blank `## Unreleased`). Between major releases, `CHANGELOG.md` accumulates every released section and is never split.
+
+Under the versioning policy above, the current 0.x line has no major bump — every release, including breaking ones, is a `0.<minor>.<patch>` bump. So the archive trigger **does not exist yet**: a breaking `0.9.2 → 0.10.0` (or any other `0.x → 0.(x+1).0`) release does not archive, no matter how large `CHANGELOG.md` has grown. The convention first applies at `1.0.0`, and at each major release after that. Until then, `CHANGELOG.md` accumulates unconditionally.
+
+ORB-10429 executed this archive ahead of `0.10.0` and produced a validated, working diff shape before its PR was rejected — on timing (there was no major-release trigger), not on the mechanism itself. Reuse that shape rather than re-deriving it, once a real major release triggers this:
+
+- `CHANGELOG.md` keeps its exact name and repo-root location; the archive gets the new name and location, never the live file. Four things bind to `CHANGELOG.md`'s current path and must keep resolving: `scripts/check-changelog-style.sh` (hardcodes `$repo_root/CHANGELOG.md`), the convention-file allowlist in `crates/orbit-core/src/command/task/paths.rs`, the never-modify list in `.orbit/auto_tasks/doc-duties.yaml`, and the references to it from this file, `CONTRIBUTING.md`, `CLAUDE.md`, ADR-0176, and ADR-0210.
+- Relocation of released sections into `docs/changelogs/` is byte-for-byte — stale task-id citations and inconsistent old bullet shapes are provenance, not defects, and must survive the move unedited.
+- The live `## Unreleased` section never moves; only already-released `## <X.Y.Z>` sections are archived.
+- Cross-link the two locations so neither reads as a dead end: the archive file links back to `CHANGELOG.md`, and `CHANGELOG.md` links forward to `docs/changelogs/` once that directory exists.
+
 ## Release checklist
 
 ### 1. Survey commits since last tag

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -71,6 +71,12 @@ Each step names the exact file or command. Do them in order.
    derives the binary tag as `v${PKG.version}`; this field is the source of
    truth that gets in front of users.
 
+   If this release is a **major** version bump, first work through the
+   CHANGELOG archiving convention in
+   [`RELEASING.md`](../../RELEASING.md#changelog-archiving) — it moves
+   released history out of `CHANGELOG.md` before this runbook's steps touch
+   any version fields. This runbook does not restate that policy.
+
 2. **Bump the plugin manifest versions** in
    [`plugin/.claude-plugin/plugin.json`](../../plugin/.claude-plugin/plugin.json)
    and


### PR DESCRIPTION
## Task

[ORB-10432](https://orbit-cli.com/tasks/ORB-10432) — Document the CHANGELOG archive-on-major-release convention and carve docs/changelogs out of the doc-duties sweep

### Description

## Problem

The release docs say nothing about when released history is moved out of `CHANGELOG.md`. The file simply grows — 19 sections, 297 bullets, 495 lines as of `0.9.2`.

The convention, as decided by the maintainer: **on a major release, the previous CHANGELOG contents are archived under `docs/changelogs/` and `CHANGELOG.md` starts fresh.** Between major releases it accumulates and is left alone.

Because that rule was unwritten, ORB-10429 was filed and executed to archive the history ahead of `0.10.0` — a minor bump, where the convention does not apply. Its PR was rejected on timing. Writing the rule down is what prevents the next re-litigation; the next legitimate trigger may be a year out.

## Two things must land together

**1. The convention, documented.**

`RELEASING.md` is the primary home — it owns the versioning policy and the CHANGELOG drafting step. `docs/runbooks/release.md` is the operational cut-a-release runbook and must also carry it, at the point in its step sequence where it applies, so an operator working from the runbook alone does not miss it.

**2. `docs/changelogs/**` carved out of the doc-duties sweep — required, not optional.**

`.orbit/auto_tasks/doc-duties.yaml` scopes itself to `docs/design/**`, `docs/runbooks/**`, "and the other prose under `docs/`". `docs/changelogs/` falls inside "other prose under `docs/`", so without a carve-out the doc-freshness runner will treat archived release history as stale documentation and rewrite it — the exact failure its own never-modify list already guards against for `CHANGELOG.md` and `.orbit/adrs/**` ("historical records — a citation that was accurate when written is provenance, not staleness"). The carve-out must land in this change, not be deferred to whenever the first archive happens; by then the trap is armed and nobody is looking at it.

## The trigger must be stated unambiguously

`RELEASING.md` currently specifies "Pre-1.0 semver: `0.<minor>.<patch>`" with **breaking → bump minor**. So in the active 0.x regime there is no major bump at all: `0.9.2 → 0.10.0` carries breaking changes and is still a minor. "Archive on a major release" therefore has no defined meaning today, and a reader can plausibly map it onto any breaking release — precisely the misreading that produced ORB-10429.

The wording must let a reader decide, from the text alone, whether a given release triggers an archive — in both the pre-1.0 and post-1.0 regimes. If the rule first applies at `1.0.0`, say that in those words. Do not paper this over with a phrase that reads fine and decides nothing.

## Mechanism already verified — record it, don't re-derive it

ORB-10429 produced a working, validated shape before it was rejected for timing. These are correctness requirements, not preferences:

- **`CHANGELOG.md` keeps its exact name and repo-root location.** Four sites bind to it: `scripts/check-changelog-style.sh` (hardcodes `$repo_root/CHANGELOG.md`, runs under `make ci-fast`), `crates/orbit-core/src/command/task/paths.rs` (repo-root convention-file allowlist), `.orbit/auto_tasks/doc-duties.yaml` (never-modify list), and the `RELEASING.md` / `CONTRIBUTING.md` / `CLAUDE.md` / ADR-0176 / ADR-0210 references. The archive is the file that gets a new name and location — never the live one.
- **Relocation is byte-for-byte.** Stale task-id citations and inconsistent old bullet shapes are provenance and must survive verbatim.
- **The in-progress `## Unreleased` section stays in the live file.** Only released sections move.
- Both files must point at each other so neither is a dead end.

## Constraints

- **Documentation and configuration only. Perform no archive.** `CHANGELOG.md` keeps its full history through the `0.10.0` cut, byte-identical. This task writes the rule and disarms the trap; it does not apply the rule.
- Do not create `docs/changelogs/` or place any file in it. The directory comes into existence at the first real major release.
- `docs/runbooks/release.md` gets the convention added without renumbering or restructuring its existing steps — they are cross-referenced from step 3's expected-failure note and from the "What `make release-check` enforces" section.
- Do not restate `RELEASING.md`'s branch/tag/promotion sequence inside the runbook; the runbook defers to it by design.
- Verify rather than trust this description: read the current `RELEASING.md` versioning-policy and step-2 sections, read doc-duties' scope and never-modify blocks, and confirm the four coupling sites still exist at the paths named.

## Out of scope

- Performing any archive, now or later in this task.
- Changing the versioning policy itself (pre-1.0 semver, breaking → minor). If the 1.0 criteria are undefined, note that — do not invent them.
- Any change to `CHANGELOG.md` content, or to version numbers in `Cargo.toml`, `plugin/npm/package.json`, or either plugin manifest.

### Acceptance Criteria

- `RELEASING.md` states the convention: on a major release, released CHANGELOG history is archived under `docs/changelogs/` and `CHANGELOG.md` starts fresh; between major releases the file accumulates and is not split.
- The trigger is stated unambiguously for both regimes — a reader in the current 0.x line can tell from the text alone whether a given release (e.g. a breaking `0.9.2 → 0.10.0` minor bump) triggers an archive, with no inference required. If the rule first applies at 1.0.0, it says so in those words.
- `docs/runbooks/release.md` carries the convention at the point in its step sequence where it applies, pointing to `RELEASING.md` for the policy rather than duplicating it. Existing step numbering is unchanged and the cross-references from step 3 and the `make release-check` section still resolve.
- `.orbit/auto_tasks/doc-duties.yaml` excludes `docs/changelogs/**` from its sweep — added to the never-modify list alongside `CHANGELOG.md` and `.orbit/adrs/**`, with the same provenance-not-staleness rationale. The execution summary quotes the scope line that would otherwise have captured it.
- The recorded mechanism includes its reasons, not just its steps: `CHANGELOG.md` keeps its exact name and root location (naming the coupling sites), relocation is byte-for-byte, and the live `## Unreleased` section does not move.
- ORB-10429 is cited as the worked example, noting it was rejected on timing rather than on method, so a future reader finds the verified diff shape instead of re-deriving it.
- `CHANGELOG.md` is byte-identical to the parent commit. No `docs/changelogs/` directory or file is created. No version numbers, code, workflows, or CI configuration change.
- The execution summary confirms each of the four coupling sites still exists at the path named, and quotes the `RELEASING.md` versioning-policy text that made the trigger ambiguous.
- `make ci-fast` passes; CI green on the PR.

## Execution Summary

<details>
<summary>Click to expand</summary>

Documented the CHANGELOG archive-on-major-release convention and closed the doc-duties sweep gap, doc/config only:

- RELEASING.md: added a new "### CHANGELOG archiving" subsection right after the versioning-policy section. States the rule (archive released history under docs/changelogs/ on a major release; CHANGELOG.md starts fresh; accumulates between majors) and resolves the ambiguity called out in the task: under the current pre-1.0 policy every release, including breaking ones, is a 0.<minor>.<patch> bump, so there is no major-release trigger yet — the convention first applies at 1.0.0. Cites ORB-10429 as the worked, validated diff shape, rejected on timing (no major-release trigger existed for 0.10.0), not on method. Records the mechanism with reasons: CHANGELOG.md keeps its exact name/repo-root location (names the four coupling sites — scripts/check-changelog-style.sh, crates/orbit-core/src/command/task/paths.rs, .orbit/auto_tasks/doc-duties.yaml, and the RELEASING.md/CONTRIBUTING.md/CLAUDE.md/ADR-0176/ADR-0210 references — all verified still present at the cited paths), relocation is byte-for-byte, and the live ## Unreleased section never moves.
- docs/runbooks/release.md: added a short pointer note inside existing step 1 (npm package version bump) directing to RELEASING.md#changelog-archiving before touching version fields on a major bump. No step renumbering; step 3 and the "What make release-check enforces" section cross-references still resolve unchanged.
- .orbit/auto_tasks/doc-duties.yaml: added docs/changelogs/** to the sweep's never-modify list alongside CHANGELOG.md and .orbit/adrs/**, same provenance-not-staleness rationale, and updated the matching acceptance-criteria line. Scope line that would otherwise have captured it: "In scope: docs/design/** (excluding docs/design/_archive/**), docs/runbooks/**, and the other prose under docs/" — docs/changelogs/ falls under "other prose under docs/" without the carve-out.

No archive performed: CHANGELOG.md is untouched (byte-identical — confirmed via git diff and scripts/check-changelog-style.sh passing), no docs/changelogs/ directory was created, no version numbers or CI config changed. Versioning policy (pre-1.0 semver, breaking → minor) unchanged; 1.0 criteria remain undefined and are not invented here.

Validation: make ci-fast passes (cargo fmt --check, generate-doc-indexes.sh --check, check-changelog-style.sh, and all other guardrail scripts all green) after adding ~/.cargo/bin to PATH, which was missing by default in this shell.

context_files unchanged — no unlisted files required modification.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10432-6a659f02`
- Behind base: 0
- Ahead of base: 1