### PR TITLE
Prefix auto-task-minted task titles with `[auto-task] ` at mint time

### DIFF
--- a/crates/orbit-core/src/auto_tasks/scheduler.rs
+++ b/crates/orbit-core/src/auto_tasks/scheduler.rs
@@ -28,6 +28,9 @@ use super::loader::{AutoTaskLoadError, collect_auto_tasks};
 use super::schedule::{AutoTaskDueDecision, decide_due};
 use super::state::{AutoTaskCursor, cursor_state_path, load_cursor_state, upsert_cursor};
 
+/// Visible provenance stamped onto every task minted from an auto-task template.
+const AUTO_TASK_TITLE_PREFIX: &str = "[auto-task] ";
+
 /// Per-definition outcome of one scheduler pass.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AutoTaskFireReport {
@@ -208,7 +211,7 @@ pub(super) fn mint_task(
     tags.push(auto_task_tag(&definition.name));
 
     runtime.add_task(TaskAddParams {
-        title: template.title.clone(),
+        title: minted_title(&template.title),
         description: template.description.clone(),
         acceptance_criteria: template.acceptance_criteria.clone(),
         tags,
@@ -219,6 +222,17 @@ pub(super) fn mint_task(
         system_created: true,
         ..TaskAddParams::default()
     })
+}
+
+/// Stamp the human-visible auto-task provenance without changing templates that
+/// already carry it. Keeping this beside the template-to-task mapping makes
+/// every mint entry point follow the same convention.
+fn minted_title(template_title: &str) -> String {
+    if template_title.starts_with(AUTO_TASK_TITLE_PREFIX) {
+        template_title.to_string()
+    } else {
+        format!("{AUTO_TASK_TITLE_PREFIX}{template_title}")
+    }
 }
 
 /// Run one scheduler pass now and project it to the deterministic-action JSON

--- a/crates/orbit-core/src/auto_tasks/tests/mint.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/mint.rs
@@ -93,6 +93,36 @@ fn mint_matches_a_scheduler_fire_field_for_field() {
 }
 
 #[test]
+fn title_prefix_is_applied_once_for_scheduler_and_manual_mint() {
+    for (template_title, expected_title) in [
+        (
+            "Chore from a clean template",
+            "[auto-task] Chore from a clean template",
+        ),
+        (
+            "[auto-task] Chore from an already-prefixed template",
+            "[auto-task] Chore from an already-prefixed template",
+        ),
+    ] {
+        let runtime = runtime();
+        let mut params = interval_params("chore", 60);
+        params.template.title = template_title.to_string();
+        runtime.auto_task_add(params).expect("add");
+        let t0 = at(2026, 1, 1, 0, 0);
+
+        fire(&runtime, t0); // baseline
+        let reports = fire(&runtime, t0 + Duration::minutes(65));
+        let scheduler_task = runtime
+            .get_task(&reports[0].1.clone().expect("scheduler task id"))
+            .expect("scheduler task");
+        let minted_task = runtime.auto_task_mint("chore").expect("manual mint");
+
+        assert_eq!(scheduler_task.title, expected_title);
+        assert_eq!(minted_task.title, expected_title);
+    }
+}
+
+#[test]
 fn mint_succeeds_for_a_disabled_definition() {
     let runtime = runtime();
     runtime

--- a/docs/design/auto-tasks/2_design.md
+++ b/docs/design/auto-tasks/2_design.md
@@ -10,7 +10,7 @@ summary: Current implementation of the auto-task record, due-math, host-local cu
 tags: [auto-tasks]
 paths: ["crates/orbit-core/src/auto_tasks/**"]
 related_features: [auto-tasks]
-related_artifacts: [ORB-10149, ORB-10439, ORB-10446, ADR-0218, ADR-0217]
+related_artifacts: [ORB-10149, ORB-10439, ORB-10441, ORB-10446, ADR-0218, ADR-0217]
 ---
 
 # Auto-tasks — Design
@@ -63,7 +63,10 @@ fires nothing; otherwise it evaluates due-math. On `Fire`, if `dedupe =
 skip_if_open` and a task tagged `auto-task:<name>` is still open, it skips
 **without advancing the cursor** — so the pending occurrence fires (once,
 collapsed) the moment the queue drains. Otherwise it mints a `system_created`
-task from the template (tagged for provenance) and advances the cursor.
+task from the template (tagged for provenance) and advances the cursor. Every
+minted title is `[auto-task] ` followed by the template title; the prefix is
+applied at the shared template-to-task mapping, so definition YAML titles stay
+clean and an already-prefixed template is not double-prefixed.
 
 The pass is the deterministic `run_auto_task_scheduler` action
 (`dispatch.rs`), wrapped in `auto_task_scheduler_pipeline` (`max_active_runs:
@@ -87,8 +90,9 @@ definitions otherwise cost a week per typo). It lives on `crud.rs` alongside the
 other verbs and delegates to `scheduler::mint_task` — the scheduler's mint path
 is already separable from due-math (it needs only the definition), so there is
 exactly one template→task mapping and a manually minted task is field-for-field
-identical to a fired one: same field mapping, same `auto-task:<name>` tag, same
-`system_created` marker, same template-supplied status.
+identical to a fired one: same field mapping, same `[auto-task] ` title
+convention, same `auto-task:<name>` tag, same `system_created` marker, same
+template-supplied status.
 
 The mint is **unconditional**. It ignores schedule due-math, `dedupe`, and
 `enabled`, and it neither reads nor writes the host-local cursor — an operator
@@ -143,5 +147,6 @@ validation correctly produces only task-side effects.
 
 - ORB-10149 — Auto-task primitive.
 - ORB-10439 — on-demand manual mint (renamed to `orbit auto-task mint <name>` by ORB-10446).
+- ORB-10441 — mint-time visible title provenance.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10441](https://orbit-cli.com/tasks/ORB-10441) — Prefix auto-task-minted task titles with `[auto-task] ` at mint time

### Description

## Problem

A task minted by the auto-task scheduler is visually indistinguishable from a hand-filed task in
`orbit task list`, on the dashboard, and in triage. The provenance exists — the
`auto-task:<name>` tag — but a tag is not visible in the surfaces where triage actually happens,
so recurring machine chores read as if a person filed them.

Establish the convention that every auto-task-minted title begins with `[auto-task] `.

## Decided approach (Daniel, 2026-07-26)

Enforce **at mint time, in code** — not by hand-editing template titles in the definition YAML.
The prefix is applied when the task is minted; `template.title` in each definition stays clean.
Rationale: the convention then holds for every future definition automatically, including ones
authored by someone who never read this task.

## Constraints

- The prefix string is exactly `[auto-task] ` — square brackets, lowercase, one trailing space,
  matching the `auto-task:<name>` tag vocabulary.
- **Idempotent.** A template title that already starts with the prefix must not be
  double-prefixed.
- **Exactly one choke point.** Applied wherever the template→task mapping lives, so every mint
  path inherits it. ORB-10439 adds a second mint entry point (`orbit auto-task generate`); once
  both have landed there must be exactly one place in the codebase where the prefix is applied.
- **Do not break downstream title consumers.** Commit-message templating derives a commit
  subject from the task title, with truncation. Confirm a prefixed title still yields a sane
  subject and that the prefix does not push the meaningful part of the title out of the
  truncation window. If it does, report it — do not quietly change commit templating to
  compensate.
- Shipped definition template titles are **not** edited to include the prefix. That is the point
  of enforcing at mint.
- **No retroactive retitle.** Existing minted tasks, open or closed, are left alone. No migration.

## Acceptance criteria

- A scheduler-minted task's title is `[auto-task] ` followed by the template title verbatim.
- A template title that already carries the prefix mints unchanged — no double prefix (test).
- The prefix is applied in exactly one location, and a test covers both the scheduler path and
  the `generate` path (ORB-10439) so a future third mint path cannot quietly skip it.
- Shipped definition YAML `template.title` values are unchanged.
- Commit-subject derivation from a prefixed title was verified on a real minted task, by
  inspecting an actual commit subject rather than by reasoning.
- Docs describing minted-task shape / auto-task provenance state the title convention.
- No existing task was retitled.


### Acceptance Criteria

- A scheduler-minted task's title is `[auto-task] ` followed by the template title verbatim
- A template title already carrying the prefix mints unchanged — no double prefix (test)
- Prefix applied in exactly one location; a test covers both the scheduler path and the generate path (ORB-10439)
- Shipped definition YAML template.title values unchanged
- Commit-subject derivation from a prefixed title verified on a real minted task's actual commit subject
- Docs describing minted-task shape / auto-task provenance state the title convention
- No existing task retitled; no migration

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added the exact `[auto-task] ` title convention at `scheduler::mint_task`, the sole template-to-task mapping used by scheduler fires and `orbit auto-task mint` (the ORB-10439 path, renamed by ORB-10446). Prefixing is idempotent.
- Added focused coverage that exercises both scheduler and manual-mint paths for clean and already-prefixed template titles.
- Documented the visible title provenance and retained clean definition YAML titles.

Assessment: Scoped change with no new dependencies or cross-crate edges. No existing task was retitled; shipped definition YAML files are unchanged.

Validation:
- `cargo test -p orbit-core auto_tasks` — 30 passed.
- `make ci-fast` — passed.
- `git diff --check` — passed.
- Real temporary workspace: minted `ORB-90000` from the shipped `friction-curation` definition. Its title was `[auto-task] Curate open friction records`; the real `git_commit` action created and `git log` confirmed subject `chore: [auto-task] Curate open friction records [ORB-90000]`, preserving the meaningful title within the subject budget. Temporary workspace and probe files were removed afterward.

Friction checkpoint: no qualifying tooling or workflow friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10441-6a6656c9`
- Behind base: 0
- Ahead of base: 1