### PR TITLE
Liveness sweep marks succeeding runs interrupted; false state cascades through pipeline_success_guard

### DIFF
--- a/crates/orbit-common/src/utility/process_identity.rs
+++ b/crates/orbit-common/src/utility/process_identity.rs
@@ -5,10 +5,144 @@
 //! value does not depend on the caller's locale or timezone. Tokens written
 //! by this helper carry a [`STABLE_TOKEN_PREFIX`] so readers can distinguish
 //! them from legacy unversioned values.
+//!
+//! [ORB-10594] A PID only names a process *within a PID namespace*. Orbit
+//! spawns sandboxed agents under `bwrap --unshare-all --proc /proc`, which
+//! gives them a private PID namespace: inside it, the host PIDs that own live
+//! job runs are invisible to both `ps` and `kill(pid, 0)`, and every liveness
+//! probe run from there reports "process not found" for a perfectly healthy
+//! worker. Sandboxed agents routinely call the Orbit CLI, and every CLI open
+//! sweeps for orphaned runs — so the token records the *namespace it was
+//! written in* and readers refuse to judge liveness across a namespace
+//! boundary.
 
 /// Prefix on versioned identity tokens. Persisted tokens that start with this
 /// prefix were written by the stable strategy and must match exactly.
-pub const STABLE_TOKEN_PREFIX: &str = "ps-lstart-utc-v1:";
+///
+/// v2 adds the writer's PID namespace: `ps-lstart-utc-v2:pidns=<inode>:<lstart>`.
+pub const STABLE_TOKEN_PREFIX: &str = "ps-lstart-utc-v2:";
+
+/// Prefix on pre-[ORB-10594] versioned tokens, which carry no namespace field.
+/// Still read (a run claimed by an older binary outlives its upgrade), never
+/// written.
+pub const STABLE_TOKEN_PREFIX_V1: &str = "ps-lstart-utc-v1:";
+
+/// Field introducing the PID namespace inside a v2 token.
+const PID_NAMESPACE_FIELD: &str = "pidns=";
+
+/// Namespace value written when the host cannot report one (non-Linux, or an
+/// unreadable `/proc/self/ns/pid`). Reads back as "namespace unknown".
+const UNKNOWN_PID_NAMESPACE: &str = "-";
+
+/// True for a token written by either versioned strategy.
+pub fn is_stable_token(token: &str) -> bool {
+    token.starts_with(STABLE_TOKEN_PREFIX) || token.starts_with(STABLE_TOKEN_PREFIX_V1)
+}
+
+/// The PID namespace a v2 token was written in, when it names one. `None` for
+/// v1/legacy tokens and for v2 tokens whose writer could not resolve one.
+pub fn token_pid_namespace(token: &str) -> Option<&str> {
+    let rest = token.strip_prefix(STABLE_TOKEN_PREFIX)?;
+    let tail = rest.strip_prefix(PID_NAMESPACE_FIELD)?;
+    let (namespace, _) = tail.split_once(':')?;
+    (namespace != UNKNOWN_PID_NAMESPACE).then_some(namespace)
+}
+
+/// The process-start portion of a versioned token, with any namespace field
+/// stripped. `None` when the token is not versioned.
+pub fn token_start_identity(token: &str) -> Option<&str> {
+    if let Some(rest) = token.strip_prefix(STABLE_TOKEN_PREFIX) {
+        return Some(match rest.strip_prefix(PID_NAMESPACE_FIELD) {
+            // The namespace value never contains ':', so the first separator
+            // ends it and everything after is the (colon-bearing) lstart.
+            Some(tail) => tail
+                .split_once(':')
+                .map(|(_, lstart)| lstart)
+                .unwrap_or(tail),
+            None => rest,
+        });
+    }
+    token.strip_prefix(STABLE_TOKEN_PREFIX_V1)
+}
+
+/// True when a persisted token and a freshly probed one describe the same
+/// process. Version-tolerant: a v1 token persisted before [ORB-10594] still
+/// verifies against a v2 probe on its process-start value, so upgrading the
+/// binary does not invalidate the owners of in-flight runs.
+pub fn stable_tokens_match(persisted: &str, probed: &str) -> bool {
+    let (Some(persisted_start), Some(probed_start)) = (
+        token_start_identity(persisted),
+        token_start_identity(probed),
+    ) else {
+        return false;
+    };
+    if persisted_start != probed_start {
+        return false;
+    }
+    match (token_pid_namespace(persisted), token_pid_namespace(probed)) {
+        (Some(recorded), Some(current)) => recorded == current,
+        _ => true,
+    }
+}
+
+/// Where the observer stands relative to the PID namespace a token was
+/// written in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PidNamespaceScope {
+    /// Observer and writer share a PID namespace: PIDs mean the same thing on
+    /// both sides, so liveness probes are authoritative.
+    Same,
+    /// Observer is in a different PID namespace than the writer. The recorded
+    /// PID names a different process here, or none at all; no probe run from
+    /// this side can say anything about the recorded process.
+    Foreign,
+    /// One side did not record a namespace (v1/legacy token, no token, or a
+    /// host that cannot report one). Probes are treated as authoritative, as
+    /// they were before [ORB-10594].
+    Unknown,
+}
+
+/// The observer's own PID namespace, as the inode number Linux reports for
+/// `/proc/self/ns/pid` (`pid:[4026531836]` → `4026531836`).
+///
+/// Constant for the lifetime of the process — a process cannot leave its PID
+/// namespace — so it is resolved once and cached; the orphan sweep asks per
+/// run.
+pub fn current_pid_namespace() -> Option<&'static str> {
+    #[cfg(target_os = "linux")]
+    {
+        use std::sync::OnceLock;
+        static NAMESPACE: OnceLock<Option<String>> = OnceLock::new();
+        return NAMESPACE
+            .get_or_init(|| {
+                let link = std::fs::read_link("/proc/self/ns/pid").ok()?;
+                let rendered = link.to_string_lossy();
+                let (_, tail) = rendered.split_once('[')?;
+                let (inode, _) = tail.split_once(']')?;
+                (!inode.is_empty()).then(|| inode.to_string())
+            })
+            .as_deref();
+    }
+    #[cfg(not(target_os = "linux"))]
+    None
+}
+
+/// Classify the observer against the namespace recorded in `persisted`.
+///
+/// Deliberately conservative in one direction only: a missing namespace on
+/// either side yields [`PidNamespaceScope::Unknown`], never `Foreign`. Treating
+/// "unknown" as foreign would disable genuine-orphan detection outright for
+/// any deployment whose workers legitimately run inside a container.
+pub fn pid_namespace_scope(persisted: Option<&str>) -> PidNamespaceScope {
+    match (
+        persisted.and_then(token_pid_namespace),
+        current_pid_namespace(),
+    ) {
+        (Some(recorded), Some(current)) if recorded == current => PidNamespaceScope::Same,
+        (Some(_), Some(_)) => PidNamespaceScope::Foreign,
+        _ => PidNamespaceScope::Unknown,
+    }
+}
 
 /// Outcome of a single process-start identity probe.
 ///
@@ -52,7 +186,12 @@ fn lstart_raw(pid: u32, stable_env: bool) -> Result<Option<String>, io::Error> {
 #[cfg(unix)]
 pub fn probe_process_start_identity(pid: u32) -> ProbeOutcome {
     match lstart_raw(pid, true) {
-        Ok(Some(raw)) => ProbeOutcome::Token(format!("{STABLE_TOKEN_PREFIX}{raw}")),
+        Ok(Some(raw)) => {
+            let namespace = current_pid_namespace().unwrap_or(UNKNOWN_PID_NAMESPACE);
+            ProbeOutcome::Token(format!(
+                "{STABLE_TOKEN_PREFIX}{PID_NAMESPACE_FIELD}{namespace}:{raw}"
+            ))
+        }
         Ok(None) => ProbeOutcome::NoProcess,
         Err(_) => ProbeOutcome::Unavailable,
     }
@@ -80,7 +219,7 @@ pub fn process_start_identity_token(pid: u32) -> Option<String> {
 /// here so callers route them through [`process_start_identity_token`].
 #[cfg(unix)]
 pub fn legacy_lstart_matches(pid: u32, persisted: &str) -> bool {
-    if persisted.starts_with(STABLE_TOKEN_PREFIX) {
+    if is_stable_token(persisted) {
         return false;
     }
     if let Ok(Some(stable_raw)) = lstart_raw(pid, true)
@@ -140,21 +279,30 @@ impl ProcessLiveness {
 /// recycled. A live PID with no token, or one whose probe could not run (`ps`
 /// unavailable in a sandbox), stays `Alive` — a probe that cannot answer must
 /// not be enough to declare a running process dead.
+///
+/// [ORB-10594] A PID recorded in another PID namespace is `Unknown`, not
+/// `Exited`: from here the number names nothing, which is not evidence that
+/// the recorded process stopped.
 #[cfg(unix)]
 pub fn probe_process_liveness(pid: u32, pid_start_time: Option<&str>) -> ProcessLiveness {
+    if pid_namespace_scope(pid_start_time) == PidNamespaceScope::Foreign {
+        return ProcessLiveness::Unknown;
+    }
     if !process_is_alive(pid) {
         return ProcessLiveness::Exited;
     }
     let Some(persisted) = pid_start_time else {
         return ProcessLiveness::Alive;
     };
-    if !persisted.starts_with(STABLE_TOKEN_PREFIX) {
+    if !is_stable_token(persisted) {
         // A legacy unversioned token that cannot be re-derived is unverifiable,
         // not falsified. The PID is alive either way.
         return ProcessLiveness::Alive;
     }
     match probe_process_start_identity(pid) {
-        ProbeOutcome::Token(current) if current == persisted => ProcessLiveness::Alive,
+        ProbeOutcome::Token(current) if stable_tokens_match(persisted, &current) => {
+            ProcessLiveness::Alive
+        }
         ProbeOutcome::Token(_) => ProcessLiveness::Exited,
         // `kill(pid, 0)` above already saw the PID; a `ps` that disagrees is a
         // race or a blocked probe, not proof of death.

--- a/crates/orbit-core/src/command/job/run/owner.rs
+++ b/crates/orbit-core/src/command/job/run/owner.rs
@@ -13,7 +13,8 @@ use orbit_common::utility::process_identity::linux_process_state;
 pub(super) use orbit_common::utility::process_identity::process_is_alive;
 #[cfg(unix)]
 use orbit_common::utility::process_identity::{
-    ProbeOutcome, STABLE_TOKEN_PREFIX, legacy_lstart_matches, probe_process_start_identity,
+    PidNamespaceScope, ProbeOutcome, is_stable_token, legacy_lstart_matches, pid_namespace_scope,
+    probe_process_start_identity, stable_tokens_match,
 };
 #[cfg(unix)]
 use std::thread;
@@ -34,6 +35,12 @@ pub(super) fn signal_run_owner_process(run: &JobRun) -> Result<String, OrbitErro
     };
     if pid == std::process::id() {
         return Ok("self_not_signalled".to_string());
+    }
+    // [ORB-10594] Ahead of the liveness check: from another PID namespace the
+    // owner is invisible, and reporting that as `already_exited` would claim a
+    // cancellation that never reached the process.
+    if pid_namespace_scope(run.pid_start_time.as_deref()) == PidNamespaceScope::Foreign {
+        return Ok("foreign_pid_namespace".to_string());
     }
     if !process_is_alive(pid) {
         return Ok("already_exited".to_string());
@@ -271,7 +278,8 @@ pub(super) fn pending_run_stale_reason(run: &JobRun) -> Option<PendingStaleReaso
             }
             OwnerIdentity::Verified
             | OwnerIdentity::LegacyLiveUnverified
-            | OwnerIdentity::ProbeUnavailable => None,
+            | OwnerIdentity::ProbeUnavailable
+            | OwnerIdentity::ForeignPidNamespace => None,
         };
     }
     pending_run_unclaimed_past_grace(run).then_some(PendingStaleReason::NeverClaimed)
@@ -309,6 +317,8 @@ pub(super) fn stale_pending_run_message(run: &JobRun, reason: PendingStaleReason
         PendingStaleReason::Owner(OwnerIdentity::LegacyLiveUnverified) => "legacy_live_unverified",
         #[cfg(unix)]
         PendingStaleReason::Owner(OwnerIdentity::ProbeUnavailable) => "probe_unavailable",
+        #[cfg(unix)]
+        PendingStaleReason::Owner(OwnerIdentity::ForeignPidNamespace) => "foreign_pid_namespace",
         PendingStaleReason::NeverClaimed => "never_claimed",
     };
     format!(
@@ -341,7 +351,8 @@ pub(super) fn running_run_owner_stale_reason(run: &JobRun) -> Option<OwnerIdenti
         identity @ (OwnerIdentity::Mismatch | OwnerIdentity::Missing) => Some(identity),
         OwnerIdentity::Verified
         | OwnerIdentity::LegacyLiveUnverified
-        | OwnerIdentity::ProbeUnavailable => None,
+        | OwnerIdentity::ProbeUnavailable
+        | OwnerIdentity::ForeignPidNamespace => None,
     }
 }
 
@@ -368,6 +379,11 @@ pub(super) fn running_run_owner_stale_reason(_run: &JobRun) -> Option<()> {
 ///   A transient probe failure must never terminalize a live worker.
 /// - `Missing` — no PID recorded, or both the probe and `kill(pid, 0)`
 ///   agree the PID is gone. Stale.
+/// - `ForeignPidNamespace` — the owner was recorded in a different PID
+///   namespace than this observer's [ORB-10594]. The recorded PID names a
+///   different process here, or none; nothing probed from this side is
+///   evidence about the owner. Stays Running, and cancellation refuses to
+///   signal (the number would name the wrong process, if any).
 #[cfg(unix)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum OwnerIdentity {
@@ -375,6 +391,7 @@ pub(super) enum OwnerIdentity {
     Mismatch,
     LegacyLiveUnverified,
     ProbeUnavailable,
+    ForeignPidNamespace,
     Missing,
 }
 
@@ -383,6 +400,7 @@ pub(super) fn classify_run_owner(run: &JobRun) -> OwnerIdentity {
     classify_run_owner_with_probes(
         run.pid,
         run.pid_start_time.as_deref(),
+        pid_namespace_scope(run.pid_start_time.as_deref()),
         probe_process_start_identity,
         |pid| legacy_lstart_matches(pid, run.pid_start_time.as_deref().unwrap_or_default()),
         process_is_alive,
@@ -392,11 +410,17 @@ pub(super) fn classify_run_owner(run: &JobRun) -> OwnerIdentity {
 /// Inner, testable form of [`classify_run_owner`] with the probes injected.
 /// Production callers go through [`classify_run_owner`]; tests pass
 /// deterministic closures to exercise rare probe states (Unavailable,
-/// NoProcess-but-alive race) without needing real misbehaving processes.
+/// NoProcess-but-alive race, cross-namespace observation) without needing real
+/// misbehaving processes or a real sandbox.
+///
+/// `scope` is passed in rather than derived so the classification stays a pure
+/// function of its inputs: a test asserting genuine-orphan detection must not
+/// change verdict because the test runner itself happens to be sandboxed.
 #[cfg(unix)]
 pub(super) fn classify_run_owner_with_probes<P, L, A>(
     pid: Option<u32>,
     persisted: Option<&str>,
+    scope: PidNamespaceScope,
     probe: P,
     legacy_match: L,
     is_alive: A,
@@ -406,6 +430,12 @@ where
     L: FnOnce(u32) -> bool,
     A: FnOnce(u32) -> bool,
 {
+    // [ORB-10594] Ordered ahead of every probe: inside a private PID namespace
+    // both `ps` and `kill(pid, 0)` answer confidently and wrongly about a PID
+    // that belongs to another namespace.
+    if scope == PidNamespaceScope::Foreign {
+        return OwnerIdentity::ForeignPidNamespace;
+    }
     let Some(pid) = pid else {
         return OwnerIdentity::Missing;
     };
@@ -416,9 +446,11 @@ where
             OwnerIdentity::Missing
         };
     };
-    if persisted.starts_with(STABLE_TOKEN_PREFIX) {
+    if is_stable_token(persisted) {
         return match probe(pid) {
-            ProbeOutcome::Token(current) if current == persisted => OwnerIdentity::Verified,
+            ProbeOutcome::Token(current) if stable_tokens_match(persisted, &current) => {
+                OwnerIdentity::Verified
+            }
             ProbeOutcome::Token(_) => OwnerIdentity::Mismatch,
             ProbeOutcome::NoProcess => {
                 if is_alive(pid) {
@@ -460,6 +492,7 @@ pub(super) fn stale_job_run_message(run: &JobRun, reason: Option<OwnerIdentity>)
         Some(OwnerIdentity::ProbeUnavailable) => "probe_unavailable",
         Some(OwnerIdentity::Verified) => "verified",
         Some(OwnerIdentity::LegacyLiveUnverified) => "legacy_live_unverified",
+        Some(OwnerIdentity::ForeignPidNamespace) => "foreign_pid_namespace",
         None => "unknown",
     };
     format!(

--- a/crates/orbit-core/src/command/job/run/reconcile.rs
+++ b/crates/orbit-core/src/command/job/run/reconcile.rs
@@ -110,7 +110,7 @@ impl OrbitRuntime {
     /// Interrupted runs are resumable from their step checkpoints via
     /// `orbit job resume <run_id>`.
     fn finalize_orphaned_job_run(&self, run: &JobRun, message: &str) -> Result<bool, OrbitError> {
-        let finished_at = Utc::now();
+        let finished_at = self.orphaned_run_finished_at(run);
         let duration_ms = run.started_at.map(|started_at| {
             finished_at
                 .signed_duration_since(started_at)
@@ -149,6 +149,42 @@ impl OrbitRuntime {
             state: JobRunState::Interrupted.to_string(),
         })?;
         Ok(true)
+    }
+
+    /// When an orphaned run actually stopped doing work.
+    ///
+    /// [ORB-10594] The sweep can notice a dead owner arbitrarily long after the
+    /// fact — orphan scans only run when some process opens the workspace — so
+    /// stamping `Utc::now()` records the moment of *detection*, not the end of
+    /// work, and inflates `duration_ms` by the whole detection lag. The run's
+    /// own audit trail stops when its work stopped, so its last event is the
+    /// better estimate. Falls back to now when the run left no trail, and
+    /// never accepts a timestamp outside `[started_at, now]` so a clock skew or
+    /// a back-dated event cannot produce a negative or absurd duration.
+    fn orphaned_run_finished_at(&self, run: &JobRun) -> DateTime<Utc> {
+        let now = Utc::now();
+        let floor = run.started_at.unwrap_or(run.scheduled_at);
+        self.last_run_activity_at(&run.run_id)
+            .unwrap_or_else(|error| {
+                tracing::debug!(
+                    target: "orbit.core.job_run",
+                    run_id = %run.run_id,
+                    error = %error,
+                    "orphaned run audit trail unreadable; stamping detection time",
+                );
+                None
+            })
+            .filter(|activity| *activity >= floor && *activity <= now)
+            .unwrap_or(now)
+    }
+
+    /// Timestamp of the most recent audit event recorded for a run.
+    fn last_run_activity_at(&self, run_id: &str) -> Result<Option<DateTime<Utc>>, OrbitError> {
+        Ok(self
+            .collect_run_audit_events(run_id)?
+            .into_iter()
+            .filter_map(|event| event.timestamp)
+            .max())
     }
 
     pub(super) fn reconcile_job_run_records(&self, runs: &[JobRun]) -> Result<usize, OrbitError> {

--- a/crates/orbit-core/src/command/job/run/tests/owner.rs
+++ b/crates/orbit-core/src/command/job/run/tests/owner.rs
@@ -5,13 +5,19 @@ use super::*;
 use super::super::JobRunListParams;
 
 #[cfg(unix)]
-use super::super::owner::{OwnerIdentity, classify_run_owner_with_probes, stale_job_run_message};
+use super::super::owner::{
+    OwnerIdentity, classify_run_owner_with_probes, pending_run_stale_reason,
+    running_run_owner_stale_reason, stale_job_run_message,
+};
 use chrono::{Duration, Utc};
 use orbit_common::types::JobRunState;
 #[cfg(unix)]
-use orbit_common::utility::process_identity::ProbeOutcome;
+use orbit_common::utility::process_identity::{PidNamespaceScope, ProbeOutcome};
 #[cfg(unix)]
-use orbit_common::utility::process_identity::{STABLE_TOKEN_PREFIX, process_start_identity_token};
+use orbit_common::utility::process_identity::{
+    STABLE_TOKEN_PREFIX, STABLE_TOKEN_PREFIX_V1, current_pid_namespace,
+    process_start_identity_token,
+};
 #[cfg(unix)]
 use std::process::{Command, Stdio};
 
@@ -215,6 +221,7 @@ fn probe_unavailable_with_live_pid_classifies_as_probe_unavailable() {
     let identity = classify_run_owner_with_probes(
         Some(4242),
         Some(versioned.as_str()),
+        PidNamespaceScope::Same,
         |_| ProbeOutcome::Unavailable,
         |_| false,
         |_| true,
@@ -235,6 +242,7 @@ fn probe_no_process_with_live_pid_classifies_as_probe_unavailable() {
     let identity = classify_run_owner_with_probes(
         Some(4242),
         Some(versioned.as_str()),
+        PidNamespaceScope::Same,
         |_| ProbeOutcome::NoProcess,
         |_| false,
         |_| true,
@@ -249,6 +257,7 @@ fn probe_unavailable_with_dead_pid_classifies_as_missing() {
     let identity = classify_run_owner_with_probes(
         Some(4242),
         Some(versioned.as_str()),
+        PidNamespaceScope::Same,
         |_| ProbeOutcome::Unavailable,
         |_| false,
         |_| false,
@@ -264,6 +273,7 @@ fn versioned_token_mismatch_with_live_pid_classifies_as_mismatch() {
     let identity = classify_run_owner_with_probes(
         Some(4242),
         Some(persisted.as_str()),
+        PidNamespaceScope::Same,
         |_| ProbeOutcome::Token(format!("{STABLE_TOKEN_PREFIX}fresh-lstart")),
         |_| false,
         |_| true,
@@ -278,6 +288,7 @@ fn versioned_token_match_classifies_as_verified() {
     let identity = classify_run_owner_with_probes(
         Some(4242),
         Some(persisted.as_str()),
+        PidNamespaceScope::Same,
         |_| ProbeOutcome::Token(format!("{STABLE_TOKEN_PREFIX}same-lstart")),
         |_| false,
         |_| true,
@@ -315,6 +326,7 @@ fn running_run_owner_stale_reason_excludes_probe_unavailable() {
     let identity = classify_run_owner_with_probes(
         run.pid,
         run.pid_start_time.as_deref(),
+        PidNamespaceScope::Same,
         |_| ProbeOutcome::Unavailable,
         |_| false,
         |_| true,
@@ -365,6 +377,161 @@ fn stale_failure_message_distinguishes_probe_outcomes() {
         probe_unavailable_message.contains("reason=probe_unavailable"),
         "{probe_unavailable_message}"
     );
+}
+
+// ---- Cross-PID-namespace regression coverage (ORB-10594) ----
+//
+// Incident 2026-08-02: `jrun-20260802-2013-2` ran to a complete success (PR
+// opened at 20:55:49Z) but its run record said `interrupted` since 20:43:00Z,
+// because an Orbit CLI invoked by a sandboxed agent — `bwrap --unshare-all
+// --proc /proc`, i.e. a private PID namespace — swept for orphans. From inside
+// that namespace the host worker PIDs are invisible, so `ps` and
+// `kill(pid, 0)` both reported "gone" for three healthy runs at once.
+
+#[cfg(unix)]
+#[test]
+fn foreign_pid_namespace_never_condemns_a_live_owner() {
+    // The exact incident shape: the observer is in another PID namespace, so
+    // every probe available to it says the owner is gone — `ps` finds no
+    // process and `kill(pid, 0)` agrees. Pre-fix this was `Missing`, which is
+    // the stale set. The recorded owner was in fact mid-run.
+    let persisted = format!("{STABLE_TOKEN_PREFIX}pidns=4026531836:Sun Aug  2 20:13:45 2026");
+    let identity = classify_run_owner_with_probes(
+        Some(83327),
+        Some(persisted.as_str()),
+        PidNamespaceScope::Foreign,
+        |_| ProbeOutcome::NoProcess,
+        |_| false,
+        |_| false,
+    );
+    assert_eq!(identity, OwnerIdentity::ForeignPidNamespace);
+}
+
+#[cfg(unix)]
+#[test]
+fn same_pid_namespace_still_detects_a_genuinely_dead_owner() {
+    // The distinguishing case: identical probe answers, but the observer
+    // shares the owner's namespace, so "not found" really does mean dead.
+    let persisted = format!("{STABLE_TOKEN_PREFIX}pidns=4026531836:Sun Aug  2 20:13:45 2026");
+    let identity = classify_run_owner_with_probes(
+        Some(83327),
+        Some(persisted.as_str()),
+        PidNamespaceScope::Same,
+        |_| ProbeOutcome::NoProcess,
+        |_| false,
+        |_| false,
+    );
+    assert_eq!(identity, OwnerIdentity::Missing);
+}
+
+#[cfg(unix)]
+#[test]
+fn foreign_pid_namespace_is_not_in_the_stale_set_for_running_or_pending_runs() {
+    // End-to-end through the production classifier: a token naming a PID
+    // namespace this process is definitely not in must leave the run alone in
+    // both the running and the pending stale gates.
+    let Some(current) = current_pid_namespace() else {
+        return; // non-Linux: no namespace to compare against.
+    };
+    let foreign = format!("{current}0000");
+    let persisted = format!("{STABLE_TOKEN_PREFIX}pidns={foreign}:Sun Aug  2 20:13:45 2026");
+
+    let mut run = running_run_with_token(999_999, Some(&persisted));
+    assert!(
+        running_run_owner_stale_reason(&run).is_none(),
+        "a run owned in another PID namespace must never be reconciled from here"
+    );
+
+    run.state = JobRunState::Pending;
+    run.created_at = Utc::now() - Duration::days(4);
+    assert!(
+        pending_run_stale_reason(&run).is_none(),
+        "a claimed pending run owned in another PID namespace must stay pending"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn same_pid_namespace_token_still_reconciles_a_dead_owner_end_to_end() {
+    // Counterpart to the test above, through the same production classifier:
+    // a token naming *this* namespace with an impossible PID is still stale,
+    // so the fix cannot be satisfied by never condemning anything.
+    let Some(current) = current_pid_namespace() else {
+        return;
+    };
+    let persisted = format!("{STABLE_TOKEN_PREFIX}pidns={current}:Sun Aug  2 20:13:45 2026");
+    let run = running_run_with_token(999_999, Some(&persisted));
+    assert_eq!(
+        running_run_owner_stale_reason(&run),
+        Some(OwnerIdentity::Missing),
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn v1_token_from_an_older_binary_still_verifies_against_a_v2_probe() {
+    // Upgrade safety: a run claimed before ORB-10594 carries a v1 token with
+    // no namespace field. Re-probing it now yields a v2 token; the owner must
+    // still verify rather than reading as a PID-reuse mismatch.
+    let persisted = format!("{STABLE_TOKEN_PREFIX_V1}Sun Aug  2 20:13:45 2026");
+    let probed = format!("{STABLE_TOKEN_PREFIX}pidns=4026531836:Sun Aug  2 20:13:45 2026");
+    let identity = classify_run_owner_with_probes(
+        Some(4242),
+        Some(persisted.as_str()),
+        PidNamespaceScope::Unknown,
+        |_| ProbeOutcome::Token(probed.clone()),
+        |_| false,
+        |_| true,
+    );
+    assert_eq!(identity, OwnerIdentity::Verified);
+
+    // ...and a genuine PID reuse under a v1 token is still caught.
+    let reused = format!("{STABLE_TOKEN_PREFIX}pidns=4026531836:Mon Aug  3 09:00:00 2026");
+    assert_eq!(
+        classify_run_owner_with_probes(
+            Some(4242),
+            Some(persisted.as_str()),
+            PidNamespaceScope::Unknown,
+            |_| ProbeOutcome::Token(reused),
+            |_| false,
+            |_| true,
+        ),
+        OwnerIdentity::Mismatch,
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn foreign_namespace_diagnostic_is_tagged_distinctly() {
+    let run = running_run_with_token(83327, Some("token"));
+    let message = stale_job_run_message(&run, Some(OwnerIdentity::ForeignPidNamespace));
+    assert!(
+        message.contains("reason=foreign_pid_namespace"),
+        "{message}"
+    );
+}
+
+#[cfg(unix)]
+fn running_run_with_token(pid: u32, token: Option<&str>) -> JobRun {
+    JobRun {
+        run_id: "qa_run".to_string(),
+        job_id: "qa_job".to_string(),
+        attempt: 1,
+        state: JobRunState::Running,
+        scheduled_at: Utc::now(),
+        started_at: Some(Utc::now()),
+        finished_at: None,
+        duration_ms: None,
+        pid: Some(pid),
+        pid_start_time: token.map(str::to_string),
+        input: None,
+        retry_source_run_id: None,
+        created_at: Utc::now(),
+        steps: Vec::new(),
+        knowledge_metrics: None,
+        resolved_crew: None,
+        crew_model: None,
+    }
 }
 
 #[cfg(unix)]

--- a/crates/orbit-core/src/command/job/run/tests/reconcile.rs
+++ b/crates/orbit-core/src/command/job/run/tests/reconcile.rs
@@ -238,6 +238,118 @@ fn pending_run_with_dead_claimed_owner_is_reconciled() {
     }));
 }
 
+/// [ORB-10594] The incident shape, end to end through the sweep: a run whose
+/// owner was recorded in another PID namespace survives a full
+/// `reconcile_stale_job_runs` pass. Inside the sandbox that condemned three
+/// healthy runs on 2026-08-02 the owner PID is invisible — 999_999 stands in
+/// for that, since no probe available here can find it either — but the
+/// namespace recorded on the token says the verdict is not this observer's to
+/// make.
+#[cfg(unix)]
+#[test]
+fn sweep_spares_a_run_whose_owner_lives_in_another_pid_namespace() {
+    use orbit_common::utility::process_identity::{STABLE_TOKEN_PREFIX, current_pid_namespace};
+
+    let (_root, runtime) = test_runtime();
+    let Some(current) = current_pid_namespace() else {
+        return; // non-Linux: namespaces are not observable.
+    };
+    let run = insert_pending_run(&runtime, "qa_foreign_ns");
+    let started_at = Utc::now() - Duration::minutes(30);
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, started_at, 999_999)
+        .expect("mark running");
+    set_run_pid_start_time(
+        &runtime,
+        &run,
+        &format!("{STABLE_TOKEN_PREFIX}pidns={current}0000:Sun Aug  2 20:13:45 2026"),
+    );
+
+    runtime
+        .reconcile_stale_job_runs(None)
+        .expect("reconcile scan");
+
+    let stored = runtime
+        .get_job_run_backend(&run.run_id)
+        .expect("read run")
+        .expect("run exists");
+    assert_eq!(
+        stored.state,
+        JobRunState::Running,
+        "a run owned in another PID namespace must survive the sweep"
+    );
+    assert!(stored.finished_at.is_none());
+    assert!(stored.duration_ms.is_none());
+}
+
+/// [ORB-10594] The counterpart the fix must not break: same sweep, same
+/// unreachable PID, but the token names *this* namespace, so the run is
+/// genuinely orphaned and is still marked interrupted.
+#[cfg(unix)]
+#[test]
+fn sweep_still_condemns_a_run_whose_owner_died_in_this_pid_namespace() {
+    use orbit_common::utility::process_identity::{STABLE_TOKEN_PREFIX, current_pid_namespace};
+
+    let (_root, runtime) = test_runtime();
+    let Some(current) = current_pid_namespace() else {
+        return;
+    };
+    let run = insert_pending_run(&runtime, "qa_local_ns_dead");
+    let started_at = Utc::now() - Duration::minutes(30);
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, started_at, 999_999)
+        .expect("mark running");
+    set_run_pid_start_time(
+        &runtime,
+        &run,
+        &format!("{STABLE_TOKEN_PREFIX}pidns={current}:Sun Aug  2 20:13:45 2026"),
+    );
+
+    runtime
+        .reconcile_stale_job_runs(None)
+        .expect("reconcile scan");
+
+    let shown = runtime.show_job_run(&run.run_id).expect("show run");
+    assert_eq!(shown.state, JobRunState::Interrupted);
+    assert!(shown.steps.iter().any(|step| {
+        step.error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("reason=process_not_found"))
+    }));
+}
+
+/// [ORB-10594] An orphaned run's recorded end of work is when its trail went
+/// quiet, not when a sweep happened to notice. Detection lag used to be booked
+/// as run duration.
+#[test]
+fn orphaned_run_finished_at_tracks_last_audit_activity_not_detection_time() {
+    let (_root, runtime) = test_runtime();
+    let run = insert_pending_run(&runtime, "qa_orphan_timing");
+    let started_at = Utc::now() - Duration::minutes(40);
+    let last_activity = started_at + Duration::minutes(5);
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, started_at, 999_999)
+        .expect("mark running with impossible pid");
+    write_run_finished_audit(&runtime, &run.run_id, last_activity);
+
+    let shown = runtime.show_job_run(&run.run_id).expect("show run");
+
+    assert_eq!(shown.state, JobRunState::Interrupted);
+    assert_eq!(shown.finished_at, Some(last_activity));
+    // ~5 minutes of work, not the ~40 minutes back to `started_at`.
+    let duration_ms = shown.duration_ms.expect("duration recorded");
+    assert!(
+        (295_000..=305_000).contains(&duration_ms),
+        "duration must span started_at..last activity, got {duration_ms}ms"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn list_job_runs_reconciles_before_state_filtering() {

--- a/crates/orbit-core/src/runtime/tests/runtime.rs
+++ b/crates/orbit-core/src/runtime/tests/runtime.rs
@@ -7,14 +7,10 @@ use serde_json::Value;
 use crate::OrbitRuntime;
 use orbit_common::types::JobRunState;
 
-use std::ffi::OsString;
-use std::sync::Mutex;
-
+use orbit_common::test_env;
 use tempfile::tempdir;
 
 use crate::command::activity::DEFAULT_ACTIVITY_FILES;
-
-static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 fn test_runtime() -> (tempfile::TempDir, OrbitRuntime, PathBuf, PathBuf) {
     let root = tempdir().expect("create tempdir");
@@ -89,13 +85,16 @@ fn runtime_init_migrates_legacy_learning_ids_and_records_audit_once() {
 
 #[test]
 fn orbit_root_env_selects_workspace_but_not_global_root() {
-    let _guard = ENV_LOCK.lock().expect("lock env");
     let home = tempdir().expect("home tempdir");
     let repo = tempdir().expect("repo tempdir");
     let workspace_root = repo.path().join(".orbit");
     seed_initialized_workspace_root(&workspace_root);
-    let _home = EnvVarGuard::set("HOME", home.path().as_os_str().to_os_string());
-    let _orbit_root = EnvVarGuard::set("ORBIT_ROOT", workspace_root.as_os_str().to_os_string());
+    let home_var = home.path().to_string_lossy().into_owned();
+    let root_var = workspace_root.to_string_lossy().into_owned();
+    let _env = test_env::scoped([
+        ("HOME", Some(home_var.as_str())),
+        ("ORBIT_ROOT", Some(root_var.as_str())),
+    ]);
 
     let resolved_roots =
         OrbitRuntime::resolve_roots_for_cwd(repo.path(), None).expect("resolve roots");
@@ -107,13 +106,13 @@ fn orbit_root_env_selects_workspace_but_not_global_root() {
 
 #[test]
 fn explicit_root_flag_pins_global_registry_root() {
-    let _guard = ENV_LOCK.lock().expect("lock env");
     let home = tempdir().expect("home tempdir");
     let repo = tempdir().expect("repo tempdir");
     let custom_root_parent = tempdir().expect("custom root parent");
     let custom_root = custom_root_parent.path().join("custom-orbit");
     seed_initialized_workspace_root(&custom_root);
-    let _home = EnvVarGuard::set("HOME", home.path().as_os_str().to_os_string());
+    let home_var = home.path().to_string_lossy().into_owned();
+    let _env = test_env::scoped([("HOME", Some(home_var.as_str()))]);
 
     let resolved_roots =
         OrbitRuntime::resolve_roots_for_cwd(repo.path(), Some(custom_root.as_path()))
@@ -131,42 +130,6 @@ fn seed_initialized_workspace_root(path: &Path) {
     std::fs::create_dir_all(path.join("resources")).expect("create resources dir");
     std::fs::create_dir_all(path.join("tasks")).expect("create tasks dir");
     std::fs::create_dir_all(path.join("state")).expect("create state dir");
-}
-
-struct EnvVarGuard {
-    key: &'static str,
-    previous: Option<OsString>,
-}
-
-impl EnvVarGuard {
-    fn set(key: &'static str, value: OsString) -> Self {
-        let previous = std::env::var_os(key);
-        unsafe {
-            std::env::set_var(key, value);
-        }
-        Self { key, previous }
-    }
-
-    fn unset(key: &'static str) -> Self {
-        let previous = std::env::var_os(key);
-        unsafe {
-            std::env::remove_var(key);
-        }
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        match &self.previous {
-            Some(value) => unsafe {
-                std::env::set_var(self.key, value);
-            },
-            None => unsafe {
-                std::env::remove_var(self.key);
-            },
-        }
-    }
 }
 
 fn reopened_stale_run_state(managed_context: Option<&str>, run_id: Option<&str>) -> JobRunState {
@@ -188,14 +151,10 @@ fn reopened_stale_run_state(managed_context: Option<&str>, run_id: Option<&str>)
         .expect("mark run with host-invisible owner");
     drop(runtime);
 
-    let _managed_context = match managed_context {
-        Some(value) => EnvVarGuard::set("ORBIT_MANAGED_RUN_CONTEXT", value.into()),
-        None => EnvVarGuard::unset("ORBIT_MANAGED_RUN_CONTEXT"),
-    };
-    let _run_id = match run_id {
-        Some(value) => EnvVarGuard::set("ORBIT_RUN_ID", value.into()),
-        None => EnvVarGuard::unset("ORBIT_RUN_ID"),
-    };
+    let _env = test_env::scoped([
+        ("ORBIT_MANAGED_RUN_CONTEXT", managed_context),
+        ("ORBIT_RUN_ID", run_id),
+    ]);
     let reopened = OrbitRuntime::from_roots(&global_root, &workspace_root).expect("reopen runtime");
     reopened
         .get_job_run_backend(&run.run_id)
@@ -210,7 +169,6 @@ fn reopened_stale_run_state(managed_context: Option<&str>, run_id: Option<&str>)
 /// recovery remains unchanged.
 #[test]
 fn managed_run_context_skips_workspace_open_reconciliation_but_not_explicit_recovery() {
-    let _guard = ENV_LOCK.lock().expect("lock env");
     let root = tempdir().expect("create tempdir");
     let global_root = root.path().join("global");
     let workspace_root = root.path().join("repo/.orbit");
@@ -229,8 +187,10 @@ fn managed_run_context_skips_workspace_open_reconciliation_but_not_explicit_reco
         .expect("mark run with host-invisible owner");
     drop(runtime);
 
-    let _managed_context = EnvVarGuard::set("ORBIT_MANAGED_RUN_CONTEXT", "true".into());
-    let _run_id = EnvVarGuard::set("ORBIT_RUN_ID", "jrun-managed-child".into());
+    let _env = test_env::scoped([
+        ("ORBIT_MANAGED_RUN_CONTEXT", Some("true")),
+        ("ORBIT_RUN_ID", Some("jrun-managed-child")),
+    ]);
     let reopened = OrbitRuntime::from_roots(&global_root, &workspace_root).expect("reopen runtime");
     let stored = reopened
         .get_job_run_backend(&run.run_id)
@@ -253,7 +213,8 @@ fn managed_run_context_skips_workspace_open_reconciliation_but_not_explicit_reco
 
 #[test]
 fn workspace_open_reconciles_without_a_complete_managed_run_context() {
-    let _guard = ENV_LOCK.lock().expect("lock env");
+    // No lock here: `reopened_stale_run_state` takes the shared `test_env`
+    // guard per iteration, and that mutex is not reentrant.
     for (managed_context, run_id) in [
         (None, Some("jrun-unmanaged")),
         (Some("false"), Some("jrun-false")),


### PR DESCRIPTION
## Task

[ORB-10594](https://orbit-cli.com/tasks/ORB-10594) — Liveness sweep marks succeeding runs interrupted; false state cascades through pipeline_success_guard

### Description

## Problem

Orbit's run-liveness check watches a process that is not the process doing the work. When that wrapper exits — which it does immediately, by design — a periodic sweep declares the run dead. The run then continues executing to a successful completion, and its recorded state is a lie that other pipelines consume as truth.

### Confirmed incident, 2026-08-02

`jrun-20260802-2013-2` (`task_pr_pipeline`, ws_orbit, crew opus) **succeeded completely**: all 9 steps `success` (worktree, implement_bundle, implement_one, commit, prepare_branch, sync_base, push, pr_open, promote_tasks), provider pid **83502** exited **0** after `duration_ms: 2514941` (~42 min) with `timed_out: false`, PR opened 20:55:49Z, ORB-10586 promoted to `review`.

Its run record says:

```
state:         interrupted
error_message: job run marked interrupted because recorded worker process is no longer
               alive (reason=process_not_found, pid=83327,
               pid_start_time=ps-lstart-utc-v1:Sun Aug  2 20:13:45 2026)
finished_at:   2026-08-02T20:43:00.148Z   <- 12 min before the work actually finished
duration_ms:   1754138                    <- ~29 min recorded vs ~42 min actual
```

The watched pid (83327, started 20:13:45) is not the provider pid (83502, started 20:13:46). Notably the `provider_processes` table tracked 83502 correctly the whole way — through `liveness: "exited", exit_code: 0`. A correct pid existed; the liveness check did not use it.

### It is a sweep, not an isolated failure

Two sibling runs were condemned in the same pass, `finished_at` 13ms apart — `jrun-20260802-1959` (`task_auto_pipeline`, pid 79202, 20:43:00.161) and `jrun-20260802-1959-2` (`task_gate_pipeline`, pid 79215, 20:43:00.154). All three had steps actively progressing at the moment they were declared dead.

### The false state cascades

Both parents kept running past 20:43:00 and then failed on guards reading the child's fabricated state:

- `jrun-…-1959-2` step 5 `require_child_success`: `deterministic action 'pipeline_success_guard' failed: task_gate_pipeline child run did not succeed: result run jrun-20260802-2013-2 status interrupted` — while its own `dispatch_child` step had succeeded at 20:43:03.472
- `jrun-…-1959` step 4 `require_gate_success`: `deterministic action 'pipeline_success_guard' failed: task_auto_pipeline gate runs did not succeed: results[0] run jrun-20260802-1959-2 status interrupted`

So the guard that exists to catch failure propagated a false failure upward from a child that was, at that moment, twelve minutes from opening a PR.

### Why this is worse than a cosmetic state error

- **Any retry or resume path keyed on `interrupted` could re-dispatch work that already landed** — duplicate PRs from a run that succeeded. Whether such a path exists is the first thing to establish.
- Recorded duration is wrong by 13 minutes on a single run, so any cost, waste, or throughput metric consuming `duration_ms`/`finished_at` is corrupted, and corrupted in the direction of under-reporting.
- Marking a run `interrupted` evidently does not stop it. Whether that is intentional advisory bookkeeping or a missing teardown is unknown and matters: if teardown were "fixed" without fixing the liveness check, the sweep would start killing healthy runs outright.
- Operationally it is a trap. This incident consumed a full orchestrator session and produced two confidently wrong diagnoses (an orphaned process, then a service restart) before the run completed and falsified both.

## Scope and constraints

- The substance is: the liveness check must not condemn a run whose work is progressing. Where the fix belongs — recording the right pid, consulting `provider_processes`, adding a heartbeat or step-progress signal, or some combination — is the implementer's call, argued in the execution summary.
- **Preserve the ability to detect a genuinely dead run.** A fix that never marks anything interrupted is not acceptable; distinguishing false positives from real deaths is the point. Establish how many past `process_not_found` runs were real deaths versus false positives before choosing, and report both counts.
- Do not change `pipeline_success_guard` to ignore `interrupted`. The guard behaved correctly given its input; the input was false. If the guard should additionally distinguish "interrupted by sweep" from "genuinely failed", argue it separately rather than weakening the guard.
- Establish empirically what the watched pid actually is (wrapper, `sh -c`, bwrap parent, double-fork intermediate) rather than assuming — the one-second gap between 83327 and 83502 is a clue, not a conclusion.
- Backfilling or repairing the three affected historical run records is out of scope; note whether it is feasible and leave it.
- Do not run `make ci`. Known pre-existing failures to name, never repair: `mcp_roundtrip::hub_mcp_serve_...` (ORB-10577), orbit-exec clippy debt (ORB-10574).

## Acceptance criteria

- A run whose provider process is alive and progressing is never marked `interrupted`, demonstrated by a regression test that reproduces the incident shape: watched pid exits early, provider process continues, sweep runs, run survives.
- A run whose work is genuinely dead is still detected and marked, with a test covering that case distinctly.
- Recorded `finished_at` and `duration_ms` reflect the real end of work, not the moment of a false condemnation.
- The cascade is broken at its source: with the liveness fix in place, a succeeding child no longer fails its parent's `pipeline_success_guard`.
- Every consumer of run `state == interrupted` is enumerated in the execution summary, with the re-dispatch/duplicate-work risk explicitly assessed and stated as present or absent.
- Count of historical false-positive interrupts reported, distinguished from genuine deaths.
- `cargo build` and the touched crates' tests pass; pre-existing failures reported, not repaired.

### Acceptance Criteria

- Live, progressing run is never marked interrupted — regression test reproduces the incident shape (watched pid exits early, provider continues, sweep runs, run survives)
- Genuinely dead run still detected and marked, covered by a distinct test
- finished_at and duration_ms reflect the real end of work, not the false condemnation
- Succeeding child no longer fails parent pipeline_success_guard; guard itself not weakened
- All consumers of state == interrupted enumerated; re-dispatch/duplicate-work risk assessed and stated
- Historical false-positive interrupt count reported, distinguished from genuine deaths
- cargo build + touched-crate tests pass; pre-existing failures reported, not repaired

## Execution Summary

<details>
<summary>Click to expand</summary>

# ORB-10594 — Liveness sweep marks succeeding runs interrupted

## Root cause (established empirically, not assumed)

The watched PID is **not** a wrapper, `sh -c`, bwrap parent, or double-fork intermediate. It is
exactly the right PID — the Orbit pipeline-worker process, recorded by
`execute_pipeline_run_now` as `std::process::id()`. The defect is on the **observer** side: the
sweep ran inside a **private PID namespace**, where host PIDs do not exist.

Evidence:

1. The run's own durable `pipeline_state_json` records the sandbox argv:
   `/usr/bin/bwrap --die-with-parent --new-session --unshare-all --share-net --ro-bind / / --dev
   /dev --proc /proc …`. `--unshare-all` includes `--unshare-pid`; `--proc /proc` mounts a fresh
   procfs for that namespace. Inside it, `ps -p 83327` finds nothing and `kill(83327, 0)` returns
   ESRCH — both probes answer confidently and wrongly, yielding `OwnerIdentity::Missing`.
2. The condemning process was **PID 40790**, cwd
   `.../worktrees/orbit-jrun-20260802-2013-2` — an agent inside the sandbox of the very run it
   condemned. Its PID sequence (40345, 40352, 40359 … 40836; +6..10 per `orbit` invocation) runs
   **concurrently, in the same seconds**, with the host sequence (190031, 195993, 196609, 202488
   … 228874). Two independent monotonic PID allocations at the same wall time = two namespaces.
   `pid_max` is 4194304, so this is not wraparound.
3. The 1-second gap between 83327 (20:13:45) and 83502 (20:13:46) is just the worker spawning its
   provider child — a red herring, not a wrapper boundary.
4. Entry point: the audit shows `task.locks.reserve.released` from PID 40790 at
   **20:43:00.155**, bracketing the three condemnations at .148 / .154 / .161. The sweep entered
   through `release_stale_owned_task_reservations` → `reconcile_stale_job_run`, then `orbit run
   history` (same PID, .205) hit `job_history` → `reconcile_stale_job_runs`.

## Why ORB-10557 did not prevent this

ORB-10557 (done, 2026-08-01) diagnosed the same root cause and shipped an env gate
(`ORBIT_MANAGED_RUN_CONTEXT` + `ORBIT_RUN_ID`). It wraps **exactly one call site**:
`reconcile_stale_job_runs_on_open` in `OrbitRuntime::from_roots`. At least five other entry points
are ungated — `job_history`, `list_job_runs`, `show_job_run`, `execute_pipeline_run_worker`, and
`release_stale_owned_task_reservations` — and the 2026-08-02 sweep entered through two of them.
A per-call-site allowlist has to be re-audited whenever a caller is added; that is how it failed.

## Fix — namespace scope is a property of the decision, not the entry point

`crates/orbit-common/src/utility/process_identity.rs`
- Identity token versioned to `ps-lstart-utc-v2:pidns=<inode>:<lstart>`, recording the writer's
  PID namespace from `/proc/self/ns/pid` (cached in a `OnceLock`; a process cannot change PID
  namespace). `-` when unresolvable.
- `pid_namespace_scope(persisted) -> Same | Foreign | Unknown`. Deliberately asymmetric: a missing
  namespace on either side is `Unknown`, never `Foreign`.
- `stable_tokens_match` is version-tolerant, so a v1 token written by an older binary still
  verifies against a v2 probe — an in-flight run is not invalidated by the upgrade — while
  same-namespace PID reuse is still caught.
- `probe_process_liveness` returns `Unknown` (not `Exited`) across a namespace boundary.

`crates/orbit-core/src/command/job/run/owner.rs`
- New `OwnerIdentity::ForeignPidNamespace`, checked **before every probe**, joining
  `ProbeUnavailable` in the never-stale set for both the running and pending gates; tagged
  `reason=foreign_pid_namespace` in diagnostics.
- `signal_run_owner_process` returns `foreign_pid_namespace` instead of falsely reporting
  `already_exited` for a cancellation that never reached the process.

`crates/orbit-core/src/command/job/run/reconcile.rs`
- `finished_at` for an orphaned run now comes from the last event in its own audit trail, clamped
  to `[started_at, now]`, falling back to now. Detection lag is no longer booked as run duration.

ORB-10557's env gate is left untouched — cheap first line of defense; this fix does not depend on
it. `pipeline_success_guard` is **not** modified: it behaved correctly on false input.

## Historical counts (from `~/.orbit/orbit.db`, per L-0009)

67 `interrupted` runs total: 60 `reason=process_not_found`, 7 `never_claimed`.
Of the 60, classified by whether the run's audit trail (`v2_audit_events` + `audit_events`, keyed
on `(workspace_id, run_id)`) shows activity **after** its recorded `finished_at`:

| verdict | count |
|---|---|
| **False positive** (work continued after condemnation) | **32** |
| Genuine death (no activity after) | 27 |
| Indeterminate (no audit trail at all) | 1 |

The 32 cluster into synchronized batches — 3 runs at 20:43:00, 5 at 19:45:23, 6 at 05:07:34, 3 at
01:58:44, 3 at 00:09:14 — the signature of one cross-namespace sweep condemning every live run at
once. The 27 genuine deaths are the capability the fix preserves. The 27 is a conservative floor:
a false positive whose work ended within the same second is counted as genuine.

## Consumers of `state == interrupted`, and the duplicate-work risk

**Risk is PRESENT, and one vector already fired in this incident.**

1. `runtime/task_reservation_cleanup.rs:279-293` — **automatic, fired on 2026-08-02.** Condemning a
   run releases its task-file reservations with `StaleRunReconciled`. The still-running run kept
   editing files it no longer held a reservation on; another dispatcher could have claimed the same
   task concurrently. No human action needed. Closed at source by this fix.
2. `command/job/resume.rs:80` — `interrupted` is a resumable state (`orbit job resume`,
   `submit_resume_run`, dashboard `jobs.rs:101`, `workflow_tools.rs:98`). **Human/dashboard
   triggered, not automatic.** Dangerous for a falsely-condemned run: resume reuses the checkpoints
   as of condemnation time, which for `jrun-…-2013-2` predate `push` and `pr_open` — so a resume
   would have re-run them and opened a **duplicate PR** for work already merged.
3. `command/job/pipeline.rs:740` + `runtime/v2_host/pipeline_actions.rs:402`
   (`pipeline_success_guard`) — the observed cascade; both parents failed on the child's false
   status.
4. `command/job/pipeline.rs:429` (`wait_pipeline_runs`) — treats `interrupted` as terminal, stops
   waiting on a run that is still working.
5. `command/job/pipeline.rs:479` (`execute_pipeline_run_worker`) — returns early if the run is
   already terminal, so a not-yet-started worker would silently refuse to run.
6. `routines/sweep.rs:604` — routine fire recorded `Failed` with "run interrupted".
7. `runtime/task_block_on_run_failure.rs:23` — explicitly **excludes** `Interrupted` from blocking a
   task. Correct as-is; no change needed.
8. Read-only/terminal-classification surfaces: `cli/command/run/support.rs:215,596-616`,
   `dashboard/api/audit.rs:434,463`, `store/sqlite/job_run_store/mod.rs:234,405`.

Marking a run `interrupted` does **not** stop it — no teardown is attached. That is why the run
survived to open its PR. This is advisory bookkeeping today; the task's warning holds — adding
teardown without this liveness fix would have started killing healthy runs outright.

## Tests

New, in `command/job/run/tests/owner.rs` and `tests/reconcile.rs` (all 9 pass):
- `sweep_spares_a_run_whose_owner_lives_in_another_pid_namespace` — the incident shape end-to-end
  through `reconcile_stale_job_runs`: owner PID invisible, every probe says gone, run survives.
- `sweep_still_condemns_a_run_whose_owner_died_in_this_pid_namespace` — identical probe answers,
  same namespace, still marked `interrupted` with `reason=process_not_found`. The fix cannot be
  satisfied by never condemning anything.
- `foreign_pid_namespace_never_condemns_a_live_owner` / `same_pid_namespace_still_detects_a_
  genuinely_dead_owner` — the same pair at the classifier seam.
- `foreign_pid_namespace_is_not_in_the_stale_set_for_running_or_pending_runs`,
  `same_pid_namespace_token_still_reconciles_a_dead_owner_end_to_end`,
  `foreign_namespace_diagnostic_is_tagged_distinctly`.
- `v1_token_from_an_older_binary_still_verifies_against_a_v2_probe` — upgrade safety, plus PID
  reuse under a v1 token still caught.
- `orphaned_run_finished_at_tracks_last_audit_activity_not_detection_time`.

`classify_run_owner_with_probes` gained an explicit `scope` parameter so the classification stays a
pure function of its inputs — a test asserting genuine-orphan detection must not change verdict
because the test runner itself happens to be sandboxed.

## Unlisted file changed (task had no context_files; all six appended)

`crates/orbit-core/src/runtime/tests/runtime.rs` — **test-only.** It used a private `ENV_LOCK` +
local `EnvVarGuard` to mutate `ORBIT_MANAGED_RUN_CONTEXT`/`ORBIT_RUN_ID`, while
`tests/reconcile.rs` mutates the same variables under `orbit_common::test_env`'s process-wide lock.
Two independent locks are not mutually exclusive — `test_env`'s own docs say so (ORB-10540). Adding
tests to `reconcile.rs` shifted the interleaving enough that the latent race fired ~every run,
flipping `managed_run_context_skips_workspace_open_reconciliation_but_not_explicit_recovery` and
poisoning `ENV_LOCK` for two siblings. Converted the four sites to `test_env::scoped` (the shared
lock) and deleted the now-unused guard; no `#[allow]` added. Verified: full `orbit-core` suite at
HEAD passes, so this race was latent, not pre-existing-failing.

## Validation

- `cargo build --workspace` — clean.
- `cargo test -p orbit-core --lib` — **725 passed, 1 failed**; `-p orbit-common --lib` 301 passed;
  `-p orbit-store --lib` 323; `-p orbit-engine --lib` 354; `-p orbit-dashboard --lib` 227;
  `-p orbit-cli --bins` 319. All 0 failed.
- `cargo fmt --all -- --check` — clean.

**Pre-existing / environmental, reported not repaired:**
- `command::init::tests::fresh_workspace_init_seeds_disabled_worktree_gc_routine` — the 1 failure.
  Depends on an ambient writable `$HOME`, which this executor sandbox mounts read-only. **Proven
  pre-existing**: fails identically with all five source files reverted to HEAD, and passes with
  `HOME=/tmp/fakehome-test`. Passes in CI's bare shell.
- `make ci-fast` cannot complete here: `test-installer-security.sh` needs `node`,
  `check-terminal-state-guard.sh` / `check-orphan-modules.sh` / `check-error-translation.sh` need
  `rg` — neither binary is on PATH in this sandbox. Every step that could run passed
  (fmt-check, doc-indexes, installer-pubkey, dependency-direction, cli-imports, stability,
  learning-layout, artifact-redaction, changelog-style, embedded-asset-portability,
  validate-codex-plugin).
- Known and untouched per the task: `mcp_roundtrip::hub_mcp_serve_…` (ORB-10577), orbit-exec clippy
  debt (ORB-10574). Not run.

## Out of scope, noted

Backfilling the three affected historical records **is feasible**: `jrun-20260802-2013-2`'s true
end is recoverable from its audit trail (last event 20:55:49Z, vs recorded 20:43:00.148Z — 12m49s
of work erased), and the same holds for the other 31 false positives. Left as-is per the task.

## ADR — BLOCKED ON SANDBOX, FULL BODY BELOW

`orbit.adr.add` failed with `{"code":"io_error","error":"io error: Read-only file system (os error
30)"}`; both `.orbit/adrs/` (worktree and primary checkout) are read-only from this executor
sandbox. The record must be created from a writable context. Full body, ready to submit verbatim:

---
**Title:** PID-namespace scope decides who may adjudicate job-run liveness
**Related tasks:** ORB-10594, ORB-10557 · **Features:** activity-job, policy-sandbox
**Tags:** dispatch, runtime, liveness, sandboxing
**Paths:** `crates/orbit-common/src/utility/process_identity.rs`,
`crates/orbit-core/src/command/job/run/owner.rs`,
`crates/orbit-core/src/command/job/run/reconcile.rs`

### Context

Orbit records a job run's owner as a PID plus a process-start identity token, and the orphan sweep
marks a `running` run `interrupted` when both `ps` and `kill(pid, 0)` say that PID is gone. A PID,
however, only names a process *within a PID namespace*. Orbit's own sandbox (`bwrap
--die-with-parent --new-session --unshare-all --share-net --dev /dev --proc /proc`) gives every
sandboxed agent a private PID namespace and a fresh procfs. Inside it, host worker PIDs are
invisible, so both probes answer confidently and wrongly: `process_not_found`. Sandboxed agents
routinely invoke the Orbit CLI, and many CLI surfaces reconcile.

**Incident 2026-08-02.** `jrun-20260802-2013-2` (`task_pr_pipeline`) ran to a complete success —
all 9 steps succeeded, provider PID 83502 exited 0 after ~42 min, PR opened at 20:55:49Z — yet its
record read `state: interrupted`, `finished_at: 20:43:00.148Z`, `duration_ms: 1754138` (~29 min).
Two sibling runs were condemned in the same pass, 13 ms apart. The condemning process was PID 40790
with cwd `.../worktrees/orbit-jrun-20260802-2013-2` — an agent inside that run's own sandbox. Its
PID sequence (40345…40836, +6..10 per invocation) runs concurrently with the host sequence
(190031…228874) in the same seconds: two independent monotonic PID allocations, i.e. two
namespaces. The false state then cascaded — both parents failed `pipeline_success_guard` on the
child's fabricated status.

**ORB-10557 already diagnosed this root cause** (2026-08-01) and shipped a gate: skip
reconciliation when `ORBIT_MANAGED_RUN_CONTEXT` + `ORBIT_RUN_ID` mark a managed child. It did not
hold, because the gate wraps exactly one call site — `reconcile_stale_job_runs_on_open` in
`OrbitRuntime::from_roots`. Reconciliation has at least five other entry points that are ungated:
`job_history`, `list_job_runs`, `show_job_run`, `execute_pipeline_run_worker`, and
`release_stale_owned_task_reservations`. The 2026-08-02 sweep entered through the last of these:
the audit shows `task.locks.reserve.released` from PID 40790 at 20:43:00.155, bracketing the three
condemnations at .148/.154/.161.

### Decision

Make namespace scope a property of the *decision*, not of the entry point.

1. The process-start identity token is versioned up to `ps-lstart-utc-v2:pidns=<inode>:<lstart>`,
   recording the PID namespace (`/proc/self/ns/pid`) of the process that wrote it. v1 tokens are
   still read and still verify against a v2 probe on their process-start value, so an in-flight run
   claimed by an older binary is not invalidated by the upgrade.
2. Owner classification compares the observer's namespace against the recorded one *before* any
   probe runs. A mismatch yields a new terminal-safe classification,
   `OwnerIdentity::ForeignPidNamespace`, which joins `ProbeUnavailable` in the never-stale set and
   is tagged `reason=foreign_pid_namespace` in diagnostics. Cancellation refuses to signal across
   the boundary for the same reason.
3. A missing namespace on either side yields `Unknown`, which behaves exactly as before. This is
   deliberately asymmetric: the guard never converts "unknown" into "foreign".
4. An orphaned run's `finished_at` is derived from the last event in its own audit trail (clamped
   to `[started_at, now]`) rather than the moment of detection.

ORB-10557's env gate is left in place: it is a cheap first line of defense for the common case, and
this ADR does not depend on it.

**Rejected alternatives**

- *Extend the env gate to every reconciliation entry point.* Cheaper, but it is a per-call-site
  allowlist that must be re-audited whenever a new caller appears — which is precisely how
  ORB-10557 failed. It also trusts an inherited environment variable rather than an observable
  kernel fact.
- *Consult `provider_processes` for liveness.* The table did track PID 83502 correctly throughout.
  But it is an audit projection of the *provider child*, not the run owner, it is absent for
  non-CLI steps, and reading it cross-namespace has the identical PID-meaning problem.
- *Add a heartbeat or step-progress signal.* Genuinely useful and orthogonal, but it changes the
  write path of every step for a defect whose cause is a misread of an existing correct signal.
  Left for a follow-up.
- *Treat "observer is not in the initial PID namespace" as foreign for tokenless runs.* Rejected:
  it would disable genuine-orphan detection outright for any deployment whose workers legitimately
  run inside a container, and it would break detection for the common `pid_start_time: None` case
  (an owner whose `ps` probe failed at claim time).
- *Weaken `pipeline_success_guard` to tolerate `interrupted`.* Explicitly out of scope. The guard
  behaved correctly on false input; the input was the defect.

### Consequences

- A run whose owner was recorded in another PID namespace can no longer be condemned from that
  namespace, through *any* reconciliation entry point, including ones added later.
- Genuine orphan detection is unchanged when observer and owner share a namespace — the case that
  covers every host-side sweep, `orbit doctor`, and the dashboard.
- Recorded `duration_ms` for genuine orphans no longer includes detection lag, so cost and
  throughput metrics reading it stop over-counting.
- The false-interrupt vector that automatically released task-file reservations
  (`StaleRunReconciled`) while the owning run was still editing those files is closed at its source.
- `Cost:` the identity token gains a namespace field, so a v2 token written by a new binary is not
  byte-comparable with a v1 token written by an old one. Comparison is version-tolerant rather than
  string equality, which is one more rule for a reader of `process_identity.rs` to hold. A
  same-namespace PID reuse is still caught; a *cross*-namespace PID reuse is now reported as
  unverifiable instead of as a mismatch, which is the correct answer but a strictly weaker one.
- `Cost:` runs claimed by a pre-ORB-10594 binary carry no namespace field, so they remain
  condemnable from a foreign namespace until they finish. The exposure is bounded by run lifetime
  (hours), and closing it would require the rejected initial-namespace heuristic.
- `Cost:` an orphaned run with no audit trail still falls back to detection time for `finished_at`.

### Status

Proposed — ORB-10594.
---

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10594-6a6fb105`
- Behind base: 0
- Ahead of base: 1