### PR TITLE
Add fail-closed Linux Bubblewrap sandbox for CLI agents

### DIFF
--- a/.orbit/adrs/accepted/ADR-0304/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0304/adr.yaml
@@ -1,0 +1,25 @@
+schema_version: 2
+id: ADR-0304
+title: Use Bubblewrap for shipped Linux CLI write confinement
+status: accepted
+owner: codex
+created_at: 2026-08-01T23:17:39.413194306Z
+accepted_at: 2026-08-01T23:26:11.357573554Z
+last_updated: 2026-08-01T23:26:11.357573554Z
+related_features:
+- policy-sandbox
+related_tasks:
+- ORB-10552
+tags:
+- sandboxing
+- linux
+- bubblewrap
+- cli-backend
+paths:
+- crates/orbit-exec/src/linux_sandbox.rs
+- crates/orbit-engine/src/activity_job/cli_runner/**/*.rs
+- crates/orbit-core/src/runtime/v2_host/sandbox.rs
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0304/body.md
+++ b/.orbit/adrs/accepted/ADR-0304/body.md
@@ -1,0 +1,11 @@
+## Context
+Linux CLI agents previously ran with the worker account's ambient filesystem rights. The real alternatives were a Bubblewrap mount-namespace boundary, a Landlock allowlist layer, or continued delegation to provider-native sandboxes; Bubblewrap closes the highest-value write gap at the existing executor wrapper seam without turning Orbit into a container runtime.
+
+## Decision
+Shipped Linux agent executors use the concrete `linux-bwrap` backend. Orbit resolves only `/usr/bin/bwrap`, capability-probes the namespaces and mounts it needs, mounts the host root read-only, rebinds canonical policy and runtime roots writable in rule order, retains the host network namespace, and fails closed unless `allow_fallback` explicitly permits bare execution. This backend claims `write_enforced` and `read_delegated`; read-policy parity remains deferred.
+
+## Consequences
+- Linux CLI agents gain kernel-backed write confinement without changing the generic `run_process + NoSandbox` contract or the macOS backend.
+- Non-subtree deny globs are snapshot-expanded; managed single-writer worktrees receive a post-run new-match check, while direct overlapping invocations fail closed.
+- Provider-native sandbox flags are neutralized only after the outer wrapper passes its capability probe, so bare fallback retains the provider boundary.
+- Cost: Bubblewrap availability depends on `/usr/bin/bwrap` plus host user-namespace policy, and write confinement deliberately leaves the broad host read surface and provider network access delegated for a later decision.

--- a/crates/orbit-common/src/types/activity_job/audit_envelope.rs
+++ b/crates/orbit-common/src/types/activity_job/audit_envelope.rs
@@ -171,6 +171,16 @@ pub enum V2AuditEventKind {
         model: Option<String>,
         cwd: Option<String>,
         wall_clock_timeout_ms: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sandbox_backend: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sandbox_trusted_wrapper: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sandbox_probe_outcome: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sandbox_write_enforcement: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sandbox_read_enforcement: Option<String>,
     },
     /// [ORB-10496] The CLI backend subprocess exists. Emitted once, immediately
     /// after spawn and before the wall-clock supervision loop, so the provider

--- a/crates/orbit-common/src/types/executor_def.rs
+++ b/crates/orbit-common/src/types/executor_def.rs
@@ -41,31 +41,31 @@ impl fmt::Display for ExecutorType {
 /// Sandbox primitive applied to a CLI-backend agent invocation. The variant
 /// names a concrete OS primitive; `orbit-exec` selects the implementation.
 ///
-/// Today only `macos-sandbox-exec` is wired; a future Linux variant
-/// (`linux-bwrap` or similar) can land alongside without changing the
-/// schema shape.
+/// Each variant names one concrete, platform-specific kernel wrapper.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum ExecutorSandboxKind {
     MacosSandboxExec,
+    LinuxBwrap,
 }
 
 impl ExecutorSandboxKind {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::MacosSandboxExec => "macos-sandbox-exec",
+            Self::LinuxBwrap => "linux-bwrap",
         }
     }
 
     /// OS this sandbox primitive can be applied on, named to match
     /// `std::env::consts::OS` (e.g. `"macos"`, `"linux"`).
     ///
-    /// Every kind is single-OS today. When a Linux variant (`linux-bwrap`
-    /// or similar) lands, add its arm here; the seed-time platform scrub in
-    /// `orbit-core` reads this to decide whether to keep a declaration.
+    /// Every kind is single-OS. The seed-time platform selector in
+    /// `orbit-core` reads this value when installing shipped executors.
     pub fn target_os(self) -> &'static str {
         match self {
             Self::MacosSandboxExec => "macos",
+            Self::LinuxBwrap => "linux",
         }
     }
 

--- a/crates/orbit-common/src/types/tests/executor_def.rs
+++ b/crates/orbit-common/src/types/tests/executor_def.rs
@@ -4,6 +4,16 @@ mod sandbox_kind_platform {
     #[test]
     fn target_os_matches_std_env_consts_naming() {
         assert_eq!(ExecutorSandboxKind::MacosSandboxExec.target_os(), "macos");
+        assert_eq!(ExecutorSandboxKind::LinuxBwrap.target_os(), "linux");
+    }
+
+    #[test]
+    fn linux_bwrap_round_trips_as_concrete_wire_value() {
+        let serialized =
+            serde_json::to_string(&ExecutorSandboxKind::LinuxBwrap).expect("serialize");
+        assert_eq!(serialized, "\"linux-bwrap\"");
+        let parsed: ExecutorSandboxKind = serde_json::from_str(&serialized).expect("deserialize");
+        assert_eq!(parsed, ExecutorSandboxKind::LinuxBwrap);
     }
 
     #[test]
@@ -11,6 +21,8 @@ mod sandbox_kind_platform {
         assert!(ExecutorSandboxKind::MacosSandboxExec.is_available_on("macos"));
         assert!(!ExecutorSandboxKind::MacosSandboxExec.is_available_on("linux"));
         assert!(!ExecutorSandboxKind::MacosSandboxExec.is_available_on("windows"));
+        assert!(ExecutorSandboxKind::LinuxBwrap.is_available_on("linux"));
+        assert!(!ExecutorSandboxKind::LinuxBwrap.is_available_on("macos"));
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/orbit-core/src/command/executor.rs
+++ b/crates/orbit-core/src/command/executor.rs
@@ -58,9 +58,8 @@ pub(super) fn seed_default_executors_for_platform(
 }
 
 /// Select the sandbox setting a *shipped* executor should be installed with on
-/// `target_os`. Shipped assets declare their macOS sandbox intent; keep it on
-/// hosts where the primitive applies and install without an OS sandbox
-/// elsewhere until a native backend for that host exists.
+/// `target_os`. Shipped assets declare sandbox intent with the macOS backend;
+/// Linux installs translate that marker to the native Bubblewrap backend.
 ///
 /// This is deliberate platform selection for Orbit's own defaults, so it is
 /// silent. It does NOT relax validation of user-authored executor defs: a
@@ -73,6 +72,7 @@ fn select_shipped_sandbox(
 ) -> Option<ExecutorSandboxKind> {
     match declared {
         Some(kind) if kind.is_available_on(target_os) => Some(kind),
+        Some(_) if target_os == "linux" => Some(ExecutorSandboxKind::LinuxBwrap),
         _ => None,
     }
 }
@@ -123,6 +123,17 @@ pub(super) fn migrated_default_executor_for_platform(
         changed = true;
     }
 
+    // Linux shipped without an OS wrapper before ORB-10552, so an installed
+    // default commonly has `None` rather than a mismatched concrete kind.
+    // Upgrade that old shipped state to Bubblewrap on the next seed.
+    if existing.sandbox.is_none()
+        && seeded.sandbox == Some(ExecutorSandboxKind::LinuxBwrap)
+        && target_os == "linux"
+    {
+        migrated.sandbox = seeded.sandbox;
+        changed = true;
+    }
+
     if changed { Some(migrated) } else { None }
 }
 
@@ -165,14 +176,10 @@ pub(super) fn parse_default_executor_for_platform(
         resource.spec.updated_at,
     );
 
-    // Shipped executor assets declare their macOS sandbox intent
-    // (`macos-sandbox-exec`), which dispatch fails closed on if the runner
-    // platform can't apply it. Select the platform-appropriate sandbox at seed
-    // time so first-install and re-install (overwrite mode) persist the value
-    // that matches the host: kept where the primitive applies, dropped
-    // elsewhere until a native backend for that host lands. This is deliberate
-    // selection for our own defaults, so — unlike the earlier mismatch
-    // handling — it is silent. See [ORB-10112] / [ORB-10047].
+    // Shipped agent assets use their sandbox field as an opt-in marker. Keep
+    // sandbox-exec on macOS, translate it to linux-bwrap on Linux, and omit it
+    // on unsupported platforms. Custom definitions never pass through this
+    // selector, so their explicit concrete choice remains fail-closed.
     def.sandbox = select_shipped_sandbox(def.sandbox, target_os);
 
     Ok(def)

--- a/crates/orbit-core/src/command/tests/executor.rs
+++ b/crates/orbit-core/src/command/tests/executor.rs
@@ -111,19 +111,22 @@ fn parse_default_executor_installs_macos_sandbox_on_macos_path() {
     );
 }
 
-/// On the Linux seed path no shipped executor carries an OS sandbox — there is
-/// no Linux backend yet — and none of them emit the platform-mismatch warning,
-/// because the selection is deliberate rather than a mismatch to flag.
+/// On Linux every shipped agent uses Bubblewrap while local-shell remains bare.
 #[test]
-fn parse_default_executor_installs_without_sandbox_on_linux_path() {
-    for (name, yaml) in DEFAULT_EXECUTOR_FILES {
-        let def = parse_default_executor_for_platform(name, yaml, LINUX)
+fn parse_default_executor_installs_linux_bwrap_on_linux_path() {
+    for name in SANDBOXED_SHIPPED {
+        let def = parse_default_executor_for_platform(name, yaml_for(name), LINUX)
             .unwrap_or_else(|err| panic!("parse {name}: {err}"));
         assert_eq!(
-            def.sandbox, None,
-            "{name} must install without an OS sandbox on the Linux path"
+            def.sandbox,
+            Some(ExecutorSandboxKind::LinuxBwrap),
+            "{name} must install linux-bwrap on the Linux path"
         );
     }
+    let local_shell =
+        parse_default_executor_for_platform("local-shell", yaml_for("local-shell"), LINUX)
+            .expect("parse local-shell");
+    assert_eq!(local_shell.sandbox, None);
 }
 
 /// The host-platform default entry point defers to the injected core: on the
@@ -132,11 +135,12 @@ fn parse_default_executor_installs_without_sandbox_on_linux_path() {
 #[test]
 fn parse_default_executor_selects_by_host_platform() {
     let def = parse_default_executor("claude", CLAUDE_YAML).expect("parse");
-    if ExecutorSandboxKind::MacosSandboxExec.is_available_on_current_platform() {
-        assert_eq!(def.sandbox, Some(ExecutorSandboxKind::MacosSandboxExec));
-    } else {
-        assert_eq!(def.sandbox, None);
-    }
+    let expected = match std::env::consts::OS {
+        "macos" => Some(ExecutorSandboxKind::MacosSandboxExec),
+        "linux" => Some(ExecutorSandboxKind::LinuxBwrap),
+        _ => None,
+    };
+    assert_eq!(def.sandbox, expected);
 }
 
 /// Re-seeding must re-align a platform-mismatched sandbox left over from a
@@ -150,7 +154,7 @@ fn migrated_default_executor_realigns_platform_mismatched_sandbox_on_linux() {
 
     let migrated = migrated_default_executor_for_platform(&existing, &seeded, LINUX)
         .expect("re-align should produce a migrated def");
-    assert_eq!(migrated.sandbox, None);
+    assert_eq!(migrated.sandbox, Some(ExecutorSandboxKind::LinuxBwrap));
     assert_eq!(migrated.executor_type, ExecutorType::DirectAgent);
 }
 
@@ -211,8 +215,7 @@ fn seed_default_executors_is_idempotent_on_macos_path() {
     }
 }
 
-/// Seeding twice on the Linux path is idempotent and preserves the unsandboxed
-/// value: no default acquires a sandbox and the second pass creates nothing.
+/// Seeding twice on Linux is idempotent and preserves linux-bwrap.
 #[test]
 fn seed_default_executors_is_idempotent_on_linux_path() {
     let store = InMemoryExecutorStore::default();
@@ -223,20 +226,28 @@ fn seed_default_executors_is_idempotent_on_linux_path() {
     let second = seed_default_executors_for_platform(&store, false, LINUX).expect("second seed");
     assert_eq!(second, 0, "re-seed must be a no-op on the Linux path");
 
-    for (name, _) in DEFAULT_EXECUTOR_FILES {
+    for name in SANDBOXED_SHIPPED {
         let def = store
             .get_executor_def(name)
             .expect("get")
             .unwrap_or_else(|| panic!("{name} seeded"));
         assert_eq!(
-            def.sandbox, None,
-            "{name} must stay unsandboxed across idempotent re-seed on Linux"
+            def.sandbox,
+            Some(ExecutorSandboxKind::LinuxBwrap),
+            "{name} must keep linux-bwrap across idempotent re-seed"
         );
     }
+    assert_eq!(
+        store
+            .get_executor_def("local-shell")
+            .expect("get")
+            .expect("local-shell seeded")
+            .sandbox,
+        None
+    );
 }
 
-/// A pre-ORB-10112 Linux install that persisted `macos-sandbox-exec` is healed
-/// on the next seed: the leftover mismatch is re-aligned to unsandboxed.
+/// A pre-ORB-10552 Linux install is upgraded to the native backend.
 #[test]
 fn seed_default_executors_heals_leftover_macos_sandbox_on_linux() {
     let store = InMemoryExecutorStore::default();
@@ -251,8 +262,48 @@ fn seed_default_executors_heals_leftover_macos_sandbox_on_linux() {
         .expect("get")
         .expect("claude present");
     assert_eq!(
-        healed.sandbox, None,
-        "leftover macos-sandbox-exec must be cleared on the Linux seed path"
+        healed.sandbox,
+        Some(ExecutorSandboxKind::LinuxBwrap),
+        "leftover macos-sandbox-exec must become linux-bwrap"
+    );
+}
+
+#[test]
+fn seed_default_executors_upgrades_old_unsandboxed_linux_default() {
+    let store = InMemoryExecutorStore::default();
+    let stale = base_def("claude", ExecutorType::DirectAgent);
+    store
+        .upsert_executor_def(&stale)
+        .expect("seed old Linux def");
+
+    seed_default_executors_for_platform(&store, false, LINUX).expect("seed");
+
+    assert_eq!(
+        store
+            .get_executor_def("claude")
+            .expect("get")
+            .expect("claude present")
+            .sandbox,
+        Some(ExecutorSandboxKind::LinuxBwrap)
+    );
+}
+
+#[test]
+fn custom_executor_sandbox_choice_is_not_rewritten_by_seed_migration() {
+    let store = InMemoryExecutorStore::default();
+    let mut custom = base_def("custom", ExecutorType::DirectAgent);
+    custom.sandbox = Some(ExecutorSandboxKind::MacosSandboxExec);
+    store.upsert_executor_def(&custom).expect("seed custom");
+
+    seed_default_executors_for_platform(&store, false, LINUX).expect("seed defaults");
+
+    assert_eq!(
+        store
+            .get_executor_def("custom")
+            .expect("get")
+            .expect("custom preserved")
+            .sandbox,
+        Some(ExecutorSandboxKind::MacosSandboxExec)
     );
 }
 

--- a/crates/orbit-core/src/runtime/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/runtime/v2_host/sandbox.rs
@@ -1,11 +1,7 @@
 use std::path::Path;
-#[cfg(target_os = "macos")]
 use std::path::PathBuf;
 
-use orbit_common::types::ExecutorSandboxKind;
-#[cfg(target_os = "macos")]
-use orbit_common::types::{ResolvedFsProfile, UNRESTRICTED_FS_PROFILE};
-#[cfg(target_os = "macos")]
+use orbit_common::types::{ExecutorSandboxKind, ResolvedFsProfile, UNRESTRICTED_FS_PROFILE};
 use orbit_engine::EnvironmentHost;
 use orbit_engine::{DispatchError, ResolvedSandbox};
 
@@ -14,10 +10,8 @@ use crate::OrbitRuntime;
 pub(super) fn resolve_executor_sandbox(
     runtime: &OrbitRuntime,
     provider: &str,
-    #[cfg(target_os = "macos")] fs_profile: Option<&str>,
-    #[cfg(not(target_os = "macos"))] _fs_profile: Option<&str>,
-    #[cfg(target_os = "macos")] subprocess_cwd: Option<&Path>,
-    #[cfg(not(target_os = "macos"))] _subprocess_cwd: Option<&Path>,
+    fs_profile: Option<&str>,
+    subprocess_cwd: Option<&Path>,
 ) -> Result<Option<ResolvedSandbox>, DispatchError> {
     let executor = runtime.get_executor_def(provider).map_err(|err| {
         DispatchError::CliInvocationFailed(format!(
@@ -42,7 +36,7 @@ pub(super) fn resolve_executor_sandbox(
             #[cfg(target_os = "macos")]
             {
                 let mut resolved =
-                    resolve_fs_profile_absolute(runtime, fs_profile).map_err(|err| {
+                    resolve_fs_profile_absolute(runtime, fs_profile, None).map_err(|err| {
                         DispatchError::CliInvocationFailed(format!(
                             "resolve fsProfile for sandbox: {err}"
                         ))
@@ -54,6 +48,37 @@ pub(super) fn resolve_executor_sandbox(
                     kind,
                     fs_profile: resolved,
                     allow_fallback: executor.allow_fallback,
+                    managed_worktree: false,
+                }))
+            }
+        }
+        ExecutorSandboxKind::LinuxBwrap => {
+            #[cfg(not(target_os = "linux"))]
+            {
+                Err(DispatchError::CliInvocationFailed(format!(
+                    "executor `{provider}` declares sandbox `linux-bwrap` but current platform is `{}`",
+                    std::env::consts::OS
+                )))
+            }
+            #[cfg(target_os = "linux")]
+            {
+                let mut resolved = resolve_fs_profile_absolute(runtime, fs_profile, subprocess_cwd)
+                    .map_err(|err| {
+                        DispatchError::CliInvocationFailed(format!(
+                            "resolve fsProfile for linux-bwrap: {err}"
+                        ))
+                    })?;
+                append_codex_side_write_roots(runtime, provider, &mut resolved)?;
+                append_linux_runtime_write_roots(runtime, &mut resolved)?;
+                append_linux_provider_state_roots(&mut resolved)?;
+                let managed_worktree = subprocess_cwd
+                    .and_then(|cwd| active_worktree_subpath(runtime, cwd))
+                    .is_some();
+                Ok(Some(ResolvedSandbox {
+                    kind,
+                    fs_profile: resolved,
+                    allow_fallback: executor.allow_fallback,
+                    managed_worktree,
                 }))
             }
         }
@@ -65,21 +90,25 @@ pub(super) fn resolve_executor_sandbox(
 /// the workspace root. The kernel's `subpath` predicate is meaningless for
 /// relative paths, so this is the layer that turns Orbit's policy into a
 /// payload `sandbox-exec` can enforce.
-#[cfg(target_os = "macos")]
 fn resolve_fs_profile_absolute(
     runtime: &OrbitRuntime,
     fs_profile: Option<&str>,
+    workspace_override: Option<&Path>,
 ) -> Result<ResolvedFsProfile, orbit_common::types::OrbitError> {
     let profile_name = fs_profile.unwrap_or(UNRESTRICTED_FS_PROFILE);
     let resolved = runtime
         .policy_engine()
         .def()
         .effective_profile(profile_name)?;
-    let workspace_root = runtime
-        .paths()
-        .repo_root
+    let workspace_root = workspace_override
+        .unwrap_or(&runtime.paths().repo_root)
         .canonicalize()
-        .unwrap_or_else(|_| runtime.paths().repo_root.clone());
+        .unwrap_or_else(|_| {
+            workspace_override.map_or_else(
+                || runtime.paths().repo_root.clone(),
+                std::path::Path::to_path_buf,
+            )
+        });
     let workspace_str = workspace_root.display().to_string();
 
     Ok(ResolvedFsProfile {
@@ -97,7 +126,6 @@ fn resolve_fs_profile_absolute(
     })
 }
 
-#[cfg(target_os = "macos")]
 fn append_codex_side_write_roots(
     runtime: &OrbitRuntime,
     provider: &str,
@@ -193,11 +221,98 @@ fn append_orbit_child_runtime_write_roots(
     }
 }
 
-#[cfg(target_os = "macos")]
 fn append_unique_modify_root(resolved: &mut ResolvedFsProfile, root: String) {
     if !resolved.modify.iter().any(|entry| entry == &root) {
         resolved.modify.push(root);
     }
+}
+
+#[cfg(target_os = "linux")]
+fn append_linux_runtime_write_roots(
+    runtime: &OrbitRuntime,
+    resolved: &mut ResolvedFsProfile,
+) -> Result<(), DispatchError> {
+    let global = runtime
+        .paths()
+        .global_dir
+        .canonicalize()
+        .unwrap_or_else(|_| runtime.paths().global_dir.clone());
+    let workspace = runtime
+        .paths()
+        .orbit_dir
+        .canonicalize()
+        .unwrap_or_else(|_| runtime.paths().orbit_dir.clone());
+
+    for directory in [
+        global.join("state/logs"),
+        global.join("tasks"),
+        workspace.join("tasks"),
+        workspace.join("learnings"),
+        workspace.join("frictions"),
+        workspace.join("state/audit"),
+        workspace.join("state/logs"),
+        workspace.join("state/job-runs"),
+    ] {
+        ensure_owned_directory(&directory)?;
+        append_unique_modify_root(resolved, directory.display().to_string());
+    }
+    for file in [
+        global.join("orbit.db"),
+        global.join("orbit.db-wal"),
+        global.join("orbit.db-shm"),
+        workspace.join("state/.id_alloc.lock"),
+        workspace.join("state/semantic.db"),
+        workspace.join("state/semantic.db-wal"),
+        workspace.join("state/semantic.db-shm"),
+    ] {
+        if file.exists() {
+            append_unique_modify_root(resolved, file.display().to_string());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn append_linux_provider_state_roots(
+    resolved: &mut ResolvedFsProfile,
+) -> Result<(), DispatchError> {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let mut directories = Vec::new();
+    if let Some(path) = std::env::var_os("CODEX_HOME").map(PathBuf::from) {
+        directories.push(path);
+    } else if let Some(home) = &home {
+        directories.push(home.join(".codex"));
+    }
+    if let Some(path) = std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from) {
+        directories.push(path);
+    } else if let Some(home) = &home {
+        directories.push(home.join(".claude"));
+    }
+    if let Some(home) = &home {
+        directories.push(home.join(".gemini"));
+        directories.push(home.join(".grok"));
+    }
+    for directory in directories {
+        ensure_owned_directory(&directory)?;
+        let canonical = directory.canonicalize().map_err(|error| {
+            DispatchError::CliInvocationPermanent(format!(
+                "canonicalize Linux provider state root `{}`: {error}",
+                directory.display()
+            ))
+        })?;
+        append_unique_modify_root(resolved, canonical.display().to_string());
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn ensure_owned_directory(path: &Path) -> Result<(), DispatchError> {
+    std::fs::create_dir_all(path).map_err(|error| {
+        DispatchError::CliInvocationPermanent(format!(
+            "create Linux sandbox runtime root `{}`: {error}",
+            path.display()
+        ))
+    })
 }
 
 /// Re-allow the active job-run worktree under `<workspace>/.orbit/state/worktrees/`
@@ -230,7 +345,6 @@ fn append_active_worktree_root(
     resolved.modify.push(worktree_root);
 }
 
-#[cfg(target_os = "macos")]
 fn active_worktree_subpath(runtime: &OrbitRuntime, subprocess_cwd: &Path) -> Option<String> {
     let cwd = subprocess_cwd
         .canonicalize()
@@ -251,7 +365,6 @@ fn active_worktree_subpath(runtime: &OrbitRuntime, subprocess_cwd: &Path) -> Opt
     Some(worktree_dir.display().to_string())
 }
 
-#[cfg(target_os = "macos")]
 fn absolutize_side_write_root(workspace_root: &str, path: &str) -> Option<String> {
     let trimmed = path.trim();
     if trimmed.is_empty() {
@@ -271,7 +384,6 @@ fn absolutize_side_write_root(workspace_root: &str, path: &str) -> Option<String
     Some(normalized.display().to_string())
 }
 
-#[cfg(target_os = "macos")]
 fn absolutize_rule(workspace_root: &str, rule: &str) -> String {
     let (negated, body) = rule
         .strip_prefix('!')

--- a/crates/orbit-core/src/runtime/v2_host/tests/sandbox.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/sandbox.rs
@@ -1,7 +1,7 @@
 use orbit_engine::V2RuntimeHost;
 
 use crate::runtime::v2_host::test_support::seeded_runtime_with_executor;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use crate::runtime::v2_host::test_support::{runtime_with_workspace_layout, seed_executor};
 
 #[test]
@@ -11,6 +11,63 @@ fn resolve_executor_sandbox_returns_none_when_executor_has_no_sandbox() {
         .resolve_executor_sandbox("codex", None, None)
         .expect("resolve");
     assert!(resolved.is_none());
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn resolve_executor_sandbox_returns_linux_descriptor_with_absolute_mounts() {
+    let runtime =
+        seeded_runtime_with_executor(Some(orbit_common::types::ExecutorSandboxKind::LinuxBwrap));
+    let resolved = runtime
+        .resolve_executor_sandbox("codex", None, None)
+        .expect("resolve")
+        .expect("descriptor");
+    assert_eq!(
+        resolved.kind,
+        orbit_common::types::ExecutorSandboxKind::LinuxBwrap
+    );
+    assert!(!resolved.managed_worktree);
+    for entry in &resolved.fs_profile.modify {
+        let body = entry.strip_prefix('!').unwrap_or(entry);
+        assert!(
+            body.starts_with('/'),
+            "linux-bwrap mount rule must be absolute: {entry}"
+        );
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn resolve_executor_sandbox_marks_only_specific_orbit_worktree_managed() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    seed_executor(
+        &runtime,
+        "claude",
+        Some(orbit_common::types::ExecutorSandboxKind::LinuxBwrap),
+    );
+    let worktrees = runtime.paths().orbit_dir.join("state/worktrees");
+    let worktree = worktrees.join("orbit-jrun-test");
+    std::fs::create_dir_all(&worktree).expect("create worktree");
+
+    let managed = runtime
+        .resolve_executor_sandbox("claude", None, Some(&worktree))
+        .expect("resolve managed")
+        .expect("descriptor");
+    assert!(managed.managed_worktree);
+    let canonical_worktree = worktree.canonicalize().expect("canonical worktree");
+    assert!(
+        managed
+            .fs_profile
+            .modify
+            .iter()
+            .any(|entry| entry == &format!("{}/**", canonical_worktree.display()))
+    );
+
+    let direct = runtime
+        .resolve_executor_sandbox("claude", None, Some(&repo_root))
+        .expect("resolve direct")
+        .expect("descriptor");
+    assert!(!direct.managed_worktree);
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/orbit-engine/src/activity_job/cli_runner/argv.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/argv.rs
@@ -1,7 +1,11 @@
 use std::collections::HashMap;
+use std::path::Path;
 
 use orbit_common::types::ExecutorSandboxKind;
-use orbit_exec::{claude_state_dir_from_env, sandbox_exec_program_for_audit};
+use orbit_exec::{
+    bwrap_program_for_audit, claude_state_dir_from_env, compile_linux_bwrap_argv,
+    sandbox_exec_program_for_audit,
+};
 
 use super::super::dispatcher::ResolvedSandbox;
 
@@ -26,12 +30,42 @@ pub(super) fn audit_argv_for_dispatch(
             out.extend(args.iter().cloned());
             out
         }
+        Some(sb) if sb.kind == ExecutorSandboxKind::LinuxBwrap => {
+            try_audit_argv_for_dispatch(program, args, Some(sb), None).unwrap_or_else(|_| {
+                let mut out = vec![
+                    bwrap_program_for_audit().to_string(),
+                    "<invalid-linux-bwrap-plan>".to_string(),
+                    program.to_string(),
+                ];
+                out.extend(args.iter().cloned());
+                out
+            })
+        }
         _ => {
             let mut out = Vec::with_capacity(args.len() + 1);
             out.push(program.to_string());
             out.extend(args.iter().cloned());
             out
         }
+    }
+}
+
+pub(super) fn try_audit_argv_for_dispatch(
+    program: &str,
+    args: &[String],
+    sandbox: Option<&ResolvedSandbox>,
+    cwd: Option<&Path>,
+) -> Result<Vec<String>, orbit_common::types::OrbitError> {
+    match sandbox {
+        Some(sb) if sb.kind == ExecutorSandboxKind::LinuxBwrap => {
+            let plan =
+                compile_linux_bwrap_argv(&sb.fs_profile, program, args, cwd, sb.managed_worktree)?;
+            let mut out = Vec::with_capacity(plan.args.len() + 1);
+            out.push(plan.wrapper);
+            out.extend(plan.args);
+            Ok(out)
+        }
+        _ => Ok(audit_argv_for_dispatch(program, args, sandbox)),
     }
 }
 

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -24,17 +24,18 @@ use super::super::workspace::{
     WorktreeBoundaryGuard, resolve_subprocess_cwd, validate_declared_worktree_pair,
 };
 use super::argv::{
-    apply_provider_static_arg_fixups, audit_argv_for_dispatch, neutralize_inner_sandbox,
+    apply_provider_static_arg_fixups, neutralize_inner_sandbox, try_audit_argv_for_dispatch,
 };
 use super::envelope::{
     cli_agent_envelope_json, parse_cli_invocation_trace, parse_cli_response_result,
     task_id_from_input,
 };
-use super::spawn::resolve_provider_launcher;
+use super::spawn::{prepare_sandbox_for_dispatch, resolve_provider_launcher};
 use super::supervisor::{
     DEFAULT_WALL_CLOCK_TIMEOUT_SECONDS, SpawnTraceContext, SpawnWithTimeoutRequest,
     spawn_with_timeout,
 };
+use orbit_exec::LinuxBwrapPostRunGuard;
 
 const STDOUT_TEXT_PREVIEW_LIMIT_BYTES: usize = 64 * 1024;
 const RESPONSE_DIAGNOSTIC_LIMIT_CHARS: usize = 1024;
@@ -91,8 +92,11 @@ pub fn run_cli_backend(
     let subprocess_cwd_string = subprocess_cwd
         .as_ref()
         .map(|path| path.display().to_string());
-    let sandbox =
+    let resolved_sandbox =
         host.resolve_executor_sandbox(&provider, fs_profile, subprocess_cwd.as_deref())?;
+    let prepared_sandbox = prepare_sandbox_for_dispatch(resolved_sandbox.as_ref())
+        .map_err(|error| DispatchError::CliInvocationPermanent(error.message))?;
+    let sandbox = prepared_sandbox.effective;
 
     let learning_context = cli_learning_context(host, input, tool_ctx.workspace_root.as_deref())?;
     let envelope_json = cli_agent_envelope_json(
@@ -163,7 +167,13 @@ pub fn run_cli_backend(
     // under bare exec it's `<program> <args...>`. The redactor still scrubs
     // the child's program name + args so secrets in argv stay redacted.
     let redaction = PatternRedactor::with_argv_secrets();
-    let audit_argv = audit_argv_for_dispatch(&resolved_program, &subprocess_args, sandbox.as_ref());
+    let audit_argv = try_audit_argv_for_dispatch(
+        &resolved_program,
+        &subprocess_args,
+        sandbox,
+        subprocess_cwd.as_deref(),
+    )
+    .map_err(|error| DispatchError::CliInvocationPermanent(error.to_string()))?;
     let argv_redacted: Vec<String> = audit_argv.iter().map(|a| redaction.apply_str(a)).collect();
 
     let stdin_blob_ref = audit.write_blob(&invocation.stdin);
@@ -191,6 +201,11 @@ pub fn run_cli_backend(
         model: model_redacted,
         cwd: subprocess_cwd_string.clone(),
         wall_clock_timeout_ms: wall_clock_timeout.as_millis() as u64,
+        sandbox_backend: prepared_sandbox.metadata.backend.clone(),
+        sandbox_trusted_wrapper: prepared_sandbox.metadata.trusted_wrapper.clone(),
+        sandbox_probe_outcome: prepared_sandbox.metadata.probe_outcome.clone(),
+        sandbox_write_enforcement: Some(prepared_sandbox.metadata.write_enforcement.clone()),
+        sandbox_read_enforcement: Some(prepared_sandbox.metadata.read_enforcement.clone()),
     });
 
     let task_id = task_id_from_input(input);
@@ -223,6 +238,17 @@ pub fn run_cli_backend(
         });
     };
 
+    let linux_post_run_guard = match sandbox {
+        Some(sandbox)
+            if sandbox.kind == orbit_common::types::ExecutorSandboxKind::LinuxBwrap
+                && sandbox.managed_worktree =>
+        {
+            LinuxBwrapPostRunGuard::capture(&sandbox.fs_profile)
+                .map_err(|error| DispatchError::CliInvocationPermanent(error.to_string()))?
+        }
+        _ => None,
+    };
+
     let spawn_result = spawn_with_timeout(SpawnWithTimeoutRequest {
         program: &resolved_program,
         args: &subprocess_args,
@@ -230,7 +256,7 @@ pub fn run_cli_backend(
         env: &child_env,
         cwd: subprocess_cwd.as_deref(),
         timeout: wall_clock_timeout,
-        sandbox: sandbox.as_ref(),
+        sandbox,
         trace: SpawnTraceContext {
             provider: &provider,
             job_run_id: run_id,
@@ -258,6 +284,12 @@ pub fn run_cli_backend(
             });
         }
     };
+
+    if let Some(guard) = linux_post_run_guard {
+        guard
+            .verify()
+            .map_err(|error| DispatchError::CliInvocationPermanent(error.to_string()))?;
+    }
 
     let stdout_blob_ref = audit.write_blob(stdout.bytes());
     let stderr_blob_ref = audit.write_blob(stderr.bytes());

--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -6,8 +6,9 @@ use std::process::{Child, Command, Stdio};
 use orbit_common::types::ExecutorSandboxKind;
 use orbit_common::utility::redaction::non_sensitive_env_vars;
 use orbit_exec::{
-    MacosSandboxSpawnRequest, compile_macos_sandbox_profile, sandbox_exec_available,
-    sandbox_exec_unavailable_message, spawn_under_macos_sandbox,
+    BwrapProbeOutcome, LinuxBwrapSpawnRequest, MacosSandboxSpawnRequest, compile_linux_bwrap_argv,
+    compile_macos_sandbox_profile, probe_bwrap, sandbox_exec_available,
+    sandbox_exec_unavailable_message, spawn_under_linux_bwrap, spawn_under_macos_sandbox,
 };
 use tempfile::NamedTempFile;
 
@@ -25,6 +26,94 @@ use super::super::dispatcher::ResolvedSandbox;
 pub(crate) struct SpawnError {
     pub(crate) permanent: bool,
     pub(crate) message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SandboxDispatchMetadata {
+    pub(super) backend: Option<String>,
+    pub(super) trusted_wrapper: Option<String>,
+    pub(super) probe_outcome: Option<String>,
+    pub(super) write_enforcement: String,
+    pub(super) read_enforcement: String,
+}
+
+pub(super) struct PreparedSandbox<'a> {
+    pub(super) effective: Option<&'a ResolvedSandbox>,
+    pub(super) metadata: SandboxDispatchMetadata,
+}
+
+/// Resolve availability before provider argv construction. This ordering is
+/// security-sensitive: provider-native flags are neutralized only when the
+/// outer wrapper is actually usable, while an explicitly allowed bare
+/// fallback keeps those flags intact.
+pub(super) fn prepare_sandbox_for_dispatch(
+    sandbox: Option<&ResolvedSandbox>,
+) -> Result<PreparedSandbox<'_>, SpawnError> {
+    match sandbox {
+        Some(sandbox) if sandbox.kind == ExecutorSandboxKind::LinuxBwrap => {
+            let probe = probe_bwrap();
+            prepare_linux_sandbox_for_dispatch_with_probe(sandbox, probe)
+        }
+        Some(sandbox) => Ok(PreparedSandbox {
+            effective: Some(sandbox),
+            metadata: SandboxDispatchMetadata {
+                backend: Some(sandbox.kind.as_str().to_string()),
+                trusted_wrapper: None,
+                probe_outcome: None,
+                write_enforcement: "write_enforced".to_string(),
+                read_enforcement: "read_delegated".to_string(),
+            },
+        }),
+        None => Ok(PreparedSandbox {
+            effective: None,
+            metadata: SandboxDispatchMetadata {
+                backend: None,
+                trusted_wrapper: None,
+                probe_outcome: None,
+                write_enforcement: "write_delegated".to_string(),
+                read_enforcement: "read_delegated".to_string(),
+            },
+        }),
+    }
+}
+
+pub(crate) fn prepare_linux_sandbox_for_dispatch_with_probe<'a>(
+    sandbox: &'a ResolvedSandbox,
+    probe: BwrapProbeOutcome,
+) -> Result<PreparedSandbox<'a>, SpawnError> {
+    if probe.available {
+        Ok(PreparedSandbox {
+            effective: Some(sandbox),
+            metadata: SandboxDispatchMetadata {
+                backend: Some("linux-bwrap".to_string()),
+                trusted_wrapper: Some(probe.trusted_path),
+                probe_outcome: Some(probe.detail),
+                write_enforcement: "write_enforced".to_string(),
+                read_enforcement: "read_delegated".to_string(),
+            },
+        })
+    } else if sandbox.allow_fallback {
+        tracing::warn!(
+            target: "orbit.engine.cli_runner",
+            reason = %probe.detail,
+            "linux-bwrap unavailable; falling back to bare exec because executor declares allow_fallback"
+        );
+        Ok(PreparedSandbox {
+            effective: None,
+            metadata: SandboxDispatchMetadata {
+                backend: Some("bare-fallback".to_string()),
+                trusted_wrapper: Some(probe.trusted_path),
+                probe_outcome: Some(probe.detail),
+                write_enforcement: "write_delegated".to_string(),
+                read_enforcement: "read_delegated".to_string(),
+            },
+        })
+    } else {
+        Err(SpawnError::permanent(format!(
+            "{}; declare allow_fallback: true to permit bare exec",
+            probe.detail
+        )))
+    }
 }
 
 impl SpawnError {
@@ -171,8 +260,45 @@ pub(super) fn spawn_child_with_optional_sandbox(
         Some(sb) if sb.kind == ExecutorSandboxKind::MacosSandboxExec => {
             spawn_macos_sandboxed(program, args, env, cwd, sb)
         }
-        Some(_) | None => spawn_bare(program, args, env, cwd),
+        Some(sb) if sb.kind == ExecutorSandboxKind::LinuxBwrap => {
+            spawn_linux_bwrap(program, args, env, cwd, sb)
+        }
+        Some(sb) => Err(SpawnError::permanent(format!(
+            "unsupported sandbox backend `{}`",
+            sb.kind
+        ))),
+        None => spawn_bare(program, args, env, cwd),
     }
+}
+
+fn spawn_linux_bwrap(
+    program: &str,
+    args: &[String],
+    env: &[(String, String)],
+    cwd: Option<&Path>,
+    sandbox: &ResolvedSandbox,
+) -> Result<SpawnedChild, SpawnError> {
+    let plan = compile_linux_bwrap_argv(
+        &sandbox.fs_profile,
+        program,
+        args,
+        cwd,
+        sandbox.managed_worktree,
+    )
+    .map_err(|error| SpawnError::permanent(error.to_string()))?;
+    let child = spawn_under_linux_bwrap(LinuxBwrapSpawnRequest {
+        plan: &plan,
+        env,
+        cwd,
+        stdin: Stdio::piped(),
+        stdout: Stdio::piped(),
+        stderr: Stdio::piped(),
+    })
+    .map_err(|error| SpawnError::transient(error.to_string()))?;
+    Ok(SpawnedChild {
+        child,
+        _profile_temp: None,
+    })
 }
 
 // pub(crate) widened for tests/ layout under ORB-00225; test reaches via exposed surface.

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
@@ -2,12 +2,14 @@
 
 use std::ffi::OsString;
 
+use orbit_common::types::ExecutorSandboxKind;
+use orbit_exec::BwrapProbeOutcome;
 use tempfile::tempdir;
 
 use super::super::super::dispatcher::ResolvedSandbox;
 use super::super::spawn::{
-    SpawnError, SpawnedChild, resolve_provider_launcher_with, spawn_bare,
-    spawn_macos_sandboxed_with,
+    SpawnError, SpawnedChild, prepare_linux_sandbox_for_dispatch_with_probe,
+    resolve_provider_launcher_with, spawn_bare, spawn_macos_sandboxed_with,
 };
 use super::test_support::{sandbox_for_test, sh_args};
 
@@ -72,6 +74,65 @@ fn spawn_macos_sandboxed_returns_error_when_sandbox_exec_missing_and_fallback_di
         "error should describe fallback opt-in: {}",
         err.message
     );
+}
+
+fn linux_sandbox_for_test(allow_fallback: bool) -> ResolvedSandbox {
+    ResolvedSandbox {
+        kind: ExecutorSandboxKind::LinuxBwrap,
+        allow_fallback,
+        ..sandbox_for_test()
+    }
+}
+
+fn failed_bwrap_probe() -> BwrapProbeOutcome {
+    BwrapProbeOutcome {
+        available: false,
+        trusted_path: "/usr/bin/bwrap".to_string(),
+        detail: "Bubblewrap capability probe failed: user namespaces disabled".to_string(),
+    }
+}
+
+#[test]
+fn linux_bwrap_probe_failure_is_permanent_when_fallback_disabled() {
+    let sandbox = linux_sandbox_for_test(false);
+    let error = prepare_linux_sandbox_for_dispatch_with_probe(&sandbox, failed_bwrap_probe())
+        .err()
+        .expect("probe failure must stop dispatch");
+    assert!(error.permanent);
+    assert!(error.message.contains("user namespaces disabled"));
+    assert!(error.message.contains("allow_fallback: true"));
+}
+
+#[test]
+fn linux_bwrap_probe_failure_uses_honest_bare_fallback_metadata() {
+    let sandbox = linux_sandbox_for_test(true);
+    let prepared = prepare_linux_sandbox_for_dispatch_with_probe(&sandbox, failed_bwrap_probe())
+        .expect("explicit fallback");
+    assert!(prepared.effective.is_none());
+    assert_eq!(prepared.metadata.backend.as_deref(), Some("bare-fallback"));
+    assert_eq!(prepared.metadata.write_enforcement, "write_delegated");
+    assert_eq!(prepared.metadata.read_enforcement, "read_delegated");
+    assert_eq!(
+        prepared.metadata.trusted_wrapper.as_deref(),
+        Some("/usr/bin/bwrap")
+    );
+}
+
+#[test]
+fn successful_linux_bwrap_probe_marks_write_enforcement() {
+    let sandbox = linux_sandbox_for_test(false);
+    let prepared = prepare_linux_sandbox_for_dispatch_with_probe(
+        &sandbox,
+        BwrapProbeOutcome {
+            available: true,
+            trusted_path: "/usr/bin/bwrap".to_string(),
+            detail: "capability probe succeeded".to_string(),
+        },
+    )
+    .expect("probe success");
+    assert!(prepared.effective.is_some());
+    assert_eq!(prepared.metadata.backend.as_deref(), Some("linux-bwrap"));
+    assert_eq!(prepared.metadata.write_enforcement, "write_enforced");
 }
 
 #[test]

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
@@ -41,6 +41,7 @@ pub(in crate::activity_job::cli_runner) fn sandbox_for_test() -> ResolvedSandbox
             modify: vec!["/tmp".to_string()],
         },
         allow_fallback: false,
+        managed_worktree: false,
     }
 }
 

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -41,6 +41,9 @@ pub struct ResolvedSandbox {
     pub fs_profile: ResolvedFsProfile,
     /// Whether to fall back to bare exec if the OS primitive is unavailable.
     pub allow_fallback: bool,
+    /// Whether the subprocess runs in an Orbit-owned disposable worktree.
+    /// Linux may snapshot-expand non-subtree deny globs only in this case.
+    pub managed_worktree: bool,
 }
 
 /// Orbit-core-owned responsibilities the v2 dispatcher delegates back across

--- a/crates/orbit-exec/src/lib.rs
+++ b/crates/orbit-exec/src/lib.rs
@@ -29,6 +29,7 @@
 //! # Dependency direction
 //! `orbit-types` → `orbit-exec` → orbit-tools
 
+pub mod linux_sandbox;
 pub mod macos_sandbox;
 pub mod process;
 pub mod result;
@@ -36,6 +37,11 @@ pub mod runner;
 pub mod sandbox;
 mod supervision;
 
+pub use linux_sandbox::{
+    BwrapProbeOutcome, LinuxBwrapPlan, LinuxBwrapPostRunGuard, LinuxBwrapSpawnRequest, bwrap_path,
+    bwrap_program_for_audit, bwrap_unavailable_message, compile_linux_bwrap_argv, probe_bwrap,
+    spawn_under_linux_bwrap,
+};
 pub use macos_sandbox::{
     MacosSandboxSpawnRequest, claude_state_dir_from_env, compile_macos_sandbox_profile,
     grok_state_dir_from_env, sandbox_exec_available, sandbox_exec_path,

--- a/crates/orbit-exec/src/linux_sandbox.rs
+++ b/crates/orbit-exec/src/linux_sandbox.rs
@@ -1,0 +1,407 @@
+//! Linux Bubblewrap write-confinement for CLI-backed agents.
+//!
+//! The backend deliberately keeps the host filesystem readable and materializes
+//! `ResolvedFsProfile::modify` as ordered bind mounts. It is therefore honest
+//! write confinement, not a general read-policy implementation.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+use orbit_common::types::{OrbitError, ResolvedFsProfile};
+use orbit_common::utility::glob::compile_glob_regex;
+use orbit_common::utility::redaction::non_sensitive_env_vars;
+
+const TRUSTED_BWRAP_PATH: &str = "/usr/bin/bwrap";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BwrapProbeOutcome {
+    pub available: bool,
+    pub trusted_path: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinuxBwrapPlan {
+    pub wrapper: String,
+    pub args: Vec<String>,
+}
+
+#[derive(Debug)]
+pub struct LinuxBwrapSpawnRequest<'a> {
+    pub plan: &'a LinuxBwrapPlan,
+    pub env: &'a [(String, String)],
+    pub cwd: Option<&'a Path>,
+    pub stdin: Stdio,
+    pub stdout: Stdio,
+    pub stderr: Stdio,
+}
+
+/// Snapshot guard for Bubblewrap's one known write-policy gap: a
+/// non-subtree deny glob cannot be represented for a path that does not exist
+/// yet. Managed worktrees are disposable and single-writer, so Orbit records
+/// existing matches before spawn and rejects any new matches after the child.
+#[derive(Debug, Clone)]
+pub struct LinuxBwrapPostRunGuard {
+    rules: Vec<String>,
+    before: BTreeSet<PathBuf>,
+}
+
+impl LinuxBwrapPostRunGuard {
+    pub fn capture(profile: &ResolvedFsProfile) -> Result<Option<Self>, OrbitError> {
+        let rules = non_subtree_denies(profile);
+        if rules.is_empty() {
+            return Ok(None);
+        }
+        let before = expand_rules(&rules)?;
+        Ok(Some(Self { rules, before }))
+    }
+
+    pub fn verify(&self) -> Result<(), OrbitError> {
+        let after = expand_rules(&self.rules)?;
+        let created = after.difference(&self.before).next();
+        if let Some(path) = created {
+            return Err(OrbitError::PolicyDenied(format!(
+                "linux-bwrap child created a path forbidden by denyModify before commit: {}",
+                path.display()
+            )));
+        }
+        Ok(())
+    }
+}
+
+pub fn bwrap_program_for_audit() -> &'static str {
+    TRUSTED_BWRAP_PATH
+}
+
+pub fn bwrap_path() -> Option<PathBuf> {
+    let path = Path::new(TRUSTED_BWRAP_PATH);
+    (cfg!(target_os = "linux") && is_executable(path)).then(|| path.to_path_buf())
+}
+
+pub fn bwrap_unavailable_message() -> String {
+    format!("trusted Bubblewrap not available at {TRUSTED_BWRAP_PATH}")
+}
+
+/// Probe the namespaces and mounts Orbit relies on rather than treating a
+/// present binary as usable. The host network namespace is retained
+/// explicitly with `--share-net`.
+pub fn probe_bwrap() -> BwrapProbeOutcome {
+    let Some(path) = bwrap_path() else {
+        return BwrapProbeOutcome {
+            available: false,
+            trusted_path: TRUSTED_BWRAP_PATH.to_string(),
+            detail: bwrap_unavailable_message(),
+        };
+    };
+    let args = base_namespace_args();
+    let output = Command::new(&path)
+        .args(&args)
+        .arg("--")
+        .arg("/bin/true")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output();
+    match output {
+        Ok(output) if output.status.success() => BwrapProbeOutcome {
+            available: true,
+            trusted_path: path.display().to_string(),
+            detail: "capability probe succeeded".to_string(),
+        },
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let detail = stderr.trim();
+            BwrapProbeOutcome {
+                available: false,
+                trusted_path: path.display().to_string(),
+                detail: format!(
+                    "Bubblewrap capability probe failed{}{}",
+                    if detail.is_empty() { "" } else { ": " },
+                    detail
+                ),
+            }
+        }
+        Err(error) => BwrapProbeOutcome {
+            available: false,
+            trusted_path: path.display().to_string(),
+            detail: format!("Bubblewrap capability probe could not execute: {error}"),
+        },
+    }
+}
+
+/// Compile a deterministic Bubblewrap argv. Every writable mount is emitted
+/// before every deny mount, so exact and subtree denials always win even when
+/// Orbit/provider runtime roots were appended after policy resolution.
+pub fn compile_linux_bwrap_argv(
+    profile: &ResolvedFsProfile,
+    program: &str,
+    args: &[String],
+    cwd: Option<&Path>,
+    managed_worktree: bool,
+) -> Result<LinuxBwrapPlan, OrbitError> {
+    let mut out = base_namespace_args();
+    // Replace mutable host pseudo-filesystems and scratch before applying
+    // policy mounts. A writable worktree nested below `/tmp` is then re-bound
+    // narrowly without exposing the rest of the host scratch tree.
+    out.extend([
+        "--dev".to_string(),
+        "/dev".to_string(),
+        "--proc".to_string(),
+        "/proc".to_string(),
+        "--tmpfs".to_string(),
+        "/tmp".to_string(),
+    ]);
+    let writable_roots = positive_mount_roots(profile)?;
+
+    for rule in profile.modify.iter().filter(|rule| !rule.starts_with('!')) {
+        for path in mount_paths_for_rule(rule, true)? {
+            push_mount(&mut out, "--bind", &path);
+        }
+    }
+    for denied in profile
+        .modify
+        .iter()
+        .filter_map(|rule| rule.strip_prefix('!'))
+    {
+        if !is_exact_or_subtree(denied)
+            && !managed_worktree
+            && overlaps_writable_root(denied, &writable_roots)
+        {
+            return Err(OrbitError::PolicyDenied(format!(
+                "linux-bwrap cannot enforce non-subtree denyModify `{denied}` for a direct invocation; use a managed worktree"
+            )));
+        }
+        for path in mount_paths_for_rule(denied, false)? {
+            push_mount(&mut out, "--ro-bind", &path);
+        }
+    }
+
+    if let Some(cwd) = cwd {
+        let cwd = canonical_existing(cwd, "sandbox cwd")?;
+        out.push("--chdir".to_string());
+        out.push(cwd.display().to_string());
+    }
+    out.push("--".to_string());
+    out.push(program.to_string());
+    out.extend(args.iter().cloned());
+
+    Ok(LinuxBwrapPlan {
+        wrapper: TRUSTED_BWRAP_PATH.to_string(),
+        args: out,
+    })
+}
+
+pub fn spawn_under_linux_bwrap(request: LinuxBwrapSpawnRequest<'_>) -> Result<Child, OrbitError> {
+    let LinuxBwrapSpawnRequest {
+        plan,
+        env,
+        cwd,
+        stdin,
+        stdout,
+        stderr,
+    } = request;
+    if plan.wrapper != TRUSTED_BWRAP_PATH {
+        return Err(OrbitError::Execution(format!(
+            "refusing untrusted Bubblewrap wrapper `{}`",
+            plan.wrapper
+        )));
+    }
+    let mut command = Command::new(TRUSTED_BWRAP_PATH);
+    command
+        .args(&plan.args)
+        .env_clear()
+        .envs(non_sensitive_env_vars())
+        .envs(env.iter().map(|(key, value)| (key, value)))
+        .stdin(stdin)
+        .stdout(stdout)
+        .stderr(stderr);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    command.spawn().map_err(|error| {
+        OrbitError::Execution(format!(
+            "failed to spawn trusted Bubblewrap `{TRUSTED_BWRAP_PATH}`: {error}"
+        ))
+    })
+}
+
+fn base_namespace_args() -> Vec<String> {
+    [
+        "--die-with-parent",
+        "--new-session",
+        "--unshare-all",
+        "--share-net",
+        "--ro-bind",
+        "/",
+        "/",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect()
+}
+
+fn push_mount(args: &mut Vec<String>, option: &str, path: &Path) {
+    let rendered = path.display().to_string();
+    args.push(option.to_string());
+    args.push(rendered.clone());
+    args.push(rendered);
+}
+
+fn positive_mount_roots(profile: &ResolvedFsProfile) -> Result<Vec<PathBuf>, OrbitError> {
+    let mut roots = BTreeSet::new();
+    for rule in profile.modify.iter().filter(|rule| !rule.starts_with('!')) {
+        for root in mount_paths_for_rule(rule, true)? {
+            roots.insert(root);
+        }
+    }
+    Ok(roots.into_iter().collect())
+}
+
+fn mount_paths_for_rule(rule: &str, require_match: bool) -> Result<Vec<PathBuf>, OrbitError> {
+    if is_exact_or_subtree(rule) {
+        let root = rule.strip_suffix("/**").unwrap_or(rule);
+        let path = canonical_existing(Path::new(root), "sandbox mount")?;
+        return Ok(vec![path]);
+    }
+    let matches = expand_rule(rule)?;
+    if require_match && matches.is_empty() {
+        return Err(OrbitError::InvalidInput(format!(
+            "linux-bwrap modify rule `{rule}` has no existing path to mount"
+        )));
+    }
+    Ok(matches.into_iter().collect())
+}
+
+fn is_exact_or_subtree(rule: &str) -> bool {
+    let body = rule.strip_suffix("/**").unwrap_or(rule);
+    !body.contains(['*', '?'])
+}
+
+fn overlaps_writable_root(rule: &str, roots: &[PathBuf]) -> bool {
+    let prefix = static_prefix(rule);
+    roots
+        .iter()
+        .any(|root| root.starts_with(&prefix) || prefix.starts_with(root))
+}
+
+fn non_subtree_denies(profile: &ResolvedFsProfile) -> Vec<String> {
+    profile
+        .modify
+        .iter()
+        .filter_map(|rule| rule.strip_prefix('!'))
+        .filter(|rule| !is_exact_or_subtree(rule))
+        .map(str::to_string)
+        .collect()
+}
+
+fn expand_rules(rules: &[String]) -> Result<BTreeSet<PathBuf>, OrbitError> {
+    let mut expanded = BTreeSet::new();
+    for rule in rules {
+        expanded.extend(expand_rule(rule)?);
+    }
+    Ok(expanded)
+}
+
+fn expand_rule(rule: &str) -> Result<BTreeSet<PathBuf>, OrbitError> {
+    let regex = compile_glob_regex(rule).map_err(|error| {
+        OrbitError::InvalidInput(format!(
+            "invalid linux-bwrap filesystem glob `{rule}`: {error}"
+        ))
+    })?;
+    let root = nearest_existing_ancestor(&static_prefix(rule))?;
+    let mut candidates = Vec::new();
+    walk_paths(&root, &mut candidates)?;
+    let mut matches = BTreeSet::new();
+    for candidate in candidates {
+        let rendered = candidate.to_string_lossy().replace('\\', "/");
+        if regex.is_match(&rendered) {
+            matches.insert(canonical_existing(&candidate, "denyModify match")?);
+        }
+    }
+    Ok(matches)
+}
+
+fn static_prefix(rule: &str) -> PathBuf {
+    let wildcard = rule.find(['*', '?']).unwrap_or(rule.len());
+    let literal = &rule[..wildcard];
+    let boundary = literal.rfind('/').unwrap_or(0);
+    let prefix = if wildcard == rule.len() {
+        literal
+    } else if boundary == 0 {
+        "/"
+    } else {
+        &literal[..boundary]
+    };
+    PathBuf::from(prefix)
+}
+
+fn nearest_existing_ancestor(path: &Path) -> Result<PathBuf, OrbitError> {
+    let mut current = path.to_path_buf();
+    while !current.exists() {
+        if !current.pop() {
+            return Err(OrbitError::InvalidInput(format!(
+                "linux-bwrap glob root `{}` has no existing ancestor",
+                path.display()
+            )));
+        }
+    }
+    canonical_existing(&current, "glob search root")
+}
+
+fn walk_paths(root: &Path, out: &mut Vec<PathBuf>) -> Result<(), OrbitError> {
+    out.push(root.to_path_buf());
+    if !root.is_dir() {
+        return Ok(());
+    }
+    let entries = std::fs::read_dir(root).map_err(|error| {
+        OrbitError::Execution(format!(
+            "read linux-bwrap glob root `{}`: {error}",
+            root.display()
+        ))
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            OrbitError::Execution(format!("read linux-bwrap glob entry: {error}"))
+        })?;
+        let path = entry.path();
+        out.push(path.clone());
+        if entry
+            .file_type()
+            .map_err(|error| {
+                OrbitError::Execution(format!("inspect `{}`: {error}", path.display()))
+            })?
+            .is_dir()
+        {
+            walk_paths(&path, out)?;
+        }
+    }
+    Ok(())
+}
+
+fn canonical_existing(path: &Path, label: &str) -> Result<PathBuf, OrbitError> {
+    path.canonicalize().map_err(|error| {
+        OrbitError::InvalidInput(format!(
+            "{label} `{}` must exist and resolve canonically: {error}",
+            path.display()
+        ))
+    })
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path)
+        .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
+}

--- a/crates/orbit-exec/tests/linux_sandbox.rs
+++ b/crates/orbit-exec/tests/linux_sandbox.rs
@@ -1,115 +1,149 @@
 #![allow(missing_docs)]
-// [ORB-10009] Fixture setup uses unwrap/expect for readability.
-#![allow(clippy::expect_used, clippy::unwrap_used)]
-#![cfg(target_os = "linux")]
-
-//! [ORB-10009] Linux-side contract tests for orbit-exec's sandbox surface.
-//!
-//! Orbit has no Linux kernel sandbox: `sandbox-exec` (SBPL) is macOS-only,
-//! and no Landlock/seccomp/namespace confinement exists yet. These tests
-//! pin the two halves of that contract on a real Linux host:
-//!
-//! 1. **Fail closed** — the macOS sandbox primitives must refuse to run
-//!    (never silently spawn an *unsandboxed* child) when `sandbox-exec` is
-//!    unavailable. `orbit-core`'s dispatcher-level twin
-//!    (`resolve_executor_sandbox_errors_on_non_macos_platform`) covers the
-//!    executor path.
-//! 2. **Honesty tripwire** — `run_process` + `NoSandbox` provides *zero*
-//!    kernel-level filesystem confinement on Linux; the policy layer
-//!    (`PolicyEngine::check_resolved`, [ORB-00418]) is the only enforcement
-//!    seam and is therefore load-bearing. If Linux sandboxing (e.g.
-//!    Landlock) is ever added, this test flips and forces the expectations
-//!    — and the CI story — to be updated together. Gate any future
-//!    kernel-primitive tests on runtime feature detection (probe, then
-//!    skip-with-message), not compile-time cfg alone.
 
 use std::process::Stdio;
 
+use orbit_common::types::ResolvedFsProfile;
 use orbit_exec::{
-    EnvironmentMode, ExecRequest, MacosSandboxSpawnRequest, NoSandbox, StdinMode, run_process,
-    sandbox_exec_available, sandbox_exec_unavailable_message, spawn_under_macos_sandbox,
+    LinuxBwrapPostRunGuard, LinuxBwrapSpawnRequest, bwrap_path, bwrap_program_for_audit,
+    compile_linux_bwrap_argv, probe_bwrap, spawn_under_linux_bwrap,
 };
 
-/// Skip-with-message helper for host prerequisites (mirrors the
-/// `sandbox_exec_can_apply()` self-skip pattern on the macOS leg).
-#[allow(clippy::print_stderr)]
-fn host_has(path: &str) -> bool {
-    let present = std::path::Path::new(path).exists();
-    if !present {
-        eprintln!("skipping: `{path}` not present on this host");
+fn profile(modify: Vec<String>) -> ResolvedFsProfile {
+    ResolvedFsProfile {
+        name: "test".to_string(),
+        read: vec!["/**".to_string()],
+        modify,
     }
-    present
 }
 
 #[test]
-fn sandbox_exec_is_unavailable_on_linux() {
-    assert!(
-        !sandbox_exec_available(),
-        "no trusted sandbox-exec should exist on Linux"
-    );
-    let message = sandbox_exec_unavailable_message();
-    assert!(
-        message.contains("sandbox-exec"),
-        "unavailable message should name the missing wrapper: {message}"
-    );
+fn trusted_resolution_never_consults_path() {
+    assert_eq!(bwrap_program_for_audit(), "/usr/bin/bwrap");
+    if let Some(path) = bwrap_path() {
+        assert_eq!(path.to_string_lossy(), "/usr/bin/bwrap");
+    }
 }
 
 #[test]
-fn spawn_under_macos_sandbox_fails_closed_on_linux() {
-    // The spawn primitive must error out — not fall back to an unsandboxed
-    // child — when the trusted wrapper is missing.
-    let marker = tempfile::NamedTempFile::new().expect("marker file");
-    let script = format!("echo escaped > {}", marker.path().display());
-    let args = ["-c".to_string(), script];
-    let result = spawn_under_macos_sandbox(MacosSandboxSpawnRequest {
-        profile_text: "(version 1)\n(allow default)\n",
-        program: "/bin/sh",
-        args: &args,
-        env: &[],
-        cwd: None,
-        stdin: Stdio::null(),
-        stdout: Stdio::null(),
-        stderr: Stdio::null(),
-    });
-    assert!(result.is_err(), "must fail closed without sandbox-exec");
-    let content = std::fs::read_to_string(marker.path()).expect("read marker");
-    assert!(
-        content.is_empty(),
-        "no child may run when the sandbox wrapper is unavailable; marker: {content:?}"
-    );
+fn argv_is_deterministic_and_orders_denies_after_writable_parent() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    let denied = workspace.join(".orbit");
+    std::fs::create_dir_all(&denied).expect("create fixture");
+    let resolved = profile(vec![
+        format!("{}/**", workspace.display()),
+        format!("!{}/**", denied.display()),
+    ]);
+
+    let plan = compile_linux_bwrap_argv(&resolved, "/bin/true", &[], Some(&workspace), false)
+        .expect("compile");
+    let joined = plan.args.join(" ");
+    for required in [
+        "--die-with-parent",
+        "--new-session",
+        "--unshare-all",
+        "--share-net",
+        "--ro-bind / /",
+        "--dev /dev",
+        "--proc /proc",
+        "--tmpfs /tmp",
+    ] {
+        assert!(
+            joined.contains(required),
+            "missing `{required}` in {joined}"
+        );
+    }
+    let writable = joined.find(&format!("--bind {0} {0}", workspace.display()));
+    let readonly = joined.find(&format!("--ro-bind {0} {0}", denied.display()));
+    assert!(writable.is_some_and(|index| readonly.is_some_and(|deny| index < deny)));
+
+    let repeated = compile_linux_bwrap_argv(&resolved, "/bin/true", &[], Some(&workspace), false)
+        .expect("compile twice");
+    assert_eq!(plan, repeated);
 }
 
-/// NOTE: this documents *current* behavior, deliberately. A child spawned
-/// through `run_process` on Linux can read any file its uid can — orbit-exec
-/// applies no kernel confinement here. The tool/policy layer
-/// (`orbit-tools` + `PolicyEngine::check_resolved`) is the only Linux
-/// enforcement seam; its integration tests live in
-/// `orbit-tools/tests/fs_enforcement_linux.rs`. If this test ever fails
-/// because confinement appeared, that is a *feature* — rewrite the Linux
-/// enforcement suite around the new primitive.
 #[test]
-fn run_process_applies_no_kernel_fs_confinement_on_linux() {
-    if !host_has("/bin/cat") {
+fn direct_invocation_fails_closed_for_overlapping_non_subtree_deny() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("create workspace");
+    let resolved = profile(vec![
+        format!("{}/**", workspace.display()),
+        format!("!{}/**/*.env", workspace.display()),
+    ]);
+    let error = compile_linux_bwrap_argv(&resolved, "/bin/true", &[], None, false)
+        .expect_err("direct invocation must fail closed");
+    assert!(error.to_string().contains("non-subtree denyModify"));
+}
+
+#[test]
+fn managed_worktree_guard_rejects_new_forbidden_match() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("create workspace");
+    let resolved = profile(vec![
+        format!("{}/**", workspace.display()),
+        format!("!{}/**/*.env", workspace.display()),
+    ]);
+    let guard = LinuxBwrapPostRunGuard::capture(&resolved)
+        .expect("capture")
+        .expect("guard required");
+    std::fs::write(workspace.join("new.env"), "secret").expect("write forbidden fixture");
+    let error = guard.verify().expect_err("new forbidden match rejected");
+    assert!(error.to_string().contains("before commit"));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn kernel_enforces_allowed_outside_and_subtree_writes_when_available() {
+    let probe = probe_bwrap();
+    if !probe.available {
+        println!("skipping real Bubblewrap test: {}", probe.detail);
         return;
     }
 
-    // A file well outside any conceivable workspace/profile allowance.
-    let outside = tempfile::NamedTempFile::new().expect("outside file");
-    std::fs::write(outside.path(), "outside-the-profile").expect("write outside file");
-
-    let request = ExecRequest {
-        program: "/bin/cat".to_string(),
-        args: vec![outside.path().display().to_string()],
-        current_dir: None,
-        timeout_ms: Some(10_000),
-        stdin_mode: StdinMode::Null,
-        environment_mode: EnvironmentMode::Inherit,
-        debug: false,
-    };
-    let result = run_process(&request, &NoSandbox).expect("spawn child");
-    assert!(result.success, "stderr: {}", result.stderr);
-    assert_eq!(
-        result.stdout, "outside-the-profile",
-        "child reads outside paths freely: policy-layer checks are the only Linux enforcement"
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    let denied = workspace.join(".orbit");
+    let outside = temp.path().join("outside");
+    std::fs::create_dir_all(&denied).expect("create denied root");
+    std::fs::create_dir_all(&outside).expect("create outside root");
+    let allowed_file = workspace.join("allowed.txt");
+    let outside_file = outside.join("outside.txt");
+    let denied_file = denied.join("denied.txt");
+    let resolved = profile(vec![
+        format!("{}/**", workspace.display()),
+        format!("!{}/**", denied.display()),
+    ]);
+    let script = format!(
+        "printf allowed > '{}'; ! printf outside > '{}'; ! printf denied > '{}'",
+        allowed_file.display(),
+        outside_file.display(),
+        denied_file.display()
     );
+    let plan = compile_linux_bwrap_argv(
+        &resolved,
+        "/bin/sh",
+        &["-c".to_string(), script],
+        Some(&workspace),
+        false,
+    )
+    .expect("compile");
+    let mut child = spawn_under_linux_bwrap(LinuxBwrapSpawnRequest {
+        plan: &plan,
+        env: &[],
+        cwd: Some(&workspace),
+        stdin: Stdio::null(),
+        stdout: Stdio::null(),
+        stderr: Stdio::null(),
+    })
+    .expect("spawn");
+    let status = child.wait().expect("wait");
+    assert!(status.success());
+    assert_eq!(
+        std::fs::read_to_string(allowed_file).expect("allowed write"),
+        "allowed"
+    );
+    assert!(!outside_file.exists());
+    assert!(!denied_file.exists());
 }

--- a/docs/design/policy-sandbox/1_overview.md
+++ b/docs/design/policy-sandbox/1_overview.md
@@ -3,7 +3,7 @@ summary: "Policy & Sandboxing — Overview"
 type: design
 title: "Policy & Sandboxing — Overview"
 owner: claude
-last_updated: 2026-07-20
+last_updated: 2026-08-01
 status: Draft
 feature: policy-sandbox
 doc_role: overview
@@ -12,7 +12,7 @@ tags: ["policy-sandbox"]
 
 # Policy & Sandboxing — Overview
 
-> **Sandbox backend status.** The only OS-level sandbox backend implemented today is `macos-sandbox-exec`. `ExecutorSandboxKind` (`crates/orbit-common/src/types/executor_def.rs`) defines no Linux or Windows variant, and `EnvironmentHost::resolve_executor_sandbox` (`crates/orbit-core/src/runtime/v2_host/sandbox.rs`) rejects `macos-sandbox-exec` on non-macOS platforms. On Linux and Windows the spawned agent subprocess runs without OS-level isolation; HTTP-tool `fs.*` enforcement and process supervision still apply. A Linux backend is named in [3_vision.md](./3_vision.md) as future work but is not in `2_design.md`'s shipped contract. [T20260505-23]
+> **Sandbox backend status.** Shipped CLI-agent executors select `macos-sandbox-exec` on macOS and `linux-bwrap` on Linux; `local-shell` remains bare. Linux Bubblewrap provides fail-closed kernel write confinement after a capability probe, while read-policy parity stays delegated. Windows has no OS wrapper. HTTP-tool `fs.*` enforcement and process supervision continue to apply on every platform. [ORB-10552] [ADR-0304]
 
 Policy & Sandboxing is Orbit's safety surface for filesystem access and process execution. It combines v2 `PolicyDef` profiles, global `denyRead` / `denyModify` rules, HTTP-tool fs enforcement, optional macOS `sandbox-exec` wrapping for CLI agents, and `orbit-exec` process supervision. [2_design.md](./2_design.md) documents what ships today; [3_vision.md](./3_vision.md) names the gaps to a fuller isolation contract.
 
@@ -25,7 +25,7 @@ Orbit runs agents against user repositories, so the safety boundary is a product
 1. **Default paths stay explicit.** Omitting `fsProfile:` maps to `unrestricted`, then still runs through profile resolution and global denies.
 2. **Profiles are activity-scoped.** A job can mix profiles by activity; evaluation happens per call, not by mutating a process-global mode.
 3. **Deny rules are global.** `denyRead` and `denyModify` are injected into every resolved profile as negated rules, so workspace policy can narrow but not erase global denies.
-4. **Execution has two layers.** `orbit-exec` always supervises child processes; CLI-agent filesystem narrowing is OS-enforced only where the configured executor uses macOS `sandbox-exec`.
+4. **Execution has two layers.** `orbit-exec` always supervises child processes; CLI-agent writes are OS-confined where the configured executor uses macOS `sandbox-exec` or Linux Bubblewrap.
 5. **Denials are evidence.** HTTP fs denials emit through `FsAuditLogger` into `V2AuditEvent` filesystem entries; [auditability](../auditability/) owns durable storage.
 
 ---
@@ -46,7 +46,7 @@ When an activity omits `fsProfile:`, the v2 host uses `UNRESTRICTED_FS_PROFILE`.
 
 ### 2.4 Enforcement depends on backend
 
-HTTP activities enforce policy in the `orbit-tools` `fs.*` builtins before any read or modify. Denials return `OrbitError::PolicyDenied` and emit audit events. CLI activities do not call those builtins; they rely on harness delegation plus the configured executor sandbox, currently macOS `sandbox-exec` for supported CLI agents.
+HTTP activities enforce policy in the `orbit-tools` `fs.*` builtins before any read or modify. Denials return `OrbitError::PolicyDenied` and emit audit events. CLI activities do not call those builtins; they rely on harness delegation plus the configured executor sandbox: `sandbox-exec` on macOS and Bubblewrap write confinement on Linux for shipped agent executors.
 
 When the default policy denies workspace `.orbit/**`, the v2 host re-allows only the narrow child Orbit runtime stores needed by currently activity-exposed write tools. It does not blanket-allow workspace `.orbit`; newly exposed Orbit write tools must add their store roots intentionally.
 
@@ -68,6 +68,7 @@ When the default policy denies workspace `.orbit/**`, the v2 host re-allows only
 | Tool-layer fs enforcement | `crates/orbit-tools/src/builtin/fs/mod.rs` (`enforce_fs_policy`, `emit_fs_event`) | [T20260419-0503] |
 | Activity `fsProfile:` binding | `crates/orbit-engine/src/activity_job/{dispatcher,job_executor,agent_loop_driver}.rs` | [T20260419-0503] |
 | Exec spawn primitive | `crates/orbit-exec/src/{lib,runner,process,sandbox}.rs` | [T20260417-0550] |
+| Linux CLI write confinement | `crates/orbit-exec/src/linux_sandbox.rs` | [ORB-10552] |
 | Process supervision | `crates/orbit-exec/src/supervision/{wait,cleanup,signal,tee}.rs` | [T20260417-0558-4], [T20260417-0558-5] |
 | Filesystem denial audit channel | `crates/orbit-tools/src/lib.rs` (`FsAuditLogger`) → `docs/design/auditability/2_design.md §3` | [T20260426-0605] |
 
@@ -83,5 +84,6 @@ When the default policy denies workspace `.orbit/**`, the v2 host re-allows only
 - **[T20260426-0622]** — Add this policy & sandboxing design folder under claude ownership.
 - **[T20260430-23]** — Shorten the policy sandbox design docs while preserving the shipped contract and ADR history.
 - **[ORB-00129]** — Keep child Orbit runtime write roots narrow under the macOS sandbox while supporting activity-exposed learning, friction, and job-run state tools.
+- **[ORB-10552]** — Add fail-closed Linux Bubblewrap write confinement for shipped CLI agents.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -3,7 +3,7 @@ summary: "Policy & Sandboxing — Design"
 type: design
 title: "Policy & Sandboxing — Design"
 owner: claude
-last_updated: 2026-07-20
+last_updated: 2026-08-01
 status: Draft
 feature: policy-sandbox
 doc_role: design
@@ -12,7 +12,7 @@ tags: ["policy-sandbox"]
 
 # Policy & Sandboxing — Design
 
-This document describes Orbit's shipped policy and sandboxing implementation: v2 `PolicyDef`, profile resolution, last-match-wins path evaluation, HTTP-tool enforcement, activity/job `fsProfile` binding, macOS CLI sandbox wrapping, and `orbit-exec` supervision. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for forward-looking gaps.
+This document describes Orbit's shipped policy and sandboxing implementation: v2 `PolicyDef`, profile resolution, last-match-wins path evaluation, HTTP-tool enforcement, activity/job `fsProfile` binding, macOS and Linux CLI sandbox wrapping, and `orbit-exec` supervision. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for forward-looking gaps.
 
 ---
 
@@ -85,6 +85,8 @@ The audit emission goes through `ctx.fs_audit: Option<Arc<dyn FsAuditLogger>>` (
 
 **Backend scope.** This enforcement fires only under `backend: http` when a builtin fs tool runs. `backend: cli` spawns Claude Code, Codex CLI, Gemini, or another harness via `cli_runner.rs`, emits `tool_allowlist.harness_delegated`, and trusts that harness for tool allowlists. On macOS, executors declaring `sandbox: macos-sandbox-exec` also get the OS-level wrapper in §7, so `fsProfile:` can still narrow CLI filesystem writes.
 
+On Linux, shipped agent executors declare `linux-bwrap`. The wrapper enforces writes from the resolved `modify` policy but deliberately records reads as `read_delegated`; this is not general read-allowlist parity.
+
 ---
 
 ## 6. Activity / Job fsProfile Binding
@@ -139,6 +141,14 @@ The child Orbit runtime roots are deliberately narrower than the workspace `.orb
 
 Negated `read` / `modify` rules become explicit SBPL denies after ordinary profile allows to preserve last-match-wins. Simple path and `/**` subtree denials compile to `subpath`; non-subpath globs such as `**/*.env` compile to `regex`. Host-owned provider side roots are the exception because the provider CLI and inherited Orbit subprocesses must write workflow state.
 
+### 7.1 Linux Bubblewrap backend
+
+On Linux, `ExecutorSandboxKind::LinuxBwrap` resolves only `/usr/bin/bwrap` and runs a real capability probe using the same private user, PID, IPC, and UTS namespaces plus mount setup required by provider execution. Absence or probe failure is permanent and fail-closed unless the executor explicitly sets `allow_fallback: true`. The availability decision happens before provider argv construction: an active outer wrapper neutralizes provider-native sandbox flags, while a bare fallback preserves them.
+
+The deterministic argv starts with a read-only bind of `/`, explicitly retains the host network namespace, and applies canonical `modify` mounts in policy order. Positive roots become writable binds; later exact or subtree denies become read-only binds. `/dev`, `/proc`, and `/tmp` are replaced with private minimal mounts, the wrapper creates a fresh session, and parent-death cleanup remains enabled.
+
+Existing matches of non-subtree negative globs are mounted read-only before spawn. Because mount namespaces cannot reject a matching filename created later, direct invocations with an overlapping non-subtree deny fail closed. An Orbit-managed single-writer worktree may run with snapshot expansion, followed by a post-run scan that rejects any newly-created forbidden match before downstream commit. Audit metadata records the effective backend, trusted wrapper, probe outcome, redacted effective argv, `write_enforced` or `write_delegated`, and the honest `read_delegated` boundary. [ORB-10552] [ADR-0304]
+
 ---
 
 ## 8. Process Supervision
@@ -192,23 +202,23 @@ Risk-weighted regression tests sit beside the implementations they guard
   construction and assert no file is written outside the policy store
   ([T20260509-28]).
 
-Tests skip on non-macOS (and on macOS hosts where `sandbox-exec` cannot
-apply) via the existing `cfg(target_os = "macos")` + `sandbox_exec_can_apply()`
-gate. SBPL-text assertions paired with each runtime case keep coverage
-non-empty on Linux CI.
+macOS runtime tests skip where `sandbox-exec` cannot apply. Linux Bubblewrap
+tests compile argv and exercise fail-closed/fallback behavior on every host;
+kernel tests probe real `/usr/bin/bwrap` and skip with its concrete capability
+failure when user or mount namespaces are unavailable.
 
 ---
 
 ## 10. Concerns & Honest Limitations
 
-1. **OS-level CLI sandboxing is macOS-only.** Linux (`bwrap`), Docker, and other wrappers remain future work; generic `run_process` still defaults to `NoSandbox`.
-2. **CLI tool allowlists are delegated.** The macOS wrapper narrows writes, but Orbit still trusts Claude/Codex/Gemini harnesses for declared `tools:`.
+1. **CLI read policy is delegated.** Both shipped OS wrappers confine writes, but Linux Bubblewrap intentionally keeps the host read surface available and neither backend replaces harness enforcement of arbitrary read globs.
+2. **CLI tool allowlists are delegated.** The OS wrappers narrow writes, but Orbit still trusts Claude/Codex/Gemini/Grok harnesses for declared `tools:`.
 3. **Provider state directories are trusted write roots.** `$HOME/.orbit` plus Codex, Claude, and Gemini state dirs are outside the activity workspace and emitted unconditionally.
 4. **Codex side-root appends are config-coupled.** If Codex is configured without the workspace-write side roots, inherited Orbit subprocesses can hit `.orbit` write denials.
 5. **macOS provenance syscall allowances are private.** `vnguard` and `Sandbox`/67 mirror current Codex startup needs and may require review after OS changes.
 6. **Pipeline env fallback can leave `fs_profile = None`.** Legacy contexts without `ORBIT_ACTIVITY_FS_PROFILE` still bypass `enforce_fs_policy`.
 7. **HTTP enforcement is helper-based.** A future builtin or non-builtin tool that skips `enforce_fs_policy` is unguarded.
-8. **Exec has no policy hook.** `proc.spawn` program allowlists are activity-layer data, not part of `PolicyDef` or `effective_profile`.
+8. **Generic exec has no policy hook.** `proc.spawn` program allowlists are activity-layer data, and `run_process + NoSandbox` remains unchanged; the OS wrappers attach only to CLI-agent dispatch.
 9. **Symlink semantics are implicit.** `workspace_relative_path` follows symlinks and rejects out-of-workspace targets, but no spec states that invariant.
 10. **Glob syntax is narrow.** Character classes, brace expansion, and POSIX bracket expressions are unsupported.
 11. **Policy result shapes are parallel.** `PolicyDecision` and `FsPolicyEvaluation` have no bridge for future non-fs evaluators.
@@ -237,5 +247,6 @@ non-empty on Linux CI.
 - **[T20260509-28]** — Validate policy and executor resource names as safe file stems before file-store path construction.
 - **[T20260509-30]** — Resolve `sandbox-exec` from trusted absolute locations and keep availability errors fail-closed and explicit.
 - **[ORB-00129]** — Re-allow narrow workspace child Orbit runtime stores for activity-exposed learning, friction, and job-run state tools without removing the default workspace `.orbit/**` deny.
+- **[ORB-10552]** — Ship fail-closed Linux Bubblewrap write confinement without claiming read-policy parity.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/policy-sandbox/3_vision.md
+++ b/docs/design/policy-sandbox/3_vision.md
@@ -18,7 +18,7 @@ This document captures the questions Orbit must answer before policy and sandbox
 
 ## 1. Open Questions
 
-1. **How far should Linux sandboxing go after the first backend?** §1.1 proposes a Bubblewrap write-confinement backend for CLI agents. Full read-policy parity, network policy, seccomp, and generic `run_process` adoption remain separate decisions.
+1. **How far should Linux sandboxing go after the first backend?** §1.1 records the shipped Bubblewrap write-confinement boundary. Full read-policy parity, network policy, seccomp, and generic `run_process` adoption remain separate decisions.
 2. **Should enforcement move below the tool layer?** A future tool that skips `enforce_fs_policy` is unguarded unless Orbit adds a `PolicyAwareFs` trait, syscall interception, or linting.
 3. **Should `proc.spawn` consult policy?** Activity program allowlists are not `PolicyDef`; future shapes include `allowExec` / `denyExec` or env access tied to `fsProfile`.
 4. **What is the symlink contract?** `workspace_relative_path` follows symlinks and denies out-of-workspace targets, but the invariant is not yet specified.
@@ -31,14 +31,14 @@ This document captures the questions Orbit must answer before policy and sandbox
 11. **How should concurrent exec handle signals?** `SignalHandlerGuard` serializes installs; worker-pool exec may need sigmasks, cancellation tokens, or a supervisor thread.
 12. **How far should CLI policy coverage go?** macOS `sandbox-exec` narrows writes, but alternatives include trapping CLI fs calls or moving more work to HTTP-backed activities.
 
-### 1.1 Proposed answer: a `linux-bwrap` CLI backend
+### 1.1 Shipped answer: a `linux-bwrap` CLI backend
 
-Orbit should add Bubblewrap as the first Linux OS-level sandbox for CLI-backed agent loops. It
-should reuse the existing executor declaration → `ResolvedSandbox` → CLI spawn path rather than
+Orbit uses Bubblewrap as the first Linux OS-level sandbox for CLI-backed agent loops. It
+reuses the existing executor declaration → `ResolvedSandbox` → CLI spawn path rather than
 starting with the generic `Sandbox` trait: the exposed gap is provider CLIs, and that is already
 the seam where macOS turns an activity's resolved `FsProfile` into an outer process wrapper.
 
-The first version is deliberately a **write-confinement backend**, not a claim of byte-for-byte
+The shipped first version is deliberately a **write-confinement backend**, not a claim of byte-for-byte
 SBPL parity. It materially improves today's bare Linux execution while keeping unsupported policy
 semantics visible instead of silently calling them enforced.
 
@@ -120,7 +120,7 @@ Bubblewrap is the pragmatic first backend because it is an unprivileged policy-c
 not a policy by itself. Orbit remains responsible for the exact mount and namespace arguments.
 The trusted-path rule, `--new-session`, namespace selection, and explicit read-policy limitation
 are therefore part of the security contract rather than incidental implementation details.
-[ORB-10552] tracks implementation of this proposed boundary.
+[ORB-10552] implements this boundary; [ADR-0304] records the choice and its deferred read-policy cost.
 
 ---
 
@@ -190,6 +190,6 @@ External reference categories:
 - **[T20260426-0605]** — Auditability folder linked from §1.10.
 - **[T20260426-0622]** — Add this folder and name the open questions.
 - **[T20260430-23]** — Shorten the policy sandbox design docs while preserving the shipped contract and ADR history.
-- **[ORB-10552]** — Implement the proposed fail-closed Linux Bubblewrap write-confinement backend for CLI agents.
+- **[ORB-10552]** — Implement the shipped fail-closed Linux Bubblewrap write-confinement backend for CLI agents.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/policy-sandbox/4_decisions.md
+++ b/docs/design/policy-sandbox/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Policy & Sandboxing — Decisions"
 type: design
 title: "Policy & Sandboxing — Decisions"
 owner: claude
-last_updated: 2026-05-16
+last_updated: 2026-08-01
 status: Draft
 feature: policy-sandbox
 doc_role: decisions
@@ -13,6 +13,8 @@ tags: ["policy-sandbox"]
 # Policy & Sandboxing — Decisions
 
 This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by ADR number. New entries follow the template in [../CONVENTIONS.md](../CONVENTIONS.md) and cite the task that made the decision real.
+
+Global ADR pointers are retrieved with `orbit tool run orbit.adr.show --input '{"id":"ADR-NNNN"}'`; the artifact store is authoritative for their full Context, Decision, and Consequences.
 
 ---
 
@@ -210,6 +212,8 @@ Use `literal` for the canonical and lock files (predictable names) and `regex` f
 - Availability messages describe the trusted absolute location instead of implying arbitrary `PATH` lookup.
 - Cost: the implementation is intentionally macOS-location-specific; if Apple moves or removes the binary, Orbit must update the trusted location list or add a new backend rather than silently accepting a user-supplied replacement.
 
+- **ADR-0304 — Use Bubblewrap for shipped Linux CLI write confinement** — Accepted.
+
 ---
 
 ## Task References
@@ -227,5 +231,6 @@ Use `literal` for the canonical and lock files (predictable names) and `regex` f
 - **[T20260508-13]** — Add `$HOME/.claude.json{,.lock,.tmp.<pid>.<ms_ts>}` sibling allows to the macOS sandbox profile so Claude can persist its main settings file.
 - **[T20260509-30]** — Resolve `sandbox-exec` from trusted absolute locations rather than inherited `PATH`.
 - **[ORB-00048]** — Extend the unconditional provider state-dir allowance set to include Grok's `$HOME/.grok` state directory while hardening fourth-family scoreboards and analytics.
+- **[ORB-10552]** — Implement fail-closed Linux Bubblewrap write confinement and preserve the explicit read-policy limitation.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10552](https://orbit-cli.com/tasks/ORB-10552) — Add fail-closed Linux Bubblewrap sandbox for CLI agents

### Description

## Problem
Orbit's CLI-backed agent sandbox is macOS-only. On Linux, shipped executor seeding removes the `macos-sandbox-exec` declaration and provider CLIs run with the worker account's ambient filesystem rights. Installing Bubblewrap in ORB-10084 removed the host prerequisite warning but did not connect Bubblewrap to Orbit's `FsProfile` or CLI dispatch path.

## Proposed Solution
Implement the `linux-bwrap` design in `docs/design/policy-sandbox/3_vision.md §1.1` at the existing executor declaration → `ResolvedSandbox` → CLI spawn seam.

- Add a concrete Linux Bubblewrap backend and select it for shipped agent executors on Linux; keep `local-shell` unsandboxed and preserve explicit custom executor choices.
- Resolve only trusted `/usr/bin/bwrap` and run a real namespace/mount capability probe. Missing, disabled, or unusable Bubblewrap fails closed unless `allow_fallback: true`.
- Mount the host filesystem read-only, then rebind only resolved positive `modify` roots plus the narrow provider/Orbit runtime roots as writable. Use private user/PID/IPC/UTS namespaces, a fresh session, parent-death cleanup, minimal proc/dev, isolated scratch, and the host network namespace.
- Enforce exact-path and subtree `denyModify` rules through later read-only mounts. Expand existing matches for non-subtree negative globs before spawn. In managed shipment worktrees, reject forbidden newly-created paths before commit; direct non-worktree invocations with overlapping unrepresentable negative globs fail closed.
- Keep the limitation honest: v1 is a write-confinement backend. Audit `write_enforced` versus `read_delegated`; do not claim general read-allowlist or arbitrary negative-read-glob parity.
- Neutralize provider-native sandbox flags only after the outer backend is known to be active. An explicitly permitted bare fallback retains the provider's own sandbox arguments.
- Update the shipped-design contract and add/allocate the required ADR when the implementation makes the decision real.

## Why It Matters
Linux is Orbit's primary worker environment, yet it currently has no kernel boundary around CLI agents. This closes the highest-value gap—writes outside the task's authorized roots—without pretending Bubblewrap can reproduce SBPL's ordered arbitrary filename globs.

## Constraints / Notes
- Keep generic `run_process + NoSandbox`, network policy, seccomp, containers, and Landlock layering out of scope.
- Preserve macOS `sandbox-exec` behavior and process-group supervision.
- Treat the Bubblewrap argv as security-sensitive policy compilation: canonical paths only, deterministic mount order, no inherited-`PATH` trust.
- The design relies on the existing single-writer assigned-worktree contract for snapshot-expanded negative globs.
- Rollback is configuration-level: shipped Linux executor seeding can omit `linux-bwrap`; do not remove the macOS backend or alter persisted custom executor definitions.

### Acceptance Criteria

- `ExecutorSandboxKind` round-trips a concrete `linux-bwrap` value, reports `target_os() == "linux"`, and rejects platform mismatches without falling back implicitly.
- Deterministic seed tests prove shipped agent executors select `macos-sandbox-exec` on macOS and `linux-bwrap` on Linux, `local-shell` remains unsandboxed, repeated seeding is idempotent, and explicit custom executor sandbox choices are preserved.
- Orbit resolves Bubblewrap only from trusted `/usr/bin/bwrap` and a capability probe proves the required namespaces and mount setup can execute a trivial child; binary absence and probe failure are permanent, actionable errors when fallback is disabled.
- With `allow_fallback: true`, an unavailable Linux backend runs bare without emitting `write_enforced` and without neutralizing provider-native sandbox flags; with fallback false, no provider child starts.
- The compiled Bubblewrap argv mounts the host root read-only, exposes only canonical resolved modify/provider/runtime roots as writable, supplies private user/PID/IPC/UTS namespaces plus fresh session, parent-death cleanup, proc/dev and isolated scratch, and explicitly retains network access.
- Kernel-backed Linux tests prove an allowed worktree write succeeds, a write outside every writable mount fails, and an exact/subtree denial such as `.orbit/**` stays read-only beneath a broader writable workspace.
- Existing matches of non-subtree negative globs are protected in the pre-spawn mount plan; a managed shipment worktree that creates a new forbidden match is rejected before commit, while the equivalent direct non-worktree invocation fails closed before spawn.
- Invocation audit output names the effective `linux-bwrap` backend, trusted wrapper, probe outcome, redacted effective argv, and separate read/write enforcement levels; it never records stronger enforcement than the branch actually used.
- Linux integration tests probe real Bubblewrap at runtime and skip with the concrete probe reason only when the host cannot apply it; cross-platform unit tests still exercise argv compilation, ordering, fail-closed, and fallback branches.
- Existing macOS sandbox compilation, provider-state allowances, trusted-wrapper resolution, audit argv, and runtime tests remain unchanged and passing.
- The same PR updates `docs/design/policy-sandbox/{1_overview,2_design,3_vision,4_decisions}.md`, allocates the global ADR before adding its pointer, and clearly distinguishes shipped write confinement from deferred read-policy parity.
- `cargo test -p orbit-exec --test linux_sandbox`, focused `orbit-engine` CLI-runner tests, focused `orbit-core` executor/sandbox tests, `cargo fmt --all -- --check`, `make ci-fast`, and `git diff --check` pass; the PR's full CI is green.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added the concrete `linux-bwrap` executor kind, deterministic Linux shipped-executor selection/migration, and tests for wire round-trip, platform selection, idempotence, local-shell, and custom executor preservation.
- Added `orbit-exec::linux_sandbox`: trusted `/usr/bin/bwrap` resolution, real namespace/mount capability probing, deterministic read-only-root/write-bind/deny-rebind argv compilation, private namespaces and scratch, explicit host-network retention, managed-worktree negative-glob snapshots, and trusted wrapper spawn.
- Wired Linux descriptor resolution and canonical provider/Orbit runtime roots through orbit-core, with worktree-relative policy resolution and explicit managed-worktree identity.
- Wired fail-closed versus explicit bare fallback before provider argv construction, so provider-native sandbox flags are neutralized only for an active outer wrapper. Added effective backend/probe/wrapper/read-write enforcement fields to invocation audit events and redacted effective Bubblewrap argv.
- Added cross-platform and Linux runtime tests for mount ordering, trusted resolution, probe classification, fallback metadata, direct non-subtree fail-closed behavior, managed new-match rejection, and kernel-backed allowed/outside/denied writes. The real kernel case skipped on this runner with the concrete probe reason: `bwrap: setting up uid map: Permission denied`.
- Updated all four policy-sandbox design documents and allocated/accepted ADR-0304, which records shipped write confinement and deferred read-policy parity.
Assessment: The implementation closes the ambient-write gap at the existing CLI wrapper seam, keeps macOS behavior and generic run_process + NoSandbox unchanged, and reports only the enforcement branch actually used.

Strategic decisions:
- ADR-0304 accepted: Bubblewrap is shipped Linux CLI write confinement; host reads and network remain delegated.
- Exact/subtree denies are emitted after every writable bind. Non-subtree denies are snapshot-expanded only for managed single-writer worktrees; overlapping direct invocations fail before spawn.

Design weaknesses / risks:
- Severity: Low — Bubblewrap availability depends on host user-namespace policy, so this runner could not execute the real kernel branch. Mitigation: the integration test probes and reports the exact reason; unrestricted CI remains authoritative.
- Severity: Intentional — the backend does not claim general read-policy parity. Mitigation: audit records `read_delegated` separately from `write_enforced`.

Deviations from original plan:
- Added `crates/orbit-common/src/types/activity_job/audit_envelope.rs` because effective backend/probe/enforcement audit metadata is a stated acceptance criterion.
- Added `crates/orbit-common/src/types/tests/executor_def.rs` and `crates/orbit-core/src/runtime/v2_host/tests/sandbox.rs` for directly affected round-trip/platform and descriptor tests.
- Added `.orbit/adrs/accepted/ADR-0304/` because the repository requires globally allocated ADR artifacts to ship with their design pointer.

Validation:
- `cargo test -p orbit-exec --test linux_sandbox` — passed (5 tests; kernel branch probe-skipped for uid-map permission denial).
- `cargo test -p orbit-common types::tests::executor_def` — passed (8 tests).
- `cargo test -p orbit-core command::tests::executor` — passed (13 tests).
- `cargo test -p orbit-core runtime::v2_host::tests::sandbox` — passed (4 tests).
- `cargo test -p orbit-engine activity_job::cli_runner::tests` — passed (87 tests).
- `cargo fmt --all -- --check` — passed.
- `make ci-fast` — passed.
- `git diff --check` — passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10552-6a6e7ab3`
- Behind base: 0
- Ahead of base: 1