### PR TITLE
Verify provider process-group death before reporting run cancellation success

### DIFF
--- a/crates/orbit-common/src/types/error.rs
+++ b/crates/orbit-common/src/types/error.rs
@@ -114,6 +114,17 @@ pub enum OrbitError {
     },
     #[error("execution failed: {0}")]
     Execution(String),
+    #[error(
+        "run cancellation incomplete: pid={pid}, pgid={pgid:?}, term_sent={term_sent}, kill_sent={kill_sent}, leader_alive={leader_alive}, group_alive={group_alive}"
+    )]
+    RunCancellationIncomplete {
+        pid: u32,
+        pgid: Option<i32>,
+        term_sent: bool,
+        kill_sent: bool,
+        leader_alive: bool,
+        group_alive: bool,
+    },
     #[error("store error: {0}")]
     Store(String),
     #[error("invalid task status transition: {0}")]

--- a/crates/orbit-common/src/utility/redaction.rs
+++ b/crates/orbit-common/src/utility/redaction.rs
@@ -163,6 +163,21 @@ pub fn redact_sensitive_env_error(error: OrbitError) -> OrbitError {
             payload: redact_sensitive_env_json(payload),
         },
         OrbitError::Execution(m) => OrbitError::Execution(redact_sensitive_env_text(&m)),
+        OrbitError::RunCancellationIncomplete {
+            pid,
+            pgid,
+            term_sent,
+            kill_sent,
+            leader_alive,
+            group_alive,
+        } => OrbitError::RunCancellationIncomplete {
+            pid,
+            pgid,
+            term_sent,
+            kill_sent,
+            leader_alive,
+            group_alive,
+        },
         OrbitError::Store(m) => OrbitError::Store(redact_sensitive_env_text(&m)),
         OrbitError::TaskStatusTransition(m) => {
             OrbitError::TaskStatusTransition(redact_sensitive_env_text(&m))
@@ -251,6 +266,21 @@ pub fn redact_all_error(error: OrbitError) -> OrbitError {
             payload: redact_json_with(payload, redact_all),
         },
         OrbitError::Execution(m) => OrbitError::Execution(redact_all(&m)),
+        OrbitError::RunCancellationIncomplete {
+            pid,
+            pgid,
+            term_sent,
+            kill_sent,
+            leader_alive,
+            group_alive,
+        } => OrbitError::RunCancellationIncomplete {
+            pid,
+            pgid,
+            term_sent,
+            kill_sent,
+            leader_alive,
+            group_alive,
+        },
         OrbitError::Store(m) => OrbitError::Store(redact_all(&m)),
         OrbitError::TaskStatusTransition(m) => OrbitError::TaskStatusTransition(redact_all(&m)),
         OrbitError::JobRunStateTransition(m) => OrbitError::JobRunStateTransition(redact_all(&m)),

--- a/crates/orbit-core/src/command/job/run/actions.rs
+++ b/crates/orbit-core/src/command/job/run/actions.rs
@@ -23,6 +23,21 @@ impl OrbitRuntime {
         actor: &str,
         source: &str,
     ) -> Result<JobRunCancelResult, OrbitError> {
+        self.cancel_job_run_with_signaller(run_id, actor, source, signal_run_owner_process)
+    }
+
+    /// Internal cancellation seam so tests can model a failed post-signal
+    /// liveness check without signalling a process they do not own.
+    pub(super) fn cancel_job_run_with_signaller<F>(
+        &self,
+        run_id: &str,
+        actor: &str,
+        source: &str,
+        signal: F,
+    ) -> Result<JobRunCancelResult, OrbitError>
+    where
+        F: FnOnce(&JobRun) -> Result<String, OrbitError>,
+    {
         let run = self
             .get_job_run_backend(run_id)?
             .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string()))?;
@@ -33,7 +48,7 @@ impl OrbitRuntime {
             })?;
         let signal_attempted = run.state == JobRunState::Running && run.pid.is_some();
         let signal_outcome = if signal_attempted {
-            Some(signal_run_owner_process(&run)?)
+            Some(signal(&run)?)
         } else {
             None
         };

--- a/crates/orbit-core/src/command/job/run/owner.rs
+++ b/crates/orbit-core/src/command/job/run/owner.rs
@@ -28,6 +28,9 @@ pub(super) fn signal_run_owner_process(run: &JobRun) -> Result<String, OrbitErro
     if pid == std::process::id() {
         return Ok("self_not_signalled".to_string());
     }
+    if !process_is_alive(pid) {
+        return Ok("already_exited".to_string());
+    }
     if !matches!(classify_run_owner(run), OwnerIdentity::Verified) {
         return Ok("owner_identity_mismatch".to_string());
     }
@@ -42,7 +45,8 @@ pub(super) fn signal_run_owner_process(run: &JobRun) -> Result<String, OrbitErro
         match send_signal_to_process_group(pgid, libc::SIGTERM) {
             Ok(()) => {}
             Err(error) if error.raw_os_error() == Some(libc::ESRCH) => {
-                return Ok("already_exited".to_string());
+                return verify_owner_termination(pid, Some(pgid), true, false)
+                    .map(|()| "already_exited".to_string());
             }
             Err(error) => {
                 return Err(OrbitError::Execution(format!(
@@ -51,14 +55,17 @@ pub(super) fn signal_run_owner_process(run: &JobRun) -> Result<String, OrbitErro
             }
         }
 
-        if wait_for_process_group_exit(pgid, RUN_OWNER_TERMINATION_GRACE) {
+        if wait_for_process_group_exit(pgid, RUN_OWNER_TERMINATION_GRACE)
+            && verify_owner_termination(pid, Some(pgid), true, false).is_ok()
+        {
             return Ok("terminated_process_group".to_string());
         }
 
         match send_signal_to_process_group(pgid, libc::SIGKILL) {
             Ok(()) => {}
             Err(error) if error.raw_os_error() == Some(libc::ESRCH) => {
-                return Ok("terminated_process_group".to_string());
+                return verify_owner_termination(pid, Some(pgid), true, true)
+                    .map(|()| "killed_process_group".to_string());
             }
             Err(error) => {
                 return Err(OrbitError::Execution(format!(
@@ -66,20 +73,23 @@ pub(super) fn signal_run_owner_process(run: &JobRun) -> Result<String, OrbitErro
                 )));
             }
         }
-        let _ = wait_for_process_group_exit(pgid, RUN_OWNER_TERMINATION_GRACE);
-        return Ok("killed_process_group".to_string());
+        wait_for_process_group_exit(pgid, RUN_OWNER_TERMINATION_GRACE);
+        return verify_owner_termination(pid, Some(pgid), true, true)
+            .map(|()| "killed_process_group".to_string());
     }
 
     // Fallback for platforms/configurations where the owner process group
     // cannot be resolved. The PID identity guard above still protects against
     // killing a reused PID.
     send_signal_to_pid(pid, libc::SIGTERM)?;
-    if wait_for_owner_exit(pid, RUN_OWNER_TERMINATION_GRACE) {
+    if wait_for_owner_exit(pid, RUN_OWNER_TERMINATION_GRACE)
+        && verify_owner_termination(pid, None, true, false).is_ok()
+    {
         Ok("terminated_owner".to_string())
     } else {
         send_signal_to_pid(pid, libc::SIGKILL)?;
-        let _ = wait_for_owner_exit(pid, RUN_OWNER_TERMINATION_GRACE);
-        Ok("killed_owner".to_string())
+        wait_for_owner_exit(pid, RUN_OWNER_TERMINATION_GRACE);
+        verify_owner_termination(pid, None, true, true).map(|()| "killed_owner".to_string())
     }
 }
 
@@ -151,11 +161,74 @@ fn process_group_is_alive(pgid: libc::pid_t) -> bool {
     if pgid <= 1 {
         return false;
     }
+    #[cfg(target_os = "linux")]
+    if let Some(alive) = linux_process_group_is_alive(pgid) {
+        return alive;
+    }
     let rc = unsafe { libc::kill(-pgid, 0) };
     if rc == 0 {
         return true;
     }
     std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+/// Linux keeps unreaped processes visible to `kill(..., 0)`, even though they
+/// can no longer run or receive signals. Treat a group consisting solely of
+/// zombies as terminated so a parent which reaps after cancellation does not
+/// make a successful cancellation look incomplete.
+#[cfg(target_os = "linux")]
+fn linux_process_group_is_alive(pgid: libc::pid_t) -> Option<bool> {
+    let entries = std::fs::read_dir("/proc").ok()?;
+    let mut found_group_member = false;
+    for entry in entries.flatten() {
+        let Ok(pid) = entry.file_name().to_string_lossy().parse::<u32>() else {
+            continue;
+        };
+        let Some((state, member_pgid)) = linux_process_state(pid) else {
+            continue;
+        };
+        if member_pgid != pgid {
+            continue;
+        }
+        found_group_member = true;
+        if state != 'Z' {
+            return Some(true);
+        }
+    }
+    found_group_member.then_some(false)
+}
+
+#[cfg(target_os = "linux")]
+fn linux_process_state(pid: u32) -> Option<(char, libc::pid_t)> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let (_, tail) = stat.rsplit_once(')')?;
+    let mut fields = tail.split_whitespace();
+    let state = fields.next()?.chars().next()?;
+    let _parent_pid = fields.next()?;
+    let process_group = fields.next()?.parse().ok()?;
+    Some((state, process_group))
+}
+
+#[cfg(unix)]
+pub(super) fn verify_owner_termination(
+    pid: u32,
+    pgid: Option<libc::pid_t>,
+    term_sent: bool,
+    kill_sent: bool,
+) -> Result<(), OrbitError> {
+    let leader_alive = process_is_alive(pid);
+    let group_alive = pgid.is_some_and(process_group_is_alive);
+    if !leader_alive && !group_alive {
+        return Ok(());
+    }
+    Err(OrbitError::RunCancellationIncomplete {
+        pid,
+        pgid: pgid.map(|group| group as i32),
+        term_sent,
+        kill_sent,
+        leader_alive,
+        group_alive,
+    })
 }
 
 /// Returns true only for Running runs whose owner is conclusively stale
@@ -381,6 +454,10 @@ where
 #[cfg(unix)]
 pub(super) fn process_is_alive(pid: u32) -> bool {
     if pid == 0 || pid > i32::MAX as u32 {
+        return false;
+    }
+    #[cfg(target_os = "linux")]
+    if matches!(linux_process_state(pid), Some(('Z', _))) {
         return false;
     }
     // Safety: signal 0 performs existence/permission checking only.

--- a/crates/orbit-core/src/command/job/run/tests/actions.rs
+++ b/crates/orbit-core/src/command/job/run/tests/actions.rs
@@ -5,6 +5,8 @@ use super::*;
 #[cfg(unix)]
 use super::super::owner::process_is_alive;
 use chrono::{Duration, Utc};
+#[cfg(unix)]
+use orbit_common::types::OrbitError;
 use std::path::Path;
 #[cfg(unix)]
 use std::process::{Command, Stdio};
@@ -183,7 +185,7 @@ fn cancel_job_run_does_not_signal_reused_pid_identity_mismatch() {
 
 #[cfg(unix)]
 #[test]
-fn cancel_job_run_terminates_owner_process_group_and_child() {
+fn cancel_job_run_kills_term_resistant_process_group() {
     use std::os::unix::process::CommandExt;
 
     let (_root, runtime) = test_runtime();
@@ -239,6 +241,87 @@ fn cancel_job_run_terminates_owner_process_group_and_child() {
     assert!(
         wait_until(StdDuration::from_secs(3), || !process_is_alive(child_pid)),
         "child process {child_pid} should be gone after process-group cancellation"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn cancellation_of_an_already_exited_process_group_is_successful() {
+    let (_root, runtime) = test_runtime();
+    let run = insert_pending_run(&runtime, "qa_cancel_exited_group");
+    let mut owner = Command::new("/bin/sh")
+        .arg("-c")
+        .arg("exit 0")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn exited owner");
+    let owner_pid = owner.id();
+    owner.wait().expect("reap exited owner");
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, Utc::now(), owner_pid)
+        .expect("mark running");
+
+    let result = runtime
+        .cancel_job_run(&run.run_id)
+        .expect("cancel exited owner");
+
+    assert_eq!(result.signal_outcome.as_deref(), Some("already_exited"));
+    assert_eq!(
+        runtime.show_job_run(&run.run_id).expect("show run").state,
+        JobRunState::Cancelled
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn cancellation_survivor_returns_typed_evidence_without_finalizing_run() {
+    let (_root, runtime) = test_runtime();
+    let run = insert_pending_run(&runtime, "qa_cancel_survivor");
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, Utc::now(), std::process::id())
+        .expect("mark running");
+
+    let error = runtime
+        .cancel_job_run_with_signaller(&run.run_id, "tester", "unit", |_| {
+            Err(OrbitError::RunCancellationIncomplete {
+                pid: 4242,
+                pgid: Some(4242),
+                term_sent: true,
+                kill_sent: true,
+                leader_alive: true,
+                group_alive: true,
+            })
+        })
+        .expect_err("a survivor must fail cancellation");
+    assert!(matches!(
+        error,
+        OrbitError::RunCancellationIncomplete {
+            pid: 4242,
+            pgid: Some(4242),
+            term_sent: true,
+            kill_sent: true,
+            leader_alive: true,
+            group_alive: true,
+        }
+    ));
+    assert_eq!(
+        runtime.show_job_run(&run.run_id).expect("show run").state,
+        JobRunState::Running,
+        "a failed liveness verification must not finalize the run"
+    );
+    assert!(
+        runtime
+            .list_session_events(20)
+            .expect("list events")
+            .iter()
+            .all(|event| event.event_type != "JobRunCancelled"),
+        "a failed cancellation must not emit a success audit event"
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-10476](https://orbit-cli.com/tasks/ORB-10476) — Verify provider process-group death before reporting run cancellation success

### Description

## Problem
Run cancellation can report signal_outcome killed_process_group and persist the run as cancelled while the provider process-group leader remains alive and orphaned under PID 1 (F2026-07-159).

## Evidence
During ORB-10456 validation, orbit run cancel jrun-20260726-2122-3 reported killed_process_group for PID/PGID 1500647. Ten one-second probes still found the exact ~/.local/bin/claude process; an explicit kill -TERM -- -1500647 terminated it immediately. Current crates/orbit-core/src/command/job/run/owner.rs returns killed_process_group after signal attempts without a post-signal liveness verification.

## Scope
Make cancellation outcome reflect observed process-group death and preserve actionable evidence when TERM/KILL does not take effect.

### Acceptance Criteria

- Cancellation verifies the recorded process/group is gone before returning or persisting killed_process_group.
- If the leader or group survives TERM/KILL, the command returns a typed partial/failed outcome with pid, pgid, signals, and liveness evidence; it must not silently mark cancellation successful.
- Deterministic tests cover an immediately exiting group, a TERM-resistant process requiring KILL, and a simulated/reproducible survivor path without signalling unrelated processes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Cancellation now verifies both the recorded owner and process group after TERM and KILL before returning a successful group/owner outcome; surviving targets return `RunCancellationIncomplete` with pid, pgid, sent-signal flags, and liveness evidence, leaving the run non-terminal.
- Treats Linux zombie-only groups as terminated so completed cancellations are not misreported while a parent has yet to reap; immediately exited owners return `already_exited`.
- Added deterministic coverage for already-exited groups, a TERM-resistant group requiring KILL, and an injected survivor path that proves cancellation neither terminalizes the run nor writes a success audit event without signalling an unrelated process.
- Expanded context with `crates/orbit-common/src/types/error.rs` and `crates/orbit-common/src/utility/redaction.rs`: the typed outcome required a common error variant and its exhaustive redaction handling.
Assessment: scoped cancellation hardening with focused coverage; no new dependencies or dependency edges.
Validation:
- `cargo test -p orbit-core command::job::run::tests::actions -- --nocapture` (8 passed)
- `make ci-fast` (passed)

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10476-6a6689fb`
- Behind base: 0
- Ahead of base: 1