### PR TITLE
Expose a guarded ADR restore path for an existing unreadable allocation

### DIFF
--- a/crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs
@@ -24,30 +24,44 @@ pub(super) fn add(
     agent: Option<String>,
     model: Option<String>,
 ) -> Result<Value, OrbitError> {
-    let title = required_string(&input, &["title"], "title")?;
-    let owner = match optional_string(&input, "owner")? {
-        Some(value) => value,
-        None => actor_label(runtime, agent.as_deref(), model.as_deref()),
-    };
-    let body = required_string(&input, &["body"], "body")?;
-    let related_features =
-        optional_string_list_alias(&input, &["related_features", "features"])?.unwrap_or_default();
-    let related_tasks =
-        optional_string_list_alias(&input, &["related_tasks", "tasks"])?.unwrap_or_default();
-    let tags = optional_string_list_alias(&input, &["tags"])?.unwrap_or_default();
-    let paths = optional_string_list_alias(&input, &["paths"])?.unwrap_or_default();
-
-    let adr = runtime.stores().adrs().add_adr(AdrCreateParams {
-        title,
-        owner,
-        related_features,
-        related_tasks,
-        tags,
-        paths,
-        body,
-    })?;
+    let params = create_params(runtime, &input, agent.as_deref(), model.as_deref())?;
+    let adr = runtime.stores().adrs().add_adr(params)?;
     runtime.record_id_allocation_audit("adr", &adr.id)?;
     Ok(adr_to_json(&adr))
+}
+
+pub(super) fn restore(
+    runtime: &OrbitRuntime,
+    input: Value,
+    agent: Option<String>,
+    model: Option<String>,
+) -> Result<Value, OrbitError> {
+    let id = required_string(&input, &["id"], "id")?;
+    let params = create_params(runtime, &input, agent.as_deref(), model.as_deref())?;
+    let adr = runtime.stores().adrs().restore_allocated_adr(&id, params)?;
+    Ok(adr_to_json(&adr))
+}
+
+fn create_params(
+    runtime: &OrbitRuntime,
+    input: &Value,
+    agent: Option<&str>,
+    model: Option<&str>,
+) -> Result<AdrCreateParams, OrbitError> {
+    Ok(AdrCreateParams {
+        title: required_string(input, &["title"], "title")?,
+        owner: match optional_string(input, "owner")? {
+            Some(value) => value,
+            None => actor_label(runtime, agent, model),
+        },
+        related_features: optional_string_list_alias(input, &["related_features", "features"])?
+            .unwrap_or_default(),
+        related_tasks: optional_string_list_alias(input, &["related_tasks", "tasks"])?
+            .unwrap_or_default(),
+        tags: optional_string_list_alias(input, &["tags"])?.unwrap_or_default(),
+        paths: optional_string_list_alias(input, &["paths"])?.unwrap_or_default(),
+        body: required_string(input, &["body"], "body")?,
+    })
 }
 
 pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {

--- a/crates/orbit-core/src/runtime/orbit_tool_host/artifact_redaction.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/artifact_redaction.rs
@@ -173,7 +173,9 @@ const TASK_ADD_NESTED: &[NestedArrayPolicy] = &[
 
 fn policy_for_action(action: OrbitBuiltinAction) -> Option<ActionPolicy> {
     match action {
-        OrbitBuiltinAction::AdrAdd | OrbitBuiltinAction::AdrUpdate => Some(ActionPolicy {
+        OrbitBuiltinAction::AdrAdd
+        | OrbitBuiltinAction::AdrRestore
+        | OrbitBuiltinAction::AdrUpdate => Some(ActionPolicy {
             free_text_fields: &["title", "body"],
             free_text_arrays: &[],
             path_fields: &[],
@@ -247,6 +249,7 @@ fn is_covered_mutating_action(action: OrbitBuiltinAction) -> bool {
     matches!(
         action,
         OrbitBuiltinAction::AdrAdd
+            | OrbitBuiltinAction::AdrRestore
             | OrbitBuiltinAction::AdrUpdate
             | OrbitBuiltinAction::AdrSupersede
             | OrbitBuiltinAction::LearningAdd
@@ -481,6 +484,7 @@ fn artifact_target(
 ) -> Result<ArtifactTarget<'_>, OrbitError> {
     match action {
         OrbitBuiltinAction::AdrAdd
+        | OrbitBuiltinAction::AdrRestore
         | OrbitBuiltinAction::AdrUpdate
         | OrbitBuiltinAction::AdrSupersede => Ok(ArtifactTarget {
             artifact_type: "adr",
@@ -540,6 +544,7 @@ fn response_string<'a>(response: &'a Value, field: &str) -> Result<&'a str, Orbi
 fn tool_name(action: OrbitBuiltinAction) -> &'static str {
     match action {
         OrbitBuiltinAction::AdrAdd => "orbit.adr.add",
+        OrbitBuiltinAction::AdrRestore => "orbit.adr.restore",
         OrbitBuiltinAction::AdrUpdate => "orbit.adr.update",
         OrbitBuiltinAction::AdrSupersede => "orbit.adr.supersede",
         OrbitBuiltinAction::LearningAdd => "orbit.learning.add",

--- a/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
@@ -20,6 +20,7 @@ pub(super) fn execute(
         OrbitBuiltinAction::AdrAdd => super::adr_tools::add(runtime, input, agent, model),
         OrbitBuiltinAction::AdrShow => super::adr_tools::show(runtime, input),
         OrbitBuiltinAction::AdrList => super::adr_tools::list(runtime, input),
+        OrbitBuiltinAction::AdrRestore => super::adr_tools::restore(runtime, input, agent, model),
         OrbitBuiltinAction::AdrUpdate => super::adr_tools::update(runtime, input, agent, model),
         OrbitBuiltinAction::AdrSupersede => {
             super::adr_tools::supersede(runtime, input, agent, model)

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/learning_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/learning_tools.rs
@@ -620,6 +620,104 @@ fn finalize_preallocated_adr_lands_supplied_id() {
     assert_eq!(adr.status, orbit_common::types::AdrStatus::Proposed);
 }
 
+#[test]
+fn adr_restore_tool_restores_exact_id_and_show_reads_body_immediately() {
+    let (_guard, runtime, repo) = test_runtime();
+    runtime
+        .finalize_preallocated_adr(
+            "ADR-0055",
+            orbit_store::AdrCreateParams {
+                title: "Lost ADR".to_string(),
+                owner: "test".to_string(),
+                related_features: Vec::new(),
+                related_tasks: vec!["ORB-10538".to_string()],
+                tags: vec!["repair".to_string()],
+                paths: vec!["crates/**".to_string()],
+                body: "lost body".to_string(),
+            },
+        )
+        .expect("seed allocated ADR");
+    std::fs::remove_dir_all(repo.join(".orbit/adrs/proposed/ADR-0055"))
+        .expect("remove seeded bundle");
+
+    let restored = runtime
+        .run_tool(
+            "orbit.adr.restore",
+            json!({
+                "id": "ADR-0055",
+                "title": "Restored ADR",
+                "owner": "codex",
+                "related_tasks": ["ORB-10538"],
+                "tags": ["repair"],
+                "paths": ["crates/**"],
+                "body": "restored exact body",
+            }),
+        )
+        .expect("restore tool succeeds");
+    assert_eq!(restored["id"], "ADR-0055");
+
+    let shown = runtime
+        .run_tool("orbit.adr.show", json!({ "id": "ADR-0055" }))
+        .expect("show restored ADR");
+    assert_eq!(shown["id"], "ADR-0055");
+    assert_eq!(shown["body"], "restored exact body");
+    assert_eq!(shown["artifact_origin"]["mode"], "local");
+
+    let retry = runtime
+        .run_tool(
+            "orbit.adr.restore",
+            json!({
+                "id": "ADR-0055",
+                "title": "Overwrite attempt",
+                "owner": "codex",
+                "body": "must not replace",
+            }),
+        )
+        .expect_err("retry must refuse readable lifecycle collision");
+    assert!(
+        matches!(retry, OrbitError::InvalidInput(_)),
+        "got {retry:?}"
+    );
+    let shown_after_retry = runtime
+        .run_tool("orbit.adr.show", json!({ "id": "ADR-0055" }))
+        .expect("show after retry");
+    assert_eq!(shown_after_retry["body"], "restored exact body");
+}
+
+#[test]
+fn adr_restore_tool_is_registered_and_refuses_unallocated_id() {
+    let registry = registry_with_builtins();
+    let schema = registry
+        .get_schema("orbit.adr.restore")
+        .expect("restore schema registered");
+    let required: Vec<&str> = schema
+        .parameters
+        .iter()
+        .filter(|param| param.required)
+        .map(|param| param.name.as_str())
+        .collect();
+    for field in ["id", "title", "body"] {
+        assert!(required.contains(&field), "missing required field {field}");
+    }
+
+    let (_guard, runtime, _repo) = test_runtime();
+    let error = runtime
+        .run_tool(
+            "orbit.adr.restore",
+            json!({
+                "id": "ADR-0099",
+                "title": "No allocation",
+                "owner": "codex",
+                "body": "body",
+            }),
+        )
+        .expect_err("unallocated id must fail");
+    assert!(
+        matches!(error, OrbitError::InvalidInput(_)),
+        "got {error:?}"
+    );
+}
+
 // --- ORB-10364: caller-role gate on the tool write surfaces ---------------
 
 /// Clear the identity pair and the authoring opt-in, then declare an executor

--- a/crates/orbit-store/src/backend/contracts/traits.rs
+++ b/crates/orbit-store/src/backend/contracts/traits.rs
@@ -70,6 +70,10 @@ pub trait AdrStoreBackend: Send + Sync {
         id: &str,
         params: AdrCreateParams,
     ) -> Result<Adr, OrbitError>;
+
+    /// [ORB-10538] Restore an ADR at an existing allocation whose local and
+    /// canonical artifacts are unreadable. Never allocates or overwrites.
+    fn restore_allocated_adr(&self, id: &str, params: AdrCreateParams) -> Result<Adr, OrbitError>;
     fn get_adr(&self, id: &str) -> Result<Option<Adr>, OrbitError>;
     fn resolve_adr_artifact(&self, id: &str) -> Result<AdrArtifactResolution, OrbitError>;
     fn list_adrs(&self) -> Result<Vec<Adr>, OrbitError>;

--- a/crates/orbit-store/src/backend/file_backends/mod.rs
+++ b/crates/orbit-store/src/backend/file_backends/mod.rs
@@ -185,6 +185,10 @@ impl AdrStoreBackend for AdrFileStore {
         self.finalize_preallocated_adr(id, params)
     }
 
+    fn restore_allocated_adr(&self, id: &str, params: AdrCreateParams) -> Result<Adr, OrbitError> {
+        self.restore_allocated_adr(id, params)
+    }
+
     fn get_adr(&self, id: &str) -> Result<Option<Adr>, OrbitError> {
         // ADRs use the WorkspaceOnly strategy per `CLAUDE.md`.
         resolve::<Adr, _>(self, id)

--- a/crates/orbit-store/src/file/adr_store/api/mod.rs
+++ b/crates/orbit-store/src/file/adr_store/api/mod.rs
@@ -232,6 +232,128 @@ impl AdrFileStore {
         Ok(adr)
     }
 
+    /// [ORB-10538] Materialize an ADR at an exact existing allocation whose
+    /// artifact is no longer readable, without allocating or overwriting.
+    ///
+    /// The allocation snapshot is compared-and-set after the exclusive local
+    /// bundle write. If another process changes that row in the meantime, the
+    /// partial local bundle is removed and the caller gets an actionable
+    /// retry/concurrency error.
+    pub(crate) fn restore_allocated_adr(
+        &self,
+        id: &str,
+        params: AdrCreateParams,
+    ) -> Result<Adr, OrbitError> {
+        validate_adr_id(id)?;
+        if params.title.trim().is_empty() {
+            return Err(OrbitError::InvalidInput(
+                "ADR title must not be empty".to_string(),
+            ));
+        }
+        if params.owner.trim().is_empty() {
+            return Err(OrbitError::InvalidInput(
+                "ADR owner must not be empty".to_string(),
+            ));
+        }
+
+        let _lock = acquire_adr_lock(&self.root, id)?;
+        let allocation = self.id_allocator.adr_allocation(id)?.ok_or_else(|| {
+            OrbitError::InvalidInput(format!(
+                "cannot restore ADR {id}: no live ADR allocation exists"
+            ))
+        })?;
+        self.restore_allocated_adr_from_snapshot(id, params, allocation)
+    }
+
+    fn restore_allocated_adr_from_snapshot(
+        &self,
+        id: &str,
+        params: AdrCreateParams,
+        allocation: IdAllocationRecord,
+    ) -> Result<Adr, OrbitError> {
+        if let Some((state, _)) = self.locate_adr(id)? {
+            return Err(OrbitError::InvalidInput(format!(
+                "cannot restore ADR {id}: a local {} lifecycle artifact already exists",
+                state.dir_name(),
+            )));
+        }
+        if self.read_complete_adr_allocation(&allocation).is_some() {
+            return Err(OrbitError::InvalidInput(format!(
+                "cannot restore ADR {id}: the allocated artifact is still readable at '{}'",
+                allocation.worktree_root.display(),
+            )));
+        }
+
+        let now = Utc::now();
+        let adr = Adr {
+            id: id.to_string(),
+            title: params.title,
+            status: AdrStatus::Proposed,
+            owner: params.owner,
+            created_at: now,
+            accepted_at: None,
+            last_updated: now,
+            related_features: params.related_features,
+            related_tasks: params.related_tasks,
+            tags: normalize_adr_tags(params.tags),
+            paths: normalize_adr_paths(params.paths),
+            supersedes: Vec::new(),
+            superseded_by: None,
+            legacy_ids: Vec::new(),
+            validation_warnings: Vec::new(),
+            legacy_validation: LegacyValidation::None,
+        };
+        let bundle = AdrBundle {
+            doc: AdrFileDocument {
+                schema_version: ADR_SCHEMA_VERSION,
+                adr,
+            },
+            body: params.body,
+        };
+        validate_bundle(&bundle)?;
+
+        let target_dir = adr_dir(&self.root, AdrStateDir::Proposed, id);
+        let Some(parent) = target_dir.parent() else {
+            return Err(OrbitError::Store(format!(
+                "cannot resolve restore parent for ADR {id}"
+            )));
+        };
+        fs::create_dir_all(parent).map_err(|error| OrbitError::Io(error.to_string()))?;
+        match fs::create_dir(&target_dir) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                return Err(OrbitError::InvalidInput(format!(
+                    "cannot restore ADR {id}: a concurrent local lifecycle artifact appeared"
+                )));
+            }
+            Err(error) => return Err(OrbitError::Io(error.to_string())),
+        }
+        if let Err(error) = write_bundle_at(&target_dir, &bundle) {
+            let _ = fs::remove_dir_all(&target_dir);
+            return Err(error);
+        }
+        let restored = match self
+            .id_allocator
+            .restore_adr_body_path_if_unchanged(&allocation, &super::layout::body_path(&target_dir))
+        {
+            Ok(restored) => restored,
+            Err(error) => {
+                let _ = fs::remove_dir_all(&target_dir);
+                return Err(error);
+            }
+        };
+        if !restored {
+            let _ = fs::remove_dir_all(&target_dir);
+            return Err(OrbitError::InvalidInput(format!(
+                "cannot restore ADR {id}: its allocation changed concurrently; inspect orbit.adr.show before retrying"
+            )));
+        }
+
+        let adr = bundle_to_adr(bundle);
+        self.upsert_index_row(&adr);
+        Ok(adr)
+    }
+
     pub(crate) fn get_adr(&self, id: &str) -> Result<Option<Adr>, OrbitError> {
         validate_adr_id(id)?;
         let Some((_, dir)) = self.locate_adr(id)? else {

--- a/crates/orbit-store/src/file/adr_store/api/tests/api.rs
+++ b/crates/orbit-store/src/file/adr_store/api/tests/api.rs
@@ -868,3 +868,124 @@ fn finalize_preallocated_adr_targets_only_the_selected_worktree() {
     assert!(!TwoWorktreeFixture::bundle_dir(&fixture.sibling_root, &adr).exists());
     assert!(fixture.semantic_db.is_file());
 }
+
+// [ORB-10538] Exact-id repair tests. Unlike hub preallocation finalization,
+// restore requires a live allocation and may only replace an unreadable body.
+
+#[test]
+fn restore_allocated_adr_preserves_id_and_reindexes() {
+    let (_dir, store) = store_with_index();
+    let allocation = store.id_allocator.allocate_adr().expect("allocate ADR");
+
+    let restored = store
+        .restore_allocated_adr(&allocation.id, create_params("Restored", "restored body"))
+        .expect("restore allocated ADR");
+
+    assert_eq!(restored.id, allocation.id);
+    assert_eq!(count_index_rows(&store), 1);
+    let allocations = store.id_allocator.adr_allocations().expect("allocations");
+    assert_eq!(allocations.len(), 1, "restore must not allocate another id");
+    assert_eq!(allocations[0].id, restored.id);
+    assert_eq!(
+        allocations[0].body_path.as_deref(),
+        Some(Path::new("proposed/ADR-0001/body.md"))
+    );
+    let AdrArtifactResolution::Local(artifact) = store
+        .resolve_adr_artifact(&restored.id)
+        .expect("resolve restored ADR")
+    else {
+        panic!("restored ADR must resolve locally")
+    };
+    assert_eq!(artifact.body, "restored body");
+}
+
+#[test]
+fn restore_allocated_adr_refuses_missing_allocation_and_lifecycle_collision() {
+    let (_dir, store) = store_with_index();
+    let missing = store
+        .restore_allocated_adr("ADR-0042", create_params("Missing", "body"))
+        .expect_err("missing allocation must fail");
+    assert!(
+        matches!(missing, OrbitError::InvalidInput(_)),
+        "got {missing:?}"
+    );
+    assert!(!store.root.join("proposed/ADR-0042").exists());
+
+    let allocation = store.id_allocator.allocate_adr().expect("allocate ADR");
+    fs::create_dir_all(store.root.join("accepted").join(&allocation.id))
+        .expect("seed unreadable lifecycle collision");
+    let collision = store
+        .restore_allocated_adr(&allocation.id, create_params("Collision", "body"))
+        .expect_err("lifecycle collision must fail");
+    assert!(
+        matches!(collision, OrbitError::InvalidInput(_)),
+        "got {collision:?}"
+    );
+    assert!(!store.root.join("proposed").join(&allocation.id).exists());
+}
+
+#[test]
+fn restore_allocated_adr_refuses_readable_artifact_and_retry_without_overwrite() {
+    let (_dir, store) = store_with_index();
+    let original = store
+        .add_adr(create_params("Original", "keep me"))
+        .expect("seed readable ADR");
+    let original_body = fs::read(
+        store
+            .root
+            .join("proposed")
+            .join(&original.id)
+            .join("body.md"),
+    )
+    .expect("read original body");
+
+    for attempt in ["first", "retry"] {
+        let error = store
+            .restore_allocated_adr(&original.id, create_params(attempt, "overwrite"))
+            .expect_err("readable artifact must never be restored over");
+        assert!(
+            matches!(error, OrbitError::InvalidInput(_)),
+            "got {error:?}"
+        );
+    }
+    assert_eq!(
+        fs::read(
+            store
+                .root
+                .join("proposed")
+                .join(&original.id)
+                .join("body.md")
+        )
+        .expect("reread original body"),
+        original_body
+    );
+}
+
+#[test]
+fn restore_allocated_adr_cleans_up_when_allocation_snapshot_changes() {
+    let (_dir, store) = store_with_index();
+    let allocation = store.id_allocator.allocate_adr().expect("allocate ADR");
+    let snapshot = store
+        .id_allocator
+        .adr_allocation(&allocation.id)
+        .expect("read allocation")
+        .expect("allocation exists");
+    store
+        .id_allocator
+        .record_adr_body_path(&allocation.id, Path::new("moved/ADR-0001/body.md"))
+        .expect("simulate concurrent allocation change");
+
+    let error = store
+        .restore_allocated_adr_from_snapshot(
+            &allocation.id,
+            create_params("Stale snapshot", "body"),
+            snapshot,
+        )
+        .expect_err("stale allocation snapshot must fail");
+    assert!(
+        matches!(error, OrbitError::InvalidInput(_)),
+        "got {error:?}"
+    );
+    assert!(!store.root.join("proposed").join(&allocation.id).exists());
+    assert_eq!(count_index_rows(&store), 0);
+}

--- a/crates/orbit-store/src/sqlite/id_allocator/mod.rs
+++ b/crates/orbit-store/src/sqlite/id_allocator/mod.rs
@@ -225,6 +225,28 @@ impl IdAllocator {
         self.project_preallocated(IdAllocationKind::Adr, id, body_path)
     }
 
+    /// [ORB-10538] Repoint an existing ADR allocation to a restored body, but
+    /// only if every allocation field still matches the caller's snapshot.
+    ///
+    /// The compare-and-set makes an exact-id restore fail closed when another
+    /// process finalizes, abandons, or otherwise changes the allocation after
+    /// the store proved its recorded artifact unreadable. It never inserts an
+    /// allocation and therefore cannot adopt an unallocated id.
+    pub fn restore_adr_body_path_if_unchanged(
+        &self,
+        expected: &IdAllocationRecord,
+        body_path: &Path,
+    ) -> Result<bool, OrbitError> {
+        if expected.kind != IdAllocationKind::Adr {
+            return Err(OrbitError::InvalidInput(format!(
+                "cannot restore ADR allocation {} from a {} snapshot",
+                expected.id,
+                expected.kind.as_str(),
+            )));
+        }
+        self.restore_body_path_if_unchanged(expected, body_path)
+    }
+
     /// [ORB-10330] Install a non-authoritative owner-local projection for a
     /// hub-preallocated learning id and its body path. See
     /// [`Self::project_preallocated_adr`] for the invariants.
@@ -565,6 +587,54 @@ impl IdAllocator {
         tx.commit()
             .map_err(|error| OrbitError::Store(error.to_string()))?;
         Ok(())
+    }
+
+    fn restore_body_path_if_unchanged(
+        &self,
+        expected: &IdAllocationRecord,
+        body_path: &Path,
+    ) -> Result<bool, OrbitError> {
+        let relative_body_path = relative_to(body_path, &self.inner.worktree_root);
+        let branch = best_effort_branch(&self.inner.worktree_root);
+        let _lock = self.acquire_lock()?;
+        let mut conn = self.lock_conn()?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let updated = tx
+            .execute(
+                "UPDATE id_allocations
+                 SET worktree_root = ?8, branch = ?9, body_path = ?10
+                 WHERE kind = ?1
+                   AND id = ?2
+                   AND allocated_at = ?3
+                   AND worktree_root = ?4
+                   AND branch IS ?5
+                   AND status = ?6
+                   AND body_path IS ?7",
+                params![
+                    expected.kind.as_str(),
+                    expected.id,
+                    expected.allocated_at,
+                    expected.worktree_root.to_string_lossy(),
+                    expected.branch,
+                    expected.status,
+                    expected
+                        .body_path
+                        .as_ref()
+                        .map(|path| path.to_string_lossy()),
+                    self.inner.worktree_root.to_string_lossy(),
+                    branch,
+                    relative_body_path.to_string_lossy(),
+                ],
+            )
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        if updated == 0 {
+            return Ok(false);
+        }
+        tx.commit()
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        Ok(true)
     }
 
     fn abandon(&self, kind: IdAllocationKind, id: &str) -> Result<(), OrbitError> {

--- a/crates/orbit-tools/src/builtin/orbit/adr/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/adr/add.rs
@@ -1,4 +1,4 @@
-use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
+use orbit_common::types::{OrbitError, ToolSchema};
 use serde_json::Value;
 
 use crate::{OrbitBuiltinAction, Tool, ToolContext};
@@ -7,62 +7,7 @@ pub struct OrbitAdrAddTool;
 
 impl Tool for OrbitAdrAddTool {
     fn schema(&self) -> ToolSchema {
-        let mut parameters = vec![
-            ToolParam {
-                name: "title".to_string(),
-                description: "ADR title (short noun phrase).".to_string(),
-                param_type: "string".to_string(),
-                required: true,
-            },
-            ToolParam {
-                name: "body".to_string(),
-                description:
-                    "ADR body as markdown. Must include Context / Decision / Consequences sections per the ADR template; at least one consequences bullet must be a labeled `Cost:` line."
-                        .to_string(),
-                param_type: "string".to_string(),
-                required: true,
-            },
-            ToolParam {
-                name: "owner".to_string(),
-                description:
-                    "Agent identity that owns the ADR (e.g. `claude`, `codex`). Defaults to the calling actor."
-                        .to_string(),
-                param_type: "string".to_string(),
-                required: false,
-            },
-            ToolParam {
-                name: "related_features".to_string(),
-                description:
-                    "Feature folder names this decision touches. Accepts a string or array of strings."
-                        .to_string(),
-                param_type: "string_list".to_string(),
-                required: false,
-            },
-            ToolParam {
-                name: "related_tasks".to_string(),
-                description:
-                    "Orbit task IDs that proposed or shipped the decision. May be empty at creation per ADR-008. Accepts a string or array of strings."
-                        .to_string(),
-                param_type: "string_list".to_string(),
-                required: false,
-            },
-            ToolParam {
-                name: "tags".to_string(),
-                description:
-                    "Free-form ADR labels. Defaults to an empty list when omitted."
-                        .to_string(),
-                param_type: "string_list".to_string(),
-                required: false,
-            },
-            ToolParam {
-                name: "paths".to_string(),
-                description:
-                    "Repo-relative glob patterns for code or docs areas constrained by this ADR. Defaults to an empty list when omitted."
-                        .to_string(),
-                param_type: "string_list".to_string(),
-                required: false,
-            },
-        ];
+        let mut parameters = super::create_params();
         parameters.extend(super::super::model_identity_params());
         ToolSchema {
             name: "orbit.adr.add".to_string(),

--- a/crates/orbit-tools/src/builtin/orbit/adr/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/adr/mod.rs
@@ -1,5 +1,66 @@
 pub mod add;
 pub mod list;
+pub mod restore;
 pub mod show;
 pub mod supersede;
 pub mod update;
+
+use orbit_common::types::ToolParam;
+
+pub(super) fn create_params() -> Vec<ToolParam> {
+    vec![
+        ToolParam {
+            name: "title".to_string(),
+            description: "ADR title (short noun phrase).".to_string(),
+            param_type: "string".to_string(),
+            required: true,
+        },
+        ToolParam {
+            name: "body".to_string(),
+            description:
+                "ADR body as markdown. Must include Context / Decision / Consequences sections per the ADR template; at least one consequences bullet must be a labeled `Cost:` line."
+                    .to_string(),
+            param_type: "string".to_string(),
+            required: true,
+        },
+        ToolParam {
+            name: "owner".to_string(),
+            description:
+                "Agent identity that owns the ADR (e.g. `claude`, `codex`). Defaults to the calling actor."
+                    .to_string(),
+            param_type: "string".to_string(),
+            required: false,
+        },
+        ToolParam {
+            name: "related_features".to_string(),
+            description:
+                "Feature folder names this decision touches. Accepts a string or array of strings."
+                    .to_string(),
+            param_type: "string_list".to_string(),
+            required: false,
+        },
+        ToolParam {
+            name: "related_tasks".to_string(),
+            description:
+                "Orbit task IDs that proposed or shipped the decision. May be empty at creation per ADR-008. Accepts a string or array of strings."
+                    .to_string(),
+            param_type: "string_list".to_string(),
+            required: false,
+        },
+        ToolParam {
+            name: "tags".to_string(),
+            description: "Free-form ADR labels. Defaults to an empty list when omitted."
+                .to_string(),
+            param_type: "string_list".to_string(),
+            required: false,
+        },
+        ToolParam {
+            name: "paths".to_string(),
+            description:
+                "Repo-relative glob patterns for code or docs areas constrained by this ADR. Defaults to an empty list when omitted."
+                    .to_string(),
+            param_type: "string_list".to_string(),
+            required: false,
+        },
+    ]
+}

--- a/crates/orbit-tools/src/builtin/orbit/adr/restore.rs
+++ b/crates/orbit-tools/src/builtin/orbit/adr/restore.rs
@@ -1,0 +1,33 @@
+use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
+use serde_json::Value;
+
+use crate::{OrbitBuiltinAction, Tool, ToolContext};
+
+pub struct OrbitAdrRestoreTool;
+
+impl Tool for OrbitAdrRestoreTool {
+    fn schema(&self) -> ToolSchema {
+        let mut parameters = vec![ToolParam {
+            name: "id".to_string(),
+            description: "Exact existing canonical ADR allocation to restore (e.g. `ADR-0042`)."
+                .to_string(),
+            param_type: "string".to_string(),
+            required: true,
+        }];
+        parameters.extend(super::create_params());
+        parameters.extend(super::super::model_identity_params());
+        ToolSchema {
+            name: "orbit.adr.restore".to_string(),
+            description:
+                "Restore an unreadable ADR at its exact existing allocation. Refuses missing allocations, readable artifacts, lifecycle collisions, and concurrent allocation changes; never allocates or overwrites."
+                    .to_string(),
+            parameters,
+            builtin: true,
+        }
+    }
+
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        super::super::reject_agent_field(&input, "orbit.adr.restore")?;
+        super::super::execute_host_action(ctx, input, OrbitBuiltinAction::AdrRestore)
+    }
+}

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -37,6 +37,9 @@ pub fn register(registry: &mut ToolRegistry) {
     // `orbit.adr.list` stays available on the CLI / dashboard `runtime.run_tool`
     // path for admin workflows.
     registry.register_inactive(adr::list::OrbitAdrListTool);
+    // Exact-id restore is an operator repair surface. Keep it available to
+    // `orbit tool run` without advertising it to ordinary agent sessions.
+    registry.register_inactive(adr::restore::OrbitAdrRestoreTool);
     registry.register_mcp(
         adr::show::OrbitAdrShowTool,
         agent_operator(McpToolPlacement::Owner),

--- a/crates/orbit-tools/src/lib.rs
+++ b/crates/orbit-tools/src/lib.rs
@@ -81,6 +81,7 @@ pub enum OrbitBuiltinAction {
     AdrAdd,
     AdrShow,
     AdrList,
+    AdrRestore,
     AdrUpdate,
     AdrSupersede,
     AutoTaskAdd,


### PR DESCRIPTION
## Task

[ORB-10538](https://orbit-cli.com/tasks/ORB-10538) — Expose a guarded ADR restore path for an existing unreadable allocation

### Description

## Problem
ORB-10479 cannot safely restore 18 lost ADR bodies until Orbit can materialize an ADR at the canonical id it already owns. `orbit.adr.add` allocates a new id and `orbit.adr.update` requires a readable artifact. The store has a `finalize_preallocated_adr` primitive for hub-allocated ids, but no user-facing repair surface limited to an existing allocation with no readable artifact.

## Required outcome
Expose a guarded CLI/tool restore operation that accepts an exact ADR id and body metadata, proves the allocation exists, proves no artifact is readable locally or canonically, and finalizes at that id without allocating or overwriting anything. Preserve ADR-0153 allocator authority and ADR-0177 worktree-local body semantics. Fail closed for a missing allocation, an already-readable artifact, a lifecycle collision, or a concurrent change.

### Acceptance Criteria

- A supported CLI/tool operation restores an ADR at an exact existing allocated id without allocating a new id.
- The operation succeeds only when the allocation exists and the ADR artifact is currently unreadable; it never overwrites or adopts a readable artifact.
- Missing allocations, readable artifacts, lifecycle collisions, and concurrent state changes fail with structured actionable errors.
- The restored bundle is indexed and immediately readable through orbit.adr.show at the same canonical id.
- Focused store and tool-host tests cover success, id preservation, collision refusal, and retry/concurrency safety.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `orbit.adr.restore`, an operator-facing `orbit tool run` operation that accepts an exact ADR id plus normal ADR creation metadata and never allocates a replacement id.
- Added store guards requiring a live allocation, refusing local lifecycle collisions and readable canonical artifacts, writing the restored Proposed bundle exclusively, compare-and-setting the allocation snapshot, cleaning partial writes on races, and refreshing the ADR index.
- Added focused store and tool-host coverage for exact-id success, immediate `orbit.adr.show`, missing/readable/lifecycle collision refusal, retry safety, and stale-snapshot concurrency cleanup.
Assessment: The repair path is fail-closed and preserves allocator authority plus worktree-local bodies; the existing hub preallocation finalizer remains unchanged.
Deviations from original plan: Expanded `context_files` to the allocator CAS implementation and the directly coupled tool registry, dispatch, redaction, and test files required to expose and validate the operation.
Validation: `cargo test -p orbit-store restore_allocated_adr` (4 passed); `cargo test -p orbit-core adr_restore_tool` (2 passed); `make ci-fast` passed; `git diff --check` passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10538-6a6e3356`
- Behind base: 0
- Ahead of base: 1