### PR TITLE
Require --force before workspace init rewrites an existing registration

### DIFF
--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -12,7 +12,7 @@ use orbit_core::command::init::{InitOptions, init_workspace_at_root};
 use orbit_remote::runtime::RemoteRuntimeFactory;
 use orbit_remote::workspace_registry;
 use orbit_remote::{HostIdentityState, HostMode, inspect_host_identity};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::role::CliCheckoutRole;
 use super::support::{detect_git_remote, dir_name_or_fallback, ensure_orbit_gitignore_entry};
@@ -54,6 +54,10 @@ pub struct WorkspaceInitArgs {
     /// No-op (kept for backwards compatibility — defaults are always refreshed on init)
     #[arg(long, hide = true)]
     pub refresh_defaults: bool,
+    /// Reconcile an already registered workspace after validating its complete
+    /// logical, checkout, and durable-identity binding.
+    #[arg(long)]
+    pub force: bool,
 }
 
 impl WorkspaceInitArgs {
@@ -176,6 +180,48 @@ impl WorkspaceInitArgs {
             _ => {}
         }
 
+        let name = self.name.unwrap_or_else(|| dir_name_or_fallback(cwd));
+        let id = canonical_workspace_id(&name);
+        let git_remote = detect_git_remote(cwd);
+        let mut registry = workspace_registry::load_registry_from(registry_path)?;
+        let existing_workspace = registry
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.id == id);
+        let existing_checkout = registry
+            .checkouts
+            .iter()
+            .find(|checkout| checkout.repo_root == cwd || checkout.orbit_dir == orbit_dir);
+        let reconciling_existing = existing_workspace.is_some() || existing_checkout.is_some();
+
+        if reconciling_existing && !self.force {
+            return Err(OrbitError::WorkspaceError(format!(
+                "workspace registration already exists for '{}' or '{}'; rerun with --force to reconcile it",
+                id,
+                cwd.display()
+            )));
+        }
+
+        if reconciling_existing {
+            validate_existing_registration(
+                existing_workspace,
+                existing_checkout,
+                cwd,
+                orbit_dir,
+                &id,
+            )?;
+            validate_workspace_identity(orbit_dir, &id)?;
+        } else if let Some(identity) = read_workspace_identity(orbit_dir)?
+            && identity.workspace_id != id
+        {
+            return Err(OrbitError::WorkspaceError(format!(
+                "workspace identity '{}' at '{}' conflicts with requested workspace '{}'; refusing to overwrite it",
+                identity.workspace_id,
+                orbit_dir.join("config.yaml").display(),
+                id
+            )));
+        }
+
         init_workspace_at_root(
             orbit_dir,
             InitOptions {
@@ -186,13 +232,6 @@ impl WorkspaceInitArgs {
             },
         )?;
         ensure_orbit_gitignore_entry(cwd, orbit_dir)?;
-
-        let name = self.name.unwrap_or_else(|| dir_name_or_fallback(cwd));
-
-        let id = canonical_workspace_id(&name);
-        let git_remote = detect_git_remote(cwd);
-
-        let mut registry = workspace_registry::load_registry_from(registry_path)?;
         let mut checkout_added = false;
         if let Some(existing) = registry.workspaces.iter_mut().find(|w| w.id == id) {
             if let Some(ship_mode) = self.ship_mode {
@@ -252,7 +291,9 @@ impl WorkspaceInitArgs {
             )?;
         }
         workspace_registry::save_registry_to(&registry, registry_path)?;
-        write_workspace_identity(orbit_dir, &id)?;
+        if !reconciling_existing {
+            write_workspace_identity(orbit_dir, &id)?;
+        }
         orbit_core::runtime::HubCoordinationExecutor::register_workspace(global_root, &id, &name)?;
 
         Ok(WorkspaceInitResult {
@@ -292,6 +333,75 @@ pub(super) fn canonical_workspace_id(name: &str) -> String {
 struct WorkspaceIdentityDocument<'a> {
     schema_version: u32,
     workspace_id: &'a str,
+}
+
+#[derive(Deserialize)]
+struct StoredWorkspaceIdentity {
+    schema_version: u32,
+    workspace_id: String,
+}
+
+fn validate_existing_registration(
+    workspace: Option<&Workspace>,
+    checkout: Option<&WorkspaceCheckout>,
+    cwd: &Path,
+    orbit_dir: &Path,
+    workspace_id: &str,
+) -> Result<(), OrbitError> {
+    let workspace = workspace.ok_or_else(|| {
+        OrbitError::WorkspaceError(format!(
+            "cannot reconcile workspace '{workspace_id}': the target checkout is bound to a different durable workspace"
+        ))
+    })?;
+    let checkout = checkout.ok_or_else(|| {
+        OrbitError::WorkspaceError(format!(
+            "cannot reconcile workspace '{workspace_id}': its durable record has no target checkout binding"
+        ))
+    })?;
+    if checkout.workspace_id != workspace.id
+        || checkout.repo_root != cwd
+        || checkout.orbit_dir != orbit_dir
+    {
+        return Err(OrbitError::WorkspaceError(format!(
+            "cannot reconcile workspace '{workspace_id}': logical record and checkout binding do not match the requested checkout"
+        )));
+    }
+    Ok(())
+}
+
+fn read_workspace_identity(
+    orbit_dir: &Path,
+) -> Result<Option<StoredWorkspaceIdentity>, OrbitError> {
+    let path = orbit_dir.join("config.yaml");
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content =
+        std::fs::read_to_string(&path).map_err(|error| OrbitError::Io(error.to_string()))?;
+    let identity = serde_yaml::from_str(&content).map_err(|error| {
+        OrbitError::WorkspaceError(format!(
+            "invalid workspace identity '{}': {error}",
+            path.display()
+        ))
+    })?;
+    Ok(Some(identity))
+}
+
+fn validate_workspace_identity(orbit_dir: &Path, workspace_id: &str) -> Result<(), OrbitError> {
+    let path = orbit_dir.join("config.yaml");
+    let identity = read_workspace_identity(orbit_dir)?.ok_or_else(|| {
+        OrbitError::WorkspaceError(format!(
+            "cannot reconcile workspace '{workspace_id}': checkout identity '{}' is missing",
+            path.display()
+        ))
+    })?;
+    if identity.schema_version != 1 || identity.workspace_id != workspace_id {
+        return Err(OrbitError::WorkspaceError(format!(
+            "cannot reconcile workspace '{workspace_id}': checkout identity '{}' does not match",
+            path.display()
+        )));
+    }
+    Ok(())
 }
 
 fn write_workspace_identity(orbit_dir: &Path, workspace_id: &str) -> Result<(), OrbitError> {

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -16,7 +16,7 @@ use super::super::show::format_workspace_show;
 use super::super::support::orbit_gitignore_block;
 
 #[test]
-fn workspace_reinit_merges_explicit_registration_updates_without_resetting_authored_state() {
+fn workspace_reinit_requires_force_and_force_reconciles_matching_registration() {
     let workspace = tempdir().expect("workspace tempdir");
     let home = tempdir().expect("home tempdir");
     let global = home.path().join(".orbit");
@@ -31,7 +31,7 @@ fn workspace_reinit_merges_explicit_registration_updates_without_resetting_autho
 
     let _env = EnvGuard::acquire().home(home.path()).cwd(workspace.path());
 
-    let init = |base_branch: Option<&str>, ship_mode: Option<&str>| WorkspaceInitArgs {
+    let init = |base_branch: Option<&str>, ship_mode: Option<&str>, force| WorkspaceInitArgs {
         name: Some("reinit-merge".to_string()),
         base_branch: base_branch.map(str::to_string),
         ship_mode: ship_mode.map(str::to_string),
@@ -41,9 +41,10 @@ fn workspace_reinit_merges_explicit_registration_updates_without_resetting_autho
         mcp: false,
         inject_agent_rules: false,
         refresh_defaults: false,
+        force,
     };
 
-    init(Some("agent-main"), None)
+    init(Some("agent-main"), None, false)
         .execute_without_runtime(None)
         .expect("initial workspace init");
 
@@ -70,7 +71,24 @@ policy:
     let routine_path = workspace.path().join(".orbit/routines/ship_sweep.yaml");
     std::fs::write(&routine_path, authored_routine).expect("author routine");
 
-    init(None, Some("pr"))
+    let registry_bytes = std::fs::read_to_string(&registry_path).expect("read protected registry");
+    let identity_path = workspace.path().join(".orbit/config.yaml");
+    let identity_bytes = std::fs::read_to_string(&identity_path).expect("read protected identity");
+    let error = init(None, Some("pr"), false)
+        .execute_without_runtime(None)
+        .expect_err("existing checkout must require force")
+        .to_string();
+    assert!(error.contains("already exists"), "unexpected: {error}");
+    assert_eq!(
+        std::fs::read_to_string(&registry_path).expect("read registry"),
+        registry_bytes
+    );
+    assert_eq!(
+        std::fs::read_to_string(&identity_path).expect("read identity"),
+        identity_bytes
+    );
+
+    init(None, Some("pr"), true)
         .execute_without_runtime(None)
         .expect("re-init with explicit PR mode");
     let after_ship_mode = workspace_registry::load_registry_from(&registry_path)
@@ -93,7 +111,7 @@ policy:
         authored_routine
     );
 
-    init(None, None)
+    init(None, None, true)
         .execute_without_runtime(None)
         .expect("re-init with omitted registration options");
     let after_omitted = workspace_registry::load_registry_from(&registry_path)
@@ -111,7 +129,7 @@ policy:
         authored_routine
     );
 
-    init(Some("release"), None)
+    init(Some("release"), None, true)
         .execute_without_runtime(None)
         .expect("re-init with explicit base branch");
     let after_base_branch = workspace_registry::load_registry_from(&registry_path)
@@ -124,7 +142,7 @@ policy:
     assert_eq!(after_base_branch.ship_mode.as_deref(), Some("pr"));
 
     let before_invalid = after_base_branch.clone();
-    let error = init(None, Some("invalid"))
+    let error = init(None, Some("invalid"), true)
         .execute_without_runtime(None)
         .expect_err("invalid ship mode must fail closed");
     assert!(error.to_string().contains("unknown ship mode 'invalid'"));
@@ -135,6 +153,102 @@ policy:
         .next()
         .expect("registered workspace");
     assert_eq!(after_invalid, before_invalid);
+}
+
+#[test]
+fn workspace_init_rejects_existing_durable_id_without_force() {
+    let first = tempdir().expect("first workspace tempdir");
+    let second = tempdir().expect("second workspace tempdir");
+    let home = tempdir().expect("home tempdir");
+    let global = home.path().join(".orbit");
+    std::fs::create_dir_all(&global).expect("create global orbit");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 1\nmachine_id = \"hm_id_collision\"\nhost_id = \"id-collision\"\nmode = \"standalone\"\n",
+    )
+    .expect("write host identity");
+    let _env = EnvGuard::acquire().home(home.path()).cwd(first.path());
+    let args = |force| WorkspaceInitArgs {
+        name: Some("shared-id".to_string()),
+        base_branch: Some("agent-main".to_string()),
+        ship_mode: None,
+        role: None,
+        owner: None,
+        task_id_start: None,
+        mcp: false,
+        inject_agent_rules: false,
+        refresh_defaults: false,
+        force,
+    };
+    args(false)
+        .execute_without_runtime(None)
+        .expect("initial workspace init");
+    let registry_path = global.join("workspaces.json");
+    let registry_bytes = std::fs::read_to_string(&registry_path).expect("read protected registry");
+
+    std::env::set_current_dir(second.path()).expect("switch to second workspace");
+    let error = args(false)
+        .execute_without_runtime(None)
+        .expect_err("existing durable ID must require force")
+        .to_string();
+    assert!(error.contains("already exists"), "unexpected: {error}");
+    assert_eq!(
+        std::fs::read_to_string(&registry_path).expect("read registry"),
+        registry_bytes
+    );
+    assert!(!second.path().join(".orbit").exists());
+}
+
+#[test]
+fn forced_workspace_reconciliation_preserves_registry_and_identity_on_validation_failure() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let home = tempdir().expect("home tempdir");
+    let global = home.path().join(".orbit");
+    std::fs::create_dir_all(&global).expect("create global orbit");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 1\nmachine_id = \"hm_force_failure\"\nhost_id = \"force-failure\"\nmode = \"standalone\"\n",
+    )
+    .expect("write host identity");
+    let _env = EnvGuard::acquire().home(home.path()).cwd(workspace.path());
+    let args = |force| WorkspaceInitArgs {
+        name: Some("force-failure".to_string()),
+        base_branch: Some("agent-main".to_string()),
+        ship_mode: Some("pr".to_string()),
+        role: None,
+        owner: None,
+        task_id_start: None,
+        mcp: false,
+        inject_agent_rules: false,
+        refresh_defaults: false,
+        force,
+    };
+    args(false)
+        .execute_without_runtime(None)
+        .expect("initial workspace init");
+    let registry_path = global.join("workspaces.json");
+    let identity_path = workspace.path().join(".orbit/config.yaml");
+    std::fs::write(
+        &identity_path,
+        "schema_version: 1\nworkspace_id: ws_other\n",
+    )
+    .expect("corrupt identity for validation test");
+    let registry_bytes = std::fs::read_to_string(&registry_path).expect("read protected registry");
+    let identity_bytes = std::fs::read_to_string(&identity_path).expect("read protected identity");
+
+    let error = args(true)
+        .execute_without_runtime(None)
+        .expect_err("mismatched identity must reject forced reconciliation")
+        .to_string();
+    assert!(error.contains("checkout identity"), "unexpected: {error}");
+    assert_eq!(
+        std::fs::read_to_string(&registry_path).expect("read registry"),
+        registry_bytes
+    );
+    assert_eq!(
+        std::fs::read_to_string(&identity_path).expect("read identity"),
+        identity_bytes
+    );
 }
 
 #[test]
@@ -163,6 +277,7 @@ fn multi_host_workspace_init_persists_an_explicit_local_owner() {
             mcp: false,
             inject_agent_rules: false,
             refresh_defaults: false,
+            force: false,
         }
         .execute_without_runtime(None)
         .expect("explicit multi-host workspace init");
@@ -203,6 +318,7 @@ fn spoke_workspace_init_can_atomically_declare_a_remote_owner_replica() {
         mcp: false,
         inject_agent_rules: false,
         refresh_defaults: false,
+        force: false,
     }
     .execute_without_runtime(None)
     .expect("atomic replica workspace init");
@@ -253,6 +369,7 @@ fn invalid_replica_init_fails_before_workspace_artifacts_or_registry_mutation() 
             mcp: false,
             inject_agent_rules: false,
             refresh_defaults: false,
+            force: false,
         }
         .execute_without_runtime(None)
         .expect_err("invalid replica declaration must fail before bootstrap")
@@ -317,7 +434,7 @@ fn workspace_init_seeds_disabled_routines_and_reinit_preserves_authored_files() 
 
     let _env = EnvGuard::acquire().home(home.path()).cwd(workspace.path());
 
-    let init = || WorkspaceInitArgs {
+    let init = |force| WorkspaceInitArgs {
         name: Some("routine-seed-test".to_string()),
         base_branch: Some("agent-main".to_string()),
         ship_mode: Some("pr".to_string()),
@@ -327,8 +444,9 @@ fn workspace_init_seeds_disabled_routines_and_reinit_preserves_authored_files() 
         mcp: false,
         inject_agent_rules: false,
         refresh_defaults: false,
+        force,
     };
-    init()
+    init(false)
         .execute_without_runtime(None)
         .expect("first workspace init");
 
@@ -376,7 +494,7 @@ policy:
     std::fs::remove_file(routines_dir.join("task_triage.yaml"))
         .expect("remove one default routine");
 
-    init()
+    init(true)
         .execute_without_runtime(None)
         .expect("second workspace init");
 
@@ -422,6 +540,7 @@ fn workspace_init_seeds_auto_detected_mcp_configs() {
         mcp: true,
         inject_agent_rules: false,
         refresh_defaults: false,
+        force: false,
     }
     .execute_without_runtime(None);
 
@@ -471,6 +590,7 @@ fn workspace_init_skips_mcp_by_default() {
         mcp: false,
         inject_agent_rules: false,
         refresh_defaults: false,
+        force: false,
     }
     .execute_without_runtime(None);
 
@@ -512,6 +632,7 @@ fn workspace_init_under_home_with_global_orbit_creates_repo_orbit() {
         mcp: false,
         inject_agent_rules: false,
         refresh_defaults: false,
+        force: false,
     }
     .execute_without_runtime(None);
 
@@ -546,6 +667,7 @@ fn workspace_init_appends_orbit_to_existing_gitignore() {
         mcp: false,
         inject_agent_rules: false,
         refresh_defaults: false,
+        force: false,
     }
     .execute_without_runtime(None);
 
@@ -569,7 +691,7 @@ fn workspace_init_replaces_legacy_bare_orbit_gitignore_line_with_managed_block()
 
     let _env = EnvGuard::acquire().home(home.path()).cwd(workspace.path());
 
-    let init = || WorkspaceInitArgs {
+    let init = |force| WorkspaceInitArgs {
         name: None,
         base_branch: Some("main".to_string()),
         ship_mode: None,
@@ -579,9 +701,10 @@ fn workspace_init_replaces_legacy_bare_orbit_gitignore_line_with_managed_block()
         mcp: false,
         inject_agent_rules: false,
         refresh_defaults: false,
+        force,
     };
 
-    init()
+    init(false)
         .execute_without_runtime(None)
         .expect("workspace init");
     let expected = format!("target/\n{}", orbit_gitignore_block());
@@ -592,7 +715,7 @@ fn workspace_init_replaces_legacy_bare_orbit_gitignore_line_with_managed_block()
     );
 
     // Re-init is idempotent: the block is not duplicated or reordered.
-    init()
+    init(true)
         .execute_without_runtime(None)
         .expect("workspace re-init");
     assert_eq!(
@@ -622,6 +745,7 @@ fn workspace_init_from_git_subdir_gitignores_repo_orbit_dir() {
         mcp: false,
         inject_agent_rules: false,
         refresh_defaults: false,
+        force: false,
     }
     .execute_without_runtime(None);
 
@@ -652,6 +776,7 @@ fn workspace_init_with_root_override_uses_custom_registry() {
         mcp: false,
         inject_agent_rules: false,
         refresh_defaults: false,
+        force: false,
     }
     .execute_without_runtime(Some(custom_root.as_path()));
 
@@ -702,6 +827,7 @@ fn workspace_init_does_not_create_orbitignore() {
         mcp: false,
         inject_agent_rules: false,
         refresh_defaults: false,
+        force: false,
     }
     .execute_without_runtime(None);
 
@@ -734,6 +860,7 @@ fn workspace_init_preserves_existing_orbitignore() {
         mcp: false,
         inject_agent_rules: false,
         refresh_defaults: false,
+        force: false,
     }
     .execute_without_runtime(None);
 
@@ -767,6 +894,7 @@ fn workspace_init_with_root_override_does_not_modify_repo_gitignore() {
         mcp: false,
         inject_agent_rules: false,
         refresh_defaults: false,
+        force: false,
     }
     .execute_without_runtime(Some(custom_root.as_path()));
 
@@ -824,6 +952,7 @@ fn nameless_tmp_workspace_registers_only_in_isolated_registry() {
             mcp: false,
             inject_agent_rules: false,
             refresh_defaults: false,
+            force: false,
         }
         .execute_without_runtime(None)
         .expect("nameless workspace init");

--- a/crates/orbit-remote/src/workspace_registry.rs
+++ b/crates/orbit-remote/src/workspace_registry.rs
@@ -119,6 +119,15 @@ pub fn register_checkout(
             checkout.workspace_id
         )));
     }
+    if let Some(existing) = registry.checkouts.iter().find(|existing| {
+        existing.repo_root == checkout.repo_root || existing.orbit_dir == checkout.orbit_dir
+    }) {
+        return Err(OrbitError::WorkspaceError(format!(
+            "checkout path '{}' is already registered to workspace '{}'",
+            checkout.repo_root.display(),
+            existing.workspace_id
+        )));
+    }
     registry.checkouts.push(checkout);
     Ok(())
 }


### PR DESCRIPTION
## Task

[ORB-10543](https://orbit-cli.com/tasks/ORB-10543) — Require --force before workspace init rewrites an existing registration

### Description

## Problem

`orbit workspace init` can encounter a path or durable workspace identity that is already present in the host registry and silently replace that registration's identity or base-branch metadata. During ORB-10536 recovery, this split Bridge's host registration from its durable task-store identity and changed its base from `agent-main` to `main`.

## Required behavior

Treat an existing registration as immutable by default. If either the target checkout path or durable workspace ID is already registered, a repeated init/register attempt without `--force` must fail clearly and leave the registry byte-for-byte unchanged.

With explicit `--force`, Orbit may reconcile the existing entry, but it must validate the proposed logical workspace record, checkout binding, base branch, and the checkout's `.orbit/config.yaml` identity before committing them atomically. Any validation or write failure must preserve the prior registration.

This task resolves F2026-08-004. F2026-08-001 contains the resulting service incident and recovery evidence.

### Acceptance Criteria

- Re-initializing a checkout path already present in the registry without --force returns a clear already-registered error and does not change the registry.
- Re-initializing a durable workspace ID already present in the registry without --force returns the same protected result.
- An explicit --force can update the intended registration only after the logical record, checkout binding, base branch, and checkout identity validate together.
- A failed forced reconciliation leaves the prior registry byte-for-byte unchanged and does not partially rewrite .orbit/config.yaml.
- Regression tests cover existing-path collision, existing-ID collision, successful forced reconciliation, and failed forced reconciliation.
- The focused workspace-init and registry test suites pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added an explicit `orbit workspace init --force` gate before any existing path or durable workspace-ID registration can be reconciled.
- Forced reconciliation now validates the logical record, exact checkout binding, and `.orbit/config.yaml` workspace identity before it updates registration metadata; existing identities are not rewritten.
- Hardened checkout registration against duplicate repository-root or Orbit-directory bindings.
- Added regression coverage for unforced path and durable-ID collisions, successful forced metadata reconciliation, and failed forced identity validation preserving both registry and config bytes.
Assessment: Scoped workspace-init and registry protection is implemented with focused regression coverage.
Validation:
- cargo test -p orbit-cli command::workspace::tests::init
- cargo test -p orbit-remote workspace_registry
- make ci-fast

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10543-6a6e5a86`
- Behind base: 0
- Ahead of base: 1