### PR TITLE
Make docs index/show honor the active task worktree

### DIFF
--- a/crates/orbit-cli/src/command/docs.rs
+++ b/crates/orbit-cli/src/command/docs.rs
@@ -206,6 +206,7 @@ impl Execute for DocsIndexArgs {
 fn print_docs_index_text(result: SemanticIndexResult) -> Result<(), OrbitError> {
     let SemanticIndexResult::Docs {
         model_id,
+        source_root,
         report,
         indexed_sources,
         stale_sources,
@@ -216,7 +217,8 @@ fn print_docs_index_text(result: SemanticIndexResult) -> Result<(), OrbitError> 
         ));
     };
     println!(
-        "Indexed docs: model={} indexed_sources={} embedded_chunks={} skipped_fields={} stale_sources={}",
+        "Indexed docs: source_root={} model={} indexed_sources={} embedded_chunks={} skipped_fields={} stale_sources={}",
+        source_root,
         model_id,
         indexed_sources,
         report.embedded_chunks,

--- a/crates/orbit-cli/src/command/semantic.rs
+++ b/crates/orbit-cli/src/command/semantic.rs
@@ -179,12 +179,14 @@ fn print_semantic_index_text(result: SemanticIndexResult) -> Result<(), OrbitErr
         }
         SemanticIndexResult::Docs {
             model_id,
+            source_root,
             report,
             indexed_sources,
             stale_sources,
         } => {
             println!(
-                "Indexed docs: model={} indexed_sources={} embedded_chunks={} skipped_fields={} stale_sources={}",
+                "Indexed docs: source_root={} model={} indexed_sources={} embedded_chunks={} skipped_fields={} stale_sources={}",
+                source_root,
                 model_id,
                 indexed_sources,
                 report.embedded_chunks,
@@ -229,10 +231,11 @@ fn print_semantic_index_text(result: SemanticIndexResult) -> Result<(), OrbitErr
             learnings,
         } => {
             println!(
-                "Indexed semantic search: tasks_model={} tasks_embedded_chunks={} tasks_skipped_fields={} docs_model={} docs_indexed_sources={} docs_embedded_chunks={} docs_skipped_fields={} docs_stale_sources={} adrs_model={} adrs_indexed_sources={} adrs_embedded_chunks={} adrs_skipped_fields={} adrs_stale_sources={} learnings_model={} learnings_indexed_sources={} learnings_embedded_chunks={} learnings_skipped_fields={} learnings_stale_sources={}",
+                "Indexed semantic search: tasks_model={} tasks_embedded_chunks={} tasks_skipped_fields={} docs_source_root={} docs_model={} docs_indexed_sources={} docs_embedded_chunks={} docs_skipped_fields={} docs_stale_sources={} adrs_model={} adrs_indexed_sources={} adrs_embedded_chunks={} adrs_skipped_fields={} adrs_stale_sources={} learnings_model={} learnings_indexed_sources={} learnings_embedded_chunks={} learnings_skipped_fields={} learnings_stale_sources={}",
                 tasks.model_id,
                 tasks.report.embedded_chunks,
                 tasks.report.skipped_fields,
+                docs.source_root,
                 docs.model_id,
                 docs.indexed_sources,
                 docs.report.embedded_chunks,

--- a/crates/orbit-cli/tests/docs.rs
+++ b/crates/orbit-cli/tests/docs.rs
@@ -3,7 +3,7 @@
 
 use std::fs;
 use std::path::PathBuf;
-use std::process::Output;
+use std::process::{Command, Output};
 
 use assert_cmd::cargo::cargo_bin_cmd;
 use orbit_common::test_env::harden_dir;
@@ -662,6 +662,101 @@ fn cli_docs_index_is_semantic_docs_alias_for_json_output() {
     );
 
     assert_eq!(semantic, docs);
+}
+
+#[test]
+#[cfg(unix)]
+fn cli_docs_index_and_show_use_the_linked_worktree_source_root() {
+    let workspace = TestWorkspace::new();
+    workspace.write(
+        "docs/worktree.md",
+        "---\ntype: context\nsummary: Worktree document\n---\nPrimary body\n",
+    );
+    for args in [
+        ["init"].as_slice(),
+        ["config", "user.email", "docs@example.test"].as_slice(),
+        ["config", "user.name", "Docs Test"].as_slice(),
+        ["add", "."].as_slice(),
+        ["commit", "-m", "seed docs workspace"].as_slice(),
+    ] {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(&workspace.work)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let linked = workspace
+        .work
+        .parent()
+        .expect("workspace parent")
+        .join("linked");
+    let output = Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            "docs-worktree",
+            linked.to_str().expect("utf-8 path"),
+        ])
+        .current_dir(&workspace.work)
+        .output()
+        .expect("create linked worktree");
+    assert!(
+        output.status.success(),
+        "git worktree add failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    fs::write(
+        linked.join("docs/worktree.md"),
+        "---\ntype: context\nsummary: Worktree document\n---\nLinked worktree body\n",
+    )
+    .expect("edit linked worktree doc");
+    workspace.write_mock_companion();
+
+    let indexed = run_orbit_with_companion(
+        &linked,
+        &workspace.home,
+        &["docs", "index", "--force"],
+        Some(&workspace.companion),
+    );
+    assert!(
+        indexed.status.success(),
+        "docs index failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&indexed.stdout),
+        String::from_utf8_lossy(&indexed.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&indexed.stdout)
+            .contains(&format!("source_root={}", linked.display()))
+    );
+
+    let shown = run_orbit(
+        &linked,
+        &workspace.home,
+        &["docs", "show", "docs/worktree.md", "--json"],
+    );
+    assert!(
+        shown.status.success(),
+        "docs show failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&shown.stdout),
+        String::from_utf8_lossy(&shown.stderr)
+    );
+    let shown: Value = serde_json::from_slice(&shown.stdout).expect("parse docs show");
+    assert_eq!(shown["body"], "Linked worktree body\n");
+
+    let primary = workspace.run_with_companion(&["docs", "index", "--force"], "primary docs index");
+    assert!(
+        String::from_utf8_lossy(&primary.stdout)
+            .contains(&format!("source_root={}", workspace.work.display()))
+    );
 }
 
 #[test]

--- a/crates/orbit-core/src/command/docs/mod.rs
+++ b/crates/orbit-core/src/command/docs/mod.rs
@@ -22,6 +22,7 @@ pub use orbit_search::{
     AdrIndexParams, AdrIndexResult, DocIndexParams, DocIndexResult, SearchResult,
 };
 use orbit_search::{score_adr_record, score_doc_record, sort_search_results};
+use std::path::{Path, PathBuf};
 
 use crate::OrbitRuntime;
 
@@ -45,6 +46,20 @@ use self::search::{
 // The original impl block (291-408) is preserved verbatim except for path adjustments
 // that are mechanical (use of super:: paths). All bodies delegate to submodules.
 impl OrbitRuntime {
+    /// Returns the checkout whose documentation commands read and index.
+    ///
+    /// Linked worktrees intentionally share Orbit metadata with the primary
+    /// checkout, but their Markdown files are branch-local. Documentation
+    /// commands must therefore use the local `.orbit` parent rather than the
+    /// shared metadata root.
+    pub fn docs_source_root(&self) -> PathBuf {
+        let local_root = self.local_root();
+        local_root
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| self.paths().repo_root.clone())
+    }
+
     pub fn docs_roots(&self) -> Result<Vec<String>, OrbitError> {
         read_docs_roots_from_config_path(&self.config_path())
     }
@@ -62,7 +77,8 @@ impl OrbitRuntime {
         doc_type: Option<DocType>,
         tag: Option<&str>,
     ) -> Result<Vec<DocRecord>, OrbitError> {
-        let mut records = walk_docs_roots(&self.paths().repo_root, &self.docs_roots()?)?;
+        let source_root = self.docs_source_root();
+        let mut records = walk_docs_roots(&source_root, &self.docs_roots()?)?;
         if let Some(doc_type) = doc_type {
             records.retain(|record| record.frontmatter.doc_type == doc_type);
         }
@@ -81,7 +97,8 @@ impl OrbitRuntime {
     }
 
     pub fn show_doc(&self, path: &str) -> Result<DocShow, OrbitError> {
-        show_doc(&self.paths().repo_root, &self.docs_roots()?, path)
+        let source_root = self.docs_source_root();
+        show_doc(&source_root, &self.docs_roots()?, path)
     }
 
     pub fn search_docs(
@@ -133,7 +150,7 @@ impl OrbitRuntime {
         // agent-facing feature join uses normalized task tags as the feature
         // selectors until that storage field exists.
         related_docs_for_context(
-            &self.paths().repo_root,
+            &self.docs_source_root(),
             &roots,
             &task.context_files,
             &task.tags,
@@ -145,9 +162,11 @@ impl OrbitRuntime {
         add_docs_root(&self.paths().repo_root, &self.config_path(), path)
     }
 
-    pub fn index_docs(&self, params: DocIndexParams) -> Result<DocIndexResult, OrbitError> {
+    pub fn index_docs(&self, mut params: DocIndexParams) -> Result<DocIndexResult, OrbitError> {
         let roots = self.docs_roots()?;
-        let sources = doc_embedding_sources(&self.paths().repo_root, &roots)?;
+        let source_root = self.docs_source_root();
+        params.source_root = source_root.to_string_lossy().into_owned();
+        let sources = doc_embedding_sources(&source_root, &roots)?;
         orbit_search::doc_index(&self.stores().semantic_vector, &sources, params)
     }
 
@@ -158,7 +177,7 @@ impl OrbitRuntime {
     }
 
     pub fn migrate_docs(&self, dry_run: bool) -> Result<DocMigrationReport, OrbitError> {
-        migrate_docs(&self.paths().repo_root, dry_run)
+        migrate_docs(&self.docs_source_root(), dry_run)
     }
 }
 

--- a/crates/orbit-core/src/command/docs/tests/mod.rs
+++ b/crates/orbit-core/src/command/docs/tests/mod.rs
@@ -13,6 +13,7 @@ mod migrate;
 mod path_util;
 mod search;
 mod walk;
+mod worktree;
 
 use std::io::Write;
 use std::path::Path;

--- a/crates/orbit-core/src/command/docs/tests/worktree.rs
+++ b/crates/orbit-core/src/command/docs/tests/worktree.rs
@@ -1,0 +1,56 @@
+//! Worktree-local docs source-root regression coverage.
+
+use std::fs;
+
+use tempfile::tempdir;
+
+use super::super::search::doc_embedding_sources;
+use crate::OrbitRuntime;
+
+#[test]
+fn docs_use_the_active_worktree_when_metadata_is_shared() {
+    let root = tempdir().expect("tempdir");
+    let global_root = root.path().join("global");
+    let primary = root.path().join("primary");
+    let worktree = root.path().join("worktree");
+    let shared_root = primary.join(".orbit");
+    let local_root = worktree.join(".orbit");
+
+    fs::create_dir_all(&global_root).expect("global root");
+    fs::create_dir_all(&shared_root).expect("shared root");
+    fs::create_dir_all(&local_root).expect("local root");
+    fs::create_dir_all(primary.join("docs")).expect("primary docs");
+    fs::create_dir_all(worktree.join("docs")).expect("worktree docs");
+    fs::write(
+        shared_root.join("config.toml"),
+        "[docs]\nroots = [\"docs/\"]\n",
+    )
+    .expect("docs config");
+    fs::write(
+        primary.join("docs/guide.md"),
+        "---\ntype: context\nsummary: Guide\n---\nPrimary body\n",
+    )
+    .expect("primary doc");
+    fs::write(
+        worktree.join("docs/guide.md"),
+        "---\ntype: context\nsummary: Guide\n---\nWorktree body\n",
+    )
+    .expect("worktree doc");
+
+    let runtime = OrbitRuntime::from_resolved_roots(&global_root, &shared_root, &local_root)
+        .expect("build runtime");
+
+    let shown = runtime
+        .show_doc("docs/guide.md")
+        .expect("show worktree doc");
+    assert_eq!(shown.body, "Worktree body\n");
+    assert_eq!(runtime.docs_source_root(), worktree);
+
+    let sources = doc_embedding_sources(
+        &runtime.docs_source_root(),
+        &runtime.docs_roots().expect("docs roots"),
+    )
+    .expect("read worktree embedding sources");
+    assert_eq!(sources.len(), 1);
+    assert_eq!(sources[0].body, "Worktree body\n");
+}

--- a/crates/orbit-core/src/command/semantic.rs
+++ b/crates/orbit-core/src/command/semantic.rs
@@ -79,6 +79,7 @@ impl OrbitRuntime {
         self.index_docs(orbit_search::DocIndexParams {
             model: params.model,
             force: params.force,
+            source_root: self.docs_source_root().to_string_lossy().into_owned(),
         })
     }
 

--- a/crates/orbit-search/src/commands/doc_index.rs
+++ b/crates/orbit-search/src/commands/doc_index.rs
@@ -9,11 +9,14 @@ use crate::{Embedder, SubprocessEmbedder};
 pub struct DocIndexParams {
     pub model: Option<String>,
     pub force: bool,
+    /// Checkout whose files supplied this embedding run.
+    pub source_root: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DocIndexResult {
     pub model_id: String,
+    pub source_root: String,
     pub report: UpsertReport,
     pub indexed_sources: usize,
     pub stale_sources: Vec<String>,
@@ -26,7 +29,13 @@ pub fn run(
 ) -> Result<DocIndexResult, OrbitError> {
     let model = parse_model(params.model.as_deref())?;
     let embedder = SubprocessEmbedder::with_model(model.alias)?;
-    run_with_embedder(vector_store, docs, &embedder, params.force)
+    run_with_embedder(
+        vector_store,
+        docs,
+        &embedder,
+        params.force,
+        params.source_root,
+    )
 }
 
 pub(crate) fn run_with_embedder(
@@ -34,10 +43,12 @@ pub(crate) fn run_with_embedder(
     docs: &[DocEmbeddingSource],
     embedder: &dyn Embedder,
     force: bool,
+    source_root: String,
 ) -> Result<DocIndexResult, OrbitError> {
     let report = vector_store.reindex_docs(docs, embedder, force)?;
     Ok(DocIndexResult {
         model_id: embedder.model_id().to_string(),
+        source_root,
         report: report.upsert,
         indexed_sources: report.indexed_sources,
         stale_sources: report.stale_sources,

--- a/crates/orbit-search/src/commands/reindex.rs
+++ b/crates/orbit-search/src/commands/reindex.rs
@@ -66,6 +66,7 @@ pub enum SemanticIndexResult {
     },
     Docs {
         model_id: String,
+        source_root: String,
         report: UpsertReport,
         indexed_sources: usize,
         stale_sources: Vec<String>,
@@ -103,6 +104,7 @@ impl From<DocIndexResult> for SemanticIndexResult {
     fn from(result: DocIndexResult) -> Self {
         Self::Docs {
             model_id: result.model_id,
+            source_root: result.source_root,
             report: result.report,
             indexed_sources: result.indexed_sources,
             stale_sources: result.stale_sources,

--- a/crates/orbit-search/src/commands/tests/doc_index.rs
+++ b/crates/orbit-search/src/commands/tests/doc_index.rs
@@ -20,9 +20,10 @@ fn doc_index_is_idempotent_by_content_hash() {
     let embedder = NoopEmbedder::small();
     let docs = vec![doc("docs/example.md", "Example", "same body")];
 
-    let first = run_with_embedder(&store, &docs, &embedder, false).unwrap();
-    let second = run_with_embedder(&store, &docs, &embedder, false).unwrap();
+    let first = run_with_embedder(&store, &docs, &embedder, false, "/repo".to_string()).unwrap();
+    let second = run_with_embedder(&store, &docs, &embedder, false, "/repo".to_string()).unwrap();
 
+    assert_eq!(first.source_root, "/repo");
     assert!(first.report.embedded_chunks > 0);
     assert_eq!(second.report.embedded_chunks, 0);
     assert!(second.report.skipped_fields > 0);


### PR DESCRIPTION
## Task

[ORB-10465](https://orbit-cli.com/tasks/ORB-10465) — Make docs index/show honor the active task worktree

### Description

## Problem
Docs indexing from a task worktree can report success while docs show returns the primary-checkout version, making same-PR documentation validation stale (F2026-07-043).

## Evidence
F2026-07-043 records 128 sources/170 chunks indexed from a worktree while ssh-tunnel.md immediately showed the pre-edit primary body. Current docs walking/index entry points live in crates/orbit-core/src/command/docs and must deliberately distinguish shared metadata from worktree file content.

## Scope
Bind file reads and indexing to the effective local checkout while preserving shared registry/index semantics where intentional.

### Acceptance Criteria

- A temp linked-worktree test edits a registered doc only in that worktree; docs index followed by docs show returns the edited body.
- Primary and worktree docs indexes cannot silently overwrite or read each other under the wrong root.
- Command output names the effective source root so successful indexing is auditable.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Bound docs list/show/search/task-context lookup, migration, and embedding-source reads to the active local worktree while retaining shared Orbit configuration and vector-store metadata.
- Added the effective docs source root to docs index and semantic index reports (JSON and text), so a shared index refresh identifies the checkout that supplied content.
- Added core regression coverage for shared metadata plus a local worktree, and a CLI test that creates a real linked Git worktree, indexes its edited document, verifies docs show returns that body, and verifies primary/worktree index output reports distinct roots.
- Extended task context to include tightly coupled orbit-search result plumbing and CLI rendering/tests needed for the required auditable output.
Assessment: The docs corpus now reads branch-local files from the active checkout; intentional shared index storage is explicitly attributed to its source checkout.
Validation:
- cargo fmt --check
- cargo test -p orbit-search doc_index_is_idempotent_by_content_hash --lib
- cargo test -p orbit-core docs_use_the_active_worktree_when_metadata_is_shared --lib
- cargo test -p orbit-cli --test docs cli_docs_index_and_show_use_the_linked_worktree_source_root -- --exact
- cargo test -p orbit-cli --test docs cli_docs_index_is_semantic_docs_alias_for_json_output -- --exact
- make ci-fast guardrails: all constituent checks passed; the executor time slice ended while the final orphan-module guard was running, and ./scripts/check-orphan-modules.sh passed on rerun.
- git diff --check

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10465-6a669295`
- Behind base: 0
- Ahead of base: 1