### PR TITLE
Make the Codex plugin validator compatible with Python 3.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ ci-fast:
 	./scripts/check-changelog-style.sh
 	./scripts/check-error-translation.sh
 	./scripts/check-orphan-modules.sh
+	./scripts/test-validate-codex-plugin.sh
 
 # Verify every workspace crate declares its stability tier
 stability:

--- a/scripts/test-validate-codex-plugin.sh
+++ b/scripts/test-validate-codex-plugin.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Exercise the repository-owned Codex plugin validator at its supported
+# Python interpreter boundary.
+set -euo pipefail
+
+repo_root="${1:-${ORBIT_REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}}"
+validator="$repo_root/scripts/validate-codex-plugin.sh"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "test-validate-codex-plugin: required binary 'python3' not on PATH" >&2
+  exit 2
+fi
+
+if ! grep -Fqx 'from __future__ import annotations' "$validator"; then
+  echo "test-validate-codex-plugin: validator must defer annotations for Python 3.9" >&2
+  exit 1
+fi
+
+python3 - <<'PY'
+from __future__ import annotations
+
+from typing import Any
+
+
+def accepts_optional_mapping(value: dict[str, Any] | None) -> list[str]:
+    return [] if value is None else list(value)
+
+
+assert accepts_optional_mapping(None) == []
+assert accepts_optional_mapping({"supported": True}) == ["supported"]
+PY
+
+fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/orbit-codex-plugin.XXXXXX")"
+trap 'rm -rf -- "$fixture_root"' EXIT
+
+cp -R "$repo_root/plugin" "$fixture_root/plugin"
+mkdir -p "$fixture_root/.agents/plugins"
+cp "$repo_root/.agents/plugins/marketplace.json" "$fixture_root/.agents/plugins/marketplace.json"
+
+"$validator" "$fixture_root"

--- a/scripts/validate-codex-plugin.sh
+++ b/scripts/validate-codex-plugin.sh
@@ -14,6 +14,8 @@ if ! command -v python3 >/dev/null 2>&1; then
 fi
 
 python3 - "$repo_root" <<'PY'
+from __future__ import annotations
+
 import json
 import re
 import sys


### PR DESCRIPTION
## Task

[ORB-10531](https://orbit-cli.com/tasks/ORB-10531) — Make the Codex plugin validator compatible with Python 3.9

### Description

## Problem

`scripts/validate-codex-plugin.sh` checks only that `python3` exists, then runs inline annotations such as `dict[str, Any] | None` at lines 42, 69, and 86. On the standard macOS `/usr/bin/python3` 3.9.6 these annotations evaluate at function definition time and raise `TypeError: unsupported operand type(s) for |: 'types.GenericAlias' and 'NoneType'` before release version comparison.

## Evidence

F2026-07-187 records the failure on Python 3.9.6. The current validator still contains the incompatible union annotations and has no explicit minimum-version check; `scripts/release-check.sh` invokes it from `make release-check`.

## Acceptance criteria

- The inline validator executes successfully under Python 3.9 without the reported annotation TypeError and reaches its normal validation result for a valid temporary plugin fixture.
- `make release-check` no longer fails before version comparison solely because the available `python3` is 3.9; if a newer interpreter is required instead, the script must reject 3.9 before execution with a clear minimum-version diagnostic and the release runbook must state that requirement. Prefer compatibility so supported macOS system Python remains usable.
- Add deterministic coverage for the supported interpreter boundary without changing plugin validation rules or release version semantics.

### Acceptance Criteria

- The inline validator executes successfully under Python 3.9 without the reported annotation TypeError and reaches its normal validation result for a valid temporary plugin fixture.
- make release-check no longer fails before version comparison solely because the available python3 is 3.9; if a newer interpreter is required instead, the script rejects 3.9 before execution with a clear minimum-version diagnostic and the release runbook states that requirement. Prefer compatibility.
- Deterministic coverage verifies the supported interpreter boundary without changing plugin validation rules or release version semantics.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `from __future__ import annotations` to the inline validator so `dict[str, Any] | None` annotations are deferred and compatible with Python 3.9 without changing validation rules.
- Added `scripts/test-validate-codex-plugin.sh`, which checks the deferred-annotation boundary, exercises equivalent Python typing under `python3`, and validates a temporary copy of the real plugin fixture.
- Registered the deterministic coverage in `make ci-fast`.
Validation:
- `./scripts/test-validate-codex-plugin.sh` passed.
- `./scripts/validate-codex-plugin.sh .` passed.
- `make ci-fast` passed.
- `bash -n scripts/validate-codex-plugin.sh scripts/test-validate-codex-plugin.sh` and `git diff --check` passed.
- `make release-check` reached version comparison; it failed only on the pre-existing remote GitHub release drift (`local 0.10.0` versus latest tag `0.10.1`), not Python execution. The environment provides Python 3.12.3; no separate Python 3.9 binary was installed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10531-6a6e40b1`
- Behind base: 0
- Ahead of base: 1