### PR TITLE
Scope global skill symlink creation to the global orbit root during init

### DIFF
--- a/crates/orbit-cli/src/command/init.rs
+++ b/crates/orbit-cli/src/command/init.rs
@@ -279,7 +279,7 @@ struct ReportedInitPaths {
 }
 
 fn reported_init_paths(root_override: Option<&Path>) -> ReportedInitPaths {
-    if root_override.is_some_and(|path| !is_global_orbit_root(path)) {
+    if root_override.is_some_and(|path| !orbit_core::runtime::is_global_orbit_root(path)) {
         ReportedInitPaths {
             skills_root: "<custom orbit root>/skills",
             config_path: "<custom orbit root>/config.toml",
@@ -290,13 +290,4 @@ fn reported_init_paths(root_override: Option<&Path>) -> ReportedInitPaths {
             config_path: "~/.orbit/config.toml",
         }
     }
-}
-
-fn is_global_orbit_root(path: &Path) -> bool {
-    global_orbit_root().is_some_and(|expected| path == expected)
-}
-
-fn global_orbit_root() -> Option<PathBuf> {
-    let home = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"))?;
-    Some(PathBuf::from(home).join(".orbit"))
 }

--- a/crates/orbit-cli/src/command/tests/init.rs
+++ b/crates/orbit-cli/src/command/tests/init.rs
@@ -54,11 +54,13 @@ fn existing_config_short_circuits_before_prompts() {
     assert!(matches!(result, Ok(None)));
 }
 
-/// End-to-end: temporary-root validation runs with an isolated discovery
-/// home, preserving the invoking account's existing skill links while it
-/// produces a fresh config.toml with generated crew tables.
+/// End-to-end: initializing against a non-global (temporary/custom) orbit
+/// root must leave the invoking account's home-scoped skill link
+/// directories untouched entirely — no removal, no re-creation, no
+/// replacement — while it still produces a fresh config.toml with generated
+/// crew tables in the custom root.
 #[test]
-fn non_interactive_init_isolates_temporary_root_skill_discovery() {
+fn non_interactive_init_against_non_global_root_leaves_home_skill_links_untouched() {
     let live_home = tempdir().expect("live home tempdir");
     let validation_home = tempdir().expect("validation home tempdir");
     let validation_root = tempdir().expect("validation root tempdir");
@@ -98,22 +100,22 @@ fn non_interactive_init_isolates_temporary_root_skill_discovery() {
     assert_discovery_sentinel(&agents_link, &agents_target);
     assert_discovery_sentinel(&claude_link, &claude_target);
     assert!(
-        validation_home
+        !validation_home
             .path()
             .join(".agents")
             .join("skills")
             .join("orbit")
-            .is_symlink(),
-        "validation links belong under the isolated HOME"
+            .exists(),
+        "a non-global root must not create home-scoped skill links"
     );
     assert!(
-        validation_home
+        !validation_home
             .path()
             .join(".claude")
             .join("skills")
             .join("orbit")
-            .is_symlink(),
-        "validation links belong under the isolated HOME"
+            .exists(),
+        "a non-global root must not create home-scoped skill links"
     );
 
     let config_path = validation_root.path().join(".orbit").join("config.toml");

--- a/crates/orbit-core/src/command/init.rs
+++ b/crates/orbit-core/src/command/init.rs
@@ -22,7 +22,7 @@ use crate::config::{
     agent_detect::{DetectedAgents, RealAgentEnvProbe, detect},
     seed_default_config,
 };
-use crate::runtime::resolve_global_root;
+use crate::runtime::{is_global_orbit_root, resolve_global_root};
 
 const LEGACY_WORKSPACE_SEEDED_SKILL_IDS: [&str; 2] = ["orbit-approve-task", "orbit-pr"];
 
@@ -157,7 +157,11 @@ pub fn init_workspace_at_root(
 
     let skill_ids = default_skill_ids();
     let mut created_skills_symlink = false;
-    if options.global_only && options.link_global_skills {
+    // Home-scoped skill link directories (`~/.agents/skills`, `~/.claude/skills`)
+    // are only ever touched for the true global Orbit root. A non-global root
+    // (a validation root, an alternate `--root`, a workspace root) must leave
+    // them exactly as found — no removal, no re-creation, no replacement.
+    if options.global_only && options.link_global_skills && is_global_orbit_root(&orbit_root) {
         for skills_links_root in &init_target.skills_links_roots {
             created_skills_symlink |=
                 ensure_skill_links(&skills_root, &skill_ids, skills_links_root, options.force)?;

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -60,7 +60,7 @@ pub use resolve::{
 };
 // `pub` for the runtime-less `orbit migrate --dry-run` inspection that moved
 // to `orbit-cmd` [ORB-10016].
-pub use resolve::{resolve_global_root, try_resolve_initialized_roots};
+pub use resolve::{is_global_orbit_root, resolve_global_root, try_resolve_initialized_roots};
 pub(crate) use task_records::TaskRecordUpdateParams;
 
 #[derive(Clone)]

--- a/crates/orbit-core/src/runtime/resolve.rs
+++ b/crates/orbit-core/src/runtime/resolve.rs
@@ -185,7 +185,7 @@ fn resolve_roots(
     //    corrupt user state.
     if let Some(repo_root) = paths::find_git_repo_root(cwd) {
         let candidate = repo_root.join(".orbit");
-        if !is_global_orbit_dir(&candidate) {
+        if !is_global_orbit_root(&candidate) {
             return Ok(log_resolved_roots(
                 cwd,
                 "git_repo_root",
@@ -196,7 +196,7 @@ fn resolve_roots(
 
     // 7. Fallback: <cwd>/.orbit, but never the global $HOME/.orbit.
     let cwd_root = paths::cwd_orbit_root(cwd);
-    if is_global_orbit_dir(&cwd_root) {
+    if is_global_orbit_root(&cwd_root) {
         return Err(OrbitError::InvalidInput(format!(
             "{} is the global Orbit root, not a workspace; run `orbit workspace init` from inside a project directory or pass `--root <path/to/.orbit>`",
             cwd_root.display()
@@ -235,7 +235,7 @@ fn find_orbit_dir_walk_up(start: &Path, boundaries: &[PathBuf]) -> Option<PathBu
     let mut current = start;
     loop {
         let candidate = current.join(".orbit");
-        if candidate.is_dir() && !is_global_orbit_dir(&candidate) {
+        if candidate.is_dir() && !is_global_orbit_root(&candidate) {
             return Some(candidate);
         }
         if boundaries
@@ -267,7 +267,13 @@ fn home_dir_boundary() -> Option<PathBuf> {
     paths::home_dir()
 }
 
-fn is_global_orbit_dir(candidate: &Path) -> bool {
+/// Whether `candidate` resolves to the global Orbit root (`$HOME/.orbit`,
+/// or `%USERPROFILE%\.orbit`). This is the single source of truth for
+/// "is this root the global one" — anything that needs to make a decision
+/// contingent on that (whether to touch home-scoped skill link
+/// directories, what path to report to the user) should call this rather
+/// than re-deriving the comparison.
+pub fn is_global_orbit_root(candidate: &Path) -> bool {
     let Some(global) = paths::home_dir().map(|home| home.join(".orbit")) else {
         return false;
     };


### PR DESCRIPTION
## Task

[ORB-10601](https://orbit-cli.com/tasks/ORB-10601) — Scope global skill symlink creation to the global orbit root during init

### Description

## Problem

`orbit init` creates symlinks into the user's home-scoped skill directories (`~/.agents/skills`, `~/.claude/skills`) regardless of which orbit root the invocation targets. When init is pointed at a non-global root, it still resolves link placement from the home directory and replaces whatever is already there, pointing the links at the alternate root's skill tree.

The observable damage: a real installation's skill links are clobbered and left dangling once the alternate root goes away. This has already happened on an operator box, where the global skill links now point into a reaped temporary directory.

## Evidence

- Link placement is computed from the home directory first; the passed root is consulted only in the no-home fallback chain, so on any host with `HOME` set the requested root is ignored for link placement (`crates/orbit-core/src/command/init.rs`, the init-target resolution helper).
- The linking step is enabled unconditionally where global init options are constructed — there is no inspection of whether a root override was supplied.
- The per-skill loop does short-circuit when an existing link already resolves to the expected target, but with an alternate root the expected target never matches, so it falls through to remove-and-recreate.
- The CLI layer already computes the exact discriminator this needs (whether the resolved root *is* the global root) but uses the result only to pick a display string.

## Trap

`crates/orbit-cli/src/command/tests/init.rs` contains an init test that positively asserts a home-scoped skill link **is** created when init runs against a throwaway root. That test encodes the current bug as intended behavior; it passes trivially because production code always follows `HOME`. A correct fix will make it fail. Amend it — do not add a second test alongside it and leave the contradiction standing.

## Constraints

- Do not change behavior for the ordinary global-root init path.
- Do not resolve this by making the link step tolerate failures or skip on error; the requirement is that the links are not touched at all for a non-global root.
- Whether to solve this by deriving the decision from the root, or by introducing an explicit opt-in flag, is yours to choose — but a new user-facing flag is a permanent surface, so justify it if you add one.

## Notes

Originally reported as a separate workspace's task (skill-link clobbering observed after an init against a custom root); the code being fixed lives here.

### Acceptance Criteria

- Running init against a non-global orbit root leaves the user's home-scoped skill link directories untouched — no removal, no re-creation, no replacement of existing entries.
- Running init against the global orbit root keeps today's linking behavior unchanged.
- What the command reports as the skill root and what it actually writes cannot disagree; the decision is made in one place rather than recomputed for display.
- A test asserts the non-global case leaves home-scoped links alone. The existing init test that currently asserts the opposite is corrected rather than left in place, and the correction is called out in the summary.
- Wording of any user-facing output and of the code stays deployment-agnostic — no host names, workspace names, or environment-specific paths.
- The crate builds and the change's own tests pass. Pre-existing unrelated failures are named, not repaired.

## Execution Summary

<details>
<summary>Click to expand</summary>

Root cause: `init_global()` (crates/orbit-core/src/command/init.rs) unconditionally forced `link_global_skills: true` regardless of whether the resolved root was the true global root (`$HOME/.orbit`). `resolve_init_target_from_root()` then always derived the skill-link placement from `HOME` (falling back to a git-repo root or parent dir only when `HOME` was unset), so any `orbit init --root <alternate>` invocation still clobbered `~/.claude/skills/*` and `~/.agents/skills/*`, pointing them at the alternate root's skill tree. The CLI layer already had the "is this the global root" discriminator (`is_global_orbit_root` in crates/orbit-cli/src/command/init.rs) but only used it to choose a display string, not to gate the write.

Fix: introduced a single decision point, `orbit_core::runtime::is_global_orbit_root(path)` (crates/orbit-core/src/runtime/resolve.rs, re-exported from runtime/mod.rs), reusing the existing canonicalize-tolerant comparison against `$HOME/.orbit` that `resolve_roots` already relied on internally (was private `is_global_orbit_dir`, now the shared public fn; all four internal call sites renamed).

- crates/orbit-core/src/command/init.rs: `init_workspace_at_root` now gates the skill-link step on `options.global_only && options.link_global_skills && is_global_orbit_root(&orbit_root)`. A non-global root now skips `ensure_skill_links` entirely — no removal, no re-creation, no replacement of whatever already lives under `~/.agents/skills` / `~/.claude/skills`. The ordinary global-root path (`orbit init` with no override, or an explicit `--root` that happens to equal `$HOME/.orbit`) is unchanged.
- crates/orbit-cli/src/command/init.rs: `reported_init_paths` now calls `orbit_core::runtime::is_global_orbit_root` instead of its own re-implementation (`is_global_orbit_root`/`global_orbit_root` locals deleted), so what the command reports as the skill root and what it actually writes are driven by the same function.
- crates/orbit-cli/src/command/tests/init.rs: corrected the trap test. `non_interactive_init_isolates_temporary_root_skill_discovery` positively asserted that a home-scoped skill symlink *was* created under an isolated validation HOME when init targeted a throwaway (non-global) root — i.e. it encoded the bug as intended behavior. Renamed to `non_interactive_init_against_non_global_root_leaves_home_skill_links_untouched` and inverted the two assertions to check the links are *not* created; the pre-existing "live sentinel" assertions (proving a *different* real HOME's links are untouched) are kept as-is since they were already correct.

Wording of user-facing output (`<custom orbit root>/skills`, `~/.orbit/skills`, etc.) was already deployment-agnostic and unchanged.

Validation:
- `cargo build -p orbit-core -p orbit-cli` — clean.
- `cargo test -p orbit-core -p orbit-cli --no-fail-fast` — all orbit-core (770) and orbit-cli (319 unit + integration) tests pass, including the corrected test and the untouched `global_init_seeds_skills_and_home_level_links` / `workspace_init_leaves_repo_skills_unseeded` cases that prove the global-root path is unchanged. Two pre-existing failures in `crates/orbit-cli/tests/docs.rs` (`cli_orbit_search_kind_adr_all_includes_superseded`, `cli_semantic_index_adrs_is_idempotent_status_agnostic_and_sweeps_stale`) are unrelated: they fail because this sandbox is itself a managed-run executor and ADR-0001 policy denies executors transitioning ADR lifecycle status ("managed-run executors cannot transition ADR lifecycle status"). Confirmed pre-existing by stashing this diff and re-running the same test against the unmodified tree — identical failure.
- `make ci-fast` — passes (fmt-check + all guardrail scripts).
- `cargo clippy -p orbit-core -p orbit-cli --all-targets` — no new warnings; the two pre-existing warnings are in orbit-common, files untouched by this change.

No context_files were added beyond the ones already listed on the task; CHANGELOG.md was intentionally left untouched per repo convention (compiled at release time).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10601-6a778008`
- Behind base: 0
- Ahead of base: 1