### PR TITLE
Surface orchestration cost metrics in the dashboard

### DIFF
--- a/crates/orbit-core/src/runtime/engine/invocation.rs
+++ b/crates/orbit-core/src/runtime/engine/invocation.rs
@@ -11,40 +11,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::OrbitRuntime;
 
-/// Conservative ownership class for managed invocation accounting.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
-#[serde(rename_all = "snake_case")]
-pub enum OrchestratorMetricsBucketKind {
-    Missing,
-    Unattributed,
-    Orchestrator,
-    Shared,
-}
-
-/// Reconciliation fields for one ownership bucket.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct OrchestratorInvocationMetricsBucket {
-    pub kind: OrchestratorMetricsBucketKind,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub orchestrator: Option<String>,
-    pub invocation_count: u64,
-    pub linked_task_count: u64,
-    pub input_tokens: u64,
-    pub cache_read_tokens: u64,
-    pub cache_create_tokens: u64,
-    pub cache_create_1h_tokens: u64,
-    pub output_tokens: u64,
-    pub provider_cost_usd: f64,
-    pub provider_cost_count: u64,
-    pub derived_cost_usd: f64,
-    pub derived_cost_count: u64,
-    pub comparable_provider_cost_usd: f64,
-    pub comparable_derived_cost_usd: f64,
-    pub comparable_cost_count: u64,
-    pub comparable_cost_delta_usd: f64,
-    pub missing_provider_count: u64,
-    pub unpriced_derived_count: u64,
-}
+pub use orbit_store::scoreboard_summary::{
+    OrchestrationBucketKind as OrchestratorMetricsBucketKind,
+    OrchestrationBucketSummary as OrchestratorInvocationMetricsBucket,
+};
 
 /// Stable, managed-execution-only accounting snapshot.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/orbit-core/src/runtime/engine/summary.rs
+++ b/crates/orbit-core/src/runtime/engine/summary.rs
@@ -1,6 +1,8 @@
 use chrono::{Duration, Utc};
 use orbit_common::types::OrbitError;
-use orbit_store::scoreboard_summary::{ScoreboardInputs, ScoreboardWindow};
+use orbit_store::scoreboard_summary::{
+    ORCHESTRATION_SCHEMA_VERSION, OrchestrationSummary, ScoreboardInputs, ScoreboardWindow,
+};
 use orbit_store::{AdrListFilter, JobRunQuery};
 
 use crate::OrbitRuntime;
@@ -29,6 +31,7 @@ impl OrbitRuntime {
         let now = Utc::now();
         let since_recent = now - Duration::days(RECENT_WINDOW_DAYS);
         let since_window = window.duration().map(|d| now - d);
+        let orchestration = self.orchestrator_invocation_metrics(since_window, Some(now))?;
 
         let audit_tool_calls = self.audit_tool_call_counts_by_role(since_window.as_ref())?;
         let audit_tool_calls_by_surface =
@@ -64,6 +67,14 @@ impl OrbitRuntime {
                 frictions: &frictions,
                 now: Some(now),
                 window,
+                orchestration: Some(OrchestrationSummary {
+                    schema_version: ORCHESTRATION_SCHEMA_VERSION,
+                    scope: "managed_execution".to_string(),
+                    as_of: orchestration.as_of,
+                    since: orchestration.since,
+                    until: orchestration.until,
+                    buckets: orchestration.buckets,
+                }),
             },
         )?;
         let _ =

--- a/crates/orbit-core/src/runtime/engine/tests/invocation.rs
+++ b/crates/orbit-core/src/runtime/engine/tests/invocation.rs
@@ -1,5 +1,6 @@
 use chrono::{Duration, Utc};
 use orbit_common::types::{InvocationTrace, TokenUsage};
+use orbit_store::scoreboard_summary::{ORCHESTRATION_SCHEMA_VERSION, ScoreboardWindow};
 use tempfile::tempdir;
 
 use crate::command::task::TaskAddParams;
@@ -294,6 +295,39 @@ fn orchestrator_accounting_classifies_conservatively_and_reconciles_every_popula
             bucket.comparable_provider_cost_usd - bucket.comparable_derived_cost_usd
         );
     }
+
+    let scoreboard = runtime
+        .generate_scoreboard_summary(Some(ScoreboardWindow::Hour))
+        .expect("generate bounded scoreboard");
+    let orchestration = scoreboard
+        .orchestration
+        .expect("scoreboard preserves orchestration projection");
+    assert_eq!(orchestration.schema_version, ORCHESTRATION_SCHEMA_VERSION);
+    assert_eq!(orchestration.scope, "managed_execution");
+    assert!(orchestration.until <= orchestration.as_of);
+    assert!(orchestration.since.is_some(), "bounded window is preserved");
+    assert_eq!(orchestration.buckets.len(), 4);
+    assert!(orchestration.buckets.iter().any(|bucket| bucket.kind
+        == OrchestratorMetricsBucketKind::Orchestrator
+        && bucket.orchestrator.as_deref() == Some("alpha")));
+    assert!(
+        orchestration
+            .buckets
+            .iter()
+            .any(|bucket| bucket.kind == OrchestratorMetricsBucketKind::Shared)
+    );
+    assert!(
+        orchestration
+            .buckets
+            .iter()
+            .any(|bucket| bucket.kind == OrchestratorMetricsBucketKind::Unattributed)
+    );
+    assert!(
+        orchestration
+            .buckets
+            .iter()
+            .any(|bucket| bucket.kind == OrchestratorMetricsBucketKind::Missing)
+    );
 }
 
 #[test]

--- a/crates/orbit-dashboard/assets/dashboard/index.html
+++ b/crates/orbit-dashboard/assets/dashboard/index.html
@@ -239,6 +239,18 @@
             </div>
           </div>
         </section>
+        <section class="panel" id="scoreboard-orchestration-panel">
+          <header>
+            <span>Managed Execution Cost</span>
+            <span class="count" id="scoreboard-orchestration-count">—</span>
+          </header>
+          <div class="body" id="scoreboard-orchestration">
+            <div class="empty-state">
+              <div class="icon">✧</div>
+              <div class="text">No managed execution cost data yet.</div>
+            </div>
+          </div>
+        </section>
         <section class="scoreboard-duel-section">
           <section class="panel" id="scoreboard-duel-matrix-panel">
             <header><span>Duel Matrix</span><span class="count" id="scoreboard-duel-count">—</span></header>

--- a/crates/orbit-dashboard/assets/dashboard/scoreboard.js
+++ b/crates/orbit-dashboard/assets/dashboard/scoreboard.js
@@ -205,6 +205,8 @@ function renderScoreboard(summary) {
   const duelCount = $("scoreboard-duel-count");
   const insightsHost = $("scoreboard-insights");
   const insightsCount = $("scoreboard-insights-count");
+  const orchestrationHost = $("scoreboard-orchestration");
+  const orchestrationCount = $("scoreboard-orchestration-count");
 
   const agentsMap = (summary && summary.agents) || {};
   const entries = Object.entries(agentsMap);
@@ -222,6 +224,8 @@ function renderScoreboard(summary) {
     if (duelCount) duelCount.textContent = "—";
     if (insightsHost) syncNodes(insightsHost, []);
     if (insightsCount) insightsCount.textContent = "—";
+    if (orchestrationHost) syncNodes(orchestrationHost, [emptyOrchestrationNode()]);
+    if (orchestrationCount) orchestrationCount.textContent = "—";
     return;
   }
 
@@ -266,6 +270,103 @@ function renderScoreboard(summary) {
       insightsCount.textContent = fired === 0 ? "—" : String(fired);
     }
   }
+
+  // This deliberately does not feed the execution-agent leaderboard above.
+  // Ownership comes from canonical task orchestrators; executor family/model
+  // remains an independent identity in `summary.agents`.
+  if (orchestrationHost) {
+    const orchestration = renderOrchestrationSummary(summary?.orchestration);
+    syncNodes(orchestrationHost, [orchestration]);
+    if (orchestrationCount) {
+      const count = Array.isArray(summary?.orchestration?.buckets)
+        ? summary.orchestration.buckets.length
+        : 0;
+      orchestrationCount.textContent = count === 0 ? "—" : `${count} buckets`;
+    }
+  }
+}
+
+function formatUsd(value) {
+  const amount = typeof value === "number" && Number.isFinite(value) ? value : 0;
+  return `$${amount.toFixed(4)}`;
+}
+
+function bucketLabel(bucket) {
+  switch (bucket?.kind) {
+    case "orchestrator": return `named orchestrator: ${bucket.orchestrator || "unknown"}`;
+    case "shared": return "shared task ownership";
+    case "unattributed": return "unattributed task ownership";
+    case "missing": return "missing linked task";
+    default: return "unknown ownership";
+  }
+}
+
+function costPopulationLine(label, total, knownCount, invocationCount, unknownCount, kind) {
+  const known = asScoreboardNumber(knownCount);
+  const totalInvocations = asScoreboardNumber(invocationCount);
+  const unknown = asScoreboardNumber(unknownCount);
+  if (known === 0) {
+    return `${label}: unknown (0/${totalInvocations} ${kind}; ${unknown} unavailable)`;
+  }
+  return `${label}: ${formatUsd(total)} (${known}/${totalInvocations} ${kind}; ${unknown} unavailable)`;
+}
+
+function renderOrchestrationBucket(bucket) {
+  const invocationCount = asScoreboardNumber(bucket?.invocation_count);
+  const comparableCount = asScoreboardNumber(bucket?.comparable_cost_count);
+  const lines = [
+    costPopulationLine(
+      "provider-reported",
+      bucket?.provider_cost_usd,
+      bucket?.provider_cost_count,
+      invocationCount,
+      bucket?.missing_provider_count,
+      "reported",
+    ),
+    costPopulationLine(
+      "derived estimate",
+      bucket?.derived_cost_usd,
+      bucket?.derived_cost_count,
+      invocationCount,
+      bucket?.unpriced_derived_count,
+      "priced",
+    ),
+  ];
+  if (comparableCount > 0) {
+    lines.push(
+      `comparable same-invocation population: provider ${formatUsd(bucket?.comparable_provider_cost_usd)} / derived ${formatUsd(bucket?.comparable_derived_cost_usd)} / delta ${formatUsd(bucket?.comparable_cost_delta_usd)} (${comparableCount}/${invocationCount})`,
+    );
+  } else {
+    lines.push(`comparable: unknown (no shared provider/derived population; do not reconcile partial sums)`);
+  }
+  return el("article", { class: "scoreboard-orchestration-bucket" }, [
+    el("strong", { text: bucketLabel(bucket) }),
+    el("span", { class: "dim", text: `${invocationCount} managed invocations · ${asScoreboardNumber(bucket?.linked_task_count)} linked tasks` }),
+    ...lines.map((text) => el("div", { text })),
+  ]);
+}
+
+function emptyOrchestrationNode() {
+  return el("div", { class: "empty-state" }, [
+    el("div", { class: "icon", text: "✧" }),
+    el("div", { class: "text", text: "No managed execution cost data yet." }),
+  ]);
+}
+
+function renderOrchestrationSummary(orchestration) {
+  if (!orchestration || !Array.isArray(orchestration.buckets)) return emptyOrchestrationNode();
+  const since = orchestration.since || "all managed execution retained";
+  const until = orchestration.until || orchestration.as_of || "unknown cutoff";
+  const children = [
+    el("p", { text: `Managed execution cost only. Direct interactive Codex or Claude orchestration-session overhead is excluded. Window: ${since} ≤ invocation < ${until} (exclusive cutoff; as of ${orchestration.as_of || "unknown"}).` }),
+    el("p", { class: "dim", text: "Provider-first estimate policy: provider-reported values are primary; derived values remain explicitly labeled estimates with their own coverage. Only the explicitly comparable same-invocation population is safe to compare." }),
+  ];
+  if (orchestration.buckets.length === 0) {
+    children.push(el("div", { class: "empty-state" }, [el("div", { class: "text", text: "No managed invocations in this bounded window." })]));
+  } else {
+    children.push(...orchestration.buckets.map(renderOrchestrationBucket));
+  }
+  return el("section", { class: "scoreboard-orchestration-summary" }, children);
 }
 
 function canonicalScoreboardRows(agentsMap) {

--- a/crates/orbit-dashboard/src/api/tests/scoreboard.rs
+++ b/crates/orbit-dashboard/src/api/tests/scoreboard.rs
@@ -6,7 +6,8 @@
 // - `?window=1h` round-trips into the serialized payload + populates
 //   `window_since`
 // - unknown values produce HTTP 400 (not a 500)
-// - schema_version is the post-bump v6 value
+// - schema_version is the post-bump v7 value with its separately-versioned
+//   managed-execution orchestration section
 
 use std::sync::Arc;
 
@@ -37,19 +38,36 @@ async fn get_scoreboard(runtime: OrbitRuntime, query: Option<&str>) -> axum::res
 }
 
 #[tokio::test]
-async fn scoreboard_default_returns_lifetime_window_and_v6_schema() {
+async fn scoreboard_default_returns_lifetime_window_and_v7_schema() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     let response = get_scoreboard(runtime, None).await;
 
     assert_eq!(response.status(), StatusCode::OK);
     let body = body_json(response).await;
-    assert_eq!(body["schema_version"].as_u64(), Some(6));
+    assert_eq!(body["schema_version"].as_u64(), Some(7));
     assert_eq!(body["window"].as_str(), Some("all"));
     assert!(
         body["window_since"].is_null(),
         "window_since is null for lifetime, got {:?}",
         body["window_since"]
     );
+    assert_eq!(body["orchestration"]["schema_version"].as_u64(), Some(1));
+    assert_eq!(body["orchestration"]["scope"], "managed_execution");
+    assert!(
+        chrono::DateTime::parse_from_rfc3339(
+            body["orchestration"]["until"]
+                .as_str()
+                .expect("until timestamp"),
+        )
+        .expect("parse until")
+            <= chrono::DateTime::parse_from_rfc3339(
+                body["orchestration"]["as_of"]
+                    .as_str()
+                    .expect("as_of timestamp"),
+            )
+            .expect("parse as_of")
+    );
+    assert!(body["orchestration"]["buckets"].is_array());
 }
 
 #[tokio::test]
@@ -59,7 +77,7 @@ async fn scoreboard_query_window_1h_populates_window_and_since() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let body = body_json(response).await;
-    assert_eq!(body["schema_version"].as_u64(), Some(6));
+    assert_eq!(body["schema_version"].as_u64(), Some(7));
     assert_eq!(body["window"].as_str(), Some("1h"));
     let since = body["window_since"]
         .as_str()
@@ -67,6 +85,29 @@ async fn scoreboard_query_window_1h_populates_window_and_since() {
     // Surface check: parses as a RFC3339 timestamp.
     let _ =
         chrono::DateTime::parse_from_rfc3339(since).expect("window_since must be valid RFC3339");
+    assert_eq!(
+        chrono::DateTime::parse_from_rfc3339(
+            body["orchestration"]["since"]
+                .as_str()
+                .expect("orchestration since"),
+        )
+        .expect("parse orchestration since"),
+        chrono::DateTime::parse_from_rfc3339(since).expect("parse scoreboard since"),
+    );
+    assert!(
+        chrono::DateTime::parse_from_rfc3339(
+            body["orchestration"]["until"]
+                .as_str()
+                .expect("until timestamp"),
+        )
+        .expect("parse until")
+            <= chrono::DateTime::parse_from_rfc3339(
+                body["orchestration"]["as_of"]
+                    .as_str()
+                    .expect("as_of timestamp"),
+            )
+            .expect("parse as_of")
+    );
 }
 
 #[tokio::test]

--- a/crates/orbit-dashboard/src/tests/dashboard_assets.rs
+++ b/crates/orbit-dashboard/src/tests/dashboard_assets.rs
@@ -527,6 +527,8 @@ async fn dashboard_scoreboard_is_reachable_under_diagnostics() {
         "scoreboard-agent-strip",
         "scoreboard-duel-matrix-host",
         "scoreboard-insights",
+        "scoreboard-orchestration",
+        "scoreboard-orchestration-count",
     ] {
         assert!(body.contains(&format!(r#"id="{id}""#)), "{id} must survive");
     }
@@ -539,6 +541,32 @@ async fn dashboard_scoreboard_is_reachable_under_diagnostics() {
             && app.contains(r#"fetchJson("/api/scoreboard?window=24h")"#),
         "the scoreboard fetch must hang off the diagnostics subtab branch"
     );
+}
+
+#[test]
+fn dashboard_scoreboard_keeps_managed_cost_ownership_out_of_executor_rankings() {
+    let scoreboard = include_str!("../../assets/dashboard/scoreboard.js");
+    let index = include_str!("../../assets/dashboard/index.html");
+
+    assert!(index.contains("Managed Execution Cost"));
+    assert!(scoreboard.contains("renderOrchestrationSummary(summary?.orchestration)"));
+    assert!(scoreboard.contains("named orchestrator"));
+    assert!(scoreboard.contains("shared task ownership"));
+    assert!(scoreboard.contains("unattributed task ownership"));
+    assert!(scoreboard.contains("missing linked task"));
+    assert!(scoreboard.contains("provider-reported"));
+    assert!(scoreboard.contains("Provider-first estimate policy"));
+    assert!(scoreboard.contains("derived estimate"));
+    assert!(scoreboard.contains("if (known === 0)"));
+    assert!(scoreboard.contains("formatUsd(total)"));
+    assert!(scoreboard.contains("comparable same-invocation population"));
+    assert!(scoreboard.contains("do not reconcile partial sums"));
+    assert!(
+        scoreboard.contains(
+            "Direct interactive Codex or Claude orchestration-session overhead is excluded"
+        )
+    );
+    assert!(scoreboard.contains("invocation < ${until} (exclusive cutoff"));
 }
 
 /// ORB-10444: the Knowledge artifact list is long enough to scroll the detail

--- a/crates/orbit-store/src/file/scoreboard/scoreboard_summary/mod.rs
+++ b/crates/orbit-store/src/file/scoreboard/scoreboard_summary/mod.rs
@@ -26,8 +26,11 @@ const SUMMARY_FILENAME: &str = "summary.json";
 // `ScoreboardInputs.window` plumbing — snapshot-sourced per-agent fields
 // (`tokens`, `pr`, `duels`, `task_review.threads`) zero out under non-`All`
 // windows because we lack a timestamped snapshot log to filter against.
+// v7 adds the separately-versioned `orchestration` projection. It deliberately
+// remains separate from execution-agent/model scoreboard rows.
 // Older readers ignore unknown fields.
-const CURRENT_SCHEMA_VERSION: u32 = 6;
+const CURRENT_SCHEMA_VERSION: u32 = 7;
+pub const ORCHESTRATION_SCHEMA_VERSION: u32 = 1;
 const RECENT_WINDOW_DAYS: i64 = 7;
 
 type FamilyScoreboard = BTreeMap<String, BTreeMap<String, u64>>;
@@ -204,7 +207,58 @@ pub struct PlanningDuelSummary {
     pub head_to_head: planning_duel_scoreboard::HeadToHeadMatrix,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Conservative ownership class for managed invocation accounting.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum OrchestrationBucketKind {
+    Missing,
+    Unattributed,
+    Orchestrator,
+    Shared,
+}
+
+/// One managed-execution accounting bucket, classified by canonical task
+/// orchestration ownership rather than executor agent or model identity.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OrchestrationBucketSummary {
+    pub kind: OrchestrationBucketKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub orchestrator: Option<String>,
+    pub invocation_count: u64,
+    pub linked_task_count: u64,
+    pub input_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_create_tokens: u64,
+    pub cache_create_1h_tokens: u64,
+    pub output_tokens: u64,
+    pub provider_cost_usd: f64,
+    pub provider_cost_count: u64,
+    pub derived_cost_usd: f64,
+    pub derived_cost_count: u64,
+    pub comparable_provider_cost_usd: f64,
+    pub comparable_derived_cost_usd: f64,
+    pub comparable_cost_count: u64,
+    pub comparable_cost_delta_usd: f64,
+    pub missing_provider_count: u64,
+    pub unpriced_derived_count: u64,
+}
+
+/// Independently-versioned accounting for managed execution only.
+///
+/// `until` is exclusive and no later than `as_of`. Provider, derived, and
+/// comparable cost populations are separate so partial sums are never implied
+/// to reconcile.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OrchestrationSummary {
+    pub schema_version: u32,
+    pub scope: String,
+    pub as_of: DateTime<Utc>,
+    pub since: Option<DateTime<Utc>>,
+    pub until: DateTime<Utc>,
+    pub buckets: Vec<OrchestrationBucketSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ScoreboardSummary {
     pub schema_version: u32,
     pub generated_at: String,
@@ -228,6 +282,10 @@ pub struct ScoreboardSummary {
     /// Planning-duel reports that are not naturally per-agent columns.
     #[serde(default)]
     pub planning_duels: PlanningDuelSummary,
+    /// Managed-execution accounting by task orchestrator, deliberately kept
+    /// outside executor-agent rankings. v7+.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub orchestration: Option<OrchestrationSummary>,
     /// Selected scoreboard window in canonical short form (`"1h"`,
     /// `"24h"`, `"7d"`, `"30d"`, `"all"`). v6+. Older readers tolerate
     /// the field's absence via `#[serde(default)]`.
@@ -297,6 +355,9 @@ pub struct ScoreboardInputs<'a> {
     /// sourced fields and filter timestamp-bearing slices to the window.
     /// See [`ScoreboardWindow`] for the per-source semantics. v6+.
     pub window: ScoreboardWindow,
+    /// Runtime/API-sourced accounting for the same bounded window. It does
+    /// not use all-time snapshot token aggregates.
+    pub orchestration: Option<OrchestrationSummary>,
 }
 
 impl<'a> Default for ScoreboardInputs<'a> {
@@ -318,6 +379,7 @@ impl<'a> Default for ScoreboardInputs<'a> {
             frictions: &[],
             now: None,
             window: ScoreboardWindow::All,
+            orchestration: None,
         }
     }
 }
@@ -529,6 +591,7 @@ pub fn generate_summary_with_inputs(
         top_tools,
         recent_7d,
         planning_duels,
+        orchestration: inputs.orchestration.clone(),
         window: inputs.window.as_str().to_string(),
         window_since: since.map(|t| t.to_rfc3339()),
     })

--- a/crates/orbit-store/src/file/scoreboard/scoreboard_summary/tests/scoreboard_summary.rs
+++ b/crates/orbit-store/src/file/scoreboard/scoreboard_summary/tests/scoreboard_summary.rs
@@ -878,3 +878,68 @@ fn window_string_round_trips_for_all_variants() {
         Err(OrbitError::InvalidInput(_))
     ));
 }
+
+#[test]
+fn orchestration_section_is_independently_versioned_and_legacy_reads_default_it() {
+    let now = Utc::now();
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let summary = generate_summary_with_inputs(
+        temp.path(),
+        &[],
+        &ScoreboardInputs {
+            orchestration: Some(OrchestrationSummary {
+                schema_version: ORCHESTRATION_SCHEMA_VERSION,
+                scope: "managed_execution".to_string(),
+                as_of: now,
+                since: Some(now - chrono::Duration::hours(1)),
+                until: now,
+                buckets: vec![OrchestrationBucketSummary {
+                    kind: OrchestrationBucketKind::Orchestrator,
+                    orchestrator: Some("sol".to_string()),
+                    invocation_count: 1,
+                    linked_task_count: 1,
+                    input_tokens: 0,
+                    cache_read_tokens: 0,
+                    cache_create_tokens: 0,
+                    cache_create_1h_tokens: 0,
+                    output_tokens: 0,
+                    provider_cost_usd: 0.0,
+                    provider_cost_count: 1,
+                    derived_cost_usd: 0.0,
+                    derived_cost_count: 0,
+                    comparable_provider_cost_usd: 0.0,
+                    comparable_derived_cost_usd: 0.0,
+                    comparable_cost_count: 0,
+                    comparable_cost_delta_usd: 0.0,
+                    missing_provider_count: 0,
+                    unpriced_derived_count: 1,
+                }],
+            }),
+            ..ScoreboardInputs::default()
+        },
+    )
+    .expect("generate summary");
+
+    let encoded = serde_json::to_value(&summary).expect("serialize summary");
+    assert_eq!(encoded["schema_version"], CURRENT_SCHEMA_VERSION);
+    assert_eq!(
+        encoded["orchestration"]["schema_version"],
+        ORCHESTRATION_SCHEMA_VERSION
+    );
+    assert_eq!(
+        encoded["orchestration"]["buckets"][0]["provider_cost_usd"],
+        0.0
+    );
+    assert_eq!(
+        encoded["orchestration"]["buckets"][0]["unpriced_derived_count"],
+        1
+    );
+
+    let legacy: ScoreboardSummary = serde_json::from_value(serde_json::json!({
+        "schema_version": 6,
+        "generated_at": now.to_rfc3339(),
+        "agents": {}
+    }))
+    .expect("deserialize v6 summary without orchestration");
+    assert!(legacy.orchestration.is_none());
+}

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -68,9 +68,10 @@ pub mod pr_scoreboard {
 
 pub mod scoreboard_summary {
     pub use crate::file::scoreboard::scoreboard_summary::{
-        AgentSummary, DuelSummary, FrictionSummary, KnowledgeSummary, PlanningDuelSummary,
-        PrSummary, RecentSummary, ScoreboardInputs, ScoreboardSummary, ScoreboardWindow,
-        TokenSummary, TopToolCall, WorkflowRunCount, generate_summary,
+        AgentSummary, DuelSummary, FrictionSummary, KnowledgeSummary, ORCHESTRATION_SCHEMA_VERSION,
+        OrchestrationBucketKind, OrchestrationBucketSummary, OrchestrationSummary,
+        PlanningDuelSummary, PrSummary, RecentSummary, ScoreboardInputs, ScoreboardSummary,
+        ScoreboardWindow, TokenSummary, TopToolCall, WorkflowRunCount, generate_summary,
         generate_summary_with_audit_tool_calls, generate_summary_with_inputs, summary_path,
         write_summary,
     };

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -128,6 +128,8 @@ After [ORB-10579], each price row also declares whether its input count is exclu
 
 After [ORB-10581] / [ADR-0310], `GET /api/metrics/orchestrators?since=&until=` reports managed-execution accounting from one unbounded, half-open invocation-fact read captured at an `as_of` timestamp. Each invocation's distinct linked task ids resolve against canonical tasks and enter exactly one conservative bucket with precedence `missing task > unattributed task > one named orchestrator > shared named orchestrators`; duplicate links and multiple tasks owned by the same orchestrator do not multiply cost. Buckets retain all five token splits and separate provider, derived, and same-population comparable cost sums, counts, and delta. Missing provider values and unpriced/invalid derived values remain explicit counts, so partial sums are never presented as reconciled totals. Direct Codex/Claude orchestration sessions that do not emit managed invocation rows remain outside this endpoint.
 
+After [ORB-10582], the canonical dashboard scoreboard embeds that runtime projection as a top-level, independently versioned `orchestration` section (scoreboard schema v7, orchestration schema v1). It obtains the same selected bounded window from the runtime rather than reusing all-time token snapshots; its `until` is exclusive and is no later than the recorded `as_of`. This panel is deliberately outside executor-agent/model rankings: named orchestrator, shared ownership, unattributed ownership, and missing-task buckets describe canonical task ownership, not the identity of the execution agent. It labels provider-reported totals, derived estimates, same-population comparable totals and delta, and unavailable populations separately. Provider and derived partial sums are never displayed as reconciled unless the explicit comparable count says they share the same invocation population. The scope remains managed execution only; direct interactive Codex or Claude orchestration-session overhead is not included.
+
 The workspace-local `model-price-audit` auto-task ([ORB-10583]) is the evidence
 collection and reconciliation guard around this table. Once weekly, it
 enumerates exact model strings from `InvocationRecord.model` telemetry and every
@@ -212,6 +214,7 @@ Each record contains timestamp, level, target, and structured fields. After [T20
 - **[ORB-10370]** — Parsed provider-reported CLI model/cost metadata, preferred the reported model at ingest, and retained structured mismatch evidence.
 - **[ORB-10579]** — Corrected GPT-5.6 price periods and cache-write rates, added gross-input accounting, and retained OpenAI cache buckets for standard short-context estimates.
 - **[ORB-10581]** — Added reconciliation-safe managed invocation accounting by canonical task orchestrator ([ADR-0310]).
+- **[ORB-10582]** — Projected managed-execution orchestration accounting into the separately versioned dashboard scoreboard section without merging it into executor rankings.
 - **[ORB-00106]** — Preserve per-task implementer attribution when `orbit run ship` moves batch PR tasks from Review to Done.
 - **[ORB-10200]** — Derive CLI audit metadata and the other cross-cutting command policies from one exhaustive command-operation registry.
 - **[ORB-10225]** — Route in-process graph MCP calls through the safe-surface allowlist and shared runtime audit boundary.


### PR DESCRIPTION
## Task

[ORB-10582](https://orbit-cli.com/tasks/ORB-10582) — Surface orchestration cost metrics in the dashboard

### Description

Project ADR-0310 managed execution metrics into Orbit's canonical dashboard and scoreboard without merging orchestration responsibility into executor-agent statistics. Show named, shared, unattributed, and missing buckets; make cost coverage and estimate semantics visible; and preserve bounded-window behavior.

### Acceptance Criteria

- The scoreboard schema gains a separately versioned top-level orchestration section sourced from the orchestrator metrics runtime/API rather than existing per-task token aggregates.
- Dashboard views keep orchestrator ownership separate from execution agent/model identity and render named, shared, unattributed, and missing buckets.
- Each visible cost value identifies whether it is provider-reported, derived, comparable, unknown, or an explicit provider-first estimate; partial sums with different populations are not visually compared as if reconciled.
- The dashboard supports genuine bounded windows consistent with the API's exclusive `as_of` cutoff and does not fall back to all-time snapshot token fields.
- The UI identifies the metric as managed execution cost and does not imply that direct interactive Codex or Claude orchestration-session overhead is included.
- Tests cover scoreboard schema compatibility/versioning, bucket rendering, zero and unknown costs, named/shared/unattributed/missing states, bounded windows, and separation from executor rankings.
- Dashboard and auditability documentation describe the attribution contract, reconciliation behavior, and current managed-execution-only scope.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Bumped the scoreboard schema to v7 and added a separately versioned v1 `orchestration` projection sourced from the runtime managed-invocation accounting API.
- Preserved bounded half-open windows by passing the selected cutoff into runtime aggregation; no all-time executor token snapshot is used for the new section.
- Added a distinct Managed Execution Cost dashboard panel with named, shared, unattributed, and missing ownership buckets, provider-reported/derived/comparable/unknown coverage labels, and explicit provider-first-estimate wording. The panel is separate from executor rankings and names the exclusion of direct interactive Codex/Claude sessions.
- Added schema/API/runtime/dashboard coverage and auditability documentation. Added the tightly coupled runtime invocation implementation and sibling invocation test selector to context_files because the shared typed projection is required to keep the metrics API and scoreboard schema compatible.

Assessment: The projection assigns ownership from canonical task orchestrators only, retains unreconciled cost populations separately, and serializes an auditable bounded-window cutoff.

Validation:
- cargo fmt --check
- cargo test -p orbit-store scoreboard_summary
- cargo test -p orbit-core orchestrator_accounting_classifies_conservatively_and_reconciles_every_population
- cargo test -p orbit-dashboard api::tests::scoreboard
- cargo test -p orbit-dashboard dashboard_scoreboard_keeps_managed_cost_ownership_out_of_executor_rankings
- make ci-fast
- git diff --check

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10582-6a6edd05`
- Behind base: 0
- Ahead of base: 1