### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/auditability/specs/coverage-matrix.md
+++ b/docs/design/auditability/specs/coverage-matrix.md
@@ -1,3 +1,9 @@
+---
+type: design
+summary: Spec: Audit Coverage Matrix
+last_validated: 2026-08-02
+---
+
 # Spec: Audit Coverage Matrix
 
 Every Orbit operation that touches code, task state, persistent runtime state, external services, or provider/tool execution must have an audit channel. This matrix defines the expected channel by operation class.

--- a/docs/design/auditability/specs/event-schema.md
+++ b/docs/design/auditability/specs/event-schema.md
@@ -1,3 +1,9 @@
+---
+type: design
+summary: Spec: Audit Event Schema
+last_validated: 2026-08-02
+---
+
 # Spec: Audit Event Schema
 
 Audit events in Orbit are split by operational level, but every channel must preserve enough stable identity, timing, status, and join keys for incident reconstruction.

--- a/docs/design/auditability/specs/redaction-retention.md
+++ b/docs/design/auditability/specs/redaction-retention.md
@@ -1,3 +1,9 @@
+---
+type: design
+summary: Spec: Redaction and Retention Boundaries
+last_validated: 2026-08-02
+---
+
 # Spec: Redaction and Retention Boundaries
 
 Audit storage must preserve enough detail to reconstruct agent behavior while redacting known secret shapes before durable persistence.

--- a/docs/design/host-registry/references/glossary.md
+++ b/docs/design/host-registry/references/glossary.md
@@ -1,3 +1,9 @@
+---
+type: design
+summary: Glossary — Host Registry
+last_validated: 2026-08-02
+---
+
 # Glossary — Host Registry
 
 Vocabulary specific to the host-registry feature. Excludes standard industry terms

--- a/docs/design/mcp-bridge/1_overview.md
+++ b/docs/design/mcp-bridge/1_overview.md
@@ -2,6 +2,7 @@
 title: Orbit MCP Bridge — Overview
 owner: codex
 last_updated: 2026-07-18
+last_validated: 2026-08-02
 status: Accepted
 feature: mcp-bridge
 doc_role: overview


### PR DESCRIPTION
## Task

[ORB-10561](https://orbit-cli.com/tasks/ORB-10561) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Batch selection was stable path order among in-scope docs without a last_validated key, then the oldest dated docs: docs/POSITIONING.md; docs/design/auditability/specs/coverage-matrix.md; docs/design/auditability/specs/event-schema.md; docs/design/auditability/specs/redaction-retention.md; docs/design/host-registry/references/glossary.md; and docs/design/mcp-bridge/1_overview.md.
- docs/design/auditability/specs/coverage-matrix.md was verified against AuditEvent, AuditGuard, V2AuditEvent/V2AuditEventKind, LoopAuditEvent, audit export/prune implementations, and operation-registry tests via rg and source reads; inferred design frontmatter and last_validated: 2026-08-02 were added.
- docs/design/auditability/specs/event-schema.md was verified against the command, v2 envelope, loop-event, and invocation-trace types in crates/orbit-common/src/types/activity_job/audit_envelope.rs, crates/orbit-common/src/types/audit_event.rs, crates/orbit-agent/src/loop_engine/audit/mod.rs, and runtime audit code; inferred design frontmatter and last_validated were added.
- docs/design/auditability/specs/redaction-retention.md was verified against BlobStore write-time redaction, PatternRedactor, redact_all, RedactingFields, artifact-redaction, AuditGuard error scrubbing, and redaction tests; inferred design frontmatter and last_validated were added.
- docs/design/host-registry/references/glossary.md was verified against host_identity.rs, HostRecord, host list/command registration, and Remote MCP discovery sources; its existing Orbit Docs inference contract classifies docs/design/<feature>/... as design, so schema-compatible design frontmatter and last_validated were added.
- docs/design/mcp-bridge/1_overview.md was verified against orbit-remote's broker/hub/link/learning composition, placement routing, runtime factory, manifest dependencies, and dependency-boundary test; only last_validated was added.
- docs/POSITIONING.md was selected but left unchanged: its context classification and heading summary are inferable, but its product positioning, audience, commercial, and strategic claims are not verifiable against repository code.
- No prose, claims, ADRs, changelogs, generated state, or formatting were changed. The selected frontmatter migrations derive type/summary from the existing tolerant docs inference rules; no sidecar or new validation system was introduced.
Assessment: Five selected docs were verified and stamped; the unverifiable positioning document was correctly left unstamped. git diff --check, scripts/generate-doc-indexes.sh --check, and make ci-fast passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10561-6a6e9ffe`
- Behind base: 0
- Ahead of base: 1