### PR TITLE
Add a disabled CI-failure remediation auto-task

### DIFF
--- a/.orbit/auto_tasks/ci-failure-remediation.yaml
+++ b/.orbit/auto_tasks/ci-failure-remediation.yaml
@@ -1,0 +1,127 @@
+schemaVersion: 1
+name: ci-failure-remediation
+description: Recurring evidence-first remediation of current GitHub Actions failures without duplicating the PR-only CI task hook
+enabled: false
+schedule:
+  cron: 15 * * * *
+template:
+  title: Remediate current GitHub Actions failures
+  description: |
+    Investigate and remediate current GitHub Actions failures for this
+    repository. This task may legitimately finish with no diff: if no
+    current, reproducible, repository-owned failure remains, persist the
+    evidence described below and report a successful no-current-failure or
+    transient-only outcome.
+
+    ## Discovery and duplicate safety
+
+    1. Enumerate this repository's workflows and recent runs with GitHub's API
+       or `gh`, and enumerate open pull requests with their current head SHAs.
+       Cover failures for the current heads of `agent-main`, `main`, and every
+       open pull request, including informational jobs such as coverage rather
+       than looking only at required checks or the main `ci` job.
+    2. The PR-only `Create orbit task on CI failure` step in
+       `.github/workflows/ci.yml` is an input and coverage signal. Search open
+       Orbit tasks for its run URL, PR number, SHA, and failure signature.
+       Reference matching tasks in the execution summary; do not create
+       another task for the same run or root cause. This remediation task owns
+       the repair and must not fan a red-run cluster out into more failure
+       tasks.
+    3. For every candidate run, record the run and job URLs, workflow, event,
+       branch or PR, run-attempt number, reported head SHA, and the current
+       branch/PR head SHA. Query the failed jobs and steps and inspect the
+       exact failed-step logs.
+    4. Independently verify the commit that Actions actually checked out from
+       the checkout step/log (`HEAD is now at`, checkout ref/SHA, or equivalent
+       unambiguous evidence). Keep the event's reported head SHA, the current
+       ref head, and the tested checkout commit distinct; PR merge SHAs are not
+       interchangeable with PR head SHAs.
+    5. Ignore a failed run as stale when its branch or PR has advanced and the
+       failure does not reproduce at the current head, or when a newer
+       successful run of the same workflow/check at the relevant current
+       commit supersedes it. Cite the advancing or superseding run and SHAs;
+       age alone is not evidence that a failure is stale.
+
+    ## Diagnosis and remediation
+
+    Cluster repeated runs by root cause before editing. Use the failing
+    command, job/step, exact error signature, tested commit, and causal
+    dependency between failures to distinguish one regression repeated across
+    push/PR runs from independent failures. Repair each current root cause
+    once, while retaining a mapping from every affected run/job to that
+    cluster.
+
+    Reproduce every current candidate at the current repository head using
+    the exact command or the narrowest faithful local equivalent. A
+    deterministic repository-owned failure is in scope and must be fixed in
+    this task's worktree. Classify a GitHub service, network, hosted-runner, or
+    other infrastructure failure as transient only with concrete evidence,
+    such as a successful retry at the same SHA plus logs showing the
+    infrastructure fault. Do not call a failure transient merely because it
+    fails to reproduce once.
+
+    Fix the underlying repository-owned cause. Do not disable a workflow,
+    weaken an assertion or lint level, add a broad allow/ignore rule, mark a
+    failing gate `continue-on-error`, remove an affected target from coverage,
+    or otherwise obtain green CI by hiding the failure. Informational checks
+    remain informational, but they must execute successfully.
+
+    ## Validation and handoff
+
+    For each fixed root cause, rerun the exact command that formerly failed.
+    Then run the repository pre-handoff gate, `make ci-fast`. After the
+    candidate commit is published through the repository's normal workflow,
+    inspect its GitHub Actions runs and require a green rerun for every
+    affected workflow/check. This includes affected informational jobs even
+    though they remain non-required. Do not declare a repair validated while
+    an affected run is missing, queued, in progress, cancelled, or red.
+
+    Persist an `execution_summary` that maps every investigated run/job URL,
+    reported head SHA, actual checkout commit, and current ref head to its
+    root-cause cluster, disposition (fixed, stale, superseded, or transient),
+    change, local reproduction, exact formerly failing validation, pre-handoff
+    result, and green GitHub rerun URL. Also map any matching PR-hook-created
+    Orbit task. For a successful no-diff pass, list the queries, current heads,
+    superseding successes or transient evidence, and why no repository-owned
+    failure remained.
+
+    ## Historical validation fixture
+
+    Use run 30232696219 as the calibration example for the evidence model, not
+    as proof of a current failure:
+
+    - `Check / Clippy / Test` → `Run CI guardrails` reported Clippy's needless
+      borrow at
+      `crates/orbit-store/src/file/task_store/v2_bundle/bundle_io/mod.rs:172`,
+      `sync_parent_dir(&staging_dir)`.
+    - `Coverage (informational)` reported that
+      `command::skill::tests::plugin_skill_symlinks_resolve_to_assets` found
+      `plugin/skills/orbit-task/SKILL.md` different from
+      `crates/orbit-core/assets/skills/orbit-task/SKILL.md`.
+    - The run metadata reported head
+      `49a2871a480b927bb31dc7a315f5ff5d130d15d0`, while the checkout log showed
+      `5cec12c53211fad3f4ca940a0565bef87787958d`. A valid investigation preserves
+      that discrepancy, clusters adjacent runs by the two root causes, and
+      tests whether either failure still exists at the relevant current head
+      before editing.
+  acceptance_criteria:
+  - Current-head failures across agent-main, main, and open pull requests were enumerated for every repository workflow, including informational jobs.
+  - Every investigated run records its reported SHA, actual checkout commit, current ref head, failed job/step, exact log evidence, and stale or superseding evidence where applicable.
+  - Repeated red runs are clustered by root cause, and every current repository-owned failure is reproduced and fixed without weakening or bypassing a check.
+  - Transient-only classifications cite infrastructure evidence and a successful same-SHA retry; a single non-reproduction is not treated as sufficient evidence.
+  - Each fixed cause passes the exact formerly failing validation and make ci-fast, and every affected required or informational GitHub Actions check executes successfully on the candidate commit.
+  - The persisted execution_summary maps each run/job URL and SHA to its root cause, disposition, change, validations, green rerun, and any matching PR-hook task.
+  - A no-current-failure or transient-only investigation is a successful no-diff outcome when its current-head queries and superseding or transient evidence are persisted.
+  task_type: bug
+  tags:
+  - ci-failure-remediation
+  - github-actions
+  - no-diff-expected
+  priority: high
+  crew: opus
+  status: backlog
+dedupe: skip_if_open
+created_by: codex
+created_at: 2026-07-27T00:00:00Z
+updated_by: codex
+updated_at: 2026-07-27T00:00:00Z

--- a/docs/design/auto-tasks/1_overview.md
+++ b/docs/design/auto-tasks/1_overview.md
@@ -1,7 +1,7 @@
 ---
 title: Auto-tasks — Overview
 owner: claude
-last_updated: 2026-07-26
+last_updated: 2026-07-27
 last_validated: 2026-07-27
 status: Accepted
 feature: auto-tasks
@@ -11,7 +11,7 @@ summary: Dynamically-defined recurring task templates minted by one generic sche
 tags: [auto-tasks]
 paths: ["crates/orbit-core/src/auto_tasks/**"]
 related_features: [auto-tasks]
-related_artifacts: [ORB-10149, ORB-10318, ORB-10348, ORB-10439, ORB-10446, ADR-0218, ADR-0217]
+related_artifacts: [ORB-10149, ORB-10318, ORB-10348, ORB-10439, ORB-10446, ORB-10514, ADR-0218, ADR-0217]
 ---
 
 # Auto-tasks — Overview
@@ -84,6 +84,10 @@ becomes just the first definition.
   friction records, re-verifies survivors against current behavior, resolves
   records that no longer reproduce, and files non-duplicate fix tasks for
   verified-real issues (ORB-10440).
+- `ci-failure-remediation` — disabled-by-default hourly investigation and
+  remediation of current-head GitHub Actions failures across integration,
+  release, and open-PR refs, with stale-run filtering, root-cause clustering,
+  PR-hook deduplication, and evidence-backed no-diff outcomes (ORB-10514).
 
 ## Task References
 
@@ -93,5 +97,6 @@ becomes just the first definition.
 - ORB-10348 — Generalized the definition into artifact-deprecation-review, adding the comment-reference sweep.
 - ORB-10439 — `orbit auto-task mint <name>`, the on-demand manual mint.
 - ORB-10440 — Daily friction-curation definition.
+- ORB-10514 — Disabled CI-failure remediation definition.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10514](https://orbit-cli.com/tasks/ORB-10514) — Add a disabled CI-failure remediation auto-task

### Description

## Problem

Orbit's GitHub Actions failures are handled inconsistently. The existing `.github/workflows/ci.yml` hook creates an Orbit task only when the main `ci` job fails on a pull request; it does not cover push failures, the informational coverage job, other workflows, stale/superseded runs, or actual remediation.

The motivating push run is [CI run 30232696219](https://github.com/danieljhkim/orbit/actions/runs/30232696219):

- `Check / Clippy / Test` failed in `Run CI guardrails` because Clippy reported a needless borrow at `crates/orbit-store/src/file/task_store/v2_bundle/bundle_io/mod.rs:172` (`sync_parent_dir(&staging_dir)`).
- `Coverage (informational)` failed because `command::skill::tests::plugin_skill_symlinks_resolve_to_assets` found that `plugin/skills/orbit-task/SKILL.md` differed from `crates/orbit-core/assets/skills/orbit-task/SKILL.md`.
- Several adjacent push and PR runs were red, so one underlying regression can create a noisy cluster of failures.
- The cited run's metadata names head `49a2871a480b927bb31dc7a315f5ff5d130d15d0`, while its checkout log shows `5cec12c53211fad3f4ca940a0565bef87787958d`; remediation must verify the commit actually tested and ignore stale runs after a branch advances.

## Objective

Add a checked-in, workspace-local auto-task definition named `ci-failure-remediation` under `.orbit/auto_tasks/`. Use the existing auto-task primitive and generic scheduler; do not add a bespoke routine, scheduler, activity, job, or new Orbit code.

The definition must:

- remain `enabled: false` in the committed result;
- use a reasonable recurring cadence and `dedupe: skip_if_open`;
- mint a high-priority backlog task assigned to a complex-work-capable crew;
- carry stable CI-remediation provenance tags and permit a legitimate no-op when no current failure remains;
- scope discovery to this repository's GitHub Actions workflows, covering current-head failures on `agent-main`, `main`, and open pull requests;
- treat the existing PR-only CI-task hook as an input/coverage signal, not a reason to create duplicate failure tasks.

The minted task instructions must require the executor to:

1. Query current GitHub Actions runs and open PR heads, then ignore a failed run when the branch/PR head has advanced and the failure no longer reproduces, or a newer successful run supersedes it.
2. Verify the run SHA, the commit actually checked out, the failing job/step, and the exact log error before diagnosing.
3. Cluster repeated failures by root cause so a burst of red runs is repaired once.
4. Reproduce each current, repo-owned failure locally; distinguish deterministic repository failures from transient GitHub/service/runner failures with evidence.
5. Fix repo-owned failures in the task worktree. Do not disable workflows, weaken assertions or lint levels, add broad allow/ignore rules, mark failing gates `continue-on-error`, or otherwise make CI green by hiding a failure.
6. Validate the exact failing commands plus the repository's pre-handoff gate, then confirm the candidate's GitHub Actions rerun is green for every affected required check. Informational checks must execute successfully even though they remain non-required.
7. Persist an execution summary mapping each investigated run/job URL and SHA to its root cause, change, and validation. A no-current-failure or transient-only pass is a successful no-diff outcome with evidence.

Keep the existing PR-only task-creation hook unless a narrowly justified reconciliation is necessary; this task is for a remediation auto-task, not a redesign of GitHub event handling.

## Documentation and safety

Update the auto-tasks overview to list this definition and reference this task. Do not enable or schedule the new definition on any host as part of implementation. Validate the YAML through Orbit's supported auto-task read/load surface without minting a durable task in the canonical workspace; use a disposable workspace if an end-to-end mint check is needed.

### Acceptance Criteria

- A checked-in `.orbit/auto_tasks/ci-failure-remediation.yaml` loads through Orbit's supported auto-task surface and has `enabled: false`, a valid recurring schedule, and `dedupe: skip_if_open`.
- The template mints a high-priority backlog task with stable CI-remediation provenance, a complex-work-capable crew, and a documented successful no-diff outcome when no current repo-owned failure remains.
- The template covers current-head GitHub Actions failures for `agent-main`, `main`, and open pull requests; it verifies the run SHA, actual checked-out commit, failed job/step, and log evidence, and ignores superseded or non-reproducing stale runs.
- The template clusters repeated runs by root cause, fixes deterministic repo-owned failures without weakening checks, and distinguishes transient infrastructure failures with evidence.
- The template requires reproduction of each current repo-owned failure, the exact formerly failing validation, the repository pre-handoff gate, and a green GitHub Actions rerun for all affected checks; informational coverage remains informational but executes successfully.
- The auto-tasks overview lists `ci-failure-remediation` and references this task, while the existing PR-only CI task hook is either retained or any reconciliation is narrowly justified and duplicate-safe.
- The motivating failures from run 30232696219 are represented as a validation fixture/example in the task instructions: the Clippy needless borrow and the `orbit-task` plugin/asset parity mismatch.
- No new scheduler, routine, activity, job, or Orbit code is introduced, no durable task is minted in the canonical workspace during validation, and the committed auto-task remains disabled.
- `make ci-fast` passes, and the final changed-file list is limited to the new auto-task definition plus directly necessary auto-task documentation or narrowly justified CI-hook reconciliation.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `.orbit/auto_tasks/ci-failure-remediation.yaml`, a checked-in hourly auto-task that remains disabled and uses `skip_if_open` to mint high-priority backlog work for the `opus` crew. Its instructions cover current-head GitHub Actions discovery on `agent-main`, `main`, and open PRs; SHA/checkout/log verification; stale-run filtering; root-cause clustering; deterministic versus transient classification; non-bypass remediation; exact, pre-handoff, and GitHub rerun validation; PR-hook deduplication; evidence-rich no-diff outcomes; and the two run 30232696219 calibration failures.
- Updated `docs/design/auto-tasks/1_overview.md` metadata, shipped-definition list, and task references for ORB-10514.
Assessment: The existing PR-only CI task hook was retained unchanged and is treated by the template as a duplicate-safe input signal. No scheduler, routine, activity, job, Orbit code, dependency, or canonical validation task was added or minted. Final changed-file scope is exactly the new definition and the auto-tasks overview.
Validation:
- `orbit auto-task show ci-failure-remediation --json` loaded the definition through the supported read surface; field assertions confirmed `enabled: false`, cron `15 * * * *`, `dedupe: skip_if_open`, high priority, backlog status, and `opus` crew.
- `orbit auto-task list --disabled --json` returned exactly one matching definition.
- `git diff --check` passed.
- `make ci-fast` passed on the final tree.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10514-6a66cd77`
- Behind base: 0
- Ahead of base: 1