### PR TITLE
Flaky test: worktree gc dry_run_and_yes_share_eligibility_but_only_yes_removes fails under parallel load

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/gc.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/gc.rs
@@ -4,7 +4,6 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::Mutex;
 
 use chrono::{Duration, Utc};
 use orbit_common::types::{
@@ -22,7 +21,11 @@ use super::super::{
     WorktreeIdentity, resolve_shared_worktree_path, resolve_worktree_path_from_prefix,
 };
 
-static WORKTREE_ROOT_ENV_LOCK: Mutex<()> = Mutex::new(());
+// Environment variables are process-global: mutating ORBIT_WORKTREE_ROOT in
+// this parallel test binary races every test that resolves a worktree path.
+// Run the two environment-specific cases in isolated copies of the test
+// process so the rest of the module stays parallel without observing them.
+const RESOLVER_ENV_CHILD: &str = "ORBIT_GC_RESOLVER_ENV_CHILD";
 
 struct FakeTaskHost {
     tasks: BTreeMap<String, Task>,
@@ -307,31 +310,39 @@ fn unattributed_run_is_retained_and_reported() {
 
 #[test]
 fn resolver_uses_workspace_local_root_without_override() {
-    let _lock = WORKTREE_ROOT_ENV_LOCK.lock().unwrap();
-    let old = std::env::var_os("ORBIT_WORKTREE_ROOT");
-    // SAFETY: this module serializes mutations of this test-only variable and
-    // restores its prior value before releasing the lock.
-    unsafe { std::env::remove_var("ORBIT_WORKTREE_ROOT") };
+    if !is_resolver_env_child("workspace-local") {
+        run_resolver_test_in_child(
+            "resolver_uses_workspace_local_root_without_override",
+            "workspace-local",
+            None,
+        );
+        return;
+    }
+
     let temp = tempdir().unwrap();
     let repo = temp.path().join("repo");
     let path = resolve_worktree_path_from_prefix(&repo, "orbit", "jrun-local").unwrap();
     assert_eq!(path, repo.join(".orbit/state/worktrees/orbit-jrun-local"));
-    restore_worktree_root(old);
 }
 
 #[test]
 fn resolver_uses_external_root_and_repository_name_when_configured() {
-    let _lock = WORKTREE_ROOT_ENV_LOCK.lock().unwrap();
-    let old = std::env::var_os("ORBIT_WORKTREE_ROOT");
+    if !is_resolver_env_child("external-root") {
+        let temp = tempdir().unwrap();
+        let root = temp.path().join("worktrees");
+        run_resolver_test_in_child(
+            "resolver_uses_external_root_and_repository_name_when_configured",
+            "external-root",
+            Some(&root),
+        );
+        return;
+    }
+
     let temp = tempdir().unwrap();
     let repo = temp.path().join("my-repo");
-    let root = temp.path().join("worktrees");
-    // SAFETY: this module serializes mutations of this test-only variable and
-    // restores its prior value before releasing the lock.
-    unsafe { std::env::set_var("ORBIT_WORKTREE_ROOT", &root) };
+    let root = PathBuf::from(std::env::var_os("ORBIT_WORKTREE_ROOT").unwrap());
     let path = resolve_worktree_path_from_prefix(&repo, "orbit", "jrun-external").unwrap();
     assert_eq!(path, root.join("my-repo/orbit-jrun-external"));
-    restore_worktree_root(old);
 }
 
 /// ORB-10427: the collector reclaimed nothing in production because it probed
@@ -829,12 +840,32 @@ fn git(current_dir: &Path, args: &[&str]) -> String {
     String::from_utf8_lossy(&output.stdout).trim().to_string()
 }
 
-fn restore_worktree_root(value: Option<std::ffi::OsString>) {
-    // SAFETY: callers hold WORKTREE_ROOT_ENV_LOCK.
-    unsafe {
-        match value {
-            Some(value) => std::env::set_var("ORBIT_WORKTREE_ROOT", value),
-            None => std::env::remove_var("ORBIT_WORKTREE_ROOT"),
+fn is_resolver_env_child(case: &str) -> bool {
+    std::env::var_os(RESOLVER_ENV_CHILD).is_some_and(|value| value == case)
+}
+
+fn run_resolver_test_in_child(test_name: &str, case: &str, root: Option<&Path>) {
+    let module = module_path!()
+        .strip_prefix(concat!(env!("CARGO_CRATE_NAME"), "::"))
+        .unwrap_or(module_path!());
+    let exact_test_name = format!("{module}::{test_name}");
+    let mut command = Command::new(std::env::current_exe().unwrap());
+    command
+        .args(["--exact", &exact_test_name, "--nocapture"])
+        .env(RESOLVER_ENV_CHILD, case);
+    match root {
+        Some(root) => {
+            command.env("ORBIT_WORKTREE_ROOT", root);
+        }
+        None => {
+            command.env_remove("ORBIT_WORKTREE_ROOT");
         }
     }
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "isolated resolver test {exact_test_name} failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }


### PR DESCRIPTION
## Task

[ORB-10437](https://orbit-cli.com/tasks/ORB-10437) — Flaky test: worktree gc dry_run_and_yes_share_eligibility_but_only_yes_removes fails under parallel load

### Description

## Problem

`orbit-engine`'s `executor::automation::vcs::worktree::tests::gc::dry_run_and_yes_share_eligibility_but_only_yes_removes` failed once during a full-suite run and then passed on both an isolated re-run and an identical repeat of the same full-suite invocation:

```
panicked at crates/orbit-engine/src/executor/automation/vcs/worktree/tests/gc.rs:177:27
```

Observed 2026-07-26 while validating [ORB-10434]. Reproduction rate in that session was 1 in 2 full-suite runs, 0 in 1 isolated run.

## Why it is likely a flake, not a regression

The test builds a real git repo in a tempdir, adds a real worktree, commits, and then exercises `collect_worktrees` in dry-run and delete modes. It shells out to `git` repeatedly while the rest of the suite runs concurrently and does the same, so it is exposed to git index/config lock contention and to filesystem timing under load. Nothing in the ORB-10434 change set touches worktree GC, and the failure did not correlate with the `replay` feature (it appeared in the `--features orbit-core/replay` pass and vanished on repeat of that same pass).

## Scope

Diagnose the actual nondeterminism at `gc.rs:177` before changing anything — it may be lock contention on the shared git process, an `mtime`/age-eligibility boundary, or byte-accounting that depends on filesystem block size. Then make the test deterministic. Do not paper over it with a retry loop, a sleep, `#[ignore]`, or serialization of the whole module if the underlying assertion is genuinely order-dependent.

Capture the failing assertion text first: the run that failed did not surface the left/right values, so an early step is reproducing with output captured (e.g. a repeated `--test-threads` stress loop).

## Provenance

Surfaced while validating [ORB-10434] (restore green CI on agent-main) and filed separately per that task's acceptance criterion 7: it is pre-existing, intermittent, and unrelated to the default-off `replay` feature that caused the ORB-10434 CI failure.

### Acceptance Criteria

- The nondeterminism at gc.rs:177 is root-caused and stated explicitly, with the captured failing assertion values as evidence
- The test passes deterministically across a repeated stress run of the full orbit-engine suite (e.g. 20 consecutive runs, no failures)
- No check weakened: the test is not ignored, retried, sleep-padded, or its assertions loosened
- cargo fmt --check and clippy remain clean

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Root-caused the flake to the two resolver tests mutating process-global ORBIT_WORKTREE_ROOT while the rest of the gc tests read that variable without their mutex. The lock serialized only the writers; it could not stop a fixture path and collect_worktrees from observing different roots under parallel execution.
- Captured the requested failing assertion at gc.rs:177 under a widened diagnostic race window: left was "skipped:unrecognized" and right was "would_remove". A separate unmodified stress run also caught setup_and_gc_derive_the_same_worktree_path comparing an external path under /tmp/.tmpCQRBX3/worktrees/repo with its workspace-local path under /tmp/.tmpj51WMp/repo, directly proving that one test observed another test tempdir through the shared environment.
- Replaced in-process set_var/remove_var and the writer-only mutex with isolated child-test processes for the workspace-local and external-root resolver cases. Command::env/env_remove changes only each child environment; the parent test process no longer mutates ORBIT_WORKTREE_ROOT, while all ordinary gc tests continue running in parallel.
- Kept every assertion unchanged. No retry, sleep, ignore, loosened assertion, or whole-module serialization was added.
Assessment: The nondeterminism is removed at its source with a test-only, one-file change. Production worktree behavior is untouched.
Validation:
- Reproduction before fix: natural gc stress failed on run 6 with cross-test external/local root values; diagnostic stress captured gc.rs:177 as left=skipped:unrecognized, right=would_remove.
- Targeted 22-test gc module under --test-threads=64: 22 passed.
- 20 consecutive full cargo test -p orbit-engine runs under --test-threads=64: all passed; each run completed 305 unit tests plus the orbit-engine integration targets with zero failures.
- cargo fmt --check: passed.
- make ci-fast: passed.
- cargo clippy -p orbit-engine --all-targets -- -D warnings: passed.
- git diff --check: passed.
Friction checkpoint:
- Filed F2026-07-148 documenting the writer-only environment lock gotcha and the captured evidence.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10437-6a664564`
- Behind base: 0
- Ahead of base: 1