### PR TITLE
[BLOCKED] Introduce the output sink and a global --format, resolved once per invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ ci-fast:
 	./scripts/test-installer-security.sh
 	./scripts/check-dependency-direction.sh
 	./scripts/check-cli-imports.sh
+	./scripts/check-terminal-state-guard.sh
 	./scripts/check-stability.sh
 	./scripts/check-learning-layout.sh
 	./scripts/check-artifact-redaction-guardrail.sh

--- a/crates/orbit-cli/src/main.rs
+++ b/crates/orbit-cli/src/main.rs
@@ -36,18 +36,114 @@ mod command;
 mod output;
 mod parse;
 
-use clap::Parser;
+use clap::{Arg, ArgMatches, Command, CommandFactory, FromArgMatches};
 use orbit_core::ActorIdentity;
 use orbit_remote::runtime::RemoteRuntimeFactory;
 
 #[cfg(test)]
 use crate::command::init::InitCommand;
 use crate::command::operation::{CommandOperation, DispatchContext, RuntimeNeed};
+use crate::output::sink::{FormatArg, OutputSink};
+
+/// Clap id and long name of the global output-format argument.
+const FORMAT_ARG_ID: &str = "format";
+
+/// The global `--format`, declared exactly once for the whole CLI.
+///
+/// It is built here and grafted onto the parsed command rather than added as a
+/// field on [`command::Cli`] because the staged terminal-interface migration
+/// [ORB-10569] owns `main.rs` while concurrent work owns the `command/` tree.
+/// Either declaration site yields the same surface: one declaration, rendered
+/// under `Options:` in `orbit --help` and accepted after a subcommand.
+fn format_arg() -> Arg {
+    Arg::new(FORMAT_ARG_ID)
+        .long(FORMAT_ARG_ID)
+        .value_name("MODE")
+        .value_parser(clap::value_parser!(FormatArg))
+        .help("Output format (default: auto — a table on a terminal, plain text when piped)")
+}
+
+/// Whether this command already declares a `--format` of its own.
+///
+/// `orbit audit export` and `orbit hook pretooluse` do, with their own value
+/// types. Those two keep their meaning; the global flag is simply not offered
+/// there.
+fn declares_format(command: &Command) -> bool {
+    command
+        .get_arguments()
+        .any(|arg| arg.get_long() == Some(FORMAT_ARG_ID))
+}
+
+/// Add [`format_arg`] to the root and to every subcommand that does not
+/// declare its own `--format`.
+///
+/// This walks the tree instead of using `Arg::global`, which would be the
+/// obvious spelling but panics here. A global arg is keyed by *id*: clap
+/// declines to propagate it into a subcommand that already defines the same id
+/// (so `audit export` keeps its own `--format`), but it then propagates the
+/// *values* of every global id up and down the whole match tree regardless of
+/// type. `orbit audit export --format csv` therefore lands an `ExportFormat`
+/// under the root's `format` id, and `orbit --format json audit export` lands a
+/// `FormatArg` under the subcommand's — each one a downcast panic in the other
+/// reader. Declaring the argument per level keeps every value at the level it
+/// was parsed at, where its type is the one that level expects.
+fn install_format_arg(command: Command) -> Command {
+    let subcommands: Vec<String> = command
+        .get_subcommands()
+        .map(|sub| sub.get_name().to_string())
+        .collect();
+
+    let mut command = if declares_format(&command) {
+        command
+    } else {
+        command.arg(format_arg())
+    };
+    for name in subcommands {
+        command = command.mut_subcommand(name, install_format_arg);
+    }
+    command
+}
+
+/// The `--format` value, taken from the deepest level that parsed one.
+///
+/// A level that owns an unrelated `--format` yields a downcast error rather
+/// than a value, which reads here as "no global format was requested".
+fn requested_format(matches: &ArgMatches) -> Option<FormatArg> {
+    let mut level = matches;
+    let mut requested = None;
+    loop {
+        if let Ok(Some(format)) = level.try_get_one::<FormatArg>(FORMAT_ARG_ID) {
+            requested = Some(*format);
+        }
+        match level.subcommand() {
+            Some((_, sub)) => level = sub,
+            None => return requested,
+        }
+    }
+}
+
+/// Parse argv into the derived CLI plus the global `--format` value.
+fn parse_cli() -> (command::Cli, Option<FormatArg>) {
+    let matches = install_format_arg(command::Cli::command()).get_matches();
+    let requested = requested_format(&matches);
+    let cli = command::Cli::from_arg_matches(&matches).unwrap_or_else(|err| err.exit());
+    (cli, requested)
+}
 
 fn main() {
     orbit_common::utility::logging::init_default_subscriber("warn");
 
-    let cli = command::Cli::parse();
+    let (cli, requested_format) = parse_cli();
+    // Resolved once per invocation, before dispatch. Nothing renders through
+    // it yet — see `output::sink` for where this sits in the migration.
+    let sink = OutputSink::from_process(requested_format);
+    tracing::debug!(
+        mode = ?sink.mode(),
+        is_tty = sink.is_tty(),
+        width = sink.width(),
+        color_allowed = sink.color_allowed(),
+        "resolved output sink"
+    );
     let root_override = cli.root.clone();
     let actor = ActorIdentity::from_env();
     let CommandOperation {

--- a/crates/orbit-cli/src/output/mod.rs
+++ b/crates/orbit-cli/src/output/mod.rs
@@ -1,5 +1,6 @@
 pub mod color;
 pub mod json;
+pub mod sink;
 pub mod table;
 
 #[cfg(test)]

--- a/crates/orbit-cli/src/output/sink.rs
+++ b/crates/orbit-cli/src/output/sink.rs
@@ -1,0 +1,278 @@
+//! The output sink: one answer per invocation to "who is reading this?".
+//!
+//! Resolved once at startup from stdout, the process environment, and the
+//! global `--format` argument, per `docs/design/terminal-interface/specs/output-modes.md`
+//! §1–§2 ([ADR-0306]). Nothing downstream re-derives these answers: the sink is
+//! the only place in this crate that queries terminal state, apart from the
+//! pre-existing local check in `command/log/tail.rs`. That property is enforced
+//! by `scripts/check-terminal-state-guard.sh`.
+//!
+//! This is step 1 of the spec's §7 migration: the sink is *resolved* but not yet
+//! *consumed*, so rendering is byte-for-byte unchanged. Later steps route the
+//! per-command `--json` booleans through [`OutputSink::resolve`]'s `legacy_json`
+//! rung, then let renderers read [`OutputSink::width`] and
+//! [`OutputSink::color_allowed`].
+
+use std::io::IsTerminal;
+
+use clap::ValueEnum;
+
+/// The value of the global `--format` argument, and of `ORBIT_FORMAT`.
+///
+/// `auto` is a request to decide from the sink; the other three name a
+/// rendering directly. There is deliberately no `plain` variant — plain is a
+/// rendering of `table` for a non-terminal sink, not a mode a caller can ask
+/// for (spec §2).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum FormatArg {
+    /// Decide from the sink: a table on a terminal, plain text otherwise.
+    Auto,
+    /// Aligned columns with a header.
+    Table,
+    /// A single JSON document.
+    Json,
+    /// One complete JSON document per line.
+    Ndjson,
+}
+
+/// The mode a renderer renders in, after `auto` has been resolved.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OutputMode {
+    /// Aligned columns with a header, truncated to the sink's width.
+    Table,
+    /// `table` with the header suppressed, borders and ANSI absent, truncation
+    /// disabled, and single-tab field separators — the form `cut -f` expects.
+    Plain,
+    /// A single JSON document.
+    Json,
+    /// One complete JSON document per line, flushed per record.
+    Ndjson,
+}
+
+/// The environment variables the sink reads, captured once so that resolution
+/// is a pure function of its inputs and can be tested without mutating the
+/// process environment.
+#[derive(Clone, Debug, Default)]
+pub struct SinkEnv {
+    /// `COLUMNS` — an explicit terminal width, preferred over querying stdout.
+    pub columns: Option<String>,
+    /// `ORBIT_FORMAT` — the environment rung of the mode precedence.
+    pub format: Option<String>,
+    /// `NO_COLOR` — any non-empty value disables color.
+    pub no_color: Option<String>,
+    /// `CLICOLOR_FORCE` — any non-empty value forces color on a terminal.
+    pub clicolor_force: Option<String>,
+    /// `TERM` — `dumb` disables color unconditionally.
+    pub term: Option<String>,
+}
+
+impl SinkEnv {
+    /// Capture the sink-relevant variables from the real process environment.
+    pub fn from_process() -> Self {
+        Self {
+            columns: read_var("COLUMNS"),
+            format: read_var("ORBIT_FORMAT"),
+            no_color: read_var("NO_COLOR"),
+            clicolor_force: read_var("CLICOLOR_FORCE"),
+            term: read_var("TERM"),
+        }
+    }
+}
+
+fn read_var(key: &str) -> Option<String> {
+    std::env::var(key).ok()
+}
+
+/// Everything a renderer is allowed to know about its destination, resolved
+/// once per invocation.
+#[derive(Clone, Copy, Debug)]
+pub struct OutputSink {
+    is_tty: bool,
+    width: u16,
+    color_allowed: bool,
+    mode: OutputMode,
+}
+
+impl OutputSink {
+    /// Resolve the sink for this invocation from the real process environment.
+    ///
+    /// Called exactly once, from `main`. `requested` is the global `--format`
+    /// value, absent when the flag was not passed.
+    pub fn from_process(requested: Option<FormatArg>) -> Self {
+        let is_tty = std::io::stdout().is_terminal();
+        // Only ask the terminal for its size when there is a terminal; a
+        // non-TTY sink has width 0 no matter what the ioctl would report.
+        let terminal_width = if is_tty { query_terminal_width() } else { None };
+        Self::resolve(
+            is_tty,
+            &SinkEnv::from_process(),
+            terminal_width,
+            requested,
+            // Migration step 2 threads the per-command `--json` boolean in
+            // here. Step 1 has no access to it — the flag lives on 86
+            // individual argument structs — so the legacy rung is inert and
+            // every `--json` branch still decides for itself.
+            false,
+        )
+    }
+
+    /// Resolve a sink from explicit inputs.
+    ///
+    /// `terminal_width` is what querying the terminal reported, or `None` when
+    /// there is nothing to query. `legacy_json` is the per-command `--json`
+    /// boolean (mode precedence rung 2).
+    ///
+    /// Tests must construct sinks through here rather than through
+    /// [`OutputSink::from_process`]: `make ci` runs without a TTY, so a test
+    /// that relies on the ambient environment asserts the piped path while
+    /// appearing to test the terminal path.
+    pub fn resolve(
+        is_tty: bool,
+        env: &SinkEnv,
+        terminal_width: Option<u16>,
+        requested: Option<FormatArg>,
+        legacy_json: bool,
+    ) -> Self {
+        Self {
+            is_tty,
+            width: resolve_width(is_tty, env, terminal_width),
+            color_allowed: resolve_color(is_tty, env),
+            mode: resolve_mode(is_tty, env, requested, legacy_json),
+        }
+    }
+
+    /// Whether stdout is a terminal.
+    pub fn is_tty(&self) -> bool {
+        self.is_tty
+    }
+
+    /// The width to truncate to. `0` means "do not truncate" — never a
+    /// guessed default, because assuming a width for a sink that has none
+    /// silently truncates data in a file.
+    pub fn width(&self) -> u16 {
+        self.width
+    }
+
+    /// Whether ANSI styling may be emitted.
+    pub fn color_allowed(&self) -> bool {
+        self.color_allowed
+    }
+
+    /// The resolved output mode.
+    pub fn mode(&self) -> OutputMode {
+        self.mode
+    }
+}
+
+/// `COLUMNS` first, then what the terminal reported, then 0.
+///
+/// A non-TTY sink is 0 regardless of either, so `COLUMNS=200 orbit … > file`
+/// cannot width-adapt a file.
+fn resolve_width(is_tty: bool, env: &SinkEnv, terminal_width: Option<u16>) -> u16 {
+    if !is_tty {
+        return 0;
+    }
+    env.columns
+        .as_deref()
+        .and_then(parse_width)
+        .or(terminal_width)
+        .unwrap_or(0)
+}
+
+/// A width is a positive integer; `0` and unparseable values mean "unknown"
+/// and fall through to the next source rather than truncating to nothing.
+fn parse_width(raw: &str) -> Option<u16> {
+    match raw.trim().parse::<u16>() {
+        Ok(0) | Err(_) => None,
+        Ok(width) => Some(width),
+    }
+}
+
+/// Color precedence, per `specs/color-and-styling.md` §2.
+///
+/// The non-TTY rung comes first and is absolute: a redirected stream is never
+/// styled, whatever the environment claims. `--no-color` and `--color=always`
+/// are rungs 1 and 3 of that list; they land with the flags themselves, which
+/// this step does not introduce.
+fn resolve_color(is_tty: bool, env: &SinkEnv) -> bool {
+    if !is_tty {
+        return false;
+    }
+    if env.term.as_deref() == Some("dumb") {
+        return false;
+    }
+    if is_set(env.no_color.as_deref()) {
+        return false;
+    }
+    if is_set(env.clicolor_force.as_deref()) {
+        return true;
+    }
+    true
+}
+
+/// Mode precedence, per `specs/output-modes.md` §2. First match wins.
+fn resolve_mode(
+    is_tty: bool,
+    env: &SinkEnv,
+    requested: Option<FormatArg>,
+    legacy_json: bool,
+) -> OutputMode {
+    // 1. `--format <mode>` explicitly passed.
+    if let Some(format) = requested {
+        return render_as(format, is_tty);
+    }
+    // 2. `--json` (per-command legacy alias).
+    if legacy_json {
+        return OutputMode::Json;
+    }
+    // 3. `ORBIT_FORMAT`. An unrecognized value falls through to `auto` rather
+    //    than failing the command — an exported variable must not break every
+    //    invocation in the shell that set it.
+    if let Some(format) = env
+        .format
+        .as_deref()
+        .and_then(|raw| FormatArg::from_str(raw.trim(), true).ok())
+    {
+        return render_as(format, is_tty);
+    }
+    // 4. `auto`.
+    render_as(FormatArg::Auto, is_tty)
+}
+
+/// Resolve `auto` against the sink; the other modes name their rendering.
+fn render_as(format: FormatArg, is_tty: bool) -> OutputMode {
+    match format {
+        FormatArg::Auto if is_tty => OutputMode::Table,
+        FormatArg::Auto => OutputMode::Plain,
+        FormatArg::Table => OutputMode::Table,
+        FormatArg::Json => OutputMode::Json,
+        FormatArg::Ndjson => OutputMode::Ndjson,
+    }
+}
+
+fn is_set(value: Option<&str>) -> bool {
+    value.is_some_and(|value| !value.is_empty())
+}
+
+/// Ask the terminal attached to stdout for its column count.
+#[cfg(unix)]
+fn query_terminal_width() -> Option<u16> {
+    // SAFETY: `winsize` is a plain-data struct with no invalid bit patterns,
+    // and `TIOCGWINSZ` only writes into it. The return code is checked before
+    // the struct is read.
+    let size = unsafe {
+        let mut size: libc::winsize = std::mem::zeroed();
+        let rc = libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, &raw mut size);
+        if rc != 0 {
+            return None;
+        }
+        size
+    };
+    (size.ws_col > 0).then_some(size.ws_col)
+}
+
+/// No terminal query outside unix; `COLUMNS` is the only width source there.
+#[cfg(not(unix))]
+fn query_terminal_width() -> Option<u16> {
+    None
+}

--- a/crates/orbit-cli/src/output/tests/mod.rs
+++ b/crates/orbit-cli/src/output/tests/mod.rs
@@ -1,1 +1,2 @@
 mod color;
+mod sink;

--- a/crates/orbit-cli/src/output/tests/sink.rs
+++ b/crates/orbit-cli/src/output/tests/sink.rs
@@ -1,0 +1,211 @@
+//! Sink resolution tests.
+//!
+//! Every sink here is built with [`OutputSink::resolve`], never
+//! [`OutputSink::from_process`]: `make ci` runs without a TTY, so a test that
+//! read the ambient environment would assert the piped path while appearing to
+//! test the terminal path.
+
+use crate::output::sink::{FormatArg, OutputMode, OutputSink, SinkEnv};
+
+/// A `SinkEnv` with every variable unset.
+fn empty_env() -> SinkEnv {
+    SinkEnv::default()
+}
+
+fn sink(is_tty: bool, env: &SinkEnv, terminal_width: Option<u16>) -> OutputSink {
+    OutputSink::resolve(is_tty, env, terminal_width, None, false)
+}
+
+// ── §1 The sink's properties ────────────────────────────────────────────────
+
+#[test]
+fn non_tty_sink_has_zero_width_and_no_color_however_loudly_the_env_claims_otherwise() {
+    let env = SinkEnv {
+        columns: Some("200".to_string()),
+        clicolor_force: Some("1".to_string()),
+        ..empty_env()
+    };
+
+    let sink = sink(false, &env, Some(120));
+
+    assert!(!sink.is_tty());
+    assert_eq!(
+        sink.width(),
+        0,
+        "a redirected stream is never width-adapted, even with COLUMNS set"
+    );
+    assert!(
+        !sink.color_allowed(),
+        "a redirected stream is never styled, even with CLICOLOR_FORCE set"
+    );
+}
+
+#[test]
+fn absent_width_disables_truncation_rather_than_defaulting_to_eighty() {
+    // A terminal that reports no size: no COLUMNS, no answer from the query.
+    let sink = sink(true, &empty_env(), None);
+
+    assert!(sink.is_tty());
+    assert_eq!(
+        sink.width(),
+        0,
+        "unknown width means do not truncate; guessing 80 silently cuts data"
+    );
+}
+
+#[test]
+fn columns_env_wins_over_the_terminal_query() {
+    let env = SinkEnv {
+        columns: Some("100".to_string()),
+        ..empty_env()
+    };
+
+    assert_eq!(sink(true, &env, Some(120)).width(), 100);
+}
+
+#[test]
+fn terminal_query_answers_when_columns_is_unusable() {
+    for columns in ["", "0", "not-a-number", "-5"] {
+        let env = SinkEnv {
+            columns: Some(columns.to_string()),
+            ..empty_env()
+        };
+
+        assert_eq!(
+            sink(true, &env, Some(120)).width(),
+            120,
+            "COLUMNS={columns:?} is not a width and must fall through"
+        );
+    }
+}
+
+#[test]
+fn tty_sink_allows_color_by_default() {
+    assert!(sink(true, &empty_env(), Some(80)).color_allowed());
+}
+
+#[test]
+fn no_color_disables_color_and_outranks_clicolor_force() {
+    let env = SinkEnv {
+        no_color: Some("1".to_string()),
+        clicolor_force: Some("1".to_string()),
+        ..empty_env()
+    };
+
+    assert!(!sink(true, &env, Some(80)).color_allowed());
+}
+
+#[test]
+fn empty_no_color_does_not_disable_color() {
+    let env = SinkEnv {
+        no_color: Some(String::new()),
+        ..empty_env()
+    };
+
+    assert!(sink(true, &env, Some(80)).color_allowed());
+}
+
+#[test]
+fn dumb_terminal_disables_color_even_when_forced() {
+    let env = SinkEnv {
+        term: Some("dumb".to_string()),
+        clicolor_force: Some("1".to_string()),
+        ..empty_env()
+    };
+
+    assert!(!sink(true, &env, Some(80)).color_allowed());
+}
+
+// ── §2 Mode resolution, one test per precedence rung ────────────────────────
+
+#[test]
+fn rung_one_explicit_format_outranks_every_lower_rung() {
+    let env = SinkEnv {
+        format: Some("ndjson".to_string()),
+        ..empty_env()
+    };
+
+    let sink = OutputSink::resolve(true, &env, Some(80), Some(FormatArg::Table), true);
+
+    assert_eq!(sink.mode(), OutputMode::Table);
+}
+
+#[test]
+fn rung_one_explicit_auto_is_still_an_explicit_choice() {
+    // `--format auto` was passed, so the legacy `--json` rung is not reached.
+    let sink = OutputSink::resolve(true, &empty_env(), Some(80), Some(FormatArg::Auto), true);
+
+    assert_eq!(sink.mode(), OutputMode::Table);
+}
+
+#[test]
+fn rung_two_legacy_json_outranks_the_environment() {
+    let env = SinkEnv {
+        format: Some("table".to_string()),
+        ..empty_env()
+    };
+
+    let sink = OutputSink::resolve(false, &env, None, None, true);
+
+    assert_eq!(sink.mode(), OutputMode::Json);
+}
+
+#[test]
+fn rung_three_environment_variable_selects_the_mode() {
+    for (raw, expected) in [
+        ("json", OutputMode::Json),
+        ("ndjson", OutputMode::Ndjson),
+        ("table", OutputMode::Table),
+        // Case-insensitive and whitespace-tolerant: an exported variable is
+        // typed by hand.
+        (" NDJSON ", OutputMode::Ndjson),
+    ] {
+        let env = SinkEnv {
+            format: Some(raw.to_string()),
+            ..empty_env()
+        };
+
+        assert_eq!(
+            OutputSink::resolve(false, &env, None, None, false).mode(),
+            expected,
+            "ORBIT_FORMAT={raw:?}"
+        );
+    }
+}
+
+#[test]
+fn rung_three_environment_auto_resolves_against_the_sink() {
+    let env = SinkEnv {
+        format: Some("auto".to_string()),
+        ..empty_env()
+    };
+
+    assert_eq!(
+        OutputSink::resolve(true, &env, Some(80), None, false).mode(),
+        OutputMode::Table
+    );
+    assert_eq!(
+        OutputSink::resolve(false, &env, None, None, false).mode(),
+        OutputMode::Plain
+    );
+}
+
+#[test]
+fn unrecognized_environment_value_falls_through_to_auto() {
+    let env = SinkEnv {
+        format: Some("yaml".to_string()),
+        ..empty_env()
+    };
+
+    assert_eq!(
+        OutputSink::resolve(true, &env, Some(80), None, false).mode(),
+        OutputMode::Table,
+        "a stray ORBIT_FORMAT must not break every command in that shell"
+    );
+}
+
+#[test]
+fn rung_four_auto_is_table_on_a_terminal_and_plain_off_one() {
+    assert_eq!(sink(true, &empty_env(), Some(80)).mode(), OutputMode::Table);
+    assert_eq!(sink(false, &empty_env(), None).mode(), OutputMode::Plain);
+}

--- a/crates/orbit-cli/src/tests/cli_format.rs
+++ b/crates/orbit-cli/src/tests/cli_format.rs
@@ -1,0 +1,146 @@
+//! The global `--format` argument's surface.
+//!
+//! One declaration ([`crate::format_arg`]) reaches every command that does not
+//! own a `--format` of its own, and the two that do are left alone.
+
+use clap::{ArgMatches, Command, CommandFactory, FromArgMatches};
+
+use crate::command::Cli;
+use crate::output::sink::FormatArg;
+use crate::{FORMAT_ARG_ID, install_format_arg, requested_format};
+
+/// Commands that declared `--format` before the global one existed, with
+/// their own value types. Adding to this list is a decision, not an accident:
+/// a command here does not accept the global flag.
+const COMMANDS_OWNING_FORMAT: &[&str] = &["orbit audit export", "orbit hook pretooluse"];
+
+/// Our argument's value name, which distinguishes it from a command's own
+/// `--format` when walking the tree.
+const GLOBAL_FORMAT_VALUE_NAME: &str = "MODE";
+
+fn parser() -> Command {
+    install_format_arg(Cli::command())
+}
+
+fn matches(argv: &[&str]) -> ArgMatches {
+    parser()
+        .try_get_matches_from(argv)
+        .unwrap_or_else(|err| panic!("{argv:?} should parse: {err}"))
+}
+
+#[test]
+fn root_help_lists_the_format_argument_with_its_modes() {
+    let help = parser().render_help().to_string();
+
+    assert!(help.contains("--format <MODE>"), "root help:\n{help}");
+    assert!(
+        help.contains("[possible values: auto, table, json, ndjson]"),
+        "root help:\n{help}"
+    );
+}
+
+#[test]
+fn format_is_accepted_before_and_after_the_subcommand() {
+    assert_eq!(
+        requested_format(&matches(&["orbit", "--format", "json", "task", "list"])),
+        Some(FormatArg::Json)
+    );
+    assert_eq!(
+        requested_format(&matches(&["orbit", "task", "list", "--format", "ndjson"])),
+        Some(FormatArg::Ndjson)
+    );
+    assert_eq!(
+        requested_format(&matches(&["orbit", "task", "--format", "table", "list"])),
+        Some(FormatArg::Table)
+    );
+}
+
+#[test]
+fn absent_format_resolves_to_none_rather_than_a_default() {
+    assert_eq!(requested_format(&matches(&["orbit", "task", "list"])), None);
+}
+
+#[test]
+fn the_deepest_format_wins() {
+    let matches = matches(&[
+        "orbit", "--format", "json", "task", "list", "--format", "table",
+    ]);
+
+    assert_eq!(requested_format(&matches), Some(FormatArg::Table));
+}
+
+#[test]
+fn a_command_owning_format_keeps_its_own_value() {
+    let matches = matches(&[
+        "orbit",
+        "audit",
+        "export",
+        "--format",
+        "csv",
+        "--output",
+        "events.csv",
+    ]);
+
+    assert_eq!(
+        requested_format(&matches),
+        None,
+        "`csv` belongs to audit export, not to the global flag"
+    );
+    // Reading a value whose type the level does not expect is a panic inside
+    // clap, not an `Err` — so this call is the regression guard for
+    // cross-level value bleed, not the assertion below it.
+    assert!(Cli::from_arg_matches(&matches).is_ok());
+}
+
+#[test]
+fn a_global_format_does_not_corrupt_a_command_owning_format() {
+    let matches = matches(&[
+        "orbit",
+        "--format",
+        "json",
+        "audit",
+        "export",
+        "--output",
+        "events.csv",
+    ]);
+
+    assert_eq!(requested_format(&matches), Some(FormatArg::Json));
+    assert!(Cli::from_arg_matches(&matches).is_ok());
+}
+
+#[test]
+fn every_command_declares_exactly_one_format_and_only_two_own_theirs() {
+    let mut owners = Vec::new();
+    walk(&parser(), "orbit", &mut owners);
+    owners.sort();
+    let owners: Vec<&str> = owners.iter().map(String::as_str).collect();
+
+    assert_eq!(owners, COMMANDS_OWNING_FORMAT);
+}
+
+/// Assert one `--format` per command, recording the commands whose `--format`
+/// is not the global one.
+fn walk(command: &Command, path: &str, owners: &mut Vec<String>) {
+    let declared: Vec<_> = command
+        .get_arguments()
+        .filter(|arg| arg.get_long() == Some(FORMAT_ARG_ID))
+        .collect();
+
+    assert_eq!(
+        declared.len(),
+        1,
+        "`{path}` declares {} `--format` arguments; expected exactly one",
+        declared.len()
+    );
+
+    let is_global_flag = declared[0]
+        .get_value_names()
+        .is_some_and(|names| names.len() == 1 && names[0] == GLOBAL_FORMAT_VALUE_NAME);
+    if !is_global_flag {
+        owners.push(path.to_string());
+    }
+
+    for sub in command.get_subcommands() {
+        walk(sub, &format!("{path} {}", sub.get_name()), owners);
+    }
+}

--- a/crates/orbit-cli/src/tests/mod.rs
+++ b/crates/orbit-cli/src/tests/mod.rs
@@ -1,2 +1,3 @@
 mod audit_middleware;
+mod cli_format;
 pub(crate) mod env_isolation;

--- a/crates/orbit-cli/tests/json_output_stability.rs
+++ b/crates/orbit-cli/tests/json_output_stability.rs
@@ -1,0 +1,124 @@
+#![allow(missing_docs)]
+// Tests use unwrap/expect to keep fixture setup readable.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+//! The per-command `--json` flag predates the global `--format` and must keep
+//! producing exactly the bytes it produced before the sink existed
+//! ([ORB-10569], `docs/design/terminal-interface/specs/output-modes.md` §7
+//! step 1).
+//!
+//! Two properties, checked separately: the exact bytes of a stable payload,
+//! and — for commands whose payload embeds machine-specific values — that
+//! nothing on the mode-resolution path perturbs them.
+
+use std::path::Path;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use tempfile::{TempDir, tempdir};
+
+/// Commands with a `--json` flag whose output must not shift. Each is a list
+/// or detail command that renders through a different code path.
+const JSON_COMMANDS: &[&[&str]] = &[&["task", "list"], &["tool", "list"], &["config", "show"]];
+
+struct Fixture {
+    _temp: TempDir,
+    home: std::path::PathBuf,
+    work: std::path::PathBuf,
+}
+
+fn fixture() -> Fixture {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let work = temp.path().join("work");
+    std::fs::create_dir_all(&home).expect("create home");
+    std::fs::create_dir_all(&work).expect("create work");
+    Fixture {
+        _temp: temp,
+        home,
+        work,
+    }
+}
+
+fn run(home: &Path, work: &Path, args: &[&str], env: &[(&str, &str)]) -> Vec<u8> {
+    let mut command = cargo_bin_cmd!("orbit");
+    command
+        .current_dir(work)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env_remove("ORBIT_ROOT")
+        .env_remove("ORBIT_FORMAT")
+        .env_remove("NO_COLOR")
+        .env_remove("CLICOLOR_FORCE")
+        .env_remove("COLUMNS");
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    command
+        .args(args)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone()
+}
+
+#[test]
+fn json_flag_output_is_untouched_by_the_global_format_machinery() {
+    let fixture = fixture();
+
+    for command in JSON_COMMANDS {
+        let mut args = command.to_vec();
+        args.push("--json");
+
+        let baseline = run(&fixture.home, &fixture.work, &args, &[]);
+        assert!(
+            !baseline.is_empty(),
+            "`orbit {} --json` produced nothing",
+            command.join(" ")
+        );
+
+        // Rung 3 (the environment) must never outrank the `--json` rung...
+        assert_eq!(
+            run(
+                &fixture.home,
+                &fixture.work,
+                &args,
+                &[("ORBIT_FORMAT", "table")]
+            ),
+            baseline,
+            "ORBIT_FORMAT changed `orbit {} --json`",
+            command.join(" ")
+        );
+        // ...and merely resolving a mode must not reach the command body,
+        // which still renders from its own `--json` boolean.
+        let mut with_format = args.clone();
+        with_format.extend(["--format", "table"]);
+        assert_eq!(
+            run(&fixture.home, &fixture.work, &with_format, &[]),
+            baseline,
+            "--format changed `orbit {} --json`",
+            command.join(" ")
+        );
+    }
+}
+
+#[test]
+fn empty_list_json_is_exactly_an_empty_array() {
+    let fixture = fixture();
+
+    for command in [
+        ["task", "list"].as_slice(),
+        ["adr", "list"].as_slice(),
+        ["learning", "list"].as_slice(),
+    ] {
+        let mut args = command.to_vec();
+        args.push("--json");
+
+        assert_eq!(
+            run(&fixture.home, &fixture.work, &args, &[]),
+            b"[]\n",
+            "`orbit {} --json` must emit a bare empty array",
+            command.join(" ")
+        );
+    }
+}

--- a/docs/design/terminal-interface/2_design.md
+++ b/docs/design/terminal-interface/2_design.md
@@ -1,13 +1,13 @@
 ---
 title: Terminal Interface — Design
 owner: claude
-last_updated: 2026-08-01
+last_updated: 2026-08-02
 last_validated: 2026-08-01
 status: Accepted
 feature: terminal-interface
 doc_role: design
 type: design
-summary: "Current orbit-cli output implementation — comfy-table bordered tables, duplicated color vocabularies, per-command --json — and where it diverges from the specs."
+summary: "Current orbit-cli output implementation — comfy-table bordered tables, duplicated color vocabularies, per-command --json, and a resolved-but-unconsumed output sink — and where it diverges from the specs."
 tags: [terminal-interface]
 paths: ["crates/orbit-cli/src/output/**", "crates/orbit-cli/src/command/**"]
 related_features: [terminal-interface]
@@ -48,17 +48,19 @@ This file is also where the drift between the two renderings is easiest to see. 
 
 The copies have already drifted: `status_color` maps `backlog` explicitly, `status_color_cell` does not. The two-edit cost is visible in the history — [T20260427-43] added a `friction` arm to both functions, and [ORB-10202] removed it from both when the status was retired. The palette itself is broader than a closed role set — `in-progress` is cyan, `review` is magenta, `done` is bold green — so it encodes more distinctions than the target vocabulary. **Diverges from [./specs/color-and-styling.md](./specs/color-and-styling.md)** [ADR-0308].
 
-## 5. No Sink Resolution
+## 5. Sink Resolution Without Consumers
 
-The CLI never asks whether stdout is a terminal, with one exception: `command/log/tail.rs` calls `stdout.is_terminal()` to decide whether to colorize the tailed stream. That check is local to the command and not reused.
+`output/sink.rs` resolves `is_tty`, `width`, `color_allowed`, and the output mode once per invocation, from `main.rs`, ahead of dispatch [ORB-10569]. It is the only place in the crate that queries terminal state — `COLUMNS`, `TIOCGWINSZ`, `NO_COLOR`, `CLICOLOR_FORCE`, `IsTerminal` — enforced by `scripts/check-terminal-state-guard.sh`, whose allowlist carries the one grandfathered exception: `command/log/tail.rs` still calls `stdout.is_terminal()` locally to decide whether to colorize the tailed stream.
 
-Consequently the two styling backends disagree about emission. `colored` internally honors `NO_COLOR` and TTY state; `comfy_table::Color` writes escape sequences unconditionally. `NO_COLOR=1 orbit task list` still emits color from the table path. Redirecting any table command to a file captures ANSI and box-drawing glyphs. Width is taken from the terminal even when there is no terminal. **Diverges from [./specs/output-modes.md](./specs/output-modes.md) §1** [ADR-0306], [ADR-0308].
+**Nothing consumes the answers yet.** That is step 1 of [./specs/output-modes.md](./specs/output-modes.md) §7, which deliberately changes no rendering: the sink is resolved and logged at `debug`, and every command still renders exactly as it did. So the emission problems below are unchanged. The two styling backends still disagree — `colored` internally honors `NO_COLOR` and TTY state; `comfy_table::Color` writes escape sequences unconditionally — so `NO_COLOR=1 orbit task list` still emits color from the table path, redirecting a table command to a file still captures ANSI and box-drawing glyphs, and `comfy-table` still takes width from the terminal even when there is no terminal. **Still diverges from [./specs/output-modes.md](./specs/output-modes.md) §1** until a renderer reads the sink [ADR-0306], [ADR-0308].
 
 ## 6. Per-Command Structured Output
 
 `--json` is declared independently on each command as `#[arg(long)] pub json: bool` and handled by an `if self.json { … } else { … }` branch inside `execute()`. 86 of 150 argument structs carry it; 64 have no machine-readable path.
 
 Because both branches are written by hand in the same function, they drift. `orbit tool list` emits seven JSON fields (`name`, `description`, `enabled`, `active`, `status`, `builtin`, `parameters`) and five table columns, and the table's `REQUIRED INPUT` column is a summary string produced by `format_required_tool_input_summary` that exists in no payload field. There is also no `ndjson` mode: `--json` on a list command emits one pretty-printed array, which a streaming consumer must buffer whole. **Diverges from [./specs/output-modes.md](./specs/output-modes.md)** [ADR-0306].
+
+A global `--format auto|table|json|ndjson` is accepted on every command that does not already own a `--format` — `audit export` and `hook pretooluse` do, with unrelated value types, and keep theirs. It resolves a mode through §2's precedence and no further: no command body reads the result yet, so passing it is currently inert. `--json` remains the only flag that changes output, unchanged byte for byte [ORB-10569].
 
 ## 7. Empty States and Errors
 
@@ -78,7 +80,7 @@ This cuts both ways: the migration prescribed by the specs will not be blocked b
 
 **The refactor's cost is concentrated in a trait signature.** `Execute::execute` returns `Result<(), OrbitError>` and writes to stdout as a side effect. Making commands return payloads changes that signature across all 154 `impl Execute` blocks, which is a single mechanical change but an unavoidably wide one. It cannot be landed incrementally per command without a transitional dual path.
 
-**Terminal width detection is not currently a dependency.** `comfy-table` resolves width internally. Moving width into an explicit sink means taking a direct dependency on `terminal_size` or equivalent, and deciding the fallback width when there is no terminal (the specs say 0 — emit untruncated — but that is a claim not yet tested against real consumers).
+**Terminal width detection needed no new dependency.** `comfy-table` still resolves width internally for the tables it draws; the sink asks `TIOCGWINSZ` through the `libc` dependency `orbit-cli` already carries on unix, after `COLUMNS`. Non-unix has no query and falls back to `COLUMNS` alone. The 0 fallback ("do not truncate") is asserted in the sink's tests but still untested against a real consumer, because nothing renders through the sink yet.
 
 **The role vocabulary is lossy on purpose and may be wrong.** Collapsing `in-progress`, `review`, and `proposed` into `active`/`neutral` discards distinctions operators may be reading today. No one has checked whether the current colors are load-bearing in practice.
 
@@ -94,5 +96,6 @@ This cuts both ways: the migration prescribed by the specs will not be blocked b
 - [ORB-10202] — removed the `friction` arm from both halves when the status was retired.
 - [ORB-10228] — added trusted MCP session context to the audit event JSON payload, but not to the printed line.
 - [ORB-10356] — made `OrbitError` `#[non_exhaustive]`, adding the `internal_error` catch-all to the payload's `code` discriminator.
+- [ORB-10569] — introduced `output/sink.rs` and the global `--format`, resolved once per invocation and not yet consumed.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/scripts/check-terminal-state-guard.sh
+++ b/scripts/check-terminal-state-guard.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The output sink is the only place in orbit-cli that asks whether stdout is a
+# terminal, how wide it is, or whether color is permitted
+# (docs/design/terminal-interface/specs/output-modes.md §1, ADR-0306). A
+# command that re-derives any of it renders differently from the sink that
+# resolved the invocation, which is the drift the sink exists to remove.
+#
+# command/log/tail.rs is the one grandfathered exception: it colorizes a
+# streamed tail from a local `is_terminal()` check, and a dependent task in the
+# staged migration removes it. Nothing may be added to the allowlist without
+# that being a decision.
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "check-terminal-state-guard: ripgrep (rg) is required; install it before running" >&2
+  exit 1
+fi
+
+cli_src="crates/orbit-cli/src"
+
+allowed=(
+  "$cli_src/output/sink.rs"
+  "$cli_src/output/tests/sink.rs"
+  "$cli_src/command/log/tail.rs"
+)
+
+# `IsTerminal` covers `x.is_terminal()` too: the trait must be imported by name
+# to call it. A bare `is_terminal()` is therefore not matched on purpose —
+# `JobRunState::is_terminal` is an unrelated domain predicate.
+patterns=(
+  '\bIsTerminal\b'
+  '\bTIOCGWINSZ\b'
+  '\bNO_COLOR\b'
+  '\bCLICOLOR'
+  '"COLUMNS"'
+)
+
+failed=0
+for pattern in "${patterns[@]}"; do
+  while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    file="${hit%%:*}"
+    permitted=0
+    for allow in "${allowed[@]}"; do
+      if [[ "$file" == "$allow" ]]; then
+        permitted=1
+        break
+      fi
+    done
+    if [[ "$permitted" -eq 0 ]]; then
+      echo "terminal state queried outside the output sink: $hit"
+      failed=1
+    fi
+  done < <(rg --no-heading --line-number "$pattern" --glob '*.rs' "$cli_src" || true)
+done
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "resolve it once in crates/orbit-cli/src/output/sink.rs and read it from there" >&2
+  exit 1
+fi
+
+echo "orbit-cli terminal state guard passed"

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -45,6 +45,7 @@ fi
 "$repo_root/scripts/test-installer-security.sh"
 "$repo_root/scripts/check-dependency-direction.sh"
 "$repo_root/scripts/check-cli-imports.sh"
+"$repo_root/scripts/check-terminal-state-guard.sh"
 "$repo_root/scripts/check-stability.sh"
 "$repo_root/scripts/check-learning-layout.sh"
 "$repo_root/scripts/check-artifact-redaction-guardrail.sh"


### PR DESCRIPTION
## Manual resolution required

Orbit preserved and pushed this task's pre-rebase candidate after the shipment pipeline stopped. This PR is intentionally blocked and must be reconciled manually before merge.

- Task: `ORB-10569`
- Run: `jrun-20260802-0239-9`
- Failed step: `sync_base`
- Error code: `pipeline_step_failed`
- Original base: `7682e7eb2501682dd5cecb4dd7dcb71a237530da`
- Target base: `f243ecb64ff9cad43ae9f521502e6a4e8cbd65d0`

## Conflicting paths

- `crates/orbit-cli/src/output/tests/mod.rs`

## Failure

```text
deterministic action `git_rebase` failed: execution failed: git_rebase: rebase of 'orbit/ORB-10569-6a6eade6' onto checkpoint 'f243ecb64ff9cad43ae9f521502e6a4e8cbd65d0' stopped with conflicts; conflicting paths: crates/orbit-cli/src/output/tests/mod.rs
```