### PR TITLE
Surface pipeline reliability on the orbit dashboard: job-run failure rate and recovery invocation rate

### DIFF
--- a/crates/orbit-common/src/types/activity_job/activity_roles.rs
+++ b/crates/orbit-common/src/types/activity_job/activity_roles.rs
@@ -1,0 +1,122 @@
+//! Structural classification of the activities a [`JobV2`] can dispatch.
+//!
+//! A job declares two structurally distinct kinds of activity:
+//!
+//! * **step activities** — the work the job exists to do;
+//! * **recovery activities** — named by `recovery_activity` at the job level
+//!   or on an individual step, dispatched only after that step fails.
+//!
+//! # Matching what the store actually records
+//!
+//! The identifier an `invocations` row carries in `activity_id` is *not*
+//! uniformly the catalog activity name. The job executor persists a dispatched
+//! step's trace under the **step id**, while a recovery dispatch — which has
+//! no step of its own — is persisted under the **recovery activity name**.
+//! A third writer (the planning-duel runner) persists under the activity name.
+//!
+//! [`JobActivityRoles::step`] therefore holds both identifiers a step
+//! invocation can be recorded under: the step's `id`, and the catalog name
+//! from its `target` (an inlined [`TargetStep`]'s `activity_name`, or an
+//! unresolved [`TargetRef`] of the form `activity:<name>`). Collecting only
+//! one of the two would leave real step work unattributed and silently deflate
+//! any denominator built from this set.
+//!
+//! Reliability reporting needs the recovery set to be *discovered* rather than
+//! enumerated in source: which activity performs recovery is a property of the
+//! workspace's job definitions, not of Orbit. [`JobV2::activity_roles`] walks
+//! the declared job structure and returns both sets, so a caller can attribute
+//! observed invocations without ever hardcoding an activity id [ORB-10588].
+//!
+//! An activity may legitimately appear in both sets (a job can name the same
+//! activity as a step target and as another step's recovery hook). Callers
+//! that need disjoint sets should treat `recovery` as taking precedence, since
+//! an invocation of a dual-role activity cannot be attributed structurally.
+
+use std::collections::BTreeSet;
+
+use super::catalog::ACTIVITY_REF_PREFIX;
+use super::job_v2::{JobV2, JobV2Step, JobV2StepBody};
+
+/// The activity ids a job can dispatch, split by the structural role the job
+/// definition assigns them.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct JobActivityRoles {
+    /// Identifiers a step invocation can be recorded under, at any nesting
+    /// depth: each step's `id` plus the catalog name of its target.
+    pub step: BTreeSet<String>,
+    /// Activities named by `recovery_activity`, at the job level or on a step.
+    pub recovery: BTreeSet<String>,
+}
+
+impl JobActivityRoles {
+    /// Folds another job's roles into this one, for catalog-wide discovery.
+    pub fn merge(&mut self, other: &JobActivityRoles) {
+        self.step.extend(other.step.iter().cloned());
+        self.recovery.extend(other.recovery.iter().cloned());
+    }
+
+    /// Activities that are only ever reached as a recovery hook.
+    ///
+    /// An activity that is also a step target is excluded: its invocations
+    /// cannot be attributed to recovery from the job structure alone.
+    pub fn recovery_only(&self) -> BTreeSet<String> {
+        self.recovery.difference(&self.step).cloned().collect()
+    }
+
+    /// Activities that are only ever reached as a step target.
+    pub fn step_only(&self) -> BTreeSet<String> {
+        self.step.difference(&self.recovery).cloned().collect()
+    }
+}
+
+impl JobV2 {
+    /// Walks this job's declared structure and returns the activity ids it can
+    /// dispatch, split into step targets and recovery hooks.
+    pub fn activity_roles(&self) -> JobActivityRoles {
+        let mut roles = JobActivityRoles::default();
+        insert_activity(&mut roles.recovery, self.recovery_activity.as_deref());
+        for step in &self.steps {
+            collect_step_roles(step, &mut roles);
+        }
+        roles
+    }
+}
+
+fn collect_step_roles(step: &JobV2Step, roles: &mut JobActivityRoles) {
+    insert_activity(&mut roles.recovery, step.recovery_activity.as_deref());
+    // The step id is what the job executor records for a dispatched step, so
+    // it belongs in the step set alongside the target's catalog name.
+    insert_activity(&mut roles.step, Some(step.id.as_str()));
+    match &step.body {
+        JobV2StepBody::Target(target) => {
+            insert_activity(&mut roles.step, target.activity_name.as_deref());
+        }
+        JobV2StepBody::TargetRef(reference) => {
+            insert_activity(&mut roles.step, Some(reference.target.as_str()));
+        }
+        JobV2StepBody::Parallel { parallel } => {
+            for branch in &parallel.branches {
+                collect_step_roles(branch, roles);
+            }
+        }
+        JobV2StepBody::FanOut { fan_out, .. } => collect_step_roles(&fan_out.worker, roles),
+        JobV2StepBody::Loop { loop_ } => {
+            for nested in &loop_.steps {
+                collect_step_roles(nested, roles);
+            }
+        }
+    }
+}
+
+/// Normalizes a declared reference to the bare activity id recorded on an
+/// invocation row. `target:` references carry the `activity:` namespace
+/// prefix; `recovery_activity` and a resolved `activity_name` do not.
+fn insert_activity(set: &mut BTreeSet<String>, raw: Option<&str>) {
+    let Some(raw) = raw else {
+        return;
+    };
+    let name = raw.strip_prefix(ACTIVITY_REF_PREFIX).unwrap_or(raw).trim();
+    if !name.is_empty() {
+        set.insert(name.to_string());
+    }
+}

--- a/crates/orbit-common/src/types/activity_job/mod.rs
+++ b/crates/orbit-common/src/types/activity_job/mod.rs
@@ -1,5 +1,6 @@
 //! Activity/job runtime types and schemaVersion 2 asset loaders.
 
+pub mod activity_roles;
 pub mod activity_v2;
 pub mod asset_loader;
 pub mod audit_envelope;
@@ -9,6 +10,7 @@ pub mod job_v2;
 pub mod schema_header;
 pub mod tool_allowlist;
 
+pub use activity_roles::JobActivityRoles;
 pub use activity_v2::{
     ActivityV2, ActivityV2Spec, AgentLoopSpec, AgentRole, Backend, DeterministicSpec, OnDenial,
     Provider, ProviderAlias, ProviderDeprecation, ProviderDiagnostic, ProviderEntryPoint,

--- a/crates/orbit-common/src/types/activity_job/tests/activity_roles.rs
+++ b/crates/orbit-common/src/types/activity_job/tests/activity_roles.rs
@@ -1,0 +1,180 @@
+//! [ORB-10588] Structural discovery of a job's step vs recovery activities.
+
+use super::super::job_v2::JobV2;
+
+fn job(yaml: &str) -> JobV2 {
+    serde_yaml::from_str::<JobV2>(yaml).expect("job should parse")
+}
+
+#[test]
+fn collects_job_level_recovery_and_flat_step_targets() {
+    let roles = job(r#"
+state: enabled
+recovery_activity: patch_up
+steps:
+  - id: build
+    target: activity:compile
+  - id: verify
+    target: activity:run_tests
+"#)
+    .activity_roles();
+
+    // Both identifiers a step invocation can be recorded under: the executor
+    // persists a dispatched step under its step id, the planning-duel runner
+    // under the activity name.
+    assert_eq!(
+        roles.step.iter().cloned().collect::<Vec<_>>(),
+        vec![
+            "build".to_string(),
+            "compile".to_string(),
+            "run_tests".to_string(),
+            "verify".to_string(),
+        ],
+        "the `activity:` namespace prefix must be stripped to match invocation rows"
+    );
+    assert_eq!(
+        roles.recovery.iter().cloned().collect::<Vec<_>>(),
+        vec!["patch_up".to_string()]
+    );
+}
+
+#[test]
+fn collects_step_level_recovery_at_every_nesting_depth() {
+    let roles = job(r#"
+state: enabled
+steps:
+  - id: outer
+    parallel:
+      join: { mode: all }
+      branches:
+        - id: branch_a
+          recovery_activity: branch_rescue
+          target: activity:branch_work
+  - id: spread
+    fan_out:
+      items: "{{ input.items }}"
+      worker:
+        id: worker
+        recovery_activity: worker_rescue
+        target: activity:worker_work
+    fan_in:
+      join: { mode: all }
+  - id: repeat
+    loop:
+      max_iterations: 3
+      steps:
+        - id: iteration
+          recovery_activity: loop_rescue
+          target: activity:loop_work
+"#)
+    .activity_roles();
+
+    for expected in [
+        // step ids, including the container steps
+        "outer",
+        "branch_a",
+        "spread",
+        "worker",
+        "repeat",
+        "iteration",
+        // target activity names
+        "branch_work",
+        "worker_work",
+        "loop_work",
+    ] {
+        assert!(
+            roles.step.contains(expected),
+            "nested parallel / fan_out / loop bodies must all be walked: missing {expected}"
+        );
+    }
+    assert_eq!(
+        roles.recovery.iter().cloned().collect::<Vec<_>>(),
+        vec![
+            "branch_rescue".to_string(),
+            "loop_rescue".to_string(),
+            "worker_rescue".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn an_activity_used_in_both_roles_is_reported_in_both_sets() {
+    // The store records only the activity id, so an invocation of a dual-role
+    // activity cannot be attributed structurally. Reporting it in both sets is
+    // what lets callers exclude it rather than guess.
+    let roles = job(r#"
+state: enabled
+steps:
+  - id: work
+    recovery_activity: shared
+    target: activity:shared
+"#)
+    .activity_roles();
+
+    assert!(roles.step.contains("shared"));
+    assert!(roles.recovery.contains("shared"));
+    assert!(
+        !roles.recovery_only().contains("shared"),
+        "a dual-role activity must not count as recovery-only"
+    );
+    assert!(
+        !roles.step_only().contains("shared"),
+        "a dual-role activity must not count as step-only"
+    );
+    // The step's own id is unambiguous and stays attributable.
+    assert!(roles.step_only().contains("work"));
+}
+
+#[test]
+fn merge_unions_roles_across_a_catalog() {
+    let mut roles = job(r#"
+state: enabled
+recovery_activity: rescue
+steps:
+  - id: one
+    target: activity:alpha
+"#)
+    .activity_roles();
+    roles.merge(
+        &job(r#"
+state: enabled
+steps:
+  - id: two
+    target: activity:beta
+"#)
+        .activity_roles(),
+    );
+
+    assert_eq!(
+        roles.step_only().into_iter().collect::<Vec<_>>(),
+        vec![
+            "alpha".to_string(),
+            "beta".to_string(),
+            "one".to_string(),
+            "two".to_string(),
+        ]
+    );
+    assert_eq!(
+        roles.recovery_only().into_iter().collect::<Vec<_>>(),
+        vec!["rescue".to_string()]
+    );
+}
+
+#[test]
+fn a_job_with_no_recovery_hook_yields_an_empty_recovery_set() {
+    // Distinguishes "recovery never fires" from "recovery is not configured";
+    // the caller renders the latter as not-applicable rather than as 0%.
+    let roles = job(r#"
+state: enabled
+steps:
+  - id: only
+    target: activity:alpha
+"#)
+    .activity_roles();
+
+    assert!(roles.recovery.is_empty());
+    assert_eq!(
+        roles.step_only().into_iter().collect::<Vec<_>>(),
+        vec!["alpha".to_string(), "only".to_string()]
+    );
+}

--- a/crates/orbit-common/src/types/activity_job/tests/mod.rs
+++ b/crates/orbit-common/src/types/activity_job/tests/mod.rs
@@ -1,3 +1,4 @@
+mod activity_roles;
 mod activity_v2;
 mod asset_loader;
 mod audit_envelope;

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -62,8 +62,8 @@ pub mod workspace;
 pub use activity_job::{
     AUDIT_ENVELOPE_SCHEMA_VERSION, ActivityAsset, ActivityV2, ActivityV2Spec, AgentLoopSpec,
     AssetLoadError, BackoffStrategy, BranchOutcome, DeterministicSpec, FanInSpec, FanOutBlock,
-    JobAsset, JobKind, JobV2, JobV2Step, JobV2StepBody, JoinMode, LoopBlock, OnDenial,
-    ParallelBlock, PipelineRef, RetrySpec, SchemaHeader, TargetStep, ToolAllowlistError,
+    JobActivityRoles, JobAsset, JobKind, JobV2, JobV2Step, JobV2StepBody, JoinMode, LoopBlock,
+    OnDenial, ParallelBlock, PipelineRef, RetrySpec, SchemaHeader, TargetStep, ToolAllowlistError,
     V2_TOOL_WILDCARD_ROOTS, V2AuditEnvelope, V2AuditEvent, V2AuditEventKind, load_activity_asset,
     load_job_asset, tool_allowed, validate_tool_allowlist,
 };

--- a/crates/orbit-core/src/metrics/mod.rs
+++ b/crates/orbit-core/src/metrics/mod.rs
@@ -11,6 +11,7 @@
 //! behavior the prior implementation produced for pack-less runs.
 
 mod ingest;
+pub mod reliability;
 mod summary;
 
 #[cfg(test)]

--- a/crates/orbit-core/src/metrics/reliability.rs
+++ b/crates/orbit-core/src/metrics/reliability.rs
@@ -1,0 +1,506 @@
+//! Pipeline-reliability aggregation over durable run state [ORB-10588].
+//!
+//! Answers two operator questions that were previously only reachable by
+//! opening SQLite by hand: how often job runs fail, and how often the recovery
+//! path fires.
+//!
+//! # Inputs
+//!
+//! Everything here derives from persisted `job_runs` and `invocations` rows.
+//! No agent-loop output, no token field, and no cost field is read — see
+//! [`orbit_store::JobRunOutcomeFact`] and
+//! [`orbit_store::ActivityInvocationCount`] for the projected column sets.
+//!
+//! # Outcome classification
+//!
+//! `job_runs.state` is not two-valued, so a "failure rate" has to say which
+//! states it counts. [`RunOutcome`] partitions the [`JobRunState`] variants:
+//!
+//! | outcome | states | in failure-rate denominator |
+//! |---|---|---|
+//! | [`RunOutcome::Succeeded`] | `success` | yes |
+//! | [`RunOutcome::Failed`] | `failed`, `timeout`, `interrupted` | yes |
+//! | [`RunOutcome::Cancelled`] | `cancelled` | no |
+//! | [`RunOutcome::Skipped`] | `skipped` | no |
+//! | [`RunOutcome::InFlight`] | `pending`, `running`, `retrying` | no |
+//! | [`RunOutcome::Unknown`] | any state this build cannot parse | no |
+//!
+//! `timeout` and `interrupted` count as failures: both are runs the pipeline
+//! intended to finish and did not. `interrupted` specifically means the owning
+//! process died without finalizing, which is a reliability event even though
+//! the run's checkpoints can seed a resumed follow-up. `cancelled` is a
+//! deliberate operator action, so counting it as a failure would make manual
+//! intervention look like breakage. `skipped` never ran.
+//!
+//! Because four of the six outcomes sit outside the denominator,
+//! `succeeded + failed` does **not** equal the run count in general. Callers
+//! render [`OutcomeCounts::settled`] as the `n` and report the excluded
+//! buckets separately; [`OutcomeCounts::total`] is kept so the gap is visible
+//! rather than implied away.
+//!
+//! # Recovery attribution
+//!
+//! Which activity performs recovery is a property of a workspace's job
+//! definitions, never of Orbit, so the recovery activity set is discovered by
+//! walking the job catalog ([`JobV2::activity_roles`]) at query time. An
+//! activity that a catalog uses in both roles is reported as ambiguous and
+//! excluded from the numerator, since its invocations cannot be attributed
+//! structurally.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use chrono::{DateTime, Duration, Utc};
+use serde::Serialize;
+
+use orbit_common::types::{JobActivityRoles, JobRunState, OrbitError};
+use orbit_store::{ActivityInvocationCount, InvocationRunCoverage, JobRunOutcomeFact};
+
+use crate::runtime::OrbitRuntime;
+
+/// Row cap for the per-run fact read backing the failure rate. Reaching it
+/// sets [`JobRunReliability::truncated`]; the cap is never applied silently.
+const MAX_JOB_RUN_FACTS: usize = 200_000;
+
+/// Denominator below which a rate is flagged [`Rate::low_sample`]. Callers
+/// mark or withhold such cells instead of rendering a confident percentage.
+pub const MIN_CONFIDENT_SAMPLE: u64 = 20;
+
+/// Bucket width for the over-time breakdown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BucketGranularity {
+    Hour,
+    Day,
+}
+
+impl BucketGranularity {
+    fn width(self) -> Duration {
+        match self {
+            Self::Hour => Duration::hours(1),
+            Self::Day => Duration::days(1),
+        }
+    }
+
+    /// Floors `at` to the start of its bucket.
+    fn floor(self, at: DateTime<Utc>) -> DateTime<Utc> {
+        let seconds = self.width().num_seconds().max(1);
+        let epoch = at.timestamp();
+        let floored = epoch.div_euclid(seconds) * seconds;
+        DateTime::from_timestamp(floored, 0).unwrap_or(at)
+    }
+}
+
+/// The explicit, half-open window (`since <= t < until`) every rate is scoped
+/// to. Carried through to the payload so no rate can be rendered without it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ReliabilityWindow {
+    /// Caller-supplied label for the window (e.g. `"7d"`), echoed to the UI.
+    pub label: String,
+    pub since: DateTime<Utc>,
+    pub until: DateTime<Utc>,
+    pub bucket: BucketGranularity,
+}
+
+impl ReliabilityWindow {
+    /// Builds a window ending at `until` and spanning `duration`, choosing a
+    /// bucket width that keeps the series legible.
+    pub fn ending_at(label: impl Into<String>, until: DateTime<Utc>, duration: Duration) -> Self {
+        let bucket = if duration <= Duration::days(2) {
+            BucketGranularity::Hour
+        } else {
+            BucketGranularity::Day
+        };
+        Self {
+            label: label.into(),
+            since: until - duration,
+            until,
+            bucket,
+        }
+    }
+}
+
+/// How a persisted `job_runs.state` is counted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunOutcome {
+    Succeeded,
+    Failed,
+    Cancelled,
+    Skipped,
+    InFlight,
+    Unknown,
+}
+
+impl RunOutcome {
+    /// Classifies a raw `job_runs.state` string.
+    ///
+    /// Parsing is deliberately tolerant: a state written by a newer binary
+    /// lands in [`RunOutcome::Unknown`] and stays visible in the counts rather
+    /// than being silently folded into success or failure.
+    pub fn classify(raw: &str) -> Self {
+        let Ok(state) = raw.parse::<JobRunState>() else {
+            return Self::Unknown;
+        };
+        match state {
+            JobRunState::Success => Self::Succeeded,
+            JobRunState::Failed | JobRunState::Timeout | JobRunState::Interrupted => Self::Failed,
+            JobRunState::Cancelled => Self::Cancelled,
+            JobRunState::Skipped => Self::Skipped,
+            JobRunState::Pending | JobRunState::Running | JobRunState::Retrying => Self::InFlight,
+        }
+    }
+}
+
+/// Run counts for one scope (overall, one job, or one time bucket).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct OutcomeCounts {
+    /// Every run in scope, including the ones outside the denominator.
+    pub total: u64,
+    pub succeeded: u64,
+    pub failed: u64,
+    pub cancelled: u64,
+    pub skipped: u64,
+    pub in_flight: u64,
+    pub unknown: u64,
+}
+
+impl OutcomeCounts {
+    fn record(&mut self, outcome: RunOutcome) {
+        self.total += 1;
+        match outcome {
+            RunOutcome::Succeeded => self.succeeded += 1,
+            RunOutcome::Failed => self.failed += 1,
+            RunOutcome::Cancelled => self.cancelled += 1,
+            RunOutcome::Skipped => self.skipped += 1,
+            RunOutcome::InFlight => self.in_flight += 1,
+            RunOutcome::Unknown => self.unknown += 1,
+        }
+    }
+
+    /// Runs that reached an outcome the failure rate is defined over.
+    ///
+    /// This is the rate's `n`. It is smaller than [`OutcomeCounts::total`]
+    /// whenever runs were cancelled, skipped, still in flight, or in a state
+    /// this build cannot parse.
+    pub fn settled(&self) -> u64 {
+        self.succeeded + self.failed
+    }
+
+    /// Runs excluded from the denominator, for the "not counted" disclosure.
+    pub fn excluded(&self) -> u64 {
+        self.cancelled + self.skipped + self.in_flight + self.unknown
+    }
+
+    /// Failure rate over settled runs, or `None` when nothing settled.
+    pub fn failure_rate(&self) -> Rate {
+        Rate::new(
+            self.failed,
+            self.settled(),
+            "settled runs (success + failed)",
+        )
+    }
+}
+
+/// A rate that carries its own denominator, so no surface can render the
+/// number without the `n` it was computed from.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Rate {
+    pub numerator: u64,
+    pub denominator: u64,
+    /// Human-readable description of what the denominator counts. Rendered
+    /// verbatim by the UI so the meaning never lives only in code.
+    pub denominator_label: String,
+    /// `numerator / denominator`, or `None` when the denominator is zero.
+    pub value: Option<f64>,
+    /// True when the denominator is below [`MIN_CONFIDENT_SAMPLE`]. Consumers
+    /// mark or withhold the percentage instead of presenting it as confident.
+    pub low_sample: bool,
+}
+
+impl Rate {
+    pub fn new(numerator: u64, denominator: u64, denominator_label: impl Into<String>) -> Self {
+        Self {
+            numerator,
+            denominator,
+            denominator_label: denominator_label.into(),
+            value: (denominator > 0).then(|| numerator as f64 / denominator as f64),
+            low_sample: denominator < MIN_CONFIDENT_SAMPLE,
+        }
+    }
+}
+
+/// Counts for one job id.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct JobOutcomeRow {
+    pub job_id: String,
+    #[serde(flatten)]
+    pub counts: OutcomeCounts,
+}
+
+/// Counts for one time bucket.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BucketOutcomeRow {
+    pub bucket_start: DateTime<Utc>,
+    pub bucket_end: DateTime<Utc>,
+    #[serde(flatten)]
+    pub counts: OutcomeCounts,
+}
+
+/// Job-run failure rate for one workspace over one window.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct JobRunReliability {
+    pub overall: OutcomeCounts,
+    /// Descending by run count, so the noisiest job leads.
+    pub by_job: Vec<JobOutcomeRow>,
+    /// Ascending by bucket start, with empty buckets present so a gap in
+    /// activity reads as a gap rather than as continuity.
+    pub over_time: Vec<BucketOutcomeRow>,
+    /// Every raw `job_runs.state` value observed in the window, with its
+    /// count. This is the evidence behind the classification table: an
+    /// operator can check what the store actually contains without querying
+    /// it, and an unrecognized state shows up here by name.
+    pub observed_states: BTreeMap<String, u64>,
+    /// True when the window held more runs than the read cap.
+    pub truncated: bool,
+}
+
+/// Recovery-path engagement for one workspace over one window.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RecoveryReliability {
+    /// Activities the job catalog names as `recovery_activity`, discovered at
+    /// query time. Empty when no job declares one — in which case the rate is
+    /// not applicable rather than zero.
+    pub recovery_activities: Vec<String>,
+    /// Activities the catalog uses as both a step target and a recovery hook.
+    /// Their invocations are excluded from the numerator because the store
+    /// does not record which role a given invocation played.
+    pub ambiguous_activities: Vec<String>,
+    /// Recovery invocations per invocation of a declared step activity. This
+    /// is the "how much extra work does recovery cost" reading.
+    pub per_step_invocation: Rate,
+    /// Share of job runs that recorded at least one invocation and had at
+    /// least one recovery invocation. This is the "how often does a run need
+    /// recovery at all" reading.
+    pub per_job_run: Rate,
+    /// Full per-activity invocation counts for the window, so the two rates
+    /// above can be audited against the rows they came from.
+    pub by_activity: Vec<ActivityCount>,
+}
+
+/// One activity's invocation counts, tagged with its discovered role.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ActivityCount {
+    pub activity_id: String,
+    pub invocation_count: u64,
+    pub job_run_count: u64,
+    pub role: ActivityRole,
+}
+
+/// The structural role a job catalog assigns an activity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivityRole {
+    /// Named only as a step target.
+    Step,
+    /// Named only as a `recovery_activity`.
+    Recovery,
+    /// Named in both roles; not attributable from the store alone.
+    Ambiguous,
+    /// Invoked but not named by any loaded job definition.
+    Unknown,
+}
+
+/// Both reliability readings for one workspace, plus the window they share.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RuntimeReliability {
+    pub window: ReliabilityWindow,
+    pub job_runs: JobRunReliability,
+    pub recovery: RecoveryReliability,
+}
+
+impl OrbitRuntime {
+    /// Computes job-run failure rate and recovery engagement for this
+    /// workspace over `window`, entirely from persisted store rows.
+    pub fn pipeline_reliability(
+        &self,
+        window: &ReliabilityWindow,
+    ) -> Result<RuntimeReliability, OrbitError> {
+        if window.since >= window.until {
+            return Err(OrbitError::InvalidInput(
+                "reliability window `since` must be earlier than `until`".to_string(),
+            ));
+        }
+        let workspace_id = self.workspace_id()?;
+        let store = self.sqlite_store()?;
+
+        let facts = store.list_job_run_outcome_facts(
+            &workspace_id,
+            window.since,
+            window.until,
+            MAX_JOB_RUN_FACTS,
+        )?;
+        let job_runs = aggregate_job_runs(&facts.facts, window, facts.truncated);
+
+        let counts =
+            store.count_invocations_by_activity(&workspace_id, window.since, window.until)?;
+        let roles = self.catalog_activity_roles()?;
+        // The distinct-run denominator has to come from the store: distinct
+        // counts do not sum across activities.
+        let recovery_ids = roles.recovery_only().into_iter().collect::<Vec<_>>();
+        let coverage = store.count_invocation_job_runs(
+            &workspace_id,
+            window.since,
+            window.until,
+            &recovery_ids,
+        )?;
+        let recovery = aggregate_recovery(&counts, &roles, coverage);
+
+        Ok(RuntimeReliability {
+            window: window.clone(),
+            job_runs,
+            recovery,
+        })
+    }
+
+    /// Unions the activity roles declared by every job in the catalog.
+    ///
+    /// Disabled jobs are included: a job disabled midway through the window
+    /// still produced the invocations being counted.
+    fn catalog_activity_roles(&self) -> Result<JobActivityRoles, OrbitError> {
+        use crate::command::job::JobCatalogFilter;
+
+        let mut roles = JobActivityRoles::default();
+        for (entry, _) in self.list_job_catalog_with_last_run(true, JobCatalogFilter::All)? {
+            roles.merge(&entry.spec.activity_roles());
+        }
+        Ok(roles)
+    }
+}
+
+/// Buckets and totals the per-run facts. Pure, so it is exercised directly by
+/// unit tests without a store.
+pub fn aggregate_job_runs(
+    facts: &[JobRunOutcomeFact],
+    window: &ReliabilityWindow,
+    truncated: bool,
+) -> JobRunReliability {
+    let mut overall = OutcomeCounts::default();
+    let mut by_job: BTreeMap<String, OutcomeCounts> = BTreeMap::new();
+    let mut by_bucket: BTreeMap<DateTime<Utc>, OutcomeCounts> = BTreeMap::new();
+    let mut observed_states: BTreeMap<String, u64> = BTreeMap::new();
+
+    for fact in facts {
+        let outcome = RunOutcome::classify(&fact.state);
+        overall.record(outcome);
+        by_job
+            .entry(fact.job_id.clone())
+            .or_default()
+            .record(outcome);
+        by_bucket
+            .entry(window.bucket.floor(fact.created_at))
+            .or_default()
+            .record(outcome);
+        *observed_states.entry(fact.state.clone()).or_default() += 1;
+    }
+
+    let mut job_rows = by_job
+        .into_iter()
+        .map(|(job_id, counts)| JobOutcomeRow { job_id, counts })
+        .collect::<Vec<_>>();
+    job_rows.sort_by(|left, right| {
+        right
+            .counts
+            .total
+            .cmp(&left.counts.total)
+            .then_with(|| left.job_id.cmp(&right.job_id))
+    });
+
+    JobRunReliability {
+        overall,
+        by_job: job_rows,
+        over_time: fill_buckets(window, &by_bucket),
+        observed_states,
+        truncated,
+    }
+}
+
+/// Materializes every bucket in the window, including empty ones, so the
+/// series cannot imply activity across a quiet stretch.
+fn fill_buckets(
+    window: &ReliabilityWindow,
+    observed: &BTreeMap<DateTime<Utc>, OutcomeCounts>,
+) -> Vec<BucketOutcomeRow> {
+    let width = window.bucket.width();
+    let mut rows = Vec::new();
+    let mut start = window.bucket.floor(window.since);
+    // A pathological window cannot outrun this: the loop advances by a fixed
+    // positive width and stops at `until`.
+    while start < window.until {
+        let end = start + width;
+        rows.push(BucketOutcomeRow {
+            bucket_start: start,
+            bucket_end: end,
+            counts: observed.get(&start).cloned().unwrap_or_default(),
+        });
+        start = end;
+    }
+    rows
+}
+
+/// Attributes invocation counts to discovered roles and derives both recovery
+/// rates. Pure, for the same reason as [`aggregate_job_runs`].
+pub fn aggregate_recovery(
+    counts: &[ActivityInvocationCount],
+    roles: &JobActivityRoles,
+    coverage: InvocationRunCoverage,
+) -> RecoveryReliability {
+    let recovery_only = roles.recovery_only();
+    let step_only = roles.step_only();
+    let ambiguous = roles
+        .recovery
+        .intersection(&roles.step)
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    let mut recovery_invocations = 0_u64;
+    let mut step_invocations = 0_u64;
+    let mut by_activity = Vec::with_capacity(counts.len());
+
+    for count in counts {
+        let role = if ambiguous.contains(&count.activity_id) {
+            ActivityRole::Ambiguous
+        } else if recovery_only.contains(&count.activity_id) {
+            ActivityRole::Recovery
+        } else if step_only.contains(&count.activity_id) {
+            ActivityRole::Step
+        } else {
+            ActivityRole::Unknown
+        };
+        match role {
+            ActivityRole::Recovery => recovery_invocations += count.invocation_count,
+            ActivityRole::Step => step_invocations += count.invocation_count,
+            ActivityRole::Ambiguous | ActivityRole::Unknown => {}
+        }
+        by_activity.push(ActivityCount {
+            activity_id: count.activity_id.clone(),
+            invocation_count: count.invocation_count,
+            job_run_count: count.job_run_count,
+            role,
+        });
+    }
+
+    RecoveryReliability {
+        recovery_activities: recovery_only.into_iter().collect(),
+        ambiguous_activities: ambiguous.into_iter().collect(),
+        per_step_invocation: Rate::new(
+            recovery_invocations,
+            step_invocations,
+            "step-activity invocations",
+        ),
+        per_job_run: Rate::new(
+            coverage.matching_job_runs,
+            coverage.total_job_runs,
+            "job runs with any recorded invocation",
+        ),
+        by_activity,
+    }
+}

--- a/crates/orbit-core/src/metrics/tests/mod.rs
+++ b/crates/orbit-core/src/metrics/tests/mod.rs
@@ -1,3 +1,4 @@
 #![allow(missing_docs)]
 
 mod ingest;
+mod reliability;

--- a/crates/orbit-core/src/metrics/tests/reliability.rs
+++ b/crates/orbit-core/src/metrics/tests/reliability.rs
@@ -1,0 +1,490 @@
+//! [ORB-10588] Pipeline-reliability aggregation.
+//!
+//! These cover the pure halves (`aggregate_job_runs` / `aggregate_recovery`),
+//! which is where every judgement call the task had to settle actually lives:
+//! which states count as failed, what the denominators are, and what happens
+//! when a denominator is empty or too small to trust.
+
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use orbit_common::types::JobActivityRoles;
+use orbit_store::{ActivityInvocationCount, InvocationRunCoverage, JobRunOutcomeFact};
+
+use crate::metrics::reliability::{
+    ActivityRole, BucketGranularity, MIN_CONFIDENT_SAMPLE, Rate, ReliabilityWindow,
+    aggregate_job_runs, aggregate_recovery,
+};
+
+fn at(hour: u32) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 8, 1, hour, 30, 0)
+        .single()
+        .expect("valid timestamp")
+}
+
+fn fact(job_id: &str, state: &str, hour: u32) -> JobRunOutcomeFact {
+    JobRunOutcomeFact {
+        job_id: job_id.to_string(),
+        state: state.to_string(),
+        created_at: at(hour),
+    }
+}
+
+fn hourly_window(from_hour: u32, to_hour: u32) -> ReliabilityWindow {
+    ReliabilityWindow {
+        label: format!("{}h", to_hour - from_hour),
+        since: Utc
+            .with_ymd_and_hms(2026, 8, 1, from_hour, 0, 0)
+            .single()
+            .expect("valid since"),
+        until: Utc
+            .with_ymd_and_hms(2026, 8, 1, to_hour, 0, 0)
+            .single()
+            .expect("valid until"),
+        bucket: BucketGranularity::Hour,
+    }
+}
+
+fn roles(step: &[&str], recovery: &[&str]) -> JobActivityRoles {
+    JobActivityRoles {
+        step: step.iter().map(|s| s.to_string()).collect(),
+        recovery: recovery.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+fn count(activity_id: &str, invocations: u64, runs: u64) -> ActivityInvocationCount {
+    ActivityInvocationCount {
+        activity_id: activity_id.to_string(),
+        invocation_count: invocations,
+        job_run_count: runs,
+    }
+}
+
+#[test]
+fn failed_timeout_and_interrupted_all_count_as_failures() {
+    // Derived from the state values the store actually holds: a run that timed
+    // out and a run whose owner died are both runs the pipeline meant to
+    // finish and did not.
+    let facts = vec![
+        fact("j", "success", 1),
+        fact("j", "failed", 1),
+        fact("j", "timeout", 1),
+        fact("j", "interrupted", 1),
+    ];
+    let result = aggregate_job_runs(&facts, &hourly_window(0, 3), false);
+
+    assert_eq!(result.overall.succeeded, 1);
+    assert_eq!(result.overall.failed, 3);
+    assert_eq!(result.overall.settled(), 4);
+    assert_eq!(result.overall.failure_rate().value, Some(0.75));
+}
+
+#[test]
+fn cancelled_skipped_and_in_flight_stay_out_of_the_denominator() {
+    let facts = vec![
+        fact("j", "success", 1),
+        fact("j", "failed", 1),
+        fact("j", "cancelled", 1),
+        fact("j", "skipped", 1),
+        fact("j", "running", 1),
+        fact("j", "pending", 1),
+        fact("j", "retrying", 1),
+    ];
+    let result = aggregate_job_runs(&facts, &hourly_window(0, 3), false);
+
+    assert_eq!(result.overall.total, 7);
+    assert_eq!(result.overall.settled(), 2, "only success + failed settle");
+    assert_eq!(result.overall.excluded(), 5);
+    assert_eq!(result.overall.cancelled, 1);
+    assert_eq!(result.overall.skipped, 1);
+    assert_eq!(result.overall.in_flight, 3);
+    // The whole point of the split: the two visible outcome counts must not be
+    // mistakable for the population.
+    assert_ne!(
+        result.overall.succeeded + result.overall.failed,
+        result.overall.total
+    );
+}
+
+#[test]
+fn an_unparseable_state_is_surfaced_rather_than_folded_into_an_outcome() {
+    let facts = vec![fact("j", "success", 1), fact("j", "quantum_superposed", 1)];
+    let result = aggregate_job_runs(&facts, &hourly_window(0, 3), false);
+
+    assert_eq!(result.overall.unknown, 1);
+    assert_eq!(result.overall.settled(), 1);
+    assert_eq!(
+        result.observed_states.get("quantum_superposed"),
+        Some(&1),
+        "the raw state value must remain visible as evidence"
+    );
+}
+
+#[test]
+fn observed_states_records_the_raw_store_values_behind_the_classification() {
+    let facts = vec![
+        fact("j", "success", 1),
+        fact("j", "success", 1),
+        fact("j", "interrupted", 1),
+    ];
+    let result = aggregate_job_runs(&facts, &hourly_window(0, 3), false);
+
+    assert_eq!(result.observed_states.get("success"), Some(&2));
+    assert_eq!(result.observed_states.get("interrupted"), Some(&1));
+    assert_eq!(result.observed_states.len(), 2);
+}
+
+#[test]
+fn a_zero_denominator_yields_no_percentage_at_all() {
+    // A window holding only in-flight runs has nothing to divide by; emitting
+    // 0% there would read as "nothing is failing".
+    let facts = vec![fact("j", "running", 1)];
+    let result = aggregate_job_runs(&facts, &hourly_window(0, 3), false);
+
+    let rate = result.overall.failure_rate();
+    assert_eq!(rate.denominator, 0);
+    assert_eq!(rate.value, None);
+    assert!(!rate.denominator_label.is_empty());
+}
+
+#[test]
+fn a_rate_below_the_confidence_threshold_is_flagged_low_sample() {
+    let small = Rate::new(1, MIN_CONFIDENT_SAMPLE - 1, "runs");
+    let large = Rate::new(1, MIN_CONFIDENT_SAMPLE, "runs");
+
+    assert!(small.low_sample, "a thin denominator must be marked");
+    assert!(!large.low_sample);
+    assert_eq!(large.denominator, MIN_CONFIDENT_SAMPLE);
+}
+
+#[test]
+fn breakdowns_split_by_job_and_by_time_bucket() {
+    let facts = vec![
+        fact("alpha", "failed", 1),
+        fact("alpha", "success", 1),
+        fact("beta", "success", 2),
+    ];
+    let result = aggregate_job_runs(&facts, &hourly_window(0, 4), false);
+
+    let alpha = result
+        .by_job
+        .iter()
+        .find(|row| row.job_id == "alpha")
+        .expect("alpha row");
+    assert_eq!(alpha.counts.failed, 1);
+    assert_eq!(alpha.counts.failure_rate().value, Some(0.5));
+
+    let bucket_1 = result
+        .over_time
+        .iter()
+        .find(|row| row.bucket_start.timestamp() == at(1).timestamp() - 30 * 60)
+        .expect("hour-1 bucket");
+    assert_eq!(bucket_1.counts.total, 2);
+    let bucket_2 = result
+        .over_time
+        .iter()
+        .find(|row| row.bucket_start.timestamp() == at(2).timestamp() - 30 * 60)
+        .expect("hour-2 bucket");
+    assert_eq!(bucket_2.counts.total, 1);
+}
+
+#[test]
+fn every_bucket_in_the_window_is_present_including_empty_ones() {
+    // A gap must render as a gap. Emitting only non-empty buckets would let a
+    // quiet stretch read as continuous activity.
+    let facts = vec![fact("j", "success", 0), fact("j", "success", 3)];
+    let result = aggregate_job_runs(&facts, &hourly_window(0, 4), false);
+
+    assert_eq!(result.over_time.len(), 4);
+    assert_eq!(result.over_time[1].counts.total, 0);
+    assert_eq!(result.over_time[2].counts.total, 0);
+    assert_eq!(result.over_time[0].counts.total, 1);
+    assert_eq!(result.over_time[3].counts.total, 1);
+}
+
+#[test]
+fn window_bucket_width_follows_the_window_length() {
+    let short = ReliabilityWindow::ending_at("24h", at(12), Duration::hours(24));
+    let long = ReliabilityWindow::ending_at("30d", at(12), Duration::days(30));
+
+    assert_eq!(short.bucket, BucketGranularity::Hour);
+    assert_eq!(long.bucket, BucketGranularity::Day);
+    assert_eq!(long.since, at(12) - Duration::days(30));
+}
+
+#[test]
+fn truncation_is_carried_through_rather_than_dropped() {
+    let result = aggregate_job_runs(&[fact("j", "success", 1)], &hourly_window(0, 3), true);
+    assert!(result.truncated);
+}
+
+#[test]
+fn recovery_rates_use_discovered_roles_and_state_their_denominators() {
+    let counts = vec![
+        count("implement", 100, 40),
+        count("rescue", 25, 20),
+        count("unrelated", 5, 5),
+    ];
+    let result = aggregate_recovery(
+        &counts,
+        &roles(&["implement"], &["rescue"]),
+        InvocationRunCoverage {
+            total_job_runs: 40,
+            matching_job_runs: 20,
+        },
+    );
+
+    assert_eq!(result.recovery_activities, vec!["rescue".to_string()]);
+    assert_eq!(result.per_step_invocation.numerator, 25);
+    assert_eq!(result.per_step_invocation.denominator, 100);
+    assert_eq!(result.per_step_invocation.value, Some(0.25));
+    assert_eq!(
+        result.per_step_invocation.denominator_label,
+        "step-activity invocations"
+    );
+    assert_eq!(result.per_job_run.value, Some(0.5));
+    assert_eq!(
+        result.per_job_run.denominator_label,
+        "job runs with any recorded invocation"
+    );
+}
+
+#[test]
+fn an_activity_no_job_declares_is_counted_but_attributed_to_neither_rate() {
+    let counts = vec![count("implement", 10, 5), count("mystery", 90, 5)];
+    let result = aggregate_recovery(
+        &counts,
+        &roles(&["implement"], &["rescue"]),
+        InvocationRunCoverage {
+            total_job_runs: 5,
+            matching_job_runs: 0,
+        },
+    );
+
+    let mystery = result
+        .by_activity
+        .iter()
+        .find(|row| row.activity_id == "mystery")
+        .expect("mystery row");
+    assert_eq!(mystery.role, ActivityRole::Unknown);
+    assert_eq!(
+        result.per_step_invocation.denominator, 10,
+        "an undeclared activity must not inflate the step denominator"
+    );
+    assert_eq!(result.per_step_invocation.numerator, 0);
+}
+
+#[test]
+fn a_dual_role_activity_is_excluded_from_the_numerator_and_flagged() {
+    let counts = vec![count("shared", 30, 10), count("implement", 60, 10)];
+    let result = aggregate_recovery(
+        &counts,
+        &roles(&["implement", "shared"], &["shared"]),
+        InvocationRunCoverage {
+            total_job_runs: 10,
+            matching_job_runs: 0,
+        },
+    );
+
+    assert_eq!(result.ambiguous_activities, vec!["shared".to_string()]);
+    assert!(result.recovery_activities.is_empty());
+    assert_eq!(
+        result.per_step_invocation.numerator, 0,
+        "an unattributable activity must not be counted as recovery"
+    );
+    assert_eq!(
+        result.per_step_invocation.denominator, 60,
+        "nor as a step activity"
+    );
+    let shared = result
+        .by_activity
+        .iter()
+        .find(|row| row.activity_id == "shared")
+        .expect("shared row");
+    assert_eq!(shared.role, ActivityRole::Ambiguous);
+}
+
+#[test]
+fn no_declared_recovery_activity_yields_an_empty_set_not_a_zero_rate() {
+    let result = aggregate_recovery(
+        &[count("implement", 50, 10)],
+        &roles(&["implement"], &[]),
+        InvocationRunCoverage {
+            total_job_runs: 10,
+            matching_job_runs: 0,
+        },
+    );
+
+    assert!(result.recovery_activities.is_empty());
+    assert_eq!(result.per_step_invocation.numerator, 0);
+    assert_eq!(result.per_step_invocation.denominator, 50);
+}
+
+/// End-to-end over a real runtime: catalog discovery, both store reads, and
+/// the aggregation wired together.
+///
+/// This is the test that pins the identifier contract. `invocations.activity_id`
+/// is *not* uniformly the catalog activity name — the job executor records a
+/// dispatched step under its **step id** and a recovery dispatch under the
+/// **recovery activity name**. Discovering only target activity names would
+/// leave every step invocation unattributed and collapse the recovery
+/// denominator to zero.
+mod end_to_end {
+    use chrono::{Duration, Utc};
+    use orbit_common::types::{InvocationTrace, JobRun, JobRunState};
+    use orbit_store::InvocationInsertParams;
+    use tempfile::tempdir;
+
+    use crate::OrbitRuntime;
+    use crate::metrics::reliability::{ActivityRole, ReliabilityWindow};
+
+    const JOB: &str = "reliability_pipeline";
+
+    fn runtime_with_job() -> (tempfile::TempDir, OrbitRuntime) {
+        let root = tempdir().expect("create tempdir");
+        let global_root = root.path().join("global");
+        let workspace_root = root.path().join("repo/.orbit");
+        std::fs::create_dir_all(&global_root).expect("create global root");
+        std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+
+        let jobs_dir = global_root.join("resources/jobs");
+        std::fs::create_dir_all(&jobs_dir).expect("create jobs dir");
+        // Mirrors the shipped pipeline shape: a nested step whose id differs
+        // from its target activity name, guarded by a recovery activity.
+        std::fs::write(
+            jobs_dir.join(format!("{JOB}.yaml")),
+            format!(
+                r#"schemaVersion: 2
+kind: Job
+metadata:
+  name: {JOB}
+spec:
+  state: enabled
+  kind: workflow
+  steps:
+    - id: work_bundle
+      loop:
+        max_iterations: 8
+        steps:
+          - id: do_one_unit
+            recovery_activity: rescue_the_step
+            spec:
+              type: deterministic
+              action: sleep
+              config: {{}}
+"#
+            ),
+        )
+        .expect("write job yaml");
+
+        let runtime =
+            OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+        (root, runtime)
+    }
+
+    fn seed_run(runtime: &OrbitRuntime, run_id: &str, state: JobRunState) {
+        let now = Utc::now();
+        let run = JobRun {
+            run_id: run_id.to_string(),
+            job_id: JOB.to_string(),
+            attempt: 1,
+            state,
+            scheduled_at: now,
+            started_at: Some(now),
+            finished_at: state.is_terminal().then_some(now),
+            duration_ms: state.is_terminal().then_some(0),
+            created_at: now,
+            pid: None,
+            pid_start_time: None,
+            input: None,
+            retry_source_run_id: None,
+            knowledge_metrics: None,
+            resolved_crew: None,
+            crew_model: None,
+            steps: Vec::new(),
+        };
+        let workspace_id = runtime.workspace_id().expect("workspace id");
+        runtime
+            .sqlite_store()
+            .expect("store")
+            .upsert_job_run_for_workspace(&workspace_id, &run, None)
+            .expect("insert run");
+    }
+
+    fn seed_invocation(runtime: &OrbitRuntime, run_id: &str, activity_id: &str) {
+        runtime
+            .insert_invocation_trace_record(&InvocationInsertParams {
+                job_run_id: run_id.to_string(),
+                activity_id: activity_id.to_string(),
+                agent: "agent".to_string(),
+                model: Some("model".to_string()),
+                slot: None,
+                task_ids: Vec::new(),
+                trace: InvocationTrace::default(),
+            })
+            .expect("insert invocation");
+    }
+
+    #[test]
+    fn step_invocations_recorded_under_their_step_id_are_attributed_as_step_work() {
+        let (_root, runtime) = runtime_with_job();
+        seed_run(&runtime, "jrun-1", JobRunState::Success);
+        seed_run(&runtime, "jrun-2", JobRunState::Failed);
+        // The executor writes the *step id*, not `sleep` or any target name.
+        seed_invocation(&runtime, "jrun-1", "do_one_unit");
+        seed_invocation(&runtime, "jrun-2", "do_one_unit");
+        seed_invocation(&runtime, "jrun-2", "do_one_unit");
+        // A recovery dispatch has no step, so it is written under the
+        // recovery activity's own name.
+        seed_invocation(&runtime, "jrun-2", "rescue_the_step");
+
+        let window = ReliabilityWindow::ending_at("24h", Utc::now(), Duration::hours(24));
+        let result = runtime
+            .pipeline_reliability(&window)
+            .expect("compute reliability");
+
+        assert_eq!(result.job_runs.overall.total, 2);
+        assert_eq!(result.job_runs.overall.failed, 1);
+        assert_eq!(result.job_runs.overall.failure_rate().denominator, 2);
+
+        let by_activity = &result.recovery.by_activity;
+        let step = by_activity
+            .iter()
+            .find(|row| row.activity_id == "do_one_unit")
+            .expect("step row");
+        assert_eq!(
+            step.role,
+            ActivityRole::Step,
+            "a step invocation recorded under its step id must not fall through to Unknown"
+        );
+        let recovery = by_activity
+            .iter()
+            .find(|row| row.activity_id == "rescue_the_step")
+            .expect("recovery row");
+        assert_eq!(recovery.role, ActivityRole::Recovery);
+
+        assert_eq!(
+            result.recovery.recovery_activities,
+            vec!["rescue_the_step".to_string()],
+            "the recovery activity must be discovered from the job catalog"
+        );
+        assert_eq!(result.recovery.per_step_invocation.numerator, 1);
+        assert_eq!(
+            result.recovery.per_step_invocation.denominator, 3,
+            "the step denominator must count the step-id invocations"
+        );
+        assert_eq!(result.recovery.per_job_run.numerator, 1);
+        assert_eq!(result.recovery.per_job_run.denominator, 2);
+    }
+
+    #[test]
+    fn a_window_with_since_at_or_after_until_is_rejected() {
+        let (_root, runtime) = runtime_with_job();
+        let now = Utc::now();
+        let window = ReliabilityWindow {
+            label: "bad".to_string(),
+            since: now,
+            until: now,
+            bucket: crate::metrics::reliability::BucketGranularity::Hour,
+        };
+        assert!(runtime.pipeline_reliability(&window).is_err());
+    }
+}

--- a/crates/orbit-dashboard/assets/dashboard/app.js
+++ b/crates/orbit-dashboard/assets/dashboard/app.js
@@ -5,6 +5,7 @@ import { el, statusPill, stateCell, fetchJson, listItems, requestJson, postJson,
 import { buildChips, cacheCrewPayload, copyTaskIdWithNotice, hasCrewOptions, openVisibleTask, renderTasks, setPinnedExternalTask, wireSearch } from './tasks.js';
 import { applyAuditHashQuery, buildAuditChips, buildAuditHash, fetchAndRenderAudit, fetchAndRenderPolicy, getActiveAuditSubtab, navigateToAuditExecution, renderAuditSummary, setActiveAuditSubtabFromButton, setAuditSubtab, syncAuditControls, wireAuditSearch, } from './audit.js';
 import { renderScoreboard } from './scoreboard.js';
+import { fetchAndRenderReliability, wireReliabilityWindowSelector } from './reliability.js';
 import { initLogTail, fitLogPanelToViewport } from './log-tail.js';
 import { renderDiagnostics, renderImplementOneCard as renderImplOne, } from './diagnostics.js';
 import { renderMarkdown } from './markdown.js';
@@ -160,6 +161,11 @@ function routerContext() {
     // callbacks (close over app.js scope)
     refreshDashboard,
     renderDiagnostics: () => renderDiagnostics(diagnosticsContext()),
+    // ORB-10588: Reliability aggregates server-side across workspaces, so a
+    // subtab switch can fetch straight away instead of waiting for the next
+    // refresh tick (and without the aggregate-view guard the other diagnostics
+    // fetches need).
+    fetchReliability: () => fetchAndRenderReliability().catch((e) => console.error("Failed to fetch reliability metrics", e)),
     fitLogPanelToViewport,
 
     // audit pass-throughs (re-exported here for router; imported at top of this file)
@@ -1374,6 +1380,16 @@ function activeRefreshJobs() {
     // implement_one) take the backend `Ws` extractor and 400 without a concrete
     // workspace — so in aggregate mode skip the whole tab and show placeholders
     // (subtab switches are likewise guarded in router.js setDiagSubtabImpl).
+    // ORB-10588: /api/metrics/reliability takes the whole DashboardState, not
+    // the `Ws` extractor, so it answers in aggregate mode too — it is fetched
+    // ahead of the guard below rather than being placeheld with the rest.
+    if (activeDiagSubtab === "reliability") {
+      jobs.push(
+        fetchAndRenderReliability()
+          .catch((e) => console.error("Failed to fetch reliability metrics", e))
+      );
+      return jobs;
+    }
     if (aggregate) {
       renderDiagnosticsPlaceholders();
       return jobs;
@@ -1639,6 +1655,7 @@ wireGlobalTaskResolver();
 buildAuditChips(auditContext());
 wireAuditSearch(auditContext());
 $("refresh-btn").addEventListener("click", refreshDashboard);
+wireReliabilityWindowSelector();
 
 initRuns(runsContext());
 initRunDetail(runDetailContext());

--- a/crates/orbit-dashboard/assets/dashboard/dashboard.css
+++ b/crates/orbit-dashboard/assets/dashboard/dashboard.css
@@ -3523,3 +3523,95 @@
       .log-foot .right { margin-left: auto; cursor: pointer; user-select: none; }
       .log-foot .right.on { color: var(--accent); }
 
+
+      /* ORB-10588 — pipeline reliability.
+         The colour rules here encode the display contract: a real reading is
+         plain, a low-`n` reading is dimmed and struck through with a dashed
+         border, and "no data" is neutral grey. A withheld rate must never be
+         able to pass for a confident one at a glance. */
+      .rel-summary {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+        gap: 10px;
+        padding: 14px 16px;
+        border-bottom: 1px solid var(--border);
+        background: var(--bg);
+      }
+      .rel-tile {
+        display: flex; flex-direction: column; gap: 4px;
+        background: var(--bg-elev);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 10px 12px;
+        min-width: 0;
+      }
+      .rel-tile-label {
+        font-family: var(--font-sans); font-size: 10px; font-weight: 600;
+        text-transform: uppercase; letter-spacing: 0.08em; color: var(--fg-dim);
+      }
+      .rel-tile-value {
+        font-family: var(--font-mono); font-size: 18px; color: var(--fg);
+      }
+      .rel-tile-hint {
+        font-family: var(--font-mono); font-size: 10px; color: var(--fg-dim);
+        overflow-wrap: anywhere;
+      }
+      .rel-rate {
+        font-family: var(--font-mono); font-size: 18px; color: var(--fg);
+      }
+      .rel-rate-low {
+        font-size: 12px; color: var(--fg-dim);
+        border: 1px dashed var(--border); border-radius: 3px;
+        padding: 1px 6px; align-self: flex-start;
+      }
+      .rel-rate-empty { font-size: 14px; color: var(--fg-dim); }
+      td .rel-rate { font-size: 12px; }
+      .rel-note {
+        margin: 0; padding: 10px 16px;
+        font-family: var(--font-mono); font-size: 11px; line-height: 1.5;
+        color: var(--fg-dim); border-bottom: 1px solid var(--border);
+      }
+      .rel-note-warn { color: var(--priority-medium); }
+      .rel-chart-wrap { padding: 14px 16px; background: var(--bg); }
+      .rel-chart-title {
+        font-family: var(--font-sans); font-size: 11px; font-weight: 600;
+        text-transform: uppercase; letter-spacing: 0.08em; color: var(--fg-dim);
+        margin-bottom: 10px;
+      }
+      .rel-chart {
+        display: flex; align-items: flex-end; gap: 2px;
+        height: 110px; padding: 6px 8px;
+        background: var(--bg-elev);
+        border: 1px solid var(--border); border-radius: 4px;
+        overflow-x: auto;
+      }
+      .rel-bar-slot {
+        flex: 1 1 auto; min-width: 4px; height: 100%;
+        display: flex; align-items: flex-end;
+      }
+      .rel-bar {
+        width: 100%; background: var(--state-failed); border-radius: 1px 1px 0 0;
+      }
+      /* A bucket whose settled count is below the confidence threshold is drawn
+         muted and hatched, so a 1-of-2 bucket cannot read as a real spike. */
+      .rel-bar-low {
+        background: repeating-linear-gradient(
+          45deg, var(--fg-dim), var(--fg-dim) 2px, transparent 2px, transparent 4px
+        );
+      }
+      .rel-bar-empty { background: var(--border); }
+      .rel-chart-axis {
+        margin-top: 6px;
+        font-family: var(--font-mono); font-size: 10px; color: var(--fg-dim);
+        display: flex; justify-content: space-between;
+      }
+      .rel-table { width: 100%; }
+      .rel-card .card-body { padding: 0; }
+      .rel-role {
+        font-family: var(--font-mono); font-size: 10px;
+        padding: 1px 6px; border-radius: 3px; border: 1px solid var(--border);
+      }
+      .rel-role-recovery { color: var(--state-failed); border-color: var(--state-failed); }
+      .rel-role-step { color: var(--state-success); border-color: var(--state-success); }
+      .rel-role-ambiguous { color: var(--priority-medium); border-color: var(--priority-medium); }
+      .rel-role-unknown { color: var(--fg-dim); }

--- a/crates/orbit-dashboard/assets/dashboard/index.html
+++ b/crates/orbit-dashboard/assets/dashboard/index.html
@@ -180,6 +180,7 @@
               <button class="subtab" data-subtab="runs" type="button">Recent Runs</button>
               <button class="subtab" data-subtab="metrics" type="button">Metrics</button>
               <button class="subtab" data-subtab="errors" type="button">Errors</button>
+              <button class="subtab" data-subtab="reliability" type="button">Reliability</button>
               <button class="subtab" data-subtab="scoreboard" type="button">Scoreboard</button>
             </nav>
             <div class="body scoreboard-table-wrap" id="diag-body" style="display: none;">
@@ -203,6 +204,47 @@
             </div>
           </section>
         </div>
+      </main>
+      <!-- ORB-10588: pipeline reliability. Like the scoreboard it replaces the
+           two-column diagnostics layout with its own full-width <main>. Every
+           rate rendered here states its window (panel header) and its n (in
+           the cell itself); small-n cells are withheld rather than rounded. -->
+      <main id="diagnostics-reliability-main" style="grid-template-columns: 1fr; display: none;">
+        <section class="panel" id="reliability-panel">
+          <header>
+            <span>Pipeline Reliability</span>
+            <span class="count" id="reliability-count">-</span>
+          </header>
+          <div class="scoreboard-controls" id="reliability-controls">
+            <div class="scoreboard-control-group">
+              <span class="scoreboard-control-label">window</span>
+              <span class="scoreboard-window-selector" id="reliability-window-selector" title="window scope">
+                <span class="scoreboard-window-seg" data-window="1h">1h</span>
+                <span class="scoreboard-window-seg" data-window="24h">24h</span>
+                <span class="scoreboard-window-seg on" data-window="7d">7d</span>
+                <span class="scoreboard-window-seg" data-window="30d">30d</span>
+              </span>
+            </div>
+            <span class="scoreboard-controls-spacer"></span>
+            <span class="scoreboard-controls-meta" id="reliability-meta">-</span>
+          </div>
+          <div class="rel-summary" id="reliability-summary"></div>
+          <p class="rel-note" id="reliability-denominator-note"></p>
+          <p class="rel-note rel-note-warn" id="reliability-truncation-note" style="display: none;"></p>
+          <div class="rel-chart-wrap">
+            <div class="rel-chart-title">Job-run failure rate over time</div>
+            <div class="rel-chart" id="reliability-over-time"></div>
+            <div class="rel-chart-axis" id="reliability-over-time-axis"></div>
+          </div>
+        </section>
+        <section class="panel" id="reliability-breakdown-panel">
+          <header><span>Attribution</span></header>
+          <div class="body" id="reliability-breakdown" style="padding: 16px; display: flex; flex-direction: column; gap: 16px; overflow-y: auto; background: var(--bg);"></div>
+        </section>
+        <section class="panel" id="reliability-activities-panel">
+          <header><span>Recovery Evidence</span></header>
+          <div class="body" id="reliability-activities" style="padding: 16px; display: flex; flex-direction: column; gap: 16px; overflow-y: auto; background: var(--bg);"></div>
+        </section>
       </main>
       <!-- Scoreboard is a diagnostics-shaped view, so it lives under the
            Diagnostics tab as a subtab rather than a top-level nav entry. Its

--- a/crates/orbit-dashboard/assets/dashboard/reliability.js
+++ b/crates/orbit-dashboard/assets/dashboard/reliability.js
@@ -1,0 +1,453 @@
+// Orbit dashboard pipeline-reliability rendering [ORB-10588].
+// Pure vanilla JS, split into ES modules with no build step.
+//
+// Renders `GET /api/metrics/reliability`: job-run failure rate and recovery
+// invocation rate, both computed server-side from durable `job_runs` /
+// `invocations` rows. Nothing here derives from tokens or cost.
+//
+// Two display rules are load-bearing and apply to every rate on this view:
+//
+//   1. A percentage is never shown without its denominator and its window.
+//      `fmtRate` renders "12.5% (n=48)" and the panel header states the
+//      window, so a number can't be read out of context.
+//   2. A rate whose denominator is below the server's confidence threshold
+//      (`low_sample`, set in orbit-core) is withheld — the cell shows the raw
+//      counts and an "n too small" marker instead of a percentage.
+//
+// The server also reports which run states it counted. `succeeded + failed`
+// is smaller than the run total whenever runs were cancelled, skipped, or are
+// still in flight, so the summary spells out the excluded bucket rather than
+// letting the two visible numbers imply they add up.
+
+import { el, syncNodes, fetchJson } from './common.js';
+
+const $ = (id) => document.getElementById(id);
+
+// Mirrors the windows the endpoint accepts. `all` is deliberately absent:
+// a failure rate with no time range is not actionable.
+const RELIABILITY_WINDOWS = ["1h", "24h", "7d", "30d"];
+const DEFAULT_RELIABILITY_WINDOW = "7d";
+
+let activeWindow = DEFAULT_RELIABILITY_WINDOW;
+
+function getReliabilityWindow() {
+  return activeWindow;
+}
+
+const pctFormatter = new Intl.NumberFormat("en-US", {
+  style: "percent",
+  maximumFractionDigits: 1,
+});
+
+function num(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+/// Renders a `Rate` from the API. Returns display text plus the CSS modifier
+/// the caller applies, so withheld and low-confidence cells are visually
+/// distinct from a real reading.
+function describeRate(rate) {
+  if (!rate || num(rate.denominator) === 0) {
+    return {
+      text: "n/a",
+      cls: "rel-rate rel-rate-empty",
+      title: rate
+        ? `no ${rate.denominator_label} in this window`
+        : "no data",
+    };
+  }
+  const n = num(rate.denominator);
+  const detail = `${num(rate.numerator)} / ${n} ${rate.denominator_label}`;
+  if (rate.low_sample) {
+    // Withheld, not rounded: a 1-in-3 sample rendered as "33%" reads far more
+    // confident than the evidence supports.
+    return {
+      text: `${num(rate.numerator)}/${n} · n too small`,
+      cls: "rel-rate rel-rate-low",
+      title: `${detail} — below the confidence threshold, percentage withheld`,
+    };
+  }
+  return {
+    text: `${pctFormatter.format(num(rate.value))} (n=${n})`,
+    cls: "rel-rate",
+    title: detail,
+  };
+}
+
+function rateCell(rate, extraClass = "") {
+  const described = describeRate(rate);
+  const node = el("span", {
+    class: `${described.cls} ${extraClass}`.trim(),
+    text: described.text,
+    title: described.title,
+  });
+  return node;
+}
+
+function fmtWindowRange(window) {
+  if (!window) return "";
+  const since = new Date(window.since);
+  const until = new Date(window.until);
+  if (Number.isNaN(since.getTime()) || Number.isNaN(until.getTime())) return "";
+  const opts = { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" };
+  return `${since.toLocaleString(undefined, opts)} → ${until.toLocaleString(undefined, opts)} UTC${
+    window.bucket ? ` · ${window.bucket} buckets` : ""
+  }`;
+}
+
+function statTile(label, value, hint) {
+  return el("div", { class: "rel-tile" }, [
+    el("span", { class: "rel-tile-label", text: label }),
+    typeof value === "string" ? el("span", { class: "rel-tile-value", text: value }) : value,
+    hint ? el("span", { class: "rel-tile-hint", text: hint }) : null,
+  ]);
+}
+
+/// The headline block: both rates, each with its `n`, plus the explicit
+/// statement of what the failure-rate denominator excludes.
+function renderSummary(payload) {
+  const host = $("reliability-summary");
+  if (!host) return;
+  const totals = payload.totals || {};
+  const runs = totals.job_runs || {};
+  const counts = runs.counts || {};
+  const recovery = totals.recovery || {};
+
+  const settled = num(counts.succeeded) + num(counts.failed);
+  const excluded =
+    num(counts.cancelled) + num(counts.skipped) + num(counts.in_flight) + num(counts.unknown);
+
+  const tiles = [
+    statTile(
+      "Job-run failure rate",
+      rateCell(runs.failure_rate),
+      `${num(counts.failed)} failed of ${settled} settled runs`,
+    ),
+    statTile(
+      "Recovery per step invocation",
+      rateCell(recovery.per_step_invocation),
+      recovery.per_step_invocation
+        ? `denominator: ${recovery.per_step_invocation.denominator_label}`
+        : "",
+    ),
+    statTile(
+      "Job runs needing recovery",
+      rateCell(recovery.per_job_run),
+      recovery.per_job_run
+        ? `denominator: ${recovery.per_job_run.denominator_label}`
+        : "",
+    ),
+    statTile(
+      "Runs in window",
+      String(num(counts.total)),
+      `${settled} settled · ${excluded} not counted`,
+    ),
+  ];
+
+  const nodes = tiles.map((tile, index) => {
+    tile.dataset.key = `rel-tile-${index}`;
+    tile.dataset.hash = tile.textContent;
+    return tile;
+  });
+  syncNodes(host, nodes);
+
+  const note = $("reliability-denominator-note");
+  if (note) {
+    // States that are terminal-but-not-an-outcome, or not terminal at all, sit
+    // outside the rate. Saying so here is what keeps "success + failed" from
+    // reading as the whole population.
+    note.textContent =
+      excluded > 0
+        ? `Failure rate is over settled runs only (success + failed = ${settled}). ` +
+          `${excluded} further run(s) in this window were cancelled, skipped, still in flight, ` +
+          `or in an unrecognized state and are excluded from the denominator.`
+        : `Failure rate is over settled runs only (success + failed = ${settled}). ` +
+          `No cancelled, skipped, in-flight, or unrecognized runs in this window.`;
+  }
+
+  const truncNote = $("reliability-truncation-note");
+  if (truncNote) {
+    truncNote.style.display = runs.truncated ? "" : "none";
+    truncNote.textContent = runs.truncated
+      ? "Window exceeded the per-read row cap; older runs in this window are not included in these counts."
+      : "";
+  }
+}
+
+function tableFrom(columns, rows, keyFn) {
+  const table = el("table", { class: "scoreboard-table rel-table" });
+  const thead = el("thead");
+  const headRow = el("tr");
+  for (const col of columns) {
+    headRow.appendChild(el("th", { class: col.num ? "num" : "", text: col.label }));
+  }
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const tbody = el("tbody");
+  for (const row of rows) {
+    const tr = el("tr");
+    for (const col of columns) {
+      const td = el("td", { class: col.num ? "num" : "" });
+      const rendered = col.render(row);
+      if (typeof rendered === "string") {
+        td.textContent = rendered;
+      } else if (rendered) {
+        td.appendChild(rendered);
+      }
+      tr.appendChild(td);
+    }
+    tr.dataset.key = keyFn(row);
+    tr.dataset.hash = tr.textContent;
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  return table;
+}
+
+function emptyState(text) {
+  const node = el("div", { class: "empty-state" }, [
+    el("div", { class: "icon", text: "✧" }),
+    el("div", { class: "text", text }),
+  ]);
+  node.dataset.key = "empty";
+  node.dataset.hash = text;
+  return node;
+}
+
+/// Failure rate broken out by workspace and by job — the two axes that make a
+/// spike attributable rather than merely alarming.
+function renderBreakdown(payload) {
+  const host = $("reliability-breakdown");
+  if (!host) return;
+  const workspaces = payload.workspaces || [];
+  if (workspaces.length === 0) {
+    syncNodes(host, [emptyState("No job runs in this window.")]);
+    return;
+  }
+
+  const cards = [];
+  const wsRows = workspaces.map((ws) => ({
+    key: ws.workspace_id,
+    label: ws.workspace_name || ws.workspace_id,
+    counts: (ws.job_runs || {}).counts || {},
+    rate: (ws.job_runs || {}).failure_rate,
+  }));
+  cards.push(
+    card("Failure rate by workspace", tableFrom(
+      [
+        { label: "workspace", render: (r) => r.label },
+        { label: "runs", num: true, render: (r) => String(num(r.counts.total)) },
+        { label: "settled", num: true, render: (r) => String(num(r.counts.succeeded) + num(r.counts.failed)) },
+        { label: "failed", num: true, render: (r) => String(num(r.counts.failed)) },
+        { label: "failure rate", num: true, render: (r) => rateCell(r.rate) },
+      ],
+      wsRows,
+      (r) => `ws-${r.key}`,
+    ), "rel-card-workspaces"),
+  );
+
+  // Jobs are flattened across workspaces and tagged, so the worst job leads
+  // regardless of which workspace it belongs to.
+  const jobRows = [];
+  for (const ws of workspaces) {
+    for (const job of (ws.job_runs || {}).by_job || []) {
+      jobRows.push({
+        key: `${ws.workspace_id}::${job.job_id}`,
+        job_id: job.job_id,
+        workspace: ws.workspace_name || ws.workspace_id,
+        counts: job.counts || {},
+        rate: job.failure_rate,
+      });
+    }
+  }
+  jobRows.sort((a, b) => num(b.counts.failed) - num(a.counts.failed) || num(b.counts.total) - num(a.counts.total));
+  cards.push(
+    card("Failure rate by job", jobRows.length
+      ? tableFrom(
+          [
+            { label: "job", render: (r) => r.job_id },
+            { label: "workspace", render: (r) => r.workspace },
+            { label: "runs", num: true, render: (r) => String(num(r.counts.total)) },
+            { label: "failed", num: true, render: (r) => String(num(r.counts.failed)) },
+            { label: "failure rate", num: true, render: (r) => rateCell(r.rate) },
+          ],
+          jobRows,
+          (r) => `job-${r.key}`,
+        )
+      : emptyState("No job runs in this window."),
+      "rel-card-jobs"),
+  );
+
+  syncNodes(host, cards);
+}
+
+function card(title, body, key) {
+  const node = el("div", { class: "audit-summary-card rel-card" }, [
+    el("div", { class: "card-title", text: title }),
+    el("div", { class: "card-body" }, [body]),
+  ]);
+  node.dataset.key = key;
+  node.dataset.hash = node.textContent;
+  return node;
+}
+
+/// The over-time series. Each bar carries its own `n` in the tooltip, and a
+/// bucket whose denominator is too small is drawn as a muted "low n" bar
+/// rather than as a tall confident spike.
+function renderOverTime(payload) {
+  const host = $("reliability-over-time");
+  if (!host) return;
+  const workspaces = payload.workspaces || [];
+
+  // Sum buckets across workspaces by start time so the series is machine-wide.
+  const merged = new Map();
+  for (const ws of workspaces) {
+    for (const bucket of (ws.job_runs || {}).over_time || []) {
+      const existing = merged.get(bucket.bucket_start) || {
+        bucket_start: bucket.bucket_start,
+        succeeded: 0,
+        failed: 0,
+        total: 0,
+      };
+      existing.succeeded += num((bucket.counts || {}).succeeded);
+      existing.failed += num((bucket.counts || {}).failed);
+      existing.total += num((bucket.counts || {}).total);
+      merged.set(bucket.bucket_start, existing);
+    }
+  }
+  const series = Array.from(merged.values()).sort((a, b) =>
+    a.bucket_start < b.bucket_start ? -1 : a.bucket_start > b.bucket_start ? 1 : 0,
+  );
+
+  if (series.length === 0) {
+    syncNodes(host, [emptyState("No job runs in this window.")]);
+    return;
+  }
+
+  const bars = series.map((point, index) => {
+    const settled = point.succeeded + point.failed;
+    const rate = settled > 0 ? point.failed / settled : null;
+    const lowSample = settled > 0 && settled < 20;
+    const bar = el("div", { class: "rel-bar-slot" });
+    const fill = el("div", {
+      class: `rel-bar${rate == null ? " rel-bar-empty" : lowSample ? " rel-bar-low" : ""}`,
+    });
+    // A bucket with no settled runs gets a hairline, not a zero-height bar
+    // that would read identically to a clean 0% bucket.
+    fill.style.height = rate == null ? "2px" : `${Math.max(2, rate * 100)}%`;
+    bar.appendChild(fill);
+    bar.title =
+      rate == null
+        ? `${new Date(point.bucket_start).toLocaleString()} — no settled runs (n=0)`
+        : `${new Date(point.bucket_start).toLocaleString()} — ${pctFormatter.format(rate)} failed` +
+          ` (${point.failed}/${settled} settled${lowSample ? ", n too small to be confident" : ""})`;
+    bar.dataset.key = `bucket-${point.bucket_start}`;
+    bar.dataset.hash = `${point.failed}-${settled}`;
+    return bar;
+  });
+
+  syncNodes(host, bars);
+  const axis = $("reliability-over-time-axis");
+  if (axis && series.length > 0) {
+    axis.textContent = `${new Date(series[0].bucket_start).toLocaleString()} → ${new Date(
+      series[series.length - 1].bucket_start,
+    ).toLocaleString()}`;
+  }
+}
+
+/// Per-activity invocation counts with the role each activity was discovered
+/// to play. This is the audit trail for the recovery rate: the numerator's
+/// membership is visible, not asserted.
+function renderActivities(payload) {
+  const host = $("reliability-activities");
+  if (!host) return;
+  const rows = [];
+  for (const ws of payload.workspaces || []) {
+    for (const activity of (ws.recovery || {}).by_activity || []) {
+      rows.push({
+        key: `${ws.workspace_id}::${activity.activity_id}`,
+        activity_id: activity.activity_id,
+        workspace: ws.workspace_name || ws.workspace_id,
+        invocation_count: num(activity.invocation_count),
+        job_run_count: num(activity.job_run_count),
+        role: activity.role || "unknown",
+      });
+    }
+  }
+  rows.sort((a, b) => b.invocation_count - a.invocation_count);
+
+  if (rows.length === 0) {
+    syncNodes(host, [emptyState("No invocations recorded in this window.")]);
+    return;
+  }
+
+  syncNodes(host, [
+    card("Invocations by activity and discovered role", tableFrom(
+      [
+        { label: "activity", render: (r) => r.activity_id },
+        { label: "role", render: (r) => el("span", { class: `rel-role rel-role-${r.role}`, text: r.role }) },
+        { label: "workspace", render: (r) => r.workspace },
+        { label: "invocations", num: true, render: (r) => String(r.invocation_count) },
+        { label: "runs touched", num: true, render: (r) => String(r.job_run_count) },
+      ],
+      rows,
+      (r) => `act-${r.key}`,
+    ), "rel-card-activities"),
+  ]);
+}
+
+function renderReliability(payload) {
+  if (!payload) return;
+  const meta = $("reliability-meta");
+  if (meta) {
+    const range = fmtWindowRange(payload.window);
+    const unreadable = (payload.unreadable_workspaces || []).length;
+    meta.textContent = range + (unreadable ? ` · ${unreadable} workspace(s) unreadable` : "");
+  }
+  const count = $("reliability-count");
+  if (count) {
+    const total = num(((payload.totals || {}).job_runs || {}).counts?.total);
+    count.textContent = `${total} runs / ${(payload.window || {}).label || ""}`;
+  }
+  renderSummary(payload);
+  renderOverTime(payload);
+  renderBreakdown(payload);
+  renderActivities(payload);
+}
+
+function fetchAndRenderReliability() {
+  return fetchJson(`/api/metrics/reliability?window=${encodeURIComponent(activeWindow)}`)
+    .then(renderReliability);
+}
+
+// Idempotent attach, matching the scoreboard selector's contract.
+function wireReliabilityWindowSelector() {
+  const selector = $("reliability-window-selector");
+  if (!selector || selector.dataset.wired === "true") return;
+  selector.dataset.wired = "true";
+  selector.addEventListener("click", (event) => {
+    const seg = event.target && event.target.closest(".scoreboard-window-seg");
+    if (!seg || !selector.contains(seg)) return;
+    const next = seg.dataset.window;
+    if (!RELIABILITY_WINDOWS.includes(next) || seg.classList.contains("on")) return;
+    for (const peer of selector.querySelectorAll(".scoreboard-window-seg")) {
+      peer.classList.remove("on");
+    }
+    seg.classList.add("on");
+    activeWindow = next;
+    fetchAndRenderReliability().catch((err) => {
+      console.error("reliability window refetch failed:", err);
+    });
+  });
+}
+
+export {
+  renderReliability,
+  fetchAndRenderReliability,
+  wireReliabilityWindowSelector,
+  getReliabilityWindow,
+  describeRate,
+  RELIABILITY_WINDOWS,
+  DEFAULT_RELIABILITY_WINDOW,
+};

--- a/crates/orbit-dashboard/assets/dashboard/router.js
+++ b/crates/orbit-dashboard/assets/dashboard/router.js
@@ -26,7 +26,13 @@ const $ = (id) => document.getElementById(id);
 // `run-detail` route. A deprecated tab was retired outright and `scoreboard`,
 // being diagnostics-shaped, now routes as `#diagnostics/scoreboard`.
 const TABS = ["tasks", "audit", "diagnostics", "knowledge", "run-detail"];
-const DIAG_SUBTABS = ["runs", "metrics", "errors", "scoreboard"];
+const DIAG_SUBTABS = ["runs", "metrics", "errors", "reliability", "scoreboard"];
+// ORB-10444/ORB-10588: subtabs that replace the two-column diagnostics layout
+// with their own full-width <main>, keyed by the element they reveal.
+const DIAG_FULL_WIDTH_MAINS = {
+  scoreboard: "diagnostics-scoreboard-main",
+  reliability: "diagnostics-reliability-main",
+};
 const RUN_DETAIL_SUBTABS = ["steps", "events"];
 const KNOWLEDGE_SUBTABS = ["learnings", "adrs", "frictions"];
 
@@ -74,24 +80,32 @@ function setDiagSubtabImpl(ctx, name) {
     subIndicator.style.left = `${activeBtn.offsetLeft}px`;
   }
 
-  // ORB-10444: Scoreboard is a diagnostics subtab. It renders into its own
-  // full-width <main>, so the two-column diagnostics layout (list + summary
-  // side card) is swapped out for it while the subtab nav stays reachable.
-  const scoreboardActive = name === "scoreboard";
-  const scoreboardMain = $("diagnostics-scoreboard-main");
+  // ORB-10444/ORB-10588: Scoreboard and Reliability are diagnostics subtabs
+  // that render into their own full-width <main>, so the two-column
+  // diagnostics layout (list + summary side card) is swapped out for them
+  // while the subtab nav stays reachable.
+  const fullWidthMain = DIAG_FULL_WIDTH_MAINS[name];
   const sideCol = $("diagnostics-side-col");
   const diagMain = $("diagnostics-main");
-  if (scoreboardMain) scoreboardMain.style.display = scoreboardActive ? "grid" : "none";
-  if (sideCol) sideCol.style.display = scoreboardActive ? "none" : "flex";
+  for (const [subtab, mainId] of Object.entries(DIAG_FULL_WIDTH_MAINS)) {
+    const node = $(mainId);
+    if (node) node.style.display = subtab === name ? "grid" : "none";
+  }
+  if (sideCol) sideCol.style.display = fullWidthMain ? "none" : "flex";
   if (diagMain) {
-    diagMain.style.gridTemplateColumns = scoreboardActive
+    diagMain.style.gridTemplateColumns = fullWidthMain
       ? "minmax(0, 1fr)"
       : "minmax(0, 2fr) minmax(280px, 1.15fr)";
   }
-  if (scoreboardActive) {
+  if (fullWidthMain) {
     $("diag-body").style.display = "none";
     $("runs-body").style.display = "none";
-    if (isAggregateView()) renderPanelPlaceholder("scoreboard-body");
+    // Reliability aggregates across workspaces server-side, so it stays live
+    // in the aggregate view; the scoreboard is per-workspace and does not.
+    if (name === "scoreboard" && isAggregateView()) renderPanelPlaceholder("scoreboard-body");
+    if (name === "reliability" && ctx.fetchReliability) {
+      ctx.fetchReliability();
+    }
     return;
   }
 

--- a/crates/orbit-dashboard/src/api/mod.rs
+++ b/crates/orbit-dashboard/src/api/mod.rs
@@ -29,6 +29,7 @@ mod jobs;
 mod learnings;
 mod log;
 mod metrics;
+mod reliability;
 mod routines;
 mod runs;
 mod scoreboard;
@@ -422,6 +423,10 @@ pub(super) fn router() -> Router<crate::state::DashboardState> {
         .route("/metrics/tools", get(metrics::tool_metrics))
         .route("/metrics/task/:id", get(metrics::task_metrics))
         .route("/metrics/orchestrators", get(metrics::orchestrator_metrics))
+        .route(
+            "/metrics/reliability",
+            get(reliability::pipeline_reliability),
+        )
         .route(
             "/metrics/invocations",
             get(metrics::invocation_metrics).post(metrics::ingest_invocation),

--- a/crates/orbit-dashboard/src/api/reliability.rs
+++ b/crates/orbit-dashboard/src/api/reliability.rs
@@ -1,0 +1,192 @@
+//! `GET /api/metrics/reliability` — pipeline reliability across workspaces
+//! [ORB-10588].
+//!
+//! Reports two rates the dashboard previously could not answer at all: how
+//! often job runs fail, and how often the recovery path fires. Both come from
+//! [`OrbitRuntime::pipeline_reliability`], which reads only persisted
+//! `job_runs` / `invocations` rows — no token or cost field is on the path.
+//!
+//! This handler takes the whole [`DashboardState`] rather than the [`Ws`]
+//! extractor, following [`super::workspaces`]: a failure spike is only
+//! attributable if the operator can see which workspace it came from. Each
+//! workspace is reported separately and a `totals` block sums the counts;
+//! rates in `totals` are recomputed from the summed counts rather than
+//! averaged, so a small workspace cannot skew the headline.
+//!
+//! [`Ws`]: crate::state::Ws
+//! [`OrbitRuntime::pipeline_reliability`]: orbit_core::OrbitRuntime::pipeline_reliability
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Json, Response};
+use chrono::Utc;
+use orbit_core::metrics::reliability::{
+    BucketOutcomeRow, JobOutcomeRow, OutcomeCounts, Rate, ReliabilityWindow, RuntimeReliability,
+};
+use orbit_core::scoreboard_summary::ScoreboardWindow;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::server_error;
+use crate::state::DashboardState;
+
+/// Window used when `?window=` is omitted. Long enough that the rates carry a
+/// usable `n` on a typical workspace, short enough to still be a current
+/// reading rather than a lifetime average.
+const DEFAULT_RELIABILITY_WINDOW: ScoreboardWindow = ScoreboardWindow::Week;
+
+/// `?window=<1h|24h|7d|30d>`.
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct ReliabilityQuery {
+    #[serde(default)]
+    window: Option<String>,
+}
+
+pub(super) async fn pipeline_reliability(
+    State(state): State<DashboardState>,
+    Query(query): Query<ReliabilityQuery>,
+) -> Response {
+    let window = match resolve_window(query.window.as_deref()) {
+        Ok(window) => window,
+        Err(message) => {
+            return (StatusCode::BAD_REQUEST, Json(json!({ "error": message }))).into_response();
+        }
+    };
+
+    // Pin one snapshot so every workspace's reliability and its name/id tag
+    // come from the same registry generation.
+    let pinned = state.pin();
+    let mut workspaces = Vec::new();
+    let mut totals = OutcomeCounts::default();
+    let mut recovery_numerator = 0_u64;
+    let mut recovery_denominator = 0_u64;
+    let mut runs_numerator = 0_u64;
+    let mut runs_denominator = 0_u64;
+    let mut truncated = false;
+    let mut unreadable = Vec::new();
+
+    for entry in pinned.entries().iter().filter(|entry| entry.active) {
+        let Ok(runtime) = pinned.runtime_for(&entry.id) else {
+            // A workspace whose runtime will not open is named rather than
+            // dropped: silently omitting it would understate every total.
+            unreadable.push(entry.id.clone());
+            continue;
+        };
+        let reliability = match runtime.pipeline_reliability(&window) {
+            Ok(reliability) => reliability,
+            Err(error) => return server_error(error),
+        };
+
+        accumulate(&mut totals, &reliability.job_runs.overall);
+        recovery_numerator += reliability.recovery.per_step_invocation.numerator;
+        recovery_denominator += reliability.recovery.per_step_invocation.denominator;
+        runs_numerator += reliability.recovery.per_job_run.numerator;
+        runs_denominator += reliability.recovery.per_job_run.denominator;
+        truncated |= reliability.job_runs.truncated;
+
+        workspaces.push(workspace_value(&entry.id, &entry.name, &reliability));
+    }
+
+    let payload = json!({
+        "window": window,
+        "workspaces": workspaces,
+        "totals": {
+            "job_runs": {
+                "counts": totals,
+                "failure_rate": totals.failure_rate(),
+                "truncated": truncated,
+            },
+            "recovery": {
+                "per_step_invocation": Rate::new(
+                    recovery_numerator,
+                    recovery_denominator,
+                    "step-activity invocations",
+                ),
+                "per_job_run": Rate::new(
+                    runs_numerator,
+                    runs_denominator,
+                    "job runs with any recorded invocation",
+                ),
+            },
+        },
+        "unreadable_workspaces": unreadable,
+    });
+    Json(payload).into_response()
+}
+
+/// Maps the shared dashboard window vocabulary onto a [`ReliabilityWindow`].
+///
+/// `all` is rejected: a rate with no stated time range is not actionable, and
+/// a lifetime average would hide exactly the spikes this view exists to
+/// surface.
+fn resolve_window(raw: Option<&str>) -> Result<ReliabilityWindow, String> {
+    let selected = match raw {
+        None => DEFAULT_RELIABILITY_WINDOW,
+        Some(value) => value
+            .parse::<ScoreboardWindow>()
+            .map_err(|error| error.to_string())?,
+    };
+    let Some(duration) = selected.duration() else {
+        return Err("window must be one of: 1h, 24h, 7d, 30d (reliability rates require an explicit time range)".to_string());
+    };
+    Ok(ReliabilityWindow::ending_at(
+        selected.as_str(),
+        Utc::now(),
+        duration,
+    ))
+}
+
+fn accumulate(totals: &mut OutcomeCounts, counts: &OutcomeCounts) {
+    totals.total += counts.total;
+    totals.succeeded += counts.succeeded;
+    totals.failed += counts.failed;
+    totals.cancelled += counts.cancelled;
+    totals.skipped += counts.skipped;
+    totals.in_flight += counts.in_flight;
+    totals.unknown += counts.unknown;
+}
+
+/// Shapes one workspace's block, attaching each scope's derived failure rate
+/// next to the counts it came from so the frontend never has to divide.
+fn workspace_value(id: &str, name: &str, reliability: &RuntimeReliability) -> Value {
+    json!({
+        "workspace_id": id,
+        "workspace_name": name,
+        "job_runs": {
+            "counts": reliability.job_runs.overall,
+            "failure_rate": reliability.job_runs.overall.failure_rate(),
+            "by_job": reliability
+                .job_runs
+                .by_job
+                .iter()
+                .map(job_row_value)
+                .collect::<Vec<_>>(),
+            "over_time": reliability
+                .job_runs
+                .over_time
+                .iter()
+                .map(bucket_row_value)
+                .collect::<Vec<_>>(),
+            "observed_states": reliability.job_runs.observed_states,
+            "truncated": reliability.job_runs.truncated,
+        },
+        "recovery": reliability.recovery,
+    })
+}
+
+fn job_row_value(row: &JobOutcomeRow) -> Value {
+    json!({
+        "job_id": row.job_id,
+        "counts": row.counts,
+        "failure_rate": row.counts.failure_rate(),
+    })
+}
+
+fn bucket_row_value(row: &BucketOutcomeRow) -> Value {
+    json!({
+        "bucket_start": row.bucket_start,
+        "bucket_end": row.bucket_end,
+        "counts": row.counts,
+        "failure_rate": row.counts.failure_rate(),
+    })
+}

--- a/crates/orbit-dashboard/src/api/tests/mod.rs
+++ b/crates/orbit-dashboard/src/api/tests/mod.rs
@@ -13,6 +13,7 @@ mod handlers;
 mod learnings;
 mod log;
 mod metrics;
+mod reliability;
 mod routines;
 mod runs;
 mod scoreboard;

--- a/crates/orbit-dashboard/src/api/tests/reliability.rs
+++ b/crates/orbit-dashboard/src/api/tests/reliability.rs
@@ -1,0 +1,190 @@
+//! [ORB-10588] `/api/metrics/reliability`.
+//!
+//! Covers the contract the UI depends on: every rate ships with its `n`, its
+//! denominator label, and the window it was computed over; the excluded
+//! outcome buckets stay visible so `success + failed` cannot be mistaken for
+//! the run total; and an unbounded window is refused rather than served.
+
+//! Test-only allowlist: endpoint tests use unwrap/expect for fixture setup.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::response::Response;
+use orbit_core::{JobRunState, OrbitRuntime};
+use serde_json::Value;
+use tower::ServiceExt;
+
+use super::super::router;
+use super::test_support::{body_json, seed_run};
+
+const JOB_ID: &str = "reliability_api";
+
+async fn request_reliability(runtime: OrbitRuntime, query: &str) -> Response {
+    Router::new()
+        .nest("/api", router())
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/metrics/reliability{query}"))
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response")
+}
+
+fn seeded_runtime() -> OrbitRuntime {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    // Two settled outcomes plus three runs that must stay out of the
+    // denominator, so the payload has something to disclose.
+    seed_run(&runtime, "jrun-ok-1", JOB_ID, JobRunState::Success);
+    seed_run(&runtime, "jrun-ok-2", JOB_ID, JobRunState::Success);
+    seed_run(&runtime, "jrun-bad-1", JOB_ID, JobRunState::Failed);
+    seed_run(&runtime, "jrun-cancel", JOB_ID, JobRunState::Cancelled);
+    seed_run(&runtime, "jrun-live", JOB_ID, JobRunState::Running);
+    runtime
+}
+
+#[tokio::test]
+async fn reliability_reports_every_rate_with_its_denominator_and_window() {
+    let response = request_reliability(seeded_runtime(), "?window=24h").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+
+    let window = &body["window"];
+    assert_eq!(window["label"], "24h");
+    assert!(
+        window["since"].is_string(),
+        "the window must state its start"
+    );
+    assert!(window["until"].is_string(), "the window must state its end");
+
+    let job_runs = &body["totals"]["job_runs"];
+    assert_eq!(job_runs["counts"]["total"], 5);
+    assert_eq!(job_runs["counts"]["succeeded"], 2);
+    assert_eq!(job_runs["counts"]["failed"], 1);
+    // The failure rate divides by settled runs only.
+    assert_eq!(job_runs["failure_rate"]["numerator"], 1);
+    assert_eq!(job_runs["failure_rate"]["denominator"], 3);
+    assert!(
+        job_runs["failure_rate"]["denominator_label"]
+            .as_str()
+            .is_some_and(|label| !label.is_empty()),
+        "a rate must carry a human-readable denominator label"
+    );
+
+    for rate in ["per_step_invocation", "per_job_run"] {
+        let node = &body["totals"]["recovery"][rate];
+        assert!(node["denominator"].is_number(), "{rate} must state its n");
+        assert!(
+            node["denominator_label"]
+                .as_str()
+                .is_some_and(|label| !label.is_empty()),
+            "{rate} must name what its denominator counts"
+        );
+    }
+}
+
+#[tokio::test]
+async fn excluded_outcomes_stay_visible_so_ok_plus_failed_is_not_the_total() {
+    let response = request_reliability(seeded_runtime(), "?window=24h").await;
+    let body = body_json(response).await;
+    let counts = &body["totals"]["job_runs"]["counts"];
+
+    assert_eq!(counts["cancelled"], 1);
+    assert_eq!(counts["in_flight"], 1);
+    let settled = counts["succeeded"].as_u64().unwrap() + counts["failed"].as_u64().unwrap();
+    assert_ne!(
+        settled,
+        counts["total"].as_u64().unwrap(),
+        "the fixture must exercise the gap between settled runs and all runs"
+    );
+}
+
+#[tokio::test]
+async fn a_thin_denominator_is_flagged_rather_than_rendered_as_confident() {
+    let response = request_reliability(seeded_runtime(), "?window=24h").await;
+    let body = body_json(response).await;
+
+    // Three settled runs is well under the confidence threshold; the flag is
+    // what lets the frontend withhold the percentage.
+    assert_eq!(
+        body["totals"]["job_runs"]["failure_rate"]["low_sample"],
+        true
+    );
+}
+
+#[tokio::test]
+async fn breakdowns_carry_per_job_and_over_time_rates() {
+    let response = request_reliability(seeded_runtime(), "?window=24h").await;
+    let body = body_json(response).await;
+    let workspace = &body["workspaces"][0];
+
+    assert!(workspace["workspace_id"].is_string());
+    let by_job = workspace["job_runs"]["by_job"]
+        .as_array()
+        .expect("by_job array");
+    let row = by_job
+        .iter()
+        .find(|row| row["job_id"] == JOB_ID)
+        .expect("seeded job row");
+    assert_eq!(row["counts"]["total"], 5);
+    assert_eq!(row["failure_rate"]["denominator"], 3);
+
+    let over_time = workspace["job_runs"]["over_time"]
+        .as_array()
+        .expect("over_time array");
+    assert!(
+        !over_time.is_empty(),
+        "the series must be materialized, empty buckets included"
+    );
+    assert!(
+        over_time
+            .iter()
+            .all(|bucket| bucket["bucket_start"].is_string()
+                && bucket["failure_rate"]["denominator"].is_number())
+    );
+
+    // The raw state values behind the classification travel with the payload.
+    let observed = &workspace["job_runs"]["observed_states"];
+    assert_eq!(observed["success"], 2);
+    assert_eq!(observed["failed"], 1);
+    assert_eq!(observed["cancelled"], 1);
+}
+
+#[tokio::test]
+async fn an_unbounded_window_is_refused_rather_than_served_without_a_range() {
+    let response = request_reliability(seeded_runtime(), "?window=all").await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = body_json(response).await;
+    assert!(
+        body["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("explicit time range")),
+        "the refusal must say why: {body}"
+    );
+}
+
+#[tokio::test]
+async fn an_unknown_window_is_a_400_not_a_silent_default() {
+    let response = request_reliability(seeded_runtime(), "?window=nonsense").await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn omitting_the_window_still_yields_an_explicit_one() {
+    let response = request_reliability(seeded_runtime(), "").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = body_json(response).await;
+    assert!(
+        body["window"]["label"]
+            .as_str()
+            .is_some_and(|l| !l.is_empty()),
+        "the default must still be named in the payload"
+    );
+    assert!(body["window"]["since"].is_string());
+}

--- a/crates/orbit-dashboard/src/lib.rs
+++ b/crates/orbit-dashboard/src/lib.rs
@@ -48,6 +48,7 @@ const MARKDOWN_JS: &str = include_str!("../assets/dashboard/markdown.js");
 const TASKS_JS: &str = include_str!("../assets/dashboard/tasks.js");
 const AUDIT_JS: &str = include_str!("../assets/dashboard/audit.js");
 const SCOREBOARD_JS: &str = include_str!("../assets/dashboard/scoreboard.js");
+const RELIABILITY_JS: &str = include_str!("../assets/dashboard/reliability.js");
 const LOG_TAIL_JS: &str = include_str!("../assets/dashboard/log-tail.js");
 const DIAGNOSTICS_JS: &str = include_str!("../assets/dashboard/diagnostics.js");
 const ROUTER_JS: &str = include_str!("../assets/dashboard/router.js");
@@ -231,6 +232,7 @@ fn run_server(args: &ServeArgs, state: state::DashboardState) -> Result<(), Orbi
         .route("/static/tasks.js", get(serve_tasks_js))
         .route("/static/audit.js", get(serve_audit_js))
         .route("/static/scoreboard.js", get(serve_scoreboard_js))
+        .route("/static/reliability.js", get(serve_reliability_js))
         .route("/static/log-tail.js", get(serve_log_tail_js))
         .route("/static/diagnostics.js", get(serve_diagnostics_js))
         .route("/static/router.js", get(serve_router_js))
@@ -336,6 +338,10 @@ async fn serve_audit_js() -> Response {
 
 async fn serve_scoreboard_js() -> Response {
     dashboard_response("application/javascript; charset=utf-8", SCOREBOARD_JS)
+}
+
+async fn serve_reliability_js() -> Response {
+    dashboard_response("application/javascript; charset=utf-8", RELIABILITY_JS)
 }
 
 async fn serve_log_tail_js() -> Response {

--- a/crates/orbit-dashboard/src/tests/dashboard_assets.rs
+++ b/crates/orbit-dashboard/src/tests/dashboard_assets.rs
@@ -5,7 +5,8 @@ use axum::response::Response;
 use crate::{
     DASHBOARD_CSP, serve_app_js, serve_audit_js, serve_common_js, serve_diagnostics_js,
     serve_index, serve_log_tail_js, serve_markdown_js, serve_marked_js, serve_purify_js,
-    serve_router_js, serve_run_detail_js, serve_runs_js, serve_scoreboard_js, serve_tasks_js,
+    serve_reliability_js, serve_router_js, serve_run_detail_js, serve_runs_js, serve_scoreboard_js,
+    serve_tasks_js,
 };
 
 #[tokio::test]
@@ -20,6 +21,7 @@ async fn dashboard_html_and_js_routes_emit_csp() {
         ("tasks", serve_tasks_js().await),
         ("audit", serve_audit_js().await),
         ("scoreboard", serve_scoreboard_js().await),
+        ("reliability", serve_reliability_js().await),
         ("log_tail", serve_log_tail_js().await),
         ("diagnostics", serve_diagnostics_js().await),
         ("router", serve_router_js().await),
@@ -391,10 +393,14 @@ fn dashboard_guards_diagnostics_and_detail_panels_in_aggregate_view() {
         );
     }
     // ORB-10444 added the scoreboard subtab, so there are three re-render sites.
+    // ORB-10588's reliability subtab is deliberately not a fourth: it is served
+    // by a cross-workspace endpoint (`/api/metrics/reliability` takes the whole
+    // DashboardState, not the `Ws` extractor), so it holds no per-workspace
+    // state to placehold and stays live in the aggregate view.
     assert_eq!(
-        router.matches("if (isAggregateView())").count(),
+        router.matches("isAggregateView()").count(),
         3,
-        "every subtab re-render site in router.js must be guarded"
+        "every per-workspace subtab re-render site in router.js must be guarded"
     );
 
     // Knowledge detail panels: each list guard also replaces its detail panel
@@ -532,8 +538,11 @@ async fn dashboard_scoreboard_is_reachable_under_diagnostics() {
     ] {
         assert!(body.contains(&format!(r#"id="{id}""#)), "{id} must survive");
     }
+    // ORB-10588 appended `reliability` to the same list.
     assert!(
-        router.contains(r#"const DIAG_SUBTABS = ["runs", "metrics", "errors", "scoreboard"];"#),
+        router.contains(
+            r#"const DIAG_SUBTABS = ["runs", "metrics", "errors", "reliability", "scoreboard"];"#
+        ),
         "the scoreboard must route as a diagnostics subtab"
     );
     assert!(
@@ -541,6 +550,121 @@ async fn dashboard_scoreboard_is_reachable_under_diagnostics() {
             && app.contains(r#"fetchJson("/api/scoreboard?window=24h")"#),
         "the scoreboard fetch must hang off the diagnostics subtab branch"
     );
+}
+
+/// ORB-10588: the reliability view routes as a diagnostics subtab and owns the
+/// ids `reliability.js` renders into.
+#[tokio::test]
+async fn dashboard_reliability_is_reachable_under_diagnostics() {
+    let body = response_body(serve_index().await).await;
+    let router = include_str!("../../assets/dashboard/router.js");
+    let app = include_str!("../../assets/dashboard/app.js");
+
+    let diagnostics_at = body
+        .find(r#"<section class="tab-pane" data-tab="diagnostics">"#)
+        .expect("diagnostics pane");
+    let reliability_at = body
+        .find(r#"id="diagnostics-reliability-main""#)
+        .expect("reliability host inside diagnostics");
+    assert!(
+        diagnostics_at < reliability_at,
+        "the reliability markup must live inside the diagnostics pane"
+    );
+    assert!(
+        body.contains(r#"<button class="subtab" data-subtab="reliability" type="button">"#),
+        "Reliability must be offered as a diagnostics subtab"
+    );
+    for id in [
+        "reliability-count",
+        "reliability-window-selector",
+        "reliability-meta",
+        "reliability-summary",
+        "reliability-denominator-note",
+        "reliability-truncation-note",
+        "reliability-over-time",
+        "reliability-breakdown",
+        "reliability-activities",
+    ] {
+        assert!(body.contains(&format!(r#"id="{id}""#)), "{id} must exist");
+    }
+    assert!(
+        app.contains(r#"if (activeDiagSubtab === "reliability")"#)
+            && app.contains("fetchAndRenderReliability()"),
+        "the reliability fetch must hang off the diagnostics subtab branch"
+    );
+    assert!(
+        router.contains(r#"reliability: "diagnostics-reliability-main""#),
+        "the reliability subtab must claim its own full-width main"
+    );
+}
+
+/// ORB-10588: a rate is only actionable with its `n` and its window, and a
+/// denominator too thin to trust must be withheld rather than rounded. Both
+/// rules live in `reliability.js`; this pins them so a later edit cannot
+/// quietly turn a withheld cell back into a confident percentage.
+#[test]
+fn dashboard_reliability_never_renders_a_rate_without_its_denominator() {
+    let reliability = include_str!("../../assets/dashboard/reliability.js");
+    let index = include_str!("../../assets/dashboard/index.html");
+
+    assert!(
+        reliability.contains("rate.low_sample"),
+        "the low-sample flag from the API must be honored"
+    );
+    assert!(
+        reliability.contains("n too small"),
+        "a withheld rate must say why it is withheld"
+    );
+    assert!(
+        reliability.contains("rel-rate-low"),
+        "a withheld rate must be visually distinct from a real one"
+    );
+    assert!(
+        reliability.contains("(n=${n})"),
+        "a rendered percentage must carry its denominator"
+    );
+    assert!(
+        reliability.contains("denominator_label"),
+        "the denominator's meaning must be rendered, not left in the backend"
+    );
+    // `all` would be a rate with no stated range; the endpoint refuses it and
+    // the selector must not offer it.
+    assert!(
+        !reliability.contains(r#""all""#),
+        "an unbounded window must not be offered"
+    );
+    assert!(
+        !index.contains(
+            r#"id="reliability-window-selector" title="window scope">
+                <span class="scoreboard-window-seg" data-window="all">"#
+        ),
+        "the reliability window selector must not offer `all`"
+    );
+}
+
+/// ORB-10588: the recovery rate must be computed from durable run state only.
+/// Friction F-token-disagreement (recorded in the task) makes any token- or
+/// cost-derived input untrustworthy, so the reliability path must not read one.
+#[test]
+fn dashboard_reliability_reads_no_token_or_cost_field() {
+    let reliability = include_str!("../../assets/dashboard/reliability.js");
+    // Field identifiers, not the words: the module's own header explains *why*
+    // it avoids these inputs, so a bare "token" match would flag the rationale.
+    for banned in [
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "cache_read_tokens",
+        "cache_create_tokens",
+        "provider_cost_usd",
+        "derived_cost_usd",
+        "total_tool_calls",
+    ] {
+        assert!(
+            !reliability.contains(banned),
+            "reliability.js must not read `{banned}` — the token/cost inputs disagree across stores"
+        );
+    }
 }
 
 #[test]
@@ -744,6 +868,10 @@ fn dashboard_assets_carry_no_project_specific_identifiers() {
         (
             "run-detail.js",
             include_str!("../../assets/dashboard/run-detail.js"),
+        ),
+        (
+            "reliability.js",
+            include_str!("../../assets/dashboard/reliability.js"),
         ),
     ];
     // Personal names and layout paths of the machine Orbit is developed on, plus

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -141,6 +141,9 @@ pub use sqlite::invocation_store::{
     InvocationAccountingQuery, InvocationInsertParams, InvocationQuery, InvocationRecord,
     InvocationToolCallRecord, TaskInvocationMetrics, ToolInvocationMetrics,
 };
+pub use sqlite::reliability_store::{
+    ActivityInvocationCount, BoundedFacts, InvocationRunCoverage, JobRunOutcomeFact,
+};
 pub use sqlite::routine_store::{
     RoutineCursor, RoutineFireIntentParams, RoutineFireRecord, RoutineFireState,
     RoutinePauseRecord, RoutineSweepLock, try_acquire_routine_sweep_lock,

--- a/crates/orbit-store/src/sqlite/mod.rs
+++ b/crates/orbit-store/src/sqlite/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod job_run_store;
 pub(crate) mod learning_index;
 pub mod migration;
 pub(crate) mod read_pool;
+pub(crate) mod reliability_store;
 pub(crate) mod routine_store;
 pub(crate) mod session_learning_state_store;
 pub mod task_registry;

--- a/crates/orbit-store/src/sqlite/reliability_store.rs
+++ b/crates/orbit-store/src/sqlite/reliability_store.rs
@@ -1,0 +1,232 @@
+//! Count-only reliability reads over `job_runs` and `invocations` [ORB-10588].
+//!
+//! These queries exist so pipeline-reliability reporting never has to load the
+//! wide row shapes that the token/cost metrics path uses. Every column read
+//! here is an identifier, a state, or a timestamp: no token column and no cost
+//! column is referenced, projected, or aggregated. That is deliberate — the
+//! worker run store and `invocations` disagree on token accounting by an order
+//! of magnitude (friction F2026-08-031), so any rate derived from those fields
+//! would be confidently wrong. Durations and counts do not share that defect.
+//!
+//! Both queries are workspace-scoped. `job_runs` carries `workspace_id`
+//! directly; `invocations` does not, so it is scoped by joining each
+//! invocation back to the run that produced it. An invocation whose owning run
+//! is absent from `job_runs` is therefore excluded rather than attributed to an
+//! arbitrary workspace.
+//!
+//! Windows are half-open (`since <= ts < until`) and compared as RFC3339 text,
+//! matching every other timestamp filter in this crate (see
+//! `list_job_runs_for_workspace` and `list_invocation_records`).
+
+use chrono::{DateTime, Utc};
+use rusqlite::params;
+
+use orbit_common::types::OrbitError;
+
+use crate::Store;
+
+/// One `job_runs` row reduced to the three fields reliability reporting needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JobRunOutcomeFact {
+    pub job_id: String,
+    /// Raw `job_runs.state` text, classified by the caller. Left unparsed here
+    /// so a state written by a newer binary is surfaced rather than dropped.
+    pub state: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Per-activity invocation counts within a window, for one workspace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActivityInvocationCount {
+    pub activity_id: String,
+    /// Number of invocation rows recorded for this activity.
+    pub invocation_count: u64,
+    /// Number of distinct job runs that recorded at least one such invocation.
+    pub job_run_count: u64,
+}
+
+/// Distinct-job-run coverage for an invocation window.
+///
+/// Both figures are `COUNT(DISTINCT job_run_id)` evaluated in one pass, which
+/// is why they are returned together: distinct-run counts do not compose, so a
+/// caller cannot derive either one by summing per-activity counts.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct InvocationRunCoverage {
+    /// Job runs that recorded at least one invocation of any activity.
+    pub total_job_runs: u64,
+    /// Job runs that recorded at least one invocation of a selected activity.
+    pub matching_job_runs: u64,
+}
+
+/// Result of a bounded fact read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoundedFacts<T> {
+    pub facts: Vec<T>,
+    /// True when the row cap was reached and older rows were dropped. Callers
+    /// must surface this rather than presenting a partial window as complete.
+    pub truncated: bool,
+}
+
+impl Store {
+    /// Lists every job run created in `[since, until)` for one workspace,
+    /// projected to `(job_id, state, created_at)`.
+    ///
+    /// Unlike [`Store::list_job_runs_for_workspace`], this does not read step
+    /// rows, input payloads, or model attribution — a reliability window can
+    /// span thousands of runs and the per-run step fan-out would dominate.
+    ///
+    /// Rows are ordered newest-first and capped at `max_rows`; when the cap
+    /// binds, the returned [`BoundedFacts::truncated`] flag is set.
+    pub fn list_job_run_outcome_facts(
+        &self,
+        workspace_id: &str,
+        since: DateTime<Utc>,
+        until: DateTime<Utc>,
+        max_rows: usize,
+    ) -> Result<BoundedFacts<JobRunOutcomeFact>, OrbitError> {
+        if max_rows == 0 {
+            return Ok(BoundedFacts {
+                facts: Vec::new(),
+                truncated: false,
+            });
+        }
+        let conn = self.read()?;
+        let mut stmt = conn
+            .prepare(
+                r#"
+                SELECT job_id, state, created_at
+                FROM job_runs
+                WHERE workspace_id = ?1 AND created_at >= ?2 AND created_at < ?3
+                ORDER BY created_at DESC, run_id ASC
+                LIMIT ?4
+                "#,
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        // Over-fetch by one so a full page can be distinguished from a page
+        // that happens to end exactly on the cap.
+        let probe = max_rows.saturating_add(1) as i64;
+        let rows = stmt
+            .query_map(
+                params![workspace_id, since.to_rfc3339(), until.to_rfc3339(), probe,],
+                |row| {
+                    Ok(JobRunOutcomeFact {
+                        job_id: row.get(0)?,
+                        state: row.get(1)?,
+                        created_at: crate::parse_timestamp(&row.get::<_, String>(2)?)?,
+                    })
+                },
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        let mut facts = rows
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let truncated = facts.len() > max_rows;
+        facts.truncate(max_rows);
+        Ok(BoundedFacts { facts, truncated })
+    }
+
+    /// Counts invocations per `activity_id` in `[since, until)`, scoped to the
+    /// runs owned by one workspace.
+    ///
+    /// Grouping happens in SQLite, so the result set is bounded by the number
+    /// of distinct activities rather than by invocation volume.
+    pub fn count_invocations_by_activity(
+        &self,
+        workspace_id: &str,
+        since: DateTime<Utc>,
+        until: DateTime<Utc>,
+    ) -> Result<Vec<ActivityInvocationCount>, OrbitError> {
+        let conn = self.read()?;
+        let mut stmt = conn
+            .prepare(
+                r#"
+                SELECT i.activity_id,
+                       COUNT(*) AS invocation_count,
+                       COUNT(DISTINCT i.job_run_id) AS job_run_count
+                FROM invocations i
+                INNER JOIN job_runs jr
+                        ON jr.run_id = i.job_run_id AND jr.workspace_id = ?1
+                WHERE i.ts >= ?2 AND i.ts < ?3
+                GROUP BY i.activity_id
+                ORDER BY invocation_count DESC, i.activity_id ASC
+                "#,
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        let rows = stmt
+            .query_map(
+                params![workspace_id, since.to_rfc3339(), until.to_rfc3339()],
+                |row| {
+                    Ok(ActivityInvocationCount {
+                        activity_id: row.get(0)?,
+                        invocation_count: row.get::<_, i64>(1)?.max(0) as u64,
+                        job_run_count: row.get::<_, i64>(2)?.max(0) as u64,
+                    })
+                },
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| OrbitError::Store(e.to_string()))
+    }
+
+    /// Counts distinct job runs with any invocation in `[since, until)`, and
+    /// the subset of those runs that invoked one of `activity_ids`.
+    ///
+    /// An empty `activity_ids` yields a zero `matching_job_runs` alongside a
+    /// real `total_job_runs`, so a caller with nothing to match still gets a
+    /// usable denominator.
+    pub fn count_invocation_job_runs(
+        &self,
+        workspace_id: &str,
+        since: DateTime<Utc>,
+        until: DateTime<Utc>,
+        activity_ids: &[String],
+    ) -> Result<InvocationRunCoverage, OrbitError> {
+        let mut bound: Vec<Box<dyn rusqlite::types::ToSql>> = vec![
+            Box::new(workspace_id.to_string()),
+            Box::new(since.to_rfc3339()),
+            Box::new(until.to_rfc3339()),
+        ];
+        // `WHEN 0` is a constant-false guard for the empty case; SQLite has no
+        // legal `IN ()` form.
+        let matching_predicate = if activity_ids.is_empty() {
+            "0".to_string()
+        } else {
+            let placeholders = activity_ids
+                .iter()
+                .enumerate()
+                .map(|(offset, _)| format!("?{}", bound.len() + offset + 1))
+                .collect::<Vec<_>>()
+                .join(", ");
+            for activity_id in activity_ids {
+                bound.push(Box::new(activity_id.clone()));
+            }
+            format!("i.activity_id IN ({placeholders})")
+        };
+
+        let sql = format!(
+            r#"
+            SELECT COUNT(DISTINCT i.job_run_id),
+                   COUNT(DISTINCT CASE WHEN {matching_predicate} THEN i.job_run_id END)
+            FROM invocations i
+            INNER JOIN job_runs jr
+                    ON jr.run_id = i.job_run_id AND jr.workspace_id = ?1
+            WHERE i.ts >= ?2 AND i.ts < ?3
+            "#
+        );
+
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            bound.iter().map(|value| value.as_ref()).collect();
+        let conn = self.read()?;
+        conn.query_row(&sql, param_refs.as_slice(), |row| {
+            Ok(InvocationRunCoverage {
+                total_job_runs: row.get::<_, i64>(0)?.max(0) as u64,
+                matching_job_runs: row.get::<_, i64>(1)?.max(0) as u64,
+            })
+        })
+        .map_err(|e| OrbitError::Store(e.to_string()))
+    }
+}

--- a/crates/orbit-store/src/sqlite/tests/mod.rs
+++ b/crates/orbit-store/src/sqlite/tests/mod.rs
@@ -1,3 +1,4 @@
 mod connection;
 mod invocation_store;
 mod read_pool;
+mod reliability_store;

--- a/crates/orbit-store/src/sqlite/tests/reliability_store.rs
+++ b/crates/orbit-store/src/sqlite/tests/reliability_store.rs
@@ -1,0 +1,264 @@
+//! [ORB-10588] Count-only reliability reads.
+//!
+//! The properties worth pinning here are the ones a wrong query would get
+//! quietly wrong: workspace scoping (including for `invocations`, which has no
+//! `workspace_id` of its own), half-open window boundaries, and the fact that
+//! distinct-run coverage is computed in one pass rather than summed.
+
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use orbit_common::types::{InvocationTrace, JobRun, JobRunState};
+
+use super::super::invocation_store::InvocationInsertParams;
+use crate::Store;
+
+const WS: &str = "ws-primary";
+const OTHER_WS: &str = "ws-other";
+
+fn at(hour: u32) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 8, 1, hour, 0, 0)
+        .single()
+        .expect("valid timestamp")
+}
+
+fn insert_run(
+    store: &Store,
+    workspace: &str,
+    run_id: &str,
+    job_id: &str,
+    state: JobRunState,
+    created: DateTime<Utc>,
+) {
+    let run = JobRun {
+        run_id: run_id.to_string(),
+        job_id: job_id.to_string(),
+        attempt: 1,
+        state,
+        scheduled_at: created,
+        started_at: Some(created),
+        finished_at: None,
+        duration_ms: None,
+        created_at: created,
+        pid: None,
+        pid_start_time: None,
+        input: None,
+        retry_source_run_id: None,
+        knowledge_metrics: None,
+        resolved_crew: None,
+        crew_model: None,
+        steps: Vec::new(),
+    };
+    store
+        .upsert_job_run_for_workspace(workspace, &run, None)
+        .expect("insert job run");
+}
+
+fn insert_invocation(store: &Store, run_id: &str, activity_id: &str) {
+    store
+        .insert_invocation_trace_record(&InvocationInsertParams {
+            job_run_id: run_id.to_string(),
+            activity_id: activity_id.to_string(),
+            agent: "agent".to_string(),
+            model: Some("model".to_string()),
+            slot: None,
+            task_ids: Vec::new(),
+            trace: InvocationTrace::default(),
+        })
+        .expect("insert invocation");
+}
+
+fn window() -> (DateTime<Utc>, DateTime<Utc>) {
+    (at(0), at(12))
+}
+
+/// Window for the invocation-backed reads.
+///
+/// `insert_invocation_trace_record` stamps `ts` itself at insert time, so a
+/// fixture cannot place an invocation at a chosen instant the way it can place
+/// a job run. These tests therefore bracket wall-clock now.
+fn invocation_window() -> (DateTime<Utc>, DateTime<Utc>) {
+    (
+        Utc::now() - Duration::hours(1),
+        Utc::now() + Duration::hours(1),
+    )
+}
+
+#[test]
+fn job_run_facts_are_scoped_to_one_workspace() {
+    let store = Store::open_in_memory().expect("open store");
+    insert_run(&store, WS, "jrun-1", "alpha", JobRunState::Success, at(1));
+    insert_run(
+        &store,
+        OTHER_WS,
+        "jrun-2",
+        "alpha",
+        JobRunState::Failed,
+        at(1),
+    );
+
+    let (since, until) = window();
+    let result = store
+        .list_job_run_outcome_facts(WS, since, until, 100)
+        .expect("list facts");
+
+    assert_eq!(result.facts.len(), 1);
+    assert_eq!(result.facts[0].job_id, "alpha");
+    assert_eq!(result.facts[0].state, "success");
+    assert!(!result.truncated);
+}
+
+#[test]
+fn the_window_is_half_open_on_both_ends() {
+    let store = Store::open_in_memory().expect("open store");
+    insert_run(
+        &store,
+        WS,
+        "before",
+        "j",
+        JobRunState::Success,
+        at(0) - Duration::seconds(1),
+    );
+    insert_run(&store, WS, "at-since", "j", JobRunState::Success, at(0));
+    insert_run(&store, WS, "at-until", "j", JobRunState::Success, at(12));
+
+    let (since, until) = window();
+    let result = store
+        .list_job_run_outcome_facts(WS, since, until, 100)
+        .expect("list facts");
+
+    // `since` is inclusive, `until` exclusive — so adjacent windows tile
+    // without double-counting a run on the boundary.
+    assert_eq!(result.facts.len(), 1);
+}
+
+#[test]
+fn the_row_cap_reports_truncation_instead_of_silently_dropping_runs() {
+    let store = Store::open_in_memory().expect("open store");
+    for index in 0..5 {
+        insert_run(
+            &store,
+            WS,
+            &format!("jrun-{index}"),
+            "j",
+            JobRunState::Success,
+            at(1) + Duration::seconds(index),
+        );
+    }
+
+    let (since, until) = window();
+    let capped = store
+        .list_job_run_outcome_facts(WS, since, until, 3)
+        .expect("list facts");
+    assert_eq!(capped.facts.len(), 3);
+    assert!(capped.truncated, "a bound that binds must be reported");
+
+    let exact = store
+        .list_job_run_outcome_facts(WS, since, until, 5)
+        .expect("list facts");
+    assert_eq!(exact.facts.len(), 5);
+    assert!(
+        !exact.truncated,
+        "a page that ends exactly on the cap is not truncated"
+    );
+}
+
+#[test]
+fn invocations_are_scoped_by_the_workspace_of_their_owning_run() {
+    // `invocations` carries no workspace_id, so this is the only thing keeping
+    // one workspace's recovery rate out of another's.
+    let store = Store::open_in_memory().expect("open store");
+    insert_run(&store, WS, "jrun-mine", "j", JobRunState::Success, at(1));
+    insert_run(
+        &store,
+        OTHER_WS,
+        "jrun-theirs",
+        "j",
+        JobRunState::Success,
+        at(1),
+    );
+    insert_invocation(&store, "jrun-mine", "implement");
+    insert_invocation(&store, "jrun-theirs", "implement");
+
+    let (since, until) = invocation_window();
+    let counts = store
+        .count_invocations_by_activity(WS, since, until)
+        .expect("count invocations");
+
+    assert_eq!(counts.len(), 1);
+    assert_eq!(counts[0].activity_id, "implement");
+    assert_eq!(counts[0].invocation_count, 1);
+    assert_eq!(counts[0].job_run_count, 1);
+}
+
+#[test]
+fn an_invocation_with_no_matching_run_row_is_excluded_rather_than_guessed() {
+    let store = Store::open_in_memory().expect("open store");
+    insert_invocation(&store, "jrun-orphan", "implement");
+
+    let (since, until) = invocation_window();
+    let counts = store
+        .count_invocations_by_activity(WS, since, until)
+        .expect("count invocations");
+    assert!(counts.is_empty());
+}
+
+#[test]
+fn activity_counts_separate_invocations_from_runs_touched() {
+    let store = Store::open_in_memory().expect("open store");
+    insert_run(&store, WS, "jrun-a", "j", JobRunState::Success, at(1));
+    insert_run(&store, WS, "jrun-b", "j", JobRunState::Success, at(1));
+    for _ in 0..3 {
+        insert_invocation(&store, "jrun-a", "implement");
+    }
+    insert_invocation(&store, "jrun-b", "implement");
+
+    let (since, until) = invocation_window();
+    let counts = store
+        .count_invocations_by_activity(WS, since, until)
+        .expect("count invocations");
+
+    assert_eq!(counts[0].invocation_count, 4);
+    assert_eq!(counts[0].job_run_count, 2, "distinct runs, not invocations");
+}
+
+#[test]
+fn run_coverage_counts_distinct_runs_across_all_selected_activities() {
+    // Summing per-activity distinct-run counts would give 3 here (2 + 1) even
+    // though only 2 distinct runs used recovery. This is why coverage is a
+    // dedicated single-pass query.
+    let store = Store::open_in_memory().expect("open store");
+    for run_id in ["jrun-a", "jrun-b", "jrun-c"] {
+        insert_run(&store, WS, run_id, "j", JobRunState::Success, at(1));
+        insert_invocation(&store, run_id, "implement");
+    }
+    insert_invocation(&store, "jrun-a", "rescue_one");
+    insert_invocation(&store, "jrun-b", "rescue_one");
+    insert_invocation(&store, "jrun-a", "rescue_two");
+
+    let (since, until) = invocation_window();
+    let coverage = store
+        .count_invocation_job_runs(
+            WS,
+            since,
+            until,
+            &["rescue_one".to_string(), "rescue_two".to_string()],
+        )
+        .expect("count coverage");
+
+    assert_eq!(coverage.total_job_runs, 3);
+    assert_eq!(coverage.matching_job_runs, 2);
+}
+
+#[test]
+fn run_coverage_with_no_selected_activities_still_reports_a_denominator() {
+    let store = Store::open_in_memory().expect("open store");
+    insert_run(&store, WS, "jrun-a", "j", JobRunState::Success, at(1));
+    insert_invocation(&store, "jrun-a", "implement");
+
+    let (since, until) = invocation_window();
+    let coverage = store
+        .count_invocation_job_runs(WS, since, until, &[])
+        .expect("count coverage");
+
+    assert_eq!(coverage.total_job_runs, 1);
+    assert_eq!(coverage.matching_job_runs, 0);
+}

--- a/docs/design/user-interface/4_decisions.md
+++ b/docs/design/user-interface/4_decisions.md
@@ -3,7 +3,7 @@ summary: "User Interface — Decisions"
 type: design
 title: "User Interface — Decisions"
 owner: gemini
-last_updated: 2026-08-01
+last_updated: 2026-08-02
 status: Draft
 feature: user-interface
 doc_role: decisions
@@ -145,6 +145,44 @@ Rejected alternative: reuse `PATCH /api/tasks/:id` with a `comment` field for co
 
 **Amendment ([ORB-10544], [ADR-0303]).** "Covers every surface" was true of the intent, not of the placement: the check lived inside the endpoint, so the MCP `orbit.workflow.ship` tool bypassed it. It now lives in the shared ship submission path and every submission surface inherits it. The endpoint's response is unchanged — it projects the shared typed conflict as the same `409 ship_run_in_flight` body.
 
+## ADR-PENDING — Pipeline reliability from durable run state, with roles discovered from the job catalog
+
+**Status:** Proposed · 2026-08 · [ORB-10588]
+
+> **Global ID not yet allocated.** `orbit.adr.add` was refused during
+> implementation — the executing worktree mounts `.orbit/` read-only, so no
+> record could be written to the ADR store. Allocate the global ID with
+> `orbit tool run orbit.adr.add` from a writable checkout and replace this
+> heading, per the [ORB-10458] convention that narratives live in the store.
+
+**Context.** The dashboard surfaced no measure of pipeline reliability. How often job runs fail, and how often the recovery path fires, were answerable only by opening SQLite by hand. A read-only analysis over a 30-day window found the recovery activity to be the second most common activity in the store — roughly one recovery invocation per 3.6 implementation attempts — a large continuous cost nobody had chosen to accept because nobody could see it. Three constraints shaped the design. The worker run store and orbit's `invocations` table disagree by an order of magnitude on tokens per run and some runs carry no cost figure at all, so any rate built on token or cost fields would display a confidently wrong number. The dashboard seeds every workspace, so no caller-specific workspace name, id prefix, crew name, or hardcoded activity-id list may appear in it. And a rate without a denominator and a stated time range is not actionable.
+
+**Decision.** Compute both rates entirely from persisted `job_runs` and `invocations` rows via count-only store queries that reference no token or cost column, and discover activity roles from the job catalog at query time.
+
+`RunOutcome` partitions the observed `job_runs.state` values. `success` is succeeded. `failed`, `timeout`, and `interrupted` are failures — all three are runs the pipeline intended to finish and did not. `cancelled` (a deliberate operator action) and `skipped` (never ran) are terminal but sit outside the rate. `pending`, `running`, and `retrying` are in flight. Anything unparseable lands in an explicit `unknown` bucket rather than being folded into an outcome. The failure rate divides by settled runs (`succeeded + failed`) only, and the payload carries the total and each excluded bucket so the UI cannot imply that ok + failed is the population.
+
+`JobV2::activity_roles()` walks the declared job structure at any nesting depth and returns the step-activity and recovery-activity sets. Recovery activities are exactly those a job names via `recovery_activity` at job or step level — a property of the workspace's own job definitions, never of Orbit. An activity a catalog uses in both roles is reported as ambiguous and excluded from the numerator, because the store records only an id and cannot say which role a given invocation played.
+
+Every rate is a `Rate { numerator, denominator, denominator_label, value, low_sample }`. `value` is `None` when the denominator is zero, so 0% can never stand in for no data. `low_sample` is set below a threshold of 20 and the frontend withholds the percentage for such cells, showing raw counts and an explicit marker. The window (`label`, `since`, `until`, `bucket`) travels with the payload, and the endpoint refuses an unbounded `all` window outright.
+
+Rejected alternative: extend the existing token-metrics path (`list_activity_invocation_metrics`, the scoreboard cost aggregation). That path selects and aggregates token and cost columns, which are known to disagree across stores. Building reliability on it would put an untrustworthy input in the query path even where the specific figures went unused, and would make the no-token-input property unverifiable by inspection. A dedicated count-only read is a few dozen lines and is checkable.
+
+Rejected alternative: reuse `list_job_runs_for_workspace` rather than adding a projected read. It hydrates full `JobRun` records and issues a per-run step query, so a 30-day window fans out to thousands of extra reads for three fields.
+
+Rejected alternative: enumerate the recovery activity ids in source. The dashboard seeds every workspace; a hardcoded list would be wrong elsewhere and stale here. Discovery costs one already-existing catalog call.
+
+Rejected alternative: count `cancelled` as a failure, or round small-`n` rates instead of withholding them. The first makes deliberate operator intervention register as pipeline breakage; the second turns a 1-of-3 bucket into a 33% spike the evidence does not support.
+
+**Consequences.**
+- Both rates are visible over an explicit window, broken down by workspace, by job, and over time, so a spike is attributable rather than merely alarming.
+- The recovery rate is reported two ways with distinct denominators — per step-activity invocation, and per job run with any recorded invocation — both labelled in the payload and rendered in the UI.
+- Distinct-run coverage needs its own single-pass store query: distinct-run counts do not compose, so summing per-activity `COUNT(DISTINCT job_run_id)` would overcount runs touched by more than one recovery activity.
+- `invocations` has no `workspace_id`, so it is scoped by joining each row back to its owning `job_runs` row. An invocation whose run is absent is excluded rather than attributed arbitrarily.
+- The identifier in `invocations.activity_id` is **not** uniformly the catalog activity name: the job executor records a dispatched step under its **step id**, a recovery dispatch under the **recovery activity name**, and the planning-duel runner under the **activity name**. The step role set therefore holds both the step id and the target's catalog name. This is a latent trap for any future consumer of `activity_id`; an end-to-end test pins it.
+- Rates window and bucket on `created_at`, not `finished_at`, so a long-running run is attributed to when it started. Windows are half-open, so adjacent windows tile without double-counting.
+- The per-run fact read is capped at 200,000 rows and reports `truncated` when the cap binds; the UI warns rather than presenting a partial window as complete.
+- This adds the instrument; it does not assert the readings are stable. The standing measurement hold on efficiency baselines drawn from the current window is unaffected.
+
 ## Task References
 
 - [T20260427-29] introduced the Canon Refined UI direction.
@@ -157,5 +195,6 @@ Rejected alternative: reuse `PATCH /api/tasks/:id` with a `comment` field for co
 - [ORB-00154] unified the Scoreboard tab into a metric-major leaderboard matrix.
 - [ORB-00030] made the dashboard global/multi-workspace (workspace-keyed state, `Ws` extractor, serve-from-anywhere, aggregate endpoints).
 - [ORB-10444] retired the deprecated tab, folded Scoreboard under Diagnostics, pinned the Knowledge detail pane, and added task ship + comments.
+- [ORB-10588] added the Reliability subtab: job-run failure rate and recovery invocation rate from durable run state.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10588](https://orbit-cli.com/tasks/ORB-10588) — Surface pipeline reliability on the orbit dashboard: job-run failure rate and recovery invocation rate

### Description

## Problem

The orbit dashboard shows no measure of pipeline reliability. Two questions an operator
asks constantly cannot currently be answered from the UI at all:

1. **How often do job runs fail?**
2. **How often does the recovery path fire?**

Both answers already exist in durable store state — `job_runs.state` and
`invocations.activity_id` — but neither is surfaced anywhere, so the only way to get them
today is to open sqlite by hand.

This is not hypothetical. A read-only analysis on 2026-08-02 over a 30-day window found
`step_failure_recovery` to be the **second most common activity in the store**: 99
invocations against 356 `implement_one`, i.e. the recovery path engages on roughly one in
every 3.6 implementation attempts. That is a large, continuous, entirely invisible cost.
Nobody chose to accept it, because nobody could see it.

## Constraints

- **Duration- and count-derived only. Do not build on token or cost fields.** Friction
  F2026-08-031 records that the worker run store and orbit's `invocations` table disagree by
  10–21× on tokens per run, and that codex runs carry no cost figure at all. Any panel built
  on those inputs would display a confidently wrong number. Revisit only once that friction
  is resolved.
- **This is a shipped surface — keep it project-agnostic.** The dashboard seeds every
  workspace. No caller-specific workspace names, task-id prefixes, crew names, or
  hardcoded activity-id lists may appear in the implementation. Activity ids and job ids
  must be discovered from the store at query time, never enumerated in source.
- **Read durable state only.** Rates must derive from persisted `job_runs` / `invocations`
  rows, never from agent-loop outputs, which are advisory and must not be depended on.
- **Every rate needs its `n` and its window.** A rate without a denominator and a stated
  time range is not actionable, and small-n cells must be visibly marked or withheld rather
  than rendered as a confident percentage.
- Turn/effort knobs and run budgets are out of scope for this task (ADR-0217).

## Questions the implementer must settle with evidence, not assumption

- Which `job_runs.state` values constitute "failed" versus merely non-terminal? The
  analysis above found runs whose parent job had reached no terminal state at all, so
  `ok + failed` does not always equal the row count — the UI must not silently imply it does.
- Is recovery rate best expressed per job run, per implementation activity, or both? Whatever
  is chosen, the denominator has to be legible in the UI itself, not just in the code.
- Does the dashboard already have a query/aggregation layer these should be added to, or does
  one need introducing? Prefer extending what exists.

## Acceptance criteria

- The dashboard surfaces a job-run failure rate over an explicit, visible time window, broken
  down enough that a spike is attributable rather than merely alarming (at minimum over time;
  by workspace and by job if the existing surface supports it).
- The dashboard surfaces a recovery invocation rate with its denominator stated in the UI.
- Both are computed from durable store state, with no token- or cost-derived inputs anywhere
  in the path.
- Every displayed rate carries its `n` and its window; small-n cells are marked or withheld.
- No project-specific identifier appears in the shipped implementation.
- The build passes and the change's own tests pass. CI on agent-main PRs is advisory — do not
  repair unrelated pre-existing failures; name any encountered instead.

## Provenance

Figures from read-only worker runs `8b945321-3bbe-4454-81ab-eac2ae06544a` and
`e97c4daa-6524-4d4f-a7a1-f21370df22d7` (2026-08-02), reading `~/.orbit/orbit.db`. Related:
F2026-08-031 (token store disagreement), and the 2026-08-02 measurement-hold entry in
`agentbase/orchestrator/memory/metrics/changes.md` explaining why efficiency baselines drawn
from the current window are not yet trustworthy — this task adds the instrument, it does not
assert the readings are stable.

### Acceptance Criteria

- Job-run failure rate is visible on the dashboard over an explicit, user-visible time window, with a breakdown that makes a spike attributable (over time at minimum; by workspace and job where the surface allows)
- Recovery invocation rate is visible with its denominator stated in the UI, not only in code
- Both metrics are computed solely from durable store state (job_runs / invocations); no token- or cost-derived input appears anywhere in the query path
- Every rate is displayed with its n and its window; small-n cells are visibly marked or withheld rather than shown as a confident percentage
- The definition of a failed job run is derived from observed job_runs.state values and documented; the UI does not imply ok + failed equals the total when non-terminal runs exist
- No project-specific workspace name, id prefix, crew name, or hardcoded activity-id list appears in the shipped implementation
- Build passes and the change's own tests pass; pre-existing unrelated failures are named rather than repaired

## Execution Summary

<details>
<summary>Click to expand</summary>

Added a Pipeline Reliability view to the dashboard (Diagnostics > Reliability) surfacing job-run failure rate and recovery invocation rate, both computed only from persisted `job_runs` / `invocations` rows.

## What changed

**orbit-common** — new `activity_job/activity_roles.rs`: `JobV2::activity_roles()` walks a job's declared structure at any nesting depth (parallel / fan_out / loop) and returns its step-activity and recovery-activity sets. Recovery activities are exactly those a job names via `recovery_activity`, so the set is discovered from the workspace's own job definitions, never enumerated in source.

**orbit-store** — new `sqlite/reliability_store.rs`: three count-only reads that reference no token or cost column — a projected `(job_id, state, created_at)` fact read (bounded, reports `truncated`), per-activity invocation counts, and single-pass distinct-run coverage. `invocations` has no `workspace_id`, so it is scoped by joining each row to its owning `job_runs` row.

**orbit-core** — new `metrics/reliability.rs`: `RunOutcome` classification plus `OrbitRuntime::pipeline_reliability(window)`, returning overall / by-job / over-time counts, the raw observed state values, and both recovery rates.

**orbit-dashboard** — `GET /api/metrics/reliability?window=1h|24h|7d|30d` (cross-workspace, takes `DashboardState` rather than the `Ws` extractor so a spike is attributable to a workspace), plus `reliability.js`, markup, CSS, and router/app wiring for the new subtab.

## Questions the task asked me to settle with evidence

**Which states are "failed".** Derived from what the store holds: `SELECT state, COUNT(*) FROM job_runs` returns `success 3627 / failed 366 / interrupted 67 / cancelled 26 / running 7`. `failed`, `timeout`, and `interrupted` count as failures (all three are runs the pipeline intended to finish and did not). `cancelled` is a deliberate operator action and `skipped` never ran, so both are terminal but excluded; `pending`/`running`/`retrying` are in flight; unparseable states land in an explicit `unknown` bucket. The rate divides by settled runs (success + failed) only, and the payload carries the total plus every excluded bucket, so `ok + failed` is never implied to be the population.

**Per job run or per invocation.** Both, with distinct denominators carried in the payload as `denominator_label` and rendered verbatim in the UI: recovery invocations per step-activity invocation, and share of job runs with any recorded invocation that had a recovery invocation.

**Existing aggregation layer.** Extended the existing store -> `OrbitRuntime` -> `/api/metrics/*` stack rather than introducing one. The existing invocation-metrics path was deliberately not reused: it selects and aggregates token/cost columns, which the cited friction shows disagree across stores by an order of magnitude.

## Bug found and fixed mid-implementation

`invocations.activity_id` is **not** uniformly the catalog activity name. The job executor records a dispatched step under its **step id** (`target.rs` passes `step.id`), a recovery dispatch under the **recovery activity name** (`recovery.rs` passes `recovery.name`), and the planning-duel runner under the **activity name**. The first version of role discovery collected only target activity names, which would have classified every step invocation as `unknown` and collapsed the step denominator to zero. The step role set now holds both the step id and the target's catalog name; an end-to-end test over a real runtime pins this.

## Validation

- `make ci-fast` — passes (exit 0).
- `cargo clippy -p orbit-common -p orbit-store -p orbit-core -p orbit-dashboard --all-targets` — clean (one pre-existing unrelated warning in `utility/process_identity.rs`).
- New tests, all passing: 5 (orbit-common role discovery), 8 (orbit-store queries), 16 (orbit-core aggregation incl. 2 end-to-end), 7 (dashboard endpoint), 3 (dashboard asset contract).
- Full suites: orbit-common 309 pass, orbit-store 331 pass, orbit-dashboard 237 pass, orbit-core 741 pass / 1 fail.
- Verified against the real store the task's provenance came from: the SQL reproduces the reported shape (30d, one workspace: `implement_one` 305, `step_failure_recovery` 72, `triage` 11, `independent_review` 4; distinct-run coverage 331 total / 68 with recovery). All four observed `activity_id` values classify correctly under the fixed discovery — three are step ids, one is a recovery activity name.

## Pre-existing failures, named not repaired

`orbit-core` `command::init::tests::fresh_workspace_init_seeds_disabled_worktree_gc_routine` fails with `Io("Read-only file system (os error 30)")`. `init_workspace_at_root` writes into the global orbit root despite a `global_root_override`, and this sandbox mounts both `.orbit/` and `~/.orbit/` read-only. Unrelated to this change (`command/init.rs` is untouched) and environmental.

## Could not be done in this environment

`orbit tool run orbit.adr.add` failed with the same read-only-mount error, so no global ADR ID could be allocated. The decision record is written in full into `docs/design/user-interface/4_decisions.md` under an `ADR-PENDING` heading that explicitly flags the missing allocation. **A global ID must be allocated from a writable checkout before merge.** This is an already-known recurring friction (F2026-08-036, F2026-08-015, F2026-08-019, F2026-08-025); I filed a duplicate before checking and withdrew it as resolved (F2026-08-043, F2026-08-044), folding the one new data point — that the mount also breaks the init test above — into the withdrawal note.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10588-6a6fc0c8`
- Behind base: 0
- Ahead of base: 1