### PR TITLE
docs: propose Linux Bubblewrap sandbox

### DIFF
--- a/docs/design/policy-sandbox/3_vision.md
+++ b/docs/design/policy-sandbox/3_vision.md
@@ -3,7 +3,7 @@ summary: "Policy & Sandboxing — Vision"
 type: design
 title: "Policy & Sandboxing — Vision"
 owner: claude
-last_updated: 2026-05-16
+last_updated: 2026-08-01
 status: Draft
 feature: policy-sandbox
 doc_role: vision
@@ -18,7 +18,7 @@ This document captures the questions Orbit must answer before policy and sandbox
 
 ## 1. Open Questions
 
-1. **Should `orbit-exec` get real `Sandbox` impls?** `NoSandbox` is still the default; candidates include `bubblewrap`, containers, seccomp, and platform wrappers.
+1. **How far should Linux sandboxing go after the first backend?** §1.1 proposes a Bubblewrap write-confinement backend for CLI agents. Full read-policy parity, network policy, seccomp, and generic `run_process` adoption remain separate decisions.
 2. **Should enforcement move below the tool layer?** A future tool that skips `enforce_fs_policy` is unguarded unless Orbit adds a `PolicyAwareFs` trait, syscall interception, or linting.
 3. **Should `proc.spawn` consult policy?** Activity program allowlists are not `PolicyDef`; future shapes include `allowExec` / `denyExec` or env access tied to `fsProfile`.
 4. **What is the symlink contract?** `workspace_relative_path` follows symlinks and denies out-of-workspace targets, but the invariant is not yet specified.
@@ -30,6 +30,97 @@ This document captures the questions Orbit must answer before policy and sandbox
 10. **Should all denials share one audit shape?** Fs denials, task-lock denials, program allowlists, and future exec denials still report through different channels; auditability asks the same question.
 11. **How should concurrent exec handle signals?** `SignalHandlerGuard` serializes installs; worker-pool exec may need sigmasks, cancellation tokens, or a supervisor thread.
 12. **How far should CLI policy coverage go?** macOS `sandbox-exec` narrows writes, but alternatives include trapping CLI fs calls or moving more work to HTTP-backed activities.
+
+### 1.1 Proposed answer: a `linux-bwrap` CLI backend
+
+Orbit should add Bubblewrap as the first Linux OS-level sandbox for CLI-backed agent loops. It
+should reuse the existing executor declaration → `ResolvedSandbox` → CLI spawn path rather than
+starting with the generic `Sandbox` trait: the exposed gap is provider CLIs, and that is already
+the seam where macOS turns an activity's resolved `FsProfile` into an outer process wrapper.
+
+The first version is deliberately a **write-confinement backend**, not a claim of byte-for-byte
+SBPL parity. It materially improves today's bare Linux execution while keeping unsupported policy
+semantics visible instead of silently calling them enforced.
+
+#### Backend and availability contract
+
+- Add `linux-bwrap` as a concrete `ExecutorSandboxKind`; shipped agent executors select it on
+  Linux while `local-shell` remains explicitly unsandboxed. Custom executor definitions keep
+  their concrete backend choice.
+- Resolve Bubblewrap only from a trusted absolute location, initially `/usr/bin/bwrap`. Never
+  accept a `PATH`-shadowed wrapper as the security boundary.
+- Probe capability, not just file existence. The probe must prove that the installed binary can
+  create the required user and mount namespaces and execute a trivial child on the running host.
+  A present binary with disabled unprivileged user namespaces is unavailable.
+- Preserve the existing `allow_fallback` field. The default remains fail-closed; an unavailable
+  backend is a permanent dispatch error with the trusted path and failed probe named. If an
+  operator explicitly permits bare fallback, Orbit must retain provider-native sandbox flags
+  rather than neutralizing them for an outer wrapper that did not start.
+
+#### Namespace and filesystem shape
+
+The wrapper should construct a deterministic Bubblewrap argv with these properties:
+
+1. Start from the host filesystem mounted read-only, then bind only resolved positive `modify`
+   roots and Orbit-owned provider/runtime state roots back as writable.
+2. Give the child private user, PID, IPC, and UTS namespaces, a fresh session, parent-death
+   cleanup, a minimal `/proc` and `/dev`, and isolated scratch space. Keep the host network
+   namespace because CLI agents must reach provider APIs; network restriction is not smuggled
+   into this filesystem task.
+3. Canonicalize every host path before it becomes a mount argument. Reject missing or escaping
+   policy roots unless the root is an Orbit-owned state directory that Orbit creates before
+   spawn. Preserve the active-worktree and narrow inherited-Orbit write allowances already
+   appended by the v2 host.
+4. Apply exact-path and subtree `denyModify` rules as later read-only mounts so they override a
+   broader writable parent. Expand non-subtree deny globs over the pre-spawn filesystem snapshot
+   and mount every existing match read-only. Record that snapshot-bound enforcement in audit
+   metadata.
+
+This gives a kernel-enforced guarantee that the child cannot mutate the host outside the
+materialized writable mounts. Non-subtree filename globs such as `**/*.env` have one unavoidable
+Bubblewrap limitation: a mount namespace cannot reject a matching filename that the child creates
+later inside an otherwise writable directory. Orbit must not describe those rules as fully
+kernel-enforced. For a managed shipment worktree, the implementation must add a post-run policy
+check that rejects forbidden newly-created paths before commit; the disposable worktree is the
+containment boundary, and the design assumes it has one writer for the duration of the invocation.
+A direct invocation without that disposable boundary must fail closed when a non-subtree
+`denyModify` overlaps a writable root rather than downgrading silently.
+
+#### Read-policy boundary
+
+The initial backend keeps the host's executable, library, certificate, and provider state surface
+readable so existing CLIs can start. It may hide concrete existing matches for `denyRead`, but it
+does not claim general `read` allowlist or arbitrary negative-glob parity. The invocation audit
+must distinguish `write_enforced` from `read_delegated`; HTTP `fs.*` calls continue to enforce the
+full policy evaluator, while CLI read restrictions remain a harness responsibility.
+
+This is preferable to either extreme: mounting the whole host read-write would not be a sandbox,
+while constructing a minimal read tree for several independently-updated provider CLIs would
+silently become a brittle container runtime. If secret-read isolation becomes the next priority,
+evaluate a second Landlock layer or a filtered filesystem view in its own ADR. Landlock is a good
+hierarchical allowlist, but it also cannot directly reproduce Orbit's ordered arbitrary path globs,
+and kernel ABI/boot enablement varies by host.
+
+#### Integration and test boundary
+
+- Keep platform compilation and trusted-wrapper spawn in `orbit-exec`; keep `FsProfile`
+  resolution, active-worktree detection, and provider/runtime side roots in `orbit-core`; keep
+  wrapper selection, provider flag handling, audit argv, and supervision in `orbit-engine`.
+- Audit the effective backend, trusted wrapper path, probe outcome, read/write enforcement level,
+  and redacted argv. Do not emit `write_enforced` when bare fallback ran.
+- Unit-test argv compilation and mount ordering on every platform. Linux runtime tests must use a
+  real `/usr/bin/bwrap` when the capability probe succeeds and otherwise skip with the probe
+  reason. End-to-end tests must prove an allowed worktree write succeeds, an outside write fails,
+  a subtree denial such as `.orbit/**` stays read-only beneath a writable workspace, provider
+  network access is not isolated, a forbidden new glob match is rejected before worktree commit,
+  a non-worktree invocation with the same unrepresentable rule fails closed, and missing/disabled
+  Bubblewrap follows fail-closed versus explicit-fallback behavior.
+
+Bubblewrap is the pragmatic first backend because it is an unprivileged policy-construction tool,
+not a policy by itself. Orbit remains responsible for the exact mount and namespace arguments.
+The trusted-path rule, `--new-session`, namespace selection, and explicit read-policy limitation
+are therefore part of the security contract rather than incidental implementation details.
+[ORB-10552] tracks implementation of this proposed boundary.
 
 ---
 
@@ -43,11 +134,11 @@ The current policy schema and merge contract live in `crates/orbit-common/src/ty
 
 ### 2.2 OS-Level Sandboxes
 
-`bubblewrap`, `sandbox-exec`, `firejail`, and seccomp-bpf are the near-term isolation options under the `Sandbox` trait. gVisor and Firecracker are heavier options when a workload tolerates a microVM boundary.
+`bubblewrap`, `sandbox-exec`, `firejail`, and seccomp-bpf are the near-term isolation options under the `Sandbox` trait. gVisor and Firecracker are heavier options when a workload tolerates a microVM boundary. Bubblewrap's own documentation emphasizes that it constructs namespaces and mounts but leaves the security policy to its caller; that makes the exact Orbit-generated argv part of the design surface, not an implementation detail.
 
 ### 2.3 Capability Systems
 
-POSIX capabilities, Capsicum, and Linux Landlock express process rights as capabilities rather than path globs. Landlock is attractive because it is hierarchical and works without root, but it is Linux-only.
+POSIX capabilities, Capsicum, and Linux Landlock express process rights as capabilities rather than path globs. Landlock is attractive because it is hierarchical and works without root, but it is Linux-only, depends on kernel ABI and boot-time enablement, and cannot directly express Orbit's ordered arbitrary filename globs.
 
 ### 2.4 Build Sandboxes
 
@@ -84,6 +175,8 @@ External reference categories:
 
 - OS-level sandboxes: bubblewrap, sandbox-exec, firejail, seccomp-bpf, gVisor, Firecracker.
 - Capability systems: POSIX capabilities, Capsicum, Linux Landlock.
+- Bubblewrap primary references: [project security model and limitations](https://github.com/containers/bubblewrap/blob/main/README.md#sandbox-security) and [command reference](https://github.com/containers/bubblewrap/blob/main/bwrap.xml).
+- Landlock primary reference: [Linux kernel userspace API](https://docs.kernel.org/userspace-api/landlock.html).
 - Build sandboxes: Bazel exec.sandbox, Buck2 hermetic execution, Nix build sandbox.
 - Supervision patterns: tini, dumb-init, Kubernetes terminationGracePeriodSeconds.
 
@@ -97,5 +190,6 @@ External reference categories:
 - **[T20260426-0605]** — Auditability folder linked from §1.10.
 - **[T20260426-0622]** — Add this folder and name the open questions.
 - **[T20260430-23]** — Shorten the policy sandbox design docs while preserving the shipped contract and ADR history.
+- **[ORB-10552]** — Implement the proposed fail-closed Linux Bubblewrap write-confinement backend for CLI agents.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## What changed

- Replaced the open-ended Linux sandbox question with a concrete `linux-bwrap` proposal.
- Defined trusted-wrapper discovery and a real namespace/mount capability probe.
- Specified the read-only host mount, narrow writable rebinds, namespace shape, fallback behavior, audit contract, and test boundary.
- Documented Bubblewrap's limits for arbitrary read and negative filename globs instead of claiming SBPL parity.
- Linked the implementation proposal to ORB-10552.

## Why

Linux CLI agents currently run without an Orbit-owned OS sandbox. Bubblewrap is already installed on the primary worker host, but Orbit does not connect it to `FsProfile` or CLI dispatch.

The proposal closes the highest-value gap—writes outside authorized roots—while making deferred read-policy parity explicit.

## Validation

- `make ci-fast`
- `git diff --check`

## Task

ORB-10552
