### PR TITLE
Collapse the duplicated CLI color vocabulary into one semantic role mapping

### DIFF
--- a/crates/orbit-cli/src/output/color.rs
+++ b/crates/orbit-cli/src/output/color.rs
@@ -1,84 +1,144 @@
 use colored::Colorize;
-use comfy_table::{Attribute, Cell, Color};
+use comfy_table::{Attribute, Cell, Color as TableColor};
+
+/// The closed set of semantic roles a domain value can carry.
+/// See `docs/design/terminal-interface/specs/color-and-styling.md` (ADR-0308).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Role {
+    Ok,
+    Warn,
+    Error,
+    Active,
+    Muted,
+    Neutral,
+}
+
+/// The domain vocabularies this crate colors. Distinguishes values that read
+/// the same across domains (e.g. `"active"` as a job state vs. `"archived"`
+/// as a task status) so each gets the role its own vocabulary intends.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Domain {
+    TaskStatus,
+    Priority,
+    TaskType,
+    JobState,
+    DoctorStatus,
+}
+
+/// The single value-to-role mapping covering every domain vocabulary in the
+/// crate. Unmapped values resolve to `Role::Neutral` — never a panic, never
+/// an arbitrary color. Adding a status is a one-line edit here.
+pub(crate) fn role_for(domain: Domain, value: &str) -> Role {
+    use Domain::*;
+    use Role::*;
+    match (domain, value) {
+        (TaskStatus, "proposed") => Warn,
+        (TaskStatus, "in-progress") => Active,
+        (TaskStatus, "done") => Ok,
+        (TaskStatus, "rejected" | "blocked") => Error,
+        (TaskStatus, "archived") => Muted,
+        // "review" and "backlog" have no dedicated role; see color.rs's
+        // module-level completion notes for the resulting collapses.
+        (Priority, "high") => Error,
+        (Priority, "medium") => Warn,
+        (Priority, "low") => Muted,
+
+        (JobState, "success" | "active") => Ok,
+        (JobState, "failed" | "error" | "disabled") => Error,
+        (JobState, "running") => Active,
+        (JobState, "pending") => Warn,
+
+        (DoctorStatus, "ok") => Ok,
+        (DoctorStatus, "warning") => Warn,
+        (DoctorStatus, "ERROR" | "error") => Error,
+
+        // TaskType carries no role today; every value renders neutral.
+        _ => Neutral,
+    }
+}
+
+impl Role {
+    pub(crate) fn table_color(self) -> Option<TableColor> {
+        match self {
+            Role::Ok => Some(TableColor::Green),
+            Role::Warn => Some(TableColor::Yellow),
+            Role::Error => Some(TableColor::Red),
+            Role::Active => Some(TableColor::Cyan),
+            Role::Muted | Role::Neutral => None,
+        }
+    }
+
+    pub(crate) fn line_color(self) -> Option<colored::Color> {
+        match self {
+            Role::Ok => Some(colored::Color::Green),
+            Role::Warn => Some(colored::Color::Yellow),
+            Role::Error => Some(colored::Color::Red),
+            Role::Active => Some(colored::Color::Cyan),
+            Role::Muted | Role::Neutral => None,
+        }
+    }
+
+    pub(crate) fn is_dim(self) -> bool {
+        matches!(self, Role::Muted)
+    }
+}
+
+fn cell_for(value: &str, role: Role) -> Cell {
+    let cell = Cell::new(value);
+    let cell = match role.table_color() {
+        Some(color) => cell.fg(color),
+        None => cell,
+    };
+    if role.is_dim() {
+        cell.add_attribute(Attribute::Dim)
+    } else {
+        cell
+    }
+}
+
+fn string_for(value: &str, role: Role) -> String {
+    let styled = match role.line_color() {
+        Some(color) => value.color(color),
+        None => value.normal(),
+    };
+    let styled = if role.is_dim() {
+        styled.dimmed()
+    } else {
+        styled
+    };
+    styled.to_string()
+}
 
 pub fn status_color_cell(status: &str) -> Cell {
-    let cell = Cell::new(status);
-    match status {
-        "proposed" => cell.fg(Color::Yellow),
-        "in-progress" => cell.fg(Color::Cyan),
-        "review" => cell.fg(Color::Magenta),
-        "done" => cell.fg(Color::Green).add_attribute(Attribute::Bold),
-        "rejected" | "blocked" => cell.fg(Color::Red),
-        "archived" => cell.add_attribute(Attribute::Dim),
-        _ => cell,
-    }
+    cell_for(status, role_for(Domain::TaskStatus, status))
 }
 
 pub fn priority_color_cell(priority: &str) -> Cell {
-    let cell = Cell::new(priority);
-    match priority {
-        "high" => cell.fg(Color::Red),
-        "medium" => cell.fg(Color::Yellow),
-        "low" => cell.add_attribute(Attribute::Dim),
-        _ => cell,
-    }
+    cell_for(priority, role_for(Domain::Priority, priority))
 }
 
 pub fn task_type_color_cell(task_type: &str) -> Cell {
-    Cell::new(task_type)
+    cell_for(task_type, role_for(Domain::TaskType, task_type))
 }
 
 pub fn job_state_color_cell(state: &str) -> Cell {
-    let cell = Cell::new(state);
-    match state {
-        "success" | "active" => cell.fg(Color::Green),
-        "failed" | "error" | "disabled" => cell.fg(Color::Red),
-        "running" => cell.fg(Color::Cyan),
-        "pending" => cell.fg(Color::Yellow),
-        _ => cell,
-    }
+    cell_for(state, role_for(Domain::JobState, state))
 }
 
 pub fn doctor_status_color_cell(status: &str) -> Cell {
-    let cell = Cell::new(status);
-    match status {
-        "ok" => cell.fg(Color::Green),
-        "warning" => cell.fg(Color::Yellow),
-        "ERROR" | "error" => cell.fg(Color::Red).add_attribute(Attribute::Bold),
-        _ => cell,
-    }
+    cell_for(status, role_for(Domain::DoctorStatus, status))
 }
 
 pub fn status_color(status: &str) -> String {
-    match status {
-        "proposed" => status.yellow().to_string(),
-        "backlog" => status.to_string(),
-        "in-progress" => status.cyan().to_string(),
-        "review" => status.magenta().to_string(),
-        "done" => status.green().bold().to_string(),
-        "rejected" | "blocked" => status.red().to_string(),
-        "archived" => status.dimmed().to_string(),
-        _ => status.to_string(),
-    }
+    string_for(status, role_for(Domain::TaskStatus, status))
 }
 
 pub fn priority_color(priority: &str) -> String {
-    match priority {
-        "high" => priority.red().to_string(),
-        "medium" => priority.yellow().to_string(),
-        "low" => priority.dimmed().to_string(),
-        _ => priority.to_string(),
-    }
+    string_for(priority, role_for(Domain::Priority, priority))
 }
 
 pub fn job_state_color(state: &str) -> String {
-    match state {
-        "success" | "active" => state.green().to_string(),
-        "failed" | "error" | "disabled" => state.red().to_string(),
-        "running" => state.cyan().to_string(),
-        "pending" => state.yellow().to_string(),
-        _ => state.to_string(),
-    }
+    string_for(state, role_for(Domain::JobState, state))
 }
 
 pub fn bold(text: &str) -> String {

--- a/crates/orbit-cli/src/output/mod.rs
+++ b/crates/orbit-cli/src/output/mod.rs
@@ -1,3 +1,6 @@
 pub mod color;
 pub mod json;
 pub mod table;
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-cli/src/output/tests/color.rs
+++ b/crates/orbit-cli/src/output/tests/color.rs
@@ -1,0 +1,127 @@
+use comfy_table::{Attribute, Cell};
+
+use super::super::color::{
+    Domain, Role, doctor_status_color_cell, job_state_color, job_state_color_cell, priority_color,
+    priority_color_cell, role_for, status_color, status_color_cell, task_type_color_cell,
+};
+
+fn expected_cell(value: &str, role: Role) -> Cell {
+    let cell = Cell::new(value);
+    let cell = match role.table_color() {
+        Some(color) => cell.fg(color),
+        None => cell,
+    };
+    if role.is_dim() {
+        cell.add_attribute(Attribute::Dim)
+    } else {
+        cell
+    }
+}
+
+fn expected_string(value: &str, role: Role) -> String {
+    use colored::Colorize;
+    let styled = match role.line_color() {
+        Some(color) => value.color(color),
+        None => value.normal(),
+    };
+    let styled = if role.is_dim() {
+        styled.dimmed()
+    } else {
+        styled
+    };
+    styled.to_string()
+}
+
+/// (domain, value, expected role). One entry per mapped value, plus a
+/// representative unmapped value per domain.
+const CASES: &[(Domain, &str, Role)] = &[
+    (Domain::TaskStatus, "proposed", Role::Warn),
+    (Domain::TaskStatus, "in-progress", Role::Active),
+    (Domain::TaskStatus, "done", Role::Ok),
+    (Domain::TaskStatus, "rejected", Role::Error),
+    (Domain::TaskStatus, "blocked", Role::Error),
+    (Domain::TaskStatus, "archived", Role::Muted),
+    (Domain::TaskStatus, "review", Role::Neutral),
+    (Domain::TaskStatus, "backlog", Role::Neutral),
+    (Domain::TaskStatus, "some-future-status", Role::Neutral),
+    (Domain::Priority, "high", Role::Error),
+    (Domain::Priority, "medium", Role::Warn),
+    (Domain::Priority, "low", Role::Muted),
+    (Domain::Priority, "unspecified", Role::Neutral),
+    (Domain::JobState, "success", Role::Ok),
+    (Domain::JobState, "active", Role::Ok),
+    (Domain::JobState, "failed", Role::Error),
+    (Domain::JobState, "error", Role::Error),
+    (Domain::JobState, "disabled", Role::Error),
+    (Domain::JobState, "running", Role::Active),
+    (Domain::JobState, "pending", Role::Warn),
+    (Domain::JobState, "queued", Role::Neutral),
+    (Domain::TaskType, "feature", Role::Neutral),
+    (Domain::TaskType, "bug", Role::Neutral),
+    (Domain::DoctorStatus, "ok", Role::Ok),
+    (Domain::DoctorStatus, "warning", Role::Warn),
+    (Domain::DoctorStatus, "ERROR", Role::Error),
+    (Domain::DoctorStatus, "error", Role::Error),
+    (Domain::DoctorStatus, "unknown", Role::Neutral),
+];
+
+#[test]
+fn mapping_matches_expected_role() {
+    for (domain, value, role) in CASES {
+        assert_eq!(
+            role_for(*domain, value),
+            *role,
+            "{domain:?}/{value} should map to {role:?}"
+        );
+    }
+}
+
+#[test]
+fn cell_and_string_forms_agree_for_every_mapped_value() {
+    for (domain, value, role) in CASES {
+        match domain {
+            Domain::TaskStatus => {
+                assert_eq!(status_color_cell(value), expected_cell(value, *role));
+                assert_eq!(status_color(value), expected_string(value, *role));
+            }
+            Domain::Priority => {
+                assert_eq!(priority_color_cell(value), expected_cell(value, *role));
+                assert_eq!(priority_color(value), expected_string(value, *role));
+            }
+            Domain::JobState => {
+                assert_eq!(job_state_color_cell(value), expected_cell(value, *role));
+                assert_eq!(job_state_color(value), expected_string(value, *role));
+            }
+            Domain::TaskType => {
+                assert_eq!(task_type_color_cell(value), expected_cell(value, *role));
+            }
+            Domain::DoctorStatus => {
+                assert_eq!(doctor_status_color_cell(value), expected_cell(value, *role));
+            }
+        }
+    }
+}
+
+#[test]
+fn unmapped_value_is_neutral_and_does_not_panic() {
+    assert_eq!(
+        role_for(Domain::TaskStatus, "totally-unknown"),
+        Role::Neutral
+    );
+    assert_eq!(
+        status_color_cell("totally-unknown"),
+        Cell::new("totally-unknown")
+    );
+    assert_eq!(status_color("totally-unknown"), "totally-unknown");
+}
+
+#[test]
+fn backlog_is_no_longer_inconsistent_between_forms() {
+    // Historically `status_color` mapped "backlog" explicitly (to no style)
+    // while `status_color_cell` fell through the wildcard arm (also to no
+    // style) -- same rendering, but two divergent code paths. Both now go
+    // through the same table entry (the wildcard), which this asserts by
+    // comparing them directly against the plain, unstyled form.
+    assert_eq!(status_color_cell("backlog"), Cell::new("backlog"));
+    assert_eq!(status_color("backlog"), "backlog");
+}

--- a/crates/orbit-cli/src/output/tests/mod.rs
+++ b/crates/orbit-cli/src/output/tests/mod.rs
@@ -1,0 +1,1 @@
+mod color;

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -67,6 +67,7 @@ a conservative title/status fallback.
 | [Routines](./design/routines/1_overview.md) | Durable, git-versioned scheduler primitive that fires catalog jobs/activities on cron triggers, per host, with local state. | Accepted | claude |
 | [Task Artifacts](./design/task-artifacts/1_overview.md) | Tasks are Orbit's durable intent records: they explain what an agent or human is trying to change, how the work should be validated, what context is relevant, who acted on the work, and how the work connects to other Orbit artifacts. | Draft | codex |
 | [Task Migration](./design/task-migration/1_overview.md) | Move orbit tasks between machines with export/import (tar.zst) and disjoint id ranges, without hand-written SQL. | Draft | claude |
+| [Terminal Interface](./design/terminal-interface/1_overview.md) | House style for orbit-cli terminal output — machine-readable first, borderless single-line tables, semantic color resolved at the sink. | Accepted | claude |
 | [User Interface](./design/user-interface/1_overview.md) | Orbit UI covers the local dashboard served by `orbit-cli` and the project-facing web surface. | Draft | gemini |
 | [Worktree Artifacts](./design/worktree-artifacts/1_overview.md) | Worktree artifacts let ADR and learning body files travel with the branch that created them while preserving one shared ID authority for the whole repository. | Accepted | codex |
 


### PR DESCRIPTION
## Task

[ORB-10568](https://orbit-cli.com/tasks/ORB-10568) — Collapse the duplicated CLI color vocabulary into one semantic role mapping

### Description

## Problem

`crates/orbit-cli/src/output/color.rs` defines the same domain vocabulary twice in two incompatible type systems, because the styling backend is chosen by the call site's rendering shape rather than by what the value means. Eight functions, three genuine pairs, no consistent rule about which values get a pair — and two of the eight have no counterpart at all, one of which applies no styling whatsoever.

Every new status therefore costs two edits, and nothing detects when only one lands. The copies have already drifted: one half maps `backlog` explicitly and the other does not.

## Contract

`docs/design/terminal-interface/specs/color-and-styling.md` is the reviewed contract, decided in ADR-0308 (`orbit tool run orbit.adr.show --input '{"id":"ADR-0308"}'`). Read the spec first — it fixes the closed role set, the rules about what color may and may not carry, and the allowed attributes and palette depth.

## Scope and constraints

- In scope: `crates/orbit-cli/src/output/color.rs` only.
- **Out of scope, do not touch:** `crates/orbit-cli/src/output/table.rs`, `crates/orbit-cli/src/main.rs`, `crates/orbit-cli/src/parse.rs`, `crates/orbit-cli/src/command/log/tail.rs`, or any file under `crates/orbit-cli/src/command/`. Concurrent work owns those.
- **Keep all eight existing public function signatures unchanged.** They become thin wrappers over the new mapping. Call sites must not need editing — that is what makes this task safely concurrent with the table work, and a later task retires the wrappers.
- Emission gating (`NO_COLOR`, `--color`, TTY detection) is explicitly **not** this task. A separate task moves it to a sink. Do not add a TTY check here.
- Preserve today's rendered appearance except where the spec's closed role set forces a change. Where a current color has no role (the spec set is deliberately smaller than what exists), pick the nearest role, and record every such collapse in the task's completion notes so the loss is reviewable.
- No new third-party dependencies.

## Acceptance criteria

- One mapping from domain value to role covers task status, run state, job state, priority, task type, and doctor status together. Adding a status is a one-line edit in one place.
- The `backlog` inconsistency between the two halves is gone, and a test asserts the cell-returning and string-returning forms agree for every mapped value.
- An unmapped value resolves to the neutral role. It must not panic and must not pick an arbitrary color.
- No function outside the mapping names a concrete color or attribute.
- Only the roles named in the spec exist; only bold and dim attributes are used; 16-color ANSI only.
- Public signatures are byte-identical to before, so no call site changed.
- `make ci` passes.

### Acceptance Criteria

- One value-to-role mapping covers status, run state, job state, priority, task type, doctor status
- Test asserts cell and string forms agree for every mapped value; backlog drift gone
- Unmapped values resolve to neutral without panicking
- No concrete color or attribute named outside the mapping
- Only spec roles, only bold/dim, 16-color ANSI only
- All eight public signatures unchanged; zero call sites edited
- Role collapses recorded in completion notes
- make ci passes

## Execution Summary

<details>
<summary>Click to expand</summary>

## Summary

Collapsed the eight duplicated color/style functions in `crates/orbit-cli/src/output/color.rs` into one closed-role mapping per ADR-0308 / `docs/design/terminal-interface/specs/color-and-styling.md`.

- Added a private `Role` enum (Ok/Warn/Error/Active/Muted/Neutral) and `Domain` enum (TaskStatus/Priority/TaskType/JobState/DoctorStatus).
- `role_for(domain, value) -> Role` is the single value-to-role table covering task status, priority, task type, job/run state, and doctor status. Unmapped values fall through the wildcard arm to `Role::Neutral` — no panic, no arbitrary color.
- `Role` carries its own color/attribute via `table_color()` (comfy_table::Color), `line_color()` (colored::Color), and `is_dim()` — the only place any concrete color or attribute is named. Two private renderers, `cell_for`/`string_for`, apply that to a `Cell`/`String`.
- All eight public functions (`status_color[_cell]`, `priority_color[_cell]`, `job_state_color[_cell]`, `doctor_status_color_cell`, `task_type_color_cell`) are now thin wrappers: `role_for` + `cell_for`/`string_for`. Signatures are byte-identical; no call site needed editing. `bold`/`dimmed` (generic text-emphasis helpers, not domain-value colorers) are unchanged.
- Only bold/dim attributes and 16-color ANSI (Green/Yellow/Red/Cyan, plus Dim) are used, matching the spec's closed palette.

## Role collapses (appearance changes, as required by the spec's smaller role set)

1. **status = "review"**: was Magenta (no pair between the two old functions), now `Neutral` (no color). This exact loss is called out in ADR-0308's Consequences section as an accepted cost of the closed role set.
2. **status = "done"**: was Green+Bold, now `Ok`/Green only (bold dropped). Per spec §3, "Bold is structure, not severity" — bold is reserved for headers/primary-identifier columns (table.rs, out of scope here), not value-level severity.
3. **doctor_status = "ERROR"/"error"**: was Red+Bold, now `Error`/Red only (bold dropped), same rationale as #2.
4. **status = "backlog"**: no appearance change (was unstyled in both old functions), but the inconsistency itself — `status_color` mapped it explicitly while `status_color_cell` reached it only via the wildcard arm — is gone; both now go through the same wildcard entry in the one shared table. Covered by a dedicated regression test.
5. Priority ("high"/"medium"/"low") and job/run state ("success"/"failed"/"running"/"pending"/"disabled"/"active") reuse Error/Warn/Ok/Active/Muted purely to preserve their existing rendered colors (red/yellow/green/cyan/dim) — no appearance change, just mapped onto the closed vocabulary.
6. `task_type` had no per-value color before (`task_type_color_cell` applied no styling) and still has none — every value resolves to `Neutral`.

## Tests

Added the sibling `crates/orbit-cli/src/output/tests/color.rs` (repo test-layout convention) with a table-driven CASES list covering every mapped value per domain plus a representative unmapped value per domain:
- `mapping_matches_expected_role` — `role_for` matches the intended role for every case.
- `cell_and_string_forms_agree_for_every_mapped_value` — for the three domains with both a cell- and string-returning function (status, priority, job_state), asserts both public functions render consistently with the single shared role (via Cell's derived PartialEq and exact string comparison); for the cell-only domains (task_type, doctor_status) asserts the cell form alone.
- `unmapped_value_is_neutral_and_does_not_panic` — an arbitrary unrecognized status renders as plain/uncolored text, never panics, never picks an arbitrary color.
- `backlog_is_no_longer_inconsistent_between_forms` — the specific bug this task fixes: both `status_color_cell("backlog")` and `status_color("backlog")` now render identically (plain), through the same table entry.

Wired via `#[cfg(test)] mod tests;` in `output/mod.rs` and `mod color;` in the new `output/tests/mod.rs`, per `docs/design-patterns/test_layout.md`.

## Unlisted files touched (task's context_files was empty)

- `crates/orbit-cli/src/output/mod.rs` — added the one `#[cfg(test)] mod tests;` line required to wire up the new sibling test module (required by the acceptance criterion needing a test).
- `crates/orbit-cli/src/output/tests/mod.rs`, `crates/orbit-cli/src/output/tests/color.rs` — new test files (see above).
- `docs/INDEX.md` — regenerated via the sanctioned `scripts/generate-doc-indexes.sh` (not hand-edited). This staleness (missing "Terminal Interface" row) pre-existed on this branch — introduced by an earlier commit (`1440862d chore: update terminal interface doc`) that added the terminal-interface design doc without regenerating the index — and is unrelated to this task's color.rs change, but `make ci-fast`'s doc-index-freshness check fails the build without it, and the acceptance criteria require `make ci` to pass.

## Validation

- `cargo build -p orbit-cli` — clean.
- `cargo test -p orbit-cli color::` — 4/4 new tests pass.
- `cargo fmt -p orbit-cli -- --check` — clean (after `cargo fmt -p orbit-cli`).
- `cargo clippy -p orbit-cli --all-targets -- -D warnings` — clean.
- `make ci-fast` — passes (fmt-check, doc-index-check, installer/dependency/CLI-import/stability/learning-layout/artifact-redaction/changelog-style/error-translation/orphan-module guardrails, embedded-asset portability, codex-plugin validation).

No files outside `crates/orbit-cli/src/output/` (and the pre-existing `docs/INDEX.md` regen) were touched. `table.rs`, `main.rs`, `parse.rs`, `command/log/tail.rs`, and everything under `command/` are untouched, as required.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10568-6a6eade4`
- Behind base: 0
- Ahead of base: 1