### PR TITLE
Ship friction curation as a disabled default auto-task

### DIFF
--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -70,6 +70,17 @@ policy:
 "#;
     let routine_path = workspace.path().join(".orbit/routines/ship_sweep.yaml");
     std::fs::write(&routine_path, authored_routine).expect("author routine");
+    let auto_task_path = workspace
+        .path()
+        .join(".orbit/auto_tasks/friction-curation.yaml");
+    let seeded_auto_task =
+        std::fs::read_to_string(&auto_task_path).expect("read seeded friction-curation definition");
+    assert!(
+        seeded_auto_task.contains("enabled: false"),
+        "workspace initialization must not enable a default auto-task"
+    );
+    let authored_auto_task = "operator-authored auto-task definition\n";
+    std::fs::write(&auto_task_path, authored_auto_task).expect("author auto-task definition");
 
     let registry_bytes = std::fs::read_to_string(&registry_path).expect("read protected registry");
     let identity_path = workspace.path().join(".orbit/config.yaml");
@@ -109,6 +120,11 @@ policy:
     assert_eq!(
         std::fs::read_to_string(&routine_path).expect("read authored routine"),
         authored_routine
+    );
+    assert_eq!(
+        std::fs::read_to_string(&auto_task_path).expect("read authored auto-task definition"),
+        authored_auto_task,
+        "workspace --force reconciliation must preserve an authored auto-task definition"
     );
 
     init(None, None, true)

--- a/crates/orbit-core/assets/auto_tasks/friction-curation.yaml
+++ b/crates/orbit-core/assets/auto_tasks/friction-curation.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+name: friction-curation
+description: Daily evidence-first deduplication, verification, resolution, and task filing for open friction records
+enabled: false
+schedule:
+  cron: 15 7 * * *
+template:
+  title: Curate open friction records
+  description: |-
+    Curate the complete open-friction corpus in this workspace. The durable output is friction status changes and fix tasks; the execution summary is only an audit trail.
+
+    ## Rules and command surfaces
+
+    - Never edit `.orbit/frictions/**` by hand. Status and body changes must go through the operator CLI: `orbit friction update <id> ...` and `orbit friction resolve <id> --json`, so resolution metadata is stamped by the store.
+    - Frictions are not indexed by `orbit search`. List them with `orbit friction list --status open --limit 500 --offset <n> --json`; keep paging until a page is shorter than the limit. Use `--q '<terms>'` plus `--status open` to retrieve likely matches when grouping candidates. Do not infer an empty corpus from `orbit search`.
+    - Search task coverage with `orbit search '<distinctive symptom or component terms>' --kind task --all --json`, then inspect plausible matches with `orbit task show <id> --json`.
+    - Treat rejected tasks as historical coverage for deduplication and audit mapping, even though they are not active coverage. For every plausible rejected task, inspect the latest rejection rationale from `orbit task show <id> --json` (including its newest history/comment evidence) before deciding the friction's disposition; do not infer meaning from the status alone.
+    - Before filing any fix task, read the installed `orbit-task` skill completely. In a source checkout where installed skills are unavailable, read `crates/orbit-core/assets/skills/orbit-task/SKILL.md` relative to the repository root. Follow it as the authority for general task shape, quality, provenance, and lifecycle rules. Do not duplicate that workflow here. Keep these friction-specific requirements: use the current workspace path; include evidence/reproduction and canonical modification-target `context_files`; add the `friction-curation` tag; and add exactly one `{"type":"resolves","target":"<canonical-friction-id>"}` relation for the canonical friction.
+    - After every task creation, immediately read it back with `orbit.task.show <task-id> --json` (or the equivalent `orbit.task.show` tool) and verify that its relations contain exactly one `{"type":"resolves","target":"<canonical-friction-id>"}` edge. A task with a missing or incorrect edge does not count as coverage: repair its relations through `orbit.task.update` before continuing, then read it back again and verify the repaired edge. Filing a task does not itself fix the friction: leave that friction open. The relation resolves it only when the task reaches `done`.
+    - Classify every rejected covering task after inspecting its latest rationale. A **terminal rejection** (intentional behavior, accepted ADR or policy decision, duplicate, obsolete report, or explicit won't-fix) can support closure only after appending a CLI/store resolution note that names the rejected task and cites the decision evidence, then resolving the friction through `orbit friction resolve <id> --json`. An **administrative rejection** (wrong workspace, malformed or mixed scope, stale evidence, or re-homing/re-authoring required) does not fix the friction: keep it open, record the `<friction-id> -> <rejected-task-id>` mapping and the required next action, and never describe it as fixed. When the current workspace owns the issue, file at most one correctly scoped active replacement; otherwise report the re-home need without creating a wrong-lane task.
+    - If a proposed fix task widens a fail-closed guard, its description and acceptance criteria must enumerate the neighboring rejection guarantees that must remain rejected (wrong workspace, malformed or mixed scope, stale evidence, re-homing/re-authoring required, and any other adjacent invalid case found during inspection) and require validation evidence for each preserved rejection. A positive reproduction alone is insufficient.
+    - Fail open. Zero open frictions or a fully current corpus is a successful no-op. When evidence is genuinely ambiguous, leave the friction open and report what remains unknown.
+
+    ## Pass
+
+    1. Snapshot every open friction using the paginated list command above.
+    2. Dedupe by underlying issue, not wording, across active, done, and rejected task history. For each group, retain the earliest well-evidenced record as canonical unless a later record materially improves the reproduction. Preserve each duplicate's existing body, append a short resolution note naming the canonical friction id and the matching evidence, then run the CLI update/resolve path. Re-query the group with `orbit friction list --status open --q '<terms>' --json` to confirm only the canonical record remains open.
+    3. Verify every surviving open friction against the current tree and current executable behavior. Cite exact files/lines, command output, tests, run ids, or version state. If it no longer reproduces, preserve the body, append the checked evidence and resolution reason, and resolve it through the CLI. If it is still real, retain it open with the evidence gathered for task filing. Do not guess.
+    4. For every verified-real survivor, search existing tasks using the task search/show commands above, including rejected tasks as historical coverage, and inspect the latest rejection rationale for every plausible rejected match. If active or done coverage clearly covers it, do not file a duplicate; record the auditable `<friction-id> -> <task-id>` mapping in the execution summary. If a rejected task has a terminal disposition, append the required resolution note naming that task and decision evidence, then resolve through the CLI/store surface. If its rejection is administrative, keep the friction open, record the rejected-task mapping and next action, and never claim it is fixed; file at most one correctly scoped active replacement only when this workspace owns the issue. If no task covers the survivor, follow the `orbit-task` skill's Create workflow and create exactly one fix task with reproduction evidence and the friction-specific workspace, canonical `context_files`, `friction-curation` tag, and `resolves:<canonical-friction-id>` relation requirements above. Complete the mandatory read-back and repair loop before recording the new `<friction-id> -> <task-id>` mapping. Never resolve a friction merely because its fix task was filed; it remains open until the resolving task reaches `done`.
+    5. Repeat the same friction queries and coverage checks before finishing. The repeat pass must produce no further status changes and no duplicate tasks. Record counts and an auditable task-to-friction mapping for every canonical, resolved, verified, covered, created, and still-ambiguous id in this task's persisted `execution_summary`.
+  acceptance_criteria:
+  - Every open friction was deduplicated against active, done, and rejected task history and evidence-checked against the current tree or behavior; every plausible rejected task's latest rejection rationale was inspected before disposition, and ambiguous records remained open.
+  - Every resolved duplicate names its canonical friction id, and every no-longer-reproducing resolution records the evidence and reason through the CLI/store surface.
+  - Every terminally rejected covering task has a CLI/store resolution note naming the rejected task and decision evidence before its friction is resolved; administrative rejections leave the friction open, record the rejected-task mapping and next action, and create at most one correctly scoped active replacement.
+  - Every verified-real friction is covered by exactly one active or done Orbit task, or by a terminally rejected task with the required resolution evidence; new tasks carry reproduction evidence and exactly one verified `resolves` relation to the canonical friction without prematurely resolving the friction.
+  - Every newly filed task is read back and repaired through `orbit.task.update` if its exact `resolves` relation is missing or incorrect before it counts as coverage.
+  - Every task proposing to widen a fail-closed guard enumerates the neighboring rejection guarantees that must remain rejected and includes validation evidence for each preserved case.
+  - A repeat pass makes no status changes and files no duplicate tasks, and its persisted execution summary contains an auditable task-to-friction mapping; an empty or already-curated corpus succeeds as a no-op.
+  task_type: chore
+  tags:
+  - friction-curation
+  - no-diff-expected
+  priority: medium
+  crew: luna
+  status: backlog
+dedupe: skip_if_open
+created_by: system
+created_at: 2026-08-01T00:00:00Z
+updated_by: system
+updated_at: 2026-08-01T00:00:00Z

--- a/crates/orbit-core/src/auto_tasks/mod.rs
+++ b/crates/orbit-core/src/auto_tasks/mod.rs
@@ -18,6 +18,13 @@
 //! - [`scheduler`] — the pass itself + the deterministic-action projection.
 //! - [`crud`] — the shared add/list/show/update/toggle/mint domain surface.
 
+use std::borrow::Cow;
+use std::path::Path;
+
+use orbit_common::types::{OrbitError, parse_auto_task_yaml};
+
+use crate::command::seed_embedded_assets;
+
 pub mod crud;
 pub mod loader;
 pub mod schedule;
@@ -35,6 +42,45 @@ pub use scheduler::{
     run_scheduler_action_json,
 };
 pub use state::{AutoTaskCursor, AutoTaskCursorState, cursor_state_path, load_cursor_state};
+
+/// Default definitions embedded in the Orbit binary and materialized into a
+/// workspace on initialization. Defaults are deliberately inert: users must
+/// explicitly mint one or enable it through the existing auto-task surface.
+pub(crate) const DEFAULT_AUTO_TASK_FILES: &[(&str, &str)] = &[(
+    "friction-curation",
+    include_str!("../../assets/auto_tasks/friction-curation.yaml"),
+)];
+
+/// Seed missing default auto-task definitions without changing an existing
+/// workspace-authored definition. Each asset is parsed before it is written so
+/// a release cannot install an unloadable default.
+pub(crate) fn seed_default_auto_tasks(orbit_dir: &Path) -> Result<usize, OrbitError> {
+    let auto_tasks_dir = auto_tasks_dir(orbit_dir);
+    seed_embedded_assets(
+        &auto_tasks_dir,
+        DEFAULT_AUTO_TASK_FILES,
+        false,
+        |name, content| {
+            let definition = parse_auto_task_yaml(content).map_err(|error| {
+                OrbitError::InvalidInput(format!(
+                    "default auto-task `{name}` failed validation: {error}"
+                ))
+            })?;
+            if definition.name != name {
+                return Err(OrbitError::InvalidInput(format!(
+                    "default auto-task file stem `{name}` does not match definition name `{}`",
+                    definition.name
+                )));
+            }
+            if definition.enabled {
+                return Err(OrbitError::InvalidInput(format!(
+                    "default auto-task `{name}` must ship disabled"
+                )));
+            }
+            Ok(Cow::Borrowed(content))
+        },
+    )
+}
 
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-core/src/auto_tasks/tests/shipped.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/shipped.rs
@@ -1,90 +1,69 @@
-//! Shipped-definition tests [ORB-10318]: every git-tracked auto-task
-//! definition under the repo's `.orbit/auto_tasks/` must parse and validate
-//! fail-closed, and the artifact-deprecation review definition must stay
-//! report-only. This is the "mechanism covered by tests" guard for the
-//! definitions that travel with the repo — a malformed definition would
-//! otherwise only surface at scheduler-fire time.
+//! Embedded default auto-task tests [ORB-10549]. Defaults must parse through
+//! the same schema as workspace definitions and remain inert until explicitly
+//! enabled or manually minted.
 
-use std::path::PathBuf;
+use orbit_common::types::{AutoTaskSchedule, DedupePolicy, parse_auto_task_yaml};
 
-use orbit_common::types::{AutoTaskSchedule, parse_auto_task_yaml};
+use crate::auto_tasks::DEFAULT_AUTO_TASK_FILES;
 
-/// The repo's git-tracked auto-task definition directory, resolved relative to
-/// this crate's manifest (`crates/orbit-core` → repo root → `.orbit/auto_tasks`).
-fn shipped_auto_tasks_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .join(".orbit/auto_tasks")
-}
-
-/// Every shipped `.yaml` definition parses and validates. Fail-closed parsing
-/// means any malformed record is an error here, not a silent skip at fire time.
+/// Every embedded default parses, uses its filename identity, and remains
+/// disabled. An enabled default would turn workspace initialization into an
+/// implicit scheduler opt-in, so make that regression deterministic here.
 #[test]
-fn shipped_definitions_all_parse() {
-    let dir = shipped_auto_tasks_dir();
-    let entries =
-        std::fs::read_dir(&dir).unwrap_or_else(|error| panic!("read {}: {error}", dir.display()));
-    let mut count = 0usize;
-    for entry in entries {
-        let path = entry.expect("dir entry").path();
-        if path.extension().and_then(|ext| ext.to_str()) != Some("yaml") {
-            continue;
-        }
-        let yaml = std::fs::read_to_string(&path)
-            .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
-        let definition = parse_auto_task_yaml(&yaml)
-            .unwrap_or_else(|error| panic!("parse {}: {error}", path.display()));
-        // The file stem is the definition's identity.
-        let stem = path.file_stem().and_then(|s| s.to_str()).expect("stem");
-        assert_eq!(
-            definition.name, stem,
-            "name must match file stem for {stem}"
-        );
-        count += 1;
-    }
+fn shipped_defaults_all_parse_and_are_disabled() {
     assert!(
-        count > 0,
+        !DEFAULT_AUTO_TASK_FILES.is_empty(),
         "expected at least one shipped auto-task definition"
     );
+    for (stem, yaml) in DEFAULT_AUTO_TASK_FILES {
+        let definition =
+            parse_auto_task_yaml(yaml).unwrap_or_else(|error| panic!("parse {stem}: {error}"));
+        assert_eq!(
+            definition.name, *stem,
+            "name must match file stem for {stem}"
+        );
+        assert!(
+            !definition.enabled,
+            "default auto-task {stem} must ship disabled"
+        );
+    }
 }
 
-/// The artifact-deprecation review definition ships enabled, on a cron cadence,
-/// and stays report-only: it carries the `no-diff-expected` and
-/// `artifact-deprecation` tags and its template never asks to mutate learnings.
+/// Friction curation is the portable default. It keeps the curation safeguards
+/// while remaining disabled until an operator opts in.
 #[test]
-fn artifact_deprecation_review_is_report_only() {
-    let path = shipped_auto_tasks_dir().join("artifact-deprecation-review.yaml");
-    let yaml = std::fs::read_to_string(&path)
-        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
-    let definition = parse_auto_task_yaml(&yaml).expect("parse artifact-deprecation-review");
+fn friction_curation_default_is_portable_and_inert() {
+    let (_, yaml) = DEFAULT_AUTO_TASK_FILES
+        .iter()
+        .find(|(name, _)| *name == "friction-curation")
+        .expect("friction-curation default");
+    let definition = parse_auto_task_yaml(yaml).expect("parse friction-curation");
 
-    assert_eq!(definition.name, "artifact-deprecation-review");
-    assert!(definition.enabled, "definition must ship enabled");
+    assert_eq!(definition.name, "friction-curation");
+    assert!(!definition.enabled, "definition must ship disabled");
     assert!(
         matches!(definition.schedule, AutoTaskSchedule::Cron { .. }),
-        "deprecation review runs on a cron cadence"
+        "friction curation runs on a cron cadence"
+    );
+    assert!(matches!(definition.dedupe, DedupePolicy::SkipIfOpen));
+    assert_eq!(definition.template.crew.as_deref(), Some("luna"));
+    assert!(
+        !yaml.contains("/home/") && !yaml.contains("/Users/"),
+        "default must not contain a machine-specific path"
     );
 
-    let tags = &definition.template.tags;
-    assert!(
-        tags.iter().any(|t| t == "no-diff-expected"),
-        "report-only run must be tagged no-diff-expected"
-    );
-    assert!(
-        tags.iter().any(|t| t == "artifact-deprecation"),
-        "definition must be tagged artifact-deprecation"
-    );
-
-    // Report-only: the prompt must not direct the agent to mutate learnings.
     let body = definition.template.description.to_lowercase();
-    assert!(
-        body.contains("report-only") || body.contains("report only"),
-        "template must state the run is report-only"
-    );
-    for forbidden in ["execution_summary", "learning stats", "fail open"] {
+    for required in [
+        "rejected tasks",
+        "terminal rejection",
+        "administrative rejection",
+        "exactly one",
+        "fail open",
+        "repeat pass",
+    ] {
         assert!(
-            body.contains(forbidden),
-            "template should reference '{forbidden}'"
+            body.contains(required),
+            "template should retain '{required}'"
         );
     }
 }

--- a/crates/orbit-core/src/command/init.rs
+++ b/crates/orbit-core/src/command/init.rs
@@ -6,6 +6,7 @@ use orbit_common::types::{OrbitError, WorkspacePaths};
 use orbit_store::{friction_store, global_executor_def_store, global_policy_def_store};
 
 use crate::OrbitRuntime;
+use crate::auto_tasks::seed_default_auto_tasks;
 use crate::command::activity::seed_default_activities;
 use crate::command::executor::seed_default_executors;
 use crate::command::job::seed_default_jobs;
@@ -35,6 +36,7 @@ pub struct InitResult {
     pub refreshed_default_executors: usize,
     pub refreshed_default_policies: usize,
     pub refreshed_default_routines: usize,
+    pub seeded_default_auto_tasks: usize,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -163,6 +165,7 @@ pub fn init_workspace_at_root(
     }
 
     let mut refreshed_default_routines = 0usize;
+    let mut seeded_default_auto_tasks = 0usize;
     let (
         refreshed_default_activities,
         refreshed_default_jobs,
@@ -219,6 +222,10 @@ pub fn init_workspace_at_root(
                 options.force,
             )?;
         }
+        // Auto-task definitions are workspace-authored after seeding. Never
+        // refresh an existing file: `workspace init --force` reconciles
+        // registration and must not overwrite an operator's definition.
+        seeded_default_auto_tasks = seed_default_auto_tasks(&orbit_root)?;
         (
             global_result.refreshed_default_activities,
             global_result.refreshed_default_jobs,
@@ -244,6 +251,7 @@ pub fn init_workspace_at_root(
         refreshed_default_executors,
         refreshed_default_policies,
         refreshed_default_routines,
+        seeded_default_auto_tasks,
     })
 }
 
@@ -675,6 +683,49 @@ mod tests {
             .expect("force-overwritten routine parses");
         assert_eq!(forced.hosts, vec!["host-b".to_string()]);
         assert!(!forced.enabled);
+    }
+
+    #[test]
+    fn workspace_init_seeds_an_inert_friction_curation_default_without_clobbering_edits() {
+        let temp = tempdir().expect("tempdir");
+        let global_root = temp.path().join("global");
+        let orbit_root = temp.path().join("repo/.orbit");
+        let options = InitOptions {
+            global_root_override: Some(global_root),
+            detected: Some(DetectedAgents::default()),
+            ..Default::default()
+        };
+
+        let initial = init_workspace_at_root(&orbit_root, options.clone())
+            .expect("initialize fresh workspace");
+        assert_eq!(initial.seeded_default_auto_tasks, 1);
+        let definition_path = orbit_root.join("auto_tasks/friction-curation.yaml");
+        let seeded = fs::read_to_string(&definition_path).expect("read seeded definition");
+        let definition = orbit_common::types::parse_auto_task_yaml(&seeded)
+            .expect("seeded definition parses through loader schema");
+        assert!(!definition.enabled);
+        assert_eq!(definition.template.crew.as_deref(), Some("luna"));
+        assert!(matches!(
+            definition.dedupe,
+            orbit_common::types::DedupePolicy::SkipIfOpen
+        ));
+        assert!(!orbit_root.join("state/auto-tasks.json").exists());
+        let loaded = crate::auto_tasks::collect_auto_tasks(&orbit_root);
+        assert!(
+            loaded.errors.is_empty(),
+            "seeded definition must load cleanly"
+        );
+        assert_eq!(loaded.definitions.len(), 1);
+        assert_eq!(loaded.definitions[0].definition.name, "friction-curation");
+
+        fs::write(&definition_path, "operator-authored definition\n").expect("write edit");
+        let repeated =
+            init_workspace_at_root(&orbit_root, options).expect("reinitialize workspace");
+        assert_eq!(repeated.seeded_default_auto_tasks, 0);
+        assert_eq!(
+            fs::read_to_string(definition_path).expect("read preserved definition"),
+            "operator-authored definition\n"
+        );
     }
 
     #[test]

--- a/docs/design/auto-tasks/1_overview.md
+++ b/docs/design/auto-tasks/1_overview.md
@@ -1,7 +1,7 @@
 ---
 title: Auto-tasks — Overview
 owner: claude
-last_updated: 2026-07-27
+last_updated: 2026-08-01
 last_validated: 2026-07-27
 status: Accepted
 feature: auto-tasks
@@ -11,7 +11,7 @@ summary: Dynamically-defined recurring task templates minted by one generic sche
 tags: [auto-tasks]
 paths: ["crates/orbit-core/src/auto_tasks/**"]
 related_features: [auto-tasks]
-related_artifacts: [ORB-10149, ORB-10318, ORB-10348, ORB-10439, ORB-10446, ORB-10514, ADR-0218, ADR-0217]
+related_artifacts: [ORB-10149, ORB-10318, ORB-10348, ORB-10439, ORB-10446, ORB-10514, ORB-10549, ADR-0218, ADR-0217]
 ---
 
 # Auto-tasks — Overview
@@ -56,6 +56,14 @@ becomes just the first definition.
   indistinguishable from a fired instance. Unconditional and cursor-inert: it
   ignores schedule, `dedupe`, and `enabled`, and never touches
   `<orbit_dir>/state/auto-tasks.json` (ORB-10439).
+- **Default catalog** — Orbit embeds a small catalog of workspace definitions.
+  Initialization materializes a missing catalog file under `.orbit/auto_tasks/`
+  but every default is `enabled: false`. Seeding neither mints a task nor
+  enables a routine or auto-task; an operator must explicitly enable the
+  definition or use the existing manual-mint surface. Re-initialization
+  preserves an existing definition byte-for-byte, including with workspace
+  reconciliation `--force`; destructive lower-level initialization reseeds
+  only because it recreates the Orbit directory.
 
 ## 3. At a Glance
 
@@ -70,6 +78,7 @@ becomes just the first definition.
 | Manual mint (`mint`, CLI-only) | `crates/orbit-core/src/auto_tasks/crud.rs` | ORB-10439 |
 | Deterministic action | `crates/orbit-core/src/runtime/v2_host/dispatch.rs` | ORB-10149 |
 | Seeded assets | `crates/orbit-core/assets/{activities,jobs,routines}/…` | ORB-10149 |
+| Default auto-task catalog | `crates/orbit-core/assets/auto_tasks/…` | ORB-10549 |
 
 ## Definitions shipped in this repo
 
@@ -80,7 +89,7 @@ becomes just the first definition.
   and resolved against their registries) via `execution_summary`; never
   mutates learnings, ADRs, tasks, friction records, or comments (ORB-10318,
   ORB-10348, [project-learnings §7.6](../project-learnings/2_design.md#76-recurring-deprecation-review-auto-task)).
-- `friction-curation` — daily evidence-first pass that deduplicates open
+- `friction-curation` — disabled-by-default daily evidence-first pass that deduplicates open
   friction records, re-verifies survivors against current behavior, resolves
   records that no longer reproduce, and files non-duplicate fix tasks for
   verified-real issues (ORB-10440).
@@ -98,5 +107,8 @@ becomes just the first definition.
 - ORB-10439 — `orbit auto-task mint <name>`, the on-demand manual mint.
 - ORB-10440 — Daily friction-curation definition.
 - ORB-10514 — Disabled CI-failure remediation definition.
+- ORB-10549 — Embedded the portable, disabled friction-curation default and
+  workspace materialization contract; ADR-0218 should be updated through the
+  Orbit ADR surface after this task lands.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10549](https://orbit-cli.com/tasks/ORB-10549) — Ship friction curation as a disabled default auto-task

### Description

## Problem
`friction-curation` has proven useful as a workspace-local auto-task, but Orbit currently ships only the generic scheduler plumbing; no auto-task definitions are seeded into new or existing workspaces. Daniel has decided that friction curation earns a default slot and that every default auto-task must be disabled by default.

## Decision
Add a shipped default-auto-task catalog and seed the current friction-curation template into workspaces as an inert definition. The default must be discoverable and ready for explicit one-shot minting or enablement, but installation and re-initialization must never schedule or mint work automatically.

## Constraints
- Seed `friction-curation` with `enabled: false`, `crew: luna`, `dedupe: skip_if_open`, and the accepted evidence-first/rejected-coverage instruction from the current Orbit workspace definition.
- Default definitions must be portable: no `/home/daniel`, `/Users/daniel`, temporary worktree, or workspace-specific absolute paths in shipped assets.
- Fresh workspace initialization may materialize missing defaults. Re-initialization must preserve user-authored/edited definitions unless the existing explicit `--force` contract authorizes replacement; it must never toggle a definition on.
- Do not introduce another top-level CLI verb merely for defaults. Use the existing init/workspace-init and auto-task surfaces.
- Update the auto-task design documentation. Do not hand-edit ADR storage; the orchestrator will update ADR-0218 through Orbit's ADR tool after the implementation lands.

### Acceptance Criteria

- A fresh workspace initialization materializes exactly one `friction-curation` default definition that parses through the existing auto-task loader and reports `enabled: false`, crew `luna`, and `dedupe: skip_if_open`.
- The shipped friction-curation instruction retains the current evidence-first dedupe, rejected-task classification, terminal-rejection closure, administrative-rejection re-homing, exact `resolves` relation verification, fail-open ambiguity, and repeat-pass guarantees.
- Every shipped/default auto-task definition is statically or test-enforced to have `enabled: false`; adding an enabled default causes a deterministic test failure.
- Installing, initializing, or re-initializing a workspace does not mint a task, enable a scheduler routine, or enable any auto-task.
- Re-initialization without `--force` preserves an existing workspace definition byte-for-byte; the documented `--force` behavior is covered and still leaves seeded defaults disabled.
- The shipped definition contains no machine-specific absolute path and resolves required skill guidance through a portable installed or repo-relative contract.
- No new top-level CLI verb is introduced; current init/workspace-init and auto-task commands remain the control surfaces.
- Auto-task design documentation accurately describes disabled default definitions, workspace materialization, preservation behavior, and explicit enable/mint semantics; the execution summary identifies the corresponding ADR-0218 update for the orchestrator to apply through Orbit's ADR tool after landing.
- Focused seeding/loader tests, `cargo fmt --check`, relevant clippy/tests, and `git diff --check` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added an embedded default-auto-task catalog that seeds exactly one portable friction-curation definition only when it is missing; seed-time schema validation rejects a default that is malformed, mismatched, or enabled.
- Shipped friction curation as enabled false, crew luna, dedupe skip_if_open, with the evidence-first dedupe, rejected-task classification, terminal/admin handling, exact resolves verification, fail-open, and repeat-pass safeguards retained.
- Preserved workspace-authored definition bytes on ordinary and workspace init --force re-initialization; seeding creates neither cursor state nor work. Added focused core/CLI coverage and updated the auto-task overview.

Assessment: Focused seeding, loader, portability, reinitialization, and disabled-default invariant checks pass. make ci-fast, cargo clippy -p orbit-core --lib --tests -- -D warnings, cargo fmt --check, and git diff --check pass.

Strategic decisions:
- Default assets live under crates/orbit-core/assets/auto_tasks/ and are embedded in the binary, separating installable defaults from this repository workspace existing auto-task definitions.

ADR follow-up:
- Update ADR-0218 through the Orbit ADR tool after landing to record the disabled embedded-default catalog and non-clobbering workspace materialization contract.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10549-6a6e69be`
- Behind base: 0
- Ahead of base: 1