### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/auditability/3_vision.md
+++ b/docs/design/auditability/3_vision.md
@@ -4,6 +4,7 @@ type: design
 title: "Auditability — Vision"
 owner: codex
 last_updated: 2026-07-18
+last_validated: 2026-07-27
 status: Draft
 feature: auditability
 doc_role: vision

--- a/docs/design/auditability/4_decisions.md
+++ b/docs/design/auditability/4_decisions.md
@@ -4,6 +4,7 @@ type: design
 title: "Auditability — Decisions"
 owner: codex
 last_updated: 2026-07-26
+last_validated: 2026-07-27
 status: Draft
 feature: auditability
 doc_role: decisions

--- a/docs/design/auto-tasks/1_overview.md
+++ b/docs/design/auto-tasks/1_overview.md
@@ -2,6 +2,7 @@
 title: Auto-tasks — Overview
 owner: claude
 last_updated: 2026-07-26
+last_validated: 2026-07-27
 status: Accepted
 feature: auto-tasks
 doc_role: overview
@@ -90,7 +91,7 @@ becomes just the first definition.
 - ORB-10148 — qa-sweep V1 (first definition; depends on this).
 - ORB-10318 — learning-deprecation-review definition (report-only stale-learning review; superseded by ORB-10348).
 - ORB-10348 — Generalized the definition into artifact-deprecation-review, adding the comment-reference sweep.
-- ORB-10439 — `orbit auto-task generate <name>`, the on-demand manual mint.
+- ORB-10439 — `orbit auto-task mint <name>`, the on-demand manual mint.
 - ORB-10440 — Daily friction-curation definition.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/auto-tasks/2_design.md
+++ b/docs/design/auto-tasks/2_design.md
@@ -2,6 +2,7 @@
 title: Auto-tasks — Design
 owner: claude
 last_updated: 2026-07-26
+last_validated: 2026-07-27
 status: Accepted
 feature: auto-tasks
 doc_role: design

--- a/docs/design/auto-tasks/3_vision.md
+++ b/docs/design/auto-tasks/3_vision.md
@@ -2,6 +2,7 @@
 title: Auto-tasks — Vision
 owner: claude
 last_updated: 2026-07-12
+last_validated: 2026-07-27
 status: Accepted
 feature: auto-tasks
 doc_role: vision

--- a/docs/design/auto-tasks/4_decisions.md
+++ b/docs/design/auto-tasks/4_decisions.md
@@ -2,6 +2,7 @@
 title: Auto-tasks — Decisions
 owner: claude
 last_updated: 2026-07-26
+last_validated: 2026-07-27
 status: Accepted
 feature: auto-tasks
 doc_role: decisions


### PR DESCRIPTION
## Task

[ORB-10490](https://orbit-cli.com/tasks/ORB-10490) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Docs that have no frontmatter block at all are **out of the rotation**: do
not invent a frontmatter block for them, because `type` and `summary` are
required fields and guessing them corrupts the docs corpus. List them in
your execution summary instead so a human can decide.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and the docs you found with no frontmatter block.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- No frontmatter block was created for a doc that lacked one; such docs are listed instead.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Batch selection: The six oldest in-scope documents with no last_validated key, ordered by path tie-break, were docs/design/auditability/3_vision.md, docs/design/auditability/4_decisions.md, docs/design/auto-tasks/1_overview.md, docs/design/auto-tasks/2_design.md, docs/design/auto-tasks/3_vision.md, and docs/design/auto-tasks/4_decisions.md. Their frontmatter was stamped with last_validated: 2026-07-27. The task context_files was updated before editing to name exactly these six targets.

Changes and verification:
- auditability/3_vision.md: verified the referenced auditability implementation anchors and paths with rg across crates and the linked design docs; no prose changes.
- auditability/4_decisions.md: verified current audit command/runtime, v2 envelope, loop event, SQLite, tracing, dashboard, and provenance anchors with rg across crates; verified ADR-0286 with orbit.adr.show. No prose changes. The historical ADR-008 April cost note was preserved because this append-only decision log records its historical context; current rotation behavior is implemented in crates/orbit-common/src/utility/log_rotation.rs.
- auto-tasks/1_overview.md: verified the schema, loader, due math, cursor, scheduler, CRUD, CLI, deterministic action, seeded assets, and shipped definitions with rg/source inspection. Corrected the stale ORB-10439 reference from orbit auto-task generate to orbit auto-task mint.
- auto-tasks/2_design.md: verified the documented implementation against crates/orbit-common/src/types/auto_task.rs, crates/orbit-core/src/auto_tasks/, CLI mint wiring, assets, and ORB-10472 task/ADR context; only frontmatter changed.
- auto-tasks/3_vision.md: verified its shipped-surface boundary and routine/auto-task references against current source and assets; only frontmatter changed.
- auto-tasks/4_decisions.md: verified the recorded auto-task schema/scheduler/CLI/worktree-local routing against current source, assets, ORB-10472, and ADR-0286; only frontmatter changed.
- No unverifiable current claim required modification; speculative questions and historical/external references were left intact.

Docs with no frontmatter block (reported and left untouched): docs/CONFIG.md, docs/LESSONS.md, docs/POSITIONING.md, docs/design/_templates/references/glossary.md, docs/design/_templates/specs/_mechanism.md, docs/design/activity-job/references/glossary.md, docs/design/activity-job/specs/audit-envelope.md, docs/design/activity-job/specs/backend-resolution.md, docs/design/agent-families/references/glossary.md, docs/design/auditability/references/glossary.md, docs/design/auditability/specs/artifact-redaction.md, docs/design/auditability/specs/coverage-matrix.md, docs/design/auditability/specs/event-schema.md, docs/design/auditability/specs/redaction-retention.md, docs/design/host-registry/references/glossary.md, docs/design/mcp-bridge/references/conformance-v1.yaml, docs/design/mcp-bridge/references/glossary.md, docs/design/orbit-docs-plugin/1_scope.md, docs/design/orbit-graph/specs/GRAPH_SPEC.md, docs/design/orbit-graph/specs/selector_corpus.txt, docs/design/policy-sandbox/references/glossary.md, docs/design/policy-sandbox/specs/fs-profile-resolution.md, docs/design/policy-sandbox/specs/sandbox-exec-contract.md, docs/design/project-learnings/references/glossary.md, docs/design/project-learnings/references/injection-layers.md, docs/design/remote-access/references/glossary.md, docs/design/remote-access/specs/ssh-tunnel.md, docs/design/task-artifacts/references/glossary.md, docs/design/task-artifacts/specs/task-bundle-v2.md, docs/design/user-interface/specs/theme.md.

Validation: git diff --check passed; make ci-fast passed. Only the six selected docs changed; no prohibited or generated files changed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10490-6a66aa5d`
- Behind base: 0
- Ahead of base: 1