### PR TITLE
Gate color and width at the sink and retire the hand-padded output paths

### DIFF
--- a/crates/orbit-cli/src/command/audit/list.rs
+++ b/crates/orbit-cli/src/command/audit/list.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use crate::command::Execute;
 use crate::parse::parse_since;
 
-use super::support::{audit_event_to_json, print_audit_event_line};
+use super::support::{AuditListFilters, audit_event_to_json, print_audit_events};
 
 #[derive(Args)]
 pub struct AuditListArgs {
@@ -63,6 +63,13 @@ pub struct AuditListArgs {
 impl Execute for AuditListArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         let since = self.since.map(|s| parse_since(&s)).transpose()?;
+        // Captured before the filter consumes them: a column the caller
+        // filtered on stays on screen even though it now reads uniform.
+        let filtered = AuditListFilters {
+            status: self.status.is_some(),
+            role: self.role.is_some(),
+            tool: self.tool.is_some(),
+        };
         let events = runtime.list_audit_events_filtered(&AuditEventFilter {
             since,
             tool_name: self.tool,
@@ -85,9 +92,7 @@ impl Execute for AuditListArgs {
             let values: Vec<Value> = events.iter().map(audit_event_to_json).collect();
             crate::output::json::print_pretty(&Value::Array(values))
         } else {
-            for event in &events {
-                print_audit_event_line(event);
-            }
+            print_audit_events(&events, filtered);
             Ok(())
         }
     }

--- a/crates/orbit-cli/src/command/audit/support.rs
+++ b/crates/orbit-cli/src/command/audit/support.rs
@@ -1,6 +1,9 @@
 use orbit_core::AuditEvent;
 use serde_json::{Value, json};
 
+use crate::output::color::{Domain, cell};
+use crate::output::table::{Column, Table};
+
 pub(super) fn audit_event_to_json(event: &AuditEvent) -> Value {
     json!({
         "id": event.id,
@@ -40,15 +43,46 @@ pub(super) fn audit_event_to_json(event: &AuditEvent) -> Value {
     })
 }
 
-pub(super) fn print_audit_event_line(event: &AuditEvent) {
-    let tool = event.tool_name.as_deref().unwrap_or("-");
-    println!(
-        "[{}] {:<8} {:<6} {}:{:<20} {}ms",
-        event.timestamp.format("%Y-%m-%dT%H:%M:%S"),
-        event.status,
-        event.role,
-        event.command,
-        tool,
-        event.duration_ms,
-    );
+/// Which columns the caller filtered on, so a column the filter made
+/// informationally uniform still stays on screen.
+#[derive(Clone, Copy, Default)]
+pub(super) struct AuditListFilters {
+    pub(super) status: bool,
+    pub(super) role: bool,
+    pub(super) tool: bool,
+}
+
+/// Render the audit log as a list view.
+///
+/// This replaces a `"[{}] {:<8} {:<6} {}:{:<20} {}ms"` format string whose
+/// padding was a literal rather than a function of the data, so a tool name
+/// over 20 characters broke the column the operator was scanning, and no
+/// header said what any column was (ADR-0306). Widths now come from the
+/// result set and the sink; `DURATION (ms)` is a number column, so magnitudes
+/// line up on their right edge and the unit is named once in the header
+/// instead of being suffixed to every value.
+pub(super) fn print_audit_events(events: &[AuditEvent], filters: AuditListFilters) {
+    let mut table = Table::new(vec![
+        Column::new("TIME").fixed(),
+        Column::new("STATUS").fixed().filtered(filters.status),
+        Column::new("ROLE").fixed().filtered(filters.role),
+        Column::new("COMMAND").fixed(),
+        Column::new("TOOL").filtered(filters.tool),
+        Column::new("DURATION (ms)").number(),
+    ])
+    .empty_message("no audit events matching the given filters");
+
+    for event in events {
+        let status = event.status.to_string();
+        table.add_row(vec![
+            comfy_table::Cell::new(event.timestamp.format("%Y-%m-%dT%H:%M:%S").to_string()),
+            cell(&status, Domain::AuditStatus),
+            comfy_table::Cell::new(&event.role),
+            comfy_table::Cell::new(&event.command),
+            comfy_table::Cell::new(event.tool_name.as_deref().unwrap_or("-")),
+            comfy_table::Cell::new(event.duration_ms.to_string()),
+        ]);
+    }
+
+    table.print();
 }

--- a/crates/orbit-cli/src/command/doctor.rs
+++ b/crates/orbit-cli/src/command/doctor.rs
@@ -4,6 +4,7 @@ use orbit_core::{OrbitError, OrbitRuntime};
 use serde_json::{Value, json};
 
 use crate::command::Execute;
+use crate::output::color::{Domain, Role};
 
 /// `orbit doctor` — workspace-level self-diagnostics [ORB-10005].
 #[derive(Args)]
@@ -82,7 +83,7 @@ impl Execute for DoctorCommand {
                 use comfy_table::Cell;
                 table.add_row(vec![
                     Cell::new(&row.check_name),
-                    crate::output::color::doctor_status_color_cell(status_label(row.status)),
+                    crate::output::color::cell(status_label(row.status), Domain::DoctorStatus),
                     Cell::new(human_detail(row)),
                 ]);
             }
@@ -91,7 +92,7 @@ impl Execute for DoctorCommand {
             if failures == 0 && warnings == 0 {
                 println!(
                     "\n{}",
-                    crate::output::color::job_state_color("Workspace healthy.")
+                    crate::output::color::text("Workspace healthy.", Role::Ok)
                 );
             } else {
                 eprintln!("\n{failures} failure(s), {warnings} warning(s).");

--- a/crates/orbit-cli/src/command/job/list.rs
+++ b/crates/orbit-cli/src/command/job/list.rs
@@ -4,6 +4,7 @@ use orbit_core::{OrbitError, OrbitRuntime};
 use serde_json::Value;
 
 use crate::command::Execute;
+use crate::output::color::Domain;
 
 use super::support::{
     format_last_run, job_catalog_filter, job_catalog_target_summary,
@@ -68,7 +69,7 @@ impl Execute for JobListArgs {
                     Cell::new(job.kind().to_string()),
                     Cell::new(target_type),
                     Cell::new(target_id),
-                    crate::output::color::job_state_color_cell(&job.state().to_string()),
+                    crate::output::color::cell(&job.state().to_string(), Domain::JobState),
                     Cell::new(format_last_run(last_run.as_ref())),
                 ]);
             }

--- a/crates/orbit-cli/src/command/job/show.rs
+++ b/crates/orbit-cli/src/command/job/show.rs
@@ -18,13 +18,13 @@ impl Execute for JobShowArgs {
         if self.json {
             crate::output::json::print_pretty(&job_catalog_to_json_with_last_run(&job, None))
         } else {
-            use crate::output::color::{bold, job_state_color};
+            use crate::output::color::{Domain, bold, text};
             println!("{} {}", bold("Job ID:"), job.job_id.as_str());
             println!("{} {}", bold("Kind:"), job.kind());
             println!(
                 "{} {}",
                 bold("State:"),
-                job_state_color(&job.state().to_string())
+                text(&job.state().to_string(), Domain::JobState)
             );
             println!("{} {}", bold("Max Active Runs:"), job.max_active_runs());
             println!("{} {}", bold("Path:"), job.path.display());

--- a/crates/orbit-cli/src/command/log/tail.rs
+++ b/crates/orbit-cli/src/command/log/tail.rs
@@ -2,11 +2,11 @@
 //! feed at `~/.orbit/state/logs/orbit.jsonl` (or wherever `--path` /
 //! `ORBIT_LOG_PATH` points). Renders the v2-terminal-console mockup's four
 //! columns: timestamp, source, code, message. Designed for human eyes by
-//! default and pipeline-friendly when stdout is not a TTY (`--json` or
+//! default and pipeline-friendly when the sink disallows color (`--json` or
 //! plain-text without ANSI escapes).
 
 use std::fs::File;
-use std::io::{self, BufRead, BufReader, IsTerminal, Seek, SeekFrom, Write};
+use std::io::{self, BufRead, BufReader, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::Duration;
@@ -16,6 +16,7 @@ use orbit_core::{OrbitError, OrbitRuntime};
 use serde_json::Value;
 
 use crate::command::Execute;
+use crate::output::sink;
 
 use super::format::{
     Filters, LevelFilter, build_filters as build_shared_filters, format_event_line,
@@ -60,10 +61,18 @@ impl Execute for TailArgs {
     fn execute(self, _runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         let path = resolve_log_path(self.path.as_deref())?;
         let filters = build_filters(&self)?;
-        let stdout = io::stdout();
-        let use_color = stdout.is_terminal();
-        let mut writer = stdout.lock();
-        run_tail(&path, &self, &filters, use_color, &mut writer).map_err(io_to_orbit)
+        // Whether to colorize is the sink's answer, not this command's: the
+        // local `is_terminal()` check that used to live here ignored NO_COLOR
+        // and disagreed with every table-rendering command (ADR-0308 §2).
+        let use_color = sink::active().color_allowed();
+        let mut writer = io::stdout().lock();
+        match run_tail(&path, &self, &filters, use_color, &mut writer) {
+            Ok(()) => Ok(()),
+            // The reader closing the pipe is how `orbit log tail -f | head`
+            // ends, not a failure to report (spec §5).
+            Err(err) if crate::output::pipe::is_broken_pipe(&err) => Ok(()),
+            Err(err) => Err(io_to_orbit(err)),
+        }
     }
 }
 

--- a/crates/orbit-cli/src/command/migrate.rs
+++ b/crates/orbit-cli/src/command/migrate.rs
@@ -143,7 +143,7 @@ fn print_status(
     if status.pending_total() == 0 {
         println!(
             "\n{}",
-            crate::output::color::job_state_color("Workspace is up to date.")
+            crate::output::color::text("Workspace is up to date.", crate::output::color::Role::Ok)
         );
         return Ok(());
     }

--- a/crates/orbit-cli/src/command/run/history.rs
+++ b/crates/orbit-cli/src/command/run/history.rs
@@ -4,6 +4,7 @@ use orbit_core::{OrbitError, OrbitRuntime};
 use serde_json::json;
 
 use crate::command::Execute;
+use crate::output::color::Domain;
 
 use super::format::{format_timestamp, format_waiting_line, summarize_error_message};
 use super::job::job_run_to_json_with_state;
@@ -91,7 +92,7 @@ pub(crate) fn print_run_history(
         }
         row.extend([
             Cell::new(run.attempt.to_string()),
-            crate::output::color::job_state_color_cell(&run.state.to_string()),
+            crate::output::color::cell(&run.state.to_string(), Domain::JobState),
             Cell::new(format_timestamp(run.started_at)),
             Cell::new(format_timestamp(run.finished_at)),
             Cell::new(last.and_then(|s| s.error_code.as_deref()).unwrap_or("-")),

--- a/crates/orbit-cli/src/command/run/steps.rs
+++ b/crates/orbit-cli/src/command/run/steps.rs
@@ -4,6 +4,8 @@ use orbit_core::runtime::run_audit::RunAuditStep;
 use orbit_core::{JobRun, JobRunStep, JobTargetType, NotFoundKind, OrbitError, OrbitRuntime};
 use serde_json::{Value, json};
 
+use crate::output::color::Domain;
+
 use super::format::{
     format_duration, format_timestamp, format_waiting_line, summarize_error_message,
 };
@@ -158,13 +160,13 @@ pub(crate) fn print_run_header(run: &JobRun) {
 }
 
 pub(crate) fn print_run_header_with_state(run: &JobRun, state: Option<&PipelineState>) {
-    use crate::output::color::{bold, dimmed, job_state_color};
+    use crate::output::color::{Domain, bold, dimmed, text};
     println!("{} {}", bold("Run ID:"), run.run_id);
     println!("{} {}", bold("Job ID:"), run.job_id);
     println!(
         "{} {}",
         bold("State:"),
-        job_state_color(&run.state.to_string())
+        text(&run.state.to_string(), Domain::JobState)
     );
     println!(
         "{} {}",
@@ -199,7 +201,7 @@ pub(crate) fn print_step_summary_table(steps: &[&JobRunStep]) -> Result<(), Orbi
         table.add_row(vec![
             Cell::new(step.step_index),
             Cell::new(&step.target_id),
-            crate::output::color::job_state_color_cell(&step.state.to_string()),
+            crate::output::color::cell(&step.state.to_string(), Domain::JobState),
             Cell::new(
                 step.duration_ms
                     .map(|ms| ms.to_string())
@@ -228,12 +230,12 @@ pub(crate) fn print_step_record(
         }));
     }
 
-    use crate::output::color::{bold, dimmed, job_state_color};
+    use crate::output::color::{Domain, bold, dimmed, text};
     println!("{} {}", bold("Run ID:"), run.run_id);
     println!("{} {}", bold("Job ID:"), run.job_id);
     println!("{} {}", bold("Target ID:"), step.target_id);
     println!("{} {}", bold("Target Type:"), step.target_type);
-    println!("{} {}", bold("State:"), job_state_color(&step.state));
+    println!("{} {}", bold("State:"), text(&step.state, Domain::JobState));
     println!(
         "{} {}",
         bold("Started:"),

--- a/crates/orbit-cli/src/command/skill/doctor.rs
+++ b/crates/orbit-cli/src/command/skill/doctor.rs
@@ -4,6 +4,7 @@ use orbit_core::{OrbitError, OrbitRuntime};
 use serde_json::{Value, json};
 
 use crate::command::Execute;
+use crate::output::color::{Domain, Role};
 
 #[derive(Args)]
 pub struct SkillDoctorArgs {
@@ -39,7 +40,7 @@ impl Execute for SkillDoctorArgs {
             use comfy_table::Cell;
             table.add_row(vec![
                 Cell::new(&row.skill_name),
-                crate::output::color::doctor_status_color_cell(status),
+                crate::output::color::cell(status, Domain::DoctorStatus),
                 Cell::new(&row.message),
             ]);
         }
@@ -48,7 +49,7 @@ impl Execute for SkillDoctorArgs {
         if issues == 0 {
             println!(
                 "\n{}",
-                crate::output::color::job_state_color("All skills healthy.")
+                crate::output::color::text("All skills healthy.", Role::Ok)
             );
         } else {
             eprintln!("\n{} issue(s) found.", issues);

--- a/crates/orbit-cli/src/command/task/output.rs
+++ b/crates/orbit-cli/src/command/task/output.rs
@@ -5,6 +5,8 @@ use orbit_common::types::{ArtifactManifestFileV2, TaskArtifact};
 use orbit_core::{OrbitError, OrbitRuntime, TaskStatus, resolve_task_dependencies};
 use serde_json::{Value, json};
 
+use crate::output::color::Domain;
+
 /// Legacy bare `commented` history entries duplicate the authoritative Comments
 /// list, so human-facing history rendering omits them (ORB-10311). Raw JSON/MCP
 /// history projections keep every event for backward compatibility.
@@ -140,9 +142,9 @@ pub(super) fn print_task_table(tasks: &[orbit_core::Task], full: bool, filtered:
         let mut row = vec![
             Cell::new(&task.id),
             Cell::new(&task.title),
-            crate::output::color::status_color_cell(&task.status.to_string()),
-            crate::output::color::priority_color_cell(&task.priority.to_string()),
-            crate::output::color::task_type_color_cell(&task.task_type.to_string()),
+            crate::output::color::cell(&task.status.to_string(), Domain::TaskStatus),
+            crate::output::color::cell(&task.priority.to_string(), Domain::Priority),
+            crate::output::color::cell(&task.task_type.to_string(), Domain::TaskType),
         ];
         if full {
             row.extend([

--- a/crates/orbit-cli/src/command/task/show.rs
+++ b/crates/orbit-cli/src/command/task/show.rs
@@ -66,7 +66,7 @@ impl Execute for TaskShowArgs {
             }
             crate::output::json::print_pretty(&value)
         } else {
-            use crate::output::color::{bold, dimmed, priority_color, status_color};
+            use crate::output::color::{Domain, bold, dimmed, text};
             println!("{} {}", bold("ID:"), task.id);
             if let Some(parent_id) = task.parent_id() {
                 println!("{} {}", bold("Parent Task:"), parent_id);
@@ -75,12 +75,12 @@ impl Execute for TaskShowArgs {
             println!(
                 "{} {}",
                 bold("Status:"),
-                status_color(&task.status.to_string())
+                text(&task.status.to_string(), Domain::TaskStatus)
             );
             println!(
                 "{} {}",
                 bold("Priority:"),
-                priority_color(&task.priority.to_string())
+                text(&task.priority.to_string(), Domain::Priority)
             );
             if let Some(complexity) = task.complexity {
                 println!("{} {}", bold("Complexity:"), complexity);

--- a/crates/orbit-cli/src/command/tool/doctor.rs
+++ b/crates/orbit-cli/src/command/tool/doctor.rs
@@ -1,5 +1,7 @@
 use orbit_core::{OrbitError, OrbitRuntime};
 
+use crate::output::color::{Domain, Role};
+
 pub(super) fn execute_doctor(runtime: &OrbitRuntime) -> Result<(), OrbitError> {
     use orbit_core::command::tool::DoctorStatus;
 
@@ -25,7 +27,7 @@ pub(super) fn execute_doctor(runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         use comfy_table::Cell;
         table.add_row(vec![
             Cell::new(&r.tool_name),
-            crate::output::color::doctor_status_color_cell(status_str),
+            crate::output::color::cell(status_str, Domain::DoctorStatus),
             Cell::new(&r.message),
         ]);
     }
@@ -34,7 +36,7 @@ pub(super) fn execute_doctor(runtime: &OrbitRuntime) -> Result<(), OrbitError> {
     if issues == 0 {
         println!(
             "\n{}",
-            crate::output::color::job_state_color("All tools healthy.")
+            crate::output::color::text("All tools healthy.", Role::Ok)
         );
     } else {
         eprintln!("\n{} issue(s) found.", issues);

--- a/crates/orbit-cli/src/command/tool/list.rs
+++ b/crates/orbit-cli/src/command/tool/list.rs
@@ -3,6 +3,7 @@ use orbit_core::{OrbitError, OrbitRuntime};
 use serde_json::{Value, json};
 
 use crate::command::Execute;
+use crate::output::color::Domain;
 
 use super::support::{format_required_tool_input_summary, tool_status};
 
@@ -60,7 +61,7 @@ impl Execute for ToolListArgs {
                 use comfy_table::Cell;
                 table.add_row(vec![
                     Cell::new(&tool.name),
-                    crate::output::color::job_state_color_cell(tool_status(tool)),
+                    crate::output::color::cell(tool_status(tool), Domain::JobState),
                     Cell::new(if tool.builtin { "yes" } else { "no" }),
                     Cell::new(format_required_tool_input_summary(&tool.parameters)),
                     Cell::new(&tool.description),

--- a/crates/orbit-cli/src/command/tool/show.rs
+++ b/crates/orbit-cli/src/command/tool/show.rs
@@ -15,7 +15,7 @@ impl Execute for ToolShowArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         let tool = runtime.show_tool(&self.name)?;
 
-        use crate::output::color::{bold, job_state_color};
+        use crate::output::color::{Domain, bold, text};
         println!("{} {}", bold("Name:"), tool.name);
         println!("{} {}", bold("Description:"), tool.description);
         println!(
@@ -26,7 +26,7 @@ impl Execute for ToolShowArgs {
         println!(
             "{} {}",
             bold("Status:"),
-            job_state_color(tool_status(&tool))
+            text(tool_status(&tool), Domain::JobState)
         );
 
         if tool.parameters.is_empty() {

--- a/crates/orbit-cli/src/main.rs
+++ b/crates/orbit-cli/src/main.rs
@@ -43,7 +43,7 @@ use orbit_remote::runtime::RemoteRuntimeFactory;
 #[cfg(test)]
 use crate::command::init::InitCommand;
 use crate::command::operation::{CommandOperation, DispatchContext, RuntimeNeed};
-use crate::output::sink::{FormatArg, OutputSink};
+use crate::output::sink::{self, FormatArg, OutputMode, OutputSink};
 
 /// Clap id and long name of the global output-format argument.
 const FORMAT_ARG_ID: &str = "format";
@@ -132,16 +132,20 @@ fn parse_cli() -> (command::Cli, Option<FormatArg>) {
 
 fn main() {
     orbit_common::utility::logging::init_default_subscriber("warn");
+    output::pipe::install_handler();
 
     let (cli, requested_format) = parse_cli();
-    // Resolved once per invocation, before dispatch. Nothing renders through
-    // it yet — see `output::sink` for where this sits in the migration.
+    // Resolved once per invocation, before dispatch, then published so every
+    // renderer reads the same answers instead of re-deriving them.
     let sink = OutputSink::from_process(requested_format);
+    sink::install(sink);
+    sink.apply_color_policy();
     tracing::debug!(
         mode = ?sink.mode(),
         is_tty = sink.is_tty(),
         width = sink.width(),
         color_allowed = sink.color_allowed(),
+        progress_allowed = sink.progress_allowed(),
         "resolved output sink"
     );
     let root_override = cli.root.clone();
@@ -228,15 +232,39 @@ fn finish_command(
     }
 }
 
+/// Report a failed command on **stderr**, in every mode.
+///
+/// The JSON error payload used to go to stdout, which meant a `--json` caller
+/// piping stdout into a parser received an error object where a result was
+/// expected, and had to distinguish the two by shape. Spec §5 puts the payload
+/// on stderr and leaves stdout carrying the payload and nothing else.
+///
+/// **Breaking change**: a script parsing `orbit ... --json` errors off stdout
+/// reads them from stderr now (`2>&1`, or check the exit code, which was
+/// already `1`).
+///
+/// Whether the report is JSON is the command's declared preference when it has
+/// one, and otherwise the sink's mode — `--format json` on a command with no
+/// `--json` flag of its own still gets a machine-readable failure.
 fn print_error(error: &orbit_core::OrbitError, tool_run_json_output: Option<bool>) {
-    if let Some(pretty) = tool_run_json_output {
+    if let Some(pretty) = json_error_format(tool_run_json_output) {
         let payload = crate::output::json::error_payload(error);
-        if crate::output::json::print_with_format(&payload, pretty).is_ok() {
+        if let Ok(rendered) = crate::output::json::render(&payload, pretty) {
+            eprintln!("{rendered}");
             return;
         }
     }
 
     eprintln!("error: {error}");
+}
+
+/// Whether to report an error as JSON, and whether to pretty-print it.
+fn json_error_format(tool_run_json_output: Option<bool>) -> Option<bool> {
+    if let Some(pretty) = tool_run_json_output {
+        return Some(pretty);
+    }
+    let sink = sink::active();
+    matches!(sink.mode(), OutputMode::Json | OutputMode::Ndjson).then(|| sink.pretty_json())
 }
 
 #[cfg(test)]

--- a/crates/orbit-cli/src/output/color.rs
+++ b/crates/orbit-cli/src/output/color.rs
@@ -1,10 +1,22 @@
+//! Semantic roles, and the two renderings of a role-tagged value.
+//!
+//! A call site tags a value with what it *means* — either directly
+//! ([`Role::Ok`] for a healthy-workspace line) or by naming the vocabulary it
+//! came from ([`role_for`]) — and [`cell`] or [`text`] turns that into ANSI.
+//! No call site names a color, and none asks whether color is permitted:
+//! emission is gated once, by the sink, via
+//! [`OutputSink::apply_color_policy`](crate::output::sink::OutputSink::apply_color_policy)
+//! for the `colored` paths here and by `output::table` for the `comfy_table`
+//! ones. See `docs/design/terminal-interface/specs/color-and-styling.md`
+//! (ADR-0308).
+
 use colored::Colorize;
 use comfy_table::{Attribute, Cell, Color as TableColor};
 
 /// The closed set of semantic roles a domain value can carry.
 /// See `docs/design/terminal-interface/specs/color-and-styling.md` (ADR-0308).
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(crate) enum Role {
+pub enum Role {
     Ok,
     Warn,
     Error,
@@ -17,18 +29,19 @@ pub(crate) enum Role {
 /// the same across domains (e.g. `"active"` as a job state vs. `"archived"`
 /// as a task status) so each gets the role its own vocabulary intends.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(crate) enum Domain {
+pub enum Domain {
     TaskStatus,
     Priority,
     TaskType,
     JobState,
     DoctorStatus,
+    AuditStatus,
 }
 
 /// The single value-to-role mapping covering every domain vocabulary in the
 /// crate. Unmapped values resolve to `Role::Neutral` — never a panic, never
 /// an arbitrary color. Adding a status is a one-line edit here.
-pub(crate) fn role_for(domain: Domain, value: &str) -> Role {
+pub fn role_for(domain: Domain, value: &str) -> Role {
     use Domain::*;
     use Role::*;
     match (domain, value) {
@@ -52,13 +65,19 @@ pub(crate) fn role_for(domain: Domain, value: &str) -> Role {
         (DoctorStatus, "warning") => Warn,
         (DoctorStatus, "ERROR" | "error") => Error,
 
+        (AuditStatus, "success") => Ok,
+        (AuditStatus, "failure") => Error,
+        // Denied is a policy outcome, not a fault: it needs attention without
+        // reading as a broken command.
+        (AuditStatus, "denied") => Warn,
+
         // TaskType carries no role today; every value renders neutral.
         _ => Neutral,
     }
 }
 
 impl Role {
-    pub(crate) fn table_color(self) -> Option<TableColor> {
+    pub fn table_color(self) -> Option<TableColor> {
         match self {
             Role::Ok => Some(TableColor::Green),
             Role::Warn => Some(TableColor::Yellow),
@@ -68,7 +87,7 @@ impl Role {
         }
     }
 
-    pub(crate) fn line_color(self) -> Option<colored::Color> {
+    pub fn line_color(self) -> Option<colored::Color> {
         match self {
             Role::Ok => Some(colored::Color::Green),
             Role::Warn => Some(colored::Color::Yellow),
@@ -78,9 +97,48 @@ impl Role {
         }
     }
 
-    pub(crate) fn is_dim(self) -> bool {
+    pub fn is_dim(self) -> bool {
         matches!(self, Role::Muted)
     }
+}
+
+/// How a call site tags a value: with a [`Role`] outright when it knows the
+/// meaning, or with the [`Domain`] the value came from when the mapping table
+/// should decide.
+///
+/// Both spellings exist because both cases are real. `"Workspace healthy."` is
+/// a sentence whose role is `Ok` and which belongs to no vocabulary; a task's
+/// `status` belongs to `TaskStatus` and must get whatever role that table says,
+/// so that adding a status stays a one-line edit in [`role_for`].
+pub trait Tag {
+    /// The role this tag assigns to `value`.
+    fn role_of(self, value: &str) -> Role;
+}
+
+impl Tag for Role {
+    fn role_of(self, _value: &str) -> Role {
+        self
+    }
+}
+
+impl Tag for Domain {
+    fn role_of(self, value: &str) -> Role {
+        role_for(self, value)
+    }
+}
+
+/// A role-tagged value as a table cell.
+///
+/// The role's color is attached unconditionally; whether `comfy_table` emits it
+/// is the sink's call, applied per render in `output::table`.
+pub fn cell(value: &str, tag: impl Tag) -> Cell {
+    cell_for(value, tag.role_of(value))
+}
+
+/// A role-tagged value as a styled line, for the `println!` paths that are not
+/// tables. Emits nothing when the sink disallowed color.
+pub fn text(value: &str, tag: impl Tag) -> String {
+    string_for(value, tag.role_of(value))
 }
 
 fn cell_for(value: &str, role: Role) -> Cell {
@@ -109,42 +167,15 @@ fn string_for(value: &str, role: Role) -> String {
     styled.to_string()
 }
 
-pub fn status_color_cell(status: &str) -> Cell {
-    cell_for(status, role_for(Domain::TaskStatus, status))
-}
-
-pub fn priority_color_cell(priority: &str) -> Cell {
-    cell_for(priority, role_for(Domain::Priority, priority))
-}
-
-pub fn task_type_color_cell(task_type: &str) -> Cell {
-    cell_for(task_type, role_for(Domain::TaskType, task_type))
-}
-
-pub fn job_state_color_cell(state: &str) -> Cell {
-    cell_for(state, role_for(Domain::JobState, state))
-}
-
-pub fn doctor_status_color_cell(status: &str) -> Cell {
-    cell_for(status, role_for(Domain::DoctorStatus, status))
-}
-
-pub fn status_color(status: &str) -> String {
-    string_for(status, role_for(Domain::TaskStatus, status))
-}
-
-pub fn priority_color(priority: &str) -> String {
-    string_for(priority, role_for(Domain::Priority, priority))
-}
-
-pub fn job_state_color(state: &str) -> String {
-    string_for(state, role_for(Domain::JobState, state))
-}
-
+/// Structure, not severity: a field label or the primary identifier column
+/// (spec §3). Never used to mean "worse" — that is what [`Role::Error`] is for.
 pub fn bold(text: &str) -> String {
     text.bold().to_string()
 }
 
+/// De-emphasis for a value the reader may skip. Prefer
+/// `text(value, Role::Muted)` when the dimness is carrying a *meaning*; this is
+/// for incidental chrome such as a bracketed timestamp.
 pub fn dimmed(text: &str) -> String {
     text.dimmed().to_string()
 }

--- a/crates/orbit-cli/src/output/mod.rs
+++ b/crates/orbit-cli/src/output/mod.rs
@@ -1,5 +1,6 @@
 pub mod color;
 pub mod json;
+pub mod pipe;
 pub mod sink;
 pub mod table;
 

--- a/crates/orbit-cli/src/output/pipe.rs
+++ b/crates/orbit-cli/src/output/pipe.rs
@@ -1,0 +1,96 @@
+//! A closed stdout is a normal way for a command to end, not a failure.
+//!
+//! `orbit task list | head -1` closes the read end after one line. The next
+//! `println!` fails with `EPIPE`, and `std::io::_print` responds by panicking —
+//! so the user's terminal fills with a backtrace for having typed `head`.
+//! `docs/design/terminal-interface/specs/output-modes.md` §5 says instead:
+//! exit `0`, silently.
+//!
+//! Two paths reach that outcome, because the crate writes stdout two ways.
+//! [`install_handler`] covers the `println!` family, whose failure mode is a
+//! panic. [`is_broken_pipe`] covers the handful of call sites that hold a
+//! locked writer and get an `io::Error` back instead.
+
+use std::io;
+
+/// Exit `0` instead of panicking when a `println!` fails on a closed stdout.
+///
+/// Installed once, from `main`, before any output. Every other panic reaches
+/// the hook this one replaced, so a genuine bug still reports normally.
+///
+/// The alternative — restoring `SIGPIPE` to `SIG_DFL` so the process dies of
+/// the signal — is also silent, but exits `141`. The spec asks for `0`: a
+/// consumer that read what it wanted and closed the pipe got what it asked
+/// for, and `set -o pipefail` should not turn that into a failed script.
+pub fn install_handler() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        if panicked_on_a_closed_stdout(info) {
+            std::process::exit(0);
+        }
+        previous(info);
+    }));
+}
+
+/// Whether an `io::Error` is the read end of stdout having gone away.
+pub fn is_broken_pipe(error: &io::Error) -> bool {
+    error.kind() == io::ErrorKind::BrokenPipe
+}
+
+fn panicked_on_a_closed_stdout(info: &std::panic::PanicHookInfo<'_>) -> bool {
+    let payload = info.payload();
+    let message = payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&str>().copied())
+        .unwrap_or_default();
+    is_closed_stdout_panic(message)
+}
+
+/// Recognize the panic `std::io::_print` raises when stdout is closed.
+///
+/// The payload is the formatted string `failed printing to stdout: <error>`,
+/// and the error's `Display` ends in `(os error 32)` — `EPIPE` on every unix.
+/// Matching the prefix alone would also swallow a full disk, which is a real
+/// failure and must keep panicking, so both halves have to agree.
+fn is_closed_stdout_panic(message: &str) -> bool {
+    message.starts_with("failed printing to stdout")
+        && (message.contains("os error 32") || message.contains("Broken pipe"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_broken_pipe_io_error_is_recognized() {
+        assert!(is_broken_pipe(&io::Error::from(io::ErrorKind::BrokenPipe)));
+        assert!(!is_broken_pipe(&io::Error::from(io::ErrorKind::WriteZero)));
+    }
+
+    #[test]
+    fn the_panic_std_raises_for_a_closed_stdout_is_recognized() {
+        // Exactly what `std::io::_print` formats, with the error `head`
+        // closing the pipe produces.
+        let raised = format!(
+            "failed printing to stdout: {}",
+            io::Error::from_raw_os_error(32)
+        );
+
+        assert!(is_closed_stdout_panic(&raised), "{raised}");
+    }
+
+    #[test]
+    fn an_unwritable_stdout_still_panics() {
+        let disk_full = format!(
+            "failed printing to stdout: {}",
+            io::Error::from_raw_os_error(28)
+        );
+
+        assert!(
+            !is_closed_stdout_panic(&disk_full),
+            "ENOSPC is a real failure and must not exit 0: {disk_full}"
+        );
+        assert!(!is_closed_stdout_panic("index out of bounds"));
+    }
+}

--- a/crates/orbit-cli/src/output/sink.rs
+++ b/crates/orbit-cli/src/output/sink.rs
@@ -2,18 +2,19 @@
 //!
 //! Resolved once at startup from stdout, the process environment, and the
 //! global `--format` argument, per `docs/design/terminal-interface/specs/output-modes.md`
-//! §1–§2 ([ADR-0306]). Nothing downstream re-derives these answers: the sink is
-//! the only place in this crate that queries terminal state, apart from the
-//! pre-existing local check in `command/log/tail.rs`. That property is enforced
-//! by `scripts/check-terminal-state-guard.sh`.
+//! §1–§2 ([ADR-0306]). Nothing downstream re-derives these answers: this module
+//! is the only place in the crate that queries terminal state, a property
+//! enforced by `scripts/check-terminal-state-guard.sh`.
 //!
-//! This is step 1 of the spec's §7 migration: the sink is *resolved* but not yet
-//! *consumed*, so rendering is byte-for-byte unchanged. Later steps route the
-//! per-command `--json` booleans through [`OutputSink::resolve`]'s `legacy_json`
-//! rung, then let renderers read [`OutputSink::width`] and
-//! [`OutputSink::color_allowed`].
+//! `main` resolves the sink, [`install`]s it, and calls
+//! [`OutputSink::apply_color_policy`]; every renderer then reads [`active`]
+//! rather than asking the environment. Color emission is decided in exactly one
+//! place: `apply_color_policy` overrides the `colored` crate's own env
+//! detection, and `output::table` hands the same answer to `comfy_table`, so the
+//! two styling backends can no longer disagree about `NO_COLOR` [ADR-0308].
 
 use std::io::IsTerminal;
+use std::sync::OnceLock;
 
 use clap::ValueEnum;
 
@@ -109,9 +110,9 @@ impl OutputSink {
             terminal_width,
             requested,
             // Migration step 2 threads the per-command `--json` boolean in
-            // here. Step 1 has no access to it — the flag lives on 86
-            // individual argument structs — so the legacy rung is inert and
-            // every `--json` branch still decides for itself.
+            // here. It lives on 86 individual argument structs, so until those
+            // are converted the legacy rung is inert and every `--json` branch
+            // still decides for itself.
             false,
         )
     }
@@ -162,6 +163,71 @@ impl OutputSink {
     pub fn mode(&self) -> OutputMode {
         self.mode
     }
+
+    /// The width to fit a rendering into, or `None` when the sink has none and
+    /// nothing may be truncated. The `0`-means-no-truncation encoding of
+    /// [`OutputSink::width`] is converted here so no renderer has to know it.
+    pub fn truncate_width(&self) -> Option<usize> {
+        (self.width > 0).then(|| usize::from(self.width))
+    }
+
+    /// Whether a spinner, bar, or ticker may be drawn (spec §6).
+    ///
+    /// A terminal is necessary but not sufficient: `json` and `ndjson` are
+    /// chosen by consumers who are not watching, so they stay silent on a TTY
+    /// too.
+    pub fn progress_allowed(&self) -> bool {
+        self.is_tty && !matches!(self.mode, OutputMode::Json | OutputMode::Ndjson)
+    }
+
+    /// Whether JSON should be pretty-printed: only for a human (spec §3).
+    pub fn pretty_json(&self) -> bool {
+        self.is_tty
+    }
+
+    /// Point the `colored` crate at this sink's answer instead of its own
+    /// environment detection.
+    ///
+    /// `colored` and `comfy_table` each ship a private `NO_COLOR`/TTY probe, and
+    /// they do not agree — that disagreement is why a redirect used to capture
+    /// escape sequences from the line-rendering paths. Overriding here, once,
+    /// makes the sink the single decider for both: `comfy_table` is told
+    /// per-render by `output::table`, and every `colored` call in the crate is
+    /// covered by this override.
+    pub fn apply_color_policy(&self) {
+        colored::control::set_override(self.color_allowed);
+    }
+}
+
+/// A sink for a destination that is not a terminal: no color, no width, plain
+/// rendering. Used before [`install`] runs — in unit tests, and in any code
+/// path that renders before `main` has resolved the real one — because
+/// assuming "no terminal" degrades to correct output, while assuming one
+/// writes escape sequences into a file.
+const PIPED: OutputSink = OutputSink {
+    is_tty: false,
+    width: 0,
+    color_allowed: false,
+    mode: OutputMode::Plain,
+};
+
+static ACTIVE: OnceLock<OutputSink> = OnceLock::new();
+
+/// Publish the sink resolved for this invocation.
+///
+/// Called once, from `main`, before dispatch. A second call is ignored rather
+/// than a panic: the sink is a read-mostly global and a duplicate install is a
+/// programming error worth neither aborting a user's command nor silently
+/// changing rendering halfway through it.
+pub fn install(sink: OutputSink) {
+    if ACTIVE.set(sink).is_err() {
+        tracing::debug!("output sink already installed; ignoring duplicate install");
+    }
+}
+
+/// The sink for this invocation, or [`PIPED`] when none was installed.
+pub fn active() -> OutputSink {
+    ACTIVE.get().copied().unwrap_or(PIPED)
 }
 
 /// `COLUMNS` first, then what the terminal reported, then 0.

--- a/crates/orbit-cli/src/output/table.rs
+++ b/crates/orbit-cli/src/output/table.rs
@@ -7,13 +7,17 @@
 //! [`Table::add_row`] is the only way to add a row and it caps every row at one
 //! line; `comfy_table`'s unbounded row constructor is not reachable from outside
 //! this module.
-
-use std::io::IsTerminal;
+//!
+//! Width and styling both come from `output::sink` (ADR-0306): a zero-width
+//! sink truncates nothing, and a sink that disallows color renders the same
+//! bytes a file redirect would.
 
 use comfy_table::{
     Attribute, Cell, CellAlignment, ColumnConstraint, ContentArrangement, Row, Table as Grid,
     Width, presets,
 };
+
+use crate::output::sink;
 
 /// Spaces between two rendered columns.
 const GUTTER: usize = 2;
@@ -160,8 +164,8 @@ impl Table {
             eprintln!("{}", self.empty_message);
             return;
         }
-        let terminal = std::io::stdout().is_terminal();
-        let rendered = self.render(sink_width(terminal), terminal);
+        let sink = sink::active();
+        let rendered = self.render(sink.truncate_width(), sink.color_allowed());
         for notice in &rendered.notices {
             eprintln!("{notice}");
         }
@@ -171,6 +175,10 @@ impl Table {
     /// Render at an explicit width. `sink_width` of `None` means the sink has no
     /// width and nothing is truncated; `styled` carries whether the sink accepts
     /// ANSI styling.
+    ///
+    /// Both arguments come from the sink in [`Table::print`]. Tests pass them
+    /// directly so geometry and styling are pinned rather than inherited from
+    /// whatever terminal ran `cargo test`.
     pub(crate) fn render(&self, sink_width: Option<usize>, styled: bool) -> Rendered {
         let visible = self.visible_columns();
         let natural = self.natural_widths(&visible);
@@ -180,7 +188,12 @@ impl Table {
         grid.load_preset(presets::NOTHING);
         grid.set_content_arrangement(ContentArrangement::Disabled);
         grid.set_truncation_indicator(ELLIPSIS);
-        if !styled {
+        // Told, never asked. Left to itself `comfy_table` probes stdout and
+        // ignores `NO_COLOR`, which is exactly the disagreement with `colored`
+        // that let a redirect capture escape sequences [ADR-0308].
+        if styled {
+            grid.enforce_styling();
+        } else {
             grid.force_no_tty();
         }
         grid.set_header(layout.iter().map(|(index, _)| {
@@ -384,23 +397,4 @@ fn truncate_middle(value: &str, width: usize) -> String {
     truncated.push_str(ELLIPSIS);
     truncated.extend(&chars[chars.len() - tail..]);
     truncated
-}
-
-/// The width the list must fit into.
-///
-/// Piped output has no width and is never truncated, which keeps a redirected
-/// list carrying whole values. On a terminal, `COLUMNS` wins over the terminal
-/// query so a caller can pin the geometry. Sourcing this from an output sink
-/// instead is ADR-0306's work; the width policy above is what consumes it.
-fn sink_width(terminal: bool) -> Option<usize> {
-    if !terminal {
-        return None;
-    }
-    if let Ok(columns) = std::env::var("COLUMNS")
-        && let Ok(width) = columns.trim().parse::<usize>()
-        && width > 0
-    {
-        return Some(width);
-    }
-    Grid::new().width().map(usize::from)
 }

--- a/crates/orbit-cli/src/output/tests/color.rs
+++ b/crates/orbit-cli/src/output/tests/color.rs
@@ -1,9 +1,6 @@
 use comfy_table::{Attribute, Cell};
 
-use super::super::color::{
-    Domain, Role, doctor_status_color_cell, job_state_color, job_state_color_cell, priority_color,
-    priority_color_cell, role_for, status_color, status_color_cell, task_type_color_cell,
-};
+use super::super::color::{Domain, Role, cell, role_for, text};
 
 fn expected_cell(value: &str, role: Role) -> Cell {
     let cell = Cell::new(value);
@@ -63,6 +60,10 @@ const CASES: &[(Domain, &str, Role)] = &[
     (Domain::DoctorStatus, "ERROR", Role::Error),
     (Domain::DoctorStatus, "error", Role::Error),
     (Domain::DoctorStatus, "unknown", Role::Neutral),
+    (Domain::AuditStatus, "success", Role::Ok),
+    (Domain::AuditStatus, "failure", Role::Error),
+    (Domain::AuditStatus, "denied", Role::Warn),
+    (Domain::AuditStatus, "unknown", Role::Neutral),
 ];
 
 #[test]
@@ -77,29 +78,33 @@ fn mapping_matches_expected_role() {
 }
 
 #[test]
-fn cell_and_string_forms_agree_for_every_mapped_value() {
+fn cell_and_text_forms_agree_for_every_mapped_value() {
     for (domain, value, role) in CASES {
-        match domain {
-            Domain::TaskStatus => {
-                assert_eq!(status_color_cell(value), expected_cell(value, *role));
-                assert_eq!(status_color(value), expected_string(value, *role));
-            }
-            Domain::Priority => {
-                assert_eq!(priority_color_cell(value), expected_cell(value, *role));
-                assert_eq!(priority_color(value), expected_string(value, *role));
-            }
-            Domain::JobState => {
-                assert_eq!(job_state_color_cell(value), expected_cell(value, *role));
-                assert_eq!(job_state_color(value), expected_string(value, *role));
-            }
-            Domain::TaskType => {
-                assert_eq!(task_type_color_cell(value), expected_cell(value, *role));
-            }
-            Domain::DoctorStatus => {
-                assert_eq!(doctor_status_color_cell(value), expected_cell(value, *role));
-            }
-        }
+        assert_eq!(
+            cell(value, *domain),
+            expected_cell(value, *role),
+            "{domain:?}/{value} as a cell"
+        );
+        assert_eq!(
+            text(value, *domain),
+            expected_string(value, *role),
+            "{domain:?}/{value} as a line"
+        );
     }
+}
+
+#[test]
+fn tagging_with_a_role_directly_bypasses_the_domain_table() {
+    // A sentence belongs to no vocabulary, so the call site names the role. It
+    // must not be looked up (and found absent, hence neutral) in one.
+    assert_eq!(
+        text("Workspace healthy.", Role::Ok),
+        expected_string("Workspace healthy.", Role::Ok)
+    );
+    assert_eq!(
+        cell("Workspace healthy.", Role::Ok),
+        expected_cell("Workspace healthy.", Role::Ok)
+    );
 }
 
 #[test]
@@ -109,10 +114,13 @@ fn unmapped_value_is_neutral_and_does_not_panic() {
         Role::Neutral
     );
     assert_eq!(
-        status_color_cell("totally-unknown"),
+        cell("totally-unknown", Domain::TaskStatus),
         Cell::new("totally-unknown")
     );
-    assert_eq!(status_color("totally-unknown"), "totally-unknown");
+    assert_eq!(
+        text("totally-unknown", Domain::TaskStatus),
+        "totally-unknown"
+    );
 }
 
 #[test]
@@ -122,6 +130,6 @@ fn backlog_is_no_longer_inconsistent_between_forms() {
     // style) -- same rendering, but two divergent code paths. Both now go
     // through the same table entry (the wildcard), which this asserts by
     // comparing them directly against the plain, unstyled form.
-    assert_eq!(status_color_cell("backlog"), Cell::new("backlog"));
-    assert_eq!(status_color("backlog"), "backlog");
+    assert_eq!(cell("backlog", Domain::TaskStatus), Cell::new("backlog"));
+    assert_eq!(text("backlog", Domain::TaskStatus), "backlog");
 }

--- a/crates/orbit-cli/src/output/tests/gating.rs
+++ b/crates/orbit-cli/src/output/tests/gating.rs
@@ -1,0 +1,235 @@
+//! The property the sink exists to establish: one decision about color, and
+//! one about width, applied identically by both styling backends.
+//!
+//! `NO_COLOR=1` on a terminal used to be honored by `colored` (the line-
+//! rendering paths) and ignored by `comfy_table` (the table-rendering ones), so
+//! a redirect captured escape sequences from half the CLI. Each test here pins
+//! one half against the other.
+
+use std::sync::{Mutex, MutexGuard};
+
+use serde_json::json;
+
+use crate::command::log::format::format_event_line;
+use crate::output::sink::{OutputSink, SinkEnv};
+use crate::output::table::{Column, Table};
+
+/// The escape byte every ANSI sequence starts with.
+const ESC: char = '\u{1b}';
+
+/// `colored`'s override is process-global, so tests that flip it run one at a
+/// time. Tests that only compare two renderings against each other do not need
+/// this lock — they agree under either global setting.
+static COLOR_OVERRIDE: Mutex<()> = Mutex::new(());
+
+/// Applies a sink's color policy for the duration of the test and restores
+/// `colored`'s own detection afterwards, on panic as well as on success.
+struct ColorPolicy {
+    /// Held, not read: dropping it releases [`COLOR_OVERRIDE`].
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl ColorPolicy {
+    fn apply(sink: &OutputSink) -> Self {
+        let lock = COLOR_OVERRIDE.lock().unwrap_or_else(|err| err.into_inner());
+        sink.apply_color_policy();
+        Self { _lock: lock }
+    }
+}
+
+impl Drop for ColorPolicy {
+    fn drop(&mut self) {
+        colored::control::unset_override();
+    }
+}
+
+/// A terminal wide enough that nothing truncates, with `NO_COLOR` set.
+fn no_color_terminal() -> OutputSink {
+    let env = SinkEnv {
+        no_color: Some("1".to_string()),
+        columns: Some("200".to_string()),
+        ..SinkEnv::default()
+    };
+    OutputSink::resolve(true, &env, Some(200), None, false)
+}
+
+/// A terminal with nothing suppressing color.
+fn plain_terminal() -> OutputSink {
+    OutputSink::resolve(true, &SinkEnv::default(), Some(200), None, false)
+}
+
+/// Stdout redirected to a file: not a terminal, so no width and no color.
+fn redirected() -> OutputSink {
+    OutputSink::resolve(false, &SinkEnv::default(), None, None, false)
+}
+
+fn render_table(sink: &OutputSink) -> String {
+    let mut table = Table::new(vec![
+        Column::new("ID").fixed(),
+        Column::new("STATUS").fixed(),
+        Column::new("TITLE"),
+    ]);
+    table.add_row(vec![
+        comfy_table::Cell::new("ORB-1"),
+        crate::output::color::cell("done", crate::output::color::Domain::TaskStatus),
+        comfy_table::Cell::new("first"),
+    ]);
+    table.add_row(vec![
+        comfy_table::Cell::new("ORB-2"),
+        crate::output::color::cell("blocked", crate::output::color::Domain::TaskStatus),
+        comfy_table::Cell::new("second"),
+    ]);
+    table
+        .render(sink.truncate_width(), sink.color_allowed())
+        .body
+}
+
+fn log_event() -> serde_json::Value {
+    json!({
+        "timestamp": "2026-08-02T03:58:00Z",
+        "level": "ERROR",
+        "target": "orbit.policy.deny",
+        "fields": { "tool": "orbit.task.add", "path": "/tmp/x" },
+    })
+}
+
+// ── The asymmetry this task exists to close ─────────────────────────────────
+
+#[test]
+fn no_color_renders_a_table_byte_for_byte_like_a_redirect() {
+    let suppressed = render_table(&no_color_terminal());
+    let piped = render_table(&redirected());
+
+    assert_eq!(
+        suppressed, piped,
+        "NO_COLOR=1 on a terminal must produce exactly what a file gets"
+    );
+    assert!(
+        !suppressed.contains(ESC),
+        "no escape sequence survives: {suppressed:?}"
+    );
+}
+
+#[test]
+fn no_color_renders_a_line_byte_for_byte_like_a_redirect() {
+    let event = log_event();
+
+    let suppressed = {
+        let sink = no_color_terminal();
+        let _policy = ColorPolicy::apply(&sink);
+        format_event_line(&event, sink.color_allowed())
+    };
+    let piped = {
+        let sink = redirected();
+        let _policy = ColorPolicy::apply(&sink);
+        format_event_line(&event, sink.color_allowed())
+    };
+
+    assert_eq!(
+        suppressed, piped,
+        "the `colored`-backed paths must agree with the `comfy_table`-backed ones"
+    );
+    assert!(
+        !suppressed.contains(ESC),
+        "no escape sequence survives: {suppressed:?}"
+    );
+}
+
+#[test]
+fn a_terminal_without_no_color_still_gets_both_kinds_of_styling() {
+    // Without this the two tests above would pass on a renderer that never
+    // emits color at all.
+    let sink = plain_terminal();
+    let _policy = ColorPolicy::apply(&sink);
+
+    assert!(
+        render_table(&sink).contains(ESC),
+        "a table on a color-allowed terminal is styled"
+    );
+    assert!(
+        format_event_line(&log_event(), sink.color_allowed()).contains(ESC),
+        "a log line on a color-allowed terminal is styled"
+    );
+}
+
+// ── Width comes from the sink ───────────────────────────────────────────────
+
+#[test]
+fn a_zero_width_sink_truncates_nothing() {
+    let sink = redirected();
+    assert_eq!(sink.width(), 0);
+    assert_eq!(
+        sink.truncate_width(),
+        None,
+        "0 means `do not truncate`, never `truncate to nothing`"
+    );
+
+    let mut table = Table::new(vec![Column::new("TITLE")]);
+    let long = "a title far longer than any terminal would ever be, repeated \
+                until it could not possibly fit inside eighty or even two \
+                hundred columns of a real terminal window";
+    table.add_row(vec![comfy_table::Cell::new(long)]);
+    table.add_row(vec![comfy_table::Cell::new("short")]);
+
+    let rendered = table.render(sink.truncate_width(), sink.color_allowed());
+
+    assert!(
+        rendered.body.contains(long),
+        "a redirected list carries whole values: {}",
+        rendered.body
+    );
+    assert!(rendered.notices.is_empty(), "nothing was dropped to fit");
+}
+
+#[test]
+fn a_sized_sink_truncates_to_its_width() {
+    // `NO_COLOR` so a line's byte count is its column count; the width under
+    // test is independent of whether the sink is styled.
+    let env = SinkEnv {
+        columns: Some("40".to_string()),
+        no_color: Some("1".to_string()),
+        ..SinkEnv::default()
+    };
+    let sink = OutputSink::resolve(true, &env, Some(200), None, false);
+
+    assert_eq!(
+        sink.truncate_width(),
+        Some(40),
+        "COLUMNS wins over the terminal's own 200"
+    );
+
+    let mut table = Table::new(vec![Column::new("TITLE")]);
+    table.add_row(vec![comfy_table::Cell::new(
+        "a title far longer than forty columns of terminal",
+    )]);
+    table.add_row(vec![comfy_table::Cell::new("short")]);
+
+    let rendered = table.render(sink.truncate_width(), sink.color_allowed());
+
+    for line in rendered.body.lines() {
+        assert!(line.chars().count() <= 40, "line exceeds the sink: {line}");
+    }
+}
+
+// ── Progress (spec §6) ──────────────────────────────────────────────────────
+
+#[test]
+fn progress_needs_a_terminal_and_a_human_facing_mode() {
+    use crate::output::sink::FormatArg;
+
+    assert!(
+        plain_terminal().progress_allowed(),
+        "an interactive table run may draw progress"
+    );
+    assert!(
+        !redirected().progress_allowed(),
+        "a redirected stream never does"
+    );
+    for format in [FormatArg::Json, FormatArg::Ndjson] {
+        let sink = OutputSink::resolve(true, &SinkEnv::default(), Some(200), Some(format), false);
+        assert!(
+            !sink.progress_allowed(),
+            "{format:?} is chosen by a consumer who is not watching, TTY or not"
+        );
+    }
+}

--- a/crates/orbit-cli/src/output/tests/mod.rs
+++ b/crates/orbit-cli/src/output/tests/mod.rs
@@ -1,3 +1,4 @@
 mod color;
+mod gating;
 mod sink;
 mod table;

--- a/crates/orbit-cli/tests/docs.rs
+++ b/crates/orbit-cli/tests/docs.rs
@@ -638,7 +638,9 @@ fn docs_tools_are_cli_only_and_visible_in_tool_list_all() {
         !output.status.success(),
         "inactive docs tool unexpectedly succeeded through tool run"
     );
-    assert!(String::from_utf8_lossy(&output.stdout).contains("inactive"));
+    // Errors, including the JSON payload, are on stderr [ORB-10570].
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("inactive"));
 
     let output = workspace.run_json(&["docs", "list", "--json"], "docs list");
     assert!(!output.as_array().expect("array").is_empty());

--- a/crates/orbit-cli/tests/learning.rs
+++ b/crates/orbit-cli/tests/learning.rs
@@ -541,8 +541,14 @@ fn executor_context_learning_tools_are_refused_with_the_same_redirect() {
     for (tool, input, echoed) in attempts {
         let output = workspace.try_run_as(&["tool", "run", tool, "--input", input], EXECUTOR);
         assert!(!output.status.success(), "{tool} must be refused");
-        // `tool run` reports failures as a JSON envelope on stdout.
-        let reported: Value = serde_json::from_slice(&output.stdout)
+        // `tool run` reports failures as a JSON envelope on stderr, so
+        // stdout carries the payload and nothing else [ORB-10570].
+        assert!(
+            output.stdout.is_empty(),
+            "{tool} must leave stdout empty on failure: {:?}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        let reported: Value = serde_json::from_slice(&output.stderr)
             .unwrap_or_else(|e| panic!("{tool} produced invalid JSON: {e}"));
         assert_eq!(reported["code"], "policy_denied", "{tool}");
         let message = reported["error"].as_str().unwrap_or_default();

--- a/crates/orbit-cli/tests/tool_list.rs
+++ b/crates/orbit-cli/tests/tool_list.rs
@@ -241,5 +241,8 @@ fn tool_run_rejects_inactive_tools() {
         ])
         .assert()
         .failure()
-        .stdout(predicate::str::contains("inactive"));
+        // The JSON error payload moved to stderr [ORB-10570]; stdout carries
+        // the payload and nothing else.
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("inactive"));
 }

--- a/crates/orbit-cli/tests/worktree_resolution.rs
+++ b/crates/orbit-cli/tests/worktree_resolution.rs
@@ -254,8 +254,10 @@ fn linked_worktree_artifacts_write_locally_and_remote_lists_return_stubs() {
         None,
     );
     assert!(!rejected_update.status.success());
+    // The JSON error payload is on stderr in every mode [ORB-10570].
+    assert!(rejected_update.stdout.is_empty());
     let rejected_payload: Value =
-        serde_json::from_slice(&rejected_update.stdout).expect("structured update error");
+        serde_json::from_slice(&rejected_update.stderr).expect("structured update error");
     assert_eq!(rejected_payload["code"], "artifact_not_local");
     assert_eq!(rejected_payload["artifact_origin"]["mode"], "federated");
     assert!(
@@ -313,8 +315,9 @@ fn linked_worktree_artifacts_write_locally_and_remote_lists_return_stubs() {
     let show_output =
         run_orbit_output(&main_repo, &home, &["adr", "show", &adr_id, "--json"], None);
     assert!(!show_output.status.success());
+    assert!(show_output.stdout.is_empty());
     let unavailable_payload: Value =
-        serde_json::from_slice(&show_output.stdout).expect("structured unavailable error");
+        serde_json::from_slice(&show_output.stderr).expect("structured unavailable error");
     assert_eq!(unavailable_payload["code"], "remote_artifact_unavailable");
     assert_eq!(unavailable_payload["artifact_origin"]["mode"], "federated");
     assert_eq!(
@@ -338,8 +341,9 @@ fn linked_worktree_artifacts_write_locally_and_remote_lists_return_stubs() {
         None,
     );
     assert!(!unknown_output.status.success());
+    assert!(unknown_output.stdout.is_empty());
     let unknown_payload: Value =
-        serde_json::from_slice(&unknown_output.stdout).expect("structured not-found error");
+        serde_json::from_slice(&unknown_output.stderr).expect("structured not-found error");
     assert_eq!(unknown_payload["code"], "not_found");
 }
 

--- a/docs/design/terminal-interface/2_design.md
+++ b/docs/design/terminal-interface/2_design.md
@@ -7,7 +7,7 @@ status: Accepted
 feature: terminal-interface
 doc_role: design
 type: design
-summary: "Current orbit-cli output implementation — borderless single-line tables, one semantic color mapping behind legacy wrappers, sink resolved but unconsumed — and where it still diverges from the specs."
+summary: "Current orbit-cli output implementation — borderless single-line tables sized by the sink, one semantic color mapping gated in one place, errors on stderr — and where it still diverges from the specs."
 tags: [terminal-interface]
 paths: ["crates/orbit-cli/src/output/**", "crates/orbit-cli/src/command/**"]
 related_features: [terminal-interface]
@@ -20,7 +20,7 @@ This document describes what `orbit-cli` renders today. It is deliberately a rec
 
 ## 1. The Output Module
 
-`crates/orbit-cli/src/output/` has three submodules and 601 lines total. `table.rs` owns list rendering, `color.rs` maps domain values to styles, `json.rs` serializes payloads and error envelopes. There is no renderer abstraction above them: they are helper functions that command bodies call directly. `table.rs` is the one module with a rendering policy of its own rather than a pass-through to a library (§2).
+`crates/orbit-cli/src/output/` has five submodules. `table.rs` owns list rendering, `color.rs` maps domain values to roles, `json.rs` serializes payloads and error envelopes, `sink.rs` resolves and publishes the invocation's rendering answers, `pipe.rs` turns a closed stdout into a silent exit. There is no renderer abstraction above them: they are helper functions that command bodies call directly. `table.rs` is the one module with a rendering policy of its own rather than a pass-through to a library (§2).
 
 `json.rs` is the closest thing to a contract. It owns `error_payload`, which projects an `OrbitError` into `{error, code}` plus optional `did_you_mean`, `artifact_origin`, and task-bundle corruption fields. Error output is therefore already payload-shaped in a way that normal output is not. Two caveats: the `code` discriminator gained a `_ => "internal_error"` catch-all when `OrbitError` became `#[non_exhaustive]` [ORB-10356], so an unmapped variant degrades silently rather than failing to compile; and a `RemoteTool` error returns the remote payload verbatim, bypassing the shape entirely, so a consumer cannot assume `code` is present.
 
@@ -30,29 +30,33 @@ This document describes what `orbit-cli` renders today. It is deliberately a rec
 
 Rendering applies the `NOTHING` preset with `ContentArrangement::Disabled`, two-space right padding on every column but the last, and a dim header row. Widths are computed from the result set: natural widths first, then flexible columns shrink widest-first to a floor of 8, then flexible columns drop from the right with a notice on stderr. Fixed columns never move. Overflow truncates with `…` — tail truncation is `comfy_table`'s, middle truncation (`Column::path`) is applied before the grid sees the cell.
 
-Two selection rules run before layout: a column whose value is identical in every row of a result set is suppressed unless the caller marked it `filtered` (the user filtered on it) or the view opted out with `keep_all_columns`, and a result set with no records prints its empty-state line to stderr, leaving stdout empty. Satisfies [./specs/table-rendering.md](./specs/table-rendering.md) §§1–6 [ADR-0307]. **Still diverges on §1's plain form** — the header renders in the piped form too, because mode resolution has not landed [ADR-0306] — and on width *sourcing*: `sink_width` reads `COLUMNS` and the terminal directly rather than an output sink. [./references/detail-commands.md](./references/detail-commands.md) records which truncatable column has a detail command and which four views still lack one.
+Two selection rules run before layout: a column whose value is identical in every row of a result set is suppressed unless the caller marked it `filtered` (the user filtered on it) or the view opted out with `keep_all_columns`, and a result set with no records prints its empty-state line to stderr, leaving stdout empty. Satisfies [./specs/table-rendering.md](./specs/table-rendering.md) §§1–6 [ADR-0307]. Width and styling are both read from the sink in `Table::print` [ORB-10570], so a zero-width sink truncates nothing and a sink that disallows color renders the bytes a file would get. **Still diverges on §1's plain form** — the header renders in the piped form too, because a command body has yet to return a payload the renderer can project [ADR-0306]. [./references/detail-commands.md](./references/detail-commands.md) records which truncatable column has a detail command and which four views still lack one.
 
-## 3. Hand-Padded Line Output
+## 3. Line Output
 
-Not every list goes through `build_table`. `orbit audit list` prints each event through `print_audit_event_line` in `command/audit/support.rs`, a single `println!` with the format string `"[{}] {:<8} {:<6} {}:{:<20} {}ms"`.
+The last hand-padded list is gone. `orbit audit list` used to print each event through `print_audit_event_line` in `command/audit/support.rs`, a single `println!` with the format string `"[{}] {:<8} {:<6} {}:{:<20} {}ms"` — literal widths that held only while every value fit, no header, and a left-aligned duration carrying its unit per row. It now builds a `Table` with computed widths, a header, a `filtered` flag per filterable column, and a right-aligned `DURATION (ms)` [ORB-10570]. Satisfies [./specs/table-rendering.md](./specs/table-rendering.md) §2 and §3.
 
-The column widths are literals, not functions of the result set, so alignment holds only while every value fits — a tool name longer than 20 characters shifts the duration column for that row alone. There is no header, so the columns are unlabeled. The duration is left-aligned with a trailing unit, so `187ms` and `0ms` do not align on their magnitudes. **Diverges from [./specs/table-rendering.md](./specs/table-rendering.md) §2 and §3** (computed widths, right-aligned numerics).
-
-98 modules under `command/` call `println!` directly for some part of their output, so this is a pattern rather than an isolated case — a consequence of the flattened per-command layout [ORB-00279], where each module owns its rendering end to end.
+98 modules under `command/` still call `println!` directly for some part of their output — detail views, field labels, confirmations — so line output remains a pattern rather than an isolated case, a consequence of the flattened per-command layout [ORB-00279], where each module owns its rendering end to end. What those `println!`s emit is now gated: every styled string goes through `output::color`, whose `colored` backend is overridden from the sink at startup.
 
 This file is also where the drift between the two renderings is easiest to see. [ORB-10228] added trusted session-context fields (`workspace_id`, `caller_machine_id`, `transport`, `mcp_call_id`) to `audit_event_to_json` in the same file, and left `print_audit_event_line` untouched. The JSON view gained provenance the human view has never shown, and nothing flagged the asymmetry.
 
-## 4. Two Color Vocabularies
+## 4. One Color Vocabulary
 
-`color.rs` defines the same mappings twice in incompatible types. Five functions — `status_color_cell`, `priority_color_cell`, `job_state_color_cell`, `doctor_status_color_cell`, `task_type_color_cell` — return `comfy_table::Cell` values for table rows. Three — `status_color`, `priority_color`, `job_state_color` — return `String` values styled by the `colored` crate for line output. The backend is chosen by the call site's rendering shape, not by the value's meaning. `doctor_status_color_cell` and `task_type_color_cell` have no String counterpart, so the pairing is not even consistent; `task_type_color_cell` applies no styling at all and exists only to satisfy the cell-returning shape.
+`color.rs` holds a single `role_for(Domain, &str) -> Role` table covering task status, priority, task type, job state, doctor status, and audit status together, and two renderings of a tagged value: `cell(value, tag)` for a table row and `text(value, tag)` for a line. A `tag` is either a `Role` the call site names outright — `text("Workspace healthy.", Role::Ok)` — or the `Domain` the value came from, which the table resolves. Unmapped values are `Neutral`, never a panic.
 
-The copies have already drifted: `status_color` maps `backlog` explicitly, `status_color_cell` does not. The two-edit cost is visible in the history — [T20260427-43] added a `friction` arm to both functions, and [ORB-10202] removed it from both when the status was retired. The palette itself is broader than a closed role set — `in-progress` is cyan, `review` is magenta, `done` is bold green — so it encodes more distinctions than the target vocabulary. **Diverges from [./specs/color-and-styling.md](./specs/color-and-styling.md)** [ADR-0308].
+The eight per-domain wrappers this replaced (`status_color`/`_cell`, `priority_color`/`_cell`, `job_state_color`/`_cell`, `doctor_status_color_cell`, `task_type_color_cell`) are gone, and with them the two-edit cost visible in the history — [T20260427-43] added a `friction` arm to two functions, [ORB-10202] removed it from two — and the `backlog` drift between the pair. Adding a status is now one line in one table. Satisfies [./specs/color-and-styling.md](./specs/color-and-styling.md) §1 [ADR-0308].
 
-## 5. Sink Resolution Without Consumers
+**Still diverges on §3's palette depth.** `comfy_table` renders `Color::Green` through `crossterm` as `\e[38;5;10m`, a 256-color code, while `colored` renders the same role as `\e[32m`. The spec asks for 16-color ANSI only; the two backends therefore still disagree about the *shade*, though no longer about *whether* to emit. **Still diverges on §3's uniform-filter rule**: a column the caller filtered on stays on screen but is still painted, in every list command.
 
-`output/sink.rs` resolves `is_tty`, `width`, `color_allowed`, and the output mode once per invocation, from `main.rs`, ahead of dispatch [ORB-10569]. It is the only place in the crate that queries terminal state — `COLUMNS`, `TIOCGWINSZ`, `NO_COLOR`, `CLICOLOR_FORCE`, `IsTerminal` — enforced by `scripts/check-terminal-state-guard.sh`, whose allowlist carries the one grandfathered exception: `command/log/tail.rs` still calls `stdout.is_terminal()` locally to decide whether to colorize the tailed stream.
+## 5. Sink Resolution
 
-**Nothing consumes the answers yet.** That is step 1 of [./specs/output-modes.md](./specs/output-modes.md) §7, which deliberately changes no rendering: the sink is resolved and logged at `debug`, and every command still renders exactly as it did. So the emission problems below are unchanged. The two styling backends still disagree — `colored` internally honors `NO_COLOR` and TTY state; `comfy_table::Color` writes escape sequences unconditionally — so `NO_COLOR=1 orbit task list` still emits color from the table path, redirecting a table command to a file still captures ANSI and box-drawing glyphs, and `comfy-table` still takes width from the terminal even when there is no terminal. **Still diverges from [./specs/output-modes.md](./specs/output-modes.md) §1** until a renderer reads the sink [ADR-0306], [ADR-0308].
+`output/sink.rs` resolves `is_tty`, `width`, `color_allowed`, and the output mode once per invocation, from `main.rs`, ahead of dispatch [ORB-10569]. It is the only place in the crate that queries terminal state — `COLUMNS`, `TIOCGWINSZ`, `NO_COLOR`, `CLICOLOR_FORCE`, `IsTerminal` — enforced by `scripts/check-terminal-state-guard.sh`, which no longer carries a grandfathered exception: `command/log/tail.rs` reads `sink::active().color_allowed()` [ORB-10570].
+
+`main` publishes the resolved sink into a `OnceLock` (`sink::install`) and calls `sink.apply_color_policy()`, which overrides `colored`'s own detection process-wide. Renderers read `sink::active()`; before `install` runs — in unit tests, and in any path that renders early — `active()` answers with a piped sink, so the failure mode is "no color, no truncation" rather than escape sequences in a file. The sink is a global rather than a parameter because `Execute::execute` takes no renderer argument; threading one through all 154 impls is the same signature change §9 describes and is deferred with it. §9 records the cost.
+
+Both backends are now told, never asked: `Table::render` calls `enforce_styling()` or `force_no_tty()` from `sink.color_allowed()`, and `colored` is overridden at startup. `NO_COLOR=1` on a terminal therefore produces byte-identical output to a redirect on both a table-rendering and a line-rendering command, asserted in `src/output/tests/gating.rs` and verified on-box under a pty. Table width comes from `sink.truncate_width()`, so a zero-width sink truncates nothing. Satisfies [./specs/output-modes.md](./specs/output-modes.md) §1 and [./specs/color-and-styling.md](./specs/color-and-styling.md) §2 [ADR-0306], [ADR-0308].
+
+**Mode is resolved but still largely unconsumed.** `sink.mode()` selects the shape of an *error* payload (§7) and gates progress, but a successful command still renders through its own `--json` branch, because command bodies do not yet return payloads. **Still diverges from [./specs/output-modes.md](./specs/output-modes.md) §2–§3** on the plain form and on `ndjson`, which no command emits.
 
 ## 6. Per-Command Structured Output
 
@@ -60,19 +64,23 @@ The copies have already drifted: `status_color` maps `backlog` explicitly, `stat
 
 Because both branches are written by hand in the same function, they drift. `orbit tool list` emits seven JSON fields (`name`, `description`, `enabled`, `active`, `status`, `builtin`, `parameters`) and five table columns, and the table's `REQUIRED INPUT` column is a summary string produced by `format_required_tool_input_summary` that exists in no payload field. There is also no `ndjson` mode: `--json` on a list command emits one pretty-printed array, which a streaming consumer must buffer whole. **Diverges from [./specs/output-modes.md](./specs/output-modes.md)** [ADR-0306].
 
-A global `--format auto|table|json|ndjson` is accepted on every command that does not already own a `--format` — `audit export` and `hook pretooluse` do, with unrelated value types, and keep theirs. It resolves a mode through §2's precedence and no further: no command body reads the result yet, so passing it is currently inert. `--json` remains the only flag that changes output, unchanged byte for byte [ORB-10569].
+A global `--format auto|table|json|ndjson` is accepted on every command that does not already own a `--format` — `audit export` and `hook pretooluse` do, with unrelated value types, and keep theirs. It resolves a mode through §2's precedence, and on the success path no command body reads the result yet, so passing it changes nothing a command prints [ORB-10569]. On the failure path it is load-bearing: `--format json` on a command with no `--json` flag of its own still produces a machine-readable error payload [ORB-10570].
 
 ## 7. Empty States and Errors
 
-Empty results are handled inconsistently. `command/policy/list.rs` and `command/task/artifacts.rs` print a sentence (`"No policy definitions found."`); most list commands print a header row with no body beneath it. Errors are routed through `main.rs::print_error`, which emits the JSON error payload when the command declared a JSON preference and a plain message otherwise — this is the one place in the CLI where output mode is resolved centrally rather than inline, and it is the shape the rest of the surface should follow.
+Empty results are handled inconsistently. `command/policy/list.rs` and `command/task/artifacts.rs` print a sentence (`"No policy definitions found."`); list commands that render through `Table` print their empty-state line to stderr and leave stdout empty.
 
-Errors are printed to stdout on the JSON path via `json::print_with_format`, not to stderr.
+Errors are routed through `main.rs::print_error`, which emits the JSON error payload when the command declared a JSON preference *or* the sink resolved a JSON mode, and a plain message otherwise. **Both go to stderr, in every mode** [ORB-10570]. This is a breaking change for any script that parsed the error object off stdout; the exit code (`1`, or `2` for a clap usage error) was already the reliable signal and is unchanged.
+
+A closed stdout is not an error. `output/pipe.rs` installs a panic hook that turns the `failed printing to stdout: … (os error 32)` panic `println!` raises into a silent `exit(0)`, and `log tail` maps a `BrokenPipe` write error to `Ok`. `orbit audit list --limit 20000 | head -1` (2.5 MB, well past the pipe buffer) exits 0 with empty stderr. Satisfies [./specs/output-modes.md](./specs/output-modes.md) §5.
 
 ## 8. Test Coverage of Output
 
 There are no output snapshots. `crates/orbit-cli/src/snapshots/` holds a single file, `audit_guard_event_json_shapes.json`, covering audit event JSON shape; `crates/orbit-cli/tests/snapshots/` holds one more, `mcp_tools_list.json`, covering the MCP tool listing. Both assert on JSON.
 
-The first rendering assertions arrived with the borderless migration [ORB-10567] and are written as behavior, not golden files. `src/output/tests/table.rs` renders at pinned widths — passed as an argument rather than read from `COLUMNS`, so a `--nocapture` run cannot change the geometry — and asserts line count, gutter, truncation, alignment, column suppression, and column dropping. `tests/table_rendering.rs` runs the binary and asserts that an *N*-record `orbit tool list --all` and `orbit task list` are *N* body lines under one header with no box glyphs, and that a zero-result list leaves stdout empty. Nothing yet asserts on ANSI emission.
+The first rendering assertions arrived with the borderless migration [ORB-10567] and are written as behavior, not golden files. `src/output/tests/table.rs` renders at pinned widths — passed as an argument rather than read from `COLUMNS`, so a `--nocapture` run cannot change the geometry — and asserts line count, gutter, truncation, alignment, column suppression, and column dropping. `tests/table_rendering.rs` runs the binary and asserts that an *N*-record `orbit tool list --all` and `orbit task list` are *N* body lines under one header with no box glyphs, and that a zero-result list leaves stdout empty.
+
+`src/output/tests/gating.rs` asserts ANSI emission [ORB-10570]: that a `NO_COLOR` terminal and a redirect render byte-identically on both a table and a log line, that a terminal *without* `NO_COLOR` renders escapes through both backends (so the equality tests cannot pass vacuously), that a zero-width sink truncates nothing, and that progress is refused off a terminal and in `json`/`ndjson`. Sinks are built with `OutputSink::resolve`, never `from_process`, because `make ci` runs without a TTY. The one test that flips `colored`'s process-global override serializes on a module mutex and restores detection on drop.
 
 ## 9. Concerns & Honest Limitations
 
@@ -80,13 +88,17 @@ The first rendering assertions arrived with the borderless migration [ORB-10567]
 
 **The refactor's cost is concentrated in a trait signature.** `Execute::execute` returns `Result<(), OrbitError>` and writes to stdout as a side effect. Making commands return payloads changes that signature across all 154 `impl Execute` blocks, which is a single mechanical change but an unavoidably wide one. It cannot be landed incrementally per command without a transitional dual path.
 
-**Terminal width detection needed no new dependency.** `comfy-table` still resolves width internally for the tables it draws; the sink asks `TIOCGWINSZ` through the `libc` dependency `orbit-cli` already carries on unix, after `COLUMNS`. Non-unix has no query and falls back to `COLUMNS` alone. The 0 fallback ("do not truncate") is asserted in the sink's tests but still untested against a real consumer, because nothing renders through the sink yet.
+**Terminal width detection needed no new dependency.** The sink asks `TIOCGWINSZ` through the `libc` dependency `orbit-cli` already carries on unix, after `COLUMNS`. Non-unix has no query and falls back to `COLUMNS` alone. `comfy-table` no longer resolves width for the tables it draws — `Table::render` passes an absolute constraint per column — so the 0 fallback ("do not truncate") reaches a real consumer and is asserted against one.
 
 **The role vocabulary is lossy on purpose and may be wrong.** Collapsing `in-progress`, `review`, and `proposed` into `active`/`neutral` discards distinctions operators may be reading today. No one has checked whether the current colors are load-bearing in practice.
 
 **Accessibility is unaudited.** The palette has never had a contrast check against common terminal themes, and the specs' "color is never the sole carrier" rule is asserted, not verified.
 
-**Nothing is enforced.** These are documents. There is no lint that rejects a new `comfy_table::Table` in a command body or a new bare `println!` of tabular data.
+**Little is enforced.** `scripts/check-terminal-state-guard.sh` rejects a new terminal-state query outside the sink, and `Table::add_row` makes a multi-line row unreachable. Nothing rejects a new `comfy_table::Table` in a command body, a new bare `println!` of tabular data, or a `colored` call that bypasses `output::color` — the last is currently harmless only because the process-wide override catches it.
+
+**The sink is a process global.** `sink::active()` is a `OnceLock` read, so a renderer's behavior depends on whether `main` ran. Unit tests get the piped default — the safe answer, but not the one an interactive run gets — so a test that means to exercise the terminal path has to build a sink explicitly and pass it in; `Table::render(width, styled)` exists for that, and `Table::print()` is the only function that reads the global. A future in-process consumer (a test harness, an embedded invocation) cannot render two different sinks concurrently.
+
+The alternative — threading the sink through `Execute::execute` — is the correct end state and is exactly [./specs/output-modes.md](./specs/output-modes.md) §7 step 3's signature change. It was not done here because it would have held the `NO_COLOR` fix behind a 154-impl refactor. Having each renderer call `OutputSink::from_process()` was also rejected: it re-derives terminal state per render, which is the drift [ADR-0306] exists to remove, and defeats the guard script. **This decision has no ADR yet** — the ADR store was not writable in the runner that landed [ORB-10570]; [ORB-10585] tracks filing it, and carries the drafted body.
 
 ## Task References
 
@@ -97,5 +109,7 @@ The first rendering assertions arrived with the borderless migration [ORB-10567]
 - [ORB-10228] — added trusted MCP session context to the audit event JSON payload, but not to the printed line.
 - [ORB-10356] — made `OrbitError` `#[non_exhaustive]`, adding the `internal_error` catch-all to the payload's `code` discriminator.
 - [ORB-10569] — introduced `output/sink.rs` and the global `--format`, resolved once per invocation and not yet consumed.
+- [ORB-10570] — wired the sink into color and width, retired the eight color wrappers and the hand-padded `audit list` line, and moved errors to stderr.
+- [ORB-10585] — files the ADR for the process-global sink, which [ORB-10570] could not allocate.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/terminal-interface/specs/color-and-styling.md
+++ b/docs/design/terminal-interface/specs/color-and-styling.md
@@ -1,7 +1,7 @@
 ---
 type: design
 summary: "Spec: Color and Styling"
-last_validated: 2026-08-01
+last_validated: 2026-08-02
 ---
 
 # Spec: Color and Styling
@@ -41,7 +41,7 @@ Resolved once, at the sink, in this precedence:
 
 `TERM=dumb` forces off regardless of 3 and 4.
 
-**Invariant:** exactly one place in the crate reads these. A call site that consults `NO_COLOR` itself is a defect, including the existing local check in `command/log/tail.rs`.
+**Invariant:** exactly one place in the crate reads these — `output/sink.rs`, enforced by `scripts/check-terminal-state-guard.sh`. A call site that consults them itself is a defect. Because the two styling crates each ship their own probe, "one place" also means the sink must *override* them rather than agree with them: `OutputSink::apply_color_policy` sets `colored`'s global override, and `output::table` passes `enforce_styling`/`force_no_tty` per render. Neither backend is left to ask.
 
 ## 3. Rules
 
@@ -65,9 +65,11 @@ Resolved once, at the sink, in this precedence:
 
 ## 6. Migration
 
-1. Define the role enum and the single domain-value mapping table.
-2. Reimplement the eight existing `*_color*` functions as thin wrappers over it, so no call site changes yet and the drift is fixed immediately.
-3. Move emission gating into the sink; delete the local `is_terminal` check in `command/log/tail.rs`.
-4. Once the sink owns gating, replace the wrappers with role-tagged values at each call site and delete the wrappers.
+1. ~~Define the role enum and the single domain-value mapping table.~~ Done.
+2. ~~Reimplement the eight existing `*_color*` functions as thin wrappers over it, so no call site changes yet and the drift is fixed immediately.~~ Done — this alone resolved the `backlog` inconsistency between `status_color` and `status_color_cell`.
+3. ~~Move emission gating into the sink; delete the local `is_terminal` check in `command/log/tail.rs`.~~ Done [ORB-10570].
+4. ~~Replace the wrappers with role-tagged values at each call site and delete the wrappers.~~ Done [ORB-10570]. A call site now passes either a `Role` it names outright or the `Domain` the value came from; `cell(value, tag)` and `text(value, tag)` are the only two renderings.
 
-Step 2 alone resolves the `backlog` inconsistency between `status_color` and `status_color_cell` and is worth landing on its own.
+**Remaining gap:** §3's "16-color ANSI only" is not met on the table path. `comfy_table` renders a role's color through `crossterm` as a 256-color code (`\e[38;5;10m` for green) while `colored` renders the same role as `\e[32m`. Both honor the sink's decision about *whether* to emit; they disagree about the shade. Closing it means either mapping roles to raw SGR codes and bypassing `comfy_table::Color`, or accepting the 256-color spelling and amending §3.
+
+**Remaining gap:** §3's "never restyle a value the user is filtering on" is unimplemented. `Column::filtered` keeps such a column on screen, but the cell is still painted, in every list command.

--- a/docs/design/terminal-interface/specs/output-modes.md
+++ b/docs/design/terminal-interface/specs/output-modes.md
@@ -1,7 +1,7 @@
 ---
 type: design
 summary: "Spec: Output Modes and Sink Resolution"
-last_validated: 2026-08-01
+last_validated: 2026-08-02
 ---
 
 # Spec: Output Modes and Sink Resolution
@@ -63,7 +63,7 @@ Precedence, first match wins:
 ## 5. Streams
 
 - **stdout carries the payload and nothing else.** Progress, warnings, counts, empty-state prose, and diagnostics go to stderr, in every mode.
-- **Errors go to stderr.** In `json`/`ndjson` modes an error is a single JSON object on stderr using the existing `error_payload` shape (`error`, `code`, and the optional `did_you_mean` / `artifact_origin` / task-bundle fields); in other modes it is a plain message. This is a change from current behavior, which writes the JSON error payload to stdout.
+- **Errors go to stderr.** In `json`/`ndjson` modes an error is a single JSON object on stderr using the existing `error_payload` shape (`error`, `code`, and the optional `did_you_mean` / `artifact_origin` / task-bundle fields); in other modes it is a plain message. Implemented in [ORB-10570]; the payload previously went to stdout, which is a **breaking change** for a script that parsed it there.
 - **Exit codes are load-bearing.** `0` success, `1` command failure, `2` usage error. A command that printed an error object must not exit `0`.
 - **A broken pipe is not an error.** `EPIPE` on stdout exits `0` silently — `orbit task list | head` must not print a panic.
 
@@ -75,10 +75,12 @@ Precedence, first match wins:
 
 ## 7. Migration
 
-1. Introduce the sink and the global `--format`; leave every command body untouched. `auto` initially resolves to today's rendering, so nothing changes yet.
-2. Route the existing per-command `--json` branches through the resolver so precedence is centralized. Still no behavior change for explicit callers.
-3. Convert command bodies to return payloads. This changes `Execute::execute`'s signature across all 154 `impl Execute` blocks and is the expensive step; it can be staged with a transitional trait method that defaults to the current side-effecting path.
-4. Once a command returns a payload, delete its inline table construction and let the renderer own it.
-5. Move error output to stderr and audit exit codes.
+1. ~~Introduce the sink and the global `--format`; leave every command body untouched.~~ Done [ORB-10569].
+2. Route the existing per-command `--json` branches through the resolver so precedence is centralized. Still no behavior change for explicit callers. **Not started** — the flag lives on 86 argument structs and `OutputSink::resolve`'s `legacy_json` rung is still passed `false`.
+3. Convert command bodies to return payloads. This changes `Execute::execute`'s signature across all 154 `impl Execute` blocks and is the expensive step; it can be staged with a transitional trait method that defaults to the current side-effecting path. **Not started.**
+4. Once a command returns a payload, delete its inline table construction and let the renderer own it. **Not started.**
+5. ~~Move error output to stderr and audit exit codes.~~ Done [ORB-10570].
 
-Step 5 is the only user-visible break for existing scripts (an error object moves from stdout to stderr). Call it out in the changelog rather than shipping it quietly.
+Steps 1 and 5 landed out of order deliberately: gating color and width at the sink (step 1's payoff) and moving errors off stdout (step 5) are both independent of the payload conversion, and holding them behind a 154-impl signature change would have left `NO_COLOR` broken for the duration.
+
+Step 5 is the only user-visible break for existing scripts (an error object moves from stdout to stderr). It is recorded against [ORB-10570] for the release drafter; per `RELEASING.md` step 2, `CHANGELOG.md` is compiled at release time rather than accumulated per-PR, so the entry is written there, not here. Do not ship it quietly.

--- a/scripts/check-terminal-state-guard.sh
+++ b/scripts/check-terminal-state-guard.sh
@@ -7,10 +7,10 @@ set -euo pipefail
 # command that re-derives any of it renders differently from the sink that
 # resolved the invocation, which is the drift the sink exists to remove.
 #
-# command/log/tail.rs is the one grandfathered exception: it colorizes a
-# streamed tail from a local `is_terminal()` check, and a dependent task in the
-# staged migration removes it. Nothing may be added to the allowlist without
-# that being a decision.
+# There is no longer a grandfathered exception: command/log/tail.rs used to
+# colorize a streamed tail from a local `is_terminal()` check, and [ORB-10570]
+# replaced it with `sink::active().color_allowed()`. Nothing may be added to
+# the allowlist without that being a decision.
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$repo_root"
@@ -25,7 +25,8 @@ cli_src="crates/orbit-cli/src"
 allowed=(
   "$cli_src/output/sink.rs"
   "$cli_src/output/tests/sink.rs"
-  "$cli_src/command/log/tail.rs"
+  # Asserts the gate the sink resolves, so it names the variables on purpose.
+  "$cli_src/output/tests/gating.rs"
 )
 
 # `IsTerminal` covers `x.is_terminal()` too: the trait must be imported by name
@@ -44,6 +45,13 @@ for pattern in "${patterns[@]}"; do
   while IFS= read -r hit; do
     [[ -z "$hit" ]] && continue
     file="${hit%%:*}"
+    # Naming a variable in prose is not querying it. Doc comments have to be
+    # able to say which variables the sink reads and why a call site stopped
+    # reading them, or the rule cannot be explained where it is enforced.
+    code="${hit#*:*:}"
+    if [[ "${code#"${code%%[![:space:]]*}"}" == //* ]]; then
+      continue
+    fi
     permitted=0
     for allow in "${allowed[@]}"; do
       if [[ "$file" == "$allow" ]]; then


### PR DESCRIPTION
## Task

[ORB-10570](https://orbit-cli.com/tasks/ORB-10570) — Gate color and width at the sink and retire the hand-padded output paths

### Description

## Problem

Three pieces exist in isolation and nothing connects them. The sink knows whether stdout is a terminal, how wide it is, and whether color is permitted — but nothing consumes those answers. The color module resolves values to semantic roles behind wrappers that still emit unconditionally. The table module applies a width policy against a width the table library resolved, not the one the sink computed.

The observable failures that remain: `NO_COLOR=1` is honored on the paths backed by one styling crate and ignored on the paths backed by the other, so a redirect still captures escape sequences. `orbit audit list` still prints through a format string whose column widths are literals rather than functions of the data, so a value wider than its literal breaks the column and there is no header at all. One command still asks about the terminal locally instead of asking the sink.

## Contract

`docs/design/terminal-interface/specs/output-modes.md` §1, §2, §5 and `docs/design/terminal-interface/specs/color-and-styling.md` §2, §4 are the reviewed contract, decided in ADR-0306 and ADR-0308. Read both before starting.

## Depends on

The sink, the role mapping, and the borderless table work must all be merged first. This task is the integration that makes them mean something.

## Scope and constraints

- In scope: wiring the sink into the color and table modules, `crates/orbit-cli/src/command/log/tail.rs`, `crates/orbit-cli/src/command/audit/support.rs`, and `crates/orbit-cli/src/main.rs` for error routing.
- Retire the color wrapper functions once call sites tag values with roles instead. Editing call sites is expected here — it was deliberately deferred to this task so it would not collide with concurrent work.
- Moving errors from stdout to stderr is a **breaking change for any script parsing errors off stdout.** Land it, and say so explicitly in the changelog entry. Do not ship it silently.
- Do not convert command bodies to return payloads. That remains a separate task.

## Acceptance criteria

- Color emission is decided in exactly one place, following the spec's precedence, and no call site consults `NO_COLOR` or terminal state. The local check in `command/log/tail.rs` is gone.
- `NO_COLOR=1` produces byte-identical output to redirecting to a file, on both a table-rendering command and a line-rendering command. Test both — this is the specific asymmetry the work exists to close.
- Table width comes from the sink, so a zero-width sink truncates nothing.
- `orbit audit list` renders through the table path: computed column widths, a header, and a right-aligned duration column.
- Errors and the JSON error payload go to stderr in every mode; stdout carries the payload and nothing else. Exit codes follow the spec, and a broken pipe exits zero without a panic — assert `orbit <list command> | head -1` is silent.
- No progress output is emitted in `json` or `ndjson`, or when stdout is not a TTY.
- `make ci` passes.

## Verification note

Verify on-box under `cargo nextest`, both with a populated environment and with `NO_COLOR`, `CLICOLOR_FORCE`, and `COLUMNS` scrubbed. GitHub CI sets none of these, so a green CI run does not validate this task's core behavior.

### Acceptance Criteria

- Color emission decided in exactly one place; log/tail.rs local check removed
- NO_COLOR=1 output byte-identical to a file redirect, on both a table and a line command
- Table width sourced from the sink; zero-width sink truncates nothing
- orbit audit list renders through the table path with computed widths, a header, right-aligned duration
- Errors and JSON error payload on stderr in every mode; stdout carries only the payload
- Broken pipe exits zero silently
- No progress output in json/ndjson or on a non-TTY
- cargo build -p orbit-cli and cargo test -p orbit-cli pass; pre-existing failures on the base branch are reported, not repaired

## Execution Summary

<details>
<summary>Click to expand</summary>

Wired the output sink into color and width, retired the hand-padded output
paths, and moved errors to stderr. Contract: specs/output-modes.md 1/2/5 and
specs/color-and-styling.md 2/4 (ADR-0306, ADR-0308).

## One decision about color

`main` publishes the resolved sink into a `OnceLock` (`sink::install`) and calls
`sink.apply_color_policy()`, which overrides the `colored` crate's own env
detection process-wide. `Table::render` tells `comfy_table` the same answer per
render (`enforce_styling` / `force_no_tty`) instead of letting it probe stdout
and ignore NO_COLOR. Neither backend asks any more, so the asymmetry that let a
redirect capture escape sequences from half the CLI is closed.

`command/log/tail.rs` reads `sink::active().color_allowed()`; its local
`is_terminal()` check is gone, and `scripts/check-terminal-state-guard.sh` no
longer carries a grandfathered allowlist entry for it. The guard also stopped
matching comments, so a doc comment may now name the variables it forbids
querying (it still catches a real query -- verified by probe).

## Roles at the call sites

Deleted the eight `*_color*` wrappers. `output::color` now exposes
`cell(value, tag)` and `text(value, tag)`, where `tag` is either a `Role` the
call site names outright (`text("Workspace healthy.", Role::Ok)`) or the
`Domain` the value came from, resolved by the one mapping table. 12 command
modules updated. Added `Domain::AuditStatus` (success->Ok, failure->Error,
denied->Warn) for the new audit table.

Behavior note: the four `job_state_color("...healthy.")` call sites were
passing prose through a job-state lookup, which returned Neutral -- they have
never been colored. They are now tagged `Role::Ok` and render green on a
terminal. Non-TTY output is unchanged.

## Width from the sink

`Table::print` reads `sink.truncate_width()` and `sink.color_allowed()`;
`table.rs`'s local `sink_width()` (which read COLUMNS and asked comfy-table for
the terminal size) is deleted. A zero-width sink truncates nothing.

## audit list through the table path

`print_audit_event_line`'s `"[{}] {:<8} {:<6} {}:{:<20} {}ms"` is replaced by
`print_audit_events`, which builds a `Table` with computed widths, a header, a
right-aligned `DURATION (ms)` column, and `filtered(...)` on STATUS / ROLE /
TOOL so a column the caller filtered on stays on screen.

## Errors and exit codes -- BREAKING

`print_error` writes to **stderr** in every mode; stdout carries the payload and
nothing else. It emits JSON when the command declared a `--json` preference *or*
the sink resolved a JSON mode, so `--format json` on a command without its own
flag now gets a machine-readable failure too.

**This is a breaking change for any script parsing errors off stdout.** Verified
on-box: `orbit task show <missing>` -> rc 1, stdout empty, plain message on
stderr; `--format json` -> rc 1, stdout empty, payload on stderr; a clap usage
error -> rc 2, stdout empty. Four integration tests that read the payload from
stdout were updated to stderr (docs.rs, learning.rs, tool_list.rs,
worktree_resolution.rs), each also asserting stdout is now empty.

CHANGELOG.md was deliberately NOT edited: the repo convention (CLAUDE.md,
RELEASING.md step 2) is that it is compiled at release time from merged work,
not accumulated per-PR. The break is recorded here, in the commit message, and
in specs/output-modes.md 5 and 7 for the release drafter to pull.

## Broken pipe

New `output/pipe.rs`. `install_handler()` turns the `failed printing to stdout:
... (os error 32)` panic that `println!` raises into a silent `exit(0)`; a
disk-full panic (ENOSPC) still panics, which is unit-tested. `log tail` maps a
`BrokenPipe` write error to `Ok` for the writer-based path. Verified on-box on
both paths with outputs well past the pipe buffer: `orbit audit list --limit
20000 | head -1` (2.5 MB) and `orbit log tail -n 50000 | head -1` (3.2 MB) both
exit 0 with empty stderr.

## Progress

The CLI emits no progress output today, so the property holds; the sink now owns
the predicate. `sink.progress_allowed()` is `is_tty && !json/ndjson`, reported
on the resolved-sink debug line and pinned by test.

## Verification

- `cargo build -p orbit-cli`, `cargo clippy -p orbit-cli --all-targets -D
  warnings`, `cargo fmt --all`, `make ci-fast`: clean.
- `cargo nextest run -p orbit-cli`: 410/411. The one failure,
  `mcp_roundtrip::hub_mcp_serve_is_checkoutless_frame_pure_and_audits_trusted_identity`,
  is **pre-existing** -- reproduced identically on base 549be4b0 in a clean
  /tmp clone (workspace-init identity conflict, unrelated to output).
- `cargo clippy --workspace --all-targets -D warnings` fails on
  `orbit-exec/tests/linux_sandbox.rs` with 50 `expect_used` errors. Also
  **pre-existing** -- reproduced on base 549be4b0. Everything else in the
  workspace is clean (`--exclude orbit-exec` passes).
- Per the task's verification note, the new tests pass both with a populated
  environment (NO_COLOR=1 COLUMNS=40 CLICOLOR_FORCE=1 ORBIT_FORMAT=json) and
  with all four scrubbed; sinks are built with `OutputSink::resolve`, never
  `from_process`, so geometry and styling are pinned rather than inherited.
- Byte-identity verified on-box under a real pty (`script -qec`), not just in
  unit tests: `orbit task list` (table) and `orbit log tail` (line) each produce
  output identical to a file redirect under NO_COLOR=1, and both emit escapes
  without it.

## Not done, deliberately

- Command bodies still do not return payloads (out of scope, ADR-0306 step 3),
  so the plain form and `ndjson` remain unimplemented on the success path.
- The sink is reached through a process-global `OnceLock` because
  `Execute::execute` takes no renderer argument. This is a real decision with a
  real rejected alternative and needs an ADR -- but `orbit.adr.add` failed with
  `io_error: Read-only file system` in this runner (`.orbit/adrs/` is on a
  read-only mount). No ID was invented. The decision and its rejected
  alternatives are stated inline in 2_design.md 9, and **ORB-10585** is filed to
  allocate the ADR; it carries the drafted body.
- Two color-spec gaps are documented rather than closed, both pre-existing and
  both crate-wide rather than local to this change: `comfy_table` renders roles
  as 256-color codes (`\e[38;5;10m`) where `colored` uses 16-color (`\e[32m`),
  against spec 3's "16-color ANSI only"; and spec 3's "never restyle a value the
  user is filtering on" is unimplemented in every list command. Fixing either in
  one command only would create inconsistency.

## Friction

Filed **F2026-08-022** (tooling, lifecycle): the job runner can persist task
records but not ADRs -- `<workspace>/.orbit/` is on a read-only mount, so
`orbit.adr.add` fails with `io_error` while `orbit.task.add`/`update` succeed,
which an executor only discovers after the same-PR ADR rule has already shaped
its doc edits. A duplicate created by a re-run of the same call was closed
immediately as F2026-08-023.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10570-6a6ec05d`
- Behind base: 0
- Ahead of base: 1