### PR TITLE
Add a weekly official model-price audit auto-task

### DIFF
--- a/.orbit/auto_tasks/model-price-audit.yaml
+++ b/.orbit/auto_tasks/model-price-audit.yaml
@@ -1,0 +1,101 @@
+schemaVersion: 1
+name: model-price-audit
+description: Weekly report-only reconciliation of the versioned model price table against official provider evidence
+enabled: true
+schedule:
+  # Once weekly: Monday 06:00 in the host-local timezone used by the generic scheduler.
+  cron: 0 6 * * 1
+template:
+  title: Audit model prices against official provider evidence
+  description: |
+    This is an evidence-first, REPORT-ONLY pricing audit. The audit may read
+    telemetry, the versioned price table, and official provider documentation,
+    and it may create at most one proposed remediation task after proving
+    material drift. It MUST NOT edit model_prices.yaml or any pricing row,
+    rewrite history, change billing configuration, or directly dispatch work.
+
+    ## Cadence and scope
+
+    This definition runs once weekly, every Monday at 06:00 in the host-local
+    timezone used by the generic auto-task scheduler. Record the retrieval
+    timestamp and UTC offset used for each audit in the execution_summary. The
+    audit covers the current versioned table at
+    `crates/orbit-common/assets/model_prices.yaml` and the workspace's
+    InvocationRecord telemetry. Direct Codex/Claude orchestration-session cost
+    is out of scope; only persisted provider invocation records and the table's
+    derived-cost contract are in scope.
+
+    ## Reconciliation procedure
+
+    1. Enumerate the exact model strings observed in `InvocationRecord.model`
+       telemetry for the available audit period. Do not normalize aliases,
+       crew names, provider labels, or remembered model names into those
+       strings.
+    2. Enumerate every currently priced provider/model row in
+       `crates/orbit-common/assets/model_prices.yaml`, including duplicate model
+       strings with distinct `effective_from` / `effective_until` periods.
+       Record the provider, exact model string, effective boundaries, input
+       basis, rates, units (USD per million tokens), cache-read and cache-write
+       tiers, output tier, and whether the period is open-ended.
+    3. For every observed model and every table row, consult only the provider's
+       authoritative pricing, model, and caching documentation. Record the
+       source URL and retrieval timestamp for each claim, the published rate
+       and unit, tier/caching semantics, model availability, and the provider's
+       effective boundary when one is stated. Official evidence that is
+       unavailable, contradictory, or ambiguous is reported as uncertainty and
+       creates no remediation task for that claim.
+    4. Treat third-party pages, aggregators, search snippets, training memory,
+       and remembered prices as non-authoritative corroboration only. They can
+       never establish a price change or justify a table edit.
+    5. Keep standard short-context pricing distinct from Fast/service-tier and
+       long-context dimensions. Flag Fast/service-tier or long-context details
+       only when current billing assumptions or observed fleet usage makes them
+       relevant; never approximate either dimension into the base table.
+
+    ## Outcome and remediation boundary
+
+    A no-diff result is successful. Its execution_summary MUST list the checked
+    official sources and retrieval times, observed exact model strings, every
+    compared table row and effective period, and the reconciliation evidence
+    supporting no material drift. Also list unavailable, contradictory, or
+    ambiguous evidence explicitly.
+
+    When (and only when) official evidence proves material drift, report the
+    affected exact model strings and rows, source URLs and retrieval timestamps,
+    published rates/units/tiers, and the evidence's effective boundary. Create
+    at most one deduplicated proposed remediation task for normal human review
+    and dispatch. That proposal must contain the evidence, affected rows/models,
+    safe versioned-change requirements, and validation criteria; it must not edit
+    pricing itself. If the exact effective cutoff is uncertain, state the
+    uncertainty and the safe boundary explicitly instead of inventing precision.
+    Any proposed price change must preserve historical rows, use non-overlapping
+    effective periods, and add a new versioned row rather than rewriting history.
+    Unavailable, contradictory, or ambiguous official evidence creates no
+    remediation task. Human review of any proposed task is mandatory.
+
+    Operators can inspect this definition without waiting for the weekly slot
+    with `orbit auto-task show model-price-audit --json`; use the scheduler's
+    dry-run mode to inspect due behavior without minting a task or advancing a
+    cursor. The generated audit task's execution_summary is the report of
+    record.
+  acceptance_criteria:
+  - Exact InvocationRecord model strings and every current provider/model price row are enumerated, including effective periods.
+  - Each authoritative source URL, retrieval timestamp, published rate, unit, tier, caching rule, and effective boundary is recorded; non-authoritative evidence is labeled and never treated as proof.
+  - No pricing file or pricing row is edited by the audit; unavailable, contradictory, or ambiguous official evidence is reported and creates no remediation task.
+  - A proven material drift creates at most one deduplicated proposed remediation task with evidence, affected rows/models, safe versioned non-overlapping changes, cutoff uncertainty, and validation criteria.
+  - A verified no-diff outcome records checked sources, observed models, effective periods, and reconciliation evidence in execution_summary.
+  - Standard short-context pricing remains separate from Fast/service-tier and long-context dimensions, which are never approximated into the base table.
+  - Dry-run inspection, human review of proposals, and the out-of-scope direct Codex/Claude orchestration-session cost are documented.
+  task_type: chore
+  tags:
+  - model-price-audit
+  - pricing
+  - no-diff-expected
+  priority: medium
+  crew: terra
+  status: backlog
+dedupe: skip_if_open
+created_by: human
+created_at: 2026-08-02T00:00:00Z
+updated_by: codex
+updated_at: 2026-08-02T00:00:00Z

--- a/crates/orbit-core/src/auto_tasks/tests/scheduler.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/scheduler.rs
@@ -2,7 +2,7 @@
 //! catch-up collapse, dedupe, disabled skip, and dry-run inertness.
 
 use chrono::{DateTime, Duration, TimeZone, Utc};
-use orbit_common::types::{TaskStatus, auto_task_tag};
+use orbit_common::types::{AutoTaskSchedule, TaskStatus, auto_task_tag};
 use tempfile::tempdir;
 
 use crate::OrbitRuntime;
@@ -113,6 +113,26 @@ fn skip_if_open_never_files_a_second_open_instance() {
     let drained = fire(&runtime, t0 + Duration::minutes(240));
     assert_eq!(drained[0].0, "fired");
     assert_eq!(runtime.list_tasks().expect("tasks").len(), 2);
+}
+
+#[test]
+fn weekly_cron_fires_once_and_dedupes_while_audit_is_open() {
+    let runtime = runtime();
+    let mut params = interval_params("model-price-audit", 60);
+    params.schedule = AutoTaskSchedule::Cron {
+        cron: "0 6 * * 1".to_string(),
+    };
+    runtime.auto_task_add(params).expect("add");
+    let first_monday = at(2026, 1, 5, 6, 0);
+
+    assert_eq!(fire(&runtime, first_monday)[0].0, "baselined");
+    assert_eq!(fire(&runtime, at(2026, 1, 12, 6, 1))[0].0, "fired");
+    assert_eq!(runtime.list_tasks().expect("tasks").len(), 1);
+
+    // The following weekly slot is deferred rather than duplicated while the
+    // report task remains open.
+    assert_eq!(fire(&runtime, at(2026, 1, 19, 6, 1))[0].0, "skipped");
+    assert_eq!(runtime.list_tasks().expect("tasks").len(), 1);
 }
 
 #[test]

--- a/crates/orbit-core/src/auto_tasks/tests/shipped.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/shipped.rs
@@ -104,6 +104,64 @@ fn artifact_deprecation_review_is_report_only() {
     }
 }
 
+#[test]
+fn model_price_audit_is_weekly_report_only_and_routes_to_terra() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(".orbit/auto_tasks/model-price-audit.yaml");
+    let yaml = std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    let definition = parse_auto_task_yaml(&yaml).expect("parse model-price-audit");
+
+    assert_eq!(definition.name, "model-price-audit");
+    assert!(definition.enabled, "definition must be enabled");
+    assert_eq!(
+        definition.schedule,
+        AutoTaskSchedule::Cron {
+            cron: "0 6 * * 1".to_string()
+        }
+    );
+    assert!(matches!(definition.dedupe, DedupePolicy::SkipIfOpen));
+    assert_eq!(definition.template.crew.as_deref(), Some("terra"));
+    assert_eq!(
+        definition.template.status,
+        orbit_common::types::TaskStatus::Backlog
+    );
+    for required_tag in ["model-price-audit", "pricing", "no-diff-expected"] {
+        assert!(
+            definition
+                .template
+                .tags
+                .iter()
+                .any(|tag| tag == required_tag),
+            "missing required tag {required_tag}"
+        );
+    }
+
+    let body = definition.template.description.to_lowercase();
+    for required in [
+        "invocationrecord",
+        "authoritative",
+        "source url",
+        "retrieval timestamp",
+        "at most one",
+        "historical rows",
+        "non-overlapping",
+        "short-context",
+        "fast/service-tier",
+        "long-context",
+        "dry-run",
+        "human review",
+        "orchestration-session cost",
+    ] {
+        assert!(
+            body.contains(required),
+            "template should retain '{required}'"
+        );
+    }
+    assert!(body.contains("must not edit model_prices.yaml"));
+}
+
 /// Friction curation is the portable default. It keeps the curation safeguards
 /// while remaining disabled until an operator opts in.
 #[test]

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -126,6 +126,21 @@ After [ORB-10338] (see [ADR-0245]), `InvocationInsertParams.trace` carries an op
 
 After [ORB-10579], each price row also declares whether its input count is exclusive or gross-with-cache. Existing rows default to exclusive accounting; GPT-5.6 rows use gross accounting, so derived pricing subtracts cached-read and both cache-write buckets from the gross input total before charging the full input rate. Checked subtraction makes inconsistent rows unknown instead of silently saturating. Codex JSONL and OpenAI-compatible response parsing retain provider-reported cached-read, standard cache-write, and output buckets; OpenAI reports no 1-hour write bucket, while a malformed stored nonzero count still has a nonzero fallback price. GPT-5.6 results are standard short-context API-equivalent derived estimates. Exact Fast/service-tier and long-context billing remains future work because Orbit does not yet retain those per-request dimensions.
 
+The workspace-local `model-price-audit` auto-task ([ORB-10583]) is the evidence
+collection and reconciliation guard around this table. Once weekly, it
+enumerates exact model strings from `InvocationRecord.model` telemetry and every
+currently priced row, then records authoritative provider pricing, model, and
+caching sources with URLs, retrieval timestamps, rates, units, tiers, and
+effective boundaries. It is report-only: it never edits pricing. A verified
+material discrepancy may create at most one deduplicated proposed remediation
+task for human review; unavailable, contradictory, or ambiguous official
+evidence creates no remediation task. Any recommendation must preserve
+historical rows and use non-overlapping versioned periods, stating uncertainty
+when the exact effective cutoff is not supported. Standard short-context rates
+remain separate from Fast/service-tier and long-context dimensions, which are
+not approximated into the base table. Direct Codex/Claude orchestration-session
+cost is outside the audit scope.
+
 After [ORB-10370], CLI response parsing also fills `InvocationTrace.provider_model` and `provider_cost_usd` directly from provider-owned result metadata. Claude exposes a `modelUsage` map and `total_cost_usd`; when Claude reports its internal helper model beside the requested model, Orbit selects the unique highest-cost map entry and preserves its key verbatim. Gemini exposes an exact model key under `stats.models` but no invocation USD total; Orbit accepts it only when the map has one entry. Codex JSONL and Grok's JSON wrapper do not currently report either value, so they remain `None`. At SQLite ingest, a non-empty provider model wins over the configured request/alias and the configured model remains the fallback. A disagreement emits a retained `WARN` event under `orbit.core.invocation` with job run, activity, CLI, requested model, and provider model fields. This structured mismatch event was chosen instead of a second invocation column: it makes provider routing drift detectable under the default logging filter without migrating or backfilling rows, while `invocations.model` remains the exact model used for pricing and aggregation.
 
 The local dashboard exposes two read-only API surfaces for these traces after [T20260508-14]: `GET /api/runs/:id/logs` returns bounded per-step CLI invocation previews, and `GET /api/diagnostics/errors` returns recent process ERROR rows plus structured agent-stderr error rows sorted newest first. Both endpoints use existing dashboard limit conventions and tolerate missing stored event rows, malformed event JSON, and missing blobs by returning empty or partial arrays.

--- a/docs/design/auto-tasks/2_design.md
+++ b/docs/design/auto-tasks/2_design.md
@@ -1,7 +1,7 @@
 ---
 title: Auto-tasks — Design
 owner: claude
-last_updated: 2026-07-26
+last_updated: 2026-08-02
 last_validated: 2026-07-27
 status: Accepted
 feature: auto-tasks
@@ -11,7 +11,7 @@ summary: Current implementation of the auto-task record, due-math, host-local cu
 tags: [auto-tasks]
 paths: ["crates/orbit-core/src/auto_tasks/**"]
 related_features: [auto-tasks]
-related_artifacts: [ORB-10149, ORB-10439, ORB-10441, ORB-10446, ORB-10472, ADR-0218, ADR-0217, ADR-0286]
+related_artifacts: [ORB-10149, ORB-10439, ORB-10441, ORB-10446, ORB-10472, ORB-10583, ADR-0218, ADR-0217, ADR-0286]
 ---
 
 # Auto-tasks — Design
@@ -140,6 +140,25 @@ asks the executor to validate recent changes hands-on and file real findings
 through Orbit. Its `no-diff-expected` tag lets workflow handoff succeed when the
 validation correctly produces only task-side effects.
 
+The workspace-local `model-price-audit` definition (ORB-10583) is an enabled
+weekly report-only consumer: it runs Monday at 06:00 in the host-local timezone,
+uses `skip_if_open`, mints a backlog chore for crew `terra`, and carries
+`model-price-audit`, `pricing`, and `no-diff-expected`. Its template compares
+exact `InvocationRecord.model` strings and every current price-table row against
+authoritative provider pricing/model/cache documentation. It records source
+URLs, retrieval timestamps, rates, units, tiers, and effective boundaries; it
+never edits pricing. A proven material drift may produce at most one deduplicated
+proposed remediation task for normal human review, while unavailable,
+contradictory, or ambiguous official evidence produces a report without a
+remediation task. No routine or portable seeded default is added for this
+workspace-local definition.
+
+Operators may inspect it with `orbit auto-task show model-price-audit --json` and
+use scheduler dry-run inspection before the weekly slot. The generated task's
+`execution_summary` is the audit report and must include no-diff evidence,
+observed models, checked sources, and effective periods when the table is
+accurate.
+
 - **Definitions are not full-text indexed.** Unlike learnings/ADRs, auto-task
   YAML is not in a SQLite/search index; discovery is a directory scan. Acceptable
   at the expected cardinality (a handful of chores per workspace).
@@ -156,5 +175,6 @@ validation correctly produces only task-side effects.
 - ORB-10439 — on-demand manual mint (renamed to `orbit auto-task mint <name>` by ORB-10446).
 - ORB-10441 — mint-time visible title provenance.
 - ORB-10472 — worktree-local, atomic definition refresh.
+- ORB-10583 — workspace-local weekly official model-price audit definition.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10583](https://orbit-cli.com/tasks/ORB-10583) — Add a weekly official model-price audit auto-task

### Description

Add one workspace-local enabled Orbit auto-task definition for a weekly evidence-first audit of the versioned model price table against official provider pricing, model, and caching documentation. The generated audit task is report-only: when it proves material drift, it creates at most one deduplicated proposed remediation task for the normal review/dispatch workflow; it never edits pricing itself. Reuse the generic workspace scheduler and do not add a new routine, portable seeded default, or auto-dispatch path.

### Acceptance Criteria

- A workspace-local schema-version-1 definition named `model-price-audit` is added under `.orbit/auto_tasks/`, is enabled, and uses a once-weekly cron schedule with timezone/cadence documented in the definition; no new routine or portable seeded default is added.
- The definition uses `dedupe: skip_if_open`, mints backlog chores, carries `model-price-audit`, `pricing`, and `no-diff-expected` tags, and assigns the generated audit task to `terra` because it reconciles multiple official sources and ambiguous billing semantics.
- The generated task enumerates exact model strings observed in InvocationRecord telemetry and every currently priced provider/model row, then checks only authoritative provider pricing, model, and caching documentation while recording source URLs, retrieval timestamps, rates, units, tiers, and effective boundaries.
- Third-party sources and remembered prices are non-authoritative; unavailable, contradictory, or ambiguous official evidence is reported and creates no remediation task.
- The audit is report-only and never edits pricing. On verified material drift it creates at most one deduplicated proposed remediation task containing the source evidence, affected rows/models, safe versioned-change requirements, and validation criteria.
- A pricing change recommendation preserves historical rows, forbids overlapping periods, and states uncertainty in the exact effective cutoff rather than inventing unsupported precision.
- When the current table is accurate, the audit is a successful no-diff outcome whose execution summary records checked sources, observed models, effective periods, and reconciliation evidence.
- Standard short-context pricing remains distinct from Fast/service-tier and long-context dimensions; the latter are flagged only when current billing assumptions or observed fleet usage make them relevant, and are never approximated into the base table.
- The generic auto-task scheduler remains the only schedule runner; `repository_definitions_all_parse`, `orbit auto-task show model-price-audit --json`, weekly due behavior, and skip-if-open duplicate suppression all pass.
- Documentation explains dry-run inspection, human review of the generated audit task, the proposed-remediation boundary, and that direct Codex/Claude orchestration-session cost is out of scope.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added enabled workspace-local .orbit/auto_tasks/model-price-audit.yaml (schema v1), scheduled weekly for Monday 06:00 host-local time, with skip_if_open, backlog chore output, terra crew routing, required tags, official-source reconciliation instructions, no-diff reporting, and a report-only proposed-remediation boundary.
- Added shipped-definition and weekly-cron scheduler coverage for parsing, configuration, due behavior, and open-task deduplication.
- Updated auto-task and auditability design docs with the model-price-audit contract, dry-run/human-review guidance, pricing-history safeguards, and out-of-scope orchestration-session cost.
Assessment: Scoped implementation reuses the generic scheduler and adds no routine, seeded default, pricing edit path, or new dependency. The audit mandate preserves exact InvocationRecord model strings, authoritative source evidence, effective-period uncertainty, historical rows, and separation of short-context/Fast/service-tier/long-context pricing.
Validation:
- orbit auto-task show model-price-audit --json
- cargo test -p orbit-core auto_tasks::tests:: --lib (38 passed)
- make ci-fast (passed)
- git diff --check (passed)

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10583-6a6ed07c`
- Behind base: 0
- Ahead of base: 1