### PR TITLE
Give delivery a deterministic execution summary instead of depending on the agent to write one

### DIFF
--- a/crates/orbit-engine/src/executor/automation/task_update/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/task_update/mod.rs
@@ -37,6 +37,10 @@ pub(super) fn update_task<H: DeterministicActionHost + TaskHost + ?Sized>(
         task_id,
         TaskActivityUpdate {
             status,
+            // ORB-10603: this step never authors the execution summary. The
+            // durable summary is written upstream — by the implementing agent,
+            // or derived from the delivered change by the commit step — and a
+            // status transition must not clobber it.
             execution_summary: None,
             comment: None,
             note,

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
@@ -2,6 +2,7 @@ mod author;
 mod git_ops;
 mod message;
 mod scope;
+mod summary;
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -21,6 +22,7 @@ use git_ops::{
 };
 use message::{batch_commit_message, finalize_commit_message, task_commit_message};
 use scope::{changed_files_for_task, collect_worktree_changes, filter_changed_files_for_task};
+use summary::ensure_durable_execution_summary;
 
 pub(in crate::executor::automation) fn git_commit<
     H: TaskHost + DeterministicActionHost + ?Sized,
@@ -181,14 +183,23 @@ pub(super) fn commit_batch_changes<H: TaskHost + DeterministicActionHost + ?Size
         )));
     };
 
-    // ORB-10313: fail closed on the durable execution outcome before resolving
-    // the delivery checkout, staging files, mutating the index, or committing.
-    reject_failed_delivery(task)?;
-
     let workspace_path = resolve_workspace_path(host, input, batch_id)?;
     ensure_named_branch(&workspace_path)?;
 
     ensure_no_unmerged_changes(&workspace_path)?;
+
+    // ORB-10603: the summary the gate reads is durable state, and nothing in the
+    // pipeline filled it when the implementing agent skipped the instruction to
+    // persist one. Derive it read-only from the change about to be delivered —
+    // never from the agent's advisory response envelope — and only when the
+    // agent persisted nothing of its own.
+    let task = ensure_durable_execution_summary(host, task.clone(), &workspace_path, batch_id)?;
+
+    // ORB-10313: fail closed on the durable execution outcome before staging
+    // files, mutating the index, or committing. Only read-only resolution and
+    // validation run ahead of it; the gate itself is unchanged, and an empty or
+    // underivable summary still refuses delivery here.
+    reject_failed_delivery(&task)?;
 
     // ADR-0219: an explicitly side-effect-only task skips this phase instead of
     // failing it. Read the tag before any gate so the carve-out is reachable
@@ -229,7 +240,7 @@ pub(super) fn commit_batch_changes<H: TaskHost + DeterministicActionHost + ?Size
         )?);
     }
 
-    let message = batch_commit_message(task);
+    let message = batch_commit_message(&task);
     let resolved_model = host.resolved_crew_model(batch_id)?;
 
     git_commit_with_identity(&workspace_path, &message, resolved_model.as_deref())?;

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/summary.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/summary.rs
@@ -1,0 +1,183 @@
+//! ORB-10603: a deterministic execution summary derived from the delivered change.
+//!
+//! Delivery refuses to hand off a task whose durable execution summary is empty
+//! (see [`reject_failed_delivery`](super::super::handoff::reject_failed_delivery)),
+//! and the only writer of that field was a prose instruction asking the
+//! implementing agent to persist one. Agent-loop output is advisory, so every
+//! run where the agent skipped the instruction wedged at commit.
+//!
+//! This module closes the gap without touching either end of the contract. It
+//! never reads the agent's returned envelope — the summary is derived from the
+//! worktree change this step is about to deliver, which is durable state any
+//! reviewer can re-check with `git status` before the commit or `git show
+//! --stat` after it. It also never overwrites a summary the agent did persist:
+//! an agent-authored account of the work is the better artifact and wins.
+//!
+//! ADR-0326 records the decision and the alternatives it rejected.
+
+use std::path::Path;
+
+use orbit_common::types::{OrbitError, Task};
+
+use crate::context::{TaskAutomationUpdate, TaskHost};
+
+use super::super::git::git_output_raw;
+use super::super::pr::meaningful_execution_summary;
+
+/// Task event recorded when Orbit, not an agent, authored the summary.
+const DERIVED_SUMMARY_EVENT: &str = "execution_summary_derived";
+
+/// Cap on individually named files; the remainder is reported as a count.
+pub(super) const MAX_LISTED_FILES: usize = 25;
+
+/// Give the task a durable execution summary when nothing else did.
+///
+/// Returns the task the caller must use from here on: unchanged when a
+/// meaningful summary is already persisted or when the worktree carries no
+/// change to describe, otherwise carrying the derived summary that was just
+/// written to the task record.
+pub(super) fn ensure_durable_execution_summary<H: TaskHost + ?Sized>(
+    host: &H,
+    task: Task,
+    workspace_path: &Path,
+    run_id: &str,
+) -> Result<Task, OrbitError> {
+    if meaningful_execution_summary(&task.execution_summary).is_some() {
+        return Ok(task);
+    }
+
+    let changes = worktree_changes(workspace_path)?;
+    if changes.is_empty() {
+        // Nothing deterministic to say. The delivery gate still refuses the
+        // empty summary, and the commit step still reports the empty stage.
+        return Ok(task);
+    }
+
+    let summary = render_derived_summary(&task.id, run_id, &changes);
+    host.apply_task_automation_update(
+        &task.id,
+        TaskAutomationUpdate {
+            execution_summary: Some(summary.clone()),
+            status_event: Some(DERIVED_SUMMARY_EVENT.to_string()),
+            status_note: Some(format!(
+                "automation: derived execution_summary from {} changed file(s) in the delivery \
+                 worktree",
+                changes.len()
+            )),
+            ..TaskAutomationUpdate::default()
+        },
+    )?;
+
+    let mut task = task;
+    task.execution_summary = summary;
+    Ok(task)
+}
+
+/// One worktree entry, reduced to the two facts a summary reports.
+#[derive(Debug, Eq, PartialEq)]
+pub(super) struct WorktreeChange {
+    pub(super) kind: &'static str,
+    pub(super) path: String,
+}
+
+/// Read the change this step will deliver without staging or mutating anything.
+///
+/// `--untracked-files=all` matches what `git add --all` would stage, so the
+/// derived summary describes the same file set the commit contains.
+fn worktree_changes(workspace_path: &Path) -> Result<Vec<WorktreeChange>, OrbitError> {
+    let raw = git_output_raw(
+        workspace_path,
+        &["status", "--porcelain=v1", "--untracked-files=all", "-z"],
+    )?;
+    Ok(parse_status_entries(&raw))
+}
+
+/// Parse `git status --porcelain=v1 -z` output.
+///
+/// Each record is `XY <path>` terminated by NUL; a rename or copy is followed
+/// by a second NUL-terminated field holding the source path, which belongs to
+/// the record before it rather than starting a new one.
+pub(super) fn parse_status_entries(raw: &str) -> Vec<WorktreeChange> {
+    let mut changes = Vec::new();
+    let mut fields = raw.split('\0');
+    while let Some(entry) = fields.next() {
+        if entry.is_empty() {
+            continue;
+        }
+        let mut codes = entry.chars();
+        let (Some(index_state), Some(worktree_state)) = (codes.next(), codes.next()) else {
+            continue;
+        };
+        // `XY ` is always three ASCII bytes, so byte 3 is a char boundary.
+        let path = entry.get(3..).unwrap_or_default().trim();
+        if matches!(index_state, 'R' | 'C') {
+            // Consume the rename/copy source field so it is not read as a record.
+            let _ = fields.next();
+        }
+        if path.is_empty() {
+            continue;
+        }
+        changes.push(WorktreeChange {
+            kind: change_kind(index_state, worktree_state),
+            path: path.to_string(),
+        });
+    }
+    changes.sort_by(|left, right| left.path.cmp(&right.path));
+    changes
+}
+
+fn change_kind(index_state: char, worktree_state: char) -> &'static str {
+    if index_state == '?' {
+        return "added";
+    }
+    if index_state == 'U'
+        || worktree_state == 'U'
+        || (index_state == 'A' && worktree_state == 'A')
+        || (index_state == 'D' && worktree_state == 'D')
+    {
+        return "unmerged";
+    }
+    let state = if index_state == ' ' {
+        worktree_state
+    } else {
+        index_state
+    };
+    match state {
+        'A' => "added",
+        'M' => "modified",
+        'D' => "deleted",
+        'R' => "renamed",
+        'C' => "copied",
+        'T' => "type-changed",
+        _ => "changed",
+    }
+}
+
+pub(super) fn render_derived_summary(
+    task_id: &str,
+    run_id: &str,
+    changes: &[WorktreeChange],
+) -> String {
+    let mut lines = vec![
+        format!(
+            "Execution summary derived by Orbit for {task_id} from the change delivered by run \
+             {run_id}; no execution summary was persisted by the implementing agent."
+        ),
+        String::new(),
+        format!("Changed files ({}):", changes.len()),
+    ];
+    for change in changes.iter().take(MAX_LISTED_FILES) {
+        lines.push(format!("- {}: {}", change.kind, change.path));
+    }
+    let remaining = changes.len().saturating_sub(MAX_LISTED_FILES);
+    if remaining > 0 {
+        lines.push(format!("- ... and {remaining} more file(s)"));
+    }
+    lines.push(String::new());
+    lines.push(
+        "This restates the worktree change the delivery commit contains and asserts nothing \
+         beyond it. Re-check it with `git show --stat` on the delivery commit."
+            .to_string(),
+    );
+    lines.join("\n")
+}

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/delivery_gate.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/delivery_gate.rs
@@ -1,8 +1,12 @@
 //! ORB-10313 regression: `commit_batch_changes` must fail closed on the durable
-//! execution outcome before it resolves the checkout, stages files, mutates the
-//! index, or creates a commit. An explicit `Outcome: failed` line — like an
-//! empty/placeholder summary — leaves HEAD, the index, and the worktree exactly
-//! as they were, while other meaningful summaries remain deliverable.
+//! execution outcome before it stages files, mutates the index, or creates a
+//! commit. An explicit `Outcome: failed` line — like an empty/placeholder
+//! summary — leaves HEAD, the index, and the worktree exactly as they were,
+//! while other meaningful summaries remain deliverable.
+//!
+//! ORB-10603 moved read-only checkout resolution and validation ahead of the
+//! gate, because the derived summary reads the worktree the gate protects.
+//! Nothing that runs before the gate mutates Git state.
 
 use std::fs;
 use std::path::Path;
@@ -14,6 +18,7 @@ use super::super::git_commit;
 use super::test_support::*;
 
 use super::super::super::git::git_output;
+use super::super::super::handoff::reject_failed_delivery;
 
 const GATED_TASK_ID: &str = "ORB-10313-GATE";
 
@@ -109,10 +114,22 @@ fn commit_batch_blocks_failed_outcome_before_any_git_mutation() {
     );
 }
 
+/// ORB-10603: the gate itself is unchanged — empty and placeholder summaries are
+/// still refused. What changed is upstream: the commit step now derives a
+/// summary from the delivered change first, so this rejection is unreachable in
+/// the ordinary case. `summary.rs` covers both halves of that behaviour.
 #[test]
-fn commit_batch_blocks_empty_summary_before_any_git_mutation() {
-    // Empty/placeholder rejection remains intact under the failed-outcome gate.
-    assert_delivery_blocked("   \n", "meaningful persisted execution_summary");
+fn delivery_gate_still_rejects_empty_and_placeholder_summaries() {
+    for summary in ["", "   \n", "TBD", "n/a", "no summary provided"] {
+        let error = reject_failed_delivery(&task_with_summary(summary))
+            .expect_err("the delivery gate refuses a summary that says nothing");
+        let message = error.to_string();
+        assert!(
+            message.contains(GATED_TASK_ID)
+                && message.contains("meaningful persisted execution_summary"),
+            "gate names the task and the missing field for '{summary}': {message}"
+        );
+    }
 }
 
 #[test]

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/mod.rs
@@ -5,4 +5,5 @@ mod base_checkpoint;
 mod delivery_gate;
 mod message;
 mod scope;
+mod summary;
 pub(in crate::executor::automation::vcs::commit) mod test_support;

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/summary.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/summary.rs
@@ -1,0 +1,204 @@
+//! ORB-10603 regression: delivery no longer wedges when the implementing agent
+//! persisted no execution summary. The commit step derives one from the change
+//! it is about to deliver, persists it to the task record, and only then meets
+//! the unchanged delivery gate. An agent-authored summary is never overwritten.
+
+use std::fs;
+use std::path::Path;
+
+use orbit_common::types::Task;
+use serde_json::{Value, json};
+
+use super::super::git_commit;
+use super::super::summary::{
+    MAX_LISTED_FILES, WorktreeChange, parse_status_entries, render_derived_summary,
+};
+use super::test_support::*;
+
+use super::super::super::git::git_output;
+
+const DERIVED_TASK_ID: &str = "ORB-10603-DERIVE";
+
+fn task_with_summary(summary: &str) -> Task {
+    let mut task = task_with_file(
+        DERIVED_TASK_ID,
+        "Deliver work the agent never summarized",
+        "src/change.txt",
+        "codex",
+    );
+    task.execution_summary = summary.to_string();
+    task
+}
+
+fn batch_input(workspace: &Path) -> Value {
+    json!({
+        "scope": "all",
+        "job_run_id": "batch-1",
+        "workspace_path": workspace.to_string_lossy().to_string(),
+    })
+}
+
+/// Put an added file and a modified file in the worktree, matching what an
+/// implement step leaves behind.
+fn stage_worktree_change(workspace: &Path) {
+    fs::create_dir_all(workspace.join("src")).unwrap();
+    fs::write(workspace.join("src/change.txt"), "delivered\n").unwrap();
+    fs::write(workspace.join("README.md"), "base\nedited\n").unwrap();
+}
+
+/// The wedge this task fixes: implementation completed, the agent wrote no
+/// summary, and delivery must proceed on a derived one.
+#[test]
+fn commit_batch_derives_summary_when_agent_persisted_none() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+    stage_worktree_change(workspace);
+
+    let host = CommitTestHost::new(vec![task_with_summary("")], workspace.to_path_buf());
+    let result = git_commit(&host, &batch_input(workspace))
+        .expect("a derived summary must satisfy the delivery gate");
+
+    assert_eq!(result["committed"], json!(true));
+    assert_eq!(
+        git_output(workspace, &["rev-list", "--count", "HEAD"])
+            .expect("commit count")
+            .trim(),
+        "2",
+        "the delivery commit was created"
+    );
+
+    let persisted = host.persisted_summaries();
+    assert_eq!(
+        persisted.len(),
+        1,
+        "exactly one derived summary is persisted: {persisted:?}"
+    );
+    let (task_id, summary) = &persisted[0];
+    assert_eq!(task_id, DERIVED_TASK_ID);
+    assert!(
+        summary.contains("Changed files (2):"),
+        "summary counts the delivered change: {summary}"
+    );
+    assert!(
+        summary.contains("- added: src/change.txt"),
+        "summary names the added file: {summary}"
+    );
+    assert!(
+        summary.contains("- modified: README.md"),
+        "summary names the modified file: {summary}"
+    );
+    assert!(
+        summary.contains("batch-1"),
+        "summary attributes the delivering run: {summary}"
+    );
+}
+
+/// A placeholder reads as no summary at all, so it is derived over rather than
+/// carried into the PR body.
+#[test]
+fn commit_batch_derives_summary_over_a_placeholder() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+    stage_worktree_change(workspace);
+
+    let host = CommitTestHost::new(vec![task_with_summary("TBD")], workspace.to_path_buf());
+    git_commit(&host, &batch_input(workspace)).expect("placeholder summaries are derived over");
+
+    let persisted = host.persisted_summaries();
+    assert_eq!(persisted.len(), 1, "{persisted:?}");
+    assert!(persisted[0].1.contains("- added: src/change.txt"));
+}
+
+/// An agent-authored summary is the better artifact and is left alone.
+#[test]
+fn commit_batch_preserves_an_agent_authored_summary() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+    stage_worktree_change(workspace);
+
+    let authored = "Outcome: success\n\nChanges:\n- Reworked the delivery gate.";
+    let host = CommitTestHost::new(vec![task_with_summary(authored)], workspace.to_path_buf());
+    git_commit(&host, &batch_input(workspace)).expect("an authored summary delivers unchanged");
+
+    assert!(
+        host.persisted_summaries().is_empty(),
+        "no derived summary overwrites the agent's own"
+    );
+    assert_eq!(
+        host.task_execution_summary(DERIVED_TASK_ID),
+        authored,
+        "durable state still holds the agent's summary"
+    );
+}
+
+/// The gate is not relaxed: with no change to describe there is nothing to
+/// derive, and the empty summary still refuses delivery without touching Git.
+#[test]
+fn commit_batch_still_blocks_when_no_change_can_be_derived() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+
+    let head_before = git_output(workspace, &["rev-parse", "HEAD"]).expect("HEAD before");
+    let host = CommitTestHost::new(vec![task_with_summary("   \n")], workspace.to_path_buf());
+    let error = git_commit(&host, &batch_input(workspace))
+        .expect_err("an underivable empty summary still blocks delivery");
+    let message = error.to_string();
+    assert!(
+        message.contains(DERIVED_TASK_ID)
+            && message.contains("meaningful persisted execution_summary"),
+        "the unchanged delivery gate produced the error: {message}"
+    );
+
+    assert!(
+        host.persisted_summaries().is_empty(),
+        "nothing derivable means nothing persisted"
+    );
+    assert_eq!(
+        git_output(workspace, &["rev-parse", "HEAD"]).expect("HEAD after"),
+        head_before,
+        "the blocked delivery created no commit"
+    );
+    assert!(
+        git_output(workspace, &["diff", "--cached", "--name-only"])
+            .expect("staged files after")
+            .trim()
+            .is_empty(),
+        "the blocked delivery staged nothing"
+    );
+}
+
+#[test]
+fn status_parsing_attaches_rename_sources_to_their_record() {
+    let raw = "R  new/path.rs\0old/path.rs\0 M src/edited.rs\0?? src/new.rs\0D  gone.rs\0";
+    let changes = parse_status_entries(raw);
+    let rendered: Vec<String> = changes
+        .iter()
+        .map(|change| format!("{}: {}", change.kind, change.path))
+        .collect();
+    assert_eq!(
+        rendered,
+        vec![
+            "deleted: gone.rs".to_string(),
+            "renamed: new/path.rs".to_string(),
+            "modified: src/edited.rs".to_string(),
+            "added: src/new.rs".to_string(),
+        ],
+        "the rename source is not read as a separate change"
+    );
+}
+
+#[test]
+fn derived_summary_truncates_long_file_lists() {
+    let changes: Vec<WorktreeChange> = (0..MAX_LISTED_FILES + 3)
+        .map(|index| WorktreeChange {
+            kind: "modified",
+            path: format!("src/file_{index:03}.rs"),
+        })
+        .collect();
+    let summary = render_derived_summary(DERIVED_TASK_ID, "batch-1", &changes);
+    assert!(
+        summary.contains(&format!("Changed files ({}):", MAX_LISTED_FILES + 3)),
+        "{summary}"
+    );
+    assert!(summary.contains("- ... and 3 more file(s)"), "{summary}");
+}

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/test_support.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/test_support.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Mutex;
 
 use chrono::Utc;
 use orbit_common::types::{
@@ -18,7 +19,10 @@ use crate::context::{
 use super::super::super::git::git_success;
 
 pub struct CommitTestHost {
-    tasks: Vec<Task>,
+    tasks: Mutex<Vec<Task>>,
+    /// ORB-10603: every `execution_summary` an automation update persisted, in
+    /// call order, so a test can assert what durable state actually received.
+    persisted_summaries: Mutex<Vec<(String, String)>>,
     crew_model: Option<String>,
     repo_root: PathBuf,
     data_root: PathBuf,
@@ -30,7 +34,8 @@ impl CommitTestHost {
         let data_root = repo_root.join(".orbit-test-data");
         let scoreboard_dir = data_root.join("scoreboard");
         Self {
-            tasks,
+            tasks: Mutex::new(tasks),
+            persisted_summaries: Mutex::new(Vec::new()),
             crew_model: None,
             repo_root,
             data_root,
@@ -42,11 +47,27 @@ impl CommitTestHost {
         self.crew_model = Some(model.into());
         self
     }
+
+    pub fn persisted_summaries(&self) -> Vec<(String, String)> {
+        self.persisted_summaries.lock().unwrap().clone()
+    }
+
+    pub fn task_execution_summary(&self, task_id: &str) -> String {
+        self.tasks
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|task| task.id == task_id)
+            .map(|task| task.execution_summary.clone())
+            .expect("task exists in the commit test host")
+    }
 }
 
 impl TaskReadHost for CommitTestHost {
     fn get_task(&self, task_id: &str) -> Result<Task, OrbitError> {
         self.tasks
+            .lock()
+            .unwrap()
             .iter()
             .find(|task| task.id == task_id)
             .cloned()
@@ -68,6 +89,8 @@ impl TaskReadHost for CommitTestHost {
     ) -> Result<Vec<Task>, OrbitError> {
         Ok(self
             .tasks
+            .lock()
+            .unwrap()
             .iter()
             .filter(|task| status.is_none_or(|status| task.status == status))
             .filter(|task| priority.is_none_or(|priority| task.priority == priority))
@@ -124,12 +147,22 @@ impl TaskWriteHost for CommitTestHost {
 
     fn apply_task_automation_update(
         &self,
-        _task_id: &str,
-        _update: TaskAutomationUpdate,
+        task_id: &str,
+        update: TaskAutomationUpdate,
     ) -> Result<(), OrbitError> {
-        Err(OrbitError::Execution(
-            "apply_task_automation_update is not needed by commit tests".to_string(),
-        ))
+        let mut tasks = self.tasks.lock().unwrap();
+        let task = tasks
+            .iter_mut()
+            .find(|task| task.id == task_id)
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, task_id.to_string()))?;
+        if let Some(execution_summary) = update.execution_summary {
+            task.execution_summary = execution_summary.clone();
+            self.persisted_summaries
+                .lock()
+                .unwrap()
+                .push((task_id.to_string(), execution_summary));
+        }
+        Ok(())
     }
 }
 

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Design"
 type: design
 title: "Activity / Job — Design"
 owner: codex
-last_updated: 2026-07-27
+last_updated: 2026-08-08
 last_validated: 2026-07-26
 status: Draft
 feature: activity-job
@@ -315,9 +315,19 @@ and the violation. Concretely, for `implement_one` in `task_pr_pipeline`:
   one.
 
 The durable `execution_summary` delivery gate ([ORB-10313] / [ADR-0236]) is
-unchanged and remains the last line. Nothing here weakens it, bypasses it, or
-synthesizes a summary to satisfy it — this check simply means a stalled
-implementer no longer reaches it.
+unchanged and remains the last line. Nothing here weakens it or bypasses it —
+this check simply means a stalled implementer no longer reaches it.
+
+After [ORB-10603] / [ADR-0326], the gate is also no longer reachable in the
+ordinary case, because the commit step fills the field it reads. When — and only
+when — durable state carries no meaningful summary, `commit_batch_changes`
+derives one from `git status` in the delivery worktree (the same file set
+`git add --all` will stage), persists it to the task record with an
+`execution_summary_derived` event, and then meets the unchanged gate. The
+derivation reads durable, re-checkable state and never the agent's advisory
+response envelope ([L-0115]); an agent-authored summary is always preserved; and
+a worktree with nothing to describe still yields no summary and is still
+refused.
 
 **Declared exceptions.** `dispatch_agent` is the only activity shipping
 `require_completion_envelope: false`: its backlog-grouping notes are advisory,
@@ -688,5 +698,6 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[ORB-10464]** — Verify that done dependencies are delivered into the pinned base before a worktree is created.
 - **[ORB-10499]** — Identify the bounded post-recovery attempt as the duplicate implement invocation, and let a re-dispatched attempt exit on a write-gated task.
 - **[ORB-10593]** — Fail dispatch at admission when a `blocked_by` target is archived, rejected, or dangling, naming the blocker.
+- **[ORB-10603]** — Derive the durable `execution_summary` from the delivered change when the implementing agent persisted none, leaving the delivery gate itself unchanged ([ADR-0326]).
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10603](https://orbit-cli.com/tasks/ORB-10603) — Give delivery a deterministic execution summary instead of depending on the agent to write one

### Description

## Problem

Delivery refuses to hand off a task whose execution summary is empty. Nothing in the pipeline ever fills it: the deterministic task-update action hardcodes the field to none, and the only thing that ever writes it is a prose instruction in the implementation activity asking the agent to do so. When the agent does not — which is often — the run wedges.

The wedge has moved but not gone. An earlier change added a delivery-rejection check ahead of index mutation, so an empty summary now fails at commit rather than stranding a merge. That was an improvement in blast radius, not a fix: the failure still fires on every run where the agent skipped the instruction.

## Doctrine — read this before choosing an approach

**Agent-loop outputs are advisory only.** Jobs and activities must never require or depend on them; decisions read durable state or deterministic re-checks. The implementation activity's own notes already record that the agent's structured result is not persisted, and the runner explicitly states that provider output is not the system of record.

This rules out the obvious shortcut. Lifting the summary out of the agent's returned envelope would satisfy the guard while making a pipeline decision depend on advisory output — that is a doctrine violation, not a fix, and it will be rejected in review no matter how well it works.

It equally rules out the other obvious shortcut: relaxing the guard on the local path. The summary is durable evidence that downstream consumers read, including the pull-request body. Deleting the requirement deletes the evidence.

What remains is to derive the summary from something the pipeline already holds deterministically and can re-check: the change itself.

## Constraints

- Do not change the guard's contract. It should still reject an empty summary; the point is that it stops being reachable in the ordinary case.
- If an agent did write a summary, that is the better artifact — keep it.
- Turn, budget, and retry knobs are out of scope and must not appear in the change.

## Notes

Sequenced ahead of the related local-mode base-branch ordering work, which depends on the semantics settled here. Do not change pipeline step ordering in this task.

### Acceptance Criteria

- A task that has been through implementation and commit carries a non-empty execution summary in durable state, without any agent having been required to write one.
- The summary is derived from durable, deterministically re-checkable state — the staged or committed change itself. It is not read from, and does not fall back to, any field of an agent's returned envelope.
- The delivery guard that rejects an empty summary stays in place and is not relaxed, weakened, or made conditional.
- An agent-authored summary, when present in durable state, is preserved rather than overwritten by the derived one.
- Regression coverage exists for the case that currently wedges: implementation completes, no agent wrote a summary, delivery proceeds.
- The crate builds and the change's own tests pass. Pre-existing unrelated failures are named, not repaired.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Problem: nothing in the pipeline ever wrote `execution_summary`, so every run whose agent skipped the prose instruction wedged at the commit-time delivery gate.

Changes:
- New `crates/orbit-engine/src/executor/automation/vcs/commit/summary.rs`: `ensure_durable_execution_summary` derives a summary from `git status --porcelain=v1 --untracked-files=all -z` in the delivery worktree (the same file set `git add --all` stages), listing each path with its change kind, capped at 25 entries plus a remainder count. It persists through `apply_task_automation_update` with an `execution_summary_derived` event. It no-ops when a meaningful summary already exists (agent-authored wins) and when there is no change to describe (nothing to derive).
- `commit/mod.rs`: `commit_batch_changes` calls it after read-only checkout resolution and branch/merge validation, before `reject_failed_delivery`. The gate is unmodified — it still rejects empty, placeholder, and `Outcome: failed` summaries; it is simply no longer reachable in the ordinary case. Nothing ahead of the gate mutates Git state; the ORB-10313 no-mutation property holds.
- Nothing reads the agent's returned envelope (L-0115 doctrine).
- `task_update/mod.rs`: comment recording why the status action keeps `execution_summary: None`.
- Tests: new `commit/tests/summary.rs` covers the wedge case (no summary -> derived -> delivery proceeds), placeholder derivation, agent-authored preservation, and the gate still blocking when nothing is derivable, plus status-parsing (rename source fields) and truncation. `commit/tests/delivery_gate.rs` keeps empty/placeholder rejection as a direct `reject_failed_delivery` unit test. `commit/tests/test_support.rs` now records automation updates.
- Docs: `docs/design/activity-job/2_design.md` delivery-gate section amended (its "nothing synthesizes a summary" claim was stale), task list and `last_updated` bumped.
- ADR-0326 filed (Proposed) with the rejected alternatives: lifting from the agent envelope, relaxing the guard, deriving at `mark_review`, and deriving after staging. Executors cannot accept ADRs, so it awaits approval.

context_files appended: the new summary module and its tests, the touched commit test files, and the design doc.

Validation: `cargo test -p orbit-engine` (363 tests, all pass), `cargo clippy -p orbit-engine --all-targets` (clean; two pre-existing warnings in orbit-common, untouched), `cargo fmt --all --check`, `make ci-fast`. Pipeline step ordering unchanged; no turn/budget/retry knobs touched.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10603-6a77838c`
- Behind base: 0
- Ahead of base: 1