### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,3 +1,9 @@
+---
+type: context
+summary: Orbit Configuration
+last_validated: 2026-07-27
+---
+
 # Orbit Configuration
 
 Reference for Orbit's runtime config — the `config.toml` consumed by `orbit run ship`, `duel-plan`, and the activity-job dispatcher. The defaults shipped with the binary live in [`crates/orbit-core/assets/config/default-config.toml`](../crates/orbit-core/assets/config/default-config.toml).

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -1,3 +1,9 @@
+---
+type: context
+summary: Lessons Learned While Building Orbit
+last_validated: 2026-07-27
+---
+
 # Lessons Learned While Building Orbit
 
 **Status:** Draft
@@ -31,9 +37,9 @@ In short, v3 results suggest MCP tools win the matchup against a generic `exec_c
 
 ## 2. The May 2026 Artifact Loss Incident
 
-On 2026-05-11, hundreds of task artifacts were wiped out due to our reckless workspace cleanup. These artifacts are now gone for good, and can never be recovered. The only way to prevent this from happening again is to implement a backup and recovery system for task artifacts [[ADR-0149](.orbit/adrs/proposed/ADR-0149)].
+On 2026-05-11, hundreds of task artifacts were wiped out due to our reckless workspace cleanup. These artifacts are now gone for good, and can never be recovered. The only way to prevent this from happening again is to implement a backup and recovery system for task artifacts ADR-0149.
 
-This was catastraphic, but also gave us a chance to amend for the sins of our bad design decisions that have been plaguing us for a while now. [[docs/design/task-artifacts/4_decisions](task-artifacts/4_decisions.md)]
+This was catastrophic, but also gave us a chance to amend for the sins of our bad design decisions that have been plaguing us for a while now. [docs/design/task-artifacts/4_decisions](design/task-artifacts/4_decisions.md)
 
 **Lesson**: Backup and recovery are not optional for long-lived artifacts.
 

--- a/docs/design/_templates/references/glossary.md
+++ b/docs/design/_templates/references/glossary.md
@@ -1,3 +1,9 @@
+---
+type: design
+summary: "Glossary: <Feature>"
+last_validated: 2026-07-27
+---
+
 # Glossary: <Feature>
 
 <!-- One paragraph: what vocabulary is in scope, and what is deliberately

--- a/docs/design/_templates/specs/_mechanism.md
+++ b/docs/design/_templates/specs/_mechanism.md
@@ -1,3 +1,9 @@
+---
+type: design
+summary: "Spec: <Mechanism>"
+last_validated: 2026-07-27
+---
+
 # Spec: <Mechanism>
 
 <!-- One-paragraph contract statement: the guarantee this mechanism provides. -->

--- a/docs/design/activity-job/references/glossary.md
+++ b/docs/design/activity-job/references/glossary.md
@@ -1,3 +1,9 @@
+---
+type: design
+summary: "Glossary: Activity / Job"
+last_validated: 2026-07-27
+---
+
 # Glossary: Activity / Job
 
 This glossary covers Orbit-specific execution-substrate vocabulary used by the Activity / Job docs. It deliberately excludes generic workflow terms such as "retry," "quorum," and "timeout" unless Orbit gives them a more specific meaning.


### PR DESCRIPTION
## Task

[ORB-10512](https://orbit-cli.com/tasks/ORB-10512) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Selected the six in-scope docs with no last_validated key, ordered by stable path tie-break: docs/CONFIG.md, docs/LESSONS.md, docs/POSITIONING.md, docs/design/_templates/references/glossary.md, docs/design/_templates/specs/_mechanism.md, and docs/design/activity-job/references/glossary.md.
- Validated and stamped five docs with last_validated: 2026-07-27. Migrated schema-compatible frontmatter on docs/CONFIG.md (type context, summary Orbit Configuration), docs/LESSONS.md (type context, summary Lessons Learned While Building Orbit), the two selected template docs (type design, summaries derived from their headings), and the Activity / Job glossary (type design, summary Glossary: Activity / Job). The inferred type and summary follow crates/orbit-core/src/command/docs/frontmatter.rs.
- docs/CONFIG.md was checked against crates/orbit-core/assets/config/default-config.toml, crates/orbit-core/src/config/runtime.rs, crates/orbit-core/src/config/bootstrap.rs, and the provider/config tests; no factual drift was found.
- docs/LESSONS.md was checked against benchmarks/graph/v1/RESULTS.md, v2/RESULTS.md, and v3/RESULTS.md. The benchmark counts and conclusions match. Fixed the genuine misspelling catastrophic and repaired the malformed/broken Markdown links. ADR-0149 is not present in this checkout, so that historical citation was retained as plain text and not treated as verified.
- The two template docs were checked against docs/design/CONVENTIONS.md and the tolerant inference/schema implementation; they contain skeleton guidance only, with no unverifiable implementation claims.
- The Activity / Job glossary claims were checked with rg against crates/orbit-common/src/types/activity_job, crates/orbit-core/src, docs/design/activity-job/2_design.md, and docs/design/activity-job/specs/audit-envelope.md; all entries were found and consistent.
- docs/POSITIONING.md was left unchanged and unstamped because its product positioning, roadmap, and audience claims are intent-level assertions not verifiable from repository implementation.
- No forbidden ADR, changelog, archive, task, graph, or generated-state files were modified.
Validation:
- make ci-fast: passed.
- cargo test -p orbit-core command::docs --lib: passed, 16 tests.
- git diff --check: passed.
Assessment: The bounded documentation rotation is complete for the verifiable portion of the batch; one selected document was deliberately left unchanged because its claims are not code-verifiable.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10512-6a66c703`
- Behind base: 0
- Ahead of base: 1