### PR TITLE
Run step-failure recovery on the provider lane's middleweight crew

### DIFF
--- a/.orbit/resources/activities/step_failure_recovery.yaml
+++ b/.orbit/resources/activities/step_failure_recovery.yaml
@@ -201,6 +201,9 @@ spec:
     - orbit
     - rg
   on_denial: terminate
+  # The reviewer role remains a prompt and telemetry label. The executor
+  # resolves this named recovery activity through the failed run's durable
+  # provider lane: Codex -> terra and Claude -> sonnet.
   role: reviewer
   # One hour accommodates provider startup plus networked git/PR operations
   # and a resumed pipeline while retaining a hard terminal bound. This bound is

--- a/crates/orbit-core/assets/activities/step_failure_recovery.yaml
+++ b/crates/orbit-core/assets/activities/step_failure_recovery.yaml
@@ -201,6 +201,9 @@ spec:
     - orbit
     - rg
   on_denial: terminate
+  # The reviewer role remains a prompt and telemetry label. The executor
+  # resolves this named recovery activity through the failed run's durable
+  # provider lane: Codex -> terra and Claude -> sonnet.
   role: reviewer
   # One hour accommodates provider startup plus networked git/PR operations
   # and a resumed pipeline while retaining a hard terminal bound. This bound is

--- a/crates/orbit-core/src/command/job/tests/catalog.rs
+++ b/crates/orbit-core/src/command/job/tests/catalog.rs
@@ -189,6 +189,29 @@ fn default_activity_catalog() -> V2ActivityCatalog {
     catalog
 }
 
+#[test]
+fn seeded_step_failure_recovery_asset_stays_aligned_and_keeps_its_reviewer_label() {
+    let seeded = DEFAULT_ACTIVITY_FILES
+        .iter()
+        .find_map(|(name, yaml)| (*name == "step_failure_recovery").then_some(*yaml))
+        .expect("seeded step failure recovery activity");
+    assert_eq!(
+        seeded,
+        include_str!("../../../../../../.orbit/resources/activities/step_failure_recovery.yaml"),
+        "dogfood and seeded recovery activity assets must remain behaviorally aligned"
+    );
+
+    let asset = load_activity_asset(seeded).expect("parse recovery activity");
+    let ActivityV2Spec::AgentLoop(spec) = asset.spec.spec else {
+        panic!("step_failure_recovery must remain an agent loop");
+    };
+    assert_eq!(
+        spec.role,
+        Some(orbit_common::types::activity_job::AgentRole::Reviewer),
+        "recovery retains its prompt/telemetry reviewer role while executor routing selects the middleweight crew"
+    );
+}
+
 fn assert_condition_tokens_are_paths(condition: &str) {
     let mut remaining = condition;
     while let Some(start) = remaining.find("{{") {

--- a/crates/orbit-core/src/runtime/v2_host/mod.rs
+++ b/crates/orbit-core/src/runtime/v2_host/mod.rs
@@ -26,10 +26,10 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
-use orbit_common::types::activity_job::AgentRole;
+use orbit_common::types::activity_job::{AgentRole, Backend, Provider};
 use orbit_common::types::{
     InvocationTrace, LearningInjectionCaps, LearningInjectionState, LearningReminder, RoleSlot,
-    UNRESTRICTED_FS_PROFILE,
+    UNRESTRICTED_FS_PROFILE, resolve_crew,
 };
 use orbit_engine::{AgentRoleConfig, EnvironmentHost};
 use orbit_engine::{DispatchError, ResolvedCliExecutor, ResolvedSandbox, V2RuntimeHost};
@@ -295,6 +295,78 @@ impl V2RuntimeHost for OrbitRuntime {
                 role, assignment,
             ),
         )
+    }
+
+    fn recovery_agent_crew_config(&self, run_id: &str) -> Result<AgentRoleConfig, DispatchError> {
+        let run = self.get_job_run_backend(run_id).map_err(|error| {
+            DispatchError::JobExecution(format!(
+                "read persisted provider lane for step_failure_recovery run `{run_id}`: {error}"
+            ))
+        })?
+        .ok_or_else(|| {
+            DispatchError::JobValidation(format!(
+                "step_failure_recovery requires a persisted provider lane for run `{run_id}`; no run record was found"
+            ))
+        })?;
+
+        let source_crew_name = run
+            .resolved_crew
+            .as_deref()
+            .map(str::trim)
+            .filter(|crew| !crew.is_empty())
+            .ok_or_else(|| {
+                DispatchError::JobValidation(format!(
+                    "step_failure_recovery requires a persisted resolved crew for run `{run_id}`; no provider lane is available"
+                ))
+            })?;
+        let source_crew = resolve_crew(source_crew_name, self.context.settings().crews()).map_err(
+            |error| {
+                DispatchError::JobValidation(format!(
+                    "step_failure_recovery cannot resolve persisted crew `{source_crew_name}` for run `{run_id}`: {error}; refusing to select a provider from ambient CLI availability"
+                ))
+            },
+        )?;
+        let provider = Provider::parse(&source_crew.assignment.provider).map_err(|error| {
+            DispatchError::JobValidation(format!(
+                "step_failure_recovery cannot determine the persisted provider lane from crew `{source_crew_name}` for run `{run_id}`: {error}"
+            ))
+        })?;
+        let required_crew = match provider {
+            Provider::Codex => "terra",
+            Provider::Claude => "sonnet",
+            other => {
+                return Err(DispatchError::JobValidation(format!(
+                    "step_failure_recovery has no configured middleweight crew for persisted provider `{}` on run `{run_id}`; required crew mapping is codex -> terra or claude -> sonnet",
+                    other.as_str()
+                )));
+            }
+        };
+        let recovery_crew = resolve_crew(required_crew, self.context.settings().crews()).map_err(
+            |error| {
+                DispatchError::JobValidation(format!(
+                    "step_failure_recovery requires provider `{}` crew `{required_crew}` for run `{run_id}`, but it is unavailable or invalid: {error}",
+                    provider.as_str()
+                ))
+            },
+        )?;
+        let config = crate::runtime::engine::environment_host::typed_role_config_from_assignment(
+            AgentRole::Reviewer,
+            &recovery_crew.assignment,
+        );
+        let usable = config.provider == Some(provider)
+            && config
+                .model
+                .as_deref()
+                .is_some_and(|model| !model.trim().is_empty())
+            && config.backend == Some(Backend::Cli);
+        if !usable {
+            return Err(DispatchError::JobValidation(format!(
+                "step_failure_recovery requires provider `{}` crew `{required_crew}` with provider `{}`, a non-empty model, and backend `cli` for run `{run_id}`; configured crew is unusable",
+                provider.as_str(),
+                provider.as_str(),
+            )));
+        }
+        Ok(config)
     }
 
     fn explicit_agent_crew_config_for_input(

--- a/crates/orbit-core/src/runtime/v2_host/tests/v2_host.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/v2_host.rs
@@ -1,6 +1,7 @@
 //! Sibling tests for `mod.rs` (the v2_host module root; migrated per ORB-10387 /
 //! docs/design-patterns/test_layout.md).
 
+use orbit_common::types::activity_job::Provider;
 use orbit_common::types::{InvocationTrace, JobRunState, TokenUsage, ToolCallTrace};
 use orbit_store::InvocationQuery;
 
@@ -19,6 +20,126 @@ fn seed_running_job_run(runtime: &OrbitRuntime, job_id: &str) -> String {
         .mark_job_run_running(&run.run_id, chrono::Utc::now(), std::process::id())
         .expect("mark run running");
     run.run_id
+}
+
+fn runtime_with_recovery_config(config: &str) -> (tempfile::TempDir, OrbitRuntime) {
+    let root = tempfile::tempdir().expect("create tempdir");
+    let global = root.path().join("home/.orbit");
+    let workspace = root.path().join("repo/.orbit");
+    std::fs::create_dir_all(&global).expect("global orbit dir");
+    std::fs::create_dir_all(&workspace).expect("workspace orbit dir");
+    std::fs::write(workspace.join("config.toml"), config).expect("write recovery config");
+    let runtime = OrbitRuntime::from_roots(&global, &workspace).expect("build runtime");
+    (root, runtime)
+}
+
+#[test]
+fn recovery_crew_maps_persisted_codex_and_claude_lanes_to_middleweight_models() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+
+    for (source_crew, expected_provider, expected_model) in [
+        ("sol", Provider::Codex, "gpt-5.6-terra"),
+        ("terra", Provider::Codex, "gpt-5.6-terra"),
+        ("luna", Provider::Codex, "gpt-5.6-terra"),
+        ("opus", Provider::Claude, "sonnet"),
+        ("sonnet", Provider::Claude, "sonnet"),
+        ("fable", Provider::Claude, "sonnet"),
+    ] {
+        let run_id = seed_running_job_run(&runtime, "recovery_lane_job");
+        runtime
+            .record_run_crew_from_input(&run_id, &serde_json::json!({ "crew": source_crew }))
+            .expect("persist source crew");
+
+        let config = V2RuntimeHost::recovery_agent_crew_config(&runtime, &run_id)
+            .expect("resolve lane-local middleweight recovery crew");
+        assert_eq!(
+            config.provider,
+            Some(expected_provider),
+            "source {source_crew}"
+        );
+        assert_eq!(
+            config.model.as_deref(),
+            Some(expected_model),
+            "source {source_crew}"
+        );
+    }
+}
+
+#[test]
+fn recovery_crew_missing_or_cross_provider_config_is_an_actionable_error() {
+    let missing_terra = r#"
+[workflow]
+default_crew = "sol"
+
+[crews.sol]
+model = "gpt-5.6-sol"
+provider = "codex"
+backend = "cli"
+"#;
+    let (_root, runtime) = runtime_with_recovery_config(missing_terra);
+    let run_id = seed_running_job_run(&runtime, "recovery_missing_crew");
+    runtime
+        .record_run_crew_from_input(&run_id, &serde_json::json!({ "crew": "sol" }))
+        .expect("persist source crew");
+    let err = V2RuntimeHost::recovery_agent_crew_config(&runtime, &run_id)
+        .expect_err("missing terra must not fall back to another provider or model");
+    assert!(err.to_string().contains("provider `codex` crew `terra`"));
+
+    let malformed_terra = r#"
+[workflow]
+default_crew = "sol"
+
+[crews.sol]
+model = "gpt-5.6-sol"
+provider = "codex"
+backend = "cli"
+
+[crews.terra]
+model = "sonnet"
+provider = "claude"
+backend = "cli"
+"#;
+    let (_root, runtime) = runtime_with_recovery_config(malformed_terra);
+    let run_id = seed_running_job_run(&runtime, "recovery_malformed_crew");
+    runtime
+        .record_run_crew_from_input(&run_id, &serde_json::json!({ "crew": "sol" }))
+        .expect("persist source crew");
+    let err = V2RuntimeHost::recovery_agent_crew_config(&runtime, &run_id)
+        .expect_err("cross-provider terra must fail closed");
+    assert!(err.to_string().contains("provider `codex` crew `terra`"));
+}
+
+#[test]
+fn recovery_invocation_persists_the_selected_middleweight_provider_and_model() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let run_id = seed_running_job_run(&runtime, "recovery_telemetry_job");
+    runtime
+        .record_run_crew_from_input(&run_id, &serde_json::json!({ "crew": "sol" }))
+        .expect("persist source crew");
+    let recovery = V2RuntimeHost::recovery_agent_crew_config(&runtime, &run_id)
+        .expect("resolve terra recovery crew");
+
+    V2RuntimeHost::persist_invocation_trace(
+        &runtime,
+        &run_id,
+        "step_failure_recovery",
+        recovery.provider.expect("validated provider").as_str(),
+        recovery.model.as_deref(),
+        &serde_json::json!({ "task_id": "ORB-10615" }),
+        &InvocationTrace::default(),
+    )
+    .expect("persist recovery invocation");
+
+    let records = runtime
+        .invocation_records(InvocationQuery {
+            job_run_id: Some(run_id),
+            limit: 1,
+            ..InvocationQuery::default()
+        })
+        .expect("query recovery invocation");
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].agent, "codex");
+    assert_eq!(records[0].model.as_deref(), Some("gpt-5.6-terra"));
 }
 
 fn payload_tool_call(seq: u32, tool_name: &str, payload: Value) -> ToolCallTrace {

--- a/crates/orbit-engine/src/activity_job/agent_role.rs
+++ b/crates/orbit-engine/src/activity_job/agent_role.rs
@@ -44,6 +44,20 @@ pub fn resolve_agent_settings(
     resolve_from_config(config.as_ref(), inline)
 }
 
+/// Resolve the explicit middleweight crew for `step_failure_recovery`.
+///
+/// Unlike ordinary role resolution, recovery must not inherit the task crew:
+/// its host derives the failed run's persisted provider lane and validates the
+/// configured lane-local recovery crew before this fallback merge occurs.
+pub fn resolve_recovery_agent_settings(
+    host: &dyn V2RuntimeHost,
+    run_id: &str,
+    inline: &AgentLoopSpec,
+) -> Result<ResolvedAgentSettings, DispatchError> {
+    let config = host.recovery_agent_crew_config(run_id)?;
+    Ok(resolve_from_config(Some(&config), inline))
+}
+
 /// Resolve the flat crew selected explicitly by a rendered activity input.
 /// Returns `None` only when the input did not select a crew, leaving untagged
 /// activities on their inline baseline. A selected crew that the host cannot

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -217,6 +217,16 @@ pub trait V2RuntimeHost: Send + Sync {
         self.agent_role_config(role)
     }
 
+    /// Resolve the dedicated, provider-lane-preserving crew for the bounded
+    /// `step_failure_recovery` activity. Implementations must derive the lane
+    /// from the persisted run identity, rather than current CLI availability
+    /// or the activity's inline defaults.
+    fn recovery_agent_crew_config(&self, run_id: &str) -> Result<AgentRoleConfig, DispatchError> {
+        Err(DispatchError::JobValidation(format!(
+            "step_failure_recovery requires a durable provider lane for run `{run_id}`, but this runtime host does not provide recovery crew resolution"
+        )))
+    }
+
     /// Resolve a flat crew selected explicitly by the rendered activity
     /// input. This is separate from role-tag lookup: modern crews have one
     /// assignment, so an activity carrying `crew` does not need a synthetic

--- a/crates/orbit-engine/src/activity_job/job_executor/mod.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/mod.rs
@@ -47,6 +47,7 @@ use crate::template::{self, TemplateContext};
 use super::agent_loop_driver::drive_agent_loop_with_session;
 use super::agent_role::{
     apply_resolved_settings, resolve_agent_settings, resolve_explicit_crew_settings,
+    resolve_recovery_agent_settings,
 };
 use super::audit_writer::{V2AuditWriter, WriteError};
 use super::dispatcher::{

--- a/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
@@ -53,7 +53,29 @@ pub(super) fn attempt_recovery_activity(
         "attempt": attempt,
         "max_attempts": max_attempts,
     });
-    let role_overridden_spec = role_overridden_recovery_spec(recovery, ctx);
+    let role_overridden_spec = match role_overridden_recovery_spec(recovery, ctx) {
+        Ok(spec) => spec,
+        Err(error) => {
+            tracing::warn!(
+                target: "orbit.engine.job_executor",
+                run_id = %ctx.run_id,
+                failed_step_id = %step.id,
+                recovery_activity = %recovery.name,
+                error = %error,
+                "step recovery crew resolution failed; preserving original step outcome"
+            );
+            emit_job_event_lossy(
+                &ctx.audit,
+                ctx.task_id(),
+                V2AuditEventKind::StepRecoveryAttempted {
+                    step_id: step.id.clone(),
+                    recovery_activity: recovery.name.clone(),
+                    recovery_succeeded: false,
+                },
+            );
+            return false;
+        }
+    };
     let spec = role_overridden_spec.as_ref().unwrap_or(&recovery.spec);
     let dispatch = dispatch_v2_activity_without_run_id_injection(V2DispatchInput {
         activity_name: &recovery.name,
@@ -167,13 +189,19 @@ pub(super) fn attempt_failure_activity(
 pub(super) fn role_overridden_recovery_spec(
     recovery: &ResolvedRecoveryActivity,
     ctx: &ExecCtx<'_>,
-) -> Option<ActivityV2Spec> {
+) -> Result<Option<ActivityV2Spec>, DispatchError> {
     let ActivityV2Spec::AgentLoop(inline_spec) = &recovery.spec else {
-        return None;
+        return Ok(None);
     };
-    let role = inline_spec.role?;
-    let resolved = resolve_agent_settings(role, ctx.host, inline_spec, &ctx.input);
+    let resolved = if recovery.name == "step_failure_recovery" {
+        resolve_recovery_agent_settings(ctx.host, &ctx.run_id, inline_spec)?
+    } else {
+        let Some(role) = inline_spec.role else {
+            return Ok(None);
+        };
+        resolve_agent_settings(role, ctx.host, inline_spec, &ctx.input)
+    };
     let mut spec = inline_spec.clone();
     apply_resolved_settings(&mut spec, &resolved);
-    Some(ActivityV2Spec::AgentLoop(spec))
+    Ok(Some(ActivityV2Spec::AgentLoop(spec)))
 }

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
@@ -228,6 +228,7 @@ fn recovery_agent_loop_uses_reviewer_role_config() {
     ));
 
     let overridden = role_overridden_recovery_spec(&recovery, &ctx)
+        .expect("generic recovery role resolution should succeed")
         .expect("role-tagged recovery should resolve");
 
     let ActivityV2Spec::AgentLoop(spec) = overridden else {
@@ -251,6 +252,7 @@ fn recovery_agent_loop_without_reviewer_config_keeps_inline_defaults() {
     ));
 
     let overridden = role_overridden_recovery_spec(&recovery, &ctx)
+        .expect("generic recovery inline fallback should succeed")
         .expect("role-tagged recovery should still produce dispatch spec");
 
     let ActivityV2Spec::AgentLoop(spec) = overridden else {
@@ -260,6 +262,55 @@ fn recovery_agent_loop_without_reviewer_config_keeps_inline_defaults() {
     assert_eq!(spec.model, None);
     assert_eq!(spec.backend, Backend::Http);
     assert_eq!(host.observed_role_lookups(), vec![AgentRole::Reviewer]);
+}
+
+#[test]
+fn step_failure_recovery_uses_the_lane_middleweight_config() {
+    for (provider, model) in [
+        (Provider::Codex, "gpt-5.6-terra"),
+        (Provider::Claude, "sonnet"),
+    ] {
+        let host = RecoveryHost::empty().with_recovery_config(AgentRoleConfig {
+            provider: Some(provider),
+            model: Some(model.to_string()),
+            backend: Some(Backend::Cli),
+        });
+        let ctx = recovery_exec_ctx(&host);
+        let recovery = step_failure_recovery_agent_loop_activity(recovery_agent_loop_spec(
+            Some(AgentRole::Reviewer),
+            Provider::Gemini,
+            Backend::Http,
+            Some("inline-model"),
+        ));
+
+        let overridden = role_overridden_recovery_spec(&recovery, &ctx)
+            .expect("middleweight recovery config should resolve")
+            .expect("agent loop recovery should produce a dispatch spec");
+        let ActivityV2Spec::AgentLoop(spec) = overridden else {
+            panic!("expected agent_loop recovery spec");
+        };
+        assert_eq!(spec.provider, provider);
+        assert_eq!(spec.model.as_deref(), Some(model));
+        assert_eq!(spec.backend, Backend::Cli);
+        assert!(host.observed_role_lookups().is_empty());
+    }
+}
+
+#[test]
+fn step_failure_recovery_requires_a_middleweight_config() {
+    let host = RecoveryHost::empty();
+    let ctx = recovery_exec_ctx(&host);
+    let recovery = step_failure_recovery_agent_loop_activity(recovery_agent_loop_spec(
+        Some(AgentRole::Reviewer),
+        Provider::Codex,
+        Backend::Cli,
+        Some("gpt-5.6-sol"),
+    ));
+
+    let err = role_overridden_recovery_spec(&recovery, &ctx)
+        .expect_err("step recovery must not fall back to its implementation crew");
+
+    assert!(err.to_string().contains("durable provider lane"));
 }
 
 #[test]
@@ -650,6 +701,13 @@ fn agent_loop_recovery_activity(spec: AgentLoopSpec) -> ResolvedRecoveryActivity
     }
 }
 
+fn step_failure_recovery_agent_loop_activity(spec: AgentLoopSpec) -> ResolvedRecoveryActivity {
+    ResolvedRecoveryActivity {
+        name: "step_failure_recovery".to_string(),
+        spec: ActivityV2Spec::AgentLoop(spec),
+    }
+}
+
 fn recovery_agent_loop_spec(
     role: Option<AgentRole>,
     provider: Provider,
@@ -722,6 +780,7 @@ struct RecoveryHost {
     calls: StdMutex<Vec<DeterministicCall>>,
     pending_fs_profiles: StdMutex<VecDeque<Option<String>>>,
     role_config: StdMutex<HashMap<AgentRole, AgentRoleConfig>>,
+    recovery_config: StdMutex<Option<AgentRoleConfig>>,
     observed_role_lookups: StdMutex<Vec<AgentRole>>,
 }
 
@@ -741,12 +800,18 @@ impl RecoveryHost {
             calls: StdMutex::new(Vec::new()),
             pending_fs_profiles: StdMutex::new(VecDeque::new()),
             role_config: StdMutex::new(HashMap::new()),
+            recovery_config: StdMutex::new(None),
             observed_role_lookups: StdMutex::new(Vec::new()),
         }
     }
 
     fn with_role_config(self, config: HashMap<AgentRole, AgentRoleConfig>) -> Self {
         *self.role_config.lock().expect("role config lock") = config;
+        self
+    }
+
+    fn with_recovery_config(self, config: AgentRoleConfig) -> Self {
+        *self.recovery_config.lock().expect("recovery config lock") = Some(config);
         self
     }
 
@@ -864,5 +929,18 @@ impl V2RuntimeHost for RecoveryHost {
             .expect("role config lock")
             .get(&role)
             .cloned()
+    }
+
+    fn recovery_agent_crew_config(&self, _run_id: &str) -> Result<AgentRoleConfig, DispatchError> {
+        self.recovery_config
+            .lock()
+            .expect("recovery config lock")
+            .clone()
+            .ok_or_else(|| {
+                DispatchError::JobValidation(
+                    "step_failure_recovery requires a durable provider lane in this test host"
+                        .to_string(),
+                )
+            })
     }
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -82,6 +82,24 @@ Fresh `orbit init` configuration advertises only detected provider CLIs. Claude 
 
 You can define any number of crews. Set the workspace-wide fallback with `workflow.default_crew`; assign a specific crew to individual tasks via the [per-task crew override](#per-task-crew-override). Crews are validated at load time: each crew must have non-empty `model`, `provider`, and `backend`; `workflow.default_crew` must name a defined crew.
 
+### Step-failure recovery crews
+
+`step_failure_recovery` is intentionally cheaper than a normal implementation
+attempt. It keeps the failed run's persisted provider lane and selects the
+configured middleweight crew in that lane: Codex runs recovery through
+`terra`; Claude runs it through `sonnet`. This mapping applies even if the
+failed task used `sol`, `opus`, or a lower-tier crew. The reviewer role on the
+activity remains a prompt and telemetry label; it does not select the recovery
+model.
+
+Both mapped crews must exist and remain usable for their own provider
+(`provider`, non-empty `model`, and `backend = "cli"`). A missing or
+cross-provider `terra`/`sonnet` fails recovery with an actionable diagnostic;
+Orbit preserves the original failed-step outcome and never changes provider
+families or escalates back to the implementation model. The recovery
+invocation trace records the selected provider and model separately for token
+and cost attribution.
+
 Crew metadata is canonical runtime data, not display-only TOML. Orbit trims
 `description` (blank becomes absent), trims each tag, drops blank tags, and stores
 tags in sorted deduplicated order. Legacy crew entries without these fields


### PR DESCRIPTION
## Task

[ORB-10615](https://orbit-cli.com/tasks/ORB-10615) — Run step-failure recovery on the provider lane's middleweight crew

### Description

## Problem

`step_failure_recovery` is an agent-loop activity tagged with the reviewer role. Since ORB-10130 flattened crews to one provider-model assignment, role resolution gives recovery the task's implementation crew. A hard task implemented by `sol` or `opus` therefore pays the heavyweight model rate again for recovery, even though recovery is a bounded diagnostic/repair mandate that should normally use the middleweight tier.

Daniel's 2026-08-08 decision: step recovery should use `terra` for the Codex provider lane or `sonnet` for the Claude provider lane.

## Change

Give recovery an explicit middleweight-crew resolution path rather than inheriting the task implementation crew. Resolve the provider lane from durable run/execution identity, then select the configured middleweight crew in that same lane:

- Codex -> `terra`
- Claude -> `sonnet`

Do not select a provider family by probing whichever CLI happens to answer first, and do not silently cross the orchestrator's provider-exclusive lane. If the required middleweight crew is absent or unusable, preserve the original failed-step outcome and emit an actionable recovery diagnostic naming the missing crew/config rather than silently escalating to `sol`/`opus` or falling back to an unrelated inline model.

Persist the actual recovery provider/model in normal invocation telemetry so the dashboard can verify the savings.

## Constraints

- This changes only the recovery activity's model selection. Implementation, review, planning, failure handoff, and task crew persistence remain unchanged.
- Keep ORB-10382's repair/delivery authority, safety gates, budgets, tools, and instruction semantics intact.
- Preserve the bounded single post-recovery attempt and the original-error behavior when recovery fails.
- Do not revive pre-ORB-10130 role-specific crew assignments.

### Acceptance Criteria

- A step recovery for a Codex-lane run dispatches through the configured `terra` crew even when the failed task used `sol`; a Claude-lane run dispatches through `sonnet` even when the task used `opus`.
- Provider-lane selection comes from durable run/execution identity and never silently hops provider families based on ambient CLI availability.
- A missing or invalid `terra`/`sonnet` recovery crew produces an actionable diagnostic naming the provider and required crew, preserves the original failed-step outcome, and does not silently escalate to a heavyweight model.
- The recovery invocation record and audit/trace identify the actual provider and model selected, so token/cost dashboards can attribute it separately.
- Implementation crew, task `crew`, independent review routing, failure handoff, recovery authority/instructions, and the executor's bounded one-post-recovery-attempt contract remain unchanged.
- Tests cover Codex/Sol -> Terra, Claude/Opus -> Sonnet, already-middleweight tasks, low-tier failed tasks, missing mapped crew, malformed crew config, and persistence of the selected recovery model.
- Both seeded and dogfood activity assets remain behaviorally aligned, affected crates build, focused recovery/catalog tests and `make ci-fast` pass, and unrelated pre-existing failures are named rather than repaired.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a dedicated step_failure_recovery crew-resolution seam that derives the provider lane from the persisted run crew, maps Codex to terra and Claude to sonnet, and validates that the mapped crew remains in the same provider lane with a model and CLI backend.
- Recovery configuration errors now log an actionable diagnostic while emitting a failed recovery attempt and preserving the original failed-step outcome; generic recovery, task crew selection, review routing, and the one-post-recovery-attempt contract are unchanged.
- Kept seeded and dogfood recovery assets aligned, documented the mapping, and added engine/core/catalog coverage for strong, middleweight, low-tier, missing, cross-provider, and invocation-telemetry cases.
- Added directly coupled context files crates/orbit-engine/src/activity_job/dispatcher.rs and crates/orbit-core/src/runtime/v2_host/tests/v2_host.rs before editing because they provide the runtime-host resolution seam and its durable-identity test coverage.
Assessment: Focused recovery and catalog tests pass; make ci-fast passes.
Validation:
- cargo test -p orbit-engine job_executor::tests::recovery (19 passed)
- cargo test -p orbit-core recovery_ (7 passed)
- make ci-fast

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10615-6a77a1cc`
- Behind base: 0
- Ahead of base: 1