### PR TITLE
fix: preserve managed runs across private PID namespaces [ORB-10557]

### DIFF
--- a/crates/orbit-core/src/command/job/run/tests/reconcile.rs
+++ b/crates/orbit-core/src/command/job/run/tests/reconcile.rs
@@ -99,6 +99,7 @@ fn show_job_run_repairs_terminal_run_missing_timing() {
 /// instead of deferring consumers forever.
 #[test]
 fn workspace_open_reconciles_orphaned_pending_children_of_interrupted_parent() {
+    let _env = orbit_common::test_env::unset(["ORBIT_MANAGED_RUN_CONTEXT", "ORBIT_RUN_ID"]);
     let (root, runtime) = test_runtime();
     let parent = insert_pending_run(&runtime, "task_auto_pipeline");
     runtime

--- a/crates/orbit-core/src/command/tool/dispatch.rs
+++ b/crates/orbit-core/src/command/tool/dispatch.rs
@@ -14,8 +14,12 @@ use serde_json::Value;
 
 use crate::OrbitRuntime;
 use crate::redact_sensitive_env_text;
+use crate::runtime::run_input::{
+    managed_run_context_from_env, managed_run_context_run_id_from_env,
+};
 
-pub(super) const ORBIT_MANAGED_RUN_CONTEXT_ENV: &str = "ORBIT_MANAGED_RUN_CONTEXT";
+#[cfg(test)]
+pub(super) use crate::runtime::run_input::ORBIT_MANAGED_RUN_CONTEXT_ENV;
 
 /// Where a tool invocation arrived from. Captured in the audit row so a single
 /// audit table can attribute tool calls back to their origin (CLI vs MCP).
@@ -478,29 +482,19 @@ pub fn trusted_mcp_audit_context(
 }
 
 pub(super) fn reservation_owner_from_env() -> Option<ReservationOwnerContext> {
-    if !managed_run_context() {
-        return None;
-    }
-
-    std::env::var("ORBIT_RUN_ID")
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-        .map(|owner_run_id| ReservationOwnerContext {
-            owner_metadata_json: Some(
-                serde_json::json!({
-                    "source": "orbit_cli",
-                })
-                .to_string(),
-            ),
-            owner_run_id,
-        })
+    managed_run_context_run_id_from_env().map(|owner_run_id| ReservationOwnerContext {
+        owner_metadata_json: Some(
+            serde_json::json!({
+                "source": "orbit_cli",
+            })
+            .to_string(),
+        ),
+        owner_run_id,
+    })
 }
 
 fn managed_run_context() -> bool {
-    std::env::var(ORBIT_MANAGED_RUN_CONTEXT_ENV)
-        .ok()
-        .is_some_and(|value| matches!(value.trim(), "1" | "true" | "TRUE"))
+    managed_run_context_from_env()
 }
 
 fn read_agent_identity_from_env() -> (Option<String>, Option<String>) {

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -46,6 +46,7 @@ use crate::command::workflow::ShipMode;
 use crate::context::ActorIdentity;
 use crate::context::OrbitContext;
 use crate::context::OrbitStores;
+use crate::runtime::run_input::managed_run_context_from_env;
 
 pub use orbit_tool_host::HubCoordinationExecutor;
 pub(crate) use orbit_tool_host::build_orbit_tool_host;
@@ -257,7 +258,15 @@ impl OrbitRuntime {
         // whose recorded owner process is conclusively gone flip to
         // `interrupted` so dashboards and `orbit job resume` see them.
         // Best-effort — a scan failure must never block opening the runtime.
-        runtime.reconcile_stale_job_runs_on_open();
+        //
+        // A managed activity child can intentionally have a private PID
+        // namespace (for example, under Linux Bubblewrap), so it cannot
+        // adjudicate the host worker's liveness. Explicit recovery surfaces
+        // still reconcile; only this opportunistic workspace-open scan is
+        // skipped for the trusted managed-run envelope [ORB-10557].
+        if !managed_run_context_from_env() {
+            runtime.reconcile_stale_job_runs_on_open();
+        }
         Ok(runtime)
     }
 

--- a/crates/orbit-core/src/runtime/orbit_tool_host/host.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/host.rs
@@ -33,6 +33,7 @@ use orbit_tools::{
 use serde_json::{Map, Value, json};
 
 use crate::OrbitRuntime;
+use crate::runtime::run_input::managed_run_context_run_id_from_env;
 
 pub(crate) fn build_orbit_tool_host(
     runtime: &OrbitRuntime,
@@ -840,16 +841,7 @@ impl OrbitToolHost for RuntimeOrbitToolHost {
 }
 
 fn trusted_env_run_id() -> Option<String> {
-    let managed = std::env::var("ORBIT_MANAGED_RUN_CONTEXT")
-        .ok()
-        .is_some_and(|value| matches!(value.trim(), "1" | "true" | "TRUE"));
-    if !managed {
-        return None;
-    }
-    std::env::var("ORBIT_RUN_ID")
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
+    managed_run_context_run_id_from_env()
 }
 
 #[cfg(test)]

--- a/crates/orbit-core/src/runtime/run_input.rs
+++ b/crates/orbit-core/src/runtime/run_input.rs
@@ -1,5 +1,35 @@
 use serde_json::Value;
 
+/// Environment marker emitted only for an Orbit-managed activity together
+/// with the owning run id. Both values form the managed-run trust boundary:
+/// the marker alone is not enough to attribute work to a run or to grant
+/// managed-child behavior.
+pub(crate) const ORBIT_MANAGED_RUN_CONTEXT_ENV: &str = "ORBIT_MANAGED_RUN_CONTEXT";
+
+/// Return the trusted managed run id from the activity envelope.
+///
+/// A managed child may have a deliberately narrower process view than its
+/// host worker (for example, under Bubblewrap's private PID namespace). Keep
+/// the marker and non-blank run id coupled so callers can make decisions at
+/// that authority boundary without trusting a standalone environment marker.
+pub(crate) fn managed_run_context_run_id_from_env() -> Option<String> {
+    let managed = std::env::var(ORBIT_MANAGED_RUN_CONTEXT_ENV)
+        .ok()
+        .is_some_and(|value| matches!(value.trim(), "1" | "true" | "TRUE"));
+    if !managed {
+        return None;
+    }
+
+    std::env::var("ORBIT_RUN_ID")
+        .ok()
+        .and_then(|value| non_empty(&value).map(ToOwned::to_owned))
+}
+
+/// Whether this process is a trusted child of an Orbit-managed run.
+pub(crate) fn managed_run_context_from_env() -> bool {
+    managed_run_context_run_id_from_env().is_some()
+}
+
 /// Extract the singular task id from run/activity input shapes that are meant
 /// to identify exactly one task.
 pub(crate) fn singular_task_id_from_input(input: &Value) -> Option<&str> {

--- a/crates/orbit-core/src/runtime/tests/runtime.rs
+++ b/crates/orbit-core/src/runtime/tests/runtime.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 
 use crate::OrbitRuntime;
+use orbit_common::types::JobRunState;
 
 use std::ffi::OsString;
 use std::sync::Mutex;
@@ -145,6 +146,14 @@ impl EnvVarGuard {
         }
         Self { key, previous }
     }
+
+    fn unset(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        unsafe {
+            std::env::remove_var(key);
+        }
+        Self { key, previous }
+    }
 }
 
 impl Drop for EnvVarGuard {
@@ -157,6 +166,106 @@ impl Drop for EnvVarGuard {
                 std::env::remove_var(self.key);
             },
         }
+    }
+}
+
+fn reopened_stale_run_state(managed_context: Option<&str>, run_id: Option<&str>) -> JobRunState {
+    let root = tempdir().expect("create tempdir");
+    let global_root = root.path().join("global");
+    let workspace_root = root.path().join("repo/.orbit");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    let runtime = OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("managed_context_probe", 1, chrono::Utc::now(), None, None)
+        .expect("insert run");
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, chrono::Utc::now(), 999_999)
+        .expect("mark run with host-invisible owner");
+    drop(runtime);
+
+    let _managed_context = match managed_context {
+        Some(value) => EnvVarGuard::set("ORBIT_MANAGED_RUN_CONTEXT", value.into()),
+        None => EnvVarGuard::unset("ORBIT_MANAGED_RUN_CONTEXT"),
+    };
+    let _run_id = match run_id {
+        Some(value) => EnvVarGuard::set("ORBIT_RUN_ID", value.into()),
+        None => EnvVarGuard::unset("ORBIT_RUN_ID"),
+    };
+    let reopened = OrbitRuntime::from_roots(&global_root, &workspace_root).expect("reopen runtime");
+    reopened
+        .get_job_run_backend(&run.run_id)
+        .expect("read run")
+        .expect("run exists")
+        .state
+}
+
+/// [ORB-10557] A managed sandbox child may not see the host worker PID. The
+/// impossible PID below models that private-namespace `process_not_found`
+/// shape; workspace open must leave the host-owned run alone, while explicit
+/// recovery remains unchanged.
+#[test]
+fn managed_run_context_skips_workspace_open_reconciliation_but_not_explicit_recovery() {
+    let _guard = ENV_LOCK.lock().expect("lock env");
+    let root = tempdir().expect("create tempdir");
+    let global_root = root.path().join("global");
+    let workspace_root = root.path().join("repo/.orbit");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    let runtime = OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("managed_context_probe", 1, chrono::Utc::now(), None, None)
+        .expect("insert run");
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, chrono::Utc::now(), 999_999)
+        .expect("mark run with host-invisible owner");
+    drop(runtime);
+
+    let _managed_context = EnvVarGuard::set("ORBIT_MANAGED_RUN_CONTEXT", "true".into());
+    let _run_id = EnvVarGuard::set("ORBIT_RUN_ID", "jrun-managed-child".into());
+    let reopened = OrbitRuntime::from_roots(&global_root, &workspace_root).expect("reopen runtime");
+    let stored = reopened
+        .get_job_run_backend(&run.run_id)
+        .expect("read run")
+        .expect("run exists");
+    assert_eq!(stored.state, JobRunState::Running);
+
+    assert_eq!(
+        reopened
+            .reconcile_stale_job_runs(None)
+            .expect("explicit reconciliation"),
+        1
+    );
+    let reconciled = reopened
+        .get_job_run_backend(&run.run_id)
+        .expect("read reconciled run")
+        .expect("run exists");
+    assert_eq!(reconciled.state, JobRunState::Interrupted);
+}
+
+#[test]
+fn workspace_open_reconciles_without_a_complete_managed_run_context() {
+    let _guard = ENV_LOCK.lock().expect("lock env");
+    for (managed_context, run_id) in [
+        (None, Some("jrun-unmanaged")),
+        (Some("false"), Some("jrun-false")),
+        (Some("not-a-boolean"), Some("jrun-malformed")),
+        (Some("true"), None),
+        (Some("1"), Some("   ")),
+    ] {
+        assert_eq!(
+            reopened_stale_run_state(managed_context, run_id),
+            JobRunState::Interrupted,
+            "managed context={managed_context:?}, run id={run_id:?}",
+        );
     }
 }
 

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -149,6 +149,14 @@ The deterministic argv starts with a read-only bind of `/`, explicitly retains t
 
 Existing matches of non-subtree negative globs are mounted read-only before spawn. Because mount namespaces cannot reject a matching filename created later, direct invocations with an overlapping non-subtree deny fail closed. An Orbit-managed single-writer worktree may run with snapshot expansion, followed by a post-run scan that rejects any newly-created forbidden match before downstream commit. Audit metadata records the effective backend, trusted wrapper, probe outcome, redacted effective argv, `write_enforced` or `write_delegated`, and the honest `read_delegated` boundary. [ORB-10552] [ADR-0304]
 
+Bubblewrap's private PID namespace also establishes a liveness-authority boundary. A nested
+`orbit` command receiving both truthy `ORBIT_MANAGED_RUN_CONTEXT` and a non-blank
+`ORBIT_RUN_ID` is a managed child, not an authority for its host pipeline worker. On runtime
+open it skips only the opportunistic orphan scan: the host worker can be alive while invisible
+inside that namespace. Top-level runtime opens and explicit host recovery surfaces retain their
+normal reconciliation behavior. Do not weaken the PID namespace, enable bare fallback, or infer
+that an invisible host worker is dead from inside a sandboxed child. [ORB-10557]
+
 ---
 
 ## 8. Process Supervision

--- a/docs/runbooks/stuck-job-runs.md
+++ b/docs/runbooks/stuck-job-runs.md
@@ -86,6 +86,13 @@ Reconciliation runs best-effort at workspace open and lazily on
 `orbit run history` / `orbit run show`. `orbit doctor` reports orphans read-only. A run
 whose PID is alive but unverifiable is deliberately left alone.
 
+Nested sandboxed activity commands are not a liveness authority for their host worker. When an
+activity child carries truthy `ORBIT_MANAGED_RUN_CONTEXT` and a non-blank `ORBIT_RUN_ID`, its
+workspace open deliberately skips the opportunistic orphan scan: Bubblewrap may place it in a
+private PID namespace where the live host worker appears absent. Investigate and reconcile from
+the host's top-level Orbit process instead. Do not remove the private PID namespace, enable a
+bare fallback, or treat the child's inability to see the worker as evidence of an orphan.
+
 Example after a worker was SIGKILLed mid-step:
 
 ```text


### PR DESCRIPTION
<!--
Thanks for sending a pull request. Fill in the sections below so reviewers can
verify scope, run the same validation locally, and confirm docs were updated when needed.
-->

## Linked Orbit task(s)

<!--
Required. List the Orbit task ID(s) this PR implements, one per line.
Example: [ORB-NNNNN] — short title
If the task has a linked external tracker ref (Jira / Linear / GitHub issue),
include that tag too: [ORB-NNNNN] [ENG-1234] — short title
-->

- [ORB-NNNNN]

## Summary

<!--
What changed and why, in 1–3 sentences. Focus on intent, not a diff dump.
-->

## Test plan

<!--
Commands you actually ran, with results. At minimum:
-->

- [ ] `make ci` passes locally (runs fmt-check, build, clippy `-D warnings`, tests)
- [ ] Targeted tests for the affected crate(s) pass
- [ ] Manual verification steps (if applicable):

## Design docs

<!--
If this PR touches behavior described in `docs/design/*`, update the affected
docs in the SAME PR: flip ADR statuses, bump `**Last updated:**`, add new ADRs
for non-obvious decisions.
-->

- [ ] N/A — this PR does not touch any code referenced by `docs/design/*`

## Notes for reviewers

<!--
Optional. Call out risky areas, rollout plan, follow-ups deferred to other
Orbit tasks, or anything reviewers should look at first.
-->
