### PR TITLE
Aggregate managed invocation cost by task orchestrator

### DIFF
--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -101,4 +101,8 @@ pub use orbit_store::{
 // Routine fire records surfaced by the dashboard's routine-health JSON API.
 pub use orbit_store::{RoutineFireRecord, RoutineFireState};
 pub use runtime::engine::ResolvedCrewProjection;
+pub use runtime::engine::{
+    OrchestratorInvocationMetrics, OrchestratorInvocationMetricsBucket,
+    OrchestratorMetricsBucketKind,
+};
 pub use runtime::{OrbitRuntime, WorkspaceRootHint, WorkspaceRuntimeBinding};

--- a/crates/orbit-core/src/runtime/engine/invocation.rs
+++ b/crates/orbit-core/src/runtime/engine/invocation.rs
@@ -1,12 +1,154 @@
-use crate::OrbitRuntime;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use chrono::{DateTime, Utc};
 use orbit_common::types::OrbitError;
 use orbit_store::{
-    ActivityInvocationMetrics, AgentInvocationMetrics, InvocationInsertParams, InvocationQuery,
-    InvocationRecord, Store, TaskInvocationMetrics, ToolInvocationMetrics,
+    ActivityInvocationMetrics, AgentInvocationMetrics, InvocationAccountingFact,
+    InvocationAccountingQuery, InvocationInsertParams, InvocationQuery, InvocationRecord, Store,
+    TaskInvocationMetrics, ToolInvocationMetrics,
 };
+use serde::{Deserialize, Serialize};
 
-pub(super) fn open_invocation_store(runtime: &OrbitRuntime) -> Result<Store, OrbitError> {
-    Store::open(&runtime.context.persistence().audit_db)
+use crate::OrbitRuntime;
+
+/// Conservative ownership class for managed invocation accounting.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum OrchestratorMetricsBucketKind {
+    Missing,
+    Unattributed,
+    Orchestrator,
+    Shared,
+}
+
+/// Reconciliation fields for one ownership bucket.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OrchestratorInvocationMetricsBucket {
+    pub kind: OrchestratorMetricsBucketKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub orchestrator: Option<String>,
+    pub invocation_count: u64,
+    pub linked_task_count: u64,
+    pub input_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_create_tokens: u64,
+    pub cache_create_1h_tokens: u64,
+    pub output_tokens: u64,
+    pub provider_cost_usd: f64,
+    pub provider_cost_count: u64,
+    pub derived_cost_usd: f64,
+    pub derived_cost_count: u64,
+    pub comparable_provider_cost_usd: f64,
+    pub comparable_derived_cost_usd: f64,
+    pub comparable_cost_count: u64,
+    pub comparable_cost_delta_usd: f64,
+    pub missing_provider_count: u64,
+    pub unpriced_derived_count: u64,
+}
+
+/// Stable, managed-execution-only accounting snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OrchestratorInvocationMetrics {
+    pub as_of: DateTime<Utc>,
+    pub since: Option<DateTime<Utc>>,
+    /// Effective exclusive upper cutoff (never later than `as_of`).
+    pub until: DateTime<Utc>,
+    pub buckets: Vec<OrchestratorInvocationMetricsBucket>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct BucketKey {
+    kind: OrchestratorMetricsBucketKind,
+    orchestrator: Option<String>,
+}
+
+#[derive(Debug, Default)]
+struct BucketAccumulator {
+    linked_task_ids: BTreeSet<String>,
+    invocation_count: u64,
+    input_tokens: u64,
+    cache_read_tokens: u64,
+    cache_create_tokens: u64,
+    cache_create_1h_tokens: u64,
+    output_tokens: u64,
+    provider_cost_usd: f64,
+    provider_cost_count: u64,
+    derived_cost_usd: f64,
+    derived_cost_count: u64,
+    comparable_provider_cost_usd: f64,
+    comparable_derived_cost_usd: f64,
+    comparable_cost_count: u64,
+    missing_provider_count: u64,
+    unpriced_derived_count: u64,
+}
+
+impl BucketAccumulator {
+    fn add(&mut self, fact: &InvocationAccountingFact) {
+        self.invocation_count = self.invocation_count.saturating_add(1);
+        self.input_tokens = self.input_tokens.saturating_add(fact.input_tokens);
+        self.cache_read_tokens = self
+            .cache_read_tokens
+            .saturating_add(fact.cache_read_tokens);
+        self.cache_create_tokens = self
+            .cache_create_tokens
+            .saturating_add(fact.cache_create_tokens);
+        self.cache_create_1h_tokens = self
+            .cache_create_1h_tokens
+            .saturating_add(fact.cache_create_1h_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(fact.output_tokens);
+        self.linked_task_ids.extend(fact.task_ids.iter().cloned());
+
+        let provider = fact.provider_cost_usd.filter(|cost| valid_cost(*cost));
+        let derived = fact.derived_cost_usd.filter(|cost| valid_cost(*cost));
+        match provider {
+            Some(cost) => {
+                self.provider_cost_usd += cost;
+                self.provider_cost_count = self.provider_cost_count.saturating_add(1);
+            }
+            None => self.missing_provider_count = self.missing_provider_count.saturating_add(1),
+        }
+        match derived {
+            Some(cost) => {
+                self.derived_cost_usd += cost;
+                self.derived_cost_count = self.derived_cost_count.saturating_add(1);
+            }
+            None => self.unpriced_derived_count = self.unpriced_derived_count.saturating_add(1),
+        }
+        if let (Some(provider), Some(derived)) = (provider, derived) {
+            self.comparable_provider_cost_usd += provider;
+            self.comparable_derived_cost_usd += derived;
+            self.comparable_cost_count = self.comparable_cost_count.saturating_add(1);
+        }
+    }
+
+    fn finish(
+        self,
+        kind: OrchestratorMetricsBucketKind,
+        orchestrator: Option<String>,
+    ) -> OrchestratorInvocationMetricsBucket {
+        OrchestratorInvocationMetricsBucket {
+            kind,
+            orchestrator,
+            invocation_count: self.invocation_count,
+            linked_task_count: self.linked_task_ids.len() as u64,
+            input_tokens: self.input_tokens,
+            cache_read_tokens: self.cache_read_tokens,
+            cache_create_tokens: self.cache_create_tokens,
+            cache_create_1h_tokens: self.cache_create_1h_tokens,
+            output_tokens: self.output_tokens,
+            provider_cost_usd: self.provider_cost_usd,
+            provider_cost_count: self.provider_cost_count,
+            derived_cost_usd: self.derived_cost_usd,
+            derived_cost_count: self.derived_cost_count,
+            comparable_provider_cost_usd: self.comparable_provider_cost_usd,
+            comparable_derived_cost_usd: self.comparable_derived_cost_usd,
+            comparable_cost_count: self.comparable_cost_count,
+            comparable_cost_delta_usd: self.comparable_provider_cost_usd
+                - self.comparable_derived_cost_usd,
+            missing_provider_count: self.missing_provider_count,
+            unpriced_derived_count: self.unpriced_derived_count,
+        }
+    }
 }
 
 impl OrbitRuntime {
@@ -33,9 +175,9 @@ impl OrbitRuntime {
 
     pub fn invocation_records(
         &self,
-        query: InvocationQuery,
+        filter: InvocationQuery,
     ) -> Result<Vec<InvocationRecord>, OrbitError> {
-        open_invocation_store(self)?.list_invocation_records(&query)
+        open_invocation_store(self)?.list_invocation_records(&filter)
     }
 
     pub fn insert_invocation_trace_record(
@@ -44,4 +186,117 @@ impl OrbitRuntime {
     ) -> Result<(), OrbitError> {
         open_invocation_store(self)?.insert_invocation_trace_record(params)
     }
+
+    /// Aggregates managed invocation telemetry by canonical task orchestrator.
+    ///
+    /// The effective window is half-open (`since <= ts < until`). Missing
+    /// tasks take precedence over unattributed tasks, which take precedence
+    /// over named/shared attribution, so incomplete ownership never charges a
+    /// known orchestrator.
+    pub fn orchestrator_invocation_metrics(
+        &self,
+        since: Option<DateTime<Utc>>,
+        until: Option<DateTime<Utc>>,
+    ) -> Result<OrchestratorInvocationMetrics, OrbitError> {
+        let as_of = Utc::now();
+        if let (Some(since), Some(until)) = (since, until)
+            && since >= until
+        {
+            return Err(OrbitError::InvalidInput(
+                "since must be earlier than until".to_string(),
+            ));
+        }
+        let effective_until = until.map_or(as_of, |until| until.min(as_of));
+        if since.is_some_and(|since| since >= effective_until) {
+            return Err(OrbitError::InvalidInput(
+                "since must be earlier than the effective upper cutoff".to_string(),
+            ));
+        }
+
+        let facts = open_invocation_store(self)?.list_invocation_accounting_facts(
+            &InvocationAccountingQuery {
+                since,
+                until: effective_until,
+            },
+        )?;
+        let task_orchestrators = self
+            .list_tasks()?
+            .into_iter()
+            .map(|task| (task.id.to_string(), task.orchestrator))
+            .collect::<HashMap<_, _>>();
+
+        let mut grouped = BTreeMap::<BucketKey, BucketAccumulator>::new();
+        for fact in &facts {
+            let key = classify_invocation(&fact.task_ids, &task_orchestrators);
+            grouped.entry(key).or_default().add(fact);
+        }
+        let buckets = grouped
+            .into_iter()
+            .map(|(key, bucket)| bucket.finish(key.kind, key.orchestrator))
+            .collect();
+
+        Ok(OrchestratorInvocationMetrics {
+            as_of,
+            since,
+            until: effective_until,
+            buckets,
+        })
+    }
+}
+
+fn classify_invocation(
+    task_ids: &[String],
+    task_orchestrators: &HashMap<String, Option<String>>,
+) -> BucketKey {
+    if task_ids.is_empty() {
+        return BucketKey {
+            kind: OrchestratorMetricsBucketKind::Unattributed,
+            orchestrator: None,
+        };
+    }
+
+    let distinct_task_ids = task_ids.iter().collect::<BTreeSet<_>>();
+    if distinct_task_ids
+        .iter()
+        .any(|task_id| !task_orchestrators.contains_key(task_id.as_str()))
+    {
+        return BucketKey {
+            kind: OrchestratorMetricsBucketKind::Missing,
+            orchestrator: None,
+        };
+    }
+
+    let owners = distinct_task_ids
+        .iter()
+        .filter_map(|task_id| task_orchestrators.get(task_id.as_str()))
+        .collect::<Vec<_>>();
+    if owners.iter().any(|owner| owner.is_none()) {
+        return BucketKey {
+            kind: OrchestratorMetricsBucketKind::Unattributed,
+            orchestrator: None,
+        };
+    }
+    let named = owners
+        .into_iter()
+        .filter_map(|owner| owner.as_ref())
+        .collect::<BTreeSet<_>>();
+    if named.len() == 1 {
+        BucketKey {
+            kind: OrchestratorMetricsBucketKind::Orchestrator,
+            orchestrator: named.into_iter().next().cloned(),
+        }
+    } else {
+        BucketKey {
+            kind: OrchestratorMetricsBucketKind::Shared,
+            orchestrator: None,
+        }
+    }
+}
+
+fn valid_cost(cost: f64) -> bool {
+    cost.is_finite() && cost >= 0.0
+}
+
+fn open_invocation_store(runtime: &OrbitRuntime) -> Result<Store, OrbitError> {
+    runtime.sqlite_store()
 }

--- a/crates/orbit-core/src/runtime/engine/mod.rs
+++ b/crates/orbit-core/src/runtime/engine/mod.rs
@@ -14,3 +14,7 @@ mod tests;
 pub use crew::{
     ConfiguredCrewProjection, ConfiguredCrewRegistryProjection, ResolvedCrewProjection,
 };
+pub use invocation::{
+    OrchestratorInvocationMetrics, OrchestratorInvocationMetricsBucket,
+    OrchestratorMetricsBucketKind,
+};

--- a/crates/orbit-core/src/runtime/engine/tests/invocation.rs
+++ b/crates/orbit-core/src/runtime/engine/tests/invocation.rs
@@ -1,0 +1,356 @@
+use chrono::{Duration, Utc};
+use orbit_common::types::{InvocationTrace, TokenUsage};
+use tempfile::tempdir;
+
+use crate::command::task::TaskAddParams;
+use crate::{
+    InvocationInsertParams, OrbitRuntime, OrchestratorInvocationMetricsBucket,
+    OrchestratorMetricsBucketKind,
+};
+
+const PRICED_MODEL: &str = "claude-opus-4-7";
+const UNPRICED_MODEL: &str = "unpriced-model";
+
+fn accounting_runtime() -> (tempfile::TempDir, OrbitRuntime) {
+    let root = tempdir().expect("create tempdir");
+    let global_root = root.path().join("global");
+    let workspace_root = root.path().join("repo/.orbit");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    std::fs::write(
+        workspace_root.join("config.toml"),
+        r#"
+[workflow]
+default_crew = "alpha"
+
+[crews.alpha]
+planner = { model = "alpha-plan", provider = "codex", backend = "cli" }
+implementer = { model = "alpha-implement", provider = "codex", backend = "cli" }
+reviewer = { model = "alpha-review", provider = "codex", backend = "cli" }
+
+[crews.beta]
+planner = { model = "beta-plan", provider = "claude", backend = "cli" }
+implementer = { model = "beta-implement", provider = "claude", backend = "cli" }
+reviewer = { model = "beta-review", provider = "claude", backend = "cli" }
+"#,
+    )
+    .expect("write config");
+    let runtime = OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+    (root, runtime)
+}
+
+fn add_task(runtime: &OrbitRuntime, title: &str, orchestrator: Option<&str>) -> String {
+    runtime
+        .add_task(TaskAddParams {
+            title: title.to_string(),
+            description: "accounting fixture".to_string(),
+            orchestrator: orchestrator.map(ToOwned::to_owned),
+            ..TaskAddParams::default()
+        })
+        .expect("add task")
+        .id
+        .to_string()
+}
+
+fn insert(
+    runtime: &OrbitRuntime,
+    index: usize,
+    task_ids: Vec<String>,
+    model: &str,
+    provider_cost_usd: Option<f64>,
+) {
+    runtime
+        .insert_invocation_trace_record(&InvocationInsertParams {
+            job_run_id: format!("jrun-accounting-{index}"),
+            activity_id: "agent_implement".to_string(),
+            agent: "codex".to_string(),
+            model: Some(model.to_string()),
+            slot: None,
+            task_ids,
+            trace: InvocationTrace {
+                usage: TokenUsage {
+                    input: 10,
+                    cache_read: 2,
+                    cache_create: 3,
+                    cache_create_1h: 4,
+                    output: 5,
+                },
+                provider_cost_usd,
+                ..InvocationTrace::default()
+            },
+        })
+        .expect("insert invocation");
+}
+
+fn bucket<'a>(
+    buckets: &'a [OrchestratorInvocationMetricsBucket],
+    kind: OrchestratorMetricsBucketKind,
+    orchestrator: Option<&str>,
+) -> &'a OrchestratorInvocationMetricsBucket {
+    buckets
+        .iter()
+        .find(|bucket| bucket.kind == kind && bucket.orchestrator.as_deref() == orchestrator)
+        .expect("metrics bucket")
+}
+
+#[test]
+fn orchestrator_accounting_classifies_conservatively_and_reconciles_every_population() {
+    let (_root, runtime) = accounting_runtime();
+    let alpha_one = add_task(&runtime, "alpha one", Some("alpha"));
+    let alpha_two = add_task(&runtime, "alpha two", Some("alpha"));
+    let beta = add_task(&runtime, "beta", Some("beta"));
+    let unattributed = add_task(&runtime, "unattributed", None);
+
+    insert(
+        &runtime,
+        0,
+        vec![alpha_one.clone(), alpha_one.clone()],
+        PRICED_MODEL,
+        Some(1.0),
+    );
+    insert(
+        &runtime,
+        1,
+        vec![alpha_one.clone(), alpha_two],
+        PRICED_MODEL,
+        None,
+    );
+    insert(
+        &runtime,
+        2,
+        vec![alpha_one.clone(), beta],
+        UNPRICED_MODEL,
+        Some(2.0),
+    );
+    insert(&runtime, 3, Vec::new(), UNPRICED_MODEL, None);
+    insert(
+        &runtime,
+        4,
+        vec![unattributed.clone()],
+        PRICED_MODEL,
+        Some(3.0),
+    );
+    insert(
+        &runtime,
+        5,
+        vec![alpha_one.clone(), unattributed],
+        PRICED_MODEL,
+        Some(-1.0),
+    );
+    insert(
+        &runtime,
+        6,
+        vec!["ORB-MISSING".to_string()],
+        PRICED_MODEL,
+        Some(4.0),
+    );
+    insert(
+        &runtime,
+        7,
+        vec![alpha_one, "ORB-MISSING-TOO".to_string()],
+        UNPRICED_MODEL,
+        None,
+    );
+
+    let metrics = runtime
+        .orchestrator_invocation_metrics(None, None)
+        .expect("orchestrator metrics");
+    assert!(metrics.until <= metrics.as_of);
+    assert_eq!(metrics.buckets.len(), 4);
+    assert_eq!(
+        bucket(
+            &metrics.buckets,
+            OrchestratorMetricsBucketKind::Orchestrator,
+            Some("alpha")
+        )
+        .invocation_count,
+        2,
+        "duplicate and same-owner task links charge alpha once per invocation"
+    );
+    assert_eq!(
+        bucket(
+            &metrics.buckets,
+            OrchestratorMetricsBucketKind::Shared,
+            None
+        )
+        .invocation_count,
+        1
+    );
+    assert_eq!(
+        bucket(
+            &metrics.buckets,
+            OrchestratorMetricsBucketKind::Unattributed,
+            None
+        )
+        .invocation_count,
+        3,
+        "no tasks and partial unattribution stay unattributed"
+    );
+    assert_eq!(
+        bucket(
+            &metrics.buckets,
+            OrchestratorMetricsBucketKind::Missing,
+            None
+        )
+        .invocation_count,
+        2,
+        "a missing task takes precedence over a known owner"
+    );
+
+    assert_eq!(
+        metrics
+            .buckets
+            .iter()
+            .map(|bucket| bucket.invocation_count)
+            .sum::<u64>(),
+        8
+    );
+    assert_eq!(
+        metrics
+            .buckets
+            .iter()
+            .map(|bucket| bucket.input_tokens)
+            .sum::<u64>(),
+        80
+    );
+    assert_eq!(
+        metrics
+            .buckets
+            .iter()
+            .map(|bucket| bucket.cache_read_tokens)
+            .sum::<u64>(),
+        16
+    );
+    assert_eq!(
+        metrics
+            .buckets
+            .iter()
+            .map(|bucket| bucket.cache_create_tokens)
+            .sum::<u64>(),
+        24
+    );
+    assert_eq!(
+        metrics
+            .buckets
+            .iter()
+            .map(|bucket| bucket.cache_create_1h_tokens)
+            .sum::<u64>(),
+        32
+    );
+    assert_eq!(
+        metrics
+            .buckets
+            .iter()
+            .map(|bucket| bucket.output_tokens)
+            .sum::<u64>(),
+        40
+    );
+    assert_eq!(
+        metrics
+            .buckets
+            .iter()
+            .map(|bucket| bucket.provider_cost_count + bucket.missing_provider_count)
+            .sum::<u64>(),
+        8
+    );
+    assert_eq!(
+        metrics
+            .buckets
+            .iter()
+            .map(|bucket| bucket.derived_cost_count + bucket.unpriced_derived_count)
+            .sum::<u64>(),
+        8
+    );
+    assert_eq!(
+        metrics
+            .buckets
+            .iter()
+            .map(|bucket| bucket.comparable_cost_count)
+            .sum::<u64>(),
+        3,
+        "only invocations with both valid costs enter comparable sums"
+    );
+    assert_eq!(
+        metrics
+            .buckets
+            .iter()
+            .map(|bucket| bucket.provider_cost_count)
+            .sum::<u64>(),
+        4,
+        "provider-only and both-cost rows contribute provider cost"
+    );
+    assert_eq!(
+        metrics
+            .buckets
+            .iter()
+            .map(|bucket| bucket.derived_cost_count)
+            .sum::<u64>(),
+        5,
+        "derived-only and both-cost rows contribute derived cost"
+    );
+    for bucket in &metrics.buckets {
+        assert_eq!(
+            bucket.comparable_cost_delta_usd,
+            bucket.comparable_provider_cost_usd - bucket.comparable_derived_cost_usd
+        );
+    }
+}
+
+#[test]
+fn orchestrator_accounting_treats_invalid_gross_price_inputs_as_unpriced() {
+    let (_root, runtime) = accounting_runtime();
+    runtime
+        .insert_invocation_trace_record(&InvocationInsertParams {
+            job_run_id: "jrun-invalid-price-input".to_string(),
+            activity_id: "agent_implement".to_string(),
+            agent: "codex".to_string(),
+            model: Some("openai/gpt-5.6-sol-2026-07-20".to_string()),
+            slot: None,
+            task_ids: Vec::new(),
+            trace: InvocationTrace {
+                usage: TokenUsage {
+                    input: 1,
+                    cache_read: 2,
+                    cache_create: 3,
+                    cache_create_1h: 4,
+                    output: 5,
+                },
+                provider_cost_usd: Some(0.5),
+                ..InvocationTrace::default()
+            },
+        })
+        .expect("insert invalid gross input row");
+
+    let metrics = runtime
+        .orchestrator_invocation_metrics(None, None)
+        .expect("orchestrator metrics");
+    let unattributed = bucket(
+        &metrics.buckets,
+        OrchestratorMetricsBucketKind::Unattributed,
+        None,
+    );
+    assert_eq!(unattributed.provider_cost_count, 1);
+    assert_eq!(unattributed.derived_cost_count, 0);
+    assert_eq!(unattributed.unpriced_derived_count, 1);
+    assert_eq!(unattributed.comparable_cost_count, 0);
+}
+
+#[test]
+fn orchestrator_accounting_rejects_inverted_or_empty_effective_windows() {
+    let (_root, runtime) = accounting_runtime();
+    let now = Utc::now();
+    assert!(
+        runtime
+            .orchestrator_invocation_metrics(Some(now), Some(now - Duration::seconds(1)))
+            .is_err()
+    );
+    assert!(
+        runtime
+            .orchestrator_invocation_metrics(
+                Some(now + Duration::minutes(1)),
+                Some(now + Duration::minutes(2))
+            )
+            .is_err(),
+        "future requests still use as_of as the effective cutoff"
+    );
+}

--- a/crates/orbit-core/src/runtime/engine/tests/mod.rs
+++ b/crates/orbit-core/src/runtime/engine/tests/mod.rs
@@ -1,4 +1,5 @@
 mod crew;
 mod deterministic_action_host;
 mod identity;
+mod invocation;
 mod task_host;

--- a/crates/orbit-dashboard/src/api/metrics.rs
+++ b/crates/orbit-dashboard/src/api/metrics.rs
@@ -36,6 +36,14 @@ pub(super) struct MetricsInvocationsQuery {
     limit: Option<usize>,
 }
 
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct OrchestratorMetricsQuery {
+    #[serde(default)]
+    since: Option<String>,
+    #[serde(default)]
+    until: Option<String>,
+}
+
 pub(super) async fn knowledge_metrics(Ws(runtime): Ws, Query(q): Query<LimitQuery>) -> Response {
     match runtime.list_job_runs(JobRunListParams {
         limit: q.limit,
@@ -64,6 +72,27 @@ pub(super) async fn task_metrics(Ws(runtime): Ws, Path(id): Path<String>) -> Res
     match runtime.task_invocation_metrics(&id) {
         Ok(row) => Json(row).into_response(),
         Err(e) => map_runtime_error(e),
+    }
+}
+
+/// Returns managed-execution invocation accounting grouped by the explicit
+/// orchestrator ownership on canonical tasks. Direct provider sessions that
+/// do not write managed invocation rows are outside this metric.
+pub(super) async fn orchestrator_metrics(
+    Ws(runtime): Ws,
+    Query(q): Query<OrchestratorMetricsQuery>,
+) -> Response {
+    let since = match parse_rfc3339_opt(q.since, "since") {
+        Ok(value) => value,
+        Err(error) => return map_runtime_error(error),
+    };
+    let until = match parse_rfc3339_opt(q.until, "until") {
+        Ok(value) => value,
+        Err(error) => return map_runtime_error(error),
+    };
+    match runtime.orchestrator_invocation_metrics(since, until) {
+        Ok(metrics) => Json(metrics).into_response(),
+        Err(error) => map_runtime_error(error),
     }
 }
 

--- a/crates/orbit-dashboard/src/api/mod.rs
+++ b/crates/orbit-dashboard/src/api/mod.rs
@@ -421,6 +421,7 @@ pub(super) fn router() -> Router<crate::state::DashboardState> {
         .route("/metrics/activity", get(metrics::activity_metrics))
         .route("/metrics/tools", get(metrics::tool_metrics))
         .route("/metrics/task/:id", get(metrics::task_metrics))
+        .route("/metrics/orchestrators", get(metrics::orchestrator_metrics))
         .route(
             "/metrics/invocations",
             get(metrics::invocation_metrics).post(metrics::ingest_invocation),

--- a/crates/orbit-dashboard/src/api/tests/metrics.rs
+++ b/crates/orbit-dashboard/src/api/tests/metrics.rs
@@ -14,7 +14,8 @@ use orbit_core::command::job::JobRunListParams;
 use orbit_core::metrics::{KnowledgeStatsSummary, aggregate as aggregate_knowledge_stats};
 use orbit_core::{
     ActivityInvocationMetrics, InvocationInsertParams, InvocationQuery, InvocationRecord,
-    JobRunState, OrbitRuntime, TaskInvocationMetrics, ToolInvocationMetrics,
+    JobRunState, OrbitRuntime, OrchestratorInvocationMetrics, OrchestratorMetricsBucketKind,
+    TaskInvocationMetrics, ToolInvocationMetrics,
 };
 use tower::ServiceExt;
 
@@ -265,6 +266,21 @@ async fn metrics_endpoints_return_runtime_shapes() {
         invocations_bytes,
         serde_json::to_vec(&expected_invocations).expect("expected invocations json")
     );
+
+    let orchestrators = request_metrics(runtime.clone(), "/metrics/orchestrators").await;
+    assert_eq!(orchestrators.status(), StatusCode::OK);
+    let orchestrator_bytes = body_bytes(orchestrators).await;
+    let decoded_orchestrators: OrchestratorInvocationMetrics =
+        serde_json::from_slice(&orchestrator_bytes).expect("orchestrator json");
+    assert_eq!(decoded_orchestrators.buckets.len(), 1);
+    assert_eq!(
+        decoded_orchestrators.buckets[0].kind,
+        OrchestratorMetricsBucketKind::Missing
+    );
+    assert_eq!(decoded_orchestrators.buckets[0].orchestrator, None);
+    assert_eq!(decoded_orchestrators.buckets[0].invocation_count, 2);
+    assert_eq!(decoded_orchestrators.buckets[0].linked_task_count, 2);
+    assert!(decoded_orchestrators.until <= decoded_orchestrators.as_of);
 }
 
 #[tokio::test]
@@ -311,6 +327,34 @@ async fn metrics_invocations_reports_invalid_rfc3339_field() {
     let payload = body_json(response).await;
     let message = payload["error"].as_str().expect("error message");
     assert!(message.contains("invalid since:"));
+}
+
+#[tokio::test]
+async fn metrics_orchestrators_validates_rfc3339_and_window_order() {
+    let runtime = seed_metrics_runtime();
+
+    let malformed =
+        request_metrics(runtime.clone(), "/metrics/orchestrators?since=not-a-date").await;
+    assert_eq!(malformed.status(), StatusCode::BAD_REQUEST);
+    let malformed_payload = body_json(malformed).await;
+    assert!(
+        malformed_payload["error"]
+            .as_str()
+            .expect("error message")
+            .contains("invalid since:")
+    );
+
+    let inverted = request_metrics(
+        runtime,
+        "/metrics/orchestrators?since=2026-08-02T00:00:01Z&until=2026-08-02T00:00:00Z",
+    )
+    .await;
+    assert_eq!(inverted.status(), StatusCode::BAD_REQUEST);
+    let inverted_payload = body_json(inverted).await;
+    assert_eq!(
+        inverted_payload["error"],
+        "since must be earlier than until"
+    );
 }
 
 #[tokio::test]

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -136,8 +136,9 @@ pub use sqlite::id_allocator::{
     with_active_id_allocations,
 };
 pub use sqlite::invocation_store::{
-    ActivityInvocationMetrics, AgentInvocationMetrics, InvocationInsertParams, InvocationQuery,
-    InvocationRecord, InvocationToolCallRecord, TaskInvocationMetrics, ToolInvocationMetrics,
+    ActivityInvocationMetrics, AgentInvocationMetrics, InvocationAccountingFact,
+    InvocationAccountingQuery, InvocationInsertParams, InvocationQuery, InvocationRecord,
+    InvocationToolCallRecord, TaskInvocationMetrics, ToolInvocationMetrics,
 };
 pub use sqlite::routine_store::{
     RoutineCursor, RoutineFireIntentParams, RoutineFireRecord, RoutineFireState,

--- a/crates/orbit-store/src/sqlite/invocation_store.rs
+++ b/crates/orbit-store/src/sqlite/invocation_store.rs
@@ -7,6 +7,7 @@ mod types;
 #[cfg(test)]
 pub(crate) use records::INVOCATION_INSERT_COLUMNS;
 pub use types::{
-    ActivityInvocationMetrics, AgentInvocationMetrics, InvocationInsertParams, InvocationQuery,
-    InvocationRecord, InvocationToolCallRecord, TaskInvocationMetrics, ToolInvocationMetrics,
+    ActivityInvocationMetrics, AgentInvocationMetrics, InvocationAccountingFact,
+    InvocationAccountingQuery, InvocationInsertParams, InvocationQuery, InvocationRecord,
+    InvocationToolCallRecord, TaskInvocationMetrics, ToolInvocationMetrics,
 };

--- a/crates/orbit-store/src/sqlite/invocation_store/records/mod.rs
+++ b/crates/orbit-store/src/sqlite/invocation_store/records/mod.rs
@@ -10,7 +10,8 @@ use orbit_common::types::{OrbitError, RoleSlot, TokenUsage, derive_cost_usd};
 use crate::{Store, now_string};
 
 use super::types::{
-    InvocationInsertParams, InvocationQuery, InvocationRecord, InvocationToolCallRecord,
+    InvocationAccountingFact, InvocationAccountingQuery, InvocationInsertParams, InvocationQuery,
+    InvocationRecord, InvocationToolCallRecord,
 };
 
 /// Every column the invocation-trace insert binds, in bind order.
@@ -117,6 +118,65 @@ impl Store {
 
         hydrate_invocation_records(self, &mut records)?;
         Ok(records)
+    }
+
+    /// Loads every invocation in the requested half-open window exactly once.
+    ///
+    /// This intentionally bypasses the detailed-list limit and hydrates only
+    /// distinct linked task ids, never tool-call rows.
+    pub fn list_invocation_accounting_facts(
+        &self,
+        query: &InvocationAccountingQuery,
+    ) -> Result<Vec<InvocationAccountingFact>, OrbitError> {
+        let conn = self.read()?;
+        let (sql, params): (&str, Vec<Box<dyn ToSql>>) = match query.since {
+            Some(since) => (
+                r#"SELECT i.id, i.ts, i.model, i.input_tokens, i.cache_read_tokens,
+                          i.cache_create_tokens, i.cache_create_1h_tokens, i.output_tokens,
+                          i.provider_cost_usd
+                   FROM invocations i
+                   WHERE i.ts >= ?1 AND i.ts < ?2
+                   ORDER BY i.ts ASC, i.id ASC"#,
+                vec![
+                    Box::new(since.to_rfc3339()),
+                    Box::new(query.until.to_rfc3339()),
+                ],
+            ),
+            None => (
+                r#"SELECT i.id, i.ts, i.model, i.input_tokens, i.cache_read_tokens,
+                          i.cache_create_tokens, i.cache_create_1h_tokens, i.output_tokens,
+                          i.provider_cost_usd
+                   FROM invocations i
+                   WHERE i.ts < ?1
+                   ORDER BY i.ts ASC, i.id ASC"#,
+                vec![Box::new(query.until.to_rfc3339())],
+            ),
+        };
+        let param_refs = params
+            .iter()
+            .map(|value| value.as_ref())
+            .collect::<Vec<_>>();
+        let mut stmt = conn
+            .prepare(sql)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let rows = stmt
+            .query_map(param_refs.as_slice(), map_invocation_accounting_fact)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let mut facts = rows
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        drop(stmt);
+        drop(conn);
+
+        if facts.is_empty() {
+            return Ok(facts);
+        }
+        let invocation_ids = facts.iter().map(|fact| fact.id).collect::<Vec<_>>();
+        let mut task_ids = self.load_invocation_task_ids(&invocation_ids)?;
+        for fact in &mut facts {
+            fact.task_ids = task_ids.remove(&fact.id).unwrap_or_default();
+        }
+        Ok(facts)
     }
 
     fn load_invocation_task_ids(
@@ -315,6 +375,46 @@ fn map_invocation_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<Invocation
         tool_call_count: row.get::<_, i64>(13)? as u64,
         task_ids: Vec::new(),
         tool_calls: Vec::new(),
+        provider_cost_usd,
+        derived_cost_usd,
+    })
+}
+
+fn map_invocation_accounting_fact(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<InvocationAccountingFact> {
+    let ts_raw: String = row.get(1)?;
+    let ts = parse_rfc3339_timestamp(&ts_raw)?;
+    let model: Option<String> = row.get(2)?;
+    let input_tokens = row.get::<_, i64>(3)? as u64;
+    let cache_read_tokens = row.get::<_, i64>(4)? as u64;
+    let cache_create_tokens = row.get::<_, i64>(5)? as u64;
+    let cache_create_1h_tokens = row.get::<_, i64>(6)? as u64;
+    let output_tokens = row.get::<_, i64>(7)? as u64;
+    let provider_cost_usd = row.get(8)?;
+    let derived_cost_usd = model.as_deref().and_then(|model| {
+        derive_cost_usd(
+            model,
+            ts,
+            &TokenUsage {
+                input: input_tokens,
+                cache_read: cache_read_tokens,
+                cache_create: cache_create_tokens,
+                cache_create_1h: cache_create_1h_tokens,
+                output: output_tokens,
+            },
+        )
+    });
+
+    Ok(InvocationAccountingFact {
+        id: row.get(0)?,
+        ts,
+        input_tokens,
+        cache_read_tokens,
+        cache_create_tokens,
+        cache_create_1h_tokens,
+        output_tokens,
+        task_ids: Vec::new(),
         provider_cost_usd,
         derived_cost_usd,
     })

--- a/crates/orbit-store/src/sqlite/invocation_store/types.rs
+++ b/crates/orbit-store/src/sqlite/invocation_store/types.rs
@@ -67,6 +67,31 @@ pub struct InvocationRecord {
     pub derived_cost_usd: Option<f64>,
 }
 
+/// Date window for reconciliation-safe invocation accounting reads.
+///
+/// `until` is always exclusive. Callers capture it before loading so rows
+/// arriving during aggregation cannot make one read internally inconsistent.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct InvocationAccountingQuery {
+    pub since: Option<DateTime<Utc>>,
+    pub until: DateTime<Utc>,
+}
+
+/// One invocation and its distinct task linkage, without detailed tool calls.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct InvocationAccountingFact {
+    pub id: i64,
+    pub ts: DateTime<Utc>,
+    pub input_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_create_tokens: u64,
+    pub cache_create_1h_tokens: u64,
+    pub output_tokens: u64,
+    pub task_ids: Vec<String>,
+    pub provider_cost_usd: Option<f64>,
+    pub derived_cost_usd: Option<f64>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ActivityInvocationMetrics {
     pub activity_id: String,

--- a/crates/orbit-store/src/sqlite/tests/invocation_store.rs
+++ b/crates/orbit-store/src/sqlite/tests/invocation_store.rs
@@ -2,6 +2,7 @@
 // invocation_store.rs) to sibling under `sqlite/tests/` per ORB-00247 and
 // docs/design-patterns/test_layout.md.
 
+use chrono::{TimeZone, Utc};
 use orbit_common::test_fixtures::{TEST_CODEX_MODEL, TEST_GEMINI_MODEL};
 use orbit_common::types::{InvocationTrace, RoleSlot, TokenUsage, ToolCallTrace};
 
@@ -10,7 +11,9 @@ use orbit_common::types::{InvocationTrace, RoleSlot, TokenUsage, ToolCallTrace};
 // which are deliberately kept out of the production price table).
 const PRICED_MODEL: &str = "claude-opus-4-7";
 
-use super::super::invocation_store::{InvocationInsertParams, InvocationQuery};
+use super::super::invocation_store::{
+    InvocationAccountingQuery, InvocationInsertParams, InvocationQuery,
+};
 use crate::Store;
 
 #[test]
@@ -312,4 +315,88 @@ fn invocation_records_leave_derived_cost_none_for_an_unpriced_model() {
     assert_eq!(records.len(), 1);
     assert_eq!(records[0].provider_cost_usd, None);
     assert_eq!(records[0].derived_cost_usd, None);
+}
+
+#[test]
+fn accounting_facts_are_unbounded_distinct_and_half_open_without_tool_hydration() {
+    let store = Store::open_in_memory().expect("open store");
+    let lower = Utc
+        .with_ymd_and_hms(2026, 8, 1, 0, 0, 0)
+        .single()
+        .expect("lower bound");
+    let upper = Utc
+        .with_ymd_and_hms(2026, 8, 2, 0, 0, 0)
+        .single()
+        .expect("upper bound");
+
+    for index in 0..125 {
+        store
+            .insert_invocation_trace_record(&InvocationInsertParams {
+                job_run_id: format!("jrun-accounting-{index}"),
+                activity_id: "implement".to_string(),
+                agent: "codex".to_string(),
+                model: Some(PRICED_MODEL.to_string()),
+                slot: None,
+                task_ids: vec![
+                    "ORB-DUPLICATE".to_string(),
+                    "ORB-DUPLICATE".to_string(),
+                    format!("ORB-{index}"),
+                ],
+                trace: InvocationTrace {
+                    usage: TokenUsage {
+                        input: 10,
+                        cache_read: 2,
+                        cache_create: 3,
+                        cache_create_1h: 4,
+                        output: 5,
+                    },
+                    tool_calls: vec![ToolCallTrace {
+                        seq: 0,
+                        tool_name: "fs.read".to_string(),
+                        result_bytes: 99,
+                        result_payload: None,
+                    }],
+                    duration_ms: 1,
+                    provider_model: None,
+                    provider_cost_usd: Some(0.25),
+                },
+            })
+            .expect("insert accounting invocation");
+    }
+
+    let connection = store.connection();
+    let conn = connection.lock().expect("lock store");
+    conn.execute(
+        "UPDATE invocations SET ts = ?1",
+        [(lower + chrono::Duration::hours(1)).to_rfc3339()],
+    )
+    .expect("place rows inside window");
+    conn.execute(
+        "UPDATE invocations SET ts = ?1 WHERE id = 1",
+        [lower.to_rfc3339()],
+    )
+    .expect("place lower boundary");
+    conn.execute(
+        "UPDATE invocations SET ts = ?1 WHERE id = 125",
+        [upper.to_rfc3339()],
+    )
+    .expect("place upper boundary");
+    drop(conn);
+
+    let facts = store
+        .list_invocation_accounting_facts(&InvocationAccountingQuery {
+            since: Some(lower),
+            until: upper,
+        })
+        .expect("load accounting facts");
+
+    assert_eq!(facts.len(), 124, "the loader has no detailed-list row cap");
+    assert_eq!(facts[0].task_ids.len(), 2, "duplicate task ids collapse");
+    assert_eq!(facts[0].cache_create_1h_tokens, 4);
+    assert_eq!(facts[0].provider_cost_usd, Some(0.25));
+    assert!(facts[0].derived_cost_usd.is_some());
+    assert!(
+        facts.iter().all(|fact| fact.id != 125),
+        "until is exclusive"
+    );
 }

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -126,6 +126,8 @@ After [ORB-10338] (see [ADR-0245]), `InvocationInsertParams.trace` carries an op
 
 After [ORB-10579], each price row also declares whether its input count is exclusive or gross-with-cache. Existing rows default to exclusive accounting; GPT-5.6 rows use gross accounting, so derived pricing subtracts cached-read and both cache-write buckets from the gross input total before charging the full input rate. Checked subtraction makes inconsistent rows unknown instead of silently saturating. Codex JSONL and OpenAI-compatible response parsing retain provider-reported cached-read, standard cache-write, and output buckets; OpenAI reports no 1-hour write bucket, while a malformed stored nonzero count still has a nonzero fallback price. GPT-5.6 results are standard short-context API-equivalent derived estimates. Exact Fast/service-tier and long-context billing remains future work because Orbit does not yet retain those per-request dimensions.
 
+After [ORB-10581] / [ADR-0310], `GET /api/metrics/orchestrators?since=&until=` reports managed-execution accounting from one unbounded, half-open invocation-fact read captured at an `as_of` timestamp. Each invocation's distinct linked task ids resolve against canonical tasks and enter exactly one conservative bucket with precedence `missing task > unattributed task > one named orchestrator > shared named orchestrators`; duplicate links and multiple tasks owned by the same orchestrator do not multiply cost. Buckets retain all five token splits and separate provider, derived, and same-population comparable cost sums, counts, and delta. Missing provider values and unpriced/invalid derived values remain explicit counts, so partial sums are never presented as reconciled totals. Direct Codex/Claude orchestration sessions that do not emit managed invocation rows remain outside this endpoint.
+
 The workspace-local `model-price-audit` auto-task ([ORB-10583]) is the evidence
 collection and reconciliation guard around this table. Once weekly, it
 enumerates exact model strings from `InvocationRecord.model` telemetry and every
@@ -209,6 +211,7 @@ Each record contains timestamp, level, target, and structured fields. After [T20
 - **[ORB-10338]** — Added the versioned model price table and query-time `derived_cost_usd`, plus a persisted `provider_cost_usd` column for reconciliation.
 - **[ORB-10370]** — Parsed provider-reported CLI model/cost metadata, preferred the reported model at ingest, and retained structured mismatch evidence.
 - **[ORB-10579]** — Corrected GPT-5.6 price periods and cache-write rates, added gross-input accounting, and retained OpenAI cache buckets for standard short-context estimates.
+- **[ORB-10581]** — Added reconciliation-safe managed invocation accounting by canonical task orchestrator ([ADR-0310]).
 - **[ORB-00106]** — Preserve per-task implementer attribution when `orbit run ship` moves batch PR tasks from Review to Done.
 - **[ORB-10200]** — Derive CLI audit metadata and the other cross-cutting command policies from one exhaustive command-operation registry.
 - **[ORB-10225]** — Route in-process graph MCP calls through the safe-surface allowlist and shared runtime audit boundary.


### PR DESCRIPTION
## Task

[ORB-10581](https://orbit-cli.com/tasks/ORB-10581) — Aggregate managed invocation cost by task orchestrator

### Description

Implement the reconciliation-safe managed execution accounting defined by ADR-0310. Read each invocation exactly once, join its distinct task ids to canonical task orchestration ownership, classify it conservatively, and expose a date-bounded runtime/API aggregate. Do not build this by summing existing per-task metrics, because shared invocations are intentionally repeated there.

### Acceptance Criteria

- Orbit store exposes an unbounded date-filtered accounting-fact loader for invocation rows and distinct linked task ids without tool-call hydration or the existing 100-row detailed-list cap.
- Runtime aggregation resolves task ids against canonical tasks and classifies every invocation exactly once as missing, unattributed, a named orchestrator, or shared using ADR-0310's precedence.
- Two or more linked tasks with one orchestrator charge that orchestrator once; mixed named orchestrators charge shared once; unresolved or partially unattributed task sets never silently charge a known orchestrator.
- Each bucket reports distinct invocation count, linked-task count, all five token splits including 1-hour cache writes, provider-cost sum and contributing count, derived-cost sum and contributing count, comparable provider/derived sums and delta, missing-provider count, and unpriced-derived count.
- Aggregation captures an `as_of` timestamp and uses an exclusive upper cutoff plus validated optional `since`/`until` bounds so repeated reads reconcile during concurrent traffic.
- For every window, bucket invocation counts, token totals, and each defined cost population reconcile exactly to the distinct source invocation population; provider and derived partial sums are never presented as comparable unless based on the same invocations.
- A new `GET /api/metrics/orchestrators?since=&until=` endpoint returns typed bucket kinds plus an optional orchestrator name and documents that it measures managed execution only.
- Tests cover more than 100 invocations, duplicate task ids, single and multiple same-owner tasks, mixed owners, no task ids, missing tasks, unattributed tasks, provider-only/derived-only/both/neither costs, invalid price data, all token buckets, time boundaries, and reconciliation invariants.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added an unbounded half-open invocation accounting-fact loader that returns each invocation once with distinct task links, all five token buckets, and provider/derived costs without tool-call hydration or the detailed-list row cap.
- Added runtime aggregation against canonical task ownership with ADR-0310 precedence (missing, unattributed, one named orchestrator, shared), exclusive as_of cutoff, validated bounds, per-bucket distinct task counts, separate provider/derived/comparable populations, and explicit unknown-cost counts.
- Added GET /api/metrics/orchestrators?since=&until= with typed bucket kinds and documented managed-execution-only scope; updated the auditability design doc.
- Added store, runtime, and API tests covering >100 rows, duplicate links, same/mixed owners, missing/unattributed/no-task cases, all token splits, provider-only/derived-only/both/neither and invalid derived inputs, half-open boundaries, bounds validation, and reconciliation invariants.

Assessment: The implementation reads source invocations once, assigns every row to exactly one conservative bucket, and exposes enough population counts to prevent unlike partial cost sums from being compared.

Deviations from original plan:
- Expanded context_files to the store/core export and engine module registration files required to expose the new public types, plus the engine test module registration. These are tightly coupled API/dispatch targets needed for compilation and downstream dashboard use.

Validation:
- make ci-fast
- cargo test -p orbit-store sqlite::tests::invocation_store
- cargo test -p orbit-core orchestrator_accounting
- cargo test -p orbit-dashboard api::tests::metrics
- cargo clippy -p orbit-store -p orbit-core -p orbit-dashboard --all-targets -- -D warnings
- git diff --check

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10581-6a6ed94c`
- Behind base: 0
- Ahead of base: 1