### PR TITLE
File the ADR for the process-global output sink

### DIFF
--- a/crates/orbit-cli/src/output/sink.rs
+++ b/crates/orbit-cli/src/output/sink.rs
@@ -8,10 +8,12 @@
 //!
 //! `main` resolves the sink, [`install`]s it, and calls
 //! [`OutputSink::apply_color_policy`]; every renderer then reads [`active`]
-//! rather than asking the environment. Color emission is decided in exactly one
-//! place: `apply_color_policy` overrides the `colored` crate's own env
-//! detection, and `output::table` hands the same answer to `comfy_table`, so the
-//! two styling backends can no longer disagree about `NO_COLOR` [ADR-0308].
+//! rather than asking the environment. The sink is a process global rather
+//! than a parameter threaded through `Execute::execute` [ADR-0314]. Color
+//! emission is decided in exactly one place: `apply_color_policy` overrides
+//! the `colored` crate's own env detection, and `output::table` hands the
+//! same answer to `comfy_table`, so the two styling backends can no longer
+//! disagree about `NO_COLOR` [ADR-0308].
 
 use std::io::IsTerminal;
 use std::sync::OnceLock;

--- a/docs/design/terminal-interface/2_design.md
+++ b/docs/design/terminal-interface/2_design.md
@@ -11,7 +11,7 @@ summary: "Current orbit-cli output implementation — borderless single-line tab
 tags: [terminal-interface]
 paths: ["crates/orbit-cli/src/output/**", "crates/orbit-cli/src/command/**"]
 related_features: [terminal-interface]
-related_artifacts: [ADR-0306, ADR-0307, ADR-0308]
+related_artifacts: [ADR-0306, ADR-0307, ADR-0308, ADR-0314]
 ---
 
 # Terminal Interface — Design
@@ -98,7 +98,7 @@ The first rendering assertions arrived with the borderless migration [ORB-10567]
 
 **The sink is a process global.** `sink::active()` is a `OnceLock` read, so a renderer's behavior depends on whether `main` ran. Unit tests get the piped default — the safe answer, but not the one an interactive run gets — so a test that means to exercise the terminal path has to build a sink explicitly and pass it in; `Table::render(width, styled)` exists for that, and `Table::print()` is the only function that reads the global. A future in-process consumer (a test harness, an embedded invocation) cannot render two different sinks concurrently.
 
-The alternative — threading the sink through `Execute::execute` — is the correct end state and is exactly [./specs/output-modes.md](./specs/output-modes.md) §7 step 3's signature change. It was not done here because it would have held the `NO_COLOR` fix behind a 154-impl refactor. Having each renderer call `OutputSink::from_process()` was also rejected: it re-derives terminal state per render, which is the drift [ADR-0306] exists to remove, and defeats the guard script. **This decision has no ADR yet** — the ADR store was not writable in the runner that landed [ORB-10570]; [ORB-10585] tracks filing it, and carries the drafted body.
+This decision — the sink as a process global rather than a parameter threaded through `Execute::execute` — is recorded in [ADR-0314], including the rejected alternatives (threading the sink through `Execute::execute` now, having each renderer call `OutputSink::from_process()` itself, a thread-local instead of a `OnceLock`).
 
 ## Task References
 

--- a/docs/design/terminal-interface/4_decisions.md
+++ b/docs/design/terminal-interface/4_decisions.md
@@ -1,8 +1,8 @@
 ---
 title: Terminal Interface — Decisions
 owner: claude
-last_updated: 2026-08-01
-last_validated: 2026-08-01
+last_updated: 2026-08-02
+last_validated: 2026-08-02
 status: Accepted
 feature: terminal-interface
 doc_role: decisions
@@ -11,23 +11,26 @@ summary: "Ordered ADR pointer index for orbit's terminal output surface."
 tags: [terminal-interface]
 paths: ["crates/orbit-cli/src/output/**"]
 related_features: [terminal-interface]
-related_artifacts: [ADR-0306, ADR-0307, ADR-0308]
+related_artifacts: [ADR-0306, ADR-0307, ADR-0308, ADR-0314]
 ---
 
 # Terminal Interface — Decisions
 
 Ordered pointer index for terminal-interface's ADRs. **Allocate the global `ADR-NNNN` via `orbit.adr.add` before adding the pointer** — never hand-author a four-digit number. The store owns the title, status, body, owner, and links; retrieve an ADR's authoritative narrative with `orbit tool run orbit.adr.show --input '{"id":"ADR-NNNN"}'`. See [CONVENTIONS.md §4](../CONVENTIONS.md#4-adr-template-strict) for the full rules (when a decision earns an ADR, the mandatory Cost line, rollups).
 
-All three entries were accepted on 2026-08-02, ahead of the implementation work that makes the code conform. That ordering is deliberate — the specs in [./specs/](./specs/) are the reviewed contract, and [2_design.md](./2_design.md) records per-mechanism where the code still diverges from it. A divergence noted there is scheduled work, not an unmade decision.
+ADR-0306, ADR-0307, and ADR-0308 were accepted on 2026-08-02, ahead of the implementation work that makes the code conform. That ordering is deliberate — the specs in [./specs/](./specs/) are the reviewed contract, and [2_design.md](./2_design.md) records per-mechanism where the code still diverges from it. A divergence noted there is scheduled work, not an unmade decision. ADR-0314 is the inverse case: the implementation ([ORB-10570]) landed first, and the ADR was filed after, once the store was writable again.
 
 - **ADR-0306 — Terminal Output Is a Rendering of a Structured Payload** — Accepted. Commands produce payloads; a central renderer resolves mode (`auto|table|json|ndjson`) from flags and TTY state. Generalizes the error payload shape established by [ORB-10356]. Implemented by [./specs/output-modes.md](./specs/output-modes.md).
 - **ADR-0307 — Borderless Tables With Truncate-to-Width Rows** — Accepted. Drops the box preset; a row is exactly one line, truncated with `…` and backed by a detail command. Reverses the wrapping arrangement introduced by [T20260411-0335]. Implemented by [./specs/table-rendering.md](./specs/table-rendering.md).
 - **ADR-0308 — One Semantic Color Vocabulary, Gated at the Sink** — Accepted. A closed role set replaces the two duplicated palettes; `NO_COLOR`, `--color`, and TTY state are resolved once. Consolidates the vocabulary [T20260427-43] extended in two places at once. Implemented by [./specs/color-and-styling.md](./specs/color-and-styling.md).
+- **ADR-0314 — The Output Sink Is a Process Global, Not a Renderer Parameter** — Accepted. `main` resolves the sink into a `OnceLock`; renderers read it rather than taking it as a parameter, because `Execute::execute` takes no renderer argument. Rejected threading it through `Execute::execute` now — that is [ADR-0306] step 3's 154-impl signature change, deferred rather than duplicated. See [2_design.md](./2_design.md) §9.
 
 ## Task References
 
 - [T20260411-0335] — introduced the table arrangement [ADR-0307] reverses.
 - [T20260427-43] — extended the duplicated color vocabulary [ADR-0308] consolidates.
 - [ORB-10356] — made `OrbitError` `#[non_exhaustive]`, establishing the error payload shape [ADR-0306] generalizes.
+- [ORB-10570] — wired the sink into color and width, the implementation [ADR-0314] documents.
+- [ORB-10585] — filed [ADR-0314], which [ORB-10570] could not allocate.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10585](https://orbit-cli.com/tasks/ORB-10585) — File the ADR for the process-global output sink

### Description

## Problem

[ORB-10570] wired the output sink into the color and table modules. Reaching the
sink from a free function called by an `Execute::execute` body that was never
given one required a process-global `OnceLock` (`output::sink::install` /
`output::sink::active`). That is a real architectural decision with a real
rejected alternative -- thread it through the trait, which is
`specs/output-modes.md` section 7 step 3 -- and the repo requires an ADR for it.

The ADR could not be filed in the same PR: the runner that executed ORB-10570
had `<workspace>/.orbit/adrs/` on a read-only mount, so `orbit.adr.add` failed
with `io_error: Read-only file system`. No ID was invented.
`docs/design/terminal-interface/2_design.md` section 9 currently states the
decision and its rejected alternatives inline and points here.

## Work

1. `orbit.adr.add` with the body below (drafted and reviewed as part of
   ORB-10570), then accept it against ORB-10570.
2. Replace the inline paragraph in `docs/design/terminal-interface/2_design.md`
   section 9 with a reference to the allocated ADR, and add the ID to that
   file's `related_artifacts` frontmatter.
3. Add the same reference to `crates/orbit-cli/src/output/sink.rs`'s module
   docs, next to the existing ADR-0306 / ADR-0308 citations.

## Drafted ADR body

Title: **The Output Sink Is a Process Global, Not a Renderer Parameter**

## Context

[ADR-0306] resolves the output sink once per invocation and requires every renderer to read it rather than re-derive terminal state. [ADR-0308] adds that color emission must be decided in exactly one place. Both presuppose that a renderer can *reach* the sink.

It cannot, by parameter. Rendering in `orbit-cli` happens inside `Execute::execute(self, &OrbitRuntime) -> Result<(), OrbitError>`, which takes no renderer argument, across 154 `impl Execute` blocks and 98 command modules that call `println!` or `Table::print()` directly. `output/table.rs::Table::print` and `output/color.rs` are free functions those bodies call; neither has a call-site-provided sink to consult.

[ADR-0306]'s migration step 3 changes that signature so commands return payloads, and is explicitly the expensive step. [ORB-10570]'s scope — gate color and width at the sink — is independent of it and was sequenced before it precisely so that `NO_COLOR=1` stops emitting escape sequences without waiting on a 154-impl refactor.

So the sink has to be reachable from a free function called by a body that was not given one.

## Decision

`main` resolves the sink and publishes it into a `OnceLock` (`output::sink::install`); renderers read `output::sink::active()`.

- Before `install` runs, `active()` answers with a **piped** sink: not a terminal, width 0, no color, plain mode. The default is chosen so the failure mode of forgetting to install is unstyled untruncated output, never escape sequences written into a file.
- A duplicate `install` is logged at `debug` and ignored, not a panic. The sink is read-mostly configuration; aborting a user's command over it, or changing rendering halfway through one, are both worse than the second call being inert.
- `main` also calls `sink.apply_color_policy()`, which overrides the `colored` crate's own process-global env detection. `comfy_table` has no equivalent global, so `output::table` passes the same answer per render via `enforce_styling` / `force_no_tty`.
- Tests never call `OutputSink::from_process`. They build a sink with `OutputSink::resolve` and pass its answers to `Table::render(width, styled)` directly. The one test that flips the `colored` global serializes on a mutex and restores detection on drop.

Rejected alternative: **thread the sink through `Execute::execute`.** This is the correct end state and is what [ADR-0306] step 3 does. Rejected *for now* because it is the same 154-impl signature change that step 3 already owns; doing it here would either duplicate that churn or merge two independently reviewable changes, and would delay the `NO_COLOR` fix behind it. When step 3 lands, `active()` becomes removable in favor of the threaded value, and this ADR should be superseded rather than extended.

Rejected alternative: **have each renderer call `OutputSink::from_process()` itself.** Cheap and needs no global, but it re-derives terminal state per render — exactly the drift [ADR-0306] exists to remove — and would re-issue a `TIOCGWINSZ` ioctl per table. It also defeats `scripts/check-terminal-state-guard.sh`, whose whole premise is that one file queries the environment.

Rejected alternative: **a thread-local rather than a `OnceLock`.** Correct for concurrent in-process consumers, but `orbit-cli` renders from one thread and a thread-local would silently answer "piped" on any worker thread that rendered, which is a harder bug to see than the limitation below.

## Consequences

- `Table::print`, `output::color`, and `command/log/tail.rs` all read one answer, so the two styling backends can no longer disagree about `NO_COLOR`. That is the property [ORB-10570] exists to establish, and it is testable without a running `main`.
- The guard script's allowlist shrinks to the sink and its tests; `command/log/tail.rs` is no longer a grandfathered exception.
- Cost: a renderer's behavior depends on whether `main` ran. A unit test gets the piped default, which is the safe answer but not the interactive one, so a test that means to exercise the terminal path must build a sink explicitly and pass it — `Table::render(width, styled)` exists for exactly that, and `Table::print()` is the only function that reads the global.
- Cost: two sinks cannot be active concurrently in one process. An embedded or in-process invocation that wanted to render for a different destination would have to wait for the threaded sink of [ADR-0306] step 3. No such consumer exists today.
- Cost: `apply_color_policy` mutates the `colored` crate's process-global override, so any test that asserts on styled output must serialize against it. One mutex in `output/tests/gating.rs` carries that today; a second such test suite would have to share it rather than add its own.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Step 1 (allocate + accept ADR-0314) was already completed by a prior orchestrator run per the task comment; verified ADR-0314 exists and is accepted (related_tasks: [ORB-10570, ORB-10585]) via `orbit tool run orbit.adr.show` against this worktree's local store (the bridge MCP `orbit_adr_show`/`orbit_task_show` tools route to a different default workspace and don't see it -- worth knowing if reusing those tools here).

Completed the remaining mechanical scope (steps 2-3):
- docs/design/terminal-interface/2_design.md: added ADR-0314 to `related_artifacts` frontmatter; replaced the section 9 paragraph that stated the process-global decision and its rejected alternatives inline (and said 'This decision has no ADR yet') with a pointer to ADR-0314.
- docs/design/terminal-interface/4_decisions.md: added an ADR-0314 entry to the ordered ADR index (ascending, after ADR-0308), added ADR-0314 to `related_artifacts` frontmatter, added ORB-10570/ORB-10585 to Task References, bumped `last_updated`/`last_validated` to 2026-08-02 per the same-PR doc-update convention.
- crates/orbit-cli/src/output/sink.rs: added an [ADR-0314] citation to the module doc comment next to the existing [ADR-0306]/[ADR-0308] citations.

Validation: `make ci-fast` passes (cargo was present at ~/.cargo/bin but not on the default PATH; ran with PATH extended). `scripts/generate-doc-indexes.sh --check` and `scripts/check-terminal-state-guard.sh` pass. No Rust logic changed, doc-comment and markdown only.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10585-6a6ece02`
- Behind base: 0
- Ahead of base: 1