### PR TITLE
Fix workspace-checkout-binding id collision under rapid sequential Orbit CLI invocations

### DIFF
--- a/crates/orbit-store/src/sqlite/task_registry/queries.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/queries.rs
@@ -22,6 +22,30 @@ pub(super) fn workspace_by_orbit_dir(
     .map_err(|e| OrbitError::Store(e.to_string()))
 }
 
+/// Machine-local checkout for a `repo_root` + `workspace_path` pair. Those two
+/// normalized paths identify the checkout itself, so a repeat bind for the same
+/// logical checkout resolves back to its existing workspace id even when the
+/// caller brought a different orbit dir (ORB-10507). Ties are broken the same
+/// way `find_rebind_candidates` orders candidates, so a registry that already
+/// holds duplicate path rows resolves deterministically.
+pub(super) fn workspace_checkout_by_paths(
+    conn: &Connection,
+    repo_root: &Path,
+    workspace_path: &Path,
+) -> Result<Option<WorkspaceCheckoutBinding>, OrbitError> {
+    conn.query_row(
+        "SELECT workspace_id, repo_root, workspace_path, orbit_dir, created_at, updated_at
+         FROM workspace_checkout_bindings
+         WHERE repo_root = ?1 AND workspace_path = ?2
+         ORDER BY updated_at DESC, workspace_id ASC
+         LIMIT 1",
+        params![path_to_string(repo_root), path_to_string(workspace_path)],
+        decode_workspace_checkout_binding,
+    )
+    .optional()
+    .map_err(|e| OrbitError::Store(e.to_string()))
+}
+
 pub(super) fn workspace_by_id(
     conn: &Connection,
     workspace_id: &str,

--- a/crates/orbit-store/src/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/store.rs
@@ -14,7 +14,7 @@ use super::projection::create_projection_symlink;
 use super::queries::{
     decode_task_bundle_binding, decode_workspace_checkout_binding, task_bundle_by_id,
     task_ids_for_workspace, workspace_by_id, workspace_by_orbit_dir, workspace_checkout_by_id,
-    write_task_index_rows,
+    workspace_checkout_by_paths, write_task_index_rows,
 };
 use super::schema::{
     apply_schema, assert_registry_user_version, reject_unsupported_registry_schema,
@@ -106,16 +106,46 @@ impl TaskRegistryStore {
 
         let workspace_id = match requested_workspace_id {
             Some(id) => id,
-            None => next_workspace_id_candidate(&tx, &slug, &workspace_path)?,
+            // A checkout is identified by its repo root and workspace path, not
+            // by the orbit dir the caller happens to be running with. Reusing
+            // the id already bound to those paths keeps a repeat bind from
+            // minting a second logical workspace for the same checkout.
+            None => match workspace_checkout_by_paths(&tx, &repo_root, &workspace_path)? {
+                Some(existing) => existing.workspace_id,
+                None => next_workspace_id_candidate(&tx, &slug, &workspace_path)?,
+            },
         };
+        let now = now_string();
         if let Some(existing) = workspace_checkout_by_id(&tx, &workspace_id)? {
-            return Err(OrbitError::Store(format!(
-                "workspace id '{workspace_id}' already has a local checkout at '{}'",
-                existing.orbit_dir.display()
-            )));
+            // The logical workspace already has a checkout, and it is bound to
+            // a different orbit dir (a matching one returned above). When the
+            // checkout paths are unchanged this is the same checkout whose
+            // orbit dir moved — the shape short-lived CLI invocations produce
+            // when they generate an ephemeral orbit dir per call — so move the
+            // binding instead of failing (ORB-10507). A checkout at genuinely
+            // different paths still conflicts: a real id clash, not a rebind.
+            if normalize_path(&existing.repo_root) != repo_root
+                || normalize_path(&existing.workspace_path) != workspace_path
+            {
+                return Err(OrbitError::Store(format!(
+                    "workspace id '{workspace_id}' already has a local checkout at '{}'",
+                    existing.orbit_dir.display()
+                )));
+            }
+            tx.execute(
+                "UPDATE workspace_checkout_bindings
+                 SET orbit_dir = ?2, updated_at = ?3
+                 WHERE workspace_id = ?1",
+                params![workspace_id, path_to_string(&orbit_dir), now],
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+            let binding = workspace_checkout_by_id(&tx, &workspace_id)?.ok_or_else(|| {
+                OrbitError::Store("failed to read rebound workspace checkout binding".into())
+            })?;
+            tx.commit().map_err(|e| OrbitError::Store(e.to_string()))?;
+            return Ok(binding);
         }
 
-        let now = now_string();
         if workspace_by_id(&tx, &workspace_id)?.is_none() {
             tx.execute(
                 "INSERT INTO workspace_bindings (

--- a/crates/orbit-store/src/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/tests/mod.rs
@@ -810,6 +810,97 @@ fn bind_workspace_is_idempotent_for_orbit_dir() {
 }
 
 #[test]
+fn bind_workspace_rebinds_same_checkout_under_a_new_orbit_dir() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let first = bind(&store, temp.path());
+
+    // A later process for the same logical checkout brings its own ephemeral
+    // orbit dir (ORB-10507). The bind must move the existing checkout binding
+    // instead of failing with "already has a local checkout".
+    let ephemeral_orbit_dir = temp.path().join(".orbit-ephemeral");
+    fs::create_dir_all(&ephemeral_orbit_dir).expect("create ephemeral orbit dir");
+    let second = store
+        .bind_workspace(BindWorkspaceParams {
+            workspace_id: Some(first.workspace_id.clone()),
+            slug: "Orbit Test".into(),
+            repo_root: temp.path().to_path_buf(),
+            workspace_path: temp.path().to_path_buf(),
+            orbit_dir: ephemeral_orbit_dir.clone(),
+            repo_fingerprint: None,
+        })
+        .expect("rebind under a new orbit dir");
+
+    assert_eq!(second.workspace_id, first.workspace_id);
+    assert_eq!(second.orbit_dir, normalize_path(&ephemeral_orbit_dir));
+    assert_eq!(
+        store
+            .find_workspace_checkout(&first.workspace_id)
+            .expect("find checkout")
+            .expect("checkout exists")
+            .orbit_dir,
+        normalize_path(&ephemeral_orbit_dir),
+        "the moved binding is the workspace's only checkout row"
+    );
+}
+
+#[test]
+fn bind_workspace_reuses_derived_id_for_same_paths_under_a_new_orbit_dir() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let repo_root = temp.path().join("repo");
+    let first_orbit_dir = repo_root.join(".orbit");
+    fs::create_dir_all(&first_orbit_dir).expect("create orbit dir");
+    let derive = |orbit_dir: PathBuf| BindWorkspaceParams {
+        workspace_id: None,
+        slug: "Orbit Test".into(),
+        repo_root: repo_root.clone(),
+        workspace_path: repo_root.clone(),
+        orbit_dir,
+        repo_fingerprint: None,
+    };
+
+    let first = store
+        .bind_workspace(derive(first_orbit_dir))
+        .expect("derive first binding");
+    let ephemeral_orbit_dir = repo_root.join(".orbit-ephemeral");
+    fs::create_dir_all(&ephemeral_orbit_dir).expect("create ephemeral orbit dir");
+    let second = store
+        .bind_workspace(derive(ephemeral_orbit_dir.clone()))
+        .expect("derive second binding");
+
+    assert_eq!(
+        second.workspace_id, first.workspace_id,
+        "the same checkout paths resolve back to one logical workspace"
+    );
+    assert_eq!(second.orbit_dir, normalize_path(&ephemeral_orbit_dir));
+}
+
+#[test]
+fn bind_workspace_rejects_reusing_an_id_for_a_different_checkout() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let first = bind(&store, temp.path());
+
+    let other_root = temp.path().join("other-repo");
+    let other_orbit_dir = other_root.join(".orbit");
+    fs::create_dir_all(&other_orbit_dir).expect("create other orbit dir");
+    let result = store.bind_workspace(BindWorkspaceParams {
+        workspace_id: Some(first.workspace_id.clone()),
+        slug: "Orbit Test".into(),
+        repo_root: other_root.clone(),
+        workspace_path: other_root,
+        orbit_dir: other_orbit_dir,
+        repo_fingerprint: None,
+    });
+
+    assert!(matches!(
+        result,
+        Err(OrbitError::Store(message)) if message.contains("already has a local checkout")
+    ));
+}
+
+#[test]
 fn bind_workspace_rejects_explicit_workspace_id_conflict() {
     let temp = TempDir::new().expect("tempdir");
     let store = store(&temp);

--- a/crates/orbit-store/src/sqlite/task_registry/workspace_id.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/workspace_id.rs
@@ -3,9 +3,17 @@ use std::path::Path;
 use orbit_common::types::OrbitError;
 use rusqlite::Connection;
 
-use super::queries::workspace_by_id;
+use super::queries::{workspace_by_id, workspace_checkout_by_id};
 use super::util::normalize_path;
 
+/// Allocate an unused logical workspace id for `slug` + `path`.
+///
+/// A candidate counts as taken when *either* registry table already claims it:
+/// the logical `workspace_bindings` row or the machine-local
+/// `workspace_checkout_bindings` row. Checking only the logical table let the
+/// allocator hand back an id whose checkout row already existed, which then
+/// failed the caller's checkout-collision check instead of retrying with the
+/// next attempt (ORB-10507).
 pub(super) fn next_workspace_id_candidate(
     conn: &Connection,
     slug: &str,
@@ -13,7 +21,9 @@ pub(super) fn next_workspace_id_candidate(
 ) -> Result<String, OrbitError> {
     for attempt in 0..1000 {
         let candidate = workspace_id_candidate(slug, path, attempt);
-        if workspace_by_id(conn, &candidate)?.is_none() {
+        if workspace_by_id(conn, &candidate)?.is_none()
+            && workspace_checkout_by_id(conn, &candidate)?.is_none()
+        {
             return Ok(candidate);
         }
     }


### PR DESCRIPTION
## Task

[ORB-10507](https://orbit-cli.com/tasks/ORB-10507) — Fix workspace-checkout-binding id collision under rapid sequential Orbit CLI invocations

### Description

## Problem
`SqliteTaskRegistryStore::bind_workspace` (`crates/orbit-store/src/sqlite/task_registry/store.rs:70-147`) derives the logical `workspace_id` deterministically from `slug` + normalized `path` only (`workspace_id_candidate` in `crates/orbit-store/src/sqlite/task_registry/workspace_id.rs:25-29`, `blake3::hash("{slug}:{path}:{attempt}")`), independent of `orbit_dir`. The early-return idempotency check at store.rs:92-105 only short-circuits when the *same* `orbit_dir` is rebinding; a second bind for the same logical `slug`/`path` but a *different* (e.g. freshly generated ephemeral) `orbit_dir` skips that early return, recomputes the same candidate id via `next_workspace_id_candidate`, and then fails at store.rs:111-116 (`workspace id '{workspace_id}' already has a local checkout at '{}'`) because a checkout-binding row for that id (registered by an earlier process against a different `orbit_dir`) already exists. This makes checkout binding non-idempotent across processes whose `orbit_dir` isn't stable for a given logical workspace path, which is exactly the shape of short-lived CLI invocations that set up their own ephemeral orbit dir per call.

## Evidence
F2026-07-177 (filed during ORB-10489's friction-curation pass, 2026-07-27): a bash loop issuing 7-8 sequential (non-`&`, single-process-at-a-time) `orbit friction`/`orbit task` CLI calls on this box intermittently hit `{"code":"store_error","error":"workspace id 'tmp-...' already has a local checkout at '/tmp/orbit-...'"}`, plus separately malformed/empty stdout on some calls in the same batch. Re-running the exact same calls individually (one Bash tool-call at a time) succeeded every time, pointing at contention in the shared SQLite-backed workspace-registration path itself rather than at the caller's own concurrency (there was none from the caller's side). Confirmed against the current tree (2026-07-27): the collision-prone code paths above are unchanged at `crates/orbit-store/src/sqlite/task_registry/store.rs:107-116` and `crates/orbit-store/src/sqlite/task_registry/workspace_id.rs:9-29`.

## Suggested fix
Either (a) key the idempotency check at store.rs:92-105 (and the collision check at 111-116) off `slug`+`path` instead of / in addition to `orbit_dir` so a repeat bind for the same logical workspace reuses the existing checkout-binding row regardless of a churny `orbit_dir`, or (b) if distinct `orbit_dir`s per logical workspace are intentionally supported as separate checkouts, give `next_workspace_id_candidate` enough entropy (e.g. incorporate `orbit_dir` into the hash input, or genuinely use the existing `attempt` retry loop) so same-`slug`+`path` binds from different `orbit_dir`s don't collide on id and instead allocate distinct ids or reuse cleanly. Either way, rapid sequential single-process CLI invocations against the same logical workspace path must not intermittently fail with `store_error`.

## Acceptance criteria
- Two sequential `bind_workspace` calls for the same `slug`+`path` but different `orbit_dir` no longer raise `workspace id '...' already has a local checkout` — they either reuse the existing binding or allocate a distinct id.
- A regression test in `crates/orbit-store/src/sqlite/task_registry/tests/mod.rs` covers the same-slug-and-path/different-orbit_dir rebind case.
- No change to the genuine cross-process SQLite write-lock behavior (the fix targets id-derivation/idempotency logic, not locking).

### Acceptance Criteria

- Two sequential bind_workspace calls for the same slug+path but different orbit_dir no longer raise "workspace id '...' already has a local checkout" — they either reuse the existing binding or allocate a distinct id.
- A regression test in crates/orbit-store/src/sqlite/task_registry/tests/mod.rs covers the same-slug-and-path/different-orbit_dir rebind case.
- No change to genuine cross-process SQLite write-lock behavior — the fix targets id-derivation/idempotency logic, not locking.

## Execution Summary

<details>
<summary>Click to expand</summary>

Made SqliteTaskRegistryStore::bind_workspace idempotent for a logical checkout whose orbit_dir changes between processes.

Root cause (refined from the task description): the collision does not come from next_workspace_id_candidate handing back the same id — that loop skips ids already present in workspace_bindings. The real path is orbit-core/src/runtime/builder.rs:build_v2_task_backends. When an ephemeral orbit dir has no config.yaml, rebind_candidate_workspace_id looks up find_rebind_candidates (matches on repo_root OR workspace_path OR orbit_dir), finds the prior binding for the same repo_root, and passes its workspace_id back into bind_workspace as an explicit request. bind_workspace's early return only fires on an exact orbit_dir match, so the explicitly requested id fell through to the checkout-collision check at store.rs:111 and failed with "workspace id '...' already has a local checkout at '...'".

Changes:
- store.rs bind_workspace: when the target workspace_id already has a checkout bound to a different orbit_dir, compare the existing checkout's normalized repo_root/workspace_path against the incoming ones. If they match, this is the same checkout whose orbit dir moved — UPDATE workspace_checkout_bindings.orbit_dir (+ updated_at) and return the rebound row. If the paths differ it is a genuine id clash and the original store error is preserved verbatim.
- store.rs bind_workspace: in the derive path (no requested id), first resolve an existing checkout by (repo_root, workspace_path) and reuse its workspace_id, so a repeat bind cannot mint a second logical workspace for the same checkout (which is what later makes find_rebind_candidates return multiple rows and fail admission).
- queries.rs: new workspace_checkout_by_paths helper (repo_root + workspace_path lookup, ordered updated_at DESC / workspace_id ASC to match find_rebind_candidates so pre-existing duplicate rows resolve deterministically).
- workspace_id.rs: next_workspace_id_candidate now treats a candidate as taken when either workspace_bindings OR workspace_checkout_bindings claims it, so an orphaned checkout row can no longer be handed out as a "free" id.

Locking is untouched: same single TransactionBehavior::Immediate transaction, same connection pragmas — the fix is purely id-derivation/idempotency.

Tests (crates/orbit-store/src/sqlite/task_registry/tests/mod.rs): bind_workspace_rebinds_same_checkout_under_a_new_orbit_dir (explicit id, same slug+path, new orbit dir → reuses the binding and the checkout row moves), bind_workspace_reuses_derived_id_for_same_paths_under_a_new_orbit_dir (derived id case), bind_workspace_rejects_reusing_an_id_for_a_different_checkout (a real clash still errors).

Scope note: queries.rs was not in context_files; it was appended because the new path-keyed lookup belongs with the other registry SQL helpers per the module's documented layout rather than inlined in store.rs.

Validation: cargo test -p orbit-store (309 passed, 3 ignored), cargo test -p orbit-core --lib runtime (298 passed — covers the builder.rs binding path), cargo clippy -p orbit-store --all-targets (only a pre-existing needless_borrow warning in bundle_io/mod.rs, untouched by this change), make ci-fast green. The original CLI-level repro was not re-run end to end: it would have to execute against the live ~/.orbit global registry, which this change is not worth mutating; the store-level regression tests cover the id-derivation logic the acceptance criteria name.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10507-6a66bf99`
- Behind base: 0
- Ahead of base: 1