### PR TITLE
Irreversible CLI commands execute with no confirmation step

### DIFF
--- a/crates/orbit-cli/src/command/audit/prune.rs
+++ b/crates/orbit-cli/src/command/audit/prune.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 use orbit_core::{OrbitError, OrbitRuntime};
 
-use crate::command::Execute;
+use crate::command::{Execute, require_confirmation};
 use crate::parse::parse_since;
 
 #[derive(Args)]
@@ -9,10 +9,14 @@ pub struct AuditPruneArgs {
     /// Prune events older than this duration (e.g. "90d", "1h")
     #[arg(long)]
     pub older_than: String,
+    /// Confirm permanent deletion of matching audit rows
+    #[arg(long)]
+    pub confirm: bool,
 }
 
 impl Execute for AuditPruneArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        require_confirmation(self.confirm, "audit pruning")?;
         let cutoff = parse_since(&self.older_than)?;
         let pruned = runtime.prune_audit_events(&cutoff)?;
         println!("Pruned {pruned} audit events");

--- a/crates/orbit-cli/src/command/docs.rs
+++ b/crates/orbit-cli/src/command/docs.rs
@@ -76,8 +76,11 @@ pub struct DocsIndexArgs {
 
 #[derive(Args)]
 pub struct DocsMigrateArgs {
-    /// Print planned diffs without writing files
-    #[arg(long)]
+    /// Apply the migration; without this flag the command only reports
+    #[arg(long, conflicts_with = "dry_run")]
+    pub confirm: bool,
+    /// Explicitly request the default non-destructive mode
+    #[arg(long, conflicts_with = "confirm")]
     pub dry_run: bool,
     /// Output as JSON
     #[arg(long)]
@@ -225,7 +228,7 @@ fn print_docs_index_text(result: SemanticIndexResult) -> Result<(), OrbitError> 
 
 impl Execute for DocsMigrateArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let report = runtime.migrate_docs(self.dry_run)?;
+        let report = runtime.migrate_docs(!self.confirm)?;
         if self.json {
             print_json(&report)
         } else if report.changed.is_empty() {

--- a/crates/orbit-cli/src/command/gc.rs
+++ b/crates/orbit-cli/src/command/gc.rs
@@ -37,11 +37,11 @@ impl Execute for GcTarget {
 #[derive(Args)]
 pub struct WorktreeGcArgs {
     /// Perform removals; without this flag the command only reports
-    #[arg(long, conflicts_with = "dry_run")]
-    pub yes: bool,
+    #[arg(long, visible_alias = "yes", conflicts_with = "dry_run")]
+    pub confirm: bool,
 
     /// Explicitly request the default non-destructive mode
-    #[arg(long, conflicts_with = "yes")]
+    #[arg(long, conflicts_with = "confirm")]
     pub dry_run: bool,
 
     /// Restrict collection to one job run
@@ -59,7 +59,7 @@ pub struct WorktreeGcArgs {
 
 impl Execute for WorktreeGcArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let result = runtime.gc_worktrees(self.yes, self.run, self.older_than_hours)?;
+        let result = runtime.gc_worktrees(self.confirm, self.run, self.older_than_hours)?;
         if self.json {
             return crate::output::json::print_pretty(&serde_json::to_value(result).map_err(
                 |error| {

--- a/crates/orbit-cli/src/command/host/retire.rs
+++ b/crates/orbit-cli/src/command/host/retire.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use orbit_core::{OrbitError, OrbitRuntime};
 use orbit_remote::{host_registry_service_at, require_local_hub_identity};
 
-use crate::command::Execute;
+use crate::command::{Execute, require_confirmation};
 
 use super::command::resolve_machine_id;
 
@@ -11,10 +11,14 @@ use super::command::resolve_machine_id;
 pub struct HostRetireArgs {
     /// Host name (or a tombstone alias resolving to the machine) to retire.
     name: String,
+    /// Confirm irreversible host retirement
+    #[arg(long)]
+    confirm: bool,
 }
 
 impl Execute for HostRetireArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        require_confirmation(self.confirm, "host retirement")?;
         let local_hub = require_local_hub_identity(&runtime.global_root())?;
         let service = host_registry_service_at(&runtime.global_root())?;
         service.require_configured_local_hub(&local_hub)?;

--- a/crates/orbit-cli/src/command/learning/migrate_layout.rs
+++ b/crates/orbit-cli/src/command/learning/migrate_layout.rs
@@ -1,5 +1,7 @@
 use clap::Args;
-use orbit_core::{OrbitError, OrbitRuntime, migrate_learning_layout_at};
+use orbit_core::{
+    OrbitError, OrbitRuntime, inspect_learning_layout_at, migrate_learning_layout_at,
+};
 use orbit_remote::runtime::RemoteRuntimeFactory;
 use serde_json::json;
 
@@ -7,6 +9,12 @@ use crate::command::Execute;
 
 #[derive(Args)]
 pub struct LearningMigrateLayoutArgs {
+    /// Apply the migration; without this flag the command only reports
+    #[arg(long, conflicts_with = "dry_run")]
+    pub confirm: bool,
+    /// Explicitly request the default non-destructive mode
+    #[arg(long, conflicts_with = "confirm")]
+    pub dry_run: bool,
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
@@ -19,27 +27,38 @@ impl LearningMigrateLayoutArgs {
     ) -> Result<(), OrbitError> {
         let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
         let roots = RemoteRuntimeFactory::resolve_roots_for_cwd(&cwd, root_override)?;
-        let report = migrate_learning_layout_at(&roots.shared_root)?;
-        if !report.already_migrated {
+        let dry_run = !self.confirm;
+        let report = if dry_run {
+            inspect_learning_layout_at(&roots.shared_root)?
+        } else {
+            migrate_learning_layout_at(&roots.shared_root)?
+        };
+        if !dry_run && !report.already_migrated {
             let runtime = RemoteRuntimeFactory::open_resolved_roots(roots)?;
             runtime.sync_learnings()?;
         }
-        print_report(&report, self.json)
+        print_report(&report, dry_run, self.json)
     }
 }
 
 impl Execute for LearningMigrateLayoutArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let report = runtime.migrate_learning_layout()?;
-        if !report.already_migrated {
+        let dry_run = !self.confirm;
+        let report = if dry_run {
+            runtime.inspect_learning_layout()?
+        } else {
+            runtime.migrate_learning_layout()?
+        };
+        if !dry_run && !report.already_migrated {
             runtime.sync_learnings()?;
         }
-        print_report(&report, self.json)
+        print_report(&report, dry_run, self.json)
     }
 }
 
 fn print_report(
     report: &orbit_core::LearningLayoutMigrationReport,
+    dry_run: bool,
     json_output: bool,
 ) -> Result<(), OrbitError> {
     if json_output {
@@ -54,6 +73,11 @@ fn print_report(
 
     if report.already_migrated {
         println!("workspace is already on the per-entity layout");
+    } else if dry_run {
+        println!(
+            "Would migrate learning layout: move {} active, {} superseded; remove superseded directory: {}",
+            report.moved_active, report.moved_superseded, report.removed_superseded_dir
+        );
     } else {
         println!(
             "Migrated learning layout: moved {} active, {} superseded; removed superseded directory: {}",

--- a/crates/orbit-cli/src/command/learning/prune.rs
+++ b/crates/orbit-cli/src/command/learning/prune.rs
@@ -10,8 +10,8 @@ pub struct LearningPruneArgs {
     #[arg(long = "stale-only", default_value_t = true)]
     pub stale_only: bool,
     /// Archive every stale learning (sets status=superseded, superseded_by=null).
-    #[arg(long, conflicts_with = "stale_only")]
-    pub delete: bool,
+    #[arg(long, visible_alias = "delete", conflicts_with = "stale_only")]
+    pub confirm: bool,
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
@@ -19,7 +19,7 @@ pub struct LearningPruneArgs {
 
 impl Execute for LearningPruneArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let (stale, deleted) = runtime.prune_learnings(self.delete)?;
+        let (stale, deleted) = runtime.prune_learnings(self.confirm)?;
         if self.json {
             crate::output::json::print_pretty(&json!({
                 "stale": stale,

--- a/crates/orbit-cli/src/command/locks.rs
+++ b/crates/orbit-cli/src/command/locks.rs
@@ -15,8 +15,8 @@ use clap::{Args, Subcommand};
 use orbit_core::{OrbitError, OrbitRuntime, TaskStatus};
 use serde_json::{Map, Value, json};
 
-use crate::command::Execute;
 use crate::command::task::output::{print_task_locks, task_lock_to_json};
+use crate::command::{Execute, require_confirmation};
 
 #[derive(Args)]
 #[command(about = "Inspect and release task file locks")]
@@ -104,10 +104,14 @@ fn lock_status_rank(status: TaskStatus) -> u8 {
 pub struct LocksReleaseArgs {
     /// Reservation ID to release (from the reservation store / debug tooling)
     pub reservation_id: String,
+    /// Confirm release of the reservation
+    #[arg(long)]
+    pub confirm: bool,
 }
 
 impl Execute for LocksReleaseArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        require_confirmation(self.confirm, "task lock release")?;
         let mut input = Map::new();
         input.insert(
             "reservation_id".to_string(),

--- a/crates/orbit-cli/src/command/migrate.rs
+++ b/crates/orbit-cli/src/command/migrate.rs
@@ -11,14 +11,17 @@ use crate::command::Execute;
 /// Both migration ledgers auto-apply on workspace open (the SQLite schema
 /// ledger inside `Store::open`, the workspace-layout registry in the runtime
 /// pre-flight), so the apply path simply opens the runtime and reports what
-/// happened. `--dry-run` inspects *without* opening a runtime, which is the
-/// only way to list pending migrations instead of silently applying them.
+/// happened. The default and `--dry-run` inspect *without* opening a runtime,
+/// which is the only way to list pending migrations instead of silently
+/// applying them. `--confirm` selects the apply path.
 #[derive(Args)]
 #[command(about = "Apply or inspect pending .orbit layout and store schema migrations")]
 pub struct MigrateCommand {
-    /// List pending migrations without applying them (exits nonzero when any
-    /// are pending)
-    #[arg(long)]
+    /// Apply pending migrations
+    #[arg(long, conflicts_with = "dry_run")]
+    pub confirm: bool,
+    /// Explicitly request the default non-destructive inspection mode
+    #[arg(long, conflicts_with = "confirm")]
     pub dry_run: bool,
     /// Emit machine-readable JSON instead of the table.
     #[arg(long)]
@@ -55,7 +58,7 @@ impl MigrateCommand {
         let pending = status.pending_total();
         if pending > 0 {
             return Err(OrbitError::Execution(format!(
-                "{pending} migration(s) pending; run `orbit migrate` to apply"
+                "{pending} migration(s) pending; run `orbit migrate --confirm` to apply"
             )));
         }
         Ok(())
@@ -153,7 +156,7 @@ fn print_status(
         println!("  schema v{} ({})", pending.version, pending.name);
     }
     println!(
-        "\nRun `orbit migrate` to apply (migrations also auto-apply on workspace open).\n\
+        "\nRun `orbit migrate --confirm` to apply (migrations also auto-apply on workspace open).\n\
          Before a major upgrade, consider backing up workspace state first:\n\
          cp -a {orbit_dir} {orbit_dir}.bak",
         orbit_dir = status.orbit_dir.display()

--- a/crates/orbit-cli/src/command/mod.rs
+++ b/crates/orbit-cli/src/command/mod.rs
@@ -40,6 +40,17 @@ pub trait Execute {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError>;
 }
 
+/// Require the standard non-interactive confirmation flag before an
+/// irreversible CLI operation proceeds.
+pub(crate) fn require_confirmation(confirm: bool, action: &str) -> Result<(), OrbitError> {
+    if confirm {
+        return Ok(());
+    }
+    Err(OrbitError::InvalidInput(format!(
+        "{action} is irreversible; pass --confirm to proceed"
+    )))
+}
+
 // Clap derive does not support per-variant subcommand `help_heading`
 // (`next_help_heading` is args-only; `subcommand_help_heading` only renames
 // the single `Commands:` block). To render grouped sections in `--help` we

--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -234,10 +234,10 @@ impl Commands {
                 )
             }
             Commands::Migrate(command) => CommandOperation::new(
-                if command.dry_run {
-                    RuntimeNeed::Forbidden
-                } else {
+                if command.confirm {
                     RuntimeNeed::Required
+                } else {
+                    RuntimeNeed::Forbidden
                 },
                 Some(admin_meta("migrate", None, Some("workspace"), None)),
                 None,
@@ -868,7 +868,7 @@ fn dispatch_mcp(command: Commands, context: DispatchContext<'_>) -> Result<(), O
 
 fn dispatch_migrate(command: Commands, context: DispatchContext<'_>) -> Result<(), OrbitError> {
     match command {
-        Commands::Migrate(command) if command.dry_run => {
+        Commands::Migrate(command) if !command.confirm => {
             command.execute_without_runtime(context.root_override)
         }
         Commands::Migrate(command) => command.execute(context.runtime()?),

--- a/crates/orbit-cli/src/command/run/cancel.rs
+++ b/crates/orbit-cli/src/command/run/cancel.rs
@@ -4,7 +4,7 @@ use clap::Args;
 use orbit_core::{OrbitError, OrbitRuntime};
 use serde_json::json;
 
-use crate::command::Execute;
+use crate::command::{Execute, require_confirmation};
 
 #[derive(Args)]
 #[command(
@@ -13,7 +13,7 @@ use crate::command::Execute;
 owner process of a running run (TERM then KILL), releases the run's task \
 reservations, and finalizes the run as `cancelled`. The primary remediation \
 for a stuck `pending` run with no live worker (orphan reconciliation also \
-clears those on workspace open).\n\nExamples:\n  orbit run cancel jrun-20260706-0120-2\n  orbit run cancel jrun-20260706-0120-2 --json"
+clears those on workspace open).\n\nExamples:\n  orbit run cancel jrun-20260706-0120-2 --confirm\n  orbit run cancel jrun-20260706-0120-2 --confirm --json"
 )]
 pub struct RunCancelArgs {
     /// Job run ID to cancel
@@ -22,10 +22,15 @@ pub struct RunCancelArgs {
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
+
+    /// Confirm process termination and irreversible run terminalization
+    #[arg(long)]
+    pub confirm: bool,
 }
 
 impl Execute for RunCancelArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        require_confirmation(self.confirm, "run cancellation")?;
         let result = runtime.cancel_job_run_with_context(&self.run_id, "cli", "run_cancel")?;
         if self.json {
             return crate::output::json::print_pretty(&json!({

--- a/crates/orbit-cli/src/command/run/tests/mod.rs
+++ b/crates/orbit-cli/src/command/run/tests/mod.rs
@@ -8,13 +8,16 @@ mod support;
 
 // Content moved from inline #[cfg(test)] mod tests in run/mod.rs per ORB-00221.
 
+use chrono::Utc;
 use clap::{Parser, error::ErrorKind};
+use orbit_common::types::{JobRun, JobRunState};
 use orbit_core::OrbitRuntime;
 use orbit_core::runtime::run_audit::RunAuditEvent;
 use serde_json::{Value, json};
 
-use crate::command::{Cli, Commands};
+use crate::command::{Cli, Commands, Execute};
 
+use super::cancel::RunCancelArgs;
 use super::*;
 
 fn parse_run(args: &[&str]) -> RunCommand {
@@ -33,6 +36,69 @@ fn assert_cli_rejects(args: &[&str], kind: ErrorKind, expected: &str) {
     assert_eq!(error.kind(), kind, "{error}");
     let message = error.to_string();
     assert!(message.contains(expected), "{message}");
+}
+
+#[test]
+fn cancel_requires_confirmation_before_terminalizing_pending_run() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    let workspace_id = runtime.workspace_id().expect("workspace id");
+    let store = runtime.sqlite_store().expect("store");
+    let now = Utc::now();
+    let run = JobRun {
+        run_id: "jrun-confirm-test".to_string(),
+        job_id: "cancel-test".to_string(),
+        attempt: 1,
+        state: JobRunState::Pending,
+        scheduled_at: now,
+        started_at: None,
+        finished_at: None,
+        duration_ms: None,
+        created_at: now,
+        pid: None,
+        pid_start_time: None,
+        input: None,
+        retry_source_run_id: None,
+        knowledge_metrics: None,
+        resolved_crew: None,
+        crew_model: None,
+        steps: Vec::new(),
+    };
+    store
+        .upsert_job_run_for_workspace(&workspace_id, &run, None)
+        .expect("insert pending run");
+
+    let error = RunCancelArgs {
+        run_id: run.run_id.clone(),
+        json: false,
+        confirm: false,
+    }
+    .execute(&runtime)
+    .expect_err("unconfirmed cancellation must refuse");
+    assert!(error.to_string().contains("--confirm"));
+    assert_eq!(
+        store
+            .get_job_run_for_workspace(&workspace_id, &run.run_id)
+            .expect("read pending run")
+            .expect("pending run")
+            .state,
+        JobRunState::Pending
+    );
+
+    RunCancelArgs {
+        run_id: run.run_id.clone(),
+        json: false,
+        confirm: true,
+    }
+    .execute(&runtime)
+    .expect("confirmed cancellation");
+    assert_eq!(
+        store
+            .get_job_run_for_workspace(&workspace_id, &run.run_id)
+            .expect("read cancelled run")
+            .expect("cancelled run")
+            .state,
+        JobRunState::Cancelled
+    );
 }
 
 #[test]

--- a/crates/orbit-cli/src/command/tests/gc.rs
+++ b/crates/orbit-cli/src/command/tests/gc.rs
@@ -18,7 +18,7 @@ fn gc_worktrees_defaults_to_dry_run_and_accepts_scopes() {
         panic!("expected gc");
     };
     let GcTarget::Worktrees(args) = command.target;
-    assert!(!args.yes);
+    assert!(!args.confirm);
     assert_eq!(args.run.as_deref(), Some("jrun-1"));
     assert_eq!(args.older_than_hours, Some(24));
 }
@@ -36,10 +36,20 @@ fn gc_help_exposes_positional_worktree_class() {
 }
 
 #[test]
-fn gc_rejects_yes_with_explicit_dry_run() {
-    let error = match Cli::try_parse_from(["orbit", "gc", "worktrees", "--yes", "--dry-run"]) {
+fn gc_rejects_confirmation_with_explicit_dry_run() {
+    let error = match Cli::try_parse_from(["orbit", "gc", "worktrees", "--confirm", "--dry-run"]) {
         Ok(_) => panic!("destructive and dry-run flags conflict"),
         Err(error) => error,
     };
     assert!(error.to_string().contains("cannot be used with"));
+}
+
+#[test]
+fn gc_preserves_yes_as_confirmation_alias() {
+    let cli = Cli::parse_from(["orbit", "gc", "worktrees", "--yes"]);
+    let Commands::Gc(command) = cli.command else {
+        panic!("expected gc");
+    };
+    let GcTarget::Worktrees(args) = command.target;
+    assert!(args.confirm);
 }

--- a/crates/orbit-cli/src/command/tests/operation.rs
+++ b/crates/orbit-cli/src/command/tests/operation.rs
@@ -14,6 +14,7 @@ fn runtime_free_command_set_is_derived_from_operations() {
         &["orbit", "mcp", "init"],
         &["orbit", "mcp", "remove"],
         &["orbit", "mcp", "serve"],
+        &["orbit", "migrate"],
         &["orbit", "migrate", "--dry-run"],
         &["orbit", "learning", "migrate-layout"],
         &["orbit", "run", "ship-sweep", "--dry-run"],
@@ -33,7 +34,7 @@ fn runtime_free_command_set_is_derived_from_operations() {
 
     let runtime_required: &[&[&str]] = &[
         &["orbit", "workspace", "list"],
-        &["orbit", "migrate"],
+        &["orbit", "migrate", "--confirm"],
         &["orbit", "learning", "list"],
         &["orbit", "run", "history"],
         &["orbit", "task", "list"],
@@ -45,6 +46,22 @@ fn runtime_free_command_set_is_derived_from_operations() {
             "{args:?} must bootstrap a workspace runtime"
         );
     }
+}
+
+#[test]
+fn migrate_only_bootstraps_the_applying_form() {
+    assert_eq!(
+        operation_for(&["orbit", "migrate"]).runtime_need,
+        RuntimeNeed::Forbidden
+    );
+    assert_eq!(
+        operation_for(&["orbit", "migrate", "--dry-run"]).runtime_need,
+        RuntimeNeed::Forbidden
+    );
+    assert_eq!(
+        operation_for(&["orbit", "migrate", "--confirm"]).runtime_need,
+        RuntimeNeed::Required
+    );
 }
 
 #[test]

--- a/crates/orbit-cli/tests/docs.rs
+++ b/crates/orbit-cli/tests/docs.rs
@@ -34,6 +34,33 @@ fn cli_docs_list_and_show_json() {
 }
 
 #[test]
+fn cli_docs_migrate_is_dry_run_by_default_and_confirm_applies() {
+    let workspace = TestWorkspace::new();
+    workspace.write(
+        "docs/design-patterns/legacy.md",
+        "# Legacy Pattern\n\nBody\n",
+    );
+    let path = workspace.work.join("docs/design-patterns/legacy.md");
+    let before = fs::read_to_string(&path).expect("read legacy doc");
+
+    let preview = workspace.run_json(&["docs", "migrate", "--json"], "docs migrate preview");
+    assert_eq!(preview["dry_run"], true);
+    assert_eq!(
+        fs::read_to_string(&path).expect("read previewed doc"),
+        before
+    );
+
+    let applied = workspace.run_json(
+        &["docs", "migrate", "--confirm", "--json"],
+        "docs migrate apply",
+    );
+    assert_eq!(applied["dry_run"], false);
+    let after = fs::read_to_string(&path).expect("read migrated doc");
+    assert_ne!(after, before);
+    assert!(after.starts_with("---\n"));
+}
+
+#[test]
 fn cli_orbit_search_federates_docs_and_adrs() {
     // ORB-00202: federated lexical search moved from `orbit docs search` to
     // `orbit search <query> --kind all` / `--kind doc` / `--kind adr`.

--- a/crates/orbit-cli/tests/host_administration.rs
+++ b/crates/orbit-cli/tests/host_administration.rs
@@ -79,7 +79,7 @@ fn spoke_routes_only_self_registration_and_rejects_direct_administration() {
 
     let mutation_commands = [
         vec!["host", "rename", "missing-host", "new-name"],
-        vec!["host", "retire", "missing-host"],
+        vec!["host", "retire", "missing-host", "--confirm"],
         vec![
             "workspace",
             "link",
@@ -341,6 +341,15 @@ fn rejected_current_host_rename_preserves_local_identity_and_registry_revision()
         .env("USERPROFILE", &home)
         .env_remove("ORBIT_ROOT")
         .args(["host", "retire", "remote"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--confirm"));
+    cargo_bin_cmd!("orbit")
+        .current_dir(&work)
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env_remove("ORBIT_ROOT")
+        .args(["host", "retire", "remote", "--confirm"])
         .assert()
         .success();
     cargo_bin_cmd!("orbit")

--- a/crates/orbit-cli/tests/learning.rs
+++ b/crates/orbit-cli/tests/learning.rs
@@ -211,10 +211,13 @@ fn cli_prune_stale_only_reports_without_modifying() {
 }
 
 #[test]
-fn cli_prune_delete_archives_stale_learnings() {
+fn cli_prune_confirm_archives_stale_learnings_and_preserves_delete_alias() {
     let workspace = TestWorkspace::new();
     let learning = workspace.add_learning("stale", &["totally-nonexistent-dir-xyz-456/**"], &[]);
-    let result = workspace.run_json(&["learning", "prune", "--delete", "--json"], "prune delete");
+    let result = workspace.run_json(
+        &["learning", "prune", "--confirm", "--json"],
+        "prune confirm",
+    );
     let deleted: Vec<&str> = result["deleted"]
         .as_array()
         .unwrap()
@@ -235,6 +238,12 @@ fn cli_prune_delete_archives_stale_learnings() {
     );
     assert_eq!(shown["status"], "superseded");
     assert!(shown["superseded_by"].is_null());
+
+    let alias = workspace.run_json(
+        &["learning", "prune", "--delete", "--json"],
+        "prune delete alias",
+    );
+    assert!(alias["deleted"].as_array().expect("deleted").is_empty());
 }
 
 #[test]
@@ -259,8 +268,21 @@ fn cli_migrate_layout_preserves_records_and_is_idempotent() {
     let superseded_before = workspace.learning_projection("superseded");
 
     workspace.convert_learning_store_to_legacy_flat();
+    let before_dry_run = snapshot_files(&workspace.work.join(".orbit/learnings"));
     let output = workspace.run(
         &["learning", "migrate-layout"],
+        None,
+        "inspect legacy learning layout",
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Would migrate learning layout"));
+    assert_eq!(
+        snapshot_files(&workspace.work.join(".orbit/learnings")),
+        before_dry_run
+    );
+
+    let output = workspace.run(
+        &["learning", "migrate-layout", "--confirm"],
         None,
         "migrate legacy learning layout",
     );
@@ -288,7 +310,7 @@ fn cli_migrate_layout_preserves_records_and_is_idempotent() {
 
     let before_rerun = snapshot_files(&learnings_root);
     let output = workspace.run(
-        &["learning", "migrate-layout"],
+        &["learning", "migrate-layout", "--confirm"],
         None,
         "rerun migrated layout",
     );

--- a/crates/orbit-cli/tests/task_trimmed_surface.rs
+++ b/crates/orbit-cli/tests/task_trimmed_surface.rs
@@ -193,12 +193,26 @@ fn task_add_attributes_from_model_flag_and_managed_identity_env() {
 fn locks_release_reaches_admin_tool_bypassing_agent_gate() {
     let workspace = TestWorkspace::new();
 
+    let refused = workspace.run_raw(&["task", "locks", "release", "no-such-reservation"]);
+    assert!(!refused.status.success());
+    assert!(
+        String::from_utf8_lossy(&refused.stderr).contains("--confirm"),
+        "{}",
+        String::from_utf8_lossy(&refused.stderr)
+    );
+
     // `orbit.task.locks.release` is inactive on the agent tool surface, so
     // `orbit task locks release` must reach it through the admin `runtime.run_tool`
     // bypass. An unknown reservation yields a structured `released: false`, NOT
     // the `ensure_tool_agent_facing` rejection.
     let output = workspace.run(
-        &["task", "locks", "release", "no-such-reservation"],
+        &[
+            "task",
+            "locks",
+            "release",
+            "no-such-reservation",
+            "--confirm",
+        ],
         "task locks release",
     );
     let value: Value = serde_json::from_slice(&output.stdout).expect("release JSON");
@@ -209,6 +223,92 @@ fn locks_release_reaches_admin_tool_bypassing_agent_gate() {
         !stderr.contains("inactive on the agent tool surface"),
         "locks-release must bypass the agent-surface gate:\n{stderr}"
     );
+}
+
+#[test]
+fn audit_prune_refuses_unconfirmed_then_deletes_when_confirmed() {
+    let workspace = TestWorkspace::new();
+    workspace.add_task("Create an audit event");
+    let before = workspace.task_json(&["audit", "list", "--limit", "100", "--json"]);
+    assert!(!before.as_array().expect("audit rows").is_empty());
+
+    let refused = workspace.run_raw(&["audit", "prune", "--older-than", "0s"]);
+    assert!(!refused.status.success());
+    assert!(String::from_utf8_lossy(&refused.stderr).contains("--confirm"));
+    let after_refusal = workspace.task_json(&["audit", "list", "--limit", "100", "--json"]);
+    assert_eq!(after_refusal, before);
+
+    let confirmed = workspace.run(
+        &["audit", "prune", "--older-than", "0s", "--confirm"],
+        "confirmed audit prune",
+    );
+    assert!(String::from_utf8_lossy(&confirmed.stdout).contains("Pruned"));
+    let after = workspace.task_json(&["audit", "list", "--limit", "100", "--json"]);
+    assert!(after.as_array().expect("audit rows").is_empty());
+}
+
+#[test]
+fn run_cancel_confirmation_precedes_run_lookup() {
+    let workspace = TestWorkspace::new();
+
+    let refused = workspace.run_raw(&["run", "cancel", "jrun-does-not-exist"]);
+    assert!(!refused.status.success());
+    assert!(String::from_utf8_lossy(&refused.stderr).contains("--confirm"));
+
+    let confirmed = workspace.run_raw(&["run", "cancel", "jrun-does-not-exist", "--confirm"]);
+    assert!(!confirmed.status.success());
+    let stderr = String::from_utf8_lossy(&confirmed.stderr);
+    assert!(stderr.contains("jrun-does-not-exist"), "{stderr}");
+    assert!(!stderr.contains("pass --confirm"), "{stderr}");
+}
+
+#[test]
+fn migrate_bare_invocation_inspects_and_confirm_applies() {
+    let workspace = TestWorkspace::new();
+    let marker = workspace.work.join(".orbit/state/layout.version");
+    fs::write(&marker, "1\n").expect("restore prior layout version");
+
+    let preview = workspace.run_raw(&["migrate"]);
+    assert!(!preview.status.success());
+    assert_eq!(
+        fs::read_to_string(&marker).expect("read previewed marker"),
+        "1\n",
+        "bare migrate must not advance the layout"
+    );
+    assert!(
+        String::from_utf8_lossy(&preview.stderr).contains("migrate --confirm"),
+        "{}",
+        String::from_utf8_lossy(&preview.stderr)
+    );
+
+    workspace.run(&["migrate", "--confirm"], "confirmed migration");
+    assert_eq!(
+        fs::read_to_string(&marker).expect("read applied marker"),
+        "2\n",
+        "confirmed migrate must advance the layout"
+    );
+}
+
+#[test]
+fn workspace_remove_is_recoverable_by_reinitializing_the_checkout() {
+    let workspace = TestWorkspace::new();
+
+    workspace.run(
+        &["workspace", "remove", "trimmed-surface-test"],
+        "deregister workspace",
+    );
+    let unregistered = workspace.run(&["workspace", "show"], "show unregistered workspace");
+    assert!(
+        String::from_utf8_lossy(&unregistered.stdout).contains("not registered as a workspace")
+    );
+
+    workspace.run(
+        &["workspace", "init", "--name", "trimmed-surface-test"],
+        "reregister workspace",
+    );
+    let restored = workspace.run(&["workspace", "show"], "show restored workspace");
+    assert!(String::from_utf8_lossy(&restored.stdout).contains("name:"));
+    assert!(String::from_utf8_lossy(&restored.stdout).contains("trimmed-surface-test"));
 }
 
 struct TestWorkspace {

--- a/crates/orbit-cmd/src/migrate.rs
+++ b/crates/orbit-cmd/src/migrate.rs
@@ -5,10 +5,11 @@
 //! registry in the [`OrbitRuntime::from_resolved_roots`] pre-flight —
 //! so `orbit migrate` is the *explicit* surface over the same machinery:
 //!
-//! - `orbit migrate` (apply): opens the runtime normally, which applies
+//! - `orbit migrate --confirm` (apply): opens the runtime normally, which applies
 //!   everything pending, then reports the resulting versions and what the
 //!   open applied.
-//! - `orbit migrate --dry-run`: inspects explicit resolved roots *without*
+//! - `orbit migrate` (the default) and `orbit migrate --dry-run`: inspect
+//!   explicit resolved roots *without*
 //!   opening the runtime (see [`migrate_dry_run_at`]) so pending migrations
 //!   are listed instead of silently applied — the only way to see "pending"
 //!   given auto-migration on open. Environment and workspace-catalog
@@ -90,7 +91,7 @@ pub fn migrate_dry_run_at(
 /// `orbit migrate` command surface for [`OrbitRuntime`] (extension trait —
 /// the implementation moved out of orbit-core in [ORB-10016]).
 pub trait MigrateCommands {
-    /// Migration status of an open runtime (the `orbit migrate` apply path).
+    /// Migration status of an open runtime (the `orbit migrate --confirm` apply path).
     /// Opening the runtime already applied everything pending — layout in
     /// the open pre-flight, schema inside `Store::open` — so this reports
     /// the resulting versions plus which layout migrations that open

--- a/crates/orbit-core/assets/skills/orbit-search/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-search/SKILL.md
@@ -83,7 +83,7 @@ Recommended (not enforced) layout: `docs/design/<feature>/`, `docs/design-patter
 | Show | `orbit docs show <path> --json` |
 | Add root | `orbit docs add <path>` (existing non-`.orbit/` roots only) |
 | Index | `orbit docs index --json` (after substantial edits/moves; idempotent via content hashes) |
-| Migrate | `orbit docs migrate --dry-run` then without, to backfill locked frontmatter for legacy `docs/design/<feature>/*.md` and `docs/design-patterns/*.md` — never touches `.orbit/` |
+| Migrate | `orbit docs migrate` to preview, then `orbit docs migrate --confirm` to backfill locked frontmatter for legacy `docs/design/<feature>/*.md` and `docs/design-patterns/*.md` — never touches `.orbit/` |
 
 ## Common Mistakes
 

--- a/crates/orbit-core/src/command/learning.rs
+++ b/crates/orbit-core/src/command/learning.rs
@@ -310,6 +310,11 @@ impl OrbitRuntime {
         migrate_learning_layout_at(&self.paths().orbit_dir)
     }
 
+    /// Report the legacy learning-layout migration without changing files.
+    pub fn inspect_learning_layout(&self) -> Result<LearningLayoutMigrationReport, OrbitError> {
+        inspect_learning_layout_at(&self.paths().orbit_dir)
+    }
+
     /// Returns the IDs of every active learning that the §7.3 staleness
     /// rules flag as stale. A learning is stale when ALL of:
     /// * every `scope.paths` glob resolves to no extant directory under
@@ -388,6 +393,14 @@ pub fn migrate_learning_layout_at(
         &workspace_orbit_dir.join("learnings"),
         workspace_orbit_dir,
     )
+}
+
+/// Report the legacy learning-layout migration for an explicit workspace root
+/// without changing files.
+pub fn inspect_learning_layout_at(
+    workspace_orbit_dir: &Path,
+) -> Result<LearningLayoutMigrationReport, OrbitError> {
+    orbit_store::learning_layout::inspect_learning_layout(&workspace_orbit_dir.join("learnings"))
 }
 
 fn is_learning_stale(runtime: &OrbitRuntime, learning: &Learning, repo_root: &Path) -> bool {

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -66,7 +66,7 @@ pub use orbit_tools::prepare_remote_task_artifact_put;
 
 // Command-layer types the CLI names in its clap surfaces.
 pub use command::docs::{DocType, TaskRelatedDoc};
-pub use command::learning::migrate_learning_layout_at;
+pub use command::learning::{inspect_learning_layout_at, migrate_learning_layout_at};
 pub use command::search::{
     GlobalSearchHit, GlobalSearchKind, GlobalSearchParams, task_selectors_contain_path,
 };

--- a/crates/orbit-store/src/file/learning_store/migration/mod.rs
+++ b/crates/orbit-store/src/file/learning_store/migration/mod.rs
@@ -77,6 +77,21 @@ pub fn migrate_learning_layout(
     })
 }
 
+/// Report the legacy learning-layout changes without acquiring the migration
+/// lock or modifying the filesystem.
+pub fn inspect_learning_layout(root: &Path) -> Result<LearningLayoutMigrationReport, OrbitError> {
+    let active = legacy_flat_learning_paths(root)?;
+    let superseded_dir = root.join(SUPERSEDED_DIR_NAME);
+    let superseded = legacy_superseded_learning_paths(&superseded_dir)?;
+    let already_migrated = active.is_empty() && superseded.is_empty() && !superseded_dir.exists();
+    Ok(LearningLayoutMigrationReport {
+        already_migrated,
+        moved_active: active.len(),
+        moved_superseded: superseded.len(),
+        removed_superseded_dir: superseded_dir.exists(),
+    })
+}
+
 fn has_legacy_flat_layout(root: &Path) -> Result<bool, OrbitError> {
     Ok(!legacy_flat_learning_paths(root)?.is_empty()
         || !legacy_superseded_learning_paths(&root.join(SUPERSEDED_DIR_NAME))?.is_empty())

--- a/crates/orbit-store/src/file/learning_store/migration/tests/migration.rs
+++ b/crates/orbit-store/src/file/learning_store/migration/tests/migration.rs
@@ -81,3 +81,23 @@ fn legacy_flat_layout_detection_names_migration_command() {
     assert!(matches!(err, OrbitError::Migration(_)));
     assert!(err.to_string().contains("orbit learning migrate-layout"));
 }
+
+#[test]
+fn dry_run_reports_without_moving_or_locking() {
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path().join("learnings");
+    fs::create_dir_all(root.join("superseded")).expect("dirs");
+    fs::write(root.join("L-0001.yaml"), "").expect("active");
+    fs::write(root.join("superseded").join("L-0002.yaml"), "").expect("superseded");
+
+    let report = inspect_learning_layout(&root).expect("dry run");
+
+    assert!(!report.already_migrated);
+    assert_eq!(report.moved_active, 1);
+    assert_eq!(report.moved_superseded, 1);
+    assert!(report.removed_superseded_dir);
+    assert!(root.join("L-0001.yaml").is_file());
+    assert!(root.join("superseded").join("L-0002.yaml").is_file());
+    assert!(!root.join("L-0001").exists());
+    assert!(!dir.path().join(WORKSPACE_LOCK_RELATIVE_PATH).exists());
+}

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -96,7 +96,7 @@ pub mod token_scoreboard {
 
 pub mod learning_layout {
     pub use crate::file::learning_store::migration::{
-        LearningLayoutMigrationReport, migrate_learning_layout,
+        LearningLayoutMigrationReport, inspect_learning_layout, migrate_learning_layout,
     };
 }
 

--- a/docs/design-patterns/command.md
+++ b/docs/design-patterns/command.md
@@ -16,6 +16,16 @@ pub trait Tool: Send + Sync {
 
 The registry at `crates/orbit-tools/src/registry.rs:31` stores `Arc<dyn Tool>` keyed by `ToolSchema::name`. Adding a tool means: writing a struct, `impl Tool`, registering in `builtin::register_builtins`. The dispatcher never changes.
 
+## Destructive CLI confirmation
+
+CLI commands never prompt or read stdin. An irreversible single action exposes
+`--confirm` and refuses before mutation when it is absent. A migration or bulk
+cleanup command is non-destructive by default (report/dry-run) and uses
+`--confirm` to apply. Existing spellings may remain as compatibility aliases
+(`--yes` for worktree GC and `--delete` for learning prune), but new commands
+must not introduce another confirmation spelling. Reversible mutations should
+instead document and test their recovery command.
+
 Two codebase-specific shapes carry non-obvious lessons; everything else is straightforward `impl Tool`.
 
 ## Reference: host-action dispatcher (`OrbitPipelineInvokeTool`)

--- a/docs/design/project-learnings/2_design.md
+++ b/docs/design/project-learnings/2_design.md
@@ -3,7 +3,7 @@ summary: "Project Learnings — Design"
 type: design
 title: "Project Learnings — Design"
 owner: claude
-last_updated: 2026-07-25
+last_updated: 2026-07-26
 status: Draft
 feature: project-learnings
 doc_role: design
@@ -92,7 +92,7 @@ evidence:
 supersedes: null                  # set to L-id if this replaces an older entry
 ```
 
-The legacy flat layout (`.orbit/learnings/<id>.yaml` plus `.orbit/learnings/superseded/<id>.yaml`) is rejected on load with an actionable migration error. `orbit learning migrate-layout` performs the explicit one-way move and leaves `tags.yaml` at `.orbit/learnings/tags.yaml`.
+The legacy flat layout (`.orbit/learnings/<id>.yaml` plus `.orbit/learnings/superseded/<id>.yaml`) is rejected on load with an actionable migration error. `orbit learning migrate-layout` reports the one-way move without changing files; `orbit learning migrate-layout --confirm` performs it and leaves `tags.yaml` at `.orbit/learnings/tags.yaml` ([ORB-10452]).
 
 ### 2.2 SQLite index
 
@@ -321,7 +321,7 @@ A learning is **stale** if any of these are true:
 - All `evidence` commit SHAs no longer exist on the active branch.
 - All `evidence` task IDs are deleted.
 
-`orbit learning prune --stale-only` reports staleness; with `--delete` it archives the record. Staleness detection is opportunistic, not automatic; nothing fires it on every commit. Phase 2 may wire it into the knowledge graph rebuild path.
+`orbit learning prune` reports staleness; with `--confirm` it archives the record. The former `--delete` spelling remains a compatibility alias. Staleness detection is opportunistic, not automatic; nothing fires it on every commit. Phase 2 may wire it into the knowledge graph rebuild path ([ORB-10452]).
 
 ### 7.3.1 Approved physical retirement
 
@@ -411,5 +411,6 @@ Learnings are workspace-scoped and checked into the repo. They travel exactly wh
 - [ORB-10346] — Removed automatic learning delivery and adopted pull delivery with reference comments.
 - [ORB-10348] — Generalized the review into `artifact-deprecation-review`: added the comment-reference sweep (Stream B) alongside the original learning-corpus-health stream ([§7.6](#76-recurring-deprecation-review-auto-task)).
 - [ORB-10364] — Gated the `add`/`update`/`supersede` authoring surfaces on caller role and redirected executors to `friction add` ([§5.1](#51-cli), [§5.2](#52-mcp-tools), ADR-0250).
+- [ORB-10452] — Made learning layout migration and stale-learning pruning non-destructive by default, with the shared non-interactive `--confirm` apply convention.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/project-learnings/4_decisions.md
+++ b/docs/design/project-learnings/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Project Learnings — Decisions"
 type: design
 title: "Project Learnings — Decisions"
 owner: claude
-last_updated: 2026-07-25
+last_updated: 2026-07-26
 status: Draft
 feature: project-learnings
 doc_role: decisions
@@ -72,7 +72,7 @@ A flat-markdown approach can be retrofitted with an index, but at that point it'
 
 ## ADR-0110 — Workspace-scoped, checked into git (not workspace-private state)
 
-**Status:** Accepted · 2026-05 · [T20260510-11] · [T20260511-5] · legacy_id: `project-learnings/ADR-003`
+**Status:** Accepted · 2026-07 · [T20260510-11] · [T20260511-5] · [ORB-10452] · legacy_id: `project-learnings/ADR-003`
 
 **Context.** Where do learning records live on disk?
 
@@ -87,6 +87,8 @@ The cross-workspace case ([3_vision.md §1.4](./3_vision.md)) is real but second
 **Decision.** Phase 1 stores learnings at `.orbit/learnings/<id>/learning.yaml`, scoped `WorkspaceOnly` per the Scoping Rules table, checked into git. The SQLite index lives under `.orbit/state/` and is rebuildable from the YAML; it does not need to be checked in.
 
 **Amendment — ORB-00096.** Learnings moved from the original flat `.orbit/learnings/<id>.yaml` / `.orbit/learnings/superseded/<id>.yaml` layout to per-entity directories at `.orbit/learnings/<id>/learning.yaml`. Status now lives only in the YAML body, and the explicit `orbit learning migrate-layout` command performs the one-way migration.
+
+**Amendment — ORB-10452.** The one-way migration is now report-only on a bare invocation and applies only with the standard non-interactive `--confirm` flag. The explicit gate preserves scriptability without an stdin prompt and makes the irreversible layout operation follow the CLI-wide destructive-command convention.
 
 **Consequences.**
 - Learnings travel with the repo. New collaborator clones, gets all the project knowledge from day zero.
@@ -311,5 +313,6 @@ Alternatives considered:
 - [ORB-10346] — Retired automatic learning delivery while retaining pull discovery, `learning_shown`, and historical usage stats.
 - [ORB-10366] — Removed the `--hooks` flag from `orbit workspace init` and the tracked inert shims; kept `orbit hook install` as an opt-in escape hatch (ADR-0248).
 - [ORB-10364] — Gated the learning authoring surfaces on caller role and redirected executors to `friction add` (ADR-0250).
+- [ORB-10452] — Made the legacy learning-layout migration report-only by default and require the standard `--confirm` apply flag (ADR-0110 amendment).
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/runbooks/upgrades.md
+++ b/docs/runbooks/upgrades.md
@@ -39,8 +39,9 @@ the complete authoritative-state inventory.
 
 ```sh
 orbit migrate --dry-run    # list pending without applying; exit 1 when any are pending
-orbit migrate              # open the workspace, auto-apply, and report
-orbit migrate --json       # machine-readable report
+orbit migrate              # same safe inspection default
+orbit migrate --confirm    # open the workspace, auto-apply, and report
+orbit migrate --json       # machine-readable inspection report
 ```
 
 Example dry run on a pre-upgrade workspace:
@@ -53,11 +54,12 @@ $ orbit migrate --dry-run
 Pending migrations:
   layout v1 (baseline) — adopt the versioned .orbit/ layout (records the current shape; changes nothing)
   schema v1 (baseline)
-error: execution failed: 2 migration(s) pending; run `orbit migrate` to apply
+error: execution failed: 2 migration(s) pending; run `orbit migrate --confirm` to apply
 ```
 
-`--dry-run` is the only way to see pending migrations. Any command that opens the workspace,
-including plain `orbit migrate`, applies them.
+Bare `orbit migrate` and the compatibility-explicit `--dry-run` form inspect without opening
+the runtime. Applying pending migrations always requires `--confirm`; the command never prompts
+or reads stdin.
 
 ## Respect the downgrade guard
 
@@ -77,8 +79,8 @@ Upgrade the binary. Never hand-edit `layout.version` to force the workspace open
 After reviewing the dry run:
 
 1. Replace or upgrade the binary.
-2. Run `orbit migrate --dry-run` to review any still-pending changes.
-3. Run `orbit migrate` to apply them.
+2. Run `orbit migrate` (or `orbit migrate --dry-run`) to review any still-pending changes.
+3. Run `orbit migrate --confirm` to apply them.
 4. Run `orbit doctor` and require all relevant checks to pass.
 5. Restart any independently managed dashboard process after swapping the binary.
 

--- a/plugin/skills/orbit-search/SKILL.md
+++ b/plugin/skills/orbit-search/SKILL.md
@@ -83,7 +83,7 @@ Recommended (not enforced) layout: `docs/design/<feature>/`, `docs/design-patter
 | Show | `orbit docs show <path> --json` |
 | Add root | `orbit docs add <path>` (existing non-`.orbit/` roots only) |
 | Index | `orbit docs index --json` (after substantial edits/moves; idempotent via content hashes) |
-| Migrate | `orbit docs migrate --dry-run` then without, to backfill locked frontmatter for legacy `docs/design/<feature>/*.md` and `docs/design-patterns/*.md` — never touches `.orbit/` |
+| Migrate | `orbit docs migrate` to preview, then `orbit docs migrate --confirm` to backfill locked frontmatter for legacy `docs/design/<feature>/*.md` and `docs/design-patterns/*.md` — never touches `.orbit/` |
 
 ## Common Mistakes
 


### PR DESCRIPTION
## Task

[ORB-10452](https://orbit-cli.com/tasks/ORB-10452) — Irreversible CLI commands execute with no confirmation step

### Description

## Problem

Orbit's destructive CLI commands are gated inconsistently. Three have a guard — `workspace teardown` requires `--confirm` (and refuses a data root that is `~/.orbit` or does not end in `.orbit`), `gc worktrees` is dry-run by default and requires `--yes`, `learning prune` reports unless given `--delete`. Others destroy or irreversibly mutate state on a bare invocation with no flag and no prompt:

- `workspace remove <ws>` — deregisters immediately
- `audit prune --older-than` — deletes audit rows
- `task locks release` — self-described in its own source as an "operator/admin escape hatch"
- `run cancel <run_id>` — SIGTERM→SIGKILL of the owner process, releases reservations, terminalises the run
- `task archive <id>`
- `host retire`
- `migrate` (and `docs migrate`, `learning migrate-layout`) — applies unless `--dry-run` is passed

A typo or an agent's misread of a command surface is enough to trigger any of these. The inconsistency is itself the problem: there is no rule a caller can rely on for which operations are safe to invoke bare.

## Constraints

- **Adopt one convention** across all of them rather than adding ad-hoc flags; the existing `--confirm` / `--yes` / dry-run-default patterns should be reconciled into a stated rule, and the rule documented where command authors will see it.
- **Prefer recoverability to gating where the operation is already reversible.** Several of these are not true destruction — `workspace remove` deregisters rather than deletes, `task archive` is reversible. For those, an undo path is a better answer than a prompt, and adding friction to a recoverable operation is a cost with no benefit. Judge each operation on whether its effect can be undone, and say so in the task's execution summary.
- **Do not break non-interactive callers.** These commands are invoked from scripts and from agent runs; a change that makes a legitimate automated invocation hang on stdin or fail is a regression. Confirmation must be satisfiable non-interactively.
- Irreversible migrations warrant a different default from routine mutations; do not flatten the distinction.
- This task is about per-command confirmation only. Actor-based authorization is a separate task and must not be pre-empted or duplicated here.

## Non-goals

Passwords or credentials. Changing what any command does when it does proceed. Touching the MCP surface.

### Acceptance Criteria

- Every CLI command that destroys or irreversibly mutates state either requires an explicit confirmation affordance or is demonstrably recoverable; the audit of which commands fall in which bucket is recorded in the task's execution summary.
- One stated convention governs confirmation across these commands; the pre-existing `--confirm` / `--yes` / dry-run-default variants are reconciled rather than extended with new one-off spellings, and the convention is documented for future command authors.
- A non-interactive caller can satisfy confirmation without a TTY; no command blocks on stdin.
- Irreversible migration commands do not apply changes on a bare invocation.
- Each newly gated command has a test covering both the unconfirmed refusal and the confirmed execution.
- No behavioural change to any command's post-confirmation effect.
- Commands judged recoverable rather than gated have their recovery path verified by a test, not merely asserted.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added one non-interactive confirmation contract: irreversible single actions require `--confirm`; migration/bulk commands report by default and use `--confirm` to apply; no path reads stdin. Documented the rule in the command pattern and synchronized the upgrade runbook, project-learning design/ADR amendment, and both checked-in orbit-search skill copies.
- Newly gated `audit prune`, `task locks release`, `run cancel`, and `host retire` before their existing effects. Post-confirmation handlers and payloads are unchanged.
- Changed bare `migrate`, `docs migrate`, and `learning migrate-layout` to inspection-only; `--confirm` selects the prior apply path. Added an additive learning-layout inspection API while preserving the stable `migrate_learning_layout` signature.
- Reconciled safe-default bulk commands onto `--confirm`: `gc worktrees` retains `--yes` as a compatibility alias, and `learning prune` retains `--delete`. Explicit `--dry-run` remains a compatible spelling for the safe migration/GC mode.
Destructive-command audit:
- Explicitly confirmed: `workspace teardown` (pre-existing gate plus root safety checks), `audit prune`, `task locks release`, `run cancel`, and `host retire`.
- Safe by default, explicit apply: `gc worktrees`, `learning prune`, `migrate`, `docs migrate`, and `learning migrate-layout`.
- Recoverable and intentionally ungated: `workspace remove` only deregisters and is recovered with `workspace init`; `task archive` is recovered with `task update <id> --status backlog`. Both recovery paths are integration-tested.
- Actor-based authorization and MCP behavior were not changed.
Validation:
- `cargo test -p orbit-store learning_store::migration` (5 passed).
- `cargo test -p orbit-cli --bin orbit command::tests` (70 passed).
- Focused real cancellation test `command::run::tests::cancel_requires_confirmation_before_terminalizing_pending_run` passed.
- `cargo test -p orbit-cli --test task_trimmed_surface --test learning --test docs --test host_administration` (54 passed total).
- Exact `--help` smoke checks confirmed `--confirm` on all changed CLI surfaces and the two compatibility aliases.
- `cargo fmt --all -- --check`, `git diff --check`, checked-in skill-copy comparison, and required `make ci-fast` passed.
Assessment: The change fails closed before irreversible work, preserves unattended callers through explicit flags and aliases, keeps stable-crate API compatibility, and adds state-level refusal/apply or recovery coverage.
Deviations from original plan:
- Expanded context to the directly affected upgrade/design docs, checked-in skill copies, orbit-cmd migration docs, CLI run tests, and public re-export files after exact command-string and stable-API audits. No new dependency edge or behavior outside the CLI confirmation scope was introduced.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10452-6a666634`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*