### PR TITLE
Add a size-budget guard/doc comment on OrbitError to catch result_large_err early

### DIFF
--- a/crates/orbit-common/src/types/error.rs
+++ b/crates/orbit-common/src/types/error.rs
@@ -69,6 +69,9 @@ pub struct DependencyNotDelivered {
 
 #[derive(Debug, Error, Serialize)]
 #[non_exhaustive]
+/// Keep this widely propagated error below its 128-byte size budget. Box the
+/// payload of any future multi-field variant so adding it does not widen every
+/// `Result<_, OrbitError>` in the workspace.
 pub enum OrbitError {
     #[error("policy denied: {0}")]
     PolicyDenied(String),
@@ -170,6 +173,11 @@ pub enum OrbitError {
     #[error("schema migration failed: {0}")]
     Migration(String),
 }
+
+const _: () = assert!(
+    std::mem::size_of::<OrbitError>() <= 128,
+    "OrbitError exceeds its 128-byte size budget; box multi-field variant payloads"
+);
 
 impl OrbitError {
     pub fn not_found(kind: NotFoundKind, id: impl Into<String>) -> Self {


### PR DESCRIPTION
## Task

[ORB-10498](https://orbit-cli.com/tasks/ORB-10498) — Add a size-budget guard/doc comment on OrbitError to catch result_large_err early

### Description

## Problem
`OrbitError` is returned by nearly every function in the workspace, so its size is a global budget, but nothing states that. Adding a struct-style variant with several `String` fields grows the enum (observed: ~88 to 128 bytes), which silently trips `clippy::result_large_err` in unrelated call sites elsewhere in the tree that merely happen to return `Result<_, OrbitError>` or `Result<_, (X, OrbitError)>`. The clippy diagnostic names only those unrelated call sites, not the enum, so the cause reads as a pre-existing lint issue rather than something the current change introduced.

## Evidence
F2026-07-170 (during ORB-10464): adding a 5-field struct-style variant tripped `clippy::result_large_err` in `vcs/freshness.rs` and `vcs/pr/open.rs`, neither touched by that change. Confirmed still live in friction-curation pass (ORB-10489, 2026-07-27): `crates/orbit-common/src/types/error.rs` has no size-budget doc comment or `const _: () = assert!(size_of::<OrbitError>() <= N)` guard anywhere in the file or crate (`grep size_of::<OrbitError>`, `result_large_err` repo-wide: zero hits). Only one variant (`DependencyNotDelivered`) has a doc comment explaining its own boxing rationale; `vcs/freshness.rs:41` and `vcs/pr/open.rs:39` still return unboxed multi-field-adjacent results with no guard against a future regression.

## Suggested fix
Add a `const _: () = assert!(size_of::<OrbitError>() <= N);` compile-time guard near the enum definition (so a future oversized variant fails to compile with a message naming the enum, not an unrelated call site), and/or a doc comment on the enum stating the size budget and that multi-field variants should box their payload.

## Acceptance criteria
- A compile-time size assertion or equivalent CI-visible guard exists for OrbitError that fails with a message pointing at the enum when it grows past budget.
- A doc comment on the enum states the size discipline (box multi-field variant payloads) for future contributors.

### Acceptance Criteria

- A compile-time size assertion or equivalent CI-visible guard exists for OrbitError that fails with a message pointing at the enum when it grows past budget.
- A doc comment on the enum states the size discipline (box multi-field variant payloads) for future contributors.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Documented OrbitError's 128-byte size budget and instructed future contributors to box multi-field variant payloads.
- Added a const compile-time assertion naming OrbitError when its size exceeds the budget.

Assessment: Narrow, compatible guard in the existing error module; no dependencies or API behavior changed.

Validation:
- cargo fmt --all -- --check
- cargo check -p orbit-common
- cargo clippy -p orbit-common --all-targets -- -D warnings
- make ci-fast
- git diff --check

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10498-6a66c14c`
- Behind base: 0
- Ahead of base: 1