### PR TITLE
Close sandbox write-grant containment and diagnostic gaps left by PR #874

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -30,7 +30,9 @@ use super::envelope::{
     cli_agent_envelope_json, parse_cli_invocation_trace, parse_cli_response_result,
     task_id_from_input,
 };
-use super::spawn::{prepare_sandbox_for_dispatch, resolve_provider_launcher};
+use super::spawn::{
+    linux_bwrap_failed_write_diagnostic, prepare_sandbox_for_dispatch, resolve_provider_launcher,
+};
 use super::supervisor::{
     DEFAULT_WALL_CLOCK_TIMEOUT_SECONDS, SpawnTraceContext, SpawnWithTimeoutRequest,
     spawn_with_timeout,
@@ -318,6 +320,24 @@ pub fn run_cli_backend(
     // and diagnostics, but only make them authoritative when the activity
     // explicitly declares that downstream templates require them.
     let exit_success = !timed_out && matches!(exit_code, Some(0));
+    let sandbox_write_diagnostic = if exit_success {
+        None
+    } else {
+        match sandbox {
+            Some(sandbox)
+                if sandbox.kind == orbit_common::types::ExecutorSandboxKind::LinuxBwrap =>
+            {
+                linux_bwrap_failed_write_diagnostic(
+                    &sandbox.fs_profile,
+                    stderr.protocol_bytes(),
+                    subprocess_cwd.as_deref(),
+                )
+                .map_err(|error| DispatchError::CliInvocationPermanent(error.to_string()))?
+                .map(|diagnostic| bounded_diagnostic(&diagnostic, &redaction))
+            }
+            _ => None,
+        }
+    };
     // A truncated capture retains the final complete JSONL events separately
     // from its diagnostic prefix. Protocol parsing must use that tail so a
     // verbose provider's final Orbit envelope remains authoritative.
@@ -373,7 +393,11 @@ pub fn run_cli_backend(
             timeout_seconds
         ))
     } else if !exit_success {
-        Some(format!("cli subprocess exited with code {:?}", exit_code))
+        Some(
+            sandbox_write_diagnostic
+                .clone()
+                .unwrap_or_else(|| format!("cli subprocess exited with code {:?}", exit_code)),
+        )
     } else if spec.require_response_envelope
         && matches!(envelope_status.as_deref(), Some("failed") | Some("timeout"))
     {
@@ -439,6 +463,10 @@ pub fn run_cli_backend(
         (
             "completion_envelope_error",
             completion_envelope_error.map_or(Value::Null, Value::String),
+        ),
+        (
+            "sandbox_write_diagnostic",
+            sandbox_write_diagnostic.map_or(Value::Null, Value::String),
         ),
         ("stdout_text", Value::String(stdout_text)),
         (

--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -3,13 +3,13 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 
-use orbit_common::types::ExecutorSandboxKind;
+use orbit_common::types::{ExecutorSandboxKind, OrbitError, ResolvedFsProfile};
 use orbit_common::utility::redaction::non_sensitive_env_vars;
 use orbit_exec::{
     BwrapProbeOutcome, LinuxBwrapSpawnRequest, MacosSandboxSpawnRequest, UnsatisfiedWriteGrant,
-    compile_linux_bwrap_argv, compile_macos_sandbox_profile, prepare_linux_bwrap_write_grants,
-    probe_bwrap, sandbox_exec_available, sandbox_exec_unavailable_message, spawn_under_linux_bwrap,
-    spawn_under_macos_sandbox,
+    compile_linux_bwrap_argv, compile_macos_sandbox_profile, linux_bwrap_write_grant_diagnostic,
+    prepare_linux_bwrap_write_grants, probe_bwrap, sandbox_exec_available,
+    sandbox_exec_unavailable_message, spawn_under_linux_bwrap, spawn_under_macos_sandbox,
 };
 use tempfile::NamedTempFile;
 
@@ -357,6 +357,76 @@ fn describe_grants(grants: &[UnsatisfiedWriteGrant]) -> String {
         .map(UnsatisfiedWriteGrant::describe)
         .collect::<Vec<_>>()
         .join("; ")
+}
+
+/// Turn a child-reported EROFS into a policy-owned denial when the failing
+/// program included the attempted path in stderr. This runs after the real
+/// Bubblewrap child exits, so it covers the production invocation boundary
+/// rather than merely explaining a path supplied by a unit test.
+pub(super) fn linux_bwrap_failed_write_diagnostic(
+    profile: &ResolvedFsProfile,
+    stderr: &[u8],
+    cwd: Option<&Path>,
+) -> Result<Option<String>, OrbitError> {
+    let stderr = String::from_utf8_lossy(stderr);
+    for line in stderr.lines().rev() {
+        if !line.contains("Read-only file system") && !line.contains("EROFS") {
+            continue;
+        }
+        for candidate in failed_write_path_candidates(line).into_iter().rev() {
+            let path = Path::new(&candidate);
+            let attempted = if path.is_absolute() {
+                path.to_path_buf()
+            } else if let Some(cwd) = cwd {
+                cwd.join(path)
+            } else {
+                continue;
+            };
+            if let Some(diagnostic) = linux_bwrap_write_grant_diagnostic(profile, &attempted)? {
+                return Ok(Some(format!(
+                    "Orbit linux-bwrap policy denied the attempted write: {diagnostic}"
+                )));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn failed_write_path_candidates(line: &str) -> Vec<String> {
+    let mut candidates = Vec::new();
+    for quote in ['\'', '"', '`'] {
+        let mut remainder = line;
+        while let Some(start) = remainder.find(quote) {
+            let after_start = &remainder[start + quote.len_utf8()..];
+            let Some(end) = after_start.find(quote) else {
+                break;
+            };
+            let candidate = after_start[..end].trim();
+            if !candidate.is_empty() {
+                candidates.push(candidate.to_string());
+            }
+            remainder = &after_start[end + quote.len_utf8()..];
+        }
+    }
+
+    // Coreutils quotes paths, but language runtimes often render
+    // `...: /path: Read-only file system`. Keep a conservative token fallback
+    // so those failures are attributable too.
+    let prefix = line
+        .split_once("Read-only file system")
+        .or_else(|| line.split_once("EROFS"))
+        .map_or(line, |(prefix, _)| prefix);
+    if let Some(token) = prefix.split_whitespace().next_back() {
+        let candidate = token
+            .trim_matches(|character: char| {
+                matches!(character, '\'' | '"' | '`' | ':' | '(' | ')' | '[' | ']')
+            })
+            .trim();
+        if !candidate.is_empty() && !candidates.iter().any(|known| known == candidate) {
+            candidates.push(candidate.to_string());
+        }
+    }
+    candidates
 }
 
 // pub(crate) widened for tests/ layout under ORB-00225; test reaches via exposed surface.

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -13,6 +13,8 @@ use orbit_common::test_fixtures::{TEST_CLAUDE_MODEL, TEST_CODEX_MODEL};
 use orbit_common::types::activity_job::{
     AgentRole, JobV2StepBody, V2AuditEventKind, load_job_asset,
 };
+#[cfg(target_os = "linux")]
+use orbit_exec::probe_bwrap;
 use orbit_store::Store;
 use tempfile::{TempDir, tempdir};
 
@@ -22,6 +24,8 @@ use crate::template::{self, TemplateContext};
 use super::super::super::agent_role::{apply_resolved_settings, resolve_agent_settings};
 use super::super::super::audit_writer::V2AuditWriter;
 use super::super::super::dispatcher::DispatchError;
+#[cfg(target_os = "linux")]
+use super::super::super::dispatcher::ResolvedSandbox;
 use super::super::super::sqlite_sink::V2SqliteSink;
 use super::super::super::workspace::{WorktreeBoundaryGuard, validate_declared_worktree_pair};
 use super::super::run_cli_backend;
@@ -871,6 +875,80 @@ fn run_cli_backend_records_resolved_cwd_in_started_event() {
         })
         .expect("cli.invocation.started cwd");
     assert_eq!(cwd, workspace_string);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn linux_bwrap_failed_invocation_names_ungranted_write_path_and_deny() {
+    if !probe_bwrap().available {
+        return;
+    }
+
+    let temp = tempdir().expect("tempdir");
+    let workspace = temp.path().join("worktree");
+    let orbit = workspace.join(".orbit");
+    fs::create_dir_all(&orbit).expect("denied Orbit root");
+    let script = workspace.join("codex");
+    write_executable(
+        &script,
+        "#!/bin/sh\ncat > /dev/null\ntouch \"$PWD/.orbit/ungranted\"\n",
+    );
+    let blocked_path = orbit.join("ungranted");
+    let profile = orbit_common::types::ResolvedFsProfile {
+        name: "implementer".to_string(),
+        read: vec![format!("{}/**", workspace.display())],
+        modify: vec![
+            format!("{}/**", workspace.display()),
+            format!("!{}/**", orbit.display()),
+        ],
+    };
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-linux-write-denial",
+        "codex:test",
+        sink_for_writer,
+    ));
+    let host = TestHost {
+        command: script.display().to_string(),
+        executor_args: Vec::new(),
+        provider_config: HashMap::new(),
+        sandbox: Some(ResolvedSandbox {
+            kind: orbit_common::types::ExecutorSandboxKind::LinuxBwrap,
+            fs_profile: profile,
+            allow_fallback: false,
+            managed_worktree: true,
+        }),
+        task_context: Some(serde_json::json!({
+            "workspace_path": workspace.display().to_string()
+        })),
+        workspace_root: None,
+    };
+    let spec = test_agent_loop_spec(Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-linux-write-denial",
+        audit,
+        &serde_json::json!({"prompt": "attempt the write"}),
+        None,
+    )
+    .expect("the invocation outcome should be classified");
+
+    assert!(!outcome.success);
+    let message = outcome.message.expect("Orbit-owned denial diagnostic");
+    assert!(
+        message.contains(&blocked_path.display().to_string()),
+        "diagnostic must name the attempted path: {message}"
+    );
+    assert!(
+        message.contains("denyModify rule"),
+        "diagnostic must name the shadowing deny: {message}"
+    );
+    assert_eq!(outcome.output["sandbox_write_diagnostic"], message);
+    assert!(!blocked_path.exists());
 }
 
 #[test]

--- a/crates/orbit-exec/src/linux_sandbox.rs
+++ b/crates/orbit-exec/src/linux_sandbox.rs
@@ -130,7 +130,9 @@ pub struct PreparedWriteGrants {
 ///
 /// This is the whole grant set. It is read off the profile that will compile
 /// the argv, so it cannot drift from what the sandbox actually enforces.
-pub fn linux_bwrap_write_grants(profile: &ResolvedFsProfile) -> Vec<WriteGrant> {
+pub fn linux_bwrap_write_grants(
+    profile: &ResolvedFsProfile,
+) -> Result<Vec<WriteGrant>, OrbitError> {
     let mut grants = Vec::new();
     for (index, rule) in profile.modify.iter().enumerate() {
         if rule.starts_with('!') || !is_narrow_reallow(&profile.modify[..index], rule) {
@@ -139,14 +141,20 @@ pub fn linux_bwrap_write_grants(profile: &ResolvedFsProfile) -> Vec<WriteGrant> 
         let Some(anchor) = exact_or_subtree_root(rule) else {
             continue;
         };
-        let kind = write_anchor_kind(&anchor, rule, &profile.modify);
+        // A later deny that covers the anchor shadows this re-allow under the
+        // profile's last-match-wins contract. Do not materialize a path the
+        // final policy denies. A narrower deny below a subtree does not match
+        // the subtree root, so the remaining writable portion is preserved.
+        if !path_is_effectively_writable(profile, &anchor)? {
+            continue;
+        }
         grants.push(WriteGrant {
             rule: rule.clone(),
             anchor,
-            kind,
+            kind: write_anchor_kind(rule),
         });
     }
-    grants
+    Ok(grants)
 }
 
 /// Materialize every granted-but-absent write anchor that falls inside a
@@ -167,7 +175,7 @@ pub fn prepare_linux_bwrap_write_grants(
         ))
     })?;
     let mut prepared = PreparedWriteGrants::default();
-    for grant in linux_bwrap_write_grants(profile) {
+    for grant in linux_bwrap_write_grants(profile)? {
         if ensure_write_anchor(&root, &grant, &mut prepared)? {
             prepared.created.push(grant.anchor);
         }
@@ -220,6 +228,15 @@ fn ensure_write_anchor(
     grant: &WriteGrant,
     prepared: &mut PreparedWriteGrants,
 ) -> Result<bool, OrbitError> {
+    let Ok(relative) = grant.anchor.strip_prefix(root) else {
+        return inspect_host_owned_anchor(root, grant, prepared);
+    };
+
+    // Validate the whole worktree-owned chain before consulting the final
+    // target. `symlink_metadata(anchor)` follows intermediate symlinks, so an
+    // existing outside target would otherwise bypass the absent-anchor checks.
+    validate_owned_anchor_components(root, relative, grant)?;
+
     match std::fs::symlink_metadata(&grant.anchor) {
         Ok(metadata) => {
             if metadata.file_type().is_symlink() {
@@ -227,6 +244,23 @@ fn ensure_write_anchor(
                     "write-grant anchor `{}` (rule `{}`) must not be a symlink",
                     grant.anchor.display(),
                     grant.rule
+                )));
+            }
+            let canonical = grant.anchor.canonicalize().map_err(|error| {
+                OrbitError::InvalidInput(format!(
+                    "write-grant anchor `{}` (rule `{}`) must resolve canonically inside `{}`: {error}",
+                    grant.anchor.display(),
+                    grant.rule,
+                    root.display()
+                ))
+            })?;
+            if !canonical.starts_with(root) {
+                return Err(OrbitError::InvalidInput(format!(
+                    "write-grant anchor `{}` (rule `{}`) resolves outside the trusted preparation root `{}` as `{}`",
+                    grant.anchor.display(),
+                    grant.rule,
+                    root.display(),
+                    canonical.display()
                 )));
             }
             let matches = match grant.kind {
@@ -252,36 +286,6 @@ fn ensure_write_anchor(
         }
     }
 
-    let Ok(relative) = grant.anchor.strip_prefix(root) else {
-        prepared.unsatisfied.push(UnsatisfiedWriteGrant {
-            rule: grant.rule.clone(),
-            anchor: grant.anchor.clone(),
-            reason: format!(
-                "the anchor does not exist and lies outside the trusted preparation root `{}`, so the host must create it before dispatch",
-                root.display()
-            ),
-        });
-        return Ok(false);
-    };
-
-    // Every component the preparation root owns must be a real directory. A
-    // symlink anywhere on that chain would let an absent anchor be created
-    // outside the root, which is the one escape this layer can cause.
-    let mut current = root.to_path_buf();
-    for component in relative.components() {
-        current.push(component);
-        if std::fs::symlink_metadata(&current)
-            .is_ok_and(|metadata| metadata.file_type().is_symlink())
-        {
-            return Err(OrbitError::InvalidInput(format!(
-                "write-grant anchor `{}` (rule `{}`) resolves through symlink `{}`; components inside the preparation root must not be a symlink",
-                grant.anchor.display(),
-                grant.rule,
-                current.display()
-            )));
-        }
-    }
-
     if let Some(parent) = grant.anchor.parent() {
         std::fs::create_dir_all(parent).map_err(|error| {
             OrbitError::Execution(format!(
@@ -290,6 +294,23 @@ fn ensure_write_anchor(
                 grant.rule
             ))
         })?;
+        let canonical_parent = parent.canonicalize().map_err(|error| {
+            OrbitError::InvalidInput(format!(
+                "write-grant anchor parent `{}` (rule `{}`) must resolve canonically inside `{}`: {error}",
+                parent.display(),
+                grant.rule,
+                root.display()
+            ))
+        })?;
+        if !canonical_parent.starts_with(root) {
+            return Err(OrbitError::InvalidInput(format!(
+                "write-grant anchor parent `{}` (rule `{}`) resolves outside the trusted preparation root `{}` as `{}`",
+                parent.display(),
+                grant.rule,
+                root.display(),
+                canonical_parent.display()
+            )));
+        }
     }
     match grant.kind {
         WriteAnchorKind::File => {
@@ -318,36 +339,132 @@ fn ensure_write_anchor(
     Ok(true)
 }
 
-/// Derive the anchor's shape from evidence, in decreasing order of authority:
-/// what is already on disk, the rule's own syntax (`<root>/**` can only be a
-/// directory), whether another rule nests beneath it, and finally whether the
-/// leaf looks like a file. Directory is the safe default for the residual case:
-/// a directory anchor still admits files created inside it, a file anchor
-/// admits nothing.
-fn write_anchor_kind(anchor: &Path, rule: &str, rules: &[String]) -> WriteAnchorKind {
-    if let Ok(metadata) = std::fs::metadata(anchor) {
-        return if metadata.is_dir() {
-            WriteAnchorKind::Directory
-        } else {
-            WriteAnchorKind::File
+fn inspect_host_owned_anchor(
+    root: &Path,
+    grant: &WriteGrant,
+    prepared: &mut PreparedWriteGrants,
+) -> Result<bool, OrbitError> {
+    match std::fs::symlink_metadata(&grant.anchor) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() {
+                return Err(OrbitError::InvalidInput(format!(
+                    "write-grant anchor `{}` (rule `{}`) must not be a symlink",
+                    grant.anchor.display(),
+                    grant.rule
+                )));
+            }
+            let matches = match grant.kind {
+                WriteAnchorKind::File => metadata.is_file(),
+                WriteAnchorKind::Directory => metadata.is_dir(),
+            };
+            if !matches {
+                return Err(OrbitError::InvalidInput(format!(
+                    "write-grant anchor `{}` (rule `{}`) exists with the wrong filesystem type",
+                    grant.anchor.display(),
+                    grant.rule
+                )));
+            }
+            Ok(false)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            prepared.unsatisfied.push(UnsatisfiedWriteGrant {
+                rule: grant.rule.clone(),
+                anchor: grant.anchor.clone(),
+                reason: format!(
+                    "the anchor does not exist and lies outside the trusted preparation root `{}`, so the host must create it before dispatch",
+                    root.display()
+                ),
+            });
+            Ok(false)
+        }
+        Err(error) => Err(OrbitError::Execution(format!(
+            "inspect write-grant anchor `{}` (rule `{}`): {error}",
+            grant.anchor.display(),
+            grant.rule
+        ))),
+    }
+}
+
+fn validate_owned_anchor_components(
+    root: &Path,
+    relative: &Path,
+    grant: &WriteGrant,
+) -> Result<(), OrbitError> {
+    let mut current = root.to_path_buf();
+    let component_count = relative.components().count();
+    for (index, component) in relative.components().enumerate() {
+        let std::path::Component::Normal(component) = component else {
+            return Err(OrbitError::InvalidInput(format!(
+                "write-grant anchor `{}` (rule `{}`) must not contain non-normal path components inside `{}`",
+                grant.anchor.display(),
+                grant.rule,
+                root.display()
+            )));
         };
+        current.push(component);
+        match std::fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(OrbitError::InvalidInput(format!(
+                    "write-grant anchor `{}` (rule `{}`) resolves through symlink `{}`; components inside the preparation root must not be a symlink",
+                    grant.anchor.display(),
+                    grant.rule,
+                    current.display()
+                )));
+            }
+            Ok(metadata) if index + 1 < component_count && !metadata.is_dir() => {
+                return Err(OrbitError::InvalidInput(format!(
+                    "write-grant anchor `{}` (rule `{}`) resolves through non-directory component `{}`",
+                    grant.anchor.display(),
+                    grant.rule,
+                    current.display()
+                )));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => break,
+            Err(error) => {
+                return Err(OrbitError::Execution(format!(
+                    "inspect write-grant anchor component `{}` (rule `{}`): {error}",
+                    current.display(),
+                    grant.rule
+                )));
+            }
+        }
     }
+    Ok(())
+}
+
+/// The policy grammar is the anchor-type contract: an exact rule denotes one
+/// file, while `<root>/**` denotes a directory subtree. Filename punctuation
+/// is never evidence, so extensionless files and dotted directories are both
+/// represented without a hardcoded path inventory.
+fn write_anchor_kind(rule: &str) -> WriteAnchorKind {
     if rule.ends_with("/**") {
-        return WriteAnchorKind::Directory;
-    }
-    let nested = format!("{}/", anchor.display());
-    if rules
-        .iter()
-        .map(|other| other.strip_prefix('!').unwrap_or(other.as_str()))
-        .any(|other| other.starts_with(&nested))
-    {
-        return WriteAnchorKind::Directory;
-    }
-    if anchor.extension().is_some() {
-        WriteAnchorKind::File
-    } else {
         WriteAnchorKind::Directory
+    } else {
+        WriteAnchorKind::File
     }
+}
+
+fn path_is_effectively_writable(
+    profile: &ResolvedFsProfile,
+    path: &Path,
+) -> Result<bool, OrbitError> {
+    let rendered = path.to_string_lossy().replace('\\', "/");
+    let mut writable = false;
+    for rule in &profile.modify {
+        let body = rule.strip_prefix('!').unwrap_or(rule.as_str());
+        if compile_glob_regex(body)
+            .map_err(|error| {
+                OrbitError::InvalidInput(format!(
+                    "invalid linux-bwrap filesystem glob `{body}`: {error}"
+                ))
+            })?
+            .is_match(&rendered)
+        {
+            writable = !rule.starts_with('!');
+        }
+    }
+    Ok(writable)
 }
 
 pub fn bwrap_program_for_audit() -> &'static str {
@@ -463,12 +580,17 @@ pub fn compile_linux_bwrap_argv(
                 push_mount(&mut out, "--ro-bind", &path);
             }
         } else if is_narrow_reallow(&profile.modify[..index], rule) {
+            let Some(anchor) = exact_or_subtree_root(rule) else {
+                continue;
+            };
+            if !path_is_effectively_writable(profile, &anchor)? {
+                continue;
+            }
             let paths = mount_paths_for_rule(rule, false)?;
             if paths.is_empty() {
                 dropped_grants.push(UnsatisfiedWriteGrant {
                     rule: rule.clone(),
-                    anchor: exact_or_subtree_root(rule)
-                        .unwrap_or_else(|| static_prefix(rule.as_str())),
+                    anchor,
                     reason: "no path on disk matches the rule, so Bubblewrap has nothing to bind and the grant stays under the surrounding read-only mount".to_string(),
                 });
                 continue;

--- a/crates/orbit-exec/tests/linux_sandbox.rs
+++ b/crates/orbit-exec/tests/linux_sandbox.rs
@@ -41,7 +41,7 @@ fn worktree_profile(worktree: &std::path::Path, reallows: Vec<String>) -> Resolv
 }
 
 #[test]
-fn absent_granted_file_and_directory_targets_are_both_materialized() {
+fn absent_anchor_kind_comes_from_rule_semantics_not_filename_shape() {
     let temp = tempfile::tempdir().expect("tempdir");
     let worktree = temp.path().join("worktree");
     std::fs::create_dir_all(&worktree).expect("worktree");
@@ -49,10 +49,10 @@ fn absent_granted_file_and_directory_targets_are_both_materialized() {
     let resolved = worktree_profile(
         &worktree,
         vec![
-            // Absent file grant, spelled as an exact leaf.
-            orbit.join("config.toml").display().to_string(),
-            // Absent directory grant, spelled as a subtree.
-            format!("{}/**", orbit.join("auto_tasks").display()),
+            // Exact rules denote files, including extensionless names.
+            orbit.join("config").display().to_string(),
+            // Subtree rules denote directories, including dotted names.
+            format!("{}/**", orbit.join("cache.v1").display()),
             // A file grant *beneath* a granted directory: the case the old
             // hardcoded `(path, kind)` table missed, because it matched the
             // directory entry by exact tuple and never created the parent.
@@ -64,12 +64,12 @@ fn absent_granted_file_and_directory_targets_are_both_materialized() {
         prepare_linux_bwrap_write_grants(&resolved, &worktree).expect("prepare policy grants");
 
     assert!(
-        orbit.join("config.toml").is_file(),
-        "an absent granted file target must be materialized"
+        orbit.join("config").is_file(),
+        "an absent extensionless exact grant must be materialized as a file"
     );
     assert!(
-        orbit.join("auto_tasks").is_dir(),
-        "an absent granted directory target must be materialized"
+        orbit.join("cache.v1").is_dir(),
+        "an absent dotted subtree grant must be materialized as a directory"
     );
     assert!(orbit.join("routines").is_dir());
     assert_eq!(prepared.created.len(), 3, "{:?}", prepared.created);
@@ -84,7 +84,7 @@ fn absent_granted_file_and_directory_targets_are_both_materialized() {
         .expect("compile");
     assert!(plan.dropped_grants.is_empty(), "{:?}", plan.dropped_grants);
     let joined = plan.args.join(" ");
-    for anchor in ["config.toml", "auto_tasks", "routines"] {
+    for anchor in ["config", "cache.v1", "routines"] {
         assert!(
             joined.contains(&format!("--bind {0} {0}", orbit.join(anchor).display())),
             "missing re-allow mount for {anchor} in {joined}"
@@ -151,7 +151,7 @@ fn definition_and_cursor_roots_stay_separate_across_local_and_shared_orbit_dirs(
         ],
     );
 
-    let grants = linux_bwrap_write_grants(&resolved);
+    let grants = linux_bwrap_write_grants(&resolved).expect("derive grants");
     let definitions = grants
         .iter()
         .find(|grant| grant.anchor == local_definitions)
@@ -221,8 +221,109 @@ fn write_grant_preparation_rejects_symlink_escape() {
     let error = prepare_linux_bwrap_write_grants(&resolved, &worktree)
         .expect_err("symlink escape must fail closed");
 
-    assert!(error.to_string().contains("must not be a symlink"));
+    assert!(error.to_string().contains("resolves through symlink"));
     assert!(!outside.join("config.toml").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn existing_write_grant_rejects_intermediate_symlink_escape() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let worktree = temp.path().join("worktree");
+    let outside = temp.path().join("outside");
+    std::fs::create_dir_all(&worktree).expect("worktree");
+    std::fs::create_dir_all(&outside).expect("outside");
+    std::fs::write(outside.join("config.toml"), "outside").expect("outside target");
+    symlink(&outside, worktree.join(".orbit")).expect("symlink Orbit root");
+    let resolved = worktree_profile(
+        &worktree,
+        vec![worktree.join(".orbit/config.toml").display().to_string()],
+    );
+
+    let error = prepare_linux_bwrap_write_grants(&resolved, &worktree)
+        .expect_err("an existing target through an intermediate symlink must fail closed");
+
+    let message = error.to_string();
+    assert!(message.contains("config.toml"), "{message}");
+    assert!(message.contains("resolves through symlink"), "{message}");
+    assert_eq!(
+        std::fs::read_to_string(outside.join("config.toml")).expect("outside unchanged"),
+        "outside"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn existing_write_grant_rejects_final_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let worktree = temp.path().join("worktree");
+    let orbit = worktree.join(".orbit");
+    let outside = temp.path().join("outside.toml");
+    std::fs::create_dir_all(&orbit).expect("Orbit root");
+    std::fs::write(&outside, "outside").expect("outside target");
+    symlink(&outside, orbit.join("config.toml")).expect("symlink final anchor");
+    let resolved = worktree_profile(
+        &worktree,
+        vec![orbit.join("config.toml").display().to_string()],
+    );
+
+    let error = prepare_linux_bwrap_write_grants(&resolved, &worktree)
+        .expect_err("a final symlink must fail closed");
+
+    let message = error.to_string();
+    assert!(message.contains("config.toml"), "{message}");
+    assert!(message.contains("resolves through symlink"), "{message}");
+}
+
+#[test]
+fn materialization_uses_final_last_match_wins_decision() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let worktree = temp.path().join("worktree");
+    let orbit = worktree.join(".orbit");
+    std::fs::create_dir_all(&worktree).expect("worktree");
+    let denied_file = orbit.join("workspace-denied");
+    let partially_writable = orbit.join("cache.v1");
+    let resolved = worktree_profile(
+        &worktree,
+        vec![
+            denied_file.display().to_string(),
+            format!("!{}", denied_file.display()),
+            format!("{}/**", partially_writable.display()),
+            format!("!{}/private/**", partially_writable.display()),
+        ],
+    );
+
+    let grants = linux_bwrap_write_grants(&resolved).expect("derive effective grants");
+    assert!(
+        grants.iter().all(|grant| grant.anchor != denied_file),
+        "a later exact deny must remove the shadowed materialization candidate: {grants:?}"
+    );
+    assert!(
+        grants
+            .iter()
+            .any(|grant| grant.anchor == partially_writable),
+        "a narrower child deny must preserve the writable remainder: {grants:?}"
+    );
+
+    let prepared =
+        prepare_linux_bwrap_write_grants(&resolved, &worktree).expect("prepare effective grants");
+    assert!(!denied_file.exists());
+    assert!(partially_writable.is_dir());
+    assert_eq!(prepared.created, vec![partially_writable.clone()]);
+
+    let plan = compile_linux_bwrap_argv(&resolved, "/bin/true", &[], Some(&worktree), true)
+        .expect("compile");
+    assert!(
+        plan.dropped_grants
+            .iter()
+            .all(|grant| grant.anchor != denied_file),
+        "a finally denied rule is not an unsatisfied grant: {:?}",
+        plan.dropped_grants
+    );
 }
 
 #[test]

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -3,7 +3,7 @@ summary: "Policy & Sandboxing — Design"
 type: design
 title: "Policy & Sandboxing — Design"
 owner: claude
-last_updated: 2026-08-02
+last_updated: 2026-08-08
 status: Draft
 feature: policy-sandbox
 doc_role: design
@@ -158,13 +158,13 @@ The ADR authoring exception follows that same ordering: trusted host setup ensur
 
 #### 7.1.1 Write-grant anchors are derived from the effective profile at each spawn
 
-`spawn_linux_bwrap` prepares mount anchors immediately before compiling argv, from the same `ResolvedFsProfile` that compiles it. The grant set is every positive exact/subtree `modify` rule that is a narrow re-allow beneath an earlier deny — the rules that need an anchor to become a bind. Broad writable roots are excluded; they are host-owned and must already exist, so an absent one still fails closed at compile.
+`spawn_linux_bwrap` prepares mount anchors immediately before compiling argv, from the same `ResolvedFsProfile` that compiles it. The grant set is every positive exact/subtree `modify` rule that is a narrow re-allow beneath an earlier deny and remains writable at its anchor after the full ordered rule list is evaluated. A later deny covering the anchor therefore prevents materialization, while a narrower deny below a writable subtree leaves the remaining subtree grant intact. Broad writable roots are excluded; they are host-owned and must already exist, so an absent one still fails closed at compile.
 
-Anchor shape is derived from evidence rather than an inventory: what is already on disk, then the rule's own syntax (`<root>/**` can only be a directory), then whether another rule nests beneath the anchor, then whether the leaf carries a file extension. Directory is the residual default because a directory anchor still admits files created inside it. This is why a grant naming a file *beneath* a granted directory now works: the directory anchor comes from the rule, not from whatever a task happened to name.
+The policy grammar is the explicit anchor-type contract: an exact rule denotes a file, while `<root>/**` denotes a directory subtree. Filename punctuation is never type evidence, so an extensionless exact rule materializes a file and a dotted subtree root materializes a directory without any hardcoded path inventory. An existing target whose filesystem type contradicts its rule fails closed.
 
-Creation is confined to the managed worktree, which is trusted and disposable. Every path component the worktree owns is checked for symlinks, files use create-new semantics, and an existing anchor of the wrong filesystem type fails closed naming the path and its rule. Anchors outside that root are the host's to create and are reported, not invented. Creating an anchor grants nothing new — the effective profile already decided the path is writable — so this is materialization, not policy.
+Creation is confined to the canonical managed worktree, which is trusted and disposable. Every worktree-owned component is checked for symlinks before both existing- and absent-target handling, the resolved existing anchor (or newly created parent) must remain inside the canonical root, and files use create-new semantics. Anchors outside that root are the host's to create and are reported, not invented. Creating an anchor grants nothing new — the final effective profile already decided the path is writable — so this is materialization, not policy.
 
-Two consequences follow from deriving at spawn rather than during `worktree_setup`. The grant set matches the profile the kernel will enforce, including the host-appended run roots that setup never saw; and it is recomputed for each provider launch, so a run whose needs grow does not depend on a snapshot taken before it started. [ORB-10602]
+Two consequences follow from deriving at spawn rather than during `worktree_setup`. The grant set matches the profile the kernel will enforce, including the host-appended run roots that setup never saw; and it is recomputed for each provider launch, so a run whose needs grow does not depend on a snapshot taken before it started. After a failed Bubblewrap child, the executor inspects EROFS stderr that names an attempted path and evaluates that path against the same effective profile, replacing a generic nonzero-exit message with an Orbit-owned missing-grant or shadowing-deny diagnostic. Children that omit the path retain the generic failure. [ORB-10602] [ORB-10607] [ADR-0329]
 
 The policy syntax remains schema v2. Existing policies without `denyModify` exceptions retain their prior behavior. After installing a binary that carries a changed shipped default, `orbit init` refreshes the machine-global policy assets without changing executor sandbox selection or `allow_fallback`; `--force` is unnecessary and would reset the global root. Workspace policy can then narrow the refreshed host boundary but cannot expand its exception surface.
 

--- a/docs/design/policy-sandbox/4_decisions.md
+++ b/docs/design/policy-sandbox/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Policy & Sandboxing — Decisions"
 type: design
 title: "Policy & Sandboxing — Decisions"
 owner: claude
-last_updated: 2026-08-02
+last_updated: 2026-08-08
 status: Draft
 feature: policy-sandbox
 doc_role: decisions
@@ -56,11 +56,11 @@ Global ADR pointers are retrieved with `orbit tool run orbit.adr.show --input '{
 
 ## ADR-004 — Deny rules inject as negated profile rules with last-match-wins evaluation
 
-**Status:** Accepted · 2026-04 · amended 2026-08 by [ORB-10560], [ORB-10573], [ORB-10602] · [T20260416-0728]
+**Status:** Accepted · 2026-04 · amended 2026-08 by [ORB-10560], [ORB-10573], [ORB-10602], [ORB-10607] · [T20260416-0728]
 
 **Context.** A separate "deny pass" before profile evaluation is the obvious shape, but it makes precedence ambiguous when a profile rule and a deny rule both match. Multiple Orbit features (workspace overrides, profile narrowing, denyModify-also-implies-denyRead-for-modify validation) need a single evaluation order.
 
-**Decision.** `effective_profile` appends every entry of `denyRead` to the profile's `read` list as `!<rule>` and walks `denyModify` in order. Ordinary modify entries append as `!<rule>`; a host-policy `!<path>` entry is an explicit exception to an earlier enclosing modify deny and is intersected with the selected profile. Workspace policy may narrow but cannot expand the host exception surface. `check_path` walks the resolved list in order and the **last match wins**. There is no separate deny pass, and task `context_files` are not policy authority — neither for evaluation nor for materialization ([ORB-10602]). On Linux, the exceptions resolved here are also the sole input to mount-anchor materialization; existing targets remain untouched and symlink/type mismatches fail closed.
+**Decision.** `effective_profile` appends every entry of `denyRead` to the profile's `read` list as `!<rule>` and walks `denyModify` in order. Ordinary modify entries append as `!<rule>`; a host-policy `!<path>` entry is an explicit exception to an earlier enclosing modify deny and is intersected with the selected profile. Workspace policy may narrow but cannot expand the host exception surface. `check_path` walks the resolved list in order and the **last match wins**. There is no separate deny pass, and task `context_files` are not policy authority — neither for evaluation nor for materialization ([ORB-10602]). On Linux, only exceptions writable under that final decision are mount-anchor materialization candidates; exact rules denote files, subtree rules denote directories, and symlink/type/containment mismatches fail closed ([ORB-10607], [ADR-0329]).
 
 **Consequences.**
 - Profile rules and deny rules are evaluated in one deterministic pass; appended denies win over earlier positive matches.
@@ -215,7 +215,7 @@ Use `literal` for the canonical and lock files (predictable names) and `regex` f
 - Cost: the implementation is intentionally macOS-location-specific; if Apple moves or removes the binary, Orbit must update the trusted location list or add a new backend rather than silently accepting a user-supplied replacement.
 
 - **ADR-0304 — Use Bubblewrap for shipped Linux CLI write confinement** — Accepted.
-- **ADR-0327 — Derive Linux sandbox write-grant anchors from the effective profile at each spawn** — Proposed · [ORB-10602]. Replaces the hardcoded `(path, kind)` inventory and the `worktree_setup` context-file snapshot: the grant set is read off the same `ResolvedFsProfile` that compiles argv, anchors are materialized per spawn inside the managed worktree, and a grant that cannot be mounted fails or is reported against its path and rule instead of being dropped.
+- **ADR-0329 — Derive Linux sandbox write-grant anchors from the effective profile at each spawn** — Proposed · [ORB-10602], [ORB-10607]. Replaces the hardcoded `(path, kind)` inventory and the `worktree_setup` context-file snapshot: the final last-match-wins grant set is read off the same `ResolvedFsProfile` that compiles argv, rule syntax supplies the anchor type, canonical worktree containment is mandatory, and failed child writes are attributed when EROFS stderr names the attempted path.
 
 ---
 
@@ -237,6 +237,7 @@ Use `literal` for the canonical and lock files (predictable names) and `regex` f
 - **[ORB-10552]** — Implement fail-closed Linux Bubblewrap write confinement and preserve the explicit read-policy limitation.
 - **[ORB-10560]** — Amend global deny resolution with profile-intersected host modify exceptions for versioned `.orbit` configuration.
 - **[ORB-10573]** — Amend Linux delivery with trusted, two-gate preparation of missing versioned-config mount anchors.
-- **[ORB-10602]** — Derive write-grant anchors from the effective profile at each spawn; remove the hardcoded target inventory and the context-file materialization gate. [ADR-0327]
+- **[ORB-10602]** — Derive write-grant anchors from the effective profile at each spawn; remove the hardcoded target inventory and the context-file materialization gate. [ADR-0329]
+- **[ORB-10607]** — Enforce final-policy materialization, canonical/symlink containment, rule-derived anchor types, and production failed-write attribution. [ADR-0329]
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10607](https://orbit-cli.com/tasks/ORB-10607) — Close sandbox write-grant containment and diagnostic gaps left by PR #874

### Description

## Problem

PR #874 implements ORB-10602's policy-derived Linux Bubblewrap write-grant preparation. Daniel is merging that change with four review findings intentionally deferred to a follow-up. The direction should remain, but the merged implementation must not be treated as the final security or diagnostic boundary.

### 1. Ungranted writes still surface as opaque EROFS

`linux_bwrap_write_grant_diagnostic` exists and is tested, but no production path calls it. `spawn_linux_bwrap` only reports grants that policy expressed but Bubblewrap could not mount. A path outside the grant set never becomes a `dropped_grant`, so an attempted write still reaches the child and surfaces as the same unattributable read-only-filesystem error ORB-10602 required removing.

Integrate the diagnostic into the actual failed-invocation outcome. A unit test of the helper is not sufficient: reproduce an attempted ungranted write through the executor boundary and assert that Orbit names the denied path and the missing/shadowing grant.

### 2. Existing anchors can escape through an intermediate symlink

`ensure_write_anchor` returns early when the final target already exists. Its component-by-component symlink validation runs only for an absent target. A path such as `<worktree>/.orbit/resources -> <outside>` can therefore resolve an existing outside target, after which compilation canonicalizes and bind-mounts that outside target writable.

Validate every worktree-owned component before the existing-target return, and prove that the canonical mount anchor remains contained by the canonical managed-worktree root. Preserve fail-closed behavior for both an intermediate symlink and a final symlink.

### 3. Materialization ignores later last-match-wins denies

`linux_bwrap_write_grants` recognizes a positive rule from the denies preceding it, but does not check whether a later rule shadows that re-allow. Workspace policy narrowing is appended after host exceptions, so the preparer can create an anchor that the final effective policy denies.

Derive materialization candidates from the final effective decision, while preserving legitimate partial narrowing beneath an otherwise writable subtree.

### 4. Anchor type still depends on filename shape

An absent exact path with an extension is inferred to be a file; an extensionless path is inferred to be a directory. Dotted directories and extensionless files therefore violate ORB-10602's file-versus-directory acceptance criterion. Replace that heuristic with an explicit or otherwise deterministic type contract derived from policy/grant semantics, without reinstating a hardcoded known-path inventory.

### Decision record gap

PR #874's summary and design index cite proposed ADR-0327, but the PR does not contain a reviewable ADR-0327 artifact while it amends accepted ADR-004. Add the missing proposed ADR bundle and reconcile the design index/accepted-decision wording with its actual lifecycle, or remove the dangling reference and record the decision through the repository's accepted process.

## Evidence

- PR: https://github.com/danieljhkim/orbit/pull/874
- Reviewed head: `cc18ae14d126ea9fd60660531df5310eb56b82e6`
- Parent task: ORB-10602

The Linux sandbox/policy workflow passed on PR #874. Its unrelated Clippy and coverage-timing failures are not part of this task.

## Constraints

- Preserve deny-by-default confinement under `.orbit/**`; do not make the worktree or Orbit directory blanket-writable.
- Do not replace the removed inventory with another hardcoded path table.
- Preserve ADR-0286's separation between worktree-local auto-task definitions and shared-root scheduler/coordination state.
- Read-only linked-worktree Git metadata remains out of scope.


### Acceptance Criteria

- An executor invocation that attempts to write an ungranted path fails with an Orbit-owned diagnostic naming the attempted path and the deny or missing grant; an end-to-end regression proves the production path, not only the diagnostic helper.
- Existing and absent grant anchors are both rejected when any worktree-owned path component is a symlink or when canonical resolution escapes the managed worktree; regression tests cover an existing outside target through an intermediate symlink and the existing absent-target case.
- Only grants writable under the final last-match-wins effective policy are materialized. A later workspace deny prevents materialization, while a narrower deny beneath an otherwise writable subtree does not incorrectly remove the remaining grant.
- Absent exact grants work for both a dotted directory and an extensionless file without filename-extension inference and without a hardcoded known-path inventory; the governing type contract is documented and tested.
- ADR-0327 exists as a reviewable repository artifact with lifecycle-consistent design references, or the dangling ADR-0327 references are removed and the decision is recorded through the accepted repository process.
- The Linux sandbox/policy tests exercise the real Bubblewrap path where available, the affected crates build, and the change's own tests pass; unrelated pre-existing failures are named rather than absorbed.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Integrated Linux Bubblewrap EROFS attribution into the real CLI executor completion path. Failed children that report an attempted path now return an Orbit-owned diagnostic naming that path and either the shadowing denyModify rule or missing grant; the outcome also exposes sandbox_write_diagnostic.
- Hardened policy-derived write grants so candidates must remain writable under the final last-match-wins rule sequence. Later covering denies suppress materialization and dropped-grant failures, while narrower child denies preserve the writable remainder.
- Replaced filename-extension inference with the explicit policy grammar contract: exact rules create file anchors and <root>/** rules create directory anchors. Added extensionless-file and dotted-directory regressions.
- Validated every worktree-owned component before existing or absent anchor handling, rejected intermediate/final symlinks and non-normal components, and required canonical existing anchors/new parents to remain inside the managed worktree.
- Added production-path and focused sandbox regressions, including a real Bubblewrap executor invocation, existing and absent intermediate-symlink escapes, final symlinks, and final-policy materialization behavior.
- Added proposed ADR-0329 through orbit.adr.add and replaced the dangling ADR-0327 design references with the allocator-issued ID; reconciled ADR-004 and the implementation design with the hardened lifecycle-consistent contract.
- Expanded context_files before editing directly affected orchestrator/tests/design files and the allocated ADR-0329 artifact directory.
Assessment: The change closes the reviewed diagnostic, containment, effective-policy, type-contract, and decision-record gaps without broadening .orbit write authority or adding dependency edges.
Validation:
- cargo test -p orbit-exec --test linux_sandbox: 14 passed, including both real Bubblewrap kernel tests.
- cargo test -p orbit-engine --lib: 362 passed, including the real Bubblewrap failed-invocation diagnostic regression.
- cargo fmt --all -- --check: passed.
- make ci-fast: passed.
Deviations from original plan:
- The global allocator issued ADR-0329 rather than the unallocated/dangling ADR-0327 cited by the prior PR; all repository references now use ADR-0329.
- The linux-bwrap executor keeps linked-worktree Git metadata read-only, so the orbit-knowledge-required git add -f of the gitignored proposed ADR bundle could not create the worktree index lock. The ADR is durably recorded through orbit.adr.add, its artifact directory is in task context_files, and F2026-08-049 records the missing host-side force-stage handoff for downstream shipment.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10607-6a77918d`
- Behind base: 0
- Ahead of base: 1