### PR TITLE
Agent-loop steps checkpoint success on a stalled implementer, deferring the failure to the delivery gate

### DIFF
--- a/.orbit/resources/activities/dispatch_agent.yaml
+++ b/.orbit/resources/activities/dispatch_agent.yaml
@@ -84,6 +84,21 @@ spec:
     Your final response is audit-only. Prefer concise JSON with `bundles`
     and `reasoning` when convenient, but the workflow does not consume it
     and downstream dispatch must not depend on it.
+  # The one sanctioned exception to the step-completion protocol check,
+  # declared rather than inherited.
+  #
+  # Every other agent_loop activity does real work whose absence must stop the
+  # pipeline, so an invocation that ends without a terminating Orbit response
+  # envelope fails its step. This one is genuinely decorative: dispatch is
+  # driven by the deterministic singleton bundles from `list_backlog_tasks`,
+  # and nothing reads these notes. An advisory note-taker that stalls has cost
+  # the run nothing, so failing the auto-pipeline over it would trade a real
+  # capability for a cosmetic one.
+  #
+  # This is a statement about *consequence*, not about output quality. Do not
+  # copy it onto an activity merely because its response is unstructured — the
+  # bar is that the activity not running at all is harmless.
+  require_completion_envelope: false
   tools:
     - orbit.task.*
     - orbit.friction.*

--- a/crates/orbit-agent/src/lib.rs
+++ b/crates/orbit-agent/src/lib.rs
@@ -58,4 +58,6 @@ pub use agent::{Agent, AgentConfig, ProviderOptions};
 pub use orbit_common::types::{InvocationTrace, TokenUsage, ToolCallTrace};
 pub use runtime::AgentRuntime;
 pub use types::{AgentInvocationSpec, AgentOperation, AgentRequest, AgentResponseStatus};
-pub use types::{is_timeout, parse_and_validate_response, peek_response_status};
+pub use types::{
+    is_timeout, parse_and_validate_response, peek_response_status, response_envelope_protocol_check,
+};

--- a/crates/orbit-agent/src/types/mod.rs
+++ b/crates/orbit-agent/src/types/mod.rs
@@ -3,7 +3,9 @@ mod response;
 
 pub use request::{AgentOperation, AgentRequest};
 pub use response::{AgentInvocationSpec, AgentResponseStatus};
-pub use response::{is_timeout, parse_and_validate_response, peek_response_status};
+pub use response::{
+    is_timeout, parse_and_validate_response, peek_response_status, response_envelope_protocol_check,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-agent/src/types/response.rs
+++ b/crates/orbit-agent/src/types/response.rs
@@ -14,7 +14,9 @@ pub(in crate::types) mod usage;
 use orbit_common::types::{OrbitError, ToolCallTrace};
 use serde_json::Value;
 
-pub use envelope::{is_timeout, parse_and_validate_response, peek_response_status};
+pub use envelope::{
+    is_timeout, parse_and_validate_response, peek_response_status, response_envelope_protocol_check,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentInvocationSpec {

--- a/crates/orbit-agent/src/types/response/envelope.rs
+++ b/crates/orbit-agent/src/types/response/envelope.rs
@@ -38,6 +38,58 @@ pub fn peek_response_status(stdout: &str) -> Option<String> {
     Some(envelope.status)
 }
 
+/// Content-blind check that a provider's stdout *terminated with* a well-formed
+/// Orbit response envelope.
+///
+/// This is the step-completion protocol signal ([ORB-10449]), not a
+/// judgement about the work: it reads only the envelope frame — that stdout
+/// parsed as JSON, that a recognizable envelope is present, that its
+/// `schemaVersion` is supported, and that its `status` is one of the three
+/// protocol tokens. It never reads `result` or `error`, and it does not care
+/// *which* status was declared. An agent that reports `status: "failed"`
+/// completed its invocation contract exactly as much as one that reports
+/// success; an agent that yielded mid-turn emitted no envelope at all.
+///
+/// Deliberately excludes [`validate_exit_alignment`]. Exit agreement is a
+/// separate classification the CLI runner already performs, and folding it in
+/// here would make a `status: "failed"` envelope indistinguishable from a
+/// missing one — which is precisely the distinction this predicate exists to
+/// draw.
+pub fn response_envelope_protocol_check(stdout: &str) -> Result<(), OrbitError> {
+    // A provider may interleave non-protocol chatter with its output — a
+    // wrapped tool writing to the same stdout, a warning line — which makes the
+    // stream unparseable as a whole even though the agent did terminate
+    // properly. Fall back to scanning the raw text so this gate tests for the
+    // termination signal, not for the tidiness of the stream around it. Failing
+    // a completed step over stray stdout would be a worse defect than the one
+    // this check exists to catch.
+    let envelope = match parse_json_documents(stdout) {
+        Ok(documents) => documents
+            .iter()
+            .rev()
+            .find_map(find_agent_response_envelope),
+        Err(_) => find_agent_response_envelope_in_string(stdout),
+    };
+    let envelope = envelope.ok_or_else(|| {
+        OrbitError::AgentProtocolViolation(
+            "stdout does not contain an Orbit response envelope".to_string(),
+        )
+    })?;
+    if envelope.schema_version != 1 {
+        return Err(OrbitError::AgentProtocolViolation(format!(
+            "unsupported schemaVersion: {}",
+            envelope.schema_version
+        )));
+    }
+    if !matches!(envelope.status.as_str(), "success" | "failed" | "timeout") {
+        return Err(OrbitError::AgentProtocolViolation(format!(
+            "unknown status: {}",
+            envelope.status
+        )));
+    }
+    Ok(())
+}
+
 fn parse_json_documents(stdout: &str) -> Result<Vec<Value>, OrbitError> {
     let mut documents = Vec::new();
     for item in Deserializer::from_str(stdout).into_iter::<Value>() {

--- a/crates/orbit-agent/src/types/tests/response.rs
+++ b/crates/orbit-agent/src/types/tests/response.rs
@@ -202,6 +202,76 @@ mod parse {
         assert_eq!(trace.duration_ms, 1234);
     }
 
+    // ----- [ORB-10449] step-completion protocol check ---------------------
+
+    #[test]
+    fn protocol_check_rejects_prose_only_stdout() {
+        // The stall shape: the provider exits 0 having emitted only prose, so
+        // there is no termination signal at all.
+        let stdout = r#"{"type":"result","subtype":"success","result":"still waiting on the background run"}"#;
+        let error = response_envelope_protocol_check(stdout).expect_err("no envelope");
+        assert!(
+            error
+                .to_string()
+                .contains("does not contain an Orbit response envelope"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn protocol_check_is_blind_to_declared_status() {
+        // Frame only: every protocol status token satisfies the check, because
+        // an agent that declares failure still ran its contract to the end.
+        for status in ["success", "failed", "timeout"] {
+            let stdout =
+                format!(r#"{{"schemaVersion":1,"status":"{status}","result":{{}},"error":null}}"#);
+            response_envelope_protocol_check(&stdout)
+                .unwrap_or_else(|error| panic!("status {status} must satisfy the frame: {error}"));
+        }
+    }
+
+    #[test]
+    fn protocol_check_rejects_an_unsupported_frame() {
+        let unsupported_version =
+            r#"{"schemaVersion":2,"status":"success","result":{},"error":null}"#;
+        assert!(
+            response_envelope_protocol_check(unsupported_version)
+                .expect_err("bad version")
+                .to_string()
+                .contains("unsupported schemaVersion: 2")
+        );
+
+        let unknown_status = r#"{"schemaVersion":1,"status":"partial","result":{},"error":null}"#;
+        assert!(
+            response_envelope_protocol_check(unknown_status)
+                .expect_err("bad status")
+                .to_string()
+                .contains("unknown status: partial")
+        );
+    }
+
+    #[test]
+    fn protocol_check_finds_the_envelope_past_interleaved_non_json_stdout() {
+        // A wrapped tool writing to the same stdout makes the document stream
+        // unparseable, but the agent still terminated. Failing a completed step
+        // over stray output would be worse than the defect this check catches.
+        let stdout = concat!(
+            "[main abc1234] chore: commit\n",
+            " 1 file changed, 2 insertions(+)\n",
+            r#"{"schemaVersion":1,"status":"success","result":{},"error":null}"#
+        );
+        response_envelope_protocol_check(stdout).expect("envelope after chatter");
+    }
+
+    #[test]
+    fn protocol_check_accepts_a_claude_wrapped_envelope() {
+        // The healthy claude shape: the Orbit envelope arrives as a JSON string
+        // nested in the wrapper's `result`.
+        let inner = r#"{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}"#;
+        let stdout = format!(r#"{{"type":"result","subtype":"success","result":"{inner}"}}"#);
+        response_envelope_protocol_check(&stdout).expect("wrapped envelope");
+    }
+
     #[test]
     fn peek_response_status_extracts_envelope_failed_from_claude_shaped_wrapper() {
         // Mimics the bug in T20260508-17: claude exits 0 with `result.subtype`

--- a/crates/orbit-common/src/types/activity_job/activity_v2.rs
+++ b/crates/orbit-common/src/types/activity_job/activity_v2.rs
@@ -81,12 +81,41 @@ pub struct AgentLoopSpec {
     /// where the loop engine applies its own timeout.
     #[serde(default = "default_cli_wall_clock_timeout_seconds")]
     pub wall_clock_timeout_seconds: u64,
-    /// Require a valid Orbit response envelope before a CLI invocation may
-    /// report success. Defaults to `false` for artifact-backed activities,
-    /// whose durable task/review/git state is authoritative. Activities that
-    /// feed response fields into downstream templates opt in explicitly.
+    /// Require a fully valid Orbit response envelope — exit alignment,
+    /// `status: success`, object `result` — before a CLI invocation may report
+    /// success. This is the **content contract**: it exists for activities that
+    /// feed response fields into downstream templates. Defaults to `false` for
+    /// artifact-backed activities, whose durable task/review/git state is
+    /// authoritative.
+    ///
+    /// Distinct from [`AgentLoopSpec::require_completion_envelope`], which asks
+    /// only whether the invocation finished at all. Setting this implies the
+    /// completion check, since an absent envelope also fails validation.
     #[serde(default)]
     pub require_response_envelope: bool,
+    /// Require the CLI invocation to *terminate with* a well-formed Orbit
+    /// response envelope. This is the **step-completion protocol contract**
+    /// ([ORB-10449], extending ADR-0224), and it defaults to `true`.
+    ///
+    /// Every `backend: cli` invocation is prompted with the response-envelope
+    /// contract, so a provider that exits 0 with no envelope did not finish its
+    /// turn — it stopped mid-work. Checkpointing that as success lets the run
+    /// advance on work that never happened and defers the failure to whatever
+    /// deterministic gate notices first, several steps downstream.
+    ///
+    /// The check is content-blind: it reads the envelope *frame* only
+    /// (presence, `schemaVersion`, status token) and never `result` or `error`,
+    /// so an agent that declares `status: "failed"` satisfies it. Agent-loop
+    /// output remains advisory; only "did the contract complete" is enforced.
+    ///
+    /// Set to `false` only for an activity whose work is genuinely decorative —
+    /// one whose non-completion should not stop the pipeline. Record why in the
+    /// asset; the exception must be explicit, not incidental.
+    ///
+    /// **CLI only.** `backend: http` is driven by the engine's own loop, which
+    /// has its own termination accounting and never renders this envelope.
+    #[serde(default = "default_require_completion_envelope")]
+    pub require_completion_envelope: bool,
     /// Optional role tag (ADR-029). When set, the engine consults
     /// `[agent.<role>]` in `config.toml` and overrides `provider`/`model`/
     /// `backend` field-by-field at dispatch time. The step-level role on
@@ -671,4 +700,12 @@ const fn default_max_iterations() -> u32 {
 
 const fn default_cli_wall_clock_timeout_seconds() -> u64 {
     300
+}
+
+/// [ORB-10449] Fail closed. An agent-loop activity that omits the field gets
+/// the step-completion protocol check, so a new or legacy asset cannot silently
+/// inherit the pre-ORB-10449 behaviour of checkpointing a stalled agent as
+/// success.
+const fn default_require_completion_envelope() -> bool {
+    true
 }

--- a/crates/orbit-core/assets/activities/dispatch_agent.yaml
+++ b/crates/orbit-core/assets/activities/dispatch_agent.yaml
@@ -84,6 +84,21 @@ spec:
     Your final response is audit-only. Prefer concise JSON with `bundles`
     and `reasoning` when convenient, but the workflow does not consume it
     and downstream dispatch must not depend on it.
+  # The one sanctioned exception to the step-completion protocol check,
+  # declared rather than inherited.
+  #
+  # Every other agent_loop activity does real work whose absence must stop the
+  # pipeline, so an invocation that ends without a terminating Orbit response
+  # envelope fails its step. This one is genuinely decorative: dispatch is
+  # driven by the deterministic singleton bundles from `list_backlog_tasks`,
+  # and nothing reads these notes. An advisory note-taker that stalls has cost
+  # the run nothing, so failing the auto-pipeline over it would trade a real
+  # capability for a cosmetic one.
+  #
+  # This is a statement about *consequence*, not about output quality. Do not
+  # copy it onto an activity merely because its response is unstructured — the
+  # bar is that the activity not running at all is harmless.
+  require_completion_envelope: false
   tools:
     - orbit.task.*
     - orbit.friction.*

--- a/crates/orbit-core/src/command/activity.rs
+++ b/crates/orbit-core/src/command/activity.rs
@@ -289,6 +289,44 @@ mod tests {
         }
     }
 
+    /// [ORB-10449] The step-completion protocol contract, asserted across every
+    /// shipped `agent_loop` activity so an exception has to be *declared*.
+    ///
+    /// The flag defaults to `true`, so a new activity inherits the check by
+    /// omitting it; this test exists to make the opt-out list explicit and to
+    /// force a deliberate edit here when one is added. `dispatch_agent` is the
+    /// sole entry: its notes are advisory and nothing consumes them, so its
+    /// non-completion is harmless. Everything else does work whose absence must
+    /// stop the pipeline.
+    #[test]
+    fn agent_step_completion_contract_is_required_except_where_declared() {
+        const DECLARED_OPT_OUTS: &[&str] = &["dispatch_agent"];
+
+        let mut checked = 0;
+        for (name, yaml) in DEFAULT_ACTIVITY_FILES {
+            let asset = load_activity_asset(yaml)
+                .unwrap_or_else(|error| panic!("parse {name} activity: {error}"));
+            let ActivityV2Spec::AgentLoop(spec) = asset.spec.spec else {
+                continue;
+            };
+            checked += 1;
+            let expected = !DECLARED_OPT_OUTS.contains(name);
+            assert_eq!(
+                spec.require_completion_envelope, expected,
+                "{name} step-completion contract drifted; add it to DECLARED_OPT_OUTS \
+                 only if the activity not running at all is harmless"
+            );
+            // Opting into the content contract without the completion contract
+            // is incoherent: an absent envelope fails content validation too,
+            // so the pair would disagree about the same invocation.
+            assert!(
+                !spec.require_response_envelope || spec.require_completion_envelope,
+                "{name} requires response content but not step completion"
+            );
+        }
+        assert!(checked > 1, "expected several agent_loop activities");
+    }
+
     #[test]
     fn agent_review_is_read_only_and_requires_an_exact_head_verdict() {
         let (_, yaml) = DEFAULT_ACTIVITY_FILES

--- a/crates/orbit-core/src/runtime/v2_host/tests/v2_host_replay.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/v2_host_replay.rs
@@ -121,6 +121,7 @@ fn http_agent_loop_tool_update_persists_runtime_identity_family() {
         provider: Provider::Claude,
         wall_clock_timeout_seconds: 30,
         require_response_envelope: false,
+        require_completion_envelope: true,
         role: None,
         proc_allowed_programs: None,
     };

--- a/crates/orbit-core/tests/grok_cli_backend_smoke.rs
+++ b/crates/orbit-core/tests/grok_cli_backend_smoke.rs
@@ -74,6 +74,7 @@ fn installed_grok_cli_backend_smoke_captures_stdout_artifact() {
         provider: Provider::Grok,
         wall_clock_timeout_seconds: 120,
         require_response_envelope: true,
+        require_completion_envelope: true,
         role: None,
         proc_allowed_programs: None,
     };

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Utc;
-use orbit_agent::{Agent, AgentConfig, AgentOperation, AgentRequest, peek_response_status};
+use orbit_agent::{
+    Agent, AgentConfig, AgentOperation, AgentRequest, peek_response_status,
+    response_envelope_protocol_check,
+};
 use orbit_common::types::activity_job::{AgentLoopSpec, V2AuditEventKind};
 use orbit_common::types::{LearningInjectionCaps, LearningInjectionState, prepend_reminder_block};
 use orbit_common::utility::redaction::{PatternRedactor, redact_sensitive_env_text};
@@ -284,8 +287,28 @@ pub fn run_cli_backend(
         .as_ref()
         .and_then(|result| result.as_ref().err())
         .map(|error| response_diagnostic(error, &redaction));
-    // ADR-0224 / L-0087: parsing is advisory unless the activity opts into strict mode.
-    let success = exit_success && (!spec.require_response_envelope || response_envelope_valid);
+    // [ORB-10449]: the step-completion protocol check. Content-blind
+    // by construction — `response_envelope_protocol_check` reads the envelope
+    // frame and never `result`/`error`, so this asks only "did the invocation
+    // run its contract to the end", never "do we believe what it said". An
+    // agent that declares `status: "failed"` passes; one that yielded mid-turn
+    // emitted no envelope and does not.
+    //
+    // Only meaningful on an otherwise-clean exit: a timeout or nonzero exit
+    // already fails the step with a more specific message.
+    let completion_envelope_error = exit_success
+        .then(|| response_envelope_protocol_check(stdout_text.as_ref()))
+        .and_then(Result::err)
+        .map(|error| completion_diagnostic(&error.to_string(), &redaction));
+    let completion_protocol_violation =
+        spec.require_completion_envelope && completion_envelope_error.is_some();
+    // Two orthogonal contracts. `require_completion_envelope` gates step
+    // completion (above); `require_response_envelope` additionally gates the
+    // envelope's *content* for activities whose downstream templates consume it
+    // (ADR-0224 / L-0087) — outside that opt-in, parsing stays advisory.
+    let success = exit_success
+        && !completion_protocol_violation
+        && (!spec.require_response_envelope || response_envelope_valid);
     let trace = parse_cli_invocation_trace(
         stdout.protocol_bytes(),
         stderr.protocol_bytes(),
@@ -309,6 +332,13 @@ pub fn run_cli_backend(
         ))
     } else if spec.require_response_envelope {
         response_envelope_error.clone()
+    } else if completion_protocol_violation {
+        // Ordered last on purpose: an activity that opted into the content
+        // contract already produced a strictly more specific diagnostic above,
+        // and the two conditions largely overlap. This branch is what the
+        // remaining activities — the ones that only ever had the advisory
+        // parse — now report instead of silently checkpointing success.
+        completion_envelope_error.clone()
     } else {
         None
     };
@@ -346,6 +376,18 @@ pub fn run_cli_backend(
         (
             "response_envelope_error",
             response_envelope_error.map_or(Value::Null, Value::String),
+        ),
+        (
+            "completion_envelope_required",
+            Value::Bool(spec.require_completion_envelope),
+        ),
+        (
+            "completion_envelope_satisfied",
+            Value::Bool(!exit_success || completion_envelope_error.is_none()),
+        ),
+        (
+            "completion_envelope_error",
+            completion_envelope_error.map_or(Value::Null, Value::String),
         ),
         ("stdout_text", Value::String(stdout_text)),
         (
@@ -403,6 +445,27 @@ pub fn run_cli_backend(
 }
 
 fn response_diagnostic(error: &str, redactor: &PatternRedactor) -> String {
+    format!(
+        "cli response envelope invalid: {}",
+        bounded_diagnostic(error, redactor)
+    )
+}
+
+/// [ORB-10449] Name the protocol violation for what it is. The old surfaced
+/// failure was whatever deterministic gate tripped several steps later, which
+/// reads as a downstream defect; this says the agent stopped before finishing
+/// its turn and points at the evidence.
+fn completion_diagnostic(error: &str, redactor: &PatternRedactor) -> String {
+    format!(
+        "agent step did not complete: the provider exited 0 but stdout carried no valid \
+         terminating Orbit response envelope ({}). The invocation ended without finishing its \
+         contract — typically an agent that yielded mid-work — so this step's work is incomplete \
+         and only what it persisted before stopping is durable.",
+        bounded_diagnostic(error, redactor)
+    )
+}
+
+fn bounded_diagnostic(error: &str, redactor: &PatternRedactor) -> String {
     let redacted = redactor.apply_str(&redact_sensitive_env_text(error));
     let bounded: String = redacted
         .chars()
@@ -413,7 +476,7 @@ fn response_diagnostic(error: &str, redactor: &PatternRedactor) -> String {
     } else {
         ""
     };
-    format!("cli response envelope invalid: {bounded}{suffix}")
+    format!("{bounded}{suffix}")
 }
 
 struct CliLearningContext {

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -217,8 +217,11 @@ fn run_cli_backend_rejects_schema_invalid_success_envelope() {
     );
 }
 
+/// [ORB-10449] The regression this task exists for: an agent that exits 0 with
+/// prose and no envelope did not finish its turn, and must not checkpoint as
+/// success just because the activity never opted into the *content* contract.
 #[test]
-fn run_cli_backend_accepts_claude_success_prose_without_envelope_for_artifact_activity() {
+fn run_cli_backend_fails_artifact_activity_when_exit_zero_carries_no_envelope() {
     let temp = tempdir().expect("tempdir");
     let script = temp.path().join("claude");
     let stdout = serde_json::json!({
@@ -254,16 +257,204 @@ fn run_cli_backend_accepts_claude_success_prose_without_envelope_for_artifact_ac
     )
     .expect("run cli backend");
 
+    assert!(!outcome.success);
+    assert_eq!(outcome.output["exit_code"], 0);
+    // The content contract is still opt-in and still off here — the step failed
+    // on the completion protocol alone.
+    assert_eq!(outcome.output["response_envelope_required"], false);
+    assert_eq!(outcome.output["completion_envelope_required"], true);
+    assert_eq!(outcome.output["completion_envelope_satisfied"], false);
+    let message = outcome.message.expect("completion protocol message");
+    assert!(message.contains("agent step did not complete"), "{message}");
+    assert!(
+        message.contains("does not contain an Orbit response envelope"),
+        "{message}"
+    );
+}
+
+/// The declared exception (`dispatch_agent`): an activity whose work is
+/// decorative keeps the pre-ORB-10449 behaviour, and the invalid envelope is
+/// still recorded as a diagnostic rather than acted on.
+#[test]
+fn run_cli_backend_keeps_advisory_activity_successful_without_an_envelope() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("claude");
+    write_executable(
+        &script,
+        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' 'advisory grouping notes, no envelope'\n",
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-advisory-response",
+        "claude:sonnet",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let mut spec = test_agent_loop_spec_for("claude", Duration::from_secs(5));
+    spec.require_completion_envelope = false;
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-advisory-response",
+        audit,
+        &serde_json::json!({"prompt": "group the backlog"}),
+        None,
+    )
+    .expect("run cli backend");
+
     assert!(outcome.success);
     assert!(outcome.message.is_none());
-    assert_eq!(outcome.output["exit_code"], 0);
-    assert_eq!(outcome.output["response_envelope_required"], false);
-    assert_eq!(outcome.output["response_envelope_valid"], false);
+    assert_eq!(outcome.output["completion_envelope_required"], false);
+    assert_eq!(outcome.output["completion_envelope_satisfied"], false);
     assert!(
-        outcome.output["response_envelope_error"]
+        outcome.output["completion_envelope_error"]
             .as_str()
-            .is_some_and(|message| message.contains("does not contain an Orbit response envelope"))
+            .is_some_and(|message| message.contains("agent step did not complete"))
     );
+}
+
+/// The completion check is content-blind. An agent that declares
+/// `status: "failed"` ran its contract to the end, so it satisfies the protocol
+/// gate; whether that declared failure means anything is a question for durable
+/// state, not for this step's success. Guards the doctrine boundary: no
+/// activity decision may read an agent-loop response's content.
+#[test]
+fn run_cli_backend_completion_check_accepts_a_declared_failure_envelope() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("codex");
+    write_executable(
+        &script,
+        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"failed\",\"result\":{},\"error\":{\"code\":\"blocked\",\"message\":\"cannot proceed\"}}'\n",
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-declared-failure",
+        "codex:gpt-5.5",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let spec = test_agent_loop_spec(Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-declared-failure",
+        audit,
+        &serde_json::json!({"task_id": "ORB-10449"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(outcome.success, "content must not decide step completion");
+    assert_eq!(outcome.output["completion_envelope_required"], true);
+    assert_eq!(outcome.output["completion_envelope_satisfied"], true);
+    assert!(outcome.output["completion_envelope_error"].is_null());
+}
+
+/// A provider that interleaves a wrapped tool's stdout with its own protocol
+/// output still terminated properly. The completion gate must key on the
+/// termination signal, not on the tidiness of the stream around it — a false
+/// positive here would fail completed work.
+#[test]
+fn run_cli_backend_completion_check_tolerates_interleaved_non_json_stdout() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("codex");
+    write_executable(
+        &script,
+        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '[main abc1234] some commit'\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\n",
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-interleaved-stdout",
+        "codex:gpt-5.5",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let spec = test_agent_loop_spec(Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-interleaved-stdout",
+        audit,
+        &serde_json::json!({"task_id": "ORB-10449"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(outcome.success);
+    assert_eq!(outcome.output["completion_envelope_satisfied"], true);
+}
+
+/// [ORB-10449] `jrun-20260726-1758-5` replayed as a fixture: claude exits 0
+/// with `stop_reason: end_turn` after parking itself on a background process,
+/// having emitted no envelope. Before this change the step checkpointed as
+/// success and the run failed three steps later at the delivery gate.
+#[test]
+fn run_cli_backend_fails_on_the_jrun_20260726_1758_5_stall_shape() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("claude");
+    let stdout = serde_json::json!({
+        "type": "result",
+        "subtype": "success",
+        "is_error": false,
+        "stop_reason": "end_turn",
+        "result": "The nextest run is still executing in the background (no failures through \
+                   1782/2693 tests so far). I'll wait for the scheduled wakeup or task \
+                   notification before analyzing results and continuing the ORB-10436 audit."
+    })
+    .to_string();
+    // The captured prose contains an apostrophe, so route it through a file
+    // rather than a single-quoted shell literal.
+    let stdout_file = temp.path().join("stdout.json");
+    fs::write(&stdout_file, &stdout).expect("write stall stdout fixture");
+    write_executable(
+        &script,
+        &format!(
+            "#!/bin/sh\ncat > /dev/null\ncat '{}'\n",
+            stdout_file.display()
+        ),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "jrun-20260726-1758-5",
+        "claude:sonnet",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    // `agent_implement`'s shipped shape: artifact-backed, so the content
+    // contract is off. Only the completion protocol stands between a stalled
+    // implementer and a green checkpoint.
+    let spec = test_agent_loop_spec_for("claude", Duration::from_secs(5));
+    assert!(!spec.require_response_envelope);
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "jrun-20260726-1758-5",
+        audit,
+        &serde_json::json!({"task_id": "ORB-10436"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(
+        !outcome.success,
+        "a stalled implementer must not checkpoint"
+    );
+    assert_eq!(outcome.output["exit_code"], 0);
+    assert_eq!(outcome.output["timed_out"], false);
+    let message = outcome.message.expect("stall message");
+    assert!(message.contains("agent step did not complete"), "{message}");
 }
 
 #[test]

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
@@ -346,6 +346,7 @@ pub(in crate::activity_job::cli_runner) fn test_agent_loop_spec(
         provider: Provider::Codex,
         wall_clock_timeout_seconds: timeout.as_secs(),
         require_response_envelope: false,
+        require_completion_envelope: true,
         role: None,
         proc_allowed_programs: None,
     }
@@ -372,6 +373,7 @@ pub(in crate::activity_job::cli_runner) fn test_agent_loop_spec_for(
         provider,
         wall_clock_timeout_seconds: timeout.as_secs(),
         require_response_envelope: false,
+        require_completion_envelope: true,
         role: None,
         proc_allowed_programs: None,
     }

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -580,8 +580,28 @@ fn run_agent_loop_activity(
             }
             run_agent_loop_via_driver(host, spec, run_id, audit, input, fs_profile)
         }
-        Backend::Cli => run_cli_backend(host, spec, run_id, audit, input, fs_profile),
+        Backend::Cli => run_cli_backend(host, spec, run_id, audit, input, fs_profile)
+            .map(|outcome| label_failure_with_step(activity_name, outcome)),
     }
+}
+
+/// [ORB-10449] Prefix a failing CLI agent-loop message with the step that
+/// produced it.
+///
+/// A run surfaces only its terminal message, and the executor's fallback
+/// (`step `<id>` completed with success=false`) is used only when the step
+/// reports no message at all. So a step that *does* report one was previously
+/// anonymous in the run record — an operator saw the symptom without the
+/// origin. Naming the step here keeps that fix in one place for every CLI
+/// agent-loop failure mode (timeout, nonzero exit, protocol violation,
+/// invalid envelope).
+fn label_failure_with_step(activity_name: &str, mut outcome: DispatchOutcome) -> DispatchOutcome {
+    if !outcome.success
+        && let Some(message) = outcome.message.take()
+    {
+        outcome.message = Some(format!("step `{activity_name}`: {message}"));
+    }
+    outcome
 }
 
 fn run_agent_loop_via_driver(

--- a/crates/orbit-engine/src/activity_job/job_executor/step.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/step.rs
@@ -75,6 +75,12 @@ pub(super) fn run_step_with_retry(
     };
 
     let mut last_err: Option<DispatchError> = None;
+    // [ORB-10449] Keep the last failing attempt's diagnostic. A step that fails
+    // via `Ok(success: false)` — every CLI agent-loop failure, including the
+    // step-completion protocol violation — used to have its message dropped on
+    // retry exhaustion, leaving the run's terminal error as the generic
+    // "completed with success=false" fallback.
+    let mut last_failed_outcome: Option<StepOutcome> = None;
     let max_attempts = retry.max_attempts.max(1);
     // Full-jitter backoff (ORB-10006): parallel workers retrying the same
     // failing dependency draw sleeps from decorrelated streams instead of
@@ -87,10 +93,12 @@ pub(super) fn run_step_with_retry(
                     return Ok(outcome);
                 }
                 // Treat a "not-success-but-no-error" outcome as retryable:
-                // another attempt may succeed. No built-in dispatch leaf
-                // produces this today (leaves signal failure via `Err`); it is
-                // retained as the block-level outcome contract. See ADR-0194.
+                // another attempt may succeed. This is the block-level outcome
+                // contract (ADR-0194), and the CLI agent-loop leaf reaches it
+                // for every provider-level failure — timeout, nonzero exit, and
+                // the [ORB-10449] step-completion protocol violation.
                 last_err = None;
+                last_failed_outcome = Some(outcome);
             }
             Err(err) if err.is_non_retryable() => {
                 emit_denied_if_applicable(&err, &step.id, &ctx.audit, ctx.task_id());
@@ -124,11 +132,11 @@ pub(super) fn run_step_with_retry(
 
     match last_err {
         Some(err) => recover_or_return_original(step, ctx, err, max_attempts, max_attempts),
-        None => Ok(StepOutcome {
+        None => Ok(last_failed_outcome.unwrap_or(StepOutcome {
             success: false,
             output: Value::Null,
             message: None,
-        }),
+        })),
     }
 }
 

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/mod.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/mod.rs
@@ -193,6 +193,10 @@ pub(super) struct ScriptedHost {
     /// [ORB-10385] Action names this host reports as absent from its registry,
     /// modelling a runtime older than the loaded catalog asset.
     unregistered: Vec<String>,
+    /// [ORB-10449] Executable this host hands back for `backend: cli` agent
+    /// loops. `None` keeps the default "no CLI mapping" refusal, so only tests
+    /// that opt in can reach the CLI runner.
+    cli_program: Option<String>,
 }
 
 impl ScriptedHost {
@@ -208,7 +212,15 @@ impl ScriptedHost {
             in_flight: AtomicUsize::new(0),
             peak_in_flight: AtomicUsize::new(0),
             unregistered: Vec::new(),
+            cli_program: None,
         }
+    }
+
+    /// [ORB-10449] Route `backend: cli` agent loops at `program`, so a test can
+    /// drive a real provider invocation through the whole step machinery.
+    pub(super) fn with_cli_program(mut self, program: impl Into<String>) -> Self {
+        self.cli_program = Some(program.into());
+        self
     }
 
     /// [ORB-10385] Make this host report `actions` as unregistered, the way an
@@ -305,9 +317,15 @@ impl V2RuntimeHost for ScriptedHost {
         &self,
         _provider: &str,
     ) -> Result<super::super::dispatcher::ResolvedCliExecutor, DispatchError> {
-        Err(DispatchError::CliInvocationFailed(
-            "scripted host: no CLI mapping".into(),
-        ))
+        match &self.cli_program {
+            Some(command) => Ok(super::super::dispatcher::ResolvedCliExecutor {
+                command: command.clone(),
+                args: Vec::new(),
+            }),
+            None => Err(DispatchError::CliInvocationFailed(
+                "scripted host: no CLI mapping".into(),
+            )),
+        }
     }
 
     fn tool_context_for_activity(

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
@@ -666,6 +666,7 @@ fn recovery_agent_loop_spec(
         provider,
         wall_clock_timeout_seconds: 30,
         require_response_envelope: false,
+        require_completion_envelope: true,
         role,
         proc_allowed_programs: None,
     }

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/step.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/step.rs
@@ -271,3 +271,184 @@ fn backoff_bound_grows_monotonically_to_cap_under_exponential() {
     }
     assert_eq!(previous, retry.backoff_cap_ms, "bound must saturate at cap");
 }
+
+// ----- [ORB-10449] Step-completion protocol -------------------------------
+
+use orbit_common::types::activity_job::{AgentLoopSpec, Backend, OnDenial, Provider};
+
+/// Build the shipped `implement_one` shape: a `backend: cli` agent loop that is
+/// artifact-backed, so the *content* contract stays off and only the
+/// step-completion contract can catch a stalled agent.
+fn agent_implement_shaped_step(id: &str, retry: Option<RetrySpec>) -> JobV2Step {
+    let spec = AgentLoopSpec {
+        instruction: "implement the task".to_string(),
+        tools: Vec::new(),
+        on_denial: OnDenial::Terminate,
+        model: None,
+        max_iterations: 1,
+        backend: Backend::Cli,
+        provider: Provider::Claude,
+        wall_clock_timeout_seconds: 30,
+        require_response_envelope: false,
+        require_completion_envelope: true,
+        role: None,
+        proc_allowed_programs: None,
+    };
+    JobV2Step {
+        id: id.to_string(),
+        when: None,
+        retry,
+        recovery_activity: None,
+        resolved_recovery_activity: None,
+        body: JobV2StepBody::Target(TargetStep {
+            spec: ActivityV2Spec::AgentLoop(spec),
+            activity_name: None,
+            fs_profile: None,
+            default_input: None,
+            timeout_seconds: 0,
+            session: None,
+            role: None,
+        }),
+    }
+}
+
+/// Write a fake provider that exits 0 after printing `stdout` and nothing else.
+fn stalled_provider(dir: &std::path::Path, stdout: &str) -> std::path::PathBuf {
+    let script = dir.join("claude");
+    std::fs::write(
+        &script,
+        format!("#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{stdout}'\n"),
+    )
+    .expect("write fake provider");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script).expect("stat").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script, perms).expect("chmod");
+    }
+    script
+}
+
+/// `jrun-20260726-1758-5` replayed end to end: the implementer exits 0 with
+/// prose and no response envelope. The run must fail *at that step* — not
+/// checkpoint it and surface a downstream symptom several steps later.
+#[test]
+fn stalled_agent_step_fails_at_the_step_that_produced_it() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let script = stalled_provider(
+        temp.path(),
+        "{\"type\":\"result\",\"subtype\":\"success\",\"stop_reason\":\"end_turn\",\
+         \"result\":\"Waiting on the background nextest run before continuing.\"}",
+    );
+    let host = ScriptedHost::new([("commit", vec![Action::Ok(json!({"committed": true}))])])
+        .with_cli_program(script.display().to_string());
+    let job = job_with_steps(vec![
+        agent_implement_shaped_step("implement_one", None),
+        target_step("commit", "commit"),
+    ]);
+
+    let writer = std::sync::Arc::new(test_writer("run-stalled"));
+    let outcome = execute_job(
+        &job,
+        json!({"task_id": "ORB-10436"}),
+        "run-stalled",
+        writer.clone(),
+        &host,
+    )
+    .expect("execute_job ok");
+
+    assert!(!outcome.success, "a stalled implementer must fail its step");
+    let message = outcome.message.expect("terminal message");
+    // Criterion: the terminal error names the step *and* the protocol
+    // violation, rather than whatever gate would have tripped later.
+    assert!(message.contains("implement_one"), "{message}");
+    assert!(message.contains("agent step did not complete"), "{message}");
+    assert!(
+        message.contains("does not contain an Orbit response envelope"),
+        "{message}"
+    );
+
+    // Recovery/retry contract: the step is not retried, and the run stops
+    // there — no later step runs on work that never happened.
+    assert_eq!(
+        host.call_count("commit"),
+        0,
+        "downstream steps must not run after a protocol violation"
+    );
+    // The step is recorded as failed, so a resume cannot skip past it.
+    let events = writer.events_snapshot().expect("audit");
+    assert!(
+        events.iter().any(|event| matches!(
+            &event.kind,
+            V2AuditEventKind::StepFinished { step_id, outcome, .. }
+                if step_id == "implement_one" && outcome == "failed"
+        )),
+        "implement_one must finish as failed, never as a success checkpoint"
+    );
+}
+
+/// An agent step that *does* terminate properly still succeeds, so the gate
+/// costs nothing on the healthy path.
+#[test]
+fn completed_agent_step_still_checkpoints_and_advances() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let script = stalled_provider(
+        temp.path(),
+        "{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}",
+    );
+    let host = ScriptedHost::new([("commit", vec![Action::Ok(json!({"committed": true}))])])
+        .with_cli_program(script.display().to_string());
+    let job = job_with_steps(vec![
+        agent_implement_shaped_step("implement_one", None),
+        target_step("commit", "commit"),
+    ]);
+
+    let outcome = run_job(
+        &host,
+        &job,
+        json!({"task_id": "ORB-10449"}),
+        "run-completed",
+    );
+
+    assert!(outcome.success, "{:?}", outcome.message);
+    assert_eq!(host.call_count("commit"), 1);
+}
+
+/// [ORB-10449] Retry exhaustion must preserve the last attempt's diagnostic.
+/// A step that fails via `Ok(success: false)` — which is every CLI agent-loop
+/// failure — used to have its message dropped, leaving the run's terminal
+/// error as the generic "completed with success=false" fallback.
+#[test]
+fn retry_exhaustion_preserves_the_last_failure_message() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let script = stalled_provider(
+        temp.path(),
+        "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"still working\"}",
+    );
+    let host = ScriptedHost::new([]).with_cli_program(script.display().to_string());
+    let job = job_with_steps(vec![agent_implement_shaped_step(
+        "implement_one",
+        Some(RetrySpec {
+            max_attempts: 2,
+            initial_backoff_ms: 1,
+            backoff_cap_ms: 1,
+            backoff_strategy: BackoffStrategy::Linear,
+        }),
+    )]);
+
+    let outcome = run_job(
+        &host,
+        &job,
+        json!({"task_id": "ORB-10449"}),
+        "run-retry-msg",
+    );
+
+    assert!(!outcome.success);
+    let message = outcome.message.expect("terminal message");
+    assert!(
+        !message.contains("completed with success=false"),
+        "the generic fallback hides the real cause: {message}"
+    );
+    assert!(message.contains("agent step did not complete"), "{message}");
+}

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
@@ -105,6 +105,7 @@ fn inline_agent_loop_spec() -> AgentLoopSpec {
         provider: Provider::Claude,
         wall_clock_timeout_seconds: 30,
         require_response_envelope: false,
+        require_completion_envelope: true,
         role: None,
         proc_allowed_programs: None,
     }

--- a/crates/orbit-engine/src/activity_job/tests/agent_loop_driver.rs
+++ b/crates/orbit-engine/src/activity_job/tests/agent_loop_driver.rs
@@ -153,6 +153,7 @@ fn replay_spec(on_denial: OnDenial) -> AgentLoopSpec {
         provider: Provider::Claude,
         wall_clock_timeout_seconds: 30,
         require_response_envelope: false,
+        require_completion_envelope: true,
         role: None,
         proc_allowed_programs: None,
     }

--- a/crates/orbit-engine/src/activity_job/tests/agent_role.rs
+++ b/crates/orbit-engine/src/activity_job/tests/agent_role.rs
@@ -20,6 +20,7 @@ fn inline_spec() -> AgentLoopSpec {
         provider: Provider::Claude,
         wall_clock_timeout_seconds: 30,
         require_response_envelope: false,
+        require_completion_envelope: true,
         role: Some(AgentRole::Implementer),
         proc_allowed_programs: None,
     }

--- a/crates/orbit-engine/src/activity_job/tests/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/tests/dispatcher.rs
@@ -121,6 +121,7 @@ fn per_dispatch_agent_override_sets_provider_model_and_renders_family() {
         max_iterations: 20,
         wall_clock_timeout_seconds: 300,
         require_response_envelope: false,
+        require_completion_envelope: true,
         role: None,
         proc_allowed_programs: None,
     });

--- a/crates/orbit-engine/tests/v2_cli_backend.rs
+++ b/crates/orbit-engine/tests/v2_cli_backend.rs
@@ -64,10 +64,13 @@ fn scenario_a_cli_dispatch_emits_envelope_events() -> Result<(), Box<dyn std::er
     let tmp_audit = tempfile::tempdir()?;
     let (writer, _sink) = build_writer(tmp_audit.path(), "smoke-cli-a")?;
 
-    // `claude` that ignores stdin and prints a canned reply.
+    // `claude` that ignores stdin and prints a canned reply. [ORB-10449] The
+    // reply is a real Orbit response envelope: exiting 0 without one is now a
+    // step-completion protocol violation, so a bare `{"status":"ok"}` would
+    // fail the step for a reason this scenario is not about.
     let fake = fake_cli(
         "claude",
-        "#!/bin/sh\ncat > /dev/null\necho '{\"status\":\"ok\"}'\n",
+        "#!/bin/sh\ncat > /dev/null\necho '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\n",
     )?;
 
     let spec = cli_agent_loop_spec(None);
@@ -314,7 +317,12 @@ fn scenario_h_cli_reference_asset_round_trip() -> Result<(), Box<dyn std::error:
 
     let tmp_audit = tempfile::tempdir()?;
     let (writer, _sink) = build_writer(tmp_audit.path(), "smoke-cli-h")?;
-    let fake = fake_cli("claude", "#!/bin/sh\ncat > /dev/null\necho ok\n")?;
+    // [ORB-10449] A round-tripped asset gets the default completion contract,
+    // so the fake must terminate with a real envelope like a live provider.
+    let fake = fake_cli(
+        "claude",
+        "#!/bin/sh\ncat > /dev/null\necho '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\n",
+    )?;
     let host = ScriptHost::new(fake.cli_path());
     let outcome = dispatch_v2_activity(V2DispatchInput {
         activity_name: &asset.name,
@@ -367,9 +375,11 @@ fn scenario_j_cli_executor_static_args_are_audited() -> Result<(), Box<dyn std::
     let tmp_audit = tempfile::tempdir()?;
     let (writer, _sink) = build_writer(tmp_audit.path(), "smoke-cli-j")?;
 
+    // [ORB-10449] Terminate with a real envelope; this scenario is about argv,
+    // not about the step-completion protocol.
     let fake = fake_cli(
         "codex",
-        "#!/bin/sh\ncat > /dev/null\necho '{\"status\":\"ok\"}'\n",
+        "#!/bin/sh\ncat > /dev/null\necho '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\n",
     )?;
 
     let mut spec = cli_agent_loop_spec(Some(Provider::Codex));
@@ -438,6 +448,7 @@ fn cli_agent_loop_spec(provider: Option<Provider>) -> AgentLoopSpec {
         provider: provider.unwrap_or(Provider::Claude),
         wall_clock_timeout_seconds: 30,
         require_response_envelope: false,
+        require_completion_envelope: true,
         role: None,
         proc_allowed_programs: None,
     }
@@ -517,6 +528,7 @@ fn synthetic_loop_session_cli_job() -> JobV2 {
                 provider: Provider::Claude,
                 wall_clock_timeout_seconds: 30,
                 require_response_envelope: false,
+                require_completion_envelope: true,
                 role: None,
                 proc_allowed_programs: None,
             }),

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -55,6 +55,8 @@ The common `agent_loop` fields are:
 - `wall_clock_timeout_seconds`
 - `require_response_envelope` (default `false`; opt in only when downstream
   templates consume structured response fields)
+- `require_completion_envelope` (default `true`; opt **out** only for an
+  activity whose non-completion is harmless — see §7.6a)
 
 A former `Groundhog(GroundhogSpec)` variant (a sibling activity kind from [T20260420-0510-2]) was removed as unused in [ORB-10332]; activity specs are now only `agent_loop` and `deterministic`.
 
@@ -242,6 +244,75 @@ The CLI path is driven by `cli_runner.rs`, added in [T20260419-0104]. The flow i
 7. Spawn the subprocess in that cwd with a wall-clock timeout.
 8. Emit `CliInvocationFinished` with stdout/stderr blob refs and timeout state.
 9. Parse the captured provider output with the existing Orbit response parser and persist its `InvocationTrace` through the host. After [ORB-10231] / [ADR-0224], envelope parsing is best-effort by default: provider exit status and timeout determine transport success while durable task/review/git artifacts remain authoritative. A valid envelope still projects its result fields, and an invalid or absent envelope is retained as bounded/redacted diagnostic metadata. Activities whose downstream templates require response fields set `require_response_envelope: true`, preserving fail-closed validation for that explicit contract.
+10. Apply the step-completion protocol check ([ORB-10449]) — see §7.6a.
+
+### 7.6a Step-completion protocol vs. response content
+
+[ORB-10231] / [ADR-0224] left one flag carrying two unrelated questions, and the
+second one went unasked. `require_response_envelope: false` was read as "this
+activity's response does not matter", when what it actually means is "nothing
+downstream *consumes* this activity's response". Whether the invocation ran its
+contract to the end is a different question, and nothing was asking it.
+
+[ORB-10449] splits them:
+
+| Flag | Question | Default | Reads |
+|---|---|---|---|
+| `require_completion_envelope` | Did the invocation finish? | `true` | envelope *frame* only |
+| `require_response_envelope` | Can downstream templates trust the fields? | `false` | full envelope incl. `result` |
+
+The completion check (`response_envelope_protocol_check` in `orbit-agent`) asks
+only whether stdout carried a well-formed Orbit response envelope: present,
+`schemaVersion: 1`, and one of the three protocol status tokens. It never reads
+`result` or `error`, and it does not care *which* status was declared — an agent
+that reports `status: "failed"` completed its contract exactly as much as one
+that reports success. **This keeps the doctrine intact**: agent-loop output stays
+advisory, and no job or activity decision reads its content. "Did the contract
+complete" is a property of the invocation, not a claim the agent makes about its
+work.
+
+Every `backend: cli` invocation is prompted with the response-envelope contract
+(`render_prompt_with_embedded_envelope`), so exiting 0 without one is a protocol
+violation, not a stylistic choice. The check applies only under `backend: cli`;
+`backend: http` is driven by the engine's own loop, which has its own
+termination accounting.
+
+Deliberate asymmetry: the completion check is *more* permissive than the content
+parser about stream shape. When the document stream will not parse — a wrapped
+tool writing to the same stdout, a stray warning line — it falls back to scanning
+the raw text for an embedded envelope. Failing a step that genuinely completed,
+over stdout tidiness, would be a worse defect than the one this check exists to
+catch.
+
+**Failure semantics.** A violation fails the step exactly as an opted-in envelope
+failure does: `DispatchOutcome { success: false }` with a message naming the step
+and the violation. Concretely, for `implement_one` in `task_pr_pipeline`:
+
+- **Not retried.** The step has no `retry:` block, and a repeat invocation of a
+  stalled agent has no new information to work with.
+- **No recovery agent.** `recovery_activity` fires on `Err`, not on a failed
+  outcome — which is the behaviour we want here. `step_failure_recovery` exists
+  to repair the *delivery path for completed work*; a stalled implementer is
+  incomplete work, and having it publish the candidate is the opposite of the fix.
+- **Run terminalizes at that step.** No later step runs, the step is audited as
+  `failed`, and the job-level `failure_activity` (`pr_failure_handoff`,
+  [ADR-0246]) still fires to preserve recoverable work.
+- **Task and worktree.** The worktree is retained with whatever the agent wrote
+  before it stopped; tasks coupled to the run move to `blocked` under the normal
+  terminal-run rules. Re-dispatch is an orchestrator decision, not an automatic
+  one.
+
+The durable `execution_summary` delivery gate ([ORB-10313] / [ADR-0236]) is
+unchanged and remains the last line. Nothing here weakens it, bypasses it, or
+synthesizes a summary to satisfy it — this check simply means a stalled
+implementer no longer reaches it.
+
+**Declared exceptions.** `dispatch_agent` is the only activity shipping
+`require_completion_envelope: false`: its backlog-grouping notes are advisory,
+deterministic singleton bundles drive dispatch, and nothing reads them, so its
+non-completion costs the run nothing. The bar is *consequence* — that the
+activity not running at all is harmless — not output quality. The opt-out list is
+pinned by a test so a new exception has to be a deliberate edit.
 
 After [T20260426-2313], stdout/stderr readers emit line-level `tracing::info!` events while the child runs, carrying `provider`, `stream`, `job_run_id`, `task_id`, and `line`. After [T20260508-8], those events also carry `cwd` when the CLI subprocess has a resolved cwd. After [T20260426-2349], the default tracing subscriber redacts formatted output. The readers still retain original bytes for the existing audit/blob path, so run logs follow blob refs rather than the live feed.
 

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -627,6 +627,21 @@ Rejected alternatives: reconciling by parent linkage (no parent run id is persis
 - Structured-output activities remain fail-closed through an explicit per-activity contract.
 - Cost: activity authors must classify the handoff correctly, and response-consuming activities need a regression that pins strict mode.
 
+**Amended by [ORB-10449].** This ADR's flag answers *"do downstream templates
+consume the response?"* — but it was also, silently, the only thing asking *"did
+the invocation finish at all?"*, and for artifact-backed activities the answer was
+"nobody is asking". A separate content-blind `require_completion_envelope`
+(default `true`) now carries the second question: it checks the envelope frame
+only — presence, `schemaVersion`, status token — never `result`/`error`, so an
+agent declaring `status: "failed"` satisfies it and agent-loop output stays
+advisory. The two flags are orthogonal and the completion check is deliberately
+more permissive about stream shape. Narrative, failure/recovery semantics, and
+the single declared exception (`dispatch_agent`) are in
+[§7.6a of `2_design.md`](./2_design.md). An ADR of its own is warranted — the
+executing activity's tool grant did not include `orbit.adr.add`, and
+[CONVENTIONS](../CONVENTIONS.md) forbids hand-authoring an unallocated heading,
+so allocation and the `4_decisions.md` entry are tracked as [ORB-10454].
+
 ---
 
 ## ADR-0225 — PR handoff recovery follows job checkpoints and exact remote leases
@@ -827,5 +842,6 @@ Recognition is the entire change: no safety gate moved. Non-terminal run, `--old
 - **[ORB-10313]** — Fail delivery before Git mutation when the durable execution outcome is not `Outcome: success`.
 - **[ORB-10363]** — Rebase task candidates after concurrent base advances and publish blocked PRs instead of stranding failed work.
 - **[ORB-10332]** — Remove the unused Groundhog activity kind and the epic/parallel pipeline layer (`task_epic_pipeline`, `epic_orchestrator`, `pipeline_wait`, legacy parallel-batch executor).
+- **[ORB-10449]** — Split step-completion protocol from response content so a stalled agent-loop step fails where it happened (amends [ADR-0224]; see [§7.6a of `2_design.md`](./2_design.md)).
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10449](https://orbit-cli.com/tasks/ORB-10449) — Agent-loop steps checkpoint success on a stalled implementer, deferring the failure to the delivery gate

### Description

## Problem

An `agent_loop` step can checkpoint as `success` when its agent invocation did no useful work and returned no valid Orbit response envelope. The run then advances several steps before failing, and it fails with an error that describes a symptom rather than the cause.

Observed on `jrun-20260726-1758-5` (task ORB-10436, `task_pr_pipeline`, crew `sonnet`). The third `implement_one` invocation ended its own turn mid-work, waiting on a background `cargo nextest` process for a wakeup that a one-shot pipeline invocation has no mechanism to deliver:

> "The nextest run is still executing in the background (no failures through 1782/2693 tests so far). I'll wait for the scheduled wakeup or task notification before analyzing results and continuing the ORB-10436 audit."

`exit_code: 0`, `stop_reason: end_turn`, `terminal_reason: completed` — not a turn cap or wall-clock cutoff. The run record for that step shows:

```
response_envelope_required: false
response_envelope_valid:    false
response_envelope_error:    "cli response envelope invalid: agent protocol violation:
                             stdout does not contain an Orbit response envelope"
```

Because the envelope was not required, the invalid envelope was recorded but not acted on; `implement_one` and `implement_bundle` both reported `success`. The run reached `commit`, where the durable delivery gate correctly refused:

```
deterministic action `git_commit` failed: task 'ORB-10436' requires a meaningful
persisted execution_summary before delivery
```

Two costs. First, diagnosis: the surfaced failure names a missing `execution_summary` at `commit`, so an operator reads it as a summary-persistence problem (the F2026-07-003 / F2026-07-014 family) when the actual event was an implementer that stopped mid-task three steps earlier. Second, waste: the pipeline spent the `commit` step and its recovery agent on a run that was already known-bad at `implement_one`.

The delivery gate is working as designed and is not the defect — it is the last line, and it held. The defect is that nothing earlier noticed.

Related friction: F2026-07-030 (filed by this run's own commit-step recovery agent, reaching the same conclusion independently).

## Doctrines this must respect

- **Agent-loop outputs are advisory only.** No job or activity may require or depend on the *content* of an agent-loop response; decisions read durable state or deterministic re-checks. A step-completion protocol check is about whether the invocation completed its contract, not about trusting what it said — any proposal must stay clearly on the correct side of that line and say why.
- **The durable delivery gate stays the source of truth.** Persisted `execution_summary` remains the delivery precondition (ORB-10313 / ADR-0246 lineage). Nothing here may weaken, bypass, or auto-synthesize past it.
- Some activities may legitimately not require an envelope. Any change must account for those rather than assume the flag is always safe to flip.

## Scope

Decide and implement how a pipeline step should treat an agent invocation that terminates without a valid response envelope, such that a stalled or protocol-violating implementer fails at the step that produced it, with a failure message that names what actually happened. Include the recovery path: whether such a step is retryable, and what state the task and worktree are left in.

## Provenance

Found while diagnosing why ORB-10436's candidate (PR #759) reached the delivery gate with an empty `execution_summary`. The candidate diff itself was sound; only the verification pass was never finished.

### Acceptance Criteria

- An agent-loop step whose invocation returns no valid Orbit response envelope does not checkpoint as success
- The run's terminal error names the implement step and the protocol violation, not a downstream symptom
- Activities that legitimately do not require an envelope keep their current behaviour, with the distinction made explicit rather than incidental
- The durable execution_summary delivery gate is unchanged and no summary is auto-synthesized to satisfy it
- No job or activity decision reads the content of an agent-loop response
- Regression coverage for an agent invocation that exits 0 with stdout containing no envelope
- The recovery/retry behaviour for the new failure path is specified and covered, including the state the task and worktree are left in
- jrun-20260726-1758-5's failure shape, replayed as a fixture, fails at implement_one

## Execution Summary

<details>
<summary>Click to expand</summary>

Split the agent-loop **step-completion protocol** contract from the **response content** contract, so an invocation that ends without a terminating Orbit response envelope fails at the step that produced it.

## Root cause

`require_response_envelope` (ADR-0224) was carrying two unrelated questions, and the second one went unasked. `false` was read as "this activity's response does not matter", when it actually means "nothing downstream *consumes* it". Nothing asked whether the invocation finished at all — so a claude that yielded mid-turn waiting on a background `cargo nextest` exited 0, emitted no envelope, and checkpointed `implement_one` as success. The run advanced three steps and failed at `git_commit`'s durable execution_summary gate, which reads as a summary-persistence defect (the F2026-07-003/F2026-07-014 family) rather than a stalled implementer.

## Change

**New flag** `AgentLoopSpec::require_completion_envelope`, default `true` (fail closed — a legacy or new asset that omits it inherits the check).

**New predicate** `orbit_agent::response_envelope_protocol_check(stdout)`. Content-blind by construction: it reads the envelope *frame* only — presence, `schemaVersion: 1`, and one of the three protocol status tokens — never `result` or `error`, and it does not care which status was declared. An agent reporting `status: "failed"` satisfies it; one that yielded mid-turn emitted no envelope and does not. **This is what keeps the doctrine intact**: agent-loop output stays advisory, no decision reads its content, and "did the contract complete" is a property of the invocation rather than a claim the agent makes about its work. Deliberately excludes `validate_exit_alignment`, which would make a `status: "failed"` envelope indistinguishable from a missing one.

`run_cli_backend` now computes the two gates independently. Message priority puts the opted-in content diagnostic first (strictly more specific, and existing messages are unchanged); the completion diagnostic is what the remaining activities now report instead of silently checkpointing success. Three new run-record fields: `completion_envelope_required` / `_satisfied` / `_error`.

**The diagnostic names what happened**: "agent step did not complete: the provider exited 0 but stdout carried no valid terminating Orbit response envelope (...)". `label_failure_with_step` in the dispatcher prefixes every failing CLI agent-loop message with `` step `<id>`: ``, so the run's terminal error names `implement_one` — that fix lands once for all CLI failure modes (timeout, nonzero exit, protocol violation, invalid envelope).

## Two defects found while implementing

1. **False-positive risk (fixed before it shipped).** A provider that interleaves a wrapped tool's stdout with its protocol output makes the JSON document stream unparseable even though the agent terminated properly. Caught by an existing worktree-guard test whose fake runs `git commit`. The check now falls back to scanning raw text — failing a completed step over stdout tidiness would be worse than the defect being caught. Covered by a test.
2. **Retry dropped the diagnostic.** `run_step_with_retry` discarded the message on retry exhaustion for any step failing via `Ok(success: false)` — i.e. every CLI agent-loop failure — leaving the run's terminal error as the generic "completed with success=false". Fixed by keeping the last failing outcome. No shipped pipeline retries an agent step, so this was latent, but it directly contradicts the acceptance criterion about naming the cause.

## Recovery / retry semantics (specified + covered)

A violation fails the step as `DispatchOutcome { success: false }` — same shape as an opted-in envelope failure, no new error classification. For `implement_one`: not retried (no `retry:` block; a repeat invocation of a stalled agent has no new information); **no recovery agent** (`recovery_activity` fires on `Err`, which is the behaviour we want — `step_failure_recovery` exists to repair delivery for *completed* work, and having it publish a stalled implementer's partial candidate is the opposite of the fix); run terminalizes at that step with the job-level `failure_activity` (`pr_failure_handoff`, ADR-0246) still firing; worktree retained with whatever was written before the stop; coupled tasks move to `blocked` under normal terminal-run rules. Re-dispatch is an orchestrator decision.

**The durable execution_summary delivery gate is untouched** — not weakened, bypassed, or auto-satisfied. It stays the last line; a stalled implementer just no longer reaches it.

## Declared exception

`dispatch_agent` ships `require_completion_envelope: false` — the only one. Its backlog-grouping notes are advisory, deterministic singleton bundles from `list_backlog_tasks` drive dispatch, and nothing reads them, so its non-completion costs the run nothing. The asset comment states the bar is *consequence* (the activity not running at all is harmless), not output quality. `agent_step_completion_contract_is_required_except_where_declared` pins the opt-out list so a new exception must be a deliberate edit, and also asserts the two flags cannot disagree (content without completion is incoherent).

## Coverage

- `orbit-agent`: 5 unit tests on the predicate — prose-only rejected, all three status tokens accepted (blindness), unsupported `schemaVersion`/status rejected, interleaved stdout tolerated, claude-wrapped envelope accepted.
- `orbit-engine` cli_runner: stall fails an artifact-backed activity; opt-out keeps prior behaviour with the diagnostic still recorded; declared-failure envelope passes; interleaved stdout passes; **`jrun-20260726-1758-5`'s exact shape replayed as a fixture** (exit 0, `stop_reason: end_turn`, the verbatim "waiting for the scheduled wakeup" prose) fails.
- `orbit-engine` job_executor: end-to-end job test — the stall fails **at `implement_one`**, the terminal message names both the step and the violation, the downstream `commit` step never runs, and the step is audited `failed`; plus a healthy-path test and a retry-message-preservation test. Required a small `ScriptedHost::with_cli_program` seam to reach the CLI runner from job-level tests.

## Scope notes

- `context_files` was empty on the task; populated with the actual modification targets.
- Updated ~10 `AgentLoopSpec` struct literals in tests (new field) and 3 integration-test fakes that emitted non-envelope stdout (`{"status":"ok"}` / `echo ok`) — those scenarios are about audit events and argv, so they now terminate with a real envelope like a live provider.
- Mirrored the `dispatch_agent` asset into `.orbit/resources/activities/` (the skill-portability test's contract requires a byte-identical copy).

## Not done — needs follow-up

**The ADR was not written.** The decision meets all three CONVENTIONS criteria (real alternative: flip `require_response_envelope: true` everywhere, or classify as a retryable `DispatchError`; forward constraint: every new agent_loop activity inherits the check; non-obvious cost: the completion check is deliberately *more* permissive than the content parser about stream shape, so the two can disagree about the same invocation). But `orbit.adr.add` is not in this activity's tool grant, and CONVENTIONS forbids hand-authoring an unallocated four-digit heading (the ORB-00098 failure mode, ADR-0153). The full narrative is in `docs/design/activity-job/2_design.md` §7.6a with an `Amended by [ORB-10449]` block on the ADR-0224 entry; allocation and the `4_decisions.md` entry are tracked as **ORB-10454**.

## Validation

`make ci-fast` clean; `cargo test --workspace` clean (64 suites); `cargo clippy --workspace --all-targets` clean. One unrelated orbit-core lib test failed once early on and did not reproduce across four subsequent full runs — a pre-existing flake, not touched by this change.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10449-6a6659ff`
- Behind base: 0
- Ahead of base: 1