### PR TITLE
Stop local-mode pipelines from leaving the local base branch ahead of its remote

### DIFF
--- a/.orbit/resources/jobs/task_local_pipeline.yaml
+++ b/.orbit/resources/jobs/task_local_pipeline.yaml
@@ -79,7 +79,11 @@ spec:
       default_input:
         job_run_id: "{{ steps.worktree.output.job_run_id }}"
         base: "{{ input.base_branch }}"
-        base_sync: "{{ input.base_sync }}"
+        # Setup honors input.base_sync when choosing the immutable starting
+        # point. By merge time, an earlier local run may legitimately have
+        # advanced this same base before its later checkpoints completed, so
+        # reconcile against the current local base and preserve that history.
+        base_sync: local
         strategy: fast_forward
         workspace_path: "{{ steps.worktree.output.workspace_path }}"
 

--- a/crates/orbit-core/assets/jobs/task_local_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_local_pipeline.yaml
@@ -79,7 +79,11 @@ spec:
       default_input:
         job_run_id: "{{ steps.worktree.output.job_run_id }}"
         base: "{{ input.base_branch }}"
-        base_sync: "{{ input.base_sync }}"
+        # Setup honors input.base_sync when choosing the immutable starting
+        # point. By merge time, an earlier local run may legitimately have
+        # advanced this same base before its later checkpoints completed, so
+        # reconcile against the current local base and preserve that history.
+        base_sync: local
         strategy: fast_forward
         workspace_path: "{{ steps.worktree.output.workspace_path }}"
 

--- a/crates/orbit-core/src/command/job/tests/catalog.rs
+++ b/crates/orbit-core/src/command/job/tests/catalog.rs
@@ -368,7 +368,7 @@ fn default_deterministic_activities_are_registered_in_the_runtime() {
 }
 
 #[test]
-fn local_task_pipeline_commits_before_merge() {
+fn local_task_pipeline_commits_before_merge_and_reconciles_with_local_base() {
     let yaml = DEFAULT_JOB_FILES
         .iter()
         .find_map(|(name, yaml)| (*name == "task_local_pipeline").then_some(*yaml))
@@ -392,6 +392,21 @@ fn local_task_pipeline_commits_before_merge() {
     assert!(
         commit_index < merge_index,
         "task local pipeline must commit before merge"
+    );
+
+    let merge = asset
+        .spec
+        .steps
+        .iter()
+        .find(|step| step.id == "merge")
+        .expect("task local pipeline has merge step");
+    let JobV2StepBody::TargetRef(merge) = &merge.body else {
+        panic!("task local pipeline merge must reference git_merge");
+    };
+    let merge_input = merge.default_input.as_ref().expect("merge input");
+    assert_eq!(
+        merge_input["base_sync"], "local",
+        "an unpublished earlier merge must be a valid base for the next local merge"
     );
 }
 

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/merge.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/merge.rs
@@ -1,0 +1,229 @@
+#![allow(missing_docs)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use orbit_common::types::{JobRun, OrbitError, OrbitEvent, Role};
+use orbit_tools::ToolContext;
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+use crate::context::DeterministicActionHost;
+
+use super::super::merge::merge_batch_worktree_into_base;
+
+const BASE_BRANCH: &str = "agent-main";
+
+#[test]
+fn unpublished_first_merge_does_not_cascade_into_second_local_merge() {
+    let temp = tempdir().unwrap();
+    let remote = temp.path().join("remote.git");
+    let seed = temp.path().join("seed");
+    let primary = temp.path().join("primary");
+    let first_worktree = temp.path().join("first-worktree");
+    let second_worktree = temp.path().join("second-worktree");
+
+    git(temp.path(), &["init", "--bare", path(&remote)]);
+    init_repo(&seed);
+    commit_file(&seed, "base.txt", "base");
+    git(&seed, &["remote", "add", "origin", path(&remote)]);
+    git(&seed, &["push", "-u", "origin", BASE_BRANCH]);
+    git(
+        temp.path(),
+        &[
+            "clone",
+            "--branch",
+            BASE_BRANCH,
+            path(&remote),
+            path(&primary),
+        ],
+    );
+    configure_identity(&primary);
+
+    add_task_worktree(&primary, &first_worktree, "orbit/first");
+    let first_commit = commit_file(&first_worktree, "first.txt", "first task");
+    let host = MergeTestHost::new(&primary, temp.path());
+
+    merge_batch_worktree_into_base(&host, &merge_input("first-run", &first_worktree, "local"))
+        .unwrap();
+
+    // A later bookkeeping checkpoint fails here: the local base contains the
+    // first task, while the remote still names the original session base.
+    assert!(is_ancestor(&primary, &first_commit, BASE_BRANCH));
+    assert!(!is_ancestor(
+        &primary,
+        &first_commit,
+        &format!("origin/{BASE_BRANCH}")
+    ));
+
+    add_task_worktree(&primary, &second_worktree, "orbit/second");
+    let second_commit_before_rebase = commit_file(&second_worktree, "second.txt", "second task");
+
+    let refusal = merge_batch_worktree_into_base(
+        &host,
+        &merge_input("second-run", &second_worktree, "remote"),
+    )
+    .unwrap_err();
+    assert!(
+        refusal
+            .to_string()
+            .contains("reconcile it or run with base_sync=local"),
+        "remote mode must retain the safety refusal: {refusal}"
+    );
+
+    merge_batch_worktree_into_base(&host, &merge_input("second-run", &second_worktree, "local"))
+        .unwrap();
+
+    let second_commit_after_rebase = git(&second_worktree, &["rev-parse", "HEAD"]);
+    assert_ne!(second_commit_after_rebase, second_commit_before_rebase);
+    assert!(is_ancestor(&primary, &first_commit, BASE_BRANCH));
+    assert!(is_ancestor(
+        &primary,
+        &second_commit_after_rebase,
+        BASE_BRANCH
+    ));
+    assert_eq!(
+        fs::read_to_string(primary.join("second.txt")).unwrap(),
+        "second task"
+    );
+}
+
+fn merge_input(run_id: &str, workspace_path: &Path, base_sync: &str) -> Value {
+    json!({
+        "run_id": run_id,
+        "workspace_path": workspace_path,
+        "base": BASE_BRANCH,
+        "base_sync": base_sync,
+    })
+}
+
+fn add_task_worktree(repo: &Path, worktree: &Path, branch: &str) {
+    git(
+        repo,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            branch,
+            path(worktree),
+            &format!("origin/{BASE_BRANCH}"),
+        ],
+    );
+    configure_identity(worktree);
+}
+
+fn init_repo(path: &Path) {
+    fs::create_dir_all(path).unwrap();
+    git(path, &["init"]);
+    git(path, &["checkout", "-b", BASE_BRANCH]);
+    configure_identity(path);
+}
+
+fn configure_identity(repo: &Path) {
+    git(repo, &["config", "user.name", "Orbit Test"]);
+    git(repo, &["config", "user.email", "orbit-test@example.com"]);
+}
+
+fn commit_file(repo: &Path, file_name: &str, contents: &str) -> String {
+    fs::write(repo.join(file_name), contents).unwrap();
+    git(repo, &["add", file_name]);
+    git(repo, &["commit", "-m", &format!("write {file_name}")]);
+    git(repo, &["rev-parse", "HEAD"])
+}
+
+fn is_ancestor(repo: &Path, ancestor: &str, descendant: &str) -> bool {
+    Command::new("git")
+        .args(["merge-base", "--is-ancestor", ancestor, descendant])
+        .current_dir(repo)
+        .status()
+        .unwrap()
+        .success()
+}
+
+fn path(path: &Path) -> &str {
+    path.to_str().unwrap()
+}
+
+fn git(current_dir: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(current_dir)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {} failed in {}:\nstdout: {}\nstderr: {}",
+        args.join(" "),
+        current_dir.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+struct MergeTestHost {
+    repo_root: PathBuf,
+    data_root: PathBuf,
+    scoreboard_dir: PathBuf,
+}
+
+impl MergeTestHost {
+    fn new(repo_root: &Path, root: &Path) -> Self {
+        Self {
+            repo_root: repo_root.to_path_buf(),
+            data_root: root.join("data"),
+            scoreboard_dir: root.join("scoreboard"),
+        }
+    }
+}
+
+impl DeterministicActionHost for MergeTestHost {
+    fn record_event(&self, _event: OrbitEvent) -> Result<(), OrbitError> {
+        Ok(())
+    }
+
+    fn repo_root(&self) -> Result<String, OrbitError> {
+        Ok(self.repo_root.to_string_lossy().to_string())
+    }
+
+    fn list_job_runs_for_gc(&self) -> Result<Vec<JobRun>, OrbitError> {
+        Ok(Vec::new())
+    }
+
+    fn data_root(&self) -> &Path {
+        &self.data_root
+    }
+
+    fn run_tool_with_context_and_role(
+        &self,
+        _name: &str,
+        _input: Value,
+        _role: Role,
+        _tool_context: ToolContext,
+    ) -> Result<Value, OrbitError> {
+        Err(OrbitError::Execution(
+            "tool execution is not needed by merge tests".to_string(),
+        ))
+    }
+
+    fn maybe_create_failure_task(
+        &self,
+        _job_id: &str,
+        _run_id: &str,
+        _error_code: &str,
+        _error_message: &str,
+        _agent: Option<&str>,
+        _model: Option<&str>,
+    ) -> Result<(), OrbitError> {
+        Ok(())
+    }
+
+    fn scoring_enabled(&self) -> bool {
+        false
+    }
+
+    fn scoreboard_dir(&self) -> &Path {
+        &self.scoreboard_dir
+    }
+}

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/mod.rs
@@ -2,4 +2,5 @@
 
 mod dependency_delivery;
 mod gc;
+mod merge;
 mod setup;

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -473,9 +473,13 @@ The CLI does not own envelope storage. `orbit-core` exposes accessors for v2 aud
 
 ### 8.9 Workflow worktree base synchronization
 
-Task-shipping workflows that create worktrees (`task_pr_pipeline`, `task_local_pipeline`, and callers such as `task_auto_pipeline`) default `base_sync` to `remote` after [T20260427-45]. Remote mode fetches `origin/<base_branch>` and creates, resets, compares, and rebases task branches against that remote-tracking ref; it does not mutate the repo root checkout or prefer stale local base branches.
+Task-shipping workflows that create worktrees (`task_pr_pipeline`, `task_local_pipeline`, and callers such as `task_auto_pipeline`) default `base_sync` to `remote` after [T20260427-45]. Remote mode fetches `origin/<base_branch>` and creates or resets task worktrees at that remote-tracking ref, so every candidate starts from published history rather than a stale local base.
 
 Direct callers can set `base_sync: local` for local-only repos or unpublished base branches. That mode resolves the local base ref and skips origin fetch.
+
+The local pipeline deliberately separates those two moments after [ORB-10604]: worktree setup still honors the caller's sync mode, but its merge checkpoint always uses `base_sync: local`. A previous bundle can advance the shared local base and then fail during bookkeeping or publication; treating that in-session commit as the next merge's rebase target prevents one post-merge failure from turning every later bundle into the remote-mode "local base is ahead" refusal. Each retry re-resolves the current local base and rebases only its own worktree, so concurrent disjoint bundles converge through the existing fast-forward/rebase loop. Exhausted contention can still fail one bundle, but it does not poison the base for later local merges.
+
+The remote-mode refusal remains part of `git_merge`: a caller that requests remote synchronization still fails when the local base carries commits absent from the fetched remote. Local mode is safe here by construction because the local pipeline owns the in-session base history. Publishing before bookkeeping was rejected as the general repair because local pipelines may intentionally run with `auto_push: false`; making publication unconditional would change the workflow's external-side-effect contract, while leaving it conditional would preserve the cascade for those sessions.
 
 ### 8.10 Workflow task admission
 
@@ -699,5 +703,6 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[ORB-10499]** — Identify the bounded post-recovery attempt as the duplicate implement invocation, and let a re-dispatched attempt exit on a write-gated task.
 - **[ORB-10593]** — Fail dispatch at admission when a `blocked_by` target is archived, rejected, or dangling, naming the blocker.
 - **[ORB-10603]** — Derive the durable `execution_summary` from the delivered change when the implementing agent persisted none, leaving the delivery gate itself unchanged ([ADR-0326]).
+- **[ORB-10604]** — Reconcile local-pipeline merges against the current in-session base while retaining the remote-mode divergence refusal.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Decisions"
 type: design
 title: "Activity / Job — Decisions"
 owner: codex
-last_updated: 2026-08-01
+last_updated: 2026-08-08
 last_validated: 2026-07-26
 status: Draft
 feature: activity-job
@@ -268,11 +268,11 @@ Folded into ADR-007's rollup for durable run state and operator inspection.
 
 ## ADR-023 — Seeded task-shipment workflows are deterministic, recoverable, and lock-aware
 
-**Status:** Accepted · 2026-05 · [T20260427-33], [T20260425-2010], [T20260427-45], [T20260430-9], [T20260430-12], [T20260430-14], [T20260421-0542-2], [T20260430-27], [T20260430-30], [T20260430-26], [T20260427-34], [T20260427-36], [T20260505-2], [T20260505-10], [T20260506-18], [T20260509-14]
+**Status:** Accepted · 2026-05 · [T20260427-33], [T20260425-2010], [T20260427-45], [T20260430-9], [T20260430-12], [T20260430-14], [T20260421-0542-2], [T20260430-27], [T20260430-30], [T20260430-26], [T20260427-34], [T20260427-36], [T20260505-2], [T20260505-10], [T20260506-18], [T20260509-14], [ORB-10604]
 
 **Context.** The seeded task workflows added many small ADRs as shipment behavior grew: run aliases, deterministic auto-dispatch, remote base selection, recovery hooks, backlog exclusions, operator status, and lock cleanup. They are one decision family: task shipment is an explicit durable workflow, not an advisory agent step or hidden side effect.
 
-**Decision.** Keep `orbit run` workflow aliases focused on execution, make automatic task shipment deterministic from backlog listing through gate fan-out, default shipping worktrees to fetched remote base refs, admit tasks through status-aware workflow gates, and protect overlapping work with durable task-lock reservations whose seeded TTL covers the child wait budget. Recovery is bounded, step-scoped on direct shipment workflows, and assigned through the configured reviewer role; child pipeline joins are followed by deterministic success guards after required cleanup, operator status is derived from persisted pipeline state, and run-owned reservations clean up when their owner run reaches a terminal state.
+**Decision.** Keep `orbit run` workflow aliases focused on execution, make automatic task shipment deterministic from backlog listing through gate fan-out, default shipping worktrees to fetched remote base refs, admit tasks through status-aware workflow gates, and protect overlapping work with durable task-lock reservations whose seeded TTL covers the child wait budget. Recovery is bounded, step-scoped on direct shipment workflows, and assigned through the configured reviewer role; child pipeline joins are followed by deterministic success guards after required cleanup, operator status is derived from persisted pipeline state, and run-owned reservations clean up when their owner run reaches a terminal state. For local shipment, use the caller-selected sync mode to construct the worktree but reconcile the merge checkpoint against the current local base, preserving commits applied by earlier bundles in the same session. Publishing before bookkeeping is not the general invariant because `auto_push: false` is a supported local-pipeline contract.
 
 Folded instances:
 
@@ -291,6 +291,7 @@ Folded instances:
 
 **Consequences.**
 - Task shipment workflows expose durable admission, recovery, status, and lock state without asking downstream steps to parse model output.
+- A failed post-merge checkpoint does not make the shared local base unusable for the next local bundle; the existing remote-mode divergence refusal still protects callers that require the fetched remote to be authoritative.
 - Auto-dispatch no longer depends on provider credentials before it has deterministic backlog bundles.
 - Gate-owned reservations serialize overlapping bundles while their owner run is alive and are released by both seeded early-release steps and engine-owned terminal cleanup.
 - Seeded gate defaults require `ttl_seconds >= dispatch_timeout_seconds` so a legal child shipment wait cannot outlive its admission reservation.
@@ -298,6 +299,7 @@ Folded instances:
 - Cost: the auto-dispatch audit trail no longer contains a model-authored advisory grouping note.
 - Cost: users of `orbit run ship local`, `orbit run ship list/show`, and `orbit run duel list/show` must update their command muscle memory and scripts.
 - Cost: default shipping workflows now require the configured base branch to be fetchable from `origin`; callers that intentionally operate without a remote must opt into `base_sync: local`.
+- Cost: the local pipeline's merge checkpoint trusts in-session local-base history and therefore does not use that checkpoint to detect unpublished local commits; callers needing that refusal must invoke remote synchronization outside this safe-by-construction path.
 - Cost: job authors must make the recovery activity generic enough for every retryable step in that job.
 - Cost: this is intentionally conservative; it does not perform semantic git cleanup, task mutation, or child-run reconciliation until a more specific recovery policy is justified.
 - Cost: default recovery now depends on the configured reviewer agent being available, and authors must decide which steps deserve recovery rather than flipping one workflow-level switch.
@@ -926,5 +928,6 @@ Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.
 - **[ORB-10332]** — Remove the unused Groundhog activity kind and the epic/parallel pipeline layer (`task_epic_pipeline`, `epic_orchestrator`, `pipeline_wait`, legacy parallel-batch executor).
 - **[ORB-10449]** — Split step-completion protocol from response content so a stalled agent-loop step fails where it happened ([ADR-0258], amending [ADR-0224]; see [§7.6a of `2_design.md`](./2_design.md)).
 - **[ORB-10464]** — Refuse workflow admission when a done dependency's work is not in the base the worktree would be cut from ([ADR-0290], resolving [F2026-07-038]).
+- **[ORB-10604]** — Split remote worktree construction from local merge reconciliation so post-merge failures do not cascade through a shipment session.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10604](https://orbit-cli.com/tasks/ORB-10604) — Stop local-mode pipelines from leaving the local base branch ahead of its remote

### Description

## Problem

In local mode the pipeline applies a merge, then does bookkeeping, then publishes. Any failure inside that window leaves the local base branch carrying commits the remote does not have. The next merge in the same session hits a guard that refuses to fast-forward a local base that is ahead of its remote, and every remaining task in the bundle fails the same way. One failure becomes a session-wide cascade.

The originally reported cascade is currently blocked by accident, not by design: an unrelated change moved a different failure earlier in the sequence, so that particular path no longer reaches the merge. The window itself is unchanged, and anything else failing inside it reproduces the cascade.

Concurrency widens the exposure. The auto pipeline fans bundles out across multiple workers against one shared local base, so the window is not merely sequential.

## What is in question

The guard that refuses to fast-forward is correct — a base that is ahead of its remote genuinely cannot be fast-forwarded, and its error message already names the configuration that would make it unnecessary. The defect is that the pipeline arranges to be in that state and then declines to use the escape hatch it advertises.

Two shapes are available and you should pick one on the merits rather than doing both: publish before the bookkeeping so the window closes immediately, or select the base-sync mode that is correct for an in-session merge so being ahead is expected rather than exceptional. The second is the smaller diff; the first is the stronger invariant. Argue the choice.

## Constraints

- Do not delete or blanket-disable the refusal. It protects against a real failure mode in the case where the base genuinely diverged.
- Do not fix this by serializing the auto pipeline's fan-out unless you can show the concurrency is not otherwise recoverable — throughput is deliberate here.
- Turn, budget, and retry knobs are out of scope.

## Sequencing

Depends on the deterministic execution-summary work landing first, which settles what happens in the earlier part of this window. Do not re-litigate that here.

### Acceptance Criteria

- A failure anywhere between applying a merge and publishing it no longer leaves the local base branch in a state that makes every subsequent merge in the same session refuse.
- Multiple tasks processed in one local-mode session succeed independently: a failure in one does not cascade into refusals for the rest.
- Concurrent bundles sharing one local base do not corrupt each other's view of that base, or the pipeline declines to run them concurrently and says so.
- The existing safety refusal is not deleted. If a case is made safe by construction, the refusal still fires for the cases that are genuinely unsafe, and a test covers both sides.
- Regression coverage exists for the cascade: two tasks in one session where the first fails after its merge is applied.
- Assets stay deployment-agnostic — no host names, workspace names, task ids, or environment-specific paths in shipped YAML.
- The crate builds and the change's own tests pass. Pre-existing unrelated failures are named, not repaired.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- The local pipeline now keeps caller-selected remote/local synchronization for worktree setup but uses the current local base at the merge checkpoint. An earlier bundle that merged and then failed bookkeeping or publication is therefore valid in-session history instead of a cascade trigger.
- The committed job asset and its shipped resource mirror remain byte-for-byte synchronized and deployment-agnostic.
- Added a deterministic two-task Git regression: the first merge advances the local base without publication, remote mode retains the existing safety refusal for the second task, and the pipeline-selected local mode rebases and merges the second task while preserving both changes.
- Added a catalog contract test and updated the Activity / Job design and rollup decision rationale, including why publish-before-bookkeeping was rejected for supported auto_push=false sessions.
Strategic decisions:
- Chose local merge synchronization over publication reordering because it fixes both pushing and intentionally non-pushing local sessions without changing external side-effect semantics. Worktree construction remains remote by default, so candidates still start from published history.
Assessment: Targeted worktree tests passed (45), targeted job-catalog tests passed (29), the focused regression passed, and make ci-fast passed.
Deviations from original plan:
- Added the shipped .orbit resource mirror, sibling test module, catalog test, and directly affected design documents to context_files before editing them; these are required registration, regression, deployment-mirror, and same-PR documentation companions to the scoped asset change.
Design weaknesses / risks:
- Severity: low. Local merge synchronization intentionally trusts the session's local-base history. Mitigation: remote mode and its local-ahead refusal remain unchanged and are exercised by the regression test.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10604-6a77918e`
- Behind base: 0
- Ahead of base: 1