### PR TITLE
Clean stale artifact citations from Orbit code comments

### DIFF
--- a/crates/orbit-agent/examples/anthropic_messages.rs
+++ b/crates/orbit-agent/examples/anthropic_messages.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
+// Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
 #![allow(
     clippy::expect_used,
     clippy::print_stderr,

--- a/crates/orbit-agent/examples/google_gemini.rs
+++ b/crates/orbit-agent/examples/google_gemini.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
+// Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
 #![allow(
     clippy::expect_used,
     clippy::print_stderr,

--- a/crates/orbit-agent/examples/guardrails_smoke.rs
+++ b/crates/orbit-agent/examples/guardrails_smoke.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
+// Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
 #![allow(
     clippy::expect_used,
     clippy::print_stderr,

--- a/crates/orbit-agent/examples/openai_compat.rs
+++ b/crates/orbit-agent/examples/openai_compat.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
+// Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
 #![allow(
     clippy::expect_used,
     clippy::print_stderr,

--- a/crates/orbit-agent/examples/redaction_smoke.rs
+++ b/crates/orbit-agent/examples/redaction_smoke.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
+// Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
 #![allow(
     clippy::expect_used,
     clippy::print_stderr,

--- a/crates/orbit-agent/examples/session_continuation.rs
+++ b/crates/orbit-agent/examples/session_continuation.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
+// Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
 #![allow(
     clippy::expect_used,
     clippy::print_stderr,

--- a/crates/orbit-agent/examples/tool_allowlist.rs
+++ b/crates/orbit-agent/examples/tool_allowlist.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
+// Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
 #![allow(
     clippy::expect_used,
     clippy::print_stderr,

--- a/crates/orbit-agent/src/lib.rs
+++ b/crates/orbit-agent/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::print_stderr, clippy::print_stdout)]
 // ORB-00004: legacy public provider surfaces still need a focused documentation pass.
 #![allow(missing_docs)]
-// ORB-00013: Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
+// Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 #![allow(
     rustdoc::broken_intra_doc_links,

--- a/crates/orbit-agent/src/loop_engine/audit/mod.rs
+++ b/crates/orbit-agent/src/loop_engine/audit/mod.rs
@@ -9,7 +9,7 @@
 //! Persistent audit storage is owned by the runtime layer. Tests use
 //! [`InMemorySink`], callers with no need for persistence use [`NullSink`].
 
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use std::path::PathBuf;

--- a/crates/orbit-agent/src/loop_engine/replay_transport.rs
+++ b/crates/orbit-agent/src/loop_engine/replay_transport.rs
@@ -10,7 +10,7 @@
 //! Not a general-purpose recorder — pairs well with a future `RecordingTransport`
 //! that would capture real provider turns into the same fixture format.
 
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use std::sync::Mutex;

--- a/crates/orbit-agent/src/loop_engine/tool_dispatch.rs
+++ b/crates/orbit-agent/src/loop_engine/tool_dispatch.rs
@@ -6,7 +6,7 @@
 //! `ToolRegistry::execute` entry point that the rest of Orbit uses, so tool
 //! behavior, policy, and attribution stay in a single source of truth.
 
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use std::collections::HashSet;

--- a/crates/orbit-cli/src/command/task/tests/command.rs
+++ b/crates/orbit-cli/src/command/task/tests/command.rs
@@ -2,8 +2,8 @@ use clap::{CommandFactory, Parser, error::ErrorKind};
 
 use crate::command::Cli;
 
-/// The trimmed `orbit task` surface has 12 subcommands. ORB-10428 supersedes
-/// the ORB-00420/ORB-10000 placement and returns lock administration here.
+/// The trimmed `orbit task` surface has 12 subcommands. ORB-10428 returns lock
+/// administration here.
 const EXPECTED_TASK_SUBCOMMANDS: [&str; 12] = [
     "add", "artifact", "locks", "list", "show", "lint", "update", "start", "archive", "export",
     "import", "reindex",
@@ -111,14 +111,14 @@ fn root_help_groups_scheduler_commands_in_layer_order() {
 
 #[test]
 fn lock_administration_lives_under_task() {
-    // `--locked` was removed from `task list` (ORB-00420).
+    // `--locked` was removed from `task list`.
     let err = match Cli::try_parse_from(["orbit", "task", "list", "--locked"]) {
         Ok(_) => panic!("`task list --locked` should no longer parse"),
         Err(err) => err,
     };
     assert_eq!(err.kind(), ErrorKind::UnknownArgument);
 
-    // ORB-10428 supersedes the ORB-00420/ORB-10000 placement: locks are task administration.
+    // ORB-10428: locks are task administration.
     Cli::try_parse_from(["orbit", "task", "locks", "list"]).expect("task locks list parses");
     Cli::try_parse_from(["orbit", "task", "locks", "list", "--json"])
         .expect("task locks list --json parses");

--- a/crates/orbit-cli/src/command/tests/sweep.rs
+++ b/crates/orbit-cli/src/command/tests/sweep.rs
@@ -1,4 +1,4 @@
-//! `orbit sweep` output/reporting tests [ORB-00423]: the quiet-by-default
+//! `orbit sweep` output/reporting tests: the quiet-by-default
 //! filtering that keeps the once-a-minute clock from growing its log, and the
 //! stable `--json` shape machine consumers depend on.
 

--- a/crates/orbit-cli/src/main.rs
+++ b/crates/orbit-cli/src/main.rs
@@ -1,8 +1,8 @@
 // ORB-00004: legacy CLI binary surfaces still need a focused documentation pass.
 #![allow(missing_docs)]
-// ORB-00013: The CLI binary prints genuine user-facing command output.
+// The CLI binary prints genuine user-facing command output.
 #![allow(clippy::print_stderr, clippy::print_stdout)]
-// ORB-00013: Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
+// Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 #![allow(
     rustdoc::broken_intra_doc_links,

--- a/crates/orbit-cli/tests/hook_install.rs
+++ b/crates/orbit-cli/tests/hook_install.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Tests use unwrap/expect to keep fixture setup readable.
+// Tests use unwrap/expect to keep fixture setup readable.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::fs;

--- a/crates/orbit-cli/tests/hook_pretooluse.rs
+++ b/crates/orbit-cli/tests/hook_pretooluse.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Tests use unwrap/expect to keep fixture setup readable.
+// Tests use unwrap/expect to keep fixture setup readable.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::fs;

--- a/crates/orbit-cli/tests/host_administration.rs
+++ b/crates/orbit-cli/tests/host_administration.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Tests use unwrap/expect to keep fixture setup readable.
+// Tests use unwrap/expect to keep fixture setup readable.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use assert_cmd::cargo::cargo_bin_cmd;

--- a/crates/orbit-cli/tests/learning.rs
+++ b/crates/orbit-cli/tests/learning.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Tests use unwrap/expect to keep fixture setup readable.
+// Tests use unwrap/expect to keep fixture setup readable.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 //! CLI parity tests for `orbit learning <subcommand>`.

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -9,7 +9,7 @@
 //! The `tools/list` snapshot is the breaking-change guard for the agent MCP
 //! surface: per RELEASING.md, any tool input/output schema change is breaking.
 #![allow(missing_docs)]
-// ORB-00013: tests use unwrap/expect to keep fixture setup readable.
+// tests use unwrap/expect to keep fixture setup readable.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::collections::BTreeSet;
@@ -132,8 +132,8 @@ impl McpWorkspace {
     }
 
     /// Spawn `orbit mcp serve`, run the MCP initialize handshake (announcing
-    /// this workspace via `_meta.orbit.workspace`, ADR-0181), and return the
-    /// connected client.
+    /// this workspace via `_meta.orbit.workspace`), and return the connected
+    /// client.
     fn serve(&self) -> McpClient {
         let child = Self::orbit_command(&self.work, &self.home)
             .args(["mcp", "serve"])
@@ -579,7 +579,7 @@ fn mcp_serve_round_trips_records_against_a_temp_workspace() {
 
     // Task create → show → list. No explicit `workspace` argument anywhere:
     // the ambient session workspace announced via initialize `_meta` must be
-    // applied (ADR-0181).
+    // applied.
     let created = client.call_tool_ok(
         "orbit_task_add",
         json!({

--- a/crates/orbit-cli/tests/semantic_companion.rs
+++ b/crates/orbit-cli/tests/semantic_companion.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Tests use unwrap/expect to keep fixture setup readable.
+// Tests use unwrap/expect to keep fixture setup readable.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::fs;

--- a/crates/orbit-cli/tests/task_tags.rs
+++ b/crates/orbit-cli/tests/task_tags.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Tests use unwrap/expect to keep fixture setup readable.
+// Tests use unwrap/expect to keep fixture setup readable.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::fs;

--- a/crates/orbit-cli/tests/task_trimmed_surface.rs
+++ b/crates/orbit-cli/tests/task_trimmed_surface.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Tests use unwrap/expect to keep fixture setup readable.
+// Tests use unwrap/expect to keep fixture setup readable.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 //! End-to-end coverage for the task surface after ORB-10428:

--- a/crates/orbit-cli/tests/tool_list.rs
+++ b/crates/orbit-cli/tests/tool_list.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Tests use unwrap/expect to keep fixture setup readable.
+// Tests use unwrap/expect to keep fixture setup readable.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::collections::BTreeSet;

--- a/crates/orbit-cli/tests/worktree_resolution.rs
+++ b/crates/orbit-cli/tests/worktree_resolution.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Tests use unwrap/expect to keep fixture setup readable.
+// Tests use unwrap/expect to keep fixture setup readable.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::fs;

--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -412,7 +412,7 @@ fn doctor_check_job_runs(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {
 /// Task relation/dependency targets that no longer resolve to a registered
 /// task bundle — the "grandfathered" relations that make a generated task
 /// index fail to rebuild against its relation validator, forcing an unbounded
-/// bundle-scan fallback (ORB-10305 / ORB-10246). Scoped to the current
+/// bundle-scan fallback (ORB-10305). Scoped to the current
 /// workspace; surfacing them here lets an operator fix or remove the offending
 /// relation before the validator trips over it at rebuild time.
 fn doctor_check_task_relations(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {

--- a/crates/orbit-common/examples/v2_asset_smoke.rs
+++ b/crates/orbit-common/examples/v2_asset_smoke.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
+// Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
 #![allow(
     clippy::expect_used,
     clippy::print_stderr,

--- a/crates/orbit-common/examples/v2_job_kind_smoke.rs
+++ b/crates/orbit-common/examples/v2_job_kind_smoke.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
+// Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
 #![allow(
     clippy::expect_used,
     clippy::print_stderr,

--- a/crates/orbit-common/examples/v2_round_trip.rs
+++ b/crates/orbit-common/examples/v2_round_trip.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
+// Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
 #![allow(
     clippy::expect_used,
     clippy::print_stderr,

--- a/crates/orbit-common/src/lib.rs
+++ b/crates/orbit-common/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::print_stderr, clippy::print_stdout)]
 // ORB-00004: legacy domain-schema surfaces still need a focused documentation pass.
 #![allow(missing_docs)]
-// ORB-00013: Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
+// Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 #![allow(
     rustdoc::broken_intra_doc_links,

--- a/crates/orbit-common/src/model_defaults.rs
+++ b/crates/orbit-common/src/model_defaults.rs
@@ -14,7 +14,7 @@
 //! source of truth" means using the provider alias directly in the asset and
 //! keeping this module authoritative for production Rust paths. The executor
 //! asset ↔ const agreement is guarded by a test in orbit-core's executor
-//! command module. See ADR-0211 for the de-hardcode + centralization decision.
+//! command module.
 //!
 //! ## Aliases vs. version pins
 //!

--- a/crates/orbit-common/src/types/activity_job/job_v2.rs
+++ b/crates/orbit-common/src/types/activity_job/job_v2.rs
@@ -1,4 +1,4 @@
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use serde::{Deserialize, Deserializer, Serialize};

--- a/crates/orbit-common/src/types/pricing.rs
+++ b/crates/orbit-common/src/types/pricing.rs
@@ -9,7 +9,7 @@
 // The shipped asset is a build-time invariant (a checked-in file this crate
 // controls), not user input; `shipped_price_table_parses_and_is_non_empty`
 // guards it in CI. See `redaction.rs` for the same documented-invariant use
-// of `expect` (ORB-00013).
+// of `expect`.
 #![allow(clippy::expect_used)]
 
 use std::sync::OnceLock;

--- a/crates/orbit-common/src/types/routine.rs
+++ b/crates/orbit-common/src/types/routine.rs
@@ -5,7 +5,7 @@
 //!
 //! Parsing is fail-closed: an invalid file is an error, never a routine that
 //! fires with defaults. Targets are catalog references only — there is no
-//! inline command form (ADR-0194 / ADR-0206 posture).
+//! inline command form (ADR-0206 posture).
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 

--- a/crates/orbit-common/src/types/task.rs
+++ b/crates/orbit-common/src/types/task.rs
@@ -27,7 +27,7 @@
 //!
 //! See [`TaskStatus::validate_transition`] for the blocklist implementation.
 
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/orbit-common/src/utility/redaction.rs
+++ b/crates/orbit-common/src/utility/redaction.rs
@@ -19,7 +19,7 @@
 //! - [`redact_all`] — env + default patterns in one pass (use when you don't
 //!   know what shape the input has and want maximum coverage)
 
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use std::{

--- a/crates/orbit-common/tests/task_artifacts_v2.rs
+++ b/crates/orbit-common/tests/task_artifacts_v2.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Tests use unwrap/expect to keep fixture setup readable.
+// Tests use unwrap/expect to keep fixture setup readable.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::fs;

--- a/crates/orbit-core/examples/v2_backend_precedence_smoke.rs
+++ b/crates/orbit-core/examples/v2_backend_precedence_smoke.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
+// Examples are user-facing smoke binaries that print progress and unwrap setup invariants.
 #![allow(
     clippy::expect_used,
     clippy::print_stderr,

--- a/crates/orbit-core/src/command/docs/search.rs
+++ b/crates/orbit-core/src/command/docs/search.rs
@@ -134,7 +134,7 @@ pub(super) fn adr_embedding_sources(
     adrs: Vec<Adr>,
 ) -> Result<Vec<AdrEmbeddingSource>, OrbitError> {
     let mut sources = Vec::new();
-    // L-0028: ADR ids can briefly appear in multiple status directories; index one source per id.
+    // ADR ids can briefly appear in multiple status directories; index one source per id.
     let adrs = adrs
         .into_iter()
         .map(|adr| (adr.id.clone(), adr))

--- a/crates/orbit-core/src/command/job/pipeline.rs
+++ b/crates/orbit-core/src/command/job/pipeline.rs
@@ -717,7 +717,7 @@ impl OrbitRuntime {
             });
         }
 
-        // L-0090: discover detached workers by registered cwd, never explicit --root.
+        // Discover detached workers by registered cwd, never explicit --root.
         // Start the observer before the process so every successfully spawned
         // worker has a parent-side path that can terminalize a pre-claim exit.
         // Passing `--root` here used to pin both the workspace and global roots

--- a/crates/orbit-core/src/command/learning.rs
+++ b/crates/orbit-core/src/command/learning.rs
@@ -127,9 +127,9 @@ impl OrbitRuntime {
     ///
     /// [ORB-10364] Deliberately ungated: by the time a caller reaches finalize
     /// the global id is already consumed and cannot be released, so a refusal
-    /// here would burn an id. When ORB-10274 (F3) routes public
-    /// `orbit.learning.add` through the broker, the caller-role gate belongs in
-    /// the preflight *before* `compose_preallocated_knowledge_add` allocates —
+    /// here would burn an id. When public `orbit.learning.add` traverses the
+    /// broker, the caller-role gate belongs in the preflight *before*
+    /// `compose_preallocated_knowledge_add` allocates —
     /// see [`crate::command::learning_authoring::ensure_learning_write_allowed`].
     pub fn finalize_preallocated_learning(
         &self,

--- a/crates/orbit-core/src/command/tests/executor.rs
+++ b/crates/orbit-core/src/command/tests/executor.rs
@@ -256,7 +256,7 @@ fn seed_default_executors_heals_leftover_macos_sandbox_on_linux() {
     );
 }
 
-/// ADR-0211 asset↔const seam: the shipped `claude.yaml` cannot reference the
+/// The asset↔const seam: the shipped `claude.yaml` cannot reference the
 /// Rust constants, so this test pins the executor asset's model pair to the
 /// authoritative `orbit-common::model_defaults` values. A drift on either side
 /// (bumping the const without the asset, or vice versa) fails here.

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::print_stderr, clippy::print_stdout)]
 // ORB-00004: legacy runtime command surfaces still need a focused documentation pass.
 #![allow(missing_docs)]
-// ORB-00013: Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
+// Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 #![allow(
     rustdoc::broken_intra_doc_links,

--- a/crates/orbit-core/src/routines/clock.rs
+++ b/crates/orbit-core/src/routines/clock.rs
@@ -20,8 +20,8 @@ pub const LAUNCHD_LABEL: &str = "com.orbit.sweep";
 pub const SYSTEMD_UNIT: &str = "orbit-sweep";
 
 /// Path launchd redirects `orbit sweep` stdout/stderr to on macOS, and the
-/// file `run_sweep` rotates so it stays bounded on an always-on host
-/// ([ORB-00423]). Single source of truth shared by the installer and the sweep
+/// file `run_sweep` rotates so it stays bounded on an always-on host. Single
+/// source of truth shared by the installer and the sweep
 /// pass so the writer and the rotator never disagree. (Linux logs to the
 /// journal, which rotates on its own, so only macOS needs this file.)
 pub fn sweep_log_path(global_root: &Path) -> PathBuf {

--- a/crates/orbit-core/src/routines/sweep.rs
+++ b/crates/orbit-core/src/routines/sweep.rs
@@ -28,7 +28,7 @@ use super::validation::{
     RoutinePlacementProvider, RoutineRegistryStatus, RoutineRegistryView, validate_routine_pins,
 };
 
-/// Dispatch seam for the sweep [ORB-00421]. The production impl
+/// Dispatch seam for the sweep. The production impl
 /// ([`RuntimeDispatch`]) wraps one `OrbitRuntime` per source workspace and
 /// dispatches through `submit_pipeline_run` / `show_job_run`; tests supply a
 /// fake so the sweep's fire / retry / overlap / outcome-sync orchestration is
@@ -136,7 +136,7 @@ pub fn run_sweep_with_providers(
     // The OS clock invokes this every minute forever; on macOS launchd
     // redirects stdout/stderr into `logs/sweep.log`. Opportunistically roll +
     // prune it here (rename-based, best-effort) so an always-on host cannot
-    // grow it without bound [ORB-00423]. No-op until the file exceeds the
+    // grow it without bound. No-op until the file exceeds the
     // configured per-file budget. `run_sweep_at_with_providers` (the explicit
     // root seam) is left
     // untouched so tests never rotate real logs.
@@ -221,7 +221,7 @@ pub fn run_sweep_at_with_providers(
     })
 }
 
-/// The dispatch-agnostic core of one sweep pass [ORB-00421]: outcome-sync
+/// The dispatch-agnostic core of one sweep pass: outcome-sync
 /// (unless dry-run), then per-routine due evaluation and fire/skip. Split out
 /// from [`run_sweep_at_with_providers`] — which owns the lock, store, and workspace discovery
 /// — so the orchestration can be driven against a temp store, a hand-built
@@ -417,7 +417,7 @@ fn sweep_routine(
 /// backoff has elapsed.
 ///
 /// Retryable means `Failed` — a run-level failure *or* a synchronous dispatch
-/// failure ([ORB-00422]): `fire` records a `submit_pipeline_run` that returns
+/// failure: `fire` records a `submit_pipeline_run` that returns
 /// `Err` as `Failed` (not `Error`) precisely because nothing dispatched, so it
 /// is unambiguously safe to re-dispatch under the same slot. `Error` is
 /// reserved for the *ambiguous* case — a crashed sweep's stale intent reclaimed
@@ -528,7 +528,7 @@ fn fire(
         Err(error) => {
             // A synchronous dispatch failure means nothing was dispatched, so
             // record it as `Failed` — retryable under the same slot within
-            // `policy.retries` ([ORB-00422]) — rather than the terminal `Error`
+            // `policy.retries` — rather than the terminal `Error`
             // the outcome sync reserves for an ambiguous crash-orphaned intent.
             store.routine_mark_fire_outcome(
                 name,

--- a/crates/orbit-core/src/routines/tests/sweep.rs
+++ b/crates/orbit-core/src/routines/tests/sweep.rs
@@ -1,4 +1,4 @@
-//! Sweep-orchestration tests [ORB-00421]: exercise the fire / idempotency /
+//! Sweep-orchestration tests exercise the fire / idempotency /
 //! overlap / retry / outcome-sync logic in `routines/sweep.rs` that shipped
 //! untested in [ORB-10021].
 //!
@@ -382,7 +382,7 @@ fn sync_reclaims_stale_intent_and_dispatched_past_timeout() {
     );
 }
 
-// ---- dispatch-error retry [ORB-00422] -------------------------------------
+// ---- dispatch-error retry --------------------------------------------------
 
 #[test]
 fn dispatch_error_is_retry_eligible_under_the_same_slot() {

--- a/crates/orbit-engine/src/activity_job/agent_loop_driver.rs
+++ b/crates/orbit-engine/src/activity_job/agent_loop_driver.rs
@@ -12,7 +12,7 @@
 //! `ORBIT_V2_REPLAY_FIXTURE=<path>` scripts an arbitrary multi-turn sequence
 //! from a JSON fixture. Default builds ignore both variables.
 
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use std::path::Path;

--- a/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
@@ -1,4 +1,4 @@
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use std::collections::VecDeque;

--- a/crates/orbit-engine/src/activity_job/job_executor/concurrency.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/concurrency.rs
@@ -1,4 +1,4 @@
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use super::*;

--- a/crates/orbit-engine/src/activity_job/job_executor/exec_ctx.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/exec_ctx.rs
@@ -1,4 +1,4 @@
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use super::*;

--- a/crates/orbit-engine/src/activity_job/job_executor/fan_out.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/fan_out.rs
@@ -1,4 +1,4 @@
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use super::*;

--- a/crates/orbit-engine/src/activity_job/job_executor/mod.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/mod.rs
@@ -23,7 +23,7 @@
 //! `loop.did_not_converge`). The retry wrapper emits `step.retry` between
 //! attempts and `step.denied` when a denial bypasses retry.
 
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use std::collections::HashMap;

--- a/crates/orbit-engine/src/activity_job/job_executor/parallel.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/parallel.rs
@@ -1,4 +1,4 @@
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use super::*;

--- a/crates/orbit-engine/src/activity_job/job_executor/step.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/step.rs
@@ -94,7 +94,7 @@ pub(super) fn run_step_with_retry(
                 }
                 // Treat a "not-success-but-no-error" outcome as retryable:
                 // another attempt may succeed. This is the block-level outcome
-                // contract (ADR-0194), and the CLI agent-loop leaf reaches it
+                // contract, and the CLI agent-loop leaf reaches it
                 // for every provider-level failure — timeout, nonzero exit, and
                 // the [ORB-10449] step-completion protocol violation.
                 last_err = None;

--- a/crates/orbit-engine/src/activity_job/job_executor/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/target.rs
@@ -1,4 +1,4 @@
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use super::*;

--- a/crates/orbit-engine/src/activity_job/tool_enforcement.rs
+++ b/crates/orbit-engine/src/activity_job/tool_enforcement.rs
@@ -1,4 +1,4 @@
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use std::sync::{Arc, Mutex};

--- a/crates/orbit-engine/src/activity_job/workspace.rs
+++ b/crates/orbit-engine/src/activity_job/workspace.rs
@@ -667,7 +667,7 @@ fn primary_fast_forward_is_benign(
     before: &GitWorktreeFingerprint,
     after: &GitWorktreeFingerprint,
 ) -> Result<bool, DispatchError> {
-    // L-0110: linked-worktree shipment owns clean base fast-forwards; the
+    // Linked-worktree shipment owns clean base fast-forwards; the
     // provider boundary still rejects primary content/history drift.
     if before.head == after.head
         || before.branch != after.branch

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/git_ops.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/git_ops.rs
@@ -11,7 +11,7 @@ pub(super) fn git_commit_with_identity(
     message: &str,
     resolved_model: Option<&str>,
 ) -> Result<(), OrbitError> {
-    // L-0112 / ADR-0249: one persisted value drives both the ambient author
+    // ADR-0249: one persisted value drives both the ambient author
     // and prepare-commit-msg Agent-Model trailer. The generic fallback remains
     // commit-capable when a run has no resolved model.
     let author = resolved_model

--- a/crates/orbit-engine/src/executor/automation/vcs/push.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/push.rs
@@ -174,8 +174,7 @@ fn validate_rewrite_checkpoint(
     local_sha: &str,
     observed_remote_sha: Option<&str>,
 ) -> Result<(), OrbitError> {
-    // L-0089 / ADR-0225: divergence is safe only with the exact durable
-    // pre-rewrite remote SHA.
+    // Divergence is safe only with the exact durable pre-rewrite remote SHA.
     let rewritten = input
         .get("rewrite_performed")
         .and_then(Value::as_bool)

--- a/crates/orbit-engine/src/lib.rs
+++ b/crates/orbit-engine/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::print_stderr, clippy::print_stdout)]
 // ORB-00004: legacy execution-engine surfaces still need a focused documentation pass.
 #![allow(missing_docs)]
-// ORB-00013: Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
+// Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 #![allow(
     rustdoc::broken_intra_doc_links,

--- a/crates/orbit-engine/tests/v2_cli_backend.rs
+++ b/crates/orbit-engine/tests/v2_cli_backend.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Integration fixtures exercise public behavior and unwrap setup invariants.
+// Integration fixtures exercise public behavior and unwrap setup invariants.
 #![allow(
     clippy::expect_used,
     clippy::print_stderr,

--- a/crates/orbit-engine/tests/v2_job_runtime.rs
+++ b/crates/orbit-engine/tests/v2_job_runtime.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 #![cfg(feature = "replay")]
-// ORB-00013: Integration fixtures exercise public behavior and unwrap setup invariants.
+// Integration fixtures exercise public behavior and unwrap setup invariants.
 #![allow(
     clippy::expect_used,
     clippy::print_stderr,

--- a/crates/orbit-engine/tests/v2_name_resolution.rs
+++ b/crates/orbit-engine/tests/v2_name_resolution.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Integration fixtures exercise public behavior and unwrap setup invariants.
+// Integration fixtures exercise public behavior and unwrap setup invariants.
 #![allow(
     clippy::expect_used,
     clippy::print_stderr,

--- a/crates/orbit-engine/tests/v2_runtime.rs
+++ b/crates/orbit-engine/tests/v2_runtime.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 #![cfg(feature = "replay")]
-// ORB-00013: Integration fixtures exercise public behavior and unwrap setup invariants.
+// Integration fixtures exercise public behavior and unwrap setup invariants.
 #![allow(
     clippy::expect_used,
     clippy::print_stderr,

--- a/crates/orbit-exec/src/lib.rs
+++ b/crates/orbit-exec/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::print_stderr, clippy::print_stdout)]
 // ORB-00004: legacy process-execution surfaces still need a focused documentation pass.
 #![allow(missing_docs)]
-// ORB-00013: Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
+// Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 #![allow(
     rustdoc::broken_intra_doc_links,

--- a/crates/orbit-mcp/src/adapter/dispatch.rs
+++ b/crates/orbit-mcp/src/adapter/dispatch.rs
@@ -464,7 +464,7 @@ pub(super) fn session_context_from_initialize(
     request: &InitializeRequestParams,
     transport_meta: &rmcp::model::Meta,
 ) -> ToolSessionContext {
-    // ADR-0181: clients deliberately announce workspace through initialize `_meta`.
+    // Clients deliberately announce workspace through initialize `_meta`.
     //
     // rmcp's wire deserializer strips `_meta` out of the request params and
     // parks it on the request extensions (surfaced here as the request

--- a/crates/orbit-mcp/src/lib.rs
+++ b/crates/orbit-mcp/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::print_stderr, clippy::print_stdout)]
 // ORB-00004: internal MCP kernel surfaces still need a focused documentation pass.
 #![allow(missing_docs)]
-// ORB-00013: Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
+// Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 #![allow(
     rustdoc::broken_intra_doc_links,

--- a/crates/orbit-policy/src/lib.rs
+++ b/crates/orbit-policy/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::print_stderr, clippy::print_stdout)]
 // ORB-00004: legacy policy surfaces still need a focused documentation pass.
 #![allow(missing_docs)]
-// ORB-00013: Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
+// Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 #![allow(
     rustdoc::broken_intra_doc_links,

--- a/crates/orbit-remote/src/knowledge_broker.rs
+++ b/crates/orbit-remote/src/knowledge_broker.rs
@@ -7,9 +7,9 @@
 //! correlation contract that ties those two halves together.
 //!
 //! It is deliberately gated inactive for F2: public `orbit.adr.add` /
-//! `orbit.learning.add` stay on the standalone compatibility allocator until F3
-//! (ORB-10274) atomically disables the legacy authoring paths, enables global
-//! issuance, and wires the D3-selected owner-finalize capability to
+//! `orbit.learning.add` stay on the standalone compatibility allocator until
+//! broker preflight atomically disables the legacy authoring paths, enables
+//! global issuance, and wires the D3-selected owner-finalize capability to
 //! [`orbit_core::OrbitRuntime::finalize_preallocated_adr`] /
 //! `finalize_preallocated_learning` plus the correlated owner-finalization
 //! audit.

--- a/crates/orbit-remote/src/lib.rs
+++ b/crates/orbit-remote/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::print_stderr, clippy::print_stdout)]
 // ORB-00004: internal feature surfaces still need a focused documentation pass.
 #![allow(missing_docs)]
-// ORB-00013: Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
+// Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 #![allow(
     rustdoc::broken_intra_doc_links,

--- a/crates/orbit-remote/tests/dep_boundary.rs
+++ b/crates/orbit-remote/tests/dep_boundary.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Tests use unwrap/expect to keep fixture setup readable.
+// Tests use unwrap/expect to keep fixture setup readable.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::collections::BTreeSet;

--- a/crates/orbit-search/src/bin/orbit-search-companion.rs
+++ b/crates/orbit-search/src/bin/orbit-search-companion.rs
@@ -1,6 +1,6 @@
 // ORB-00004: legacy companion binary surfaces still need a focused documentation pass.
 #![allow(missing_docs)]
-// ORB-00013: Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
+// Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 #![allow(
     rustdoc::broken_intra_doc_links,

--- a/crates/orbit-search/src/embedder.rs
+++ b/crates/orbit-search/src/embedder.rs
@@ -5,7 +5,7 @@
 //! and self-describe via `model_id` / `dim` / `max_input_tokens`. The catalog
 //! pins the three fastembed-rs models the install command knows how to fetch.
 
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use orbit_common::types::OrbitError;

--- a/crates/orbit-search/src/lib.rs
+++ b/crates/orbit-search/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::print_stderr, clippy::print_stdout)]
 // ORB-00004: legacy semantic-indexing surfaces still need a focused documentation pass.
 #![allow(missing_docs)]
-// ORB-00013: Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
+// Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 #![allow(
     rustdoc::broken_intra_doc_links,

--- a/crates/orbit-search/tests/parity.rs
+++ b/crates/orbit-search/tests/parity.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Tests use unwrap/expect to keep fixture setup readable.
+// Tests use unwrap/expect to keep fixture setup readable.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 //! Behavioral parity smoke for the relocated VectorStore.

--- a/crates/orbit-store/src/file/adr_store/api/mod.rs
+++ b/crates/orbit-store/src/file/adr_store/api/mod.rs
@@ -1,4 +1,4 @@
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use std::fs;

--- a/crates/orbit-store/src/file/learning_store/api/crud.rs
+++ b/crates/orbit-store/src/file/learning_store/api/crud.rs
@@ -1,4 +1,4 @@
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use chrono::{DateTime, Utc};

--- a/crates/orbit-store/src/file/learning_store/api/lifecycle.rs
+++ b/crates/orbit-store/src/file/learning_store/api/lifecycle.rs
@@ -1,4 +1,4 @@
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use chrono::Utc;

--- a/crates/orbit-store/src/file/learning_store/api/mod.rs
+++ b/crates/orbit-store/src/file/learning_store/api/mod.rs
@@ -1,4 +1,4 @@
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 //! Split of the learning-store API surface (ORB-00116).

--- a/crates/orbit-store/src/file/learning_store/api/search_index.rs
+++ b/crates/orbit-store/src/file/learning_store/api/search_index.rs
@@ -1,4 +1,4 @@
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use std::sync::Arc;

--- a/crates/orbit-store/src/file/learning_store/api/store.rs
+++ b/crates/orbit-store/src/file/learning_store/api/store.rs
@@ -1,4 +1,4 @@
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use std::path::PathBuf;

--- a/crates/orbit-store/src/file/learning_store/api/validation.rs
+++ b/crates/orbit-store/src/file/learning_store/api/validation.rs
@@ -1,4 +1,4 @@
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 // ORB-10046: this module previously validated learning comment/vote JSONL

--- a/crates/orbit-store/src/file/scoreboard/duel_scoreboard/mod.rs
+++ b/crates/orbit-store/src/file/scoreboard/duel_scoreboard/mod.rs
@@ -22,7 +22,7 @@
 //!   because scores are recorded with the `TaskClass` built from git at
 //!   record time and the CLI never needs to touch git.
 
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::print_stderr, clippy::print_stdout)]
 // ORB-00004: legacy persistence surfaces still need a focused documentation pass.
 #![allow(missing_docs)]
-// ORB-00013: Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
+// Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 #![allow(
     rustdoc::broken_intra_doc_links,

--- a/crates/orbit-store/src/sqlite/task_registry/types.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/types.rs
@@ -70,7 +70,7 @@ pub struct TaskIndexFilter {
 /// [`validate_relation_targets_exist`](crate::sqlite::task_registry::TaskRegistryStore)
 /// rejects at index-rebuild time. These are the "grandfathered" relations that
 /// make an index rebuild fail its validator and fall back to a full bundle
-/// scan (see ORB-10305 / ORB-10246).
+/// scan (see ORB-10305).
 ///
 /// `relation_type` carries the canonical snake_case name as stored in the
 /// registry (`related_to`, `blocked_by`, …); non-`ORB-` targets (friction /

--- a/crates/orbit-tools/src/builtin/orbit/duel/plan_winner.rs
+++ b/crates/orbit-tools/src/builtin/orbit/duel/plan_winner.rs
@@ -1,4 +1,4 @@
-// ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
+// Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
 use orbit_common::types::{AgentFamily, OrbitError, RoleSlot, ToolParam, ToolSchema};

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -298,7 +298,7 @@ pub(super) fn resolve_workspace_argument(
     input: &mut Value,
     tool_name: &str,
 ) -> Result<String, OrbitError> {
-    // ADR-0181: MCP workspace defaults come from explicit session context, never process cwd.
+    // MCP workspace defaults come from explicit session context, never process cwd.
     let explicit = optional_string_alias(input, &["workspace"])?;
     let session = ctx
         .session_context

--- a/crates/orbit-tools/src/builtin/orbit/task/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add.rs
@@ -22,7 +22,7 @@ impl Tool for OrbitTaskAddTool {
                 param_type: "string".to_string(),
                 required: true,
             },
-            // ADR-0149: `workspace` is the binding key for ~/.orbit/tasks/workspaces/<id>/
+            // `workspace` is the binding key for ~/.orbit/tasks/workspaces/<id>/
             // home-store projection; ambient MCP session context may supply this field,
             // but process cwd must never be used as the fallback.
             ToolParam {

--- a/crates/orbit-tools/src/lib.rs
+++ b/crates/orbit-tools/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::print_stderr, clippy::print_stdout)]
 // ORB-00004: legacy tool-registry surfaces still need a focused documentation pass.
 #![allow(missing_docs)]
-// ORB-00013: Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
+// Unit tests use unwrap/expect for fixture setup; production call sites remain linted.
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 #![allow(
     rustdoc::broken_intra_doc_links,

--- a/crates/orbit-tools/tests/policy_deny_tracing.rs
+++ b/crates/orbit-tools/tests/policy_deny_tracing.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Tests use unwrap/expect to keep fixture setup readable.
+// Tests use unwrap/expect to keep fixture setup readable.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::collections::HashMap;

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-// ORB-00013: Tests use unwrap/expect to keep fixture setup readable.
+// Tests use unwrap/expect to keep fixture setup readable.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::collections::BTreeSet;


### PR DESCRIPTION
## Task

[ORB-10481](https://orbit-cli.com/tasks/ORB-10481) — Clean stale artifact citations from Orbit code comments

### Description

## Problem
ORB-10477 found dangling or stale artifact IDs in Orbit code comments: 70 ORB-00013 lint-rationale citations, unrecoverable learning/ADR citations, rejected-task deferrals, and legacy task IDs no longer present in any workspace registry. The inline technical claims generally remain useful, but the identifiers no longer provide retrievable authority.

## Scope
Clean comment and doc-comment citations only. Preserve the technical rationale and code behavior. Remove a dead half of a mixed citation while retaining any live artifact ID. Rewrite future-facing prose that promises rejected ORB-10274 work so it describes the current ORB-10364 gate and the actual remaining preflight invariant without inventing a successor task.

The low-value ORB-00388 references in metrics comments deliberately remain: those comments describe intentionally removed historical behavior, so rejected status is meaningful provenance rather than a dangling promise.

Do not edit user-facing error strings or test assertions merely because they contain an artifact ID. Do not mutate learning, ADR, task, or friction records in this task; the deterministic learning-scope repairs from ORB-10477 are being applied separately through the authoritative knowledge surface.

## Concurrency and safety
Another orchestrator may be active. Work only in the pipeline-created dedicated worktree, inspect the current diff before edits, and preserve unrelated concurrent changes.

### Acceptance Criteria

- All ORB-00013 comment citations are removed or replaced with self-contained lint rationale; the existing narrow allow attributes and code behavior are unchanged.
- Comments citing L-0089, L-0090, L-0110, L-0112, L-0028, ADR-0149, ADR-0181, ADR-0194, ADR-0211, or ADR-0225 retain their technical claim while removing only unresolvable IDs; live mixed citations such as ADR-0249 or ADR-0206 remain.
- Future-facing ORB-10274 comments no longer promise delivery from the rejected task and instead state the current gate/preflight invariant without inventing a task ID.
- ORB-10246 is removed from mixed ORB-10305 citations, legacy ORB-00420/00421/00422/00423 provenance is removed or replaced only where a real current successor is already established, and ORB-00388 historical-removal comments remain unchanged.
- make ci-fast passes and a comment-only artifact-ID sweep confirms no scoped stale citation was missed; non-comment strings and synthetic fixture IDs are not mechanically rewritten.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Removed all 70 ORB-00013 prefixes from scoped lint-rationale comments while preserving the associated narrow allow attributes and explanations.
- Removed unrecoverable learning and ADR citation IDs while retaining their inline technical claims; kept live mixed citations ADR-0249, ADR-0206, and ORB-10305.
- Reworded the ORB-10274 future-facing comments around the current broker preflight/caller-role-gate invariant, removed ORB-10246 and legacy ORB-00420–00423 provenance, and left ORB-00388 historical-removal comments unchanged.

Assessment: Comment-only cleanup across 90 already-scoped files; no behavior, assertions, or user-facing strings changed.

Validation:
- make ci-fast (passed)
- git diff --check (passed)
- targeted comment-only stale-ID sweep (no matches)
- diff audit confirmed changed lines are comments/doc-comments only.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10481-6a66a1e1`
- Behind base: 0
- Ahead of base: 1