### PR TITLE
CLI attributes every caller as human, laundering agent-initiated commands

### DIFF
--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -9,7 +9,7 @@
 use std::path::Path;
 
 use orbit_common::types::{normalize_agent_family_for_model, normalize_optional_attribution_label};
-use orbit_core::{OrbitError, OrbitRuntime};
+use orbit_core::{ActorIdentity, OrbitError, OrbitRuntime};
 use serde_json::Value;
 
 use super::{Commands, Execute};
@@ -86,6 +86,17 @@ impl CommandOperation {
             suppress_errors,
             dispatch,
         }
+    }
+
+    /// Apply the process actor resolved by the runtime bootstrap to the CLI
+    /// guard's audit row. Tool dispatch may replace this row with its own
+    /// more specific audited invocation, but pre-dispatch failures and all
+    /// direct commands must use the same actor identity as the runtime.
+    pub fn attribute_to(mut self, actor: &ActorIdentity) -> Self {
+        if let Some(meta) = self.audit_meta.as_mut() {
+            meta.role.clone_from(&actor.label);
+        }
+        self
     }
 }
 

--- a/crates/orbit-cli/src/main.rs
+++ b/crates/orbit-cli/src/main.rs
@@ -49,13 +49,14 @@ fn main() {
 
     let cli = command::Cli::parse();
     let root_override = cli.root.clone();
+    let actor = ActorIdentity::from_env();
     let CommandOperation {
         runtime_need,
         audit_meta,
         json_error_preference,
         suppress_errors,
         dispatch,
-    } = cli.command.operation();
+    } = cli.command.operation().attribute_to(&actor);
 
     if matches!(runtime_need, RuntimeNeed::Forbidden) {
         let result = dispatch(
@@ -77,9 +78,7 @@ fn main() {
                 std::process::exit(1);
             }
         }
-        // Direct CLI commands are human-driven by default. Tool-dispatch paths
-        // reclassify themselves as agent-driven inside `execute_tool_command`.
-        .with_actor(ActorIdentity::human("human"));
+        .with_actor(actor);
 
     let context = DispatchContext::with_runtime(&runtime, root_override.as_deref());
     let result = match audit_meta {

--- a/crates/orbit-cli/src/tests/audit_middleware.rs
+++ b/crates/orbit-cli/src/tests/audit_middleware.rs
@@ -8,7 +8,8 @@ use super::super::audit_middleware::*;
 use orbit_common::test_env::{self, AGENT_IDENTITY_ENV};
 use orbit_common::test_fixtures::TEST_CODEX_MODEL;
 use orbit_common::types::AuditEventStatus;
-use orbit_core::{OrbitError, OrbitRuntime};
+use orbit_core::context::ActorKind;
+use orbit_core::{ActorIdentity, OrbitError, OrbitRuntime};
 
 fn meta_for(args: &[&str]) -> CommandMeta {
     let cli = Cli::parse_from(args);
@@ -28,6 +29,53 @@ fn audit_event_for_meta_without_orbit_run_id(meta: CommandMeta) -> AuditEvent {
         .expect("list audit events");
     assert_eq!(events.len(), 1);
     events.into_iter().next().expect("single audit event")
+}
+
+fn audit_event_for_actor(actor: ActorIdentity) -> AuditEvent {
+    let runtime = OrbitRuntime::in_memory()
+        .expect("build in-memory runtime")
+        .with_actor(actor.clone());
+    let meta = Cli::parse_from(["orbit", "search", "actor"])
+        .command
+        .operation()
+        .attribute_to(&actor)
+        .audit_meta
+        .expect("search is audited");
+    {
+        let mut guard = AuditGuard::new(&runtime, meta);
+        guard.mark_success();
+    }
+
+    runtime
+        .list_audit_events(None, None, Some(AuditEventStatus::Success), None, 8)
+        .expect("list audit events")
+        .into_iter()
+        .next()
+        .expect("single audit event")
+}
+
+#[test]
+fn cli_agent_envelope_records_canonical_actor_family() {
+    let _env = test_env::unset(AGENT_IDENTITY_ENV.iter().copied());
+    // SAFETY: the shared test-env guard serializes and restores this mutation.
+    unsafe {
+        std::env::set_var("ORBIT_AGENT_MODEL", "gpt-5.6-sol");
+    }
+
+    let actor = ActorIdentity::from_env();
+    assert_eq!(actor.kind, ActorKind::Agent);
+    assert_eq!(actor.label, "codex");
+    assert_eq!(audit_event_for_actor(actor).role, "codex");
+}
+
+#[test]
+fn cli_without_agent_envelope_records_unknown_actor() {
+    let _env = test_env::unset(AGENT_IDENTITY_ENV.iter().copied());
+
+    let actor = ActorIdentity::from_env();
+    assert_eq!(actor.kind, ActorKind::Unknown);
+    assert_eq!(actor.label, "unknown");
+    assert_eq!(audit_event_for_actor(actor).role, "unknown");
 }
 
 #[test]

--- a/crates/orbit-core/src/command/learning_authoring.rs
+++ b/crates/orbit-core/src/command/learning_authoring.rs
@@ -105,6 +105,10 @@ impl LearningWriteAttempt<'_> {
 pub fn learning_author_role() -> LearningAuthorRole {
     let identity = ActorIdentity::from_env();
     match identity.kind {
+        // Unknown is an attribution state, not a new authorization policy.
+        // Preserve the pre-existing unenveloped CLI behavior until actor-aware
+        // gating is designed and shipped separately.
+        ActorKind::Unknown => LearningAuthorRole::Human,
         ActorKind::Human => LearningAuthorRole::Human,
         ActorKind::Agent if author_opt_in() => LearningAuthorRole::AuthorizedAgent {
             label: identity.label,

--- a/crates/orbit-core/src/command/tests/learning_authoring.rs
+++ b/crates/orbit-core/src/command/tests/learning_authoring.rs
@@ -50,7 +50,7 @@ fn denial_message(result: Result<(), OrbitError>) -> String {
 }
 
 #[test]
-fn no_agent_identity_env_resolves_to_the_human_role_and_allows_every_write() {
+fn no_agent_identity_env_preserves_the_existing_authoring_policy() {
     let _env = scoped_identity_env(&[]);
 
     assert_eq!(learning_author_role(), LearningAuthorRole::Human);
@@ -79,7 +79,7 @@ fn agent_identity_env_without_opt_in_resolves_to_the_executor_role() {
     assert_eq!(
         learning_author_role(),
         LearningAuthorRole::Executor {
-            label: "claude-opus-5".to_string()
+            label: "claude".to_string()
         }
     );
 }
@@ -105,7 +105,7 @@ fn executor_add_is_refused_with_the_friction_redirect_and_the_attempted_payload(
     let message = denial_message(ensure_learning_write_allowed(add_attempt()));
 
     assert!(message.contains("learning add"), "names the operation");
-    assert!(message.contains("claude-opus-5"), "names the identity");
+    assert!(message.contains("claude"), "names the canonical identity");
     assert!(
         message.contains("orbit friction add") && message.contains("orbit.friction.add"),
         "redirects to the friction surface: {message}"
@@ -176,7 +176,7 @@ fn the_explicit_orchestrator_opt_in_allows_agent_context_writes() {
         assert_eq!(
             learning_author_role(),
             LearningAuthorRole::AuthorizedAgent {
-                label: "claude-opus-5".to_string()
+                label: "claude".to_string()
             },
             "`{truthy}` opts in"
         );
@@ -202,8 +202,8 @@ fn a_non_affirmative_opt_in_value_does_not_bypass_the_gate() {
     }
 }
 
-/// The opt-in alone is not an identity: without the agent env pair the caller
-/// is still simply a human, and nothing changes.
+/// The opt-in alone is not an identity. The runtime actor remains unknown,
+/// while this task deliberately preserves the existing authoring policy.
 #[test]
 fn the_opt_in_without_agent_identity_is_still_the_human_role() {
     let _env = scoped_identity_env(&[(LEARNING_AUTHOR_OPT_IN_ENV, "1")]);

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use orbit_common::types::{Crew, WorkspacePaths};
+use orbit_common::types::{Crew, WorkspacePaths, normalize_agent_family_for_model};
 use orbit_engine::PrConfig;
 use orbit_policy::PolicyEngine;
 use orbit_search::{EmbedWorker, VectorStore};
@@ -21,6 +21,7 @@ const ORBIT_AGENT_MODEL: &str = "ORBIT_AGENT_MODEL";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ActorKind {
+    Unknown,
     Human,
     Agent,
 }
@@ -32,6 +33,13 @@ pub struct ActorIdentity {
 }
 
 impl ActorIdentity {
+    pub fn unknown() -> Self {
+        Self {
+            kind: ActorKind::Unknown,
+            label: "unknown".to_string(),
+        }
+    }
+
     pub fn human(label: impl Into<String>) -> Self {
         Self {
             kind: ActorKind::Human,
@@ -46,20 +54,32 @@ impl ActorIdentity {
         }
     }
 
-    pub(crate) fn from_env() -> Self {
-        let actor_label = std::env::var(ORBIT_AGENT_MODEL)
+    /// Resolve the self-reported process identity used by CLI and dashboard
+    /// entry points.
+    ///
+    /// The environment is not an authentication boundary. Agent values are
+    /// therefore reduced to the same canonical family used by tool dispatch,
+    /// and an absent or inconsistent envelope is recorded as `unknown` rather
+    /// than claiming that a human was present.
+    pub fn from_env() -> Self {
+        let agent = std::env::var(ORBIT_AGENT_NAME)
             .ok()
-            .or_else(|| std::env::var(ORBIT_AGENT_NAME).ok())
-            .map(|value| value.trim().to_string())
-            .filter(|value| !value.is_empty());
+            .filter(|value| !value.trim().is_empty());
+        let model = std::env::var(ORBIT_AGENT_MODEL)
+            .ok()
+            .filter(|value| !value.trim().is_empty());
 
-        actor_label.map(Self::agent).unwrap_or_default()
+        normalize_agent_family_for_model(agent.as_deref(), model.as_deref())
+            .ok()
+            .flatten()
+            .map(Self::agent)
+            .unwrap_or_default()
     }
 }
 
 impl Default for ActorIdentity {
     fn default() -> Self {
-        Self::human("human")
+        Self::unknown()
     }
 }
 

--- a/crates/orbit-core/src/runtime/engine/tests/task_host.rs
+++ b/crates/orbit-core/src/runtime/engine/tests/task_host.rs
@@ -14,8 +14,8 @@ use orbit_engine::{
 use serde_json::{Value, json};
 use tempfile::tempdir;
 
-use crate::OrbitRuntime;
 use crate::command::task::{SYSTEM_ACTOR_LABEL, TaskAddParams, TaskUpdateParams};
+use crate::{ActorIdentity, OrbitRuntime};
 
 fn test_runtime() -> (tempfile::TempDir, OrbitRuntime) {
     let root = tempdir().expect("create tempdir");
@@ -841,11 +841,12 @@ fn generic_automation_status_update_uses_system_history_and_preserves_implemente
 }
 
 #[test]
-fn direct_update_task_keeps_default_human_attribution() {
+fn direct_update_task_uses_unknown_attribution_without_an_actor_envelope() {
     let (_root, runtime) = test_runtime();
+    let runtime = runtime.with_actor(ActorIdentity::unknown());
     let task = runtime
         .add_task(TaskAddParams {
-            title: "Human comment".to_string(),
+            title: "Unenveloped comment".to_string(),
             description: "Exercise direct update attribution.".to_string(),
             workspace_path: Some(".".to_string()),
             ..Default::default()
@@ -856,7 +857,7 @@ fn direct_update_task_keeps_default_human_attribution() {
         .update_task(
             &task.id,
             TaskUpdateParams {
-                comment: Some("Human-visible note.".to_string()),
+                comment: Some("Visible note.".to_string()),
                 ..Default::default()
             },
         )
@@ -865,9 +866,9 @@ fn direct_update_task_keeps_default_human_attribution() {
     let comments = runtime
         .get_task_comments(&task.id)
         .expect("reload comments");
-    let comment = comments.last().expect("human comment");
-    assert_eq!(comment.by, "human");
-    assert_eq!(comment.message, "Human-visible note.");
+    let comment = comments.last().expect("direct comment");
+    assert_eq!(comment.by, "unknown");
+    assert_eq!(comment.message, "Visible note.");
     // ORB-10311: the full comment is persisted, but no redundant `commented`
     // history entry is emitted alongside it.
     let history = runtime.get_task_history(&task.id).expect("reload history");

--- a/crates/orbit-dashboard/src/state.rs
+++ b/crates/orbit-dashboard/src/state.rs
@@ -40,7 +40,7 @@ use axum::http::request::Parts;
 use axum::response::{IntoResponse, Json, Response};
 use orbit_common::types::WorkspaceStatus;
 use orbit_core::runtime::WorkspaceRuntimeBinding;
-use orbit_core::{ActorIdentity, OrbitError, OrbitRuntime, ShipMode};
+use orbit_core::{OrbitError, OrbitRuntime, ShipMode};
 use orbit_remote::{
     runtime::{RemoteRuntimeFactory, workspace_runtime_binding},
     workspace_registry,
@@ -263,8 +263,7 @@ impl StateInner {
             &orbit_dir,
             binding.clone(),
         )
-        .map_err(|e| WsRejection::build_failed(id, &e))?
-        .with_actor(ActorIdentity::human("human"));
+        .map_err(|e| WsRejection::build_failed(id, &e))?;
         let runtime = Arc::new(runtime);
 
         // Test seam: pause between build and publish so a test can rebind +

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -3,7 +3,7 @@ summary: "Auditability — Design"
 type: design
 title: "Auditability — Design"
 owner: codex
-last_updated: 2026-07-25
+last_updated: 2026-07-26
 status: Draft
 feature: auditability
 doc_role: design
@@ -40,7 +40,7 @@ The CLI RAII guard in `crates/orbit-cli/src/audit_middleware.rs` defaults to fai
 
 [ORB-10200] moved command and subcommand metadata selection out of the middleware into the exhaustive `Commands::operation` registry in `crates/orbit-cli/src/command/operation.rs`. The same operation declaration now owns dispatch, runtime bootstrap policy, audit metadata, JSON error preference, and hook error suppression, so a new top-level command cannot compile until all five concerns are declared; `audit_middleware.rs` owns only audit persistence.
 
-For `orbit tool run`, [T20260427-52] first collapsed duplicate `agent` + `model` inputs. [ORB-00080] later made the family the durable identity: agent-facing `model` inputs should be `codex`, `claude`, `gemini`, or `grok`, while full model strings remain accepted for compatibility and normalize to the family before persistence. Missing identity falls back to `agent` for tool dispatch, while direct non-tool CLI commands use `admin`.
+For `orbit tool run`, [T20260427-52] first collapsed duplicate `agent` + `model` inputs. [ORB-00080] later made the family the durable identity: agent-facing `model` inputs should be `codex`, `claude`, `gemini`, or `grok`, while full model strings remain accepted for compatibility and normalize to the family before persistence. [ORB-10451] applies that same trust boundary to runtime bootstrap: CLI and dashboard processes canonicalize `ORBIT_AGENT_NAME` / `ORBIT_AGENT_MODEL` to an agent family, and an absent or inconsistent envelope records `unknown` instead of asserting verified human presence. This changes attribution only; actor-based command gating remains separate work.
 
 After [T20260428-4], tool-invocation audit is written at the OrbitRuntime dispatch boundary for registered CLI/MCP tools. A `ToolEntryPoint` discriminator surfaces as `subcommand: "run"` or `"run-mcp"`, setup failures inside dispatch are audited, and `duration_ms` is clamped to at least `1`. [ORB-10225] extracted the shared boundary behind registry-backed dispatch and temporarily routed adapter-owned graph implementations through it; [ORB-10325] later removed graph from the registered tool and MCP surfaces, leaving `orbit graph` as a direct CLI command; [ORB-10357] then removed that CLI command too, so the graph has no audited surface of any kind. The legacy CLI guard skips its own emission when the runtime sets a per-thread `mark_tool_audit_recorded` signal; pre-runtime CLI failures such as invalid JSON still produce the existing guard-side row.
 
@@ -97,7 +97,7 @@ Dashboard log previews added by [T20260508-14] are derived views over `.orbit/st
 
 Orbit currently carries identity through related fields rather than one universal key:
 
-- Direct CLI commands preserve their human/admin and caller-input compatibility behavior. Standalone MCP is exactly `unverified`; only an authenticated managed envelope can supply MCP agent/model audit identity.
+- Direct CLI commands and dashboard runtime construction share the env-derived `agent family` / `unknown` actor rule. Standalone MCP is exactly `unverified`; only an authenticated managed envelope can supply MCP agent/model audit identity.
 - `V2AuditEnvelope.agent_identity` records the workflow-envelope actor. CLI-launched v2 runs use `system`; concrete provider activity appears in event bodies and metrics.
 - Task records carry `created_by`, `planned_by`, `implemented_by`, `agent`, and `model`.
 - Invocation metrics record agent family and configured runtime model beside job run and activity ids.
@@ -196,5 +196,6 @@ Each record contains timestamp, level, target, and structured fields. After [T20
 - **[ORB-10319]** — Move Remote MCP policy/preflight and global audit composition out of CLI/Core ownership while preserving the shared `ToolEntryPoint::Mcp` audit contract.
 - **[ORB-10325]** — Remove graph from MCP and registered tool dispatch while preserving the direct `orbit graph` CLI.
 - **[ORB-10357]** — Remove the direct `orbit graph` CLI too; the graph has no audited surface left.
+- **[ORB-10451]** — Attribute CLI and dashboard runtimes from the canonical agent env envelope, recording unenveloped callers as unknown.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10451](https://orbit-cli.com/tasks/ORB-10451) — CLI attributes every caller as human, laundering agent-initiated commands

### Description

## Problem

`orbit-core` already models the caller: `ActorKind::{Human, Agent}` with `ActorIdentity::from_env()`, which derives `Agent` from `ORBIT_AGENT_MODEL` / `ORBIT_AGENT_NAME` and otherwise defaults to `Human`. The CLI does not use it — `crates/orbit-cli/src/main.rs` constructs `ActorIdentity::human("human")` unconditionally, commented "Direct CLI commands are human-driven by default." The dashboard does the same in `crates/orbit-dashboard/src/state.rs`.

Consequence: an agent that shells out to `orbit ...` — the common case on dk-server-1, where runners have a shell — is recorded as a human actor, and the audit middleware stamps `role: "admin"` on the command. The audit trail therefore cannot distinguish agent-initiated from human-initiated CLI activity, and any future actor-based policy built on top of it would be reading a constant.

This is a prerequisite for actor-aware gating of destructive commands; on its own it is an observability fix, not an enforcement change.

## Constraints

- Env-derived identity is **self-reported and untrusted**. `orbit-core`'s tool dispatch already states this trust boundary explicitly and persists a canonical agent *family* rather than the raw model string; whatever the CLI does must be consistent with that existing treatment rather than inventing a second notion of trust.
- Ambiguity must not resolve to `Human`. An absent envelope means unknown, and the recorded value must not assert human presence it cannot establish.
- No behaviour change to any command's execution path in this task — attribution and audit records only. Gating is a separate task.
- The existing `Actor` attribution type in `orbit-common` (`created_by` / `assigned_to`) and the runtime `ActorIdentity` are distinct concepts; do not collapse them.
- Backfill/migration of historical audit rows is out of scope.

## Non-goals

Blocking or prompting on any command; introducing credentials; changing the MCP capability model.

## Notes

Related: separate tasks cover enforcement at the tool-dispatch chokepoint and confirmation on ungated destructive commands. This task lands first because both depend on the CLI reporting a real actor.

### Acceptance Criteria

- A CLI invocation carrying an agent env envelope is recorded with an agent actor, and the audit record's role reflects that rather than the unconditional admin/human value.
- A CLI invocation with no envelope is recorded as an actor that does not falsely assert verified human presence; the chosen representation is documented in the code.
- The dashboard entry point resolves its actor by the same rule as the CLI — no second hardcoded identity remains in the tree.
- Agent-family canonicalisation matches the existing treatment in tool dispatch; a raw self-reported model string is not persisted verbatim as identity.
- No command changes what it does or whether it succeeds as a result of this task; existing tests pass unmodified except where they assert the hardcoded human value.
- Test coverage exercises both the enveloped and unenveloped CLI paths.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added an explicit Unknown runtime actor and made ActorIdentity::from_env canonicalize the self-reported ORBIT_AGENT_NAME / ORBIT_AGENT_MODEL envelope to an agent family; absent or inconsistent envelopes now record unknown rather than human.
- Applied that shared actor to CLI audit metadata and removed the CLI/dashboard hardcoded human runtime overrides.
- Preserved existing learning-authoring authorization behavior for unknown callers so this observability task does not introduce actor-based gating.
- Added CLI audit coverage for canonical enveloped agents and unenveloped unknown callers, updated directly affected identity assertions, and synchronized the auditability design document.
- Expanded context_files to include crates/orbit-core/src/runtime/engine/tests/task_host.rs after the full orbit-core suite exposed its directly affected hardcoded human assertion.
Assessment: The change is scoped to attribution and audit identity. Command dispatch, success/failure behavior, and existing authorization remain unchanged; raw model strings from the env envelope are not persisted as runtime identity.
Validation:
- cargo test -p orbit-core --lib --no-fail-fast: 623 passed, 1 directly affected hardcoded-human assertion failed before its expected value was updated; that updated test then passed in isolation.
- cargo test -p orbit-cli --no-fail-fast: all unit and integration tests passed.
- cargo test -p orbit-dashboard state --no-fail-fast: 9 passed.
- make ci-fast: passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10451-6a6662be`
- Behind base: 0
- Ahead of base: 1