### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/mcp-bridge/2_design.md
+++ b/docs/design/mcp-bridge/2_design.md
@@ -2,6 +2,7 @@
 title: Orbit MCP Bridge — Design
 owner: codex
 last_updated: 2026-08-01
+last_validated: 2026-08-02
 status: Accepted
 feature: mcp-bridge
 doc_role: design

--- a/docs/design/mcp-bridge/3_vision.md
+++ b/docs/design/mcp-bridge/3_vision.md
@@ -2,6 +2,7 @@
 title: Orbit MCP Bridge — Vision
 owner: codex
 last_updated: 2026-07-18
+last_validated: 2026-08-02
 status: Accepted
 feature: mcp-bridge
 doc_role: vision

--- a/docs/design/mcp-bridge/4_decisions.md
+++ b/docs/design/mcp-bridge/4_decisions.md
@@ -2,6 +2,7 @@
 title: Orbit MCP Bridge — Decisions
 owner: codex
 last_updated: 2026-07-20
+last_validated: 2026-08-02
 status: Accepted
 feature: mcp-bridge
 doc_role: decisions

--- a/docs/design/mcp-bridge/references/glossary.md
+++ b/docs/design/mcp-bridge/references/glossary.md
@@ -1,3 +1,9 @@
+---
+type: glossary
+summary: "Glossary — Orbit MCP Bridge"
+last_validated: 2026-08-02
+---
+
 # Glossary — Orbit MCP Bridge
 
 Vocabulary specific to the singular-hub, placement-aware Orbit MCP feature.

--- a/docs/design/mcp-session-context/1_overview.md
+++ b/docs/design/mcp-session-context/1_overview.md
@@ -4,11 +4,12 @@ type: design
 title: "MCP Session Context — Overview"
 owner: codex
 last_updated: 2026-07-18
+last_validated: 2026-08-02
 status: Accepted
 feature: mcp-session-context
 doc_role: overview
 tags: ["mcp-session-context", "mcp", "workspace"]
-paths: ["crates/orbit-mcp/**", "crates/orbit-remote/src/mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool.rs"]
+paths: ["crates/orbit-mcp/**", "crates/orbit-remote/src/mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool/**"]
 related_features: ["mcp-session-context", "task-artifacts"]
 related_artifacts: ["ORB-00256", "ORB-10228", "ORB-10319", "ADR-0181", "ADR-0149"]
 ---
@@ -46,7 +47,7 @@ Before [ORB-00256], every MCP call to `orbit.task.add` had to pass `workspace`. 
 | MCP initialization parsing | `crates/orbit-mcp/src/adapter/dispatch.rs` | [ORB-00256] |
 | Session metadata DTO | `crates/orbit-common/src/types/tool.rs` | [ORB-00256] |
 | Trusted provenance, capabilities, and per-call correlation | common DTOs, generic MCP session framing, Remote host policy, Core runtime, audit store | [ORB-10228], [ORB-10319] |
-| Runtime dispatch thread-through | `crates/orbit-core/src/command/tool.rs` | [ORB-00256] |
+| Runtime dispatch thread-through | `crates/orbit-core/src/command/tool/` | [ORB-00256] |
 | MCP host and server composition | `crates/orbit-remote/src/mcp/mod.rs` | [ORB-10319] |
 | Route selection, exact-checkout resolution, and placement preflight | `crates/orbit-remote/src/mcp/host.rs` | [ORB-10262], [ORB-10319] |
 | Builtin explicit/session workspace-argument fallback | `crates/orbit-tools/src/builtin/orbit/mod.rs` | [ORB-00256] |


### PR DESCRIPTION
## Task

[ORB-10564](https://orbit-cli.com/tasks/ORB-10564) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Batch selection: the six oldest in-scope documents were the five never-validated docs first by stable path — docs/POSITIONING.md, docs/design/mcp-bridge/2_design.md, docs/design/mcp-bridge/3_vision.md, docs/design/mcp-bridge/4_decisions.md, docs/design/mcp-bridge/references/glossary.md, and docs/design/mcp-session-context/1_overview.md — before any dated documents.
- Stamped docs/design/mcp-bridge/2_design.md, 3_vision.md, and 4_decisions.md with last_validated: 2026-08-02. Verified the documented crate boundaries, MCP placement/capability/session symbols, hub/config/registration/knowledge paths, and related source references with test -e and rg checks; all referenced relative Markdown links resolved.
- Migrated docs/design/mcp-bridge/references/glossary.md using Orbit Docs' existing inference contract: type=glossary and summary="Glossary — Orbit MCP Bridge" derived from its path and first heading, then added last_validated: 2026-08-02. Verified each glossary term against the MCP Bridge design sections and current McpToolPlacement, BrokerMcpHost, HubMcpHost, RemoteStore, knowledge-broker, and search source symbols.
- Stamped docs/design/mcp-session-context/1_overview.md with last_validated: 2026-08-02. Corrected the stale command/tool.rs reference to the current command/tool/ module directory in both paths metadata and the source map; verified dispatch, session-context, host, and builtin symbols with rg and filesystem checks.
- Left docs/POSITIONING.md unchanged and unstamped: its product-positioning and strategic claims are not reliably verifiable against repository code, so no metadata was migrated.
- No forbidden ADR, changelog, archive, or generated-state files changed. Markdown relative-link and fence checks passed; git diff --check passed. make ci-fast passed.

Assessment: Bounded documentation validation completed with only one directly evidenced stale path correction and schema-compatible metadata migration; no prose reflow or new sections were added.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10564-6a6ea43b`
- Behind base: 0
- Ahead of base: 1