### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/executors/4_decisions.md
+++ b/docs/design/executors/4_decisions.md
@@ -2,6 +2,7 @@
 title: Executors — Decisions
 owner: claude
 last_updated: 2026-07-26
+last_validated: 2026-07-27
 status: Draft
 feature: executors
 doc_role: decisions

--- a/docs/design/executors/specs/external-executor-protocol.md
+++ b/docs/design/executors/specs/external-executor-protocol.md
@@ -2,6 +2,7 @@
 title: External Executor Protocol v1 (Retired)
 owner: claude
 last_updated: 2026-07-26
+last_validated: 2026-07-27
 status: Retired
 feature: executors
 type: design

--- a/docs/design/host-registry/1_overview.md
+++ b/docs/design/host-registry/1_overview.md
@@ -2,6 +2,7 @@
 title: Host Registry — Overview
 owner: claude
 last_updated: 2026-07-20
+last_validated: 2026-07-27
 status: Accepted
 feature: host-registry
 doc_role: overview

--- a/docs/design/host-registry/2_design.md
+++ b/docs/design/host-registry/2_design.md
@@ -2,6 +2,7 @@
 title: Host Registry — Design
 owner: claude
 last_updated: 2026-07-20
+last_validated: 2026-07-27
 status: Accepted
 feature: host-registry
 doc_role: design

--- a/docs/design/host-registry/3_vision.md
+++ b/docs/design/host-registry/3_vision.md
@@ -2,6 +2,7 @@
 title: Host Registry — Vision
 owner: claude
 last_updated: 2026-07-18
+last_validated: 2026-07-27
 status: Accepted
 feature: host-registry
 doc_role: vision

--- a/docs/design/host-registry/4_decisions.md
+++ b/docs/design/host-registry/4_decisions.md
@@ -2,6 +2,7 @@
 title: Host Registry — Decisions
 owner: claude
 last_updated: 2026-07-20
+last_validated: 2026-07-27
 status: Accepted
 feature: host-registry
 doc_role: decisions


### PR DESCRIPTION
## Task

[ORB-10492](https://orbit-cli.com/tasks/ORB-10492) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Docs that have no frontmatter block at all are **out of the rotation**: do
not invent a frontmatter block for them, because `type` and `summary` are
required fields and guessing them corrupts the docs corpus. List them in
your execution summary instead so a human can decide.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and the docs you found with no frontmatter block.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- No frontmatter block was created for a doc that lacked one; such docs are listed instead.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Batch selection:
- Worked exactly the six task-admitted oldest missing-validation documents, with path tie-break ordering: docs/design/executors/4_decisions.md, docs/design/executors/specs/external-executor-protocol.md, docs/design/host-registry/1_overview.md, docs/design/host-registry/2_design.md, docs/design/host-registry/3_vision.md, and docs/design/host-registry/4_decisions.md.
- Each selected document had a frontmatter block and was missing last_validated in the pre-change tree. No other document was modified.

Changes and verification:
- docs/design/executors/4_decisions.md: added last_validated: 2026-07-27 only. Verified the retired-protocol decision with crates/orbit-common/src/types/executor_def.rs, crates/orbit-common/src/types/tests/executor_def.rs, the executor-def store tests, and rg -n 'ExternalExecutor|ActivityExecutorRegistry|run_subprocess_executor' crates --glob '*.rs'. The external wire enum and persistence round trips remain; deleted v1 runtime symbols/artifacts are absent.
- docs/design/executors/specs/external-executor-protocol.md: added last_validated: 2026-07-27 only. Verified the retired/inert status, retained ExecutorType::External parsing, and historical fixture/template paths against the same executor source/tests plus existence checks for crates/orbit-engine/src/executor/tests/external.rs and crates/orbit-core/assets/executors/external.example.yaml; both deleted artifacts are absent.
- docs/design/host-registry/1_overview.md: added last_validated: 2026-07-27 only. Verified the orbit-remote vertical boundary against ARCHITECTURE.md, crates/orbit-remote/Cargo.toml, and crates/orbit-remote/src/lib.rs; verified current orbit --version, orbit host --help, and orbit init --help surfaces and the retained/removal status of MCP discovery.
- docs/design/host-registry/2_design.md: added last_validated: 2026-07-27 only. Verified identity, workspace registry, host registry, cache, persistence, MCP discovery, revision/projection, and feature-boundary claims against crates/orbit-remote/src/{host_identity.rs,workspace_registry.rs,host_registry.rs,registry_cache.rs}, the Remote persistence/MCP modules, ARCHITECTURE.md, and targeted rg checks. The document's explicitly pending placement/polling phases remain without a corresponding completed workflow surface.
- docs/design/host-registry/3_vision.md: added last_validated: 2026-07-27 only. Verified its explicitly speculative status, internal links, and current orbit-remote boundary against ARCHITECTURE.md and the Remote crate/module surface; no unsupported implementation claim required correction.
- docs/design/host-registry/4_decisions.md: added last_validated: 2026-07-27 only. Verified ADR-0240 with orbit.adr.show, and checked the crate boundary, discovery-tool status, registry revision/projection claims, and dormant knowledge substrate against ARCHITECTURE.md and targeted rg checks across orbit-remote, orbit-store, and orbit-common.
- Selected-document relative links resolve, fenced code blocks are paired, and no spelling or genuinely broken-markdown corrections were needed.

Unvalidated:
- No claim in the six stamped documents was left unvalidated.
- All documents outside the six-document batch were left untouched and no validation stamp was added to them. Documents with no frontmatter block, therefore excluded from rotation, are: docs/CONFIG.md, docs/LESSONS.md, docs/POSITIONING.md, docs/design/_templates/references/glossary.md, docs/design/_templates/specs/_mechanism.md, docs/design/activity-job/references/glossary.md, docs/design/activity-job/specs/audit-envelope.md, docs/design/activity-job/specs/backend-resolution.md, docs/design/agent-families/references/glossary.md, docs/design/auditability/references/glossary.md, docs/design/auditability/specs/artifact-redaction.md, docs/design/auditability/specs/coverage-matrix.md, docs/design/auditability/specs/event-schema.md, docs/design/auditability/specs/redaction-retention.md, docs/design/host-registry/references/glossary.md, docs/design/mcp-bridge/references/glossary.md, docs/design/orbit-docs-plugin/1_scope.md, docs/design/orbit-graph/specs/GRAPH_SPEC.md, docs/design/policy-sandbox/references/glossary.md, docs/design/policy-sandbox/specs/fs-profile-resolution.md, docs/design/policy-sandbox/specs/sandbox-exec-contract.md, docs/design/project-learnings/references/glossary.md, docs/design/project-learnings/references/injection-layers.md, docs/design/remote-access/references/glossary.md, docs/design/remote-access/specs/ssh-tunnel.md, docs/design/task-artifacts/references/glossary.md, and docs/design/user-interface/specs/theme.md.

Validation:
- make ci-fast passed.
- git diff --check passed.
- Protected/generated-path check passed: no .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, .orbit/tasks/, or .orbit/graph/ changes.
- Final diff contains exactly the six selected documents and six added last_validated lines.

Assessment: Documentation upkeep is complete with an evidence-backed, stamp-only diff; no new document, section, prose reflow, or generated state was authored.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10492-6a66ac34`
- Behind base: 0
- Ahead of base: 1