### PR TITLE
Tolerate benign primary-checkout dirt when HEAD is unchanged

### DIFF
--- a/.orbit/adrs/accepted/ADR-0293/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0293/adr.yaml
@@ -1,0 +1,22 @@
+schema_version: 2
+id: ADR-0293
+title: Stationary primary HEAD tolerates record-store dirt only
+status: accepted
+owner: claude
+created_at: 2026-07-27T01:18:17.059025988Z
+accepted_at: 2026-07-27T01:18:25.906846717Z
+last_updated: 2026-07-27T01:18:25.906846717Z
+related_features: []
+related_tasks:
+- ORB-10493
+- ORB-10471
+tags:
+- worktree
+- integrity
+- pipeline
+paths:
+- crates/orbit-engine/src/activity_job/workspace.rs
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0293/body.md
+++ b/.orbit/adrs/accepted/ADR-0293/body.md
@@ -1,0 +1,30 @@
+## Context
+
+`WorktreeIntegrityGuard::verify` compares the registered primary checkout before and after a provider invocation. Until now it had exactly one benign case: `primary_fast_forward_is_benign`, which accepts a proven same-branch fast-forward whose dirt does not intersect `run_changed_paths` (ORB-10471). That helper rejects `before.head == after.head` on its first clause, so a primary that never moved but merely gained or lost dirt was always fatal.
+
+F2026-07-166 is the cost: run `jrun-20260726-2223-8` (ORB-10467) lost a complete, validated 13-file implementation because an out-of-run learning-curation pass re-serialized 12 already-tracked `.orbit/learnings/*/learning.yaml` files in the primary while its HEAD and branch stood still. `conflicting_paths` was empty; the guard raised a non-retryable `primary_checkout_drift` anyway and burned the step's entire `max_attempts=1` budget. This dirt class is endemic, not exceptional: Orbit's own engine and curation passes rewrite the primary's `.orbit/` records continuously while pipelines run.
+
+The obvious fix — reuse the fast-forward rule verbatim, accepting any stationary-HEAD delta disjoint from `run_changed_paths` — is unsafe, and the existing suite proves it. Five tests (`primary_escape_is_typed_non_retryable_and_preserves_both_checkouts`, `primary_content_mutation_is_typed_even_when_assigned_content_also_changes`, `staged_only_primary_delta_reports_its_path_and_index_identity`, `unchanged_pre_dirty_path_is_excluded_from_escape_diagnostic`, `primary_escape_is_checked_after_nonzero_exit_and_timeout`) encode the ORB-10134 data-loss hazard: a provider that escapes its assigned worktree and edits the primary. Every one of those escapes is disjoint from the run's own paths — `primary_content_mutation_is_typed_even_when_assigned_content_also_changes` is named for exactly that shape — so a pure disjointness rule silently accepts all five.
+
+The asymmetry is evidential. A fast-forward carries positive proof that Git itself produced the delta (`merge-base --is-ancestor` over a moved HEAD). A stationary HEAD carries no such proof: at the Git layer, a curation pass rewriting a record and a provider stray-writing a source file are indistinguishable by authorship. Only the *path class* separates them.
+
+## Decision
+
+Add a second benign case, `primary_dirt_only_delta_is_benign`, that is deliberately narrower than the fast-forward rule. A stationary-HEAD primary delta is accepted only when all of the following hold:
+
+1. `before.head == after.head` and `before.branch == after.branch`;
+2. the delta is fully explained by dirt-path movement (`primary_dirt_mutations` is non-empty) — an unattributable fingerprint change falls through and fails closed;
+3. no mutated path intersects `run_changed_paths` (the same gate ORB-10471 introduced);
+4. **every** mutated path lives under `.orbit/`, Orbit's own record store.
+
+Clause 4 is the load-bearing addition. `.orbit/` holds tasks, ADRs, learnings, frictions, and routines: content the engine driving the pipeline rewrites as a matter of course, and content that is never a run's code candidate. A primary mutation anywhere else — source, manifests, CI config — remains `primary_checkout_drift` regardless of disjointness, preserving ORB-10134 escape detection intact.
+
+Acceptance is logged at `info` on `orbit.engine.cli_runner` with the ignored paths, matching the fast-forward case. The guard never cleans or reconciles the dirt it ignores.
+
+## Consequences
+
+- The F2026-07-166 class of loss is closed: concurrent record-store curation can no longer strand a validated implementation.
+- Provider-escape detection is unchanged. All five ORB-10134 escape tests still fail closed, and `stationary_primary_source_edit_stays_fail_closed_even_when_disjoint` pins the divergence so a future "simplification" to pure disjointness fails loudly.
+- The two benign cases now apply asymmetric rules, which is a genuine complexity cost to carry.
+- **Cost:** clause 4 is a path-prefix heuristic, not a proof of authorship. A benign out-of-run pass that touches a primary file *outside* `.orbit/` still fails the guard, and a provider that escapes to write inside the primary's `.orbit/` is now tolerated. Both are chosen deliberately: the first errs fail-closed on the guard's own hazard, and the second is a records-not-code blast radius that the run's own record writes already produce. If either turns out to matter, the follow-up is authorship evidence (e.g. fingerprinting per-path mtime or an engine-owned write ledger), not a wider prefix list.
+- **Cost:** this narrows the literal fix ORB-10493 proposed ("compare only the dirt paths that intersect `run_changed_paths`"). Its first acceptance criterion is met for the friction's actual repro, which is a record-store delta, but not for an arbitrary disjoint tracked file. Rejected alternative: implement the criterion literally and rewrite the five escape tests — that trades an intermittent, recoverable failure for a silent data-loss regression, which is the wrong direction on this guard.

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -1779,6 +1779,122 @@ fn primary_dirt_intersecting_the_run_defeats_a_fast_forward() {
 }
 
 #[test]
+fn stationary_primary_record_store_dirt_disjoint_from_the_run_is_accepted() {
+    let fixture = linked_worktree_fixture();
+    let tracked_record = ".orbit/learnings/L-0001/learning.yaml";
+    write_primary_file(&fixture, tracked_record, "id: L-0001\n");
+    git_ok(&fixture.primary, &["add", "--", tracked_record]);
+    git_ok(&fixture.primary, &["commit", "-m", "track a learning"]);
+
+    let guard = boundary_guard(&fixture, "ORB-STATIONARY-DIRT", "run-stationary-dirt");
+
+    fs::write(fixture.assigned.join("candidate.txt"), "candidate\n").expect("write run candidate");
+    // The F2026-07-166 shape: an out-of-run curation pass re-serializes an
+    // already-tracked record and drops an untracked sibling, all disjoint from
+    // the run, while the primary HEAD and branch never move.
+    let head_before = git_bytes(&fixture.primary, &["rev-parse", "HEAD"]);
+    write_primary_file(&fixture, tracked_record, "id: L-0001\ntags: []\n");
+    let untracked_record = write_primary_file(
+        &fixture,
+        ".orbit/frictions/F-0002/friction.yaml",
+        "id: F-0002\n",
+    );
+
+    let (result, events) = capture_events(|| guard.verify());
+    result.expect("stationary record-store dirt disjoint from the run must not raise drift");
+
+    assert_eq!(
+        git_bytes(&fixture.primary, &["rev-parse", "HEAD"]),
+        head_before,
+        "the accepted case is defined by an unmoved primary HEAD"
+    );
+    assert!(
+        events.iter().any(|event| event
+            .field("ignored_primary_paths")
+            .is_some_and(|paths| paths.contains(tracked_record)
+                && paths.contains(".orbit/frictions/F-0002/friction.yaml"))),
+        "the accepted stationary delta must report both ignored primary paths: {events:?}"
+    );
+    assert!(
+        untracked_record.exists(),
+        "the guard must not clean the primary dirt it ignored"
+    );
+}
+
+#[test]
+fn stationary_primary_source_edit_stays_fail_closed_even_when_disjoint() {
+    let fixture = linked_worktree_fixture();
+    let guard = boundary_guard(&fixture, "ORB-STATIONARY-SOURCE", "run-stationary-source");
+
+    fs::write(fixture.assigned.join("candidate.txt"), "candidate\n").expect("write run candidate");
+    // Disjoint from the run, but outside Orbit's record store: this is the
+    // ORB-10134 escape shape, and no path-disjointness argument may excuse it.
+    write_primary_file(
+        &fixture,
+        ".orbit/learnings/L-0003/learning.yaml",
+        "id: L-0003\n",
+    );
+    write_primary_file(&fixture, "src/escaped.rs", "fn escaped() {}\n");
+
+    let error = guard
+        .verify()
+        .expect_err("a primary source edit must remain fail closed");
+
+    assert_worktree_integrity_error(
+        &error,
+        "primary_checkout_drift",
+        ("ORB-STATIONARY-SOURCE", "run-stationary-source", "codex"),
+        &fixture,
+        "src/escaped.rs",
+    );
+    assert_eq!(
+        worktree_integrity_diagnostic(&error)["conflicting_paths"],
+        serde_json::json!([]),
+        "the source edit is fatal on its path class, not on run interference"
+    );
+}
+
+#[test]
+fn stationary_primary_dirt_intersecting_the_run_remains_a_typed_drift_failure() {
+    // Both paths are inside the record store, so only the intersection with
+    // `run_changed_paths` can be what keeps them fail-closed.
+    for (kind, shared) in [
+        ("untracked", ".orbit/frictions/F-0009/friction.yaml"),
+        ("tracked", ".orbit/routines/worktree_gc.yaml"),
+    ] {
+        let fixture = linked_worktree_fixture();
+        if kind == "tracked" {
+            write_primary_file(&fixture, shared, "schemaVersion: 1\n");
+            git_ok(&fixture.primary, &["add", "--", shared]);
+            git_ok(&fixture.primary, &["commit", "-m", "track a routine"]);
+        }
+        let run_id = format!("run-stationary-{kind}-interference");
+        let task_id = format!("ORB-STATIONARY-{}", kind.to_ascii_uppercase());
+        let guard = boundary_guard(&fixture, &task_id, &run_id);
+
+        write_worktree_file(&fixture.assigned, shared, "run candidate\n");
+        write_primary_file(&fixture, shared, "primary escape\n");
+
+        let error = guard
+            .verify()
+            .expect_err("primary dirt on a path the run touched must fail closed");
+
+        assert_worktree_integrity_error(
+            &error,
+            "primary_checkout_drift",
+            (&task_id, &run_id, "codex"),
+            &fixture,
+            shared,
+        );
+        assert_eq!(
+            worktree_integrity_diagnostic(&error)["conflicting_paths"],
+            serde_json::json!([shared]),
+            "stationary {kind} interference must be named as a conflicting path"
+        );
+    }
+}
+
+#[test]
 fn primary_branch_switch_remains_a_typed_drift_failure() {
     let fixture = linked_worktree_fixture();
     let guard = boundary_guard(&fixture, "ORB-PRIMARY-BRANCH", "run-primary-branch");
@@ -1918,6 +2034,19 @@ fn advance_primary(fixture: &LinkedWorktreeFixture, path: &str) {
     fs::write(fixture.primary.join(path), "merged\n").expect("write merged PR file");
     git_ok(&fixture.primary, &["add", "--", path]);
     git_ok(&fixture.primary, &["commit", "-m", "merge sibling PR"]);
+}
+
+/// Write a (possibly nested) path inside the registered primary checkout.
+fn write_primary_file(fixture: &LinkedWorktreeFixture, path: &str, contents: &str) -> PathBuf {
+    write_worktree_file(&fixture.primary, path, contents)
+}
+
+fn write_worktree_file(root: &Path, path: &str, contents: &str) -> PathBuf {
+    let target = root.join(path);
+    fs::create_dir_all(target.parent().expect("nested path has a parent"))
+        .expect("create parent dirs");
+    fs::write(&target, contents).expect("write checkout file");
+    target
 }
 
 fn git_ok(repo: &Path, args: &[&str]) {

--- a/crates/orbit-engine/src/activity_job/workspace.rs
+++ b/crates/orbit-engine/src/activity_job/workspace.rs
@@ -562,12 +562,14 @@ impl WorktreeBoundaryGuard {
     }
 
     /// Compare both monitored checkouts after the provider reaches any
-    /// terminal outcome. An externally advanced primary branch is benign when
-    /// it is a proven same-branch fast-forward that did not disturb any path
-    /// this run touched: linked worktrees keep their own HEAD, and the
-    /// shipment rebase checkpoint owns reconciliation with the new base.
-    /// Primary rewrites, primary dirt overlapping the run, and history changes
-    /// in the assigned worktree remain typed, fail-closed violations.
+    /// terminal outcome. A primary delta is benign in exactly two shapes: a
+    /// proven same-branch fast-forward, or a stationary HEAD whose only
+    /// movement is Orbit record-store dirt. Both require that the delta left
+    /// every path this run touched alone: linked worktrees keep their own
+    /// HEAD, and the shipment rebase checkpoint owns reconciliation with a new
+    /// base. Primary rewrites, primary branch switches, primary source edits,
+    /// primary dirt overlapping the run, and history changes in the assigned
+    /// worktree remain typed, fail-closed violations.
     pub(crate) fn verify(self) -> Result<(), DispatchError> {
         let assigned_after = git_fingerprint(&self.assigned_root)?;
         let primary_after = git_fingerprint(&self.primary_root)?;
@@ -603,6 +605,23 @@ impl WorktreeBoundaryGuard {
         }
 
         if primary_after == self.primary_before {
+            return Ok(());
+        }
+
+        if primary_dirt_only_delta_is_benign(
+            &self.primary_before,
+            &primary_after,
+            &primary_dirt_paths,
+            &conflicting_paths,
+        ) {
+            tracing::info!(
+                target: "orbit.engine.cli_runner",
+                task_id = %self.task_id,
+                run_id = %self.run_id,
+                primary_head = %primary_after.head,
+                ignored_primary_paths = ?primary_dirt_paths,
+                "accepted concurrent primary record-store dirt disjoint from the run; primary HEAD and branch never moved"
+            );
             return Ok(());
         }
 
@@ -675,6 +694,46 @@ impl WorktreeBoundaryGuard {
             diagnostic: diagnostic.to_string(),
         }
     }
+}
+
+/// Orbit's own record store inside a checkout. Tasks, ADRs, learnings,
+/// frictions, and routines under this prefix are rewritten continuously by the
+/// engine that drives the pipeline and by out-of-run curation passes; they are
+/// never part of a run's code candidate, so the primary's copy moving under a
+/// stationary HEAD carries no data-loss signal.
+const ORBIT_RECORD_STORE_PREFIX: &str = ".orbit/";
+
+/// Accept a primary checkout that never moved but merely gained or lost record
+/// store dirt away from the run.
+///
+/// `primary_fast_forward_is_benign` covers the case where the primary branch
+/// advanced; it rejects `before.head == after.head` on its first clause, which
+/// left a stationary primary with *any* unrelated dirt delta reported as
+/// `primary_checkout_drift` (F2026-07-166: an out-of-run curation pass
+/// re-serializing tracked `.orbit/learnings/*/learning.yaml` files killed a
+/// complete, validated implementation).
+///
+/// Unlike a fast-forward, a stationary HEAD offers no positive proof that Git
+/// itself produced the delta, so acceptance is deliberately narrower than
+/// "disjoint from the run" alone (ADR-0293): every mutated path must live in
+/// the record store. A provider that escapes its worktree to edit source in
+/// the primary — the ORB-10134 data-loss hazard — keeps failing closed even
+/// when the file it touched is one this run never looked at. The delta must
+/// also be fully explained by dirt-path movement; an otherwise unattributable
+/// fingerprint change is not something this branch understands.
+fn primary_dirt_only_delta_is_benign(
+    before: &GitWorktreeFingerprint,
+    after: &GitWorktreeFingerprint,
+    primary_dirt_paths: &[String],
+    conflicting_paths: &[String],
+) -> bool {
+    before.head == after.head
+        && before.branch == after.branch
+        && !primary_dirt_paths.is_empty()
+        && conflicting_paths.is_empty()
+        && primary_dirt_paths
+            .iter()
+            .all(|path| path.starts_with(ORBIT_RECORD_STORE_PREFIX))
 }
 
 fn primary_fast_forward_is_benign(


### PR DESCRIPTION
## Task

[ORB-10493](https://orbit-cli.com/tasks/ORB-10493) — Tolerate benign primary-checkout dirt when HEAD is unchanged

### Description

## Problem
`WorktreeIntegrityGuard::verify` (`crates/orbit-engine/src/activity_job/workspace.rs`) has two branches: a fast-forward path (now fixed by ORB-10471 to scope dirt checks to `conflicting_paths`) and a HEAD-unchanged path. The HEAD-unchanged path has no benign case at all: `primary_fast_forward_is_benign` (workspace.rs:665-684) returns `false` immediately when `before.head == after.head`, so a primary checkout that never moved but merely had an unrelated tracked file's content change (or gained/lost dirt disjoint from the run) still fails the guard with `primary_checkout_drift`.

## Evidence
F2026-07-166: run `jrun-20260726-2223-8` (ORB-10467) failed `implement_one` after a complete, validated implementation (13 files, full execution_summary, tests green) because an out-of-run learning-curation pass re-serialized 12 already-tracked `.orbit/learnings/*/learning.yaml` files (disjoint from every path the run touched) while the primary HEAD/branch stayed unchanged. `conflicting_paths` was empty; the guard still raised a fatal, non-retryable violation, burning the step's entire `max_attempts=1` retry budget. Confirmed still live in ORB-10489 friction-curation pass (2026-07-27): `primary_fast_forward_is_benign` unchanged at workspace.rs:665-684.

This is a distinct code path from ORB-10471's scope: ORB-10471 fixes the fast-forward case (`before.head != after.head`, ancestor proven); this friction's repro has `before.head == after.head`, which `primary_fast_forward_is_benign` rejects on its very first clause before any dirt-relevance check runs.

## Suggested fix
Add an acceptance path for the HEAD-unchanged case: when `primary_before.head == primary_after.head` and `primary_before.branch == primary_after.branch`, compare only the primary's dirt paths that intersect `run_changed_paths` (the same `conflicting_paths` computation ORB-10471 introduces for the fast-forward case) rather than requiring literal `dirty_paths`/`path_states`/`tracked_patch_sha256`/`untracked_content` equality. Keep fail-closed for any primary mutation that does intersect the run's own changed paths.

## Acceptance criteria
- An unchanged primary HEAD/branch plus a disjoint tracked-content or untracked-path delta is accepted and logged, not raised as `primary_checkout_drift`.
- A primary mutation intersecting `run_changed_paths` while HEAD is unchanged still fails with a typed integrity violation.
- Existing HEAD-unchanged branch-switch and rewrite detection remain fail-closed.


### Acceptance Criteria

- An unchanged primary HEAD/branch plus a disjoint tracked-content or untracked-path delta is accepted and logged, not raised as primary_checkout_drift.
- A primary mutation intersecting run_changed_paths while HEAD is unchanged still fails with a typed integrity violation.
- Existing HEAD-unchanged branch-switch and rewrite detection remain fail-closed.

## Execution Summary

<details>
<summary>Click to expand</summary>

Added a second benign case to `WorktreeBoundaryGuard::verify` for the HEAD-unchanged primary-checkout path (crates/orbit-engine/src/activity_job/workspace.rs), closing the F2026-07-166 loss class.

Implementation:
- New `primary_dirt_only_delta_is_benign(before, after, primary_dirt_paths, conflicting_paths)` accepts a stationary primary only when: `before.head == after.head`, `before.branch == after.branch`, the delta is explained by dirt-path movement (`primary_dirt_mutations` non-empty), `conflicting_paths` (dirt ∩ `run_changed_paths`, the ORB-10471 computation) is empty, and every mutated path lives under the `.orbit/` record store (`ORBIT_RECORD_STORE_PREFIX`).
- `verify` consults it before `primary_fast_forward_is_benign` and logs acceptance at info on `orbit.engine.cli_runner` with `ignored_primary_paths`, mirroring the fast-forward case. The guard never cleans the dirt it ignores. `primary_fast_forward_is_benign` is untouched, so the ORB-10471 fast-forward path is unchanged.

Design decision (ADR-0293, accepted, related to ORB-10493/ORB-10471): the record-store path-class clause is deliberately narrower than the literal fix the task proposed ("compare only dirt paths intersecting `run_changed_paths`"). Implementing that verbatim would silently accept all five existing ORB-10134 provider-escape tests (`primary_escape_is_typed_non_retryable_and_preserves_both_checkouts`, `primary_content_mutation_is_typed_even_when_assigned_content_also_changes`, `staged_only_primary_delta_reports_its_path_and_index_identity`, `unchanged_pre_dirty_path_is_excluded_from_escape_diagnostic`, `primary_escape_is_checked_after_nonzero_exit_and_timeout`) — every one of those escapes is already disjoint from the run's paths. A fast-forward carries positive proof Git produced the delta (`merge-base --is-ancestor`); a stationary HEAD carries none, so only the path class separates curation from escape. AC1 is therefore met for the friction's actual repro (record-store delta, tracked-content and untracked-path shapes) but not for an arbitrary disjoint file outside `.orbit/`; the rejected alternative and its cost are recorded in the ADR's Consequences.

Tests (crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs), all three new:
- `stationary_primary_record_store_dirt_disjoint_from_the_run_is_accepted` — the exact F2026-07-166 shape (already-tracked `.orbit/learnings/*/learning.yaml` re-serialized plus a new untracked `.orbit/frictions/...` file, HEAD/branch unmoved): accepted, both ignored paths named in the info event, primary dirt left in place (AC1).
- `stationary_primary_dirt_intersecting_the_run_remains_a_typed_drift_failure` — both tracked and untracked shapes, both inside `.orbit/`, so only run-intersection can be what fails them: typed `primary_checkout_drift` with the shared path in `conflicting_paths` (AC2).
- `stationary_primary_source_edit_stays_fail_closed_even_when_disjoint` — a disjoint `src/escaped.rs` write with empty `conflicting_paths`: still `primary_checkout_drift`, pinning the divergence from pure disjointness.
Added test helpers `write_primary_file` / `write_worktree_file` for nested-path writes.

AC3 (HEAD-unchanged branch-switch and rewrite detection stay fail-closed) is covered by the untouched pre-existing tests, which still pass: `primary_branch_switch_remains_a_typed_drift_failure`, the five escape tests above, and `assigned_history_divergence_is_a_typed_worktree_content_conflict`.

Validation: `cargo test -p orbit-engine` — 339 lib tests + integration targets, 0 failures (all 47 orchestrator tests green, including the five ORB-10134 escape tests). `make ci-fast` passes. `cargo clippy -p orbit-engine --all-targets` produces no warnings for orbit-engine (one pre-existing, unrelated `needless_borrow` warning in orbit-store).

Scope: only the two `context_files` were modified, plus the new ADR-0293 record. No new dependencies, no cross-crate edges.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10493-6a66b085`
- Behind base: 0
- Ahead of base: 1

*authored by: claude*