### PR TITLE
Expose the workflow execution surface as operator-only MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ codex plugin add orbit@orbit
 | Shared Orbit skills | Bundled from `plugin/skills/` | Bundled from `plugin/skills/` | Seeded by `orbit workspace init` |
 | Web dashboard (`orbit web serve`) | No | No | Yes |
 | Other agent CLIs | No, scoped to Claude Code | No, scoped to Codex | Yes |
-| Workflows (i.e. `orbit run ship`) | No | No | Yes |
+| Workflows (ship, run show/list/resume) | No — plugin MCP is agent-capability | No — plugin MCP is agent-capability | Yes — CLI, or MCP via `orbit mcp serve --capabilities operator` |
 
 </details>
 
@@ -243,10 +243,19 @@ The surface is namespaced by artifact:
 | `orbit.learning.*` | Author, edit, show, list, supersede project learnings |
 | `orbit.friction.*` | Record, edit, show, list, resolve operational frictions; list taxonomy tags |
 | `orbit.docs.*` | List and show indexed Markdown under `[docs].roots`; register additional roots |
+| `orbit.workflow.*` | Operator-only ship submission plus durable run show, list, and resume |
 
 Not every tool is intended for agent calls. Lifecycle/admin operations (`docs.index`, `docs.migrate`, `semantic.*`, `learning.sync`, `task.locks.*`, and `friction.*` reads/updates) are typically driven by humans via the CLI; the recommended agent permission profile auto-allows discovery/write tools and prompts on the rest. See `.claude/settings.json` (and `.codex/`, `.grok/`, `.gemini/` equivalents) in the seeded workspace for the default agent-facing subset.
 
 A few admin and destructive tools — `orbit.task.delete`, `orbit.task.lint`, `orbit.semantic.uninstall`, `orbit.adr.list` (agents use `orbit search --kind adr`), `orbit.learning.prune` — stay registered for operator use via `orbit tool run` and their CLI equivalents, but are hidden from the agent MCP surface.
+
+In a single-host deployment, start a deliberate operator session with
+`orbit mcp serve --capabilities operator` and announce the workspace through MCP
+initialize metadata (or the tool's `workspace` argument). The default plugin and
+`orbit workspace init --mcp` registrations remain agent-capability sessions and
+do not advertise workflow tools. Workflow ship/resume calls from an
+Orbit-managed run are rejected, so an executing agent cannot recursively fan
+out more runs; run observation remains an operator-only read surface.
 
 ---
 

--- a/crates/orbit-cli/src/command/mcp/command.rs
+++ b/crates/orbit-cli/src/command/mcp/command.rs
@@ -55,8 +55,8 @@ pub struct ServeArgs {
     /// Serve only checkoutless coordination tools as the fixed local hub.
     #[arg(long)]
     pub hub: bool,
-    /// Exact non-hierarchical capability for this hub server session.
-    #[arg(long, value_name = "CAPABILITY", requires = "hub")]
+    /// Exact non-hierarchical capability for this broker or hub session.
+    #[arg(long, value_name = "CAPABILITY")]
     pub capabilities: Option<McpCapability>,
 }
 

--- a/crates/orbit-cli/src/command/tests/mod.rs
+++ b/crates/orbit-cli/src/command/tests/mod.rs
@@ -113,12 +113,18 @@ fn cli_parses_hub_mcp_serve_with_one_exact_capability() {
 }
 
 #[test]
-fn cli_rejects_mcp_capability_without_hub_and_unknown_values() {
-    assert_cli_rejects(
-        &["orbit", "mcp", "serve", "--capabilities", "agent"],
-        ErrorKind::MissingRequiredArgument,
-        "--hub",
-    );
+fn cli_parses_broker_capability_and_rejects_unknown_values() {
+    let cli = Cli::parse_from(["orbit", "mcp", "serve", "--capabilities", "operator"]);
+    match cli.command {
+        Commands::Mcp(command) => match command.command {
+            McpSubcommand::Serve(args) => {
+                assert!(!args.hub);
+                assert_eq!(args.capabilities, Some(McpCapability::Operator));
+            }
+            _ => panic!("expected mcp serve"),
+        },
+        _ => panic!("expected top-level mcp command"),
+    }
     assert_cli_rejects(
         &["orbit", "mcp", "serve", "--hub", "--capabilities", "admin"],
         ErrorKind::ValueValidation,

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -135,8 +135,18 @@ impl McpWorkspace {
     /// this workspace via `_meta.orbit.workspace`), and return the connected
     /// client.
     fn serve(&self) -> McpClient {
+        self.serve_with_args(&[])
+    }
+
+    fn serve_operator(&self) -> McpClient {
+        self.serve_with_args(&["--capabilities", "operator"])
+    }
+
+    fn serve_with_args(&self, extra_args: &[&str]) -> McpClient {
+        let mut args = vec!["mcp", "serve"];
+        args.extend_from_slice(extra_args);
         let child = Self::orbit_command(&self.work, &self.home)
-            .args(["mcp", "serve"])
+            .args(args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -330,6 +340,10 @@ fn mcp_serve_tools_list_matches_production_snapshot() {
         "orbit_task_delete",
         "orbit_task_lint",
         "orbit_learning_prune",
+        "orbit_workflow_ship",
+        "orbit_workflow_run_show",
+        "orbit_workflow_run_list",
+        "orbit_workflow_run_resume",
     ] {
         assert!(!names.contains(&hidden), "{hidden} leaked into: {names:?}");
     }
@@ -366,6 +380,31 @@ fn mcp_serve_tools_list_matches_production_snapshot() {
          with `ORBIT_MCP_UPDATE_SNAPSHOT=1 cargo test -p orbit-cli --test mcp_roundtrip` and \
          call the release breaking."
     );
+}
+
+#[test]
+fn operator_broker_advertises_and_calls_the_workflow_family() {
+    let workspace = McpWorkspace::init();
+    let mut client = workspace.serve_operator();
+    let response = client.request("tools/list", Value::Null);
+    let names = response["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .filter_map(|tool| tool["name"].as_str())
+        .collect::<BTreeSet<_>>();
+
+    for expected in [
+        "orbit_workflow_ship",
+        "orbit_workflow_run_show",
+        "orbit_workflow_run_list",
+        "orbit_workflow_run_resume",
+    ] {
+        assert!(names.contains(expected), "missing {expected}: {names:?}");
+    }
+
+    let listed = client.call_tool_ok("orbit_workflow_run_list", json!({}));
+    assert_eq!(listed["items"], json!([]));
 }
 
 #[test]
@@ -573,7 +612,7 @@ fn mcp_serve_round_trips_records_against_a_temp_workspace() {
         "orbit_friction_update",
         json!({ "id": friction_id, "status": "triaged", "model": "codex" }),
     );
-    assert_eq!(denied["code"], "invalid_input");
+    assert_eq!(denied["code"], "capability_denied");
     assert!(
         denied["message"]
             .as_str()
@@ -711,9 +750,18 @@ fn mcp_registered_calls_are_audited_but_unknown_names_are_not_dispatched() {
     assert_eq!(error["code"], "invalid_input");
     let removed = client.call_tool_err("orbit_removed_tool", json!({ "model": "codex" }));
     assert_eq!(removed["code"], "tool_not_found");
+    let workflow_denied = client.call_tool_err(
+        "orbit_workflow_ship",
+        json!({ "task_ids": ["ORB-00001"], "model": "codex" }),
+    );
+    assert_eq!(workflow_denied["code"], "capability_denied");
     drop(client);
 
-    for (tool_name, status) in [("orbit.search", "success"), ("orbit.task.add", "failure")] {
+    for (tool_name, status) in [
+        ("orbit.search", "success"),
+        ("orbit.task.add", "failure"),
+        ("orbit.workflow.ship", "denied"),
+    ] {
         let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
             .args(["audit", "list", "--tool", tool_name, "--json"])
             .output()

--- a/crates/orbit-common/src/authorization.rs
+++ b/crates/orbit-common/src/authorization.rs
@@ -129,6 +129,30 @@ impl GovernedOperation {
 ///    process state.
 pub const GOVERNED_OPERATIONS: &[GovernedOperation] = &[
     GovernedOperation {
+        id: "orbit.workflow.ship",
+        surface: OperationSurface::Tool,
+        allowed: &[McpCapability::Operator],
+        rationale: "dispatching a ship workflow creates managed runs and worktrees",
+    },
+    GovernedOperation {
+        id: "orbit.workflow.run.show",
+        surface: OperationSurface::Tool,
+        allowed: &[McpCapability::Operator],
+        rationale: "workflow run observation is an operator surface",
+    },
+    GovernedOperation {
+        id: "orbit.workflow.run.list",
+        surface: OperationSurface::Tool,
+        allowed: &[McpCapability::Operator],
+        rationale: "workflow run observation is an operator surface",
+    },
+    GovernedOperation {
+        id: "orbit.workflow.run.resume",
+        surface: OperationSurface::Tool,
+        allowed: &[McpCapability::Operator],
+        rationale: "resuming a workflow creates another managed run",
+    },
+    GovernedOperation {
         id: "orbit.task.delete",
         surface: OperationSurface::Tool,
         allowed: &[McpCapability::Operator],

--- a/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
@@ -82,6 +82,14 @@ pub(super) fn execute(
         OrbitBuiltinAction::TaskShow => super::task_tools::show(runtime, input),
         OrbitBuiltinAction::TaskStart => super::task_tools::start(runtime, input, agent, model),
         OrbitBuiltinAction::TaskUpdate => super::task_tools::update(runtime, input, agent, model),
+        OrbitBuiltinAction::WorkflowShip => {
+            super::workflow_tools::ship(runtime, input, agent, model)
+        }
+        OrbitBuiltinAction::WorkflowRunShow => super::workflow_tools::show(runtime, input),
+        OrbitBuiltinAction::WorkflowRunList => super::workflow_tools::list(runtime, input),
+        OrbitBuiltinAction::WorkflowRunResume => {
+            super::workflow_tools::resume(runtime, input, agent, model)
+        }
     }?;
     super::artifact_redaction::finish_tool_response(
         runtime,

--- a/crates/orbit-core/src/runtime/orbit_tool_host/mod.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/mod.rs
@@ -13,6 +13,7 @@ mod search_tools;
 mod semantic_tools;
 mod state_tools;
 mod task_tools;
+mod workflow_tools;
 
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/mod.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/mod.rs
@@ -1,3 +1,4 @@
 mod learning_tools;
 mod state_tools;
 mod task_tools;
+mod workflow_tools;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/workflow_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/workflow_tools.rs
@@ -1,0 +1,58 @@
+use std::collections::BTreeSet;
+
+use chrono::Utc;
+use orbit_common::types::{AuditEventStatus, McpCapability, Role, ToolSessionContext};
+use orbit_tools::ToolContext;
+use serde_json::json;
+
+use super::super::test_support::{run_tool_as_operator, test_runtime};
+
+#[test]
+fn operator_can_observe_runs_and_agent_denial_is_audited() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("task_auto_pipeline", 1, Utc::now(), None, None)
+        .expect("insert run");
+
+    let shown = run_tool_as_operator(
+        &runtime,
+        "orbit.workflow.run.show",
+        json!({"id": run.run_id}),
+    )
+    .expect("operator run show");
+    assert_eq!(shown["run_id"], json!(run.run_id));
+
+    let listed = run_tool_as_operator(&runtime, "orbit.workflow.run.list", json!({}))
+        .expect("operator run list");
+    assert_eq!(listed["items"][0]["run_id"], json!(run.run_id));
+
+    let denied = runtime.run_tool_with_context_and_role(
+        "orbit.workflow.run.show",
+        json!({"id": run.run_id}),
+        Role::Admin,
+        ToolContext {
+            session_context: ToolSessionContext {
+                effective_capabilities: BTreeSet::from([McpCapability::Agent]),
+                ..ToolSessionContext::default()
+            },
+            ..ToolContext::default()
+        },
+    );
+    assert!(
+        matches!(
+            denied,
+            Err(orbit_common::types::OrbitError::CapabilityDenied(_))
+        ),
+        "{denied:?}"
+    );
+
+    let audit = runtime
+        .list_audit_events(None, None, Some(AuditEventStatus::Denied), None, 20)
+        .expect("read denial audit");
+    assert!(audit.iter().any(|event| {
+        event.command == "authorization"
+            && event.target_id.as_deref() == Some("orbit.workflow.run.show")
+    }));
+}

--- a/crates/orbit-core/src/runtime/orbit_tool_host/workflow_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/workflow_tools.rs
@@ -1,0 +1,139 @@
+use std::collections::BTreeSet;
+use std::str::FromStr;
+
+use chrono::{DateTime, Utc};
+use orbit_common::types::{JobRun, JobRunState, OrbitError, normalize_optional_attribution_label};
+use serde_json::{Value, json};
+
+use crate::command::job::JobRunListParams;
+use crate::{OrbitRuntime, ShipMode};
+
+use super::input::{optional_bool_alias, parse_string_array_field};
+use super::json::serialize_error;
+
+const DEFAULT_RUN_LIST_LIMIT: usize = 25;
+const MAX_RUN_LIST_LIMIT: usize = 200;
+
+pub(super) fn ship(
+    runtime: &OrbitRuntime,
+    input: Value,
+    agent: Option<String>,
+    model: Option<String>,
+) -> Result<Value, OrbitError> {
+    let task_ids = parse_string_array_field(&input, "task_ids")?;
+    let unique = task_ids.iter().collect::<BTreeSet<_>>();
+    if unique.len() != task_ids.len() {
+        return Err(OrbitError::InvalidInput(
+            "`task_ids` must not contain duplicates".to_string(),
+        ));
+    }
+    let mode = match optional_string(&input, "mode")? {
+        Some(raw) => ShipMode::parse(&raw)?,
+        None => runtime
+            .workspace_runtime_binding()
+            .map_or(ShipMode::Pr, |binding| binding.ship_mode),
+    };
+    let base = optional_string(&input, "base")?;
+    let review = optional_bool_alias(&input, &["review"])?.unwrap_or(false);
+    let review_crew = optional_string(&input, "review_crew")?;
+    let actor = actor(runtime, agent.as_deref(), model.as_deref());
+    let invoke = runtime.submit_ship_run(
+        mode,
+        base.as_deref(),
+        &task_ids,
+        review,
+        review_crew.as_deref(),
+        Some(&actor),
+    )?;
+    Ok(json!({
+        "workflow": "ship",
+        "job_id": invoke.job_name,
+        "run_id": invoke.run_id,
+        "state": if invoke.queued { "queued" } else { "submitted" },
+        "submitted_at": invoke.submitted_at,
+    }))
+}
+
+pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
+    let id = orbit_common::types::required_string(&input, &["id"], "id")?;
+    run_json(&runtime.show_job_run(&id)?)
+}
+
+pub(super) fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
+    let state = optional_string(&input, "state")?;
+    let terminal_only = state.as_deref() == Some("terminal");
+    let state = state
+        .filter(|value| value != "terminal")
+        .map(|value| {
+            JobRunState::from_str(&value)
+                .map_err(|error| OrbitError::InvalidInput(format!("`state` {error}")))
+        })
+        .transpose()?;
+    let since = optional_string(&input, "since")?
+        .map(|value| {
+            DateTime::parse_from_rfc3339(&value)
+                .map(|value| value.with_timezone(&Utc))
+                .map_err(|error| OrbitError::InvalidInput(format!("`since` {error}")))
+        })
+        .transpose()?;
+    let runs = runtime.list_job_runs(JobRunListParams {
+        job_id: optional_string(&input, "job_id")?,
+        state,
+        terminal_only,
+        since,
+        limit: Some(parse_limit(&input)?),
+    })?;
+    let items = runs.iter().map(run_json).collect::<Result<Vec<_>, _>>()?;
+    Ok(json!({ "items": items }))
+}
+
+pub(super) fn resume(
+    runtime: &OrbitRuntime,
+    input: Value,
+    agent: Option<String>,
+    model: Option<String>,
+) -> Result<Value, OrbitError> {
+    let id = orbit_common::types::required_string(&input, &["id"], "id")?;
+    let actor = actor(runtime, agent.as_deref(), model.as_deref());
+    let invoke = runtime.submit_resume_run(&id, Some(&actor))?;
+    Ok(json!({
+        "workflow": "resume",
+        "job_id": invoke.job_name,
+        "run_id": invoke.run_id,
+        "retry_source_run_id": id,
+        "state": if invoke.queued { "queued" } else { "submitted" },
+        "submitted_at": invoke.submitted_at,
+    }))
+}
+
+fn optional_string(input: &Value, field: &str) -> Result<Option<String>, OrbitError> {
+    orbit_common::types::optional_string(input, field)
+}
+
+fn actor(runtime: &OrbitRuntime, agent: Option<&str>, model: Option<&str>) -> String {
+    normalize_optional_attribution_label(model.or(agent), model)
+        .unwrap_or_else(|| runtime.actor_label().to_string())
+}
+
+fn parse_limit(input: &Value) -> Result<usize, OrbitError> {
+    let Some(value) = input.get("limit") else {
+        return Ok(DEFAULT_RUN_LIST_LIMIT);
+    };
+    let limit = value.as_u64().ok_or_else(|| {
+        OrbitError::InvalidInput("`limit` must be a positive integer".to_string())
+    })?;
+    if limit == 0 {
+        return Err(OrbitError::InvalidInput(
+            "`limit` must be at least 1".to_string(),
+        ));
+    }
+    usize::try_from(limit.min(MAX_RUN_LIST_LIMIT as u64))
+        .map_err(|_| OrbitError::InvalidInput("`limit` is too large".to_string()))
+}
+
+fn run_json(run: &JobRun) -> Result<Value, OrbitError> {
+    let mut value = serde_json::to_value(run).map_err(serialize_error("serialize workflow run"))?;
+    value["steps"] = serde_json::to_value(&run.steps)
+        .map_err(serialize_error("serialize workflow run steps"))?;
+    Ok(value)
+}

--- a/crates/orbit-mcp/src/adapter/dispatch.rs
+++ b/crates/orbit-mcp/src/adapter/dispatch.rs
@@ -261,7 +261,7 @@ impl OrbitToolServer {
                 .map(ToString::to_string)
                 .collect::<Vec<_>>()
                 .join(", ");
-            let denial = OrbitError::InvalidInput(format!(
+            let denial = OrbitError::CapabilityDenied(format!(
                 "MCP capability denied for tool '{canonical}': the effective session set must contain one of [{allowed}]"
             ));
             let denial = self

--- a/crates/orbit-mcp/src/adapter/tests/dispatch.rs
+++ b/crates/orbit-mcp/src/adapter/tests/dispatch.rs
@@ -292,6 +292,10 @@ async fn d3_context_membership_filters_tool_list_and_call() {
         .await
         .expect("capability denial is a structured tool error");
     assert_eq!(called.is_error, Some(true));
+    let structured = called
+        .structured_content
+        .expect("capability denial has structured content");
+    assert_eq!(structured["code"], "capability_denied");
 
     let mut operator_context = ToolSessionContext::trusted_local(None, None, None);
     operator_context.effective_capabilities = [McpCapability::Operator].into_iter().collect();

--- a/crates/orbit-remote/src/mcp/contract.rs
+++ b/crates/orbit-remote/src/mcp/contract.rs
@@ -14,7 +14,8 @@ use super::schema::remote_input_schema;
 /// Bumping this fact prevents a newer client from negotiating successfully
 /// with a hub that has the same canonical tool schemas but no allocation seam.
 pub const MCP_CONTRACT_REVISION: u32 = 3;
-pub const CANONICAL_MCP_REGISTRY_REVISION: u32 = 1;
+/// Revision 2 adds the operator-only workflow execution family [ORB-10534].
+pub const CANONICAL_MCP_REGISTRY_REVISION: u32 = 2;
 pub const HUB_SCHEMA_DOMAIN: &str = "orbit.mcp.hub-schema.v1";
 pub const HUB_CONTRACT_INSTRUCTIONS_PREFIX: &str = "orbit-hub-contract-v1:";
 

--- a/crates/orbit-remote/src/mcp/host.rs
+++ b/crates/orbit-remote/src/mcp/host.rs
@@ -217,7 +217,7 @@ impl BrokerMcpHost {
             .map(ToString::to_string)
             .collect::<Vec<_>>()
             .join(", ");
-        Err(OrbitError::InvalidInput(format!(
+        Err(OrbitError::CapabilityDenied(format!(
             "MCP capability denied for tool '{}': the effective session set must contain one of [{required}]",
             definition.schema.name
         )))
@@ -659,7 +659,15 @@ impl BrokerMcpHost {
             self.record_preflight_denial(name, &input, &context, &error);
             return Err(error);
         }
-        let require_local = definition.policy.placement() != McpToolPlacement::Hub || with_context;
+        // Hub placement describes coordination ownership. In today's
+        // single-host deployment the workflow executor still needs the exact
+        // selected checkout, so an operator broker short-circuits these tools
+        // through its local runtime. Spokes continue routing them to the hub;
+        // multi-host execution remains deliberately deferred.
+        let local_workflow_execution = name.starts_with("orbit.workflow.") && !self.is_spoke()?;
+        let require_local = definition.policy.placement() != McpToolPlacement::Hub
+            || with_context
+            || local_workflow_execution;
         let (workspace_id, binding) = match self.resolve_workspace(selector, require_local) {
             Ok(resolved) => resolved,
             Err(error) => {
@@ -676,7 +684,10 @@ impl BrokerMcpHost {
             self.record_preflight_denial(name, &input, &context, &error);
             return Err(error);
         }
-        if definition.policy.placement() == McpToolPlacement::Hub && !with_context {
+        if definition.policy.placement() == McpToolPlacement::Hub
+            && !with_context
+            && !local_workflow_execution
+        {
             context.workspace_id = Some(workspace_id.clone());
             context.workspace = Some(workspace_id.clone());
             if let Some(object) = input.as_object_mut()

--- a/crates/orbit-remote/src/mcp/mod.rs
+++ b/crates/orbit-remote/src/mcp/mod.rs
@@ -49,11 +49,6 @@ pub fn serve_mcp_stdio(
     // Parse the trusted file, when present, before constructing either server
     // host. Workspace/cwd config never participates in this load.
     let trusted_config = load_trusted_mcp_config(&global_root)?;
-    if !hub && requested_capability.is_some() {
-        return Err(OrbitError::InvalidInput(
-            "--capabilities requires --hub".to_string(),
-        ));
-    }
     let capability = requested_capability.unwrap_or(McpCapability::Agent);
     let (host, mut trusted_context, composition): (
         Arc<dyn McpHost>,

--- a/crates/orbit-remote/src/mcp/tests/contract.rs
+++ b/crates/orbit-remote/src/mcp/tests/contract.rs
@@ -34,11 +34,11 @@ fn frozen_hub_schema_golden_vector() {
         String::from_utf8(bytes).expect("utf8"),
         concat!(
             "orbit.mcp.hub-schema.v1\0",
-            r#"{"canonical_registry_revision":1,"capability":"agent","tools":[{"advertised_name":"orbit_task_show","canonical_name":"orbit.task.show","description":"Show one task","input_schema":{"additionalProperties":true,"properties":{"id":{"description":"Task ID","type":"string"}},"required":["id"],"type":"object"}}]}"#,
+            r#"{"canonical_registry_revision":2,"capability":"agent","tools":[{"advertised_name":"orbit_task_show","canonical_name":"orbit.task.show","description":"Show one task","input_schema":{"additionalProperties":true,"properties":{"id":{"description":"Task ID","type":"string"}},"required":["id"],"type":"object"}}]}"#,
         )
     );
     assert_eq!(
         hub_schema_digest(&fixture_definitions(), McpCapability::Agent).expect("digest"),
-        "ec8ef56c153562d0f4125cee1b3932c33ed30eb8509601aa5652a351a7b6a8f7"
+        "8c5856e3838ac33eab4e66401d846b9cc6f262a23d30af964c843496c0fe4ee8"
     );
 }

--- a/crates/orbit-remote/src/mcp/tests/discovery.rs
+++ b/crates/orbit-remote/src/mcp/tests/discovery.rs
@@ -69,7 +69,7 @@ fn remote_owns_the_exact_global_discovery_definitions() {
     );
 
     let canonical = canonical_mcp_tool_definitions().expect("canonical definitions");
-    assert_eq!(canonical.len(), 28, "the frozen production surface changed");
+    assert_eq!(canonical.len(), 32, "the frozen production surface changed");
     assert_eq!(
         canonical
             .iter()

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -10,6 +10,7 @@ pub mod search;
 pub mod semantic;
 pub mod state;
 pub mod task;
+pub mod workflow;
 
 use orbit_common::types::{
     McpToolPlacement, McpToolPolicy, OrbitError, ToolParam, normalize_agent_family_for_model,
@@ -148,6 +149,22 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register_mcp(
         search::OrbitSearchTool,
         agent_operator(McpToolPlacement::Composite),
+    );
+    registry.register_mcp(
+        workflow::OrbitWorkflowShipTool,
+        McpToolPolicy::operator_only(McpToolPlacement::Hub),
+    );
+    registry.register_mcp(
+        workflow::OrbitWorkflowRunShowTool,
+        McpToolPolicy::operator_only(McpToolPlacement::Hub),
+    );
+    registry.register_mcp(
+        workflow::OrbitWorkflowRunListTool,
+        McpToolPolicy::operator_only(McpToolPlacement::Hub),
+    );
+    registry.register_mcp(
+        workflow::OrbitWorkflowRunResumeTool,
+        McpToolPolicy::operator_only(McpToolPlacement::Hub),
     );
     registry.register_inactive(semantic::install::OrbitSemanticInstallTool);
     // ORB-00289: destructive teardown of the local semantic index —

--- a/crates/orbit-tools/src/builtin/orbit/workflow/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/workflow/mod.rs
@@ -1,0 +1,166 @@
+use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
+use serde_json::Value;
+
+use crate::{OrbitBuiltinAction, Tool, ToolContext};
+
+pub struct OrbitWorkflowShipTool;
+pub struct OrbitWorkflowRunShowTool;
+pub struct OrbitWorkflowRunListTool;
+pub struct OrbitWorkflowRunResumeTool;
+
+fn run_id_param() -> ToolParam {
+    ToolParam {
+        name: "id".to_string(),
+        description: "Job run ID.".to_string(),
+        param_type: "string".to_string(),
+        required: true,
+    }
+}
+
+fn execute(
+    ctx: &ToolContext,
+    input: Value,
+    action: OrbitBuiltinAction,
+) -> Result<Value, OrbitError> {
+    if ctx
+        .orbit_host
+        .as_ref()
+        .is_some_and(|host| host.task_scope().run_id.is_some())
+        && matches!(
+            action,
+            OrbitBuiltinAction::WorkflowShip | OrbitBuiltinAction::WorkflowRunResume
+        )
+    {
+        return Err(OrbitError::CapabilityDenied(
+            "managed runs cannot dispatch or resume workflow runs; finish the current leaf mandate and let its operator submit follow-up work"
+                .to_string(),
+        ));
+    }
+    super::execute_host_action(ctx, input, action)
+}
+
+impl Tool for OrbitWorkflowShipTool {
+    fn schema(&self) -> ToolSchema {
+        let mut parameters = vec![
+            ToolParam {
+                name: "task_ids".to_string(),
+                description: "Explicit task IDs to ship; at least one is required.".to_string(),
+                param_type: "string_list".to_string(),
+                required: true,
+            },
+            ToolParam {
+                name: "mode".to_string(),
+                description:
+                    "Optional ship mode (`pr` or `local`); defaults to workspace configuration."
+                        .to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "base".to_string(),
+                description: "Optional base branch override.".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "review".to_string(),
+                description: "Whether to run an independent review before shipment.".to_string(),
+                param_type: "boolean".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "review_crew".to_string(),
+                description: "Explicit crew for the independent review step.".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+        ];
+        parameters.extend(super::model_identity_params());
+        ToolSchema {
+            name: "orbit.workflow.ship".to_string(),
+            description: "Submit an explicit set of tasks to the ship workflow and return its durable run ID."
+                .to_string(),
+            parameters,
+            builtin: true,
+        }
+    }
+
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        execute(ctx, input, OrbitBuiltinAction::WorkflowShip)
+    }
+}
+
+impl Tool for OrbitWorkflowRunShowTool {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "orbit.workflow.run.show".to_string(),
+            description: "Fetch one durable workflow run by ID.".to_string(),
+            parameters: vec![run_id_param()],
+            builtin: true,
+        }
+    }
+
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        execute(ctx, input, OrbitBuiltinAction::WorkflowRunShow)
+    }
+}
+
+impl Tool for OrbitWorkflowRunListTool {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "orbit.workflow.run.list".to_string(),
+            description: "List durable workflow runs newest-first with optional bounded filters."
+                .to_string(),
+            parameters: vec![
+                ToolParam {
+                    name: "limit".to_string(),
+                    description: "Maximum runs to return (default 25, maximum 200).".to_string(),
+                    param_type: "integer".to_string(),
+                    required: false,
+                },
+                ToolParam {
+                    name: "job_id".to_string(),
+                    description: "Optional job ID filter.".to_string(),
+                    param_type: "string".to_string(),
+                    required: false,
+                },
+                ToolParam {
+                    name: "state".to_string(),
+                    description: "Optional concrete run-state filter, or `terminal`.".to_string(),
+                    param_type: "string".to_string(),
+                    required: false,
+                },
+                ToolParam {
+                    name: "since".to_string(),
+                    description: "Optional RFC 3339 lower bound for run creation time.".to_string(),
+                    param_type: "string".to_string(),
+                    required: false,
+                },
+            ],
+            builtin: true,
+        }
+    }
+
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        execute(ctx, input, OrbitBuiltinAction::WorkflowRunList)
+    }
+}
+
+impl Tool for OrbitWorkflowRunResumeTool {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "orbit.workflow.run.resume".to_string(),
+            description: "Resume a terminal resumable workflow run as a new linked run."
+                .to_string(),
+            parameters: vec![run_id_param()],
+            builtin: true,
+        }
+    }
+
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        execute(ctx, input, OrbitBuiltinAction::WorkflowRunResume)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-tools/src/builtin/orbit/workflow/tests/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/workflow/tests/mod.rs
@@ -1,0 +1,61 @@
+use orbit_common::types::OrbitError;
+use serde_json::json;
+use std::sync::Arc;
+
+use super::*;
+use crate::{OrbitTaskScope, OrbitToolHost, ReservationOwnerContext};
+
+struct ManagedHost;
+
+impl OrbitToolHost for ManagedHost {
+    fn execute(
+        &self,
+        _action: OrbitBuiltinAction,
+        _input: serde_json::Value,
+        _agent: Option<String>,
+        _model: Option<String>,
+        _reservation_owner: Option<ReservationOwnerContext>,
+    ) -> Result<serde_json::Value, OrbitError> {
+        Ok(json!({"observed": true}))
+    }
+
+    fn task_scope(&self) -> OrbitTaskScope {
+        OrbitTaskScope {
+            run_id: Some("jrun-managed".to_string()),
+            ..OrbitTaskScope::default()
+        }
+    }
+}
+
+fn managed_context() -> ToolContext {
+    ToolContext {
+        orbit_host: Some(Arc::new(ManagedHost)),
+        ..ToolContext::default()
+    }
+}
+
+#[test]
+fn managed_run_rejects_dispatch_before_host_resolution() {
+    let context = managed_context();
+
+    let error = OrbitWorkflowShipTool
+        .execute(&context, json!({"task_ids": ["ORB-00001"]}))
+        .expect_err("managed run must not recursively dispatch");
+
+    assert!(
+        matches!(error, OrbitError::CapabilityDenied(_)),
+        "{error:?}"
+    );
+    assert!(error.to_string().contains("managed runs cannot dispatch"));
+}
+
+#[test]
+fn observation_remains_non_mutating_inside_managed_run() {
+    let context = managed_context();
+
+    let output = OrbitWorkflowRunShowTool
+        .execute(&context, json!({"id": "jrun-example"}))
+        .expect("observation remains available");
+
+    assert_eq!(output, json!({"observed": true}));
+}

--- a/crates/orbit-tools/src/lib.rs
+++ b/crates/orbit-tools/src/lib.rs
@@ -125,6 +125,10 @@ pub enum OrbitBuiltinAction {
     TaskShow,
     TaskStart,
     TaskUpdate,
+    WorkflowRunList,
+    WorkflowRunResume,
+    WorkflowRunShow,
+    WorkflowShip,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/crates/orbit-tools/tests/mcp_definitions.rs
+++ b/crates/orbit-tools/tests/mcp_definitions.rs
@@ -29,12 +29,35 @@ impl Tool for TestTool {
 fn canonical_builtin_definitions_are_workspace_independent() {
     let definitions =
         canonical_builtin_mcp_tool_definitions().expect("builtin MCP definitions are valid");
-    assert_eq!(definitions.len(), 26);
+    assert_eq!(definitions.len(), 30);
     assert!(
         definitions
             .iter()
             .all(|definition| definition.schema.builtin)
     );
+}
+
+#[test]
+fn workflow_family_is_hub_placed_and_operator_only() {
+    let definitions =
+        canonical_builtin_mcp_tool_definitions().expect("builtin MCP definitions are valid");
+
+    for name in [
+        "orbit.workflow.ship",
+        "orbit.workflow.run.show",
+        "orbit.workflow.run.list",
+        "orbit.workflow.run.resume",
+    ] {
+        let definition = definitions
+            .iter()
+            .find(|definition| definition.schema.name == name)
+            .unwrap_or_else(|| panic!("missing workflow definition {name}"));
+        assert_eq!(definition.policy.placement(), McpToolPlacement::Hub);
+        assert_eq!(
+            definition.policy.allowed_capabilities(),
+            &std::collections::BTreeSet::from([orbit_common::types::McpCapability::Operator])
+        );
+    }
 }
 
 #[test]

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -114,6 +114,10 @@ fn workflow_critical_tools_remain_registered() {
         "orbit.pipeline.invoke",
         "orbit.pipeline.wait",
         "orbit.search",
+        "orbit.workflow.ship",
+        "orbit.workflow.run.show",
+        "orbit.workflow.run.list",
+        "orbit.workflow.run.resume",
         // ORB-00289: `orbit.semantic.uninstall` is inactive on the agent
         // surface; its inactive-classification is covered by
         // `inactive_ops_tools_*` and `INACTIVE_TOOL_NAMES` above.

--- a/docs/design/mcp-bridge/2_design.md
+++ b/docs/design/mcp-bridge/2_design.md
@@ -1,7 +1,7 @@
 ---
 title: Orbit MCP Bridge — Design
 owner: codex
-last_updated: 2026-07-20
+last_updated: 2026-08-01
 status: Accepted
 feature: mcp-bridge
 doc_role: design
@@ -10,7 +10,7 @@ summary: Target design for a local Orbit MCP broker with one SSH hub link, hub-o
 tags: [mcp, remote-access, host-registry, bridge, ssh, routing]
 paths: ["crates/orbit-remote/**", "crates/orbit-mcp/**", "crates/orbit-core/**", "crates/orbit-tools/**", "crates/orbit-store/**", "crates/orbit-common/**"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access, orbit-search, project-learnings]
-related_artifacts: [ORB-00424, ORB-10257, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ORB-10330, ORB-10332, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
+related_artifacts: [ORB-00424, ORB-10257, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ORB-10330, ORB-10332, ORB-10534, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
 ---
 
 # Orbit MCP Bridge — Design
@@ -741,6 +741,24 @@ pushes or relays execution.
 V1 is submit + observe. Cancellation and automatic backlog discovery are excluded.
 Generic pipeline invoke/wait tools are not compatibility targets for this surface.
 
+[ORB-10534] implements the single-host slice as four hub-class, operator-only
+tools: `orbit.workflow.ship`, `orbit.workflow.run.show`,
+`orbit.workflow.run.list`, and `orbit.workflow.run.resume`. A deliberate local
+operator obtains that surface with `orbit mcp serve --capabilities operator`;
+ordinary plugin/local registrations remain fixed to `agent`. The broker resolves
+the exact selected checkout and short-circuits workflow execution through its
+runtime, so ship and resume reuse the same durable submission services as the
+dashboard HTTP endpoints. The runtime converts the authenticated managed-process
+marker plus `ORBIT_RUN_ID` into a trusted in-band run scope; ship/resume reject
+that scope before host dispatch, preventing a leaf executor from recursively
+creating runs without trusting model-authored input.
+
+The fixed checkoutless `--hub` endpoint cannot yet execute these checkout-backed
+workflow tools, and remote spoke-to-hub execution is therefore deferred. This is
+an explicit current limitation rather than a fallback to process cwd or a local
+spoke checkout; the single-host operator broker is the supported MCP execution
+path until hub-side run admission owns a checkout-independent execution service.
+
 ## 9. Audit, Identity, and Uncertain Outcomes
 
 Hub-class calls record one canonical action audit on the hub with:
@@ -932,6 +950,10 @@ Required validation:
   binding before `runner` is a security boundary.
 - **Two client registrations remain.** Orbit and Bridge own different domains;
   cosmetic aggregation is not worth recreating duplicate Orbit contracts.
+- **Operator workflow execution is single-host today.** The deliberate local
+  operator broker can submit and observe runs, while the fixed checkoutless hub
+  endpoint and spoke routing do not yet own the runtime service required to
+  execute them. Those paths fail rather than selecting a checkout implicitly.
 
 ## Task References
 
@@ -967,5 +989,8 @@ Required validation:
 - [ORB-10332] — removed the `orbit.host.list` MCP discovery tool as unused; the
   `orbit host list` CLI command and the `orbit.workspace.list` / `orbit.crew.list`
   MCP discovery tools remain.
+- [ORB-10534] — registered the operator-only workflow family, added single-host
+  operator broker capability selection, reused runtime ship/show/list/resume,
+  and added the managed-run self-dispatch guard.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-bridge/references/conformance-v1.yaml
+++ b/docs/design/mcp-bridge/references/conformance-v1.yaml
@@ -65,6 +65,10 @@ tools:
   orbit.friction.update: { placement: hub, scope: workspace-required, allowed_capabilities: [operator] }
   orbit.workspace.list: { placement: hub, scope: global, allowed_capabilities: [operator] }
   orbit.crew.list: { placement: hub, scope: workspace-required, allowed_capabilities: [agent, operator] }
+  orbit.workflow.ship: { placement: hub, scope: workspace-required, allowed_capabilities: [operator] }
+  orbit.workflow.run.show: { placement: hub, scope: workspace-required, allowed_capabilities: [operator] }
+  orbit.workflow.run.list: { placement: hub, scope: workspace-required, allowed_capabilities: [operator] }
+  orbit.workflow.run.resume: { placement: hub, scope: workspace-required, allowed_capabilities: [operator] }
   orbit.search: { placement: composite, scope: workspace-required, allowed_capabilities: [agent, operator] }
   orbit.adr.add: { placement: composite, scope: workspace-required, allowed_capabilities: [agent, operator] }
   orbit.adr.show: { placement: owner, scope: workspace-required, allowed_capabilities: [agent, operator] }
@@ -83,11 +87,11 @@ tools:
 hub_schema_digest:
   domain_tag: orbit.mcp.hub-schema.v1
   contract_revision: 3
-  canonical_registry_revision: 1
+  canonical_registry_revision: 2
   golden_vector:
     capability: agent
-    canonical_json: '{"canonical_registry_revision":1,"capability":"agent","tools":[{"advertised_name":"orbit_task_show","canonical_name":"orbit.task.show","description":"Show one task","input_schema":{"additionalProperties":true,"properties":{"id":{"description":"Task ID","type":"string"}},"required":["id"],"type":"object"}}]}'
-    expected_sha256: ec8ef56c153562d0f4125cee1b3932c33ed30eb8509601aa5652a351a7b6a8f7
+    canonical_json: '{"canonical_registry_revision":2,"capability":"agent","tools":[{"advertised_name":"orbit_task_show","canonical_name":"orbit.task.show","description":"Show one task","input_schema":{"additionalProperties":true,"properties":{"id":{"description":"Task ID","type":"string"}},"required":["id"],"type":"object"}}]}'
+    expected_sha256: 8c5856e3838ac33eab4e66401d846b9cc6f262a23d30af964c843496c0fe4ee8
   inputs:
     - canonical schema name, description, and input schema for every hub-placed tool
     - canonical schema name, description, and input schema for every composite tool's hub step


### PR DESCRIPTION
## Task

[ORB-10534](https://orbit-cli.com/tasks/ORB-10534) — Expose the workflow execution surface as operator-only MCP tools

### Description

## Problem

Orbit's MCP registry contains no tool for its own execution surface. There is no `orbit.workflow.*` and no `orbit.run.*` entry anywhere in `crates/`. Dispatching and observing a run is reachable only two ways: the `orbit run ship` CLI, and the localhost dashboard HTTP API (`POST /api/workflows/ship`, `GET /api/runs/:id`, `GET /api/job-runs`, `POST /api/job-runs/:id/resume`).

Two consequences follow. Any MCP client that needs to dispatch work must reach around Orbit through a separate HTTP wrapper — this is a large part of why Bridge's `workflow_*` tools exist. And plugin consumers get no workflow surface at all, which the README's plugin/CLI table records as `Workflows (i.e. orbit run ship) | No | No | Yes`.

The design work is already done and unimplemented. `docs/design/mcp-bridge/2_design.md` §8.2 names the targets — `orbit.workflow.ship`, `orbit.workflow.run.show`, `orbit.workflow.run.list` — and classifies workflow tools as `hub` placement operator tools in §8.1. Nothing implements them.

There is an adjacent precedent worth reading before designing: `orbit.pipeline.invoke` and `orbit.pipeline.wait` are registered active but carry no `McpToolPolicy`, so they are present in the registry and unreachable over MCP.

## Scope

Register the workflow execution family as MCP tools restricted to operator capability.

Ship the family, not a single tool. A submit-only tool gives a caller fire-and-forget with no observation; submit plus observation plus resume is the minimum coherent set. Bridge needed four wrappers for this reason. §8.2 names three; the resume verb is an addition this task should cover or explicitly defer with a reason.

Out of scope: any change to Bridge, whose existing HTTP wrappers must keep working untouched; a CLI wave-drainer or `--loop`; and broadening access to agent-capability or plugin clients.

## Constraints

**Self-dispatch must fail closed.** An agent running inside a ship run must not be able to spawn further runs — that breaks the one-scoped-leaf-mandate model and makes cost unbounded via worktree fan-out. Two existing mechanisms are relevant and the task must choose between them with a stated rationale: `McpCapability::Runner` is stamped only by the run's own dispatcher (`crates/orbit-core/src/runtime/v2_host/dispatch.rs`, ORB-10453) and is deliberately not inherited by an agent inside that run; separately `ORBIT_RUN_ID` and `ORBIT_MANAGED_RUN_CONTEXT` are set in every dispatched child's environment. An in-band capability check is stronger than environment sniffing; if the environment route is chosen, justify it.

**The capability model is the main design risk, and resolving it is part of the task.** Local and plugin MCP sessions hardcode `{Agent}` via `ToolSessionContext::trusted_local`, and `orbit mcp serve --capabilities` currently requires `--hub`. The design doc's `hub` placement assumes a hub/spoke split that is not fully built. The task must state how an operator-capability session is obtained in today's single-host deployment, or state what it defers and why. Do not assume the hub exists.

**Hidden means recognized-but-not-advertised, not unknown.** The established behaviour is that a call to a tool the session cannot see reaches the audited denial path rather than being misclassified as an unknown name. Preserve that.

**Agent-loop outputs stay advisory.** No job or activity may require or depend on these tools' outputs; decisions read durable state or deterministic re-checks.

**Shipped surfaces stay project-agnostic.** Registered tool names, descriptions, and any seeded asset must contain no constellation-specific names, ids, or layout.

## Acceptance criteria

Listed separately.

### Acceptance Criteria

- The workflow execution family (ship, run show, run list, and resume or a documented deferral) is registered and callable from an operator-capability MCP session, and a ship call produces a run equivalent to the one produced by POST /api/workflows/ship for the same explicit task ids.
- An agent-capability session does not receive these tools from list_tools, and a direct call by canonical name returns a capability-denied error through the audited denial path with an audit record written — not a not_found for an unknown name.
- A call originating inside a managed run is rejected fail-closed, covered by a deterministic test that exercises the in-run case rather than only asserting the guard exists.
- The pinned-surface tests are updated so the new tools' visibility is asserted, and the suite fails if any of them becomes advertised to an agent-capability session.
- The README plugin vs. CLI table's Workflows row states what is true after the change, including which client capability is required.
- Bridge requires no change: its existing workflow_* HTTP wrappers continue to pass their tests against the modified server.
- The task's execution summary states how an operator-capability session is obtained in a single-host deployment, or records the deferral and its reason.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Registered orbit.workflow.ship plus run.show, run.list, and run.resume as hub-placement, operator-only MCP tools, with runtime handlers reusing the existing submit_ship_run, show_job_run, list_job_runs, and submit_resume_run services.
- Added the workflow operations to the shared authorization registry so direct agent-capability calls return capability_denied and persist audited denied records; changed the MCP adapter denial code accordingly.
- Prevented recursive ship/resume from managed runs by checking the trusted in-band OrbitToolHost run scope populated only from the managed process marker plus ORBIT_RUN_ID. Observation remains read-only.
- Enabled deliberate single-host operator broker sessions via orbit mcp serve --capabilities operator. The broker resolves the exact selected checkout for workflow execution; the fixed checkoutless hub and spoke execution path are explicitly deferred and fail without implicit checkout fallback.
- Updated canonical/conformance policy fixtures, advanced the negotiated canonical MCP registry revision to 2, pinned agent invisibility and operator visibility/callability, and documented the plugin/CLI capability boundary. Bridge/dashboard code was unchanged.
- Expanded context_files before touching the Core host seam, Remote broker/contract, CLI capability parser, MCP adapter, frozen conformance fixture, and their tightly coupled tests.
Assessment: The coherent workflow family is callable from a deliberate single-host operator MCP session, hidden from default agent sessions, audited on denial, and protected against managed-run self-dispatch. Resume was implemented rather than deferred.
Strategic decisions:
- Used the trusted runtime run scope instead of reading environment variables in the tool implementation; the environment marker is converted to scope at the existing host boundary.
- Kept hub placement metadata while routing the current single-host broker through its exact-checkout runtime. This preserves the target topology without pretending the checkoutless multi-host hub can execute runs today.
Design weaknesses / risks:
- Severity: known limitation. Fixed --hub and spoke-to-hub workflow execution remain deferred because HubCoordinationExecutor intentionally has no checkout-backed OrbitRuntime. Mitigation: document the supported local operator broker command and fail rather than infer cwd or a spoke checkout.
Validation:
- cargo test -p orbit-tools --test mcp_definitions --test public_tool_surface; workflow managed-run unit tests.
- cargo test -p orbit-core runtime::orbit_tool_host::tests::workflow_tools; orbit-common authorization and governed-tool registry tests.
- Full orbit-mcp tests; full orbit-cli mcp_roundtrip tests including operator list/call and agent denied audit.
- Focused orbit-remote conformance/discovery/contract tests; prior full Remote MCP test run passed 62/64 before the two intentional frozen fixtures were updated, then both updated failures passed.
- Dashboard compatibility: all 11 ship endpoint tests and all 3 resume endpoint tests passed. An earlier broad runs filter completed 28 relevant tests before the unrelated oversized audit-event scan exceeded 60 seconds and was interrupted.
- make ci-fast and git diff --check passed.
Friction: filed F2026-08-003 for the missing cataloged ~/.orbit orbit-knowledge skill path; the plugin-cache copy was used successfully.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10534-6a6e3356`
- Behind base: 0
- Ahead of base: 1