### PR TITLE
Restore workspace clippy: orbit-exec integration test trips expect_used/unwrap_used

### DIFF
--- a/crates/orbit-exec/tests/linux_sandbox.rs
+++ b/crates/orbit-exec/tests/linux_sandbox.rs
@@ -1,4 +1,6 @@
 #![allow(missing_docs)]
+// Integration tests use unwrap/expect for fixture setup and print skip details.
+#![allow(clippy::expect_used, clippy::print_stdout, clippy::unwrap_used)]
 #![cfg(target_os = "linux")]
 
 use std::process::Stdio;


### PR DESCRIPTION
## Task

[ORB-10574](https://orbit-cli.com/tasks/ORB-10574) — Restore workspace clippy: orbit-exec integration test trips expect_used/unwrap_used

### Description

## Problem

`cargo clippy --workspace --all-targets -- -D warnings` — the merge gate in `make ci` — fails with 38 errors, all in `crates/orbit-exec/tests/linux_sandbox.rs`. Every one is `clippy::expect_used` or `clippy::unwrap_used` on fixture setup (`tempfile::tempdir().expect("tempdir")`, `std::fs::create_dir_all(...).expect("create fixture")`, and so on).

The crate's own `src/lib.rs` carries `#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]`, but that attribute does not reach an integration test, which compiles as its own crate. `linux_sandbox.rs` declares only `#![allow(missing_docs)]`, so it inherits the workspace deny-by-default without the test exemption every other test file in the repo carries.

No other crate in the workspace has a clippy error — the failure is confined to this one file.

## Provenance

Predates ORB-10569, which found it while running the gate. The file was introduced by ORB-10552 and last touched by ORB-10560.

## Fix

Either add the conventional test header used everywhere else —

```rust
// Tests use unwrap/expect to keep fixture setup readable.
#![allow(clippy::expect_used, clippy::unwrap_used)]
```

— or, if the sandbox tests should hold a stricter bar than the rest of the suite, convert the call sites. That is the decision the task has to make; the blanket allow is the repo's default and the smaller change.

## Acceptance criteria

- `cargo clippy --workspace --all-targets -- -D warnings` exits clean.
- The chosen approach is consistent with the repo convention, or the deviation is stated in the commit message.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added the repository-standard integration-test clippy allowances to crates/orbit-exec/tests/linux_sandbox.rs for expect/unwrap fixture setup and the test's existing Bubblewrap skip diagnostics.
- No production code or dependencies changed.
Assessment: The scoped test-only change restores the workspace lint convention and keeps fixture code readable. The print_stdout allowance is necessary because the existing skip messages are also checked by the workspace clippy gate.
Validation:
- cargo clippy --workspace --all-targets -- -D warnings (passed)
- make ci-fast (passed)
- git diff --check (passed)

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10574-6a6fa4cd`
- Behind base: 0
- Ahead of base: 1