### PR TITLE
Redaction on knowledge-record writes has undefined coverage: host and key identifiers pasted from terminal output pass through unredacted

### DIFF
--- a/crates/orbit-agent/README.md
+++ b/crates/orbit-agent/README.md
@@ -164,6 +164,12 @@ the default env-value and pattern redaction. The default ruleset scrubs:
 - `Bearer <token>` anywhere in the payload
 - high-confidence provider token shapes such as `sk-...`, `ghp_...`, and
   `xox...` values
+- structural OpenSSH public-key fingerprints and comments, plus host/address
+  identifiers in canonical connection diagnostics
+
+The author-facing field policy, complete pattern-family inventory, and response
+detail contract live in
+[`docs/design/auditability/specs/artifact-redaction.md`](../../docs/design/auditability/specs/artifact-redaction.md).
 
 Redaction runs at **write time**, not read time — the stored bytes are
 already safe, and blob references point to the redacted content hash. A future

--- a/crates/orbit-common/src/utility/redaction.rs
+++ b/crates/orbit-common/src/utility/redaction.rs
@@ -15,7 +15,7 @@
 //!
 //! Callers pick the layer they need:
 //! - [`redact_sensitive_env_text`] — scrub live env-var values from a string
-//! - [`PatternRedactor`] — regex pattern scrubbing (HTTP / argv / JSON)
+//! - [`PatternRedactor`] — regex pattern scrubbing (HTTP / argv / JSON / SSH diagnostics)
 //! - [`redact_all`] — env + default patterns in one pass (use when you don't
 //!   know what shape the input has and want maximum coverage)
 
@@ -532,20 +532,20 @@ pub fn is_sensitive_env_name(name: &str) -> bool {
 // Pattern-based redaction (HTTP + argv)
 // ---------------------------------------------------------------------------
 
-/// Regex-driven scrubber for HTTP-shape and argv-shape secrets.
+/// Regex-driven scrubber for credential shapes and infrastructure identifiers.
 ///
-/// Builds to `default()` give you the same coverage as the former
-/// `RedactionMiddleware` (Authorization / x-api-key / URL key params /
-/// Bearer / raw header lines). Use [`PatternRedactor::with_argv_secrets`] to
-/// also catch bare `sk-…` tokens — needed when scrubbing subprocess argv where
-/// a provider key sometimes ends up mis-configured.
+/// Builds to `default()` cover Authorization / x-api-key / URL key params /
+/// Bearer / raw header lines, high-confidence provider credentials, and
+/// structurally recognizable SSH fingerprints, public-key comments, and
+/// connection hosts. Use [`PatternRedactor::with_argv_secrets`] to also catch
+/// short bare `sk-…` tokens — needed when scrubbing subprocess argv where a
+/// provider key sometimes ends up mis-configured.
 pub struct PatternRedactor {
     patterns: Vec<(Regex, &'static str)>,
 }
 
 impl PatternRedactor {
-    /// HTTP-only default: Authorization / x-api-key / api_key / URL key
-    /// params / Bearer in both JSON and raw-header form.
+    /// Shared default for unknown-shape persisted text.
     pub fn http_default() -> Self {
         let patterns = vec![
             (
@@ -579,6 +579,66 @@ impl PatternRedactor {
             (
                 Regex::new(r"(?i)([?&]key=)[^&\s]+").expect("valid regex"),
                 "${1}[REDACTED_AUTH]",
+            ),
+            // `ssh-keygen -l` output: redact the fingerprint and the key comment,
+            // while retaining key size and algorithm for diagnostic value.
+            (
+                Regex::new(
+                    r"(?im)^(\s*\d{3,4}\s+)SHA256:[A-Za-z0-9+/]{43}\s+[^\r\n]+?\s+(\((?:RSA|DSA|ECDSA|ED25519)\))\s*$",
+                )
+                .expect("valid regex"),
+                "${1}[REDACTED_SSH_FINGERPRINT] [REDACTED_SSH_KEY_COMMENT] ${2}",
+            ),
+            // OpenSSH verbose key-offer lines identify the local key through a
+            // path or comment immediately before its algorithm and fingerprint.
+            (
+                Regex::new(
+                    r"(?im)^(\s*(?:debug\d+:\s*)?(?:Offering public key|Will attempt key|Server accepts key):\s+)[^\r\n]+?\s+((?:RSA|DSA|ECDSA|ED25519)(?:-SK)?\s+)SHA256:[A-Za-z0-9+/]{43}([^\r\n]*)$",
+                )
+                .expect("valid regex"),
+                "${1}[REDACTED_SSH_KEY_COMMENT] ${2}[REDACTED_SSH_FINGERPRINT]${3}",
+            ),
+            // A serialized OpenSSH public key may carry an arbitrary comment
+            // after its base64 material. Preserve the public key, redact only
+            // the comment that commonly names a person, host, or key role.
+            (
+                Regex::new(
+                    r"(?im)^(\s*(?:ssh-(?:rsa|dss|ed25519)|ecdsa-sha2-nistp(?:256|384|521)|sk-(?:ssh-ed25519|ecdsa-sha2-nistp256)@openssh\.com)\s+[A-Za-z0-9+/]{20,}={0,3})\s+[^\r\n]+$",
+                )
+                .expect("valid regex"),
+                "${1} [REDACTED_SSH_KEY_COMMENT]",
+            ),
+            // Host redaction is deliberately limited to canonical OpenSSH
+            // diagnostic sentences. A general hostname regex would erase
+            // repository prose, model names, paths, and other useful records.
+            (
+                Regex::new(
+                    r"(?im)^(\s*(?:debug\d+:\s*)?Connecting to\s+)\S+(?:\s+\[[^\]\r\n]+\])?(\s+port\s+\d+\.)\s*$",
+                )
+                .expect("valid regex"),
+                "${1}[REDACTED_SSH_HOST]${2}",
+            ),
+            (
+                Regex::new(
+                    r"(?im)^(\s*(?:debug\d+:\s*)?Authenticating to\s+)\S+(\s+as\s+[^\r\n]+)$",
+                )
+                .expect("valid regex"),
+                "${1}[REDACTED_SSH_HOST]${2}",
+            ),
+            (
+                Regex::new(
+                    r"(?im)^(\s*Authenticated to\s+)\S+(?:\s+\([^\r\n)]+\))?(\.)\s*$",
+                )
+                .expect("valid regex"),
+                "${1}[REDACTED_SSH_HOST]${2}",
+            ),
+            (
+                Regex::new(r"SHA256:[A-Za-z0-9+/]{43}=").expect("valid regex"),
+                "[REDACTED_SSH_FINGERPRINT]",
+            ),
+            (
+                Regex::new(r"SHA256:[A-Za-z0-9+/]{43}\b").expect("valid regex"),
+                "[REDACTED_SSH_FINGERPRINT]",
             ),
             (
                 Regex::new(r"sk-[A-Za-z0-9_\-]{20,}").expect("valid regex"),
@@ -682,8 +742,8 @@ impl Default for PatternRedactor {
 // Combined
 // ---------------------------------------------------------------------------
 
-/// Apply env-value and default HTTP pattern redaction in one pass. Use when
-/// the input shape is unknown (log lines, aggregated error messages).
+/// Apply env-value and default pattern redaction in one pass. Use when the
+/// input shape is unknown (knowledge records, log lines, aggregated errors).
 pub fn redact_all(input: &str) -> String {
     let env_scrubbed = redact_sensitive_env_text(input);
     default_pattern_redactor().apply_str(&env_scrubbed)

--- a/crates/orbit-common/src/utility/tests/redaction.rs
+++ b/crates/orbit-common/src/utility/tests/redaction.rs
@@ -93,6 +93,45 @@ fn redact_all_scrubs_provider_scm_cloud_tokens_and_connection_passwords() {
 }
 
 #[test]
+fn redact_all_scrubs_structural_ssh_key_and_host_identifiers() {
+    let fingerprint = format!("SHA256:{}", "A".repeat(43));
+    let public_key = format!("ssh-ed25519 {}", "B".repeat(48));
+    let raw = format!(
+        "256 {fingerprint} automation@build-node.example.test (ED25519)\n\
+         debug1: Offering public key: automation@build-node.example.test ED25519 {fingerprint} agent\n\
+         {public_key} deploy@mirror-node.example.test\n\
+         debug1: Connecting to build-node.example.test [192.0.2.10] port 22.\n\
+         debug1: Authenticating to build-node.example.test:22 as 'git'\n\
+         Authenticated to build-node.example.test ([192.0.2.10]:22)."
+    );
+
+    let redacted = redact_all(&raw);
+
+    assert!(!redacted.contains(&fingerprint));
+    assert!(!redacted.contains("automation@build-node.example.test"));
+    assert!(!redacted.contains("deploy@mirror-node.example.test"));
+    assert!(!redacted.contains("build-node.example.test"));
+    assert!(!redacted.contains("192.0.2.10"));
+    assert_eq!(redacted.matches("[REDACTED_SSH_FINGERPRINT]").count(), 2);
+    assert_eq!(redacted.matches("[REDACTED_SSH_KEY_COMMENT]").count(), 3);
+    assert_eq!(redacted.matches("[REDACTED_SSH_HOST]").count(), 3);
+    assert!(redacted.contains(&public_key));
+}
+
+#[test]
+fn redact_all_preserves_knowledge_record_identifiers_and_paths() {
+    let legitimate = concat!(
+        "commit 238a89cbec9abf478d13ed2bf3ca7d28a722c21c\n",
+        "run jrun-20260802-2012-4 task ORB-12345\n",
+        "worktree /srv/worktrees/jrun-20260802-2012-4/src/module\n",
+        "model gpt-5.6-sol\n",
+        "blob sha256:4f1c2a709db7089bd3da48e35a3a2f77d6c0f41d8d792f0dcb163a7d89fd53e0"
+    );
+
+    assert_eq!(redact_all(legitimate), legitimate);
+}
+
+#[test]
 fn high_confidence_single_token_detection_covers_provider_scm_cloud_families() {
     let credentials = [
         format!("AIza{}", "A".repeat(35)),

--- a/crates/orbit-core/src/runtime/orbit_tool_host/artifact_redaction.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/artifact_redaction.rs
@@ -34,6 +34,7 @@ impl ArtifactRedactionKind {
 pub(super) struct ArtifactRedactionField {
     pub field_path: String,
     pub kinds: BTreeSet<ArtifactRedactionKind>,
+    pub classes: BTreeSet<&'static str>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -46,11 +47,38 @@ impl ArtifactRedactionReport {
         !self.fields.is_empty()
     }
 
-    fn push(&mut self, field_path: String, kinds: BTreeSet<ArtifactRedactionKind>) {
+    fn push(
+        &mut self,
+        field_path: String,
+        kinds: BTreeSet<ArtifactRedactionKind>,
+        classes: BTreeSet<&'static str>,
+    ) {
         if !kinds.is_empty() {
-            self.fields
-                .push(ArtifactRedactionField { field_path, kinds });
+            self.fields.push(ArtifactRedactionField {
+                field_path,
+                kinds,
+                classes,
+            });
         }
+    }
+
+    fn response_details(&self) -> Value {
+        Value::Array(
+            self.fields
+                .iter()
+                .map(|field| {
+                    json!({
+                        "field_path": field.field_path,
+                        "redaction_kinds": field
+                            .kinds
+                            .iter()
+                            .map(|kind| kind.as_str())
+                            .collect::<Vec<_>>(),
+                        "redaction_classes": field.classes,
+                    })
+                })
+                .collect(),
+        )
     }
 }
 
@@ -100,6 +128,7 @@ pub(super) fn finish_tool_response(
             "redactions_applied".to_string(),
             Value::Bool(report.redactions_applied()),
         );
+        object.insert("redactions".to_string(), report.response_details());
     }
     if report.redactions_applied() {
         emit_audit_events(runtime, action, response, report, agent, model)?;
@@ -273,10 +302,10 @@ fn sanitize_string_field(
     let Some(Value::String(raw)) = object.get(key) else {
         return Ok(());
     };
-    let (sanitized, kinds) = sanitize_string(raw, field_path, mode)?;
+    let (sanitized, kinds, classes) = sanitize_string(raw, field_path, mode)?;
     if sanitized != *raw {
         object.insert(key.to_string(), Value::String(sanitized));
-        report.push(field_path.to_string(), kinds);
+        report.push(field_path.to_string(), kinds, classes);
     }
     Ok(())
 }
@@ -290,10 +319,10 @@ fn sanitize_string_array_field(
 ) -> Result<(), OrbitError> {
     match object.get_mut(key) {
         Some(Value::String(raw)) => {
-            let (sanitized, kinds) = sanitize_string(raw, field_path, mode)?;
+            let (sanitized, kinds, classes) = sanitize_string(raw, field_path, mode)?;
             if sanitized != *raw {
                 *raw = sanitized;
-                report.push(field_path.to_string(), kinds);
+                report.push(field_path.to_string(), kinds, classes);
             }
         }
         Some(Value::Array(items)) => {
@@ -302,10 +331,10 @@ fn sanitize_string_array_field(
                     continue;
                 };
                 let item_path = format!("{field_path}[{index}]");
-                let (sanitized, kinds) = sanitize_string(raw, &item_path, mode)?;
+                let (sanitized, kinds, classes) = sanitize_string(raw, &item_path, mode)?;
                 if sanitized != *raw {
                     *raw = sanitized;
-                    report.push(item_path, kinds);
+                    report.push(item_path, kinds, classes);
                 }
             }
         }
@@ -354,10 +383,10 @@ fn sanitize_nested_string_array_field(
             continue;
         };
         let field_path = format!("{}[{index}].{key}", policy.array_key);
-        let (sanitized, kinds) = sanitize_string(raw, &field_path, policy.mode)?;
+        let (sanitized, kinds, classes) = sanitize_string(raw, &field_path, policy.mode)?;
         if sanitized != *raw {
             entry.insert(key.to_string(), Value::String(sanitized));
-            report.push(field_path, kinds);
+            report.push(field_path, kinds, classes);
         }
     }
     Ok(())
@@ -367,15 +396,24 @@ fn sanitize_string(
     raw: &str,
     field_path: &str,
     mode: TextMode,
-) -> Result<(String, BTreeSet<ArtifactRedactionKind>), OrbitError> {
+) -> Result<
+    (
+        String,
+        BTreeSet<ArtifactRedactionKind>,
+        BTreeSet<&'static str>,
+    ),
+    OrbitError,
+> {
     match mode {
         TextMode::PathOnly => {
             let sanitized = redact_home_dir(raw);
             let mut kinds = BTreeSet::new();
+            let mut classes = BTreeSet::new();
             if sanitized != raw {
                 kinds.insert(ArtifactRedactionKind::HomeDir);
+                classes.insert("home_directory");
             }
-            Ok((sanitized, kinds))
+            Ok((sanitized, kinds, classes))
         }
         TextMode::Free => {
             if is_high_confidence_single_token_credential(raw) {
@@ -389,18 +427,38 @@ fn sanitize_string(
             let pattern_scrubbed = redact_all(raw);
             let sanitized = redact_home_dir(&pattern_scrubbed);
             let mut kinds = BTreeSet::new();
+            let mut classes = BTreeSet::new();
             if env_scrubbed != raw {
                 kinds.insert(ArtifactRedactionKind::Env);
+                classes.insert("sensitive_environment_value");
             }
             if pattern_scrubbed != env_scrubbed {
                 kinds.insert(ArtifactRedactionKind::Pattern);
+                classes.extend(pattern_redaction_classes(&env_scrubbed, &pattern_scrubbed));
             }
             if sanitized != pattern_scrubbed {
                 kinds.insert(ArtifactRedactionKind::HomeDir);
+                classes.insert("home_directory");
             }
-            Ok((sanitized, kinds))
+            Ok((sanitized, kinds, classes))
         }
     }
+}
+
+fn pattern_redaction_classes(before: &str, after: &str) -> BTreeSet<&'static str> {
+    [
+        ("[REDACTED_AUTH]", "authorization"),
+        ("[REDACTED_SECRET]", "credential"),
+        ("[REDACTED_API_KEY]", "credential"),
+        ("[REDACTED_SSH_FINGERPRINT]", "ssh_fingerprint"),
+        ("[REDACTED_SSH_KEY_COMMENT]", "ssh_key_comment"),
+        ("[REDACTED_SSH_HOST]", "ssh_host"),
+    ]
+    .into_iter()
+    .filter_map(|(marker, class)| {
+        (after.matches(marker).count() > before.matches(marker).count()).then_some(class)
+    })
+    .collect()
 }
 
 fn emit_audit_events(
@@ -429,6 +487,7 @@ fn emit_audit_events(
             "actor": actor,
             "tool_name": tool_name,
             "redaction_kinds": redaction_kinds,
+            "redaction_classes": field.classes,
         });
         runtime.record_audit_event(&AuditEventInsertParams {
             execution_id: audit_execution_id("audit-artifact-redaction"),
@@ -768,6 +827,14 @@ mod tests {
             .expect("task add succeeds");
 
         assert_eq!(output["redactions_applied"], true);
+        assert_eq!(
+            output["redactions"],
+            json!([{
+                "field_path": "title",
+                "redaction_kinds": ["env"],
+                "redaction_classes": ["sensitive_environment_value"]
+            }])
+        );
         let id = output["id"].as_str().expect("task id");
         let task = runtime.get_task(id).expect("task persisted");
         assert_eq!(task.title, "leaked [REDACTED_ENV]");
@@ -787,6 +854,37 @@ mod tests {
         assert!(arguments.contains("\"field_path\":\"title\""));
         assert!(arguments.contains("\"env\""));
         assert!(!arguments.contains(token));
+    }
+
+    #[test]
+    fn dispatch_reports_structural_ssh_redaction_classes() {
+        let (_root, runtime, _repo_root) = test_runtime();
+        let fingerprint = format!("SHA256:{}", "A".repeat(43));
+
+        let output = runtime
+            .execute_tool_command(
+                "orbit.task.add",
+                json!({
+                    "title": "SSH diagnostic",
+                    "description": format!(
+                        "debug1: Connecting to build-node.example.test [192.0.2.10] port 22.\n256 {fingerprint} automation@build-node.example.test (ED25519)"
+                    ),
+                    "workspace": ".",
+                }),
+                Some("codex".to_string()),
+                Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+            )
+            .expect("task add succeeds");
+
+        assert_eq!(output["redactions_applied"], true);
+        assert_eq!(
+            output["redactions"],
+            json!([{
+                "field_path": "description",
+                "redaction_kinds": ["pattern"],
+                "redaction_classes": ["ssh_fingerprint", "ssh_host", "ssh_key_comment"]
+            }])
+        );
     }
 
     #[test]
@@ -862,6 +960,7 @@ mod tests {
             .expect("task update succeeds");
 
         assert_eq!(output["redactions_applied"], false);
+        assert_eq!(output["redactions"], json!([]));
         let events = runtime
             .list_audit_events(None, Some("orbit.task.update".to_string()), None, None, 16)
             .expect("L-0009: same backing query as `orbit audit list --json`");

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -4,7 +4,7 @@ type: design
 title: "Auditability — Design"
 owner: codex
 last_updated: 2026-08-02
-last_validated: 2026-07-27
+last_validated: 2026-08-02
 status: Draft
 feature: auditability
 doc_role: design
@@ -89,7 +89,7 @@ Loop events reference hashes for request bodies, response bodies, tool inputs, a
 
 `crates/orbit-common/src/utility/blob_store.rs` writes content-addressed blobs under `{root}/{hash_prefix}/{hash}`. The hash is computed after redaction, and existing blob paths are reused.
 
-`crates/orbit-common/src/utility/redaction.rs` centralizes sensitive live environment value scrubbing plus regex-based HTTP/argv patterns for authorization headers, API keys, bearer tokens, JSON API-key fields, and high-confidence provider token shapes. CLI audit errors, blob bytes, selected pipeline outputs/errors, artifact write tools, and the default tracing subscriber all redact before persistence or terminal/JSONL output. Artifact tool coverage and refuse-vs-mask rules live in [specs/artifact-redaction.md](./specs/artifact-redaction.md). The smoke example `crates/orbit-agent/examples/redaction_smoke.rs` verifies stored blob bytes omit the raw secret and contain a marker.
+`crates/orbit-common/src/utility/redaction.rs` centralizes sensitive live environment value scrubbing plus regex-based HTTP/argv/SSH patterns for authorization headers, API keys, bearer tokens, JSON API-key fields, high-confidence provider token shapes, SSH public-key fingerprints and comments, and hosts in canonical OpenSSH diagnostic sentences. CLI audit errors, blob bytes, selected pipeline outputs/errors, artifact write tools, and the default tracing subscriber all redact before persistence or terminal/JSONL output. Artifact tool coverage, the current pattern-family inventory, and refuse-vs-mask rules live in [specs/artifact-redaction.md](./specs/artifact-redaction.md). The smoke example `crates/orbit-agent/examples/redaction_smoke.rs` verifies stored blob bytes omit the raw secret and contain a marker. [ORB-10591]
 
 Dashboard log previews added by [T20260508-14] are derived views over the `v2_audit_events` SQLite store and `.orbit/state/audit/blobs`; they do not duplicate full transcripts into a separate transcript store. Preview responses are byte- and line-capped, apply defensive read-time redaction with the shared redactor, and preserve existing write-time redaction markers. The focused diagnostics error feed is also derived, combining global ERROR tracing rows with structured `ERROR <target>:` lines found in agent stderr blobs. No `.orbit/state/diagnostics/errors/` store exists in this design; retention remains bounded by the existing v2 audit, blob, and global log retention roots.
 
@@ -215,6 +215,7 @@ Each record contains timestamp, level, target, and structured fields. After [T20
 - **[ORB-10579]** — Corrected GPT-5.6 price periods and cache-write rates, added gross-input accounting, and retained OpenAI cache buckets for standard short-context estimates.
 - **[ORB-10581]** — Added reconciliation-safe managed invocation accounting by canonical task orchestrator ([ADR-0310]).
 - **[ORB-10582]** — Projected managed-execution orchestration accounting into the separately versioned dashboard scoreboard section without merging it into executor rankings.
+- **[ORB-10591]** — Document the artifact-write redaction boundary, add structural SSH identifier coverage, and return field-level redaction details.
 - **[ORB-00106]** — Preserve per-task implementer attribution when `orbit run ship` moves batch PR tasks from Review to Done.
 - **[ORB-10200]** — Derive CLI audit metadata and the other cross-cutting command policies from one exhaustive command-operation registry.
 - **[ORB-10225]** — Route in-process graph MCP calls through the safe-surface allowlist and shared runtime audit boundary.

--- a/docs/design/auditability/specs/artifact-redaction.md
+++ b/docs/design/auditability/specs/artifact-redaction.md
@@ -2,12 +2,14 @@
 type: design
 summary: "Spec: Artifact Write Redaction"
 tags: ["auditability"]
-last_validated: 2026-08-01
+last_validated: 2026-08-02
 ---
 
 # Spec: Artifact Write Redaction
 
 Orbit artifact tools persist repo-backed YAML, markdown, and JSON. Their write boundary sanitizes selected input fields after `OrbitBuiltinAction` is known and before typed params are built. The sanitizer is action-keyed rather than field-blind, so structural IDs, statuses, tags, and artifact blobs keep their native validation rules.
+
+This is the author-facing inventory for the shipped artifact-write redactor. Redaction is a backstop: authors should summarize terminal diagnostics and environment dumps instead of pasting them verbatim whenever the source can be reduced safely.
 
 ## Field Policy
 
@@ -25,6 +27,20 @@ Orbit artifact tools persist repo-backed YAML, markdown, and JSON. Their write b
 
 Task and friction tags are taxonomy fields and pass through verbatim. Learning `scope.tags[]` are matching metadata and are treated as free text.
 
+The table establishes the knowledge-primitive boundary: ADRs, learnings, tasks, and frictions are covered on their listed add/update operations. Registered docs are ordinary repository files rather than an Orbit mutation primitive, so doc edits do not pass through this write sanitizer.
+
+## Pattern Set
+
+Free-text fields first replace values of live environment variables whose names are credential-shaped (`SECRET`, `TOKEN`, `PASSWORD`, `API_KEY`, `PRIVATE`, `CREDENTIAL`, `COOKIE`, `SESSION`, `BEARER`, or `AUTH`). The shared structural patterns then mask:
+
+- JSON and raw header forms of `Authorization`, `x-api-key`, and `api_key`; bearer values; and `key` query parameters
+- OpenAI, Google, GitLab, GitHub, AWS, npm, and Slack credential token shapes, AWS secret assignments, and URI user-info passwords
+- OpenSSH `SHA256:` public-key fingerprints
+- comments on serialized OpenSSH public keys, and the key descriptor/comment on `ssh-keygen -l` and canonical verbose key-offer lines
+- host/address identifiers only in canonical OpenSSH `Connecting to`, `Authenticating to`, and `Authenticated to` diagnostics
+
+SSH replacements are class-labelled as `[REDACTED_SSH_FINGERPRINT]`, `[REDACTED_SSH_KEY_COMMENT]`, or `[REDACTED_SSH_HOST]`. Host matching is deliberately contextual rather than a general hostname rule. Commit SHAs, lowercase content hashes, run ids, task ids, worktree paths, repository names, and model strings are not secret classes and are preserved unless they literally contain a separately recognized credential or live sensitive environment value. [ORB-10591]
+
 ## Refuse vs Mask
 
 Free-text fields reject a value that is exactly one high-confidence credential token:
@@ -37,7 +53,7 @@ The rejection is a typed `OrbitError::SensitiveInput` and never includes the tok
 
 ## Response and Audit Contract
 
-Covered mutating tools add `redactions_applied: bool` to object responses. It is `true` only when at least one persisted field changed from the caller's input. Re-running a write with already-redacted text is idempotent: no field changes means `redactions_applied: false` and no redaction audit event.
+Covered mutating tools add `redactions_applied: bool` and `redactions: [{field_path, redaction_kinds, redaction_classes}]` to object responses. The boolean is `true` only when at least one persisted field changed from the caller's input. The detail list names every changed field, whether environment, structural-pattern, or home-directory normalization acted, and concrete safe classes such as `credential`, `ssh_fingerprint`, `ssh_key_comment`, or `ssh_host`. Re-running a write with already-redacted text is idempotent: no field changes means `redactions_applied: false`, `redactions: []`, and no redaction audit event.
 
 When a field changes, Orbit emits one command-audit row per field. The payload contains only:
 
@@ -46,6 +62,7 @@ When a field changes, Orbit emits one command-audit row per field. The payload c
 - actor
 - tool name
 - redaction kinds: `env`, `pattern`, `home_dir`
+- redaction classes: `sensitive_environment_value`, `home_directory`, `authorization`, `credential`, or the structural SSH classes above
 
 Original and redacted values are not recorded. Tests should inspect these rows through the same backing surface as `orbit audit list --json` per L-0009.
 
@@ -55,3 +72,4 @@ Original and redacted values are not recorded. Tests should inspect these rows t
 - Raw task artifact blob redaction through `orbit.task.artifact.put` or task `artifacts` / `upsert_artifacts`.
 - General-purpose schema validation in the sanitizer; existing typed parsers keep reporting shape errors.
 - Auto-publish, commit, or remote cleanup behavior after a secret has already entered history.
+- Automatic sweeps of existing authored records or git history rewriting; see the forward-only decision recorded for [ORB-10591].

--- a/docs/design/auditability/specs/redaction-retention.md
+++ b/docs/design/auditability/specs/redaction-retention.md
@@ -19,6 +19,7 @@ Auditability and secrecy pull in opposite directions. Orbit needs faithful recor
 - Pipeline outputs persisted by runtime helpers are scrubbed for sensitive live environment values.
 - HTTP-shaped payload redaction covers authorization headers, x-api-key headers, JSON API-key fields, and bearer tokens.
 - Shared pattern redaction covers high-confidence provider token shapes embedded in prose; exact whole-token artifact fields are rejected instead of persisted.
+- Shared pattern redaction covers structural OpenSSH fingerprints, public-key comments, and connection hosts without applying a general hostname or high-entropy-string heuristic.
 - CLI argv redaction uses HTTP defaults plus bare `sk-...` token scrubbing when argv-shaped data is being persisted.
 - Orbit artifact write tools use the action-keyed field policy in [artifact-redaction.md](./artifact-redaction.md) before YAML/markdown/JSON persistence.
 - Default tracing output redacts string field values, `Debug`-formatted field values, and unstructured `message` fields before writing stderr or `~/.orbit/state/logs/orbit.jsonl`.
@@ -60,6 +61,8 @@ Global process tracing:
 - If pruning deletes command audit rows, file-backed run traces and blobs are not automatically pruned unless a future retention task adds that coupling.
 
 ## Migration Path
+
+Redaction changes are forward-only. Orbit does not automatically sweep existing authored records, because masking without an author review can destroy their meaning. Git history rewriting is outside the artifact-write boundary and requires a separate, explicit operator incident-response decision. [ORB-10591]
 
 Future retention work should add:
 


### PR DESCRIPTION
## Task

[ORB-10591](https://orbit-cli.com/tasks/ORB-10591) — Redaction on knowledge-record writes has undefined coverage: host and key identifiers pasted from terminal output pass through unredacted

### Description

## Problem

A redactor runs on the friction write path — `orbit_friction_add` returns a
`redactions_applied` boolean, observed `true` on one write and `false` on another the same day.
But its coverage is documented nowhere, its pattern set is not visible to authors, and the flag
does not say what it acted on. An author cannot tell whether the redactor examined their content
and found nothing, or never looked for the class of thing they just pasted.

It demonstrably does not cover host and key identifiers. F2026-07-002 (2026-07-04, still `open`)
was written straight from `ssh -v` output and persists, committed to git, containing:

- an SSH public-key fingerprint in full, `SHA256:` form
- that key's comment, which names the host and its role
- the host name itself, and the set of repositories still reachable from it via one remote
- the filesystem path pattern of the migration-target bare remotes

## Severity — stated precisely, because it is easy to over- or under-read

**This is not a credential exposure.** An SSH fingerprint is a hash of the *public* key; it is
what `ssh -v` prints when offering a key and what forges display in their UI. It cannot
authenticate anything, and no key rotation is warranted on account of this record.

What the record does contain is an infrastructure sketch — which key, on which host, in which
role, reaching which repositories, migrating where. Low-grade individually. The reason to fix it
is the mechanism, not this instance: an agent mid-incident pasted raw terminal diagnostics into a
durable, git-committed record, and nothing between the agent and the commit examined it for that
class of content. The same reflex on a different day catches a token, a connection string, or an
environment dump.

## Constraints

- **Shipped surface.** The redactor seeds every workspace. No project-specific hostnames, key
  comments, paths, or repository names may appear in the pattern set or in test fixtures.
  Patterns must be structural (shape of the thing) rather than enumerations of this deployment's
  particulars.
- **Over-redaction is the worse failure.** Knowledge records are full of legitimate
  high-entropy strings — commit SHAs, run ids, task ids, worktree paths, model strings, blob
  refs. A redactor that eats those makes records unusable and un-auditable, and the damage is
  silent. Whatever is added must be demonstrated not to fire on those.
- **Redacting forward does not unpublish.** F2026-07-002 has been in git history since
  2026-07-04. Scrubbing the working copy changes what is read, not what was committed. Whether
  history rewriting is in scope is a decision for Daniel, not an implementation detail to be
  taken silently in either direction.
- CI on agent-main PRs is advisory; do not repair unrelated pre-existing failures.

## Questions to settle with evidence, not assumption

- Where does the redactor live, what is its current pattern set, and is that set written down
  anywhere an author could find it? Establish the baseline before extending it.
- Does it run on all knowledge primitives — learnings, ADRs, tasks, docs — or only frictions? A
  redactor that guards one write path and not its siblings gives false assurance.
- Should `redactions_applied: true` report *what* was redacted, so an author can tell a
  false positive from a real catch? Today it is an unfalsifiable boolean.
- Is redaction the right control at all for this class, or is it better handled by telling
  authors not to paste raw terminal output — with redaction as the backstop rather than the
  primary defence? Both may be warranted; the task should not assume only one.
- Should existing records be swept, and if so, does the sweep re-derive or preserve the original
  meaning of the redacted passage?

## Scope note

This is deliberately narrower than the corpus-quality problem tracked separately (friction titles;
and the observation that several frictions are really incident reports). The overlap is only that
both surfaced while reading the same records. Fixing either does not fix the other.

## Provenance

Observed 2026-08-02 reading the friction corpus. `redactions_applied` values seen on live writes
that day: `true` and `false` on two different records, with no accompanying detail in either
response. F2026-07-002 read from the working tree.

### Acceptance Criteria

- The redactor's current pattern set and its scope across knowledge primitives are established and written down where a record author will encounter them
- Host and key identifiers of the class found in F2026-07-002 — public-key fingerprints and key comments at minimum — no longer pass through the write path unhandled
- The change is demonstrated not to fire on legitimate high-entropy content that knowledge records depend on: commit SHAs, run ids, task ids, worktree paths, model strings
- Patterns are structural, with no deployment-specific hostname, key comment, path, or repository name in the implementation or its test fixtures
- An author can determine what was redacted from a write, not merely that something was
- A decision is recorded on whether existing records are swept and whether git history rewriting is in or out of scope — not left implicit
- Build passes and the change's own tests pass; pre-existing unrelated failures are named rather than repaired

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Extended the shared structural redactor with OpenSSH SHA256 public-key fingerprints, serialized and diagnostic key comments, and hosts/addresses in canonical OpenSSH connection diagnostics. Replacements are class-labelled and avoid a general hostname or entropy heuristic.
- Added positive SSH coverage plus negative coverage proving commit SHAs, lowercase content hashes, run ids, task ids, worktree paths, and model strings remain unchanged.
- Covered artifact-write responses now retain redactions_applied and add per-field redactions entries with redaction_kinds and concrete redaction_classes; audit rows carry the same safe classes.
- Documented the current pattern-family inventory, exact ADR/learning/task/friction write coverage, the unguarded ordinary-doc boundary, author guidance, and the forward-only existing-record/history policy. Updated the orbit-agent default-ruleset README because it was directly coupled and would otherwise become stale.
Assessment: The change is narrowly structural, preserves compatibility through the existing boolean, exposes falsifiable redaction detail, and has focused end-to-end write-path coverage. No new dependency edge or unrelated code change was introduced.
Validation:
- cargo test -p orbit-common utility::tests::redaction: 13 passed.
- cargo test -p orbit-core runtime::orbit_tool_host::artifact_redaction::tests: 11 passed.
- make ci-fast: passed.
- git diff --check: passed.
Strategic decisions: New patterns apply forward only. Existing records are not swept automatically because only an author or operator can preserve narrative meaning; git history rewriting requires a separate explicit incident-response decision.
Design weaknesses / risks: Structural matching intentionally does not redact arbitrary hostnames outside recognizable OpenSSH diagnostics, so unknown terminal-output shapes remain possible. Existing records and history remain readable until operator review.
Deviations from original plan: orbit.adr.add could not allocate the intended ADR because the pipeline worktree mounts .orbit read-only and returned io_error Read-only file system. The decision is still explicit in the affected auditability specs. F2026-08-036 records the allowlisted-tool and mount-policy mismatch. The final context_files omit the unmodified ADR store and decision index targets.
Pre-existing unrelated failures: none observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10591-6a6fa4cc`
- Behind base: 0
- Ahead of base: 1