### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/activity-job/specs/audit-envelope.md
+++ b/docs/design/activity-job/specs/audit-envelope.md
@@ -1,6 +1,13 @@
+---
+type: design
+summary: "Spec: V2 Audit Envelope"
+tags: ["activity-job"]
+last_validated: 2026-08-01
+---
+
 # Spec: V2 Audit Envelope
 
-Activity / Job runs emit a structured v2 audit tree that describes run, step, activity, and control-flow structure. This tree is append-only JSONL and coexists with the lower-level loop transcript/blob sink rather than replacing it.
+Activity / Job runs emit a structured v2 audit tree that describes run, step, activity, and control-flow structure. This tree is stored as append-only SQLite audit rows and coexists with the lower-level loop-event/blob sink rather than replacing it.
 
 ## Why This Exists
 
@@ -36,24 +43,19 @@ Common event families are:
 
 `cli.invocation.started` includes redacted argv, stdin blob ref, optional model, wall-clock timeout, and optional `cwd`. When present, `cwd` is the subprocess working directory selected by Activity/Job's workspace resolver.
 
-Loop-engine HTTP and tool-call events remain in the lower-level sink and are related to the envelope tree by parentage and shared run identity.
+Loop-engine HTTP and tool-call events remain in the lower-level sink and can be correlated with the envelope rows by shared run identity. They are not v2-envelope descendants: the SQLite loop-event rows do not carry an envelope `parent_event_id`.
 
 ## Persistence Layout
 
-Envelope events append to:
+In production, envelope events append to the SQLite `v2_audit_events` table with `source: v2_envelope`.
+
+Loop-engine events use the same table with `source: loop_event`. Content-addressed blobs remain under:
 
 ```text
-.orbit/state/audit/v2_loop/<run_id>.jsonl
-```
-
-Loop-engine events and blobs continue to use the sibling audit layout under:
-
-```text
-.orbit/state/audit/loop/<run_id>.jsonl      created on first loop event
 .orbit/state/audit/blobs/<hh>/<hash>
 ```
 
-The v2 writer may also keep an in-memory snapshot for smoke assertions and CLI summaries.
+The v2 writer also keeps an in-memory snapshot for smoke assertions and CLI summaries. Its legacy `envelope_log_path()` hook returns `None` for the SQLite-backed production writer.
 
 ## CLI Inspection
 
@@ -65,7 +67,7 @@ The v2 writer may also keep an in-memory snapshot for smoke assertions and CLI s
 
 ## Invariants
 
-- Envelope writes are append-only, one JSON object per line.
+- Envelope writes are append-only rows whose payload is one JSON object.
 - Disk persistence failure should not crash the run by itself; the in-memory event stream is still load-bearing.
 - `workspace_path` is attached when the caller has a meaningful repo identity.
 - CLI invocation start events include `cwd` when the runtime selected a subprocess working directory.
@@ -74,8 +76,8 @@ The v2 writer may also keep an in-memory snapshot for smoke assertions and CLI s
 ## Failure Modes
 
 - Audit writer mutex poisoning surfaces as a structured audit failure.
-- JSONL persistence can fail independently of in-memory event capture.
-- Reviewers may need both the envelope JSONL and the lower-level loop JSONL/blob store to reconstruct a full run.
+- SQLite persistence can fail independently of in-memory event capture.
+- Reviewers may need both the envelope and loop-event rows, plus the blob store, to reconstruct a full run.
 
 ## Migration Notes
 

--- a/docs/design/activity-job/specs/backend-resolution.md
+++ b/docs/design/activity-job/specs/backend-resolution.md
@@ -1,6 +1,13 @@
+---
+type: design
+summary: "Spec: Backend Resolution and Session Constraints"
+tags: ["activity-job"]
+last_validated: 2026-08-01
+---
+
 # Spec: Backend Resolution and Session Constraints
 
-> **v1 release scope.** v1 ships `backend: cli` as the only supported agent invocation path. The `backend: http` resolution rules below are still load-bearing in code (the resolver still runs, and HTTP-only constraints are still enforced for `loop`/`session:`), but `backend: http` is **not** part of the v1 release surface. Treat any HTTP-related rule below as preview-only until v2.
+> **Current release scope.** `backend: cli` remains the default and is available for the CLI-backed providers. `backend: http` is also a supported path for providers with a wired HTTP transport (currently Claude); the HTTP-only `loop`/`session:` constraint remains load-bearing.
 
 Activity / Job assets must never reach dispatch with unresolved backend intent. Orbit resolves `backend: auto` to a concrete backend once per run, then validates the concrete shape before execution begins. This keeps backend choice, provider wiring, and session semantics auditable instead of implicit.
 
@@ -21,7 +28,7 @@ Orbit resolves `backend: auto` using this precedence order:
 1. CLI flag override
 2. `ORBIT_BACKEND`
 3. config `[runtime] backend`
-4. hard-coded fallback `http`
+4. hard-coded fallback `cli`
 
 If any tier literally says `auto`, Orbit folds it to the hard-coded fallback. Downstream code must only observe `http` or `cli`.
 
@@ -30,15 +37,14 @@ If any tier literally says `auto`, Orbit folds it to the hard-coded fallback. Do
 - `Backend::Auto` does not survive past the orbit-core load path.
 - `target: activity:<name>` resolution happens before job execution begins.
 - A loop-body step with `session:` must resolve to `backend: http`.
-- `backend: http` against an unwired provider fails structurally; it does not silently fall back to CLI.
-- Concurrent shapes (`parallel`, `fan_out`) may not share one named `session:` binding.
+- `backend: http` against an unwired provider fails with structured input validation; it does not silently fall back to CLI.
 
 ## Failure Modes
 
 - Invalid backend flag or config values reject the run before dispatch.
 - Unresolved `TargetRef` reaching the executor is a caller bug and surfaces as `JobValidation`.
 - Loop/session/backend incompatibility rejects the job at load time when possible and again at runtime if a flat target shape still violates the rule.
-- `backend: http` plus unwired provider returns `UnwiredHttpTransport`.
+- `backend: http` plus an unwired provider returns a structured validation error naming the provider and missing HTTP transport.
 
 ## Migration Notes
 

--- a/docs/design/agent-families/references/glossary.md
+++ b/docs/design/agent-families/references/glossary.md
@@ -1,8 +1,15 @@
+---
+type: design
+summary: "Agent Families — Glossary"
+tags: ["agent-families"]
+last_validated: 2026-08-01
+---
+
 # Agent Families — Glossary
 
 **agent family** — A stable identifier (`claude`, `codex`, `gemini`, `grok`) representing a coherent set of models, CLIs, and integration requirements that Orbit treats uniformly for attribution, execution, and analytics.
 
-**model pair** — The `(orchestrator, helper)` model duo resolved for a family via `resolve_agent_model_pair()`. Used by activity jobs and planning duels.
+**model pair** — The `(orchestrator, helper)` model duo represented by `AgentModelPair`, loaded from an executor's `model_pair_override` via `configured_agent_model_pair()` and exposed to planning duels through `resolved_agent_model_pair()`.
 
 **duel candidate** — A family in the active `[duel].candidates` allowlist. Defaults to `all_agent_families()` and must keep at least three distinct families so role permutations remain valid.
 

--- a/docs/design/auditability/references/glossary.md
+++ b/docs/design/auditability/references/glossary.md
@@ -1,17 +1,24 @@
+---
+type: design
+summary: "Glossary: Auditability"
+tags: ["auditability"]
+last_validated: 2026-08-01
+---
+
 # Glossary: Auditability
 
 This glossary covers Orbit-specific auditability terms only. Generic observability, database, and security terms are excluded unless Orbit assigns them a specific meaning.
 
 | Term | Meaning |
 |------|---------|
-| **Audit channel** | One of Orbit's distinct audit storage paths: command audit rows, v2 envelope JSONL, loop audit JSONL, blobs, or invocation metrics. See [../2_design.md §1](../2_design.md#1-storage-roots-and-audit-channels). |
+| **Audit channel** | One of Orbit's distinct audit storage paths: command audit rows, v2 envelope rows, loop-event rows, blobs, or invocation metrics. See [../2_design.md §1](../2_design.md#1-storage-roots-and-audit-channels). |
 | **Blob reference** | A sha256 string stored in an audit event that points to redacted content-addressed payload bytes. See [../2_design.md §5](../2_design.md#5-loop-level-provider-and-tool-events). |
 | **Command audit row** | A compact SQLite `AuditEvent` record for a CLI or targeted runtime operation. See [../2_design.md §2](../2_design.md#2-command-audit-rows). |
 | **Coverage matrix** | The prescriptive map from operation class to required audit channel. See [../2_design.md §3](../2_design.md#3-tool-driven-and-runtime-audit-records) and [../specs/coverage-matrix.md](../specs/coverage-matrix.md). |
 | **Invocation trace** | A metrics-oriented usage record keyed by job run, activity, task ids, agent, model, tokens, and tool-call summaries. See [../2_design.md §8](../2_design.md#8-query-export-and-metrics-surfaces). |
 | **Loop audit event** | A provider/tool-level event emitted by the HTTP loop engine for sessions, HTTP turns, tool calls, iteration boundaries, or policy denials. See [../2_design.md §5](../2_design.md#5-loop-level-provider-and-tool-events). |
 | **Redaction boundary** | The point before durable write where Orbit removes known secret shapes from audit payloads or error strings. See [../2_design.md §6](../2_design.md#6-blob-storage-and-redaction). |
-| **Run trace** | The workspace-local file-backed reconstruction material for one activity/job run: v2 envelope JSONL, loop JSONL, and blobs. See [../2_design.md §4](../2_design.md#4-activityjob-envelope-events). |
+| **Run trace** | The workspace-local reconstruction material for one activity/job run: v2 envelope rows, loop-event rows, and content-addressed blobs. See [../2_design.md §4](../2_design.md#4-activityjob-envelope-events). |
 | **Task history** | The persisted lifecycle and comment trail attached to a task, used beside command/tool audit rows to show task-state changes over time. See [../2_design.md §7](../2_design.md#7-identity-and-attribution) and [../specs/coverage-matrix.md](../specs/coverage-matrix.md). |
 | **V2 audit envelope** | The activity/job wrapper event containing schema version, event id, run id, agent identity, optional parent id, optional workspace path, and a typed body. See [../2_design.md §4](../2_design.md#4-activityjob-envelope-events). |
-| **Workspace provenance** | The `workspace_path` attached to file-backed v2 audit envelope events so traces can be filtered back to the repository that produced them. See [../2_design.md §4](../2_design.md#4-activityjob-envelope-events). |
+| **Workspace provenance** | The `workspace_path` attached to v2 audit envelope events so traces can be filtered back to the repository that produced them. See [../2_design.md §4](../2_design.md#4-activityjob-envelope-events). |

--- a/docs/design/auditability/specs/artifact-redaction.md
+++ b/docs/design/auditability/specs/artifact-redaction.md
@@ -1,3 +1,10 @@
+---
+type: design
+summary: "Spec: Artifact Write Redaction"
+tags: ["auditability"]
+last_validated: 2026-08-01
+---
+
 # Spec: Artifact Write Redaction
 
 Orbit artifact tools persist repo-backed YAML, markdown, and JSON. Their write boundary sanitizes selected input fields after `OrbitBuiltinAction` is known and before typed params are built. The sanitizer is action-keyed rather than field-blind, so structural IDs, statuses, tags, and artifact blobs keep their native validation rules.


### PR DESCRIPTION
## Task

[ORB-10528](https://orbit-cli.com/tasks/ORB-10528) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Batch selected exactly six docs by the required missing-then-oldest `last_validated` ordering: docs/POSITIONING.md, docs/design/activity-job/specs/audit-envelope.md, docs/design/activity-job/specs/backend-resolution.md, docs/design/agent-families/references/glossary.md, docs/design/auditability/references/glossary.md, and docs/design/auditability/specs/artifact-redaction.md. All six were frontmatter-less and therefore sorted before dated docs; ties were resolved by path.
- docs/design/activity-job/specs/audit-envelope.md: verified `V2AuditEnvelope`, `V2AuditWriter`, `V2SqliteSink`, `collect_run_audit_events`, `run events`, `run trace`, and `run logs` with `rg`/source reads. Corrected the stale JSONL/parentage persistence description to the current SQLite envelope/loop-event rows and blob layout, then migrated inferred frontmatter as type `design`, summary `Spec: V2 Audit Envelope`, tag `activity-job`, and stamped `last_validated: 2026-08-01`.
- docs/design/activity-job/specs/backend-resolution.md: verified `resolve_backend_precedence`, `Backend::Auto`, `Provider::has_http_transport`, loop/session validation, schemaVersion-2 loading, and CLI help with `rg`/source reads. Corrected the fallback from `http` to `cli`, updated current HTTP support/error behavior, removed an unsupported concurrent-session claim, then migrated inferred frontmatter as type `design`, summary `Spec: Backend Resolution and Session Constraints`, tag `activity-job`, and stamped it.
- docs/design/agent-families/references/glossary.md: verified `all_agent_families`, executor model-pair overrides, `configured_agent_model_pair`, and `resolved_agent_model_pair` with `rg`/source reads. Corrected the retired function name and migrated inferred frontmatter as type `design`, summary `Agent Families — Glossary`, tag `agent-families`, and stamped it.
- docs/design/auditability/references/glossary.md: verified audit storage, envelope/loop event sources, blob storage, invocation records, and linked paths with `rg`/source reads. Corrected stale JSONL/file-backed terminology, migrated inferred frontmatter as type `design`, summary `Glossary: Auditability`, tag `auditability`, and stamped it.
- docs/design/auditability/specs/artifact-redaction.md: verified `sanitize_tool_input`, action policies, credential handling, `redactions_applied`, audit payloads, and idempotence against `crates/orbit-core/src/runtime/orbit_tool_host/artifact_redaction.rs` with `rg`/source reads and existing tests. No prose correction was needed; migrated inferred frontmatter as type `design`, summary `Spec: Artifact Write Redaction`, tag `auditability`, and stamped it.
- docs/POSITIONING.md was left completely unchanged and unstamped because its product positioning, audience, roadmap, and non-negotiable claims are not fully verifiable from repository code.
- No new document, section, metadata field, sidecar, generated state, forbidden historical file, or asset identifier was added.

Assessment: Five code-anchored docs were verified and refreshed with schema-compatible inferred frontmatter plus earned validation dates. The one non-code-observable positioning doc was correctly reported without a stamp.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10528-6a6e29b8`
- Behind base: 0
- Ahead of base: 1