### PR TITLE
agent_implement cannot allocate an ADR ID, so implementers ship decisions with no ADR

### DIFF
--- a/.orbit/resources/activities/agent_implement.yaml
+++ b/.orbit/resources/activities/agent_implement.yaml
@@ -149,6 +149,7 @@ spec:
         can produce it cheaply and accurately.
   tools:
     - orbit.task.*
+    - orbit.adr.add
     - orbit.friction.*
     - orbit.search
     - orbit.learning.show

--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -149,6 +149,7 @@ spec:
         can produce it cheaply and accurately.
   tools:
     - orbit.task.*
+    - orbit.adr.add
     - orbit.friction.*
     - orbit.search
     - orbit.learning.show

--- a/crates/orbit-core/src/command/activity.rs
+++ b/crates/orbit-core/src/command/activity.rs
@@ -171,7 +171,9 @@ pub(crate) fn seed_default_activities(
 
 #[cfg(test)]
 mod tests {
-    use orbit_common::types::activity_job::{AgentRole, OnDenial, tool_allowed};
+    use orbit_common::types::activity_job::{
+        AgentRole, OnDenial, tool_allowed, validate_tool_allowlist,
+    };
     use orbit_common::types::{ActivityV2Spec, load_activity_asset};
     use tempfile::tempdir;
 
@@ -261,6 +263,27 @@ mod tests {
                 assert!(instruction.contains("Before the first write"));
                 assert!(instruction.contains("git rev-parse --show-toplevel"));
                 assert!(instruction.contains("worktree_mismatch"));
+            }
+            other => panic!("expected agent_loop activity, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_implement_grants_concrete_adr_allocation() {
+        let (_, yaml) = DEFAULT_ACTIVITY_FILES
+            .iter()
+            .find(|(name, _)| *name == "agent_implement")
+            .expect("agent implement activity is seeded");
+        let asset = load_activity_asset(yaml).expect("parse agent implement activity");
+        match asset.spec.spec {
+            ActivityV2Spec::AgentLoop(spec) => {
+                assert!(
+                    spec.tools.iter().any(|tool| tool == "orbit.adr.add"),
+                    "implementers must be able to allocate global ADR IDs"
+                );
+                validate_tool_allowlist(&spec.tools)
+                    .expect("agent implement allowlist must remain valid");
+                assert!(tool_allowed("orbit.adr.add", &spec.tools));
             }
             other => panic!("expected agent_loop activity, got {other:?}"),
         }


### PR DESCRIPTION
## Task

[ORB-10455](https://orbit-cli.com/tasks/ORB-10455) — agent_implement cannot allocate an ADR ID, so implementers ship decisions with no ADR

### Description

## Problem

`docs/design/CONVENTIONS.md` §4 makes ADR allocation order non-negotiable: before writing an `## ADR-NNNN` heading, the author must allocate the global ID via `orbit.adr.add`, and hand-authoring an unallocated four-digit heading is the failure mode [ORB-00098] resolved (see [ADR-0153]).

`agent_implement` is the activity that produces the decisions ADRs exist to record, but `orbit.adr.add` is not in its `tools:` allowlist. An implementer that makes an ADR-worthy decision therefore has no compliant path: it cannot allocate, and it must not hand-author. The observed outcome is that the ADR simply does not get written and the narrative is left in design-doc prose with a follow-up task.

Observed on [ORB-10449], which split the agent-loop step-completion contract from the response content contract — a decision meeting all three CONVENTIONS criteria for its own ADR. Its execution summary records the block verbatim: "`orbit.adr.add` is not in this activity's tool grant, and CONVENTIONS forbids hand-authoring an unallocated four-digit heading."

The activity's own instruction already assumes the capability exists — step 6 tells the implementer to "cite its ID in the ADR's Consequences section" and to surface rejected alternatives in the ADR.

## Scope

Give `agent_implement` a usable, compliant path to allocate an ADR ID.

## Constraints (verified, non-obvious)

- **The mirror must stay byte-identical.** `crates/orbit-core/assets/activities/agent_implement.yaml` and `.orbit/resources/activities/agent_implement.yaml` are currently identical, and the skill-portability test's contract requires that. Both copies change together.
- **`orbit.adr.` is not a permitted wildcard root.** `V2_TOOL_WILDCARD_ROOTS` in `crates/orbit-common/src/types/activity_job/tool_allowlist.rs` does not list it, so a wildcard entry fails asset-load validation. Widening that list is a separate decision and is out of scope here — do not add a root to it.
- **No caller-role gate stands in the way.** Unlike `orbit.learning.add` (gated to human/orchestrator context, ORB-10364), `orbit.adr.*` has no authoring-role gate, so the grant is actually exercisable from implementer context. Do not add one.
- This asset seeds every workspace. Keep the change project-agnostic — no constellation-specific names, paths, or artifact IDs in shipped asset text.
- Minimal surface. This is a capability the activity already assumes; it is not an invitation to restructure the allowlist or rewrite the instruction block.

## Notes

Shares a modification surface with [ORB-10449] (`crates/orbit-core/src/command/activity.rs`, `crates/orbit-core/assets/activities/`), which is in flight — hence the dependency.

### Acceptance Criteria

- `agent_implement` can allocate a global ADR ID from implementer context without hand-authoring a heading
- The canonical asset and its `.orbit/resources/activities/` mirror remain byte-identical
- The allowlist entry passes `validate_tool_allowlist` without any change to `V2_TOOL_WILDCARD_ROOTS`
- A test pins the grant so a future allowlist edit that drops it fails rather than silently regressing the CONVENTIONS path
- No change to the caller-role gating of any orbit knowledge tool
- `make ci-fast` and `cargo clippy --workspace --all-targets` clean

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added the concrete `orbit.adr.add` grant to the shipped `agent_implement` asset and its byte-identical resource mirror, giving implementers a compliant global ADR-ID allocation path without widening wildcard roots.
- Added a focused activity test that pins the grant, validates the parsed allowlist, and verifies runtime permission matching.
Assessment: Minimal scoped change. Caller-role gates and `V2_TOOL_WILDCARD_ROOTS` were not changed.
Validation:
- `cargo test -p orbit-core agent_implement_grants_concrete_adr_allocation`
- `cargo clippy --workspace --all-targets --quiet`
- `make ci-fast`
- Mirror comparison and `git diff --check`

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10455-6a666c7f`
- Behind base: 0
- Ahead of base: 1