### PR TITLE
Dashboard-initiated ship runs fail immediately: provider launcher not resolvable from the server process (spawn claude ENOENT)

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -29,6 +29,7 @@ use super::envelope::{
     cli_agent_envelope_json, parse_cli_invocation_trace, parse_cli_response_result,
     task_id_from_input,
 };
+use super::spawn::resolve_provider_launcher;
 use super::supervisor::{
     DEFAULT_WALL_CLOCK_TIMEOUT_SECONDS, SpawnTraceContext, SpawnWithTimeoutRequest,
     spawn_with_timeout,
@@ -148,6 +149,9 @@ pub fn run_cli_backend(
         .invoke(agent_req)
         .map_err(|err| DispatchError::CliInvocationPermanent(format!("agent invoke: {err}")))?;
     let model = agent.model_name().map(str::to_string);
+    let resolved_program =
+        resolve_provider_launcher(&provider, &invocation.program, subprocess_cwd.as_deref())
+            .map_err(|err| DispatchError::CliInvocationPermanent(err.message))?;
 
     let mut subprocess_args = Vec::with_capacity(cli_executor.args.len() + invocation.args.len());
     subprocess_args.extend(cli_executor.args.iter().cloned());
@@ -158,8 +162,7 @@ pub fn run_cli_backend(
     // under bare exec it's `<program> <args...>`. The redactor still scrubs
     // the child's program name + args so secrets in argv stay redacted.
     let redaction = PatternRedactor::with_argv_secrets();
-    let audit_argv =
-        audit_argv_for_dispatch(&invocation.program, &subprocess_args, sandbox.as_ref());
+    let audit_argv = audit_argv_for_dispatch(&resolved_program, &subprocess_args, sandbox.as_ref());
     let argv_redacted: Vec<String> = audit_argv.iter().map(|a| redaction.apply_str(a)).collect();
 
     let stdin_blob_ref = audit.write_blob(&invocation.stdin);
@@ -206,7 +209,7 @@ pub fn run_cli_backend(
         agent_task_id: task_id,
     });
     let spawn_result = spawn_with_timeout(SpawnWithTimeoutRequest {
-        program: &invocation.program,
+        program: &resolved_program,
         args: &subprocess_args,
         stdin_bytes: &invocation.stdin,
         env: &child_env,

--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -1,4 +1,6 @@
-use std::path::Path;
+use std::collections::HashSet;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 
 use orbit_common::types::ExecutorSandboxKind;
@@ -54,6 +56,100 @@ impl SpawnError {
             _ => Self::transient(message),
         }
     }
+}
+
+/// Resolve a provider launcher without relying solely on the parent process's
+/// ambient `PATH`.
+///
+/// ADR-0259: every CLI-backed provider enters through this resolver so service,
+/// routine, dashboard, and interactive dispatches use the same lookup policy.
+pub(crate) fn resolve_provider_launcher(
+    provider: &str,
+    program: &str,
+    cwd: Option<&Path>,
+) -> Result<String, SpawnError> {
+    let path = std::env::var_os("PATH");
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    resolve_provider_launcher_with(provider, program, path.as_deref(), home.as_deref(), cwd)
+}
+
+// pub(crate) widened for sibling tests under the repository's enforced test layout.
+pub(crate) fn resolve_provider_launcher_with(
+    provider: &str,
+    program: &str,
+    path: Option<&OsStr>,
+    home: Option<&Path>,
+    cwd: Option<&Path>,
+) -> Result<String, SpawnError> {
+    let configured = Path::new(program);
+    if configured.components().count() > 1 {
+        return Ok(program.to_string());
+    }
+
+    let mut search_dirs = Vec::new();
+    let mut seen = HashSet::new();
+    if let Some(path) = path {
+        for dir in std::env::split_paths(path) {
+            let dir = if dir.is_relative() {
+                cwd.map_or(dir.clone(), |cwd| cwd.join(&dir))
+            } else {
+                dir
+            };
+            if seen.insert(dir.clone()) {
+                search_dirs.push(dir);
+            }
+        }
+    }
+    if let Some(home) = home {
+        for relative in [".local/bin", ".orbit/bin", ".cargo/bin", "bin"] {
+            let dir = home.join(relative);
+            if seen.insert(dir.clone()) {
+                search_dirs.push(dir);
+            }
+        }
+    }
+
+    let mut searched = Vec::with_capacity(search_dirs.len());
+    for dir in search_dirs {
+        let candidate = dir.join(program);
+        searched.push(candidate.clone());
+        if candidate.is_file() {
+            return Ok(candidate.to_string_lossy().into_owned());
+        }
+        #[cfg(windows)]
+        if configured.extension().is_none() {
+            for extension in windows_executable_extensions() {
+                let candidate = dir.join(format!("{program}{extension}"));
+                searched.push(candidate.clone());
+                if candidate.is_file() {
+                    return Ok(candidate.to_string_lossy().into_owned());
+                }
+            }
+        }
+    }
+
+    let searched = if searched.is_empty() {
+        "<no PATH or HOME search locations available>".to_string()
+    } else {
+        searched
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    Err(SpawnError::permanent(format!(
+        "provider launcher `{program}` for provider `{provider}` was not found; searched: {searched}"
+    )))
+}
+
+#[cfg(windows)]
+fn windows_executable_extensions() -> Vec<String> {
+    std::env::var("PATHEXT")
+        .unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string())
+        .split(';')
+        .filter(|extension| !extension.is_empty())
+        .map(str::to_ascii_lowercase)
+        .collect()
 }
 
 #[derive(Debug)]

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
@@ -5,7 +5,10 @@ use std::ffi::OsString;
 use tempfile::tempdir;
 
 use super::super::super::dispatcher::ResolvedSandbox;
-use super::super::spawn::{SpawnError, SpawnedChild, spawn_bare, spawn_macos_sandboxed_with};
+use super::super::spawn::{
+    SpawnError, SpawnedChild, resolve_provider_launcher_with, spawn_bare,
+    spawn_macos_sandboxed_with,
+};
 use super::test_support::{sandbox_for_test, sh_args};
 
 #[test]
@@ -106,6 +109,68 @@ fn spawn_io_error_classification_table() {
             classified.permanent, expect_permanent,
             "kind {kind:?} misclassified (permanent={})",
             classified.permanent
+        );
+    }
+}
+
+#[test]
+fn provider_launcher_resolution_falls_back_to_temp_home_with_scrubbed_path() {
+    let temp = tempdir().expect("tempdir");
+    let fake_path = temp.path().join("system-bin");
+    let home = temp.path().join("home");
+    let provider_bin = home.join(".local/bin");
+    std::fs::create_dir_all(&fake_path).expect("create fake PATH");
+    std::fs::create_dir_all(&provider_bin).expect("create provider bin");
+    let launcher = provider_bin.join("claude");
+    std::fs::write(&launcher, "#!/bin/sh\nexit 0\n").expect("write fake provider launcher");
+
+    let resolved = resolve_provider_launcher_with(
+        "claude",
+        "claude",
+        Some(fake_path.as_os_str()),
+        Some(&home),
+        None,
+    )
+    .expect("HOME fallback should resolve provider");
+
+    assert_eq!(resolved, launcher.to_string_lossy());
+}
+
+#[test]
+fn missing_provider_launcher_error_names_provider_and_searched_locations() {
+    let temp = tempdir().expect("tempdir");
+    let fake_path = temp.path().join("system-bin");
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&fake_path).expect("create fake PATH");
+    std::fs::create_dir_all(&home).expect("create fake HOME");
+
+    let error = resolve_provider_launcher_with(
+        "claude",
+        "claude",
+        Some(fake_path.as_os_str()),
+        Some(&home),
+        None,
+    )
+    .expect_err("missing launcher must fail");
+
+    assert!(error.permanent, "missing launcher must remain permanent");
+    assert!(
+        error.message.contains("provider `claude`"),
+        "error should name the provider: {}",
+        error.message
+    );
+    for searched in [
+        fake_path.join("claude"),
+        home.join(".local/bin/claude"),
+        home.join(".orbit/bin/claude"),
+        home.join(".cargo/bin/claude"),
+        home.join("bin/claude"),
+    ] {
+        assert!(
+            error.message.contains(&searched.display().to_string()),
+            "error should name searched location {}: {}",
+            searched.display(),
+            error.message
         );
     }
 }

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -324,6 +324,16 @@ After [T20260427-51], macOS CLI invocations declaring `sandbox: macos-sandbox-ex
 
 After [T20260509-40], bare Unix CLI subprocesses enter their own process group, matching the macOS sandbox wrapper's kill boundary. The supervisor kills that process group on timeout, also kills any remaining group members after the main child exits before joining output readers, and bounds timeout-path reader joins so a leaked pipe writer cannot hang the activity supervisor. Non-Unix platforms keep the immediate-child kill fallback until Orbit has an equivalent process-tree primitive there.
 
+After [ORB-10456], every bare provider launcher is resolved before audit and
+spawn at the shared `orbit-engine` CLI boundary ([ADR-0259]). Lookup preserves
+configured paths verbatim; bare names search the process `PATH` first, then
+portable user-local directories derived from `HOME` (`.local/bin`,
+`.orbit/bin`, `.cargo/bin`, and `bin`). Dashboard Ship, routine sweep,
+`orbit run ship`, and direct job execution all converge on this boundary, so
+none depends solely on the environment inherited by its entry process. A
+missing launcher remains a permanent failure, but the diagnostic names the
+provider and every path Orbit searched.
+
 After [T20260430-15], the CLI stdin envelope carries rendered activity input and durable `run_id` beside instruction, prompt, tools, and model. When input identifies one task, orbit-core embeds a canonical task snapshot with `input.workspace_path` / `input.repo_root` taking precedence over stored paths. After [T20260508-8], `backend: cli` also uses a shared workspace resolver for subprocess cwd: `input.workspace_path`, then `task.workspace_path`, then best-effort `ToolContext.workspace_root`. Declared input/task paths must already be directories; stale worktrees fail as `CliInvocationFailed` before `CliInvocationStarted` is emitted. After [T20260505-10], Orbit-managed CLI subprocesses receive `ORBIT_RUN_ID` plus an Orbit-managed run-context marker; `orbit tool run` requires both before it populates `ToolContext` reservation ownership. Direct manual CLI tool calls, including calls with only `ORBIT_RUN_ID`, remain unowned.
 
 The older `AgentRuntime` trait and `providers/*_cli.rs` files are not deprecated leftovers; they are the shipped `backend: cli` implementation.
@@ -651,5 +661,6 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[ORB-10332]** — Remove the unused Groundhog activity kind and the epic/parallel pipeline layer (`task_epic_pipeline`, `epic_orchestrator`, `pipeline_wait`, legacy parallel-batch executor).
 - **[ORB-10414]** — Make HTTP replay an explicit default-off cargo feature and keep replay environment variables inert in default builds.
 - **[ORB-10434]** — Extend the replay opt-in to orbit-core (`orbit-core/replay`) so its fixture-backed v2_host test keeps running hermetically instead of demanding a live credential.
+- **[ORB-10456]** — Resolve provider launchers at the shared CLI spawn boundary and report provider-aware searched-location diagnostics.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -778,8 +778,24 @@ Recognition is the entire change: no safety gate moved. Non-terminal run, `--old
 
 ---
 
+## ADR-0259 — Provider launchers resolve at the shared CLI spawn boundary
+
+**Status:** Proposed · 2026-07 · [ORB-10456]
+
+**Context.** Dashboard shipment reproduced the same provider-launcher ENOENT previously seen in routine sweeps: independent process entry points inherited different `PATH` values even though every `backend: cli` provider invocation converges on one engine spawn boundary. The alternatives were to keep pinning `PATH` in each service/entry point or resolve configured launcher names once at that shared boundary.
+
+**Decision.** Resolve every bare provider launcher at the orbit-engine CLI spawn boundary. Search the process `PATH` first, then portable per-user fallback directories derived from `HOME`; preserve explicitly pathed commands unchanged. Missing-launcher failures remain permanent and name the provider plus every searched path.
+
+**Consequences.**
+- Dashboard, routine, CLI ship, and direct job dispatch share one provider-launcher resolution mechanism rather than depending on each parent environment being curated.
+- Explicit command paths and `PATH` precedence remain authoritative, while common user-local installations work from scrubbed service environments.
+- Cost: Orbit now recognizes a small ordered set of conventional user-local bin directories outside `PATH`, so moving a launcher into a new convention requires extending and testing that list.
+
+---
+
 ## Task References
 
+- **[ORB-10456]** — Resolve provider launchers at the shared CLI spawn boundary and add provider-aware missing-launcher diagnostics ([ADR-0259]).
 - **[ORB-10454]** — Allocate [ADR-0258] for the step-completion / response-content split and retire the IOU in ADR-0224's amendment block.
 - **[ORB-10427]** — Share one worktree-path derivation between `setup_worktree` and gc; collect bundles only when every member has settled.
 - **[ORB-10393]** — Port planning-duel planner and arbiter legs to seeded v2


### PR DESCRIPTION
## Task

[ORB-10456](https://orbit-cli.com/tasks/ORB-10456) — Dashboard-initiated ship runs fail immediately: provider launcher not resolvable from the server process (spawn claude ENOENT)

### Description

## Problem

The Ship button added by ORB-10444 dispatches successfully, but the resulting pipeline run dies within ~1.4s. Every dashboard-initiated ship is currently dead on arrival.

Observed run `jrun-20260726-2043-3` (job `task_pr_pipeline`, workspace `ws_orbit`, crew `opus`, 2026-07-26 20:43:54Z):

```
state: failed  (duration 1412ms)
step 0  activity:worktree          -> success (541ms)
step 1  activity:implement_bundle  -> error   (323ms)
step 2  activity:implement_one     -> error   (322ms)

error: execution failed: v2 job dispatch: cli invocation failed (permanent):
       spawn claude: failed to spawn `claude`: No such file or directory (os error 2)
```

## What the evidence already establishes

- The failure is **not** in ship dispatch, task admission, or worktree setup — step 0 succeeded, so the run reached the agent step with a valid worktree.
- The failure is at process spawn: `claude` is not resolvable on the `PATH` of the process that spawned it. ENOENT is classified `permanent` by `SpawnError::from_spawn_io`, so the step retry wrapper fails fast — correct behavior, not the bug.
- The same class of failure has bitten this system before, from a different entry point: scheduled routine sweeps could not find provider launchers installed in `~/.local/bin`, fixed by pinning an explicit user PATH in `crates/orbit-core/assets/clock/orbit-sweep.service`. That unit is the only place in the repo that pins a provider-visible PATH.

## What is still a hypothesis

That the orbit server/dashboard process runs under an environment (systemd user unit, shell-launched daemon, or otherwise) whose `PATH` lacks the directory holding the `claude` launcher. **Confirm this before changing anything**: determine, with commands, the exact `PATH`, unit file, and environment actually in effect for the process that serves the dashboard and dispatches its ship runs, and where the `claude` launcher actually lives on that host. Then state the confirmed root cause before implementing.

## Why It Matters

Ship-from-dashboard is the feature ORB-10444 exists to deliver; it currently cannot complete a single run. The failure is also silent from the operator's point of view until they open the run — the button reports a run id and the run then dies.

## Constraints / Notes

- **A fix that only pins PATH on one more unit file is not sufficient by itself.** Provider-launcher resolution has now failed from two independent entry points (scheduled sweeps, dashboard-dispatched runs); any fix that leaves a third entry point relying on ambient inherited `PATH` re-opens this bug. Decide deliberately whether the resolution belongs at the spawn site or in the environment, and justify the choice in the execution summary.
- **Do not weaken the ENOENT-is-permanent classification** in `crates/orbit-engine/src/activity_job/cli_runner/spawn.rs` to make the symptom retry away. The fast failure is correct.
- **CI cannot validate this.** GitHub CI sets none of the relevant runtime environment, so a green CI run proves nothing about the fix. Validation must include reproducing the failure and then demonstrating success on the actual host environment — under both a populated and a minimal/scrubbed environment.
- Any error surfaced to the operator should name *what* could not be found, not just relay the raw OS error — a missing provider launcher is an operator-actionable condition.
- `orbit` is PR+CI-gated: branch off `agent-main`, dedicated worktree, land via PR.
- Anything under `crates/*/assets/**` is a shipped, project-agnostic surface: no host names, personal paths, or internal identifiers may be baked into a unit file or asset.

## Anti-scope

Do not redesign ship dispatch, the activity graph, or the retry policy. This is a root-cause fix for provider launcher resolution plus the diagnostics needed to make the next occurrence obvious.

### Acceptance Criteria

- Execution summary names the confirmed root cause, citing the commands run and their output: the exact process/unit serving the dashboard, the `PATH` in effect for it, and the resolved location of the `claude` launcher on the host.
- A ship dispatched from the dashboard for a `backlog` task reaches the agent step and executes it — the run advances past `implement_bundle`/`implement_one` instead of failing at spawn. Evidenced by a new run id and its step states in the execution summary.
- The same dispatch succeeds when initiated from a minimal/scrubbed environment (no inherited developer shell `PATH`), demonstrating the fix does not depend on ambient environment. Reproduce the original failure first, then show it resolved.
- Every entry point that spawns a provider CLI resolves the launcher by the same mechanism — enumerate the entry points in the execution summary and show that none is left depending solely on inherited ambient `PATH`.
- ENOENT remains classified permanent: `SpawnError::from_spawn_io` still maps `NotFound`/`PermissionDenied` to permanent, asserted by the existing tests passing unmodified.
- When a provider launcher genuinely cannot be found, the run's error message identifies the missing provider and the locations searched, not only the raw OS error. Covered by a test on the error-construction path.
- A regression test covers launcher resolution under an environment lacking the provider directory (temp HOME / fake PATH, no reliance on the host's real installation).
- `cargo test` passes for every crate touched, and `cargo clippy -- -D warnings` is clean on them.
- No host-specific or personal path is introduced into any file under `crates/*/assets/**`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added one provider-launcher resolver at orbit-engine CLI dispatch. Bare names search the process PATH first, then HOME-derived .local/bin, .orbit/bin, .cargo/bin, and bin; configured paths remain unchanged. Audit argv and spawn now use the same resolved launcher.
- Missing launchers remain permanent and now report the provider plus every searched location. Existing SpawnError::from_spawn_io classification was not changed.
- Added hermetic fake-PATH/fake-HOME fallback and missing-diagnostic tests, and documented the shared boundary in activity-job design plus proposed ADR-0259. No crates/*/assets file changed.

Confirmed root cause:
- ps -eo pid,ppid,lstart,args and ss -ltnp identified PID 1366257 as the SSH-session dashboard on 127.0.0.1:7877: orbit web serve --no-open --port 7877 --global, parent sshd PID 1366256, cgroup session-49.scope. It had no systemd unit. /proc/1366257/environ reported PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin.
- command -v claude returned ~/.local/bin/claude; readlink -f resolved ~/.local/share/claude/versions/2.1.220. env -i HOME=~ PATH=<PID-1366257-PATH> sh -c claude --version reproduced sh: claude: not found and exit=127.
- systemctl --user show/cat orbit-web.service identified the separate PID 1366182 service on 127.0.0.1:7878, unit ~/.config/systemd/user/orbit-web.service, with PATH=~/.local/bin:~/.orbit/bin:/usr/local/bin:/usr/bin:/bin. journalctl --user-unit orbit-web.service had no entry for failed run jrun-20260726-2043-3. The failing dashboard was therefore the SSH-session process whose inherited PATH omitted the installed launcher, not task admission, worktree setup, retry classification, or the systemd unit.

Entry-point audit:
- rg over crates/orbit-agent and crates/orbit-engine found one provider process-spawn leaf: dispatcher.rs routes Backend::Cli to run_cli_backend, which resolves once and calls spawn_with_timeout; spawn.rs owns the only provider Command::new.
- Dashboard POST /api/workflows/ship, orbit run ship, orbit job run, routine sweep/ship-sweep, and orbit.pipeline.invoke all enter the same job dispatcher and therefore the same resolver. Provider runtimes only render AgentInvocationSpec and do not spawn. No entry point remains solely ambient-PATH dependent.

Live validation:
- Scrubbed dashboard: started the branch binary from env -i with HOME=~ and PATH=/usr/bin:/bin on PID 1466454, port 7889, then POSTed the exact dashboard one-click body for validation task ORB-10459. Parent run jrun-20260726-2117 produced task_pr_pipeline child jrun-20260726-2117-3. Its audit recorded cli.invocation.started argv[0]=~/.local/bin/claude; implement_one and implement_bundle both finished success. The intentionally edit-free smoke later failed only at git_commit with 0 staged/unstaged/untracked files, after the acceptance-relevant provider step had succeeded.
- Populated dashboard: started the same branch binary with the developer PATH on PID 1491583, port 7891, and dispatched ORB-10460. Parent jrun-20260726-2122 produced child jrun-20260726-2122-3; audit again recorded ~/.local/bin/claude and both implement_one and implement_bundle finished success. The run was cancelled during the intentionally pointless no-diff commit recovery after capturing the required evidence.
- Both smoke worktrees stayed clean and their agents persisted Outcome: success summaries naming their run IDs. Thus the original ENOENT reproduced under the old scrubbed environment and the fixed branch advanced through the provider step under both scrubbed and populated environments.

Validation:
- cargo test -p orbit-engine: 314 unit tests plus v2_cli_backend and v2_name_resolution integration tests passed; existing ENOENT/EACCES permanence table passed unmodified.
- cargo clippy -p orbit-engine -- -D warnings: clean.
- make ci-fast: passed.
- git diff --check: passed. git diff -- crates/*/assets/** was empty.

Assessment: the fix is centralized at the only provider spawn boundary, retains PATH precedence and permanent spawn semantics, improves operator diagnostics, and introduces no dependency edge or host-specific shipped asset.

Deviations from original plan:
- The live smoke tasks deliberately made no repository edits to respect the no-commit-before-human-approval rule. Consequently their provider steps succeeded but downstream commit could not terminalize successfully; this does not weaken the direct launcher-resolution evidence requested by the task.
- Scope corrected from supervisor.rs to orchestrator.rs before finalizing context_files because resolution must precede audit argv construction.

Friction checkpoint:
- F2026-07-158 records the recurring ambient-PATH failure class and is resolved by this task.
- F2026-07-159 records a separate cancellation diagnostic defect observed during smoke cleanup: run cancel reported killed_process_group while the provider leader survived; exact PGID 1500647 was then terminated with SIGTERM. Recommended follow-up: fix cancellation verification/reporting.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10456-6a6676d9`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*