### PR TITLE
Diagnose and safely repair stale task reservations with orbit doctor

### DIFF
--- a/crates/orbit-cli/src/command/doctor.rs
+++ b/crates/orbit-cli/src/command/doctor.rs
@@ -17,6 +17,10 @@ pub struct DoctorCommand {
     #[arg(long)]
     pub fix_stale_locks: bool,
 
+    /// Release only task reservations whose owner/task state is conclusively inactive.
+    #[arg(long)]
+    pub fix_stale_task_locks: bool,
+
     /// Remove retired graph state from this worktree and the shared workspace.
     #[arg(long)]
     pub remove_graph: bool,
@@ -33,6 +37,12 @@ impl Execute for DoctorCommand {
             let removed = runtime.remove_stale_lock_files()?;
             if !self.json {
                 println!("Removed {removed} stale lock file(s).");
+            }
+        }
+        if self.fix_stale_task_locks {
+            let released = runtime.clear_stale_task_reservations()?;
+            if !self.json {
+                println!("Released {released} stale task reservation(s).");
             }
         }
         if self.remove_graph {
@@ -67,7 +77,7 @@ impl Execute for DoctorCommand {
                 table.add_row(vec![
                     Cell::new(&row.check_name),
                     crate::output::color::doctor_status_color_cell(status_label(row.status)),
-                    Cell::new(&row.message),
+                    Cell::new(human_detail(row)),
                 ]);
             }
             println!("{table}");
@@ -102,7 +112,14 @@ fn status_label(status: WorkspaceDoctorStatus) -> &'static str {
     }
 }
 
-fn doctor_row_json(row: &WorkspaceDoctorResult) -> Value {
+pub(crate) fn human_detail(row: &WorkspaceDoctorResult) -> String {
+    row.remediation.as_ref().map_or_else(
+        || row.message.clone(),
+        |remediation| format!("{}\nAction: {remediation}", row.message),
+    )
+}
+
+pub(crate) fn doctor_row_json(row: &WorkspaceDoctorResult) -> Value {
     json!({
         "check": row.check_name,
         "status": match row.status {
@@ -112,5 +129,6 @@ fn doctor_row_json(row: &WorkspaceDoctorResult) -> Value {
             WorkspaceDoctorStatus::Skipped => "skipped",
         },
         "message": row.message,
+        "remediation": row.remediation,
     })
 }

--- a/crates/orbit-cli/src/command/tests/doctor.rs
+++ b/crates/orbit-cli/src/command/tests/doctor.rs
@@ -1,0 +1,38 @@
+use orbit_cmd::{WorkspaceDoctorResult, WorkspaceDoctorStatus};
+
+use super::super::doctor::{doctor_row_json, human_detail};
+
+#[test]
+fn doctor_warning_renders_structured_and_human_remediation() {
+    let row = WorkspaceDoctorResult {
+        check_name: "task-reservations".to_string(),
+        status: WorkspaceDoctorStatus::Warning,
+        message: "reservation-123 is stale".to_string(),
+        remediation: Some("Run `orbit doctor --fix-stale-task-locks`.".to_string()),
+    };
+
+    let json = doctor_row_json(&row);
+    assert_eq!(
+        json["remediation"],
+        "Run `orbit doctor --fix-stale-task-locks`."
+    );
+    let human = human_detail(&row);
+    assert!(human.contains("reservation-123 is stale"), "{human}");
+    assert!(
+        human.contains("Action: Run `orbit doctor --fix-stale-task-locks`."),
+        "{human}"
+    );
+}
+
+#[test]
+fn healthy_doctor_row_has_null_remediation_and_no_action_line() {
+    let row = WorkspaceDoctorResult {
+        check_name: "task-reservations".to_string(),
+        status: WorkspaceDoctorStatus::Ok,
+        message: "none stale".to_string(),
+        remediation: None,
+    };
+
+    assert!(doctor_row_json(&row)["remediation"].is_null());
+    assert_eq!(human_detail(&row), "none stale");
+}

--- a/crates/orbit-cli/src/command/tests/mod.rs
+++ b/crates/orbit-cli/src/command/tests/mod.rs
@@ -1,6 +1,7 @@
 // Content moved from inline #[cfg(test)] mod tests in command/mod.rs per ORB-00221.
 // tests/mod.rs can directly contain tests for the declaring parent module (exempt from orphan rules).
 
+mod doctor;
 mod friction;
 mod gc;
 mod init;
@@ -44,6 +45,7 @@ fn cli_parses_doctor_stale_lock_cleanup() {
     match cli.command {
         Commands::Doctor(command) => {
             assert!(command.fix_stale_locks);
+            assert!(!command.fix_stale_task_locks);
             assert!(command.remove_graph);
             assert!(command.json);
             // [ORB-10501] Repairs are opt-in: an unflagged run only diagnoses.
@@ -51,6 +53,25 @@ fn cli_parses_doctor_stale_lock_cleanup() {
         }
         _ => panic!("expected top-level doctor command"),
     }
+}
+
+#[test]
+fn cli_parses_doctor_stale_task_lock_repair_without_blanket_fix() {
+    let cli = Cli::parse_from(["orbit", "doctor", "--fix-stale-task-locks"]);
+    match cli.command {
+        Commands::Doctor(command) => {
+            assert!(command.fix_stale_task_locks);
+            assert!(!command.fix_stale_locks);
+            assert!(!command.fix_orphaned_allocations);
+        }
+        _ => panic!("expected top-level doctor command"),
+    }
+
+    assert_cli_rejects(
+        &["orbit", "doctor", "--fix"],
+        ErrorKind::UnknownArgument,
+        "unexpected argument '--fix'",
+    );
 }
 
 /// [ORB-10501] The guarded repair for allocations pinned to a reaped worktree.

--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -5,6 +5,8 @@
 //! integrity and schema-ledger version, free disk space on the volume
 //! holding `.orbit`, semantic-index staleness, leftover lock files from
 //! crashed holders, orphaned `running`/`pending` job runs, task
+//! reservations whose owner or terminal task association is conclusively
+//! inactive, task
 //! relation/dependency targets that no longer resolve in the registry
 //! (grandfathered relations that block index rebuilds — ORB-10305), and
 //! learning/ADR id allocations pinned to a worktree that has since been
@@ -49,13 +51,38 @@ pub struct WorkspaceDoctorResult {
     pub status: WorkspaceDoctorStatus,
     /// Human-readable detail line.
     pub message: String,
+    /// Exact repair command or explicit manual next step for warning/error rows.
+    pub remediation: Option<String>,
 }
 
 fn check(name: &str, status: WorkspaceDoctorStatus, message: String) -> WorkspaceDoctorResult {
+    let remediation = matches!(
+        status,
+        WorkspaceDoctorStatus::Warning | WorkspaceDoctorStatus::Error
+    )
+    .then(|| {
+        "Address the condition named in the diagnostic details, then rerun `orbit doctor`."
+            .to_string()
+    });
     WorkspaceDoctorResult {
         check_name: name.to_string(),
         status,
         message,
+        remediation,
+    }
+}
+
+fn actionable_check(
+    name: &str,
+    status: WorkspaceDoctorStatus,
+    message: String,
+    remediation: String,
+) -> WorkspaceDoctorResult {
+    WorkspaceDoctorResult {
+        check_name: name.to_string(),
+        status,
+        message,
+        remediation: Some(remediation),
     }
 }
 
@@ -81,6 +108,9 @@ pub trait DoctorCommands {
     /// is currently held by another process.
     fn remove_stale_lock_files(&self) -> Result<usize, OrbitError>;
 
+    /// Release reservations that remain conclusively stale after a write-boundary recheck.
+    fn clear_stale_task_reservations(&self) -> Result<usize, OrbitError>;
+
     /// Remove retired graph state from the exact worktree-local and shared
     /// workspace locations. Missing locations are a successful no-op.
     fn remove_retired_graph_state(&self) -> Result<usize, OrbitError>;
@@ -104,6 +134,7 @@ impl DoctorCommands for OrbitRuntime {
             doctor_check_semantic_index(self),
             doctor_check_stale_locks(self),
             doctor_check_job_runs(self),
+            doctor_check_task_reservations(self),
             doctor_check_task_relations(self),
             doctor_check_id_allocations(self),
         ])
@@ -117,6 +148,10 @@ impl DoctorCommands for OrbitRuntime {
             }
         }
         Ok(removed)
+    }
+
+    fn clear_stale_task_reservations(&self) -> Result<usize, OrbitError> {
+        self.release_stale_task_reservations()
     }
 
     fn remove_retired_graph_state(&self) -> Result<usize, OrbitError> {
@@ -235,13 +270,14 @@ fn doctor_check_semantic_index(runtime: &OrbitRuntime) -> WorkspaceDoctorResult 
                     "no semantic embeddings indexed yet".to_string(),
                 )
             } else if stats.rows.stale_rows > 0 {
-                check(
+                actionable_check(
                     "semantic-index",
                     WorkspaceDoctorStatus::Warning,
                     format!(
                         "{} of {total} embedding rows are stale; re-run `orbit semantic index`",
                         stats.rows.stale_rows
                     ),
+                    "Run `orbit semantic index`, then rerun `orbit doctor`.".to_string(),
                 )
             } else {
                 check(
@@ -282,7 +318,7 @@ fn doctor_check_stale_locks(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {
             format!("{} lock file(s) scanned, none stale", lock_files.len()),
         )
     } else {
-        check(
+        actionable_check(
             "stale-locks",
             WorkspaceDoctorStatus::Warning,
             format!(
@@ -291,8 +327,61 @@ fn doctor_check_stale_locks(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {
                 stale.len(),
                 stale.join("; ")
             ),
+            "Run `orbit doctor --fix-stale-locks`.".to_string(),
         )
     }
+}
+
+/// Active task reservations are diagnosed separately from filesystem lock
+/// files. The runtime classifier deliberately ignores fresh/live/ambiguous
+/// reservations and reports only owner/task states that prove inactivity.
+fn doctor_check_task_reservations(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {
+    let stale = match runtime.list_stale_task_reservations() {
+        Ok(stale) => stale,
+        Err(error) => {
+            return actionable_check(
+                "task-reservations",
+                WorkspaceDoctorStatus::Warning,
+                format!("cannot inspect active task reservations: {error}"),
+                "Resolve the store/runtime error, then rerun `orbit doctor`.".to_string(),
+            );
+        }
+    };
+    if stale.is_empty() {
+        return check(
+            "task-reservations",
+            WorkspaceDoctorStatus::Ok,
+            "no conclusively stale active task reservations".to_string(),
+        );
+    }
+    let detail = stale
+        .iter()
+        .map(|reservation| {
+            let tasks = if reservation.task_ids.is_empty() {
+                "no associated tasks".to_string()
+            } else {
+                format!("tasks {}", reservation.task_ids.join(", "))
+            };
+            let owner = reservation
+                .owner_run_id
+                .as_deref()
+                .map_or_else(|| "unowned".to_string(), |run_id| format!("run {run_id}"));
+            format!(
+                "{} ({tasks}, {owner}): {}",
+                reservation.reservation_id, reservation.reason
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    actionable_check(
+        "task-reservations",
+        WorkspaceDoctorStatus::Warning,
+        format!(
+            "{} conclusively stale active task reservation(s): {detail}",
+            stale.len()
+        ),
+        "Run `orbit doctor --fix-stale-task-locks`.".to_string(),
+    )
 }
 
 /// Delete one dead-holder lock only after acquiring its advisory lock. A
@@ -443,10 +532,11 @@ fn doctor_check_job_runs(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {
             ids.join(", ")
         ));
     }
-    check(
+    actionable_check(
         "job-runs",
         WorkspaceDoctorStatus::Warning,
         segments.join("; "),
+        "For each named running run use `orbit job resume <run_id>`; for each named pending run use `orbit run cancel <run_id>`.".to_string(),
     )
 }
 
@@ -489,7 +579,7 @@ fn doctor_check_task_relations(runtime: &OrbitRuntime) -> WorkspaceDoctorResult 
                 })
                 .collect::<Vec<_>>()
                 .join("; ");
-            check(
+            actionable_check(
                 "task-relations",
                 WorkspaceDoctorStatus::Warning,
                 format!(
@@ -497,6 +587,7 @@ fn doctor_check_task_relations(runtime: &OrbitRuntime) -> WorkspaceDoctorResult 
                      until fixed or removed: {detail}",
                     dangling.len()
                 ),
+                "Inspect each named source with `orbit task show <task-id>` and update or remove its unresolved relation/dependency target.".to_string(),
             )
         }
     }
@@ -548,7 +639,7 @@ fn doctor_check_id_allocations(runtime: &OrbitRuntime) -> WorkspaceDoctorResult 
     {
         detail.push_str(&format!("; and {remaining} more"));
     }
-    check(
+    actionable_check(
         "id-allocations",
         WorkspaceDoctorStatus::Warning,
         format!(
@@ -557,6 +648,7 @@ fn doctor_check_id_allocations(runtime: &OrbitRuntime) -> WorkspaceDoctorResult 
              --fix-orphaned-allocations`: {detail}",
             orphaned.len()
         ),
+        "Run `orbit doctor --fix-orphaned-allocations` after confirming the named worktrees are gone.".to_string(),
     )
 }
 

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -8,6 +8,7 @@ use fs2::FileExt;
 use orbit_common::types::{JobRun, JobRunState};
 
 use orbit_core::OrbitRuntime;
+use orbit_store::TaskReservationReserveParams;
 
 use crate::doctor::{
     DoctorCommands, WorkspaceDoctorResult, WorkspaceDoctorStatus, collect_lock_files,
@@ -45,7 +46,7 @@ fn healthy_fresh_workspace_has_no_failures() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     let results = runtime.doctor_workspace().expect("doctor");
 
-    assert_eq!(results.len(), 8, "one row per check: {results:?}");
+    assert_eq!(results.len(), 9, "one row per check: {results:?}");
     assert!(
         results
             .iter()
@@ -77,6 +78,10 @@ fn healthy_fresh_workspace_has_no_failures() {
         status_of(&results, "job-runs").status,
         WorkspaceDoctorStatus::Ok
     );
+    assert_eq!(
+        status_of(&results, "task-reservations").status,
+        WorkspaceDoctorStatus::Ok
+    );
     // No tasks yet → no unresolved relation/dependency targets.
     assert_eq!(
         status_of(&results, "task-relations").status,
@@ -86,6 +91,75 @@ fn healthy_fresh_workspace_has_no_failures() {
     assert_eq!(
         status_of(&results, "id-allocations").status,
         WorkspaceDoctorStatus::Ok
+    );
+}
+
+#[test]
+fn every_warning_or_error_has_structured_remediation() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    fs::write(
+        temp.path().join("repo").join(".orbit").join("config.toml"),
+        "not = [valid toml",
+    )
+    .expect("write broken config");
+
+    let results = runtime.doctor_workspace().expect("doctor");
+    let actionable = results.iter().filter(|row| {
+        matches!(
+            row.status,
+            WorkspaceDoctorStatus::Warning | WorkspaceDoctorStatus::Error
+        )
+    });
+    for row in actionable {
+        assert!(
+            row.remediation
+                .as_ref()
+                .is_some_and(|value| !value.is_empty()),
+            "actionable row needs remediation: {row:?}"
+        );
+    }
+}
+
+#[test]
+fn absent_owner_task_reservation_warning_names_context_reason_and_exact_repair() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let store = runtime.sqlite_store().expect("store");
+    let reservation = store
+        .reserve_task_reservation(&TaskReservationReserveParams {
+            workspace_orbit_dir: runtime.paths().orbit_dir.to_string_lossy().into_owned(),
+            workspace_id: None,
+            task_ids: vec!["ORB-12345".to_string()],
+            requested_files: vec!["file:src/lib.rs".to_string()],
+            actor: "test".to_string(),
+            ttl_seconds: 3600,
+            owner_run_id: Some("jrun-missing".to_string()),
+            owner_metadata_json: None,
+        })
+        .expect("reserve")
+        .reservation_id
+        .expect("reservation id");
+
+    let results = runtime.doctor_workspace().expect("doctor");
+    let row = status_of(&results, "task-reservations");
+    assert_eq!(row.status, WorkspaceDoctorStatus::Warning, "{row:?}");
+    assert!(row.message.contains(&reservation), "{}", row.message);
+    assert!(row.message.contains("ORB-12345"), "{}", row.message);
+    assert!(row.message.contains("jrun-missing"), "{}", row.message);
+    assert!(row.message.contains("is absent"), "{}", row.message);
+    assert_eq!(
+        row.remediation.as_deref(),
+        Some("Run `orbit doctor --fix-stale-task-locks`.")
+    );
+    let still_active = store
+        .inspect_active_task_reservations(&runtime.paths().orbit_dir.to_string_lossy(), None)
+        .expect("inspect after read-only doctor");
+    assert!(
+        still_active
+            .iter()
+            .any(|candidate| candidate.reservation_id == reservation),
+        "ordinary doctor must not release a diagnosed reservation"
     );
 }
 

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -25,6 +25,7 @@ mod task_block_on_run_failure;
 mod task_locks;
 mod task_records;
 mod task_reservation_cleanup;
+pub use task_reservation_cleanup::StaleTaskReservation;
 pub(crate) mod tool_exec;
 mod v2_host;
 

--- a/crates/orbit-core/src/runtime/task_reservation_cleanup.rs
+++ b/crates/orbit-core/src/runtime/task_reservation_cleanup.rs
@@ -1,10 +1,11 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use chrono::{DateTime, Utc};
-use orbit_common::types::{JobRunState, OrbitError};
+use orbit_common::types::{JobRunState, OrbitError, TaskStatus};
 use orbit_store::{
-    ReleasedTaskReservation, TaskReservationOwnedConflictsParams,
-    TaskReservationReleaseByOwnerParams, TaskReservationReleaseReason,
+    ActiveTaskReservation, ReleasedTaskReservation, TaskReservationOwnedConflictsParams,
+    TaskReservationReleaseByOwnerParams, TaskReservationReleaseParams,
+    TaskReservationReleaseReason,
 };
 use serde_json::json;
 
@@ -15,7 +16,153 @@ use super::task_locks::{
     workspace_task_reservation_id,
 };
 
+/// A task reservation that Orbit can prove is no longer protecting live work.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StaleTaskReservation {
+    pub reservation_id: String,
+    pub task_ids: Vec<String>,
+    pub owner_run_id: Option<String>,
+    pub reason: String,
+}
+
 impl OrbitRuntime {
+    /// Read-only classification used by `orbit doctor`.
+    ///
+    /// A reservation is conclusive only when its owner run is absent,
+    /// terminal, or already satisfies the existing orphan-run classifier; or
+    /// when it is unowned and every associated task is `done` (Orbit's only
+    /// terminal task status). Empty/missing/mixed task associations remain
+    /// ambiguous and are deliberately ignored.
+    pub fn list_stale_task_reservations(&self) -> Result<Vec<StaleTaskReservation>, OrbitError> {
+        let reservations = self
+            .stores()
+            .task_reservations()
+            .inspect_active_task_reservations(
+                &workspace_orbit_dir(self),
+                workspace_task_reservation_id(self)?.as_deref(),
+            )?;
+        let mut stale = Vec::new();
+        for reservation in reservations {
+            if let Some(reason) = self.classify_stale_task_reservation(&reservation)? {
+                stale.push(StaleTaskReservation {
+                    reservation_id: reservation.reservation_id,
+                    task_ids: reservation.task_ids,
+                    owner_run_id: reservation.owner_run_id,
+                    reason,
+                });
+            }
+        }
+        Ok(stale)
+    }
+
+    /// Release reservations that are still conclusively stale when re-read
+    /// immediately before their individual mutation. Replays are no-ops.
+    pub fn release_stale_task_reservations(&self) -> Result<usize, OrbitError> {
+        let candidate_ids = self
+            .list_stale_task_reservations()?
+            .into_iter()
+            .map(|candidate| candidate.reservation_id)
+            .collect::<Vec<_>>();
+        let mut released = 0;
+        for reservation_id in candidate_ids {
+            let current = self
+                .stores()
+                .task_reservations()
+                .inspect_active_task_reservations(
+                    &workspace_orbit_dir(self),
+                    workspace_task_reservation_id(self)?.as_deref(),
+                )?
+                .into_iter()
+                .find(|reservation| reservation.reservation_id == reservation_id);
+            let Some(current) = current else {
+                continue;
+            };
+            let Some(stale_reason) = self.classify_stale_task_reservation(&current)? else {
+                continue;
+            };
+            let result = self.stores().task_reservations().release_task_reservation(
+                TaskReservationReleaseParams {
+                    workspace_orbit_dir: workspace_orbit_dir(self),
+                    workspace_id: workspace_task_reservation_id(self)?,
+                    reservation_id: current.reservation_id.clone(),
+                    release_reason: TaskReservationReleaseReason::DoctorStaleTaskLock,
+                    release_metadata_json: Some(
+                        json!({
+                            "source": "orbit doctor --fix-stale-task-locks",
+                            "stale_reason": stale_reason,
+                            "owner_run_id": current.owner_run_id,
+                            "task_ids": current.task_ids,
+                        })
+                        .to_string(),
+                    ),
+                },
+            )?;
+            emit_expired_reservation_events(self, &result.expired_reservations)?;
+            if let Some(reservation) = result.reservation.as_ref() {
+                emit_task_lock_release_event(
+                    self,
+                    reservation,
+                    TaskReservationReleaseReason::DoctorStaleTaskLock,
+                )?;
+                released += 1;
+            }
+        }
+        Ok(released)
+    }
+
+    fn classify_stale_task_reservation(
+        &self,
+        reservation: &ActiveTaskReservation,
+    ) -> Result<Option<String>, OrbitError> {
+        if let Some(owner_run_id) = reservation.owner_run_id.as_deref() {
+            let Some(run) = self.get_job_run_backend(owner_run_id)? else {
+                return Ok(Some(format!("owner run {owner_run_id} is absent")));
+            };
+            if run.state.is_terminal() {
+                return Ok(Some(format!(
+                    "owner run {owner_run_id} is terminal ({})",
+                    run.state
+                )));
+            }
+            let orphaned_running = self
+                .list_orphaned_running_job_runs()?
+                .into_iter()
+                .any(|orphan| orphan.run_id == owner_run_id);
+            let orphaned_pending = self
+                .list_orphaned_pending_job_runs()?
+                .into_iter()
+                .any(|orphan| orphan.run_id == owner_run_id);
+            if orphaned_running || orphaned_pending {
+                return Ok(Some(format!(
+                    "owner run {owner_run_id} is conclusively orphaned ({})",
+                    run.state
+                )));
+            }
+            return Ok(None);
+        }
+
+        if reservation.task_ids.is_empty() {
+            return Ok(None);
+        }
+        let statuses = self
+            .list_tasks()?
+            .into_iter()
+            .map(|task| (task.id, task.status))
+            .collect::<BTreeMap<_, _>>();
+        let all_done = reservation
+            .task_ids
+            .iter()
+            .all(|task_id| statuses.get(task_id) == Some(&TaskStatus::Done));
+        if all_done {
+            Ok(Some(format!(
+                "unowned reservation references only terminal done task(s): {}",
+                reservation.task_ids.join(", ")
+            )))
+        } else {
+            Ok(None)
+        }
+    }
+
     pub(crate) fn finalize_job_run_with_reservation_cleanup(
         &self,
         run_id: &str,

--- a/crates/orbit-core/src/runtime/tests/task_reservation_cleanup.rs
+++ b/crates/orbit-core/src/runtime/tests/task_reservation_cleanup.rs
@@ -33,6 +33,22 @@ fn create_context_task(
     id_hint: &str,
     context_file: &str,
 ) -> String {
+    create_context_task_with_status(
+        runtime,
+        repo_root,
+        id_hint,
+        context_file,
+        TaskStatus::Backlog,
+    )
+}
+
+fn create_context_task_with_status(
+    runtime: &OrbitRuntime,
+    repo_root: &std::path::Path,
+    id_hint: &str,
+    context_file: &str,
+    status: TaskStatus,
+) -> String {
     let task = runtime
         .stores()
         .task_records()
@@ -53,7 +69,7 @@ fn create_context_task(
             created_by: Some("test".to_string()),
             planned_by: None,
             implemented_by: None,
-            status: TaskStatus::Backlog,
+            status,
             priority: TaskPriority::Medium,
             complexity: None,
             task_type: TaskType::Chore,
@@ -64,6 +80,30 @@ fn create_context_task(
         })
         .expect("create task");
     task.id
+}
+
+fn reserve_direct(
+    runtime: &OrbitRuntime,
+    task_ids: Vec<String>,
+    file: &str,
+    owner_run_id: Option<&str>,
+) -> String {
+    runtime
+        .stores()
+        .task_reservations()
+        .reserve_task_reservation(TaskReservationReserveParams {
+            workspace_orbit_dir: workspace_orbit_dir(runtime),
+            workspace_id: workspace_task_reservation_id(runtime).expect("workspace reservation id"),
+            task_ids,
+            requested_files: vec![file.to_string()],
+            actor: "test".to_string(),
+            ttl_seconds: 3600,
+            owner_run_id: owner_run_id.map(str::to_string),
+            owner_metadata_json: None,
+        })
+        .expect("reserve directly")
+        .reservation_id
+        .expect("reservation id")
 }
 
 fn insert_running_run(
@@ -146,6 +186,131 @@ fn release_audit_payloads(runtime: &OrbitRuntime) -> Vec<Value> {
         .filter_map(|event| event.arguments_json)
         .map(|raw| serde_json::from_str(&raw).expect("parse audit json"))
         .collect()
+}
+
+#[cfg(unix)]
+#[test]
+fn doctor_repair_releases_only_rechecked_conclusive_stale_classes_and_is_idempotent() {
+    let (_root, runtime, repo_root) = test_runtime();
+    std::fs::create_dir_all(repo_root.join("src")).expect("create src");
+
+    let fresh_task = create_context_task(&runtime, &repo_root, "fresh", "file:src/fresh.rs");
+    let done_task = create_context_task_with_status(
+        &runtime,
+        &repo_root,
+        "done",
+        "file:src/done.rs",
+        TaskStatus::Done,
+    );
+    let live_run = insert_running_run(&runtime, "live", std::process::id());
+    let terminal_run = insert_running_run(&runtime, "terminal", std::process::id());
+    runtime
+        .stores()
+        .jobs()
+        .finalize_job_run(
+            &terminal_run.run_id,
+            JobRunState::Success,
+            Utc::now(),
+            Some(1),
+        )
+        .expect("terminalize owner without cleanup");
+    let orphan_run = insert_running_run(&runtime, "orphan", 999_999);
+
+    let fresh = reserve_direct(&runtime, vec![fresh_task], "file:src/fresh.rs", None);
+    let live = reserve_direct(
+        &runtime,
+        Vec::new(),
+        "file:src/live.rs",
+        Some(&live_run.run_id),
+    );
+    let ambiguous = reserve_direct(
+        &runtime,
+        vec!["ORB-missing".to_string()],
+        "file:src/ambiguous.rs",
+        None,
+    );
+    let absent = reserve_direct(
+        &runtime,
+        Vec::new(),
+        "file:src/absent.rs",
+        Some("jrun-absent"),
+    );
+    let terminal = reserve_direct(
+        &runtime,
+        Vec::new(),
+        "file:src/terminal.rs",
+        Some(&terminal_run.run_id),
+    );
+    let orphan = reserve_direct(
+        &runtime,
+        Vec::new(),
+        "file:src/orphan.rs",
+        Some(&orphan_run.run_id),
+    );
+    let done = reserve_direct(&runtime, vec![done_task], "file:src/done.rs", None);
+
+    let diagnosed = runtime
+        .list_stale_task_reservations()
+        .expect("diagnose reservations");
+    let diagnosed_ids = diagnosed
+        .iter()
+        .map(|candidate| candidate.reservation_id.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        diagnosed_ids,
+        [&absent, &terminal, &orphan, &done]
+            .into_iter()
+            .map(String::as_str)
+            .collect()
+    );
+    assert!(
+        diagnosed
+            .iter()
+            .all(|candidate| !candidate.reason.is_empty()),
+        "every stale class names its reason: {diagnosed:?}"
+    );
+
+    assert_eq!(
+        runtime.release_stale_task_reservations().expect("repair"),
+        4
+    );
+    assert_eq!(
+        runtime
+            .release_stale_task_reservations()
+            .expect("idempotent repair"),
+        0
+    );
+
+    let active = runtime
+        .stores()
+        .task_reservations()
+        .list_active_task_reservations(
+            &workspace_orbit_dir(&runtime),
+            workspace_task_reservation_id(&runtime)
+                .expect("workspace reservation id")
+                .as_deref(),
+        )
+        .expect("list survivors");
+    let survivor_ids = active
+        .reservations
+        .iter()
+        .map(|reservation| reservation.reservation_id.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        survivor_ids,
+        [&fresh, &live, &ambiguous]
+            .into_iter()
+            .map(String::as_str)
+            .collect()
+    );
+
+    let payloads = release_audit_payloads(&runtime);
+    for released_id in [&absent, &terminal, &orphan, &done] {
+        assert!(payloads.iter().any(|payload| {
+            payload["reservation_id"] == released_id.as_str()
+                && payload["release_reason"] == "doctor_stale_task_lock"
+        }));
+    }
 }
 
 #[test]

--- a/crates/orbit-store/src/backend/contracts/params.rs
+++ b/crates/orbit-store/src/backend/contracts/params.rs
@@ -199,6 +199,7 @@ pub enum TaskReservationReleaseReason {
     Explicit,
     RunTerminal,
     StaleRunReconciled,
+    DoctorStaleTaskLock,
     TtlExpired,
 }
 
@@ -208,6 +209,7 @@ impl TaskReservationReleaseReason {
             Self::Explicit => "explicit",
             Self::RunTerminal => "run_terminal",
             Self::StaleRunReconciled => "stale_run_reconciled",
+            Self::DoctorStaleTaskLock => "doctor_stale_task_lock",
             Self::TtlExpired => "ttl_expired",
         }
     }

--- a/crates/orbit-store/src/backend/contracts/traits.rs
+++ b/crates/orbit-store/src/backend/contracts/traits.rs
@@ -168,6 +168,13 @@ pub trait TaskArtifactStoreBackend: Send + Sync {
 }
 
 pub trait TaskReservationStoreBackend: Send + Sync {
+    /// Read active reservations without expiring or otherwise mutating rows.
+    fn inspect_active_task_reservations(
+        &self,
+        workspace_orbit_dir: &str,
+        workspace_id: Option<&str>,
+    ) -> Result<Vec<ActiveTaskReservation>, OrbitError>;
+
     fn list_active_task_reservations(
         &self,
         workspace_orbit_dir: &str,

--- a/crates/orbit-store/src/backend/sqlite_backends.rs
+++ b/crates/orbit-store/src/backend/sqlite_backends.rs
@@ -9,9 +9,9 @@ use super::contracts::{
     TaskReservationReleaseResult, TaskReservationReserveParams, TaskReservationReserveResult,
     TaskReservationStoreBackend, ToolStoreBackend,
 };
-use crate::Store;
 use crate::scope::{ScopeStrategy, ScopedStore, resolve};
 use crate::sqlite::audit_event_store::{AuditEventFilter, AuditEventInsertParams};
+use crate::{ActiveTaskReservation, Store};
 
 #[derive(Clone)]
 pub(crate) struct SqliteToolStoreBackend {
@@ -173,6 +173,15 @@ pub(crate) struct SqliteTaskReservationStoreBackend {
 }
 
 impl TaskReservationStoreBackend for SqliteTaskReservationStoreBackend {
+    fn inspect_active_task_reservations(
+        &self,
+        workspace_orbit_dir: &str,
+        workspace_id: Option<&str>,
+    ) -> Result<Vec<ActiveTaskReservation>, OrbitError> {
+        self.store
+            .inspect_active_task_reservations(workspace_orbit_dir, workspace_id)
+    }
+
     fn list_active_task_reservations(
         &self,
         workspace_orbit_dir: &str,

--- a/crates/orbit-store/src/sqlite/task_reservation_store/mod.rs
+++ b/crates/orbit-store/src/sqlite/task_reservation_store/mod.rs
@@ -16,6 +16,47 @@ use crate::{
 };
 
 impl Store {
+    /// Inspect active reservations through a pooled read connection. Unlike
+    /// the operational list/check paths, this does not opportunistically mark
+    /// expired rows released, which keeps `orbit doctor` strictly read-only.
+    pub fn inspect_active_task_reservations(
+        &self,
+        workspace_orbit_dir: &str,
+        workspace_id: Option<&str>,
+    ) -> Result<Vec<ActiveTaskReservation>, OrbitError> {
+        self.with_read_connection(|conn| {
+            let now = crate::now_string();
+            let sql = format!(
+                "SELECT {}
+                 FROM task_reservations
+                 WHERE {}
+                   AND released_at IS NULL
+                   AND expires_at > ?3
+                 ORDER BY created_at ASC, reservation_id ASC",
+                select_reservation_columns(),
+                reservation_scope_clause(),
+            );
+            let mut stmt = conn
+                .prepare(&sql)
+                .map_err(|error| OrbitError::Store(error.to_string()))?;
+            let rows = stmt
+                .query_map(
+                    params![workspace_id, workspace_orbit_dir, now],
+                    reservation_row,
+                )
+                .map_err(|error| OrbitError::Store(error.to_string()))?;
+
+            let mut reservations = Vec::new();
+            for row in rows {
+                reservations.push(
+                    row.map_err(|error| OrbitError::Store(error.to_string()))?
+                        .into_active()?,
+                );
+            }
+            Ok(reservations)
+        })
+    }
+
     pub fn list_active_task_reservations(
         &self,
         workspace_orbit_dir: &str,

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -4,7 +4,7 @@ summary: Check Orbit workspace, database, dashboard, log-sink, job-run, and rout
 tags: [operations, health, doctor, dashboard, routines]
 paths: ["crates/orbit-cmd/src/doctor.rs", "crates/orbit-core/src/command/job/run/reconcile.rs"]
 related_features: [orbit-core, activity-job, routines]
-related_artifacts: [ORB-10005, ORB-10070, ORB-10473, ORB-10501, ADR-0291, ADR-0296]
+related_artifacts: [ORB-10005, ORB-10070, ORB-10473, ORB-10501, ORB-10558, ADR-0291, ADR-0296]
 ---
 
 # Check Orbit Health
@@ -14,7 +14,7 @@ database recovery, or upgrade.
 
 ## Run `orbit doctor`
 
-`orbit doctor` performs eight checks in order. Every check degrades to a row rather than
+`orbit doctor` performs nine checks in order. Every check degrades to a row rather than
 aborting unless the store itself cannot open.
 
 | Check | What it verifies |
@@ -25,6 +25,7 @@ aborting unless the store itself cannot open.
 | `semantic-index` | stale embedding rows; skipped if never indexed |
 | `stale-locks` | `.lock` files under `state/`, `tasks/`, `learnings/`, and `adrs/.locks/` whose recorded holder PID is dead |
 | `job-runs` | orphaned `pending` or `running` runs whose owner process is gone |
+| `task-reservations` | active reservations whose owner run or terminal task association proves the reservation stale |
 | `task-relations` | unresolved relation/dependency targets that would block a task-index rebuild |
 | `id-allocations` | learning/ADR ids pinned to a worktree that no longer exists, with no readable body |
 
@@ -41,15 +42,46 @@ $ orbit doctor
 │                            the flock; safe to delete): …/state/layout.lock                  │
 │                            (dead pid 154488, op: layout upgrade, since 2026-07-04T09:25…)   │
 │ job-runs         ok        no orphaned job runs                                              │
+│ task-reservations ok       no conclusively stale active task reservations                    │
 │ task-relations   ok        no unresolved relation/dependency targets                        │
 │ id-allocations   ok        no learning/ADR allocations pinned to a missing worktree         │
 0 failure(s), 1 warning(s).
 ```
 
 The command exits nonzero only when at least one check is `ERROR`; warnings and skips exit
-zero. `--json` emits an array of objects with `check`, `status`, and `message` fields; statuses
-are lowercase. Lock files flagged by `stale-locks` include holder diagnostics and are safe to
-delete only after confirming the holder PID is dead.
+zero. `--json` emits an array of objects with `check`, `status`, `message`, and `remediation`
+fields; statuses are lowercase and `remediation` is `null` for healthy/skipped rows. Human
+output prints the same guidance as an `Action:` line. Lock files flagged by `stale-locks`
+include holder diagnostics and are safe to delete only after confirming the holder PID is dead.
+
+### Repair stale task reservations
+
+The `task-reservations` check is read-only and intentionally narrower than task-lock listing.
+It warns only when Orbit can prove one of these conditions:
+
+- the recorded owner run no longer exists;
+- the recorded owner run is terminal;
+- the existing run-owner classifier proves a pending/running owner orphaned; or
+- an unowned reservation has one or more associated tasks and every one is `done`, Orbit's
+  terminal task status.
+
+Fresh reservations, reservations owned by live or inconclusively probed runs, and unowned
+reservations with empty, missing, mixed, or non-terminal task associations remain untouched.
+Each warning names the `reservation-…` id, its task/run context, the stale reason, and the exact
+repair command:
+
+```sh
+orbit doctor --fix-stale-task-locks
+```
+
+The repair re-reads and reclassifies each candidate immediately before releasing it, uses the
+normal task-lock release audit path with the `doctor_stale_task_lock` reason, and is idempotent.
+This is distinct from `--fix-stale-locks`, which handles dead-holder filesystem `.lock` files.
+
+There is deliberately no blanket `--fix` or resolve-all option. Configuration repair, database
+recovery, job cancellation, graph cleanup, id-allocation retirement, filesystem lock deletion,
+and task-reservation release have different evidence and safety gates, so each repair remains
+explicit and safety-scoped.
 
 An `id-allocations` warning means an id was allocated inside a worktree that has since been
 reaped, before its body was merged: the body is unrecoverable and the row would otherwise stay


### PR DESCRIPTION
## Task

[ORB-10558](https://orbit-cli.com/tasks/ORB-10558) — Diagnose and safely repair stale task reservations with orbit doctor

### Description

## Problem
`orbit doctor` distinguishes stale filesystem lock files but does not inspect transient task-lock reservations. Operators who encounter a wedged task must discover an internal `reservation-…` id through debug tooling, and doctor rows do not consistently expose a structured, exact remediation command.

## Why It Matters
Task IDs and reservation IDs are easy to confuse. A bare `{ "released": false }` leaves the operator without a safe next step, while a blanket repair-all command would collapse deliberately different safety gates for config, graph cleanup, id allocation retirement, job cancellation, and lock release.

## Decision
Keep ordinary `orbit doctor` read-only. Add a distinct `task-reservations` check and an explicit `--fix-stale-task-locks` bulk repair flag. The repair must release only reservations Orbit can conclusively prove stale and must re-verify immediately before mutation. Do not add a global `--fix`/`resolve-all` switch. Extend doctor results with structured remediation guidance so warning/error rows name the exact command or manual next step; healthy/skipped rows need no remediation.

## Constraints / Notes
- Preserve the existing plural `task locks` command namespace for compatibility; do not add another namespace spelling.
- Do not conflate dead-holder `.lock` files (`--fix-stale-locks`) with task reservations (`--fix-stale-task-locks`).
- Fresh reservations, live-owner reservations, and ambiguous unowned reservations must never be released.
- Repair must preserve task-lock audit history and be idempotent.
- Update the health-check runbook and machine-readable JSON contract.

### Acceptance Criteria

- `orbit doctor` emits a read-only `task-reservations` row that is `ok` when no conclusively stale active reservations exist and `warning` when they do; the warning names each `reservation-…` id, associated task/run context, the reason it is stale, and the exact `orbit doctor --fix-stale-task-locks` remediation.
- `orbit doctor --fix-stale-task-locks` rechecks candidates at the write boundary, releases only reservations whose owner run is absent/terminal/conclusively orphaned or whose task association is otherwise provably inactive under a documented rule, records the normal task-lock release audit metadata, and is idempotent.
- Deterministic tests prove that fresh reservations, live-owner reservations, and ambiguous unowned reservations remain untouched, while each supported stale class is diagnosed and safely released.
- Every actionable warning/error `WorkspaceDoctorResult` provides structured remediation guidance; `orbit doctor --json` includes it as a separate field and human output makes the action visible without requiring operators to infer an argument from prose.
- No blanket `--fix` or resolve-all command is added; documentation explains why repairs remain explicit and safety-scoped.
- `cargo test -p orbit-cmd`, the relevant `orbit-cli` doctor tests, `cargo fmt --check`, and `cargo clippy` for touched crates pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a strictly read-only task-reservation doctor classifier and a new task-reservations row. It diagnoses absent, terminal, and conclusively orphaned owner runs plus unowned reservations associated only with terminal done tasks, while preserving fresh, live-owner, and ambiguous unowned reservations.
- Added --fix-stale-task-locks with per-candidate write-boundary reclassification, idempotent release, dedicated doctor_stale_task_lock metadata, and the normal task-lock release audit event.
- Added structured remediation to every warning/error doctor result, a separate remediation field in JSON, visible Action lines in human output, and explicit CLI parsing without a blanket --fix surface.
- Added deterministic core, command, and CLI coverage and updated the health-check runbook with safety rules and explicit-repair rationale.
Assessment: The implementation is conservative and race-aware; ordinary doctor uses a pooled SELECT-only store path, and repair mutates only candidates that remain conclusively stale on immediate reinspection.
Deviations from original plan: Expanded context_files to the orbit-store reservation contract/backend, runtime module re-export, and CLI sibling-test directory because strict read-only diagnosis required a non-expiring query path and the new public diagnostic/test surfaces required their coupled registration files.
Validation: cargo test -p orbit-core task_reservation_cleanup; cargo test -p orbit-cmd; cargo test -p orbit-cli doctor; cargo clippy -p orbit-store -p orbit-core -p orbit-cmd -p orbit-cli --all-targets -- -D warnings; cargo clippy -p orbit-cmd --all-targets -- -D warnings; make ci-fast; git diff --check. All passed.
Friction: Filed F2026-08-014 for two transient read-only-filesystem failures from the required task.show checkpoint that later resolved without changes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10558-6a6e9589`
- Behind base: 0
- Ahead of base: 1