### PR TITLE
Add explicit orchestration ownership to tasks

### DIFF
--- a/crates/orbit-cli/src/command/task/add.rs
+++ b/crates/orbit-cli/src/command/task/add.rs
@@ -59,6 +59,9 @@ pub struct TaskAddArgs {
     /// Named crew to use when running this task
     #[arg(long)]
     pub crew: Option<String>,
+    /// Named crew responsible for orchestration attribution
+    #[arg(long)]
+    pub orchestrator: Option<String>,
     /// Explicit agent model to persist on the task artifact
     #[arg(long)]
     pub model: Option<String>,
@@ -101,6 +104,7 @@ impl Execute for TaskAddArgs {
                     .collect::<Result<Vec<_>, _>>()?,
                 source_task_id: self.source_task.clone(),
                 crew: self.crew,
+                orchestrator: self.orchestrator,
             },
             agent,
             model,

--- a/crates/orbit-cli/src/command/task/output.rs
+++ b/crates/orbit-cli/src/command/task/output.rs
@@ -55,6 +55,7 @@ pub(crate) fn task_to_json(
         "source_task_id": task.source_task_id(),
         "job_run_id": task.job_run_id,
         "crew": task.crew,
+        "orchestrator": task.orchestrator,
         "created_at": task.created_at.to_rfc3339(),
         "updated_at": task.updated_at.to_rfc3339(),
     })
@@ -105,6 +106,7 @@ pub(crate) fn task_lock_to_json(task: &orbit_core::Task) -> Value {
         "status": task.status.to_string(),
         "job_run_id": task.job_run_id,
         "crew": task.crew,
+        "orchestrator": task.orchestrator,
         "context_files": task.context_files,
     })
 }

--- a/crates/orbit-cli/src/command/task/update.rs
+++ b/crates/orbit-cli/src/command/task/update.rs
@@ -59,6 +59,9 @@ pub struct TaskUpdateArgs {
     /// Named crew to use when running this task (empty string clears)
     #[arg(long)]
     pub crew: Option<String>,
+    /// Named crew responsible for orchestration attribution (empty string clears)
+    #[arg(long)]
+    pub orchestrator: Option<String>,
     /// Comma-separated task context selectors (empty string clears). Prefer
     /// `file:`, `dir:`, or `symbol:` forms; legacy raw paths are accepted and upgraded.
     #[arg(long = "context", alias = "context-files")]
@@ -94,6 +97,7 @@ impl Execute for TaskUpdateArgs {
             pr_status,
             job_run_id,
             crew,
+            orchestrator,
             context_files,
             artifacts,
             model,
@@ -115,6 +119,13 @@ impl Execute for TaskUpdateArgs {
             }
         });
         let crew = crew.map(|value| {
+            if value.trim().is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        });
+        let orchestrator = orchestrator.map(|value| {
             if value.trim().is_empty() {
                 None
             } else {
@@ -160,6 +171,7 @@ impl Execute for TaskUpdateArgs {
                 pr_status,
                 job_run_id,
                 crew,
+                orchestrator,
                 context_files: context_files.map(|c| crate::parse::csv_to_vec(&c)),
                 upsert_artifacts,
                 ..Default::default()

--- a/crates/orbit-common/src/types/task.rs
+++ b/crates/orbit-common/src/types/task.rs
@@ -598,6 +598,10 @@ pub struct Task {
     pub job_run_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub crew: Option<String>,
+    /// Explicit named crew that owns orchestration of this task. This is
+    /// attribution metadata only; execution resolution continues to use `crew`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub orchestrator: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/crates/orbit-common/src/types/task_artifacts.rs
+++ b/crates/orbit-common/src/types/task_artifacts.rs
@@ -68,6 +68,9 @@ pub struct TaskEnvelopeV2 {
     pub job_run_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub crew: Option<String>,
+    /// Named crew responsible for task orchestration, distinct from execution crew.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub orchestrator: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub relations: Vec<TaskRelation>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/orbit-common/src/types/tests/task_artifacts.rs
+++ b/crates/orbit-common/src/types/tests/task_artifacts.rs
@@ -68,6 +68,7 @@ updated_at: 2026-05-10T12:00:00Z
             pr_status: None,
             job_run_id: None,
             crew: None,
+            orchestrator: None,
             relations: Vec::new(),
             tags: Vec::new(),
             context_files: Vec::new(),
@@ -110,6 +111,28 @@ updated_at: 2026-05-10T12:00:00Z
         let mut envelope = valid_envelope("ORB-00001");
         envelope.schema_version = 2;
         assert!(envelope.validate().is_err());
+    }
+
+    #[test]
+    fn version_one_envelope_defaults_missing_orchestrator() {
+        let envelope = serde_yaml::from_str::<TaskEnvelopeV2>(&valid_envelope_yaml("ORB-00001"))
+            .expect("legacy v1 envelope remains readable");
+        assert_eq!(envelope.schema_version, TASK_ARTIFACT_SCHEMA_VERSION);
+        assert_eq!(envelope.orchestrator, None);
+    }
+
+    #[test]
+    fn version_one_envelope_round_trips_orchestrator_without_schema_bump() {
+        let mut envelope = valid_envelope("ORB-00001");
+        envelope.orchestrator = Some("orchestration-crew".to_string());
+
+        let yaml = serde_yaml::to_string(&envelope).expect("serialize envelope");
+        assert!(yaml.contains("schema_version: 1"));
+        assert!(yaml.contains("orchestrator: orchestration-crew"));
+        assert_eq!(
+            serde_yaml::from_str::<TaskEnvelopeV2>(&yaml).expect("deserialize envelope"),
+            envelope
+        );
     }
 
     #[test]

--- a/crates/orbit-core/src/command/search/tests/mod.rs
+++ b/crates/orbit-core/src/command/search/tests/mod.rs
@@ -64,6 +64,7 @@ fn add_task_with_status(runtime: &OrbitRuntime, title: &str, status: TaskStatus)
             external_refs: Vec::new(),
             source_task_id: None,
             crew: None,
+            orchestrator: None,
             comments: Vec::new(),
         })
         .expect("create task")

--- a/crates/orbit-core/src/command/task/add.rs
+++ b/crates/orbit-core/src/command/task/add.rs
@@ -63,6 +63,7 @@ impl OrbitRuntime {
             normalize_workspace_path(&self.paths().repo_root, params.workspace_path.as_deref())?;
         let dependencies = normalize_task_dependencies(params.dependencies.clone())?;
         self.validate_crew_name(params.crew.as_deref())?;
+        self.validate_crew_name(params.orchestrator.as_deref())?;
 
         let prune_root = context_workspace_root(&self.paths().repo_root, workspace_path.as_deref());
         let normalized_context_files =
@@ -95,6 +96,7 @@ impl OrbitRuntime {
                 external_refs: params.external_refs.clone(),
                 source_task_id: params.source_task_id.clone(),
                 crew: params.crew.clone(),
+                orchestrator: params.orchestrator.clone(),
                 comments: comments.clone(),
             })?;
             Ok((

--- a/crates/orbit-core/src/command/task/params.rs
+++ b/crates/orbit-core/src/command/task/params.rs
@@ -28,6 +28,8 @@ pub struct TaskAddParams {
     pub external_refs: Vec<ExternalRef>,
     pub source_task_id: Option<String>,
     pub crew: Option<String>,
+    /// Named crew responsible for orchestration attribution, not execution.
+    pub orchestrator: Option<String>,
 }
 
 impl Default for TaskAddParams {
@@ -52,6 +54,7 @@ impl Default for TaskAddParams {
             external_refs: Vec::new(),
             source_task_id: None,
             crew: None,
+            orchestrator: None,
         }
     }
 }
@@ -76,6 +79,7 @@ pub struct TaskUpdateParams {
     pub pr_status: Option<Option<String>>,
     pub job_run_id: Option<Option<String>>,
     pub crew: Option<Option<String>>,
+    pub orchestrator: Option<Option<String>>,
     pub context_files: Option<Vec<String>>,
     pub upsert_artifacts: Vec<TaskArtifact>,
 }
@@ -103,6 +107,7 @@ impl TaskUpdateParams {
             || self.pr_status.is_some()
             || self.job_run_id.is_some()
             || self.crew.is_some()
+            || self.orchestrator.is_some()
             || self.context_files.is_some()
             || !self.upsert_artifacts.is_empty()
     }
@@ -132,6 +137,7 @@ impl From<TaskUpdateParams> for TaskRecordUpdateParams {
             pr_status: p.pr_status,
             job_run_id: p.job_run_id,
             crew: p.crew,
+            orchestrator: p.orchestrator,
             context_files: p.context_files,
             upsert_artifacts: p.upsert_artifacts,
             ..Default::default()

--- a/crates/orbit-core/src/command/task/tests/mod.rs
+++ b/crates/orbit-core/src/command/task/tests/mod.rs
@@ -14,6 +14,24 @@ pub(super) fn test_runtime() -> (tempfile::TempDir, OrbitRuntime) {
     let workspace_root = repo_root.join(".orbit");
     std::fs::create_dir_all(&global_root).expect("create global root");
     std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    std::fs::write(
+        workspace_root.join("config.toml"),
+        r#"
+[workflow]
+default_crew = "implementer"
+
+[crews.implementer]
+model = "implementer-model"
+provider = "codex"
+backend = "cli"
+
+[crews.orchestration]
+model = "orchestration-model"
+provider = "codex"
+backend = "cli"
+"#,
+    )
+    .expect("write crew config");
     let runtime =
         OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build test runtime");
     (root, runtime)

--- a/crates/orbit-core/src/command/task/tests/update.rs
+++ b/crates/orbit-core/src/command/task/tests/update.rs
@@ -117,6 +117,84 @@ fn update_status_covers_approve_transitions() {
     assert_eq!(done.status, TaskStatus::Done);
 }
 
+#[test]
+fn orchestrator_is_explicit_mutable_before_start_and_never_routes_execution() {
+    let (_root, runtime) = test_runtime();
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Orchestration ownership".to_string(),
+            description: "Keep orchestration attribution separate from execution.".to_string(),
+            crew: Some("implementer".to_string()),
+            orchestrator: Some("orchestration".to_string()),
+            ..Default::default()
+        })
+        .expect("add task with orchestration attribution");
+    assert_eq!(task.orchestrator.as_deref(), Some("orchestration"));
+    assert_eq!(
+        runtime
+            .resolve_crew_for_task(None, task.crew.as_deref())
+            .expect("resolve execution crew")
+            .name,
+        "implementer"
+    );
+
+    let changed = runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                orchestrator: Some(Some("implementer".to_string())),
+                ..Default::default()
+            },
+        )
+        .expect("change orchestration attribution while proposed");
+    assert_eq!(changed.orchestrator.as_deref(), Some("implementer"));
+    let cleared = runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                orchestrator: Some(None),
+                ..Default::default()
+            },
+        )
+        .expect("clear orchestration attribution while proposed");
+    assert_eq!(cleared.orchestrator, None);
+
+    let invalid = runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                orchestrator: Some(Some("missing".to_string())),
+                ..Default::default()
+            },
+        )
+        .expect_err("reject unconfigured orchestrator");
+    assert!(invalid.to_string().contains("missing"), "{invalid}");
+
+    runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                plan: Some("Implement it.".to_string()),
+                status: Some(TaskStatus::InProgress),
+                ..Default::default()
+            },
+        )
+        .expect("start task");
+    let immutable = runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                orchestrator: Some(Some("orchestration".to_string())),
+                ..Default::default()
+            },
+        )
+        .expect_err("orchestrator becomes immutable after execution starts");
+    assert!(
+        immutable.to_string().contains("proposed or backlog"),
+        "{immutable}"
+    );
+}
+
 /// Walks a task through backlog -> in-progress -> review -> done using only
 /// `update_task`, satisfying the plan and execution-summary guards.
 fn drive_to_done(runtime: &OrbitRuntime, id: &str) -> Task {

--- a/crates/orbit-core/src/command/task/update.rs
+++ b/crates/orbit-core/src/command/task/update.rs
@@ -101,6 +101,15 @@ impl OrbitRuntime {
         if let Some(crew) = &params.crew {
             self.validate_crew_name(crew.as_deref())?;
         }
+        if let Some(orchestrator) = &params.orchestrator {
+            self.validate_crew_name(orchestrator.as_deref())?;
+            if !matches!(task.status, TaskStatus::Proposed | TaskStatus::Backlog) {
+                return Err(OrbitError::InvalidInput(format!(
+                    "task {id} is {}; orchestrator can only be changed while proposed or backlog",
+                    task.status
+                )));
+            }
+        }
         // Archived tasks accept exactly one mutation: the guarded restore to
         // backlog (formerly `orbit task unarchive`). Everything else requires
         // restoring the task first.

--- a/crates/orbit-core/src/runtime/orbit_tool_host/host.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/host.rs
@@ -262,6 +262,7 @@ impl HubCoordinationExecutor {
             external_refs: Vec::new(),
             source_task_id: None,
             crew: optional_string(&input, "crew")?,
+            orchestrator: optional_string(&input, "orchestrator")?,
             comments: Vec::new(),
         })?;
         self.task_json(&task)
@@ -295,6 +296,7 @@ impl HubCoordinationExecutor {
             "pr_status",
             "job_run_id",
             "crew",
+            "orchestrator",
             "context_files",
             "context",
             "artifacts",
@@ -393,6 +395,15 @@ impl HubCoordinationExecutor {
             .transpose()?;
         let explicit_planned_by = raw_clearable(&input, "planned_by")?;
         let explicit_implemented_by = raw_clearable(&input, "implemented_by")?;
+        let orchestrator = raw_clearable(&input, "orchestrator")?;
+        if orchestrator.is_some() {
+            if !matches!(current.status, TaskStatus::Proposed | TaskStatus::Backlog) {
+                return Err(OrbitError::InvalidInput(format!(
+                    "task {id} is {}; orchestrator can only be changed while proposed or backlog",
+                    current.status
+                )));
+            }
+        }
         self.inner.tasks.document.update_task_document(
             &id,
             TaskDocumentUpdateParams {
@@ -431,6 +442,7 @@ impl HubCoordinationExecutor {
                 source_task_id: raw_clearable(&input, "source_task_id")?,
                 job_run_id: raw_clearable(&input, "job_run_id")?,
                 crew: raw_clearable(&input, "crew")?,
+                orchestrator,
                 created_by: None,
             },
         )?;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/json.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/json.rs
@@ -69,6 +69,7 @@ pub(super) fn task_to_json(task: &Task, status_by_id: &BTreeMap<String, TaskStat
         "source_task_id": task.source_task_id(),
         "job_run_id": task.job_run_id,
         "crew": task.crew,
+        "orchestrator": task.orchestrator,
         "created_at": task.created_at.to_rfc3339(),
         "updated_at": task.updated_at.to_rfc3339(),
     })
@@ -167,11 +168,13 @@ fn task_field_to_json(
         "history" => serialize_history(&runtime.get_task_history(&task.id)?),
         "context_files" => serde_json::to_value(&task.context_files)
             .map_err(serialize_error("serialize context files")),
+        "orchestrator" => serde_json::to_value(&task.orchestrator)
+            .map_err(serialize_error("serialize orchestrator")),
         "artifacts" => Ok(serialize_task_artifacts(
             &runtime.get_task_artifacts(&task.id)?,
         )),
         other => Err(OrbitError::InvalidInput(format!(
-            "unknown field selector `{other}`. Valid values: comments, plan, execution_summary, description, acceptance_criteria, dependencies, resolved_dependencies, tags, history, context_files, artifacts"
+            "unknown field selector `{other}`. Valid values: comments, plan, execution_summary, description, acceptance_criteria, dependencies, resolved_dependencies, tags, history, context_files, orchestrator, artifacts"
         ))),
     }
 }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
@@ -70,6 +70,7 @@ pub(super) fn add(
             external_refs: Vec::new(),
             source_task_id: None,
             crew: optional_string(&input, "crew")?,
+            orchestrator: optional_string(&input, "orchestrator")?,
         },
         agent,
         model,
@@ -319,6 +320,7 @@ pub(super) fn update(
             pr_status: optional_raw_string(&input, "pr_status")?.map(empty_string_to_none),
             job_run_id: optional_raw_string(&input, "job_run_id")?.map(empty_string_to_none),
             crew: optional_raw_string(&input, "crew")?.map(empty_string_to_none),
+            orchestrator: optional_raw_string(&input, "orchestrator")?.map(empty_string_to_none),
             context_files: optional_csv_or_string_list_alias(
                 &input,
                 &["context_files", "context"],

--- a/crates/orbit-core/src/runtime/orbit_tool_host/test_support.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/test_support.rs
@@ -88,6 +88,7 @@ pub(super) fn create_task(
             external_refs: Vec::new(),
             source_task_id: None,
             crew: None,
+            orchestrator: None,
             comments: Vec::new(),
         })
         .expect("create task")

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
@@ -540,6 +540,7 @@ fn task_add_and_show_tools_roundtrip_crew() {
                 "description": "Exercise crew input on the agent-facing create path.",
                 "workspace": ".",
                 "crew": "sol",
+                "orchestrator": "sol",
             }),
             Some("codex".to_string()),
             Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
@@ -547,6 +548,7 @@ fn task_add_and_show_tools_roundtrip_crew() {
         .expect("task add tool succeeds with a valid crew");
     let task_id = added["id"].as_str().expect("task id");
     assert_eq!(added.get("crew"), Some(&json!("sol")));
+    assert_eq!(added.get("orchestrator"), Some(&json!("sol")));
 
     let shown = runtime
         .execute_tool_command(
@@ -557,6 +559,7 @@ fn task_add_and_show_tools_roundtrip_crew() {
         )
         .expect("task show tool succeeds");
     assert_eq!(shown.get("crew"), Some(&json!("sol")));
+    assert_eq!(shown.get("orchestrator"), Some(&json!("sol")));
 }
 
 #[test]

--- a/crates/orbit-core/src/runtime/task_records.rs
+++ b/crates/orbit-core/src/runtime/task_records.rs
@@ -34,6 +34,7 @@ pub(crate) struct TaskRecordUpdateParams {
     pub(crate) source_task_id: Option<Option<String>>,
     pub(crate) job_run_id: Option<Option<String>>,
     pub(crate) crew: Option<Option<String>>,
+    pub(crate) orchestrator: Option<Option<String>>,
     pub(crate) status_event: Option<String>,
     pub(crate) status_note: Option<String>,
     pub(crate) append_history: Vec<TaskHistoryEntry>,
@@ -63,6 +64,7 @@ impl TaskRecordUpdateParams {
             || self.source_task_id.is_some()
             || self.job_run_id.is_some()
             || self.crew.is_some()
+            || self.orchestrator.is_some()
     }
 
     fn has_history_changes(&self) -> bool {
@@ -140,6 +142,7 @@ impl TaskRecordService<'_> {
                     source_task_id: params.source_task_id.clone(),
                     job_run_id: params.job_run_id.clone(),
                     crew: params.crew.clone(),
+                    orchestrator: params.orchestrator.clone(),
                 },
             )?;
         }

--- a/crates/orbit-core/src/runtime/tests/authorization.rs
+++ b/crates/orbit-core/src/runtime/tests/authorization.rs
@@ -58,6 +58,7 @@ fn seed_task(runtime: &OrbitRuntime) -> String {
             external_refs: Vec::new(),
             source_task_id: None,
             crew: None,
+            orchestrator: None,
             comments: Vec::new(),
         })
         .expect("create task")

--- a/crates/orbit-core/src/runtime/tests/task_block_on_run_failure.rs
+++ b/crates/orbit-core/src/runtime/tests/task_block_on_run_failure.rs
@@ -60,6 +60,7 @@ fn create_backlog_task(
             external_refs: Vec::new(),
             source_task_id: None,
             crew: None,
+            orchestrator: None,
             comments: Vec::new(),
         })
         .expect("create task")

--- a/crates/orbit-core/src/runtime/tests/task_reservation_cleanup.rs
+++ b/crates/orbit-core/src/runtime/tests/task_reservation_cleanup.rs
@@ -76,6 +76,7 @@ fn create_context_task_with_status(
             external_refs: Vec::new(),
             source_task_id: None,
             crew: None,
+            orchestrator: None,
             comments: Vec::new(),
         })
         .expect("create task");

--- a/crates/orbit-core/src/runtime/tests/tool_exec.rs
+++ b/crates/orbit-core/src/runtime/tests/tool_exec.rs
@@ -38,6 +38,7 @@ fn run_tool_context_allowlist_honors_task_wildcard() {
             external_refs: Vec::new(),
             source_task_id: None,
             crew: None,
+            orchestrator: None,
             comments: Vec::new(),
         })
         .expect("create task");

--- a/crates/orbit-core/src/runtime/v2_host/tests/triage.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/triage.rs
@@ -63,6 +63,7 @@ fn create_backlog_task(
             external_refs: Vec::new(),
             source_task_id: None,
             crew: None,
+            orchestrator: None,
             comments: Vec::new(),
         })
         .expect("create task")

--- a/crates/orbit-dashboard/assets/dashboard/tasks.js
+++ b/crates/orbit-dashboard/assets/dashboard/tasks.js
@@ -154,6 +154,7 @@ function filterTasks(tasks, context) {
 }
 
 const TASK_META_FIELDS = [
+  ["orchestrator", "orchestrator"],
   ["implemented_by", "implemented_by"],
   ["planned_by", "planned_by"],
   ["created_by", "created_by"],

--- a/crates/orbit-dashboard/src/api/tasks.rs
+++ b/crates/orbit-dashboard/src/api/tasks.rs
@@ -102,6 +102,8 @@ pub(super) struct CreateTaskBody {
     source_task_id: Option<String>,
     #[serde(default)]
     crew: Option<String>,
+    #[serde(default)]
+    orchestrator: Option<String>,
 }
 
 fn default_priority() -> TaskPriority {
@@ -143,6 +145,8 @@ pub(super) struct UpdateTaskBody {
     context_files: Option<Vec<String>>,
     #[serde(default, deserialize_with = "deserialize_nullable_string_patch_field")]
     crew: Option<Option<String>>,
+    #[serde(default, deserialize_with = "deserialize_nullable_string_patch_field")]
+    orchestrator: Option<Option<String>>,
 }
 
 fn deserialize_nullable_string_patch_field<'de, D>(
@@ -515,6 +519,7 @@ pub(super) async fn create_task_action(
         external_refs: body.external_refs,
         source_task_id: body.source_task_id,
         crew: body.crew,
+        orchestrator: body.orchestrator,
     };
     match runtime.add_task_with_identity(params, None, None) {
         Ok(task) => match dashboard_status_index(&runtime) {
@@ -556,6 +561,7 @@ pub(super) async fn update_task_action(
         pr_status: body.pr_status,
         job_run_id: None,
         crew: body.crew,
+        orchestrator: body.orchestrator,
         context_files: body.context_files,
         upsert_artifacts: Vec::new(),
     };

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/message.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/message.rs
@@ -173,6 +173,7 @@ fn task_with_type(task_type: TaskType, title: &str) -> Task {
         relations: Vec::new(),
         job_run_id: None,
         crew: None,
+        orchestrator: None,
         created_at: now,
         updated_at: now,
     }

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/test_support.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/test_support.rs
@@ -303,6 +303,7 @@ pub fn task_with_file(id: &str, title: &str, path: &str, implemented_by: &str) -
         relations: Vec::new(),
         job_run_id: Some("batch-1".to_string()),
         crew: None,
+        orchestrator: None,
         created_at: now,
         updated_at: now,
     }

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
@@ -415,6 +415,7 @@ pub fn task(id: &str, title: &str, execution_summary: &str) -> Task {
         relations: Vec::new(),
         job_run_id: None,
         crew: None,
+        orchestrator: None,
         created_at: now,
         updated_at: now,
     }

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/dependency_delivery.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/dependency_delivery.rs
@@ -502,6 +502,7 @@ fn task_fixture(id: &str, status: TaskStatus) -> Task {
         relations: Vec::new(),
         job_run_id: None,
         crew: None,
+        orchestrator: None,
         created_at: now,
         updated_at: now,
     }

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/gc.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/gc.rs
@@ -91,6 +91,7 @@ fn task_fixture(id: &str, status: TaskStatus) -> Task {
         relations: Vec::new(),
         job_run_id: None,
         crew: None,
+        orchestrator: None,
         created_at: now,
         updated_at: now,
     }

--- a/crates/orbit-search/src/commands/tests/related.rs
+++ b/crates/orbit-search/src/commands/tests/related.rs
@@ -64,6 +64,7 @@ fn task(id: &str, title: &str, description: &str) -> Task {
         relations: Vec::new(),
         job_run_id: None,
         crew: None,
+        orchestrator: None,
         created_at: Utc::now(),
         updated_at: Utc::now(),
     }

--- a/crates/orbit-search/src/commands/tests/search.rs
+++ b/crates/orbit-search/src/commands/tests/search.rs
@@ -66,6 +66,7 @@ fn task(id: &str, title: &str, description: &str, plan: &str) -> Task {
         relations: Vec::new(),
         job_run_id: None,
         crew: None,
+        orchestrator: None,
         created_at: Utc::now(),
         updated_at: Utc::now(),
     }

--- a/crates/orbit-search/src/vector/store/tests/tasks.rs
+++ b/crates/orbit-search/src/vector/store/tests/tasks.rs
@@ -27,6 +27,7 @@ fn task(id: &str, title: &str, description: &str) -> Task {
         relations: Vec::new(),
         job_run_id: None,
         crew: None,
+        orchestrator: None,
         tags: Vec::new(),
         created_at: Utc::now(),
         updated_at: Utc::now(),

--- a/crates/orbit-search/src/vector/tests/task_fields.rs
+++ b/crates/orbit-search/src/vector/tests/task_fields.rs
@@ -26,6 +26,7 @@ fn task() -> Task {
         relations: Vec::new(),
         job_run_id: None,
         crew: None,
+        orchestrator: None,
         tags: Vec::new(),
         created_at: Utc::now(),
         updated_at: Utc::now(),

--- a/crates/orbit-search/tests/parity.rs
+++ b/crates/orbit-search/tests/parity.rs
@@ -36,6 +36,7 @@ fn fixture_task(id: &str) -> Task {
         relations: Vec::new(),
         job_run_id: None,
         crew: None,
+        orchestrator: None,
         tags: Vec::new(),
         created_at: Utc::now(),
         updated_at: Utc::now(),

--- a/crates/orbit-store/src/backend/contracts/params.rs
+++ b/crates/orbit-store/src/backend/contracts/params.rs
@@ -120,6 +120,7 @@ pub struct TaskCreateParams {
     pub external_refs: Vec<ExternalRef>,
     pub source_task_id: Option<String>,
     pub crew: Option<String>,
+    pub orchestrator: Option<String>,
     pub comments: Vec<TaskComment>,
 }
 
@@ -153,6 +154,7 @@ pub struct TaskDocumentUpdateParams {
     pub source_task_id: Option<Option<String>>,
     pub job_run_id: Option<Option<String>>,
     pub crew: Option<Option<String>>,
+    pub orchestrator: Option<Option<String>>,
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/orbit-store/src/backend/factory/tests/factory.rs
+++ b/crates/orbit-store/src/backend/factory/tests/factory.rs
@@ -35,6 +35,7 @@ fn task_params(title: &str, status: TaskStatus) -> TaskCreateParams {
         external_refs: Vec::new(),
         source_task_id: None,
         crew: None,
+        orchestrator: None,
         comments: Vec::new(),
     }
 }
@@ -91,6 +92,7 @@ fn workspace_task_backends_exposes_create_get_and_list_trait_surface() {
             external_refs: Vec::new(),
             source_task_id: None,
             crew: None,
+            orchestrator: None,
             comments: Vec::new(),
         })
         .expect("create task");

--- a/crates/orbit-store/src/file/friction_store/tests/friction_store.rs
+++ b/crates/orbit-store/src/file/friction_store/tests/friction_store.rs
@@ -203,6 +203,7 @@ fn task(id: &str, status: TaskStatus) -> Task {
         relations: Vec::new(),
         job_run_id: None,
         crew: None,
+        orchestrator: None,
         created_at: now,
         updated_at: now,
     }

--- a/crates/orbit-store/src/file/scoreboard/scoreboard_summary/tests/scoreboard_summary.rs
+++ b/crates/orbit-store/src/file/scoreboard/scoreboard_summary/tests/scoreboard_summary.rs
@@ -511,6 +511,7 @@ fn test_task_no_attrib(id: &str, status: TaskStatus) -> orbit_common::types::Tas
         relations: Vec::new(),
         job_run_id: None,
         crew: None,
+        orchestrator: None,
         created_at: Utc::now(),
         updated_at: Utc::now(),
     }

--- a/crates/orbit-store/src/file/task_store/tests/test_support.rs
+++ b/crates/orbit-store/src/file/task_store/tests/test_support.rs
@@ -29,6 +29,7 @@ pub(crate) fn sample_bundle(id: &str) -> TaskBundleV2 {
             pr_status: None,
             job_run_id: None,
             crew: None,
+            orchestrator: None,
             relations: Vec::new(),
             tags: vec!["task-artifacts".to_string()],
             context_files: vec!["docs/design/task-artifacts/2_design.md".to_string()],

--- a/crates/orbit-store/src/file/task_store/v2/crud.rs
+++ b/crates/orbit-store/src/file/task_store/v2/crud.rs
@@ -44,6 +44,7 @@ impl TaskV2Store {
                 pr_status: None,
                 job_run_id: None,
                 crew: params.crew,
+                orchestrator: params.orchestrator,
                 relations,
                 tags: normalize_task_tags(params.tags),
                 context_files: params.context_files,

--- a/crates/orbit-store/src/file/task_store/v2/index.rs
+++ b/crates/orbit-store/src/file/task_store/v2/index.rs
@@ -113,6 +113,7 @@ impl TaskV2Store {
             relations: bundle.envelope.relations,
             job_run_id: bundle.envelope.job_run_id,
             crew: bundle.envelope.crew,
+            orchestrator: bundle.envelope.orchestrator,
             created_at: bundle.envelope.created_at,
             updated_at: bundle.envelope.updated_at,
         })

--- a/crates/orbit-store/src/file/task_store/v2/tests/crud.rs
+++ b/crates/orbit-store/src/file/task_store/v2/tests/crud.rs
@@ -5,9 +5,9 @@ fn create_get_and_list_task_round_trip_through_v2_bundle() {
     let temp = TempDir::new().expect("tempdir");
     let store = store(&temp);
 
-    let created = store
-        .create_task(create_params("Build task v2", TaskStatus::Backlog))
-        .expect("create task");
+    let mut params = create_params("Build task v2", TaskStatus::Backlog);
+    params.orchestrator = Some("orchestration".to_string());
+    let created = store.create_task(params).expect("create task");
 
     assert_eq!(created.id, "ORB-00000");
     assert_eq!(
@@ -36,6 +36,7 @@ fn create_get_and_list_task_round_trip_through_v2_bundle() {
         .expect("get task")
         .expect("task exists");
     assert_eq!(fetched.title, created.title);
+    assert_eq!(fetched.orchestrator.as_deref(), Some("orchestration"));
 
     let listed = store.list_tasks().expect("list tasks");
     assert_eq!(listed.len(), 1);

--- a/crates/orbit-store/src/file/task_store/v2/tests/mod.rs
+++ b/crates/orbit-store/src/file/task_store/v2/tests/mod.rs
@@ -66,6 +66,7 @@ pub(super) fn create_params(title: &str, status: TaskStatus) -> TaskCreateParams
         ],
         source_task_id: None,
         crew: None,
+        orchestrator: None,
         comments: vec![TaskComment {
             at: now,
             by: "daniel".to_string(),

--- a/crates/orbit-store/src/file/task_store/v2/updates.rs
+++ b/crates/orbit-store/src/file/task_store/v2/updates.rs
@@ -104,6 +104,10 @@ impl TaskV2Store {
                 bundle.envelope.crew = value.clone();
                 envelope_changed = true;
             }
+            if let Some(value) = &fields.orchestrator {
+                bundle.envelope.orchestrator = value.clone();
+                envelope_changed = true;
+            }
             if let Some(value) = &fields.external_refs {
                 bundle.envelope.external_refs = value.clone();
                 envelope_changed = true;

--- a/crates/orbit-store/src/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/tests/mod.rs
@@ -74,6 +74,7 @@ fn envelope(
         pr_status: None,
         job_run_id: None,
         crew: None,
+        orchestrator: None,
         relations,
         tags,
         context_files: Vec::new(),

--- a/crates/orbit-store/src/task_migration/tests/mod.rs
+++ b/crates/orbit-store/src/task_migration/tests/mod.rs
@@ -61,6 +61,7 @@ fn make_bundle(id: &str, title: &str, relations: Vec<TaskRelation>) -> TaskBundl
             pr_status: None,
             job_run_id: None,
             crew: None,
+            orchestrator: Some("archive-orchestrator".to_string()),
             relations,
             tags: vec!["migration".to_string()],
             context_files: Vec::new(),
@@ -180,6 +181,10 @@ fn round_trip_keeps_ids_and_content() {
     .unwrap();
     assert_eq!(landed_a, a);
     assert_eq!(landed_b, b);
+    assert_eq!(
+        landed_a.envelope.orchestrator.as_deref(),
+        Some("archive-orchestrator")
+    );
 
     // Index rows exist and allocator advanced past ORB-00001.
     assert_eq!(

--- a/crates/orbit-tools/src/builtin/orbit/task/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add.rs
@@ -89,6 +89,12 @@ impl Tool for OrbitTaskAddTool {
                 param_type: "string".to_string(),
                 required: false,
             },
+            ToolParam {
+                name: "orchestrator".to_string(),
+                description: "Optional named crew responsible for orchestration attribution; does not select execution".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
         ];
         parameters.extend(super::super::model_identity_params());
 

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
@@ -165,6 +165,7 @@ fn schema_exposes_only_trimmed_create_task_fields() {
             "type",
             "relations",
             "crew",
+            "orchestrator",
             "model",
         ]
     );

--- a/crates/orbit-tools/src/builtin/orbit/task/update.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/update.rs
@@ -127,6 +127,12 @@ impl Tool for OrbitTaskUpdateTool {
                 required: false,
             },
             ToolParam {
+                name: "orchestrator".to_string(),
+                description: "Named crew responsible for orchestration attribution (empty string clears; mutable only before execution)".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
                 name: "context_files".to_string(),
                 description:
                     "Task context selectors as a comma-separated string or array of strings. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files referenced only for context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically."

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -259,6 +259,7 @@ fn task_add_schema_uses_trimmed_authoring_surface() {
             "type",
             "relations",
             "crew",
+            "orchestrator",
             "model",
         ]
     );
@@ -289,6 +290,13 @@ fn task_update_dependency_params_remain_in_agent_tool_schema() {
     assert!(
         schema.parameters.iter().any(|param| param.name == "crew"),
         "orbit.task.update should expose crew"
+    );
+    assert!(
+        schema
+            .parameters
+            .iter()
+            .any(|param| param.name == "orchestrator"),
+        "orbit.task.update should expose explicit orchestration attribution"
     );
 }
 

--- a/docs/design/task-artifacts/2_design.md
+++ b/docs/design/task-artifacts/2_design.md
@@ -3,7 +3,7 @@ summary: "Task Artifacts — Design"
 type: design
 title: "Task Artifacts — Design"
 owner: codex
-last_updated: 2026-07-26
+last_updated: 2026-08-02
 status: Draft
 feature: task-artifacts
 doc_role: design
@@ -64,6 +64,8 @@ type: feature
 priority: high
 complexity: hard
 job_run_id: null
+crew: implementer-crew
+orchestrator: orchestration-crew
 relations:
   - type: supersedes
     target: ORB-00000
@@ -79,7 +81,7 @@ created_at: 2026-05-11T00:00:00Z
 updated_at: 2026-05-11T00:00:00Z
 ```
 
-The envelope should not include prose bodies, comments, review message bodies, execution summaries, `workspace_path`, `repo_root`, `agent`, `model`, or the old `batch_id` name. Local execution bindings live in the local task registry, keyed by task ID and workspace binding. Execution fan-out membership is `job_run_id`, a foreign reference to the job-run store rather than a task relation. `relations` can also carry cross-artifact provenance via `produces` and `resolves` targets (`ORB-`, `F`, `L`, or `ADR-` IDs); legacy task relation types remain task-only. `schema_version` restarts at `1` because the reset defines a new artifact family; the cutover command knows how to read the old schema but v2 does not continue its compatibility stream.
+The envelope should not include prose bodies, comments, review message bodies, execution summaries, `workspace_path`, `repo_root`, `agent`, `model`, or the old `batch_id` name. Local execution bindings live in the local task registry, keyed by task ID and workspace binding. Execution fan-out membership is `job_run_id`, a foreign reference to the job-run store rather than a task relation. `crew` selects the named execution crew; `orchestrator` is separate, explicit attribution for the named crew responsible for orchestrating the task. It never selects a model/provider and is never inferred from actor attribution or `crew`. A non-empty orchestrator must name a configured crew and may be set, changed, or cleared only while the task is `proposed` or `backlog`; stored aliases remain readable if configuration later removes them. `relations` can also carry cross-artifact provenance via `produces` and `resolves` targets (`ORB-`, `F`, `L`, or `ADR-` IDs); legacy task relation types remain task-only. `schema_version` remains `1`: readers default a missing `orchestrator` to `null`, but older writers may drop the new field, so forward compatibility is limited to tolerant reads rather than preservation through legacy rewrites.
 
 ## 3. Prose Documents
 

--- a/docs/design/task-artifacts/specs/task-bundle-v2.md
+++ b/docs/design/task-artifacts/specs/task-bundle-v2.md
@@ -93,6 +93,8 @@ type: chore
 priority: medium
 complexity: null
 job_run_id: null
+crew: implementer-crew
+orchestrator: orchestration-crew
 relations:
   - type: resolves
     target: F2026-05-007
@@ -108,7 +110,7 @@ updated_at: 2026-05-11T00:00:00Z
 
 The envelope must not contain `description`, `acceptance_criteria`, `plan`, `execution_summary`, `history`, `comments`, or `review_threads`.
 The envelope must not contain local-only `workspace_path` or `repo_root`; those live in the local registry workspace binding.
-The envelope must not contain the old `batch_id` name or internal execution-routing fields such as `agent` and `model`; job-run membership is stored as `job_run_id`, while durable task attribution uses `created_by`, `planned_by`, and `implemented_by`.
+The envelope must not contain the old `batch_id` name or internal execution-routing fields such as `agent` and `model`; job-run membership is stored as `job_run_id`, while durable task attribution uses `created_by`, `planned_by`, `implemented_by`, and the explicit `orchestrator` named-crew alias. `crew` is execution selection only; `orchestrator` is read-only orchestration attribution, never a model/provider selector. It is mutable only in `proposed` and `backlog`, and a missing field in a schema-v1 bundle reads as `null`. A legacy writer can omit this additive field, so schema-v1 compatibility guarantees readability rather than preservation across legacy writes.
 Task-only relation types must target `ORB-` IDs. `produces` and `resolves` may additionally target friction, learning, and ADR IDs.
 
 ## Documents


### PR DESCRIPTION
## Task

[ORB-10580](https://orbit-cli.com/tasks/ORB-10580) — Add explicit orchestration ownership to tasks

### Description

Implement ADR-0310's v1 task attribution contract. Add optional `orchestrator` task metadata containing a registered named crew alias. It must remain distinct from execution `crew`, be explicit rather than inferred, preserve legacy readability, and become immutable once task execution starts. Plumb the field through local and checkoutless task writes, persistence, CLI, MCP/tool schemas, task API/detail projections, tests, and task-artifact documentation.

### Acceptance Criteria

- Task and task-envelope models expose `orchestrator: Option<String>` with omission for `None`; existing version-1 bundles deserialize as `None` and new bundles round-trip without a task artifact schema bump.
- Task add and update accept an orchestrator on every local, checkoutless, CLI, MCP, and builtin-tool write path, including an explicit clear operation while the task is proposed or backlog.
- Explicit non-empty writes validate against the same authoritative named-crew registry as execution crew, while reads continue to tolerate a stored alias that is no longer configured.
- The orchestrator may be assigned, changed, or cleared only while a task is proposed or backlog and is rejected once the task is in-progress, review, blocked, or done.
- Execution crew resolution continues to use only `task.crew`; `task.orchestrator` never selects the implementing model or provider and is never inferred from created_by, implemented_by, execution crew, or runtime actor.
- Task JSON, CLI show output, task detail API/projection, and dashboard task details expose the field as a separate read-only attribution value.
- Tests cover legacy bundle compatibility, new bundle and archive round-trip, add/update/clear, invalid crew aliases, post-start immutability, local and hub paths, generated tool schemas, MCP snapshots, and execution-routing non-interference.
- Task artifact and configuration documentation define semantics, lifecycle mutability, schema-v1 forward-compatibility limitations, and the distinction from execution crew.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added optional task/envelope `orchestrator` attribution with schema-v1 omission and legacy-read compatibility.
- Plumbed create/update/clear through runtime, persistence, CLI, MCP/builtin schemas, dashboard details, JSON projections, and archive/bundle paths; mutation is limited to proposed/backlog and execution resolution continues to read only `crew`.
- Added model, lifecycle, tool-schema, bundle, and archive round-trip coverage; documented field semantics and forward-compatibility limits.
Assessment: scoped implementation is formatted, compiles across the workspace, and passes targeted tests plus `make ci-fast`.
Deviations from original plan:
- Expanded context selectors for tightly coupled public Task fixture and archive test updates required by the added field.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10580-6a6ec836`
- Behind base: 0
- Ahead of base: 1