### PR TITLE
Restore green CI on agent-main

### DIFF
--- a/crates/orbit-core/Cargo.toml
+++ b/crates/orbit-core/Cargo.toml
@@ -13,6 +13,11 @@ workspace = true
 
 [features]
 clap = ["orbit-common/clap"]
+# [ORB-10434] Opt-in scripted replay for orbit-core's own agent-loop tests.
+# Forwards to orbit-engine's default-off `replay` feature ([ORB-10414]);
+# without it `replay_active()` is compiled to `false` and the HTTP agent loop
+# demands a live provider credential.
+replay = ["orbit-engine/replay"]
 
 [dependencies]
 chrono.workspace = true

--- a/crates/orbit-core/src/runtime/v2_host/tests/mod.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/mod.rs
@@ -7,3 +7,6 @@ mod sandbox;
 mod task_context;
 mod triage;
 mod v2_host;
+// Replay-transport-backed cases; default-off per [ORB-10414]. [ORB-10434]
+#[cfg(feature = "replay")]
+mod v2_host_replay;

--- a/crates/orbit-core/src/runtime/v2_host/tests/v2_host.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/v2_host.rs
@@ -1,64 +1,11 @@
 //! Sibling tests for `mod.rs` (the v2_host module root; migrated per ORB-10387 /
 //! docs/design-patterns/test_layout.md).
 
-use std::sync::{Mutex, MutexGuard, OnceLock};
-
-use orbit_common::types::activity_job::{AgentLoopSpec, Backend, OnDenial, Provider};
-use orbit_common::types::{
-    InvocationTrace, JobRunState, TaskPriority, TaskStatus, TaskType, TokenUsage, ToolCallTrace,
-};
-use orbit_engine::{V2AuditWriter, drive_agent_loop, reset_replay_transport};
+use orbit_common::types::{InvocationTrace, JobRunState, TokenUsage, ToolCallTrace};
 use orbit_store::InvocationQuery;
-use tempfile::NamedTempFile;
 
-use super::super::test_support::{runtime_with_workspace_layout, seed_list_backlog_task};
+use super::super::test_support::runtime_with_workspace_layout;
 use super::super::*;
-
-fn replay_env_guard() -> MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-}
-
-struct ReplayFixtureGuard {
-    prior: Option<String>,
-}
-
-impl ReplayFixtureGuard {
-    fn set(path: &std::path::Path) -> Self {
-        let prior = std::env::var("ORBIT_V2_REPLAY_FIXTURE").ok();
-        // SAFETY: replay fixture env mutation is serialized by `replay_env_guard`.
-        unsafe {
-            std::env::set_var("ORBIT_V2_REPLAY_FIXTURE", path);
-        }
-        reset_replay_transport();
-        Self { prior }
-    }
-}
-
-impl Drop for ReplayFixtureGuard {
-    fn drop(&mut self) {
-        reset_replay_transport();
-        // SAFETY: replay fixture env mutation is serialized by `replay_env_guard`.
-        unsafe {
-            match &self.prior {
-                Some(value) => std::env::set_var("ORBIT_V2_REPLAY_FIXTURE", value),
-                None => std::env::remove_var("ORBIT_V2_REPLAY_FIXTURE"),
-            }
-        }
-    }
-}
-
-fn write_replay_fixture(value: Value) -> NamedTempFile {
-    let file = NamedTempFile::new().expect("fixture temp file");
-    std::fs::write(
-        file.path(),
-        serde_json::to_vec(&value).expect("serialize replay fixture"),
-    )
-    .expect("write replay fixture");
-    file
-}
 
 fn seed_running_job_run(runtime: &OrbitRuntime, job_id: &str) -> String {
     let run = runtime
@@ -210,81 +157,6 @@ fn persist_invocation_trace_records_fs_read_double_read_metrics() {
     assert_eq!(metrics.actual_fs_read_tokens_during_run, 30);
     assert_eq!(metrics.double_read_rate, Some(1.0));
     assert_eq!(metrics.total_llm_input_tokens, 50);
-}
-
-#[test]
-fn http_agent_loop_tool_update_persists_runtime_identity_family() {
-    let _lock = replay_env_guard();
-    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
-    let task = seed_list_backlog_task(
-        &runtime,
-        "runtime identity regression",
-        TaskStatus::InProgress,
-        TaskPriority::Medium,
-        TaskType::Chore,
-        None,
-        Vec::new(),
-    );
-    let fixture = write_replay_fixture(serde_json::json!({
-        "turns": [
-            {
-                "content": [{
-                    "kind": "tool_use",
-                    "id": "toolu_identity_update",
-                    "name": "orbit.task.update",
-                    "input": {
-                        "id": task.id.clone(),
-                        "status": "review",
-                        "execution_summary": "Identity regression covered.",
-                        "model": "grok-build"
-                    }
-                }],
-                "stop_reason": "tool_use"
-            },
-            {
-                "content": [{ "kind": "text", "text": "done" }],
-                "stop_reason": "end_turn"
-            }
-        ]
-    }));
-    let _guard = ReplayFixtureGuard::set(fixture.path());
-    let audit_dir = tempfile::tempdir().expect("audit tempdir");
-    let audit = V2AuditWriter::with_disk_sinks(
-        audit_dir.path(),
-        Store::open_in_memory().expect("audit store"),
-        "ws_test",
-        "http-identity-regression",
-        format!("claude:{}", orbit_common::test_fixtures::TEST_CLAUDE_MODEL),
-        None,
-    )
-    .expect("audit writer");
-    let spec = AgentLoopSpec {
-        instruction: "exercise tool identity".to_string(),
-        tools: vec!["orbit.task.update".to_string()],
-        on_denial: OnDenial::Terminate,
-        model: Some(orbit_common::test_fixtures::TEST_CLAUDE_MODEL.to_string()),
-        max_iterations: 2,
-        backend: Backend::Http,
-        provider: Provider::Claude,
-        wall_clock_timeout_seconds: 30,
-        require_response_envelope: false,
-        role: None,
-        proc_allowed_programs: None,
-    };
-
-    drive_agent_loop(
-        &spec,
-        None,
-        "http-identity-regression",
-        audit,
-        &serde_json::json!({ "prompt": "update the task" }),
-        &runtime,
-        None,
-    )
-    .expect("replay agent loop succeeds");
-
-    let updated = runtime.get_task(&task.id).expect("updated task");
-    assert_eq!(updated.implemented_by.as_deref(), Some("claude"));
 }
 
 #[test]

--- a/crates/orbit-core/src/runtime/v2_host/tests/v2_host_replay.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/v2_host_replay.rs
@@ -1,0 +1,141 @@
+//! Replay-backed sibling tests for `mod.rs`.
+//!
+//! These drive the HTTP agent loop through `orbit-engine`'s scripted replay
+//! transport, which [ORB-10414] made an explicit, default-off cargo feature:
+//! `replay_active()` returns `false` unless `orbit-engine/replay` is selected,
+//! so without the feature `drive_agent_loop` falls through to the live
+//! Anthropic transport and demands a real credential. They therefore live
+//! behind orbit-core's own `replay` feature (which forwards to
+//! `orbit-engine/replay`) and run in the dedicated opt-in guardrail pass, the
+//! same way orbit-engine's `tests/agent_loop_driver.rs` does. [ORB-10434]
+
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+use orbit_common::types::activity_job::{AgentLoopSpec, Backend, OnDenial, Provider};
+use orbit_common::types::{TaskPriority, TaskStatus, TaskType};
+use orbit_engine::{V2AuditWriter, drive_agent_loop, reset_replay_transport};
+use tempfile::NamedTempFile;
+
+use super::super::test_support::{runtime_with_workspace_layout, seed_list_backlog_task};
+use super::super::*;
+
+fn replay_env_guard() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+struct ReplayFixtureGuard {
+    prior: Option<String>,
+}
+
+impl ReplayFixtureGuard {
+    fn set(path: &std::path::Path) -> Self {
+        let prior = std::env::var("ORBIT_V2_REPLAY_FIXTURE").ok();
+        // SAFETY: replay fixture env mutation is serialized by `replay_env_guard`.
+        unsafe {
+            std::env::set_var("ORBIT_V2_REPLAY_FIXTURE", path);
+        }
+        reset_replay_transport();
+        Self { prior }
+    }
+}
+
+impl Drop for ReplayFixtureGuard {
+    fn drop(&mut self) {
+        reset_replay_transport();
+        // SAFETY: replay fixture env mutation is serialized by `replay_env_guard`.
+        unsafe {
+            match &self.prior {
+                Some(value) => std::env::set_var("ORBIT_V2_REPLAY_FIXTURE", value),
+                None => std::env::remove_var("ORBIT_V2_REPLAY_FIXTURE"),
+            }
+        }
+    }
+}
+
+fn write_replay_fixture(value: Value) -> NamedTempFile {
+    let file = NamedTempFile::new().expect("fixture temp file");
+    std::fs::write(
+        file.path(),
+        serde_json::to_vec(&value).expect("serialize replay fixture"),
+    )
+    .expect("write replay fixture");
+    file
+}
+
+#[test]
+fn http_agent_loop_tool_update_persists_runtime_identity_family() {
+    let _lock = replay_env_guard();
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let task = seed_list_backlog_task(
+        &runtime,
+        "runtime identity regression",
+        TaskStatus::InProgress,
+        TaskPriority::Medium,
+        TaskType::Chore,
+        None,
+        Vec::new(),
+    );
+    let fixture = write_replay_fixture(serde_json::json!({
+        "turns": [
+            {
+                "content": [{
+                    "kind": "tool_use",
+                    "id": "toolu_identity_update",
+                    "name": "orbit.task.update",
+                    "input": {
+                        "id": task.id.clone(),
+                        "status": "review",
+                        "execution_summary": "Identity regression covered.",
+                        "model": "grok-build"
+                    }
+                }],
+                "stop_reason": "tool_use"
+            },
+            {
+                "content": [{ "kind": "text", "text": "done" }],
+                "stop_reason": "end_turn"
+            }
+        ]
+    }));
+    let _guard = ReplayFixtureGuard::set(fixture.path());
+    let audit_dir = tempfile::tempdir().expect("audit tempdir");
+    let audit = V2AuditWriter::with_disk_sinks(
+        audit_dir.path(),
+        Store::open_in_memory().expect("audit store"),
+        "ws_test",
+        "http-identity-regression",
+        format!("claude:{}", orbit_common::test_fixtures::TEST_CLAUDE_MODEL),
+        None,
+    )
+    .expect("audit writer");
+    let spec = AgentLoopSpec {
+        instruction: "exercise tool identity".to_string(),
+        tools: vec!["orbit.task.update".to_string()],
+        on_denial: OnDenial::Terminate,
+        model: Some(orbit_common::test_fixtures::TEST_CLAUDE_MODEL.to_string()),
+        max_iterations: 2,
+        backend: Backend::Http,
+        provider: Provider::Claude,
+        wall_clock_timeout_seconds: 30,
+        require_response_envelope: false,
+        role: None,
+        proc_allowed_programs: None,
+    };
+
+    drive_agent_loop(
+        &spec,
+        None,
+        "http-identity-regression",
+        audit,
+        &serde_json::json!({ "prompt": "update the task" }),
+        &runtime,
+        None,
+    )
+    .expect("replay agent loop succeeds");
+
+    let updated = runtime.get_task(&task.id).expect("updated task");
+    assert_eq!(updated.implemented_by.as_deref(), Some("claude"));
+}

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -222,6 +222,8 @@ The HTTP path is driven by `agent_loop_driver.rs`. It:
 
 This path is narrower than the schema: `Provider::has_http_transport()` currently returns true only for `claude`, so non-replay uses `AnthropicMessagesTransport`. Default builds ignore `ORBIT_V2_REPLAY` and `ORBIT_V2_REPLAY_FIXTURE`; scripted replay is enabled for explicit smoke and fixture use only when orbit-engine's `replay` cargo feature is selected ([ORB-10414]).
 
+Because the feature is default-off, **any crate with a replay-fixture-backed test must opt in itself** — a test that merely sets `ORBIT_V2_REPLAY_FIXTURE` silently falls through to the live Anthropic transport and fails on a credential-free runner. orbit-core does this via its own `replay` feature, which forwards to `orbit-engine/replay` and gates `runtime/v2_host/tests/v2_host_replay.rs`. `scripts/ci-guardrails.sh` lints and runs the opt-in configuration for orbit-engine and orbit-core in one extra pass (`--features orbit-core/replay`), so both the default and replay configurations stay covered ([ORB-10434]).
+
 The allowlist is enforced in the loop engine on this path. A denied tool becomes a structural `DispatchError::ToolDenied` so the job retry wrapper can classify it as non-retryable.
 
 After [T20260426-0526], completed HTTP loop outcomes become `InvocationTrace` records under the job run ID and step ID, including loop-body `session:` steps.
@@ -575,5 +577,6 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[ORB-10232]** — Model recoverable PR handoff as checkpointed job activities with exact-SHA force-push provenance.
 - **[ORB-10332]** — Remove the unused Groundhog activity kind and the epic/parallel pipeline layer (`task_epic_pipeline`, `epic_orchestrator`, `pipeline_wait`, legacy parallel-batch executor).
 - **[ORB-10414]** — Make HTTP replay an explicit default-off cargo feature and keep replay environment variables inert in default builds.
+- **[ORB-10434]** — Extend the replay opt-in to orbit-core (`orbit-core/replay`) so its fixture-backed v2_host test keeps running hermetically instead of demanding a live credential.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -16,16 +16,19 @@ cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
 # The replay smokes require an explicit feature, so the default workspace
 # clippy pass skips them. Keep that opt-in path compiled and linted too.
-cargo clippy -p orbit-engine --all-targets --features replay -- -D warnings
+# orbit-core rides along: its replay-backed v2_host test needs the same
+# transport, and `orbit-core/replay` forwards to `orbit-engine/replay`, so one
+# pass covers both crates' opt-in configuration. [ORB-10414] [ORB-10434]
+cargo clippy -p orbit-engine -p orbit-core --all-targets --features orbit-core/replay -- -D warnings
 # The converted v2 integration tests are included in the default test surface;
 # exercise the replay-gated cases separately so both configurations run.
 if cargo nextest --version >/dev/null 2>&1; then
   cargo nextest run --workspace --lib --bins --tests
-  cargo nextest run -p orbit-engine --features replay --lib --bins --tests
+  cargo nextest run -p orbit-engine -p orbit-core --features orbit-core/replay --lib --bins --tests
 else
   echo "cargo-nextest not found; falling back to cargo test" >&2
   cargo test --workspace --lib --bins --tests
-  cargo test -p orbit-engine --features replay --lib --bins --tests
+  cargo test -p orbit-engine -p orbit-core --features orbit-core/replay --lib --bins --tests
 fi
 cargo test --workspace --doc
 RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace


### PR DESCRIPTION
## Task

[ORB-10434](https://orbit-cli.com/tasks/ORB-10434) — Restore green CI on agent-main

### Description

## Problem

The `CI` workflow is red on every recent push to `agent-main` (observed 2026-07-26: four
consecutive completed runs failed, plus an in-progress run whose Coverage job had already
failed). `MSRV`, `Linux Sandbox & Policy Enforcement`, `macOS Sandbox`, and `CodeQL` are green.

The failing jobs are `Check / Clippy / Test` and its sibling `Coverage (informational)`. The
observed signature, identical across every failure:

```
test runtime::v2_host::tests::v2_host::http_agent_loop_tool_update_persists_runtime_identity_family ... FAILED
panicked at crates/orbit-core/src/runtime/v2_host/tests/v2_host.rs:284:6:
replay agent loop succeeds: AgentLoopFailed("no provider credential available — host.api_key_for returned an error")
```

Summary line: 2679 passed, 1 failed, 5 skipped. It is not clippy, fmt, or build.

**That signature is the entry point, not the scope.** The mandate is the branch being green,
not this one test. Fix the root cause, re-run the full workflow set, and keep going until the
required checks pass end to end — a second failure surfacing behind this one is in scope.

Do not treat the reported symptom as a diagnosis. A test that depends on a provider credential
being present in the runner environment may be wrong in the test, wrong in the host's
credential-resolution path, or wrong in the workflow — establish which before changing
anything, and say so in the commit description.

## Constraints

- Scope is `agent-main` CI. Open PRs are out of scope; the one red open PR (#679, astro
  dependency bump) fails for an unrelated reason predating this and is not part of this task.
- **Do not weaken a check to make it pass.** Deleting the test, `#[ignore]`-ing it, marking it
  `allow_fail`, loosening an assertion, or dropping the job from the workflow are all
  non-answers. If the check itself turns out to be wrong or obsolete, stop and report that
  conclusion with evidence in the task rather than acting on it — a check-semantics change is
  a separate, human-approved decision.
- **No real provider credentials in CI.** Do not add API-key secrets to a workflow, and do not
  make green CI contingent on a credential being configured. A unit/integration test in this
  suite must pass hermetically on a runner with no provider access.
- Tests, source, and workflow files may all be read; prefer the smallest change that removes
  the real defect. Do not opportunistically refactor unrelated code.
- Follow the repo's existing test-harness conventions for stubbing/faking the agent-loop host
  rather than inventing a new mechanism, if such a convention already exists.

## Acceptance criteria

1. Root cause is identified and stated explicitly: which layer is wrong (test setup, host
   credential resolution, or workflow config) and what evidence establishes it.
2. The `CI` workflow passes on the candidate branch — `Check / Clippy / Test`, `MSRV`, and
   `Linux Sandbox & Policy Enforcement` all green. `Coverage (informational)` must also run
   without the panic above.
3. `cargo fmt --check` and clippy remain clean; no new warnings.
4. The previously-failing test still exercises the behaviour it was written to cover
   (runtime-identity-family persistence through a tool update on the agent loop). Demonstrate
   this — e.g. show the test fails if the behaviour under test is reverted.
5. No provider credential, API key, or secret is required for the suite to pass, and none is
   added to any workflow file.
6. Full test suite passes locally with no provider credentials in the environment.
7. If any additional failure signature appears once this one is cleared, it is either fixed
   under this task or filed with a clear account of why it is separate.

### Acceptance Criteria

- Root cause identified and stated explicitly, with evidence for which layer is at fault (test setup vs host credential resolution vs workflow config)
- CI workflow green on the candidate branch: Check / Clippy / Test, MSRV, and Linux Sandbox & Policy Enforcement all pass; Coverage runs without the panic
- cargo fmt --check clean and clippy clean with no new warnings
- The previously-failing test still covers runtime-identity-family persistence through an agent-loop tool update, demonstrated by showing it fails when the behaviour is reverted
- No provider credential, API key, or secret is required for the suite to pass, and none is added to any workflow file
- Full test suite passes locally in an environment with no provider credentials
- No check weakened: no test deleted, ignored, or assertion loosened, and no job removed from the workflow

## Execution Summary

<details>
<summary>Click to expand</summary>

## Root cause: build configuration, not the test's logic and not host credential resolution

[ORB-10414] (commit 6a569b6a, 2026-07-26 01:37) turned scripted HTTP replay into a default-off cargo feature. `replay_active()` in `crates/orbit-engine/src/activity_job/agent_loop_driver.rs:242` now short-circuits on `if !cfg!(feature = "replay") { return false }` *before* reading `ORBIT_V2_REPLAY_FIXTURE`.

That commit correctly gated orbit-engine's own replay tests (`#![cfg(feature = "replay")]`, `#[cfg(feature = "replay")] mod agent_loop_driver;`) and added a dedicated `-p orbit-engine --features replay` pass to `scripts/ci-guardrails.sh`. It missed that **orbit-core also has a replay-fixture-backed test** — `http_agent_loop_tool_update_persists_runtime_identity_family`. orbit-core depends on orbit-engine without the feature, so in that crate `replay_active()` compiles to `false`, `drive_inner` falls through to the live `AnthropicMessagesTransport` branch, and `api_key` is `None` on a credential-free runner:

```
AgentLoopFailed("no provider credential available — host.api_key_for returned an error")
```

Evidence for the layer at fault:
- Setting a feature, not a credential, makes it pass: `cargo test -p orbit-core --features replay` is green with `ANTHROPIC_API_KEY` unset.
- `api_key_for` (`v2_host/mod.rs:326`) is correct as written — no key present must be an error; it is the innocent messenger named in the panic.
- The workflow is correct — the fix must not require a secret, and none was added.
- Timeline corroborates: the test was introduced in 1e919b1b and moved unchanged by [ORB-10387] (6775d240); it only went red once 6a569b6a landed the feature gate. Nothing in the test or the workflow changed.

The failure mode is silent by construction: gating a crate's behaviour behind a default-off feature produces no compile error in *dependent* crates whose tests rely on that behaviour — they just take the other branch at runtime.

## Fix — mirror the convention [ORB-10414] already established

1. `crates/orbit-core/Cargo.toml` — add `replay = ["orbit-engine/replay"]`.
2. Move the replay test to a new sibling `crates/orbit-core/src/runtime/v2_host/tests/v2_host_replay.rs` (with its `replay_env_guard` / `ReplayFixtureGuard` / `write_replay_fixture` helpers, which are used by nothing else), declared `#[cfg(feature = "replay")]` in `tests/mod.rs` — exactly how orbit-engine gates `tests/agent_loop_driver.rs`. Extracting to its own file avoids per-item cfg noise and dead-code warnings in the default configuration.
3. `scripts/ci-guardrails.sh` — fold orbit-core into the existing opt-in pass rather than adding a third compile: `-p orbit-engine -p orbit-core --features orbit-core/replay` for both the clippy and the test invocation.

Rejected: adding `features = ["replay"]` to a dev-dependency on orbit-engine. It is a one-line change, but dev-dep features unify workspace-wide during a test build, so orbit-engine would be built with `replay` on in the *default* pass. That would silently compile out `tests/agent_loop_driver_default.rs::replay_environment_is_inert_without_feature` (it is `#[cfg(not(feature = "replay"))]`) and it is not run in the feature-on pass either — the [ORB-10414] inertness guard would then run nowhere. Rejected as weakening a check.

No test deleted, ignored, or loosened; no job removed; no secret added.

## Validation (local, no provider credentials — ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN/OPENAI_API_KEY unset)

- `cargo nextest run --workspace --lib --bins --tests` (the CI command, pinned nextest 0.9.136): **2689 passed, 0 failed, 5 skipped**.
- `cargo nextest run -p orbit-engine -p orbit-core --features orbit-core/replay --lib --bins --tests`: **937 passed, 0 failed**, including the relocated test.
- `cargo fmt --all --check`: clean. `cargo clippy --workspace --all-targets -- -D warnings` and the replay-feature clippy pass: clean, no new warnings.
- `cargo test --workspace --doc`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`: clean.
- `cargo check --workspace --locked` (MSRV job's command): clean; `Cargo.lock` unchanged (a feature addition does not touch it).
- All ten guardrail shell scripts: exit 0.
- Coverage job (`cargo llvm-cov --workspace`) uses default features, so the replay test is not compiled there and the panic cannot recur.

**Test still has teeth (criterion 4).** Reverting the behaviour under test — making input-supplied identity win over runtime identity in `resolve_identity` (`crates/orbit-tools/src/builtin/orbit/mod.rs:186`) — makes it fail on the right assertion, then I restored the source:

```
assertion `left == right` failed
  left: Some("grok-build")
 right: Some("claude")
```

## Additional failures found and filed separately (criterion 7)

Both are pre-existing, unrelated to this root cause, and invisible on GitHub runners:

- **ORB-10436** — ambient managed-run env leaks break three tests when the suite is run by an Orbit executor: `orbit-core` `direct_update_task_keeps_default_human_attribution` (reads `ORBIT_AGENT_MODEL`, got `claude-opus-5` where `human` was expected) and two `orbit-remote` `persistence::tests::knowledge` cases (validate a fixture run id against ambient `ORBIT_RUN_ID`). Same family as [ORB-10350]; `orbit-common/src/test_env.rs` exists for exactly this but adoption is partial. Note the runner shape matters: `cargo test` shares one process and can mask the leak, `nextest` forks per test and exposes it. Also filed as friction.
- **ORB-10437** — `orbit-engine` `worktree::tests::gc::dry_run_and_yes_share_eligibility_but_only_yes_removes` failed once under parallel load, then passed in isolation and on an identical repeat of the same invocation. Intermittent; the test shells out to real `git` while the rest of the suite does the same.

## Scope note

Appended to `context_files`: the new `tests/v2_host_replay.rs`, its `tests/mod.rs` declaration, and `docs/design/activity-job/2_design.md` (the repo requires design-doc updates in the same PR — I extended the [ORB-10414] replay paragraph to state that any crate with replay-backed tests must opt in itself, and added an ORB-10434 entry to the task list). `api_key_for` was listed in the original context but is *not* modified: it was the suspected culprit and turned out to be correct.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10434-6a65a6d8`
- Behind base: 0
- Ahead of base: 1