### PR TITLE
Add a daily friction-curation auto-task definition (runtime crew sol)

### DIFF
--- a/.orbit/auto_tasks/friction-curation.yaml
+++ b/.orbit/auto_tasks/friction-curation.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+name: friction-curation
+description: Daily evidence-first deduplication, verification, resolution, and task filing for open friction records
+enabled: true
+schedule:
+  cron: 15 7 * * *
+template:
+  title: Curate open friction records
+  description: |-
+    Curate the complete open-friction corpus in this workspace. The durable output is friction status changes and fix tasks; the execution summary is only an audit trail.
+
+    ## Rules and command surfaces
+
+    - Never edit `.orbit/frictions/**` by hand. Status and body changes must go through the operator CLI: `orbit friction update <id> ...` and `orbit friction resolve <id> --json`, so resolution metadata is stamped by the store.
+    - Frictions are not indexed by `orbit search`. List them with `orbit friction list --status open --limit 500 --offset <n> --json`; keep paging until a page is shorter than the limit. Use `--q '<terms>'` plus `--status open` to retrieve likely matches when grouping candidates. Do not infer an empty corpus from `orbit search`.
+    - Search task coverage with `orbit search '<distinctive symptom or component terms>' --kind task --all --json`, then inspect plausible matches with `orbit task show <id> --json`.
+    - Create tasks only through `orbit tool run orbit.task.add --input '<json>'`, including `model`, the current workspace path, evidence/reproduction, appropriate context selectors, tag `friction-curation`, and relation `{"type":"resolves","target":"<friction-id>"}`. A filed task does not itself fix the friction: leave that friction open. The relation will resolve it only when the task reaches done.
+    - Fail open. Zero open frictions or a fully current corpus is a successful no-op. When evidence is genuinely ambiguous, leave the friction open and report what remains unknown.
+
+    ## Pass
+
+    1. Snapshot every open friction using the paginated list command above.
+    2. Dedupe by underlying issue, not wording. For each group, retain the earliest well-evidenced record as canonical unless a later record materially improves the reproduction. Preserve each duplicate's existing body, append a short resolution note naming the canonical friction id and the matching evidence, then run the CLI update/resolve path. Re-query the group with `orbit friction list --status open --q '<terms>' --json` to confirm only the canonical record remains open.
+    3. Verify every surviving open friction against the current tree and current executable behavior. Cite exact files/lines, command output, tests, run ids, or version state. If it no longer reproduces, preserve the body, append the checked evidence and resolution reason, and resolve it through the CLI. If it is still real, retain it open with the evidence gathered for task filing. Do not guess.
+    4. For every verified-real survivor, search existing tasks using the task search/show commands above. If an existing task clearly covers it, do not file a duplicate; record the covering task id in the audit summary. Otherwise create exactly one fix task through `orbit.task.add`, with reproduction evidence and a `resolves:<friction-id>` relation as described above. Never resolve a friction merely because its fix task was filed.
+    5. Repeat the same friction queries and coverage checks before finishing. The repeat pass must produce no further status changes and no duplicate tasks. Record counts and every canonical/resolved/verified/covered/created id in this task's persisted `execution_summary`.
+  acceptance_criteria:
+  - Every open friction was deduplicated and evidence-checked against the current tree or behavior; ambiguous records remained open.
+  - Every resolved duplicate names its canonical friction id, and every no-longer-reproducing resolution records the evidence and reason through the CLI/store surface.
+  - Every verified-real friction is covered by exactly one existing or newly filed Orbit task; new tasks carry reproduction evidence and a resolves relation without prematurely resolving the friction.
+  - A repeat pass makes no status changes and files no duplicate tasks; an empty or already-curated corpus succeeds as a no-op.
+  task_type: chore
+  tags:
+  - friction-curation
+  - no-diff-expected
+  priority: medium
+  crew: sol
+  status: backlog
+dedupe: skip_if_open
+created_by: human
+created_at: 2026-07-26T18:34:51.768896096+00:00
+updated_by: human
+updated_at: 2026-07-26T18:34:51.768896096+00:00

--- a/docs/design/auto-tasks/1_overview.md
+++ b/docs/design/auto-tasks/1_overview.md
@@ -79,6 +79,10 @@ becomes just the first definition.
   and resolved against their registries) via `execution_summary`; never
   mutates learnings, ADRs, tasks, friction records, or comments (ORB-10318,
   ORB-10348, [project-learnings §7.6](../project-learnings/2_design.md#76-recurring-deprecation-review-auto-task)).
+- `friction-curation` — daily evidence-first pass that deduplicates open
+  friction records, re-verifies survivors against current behavior, resolves
+  records that no longer reproduce, and files non-duplicate fix tasks for
+  verified-real issues (ORB-10440).
 
 ## Task References
 
@@ -87,5 +91,6 @@ becomes just the first definition.
 - ORB-10318 — learning-deprecation-review definition (report-only stale-learning review; superseded by ORB-10348).
 - ORB-10348 — Generalized the definition into artifact-deprecation-review, adding the comment-reference sweep.
 - ORB-10439 — `orbit auto-task generate <name>`, the on-demand manual mint.
+- ORB-10440 — Daily friction-curation definition.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10440](https://orbit-cli.com/tasks/ORB-10440) — Add a daily friction-curation auto-task definition (runtime crew sol)

### Description

## Problem

Open friction records accumulate with no recurring curation. Nothing dedupes them, nothing
re-checks whether a reported issue still reproduces after intervening changes, and nothing
converts a real friction into an Orbit task that would actually fix it. The corpus therefore
rots in both directions: duplicates inflate it, and records that were fixed weeks ago still read
as open, which makes the whole set untrustworthy as a signal.

Add a checked-in auto-task **definition** that runs daily and performs a full curation pass over
open frictions. This is a data + docs change — a new `.orbit/auto_tasks/<name>.yaml` record plus
the docs that enumerate shipped definitions. It should require no orbit source change; if it
turns out to, stop and report rather than expanding scope.

**Runtime crew is `sol`** — i.e. `template.crew: sol` in the definition. That is the crew of the
task this definition mints daily, and is separate from whichever crew implements *this* task.

## What a pass must accomplish

Stated as outcomes; the mandate wording is the deliverable.

1. **Dedupe** — find open frictions describing the same underlying issue. Keep one canonical
   record, resolve the rest, and name the canonical id in each resolved record so the trail
   survives.
2. **Verify** — for each surviving open friction, establish from the current tree and current
   behavior whether the issue is still real and still present. Evidence-first: "still broken" or
   "already fixed" must cite what was actually checked.
3. **Close out** — frictions that no longer reproduce get resolved, with the reason recorded in
   the record. Genuinely ambiguous ones stay open rather than being guessed at in either
   direction.
4. **File the fix** — each verified-real friction not already covered by an existing task gets
   an Orbit task created to address it, in the correct workspace, carrying the reproduction
   evidence gathered in step 2.

## Constraints

- **Friction states are `open | triaged | resolved`** (`FrictionStatus`,
  `crates/orbit-common/src/types/friction.rs`). There is no "closed" state — do not invent one,
  and do not have the mandate ask for one.
- **Authority (decided, Daniel 2026-07-26):** `orbit.friction.update` is operator-only and is
  **not** in the agent MCP toolset — an executor cannot flip friction status over MCP. The
  mandate directs status changes through the on-box CLI (`orbit friction update` /
  `orbit friction resolve`), which is not MCP-gated. Do **not** widen MCP exposure as part of
  this task.
- **Frictions are not in the search index.** `orbit.search`/`orbit_search` has no friction kind
  and rejects one. Dedupe and lookup must go through `orbit.friction.list`'s free-text `q` and
  its filters. A mandate that tells the executor to search frictions via `orbit_search` will
  silently find nothing and the pass will report a clean corpus that isn't.
- **Task↔friction linkage is task-side.** A task carrying a `resolves:<friction-id>` relation
  auto-resolves the friction through the existing relation side-effect path. Prefer that over
  hand-resolving a friction at the moment its fix task is merely *filed* — a filed fix is not a
  resolved friction.
- **Durable side effects only.** The friction status changes and the tasks created are the real
  output; the narrative summary is advisory. Nothing — no job, activity, or downstream decision —
  may depend on the agent-loop text.
- `dedupe: skip_if_open`, so a backed-up queue does not stack instances.
- **Fail open.** Zero open frictions, or a corpus where nothing is stale, is a valid
  "nothing to do" result, not an error.
- **Idempotent across days.** A second pass over an already-curated corpus makes no status
  changes and files no duplicate tasks. The mandate must make the executor check for existing
  coverage before filing.
- Tag the minted task so its instances are findable, and include `no-diff-expected` — a correct
  run's effects are entirely friction- and task-side, and workflow handoff must not fail for
  want of a diff.
- Never hand-edit or delete friction files on disk; go through the CLI/store so frontmatter
  stamping (`resolved_at`, `resolved_by_task`) stays correct.
- Write the definition through the supported write surface so schedule and crew are validated at
  write time, rather than dropping unvalidated YAML into the directory.

## Acceptance criteria

- New definition exists under `.orbit/auto_tasks/`, parses fail-closed, has file stem == `name`,
  and appears in `orbit auto-task list`.
- Schedule is a daily cron; `template.crew` is `sol`; `dedupe: skip_if_open`; template status is
  `backlog`.
- Validated by minting an instance and walking the mandate end-to-end: every command it names
  exists and works from the executor's environment — in particular that a friction status change
  actually succeeds via the CLI path, and that the friction lookups it prescribes really do
  return records.
- The mandate is demonstrably executable against the real open-friction corpus: at least one
  dedupe-or-verify judgement was reached with cited evidence during validation.
- A repeat pass over the curated corpus produces no changes and no duplicate tasks.
- The auto-tasks docs' "Definitions shipped in this repo" list documents it.
- No orbit source code changed.


### Acceptance Criteria

- New definition under .orbit/auto_tasks/ parses fail-closed, file stem == name, and appears in `orbit auto-task list`
- Schedule is a daily cron; template.crew is sol; dedupe: skip_if_open; template status backlog
- Mandate validated end-to-end by minting an instance: every command it names works from the executor's environment, including a real friction status change via the CLI path
- At least one dedupe-or-verify judgement reached with cited evidence against the real open-friction corpus during validation
- A repeat pass over an already-curated corpus makes no status changes and files no duplicate tasks
- Minted task is tagged for findability and carries no-diff-expected so workflow handoff succeeds with task/friction-only side effects
- auto-tasks docs 'Definitions shipped in this repo' list documents the new definition
- No orbit source code changed

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `.orbit/auto_tasks/friction-curation.yaml` through the validated auto-task write surface. The daily definition uses cron `15 7 * * *`, `dedupe: skip_if_open`, runtime crew `sol`, backlog status, and `friction-curation` plus `no-diff-expected` tags. Its mandate paginates the real friction corpus through friction list/query commands, deduplicates with canonical-id trails, verifies current behavior evidence-first, resolves only through the operator CLI/store, checks task coverage, files relation-backed fix tasks, fails open, and requires an idempotent repeat pass.
- Documented `friction-curation` in the auto-task overview's shipped-definitions list and task references. No Orbit source code changed.
- Minted canonical validation instance ORB-10447; it is backlog, crew `sol`, and carries `auto-task:friction-curation`, `friction-curation`, and `no-diff-expected`. Persisted its end-to-end curation audit summary.
- Validated against the real corpus: retained F2026-07-099 as the canonical MCP workspace-routing issue; appended canonical evidence and resolved duplicate records F2026-07-137, F2026-07-145, and F2026-07-149 through `orbit friction update` plus `orbit friction resolve`, confirming stamped `resolved_at` values. Hybrid task search found no current fix covering the live integration failure, so ORB-10448 was filed with evidence and a `resolves:F2026-07-099` relation; F2026-07-099 remains open until that task reaches done.
- Repeated the focused open-friction and task-coverage pass twice. The friction snapshots matched at SHA-256 `a04dd2afbd12d479b785840e279ed17b0808965605cf64c1077128f3acbee717`; task snapshots matched at `64534f17e5abcf9bd91104bb9cff427695ee1a37e660cdb3944c1eb14af7a6e8`. No second-pass status change or duplicate task was produced.

Validation:
- `orbit auto-task --root <worktree>/.orbit list/show --json`: definition parses and is listed; file stem equals `name`; schedule, crew, status, tags, and dedupe match the task.
- Current workspace CLI manual generate: canonical ORB-10447 minted successfully. Every command named by the mandate was exercised successfully, including real friction update/resolve and `orbit tool run orbit.task.add`.
- `make ci-fast`: passed.
- `git diff --check`: passed; final scope is the new definition plus the auto-task overview only.

Deviations from original plan:
- The installed Orbit binary predates manual generate, so validation used the already-built current workspace CLI. Because linked-worktree auto-task definitions resolve through the shared root while the checked-in file must live in the worktree, the definition was temporarily created through the supported surface in the shared root solely for the canonical mint and then removed; the retained definition is worktree-local. An initial isolated-root mint allocated ORB-00000 and was archived; ORB-10447 is the sole canonical open validation instance.

Assessment: The data/docs-only change satisfies the scoped acceptance criteria, and the real-corpus validation demonstrates executable status mutation, evidence-backed dedupe/verification, fix-task linkage, findability, and repeat-pass idempotency without source changes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10440-6a665267`
- Behind base: 0
- Ahead of base: 1