### PR TITLE
Verify ORB-10471 also fixes the dirty-to-clean fast-forward drift variant (F2026-07-172)

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -1748,6 +1748,49 @@ fn benign_primary_fast_forward_ignores_primary_dirt_disjoint_from_the_run() {
 }
 
 #[test]
+fn dirty_to_clean_primary_fast_forward_is_accepted() {
+    // The F2026-07-172 shape: the primary already carries untracked
+    // record-store dirt when the guard captures its "before" state, then a
+    // fast-forward commit lands exactly that pre-existing dirty content, so
+    // `dirty_paths` moves from non-empty to empty even though no interference
+    // occurred (HEAD proven to have advanced, `conflicting_paths` empty).
+    let fixture = linked_worktree_fixture();
+    let dirty_record = ".orbit/learnings/L-0009/learning.yaml";
+    write_primary_file(&fixture, dirty_record, "id: L-0009\n");
+
+    let guard = boundary_guard(&fixture, "ORB-DIRTY-TO-CLEAN-FF", "run-dirty-to-clean-ff");
+
+    fs::write(fixture.assigned.join("candidate.txt"), "candidate\n").expect("write run candidate");
+    let head_before = git_bytes(&fixture.primary, &["rev-parse", "HEAD"]);
+    git_ok(&fixture.primary, &["add", "--", dirty_record]);
+    git_ok(
+        &fixture.primary,
+        &[
+            "commit",
+            "-m",
+            "commit exactly the pre-existing dirty content",
+        ],
+    );
+
+    let (result, events) = capture_events(|| guard.verify());
+    result.expect(
+        "a fast-forward that lands exactly the primary's pre-existing dirty content must be accepted",
+    );
+
+    assert_ne!(
+        git_bytes(&fixture.primary, &["rev-parse", "HEAD"]),
+        head_before,
+        "the accepted case is defined by a proven fast-forward advance"
+    );
+    assert!(
+        events.iter().any(|event| event
+            .field("ignored_primary_paths")
+            .is_some_and(|paths| paths.contains(dirty_record))),
+        "the accepted fast-forward must report the dirty-to-clean path: {events:?}"
+    );
+}
+
+#[test]
 fn primary_dirt_intersecting_the_run_defeats_a_fast_forward() {
     for (kind, shared) in [("untracked", "shared-new.txt"), ("tracked", "README.md")] {
         let fixture = linked_worktree_fixture();


### PR DESCRIPTION
## Task

[ORB-10495](https://orbit-cli.com/tasks/ORB-10495) — Verify ORB-10471 also fixes the dirty-to-clean fast-forward drift variant (F2026-07-172)

### Description

## Problem
F2026-07-172 documents a `primary_checkout_drift` false positive on a genuine fast-forward: primary HEAD advanced `1bc5ceb0 -> c3bfe410` (a proven ancestor per `git merge-base --is-ancestor`), but `dirty_paths` went from non-empty to empty because commit `c3bfe410` landed exactly the primary's pre-existing dirty `.orbit/learnings/*.yaml` content. The old `primary_fast_forward_is_benign` rejected this on the literal `dirty_paths` equality clause even though no interference occurred.

ORB-10471 ("Ignore unrelated primary dirt when validating a benign fast-forward", done) rewrote this exact function to drop the four global byte-identity comparisons in favor of a `conflicting_paths` (intersection with `run_changed_paths`) check, for a fast-forward where HEAD demonstrably moved. F2026-07-172's repro is a fast-forward case (HEAD moved), so it is very likely already fixed by ORB-10471 as a side effect — but ORB-10471's stated scope and evidence only name F2026-07-139 (untracked-addition variant), not this dirty-to-clean variant, so it was not safe to assume coverage or add a relation to an in-flight task during curation (ORB-10489).

## What to do
1. Read the current `primary_fast_forward_is_benign` implementation (post-ORB-10471) in `crates/orbit-engine/src/activity_job/workspace.rs`.
2. Confirm whether a dirty-to-clean `dirty_paths` transition during a proven fast-forward with empty `conflicting_paths` is now accepted (add a targeted test reproducing F2026-07-172's exact shape if one does not already exist).
3. If confirmed fixed: resolve F2026-07-172 via `orbit friction resolve` citing the passing test/behavior as evidence.
4. If NOT fixed: implement the same `conflicting_paths`-scoping fix for this transition shape.

## Evidence
F2026-07-172 (during ORB-10480, run jrun-20260726-2320-4): primary transition 1bc5ceb0 -> c3bfe410 (commit "chore: update learnings"), same 12 files as F2026-07-166/171, `conflicting_paths` empty, assigned worktree entirely untouched.


### Acceptance Criteria

- A test or manual repro confirms whether the current primary_fast_forward_is_benign accepts a dirty-to-clean transition during a proven fast-forward with empty conflicting_paths.
- F2026-07-172 is resolved via the friction CLI with the confirming evidence, or a fix landing alongside a new passing test if it was not already covered.

## Execution Summary

<details>
<summary>Click to expand</summary>

Confirmed the fix is already covered: post-ORB-10471, `primary_fast_forward_is_benign`
(crates/orbit-engine/src/activity_job/workspace.rs:739) no longer inspects `dirty_paths`
shape at all. It only requires: HEAD proved to advance (`before.head != after.head` plus
`git merge-base --is-ancestor`), branch unchanged, and `conflicting_paths` (primary dirt
paths intersecting the run's changed paths) empty. A dirty-to-clean `dirty_paths`
transition during a proven fast-forward with empty `conflicting_paths` — F2026-07-172's
exact shape — already satisfies all three clauses and returns `true` (benign).

Added a regression test to lock this in: `dirty_to_clean_primary_fast_forward_is_accepted`
in crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs. It reproduces
F2026-07-172's shape directly: the registered primary carries untracked
`.orbit/learnings/*` dirt at guard-capture time, then a fast-forward commit lands exactly
that dirty content verbatim (dirty_paths non-empty -> empty, conflicting_paths stays
empty, HEAD proven to advance via merge-base ancestor check). Test passes against the
current, unmodified `primary_fast_forward_is_benign` — no production code change was
needed.

Validation: `cargo test -p orbit-engine dirty_to_clean_primary_fast_forward_is_accepted`
(1 passed) and `make ci-fast` (fmt-check + guardrail scripts) both pass.

Resolved F2026-07-172 via `orbit friction update --status resolved` with a curation
resolution note citing ORB-10471 and this new test as evidence.

No context_files were listed on this task (tags: friction-curation, no-diff-expected);
the one file touched — the new test in orchestrator.rs — is an in-scope addition per the
task's own acceptance criteria ("a test... confirms whether... is accepted"), not scope
drift.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10495-6a66bfcb`
- Behind base: 0
- Ahead of base: 1