### PR TITLE
Run embedded-asset portability checks in make ci-fast

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ ci-fast:
 	./scripts/check-changelog-style.sh
 	./scripts/check-error-translation.sh
 	./scripts/check-orphan-modules.sh
+	./scripts/check-embedded-asset-portability.py
 	./scripts/test-validate-codex-plugin.sh
 
 # Verify every workspace crate declares its stability tier

--- a/scripts/check-embedded-asset-portability.py
+++ b/scripts/check-embedded-asset-portability.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Keep embedded skills and activities portable across consumer workspaces."""
+
+from __future__ import annotations
+
+import re
+import sys
+import tempfile
+from argparse import ArgumentParser
+from pathlib import Path
+
+
+SOURCE_PATH = "crates/..."
+PRIVATE_NAMES = ("almanac", "dk-mac", "dk-server", "Constellation")
+PERSONAL_NAMES = ("Daniel",)
+
+
+def artifact_ids(content: str) -> list[str]:
+    """Return concrete workspace-local artifact IDs, not placeholders."""
+    boundary = r"(?<![A-Za-z0-9])"
+    patterns = (
+        rf"{boundary}ORB-\d+",
+        rf"{boundary}ADR-\d+",
+        rf"{boundary}L-\d{{3,}}",
+        rf"{boundary}F\d{{4}}-\d{{2}}-\d{{3}}",
+        rf"{boundary}T\d{{6,}}",
+    )
+    return [match.group() for pattern in patterns for match in re.finditer(pattern, content)]
+
+
+def violations(content: str) -> list[str]:
+    """Return all repository-portability violations in one embedded asset."""
+    found: list[str] = []
+    if "crates/" in content:
+        found.append(f"Orbit source path `{SOURCE_PATH}`")
+
+    for name in PRIVATE_NAMES:
+        if name in content:
+            found.append(f"private name `{name}`")
+    for name in PERSONAL_NAMES:
+        if name in content:
+            found.append(f"personal name `{name}` (state the role, not the person)")
+
+    if re.search(r'"model"\s*:\s*"codex"', content):
+        found.append("hard-coded agent model `codex`")
+
+    design_doc = re.search(r"(?<![A-Za-z0-9])\d_[a-z_]+\.md", content)
+    if design_doc:
+        found.append(f"fixed design-doc filename `{design_doc.group()}`")
+
+    found.extend(f"workspace-local artifact id `{artifact_id}`" for artifact_id in artifact_ids(content))
+    return found
+
+
+def failures_under(label: str, root: Path) -> list[str]:
+    failures: list[str] = []
+    for path in sorted(candidate for candidate in root.rglob("*") if candidate.is_file()):
+        relative = path.relative_to(root)
+        for violation in violations(path.read_text(encoding="utf-8")):
+            failures.append(f"{label}/{relative}: {violation}")
+    return failures
+
+
+def check_assets(root: Path) -> list[str]:
+    return failures_under("skills", root / "skills") + failures_under("activities", root / "activities")
+
+
+def verify_fixture_reporting() -> None:
+    """Prove that the fast check emits a useful path and violation."""
+    with tempfile.TemporaryDirectory(prefix="orbit-portability-") as temporary:
+        assets = Path(temporary)
+        fixture = assets / "skills" / "fixture.md"
+        fixture.parent.mkdir()
+        fixture.write_text("See ORB-10530 before handoff.\n", encoding="utf-8")
+        (assets / "activities").mkdir()
+
+        expected = "skills/fixture.md: workspace-local artifact id `ORB-10530`"
+        failures = check_assets(assets)
+        if failures != [expected]:
+            raise RuntimeError(
+                "temporary fixture did not report its relative path and violation: "
+                f"expected {expected!r}, got {failures!r}"
+            )
+
+
+def main() -> int:
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--assets-root",
+        type=Path,
+        help="assets root to scan (used by the fixture regression check)",
+    )
+    arguments = parser.parse_args()
+    repo_root = Path(__file__).resolve().parent.parent
+    assets = arguments.assets_root or repo_root / "crates" / "orbit-core" / "assets"
+
+    try:
+        verify_fixture_reporting()
+        failures = check_assets(assets)
+    except (OSError, RuntimeError) as error:
+        print(f"embedded-asset-portability: {error}", file=sys.stderr)
+        return 2
+
+    if failures:
+        print(
+            "embedded assets under crates/orbit-core/assets/{skills,activities}/ "
+            "are not repository-agnostic:",
+            file=sys.stderr,
+        )
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Task

[ORB-10530](https://orbit-cli.com/tasks/ORB-10530) — Run embedded-asset portability checks in make ci-fast

### Description

## Problem

The pre-handoff gate `make ci-fast` in `Makefile:113-124` does not check the repository-agnostic embedded-asset invariant. The current `embedded_assets_are_repository_agnostic` test at `crates/orbit-core/src/command/skill.rs:668-690` remains in the compiled `orbit-core` suite, and `scripts/ci-guardrails.sh` runs that suite, but `ci-fast` is intentionally no-compile and omits it. ORB-10521 removed the separate cross-surface plugin parity assertion, so this task must cover portability only.

## Evidence

In the current tree, `make ci-fast` invokes only formatting and shell guardrails (Makefile:113-124), while the portability test remains a Rust unit test (skill.rs:668-690). A task can therefore pass the agent gate while introducing a workspace-local artifact id or personal-name leak into an embedded skill/activity asset; the full CI test is the first repository-owned signal.

## Scope

Add a deterministic, no-compile portability check suitable for `make ci-fast`, wire it into that target, and retain the existing compiled regression test. Do not restore plugin-to-bundled-skill byte parity.

## Acceptance criteria

- Running `make ci-fast` executes the embedded skills/activities portability check and reports the offending relative asset path and violation when a temporary fixture contains a forbidden workspace-local reference.
- The check passes on the current tree and remains independent of the removed plugin parity contract; `cargo test -p orbit-core --lib embedded_assets_are_repository_agnostic` remains available as defense in depth.
- The implementation uses only existing repository tooling or a checked-in script and does not add a compile step to `ci-fast`.

### Acceptance Criteria

- Running make ci-fast executes the embedded skills/activities portability check and reports the offending relative asset path and violation when a temporary fixture contains a forbidden workspace-local reference.
- The check passes on the current tree and remains independent of the removed plugin parity contract; cargo test -p orbit-core --lib embedded_assets_are_repository_agnostic remains available as defense in depth.
- The implementation uses only existing repository tooling or a checked-in script and does not add a compile step to ci-fast.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added scripts/check-embedded-asset-portability.py, a deterministic Python guard that scans only embedded skills and activities for the repository-local leak families covered by the retained Rust regression.
- The guard self-tests a temporary fixture and exposes --assets-root for fixture validation; it reports skills/fixture.md plus workspace-local artifact ID ORB-10530 on failure.
- Wired the no-compile guard into make ci-fast; no plugin parity check was added and the compiled Rust test remains unchanged.
Assessment: Scoped, no-compile portability defense now runs in the agent handoff gate.
Validation:
- make ci-fast
- Temporary fixture via scripts/check-embedded-asset-portability.py --assets-root (expected failure reported relative path and violation)
- cargo test -p orbit-core --lib embedded_assets_are_repository_agnostic
- git diff --check

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10530-6a6e5a8e`
- Behind base: 0
- Ahead of base: 1