### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/agent-families/1_overview.md
+++ b/docs/design/agent-families/1_overview.md
@@ -3,7 +3,8 @@ summary: "Agent Families — Overview"
 type: design
 title: "Agent Families — Overview"
 owner: grok
-last_updated: 2026-07-11
+last_updated: 2026-07-27
+last_validated: 2026-07-27
 status: Draft
 feature: agent-families
 doc_role: overview
@@ -23,7 +24,7 @@ Family defaults were originally also used to pick activity role models, but that
 ## 2. Core Concepts
 
 - **Agent Family:** A stable identifier such as `claude`, `codex`, `gemini`, or `grok` used for routing, attribution, and legacy model inference.
-- **Model Inference:** `agent_from_model()` and `infer_agent_family_from_model()` map concrete model strings to families. `infer_agent_family_from_model()` remains for legacy artifact recovery.
+- **Model Inference:** `agent_from_model()` and `provider_from_model()` in `crates/orbit-common/src/types/actor.rs`, together with `infer_agent_family_from_model()` in `crates/orbit-common/src/types/agent_pair.rs`, map concrete model strings to families and providers. `infer_agent_family_from_model()` remains for legacy artifact recovery.
 - **Crew:** A named provider-model-backend assignment loaded from `.orbit/config.toml` under `[crews.<name>]`; every activity role resolves to it.
 - **Default Crew:** `[workflow].default_crew` names the workspace fallback when a task does not specify `crew`.
 - **Executor:** A YAML definition in `crates/orbit-core/assets/executors/<family>.yaml` describing how to invoke an agent CLI.
@@ -33,14 +34,14 @@ Family defaults were originally also used to pick activity role models, but that
 
 | Concern | File | Task |
 |---------|------|------|
-| Family inference and crew resolver | `crates/orbit-common/src/types/agent_pair.rs` | [ORB-00042], [ORB-00058], [ORB-10130] |
+| Family inference and crew resolver | `crates/orbit-common/src/types/actor.rs`, `crates/orbit-common/src/types/agent_pair.rs` | [ORB-00042], [ORB-00058], [ORB-10130] |
 | Task-level crew field | `crates/orbit-common/src/types/task.rs` | [ORB-00058] |
 | Runtime config loading | `crates/orbit-core/src/config/runtime.rs` | [ORB-00058] |
 | Default config template | `crates/orbit-core/assets/config/default-config.toml` | [ORB-00058] |
 | Run-time crew resolution | `crates/orbit-core/src/runtime/engine/crew.rs` | [ORB-00058] |
 | Duel candidate and model config | `crates/orbit-core/src/config/runtime.rs` | [ORB-00072] |
 | Tool and CLI crew surfaces | `crates/orbit-tools/src/builtin/orbit/task/` | [ORB-00058] |
-| Grok family onboarding | `crates/orbit-common/src/types/agent_pair.rs` | [ORB-00042] |
+| Grok family onboarding | `crates/orbit-common/src/types/actor.rs`, `crates/orbit-common/src/types/agent_pair.rs` | [ORB-00042] |
 
 ## Task References
 

--- a/docs/design/agent-families/2_design.md
+++ b/docs/design/agent-families/2_design.md
@@ -3,7 +3,8 @@ summary: "Agent Families — Design"
 type: design
 title: "Agent Families — Design"
 owner: human
-last_updated: 2026-07-18
+last_updated: 2026-07-27
+last_validated: 2026-07-27
 status: Draft
 feature: agent-families
 doc_role: design
@@ -16,7 +17,7 @@ This document describes the current implementation of Orbit agent families, crew
 
 ## 1. Family Registry
 
-The family registry lives in `crates/orbit-common/src/types/agent_pair.rs`. `all_agent_families()` returns the supported family identifiers, while `agent_from_model()` and `infer_agent_family_from_model()` map model prefixes to those families. Prefix inference remains intentionally conservative because older persisted artifacts may only contain a model string.
+The family registry spans `crates/orbit-common/src/types/actor.rs` and `crates/orbit-common/src/types/agent_pair.rs`. `all_agent_families()` returns the supported family identifiers; `agent_from_model()` and `provider_from_model()` infer family and provider from model strings in `actor.rs`; and `infer_agent_family_from_model()` in `agent_pair.rs` remains the conservative recovery helper for older persisted artifacts.
 
 Adding a family is still a cross-cutting change: executor assets, sandbox behavior, provider inference, review automation, and scoreboard code all need review. The fixed registry forces that audit instead of silently accepting unknown families.
 
@@ -55,8 +56,7 @@ Duel-plan has an explicit `[duel]` section in `.orbit/config.toml`. `candidates`
 The duel model precedence is:
 
 1. `[duel.models.<family>]`
-2. `.orbit/executors/<family>.yaml::model_pair_override`
-3. `resolve_agent_model_pair()` builtin defaults
+2. `.orbit/executors/<family>.yaml::model_pair_override`, resolved through the executor-backed `resolved_agent_model_pair()` host method
 
 This precedence is scoped to duel role selection through `DeterministicActionHost::duel_orchestrator_model`; non-duel model identity, envelope rendering, review sync, and task-review scoring continue to start at executor overrides and builtin defaults.
 

--- a/docs/design/agent-families/3_vision.md
+++ b/docs/design/agent-families/3_vision.md
@@ -4,6 +4,7 @@ type: design
 title: "Agent Families — Vision"
 owner: human
 last_updated: 2026-07-11
+last_validated: 2026-07-27
 status: Draft
 feature: agent-families
 doc_role: vision

--- a/docs/design/agent-families/4_decisions.md
+++ b/docs/design/agent-families/4_decisions.md
@@ -3,7 +3,8 @@ summary: "Agent Families — Decisions"
 type: design
 title: "Agent Families — Decisions"
 owner: grok
-last_updated: 2026-07-11
+last_updated: 2026-07-27
+last_validated: 2026-07-27
 status: Draft
 feature: agent-families
 doc_role: decisions
@@ -75,9 +76,9 @@ See full ADR-0151 for context, alternatives considered, and cost analysis.
 
 ## ADR-0167 — Favor claude (opus) for planner role on planning duels and design-shaped plans
 
-**Status:** Proposed · 2026-05-18 · cites [AO-002](../../agent-observations/AO-002/observation.md) · (acceptance pending a related task — see [CONVENTIONS.md §4](../CONVENTIONS.md#4-adr-template-strict))
+**Status:** Proposed · 2026-05-18 · cites AO-002 · (acceptance pending a related task — see [CONVENTIONS.md §4](../CONVENTIONS.md#4-adr-template-strict))
 
-**Context.** AO-002 ([Instruction surface shapes plan output, not tool selection](../../agent-observations/AO-002/observation.md)) closed on 2026-05-18 after four experiments spanning four Gemini-as-planner implementation/audit duels and one 4-model cross-read on an identical UX-design task. Three observations recurred across the thread:
+**Context.** AO-002 ("Instruction surface shapes plan output, not tool selection") closed on 2026-05-18 after four experiments spanning four Gemini-as-planner implementation/audit duels and one 4-model cross-read on an identical UX-design task. Three observations recurred across the thread:
 
 - Gemini ranked last on plan depth on every task shape tested (implementation, audit, refactor, UX-taste), losing every duel it played as planner. Arbiter rationales consistently cited graph-discovery gaps, hallucinated symbols, generic findings, and thin ADR content.
 - Claude won every duel it entered as planner in the window, including the UX-redesign duel (ORB-00154), where claude's metric-major layout call was the differentiating taste signal. Codex placed in the middle — thorough plans without bold design calls, ranked above grok and gemini but below claude on plan depth in the 4-way UX comparison.

--- a/docs/design/auditability/1_overview.md
+++ b/docs/design/auditability/1_overview.md
@@ -3,7 +3,8 @@ summary: "Auditability — Overview"
 type: design
 title: "Auditability — Overview"
 owner: codex
-last_updated: 2026-07-18
+last_updated: 2026-07-27
+last_validated: 2026-07-27
 status: Draft
 feature: auditability
 doc_role: overview
@@ -38,13 +39,13 @@ The CLI audit middleware and runtime tool-dispatch paths write persistent `Audit
 
 MCP audit keeps legacy meanings stable: `host` is still the executing-process hostname, `session_id` is unchanged, and `job_run_id` remains canonical run correlation. Additive fields identify validated workspace, caller/process machines and display hosts, transport, the complete effective capability set, origin session, unique MCP call, and lease. Standalone calls are `unverified`; client JSON cannot populate trusted columns. [ORB-10228]
 
-### 2.3 Activity/job run traces are file-backed JSONL trees
+### 2.3 Activity/job run traces are SQLite-backed trees
 
-The v2 activity/job runtime emits `V2AuditEvent` envelopes for run, step, activity, fan-out, loop, filesystem, denial, and CLI-backend lifecycle events under `.orbit/state/audit/v2_loop/`. This layer is the workflow replay spine: it carries `run_id`, `event_id`, `parent_event_id`, `agent_identity`, and optional `workspace_path`. `orbit run events`, `orbit run trace`, `orbit run show -s`, and `orbit run logs -s` expose the same activity DAG `step.id` source of truth after [T20260426-0705] and [T20260426-0709].
+The v2 activity/job runtime emits `V2AuditEvent` envelopes for run, step, activity, fan-out, loop, filesystem, denial, and CLI-backend lifecycle events into the `v2_audit_events` SQLite store. This layer is the workflow replay spine: it carries `run_id`, `event_id`, `parent_event_id`, `agent_identity`, and optional `workspace_path`. `orbit run events`, `orbit run trace`, `orbit run show -s`, and `orbit run logs -s` expose the same activity DAG `step.id` source of truth after [T20260426-0705] and [T20260426-0709].
 
 ### 2.4 Agent-loop audit events preserve provider and tool detail
 
-The HTTP loop engine emits `LoopAuditEvent` records for sessions, HTTP requests/responses, tool requests/results, iteration boundaries, and policy denials. Loop JSONL materializes under `.orbit/state/audit/loop/` only once a run emits loop-level events; large request, response, input, and output bodies are stored as redacted content-addressed blobs under `.orbit/state/audit/blobs/`.
+The HTTP loop engine emits `LoopAuditEvent` records for sessions, HTTP requests/responses, tool requests/results, iteration boundaries, and policy denials. Loop events are persisted in the same `v2_audit_events` SQLite store only when emitted; large request, response, input, and output bodies are stored as redacted content-addressed blobs under `.orbit/state/audit/blobs/`.
 
 ### 2.5 Invocation metrics are adjacent, not a replacement
 
@@ -67,9 +68,9 @@ The default tracing subscriber appends redacted structured events to `~/.orbit/s
 | Audit design ownership | `docs/design/auditability/` | [T20260426-0605] |
 | Command audit records and queries | `crates/orbit-common/src/types/audit_event.rs`, `crates/orbit-cli/src/command/audit/`, `crates/orbit-store/src/sqlite/audit_event_store/` | [T20260426-0605] |
 | Remote MCP preflight, placement denials, and checkoutless global audit writes | `crates/orbit-remote/src/mcp/host.rs`, `crates/orbit-remote/src/lib.rs` | [ORB-10228], [ORB-10262], [ORB-10319] |
-| V2 activity/job envelopes and JSONL sink | `crates/orbit-common/src/types/activity_job/audit_envelope.rs`, `crates/orbit-engine/src/activity_job/audit_writer.rs` | [T20260419-0002], [T20260426-0519] |
+| V2 activity/job envelopes and SQLite sink | `crates/orbit-common/src/types/activity_job/audit_envelope.rs`, `crates/orbit-engine/src/activity_job/audit_writer.rs`, `crates/orbit-engine/src/activity_job/sqlite_sink.rs` | [T20260419-0002], [T20260426-0519] |
 | Run trace inspection CLI | `crates/orbit-cli/src/command/run/mod.rs`, `crates/orbit-core/src/runtime/run_audit.rs` | [T20260426-0705], [T20260426-0709] |
-| Loop audit events and blobs | `crates/orbit-agent/src/loop_engine/audit/mod.rs`, `crates/orbit-common/src/utility/blob_store.rs` | [T20260426-0605] |
+| Loop audit events and blobs | `crates/orbit-agent/src/loop_engine/audit/mod.rs`, `crates/orbit-engine/src/activity_job/sqlite_sink.rs`, `crates/orbit-common/src/utility/blob_store.rs` | [T20260426-0605] |
 | Redaction utilities | `crates/orbit-common/src/utility/redaction.rs` | [T20260426-0605], [T20260426-2349] |
 | Global tracing JSONL feed and live projections | `crates/orbit-common/src/utility/logging.rs`, selected FS/proc/task producers | [T20260426-2343], [T20260427-0023] |
 | Friction artifact feedback loop | `.orbit/frictions/`, `crates/orbit-store/src/file/friction_store/`, `crates/orbit-dashboard/src/api/frictions.rs` | [T20260510-13], [ORB-00062] |

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -3,7 +3,8 @@ summary: "Auditability — Design"
 type: design
 title: "Auditability — Design"
 owner: codex
-last_updated: 2026-07-26
+last_updated: 2026-07-27
+last_validated: 2026-07-27
 status: Draft
 feature: auditability
 doc_role: design
@@ -18,13 +19,12 @@ This document describes Orbit's shipped auditability implementation across comma
 
 ## 1. Storage Roots and Audit Channels
 
-Auditability is split across five channels:
+Auditability is split across four channels:
 
 1. **Command audit records.** SQLite rows in the configured audit database; queried through `orbit audit`.
-2. **V2 activity/job envelope events.** JSONL under `.orbit/state/audit/v2_loop/{run_id}.jsonl`.
-3. **Loop-level provider/tool events.** JSONL under `.orbit/state/audit/loop/{run_id}.jsonl`, created lazily when a run emits loop events.
-4. **Global tracing events.** Redacted JSONL under `~/.orbit/state/logs/orbit.jsonl`.
-5. **Invocation metrics.** SQLite records keyed by job run, activity, task, agent, model, usage, and tool-call summaries.
+2. **V2 activity/job and loop events.** SQLite rows in `v2_audit_events`, with loop rows created only when a run emits loop events; redacted content-addressed blobs remain under `.orbit/state/audit/blobs/`.
+3. **Global tracing events.** Redacted JSONL under `~/.orbit/state/logs/orbit.jsonl`.
+4. **Invocation metrics.** SQLite records keyed by job run, activity, task, agent, model, usage, and tool-call summaries.
 
 The split is deliberate: command rows stay compact and queryable; envelopes preserve workflow structure; loop audit preserves provider/tool detail; tracing gives operators a live feed before workspace context exists; metrics answer cost and scoreboard questions without scraping transcripts. [T20260426-0519] moved file-backed run traces under `.orbit/state/audit/` while command audit rows remained in SQLite.
 
@@ -69,17 +69,17 @@ After [T20260427-0023], selected canonical stores also project live tracing even
 
 `V2AuditEnvelope` lives in `crates/orbit-common/src/types/activity_job/audit_envelope.rs`. Each envelope carries `schemaVersion`, `event_type`, `event_id`, timestamp, `run_id`, `agent_identity`, optional `parent_event_id`, optional `workspace_path`, and a tagged `V2AuditEventKind`. Event families cover run, step, retry, skip, denial, join, fan-out/fan-in, loop, activity, filesystem, tool denial, CLI-backend delegation, and subprocess lifecycle. After [T20260508-8], `CliInvocationStarted` also records the resolved subprocess `cwd` when one is supplied by the Activity/Job workspace resolver.
 
-`V2AuditWriter` in `crates/orbit-engine/src/activity_job/audit_writer.rs` assigns event ids, maintains per-thread parent stacks, emits through `V2JsonlSink`, keeps a smoke-verification snapshot, and exposes the inner loop sink for provider/tool events. CLI-launched v2 runs stamp envelope `agent_identity` as `system`; concrete agent identity lives in activity configuration, CLI invocation events, and invocation metrics.
+`V2AuditWriter` in `crates/orbit-engine/src/activity_job/audit_writer.rs` assigns event ids, maintains per-thread parent stacks, emits through `V2SqliteSink` in `crates/orbit-engine/src/activity_job/sqlite_sink.rs`, keeps a smoke-verification snapshot, and exposes the inner loop sink for provider/tool events. CLI-launched v2 runs stamp envelope `agent_identity` as `system`; concrete agent identity lives in activity configuration, CLI invocation events, and invocation metrics.
 
-`crates/orbit-engine/src/activity_job/jsonl_sink.rs` appends one JSON object per line under `v2_loop/` and flushes per write. `crates/orbit-core/src/runtime/run_audit.rs` is the read-side accessor after [T20260426-0709], deriving activity DAG `step.id` values from `parent_event_id` ancestry and resolving CLI stdout/stderr blob references for `orbit run logs`. After [T20260508-14], the same accessor tolerates malformed read-side JSONL lines and missing blobs for dashboard inspection, returning partial per-step CLI invocation records with run id, event id, timestamp, step index, exit status, timeout, duration, provider, blob refs, and bounded stdout/stderr material.
+`V2SqliteSink` stores one serialized event payload per row in `v2_audit_events`. `crates/orbit-core/src/runtime/run_audit.rs` is the read-side accessor after [T20260426-0709], deriving activity DAG `step.id` values from `parent_event_id` ancestry and resolving CLI stdout/stderr blob references for `orbit run logs`. After [T20260508-14], the same accessor tolerates malformed stored event JSON and missing blobs for dashboard inspection, returning partial per-step CLI invocation records with run id, event id, timestamp, step index, exit status, timeout, duration, provider, blob refs, and bounded stdout/stderr material.
 
 ---
 
 ## 5. Loop-Level Provider and Tool Events
 
-`LoopAuditEvent` in `crates/orbit-agent/src/loop_engine/audit/mod.rs` covers session spawn/close, HTTP request/response, tool-call request/result, iteration boundary, and policy denial. `JsonlFileSink` creates `{audit_root}/loop/{run_id}.jsonl` lazily on the first loop event and writes payload blobs to `{audit_root}/blobs/`; runtime callers pass `.orbit/state/audit` as `audit_root`. [T20260506-2] removed zero-byte loop JSONL placeholders for runs that only emit v2 envelope events or CLI-backend blobs.
+`LoopAuditEvent` in `crates/orbit-agent/src/loop_engine/audit/mod.rs` covers session spawn/close, HTTP request/response, tool-call request/result, iteration boundary, and policy denial. `V2SqliteSink` persists loop events lazily into `v2_audit_events` and writes payload blobs to `{audit_root}/blobs/`; runtime callers pass `.orbit/state/audit` as `audit_root`. [T20260506-2] removed the old zero-byte loop JSONL placeholders for runs that only emit v2 envelope events or CLI-backend blobs.
 
-Loop events reference hashes for request bodies, response bodies, tool inputs, and tool outputs instead of embedding the bodies inline. This keeps event lines queryable while preserving replay material in redacted blob storage.
+Loop events reference hashes for request bodies, response bodies, tool inputs, and tool outputs instead of embedding the bodies inline. This keeps event rows queryable while preserving replay material in redacted blob storage.
 
 ---
 
@@ -89,7 +89,7 @@ Loop events reference hashes for request bodies, response bodies, tool inputs, a
 
 `crates/orbit-common/src/utility/redaction.rs` centralizes sensitive live environment value scrubbing plus regex-based HTTP/argv patterns for authorization headers, API keys, bearer tokens, JSON API-key fields, and high-confidence provider token shapes. CLI audit errors, blob bytes, selected pipeline outputs/errors, artifact write tools, and the default tracing subscriber all redact before persistence or terminal/JSONL output. Artifact tool coverage and refuse-vs-mask rules live in [specs/artifact-redaction.md](./specs/artifact-redaction.md). The smoke example `crates/orbit-agent/examples/redaction_smoke.rs` verifies stored blob bytes omit the raw secret and contain a marker.
 
-Dashboard log previews added by [T20260508-14] are derived views over `.orbit/state/audit/v2_loop` and `.orbit/state/audit/blobs`; they do not duplicate full transcripts into SQLite. Preview responses are byte- and line-capped, apply defensive read-time redaction with the shared redactor, and preserve existing write-time redaction markers. The focused diagnostics error feed is also derived, combining global ERROR tracing rows with structured `ERROR <target>:` lines found in agent stderr blobs. No `.orbit/state/diagnostics/errors/` store exists in this design; retention remains bounded by the existing v2 audit, blob, and global log retention roots.
+Dashboard log previews added by [T20260508-14] are derived views over the `v2_audit_events` SQLite store and `.orbit/state/audit/blobs`; they do not duplicate full transcripts into a separate transcript store. Preview responses are byte- and line-capped, apply defensive read-time redaction with the shared redactor, and preserve existing write-time redaction markers. The focused diagnostics error feed is also derived, combining global ERROR tracing rows with structured `ERROR <target>:` lines found in agent stderr blobs. No `.orbit/state/diagnostics/errors/` store exists in this design; retention remains bounded by the existing v2 audit, blob, and global log retention roots.
 
 ---
 
@@ -124,7 +124,7 @@ After [ORB-10338] (see [ADR-0245]), `InvocationInsertParams.trace` carries an op
 
 After [ORB-10370], CLI response parsing also fills `InvocationTrace.provider_model` and `provider_cost_usd` directly from provider-owned result metadata. Claude exposes a `modelUsage` map and `total_cost_usd`; when Claude reports its internal helper model beside the requested model, Orbit selects the unique highest-cost map entry and preserves its key verbatim. Gemini exposes an exact model key under `stats.models` but no invocation USD total; Orbit accepts it only when the map has one entry. Codex JSONL and Grok's JSON wrapper do not currently report either value, so they remain `None`. At SQLite ingest, a non-empty provider model wins over the configured request/alias and the configured model remains the fallback. A disagreement emits a retained `WARN` event under `orbit.core.invocation` with job run, activity, CLI, requested model, and provider model fields. This structured mismatch event was chosen instead of a second invocation column: it makes provider routing drift detectable under the default logging filter without migrating or backfilling rows, while `invocations.model` remains the exact model used for pricing and aggregation.
 
-The local dashboard exposes two read-only API surfaces for these traces after [T20260508-14]: `GET /api/runs/:id/logs` returns bounded per-step CLI invocation previews, and `GET /api/diagnostics/errors` returns recent process ERROR rows plus structured agent-stderr error rows sorted newest first. Both endpoints use existing dashboard limit conventions and tolerate missing v2 audit files, malformed lines, and missing blobs by returning empty or partial arrays.
+The local dashboard exposes two read-only API surfaces for these traces after [T20260508-14]: `GET /api/runs/:id/logs` returns bounded per-step CLI invocation previews, and `GET /api/diagnostics/errors` returns recent process ERROR rows plus structured agent-stderr error rows sorted newest first. Both endpoints use existing dashboard limit conventions and tolerate missing stored event rows, malformed event JSON, and missing blobs by returning empty or partial arrays.
 
 After [T20260428-11], compact `summary.json` counts all audited tool-run attempts and failed attempts from command-audit rows where `command: tool`, `subcommand` is `"run"` or `"run-mcp"`, and `tool_name` is present. Token totals still come from invocation/token scoreboards, with legacy tool-call totals used only as a max overlay to avoid obvious double counting.
 
@@ -144,13 +144,13 @@ Each record contains timestamp, level, target, and structured fields. After [T20
 
 ## 10. Concerns & Honest Limitations
 
-1. **Tamper evidence is promised more strongly than implemented.** SQLite rows and JSONL files do not yet have hash chains, signatures, or external transparency logs.
-2. **Audit is split across stores.** Command rows, v2 JSONL, loop JSONL, blobs, job-run state, and invocation metrics share ids but lack one joined operator command.
+1. **Tamper evidence is promised more strongly than implemented.** SQLite rows and JSONL tracing files do not yet have hash chains, signatures, or external transparency logs.
+2. **Audit is split across stores.** Command rows, v2/loop SQLite events, tracing JSONL, blobs, job-run state, and invocation metrics share ids but lack one joined operator command.
 3. **`orbit audit` does not audit itself.** That avoids recursion but leaves audit reads, exports, and prunes outside the normal guard.
 4. **Some command-audit fields are sparse.** `stdout_truncated`, `stderr_truncated`, and `session_id` often remain `None`.
 5. **CLI backend tool enforcement is weaker than HTTP.** Activity/job audit records the CLI backend allowlist as harness-delegated rather than enforcing Orbit-level tool denial semantics inside the provider path.
 6. **Redaction covers known secret shapes.** Environment-value and regex redaction reduce risk but cannot prove arbitrary user secrets are absent from every payload.
-7. **The global tracing feed is v1-simple.** It has no rotation and no cross-process line lock; readers should tolerate rare malformed lines if concurrent processes interleave large writes.
+7. **The global tracing feed is process-shared.** It is size-rotated and pruned on startup, but has no cross-process line lock; readers should tolerate rare malformed lines if concurrent processes interleave large writes.
 8. **Coverage is still expanding.** Some deterministic mutations write explicit audit rows; others rely on enclosing command/job context. The coverage matrix should become the review checklist for new mutation paths.
 
 ---


### PR DESCRIPTION
## Task

[ORB-10488](https://orbit-cli.com/tasks/ORB-10488) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Docs that have no frontmatter block at all are **out of the rotation**: do
not invent a frontmatter block for them, because `type` and `summary` are
required fields and guessing them corrupts the docs corpus. List them in
your execution summary instead so a human can decide.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and the docs you found with no frontmatter block.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- No frontmatter block was created for a doc that lacked one; such docs are listed instead.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Batch selection:
- Validated the six docs named by the task plan: the four frontmatter-bearing docs under docs/design/agent-families/ followed by docs/design/auditability/1_overview.md and 2_design.md. They were the missing-last_validated/oldest stable-path batch for this run.
- No files outside those six docs were modified. No .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was touched.

Changes and verification:
- docs/design/agent-families/1_overview.md: stamped last_updated and last_validated as 2026-07-27; corrected family/provider inference ownership and the at-a-glance source paths. Verified actor.rs, agent_pair.rs, runtime/config files, and referenced crew/tool paths with rg, sed, and ls.
- docs/design/agent-families/2_design.md: stamped both dates; corrected the registry source description and duel model precedence to match the executor-backed resolved_agent_model_pair host path. Verified raw/runtime config, bootstrap seeding, agent detection, crew resolution, task/tool surfaces, and duel host/role code with rg and sed.
- docs/design/agent-families/3_vision.md: stamped last_validated 2026-07-27 after verifying its internal links and referenced family/crew paths.
- docs/design/agent-families/4_decisions.md: stamped both dates and fixed the broken AO-002 link while retaining the historical decision text. Verified the referenced convention link and current family/crew implementation paths.
- docs/design/auditability/1_overview.md: stamped both dates; corrected v2 and loop persistence from legacy JSONL wording to the v2_audit_events SQLite store, added the SQLite sink to the source map, and verified audit/store/sink/blob/CLI paths.
- docs/design/auditability/2_design.md: stamped both dates; corrected the channel count, sink/store descriptions, dashboard read-side behavior, loop wording, and limitations to match V2SqliteSink, v2_audit_events, run_audit.rs, legacy import compatibility, and current CLI/dashboard routes.
- All six docs had frontmatter blocks; no doc or individual claim was stamped without repository-grounded checks. Historical task/ADR references were retained as provenance where they describe past implementations.

Docs found without a frontmatter block and left out of rotation:
docs/CONFIG.md, docs/LESSONS.md, docs/POSITIONING.md, docs/design/_templates/references/glossary.md, docs/design/_templates/specs/_mechanism.md, docs/design/activity-job/references/glossary.md, docs/design/activity-job/specs/audit-envelope.md, docs/design/activity-job/specs/backend-resolution.md, docs/design/agent-families/references/glossary.md, docs/design/auditability/references/glossary.md, docs/design/auditability/specs/artifact-redaction.md, docs/design/auditability/specs/coverage-matrix.md, docs/design/auditability/specs/event-schema.md, docs/design/auditability/specs/redaction-retention.md, docs/design/orbit-docs-plugin/1_scope.md, docs/design/orbit-graph/specs/GRAPH_SPEC.md, docs/design/policy-sandbox/references/glossary.md, docs/design/policy-sandbox/specs/fs-profile-resolution.md, docs/design/policy-sandbox/specs/sandbox-exec-contract.md, docs/design/project-learnings/references/glossary.md, docs/design/project-learnings/references/injection-layers.md, docs/design/remote-access/references/glossary.md, docs/design/remote-access/specs/ssh-tunnel.md, docs/design/task-artifacts/references/glossary.md, docs/design/task-artifacts/specs/task-bundle-v2.md, docs/design/user-interface/specs/theme.md, docs/runbooks/CONVENTIONS.md, docs/runbooks/audit-trail.md, docs/runbooks/database-recovery.md, docs/runbooks/health-checks.md, docs/runbooks/logging.md, docs/runbooks/release.md, docs/runbooks/state-and-backup.md, docs/runbooks/stuck-job-runs.md, docs/runbooks/upgrades.md.

Validation:
- git diff --check passed.
- make ci-fast passed (fmt check, doc index check, installer/dependency/import/stability/learning/artifact/changelog/error/orphan guardrails).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10488-6a66a6a9`
- Behind base: 0
- Ahead of base: 1