### PR TITLE
[BLOCKED] Validate the workflow-tool self-dispatch guard and ship path on-box

### DIFF
--- a/crates/orbit-common/src/test_env.rs
+++ b/crates/orbit-common/src/test_env.rs
@@ -57,20 +57,37 @@ pub struct ScopedEnv {
 /// Clear `names` for the returned guard's lifetime, restoring prior values on
 /// drop. Names that are already unset are restored as unset.
 pub fn unset<'a>(names: impl IntoIterator<Item = &'a str>) -> ScopedEnv {
+    scoped(names.into_iter().map(|name| (name, None)))
+}
+
+/// Apply an explicit environment for the returned guard's lifetime, restoring
+/// prior values on drop. `Some(value)` sets the variable, `None` clears it.
+///
+/// Use this instead of a bespoke set/restore pair whenever a test needs a
+/// variable *present*: it captures the prior value the same way [`unset`] does
+/// and takes the same process-wide lock, so a test that populates
+/// `ORBIT_MANAGED_RUN_CONTEXT` cannot interleave with a sibling asserting the
+/// unmanaged default (ORB-10540). A guard built here and a guard built by
+/// [`unset`] are mutually exclusive; two independent locks would not be.
+pub fn scoped<'a>(vars: impl IntoIterator<Item = (&'a str, Option<&'a str>)>) -> ScopedEnv {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     let lock = LOCK
         .get_or_init(|| Mutex::new(()))
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let saved = names
-        .into_iter()
-        .map(|name| (name.to_string(), std::env::var(name).ok()))
+    let requested = vars.into_iter().collect::<Vec<_>>();
+    let saved = requested
+        .iter()
+        .map(|(name, _)| ((*name).to_string(), std::env::var(name).ok()))
         .collect::<Vec<_>>();
     // SAFETY: the guard holds the process-wide lock for the whole mutation
     // window, so no other guarded reader/writer runs concurrently.
     unsafe {
-        for (name, _) in &saved {
-            std::env::remove_var(name);
+        for (name, value) in &requested {
+            match value {
+                Some(value) => std::env::set_var(name, value),
+                None => std::env::remove_var(name),
+            }
         }
     }
     ScopedEnv { _lock: lock, saved }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/test_support.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/test_support.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use orbit_common::types::{
     McpCapability, OrbitError, Role, Task, TaskPriority, TaskStatus, TaskType, ToolSessionContext,
@@ -118,50 +117,41 @@ pub(crate) fn invalid_input_message<T>(result: Result<T, OrbitError>) -> String 
     }
 }
 
-pub(crate) struct UnmanagedToolEnvGuard {
-    _lock: MutexGuard<'static, ()>,
-    vars: Vec<(&'static str, Option<String>)>,
+/// Every variable an `orbit-engine` managed run exports that a tool-host test
+/// must state rather than inherit.
+const TOOL_ENV: [&str; 8] = [
+    "ORBIT_MANAGED_RUN_CONTEXT",
+    "ORBIT_TASK_ID",
+    "ORBIT_ACTIVE_TASK_ID",
+    "ORBIT_AGENT_NAME",
+    "ORBIT_AGENT_MODEL",
+    "ORBIT_RUN_ID",
+    "ORBIT_ACTIVITY_ID",
+    "ORBIT_STEP_INDEX",
+];
+
+/// Clear the managed-run envelope for the guard's lifetime.
+///
+/// Delegates to `orbit_common::test_env` rather than holding a private lock:
+/// the managed and unmanaged tool-host tests mutate the same process
+/// environment, so they have to serialize against *each other* and against the
+/// `test_env::unset` callers elsewhere in this crate. Two independent mutexes
+/// would let a managed-env test publish `ORBIT_RUN_ID` while a sibling was
+/// asserting its absence (ORB-10540).
+pub(crate) fn unmanaged_tool_env_guard() -> orbit_common::test_env::ScopedEnv {
+    orbit_common::test_env::unset(TOOL_ENV)
 }
 
-pub(crate) fn unmanaged_tool_env_guard() -> UnmanagedToolEnvGuard {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    let lock = LOCK
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let names = [
-        "ORBIT_MANAGED_RUN_CONTEXT",
-        "ORBIT_TASK_ID",
-        "ORBIT_ACTIVE_TASK_ID",
-        "ORBIT_AGENT_NAME",
-        "ORBIT_AGENT_MODEL",
-        "ORBIT_RUN_ID",
-        "ORBIT_ACTIVITY_ID",
-        "ORBIT_STEP_INDEX",
-    ];
-    let vars = names
-        .into_iter()
-        .map(|name| (name, std::env::var(name).ok()))
-        .collect::<Vec<_>>();
-    // SAFETY: the guard serializes these test env mutations and restores values on drop.
-    unsafe {
-        for (name, _) in &vars {
-            std::env::remove_var(name);
-        }
-    }
-    UnmanagedToolEnvGuard { _lock: lock, vars }
-}
-
-impl Drop for UnmanagedToolEnvGuard {
-    fn drop(&mut self) {
-        // SAFETY: the guard holds the serialization lock for the full mutation window.
-        unsafe {
-            for (name, value) in &self.vars {
-                match value {
-                    Some(value) => std::env::set_var(name, value),
-                    None => std::env::remove_var(name),
-                }
-            }
-        }
-    }
+/// Populate the exact envelope `orbit-engine` exports into a managed run's
+/// activity processes, leaving every other tool-env variable cleared.
+///
+/// This is the production input to `trusted_env_run_id`: the marker
+/// authenticates the envelope and `ORBIT_RUN_ID` carries the run. A test that
+/// hand-builds a host reporting a run id skips exactly this step.
+pub(crate) fn managed_tool_env_guard(run_id: &str) -> orbit_common::test_env::ScopedEnv {
+    orbit_common::test_env::scoped(TOOL_ENV.into_iter().map(|name| match name {
+        "ORBIT_MANAGED_RUN_CONTEXT" => (name, Some("1")),
+        "ORBIT_RUN_ID" => (name, Some(run_id)),
+        _ => (name, None),
+    }))
 }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/workflow_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/workflow_tools.rs
@@ -1,11 +1,221 @@
 use std::collections::BTreeSet;
 
 use chrono::Utc;
-use orbit_common::types::{AuditEventStatus, McpCapability, Role, ToolSessionContext};
+use orbit_common::types::{
+    AuditEventStatus, JobRunState, McpCapability, OrbitError, Role, ToolSessionContext,
+};
 use orbit_tools::ToolContext;
-use serde_json::json;
+use serde_json::{Value, json};
 
-use super::super::test_support::{run_tool_as_operator, test_runtime};
+use super::super::build_orbit_tool_host;
+use super::super::test_support::{
+    managed_tool_env_guard, run_tool_as_operator, test_runtime, unmanaged_tool_env_guard,
+};
+use crate::OrbitRuntime;
+
+/// The default-named ship job. Loaded from the *global* orbit root, so a
+/// fixture has to seed it there rather than in the workspace's `.orbit`.
+const SHIP_JOB: &str = "task_auto_pipeline";
+
+/// Task ids used by the ship fixtures. Deliberately synthetic: no shipped test
+/// fixture may name a real task, path, or workspace.
+const SHIP_TASK_IDS: [&str; 2] = ["TST-00001", "TST-00002"];
+
+/// Seed the stub sleep workflow under `<global root>/resources/jobs` so a ship
+/// submission resolves a real, enabled job asset without dragging in git or
+/// agent machinery.
+fn write_ship_job_asset(runtime: &OrbitRuntime) {
+    let jobs_dir = runtime.global_root().join("resources/jobs");
+    std::fs::create_dir_all(&jobs_dir).expect("create jobs dir");
+    std::fs::write(
+        jobs_dir.join(format!("{SHIP_JOB}.yaml")),
+        format!(
+            r#"schemaVersion: 2
+kind: Job
+metadata:
+  name: {SHIP_JOB}
+spec:
+  state: enabled
+  kind: workflow
+  steps:
+    - id: nap
+      spec:
+        type: deterministic
+        action: sleep
+        config: {{}}
+"#
+        ),
+    )
+    .expect("write ship job asset");
+}
+
+/// A terminal, resumable source run for the `run.resume` half of each
+/// direction. `resume` requires an interrupted/failed/timed-out source.
+fn seed_failed_run(runtime: &OrbitRuntime) -> String {
+    let now = Utc::now();
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run(SHIP_JOB, 1, now, Some(json!({"mode": "pr"})), None)
+        .expect("insert source run");
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, now, std::process::id())
+        .expect("start source run");
+    runtime
+        .stores()
+        .jobs()
+        .finalize_job_run(&run.run_id, JobRunState::Failed, now, Some(0))
+        .expect("finalize source run");
+    run.run_id
+}
+
+fn ship_input() -> Value {
+    json!({"task_ids": SHIP_TASK_IDS, "mode": "pr"})
+}
+
+fn capability_denial(result: Result<Value, OrbitError>) -> String {
+    match result {
+        Err(OrbitError::CapabilityDenied(message)) => message,
+        Err(error) => panic!("expected a capability denial, got {error:?}"),
+        Ok(value) => panic!("expected a capability denial, got {value}"),
+    }
+}
+
+/// ORB-10540: the in-run denial, driven by the environment rather than by a
+/// hand-built host.
+///
+/// Nothing here states a run id to the tool layer. `ORBIT_MANAGED_RUN_CONTEXT`
+/// authenticates the envelope and `ORBIT_RUN_ID` carries the id;
+/// `trusted_env_run_id` turns that pair into the host's task scope during
+/// `run_tool_with_context_and_role`, and the scope is what the guard reads.
+/// That env-to-scope step is the one the ORB-10534 suite mocked away, and the
+/// one GitHub CI cannot exercise because it exports no `ORBIT_*` at all.
+///
+/// The session still holds operator capability, so the authorization
+/// chokepoint admits the call: what refuses it is the self-dispatch guard, not
+/// a missing capability.
+#[test]
+fn managed_run_environment_denies_ship_and_resume_end_to_end() {
+    let _env = managed_tool_env_guard("jrun-test-managed");
+    let (_root, runtime, _repo_root) = test_runtime();
+    write_ship_job_asset(&runtime);
+    let source_run_id = seed_failed_run(&runtime);
+
+    // The step the mock skipped: a host built with no explicit run id still
+    // reports one, because the environment supplied it.
+    assert_eq!(
+        build_orbit_tool_host(&runtime, None, None)
+            .task_scope()
+            .run_id
+            .as_deref(),
+        Some("jrun-test-managed"),
+    );
+
+    let ship = capability_denial(run_tool_as_operator(
+        &runtime,
+        "orbit.workflow.ship",
+        ship_input(),
+    ));
+    assert!(ship.contains("managed runs cannot dispatch"), "{ship}");
+
+    let resume = capability_denial(run_tool_as_operator(
+        &runtime,
+        "orbit.workflow.run.resume",
+        json!({"id": source_run_id}),
+    ));
+    assert!(resume.contains("managed runs cannot dispatch"), "{resume}");
+
+    // The denial is the guard's, so nothing was dispatched: the seeded source
+    // run is still the only run in the workspace.
+    let runs = runtime
+        .list_job_runs(crate::command::job::JobRunListParams::default())
+        .expect("list runs");
+    assert_eq!(
+        runs.iter().map(|run| &run.run_id).collect::<Vec<_>>(),
+        vec![&source_run_id],
+        "a denied dispatch must not persist a run"
+    );
+}
+
+/// ORB-10540: the permitted direction, same tools and same operator session,
+/// with the managed-run envelope absent.
+///
+/// Without this the denial test above cannot distinguish a working guard from
+/// one that refuses unconditionally. Both verbs reach the runtime and produce
+/// real runs.
+#[test]
+fn unmanaged_environment_admits_operator_ship_and_resume() {
+    let _env = unmanaged_tool_env_guard();
+    let (_root, runtime, _repo_root) = test_runtime();
+    write_ship_job_asset(&runtime);
+    let source_run_id = seed_failed_run(&runtime);
+
+    // The mirror of the denial test's scope assertion: with no envelope there is
+    // no run scope, which is what leaves the guard inert.
+    assert_eq!(
+        build_orbit_tool_host(&runtime, None, None)
+            .task_scope()
+            .run_id,
+        None,
+    );
+
+    let shipped = run_tool_as_operator(&runtime, "orbit.workflow.ship", ship_input())
+        .expect("unmanaged operator ship is admitted");
+    assert_eq!(shipped["workflow"], json!("ship"));
+    assert_eq!(shipped["job_id"], json!(SHIP_JOB));
+    let shipped_run_id = shipped["run_id"].as_str().expect("ship run id").to_string();
+
+    let resumed = run_tool_as_operator(
+        &runtime,
+        "orbit.workflow.run.resume",
+        json!({"id": source_run_id}),
+    )
+    .expect("unmanaged operator resume is admitted");
+    assert_eq!(resumed["workflow"], json!("resume"));
+    assert_eq!(resumed["retry_source_run_id"], json!(source_run_id));
+
+    let resumed_run_id = resumed["run_id"].as_str().expect("resume run id");
+    let stored = runtime
+        .show_job_run(&shipped_run_id)
+        .expect("shipped run is persisted");
+    assert_eq!(stored.job_id, SHIP_JOB);
+    assert_eq!(
+        stored.input.expect("ship input")["task_ids"],
+        json!(SHIP_TASK_IDS)
+    );
+    assert_eq!(
+        runtime
+            .show_job_run(resumed_run_id)
+            .expect("resumed run is persisted")
+            .retry_source_run_id
+            .as_deref(),
+        Some(source_run_id.as_str())
+    );
+}
+
+/// ORB-10540: the guard is narrow. Inside the same managed envelope that
+/// refuses ship and resume, the read-only verbs still answer — a blanket
+/// in-run denial would break run observation for every agent.
+#[test]
+fn managed_run_environment_still_permits_run_observation() {
+    let _env = managed_tool_env_guard("jrun-test-managed-observe");
+    let (_root, runtime, _repo_root) = test_runtime();
+    let source_run_id = seed_failed_run(&runtime);
+
+    let shown = run_tool_as_operator(
+        &runtime,
+        "orbit.workflow.run.show",
+        json!({"id": source_run_id}),
+    )
+    .expect("run.show remains available inside a managed run");
+    assert_eq!(shown["run_id"], json!(source_run_id));
+
+    let listed = run_tool_as_operator(&runtime, "orbit.workflow.run.list", json!({}))
+        .expect("run.list remains available inside a managed run");
+    assert_eq!(listed["items"][0]["run_id"], json!(source_run_id));
+}
 
 #[test]
 fn operator_can_observe_runs_and_agent_denial_is_audited() {

--- a/crates/orbit-dashboard/src/api/tests/runs.rs
+++ b/crates/orbit-dashboard/src/api/tests/runs.rs
@@ -1461,3 +1461,91 @@ async fn ship_endpoint_rejects_duplicate_task_ids() {
             .is_some_and(|message| message.contains("duplicate task id"))
     );
 }
+
+/// ORB-10540: the MCP `orbit.workflow.ship` tool and `POST /api/workflows/ship`
+/// are two front doors onto one irreversible operation, so they have to agree.
+///
+/// Both calls name the same explicit task ids and neither states a mode, so the
+/// resolved ship mode is derived rather than echoed — the workspace binding here
+/// is `local`, which is *not* the endpoint's historical `pr` fallback, so a
+/// surface that resolved the mode its own way would show up as a mismatch.
+///
+/// The HTTP call goes first on purpose: the endpoint refuses a second dispatch
+/// for a task already carried by a non-terminal run, and the tool has no such
+/// guard, so this is the only order in which both surfaces can dispatch the same
+/// ids. (That asymmetry is a real finding, filed as ORB-10544 rather than fixed
+/// here.)
+///
+/// `ORBIT_OPERATOR` is how this crate's tests reach an operator-authorized tool
+/// call: `run_tool_with_context_and_role` — the form a validated MCP operator
+/// session takes — is crate-private to `orbit-core`, and the session-capability
+/// spelling of these same tools is covered by the `orbit-core` tool-host tests.
+/// Both spellings resolve to `McpCapability::Operator` at the one chokepoint and
+/// then execute the identical tool.
+#[tokio::test]
+async fn mcp_ship_tool_and_http_ship_endpoint_produce_equivalent_runs() {
+    const TASK_IDS: [&str; 2] = ["TST-00001", "TST-00002"];
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let global_root = tmp.path().join("global");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    write_replay_job_under(&global_root, "task_auto_pipeline");
+    let (orbit_dir, repo_root) = seed_ship_workspace(tmp.path(), "alpha");
+    let runtime = OrbitRuntime::from_roots_with_binding(
+        &global_root,
+        &orbit_dir,
+        WorkspaceRuntimeBinding {
+            workspace_id: "ws_alpha".to_string(),
+            repo_root,
+            ship_mode: ShipMode::Local,
+        },
+    )
+    .expect("build bound runtime");
+
+    let response = request_ship(runtime.clone(), Some(json!({ "task_ids": TASK_IDS }))).await;
+    let status = response.status();
+    let http = body_json(response).await;
+    assert_eq!(status, StatusCode::OK, "unexpected ship response: {http}");
+
+    // Scoped to the synchronous tool call: the guard holds a process-wide lock,
+    // which must not span an `.await`.
+    let tool = {
+        let _env = orbit_common::test_env::scoped(
+            std::iter::once((
+                orbit_common::authorization::OPERATOR_OVERRIDE_ENV,
+                Some("1"),
+            ))
+            .chain(
+                orbit_common::test_env::MANAGED_RUN_ENV
+                    .iter()
+                    .map(|name| (*name, None)),
+            ),
+        );
+        runtime
+            .run_tool("orbit.workflow.ship", json!({ "task_ids": TASK_IDS }))
+            .expect("operator ship through the tool surface")
+    };
+
+    assert_eq!(tool["workflow"], http["workflow"]);
+    assert_eq!(tool["job_id"], http["job_id"]);
+    assert_eq!(tool["job_id"], json!("task_auto_pipeline"));
+
+    let run_input = |payload: &Value| {
+        runtime
+            .show_job_run(payload["run_id"].as_str().expect("run id"))
+            .expect("submitted run is persisted")
+            .input
+            .expect("persisted run input")
+    };
+    let http_input = run_input(&http);
+    let tool_input = run_input(&tool);
+
+    assert_ne!(
+        http["run_id"], tool["run_id"],
+        "the two surfaces must produce distinct runs to compare"
+    );
+    assert_eq!(http_input["mode"], json!("local"));
+    assert_eq!(tool_input["mode"], http_input["mode"]);
+    assert_eq!(http_input["task_ids"], json!(TASK_IDS));
+    assert_eq!(tool_input["task_ids"], http_input["task_ids"]);
+}

--- a/docs/design/mcp-bridge/2_design.md
+++ b/docs/design/mcp-bridge/2_design.md
@@ -10,7 +10,7 @@ summary: Target design for a local Orbit MCP broker with one SSH hub link, hub-o
 tags: [mcp, remote-access, host-registry, bridge, ssh, routing]
 paths: ["crates/orbit-remote/**", "crates/orbit-mcp/**", "crates/orbit-core/**", "crates/orbit-tools/**", "crates/orbit-store/**", "crates/orbit-common/**"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access, orbit-search, project-learnings]
-related_artifacts: [ORB-00424, ORB-10257, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ORB-10330, ORB-10332, ORB-10534, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
+related_artifacts: [ORB-00424, ORB-10257, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ORB-10330, ORB-10332, ORB-10534, ORB-10540, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240]
 ---
 
 # Orbit MCP Bridge — Design
@@ -753,6 +753,18 @@ marker plus `ORBIT_RUN_ID` into a trusted in-band run scope; ship/resume reject
 that scope before host dispatch, preventing a leaf executor from recursively
 creating runs without trusting model-authored input.
 
+[ORB-10540] pins that guard from the environment rather than from a hand-built
+host: the tool-host tests populate the managed-process marker and `ORBIT_RUN_ID`
+and observe ship and resume refused, scrub the same envelope and observe both
+admitted, and show `run.show` / `run.list` still answering inside a managed run.
+The MCP ship tool and `POST /api/workflows/ship` are also compared directly for
+one explicit task-id selection and agree on job id, resolved ship mode, and
+coupled task ids. Two consequences of that comparison are recorded rather than
+changed here: GitHub CI exports no `ORBIT_*`, so only an on-box run exercises
+the env-to-scope path at all; and the dashboard endpoint's duplicate-dispatch
+guard is endpoint-local, so the MCP tool can still dispatch a second run for a
+task already in flight ([ORB-10544]).
+
 The fixed checkoutless `--hub` endpoint cannot yet execute these checkout-backed
 workflow tools, and remote spoke-to-hub execution is therefore deferred. This is
 an explicit current limitation rather than a fallback to process cwd or a local
@@ -992,5 +1004,8 @@ Required validation:
 - [ORB-10534] — registered the operator-only workflow family, added single-host
   operator broker capability selection, reused runtime ship/show/list/resume,
   and added the managed-run self-dispatch guard.
+- [ORB-10540] — validated that guard end to end from the managed-run environment
+  in both directions, and pinned MCP/HTTP ship equivalence for the same explicit
+  task ids.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Manual resolution required

Orbit preserved and pushed this task's pre-rebase candidate after the shipment pipeline stopped. This PR is intentionally blocked and must be reconciled manually before merge.

- Task: `ORB-10540`
- Run: `jrun-20260801-1854-3`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `9b7dcbcc16efe2400a4f610dd657bed7276fc795`
- Target base: `07ee92751c666be16355030503f3cf8e5d22239c`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: cli subprocess exceeded 5400s wall-clock timeout
```