### PR TITLE
Executors cannot write ADRs from the sandbox; decisions round-trip through a human transcription

### DIFF
--- a/crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs
@@ -18,6 +18,7 @@ use orbit_store::{
 use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
+use crate::runtime::run_input::managed_run_context_from_env;
 
 impl OrbitRuntime {
     /// Reconcile a complete federated ADR bundle into this runtime's current
@@ -169,6 +170,8 @@ pub(super) fn update(
         .map(|raw| AdrStatus::from_str(&raw).map_err(OrbitError::InvalidInput))
         .transpose()?;
 
+    ensure_managed_run_update_allowed(&existing, new_status)?;
+
     let fields = AdrDocumentUpdateParams {
         title: optional_string(&input, "title")?,
         owner: optional_string(&input, "owner")?,
@@ -246,6 +249,32 @@ pub(super) fn update(
         .get_adr(&id)?
         .ok_or_else(|| OrbitError::not_found(NotFoundKind::Adr, id.clone()))?;
     Ok(adr_to_json(&updated))
+}
+
+/// Executors may refine the Proposed record they just authored, but approval
+/// remains a separate human/orchestrator action. The preflight runs before any
+/// document write so a combined body+status request cannot partially mutate
+/// the ADR before its lifecycle transition is denied.
+fn ensure_managed_run_update_allowed(
+    existing: &Adr,
+    target: Option<AdrStatus>,
+) -> Result<(), OrbitError> {
+    if !managed_run_context_from_env() {
+        return Ok(());
+    }
+    if existing.status != AdrStatus::Proposed {
+        return Err(OrbitError::PolicyDenied(format!(
+            "managed-run executors may update only Proposed ADRs; {} is {}",
+            existing.id, existing.status
+        )));
+    }
+    if target.is_some_and(|status| status != AdrStatus::Proposed) {
+        return Err(OrbitError::PolicyDenied(format!(
+            "managed-run executors cannot transition ADR lifecycle status; {} must remain Proposed for separate approval",
+            existing.id
+        )));
+    }
+    Ok(())
 }
 
 pub(super) fn supersede(

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/adr_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/adr_tools.rs
@@ -1,0 +1,113 @@
+use orbit_common::types::OrbitError;
+use serde_json::json;
+
+use super::super::test_support::{managed_tool_env_guard, test_runtime, unmanaged_tool_env_guard};
+
+const BODY: &str = "## Context\nA real choice existed.\n\n## Decision\nKeep approval separate.\n\n## Consequences\n- Creation stays Proposed.\n- Cost: approval requires another actor.\n";
+
+#[test]
+fn managed_run_can_refine_proposed_adr_but_cannot_accept_it() {
+    let (_temp, runtime, _repo_root) = test_runtime();
+    let created = {
+        let _env = unmanaged_tool_env_guard();
+        super::super::adr_tools::add(
+            &runtime,
+            json!({
+                "title": "Executor proposal",
+                "body": BODY,
+                "owner": "codex",
+                "related_tasks": ["ORB-10596"]
+            }),
+            None,
+            Some("codex".to_string()),
+        )
+        .expect("create Proposed ADR")
+    };
+    let id = created["id"].as_str().expect("ADR id");
+
+    {
+        let _env = managed_tool_env_guard("jrun-adr-authoring-test");
+        let updated = super::super::adr_tools::update(
+            &runtime,
+            json!({"id": id, "title": "Refined executor proposal"}),
+            None,
+            Some("codex".to_string()),
+        )
+        .expect("executor may refine Proposed ADR");
+        assert_eq!(updated["title"], "Refined executor proposal");
+
+        let denied = super::super::adr_tools::update(
+            &runtime,
+            json!({
+                "id": id,
+                "body": "must not partially land",
+                "status": "accepted"
+            }),
+            None,
+            Some("codex".to_string()),
+        )
+        .expect_err("executor acceptance must be denied");
+        assert!(
+            matches!(denied, OrbitError::PolicyDenied(_)),
+            "unexpected error: {denied:?}"
+        );
+    }
+
+    let unchanged =
+        super::super::adr_tools::show(&runtime, json!({"id": id})).expect("read after denial");
+    assert_eq!(unchanged["status"], "proposed");
+    assert_eq!(unchanged["body"].as_str().expect("body"), BODY.trim_end());
+
+    let accepted = {
+        let _env = unmanaged_tool_env_guard();
+        super::super::adr_tools::update(
+            &runtime,
+            json!({"id": id, "status": "accepted"}),
+            None,
+            Some("codex".to_string()),
+        )
+        .expect("separate unmanaged approval remains available")
+    };
+    assert_eq!(accepted["status"], "accepted");
+}
+
+#[test]
+fn managed_run_cannot_rewrite_an_accepted_adr() {
+    let (_temp, runtime, _repo_root) = test_runtime();
+    let accepted_id = {
+        let _env = unmanaged_tool_env_guard();
+        let created = super::super::adr_tools::add(
+            &runtime,
+            json!({
+                "title": "Accepted history",
+                "body": BODY,
+                "owner": "human",
+                "related_tasks": ["ORB-10596"]
+            }),
+            None,
+            None,
+        )
+        .expect("create ADR");
+        let id = created["id"].as_str().expect("ADR id").to_string();
+        super::super::adr_tools::update(
+            &runtime,
+            json!({"id": id, "status": "accepted"}),
+            None,
+            None,
+        )
+        .expect("accept ADR");
+        id
+    };
+
+    let denied = {
+        let _env = managed_tool_env_guard("jrun-adr-history-test");
+        super::super::adr_tools::update(
+            &runtime,
+            json!({"id": accepted_id, "title": "Executor rewrite"}),
+            None,
+            Some("codex".to_string()),
+        )
+        .expect_err("accepted ADR rewrite must be denied")
+    };
+    assert!(matches!(denied, OrbitError::PolicyDenied(_)));
+}

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/mod.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/mod.rs
@@ -1,3 +1,4 @@
+mod adr_tools;
 mod friction_tools;
 mod learning_tools;
 mod state_tools;

--- a/crates/orbit-core/src/runtime/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/runtime/v2_host/sandbox.rs
@@ -69,7 +69,7 @@ pub(super) fn resolve_executor_sandbox(
                         ))
                     })?;
                 append_codex_side_write_roots(runtime, provider, &mut resolved)?;
-                append_linux_runtime_write_roots(runtime, &mut resolved)?;
+                append_linux_runtime_write_roots(runtime, subprocess_cwd, &mut resolved)?;
                 append_linux_provider_state_roots(&mut resolved)?;
                 let managed_worktree = subprocess_cwd
                     .and_then(|cwd| active_worktree_subpath(runtime, cwd))
@@ -230,6 +230,7 @@ fn append_unique_modify_root(resolved: &mut ResolvedFsProfile, root: String) {
 #[cfg(target_os = "linux")]
 fn append_linux_runtime_write_roots(
     runtime: &OrbitRuntime,
+    subprocess_cwd: Option<&Path>,
     resolved: &mut ResolvedFsProfile,
 ) -> Result<(), DispatchError> {
     let global = runtime
@@ -267,6 +268,17 @@ fn append_linux_runtime_write_roots(
     ] {
         if file.exists() {
             append_unique_modify_root(resolved, file.display().to_string());
+        }
+    }
+
+    // `orbit.adr.add` writes the Proposed bundle into the invoking checkout,
+    // not the shared workspace root. Re-allow only Proposed bundles and their
+    // per-record lock directory inside a recognized managed worktree; the
+    // surrounding worktree `.orbit/**` mount stays read-only, including the
+    // accepted/superseded ADR states and every unrelated/future store.
+    if let Some(worktree) = subprocess_cwd.and_then(|cwd| active_worktree_root(runtime, cwd)) {
+        for directory in ensure_managed_worktree_adr_roots(&worktree)? {
+            append_unique_modify_root(resolved, directory.display().to_string());
         }
     }
     Ok(())
@@ -315,6 +327,65 @@ fn ensure_owned_directory(path: &Path) -> Result<(), DispatchError> {
     })
 }
 
+#[cfg(target_os = "linux")]
+fn ensure_managed_worktree_adr_roots(worktree: &Path) -> Result<[PathBuf; 2], DispatchError> {
+    let orbit = worktree.join(".orbit");
+    let adrs = orbit.join("adrs");
+    for parent in [&orbit, &adrs] {
+        match std::fs::symlink_metadata(parent) {
+            Ok(metadata) if !metadata.file_type().is_symlink() && metadata.is_dir() => {}
+            Ok(_) => {
+                return Err(DispatchError::CliInvocationPermanent(format!(
+                    "managed-worktree ADR parent `{}` must be a real directory",
+                    parent.display()
+                )));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                std::fs::create_dir(parent).map_err(|error| {
+                    DispatchError::CliInvocationPermanent(format!(
+                        "create managed-worktree ADR parent `{}`: {error}",
+                        parent.display()
+                    ))
+                })?;
+            }
+            Err(error) => {
+                return Err(DispatchError::CliInvocationPermanent(format!(
+                    "inspect managed-worktree ADR parent `{}`: {error}",
+                    parent.display()
+                )));
+            }
+        }
+    }
+
+    let roots = [adrs.join("proposed"), adrs.join(".locks")];
+    for directory in &roots {
+        match std::fs::symlink_metadata(directory) {
+            Ok(metadata) if !metadata.file_type().is_symlink() && metadata.is_dir() => {}
+            Ok(_) => {
+                return Err(DispatchError::CliInvocationPermanent(format!(
+                    "managed-worktree ADR root `{}` must be a real directory",
+                    directory.display()
+                )));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                std::fs::create_dir(directory).map_err(|error| {
+                    DispatchError::CliInvocationPermanent(format!(
+                        "create managed-worktree ADR root `{}`: {error}",
+                        directory.display()
+                    ))
+                })?;
+            }
+            Err(error) => {
+                return Err(DispatchError::CliInvocationPermanent(format!(
+                    "inspect managed-worktree ADR root `{}`: {error}",
+                    directory.display()
+                )));
+            }
+        }
+    }
+    Ok(roots)
+}
+
 /// Re-allow the active job-run worktree under `<workspace>/.orbit/state/worktrees/`
 /// for every provider, after the policy's `denyModify .orbit/**` rule. Without
 /// this, `task_pr_pipeline` runs whose subprocess cwd lives under
@@ -346,6 +417,10 @@ fn append_active_worktree_root(
 }
 
 fn active_worktree_subpath(runtime: &OrbitRuntime, subprocess_cwd: &Path) -> Option<String> {
+    active_worktree_root(runtime, subprocess_cwd).map(|worktree| worktree.display().to_string())
+}
+
+fn active_worktree_root(runtime: &OrbitRuntime, subprocess_cwd: &Path) -> Option<PathBuf> {
     let cwd = subprocess_cwd
         .canonicalize()
         .unwrap_or_else(|_| subprocess_cwd.to_path_buf());
@@ -361,8 +436,7 @@ fn active_worktree_subpath(runtime: &OrbitRuntime, subprocess_cwd: &Path) -> Opt
     let relative = cwd.strip_prefix(&worktrees_root).ok()?;
     let mut components = relative.components();
     let first = components.next()?;
-    let worktree_dir = worktrees_root.join(first.as_os_str());
-    Some(worktree_dir.display().to_string())
+    Some(worktrees_root.join(first.as_os_str()))
 }
 
 fn absolutize_side_write_root(workspace_root: &str, path: &str) -> Option<String> {

--- a/crates/orbit-core/src/runtime/v2_host/tests/sandbox.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/sandbox.rs
@@ -62,6 +62,16 @@ fn resolve_executor_sandbox_marks_only_specific_orbit_worktree_managed() {
             .iter()
             .any(|entry| entry == &format!("{}/**", canonical_worktree.display()))
     );
+    for allowed in [".orbit/adrs/proposed", ".orbit/adrs/.locks"] {
+        assert!(
+            managed
+                .fs_profile
+                .modify
+                .iter()
+                .any(|entry| entry == &canonical_worktree.join(allowed).display().to_string()),
+            "managed worktree must narrowly re-allow {allowed}"
+        );
+    }
 
     let direct = runtime
         .resolve_executor_sandbox("claude", None, Some(&repo_root))
@@ -121,6 +131,9 @@ fn resolve_executor_sandbox_orders_versioned_orbit_exceptions_after_default_deny
     for protected in [
         format!("{}/state/**", orbit.display()),
         format!("{}/tasks/**", orbit.display()),
+        format!("{}/learnings/**", orbit.display()),
+        format!("{}/adrs/accepted/**", orbit.display()),
+        format!("{}/adrs/superseded/**", orbit.display()),
         format!("{}/future-store/**", orbit.display()),
     ] {
         assert!(
@@ -128,6 +141,47 @@ fn resolve_executor_sandbox_orders_versioned_orbit_exceptions_after_default_deny
             "worktree store must not be re-allowed by policy: {protected} in {modify:?}"
         );
     }
+    for allowed in ["adrs/proposed", "adrs/.locks"] {
+        assert!(
+            modify
+                .iter()
+                .any(|rule| rule == &orbit.join(allowed).display().to_string()),
+            "the active worktree Proposed ADR surface must be allowed: {modify:?}"
+        );
+    }
+    assert!(
+        !modify
+            .iter()
+            .any(|rule| rule == &orbit.join("adrs").display().to_string()),
+        "the ADR parent must remain read-only: {modify:?}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn resolve_executor_sandbox_rejects_symlinked_managed_worktree_adr_root() {
+    use std::os::unix::fs::symlink;
+
+    let (root, runtime, _repo_root) = runtime_with_workspace_layout();
+    seed_executor(
+        &runtime,
+        "claude",
+        Some(orbit_common::types::ExecutorSandboxKind::LinuxBwrap),
+    );
+    let worktree = runtime
+        .paths()
+        .orbit_dir
+        .join("state/worktrees/orbit-jrun-symlinked-adrs");
+    let adrs = worktree.join(".orbit/adrs");
+    let outside = root.path().join("outside-proposals");
+    std::fs::create_dir_all(&adrs).expect("ADR parent");
+    std::fs::create_dir(&outside).expect("outside proposals");
+    symlink(&outside, adrs.join("proposed")).expect("symlink proposed root");
+
+    let error = runtime
+        .resolve_executor_sandbox("claude", None, Some(&worktree))
+        .expect_err("symlinked Proposed root must fail closed");
+    assert!(error.to_string().contains("must be a real directory"));
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/orbit-store/src/sqlite/id_allocator/tests/id_allocator.rs
+++ b/crates/orbit-store/src/sqlite/id_allocator/tests/id_allocator.rs
@@ -271,7 +271,7 @@ fn learning_id_format_migration_renames_and_is_idempotent() {
 }
 
 #[test]
-fn multi_process_allocation_is_dense_for_adrs_and_learnings() {
+fn multi_process_allocation_is_dense_across_worktrees_for_adrs_and_learnings() {
     for kind in [IdAllocationKind::Adr, IdAllocationKind::Learning] {
         assert_multi_process_dense(kind);
     }
@@ -283,6 +283,7 @@ fn allocate_ids_child() {
         return;
     };
     let root = std::env::var("ORBIT_ID_ALLOCATOR_CHILD_ROOT").expect("root env");
+    let worktree = std::env::var("ORBIT_ID_ALLOCATOR_CHILD_WORKTREE").expect("worktree env");
     let output = std::env::var("ORBIT_ID_ALLOCATOR_CHILD_OUTPUT").expect("output env");
     let count: usize = std::env::var("ORBIT_ID_ALLOCATOR_CHILD_COUNT")
         .expect("count env")
@@ -293,7 +294,11 @@ fn allocate_ids_child() {
         "learning" => IdAllocationKind::Learning,
         other => panic!("unknown kind {other}"),
     };
-    let allocator = IdAllocator::open(allocator_config(Path::new(&root))).expect("allocator");
+    let allocator = IdAllocator::open(allocator_config_for_worktree(
+        Path::new(&root),
+        Path::new(&worktree),
+    ))
+    .expect("allocator");
     let mut ids = Vec::with_capacity(count);
     for _ in 0..count {
         let allocation = match kind {
@@ -312,6 +317,10 @@ fn assert_multi_process_dense(kind: IdAllocationKind) {
     let count = 50usize;
     let output_a = temp.path().join("ids-a.txt");
     let output_b = temp.path().join("ids-b.txt");
+    let worktree_a = temp.path().join("worktree-a");
+    let worktree_b = temp.path().join("worktree-b");
+    std::fs::create_dir_all(&worktree_a).expect("worktree a");
+    std::fs::create_dir_all(&worktree_b).expect("worktree b");
     let kind_name = kind.as_str();
 
     let mut child_a = Command::new(&exe)
@@ -322,6 +331,7 @@ fn assert_multi_process_dense(kind: IdAllocationKind) {
         ])
         .env("ORBIT_ID_ALLOCATOR_CHILD_KIND", kind_name)
         .env("ORBIT_ID_ALLOCATOR_CHILD_ROOT", temp.path())
+        .env("ORBIT_ID_ALLOCATOR_CHILD_WORKTREE", &worktree_a)
         .env("ORBIT_ID_ALLOCATOR_CHILD_OUTPUT", &output_a)
         .env("ORBIT_ID_ALLOCATOR_CHILD_COUNT", count.to_string())
         .spawn()
@@ -334,6 +344,7 @@ fn assert_multi_process_dense(kind: IdAllocationKind) {
         ])
         .env("ORBIT_ID_ALLOCATOR_CHILD_KIND", kind_name)
         .env("ORBIT_ID_ALLOCATOR_CHILD_ROOT", temp.path())
+        .env("ORBIT_ID_ALLOCATOR_CHILD_WORKTREE", &worktree_b)
         .env("ORBIT_ID_ALLOCATOR_CHILD_OUTPUT", &output_b)
         .env("ORBIT_ID_ALLOCATOR_CHILD_COUNT", count.to_string())
         .spawn()
@@ -354,16 +365,33 @@ fn assert_multi_process_dense(kind: IdAllocationKind) {
         })
         .collect();
     assert_eq!(sequences, (1..=(count as u32 * 2)).collect::<Vec<_>>());
+
+    let allocator = IdAllocator::open(allocator_config(temp.path())).expect("inspect allocator");
+    let records = match kind {
+        IdAllocationKind::Adr => allocator.adr_allocations(),
+        IdAllocationKind::Learning => allocator.learning_allocations(),
+    }
+    .expect("allocation records");
+    let by_worktree = records.iter().fold(BTreeMap::new(), |mut counts, record| {
+        *counts.entry(record.worktree_root.clone()).or_insert(0usize) += 1;
+        counts
+    });
+    assert_eq!(by_worktree.get(&worktree_a), Some(&count));
+    assert_eq!(by_worktree.get(&worktree_b), Some(&count));
 }
 
 fn allocator_config(root: &Path) -> IdAllocatorConfig {
+    allocator_config_for_worktree(root, root)
+}
+
+fn allocator_config_for_worktree(root: &Path, worktree: &Path) -> IdAllocatorConfig {
     IdAllocatorConfig::new(
         root.join(".orbit/state/semantic.db"),
         root.join(".orbit/state/.id_alloc.lock"),
         root.join(".orbit"),
-        root.to_path_buf(),
-        root.join(".orbit/adrs"),
-        root.join(".orbit/learnings"),
+        worktree.to_path_buf(),
+        worktree.join(".orbit/adrs"),
+        worktree.join(".orbit/learnings"),
     )
 }
 

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -140,7 +140,11 @@ The compiled macOS profile denies by default, allows broad reads required by age
 - Codex side-write roots from runtime provider config, appended after policy denies so workflow state remains writable under the outer sandbox
 - narrow child Orbit runtime roots appended by the v2 host after policy denies: global logs, global `orbit.db*`, global tasks, workspace `.orbit/tasks/**`, workspace `.orbit/learnings/**`, workspace `.orbit/frictions/**`, workspace audit/logs, workspace semantic DB sidecars, and workspace `.orbit/state/job-runs/**`
 
-The child Orbit runtime roots are deliberately narrower than the workspace `.orbit` tree. They cover stores used by currently activity-exposed Orbit write tools: task/review/artifact/duel writes under `.orbit/tasks/**`, learning curation under `.orbit/learnings/**`, friction reporting under `.orbit/frictions/**`, `orbit.state.set` writes under `.orbit/state/job-runs/**`, and startup/runtime audit, log, semantic-index, and global database writes. Registered stores that are not exposed by the current activity allowlists, including `.orbit/adrs/**` and graph write roots, remain outside this inventory and must be revisited when those write tools are exposed.
+The child Orbit runtime roots are deliberately narrower than the workspace `.orbit` tree. They cover stores used by currently activity-exposed Orbit write tools: task/review/artifact/duel writes under `.orbit/tasks/**`, learning curation under `.orbit/learnings/**`, friction reporting under `.orbit/frictions/**`, `orbit.state.set` writes under `.orbit/state/job-runs/**`, and startup/runtime audit, log, semantic-index, and global database writes. Graph write roots and every unlisted or future store remain outside this inventory.
+
+`agent_implement` also exposes `orbit.adr.add` and `orbit.adr.update` ([ORB-10596]). On Linux, only the active managed worktree's `.orbit/adrs/proposed` and `.orbit/adrs/.locks` directories are bind-mounted writable after the enclosing worktree `.orbit/**` read-only mount; Accepted/Superseded ADRs and learning, task, state, and unknown local stores remain read-only. Allocation still uses the workspace-shared semantic database and `.id_alloc.lock`, so simultaneous worktrees serialize ID selection while each Proposed body lands under `<job-worktree>/.orbit/adrs/proposed/<id>/`. The allocator records that worktree-relative body path, allowing an orchestrator runtime to resolve and search it as a federated artifact while the worktree is live. macOS already re-allows the active job worktree as a whole after the policy deny, so this change adds no macOS SBPL allowance and changes no policy YAML.
+
+Creation remains Proposed-only. In a managed-run context, `orbit.adr.update` may correct the title, body, and metadata of a Proposed record, but it cannot transition lifecycle status or modify an Accepted record. Acceptance and historical correction remain separate unmanaged human/orchestrator actions. A hub-side allocator or a second pending-decision queue was rejected: the existing shared allocator and federated artifact resolution already provide collision safety and discovery, while another protocol would duplicate allocation and introduce a second promotion lifecycle.
 
 Negated `read` / `modify` rules become explicit SBPL denies in resolved order. Explicit host-policy exceptions and host-owned runtime roots appear after the enclosing deny, preserving last-match-wins without opening unrelated siblings. Simple path and `/**` subtree denials compile to `subpath`; non-subpath globs such as `**/*.env` compile to `regex`.
 
@@ -149,6 +153,8 @@ Negated `read` / `modify` rules become explicit SBPL denies in resolved order. E
 On Linux, `ExecutorSandboxKind::LinuxBwrap` resolves only `/usr/bin/bwrap` and runs a real capability probe using the same private user, PID, IPC, and UTS namespaces plus mount setup required by provider execution. Absence or probe failure is permanent and fail-closed unless the executor explicitly sets `allow_fallback: true`. The availability decision happens before provider argv construction: an active outer wrapper neutralizes provider-native sandbox flags, while a bare fallback preserves them.
 
 The deterministic argv starts with a read-only bind of `/`, explicitly retains the host network namespace, and applies canonical `modify` mounts in policy order. Broad positive roots are mounted before denials. A positive exact/subtree root is mounted after an earlier deny only when it is strictly nested beneath that denied root; equal or ancestor positives cannot mask the protection. This implements versioned-config and trusted runtime-store re-allows while unknown `.orbit` children remain read-only. A re-allowed file or directory must already exist because Bubblewrap cannot bind-mount a nonexistent child beneath a read-only parent. `/dev`, `/proc`, and `/tmp` are replaced with private minimal mounts, the wrapper creates a fresh session, and parent-death cleanup remains enabled.
+
+The ADR authoring exception follows that same ordering: trusted host setup ensures only `<active-worktree>/.orbit/adrs/{proposed,.locks}` exists, then mounts those exact directories writable after the local `.orbit/**` deny. The ADR parent and its Accepted/Superseded lifecycle directories remain read-only. This does not add a policy exception, does not re-allow the shared workspace ADR tree, and does not expose any sibling under the worktree-local `.orbit` directory.
 
 Before provider launch, `worktree_setup` asks the runtime host to prepare missing versioned-config mount anchors for `agent_implement`. The runtime resolves that activity's effective profile, then intersects it with each task's exact canonical selector and a fixed file/directory inventory. Files use create-new semantics; directories use single-directory creation. A preflight rejects symlinks and wrong filesystem types, and existing targets are never opened for writing. The only parent it may create is the worktree-local `.orbit` directory needed by an otherwise-authorized target. Protected stores, unknown `.orbit` children, dotenv/secret paths, traversal, profile-denied targets, and any path outside the canonical disposable worktree are not candidates. The parent workspace and task records are untouched by preparation. [ORB-10573]
 
@@ -269,7 +275,12 @@ tests compile argv and exercise fail-closed/fallback behavior on every host;
 kernel tests probe real `/usr/bin/bwrap` and skip with its concrete capability
 failure when user or mount namespaces are unavailable. The Linux argv and
 kernel cases also cover writable versioned `.orbit` paths versus protected
-state, record, database/lock, and unknown paths ([ORB-10560]).
+state, record, database/lock, and unknown paths ([ORB-10560]). Runtime-host
+tests pin the managed-worktree ADR mount as the sole local record-store
+exception, tool-host tests prove executors can refine Proposed ADRs but cannot
+accept or rewrite Accepted records, and the SQLite allocator race test launches
+two child processes with distinct worktree roots against one database/lock and
+asserts 100 collision-free dense IDs per artifact kind ([ORB-10596]).
 
 ---
 
@@ -315,5 +326,6 @@ state, record, database/lock, and unknown paths ([ORB-10560]).
 - **[ORB-10553]** — Rescue the Ubuntu host prerequisite for the shipped Linux Bubblewrap probe.
 - **[ORB-10560]** — Add host-policy modify exceptions for the explicit versioned `.orbit` surface while preserving protected stores and unknown-path denial.
 - **[ORB-10573]** — Materialize only exact missing versioned-config anchors gated by both task scope and the effective host policy/profile before Linux provider launch.
+- **[ORB-10596]** — Allow executor-authored Proposed ADRs through one narrow managed-worktree mount while preserving global allocation, federated discovery, and separate acceptance.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10596](https://orbit-cli.com/tasks/ORB-10596) — Executors cannot write ADRs from the sandbox; decisions round-trip through a human transcription

### Description

## Problem

An executor that reaches a genuine architectural decision cannot record it. `.orbit/adrs/` is mounted read-only in job worktrees (F2026-08-022), so `orbit.adr.add` fails:

```
{"code":"io_error","error":"io error: Read-only file system (os error 30)"}
```

The established workaround is for the executor to draft the full ADR body into its `execution_summary` and for the orchestrator to transcribe it into `orbit.adr.add` from a writable context. ORB-10594 did exactly this: a complete, well-formed ADR — Context, Decision, five rejected alternatives, three labeled `Cost:` consequences — sat inert in an execution summary until a human-driven session copied it out verbatim as ADR-0317.

The cost of that relay:

- **A round-trip per decision.** The executor has the full context at the moment of the decision; the orchestrator has to be asked, has to read the summary, and has to transcribe. Nothing is added in the copy.
- **Fidelity risk.** The transfer is manual text handling. Nothing verifies the transcribed record matches what the executor wrote, and the executor's own tests and code are the evidence for the claims in the body.
- **Silent loss.** If nobody reads the execution summary, the decision is never recorded at all. There is no queue, no signal, and no way to discover that an ADR is waiting.
- **The task spec has to carry the workaround.** ORB-10594's spec instructed the executor not to invent an ID and to draft the body instead — boilerplate that has to be repeated in every spec that might produce a decision.

## Why the directory is locked, and what a fix must not break

The read-only mount is not arbitrary. ADR IDs are **globally allocated**, and job runs execute concurrently by design. Two runs allocating an ID at the same moment is exactly the race the lock prevents. Any fix must keep concurrent allocation safe.

Note also that `.orbit/adrs/proposed/` is gitignored by design (ORB-10303 / ADR-0302), so a Proposed ADR written on the box never reaches a Cowork mount or a PR. Whatever the write path becomes, the record has to be discoverable by the orchestrator afterwards — a write that succeeds but lands somewhere nobody looks is not an improvement over the execution-summary relay.

## Scope and constraints

- The substance is: an executor should be able to record a decision at the moment it makes one, without a human relay, without inventing an ID, and without racing another run for one.
- Mechanism is the implementer's call and should be argued in the execution summary. Plausible shapes, none endorsed: allocate the ID through the orbit server rather than the filesystem so the worktree never needs write access; a narrow writable bind for `.orbit/adrs/` with server-side ID allocation; a staging area the orchestrator promotes; or an explicit "pending ADR" queue surfaced by the CLI. Argue against at least one alternative you did not pick.
- **Do not widen the sandbox mount generally.** If the answer involves a writable path, it must be scoped to ADR authoring specifically, and the reasoning for why that path is safe when others are not must be explicit.
- Preserve the human-approval property. ADRs are Proposed on creation and accepted separately; an executor writing an ADR must not be able to mark it Accepted. Check whether the same reasoning applies to `orbit.adr.update` on an existing record — modification may deserve a different answer than creation, and if so, say why rather than treating them as one feature.
- If the outcome is that executors should keep drafting into `execution_summary`, that is an acceptable finding — but then the gap to close is discoverability: a way to list decisions awaiting transcription so none is lost silently. Report which conclusion you reached and why.
- Learnings remain human/orchestrator-only. This task is about ADRs and does not change who may author a learning.
- Do not run `make ci`. Known pre-existing failures to name, never repair: `mcp_roundtrip::hub_mcp_serve_...` (ORB-10577), orbit-exec clippy debt (ORB-10574), and `command::init::tests::fresh_workspace_init_seeds_disabled_worktree_gc_routine` (needs a writable ambient `$HOME`; fails in executor sandboxes, passes in CI).

## Acceptance criteria

- An executor running in a job worktree can record an architectural decision without a human transcribing it, or a reasoned finding is delivered explaining why it should not and what closes the discoverability gap instead.
- Concurrent ADR creation from two simultaneous runs cannot allocate the same ID, demonstrated by a test that exercises the race rather than asserting it in prose.
- An executor cannot mark an ADR Accepted; the Proposed-then-approved lifecycle is intact.
- A record created from a job worktree is discoverable afterwards by the orchestrator — state where it lands and how it is found.
- The sandbox mount is not broadened beyond ADR authoring; the diff to any policy or mount configuration is enumerated and justified.
- The `orbit.adr.update` case is addressed explicitly, whether or not it is changed.
- `cargo build` and the touched crates' tests pass; pre-existing failures reported, not repaired.

### Acceptance Criteria

- Executor records an ADR from a job worktree without human transcription, or delivers a reasoned finding plus a discoverability fix for pending decisions
- Concurrent creation from two simultaneous runs cannot collide on an ID, proven by a test exercising the race
- Executor cannot mark an ADR Accepted; Proposed-then-approved lifecycle intact
- A record created from a job worktree is discoverable by the orchestrator afterwards; landing location stated
- Sandbox mount not broadened beyond ADR authoring; policy/mount diff enumerated and justified
- orbit.adr.update addressed explicitly, whether or not changed
- cargo build + touched-crate tests pass; pre-existing failures reported, not repaired

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Linux Bubblewrap now prepares and re-allows exactly `<active-job-worktree>/.orbit/adrs/proposed` and `.orbit/adrs/.locks` after the local `.orbit/**` read-only mount. The parent, Accepted/Superseded ADRs, learnings, tasks, state, and unknown stores remain read-only. Parent/root symlinks and wrong filesystem types fail closed. No policy YAML, activity allowlist, shared workspace mount, macOS SBPL rule, or general sandbox scope changed.
- `orbit.adr.add` keeps its existing global SQLite allocator + `.id_alloc.lock` and Proposed-only creation semantics. Bodies land at `<job-worktree>/.orbit/adrs/proposed/<id>/`; the shared allocation row records that worktree/body path, so an orchestrator can discover it through federated `orbit.search` / `orbit.adr.show` while the worktree is live and reconcile it into the landing checkout.
- `orbit.adr.update` is explicitly split from creation: managed-run executors may refine a Proposed record's document fields, but cannot change lifecycle status or modify an Accepted record. A combined body+Accepted request is denied before any partial document write. Unmanaged human/orchestrator acceptance remains available and still requires a related task.
- Strengthened the real multi-process allocator race test: two simultaneous child processes now use distinct worktree roots against one shared allocator database/lock; 100 IDs per artifact kind are collision-free, dense, and attributed evenly to the two worktrees. Existing two-worktree ADR tests verify federated discovery.
- Updated the policy-sandbox design with the landing location, discovery path, exact mount diff, lifecycle split, and rejected alternative.
Assessment: The change uses Orbit's existing global allocator and worktree federation rather than adding a hub allocation protocol or a second pending-decision queue. It narrows Linux write exposure to Proposed bundles plus required record locks and keeps approval separate.
Strategic decisions:
- Rejected a hub endpoint/staging queue because it duplicates already-shipped allocation and federation machinery and creates another promotion lifecycle.
- Preserved `orbit.adr.update` only for Proposed corrections in executor context; historical Accepted records require a separate actor.
Deviations from original plan:
- `orbit.adr.add` was invoked from this activity with the complete decision body, but the currently installed pre-fix sandbox still returned `io error: Read-only file system (os error 30)`. No ID or design-doc pointer was invented. The compiled change enables this call for subsequent job worktrees; the current invocation cannot retroactively change its outer mount. This is the bootstrap condition the task fixes, not a new friction report.
Validation:
- `cargo build` — passed.
- `cargo test -p orbit-store` — passed (336 passed, 4 ignored), including the distinct-worktree multi-process race and federated ADR resolution.
- `cargo test -p orbit-core` — 769 passed, 1 ignored; only the task-declared pre-existing `command::init::tests::fresh_workspace_init_seeds_disabled_worktree_gc_routine` failed because ambient `$HOME` is read-only in the executor sandbox. New ADR lifecycle tests (2) and sandbox tests (6) pass when targeted and in the full run.
- `make ci-fast` — passed.
- `git diff --check` — passed.
Known pre-existing failures not exercised or repaired: `mcp_roundtrip::hub_mcp_serve_...` (ORB-10577) and orbit-exec clippy debt (ORB-10574); `make ci` was intentionally not run per repository instructions.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10596-6a6fd9d6`
- Behind base: 0
- Ahead of base: 1