### PR TITLE
Add `orbit auto-task generate <name>` to mint a task from a definition on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The constraints are the point — they're what keep agent-assisted code shippabl
 
 - **Dependency-ordered execution.** Tasks carry `dependencies` and typed `relations` (`blocked_by`, …). The pipeline gates admission on them, so a dependent task waits for its blocker to reach `done` instead of being hand-sequenced by whoever is dispatching — declare the order once and let the queue enforce it.
 
-- **Recurring work as data, not code.** `orbit auto-task add/list/show/update/toggle` defines `.orbit/auto_tasks/*.yaml` templates with a cron or interval schedule and a dedupe policy; a seeded scheduler routine mints tasks from the due ones, collapsing catch-up runs and skipping duplicates when one is already open. Provider-neutral, checked into the repo.
+- **Recurring work as data, not code.** `orbit auto-task add/list/show/update/toggle` defines `.orbit/auto_tasks/*.yaml` templates with a cron or interval schedule and a dedupe policy; a seeded scheduler routine mints tasks from the due ones, collapsing catch-up runs and skipping duplicates when one is already open. `orbit auto-task generate <name>` mints one on demand — same template mapping, same provenance — so a new definition can be exercised without waiting for its slot. Provider-neutral, checked into the repo.
 
 - **Conflict-aware parallel execution.** For `orbit run ship`, each agent run lands in its own git worktree per task, and the gate pipeline reserves task `context_files` as locks before fanning out, rejecting overlapping reservations up front instead of producing merge conflicts later (see [merge throughput chart](docs/assets/merge-throughput.png)). → [docs/design/activity-job/](docs/design/activity-job/)
 

--- a/crates/orbit-cli/src/command/auto_task/command.rs
+++ b/crates/orbit-cli/src/command/auto_task/command.rs
@@ -4,6 +4,7 @@ use orbit_core::{OrbitError, OrbitRuntime};
 use crate::command::Execute;
 
 use super::add::AutoTaskAddArgs;
+use super::generate::AutoTaskGenerateArgs;
 use super::list::AutoTaskListArgs;
 use super::show::AutoTaskShowArgs;
 use super::toggle::AutoTaskToggleArgs;
@@ -34,6 +35,9 @@ pub enum AutoTaskSubcommand {
     Update(AutoTaskUpdateArgs),
     /// Enable or disable a definition (the kill-switch; not a delete)
     Toggle(AutoTaskToggleArgs),
+    /// Mint a task from a definition now (ignores schedule, dedupe, and
+    /// `enabled`; leaves the scheduler cursor untouched)
+    Generate(AutoTaskGenerateArgs),
 }
 
 impl Execute for AutoTaskSubcommand {
@@ -44,6 +48,7 @@ impl Execute for AutoTaskSubcommand {
             AutoTaskSubcommand::Show(args) => args.execute(runtime),
             AutoTaskSubcommand::Update(args) => args.execute(runtime),
             AutoTaskSubcommand::Toggle(args) => args.execute(runtime),
+            AutoTaskSubcommand::Generate(args) => args.execute(runtime),
         }
     }
 }

--- a/crates/orbit-cli/src/command/auto_task/generate.rs
+++ b/crates/orbit-cli/src/command/auto_task/generate.rs
@@ -1,0 +1,27 @@
+use clap::Args;
+use orbit_core::{OrbitError, OrbitRuntime};
+
+use crate::command::Execute;
+use crate::command::task::output::task_to_json_for_runtime;
+
+#[derive(Args)]
+pub struct AutoTaskGenerateArgs {
+    /// Definition name
+    pub name: String,
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for AutoTaskGenerateArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let task = runtime.auto_task_generate(&self.name)?;
+
+        if self.json {
+            crate::output::json::print_pretty(&task_to_json_for_runtime(runtime, &task)?)
+        } else {
+            println!("{} {}", task.id, task.title);
+            Ok(())
+        }
+    }
+}

--- a/crates/orbit-cli/src/command/auto_task/mod.rs
+++ b/crates/orbit-cli/src/command/auto_task/mod.rs
@@ -1,5 +1,6 @@
 mod add;
 mod command;
+mod generate;
 mod list;
 pub(crate) mod output;
 mod schedule_args;

--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -531,6 +531,7 @@ impl Commands {
                     AutoTaskSubcommand::Show(args) => ("show", Some(args.name.as_str())),
                     AutoTaskSubcommand::Update(args) => ("update", Some(args.name.as_str())),
                     AutoTaskSubcommand::Toggle(args) => ("toggle", Some(args.name.as_str())),
+                    AutoTaskSubcommand::Generate(args) => ("generate", Some(args.name.as_str())),
                 };
                 CommandOperation::new(
                     RuntimeNeed::Required,

--- a/crates/orbit-core/src/auto_tasks/crud.rs
+++ b/crates/orbit-core/src/auto_tasks/crud.rs
@@ -3,10 +3,14 @@
 //! are git-versioned YAML under `<orbit_dir>/auto_tasks/<name>.yaml`; these
 //! methods are the single choke point that reads/writes them, so both entry
 //! points stay consistent. Disabling is a `toggle`, never a delete.
+//!
+//! `generate` (CLI-only by design — see `docs/design/mcp-bridge/2_design.md`)
+//! rides here too: it mints a task from a definition on demand by reusing the
+//! scheduler's mint path, so there is exactly one template→task mapping.
 
 use orbit_common::types::{
     AUTO_TASK_SCHEMA_VERSION, AutoTaskDefinition, AutoTaskSchedule, AutoTaskTemplate, DedupePolicy,
-    OrbitError,
+    OrbitError, Task,
 };
 use orbit_common::utility::fs::write_text_with_parent;
 
@@ -14,6 +18,7 @@ use crate::OrbitRuntime;
 
 use super::loader::{collect_auto_tasks, definition_path};
 use super::schedule::validate_schedule;
+use super::scheduler::mint_task;
 
 /// Parameters for creating a definition.
 #[derive(Debug, Clone)]
@@ -125,6 +130,26 @@ impl OrbitRuntime {
         let mut definition = self.require_auto_task(name)?;
         definition.enabled = enabled;
         self.stamp_and_write(definition)
+    }
+
+    /// Mint one task from a definition on demand — the manual counterpart to a
+    /// scheduler fire, so a new or edited definition can be exercised without
+    /// waiting for its cron slot [ORB-10439].
+    ///
+    /// The mint is **unconditional**: schedule due-math, `dedupe`, and
+    /// `enabled` are all ignored, and the host-local cursor at
+    /// `<orbit_dir>/state/auto-tasks.json` is neither read nor written — an
+    /// operator naming a definition explicitly means it, and a manual mint must
+    /// not perturb scheduler state. Because it reuses the scheduler's
+    /// [`mint_task`], the result is field-for-field identical to a fired
+    /// instance, provenance tag and `system_created` marker included; that also
+    /// means an open generated instance is visible to `skip_if_open` dedupe on
+    /// the next pass, exactly as a fired one would be.
+    ///
+    /// An unknown name is an `InvalidInput` error naming the definition.
+    pub fn auto_task_generate(&self, name: &str) -> Result<Task, OrbitError> {
+        let definition = self.require_auto_task(name)?;
+        mint_task(self, &definition)
     }
 
     fn require_auto_task(&self, name: &str) -> Result<AutoTaskDefinition, OrbitError> {

--- a/crates/orbit-core/src/auto_tasks/mod.rs
+++ b/crates/orbit-core/src/auto_tasks/mod.rs
@@ -16,7 +16,7 @@
 //!   native), with catch-up collapse.
 //! - [`state`] — host-local, workspace-scoped last-fired cursors.
 //! - [`scheduler`] — the pass itself + the deterministic-action projection.
-//! - [`crud`] — the shared add/list/show/update/toggle domain surface.
+//! - [`crud`] — the shared add/list/show/update/toggle/generate domain surface.
 
 pub mod crud;
 pub mod loader;

--- a/crates/orbit-core/src/auto_tasks/scheduler.rs
+++ b/crates/orbit-core/src/auto_tasks/scheduler.rs
@@ -193,7 +193,16 @@ fn is_open_status(status: TaskStatus) -> bool {
     )
 }
 
-fn mint_task(runtime: &OrbitRuntime, definition: &AutoTaskDefinition) -> Result<Task, OrbitError> {
+/// Mint one task from a definition's template — the single template→task
+/// mapping in the system. Deliberately independent of due-math, cursors, and
+/// dedupe: it needs only the definition, so the manual
+/// [`OrbitRuntime::auto_task_generate`](crate::OrbitRuntime::auto_task_generate)
+/// path reuses it verbatim and a generated task is field-for-field identical to
+/// a fired one, provenance tag and `system_created` marker included.
+pub(super) fn mint_task(
+    runtime: &OrbitRuntime,
+    definition: &AutoTaskDefinition,
+) -> Result<Task, OrbitError> {
     let template = &definition.template;
     let mut tags = template.tags.clone();
     tags.push(auto_task_tag(&definition.name));

--- a/crates/orbit-core/src/auto_tasks/tests/generate.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/generate.rs
@@ -1,0 +1,239 @@
+//! Manual-mint tests [ORB-10439]: `auto_task_generate` is unconditional
+//! (ignores schedule due-math, `dedupe`, and `enabled`), leaves the host-local
+//! cursor untouched, and produces a task field-for-field identical to a
+//! scheduler fire.
+
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use orbit_common::types::{DedupePolicy, Task, TaskStatus, auto_task_tag};
+use serde_json::Value;
+
+use crate::OrbitRuntime;
+use crate::auto_tasks::scheduler::{SchedulerOptions, run_auto_task_scheduler_at};
+use crate::auto_tasks::state::cursor_state_path;
+
+use super::interval_params;
+
+fn runtime() -> OrbitRuntime {
+    OrbitRuntime::in_memory().expect("build in-memory runtime")
+}
+
+fn at(y: i32, m: u32, d: u32, h: u32, min: u32) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(y, m, d, h, min, 0)
+        .single()
+        .expect("valid ts")
+}
+
+/// One scheduler pass, projected to `(action, task_id)` per definition.
+fn fire(runtime: &OrbitRuntime, now: DateTime<Utc>) -> Vec<(String, Option<String>)> {
+    let outcome = run_auto_task_scheduler_at(runtime, now, SchedulerOptions::default())
+        .expect("scheduler pass");
+    outcome
+        .reports
+        .iter()
+        .map(|report| (report.action.to_string(), report.task_id.clone()))
+        .collect()
+}
+
+/// Raw bytes of the cursor state file, or `None` when it does not exist.
+fn cursor_bytes(runtime: &OrbitRuntime) -> Option<Vec<u8>> {
+    std::fs::read(cursor_state_path(&runtime.paths().state_dir)).ok()
+}
+
+/// A task's JSON projection with the identity/clock fields stripped, so two
+/// tasks minted at different moments compare on their template-derived content
+/// alone — and any future `Task` field the mint path starts populating is
+/// covered without touching this helper.
+fn content(task: &Task) -> Value {
+    let mut value = serde_json::to_value(task).expect("task json");
+    let object = value.as_object_mut().expect("task json object");
+    for volatile in ["id", "created_at", "updated_at"] {
+        object.remove(volatile);
+    }
+    value
+}
+
+#[test]
+fn generate_matches_a_scheduler_fire_field_for_field() {
+    let runtime = runtime();
+    runtime
+        .auto_task_add(interval_params("chore", 60))
+        .expect("add");
+    let t0 = at(2026, 1, 1, 0, 0);
+
+    fire(&runtime, t0); // baseline
+    let reports = fire(&runtime, t0 + Duration::minutes(65));
+    assert_eq!(reports[0].0, "fired");
+    let fired = runtime
+        .get_task(&reports[0].1.clone().expect("task id"))
+        .expect("fired task");
+
+    let generated = runtime.auto_task_generate("chore").expect("generate");
+
+    assert_ne!(generated.id, fired.id, "generate mints a distinct task");
+    assert_eq!(
+        content(&generated),
+        content(&fired),
+        "a generated task must be indistinguishable from a fired one"
+    );
+    assert!(
+        generated.tags.contains(&auto_task_tag("chore")),
+        "expected provenance tag, got {:?}",
+        generated.tags
+    );
+    assert_eq!(
+        generated.created_by.as_deref(),
+        Some("system"),
+        "generate mints with the system_created identity"
+    );
+    assert_eq!(
+        generated.status,
+        TaskStatus::Backlog,
+        "generate honors the template-supplied status default"
+    );
+}
+
+#[test]
+fn generate_succeeds_for_a_disabled_definition() {
+    let runtime = runtime();
+    runtime
+        .auto_task_add(interval_params("chore", 60))
+        .expect("add");
+    runtime
+        .auto_task_toggle("chore", false)
+        .expect("toggle off");
+
+    let generated = runtime.auto_task_generate("chore").expect("generate");
+    assert!(generated.tags.contains(&auto_task_tag("chore")));
+    assert_eq!(runtime.list_tasks().expect("tasks").len(), 1);
+}
+
+#[test]
+fn generate_succeeds_while_an_instance_is_open_under_skip_if_open() {
+    let runtime = runtime();
+    let params = interval_params("chore", 60);
+    assert_eq!(params.dedupe, DedupePolicy::SkipIfOpen);
+    runtime.auto_task_add(params).expect("add");
+
+    let first = runtime.auto_task_generate("chore").expect("generate");
+    assert!(first.tags.contains(&auto_task_tag("chore")));
+
+    // The first instance is open (backlog), yet a second manual mint still lands.
+    let second = runtime.auto_task_generate("chore").expect("generate again");
+    assert_ne!(first.id, second.id);
+    assert_eq!(runtime.list_tasks().expect("tasks").len(), 2);
+}
+
+#[test]
+fn generate_leaves_the_cursor_byte_identical() {
+    let runtime = runtime();
+    runtime
+        .auto_task_add(interval_params("chore", 60))
+        .expect("add");
+    let t0 = at(2026, 1, 1, 0, 0);
+
+    // Before any scheduler pass the file does not exist — generate must not
+    // create it.
+    assert!(cursor_bytes(&runtime).is_none());
+    runtime.auto_task_generate("chore").expect("generate");
+    assert!(
+        cursor_bytes(&runtime).is_none(),
+        "generate must not create cursor state"
+    );
+
+    fire(&runtime, t0); // baseline writes the cursor
+    let before = cursor_bytes(&runtime).expect("cursor state after baseline");
+    runtime.auto_task_generate("chore").expect("generate");
+    assert_eq!(
+        cursor_bytes(&runtime).expect("cursor state after generate"),
+        before,
+        "generate must not read-modify-write the cursor"
+    );
+}
+
+#[test]
+fn generate_does_not_change_the_next_scheduler_decision() {
+    // `always` dedupe isolates the cursor question from the provenance-tag
+    // question: the only thing that could move the next pass is the cursor.
+    let mut params = interval_params("chore", 60);
+    params.dedupe = DedupePolicy::Always;
+    let t0 = at(2026, 1, 1, 0, 0);
+
+    let control = runtime();
+    control.auto_task_add(params.clone()).expect("add");
+    fire(&control, t0); // baseline
+    let control_outcome = run_auto_task_scheduler_at(
+        &control,
+        t0 + Duration::minutes(65),
+        SchedulerOptions::default(),
+    )
+    .expect("control pass");
+
+    let generated = runtime();
+    generated.auto_task_add(params).expect("add");
+    fire(&generated, t0); // baseline
+    generated.auto_task_generate("chore").expect("generate");
+    let generated_outcome = run_auto_task_scheduler_at(
+        &generated,
+        t0 + Duration::minutes(65),
+        SchedulerOptions::default(),
+    )
+    .expect("pass after generate");
+
+    assert_eq!(control_outcome.reports[0].action, "fired");
+    assert_eq!(
+        generated_outcome.reports[0].action,
+        control_outcome.reports[0].action,
+    );
+    assert_eq!(
+        generated_outcome.reports[0].slot, control_outcome.reports[0].slot,
+        "the consumed slot must be unaffected by a manual mint"
+    );
+}
+
+#[test]
+fn an_open_generated_instance_defers_the_next_fire_like_a_fired_one() {
+    // The flip side of provenance parity: a generated task carries the
+    // `auto-task:<name>` tag, so `skip_if_open` sees it exactly as it sees a
+    // fired instance. That is the point — a hand-copied task is invisible to
+    // dedupe, and this surface exists so a manual mint is not.
+    let runtime = runtime();
+    runtime
+        .auto_task_add(interval_params("chore", 60))
+        .expect("add");
+    let t0 = at(2026, 1, 1, 0, 0);
+
+    fire(&runtime, t0); // baseline
+    let generated = runtime.auto_task_generate("chore").expect("generate");
+
+    let deferred = fire(&runtime, t0 + Duration::minutes(65));
+    assert_eq!(deferred[0].0, "skipped");
+    assert_eq!(runtime.list_tasks().expect("tasks").len(), 1);
+
+    // The cursor never advanced, so the pending occurrence fires (once) the
+    // moment the queue drains — the same recovery as a stalled fired instance.
+    runtime
+        .update_task(
+            &generated.id,
+            crate::command::task::TaskUpdateParams {
+                status: Some(TaskStatus::Rejected),
+                ..Default::default()
+            },
+        )
+        .expect("close generated task");
+    let drained = fire(&runtime, t0 + Duration::minutes(125));
+    assert_eq!(drained[0].0, "fired");
+    assert_eq!(runtime.list_tasks().expect("tasks").len(), 2);
+}
+
+#[test]
+fn generate_with_an_unknown_name_errors_naming_the_definition() {
+    let runtime = runtime();
+    let error = runtime
+        .auto_task_generate("nope")
+        .expect_err("unknown definition must fail");
+    assert!(
+        error.to_string().contains("nope"),
+        "error must name the definition, got: {error}"
+    );
+    assert!(runtime.list_tasks().expect("tasks").is_empty());
+}

--- a/crates/orbit-core/src/auto_tasks/tests/mod.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/mod.rs
@@ -5,6 +5,7 @@ use orbit_common::types::{
 use crate::auto_tasks::crud::AutoTaskAddParams;
 
 mod crud;
+mod generate;
 mod schedule;
 mod scheduler;
 mod shipped;

--- a/docs/design/auto-tasks/1_overview.md
+++ b/docs/design/auto-tasks/1_overview.md
@@ -1,7 +1,7 @@
 ---
 title: Auto-tasks — Overview
 owner: claude
-last_updated: 2026-07-25
+last_updated: 2026-07-26
 status: Accepted
 feature: auto-tasks
 doc_role: overview
@@ -10,7 +10,7 @@ summary: Dynamically-defined recurring task templates minted by one generic sche
 tags: [auto-tasks]
 paths: ["crates/orbit-core/src/auto_tasks/**"]
 related_features: [auto-tasks]
-related_artifacts: [ORB-10149, ORB-10318, ORB-10348, ADR-0218, ADR-0217]
+related_artifacts: [ORB-10149, ORB-10318, ORB-10348, ORB-10439, ADR-0218, ADR-0217]
 ---
 
 # Auto-tasks — Overview
@@ -50,6 +50,11 @@ becomes just the first definition.
   surface.
 - **Dedupe & provenance** — each minted task carries an `auto-task:<name>` tag;
   `skip_if_open` uses that tag to avoid firing while a prior instance is open.
+- **Manual mint** — `orbit auto-task generate <name>` mints one task from a
+  definition immediately, reusing the scheduler's mint path so the result is
+  indistinguishable from a fired instance. Unconditional and cursor-inert: it
+  ignores schedule, `dedupe`, and `enabled`, and never touches
+  `<orbit_dir>/state/auto-tasks.json` (ORB-10439).
 
 ## 3. At a Glance
 
@@ -61,6 +66,7 @@ becomes just the first definition.
 | Host-local cursor | `crates/orbit-core/src/auto_tasks/state.rs` | ORB-10149 |
 | Scheduler pass | `crates/orbit-core/src/auto_tasks/scheduler.rs` | ORB-10149 |
 | CRUD (CLI + MCP shared) | `crates/orbit-core/src/auto_tasks/crud.rs` | ORB-10149 |
+| Manual mint (`generate`, CLI-only) | `crates/orbit-core/src/auto_tasks/crud.rs` | ORB-10439 |
 | Deterministic action | `crates/orbit-core/src/runtime/v2_host/dispatch.rs` | ORB-10149 |
 | Seeded assets | `crates/orbit-core/assets/{activities,jobs,routines}/…` | ORB-10149 |
 
@@ -80,5 +86,6 @@ becomes just the first definition.
 - ORB-10148 — qa-sweep V1 (first definition; depends on this).
 - ORB-10318 — learning-deprecation-review definition (report-only stale-learning review; superseded by ORB-10348).
 - ORB-10348 — Generalized the definition into artifact-deprecation-review, adding the comment-reference sweep.
+- ORB-10439 — `orbit auto-task generate <name>`, the on-demand manual mint.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/auto-tasks/2_design.md
+++ b/docs/design/auto-tasks/2_design.md
@@ -1,16 +1,16 @@
 ---
 title: Auto-tasks — Design
 owner: claude
-last_updated: 2026-07-12
+last_updated: 2026-07-26
 status: Accepted
 feature: auto-tasks
 doc_role: design
 type: design
-summary: Current implementation of the auto-task record, due-math, host-local cursor, generic scheduler, and CRUD surfaces.
+summary: Current implementation of the auto-task record, due-math, host-local cursor, generic scheduler, CRUD surfaces, and the on-demand manual mint.
 tags: [auto-tasks]
 paths: ["crates/orbit-core/src/auto_tasks/**"]
 related_features: [auto-tasks]
-related_artifacts: [ORB-10149, ADR-0218, ADR-0217]
+related_artifacts: [ORB-10149, ORB-10439, ADR-0218, ADR-0217]
 ---
 
 # Auto-tasks — Design
@@ -79,6 +79,48 @@ rejects duplicate names; update patches present fields; toggle flips `enabled`
 (cron parse / interval > 0) and crew at write time, so a bad definition is never
 persisted.
 
+## 5b. Manual mint — `generate` (ORB-10439)
+
+`orbit auto-task generate <name>` mints one task from a definition on demand, so
+a new or edited definition can be exercised without waiting for its slot (weekly
+definitions otherwise cost a week per typo). It lives on `crud.rs` alongside the
+other verbs and delegates to `scheduler::mint_task` — the scheduler's mint path
+is already separable from due-math (it needs only the definition), so there is
+exactly one template→task mapping and a generated task is field-for-field
+identical to a fired one: same field mapping, same `auto-task:<name>` tag, same
+`system_created` marker, same template-supplied status.
+
+The mint is **unconditional**. It ignores schedule due-math, `dedupe`, and
+`enabled`, and it neither reads nor writes the host-local cursor — an operator
+naming a definition explicitly means it, and a manual mint must not perturb
+scheduler state. Unknown names fail loudly (`InvalidInput` naming the
+definition), so the CLI exits non-zero rather than silently no-op'ing.
+
+Deliberately rejected:
+
+- **A `generate`-local mint implementation.** A second template→task mapping
+  would drift from the scheduler's, and the provenance parity that makes the
+  feature worth having is precisely what drift destroys.
+- **Honoring `enabled`/`dedupe`/due-math.** That makes `generate` a "run the
+  scheduler early" button, which the existing `run_auto_task_scheduler` action
+  already is. The gap being closed is *manual mint*, not *early fire*.
+- **Advancing the cursor.** It would consume a real scheduled slot, silently
+  cancelling the next automatic fire.
+- **`--dry-run` / `--force` flags.** `--force` has nothing to override — the mint
+  is already unconditional — and `--dry-run` would only re-print the template
+  that `auto-task show` already renders. The surface is `<name>` plus `--json`,
+  matching the sibling subcommands.
+
+One consequence follows from parity and is intended: because a generated task
+carries the provenance tag, an open one is visible to `skip_if_open` on the next
+scheduler pass and defers that fire, exactly as an open fired instance does. The
+cursor does not advance, so the deferred occurrence fires once when the queue
+drains. This is the behavior the hand-copy workaround could not provide.
+
+`generate` is CLI-only. Per the mcp-bridge design (`docs/design/mcp-bridge/2_design.md`,
+auto_task placement row) the auto_task MCP tools manage the Git-versioned
+definition and do not mint tasks; no MCP tool was added.
+
 ## 6. Concerns & Honest Limitations
 
 The checked-in `qa-sweep` definition is the first concrete consumer. It files a
@@ -100,5 +142,6 @@ validation correctly produces only task-side effects.
 ## Task References
 
 - ORB-10149 — Auto-task primitive.
+- ORB-10439 — `orbit auto-task generate <name>`, the on-demand manual mint.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10439](https://orbit-cli.com/tasks/ORB-10439) — Add `orbit auto-task generate <name>` to mint a task from a definition on demand

### Description

## Problem

`orbit auto-task` can define, inspect, edit, and disable a definition, but there is no way to
**mint a task from one on demand**. Consequences today:

- A new or edited definition cannot be exercised without waiting for its cron slot. `qa-sweep`
  is hourly, but `artifact-deprecation-review` is weekly — a typo in a template costs a week to
  observe.
- The workaround is hand-copying the template into `orbit task add`, which silently loses the
  things that make a minted task an auto-task instance: the `auto-task:<name>` provenance tag
  and the `system_created` marker. Dedupe (`skip_if_open`) keys off that tag, so a hand-copied
  instance is invisible to the scheduler.

Add a `generate` subcommand that mints the task properly.

## Decided semantics — pure manual mint (Daniel, 2026-07-26)

`generate` mints **unconditionally**. It ignores schedule due-math, it ignores `dedupe`, it
ignores `enabled`, and it neither reads nor writes the host-local cursor at
`<orbit_dir>/state/auto-tasks.json`. An operator naming a definition explicitly means it, and a
manual mint must not perturb scheduler state. Guard flags (`--dry-run`, `--force`) are the
implementer's call — argue for what the surface actually needs rather than adding both by
reflex.

## Constraints

- **Provenance parity is the point.** A generated task must be indistinguishable from a
  scheduler-minted one: same template field mapping, same `auto-task:<name>` tag, same
  `system_created: true`, same template-supplied `status` default.
- **No second minting implementation.** The scheduler's mint path is the single source of truth
  for template→task mapping; `generate` reuses it. It is already separable from due-math (it
  needs only the definition), so this should not require restructuring the scheduler.
- **Follow the existing shared-implementation convention.** `add/list/show/update/toggle` all
  funnel through one choke point that both the CLI and the MCP tools call; `generate` belongs on
  the same footing rather than as CLI-local logic.
- **MCP exposure is explicitly out of scope and must not be added.** The mcp-bridge design
  (`docs/design/mcp-bridge/2_design.md`, auto_task placement row) states that auto_task MCP CRUD
  "manages the Git-versioned definition; it does not mint tasks". If implementing makes a case
  that the boundary should move, file a friction — do not move it here.
- An unknown or missing definition name fails loudly (clear non-zero exit naming the
  definition), never a panic and never a silent no-op.
- `--json` output shape consistent with the sibling subcommands.
- Every surface that enumerates the auto-task subcommand list must stay accurate — including
  in-binary help, the README, and the auto-tasks design docs' CRUD-surfaces section.

## Acceptance criteria

- `orbit auto-task generate <name>` mints exactly one task from the named definition and reports
  its id; `--json` emits the created task.
- The generated task carries the `auto-task:<name>` provenance tag and is `system_created`;
  field-for-field template fidelity against the scheduler's mint is asserted by a test, not by
  eye.
- Generating from a **disabled** definition succeeds. Generating while an instance is already
  open under `dedupe: skip_if_open` succeeds.
- Cursor state is byte-identical before and after a `generate`, and a subsequent scheduler pass
  fires exactly as it would have if the generate had never happened — covered by a test.
- Unknown definition name exits non-zero with a message naming it.
- No new MCP tool is registered; the MCP tools-list snapshot is unchanged.
- Validated hands-on: the real CLI was run against a real definition and the minted task
  inspected, not merely unit-tested.


### Acceptance Criteria

- `orbit auto-task generate <name>` mints one task from the named definition and reports its id; --json emits the created task
- Generated task carries the auto-task:<name> provenance tag and system_created; template fidelity vs the scheduler mint asserted by test
- Generating from a disabled definition succeeds; generating while an instance is open under dedupe: skip_if_open succeeds
- Cursor state at <orbit_dir>/state/auto-tasks.json is unchanged by a generate, and a later scheduler pass fires exactly as it would have otherwise (test)
- Unknown definition name exits non-zero with a message naming the definition
- No new MCP tool registered; MCP tools-list snapshot unchanged
- Subcommand-list surfaces (in-binary help, README, auto-tasks design docs) all include generate
- Validated hands-on through the real CLI against a real definition, not only via unit tests

## Execution Summary

<details>
<summary>Click to expand</summary>

Added `orbit auto-task generate <name>` — an on-demand manual mint that produces a task indistinguishable from a scheduler fire.

## Implementation

- `crates/orbit-core/src/auto_tasks/scheduler.rs` — promoted `mint_task` from private to `pub(super)` and documented it as the single template→task mapping. No behavior change; it was already separable from due-math (it needs only the definition), so no scheduler restructuring was required.
- `crates/orbit-core/src/auto_tasks/crud.rs` — new `OrbitRuntime::auto_task_generate(name)`, on the same shared choke point as add/list/show/update/toggle. It resolves the definition via the existing `require_auto_task` (so an unknown name is an `InvalidInput` naming it) and delegates to `scheduler::mint_task`. There is no second minting implementation.
- `crates/orbit-cli/src/command/auto_task/generate.rs` (new) + `command.rs`/`mod.rs` wiring — `<name>` positional plus `--json`, matching the sibling subcommands. Plain text prints `<id> <title>`; `--json` emits the created task through `task::output::task_to_json_for_runtime`, the same projection `orbit task add --json` uses.
- `crates/orbit-cli/src/command/operation.rs` — added the `Generate` arm to the auto-task audit-metadata match (`subcommand = "generate"`, target = definition name). This file was outside the task's `context_files`; the match is exhaustive so the arm is required to compile, and L-0013 requires CLI audit metadata to track subcommand changes. Appended to `context_files`.

## Semantics (as decided)

The mint is unconditional: it ignores schedule due-math, `dedupe`, and `enabled`, and it neither reads nor writes `<orbit_dir>/state/auto-tasks.json`.

**Guard flags: implemented neither `--dry-run` nor `--force`, deliberately.** `--force` has nothing to override — the mint is already unconditional, so the flag would be a no-op that implies a gate exists. `--dry-run` would only re-render the template that `auto-task show` already prints, without the one thing a dry run is for (a due/dedupe decision preview), which `run_auto_task_scheduler --dry-run` already provides. The surface is `<name>` + `--json`. Rationale and the rejected alternatives are recorded in the design doc.

## MCP

No MCP tool added, per the mcp-bridge design's auto_task placement row (verified at `docs/design/mcp-bridge/2_design.md:330`: MCP CRUD "manages the Git-versioned definition; it does not mint tasks"). `crates/orbit-cli/tests/snapshots/mcp_tools_list.json` is unchanged (`git diff` on the snapshot dir is empty) and `mcp_roundtrip` passes.

## One intended consequence, documented

Because a generated task carries the `auto-task:<name>` provenance tag, an open generated instance IS visible to `skip_if_open` on the next scheduler pass and defers that fire — exactly as an open fired instance does. This is the flip side of provenance parity and is precisely what the hand-copy workaround could not provide (the problem statement calls a hand-copied instance's invisibility to dedupe a defect). The cursor does not advance, so the deferred occurrence fires once, collapsed, when the queue drains. Covered by `an_open_generated_instance_defers_the_next_fire_like_a_fired_one`.

## Tests — 7 new, in `crates/orbit-core/src/auto_tasks/tests/generate.rs`

- `generate_matches_a_scheduler_fire_field_for_field` — template fidelity asserted structurally: both tasks are serialized to JSON with `id`/`created_at`/`updated_at` stripped and compared whole, so a future `Task` field the mint path starts populating is covered without editing the helper. Also asserts the provenance tag, `created_by == "system"` (the `system_created` marker), and the template-supplied status.
- `generate_succeeds_for_a_disabled_definition`
- `generate_succeeds_while_an_instance_is_open_under_skip_if_open`
- `generate_leaves_the_cursor_byte_identical` — asserts generate neither creates the cursor file when absent nor changes its bytes when present.
- `generate_does_not_change_the_next_scheduler_decision` — control vs. post-generate runtime; identical action and identical consumed slot. Uses `dedupe: always` to isolate the cursor question from the provenance-tag question.
- `an_open_generated_instance_defers_the_next_fire_like_a_fired_one`
- `generate_with_an_unknown_name_errors_naming_the_definition`

## Hands-on validation (real CLI, real definition)

Built the binary, `orbit init`'d a scratch workspace, copied the repo's real `artifact-deprecation-review.yaml` into it, and drove the real CLI:

- `auto-task --help` lists `generate` in-binary.
- `auto-task generate artifact-deprecation-review` → `ORB-00000`; `task show --json` confirmed `tags` include `auto-task:artifact-deprecation-review` alongside the template's own tags, `created_by: system`, `status: backlog`, `crew: sol`, 4 acceptance criteria, full 4053-char template body.
- Unknown name → `error: invalid input: no such auto-task 'does-not-exist'`, exit 1.
- After `toggle off`, generate still succeeded (ORB-00001); generating again with an open instance under `skip_if_open` succeeded (ORB-00002, `--json` emitted the created task).
- Cursor: absent before and after generate on a fresh workspace. Then ran the real `auto_task_scheduler_pipeline` job (baselined, wrote the cursor), took a sha256, ran generate (ORB-00003), re-hashed — byte-identical.

Scratch workspace removed afterward; no tasks were minted into a real workspace store.

## Docs

- `README.md` — feature bullet now names `generate`.
- `docs/design/auto-tasks/1_overview.md` — new "Manual mint" core concept, At-a-Glance row, task reference; `last_updated` bumped.
- `docs/design/auto-tasks/2_design.md` — new §5b covering the surface, the unconditional/cursor-inert semantics, four explicitly rejected alternatives (a generate-local mint implementation; honoring enabled/dedupe/due-math; advancing the cursor; the guard flags), the dedupe-visibility consequence, and the CLI-only/no-MCP boundary; `last_updated` and `related_artifacts` bumped.

No ADR was minted: the semantics were pre-decided by the human on 2026-07-26 and this extends ADR-0218's existing "full CRUD via CLI and MCP" decision rather than reversing it, so the rejected alternatives are recorded in the design doc instead. ADR tooling is also outside this activity's allowlist.

## Validation run

- `make ci-fast` — passes (required `cargo fmt --all` first).
- `cargo test -p orbit-core auto_tasks` — 29 passed, 0 failed.
- `cargo test -p orbit-cli` — 331 passed across 12 binaries, 0 failed (includes `mcp_roundtrip`'s tools-list snapshot and the root-help section assertions).

No new dependencies, no new cross-crate dependency edges, no `#[allow(...)]` suppressions.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10439-6a664eba`
- Behind base: 0
- Ahead of base: 1