### PR TITLE
Document Ubuntu AppArmor prerequisite for Linux Bubblewrap sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The constraints are the point — they're what keep agent-assisted code shippabl
 
 - **Conflict-aware parallel execution.** For `orbit run ship`, each agent run lands in its own git worktree per task, and the gate pipeline reserves task `context_files` as locks before fanning out, rejecting overlapping reservations up front instead of producing merge conflicts later (see [merge throughput chart](docs/assets/merge-throughput.png)). → [docs/design/activity-job/](docs/design/activity-job/)
 
-- **Sandboxed-by-default execution.** Dispatched agent CLIs run under an OS-level sandbox out of the box — FS access scoped to the worktree, network egress gated by per-activity policy. **macOS only today** (via `sandbox-exec`); on Linux/Windows the agent subprocess runs unsandboxed, with in-process FS guards still covering HTTP tools. → [docs/design/policy-sandbox](docs/design/policy-sandbox/)
+- **Sandboxed-by-default execution.** Dispatched agent CLIs run under an OS-level sandbox out of the box — FS access scoped to the worktree, network egress gated by per-activity policy. macOS uses `sandbox-exec`; Linux uses `linux-bwrap` through `/usr/bin/bwrap` after a capability probe. Windows and other unsupported platforms have no shipped OS-level backend, while in-process FS guards still cover HTTP tools. → [docs/design/policy-sandbox](docs/design/policy-sandbox/)
 
 ---
 
@@ -64,7 +64,7 @@ Paste the prompt below into your agent (Claude Code, Codex CLI, or Gemini CLI) *
 > 1. Ask me where I want to clone the Orbit repository (suggest something like `~/code/orbit` or `~/dev/orbit`).
 > 2. Verify the Rust toolchain. Run `cargo --version` and `rustc --version`. Orbit declares `rust-version = "1.89"` (MSRV), so I need Rust **1.89 or newer**. If cargo is missing, or rustc is older than 1.89, **stop and ask me before installing anything** — the canonical path is `rustup` (`curl https://sh.rustup.rs | sh`), but that modifies shell profile, so I want to confirm first. If rustup is already installed but the toolchain is old, suggest `rustup update stable` and confirm before running.
 > 3. Clone `https://github.com/danieljhkim/orbit` into the location from step 1, then run `make install`. This builds with cargo and copies the `orbit` binary to `$INSTALL_BIN_DIR` (default: `~/.cargo/bin`). Confirm the install path with me before running. Verify with `orbit --version`.
-> 4. Run `orbit init` to initialize global state at `~/.orbit`.
+> 4. Run `orbit init` to initialize global state at `~/.orbit`. It selects the host-appropriate sandbox for the shipped executor definitions: `macos-sandbox-exec` on macOS, `linux-bwrap` on Linux, and no OS-level backend on unsupported platforms. On Linux, after `orbit init`, follow the [Linux Bubblewrap host prerequisite](#linux-bubblewrap-host-prerequisite) below and require its capability probe to pass before dispatching agents.
 > 5. From *this* repository (not the Orbit clone), run `orbit workspace init --mcp`. This creates `.orbit/` here and auto-registers Orbit's MCP server with installed agent CLIs (Claude Code, Codex, Gemini).
 > 6. Ask me whether to enable semantic search (**optional**). `orbit semantic install` downloads a small embedder companion plus the default bge-small model (lives under `~/.orbit/embed/`) and powers `orbit search <query> --hybrid` / `orbit search similar <task-id>` over tasks. It requires macOS arm64 or Linux x86_64/aarch64 with glibc >= 2.38; Intel macOS is unsupported for semantic search. Don't install without my OK. If I accept and tasks already exist in this workspace, also run `orbit semantic index` to backfill the corpus.
 > 7. Read the key documents so you actually understand the model:
@@ -90,7 +90,7 @@ Paste the prompt below into your agent (Claude Code, Codex CLI, or Gemini CLI) *
 
 Faster to get running, and the right choice if you don't need to change how Orbit works: `curl`, Homebrew, or an agent plugin all give you a released, signed build. You give up the ability to reshape Orbit's conventions in place — you can always clone later and keep your `.orbit/` state.
 
-**Prerequisites:** at least one supported agent CLI (Codex, Claude Code, or Gemini CLI), authenticated. For PR-based workflows (i.e., `orbit run ship` in the default `--mode pr`), `gh` installed and authenticated; otherwise use `--mode local`.
+**Prerequisites:** at least one supported agent CLI (Codex, Claude Code, or Gemini CLI), authenticated. For PR-based workflows (i.e., `orbit run ship` in the default `--mode pr`), `gh` installed and authenticated; otherwise use `--mode local`. On Linux, install and verify the [Linux Bubblewrap host prerequisite](#linux-bubblewrap-host-prerequisite) after `orbit init`.
 
 <details>
 <summary><strong>Manual setup commands</strong> — copy these into your terminal (click to expand)</summary>
@@ -141,6 +141,31 @@ orbit web connect my-server
 
 </details>
 <br>
+
+### Linux Bubblewrap host prerequisite
+
+`orbit init` persists the host-appropriate sandbox into the shipped executor artifacts. On Linux that value is `linux-bwrap`, which resolves the trusted wrapper at `/usr/bin/bwrap` and fails closed if its namespace-and-mount capability probe cannot run. Install Bubblewrap before dispatching an agent. Ubuntu 24.04 (Noble) also enables AppArmor restrictions on unprivileged user namespaces; without the distro's narrow Bubblewrap profile, the probe fails with `bwrap: setting up uid map: Permission denied`.
+
+On Ubuntu 24.04, run this remediation and verification sequence. It installs the packaged `bwrap-userns-restrict` profile under `/etc/apparmor.d/`, loads it, confirms that AppArmor knows the profile, and runs the same capability shape Orbit probes:
+
+```bash
+sudo apt-get update
+sudo apt-get install --yes bubblewrap apparmor-profiles
+test -x /usr/bin/bwrap
+test -f /etc/apparmor.d/bwrap-userns-restrict
+sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
+grep -Fq 'bwrap-userns-restrict' /sys/kernel/security/apparmor/profiles
+
+/usr/bin/bwrap \
+  --die-with-parent \
+  --new-session \
+  --unshare-all \
+  --share-net \
+  --ro-bind / / \
+  -- /bin/true
+```
+
+The final command must exit successfully. If it still reports the UID-map error, do not disable `kernel.apparmor_restrict_unprivileged_userns` globally and do not enable `allow_fallback`; both weaken or bypass the fail-closed boundary. Re-check the packaged profile path and load output, then rerun the probe. Non-Linux setup paths are unchanged.
 
 Full command reference: `orbit --help` and [orbit-cli.com](https://orbit-cli.com).
 

--- a/README.md
+++ b/README.md
@@ -146,12 +146,16 @@ orbit web connect my-server
 
 `orbit init` persists the host-appropriate sandbox into the shipped executor artifacts. On Linux that value is `linux-bwrap`, which resolves the trusted wrapper at `/usr/bin/bwrap` and fails closed if its namespace-and-mount capability probe cannot run. Install Bubblewrap before dispatching an agent. Ubuntu 24.04 (Noble) also enables AppArmor restrictions on unprivileged user namespaces; without the distro's narrow Bubblewrap profile, the probe fails with `bwrap: setting up uid map: Permission denied`.
 
-On Ubuntu 24.04, run this remediation and verification sequence. It installs the packaged `bwrap-userns-restrict` profile under `/etc/apparmor.d/`, loads it, confirms that AppArmor knows the profile, and runs the same capability shape Orbit probes:
+On Ubuntu 24.04, run this remediation and verification sequence. The package ships `bwrap-userns-restrict` under `/usr/share/apparmor/extra-profiles/`; copy that narrow profile into `/etc/apparmor.d/`, load it, confirm that AppArmor knows it, and run the same capability shape Orbit probes:
 
 ```bash
 sudo apt-get update
 sudo apt-get install --yes bubblewrap apparmor-profiles
 test -x /usr/bin/bwrap
+test -f /usr/share/apparmor/extra-profiles/bwrap-userns-restrict
+sudo install -m 0644 \
+  /usr/share/apparmor/extra-profiles/bwrap-userns-restrict \
+  /etc/apparmor.d/bwrap-userns-restrict
 test -f /etc/apparmor.d/bwrap-userns-restrict
 sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
 grep -Fq 'bwrap-userns-restrict' /sys/kernel/security/apparmor/profiles

--- a/crates/orbit-core/assets/skills/orbit/references/guide.md
+++ b/crates/orbit-core/assets/skills/orbit/references/guide.md
@@ -10,7 +10,7 @@ Get a first-time user from zero to a usable Orbit workspace, then hand off to `o
 
 ## Canonical sources
 
-The README and config reference live in the Orbit repo. On a non-clone install path (plugin or binary-only install) there is no local copy yet — use `WebFetch` against the raw URLs below instead of answering from this snapshot.
+The README and config reference live in the Orbit repo. On a non-clone install path (plugin or binary-only install) there is no local copy yet — use `WebFetch` against the raw URLs below instead of answering from this snapshot. The README's `Linux Bubblewrap host prerequisite` section is also the canonical source for the volatile Linux package, AppArmor, and capability-verification commands.
 
 - Repo: https://github.com/danieljhkim/orbit
 - Raw README: https://raw.githubusercontent.com/danieljhkim/orbit/main/README.md
@@ -43,7 +43,7 @@ Do not paraphrase the commands here. Re-read the README at invocation time; it m
 
 ## Step 3 — Run setup
 
-Follow the destructive-action confirmation rules stated in the README's "Setup via Agent Prompt" block — that is the source of truth. If a step fails (missing toolchain, permission error, registration error), surface the failure and offer `orbit-task` friction reporting to capture it. First-time setup is exactly the signal that exists for.
+Follow the destructive-action confirmation rules stated in the README's "Setup via Agent Prompt" block — that is the source of truth. If a step fails (missing toolchain, permission error, registration error), surface the failure and offer `orbit-task` friction reporting to capture it. After `orbit init`, re-read the current README and route Linux host-readiness work to its `Linux Bubblewrap host prerequisite` section; require that section's `/usr/bin/bwrap` capability probe to pass before handing off to an agent. First-time setup is exactly the signal that exists for.
 
 ## Step 4 — Verify
 
@@ -112,7 +112,7 @@ launch command.
 
 ## Anti-patterns (DO NOT)
 
-- Don't inline install commands, prereq versions, or destructive-action rules in this file. They rot independently from the README.
+- Don't inline install commands, Linux AppArmor remediation, prerequisite versions, or destructive-action rules in this file. They rot independently from the README.
 - Don't run the README setup block from memory. Read it at invocation time.
 - Don't trigger this reference once `.orbit/` exists — use the rest of the `orbit` skill.
 - Don't author the first task silently. Route through `orbit-task`'s create workflow.

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -3,7 +3,7 @@ summary: "Policy & Sandboxing — Design"
 type: design
 title: "Policy & Sandboxing — Design"
 owner: claude
-last_updated: 2026-08-01
+last_updated: 2026-08-02
 status: Draft
 feature: policy-sandbox
 doc_role: design
@@ -157,6 +157,45 @@ inside that namespace. Top-level runtime opens and explicit host recovery surfac
 normal reconciliation behavior. Do not weaken the PID namespace, enable bare fallback, or infer
 that an invisible host worker is dead from inside a sandboxed child. [ORB-10557]
 
+### 7.2 Linux host readiness on Ubuntu 24.04
+
+Ubuntu 24.04 (Noble) enables AppArmor restriction of unprivileged user namespaces through
+`kernel.apparmor_restrict_unprivileged_userns`. When `/usr/bin/bwrap` starts Orbit's probe,
+Bubblewrap creates the private user namespace and configures its UID map. If AppArmor has no
+narrow profile granting that operation to Bubblewrap, the kernel rejects the setup and bwrap
+reports `bwrap: setting up uid map: Permission denied`. A present executable is therefore not
+enough; the real namespace-and-mount probe in `probe_bwrap` must succeed.
+
+The supported Noble remediation is the distro `apparmor-profiles` package's
+`bwrap-userns-restrict` profile. Install Bubblewrap and the profile package, confirm the profile
+is present at `/etc/apparmor.d/bwrap-userns-restrict`, and load it with
+`apparmor_parser -r`. Verify both that the profile is visible to AppArmor and that the exact
+probe shape used by Orbit exits successfully:
+
+```bash
+sudo apt-get update
+sudo apt-get install --yes bubblewrap apparmor-profiles
+test -x /usr/bin/bwrap
+test -f /etc/apparmor.d/bwrap-userns-restrict
+sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
+grep -Fq 'bwrap-userns-restrict' /sys/kernel/security/apparmor/profiles
+/usr/bin/bwrap --die-with-parent --new-session --unshare-all --share-net \
+  --ro-bind / / -- /bin/true
+```
+
+To roll back only this host remediation, unload the packaged profile with
+`sudo apparmor_parser -R /etc/apparmor.d/bwrap-userns-restrict`; do not delete the
+package-managed file. The probe should then fail again on a host where the global restriction is
+active, and re-running the `-r` command restores the remediation. Do not disable
+`kernel.apparmor_restrict_unprivileged_userns` globally or install a broad unconfined profile:
+those changes expand the user-namespace attack surface beyond Bubblewrap. Do not set
+`allow_fallback: true` to hide a failed probe, because that bypasses the fail-closed OS boundary
+and runs the provider without `linux-bwrap`.
+
+This subsection records the shipped Linux behavior from [ORB-10552] and the Ubuntu host rescue
+context from [ORB-10553]. No sandbox design decision changed, and this operational remediation
+requires no new ADR.
+
 ---
 
 ## 8. Process Supervision
@@ -256,5 +295,6 @@ failure when user or mount namespaces are unavailable.
 - **[T20260509-30]** — Resolve `sandbox-exec` from trusted absolute locations and keep availability errors fail-closed and explicit.
 - **[ORB-00129]** — Re-allow narrow workspace child Orbit runtime stores for activity-exposed learning, friction, and job-run state tools without removing the default workspace `.orbit/**` deny.
 - **[ORB-10552]** — Ship fail-closed Linux Bubblewrap write confinement without claiming read-policy parity.
+- **[ORB-10553]** — Rescue the Ubuntu host prerequisite for the shipped Linux Bubblewrap probe.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -167,8 +167,8 @@ reports `bwrap: setting up uid map: Permission denied`. A present executable is 
 enough; the real namespace-and-mount probe in `probe_bwrap` must succeed.
 
 The supported Noble remediation is the distro `apparmor-profiles` package's
-`bwrap-userns-restrict` profile. Install Bubblewrap and the profile package, confirm the profile
-is present at `/etc/apparmor.d/bwrap-userns-restrict`, and load it with
+`bwrap-userns-restrict` profile. The package provides it under
+`/usr/share/apparmor/extra-profiles/`; copy it into `/etc/apparmor.d/` and load that copy with
 `apparmor_parser -r`. Verify both that the profile is visible to AppArmor and that the exact
 probe shape used by Orbit exits successfully:
 
@@ -176,6 +176,10 @@ probe shape used by Orbit exits successfully:
 sudo apt-get update
 sudo apt-get install --yes bubblewrap apparmor-profiles
 test -x /usr/bin/bwrap
+test -f /usr/share/apparmor/extra-profiles/bwrap-userns-restrict
+sudo install -m 0644 \
+  /usr/share/apparmor/extra-profiles/bwrap-userns-restrict \
+  /etc/apparmor.d/bwrap-userns-restrict
 test -f /etc/apparmor.d/bwrap-userns-restrict
 sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
 grep -Fq 'bwrap-userns-restrict' /sys/kernel/security/apparmor/profiles
@@ -184,9 +188,11 @@ grep -Fq 'bwrap-userns-restrict' /sys/kernel/security/apparmor/profiles
 ```
 
 To roll back only this host remediation, unload the packaged profile with
-`sudo apparmor_parser -R /etc/apparmor.d/bwrap-userns-restrict`; do not delete the
-package-managed file. The probe should then fail again on a host where the global restriction is
-active, and re-running the `-r` command restores the remediation. Do not disable
+`sudo apparmor_parser -R /etc/apparmor.d/bwrap-userns-restrict`, then remove only the copied
+`/etc/apparmor.d/bwrap-userns-restrict` file; leave the package-managed source under
+`/usr/share/apparmor/extra-profiles/` intact. The probe should then fail again on a host where the
+global restriction is active, and repeating the copy-and-load sequence restores the remediation.
+Do not disable
 `kernel.apparmor_restrict_unprivileged_userns` globally or install a broad unconfined profile:
 those changes expand the user-namespace attack surface beyond Bubblewrap. Do not set
 `allow_fallback: true` to hide a failed probe, because that bypasses the fail-closed OS boundary

--- a/plugin/skills/orbit/references/guide.md
+++ b/plugin/skills/orbit/references/guide.md
@@ -10,7 +10,7 @@ Get a first-time user from zero to a usable Orbit workspace, then hand off to `o
 
 ## Canonical sources
 
-The README and config reference live in the Orbit repo. On a non-clone install path (plugin or binary-only install) there is no local copy yet — use `WebFetch` against the raw URLs below instead of answering from this snapshot.
+The README and config reference live in the Orbit repo. On a non-clone install path (plugin or binary-only install) there is no local copy yet — use `WebFetch` against the raw URLs below instead of answering from this snapshot. The README's `Linux Bubblewrap host prerequisite` section is also the canonical source for the volatile Linux package, AppArmor, and capability-verification commands.
 
 - Repo: https://github.com/danieljhkim/orbit
 - Raw README: https://raw.githubusercontent.com/danieljhkim/orbit/main/README.md
@@ -43,7 +43,7 @@ Do not paraphrase the commands here. Re-read the README at invocation time; it m
 
 ## Step 3 — Run setup
 
-Follow the destructive-action confirmation rules stated in the README's "Setup via Agent Prompt" block — that is the source of truth. If a step fails (missing toolchain, permission error, registration error), surface the failure and offer `orbit-task` friction reporting to capture it. First-time setup is exactly the signal that exists for.
+Follow the destructive-action confirmation rules stated in the README's "Setup via Agent Prompt" block — that is the source of truth. If a step fails (missing toolchain, permission error, registration error), surface the failure and offer `orbit-task` friction reporting to capture it. After `orbit init`, re-read the current README and route Linux host-readiness work to its `Linux Bubblewrap host prerequisite` section; require that section's `/usr/bin/bwrap` capability probe to pass before handing off to an agent. First-time setup is exactly the signal that exists for.
 
 ## Step 4 — Verify
 
@@ -112,7 +112,7 @@ launch command.
 
 ## Anti-patterns (DO NOT)
 
-- Don't inline install commands, prereq versions, or destructive-action rules in this file. They rot independently from the README.
+- Don't inline install commands, Linux AppArmor remediation, prerequisite versions, or destructive-action rules in this file. They rot independently from the README.
 - Don't run the README setup block from memory. Read it at invocation time.
 - Don't trigger this reference once `.orbit/` exists — use the rest of the `orbit` skill.
 - Don't author the first task silently. Route through `orbit-task`'s create workflow.


### PR DESCRIPTION
## Task

[ORB-10556](https://orbit-cli.com/tasks/ORB-10556) — Document Ubuntu AppArmor prerequisite for Linux Bubblewrap sandbox

### Description

## Problem
Orbit now seeds `linux-bwrap` for shipped CLI agent executors during `orbit init`, but the user-facing setup path does not explain the Linux host prerequisite. `README.md` still says OS-level sandboxing is macOS-only, and Ubuntu 24.04 enables AppArmor user-namespace restrictions that make Orbit's faithful Bubblewrap probe fail with `bwrap: setting up uid map: Permission denied` unless the distro's packaged `bwrap-userns-restrict` profile is installed and loaded.

## Required documentation shape
- Make `README.md` the canonical source for install commands and prerequisites. Correct the stale macOS-only feature claim, explain that `orbit init` selects the host sandbox and persists it into shipped executor artifacts, document `/usr/bin/bwrap` plus the Ubuntu 24.04 packaged AppArmor profile, give a real capability verification, and identify the exact UID-map failure.
- Update `crates/orbit-core/assets/skills/orbit/references/guide.md` as Daniel requested. Preserve its anti-drift rule: the guide should route agents to the README's current Linux prerequisite commands and require verification after `orbit init`, rather than copying version-sensitive package instructions into the skill.
- Add an operator-facing host-readiness/troubleshooting subsection to `docs/design/policy-sandbox/2_design.md` that explains why AppArmor blocks UID-map creation, the narrow packaged-profile remediation, verification, and rollback.

## Constraints / Notes
- Do not recommend `allow_fallback: true`, disabling `kernel.apparmor_restrict_unprivileged_userns`, or a broad unconfined AppArmor profile. Those weaken the fail-closed boundary.
- The supported remediation on Ubuntu Noble is the distro `apparmor-profiles` package's `bwrap-userns-restrict` profile, installed under `/etc/apparmor.d/` and loaded with `apparmor_parser`.
- This records shipped behavior from ORB-10552 and the 2026-08-01 ORB-10553 rescue; it does not change sandbox design, so no new ADR is expected.
- Keep non-Linux setup paths unchanged.

### Acceptance Criteria

- `README.md` no longer says OS-level sandboxing is macOS-only and accurately distinguishes macOS `sandbox-exec`, Linux `linux-bwrap`, and unsupported platforms.
- The README's setup/prerequisite path states that `orbit init` selects the host-appropriate sandbox in shipped executor artifacts and includes an executable Ubuntu 24.04 remediation and capability-verification sequence for `/usr/bin/bwrap`.
- `crates/orbit-core/assets/skills/orbit/references/guide.md` tells setup agents to verify the Linux sandbox prerequisite after `orbit init`, routes commands to the freshly-read README, and does not duplicate volatile install commands.
- `docs/design/policy-sandbox/2_design.md` documents the AppArmor cause of `bwrap: setting up uid map: Permission denied`, the narrow packaged-profile fix, verification, rollback, and why global restriction disablement or `allow_fallback` is not the recommended remedy.
- The docs cite ORB-10552 and the ORB-10553 rescue context, state that no design decision changed, and require no new ADR.
- `make ci-fast` and `git diff --check` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated README.md as the canonical source for platform-specific sandbox support, orbit init executor seeding, and Ubuntu 24.04 Bubblewrap/AppArmor remediation plus the exact capability probe.
- Updated the Orbit setup guide to re-read and route Linux host readiness to README without copying volatile commands.
- Mirrored the guide update in plugin/skills/orbit/references/guide.md; appended this file to context_files because shipped skill assets must stay synchronized.
- Added the Ubuntu AppArmor cause, narrow packaged-profile remediation, verification, rollback, security non-recommendations, and ORB-10552/ORB-10553 operational context to the policy sandbox design doc; no ADR added.
Assessment: Documentation-only change is scoped to the requested surfaces and preserves non-Linux setup paths.
Validation: make ci-fast passed; git diff --check passed; the two guide copies are identical.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10556-6a6e96ab`
- Behind base: 0
- Ahead of base: 1