### PR TITLE
Bound or externalize oversized pull-request bodies before GitHub create

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/pr/body.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/body.rs
@@ -4,6 +4,8 @@ use crate::context::PrConfig;
 
 use super::super::freshness::BranchFreshness;
 
+pub(super) const GITHUB_PR_BODY_BYTE_LIMIT: usize = 65_536;
+
 /// Builds the generated PR body. One-task PRs use the task-contract-first
 /// layout; multi-task callers intentionally keep the historical batch layout
 /// until those legacy paths are retired.
@@ -25,7 +27,52 @@ pub(super) fn build_batch_pr_body(
         body.push_str(&signature);
     }
 
-    body
+    bound_pr_body(body, tasks)
+}
+
+/// Projects a PR body into GitHub's UTF-8 byte limit while keeping the
+/// complete task artifacts as the durable source of execution detail.
+pub(super) fn bound_pr_body(body: String, tasks: &[Task]) -> String {
+    if body.len() <= GITHUB_PR_BODY_BYTE_LIMIT {
+        return body;
+    }
+
+    let task_ids = tasks
+        .iter()
+        .map(|task| task.id.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let durable_record = if task_ids.is_empty() {
+        "the persisted Orbit task artifacts".to_string()
+    } else {
+        format!("the persisted Orbit task artifacts for {task_ids}")
+    };
+    let audit_note = format!(
+        "\n\n> **Audit note:** GitHub limits PR bodies to {GITHUB_PR_BODY_BYTE_LIMIT} bytes. This projection is truncated; complete task artifacts remain the durable record in {durable_record}."
+    );
+    let retained_body_bytes = GITHUB_PR_BODY_BYTE_LIMIT.saturating_sub(audit_note.len());
+
+    if retained_body_bytes == 0 {
+        return truncate_utf8(&audit_note, GITHUB_PR_BODY_BYTE_LIMIT).to_string();
+    }
+
+    format!(
+        "{}{}",
+        truncate_utf8(&body, retained_body_bytes),
+        audit_note
+    )
+}
+
+fn truncate_utf8(value: &str, max_bytes: usize) -> &str {
+    if value.len() <= max_bytes {
+        return value;
+    }
+
+    let mut end = max_bytes;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    &value[..end]
 }
 
 pub(super) fn build_single_task_pr_body(

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/open.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/open.rs
@@ -12,7 +12,9 @@ use super::super::git::git_output;
 use super::super::handoff::{
     FailedHandoffPhase, HandoffContext, load_handoff_context, record_failed_handoff,
 };
-use super::body::{build_batch_pr_body, default_pr_title};
+use super::body::{
+    GITHUB_PR_BODY_BYTE_LIMIT, bound_pr_body, build_batch_pr_body, default_pr_title,
+};
 
 pub(in crate::executor::automation) fn pr_open<
     H: DeterministicActionHost + TaskHost + Sync + ?Sized,
@@ -89,6 +91,7 @@ fn open_or_reuse_pr<H: DeterministicActionHost + TaskHost + ?Sized>(
                 pr_opener_model.as_deref(),
             )
         });
+    let body = bound_pr_body(body, &context.tasks);
     let tool_context = ToolContext {
         cwd: Some(context.workspace_path.to_string_lossy().to_string()),
         allowed_tools: vec![],
@@ -109,6 +112,11 @@ fn open_or_reuse_pr<H: DeterministicActionHost + TaskHost + ?Sized>(
             freshness: &freshness,
         })),
         Ok(None) => {
+            tracing::info!(
+                constructed_body_bytes = body.len(),
+                allowed_body_bytes = GITHUB_PR_BODY_BYTE_LIMIT,
+                "creating pull request with bounded body projection"
+            );
             let created = host
                 .run_tool_with_context_and_role(
                     "github.pr.create",
@@ -168,6 +176,7 @@ pub(in crate::executor::automation::vcs) fn open_or_reuse_unchecked<
     title: &str,
     body: &str,
 ) -> Result<(String, Option<String>, bool), OrbitError> {
+    let body = bound_pr_body(body.to_string(), &[]);
     let tool_context = ToolContext {
         cwd: Some(workspace_path.to_string_lossy().to_string()),
         allowed_tools: vec![],
@@ -176,6 +185,11 @@ pub(in crate::executor::automation::vcs) fn open_or_reuse_unchecked<
     if let Some((number, url)) = find_pr_by_head(host, head, tool_context.clone())? {
         return Ok((number, url, false));
     }
+    tracing::info!(
+        constructed_body_bytes = body.len(),
+        allowed_body_bytes = GITHUB_PR_BODY_BYTE_LIMIT,
+        "creating unchecked pull request with bounded body projection"
+    );
     let created = host.run_tool_with_context_and_role(
         "github.pr.create",
         json!({

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/body.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/body.rs
@@ -4,6 +4,93 @@ use super::super::body::*;
 use super::test_support::*;
 
 #[test]
+fn pr_body_at_github_byte_limit_is_preserved() {
+    let mut task = task_with_contract(
+        "ORB-10474",
+        "Bound PR body",
+        "x",
+        "Keep the generated body within GitHub's limit.",
+        &[],
+        None,
+    );
+    let initial_body = build_batch_pr_body(
+        &[task.clone()],
+        &freshness(),
+        &[],
+        &test_pr_config(None),
+        None,
+    );
+    task.execution_summary = "x".repeat(GITHUB_PR_BODY_BYTE_LIMIT - initial_body.len() + 1);
+
+    let body = build_batch_pr_body(&[task], &freshness(), &[], &test_pr_config(None), None);
+
+    assert_eq!(body.len(), GITHUB_PR_BODY_BYTE_LIMIT);
+    assert!(!body.contains("**Audit note:**"));
+}
+
+#[test]
+fn oversized_multibyte_pr_body_is_truncated_on_a_utf8_boundary() {
+    let task = task_with_contract(
+        "ORB-10474",
+        "Bound PR body",
+        &"é".repeat(GITHUB_PR_BODY_BYTE_LIMIT),
+        "Keep the generated body within GitHub's limit.",
+        &[],
+        None,
+    );
+
+    let body = build_batch_pr_body(&[task], &freshness(), &[], &test_pr_config(None), None);
+
+    assert!(body.len() <= GITHUB_PR_BODY_BYTE_LIMIT);
+    assert!(body.contains("**Audit note:**"));
+    assert!(body.contains("ORB-10474"));
+    assert!(std::str::from_utf8(body.as_bytes()).is_ok());
+}
+
+#[test]
+fn oversized_single_task_body_keeps_an_audit_reference_to_its_artifact() {
+    let task = task_with_contract(
+        "ORB-10474",
+        "Bound PR body",
+        &"x".repeat(GITHUB_PR_BODY_BYTE_LIMIT),
+        "Keep the generated body within GitHub's limit.",
+        &[],
+        None,
+    );
+
+    let body = build_batch_pr_body(&[task], &freshness(), &[], &test_pr_config(None), None);
+
+    assert!(body.len() <= GITHUB_PR_BODY_BYTE_LIMIT);
+    assert!(body.contains("complete task artifacts remain the durable record in the persisted Orbit task artifacts for ORB-10474"));
+}
+
+#[test]
+fn oversized_batch_body_keeps_an_audit_reference_to_every_task_artifact() {
+    let body = build_batch_pr_body(
+        &[
+            task(
+                "ORB-10474",
+                "First task",
+                &"x".repeat(GITHUB_PR_BODY_BYTE_LIMIT),
+            ),
+            task(
+                "ORB-10475",
+                "Second task",
+                &"x".repeat(GITHUB_PR_BODY_BYTE_LIMIT),
+            ),
+        ],
+        &freshness(),
+        &[],
+        &test_pr_config(None),
+        None,
+    );
+
+    assert!(body.len() <= GITHUB_PR_BODY_BYTE_LIMIT);
+    assert!(body.contains("ORB-10474, ORB-10475"));
+    assert!(body.contains("**Audit note:**"));
+}
+
+#[test]
 fn task_url_rendering_covers_template_and_external_ref_priority() {
     let plain = task_with_contract("T123", "Plain task", "done", "", &[], None);
     assert_eq!(task_url(&plain, &test_pr_config(None)), None);

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/open.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/open.rs
@@ -2,6 +2,7 @@ use super::super::open::pr_open;
 use super::super::promote::pr_promote;
 use super::test_support::*;
 
+use super::super::body::GITHUB_PR_BODY_BYTE_LIMIT;
 use crate::context::TaskReadHost;
 use orbit_common::types::TaskStatus;
 use serde_json::json;
@@ -270,4 +271,26 @@ fn pr_open_preserves_non_empty_explicit_body() {
 
     pr_open(&host, &input).expect("create PR with explicit body");
     assert_eq!(host.pr_create_body(), "Custom reviewer handoff.");
+}
+
+#[test]
+fn pr_open_bounds_an_oversized_explicit_body_before_github_create() {
+    let workspace = pr_workspace();
+    let host = PrOpenTestHost::new(
+        vec![batch_task(
+            "ORB-10474",
+            "Bound explicit body",
+            "Outcome: success\nChanges:\n- Ready.",
+        )],
+        workspace.repo.clone(),
+    );
+    let mut input = pr_open_input(&workspace.repo, vec!["ORB-10474"]);
+    input["body"] = json!("é".repeat(GITHUB_PR_BODY_BYTE_LIMIT));
+
+    pr_open(&host, &input).expect("create PR with bounded explicit body");
+
+    let body = host.pr_create_body();
+    assert!(body.len() <= GITHUB_PR_BODY_BYTE_LIMIT);
+    assert!(body.contains("**Audit note:**"));
+    assert!(body.contains("ORB-10474"));
 }


### PR DESCRIPTION
## Task

[ORB-10474](https://orbit-cli.com/tasks/ORB-10474) — Bound or externalize oversized pull-request bodies before GitHub create

### Description

## Problem
pr_open embeds the complete persisted execution_summary into the GitHub PR body without enforcing GitHub maximum body size. ORB-10445 produced 66,319 UTF-8 bytes and GitHub rejected createPullRequest after implementation, commit, sync, and push (F2026-07-151).

## Evidence
Current crates/orbit-engine/src/executor/automation/vcs/pr/body.rs renders the full summary in details and open.rs passes the body to github.pr.create; no 65,536-byte bound or externalization path exists.

## Scope
Preserve the full task artifact while constructing a deterministic, valid PR projection with measured byte limits.

### Acceptance Criteria

- PR body construction measures UTF-8 bytes and never calls github.pr.create with a body above the configured/GitHub limit.
- Oversized summaries remain complete in the task artifact and the PR body contains a bounded summary plus a durable reference/audit note.
- Boundary tests cover exactly-at-limit, multibyte-over-limit, single-task, and batch bodies; diagnostics report constructed and allowed sizes before the external call.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a 65,536-byte UTF-8 projection limit for generated and explicit PR bodies, preserving complete task artifacts as the durable record and appending an audit note with task IDs when truncation occurs.
- Enforced the projection immediately before every github.pr.create path and logged constructed and allowed byte counts before the external call.
- Added exact-limit, multibyte overflow, oversized single-task, oversized batch, and explicit-body boundary coverage.
Assessment: PR creation cannot receive an oversized UTF-8 body; task execution summaries remain unmodified in persisted task artifacts.
Validation:
- cargo fmt --check
- cargo test -p orbit-engine executor::automation::vcs::pr::tests (37 passed)
- make ci-fast
Deviations from original plan:
- Added the directly affected PR body and open test files to context_files before editing; they are required to validate the stated boundaries and create-call guarantee.
Friction checkpoint: no report filed; no qualifying workflow or tooling friction surfaced.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10474-6a668c00`
- Behind base: 0
- Ahead of base: 1