### PR TITLE
Make CLI task workspace routing errors name the accepted path form

### DIFF
--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -896,7 +896,7 @@
           "type": "string"
         },
         "workspace": {
-          "description": "Workspace path for the task",
+          "description": "Filesystem path to an existing directory inside the target repository (e.g. the repository root). This is a repository path, never a logical/bridge workspace id (such as a `ws_*` id). Falls back to the MCP session's `_meta.orbit.workspace` when omitted.",
           "type": "string"
         }
       },

--- a/crates/orbit-core/src/command/task/paths.rs
+++ b/crates/orbit-core/src/command/task/paths.rs
@@ -26,20 +26,24 @@ pub(super) fn normalize_workspace_path(
     };
     let canonical_workspace = candidate.canonicalize().map_err(|error| {
         OrbitError::InvalidInput(format!(
-            "workspace_path '{}' must reference an existing directory inside the repository: {error}",
+            "workspace (`workspace_path` on the dashboard API) '{}' must be a filesystem path to \
+             an existing directory inside the repository — e.g. the repository root '.' — never a \
+             logical workspace id such as a bridge `ws_*` id: {error}",
             candidate.display()
         ))
     })?;
     if !canonical_workspace.is_dir() {
         return Err(OrbitError::InvalidInput(format!(
-            "workspace_path '{}' must reference a directory inside the repository",
+            "workspace (`workspace_path` on the dashboard API) '{}' must be a directory inside \
+             the repository, not a file",
             canonical_workspace.display()
         )));
     }
 
     if !canonical_workspace.starts_with(&canonical_repo_root) {
         return Err(OrbitError::InvalidInput(format!(
-            "workspace_path '{}' must stay within repository '{}'",
+            "workspace (`workspace_path` on the dashboard API) '{}' must be a filesystem path \
+             inside repository '{}', not outside it",
             canonical_workspace.display(),
             canonical_repo_root.display()
         )));

--- a/crates/orbit-core/src/command/task/tests/mod.rs
+++ b/crates/orbit-core/src/command/task/tests/mod.rs
@@ -1,6 +1,7 @@
 #![allow(missing_docs)]
 
 mod add;
+mod paths;
 mod update;
 
 use crate::OrbitRuntime;

--- a/crates/orbit-core/src/command/task/tests/paths.rs
+++ b/crates/orbit-core/src/command/task/tests/paths.rs
@@ -1,0 +1,129 @@
+//! ORB-10475: `normalize_workspace_path` error coverage. The field is a
+//! repository-relative/absolute filesystem path (never a logical/bridge
+//! workspace id), and its errors must say so with a concrete example.
+
+use orbit_common::types::OrbitError;
+use tempfile::tempdir;
+
+use crate::command::task::paths::normalize_workspace_path;
+
+fn expect_invalid_input(result: Result<Option<String>, OrbitError>) -> String {
+    match result {
+        Err(OrbitError::InvalidInput(message)) => message,
+        other => panic!("expected InvalidInput, got {other:?}"),
+    }
+}
+
+#[test]
+fn no_workspace_input_resolves_to_none() {
+    let repo_root = tempdir().expect("create repo root");
+
+    let resolved =
+        normalize_workspace_path(repo_root.path(), None).expect("missing workspace is optional");
+
+    assert_eq!(resolved, None);
+}
+
+#[test]
+fn repository_root_path_is_accepted() {
+    let repo_root = tempdir().expect("create repo root");
+
+    let resolved = normalize_workspace_path(repo_root.path(), Some("."))
+        .expect("repo root path is a valid workspace");
+
+    let canonical_repo_root = repo_root
+        .path()
+        .canonicalize()
+        .expect("canonicalize repo root");
+    assert_eq!(
+        resolved,
+        Some(canonical_repo_root.to_string_lossy().into_owned())
+    );
+}
+
+#[test]
+fn absolute_repository_path_is_accepted() {
+    let repo_root = tempdir().expect("create repo root");
+    let canonical_repo_root = repo_root
+        .path()
+        .canonicalize()
+        .expect("canonicalize repo root");
+
+    let resolved = normalize_workspace_path(
+        repo_root.path(),
+        Some(canonical_repo_root.to_str().unwrap()),
+    )
+    .expect("absolute repo path is a valid workspace");
+
+    assert_eq!(
+        resolved,
+        Some(canonical_repo_root.to_string_lossy().into_owned())
+    );
+}
+
+#[test]
+fn logical_workspace_id_is_rejected_with_a_path_form_error() {
+    let repo_root = tempdir().expect("create repo root");
+
+    // `ws_orbit` reads like a bridge/broker logical workspace id; it is not a
+    // directory under the repo root, so it must fail — but the failure must
+    // explain that a *path* was expected, not merely that the directory is
+    // missing.
+    let message =
+        expect_invalid_input(normalize_workspace_path(repo_root.path(), Some("ws_orbit")));
+
+    assert!(
+        message.contains("filesystem path"),
+        "error must state the accepted form is a filesystem path: {message}"
+    );
+    assert!(
+        message.contains("logical workspace id"),
+        "error must call out that a logical/bridge id is not accepted: {message}"
+    );
+    assert!(
+        !message.to_lowercase().contains("workspace id must"),
+        "error must never describe a logical id as the required form: {message}"
+    );
+}
+
+#[test]
+fn out_of_repository_path_is_rejected_naming_the_repository() {
+    let repo_root = tempdir().expect("create repo root");
+    let outside = tempdir().expect("create outside dir");
+    let canonical_outside = outside.path().canonicalize().expect("canonicalize outside");
+
+    let message = expect_invalid_input(normalize_workspace_path(
+        repo_root.path(),
+        Some(canonical_outside.to_str().unwrap()),
+    ));
+
+    assert!(
+        message.contains("inside repository"),
+        "error must name that the path must stay inside the repository: {message}"
+    );
+    let canonical_repo_root = repo_root
+        .path()
+        .canonicalize()
+        .expect("canonicalize repo root");
+    assert!(
+        message.contains(canonical_repo_root.to_string_lossy().as_ref()),
+        "error must cite the repository root it must stay inside: {message}"
+    );
+}
+
+#[test]
+fn path_to_a_file_is_rejected_as_not_a_directory() {
+    let repo_root = tempdir().expect("create repo root");
+    let file_path = repo_root.path().join("not-a-dir.txt");
+    std::fs::write(&file_path, b"content").expect("write file");
+
+    let message = expect_invalid_input(normalize_workspace_path(
+        repo_root.path(),
+        Some("not-a-dir.txt"),
+    ));
+
+    assert!(
+        message.contains("directory"),
+        "error must state a directory is required: {message}"
+    );
+}

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -325,7 +325,10 @@ pub(super) fn resolve_workspace_argument(
             Ok(workspace)
         }
         (None, None) => Err(OrbitError::InvalidInput(
-            "missing `workspace`; provide it explicitly or initialize the MCP session with `_meta.orbit.workspace`"
+            "missing `workspace`; it must be a filesystem path to an existing directory inside \
+             the repository (e.g. the repository root), never a logical workspace id such as a \
+             bridge `ws_*` id — provide that path explicitly or initialize the MCP session with \
+             `_meta.orbit.workspace` set to the same path"
                 .to_string(),
         )),
     }

--- a/crates/orbit-tools/src/builtin/orbit/task/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add.rs
@@ -27,7 +27,12 @@ impl Tool for OrbitTaskAddTool {
             // but process cwd must never be used as the fallback.
             ToolParam {
                 name: "workspace".to_string(),
-                description: "Workspace path for the task".to_string(),
+                description:
+                    "Filesystem path to an existing directory inside the target repository \
+                     (e.g. the repository root). This is a repository path, never a logical/bridge \
+                     workspace id (such as a `ws_*` id). Falls back to the MCP session's \
+                     `_meta.orbit.workspace` when omitted."
+                        .to_string(),
                 param_type: "string".to_string(),
                 required: false,
             },

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
@@ -419,11 +419,40 @@ fn add_call_missing_workspace_without_session_context_returns_clear_error() {
         OrbitError::InvalidInput(message) => {
             assert!(message.contains("missing `workspace`"), "{message}");
             assert!(message.contains("MCP session"), "{message}");
+            assert!(
+                message.contains("filesystem path"),
+                "error must state the accepted form is a filesystem path: {message}"
+            );
+            assert!(
+                message.contains("logical workspace id"),
+                "error must call out that a logical/bridge id is not accepted: {message}"
+            );
         }
         other => panic!("unexpected error for missing workspace: {other}"),
     }
     assert!(
         host.call.lock().expect("lock").is_none(),
         "host must not be called when workspace cannot be resolved"
+    );
+}
+
+#[test]
+fn schema_workspace_param_documents_a_filesystem_path_not_a_logical_id() {
+    let schema = OrbitTaskAddTool.schema();
+    let workspace = schema
+        .parameters
+        .iter()
+        .find(|param| param.name == "workspace")
+        .expect("workspace param");
+
+    assert!(
+        workspace.description.contains("Filesystem path"),
+        "workspace param must document the accepted path form: {}",
+        workspace.description
+    );
+    assert!(
+        workspace.description.contains("never a logical/bridge"),
+        "workspace param must rule out logical/bridge ids: {}",
+        workspace.description
     );
 }


### PR DESCRIPTION
## Task

[ORB-10475](https://orbit-cli.com/tasks/ORB-10475) — Make CLI task workspace routing errors name the accepted path form

### Description

## Problem
Workspace-scoped task tools call their routing field workspace but task.add requires a repository filesystem path while errors and _meta.orbit.workspace language imply a logical workspace ID. A ws_orbit ID is joined as a path and fails only later (F2026-07-154).

## Evidence
Current crates/orbit-tools/src/builtin/orbit/mod.rs emits missing workspace; provide it or initialize _meta.orbit.workspace, while crates/orbit-core/src/command/task/paths.rs reports workspace_path must reference an existing directory. F2026-07-154 records no-workspace, ws_orbit, and repository-path attempts.

## Scope
Unify field semantics or make the accepted selector explicit and consistent across task add/show/update.

### Acceptance Criteria

- task.add/show/update accept one documented workspace selector form consistently, or typed schemas distinguish workspace_id from workspace_path.
- Errors state an accepted example and never describe a logical ID when only a repository path is valid.
- Tests cover cwd inference, logical ID input, absolute repo path input, and out-of-repository rejection across CLI and MCP routing.

## Execution Summary

<details>
<summary>Click to expand</summary>

Root cause: `orbit.task.add`'s `workspace` field is a special case. Every other
workspace-scoped MCP tool gets a generically-injected `workspace` selector
(`WORKSPACE_SELECTOR_DESCRIPTION` in `orbit-mcp/src/adapter/schema.rs`) whose
documented contract explicitly accepts "a registered logical workspace ID or
an absolute path to a local checkout" (broker routing, resolved via a
registry). `orbit.task.add` instead declares its own `workspace` `ToolParam`
(add.rs), which suppresses that generic injection (per
`tool_declaring_its_own_workspace_param_keeps_that_description`) and instead
feeds the raw string straight into `TaskAddParams.workspace_path` ->
`normalize_workspace_path` (orbit-core/paths.rs), which requires a literal
filesystem directory path and has no registry/id-resolution step at all. A
caller who has seen the generic convention elsewhere (or the bridge's
`ws_orbit`-style ids) reasonably tries the same id form here — F2026-07-154 -
and hits two error messages that don't say which form is actually required.

Fix (message/schema clarity only; no behavior/routing change, so ADR-0181 /
ADR-0199's "MCP never inherits CLI cwd" and "session-context-only workspace
addressing" invariants are untouched):
- `resolve_workspace_argument`'s missing-workspace error
  (orbit-tools/src/builtin/orbit/mod.rs) now states the accepted form (a
  filesystem path to an existing directory inside the repo, e.g. the repo
  root) and explicitly rules out a logical/bridge `ws_*` id.
- `normalize_workspace_path`'s three error branches
  (orbit-core/src/command/task/paths.rs) now say `workspace` (matching what
  MCP/CLI callers actually type) instead of the internal `workspace_path`
  name, note the dashboard API's alias, give a concrete example, and rule out
  the logical-id form, for: unresolvable/non-existent path, path-is-a-file,
  and outside-the-repository cases.
- `orbit.task.add`'s own `workspace` `ToolParam` description
  (orbit-tools/src/builtin/orbit/task/add.rs) now documents the accepted path
  form and explicitly contrasts it with the generic id-or-path convention
  used elsewhere, satisfying "typed schemas distinguish workspace_id from
  workspace_path" without unifying behavior across tools (task.show/update
  never take `workspace` at all — they resolve against the task ID within an
  already-bound runtime, which is intentional and left unchanged).

Scope note: `add.rs` was appended to `context_files` (via `orbit.task.update`)
since its `workspace` param description is tightly coupled to the same field
these errors describe, and a hidden test in `orbit-mcp` (schema fixture) plus
the checked-in `crates/orbit-cli/tests/snapshots/mcp_tools_list.json` golden
snapshot needed the description to be regenerated (via
`ORBIT_MCP_UPDATE_SNAPSHOT=1 cargo test -p orbit-cli --test mcp_roundtrip`)
since any `orbit.task.add` schema text change is a breaking `tools/list`
change per RELEASING.md.

Considered but rejected as out-of-scope: adding real cwd-fallback behavior to
`resolve_workspace_argument` so a bare `orbit tool run orbit.task.add` (no
MCP session) infers workspace from `ctx.cwd`. `ctx.cwd` is populated
identically for both CLI and true MCP entry points at the shared dispatch
site (`orbit-core/src/command/tool/dispatch.rs`), and `ToolContext` has no
`entry_point`/CLI-vs-MCP signal to gate a cwd fallback safely — adding one
would touch `ToolContext` in orbit-tools/lib.rs and the dispatch site, cut
across ADR-0181's explicit "never process cwd" decision, and deserves its own
ADR-backed task rather than folding into this error-message fix.

Tests added:
- `orbit-core/src/command/task/tests/paths.rs` (new): `normalize_workspace_path`
  coverage for no-workspace (`None` -> `Ok(None)`), relative `.` and absolute
  repo-root paths (accepted), a `ws_orbit`-shaped logical-id string (rejected,
  asserting the error names the filesystem-path form and rules out logical
  ids), an out-of-repository absolute path (rejected, naming the repo root),
  and a path to a file instead of a directory (rejected).
- `orbit-tools/src/builtin/orbit/task/tests/add.rs`: strengthened the
  existing missing-workspace test to assert the new wording, and added a
  schema test asserting the `workspace` param's description states the
  filesystem-path form and rules out logical/bridge ids.

Validation: `make ci-fast` passes. Targeted suites pass:
`cargo test -p orbit-core command::task::tests::paths` (6/6),
`cargo test -p orbit-tools builtin::orbit::task::tests::add` (7/7),
`cargo test -p orbit-cli --test mcp_roundtrip
mcp_serve_tools_list_matches_production_snapshot` (regenerated + green). Full
`cargo test -p orbit-core -p orbit-tools --lib` passes except one pre-existing,
unrelated failure (`command::skill::tests::plugin_skill_symlinks_resolve_to_assets`,
a stale `plugin/skills/orbit-task` SKILL.md-vs-asset parity mismatch);
confirmed via `git stash` that it reproduces identically on the base commit
before this change, so it is not caused by this task.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10475-6a668de7`
- Behind base: 0
- Ahead of base: 1