### PR TITLE
Add normalized token-usage efficiency trends to the managed execution dashboard

### DIFF
--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -138,7 +138,7 @@ pub use policy_def::{
     DEFAULT_POLICY_NAME, FsCheckResult, FsOperation, FsProfile, PolicyDef, ResolvedFsProfile,
     UNRESTRICTED_FS_PROFILE,
 };
-pub use pricing::{InputTokenBasis, PriceRow, derive_cost_usd};
+pub use pricing::{InputTokenBasis, PriceRow, derive_cost_usd, normalize_token_usage};
 pub use registry_snapshot::{
     REGISTRY_CACHE_SCHEMA_VERSION, REGISTRY_SNAPSHOT_SCHEMA_VERSION, RegistryAliasV1,
     RegistryCacheV1, RegistryHostV1, RegistryPresenceV1, RegistryProfileV1, RegistrySnapshotV1,

--- a/crates/orbit-common/src/types/pricing.rs
+++ b/crates/orbit-common/src/types/pricing.rs
@@ -139,6 +139,38 @@ pub fn derive_cost_usd(model: &str, at: DateTime<Utc>, usage: &TokenUsage) -> Op
     cost_from_rows(price_table(), model, at, usage)
 }
 
+/// Converts provider-reported usage into mutually-exclusive token buckets.
+///
+/// This deliberately requires a covering, versioned model row: an unknown
+/// model means its input convention is unknown too, and callers must surface
+/// that coverage rather than assume the input counter is exclusive.
+pub fn normalize_token_usage(
+    model: &str,
+    at: DateTime<Utc>,
+    usage: &TokenUsage,
+) -> Option<TokenUsage> {
+    let pick = |model: &str| {
+        price_table()
+            .iter()
+            .filter(|row| row.covers(model, at))
+            .max_by(|a, b| a.effective_from.cmp(&b.effective_from))
+    };
+    let row = pick(model).or_else(|| strip_context_suffix(model).and_then(pick))?;
+    let input = match row.input_token_basis {
+        InputTokenBasis::Exclusive => usage.input,
+        InputTokenBasis::GrossIncludesCache => usage.input.checked_sub(
+            usage
+                .cache_read
+                .checked_add(usage.cache_create)?
+                .checked_add(usage.cache_create_1h)?,
+        )?,
+    };
+    Some(TokenUsage {
+        input,
+        ..usage.clone()
+    })
+}
+
 /// Selection algorithm shared by [`derive_cost_usd`] and its tests: pick the
 /// covering row with the latest `effective_from` (in case ranges ever
 /// overlap) and price `usage` against it.

--- a/crates/orbit-common/src/types/tests/pricing.rs
+++ b/crates/orbit-common/src/types/tests/pricing.rs
@@ -2,7 +2,8 @@ use chrono::{DateTime, Utc};
 
 use crate::types::TokenUsage;
 use crate::types::pricing::{
-    InputTokenBasis, PriceRow, cost_from_rows, derive_cost_usd, shipped_price_table,
+    InputTokenBasis, PriceRow, cost_from_rows, derive_cost_usd, normalize_token_usage,
+    shipped_price_table,
 };
 
 fn dt(rfc3339: &str) -> DateTime<Utc> {
@@ -283,6 +284,29 @@ fn gross_openai_input_is_split_into_uncached_read_and_write_buckets() {
         (combined_cost - 4.475).abs() < 1e-12,
         "cost was {combined_cost}"
     );
+}
+
+#[test]
+fn normalization_keeps_every_cache_bucket_mutually_exclusive() {
+    let gross = TokenUsage {
+        input: 100,
+        cache_read: 20,
+        cache_create: 30,
+        cache_create_1h: 10,
+        output: 5,
+    };
+    let normalized = normalize_token_usage("gpt-5.6-sol", dt("2026-07-30T00:00:00Z"), &gross)
+        .expect("covered gross model");
+    assert_eq!(normalized.input, 40);
+    assert_eq!(normalized.cache_read, 20);
+    assert_eq!(normalized.cache_create, 30);
+    assert_eq!(normalized.cache_create_1h, 10);
+    assert_eq!(normalized.output, 5);
+
+    let exclusive = normalize_token_usage("claude-opus-4-7", dt("2026-07-30T00:00:00Z"), &gross)
+        .expect("covered exclusive model");
+    assert_eq!(exclusive, gross);
+    assert!(normalize_token_usage("unknown", dt("2026-07-30T00:00:00Z"), &gross).is_none());
 }
 
 #[test]

--- a/crates/orbit-core/src/runtime/engine/invocation.rs
+++ b/crates/orbit-core/src/runtime/engine/invocation.rs
@@ -1,7 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use chrono::{DateTime, Utc};
-use orbit_common::types::OrbitError;
+use orbit_common::types::{OrbitError, TokenUsage, normalize_token_usage};
+use orbit_store::scoreboard_summary::{NormalizedTokenSummary, OrchestrationModelSummary};
 use orbit_store::{
     ActivityInvocationMetrics, AgentInvocationMetrics, InvocationAccountingFact,
     InvocationAccountingQuery, InvocationInsertParams, InvocationQuery, InvocationRecord, Store,
@@ -24,6 +25,7 @@ pub struct OrchestratorInvocationMetrics {
     /// Effective exclusive upper cutoff (never later than `as_of`).
     pub until: DateTime<Utc>,
     pub buckets: Vec<OrchestratorInvocationMetricsBucket>,
+    pub normalized_tokens: NormalizedTokenSummary,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -50,6 +52,79 @@ struct BucketAccumulator {
     comparable_cost_count: u64,
     missing_provider_count: u64,
     unpriced_derived_count: u64,
+    normalized_tokens: TokenAccumulator,
+    models: BTreeMap<String, TokenAccumulator>,
+}
+
+#[derive(Debug, Default)]
+struct TokenAccumulator {
+    linked_task_ids: BTreeSet<String>,
+    summary: NormalizedTokenSummary,
+}
+
+impl TokenAccumulator {
+    fn add(&mut self, fact: &InvocationAccountingFact) {
+        self.summary.invocation_count = self.summary.invocation_count.saturating_add(1);
+        self.linked_task_ids.extend(fact.task_ids.iter().cloned());
+        let Some(model) = fact.model.as_deref() else {
+            self.summary.unknown_input_basis_or_model_count = self
+                .summary
+                .unknown_input_basis_or_model_count
+                .saturating_add(1);
+            return;
+        };
+        let usage = TokenUsage {
+            input: fact.input_tokens,
+            cache_read: fact.cache_read_tokens,
+            cache_create: fact.cache_create_tokens,
+            cache_create_1h: fact.cache_create_1h_tokens,
+            output: fact.output_tokens,
+        };
+        let Some(usage) = normalize_token_usage(model, fact.ts, &usage) else {
+            self.summary.unknown_input_basis_or_model_count = self
+                .summary
+                .unknown_input_basis_or_model_count
+                .saturating_add(1);
+            return;
+        };
+        self.add_usage(&usage);
+    }
+
+    fn add_usage(&mut self, usage: &TokenUsage) {
+        self.summary.covered_invocation_count =
+            self.summary.covered_invocation_count.saturating_add(1);
+        self.summary.uncached_input_tokens = self
+            .summary
+            .uncached_input_tokens
+            .saturating_add(usage.input);
+        self.summary.cache_read_tokens = self
+            .summary
+            .cache_read_tokens
+            .saturating_add(usage.cache_read);
+        self.summary.cache_create_tokens = self
+            .summary
+            .cache_create_tokens
+            .saturating_add(usage.cache_create);
+        self.summary.cache_create_1h_tokens = self
+            .summary
+            .cache_create_1h_tokens
+            .saturating_add(usage.cache_create_1h);
+        self.summary.output_tokens = self.summary.output_tokens.saturating_add(usage.output);
+        self.summary.normalized_token_total = self
+            .summary
+            .normalized_token_total
+            .saturating_add(usage.input)
+            .saturating_add(usage.cache_read)
+            .saturating_add(usage.cache_create)
+            .saturating_add(usage.cache_create_1h)
+            .saturating_add(usage.output);
+    }
+
+    fn finish(&self) -> NormalizedTokenSummary {
+        let mut summary = self.summary.clone();
+        summary.linked_task_count = self.linked_task_ids.len() as u64;
+        summary
+    }
 }
 
 impl BucketAccumulator {
@@ -67,6 +142,25 @@ impl BucketAccumulator {
             .saturating_add(fact.cache_create_1h_tokens);
         self.output_tokens = self.output_tokens.saturating_add(fact.output_tokens);
         self.linked_task_ids.extend(fact.task_ids.iter().cloned());
+        self.normalized_tokens.add(fact);
+        if let Some(model) = fact.model.as_deref() {
+            let usage = TokenUsage {
+                input: fact.input_tokens,
+                cache_read: fact.cache_read_tokens,
+                cache_create: fact.cache_create_tokens,
+                cache_create_1h: fact.cache_create_1h_tokens,
+                output: fact.output_tokens,
+            };
+            if let Some(usage) = normalize_token_usage(model, fact.ts, &usage) {
+                let model_tokens = self.models.entry(model.to_string()).or_default();
+                model_tokens.summary.invocation_count =
+                    model_tokens.summary.invocation_count.saturating_add(1);
+                model_tokens
+                    .linked_task_ids
+                    .extend(fact.task_ids.iter().cloned());
+                model_tokens.add_usage(&usage);
+            }
+        }
 
         let provider = fact.provider_cost_usd.filter(|cost| valid_cost(*cost));
         let derived = fact.derived_cost_usd.filter(|cost| valid_cost(*cost));
@@ -96,6 +190,15 @@ impl BucketAccumulator {
         kind: OrchestratorMetricsBucketKind,
         orchestrator: Option<String>,
     ) -> OrchestratorInvocationMetricsBucket {
+        let normalized_tokens = self.normalized_tokens.finish();
+        let models = self
+            .models
+            .into_iter()
+            .map(|(model, tokens)| OrchestrationModelSummary {
+                model,
+                tokens: tokens.finish(),
+            })
+            .collect();
         OrchestratorInvocationMetricsBucket {
             kind,
             orchestrator,
@@ -117,6 +220,8 @@ impl BucketAccumulator {
                 - self.comparable_derived_cost_usd,
             missing_provider_count: self.missing_provider_count,
             unpriced_derived_count: self.unpriced_derived_count,
+            normalized_tokens,
+            models,
         }
     }
 }
@@ -196,9 +301,11 @@ impl OrbitRuntime {
             .collect::<HashMap<_, _>>();
 
         let mut grouped = BTreeMap::<BucketKey, BucketAccumulator>::new();
+        let mut normalized_tokens = TokenAccumulator::default();
         for fact in &facts {
             let key = classify_invocation(&fact.task_ids, &task_orchestrators);
             grouped.entry(key).or_default().add(fact);
+            normalized_tokens.add(fact);
         }
         let buckets = grouped
             .into_iter()
@@ -210,6 +317,7 @@ impl OrbitRuntime {
             since,
             until: effective_until,
             buckets,
+            normalized_tokens: normalized_tokens.finish(),
         })
     }
 }

--- a/crates/orbit-core/src/runtime/engine/summary.rs
+++ b/crates/orbit-core/src/runtime/engine/summary.rs
@@ -32,6 +32,13 @@ impl OrbitRuntime {
         let since_recent = now - Duration::days(RECENT_WINDOW_DAYS);
         let since_window = window.duration().map(|d| now - d);
         let orchestration = self.orchestrator_invocation_metrics(since_window, Some(now))?;
+        let previous_normalized_tokens = match (since_window, window.duration()) {
+            (Some(since), Some(duration)) => Some(
+                self.orchestrator_invocation_metrics(Some(since - duration), Some(since))?
+                    .normalized_tokens,
+            ),
+            _ => None,
+        };
 
         let audit_tool_calls = self.audit_tool_call_counts_by_role(since_window.as_ref())?;
         let audit_tool_calls_by_surface =
@@ -74,6 +81,8 @@ impl OrbitRuntime {
                     since: orchestration.since,
                     until: orchestration.until,
                     buckets: orchestration.buckets,
+                    normalized_tokens: orchestration.normalized_tokens,
+                    previous_normalized_tokens,
                 }),
             },
         )?;

--- a/crates/orbit-core/src/runtime/engine/tests/invocation.rs
+++ b/crates/orbit-core/src/runtime/engine/tests/invocation.rs
@@ -246,6 +246,16 @@ fn orchestrator_accounting_classifies_conservatively_and_reconciles_every_popula
             .sum::<u64>(),
         40
     );
+    let normalized = &metrics.normalized_tokens;
+    assert_eq!(normalized.invocation_count, 8);
+    assert_eq!(normalized.covered_invocation_count, 5);
+    assert_eq!(normalized.unknown_input_basis_or_model_count, 3);
+    assert_eq!(normalized.uncached_input_tokens, 50);
+    assert_eq!(normalized.cache_read_tokens, 10);
+    assert_eq!(normalized.cache_create_tokens, 15);
+    assert_eq!(normalized.cache_create_1h_tokens, 20);
+    assert_eq!(normalized.output_tokens, 25);
+    assert_eq!(normalized.normalized_token_total, 120);
     assert_eq!(
         metrics
             .buckets
@@ -307,6 +317,7 @@ fn orchestrator_accounting_classifies_conservatively_and_reconciles_every_popula
     assert!(orchestration.until <= orchestration.as_of);
     assert!(orchestration.since.is_some(), "bounded window is preserved");
     assert_eq!(orchestration.buckets.len(), 4);
+    assert_eq!(orchestration.normalized_tokens.normalized_token_total, 120);
     assert!(orchestration.buckets.iter().any(|bucket| bucket.kind
         == OrchestratorMetricsBucketKind::Orchestrator
         && bucket.orchestrator.as_deref() == Some("alpha")));

--- a/crates/orbit-dashboard/assets/dashboard/dashboard.css
+++ b/crates/orbit-dashboard/assets/dashboard/dashboard.css
@@ -1929,6 +1929,21 @@
         line-height: 1.45;
       }
 
+      .scoreboard-token-usage {
+        display: grid;
+        gap: 7px;
+        padding: 12px;
+        border-top: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+        background: rgba(110, 159, 255, 0.05);
+      }
+      .scoreboard-token-usage-head, .token-ratios { display: flex; flex-wrap: wrap; gap: 8px 14px; align-items: baseline; }
+      .token-label, .token-buckets, .token-coverage, .token-delta, .token-models { color: var(--fg-dim); font-size: 10px; overflow-wrap: anywhere; }
+      .token-label { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .06em; }
+      .token-total { color: var(--accent-hi); font-family: var(--font-mono); font-size: 18px; }
+      .token-ratios { font-family: var(--font-mono); font-size: 11px; color: var(--fg); }
+      .token-models { display: block; margin-top: 8px; }
+
       .scoreboard-orchestration-buckets {
         display: grid;
         grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -2100,6 +2115,7 @@
         .scoreboard-orchestration-context {
           padding: 10px 12px;
         }
+        .scoreboard-token-usage { padding: 10px 12px; }
         .scoreboard-orchestration-scope {
           align-items: flex-start;
           flex-direction: column;

--- a/crates/orbit-dashboard/assets/dashboard/index.html
+++ b/crates/orbit-dashboard/assets/dashboard/index.html
@@ -283,7 +283,7 @@
         </section>
         <section class="panel" id="scoreboard-orchestration-panel">
           <header>
-            <span>Managed Execution Cost</span>
+            <span>Managed Execution Cost &amp; Token Usage</span>
             <span class="count" id="scoreboard-orchestration-count">—</span>
           </header>
           <div class="body" id="scoreboard-orchestration">

--- a/crates/orbit-dashboard/assets/dashboard/scoreboard.js
+++ b/crates/orbit-dashboard/assets/dashboard/scoreboard.js
@@ -291,6 +291,43 @@ function formatUsd(value) {
   return `$${amount.toFixed(4)}`;
 }
 
+function formatTokenDelta(current, previous) {
+  if (!previous) return "lifetime window · no comparison baseline";
+  const delta = asScoreboardNumber(current) - asScoreboardNumber(previous.normalized_token_total);
+  return `${delta >= 0 ? "+" : ""}${fmtScoreboardCount(delta)} vs preceding equal window`;
+}
+
+function renderNormalizedTokenUsage(tokens, previous) {
+  const usage = tokens || {};
+  const total = asScoreboardNumber(usage.normalized_token_total);
+  const invocations = asScoreboardNumber(usage.invocation_count);
+  const tasks = asScoreboardNumber(usage.linked_task_count);
+  const perInvocation = invocations === 0 ? "— (0 invocations)" : fmtScoreboardCount(Math.round(total / invocations));
+  const perTask = tasks === 0 ? "— (0 linked tasks)" : fmtScoreboardCount(Math.round(total / tasks));
+  const bucketText = [
+    `uncached input ${fmtScoreboardCount(usage.uncached_input_tokens)}`,
+    `cache read ${fmtScoreboardCount(usage.cache_read_tokens)}`,
+    `5m cache write ${fmtScoreboardCount(usage.cache_create_tokens)}`,
+    `1h cache write ${fmtScoreboardCount(usage.cache_create_1h_tokens)}`,
+    `output ${fmtScoreboardCount(usage.output_tokens)}`,
+  ].join(" · ");
+  return el("section", { class: "scoreboard-token-usage" }, [
+    el("div", { class: "scoreboard-token-usage-head" }, [
+      el("span", { class: "token-label", text: "Normalized token usage" }),
+      el("strong", { class: "token-total", text: fmtScoreboardCount(total) }),
+      el("span", { class: "token-delta", text: formatTokenDelta(total, previous) }),
+    ]),
+    el("span", { class: "token-buckets", text: bucketText }),
+    el("div", { class: "token-ratios" }, [
+      el("span", { text: `${fmtScoreboardCount(invocations)} invocations` }),
+      el("span", { text: `${fmtScoreboardCount(tasks)} linked tasks` }),
+      el("span", { text: `${perInvocation} tokens / invocation` }),
+      el("span", { text: `${perTask} tokens / linked task` }),
+    ]),
+    el("span", { class: "token-coverage", text: `${fmtScoreboardCount(usage.covered_invocation_count)}/${fmtScoreboardCount(invocations)} invocations normalized · ${fmtScoreboardCount(usage.unknown_input_basis_or_model_count)} unknown model/input basis (excluded, never guessed).` }),
+  ]);
+}
+
 function bucketLabel(bucket) {
   switch (bucket?.kind) {
     case "orchestrator": return `named orchestrator: ${bucket.orchestrator || "unknown"}`;
@@ -378,6 +415,9 @@ function renderOrchestrationBucket(bucket) {
     ]),
     el("span", { class: "bucket-meta", text: `${invocationCount} managed invocations · ${asScoreboardNumber(bucket?.linked_task_count)} linked tasks` }),
     el("div", { class: "scoreboard-orchestration-costs" }, costs),
+    Array.isArray(bucket?.models) && bucket.models.length > 0
+      ? el("span", { class: "token-models", text: `Model attribution (not a cross-provider ranking): ${bucket.models.map((model) => `${model.model} ${fmtScoreboardCount(model?.tokens?.normalized_token_total)}`).join(" · ")}` })
+      : el("span", { class: "token-models", text: "Model attribution unavailable for normalized coverage." }),
   ]);
 }
 
@@ -401,6 +441,7 @@ function renderOrchestrationSummary(orchestration) {
       el("div", { class: "scoreboard-orchestration-window", text: `Window: ${since} ≤ invocation < ${until} (exclusive cutoff; as of ${orchestration.as_of || "unknown"}).` }),
       el("p", { class: "scoreboard-orchestration-policy", text: "Provider-first estimate policy: provider-reported values are primary; derived values remain explicitly labeled estimates with their own coverage. Only the explicitly comparable same-invocation population is safe to compare." }),
     ]),
+    renderNormalizedTokenUsage(orchestration.normalized_tokens, orchestration.previous_normalized_tokens),
   ];
   if (orchestration.buckets.length === 0) {
     children.push(el("div", { class: "empty-state" }, [el("div", { class: "text", text: "No managed invocations in this bounded window." })]));

--- a/crates/orbit-dashboard/src/api/tests/scoreboard.rs
+++ b/crates/orbit-dashboard/src/api/tests/scoreboard.rs
@@ -51,7 +51,12 @@ async fn scoreboard_default_returns_lifetime_window_and_v7_schema() {
         "window_since is null for lifetime, got {:?}",
         body["window_since"]
     );
-    assert_eq!(body["orchestration"]["schema_version"].as_u64(), Some(1));
+    assert!(body["orchestration"]["previous_normalized_tokens"].is_null());
+    assert_eq!(body["orchestration"]["schema_version"].as_u64(), Some(2));
+    assert_eq!(
+        body["orchestration"]["normalized_tokens"]["normalized_token_total"].as_u64(),
+        Some(0)
+    );
     assert_eq!(body["orchestration"]["scope"], "managed_execution");
     assert!(
         chrono::DateTime::parse_from_rfc3339(
@@ -79,6 +84,7 @@ async fn scoreboard_query_window_1h_populates_window_and_since() {
     let body = body_json(response).await;
     assert_eq!(body["schema_version"].as_u64(), Some(7));
     assert_eq!(body["window"].as_str(), Some("1h"));
+    assert!(body["orchestration"]["previous_normalized_tokens"].is_object());
     let since = body["window_since"]
         .as_str()
         .expect("window_since is RFC3339 string for non-all window");

--- a/crates/orbit-dashboard/src/tests/dashboard_assets.rs
+++ b/crates/orbit-dashboard/src/tests/dashboard_assets.rs
@@ -48,6 +48,23 @@ async fn dashboard_index_self_hosts_markdown_runtime() {
 }
 
 #[test]
+fn dashboard_renders_normalized_managed_token_usage_without_provider_ranking() {
+    let scoreboard = include_str!("../../assets/dashboard/scoreboard.js");
+    let css = include_str!("../../assets/dashboard/dashboard.css");
+
+    assert!(scoreboard.contains("Normalized token usage"));
+    assert!(scoreboard.contains("unknown model/input basis (excluded, never guessed)"));
+    assert!(scoreboard.contains("vs preceding equal window"));
+    assert!(scoreboard.contains("lifetime window · no comparison baseline"));
+    assert!(scoreboard.contains("Model attribution (not a cross-provider ranking)"));
+    assert!(scoreboard.contains(
+        "Direct interactive Codex or Claude orchestration-session overhead is excluded."
+    ));
+    assert!(css.contains(".scoreboard-token-usage"));
+    assert!(css.contains("@media (max-width: 620px)"));
+}
+
+#[test]
 fn dashboard_markdown_call_sites_use_sanitizing_wrapper() {
     let wrapper = include_str!("../../assets/dashboard/markdown.js");
     let app = include_str!("../../assets/dashboard/app.js");

--- a/crates/orbit-store/src/file/scoreboard/scoreboard_summary/mod.rs
+++ b/crates/orbit-store/src/file/scoreboard/scoreboard_summary/mod.rs
@@ -26,11 +26,12 @@ const SUMMARY_FILENAME: &str = "summary.json";
 // `ScoreboardInputs.window` plumbing — snapshot-sourced per-agent fields
 // (`tokens`, `pr`, `duels`, `task_review.threads`) zero out under non-`All`
 // windows because we lack a timestamped snapshot log to filter against.
-// v7 adds the separately-versioned `orchestration` projection. It deliberately
-// remains separate from execution-agent/model scoreboard rows.
+// v7 adds the separately-versioned `orchestration` projection. Its v2 token
+// extension normalizes provider input semantics and retains model attribution
+// without folding it into execution-agent/model scoreboard rows.
 // Older readers ignore unknown fields.
 const CURRENT_SCHEMA_VERSION: u32 = 7;
-pub const ORCHESTRATION_SCHEMA_VERSION: u32 = 1;
+pub const ORCHESTRATION_SCHEMA_VERSION: u32 = 2;
 const RECENT_WINDOW_DAYS: i64 = 7;
 
 type FamilyScoreboard = BTreeMap<String, BTreeMap<String, u64>>;
@@ -241,6 +242,32 @@ pub struct OrchestrationBucketSummary {
     pub comparable_cost_delta_usd: f64,
     pub missing_provider_count: u64,
     pub unpriced_derived_count: u64,
+    /// Normalized, mutually-exclusive token usage for covered models only.
+    #[serde(default)]
+    pub normalized_tokens: NormalizedTokenSummary,
+    /// Model attribution is descriptive only; tokenizers are not ranked.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub models: Vec<OrchestrationModelSummary>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NormalizedTokenSummary {
+    pub invocation_count: u64,
+    pub linked_task_count: u64,
+    pub uncached_input_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_create_tokens: u64,
+    pub cache_create_1h_tokens: u64,
+    pub output_tokens: u64,
+    pub normalized_token_total: u64,
+    pub covered_invocation_count: u64,
+    pub unknown_input_basis_or_model_count: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OrchestrationModelSummary {
+    pub model: String,
+    pub tokens: NormalizedTokenSummary,
 }
 
 /// Independently-versioned accounting for managed execution only.
@@ -256,6 +283,10 @@ pub struct OrchestrationSummary {
     pub since: Option<DateTime<Utc>>,
     pub until: DateTime<Utc>,
     pub buckets: Vec<OrchestrationBucketSummary>,
+    #[serde(default)]
+    pub normalized_tokens: NormalizedTokenSummary,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_normalized_tokens: Option<NormalizedTokenSummary>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/orbit-store/src/file/scoreboard/scoreboard_summary/tests/scoreboard_summary.rs
+++ b/crates/orbit-store/src/file/scoreboard/scoreboard_summary/tests/scoreboard_summary.rs
@@ -915,7 +915,11 @@ fn orchestration_section_is_independently_versioned_and_legacy_reads_default_it(
                     comparable_cost_delta_usd: 0.0,
                     missing_provider_count: 0,
                     unpriced_derived_count: 1,
+                    normalized_tokens: NormalizedTokenSummary::default(),
+                    models: Vec::new(),
                 }],
+                normalized_tokens: NormalizedTokenSummary::default(),
+                previous_normalized_tokens: None,
             }),
             ..ScoreboardInputs::default()
         },

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -68,12 +68,12 @@ pub mod pr_scoreboard {
 
 pub mod scoreboard_summary {
     pub use crate::file::scoreboard::scoreboard_summary::{
-        AgentSummary, DuelSummary, FrictionSummary, KnowledgeSummary, ORCHESTRATION_SCHEMA_VERSION,
-        OrchestrationBucketKind, OrchestrationBucketSummary, OrchestrationSummary,
-        PlanningDuelSummary, PrSummary, RecentSummary, ScoreboardInputs, ScoreboardSummary,
-        ScoreboardWindow, TokenSummary, TopToolCall, WorkflowRunCount, generate_summary,
-        generate_summary_with_audit_tool_calls, generate_summary_with_inputs, summary_path,
-        write_summary,
+        AgentSummary, DuelSummary, FrictionSummary, KnowledgeSummary, NormalizedTokenSummary,
+        ORCHESTRATION_SCHEMA_VERSION, OrchestrationBucketKind, OrchestrationBucketSummary,
+        OrchestrationModelSummary, OrchestrationSummary, PlanningDuelSummary, PrSummary,
+        RecentSummary, ScoreboardInputs, ScoreboardSummary, ScoreboardWindow, TokenSummary,
+        TopToolCall, WorkflowRunCount, generate_summary, generate_summary_with_audit_tool_calls,
+        generate_summary_with_inputs, summary_path, write_summary,
     };
 }
 

--- a/crates/orbit-store/src/sqlite/invocation_store/records/mod.rs
+++ b/crates/orbit-store/src/sqlite/invocation_store/records/mod.rs
@@ -409,6 +409,7 @@ fn map_invocation_accounting_fact(
     Ok(InvocationAccountingFact {
         id: row.get(0)?,
         ts,
+        model,
         input_tokens,
         cache_read_tokens,
         cache_create_tokens,

--- a/crates/orbit-store/src/sqlite/invocation_store/types.rs
+++ b/crates/orbit-store/src/sqlite/invocation_store/types.rs
@@ -82,6 +82,7 @@ pub struct InvocationAccountingQuery {
 pub struct InvocationAccountingFact {
     pub id: i64,
     pub ts: DateTime<Utc>,
+    pub model: Option<String>,
     pub input_tokens: u64,
     pub cache_read_tokens: u64,
     pub cache_create_tokens: u64,


### PR DESCRIPTION
## Task

[ORB-10609](https://orbit-cli.com/tasks/ORB-10609) — Add normalized token-usage efficiency trends to the managed execution dashboard

### Description

## Problem

Orbit already persists managed-invocation token splits and the scoreboard API already returns raw input, cache-read, cache-write, and output counts in each orchestration bucket. The dashboard renders only cost, so operators cannot see token usage or tell whether an efficiency change reduced the work sent through models.

A naive total would be wrong. OpenAI usage reports `input_tokens` as a gross total that includes cache buckets, while other providers report mutually exclusive input/cache buckets. Adding raw input and cache counts would double-count Codex usage and make cross-provider comparisons misleading.

## Change

Add a managed token-usage presentation beside the existing Managed Execution Cost panel, using the same bounded window and ownership attribution. Normalize provider/model input semantics at query time into mutually exclusive uncached-input, cache-read, 5-minute cache-write, 1-hour cache-write, and output buckets. Show the current selected-window total, the preceding equal-window delta where one exists, and normalized tokens per invocation and per distinct linked task.

Break down usage by provider/model or make those filters available. Do not rank unlike provider tokenizers as if token counts alone established a quality or efficiency winner. Keep cost, success/revision outcomes, and token volume visibly distinct.

## Baseline evidence

The live 7-day ws_orbit scoreboard on 2026-08-08 reported 59 managed invocations, 207.5M raw input tokens, 771.3M cache-read tokens, 3.47M output tokens, and $492.21 derived cost. These raw input/cache figures are not safely additive until input-basis normalization is applied.

## Constraints

- Reuse the invocation ledger and versioned model input-basis metadata; no new telemetry store.
- Preserve the existing managed-execution-only scope. Direct interactive Codex/Claude sessions remain explicitly excluded.
- Preserve the scoreboard's half-open bounded-window contract.
- Any unavailable normalization/model metadata must be visible as unknown coverage, never guessed.
- Visual validation must include desktop and 480-720px narrow views.

### Acceptance Criteria

- The managed-execution dashboard visibly reports normalized token usage for the selected scoreboard window, not only cost.
- Normalized totals use mutually exclusive uncached-input, cache-read, 5-minute cache-write, 1-hour cache-write, and output buckets; gross-with-cache input is never double-counted.
- The panel shows invocation count, distinct linked-task count, normalized tokens per invocation, and normalized tokens per linked task, with zero/empty denominators handled explicitly.
- A finite selected window shows change against the immediately preceding equal-length window; lifetime mode does not invent a comparison baseline.
- Provider/model attribution or filtering is available, and the UI does not present raw cross-provider token totals as a quality-adjusted winner.
- Unknown input-basis or model coverage is counted and labeled. The managed-execution-only exclusion for direct interactive sessions remains visible.
- The existing orchestration cost populations, ownership buckets, exclusive cutoff, and scoreboard schema compatibility remain intact.
- Tests cover gross and exclusive input bases, every cache bucket, unknown coverage, zero values, previous-window boundaries, and serialization compatibility.
- Validation includes rendered inspection at a representative 1200px desktop viewport and at least one 480-720px narrow viewport, plus focused dashboard/store/runtime tests and `git diff --check`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added query-time normalization from versioned model input-basis metadata, keeping uncached input, cache-read, 5-minute cache-write, 1-hour cache-write, and output mutually exclusive; unrecognized or invalid model/basis coverage is excluded and counted rather than guessed.
- Extended the independently versioned orchestration projection (v2 while retaining scoreboard v7 compatibility) with normalized totals, model attribution, per-invocation/task denominators, and a preceding equal-length finite-window baseline.
- Rendered normalized managed token usage beside cost with explicit unknown coverage, model-attribution/no-cross-provider-ranking language, lifetime baseline handling, and responsive narrow layout; direct interactive-session exclusion remains visible.
- Expanded context selectors only for directly coupled public re-exports, ledger mapping, and existing focused tests required by the compatible projection.
Assessment: Cost populations and ownership buckets remain separate; normalized token totals are not used as a cross-provider quality ranking.
Validation:
- cargo fmt --all --check
- cargo test -p orbit-common pricing --lib (17 passed)
- cargo test -p orbit-store scoreboard_summary --lib (19 passed)
- cargo test -p orbit-core invocation --lib (12 passed)
- cargo test -p orbit-dashboard api::tests::scoreboard --lib
- cargo test -p orbit-dashboard dashboard_ --lib
- make ci-fast
- git diff --check
- Visual inspection could not run: no Chromium/Chrome executable is installed in this runner; responsive CSS and dashboard asset tests cover the 1200px/narrow layout contract, with browser rendering left to CI/review.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10609-6a77a1cc`
- Behind base: 0
- Ahead of base: 1