### PR TITLE
Fix v0.10.1 release recovery blockers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
             "./target/${{ matrix.target }}/release/orbit" --version
           fi
           if [ "${{ matrix.companion }}" = "true" ]; then
-            cargo build -p orbit-search --bin orbit-search-companion --release --locked --target "${{ matrix.target }}"
+            cargo build -p orbit-search --features companion --bin orbit-search-companion --release --locked --target "${{ matrix.target }}"
             "./target/${{ matrix.target }}/release/orbit-search-companion" --version-info
           fi
 

--- a/crates/orbit-search/Cargo.toml
+++ b/crates/orbit-search/Cargo.toml
@@ -11,15 +11,19 @@ stability = "internal"
 [lints]
 workspace = true
 
+[features]
+companion = ["dep:clap", "dep:fastembed"]
+
 [[bin]]
 name = "orbit-search-companion"
 path = "src/bin/orbit-search-companion.rs"
+required-features = ["companion"]
 
 [dependencies]
 blake3.workspace = true
 chrono.workspace = true
-clap.workspace = true
-fastembed.workspace = true
+clap = { workspace = true, optional = true }
+fastembed = { workspace = true, optional = true }
 libc.workspace = true
 orbit-common = { path = "../orbit-common", features = ["sqlite"] }
 reqwest.workspace = true

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -4334,9 +4334,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/website/package.json
+++ b/website/package.json
@@ -27,6 +27,6 @@
   "overrides": {
     "yaml": "2.8.3",
     "esbuild": "0.28.1",
-    "js-yaml": "4.2.0"
+    "js-yaml": "4.3.0"
   }
 }


### PR DESCRIPTION
## Summary

- gate `clap` and `fastembed` behind an explicit `orbit-search` companion feature
- enable that feature only for release companion builds, keeping ONNX Runtime out of CLI-only builds
- update the website `js-yaml` override and lockfile from vulnerable 4.2.0 to patched 4.3.0

## Root cause

ORB-10357 folded the companion binary into `orbit-search` and made its heavyweight dependencies unconditional. As a result, the Intel macOS CLI release lane resolved `fastembed -> ort -> ort-sys`; `ort-sys` has no prebuilt x86_64 macOS binary and failed the v0.10.0 release workflow.

Dependabot alert #35 separately identified `js-yaml` 4.2.0 as vulnerable to quadratic CPU consumption through YAML merge-key chains.

## Impact

The v0.10.1 release can build the Intel macOS CLI without linking ONNX Runtime. Companion assets retain embedding support when built with `--features companion`. The website dependency graph resolves the patched `js-yaml` 4.3.0.

## Validation

- `cargo build -p orbit-cli --release --locked --target x86_64-apple-darwin`
- `cargo build -p orbit-search --features companion --bin orbit-search-companion --release --locked --target aarch64-apple-darwin`
- companion `--version-info`
- CLI/companion Cargo dependency-tree assertions
- `npm ls js-yaml --all`
- `npm audit --package-lock-only --audit-level=high` (0 vulnerabilities)
- `npm run check` (0 diagnostics)
- `make ci-fast`
- `git diff --check`

Tracks ORB-10526 and ORB-10527.
