### PR TITLE
Friction records have no author-settable title; derivation from the first body line yields unusable titles and hides duplicates

### DIFF
--- a/crates/orbit-cli/src/command/tests/friction_help/add.txt
+++ b/crates/orbit-cli/src/command/tests/friction_help/add.txt
@@ -5,6 +5,7 @@ Usage: orbit friction add [OPTIONS] --body <BODY> --model <MODEL>
 Options:
       --body <BODY>                Markdown body describing what happened and why it caused friction
       --root <ROOT>                Override the Orbit root directory (highest precedence)
+      --title <TITLE>              One-line record handle, max 120 chars; derived when omitted
       --tag <TAGS>                 Friction taxonomy tag; repeat or comma-separate for multiple tags
       --during-task <DURING_TASK>  Optional task ID being worked on when friction occurred
       --model <MODEL>              Agent family to attribute the record to (`codex`, `claude`, `gemini`, or `grok`)

--- a/crates/orbit-cli/src/command/tests/friction_help/update.txt
+++ b/crates/orbit-cli/src/command/tests/friction_help/update.txt
@@ -10,5 +10,6 @@ Options:
       --status <STATUS>  Optional status: open, triaged, or resolved
       --tag <TAGS>       Optional replacement taxonomy tag; repeat or comma-separate for multiple tags
       --body <BODY>      Optional replacement markdown body
+      --title <TITLE>    Optional replacement title, max 120 chars; empty restores derivation
       --json             Output as JSON
   -h, --help             Print help

--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -803,6 +803,12 @@
         "required": true
       },
       {
+        "description": "One-line handle identifying the problem, at most 120 characters. This is what lists and searches show, so name the surface and the failure. Derived from the body's opening line when omitted",
+        "name": "title",
+        "param_type": "string",
+        "required": false
+      },
+      {
         "description": "Friction taxonomy tags as a string or array; valid tags: build | docs | lifecycle | naming | other | policy | skill-guidance | tooling; defaults to other",
         "name": "tags",
         "param_type": "string_list",
@@ -940,6 +946,12 @@
       {
         "description": "Optional replacement markdown body",
         "name": "body",
+        "param_type": "string",
+        "required": false
+      },
+      {
+        "description": "Optional replacement one-line title, at most 120 characters; an empty string restores derivation from the body",
+        "name": "title",
         "param_type": "string",
         "required": false
       }

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -516,6 +516,10 @@
           ],
           "description": "Friction taxonomy tags as a string or array; valid tags: build | docs | lifecycle | naming | other | policy | skill-guidance | tooling; defaults to other"
         },
+        "title": {
+          "description": "One-line handle identifying the problem, at most 120 characters. This is what lists and searches show, so name the surface and the failure. Derived from the body's opening line when omitted",
+          "type": "string"
+        },
         "workspace": {
           "description": "Workspace selector for broker routing: a registered logical workspace ID or an absolute path to a local checkout (a linked Git worktree resolves to its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from process cwd.",
           "type": "string"

--- a/crates/orbit-common/src/friction/mod.rs
+++ b/crates/orbit-common/src/friction/mod.rs
@@ -5,10 +5,12 @@
 //! wiring all derive from it.
 
 pub mod operations;
+pub mod title;
 
 pub use operations::{
     FRICTION_OPERATIONS, FrictionOperation, FrictionVerb, friction_operation, friction_operations,
 };
+pub use title::{FRICTION_TITLE_MAX_CHARS, derive_title, effective_title, normalize_title};
 
 /// Default friction tags and their human-readable glosses.
 ///

--- a/crates/orbit-common/src/friction/operations.rs
+++ b/crates/orbit-common/src/friction/operations.rs
@@ -16,6 +16,7 @@ use crate::operation::{
 use crate::types::McpToolPlacement;
 
 use super::friction_tags_literal;
+use super::title::FRICTION_TITLE_MAX_CHARS;
 
 /// Every verb the friction noun supports.
 ///
@@ -92,6 +93,16 @@ const ADD: FrictionOperation = FrictionOperation {
             cli: Some(CliBinding {
                 kind: flag("body"),
                 help: BODY_HELP,
+            }),
+        },
+        ParamSpec {
+            name: "title",
+            param_type: ParamType::String,
+            required: false,
+            mcp_description: Some(ADD_TITLE_HELP),
+            cli: Some(CliBinding {
+                kind: flag("title"),
+                help: ADD_TITLE_CLI_HELP,
             }),
         },
         ParamSpec {
@@ -247,6 +258,16 @@ const UPDATE: FrictionOperation = FrictionOperation {
             }),
         },
         text_param("body", "Optional replacement markdown body"),
+        ParamSpec {
+            name: "title",
+            param_type: ParamType::String,
+            required: false,
+            mcp_description: Some(UPDATE_TITLE_HELP),
+            cli: Some(CliBinding {
+                kind: flag("title"),
+                help: UPDATE_TITLE_CLI_HELP,
+            }),
+        },
     ],
     rejects_agent_field: false,
     mcp: McpExposure::OperatorOnly(McpToolPlacement::Hub),
@@ -281,6 +302,12 @@ pub fn friction_operation(name: &str) -> Option<&'static FrictionOperation> {
 const FRICTION_ID_HELP: Description = Description::Static("Friction record id, e.g. F2026-05-001");
 const BODY_HELP: Description =
     Description::Static("Markdown body describing what happened and why it caused friction");
+// The MCP descriptions carry the authoring guidance an agent needs at call
+// time; the CLI help stays one line so `--help` keeps its compact layout.
+const ADD_TITLE_HELP: Description = Description::Computed(add_title_description);
+const ADD_TITLE_CLI_HELP: Description = Description::Computed(add_title_cli_help);
+const UPDATE_TITLE_HELP: Description = Description::Computed(update_title_description);
+const UPDATE_TITLE_CLI_HELP: Description = Description::Computed(update_title_cli_help);
 const DURING_TASK_HELP: Description =
     Description::Static("Optional task ID being worked on when friction occurred");
 
@@ -334,6 +361,31 @@ const fn flag(long: &'static str) -> CliArgKind {
         long,
         delimiter: None,
     }
+}
+
+fn add_title_description() -> String {
+    format!(
+        "One-line handle identifying the problem, at most {FRICTION_TITLE_MAX_CHARS} characters. \
+         This is what lists and searches show, so name the surface and the failure. \
+         Derived from the body's opening line when omitted"
+    )
+}
+
+fn update_title_description() -> String {
+    format!(
+        "Optional replacement one-line title, at most {FRICTION_TITLE_MAX_CHARS} characters; \
+         an empty string restores derivation from the body"
+    )
+}
+
+fn add_title_cli_help() -> String {
+    format!("One-line record handle, max {FRICTION_TITLE_MAX_CHARS} chars; derived when omitted")
+}
+
+fn update_title_cli_help() -> String {
+    format!(
+        "Optional replacement title, max {FRICTION_TITLE_MAX_CHARS} chars; empty restores derivation"
+    )
 }
 
 fn add_tags_description() -> String {

--- a/crates/orbit-common/src/friction/tests.rs
+++ b/crates/orbit-common/src/friction/tests.rs
@@ -4,6 +4,8 @@
 //! bijection, names are unique and well-formed, and the shipped MCP/CLI strings
 //! are what consumers already depend on.
 
+mod title;
+
 use std::collections::BTreeSet;
 
 use super::operations::{FRICTION_OPERATIONS, FrictionVerb, friction_operation};

--- a/crates/orbit-common/src/friction/tests/title.rs
+++ b/crates/orbit-common/src/friction/tests/title.rs
@@ -1,0 +1,230 @@
+//! Title derivation reads body structure, not vocabulary.
+//!
+//! Every fixture below is synthetic. The generic section labels appear as
+//! *inputs* the structural rules must survive — no rule anywhere consults a
+//! list of them, and adding a new label spelling must not require a new case.
+
+use crate::friction::title::{
+    FRICTION_TITLE_MAX_CHARS, derive_title, effective_title, normalize_title,
+};
+
+/// A body with a single heading: the heading is the record's own title.
+const SOLE_HEADING: &str = "\
+## Task update refuses a record the sibling read just resolved
+
+The read path scans every registered scope; the write path stops at the
+default one.";
+
+/// A structured report: sibling headings at the same level, so the first one
+/// labels a section rather than the record.
+const SECTIONED_REPORT: &str = "\
+## What happened
+
+The update verb rejected an id the show verb had just returned.
+
+## Evidence
+
+Two calls, one id, opposite outcomes.
+
+## Why this is friction
+
+The failure reads as a missing record rather than a routing miss.";
+
+/// The same report shape written with bold lead-ins instead of headings.
+const BOLD_LEAD_REPORT: &str = "\
+**What happened.** The update verb rejected an id the show verb had just returned.
+
+**Root cause.** Only the read path scans beyond the default scope.";
+
+#[test]
+fn a_sole_heading_is_the_records_own_title() {
+    assert_eq!(
+        derive_title(SOLE_HEADING).as_deref(),
+        Some("Task update refuses a record the sibling read just resolved")
+    );
+}
+
+#[test]
+fn a_section_label_yields_the_prose_it_introduces() {
+    // The label is skipped because peers follow it, not because of its words.
+    assert_eq!(
+        derive_title(SECTIONED_REPORT).as_deref(),
+        Some("The update verb rejected an id the show verb had just returned.")
+    );
+}
+
+#[test]
+fn an_unfamiliar_section_label_is_skipped_on_the_same_evidence() {
+    let body = SECTIONED_REPORT.replace("What happened", "Beobachtung");
+    assert_eq!(
+        derive_title(&body).as_deref(),
+        Some("The update verb rejected an id the show verb had just returned.")
+    );
+}
+
+#[test]
+fn a_deeper_sibling_does_not_demote_a_leading_title() {
+    let body = "# Dispatch drops a queued run\n\n## Evidence\n\nOne run, no worker.";
+    assert_eq!(
+        derive_title(body).as_deref(),
+        Some("Dispatch drops a queued run")
+    );
+}
+
+#[test]
+fn a_bold_lead_in_yields_the_sentence_it_opens() {
+    assert_eq!(
+        derive_title(BOLD_LEAD_REPORT).as_deref(),
+        Some("The update verb rejected an id the show verb had just returned.")
+    );
+}
+
+#[test]
+fn a_line_that_is_only_a_bold_run_is_the_title() {
+    let body = "**Queued runs never reach a worker**\n\nThe dispatcher exits first.";
+    assert_eq!(
+        derive_title(body).as_deref(),
+        Some("Queued runs never reach a worker")
+    );
+}
+
+/// The unit is the paragraph, not the line. A hard-wrapped body would
+/// otherwise be cut at whatever column its author's editor used.
+#[test]
+fn a_hard_wrapped_opening_reads_as_one_paragraph() {
+    let body = "The update verb rejected an id\nthe show verb had just returned.\n\nMore detail.";
+
+    assert_eq!(
+        derive_title(body).as_deref(),
+        Some("The update verb rejected an id the show verb had just returned.")
+    );
+}
+
+#[test]
+fn a_hard_wrapped_section_body_reads_as_one_paragraph() {
+    let body = "## What happened\n\nThe update verb rejected an id\nthe show verb had just \
+                returned.\n\n## Evidence\n\nTwo calls.";
+
+    assert_eq!(
+        derive_title(body).as_deref(),
+        Some("The update verb rejected an id the show verb had just returned.")
+    );
+}
+
+#[test]
+fn a_headingless_paragraph_is_clamped_to_the_title_budget() {
+    let body = format!("{} and then some more text.", "word ".repeat(60));
+    let title = derive_title(&body).expect("derived title");
+
+    assert!(
+        title.chars().count() <= FRICTION_TITLE_MAX_CHARS,
+        "{title} is {} characters",
+        title.chars().count()
+    );
+    assert!(title.ends_with('…'), "{title}");
+    assert!(!title.contains("  "), "{title}");
+}
+
+#[test]
+fn a_clamped_title_cuts_at_a_word_boundary() {
+    let body = "supercalifragilistic ".repeat(20);
+    let title = derive_title(&body).expect("derived title");
+
+    assert!(title.ends_with("supercalifragilistic…"), "{title}");
+}
+
+#[test]
+fn a_short_body_is_not_clamped() {
+    let title = derive_title("Dispatch drops a queued run.").expect("derived title");
+
+    assert_eq!(title, "Dispatch drops a queued run.");
+    assert!(!title.ends_with('…'));
+}
+
+#[test]
+fn list_and_quote_markers_are_not_part_of_the_title() {
+    assert_eq!(
+        derive_title("- Dispatch drops a queued run").as_deref(),
+        Some("Dispatch drops a queued run")
+    );
+    assert_eq!(
+        derive_title("1. Dispatch drops a queued run").as_deref(),
+        Some("Dispatch drops a queued run")
+    );
+    assert_eq!(
+        derive_title("> Dispatch drops a queued run").as_deref(),
+        Some("Dispatch drops a queued run")
+    );
+}
+
+#[test]
+fn a_body_that_is_only_headings_falls_back_to_the_first_one() {
+    assert_eq!(
+        derive_title("## What happened\n\n## Evidence").as_deref(),
+        Some("What happened")
+    );
+}
+
+#[test]
+fn a_body_with_no_text_derives_nothing() {
+    assert_eq!(derive_title("   \n\n\t\n"), None);
+}
+
+#[test]
+fn a_stored_title_wins_over_the_body() {
+    assert_eq!(
+        effective_title(
+            Some("Update ignores non-default scopes"),
+            SECTIONED_REPORT,
+            "F1"
+        ),
+        "Update ignores non-default scopes"
+    );
+}
+
+#[test]
+fn a_blank_stored_title_falls_through_to_derivation() {
+    assert_eq!(
+        effective_title(Some("   "), SOLE_HEADING, "F1"),
+        "Task update refuses a record the sibling read just resolved"
+    );
+}
+
+#[test]
+fn a_record_with_neither_title_nor_text_falls_back_to_its_id() {
+    assert_eq!(effective_title(None, "", "F0000-00-000"), "F0000-00-000");
+}
+
+#[test]
+fn an_author_title_is_collapsed_to_one_line() {
+    assert_eq!(
+        normalize_title("  Update ignores\n  non-default scopes  ").expect("normalized"),
+        "Update ignores non-default scopes"
+    );
+}
+
+#[test]
+fn a_blank_author_title_is_rejected() {
+    let error = normalize_title(" \n ").expect_err("blank title");
+
+    assert!(error.to_string().contains("must not be blank"), "{error}");
+}
+
+#[test]
+fn an_author_title_past_the_budget_is_rejected() {
+    let error = normalize_title(&"x".repeat(FRICTION_TITLE_MAX_CHARS + 1)).expect_err("long title");
+
+    assert!(
+        error
+            .to_string()
+            .contains(&FRICTION_TITLE_MAX_CHARS.to_string()),
+        "{error}"
+    );
+}
+
+#[test]
+fn an_author_title_at_the_budget_is_accepted() {
+    let title = "x".repeat(FRICTION_TITLE_MAX_CHARS);
+
+    assert_eq!(normalize_title(&title).expect("boundary title"), title);
+}

--- a/crates/orbit-common/src/friction/title.rs
+++ b/crates/orbit-common/src/friction/title.rs
@@ -1,0 +1,232 @@
+//! The friction record title — one short handle per record.
+//!
+//! A friction record's handle is an author-supplied `title` on the record
+//! ([`normalize_title`]). Derivation from the body ([`derive_title`]) is the
+//! fallback for a record whose author supplied none, and the only source for
+//! records written before the field existed.
+//!
+//! Derivation reads the body's *structure*, never its vocabulary. A markdown
+//! document that opens with a heading is doing one of two things, and the
+//! difference is structural rather than lexical:
+//!
+//! - the heading is the document's own title — it is the only heading at its
+//!   level or shallower, so nothing else in the body claims to be a peer;
+//! - the heading labels the first *section* of a structured report — sibling
+//!   headings at the same level follow it, so the label describes a part of
+//!   the record rather than the record.
+//!
+//! In the second case the subject of the record is the prose the label
+//! introduces, so derivation skips the label. The same reasoning applies to a
+//! bold run that opens a prose line: an inline lead-in labels the sentence
+//! that follows it on the same line, so the sentence is the candidate.
+//!
+//! No list of known section headings appears here. Such a list is a symptom
+//! fix — it is unmaintainable across authors and untranslatable across
+//! languages — and it cannot help the opposite failure, an opening paragraph
+//! long enough to be unreadable in any list view. [`FRICTION_TITLE_MAX_CHARS`]
+//! bounds that one.
+
+use crate::types::OrbitError;
+
+/// Maximum length, in characters, of a friction record title.
+///
+/// Long enough for a specific one-line problem statement, short enough to sit
+/// in a CLI table column or a dashboard row without wrapping.
+pub const FRICTION_TITLE_MAX_CHARS: usize = 120;
+
+/// The ellipsis appended to a title clamped at [`FRICTION_TITLE_MAX_CHARS`].
+const ELLIPSIS: char = '…';
+
+/// Shortest clamped prefix worth cutting back to a word boundary for. Below
+/// this, honouring the boundary would discard more than it saves.
+const MIN_WORD_BOUNDARY_PREFIX: usize = FRICTION_TITLE_MAX_CHARS / 2;
+
+/// Normalize and validate an author-supplied title.
+///
+/// A title is a single line: interior newlines and whitespace runs collapse to
+/// single spaces so the stored value renders the same in every consumer.
+pub fn normalize_title(raw: &str) -> Result<String, OrbitError> {
+    let title = collapse_whitespace(raw);
+    if title.is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "friction `title` must not be blank".to_string(),
+        ));
+    }
+    let length = title.chars().count();
+    if length > FRICTION_TITLE_MAX_CHARS {
+        return Err(OrbitError::InvalidInput(format!(
+            "friction `title` must be at most {FRICTION_TITLE_MAX_CHARS} characters, got {length}; \
+             it is the record's handle in lists and search — keep the full report in `body`"
+        )));
+    }
+    Ok(title)
+}
+
+/// Derive a title from a friction body.
+///
+/// Returns `None` only for a body with no textual content at all.
+pub fn derive_title(body: &str) -> Option<String> {
+    let lines = body.lines().collect::<Vec<_>>();
+    let first_index = lines.iter().position(|line| !line.trim().is_empty())?;
+    let candidate = candidate_text(&lines, first_index);
+    let candidate = collapse_whitespace(&strip_line_decoration(&candidate));
+    if candidate.is_empty() {
+        return None;
+    }
+    Some(clamp_title(&candidate))
+}
+
+/// The handle to show for a record: the stored title, the derived one, or —
+/// for a record with neither — its id, which at least resolves.
+pub fn effective_title(stored: Option<&str>, body: &str, id: &str) -> String {
+    stored
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .map(ToString::to_string)
+        .or_else(|| derive_title(body))
+        .unwrap_or_else(|| id.to_string())
+}
+
+/// Pick the text that carries the record's subject, skipping a leading label.
+fn candidate_text(lines: &[&str], first_index: usize) -> String {
+    let first = lines[first_index].trim();
+
+    if let Some(level) = heading_level(first) {
+        let text = heading_text(first);
+        // A heading with a peer or shallower sibling labels a section of a
+        // structured report; the record's subject is the prose it introduces.
+        if has_further_heading(lines, first_index, level) {
+            return first_prose_paragraph(lines, first_index).unwrap_or(text);
+        }
+        return text;
+    }
+
+    strip_bold_lead(&paragraph_from(lines, first_index))
+}
+
+/// Join the paragraph starting at `start` into one string.
+///
+/// The unit is the paragraph, not the line: a hard-wrapped body states its
+/// subject across a wrap, and reading a single line would cut the sentence at
+/// whatever column the author's editor happened to use.
+fn paragraph_from(lines: &[&str], start: usize) -> String {
+    lines
+        .iter()
+        .skip(start)
+        .map(|line| line.trim())
+        .take_while(|line| !line.is_empty() && heading_level(line).is_none())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// The first paragraph after `first_index` that is not itself a heading.
+fn first_prose_paragraph(lines: &[&str], first_index: usize) -> Option<String> {
+    let start = lines
+        .iter()
+        .enumerate()
+        .skip(first_index + 1)
+        .find(|(_, line)| {
+            let line = line.trim();
+            !line.is_empty() && heading_level(line).is_none()
+        })
+        .map(|(index, _)| index)?;
+    Some(strip_bold_lead(&paragraph_from(lines, start)))
+}
+
+/// Drop a leading `**bold**` lead-in, keeping the sentence it introduces.
+///
+/// An inline lead-in labels the sentence beside it; a line that is nothing but
+/// the bold run is itself the subject.
+fn strip_bold_lead(text: &str) -> String {
+    match split_bold_lead(text) {
+        Some((label, rest)) if rest.is_empty() => label.to_string(),
+        Some((_, rest)) => rest.to_string(),
+        None => text.to_string(),
+    }
+}
+
+/// The ATX heading level of `line`, if it is a heading.
+fn heading_level(line: &str) -> Option<usize> {
+    let hashes = line.chars().take_while(|c| *c == '#').count();
+    (hashes > 0 && hashes <= 6).then_some(hashes)
+}
+
+/// A heading line's text, with its markers removed.
+fn heading_text(line: &str) -> String {
+    line.trim_start_matches('#')
+        .trim_end_matches('#')
+        .trim()
+        .to_string()
+}
+
+/// Whether any later line is a heading at `level` or shallower — the signal
+/// that the heading at `first_index` is one section among several.
+fn has_further_heading(lines: &[&str], first_index: usize, level: usize) -> bool {
+    lines
+        .iter()
+        .skip(first_index + 1)
+        .filter_map(|line| heading_level(line.trim()))
+        .any(|other| other <= level)
+}
+
+/// Split a leading `**bold**` run from the rest of its line.
+fn split_bold_lead(line: &str) -> Option<(&str, &str)> {
+    let rest = line.strip_prefix("**")?;
+    let close = rest.find("**")?;
+    let label = rest[..close].trim();
+    if label.is_empty() {
+        return None;
+    }
+    Some((label, rest[close + 2..].trim()))
+}
+
+/// Remove leading block markers (quote, list, heading) a title should not carry.
+fn strip_line_decoration(line: &str) -> String {
+    let mut value = line.trim();
+    loop {
+        let stripped = value
+            .strip_prefix('>')
+            .or_else(|| value.strip_prefix("- "))
+            .or_else(|| value.strip_prefix("* "))
+            .or_else(|| value.strip_prefix("+ "))
+            .or_else(|| strip_ordered_marker(value))
+            .map(str::trim_start);
+        match stripped {
+            Some(next) if next != value => value = next,
+            _ => break,
+        }
+    }
+    value.trim_start_matches('#').trim().to_string()
+}
+
+/// Strip an ordered-list marker (`1.` / `2)`), if the line opens with one.
+fn strip_ordered_marker(line: &str) -> Option<&str> {
+    let digits = line.chars().take_while(char::is_ascii_digit).count();
+    if digits == 0 {
+        return None;
+    }
+    let rest = &line[digits..];
+    rest.strip_prefix(". ").or_else(|| rest.strip_prefix(") "))
+}
+
+/// Collapse every whitespace run to a single space and trim the result.
+fn collapse_whitespace(raw: &str) -> String {
+    raw.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Bound a candidate at [`FRICTION_TITLE_MAX_CHARS`], preferring a word boundary.
+fn clamp_title(candidate: &str) -> String {
+    if candidate.chars().count() <= FRICTION_TITLE_MAX_CHARS {
+        return candidate.to_string();
+    }
+    let budget = FRICTION_TITLE_MAX_CHARS - 1;
+    let mut prefix = candidate.chars().take(budget).collect::<String>();
+    if let Some(boundary) = prefix.rfind(char::is_whitespace)
+        && prefix[..boundary].chars().count() >= MIN_WORD_BOUNDARY_PREFIX
+    {
+        prefix.truncate(boundary);
+    }
+    let mut title = prefix.trim_end().to_string();
+    title.push(ELLIPSIS);
+    title
+}

--- a/crates/orbit-common/src/types/friction.rs
+++ b/crates/orbit-common/src/types/friction.rs
@@ -47,6 +47,14 @@ impl FromStr for FrictionStatus {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FrictionRecord {
     pub id: String,
+    /// The record's handle in lists, tables, and search.
+    ///
+    /// Author-supplied through `orbit.friction.add` / `.update`, and filled in
+    /// from the body at write time when the author supplies none. `None` for a
+    /// record written before the field existed; those derive a handle on read
+    /// (`orbit_common::friction::effective_title`), so no migration is owed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     /// Model identifier for this friction record (per-invocation actual execution).
     pub model: String,
     pub created_at: DateTime<Utc>,
@@ -66,6 +74,8 @@ pub struct FrictionRecord {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FrictionFrontmatter {
     pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     pub model: String,
     pub created_at: DateTime<Utc>,
     #[serde(default)]

--- a/crates/orbit-core/src/runtime/orbit_tool_host/friction_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/friction_tools.rs
@@ -10,10 +10,10 @@
 use std::str::FromStr;
 
 use chrono::{DateTime, TimeZone, Utc};
-use orbit_common::friction::FrictionVerb;
+use orbit_common::friction::{FrictionVerb, effective_title, normalize_title};
 use orbit_common::types::{
-    FrictionRecord, FrictionStatus, OrbitError, optional_csv_or_string_list_alias, optional_string,
-    required_string,
+    FrictionRecord, FrictionStatus, OrbitError, optional_csv_or_string_list_alias,
+    optional_raw_string, optional_string, required_string,
 };
 use orbit_store::friction_store::{
     FrictionAddParams, FrictionListFilter, FrictionUpdateParams, StoredFrictionRecord,
@@ -47,6 +47,9 @@ pub(super) fn dispatch(
 
 fn add(runtime: &OrbitRuntime, input: Value, model: Option<String>) -> Result<Value, OrbitError> {
     let body = required_string(&input, &["body", "description"], "body")?;
+    let title = optional_raw_string(&input, "title")?
+        .map(|raw| normalize_title(&raw))
+        .transpose()?;
     let tags = optional_csv_or_string_list_alias(&input, &["tags", "tag"])?.unwrap_or_default();
     let during_task = optional_string(&input, "during_task")?
         .or_else(|| optional_string(&input, "task_id").ok().flatten());
@@ -60,6 +63,7 @@ fn add(runtime: &OrbitRuntime, input: Value, model: Option<String>) -> Result<Va
         &runtime.data_root().join("frictions"),
         FrictionAddParams {
             model,
+            title,
             body,
             tags,
             during_task,
@@ -141,9 +145,16 @@ fn update(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
         .transpose()?;
     let tags = optional_csv_or_string_list_alias(&input, &["tags", "tag"])?;
     let body = optional_string(&input, "body")?;
-    if status.is_none() && tags.is_none() && body.is_none() {
+    // An explicit empty `title` clears the stored one, which restores
+    // derivation from the body — distinct from omitting the field entirely.
+    let title = match optional_raw_string(&input, "title")? {
+        None => None,
+        Some(raw) if raw.trim().is_empty() => Some(None),
+        Some(raw) => Some(Some(normalize_title(&raw)?)),
+    };
+    if status.is_none() && tags.is_none() && body.is_none() && title.is_none() {
         return Err(OrbitError::InvalidInput(
-            "orbit.friction.update requires `status`, `tags`, or `body`".to_string(),
+            "orbit.friction.update requires `status`, `tags`, `body`, or `title`".to_string(),
         ));
     }
     let stored = update_friction(
@@ -152,6 +163,7 @@ fn update(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
         FrictionUpdateParams {
             status,
             tags,
+            title,
             body,
             resolved_by_task: None,
             updated_at: Utc::now(),
@@ -236,31 +248,26 @@ fn record_to_json(stored: StoredFrictionRecord) -> Result<Value, OrbitError> {
         .map_err(|error| OrbitError::Store(format!("serialize friction record: {error}")))?;
     if let Some(object) = value.as_object_mut() {
         object.insert("path".to_string(), json!(stored.path.to_string_lossy()));
+        // `title` is always present on the wire: a record written before the
+        // field existed derives one here rather than reaching consumers blank.
         object.insert("title".to_string(), json!(record_title(&stored.record)));
     }
     Ok(value)
 }
 
 fn record_title(record: &FrictionRecord) -> String {
-    record
-        .body
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty())
-        .map(|line| line.trim_start_matches('#').trim().to_string())
-        .filter(|line| !line.is_empty())
-        .unwrap_or_else(|| record.id.clone())
+    effective_title(record.title.as_deref(), &record.body, &record.id)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn record_to_json_includes_resolved_by_task() {
-        let stored = StoredFrictionRecord {
+    fn stored_record(title: Option<&str>, body: &str) -> StoredFrictionRecord {
+        StoredFrictionRecord {
             record: FrictionRecord {
                 id: "F2026-05-007".to_string(),
+                title: title.map(ToString::to_string),
                 model: "codex".to_string(),
                 created_at: Utc.with_ymd_and_hms(2026, 5, 17, 4, 5, 0).unwrap(),
                 status: FrictionStatus::Resolved,
@@ -268,13 +275,43 @@ mod tests {
                 resolved_at: Some(Utc.with_ymd_and_hms(2026, 5, 17, 4, 10, 0).unwrap()),
                 during_task: None,
                 resolved_by_task: Some("ORB-00093".to_string()),
-                body: "Resolved by task".to_string(),
+                body: body.to_string(),
             },
             path: "frictions/2026-05/F007.md".into(),
-        };
+        }
+    }
 
-        let value = record_to_json(stored).unwrap();
+    #[test]
+    fn record_to_json_includes_resolved_by_task() {
+        let value = record_to_json(stored_record(None, "Resolved by task")).unwrap();
 
         assert_eq!(value["resolved_by_task"], json!("ORB-00093"));
+    }
+
+    #[test]
+    fn record_to_json_prefers_the_stored_title() {
+        let value = record_to_json(stored_record(
+            Some("Queued runs never reach a worker"),
+            "## What happened\n\nSomething else entirely.",
+        ))
+        .unwrap();
+
+        assert_eq!(value["title"], json!("Queued runs never reach a worker"));
+    }
+
+    /// A record written before the field existed still projects a usable
+    /// handle, so the corpus needs no rewrite to become readable.
+    #[test]
+    fn record_to_json_derives_a_title_for_a_record_without_one() {
+        let value = record_to_json(stored_record(
+            None,
+            "## What happened\n\nThe worker exited before claiming the run.\n\n## Evidence\n\nOne log line.",
+        ))
+        .unwrap();
+
+        assert_eq!(
+            value["title"],
+            json!("The worker exited before claiming the run.")
+        );
     }
 }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/host.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/host.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use chrono::Utc;
-use orbit_common::friction::FrictionVerb;
+use orbit_common::friction::{FrictionVerb, effective_title, normalize_title};
 use orbit_common::types::{
     FrictionStatus, NotFoundKind, OrbitError, Task, TaskComment, TaskPriority, TaskStatus,
     TaskType, ToolSessionContext, is_valid_friction_id, normalize_optional_attribution_label,
@@ -720,6 +720,9 @@ impl HubCoordinationExecutor {
                     &root,
                     FrictionAddParams {
                         model,
+                        title: optional_raw_string(&input, "title")?
+                            .map(|raw| normalize_title(&redact_all(&raw)))
+                            .transpose()?,
                         body: redact_all(&required_string(
                             &input,
                             &["body", "description"],
@@ -745,9 +748,15 @@ impl HubCoordinationExecutor {
                     .transpose()?;
                 let tags = optional_csv_or_string_list_alias(&input, &["tags", "tag"])?;
                 let body = optional_string(&input, "body")?.map(|value| redact_all(&value));
-                if status.is_none() && tags.is_none() && body.is_none() {
+                let title = match optional_raw_string(&input, "title")? {
+                    None => None,
+                    Some(raw) if raw.trim().is_empty() => Some(None),
+                    Some(raw) => Some(Some(normalize_title(&redact_all(&raw))?)),
+                };
+                if status.is_none() && tags.is_none() && body.is_none() && title.is_none() {
                     return Err(OrbitError::InvalidInput(
-                        "orbit.friction.update requires `status`, `tags`, or `body`".to_string(),
+                        "orbit.friction.update requires `status`, `tags`, `body`, or `title`"
+                            .to_string(),
                     ));
                 }
                 friction_json(update_friction(
@@ -756,6 +765,7 @@ impl HubCoordinationExecutor {
                     FrictionUpdateParams {
                         status,
                         tags,
+                        title,
                         body,
                         resolved_by_task: None,
                         updated_at: Utc::now(),
@@ -812,8 +822,22 @@ fn raw_clearable(input: &Value, field: &str) -> Result<Option<Option<String>>, O
 fn friction_json(
     stored: orbit_store::friction_store::StoredFrictionRecord,
 ) -> Result<Value, OrbitError> {
-    serde_json::to_value(&stored.record)
-        .map_err(|error| OrbitError::Store(format!("serialize friction record: {error}")))
+    let record = &stored.record;
+    let mut value = serde_json::to_value(record)
+        .map_err(|error| OrbitError::Store(format!("serialize friction record: {error}")))?;
+    // Match the checkout-backed projection: `title` is always on the wire, so
+    // a hub consumer never has to know derivation exists.
+    if let Some(object) = value.as_object_mut() {
+        object.insert(
+            "title".to_string(),
+            json!(effective_title(
+                record.title.as_deref(),
+                &record.body,
+                &record.id
+            )),
+        );
+    }
+    Ok(value)
 }
 
 fn strip_private_friction_paths(value: &mut Value) {

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/friction_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/friction_tools.rs
@@ -1,0 +1,157 @@
+//! The friction write surface, exercised through the registered tools
+//! [ORB-10590].
+//!
+//! These are the boundary tests for the record handle: what an author can set,
+//! what the surface refuses, and what a caller who sets nothing gets.
+
+use orbit_common::friction::FRICTION_TITLE_MAX_CHARS;
+use orbit_common::test_fixtures::TEST_CODEX_MODEL;
+use serde_json::{Value, json};
+
+use super::super::test_support::{invalid_input_message, run_tool_as_operator, test_runtime};
+
+/// A structured report whose opening line labels a section rather than the
+/// record — the shape derivation has to see through.
+const SECTIONED_BODY: &str = "## What happened\n\nThe worker exited before claiming the run.\n\n\
+                              ## Evidence\n\nOne log line.";
+
+fn add(input: Value) -> Result<Value, orbit_common::types::OrbitError> {
+    let (_temp, runtime, _repo) = test_runtime();
+    run_tool_as_operator(&runtime, "orbit.friction.add", input)
+}
+
+#[test]
+fn add_records_the_authors_title() {
+    let record = add(json!({
+        "body": SECTIONED_BODY,
+        "title": "Worker exits before claiming its run",
+        "model": TEST_CODEX_MODEL,
+    }))
+    .expect("add with title");
+
+    assert_eq!(
+        record["title"],
+        json!("Worker exits before claiming its run")
+    );
+}
+
+#[test]
+fn add_without_a_title_falls_back_to_the_bodys_subject() {
+    let record = add(json!({ "body": SECTIONED_BODY, "model": TEST_CODEX_MODEL }))
+        .expect("add without title");
+
+    assert_eq!(
+        record["title"],
+        json!("The worker exited before claiming the run.")
+    );
+}
+
+#[test]
+fn add_refuses_a_title_too_long_to_read_in_a_list() {
+    let message = invalid_input_message(add(json!({
+        "body": SECTIONED_BODY,
+        "title": "x".repeat(FRICTION_TITLE_MAX_CHARS + 1),
+        "model": TEST_CODEX_MODEL,
+    })));
+
+    assert!(message.contains("`title`"), "{message}");
+    assert!(
+        message.contains(&FRICTION_TITLE_MAX_CHARS.to_string()),
+        "{message}"
+    );
+}
+
+#[test]
+fn add_refuses_a_blank_title() {
+    let message = invalid_input_message(add(json!({
+        "body": SECTIONED_BODY,
+        "title": "   ",
+        "model": TEST_CODEX_MODEL,
+    })));
+
+    assert!(message.contains("must not be blank"), "{message}");
+}
+
+#[test]
+fn a_multi_line_title_is_stored_as_one_line() {
+    let record = add(json!({
+        "body": SECTIONED_BODY,
+        "title": "Worker exits\nbefore claiming its run",
+        "model": TEST_CODEX_MODEL,
+    }))
+    .expect("add with multi-line title");
+
+    assert_eq!(
+        record["title"],
+        json!("Worker exits before claiming its run")
+    );
+}
+
+#[test]
+fn update_retitles_a_record_without_touching_its_body() {
+    let (_temp, runtime, _repo) = test_runtime();
+    let seeded = run_tool_as_operator(
+        &runtime,
+        "orbit.friction.add",
+        json!({ "body": SECTIONED_BODY, "model": TEST_CODEX_MODEL }),
+    )
+    .expect("seed record");
+    let id = seeded["id"].as_str().expect("record id");
+
+    let updated = run_tool_as_operator(
+        &runtime,
+        "orbit.friction.update",
+        json!({ "id": id, "title": "Worker exits before claiming its run" }),
+    )
+    .expect("retitle");
+
+    assert_eq!(
+        updated["title"],
+        json!("Worker exits before claiming its run")
+    );
+    assert_eq!(updated["body"], seeded["body"]);
+}
+
+#[test]
+fn an_empty_update_title_restores_derivation() {
+    let (_temp, runtime, _repo) = test_runtime();
+    let seeded = run_tool_as_operator(
+        &runtime,
+        "orbit.friction.add",
+        json!({ "body": SECTIONED_BODY, "title": "Set by hand", "model": TEST_CODEX_MODEL }),
+    )
+    .expect("seed record");
+    let id = seeded["id"].as_str().expect("record id");
+
+    let updated = run_tool_as_operator(
+        &runtime,
+        "orbit.friction.update",
+        json!({ "id": id, "title": "" }),
+    )
+    .expect("clear title");
+
+    assert_eq!(
+        updated["title"],
+        json!("The worker exited before claiming the run.")
+    );
+}
+
+#[test]
+fn update_still_requires_at_least_one_mutable_field() {
+    let (_temp, runtime, _repo) = test_runtime();
+    let seeded = run_tool_as_operator(
+        &runtime,
+        "orbit.friction.add",
+        json!({ "body": SECTIONED_BODY, "model": TEST_CODEX_MODEL }),
+    )
+    .expect("seed record");
+    let id = seeded["id"].as_str().expect("record id");
+
+    let message = invalid_input_message(run_tool_as_operator(
+        &runtime,
+        "orbit.friction.update",
+        json!({ "id": id }),
+    ));
+
+    assert!(message.contains("`title`"), "{message}");
+}

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/mod.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/mod.rs
@@ -1,3 +1,4 @@
+mod friction_tools;
 mod learning_tools;
 mod state_tools;
 mod task_tools;

--- a/crates/orbit-core/src/runtime/v2_host/triage.rs
+++ b/crates/orbit-core/src/runtime/v2_host/triage.rs
@@ -132,6 +132,10 @@ fn mark_triage_gave_up(
         &runtime.data_root().join("frictions"),
         FrictionAddParams {
             model: "system".to_string(),
+            title: Some(format!(
+                "Triage exhausted its re-backlog budget for task {}",
+                task.id
+            )),
             body: format!(
                 "Triage exhausted its re-backlog budget ({max_rebacklogs}) for task {} — \
                  its workflow runs keep failing (latest: {run_id}). The task stays \

--- a/crates/orbit-core/tests/relation_auto_close.rs
+++ b/crates/orbit-core/tests/relation_auto_close.rs
@@ -28,6 +28,7 @@ fn add_test_friction(runtime: &OrbitRuntime) -> String {
         &runtime.data_root().join("frictions"),
         FrictionAddParams {
             model: "codex".to_string(),
+            title: None,
             body: "Approval should close this friction".to_string(),
             tags: vec!["tooling".to_string()],
             during_task: None,

--- a/crates/orbit-dashboard/src/api/frictions.rs
+++ b/crates/orbit-dashboard/src/api/frictions.rs
@@ -106,6 +106,8 @@ pub(super) struct CreateFrictionBody {
     #[serde(default)]
     model: Option<String>,
     #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
     body: Option<String>,
     #[serde(default)]
     tags: Option<Vec<String>>,
@@ -119,6 +121,10 @@ pub(super) struct FrictionPatchBody {
     status: Option<String>,
     #[serde(default)]
     tags: Option<Vec<String>>,
+    /// Retitling a record is triage, not a body edit: an operator can give a
+    /// legacy record a usable handle without touching its append-only report.
+    #[serde(default)]
+    title: Option<String>,
 }
 
 pub(super) async fn list_frictions(
@@ -189,6 +195,7 @@ pub(super) async fn create_friction_action(
     let mut call = FrictionCall::new(FrictionVerb::Add);
     let built = (|| {
         call.set_optional("model", body.model.as_deref())?;
+        call.set_optional("title", body.title.as_deref())?;
         if let Some(friction_body) = body.body {
             call.set("body", Value::String(friction_body))?;
         }
@@ -238,8 +245,9 @@ pub(super) async fn update_friction_action(
         return bad_request("request body must include `status` or `tags`".to_string());
     };
     let status = body.status.as_deref().and_then(non_empty_string);
-    if status.is_none() && body.tags.is_none() {
-        return bad_request("request body must include `status` or `tags`".to_string());
+    let title = body.title.as_deref().and_then(non_empty_string);
+    if status.is_none() && body.tags.is_none() && title.is_none() {
+        return bad_request("request body must include `status`, `tags`, or `title`".to_string());
     }
 
     let built = id_call(FrictionVerb::Update, id).and_then(|mut call| {
@@ -248,6 +256,9 @@ pub(super) async fn update_friction_action(
         }
         if let Some(tags) = body.tags {
             call.set("tags", json!(tags))?;
+        }
+        if let Some(title) = title {
+            call.set("title", Value::String(title))?;
         }
         Ok(call)
     });

--- a/crates/orbit-store/src/file/friction_store/mod.rs
+++ b/crates/orbit-store/src/file/friction_store/mod.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Datelike, TimeZone, Utc};
-use orbit_common::friction::DEFAULT_FRICTION_TAGS;
+use orbit_common::friction::{DEFAULT_FRICTION_TAGS, derive_title};
 use orbit_common::types::{
     FrictionFrontmatter, FrictionRecord, FrictionStatus, OrbitError, Task, TaskStatus,
     all_agent_families, infer_agent_family_from_model, normalize_optional_attribution_label,
@@ -235,6 +235,9 @@ fn directory_trees_identical(left: &Path, right: &Path) -> Result<bool, OrbitErr
 #[derive(Debug, Clone)]
 pub struct FrictionAddParams {
     pub model: String,
+    /// The record's handle. Callers pass the author's title, or `None` to let
+    /// the store derive one from the body.
+    pub title: Option<String>,
     pub body: String,
     pub tags: Vec<String>,
     pub during_task: Option<String>,
@@ -255,6 +258,9 @@ pub struct FrictionListFilter {
 pub struct FrictionUpdateParams {
     pub status: Option<FrictionStatus>,
     pub tags: Option<Vec<String>>,
+    /// `Some(Some(title))` sets the stored title; `Some(None)` clears it and
+    /// restores derivation from the body.
+    pub title: Option<Option<String>>,
     pub body: Option<String>,
     pub resolved_by_task: Option<String>,
     pub updated_at: DateTime<Utc>,
@@ -288,10 +294,14 @@ pub fn add_friction(
                 path.display()
             )));
         }
+        // Derivation runs here, not on read, so every new record carries an
+        // explicit handle its next reader can see and correct in the file.
+        let title = params.title.clone().or_else(|| derive_title(&params.body));
         write_record_at(
             &path,
             &FrictionRecord {
                 id,
+                title,
                 model: params.model.trim().to_string(),
                 created_at: params.created_at,
                 status: FrictionStatus::Open,
@@ -398,6 +408,9 @@ pub fn update_friction(
             let taxonomy = load_tag_taxonomy(frictions_root)?;
             stored.record.tags = normalize_and_validate_tags(tags, &taxonomy)?;
         }
+        if let Some(title) = params.title {
+            stored.record.title = title;
+        }
         if let Some(body) = params.body {
             stored.record.body = body;
         }
@@ -437,6 +450,7 @@ pub fn resolve_friction(
         FrictionUpdateParams {
             status: Some(FrictionStatus::Resolved),
             tags: None,
+            title: None,
             body: None,
             resolved_by_task: None,
             updated_at: resolved_at,
@@ -456,6 +470,7 @@ pub fn resolve_friction_by_task(
         FrictionUpdateParams {
             status: Some(FrictionStatus::Resolved),
             tags: None,
+            title: None,
             body: None,
             resolved_by_task: Some(task_id.to_string()),
             updated_at: resolved_at,
@@ -615,6 +630,10 @@ fn record_matches_query(record: &FrictionRecord, raw_query: &str) -> bool {
         return true;
     }
     record.id.to_lowercase().contains(&query)
+        || record
+            .title
+            .as_deref()
+            .is_some_and(|title| title.to_lowercase().contains(&query))
         || record.model.to_lowercase().contains(&query)
         || record.status.as_str().contains(&query)
         || record
@@ -698,6 +717,7 @@ fn write_record_at(
 ) -> Result<StoredFrictionRecord, OrbitError> {
     let frontmatter = FrictionFrontmatter {
         id: record.id.clone(),
+        title: record.title.clone(),
         model: record.model.clone(),
         created_at: record.created_at,
         status: record.status,
@@ -735,6 +755,7 @@ fn read_record_at(path: &Path) -> Result<StoredFrictionRecord, OrbitError> {
     Ok(StoredFrictionRecord {
         record: FrictionRecord {
             id: frontmatter.id,
+            title: frontmatter.title,
             model: frontmatter.model,
             created_at: frontmatter.created_at,
             status: frontmatter.status,

--- a/crates/orbit-store/src/file/friction_store/tests/friction_store.rs
+++ b/crates/orbit-store/src/file/friction_store/tests/friction_store.rs
@@ -116,6 +116,130 @@ fn id_allocation_resets_across_month_boundary() {
     assert_eq!(next_month.record.id, "F2026-06-001");
 }
 
+/// Titles are resolved once, at write time, so the file itself carries the
+/// handle rather than every reader re-deriving one [ORB-10590].
+#[test]
+fn add_stores_the_authors_title_in_the_frontmatter() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let mut add = params(TEST_CODEX_MODEL, Utc::now(), vec!["tooling"]);
+    add.title = Some("Queued runs never reach a worker".to_string());
+
+    let stored = add_friction(root, add).expect("add with title");
+
+    assert_eq!(
+        stored.record.title.as_deref(),
+        Some("Queued runs never reach a worker")
+    );
+    let raw = fs::read_to_string(&stored.path).expect("read record");
+    assert!(
+        raw.contains("title: Queued runs never reach a worker"),
+        "{raw}"
+    );
+    let reread = show_friction(root, &stored.record.id)
+        .expect("show")
+        .expect("record");
+    assert_eq!(reread.record.title, stored.record.title);
+}
+
+#[test]
+fn add_without_a_title_persists_the_derived_one() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let mut add = params(TEST_CODEX_MODEL, Utc::now(), vec!["tooling"]);
+    add.body = "## What happened\n\nThe worker exited before claiming the run.\n\n## Evidence\n\nOne log line.".to_string();
+
+    let stored = add_friction(root, add).expect("add without title");
+
+    assert_eq!(
+        stored.record.title.as_deref(),
+        Some("The worker exited before claiming the run.")
+    );
+}
+
+#[test]
+fn update_sets_and_clears_the_stored_title() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let stored = add_friction(root, params(TEST_CODEX_MODEL, Utc::now(), vec!["tooling"]))
+        .expect("seed record");
+
+    let retitled = update_friction(
+        root,
+        &stored.record.id,
+        FrictionUpdateParams {
+            status: None,
+            tags: None,
+            title: Some(Some("Queued runs never reach a worker".to_string())),
+            body: None,
+            resolved_by_task: None,
+            updated_at: Utc::now(),
+        },
+    )
+    .expect("set title");
+    assert_eq!(
+        retitled.record.title.as_deref(),
+        Some("Queued runs never reach a worker")
+    );
+
+    let cleared = update_friction(
+        root,
+        &stored.record.id,
+        FrictionUpdateParams {
+            status: None,
+            tags: None,
+            title: Some(None),
+            body: None,
+            resolved_by_task: None,
+            updated_at: Utc::now(),
+        },
+    )
+    .expect("clear title");
+    assert_eq!(cleared.record.title, None);
+}
+
+/// A record written before the field existed still parses; its handle comes
+/// from derivation on read, so no migration pass is owed.
+#[test]
+fn a_record_without_a_title_field_still_parses() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let month = root.join("2026-05");
+    fs::create_dir_all(&month).expect("month dir");
+    fs::write(
+        month.join("F001.md"),
+        "---\nid: F2026-05-001\nmodel: codex\ncreated_at: 2026-05-17T04:05:00Z\n\
+         status: open\ntags:\n- tooling\n---\nThe worker exited before claiming the run.\n",
+    )
+    .expect("legacy record");
+
+    let stored = show_friction(root, "F2026-05-001")
+        .expect("show")
+        .expect("record");
+
+    assert_eq!(stored.record.title, None);
+    assert_eq!(
+        stored.record.body,
+        "The worker exited before claiming the run."
+    );
+}
+
+#[test]
+fn the_query_filter_matches_a_stored_title() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let mut add = params(TEST_CODEX_MODEL, Utc::now(), vec!["tooling"]);
+    add.title = Some("Queued runs never reach a worker".to_string());
+    add_friction(root, add).expect("add with title");
+
+    let filter = FrictionListFilter {
+        q: Some("never reach".to_string()),
+        ..FrictionListFilter::default()
+    };
+
+    assert_eq!(list_frictions(root, &filter).expect("list").len(), 1);
+}
+
 #[test]
 fn tag_validation_uses_taxonomy_file() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -173,6 +297,7 @@ fn stats_render_zero_rows_for_known_grok_family() {
 fn params(model: &str, created_at: DateTime<Utc>, tags: Vec<&str>) -> FrictionAddParams {
     FrictionAddParams {
         model: model.to_string(),
+        title: None,
         body: "Body".to_string(),
         tags: tags.into_iter().map(str::to_string).collect(),
         during_task: None,

--- a/crates/orbit-store/src/file/scoreboard/scoreboard_summary/tests/scoreboard_summary.rs
+++ b/crates/orbit-store/src/file/scoreboard/scoreboard_summary/tests/scoreboard_summary.rs
@@ -596,6 +596,7 @@ fn summary_exposes_friction_reported_counts_from_records() {
         crate::friction_store::StoredFrictionRecord {
             record: orbit_common::types::FrictionRecord {
                 id: "F001".to_string(),
+                title: None,
                 model: "codex".to_string(),
                 created_at: Utc::now(),
                 status: orbit_common::types::FrictionStatus::Open,
@@ -610,6 +611,7 @@ fn summary_exposes_friction_reported_counts_from_records() {
         crate::friction_store::StoredFrictionRecord {
             record: orbit_common::types::FrictionRecord {
                 id: "F002".to_string(),
+                title: None,
                 model: "claude-3-opus".to_string(),
                 created_at: Utc::now(),
                 status: orbit_common::types::FrictionStatus::Resolved,

--- a/crates/orbit-tools/src/builtin/orbit/friction/tests/derived_schema.rs
+++ b/crates/orbit-tools/src/builtin/orbit/friction/tests/derived_schema.rs
@@ -5,7 +5,8 @@
 // docs/design-patterns/test_layout.md.
 
 use orbit_common::friction::{
-    DEFAULT_FRICTION_TAGS, FRICTION_OPERATIONS, FrictionVerb, friction_tags_literal,
+    DEFAULT_FRICTION_TAGS, FRICTION_OPERATIONS, FRICTION_TITLE_MAX_CHARS, FrictionVerb,
+    friction_tags_literal,
 };
 use orbit_common::types::{McpToolPlacement, ToolSchema};
 
@@ -53,8 +54,10 @@ fn tags_parameter_description_lists_default_taxonomy() {
     }
 }
 
-/// The `add` schema as it shipped before the registry existed. Parameter order
-/// is part of the contract: it drives the `mcp_tools_list` snapshot.
+/// The `add` schema. Parameter order is part of the contract: it drives the
+/// `mcp_tools_list` snapshot. `title` was appended after `body` by [ORB-10590],
+/// which gave friction authors a settable record handle; every other parameter
+/// keeps the position and wording it shipped with.
 #[test]
 fn add_schema_matches_the_shipped_contract() {
     let schema = schema_for(FrictionVerb::Add);
@@ -69,6 +72,7 @@ fn add_schema_matches_the_shipped_contract() {
         param_shape(&schema),
         vec![
             ("body", "string", true),
+            ("title", "string", false),
             ("tags", "string_list", false),
             ("during_task", "string", false),
             ("model", "string", true),
@@ -79,13 +83,35 @@ fn add_schema_matches_the_shipped_contract() {
         "Markdown body describing what happened and why it caused friction"
     );
     assert_eq!(
-        schema.parameters[2].description,
+        schema.parameters[3].description,
         "Optional task ID being worked on when friction occurred"
     );
     assert_eq!(
-        schema.parameters[3].description,
+        schema.parameters[4].description,
         "Required agent family for attribution (`codex`, `claude`, `gemini`, or `grok`)"
     );
+}
+
+/// Both write verbs describe the title budget from the one constant that
+/// enforces it, so the schema cannot drift from the validator.
+#[test]
+fn title_parameter_descriptions_quote_the_enforced_budget() {
+    for verb in [FrictionVerb::Add, FrictionVerb::Update] {
+        let schema = schema_for(verb);
+        let title = schema
+            .parameters
+            .iter()
+            .find(|param| param.name == "title")
+            .expect("title parameter");
+
+        assert!(
+            title
+                .description
+                .contains(&FRICTION_TITLE_MAX_CHARS.to_string()),
+            "{}",
+            title.description
+        );
+    }
 }
 
 #[test]
@@ -132,7 +158,7 @@ fn update_schema_keeps_its_spelled_out_id_description() {
         .iter()
         .map(|param| param.name.as_str())
         .collect();
-    assert_eq!(params, vec!["id", "status", "tags", "body"]);
+    assert_eq!(params, vec!["id", "status", "tags", "body", "title"]);
     assert_eq!(
         schema.parameters[0].description,
         "Friction record id, e.g. F2026-05-001"

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -155,6 +155,8 @@ After [T20260428-17] and [T20260430-4], local task review and GitHub PR review a
 
 After [T20260510-13] and [ORB-00062], friction reporting is outside the task lifecycle: `orbit.friction.add` writes markdown records under `.orbit/frictions/`; `orbit.friction.list/show/tags/update/resolve` expose scan and triage helpers; and `orbit.friction.stats` computes `open`, `triaged`, `resolved_this_month`, total resolved count, and model/tag rates on demand from that corpus plus task completion attribution. After [ORB-10202], `friction` is no longer a `TaskStatus` variant or accepted persisted task value. The dashboard `Knowledge > Frictions` subtab delegates to the same tool helpers through `/api/frictions*`, so human triage and CLI/MCP reads share one vocabulary and stats shape.
 
+After [ORB-10590], a record carries an author-settable `title` — its handle in `friction list`, the dashboard, and the pre-filing search that decides whether a problem is already known. `orbit.friction.add` accepts it and `orbit.friction.update` can retitle a record without touching its append-only body. Callers that supply none get one derived from the body at write time, so the frontmatter always states the handle rather than leaving every reader to re-derive it; records written before the field existed carry no `title` and derive one on read instead, which is why no migration pass is owed. Derivation is structural (`orbit_common::friction::title`): a leading heading is the record's own title only when no sibling heading at its level or shallower follows it, a leading bold run is an inline lead-in whose sentence is the subject, and the result is clamped to `FRICTION_TITLE_MAX_CHARS`. There is no separate `summary` field — [ADR-0323] records why the record keeps exactly one short handle.
+
 ---
 
 ## 9. Global Process Tracing JSONL
@@ -225,5 +227,7 @@ Each record contains timestamp, level, target, and structured fields. After [T20
 - **[ORB-10325]** — Remove graph from MCP and registered tool dispatch while preserving the direct `orbit graph` CLI.
 - **[ORB-10357]** — Remove the direct `orbit graph` CLI too; the graph has no audited surface left.
 - **[ORB-10451]** — Attribute CLI and dashboard runtimes from the canonical agent env envelope, recording unenveloped callers as unknown.
+
+- **[ORB-10590]** — Gave friction records an author-settable `title` and replaced first-line derivation with a structural, write-time fallback ([ADR-0323]).
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/auditability/4_decisions.md
+++ b/docs/design/auditability/4_decisions.md
@@ -389,6 +389,26 @@ Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.
 
 ---
 
+## ADR-0323 — Friction records carry an author-settable title; derivation is a structural fallback
+
+**Status:** Proposed · 2026-08 · [ORB-10590]
+
+**Context.** A friction record's handle was not a field. `title` existed only on the wire, derived by the read projection from the body's first non-empty line. No write surface accepted one, and nothing said the first line was load-bearing. On a 41-record corpus the derivation tracked authoring style rather than content: a body opening with a section heading derived that label as its title, a body opening with a long lead paragraph derived the whole paragraph. Two records six days apart documented the same bug under the same generic label, so the pre-filing search for prior art found nothing recognisable.
+
+**Decision.** `title` becomes a stored `Option<String>` on the record and its frontmatter, settable through `orbit.friction.add` and retitleable through `orbit.friction.update` without touching the append-only body. Derivation moves to write time and persists what it produced; it stays as the read-side fallback so records written before the field existed need no migration. Derivation is structural, never lexical: a leading heading is a title only when no sibling heading at its level or shallower follows it, a leading bold run is an inline lead-in whose sentence is the subject, and the result is clamped to `FRICTION_TITLE_MAX_CHARS`. No `summary` field is introduced — the record keeps one short handle plus the full report.
+
+**Consequences.**
+- Every record lands with a handle naming its subject, and the existing corpus self-heals on read for both failure modes.
+- A hardcoded list of generic section headings was rejected: it encodes one language and one house style, needs an edit per new label, and cannot address the overlong case at all. Heading count alone separated every well-titled record from every badly-titled one in the surveyed corpus.
+- Refusing an add whose derived title looks non-identifying was rejected as a break for existing callers and the same brittle judgement in a different place.
+- Cost: the `orbit.friction.add` / `.update` MCP schemas gain a parameter. Additive and optional, but still release-visible schema drift.
+- Cost: the structural rules can still under-serve a body whose subject appears in its second sentence; the stored field is the escape hatch, which is why derivation is only the fallback.
+- Cost: `--title` is unreachable until the deployed `orbit` binary is rebuilt, so records that need a human title cannot be retitled the moment this lands. The data pass for the records that motivated the decision is [ORB-10598].
+
+Full narrative: `orbit tool run orbit.adr.show --input '{"id":"ADR-0323"}'`.
+
+---
+
 ## Task References
 
 - **[T20260419-0002]** — Add workspace provenance and v2 audit envelope events for activity/job execution.
@@ -434,5 +454,7 @@ Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.
 - **[ORB-10519]** — Keep the persisted crew-model author and process-scoped Orbit committer while removing hook-specific trailer input and provider-commit adoption ([ADR-0299], superseding [ADR-0249] and [ADR-0294]).
 - **[ORB-10369]** — Introduce the persisted resolved crew model as the pipeline commit author with generic fallback and no alias resolver ([ADR-0249], superseded by [ADR-0299]).
 - **[ORB-10496]** — Record the spawned provider subprocess PID as its own audit event and expose read-time liveness through run status and `orbit run show`.
+
+- **[ORB-10590]** — Make the friction record handle an author-settable field and derive it structurally when omitted ([ADR-0323]).
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/plugin/skills/orbit-task/SKILL.md
+++ b/plugin/skills/orbit-task/SKILL.md
@@ -130,10 +130,15 @@ Friction bodies are append-only markdown reports under `.orbit/frictions/`; thei
 
 ```bash
 orbit tool run orbit.friction.add --input '{
+  "title": "<one line naming the surface and the failure, max 120 chars>",
   "body": "<what happened, where, and why it caused friction>",
   "tags": ["<tag from table>"], "during_task": "<optional task id>",
   "model": "<agent-family>"
 }'
 ```
+
+**Write the `title` yourself.** It is the record's handle everywhere the corpus is scanned — `friction list`, the dashboard, and the search you run *before* filing to check whether a problem is already known. A record whose handle does not name its subject is invisible to that search, which is how the same bug gets diagnosed twice. Name the surface and the failure (`orbit.task.update rejects an id orbit.task.show resolves`), not the shape of your report.
+
+Omitting `title` is allowed and derives one from the body: the opening line, minus a leading section label, clamped to 120 characters. Derivation cannot invent a subject the opening line does not state, so a body that opens with a section heading gets whatever that section's first sentence says. `orbit friction update --title` retitles an existing record without touching its append-only body.
 
 **Rules:** never silently ignore an Orbit problem — always report; never implement large design changes inline, track them first; name the concrete command/file/workflow that broke; report genuine friction only.


### PR DESCRIPTION
## Task

[ORB-10590](https://orbit-cli.com/tasks/ORB-10590) — Friction records have no author-settable title; derivation from the first body line yields unusable titles and hides duplicates

### Description

## Problem

A friction record's `title` and `summary` are both derived from the first line of its body.
Nothing lets the author set them: **0 of 41 friction files on disk carry a `title` field**, and
the write surface (`orbit_friction_add`) accepts only `body, during_task, model, tags,
workspace`. The first line is therefore load-bearing, and nothing anywhere says so.

When an author opens the body with a generic section heading — a normal way to structure a
written report — the record's title becomes that heading. Four records currently carry titles
that identify nothing:

| record | derived title |
|---|---|
| F2026-07-030 | `What happened` |
| F2026-07-032 | `What happened` |
| F2026-08-006 | `What happened` |
| F2026-07-031 | the entire 700-character opening paragraph, as both title **and** summary |

All four have substantive, well-diagnosed bodies. Only the handle is broken.

## Demonstrated harm: the defect manufactures duplicates

**F2026-07-032 (2026-07-27) and F2026-08-006 (2026-08-02) are the same bug** — `orbit_task_update`
lacking the cross-workspace fallback scan that `orbit_task_show` performs. Two executors, six days
apart, each re-derived the full diagnosis from scratch. Both records are titled `What happened`, so
a search for prior art before filing would have surfaced nothing recognisable. The corpus is meant
to be small and high-signal; untitled records are invisible to the person deciding whether a
problem is already known.

## Why it looks intermittent rather than systematic

The pattern tracks authoring style, not correctness. All four affected records were written by
`model: claude`, whose house style is a structured report (`## What happened` → `## Evidence` →
`## Why this is friction`). All 23 `model: codex` records open with a headingless prose paragraph,
so their derived title is the opening sentence — descriptive by accident of style, not by design.
Claude-authored records that happen to lead with a specific heading (F2026-07-014, F2026-07-015,
F2026-07-027) read perfectly. The result presents as random noise, which is likely why it has
persisted.

Note the two failure modes are opposites — a title too short to identify anything, and a title so
long it is unreadable in any list view. A fix that only addresses one leaves the other.

## Constraints

- **Shipped surface.** Friction records and their tooling seed every workspace. No project-specific
  ids, names, or paths may appear in the implementation or in test fixtures. The `F-` ids above are
  evidence for this report only — do not embed them in shipped code or tests.
- **41 existing records must remain readable** under whatever scheme is chosen; a migration that
  strands or rewrites existing bodies is not acceptable without an explicit decision.
- Be wary of a fix that hardcodes a list of generic English section headings to skip. It is
  brittle, it is not portable across authors or languages, and it treats a symptom of the missing
  field rather than the missing field.
- CI on agent-main PRs is advisory; do not repair unrelated pre-existing failures.

## Questions to settle with evidence, not assumption

- Should a title be **stored** on the record (author-supplied, with derivation as fallback) or
  **derived** more carefully? Storing it makes the field explicit but changes the record schema and
  every writer; deriving it keeps writers unchanged but leaves the field implicit.
- `title` and `summary` currently hold the identical value. Is that intended, or has summary
  silently never been implemented?
- Where is the derivation actually performed — at write time into the file, or at read time by the
  search/serve layer? That determines whether existing records self-heal on a fix or need a pass.
- Should the write path reject or warn on a title that is obviously non-identifying, and if so,
  what makes that judgement portable?

## Remediation of existing records

The four records above need usable titles. Whether that happens via the same change or a follow-up
pass is the implementer's call, but leaving them is not acceptable — F2026-07-032 and F2026-08-006
should also be cross-referenced or merged, since they document one bug.

## Provenance

Surveyed 2026-08-02 across all friction files in the constellation tree plus an `orbit_search`
sweep. Counts: 41 records total, 18 `claude` / 23 `codex`, 0 carrying a `title` field, 4 with
non-identifying derived titles, all 4 `claude`. Related: bridge friction F2026-08-002 records a
sibling gap — the same write surface accepts no author parameter, so tasks created through it
record `created_by: unknown`. Both are instances of a record field existing on read that the
writer cannot set.

### Acceptance Criteria

- A friction author can determine the record's title, and the mechanism is documented where friction authors will encounter it
- No friction can land with a title that fails to identify its subject; both failure modes are addressed — the generic-section-heading case and the entire-opening-paragraph case
- title and summary are either meaningfully distinct or deliberately unified, with the decision recorded rather than left implicit
- The 41 existing friction records remain readable, and the four with non-identifying titles (three generic, one overlong) end up with usable ones
- F2026-07-032 and F2026-08-006 are cross-referenced or merged as duplicates of one underlying bug
- No project-specific friction id, workspace name, or path appears in the shipped implementation or its test fixtures
- The fix does not rely on a hardcoded list of generic English section headings as its primary mechanism
- Build passes and the change's own tests pass; pre-existing unrelated failures are named rather than repaired

## Execution Summary

<details>
<summary>Click to expand</summary>

## What shipped

`title` is now a stored, author-settable field on friction records, and body derivation is a structural fallback rather than the only mechanism. [ADR-0323] carries the decision; the four questions the task posed are answered with evidence below.

**Schema.** `FrictionRecord` and `FrictionFrontmatter` gain `title: Option<String>` (`skip_serializing_if`), so a record written before the field existed parses unchanged and no migration is owed.

**Write surface.** `orbit.friction.add` accepts `title`; `orbit.friction.update` accepts it too and treats an explicit empty string as "clear and go back to deriving". Both are declared once in the operation registry, so the CLI flags, MCP schemas, and dashboard field-name validation derive from one place. The dashboard's `POST`/`PATCH /api/frictions` bodies accept `title` as well, so human triage can retitle a legacy record without touching its append-only body. Machine-filed triage friction (`v2_host/triage.rs`) now passes an explicit title.

**Where derivation runs.** At write time, into the file. An add with no `title` derives one and persists it, so the frontmatter always states the handle. Read-time derivation survives only as the compatibility path for records that predate the field — which is what lets the existing corpus self-heal without a rewrite.

**The derivation itself** (`orbit_common::friction::title`, ~90 LOC, no word list anywhere):
- A leading ATX heading is the record's own title *only* when no later heading at its level or shallower follows it. A heading with siblings labels the first section of a structured report, so the subject is the prose it introduces and the label is skipped.
- A leading `**bold**` run opening a prose line is an inline lead-in; the sentence beside it is the subject. A line that is nothing but the bold run is itself the subject.
- The unit is the paragraph, not the line — a hard-wrapped body would otherwise be cut at whatever column its author's editor used.
- The result is clamped to `FRICTION_TITLE_MAX_CHARS` (120) at a word boundary. An author-supplied title is validated against the same bound and collapsed to one line; past it the write is refused rather than truncated.

Both tool-host implementations (checkout-backed and the checkoutless hub coordination executor) call the same validator, so the two write paths cannot disagree about what a legal title is.

## Answers to the task's four questions

1. **Stored or derived?** Stored, with derivation as fallback. Derivation cannot invent a subject a body never states; the field can.
2. **Is `title` == `summary` intended?** There is no `summary` field and never has been — no store field, no schema parameter, no projection anywhere in the codebase. What consumers call a summary is either `title` or a client-side `truncate(body)`. Deliberately unified, recorded in ADR-0323 §4.
3. **Where was derivation performed?** Read time, in `record_to_json`. That is why the existing corpus self-heals on this change for both failure modes.
4. **Should the write path reject a non-identifying title?** No — considered and rejected in the ADR. A write gate would break existing callers and would need the same brittle judgement the heading list needs. The skill text asks for the title; the structural rules make the fallback usable when it is not given.

## Validation

- `cargo test --workspace`: 1619 passed, 0 failed. `make ci-fast`: clean.
- 30 new tests: derivation and validation (`orbit-common`), persistence and clearing (`orbit-store`), the tool write boundary end-to-end (`orbit-core`), and the schema contract (`orbit-tools`).
- Regenerated three frozen surfaces, each an additive-only diff: `mcp_tools_list.json`, `output_goldens/tool_list.json`, and the `friction add`/`update` `--help` goldens.
- **Ran the real implementation over the 39-record corpus that motivated the task** (throwaway harness, removed). Every record now derives an identifying handle. The three `What happened` records and the 700-character one all resolve to their actual first diagnostic statement. Two records (F2026-07-032, F2026-08-006) derive a weaker handle because their opening sentence buries the subject behind a long inline path — that is the documented limit of derivation, and it is what the stored field exists for.
- The corpus is also the evidence that the structural rule is the right one: heading count alone separated every well-titled record from every badly-titled one, with no word ever consulted.

## Not done in this run, and why

**The four records are not retitled.** No surface reachable from this executor can do it:
- Every Orbit state root here is mounted read-only (worktree, primary checkout, `~/.orbit`, and the target workspace's `.orbit`), so the local CLI cannot write — `dangerouslyDisableSandbox` does not help, it is the mount namespace.
- The Bridge MCP server *can* write (this summary, [ADR-0323], and [ORB-10598] all went through it), but its `orbit_friction_update` wrapper exposes only `status` and `tags` — neither `title` nor `body`.
- `--title` does not exist in any deployed binary yet; it is what this change ships.

Filed as **[ORB-10598]** with the four proposed titles written out, ready to run once the binary is rebuilt. F2026-08-006's proposed title names F2026-07-032, which is the duplicate cross-reference the task asked for. ADR-0323's consequences cite it.

Filed **F2026-08-045** for the read-only-state-mount friction: the executor envelope tells agents to fall back to the CLI when MCP is unavailable, but in this sandbox the CLI is the surface that cannot write and MCP is the one that can, and the error (`io error: Read-only file system`) names neither the cause nor the alternative.

**Pre-existing, unrelated, not repaired:** two tests fail intermittently under this sandbox and pass in isolation — `job_pipeline::worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic` (needs process spawn) and `init::fresh_workspace_init_seeds_disabled_worktree_gc_routine` (writes skill links into `~/.agents/skills`, mounted read-only). Neither touches friction code. CI runs unrestricted.

## Docs

- `plugin/skills/orbit-task/SKILL.md` §4 — the friction-filing example now leads with `title`, and explains why the author should write it: it is the handle the pre-filing duplicate search matches against. This is where friction authors actually encounter the mechanism.
- `docs/design/auditability/2_design.md` §8 and `4_decisions.md` — the field, the derivation rules, and the ADR-0323 entry.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10590-6a6fcfa2`
- Behind base: 0
- Ahead of base: 1