### PR TITLE
Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,6 +1,7 @@
 ---
 type: context
 summary: Entry point for Orbit feature designs and operational runbooks.
+last_validated: 2026-07-26
 tags: [docs, index, design, operations, runbooks]
 related_features: [orbit-docs, activity-job, auditability, routines]
 related_artifacts: [ORB-10014]

--- a/docs/design/CONVENTIONS.md
+++ b/docs/design/CONVENTIONS.md
@@ -2,6 +2,7 @@
 title: Design Doc Conventions
 owner: daniel
 last_updated: 2026-07-20
+last_validated: 2026-07-26
 status: Accepted
 ---
 

--- a/docs/design/activity-job/1_overview.md
+++ b/docs/design/activity-job/1_overview.md
@@ -4,6 +4,7 @@ type: design
 title: "Activity / Job — Overview"
 owner: codex
 last_updated: 2026-07-20
+last_validated: 2026-07-26
 status: Draft
 feature: activity-job
 doc_role: overview

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -4,6 +4,7 @@ type: design
 title: "Activity / Job — Design"
 owner: codex
 last_updated: 2026-07-26
+last_validated: 2026-07-26
 status: Draft
 feature: activity-job
 doc_role: design
@@ -393,36 +394,37 @@ After [ORB-10313], the VCS handoff seam uses one shared durable predicate (`reje
 
 Risk-weighted regression tests live next to the executor modules they guard
 under `crates/orbit-engine/src/activity_job/job_executor/tests/`
-([T20260509-7]). Each executor-block module has a sibling `*_tests.rs` and
-each test names the specific invariant it guards in the function name. The
+([T20260509-7]). Each executor-block module has a matching test module under
+`tests/`, and each test names the specific invariant it guards in the function
+name. The
 current surface:
 
-- `step_tests.rs` (`step.rs`) — linear step success and pipeline propagation,
+- `step.rs` (`step.rs`) — linear step success and pipeline propagation,
   failure short-circuit (mod.rs:131-148), retry `max_attempts` exhaustion,
   non-retryable bypass, success on intermediate attempt, and
   `compute_backoff_ms` linear/exponential monotonicity and cap behavior.
-- `parallel_tests.rs` (`parallel.rs`) — `JoinMode::All`, `JoinMode::Any`,
+- `parallel.rs` (`parallel.rs`) — `JoinMode::All`, `JoinMode::Any`,
   `JoinMode::Quorum`, `StepJoin` audit event ordering, and audit
   parent-stack inheritance into branch threads.
-- `fanout_tests.rs` (`fan_out.rs`) — empty items emit `FanoutDispatched{0}`
+- `fanout.rs` (`fan_out.rs`) — empty items emit `FanoutDispatched{0}`
   and `FaninJoined{0,0}`, collected outputs are spawn-index ordered even
   when workers complete out of order, `max_workers` semaphore caps
   in-flight workers, structural error surfaces under unsatisfied join,
   `fan_in.collect` writes the collected value under the alias key, and
   per-worker `WorkerState` events appear in `dispatched`→`finished` order.
-- `loop_tests.rs` (`loop_block.rs`) — `items` length over `max_iterations`
+- `loop.rs` (`loop_block.rs`) — `items` length over `max_iterations`
   errors, `break_when` exits with `LoopIterationEnd{broke=true}`,
   exhausting iterations emits `LoopDidNotConverge`, and the loop exits on
   first body failure.
-- `pipeline_durability_tests.rs` (`exec_ctx.rs`, `fan_out.rs:53-56`) —
+- `pipeline_durability.rs` (`exec_ctx.rs`, `fan_out.rs:53-56`) —
   a step's output remains visible to later steps via
   `{{ steps.<id>.output.* }}`, and the pipeline snapshot taken into
   fan-out workers preserves upstream values past the fan-out boundary.
 
 Shared host scaffolding (`ScriptedHost`, `Action`, job/step builders) lives
 in `tests/mod.rs` so each block module stays focused on its own invariants.
-New executor blocks must land with a sibling `*_tests.rs` covering the
-analogous invariants — see [ADR-0011].
+New executor blocks must land with a matching test module under `tests/`
+covering the analogous invariants — see [ADR-047](./4_decisions.md#adr-047--each-new-executor-block-ships-with-a-sibling-test-module).
 
 ---
 

--- a/docs/design/activity-job/3_vision.md
+++ b/docs/design/activity-job/3_vision.md
@@ -4,6 +4,7 @@ type: design
 title: "Activity / Job — Vision"
 owner: codex
 last_updated: 2026-07-20
+last_validated: 2026-07-26
 status: Draft
 feature: activity-job
 doc_role: vision

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -4,6 +4,7 @@ type: design
 title: "Activity / Job — Decisions"
 owner: codex
 last_updated: 2026-07-26
+last_validated: 2026-07-26
 status: Draft
 feature: activity-job
 doc_role: decisions
@@ -475,6 +476,19 @@ Folded into ADR-002's rollup for explicit agent dispatch boundaries.
 - The split preserves the existing engine/core and CLI-runner boundaries; no new crate edge or provider type crosses the activity/job layer.
 - Cost: private helper movement now requires maintaining intra-module visibility and imports across several files instead of one lexical scope.
 
+## ADR-047 — Each new executor block ships with a sibling test module
+
+**Status:** Accepted · 2026-05 · [T20260509-7]
+
+**Context.** The v2 job executor sub-modules (`step.rs`, `parallel.rs`, `fan_out.rs`, `loop_block.rs`, `target.rs`, `recovery.rs`) own non-trivial concurrency, ordering, and audit invariants. Without test coverage co-located with each block, regressions to those invariants surface only as production failures or as audit-trace anomalies that are hard to reproduce.
+
+**Decision.** Every executor-block module under `crates/orbit-engine/src/activity_job/job_executor/` gets a matching test module under `tests/` whose test function names name the specific invariant or failure mode each test guards. The block-specific layout includes `step.rs`, `parallel.rs`, `fanout.rs`, `loop.rs`, and `pipeline_durability.rs`, alongside focused modules for `audit.rs`, `recovery.rs`, `resume.rs`, `target.rs`, `templating.rs`, and `validate.rs`. Shared scaffolding (`ScriptedHost`, `Action`, job/step builders) lives in `tests/mod.rs` so block modules stay focused on their own invariants and don't fork the host shape. Sandbox and policy boundary coverage lives next to the implementations they guard: `crates/orbit-exec/src/macos_sandbox/` (read-deny enforcement and a realistic agent_loop profile boundary) and `crates/orbit-policy/src/engine.rs#tests` (global denyRead/denyModify last-match-wins, unknown-profile error, matched_rule observability).
+
+**Consequences.**
+- Future refactors of an executor block must keep the matching invariant test alive in its corresponding test module or update it to reflect the new contract.
+- New blocks (e.g. a future `dag` or `gate` construct) must land with a matching test module covering at least the invariants enumerated in the seed surface.
+- Shared scaffolding in `tests/mod.rs` is the consolidation seam — broaden it (agent_loop or shell hosts, additional builders) there rather than re-deriving in each block module.
+
 ## ADR-048 — Auto-populate `task.context_files` from the winning duel plan
 
 **Status:** Accepted · 2026-05 · [T20260509-9]
@@ -497,19 +511,6 @@ The plumbing adds a single optional field to `TaskAutomationUpdate` (`context_fi
 - Section-recognition heuristics drift between writers is bounded by the strict rule above; future planner agents that emit non-conforming shapes simply fall back to the preserve-existing branch instead of triggering best-effort guesses.
 - A new `TaskAutomationUpdate.context_files` field touches every existing automation call site, but the `..Default::default()` pattern keeps each site at the "leave untouched" default. A regression test in `task_host` guards that contract.
 - Operators get a `PlanningDuelContextFileSkipped` event channel for debugging stale or malformed plan markdown, instead of silently-dropped entries.
-
-## ADR-047 — Each new executor block ships with a sibling test module
-
-**Status:** Accepted · 2026-05 · [T20260509-7]
-
-**Context.** The v2 job executor sub-modules (`step.rs`, `parallel.rs`, `fan_out.rs`, `loop_block.rs`, `target.rs`, `recovery.rs`) own non-trivial concurrency, ordering, and audit invariants. Without test coverage co-located with each block, regressions to those invariants surface only as production failures or as audit-trace anomalies that are hard to reproduce.
-
-**Decision.** Every executor-block module under `crates/orbit-engine/src/activity_job/job_executor/` gets a sibling `*_tests.rs` in `tests/` whose test function names name the specific invariant or failure mode each test guards. The current layout is `step_tests.rs`, `parallel_tests.rs`, `fanout_tests.rs`, `loop_tests.rs`, and `pipeline_durability_tests.rs`, alongside the pre-existing `audit_tests.rs`, `recovery_tests.rs`, and `target_tests.rs`. Shared scaffolding (`ScriptedHost`, `Action`, job/step builders) lives in `tests/mod.rs` so block modules stay focused on their own invariants and don't fork the host shape. Sandbox and policy boundary coverage lives next to the implementations they guard: `crates/orbit-exec/src/macos_sandbox/` (read-deny enforcement and a realistic agent_loop profile boundary) and `crates/orbit-policy/src/engine.rs#tests` (global denyRead/denyModify last-match-wins, unknown-profile error, matched_rule observability).
-
-**Consequences.**
-- Future refactors of an executor block must keep the matching invariant test alive in the same-named test file or update it to reflect the new contract.
-- New blocks (e.g. a future `dag` or `gate` construct) must land with a sibling test module covering at least the invariants enumerated in the seed surface.
-- Shared scaffolding in `tests/mod.rs` is the consolidation seam — broaden it (agent_loop or shell hosts, additional builders) there rather than re-deriving in each block module.
 
 ## ADR-049 — Condition guards stay equality-only
 
@@ -665,11 +666,11 @@ Rejected alternatives: reconciling by parent linkage (no parent run id is persis
 
 **Context.** During ORB-10262, `task_pr_pipeline` advanced a task to review and published a PR even though the durable execution summary began `Outcome: failed`. `commit_batch_changes` mutated Git without checking the durable outcome, and `load_handoff_context` treated every nonempty, non-placeholder summary as promotable, so a nonempty summary reporting failure still delivered (friction F2026-07-091). The alternatives were to make the advisory agent response envelope authoritative or to teach `pipeline_success_guard` to parse task prose; both move the source of truth away from the durable task record.
 
-**Decision.** Add one shared durable predicate (`require_delivery_success`) in the VCS handoff seam that reads the persisted task execution summary and requires its first nonblank line to be exactly `Outcome: success`. A `failed`, missing, malformed, or unknown outcome fails closed with a typed error naming the task and rejected value; empty and placeholder summaries keep their existing rejection. Enforce it in `commit_batch_changes` before the checkout is resolved, files staged, the index changed, or a commit created, and again in `load_handoff_context` so every fresh or resumed `pr_prepare`, rebase, push, `pr_open`, `pr_promote`, and no-diff promotion revalidates durable state. The durable task record stays the delivery authority; the response envelope is not made authoritative and `pipeline_success_guard` is unchanged.
+**Decision.** Keep one shared durable predicate (`reject_failed_delivery`) in the VCS handoff seam that reads the persisted task execution summary and blocks delivery when its first nonblank line is exactly `Outcome: failed`. Empty and placeholder summaries remain rejected by the existing meaningful-summary guard; other meaningful summary shapes remain deliverable. Enforce the predicate in `commit_batch_changes` before the checkout is resolved, files staged, the index changed, or a commit created, and again in `load_handoff_context` so every fresh or resumed `pr_prepare`, rebase, push, `pr_open`, `pr_promote`, and no-diff promotion revalidates durable state. The durable task record stays the delivery authority; the response envelope is not made authoritative and `pipeline_success_guard` is unchanged.
 
 **Consequences.**
-- Delivery fails closed against the durable record: a failed, unchecked, or malformed outcome cannot commit, push, open a PR, or promote a task, on both fresh and replayed pipelines.
-- Agents must write `Outcome: success` as the first nonblank execution-summary line for delivery to proceed; nonempty prose alone is no longer sufficient.
+- Delivery fails closed against the durable record: an empty or placeholder summary, or an explicit `Outcome: failed` line, cannot commit, push, open a PR, or promote a task, on both fresh and replayed pipelines.
+- Agents should write `Outcome: success` as the first nonblank execution-summary line to make the durable outcome explicit; other meaningful non-empty prose remains deliverable.
 - Cost: the delivery contract now depends on a summary-line convention; a genuinely successful task whose summary omits or misformats the outcome line is blocked until the durable summary is corrected.
 
 ---

--- a/scripts/generate-doc-indexes.sh
+++ b/scripts/generate-doc-indexes.sh
@@ -226,11 +226,17 @@ render_design_rows() {
 
 render_index() {
   local output="$1"
+  local last_validated
+
+  last_validated="$(frontmatter_value "$docs_dir/INDEX.md" last_validated)"
 
   {
     printf '%s\n' '---'
     printf '%s\n' 'type: context'
     printf '%s\n' 'summary: Entry point for Orbit feature designs and operational runbooks.'
+    if [[ -n "$last_validated" ]]; then
+      printf 'last_validated: %s\n' "$last_validated"
+    fi
     printf '%s\n' 'tags: [docs, index, design, operations, runbooks]'
     printf '%s\n' 'related_features: [orbit-docs, activity-job, auditability, routines]'
     printf '%s\n' 'related_artifacts: [ORB-10014]'


### PR DESCRIPTION
## Task

[ORB-10438](https://orbit-cli.com/tasks/ORB-10438) — Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Docs that have no frontmatter block at all are **out of the rotation**: do
not invent a frontmatter block for them, because `type` and `summary` are
required fields and guessing them corrupts the docs corpus. List them in
your execution summary instead so a human can decide.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and the docs you found with no frontmatter block.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- No frontmatter block was created for a doc that lacked one; such docs are listed instead.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Batch selection:
- Selected exactly six docs with no last_validated, ordered by path after the missing-date group: docs/INDEX.md, docs/design/CONVENTIONS.md, docs/design/activity-job/1_overview.md, docs/design/activity-job/2_design.md, docs/design/activity-job/3_vision.md, and docs/design/activity-job/4_decisions.md.
Changes and verification:
- docs/INDEX.md: stamped 2026-07-26. Verified generated content and links with scripts/generate-doc-indexes.sh --check; verified the documented CLI surface with orbit --version, orbit activity --help, orbit job --help, and orbit run --help.
- scripts/generate-doc-indexes.sh: taught the generator to preserve the existing docs/INDEX.md last_validated field, so the generated document retains its validation stamp.
- docs/design/CONVENTIONS.md: stamped 2026-07-26. Verified the referenced scaffold files and frontmatter/section rules against docs/design/_templates/.
- docs/design/activity-job/1_overview.md: stamped 2026-07-26. Verified the listed source paths and symbols, schema and asset claims, and CLI surfaces against current crates/orbit-common, crates/orbit-core, crates/orbit-engine, crates/orbit-cmd, and seeded assets.
- docs/design/activity-job/2_design.md: stamped 2026-07-26. Corrected executor test module names and the stale ADR reference to match crates/orbit-engine/src/activity_job/job_executor/tests/; verified the delivery predicate against crates/orbit-engine/src/executor/automation/vcs/handoff.rs and validated schema, backend, target-ref, recovery, and run inspection claims with source scans and targeted tests.
- docs/design/activity-job/3_vision.md: stamped 2026-07-26. Verified backend/provider, HTTP transport, tool-policy, audit, seeded-asset, and internal-link claims against current source and assets.
- docs/design/activity-job/4_decisions.md: stamped 2026-07-26. Corrected ADR ordering, current executor test-module layout, and ADR-0236 delivery-predicate semantics; verified these against source, test-module listings, and targeted tests.
Validation:
- cargo test -p orbit-common --lib activity_job: 31 passed.
- cargo test -p orbit-engine --test v2_cli_backend --test v2_name_resolution: 2 passed.
- make ci-fast: passed.
- git diff --check and selected-document link checks: passed.
Unvalidated and unmodified:
- No batch document or individual claim was left unvalidated.
- In-scope docs with no frontmatter block, excluded from rotation and left unmodified: docs/CONFIG.md, docs/LESSONS.md, docs/POSITIONING.md, docs/design/_templates/references/glossary.md, docs/design/_templates/specs/_mechanism.md, docs/design/activity-job/references/glossary.md, docs/design/activity-job/specs/audit-envelope.md, docs/design/activity-job/specs/backend-resolution.md, docs/design/agent-families/references/glossary.md, docs/design/auditability/references/glossary.md, docs/design/auditability/specs/artifact-redaction.md, docs/design/auditability/specs/coverage-matrix.md, docs/design/auditability/specs/event-schema.md, docs/design/auditability/specs/redaction-retention.md, docs/design/host-registry/references/glossary.md, docs/design/mcp-bridge/references/glossary.md, docs/design/orbit-docs-plugin/1_scope.md, docs/design/orbit-graph/specs/GRAPH_SPEC.md, docs/design/policy-sandbox/references/glossary.md, docs/design/policy-sandbox/specs/fs-profile-resolution.md, docs/design/policy-sandbox/specs/sandbox-exec-contract.md, docs/design/project-learnings/references/glossary.md, docs/design/project-learnings/references/injection-layers.md, docs/design/remote-access/references/glossary.md, docs/design/remote-access/specs/ssh-tunnel.md, docs/design/task-artifacts/references/glossary.md, docs/design/task-artifacts/specs/task-bundle-v2.md, and docs/design/user-interface/specs/theme.md.
Assessment: Documentation rotation completed within scope. No protected historical or generated state paths were modified; docs/INDEX.md is regenerated through its checked-in generator.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10438-6a664564`
- Behind base: 0
- Ahead of base: 1