### PR TITLE
Include frontmatter-less documents in doc-duty rotation

### DIFF
--- a/.orbit/auto_tasks/doc-duties.yaml
+++ b/.orbit/auto_tasks/doc-duties.yaml
@@ -18,16 +18,24 @@ template:
     checked against reality. It is NOT `last_updated`: editing a doc changes
     `last_updated`, confirming a doc is still true changes `last_validated`.
 
-    1. List every in-scope doc together with its `last_validated` value.
+    1. List every in-scope doc together with its `last_validated` value. A
+       document with no frontmatter block has no `last_validated` value and is
+       treated as never validated.
     2. Order them: docs with **no** `last_validated` key first (never validated),
        then oldest date first. Break ties by path so the order is stable.
     3. Take the **6 oldest**. That is this run's batch. Do not take more — a
        bounded batch that is done properly beats a broad pass that is not.
 
-    Docs that have no frontmatter block at all are **out of the rotation**: do
-    not invent a frontmatter block for them, because `type` and `summary` are
-    required fields and guessing them corrupts the docs corpus. List them in
-    your execution summary instead so a human can decide.
+    Documents with no frontmatter block are eligible for the rotation. When
+    one is selected, determine whether Orbit Docs' existing tolerant inference
+    contract supports a confident classification: `type` must be one of the
+    existing allowed values and `summary` must follow the existing document
+    heading/content rule. If classification and verification are successful,
+    you may prepend a schema-compatible frontmatter block, then add
+    `last_validated` only after the selected document has actually been
+    checked. Do not invent metadata fields, sidecars, or validation markers.
+    If classification is uncertain or claims cannot be verified, leave the
+    document unchanged and report the skip.
 
     ## What to do with each doc in the batch
 
@@ -83,13 +91,19 @@ template:
     Your execution summary is the artifact a human reads. State: which docs were
     in the batch and why they were selected, what you changed in each with the
     verification command behind it, which docs or claims you left unvalidated
-    and why, and the docs you found with no frontmatter block.
+    and why, and for each selected frontmatter-less doc whether frontmatter was
+    migrated, the derived `type` and `summary`, and the verification evidence.
+    Report selected docs left unchanged because their classification or claims
+    could not be verified confidently.
   acceptance_criteria:
   - Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
   - Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
   - Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
   - No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
-  - No frontmatter block was created for a doc that lacked one; such docs are listed instead.
+  - Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
+  - Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
+  - A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
+  - No new metadata field, sidecar, or validation-marker system is introduced.
   - No new document or new section was authored.
   - Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
   - make ci-fast passes.


### PR DESCRIPTION
## Task

[ORB-10506](https://orbit-cli.com/tasks/ORB-10506) — Include frontmatter-less documents in doc-duty rotation

### Description

## Problem

ORB-10492 completed a strong evidence-backed doc-duty pass, but its execution summary identified a permanent blind spot: documents without frontmatter are excluded from rotation. That currently leaves `docs/CONFIG.md`, `docs/LESSONS.md`, `docs/POSITIONING.md`, and the listed frontmatter-less design references/specs/templates outside recurring validation even though they are otherwise in the duty's documented `docs/**` scope.

## Change

Update only `.orbit/auto_tasks/doc-duties.yaml` so future generated doc-duty tasks include frontmatter-less documents in the same bounded six-document rotation.

Treat a document with no frontmatter as never validated, ahead of dated documents, with the existing stable path tie-break. When one is selected, the duty may prepend schema-compatible frontmatter using Orbit Docs' existing tolerant inference contract for `type` and `summary`, then add `last_validated` only after the document has actually been checked. Do not create a second validation marker or separate tracking file.

Retain the six-document batch limit, evidence-backed validation standard, and all historical/generated-state exclusions. Update the reporting and acceptance language so a newly migrated document is reported with the derived metadata and verification performed. This task changes the auto-task template only; it does not edit the excluded documents themselves or retroactively mutate ORB-10492.

## Architecture / scope constraints

ADR-0169 permits tolerant inference and an opt-in path to schema-compatible frontmatter. Reuse that contract rather than inventing metadata fields or classification rules. Keep `type` within the existing allowed values and derive `summary` from the existing document heading/content rule. If a selected file cannot be classified or validated confidently, leave it unchanged and report the skip.

This is deliberately a single-file policy adjustment with no runtime, schema, or command changes.

### Acceptance Criteria

- `.orbit/auto_tasks/doc-duties.yaml` no longer excludes a document solely because it lacks frontmatter; such documents sort as never validated and are eligible for the same stable six-document batch.
- The template permits frontmatter creation only for a selected document and requires `type` and `summary` to follow Orbit Docs' existing inference/schema contract; no new metadata field, sidecar, or validation-marker system is introduced.
- `last_validated` may be added only after the selected document is actually verified, and uncertain classification or unverifiable claims leave the document unchanged and are reported.
- The six-document limit and exclusions for `.orbit/adrs/**`, `CHANGELOG.md`, `docs/changelogs/**`, `docs/design/_archive/**`, `.orbit/tasks/**`, `.orbit/graph/**`, and generated state remain intact.
- The generated-task reporting and acceptance language records migrated frontmatter plus verification evidence and no longer requires all frontmatter-less documents to remain untouched.
- No document outside `.orbit/auto_tasks/doc-duties.yaml` is modified, and `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated `.orbit/auto_tasks/doc-duties.yaml` so frontmatter-less in-scope documents are treated as never validated and enter the stable six-document rotation ahead of dated documents.
- Added the constrained opt-in migration path: only a selected document with confidently inferred Orbit Docs `type` and `summary` may receive schema-compatible frontmatter; `last_validated` is added only after verification, while uncertain or unverifiable documents remain unchanged and are reported.
- Updated reporting and acceptance language to require migrated metadata and verification evidence, while preserving all historical/generated-state exclusions and the single-file scope.
Assessment: The policy template now covers the documented frontmatter-less blind spot without adding metadata, sidecars, validation markers, runtime changes, or edits outside the requested file.
Validation: `git diff --check`; YAML parsed successfully with Python PyYAML; `make ci-fast` passed; final status contained only `.orbit/auto_tasks/doc-duties.yaml`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10506-6a66b51f`
- Behind base: 0
- Ahead of base: 1