### PR TITLE
orbit doctor reports the layout-upgrade lock as a dead-holder stale lock after every normal workspace init

### DIFF
--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -254,9 +254,10 @@ fn doctor_check_semantic_index(runtime: &OrbitRuntime) -> WorkspaceDoctorResult 
     }
 }
 
-/// Lock files whose recorded holder PID is dead. Advisory `flock`s are
-/// released by the OS on process death, so these are leftover metadata
-/// from crashed holders — a crash signal, not an availability problem.
+/// Lock files whose recorded holder PID is dead. Clean lock-guard releases
+/// clear their diagnostic metadata while still holding the advisory `flock`,
+/// so metadata found here is from an interrupted/crashed holder — a crash
+/// signal, not an availability problem.
 fn doctor_check_stale_locks(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {
     let lock_files = collect_lock_files(runtime.paths());
     let mut stale = Vec::new();

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -191,6 +191,29 @@ fn dead_holder_lock_file_is_reported_stale() {
 
 #[cfg(unix)]
 #[test]
+fn interrupted_layout_upgrade_is_reported_stale() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let lock_path = temp
+        .path()
+        .join("repo")
+        .join(".orbit")
+        .join("state")
+        .join("layout.lock");
+    write_holder_lock(&lock_path, reaped_child_pid(), "layout upgrade");
+
+    let results = runtime.doctor_workspace().expect("doctor");
+    let locks = status_of(&results, "stale-locks");
+    assert_eq!(locks.status, WorkspaceDoctorStatus::Warning, "{locks:?}");
+    assert!(
+        locks.message.contains("layout.lock") && locks.message.contains("layout upgrade"),
+        "message names the interrupted layout upgrade: {}",
+        locks.message
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn stale_task_learning_and_adr_lock_files_are_removed() {
     let temp = tempfile::tempdir().expect("tempdir");
     let runtime = workspace_runtime(&temp);

--- a/crates/orbit-store/src/file_lock/mod.rs
+++ b/crates/orbit-store/src/file_lock/mod.rs
@@ -14,7 +14,8 @@
 //! and emits a `tracing::warn!` once a waiter has been blocked past a
 //! threshold. Holder metadata is advisory only — the OS `flock` is the source
 //! of truth; the metadata is read solely to enrich the error/warning a blocked
-//! waiter reports.
+//! waiter reports. A clean guard drop clears the metadata while still holding
+//! the flock, while an abrupt process death leaves it behind as a crash signal.
 //!
 //! The returned [`FileLockGuard`] follows the RAII-guard pattern
 //! (`docs/design-patterns/raii_guard.md`): the OS lock is released when the
@@ -61,9 +62,10 @@ impl Default for LockOptions {
     }
 }
 
-/// RAII guard over an exclusive advisory file lock. The lock is released when
-/// the wrapped [`File`] is dropped (`fs2` unlocks on close), so callers hold
-/// the guard for the critical section and rely on scope exit to release it.
+/// RAII guard over an exclusive advisory file lock. A clean drop clears the
+/// diagnostic holder metadata before the wrapped [`File`] is dropped (and
+/// `fs2` unlocks on close), while a process crash leaves the metadata behind
+/// for `orbit doctor` to report.
 #[derive(Debug)]
 #[must_use = "the advisory lock is released as soon as the guard is dropped"]
 pub(crate) struct FileLockGuard {
@@ -71,6 +73,18 @@ pub(crate) struct FileLockGuard {
     // `flock`. Named with a leading underscore so dead-code analysis does not
     // flag the never-read field (mirrors `SignalHandlerGuard::_lock`).
     _file: File,
+}
+
+impl Drop for FileLockGuard {
+    fn drop(&mut self) {
+        // Clear the diagnostic marker before closing the descriptor. The flock
+        // is therefore held throughout the metadata transition, so a waiter
+        // cannot observe a clean release as a stale holder or race a path
+        // replacement. Best-effort matches acquisition metadata handling:
+        // advisory diagnostics must never turn a successful release into an
+        // application failure.
+        let _ = clear_holder(&self._file);
+    }
 }
 
 /// Metadata written into a lock file by its current holder. Advisory and
@@ -238,6 +252,12 @@ fn write_holder_inner(mut file: &File, holder: &LockHolder) -> std::io::Result<(
     file.seek(SeekFrom::Start(0))?;
     file.set_len(0)?;
     file.write_all(json.as_bytes())?;
+    file.flush()?;
+    Ok(())
+}
+
+fn clear_holder(mut file: &File) -> std::io::Result<()> {
+    file.set_len(0)?;
     file.flush()?;
     Ok(())
 }

--- a/crates/orbit-store/src/file_lock/tests/file_lock.rs
+++ b/crates/orbit-store/src/file_lock/tests/file_lock.rs
@@ -31,7 +31,16 @@ fn acquire_release_then_reacquire() {
 
     {
         let _guard: FileLockGuard = acquire_exclusive(&path, "first").expect("first acquire");
+        assert_eq!(
+            read_lock_holder(&path).expect("holder while held").label,
+            "first"
+        );
     } // guard dropped here -> flock released
+
+    assert!(
+        read_lock_holder(&path).is_none(),
+        "clean release must clear diagnostic holder metadata"
+    );
 
     // Parent dirs were created by the first acquisition; a second one succeeds.
     let _guard = acquire_exclusive(&path, "second").expect("second acquire after release");

--- a/crates/orbit-store/src/layout/tests/mod.rs
+++ b/crates/orbit-store/src/layout/tests/mod.rs
@@ -8,9 +8,11 @@ use orbit_common::types::{OrbitError, TaskStatus};
 
 use super::{
     LAYOUT_MIGRATIONS, LayoutMigration, SUPPORTED_LAYOUT_VERSION, current_layout_version,
-    pending_layout_migrations, pending_with, upgrade_with, upgrade_workspace_layout,
+    pending_layout_migrations, pending_with, upgrade_lock_path, upgrade_with,
+    upgrade_workspace_layout,
 };
 use crate::file::task_store::v2_bundle::read_bundle_at;
+use crate::file_lock::read_lock_holder;
 
 fn temp_orbit_dir() -> tempfile::TempDir {
     tempfile::tempdir().expect("create temp .orbit dir")
@@ -18,6 +20,89 @@ fn temp_orbit_dir() -> tempfile::TempDir {
 
 fn marker_contents(orbit_dir: &Path) -> String {
     fs::read_to_string(orbit_dir.join("state").join("layout.version")).expect("read marker")
+}
+
+#[cfg(unix)]
+const CRASH_CHILD_TEST: &str = "layout::tests::crash_during_layout_upgrade_child";
+
+#[cfg(unix)]
+fn blocking_apply(_orbit_dir: &Path) -> Result<(), OrbitError> {
+    let (Ok(ready_path), Ok(_lock_path)) = (
+        std::env::var("ORBIT_LAYOUT_CRASH_READY"),
+        std::env::var("ORBIT_LAYOUT_CRASH_LOCK"),
+    ) else {
+        return Ok(());
+    };
+    fs::write(ready_path, b"migration started").expect("write migration readiness");
+    std::thread::sleep(std::time::Duration::from_secs(60));
+    Ok(())
+}
+
+#[cfg(unix)]
+const INTERRUPTED_REGISTRY: &[LayoutMigration] = &[LayoutMigration {
+    version: 1,
+    name: "blocking migration",
+    description: "wait for the test process to be interrupted",
+    apply: blocking_apply,
+}];
+
+#[cfg(unix)]
+#[test]
+#[ignore = "helper process for interrupted_layout_upgrade_leaves_stale_holder_metadata"]
+fn crash_during_layout_upgrade_child() {
+    let (Ok(orbit_dir), Ok(lock_path), Ok(ready_path)) = (
+        std::env::var("ORBIT_LAYOUT_CRASH_ORBIT_DIR"),
+        std::env::var("ORBIT_LAYOUT_CRASH_LOCK"),
+        std::env::var("ORBIT_LAYOUT_CRASH_READY"),
+    ) else {
+        return;
+    };
+    let _ = lock_path;
+    let _ = ready_path;
+    upgrade_with(Path::new(&orbit_dir), INTERRUPTED_REGISTRY).expect("child upgrade");
+}
+
+#[cfg(unix)]
+#[test]
+fn interrupted_layout_upgrade_leaves_stale_holder_metadata() {
+    let temp = temp_orbit_dir();
+    let lock_path = upgrade_lock_path(temp.path());
+    let ready_path = temp.path().join("migration-ready");
+    let exe = std::env::current_exe().expect("current test exe");
+    let mut child = std::process::Command::new(exe)
+        .args(["--exact", CRASH_CHILD_TEST, "--ignored"])
+        .env("ORBIT_LAYOUT_CRASH_ORBIT_DIR", temp.path())
+        .env("ORBIT_LAYOUT_CRASH_LOCK", &lock_path)
+        .env("ORBIT_LAYOUT_CRASH_READY", &ready_path)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn layout-upgrade child");
+
+    let start = std::time::Instant::now();
+    while !ready_path.exists() {
+        if start.elapsed() > std::time::Duration::from_secs(20) {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("layout-upgrade child never entered migration");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+
+    let child_pid = child.id();
+    child.kill().expect("SIGKILL layout-upgrade child");
+    child.wait().expect("reap layout-upgrade child");
+
+    let holder = read_lock_holder(&lock_path).expect("crashed holder metadata remains");
+    assert_eq!(holder.pid, child_pid);
+    assert_eq!(holder.label, "layout upgrade");
+    assert_eq!(current_layout_version(temp.path()).expect("version"), 0);
+
+    // The interrupted migration can be resumed, and its clean release clears
+    // the metadata that the crash intentionally left behind.
+    upgrade_with(temp.path(), INTERRUPTED_REGISTRY).expect("resume upgrade");
+    assert_eq!(current_layout_version(temp.path()).expect("version"), 1);
+    assert!(read_lock_holder(&lock_path).is_none());
 }
 
 // ── shipping registry ──
@@ -59,6 +144,10 @@ fn fresh_workspace_adopts_the_baseline_and_stamps_the_marker() {
     assert_eq!(
         current_layout_version(temp.path()).expect("version"),
         SUPPORTED_LAYOUT_VERSION
+    );
+    assert!(
+        read_lock_holder(&upgrade_lock_path(temp.path())).is_none(),
+        "a completed layout upgrade must not leave stale holder metadata"
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-10553](https://orbit-cli.com/tasks/ORB-10553) — orbit doctor reports the layout-upgrade lock as a dead-holder stale lock after every normal workspace init

### Description

Rerouted from ws_polaris ORB-10524 (2026-08-01). The finding was filed by a qa-sweep in polaris, but both the defect and its fix live entirely in this repo. Evidence below is the original reporter's, verbatim in substance.

## Problem

`orbit doctor`'s stale-locks check is documented as "a crash signal, not an availability problem", but it fires on every normal first use of a workspace. Nothing has crashed.

## Repro

Against a scratch workspace built from `orbit-cli` at commit `0a32772e`:

```
$ orbit --root /tmp/orbit-qa-root init          # accept defaults
$ cd /tmp/orbit-qa-sweep && git init && git commit --allow-empty -m init
$ orbit --root /tmp/orbit-qa-root workspace init
workspace 'orbit-qa-sweep' initialized ...
$ orbit --root /tmp/orbit-qa-root doctor
...
stale-locks  warning  1 lock file(s) left by dead holders (the OS already released the
                      flock; safe to delete): /tmp/orbit-qa-root/state/layout.lock
                      (dead pid 412693, op: layout upgrade, since 2026-07-27T05:07:22Z)
0 failure(s), 1 warning(s).
```

`orbit doctor --fix-stale-locks` clears it, but the warning returns on the next layout-version bump for every workspace, because the lock file is architecturally never cleaned up on a normal release.

## Root cause

`layout::upgrade_with` acquires the upgrade lock via `file_lock::acquire_exclusive(&upgrade_lock_path(orbit_dir), "layout upgrade")`. `FileLockGuard::Drop` releases only the OS `flock` — it never deletes the lock file or the holder metadata (pid/timestamp/label) written by `write_holder` at acquisition.

That is correct for locks reacquired often, where the metadata is simply overwritten next time. The layout-upgrade lock is the opposite: a one-shot acquisition per `.orbit` directory, taken by a short-lived CLI process that necessarily exits immediately after. So the first process ever to run a layout migration leaves permanent dead-holder metadata, and `doctor_check_stale_locks` — which only asks "is the recorded pid alive" — cannot distinguish that from a genuine crash mid-upgrade.

The contrasting precedent is in this repo: `file/task_store/v2_bundle/lock.rs` explicitly calls `remove_task_bundle_lock_sentinel` after a successful release. The layout-upgrade lock has no equivalent, and neither do the per-id locks in `file/adr_store/lock.rs` and `file/learning_store/lock.rs`.

## Constraints

- Whichever way this is fixed, a real crash mid-upgrade must still be reported. The value of the check is that it distinguishes a crashed holder from a completed one; a fix that silences the warning unconditionally destroys the signal it was added for.
- The per-id ADR and learning locks have the same shape. Decide whether they share the defect and say so either way, rather than fixing only the reported instance.
- `doctor`'s own doc comment states the intended contract. Whatever is chosen, the code and that comment must end up agreeing.

## Suggested directions (not prescriptive)

Delete `upgrade_lock_path(orbit_dir)` after a successful `upgrade_with`, mirroring the task-bundle sentinel; or have `doctor_check_stale_locks` special-case the layout-upgrade lock so only an in-progress or unwritten migration marker counts as stale.

### Acceptance Criteria

- A fresh `orbit init` + `orbit workspace init` + `orbit doctor` sequence reports 0 warnings; the layout-upgrade lock no longer surfaces as a dead holder after a normal, completed upgrade.
- A genuine crash mid-upgrade is still reported as a stale lock — covered by a test that simulates an interrupted upgrade rather than only the happy path.
- The per-id ADR and learning locks are assessed for the same defect, and the outcome is stated explicitly whether or not they are changed.
- `doctor_check_stale_locks`'s doc comment and its actual behaviour agree.
- Regression coverage for the normal-completion case, so this cannot silently return on the next layout-version bump.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added FileLockGuard::Drop cleanup that truncates holder metadata while the advisory flock remains held; abrupt process death still leaves metadata for diagnostics.
- Added regression coverage for clean release, completed layout upgrades, a SIGKILL-interrupted layout migration with resume, and doctor reporting of a stale layout lock.
- Updated doctor_check_stale_locks documentation to match the clean-release/crash behavior.
- The ADR and learning per-id locks use the same shared FileLockGuard, so they receive the same metadata cleanup; no lock-specific changes were needed.
- Added crates/orbit-cmd/src/tests/doctor.rs to context_files because the stale-lock regression coverage belongs there.
Assessment: Minimal shared-guard fix preserves stale-crash detection, keeps lock files reusable, and avoids path/unlink races.
Validation:
- cargo test -p orbit-store --lib file_lock::tests::file_lock:: (6 passed, 1 ignored)
- cargo test -p orbit-store --lib layout::tests:: (26 passed, 1 ignored)
- cargo test -p orbit-cmd --lib tests::doctor:: (19 passed)
- make ci-fast passed
- git diff --check passed

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10553-6a6e86ad`
- Behind base: 0
- Ahead of base: 1