### PR TITLE
Align task/implement guidance and grants with current safe tool behavior

### DIFF
--- a/.orbit/resources/activities/agent_implement.yaml
+++ b/.orbit/resources/activities/agent_implement.yaml
@@ -150,6 +150,7 @@ spec:
   tools:
     - orbit.task.*
     - orbit.adr.add
+    - orbit.adr.update
     - orbit.friction.*
     - orbit.search
     - orbit.learning.show

--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -150,6 +150,7 @@ spec:
   tools:
     - orbit.task.*
     - orbit.adr.add
+    - orbit.adr.update
     - orbit.friction.*
     - orbit.search
     - orbit.learning.show

--- a/crates/orbit-core/assets/skills/orbit-task/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-task/SKILL.md
@@ -9,7 +9,7 @@ Both surfaces (MCP `orbit_task_*` / CLI `orbit tool run orbit.task.*`) accept id
 
 ## 1. Create
 
-Create a task another engineer or agent can execute without guessing: a crisp problem description plus strong acceptance criteria. The execution plan is authored later, at pickup.
+Create a task another engineer or agent can execute without guessing: a crisp problem description plus strong acceptance criteria. The execution plan is authored later, at pickup, and persisted with `orbit.task.update`.
 
 **Workflow:**
 1. Confirm objective, constraints, and done criteria.
@@ -18,7 +18,7 @@ Create a task another engineer or agent can execute without guessing: a crisp pr
 4. Optionally enumerate files/dirs/symbols this task will modify or delete as canonical selectors (`file:`, `dir:`, `symbol:path#name:kind`) in `context_files`. `context_files` is optional unless your workspace's own policy requires it — leaving it empty is valid, and never guess entries to avoid an empty field. When you do fill it: only modification targets — not read-for-context files, conventions/pattern docs (cite those in prose instead), or files that don't exist yet. Design docs your repo co-locates with the code they describe are the exception (co-change with implementation). Every selector must resolve inside the target workspace's root; an out-of-root path fails pipeline admission. Prefer `file:`/`symbol:` over `dir:` when changes can be named more precisely.
 5. Set `complexity` (`low`/`medium`/`hard`) whenever scope is clear enough to judge — batching honors this when dispatching work.
 6. Add assumptions, risks, and rollback notes to the description when they matter.
-7. Call `orbit.task.add` with description, acceptance criteria, `context_files` (when filled), workspace, complexity, and `model`. Leave `plan` blank unless pre-seeding is justified.
+7. Call `orbit.task.add` with description, acceptance criteria, `context_files` (when filled), workspace, complexity, and `model`. Do not pass the retired `plan` field; persist the plan later at pickup with `orbit.task.update`.
 8. Confirm via the tool result, or re-fetch with `orbit.task.show`.
 
 **Operating rules:** Never edit task files directly. Never invent task IDs — `orbit.task.add` allocates them. `description` should be multi-line markdown for non-trivial tasks. Required: `title`, `description`, `workspace`. Strongly prefer `acceptance_criteria` and `complexity`. Valid `type`: `feature`, `bug`, `refactor`, `chore` — use friction (below) for self-reported tooling issues, not a task type. Blank/missing companion files (`plan.md`, `execution-summary.md`) are blank fields — repair via `orbit.task.update`, never by hand.
@@ -35,7 +35,7 @@ orbit tool run orbit.task.add --input '{
   "title": "<title>", "description": "<multi-line markdown>",
   "acceptance_criteria": ["<observable outcome 1>", "<observable outcome 2>"],
   "context_files": ["file:src/lib.rs", "dir:src/command", "symbol:src/lib.rs#run:function"],
-  "plan": "", "workspace": "<path>", "priority": "<low|medium|high|critical>",
+  "workspace": "<path>", "priority": "<low|medium|high|critical>",
   "complexity": "<low|medium|hard>", "type": "<feature|bug|refactor|chore>",
   "model": "<agent-family>"
 }'
@@ -64,7 +64,7 @@ Carry a task (or human request, once created above) from intent to verified impl
 
 **Step 3 — Start.** `orbit.task.start` with a `note`. Moves `backlog`/`proposed` → `in-progress` (records approval automatically). Starting from `proposed` still requires a real plan.
 
-**Step 4 — Implement and validate.** Follow the plan, inspecting files directly with `fs.read`. Verify transitive impact during implementation/review with `rg` (with shell access) or by inspecting callers directly; run the repo-approved verification commands (honor repo instructions if tests are forbidden).
+**Step 4 — Implement and validate.** Follow the plan, inspecting files directly with `fs.read`. Verify transitive impact during implementation/review with `rg` (with shell access) or by inspecting callers directly; run the repo-approved verification commands (honor repo instructions if tests are forbidden). In a linked pipeline worktree, never use positional `git stash`/`git stash pop`: refs and the stash list are repository-global, so a positional pop can restore another session's work. Instead, record the assigned worktree's initial `git rev-parse HEAD` value and compare against that explicit baseline with `git diff <baseline-sha> -- <paths>`.
 
 **Step 5 — Summarize and hand off.** Persist `execution_summary` via `orbit.task.update` first (template below). Friction checkpoint: if the task surfaced a contradicted assumption, recurring failure mode, non-obvious gotcha, or incident root cause, file it with `orbit.friction.add` (see §4). Project learnings are curated by the workspace's orchestrator or owner, not by task executors — the learning authoring gate refuses `orbit.learning.add`/`update`/`supersede` from executor context, so calling `orbit-knowledge`'s `add` action here is a wasted call, not a judgment call. Skip filing if none of the trigger conditions apply. Then:
 - **Under an activity envelope** (e.g. `agent_implement`): persist the summary only — the pipeline owns the `review` transition after commit/merge/PR steps succeed.

--- a/crates/orbit-core/src/command/activity.rs
+++ b/crates/orbit-core/src/command/activity.rs
@@ -269,7 +269,7 @@ mod tests {
     }
 
     #[test]
-    fn agent_implement_grants_concrete_adr_allocation() {
+    fn agent_implement_grants_allocate_then_update_adr() {
         let (_, yaml) = DEFAULT_ACTIVITY_FILES
             .iter()
             .find(|(name, _)| *name == "agent_implement")
@@ -277,13 +277,15 @@ mod tests {
         let asset = load_activity_asset(yaml).expect("parse agent implement activity");
         match asset.spec.spec {
             ActivityV2Spec::AgentLoop(spec) => {
-                assert!(
-                    spec.tools.iter().any(|tool| tool == "orbit.adr.add"),
-                    "implementers must be able to allocate global ADR IDs"
-                );
+                for tool in ["orbit.adr.add", "orbit.adr.update"] {
+                    assert!(
+                        spec.tools.iter().any(|granted| granted == tool),
+                        "implementers must be able to {tool} ADR artifacts"
+                    );
+                    assert!(tool_allowed(tool, &spec.tools));
+                }
                 validate_tool_allowlist(&spec.tools)
                     .expect("agent implement allowlist must remain valid");
-                assert!(tool_allowed("orbit.adr.add", &spec.tools));
             }
             other => panic!("expected agent_loop activity, got {other:?}"),
         }


### PR DESCRIPTION
## Task

[ORB-10463](https://orbit-cli.com/tasks/ORB-10463) — Align task/implement guidance and grants with current safe tool behavior

### Description

## Problem
Three current contract gaps share the executor guidance surface. The task skill still sends retired plan to orbit.task.add (F2026-07-032). Pipeline worktrees receive no warning that refs/stash is repository-global and positional stash pop can consume another session's WIP (F2026-07-142). agent_implement grants orbit.adr.add but not orbit.adr.update, so allocate-then-accept cannot be completed within the declared allowlist (F2026-07-156).

## Evidence
The effective and repo asset orbit-task SKILL.md still includes plan in task.add. F2026-07-142 records a failed pathspec followed by stash pop restoring another worktree's stash. crates/orbit-core/assets/activities/agent_implement.yaml grants orbit.adr.add only at line 152, while the current envelope reproduces the same allowlist.

## Scope
Correct the authored assets and their contract tests; do not broaden unrelated executor permissions.

### Acceptance Criteria

- orbit-task task.add examples/workflow omit the retired plan field and state that plan is persisted later through task.update.
- Pipeline executor guidance explicitly prohibits positional git stash/pop in linked worktrees and gives a safe baseline-comparison alternative.
- agent_implement declares orbit.adr.update alongside orbit.adr.add, and an asset/schema test pins the allocate-then-update grant pair.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated the authored orbit-task guidance and task.add example to omit the retired plan field and direct plan persistence through orbit.task.update at pickup.
- Added linked-worktree Git safety guidance prohibiting positional stash/pop and documenting explicit HEAD-baseline diffs.
- Granted orbit.adr.update alongside orbit.adr.add in the authored and seeded agent_implement activity mirrors, and extended the focused allowlist test to pin both grants.
Assessment: The scoped assets are byte-identical, the concrete ADR grant pair is validated, and no scope expansion was needed.
Validation:
- cargo test -p orbit-core agent_implement_grants_allocate_then_update_adr
- cmp -s crates/orbit-core/assets/activities/agent_implement.yaml .orbit/resources/activities/agent_implement.yaml
- git diff --check
- make ci-fast

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10463-6a6688e8`
- Behind base: 0
- Ahead of base: 1