### PR TITLE
Make task-pilot read-only sandboxing work on Linux

### DIFF
--- a/.orbit/resources/activities/task_pilot.yaml
+++ b/.orbit/resources/activities/task_pilot.yaml
@@ -5,36 +5,116 @@ metadata:
 spec:
   type: agent_loop
   require_response_envelope: true
-  description: Read-only bounded task preflight with no repository-write or task-update grant.
+  # Read-only direct activities must select a read-only profile explicitly.
+  # Omitting this falls back to unrestricted workspace writes, which both
+  # violates the pilot contract and makes Linux reject non-subtree env denies.
+  fsProfile: reviewer
+  description: >
+    Read-only task preflight for one explicit bounded partition. The pilot
+    inspects the selected workspace and target branch, returns exact canonical
+    context_files proposals plus orchestration recommendations, and has no
+    repository-write, task-update, lifecycle, dispatch, or scheduling grant.
   input_schema_json:
     type: object
     required: [task_ids, workspace_path, base_branch, crew, partition_index]
     properties:
-      task_ids: {type: array, minItems: 1, maxItems: 5, items: {type: string}}
-      workspace_path: {type: string}
-      base_branch: {type: string}
-      crew: {type: string}
-      partition_index: {type: number}
+      task_ids:
+        type: array
+        minItems: 1
+        maxItems: 5
+        items:
+          type: string
+      workspace_path:
+        type: string
+      base_branch:
+        type: string
+      crew:
+        type: string
+      partition_index:
+        type: number
+  # Agent-returned data is advisory until apply_task_pilot_results validates
+  # the complete fan-in, so keep fields optional at this boundary and let that
+  # validation step — not the schema — reject an incomplete partition.
   output_schema_json:
     type: object
     properties:
-      partition_index: {type: number}
-      task_ids: {type: array, items: {type: string}}
-      tasks: {type: array, items: {type: object}}
-      summary: {type: string}
+      partition_index:
+        type: number
+      task_ids:
+        type: array
+        items:
+          type: string
+      tasks:
+        type: array
+        items:
+          type: object
+      summary:
+        type: string
   instruction: |
-    You are Orbit's task-pilot for one explicit partition of at most five task IDs.
-    Read each task with orbit.task.show, inspect the target branch and accepted
-    ADRs using only read tools, and return exact context_files_before and canonical
-    file:/dir:/symbol: context_files_after values. Use disposition selectors for
-    non-empty values; use verified_no_diff or host_operational plus concrete
-    evidence for an empty value. Report recommended_crew, recommended_complexity,
-    blocked_by, duplicate_of, already_landed, adr_conflicts, utility_warnings,
-    and surface_warnings. Never update tasks, edit files, promote, dispatch,
-    implement, commit, push, invoke pipelines, or choose an architecture alternative.
-    Return one successful Orbit response envelope with partition_index, exact
-    task_ids, one tasks entry per ID, and summary. Fail the whole partition if
-    any task cannot be assessed.
+    You are Orbit's task-pilot for one explicit, bounded partition.
+
+    Input contains `task_ids` (one to five exact IDs), `workspace_path`,
+    `base_branch`, `crew`, and `partition_index`. Work only on those task IDs
+    and treat the workspace as read-only.
+
+    For every task:
+
+    1. Call `orbit.task.show` and read its title, description, acceptance
+       criteria, plan, tags, relations, status, and exact current
+       `context_files`. Use `orbit.search` for the task ID and relevant design
+       terms; inspect accepted ADRs with `orbit.adr.show` when a result points
+       to one.
+    2. With `proc.spawn` run only read-only `git`/`rg` commands. Verify the
+       workspace Git top-level, inspect `base_branch`, and determine every real
+       file, directory, or symbol the stated change would modify or delete.
+       Use `fs.read` to inspect candidate targets. Do not edit repository files.
+    3. Propose `context_files_after` as exact canonical selectors using only
+       `file:`, `dir:`, or `symbol:`. Every anchor must already exist inside
+       `workspace_path`; omit read-for-context files. Preserve the exact current
+       list as `context_files_before`.
+    4. If the task genuinely requires no repository diff, return an empty
+       `context_files_after`, disposition `verified_no_diff`, and concrete
+       `evidence`. For host-operational work use `host_operational` with
+       evidence. Otherwise use disposition `selectors`. Never use an empty list
+       merely because inspection was inconclusive.
+    5. Report recommendations only; do not apply them:
+       `recommended_crew`, `recommended_complexity`, real `blocked_by` task IDs,
+       `duplicate_of`, `already_landed`, `adr_conflicts`, `utility_warnings`,
+       and `surface_warnings`. Cite evidence for duplicates/already-landed work
+       and ADR conflicts. Do not choose an architecture alternative silently.
+
+    Hard bounds:
+    - Never update a task, transition lifecycle state, promote, dispatch,
+      invoke a pipeline, edit/delete files, commit, push, or open a PR.
+    - Never inspect or report on task IDs outside the input partition except
+      when citing a concrete dependency, duplicate, or accepted ADR.
+    - Preserve provider provenance: task-pilot is a role, not an actor family.
+
+    Return exactly one Orbit response envelope:
+    {"schemaVersion":1,"status":"success","result":{
+      "partition_index":0,
+      "task_ids":["ORB-NNNNN"],
+      "tasks":[{
+        "task_id":"ORB-NNNNN",
+        "context_files_before":[],
+        "context_files_after":["file:path/to/target"],
+        "disposition":"selectors|verified_no_diff|host_operational",
+        "evidence":"required when context_files_after is empty",
+        "recommended_crew":"luna",
+        "recommended_complexity":"low|medium|hard",
+        "blocked_by":[],
+        "duplicate_of":null,
+        "already_landed":null,
+        "adr_conflicts":[],
+        "utility_warnings":[],
+        "surface_warnings":[]
+      }],
+      "summary":"one short partition summary"
+    },"error":null}
+
+    Copy `partition_index` and `task_ids` exactly from the input and return one
+    task assessment per input ID. If any task cannot be assessed, return a
+    failed envelope for the whole partition; never omit it or claim success.
   tools:
     - orbit.task.show
     - orbit.task.list
@@ -43,6 +123,8 @@ spec:
     - orbit.learning.show
     - fs.read
     - proc.spawn
-  proc_allowed_programs: [git, rg]
+  proc_allowed_programs:
+    - git
+    - rg
   on_denial: terminate
   wall_clock_timeout_seconds: 1800

--- a/crates/orbit-core/assets/activities/task_pilot.yaml
+++ b/crates/orbit-core/assets/activities/task_pilot.yaml
@@ -5,6 +5,10 @@ metadata:
 spec:
   type: agent_loop
   require_response_envelope: true
+  # Read-only direct activities must select a read-only profile explicitly.
+  # Omitting this falls back to unrestricted workspace writes, which both
+  # violates the pilot contract and makes Linux reject non-subtree env denies.
+  fsProfile: reviewer
   description: >
     Read-only task preflight for one explicit bounded partition. The pilot
     inspects the selected workspace and target branch, returns exact canonical

--- a/crates/orbit-core/src/command/activity.rs
+++ b/crates/orbit-core/src/command/activity.rs
@@ -396,7 +396,18 @@ mod tests {
             .iter()
             .find(|(name, _)| *name == "task_pilot")
             .expect("task pilot activity is seeded");
+        let workspace_yaml =
+            include_str!("../../../../.orbit/resources/activities/task_pilot.yaml");
+        assert_eq!(
+            *yaml, workspace_yaml,
+            "shipped and workspace task-pilot resources must remain byte-identical"
+        );
         let asset = load_activity_asset(yaml).expect("parse task pilot activity");
+        assert_eq!(
+            asset.spec.fs_profile.as_deref(),
+            Some("reviewer"),
+            "read-only direct activities must not inherit unrestricted workspace writes"
+        );
         assert!(
             asset.spec.output_schema_json.get("required").is_none(),
             "agent-returned task-pilot fields stay advisory until deterministic apply"

--- a/crates/orbit-core/src/command/job/tests/catalog.rs
+++ b/crates/orbit-core/src/command/job/tests/catalog.rs
@@ -306,6 +306,21 @@ fn task_pilot_pipeline_defaults_to_luna_and_bounded_all_join_partitions() {
         yaml.contains("Invoked-only"),
         "task pilot must remain an explicitly invoked workflow"
     );
+
+    let mut resolved = load_job_asset(yaml).expect("task pilot pipeline parses for resolution");
+    resolve_job_target_refs(&mut resolved.spec, &default_activity_catalog())
+        .expect("task pilot activity references resolve");
+    let JobV2StepBody::FanOut { fan_out, .. } = &resolved.spec.steps[1].body else {
+        panic!("resolved task pilot agent work must remain a fan-out");
+    };
+    let JobV2StepBody::Target(pilot) = &fan_out.worker.body else {
+        panic!("task pilot worker must resolve to an activity target");
+    };
+    assert_eq!(
+        pilot.fs_profile.as_deref(),
+        Some("reviewer"),
+        "resolved task-pilot worker must preserve the read-only filesystem profile"
+    );
 }
 
 /// [ORB-10385] Every deterministic action reachable from a shipped job —

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/argv.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/argv.rs
@@ -1,13 +1,37 @@
 #![allow(missing_docs)]
 
 use std::collections::HashMap;
+#[cfg(target_os = "linux")]
+use std::process::Stdio;
 
+#[cfg(target_os = "linux")]
+use chrono::Utc;
+#[cfg(target_os = "linux")]
+use orbit_common::types::{
+    ActivityV2Spec, ExecutorSandboxKind, FsOperation, PolicyDef, ResourceKind, load_activity_asset,
+    parse_policy_resource,
+};
 use orbit_exec::sandbox_exec_program_for_audit;
+#[cfg(target_os = "linux")]
+use orbit_exec::{
+    LinuxBwrapSpawnRequest, bwrap_program_for_audit, compile_linux_bwrap_argv, probe_bwrap,
+    spawn_under_linux_bwrap,
+};
 
+#[cfg(target_os = "linux")]
+use super::super::argv::try_audit_argv_for_dispatch;
 use super::super::argv::{
     audit_argv_for_dispatch, neutralize_inner_sandbox, rewrite_debug_file_value,
 };
 use super::test_support::sandbox_for_test;
+#[cfg(target_os = "linux")]
+use crate::activity_job::ResolvedSandbox;
+
+#[cfg(target_os = "linux")]
+const TASK_PILOT_ACTIVITY: &str =
+    include_str!("../../../../../orbit-core/assets/activities/task_pilot.yaml");
+#[cfg(target_os = "linux")]
+const DEFAULT_POLICY: &str = include_str!("../../../../../orbit-core/assets/policies/default.yaml");
 
 #[test]
 fn audit_argv_for_dispatch_prepends_sandbox_exec_when_sandbox_active() {
@@ -37,6 +61,154 @@ fn audit_argv_for_dispatch_returns_bare_when_no_sandbox() {
         None,
     );
     assert_eq!(argv, vec!["/usr/bin/claude", "-p", "hello"]);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn task_pilot_reviewer_profile_starts_direct_linux_invocation_with_env_denies() {
+    let activity = load_activity_asset(TASK_PILOT_ACTIVITY).expect("parse task-pilot activity");
+    let profile_name = activity
+        .spec
+        .fs_profile
+        .as_deref()
+        .expect("task-pilot must select an explicit fsProfile");
+    assert_eq!(profile_name, "reviewer");
+    let ActivityV2Spec::AgentLoop(agent) = &activity.spec.spec else {
+        panic!("task-pilot must remain an agent-loop activity");
+    };
+    assert!(!agent.tools.iter().any(|tool| {
+        matches!(
+            tool.as_str(),
+            "fs.write" | "fs.patch" | "fs.delete" | "orbit.task.update" | "orbit.task.*"
+        )
+    }));
+
+    let resource =
+        parse_policy_resource(DEFAULT_POLICY, "default task-pilot policy").expect("parse policy");
+    assert_eq!(resource.kind, ResourceKind::Policy);
+    assert_eq!(
+        resource.spec.deny_read,
+        ["**/.env", "**/.env.*", "**/*.env", "**/*.env.*"]
+    );
+    assert_eq!(
+        resource.spec.deny_modify,
+        [
+            ".orbit/**",
+            "!.orbit/auto_tasks/**",
+            "!.orbit/routines/**",
+            "!.orbit/config.yaml",
+            "!.orbit/config.toml",
+            "!.orbit/resources/**",
+            "**/.env",
+            "**/.env.*",
+            "**/*.env",
+            "**/*.env.*",
+        ]
+    );
+    let now = Utc::now();
+    let policy = PolicyDef {
+        name: resource.metadata.name,
+        description: resource.spec.description,
+        deny_read: resource.spec.deny_read,
+        deny_modify: resource.spec.deny_modify,
+        fs_profiles: resource.spec.fs_profiles,
+        created_at: now,
+        updated_at: now,
+    };
+    assert!(
+        policy
+            .check_path(profile_name, FsOperation::Read, "src/lib.rs")
+            .expect("check workspace read")
+            .allowed
+    );
+    assert!(
+        !policy
+            .check_path(profile_name, FsOperation::Read, ".env")
+            .expect("check env read")
+            .allowed
+    );
+    for path in ["src/lib.rs", ".orbit/tasks/ORB-10584/task.yaml", ".env"] {
+        assert!(
+            !policy
+                .check_path(profile_name, FsOperation::Modify, path)
+                .unwrap_or_else(|error| panic!("check modify path {path}: {error}"))
+                .allowed,
+            "task-pilot reviewer profile must not modify {path}"
+        );
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(workspace.join(".orbit")).expect("create workspace fixture");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let workspace_root = workspace.display().to_string();
+    let mut effective = policy
+        .effective_profile(profile_name)
+        .expect("resolve reviewer profile");
+    effective.read = effective
+        .read
+        .iter()
+        .map(|rule| absolutize_test_rule(&workspace_root, rule))
+        .collect();
+    effective.modify = effective
+        .modify
+        .iter()
+        .map(|rule| absolutize_test_rule(&workspace_root, rule))
+        .collect();
+    assert!(
+        effective.modify.iter().all(|rule| rule.starts_with('!')),
+        "reviewer profile must not contain a positive workspace modify grant: {:?}",
+        effective.modify
+    );
+
+    let sandbox = ResolvedSandbox {
+        kind: ExecutorSandboxKind::LinuxBwrap,
+        fs_profile: effective.clone(),
+        allow_fallback: false,
+        managed_worktree: false,
+    };
+    let argv = try_audit_argv_for_dispatch("/bin/true", &[], Some(&sandbox), Some(&workspace))
+        .expect("direct task-pilot Bubblewrap plan must compile");
+    assert_eq!(
+        argv.first().map(String::as_str),
+        Some(bwrap_program_for_audit())
+    );
+
+    let probe = probe_bwrap();
+    if !probe.available {
+        return;
+    }
+    let plan = compile_linux_bwrap_argv(&effective, "/bin/true", &[], Some(&workspace), false)
+        .expect("compile task-pilot Bubblewrap invocation");
+    let mut child = spawn_under_linux_bwrap(LinuxBwrapSpawnRequest {
+        plan: &plan,
+        env: &[],
+        cwd: Some(&workspace),
+        stdin: Stdio::null(),
+        stdout: Stdio::null(),
+        stderr: Stdio::null(),
+    })
+    .expect("start direct task-pilot Bubblewrap invocation");
+    assert!(
+        child
+            .wait()
+            .expect("wait for task-pilot invocation")
+            .success()
+    );
+}
+
+#[cfg(target_os = "linux")]
+fn absolutize_test_rule(workspace_root: &str, rule: &str) -> String {
+    let (negated, body) = rule
+        .strip_prefix('!')
+        .map_or((false, rule), |body| (true, body));
+    let body = body.trim_start_matches("./");
+    let absolute = format!("{}/{body}", workspace_root.trim_end_matches('/'));
+    if negated {
+        format!("!{absolute}")
+    } else {
+        absolute
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-10584](https://orbit-cli.com/tasks/ORB-10584) — Make task-pilot read-only sandboxing work on Linux

### Description

Repair the max-mode task-pilot admission failure recorded as F2026-08-021. The `task_pilot` activity is contractually read-only but omits `fsProfile`, so Orbit resolves the unrestricted modify profile; Linux Bubblewrap then correctly rejects a direct invocation because global non-subtree `.env` denyModify rules overlap that writable root. Bind task-pilot to the existing read-only `reviewer` filesystem profile, preserve its read-only tool contract, update shipped and workspace resource copies, and prove direct Linux execution no longer requires a managed worktree.

### Acceptance Criteria

- The canonical `task_pilot` activity and the workspace-local resource copy explicitly select the existing `reviewer` fsProfile.
- The effective task-pilot profile permits workspace reads, permits no workspace modifications, and retains all global denyRead and denyModify rules.
- A direct Linux Bubblewrap task-pilot invocation with the default non-subtree `.env` deny rules compiles and starts without the `use a managed worktree` policy denial.
- The change does not weaken, remove, reorder, or special-case global `.env` or `.orbit` protections and does not grant task-pilot repository or task mutation authority.
- Catalog/resource parity tests cover the fsProfile value, and a regression test exercises the task-pilot activity through the Linux direct-invocation sandbox path.
- The canonical task_pilot_pipeline succeeds far enough to run the pilot agent in an authoritative workspace and still leaves deterministic context_files application as the only write boundary.
- Documentation or an inline invariant explains why read-only direct activities must not fall back to the unrestricted filesystem profile.
- F2026-08-021 is linked and resolves automatically when this task reaches done.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Bound both canonical and workspace-local task_pilot activity resources to the existing reviewer fsProfile, synchronized the two resources byte-for-byte, and documented why read-only direct activities cannot use the implicit unrestricted fallback.
- Added resource parity and resolved job-catalog assertions for fsProfile propagation while preserving the existing read-only tool and deterministic-apply boundaries.
- Added a Linux regression that loads the canonical activity and default policy, locks the global deny order, verifies workspace-read/no-workspace-modify behavior, compiles the direct Bubblewrap dispatch path without managed-worktree mode, and starts /bin/true when Bubblewrap is available.
- Expanded context_files to include the two directly coupled catalog/regression test targets. The existing resolves relation to F2026-08-021 remains present.
Assessment: The scoped configuration defect is fixed without policy or dependency changes; task-pilot retains no repository-write, task-update, lifecycle, or dispatch tool authority.
Validation:
- make ci-fast (passed)
- cargo test -p orbit-core task_pilot_is_read_only_bounded_and_uses_advisory_output --lib (passed)
- cargo test -p orbit-core task_pilot_pipeline_defaults_to_luna_and_bounded_all_join_partitions --lib (passed)
- cargo test -p orbit-engine task_pilot_reviewer_profile_starts_direct_linux_invocation_with_env_denies --lib (passed)
- cmp canonical/workspace task_pilot YAML and git diff --check (passed)
- Live authoritative pipeline validation could not run from the isolated executor worktree: jrun-20260802-2221 correctly rejected a requested worktree path because the active workspace is the primary checkout, and overriding --root to the task worktree was denied by its read-only .orbit mount. This is an executor isolation limitation; post-merge CI/operator validation remains authoritative.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10584-6a6fc0c9`
- Behind base: 0
- Ahead of base: 1