### PR TITLE
Detect and repair id-allocation rows pinned to worktrees that no longer exist

### DIFF
--- a/.orbit/adrs/accepted/ADR-0296/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0296/adr.yaml
@@ -1,0 +1,24 @@
+schema_version: 2
+id: ADR-0296
+title: Detect and retire id allocations pinned to a reaped worktree
+status: accepted
+owner: claude
+created_at: 2026-07-27T02:55:47.419331209Z
+accepted_at: 2026-07-27T02:56:21.490547214Z
+last_updated: 2026-07-27T02:56:21.490547214Z
+related_features:
+- worktree-artifacts
+related_tasks:
+- ORB-10501
+tags:
+- worktree-artifacts
+- lifecycle
+- doctor
+paths:
+- crates/orbit-store/src/sqlite/id_allocator/**
+- crates/orbit-cmd/src/doctor.rs
+- crates/orbit-cli/src/command/doctor.rs
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0296/body.md
+++ b/.orbit/adrs/accepted/ADR-0296/body.md
@@ -1,0 +1,22 @@
+## Context
+
+Learning and ADR ids come from one shared SQLite allocator and are pinned to the worktree that allocated them, with the body written into that worktree (ADR-0177). Lists model a body that is not readable here as a *remote stub*, which assumes the body still exists in some other checkout.
+
+That assumption has no steady state. When a job-run worktree is reaped before its body was finalized and merged, the allocation row outlives every path that could resolve it: the row stays visible as `reserved`/`merged` forever, the body is unrecoverable, and nothing detects or prunes it. F2026-07-161 measured 35 of 113 allocated learning ids in `ws_orbit` as unreadable remote stubs (17 `reserved`, 18 `merged`), several pinned to worktrees confirmed gone from disk; the same pattern hit ADR-0149, 0181, 0194, 0211, and 0225. `learning sync` cannot help — it reconciles only from locally readable YAML (F2026-07-094 b).
+
+The allocator already had `abandon_learning`/`abandon_adr`, but they were reachable only from create-rollback and refuse any row that recorded a body path, which is exactly what a stranded `merged` row has.
+
+## Decision
+
+Define an **orphaned allocation** as a row satisfying both conditions: its pinned `worktree_root` no longer exists on disk, *and* its body is unreadable both canonically and through the recorded `body_path`. Both are required — a live sibling worktree is an ordinary remote stub, and a canonically present body makes a stale `worktree_root` harmless.
+
+Report orphans through a new `id-allocations` `orbit doctor` check, and retire them with the guarded `orbit doctor --fix-orphaned-allocations`. Repair flips `status` to `abandoned` rather than deleting the row: `max_sequence` counts abandoned rows, so a retired id is never reissued, and the row keeps its recorded worktree, branch, and `body_path` for forensics. The new allocator entry point differs from the create-rollback `abandon` in accepting a `merged` row and in guarding on the missing worktree, re-checked inside the write transaction. The owning store re-verifies both orphan conditions immediately before each write, so a caller working from a stale scan cannot retire a recoverable id. Learning repair additionally drops the stale envelope index row, which is pinned to the same dead body.
+
+## Consequences
+
+- The permanently-orphaned class is detectable rather than inferred by hand-reading `learning list --include-remote`, and repairable without hand-editing `.orbit/` or the SQLite store.
+- Retired ids stay consumed, so repair can never cause a collision with an id that was cited in a commit message or a doc.
+- Deleting the row was rejected: it would let `max_sequence` reissue the id, and would destroy the only remaining record of where the body was written.
+- Repair is opt-in behind an explicit flag; the check itself only warns, and an ordinary `orbit doctor` run mutates nothing.
+- Cost: the orphan test is duplicated per artifact kind (two ~25 LOC store methods) because ADR and learning bodies resolve differently; lifting it into the allocator would push artifact layout knowledge down into the id authority, which is the boundary ADR-0177 draws.
+- Cost: `worktree_root.exists()` is a liveness heuristic — a worktree on an unmounted volume reads as reaped. The refuse-on-recoverable guard and the opt-in flag bound the blast radius to a status flip that never touches a body file.

--- a/crates/orbit-cli/src/command/doctor.rs
+++ b/crates/orbit-cli/src/command/doctor.rs
@@ -20,6 +20,11 @@ pub struct DoctorCommand {
     /// Remove retired graph state from this worktree and the shared workspace.
     #[arg(long)]
     pub remove_graph: bool,
+
+    /// Abandon learning/ADR id allocations whose pinned worktree is gone and whose body is
+    /// unreadable, before diagnosing the workspace. The ids are never reissued.
+    #[arg(long)]
+    pub fix_orphaned_allocations: bool,
 }
 
 impl Execute for DoctorCommand {
@@ -34,6 +39,12 @@ impl Execute for DoctorCommand {
             let removed = runtime.remove_retired_graph_state()?;
             if !self.json {
                 println!("Removed {removed} retired graph location(s).");
+            }
+        }
+        if self.fix_orphaned_allocations {
+            let cleared = runtime.clear_orphaned_id_allocations()?;
+            if !self.json {
+                println!("Abandoned {cleared} orphaned id allocation(s).");
             }
         }
         let results = runtime.doctor_workspace()?;

--- a/crates/orbit-cli/src/command/tests/mod.rs
+++ b/crates/orbit-cli/src/command/tests/mod.rs
@@ -46,6 +46,21 @@ fn cli_parses_doctor_stale_lock_cleanup() {
             assert!(command.fix_stale_locks);
             assert!(command.remove_graph);
             assert!(command.json);
+            // [ORB-10501] Repairs are opt-in: an unflagged run only diagnoses.
+            assert!(!command.fix_orphaned_allocations);
+        }
+        _ => panic!("expected top-level doctor command"),
+    }
+}
+
+/// [ORB-10501] The guarded repair for allocations pinned to a reaped worktree.
+#[test]
+fn cli_parses_doctor_orphaned_allocation_repair() {
+    let cli = Cli::parse_from(["orbit", "doctor", "--fix-orphaned-allocations"]);
+    match cli.command {
+        Commands::Doctor(command) => {
+            assert!(command.fix_orphaned_allocations);
+            assert!(!command.fix_stale_locks);
         }
         _ => panic!("expected top-level doctor command"),
     }

--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -4,9 +4,11 @@
 //! surfaces with whole-workspace checks: config validity, store database
 //! integrity and schema-ledger version, free disk space on the volume
 //! holding `.orbit`, semantic-index staleness, leftover lock files from
-//! crashed holders, orphaned `running`/`pending` job runs, and task
+//! crashed holders, orphaned `running`/`pending` job runs, task
 //! relation/dependency targets that no longer resolve in the registry
-//! (grandfathered relations that block index rebuilds — ORB-10305).
+//! (grandfathered relations that block index rebuilds — ORB-10305), and
+//! learning/ADR id allocations pinned to a worktree that has since been
+//! reaped (ORB-10501).
 //!
 //! Every check degrades rather than errors: subsystems that are absent in a
 //! fresh workspace report [`WorkspaceDoctorStatus::Skipped`], and probe
@@ -83,6 +85,11 @@ pub trait DoctorCommands {
     /// workspace locations. Missing locations are a successful no-op.
     fn remove_retired_graph_state(&self) -> Result<usize, OrbitError>;
 
+    /// [ORB-10501] Abandon every learning/ADR allocation whose pinned worktree
+    /// is gone and whose body is unreadable, returning how many rows were
+    /// retired. Each row is re-verified by the owning store before its write.
+    fn clear_orphaned_id_allocations(&self) -> Result<usize, OrbitError>;
+
     /// Cheap store write probe for health endpoints: open the store and
     /// acquire + roll back the write lock without mutating anything.
     fn health_check_store_writable(&self) -> Result<String, OrbitError>;
@@ -98,6 +105,7 @@ impl DoctorCommands for OrbitRuntime {
             doctor_check_stale_locks(self),
             doctor_check_job_runs(self),
             doctor_check_task_relations(self),
+            doctor_check_id_allocations(self),
         ])
     }
 
@@ -123,6 +131,10 @@ impl DoctorCommands for OrbitRuntime {
             }
         }
         Ok(removed)
+    }
+
+    fn clear_orphaned_id_allocations(&self) -> Result<usize, OrbitError> {
+        Ok(self.abandon_orphaned_id_allocations()?.len())
     }
 
     fn health_check_store_writable(&self) -> Result<String, OrbitError> {
@@ -487,6 +499,64 @@ fn doctor_check_task_relations(runtime: &OrbitRuntime) -> WorkspaceDoctorResult 
             )
         }
     }
+}
+
+/// How many orphaned allocations the doctor message names before summarizing
+/// the rest. A workspace can accumulate dozens; the row stays readable while
+/// still reporting the true total.
+const ORPHANED_ALLOCATION_DETAIL_LIMIT: usize = 10;
+
+/// Learning/ADR id allocations pinned to a worktree that no longer exists and
+/// whose body is unreadable anywhere locally (ORB-10501). These rows can never
+/// resolve again — the body died with its worktree — so they are permanent
+/// dead weight in `learning list --include-remote` and the ADR list until they
+/// are retired.
+fn doctor_check_id_allocations(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {
+    let orphaned = match runtime.list_orphaned_id_allocations() {
+        Ok(orphaned) => orphaned,
+        Err(error) => {
+            return check(
+                "id-allocations",
+                WorkspaceDoctorStatus::Warning,
+                format!("cannot inspect id allocations: {error}"),
+            );
+        }
+    };
+    if orphaned.is_empty() {
+        return check(
+            "id-allocations",
+            WorkspaceDoctorStatus::Ok,
+            "no learning/ADR allocations pinned to a missing worktree".to_string(),
+        );
+    }
+    let mut detail = orphaned
+        .iter()
+        .take(ORPHANED_ALLOCATION_DETAIL_LIMIT)
+        .map(|record| {
+            format!(
+                "{} ({}, worktree {})",
+                record.id,
+                record.status,
+                record.worktree_root.display()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    if let Some(remaining) = orphaned.len().checked_sub(ORPHANED_ALLOCATION_DETAIL_LIMIT)
+        && remaining > 0
+    {
+        detail.push_str(&format!("; and {remaining} more"));
+    }
+    check(
+        "id-allocations",
+        WorkspaceDoctorStatus::Warning,
+        format!(
+            "{} learning/ADR allocation(s) pinned to a worktree that no longer exists, with no \
+             readable body — unrecoverable; clear with `orbit doctor \
+             --fix-orphaned-allocations`: {detail}",
+            orphaned.len()
+        ),
+    )
 }
 
 /// Free/total space thresholds for the volume containing `path`.

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -1,7 +1,7 @@
 //! Sibling tests for `command/doctor.rs` — workspace self-diagnostics [ORB-10005].
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 use fs2::FileExt;
@@ -45,7 +45,7 @@ fn healthy_fresh_workspace_has_no_failures() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     let results = runtime.doctor_workspace().expect("doctor");
 
-    assert_eq!(results.len(), 7, "one row per check: {results:?}");
+    assert_eq!(results.len(), 8, "one row per check: {results:?}");
     assert!(
         results
             .iter()
@@ -80,6 +80,11 @@ fn healthy_fresh_workspace_has_no_failures() {
     // No tasks yet → no unresolved relation/dependency targets.
     assert_eq!(
         status_of(&results, "task-relations").status,
+        WorkspaceDoctorStatus::Ok
+    );
+    // No ids allocated yet → nothing pinned to a reaped worktree.
+    assert_eq!(
+        status_of(&results, "id-allocations").status,
         WorkspaceDoctorStatus::Ok
     );
 }
@@ -398,6 +403,100 @@ fn fresh_pending_run_is_not_reported_as_orphan() {
     let results = runtime.doctor_workspace().expect("doctor");
     let job_runs = status_of(&results, "job-runs");
     assert_eq!(job_runs.status, WorkspaceDoctorStatus::Ok, "{job_runs:?}");
+}
+
+/// [ORB-10501] Allocate a learning id from a worktree that is then reaped —
+/// the steady state behind F2026-07-161, where a job-run worktree is GC'd
+/// before its learning body was ever merged. Returns the stranded id.
+fn seed_learning_allocation_in(runtime: &OrbitRuntime, worktree: &Path, reap: bool) -> String {
+    fs::create_dir_all(worktree).expect("seed worktree");
+    let paths = runtime.paths();
+    // The effective semantic.db path is config-resolved, so read it from the
+    // runtime rather than reconstructing the default layout.
+    let semantic_db = PathBuf::from(
+        runtime.persistence_config_json()["semantic"]["path"]
+            .as_str()
+            .expect("semantic db path"),
+    );
+    let allocator = orbit_store::IdAllocator::open(orbit_store::IdAllocatorConfig::new(
+        semantic_db,
+        paths.state_dir.join(".id_alloc.lock"),
+        paths.orbit_dir.clone(),
+        worktree.to_path_buf(),
+        paths.adrs_dir.clone(),
+        paths.learnings_dir.clone(),
+    ))
+    .expect("open allocator");
+    let id = allocator.allocate_learning().expect("allocate learning").id;
+    drop(allocator);
+    if reap {
+        fs::remove_dir_all(worktree).expect("reap worktree");
+    }
+    id
+}
+
+#[test]
+fn allocation_pinned_to_a_reaped_worktree_is_reported_and_repairable() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let id = seed_learning_allocation_in(&runtime, &temp.path().join("ghost-worktree"), true);
+
+    let row = status_of(
+        &runtime.doctor_workspace().expect("doctor"),
+        "id-allocations",
+    )
+    .clone();
+    assert_eq!(row.status, WorkspaceDoctorStatus::Warning, "{row:?}");
+    assert!(
+        row.message.contains(&id) && row.message.contains("--fix-orphaned-allocations"),
+        "message names the orphan and its repair: {}",
+        row.message
+    );
+
+    assert_eq!(
+        runtime
+            .clear_orphaned_id_allocations()
+            .expect("clear orphaned allocations"),
+        1
+    );
+    assert_eq!(
+        status_of(
+            &runtime.doctor_workspace().expect("doctor"),
+            "id-allocations"
+        )
+        .status,
+        WorkspaceDoctorStatus::Ok
+    );
+    assert_eq!(
+        runtime
+            .clear_orphaned_id_allocations()
+            .expect("repeat repair"),
+        0,
+        "repair is idempotent once the row is abandoned"
+    );
+}
+
+/// An allocation whose worktree is still on disk is an ordinary remote stub —
+/// its body may yet be merged — so neither the check nor the repair touches it.
+#[test]
+fn allocation_with_a_live_worktree_is_left_alone() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let _id = seed_learning_allocation_in(&runtime, &temp.path().join("live-worktree"), false);
+
+    assert_eq!(
+        status_of(
+            &runtime.doctor_workspace().expect("doctor"),
+            "id-allocations"
+        )
+        .status,
+        WorkspaceDoctorStatus::Ok
+    );
+    assert_eq!(
+        runtime.clear_orphaned_id_allocations().expect("clear"),
+        0,
+        "a live worktree is not an orphan"
+    );
 }
 
 #[cfg(unix)]

--- a/crates/orbit-core/src/command/id_allocation.rs
+++ b/crates/orbit-core/src/command/id_allocation.rs
@@ -1,0 +1,68 @@
+//! [ORB-10501] Detection and repair for id-allocation rows whose pinned
+//! worktree no longer exists.
+//!
+//! Learning and ADR ids are allocated from one shared SQLite allocator and
+//! pinned to the worktree that allocated them (`docs/design/worktree-artifacts/`).
+//! When that worktree is reaped before the body is finalized and merged, the
+//! allocation row outlives every path that could resolve it: the body is
+//! unrecoverable, the row stays visible as a `reserved`/`merged` remote stub
+//! forever, and nothing prunes it. `orbit doctor` reports these rows and
+//! `orbit doctor --fix-orphaned-allocations` retires them.
+//!
+//! The stores own the orphan test — both kinds require a missing worktree
+//! *and* an unreadable body — so this surface only fans out over the two
+//! kinds and keeps the ordering stable.
+
+use orbit_common::types::OrbitError;
+use orbit_store::{IdAllocationKind, IdAllocationRecord};
+
+use crate::OrbitRuntime;
+
+impl OrbitRuntime {
+    /// Every learning and ADR allocation that can never resolve to a body
+    /// again, ordered by kind then id.
+    pub fn list_orphaned_id_allocations(&self) -> Result<Vec<IdAllocationRecord>, OrbitError> {
+        let mut orphaned = self.stores().adrs().list_orphaned_adr_allocations()?;
+        orphaned.extend(
+            self.stores()
+                .learnings()
+                .list_orphaned_learning_allocations()?,
+        );
+        orphaned.sort_by(|left, right| {
+            left.kind
+                .as_str()
+                .cmp(right.kind.as_str())
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        Ok(orphaned)
+    }
+
+    /// Abandon every currently-orphaned allocation, returning the rows that
+    /// were retired.
+    ///
+    /// Each row is re-verified by the owning store immediately before its
+    /// write, so an allocation that stopped qualifying between the scan and
+    /// the repair (a worktree re-created, a body synced back) is refused
+    /// rather than silently retired. A refusal fails the whole call: the
+    /// caller asked to clear a set it had just been shown, and a changed set
+    /// deserves a fresh look rather than a partial sweep.
+    pub fn abandon_orphaned_id_allocations(&self) -> Result<Vec<IdAllocationRecord>, OrbitError> {
+        let mut abandoned = Vec::new();
+        for record in self.list_orphaned_id_allocations()? {
+            let cleared = match record.kind {
+                IdAllocationKind::Adr => self
+                    .stores()
+                    .adrs()
+                    .abandon_orphaned_adr_allocation(&record.id)?,
+                IdAllocationKind::Learning => self
+                    .stores()
+                    .learnings()
+                    .abandon_orphaned_learning_allocation(&record.id)?,
+            };
+            if cleared {
+                abandoned.push(record);
+            }
+        }
+        Ok(abandoned)
+    }
+}

--- a/crates/orbit-core/src/command/mod.rs
+++ b/crates/orbit-core/src/command/mod.rs
@@ -51,6 +51,7 @@ pub mod backend_resolver;
 pub(crate) mod docs;
 pub(crate) mod executor;
 pub mod gc;
+pub(crate) mod id_allocation;
 pub mod init;
 pub mod job;
 pub mod learning;

--- a/crates/orbit-store/src/backend/contracts/traits.rs
+++ b/crates/orbit-store/src/backend/contracts/traits.rs
@@ -10,6 +10,8 @@ use std::collections::BTreeMap;
 
 use super::params::*;
 
+use crate::sqlite::id_allocator::IdAllocationRecord;
+
 use crate::sqlite::audit_event_store::{
     AuditEventFilter, AuditEventInsertParams, AuditRoleAggregate, AuditToolAggregate,
     AuditToolCallCountsByRole, AuditToolCallCountsBySurfaceAndRole, AuditTopToolCall,
@@ -78,6 +80,16 @@ pub trait AdrStoreBackend: Send + Sync {
         include_remote: bool,
     ) -> Result<Vec<AdrListEntry>, OrbitError>;
     fn get_adr_remote_stub(&self, id: &str) -> Result<Option<RemoteArtifactStub>, OrbitError>;
+
+    /// [ORB-10501] Allocations pinned to a worktree that no longer exists and
+    /// whose bundle is not readable anywhere locally — permanently orphaned
+    /// index rows, reported by `orbit doctor`.
+    fn list_orphaned_adr_allocations(&self) -> Result<Vec<IdAllocationRecord>, OrbitError>;
+
+    /// [ORB-10501] Abandon one orphaned allocation row. `false` when the id
+    /// has no live allocation; an error when it is still recoverable.
+    fn abandon_orphaned_adr_allocation(&self, id: &str) -> Result<bool, OrbitError>;
+
     fn update_adr_status(&self, id: &str, new_status: AdrStatus) -> Result<(), OrbitError>;
     fn update_adr_document(
         &self,
@@ -393,6 +405,16 @@ pub trait LearningStoreBackend: Send + Sync {
         include_remote: bool,
     ) -> Result<Vec<LearningListEntry>, OrbitError>;
     fn get_learning_remote_stub(&self, id: &str) -> Result<Option<RemoteArtifactStub>, OrbitError>;
+
+    /// [ORB-10501] Allocations pinned to a worktree that no longer exists and
+    /// whose body is not readable anywhere locally — permanently orphaned
+    /// index rows, reported by `orbit doctor`.
+    fn list_orphaned_learning_allocations(&self) -> Result<Vec<IdAllocationRecord>, OrbitError>;
+
+    /// [ORB-10501] Abandon one orphaned allocation row. `false` when the id
+    /// has no live allocation; an error when it is still recoverable.
+    fn abandon_orphaned_learning_allocation(&self, id: &str) -> Result<bool, OrbitError>;
+
     fn search_learnings(
         &self,
         params: LearningSearchParams,

--- a/crates/orbit-store/src/backend/file_backends/mod.rs
+++ b/crates/orbit-store/src/backend/file_backends/mod.rs
@@ -14,6 +14,7 @@ use super::contracts::{
     TaskCreateParams, TaskDocumentStoreBackend, TaskDocumentUpdateParams, TaskHistoryStoreBackend,
     TaskHistoryUpdateParams, TaskStoreBackend,
 };
+use crate::IdAllocationRecord;
 use crate::file::adr_store::AdrFileStore;
 use crate::file::executor_def_store::ExecutorDefFileStore;
 use crate::file::learning_store::LearningFileStore;
@@ -213,6 +214,14 @@ impl AdrStoreBackend for AdrFileStore {
         AdrFileStore::get_adr_remote_stub(self, id)
     }
 
+    fn list_orphaned_adr_allocations(&self) -> Result<Vec<IdAllocationRecord>, OrbitError> {
+        AdrFileStore::list_orphaned_adr_allocations(self)
+    }
+
+    fn abandon_orphaned_adr_allocation(&self, id: &str) -> Result<bool, OrbitError> {
+        AdrFileStore::abandon_orphaned_adr_allocation(self, id)
+    }
+
     fn update_adr_status(&self, id: &str, new_status: AdrStatus) -> Result<(), OrbitError> {
         self.update_adr_status(id, new_status)
     }
@@ -275,6 +284,14 @@ impl LearningStoreBackend for LearningFileStore {
 
     fn get_learning_remote_stub(&self, id: &str) -> Result<Option<RemoteArtifactStub>, OrbitError> {
         LearningFileStore::get_learning_remote_stub(self, id)
+    }
+
+    fn list_orphaned_learning_allocations(&self) -> Result<Vec<IdAllocationRecord>, OrbitError> {
+        LearningFileStore::list_orphaned_learning_allocations(self)
+    }
+
+    fn abandon_orphaned_learning_allocation(&self, id: &str) -> Result<bool, OrbitError> {
+        LearningFileStore::abandon_orphaned_learning_allocation(self, id)
     }
 
     fn search_learnings(

--- a/crates/orbit-store/src/file/adr_store/api/mod.rs
+++ b/crates/orbit-store/src/file/adr_store/api/mod.rs
@@ -384,6 +384,54 @@ impl AdrFileStore {
         Ok(Some(remote_stub_from_allocation(&record)))
     }
 
+    /// [ORB-10501] ADR allocations that can never resolve to a bundle again:
+    /// the worktree they were pinned to is gone from disk *and* no local or
+    /// recorded bundle is readable here. See
+    /// `LearningFileStore::list_orphaned_learning_allocations` for why both
+    /// conditions are required.
+    pub(crate) fn list_orphaned_adr_allocations(
+        &self,
+    ) -> Result<Vec<IdAllocationRecord>, OrbitError> {
+        let mut orphaned = Vec::new();
+        for record in self.id_allocator.adr_allocations()? {
+            if !record.worktree_is_missing() {
+                continue;
+            }
+            if self.get_adr(&record.id)?.is_some() || self.read_adr_allocation(&record)?.is_some() {
+                continue;
+            }
+            orphaned.push(record);
+        }
+        Ok(orphaned)
+    }
+
+    /// [ORB-10501] Clear one orphaned allocation row, re-verifying both orphan
+    /// conditions immediately before the write. Returns `false` when `id` has
+    /// no live allocation row; refuses with `InvalidInput` when the row is
+    /// still recoverable.
+    pub(crate) fn abandon_orphaned_adr_allocation(&self, id: &str) -> Result<bool, OrbitError> {
+        validate_adr_id(id)?;
+        let Some(record) = self.id_allocator.adr_allocation(id)? else {
+            return Ok(false);
+        };
+        if !record.worktree_is_missing() {
+            return Err(OrbitError::InvalidInput(format!(
+                "ADR '{id}' is not orphaned: its recorded worktree '{}' still exists",
+                record.worktree_root.display()
+            )));
+        }
+        if self.get_adr(id)?.is_some() || self.read_adr_allocation(&record)?.is_some() {
+            return Err(OrbitError::InvalidInput(format!(
+                "ADR '{id}' is not orphaned: its bundle is still readable"
+            )));
+        }
+        if !self.id_allocator.abandon_orphaned_adr(id)? {
+            return Ok(false);
+        }
+        self.delete_index_row(id);
+        Ok(true)
+    }
+
     /// Updates ADR status, moving the bundle between state directories and
     /// refreshing the index row. Index update is best-effort: a failure is
     /// logged but does not roll back the filesystem move.

--- a/crates/orbit-store/src/file/learning_store/api/crud.rs
+++ b/crates/orbit-store/src/file/learning_store/api/crud.rs
@@ -348,6 +348,65 @@ impl LearningFileStore {
         Ok(Some(remote_stub_from_allocation(&record)))
     }
 
+    /// [ORB-10501] Learning allocations that can never resolve to a body
+    /// again: the worktree they were pinned to is gone from disk *and* no
+    /// canonical or recorded copy of the body is readable here.
+    ///
+    /// Both conditions are required. A live sibling worktree is an ordinary
+    /// remote stub, and a canonically-present body makes a stale
+    /// `worktree_root` harmless — neither is dead weight.
+    pub(crate) fn list_orphaned_learning_allocations(
+        &self,
+    ) -> Result<Vec<IdAllocationRecord>, OrbitError> {
+        let mut orphaned = Vec::new();
+        for record in self.id_allocator.learning_allocations()? {
+            if !record.worktree_is_missing() {
+                continue;
+            }
+            if self.read_learning_allocation(&record)?.is_some() {
+                continue;
+            }
+            orphaned.push(record);
+        }
+        Ok(orphaned)
+    }
+
+    /// [ORB-10501] Clear one orphaned allocation row, re-verifying both orphan
+    /// conditions immediately before the write. Returns `false` when `id` has
+    /// no live allocation row; refuses with `InvalidInput` when the row is
+    /// still recoverable, so a caller working from a stale scan cannot retire
+    /// a readable learning.
+    pub(crate) fn abandon_orphaned_learning_allocation(
+        &self,
+        id: &str,
+    ) -> Result<bool, OrbitError> {
+        validate_learning_id(id)?;
+        let Some(record) = self.id_allocator.learning_allocation(id)? else {
+            return Ok(false);
+        };
+        if !record.worktree_is_missing() {
+            return Err(OrbitError::InvalidInput(format!(
+                "learning '{id}' is not orphaned: its recorded worktree '{}' still exists",
+                record.worktree_root.display()
+            )));
+        }
+        if self.read_learning_allocation(&record)?.is_some() {
+            return Err(OrbitError::InvalidInput(format!(
+                "learning '{id}' is not orphaned: its body is still readable"
+            )));
+        }
+        if !self.id_allocator.abandon_orphaned_learning(id)? {
+            return Ok(false);
+        }
+        // The envelope index row is pinned to the same dead body; leaving it
+        // behind is the stale-`reserved`-row half of F2026-07-094.
+        if let Some(index) = &self.index {
+            index.delete_learning_index_row(&self.workspace_id, id)?;
+        }
+        self.invalidate_envelope_cache();
+        Ok(true)
+    }
+
     pub(crate) fn update_learning(
         &self,
         id: &str,

--- a/crates/orbit-store/src/sqlite/id_allocator/mod.rs
+++ b/crates/orbit-store/src/sqlite/id_allocator/mod.rs
@@ -7,7 +7,9 @@ use chrono::{DateTime, Utc};
 use orbit_common::types::OrbitError;
 use orbit_common::utility::fs::atomic_write_text;
 use orbit_common::utility::git::{CurrentBranchStatus, current_branch};
-use rusqlite::{Connection, Transaction, TransactionBehavior, params, types::Type};
+use rusqlite::{
+    Connection, OptionalExtension, Transaction, TransactionBehavior, params, types::Type,
+};
 use serde::{Deserialize, Serialize};
 use serde_yaml::{Mapping, Value};
 
@@ -62,6 +64,18 @@ impl IdAllocationRecord {
                 self.worktree_root.join(body_path)
             }
         })
+    }
+
+    /// [ORB-10501] Whether the worktree this id was allocated in is gone from
+    /// disk.
+    ///
+    /// This is what separates a transient "remote stub" — the body lives in a
+    /// sibling checkout that simply is not this one — from a permanent orphan:
+    /// once the pinned worktree is reaped, a `body_path` recorded relative to
+    /// it can never resolve again, so the row is dead weight the index carries
+    /// forever.
+    pub fn worktree_is_missing(&self) -> bool {
+        !self.worktree_root.exists()
     }
 }
 
@@ -230,6 +244,19 @@ impl IdAllocator {
     /// partial ADR create does not leak a half-visible ID.
     pub fn abandon_adr(&self, id: &str) -> Result<(), OrbitError> {
         self.abandon(IdAllocationKind::Adr, id)
+    }
+
+    /// [ORB-10501] Abandon a learning allocation whose pinned worktree is gone.
+    /// See [`Self::abandon_orphaned`] for the guard and how this differs from
+    /// [`Self::abandon_learning`].
+    pub fn abandon_orphaned_learning(&self, id: &str) -> Result<bool, OrbitError> {
+        self.abandon_orphaned(IdAllocationKind::Learning, id)
+    }
+
+    /// [ORB-10501] Abandon an ADR allocation whose pinned worktree is gone.
+    /// See [`Self::abandon_orphaned`].
+    pub fn abandon_orphaned_adr(&self, id: &str) -> Result<bool, OrbitError> {
+        self.abandon_orphaned(IdAllocationKind::Adr, id)
     }
 
     pub fn adr_allocation(&self, id: &str) -> Result<Option<IdAllocationRecord>, OrbitError> {
@@ -566,6 +593,59 @@ impl IdAllocator {
         tx.commit()
             .map_err(|error| OrbitError::Store(error.to_string()))?;
         Ok(())
+    }
+
+    /// [ORB-10501] Abandon an allocation whose pinned worktree no longer
+    /// exists, so the index stops carrying a row nothing can ever resolve.
+    ///
+    /// Two things separate this from [`Self::abandon`], which exists for
+    /// create-rollback: it accepts a `merged` row that already recorded a
+    /// `body_path` (that path died with its worktree), and it is guarded on
+    /// the worktree being gone rather than on the row never having been
+    /// finalized. The guard is re-checked inside the write transaction — the
+    /// caller's classifying scan and this repair are separate steps, and a
+    /// worktree can be re-created in between.
+    ///
+    /// Returns `false` when `id` has no live allocation row (already
+    /// abandoned, or never allocated). The row keeps its recorded worktree,
+    /// branch, and `body_path` for forensics; only `status` moves. Sequence
+    /// density is unaffected: [`max_sequence`] counts abandoned rows too, so
+    /// an abandoned id is never handed out again.
+    fn abandon_orphaned(&self, kind: IdAllocationKind, id: &str) -> Result<bool, OrbitError> {
+        let _lock = self.acquire_lock()?;
+        let mut conn = self.lock_conn()?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let worktree_root = tx
+            .query_row(
+                "SELECT worktree_root
+                 FROM id_allocations
+                 WHERE kind = ?1 AND id = ?2 AND status != ?3",
+                params![kind.as_str(), id, STATUS_ABANDONED],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let Some(worktree_root) = worktree_root else {
+            return Ok(false);
+        };
+        if Path::new(&worktree_root).exists() {
+            return Err(OrbitError::InvalidInput(format!(
+                "refusing to abandon {} {id}: its recorded worktree '{worktree_root}' still exists",
+                kind.as_str()
+            )));
+        }
+        tx.execute(
+            "UPDATE id_allocations
+             SET status = ?3
+             WHERE kind = ?1 AND id = ?2",
+            params![kind.as_str(), id, STATUS_ABANDONED],
+        )
+        .map_err(|error| OrbitError::Store(error.to_string()))?;
+        tx.commit()
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        Ok(true)
     }
 
     fn allocation(

--- a/crates/orbit-store/src/sqlite/id_allocator/tests/id_allocator.rs
+++ b/crates/orbit-store/src/sqlite/id_allocator/tests/id_allocator.rs
@@ -127,6 +127,84 @@ fn abandoned_learning_allocation_advances_sequence_but_is_hidden() {
     assert_eq!(visible, vec!["L-0002"]);
 }
 
+/// [ORB-10501] A worktree reaped after allocation leaves rows nothing can ever
+/// resolve. The guarded abandon retires both a `reserved` row and a `merged`
+/// row whose recorded `body_path` died with the worktree, and the ids stay
+/// consumed so no future allocation reuses them.
+#[test]
+fn abandons_allocations_whose_pinned_worktree_was_reaped() {
+    let temp = TempDir::new().expect("tempdir");
+    let ghost = temp.path().join("ghost-worktree");
+    std::fs::create_dir_all(&ghost).expect("ghost worktree");
+    let mut config = allocator_config(temp.path());
+    config.worktree_root = ghost.clone();
+    let allocator = IdAllocator::open(config).expect("allocator");
+
+    let learning = allocator.allocate_learning().expect("learning");
+    let adr = allocator.allocate_adr().expect("adr");
+    allocator
+        .record_learning_body_path(&learning.id, &ghost.join("learning.yaml"))
+        .expect("record body path");
+
+    std::fs::remove_dir_all(&ghost).expect("reap worktree");
+
+    assert!(
+        allocator
+            .abandon_orphaned_learning(&learning.id)
+            .expect("abandon learning")
+    );
+    assert!(
+        allocator
+            .abandon_orphaned_adr(&adr.id)
+            .expect("abandon adr")
+    );
+
+    assert!(
+        allocator
+            .learning_allocation(&learning.id)
+            .expect("learning row")
+            .is_none()
+    );
+    assert!(
+        allocator
+            .adr_allocation(&adr.id)
+            .expect("adr row")
+            .is_none()
+    );
+    // Repeat repair is a no-op rather than an error, and the retired ids are
+    // never handed out again.
+    assert!(
+        !allocator
+            .abandon_orphaned_learning(&learning.id)
+            .expect("repeat abandon")
+    );
+    assert_eq!(allocator.allocate_learning().expect("next").id, "L-0002");
+    assert_eq!(allocator.allocate_adr().expect("next adr").id, "ADR-0002");
+}
+
+/// [ORB-10501] The guard is what separates a live sibling worktree from a
+/// reaped one: an allocation whose worktree still exists is refused, so a
+/// caller working from a stale scan cannot retire a recoverable id.
+#[test]
+fn refuses_to_abandon_an_allocation_whose_worktree_still_exists() {
+    let temp = TempDir::new().expect("tempdir");
+    let allocator = IdAllocator::open(allocator_config(temp.path())).expect("allocator");
+    let learning = allocator.allocate_learning().expect("learning");
+
+    let error = allocator
+        .abandon_orphaned_learning(&learning.id)
+        .expect_err("a live worktree must be refused");
+
+    assert!(error.to_string().contains("still exists"), "{error}");
+    assert!(
+        allocator
+            .learning_allocation(&learning.id)
+            .expect("learning row")
+            .is_some(),
+        "a refused repair must leave the row untouched"
+    );
+}
+
 #[test]
 fn backfills_existing_adrs_idempotently_and_allocates_after_max() {
     let temp = TempDir::new().expect("tempdir");

--- a/docs/design/worktree-artifacts/1_overview.md
+++ b/docs/design/worktree-artifacts/1_overview.md
@@ -3,14 +3,14 @@ summary: "Worktree Artifacts - Overview"
 type: design
 title: "Worktree Artifacts - Overview"
 owner: codex
-last_updated: 2026-05-20
+last_updated: 2026-07-27
 status: Accepted
 feature: worktree-artifacts
 doc_role: overview
 tags: ["worktree-artifacts"]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-cli/**"]
 related_features: ["worktree-artifacts"]
-related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ADR-0177"]
+related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10501", "ADR-0177", "ADR-0296"]
 ---
 
 # Worktree Artifacts - Overview
@@ -35,7 +35,8 @@ The three-task sequence split this apart:
 | Local root | The current worktree `.orbit/`, used for ADR and learning body files. |
 | Allocation row | A row in `id_allocations` recording ID, kind, allocation status, recorded worktree, branch, and `body_path`. |
 | Local-readable artifact | An allocation whose recorded body path exists and can be read by the current process. |
-| Remote stub | A list row for an allocation whose body is not locally readable, shown only with `include_remote`. |
+| Remote stub | A list row for an allocation whose body is not locally readable, shown only with `include_remote`. Assumes the body still exists in *some* worktree. |
+| Orphaned allocation | An allocation whose pinned worktree is gone from disk *and* whose body is unreadable everywhere locally — a remote stub that can never resolve again. Detected by the `id-allocations` doctor check and retired by `orbit doctor --fix-orphaned-allocations` [ORB-10501]. |
 
 ## 3. At a Glance
 
@@ -46,12 +47,14 @@ The three-task sequence split this apart:
 | ADR body storage and federation | `crates/orbit-store/src/file/adr_store/api/` | [ORB-00201] |
 | Learning body storage and federation | `crates/orbit-store/src/file/learning_store/api/crud.rs` | [ORB-00201] |
 | CLI/tool remote listing | `crates/orbit-core/src/runtime/orbit_tool_host/` and `crates/orbit-cli/src/command/learning/` | [ORB-00201] |
-| Decision log | `docs/design/worktree-artifacts/4_decisions.md` | [ADR-0177] |
+| Orphaned-allocation detection and repair | `crates/orbit-core/src/command/id_allocation.rs`, `crates/orbit-cmd/src/doctor.rs` | [ORB-10501] |
+| Decision log | `docs/design/worktree-artifacts/4_decisions.md` | [ADR-0177], [ADR-0296] |
 
 ## Task References
 
 - [ORB-00199] split Orbit runtime resolution into shared and local roots.
 - [ORB-00200] introduced the global ADR/Learning allocator and `L-NNNN` learning IDs.
 - [ORB-00201] moved ADR/Learning body writes to the current worktree and added read federation.
+- [ORB-10501] added detection and guarded repair for allocations pinned to a worktree that no longer exists.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/worktree-artifacts/4_decisions.md
+++ b/docs/design/worktree-artifacts/4_decisions.md
@@ -3,14 +3,14 @@ summary: "Worktree Artifacts - Decisions"
 type: design
 title: "Worktree Artifacts - Decisions"
 owner: codex
-last_updated: 2026-07-19
+last_updated: 2026-07-27
 status: Accepted
 feature: worktree-artifacts
 doc_role: decisions
 tags: ["worktree-artifacts"]
 paths: ["crates/orbit-remote/**", "crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-cli/**"]
 related_features: ["worktree-artifacts", "host-registry", "mcp-bridge"]
-related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10272", "ORB-10297", "ORB-10330", "ADR-0177", "ADR-0229"]
+related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10272", "ORB-10297", "ORB-10330", "ORB-10501", "ADR-0177", "ADR-0229", "ADR-0296"]
 ---
 
 # Worktree Artifacts - Decisions
@@ -52,6 +52,22 @@ proxies to or reads a spoke owner's worktree.
 - Cost: list/show paths now carry a federation boundary and must handle `body_path` metadata, remote stubs, and stale worktree paths.
 - Cost: public HTTP, MCP, and CLI error mappers must preserve the origin discriminator and stable federation codes.
 
+## ADR-0296 - Detect and retire id allocations pinned to a reaped worktree
+
+**Status:** Accepted - 2026-07 - [ORB-10501]
+
+**Context.** ADR-0177 pins each allocated id to the worktree that wrote its body, and models a body that is not readable here as a *remote stub* — which assumes the body still exists in some other checkout. That assumption has no steady state. When a job-run worktree is reaped before its body was finalized and merged, the allocation row outlives every path that could resolve it: the row stays visible as `reserved`/`merged` forever, the body is unrecoverable, and nothing detects or prunes it. F2026-07-161 measured 35 of 113 allocated learning ids in `ws_orbit` as unreadable remote stubs (17 `reserved`, 18 `merged`), several pinned to worktrees confirmed gone from disk; the same pattern hit ADR-0149, 0181, 0194, 0211, and 0225. `learning sync` cannot help — it reconciles only from locally readable YAML (F2026-07-094 b). The allocator's `abandon_learning`/`abandon_adr` existed but were reachable only from create-rollback and refuse any row that recorded a body path, which is exactly what a stranded `merged` row has.
+
+**Decision.** An allocation is **orphaned** when both hold: its pinned `worktree_root` no longer exists on disk, *and* its body is unreadable both canonically and through the recorded `body_path`. Both are required — a live sibling worktree is an ordinary remote stub, and a canonically present body makes a stale `worktree_root` harmless. Orphans are reported by the `id-allocations` `orbit doctor` check and retired by the guarded `orbit doctor --fix-orphaned-allocations`. Repair flips `status` to `abandoned` rather than deleting the row: `max_sequence` counts abandoned rows, so a retired id is never reissued, and the row keeps its recorded worktree, branch, and `body_path` for forensics. The new allocator entry point differs from the create-rollback `abandon` in accepting a `merged` row and in guarding on the missing worktree, re-checked inside the write transaction; the owning store re-verifies both orphan conditions immediately before each write, so a caller working from a stale scan cannot retire a recoverable id. Learning repair additionally drops the stale envelope index row pinned to the same dead body.
+
+**Consequences.**
+- The permanently-orphaned class is detectable rather than inferred by hand-reading `learning list --include-remote`, and repairable without hand-editing `.orbit/` or the SQLite store.
+- Retired ids stay consumed, so repair can never collide with an id already cited in a commit message or a doc.
+- Deleting the row was rejected: `max_sequence` would reissue the id, and the only remaining record of where the body was written would be destroyed.
+- Repair is opt-in behind an explicit flag; the check only warns, and an ordinary `orbit doctor` run mutates nothing.
+- Cost: the orphan test is duplicated per artifact kind (two ~25 LOC store methods) because ADR and learning bodies resolve differently; lifting it into the allocator would push artifact-layout knowledge down into the id authority, which is the boundary ADR-0177 draws.
+- Cost: `worktree_root.exists()` is a liveness heuristic — a worktree on an unmounted volume reads as reaped. The refuse-on-recoverable guard and the opt-in flag bound the blast radius to a status flip that never touches a body file.
+
 ## Task References
 
 - [ORB-00199] introduced shared/local root resolution.
@@ -65,5 +81,8 @@ proxies to or reads a spoke owner's worktree.
   composition that consume a hub allocation into the exact owner checkout — one
   hub allocation, one owner finalization, correlated by `mcp_call_id`, with
   replica/foreign-spoke rejection before allocation and no local sequence advance.
+- [ORB-10501] added detection and guarded repair for allocations whose pinned
+  worktree was reaped, closing the steady-state gap the remote-stub model left
+  open.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -4,7 +4,7 @@ summary: Check Orbit workspace, database, dashboard, log-sink, job-run, and rout
 tags: [operations, health, doctor, dashboard, routines]
 paths: ["crates/orbit-cmd/src/doctor.rs", "crates/orbit-core/src/command/job/run/reconcile.rs"]
 related_features: [orbit-core, activity-job, routines]
-related_artifacts: [ORB-10005, ORB-10070, ORB-10473, ADR-0291]
+related_artifacts: [ORB-10005, ORB-10070, ORB-10473, ORB-10501, ADR-0291, ADR-0296]
 ---
 
 # Check Orbit Health
@@ -14,7 +14,7 @@ database recovery, or upgrade.
 
 ## Run `orbit doctor`
 
-`orbit doctor` performs seven checks in order. Every check degrades to a row rather than
+`orbit doctor` performs eight checks in order. Every check degrades to a row rather than
 aborting unless the store itself cannot open.
 
 | Check | What it verifies |
@@ -26,6 +26,7 @@ aborting unless the store itself cannot open.
 | `stale-locks` | `.lock` files under `state/`, `tasks/`, `learnings/`, and `adrs/.locks/` whose recorded holder PID is dead |
 | `job-runs` | orphaned `pending` or `running` runs whose owner process is gone |
 | `task-relations` | unresolved relation/dependency targets that would block a task-index rebuild |
+| `id-allocations` | learning/ADR ids pinned to a worktree that no longer exists, with no readable body |
 
 Example:
 
@@ -41,6 +42,7 @@ $ orbit doctor
 │                            (dead pid 154488, op: layout upgrade, since 2026-07-04T09:25…)   │
 │ job-runs         ok        no orphaned job runs                                              │
 │ task-relations   ok        no unresolved relation/dependency targets                        │
+│ id-allocations   ok        no learning/ADR allocations pinned to a missing worktree         │
 0 failure(s), 1 warning(s).
 ```
 
@@ -48,6 +50,15 @@ The command exits nonzero only when at least one check is `ERROR`; warnings and 
 zero. `--json` emits an array of objects with `check`, `status`, and `message` fields; statuses
 are lowercase. Lock files flagged by `stale-locks` include holder diagnostics and are safe to
 delete only after confirming the holder PID is dead.
+
+An `id-allocations` warning means an id was allocated inside a worktree that has since been
+reaped, before its body was merged: the body is unrecoverable and the row would otherwise stay
+in `orbit learning list --include-remote` (and the ADR list) forever. Confirm the named
+worktrees really are gone — a volume that is merely unmounted reads the same way — then retire
+the rows with `orbit doctor --fix-orphaned-allocations`. The repair re-verifies every row
+before writing, refuses any that became readable again, and flips the row to `abandoned`
+instead of deleting it, so the retired ids are never reissued (ADR-0296, ORB-10501). Without
+the flag, `orbit doctor` only reports.
 
 Graph is retired under ADR-0291 and is not inspected by ordinary health checks. To remove
 leftover state explicitly, run `orbit doctor --remove-graph`. This deletes only the current


### PR DESCRIPTION
## Task

[ORB-10501](https://orbit-cli.com/tasks/ORB-10501) — Detect and repair id-allocation rows pinned to worktrees that no longer exist

### Description

## Problem
Learning and ADR ids allocated through the shared allocator, but never finalized before their pinned worktree was reaped, become permanently orphaned: the allocation row survives forever (`reserved`/`merged` status), the body is unrecoverable, and there is no detection or repair path.

## Evidence
F2026-07-161 (report-only, ORB-10477): `orbit learning list --include-remote --json` for ws_orbit shows 113 allocated ids, 35 remote stubs with no readable body (17 `reserved`, 18 `merged`); several (e.g. L-0089, L-0101) pin to worktrees confirmed no longer present on disk. The same pattern hits ADRs (ADR-0149, 0181, 0194, 0211, 0225 cited in source comments, all `remote_artifact_unavailable`). `docs/design/worktree-artifacts/1_overview.md` defines a "remote stub" assuming the body still exists in *some* worktree — it does not address the steady-state case where the pinned worktree has since been GC'd.

F2026-07-094(b) (2026-07-19): separately, `orbit learning sync` (reconcile SQLite envelope from YAML) rebuilds entries but leaves stale `reserved`-status index rows pointing at deleted worktrees; there is no CLI command to clear a reservation row for an abandoned worktree/branch. `sync` only reconciles from locally-readable YAML — it does not prune reservations whose worktree is gone.

Both confirmed still live in friction-curation pass (ORB-10489, 2026-07-27): live counts matched exactly (113 total / 35 remote stubs); `crates/orbit-cmd/src/doctor.rs` has no check for allocations pinned to a nonexistent worktree; `abandon_learning`/`abandon_adr` (`crates/orbit-store/src/sqlite/id_allocator/mod.rs:225-232`) exist but are only invoked internally on create-rollback, with no CLI surface.

## Suggested fix
1. Add a `doctor` check that reports allocations (`learning`/`adr`) whose pinned `worktree_root` no longer exists on disk.
2. Expose a guarded CLI/tool repair path (using the existing internal `abandon_learning`/`abandon_adr`) to clear such orphaned reservation rows once confirmed unrecoverable, so the index does not accumulate permanent dead weight.

## Acceptance criteria
- `orbit doctor` (or equivalent) surfaces learning/ADR allocations whose pinned worktree no longer exists.
- A guarded CLI or tool command can clear/abandon such an orphaned allocation row without hand-editing `.orbit/` or the sqlite store directly.


Note: this task covers F2026-07-161 fully and F2026-07-094 part (b) only (the CLI-repair gap for orphaned reservation rows). F2026-07-094 part (a) — worktree removal risking learning-body loss without a pre-check — is a separate, unconfirmed-here concern and is deliberately NOT tied to this task via a resolves relation, so completing this task does not prematurely resolve that unaddressed half of F2026-07-094.

### Acceptance Criteria

- orbit doctor (or equivalent) surfaces learning/ADR allocations whose pinned worktree no longer exists.
- A guarded CLI or tool command can clear/abandon such an orphaned allocation row without hand-editing .orbit/ or the sqlite store directly.

## Execution Summary

<details>
<summary>Click to expand</summary>

Detection and guarded repair for id-allocation rows pinned to a reaped worktree (F2026-07-161; F2026-07-094 part b only).

## Definition
An allocation is orphaned only when BOTH hold: its pinned `worktree_root` is gone from disk AND its body is unreadable both canonically and via the recorded `body_path`. A live sibling worktree is an ordinary remote stub; a canonically-present body makes a stale worktree path harmless. Neither is dead weight, so neither is touched.

## Detection (AC 1)
New `id-allocations` check in `orbit doctor` (crates/orbit-cmd/src/doctor.rs), backed by `OrbitRuntime::list_orphaned_id_allocations` (new crates/orbit-core/src/command/id_allocation.rs) over two new store-backend methods per kind. Warning row names the first 10 orphans with status + pinned worktree and reports `and N more` (no silent truncation).

Smoke-tested read-only against the live ws_orbit allocator: 32 orphans found, including ADR-0211 and ADR-0225 from the friction evidence. No repair was run on real data.

## Repair (AC 2)
`orbit doctor --fix-orphaned-allocations` (crates/orbit-cli/src/command/doctor.rs) -> `DoctorCommands::clear_orphaned_id_allocations` -> `OrbitRuntime::abandon_orphaned_id_allocations`. Three guards: the owning store re-verifies both orphan conditions immediately before each write and refuses with InvalidInput if the row became recoverable; the new `IdAllocator::abandon_orphaned_{learning,adr}` re-checks the missing worktree inside the write transaction; repair is opt-in behind the flag, so a plain `orbit doctor` mutates nothing. Unlike the create-rollback `abandon`, the new path accepts a `merged` row that already recorded a `body_path` (that path died with its worktree). Status flips to `abandoned` rather than deleting the row: `max_sequence` counts abandoned rows, so retired ids are never reissued, and worktree/branch/body_path are kept for forensics. Learning repair also drops the stale envelope index row (the F2026-07-094(b) stale-row half).

## Files
Store: sqlite/id_allocator/mod.rs (`IdAllocationRecord::worktree_is_missing`, guarded `abandon_orphaned`), learning_store/api/crud.rs, adr_store/api/mod.rs, backend/contracts/traits.rs, backend/file_backends/mod.rs. Core: command/id_allocation.rs (new) + command/mod.rs. Cmd: doctor.rs. CLI: command/doctor.rs.

## Docs
ADR-0296 (Accepted, [ORB-10501]) added to docs/design/worktree-artifacts/4_decisions.md; `Orphaned allocation` concept + file map added to 1_overview.md; `docs/runbooks/health-checks.md` updated (seven -> eight checks, new row, repair procedure incl. the unmounted-volume caveat). Both design docs' `last_updated` and `related_artifacts` bumped.

## Validation
`make ci-fast` passes (exit 0). New tests: 2 allocator tests (reaped-worktree abandon incl. merged row + id-density; refusal when the worktree still exists), 2 doctor tests (reported and repairable, idempotent; live worktree left alone), 1 CLI parse test; existing doctor check-count assertion updated 7 -> 8. Suites green: orbit-store lib 311, orbit-cmd lib 49, orbit-cli bins 251. `cargo clippy` on the four touched crates adds no new warnings (2 pre-existing ones in files this task does not touch).

Pre-existing failure, NOT caused by this change: `orbit-core --lib` `command::skill::tests::plugin_skill_symlinks_resolve_to_assets` fails because `plugin/skills/orbit-task/SKILL.md` diverged from its asset source in commit 737fee8a [ORB-10463]; nothing under `plugin/` or the skill assets is in this task's diff, and the other 666 orbit-core lib tests pass. Filed as F2026-07-181.

## Scope notes
context_files extended with the files needed to make the scoped change compile and stay documented: the two store impls, the backend trait + its single impl, orbit-core's command/mod.rs (new module registration; the new id_allocation.rs itself cannot be a selector until it exists in the tree), the CLI parse-test file, and the three affected docs. F2026-07-094 part (a) — worktree removal risking body loss without a pre-check — is deliberately untouched.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10501-6a66c537`
- Behind base: 0
- Ahead of base: 1

*authored by: claude*