### PR TITLE
Give learning.supersede an explicit remote-stub error like learning.show

### DIFF
--- a/crates/orbit-core/src/command/learning.rs
+++ b/crates/orbit-core/src/command/learning.rs
@@ -89,6 +89,12 @@ impl OrbitRuntime {
             id: old_id,
             with: new_id,
         })?;
+        // Keep lifecycle writes consistent with `learning show`: an allocated
+        // record whose body belongs to an unreadable sibling worktree is a
+        // remote stub, not an unallocated id. Perform this after the role gate
+        // so executor callers still cannot probe learning existence.
+        self.get_learning(old_id)?;
+        self.get_learning(new_id)?;
         self.supersede_learning(old_id, new_id)
     }
 

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/learning_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/learning_tools.rs
@@ -23,6 +23,7 @@ use orbit_common::types::{
 use orbit_store::{LearningCreateParams, LearningSearchParams};
 use orbit_tools::ToolRegistry;
 use serde_json::{Value, json};
+use tempfile::tempdir;
 
 use super::super::test_support::test_runtime;
 use crate::OrbitRuntime;
@@ -339,6 +340,49 @@ fn supersede_rejects_id_equal_to_with() {
     )
     .expect_err("self-supersede rejected");
     assert!(matches!(err, OrbitError::InvalidInput(_)));
+}
+
+#[test]
+fn supersede_reports_an_unreadable_remote_stub_like_show() {
+    let root = tempdir().expect("tempdir");
+    let global_root = root.path().join("global");
+    let shared_root = root.path().join("repo/.orbit");
+    let remote_root = root.path().join("remote/.orbit");
+    let local_root = root.path().join("local/.orbit");
+    for path in [&global_root, &shared_root, &remote_root, &local_root] {
+        std::fs::create_dir_all(path).expect("create runtime root");
+    }
+
+    let remote = OrbitRuntime::from_resolved_roots(&global_root, &shared_root, &remote_root)
+        .expect("remote runtime");
+    let remote_learning = create_minimal(&remote, "remote", &[], &[]);
+    std::fs::remove_file(
+        remote_root
+            .join("learnings")
+            .join(&remote_learning.id)
+            .join("learning.yaml"),
+    )
+    .expect("remove remote learning body");
+
+    let local = OrbitRuntime::from_resolved_roots(&global_root, &shared_root, &local_root)
+        .expect("local runtime");
+    let replacement = create_minimal(&local, "replacement", &[], &[]);
+    let _env = human_context_env();
+
+    let err = super::super::learning_tools::supersede(
+        &local,
+        json!({"id": remote_learning.id, "with": replacement.id}),
+        None,
+        None,
+    )
+    .expect_err("remote stub is not locally mutable");
+
+    let OrbitError::Store(message) = err else {
+        panic!("expected remote-stub store error");
+    };
+    assert!(message.contains("is recorded in another worktree"));
+    assert!(message.contains("body is not locally readable"));
+    assert!(message.contains("worktree_root="));
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-10503](https://orbit-cli.com/tasks/ORB-10503) — Give learning.supersede an explicit remote-stub error like learning.show

### Description

## Problem
`orbit.learning.show` gives an explicit, actionable error when a learning is a remote stub whose body is not locally readable ("is recorded in another worktree and its body is not locally readable; worktree_root=..., branch=..."). `orbit.learning.supersede` does not: it calls the raw store `get_learning`/`locate_learning` path, which has no federated/remote-stub awareness and falls straight to a generic `OrbitError::not_found`, indistinguishable from "this id was never allocated".

## Evidence
F2026-07-026 (during ORB-10182): `orbit.learning.show` returned remote learning L-0078 successfully, but `orbit.learning.supersede {old_id:L-0078,new_id:L-0080}` immediately returned "learning not found: L-0078".

Confirmed still live in friction-curation pass (ORB-10489, 2026-07-27): `orbit.learning.show`'s explicit remote-stub error now exists at `crates/orbit-core/src/command/learning.rs:155-168,399-406` (`remote_artifact_error`) — this part is fixed. `orbit.learning.supersede` (`learning_tools.rs:196-205` -> `crates/orbit-store/src/file/learning_store/api/lifecycle.rs:38-41`) still has no equivalent check and returns generic `OrbitError::not_found`.

## Suggested fix
Route `orbit.learning.supersede`'s (and any other lifecycle-mutating learning tool's) lookup through the same remote-stub-aware path `orbit.learning.show` already uses, so a remote-only stub produces the same explicit, actionable error rather than a generic not-found.

## Acceptance criteria
- `orbit.learning.supersede` against a remote-stub id returns an error explicitly stating the body is not locally readable (matching `orbit.learning.show`'s error shape), not a generic not-found.

### Acceptance Criteria

- orbit.learning.supersede against a remote-stub id returns an error explicitly stating the body is not locally readable (matching orbit.learning.show's error shape), not a generic not-found.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a post-authoring-gate federated lookup for both supersede IDs, so unreadable remote learning stubs return the same actionable body-not-locally-readable error used by learning.show.
- Added a focused two-worktree regression test that removes a remote learning body and asserts orbit.learning.supersede reports the remote-stub error.
- Added file:crates/orbit-core/src/command/learning.rs to context_files because the shared authoring lifecycle method is required to keep CLI and tool behavior consistent.
Assessment: Scoped behavior change preserves the executor write gate while making human-authorized supersede failures actionable.
Validation:
- cargo fmt --check
- cargo test -p orbit-core supersede_reports_an_unreadable_remote_stub_like_show --lib
- make ci-fast
Friction checkpoint: no new friction found.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10503-6a66c14d`
- Behind base: 0
- Ahead of base: 1