### PR TITLE
Correct GPT-5.6 prices and cached-input accounting

### DIFF
--- a/crates/orbit-agent/src/providers/openai_compat/chat_completions_transport.rs
+++ b/crates/orbit-agent/src/providers/openai_compat/chat_completions_transport.rs
@@ -17,7 +17,8 @@ use crate::loop_engine::transport::{
 
 use super::wire::{
     ChatCompletionsRequest, ChatCompletionsResponse, FunctionDefinition, IncomingMessage,
-    IncomingToolCall, OutgoingFunctionCall, OutgoingToolCall, RequestMessage, ToolDefinition,
+    IncomingToolCall, IncomingUsage, OutgoingFunctionCall, OutgoingToolCall, RequestMessage,
+    ToolDefinition,
 };
 
 const DEFAULT_BASE_URL: &str = "https://api.openai.com";
@@ -146,16 +147,7 @@ impl LoopTransport for OpenAiCompatTransport {
             })?;
 
         let content = map_incoming_message(choice.message);
-        let usage = TurnUsage {
-            input_tokens: parsed.usage.prompt_tokens,
-            output_tokens: parsed.usage.completion_tokens,
-            cache_read_input_tokens: parsed
-                .usage
-                .prompt_tokens_details
-                .map(|details| details.cached_tokens)
-                .unwrap_or(0),
-            cache_creation_input_tokens: 0,
-        };
+        let usage = turn_usage_from_wire(parsed.usage);
 
         Ok(TurnResponse {
             content,
@@ -166,6 +158,20 @@ impl LoopTransport for OpenAiCompatTransport {
             endpoint,
             http_status,
         })
+    }
+}
+
+pub(super) fn turn_usage_from_wire(usage: IncomingUsage) -> TurnUsage {
+    let details = usage.prompt_tokens_details.unwrap_or_default();
+    TurnUsage {
+        input_tokens: usage.prompt_tokens,
+        output_tokens: usage.completion_tokens,
+        cache_read_input_tokens: details.cached_tokens,
+        // Compatibility layers use both placements. They may echo the same
+        // aggregate in both, so prefer the larger value instead of summing.
+        cache_creation_input_tokens: details
+            .cache_write_tokens
+            .max(usage.cache_creation_input_tokens),
     }
 }
 

--- a/crates/orbit-agent/src/providers/openai_compat/mod.rs
+++ b/crates/orbit-agent/src/providers/openai_compat/mod.rs
@@ -7,4 +7,7 @@
 mod chat_completions_transport;
 mod wire;
 
+#[cfg(test)]
+mod tests;
+
 pub use chat_completions_transport::OpenAiCompatTransport;

--- a/crates/orbit-agent/src/providers/openai_compat/tests/mod.rs
+++ b/crates/orbit-agent/src/providers/openai_compat/tests/mod.rs
@@ -1,0 +1,1 @@
+mod transport;

--- a/crates/orbit-agent/src/providers/openai_compat/tests/transport.rs
+++ b/crates/orbit-agent/src/providers/openai_compat/tests/transport.rs
@@ -1,0 +1,43 @@
+use super::super::chat_completions_transport::turn_usage_from_wire;
+use super::super::wire::IncomingUsage;
+
+#[test]
+fn response_usage_retains_cached_reads_and_standard_cache_writes() {
+    let usage: IncomingUsage = serde_json::from_value(serde_json::json!({
+        "prompt_tokens": 1_000,
+        "completion_tokens": 50,
+        "prompt_tokens_details": {
+            "cached_tokens": 200,
+            "cache_write_tokens": 300
+        }
+    }))
+    .expect("valid OpenAI-compatible usage");
+
+    let mapped = turn_usage_from_wire(usage);
+    assert_eq!(mapped.input_tokens, 1_000);
+    assert_eq!(mapped.cache_read_input_tokens, 200);
+    assert_eq!(mapped.cache_creation_input_tokens, 300);
+    assert_eq!(mapped.output_tokens, 50);
+}
+
+#[test]
+fn response_usage_accepts_cache_creation_alias() {
+    let usage: IncomingUsage = serde_json::from_value(serde_json::json!({
+        "prompt_tokens_details": {
+            "cache_creation_tokens": 17
+        }
+    }))
+    .expect("valid compatibility-layer usage");
+
+    assert_eq!(turn_usage_from_wire(usage).cache_creation_input_tokens, 17);
+}
+
+#[test]
+fn response_usage_accepts_a_top_level_cache_write_counter() {
+    let usage: IncomingUsage = serde_json::from_value(serde_json::json!({
+        "cache_creation_input_tokens": 23
+    }))
+    .expect("valid compatibility-layer usage");
+
+    assert_eq!(turn_usage_from_wire(usage).cache_creation_input_tokens, 23);
+}

--- a/crates/orbit-agent/src/providers/openai_compat/wire.rs
+++ b/crates/orbit-agent/src/providers/openai_compat/wire.rs
@@ -106,10 +106,28 @@ pub struct IncomingUsage {
     pub completion_tokens: u64,
     #[serde(default)]
     pub prompt_tokens_details: Option<PromptTokenDetails>,
+    /// Compatibility-layer aggregate when cache writes are reported beside
+    /// `prompt_tokens` rather than inside `prompt_tokens_details`.
+    #[serde(
+        default,
+        alias = "cache_creation_tokens",
+        alias = "cache_write_tokens",
+        alias = "cache_write_input_tokens"
+    )]
+    pub cache_creation_input_tokens: u64,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct PromptTokenDetails {
     #[serde(default)]
     pub cached_tokens: u64,
+    /// Standard 5-minute cache writes reported by OpenAI-compatible providers.
+    /// The aliases cover the field names used by common compatibility layers.
+    #[serde(
+        default,
+        alias = "cache_creation_tokens",
+        alias = "cache_creation_input_tokens",
+        alias = "cache_write_input_tokens"
+    )]
+    pub cache_write_tokens: u64,
 }

--- a/crates/orbit-agent/src/types/response/usage.rs
+++ b/crates/orbit-agent/src/types/response/usage.rs
@@ -228,6 +228,12 @@ const STANDARD_CACHE_CREATE_KEYS: &[&str] = &[
     "cacheCreationInputTokens",
     "cache_create_tokens",
     "cacheCreateTokens",
+    "cache_write_input_tokens",
+    "cacheWriteInputTokens",
+    "cache_write_tokens",
+    "cacheWriteTokens",
+    "cache_creation_tokens",
+    "cacheCreationTokens",
 ];
 
 const CACHE_CREATION_KEY: &str = "cache_creation";

--- a/crates/orbit-agent/src/types/tests/response.rs
+++ b/crates/orbit-agent/src/types/tests/response.rs
@@ -156,11 +156,16 @@ mod parse {
             "{\"type\":\"thread.started\",\"thread_id\":\"thread-1\"}\n",
             "{\"type\":\"turn.started\"}\n",
             "{\"type\":\"item.completed\",\"item\":{\"id\":\"item-0\",\"type\":\"agent_message\",\"text\":\"{\\\"schemaVersion\\\":1,\\\"status\\\":\\\"success\\\",\\\"result\\\":{},\\\"error\\\":null}\"}}\n",
-            "{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":17389,\"cached_input_tokens\":0,\"output_tokens\":22,\"reasoning_output_tokens\":0}}\n"
+            "{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":17389,\"cached_input_tokens\":2000,\"cache_write_tokens\":300,\"output_tokens\":22,\"reasoning_output_tokens\":0}}\n"
         );
 
         let (_, _, trace) =
             parse_and_validate_response(&exec(stdout, "", Some(0), true)).expect("Codex parses");
+        assert_eq!(trace.usage.input, 17_389);
+        assert_eq!(trace.usage.cache_read, 2_000);
+        assert_eq!(trace.usage.cache_create, 300);
+        assert_eq!(trace.usage.cache_create_1h, 0);
+        assert_eq!(trace.usage.output, 22);
         assert_eq!(trace.provider_model, None);
         assert_eq!(trace.provider_cost_usd, None);
     }

--- a/crates/orbit-common/assets/model_prices.yaml
+++ b/crates/orbit-common/assets/model_prices.yaml
@@ -33,13 +33,14 @@
 # to fall back to the base row (see `pricing::strip_context_suffix`). Add a
 # distinct `model[1m]` row only if a provider charges a long-context premium.
 #
-# Rates are USD per 1,000,000 tokens. Anthropic prompt-cache economics:
+# Rates are USD per 1,000,000 tokens. `input_token_basis` defaults to
+# `exclusive`; `gross_includes_cache` marks provider input totals that already
+# include cached reads and writes. Anthropic prompt-cache economics:
 # cache_read ≈ 0.1x input, cache_create (5m TTL) = 1.25x input,
 # cache_create_1h (1h TTL) = 2x input. Providers with no 1h-TTL tier
-# (OpenAI/Gemini/xAI) set cache_create_1h to the input rate (their 1h token
-# count is always zero, so the rate is never applied) and price cache-creation
-# at the input rate. `effective_until` is exclusive; omit (or `null`) for the
-# current open-ended rate.
+# (OpenAI/Gemini/xAI) report no 1h count. Their explicit nonzero fallback rate
+# prevents malformed nonzero data from being priced as free. `effective_until`
+# is exclusive; omit (or `null`) for the current open-ended rate.
 prices:
   # ── Anthropic / Claude (crews: opus, sonnet, fable) ──────────────────────
   # Opus 5 launched 2026-07-24 at the same rates as Opus 4.8 (verified against
@@ -117,34 +118,69 @@ prices:
     output_per_million_usd: 50.0
 
   # ── OpenAI / Codex (crews: sol, terra, luna) ─────────────────────────────
-  # No separate cache-write premium: a cache-creation token bills at the input
-  # rate; cached reads are discounted. No 1h tier (count always zero).
+  # Standard short-context API-equivalent rates. OpenAI input totals are gross:
+  # cached reads and writes are included and are subtracted before the full
+  # input rate is applied. OpenAI reports no 1h tier; the nonzero 5m fallback
+  # rate prevents malformed nonzero 1h data from being treated as free.
   - model: "gpt-5.6-sol"
     effective_from: "2026-07-17T00:00:00Z"
-    effective_until: null
+    effective_until: "2026-07-30T00:00:00Z"
+    input_token_basis: gross_includes_cache
     input_per_million_usd: 5.0
     cache_read_per_million_usd: 0.5
-    cache_create_per_million_usd: 5.0
-    cache_create_1h_per_million_usd: 5.0
+    cache_create_per_million_usd: 6.25
+    cache_create_1h_per_million_usd: 6.25
+    output_per_million_usd: 30.0
+
+  - model: "gpt-5.6-sol"
+    effective_from: "2026-07-30T00:00:00Z"
+    effective_until: null
+    input_token_basis: gross_includes_cache
+    input_per_million_usd: 5.0
+    cache_read_per_million_usd: 0.5
+    cache_create_per_million_usd: 6.25
+    cache_create_1h_per_million_usd: 6.25
     output_per_million_usd: 30.0
 
   - model: "gpt-5.6-terra"
     effective_from: "2026-07-17T00:00:00Z"
-    effective_until: null
+    effective_until: "2026-07-30T00:00:00Z"
+    input_token_basis: gross_includes_cache
     input_per_million_usd: 2.5
     cache_read_per_million_usd: 0.25
+    cache_create_per_million_usd: 3.125
+    cache_create_1h_per_million_usd: 3.125
+    output_per_million_usd: 15.0
+
+  - model: "gpt-5.6-terra"
+    effective_from: "2026-07-30T00:00:00Z"
+    effective_until: null
+    input_token_basis: gross_includes_cache
+    input_per_million_usd: 2.0
+    cache_read_per_million_usd: 0.2
     cache_create_per_million_usd: 2.5
     cache_create_1h_per_million_usd: 2.5
-    output_per_million_usd: 15.0
+    output_per_million_usd: 12.0
 
   - model: "gpt-5.6-luna"
     effective_from: "2026-07-17T00:00:00Z"
-    effective_until: null
+    effective_until: "2026-07-30T00:00:00Z"
+    input_token_basis: gross_includes_cache
     input_per_million_usd: 1.0
     cache_read_per_million_usd: 0.1
-    cache_create_per_million_usd: 1.0
-    cache_create_1h_per_million_usd: 1.0
+    cache_create_per_million_usd: 1.25
+    cache_create_1h_per_million_usd: 1.25
     output_per_million_usd: 6.0
+
+  - model: "gpt-5.6-luna"
+    effective_from: "2026-07-30T00:00:00Z"
+    effective_until: null
+    input_token_basis: gross_includes_cache
+    input_per_million_usd: 0.2
+    cache_read_per_million_usd: 0.02
+    cache_create_per_million_usd: 0.25
+    cache_create_1h_per_million_usd: 0.25
+    output_per_million_usd: 1.2
 
   # ── Google / Gemini (crew: gemini) ───────────────────────────────────────
   # Gemini 3.5 Flash, launched Google I/O 2026 at 1.50/9.00; cached input 0.15.

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -138,7 +138,7 @@ pub use policy_def::{
     DEFAULT_POLICY_NAME, FsCheckResult, FsOperation, FsProfile, PolicyDef, ResolvedFsProfile,
     UNRESTRICTED_FS_PROFILE,
 };
-pub use pricing::{PriceRow, derive_cost_usd};
+pub use pricing::{InputTokenBasis, PriceRow, derive_cost_usd};
 pub use registry_snapshot::{
     REGISTRY_CACHE_SCHEMA_VERSION, REGISTRY_SNAPSHOT_SCHEMA_VERSION, RegistryAliasV1,
     RegistryCacheV1, RegistryHostV1, RegistryPresenceV1, RegistryProfileV1, RegistrySnapshotV1,

--- a/crates/orbit-common/src/types/pricing.rs
+++ b/crates/orbit-common/src/types/pricing.rs
@@ -19,6 +19,21 @@ use serde::Deserialize;
 
 use super::invocation::TokenUsage;
 
+/// How a provider reports the input-token total carried by [`TokenUsage`].
+///
+/// Most providers report mutually exclusive input and cache buckets. OpenAI
+/// reports a gross input total that already includes cached reads and writes,
+/// so those buckets must be removed before the full input rate is applied.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum InputTokenBasis {
+    /// `TokenUsage::input` excludes every cache bucket.
+    #[default]
+    Exclusive,
+    /// `TokenUsage::input` includes cache reads and both cache-write buckets.
+    GrossIncludesCache,
+}
+
 const MODEL_PRICES_YAML: &str = include_str!("../../assets/model_prices.yaml");
 
 /// One versioned price row: USD per million tokens, by exact model string
@@ -30,6 +45,10 @@ pub struct PriceRow {
     pub effective_from: DateTime<Utc>,
     #[serde(default)]
     pub effective_until: Option<DateTime<Utc>>,
+    /// Provider reporting convention for [`TokenUsage::input`]. Existing rows
+    /// default to [`InputTokenBasis::Exclusive`] for backward compatibility.
+    #[serde(default)]
+    pub input_token_basis: InputTokenBasis,
     pub input_per_million_usd: f64,
     pub cache_read_per_million_usd: f64,
     /// Rate for standard 5-minute-TTL cache-creation (write) tokens
@@ -51,12 +70,25 @@ impl PriceRow {
             && self.effective_until.is_none_or(|until| at < until)
     }
 
-    fn cost_usd(&self, usage: &TokenUsage) -> f64 {
-        rate(usage.input, self.input_per_million_usd)
-            + rate(usage.cache_read, self.cache_read_per_million_usd)
-            + rate(usage.cache_create, self.cache_create_per_million_usd)
-            + rate(usage.cache_create_1h, self.cache_create_1h_per_million_usd)
-            + rate(usage.output, self.output_per_million_usd)
+    fn cost_usd(&self, usage: &TokenUsage) -> Option<f64> {
+        let input = match self.input_token_basis {
+            InputTokenBasis::Exclusive => usage.input,
+            InputTokenBasis::GrossIncludesCache => {
+                let cache_detail = usage
+                    .cache_read
+                    .checked_add(usage.cache_create)?
+                    .checked_add(usage.cache_create_1h)?;
+                usage.input.checked_sub(cache_detail)?
+            }
+        };
+
+        Some(
+            rate(input, self.input_per_million_usd)
+                + rate(usage.cache_read, self.cache_read_per_million_usd)
+                + rate(usage.cache_create, self.cache_create_per_million_usd)
+                + rate(usage.cache_create_1h, self.cache_create_1h_per_million_usd)
+                + rate(usage.output, self.output_per_million_usd),
+        )
     }
 }
 
@@ -125,7 +157,7 @@ pub(super) fn cost_from_rows(
     // then fall back to the base key with any context-window suffix stripped.
     pick(model)
         .or_else(|| strip_context_suffix(model).and_then(pick))
-        .map(|row| row.cost_usd(usage))
+        .and_then(|row| row.cost_usd(usage))
 }
 
 #[cfg(test)]

--- a/crates/orbit-common/src/types/tests/pricing.rs
+++ b/crates/orbit-common/src/types/tests/pricing.rs
@@ -1,7 +1,9 @@
 use chrono::{DateTime, Utc};
 
 use crate::types::TokenUsage;
-use crate::types::pricing::{PriceRow, cost_from_rows, derive_cost_usd, shipped_price_table};
+use crate::types::pricing::{
+    InputTokenBasis, PriceRow, cost_from_rows, derive_cost_usd, shipped_price_table,
+};
 
 fn dt(rfc3339: &str) -> DateTime<Utc> {
     DateTime::parse_from_rfc3339(rfc3339)
@@ -183,12 +185,142 @@ fn flat_row(model: &str, effective_from: &str, input_per_million_usd: f64) -> Pr
         model: model.to_string(),
         effective_from: dt(effective_from),
         effective_until: None,
+        input_token_basis: InputTokenBasis::Exclusive,
         input_per_million_usd,
         cache_read_per_million_usd: 0.0,
         cache_create_per_million_usd: 0.0,
         cache_create_1h_per_million_usd: 0.0,
         output_per_million_usd: 0.0,
     }
+}
+
+fn covering_rows(model: &str, at: DateTime<Utc>) -> Vec<&'static PriceRow> {
+    shipped_price_table()
+        .iter()
+        .filter(|row| {
+            row.model == model
+                && at >= row.effective_from
+                && row.effective_until.is_none_or(|until| at < until)
+        })
+        .collect()
+}
+
+#[test]
+fn gpt_5_6_rates_change_at_the_exclusive_july_30_boundary_without_overlap() {
+    let historical_at = dt("2026-07-29T23:59:59Z");
+    let current_at = dt("2026-07-30T00:00:00Z");
+    let expected = [
+        (
+            "gpt-5.6-sol",
+            [5.0, 0.5, 6.25, 30.0],
+            [5.0, 0.5, 6.25, 30.0],
+        ),
+        (
+            "gpt-5.6-terra",
+            [2.5, 0.25, 3.125, 15.0],
+            [2.0, 0.2, 2.5, 12.0],
+        ),
+        (
+            "gpt-5.6-luna",
+            [1.0, 0.1, 1.25, 6.0],
+            [0.2, 0.02, 0.25, 1.2],
+        ),
+    ];
+
+    for (model, historical, current) in expected {
+        let historical_rows = covering_rows(model, historical_at);
+        let current_rows = covering_rows(model, current_at);
+        assert_eq!(historical_rows.len(), 1, "{model} historical coverage");
+        assert_eq!(current_rows.len(), 1, "{model} current coverage");
+
+        let rates = |row: &PriceRow| {
+            [
+                row.input_per_million_usd,
+                row.cache_read_per_million_usd,
+                row.cache_create_per_million_usd,
+                row.output_per_million_usd,
+            ]
+        };
+        assert_eq!(
+            rates(historical_rows[0]),
+            historical,
+            "{model} historical rates"
+        );
+        assert_eq!(rates(current_rows[0]), current, "{model} current rates");
+        assert_eq!(
+            historical_rows[0].input_token_basis,
+            InputTokenBasis::GrossIncludesCache
+        );
+        assert_eq!(
+            current_rows[0].input_token_basis,
+            InputTokenBasis::GrossIncludesCache
+        );
+    }
+}
+
+#[test]
+fn gross_openai_input_is_split_into_uncached_read_and_write_buckets() {
+    let at = dt("2026-07-30T00:00:00Z");
+    let cached = TokenUsage {
+        input: 1_000_000,
+        cache_read: 500_000,
+        ..TokenUsage::default()
+    };
+    let cached_cost = derive_cost_usd("gpt-5.6-sol", at, &cached).expect("priced");
+    assert!(
+        (cached_cost - 2.75).abs() < f64::EPSILON,
+        "cost was {cached_cost}"
+    );
+
+    let combined = TokenUsage {
+        input: 1_000_000,
+        cache_read: 200_000,
+        cache_create: 300_000,
+        ..TokenUsage::default()
+    };
+    let combined_cost = derive_cost_usd("gpt-5.6-sol", at, &combined).expect("priced");
+    assert!(
+        (combined_cost - 4.475).abs() < 1e-12,
+        "cost was {combined_cost}"
+    );
+}
+
+#[test]
+fn gross_openai_input_rejects_cache_detail_larger_than_the_total() {
+    let invalid = TokenUsage {
+        input: 100,
+        cache_read: 60,
+        cache_create: 41,
+        ..TokenUsage::default()
+    };
+    assert_eq!(
+        derive_cost_usd("gpt-5.6-sol", dt("2026-07-30T00:00:00Z"), &invalid),
+        None
+    );
+}
+
+#[test]
+fn malformed_openai_one_hour_writes_are_not_priced_as_free() {
+    let usage = TokenUsage {
+        input: 1_000_000,
+        cache_create_1h: 100_000,
+        ..TokenUsage::default()
+    };
+    let cost = derive_cost_usd("gpt-5.6-sol", dt("2026-07-30T00:00:00Z"), &usage)
+        .expect("nonzero fallback rate prices malformed 1h data");
+    assert!((cost - 5.125).abs() < 1e-12, "cost was {cost}");
+}
+
+#[test]
+fn exclusive_input_rows_preserve_existing_non_openai_accounting() {
+    let usage = TokenUsage {
+        input: 1_000_000,
+        cache_read: 500_000,
+        ..TokenUsage::default()
+    };
+    let cost =
+        derive_cost_usd("claude-opus-4-7", dt("2026-07-30T00:00:00Z"), &usage).expect("priced");
+    assert!((cost - 5.25).abs() < f64::EPSILON, "cost was {cost}");
 }
 
 #[test]

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -646,6 +646,8 @@ fn run_agent_loop_via_driver(
         "usage".to_string(),
         serde_json::json!({
             "input_tokens": outcome.usage.input_tokens,
+            "cache_read_input_tokens": outcome.usage.cache_read_input_tokens,
+            "cache_creation_input_tokens": outcome.usage.cache_creation_input_tokens,
             "output_tokens": outcome.usage.output_tokens,
         }),
     );
@@ -686,9 +688,9 @@ pub(crate) fn loop_outcome_trace(
             input: outcome.usage.input_tokens,
             cache_read: outcome.usage.cache_read_input_tokens,
             cache_create: outcome.usage.cache_creation_input_tokens,
-            // The agent loop reports a single cache-creation counter; the 1h/5m
-            // TTL split isn't surfaced here yet, so all cache-creation tokens
-            // are treated as the standard (5m) rate (ORB-10338 follow-up).
+            // OpenAI-compatible and generic agent-loop usage reports a single
+            // cache-creation counter. The 1h/5m TTL split isn't surfaced here,
+            // so all reported writes retain the standard (5m) rate.
             cache_create_1h: 0,
             output: outcome.usage.output_tokens,
         },

--- a/crates/orbit-store/src/sqlite/tests/invocation_store.rs
+++ b/crates/orbit-store/src/sqlite/tests/invocation_store.rs
@@ -228,6 +228,64 @@ fn invocation_records_round_trip_one_hour_cache_writes_and_derive_ground_truth()
 }
 
 #[test]
+fn historical_invocation_is_repriced_at_query_time_without_a_migration() {
+    let store = Store::open_in_memory().expect("open store");
+
+    store
+        .insert_invocation_trace_record(&InvocationInsertParams {
+            job_run_id: "jrun-historical-gpt".to_string(),
+            activity_id: "implement_one".to_string(),
+            agent: "codex".to_string(),
+            model: Some("gpt-5.6-terra".to_string()),
+            slot: None,
+            task_ids: vec!["ORB-10579".to_string()],
+            trace: InvocationTrace {
+                usage: TokenUsage {
+                    // OpenAI input is gross: 500k uncached + 200k read + 300k write.
+                    input: 1_000_000,
+                    cache_read: 200_000,
+                    cache_create: 300_000,
+                    output: 1_000_000,
+                    ..TokenUsage::default()
+                },
+                ..InvocationTrace::default()
+            },
+        })
+        .expect("insert invocation");
+
+    // Simulate a row stored before the July 30 price change. No schema or row
+    // migration is involved; the query-time lookup uses this persisted date.
+    store
+        .with_transaction(|tx| {
+            tx.connection()
+                .execute(
+                    "UPDATE invocations SET ts = ?1 WHERE job_run_id = ?2",
+                    ["2026-07-29T23:59:59+00:00", "jrun-historical-gpt"],
+                )
+                .map_err(|error| orbit_common::types::OrbitError::Store(error.to_string()))?;
+            Ok(())
+        })
+        .expect("set historical timestamp");
+
+    let records = store
+        .list_invocation_records(&InvocationQuery {
+            job_run_id: Some("jrun-historical-gpt".to_string()),
+            limit: 10,
+            ..InvocationQuery::default()
+        })
+        .expect("list historical invocation");
+
+    let derived = records[0]
+        .derived_cost_usd
+        .expect("historical row is priced");
+    // Historical Terra: 0.5M*$2.50 + 0.2M*$0.25 + 0.3M*$3.125 + 1M*$15.
+    assert!(
+        (derived - 17.2375).abs() < 1e-12,
+        "derived cost was {derived}"
+    );
+}
+
+#[test]
 fn invocation_records_leave_derived_cost_none_for_an_unpriced_model() {
     let store = Store::open_in_memory().expect("open store");
 

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -3,7 +3,7 @@ summary: "Auditability — Design"
 type: design
 title: "Auditability — Design"
 owner: codex
-last_updated: 2026-07-27
+last_updated: 2026-08-02
 last_validated: 2026-07-27
 status: Draft
 feature: auditability
@@ -124,6 +124,8 @@ After [ORB-10337], `POST /api/metrics/invocations` accepts the existing `Invocat
 
 After [ORB-10338] (see [ADR-0245]), `InvocationInsertParams.trace` carries an optional `provider_cost_usd` — the provider's own reported total, persisted verbatim in a new `invocations.provider_cost_usd` column for Daniel's monthly manual reconciliation. `InvocationRecord` also exposes `derived_cost_usd`, computed at read time (not stored) by `orbit_common::types::pricing::derive_cost_usd` from the row's model, timestamp, and token splits against a versioned price table shipped as `crates/orbit-common/assets/model_prices.yaml` — rows keyed by exact model string plus an `effective_from`/`effective_until` range, loaded once behind a `OnceLock`. Adding or correcting a rate is a YAML edit; no Rust change and no backfill are needed, and existing rows re-price automatically the next time they are read. `derived_cost_usd` is `None` whenever no price row covers the model/date, and it never overwrites `provider_cost_usd`.
 
+After [ORB-10579], each price row also declares whether its input count is exclusive or gross-with-cache. Existing rows default to exclusive accounting; GPT-5.6 rows use gross accounting, so derived pricing subtracts cached-read and both cache-write buckets from the gross input total before charging the full input rate. Checked subtraction makes inconsistent rows unknown instead of silently saturating. Codex JSONL and OpenAI-compatible response parsing retain provider-reported cached-read, standard cache-write, and output buckets; OpenAI reports no 1-hour write bucket, while a malformed stored nonzero count still has a nonzero fallback price. GPT-5.6 results are standard short-context API-equivalent derived estimates. Exact Fast/service-tier and long-context billing remains future work because Orbit does not yet retain those per-request dimensions.
+
 After [ORB-10370], CLI response parsing also fills `InvocationTrace.provider_model` and `provider_cost_usd` directly from provider-owned result metadata. Claude exposes a `modelUsage` map and `total_cost_usd`; when Claude reports its internal helper model beside the requested model, Orbit selects the unique highest-cost map entry and preserves its key verbatim. Gemini exposes an exact model key under `stats.models` but no invocation USD total; Orbit accepts it only when the map has one entry. Codex JSONL and Grok's JSON wrapper do not currently report either value, so they remain `None`. At SQLite ingest, a non-empty provider model wins over the configured request/alias and the configured model remains the fallback. A disagreement emits a retained `WARN` event under `orbit.core.invocation` with job run, activity, CLI, requested model, and provider model fields. This structured mismatch event was chosen instead of a second invocation column: it makes provider routing drift detectable under the default logging filter without migrating or backfilling rows, while `invocations.model` remains the exact model used for pricing and aggregation.
 
 The local dashboard exposes two read-only API surfaces for these traces after [T20260508-14]: `GET /api/runs/:id/logs` returns bounded per-step CLI invocation previews, and `GET /api/diagnostics/errors` returns recent process ERROR rows plus structured agent-stderr error rows sorted newest first. Both endpoints use existing dashboard limit conventions and tolerate missing stored event rows, malformed event JSON, and missing blobs by returning empty or partial arrays.
@@ -191,6 +193,7 @@ Each record contains timestamp, level, target, and structured fields. After [T20
 - **[ORB-10337]** — Added dashboard HTTP ingestion for worker invocation records without changing the invocation schema.
 - **[ORB-10338]** — Added the versioned model price table and query-time `derived_cost_usd`, plus a persisted `provider_cost_usd` column for reconciliation.
 - **[ORB-10370]** — Parsed provider-reported CLI model/cost metadata, preferred the reported model at ingest, and retained structured mismatch evidence.
+- **[ORB-10579]** — Corrected GPT-5.6 price periods and cache-write rates, added gross-input accounting, and retained OpenAI cache buckets for standard short-context estimates.
 - **[ORB-00106]** — Preserve per-task implementer attribution when `orbit run ship` moves batch PR tasks from Review to Done.
 - **[ORB-10200]** — Derive CLI audit metadata and the other cross-cutting command policies from one exhaustive command-operation registry.
 - **[ORB-10225]** — Route in-process graph MCP calls through the safe-surface allowlist and shared runtime audit boundary.

--- a/docs/design/auditability/4_decisions.md
+++ b/docs/design/auditability/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Auditability — Decisions"
 type: design
 title: "Auditability — Decisions"
 owner: codex
-last_updated: 2026-07-27
+last_updated: 2026-08-02
 last_validated: 2026-07-27
 status: Draft
 feature: auditability
@@ -328,11 +328,11 @@ Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.
 
 ## ADR-0245 — Derive invocation cost at query time from a versioned price table
 
-**Status:** Accepted · 2026-07 · [ORB-10338] [ORB-10370]
+**Status:** Accepted · 2026-07 · [ORB-10338] [ORB-10370] [ORB-10579]
 
 **Context.** The invocation store already retained exact per-invocation token splits, but had no notion of USD cost — cost existed only as a provider-reported total buried in the worker's unparsed per-run JSON, never joined to a model or token split. [ORB-10338] adds cost. Two real alternatives existed: (a) compute cost once at ingest time and store it as a frozen column, or (b) keep rows token-only and derive cost from a versioned price table looked up by exact model string and the invocation's timestamp on every read/aggregate.
 
-**Decision.** Cost is derived at query time, not stored. `orbit_common::types::pricing` ships a versioned price table as an in-repo YAML asset (`crates/orbit-common/assets/model_prices.yaml`), keyed by exact model string plus an `effective_from`/`effective_until` date range, parsed once behind a `OnceLock` cache. `InvocationRecord` gains `derived_cost_usd` (computed at read time from the row's token splits, model, and timestamp against the price table) alongside a new `provider_cost_usd` column that persists the provider's own reported total verbatim for monthly manual reconciliation. Adding or correcting a price row is a YAML edit, not a Rust code change.
+**Decision.** Cost is derived at query time, not stored. `orbit_common::types::pricing` ships a versioned price table as an in-repo YAML asset (`crates/orbit-common/assets/model_prices.yaml`), keyed by exact model string plus an `effective_from`/`effective_until` date range and an input-token billing basis, parsed once behind a `OnceLock` cache. Exclusive input totals remain the backward-compatible default; gross totals include cache buckets, which derived pricing removes with checked arithmetic before charging the full input rate. `InvocationRecord` gains `derived_cost_usd` (computed at read time from the row's token splits, model, and timestamp against the price table) alongside a new `provider_cost_usd` column that persists the provider's own reported total verbatim for monthly manual reconciliation. Adding or correcting a price row is a YAML edit, not a database migration.
 
 **Consequences.**
 - Historical invocation rows re-price automatically when a price row is corrected or backfilled — no migration/backfill script needed to fix a wrong rate.
@@ -340,7 +340,9 @@ Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.
 - `provider_cost_usd` never changes once written, so it stays the ground truth Daniel reconciles against monthly even if `derived_cost_usd` for the same row changes later.
 - [ORB-10370] wires Claude CLI `total_cost_usd` into that column from the same parse that captures provider model identity; providers that report no USD total keep `NULL`.
 - Cost: because derived cost is recomputed on every read instead of frozen at ingest, editing a price row after the fact silently changes the reported cost of every past invocation under that model/date range — there is no record of what a row's derived cost "used to be", unlike the immutable `provider_cost_usd`.
-- Cache-write TTL split: `TokenUsage`/`PriceRow` distinguish 5-minute-TTL cache-creation tokens (`cache_create`, 1.25x input) from 1-hour-TTL (`cache_create_1h`, 2x input), since Anthropic prices them differently; the store persists both. Validated against real worker run 91d7ef01 (`claude-opus-4-8[1m]` → $1.014018 exactly). The ingest path does not yet parse the provider's `ephemeral_1h`/`ephemeral_5m` split, so persisted 1h counts are currently zero (all cache-creation prices at the 5m rate) until that wiring lands — a documented follow-up, matching the pattern by which `provider_cost_usd` was added ahead of its ingest wiring.
+- Cache-write TTL split: `TokenUsage`/`PriceRow` distinguish 5-minute-TTL cache-creation tokens (`cache_create`, 1.25x input) from 1-hour-TTL (`cache_create_1h`, 2x input), since Anthropic prices them differently; the store persists both. Validated against real worker run 91d7ef01 (`claude-opus-4-8[1m]` → $1.014018 exactly). Claude response parsing retains the provider's TTL split. Codex JSONL and OpenAI-compatible parsing retain standard writes when reported; OpenAI's 1-hour bucket stays zero, and an anomalous stored nonzero count is not priced as free.
+- GPT-5.6 cost is a standard short-context API-equivalent estimate. Exact Fast/service-tier and long-context pricing is deliberately unknown until per-request service-tier and context dimensions are retained.
+- Cost: gross-input rows with cache detail larger than the gross total now return unknown rather than producing a partial estimate, so malformed telemetry can reduce reported cost coverage.
 - Model-string keying: rows are keyed by the exact string that lands in `InvocationRecord.model`. A context-window suffix (`claude-opus-4-8[1m]`) is stripped to fall back to the base row rather than duplicating rows, since it bills at base rates; a distinct `model[1m]` row would win by exact match if a long-context premium ever applied. After [ORB-10370], provider-reported CLI model keys replace configured aliases at ingest when available; the configured value remains the fallback, and a structured warning retains requested/reported disagreement without adding a second database column.
 
 ---
@@ -428,6 +430,7 @@ Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.
 - **[ORB-10202]** — Remove the retired friction task status and consolidate task mutation attribution and record-parameter construction.
 - **[ORB-10338]** — Add the versioned model price table and query-time `derived_cost_usd`, plus a persisted `provider_cost_usd` column for reconciliation.
 - **[ORB-10370]** — Fill provider model/cost trace fields from CLI result JSON and prefer reported model identity at invocation ingest.
+- **[ORB-10579]** — Correct GPT-5.6 price periods, cache-write rates, gross-input accounting, and standard short-context estimate boundaries.
 - **[ORB-10519]** — Keep the persisted crew-model author and process-scoped Orbit committer while removing hook-specific trailer input and provider-commit adoption ([ADR-0299], superseding [ADR-0249] and [ADR-0294]).
 - **[ORB-10369]** — Introduce the persisted resolved crew model as the pipeline commit author with generic fallback and no alias resolver ([ADR-0249], superseded by [ADR-0299]).
 - **[ORB-10496]** — Record the spawned provider subprocess PID as its own audit event and expose read-time liveness through run status and `orbit run show`.


### PR DESCRIPTION
## Task

[ORB-10579](https://orbit-cli.com/tasks/ORB-10579) — Correct GPT-5.6 prices and cached-input accounting

### Description

Repair managed Codex execution-cost estimates under ADR-0245. Correct the historical GPT-5.6 cache-write rates, add the July 30 Terra and Luna price periods, and make derived pricing treat OpenAI input totals as gross totals that already include cached reads and cache writes. Extend Codex JSONL and OpenAI-compatible usage parsing to retain cache-write tokens when the provider reports them. This task covers standard, short-context API-equivalent pricing only; request-level long-context and Fast/service-tier billing fidelity remain future work.

### Acceptance Criteria

- The price table represents Sol, Terra, and Luna standard short-context rates from 2026-07-17 through the exclusive 2026-07-30 boundary with input/cache-read/cache-write/output USD-per-million values of Sol 5/0.5/6.25/30, Terra 2.5/0.25/3.125/15, and Luna 1/0.1/1.25/6.
- The price table represents rates from 2026-07-30 onward as Sol 5/0.5/6.25/30, Terra 2/0.2/2.5/12, and Luna 0.2/0.02/0.25/1.2, with no overlapping effective periods.
- Pricing metadata distinguishes gross input totals that include cache buckets from exclusive input totals while preserving backward-compatible behavior for existing non-OpenAI rows.
- Derived cost subtracts cached-read and cache-write buckets from gross input before applying the full input rate, and rejects or returns unknown when cache detail exceeds gross input instead of silently saturating.
- Codex JSONL and OpenAI-compatible response parsing retain cached-read, 5-minute cache-write, and output token buckets when reported; 1-hour cache-write remains zero for OpenAI but is not silently priced as free if nonzero malformed data appears.
- A stored historical invocation is repriced correctly at query time without a database migration.
- Tests cover the July 30 exclusive boundary, unchanged Sol price, Terra and Luna reductions, cache-write pricing, a gross-input cached example, combined cached-read/cache-write input, invalid bucket totals, and both response parsers.
- Auditability documentation labels the result a standard short-context API-equivalent derived estimate and records that exact Fast and long-context pricing requires future per-request service-tier telemetry.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added contiguous GPT-5.6 Sol, Terra, and Luna pricing periods at the exclusive 2026-07-30 boundary, corrected 5-minute cache-write rates, and marked OpenAI input totals as gross-with-cache.
- Added checked gross-input normalization so uncached input excludes cached-read and cache-write buckets; invalid bucket totals return unknown while existing non-OpenAI rows retain exclusive-input behavior.
- Retained Codex JSONL and OpenAI-compatible cached-read, standard cache-write, and output usage, including nested and top-level compatibility aliases, and propagated cache buckets through loop metadata/traces.
- Added pricing boundary/accounting tests, parser tests, and a stored historical invocation repricing test; updated auditability design and ADR-0245 documentation for standard short-context API-equivalent estimates and the Fast/long-context telemetry limitation.
- Expanded context_files to include `crates/orbit-common/src/types/mod.rs` for the required public enum re-export and `dir:crates/orbit-agent/src/providers/openai_compat` for the wire schema plus sibling tests.
Assessment: The scoped implementation satisfies the pricing, accounting, parser, historical repricing, and documentation criteria without a database migration or new dependency edge.
Checks:
- `cargo test -p orbit-common pricing --lib` (16 passed)
- `cargo test -p orbit-agent openai_compat --lib` (3 passed)
- `cargo test -p orbit-agent codex_jsonl_reports_usage_but_no_model_or_cost --lib` (1 passed)
- `cargo test -p orbit-store invocation_records --lib` (6 passed)
- `cargo test -p orbit-store historical_invocation_is_repriced_at_query_time_without_a_migration --lib` (1 passed)
- `cargo check -p orbit-engine` passed
- `git diff --check` passed
- `make ci-fast` reached the terminal-state guard and failed only on pre-existing `crates/orbit-cli/src/output/table.rs` uses outside this task diff; filed F2026-08-024.
Design weaknesses / risks:
- Exact Fast/service-tier and long-context prices remain intentionally unknown until request-level telemetry is retained.
- `orbit.adr.update` for durable ADR-0245 synchronization failed because the artifact filesystem was read-only; the checked-in decision doc is current and F2026-08-025 records the tooling gap.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10579-6a6ec746`
- Behind base: 0
- Ahead of base: 1