### PR TITLE
Ignore unrelated primary dirt when validating a benign fast-forward

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -1722,6 +1722,87 @@ fn non_fast_forward_primary_move_remains_a_typed_drift_failure() {
 }
 
 #[test]
+fn benign_primary_fast_forward_ignores_primary_dirt_disjoint_from_the_run() {
+    let fixture = linked_worktree_fixture();
+    let guard = boundary_guard(&fixture, "ORB-BENIGN-FF-DIRT", "run-benign-ff-dirt");
+
+    fs::write(fixture.assigned.join("candidate.txt"), "candidate\n").expect("write run candidate");
+    advance_primary(&fixture, "merged-pr.txt");
+    let unrelated = fixture.primary.join(".orbit/routines/worktree_gc.yaml");
+    fs::create_dir_all(unrelated.parent().expect("routines parent")).expect("create routines dir");
+    fs::write(&unrelated, "schemaVersion: 1\n").expect("write unrelated primary dirt");
+
+    let (result, events) = capture_events(|| guard.verify());
+    result.expect("an unrelated untracked primary path must not defeat a benign fast-forward");
+
+    assert!(
+        events.iter().any(|event| event
+            .field("ignored_primary_paths")
+            .is_some_and(|paths| paths.contains(".orbit/routines/worktree_gc.yaml"))),
+        "the accepted fast-forward must report the ignored primary path: {events:?}"
+    );
+    assert!(
+        unrelated.exists(),
+        "the guard must not clean the primary dirt it ignored"
+    );
+}
+
+#[test]
+fn primary_dirt_intersecting_the_run_defeats_a_fast_forward() {
+    for (kind, shared) in [("untracked", "shared-new.txt"), ("tracked", "README.md")] {
+        let fixture = linked_worktree_fixture();
+        let run_id = format!("run-{kind}-interference");
+        let task_id = format!("ORB-{}-INTERFERENCE", kind.to_ascii_uppercase());
+        let guard = boundary_guard(&fixture, &task_id, &run_id);
+
+        fs::write(fixture.assigned.join(shared), "run candidate\n").expect("write run candidate");
+        advance_primary(&fixture, "merged-pr.txt");
+        fs::write(fixture.primary.join(shared), "primary escape\n").expect("write primary escape");
+
+        let error = guard
+            .verify()
+            .expect_err("primary dirt on a path the run touched must fail closed");
+
+        assert_worktree_integrity_error(
+            &error,
+            "primary_checkout_drift",
+            (&task_id, &run_id, "codex"),
+            &fixture,
+            shared,
+        );
+        assert_eq!(
+            worktree_integrity_diagnostic(&error)["conflicting_paths"],
+            serde_json::json!([shared]),
+            "{kind} interference must be named as a conflicting path"
+        );
+    }
+}
+
+#[test]
+fn primary_branch_switch_remains_a_typed_drift_failure() {
+    let fixture = linked_worktree_fixture();
+    let guard = boundary_guard(&fixture, "ORB-PRIMARY-BRANCH", "run-primary-branch");
+
+    fs::write(fixture.assigned.join("candidate.txt"), "candidate\n").expect("write run candidate");
+    git_ok(
+        &fixture.primary,
+        &["checkout", "-b", "orbit-primary-switch"],
+    );
+
+    let error = guard
+        .verify()
+        .expect_err("a primary branch switch must remain fail closed");
+
+    assert_worktree_integrity_error(
+        &error,
+        "primary_checkout_drift",
+        ("ORB-PRIMARY-BRANCH", "run-primary-branch", "codex"),
+        &fixture,
+        "<branch-ref>",
+    );
+}
+
+#[test]
 fn primary_escape_is_checked_after_nonzero_exit_and_timeout() {
     for (terminal, trailer, timeout) in [
         ("nonzero", "exit 23", Duration::from_secs(5)),
@@ -1806,6 +1887,37 @@ fn linked_worktree_fixture() -> LinkedWorktreeFixture {
         assigned: assigned.canonicalize().expect("canonical assigned"),
         temp,
     }
+}
+
+/// Capture a boundary guard over the fixture's validated linked-worktree pair.
+fn boundary_guard(
+    fixture: &LinkedWorktreeFixture,
+    task_id: &str,
+    run_id: &str,
+) -> WorktreeBoundaryGuard {
+    let input = worktree_input(fixture, task_id);
+    let pair =
+        validate_declared_worktree_pair(&input, None, run_id, "codex", Some(&fixture.primary))
+            .expect("validate declared pair")
+            .expect("linked worktree pair");
+    WorktreeBoundaryGuard::capture(
+        &input,
+        None,
+        run_id,
+        "codex",
+        Some(&fixture.assigned),
+        Some(&fixture.primary),
+        Some(&pair),
+    )
+    .expect("capture boundary guard")
+    .expect("boundary guard enabled")
+}
+
+/// Fast-forward the registered primary the way a merged sibling PR does.
+fn advance_primary(fixture: &LinkedWorktreeFixture, path: &str) {
+    fs::write(fixture.primary.join(path), "merged\n").expect("write merged PR file");
+    git_ok(&fixture.primary, &["add", "--", path]);
+    git_ok(&fixture.primary, &["commit", "-m", "merge sibling PR"]);
 }
 
 fn git_ok(repo: &Path, args: &[&str]) {

--- a/crates/orbit-engine/src/activity_job/workspace.rs
+++ b/crates/orbit-engine/src/activity_job/workspace.rs
@@ -563,10 +563,11 @@ impl WorktreeBoundaryGuard {
 
     /// Compare both monitored checkouts after the provider reaches any
     /// terminal outcome. An externally advanced primary branch is benign when
-    /// it is a clean fast-forward: linked worktrees keep their own HEAD, and
-    /// the shipment rebase checkpoint owns reconciliation with the new base.
-    /// Primary rewrites/content mutation and history changes in the assigned
-    /// worktree remain typed, fail-closed violations.
+    /// it is a proven same-branch fast-forward that did not disturb any path
+    /// this run touched: linked worktrees keep their own HEAD, and the
+    /// shipment rebase checkpoint owns reconciliation with the new base.
+    /// Primary rewrites, primary dirt overlapping the run, and history changes
+    /// in the assigned worktree remain typed, fail-closed violations.
     pub(crate) fn verify(self) -> Result<(), DispatchError> {
         let assigned_after = git_fingerprint(&self.assigned_root)?;
         let primary_after = git_fingerprint(&self.primary_root)?;
@@ -576,9 +577,15 @@ impl WorktreeBoundaryGuard {
             changed_paths(&self.assigned_root, &self.assigned_before, &assigned_after);
         let primary_changed_paths =
             changed_paths(&self.primary_root, &self.primary_before, &primary_after);
-        let conflicting_paths = run_changed_paths
+        // Interference is judged against the primary's *dirt*, not against the
+        // commits a fast-forward brought in: a merged sibling PR that touched
+        // the same file the run touched is base advance, which the shipment
+        // rebase checkpoint reconciles, not a boundary violation.
+        let primary_dirt_paths = primary_dirt_mutations(&self.primary_before, &primary_after);
+        let run_path_index = run_changed_paths.iter().collect::<BTreeSet<_>>();
+        let conflicting_paths = primary_dirt_paths
             .iter()
-            .filter(|path| primary_changed_paths.contains(path))
+            .filter(|path| run_path_index.contains(path))
             .cloned()
             .collect::<Vec<_>>();
 
@@ -589,6 +596,7 @@ impl WorktreeBoundaryGuard {
                 &primary_after,
                 &run_changed_paths,
                 &primary_changed_paths,
+                &primary_dirt_paths,
                 &conflicting_paths,
                 "the assigned worktree history or branch changed during implementation",
             ));
@@ -598,15 +606,19 @@ impl WorktreeBoundaryGuard {
             return Ok(());
         }
 
-        if primary_fast_forward_is_benign(&self.primary_root, &self.primary_before, &primary_after)?
-        {
+        if primary_fast_forward_is_benign(
+            &self.primary_root,
+            &self.primary_before,
+            &primary_after,
+            &conflicting_paths,
+        )? {
             tracing::info!(
                 target: "orbit.engine.cli_runner",
                 task_id = %self.task_id,
                 run_id = %self.run_id,
                 primary_before = %self.primary_before.head,
                 primary_after = %primary_after.head,
-                conflicting_paths = ?conflicting_paths,
+                ignored_primary_paths = ?primary_dirt_paths,
                 "accepted concurrent primary fast-forward; shipment base synchronization owns reconciliation"
             );
             return Ok(());
@@ -618,6 +630,7 @@ impl WorktreeBoundaryGuard {
             &primary_after,
             &primary_changed_paths,
             &primary_changed_paths,
+            &primary_dirt_paths,
             &conflicting_paths,
             "the registered primary checkout changed without a clean same-branch fast-forward",
         ))
@@ -631,6 +644,7 @@ impl WorktreeBoundaryGuard {
         primary_after: &GitWorktreeFingerprint,
         reported_paths: &[String],
         primary_changed_paths: &[String],
+        primary_dirt_paths: &[String],
         conflicting_paths: &[String],
         reason: &str,
     ) -> DispatchError {
@@ -647,6 +661,7 @@ impl WorktreeBoundaryGuard {
             "changed_paths": reported_paths,
             "run_changed_paths": changed_paths(&self.assigned_root, &self.assigned_before, assigned_after),
             "primary_changed_paths": primary_changed_paths,
+            "primary_dirt_paths": primary_dirt_paths,
             "conflicting_paths": conflicting_paths,
             "assigned_changed": assigned_after != &self.assigned_before,
             "assigned_before": self.assigned_before,
@@ -666,16 +681,15 @@ fn primary_fast_forward_is_benign(
     root: &Path,
     before: &GitWorktreeFingerprint,
     after: &GitWorktreeFingerprint,
+    conflicting_paths: &[String],
 ) -> Result<bool, DispatchError> {
-    // Linked-worktree shipment owns clean base fast-forwards; the
-    // provider boundary still rejects primary content/history drift.
-    if before.head == after.head
-        || before.branch != after.branch
-        || before.dirty_paths != after.dirty_paths
-        || before.path_states != after.path_states
-        || before.tracked_patch_sha256 != after.tracked_patch_sha256
-        || before.untracked_content != after.untracked_content
-    {
+    // Linked-worktree shipment owns clean base fast-forwards; the provider
+    // boundary still rejects primary rewrites and any primary dirt that lands
+    // on a path this run touched. Primary dirt disjoint from the run — a
+    // concurrent Orbit process dropping an unrelated file, for instance — is
+    // not interference and must not convert a benign base advance into
+    // primary_checkout_drift (F2026-07-139).
+    if before.head == after.head || before.branch != after.branch || !conflicting_paths.is_empty() {
         return Ok(false);
     }
     Ok(git_output_raw(
@@ -684,6 +698,42 @@ fn primary_fast_forward_is_benign(
     )?
     .status
     .success())
+}
+
+/// Paths whose working-state identity in a checkout actually changed, judged
+/// independently of HEAD movement.
+///
+/// `staged_patch_sha256` is deliberately excluded: it is a diff against HEAD,
+/// so a concurrent fast-forward alone rewrites it for every already-dirty path
+/// even though nobody touched the file. `index_entry_sha256` carries the same
+/// staged content identity without that dependency.
+fn primary_dirt_mutations(
+    before: &GitWorktreeFingerprint,
+    after: &GitWorktreeFingerprint,
+) -> Vec<String> {
+    fn dirt_identity(
+        state: &GitPathState,
+    ) -> (&Option<String>, &Option<String>, bool, &Option<String>) {
+        (
+            &state.index_entry_sha256,
+            &state.worktree_patch_sha256,
+            state.worktree_present,
+            &state.untracked_content_sha256,
+        )
+    }
+
+    before
+        .path_states
+        .keys()
+        .chain(after.path_states.keys())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .filter(|path| {
+            before.path_states.get(*path).map(dirt_identity)
+                != after.path_states.get(*path).map(dirt_identity)
+        })
+        .cloned()
+        .collect()
 }
 
 fn declared_workspace_path(input: &Value, task_ctx: Option<&Value>) -> Option<String> {

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Design"
 type: design
 title: "Activity / Job — Design"
 owner: codex
-last_updated: 2026-07-26
+last_updated: 2026-07-27
 last_validated: 2026-07-26
 status: Draft
 feature: activity-job
@@ -154,7 +154,9 @@ After [ORB-10363], `JobV2.failure_activity` is a terminal, best-effort hook dist
 
 After [ORB-10385] / [ADR-0252], a job's reachable deterministic actions are checked against the executing runtime before its first step runs. `V2RuntimeHost::has_deterministic_action` reports the host's registry; `validate_job_deterministic_actions` walks the job's `recovery_activity`, `failure_activity`, every step's `recovery_activity`, and every resolved deterministic target (recursing through `parallel:`, `fan_out:`, and `loop:`) and fails the run with `DeterministicActionUnavailable` naming both the activity and the action. Because the check runs inside `execute_job_with_resume` ahead of step one, the run never reaches `worktree_setup`, so no task is admitted and no worktree is created. Unknown actions are never skipped, and the default trait implementation reports `true`, so a host that cannot enumerate its registry keeps surfacing the miss at dispatch. The gate does not weaken the failure hook: an action that becomes unavailable after admission still leaves the original failed-step error authoritative.
 
-The linked-worktree boundary guard now treats a clean same-branch primary fast-forward as concurrent base movement, not provider escape. The assigned checkout retains its own HEAD, so the later `pr_prepare`/`git_rebase` checkpoints reconcile that movement. Primary resets, force-moves, branch switches, or working-content mutations surface as `primary_checkout_drift`; history or branch movement inside the assigned worktree surfaces as `worktree_content_conflict`. Conflict diagnostics report `run_changed_paths`, `primary_changed_paths`, and their `conflicting_paths` separately instead of presenting the primary's entire moved set as the task's conflict.
+The linked-worktree boundary guard now treats a clean same-branch primary fast-forward as concurrent base movement, not provider escape. The assigned checkout retains its own HEAD, so the later `pr_prepare`/`git_rebase` checkpoints reconcile that movement. Primary resets, force-moves, and branch switches surface as `primary_checkout_drift`; history or branch movement inside the assigned worktree surfaces as `worktree_content_conflict`. Conflict diagnostics report `run_changed_paths`, `primary_changed_paths`, and their `conflicting_paths` separately instead of presenting the primary's entire moved set as the task's conflict.
+
+After [ORB-10471] / [ADR-0292], whether primary working-content counts against that fast-forward is decided by interference with the run, not by byte-identity of the whole primary dirty state. The guard derives `primary_dirt_paths` — the paths whose index entry, index-to-worktree patch, worktree presence, or untracked blob identity actually moved — deliberately excluding the HEAD-relative `staged_patch_sha256`, which a fast-forward alone rewrites for every already-dirty path. `conflicting_paths` is that dirt intersected with `run_changed_paths`, so a merged sibling PR touching a file the run also touched stays base movement rather than a conflict. A fast-forward is accepted only when it is a proven same-branch ancestor advance *and* that intersection is empty; the ignored dirt is named in the acceptance log as `ignored_primary_paths` and in every drift diagnostic as `primary_dirt_paths`. This closes friction F2026-07-139, where one unrelated untracked primary file turned a benign base advance into `primary_checkout_drift` after valid implementation.
 
 PR creation is restartable within its own checkpoint. `pr_open` first looks up the open PR by head branch; only the explicit no-PR result permits `github.pr.create`. If creation succeeds but PR view or local step-output persistence fails, the retry finds that same external PR and returns it as reused. `pr_promote` then idempotently applies the GitHub PR external ref and the per-task implementation attribution before moving tasks to `review`.
 
@@ -659,6 +661,7 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[ORB-00075]** — Unify ship aliases into async `orbit run ship`.
 - **[ORB-10002]** — Job-run checkpoint/resume: per-step `PipelineState` checkpoints, the terminal `interrupted` state for orphaned runs, workspace-open orphan scan, and `orbit job resume`.
 - **[ORB-10470]** — Make resume a detached submission whose worker resumes from the run's own checkpoints, and reconcile blocked/re-stamped tasks against the run's explicit retry lineage ([ADR-0289]).
+- **[ORB-10471]** — Judge a primary fast-forward against the dirt that interferes with the run instead of the primary's whole dirty state ([ADR-0292]).
 - **[T20260509-30]** — Resolve the macOS `sandbox-exec` wrapper from a trusted absolute path before CLI spawn.
 - **[T20260509-38]** — Run legacy parallel-batch workers through cancellable pipeline runs so timeout failure paths return promptly.
 - **[T20260509-40]** — Run CLI subprocesses in killable process groups and bound timeout-path output reader joins.

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Decisions"
 type: design
 title: "Activity / Job — Decisions"
 owner: codex
-last_updated: 2026-07-26
+last_updated: 2026-07-27
 last_validated: 2026-07-26
 status: Draft
 feature: activity-job
@@ -809,8 +809,17 @@ Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.
 
 ---
 
+## ADR-0292 — Primary fast-forward acceptance is decided by interference with the run, not primary dirty-state byte-identity
+
+**Status:** Proposed · 2026-07 · [ORB-10471]
+
+Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.show --input '{"id":"ADR-0292"}'`.
+
+---
+
 ## Task References
 
+- **[ORB-10471]** — Scope the worktree boundary guard's primary dirt check to paths the run touched, so unrelated primary dirt no longer defeats a benign fast-forward ([ADR-0292]).
 - **[ORB-10470]** — Make resume submit a detached run that starts at the failed checkpoint, and reconcile blocked/re-stamped tasks against the run's retry lineage ([ADR-0289]).
 - **[ORB-10467]** — Require independent review to reconcile late task authority and every acceptance criterion ([ADR-0288]).
 - **[ORB-10456]** — Resolve provider launchers at the shared CLI spawn boundary and add provider-aware missing-launcher diagnostics ([ADR-0259]).


### PR DESCRIPTION
## Task

[ORB-10471](https://orbit-cli.com/tasks/ORB-10471) — Ignore unrelated primary dirt when validating a benign fast-forward

### Description

## Problem
WorktreeBoundaryGuard accepts a primary fast-forward only when every primary dirty-state field is byte-identical before/after. An unrelated new untracked path therefore converts an otherwise-benign fast-forward into primary_checkout_drift after valid implementation (F2026-07-139).

## Evidence
F2026-07-139 records primary 4dddd94→1691ec4 as a proven ancestor fast-forward plus unrelated .orbit/routines/worktree_gc.yaml. Current workspace.rs compares dirty_paths, path_states, tracked_patch_sha256, and untracked_content globally before checking ancestry.

## Scope
Scope dirt checks to interference with the assigned run while retaining fail-closed behavior for rewrites and overlapping tracked mutations.


### Acceptance Criteria

- A clean primary fast-forward plus a disjoint new untracked path is accepted and reports the ignored path as audit metadata.
- A primary tracked or untracked mutation intersecting the run changed paths still fails with conflicting_paths.
- Branch switches, resets/non-fast-forwards, and overlapping tracked patch changes remain typed integrity failures.

## Execution Summary

<details>
<summary>Click to expand</summary>

Scoped the linked-worktree boundary guard's primary dirt check to interference with the assigned run, so an unrelated new untracked primary path no longer converts a benign fast-forward into primary_checkout_drift (F2026-07-139).

Implementation (crates/orbit-engine/src/activity_job/workspace.rs):
- Added `primary_dirt_mutations`, deriving the paths whose HEAD-independent working-state identity moved: `index_entry_sha256`, `worktree_patch_sha256` (index-to-worktree), `worktree_present`, and `untracked_content_sha256`. `staged_patch_sha256` is deliberately excluded because it is a diff against HEAD, so a fast-forward alone rewrites it for every already-dirty path; `index_entry_sha256` carries the same staged content identity without that dependency.
- Redefined `conflicting_paths` as `primary_dirt_paths INTERSECT run_changed_paths` (previously `run_changed_paths INTERSECT primary_changed_paths`), so commits a fast-forward carried are treated as base movement the shipment rebase checkpoint reconciles, not as conflicts.
- `primary_fast_forward_is_benign` now takes `conflicting_paths` and replaces the four global byte-identity comparisons (dirty_paths, path_states, tracked_patch_sha256, untracked_content) with: same branch, HEAD actually moved, empty conflicting_paths, and a proven `merge-base --is-ancestor` advance. Everything else stays fail-closed.
- Diagnostics/observability: integrity diagnostics gained `primary_dirt_paths` alongside the existing `primary_changed_paths` and `conflicting_paths`; the acceptance log now names the tolerated dirt as `ignored_primary_paths`.

Tests (crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs), one per acceptance criterion, plus `boundary_guard`/`advance_primary` helpers:
- `benign_primary_fast_forward_ignores_primary_dirt_disjoint_from_the_run` — clean FF plus a disjoint new untracked `.orbit/routines/worktree_gc.yaml` is accepted, the ignored path is reported as `ignored_primary_paths`, and the guard does not clean it.
- `primary_dirt_intersecting_the_run_defeats_a_fast_forward` — table-driven over untracked and tracked (README.md) primary mutation on a path the run touched; both still fail with `primary_checkout_drift` and name the path in `conflicting_paths`.
- `primary_branch_switch_remains_a_typed_drift_failure` — a primary branch switch remains typed drift. Existing `non_fast_forward_primary_move_remains_a_typed_drift_failure` (reset --hard) and `assigned_history_divergence_is_a_typed_worktree_content_conflict` continue to pass unmodified.

Docs updated in the same change: docs/design/activity-job/2_design.md (interference-based acceptance paragraph + ORB-10471 task reference, last_updated bumped) and docs/design/activity-job/4_decisions.md (ADR-0292 entry + task reference). ADR-0292 'Primary fast-forward acceptance is decided by interference with the run, not primary dirty-state byte-identity' is in the ADR store (status proposed), and records both rejected alternatives (untracked-only carve-out; dropping the dirt check under a proven FF) and the cost: under a concurrent proven fast-forward, a provider escape writing a primary path disjoint from everything the run touched is now accepted-and-logged rather than failing the run.

Validation: `cargo test -p orbit-engine --lib activity_job::cli_runner` — 76 passed, 0 failed. `cargo clippy -p orbit-engine --all-targets` — clean (the only warning is a pre-existing `needless_borrow` in orbit-store, untouched by this task). `make ci-fast` — all guardrails passed. No new dependencies, no new crate edges, no files changed outside the task's context_files.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10471-6a66a750`
- Behind base: 0
- Ahead of base: 1