### PR TITLE
Ship the missing layout migration for the removed status: friction and review_threads on-disk formats

### DIFF
--- a/crates/orbit-store/src/layout/mod.rs
+++ b/crates/orbit-store/src/layout/mod.rs
@@ -38,13 +38,15 @@
 //!   acquisition, so concurrent opens do not interleave migrations. The
 //!   up-to-date fast path never touches the lock.
 
+use std::fs;
 use std::path::{Path, PathBuf};
 
-use orbit_common::types::OrbitError;
+use orbit_common::types::{OrbitError, is_valid_orb_task_id};
+use orbit_common::utility::fs::atomic_write_text;
 
 /// Highest workspace-layout version this binary knows how to produce.
 /// Bump together with a new [`LAYOUT_MIGRATIONS`] entry — never without one.
-pub const SUPPORTED_LAYOUT_VERSION: u32 = 1;
+pub const SUPPORTED_LAYOUT_VERSION: u32 = 2;
 
 /// Marker file recording the workspace's current layout version, relative to
 /// the workspace `.orbit` directory. Lives under `state/` (gitignored
@@ -72,18 +74,192 @@ pub(crate) struct LayoutMigration {
 /// Stable ordered registry of workspace-layout migrations. Append-only:
 /// never renumber or edit an entry that has shipped. Every breaking
 /// `.orbit/` layout change REQUIRES an entry here (see `RELEASING.md`).
-pub(crate) const LAYOUT_MIGRATIONS: &[LayoutMigration] = &[LayoutMigration {
-    version: 1,
-    name: "baseline",
-    description: "adopt the versioned .orbit/ layout (records the current shape; changes nothing)",
-    apply: apply_baseline_layout,
-}];
+pub(crate) const LAYOUT_MIGRATIONS: &[LayoutMigration] = &[
+    LayoutMigration {
+        version: 1,
+        name: "baseline",
+        description: "adopt the versioned .orbit/ layout (records the current shape; changes nothing)",
+        apply: apply_baseline_layout,
+    },
+    LayoutMigration {
+        version: 2,
+        name: "archive-friction-tasks",
+        description: "rewrite affected task records from status 'friction' to 'archived', preserving the task and its event history",
+        apply: apply_archive_friction_tasks,
+    },
+];
 
 /// v1 baseline: the current `.orbit/` shape. Intentionally a no-op — running
 /// it on any existing workspace changes nothing and then records version 1,
 /// which is how pre-versioning workspaces adopt the marker.
 fn apply_baseline_layout(_orbit_dir: &Path) -> Result<(), OrbitError> {
     Ok(())
+}
+
+/// v2: `TaskStatus::Friction` was removed in ORB-10202, so a persisted task
+/// carrying that status no longer deserializes. Preserve the record but keep
+/// it out of active work by mapping the removed status to `archived` in both
+/// the task envelope and its event history.
+///
+/// Task projections may be symlinks into the canonical global bundle store.
+/// `Path::is_dir` deliberately follows those direct projection entries; the
+/// migration never recurses beyond one task bundle.
+fn apply_archive_friction_tasks(orbit_dir: &Path) -> Result<(), OrbitError> {
+    let tasks_dir = orbit_dir.join("tasks");
+    let entries = match fs::read_dir(&tasks_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(layout_io_error(
+                "read projected task directory",
+                &tasks_dir,
+                error,
+            ));
+        }
+    };
+
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            layout_io_error("read projected task directory entry", &tasks_dir, error)
+        })?;
+        let bundle_dir = entry.path();
+        let is_task_bundle = bundle_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(is_valid_orb_task_id);
+        if !is_task_bundle || !bundle_dir.is_dir() {
+            continue;
+        }
+
+        migrate_event_statuses(&bundle_dir.join("events.jsonl"))?;
+        migrate_envelope_status(&bundle_dir.join("task.yaml"))?;
+    }
+    Ok(())
+}
+
+fn migrate_envelope_status(path: &Path) -> Result<(), OrbitError> {
+    let raw = match fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(layout_io_error("read task envelope", path, error)),
+    };
+    let mut value: serde_yaml::Value = serde_yaml::from_str(&raw).map_err(|error| {
+        OrbitError::Migration(format!(
+            "cannot parse task envelope '{}' while archiving removed friction status: {error}",
+            path.display()
+        ))
+    })?;
+    let Some(mapping) = value.as_mapping_mut() else {
+        return Err(OrbitError::Migration(format!(
+            "task envelope '{}' is not a YAML mapping",
+            path.display()
+        )));
+    };
+    if !replace_string_field(mapping, "status", "friction", "archived") {
+        return Ok(());
+    }
+
+    let migrated = serde_yaml::to_string(&value).map_err(|error| {
+        OrbitError::Migration(format!(
+            "cannot serialize migrated task envelope '{}': {error}",
+            path.display()
+        ))
+    })?;
+    atomic_write_text(path, &migrated)
+        .map_err(|error| layout_io_error("rewrite task envelope", path, error))
+}
+
+fn migrate_event_statuses(path: &Path) -> Result<(), OrbitError> {
+    let raw = match fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(layout_io_error("read task event history", path, error)),
+    };
+    let mut migrated = String::with_capacity(raw.len());
+    let mut changed = false;
+
+    for chunk in raw.split_inclusive('\n') {
+        // An unterminated final row is a crash tail ignored by the bundle
+        // reader. Preserve it byte-for-byte so this migration does not turn a
+        // partial append into an apparently committed event.
+        if !chunk.ends_with('\n') {
+            migrated.push_str(chunk);
+            continue;
+        }
+        let line = chunk
+            .strip_suffix('\n')
+            .unwrap_or(chunk)
+            .strip_suffix('\r')
+            .unwrap_or_else(|| chunk.strip_suffix('\n').unwrap_or(chunk));
+        let mut value: serde_json::Value = serde_json::from_str(line).map_err(|error| {
+            OrbitError::Migration(format!(
+                "cannot parse task event history row at '{}': {error}",
+                path.display()
+            ))
+        })?;
+        let row_changed = value.as_object_mut().is_some_and(|object| {
+            replace_json_string_field(object, "from_status", "friction", "archived")
+                | replace_json_string_field(object, "to_status", "friction", "archived")
+        });
+        if row_changed {
+            migrated.push_str(&serde_json::to_string(&value).map_err(|error| {
+                OrbitError::Migration(format!(
+                    "cannot serialize migrated task event history '{}': {error}",
+                    path.display()
+                ))
+            })?);
+            if chunk.ends_with("\r\n") {
+                migrated.push('\r');
+            }
+            migrated.push('\n');
+            changed = true;
+        } else {
+            migrated.push_str(chunk);
+        }
+    }
+
+    if !changed {
+        return Ok(());
+    }
+    atomic_write_text(path, &migrated)
+        .map_err(|error| layout_io_error("rewrite task event history", path, error))
+}
+
+fn replace_string_field(
+    mapping: &mut serde_yaml::Mapping,
+    field: &str,
+    old: &str,
+    new: &str,
+) -> bool {
+    let key = serde_yaml::Value::String(field.to_string());
+    let Some(value) = mapping.get_mut(&key) else {
+        return false;
+    };
+    if value.as_str() != Some(old) {
+        return false;
+    }
+    *value = serde_yaml::Value::String(new.to_string());
+    true
+}
+
+fn replace_json_string_field(
+    object: &mut serde_json::Map<String, serde_json::Value>,
+    field: &str,
+    old: &str,
+    new: &str,
+) -> bool {
+    let Some(value) = object.get_mut(field) else {
+        return false;
+    };
+    if value.as_str() != Some(old) {
+        return false;
+    }
+    *value = serde_json::Value::String(new.to_string());
+    true
+}
+
+fn layout_io_error(operation: &str, path: &Path, error: std::io::Error) -> OrbitError {
+    OrbitError::Migration(format!("{operation} '{}': {error}", path.display()))
 }
 
 /// Registry metadata for one layout migration, as surfaced to `orbit

--- a/crates/orbit-store/src/layout/tests/mod.rs
+++ b/crates/orbit-store/src/layout/tests/mod.rs
@@ -1,14 +1,16 @@
 //! Sibling tests for the workspace-layout migration registry (ORB-10012).
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
-use orbit_common::types::OrbitError;
+use orbit_common::types::{OrbitError, TaskStatus};
 
 use super::{
     LAYOUT_MIGRATIONS, LayoutMigration, SUPPORTED_LAYOUT_VERSION, current_layout_version,
     pending_layout_migrations, pending_with, upgrade_with, upgrade_workspace_layout,
 };
+use crate::file::task_store::v2_bundle::read_bundle_at;
 
 fn temp_orbit_dir() -> tempfile::TempDir {
     tempfile::tempdir().expect("create temp .orbit dir")
@@ -50,7 +52,10 @@ fn fresh_workspace_adopts_the_baseline_and_stamps_the_marker() {
     assert_eq!(report.from_version, 0);
     assert_eq!(report.to_version, SUPPORTED_LAYOUT_VERSION);
     assert_eq!(report.applied.len(), LAYOUT_MIGRATIONS.len());
-    assert_eq!(marker_contents(temp.path()).trim(), "1");
+    assert_eq!(
+        marker_contents(temp.path()).trim(),
+        SUPPORTED_LAYOUT_VERSION.to_string()
+    );
     assert_eq!(
         current_layout_version(temp.path()).expect("version"),
         SUPPORTED_LAYOUT_VERSION
@@ -104,6 +109,159 @@ fn corrupt_marker_is_a_typed_error_naming_the_file() {
     let message = error.to_string();
     assert!(message.contains("layout.version"), "{message}");
     assert!(message.contains("banana"), "{message}");
+}
+
+// ── shipping v2 migration ──
+
+fn seed_task_bundle(orbit_dir: &Path, id: &str, status: &str) -> std::path::PathBuf {
+    let bundle_dir = orbit_dir.join("tasks").join(id);
+    fs::create_dir_all(bundle_dir.join("artifacts")).expect("create task bundle");
+    fs::write(
+        bundle_dir.join("task.yaml"),
+        format!(
+            "schema_version: 1\nid: {id}\ntitle: Legacy task\nstatus: {status}\ntype: bug\npriority: medium\ncreated_at: 2026-07-01T00:00:00Z\nupdated_at: 2026-07-01T00:00:00Z\n"
+        ),
+    )
+    .expect("write task envelope");
+    for document in [
+        "description.md",
+        "acceptance.md",
+        "plan.md",
+        "execution-summary.md",
+    ] {
+        fs::write(bundle_dir.join(document), "").expect("write task document");
+    }
+    fs::write(
+        bundle_dir.join("events.jsonl"),
+        format!(
+            "{{\"schema_version\":1,\"event_id\":\"EV-0001\",\"at\":\"2026-07-01T00:00:00Z\",\"by\":\"codex\",\"type\":\"created\",\"to_status\":\"{status}\"}}\n\
+             {{\"schema_version\":1,\"event_id\":\"EV-0002\",\"at\":\"2026-07-01T00:01:00Z\",\"by\":\"codex\",\"type\":\"updated\",\"from_status\":\"{status}\"}}\n"
+        ),
+    )
+    .expect("write task events");
+    fs::write(bundle_dir.join("comments.jsonl"), "").expect("write task comments");
+    bundle_dir
+}
+
+fn workspace_bytes(root: &Path) -> BTreeMap<std::path::PathBuf, Vec<u8>> {
+    fn visit(root: &Path, current: &Path, files: &mut BTreeMap<std::path::PathBuf, Vec<u8>>) {
+        for entry in fs::read_dir(current).expect("read workspace fixture") {
+            let path = entry.expect("workspace fixture entry").path();
+            if path.is_dir() {
+                visit(root, &path, files);
+            } else {
+                files.insert(
+                    path.strip_prefix(root)
+                        .expect("relative fixture path")
+                        .to_path_buf(),
+                    fs::read(&path).expect("read fixture file"),
+                );
+            }
+        }
+    }
+
+    let mut files = BTreeMap::new();
+    visit(root, root, &mut files);
+    files
+}
+
+#[test]
+fn legacy_friction_task_fails_before_layout_upgrade_and_opens_after() {
+    let temp = temp_orbit_dir();
+    let bundle_dir = seed_task_bundle(temp.path(), "ORB-00001", "friction");
+    fs::create_dir_all(temp.path().join("state")).expect("create state");
+    fs::write(temp.path().join("state/layout.version"), "1\n").expect("stamp v1");
+
+    let before = read_bundle_at(&bundle_dir).expect_err("removed status must fail");
+    assert!(before.to_string().contains("friction"), "{before}");
+
+    let report = upgrade_workspace_layout(temp.path()).expect("apply v2 migration");
+    assert_eq!(report.from_version, 1);
+    assert_eq!(report.to_version, 2);
+    assert_eq!(report.applied.len(), 1);
+    assert_eq!(report.applied[0].name, "archive-friction-tasks");
+
+    let after = read_bundle_at(&bundle_dir).expect("migrated task bundle opens");
+    assert_eq!(after.envelope.status, TaskStatus::Archived);
+    assert_eq!(
+        after.events.first().and_then(|event| event.to_status),
+        Some(TaskStatus::Archived)
+    );
+    assert_eq!(
+        after.events.last().and_then(|event| event.from_status),
+        Some(TaskStatus::Archived)
+    );
+}
+
+#[test]
+fn friction_migration_is_idempotent_and_safe_to_replay_before_marker_advance() {
+    let temp = temp_orbit_dir();
+    let bundle_dir = seed_task_bundle(temp.path(), "ORB-00002", "friction");
+    fs::create_dir_all(temp.path().join("state")).expect("create state");
+    fs::write(temp.path().join("state/layout.version"), "1\n").expect("stamp v1");
+
+    // Simulate a crash after apply returned but before the marker advanced.
+    (LAYOUT_MIGRATIONS[1].apply)(temp.path()).expect("first apply");
+    let after_first_apply = workspace_bytes(temp.path());
+    assert_eq!(current_layout_version(temp.path()).expect("version"), 1);
+
+    let report = upgrade_workspace_layout(temp.path()).expect("replay after interruption");
+    assert_eq!(report.applied.len(), 1);
+    assert_eq!(report.applied[0].version, 2);
+    assert_eq!(
+        read_bundle_at(&bundle_dir).expect("bundle").envelope.status,
+        TaskStatus::Archived
+    );
+
+    let after_marker_advance = workspace_bytes(temp.path());
+    let rerun = upgrade_workspace_layout(temp.path()).expect("idempotent rerun");
+    assert!(rerun.applied.is_empty());
+    assert_eq!(workspace_bytes(temp.path()), after_marker_advance);
+
+    // The replay changed only the marker; task bundle bytes were already final
+    // after the first application.
+    for (path, bytes) in after_first_apply {
+        if path != Path::new("state/layout.version") {
+            assert_eq!(after_marker_advance.get(&path), Some(&bytes));
+        }
+    }
+}
+
+#[test]
+fn dry_run_metadata_lists_plain_friction_task_outcome() {
+    let temp = temp_orbit_dir();
+    fs::create_dir_all(temp.path().join("state")).expect("create state");
+    fs::write(temp.path().join("state/layout.version"), "1\n").expect("stamp v1");
+
+    let pending = pending_layout_migrations(temp.path()).expect("pending");
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].version, 2);
+    assert_eq!(pending[0].name, "archive-friction-tasks");
+    assert!(pending[0].description.contains("status 'friction'"));
+    assert!(pending[0].description.contains("'archived'"));
+    assert!(pending[0].description.contains("preserving the task"));
+}
+
+#[test]
+fn legacy_review_thread_sidecars_are_ignored_when_bundle_opens() {
+    let temp = temp_orbit_dir();
+    let bundle_dir = seed_task_bundle(temp.path(), "ORB-00003", "backlog");
+    let review_threads = bundle_dir.join("review-threads");
+    fs::create_dir_all(&review_threads).expect("create legacy review threads");
+    fs::write(
+        review_threads.join("RT-0001.yaml"),
+        "schema_version: 1\nthread_id: RT-0001\nstatus: open\nmessages: []\ncreated_at: 2026-07-01T00:00:00Z\nupdated_at: 2026-07-01T00:00:00Z\n",
+    )
+    .expect("write legacy review metadata");
+    fs::write(review_threads.join("RT-0001.md"), "Legacy review body.\n")
+        .expect("write legacy review body");
+
+    let bundle = read_bundle_at(&bundle_dir).expect("legacy bundle opens");
+    assert_eq!(bundle.envelope.status, TaskStatus::Backlog);
+    assert!(
+        review_threads.is_dir(),
+        "opening leaves ignored sidecars untouched"
+    );
 }
 
 // ── test-only v2 registry: exercises a real layout change end to end ──
@@ -179,7 +337,8 @@ fn toy_v2_migration_applies_in_order_and_advances_the_marker() {
 fn upgrade_applies_only_migrations_newer_than_the_marker() {
     let temp = temp_orbit_dir();
     // Already on v1: only the v2 entry should run.
-    upgrade_workspace_layout(temp.path()).expect("adopt baseline");
+    fs::create_dir_all(temp.path().join("state")).expect("mkdir state");
+    fs::write(temp.path().join("state/layout.version"), "1\n").expect("stamp v1");
     fs::write(temp.path().join("notes.txt"), "hello").expect("write legacy file");
 
     let report = upgrade_with(temp.path(), TOY_V2_REGISTRY).expect("upgrade");


### PR DESCRIPTION
## Task

[ORB-10435](https://orbit-cli.com/tasks/ORB-10435) — Ship the missing layout migration for the removed status: friction and review_threads on-disk formats

### Description

## Problem

Two changes in the unreleased 0.10.0 window altered on-disk `.orbit/` formats without shipping the layout migration that `RELEASING.md` requires.

- **ORB-10202** deleted `TaskStatus::Friction`. The test `task_status_rejects_removed_friction_variant` pins that `serde_json::from_str::<TaskStatus>("\"friction\"")` now **errors**. A workspace holding a task persisted with that status fails to deserialize it after upgrading.
- **ORB-10332** dropped `review_threads` from `TaskBundleV2` and its sidecars.

`RELEASING.md` § "Breaking `.orbit/` layout changes" is explicit: since ORB-10012, a breaking layout change **requires** a `LAYOUT_MIGRATIONS` entry shipped with it — "an undocumented break is no longer an option." Neither change shipped one. `crates/orbit-store/src/layout/mod.rs:75` still holds exactly one entry (`version: 1, name: "baseline"`, "changes nothing") and `SUPPORTED_LAYOUT_VERSION` is still `1`.

## Sizing — read this before designing

**There are no known external users.** This is insurance against a break that probably has zero real-world instances, and it is being filed so 0.10.0 doesn't ship a self-acknowledged process violation. Size it accordingly: a minimal, conservative migration that makes an affected workspace open cleanly. Do **not** build a general data-rescue framework, a reporting surface, a CLI flag, or a recovery mode. Added surface here earns nothing.

## What must be determined, not assumed

- **Whether the `review_threads` half needs a migration at all.** If the bundle deserializer already ignores unknown fields, a legacy bundle loads fine and merely drops the data, and no migration step is warranted. Verify against the actual serde attributes and a real legacy fixture; if it is already tolerated, say so in the execution summary and do not invent work for it.
- **What to do with a task whose persisted status is `friction`.** Dropping the task and rewriting the status are materially different outcomes — one loses a record, the other keeps a task whose status no longer means what it meant. Pick one, justify it in the execution summary, and make the choice visible in the migration's `description` field so an operator reading `orbit migrate --dry-run` understands what will happen to their data.

## Constraints

- **The registry entry and the version bump ship together.** `layout/mod.rs:46` states it directly: "Bump together with a new `LAYOUT_MIGRATIONS` entry — never without one."
- **Idempotent or staged (write-new-then-swap).** Layout migrations auto-apply during the workspace-open pre-flight and re-run after a crash — the `state/layout.version` marker only advances after an entry's apply succeeds. Running twice must be a no-op; an interrupted run must be safe to resume.
- **Do not re-add `TaskStatus::Friction`.** The removal is intentional and is itself a listed breaking change for 0.10.0. This migration cleans up persisted state; it does not restore the variant or relax the deserializer.
- **Do not loosen the downgrade guard.** A workspace written by a newer orbit refusing to open under an older binary is deliberate.
- **`orbit migrate --dry-run` must list the pending migration** before an upgrade applies it — that is the operator's only preview.
- PR mode — `orbit` is PR+CI gated. Branch off `agent-main`, land via PR.

## Timing

This gates the `v0.10.0` tag. `agent-main` CI is currently red and is being fixed separately; this task should land on a green base.

## Out of scope

- The `CHANGELOG.md` `## 0.10.0` section and the four version-file bumps — those belong to the separate "Prepare v0.10.0 release" task.
- Any change to the SQLite schema ledger (`SUPPORTED_SCHEMA_VERSION`, currently 10). That mechanism is separate from the layout registry and is not implicated.
- Auditing earlier releases for the same class of omission.

### Acceptance Criteria

- `LAYOUT_MIGRATIONS` gains an entry and `SUPPORTED_LAYOUT_VERSION` is bumped in the same commit, per the invariant documented at `crates/orbit-store/src/layout/mod.rs:46`.
- A test fixture workspace containing a task persisted with `status: friction` fails to open on the parent commit and opens cleanly on the branch. Paste both outcomes in the execution summary.
- The `review_threads` question is answered with evidence: either a fixture proves a legacy bundle already deserializes (and no migration step was added for it), or a migration step is added and covered by its own fixture. State which, and quote the serde attribute or test that settles it.
- The migration is idempotent: applying it twice leaves the workspace byte-identical after the first application, and a workspace interrupted mid-apply (marker not advanced) re-applies safely. Both covered by tests.
- `orbit migrate --dry-run` lists the new pending migration on an unmigrated workspace, and its `description` states plainly what happens to an affected task record.
- `TaskStatus::Friction` is not reintroduced and the deserializer is not relaxed — `task_status_rejects_removed_friction_variant` still passes unmodified.
- No new CLI flag, MCP tool, config key, or recovery mode is added.
- `cargo test --workspace` and `cargo clippy --all-targets -- -D warnings` pass; `make ci-fast` passes; CI green on the PR.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Bumped `SUPPORTED_LAYOUT_VERSION` from 1 to 2 together with the `archive-friction-tasks` registry entry.
- Added an idempotent migration that follows direct `.orbit/tasks/ORB-xxxxx` projection entries and atomically rewrites exact persisted `friction` values in `task.yaml` status plus `events.jsonl` `from_status`/`to_status` fields to `archived`.
- Chose `archived` rather than dropping the task: it preserves the record and event history while keeping a legacy friction report out of active work. The dry-run description states that outcome plainly.
- Added real task-bundle fixtures for pre/post migration deserialization, apply-twice byte stability, replay after apply-before-marker interruption, dry-run metadata, and legacy review-thread sidecars.

Fixture evidence:
- Parent commit `42f2a6ee`: `cargo test -p orbit-store orb_10435_parent_fixture_opens_legacy_friction_task -- --nocapture` exited 101. The fixture open failed with `unknown variant friction, expected one of proposed, backlog, in-progress, in_progress, review, done, blocked, archived, rejected, someday`.
- Branch: `cargo test -p orbit-store legacy_friction_task_fails_before_layout_upgrade_and_opens_after -- --nocapture` passed (1 passed). The same fixture first reproduces that deserialization error, then opens with envelope/event statuses equal to `TaskStatus::Archived` after layout v2 applies.

Review-thread determination:
- No review-thread migration was added. `TaskBundleV2` is assembled file-by-file rather than deserialized from the bundle directory, so an unrecognized `review-threads/` sidecar directory is never read. The real legacy-sidecar fixture test `legacy_review_thread_sidecars_are_ignored_when_bundle_opens` passes and proves the bundle opens while the ignored sidecars remain untouched.

Dry-run evidence:
- `target/debug/orbit migrate --dry-run --root /tmp/orb10435-dryrun/.orbit --json` against a v1 marker listed pending layout v2 `archive-friction-tasks` with description `rewrite affected task records from status 'friction' to 'archived', preserving the task and its event history`; exit 1 was the documented pending-migration signal.

Validation:
- `cargo test -p orbit-store layout::tests` — passed (25 tests).
- `cargo test -p orbit-common task_status_rejects_removed_friction_variant` — passed unmodified (1 test).
- `make ci-fast` — passed.
- `cargo test --workspace` — passed.
- `cargo clippy --all-targets -- -D warnings` — passed.
- `git diff --check` — passed.

Assessment: The change is confined to the two planned layout files, adds no surface or dependency, preserves the downgrade guard and removed-status rejection, and is ready for the pipeline-owned commit/PR/CI stages.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10435-6a664564`
- Behind base: 0
- Ahead of base: 1