### PR TITLE
Add visual styling to the managed execution cost panel

### DIFF
--- a/crates/orbit-dashboard/assets/dashboard/dashboard.css
+++ b/crates/orbit-dashboard/assets/dashboard/dashboard.css
@@ -1870,6 +1870,266 @@
       .scoreboard-insights .ag.gemini { color: var(--ag-gemini); background: var(--ag-gemini-low); }
       .scoreboard-insights .ag.grok   { color: var(--ag-grok);   background: var(--ag-grok-low); }
 
+      #scoreboard-orchestration-panel {
+        align-self: start;
+      }
+
+      #scoreboard-orchestration-panel > .body {
+        padding: 0;
+      }
+
+      .scoreboard-orchestration-summary {
+        min-width: 0;
+        font-size: 12px;
+      }
+
+      .scoreboard-orchestration-context {
+        display: grid;
+        grid-template-columns: minmax(260px, 1fr) minmax(300px, auto);
+        gap: 8px 20px;
+        padding: 12px 16px;
+        border-bottom: 1px solid var(--border);
+        background: #050505;
+        color: var(--fg-dim);
+      }
+
+      .scoreboard-orchestration-scope {
+        display: flex;
+        align-items: baseline;
+        gap: 8px;
+        min-width: 0;
+      }
+
+      .scoreboard-orchestration-scope .scope-label {
+        flex: 0 0 auto;
+        padding: 1px 6px;
+        border: 1px solid var(--border);
+        border-radius: 2px;
+        color: var(--fg);
+        font-family: var(--font-mono);
+        font-size: 9px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+      }
+
+      .scoreboard-orchestration-window {
+        min-width: 0;
+        color: var(--fg-dim);
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-align: right;
+        overflow-wrap: anywhere;
+      }
+
+      .scoreboard-orchestration-policy {
+        grid-column: 1 / -1;
+        margin: 0;
+        max-width: 1100px;
+        color: var(--fg-dim);
+        line-height: 1.45;
+      }
+
+      .scoreboard-orchestration-buckets {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 10px;
+        padding: 12px;
+      }
+
+      .scoreboard-orchestration-bucket {
+        --ownership: var(--fg-dim);
+        min-width: 0;
+        padding: 12px;
+        border: 1px solid var(--border);
+        border-left: 2px solid var(--ownership);
+        border-radius: 2px;
+        background: var(--bg);
+      }
+
+      .scoreboard-orchestration-bucket.kind-orchestrator { --ownership: var(--accent); }
+      .scoreboard-orchestration-bucket.kind-shared { --ownership: var(--status-review); }
+      .scoreboard-orchestration-bucket.kind-unattributed { --ownership: var(--status-proposed); }
+      .scoreboard-orchestration-bucket.kind-missing { --ownership: var(--status-blocked); }
+
+      .scoreboard-orchestration-bucket-head {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        min-width: 0;
+        color: var(--fg);
+      }
+
+      .scoreboard-orchestration-bucket-head .ownership-mark {
+        flex: 0 0 auto;
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--ownership);
+        box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.04);
+      }
+
+      .scoreboard-orchestration-bucket-head strong {
+        min-width: 0;
+        font-size: 13px;
+        font-weight: 600;
+        overflow-wrap: anywhere;
+      }
+
+      .scoreboard-orchestration-bucket .bucket-meta {
+        display: block;
+        margin: 3px 0 10px 15px;
+        color: var(--fg-dim);
+        font-family: var(--font-mono);
+        font-size: 10px;
+      }
+
+      .scoreboard-orchestration-costs {
+        display: grid;
+        gap: 5px;
+      }
+
+      .scoreboard-orchestration-cost {
+        display: grid;
+        grid-template-columns: minmax(125px, 0.85fr) minmax(84px, auto) minmax(120px, 1.15fr);
+        align-items: baseline;
+        gap: 6px 12px;
+        min-width: 0;
+        padding: 6px 8px;
+        border: 1px solid transparent;
+      }
+
+      .scoreboard-orchestration-cost.primary {
+        border-color: rgba(110, 159, 255, 0.22);
+        background: rgba(110, 159, 255, 0.08);
+      }
+
+      .scoreboard-orchestration-cost.comparable {
+        margin-top: 2px;
+        padding-top: 8px;
+        border-top-color: var(--border);
+      }
+
+      .scoreboard-orchestration-cost .cost-label {
+        min-width: 0;
+        color: var(--fg-dim);
+        font-family: var(--font-mono);
+        font-size: 10px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        overflow-wrap: anywhere;
+      }
+
+      .scoreboard-orchestration-cost.primary .cost-label {
+        color: var(--accent-hi);
+      }
+
+      .scoreboard-orchestration-cost .cost-value {
+        color: var(--fg);
+        font-family: var(--font-mono);
+        font-size: 13px;
+        font-weight: 500;
+        font-feature-settings: "tnum";
+        white-space: nowrap;
+      }
+
+      .scoreboard-orchestration-cost.primary .cost-value {
+        color: var(--accent-hi);
+        font-size: 15px;
+      }
+
+      .scoreboard-orchestration-cost .cost-value.unknown {
+        color: var(--fg-dim);
+        font-size: 11px;
+        font-weight: 400;
+      }
+
+      .scoreboard-orchestration-cost .cost-coverage {
+        min-width: 0;
+        color: var(--fg-dim);
+        font-size: 10px;
+        overflow-wrap: anywhere;
+      }
+
+      .scoreboard-orchestration-cost .cost-comparison {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-column: 2 / -1;
+        gap: 6px;
+        min-width: 0;
+      }
+
+      .scoreboard-orchestration-cost .cost-comparison > span {
+        display: grid;
+        gap: 1px;
+        min-width: 0;
+      }
+
+      .scoreboard-orchestration-cost .cost-comparison .k {
+        color: var(--fg-dim);
+        font-family: var(--font-mono);
+        font-size: 9px;
+        text-transform: uppercase;
+      }
+
+      .scoreboard-orchestration-cost .cost-comparison strong {
+        color: var(--fg);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 500;
+        font-feature-settings: "tnum";
+        overflow-wrap: anywhere;
+      }
+
+      .scoreboard-orchestration-cost.comparable .cost-coverage {
+        grid-column: 2 / -1;
+      }
+
+      @media (max-width: 900px) {
+        .scoreboard-orchestration-context {
+          grid-template-columns: minmax(0, 1fr);
+        }
+        .scoreboard-orchestration-window {
+          text-align: left;
+        }
+        .scoreboard-orchestration-buckets {
+          grid-template-columns: minmax(0, 1fr);
+        }
+      }
+
+      @media (max-width: 620px) {
+        .scoreboard-orchestration-context {
+          padding: 10px 12px;
+        }
+        .scoreboard-orchestration-scope {
+          align-items: flex-start;
+          flex-direction: column;
+          gap: 5px;
+        }
+        .scoreboard-orchestration-buckets {
+          gap: 8px;
+          padding: 8px;
+        }
+        .scoreboard-orchestration-bucket {
+          padding: 10px;
+        }
+        .scoreboard-orchestration-cost {
+          grid-template-columns: minmax(0, 1fr) auto;
+          gap: 3px 10px;
+        }
+        .scoreboard-orchestration-cost .cost-coverage,
+        .scoreboard-orchestration-cost.comparable .cost-coverage {
+          grid-column: 1 / -1;
+        }
+        .scoreboard-orchestration-cost .cost-comparison {
+          grid-template-columns: minmax(0, 1fr);
+          grid-column: 1 / -1;
+        }
+        .scoreboard-orchestration-cost .cost-comparison > span {
+          grid-template-columns: 70px minmax(0, 1fr);
+          align-items: baseline;
+        }
+      }
+
       .subtabs {
         display: flex;
         gap: 4px;
@@ -3262,5 +3522,4 @@
       .log-foot .filter-pill.on:hover { border-color: var(--accent-hover); }
       .log-foot .right { margin-left: auto; cursor: pointer; user-select: none; }
       .log-foot .right.on { color: var(--accent); }
-
 

--- a/crates/orbit-dashboard/assets/dashboard/scoreboard.js
+++ b/crates/orbit-dashboard/assets/dashboard/scoreboard.js
@@ -301,20 +301,32 @@ function bucketLabel(bucket) {
   }
 }
 
-function costPopulationLine(label, total, knownCount, invocationCount, unknownCount, kind) {
+function costPopulationLine(label, total, knownCount, invocationCount, unknownCount, kind, primary = false) {
   const known = asScoreboardNumber(knownCount);
   const totalInvocations = asScoreboardNumber(invocationCount);
   const unknown = asScoreboardNumber(unknownCount);
+  const className = primary ? "scoreboard-orchestration-cost primary" : "scoreboard-orchestration-cost";
   if (known === 0) {
-    return `${label}: unknown (0/${totalInvocations} ${kind}; ${unknown} unavailable)`;
+    return el("div", { class: className }, [
+      el("span", { class: "cost-label", text: label }),
+      el("strong", { class: "cost-value unknown", text: "unknown" }),
+      el("span", { class: "cost-coverage", text: `0/${totalInvocations} ${kind} · ${unknown} unavailable` }),
+    ]);
   }
-  return `${label}: ${formatUsd(total)} (${known}/${totalInvocations} ${kind}; ${unknown} unavailable)`;
+  return el("div", { class: className }, [
+    el("span", { class: "cost-label", text: label }),
+    el("strong", { class: "cost-value", text: formatUsd(total) }),
+    el("span", { class: "cost-coverage", text: `${known}/${totalInvocations} ${kind} · ${unknown} unavailable` }),
+  ]);
 }
 
 function renderOrchestrationBucket(bucket) {
   const invocationCount = asScoreboardNumber(bucket?.invocation_count);
   const comparableCount = asScoreboardNumber(bucket?.comparable_cost_count);
-  const lines = [
+  const kind = ["orchestrator", "shared", "unattributed", "missing"].includes(bucket?.kind)
+    ? bucket.kind
+    : "unknown";
+  const costs = [
     costPopulationLine(
       "provider-reported",
       bucket?.provider_cost_usd,
@@ -322,6 +334,7 @@ function renderOrchestrationBucket(bucket) {
       invocationCount,
       bucket?.missing_provider_count,
       "reported",
+      true,
     ),
     costPopulationLine(
       "derived estimate",
@@ -333,16 +346,38 @@ function renderOrchestrationBucket(bucket) {
     ),
   ];
   if (comparableCount > 0) {
-    lines.push(
-      `comparable same-invocation population: provider ${formatUsd(bucket?.comparable_provider_cost_usd)} / derived ${formatUsd(bucket?.comparable_derived_cost_usd)} / delta ${formatUsd(bucket?.comparable_cost_delta_usd)} (${comparableCount}/${invocationCount})`,
-    );
+    costs.push(el("div", { class: "scoreboard-orchestration-cost comparable" }, [
+      el("span", { class: "cost-label", text: "comparable same-invocation population" }),
+      el("span", { class: "cost-comparison" }, [
+        el("span", {}, [
+          el("span", { class: "k", text: "provider" }),
+          el("strong", { text: formatUsd(bucket?.comparable_provider_cost_usd) }),
+        ]),
+        el("span", {}, [
+          el("span", { class: "k", text: "derived" }),
+          el("strong", { text: formatUsd(bucket?.comparable_derived_cost_usd) }),
+        ]),
+        el("span", {}, [
+          el("span", { class: "k", text: "delta" }),
+          el("strong", { text: formatUsd(bucket?.comparable_cost_delta_usd) }),
+        ]),
+      ]),
+      el("span", { class: "cost-coverage", text: `${comparableCount}/${invocationCount} invocations` }),
+    ]));
   } else {
-    lines.push(`comparable: unknown (no shared provider/derived population; do not reconcile partial sums)`);
+    costs.push(el("div", { class: "scoreboard-orchestration-cost comparable" }, [
+      el("span", { class: "cost-label", text: "comparable" }),
+      el("strong", { class: "cost-value unknown", text: "unknown" }),
+      el("span", { class: "cost-coverage", text: "no shared provider/derived population · do not reconcile partial sums" }),
+    ]));
   }
-  return el("article", { class: "scoreboard-orchestration-bucket" }, [
-    el("strong", { text: bucketLabel(bucket) }),
-    el("span", { class: "dim", text: `${invocationCount} managed invocations · ${asScoreboardNumber(bucket?.linked_task_count)} linked tasks` }),
-    ...lines.map((text) => el("div", { text })),
+  return el("article", { class: `scoreboard-orchestration-bucket kind-${kind}` }, [
+    el("div", { class: "scoreboard-orchestration-bucket-head" }, [
+      el("span", { class: "ownership-mark" }),
+      el("strong", { text: bucketLabel(bucket) }),
+    ]),
+    el("span", { class: "bucket-meta", text: `${invocationCount} managed invocations · ${asScoreboardNumber(bucket?.linked_task_count)} linked tasks` }),
+    el("div", { class: "scoreboard-orchestration-costs" }, costs),
   ]);
 }
 
@@ -358,13 +393,19 @@ function renderOrchestrationSummary(orchestration) {
   const since = orchestration.since || "all managed execution retained";
   const until = orchestration.until || orchestration.as_of || "unknown cutoff";
   const children = [
-    el("p", { text: `Managed execution cost only. Direct interactive Codex or Claude orchestration-session overhead is excluded. Window: ${since} ≤ invocation < ${until} (exclusive cutoff; as of ${orchestration.as_of || "unknown"}).` }),
-    el("p", { class: "dim", text: "Provider-first estimate policy: provider-reported values are primary; derived values remain explicitly labeled estimates with their own coverage. Only the explicitly comparable same-invocation population is safe to compare." }),
+    el("div", { class: "scoreboard-orchestration-context" }, [
+      el("div", { class: "scoreboard-orchestration-scope" }, [
+        el("span", { class: "scope-label", text: "Managed execution only" }),
+        el("span", { text: "Direct interactive Codex or Claude orchestration-session overhead is excluded." }),
+      ]),
+      el("div", { class: "scoreboard-orchestration-window", text: `Window: ${since} ≤ invocation < ${until} (exclusive cutoff; as of ${orchestration.as_of || "unknown"}).` }),
+      el("p", { class: "scoreboard-orchestration-policy", text: "Provider-first estimate policy: provider-reported values are primary; derived values remain explicitly labeled estimates with their own coverage. Only the explicitly comparable same-invocation population is safe to compare." }),
+    ]),
   ];
   if (orchestration.buckets.length === 0) {
     children.push(el("div", { class: "empty-state" }, [el("div", { class: "text", text: "No managed invocations in this bounded window." })]));
   } else {
-    children.push(...orchestration.buckets.map(renderOrchestrationBucket));
+    children.push(el("div", { class: "scoreboard-orchestration-buckets" }, orchestration.buckets.map(renderOrchestrationBucket)));
   }
   return el("section", { class: "scoreboard-orchestration-summary" }, children);
 }

--- a/crates/orbit-dashboard/src/tests/dashboard_assets.rs
+++ b/crates/orbit-dashboard/src/tests/dashboard_assets.rs
@@ -569,6 +569,47 @@ fn dashboard_scoreboard_keeps_managed_cost_ownership_out_of_executor_rankings() 
     assert!(scoreboard.contains("invocation < ${until} (exclusive cutoff"));
 }
 
+#[test]
+fn dashboard_managed_execution_cost_panel_has_responsive_presentation_hooks() {
+    let scoreboard = include_str!("../../assets/dashboard/scoreboard.js");
+    let css = include_str!("../../assets/dashboard/dashboard.css");
+
+    assert!(
+        scoreboard.contains("scoreboard-orchestration-context")
+            && scoreboard.contains("scoreboard-orchestration-buckets")
+            && scoreboard.contains("scoreboard-orchestration-bucket-head"),
+        "scope metadata and ownership buckets need separate presentation groups"
+    );
+    assert!(
+        scoreboard.contains("cost-value")
+            && scoreboard.contains("cost-coverage")
+            && scoreboard.contains("cost-comparison"),
+        "cost amount, coverage, and comparison text need independent styling hooks"
+    );
+    assert!(
+        scoreboard.contains("scoreboard-orchestration-cost primary")
+            && scoreboard.contains("\"reported\",\n      true,"),
+        "provider-reported cost must receive the primary visual treatment"
+    );
+    for kind in ["orchestrator", "shared", "unattributed", "missing"] {
+        assert!(
+            css.contains(&format!(".scoreboard-orchestration-bucket.kind-{kind}")),
+            "the {kind} ownership bucket needs a distinct theme-variable accent"
+        );
+    }
+    assert!(
+        css.contains("#scoreboard-orchestration-panel {\n        align-self: start;")
+            && css.contains("grid-template-columns: repeat(2, minmax(0, 1fr));"),
+        "the desktop panel must stay content-height and use a compact bucket grid"
+    );
+    assert!(
+        css.contains("@media (max-width: 900px)")
+            && css.contains("@media (max-width: 620px)")
+            && css.contains("overflow-wrap: anywhere;"),
+        "the managed-cost layout must collapse and wrap safely at narrow widths"
+    );
+}
+
 /// ORB-10444: the Knowledge artifact list is long enough to scroll the detail
 /// pane out of view mid-read. The pane is pinned below the fixed chrome and
 /// bounded to the remaining viewport so its body scrolls internally rather than


### PR DESCRIPTION
## Task

[ORB-10589](https://orbit-cli.com/tasks/ORB-10589) — Add visual styling to the managed execution cost panel

### Description

Follow up ORB-10582 with a CSS-first presentation pass for the Managed Execution Cost panel. Replace the unstyled telemetry-dump appearance with a compact, readable hierarchy consistent with the existing scoreboard. Preserve the landed aggregation, attribution, window, and cost semantics. JavaScript changes are limited to adding presentation hooks or semantic grouping that CSS cannot express; do not change the API or scoreboard data contract. This task is for tomorrow and must remain proposed until explicitly promoted.

### Acceptance Criteria

- The existing `scoreboard-orchestration-summary` and bucket presentation receives explicit styling in `dashboard.css`, using Orbit's existing theme variables and visual language.
- At a representative 1200px desktop viewport, scope/window information is secondary, bucket ownership and primary cost values are immediately scannable, labels do not run together, and the panel height is driven by useful content rather than a large empty region.
- At a representative narrow viewport of 480–720px, the layout collapses cleanly without horizontal overflow, clipped values, or unreadable cost lines.
- Named, shared, unattributed, and missing buckets remain distinguishable, while provider-reported values stay primary and derived/comparable/unknown states remain honestly labeled.
- The aggregation API, scoreboard schema, bounded-window behavior, and managed-execution-only scope are unchanged.
- Validation includes rendered visual inspection at both desktop and narrow widths, recorded in the execution summary, in addition to targeted dashboard asset tests and `git diff --check`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Reworked the managed-execution renderer into semantic context, ownership, cost, coverage, and comparison groups while preserving the existing scoreboard payload and cost calculations.
- Added a compact two-column desktop bucket grid, content-height panel behavior, existing-theme ownership accents, provider-primary cost styling, and responsive single-column rules for narrow screens.
- Added dashboard asset coverage for presentation hooks, ownership variants, provider priority, content-height behavior, and responsive wrapping.
Assessment: The presentation is compact and scannable without changing aggregation, attribution, bounded-window, or managed-execution-only semantics. Provider values remain primary; derived, comparable, unavailable, and unknown states remain explicit.
Validation:
- cargo test -p orbit-dashboard dashboard_: 20 passed.
- make ci-fast: passed.
- git diff --check: passed.
- Rendered the live dashboard.css and scoreboard.js with representative bucket data in Chrome for Testing at 1200x900, 600x900, and 480x900. Desktop inspection confirmed secondary scope/window copy, a compact two-column ownership grid, prominent provider costs, separated labels, and content-driven panel height. Narrow inspection confirmed a clean single-column collapse at both 600px and the 480px boundary with wrapped metadata, readable cost/comparison lines, no clipping, and no horizontal overflow.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10589-6a6fa50b`
- Behind base: 0
- Ahead of base: 1