### PR TITLE
Make task-bundle creation atomic and isolate corrupt bundles during reads

### DIFF
--- a/crates/orbit-cli/src/output/json.rs
+++ b/crates/orbit-cli/src/output/json.rs
@@ -40,6 +40,13 @@ pub fn error_payload(error: &OrbitError) -> Value {
     {
         object.insert("artifact_origin".to_string(), json!(artifact_origin));
     }
+    if let Some((task_id, path, reason)) = error.task_bundle_corruption()
+        && let Some(object) = payload.as_object_mut()
+    {
+        object.insert("task_id".to_string(), json!(task_id));
+        object.insert("path".to_string(), json!(path));
+        object.insert("reason".to_string(), json!(reason));
+    }
     payload
 }
 
@@ -72,6 +79,7 @@ fn error_code(error: &OrbitError) -> &str {
         OrbitError::OutcomeUnknown { .. } => "outcome_unknown",
         OrbitError::RemoteTool { code, .. } => code.as_str(),
         OrbitError::Execution(_) => "execution_failed",
+        OrbitError::TaskBundleCorrupt { .. } => "task_bundle_corrupt",
         OrbitError::Store(_) => "store_error",
         OrbitError::TaskStatusTransition(_) => "task_status_transition",
         OrbitError::JobRunStateTransition(_) => "job_run_state_transition",

--- a/crates/orbit-common/src/types/error.rs
+++ b/crates/orbit-common/src/types/error.rs
@@ -125,6 +125,12 @@ pub enum OrbitError {
         leader_alive: bool,
         group_alive: bool,
     },
+    #[error("task bundle corrupt for {task_id} at {path}: {reason}")]
+    TaskBundleCorrupt {
+        task_id: String,
+        path: String,
+        reason: String,
+    },
     #[error("store error: {0}")]
     Store(String),
     #[error("invalid task status transition: {0}")]
@@ -202,6 +208,17 @@ impl OrbitError {
             Self::InvalidInputDiagnostic { did_you_mean, .. } if !did_you_mean.is_empty() => {
                 Some(did_you_mean)
             }
+            _ => None,
+        }
+    }
+
+    pub fn task_bundle_corruption(&self) -> Option<(&str, &str, &str)> {
+        match self {
+            Self::TaskBundleCorrupt {
+                task_id,
+                path,
+                reason,
+            } => Some((task_id, path, reason)),
             _ => None,
         }
     }

--- a/crates/orbit-common/src/utility/redaction.rs
+++ b/crates/orbit-common/src/utility/redaction.rs
@@ -178,6 +178,15 @@ pub fn redact_sensitive_env_error(error: OrbitError) -> OrbitError {
             leader_alive,
             group_alive,
         },
+        OrbitError::TaskBundleCorrupt {
+            task_id,
+            path,
+            reason,
+        } => OrbitError::TaskBundleCorrupt {
+            task_id: redact_sensitive_env_text(&task_id),
+            path: redact_sensitive_env_text(&path),
+            reason: redact_sensitive_env_text(&reason),
+        },
         OrbitError::Store(m) => OrbitError::Store(redact_sensitive_env_text(&m)),
         OrbitError::TaskStatusTransition(m) => {
             OrbitError::TaskStatusTransition(redact_sensitive_env_text(&m))
@@ -280,6 +289,15 @@ pub fn redact_all_error(error: OrbitError) -> OrbitError {
             kill_sent,
             leader_alive,
             group_alive,
+        },
+        OrbitError::TaskBundleCorrupt {
+            task_id,
+            path,
+            reason,
+        } => OrbitError::TaskBundleCorrupt {
+            task_id: redact_all(&task_id),
+            path: redact_all(&path),
+            reason: redact_all(&reason),
         },
         OrbitError::Store(m) => OrbitError::Store(redact_all(&m)),
         OrbitError::TaskStatusTransition(m) => OrbitError::TaskStatusTransition(redact_all(&m)),

--- a/crates/orbit-core/src/command/task/add.rs
+++ b/crates/orbit-core/src/command/task/add.rs
@@ -1,6 +1,6 @@
 use orbit_common::types::{
     OrbitError, OrbitEvent, Task, TaskStatus, TaskType, normalize_task_dependencies,
-    normalize_task_tags, prune_missing_context_files, validate_task_dependencies,
+    normalize_task_tags, prune_missing_context_files,
 };
 use orbit_common::utility::redaction::redact_all;
 use orbit_store::TaskCreateParams as StoreTaskCreateParams;
@@ -63,7 +63,6 @@ impl OrbitRuntime {
         let workspace_path =
             normalize_workspace_path(&self.paths().repo_root, params.workspace_path.as_deref())?;
         let dependencies = normalize_task_dependencies(params.dependencies.clone())?;
-        validate_task_dependencies(&self.list_tasks()?, None, &dependencies)?;
         self.validate_crew_name(params.crew.as_deref())?;
 
         let prune_root = context_workspace_root(&self.paths().repo_root, workspace_path.as_deref());

--- a/crates/orbit-core/src/command/task/tests/add.rs
+++ b/crates/orbit-core/src/command/task/tests/add.rs
@@ -1,5 +1,5 @@
 use crate::command::task::{TaskAddParams, compute_task_add_warnings};
-use orbit_common::types::{TaskStatus, TaskType};
+use orbit_common::types::{OrbitError, TaskStatus, TaskType};
 
 use super::test_runtime;
 
@@ -28,6 +28,62 @@ fn task_add_enters_proposed_and_requires_approval_before_backlog() {
         .start_task(&task.id, Some("start approved task".to_string()), None)
         .expect("backlog task starts directly");
     assert_eq!(started.status, TaskStatus::InProgress);
+}
+
+#[test]
+fn task_add_does_not_scan_unrelated_corrupt_bundles() {
+    let (root, runtime) = test_runtime();
+    let task_a = runtime
+        .add_task(TaskAddParams {
+            title: "Readable A".to_string(),
+            description: "A remains readable.".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("create task A");
+    let task_c = runtime
+        .add_task(TaskAddParams {
+            title: "Corrupt C".to_string(),
+            description: "C will be malformed.".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("create task C");
+
+    let workspace_bundles = root.path().join("global/tasks/workspaces");
+    let workspace_dir = std::fs::read_dir(&workspace_bundles)
+        .expect("read workspace bundle roots")
+        .next()
+        .expect("one workspace bundle root")
+        .expect("workspace bundle entry")
+        .path();
+    let corrupt_dir = workspace_dir.join(&task_c.id);
+    std::fs::remove_file(corrupt_dir.join("description.md")).expect("malform task C");
+
+    assert_eq!(
+        runtime
+            .get_task(&task_a.id)
+            .expect("show unrelated task A")
+            .id,
+        task_a.id
+    );
+    let task_b = runtime
+        .add_task(TaskAddParams {
+            title: "New B".to_string(),
+            description: "B must not scan C.".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("add task B despite corrupt task C");
+    assert_ne!(task_b.id, task_c.id);
+    assert!(matches!(
+        runtime.list_tasks(),
+        Err(OrbitError::TaskBundleCorrupt { task_id, .. }) if task_id == task_c.id
+    ));
+    assert!(
+        corrupt_dir.is_dir(),
+        "diagnosis must not quarantine or delete C"
+    );
 }
 
 // --- ORB-00251: context_files omission / over-inclusion warning helper tests ---

--- a/crates/orbit-mcp/src/error.rs
+++ b/crates/orbit-mcp/src/error.rs
@@ -31,6 +31,13 @@ fn error_payload(err: &OrbitError) -> Value {
     {
         object.insert("artifact_origin".to_string(), json!(artifact_origin));
     }
+    if let Some((task_id, path, reason)) = err.task_bundle_corruption()
+        && let Some(object) = payload.as_object_mut()
+    {
+        object.insert("task_id".to_string(), json!(task_id));
+        object.insert("path".to_string(), json!(path));
+        object.insert("reason".to_string(), json!(reason));
+    }
     payload
 }
 
@@ -67,6 +74,7 @@ fn error_code(err: &OrbitError) -> &str {
         OrbitError::OutcomeUnknown { .. } => "outcome_unknown",
         OrbitError::RemoteTool { code, .. } => code.as_str(),
         OrbitError::Execution(_) => "execution_failed",
+        OrbitError::TaskBundleCorrupt { .. } => "task_bundle_corrupt",
         OrbitError::Store(_) => "store_error",
         OrbitError::WorkspaceError(_) => "workspace_error",
         OrbitError::Io(_) => "io_error",

--- a/crates/orbit-mcp/src/tests/error.rs
+++ b/crates/orbit-mcp/src/tests/error.rs
@@ -68,3 +68,17 @@ fn hub_transport_errors_keep_stable_codes_and_call_identity() {
     assert_eq!(remote["code"], "invalid_input");
     assert_eq!(remote["detail"], 7);
 }
+
+#[test]
+fn task_bundle_corruption_has_a_stable_code_and_structured_context() {
+    let payload = error_payload(&OrbitError::TaskBundleCorrupt {
+        task_id: "ORB-00123".to_string(),
+        path: "/safe/tasks/ORB-00123".to_string(),
+        reason: "missing description.md".to_string(),
+    });
+
+    assert_eq!(payload["code"], "task_bundle_corrupt");
+    assert_eq!(payload["task_id"], "ORB-00123");
+    assert_eq!(payload["path"], "/safe/tasks/ORB-00123");
+    assert_eq!(payload["reason"], "missing description.md");
+}

--- a/crates/orbit-store/src/file/task_store/v2/tests/crud.rs
+++ b/crates/orbit-store/src/file/task_store/v2/tests/crud.rs
@@ -59,6 +59,71 @@ fn create_task_allocates_globally_monotonic_orb_ids() {
 }
 
 #[test]
+fn unrelated_reads_and_creates_survive_a_corrupt_bundle() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let task_a = store
+        .create_task(create_params("Readable A", TaskStatus::Backlog))
+        .expect("create task A");
+    let task_c = store
+        .create_task(create_params("Corrupt C", TaskStatus::Backlog))
+        .expect("create task C");
+    let corrupt_dir = store
+        .bundle_store
+        .bundle_path(&task_c.id)
+        .expect("corrupt bundle path");
+
+    // Review-thread sidecars were retired in ORB-10332. Their absence is a
+    // supported legacy/recovery state and reads must not "repair" it by
+    // mutating or quarantining the otherwise-valid bundle.
+    let retired_review_dir = corrupt_dir.join("review-threads");
+    assert!(!retired_review_dir.exists());
+    assert_eq!(
+        store
+            .get_task(&task_a.id)
+            .expect("read unrelated task A")
+            .expect("task A exists")
+            .id,
+        task_a.id
+    );
+    assert!(
+        !retired_review_dir.exists(),
+        "reading another task must leave the legacy missing sidecar untouched"
+    );
+
+    let missing_path = corrupt_dir.join("description.md");
+    fs::remove_file(&missing_path).expect("malform task C");
+    let task_b = store
+        .create_task(create_params("New B", TaskStatus::Backlog))
+        .expect("create task B despite unrelated corrupt task C");
+    assert_eq!(task_b.id, "ORB-00002");
+
+    for error in [
+        store
+            .list_tasks()
+            .expect_err("list must surface corruption"),
+        store
+            .search_tasks("anything")
+            .expect_err("search must surface corruption"),
+    ] {
+        assert!(matches!(
+            error,
+            OrbitError::TaskBundleCorrupt {
+                task_id,
+                path,
+                reason,
+            } if task_id == task_c.id
+                && path == corrupt_dir.to_string_lossy()
+                && reason.contains("description.md")
+        ));
+    }
+    assert!(
+        corrupt_dir.is_dir() && !missing_path.exists(),
+        "diagnostics must not delete, move, or silently repair the corrupt bundle"
+    );
+}
+
+#[test]
 fn delete_task_removes_v2_bundle_and_index_rows() {
     let temp = TempDir::new().expect("tempdir");
     let store = store(&temp);

--- a/crates/orbit-store/src/file/task_store/v2_bundle.rs
+++ b/crates/orbit-store/src/file/task_store/v2_bundle.rs
@@ -21,8 +21,8 @@ pub(crate) mod lock;
 pub(crate) mod task_bundle_types;
 
 pub(crate) use bundle_io::{
-    append_jsonl_row, cleanup_partial_bundle_best_effort, copy_artifact_blobs, read_bundle_at,
-    write_bundle_at,
+    append_jsonl_row, cleanup_partial_bundle_best_effort, read_bundle_at, write_bundle_at,
+    write_bundle_with_artifacts_at,
 };
 pub(crate) use lock::{
     ensure_projection_entry_removable, remove_projection_entry, remove_task_bundle_lock_sentinel,

--- a/crates/orbit-store/src/file/task_store/v2_bundle/bundle_io/mod.rs
+++ b/crates/orbit-store/src/file/task_store/v2_bundle/bundle_io/mod.rs
@@ -1,6 +1,7 @@
 use std::fs::{self, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use orbit_common::migration::Plan;
 use orbit_common::types::{
@@ -10,7 +11,9 @@ use orbit_common::types::{
     TASK_EVENTS_FILE_NAME, TASK_EXECUTION_SUMMARY_FILE_NAME, TASK_PLAN_FILE_NAME, TaskCommentRowV2,
     TaskEnvelopeV2, TaskEventRowV2,
 };
-use orbit_common::utility::fs::{atomic_write_bytes, atomic_write_text, with_exclusive_file_lock};
+use orbit_common::utility::fs::{
+    atomic_write_bytes, atomic_write_text, sync_parent_dir, with_exclusive_file_lock,
+};
 use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha256};
 
@@ -18,11 +21,42 @@ use super::task_bundle_types::TaskBundleV2;
 use crate::file::task_store::task_migrations;
 use crate::file::yaml_doc::{parse_yaml_with, write_yaml_atomic_with};
 
+static STAGING_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
 /// Write a new v2 bundle at `bundle_dir`.
 ///
-/// This is a creation-only primitive and refuses to write into an existing
-/// bundle directory. Use narrower update helpers for later mutations.
+/// The complete bundle is assembled in a unique sibling directory and renamed
+/// into place only after every required file and directory is durable. This is
+/// a creation-only primitive and refuses to write into an existing bundle
+/// directory. Use narrower update helpers for later mutations.
 pub(crate) fn write_bundle_at(bundle_dir: &Path, bundle: &TaskBundleV2) -> Result<(), OrbitError> {
+    write_bundle_atomically(bundle_dir, bundle, None, publish_staged_bundle)
+}
+
+/// Write a complete imported bundle, including every blob in its artifact
+/// manifest, before publishing the destination directory.
+pub(crate) fn write_bundle_with_artifacts_at(
+    bundle_dir: &Path,
+    bundle: &TaskBundleV2,
+    source_bundle_dir: &Path,
+) -> Result<(), OrbitError> {
+    write_bundle_atomically(
+        bundle_dir,
+        bundle,
+        Some(source_bundle_dir),
+        publish_staged_bundle,
+    )
+}
+
+fn write_bundle_atomically<F>(
+    bundle_dir: &Path,
+    bundle: &TaskBundleV2,
+    artifact_source: Option<&Path>,
+    publish: F,
+) -> Result<(), OrbitError>
+where
+    F: FnOnce(&Path, &Path) -> std::io::Result<()>,
+{
     if bundle_dir.exists() {
         return Err(OrbitError::Store(format!(
             "task bundle already exists at {}",
@@ -31,8 +65,33 @@ pub(crate) fn write_bundle_at(bundle_dir: &Path, bundle: &TaskBundleV2) -> Resul
     }
     validate_bundle_dir_matches_task_id(bundle_dir, &bundle.envelope.id)?;
     validate_bundle(bundle)?;
-    ensure_bundle_dirs(bundle_dir)?;
+    let staging_dir = create_staging_dir(bundle_dir)?;
+    let result = (|| {
+        write_bundle_contents(&staging_dir, bundle)?;
+        if let Some(manifest) = &bundle.artifact_manifest
+            && !manifest.files.is_empty()
+        {
+            let source = artifact_source.ok_or_else(|| {
+                OrbitError::Store(format!(
+                    "task bundle {} has artifact files but no artifact source was supplied",
+                    bundle.envelope.id
+                ))
+            })?;
+            copy_artifact_blobs(source, &staging_dir, manifest)?;
+        }
+        read_bundle_for_id(&staging_dir, &bundle.envelope.id)?;
+        sync_staged_bundle_dirs(&staging_dir)?;
+        publish(&staging_dir, bundle_dir).map_err(OrbitError::from)
+    })();
 
+    if let Err(error) = &result {
+        cleanup_partial_bundle_best_effort(&staging_dir, "atomic bundle staging", error);
+    }
+    result
+}
+
+fn write_bundle_contents(bundle_dir: &Path, bundle: &TaskBundleV2) -> Result<(), OrbitError> {
+    ensure_bundle_dirs(bundle_dir)?;
     write_yaml_atomic_with(
         &bundle_dir.join(TASK_ENVELOPE_FILE_NAME),
         &bundle.envelope,
@@ -71,15 +130,91 @@ pub(crate) fn write_bundle_at(bundle_dir: &Path, bundle: &TaskBundleV2) -> Resul
     Ok(())
 }
 
+fn create_staging_dir(bundle_dir: &Path) -> Result<PathBuf, OrbitError> {
+    let parent = bundle_dir.parent().ok_or_else(|| {
+        OrbitError::Store(format!(
+            "task bundle path has no parent: {}",
+            bundle_dir.display()
+        ))
+    })?;
+    fs::create_dir_all(parent).map_err(OrbitError::from)?;
+    let bundle_name = bundle_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            OrbitError::Store(format!("invalid task bundle path {}", bundle_dir.display()))
+        })?;
+
+    for _ in 0..32 {
+        let sequence = STAGING_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let candidate = parent.join(format!(
+            ".{bundle_name}.{}.{}.staging",
+            std::process::id(),
+            sequence
+        ));
+        match fs::create_dir(&candidate) {
+            Ok(()) => return Ok(candidate),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(OrbitError::from(error)),
+        }
+    }
+    Err(OrbitError::Store(format!(
+        "could not allocate a staging directory for task bundle {}",
+        bundle_dir.display()
+    )))
+}
+
+fn sync_staged_bundle_dirs(staging_dir: &Path) -> Result<(), OrbitError> {
+    let artifact_dir = staging_dir.join(TASK_ARTIFACTS_DIR_NAME);
+    let artifact_files_dir = artifact_dir.join(TASK_ARTIFACT_FILES_DIR_NAME);
+    sync_parent_dir(&artifact_files_dir).map_err(OrbitError::from)?;
+    sync_parent_dir(&artifact_dir).map_err(OrbitError::from)?;
+    sync_parent_dir(&staging_dir).map_err(OrbitError::from)
+}
+
+fn publish_staged_bundle(staging_dir: &Path, bundle_dir: &Path) -> std::io::Result<()> {
+    fs::rename(staging_dir, bundle_dir)?;
+    sync_parent_dir(bundle_dir)
+}
+
 pub(crate) fn read_bundle_at(bundle_dir: &Path) -> Result<TaskBundleV2, OrbitError> {
     let expected_task_id = task_id_from_bundle_dir(bundle_dir)?;
+    read_bundle_for_id(bundle_dir, &expected_task_id).map_err(|error| match error {
+        OrbitError::NotFound {
+            kind: NotFoundKind::Task,
+            ..
+        }
+        | OrbitError::TaskBundleCorrupt { .. }
+        | OrbitError::Io(_) => error,
+        other => OrbitError::TaskBundleCorrupt {
+            task_id: expected_task_id,
+            path: bundle_dir.to_string_lossy().into_owned(),
+            reason: other.to_string(),
+        },
+    })
+}
+
+fn read_bundle_for_id(
+    bundle_dir: &Path,
+    expected_task_id: &str,
+) -> Result<TaskBundleV2, OrbitError> {
     let envelope_path = bundle_dir.join(TASK_ENVELOPE_FILE_NAME);
     if !envelope_path.is_file() {
-        return Err(OrbitError::not_found(NotFoundKind::Task, expected_task_id));
+        return Err(OrbitError::not_found(
+            NotFoundKind::Task,
+            expected_task_id.to_string(),
+        ));
     }
     let envelope: TaskEnvelopeV2 =
         read_migrated_yaml_file(&envelope_path, task_migrations::envelope_plan())?;
-    validate_bundle_dir_matches_task_id(bundle_dir, &envelope.id)?;
+    if envelope.id != expected_task_id {
+        return Err(OrbitError::Store(format!(
+            "task bundle directory {} represents task id {} but contains task id {}",
+            bundle_dir.display(),
+            expected_task_id,
+            envelope.id
+        )));
+    }
 
     let bundle = TaskBundleV2 {
         envelope,

--- a/crates/orbit-store/src/file/task_store/v2_bundle/bundle_io/tests/mod.rs
+++ b/crates/orbit-store/src/file/task_store/v2_bundle/bundle_io/tests/mod.rs
@@ -14,7 +14,7 @@ use tempfile::TempDir;
 
 use super::super::super::tests::test_support::{bundle_store, sample_bundle};
 use super::super::*;
-use super::read_task_events;
+use super::{read_task_events, write_bundle_atomically};
 
 #[test]
 fn write_and_read_bundle_round_trips_v2_shape() {
@@ -46,6 +46,50 @@ fn write_and_read_bundle_round_trips_v2_shape() {
             .join(TASK_ARTIFACTS_DIR_NAME)
             .join(TASK_ARTIFACT_FILES_DIR_NAME)
             .is_dir()
+    );
+}
+
+#[test]
+fn interrupted_bundle_publish_never_exposes_partial_final_directory() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = bundle_store(&temp);
+    let bundle = sample_bundle("ORB-00000");
+    let bundle_dir = store.bundle_path("ORB-00000").expect("bundle path");
+
+    let error = write_bundle_atomically(&bundle_dir, &bundle, None, |staging, final_path| {
+        assert!(
+            !final_path.exists(),
+            "final path must remain absent while staging"
+        );
+        assert!(staging.join(TASK_ENVELOPE_FILE_NAME).is_file());
+        assert!(staging.join(TASK_EVENTS_FILE_NAME).is_file());
+        assert!(
+            staging
+                .join(TASK_ARTIFACTS_DIR_NAME)
+                .join(TASK_ARTIFACT_FILES_DIR_NAME)
+                .is_dir()
+        );
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Interrupted,
+            "simulated interruption before rename",
+        ))
+    })
+    .expect_err("interrupted publish must fail");
+
+    assert!(matches!(error, OrbitError::Io(message) if message.contains("simulated interruption")));
+    assert!(
+        !bundle_dir.exists(),
+        "an interrupted writer must not expose the canonical bundle path"
+    );
+    let parent = bundle_dir.parent().expect("bundle parent");
+    let staging_entries = fs::read_dir(parent)
+        .expect("read bundle parent")
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_name().to_string_lossy().ends_with(".staging"))
+        .collect::<Vec<_>>();
+    assert!(
+        staging_entries.is_empty(),
+        "handled failures clean their private staging directories"
     );
 }
 
@@ -204,7 +248,11 @@ fn read_bundle_rejects_directory_name_that_differs_from_task_id() {
 
     assert!(matches!(
         read_bundle_at(&renamed),
-        Err(OrbitError::Store(message)) if message.contains("does not match task id")
+        Err(OrbitError::TaskBundleCorrupt {
+            task_id,
+            reason,
+            ..
+        }) if task_id == "ORB-00009" && reason.contains("contains task id ORB-00000")
     ));
 }
 
@@ -258,7 +306,11 @@ fn read_bundle_rejects_manifest_entry_with_missing_artifact_file() {
 
     assert!(matches!(
         store.read_bundle("ORB-00000"),
-        Err(OrbitError::Store(message)) if message.contains("missing file")
+        Err(OrbitError::TaskBundleCorrupt {
+            task_id,
+            reason,
+            ..
+        }) if task_id == "ORB-00000" && reason.contains("missing file")
     ));
 }
 
@@ -277,6 +329,10 @@ fn read_bundle_rejects_event_status_newer_than_envelope_status() {
 
     assert!(matches!(
         store.read_bundle("ORB-00000"),
-        Err(OrbitError::Store(message)) if message.contains("event log status")
+        Err(OrbitError::TaskBundleCorrupt {
+            task_id,
+            reason,
+            ..
+        }) if task_id == "ORB-00000" && reason.contains("event log status")
     ));
 }

--- a/crates/orbit-store/src/task_migration/mod.rs
+++ b/crates/orbit-store/src/task_migration/mod.rs
@@ -27,8 +27,8 @@
 //! under `artifacts/files/**`. Export tars the entire canonical bundle tree, so
 //! blobs are always present in the archive. Import validates each blob against
 //! the manifest during staging ([`read_bundle_at`] hashes every file), then
-//! writes the manifest with [`write_bundle_at`] and copies the blob tree with
-//! [`copy_artifact_blobs`] under the same rollback guard as the manifest.
+//! publishes the bundle and blob tree together with
+//! [`write_bundle_with_artifacts_at`] under the same rollback guard.
 //!
 //! ## Backfilling stranded bundles
 //! Before ORB-10042, `write_bundle_at` wrote only the manifest, so any
@@ -63,7 +63,7 @@ use orbit_common::types::{OrbitError, TASK_ARTIFACT_SCHEMA_VERSION, validate_orb
 use serde::{Deserialize, Serialize};
 
 use crate::file::task_store::v2_bundle::{
-    TaskBundleV2, copy_artifact_blobs, read_bundle_at, write_bundle_at,
+    TaskBundleV2, read_bundle_at, write_bundle_at, write_bundle_with_artifacts_at,
 };
 use crate::sqlite::task_registry::{
     ProjectionRebuildResult, RegisterWorkspaceParams, TaskRegistryStore, parse_orb_task_number,
@@ -402,17 +402,16 @@ pub fn import_tasks(
             };
             let bundle = remap_bundle(&staged.bundle, &final_id, &id_remap);
             let dir = registry.canonical_task_bundle_path(&target.workspace_id, &final_id)?;
-            write_bundle_at(&dir, &bundle)?;
-            guard.written_dirs.push(dir.clone());
-            // Copy `artifacts/files/**` blobs from the staged archive tree
-            // *after* the manifest lands; the guard already tracks `dir`, so a
-            // failure here rolls back the whole bundle. `write_bundle_at`
-            // writes the manifest only, so without this step the canonical
-            // bundle would fail `read_bundle_at` on the next reindex pass
-            // (ORB-10042).
-            if let Some(manifest) = bundle.artifact_manifest.as_ref() {
-                copy_artifact_blobs(&staged.staging_dir, &dir, manifest)?;
+            if bundle
+                .artifact_manifest
+                .as_ref()
+                .is_some_and(|manifest| !manifest.files.is_empty())
+            {
+                write_bundle_with_artifacts_at(&dir, &bundle, &staged.staging_dir)?;
+            } else {
+                write_bundle_at(&dir, &bundle)?;
             }
+            guard.written_dirs.push(dir.clone());
             registry.register_task_bundle(&final_id, &target.workspace_id, &dir)?;
             guard.registered_ids.push(final_id.clone());
             if let Some(number) = parse_orb_task_number(&final_id) {

--- a/crates/orbit-store/src/task_migration/tests/mod.rs
+++ b/crates/orbit-store/src/task_migration/tests/mod.rs
@@ -653,7 +653,7 @@ fn round_trip_preserves_artifact_blobs() {
 /// module docs stays honest.
 #[test]
 fn backfill_via_copy_artifact_blobs_restores_stranded_bundle() {
-    use crate::file::task_store::v2_bundle::copy_artifact_blobs;
+    use crate::file::task_store::v2_bundle::bundle_io::copy_artifact_blobs;
 
     let src = TempDir::new().unwrap();
     let dst = TempDir::new().unwrap();

--- a/docs/design/task-artifacts/2_design.md
+++ b/docs/design/task-artifacts/2_design.md
@@ -3,7 +3,7 @@ summary: "Task Artifacts — Design"
 type: design
 title: "Task Artifacts — Design"
 owner: codex
-last_updated: 2026-05-17
+last_updated: 2026-07-26
 status: Draft
 feature: task-artifacts
 doc_role: design
@@ -33,9 +33,6 @@ The v2 task bundle is status-neutral. The canonical bundle lives in the user's l
         execution-summary.md
         events.jsonl
         comments.jsonl
-        review-threads/
-          RT-0001.yaml
-          RT-0001.md
         artifacts/
           manifest.yaml
           files/
@@ -119,11 +116,9 @@ APIs should treat the Markdown file as the source of truth. They may offer parse
 {"schema_version":1,"comment_id":"C-0001","at":"2026-05-11T00:00:00Z","by":"daniel","body":"Start over from the schema reset."}
 ```
 
-Review threads get one metadata envelope and one Markdown body per thread. This keeps thread state structured while making review prose easy to read and diff.
+JSONL appends use a single-line JSON record, append mode, flush, and file sync before success. Readers tolerate a final unterminated or invalid line as tail corruption: valid preceding rows remain readable, and repair may truncate only the corrupt tail. Sidecar rewrites use write-temp-in-same-directory, file sync, atomic rename, and parent-directory sync.
 
-JSONL appends use a single-line JSON record, append mode, flush, and file sync before success. Readers tolerate a final unterminated or invalid line as tail corruption: valid preceding rows remain readable, and repair may truncate only the corrupt tail. Sidecar rewrites and review-thread YAML updates use write-temp-in-same-directory, file sync, atomic rename, and parent-directory sync.
-
-V2 does not provide cross-file transactions. A crash can leave an appended event before the envelope status update, artifact files before the manifest update, or updated review-thread files before stale thread files are removed. The store must keep every intermediate state readable and recoverable, but generated repair/indexing passes are responsible for reconciling partial multi-file mutations.
+V2 does not provide cross-file transactions for later mutations. A crash can leave an appended event before the envelope status update or artifact files before the manifest update. New-bundle creation is stricter: Orbit assembles and validates the entire bundle in a sibling staging directory, fsyncs it, and atomically renames the directory into its canonical path. A failed or interrupted create therefore leaves the final task path absent rather than exposing a partial bundle.
 
 ## 5. Artifact Manifest
 
@@ -195,8 +190,9 @@ The v2 bundle is local and file-backed, so multi-file mutations are not fully tr
 - Document updates may write Markdown sidecars before `task.yaml`; readers return the sidecar content and the previous envelope metadata until the next successful mutation.
 - History updates may append `events.jsonl` before `task.yaml`; readers reject bundles when the last status event does not match the envelope status.
 - Artifact updates may write files before `manifest.yaml`; unreferenced files under `artifacts/files/` are ignored, while manifest entries with missing files, size drift, or hash drift are corruption and fail loudly.
-- Review-thread rewrites tombstone removed thread IDs before pruning files, so a crash before prune does not resurrect deleted threads.
 - Generated index writes may fail after the envelope changes; `updated_at` validation detects the stale row and rebuilds from bundles before indexed reads.
+
+Malformed registered bundles produce a typed `task_bundle_corrupt` diagnostic naming the affected task and canonical path. Direct reads and task creation do not scan unrelated bundles, while list and search retain their fail-loud behavior. Diagnosis never deletes, moves, or repairs the malformed directory; operators can inspect or quarantine it explicitly. Legacy `review-threads/` sidecars were retired in [ORB-10332], so either their presence or absence is ignored non-destructively.
 
 Task lock reservations in v2 mode require `.orbit/config.yaml` to provide the workspace binding. If that file disappears while a runtime is active, lock writes fail instead of silently creating legacy `NULL`-workspace reservations.
 
@@ -243,12 +239,11 @@ The public task API should expose the v2 bundle model directly:
 - envelope metadata from `task.yaml`;
 - Markdown documents by document name (`description`, `acceptance`, `plan`, `execution-summary`);
 - append-only streams for events and comments;
-- review-thread metadata plus Markdown message bodies;
 - artifact manifest entries.
 
-CLI and tool selectors may keep friendly names such as `description`, `plan`, and `execution-summary`, but they should be implemented as first-class document reads and writes. New internal code should operate on a bundle abstraction with explicit envelope, document, log, thread, and artifact fields.
+CLI and tool selectors may keep friendly names such as `description`, `plan`, and `execution-summary`, but they should be implemented as first-class document reads and writes. New internal code should operate on a bundle abstraction with explicit envelope, document, log, and artifact fields.
 
-The public `Task` DTO should not embed legacy relation fields (`parent_id`, `dependencies`, `source_task_id`), local workspace bindings (`workspace_path`, `repo_root`), append-heavy streams (`comments`, `history`, `review_threads`), or internal execution-routing fields (`agent`, `model`). It carries typed `relations`, `job_run_id`, envelope metadata, and durable attribution fields. Consumers that need comments, history, review threads, or workspace binding metadata should call the dedicated bundle/registry APIs.
+The public `Task` DTO should not embed legacy relation fields (`parent_id`, `dependencies`, `source_task_id`), local workspace bindings (`workspace_path`, `repo_root`), append-heavy streams (`comments`, `history`), or internal execution-routing fields (`agent`, `model`). It carries typed `relations`, `job_run_id`, envelope metadata, and durable attribution fields. Consumers that need comments, history, or workspace binding metadata should call the dedicated bundle/registry APIs.
 
 `orbit.task.locks.*` remains a local operational surface, not a task artifact. Lock reservations live in SQLite keyed by workspace binding and canonical `ORB-*` task IDs, and expire by TTL.
 
@@ -264,13 +259,12 @@ Lexical and semantic search should index each logical field independently:
 - `plan`
 - `execution_summary`
 - `comments`
-- `review_threads` (message bodies, message authors, and paths)
 - `external_refs` (system and id)
 - artifact paths plus selected artifact text, when media type permits
 
 This preserves field-aware semantic search while making file boundaries visible in snippets. The embedding index should store field names that match the v2 logical document names; `execution-summary.md` is exposed as `execution_summary` to match the tool/API field.
 
-The current Phase 5 implementation is intentionally asymmetric while indexes are still being wired. Lexical search scans the broader set above. Semantic search indexes task title, description, acceptance, plan, and execution summary; semantic parity for comments, review messages and paths/authors, external refs, and artifacts remains Phase 5 follow-up work.
+The current Phase 5 implementation is intentionally asymmetric while indexes are still being wired. Lexical search scans the broader set above. Semantic search indexes task title, description, acceptance, plan, and execution summary; semantic parity for comments, external refs, and artifacts remains Phase 5 follow-up work.
 
 Until generated full-text indexes land, the working implementation performs O(N x files-per-task) lexical scans by reading every registered bundle and any candidate text artifact files. That is acceptable only as a cutover bridge; generated search rows will replace the per-query artifact reads.
 
@@ -294,7 +288,7 @@ The reset should be a one-time cutover rather than a long-lived compatibility la
 8. Keep existing `plan.md` and `execution-summary.md`.
 9. Move `history` into `events.jsonl`.
 10. Move `comments` into `comments.jsonl`.
-11. Move `review_threads` into `review-threads/`.
+11. Leave any legacy review-thread sidecars outside the active v2 model.
 12. Rewrite `task.yaml` as the v2 envelope without old IDs or embedded prose.
 13. Rewrite task-lock reservations from old IDs to canonical IDs or release stale reservations with an audit event.
 14. Rebuild task tag, semantic, status, terminal-month, and relation indexes from disk.
@@ -321,6 +315,8 @@ Binary artifacts increase storage flexibility and require stronger validation. C
 
 ## Task References
 
+- [ORB-10332] — Retired the unused review-thread task surface and made legacy sidecars inert.
+- [ORB-10466] — Made new-bundle publication atomic and isolated unrelated operations from malformed bundles.
 - [T20260505-12] — Designed git-orphan-branch task sync and documented the current sync-era task bundle assumptions.
 - [T20260506-11] — Removed knowledge-graph task attribution and documented why old task IDs were only local search keys.
 

--- a/docs/design/task-artifacts/specs/task-bundle-v2.md
+++ b/docs/design/task-artifacts/specs/task-bundle-v2.md
@@ -41,11 +41,17 @@ comments.jsonl
 Required directories:
 
 ```text
-review-threads/
 artifacts/
 ```
 
 `artifacts/manifest.yaml` is required when `artifacts/files/` contains any files.
+Legacy `review-threads/` directories are inert sidecars: readers ignore them
+when present and do not require, create, remove, or quarantine them when absent.
+
+New bundles must be assembled and validated in a unique sibling staging
+directory, including all manifest-referenced artifact blobs, then published by
+an atomic directory rename. An interrupted create must leave the canonical task
+path absent rather than expose a partial bundle.
 
 ## Local Store and Workspace Projection
 
@@ -149,18 +155,13 @@ Writers must not rewrite prior event lines except during explicit cutover or rep
 Comment bodies are Markdown strings. Multi-line bodies must be JSON escaped inside one JSONL row, not spread across lines.
 Comment appends follow the same atomicity and tail-repair rules as `events.jsonl`.
 
-## Review Threads
+## Retired Review-Thread Sidecars
 
-Each review thread uses:
-
-```text
-review-threads/<thread-id>.yaml
-review-threads/<thread-id>.md
-```
-
-The YAML file stores status, file path, line/range metadata, external review IDs, timestamps, and message metadata. The Markdown file stores message bodies in chronological order with stable message anchors.
-The YAML file must include `schema_version: 1`. YAML rewrites use write-temp-in-same-directory, file sync, atomic rename, and parent-directory sync.
-Review-thread rewrites must validate the complete replacement set before writing and must not remove `review-threads/` before the replacement is durable. Crash recovery may leave stale thread files behind, but it must not leave the bundle unreadable solely because the directory vanished.
+The `orbit.task.review_thread.*` surface was retired in [ORB-10332]. Existing
+`review-threads/` directories may remain for forensic inspection, but they are
+not part of bundle validity. Recovery is non-destructive: ordinary reads,
+lists, searches, and creates neither delete nor silently recreate those
+sidecars.
 
 ## Relations
 
@@ -200,9 +201,14 @@ The file bundle does not provide all-or-nothing transactions across Markdown sid
 - `task.yaml` remains canonical for structured metadata.
 - JSONL tail corruption is repaired only at the final partial row; corruption before the tail is an error.
 - The last event with `to_status` must match `task.yaml.status`; mismatches are corruption and must fail reads.
-- Review-thread tombstones hide deleted thread IDs if a rewrite crashes before orphan file pruning.
 - Generated indexes are invalid when count or `updated_at` stamps differ from registered bundle envelopes and must be rebuilt from bundles.
 - Artifact manifest entries must reference existing relative files with matching size and SHA-256; unmanifested files are ignored until a future compaction/prune command removes them.
+
+Malformed registered bundles surface as a typed `task_bundle_corrupt`
+diagnostic containing the task ID, canonical path, and reason. Direct lookup of
+another ID and allocation/publication of a new task must not scan the malformed
+bundle. List and search remain fail-loud and return that diagnostic. None of
+these query paths may delete, move, repair, or quarantine bundle bytes.
 
 ## Artifacts
 
@@ -239,7 +245,7 @@ Cutover from the current pre-reset task schema must:
 9. Preserve existing `execution-summary.md`.
 10. Convert YAML `history` to `events.jsonl`.
 11. Convert YAML `comments` to `comments.jsonl`.
-12. Convert YAML `review_threads` to `review-threads/`.
+12. Preserve any legacy review-thread files as inert sidecars.
 13. Rewrite `task.yaml` with schema version 1 and no old ID aliases.
 14. Rewrite or release active task-lock reservations.
 15. Record generated status, terminal-month, relation, tag, and semantic-index rebuild inputs.
@@ -248,4 +254,4 @@ Cutover must be idempotent for interrupted local runs. A partially converted tas
 
 ## Agent Signature
 
-Last revised by `codex` on 2026-05-11.
+Last revised by `codex` on 2026-07-26 for [ORB-10466].


### PR DESCRIPTION
## Task

[ORB-10466](https://orbit-cli.com/tasks/ORB-10466) — Make task-bundle creation atomic and isolate corrupt bundles during reads

### Description

## Problem
A half-created task directory missing review-threads can poison every task read and create in a workspace (F2026-07-097). Current write_bundle_at creates the destination directory before writing required files, so an interruption can expose an invalid bundle.

## Evidence
F2026-07-097 names the ORB-10349 husk and repeated missing review thread directory failures on unrelated task.show/task.add. bundle_io/mod.rs:25 creates and populates the final bundle directory directly.

## Scope
Publish new bundles atomically and ensure one corrupt bundle cannot block unrelated IDs or new allocations.

### Acceptance Criteria

- Task creation writes a complete bundle in a sibling staging directory and atomically renames it into place; interruption tests never expose a partial final directory.
- Showing task A and adding task B succeed when unrelated task C is malformed, while list/search surface C with a typed corruption diagnostic.
- Recovery/quarantine behavior is non-destructive and covered for a missing review-threads directory.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- New task bundles are assembled and validated in unique sibling staging directories, including imported artifact blobs, then fsynced and atomically renamed into the canonical path. Handled pre-publish failures clean staging without ever exposing a partial final directory.
- Malformed persisted bundles now return OrbitError::TaskBundleCorrupt with task_id, path, and reason; CLI/MCP JSON surfaces use the stable task_bundle_corrupt code and structured fields. List/search fail loudly on the affected task while direct reads of other IDs remain isolated.
- Removed the unnecessary workspace-wide list from new-task dependency validation, so adding task B cannot be blocked by unrelated corrupt task C. Store and runtime regression tests cover show/add isolation, list/search diagnostics, and non-destructive preservation.
- Preserved task-import artifact semantics by publishing manifests and referenced blobs together, and reconciled the task-artifact design docs with atomic creation and ORB-10332s retired review-thread sidecars. Missing legacy review-threads directories are accepted and never silently created, moved, deleted, or repaired.
Assessment: The implementation satisfies all three acceptance criteria with deterministic interruption and corruption tests. Atomic publication is confined to creation; existing single-file update crash semantics are unchanged.
Validation:
- make ci-fast
- cargo check -p orbit-cli -p orbit-mcp
- cargo test -p orbit-store --lib (304 passed, 3 ignored)
- cargo test -p orbit-store task_migration::tests:: (14 passed)
- cargo test -p orbit-core command::task::tests::add:: (9 passed)
- cargo test -p orbit-mcp task_bundle_corruption_has_a_stable_code_and_structured_context
- cargo fmt --all -- --check; git diff --check
Deviations from original scope:
- Added tightly coupled OrbitError, CLI/MCP projection, core task-add, task-migration, tests, and design-doc targets to context_files before editing. These were required to provide the stated typed diagnostic, keep the user-visible add path isolated, preserve artifact imports after atomic publication, and keep the documented bundle contract current.
- The acceptance criterion named a missing review-threads directory, but ORB-10332 had already retired that surface. The implementation preserves the intended non-destructive recovery guarantee without resurrecting deleted functionality; this contradicted assumption was filed as F2026-07-168.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10466-6a668cf3`
- Behind base: 0
- Ahead of base: 1