### PR TITLE
Make SQLite migrations safe for legacy databases and long-lived workers

### DIFF
--- a/.orbit/adrs/accepted/ADR-0287/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0287/adr.yaml
@@ -1,0 +1,24 @@
+schema_version: 2
+id: ADR-0287
+title: Freeze shipped SQLite baselines and preflight worker schema compatibility
+status: accepted
+owner: codex
+created_at: 2026-07-26T22:27:41.683352597Z
+accepted_at: 2026-07-26T22:27:45.849235764Z
+last_updated: 2026-07-26T22:27:45.849235764Z
+related_features:
+- sqlite-migrations
+- pipeline-workers
+related_tasks:
+- ORB-10462
+tags:
+- sqlite
+- migration
+- worker-coordination
+paths:
+- crates/orbit-store/src/sqlite/migration/**
+- crates/orbit-core/src/command/job/pipeline.rs
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0287/body.md
+++ b/.orbit/adrs/accepted/ADR-0287/body.md
@@ -1,0 +1,10 @@
+## Context
+The versioned SQLite ledger skips migrations already recorded, so editing the v1 baseline alone changes fresh databases but not legacy databases. A long-lived worker can also retain an older runtime while another Orbit process advances the shared database, causing a late downgrade-guard error only when telemetry reopens the store after agent work. The alternatives were to rerun the mutable baseline on every open or to preserve shipped versions and require append-only upgrades plus an early worker compatibility check.
+
+## Decision
+Treat the v1 baseline as an immutable historical artifact guarded by a structural fingerprint. Every schema change after v1 must use a new append-only migration, and tests compare a fresh database with a v1 database upgraded through every registered version. Pipeline workers reopen the store once before claiming the run so compatible pending migrations apply and incompatible newer schemas fail before agent work. Invocation telemetry remains non-fatal and records durable degradation evidence.
+
+## Consequences
+- Fresh and legacy databases converge through the same ordered registry, and baseline-only edits fail structural tests.
+- Long-lived workers pay one additional SQLite open before claiming a run and cannot discover schema incompatibility only after useful agent work.
+- Cost: schema authors must append a migration and update structural expectations instead of editing the fresh baseline in place; the baseline fingerprint is intentionally strict.

--- a/crates/orbit-core/src/command/job/pipeline.rs
+++ b/crates/orbit-core/src/command/job/pipeline.rs
@@ -316,6 +316,8 @@ impl OrbitRuntime {
     }
 
     pub fn execute_pipeline_run_worker(&self, run_id: &str) -> Result<(), OrbitError> {
+        self.preflight_pipeline_worker_store()?;
+
         // [ORB-10070] Claim the queued run for this worker process so orphan
         // reconciliation can tell a pending run whose worker is alive and
         // polling for its admission slot apart from one whose worker died
@@ -373,6 +375,18 @@ impl OrbitRuntime {
 
             return self.execute_pipeline_run_now(&run, &yaml_path);
         }
+    }
+
+    /// Reopen the shared SQLite store before the worker claims a run.
+    ///
+    /// ADR-0287: another Orbit process may advance the host-global database
+    /// while this runtime remains alive. Reopening here applies migrations
+    /// supported by this binary or trips the downgrade guard before any agent
+    /// work. Invocation persistence still reopens independently, but it can no
+    /// longer be the first compatibility check after useful work completes.
+    pub(crate) fn preflight_pipeline_worker_store(&self) -> Result<(), OrbitError> {
+        drop(self.sqlite_store()?);
+        Ok(())
     }
 
     pub fn normalize_pipeline_wait_timeout(raw: Option<u64>) -> Result<u64, OrbitError> {

--- a/crates/orbit-core/src/command/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/command/tests/job_pipeline.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 
 use chrono::Utc;
-use orbit_common::types::{AuditEventStatus, JobRunState};
+use orbit_common::types::{AuditEventStatus, JobRunState, OrbitError};
+use orbit_store::sqlite::migration::SUPPORTED_SCHEMA_VERSION;
 use tempfile::TempDir;
 
 use crate::OrbitRuntime;
@@ -156,6 +157,80 @@ fn worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic() {
                 .as_deref()
                 .is_some_and(|error| error.contains("before claiming"))
     }));
+}
+
+#[test]
+fn long_lived_worker_reopens_and_applies_compatible_pending_schema() {
+    let (_root, runtime) = test_runtime();
+    let store = runtime.sqlite_store().expect("open store fixture");
+    {
+        let connection = store.connection();
+        let conn = connection.lock().expect("store connection");
+        conn.execute("DELETE FROM schema_meta WHERE key = 'migration.v0011'", [])
+            .expect("rewind routine migration ledger");
+        conn.execute_batch(
+            "DROP TABLE routine_pauses;
+             DROP TABLE routine_fires;
+             DROP TABLE routine_cursors;",
+        )
+        .expect("rewind routine schema");
+    }
+
+    runtime
+        .preflight_pipeline_worker_store()
+        .expect("compatible worker preflight");
+
+    assert_eq!(
+        store.schema_version().expect("schema after preflight"),
+        SUPPORTED_SCHEMA_VERSION
+    );
+    let connection = store.connection();
+    let conn = connection.lock().expect("store connection");
+    let routine_tables: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master
+             WHERE type = 'table' AND name IN (
+                 'routine_cursors', 'routine_fires', 'routine_pauses'
+             )",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count routine tables");
+    assert_eq!(routine_tables, 3);
+}
+
+#[test]
+fn newer_schema_fails_before_worker_claims_or_executes() {
+    let (_root, runtime) = test_runtime();
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("task_gate_pipeline", 1, Utc::now(), None, None)
+        .expect("insert pending run");
+    let store = runtime.sqlite_store().expect("open store fixture");
+    {
+        let connection = store.connection();
+        let conn = connection.lock().expect("store connection");
+        conn.execute(
+            "INSERT INTO schema_meta(key, value, updated_at)
+             VALUES (?1, 'future_schema', '2099-01-01T00:00:00Z')",
+            [format!(
+                "migration.v{:04}",
+                SUPPORTED_SCHEMA_VERSION.saturating_add(1)
+            )],
+        )
+        .expect("advance store beyond worker");
+    }
+
+    let error = runtime
+        .execute_pipeline_run_worker(&run.run_id)
+        .expect_err("newer schema must fail worker preflight");
+    assert!(matches!(error, OrbitError::Migration(_)), "{error:?}");
+
+    let stored = runtime.show_job_run(&run.run_id).expect("show pending run");
+    assert_eq!(stored.state, JobRunState::Pending);
+    assert_eq!(stored.pid, None);
+    assert!(stored.steps.is_empty());
 }
 
 #[test]

--- a/crates/orbit-store/src/sqlite/migration/ledger.rs
+++ b/crates/orbit-store/src/sqlite/migration/ledger.rs
@@ -86,12 +86,19 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "invocation_telemetry_columns",
         apply: super::apply_invocation_telemetry_columns,
     },
+    // ADR-0287: baseline v1 is frozen; schema added later always advances
+    // through an append-only ledger entry.
+    Migration {
+        version: 11,
+        name: "routine_scheduler_schema",
+        apply: super::apply_routine_scheduler_schema,
+    },
 ];
 
 /// Highest schema version this binary knows how to produce. Public for
 /// the future `orbit migrate` surface (P3.4), alongside
 /// [`AppliedMigration`] and the `Store` version accessors.
-pub const SUPPORTED_SCHEMA_VERSION: u32 = 10;
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 11;
 
 const LEDGER_KEY_PREFIX: &str = "migration.v";
 

--- a/crates/orbit-store/src/sqlite/migration/mod.rs
+++ b/crates/orbit-store/src/sqlite/migration/mod.rs
@@ -88,6 +88,9 @@ pub fn pending_schema_migrations_after(current_version: u32) -> Vec<PendingSchem
 /// run on both a fresh database and any legacy database created by the
 /// pre-versioning migration code, which is how existing databases adopt
 /// the versioned ledger.
+///
+/// ADR-0287: this shipped structure is immutable. Later schema belongs in a
+/// new migration so databases that already recorded v1 receive it too.
 fn apply_baseline_schema(conn: &Connection) -> Result<(), OrbitError> {
     conn.execute_batch(
         r#"
@@ -174,10 +177,8 @@ fn apply_baseline_schema(conn: &Connection) -> Result<(), OrbitError> {
                 input_tokens INTEGER NOT NULL DEFAULT 0,
                 cache_read_tokens INTEGER NOT NULL DEFAULT 0,
                 cache_create_tokens INTEGER NOT NULL DEFAULT 0,
-                cache_create_1h_tokens INTEGER NOT NULL DEFAULT 0,
                 output_tokens INTEGER NOT NULL DEFAULT 0,
-                tool_call_count INTEGER NOT NULL DEFAULT 0,
-                provider_cost_usd REAL
+                tool_call_count INTEGER NOT NULL DEFAULT 0
             );
 
             CREATE TABLE IF NOT EXISTS invocation_tasks (
@@ -234,9 +235,8 @@ fn apply_baseline_schema(conn: &Connection) -> Result<(), OrbitError> {
     ensure_audit_events_schema(conn)?;
     ensure_task_reservations_schema(conn)?;
     ensure_learning_index_schema(conn)?;
-    ensure_invocation_schema(conn)?;
+    ensure_invocation_schema_v1(conn)?;
     ensure_v2_state_consolidation_schema(conn)?;
-    ensure_routine_schema(conn)?;
 
     Ok(())
 }
@@ -608,11 +608,6 @@ fn apply_invocation_telemetry_columns(conn: &Connection) -> Result<(), OrbitErro
     {
         return Ok(());
     }
-    ensure_invocation_schema(conn)
-}
-
-fn ensure_invocation_schema(conn: &Connection) -> Result<(), OrbitError> {
-    add_column_if_missing(conn, "ALTER TABLE invocations ADD COLUMN slot TEXT")?;
     add_column_if_missing(
         conn,
         "ALTER TABLE invocations ADD COLUMN provider_cost_usd REAL",
@@ -621,6 +616,11 @@ fn ensure_invocation_schema(conn: &Connection) -> Result<(), OrbitError> {
         conn,
         "ALTER TABLE invocations ADD COLUMN cache_create_1h_tokens INTEGER NOT NULL DEFAULT 0",
     )?;
+    ensure_invocation_schema_v1(conn)
+}
+
+fn ensure_invocation_schema_v1(conn: &Connection) -> Result<(), OrbitError> {
+    add_column_if_missing(conn, "ALTER TABLE invocations ADD COLUMN slot TEXT")?;
     conn.execute_batch(
         r#"
             CREATE INDEX IF NOT EXISTS idx_invocations_job_run_id
@@ -684,12 +684,10 @@ fn ensure_v2_state_consolidation_schema(conn: &Connection) -> Result<(), OrbitEr
                 retry_source_run_id TEXT,
                 knowledge_metrics_json TEXT,
                 resolved_crew TEXT,
-                crew_model TEXT,
                 planner_model TEXT,
                 implementer_model TEXT,
                 reviewer_model TEXT,
                 pipeline_state_json TEXT,
-                archived_at TEXT,
                 PRIMARY KEY(workspace_id, run_id)
             );
 
@@ -748,6 +746,14 @@ fn apply_flat_crew_model(conn: &Connection) -> Result<(), OrbitError> {
 
 fn apply_job_run_archive_stage(conn: &Connection) -> Result<(), OrbitError> {
     add_column_if_missing(conn, "ALTER TABLE job_runs ADD COLUMN archived_at TEXT")
+}
+
+/// v11 `routine_scheduler_schema` migration (ORB-10462): routine tables were
+/// added only to the mutable v1 baseline after the ledger shipped. Register
+/// the idempotent schema step so existing databases receive the same tables
+/// as fresh databases before the baseline is frozen by ADR-0287.
+fn apply_routine_scheduler_schema(conn: &Connection) -> Result<(), OrbitError> {
+    ensure_routine_schema(conn)
 }
 
 /// v5 `host_registry_core` migration (ORB-10255): durable machine identity,

--- a/crates/orbit-store/src/sqlite/migration/tests/ledger.rs
+++ b/crates/orbit-store/src/sqlite/migration/tests/ledger.rs
@@ -61,6 +61,9 @@ fn fresh_db_applies_baseline_and_records_ledger() {
     assert_eq!(applied[9].version, 10);
     assert_eq!(applied[9].name, "invocation_telemetry_columns");
     assert!(!applied[9].applied_at.is_empty());
+    assert_eq!(applied[10].version, 11);
+    assert_eq!(applied[10].name, "routine_scheduler_schema");
+    assert!(!applied[10].applied_at.is_empty());
 }
 
 #[test]
@@ -201,6 +204,10 @@ fn legacy_db_adopts_versioned_ledger() {
                 "migration.v0010".to_string(),
                 "invocation_telemetry_columns".to_string()
             ),
+            (
+                "migration.v0011".to_string(),
+                "routine_scheduler_schema".to_string()
+            ),
         ]
     );
 }
@@ -212,7 +219,7 @@ fn refuses_db_from_a_newer_binary() {
 
     conn.execute(
         "INSERT INTO schema_meta(key, value, updated_at)
-         VALUES ('migration.v0011', 'from-the-future', '2099-01-01T00:00:00Z')",
+         VALUES ('migration.v0012', 'from-the-future', '2099-01-01T00:00:00Z')",
         [],
     )
     .expect("record future migration");
@@ -292,7 +299,7 @@ fn store_reopens_database_at_shipped_schema_v4_and_applies_through_latest() {
     );
     assert_eq!(
         applied.last().map(|migration| migration.name.as_str()),
-        Some("invocation_telemetry_columns")
+        Some("routine_scheduler_schema")
     );
     let connection = store.connection();
     let conn = connection.lock().expect("connection");
@@ -619,4 +626,87 @@ fn migrated_legacy_db_carries_every_invocation_insert_column() {
             },
         })
         .expect("insert invocation trace into migrated legacy database");
+}
+
+fn schema_column_fingerprint(conn: &Connection) -> String {
+    let mut table_statement = conn
+        .prepare(
+            "SELECT name FROM sqlite_master
+             WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+             ORDER BY name",
+        )
+        .expect("prepare table list");
+    let tables = table_statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .expect("query table list")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect table list");
+
+    tables
+        .into_iter()
+        .map(|table| {
+            let mut column_statement = conn
+                .prepare(&format!("PRAGMA table_info({table})"))
+                .expect("prepare column list");
+            let columns = column_statement
+                .query_map([], |row| row.get::<_, String>(1))
+                .expect("query column list")
+                .collect::<Result<Vec<_>, _>>()
+                .expect("collect column list");
+            format!("{table}:{}\n", columns.join(","))
+        })
+        .collect()
+}
+
+/// ADR-0287: v1 is a shipped historical artifact. This fingerprint is
+/// deliberately strict: adding a fresh-only table or column to the baseline
+/// fails here and requires an append-only migration instead.
+#[test]
+fn shipped_v1_baseline_structure_is_frozen() {
+    let conn = Connection::open_in_memory().expect("open v1 database");
+    ledger::run_migrations(&conn, &ledger::MIGRATIONS[..1]).expect("apply v1 only");
+
+    assert_eq!(
+        schema_column_fingerprint(&conn),
+        concat!(
+            "adrs:id,status,title,owner,related_features,related_tasks,tags,paths,legacy_ids,supersedes,superseded_by,validation_warnings,legacy_validation,created_at,accepted_at,last_updated\n",
+            "agent_sessions:session_id,task_id,identity_id,identity_name,identity_role,identity_block,skill_names,composed_context_hash,effective_allowed_tools,tool_calls,outcome,status,created_at,updated_at\n",
+            "audit_events:id,execution_id,timestamp,command,subcommand,tool_name,target_type,target_id,role,status,exit_code,duration_ms,working_directory,arguments_json,stdout_truncated,stderr_truncated,error_message,host,pid,session_id,task_id,job_run_id,activity_id,step_index\n",
+            "invocation_tasks:invocation_id,task_id\n",
+            "invocations:id,ts,job_run_id,activity_id,agent,model,slot,duration_ms,input_tokens,cache_read_tokens,cache_create_tokens,output_tokens,tool_call_count\n",
+            "job_run_steps:workspace_id,run_id,step_index,target_type,target_id,state,started_at,finished_at,duration_ms,exit_code,error_code,error_message,agent_response_json\n",
+            "job_runs:run_id,workspace_id,job_id,attempt,state,scheduled_at,started_at,finished_at,duration_ms,created_at,pid,pid_start_time,input_json,retry_source_run_id,knowledge_metrics_json,resolved_crew,planner_model,implementer_model,reviewer_model,pipeline_state_json\n",
+            "learnings_index:id,status,paths,tags,summary,updated_at,priority\n",
+            "schema_meta:key,value,updated_at\n",
+            "session_learning_state:workspace_id,session_id,learning_injection_state_json,updated_at\n",
+            "task_reservations:reservation_id,workspace_orbit_dir,workspace_id,task_ids_json,files_json,actor,created_at,expires_at,released_at,owner_run_id,owner_metadata_json,release_reason,release_metadata_json\n",
+            "tool_calls:invocation_id,seq,tool_name,result_bytes\n",
+            "tools:name,path,description,parameters_json,enabled,builtin,created_at,updated_at\n",
+            "v2_audit_events:id,workspace_id,event_id,source,schema_version,event_type,ts,run_id,agent_identity,parent_event_id,workspace_path,payload_json\n",
+        )
+    );
+}
+
+/// A database that recorded shipped v1 and then advances through every
+/// registered migration must expose the same table/column structure as a
+/// database created fresh by the current binary.
+#[test]
+fn v1_upgrade_and_fresh_database_have_identical_columns() {
+    let fresh = Connection::open_in_memory().expect("open fresh database");
+    apply_schema(&fresh).expect("migrate fresh database");
+
+    let legacy = Connection::open_in_memory().expect("open legacy database");
+    ledger::run_migrations(&legacy, &ledger::MIGRATIONS[..1]).expect("record shipped v1");
+    ledger::run_migrations(&legacy, ledger::MIGRATIONS).expect("upgrade through registry");
+
+    assert_eq!(
+        applied_migrations(&legacy)
+            .expect("legacy migration ledger")
+            .len(),
+        ledger::MIGRATIONS.len()
+    );
+    assert_eq!(
+        schema_column_fingerprint(&legacy),
+        schema_column_fingerprint(&fresh)
+    );
 }


### PR DESCRIPTION
## Task

[ORB-10462](https://orbit-cli.com/tasks/ORB-10462) — Make SQLite migrations safe for legacy databases and long-lived workers

### Description

## Problem
Two production incidents expose one migration-safety gap. A long-lived worker reopened a database after another binary advanced its schema and failed only after useful agent work (F2026-07-031). Separately, columns added only to the v1 baseline never reach databases whose migration ledger already records v1 (F2026-07-106).

## Evidence
F2026-07-031 names jrun-20260713-0305-3 and the v3→v4 downgrade-guard failure during persist_invocation_trace. F2026-07-106 traces baseline-only add_column_if_missing calls and records provider_cost_usd absent from existing databases. The current migration ledger lives under crates/orbit-store/src/sqlite/migration/.

## Scope
Add a durable upgrade rule and worker/store coordination; telemetry persistence must not discard completed task work.

### Acceptance Criteria

- A legacy database migrated through every registered version has the same required columns as a fresh database, with a structural regression test that fails on baseline-only schema edits.
- A long-lived worker encountering a database advanced by another compatible Orbit process either reopens compatibly or fails before agent work; it cannot fail only at invocation persistence.
- Invocation/telemetry persistence failure is surfaced durably without converting otherwise-completed implementation work into a failed run.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Froze the shipped v1 SQLite baseline and moved post-v1 routine scheduler structure into append-only migration v11, while preserving prior ledger entries and advancing SUPPORTED_SCHEMA_VERSION.
- Added strict baseline and legacy-v1-to-fresh whole-schema column fingerprint regressions so fresh-only table or column edits fail validation.
- Added pipeline-worker store preflight before run claim, with long-lived-runtime coverage for compatible migration reopen and newer-schema fail-fast behavior.
- Recorded accepted ADR-0287 for immutable baselines and early worker/store compatibility.
- Verified the existing ORB-10367 degraded-telemetry contract remains non-fatal and durably observable through telemetry.persist_failed run audit events.
Assessment: The migration ledger is append-only, fresh and legacy schemas converge, and workers discover store compatibility before agent execution. No scope additions or dependency changes were required.
Validation:
- cargo test -p orbit-store sqlite::migration::tests --lib (26 passed)
- cargo test -p orbit-core command::tests::job_pipeline --lib (8 passed)
- cargo test -p orbit-engine failed_invocation_trace_persist_does_not_fail_the_step --lib (1 passed)
- make ci-fast (passed)
- git diff --check (passed)

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10462-6a6688e8`
- Behind base: 0
- Ahead of base: 1