### PR TITLE
Convert 4_decisions.md from ADR narrative log to pointer index over .orbit/adrs

### DIFF
--- a/docs/design/CONVENTIONS.md
+++ b/docs/design/CONVENTIONS.md
@@ -1,7 +1,7 @@
 ---
 title: Design Doc Conventions
 owner: daniel
-last_updated: 2026-07-20
+last_updated: 2026-07-26
 last_validated: 2026-07-26
 status: Accepted
 ---
@@ -21,7 +21,7 @@ docs/design/<feature>/
 ├── 1_overview.md       recommended — what and why
 ├── 2_design.md         recommended — current implementation
 ├── 3_vision.md         recommended — forward-looking
-├── 4_decisions.md      recommended — ADR log (append-only)
+├── 4_decisions.md      recommended — ADR pointer index
 ├── specs/              recommended folder; may be empty initially
 │   └── <mechanism>.md  one mechanism per file
 └── references/         recommended folder; may be empty initially
@@ -65,7 +65,7 @@ The template frontmatter also carries the orbit-docs retrieval fields (`type`, `
 | **1_overview.md** | Elevator paragraph · §1 Motivation · §2 Core Concepts · §3 At a Glance (table: concern → file → task) · Task References |
 | **2_design.md** | Scope paragraph · mechanism sections (variable count, numbered) · §N Concerns & Honest Limitations (mandatory last section) · Task References |
 | **3_vision.md** | Scope paragraph · §1 Open Questions (numbered) · §2 Prior Work (subsections by category) · §3 What May Be Distinctive · §4 References (Orbit-internal + External) · Task References |
-| **4_decisions.md** | Format explainer · ADR entries in ascending number order |
+| **4_decisions.md** | Pointer-index explainer (including the `orbit.adr.show` command) · ADR pointers in ascending number order |
 
 Every numbered doc ends with a **Task References** section listing only the task IDs cited in that doc, plus the line:
 
@@ -75,18 +75,18 @@ Every numbered doc ends with a **Task References** section listing only the task
 
 ## 4. ADR Template (strict)
 
-**Allocation order is non-negotiable.** Before writing the heading or body, allocate the global ID via `orbit.adr.add` (see the `orbit-knowledge` skill and [ADR-0153]). The local heading then uses the allocated global ID verbatim — never invent a four-digit number that "looks global." The store is the source of truth for ID, status, owner, `related_features`, and `related_tasks`; the local `4_decisions.md` entry is the long-form narrative log keyed on that same global ID.
+**Allocation order is non-negotiable.** Before adding an ADR pointer, allocate the global ID via `orbit.adr.add` (see the `orbit-knowledge` skill and [ADR-0153]). The local pointer then uses the allocated global ID verbatim — never invent a four-digit number that "looks global." The store is the source of truth for the title, body, ID, status, owner, `related_features`, and `related_tasks`; `4_decisions.md` is an ordered pointer index, not a second narrative log.
 
-Copy the ADR block from [`_templates/4_decisions.md`](./_templates/4_decisions.md): a `## ADR-NNNN — <title>` heading, a `**Status:** <status> · YYYY-MM · [task]` line, then `Context` / `Decision` / `Consequences`, where the Consequences list ends with a `Cost:` bullet.
+Copy the pointer from [`_templates/4_decisions.md`](./_templates/4_decisions.md): `- **ADR-NNNN — <title>** — <status>.` Readers retrieve the authoritative `Context` / `Decision` / `Consequences` body with `orbit tool run orbit.adr.show --input '{"id":"ADR-NNNN"}'`. The store body, not the local index, must carry the ADR's mandatory `Cost:` consequence.
 
 Rules:
 
-- **Allocate first.** `orbit.adr.add` returns the global `ADR-NNNN` (4-digit, zero-padded). That ID is your local heading. Never hand-author headings under `## ADR-` without an allocation behind them. Bypassing this is the failure mode [ORB-00098] resolved; see [ADR-0153].
+- **Allocate first.** `orbit.adr.add` returns the global `ADR-NNNN` (4-digit, zero-padded). That ID is your local pointer. Never hand-author an `ADR-NNNN` pointer without an allocation behind it. Bypassing this is the failure mode [ORB-00098] resolved; see [ADR-0153].
 - **Inline cross-references** use the global ID (`[ADR-0042]`), resolvable via `orbit tool run orbit.adr.show --input '{"id":"ADR-0042"}'`.
-- Numbers are append-only; superseded entries stay in place with status updated.
-- `Proposed` allowed only before the relevant task ships. Flip to `Accepted` + task ID via `orbit.adr.update` (which also flips the markdown status line on the next edit) when it lands.
-- Every ADR must cite at least one cost. No cost = the decision wasn't real.
-- **Legacy 3-digit headings.** Existing local 3-digit headings (`## ADR-NNN`) authored before the global-ID convention are grandfathered. They may be backfilled opportunistically when a folder is being substantially edited; when backfilled, the local heading is rewritten to the allocated global ID and the original local ID is preserved as a `legacy_id` in the store record. See `docs/design/project-learnings/4_decisions.md` and `docs/design/agent-families/4_decisions.md` for worked examples.
+- Numbers are append-only; superseded records stay in the index with their store status.
+- `Proposed` is allowed only before the relevant task ships. Flip the store record to `Accepted` via `orbit.adr.update` when it lands, then refresh the index status on its next edit.
+- Every ADR body must cite at least one cost. No cost = the decision wasn't real.
+- **Legacy 3-digit headings.** Existing local 3-digit headings (`## ADR-NNN`) authored before the global-ID convention are grandfathered narrative records until separately backfilled. When backfilled, allocate the global ID first, preserve the original local ID as a `legacy_id` in the store record, verify that the store body carries the narrative, and replace the local body with its global pointer. See `docs/design/project-learnings/4_decisions.md` and `docs/design/agent-families/4_decisions.md` for worked examples.
 
 An entry earns its own ADR only if **all three** hold:
 
@@ -103,8 +103,8 @@ If only one or two hold, the decision belongs in `2_design.md` prose, as a row i
 When a cluster of accepted ADRs all instantiate the same underlying decision (e.g. "added language X to the tree-sitter extractor set"), the cluster may be folded into a single rollup ADR:
 
 - The rollup either reuses the parent ADR's number with an expanded body and a per-instance table, or claims a new number that lists the cluster.
-- Each folded entry stays in place with `Status: Superseded by ADR-NNN (folded)` and a one-line pointer; the body is removed.
-- The rollup must preserve every Cost line from the folded entries that doesn't duplicate a cost already named.
+- Each folded entry stays in the index with the store status (for example, `Superseded by ADR-NNN (folded)`).
+- The rollup's store body must preserve every Cost line from the folded entries that doesn't duplicate a cost already named.
 - Compaction is a normal maintenance operation, not an emergency cleanup. Owners should fold a cluster when the third instance lands, not the tenth.
 
 ---
@@ -125,7 +125,7 @@ Rules:
 
 Copy [`_templates/specs/_mechanism.md`](./_templates/specs/_mechanism.md): a one-paragraph contract statement, a **Why This Exists** section, mechanism-specific sections, and an optional **Agent Signature**.
 
-A spec is **prescriptive**. It names invariants ("writes do not fall back"), failure modes ("detached HEAD errors"), and migration paths. It is *not* a design-rationale doc — rationale lives in `4_decisions.md`.
+A spec is **prescriptive**. It names invariants ("writes do not fall back"), failure modes ("detached HEAD errors"), and migration paths. It is *not* a design-rationale doc — rationale lives in the ADR store and is indexed by `4_decisions.md`.
 
 ---
 

--- a/docs/design/_templates/4_decisions.md
+++ b/docs/design/_templates/4_decisions.md
@@ -16,28 +16,17 @@ related_artifacts: [ADR-NNNN]
 
 # <Feature> — Decisions
 
-ADR log for <feature>. Entries are append-only and ordered by ascending global
-ID. **Allocate the global `ADR-NNNN` via `orbit.adr.add` before writing the
-heading** — never hand-author a four-digit number. The store owns ID, status,
-owner, and links; this file is the long-form narrative keyed on that same ID.
-See [CONVENTIONS.md §4](../CONVENTIONS.md#4-adr-template-strict) for the full rules
-(when a decision earns an ADR, the mandatory Cost line, rollups).
+Ordered pointer index for <feature>'s ADRs. **Allocate the global `ADR-NNNN`
+via `orbit.adr.add` before adding the pointer** — never hand-author a four-digit
+number. The store owns the title, status, body, owner, and links; retrieve an
+ADR's authoritative narrative with `orbit tool run orbit.adr.show --input
+'{"id":"ADR-NNNN"}'`. See [CONVENTIONS.md §4](../CONVENTIONS.md#4-adr-template-strict)
+for the full rules (when a decision earns an ADR, the mandatory Cost line,
+rollups).
 
 <!-- Copy the block below for each new ADR. Delete this comment in real docs. -->
 
-## ADR-NNNN — <short title, noun phrase>
-
-**Status:** <Accepted | Proposed | Superseded by ADR-MMMM> · YYYY-MM · [ORB-NNNNN]
-
-**Context.** <1–3 sentences. Why this forced a decision.>
-
-**Decision.** <1–3 sentences. What we chose.>
-
-**Consequences.**
-
-- <consequence>
-- Cost: <explicit tradeoff — every ADR must name at least one cost a reader
-  could not infer from the decision itself>
+- **ADR-NNNN — <short title, noun phrase>** — <Accepted | Proposed | Superseded by ADR-MMMM>.
 
 ## Task References
 

--- a/docs/design/operations-as-data/4_decisions.md
+++ b/docs/design/operations-as-data/4_decisions.md
@@ -15,107 +15,18 @@ related_artifacts: [ORB-10358, ADR-0209, ADR-0253, ADR-0254, ADR-0255]
 
 # Operations as Data — Decisions
 
-ADR log for operations-as-data. Entries are append-only and ordered by ascending
-global ID. The store owns ID, status, owner, and links; this file is the
-long-form narrative keyed on that same ID. See
-[CONVENTIONS.md §4](../CONVENTIONS.md#4-adr-template-strict) for the rules.
+Ordered pointer index for operations-as-data ADRs. The store owns each title,
+status, and authoritative narrative; print a body with `orbit tool run
+orbit.adr.show --input '{"id":"ADR-NNNN"}'`. See [CONVENTIONS.md §4](../CONVENTIONS.md#4-adr-template-strict)
+for the rules.
 
 The parent bearing is **ADR-0209** (north-star: operations as data behind an
 operation registry), whose stored body now carries the friction pilot outcome and
 the ratchet.
 
-## ADR-0253 — Split spec/handler table joined by a typed verb enum
-
-**Status:** Accepted · 2026-07 · [ORB-10358]
-
-**Context.** ADR-0209 bearing 1 describes one operation table holding both the
-serializable definition and its handler. Orbit's layering makes that
-unreachable: every surface (`orbit-tools`, `orbit-cli`, `orbit-dashboard`) must
-read the definition, so it has to live at or below `orbit-common`; handlers need
-`&OrbitRuntime`, which lives in `orbit-core`, well above it. Co-locating them
-would either drag the runtime into the leaf crate or lift the specs above the
-surfaces that consume them — both new dependency edges that `ARCHITECTURE.md`
-forbids.
-
-**Decision.** Split the table across the two crates and join it with the noun's
-typed verb enum: `&'static [OperationSpec<V>]` in `orbit-common`, an exhaustive
-`match` on `V` in `orbit-core`. `V` is the only thing both halves share, and
-because both the spec lookup and the handler dispatch are exhaustive matches, a
-verb that is declared but not implemented fails to compile.
-
-**Consequences.**
-
-- Compile-time completeness across a crate boundary with no codegen, no trait
-  object, and no runtime registration phase.
-- Adding a verb breaks the build in exactly two known places, which is a usable
-  to-do list rather than a silent gap.
-- Future noun migrations should adopt this shape rather than re-attempting
-  co-location; ADR-0209's stored body records the correction.
-- If ADR-0209 bearing 2 (knowledge/execution split) moves knowledge handlers
-  below the surfaces, the halves could merge and this ADR would be superseded.
-- Cost: "the operation table" is now two files in two crates, so a reader
-  looking for an operation's behavior must follow the verb enum to find the
-  handler — the definition alone does not tell you what happens.
-
-## ADR-0254 — Renderers and HTTP routes stay hand-written
-
-**Status:** Accepted · 2026-07 · [ORB-10358]
-
-**Context.** Once verbs are data, the obvious next step is to make the rest of
-each surface data too: CLI output formatting and dashboard REST routes were both
-candidates. Both would have grown the registry and both were rejected during the
-friction pilot.
-
-**Decision.** The spec declares *which* rendering a verb wants (`CliRender`) but
-not how to render; the friction record and table printers stay in `orbit-cli` and
-know friction field names. Dashboard route shapes, serde request bodies, and
-HTTP-specific defaults stay hand-written in `orbit-dashboard`, which takes only
-tool names and parameter names from the registry.
-
-**Consequences.**
-
-- The registry stays a description of *operations*, not of presentation, which
-  keeps it readable and keeps its blast radius to contract.
-- A REST path remains an interface design decision made per route, not a
-  mechanical consequence of adding a verb.
-- Adding a friction verb that should be reachable over HTTP is still a two-place
-  change (registry + route).
-- A noun whose output has a genuinely new shape needs a new `CliRender` variant
-  plus a renderer — also two places.
-- Cost: the dashboard is only partially derived, so it remains possible to add a
-  verb and forget the route entirely; nothing fails, the verb is simply absent
-  from the web UI, and no test catches it.
-
-## ADR-0255 — Freeze the pre-migration surface as fixtures before migrating
-
-**Status:** Accepted · 2026-07 · [ORB-10358]
-
-**Context.** The pilot's hard requirement was that CLI argv/output and MCP tool
-schemas stay wire-compatible. Derived clap help output is only byte-stable
-because the adapter reproduces `#[derive(Args)]`'s conventions (arg id,
-SCREAMING_SNAKE value name, declaration-order display) — a correspondence
-nothing in the type system enforces. Verifying it after the fact, from the
-migrated code, proves nothing.
-
-**Decision.** Capture the pre-migration surface before writing any migration
-code, and commit it as test fixtures. For friction: `orbit friction [<verb>]
---help` for all eight pages, captured from the binary built at the prior commit
-and frozen under `crates/orbit-cli/src/command/tests/friction_help/`, asserted
-via `include_str!`. The already-in-tree `mcp_tools_list.json` snapshot serves the
-same role for MCP, where an empty `git diff` is the proof.
-
-**Consequences.**
-
-- "Wire compatible" became a checkable claim rather than a review assertion; the
-  friction migration reproduces all eight help pages and the MCP snapshot
-  byte-for-byte.
-- The fixtures keep working after the migration as a regression guard on the
-  derived surface, including across clap upgrades.
-- Every future noun migration must do this first — the cookbook makes it Step 0.
-- Cost: the fixtures encode incidental formatting (clap's global-arg placement,
-  column alignment), so an intentional, approved CLI change now requires
-  re-blessing files whose diff is mostly noise — and the fixture must be
-  distinguished from a genuine regression by a human reading the PR.
+- **ADR-0253 — Split spec/handler table joined by a typed verb enum** — Accepted.
+- **ADR-0254 — Renderers and HTTP routes stay hand-written** — Accepted.
+- **ADR-0255 — Freeze the pre-migration surface as fixtures before migrating** — Accepted.
 
 ## Task References
 

--- a/docs/design/orbit-graph/4_decisions.md
+++ b/docs/design/orbit-graph/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Orbit Graph — Decisions"
 type: design
 title: "Orbit Graph — Decisions"
 owner: claude
-last_updated: 2026-07-25
+last_updated: 2026-07-26
 status: Draft
 feature: orbit-graph
 doc_role: decisions
@@ -13,9 +13,11 @@ related_features: [knowledge-graph]
 
 # Orbit Graph — Decisions
 
-ADR-style log of non-obvious `orbit-graph` decisions. Each entry names the pressure, the choice, and the tradeoff. Entries are append-only and keyed by global ADR ID; superseded entries are marked, not deleted.
-
-Format for each entry: **Status · Date · Task(s)**, then *Context → Decision → Consequences*. Cost lines are mandatory.
+This index records non-obvious `orbit-graph` decisions in global ADR order.
+Store-backed pointers list the ID, title, and status; print their authoritative
+bodies with `orbit tool run orbit.adr.show --input '{"id":"ADR-NNNN"}'`.
+Older entries below remain unchanged until their narratives are separately
+verified in the ADR store.
 
 ---
 
@@ -124,19 +126,7 @@ Format for each entry: **Status · Date · Task(s)**, then *Context → Decision
 - Lost for now: cutover-only `callees`, `impact`, `trace`, the changed `sync` shape, and the extended graph-equiv corpus.
 - Cost: **cutover pauses.** The `orbit-graph` backend remains available for development, but agents lose the new cutover-only APIs until the root causes are fixed and a new cutover passes the gates.
 
-## ADR-0195 — Watcher-backed graph reads
-
-**Status:** Accepted · 2026-06-13 · [ORB-00377] · Supersedes ADR-0188
-
-**Context.** ORB-00377 found that the MCP `orbit.graph.*` read path was effectively poll-on-read: the 500ms `Windowed` policy elapsed between most agent calls, so each query paid for a full worktree diff before running the SQLite lookup. Lengthening the window would reduce frequency but would keep query latency coupled to repository size.
-
-**Decision.** Long-lived MCP graph handles use a watcher-backed policy: `Graph::open` performs one initial auto sync, starts a `notify` watcher scoped to the worktree, coalesces relevant filesystem events behind a debounce, and runs sync in the background. Query methods do not run inline sync for this policy; they read from a cached SQLite connection. The freshness contract is eventual: after a same-process file edit, graph reads may remain stale until the watcher observes and syncs the event, normally within the debounce plus sync duration; callers needing a hard read-after-write barrier must call `Graph::sync`/`orbit.graph.sync` before querying.
-
-**Consequences.**
-- Repeated graph reads with no intervening edits are pure SQLite lookups and do not initiate scanner walks.
-- Watcher overflow or watcher errors request a coalesced auto sync, preserving the conservative fallback path.
-- `Windowed` remains available as an explicit fallback policy, but it is no longer the MCP default.
-- Cost: the MCP process now depends on platform filesystem watcher behavior and may serve stale graph data during the documented debounce-plus-sync window.
+- **ADR-0195 — Watcher-backed graph reads** — Accepted.
 
 ## ADR-0197 — Remove the orbit-graph equivalence and benchmark harness
 

--- a/docs/design/user-interface/4_decisions.md
+++ b/docs/design/user-interface/4_decisions.md
@@ -12,7 +12,10 @@ tags: ["user-interface"]
 
 # User Interface — Decisions
 
-This append-only ADR log records UI decisions in ascending order. Each entry keeps its status line, cited task ID, decision summary, and at least one explicit cost.
+This index records UI ADRs in ascending order. Store-backed entries list their
+global ID, title, and status; print their authoritative bodies with `orbit tool
+run orbit.adr.show --input '{"id":"ADR-NNNN"}'`. Legacy entries below remain
+unchanged until their narratives are separately verified in the ADR store.
 
 ## ADR-001 — Canon Refined Aesthetic
 
@@ -62,19 +65,7 @@ This append-only ADR log records UI decisions in ascending order. Each entry kee
 - Operators get one clear scroll target for raw log rows while live-tail controls stay visible during short-screen monitoring.
 - Cost: The Tasks view trades narrow-screen stacking for denser columns so the live log remains in the first viewport.
 
-## ADR-0166 — Grouped Scoreboard Sections
-
-**Status:** Accepted · 2026-05 · [ORB-00144]
-
-**Context.** The scoreboard started as one compact per-agent table. Adding knowledge-artifact counters and planning-duel matrix data made the flat table mix delivery attribution, review work, operations, knowledge stewardship, and duel outcomes in one scan path. Alternatives were to keep widening the table, add column groups inside the same table, or split the view into focused sections.
-
-**Decision.** Render the dashboard scoreboard as focused sections: Delivery, Review, Knowledge, Operations, Planning Duels, a family-vs-family Duel Matrix, and Attribution Cleanup for non-canonical rows. Keep compact pair cells where they still help local interpretation, but do not treat the whole scoreboard as one primary flat leaderboard.
-
-**Consequences.**
-- Operators can inspect one contribution dimension at a time without conflating task creation, planning, implementation, review, tool usage, and knowledge artifacts.
-- Non-canonical attribution rows stay visible but no longer compete with canonical agent families in primary sections.
-- No single Rust code anchor; this is enforced by dashboard rendering and design review, and workspace-local ADR comments should not be embedded in shipped dashboard assets.
-- Cost: Cross-section comparison now requires scanning multiple tables instead of one row, and future metrics must choose an explicit section before being added.
+- **ADR-0166 — Grouped Scoreboard Sections** — Accepted.
 
 ## ADR-0167 — Extract Dashboard + JSON API to orbit-dashboard Crate
 


### PR DESCRIPTION
## Task

[ORB-10457](https://orbit-cli.com/tasks/ORB-10457) — Convert 4_decisions.md from ADR narrative log to pointer index over .orbit/adrs

### Description

## Problem

`docs/design/<feature>/4_decisions.md` duplicates content that already lives in the ADR store. Every entry carries a full `Context / Decision / Consequences` narrative body, and the same body is the source of truth in `.orbit/adrs/<status>/ADR-NNNN/body.md`. Two copies of the same prose, only one of which is authoritative, in ~3.9k lines across 25 files. The store record also owns id, status, owner, `related_features`, and `related_tasks` (`CONVENTIONS.md` §4 already says so), so the markdown status lines are a second drift surface on top of the bodies.

Nobody updates both. The store is what `orbit.adr.show` and the docs surfaces read; the markdown is what a human browsing a feature folder reads. They diverge silently.

## Desired end state

`4_decisions.md` stops being a narrative log and becomes a **pointer index**: an ordered list of the feature's ADRs that tells a reader which decisions exist, in what order, and where to read each one — without restating any of them. The feature folder stays self-navigable; the store stays the single source of ADR prose.

## Constraints

- **No content loss.** An ADR narrative may only be removed from markdown when the corresponding store record exists and its `body.md` carries that narrative. Verify per entry, do not assume.
- Roughly a third of current local headings have no store record — legacy 3-digit ids never backfilled, plus some 4-digit headings that were hand-authored without an allocation. **These are out of scope and must be left untouched, bodies intact.** A separate task handles them. Do not allocate new ADR ids in this task; do not write to `.orbit/`.
- Scope is active feature folders only. `docs/design/_archive/**` is not touched.
- `CONVENTIONS.md` and `_templates/4_decisions.md` are part of the deliverable, not an afterthought — the convention doc is the source of truth for the convention (its own words), so the rule must be stated there and the template must instantiate it. §3's required-sections table and §4's ADR template both describe the old shape.
- The convention must still say where the authoritative body lives and how to retrieve it, and must keep the existing allocation-order rule (`orbit.adr.add` first, global id verbatim) intact — this task changes what markdown holds, not how ADRs are allocated.
- Existing inline cross-references to ADR ids elsewhere in the docs tree must keep resolving.
- Everything shipped under `crates/*/assets/` and `plugin/skills/` is project-agnostic; if this convention change touches a shipped surface, no orbit-specific ids, feature names, or folder layout may leak into it.

## Acceptance criteria

- `CONVENTIONS.md` describes the pointer-index shape as the convention, with the old narrative-log shape removed rather than left alongside it; §3 and §4 are consistent with each other and with the template.
- `_templates/4_decisions.md` produces a conforming file when copied into a new feature folder.
- Every active-folder entry whose narrative is confirmed present in the store is reduced to its pointer form; every entry that is not is unchanged.
- A reader of any converted `4_decisions.md` can still tell, without opening another tool: which ADRs the feature has, in number order, each one's title and status, and the command that prints the body.
- Diff review shows no ADR narrative deleted without a verified store copy — state in the execution summary how that was verified, and list the entries deliberately left with bodies.
- No writes to `.orbit/`, no new ADR allocations, no changes under `docs/design/_archive/`.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced the design-doc convention and template narrative ADR-log model with an ordered pointer-index model. New pointers retain global ID, title, and status; the documented orbit.adr.show command retrieves the authoritative body. Allocation order and global IDs remain unchanged.
- Converted the five active entries whose normalized Context/Decision/Consequences content exactly matched their corresponding accepted ADR store body: operations-as-data ADR-0253, ADR-0254, ADR-0255; orbit-graph ADR-0195; user-interface ADR-0166.
- Added retrieval guidance to each converted folder and preserved all unmatched entries intact.
Verification:
- For every active four-digit local entry with an accepted store record, compared its heading-delimited narrative (excluding local status metadata and normalizing Markdown/whitespace) against .orbit/adrs/accepted/<id>/body.md. Only the five listed entries matched exactly; a repeat scan found no remaining exact matches.
- Deliberately retained bodies: activity-job ADR-001–ADR-052, ADR-0194, ADR-0214, ADR-0216, ADR-0224, ADR-0225, ADR-0233, ADR-0236, ADR-0246, ADR-0251, ADR-0252, ADR-0253, ADR-0258, ADR-0259; agent-families ADR-0151, ADR-0154, ADR-0155, ADR-0156, ADR-0167, ADR-0211, ADR-0213; auditability ADR-001–ADR-024, ADR-0164, ADR-0173, ADR-0245, ADR-0249; auto-tasks ADR-0218, ADR-0219; executors ADR-0196; host-registry ADR-0226–ADR-0232, ADR-0235, ADR-0240; mcp-bridge ADR-0226–ADR-0232, ADR-0235, ADR-0240; mcp-session-context ADR-0181, ADR-0199; orbit-core ADR-0203, ADR-0209; orbit-docs ADR-0169, ADR-0170, ADR-0171, ADR-0180; orbit-graph ADR-0184–ADR-0190, ADR-0192, ADR-0197–ADR-0199, ADR-0202; orbit-search ADR-001–ADR-008, ADR-0174, ADR-0175, ADR-0176, ADR-0179, ADR-0180, ADR-0244; policy-sandbox ADR-001–ADR-015; project-learnings ADR-0108–ADR-0112, ADR-0157, ADR-0210, ADR-0212, ADR-0242, ADR-0248, ADR-0250; remote-access ADR-0200, ADR-0201, ADR-0234; routines ADR-0204–ADR-0208, ADR-0215, ADR-0223; task-artifacts ADR-001–ADR-009, ADR-0182; user-interface ADR-001–ADR-004, ADR-0167, ADR-0168, ADR-00030, ADR-0256, ADR-0257. They are legacy, unallocated, missing-store, or store-content-different records and therefore were not safely removable.
- make ci-fast passed. git diff --check passed. Confirmed no changes under .orbit/ or docs/design/_archive/.
Assessment: The new convention and scaffold make the ADR store the only prose source while the exact verified entries are compact, self-navigable indexes. The retained records avoid deleting prose where store equivalence was not proven.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10457-6a667bc0`
- Behind base: 0
- Ahead of base: 1