### PR TITLE
chore(release): promote v0.10.1 to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
             "./target/${{ matrix.target }}/release/orbit" --version
           fi
           if [ "${{ matrix.companion }}" = "true" ]; then
-            cargo build -p orbit-search --bin orbit-search-companion --release --locked --target "${{ matrix.target }}"
+            cargo build -p orbit-search --features companion --bin orbit-search-companion --release --locked --target "${{ matrix.target }}"
             "./target/${{ matrix.target }}/release/orbit-search-companion" --version-info
           fi
 

--- a/crates/orbit-search/Cargo.toml
+++ b/crates/orbit-search/Cargo.toml
@@ -11,15 +11,19 @@ stability = "internal"
 [lints]
 workspace = true
 
+[features]
+companion = ["dep:clap", "dep:fastembed"]
+
 [[bin]]
 name = "orbit-search-companion"
 path = "src/bin/orbit-search-companion.rs"
+required-features = ["companion"]
 
 [dependencies]
 blake3.workspace = true
 chrono.workspace = true
-clap.workspace = true
-fastembed.workspace = true
+clap = { workspace = true, optional = true }
+fastembed = { workspace = true, optional = true }
 libc.workspace = true
 orbit-common = { path = "../orbit-common", features = ["sqlite"] }
 reqwest.workspace = true

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -4334,9 +4334,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/website/package.json
+++ b/website/package.json
@@ -27,6 +27,6 @@
   "overrides": {
     "yaml": "2.8.3",
     "esbuild": "0.28.1",
-    "js-yaml": "4.2.0"
+    "js-yaml": "4.3.0"
   }
 }


### PR DESCRIPTION
## Release

Promotes the tested `agent-main` state for [Orbit v0.10.1](https://github.com/danieljhkim/orbit/releases/tag/v0.10.1) to the production `main` branch.

## Release verification

- [v0.10.1 release workflow](https://github.com/danieljhkim/orbit/actions/runs/30240287667) passed
- all six CLI and companion build targets passed
- Intel macOS CLI build passed after removing companion-only ONNX Runtime dependencies from the CLI graph
- GitHub Release and signed checksums published
- Homebrew tap updated
- macOS arm64 and Ubuntu 24.04 installer smoke tests passed
- website dependency graph uses patched `js-yaml` 4.3.0

This PR should be merged with a merge commit to preserve the `agent-main → main` release-promotion boundary.
