### PR TITLE
Expose federated and unavailable ADRs consistently through the CLI

### DIFF
--- a/crates/orbit-cli/src/command/adr.rs
+++ b/crates/orbit-cli/src/command/adr.rs
@@ -9,7 +9,7 @@
 //! input parsing and filter semantics.
 //!
 //! Mirrors the shape of `orbit docs` (ORB-00280): one-file parent command
-//! with a `list` subcommand and a `--json` toggle. Add new ADR
+//! with `list` and `show` subcommands and a `--json` toggle. Add new ADR
 //! subcommands here as they get promoted to the CLI surface.
 
 use clap::{Args, Subcommand};
@@ -29,6 +29,8 @@ pub struct AdrCommand {
 pub enum AdrSubcommand {
     /// List ADRs with optional filters
     List(AdrListArgs),
+    /// Show one ADR, including its body and artifact origin
+    Show(AdrShowArgs),
 }
 
 #[derive(Args)]
@@ -57,10 +59,19 @@ pub struct AdrListArgs {
     /// When set, return only ADRs with `legacy_validation = warned`
     #[arg(long = "validation-warned")]
     pub validation_warned: bool,
-    /// Include allocation rows whose body files are not locally readable as remote stubs
+    /// Include allocated federated ADRs whose body files are not locally readable as remote stubs
     #[arg(long = "include-remote")]
     pub include_remote: bool,
     /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args)]
+pub struct AdrShowArgs {
+    /// Canonical ADR ID (for example `ADR-0259`)
+    pub id: String,
+    /// Output as JSON, including typed unavailable/not-found errors
     #[arg(long)]
     pub json: bool,
 }
@@ -69,7 +80,17 @@ impl Execute for AdrCommand {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         match self.command {
             AdrSubcommand::List(args) => args.execute(runtime),
+            AdrSubcommand::Show(args) => args.execute(runtime),
         }
+    }
+}
+
+impl Execute for AdrShowArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let value = runtime.run_tool("orbit.adr.show", serde_json::json!({ "id": self.id }))?;
+
+        let _ = self.json;
+        crate::output::json::print_pretty(&value)
     }
 }
 

--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -499,13 +499,14 @@ impl Commands {
             }
             Commands::Adr(command) => {
                 use super::adr::AdrSubcommand;
-                let subcommand = match &command.command {
-                    AdrSubcommand::List(_) => "list",
+                let (subcommand, target_id, json) = match &command.command {
+                    AdrSubcommand::List(args) => ("list", None, args.json),
+                    AdrSubcommand::Show(args) => ("show", Some(args.id.as_str()), args.json),
                 };
                 CommandOperation::new(
                     RuntimeNeed::Required,
-                    Some(admin_meta("adr", Some(subcommand), Some("adr"), None)),
-                    None,
+                    Some(admin_meta("adr", Some(subcommand), Some("adr"), target_id)),
+                    json.then_some(true),
                     false,
                     runtime_dispatch!(Adr),
                 )

--- a/crates/orbit-cli/src/command/tests/operation.rs
+++ b/crates/orbit-cli/src/command/tests/operation.rs
@@ -103,6 +103,10 @@ fn json_error_preferences_are_derived_from_operations() {
         operation_for(&["orbit", "docs", "list"]).json_error_preference,
         None
     );
+    assert_eq!(
+        operation_for(&["orbit", "adr", "show", "ADR-0259", "--json"]).json_error_preference,
+        Some(true)
+    );
 }
 
 #[test]
@@ -125,4 +129,11 @@ fn audit_command_is_the_only_operation_without_audit_metadata() {
     assert_eq!(meta.command, "task");
     assert_eq!(meta.subcommand.as_deref(), Some("show"));
     assert_eq!(meta.target_id.as_deref(), Some("ORB-10200"));
+
+    let adr_meta = operation_for(&["orbit", "adr", "show", "ADR-0259"])
+        .audit_meta
+        .expect("ADR show is audited");
+    assert_eq!(adr_meta.command, "adr");
+    assert_eq!(adr_meta.subcommand.as_deref(), Some("show"));
+    assert_eq!(adr_meta.target_id.as_deref(), Some("ADR-0259"));
 }

--- a/crates/orbit-cli/src/output/json.rs
+++ b/crates/orbit-cli/src/output/json.rs
@@ -60,7 +60,10 @@ fn error_code(error: &OrbitError) -> &str {
             NotFoundKind::Job => "job_not_found",
             NotFoundKind::JobRun => "job_run_not_found",
             NotFoundKind::Activity => "activity_not_found",
-            NotFoundKind::Adr => "adr_not_found",
+            // ADR reads expose the same stable distinction as the tool and
+            // federation contracts: absent allocations are `not_found`, while
+            // allocated-but-unreadable bodies are `remote_artifact_unavailable`.
+            NotFoundKind::Adr => "not_found",
             NotFoundKind::DesignFeature => "design_feature_not_found",
             NotFoundKind::Learning => "learning_not_found",
             NotFoundKind::AgentSession => "agent_session_not_found",

--- a/crates/orbit-cli/tests/worktree_resolution.rs
+++ b/crates/orbit-cli/tests/worktree_resolution.rs
@@ -221,18 +221,8 @@ fn linked_worktree_artifacts_write_locally_and_remote_lists_return_stubs() {
     let local_orbit_entries = sorted_child_names(&linked_orbit);
     assert_eq!(local_orbit_entries, vec!["adrs", "learnings"]);
 
-    let federated_show = run_orbit_json(
-        &main_repo,
-        &home,
-        &[
-            "tool",
-            "run",
-            "orbit.adr.show",
-            "--input",
-            &format!(r#"{{"id":"{adr_id}","model":"codex"}}"#),
-        ],
-        None,
-    );
+    let federated_show =
+        run_orbit_json(&main_repo, &home, &["adr", "show", &adr_id, "--json"], None);
     assert_eq!(federated_show["id"], adr_id);
     assert!(
         federated_show["body"]
@@ -289,13 +279,13 @@ fn linked_worktree_artifacts_write_locally_and_remote_lists_return_stubs() {
     // subcommand, which routes through `runtime.run_tool` and so bypasses
     // `ensure_tool_agent_facing` while preserving the tool's filter
     // semantics (including `--include-remote`).
-    let adr_default = run_orbit_json(&main_repo, &home, &["adr", "list"], None);
+    let adr_default = run_orbit_json(&main_repo, &home, &["adr", "list", "--json"], None);
     assert!(!array_contains_id(&adr_default, &adr_id));
 
     let adr_remote = run_orbit_json(
         &main_repo,
         &home,
-        &["adr", "list", "--include-remote"],
+        &["adr", "list", "--include-remote", "--json"],
         None,
     );
     let adr_stub = find_id(&adr_remote, &adr_id);
@@ -320,18 +310,8 @@ fn linked_worktree_artifacts_write_locally_and_remote_lists_return_stubs() {
     assert_eq!(learning_stub["remote"], json!(true));
     assert!(learning_stub["body"].is_null());
 
-    let show_output = run_orbit_output(
-        &main_repo,
-        &home,
-        &[
-            "tool",
-            "run",
-            "orbit.adr.show",
-            "--input",
-            &format!(r#"{{"id":"{adr_id}","model":"codex"}}"#),
-        ],
-        None,
-    );
+    let show_output =
+        run_orbit_output(&main_repo, &home, &["adr", "show", &adr_id, "--json"], None);
     assert!(!show_output.status.success());
     let unavailable_payload: Value =
         serde_json::from_slice(&show_output.stdout).expect("structured unavailable error");
@@ -350,6 +330,17 @@ fn linked_worktree_artifacts_write_locally_and_remote_lists_return_stubs() {
             .get("body_path")
             .is_none()
     );
+
+    let unknown_output = run_orbit_output(
+        &main_repo,
+        &home,
+        &["adr", "show", "ADR-9999", "--json"],
+        None,
+    );
+    assert!(!unknown_output.status.success());
+    let unknown_payload: Value =
+        serde_json::from_slice(&unknown_output.stdout).expect("structured not-found error");
+    assert_eq!(unknown_payload["code"], "not_found");
 }
 
 fn assert_root_fields(value: &Value, shared_root: &Path, local_root: &Path) {


### PR DESCRIPTION
## Task

[ORB-10532](https://orbit-cli.com/tasks/ORB-10532) — Expose federated and unavailable ADRs consistently through the CLI

### Description

## Problem

The ADR CLI exposes only `list`; it has no `orbit adr show` command. Its list surface also omits allocations whose body is federated or unavailable. The tool surface can distinguish `remote_artifact_unavailable` from `not_found`, but an operator following the documented CLI path cannot make that distinction.

## Evidence

F2026-08-001 records `orbit adr --help` exposing only `list`, `orbit adr list --json` omitting ADR-0259 and ADR-0295, and `orbit tool run orbit.adr.show` resolving those allocated ids as remote-artifact failures when queried from the canonical workspace. In the current checkout, `crates/orbit-cli/src/command/adr.rs` still defines the list-only command, while `crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs` already contains the typed show/list resolver paths.

## Acceptance criteria

- `orbit adr show ADR-0259 --json` (or the equivalent documented command) returns the typed `remote_artifact_unavailable` result and credential-safe artifact origin for an allocated but unreadable federated ADR, while a truly unknown id remains `not_found`.
- `orbit adr list --json` has an explicit, documented way to include allocated federated/unavailable ADRs and does not silently omit ADR-0259 or ADR-0295 when those allocations are present.
- Local ADR precedence, status filtering, and no-remote-mutation behavior remain covered by deterministic CLI/tool tests.

### Acceptance Criteria

- orbit adr show ADR-0259 --json (or the equivalent documented command) returns typed remote_artifact_unavailable with credential-safe artifact origin for an allocated but unreadable federated ADR, while a truly unknown id remains not_found.
- orbit adr list --json has an explicit documented way to include allocated federated/unavailable ADRs and does not silently omit ADR-0259 or ADR-0295 when those allocations are present.
- Local ADR precedence, status filtering, and no-remote-mutation behavior remain covered by deterministic CLI/tool tests.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `orbit adr show <ADR-ID> --json`, forwarding through the existing typed ADR resolver and recording audited command metadata for the selected ADR.
- Documented `orbit adr list --include-remote --json` as the explicit path for allocated federated ADR stubs.
- Normalized unknown ADR JSON errors to `not_found`; allocated unreadable artifacts retain `remote_artifact_unavailable` and credential-safe origin fields.
- Extended deterministic worktree coverage for CLI local/federated show, unavailable stubs, unknown IDs, list inclusion, and no-remote-mutation behavior.
Assessment: focused change reuses the established tool resolver; no remote mutation path was added.
Validation:
- `cargo fmt --check`
- `cargo test -p orbit-cli --test worktree_resolution linked_worktree_artifacts_write_locally_and_remote_lists_return_stubs`
- `cargo test -p orbit-cli command::tests::operation`
- `make ci-fast`
Scope notes:
- Added `crates/orbit-cli/src/command/operation.rs`, `crates/orbit-cli/src/command/tests/operation.rs`, `crates/orbit-cli/src/output/json.rs`, and `crates/orbit-cli/tests/worktree_resolution.rs` to context_files because audited dispatch metadata, error-code parity, and direct CLI coverage were required.
Friction checkpoint: no new recurring tooling or instruction issue observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10532-6a6e428e`
- Behind base: 0
- Ahead of base: 1