### PR TITLE
Introduce task-pilot as a plugin agent and Orbit activity/job

### DIFF
--- a/.orbit/resources/activities/apply_task_pilot_results.yaml
+++ b/.orbit/resources/activities/apply_task_pilot_results.yaml
@@ -1,0 +1,30 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: apply_task_pilot_results
+spec:
+  type: deterministic
+  description: Validate all task-pilot proposals, then replace only context_files.
+  input_schema_json:
+    type: object
+    required: [prepared, results, workspace_path, crew]
+    properties:
+      prepared: {type: object}
+      results: {type: array, items: {type: object}}
+      workspace_path: {type: string}
+      crew: {type: string}
+  output_schema_json:
+    type: object
+    required: [status, mode, crew, workspace_path, discovery, partition_decisions, partition_count, failed_partitions, tasks]
+    properties:
+      status: {type: string, enum: [success]}
+      mode: {type: string, enum: [automatic, explicit]}
+      crew: {type: string}
+      workspace_path: {type: string}
+      discovery: {type: object}
+      partition_decisions: {type: array, items: {type: object}}
+      partition_count: {type: number}
+      failed_partitions: {type: array, items: {type: object}}
+      tasks: {type: array, items: {type: object}}
+  action: apply_task_pilot_results
+  config: {}

--- a/.orbit/resources/activities/prepare_task_pilot.yaml
+++ b/.orbit/resources/activities/prepare_task_pilot.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: prepare_task_pilot
+spec:
+  type: deterministic
+  description: >
+    Select task-pilot candidates in the active workspace and partition them
+    into bounded groups. With explicit task_ids it selects exactly those
+    workspace tasks, including tasks with non-empty context_files. Without
+    task_ids it selects only proposed/backlog tasks whose context_files are
+    empty, excluding no-diff-needed/no-diff-expected tasks and every active,
+    review, or terminal status. This action never promotes or dispatches work.
+  input_schema_json:
+    type: object
+    properties:
+      task_ids:
+        type: array
+        items:
+          type: string
+      workspace_path:
+        type: string
+      max_tasks:
+        type: number
+        minimum: 1
+        maximum: 500
+      max_partition_size:
+        type: number
+        minimum: 1
+        maximum: 5
+  output_schema_json:
+    type: object
+    required: [mode, workspace_path, task_count, task_ids, tasks, partition_size, partition_count, partitions, excluded]
+    properties:
+      mode: {type: string, enum: [automatic, explicit]}
+      workspace_path: {type: string}
+      task_count: {type: number}
+      task_ids: {type: array, items: {type: string}}
+      tasks: {type: array, items: {type: object}}
+      partition_size: {type: number}
+      partition_count: {type: number}
+      partitions: {type: array, items: {type: object}}
+      excluded: {type: array, items: {type: object}}
+  action: prepare_task_pilot
+  config: {}

--- a/.orbit/resources/activities/task_pilot.yaml
+++ b/.orbit/resources/activities/task_pilot.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: task_pilot
+spec:
+  type: agent_loop
+  require_response_envelope: true
+  description: Read-only bounded task preflight with no repository-write or task-update grant.
+  input_schema_json:
+    type: object
+    required: [task_ids, workspace_path, base_branch, crew, partition_index]
+    properties:
+      task_ids: {type: array, minItems: 1, maxItems: 5, items: {type: string}}
+      workspace_path: {type: string}
+      base_branch: {type: string}
+      crew: {type: string}
+      partition_index: {type: number}
+  output_schema_json:
+    type: object
+    properties:
+      partition_index: {type: number}
+      task_ids: {type: array, items: {type: string}}
+      tasks: {type: array, items: {type: object}}
+      summary: {type: string}
+  instruction: |
+    You are Orbit's task-pilot for one explicit partition of at most five task IDs.
+    Read each task with orbit.task.show, inspect the target branch and accepted
+    ADRs using only read tools, and return exact context_files_before and canonical
+    file:/dir:/symbol: context_files_after values. Use disposition selectors for
+    non-empty values; use verified_no_diff or host_operational plus concrete
+    evidence for an empty value. Report recommended_crew, recommended_complexity,
+    blocked_by, duplicate_of, already_landed, adr_conflicts, utility_warnings,
+    and surface_warnings. Never update tasks, edit files, promote, dispatch,
+    implement, commit, push, invoke pipelines, or choose an architecture alternative.
+    Return one successful Orbit response envelope with partition_index, exact
+    task_ids, one tasks entry per ID, and summary. Fail the whole partition if
+    any task cannot be assessed.
+  tools:
+    - orbit.task.show
+    - orbit.task.list
+    - orbit.adr.show
+    - orbit.search
+    - orbit.learning.show
+    - fs.read
+    - proc.spawn
+  proc_allowed_programs: [git, rg]
+  on_denial: terminate
+  wall_clock_timeout_seconds: 1800

--- a/.orbit/resources/jobs/task_pilot_pipeline.yaml
+++ b/.orbit/resources/jobs/task_pilot_pipeline.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 2
+kind: Job
+metadata:
+  name: task_pilot_pipeline
+spec:
+  state: enabled
+  kind: workflow
+  max_active_runs: 3
+  default_input:
+    task_ids: []
+    workspace_path: .
+    base_branch: agent-main
+    crew: luna
+    max_tasks: 50
+    max_partition_size: 5
+  steps:
+    - id: prepare
+      target: activity:prepare_task_pilot
+      default_input:
+        task_ids: "{{ input.task_ids }}"
+        workspace_path: "{{ input.workspace_path }}"
+        max_tasks: "{{ input.max_tasks }}"
+        max_partition_size: "{{ input.max_partition_size }}"
+    - id: pilots
+      fan_out:
+        items: "{{ steps.prepare.output.partitions }}"
+        max_workers: 5
+        worker:
+          id: pilot
+          target: activity:task_pilot
+          default_input:
+            task_ids: "{{ item.task_ids }}"
+            partition_index: "{{ item.partition_index }}"
+            workspace_path: "{{ steps.prepare.output.workspace_path }}"
+            base_branch: "{{ input.base_branch }}"
+            crew: "{{ input.crew }}"
+      fan_in:
+        join: {mode: all}
+        collect: pilot_results
+    - id: apply
+      target: activity:apply_task_pilot_results
+      default_input:
+        prepared: "{{ steps.prepare.output }}"
+        results: "{{ steps.pilot_results.output }}"
+        workspace_path: "{{ steps.prepare.output.workspace_path }}"
+        crew: "{{ input.crew }}"

--- a/crates/orbit-core/assets/activities/apply_task_pilot_results.yaml
+++ b/crates/orbit-core/assets/activities/apply_task_pilot_results.yaml
@@ -1,0 +1,60 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: apply_task_pilot_results
+spec:
+  type: deterministic
+  description: >
+    Fail-closed task-pilot apply boundary. It validates complete partition
+    coverage, exact before snapshots, dispositions, canonical in-workspace
+    file/dir/symbol selectors, and target existence before the first mutation.
+    It then replaces only context_files on the prepared tasks. Every other task
+    field, lifecycle state, dispatch state, and recommendation remains unchanged.
+  input_schema_json:
+    type: object
+    required: [prepared, results, workspace_path, crew]
+    properties:
+      prepared:
+        type: object
+      results:
+        type: array
+        items:
+          type: object
+      workspace_path:
+        type: string
+      crew:
+        type: string
+  output_schema_json:
+    type: object
+    required:
+      [status, mode, crew, workspace_path, discovery, partition_decisions,
+       partition_count, failed_partitions, tasks]
+    properties:
+      status:
+        type: string
+        enum: [success]
+      mode:
+        type: string
+        enum: [automatic, explicit]
+      crew:
+        type: string
+      workspace_path:
+        type: string
+      discovery:
+        type: object
+      partition_decisions:
+        type: array
+        items:
+          type: object
+      partition_count:
+        type: number
+      failed_partitions:
+        type: array
+        items:
+          type: object
+      tasks:
+        type: array
+        items:
+          type: object
+  action: apply_task_pilot_results
+  config: {}

--- a/crates/orbit-core/assets/activities/prepare_task_pilot.yaml
+++ b/crates/orbit-core/assets/activities/prepare_task_pilot.yaml
@@ -1,0 +1,65 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: prepare_task_pilot
+spec:
+  type: deterministic
+  description: >
+    Select task-pilot candidates in the active workspace and partition them
+    into bounded groups. With explicit task_ids it selects exactly those
+    workspace tasks, including tasks with non-empty context_files. Without
+    task_ids it selects only proposed/backlog tasks whose context_files are
+    empty, excluding no-diff-needed/no-diff-expected tasks and every active,
+    review, or terminal status. This action never promotes or dispatches work.
+  input_schema_json:
+    type: object
+    properties:
+      task_ids:
+        type: array
+        items:
+          type: string
+      workspace_path:
+        type: string
+      max_tasks:
+        type: number
+        minimum: 1
+        maximum: 500
+      max_partition_size:
+        type: number
+        minimum: 1
+        maximum: 5
+  output_schema_json:
+    type: object
+    required:
+      [mode, workspace_path, task_count, task_ids, tasks, partition_size,
+       partition_count, partitions, excluded]
+    properties:
+      mode:
+        type: string
+        enum: [automatic, explicit]
+      workspace_path:
+        type: string
+      task_count:
+        type: number
+      task_ids:
+        type: array
+        items:
+          type: string
+      tasks:
+        type: array
+        items:
+          type: object
+      partition_size:
+        type: number
+      partition_count:
+        type: number
+      partitions:
+        type: array
+        items:
+          type: object
+      excluded:
+        type: array
+        items:
+          type: object
+  action: prepare_task_pilot
+  config: {}

--- a/crates/orbit-core/assets/activities/task_pilot.yaml
+++ b/crates/orbit-core/assets/activities/task_pilot.yaml
@@ -1,0 +1,125 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: task_pilot
+spec:
+  type: agent_loop
+  require_response_envelope: true
+  description: >
+    Read-only task preflight for one explicit bounded partition. The pilot
+    inspects the selected workspace and target branch, returns exact canonical
+    context_files proposals plus orchestration recommendations, and has no
+    repository-write, task-update, lifecycle, dispatch, or scheduling grant.
+  input_schema_json:
+    type: object
+    required: [task_ids, workspace_path, base_branch, crew, partition_index]
+    properties:
+      task_ids:
+        type: array
+        minItems: 1
+        maxItems: 5
+        items:
+          type: string
+      workspace_path:
+        type: string
+      base_branch:
+        type: string
+      crew:
+        type: string
+      partition_index:
+        type: number
+  # Agent-returned data is advisory until apply_task_pilot_results validates
+  # the complete fan-in. Keep fields optional at this boundary per L-0115.
+  output_schema_json:
+    type: object
+    properties:
+      partition_index:
+        type: number
+      task_ids:
+        type: array
+        items:
+          type: string
+      tasks:
+        type: array
+        items:
+          type: object
+      summary:
+        type: string
+  instruction: |
+    You are Orbit's task-pilot for one explicit, bounded partition.
+
+    Input contains `task_ids` (one to five exact IDs), `workspace_path`,
+    `base_branch`, `crew`, and `partition_index`. Work only on those task IDs
+    and treat the workspace as read-only.
+
+    For every task:
+
+    1. Call `orbit.task.show` and read its title, description, acceptance
+       criteria, plan, tags, relations, status, and exact current
+       `context_files`. Use `orbit.search` for the task ID and relevant design
+       terms; inspect accepted ADRs with `orbit.adr.show` when a result points
+       to one.
+    2. With `proc.spawn` run only read-only `git`/`rg` commands. Verify the
+       workspace Git top-level, inspect `base_branch`, and determine every real
+       file, directory, or symbol the stated change would modify or delete.
+       Use `fs.read` to inspect candidate targets. Do not edit repository files.
+    3. Propose `context_files_after` as exact canonical selectors using only
+       `file:`, `dir:`, or `symbol:`. Every anchor must already exist inside
+       `workspace_path`; omit read-for-context files. Preserve the exact current
+       list as `context_files_before`.
+    4. If the task genuinely requires no repository diff, return an empty
+       `context_files_after`, disposition `verified_no_diff`, and concrete
+       `evidence`. For host-operational work use `host_operational` with
+       evidence. Otherwise use disposition `selectors`. Never use an empty list
+       merely because inspection was inconclusive.
+    5. Report recommendations only; do not apply them:
+       `recommended_crew`, `recommended_complexity`, real `blocked_by` task IDs,
+       `duplicate_of`, `already_landed`, `adr_conflicts`, `utility_warnings`,
+       and `surface_warnings`. Cite evidence for duplicates/already-landed work
+       and ADR conflicts. Do not choose an architecture alternative silently.
+
+    Hard bounds:
+    - Never update a task, transition lifecycle state, promote, dispatch,
+      invoke a pipeline, edit/delete files, commit, push, or open a PR.
+    - Never inspect or report on task IDs outside the input partition except
+      when citing a concrete dependency, duplicate, or accepted ADR.
+    - Preserve provider provenance: task-pilot is a role, not an actor family.
+
+    Return exactly one Orbit response envelope:
+    {"schemaVersion":1,"status":"success","result":{
+      "partition_index":0,
+      "task_ids":["ORB-00000"],
+      "tasks":[{
+        "task_id":"ORB-00000",
+        "context_files_before":[],
+        "context_files_after":["file:path/to/target"],
+        "disposition":"selectors|verified_no_diff|host_operational",
+        "evidence":"required when context_files_after is empty",
+        "recommended_crew":"luna",
+        "recommended_complexity":"low|medium|hard",
+        "blocked_by":[],
+        "duplicate_of":null,
+        "already_landed":null,
+        "adr_conflicts":[],
+        "utility_warnings":[],
+        "surface_warnings":[]
+      }],
+      "summary":"one short partition summary"
+    },"error":null}
+
+    Copy `partition_index` and `task_ids` exactly from the input and return one
+    task assessment per input ID. If any task cannot be assessed, return a
+    failed envelope for the whole partition; never omit it or claim success.
+  tools:
+    - orbit.task.show
+    - orbit.task.list
+    - orbit.adr.show
+    - orbit.search
+    - orbit.learning.show
+    - fs.read
+    - proc.spawn
+  proc_allowed_programs:
+    - git
+    - rg
+  on_denial: terminate
+  wall_clock_timeout_seconds: 1800

--- a/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
@@ -1,0 +1,59 @@
+# Invoked-only task-pilot pipeline [ORB-10510].
+#
+# Automatic mode (task_ids empty) discovers only proposed/backlog tasks in the
+# active workspace with empty context_files, excluding no-diff tasks. Explicit
+# mode audits exactly the named workspace tasks, including non-empty selectors.
+# Preparation never promotes or dispatches a task. Each read-only Luna-backed
+# pilot receives at most five tasks. The all-join makes any failed partition
+# fail the run before the context-only deterministic apply step can execute.
+
+schemaVersion: 2
+kind: Job
+metadata:
+  name: task_pilot_pipeline
+spec:
+  state: enabled
+  kind: workflow
+  max_active_runs: 3
+  default_input:
+    task_ids: []
+    workspace_path: .
+    base_branch: agent-main
+    crew: luna
+    max_tasks: 50
+    max_partition_size: 5
+
+  steps:
+    - id: prepare
+      target: activity:prepare_task_pilot
+      default_input:
+        task_ids: "{{ input.task_ids }}"
+        workspace_path: "{{ input.workspace_path }}"
+        max_tasks: "{{ input.max_tasks }}"
+        max_partition_size: "{{ input.max_partition_size }}"
+
+    - id: pilots
+      fan_out:
+        items: "{{ steps.prepare.output.partitions }}"
+        max_workers: 5
+        worker:
+          id: pilot
+          target: activity:task_pilot
+          default_input:
+            task_ids: "{{ item.task_ids }}"
+            partition_index: "{{ item.partition_index }}"
+            workspace_path: "{{ steps.prepare.output.workspace_path }}"
+            base_branch: "{{ input.base_branch }}"
+            crew: "{{ input.crew }}"
+      fan_in:
+        join:
+          mode: all
+        collect: pilot_results
+
+    - id: apply
+      target: activity:apply_task_pilot_results
+      default_input:
+        prepared: "{{ steps.prepare.output }}"
+        results: "{{ steps.pilot_results.output }}"
+        workspace_path: "{{ steps.prepare.output.workspace_path }}"
+        crew: "{{ input.crew }}"

--- a/crates/orbit-core/src/command/activity.rs
+++ b/crates/orbit-core/src/command/activity.rs
@@ -31,6 +31,10 @@ pub(crate) const DEFAULT_ACTIVITY_FILES: &[(&str, &str)] = &[
         include_str!("../../assets/activities/apply_triage_dispositions.yaml"),
     ),
     (
+        "apply_task_pilot_results",
+        include_str!("../../assets/activities/apply_task_pilot_results.yaml"),
+    ),
+    (
         "dispatch_agent",
         include_str!("../../assets/activities/dispatch_agent.yaml"),
     ),
@@ -95,6 +99,10 @@ pub(crate) const DEFAULT_ACTIVITY_FILES: &[(&str, &str)] = &[
         include_str!("../../assets/activities/pr_promote.yaml"),
     ),
     (
+        "prepare_task_pilot",
+        include_str!("../../assets/activities/prepare_task_pilot.yaml"),
+    ),
+    (
         "propose_duel_plan",
         include_str!("../../assets/activities/propose_duel_plan.yaml"),
     ),
@@ -126,6 +134,10 @@ pub(crate) const DEFAULT_ACTIVITY_FILES: &[(&str, &str)] = &[
     (
         "summarize_epic",
         include_str!("../../assets/activities/summarize_epic.yaml"),
+    ),
+    (
+        "task_pilot",
+        include_str!("../../assets/activities/task_pilot.yaml"),
     ),
     (
         "triage_failed_runs",
@@ -375,6 +387,57 @@ mod tests {
                 assert!(spec.instruction.contains("Do not edit"));
             }
             other => panic!("expected agent_loop agent_review, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn task_pilot_is_read_only_bounded_and_uses_advisory_output() {
+        let (_, yaml) = DEFAULT_ACTIVITY_FILES
+            .iter()
+            .find(|(name, _)| *name == "task_pilot")
+            .expect("task pilot activity is seeded");
+        let asset = load_activity_asset(yaml).expect("parse task pilot activity");
+        assert!(
+            asset.spec.output_schema_json.get("required").is_none(),
+            "agent-returned task-pilot fields stay advisory until deterministic apply"
+        );
+        assert_eq!(
+            asset.spec.input_schema_json["properties"]["task_ids"]["maxItems"],
+            serde_json::json!(5)
+        );
+        match asset.spec.spec {
+            ActivityV2Spec::AgentLoop(spec) => {
+                assert!(spec.require_response_envelope);
+                assert_eq!(spec.role, None, "task-pilot is not a new crew role");
+                assert_eq!(spec.on_denial, OnDenial::Terminate);
+                assert!(!spec.tools.iter().any(|tool| tool == "orbit.task.update"));
+                assert!(!spec.tools.iter().any(|tool| tool == "orbit.task.*"));
+                assert!(!spec.tools.iter().any(|tool| {
+                    matches!(
+                        tool.as_str(),
+                        "fs.write" | "fs.patch" | "fs.delete" | "orbit.pipeline.invoke"
+                    )
+                }));
+                assert!(
+                    spec.proc_allowed_programs
+                        .as_deref()
+                        .unwrap_or_default()
+                        .iter()
+                        .all(|program| matches!(program.as_str(), "git" | "rg"))
+                );
+                assert!(
+                    !spec
+                        .proc_allowed_programs
+                        .as_deref()
+                        .unwrap_or_default()
+                        .iter()
+                        .any(|program| program == "orbit"),
+                    "proc.spawn must not bypass the scoped Orbit tool allowlist"
+                );
+                assert!(spec.instruction.contains("Never update a task"));
+                assert!(spec.instruction.contains("one to five"));
+            }
+            other => panic!("expected agent_loop task_pilot activity, got {other:?}"),
         }
     }
 

--- a/crates/orbit-core/src/command/job/catalog.rs
+++ b/crates/orbit-core/src/command/job/catalog.rs
@@ -41,6 +41,10 @@ const DEFAULT_JOB_FILES: &[(&str, &str)] = &[
         include_str!("../../../assets/jobs/task_local_pipeline.yaml"),
     ),
     (
+        "task_pilot_pipeline",
+        include_str!("../../../assets/jobs/task_pilot_pipeline.yaml"),
+    ),
+    (
         "task_pr_pipeline",
         include_str!("../../../assets/jobs/task_pr_pipeline.yaml"),
     ),

--- a/crates/orbit-core/src/command/job/tests/catalog.rs
+++ b/crates/orbit-core/src/command/job/tests/catalog.rs
@@ -37,6 +37,10 @@ const DEFAULT_JOB_FILES: &[(&str, &str)] = &[
         include_str!("../../../../assets/jobs/task_local_pipeline.yaml"),
     ),
     (
+        "task_pilot_pipeline",
+        include_str!("../../../../assets/jobs/task_pilot_pipeline.yaml"),
+    ),
+    (
         "task_pr_pipeline",
         include_str!("../../../../assets/jobs/task_pr_pipeline.yaml"),
     ),
@@ -251,6 +255,57 @@ fn default_job_target_refs_resolve_against_default_activities() {
         resolve_job_target_refs(&mut asset.spec, &catalog)
             .unwrap_or_else(|err| panic!("default job {job_name} refs resolve: {err}"));
     }
+}
+
+#[test]
+fn task_pilot_pipeline_defaults_to_luna_and_bounded_all_join_partitions() {
+    let yaml = DEFAULT_JOB_FILES
+        .iter()
+        .find_map(|(name, yaml)| (*name == "task_pilot_pipeline").then_some(*yaml))
+        .expect("task pilot pipeline exists");
+    let asset = load_job_asset(yaml).expect("task pilot pipeline parses");
+    let defaults = asset.spec.default_input.as_ref().expect("default input");
+    assert_eq!(defaults["task_ids"], json!([]));
+    assert_eq!(defaults["crew"], "luna");
+    assert_eq!(defaults["max_partition_size"], 5);
+    assert_eq!(asset.spec.steps.len(), 3);
+
+    let JobV2StepBody::TargetRef(prepare) = &asset.spec.steps[0].body else {
+        panic!("task pilot preparation must be deterministic activity reference");
+    };
+    assert_eq!(prepare.target, "activity:prepare_task_pilot");
+    let prepare_input = prepare.default_input.as_ref().expect("prepare input");
+    assert_eq!(prepare_input["task_ids"], "{{ input.task_ids }}");
+
+    let JobV2StepBody::FanOut { fan_out, fan_in } = &asset.spec.steps[1].body else {
+        panic!("task pilot agent work must fan out");
+    };
+    assert_eq!(fan_out.items, "{{ steps.prepare.output.partitions }}");
+    assert_eq!(fan_out.max_workers, 5);
+    assert_eq!(
+        fan_in.join,
+        orbit_common::types::activity_job::JoinMode::All
+    );
+    assert_eq!(fan_in.collect.as_deref(), Some("pilot_results"));
+    let JobV2StepBody::TargetRef(pilot) = &fan_out.worker.body else {
+        panic!("task pilot worker must reference agent activity");
+    };
+    assert_eq!(pilot.target, "activity:task_pilot");
+    let pilot_input = pilot.default_input.as_ref().expect("pilot input");
+    assert_eq!(pilot_input["task_ids"], "{{ item.task_ids }}");
+    assert_eq!(pilot_input["crew"], "{{ input.crew }}");
+
+    let JobV2StepBody::TargetRef(apply) = &asset.spec.steps[2].body else {
+        panic!("task pilot apply must be deterministic activity reference");
+    };
+    assert_eq!(apply.target, "activity:apply_task_pilot_results");
+    let apply_input = apply.default_input.as_ref().expect("apply input");
+    assert_eq!(apply_input["prepared"], "{{ steps.prepare.output }}");
+    assert_eq!(apply_input["results"], "{{ steps.pilot_results.output }}");
+    assert!(
+        yaml.contains("Invoked-only"),
+        "task pilot must remain an explicitly invoked workflow"
+    );
 }
 
 /// [ORB-10385] Every deterministic action reachable from a shipped job —

--- a/crates/orbit-core/src/runtime/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/v2_host/dispatch.rs
@@ -15,7 +15,7 @@ use crate::runtime::task_locks::{
     requested_task_files, task_lock_conflicts, workspace_orbit_dir, workspace_task_reservation_id,
 };
 
-use super::{backlog_exclusion, pipeline_actions, triage};
+use super::{backlog_exclusion, pipeline_actions, task_pilot, triage};
 
 /// Every deterministic action name this dispatch table can execute.
 ///
@@ -36,6 +36,7 @@ use super::{backlog_exclusion, pipeline_actions, triage};
 /// terminal hook, in `command/job/exec.rs`) and `worktree_gc` (below).
 pub(super) const REGISTERED_DETERMINISTIC_ACTIONS: &[&str] = &[
     "apply_triage_dispositions",
+    "apply_task_pilot_results",
     "context_conflict_check",
     "gate_starvation_fail",
     "git_commit",
@@ -53,6 +54,7 @@ pub(super) const REGISTERED_DETERMINISTIC_ACTIONS: &[&str] = &[
     "pr_open",
     "pr_prepare",
     "pr_promote",
+    "prepare_task_pilot",
     "promote_agent_main",
     "release_locks",
     "reserve_locks",
@@ -290,6 +292,12 @@ pub(super) fn run_deterministic(
         // bounds: candidates-only, `environmental`-only re-backlog, durable
         // re-backlog budget, idempotent under overlap [ORB-10129].
         "apply_triage_dispositions" => triage::apply_triage_dispositions(runtime, action, input),
+        // Materialize a workspace-scoped task-pilot working set and partition
+        // it into bounded groups without promoting or dispatching any task.
+        "prepare_task_pilot" => task_pilot::prepare(runtime, action, input),
+        // Validate all agent proposals before writing, then replace only the
+        // exact prepared tasks' context_files fields.
+        "apply_task_pilot_results" => task_pilot::apply(runtime, action, input),
         // Materialize an epic's working set for the orchestrator:
         // the epic task itself plus non-terminal subtasks
         // (`parent_id == epic_task_id` and status not done, review,

--- a/crates/orbit-core/src/runtime/v2_host/mod.rs
+++ b/crates/orbit-core/src/runtime/v2_host/mod.rs
@@ -15,6 +15,7 @@ mod learning_reminders;
 mod pipeline_actions;
 mod sandbox;
 mod task_context;
+mod task_pilot;
 #[cfg(test)]
 mod test_support;
 #[cfg(test)]

--- a/crates/orbit-core/src/runtime/v2_host/task_pilot.rs
+++ b/crates/orbit-core/src/runtime/v2_host/task_pilot.rs
@@ -1,0 +1,679 @@
+//! Deterministic support actions for the task-pilot workflow [ORB-10510].
+//!
+//! The agent leg only proposes task metadata. These actions own discovery,
+//! partitioning, canonical selector validation, and the sole permitted write:
+//! replacing `context_files` on the exact tasks prepared for the run.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use orbit_common::types::{Task, TaskStatus};
+use orbit_common::utility::selector::{
+    anchor_path, canonical_selector_in_workspace, exists_in_workspace,
+};
+use orbit_engine::DispatchError;
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+use crate::command::task::TaskUpdateParams;
+
+const DEFAULT_MAX_PARTITION_SIZE: usize = 5;
+const HARD_MAX_PARTITION_SIZE: usize = 5;
+const DEFAULT_MAX_TASKS: usize = 50;
+const HARD_MAX_TASKS: usize = 500;
+const NO_DIFF_TAGS: [&str; 2] = ["no-diff-needed", "no-diff-expected"];
+
+pub(super) fn prepare(
+    runtime: &OrbitRuntime,
+    action: &str,
+    input: &Value,
+) -> Result<Value, DispatchError> {
+    let workspace_root = requested_workspace_root(runtime, action, input)?;
+    let max_partition_size = bounded_usize(
+        action,
+        input,
+        "max_partition_size",
+        DEFAULT_MAX_PARTITION_SIZE,
+        HARD_MAX_PARTITION_SIZE,
+    )?;
+    let max_tasks = bounded_usize(
+        action,
+        input,
+        "max_tasks",
+        DEFAULT_MAX_TASKS,
+        HARD_MAX_TASKS,
+    )?;
+    let explicit_task_ids = string_array(input, "task_ids", action)?;
+    let explicit_mode = !explicit_task_ids.is_empty();
+    let all_tasks = runtime
+        .list_tasks()
+        .map_err(|error| action_failed(action, format!("list workspace tasks: {error}")))?;
+    let by_id = all_tasks
+        .iter()
+        .map(|task| (task.id.as_str(), task))
+        .collect::<BTreeMap<_, _>>();
+
+    let (mode, selected, excluded) = if explicit_mode {
+        let mut seen = BTreeSet::new();
+        let selected = explicit_task_ids
+            .iter()
+            .map(|task_id| {
+                if !seen.insert(task_id.as_str()) {
+                    return Err(action_failed(
+                        action,
+                        format!("explicit task_ids contains duplicate {task_id}"),
+                    ));
+                }
+                by_id.get(task_id.as_str()).copied().ok_or_else(|| {
+                    action_failed(
+                        action,
+                        format!("task {task_id} does not exist in the selected workspace"),
+                    )
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        ("explicit", selected, Vec::new())
+    } else {
+        let mut selected = Vec::new();
+        let mut excluded = Vec::new();
+        let mut candidates = all_tasks.iter().collect::<Vec<_>>();
+        candidates.sort_by(|left, right| {
+            left.created_at
+                .cmp(&right.created_at)
+                .then(left.id.cmp(&right.id))
+        });
+        for task in candidates {
+            let reason = automatic_exclusion_reason(task);
+            if let Some(reason) = reason {
+                excluded.push(json!({ "task_id": task.id, "reason": reason }));
+            } else {
+                selected.push(task);
+            }
+        }
+        ("automatic", selected, excluded)
+    };
+
+    if selected.len() > max_tasks {
+        return Err(action_failed(
+            action,
+            format!(
+                "{mode} task-pilot selection contains {} tasks, exceeding max_tasks {max_tasks}",
+                selected.len()
+            ),
+        ));
+    }
+
+    let task_snapshots = selected
+        .iter()
+        .map(|task| task_snapshot(task))
+        .collect::<Vec<_>>();
+    let partitions = selected
+        .chunks(max_partition_size)
+        .enumerate()
+        .map(|(partition_index, tasks)| {
+            json!({
+                "partition_index": partition_index,
+                "task_ids": tasks.iter().map(|task| task.id.clone()).collect::<Vec<_>>(),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    Ok(json!({
+        "mode": mode,
+        "workspace_path": workspace_root,
+        "task_count": selected.len(),
+        "task_ids": selected.iter().map(|task| task.id.clone()).collect::<Vec<_>>(),
+        "tasks": task_snapshots,
+        "partition_size": max_partition_size,
+        "partition_count": partitions.len(),
+        "partitions": partitions,
+        "excluded": excluded,
+    }))
+}
+
+pub(super) fn apply(
+    runtime: &OrbitRuntime,
+    action: &str,
+    input: &Value,
+) -> Result<Value, DispatchError> {
+    let workspace_root = requested_workspace_root(runtime, action, input)?;
+    let prepared = input
+        .get("prepared")
+        .and_then(Value::as_object)
+        .ok_or_else(|| action_failed(action, "`prepared` must be an object"))?;
+    let prepared_workspace = prepared
+        .get("workspace_path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| action_failed(action, "prepared.workspace_path must be a string"))?;
+    if Path::new(prepared_workspace) != workspace_root {
+        return Err(action_failed(
+            action,
+            format!(
+                "prepared workspace {prepared_workspace} does not match active workspace {}",
+                workspace_root.display()
+            ),
+        ));
+    }
+    let mode = prepared
+        .get("mode")
+        .and_then(Value::as_str)
+        .ok_or_else(|| action_failed(action, "prepared.mode must be a string"))?;
+    let expected_partitions = prepared
+        .get("partitions")
+        .and_then(Value::as_array)
+        .ok_or_else(|| action_failed(action, "prepared.partitions must be an array"))?;
+    let prepared_tasks = prepared
+        .get("tasks")
+        .and_then(Value::as_array)
+        .ok_or_else(|| action_failed(action, "prepared.tasks must be an array"))?;
+    let results = input
+        .get("results")
+        .and_then(Value::as_array)
+        .ok_or_else(|| action_failed(action, "`results` must be an array"))?;
+
+    if results.len() != expected_partitions.len() {
+        return Err(action_failed(
+            action,
+            format!(
+                "expected {} task-pilot partition results, received {}",
+                expected_partitions.len(),
+                results.len()
+            ),
+        ));
+    }
+
+    let prepared_before = prepared_tasks
+        .iter()
+        .map(|entry| {
+            let task_id = required_string(entry, "task_id", action)?;
+            let before = required_string_array(entry, "context_files_before", action)?;
+            Ok((task_id.to_string(), before))
+        })
+        .collect::<Result<BTreeMap<_, _>, DispatchError>>()?;
+
+    // Validate every partition and every selector before the first mutation.
+    // A malformed or failed partition therefore cannot partially apply the
+    // otherwise-valid partitions that happened to precede it.
+    let mut validated = Vec::with_capacity(prepared_before.len());
+    let mut seen_task_ids = BTreeSet::new();
+    for (position, (expected, result)) in expected_partitions.iter().zip(results).enumerate() {
+        let expected_index = expected
+            .get("partition_index")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| {
+                action_failed(
+                    action,
+                    format!("prepared.partitions[{position}].partition_index is invalid"),
+                )
+            })?;
+        let expected_ids = required_string_array(expected, "task_ids", action)?;
+        let result_object = result.as_object().ok_or_else(|| {
+            action_failed(
+                action,
+                format!("partition {expected_index} failed or returned no structured result"),
+            )
+        })?;
+        let result_index = result_object
+            .get("partition_index")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| {
+                action_failed(
+                    action,
+                    format!("partition result {position} is missing partition_index"),
+                )
+            })?;
+        if result_index != expected_index {
+            return Err(action_failed(
+                action,
+                format!(
+                    "partition result {position} reports index {result_index}, expected {expected_index}"
+                ),
+            ));
+        }
+        let result_ids = result_object
+            .get("task_ids")
+            .ok_or_else(|| action_failed(action, "`task_ids` must be an array"))
+            .and_then(|value| string_array_value(value, "task_ids", action))?;
+        if result_ids != expected_ids {
+            return Err(action_failed(
+                action,
+                format!("partition {expected_index} task_ids do not match the prepared partition"),
+            ));
+        }
+        let assessments = result_object
+            .get("tasks")
+            .and_then(Value::as_array)
+            .ok_or_else(|| {
+                action_failed(
+                    action,
+                    format!("partition {expected_index}.tasks must be an array"),
+                )
+            })?;
+        if assessments.len() != expected_ids.len() {
+            return Err(action_failed(
+                action,
+                format!(
+                    "partition {expected_index} returned {} task assessments for {} tasks",
+                    assessments.len(),
+                    expected_ids.len()
+                ),
+            ));
+        }
+        let assessments_by_id = assessments
+            .iter()
+            .map(|assessment| {
+                let task_id = required_string(assessment, "task_id", action)?;
+                Ok((task_id.to_string(), assessment))
+            })
+            .collect::<Result<BTreeMap<_, _>, DispatchError>>()?;
+        if assessments_by_id.len() != assessments.len() {
+            return Err(action_failed(
+                action,
+                format!("partition {expected_index} contains duplicate task assessments"),
+            ));
+        }
+
+        for task_id in expected_ids {
+            if !seen_task_ids.insert(task_id.clone()) {
+                return Err(action_failed(
+                    action,
+                    format!("task {task_id} appears in more than one partition result"),
+                ));
+            }
+            let assessment = assessments_by_id.get(&task_id).ok_or_else(|| {
+                action_failed(
+                    action,
+                    format!("partition {expected_index} omitted task {task_id}"),
+                )
+            })?;
+            let expected_before = prepared_before.get(&task_id).ok_or_else(|| {
+                action_failed(action, format!("task {task_id} was not in prepared.tasks"))
+            })?;
+            let reported_before =
+                required_string_array(assessment, "context_files_before", action)?;
+            if &reported_before != expected_before {
+                return Err(action_failed(
+                    action,
+                    format!(
+                        "task {task_id} context_files_before does not match the prepared snapshot"
+                    ),
+                ));
+            }
+            let current = runtime.get_task(&task_id).map_err(|error| {
+                action_failed(action, format!("reload task {task_id}: {error}"))
+            })?;
+            if current.context_files != *expected_before {
+                return Err(action_failed(
+                    action,
+                    format!(
+                        "task {task_id} context_files changed after preparation; refusing stale pilot output"
+                    ),
+                ));
+            }
+            let disposition = required_string(assessment, "disposition", action)?;
+            let after = required_string_array(assessment, "context_files_after", action)?;
+            validate_after_selectors(
+                action,
+                &task_id,
+                disposition,
+                assessment,
+                &after,
+                &workspace_root,
+            )?;
+            validate_recommendations(action, &task_id, assessment)?;
+            validated.push((
+                task_id,
+                expected_before.clone(),
+                after,
+                (*assessment).clone(),
+            ));
+        }
+    }
+
+    if seen_task_ids.len() != prepared_before.len() {
+        return Err(action_failed(
+            action,
+            "partition results did not cover every prepared task",
+        ));
+    }
+
+    let mut task_results = Vec::with_capacity(validated.len());
+    for (task_id, before, after, mut assessment) in validated {
+        let changed = before != after;
+        if changed {
+            runtime
+                .update_task(
+                    &task_id,
+                    TaskUpdateParams {
+                        context_files: Some(after.clone()),
+                        ..TaskUpdateParams::default()
+                    },
+                )
+                .map_err(|error| {
+                    action_failed(
+                        action,
+                        format!("apply validated context_files for task {task_id}: {error}"),
+                    )
+                })?;
+        }
+        if let Value::Object(fields) = &mut assessment {
+            fields.insert("applied".to_string(), Value::Bool(changed));
+        }
+        task_results.push(assessment);
+    }
+
+    Ok(json!({
+        "status": "success",
+        "mode": mode,
+        "crew": input.get("crew").cloned().unwrap_or(Value::Null),
+        "workspace_path": workspace_root,
+        "discovery": {
+            "task_ids": prepared.get("task_ids").cloned().unwrap_or_else(|| json!([])),
+            "excluded": prepared.get("excluded").cloned().unwrap_or_else(|| json!([])),
+        },
+        "partition_decisions": expected_partitions,
+        "partition_count": expected_partitions.len(),
+        "failed_partitions": [],
+        "tasks": task_results,
+    }))
+}
+
+fn automatic_exclusion_reason(task: &Task) -> Option<&'static str> {
+    if !matches!(task.status, TaskStatus::Proposed | TaskStatus::Backlog) {
+        return Some("status_not_eligible");
+    }
+    if !task.context_files.is_empty() {
+        return Some("context_files_not_empty");
+    }
+    if task
+        .tags
+        .iter()
+        .any(|tag| NO_DIFF_TAGS.contains(&tag.as_str()))
+    {
+        return Some("no_diff_task");
+    }
+    None
+}
+
+fn task_snapshot(task: &Task) -> Value {
+    json!({
+        "task_id": task.id,
+        "title": task.title,
+        "status": task.status,
+        "tags": task.tags,
+        "context_files_before": task.context_files,
+    })
+}
+
+fn validate_after_selectors(
+    action: &str,
+    task_id: &str,
+    disposition: &str,
+    assessment: &Value,
+    selectors: &[String],
+    workspace_root: &Path,
+) -> Result<(), DispatchError> {
+    if selectors.is_empty() {
+        if !matches!(disposition, "verified_no_diff" | "host_operational") {
+            return Err(action_failed(
+                action,
+                format!(
+                    "task {task_id} may keep empty context_files only with verified_no_diff or host_operational disposition"
+                ),
+            ));
+        }
+        required_string(assessment, "evidence", action)?;
+        return Ok(());
+    }
+    if disposition != "selectors" {
+        return Err(action_failed(
+            action,
+            format!(
+                "task {task_id} has non-empty context_files_after but disposition is {disposition}"
+            ),
+        ));
+    }
+
+    let mut seen = BTreeSet::new();
+    for selector in selectors {
+        let trimmed = selector.trim();
+        if !matches!(
+            trimmed.split_once(':').map(|(kind, _)| kind),
+            Some("file" | "dir" | "symbol")
+        ) {
+            return Err(action_failed(
+                action,
+                format!("task {task_id} selector {selector:?} must use file:, dir:, or symbol:"),
+            ));
+        }
+        let canonical =
+            canonical_selector_in_workspace(trimmed, workspace_root).map_err(|error| {
+                action_failed(
+                    action,
+                    format!("task {task_id} selector {selector:?} is invalid: {error}"),
+                )
+            })?;
+        if canonical != trimmed {
+            return Err(action_failed(
+                action,
+                format!(
+                    "task {task_id} selector {selector:?} is not canonical; expected {canonical:?}"
+                ),
+            ));
+        }
+        if !exists_in_workspace(&canonical, workspace_root) {
+            return Err(action_failed(
+                action,
+                format!(
+                    "task {task_id} selector {selector:?} does not resolve to an existing in-workspace target"
+                ),
+            ));
+        }
+        validate_selector_target_kind(action, task_id, &canonical, workspace_root)?;
+        if !seen.insert(canonical) {
+            return Err(action_failed(
+                action,
+                format!("task {task_id} repeats selector {selector:?}"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_recommendations(
+    action: &str,
+    task_id: &str,
+    assessment: &Value,
+) -> Result<(), DispatchError> {
+    required_string(assessment, "recommended_crew", action)?;
+    let complexity = required_string(assessment, "recommended_complexity", action)?;
+    if !matches!(complexity, "low" | "medium" | "hard") {
+        return Err(action_failed(
+            action,
+            format!("task {task_id} recommended_complexity must be low, medium, or hard"),
+        ));
+    }
+    for field in [
+        "blocked_by",
+        "adr_conflicts",
+        "utility_warnings",
+        "surface_warnings",
+    ] {
+        string_array_value(
+            assessment.get(field).ok_or_else(|| {
+                action_failed(action, format!("task {task_id} is missing {field}"))
+            })?,
+            field,
+            action,
+        )?;
+    }
+    for field in ["duplicate_of", "already_landed"] {
+        if assessment.get(field).is_none() {
+            return Err(action_failed(
+                action,
+                format!("task {task_id} is missing {field} recommendation"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_selector_target_kind(
+    action: &str,
+    task_id: &str,
+    selector: &str,
+    workspace_root: &Path,
+) -> Result<(), DispatchError> {
+    let anchor = anchor_path(selector).map_err(|error| {
+        action_failed(
+            action,
+            format!("task {task_id} selector {selector:?} has no filesystem anchor: {error}"),
+        )
+    })?;
+    let resolved = workspace_root.join(anchor);
+    let correct_kind = if selector.starts_with("dir:") {
+        resolved.is_dir()
+    } else {
+        resolved.is_file()
+    };
+    if correct_kind {
+        Ok(())
+    } else {
+        Err(action_failed(
+            action,
+            format!(
+                "task {task_id} selector {selector:?} does not match the target's file/directory kind"
+            ),
+        ))
+    }
+}
+
+fn requested_workspace_root(
+    runtime: &OrbitRuntime,
+    action: &str,
+    input: &Value,
+) -> Result<PathBuf, DispatchError> {
+    let runtime_root = runtime.paths().repo_root.canonicalize().map_err(|error| {
+        action_failed(action, format!("canonicalize runtime workspace: {error}"))
+    })?;
+    let requested = input
+        .get("workspace_path")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| runtime_root.clone());
+    let requested = if requested.is_absolute() {
+        requested
+    } else {
+        runtime_root.join(requested)
+    };
+    let requested = requested.canonicalize().map_err(|error| {
+        action_failed(
+            action,
+            format!(
+                "canonicalize requested workspace {}: {error}",
+                requested.display()
+            ),
+        )
+    })?;
+    if requested != runtime_root {
+        return Err(action_failed(
+            action,
+            format!(
+                "requested workspace {} does not match active workspace {}",
+                requested.display(),
+                runtime_root.display()
+            ),
+        ));
+    }
+    Ok(runtime_root)
+}
+
+fn bounded_usize(
+    action: &str,
+    input: &Value,
+    field: &str,
+    default: usize,
+    max: usize,
+) -> Result<usize, DispatchError> {
+    let value = input
+        .get(field)
+        .and_then(Value::as_u64)
+        .unwrap_or(default as u64);
+    if value == 0 || value > max as u64 {
+        return Err(action_failed(
+            action,
+            format!("`{field}` must be between 1 and {max}"),
+        ));
+    }
+    Ok(value as usize)
+}
+
+fn string_array(input: &Value, field: &str, action: &str) -> Result<Vec<String>, DispatchError> {
+    match input.get(field) {
+        None | Some(Value::Null) => Ok(Vec::new()),
+        Some(value) => string_array_value(value, field, action),
+    }
+}
+
+fn string_array_value(
+    value: &Value,
+    field: &str,
+    action: &str,
+) -> Result<Vec<String>, DispatchError> {
+    value
+        .as_array()
+        .ok_or_else(|| action_failed(action, format!("`{field}` must be an array")))
+        .and_then(|values| {
+            values
+                .iter()
+                .map(|value| {
+                    value.as_str().map(ToOwned::to_owned).ok_or_else(|| {
+                        action_failed(action, format!("`{field}` must contain only strings"))
+                    })
+                })
+                .collect()
+        })
+}
+
+fn required_string_array(
+    input: &Value,
+    field: &str,
+    action: &str,
+) -> Result<Vec<String>, DispatchError> {
+    input
+        .get(field)
+        .and_then(Value::as_array)
+        .ok_or_else(|| action_failed(action, format!("`{field}` must be an array")))
+        .and_then(|values| {
+            values
+                .iter()
+                .map(|value| {
+                    value.as_str().map(ToOwned::to_owned).ok_or_else(|| {
+                        action_failed(action, format!("`{field}` must contain only strings"))
+                    })
+                })
+                .collect()
+        })
+}
+
+fn required_string<'a>(
+    input: &'a Value,
+    field: &str,
+    action: &str,
+) -> Result<&'a str, DispatchError> {
+    input
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| action_failed(action, format!("`{field}` must be a non-empty string")))
+}
+
+fn action_failed(action: &str, message: impl Into<String>) -> DispatchError {
+    DispatchError::DeterministicActionFailed {
+        action: action.to_string(),
+        message: message.into(),
+    }
+}

--- a/crates/orbit-core/src/runtime/v2_host/tests/mod.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/mod.rs
@@ -5,6 +5,7 @@ mod learning_reminders;
 mod pipeline_actions;
 mod sandbox;
 mod task_context;
+mod task_pilot;
 mod triage;
 mod v2_host;
 // Replay-transport-backed cases; default-off per [ORB-10414]. [ORB-10434]

--- a/crates/orbit-core/src/runtime/v2_host/tests/task_pilot.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/task_pilot.rs
@@ -1,0 +1,395 @@
+use orbit_common::types::{Task, TaskPriority, TaskStatus, TaskType};
+use serde_json::{Value, json};
+
+use super::super::task_pilot::{apply, prepare};
+use crate::OrbitRuntime;
+use crate::command::task::TaskAddParams;
+use crate::runtime::v2_host::test_support::{runtime_with_workspace_layout, write_workspace_file};
+
+fn seed_task(
+    runtime: &OrbitRuntime,
+    title: &str,
+    status: TaskStatus,
+    tags: &[&str],
+    context_files: &[&str],
+) -> Task {
+    runtime
+        .add_task(TaskAddParams {
+            title: title.to_string(),
+            description: format!("Fixture task: {title}"),
+            acceptance_criteria: vec!["The fixture outcome is observable.".to_string()],
+            tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
+            plan: "Inspect and update the fixture.".to_string(),
+            context_files: context_files
+                .iter()
+                .map(|selector| (*selector).to_string())
+                .collect(),
+            workspace_path: Some(".".to_string()),
+            priority: TaskPriority::Medium,
+            task_type: Some(TaskType::Chore),
+            status: Some(status),
+            ..TaskAddParams::default()
+        })
+        .expect("seed task")
+}
+
+fn prepared(runtime: &OrbitRuntime, repo_root: &std::path::Path, task_ids: &[String]) -> Value {
+    prepare(
+        runtime,
+        "prepare_task_pilot",
+        &json!({
+            "task_ids": task_ids,
+            "workspace_path": repo_root,
+        }),
+    )
+    .expect("prepare explicit task-pilot selection")
+}
+
+fn selector_assessment(task: &Task, after: Vec<&str>) -> Value {
+    json!({
+        "task_id": task.id,
+        "context_files_before": task.context_files,
+        "context_files_after": after,
+        "disposition": "selectors",
+        "recommended_crew": "luna",
+        "recommended_complexity": "medium",
+        "blocked_by": [],
+        "duplicate_of": null,
+        "already_landed": null,
+        "adr_conflicts": [],
+        "utility_warnings": [],
+        "surface_warnings": [],
+    })
+}
+
+fn partition_result(partition_index: usize, task_ids: &[String], tasks: Vec<Value>) -> Value {
+    json!({
+        "partition_index": partition_index,
+        "task_ids": task_ids,
+        "tasks": tasks,
+        "summary": "fixture partition",
+    })
+}
+
+#[test]
+fn automatic_discovery_filters_status_context_and_no_diff_tags_then_partitions() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "src/existing.rs");
+    let mut eligible = Vec::new();
+    for index in 0..7 {
+        eligible.push(seed_task(
+            &runtime,
+            &format!("eligible-{index}"),
+            if index % 2 == 0 {
+                TaskStatus::Proposed
+            } else {
+                TaskStatus::Backlog
+            },
+            &[],
+            &[],
+        ));
+    }
+    let active = seed_task(&runtime, "active", TaskStatus::InProgress, &[], &[]);
+    let review = seed_task(&runtime, "review", TaskStatus::Review, &[], &[]);
+    let terminal = seed_task(&runtime, "terminal", TaskStatus::Done, &[], &[]);
+    let no_diff = seed_task(
+        &runtime,
+        "no-diff",
+        TaskStatus::Backlog,
+        &["no-diff-needed"],
+        &[],
+    );
+    let scoped = seed_task(
+        &runtime,
+        "already-scoped",
+        TaskStatus::Backlog,
+        &[],
+        &["file:src/existing.rs"],
+    );
+
+    let output = prepare(
+        &runtime,
+        "prepare_task_pilot",
+        &json!({ "workspace_path": repo_root }),
+    )
+    .expect("automatic discovery");
+
+    assert_eq!(output["mode"], "automatic");
+    assert_eq!(output["task_count"], 7);
+    assert_eq!(output["partition_count"], 2);
+    assert_eq!(
+        output["partitions"][0]["task_ids"]
+            .as_array()
+            .unwrap()
+            .len(),
+        5
+    );
+    assert_eq!(
+        output["partitions"][1]["task_ids"]
+            .as_array()
+            .unwrap()
+            .len(),
+        2
+    );
+    let selected = output["task_ids"].as_array().expect("selected task ids");
+    for task in eligible {
+        assert!(selected.iter().any(|value| value == &json!(task.id)));
+    }
+    let excluded = output["excluded"].as_array().expect("excluded entries");
+    for task in [active, review, terminal] {
+        assert!(excluded.iter().any(|entry| {
+            entry["task_id"] == task.id && entry["reason"] == "status_not_eligible"
+        }));
+    }
+    assert!(
+        excluded
+            .iter()
+            .any(|entry| { entry["task_id"] == no_diff.id && entry["reason"] == "no_diff_task" })
+    );
+    assert!(excluded.iter().any(|entry| {
+        entry["task_id"] == scoped.id && entry["reason"] == "context_files_not_empty"
+    }));
+}
+
+#[test]
+fn explicit_mode_selects_exact_ids_even_with_nonempty_context_or_active_status() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "src/existing.rs");
+    let scoped = seed_task(
+        &runtime,
+        "scoped",
+        TaskStatus::Review,
+        &[],
+        &["file:src/existing.rs"],
+    );
+    let backlog = seed_task(&runtime, "backlog", TaskStatus::Backlog, &[], &[]);
+
+    let output = prepared(
+        &runtime,
+        &repo_root,
+        &[scoped.id.clone(), backlog.id.clone()],
+    );
+
+    assert_eq!(output["mode"], "explicit");
+    assert_eq!(output["task_ids"], json!([scoped.id, backlog.id]));
+    assert_eq!(output["excluded"], json!([]));
+}
+
+#[test]
+fn apply_validates_all_results_then_mutates_context_files_only() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "src/alpha.rs");
+    let alpha = seed_task(&runtime, "alpha", TaskStatus::Backlog, &["pilot"], &[]);
+    let operational = seed_task(
+        &runtime,
+        "operational",
+        TaskStatus::Backlog,
+        &["host-operation"],
+        &[],
+    );
+    let task_ids = vec![alpha.id.clone(), operational.id.clone()];
+    let prepared_snapshot = prepared(&runtime, &repo_root, &task_ids);
+    let before_alpha = runtime.get_task(&alpha.id).expect("alpha before");
+    let before_operational = runtime
+        .get_task(&operational.id)
+        .expect("operational before");
+    let result = partition_result(
+        0,
+        &task_ids,
+        vec![
+            selector_assessment(&alpha, vec!["file:src/alpha.rs"]),
+            json!({
+                "task_id": operational.id,
+                "context_files_before": [],
+                "context_files_after": [],
+                "disposition": "host_operational",
+                "evidence": "Changes host service state only; no repository artifact is modified.",
+                "recommended_crew": "luna",
+                "recommended_complexity": "low",
+                "blocked_by": [],
+                "duplicate_of": null,
+                "already_landed": null,
+                "adr_conflicts": [],
+                "utility_warnings": ["requires host access"],
+                "surface_warnings": [],
+            }),
+        ],
+    );
+
+    let output = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": prepared_snapshot,
+            "results": [result],
+            "workspace_path": repo_root,
+            "crew": "luna",
+        }),
+    )
+    .expect("apply validated pilot results");
+
+    let after_alpha = runtime.get_task(&alpha.id).expect("alpha after");
+    let after_operational = runtime
+        .get_task(&operational.id)
+        .expect("operational after");
+    assert_eq!(after_alpha.context_files, vec!["file:src/alpha.rs"]);
+    assert_eq!(after_operational.context_files, Vec::<String>::new());
+    assert_eq!(after_alpha.title, before_alpha.title);
+    assert_eq!(after_alpha.status, before_alpha.status);
+    assert_eq!(after_alpha.tags, before_alpha.tags);
+    assert_eq!(after_alpha.plan, before_alpha.plan);
+    assert_eq!(after_operational.title, before_operational.title);
+    assert_eq!(after_operational.status, before_operational.status);
+    assert_eq!(output["status"], "success");
+    assert_eq!(output["crew"], "luna");
+    assert_eq!(output["tasks"][0]["context_files_before"], json!([]));
+    assert_eq!(
+        output["tasks"][0]["context_files_after"],
+        json!(["file:src/alpha.rs"])
+    );
+    assert_eq!(output["tasks"][0]["applied"], true);
+    assert_eq!(output["tasks"][1]["applied"], false);
+    assert_eq!(
+        output["tasks"][1]["utility_warnings"],
+        json!(["requires host access"])
+    );
+}
+
+#[test]
+fn invalid_selector_in_later_assessment_prevents_every_mutation() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "src/alpha.rs");
+    let alpha = seed_task(&runtime, "alpha", TaskStatus::Backlog, &[], &[]);
+    let beta = seed_task(&runtime, "beta", TaskStatus::Backlog, &[], &[]);
+    let task_ids = vec![alpha.id.clone(), beta.id.clone()];
+    let prepared_snapshot = prepared(&runtime, &repo_root, &task_ids);
+    let result = partition_result(
+        0,
+        &task_ids,
+        vec![
+            selector_assessment(&alpha, vec!["file:src/alpha.rs"]),
+            selector_assessment(&beta, vec!["file:src/missing.rs"]),
+        ],
+    );
+
+    let error = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": prepared_snapshot,
+            "results": [result],
+            "workspace_path": repo_root,
+            "crew": "luna",
+        }),
+    )
+    .expect_err("missing selector target must fail closed");
+
+    assert!(error.to_string().contains("does not resolve"));
+    assert!(
+        runtime
+            .get_task(&alpha.id)
+            .unwrap()
+            .context_files
+            .is_empty()
+    );
+    assert!(runtime.get_task(&beta.id).unwrap().context_files.is_empty());
+}
+
+#[test]
+fn empty_context_requires_verified_no_diff_or_host_operational_evidence() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    let task = seed_task(&runtime, "no-diff", TaskStatus::Backlog, &[], &[]);
+    let task_ids = vec![task.id.clone()];
+    let invalid_prepared = prepared(&runtime, &repo_root, &task_ids);
+    let invalid = partition_result(
+        0,
+        &task_ids,
+        vec![json!({
+            "task_id": task.id,
+            "context_files_before": [],
+            "context_files_after": [],
+            "disposition": "selectors",
+        })],
+    );
+
+    let error = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": invalid_prepared,
+            "results": [invalid],
+            "workspace_path": repo_root,
+            "crew": "luna",
+        }),
+    )
+    .expect_err("unverified empty result must fail");
+    assert!(error.to_string().contains("verified_no_diff"));
+
+    let valid_prepared = prepared(&runtime, &repo_root, &task_ids);
+    let valid = partition_result(
+        0,
+        &task_ids,
+        vec![json!({
+            "task_id": task.id,
+            "context_files_before": [],
+            "context_files_after": [],
+            "disposition": "verified_no_diff",
+            "evidence": "The requested behavior already exists on the target branch.",
+            "recommended_crew": "luna",
+            "recommended_complexity": "low",
+            "blocked_by": [],
+            "duplicate_of": null,
+            "already_landed": null,
+            "adr_conflicts": [],
+            "utility_warnings": [],
+            "surface_warnings": [],
+        })],
+    );
+    let output = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": valid_prepared,
+            "results": [valid],
+            "workspace_path": repo_root,
+            "crew": "luna",
+        }),
+    )
+    .expect("verified no-diff result is valid");
+    assert_eq!(output["tasks"][0]["applied"], false);
+}
+
+#[test]
+fn out_of_workspace_selector_is_rejected_before_mutation() {
+    let (root, runtime, repo_root) = runtime_with_workspace_layout();
+    let outside = root.path().join("outside.rs");
+    std::fs::write(&outside, "outside").expect("write outside fixture");
+    let task = seed_task(&runtime, "escape", TaskStatus::Backlog, &[], &[]);
+    let task_ids = vec![task.id.clone()];
+    let prepared = prepared(&runtime, &repo_root, &task_ids);
+    let outside_selector = format!("file:{}", outside.display());
+    let result = partition_result(
+        0,
+        &task_ids,
+        vec![json!({
+            "task_id": task.id,
+            "context_files_before": [],
+            "context_files_after": [outside_selector],
+            "disposition": "selectors",
+        })],
+    );
+
+    let error = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": prepared,
+            "results": [result],
+            "workspace_path": repo_root,
+            "crew": "luna",
+        }),
+    )
+    .expect_err("out-of-workspace selector must fail");
+    assert!(error.to_string().contains("inside workspace"));
+    assert!(runtime.get_task(&task.id).unwrap().context_files.is_empty());
+}

--- a/plugin/agents/orbit-task-pilot.md
+++ b/plugin/agents/orbit-task-pilot.md
@@ -1,0 +1,20 @@
+---
+name: orbit-task-pilot
+description: Read-only bounded preflight for Orbit task metadata. Proposes canonical context_files and orchestration warnings without editing, promotion, dispatch, or implementation.
+tools: Read, Grep, Glob, Bash
+skills: orbit-task-pilot
+---
+
+You are Orbit's task-pilot agent.
+
+Follow the `orbit-task-pilot` skill contract for the explicit workspace, target
+branch, and partition of at most five task IDs supplied by the caller.
+
+You are read-only. Never edit repository files, mutate tasks, change lifecycle
+state, promote or dispatch work, invoke pipelines, commit, push, merge, or open
+a PR. Bash is limited to read-only inspection such as `git diff`, `git log`,
+`git status`, and `rg`.
+
+Return exact before/after selector proposals and the requested crew,
+dependency, duplicate/already-landed, ADR, utility, and surface recommendations.
+If any task in the partition cannot be assessed, fail the whole partition.

--- a/plugin/skills/orbit-task-pilot/SKILL.md
+++ b/plugin/skills/orbit-task-pilot/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: orbit-task-pilot
+description: Read-only preflight for a bounded partition of Orbit tasks. Use when an orchestrator needs exact canonical context_files proposals, crew/complexity and dependency recommendations, duplicate or already-landed evidence, ADR conflicts, and utility/surface warnings without promotion, dispatch, implementation, or task mutation.
+---
+
+# Orbit Task Pilot
+
+## Contract
+
+Accept only an explicit target workspace, target branch, and a partition of one
+to five Orbit task IDs. Inspect those tasks and return proposals; do not apply
+them.
+
+For each task:
+
+1. Read the complete task record and preserve the current selector list exactly
+   as `context_files_before`.
+2. Inspect the target branch, modification/deletion targets, related tasks, and
+   relevant accepted ADRs using read-only tools.
+3. Return `context_files_after` using only canonical `file:`, `dir:`, or
+   `symbol:` selectors whose anchors exist inside the target workspace. Include
+   modification/deletion targets only, never read-for-context files.
+4. Use disposition `selectors` for a non-empty proposal. An empty proposal is
+   valid only with `verified_no_diff` or `host_operational` plus concrete
+   evidence.
+5. Report recommendations for crew, complexity, real blockers, duplicates,
+   already-landed work, ADR conflicts, utility, and public surface. Do not apply
+   those recommendations or silently select an architecture alternative.
+
+## Hard bounds
+
+- Never edit, create, move, or delete repository files.
+- Never update an Orbit task or transition lifecycle state.
+- Never promote, dispatch, implement, invoke a pipeline, commit, push, merge,
+  open a PR, or approve work.
+- Never expand the partition beyond the supplied IDs except to cite a concrete
+  dependency, duplicate, or accepted ADR.
+- Task-pilot is an operational role, not a provider, crew, actor identity,
+  capability, scheduler, or task store.
+
+## Result
+
+Return one partition object containing the exact `partition_index` and
+`task_ids`, one task assessment per supplied ID, and a short summary. Each
+assessment contains:
+
+- `task_id`
+- exact `context_files_before` and proposed `context_files_after`
+- `disposition` and, for an empty proposal, `evidence`
+- `recommended_crew` and `recommended_complexity`
+- `blocked_by`, `duplicate_of`, and `already_landed`
+- `adr_conflicts`, `utility_warnings`, and `surface_warnings`
+
+Fail the whole partition if any supplied task cannot be assessed. Never omit a
+task or summarize a failed partition as successful.

--- a/scripts/smoke-plugin-install.sh
+++ b/scripts/smoke-plugin-install.sh
@@ -250,10 +250,19 @@ fi
 python3 - "$TMPDIR_ROOT/codex-plugin-add.json" <<'PY'
 import json
 import sys
+from pathlib import Path
 payload = json.load(open(sys.argv[1], encoding="utf-8"))
 if payload.get("name") != "orbit" or payload.get("marketplaceName") != "orbit":
     raise SystemExit(f"FAIL: expected installed orbit@orbit, got {payload!r}")
-print(f"codex plugin installed => {payload.get('installedPath')}")
+installed = Path(payload.get("installedPath", ""))
+required = [
+    installed / "skills" / "orbit-task-pilot" / "SKILL.md",
+    installed / "agents" / "orbit-task-pilot.md",
+]
+missing = [str(path) for path in required if not path.is_file()]
+if missing:
+    raise SystemExit(f"FAIL: installed Orbit plugin is missing task-pilot assets: {missing}")
+print(f"codex plugin installed with task-pilot assets => {installed}")
 PY
 
 if ! "${CODEX_ENV[@]}" codex mcp list --json \
@@ -311,6 +320,7 @@ required = [
     "orbit:orbit-search",
     "orbit:orbit-knowledge",
     "orbit:orbit-graph",
+    "orbit:orbit-task-pilot",
 ]
 missing = [name for name in required if name not in text]
 if missing:

--- a/scripts/validate-codex-plugin.sh
+++ b/scripts/validate-codex-plugin.sh
@@ -136,6 +136,38 @@ def validate_skill_frontmatter(skill_dir: Path) -> None:
             errors.append(f"skill {skill_dir.name} frontmatter field {key} must be non-empty")
 
 
+def validate_task_pilot_assets() -> None:
+    skill_path = plugin_root / "skills" / "orbit-task-pilot" / "SKILL.md"
+    agent_path = plugin_root / "agents" / "orbit-task-pilot.md"
+    if not skill_path.is_file():
+        errors.append("plugin is missing skills/orbit-task-pilot/SKILL.md")
+    else:
+        skill = skill_path.read_text(encoding="utf-8")
+        for required in (
+            "context_files_before",
+            "context_files_after",
+            "verified_no_diff",
+            "Never update an Orbit task",
+        ):
+            if required not in skill:
+                errors.append(f"orbit-task-pilot skill is missing contract marker {required!r}")
+    if not agent_path.is_file():
+        errors.append("plugin is missing agents/orbit-task-pilot.md")
+    else:
+        agent = agent_path.read_text(encoding="utf-8")
+        for required in (
+            "name: orbit-task-pilot",
+            "skills: orbit-task-pilot",
+            "tools: Read, Grep, Glob, Bash",
+            "Never edit repository files",
+        ):
+            if required not in agent:
+                errors.append(f"orbit-task-pilot agent is missing profile marker {required!r}")
+        for forbidden in ("tools: Read, Grep, Glob, Bash, Edit", "Write", "orbit.task.update"):
+            if forbidden in agent:
+                errors.append(f"orbit-task-pilot agent contains forbidden write marker {forbidden!r}")
+
+
 manifest = load_json(manifest_path, "plugin/.codex-plugin/plugin.json")
 if manifest is not None:
     reject_todos(manifest, "plugin.json")
@@ -228,6 +260,7 @@ if manifest is not None:
     else:
         for skill_dir in sorted(path for path in skills_root.iterdir() if path.is_dir()):
             validate_skill_frontmatter(skill_dir)
+    validate_task_pilot_assets()
 
     marketplace = load_json(marketplace_path, ".agents/plugins/marketplace.json")
     if marketplace is not None and name is not None:


### PR DESCRIPTION
## Task

[ORB-10510](https://orbit-cli.com/tasks/ORB-10510) — Introduce task-pilot as a plugin agent and Orbit activity/job

### Description

## Problem

Max-mode task preparation currently relies on ad-hoc runner mandates. That makes the role easy to over-broaden: one coarse runner can inspect too many unrelated tasks, under-scope `context_files`, or accidentally blur metadata preparation with promotion and implementation. Orbit's plugin already ships scoped reader/editor agent profiles, and Orbit already composes agent activities through jobs, but neither surface defines a bounded task-preflight role.

## Decision / Scope

Introduce `task-pilot` as an operational role, not a provider family, implementation crew, actor identity, or new authorization capability.

### Plugin surface

Ship an `orbit-task-pilot` plugin agent and a shared skill contract. The role accepts an explicit small partition of task IDs and a target workspace, inspects the current target branch plus relevant accepted ADRs, and returns:
- exact canonical `context_files` updates;
- crew/complexity recommendations;
- real `blocked_by` recommendations;
- duplicate or already-landed evidence;
- ADR conflicts and utility/surface warnings.

The plugin agent may update `context_files` only. It must not promote, dispatch, implement, edit repository files, or silently choose an architecture alternative.

### Orbit surface

Ship a thin `task_pilot` agent activity and `task_pilot_pipeline` job using existing activity/job/provider primitives. The activity always receives one explicit bounded partition. The job supports two entry modes: (1) automatic discovery of eligible proposed/backlog tasks in the selected workspace whose `context_files` are empty, and (2) explicit `task_ids` for targeted or repeat audits, including stale or overbroad non-empty selectors. A small deterministic preparation action performs discovery/filtering/partitioning, then the job fans out one Luna-backed pilot per bounded partition (default no more than five tasks). The agent activity returns structured proposals and has no repository-write or broad task-update authority. A deterministic apply action validates selectors and persists only `context_files`; all other recommendations remain report output for the orchestrator.

Luna is the default crew/model for the role but remains configurable through the existing crew mechanism. Persisted provenance remains the provider family (`codex`), not `task-pilot`.

## Constraints

- Reuse the existing task selector validation and activity/job machinery.
- Do not add a new executor type, provider/crew identity, scheduler, capability, or parallel task store.
- Auto-discovery excludes in-progress, review, done, rejected, and archived tasks, plus tasks tagged `no-diff-needed` or `no-diff-expected`; it must not promote or dispatch discovered work.
- An explicit `task_ids` mode remains available for targeted or repeat audits and does not require selectors to be empty.
- A selector must resolve inside the target workspace and name a real modification/deletion target. Empty is valid for no-diff or host-operational tasks.
- Repository files are read-only during pilot execution.
- Discovery/partition and context-only application are deterministic support actions inside the job, not new public commands. The agent activity does not receive a general `orbit.task.update` grant.
- Partition failures are isolated and auditable; a failed partition must not report overall success or partially apply unvalidated selectors.
- The role may recommend crew/dependencies/relations but v1 does not apply them.
- No ADR is required while the implementation remains composition of existing primitives. Stop and request an ADR if implementation would add distinct identity, capability, authority, or scheduling semantics.

## Motivation / Evidence

During 2026-07-26 max-mode preparation, a single broad context runner handled 19 unrelated tasks and over-narrowed ORB-10491 to deletion directories, dropping manifest/config/doc modification targets required by its accepted scope. Focused partition ownership is the guardrail this role exists to make repeatable.

### Acceptance Criteria

- The shipped plugin exposes an orbit-task-pilot agent profile plus a shared task-pilot skill contract, and plugin validation/smoke checks confirm the assets are packaged for supported hosts.
- The Orbit catalog exposes a task_pilot agent activity that accepts one explicit bounded task partition and a task_pilot_pipeline job with both automatic empty-context discovery and explicit task_ids modes.
- Automatic discovery is workspace-scoped to eligible proposed/backlog tasks with empty context_files, excludes in-progress/review/terminal tasks and no-diff-needed/no-diff-expected tasks, and never promotes or dispatches discovered work.
- The job fans out bounded partitions with a default maximum of five tasks per pilot and uses Luna by default through the existing crew/model resolution path.
- The agent activity has no repository-write or general task-update grant; a deterministic apply step can persist only selectors that pass canonical workspace validation into context_files, leaving every other task field and lifecycle/dispatch state unchanged.
- Canonical selector validation rejects missing or out-of-workspace targets before mutation, while empty context_files remains valid for verified no-diff or host-operational tasks.
- The structured result reports discovery/partition decisions, exact context_files before/after values, and crew/dependency/duplicate/ADR/utility recommendations for each task; a failed partition cannot be summarized as success.
- Focused activity/job tests cover discovery filters, explicit-input mode, partitioning, selector rejection, no-diff handling, mutation boundaries, and partial failure; plugin checks plus make ci-fast pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Shipped the orbit-task-pilot plugin agent profile and shared orbit-task-pilot skill contract, with validation and install-smoke assertions that the packaged plugin contains both assets.
- Added seeded task_pilot, prepare_task_pilot, and apply_task_pilot_results activities plus the invoked-only task_pilot_pipeline job. The job supports automatic empty-context discovery and explicit task_ids, defaults to Luna, partitions at no more than five tasks, and uses an all-join so a failed partition stops before apply.
- Implemented deterministic workspace/status/tag discovery filters and fail-closed context-only application. All partition coverage, stale before-snapshots, no-diff evidence, recommendation fields, and canonical existing in-workspace file/dir/symbol selectors are validated before the first task mutation; only context_files is submitted to TaskUpdateParams.
- Added focused activity, catalog, and v2-host tests covering permissions, Luna/default job wiring, discovery filters, explicit selection, partitioning, selector rejection, verified no-diff/host-operational handling, mutation boundaries, and partial failure.
Assessment: The implementation composes existing activity/job/crew/task-update primitives, so no new provider identity, capability, scheduler, dependency edge, or ADR was introduced. All scoped files were already covered by the task context selectors.
Validation: cargo test -p orbit-core task_pilot (8 passed); command job catalog tests (29 passed); command activity tests (10 passed); scripts/validate-codex-plugin.sh; bash syntax checks; YAML parse checks; git diff --check; make ci-fast. scripts/smoke-plugin-install.sh could not execute because this runner has no npx binary (exit 2 before any smoke step); the script changes are syntax-checked and CI remains the unrestricted smoke authority.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10510-6a66c53d`
- Behind base: 0
- Ahead of base: 1