### PR TITLE
Fix executor MCP workspace routing for task and search tools

### DIFF
--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -767,3 +767,199 @@ fn mcp_registered_calls_are_audited_but_removed_graph_names_are_not_dispatched()
     let rows: Value = serde_json::from_slice(&output.stdout).expect("parse graph audit rows");
     assert_eq!(rows, json!([]));
 }
+
+/// ORB-10448 / F2026-07-099: the managed-executor shape.
+///
+/// An activity runs from a linked Git worktree and reaches Orbit through a
+/// general-purpose MCP client, which cannot announce `_meta.orbit.workspace`
+/// at initialize. Two things had to hold for that to work and neither did:
+/// the workspace selector must be advertised so a schema-following caller can
+/// supply it, and the selector must route coordination reads to the partition
+/// the checkout-local surfaces use, even for a workspace whose logical
+/// registry ID and checkout identity diverged before `orbit workspace init`
+/// converged them (L-0098).
+#[test]
+fn worktree_backed_activity_routes_task_and_search_by_advertised_workspace_argument() {
+    let workspace = McpWorkspace::init();
+
+    // Diverge the logical registry ID from the checkout identity that keys the
+    // coordination task registry. This is the production shape the friction was
+    // filed from; a freshly initialized workspace writes both from one value.
+    let registry_path = workspace.home.join(".orbit").join("workspaces.json");
+    let registry = std::fs::read_to_string(&registry_path).expect("read workspace registry");
+    std::fs::write(
+        &registry_path,
+        registry.replace("ws_mcp-roundtrip", "ws_legacy-logical"),
+    )
+    .expect("write diverged workspace registry");
+    let identity =
+        std::fs::read_to_string(workspace.work.join(".orbit").join("config.yaml")).expect("read");
+    assert!(
+        identity.contains("ws_mcp-roundtrip"),
+        "checkout identity must keep the pre-divergence ID: {identity}"
+    );
+
+    // A task authored through the checkout-local CLI surface. Before the fix,
+    // MCP looked for it under the logical ID and found an empty partition.
+    let add_input = json!({
+        "title": "Worktree routing regression",
+        "description": "Authored via the CLI fallback",
+        "workspace": workspace.work.to_str().expect("utf8 checkout path"),
+        "model": "codex",
+    })
+    .to_string();
+    let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args(["tool", "run", "orbit.task.add", "--input", &add_input])
+        .output()
+        .expect("author task through the CLI fallback");
+    assert!(
+        output.status.success(),
+        "CLI task add failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let created: Value = serde_json::from_slice(&output.stdout).expect("parse created task");
+    let task_id = created["id"].as_str().expect("task id").to_string();
+
+    let worktree = add_linked_worktree(&workspace.work);
+
+    // The executor's client: no `_meta.orbit.workspace`, cwd inside the linked
+    // worktree.
+    let child = McpWorkspace::orbit_command(&worktree, &workspace.home)
+        .args(["mcp", "serve"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn worktree-backed MCP server");
+    let mut client = McpClient::new(child);
+    client.request(
+        "initialize",
+        json!({
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": { "name": "managed-executor", "version": "0" }
+        }),
+    );
+    client.notify("notifications/initialized");
+
+    // Every workspace-scoped tool must advertise the selector it requires.
+    let listed = client.request("tools/list", Value::Null);
+    let unadvertised = listed["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .filter(|tool| tool["inputSchema"]["properties"]["workspace"].is_null())
+        .filter_map(|tool| tool["name"].as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        unadvertised.is_empty(),
+        "workspace-scoped tools require a selector they do not advertise: {unadvertised:?}"
+    );
+
+    let selector = worktree.to_str().expect("utf8 worktree path");
+    for workspace_selector in [selector, "ws_legacy-logical"] {
+        let shown = client.call_tool_ok(
+            "orbit_task_show",
+            json!({ "id": task_id, "workspace": workspace_selector }),
+        );
+        assert_eq!(
+            shown["id"],
+            json!(task_id),
+            "task show must resolve through selector `{workspace_selector}`"
+        );
+        assert_eq!(shown["title"], "Worktree routing regression");
+    }
+
+    let updated = client.call_tool_ok(
+        "orbit_task_update",
+        json!({
+            "id": task_id,
+            "execution_summary": "Routed from a linked worktree",
+            "workspace": selector,
+            "model": "codex",
+        }),
+    );
+    assert_eq!(
+        updated["execution_summary"],
+        "Routed from a linked worktree"
+    );
+
+    let found = client.call_tool_ok(
+        "orbit_search",
+        json!({ "query": "Worktree routing regression", "workspace": selector }),
+    );
+    assert!(
+        found["results"]
+            .as_array()
+            .expect("search results")
+            .iter()
+            .any(|hit| hit["id"] == json!(task_id)),
+        "search must reach the same workspace from the worktree: {found}"
+    );
+    drop(client);
+
+    // The `orbit tool run` fallback stays functional from the worktree, and it
+    // observes the write MCP just made — both surfaces address one partition.
+    let output = McpWorkspace::orbit_command(&worktree, &workspace.home)
+        .args([
+            "tool",
+            "run",
+            "orbit.task.show",
+            "--input",
+            &format!(r#"{{"id":"{task_id}"}}"#),
+            "--fields",
+            "id,execution_summary",
+        ])
+        .output()
+        .expect("run the CLI fallback from the worktree");
+    assert!(
+        output.status.success(),
+        "CLI fallback failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let shown: Value = serde_json::from_slice(&output.stdout).expect("parse CLI task show");
+    assert_eq!(shown["id"], json!(task_id));
+    assert_eq!(shown["execution_summary"], "Routed from a linked worktree");
+}
+
+/// Commit the checkout and attach a linked worktree, mirroring how the engine
+/// stages a managed run.
+fn add_linked_worktree(work: &Path) -> PathBuf {
+    let commit = Command::new("git")
+        .args([
+            "-c",
+            "user.email=mcp-roundtrip@orbit.test",
+            "-c",
+            "user.name=mcp-roundtrip",
+            "commit",
+            "--quiet",
+            "--allow-empty",
+            "-m",
+            "worktree fixture base",
+        ])
+        .current_dir(work)
+        .output()
+        .expect("commit worktree base");
+    assert!(commit.status.success(), "git commit failed: {commit:?}");
+
+    let worktree = work
+        .parent()
+        .expect("checkout parent")
+        .join("linked-worktree");
+    let added = Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "--quiet",
+            "-b",
+            "orbit/worktree-fixture",
+            worktree.to_str().expect("utf8 worktree path"),
+        ])
+        .current_dir(work)
+        .output()
+        .expect("attach linked worktree");
+    assert!(added.status.success(), "git worktree add failed: {added:?}");
+    worktree
+}

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -81,6 +81,10 @@
         "title": {
           "description": "ADR title (short noun phrase).",
           "type": "string"
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
+          "type": "string"
         }
       },
       "required": [
@@ -102,6 +106,10 @@
         },
         "legacy_id": {
           "description": "Legacy ID alias (e.g. `activity-job/ADR-039`). Either `id` or `legacy_id` must be provided; specifying both is an error.",
+          "type": "string"
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
           "type": "string"
         }
       },
@@ -130,6 +138,10 @@
         },
         "old_id": {
           "description": "ADR being superseded.",
+          "type": "string"
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
           "type": "string"
         }
       },
@@ -277,6 +289,10 @@
             }
           ],
           "description": "Replacement validation_warnings list."
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
+          "type": "string"
         }
       },
       "required": [
@@ -330,6 +346,10 @@
             }
           ],
           "description": "Task template: `{ title, description?, acceptance_criteria?, task_type?, tags?, priority?, crew?, status? }`. Provider-neutral — no turn knobs. Required."
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
+          "type": "string"
         }
       },
       "required": [
@@ -348,6 +368,10 @@
       "properties": {
         "name": {
           "description": "Definition name. Required.",
+          "type": "string"
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
           "type": "string"
         }
       },
@@ -369,6 +393,10 @@
         },
         "name": {
           "description": "Definition name. Required.",
+          "type": "string"
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
           "type": "string"
         }
       },
@@ -424,6 +452,10 @@
             }
           ],
           "description": "Replacement task template object."
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
+          "type": "string"
         }
       },
       "required": [
@@ -483,6 +515,10 @@
             }
           ],
           "description": "Friction taxonomy tags as a string or array; valid tags: build | docs | lifecycle | naming | other | policy | skill-guidance | tooling; defaults to other"
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
+          "type": "string"
         }
       },
       "required": [
@@ -497,7 +533,12 @@
     "description": "List configured friction taxonomy tags",
     "inputSchema": {
       "additionalProperties": true,
-      "properties": {},
+      "properties": {
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
+          "type": "string"
+        }
+      },
       "type": "object"
     },
     "name": "orbit_friction_tags"
@@ -556,6 +597,10 @@
         "summary": {
           "description": "One-line headline (≤ 280 chars). Required.",
           "type": "string"
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
+          "type": "string"
         }
       },
       "required": [
@@ -573,6 +618,10 @@
       "properties": {
         "id": {
           "description": "learning ID",
+          "type": "string"
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
           "type": "string"
         }
       },
@@ -594,6 +643,10 @@
         },
         "with": {
           "description": "ID of the replacement learning. Must differ from `id`. Both records must exist.",
+          "type": "string"
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
           "type": "string"
         }
       },
@@ -652,6 +705,10 @@
         },
         "summary": {
           "description": "Replace `summary` (≤ 280 chars).",
+          "type": "string"
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
           "type": "string"
         }
       },
@@ -732,6 +789,10 @@
             }
           ],
           "description": "AND-filter by tag. Repeat or pass an array. Applies to task, doc, learning, and ADR."
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
+          "type": "string"
         }
       },
       "type": "object"
@@ -877,6 +938,10 @@
         "note": {
           "description": "Optional approval note",
           "type": "string"
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
+          "type": "string"
         }
       },
       "required": [
@@ -911,6 +976,10 @@
         },
         "source_path": {
           "description": "Source file to store as a task artifact.",
+          "type": "string"
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
           "type": "string"
         }
       },
@@ -992,6 +1061,10 @@
         "type": {
           "description": "Optional task type filter",
           "type": "string"
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
+          "type": "string"
         }
       },
       "type": "object"
@@ -1046,6 +1119,10 @@
         "with_context": {
           "description": "Optional boolean. When true, include a `related_docs` array matched from task context selectors and feature tags.",
           "type": "boolean"
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
+          "type": "string"
         }
       },
       "required": [
@@ -1084,6 +1161,10 @@
         },
         "note": {
           "description": "Optional lifecycle note for the start transition",
+          "type": "string"
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
           "type": "string"
         }
       },
@@ -1247,6 +1328,10 @@
             "refactor",
             "chore"
           ],
+          "type": "string"
+        },
+        "workspace": {
+          "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
           "type": "string"
         }
       },

--- a/crates/orbit-core/src/runtime/orbit_tool_host/host.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/host.rs
@@ -95,12 +95,38 @@ impl HubCoordinationExecutor {
         legacy_friction_root: Option<PathBuf>,
     ) -> Result<Self, OrbitError> {
         let workspace_id = workspace_id.into();
+        let task_partition_id = workspace_id.clone();
+        Self::new_with_task_partition(
+            global_root,
+            workspace_id,
+            task_partition_id,
+            legacy_friction_root,
+        )
+    }
+
+    /// Same as [`HubCoordinationExecutor::new`], but pins the coordination task
+    /// registry to an explicit partition key.
+    ///
+    /// `orbit workspace init` writes one ID to the host registry, the checkout
+    /// identity, and the task registry, so the two keys normally coincide. For
+    /// workspaces registered before that convergence they differ (L-0098), and
+    /// the task registry only answers to the checkout-identity key. A caller
+    /// that has resolved a validated local checkout passes that key here so
+    /// coordination reads and writes land in the partition the checkout-local
+    /// surfaces already use; `workspace_id` stays the logical ID that owns
+    /// friction partitioning and audit identity.
+    pub fn new_with_task_partition(
+        global_root: &Path,
+        workspace_id: impl Into<String>,
+        task_partition_id: impl Into<String>,
+        legacy_friction_root: Option<PathBuf>,
+    ) -> Result<Self, OrbitError> {
         let registry = TaskRegistryStore::open(&task_registry_path(global_root))?;
-        let tasks = coordination_task_backends(registry, workspace_id.clone());
+        let tasks = coordination_task_backends(registry, task_partition_id.into());
         Ok(Self {
             inner: Arc::new(HubCoordinationState {
                 global_root: global_root.to_path_buf(),
-                workspace_id,
+                workspace_id: workspace_id.into(),
                 legacy_friction_root,
                 tasks,
             }),

--- a/crates/orbit-mcp/src/adapter/dispatch.rs
+++ b/crates/orbit-mcp/src/adapter/dispatch.rs
@@ -16,7 +16,7 @@ use serde_json::{Map, Value};
 
 use super::OrbitToolServer;
 use super::name_map::{ToolNameCollision, build_name_map};
-use super::schema::schema_to_tool;
+use super::schema::{ensure_workspace_selector, schema_to_tool};
 use super::structured::mcp_structured_content;
 use crate::error::tool_error_result;
 use crate::{McpCustomRequestError, McpRequestKind, McpResultDecoration, McpToolExtension};
@@ -109,15 +109,23 @@ impl OrbitToolServer {
             .collect())
     }
 
+    /// Resolve the advertised wire input schema for one canonical definition.
+    ///
+    /// Whoever owns the schema — the host resolver or an in-process extension —
+    /// the broker's workspace routing contract is the adapter's to advertise,
+    /// so the selector is injected here rather than duplicated in every
+    /// resolver.
     pub(super) fn input_schema_for(
         &self,
         definition: &McpToolDefinition,
     ) -> Result<Map<String, Value>, OrbitError> {
-        if let Some(extension) = self.extension_for(&definition.schema.name)? {
-            extension.input_schema(definition)
+        let mut schema = if let Some(extension) = self.extension_for(&definition.schema.name)? {
+            extension.input_schema(definition)?
         } else {
-            self.input_schema_resolver.input_schema(definition)
-        }
+            self.input_schema_resolver.input_schema(definition)?
+        };
+        ensure_workspace_selector(&mut schema, definition);
+        Ok(schema)
     }
 
     // pub(super) visibility widened from private so that adapter::tests (sibling under adapter)

--- a/crates/orbit-mcp/src/adapter/schema.rs
+++ b/crates/orbit-mcp/src/adapter/schema.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use orbit_common::types::{ToolParam, ToolSchema};
+use orbit_common::types::{McpToolDefinition, McpToolScope, ToolParam, ToolSchema};
 use rmcp::model::{JsonObject, Tool};
 use serde_json::{Map, Value, json};
 
@@ -10,6 +10,43 @@ pub(super) fn schema_to_tool(schema: ToolSchema, input_schema: JsonObject) -> To
     let description = schema.description.clone();
     let advertised_name = sanitize_tool_name(&schema.name);
     Tool::new(advertised_name, description, Arc::new(input_schema))
+}
+
+/// Canonical name of the broker's workspace-routing argument.
+pub(crate) const WORKSPACE_SELECTOR_PARAM: &str = "workspace";
+
+const WORKSPACE_SELECTOR_DESCRIPTION: &str = "Workspace selector for broker routing: a registered logical workspace ID or an absolute \
+     path to a local checkout (a linked Git worktree resolves to its registered checkout). \
+     Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never \
+     inferred from process cwd.";
+
+/// Advertise the workspace selector on every workspace-scoped tool.
+///
+/// The broker rejects a [`McpToolScope::WorkspaceRequired`] call that carries
+/// no selector, taking it from either the `workspace` argument or the trusted
+/// session context announced through initialize `_meta`. General-purpose MCP
+/// clients cannot inject custom initialize metadata, so the argument is the
+/// only selector a managed executor can actually supply — and a tool that
+/// requires it without advertising it is uncallable from a schema-following
+/// caller (F2026-07-099, ORB-10448). Tools that already declare their own
+/// `workspace` parameter keep their own description.
+pub(super) fn ensure_workspace_selector(schema: &mut JsonObject, definition: &McpToolDefinition) {
+    if definition.policy.scope() != McpToolScope::WorkspaceRequired {
+        return;
+    }
+    let Some(properties) = schema.get_mut("properties").and_then(Value::as_object_mut) else {
+        return;
+    };
+    if properties.contains_key(WORKSPACE_SELECTOR_PARAM) {
+        return;
+    }
+    properties.insert(
+        WORKSPACE_SELECTOR_PARAM.to_string(),
+        json!({
+            "type": "string",
+            "description": WORKSPACE_SELECTOR_DESCRIPTION,
+        }),
+    );
 }
 
 pub(crate) fn build_input_schema(tool_name: &str, params: &[ToolParam]) -> JsonObject {

--- a/crates/orbit-mcp/src/adapter/tests/schema.rs
+++ b/crates/orbit-mcp/src/adapter/tests/schema.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use orbit_common::types::{McpCapability, McpTransport, ToolParam, ToolSessionContext};
+use orbit_common::types::{
+    McpCapability, McpToolDefinition, McpToolPlacement, McpToolPolicy, McpToolScope, McpTransport,
+    ToolParam, ToolSchema, ToolSessionContext,
+};
 use rmcp::model::{ClientCapabilities, Implementation, InitializeRequestParams, Meta};
 
 use super::super::dispatch::session_context_from_initialize;
@@ -127,6 +130,111 @@ fn required_string_list_param_is_advertised_as_string_or_array() {
             .iter()
             .any(|shape| shape.get("type").and_then(Value::as_str) == Some("string")),
         "selectors must accept a bare string: {any_of:?}"
+    );
+}
+
+// --- ORB-10448 / F2026-07-099: the broker's workspace selector must be
+// advertised on every workspace-scoped tool. A managed executor speaks through
+// a general-purpose MCP client that cannot inject initialize `_meta`, so the
+// call argument is its only routing surface.
+
+fn definition_with_scope(
+    name: &str,
+    parameters: Vec<ToolParam>,
+    scope: McpToolScope,
+) -> McpToolDefinition {
+    let schema = ToolSchema {
+        name: name.to_string(),
+        description: String::new(),
+        parameters,
+        builtin: true,
+    };
+    let policy = McpToolPolicy::agent_and_operator(McpToolPlacement::Hub).with_scope(scope);
+    McpToolDefinition::new(schema, policy).expect("test definition policy is valid")
+}
+
+fn advertised_properties(definition: &McpToolDefinition) -> serde_json::Map<String, Value> {
+    let server = OrbitToolServer::new(Arc::new(SessionContextHost::default()));
+    let schema = server
+        .input_schema_for(definition)
+        .expect("input schema resolves");
+    schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .cloned()
+        .expect("properties object")
+}
+
+#[test]
+fn workspace_scoped_tool_advertises_the_broker_workspace_selector() {
+    let definition = definition_with_scope(
+        "orbit.task.show",
+        vec![param("id")],
+        McpToolScope::WorkspaceRequired,
+    );
+
+    let properties = advertised_properties(&definition);
+    let workspace = properties
+        .get("workspace")
+        .and_then(Value::as_object)
+        .expect("workspace selector advertised on a workspace-scoped tool");
+
+    assert_eq!(
+        workspace.get("type").and_then(Value::as_str),
+        Some("string")
+    );
+    let description = workspace
+        .get("description")
+        .and_then(Value::as_str)
+        .expect("selector carries routing guidance");
+    assert!(
+        description.contains("absolute path to a local checkout"),
+        "selector must document the checkout-path form: {description}"
+    );
+    assert!(
+        description.contains("worktree"),
+        "selector must state that a linked worktree resolves: {description}"
+    );
+}
+
+#[test]
+fn global_scoped_tool_does_not_advertise_a_workspace_selector() {
+    let definition = definition_with_scope(
+        "orbit.workspace.list",
+        vec![param("limit")],
+        McpToolScope::Global,
+    );
+
+    let properties = advertised_properties(&definition);
+
+    assert!(
+        !properties.contains_key("workspace"),
+        "a global tool routes without a workspace: {properties:?}"
+    );
+}
+
+#[test]
+fn tool_declaring_its_own_workspace_param_keeps_that_description() {
+    let declared = ToolParam {
+        name: "workspace".to_string(),
+        description: "Workspace path for the task".to_string(),
+        param_type: "string".to_string(),
+        required: false,
+    };
+    let definition = definition_with_scope(
+        "orbit.task.add",
+        vec![param("title"), declared],
+        McpToolScope::WorkspaceRequired,
+    );
+
+    let properties = advertised_properties(&definition);
+
+    assert_eq!(
+        properties["workspace"]
+            .get("description")
+            .and_then(Value::as_str),
+        Some("Workspace path for the task"),
+        "injection must not overwrite a tool's own selector documentation"
     );
 }
 

--- a/crates/orbit-remote/src/mcp/host.rs
+++ b/crates/orbit-remote/src/mcp/host.rs
@@ -529,6 +529,44 @@ impl BrokerMcpHost {
             .map_err(|error| OrbitError::Execution(format!("serialize crew discovery: {error}")))
     }
 
+    /// Resolve the coordination task-registry partition key for a workspace.
+    ///
+    /// The host registry keys workspaces by their logical ID while the
+    /// coordination task registry partitions by the checkout identity recorded
+    /// in `.orbit/config.yaml`. `orbit workspace init` writes both from the same
+    /// value, but workspaces registered before that convergence carry two
+    /// distinct keys (L-0098) — and reading coordination tasks under the
+    /// logical key then silently resolves an empty partition, so every hub-
+    /// placement task tool reports `task not found` for tasks the checkout-local
+    /// surfaces serve fine (F2026-07-099, ORB-10448).
+    ///
+    /// A validated exact-checkout binding already carries the identity key and
+    /// is authoritative. Without one, fall back to the registered checkout's
+    /// identity document, then to the logical ID for a genuinely checkoutless
+    /// workspace.
+    fn coordination_workspace_id(
+        &self,
+        workspace_id: &str,
+        binding: Option<&ExactCheckoutBinding>,
+    ) -> String {
+        if let Some(binding) = binding {
+            return binding.key.workspace_id.clone();
+        }
+        let registry_path = crate::workspace_registry::registry_path_for(&self.global_root);
+        let Ok(registry) = crate::workspace_registry::load_registry_from(&registry_path) else {
+            return workspace_id.to_string();
+        };
+        registry
+            .checkouts
+            .iter()
+            .find(|checkout| checkout.workspace_id == workspace_id)
+            .and_then(|checkout| {
+                read_workspace_identity(&checkout.orbit_dir.join("config.yaml")).ok()
+            })
+            .map(|identity| identity.workspace_id)
+            .unwrap_or_else(|| workspace_id.to_string())
+    }
+
     fn legacy_friction_root(
         &self,
         workspace_id: &str,
@@ -671,8 +709,14 @@ impl BrokerMcpHost {
                 return result;
             }
             let legacy_root = self.legacy_friction_root(&workspace_id, binding.as_ref());
-            let result = HubCoordinationExecutor::new(&self.global_root, workspace_id, legacy_root)
-                .and_then(|executor| executor.execute_tool(name, input, context.clone()));
+            let task_partition_id = self.coordination_workspace_id(&workspace_id, binding.as_ref());
+            let result = HubCoordinationExecutor::new_with_task_partition(
+                &self.global_root,
+                workspace_id,
+                task_partition_id,
+                legacy_root,
+            )
+            .and_then(|executor| executor.execute_tool(name, input, context.clone()));
             self.record_coordination_outcome(name, &context, &result);
             return result;
         }

--- a/docs/design/mcp-session-context/2_design.md
+++ b/docs/design/mcp-session-context/2_design.md
@@ -3,14 +3,14 @@ summary: "MCP Session Context — Design"
 type: design
 title: "MCP Session Context — Design"
 owner: codex
-last_updated: 2026-07-19
+last_updated: 2026-07-26
 status: Accepted
 feature: mcp-session-context
 doc_role: design
 tags: ["mcp-session-context", "mcp", "workspace"]
 paths: ["crates/orbit-mcp/**", "crates/orbit-remote/src/mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool.rs"]
 related_features: ["mcp-session-context", "task-artifacts"]
-related_artifacts: ["ORB-00256", "ORB-10228", "ORB-10262", "ORB-10319", "ADR-0181", "ADR-0199", "ADR-0149"]
+related_artifacts: ["ORB-00256", "ORB-10228", "ORB-10262", "ORB-10319", "ORB-10448", "ADR-0181", "ADR-0199", "ADR-0149"]
 ---
 
 # MCP Session Context — Design
@@ -58,6 +58,36 @@ selector to a logical workspace and, when placement requires it, an exact checko
 Remote preflight owns routing and authorization; it does not replace the builtin's
 explicit-over-session input contract. [ORB-10262], [ORB-10319]
 
+### 3a. The selector is advertised, not implied
+
+Step 1 is the only step a general-purpose MCP client can reach: no shipping client lets a
+caller inject `initialize.params._meta`, so a managed executor speaking through one has the
+`workspace` argument and nothing else. `crates/orbit-mcp/src/adapter/schema.rs` therefore
+injects an optional `workspace` string property into the advertised input schema of every
+`McpToolScope::WorkspaceRequired` definition, and
+`OrbitToolServer::input_schema_for` applies it to host-resolved and extension-owned schemas
+alike. A tool that declares its own `workspace` parameter — `orbit.task.add` ([ADR-0149]),
+`orbit.crew.list` — keeps its own description. Global-scoped tools get nothing.
+
+Advertising at the adapter rather than in each tool's `ToolSchema` keeps the requirement
+stated once, next to the scope that creates it: the broker rejects a scoped call without a
+selector, so the broker's schema layer is what owns telling callers about it. [ORB-10448]
+
+### 3b. Coordination reads follow checkout identity
+
+A hub-placement call resolves against the coordination task registry, which partitions by the
+workspace identity written to `.orbit/config.yaml` — not by the logical ID in the host
+registry. `orbit workspace init` writes both from one value, so they normally coincide; for
+workspaces registered before that convergence they differ (L-0098), and a validated
+`ExactCheckoutBinding` carries the identity key precisely because of it.
+
+`BrokerMcpHost::coordination_workspace_id` resolves the partition key from that binding, then
+from the registered checkout's identity document, then falls back to the logical ID for a
+genuinely checkoutless workspace. Friction partitioning and audit identity stay on the logical
+ID. Without this, every hub-placement task tool addressed an empty partition on a diverged
+workspace and reported `task not found` for tasks the checkout-local CLI served fine
+(F2026-07-099). [ORB-10448]
+
 ## 4. Task Add
 
 `orbit.task.add` advertises `workspace` as optional over the tool schema while still accepting explicit callers unchanged. The host action still receives a concrete `workspace` field because the tool wrapper resolves or rejects before dispatch.
@@ -82,5 +112,6 @@ The external channel carries a workspace address, not a trusted workspace ID. Th
 - [ORB-10228] implemented trusted provenance, anti-spoofing, capability-set propagation and audit, call correlation, and audit migration v7.
 - [ORB-10262] implemented exact-checkout workspace resolution, placement preflight, capability enforcement, and runtime caching by exact binding.
 - [ORB-10319] moved broker/session resolution and MCP composition into the vertical `orbit-remote` feature crate while leaving runtime audit/dispatch in Core.
+- [ORB-10448] advertised the workspace selector on every workspace-scoped tool and routed hub-placement coordination reads by checkout identity, making the [ADR-0181] "clients that cannot send initialize metadata pass `workspace` explicitly" path reachable from a managed worktree activity.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-session-context/4_decisions.md
+++ b/docs/design/mcp-session-context/4_decisions.md
@@ -3,14 +3,14 @@ summary: "MCP Session Context — Decisions"
 type: design
 title: "MCP Session Context — Decisions"
 owner: codex
-last_updated: 2026-07-18
+last_updated: 2026-07-26
 status: Accepted
 feature: mcp-session-context
 doc_role: decisions
 tags: ["mcp-session-context", "mcp", "workspace"]
 paths: ["crates/orbit-mcp/**", "crates/orbit-remote/src/mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool.rs"]
 related_features: ["mcp-session-context", "task-artifacts"]
-related_artifacts: ["ORB-00256", "ORB-00406", "ORB-10228", "ORB-10262", "ORB-10319", "ADR-0181", "ADR-0199", "ADR-0149"]
+related_artifacts: ["ORB-00256", "ORB-00406", "ORB-10228", "ORB-10262", "ORB-10319", "ORB-10448", "ADR-0181", "ADR-0199", "ADR-0149"]
 ---
 
 # MCP Session Context — Decisions
@@ -21,7 +21,7 @@ ADR log for MCP session context. Format follows [docs/design/CONVENTIONS.md §4]
 
 ## ADR-0181 — MCP ambient workspace session context
 
-**Status:** Accepted · 2026-05 · [ORB-00256], amended 2026-07 · [ORB-10228]
+**Status:** Accepted · 2026-05 · [ORB-00256], amended 2026-07 · [ORB-10228], selector advertised 2026-07 · [ORB-10448]
 
 **Context.** MCP tools need CLI-like workspace ergonomics, but [ADR-0149] makes process-cwd defaults unsafe because worktree cwd can bind to a different `workspace_id`. The viable alternatives were per-call workspace input forever, a one-shot workspace lookup tool that clients cache, or a deliberate session-level signal from the MCP client.
 
@@ -39,7 +39,7 @@ ADR log for MCP session context. Format follows [docs/design/CONVENTIONS.md §4]
 
 ## ADR-0199 — Workspace_path-addressable MCP host tools with surface-scoped containment
 
-**Status:** Accepted · 2026-07 · [ORB-00406], implemented by [ORB-10262]
+**Status:** Accepted · 2026-07 · [ORB-00406], implemented by [ORB-10262], coordination partition key corrected 2026-07 · [ORB-10448]
 
 **Context.** MCP host tools (`orbit.task.*`, `orbit.adr.*`, `orbit.learning.*`, `orbit.friction.*`, `orbit.search`) bind to a single `OrbitRuntime` resolved at `serve` launch from cwd discovery; when none is found the server installs `EmptyMcpHost` and advertises an empty `tools/list`, so clients that launch the server without the repo as cwd lose the entire host surface (e.g. Cowork, which launches with cwd / `CLAUDE_PROJECT_DIR` set to an internal scratchpad; see [ORB-00405] and learning L-0065). [ADR-0181] already routes workspace *addressing* per-call → session-context, but tool *registration* still gates on launch discovery. The real alternatives were to keep launch-gated registration and require every client to fix cwd, or to advertise host tools unconditionally and resolve the runtime per call.
 
@@ -58,5 +58,6 @@ ADR log for MCP session context. Format follows [docs/design/CONVENTIONS.md §4]
 - [ORB-10228] accepted and implemented the trusted-provenance amendment to [ADR-0181].
 - [ORB-10262] accepted and implemented ADR-0199 through the exact-checkout local broker.
 - [ORB-10319] consolidated the broker/session implementation in `orbit-remote`; it does not change ADR-0181 or ADR-0199 semantics.
+- [ORB-10448] made both ADRs reachable from a managed worktree activity: the `workspace` selector is now advertised on every workspace-scoped tool, and hub-placement coordination reads address the checkout-identity partition. Neither changes ADR-0181 or ADR-0199 semantics; see [2_design.md §3a–3b](./2_design.md). The advertised-selector contract is a breaking `tools/list` schema change (RELEASING.md) and may warrant its own allocated ADR — this task's activity was not granted `orbit.adr.add`, so no global ID was allocated.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10448](https://orbit-cli.com/tasks/ORB-10448) — Fix executor MCP workspace routing for task and search tools

### Description

## Problem

Executor activities repeatedly receive Orbit MCP task/search tools whose runtime requires workspace routing that the advertised call schema does not expose and whose injected worktree session context does not reach the tool call. Calls fail with `requires a workspace selector` or `task not found`, while `orbit tool run orbit.task.show|update|search` succeeds from the same worktree.

## Evidence

Canonical friction F2026-07-099 records the first well-evidenced occurrence. F2026-07-137, F2026-07-145, and F2026-07-149 independently reproduced the same failure on 2026-07-26 and were resolved as duplicates during ORB-10440 validation. Current source expects workspace propagation through initialize metadata (`crates/orbit-mcp/src/adapter/dispatch.rs` and adapter schema tests), so the live executor integration is violating that contract.

## Scope

Trace the executor MCP initialization/call path, make the injected workspace unambiguous and schema-compatible, and add a regression that exercises task show/update plus search from a managed worktree context. Preserve the CLI fallback. No new dependency edge is expected.

### Acceptance Criteria

- A managed executor invocation can call Orbit MCP task show/update and search for its injected task from a linked worktree without an unadvertised input field or task-not-found error.
- The effective tool schema/session contract either carries workspace through trusted initialize metadata end-to-end or advertises a callable workspace selector consistently; tests cover the selected contract.
- Regression coverage exercises the same worktree-backed activity shape reported by F2026-07-099 and its duplicates, while the `orbit tool run` fallback remains functional.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success. Fixed both independent defects behind F2026-07-099 (and duplicates F2026-07-137/145/149).

Reproduced first, against the live registry from this linked worktree, by driving `orbit mcp serve` over raw JSON-RPC with no initialize `_meta`:
1. `orbit_task_show`/`orbit_task_update`/`orbit_search`/`orbit_task_list` advertised no `workspace` property, yet the broker rejected every call with `requires a workspace selector`.
2. Supplying the selector (`ws_orbit`, `orbit-5c61b3`, or the absolute worktree/checkout path) still returned `task not found: ORB-10448`, and `orbit_task_list` returned an empty array.

Root causes:
1. Schema. The broker requires a selector for every `McpToolScope::WorkspaceRequired` tool, taken from the `workspace` argument or `_meta.orbit.workspace` at initialize. No general-purpose MCP client can inject initialize `_meta`, so the argument is a managed executor's only routing surface — and only `orbit.task.add` and `orbit.crew.list` declared it.
2. Routing. `BrokerMcpHost::resolved_call` passed the *logical* host-registry workspace ID (`ws_orbit`) to `HubCoordinationExecutor`, but the coordination task registry partitions by the *checkout identity* in `.orbit/config.yaml` (`orbit-5c61b3`). `orbit workspace init` writes both from one value, so they normally coincide; on workspaces registered before that convergence they differ (L-0098), and every hub-placement task tool (show/list/update/start/add/approve/artifact.put) silently addressed an empty partition. `ExactCheckoutBinding.key.workspace_id` already carried the right key; nothing read it. This is why `orbit tool run` worked from the same cwd — it resolves the checkout-local runtime and never crosses the coordination partition.

Changes:
- `crates/orbit-mcp/src/adapter/schema.rs`: `ensure_workspace_selector` injects an optional `workspace` string property (documenting the logical-ID and absolute-checkout-path forms, and that a linked worktree resolves) into the advertised schema of every workspace-scoped definition. Tools declaring their own `workspace` keep their description; global-scoped tools get nothing.
- `crates/orbit-mcp/src/adapter/dispatch.rs`: `input_schema_for` applies it to host-resolved and extension-owned schemas alike, so the contract is stated once beside the scope that creates it.
- `crates/orbit-core/src/runtime/orbit_tool_host/host.rs`: added `HubCoordinationExecutor::new_with_task_partition`; `new` delegates to it unchanged.
- `crates/orbit-remote/src/mcp/host.rs`: added `BrokerMcpHost::coordination_workspace_id` (validated binding -> registered checkout identity document -> logical ID) and used it for the coordination task registry. Friction partitioning, audit identity, session context, and the spoke `remote_hub_call` path keep the logical ID.

Selected contract: acceptance criterion 2's second option (advertise a callable selector consistently). The first option is unreachable — no shipping MCP client lets a caller set initialize `_meta`.

Regression coverage:
- `crates/orbit-mcp/src/adapter/tests/schema.rs`: three unit tests — workspace-scoped tools advertise the selector with routing guidance, global-scoped tools do not, and a tool's own `workspace` description survives injection.
- `crates/orbit-cli/tests/mcp_roundtrip.rs`: `worktree_backed_activity_routes_task_and_search_by_advertised_workspace_argument` builds the reported shape end-to-end — real workspace with a deliberately diverged logical/identity ID pair, a task authored through the `orbit tool run` fallback, a linked Git worktree, and `orbit mcp serve` spawned with cwd in that worktree and initialize carrying no `_meta`. It asserts no advertised tool requires an unadvertised selector, then show (both selector forms) / update / search over MCP, then re-reads through the `orbit tool run` fallback from the worktree to prove both surfaces address one partition. Verified this test FAILS with exactly `task not found` when the routing fix is stubbed out.

Docs (same-PR rule): `docs/design/mcp-session-context/2_design.md` gains §3a (selector advertised, not implied) and §3b (coordination reads follow checkout identity); ORB-10448 cited on the ADR-0181 and ADR-0199 status lines and in both Task References sections; `last_updated` bumped. No new ADR number was allocated — `orbit.adr.add` is outside this activity's tool allowlist — and 4_decisions.md records that the advertised-selector contract may warrant its own allocated ADR.

Breaking-change note for the release drafter: this changes `tools/list` input schemas for 21 tools, which RELEASING.md classifies as breaking. `crates/orbit-cli/tests/snapshots/mcp_tools_list.json` was regenerated via `ORBIT_MCP_UPDATE_SNAPSHOT=1`; the diff is additive (the `workspace` property, nowhere required).

Validation: `make ci-fast` passes. `cargo test` green for orbit-mcp (37), orbit-remote, orbit-core (623), orbit-tools, and the full orbit-cli suite including all 7 mcp_roundtrip tests. `cargo clippy --all-targets` clean on the changed crates. Also confirmed live against the real registry with the rebuilt binary from this worktree: all 23 advertised tools now expose `workspace`, and `orbit_task_show`/`orbit_task_list` resolve ORB-10448 under both the `ws_orbit` and absolute-path selectors. `orbit tool run` fallback preserved and asserted. No new dependency edge.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10448-6a6656c9`
- Behind base: 0
- Ahead of base: 1