### PR TITLE
Stop auto-tasks from mutating tracked configuration in the shared primary checkout

### DIFF
--- a/.orbit/adrs/proposed/ADR-0286/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0286/adr.yaml
@@ -1,0 +1,22 @@
+schema_version: 2
+id: ADR-0286
+title: Route tracked auto-task definitions through the active worktree
+status: proposed
+owner: codex
+created_at: 2026-07-26T22:27:38.501404867Z
+last_updated: 2026-07-26T22:27:38.501404867Z
+related_features:
+- auto-tasks
+- activity-job
+related_tasks:
+- ORB-10472
+tags:
+- auto-tasks
+- worktree-integrity
+paths:
+- crates/orbit-core/src/auto_tasks/**
+- crates/orbit-engine/src/activity_job/workspace.rs
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/proposed/ADR-0286/body.md
+++ b/.orbit/adrs/proposed/ADR-0286/body.md
@@ -1,0 +1,10 @@
+## Context
+Auto-task definition CRUD used the shared Orbit root even when a workflow executor was assigned a linked worktree. That let a refresh expose tracked dirt in the registered primary checkout while unrelated implementation guards were sampling it. The alternatives were to tolerate auto_tasks drift in the integrity guard or to make tracked definition mutation worktree-local.
+
+## Decision
+Read and replace tracked auto-task definitions through the runtime local root. Keep scheduler cursors and coordination state under the shared root, and replace each definition atomically so a failed refresh cannot expose partial bytes.
+
+## Consequences
+- Linked-worktree refreshes become ordinary branch changes and concurrent implementation guards continue to observe an unchanged primary checkout.
+- Primary-checkout operator commands retain existing behavior because local and shared roots are identical there.
+- Cost: callers in linked worktrees see that checkout version of definition YAML while scheduler cursor state remains shared, so definition and cursor roots must remain deliberately separate.

--- a/crates/orbit-core/src/auto_tasks/crud.rs
+++ b/crates/orbit-core/src/auto_tasks/crud.rs
@@ -1,8 +1,10 @@
 //! Auto-task CRUD [ORB-10149]: the shared domain surface behind both the CLI
 //! (`orbit auto-task …`) and the MCP tools (`orbit.auto_task.*`). Definitions
-//! are git-versioned YAML under `<orbit_dir>/auto_tasks/<name>.yaml`; these
-//! methods are the single choke point that reads/writes them, so both entry
-//! points stay consistent. Disabling is a `toggle`, never a delete.
+//! are git-versioned YAML under `<local_orbit_dir>/auto_tasks/<name>.yaml`;
+//! these methods are the single choke point that reads/writes them, so both
+//! entry points stay consistent. In a linked worktree, `local_orbit_dir`
+//! belongs to that checkout rather than the registered primary checkout.
+//! Disabling is a `toggle`, never a delete.
 //!
 //! `mint` (CLI-only by design — see `docs/design/mcp-bridge/2_design.md`)
 //! rides here too: it mints a task from a definition on demand by reusing the
@@ -12,7 +14,7 @@ use orbit_common::types::{
     AUTO_TASK_SCHEMA_VERSION, AutoTaskDefinition, AutoTaskSchedule, AutoTaskTemplate, DedupePolicy,
     OrbitError, Task,
 };
-use orbit_common::utility::fs::write_text_with_parent;
+use orbit_common::utility::fs::atomic_write_text;
 
 use crate::OrbitRuntime;
 
@@ -64,7 +66,7 @@ impl OrbitRuntime {
         };
         self.validate_auto_task(&definition)?;
 
-        let path = definition_path(&self.paths().orbit_dir, &definition.name);
+        let path = definition_path(&self.paths().local_dir, &definition.name);
         if path.exists() {
             return Err(OrbitError::InvalidInput(format!(
                 "auto-task '{}' already exists; update or toggle it instead",
@@ -79,7 +81,7 @@ impl OrbitRuntime {
     /// Fail-closed load errors are surfaced as an error only when nothing
     /// loaded; otherwise malformed files are simply skipped by the loader.
     pub fn auto_task_list(&self) -> Result<Vec<AutoTaskDefinition>, OrbitError> {
-        let collection = collect_auto_tasks(&self.paths().orbit_dir);
+        let collection = collect_auto_tasks(&self.paths().local_dir);
         Ok(collection
             .definitions
             .into_iter()
@@ -89,7 +91,7 @@ impl OrbitRuntime {
 
     /// Show one definition by name, or `None` if it does not exist.
     pub fn auto_task_show(&self, name: &str) -> Result<Option<AutoTaskDefinition>, OrbitError> {
-        let path = definition_path(&self.paths().orbit_dir, name);
+        let path = definition_path(&self.paths().local_dir, name);
         if !path.exists() {
             return Ok(None);
         }
@@ -181,11 +183,18 @@ impl OrbitRuntime {
     }
 
     fn write_auto_task(&self, definition: &AutoTaskDefinition) -> Result<(), OrbitError> {
-        let path = definition_path(&self.paths().orbit_dir, &definition.name);
+        // ADR-0286: tracked definition mutation belongs to the active
+        // worktree; shared state remains under `orbit_dir`.
+        let path = definition_path(&self.paths().local_dir, &definition.name);
         let yaml = serde_yaml::to_string(definition).map_err(|error| {
             OrbitError::Io(format!("encode auto-task '{}': {error}", definition.name))
         })?;
-        write_text_with_parent(&path, &yaml)
-            .map_err(|error| OrbitError::Io(format!("write {}: {error}", path.display())))
+        atomic_write_text(&path, &yaml).map_err(|error| {
+            OrbitError::Io(format!(
+                "atomically refresh auto-task '{}' at {}: {error}",
+                definition.name,
+                path.display()
+            ))
+        })
     }
 }

--- a/crates/orbit-core/src/auto_tasks/scheduler.rs
+++ b/crates/orbit-core/src/auto_tasks/scheduler.rs
@@ -64,16 +64,19 @@ pub struct SchedulerOptions {
 
 /// Run one scheduler pass over the definitions in `runtime`'s workspace at an
 /// explicit `now` (the test seam). Loads definitions from
-/// `<orbit_dir>/auto_tasks/`, cursors from `<orbit_dir>/state/auto-tasks.json`.
+/// `<local_orbit_dir>/auto_tasks/`, cursors from
+/// `<shared_orbit_dir>/state/auto-tasks.json`.
 pub fn run_auto_task_scheduler_at(
     runtime: &OrbitRuntime,
     now: DateTime<Utc>,
     options: SchedulerOptions,
 ) -> Result<AutoTaskSchedulerOutcome, OrbitError> {
-    let orbit_dir = runtime.paths().orbit_dir.clone();
+    // ADR-0286: definitions are tracked checkout content, while cursor state
+    // is host-local coordination state shared by linked worktrees.
+    let definition_root = runtime.paths().local_dir.clone();
     let state_path = cursor_state_path(&runtime.paths().state_dir);
 
-    let collection = collect_auto_tasks(&orbit_dir);
+    let collection = collect_auto_tasks(&definition_root);
     let cursors = load_cursor_state(&state_path);
 
     let mut reports = Vec::new();

--- a/crates/orbit-core/src/auto_tasks/tests/crud.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/crud.rs
@@ -1,7 +1,10 @@
 //! CRUD-surface tests [ORB-10149]: add/list/show/update/toggle roundtrip,
 //! duplicate rejection, fail-closed parsing, and the no-turn-knobs guarantee.
 
+use std::fs;
+
 use orbit_common::types::{AutoTaskSchedule, DedupePolicy, parse_auto_task_yaml};
+use tempfile::tempdir;
 
 use crate::OrbitRuntime;
 use crate::auto_tasks::crud::AutoTaskUpdateParams;
@@ -142,4 +145,92 @@ template:
   title: Chore
 "#;
     assert!(parse_auto_task_yaml(top_level_turns).is_err());
+}
+
+#[test]
+fn linked_worktree_refresh_is_atomic_and_never_mutates_primary_definition() {
+    let root = tempdir().expect("tempdir");
+    let global_root = root.path().join("global");
+    let primary_orbit = root.path().join("primary/.orbit");
+    let worktree_orbit = root.path().join("worktree/.orbit");
+    for path in [&global_root, &primary_orbit, &worktree_orbit] {
+        fs::create_dir_all(path).expect("runtime root");
+    }
+    let runtime = OrbitRuntime::from_resolved_roots(&global_root, &primary_orbit, &worktree_orbit)
+        .expect("two-root runtime");
+
+    runtime
+        .auto_task_add(interval_params("doc-duties", 60))
+        .expect("seed worktree definition");
+    let worktree_path = worktree_orbit.join("auto_tasks/doc-duties.yaml");
+    let primary_path = primary_orbit.join("auto_tasks/doc-duties.yaml");
+    fs::create_dir_all(primary_path.parent().expect("primary parent")).expect("primary parent");
+    fs::copy(&worktree_path, &primary_path).expect("seed primary definition");
+    let primary_before = fs::read(&primary_path).expect("primary before");
+
+    runtime
+        .auto_task_update(
+            "doc-duties",
+            AutoTaskUpdateParams {
+                description: Some("refreshed in the assigned worktree".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("refresh");
+
+    assert_eq!(
+        fs::read(&primary_path).expect("primary after"),
+        primary_before,
+        "tracked primary definition must stay byte-identical"
+    );
+    let refreshed = fs::read_to_string(&worktree_path).expect("worktree definition");
+    assert!(refreshed.contains("refreshed in the assigned worktree"));
+    assert!(
+        fs::read_dir(worktree_path.parent().expect("worktree parent"))
+            .expect("list worktree auto_tasks")
+            .all(|entry| {
+                !entry
+                    .expect("directory entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .ends_with(".tmp")
+            }),
+        "atomic replacement must not leave staging files"
+    );
+}
+
+#[test]
+fn failed_linked_worktree_refresh_preserves_primary_and_names_definition() {
+    let root = tempdir().expect("tempdir");
+    let global_root = root.path().join("global");
+    let primary_orbit = root.path().join("primary/.orbit");
+    let worktree_orbit = root.path().join("worktree/.orbit");
+    for path in [&global_root, &primary_orbit, &worktree_orbit] {
+        fs::create_dir_all(path).expect("runtime root");
+    }
+
+    let primary_path = primary_orbit.join("auto_tasks/doc-duties.yaml");
+    fs::create_dir_all(primary_path.parent().expect("primary parent")).expect("primary parent");
+    fs::write(&primary_path, "primary-definition-bytes\n").expect("primary definition");
+    let primary_before = fs::read(&primary_path).expect("primary before");
+
+    // A non-directory local `auto_tasks` path makes the refresh fail before a
+    // staged file can be committed. This models a filesystem failure without
+    // relying on platform-specific permission behavior.
+    fs::write(worktree_orbit.join("auto_tasks"), "not a directory").expect("blocking path");
+    let runtime = OrbitRuntime::from_resolved_roots(&global_root, &primary_orbit, &worktree_orbit)
+        .expect("two-root runtime");
+    let error = runtime
+        .auto_task_add(interval_params("doc-duties", 60))
+        .expect_err("refresh must fail");
+
+    assert!(
+        error.to_string().contains("doc-duties"),
+        "durable tool error must identify the auto-task: {error}"
+    );
+    assert_eq!(
+        fs::read(&primary_path).expect("primary after"),
+        primary_before,
+        "failed refresh must leave primary byte-identical"
+    );
 }

--- a/crates/orbit-core/src/auto_tasks/tests/scheduler.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/scheduler.rs
@@ -3,6 +3,7 @@
 
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use orbit_common::types::{TaskStatus, auto_task_tag};
+use tempfile::tempdir;
 
 use crate::OrbitRuntime;
 use crate::auto_tasks::scheduler::{SchedulerOptions, run_auto_task_scheduler_at};
@@ -162,4 +163,38 @@ fn dry_run_creates_nothing_and_persists_no_cursor() {
     let again = run_auto_task_scheduler_at(&runtime, t0, SchedulerOptions { dry_run: true })
         .expect("dry run 2");
     assert_eq!(again.reports[0].action, "would_baseline");
+}
+
+#[test]
+fn linked_worktree_scheduler_reads_local_definition_and_writes_shared_cursor() {
+    let root = tempdir().expect("tempdir");
+    let global_root = root.path().join("global");
+    let primary_orbit = root.path().join("primary/.orbit");
+    let worktree_orbit = root.path().join("worktree/.orbit");
+    for path in [&global_root, &primary_orbit, &worktree_orbit] {
+        std::fs::create_dir_all(path).expect("runtime root");
+    }
+    let runtime = OrbitRuntime::from_resolved_roots(&global_root, &primary_orbit, &worktree_orbit)
+        .expect("two-root runtime");
+    runtime
+        .auto_task_add(interval_params("local-chore", 60))
+        .expect("local definition");
+
+    let outcome =
+        run_auto_task_scheduler_at(&runtime, at(2026, 1, 1, 0, 0), SchedulerOptions::default())
+            .expect("scheduler pass");
+
+    assert_eq!(outcome.reports[0].name, "local-chore");
+    assert!(
+        primary_orbit.join("state/auto-tasks.json").is_file(),
+        "cursor state remains shared"
+    );
+    assert!(
+        !worktree_orbit.join("state/auto-tasks.json").exists(),
+        "linked worktree must not fork host-local cursor state"
+    );
+    assert!(
+        !primary_orbit.join("auto_tasks/local-chore.yaml").exists(),
+        "scheduler/CRUD must not materialize tracked definitions in primary"
+    );
 }

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -1264,6 +1264,194 @@ fn two_in_flight_worktrees_survive_one_primary_merge_advance() {
 }
 
 #[test]
+fn concurrent_auto_task_refresh_stays_in_assigned_worktree_during_boundary_checks() {
+    let fixture = linked_worktree_fixture();
+    let definition_dir = fixture.assigned.join(".orbit/auto_tasks");
+    fs::create_dir_all(&definition_dir).expect("definition dir");
+    let definition_path = definition_dir.join("doc-duties.yaml");
+    fs::write(
+        &definition_path,
+        "schemaVersion: 1\nname: doc-duties\nrevision: 0\n",
+    )
+    .expect("seed definition");
+    git_ok(
+        &fixture.assigned,
+        &["add", ".orbit/auto_tasks/doc-duties.yaml"],
+    );
+    git_ok(
+        &fixture.assigned,
+        &["commit", "-m", "seed auto-task definition"],
+    );
+    git_ok(
+        &fixture.primary,
+        &["merge", "--ff-only", "orbit-integrity-test"],
+    );
+
+    let implement_worktree = fixture.root().join("disjoint-implement");
+    git_ok(
+        &fixture.primary,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "orbit-disjoint-implement",
+            implement_worktree
+                .to_str()
+                .expect("utf8 implement worktree"),
+        ],
+    );
+    let implement_worktree = implement_worktree
+        .canonicalize()
+        .expect("canonical implement worktree");
+    let input_one = worktree_input(&fixture, "ORB-AUTO-TASK-REFRESH");
+    let input_two = serde_json::json!({
+        "prompt": "implement disjoint work",
+        "task_id": "ORB-DISJOINT-IMPLEMENT",
+        "workspace_path": implement_worktree,
+        "repo_root": implement_worktree,
+    });
+    let pair_one = validate_declared_worktree_pair(
+        &input_one,
+        None,
+        "run-auto-task-refresh",
+        "codex",
+        Some(&fixture.primary),
+    )
+    .expect("validate refresh pair")
+    .expect("refresh linked pair");
+    let pair_two = validate_declared_worktree_pair(
+        &input_two,
+        None,
+        "run-disjoint-implement",
+        "claude",
+        Some(&fixture.primary),
+    )
+    .expect("validate implement pair")
+    .expect("implement linked pair");
+    let refresh_guard = WorktreeBoundaryGuard::capture(
+        &input_one,
+        None,
+        "run-auto-task-refresh",
+        "codex",
+        Some(&fixture.assigned),
+        Some(&fixture.primary),
+        Some(&pair_one),
+    )
+    .expect("capture refresh guard")
+    .expect("refresh guard enabled");
+    let implement_guard = WorktreeBoundaryGuard::capture(
+        &input_two,
+        None,
+        "run-disjoint-implement",
+        "claude",
+        Some(&implement_worktree),
+        Some(&fixture.primary),
+        Some(&pair_two),
+    )
+    .expect("capture implement guard")
+    .expect("implement guard enabled");
+    let primary_before = git_bytes(&fixture.primary, &["status", "--porcelain=v2", "-z"]);
+
+    let (staged_tx, staged_rx) = std::sync::mpsc::channel();
+    let (continue_tx, continue_rx) = std::sync::mpsc::channel();
+    let writer = std::thread::spawn(move || {
+        for revision in 1..=32 {
+            let staged = definition_dir.join(format!(".doc-duties.{revision}.tmp"));
+            fs::write(
+                &staged,
+                format!("schemaVersion: 1\nname: doc-duties\nrevision: {revision}\n"),
+            )
+            .expect("stage definition");
+            if revision == 1 {
+                staged_tx.send(()).expect("signal staged refresh");
+                continue_rx.recv().expect("continue refresh");
+            }
+            fs::rename(&staged, &definition_path).expect("atomically refresh definition");
+        }
+    });
+
+    staged_rx.recv().expect("refresh reached staging point");
+    implement_guard
+        .verify()
+        .expect("disjoint boundary snapshot must not report primary checkout drift");
+    continue_tx.send(()).expect("release refresh");
+    writer.join().expect("refresh thread");
+    refresh_guard
+        .verify()
+        .expect("refresh boundary must remain inside its assigned worktree");
+
+    assert_eq!(
+        git_bytes(&fixture.primary, &["status", "--porcelain=v2", "-z"]),
+        primary_before,
+        "concurrent refresh must leave registered primary byte-identical"
+    );
+    assert!(
+        fixture
+            .assigned
+            .join(".orbit/auto_tasks/doc-duties.yaml")
+            .is_file()
+    );
+}
+
+#[test]
+fn failed_auto_task_refresh_preserves_primary_and_audits_definition_and_run() {
+    let fixture = linked_worktree_fixture();
+    let primary_before = git_bytes(&fixture.primary, &["status", "--porcelain=v2", "-z"]);
+    let script = fixture.root().join("codex");
+    write_executable(
+        &script,
+        "#!/bin/sh\ncat > /dev/null\nmkdir -p .orbit/auto_tasks\nprintf 'partial\\n' > .orbit/auto_tasks/.doc-duties.tmp\nrm .orbit/auto_tasks/.doc-duties.tmp\nprintf 'auto-task doc-duties refresh failed\\n' >&2\nexit 23\n",
+    );
+    let mut host = TestHost::with_command(script.display().to_string());
+    host.workspace_root = Some(fixture.primary.clone());
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink.clone();
+    let audit = Arc::new(V2AuditWriter::new(
+        "run-auto-task-refresh-failed",
+        "codex:gpt-5.5",
+        sink_for_writer,
+    ));
+
+    let outcome = run_cli_backend(
+        &host,
+        &test_agent_loop_spec(Duration::from_secs(5)),
+        "run-auto-task-refresh-failed",
+        audit.clone(),
+        &worktree_input(&fixture, "ORB-AUTO-TASK-REFRESH"),
+        None,
+    )
+    .expect("failed provider remains an audited dispatch outcome");
+
+    assert!(!outcome.success);
+    assert_eq!(
+        git_bytes(&fixture.primary, &["status", "--porcelain=v2", "-z"]),
+        primary_before,
+        "failed refresh must leave registered primary byte-identical"
+    );
+    let events = audit.events_snapshot().expect("audit events");
+    let failed = events
+        .iter()
+        .find_map(|event| match &event.kind {
+            V2AuditEventKind::CliInvocationFinished {
+                exit_code,
+                stderr_blob_ref,
+                ..
+            } if *exit_code == Some(23) => Some((
+                event.envelope.run_id.as_str(),
+                stderr_blob_ref.as_deref().expect("stderr blob"),
+            )),
+            _ => None,
+        })
+        .expect("durable failed-refresh event");
+    assert_eq!(failed.0, "run-auto-task-refresh-failed");
+    assert_eq!(
+        sink.blob(failed.1).as_deref(),
+        Some(b"auto-task doc-duties refresh failed\n".as_slice()),
+        "failure evidence must identify the auto-task"
+    );
+}
+
+#[test]
 fn unchanged_pre_dirty_path_is_excluded_from_escape_diagnostic() {
     let fixture = linked_worktree_fixture();
     fs::write(

--- a/crates/orbit-engine/src/activity_job/tests/workspace.rs
+++ b/crates/orbit-engine/src/activity_job/tests/workspace.rs
@@ -152,3 +152,17 @@ fn resolve_subprocess_cwd_rejects_declared_missing_path() {
         other => panic!("expected CliInvocationFailed, got {other:?}"),
     }
 }
+
+#[test]
+fn vanished_untracked_staging_file_is_not_a_snapshot_failure() {
+    let root = tempdir().expect("tempdir");
+    let path = root.path().join(".tracked.yaml.refresh.tmp");
+    std::fs::write(&path, "staged").expect("stage file");
+    std::fs::remove_file(&path).expect("atomic rename consumed staging file");
+
+    assert_eq!(
+        untracked_file_identity(root.path(), ".tracked.yaml.refresh.tmp")
+            .expect("vanished staging file is benign"),
+        None
+    );
+}

--- a/crates/orbit-engine/src/activity_job/workspace.rs
+++ b/crates/orbit-engine/src/activity_job/workspace.rs
@@ -767,14 +767,23 @@ fn git_fingerprint(root: &Path) -> Result<GitWorktreeFingerprint, DispatchError>
             "--",
         ],
     )?;
-    let untracked_paths = nul_paths(&git_stdout_bytes(
+    let discovered_untracked_paths = nul_paths(&git_stdout_bytes(
         root,
         &["ls-files", "--others", "--exclude-standard", "-z", "--"],
     )?);
+    let mut untracked_paths = Vec::with_capacity(discovered_untracked_paths.len());
     let mut untracked_content = BTreeMap::new();
-    for path in &untracked_paths {
-        let identity = git_stdout(root, &["hash-object", "--no-filters", "--", path])?;
-        untracked_content.insert(path.clone(), format!("git-blob:{identity}"));
+    for path in discovered_untracked_paths {
+        let Some(identity) = untracked_file_identity(root, &path)? else {
+            // ADR-0286: an atomic tracked-file replacement briefly exposes an
+            // untracked sibling temp file. It may disappear between
+            // `ls-files` and `hash-object`; that file was never part of a
+            // stable checkout state, so omit it instead of turning an
+            // unrelated boundary snapshot into a permanent failure.
+            continue;
+        };
+        untracked_content.insert(path.clone(), identity);
+        untracked_paths.push(path);
     }
 
     let mut dirty_paths = nul_paths(&git_stdout_bytes(
@@ -843,6 +852,23 @@ fn git_fingerprint(root: &Path) -> Result<GitWorktreeFingerprint, DispatchError>
         dirty_paths,
         path_states,
     })
+}
+
+pub(crate) fn untracked_file_identity(
+    root: &Path,
+    path: &str,
+) -> Result<Option<String>, DispatchError> {
+    let args = ["hash-object", "--no-filters", "--", path];
+    let output = git_output_raw(root, &args)?;
+    if output.status.success() {
+        let identity = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        return Ok(Some(format!("git-blob:{identity}")));
+    }
+
+    match fs::symlink_metadata(root.join(path)) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        _ => Err(git_command_error(root, &args, &output)),
+    }
 }
 
 fn changed_paths(

--- a/docs/design/auto-tasks/2_design.md
+++ b/docs/design/auto-tasks/2_design.md
@@ -10,7 +10,7 @@ summary: Current implementation of the auto-task record, due-math, host-local cu
 tags: [auto-tasks]
 paths: ["crates/orbit-core/src/auto_tasks/**"]
 related_features: [auto-tasks]
-related_artifacts: [ORB-10149, ORB-10439, ORB-10441, ORB-10446, ADR-0218, ADR-0217]
+related_artifacts: [ORB-10149, ORB-10439, ORB-10441, ORB-10446, ORB-10472, ADR-0218, ADR-0217, ADR-0286]
 ---
 
 # Auto-tasks — Design
@@ -31,10 +31,14 @@ documented under `docs/design/routines/`.
 (default `backlog`). Per ADR-0217 there are **no turn-based knobs**; `deny_unknown_fields`
 makes a stray `max_turns`/`turns` a hard parse error.
 
-Definitions live as `.orbit/auto_tasks/<name>.yaml`. Discovery
-(`loader.rs`) scans the directory, parses each file fail-closed, and rejects any
-file whose stem ≠ its `name`, so the on-disk identity and the `auto-task:<name>`
-provenance tag stay in lockstep.
+Definitions live as `.orbit/auto_tasks/<name>.yaml` in the active checkout.
+Discovery (`loader.rs`) scans the directory, parses each file fail-closed, and
+rejects any file whose stem ≠ its `name`, so the on-disk identity and the
+`auto-task:<name>` provenance tag stay in lockstep. In a linked-worktree
+runtime, definition discovery and CRUD use `WorkspacePaths::local_dir`;
+host-local cursor state continues to use the shared root. This split makes
+definition edits ordinary branch content instead of transient tracked dirt in
+the registered primary checkout (ADR-0286).
 
 ## 2. Due computation and catch-up collapse
 
@@ -80,7 +84,9 @@ add/list/show/update/toggle`) and the MCP tools (`orbit.auto_task.*`). Add
 rejects duplicate names; update patches present fields; toggle flips `enabled`
 (disabling is preserved, never a delete). Both surfaces validate the schedule
 (cron parse / interval > 0) and crew at write time, so a bad definition is never
-persisted.
+persisted. Successful writes replace the target atomically; a staging or rename
+failure leaves the previous definition bytes intact. In a primary checkout the
+local and shared roots are identical, preserving the operator-facing path.
 
 ## 5b. Manual mint — `mint` (ORB-10439, renamed by ORB-10446)
 
@@ -148,5 +154,6 @@ validation correctly produces only task-side effects.
 - ORB-10149 — Auto-task primitive.
 - ORB-10439 — on-demand manual mint (renamed to `orbit auto-task mint <name>` by ORB-10446).
 - ORB-10441 — mint-time visible title provenance.
+- ORB-10472 — worktree-local, atomic definition refresh.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/auto-tasks/4_decisions.md
+++ b/docs/design/auto-tasks/4_decisions.md
@@ -1,7 +1,7 @@
 ---
 title: Auto-tasks — Decisions
 owner: claude
-last_updated: 2026-07-12
+last_updated: 2026-07-26
 status: Accepted
 feature: auto-tasks
 doc_role: decisions
@@ -10,7 +10,7 @@ summary: ADR log for the auto-task primitive.
 tags: [auto-tasks]
 paths: ["crates/orbit-core/src/auto_tasks/**"]
 related_features: [auto-tasks]
-related_artifacts: [ADR-0218, ADR-0219]
+related_artifacts: [ADR-0218, ADR-0219, ADR-0286]
 ---
 
 # Auto-tasks — Decisions
@@ -73,9 +73,36 @@ Orbit creates neither an empty commit nor an empty PR.
 - Cost: a mistakenly tagged task can reach review without repository changes,
   so the tag is a privileged workflow exemption.
 
+## ADR-0286 — Route tracked auto-task definitions through the active worktree
+
+**Status:** Proposed · 2026-07 · [ORB-10472]
+
+**Context.** Auto-task definition CRUD used the shared Orbit root even when a
+workflow executor was assigned a linked worktree. That let a refresh expose
+tracked dirt in the registered primary checkout while unrelated implementation
+guards were sampling it. The alternatives were to tolerate `auto_tasks` drift
+in the integrity guard or to make tracked definition mutation worktree-local.
+
+**Decision.** Read and replace tracked auto-task definitions through the runtime
+local root. Keep scheduler cursors and coordination state under the shared root,
+and replace each definition atomically so a failed refresh cannot expose partial
+bytes.
+
+**Consequences.**
+
+- Linked-worktree refreshes become ordinary branch changes and concurrent
+  implementation guards continue to observe an unchanged primary checkout.
+- Primary-checkout operator commands retain existing behavior because local and
+  shared roots are identical there.
+- Cost: callers in linked worktrees see that checkout version of definition
+  YAML while scheduler cursor state remains shared, so definition and cursor
+  roots must remain deliberately separate.
+
 ## Task References
 
 - [ORB-10149] — Shipped the auto-task primitive (record, scheduler, CRUD, assets).
 - [ORB-10148] — Added the QA definition and no-diff workflow exemption.
+- [ORB-10472] — Isolated auto-task definition refresh from the registered
+  primary checkout.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10472](https://orbit-cli.com/tasks/ORB-10472) — Stop auto-tasks from mutating tracked configuration in the shared primary checkout

### Description

## Problem
An auto-task regenerated .orbit/auto_tasks/doc-duties.yaml directly in the shared primary checkout, producing unrelated tracked dirt that failed a concurrent implement_one integrity guard (F2026-07-144).

## Evidence
F2026-07-144 records jrun-20260726-0503 and the doc-duties rewrite after auto-commit 9f03a80d. The assigned ORB-10397 worktree was intact; only primary tracked state drifted.

## Scope
Make auto-task artifact refreshes transactional and isolated from the registered primary working tree used as workflow substrate.

### Acceptance Criteria

- Auto-task scheduler/refresh writes occur in an isolated worktree or an atomic store path that never leaves tracked primary dirt visible to concurrent runs.
- A concurrency test refreshes an auto-task while implement boundary snapshots run and produces no primary_checkout_drift for disjoint work.
- A failed refresh leaves the primary checkout byte-identical and surfaces a durable error tied to the auto-task/run id.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Routed auto-task definition CRUD, listing, lookup, and scheduler discovery through `WorkspacePaths::local_dir`, while retaining cursor/coordination state under the shared `state_dir`.
- Replaced definition writes with the existing durable atomic-write primitive and added auto-task/path context to refresh failures.
- Added two-root CRUD/scheduler regressions, a synchronized two-worktree boundary-concurrency regression proving disjoint implement snapshots do not report `primary_checkout_drift`, and failed-refresh audit coverage tying durable stderr evidence to both the auto-task name and run id.
- Made boundary fingerprinting tolerate an atomic staging file that vanishes between untracked discovery and hashing.
- Added proposed ADR-0286 and updated the auto-task design/decision docs with the local-definition/shared-cursor routing contract.

Strategic decisions:
- Tracked configuration follows the active checkout; host-local cursor state remains shared across linked worktrees.
- Atomic replacement is used at the existing CRUD choke point so CLI and MCP mutations share the same transaction boundary.

Assessment: The primary checkout remains byte-identical for successful and failed linked-worktree refreshes, definition replacement is atomic, and the concurrency test uses genuinely disjoint linked worktrees with an explicit synchronization point.

Validation:
- `cargo test -p orbit-core auto_tasks::tests::crud -- --nocapture` (9 passed)
- `cargo test -p orbit-core auto_tasks::tests::scheduler -- --nocapture` (8 passed)
- `cargo test -p orbit-engine concurrent_auto_task_refresh_stays_in_assigned_worktree_during_boundary_checks -- --nocapture` (passed after strengthening the disjoint-worktree setup)
- `cargo test -p orbit-engine failed_auto_task_refresh_preserves_primary_and_audits_definition_and_run -- --nocapture` (passed)
- `cargo test -p orbit-engine vanished_untracked_staging_file_is_not_a_snapshot_failure -- --nocapture` (passed)
- `make ci-fast` (passed)

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10472-6a6688e8`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*