### PR TITLE
Gate Linux Bubblewrap integration tests to Linux hosts

### DIFF
--- a/crates/orbit-exec/tests/linux_sandbox.rs
+++ b/crates/orbit-exec/tests/linux_sandbox.rs
@@ -1,4 +1,5 @@
 #![allow(missing_docs)]
+#![cfg(target_os = "linux")]
 
 use std::process::Stdio;
 


### PR DESCRIPTION
## Task

[ORB-10566](https://orbit-cli.com/tasks/ORB-10566) — Gate Linux Bubblewrap integration tests to Linux hosts

### Description

## Problem
Merged PR #842 for ORB-10560 passed the Linux sandbox/policy lane but failed the GitHub Actions `macOS Sandbox` job. That job runs `cargo test -p orbit-exec --locked`, which compiles and executes `crates/orbit-exec/tests/linux_sandbox.rs` on macOS. Four tests rely on Linux Bubblewrap mount ordering, Linux path identity, or Linux-only post-run matching behavior and fail on the macOS runner; the actual macOS sandbox suite passes 40/40.

## Evidence
- Merged source: ORB-10560 / PR #842, merge commit `6bf4c86a44fd5254dc10d2ab5043732037440700`.
- Failing check: `macOS Sandbox`, workflow run 30727926965, job 91442970223, exit 101.
- Failures: `argv_is_deterministic_and_orders_denies_after_writable_parent`, `argv_reallows_only_narrow_existing_paths_after_orbit_deny`, `direct_invocation_fails_closed_for_overlapping_non_subtree_deny`, and `managed_worktree_guard_rejects_new_forbidden_match`.
- The same target emits unused Linux-only import warnings on macOS.

## Required direction
Make the platform boundary explicit: gate the Linux Bubblewrap integration-test target to Linux (prefer a file-level target cfg or an equivalently complete boundary), while retaining every Linux compiler, fail-closed, post-run guard, and real-kernel probe case on Linux. Do not weaken assertions, special-case macOS path strings, or change production sandbox behavior to satisfy an irrelevant host.

## Coordination
This is a post-merge CI regression follow-up for ORB-10560 / PR #842. Land it as a narrow follow-up PR against `agent-main`; no history rewriting or changes to the merged PR.

## Constraints / Notes
- Keep the change test-only unless new evidence proves production code is at fault.
- Preserve the macOS `orbit-exec` unit/runtime sandbox coverage.
- Preserve Linux test discovery; do not accidentally turn the Linux target into zero tests.

### Acceptance Criteria

- On macOS, `cargo test -p orbit-exec --locked` passes without compiling or running Linux Bubblewrap integration cases and without unused Linux-only import warnings from `tests/linux_sandbox.rs`.
- On Linux, `cargo test -p orbit-exec --test linux_sandbox --locked` discovers and passes the existing Bubblewrap argv, narrow re-allow, fail-closed, post-run guard, and kernel-probe cases; the target is not reduced to zero tests.
- The production files under `crates/orbit-exec/src/` and the GitHub Actions workflow remain unchanged unless concrete validation evidence demonstrates that a test-only platform gate is insufficient.
- `make ci-fast` and `git diff --check` pass.
- The follow-up PR's `macOS Sandbox` and `Linux Sandbox & Policy Enforcement` checks both pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a file-level `cfg(target_os = "linux")` to `crates/orbit-exec/tests/linux_sandbox.rs`, keeping the complete Bubblewrap integration target Linux-only while preserving all existing Linux cases.
- No production files, workflow files, or unrelated files changed.
Assessment: The Linux integration target ran 9 tests with 9 passed; `cargo test -p orbit-exec --locked` passed with 29 unit tests plus 9 Linux integration tests; `make ci-fast` passed; `git diff --check` passed. The macOS runner was not available locally, but the file-level target boundary directly excludes this integration target on non-Linux hosts while retaining orbit-exec's macOS unit coverage.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10566-6a6f9e3d`
- Behind base: 0
- Ahead of base: 1