### PR TITLE
Surface detached pipeline-worker startup failures and guarantee routine-run claiming

### DIFF
--- a/crates/orbit-core/src/command/job/pipeline.rs
+++ b/crates/orbit-core/src/command/job/pipeline.rs
@@ -1,3 +1,5 @@
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc;
@@ -27,6 +29,7 @@ const PIPELINE_WAIT_DEFAULT_TIMEOUT_SECONDS: u64 = 3600;
 const PIPELINE_WAIT_MAX_TIMEOUT_SECONDS: u64 = 7200;
 const PIPELINE_WAIT_DEFAULT_POLL_SECONDS: u64 = 5;
 const PIPELINE_WAIT_MIN_POLL_SECONDS: u64 = 1;
+const PIPELINE_WORKER_LOG_TAIL_BYTES: u64 = 16 * 1024;
 // ADR-0233: independent review is a post-publication exact-head child Run.
 const INDEPENDENT_REVIEW_JOB: &str = "task_review_pipeline";
 
@@ -294,10 +297,13 @@ impl OrbitRuntime {
             let queued = !pipeline_run_is_runnable(&active_runs, &run.run_id, spec.max_active_runs);
 
             if let Err(error) = self.spawn_pipeline_worker(&run.run_id, actor) {
+                let worker_log = pipeline_worker_log_path(&self.paths().logs_dir, &run.run_id);
                 let message = format!(
-                    "pipeline worker for run '{}' could not start from registered workspace '{}': {error}",
+                    "pipeline worker for run '{}' could not start from registered workspace '{}': \
+                     {error}; worker log: '{}'",
                     run.run_id,
                     self.paths().repo_root.display(),
+                    worker_log.display(),
                 );
                 let _ = self.finalize_pipeline_worker_startup_failure(&run, &message, actor);
                 return Err(error);
@@ -707,6 +713,19 @@ impl OrbitRuntime {
         })?;
         let mut command = Command::new(resolve_pipeline_worker_executable(current_exe));
         configure_pipeline_worker_command(&mut command, &self.paths().repo_root, run_id);
+        let worker_log =
+            configure_pipeline_worker_stdio(&mut command, &self.paths().logs_dir, run_id)?;
+        self.spawn_pipeline_worker_process(run_id, actor, command, worker_log)
+            .map(|_| ())
+    }
+
+    pub(crate) fn spawn_pipeline_worker_process(
+        &self,
+        run_id: &str,
+        actor: Option<&str>,
+        mut command: Command,
+        worker_log: PathBuf,
+    ) -> Result<u32, OrbitError> {
         #[cfg(unix)]
         unsafe {
             command.pre_exec(|| {
@@ -729,6 +748,7 @@ impl OrbitRuntime {
         let run_id_for_observer = run_id.to_string();
         let actor_for_observer = actor.map(ToOwned::to_owned);
         let workspace_for_observer = self.paths().repo_root.clone();
+        let worker_log_for_observer = worker_log.clone();
         thread::Builder::new()
             .name(format!("pipeline-start-{run_id}"))
             .spawn(move || {
@@ -739,6 +759,7 @@ impl OrbitRuntime {
                     &run_id_for_observer,
                     child,
                     &workspace_for_observer,
+                    &worker_log_for_observer,
                     actor_for_observer.as_deref(),
                 ) {
                     tracing::error!(
@@ -756,9 +777,11 @@ impl OrbitRuntime {
         let child = command
             .spawn()
             .map_err(|error| OrbitError::Execution(format!("spawn pipeline worker: {error}")))?;
+        let child_pid = child.id();
         sender.send(child).map_err(|error| {
             OrbitError::Execution(format!("hand pipeline worker to startup observer: {error}"))
-        })
+        })?;
+        Ok(child_pid)
     }
 
     pub(crate) fn monitor_pipeline_worker_startup(
@@ -766,6 +789,7 @@ impl OrbitRuntime {
         run_id: &str,
         mut child: Child,
         workspace: &Path,
+        worker_log: &Path,
         actor: Option<&str>,
     ) -> Result<(), OrbitError> {
         let child_pid = child.id();
@@ -782,6 +806,7 @@ impl OrbitRuntime {
                         "worker_pid": child_pid,
                         "owner_pid": owner_pid,
                         "workspace": workspace,
+                        "worker_log": worker_log,
                         "state": run.state.to_string(),
                     }),
                     None,
@@ -797,9 +822,19 @@ impl OrbitRuntime {
                     "observe pipeline worker process for run '{run_id}': {error}"
                 ))
             })? {
+                let output = read_pipeline_worker_log_tail(worker_log);
+                let output_detail = output
+                    .as_deref()
+                    .filter(|value| !value.is_empty())
+                    .map(|value| format!("; worker output:\n{value}"))
+                    .unwrap_or_default();
                 let message = format!(
-                    "pipeline worker for run '{run_id}' exited with status {status} before claiming the persisted run from registered workspace '{}'; verify workspace registration and worker root discovery",
+                    "pipeline worker for run '{run_id}' exited with status {status} before \
+                     claiming the persisted run from registered workspace '{}'; worker log: \
+                     '{}'{output_detail}; verify workspace registration, worker root discovery, \
+                     and action availability",
                     workspace.display(),
+                    worker_log.display(),
                 );
                 self.finalize_pipeline_worker_startup_failure(&run, &message, actor)?;
                 return Ok(());
@@ -850,6 +885,7 @@ impl OrbitRuntime {
             json!({
                 "run_id": run.run_id,
                 "workspace": self.paths().repo_root,
+                "worker_log": pipeline_worker_log_path(&self.paths().logs_dir, &run.run_id),
             }),
             Some(message.to_string()),
         )
@@ -1271,9 +1307,103 @@ pub(crate) fn configure_pipeline_worker_command(
         .arg("run-pipeline-worker")
         .arg(run_id)
         .current_dir(workspace)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .stdin(Stdio::null());
+}
+
+pub(crate) fn pipeline_worker_log_path(logs_dir: &Path, run_id: &str) -> PathBuf {
+    logs_dir.join(format!("{run_id}.worker.log"))
+}
+
+pub(crate) fn configure_pipeline_worker_stdio(
+    command: &mut Command,
+    logs_dir: &Path,
+    run_id: &str,
+) -> Result<PathBuf, OrbitError> {
+    std::fs::create_dir_all(logs_dir).map_err(|error| {
+        OrbitError::Io(format!(
+            "create pipeline worker log directory '{}': {error}",
+            logs_dir.display()
+        ))
+    })?;
+    restrict_pipeline_worker_log_directory(logs_dir)?;
+
+    let log_path = pipeline_worker_log_path(logs_dir, run_id);
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let log = options.open(&log_path).map_err(|error| {
+        OrbitError::Io(format!(
+            "open pipeline worker log '{}': {error}",
+            log_path.display()
+        ))
+    })?;
+    restrict_pipeline_worker_log_file(&log_path)?;
+    let stdout = log.try_clone().map_err(|error| {
+        OrbitError::Io(format!(
+            "clone pipeline worker log '{}': {error}",
+            log_path.display()
+        ))
+    })?;
+    command.stdout(Stdio::from(stdout)).stderr(Stdio::from(log));
+    Ok(log_path)
+}
+
+fn read_pipeline_worker_log_tail(path: &Path) -> Option<String> {
+    let mut file = File::open(path).ok()?;
+    let len = file.metadata().ok()?.len();
+    let start = len.saturating_sub(PIPELINE_WORKER_LOG_TAIL_BYTES);
+    file.seek(SeekFrom::Start(start)).ok()?;
+    let mut bytes = Vec::with_capacity((len - start) as usize);
+    file.read_to_end(&mut bytes).ok()?;
+    let output = String::from_utf8_lossy(&bytes);
+    let output = orbit_common::utility::logging::redact_event_text(output.trim());
+    if output.is_empty() {
+        None
+    } else if start > 0 {
+        Some(format!(
+            "[truncated to final {PIPELINE_WORKER_LOG_TAIL_BYTES} bytes]\n{output}"
+        ))
+    } else {
+        Some(output)
+    }
+}
+
+#[cfg(unix)]
+fn restrict_pipeline_worker_log_directory(path: &Path) -> Result<(), OrbitError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)).map_err(|error| {
+        OrbitError::Io(format!(
+            "restrict pipeline worker log directory '{}': {error}",
+            path.display()
+        ))
+    })
+}
+
+#[cfg(not(unix))]
+fn restrict_pipeline_worker_log_directory(_path: &Path) -> Result<(), OrbitError> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn restrict_pipeline_worker_log_file(path: &Path) -> Result<(), OrbitError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|error| {
+        OrbitError::Io(format!(
+            "restrict pipeline worker log '{}': {error}",
+            path.display()
+        ))
+    })
+}
+
+#[cfg(not(unix))]
+fn restrict_pipeline_worker_log_file(_path: &Path) -> Result<(), OrbitError> {
+    Ok(())
 }
 
 fn pipeline_run_is_runnable(runs: &[JobRun], run_id: &str, max_active_runs: u32) -> bool {

--- a/crates/orbit-core/src/command/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/command/tests/job_pipeline.rs
@@ -1,6 +1,8 @@
 use std::ffi::OsStr;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use orbit_common::types::{AuditEventStatus, JobRunState, OrbitError};
@@ -10,7 +12,8 @@ use tempfile::TempDir;
 use crate::OrbitRuntime;
 use crate::command::job::JobRunListParams;
 use crate::command::job::pipeline::{
-    configure_pipeline_worker_command, resolve_pipeline_worker_executable,
+    configure_pipeline_worker_command, configure_pipeline_worker_stdio, pipeline_worker_log_path,
+    resolve_pipeline_worker_executable,
 };
 use crate::command::task::TaskAddParams;
 use crate::command::workflow::ShipMode;
@@ -113,24 +116,22 @@ fn worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic() {
         .jobs()
         .insert_job_run("task_gate_pipeline", 1, Utc::now(), None, None)
         .expect("insert pending run");
-    let child = Command::new("sh")
-        .args(["-c", "exit 23"])
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn failing worker fixture");
+    let mut command = Command::new("sh");
+    command.args([
+        "-c",
+        "printf 'worker stdout context\\n'; \
+         printf 'action registration missing: routine_dispatch\\n' >&2; \
+         exit 23",
+    ]);
+    let log_path =
+        configure_pipeline_worker_stdio(&mut command, &runtime.paths().logs_dir, &run.run_id)
+            .expect("configure worker log");
 
     runtime
-        .monitor_pipeline_worker_startup(
-            &run.run_id,
-            child,
-            &runtime.paths().repo_root,
-            Some("test"),
-        )
-        .expect("observe worker exit");
+        .spawn_pipeline_worker_process(&run.run_id, Some("test"), command, log_path.clone())
+        .expect("spawn detached failing worker fixture");
 
-    let stored = runtime.show_job_run(&run.run_id).expect("show failed run");
+    let stored = wait_for_worker_ownership_outcome(&runtime, &run.run_id);
     assert_eq!(stored.state, JobRunState::Interrupted);
     assert!(stored.finished_at.is_some());
     assert!(stored.pid.is_none());
@@ -145,6 +146,22 @@ fn worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic() {
     );
     assert!(message.contains("exit status: 23"), "{message}");
     assert!(message.contains("registered workspace"), "{message}");
+    assert!(
+        message.contains("action registration missing: routine_dispatch"),
+        "{message}"
+    );
+    assert!(
+        message.contains(&log_path.display().to_string()),
+        "{message}"
+    );
+
+    assert_eq!(
+        log_path,
+        pipeline_worker_log_path(&runtime.paths().logs_dir, &run.run_id)
+    );
+    let durable_output = std::fs::read_to_string(&log_path).expect("read durable worker log");
+    assert!(durable_output.contains("worker stdout context"));
+    assert!(durable_output.contains("action registration missing: routine_dispatch"));
 
     let audits = runtime
         .list_audit_events(None, None, Some(AuditEventStatus::Failure), None, 20)
@@ -157,6 +174,103 @@ fn worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic() {
                 .as_deref()
                 .is_some_and(|error| error.contains("before claiming"))
     }));
+}
+
+#[cfg(unix)]
+#[test]
+fn routine_style_detached_worker_is_claimed_within_ownership_window() {
+    let (_root, runtime) = test_runtime();
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("auto_task_scheduler_pipeline", 1, Utc::now(), None, None)
+        .expect("insert routine-dispatched run");
+    let mut command = Command::new("sh");
+    command.args(["-c", "printf 'routine worker startup\\n' >&2; sleep 0.25"]);
+    let log_path =
+        configure_pipeline_worker_stdio(&mut command, &runtime.paths().logs_dir, &run.run_id)
+            .expect("configure routine worker log");
+
+    let started = Instant::now();
+    let worker_pid = runtime
+        .spawn_pipeline_worker_process(
+            &run.run_id,
+            Some("routine-sweep"),
+            command,
+            log_path.clone(),
+        )
+        .expect("spawn detached routine worker fixture");
+    runtime
+        .stores()
+        .jobs()
+        .claim_pending_job_run_owner(&run.run_id, worker_pid)
+        .expect("claim routine run");
+
+    let stored = wait_for_worker_ownership_outcome(&runtime, &run.run_id);
+    assert_eq!(stored.state, JobRunState::Pending);
+    assert_eq!(stored.pid, Some(worker_pid));
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "detached routine worker exceeded ownership window"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let audits = runtime
+            .list_audit_events(None, None, None, None, 20)
+            .expect("list claimed-worker audit");
+        if audits.iter().any(|audit| {
+            audit.tool_name.as_deref() == Some("pipeline.worker.claimed")
+                && audit.target_id.as_deref() == Some(run.run_id.as_str())
+        }) {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "ownership observer did not persist a claimed audit"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    assert_eq!(
+        log_path,
+        pipeline_worker_log_path(&runtime.paths().logs_dir, &run.run_id)
+    );
+    let durable_output = wait_for_log_contains(&log_path, "routine worker startup");
+    assert!(durable_output.contains("routine worker startup"));
+}
+
+fn wait_for_worker_ownership_outcome(
+    runtime: &OrbitRuntime,
+    run_id: &str,
+) -> orbit_common::types::JobRun {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let stored = runtime.show_job_run(run_id).expect("show worker run");
+        if stored.pid.is_some() || stored.state != JobRunState::Pending {
+            return stored;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "worker remained pending and unclaimed beyond ownership window"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn wait_for_log_contains(path: &Path, expected: &str) -> String {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let output = std::fs::read_to_string(path).expect("read durable worker log");
+        if output.contains(expected) {
+            return output;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "worker log did not contain expected output: {expected}"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
 }
 
 #[test]

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -431,6 +431,8 @@ After [ORB-10470] / [ADR-0289], resume is a durable *submission* scoped by expli
 
 After [ORB-10070], orphan reconciliation also covers `pending` runs. Pipeline workers claim their queued run at startup (`claim_pending_job_run_owner` records `pid` + start-time token while the run is still `pending`), so a queued run polling for its admission slot carries a probeable owner exactly like a running run. Reconcile finalizes a pending run as `interrupted` (`Pending + Interrupt` is now a legal transition) in two conclusive cases: its claimed owner is `Mismatch`/`Missing`, or it was never claimed and is older than a 30-minute grace window (covering workers that died before claiming and queued runs written by pre-claim binaries, e.g. stranded by a host reboot after their parent run was interrupted). Inconclusive probes and fresh unclaimed runs stay `pending`. `orbit doctor`'s `job-runs` check reports both orphan classes read-only, and `orbit run cancel <run_id>` gives operators a direct terminalization path.
 
+After [ORB-10461], every detached pipeline worker appends stdout and stderr to the private run-addressable path `.orbit/state/logs/<run_id>.worker.log`. The parent-side startup observer records that path in claimed/failure audit events. If the child exits before setting its pending-run owner, the observer terminalizes the same run as `interrupted` and copies a redacted, bounded tail of the worker output into the synthetic diagnostic step; startup and action-registration errors are therefore inspectable by run id without waiting for the stale-run grace window. Normal claimed-worker execution and admission polling are unchanged.
+
 The loop shares one pipeline map and session map across iterations, which makes cross-iteration `session:` meaningful.
 
 ### 8.7 Invocation metrics
@@ -672,6 +674,7 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[ORB-10414]** — Make HTTP replay an explicit default-off cargo feature and keep replay environment variables inert in default builds.
 - **[ORB-10434]** — Extend the replay opt-in to orbit-core (`orbit-core/replay`) so its fixture-backed v2_host test keeps running hermetically instead of demanding a live credential.
 - **[ORB-10456]** — Resolve provider launchers at the shared CLI spawn boundary and report provider-aware searched-location diagnostics.
+- **[ORB-10461]** — Persist detached pipeline-worker output by run id and terminalize pre-claim exits with the captured startup diagnostic.
 - **[ORB-10464]** — Verify that done dependencies are delivered into the pinned base before a worktree is created.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10461](https://orbit-cli.com/tasks/ORB-10461) — Surface detached pipeline-worker startup failures and guarantee routine-run claiming

### Description

## Problem
Detached run-pipeline-worker children still discard stdout/stderr, so an immediate startup/action-registration failure can leave a submitted run pending with no durable diagnostic (F2026-07-007). The same worker-ownership path produced never_claimed routine runs under systemd (F2026-07-016).

## Evidence
crates/orbit-core/src/command/job/pipeline.rs:1155-1160 spawns run-pipeline-worker with both streams set to Stdio::null. F2026-07-007 records jrun-20260711-1843 remaining pending until the hidden worker command was run in foreground; F2026-07-016 records routine-dispatched runs terminalizing never_claimed.

## Scope
Make worker startup/claim failure observable and deterministic without changing normal pipeline semantics.

### Acceptance Criteria

- An immediate detached-worker exit records a terminal run error with the underlying spawn/action message instead of leaving the run pending.
- A deterministic routine/systemd-style fixture proves a submitted worker is claimed or terminalized within the ownership window.
- Worker stdout/stderr or an equivalent structured startup channel is durably discoverable by run id, with regression tests for the F2026-07-007 and F2026-07-016 paths.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Detached pipeline workers now append stdout/stderr to the private, predictable `.orbit/state/logs/<run_id>.worker.log` path instead of discarding both streams. Claimed and failed startup audits carry the same path.
- The startup observer reads a redacted 16 KiB tail when a child exits before claiming, terminalizes the original pending run as `interrupted`, and persists the underlying worker/action output in its diagnostic step.
- Added deterministic detached fixtures for both ownership outcomes: an immediate action-registration-style stderr failure terminalizes within two seconds, while a routine/systemd-style worker claim is observed and audited within the same bounded window. Both assert run-id log discovery.
- Added `docs/design/activity-job/2_design.md` to task context and documented the new startup-log/terminalization contract, as required by the repository's same-PR design-doc policy.

Validation:
- `cargo test -p orbit-core --lib command::tests::job_pipeline -- --nocapture`: 9 passed.
- `make ci-fast`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- Additional `cargo clippy -p orbit-core --lib -- -D warnings` could not complete because the baseline currently fails in unmodified files: `orbit-store/.../bundle_io/mod.rs:172` (`needless_borrow`) and, with `--no-deps`, `orbit-core/src/command/job/run/owner.rs:226` (`unnecessary_cast`).

Assessment: The scoped worker boundary is now deterministic and operationally inspectable without changing normal claimed-worker execution or queue admission semantics.
Design weaknesses / risks:
- Severity: low. Per-run worker logs append for the run lifetime and are not yet included in the global JSONL archive-pruning policy. Mitigation: keep files private (directory 0700/file 0600) and align their retention with durable run retention in follow-up operations work if fleet volume warrants it.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10461-6a66bf62`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*