### PR TITLE
workspace init --force does not cover a pre-seeded checkout identity

### DIFF
--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -4,7 +4,8 @@ use chrono::Utc;
 use clap::Args;
 use orbit_cmd::agent_rules::{InjectionAction, inject_agent_rules};
 use orbit_common::types::{
-    Workspace, WorkspaceCheckout, WorkspaceCheckoutRole, WorkspaceStatus, validate_machine_id,
+    Workspace, WorkspaceCheckout, WorkspaceCheckoutRole, WorkspaceRegistry, WorkspaceStatus,
+    validate_machine_id,
 };
 use orbit_common::utility::fs::atomic_write_text;
 use orbit_core::OrbitError;
@@ -55,7 +56,8 @@ pub struct WorkspaceInitArgs {
     #[arg(long, hide = true)]
     pub refresh_defaults: bool,
     /// Reconcile an already registered workspace after validating its complete
-    /// logical, checkout, and durable-identity binding.
+    /// logical, checkout, and durable-identity binding, or replace a checkout
+    /// identity that no registration claims.
     #[arg(long)]
     pub force: bool,
 }
@@ -214,12 +216,27 @@ impl WorkspaceInitArgs {
         } else if let Some(identity) = read_workspace_identity(orbit_dir)?
             && identity.workspace_id != id
         {
-            return Err(OrbitError::WorkspaceError(format!(
-                "workspace identity '{}' at '{}' conflicts with requested workspace '{}'; refusing to overwrite it",
-                identity.workspace_id,
-                orbit_dir.join("config.yaml").display(),
-                id
-            )));
+            // A checkout can carry an identity the registry never recorded:
+            // any command that opens a runtime in an uninitialized checkout
+            // seeds a bootstrap id. Replacing one is explicit reconciliation,
+            // so it needs --force — but --force must not detach an identity a
+            // durable registration still claims.
+            if !self.force {
+                return Err(OrbitError::WorkspaceError(format!(
+                    "workspace identity '{}' at '{}' conflicts with requested workspace '{}'; rerun with --force to reconcile it",
+                    identity.workspace_id,
+                    orbit_dir.join("config.yaml").display(),
+                    id
+                )));
+            }
+            if registry_claims(&registry, &identity.workspace_id) {
+                return Err(OrbitError::WorkspaceError(format!(
+                    "cannot reconcile workspace '{}': checkout identity '{}' at '{}' is claimed by an existing registration",
+                    id,
+                    identity.workspace_id,
+                    orbit_dir.join("config.yaml").display()
+                )));
+            }
         }
 
         init_workspace_at_root(
@@ -367,6 +384,18 @@ fn validate_existing_registration(
         )));
     }
     Ok(())
+}
+
+/// True when either registry authority still binds `workspace_id`.
+fn registry_claims(registry: &WorkspaceRegistry, workspace_id: &str) -> bool {
+    registry
+        .workspaces
+        .iter()
+        .any(|workspace| workspace.id == workspace_id)
+        || registry
+            .checkouts
+            .iter()
+            .any(|checkout| checkout.workspace_id == workspace_id)
 }
 
 fn read_workspace_identity(

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -278,6 +278,149 @@ fn workspace_init_rejects_existing_durable_id_without_force() {
 }
 
 #[test]
+fn force_replaces_a_checkout_identity_that_no_registration_claims() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let home = tempdir().expect("home tempdir");
+    let global = home.path().join(".orbit");
+    std::fs::create_dir_all(&global).expect("create global orbit");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 1\nmachine_id = \"hm_bootstrap\"\nhost_id = \"bootstrap-host\"\nmode = \"standalone\"\n",
+    )
+    .expect("write host identity");
+    let _env = EnvGuard::acquire().home(home.path()).cwd(workspace.path());
+
+    // Any command that opens a runtime in an uninitialized checkout seeds a
+    // legacy bootstrap identity here before `workspace init` ever runs.
+    let orbit_dir = workspace.path().join(".orbit");
+    std::fs::create_dir_all(&orbit_dir).expect("create checkout orbit dir");
+    let identity_path = orbit_dir.join("config.yaml");
+    let bootstrap_identity = "schema_version: 1\nworkspace_id: work-a1b2c3\n";
+    std::fs::write(&identity_path, bootstrap_identity).expect("seed bootstrap identity");
+
+    let args = |force| WorkspaceInitArgs {
+        name: Some("bootstrap-claim".to_string()),
+        base_branch: Some("agent-main".to_string()),
+        ship_mode: None,
+        role: None,
+        owner: None,
+        task_id_start: None,
+        mcp: false,
+        inject_agent_rules: false,
+        refresh_defaults: false,
+        force,
+    };
+
+    let registry_path = global.join("workspaces.json");
+    let error = args(false)
+        .execute_without_runtime(None)
+        .expect_err("a conflicting checkout identity must require force")
+        .to_string();
+    assert!(error.contains("rerun with --force"), "unexpected: {error}");
+    assert_eq!(
+        std::fs::read_to_string(&identity_path).expect("read identity"),
+        bootstrap_identity
+    );
+    assert!(!registry_path.exists(), "refusal must not seed a registry");
+
+    args(true)
+        .execute_without_runtime(None)
+        .expect("force must reconcile an unclaimed checkout identity");
+    let expected_id = canonical_workspace_id("bootstrap-claim");
+    assert!(
+        std::fs::read_to_string(&identity_path)
+            .expect("read reconciled identity")
+            .contains(&expected_id),
+        "force must rewrite the checkout identity"
+    );
+    let registry = workspace_registry::load_registry_from(&registry_path).expect("load registry");
+    assert_eq!(registry.workspaces.len(), 1);
+    assert_eq!(registry.workspaces[0].id, expected_id);
+    assert_eq!(registry.checkouts.len(), 1);
+    assert_eq!(registry.checkouts[0].workspace_id, expected_id);
+    assert_eq!(
+        std::fs::canonicalize(&registry.checkouts[0].repo_root).expect("canonical checkout root"),
+        std::fs::canonicalize(workspace.path()).expect("canonical workspace root")
+    );
+}
+
+#[test]
+fn force_refuses_to_replace_a_checkout_identity_a_registration_still_claims() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let home = tempdir().expect("home tempdir");
+    let global = home.path().join(".orbit");
+    std::fs::create_dir_all(&global).expect("create global orbit");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 1\nmachine_id = \"hm_claimed\"\nhost_id = \"claimed-host\"\nmode = \"standalone\"\n",
+    )
+    .expect("write host identity");
+    let _env = EnvGuard::acquire().home(home.path()).cwd(workspace.path());
+
+    // A registered workspace bound to some *other* checkout: this checkout's
+    // stray identity claims it, so no registry lookup by path reconciles it.
+    let now = Utc::now();
+    let claimed = Workspace {
+        id: "ws_claimed".to_string(),
+        name: "claimed".to_string(),
+        owner_machine_id: None,
+        git_remote: None,
+        ship_mode: None,
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: now,
+        updated_at: now,
+    };
+    let other_root = home.path().join("elsewhere");
+    let registry = WorkspaceRegistry {
+        workspaces: vec![claimed.clone()],
+        checkouts: vec![WorkspaceCheckout::owner(
+            claimed.id.clone(),
+            other_root.clone(),
+            other_root.join(".orbit"),
+        )],
+        ..Default::default()
+    };
+    let registry_path = global.join("workspaces.json");
+    workspace_registry::save_registry_to(&registry, &registry_path).expect("seed registry");
+    let registry_bytes = std::fs::read_to_string(&registry_path).expect("read protected registry");
+
+    let orbit_dir = workspace.path().join(".orbit");
+    std::fs::create_dir_all(&orbit_dir).expect("create checkout orbit dir");
+    let identity_path = orbit_dir.join("config.yaml");
+    let claimed_identity = "schema_version: 1\nworkspace_id: ws_claimed\n";
+    std::fs::write(&identity_path, claimed_identity).expect("seed claimed identity");
+
+    let error = WorkspaceInitArgs {
+        name: Some("claim-jumper".to_string()),
+        base_branch: Some("agent-main".to_string()),
+        ship_mode: None,
+        role: None,
+        owner: None,
+        task_id_start: None,
+        mcp: false,
+        inject_agent_rules: false,
+        refresh_defaults: false,
+        force: true,
+    }
+    .execute_without_runtime(None)
+    .expect_err("force must not detach a claimed checkout identity")
+    .to_string();
+    assert!(
+        error.contains("claimed by an existing registration"),
+        "unexpected: {error}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&identity_path).expect("read identity"),
+        claimed_identity
+    );
+    assert_eq!(
+        std::fs::read_to_string(&registry_path).expect("read registry"),
+        registry_bytes
+    );
+}
+
+#[test]
 fn forced_workspace_reconciliation_preserves_registry_and_identity_on_validation_failure() {
     let workspace = tempdir().expect("workspace tempdir");
     let home = tempdir().expect("home tempdir");


### PR DESCRIPTION
## Task

[ORB-10577](https://orbit-cli.com/tasks/ORB-10577) — workspace init --force does not cover a pre-seeded checkout identity

### Description

## Problem

`crates/orbit-cli/tests/mcp_roundtrip.rs::hub_mcp_serve_is_checkoutless_frame_pure_and_audits_trusted_identity` fails on `agent-main`: `workspace init --name mcp-roundtrip --force` is rejected with `workspace identity 'work-XXXXXX' at '<tmp>/work/.orbit/config.yaml' conflicts with requested workspace 'ws_mcp-roundtrip'; refusing to overwrite it`.

`crates/orbit-cli/src/command/workspace/init.rs` computes `reconciling_existing` from the registry (`existing_workspace` / `existing_checkout`). When `orbit host register` has seeded only a local `.orbit/config.yaml` identity and no registry entry, `reconciling_existing` is false, so control reaches the `else if let Some(identity) = read_workspace_identity(...)` arm — which never consults `self.force`. `--force` is therefore inert on exactly the path the hub fixture exercises.

Introduced by ORB-10543 (`Require --force before workspace init rewrites an existing registration`).

## Acceptance criteria

- `--force` reconciles a local-identity-only conflict, or the fixture's bootstrap sequence is corrected — whichever matches the intended contract.
- `cargo test -p orbit-cli --test mcp_roundtrip` passes.

## Provenance

Found while validating ORB-10567 (borderless tables); the failure is unrelated to that change and reproduces on the untouched code path.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Made `--force` cover the local-identity-only conflict in `crates/orbit-cli/src/command/workspace/init.rs`.

Root cause: ORB-10543 gated reconciliation on `reconciling_existing` (derived from the workspace registry). When a checkout carries a `.orbit/config.yaml` identity that the registry never recorded — any command that opens a runtime in an uninitialized checkout seeds a legacy `<slug>-<6char>` bootstrap id — control reached the `else if let Some(identity) = read_workspace_identity(..)` arm, which refused unconditionally and never consulted `self.force`.

Change (init.rs):
- That arm now returns the refusal only when `--force` is absent, and its message points at `--force` (`"...; rerun with --force to reconcile it"`) instead of the dead-end "refusing to overwrite it".
- With `--force`, the stray identity is replaced (the existing `if !reconciling_existing { write_workspace_identity(..) }` path rewrites config.yaml), but only after a new `registry_claims()` helper confirms neither registry authority (`workspaces` nor `checkouts`) still binds that workspace id. A claimed identity is still refused with "claimed by an existing registration", so `--force` cannot silently detach a durable registration.
- Updated the `--force` clap doc comment to state the added capability.

The ORB-10543 guards are untouched: re-init of a registered workspace still requires `--force`, and forced reconciliation still validates the full logical/checkout/durable-identity binding (`forced_workspace_reconciliation_preserves_registry_and_identity_on_validation_failure` passes unchanged).

Fixture note: no change was needed in `crates/orbit-cli/tests/mcp_roundtrip.rs`. ORB-10587 (2cd5a104) already reordered `McpWorkspace::init_with_mode` to run `workspace init` before `host register` and dropped the `--force` argument, so the hub fixture no longer exercises the pre-seeded-identity path. The contract fix is covered directly by unit tests instead.

Tests added (crates/orbit-cli/src/command/workspace/tests/init.rs):
- `force_replaces_a_checkout_identity_that_no_registration_claims` — seeds a `work-a1b2c3` bootstrap config.yaml with no registry entry; asserts the un-forced init fails pointing at `--force` and mutates nothing, then that `--force` rewrites the identity and registers workspace + checkout.
- `force_refuses_to_replace_a_checkout_identity_a_registration_still_claims` — registry holds `ws_claimed` bound to a different checkout while this checkout's config.yaml claims it; `--force` is refused and both registry and identity bytes are preserved.

Validation (all run locally, all green):
- `cargo test -p orbit-cli --test mcp_roundtrip` — 8 passed (acceptance criterion; includes `hub_mcp_serve_is_checkoutless_frame_pure_and_audits_trusted_identity`).
- `cargo test -p orbit-cli --bin orbit workspace::tests::init` — 22 passed.
- `cargo clippy -p orbit-cli --all-targets` — clean.
- `make ci-fast` — exit 0 (needed `rg` and `node` on PATH; they live at ~/.local/bin and ~/.nvm/versions/node/v24.18.0/bin on this host).

No context_files appended (both listed files were the only ones considered; only init.rs and its sibling tests file changed). No new dependencies, no doc/ADR surface exists for this guard.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10577-6a6f9f4a`
- Behind base: 0
- Ahead of base: 1