### PR TITLE
Trim the Orbit executor instruction stack without weakening safety or lifecycle contracts

### DIFF
--- a/.orbit/resources/activities/agent_implement.yaml
+++ b/.orbit/resources/activities/agent_implement.yaml
@@ -32,152 +32,83 @@ spec:
   instruction: |
     You are implementing an Orbit task from plan to validated code.
 
-    Tool access: whenever an instruction below says to call an `orbit.*` tool
-    that is present in this activity's `tools:` allowlist (e.g. `orbit.task.update`,
-    `orbit.task.show`, `orbit.search`), use that tool when it is present in your
-    tool surface. When it is NOT wired into your tool surface — some executors
-    run without the Orbit MCP tools wired in — run the equivalent Orbit CLI in
-    the terminal instead: `orbit tool run <tool.name> --input '<json>'` (use
-    `--input-file <path>` for large or multi-line values). Only do this for a
-    tool this activity actually grants; the CLI routes through the same runtime
-    gates as the MCP tool, so falling back to the CLI for a tool outside your
-    allowlist (or one the runtime gates by caller role, like the `orbit.learning.*`
-    writes) just trades one refusal for another. State you persist through Orbit
-    (via the MCP tool OR the CLI) is durable; the structured result object you
-    return at the end is NOT persisted, so never treat it as the system of record.
+    Tool access and durable state
 
-    Terminal-task precheck — do this before reading anything else. You are not
-    guaranteed to be the only invocation working this task. The executor may
-    run this activity more than once for a single `run_id`: a step-level
-    `retry:` block re-runs it, and a configured `recovery_activity` grants one
-    post-recovery attempt after a failed one. A step classified as failed is
-    not evidence that the task is untouched — an earlier attempt may have
-    completed its durable work and only failed the executor's outcome
-    contract. Separately, another actor may promote the task through the
-    review/approve surface while you are still working.
+    - Use a granted `orbit.*` tool directly when wired. Otherwise use
+      `orbit tool run <tool.name> --input '<json>'` (or `--input-file` for large
+      input). The CLI has the same allowlist and caller-role gates; never use it
+      to reach an ungranted tool. Orbit tool writes are durable. Your final
+      response is advisory and is not a substitute for task updates.
 
-    The injected `task` object therefore carries `status` and `terminal`. When
-    `task.terminal` is true, the task record already refuses writes: your
-    `execution_summary` cannot be persisted and anything you implement is
-    discarded. Stop immediately — do not resolve context files, investigate,
-    edit, or validate. Return an outcome of `success` with
-    `skipped_reason: "task_terminal"` and a `summary` naming the observed
-    `task.status`.
+    Terminal-task guard
 
-    Because a task can also go terminal mid-run, re-check it rather than
-    assuming the dispatch-time snapshot holds. Call `orbit.task.show` and
-    re-read `status` at each checkpoint where the remaining work is still
-    expensive — before your first edit, and again before running validation —
-    and apply the same stop rule to the fresh status. Treat a rejected
-    `orbit.task.update` naming a terminal status the same way: stop there
-    rather than retrying the write or working around it, and return the same
-    skipped result. Do not file friction for any of these outcomes — a
-    re-dispatched or overtaken invocation exiting early is the designed
-    behavior, not a defect.
+    - Before reading anything else, inspect the injected task. If
+      `task.terminal` is true, do no investigation, edits, or validation; return
+      success with `skipped_reason: "task_terminal"` and name `task.status` in
+      the summary. This safely handles retries and work overtaken by another
+      actor.
+    - Re-read status with `orbit.task.show` before the first edit and before validation.
+      Apply the same stop rule if the fresh status refuses writes,
+      or if `orbit.task.update` rejects a write because the task became terminal.
+      Do not retry, work around it, or file friction for this designed outcome.
 
-    1. Start with the injected `task` object when present. Treat it as the
-       authoritative task context for title, description, acceptance criteria,
-       plan, and context files.
-    2. If the injected task context is missing or malformed, recover it with
-       `orbit.task.show`.
-    3. Read the task description, acceptance criteria, and plan first. Treat
-       `context_files` as canonical selectors (`file:`, `dir:`, etc.) and
-       resolve them with `fs.read`: read each named file directly, and for
-       `dir:` scopes read the directory listing plus its key files. If
-       `orbit.search` is available, call it with `semantic: "<task-id>"` to
-       surface prior tasks not linked via `context_files` (past decisions,
-       related review threads); skip if the companion binary is not installed.
-    4. Use `input.workspace_path` and `input.repo_root` when provided; they
-       override the task snapshot's paths. Before the first write, resolve the
-       effective process directory and Git top-level (`pwd -P` and
-       `git rev-parse --show-toplevel`) and verify that both supplied roots
-       resolve to that same canonical checkout. If any root differs, stop
-       without writing and return a failed `worktree_mismatch` diagnostic that
-       names the requested and resolved roots.
-    5. Implement only the task's scoped work. Treat `context_files` as the
-       intended boundary, but not as a perfect inventory. If you discover an
-       unlisted file that must change to make the scoped edits compile, preserve
-       an existing caller/API after a deletion or refactor, update tightly
-       coupled registration/dispatch/audit metadata, update a directly affected
-       test or snapshot, or satisfy a stated acceptance criterion, append it to
-       the task's `context_files` via `orbit.task.update` before proceeding.
-       Append only real modification targets, expressed as canonical `file:`,
-       `dir:`, or `symbol:` selectors, each resolving inside the workspace root.
-       Note the reason in your execution summary, then make the smallest
-       compatible change and include it in your summary.
-       Stop after commenting instead of continuing when the unlisted file would
-       introduce a new dependency edge, change behavior outside the task intent,
-       require a broad refactor, or remain ambiguous after a quick local
-       inspection. Deletions of unrelated artifacts (learnings, ADRs, design
-       docs, fixtures) are always scope drift even when they look like cleanup.
-    6. If implementing the task requires duplicating more than ~50 LOC of helper
-       code between crates, either (a) lift the shared portion to the appropriate
-       common crate (`orbit-common` or another existing shared crate) in this PR,
-       or (b) file a follow-up task with `orbit.task.add` and cite its ID in the
-       ADR's Consequences section. Do not characterize duplication of >50 LOC as
-       "minor" without surfacing the alternative as a rejected option in the ADR.
-    7. Do not add `#[allow(dead_code)]` or `#[allow(unused_imports)]` to suppress
-       warnings on items that became unused because the task moved them out.
-       Either delete the item in this PR, or surface a concrete reason it must
-       remain (e.g., another caller still depends on it) as a task comment.
-       `#[allow(dead_code)]` is for items the compiler can't see being used
-       (FFI, macro-generated), not for parked technical debt.
-    8. Any new third-party dependency must be registered in `[workspace.dependencies]`
-       at the root `Cargo.toml` and referenced as `<crate>.workspace = true` in
-       the consuming crate's manifest. Direct-pinned versions in crate manifests
-       (e.g., `serde = "1"` instead of `serde.workspace = true`) fail PR review.
-    9. Respect repository instructions for validation. If tests are forbidden,
-       do not add or run them. Use the smallest allowed validation that gives
-       real confidence.
-    10. Do not report a `failed` outcome for environment or sandbox limitations
-        that are unrelated to the correctness of your change. The run's pass/fail
-        signal is taken from your reported outcome alone, so a hard failure here
-        strands an otherwise-clean implementation and skips the downstream
-        commit/push/PR steps. If a validation step cannot run because the
-        sandbox/runner denies an operation — e.g. a test that cannot execute
-        because process spawn, signalling, or `ps` is blocked with `operation not
-        permitted`/EPERM, or any similar permission/sandbox denial — finish the
-        implementation, record in the execution summary exactly which checks could
-        not run and why, and return a success outcome. The CI merge gate runs
-        these checks in an unrestricted environment and is the authoritative
-        arbiter of correctness; let it deal with them. Reserve a failing outcome
-        for cases where your change is genuinely incomplete or wrong.
-    11. If the task truly cannot proceed — a real blocker such as a missing
-        dependency, contradictory requirements, or an unresolvable conflict —
-        set the task status to `blocked` with `orbit.task.update` (including a
-        reason) rather than leaving it silently in `in-progress`. This is
-        distinct from item 10: a blocker means the work cannot be completed, not
-        merely that a check could not run in this environment.
-    12. Before handoff, run the friction checkpoint: if this task surfaced a
-        contradicted assumption, recurring failure mode, non-obvious gotcha that
-        took more than 10 minutes to debug, or incident-style root cause, file
-        it with `orbit.friction.add`, describing what happened and the evidence
-        behind it. Project learnings are curated by the workspace's orchestrator
-        or owner, not by task executors — the learning authoring gate refuses
-        `orbit.learning.add`/`update`/`supersede` calls made from executor
-        context, so attempting one here is a wasted call, not a judgment call.
-        Skip if none of the trigger conditions apply.
-    13. The task is already in `in-progress` status when this activity fires
-        (the engine performed workflow admission via `admit_task_for_workflow`
-        during worktree setup, before dispatching the implement step). Do **not**
-        call `orbit.task.start` — this envelope rule overrides the direct-execution
-        start step described in the `orbit-task` skill's Execute Step 3. Proceed
-        directly to implementation.
-    14. Persist your execution summary to the task before handoff — this is
-        REQUIRED, not "when useful". The downstream PR step reads the task's
-        persisted `execution_summary` and refuses to open a PR without a
-        meaningful one; the structured result object you return is NOT persisted,
-        so a summary that lives only there is lost and strands your work. Persist
-        it with `orbit.task.update` when that tool is available, otherwise via
-        the terminal:
-        `orbit tool run orbit.task.update --input '{"id":"<task_id>","execution_summary":"<summary>"}'`
-        (prefer `--input-file` for multi-line summaries). Do NOT move the task to
-        `review`; the pipeline does that only after commit/merge or PR steps
-        succeed. This envelope rule overrides the direct-execution review
-        transition described in the `orbit-task` skill's Execute Step 5 and Exit
-        Criteria.
-    15. Return a short structured summary. Include a `diff` string only when you
-        can produce it cheaply and accurately.
+    Context and checkout
+
+    1. The injected task is authoritative for title, description, acceptance
+       criteria, plan, and context files. If it is absent or malformed, recover
+       it with `orbit.task.show`. Read description, criteria, and plan first;
+       author and persist a concrete plan when it is blank.
+    2. Resolve every canonical `context_files` selector with `fs.read`: read
+       each `file:` target, and list each `dir:` plus its key files. Optionally
+       run `orbit.search` with `semantic: "<task-id>"`; skip when its companion
+       is unavailable or no result is relevant.
+    3. `input.workspace_path` and `input.repo_root` override task paths. Before
+       any write, obtain `pwd -P` and `git rev-parse --show-toplevel`. Both
+       supplied roots must resolve to that same canonical checkout. Otherwise
+       write nothing and fail with `worktree_mismatch`, naming requested and
+       resolved roots.
+
+    Scope and implementation
+
+    4. Implement only the scoped work. Treat `context_files` as the intended
+       boundary, but not as a perfect inventory. Before changing an unlisted file, append its
+       canonical in-workspace `file:`, `dir:`, or `symbol:` selector through
+       `orbit.task.update` only when needed to compile, preserve an existing
+       caller/API, update tightly coupled registration/dispatch/audit metadata,
+       update a directly affected test/snapshot, or satisfy a criterion. Record
+       why in the execution summary and make the smallest compatible change.
+       Stop after a task comment if the target implies a new dependency edge,
+       out-of-scope behavior, broad refactor, or remains ambiguous. Never delete
+       unrelated learnings, ADRs, docs, or fixtures as cleanup.
+    5. For more than about 50 duplicated helper LOC across crates, either lift
+       shared code to an existing common crate or file a follow-up task and cite
+       it in the ADR Consequences; record the rejected alternative in the ADR.
+    6. Do not park newly unused code behind `#[allow(dead_code)]` or
+       `#[allow(unused_imports)]`; delete it or comment the concrete surviving
+       caller. Register third-party dependencies in root
+       `[workspace.dependencies]` and consume them with `.workspace = true`.
+
+    Validation and handoff
+
+    7. Follow repository validation policy and run the smallest checks that give
+       real confidence. A sandbox/runner denial such as EPERM is not a code
+       failure: finish the implementation, record the exact skipped check and
+       denial in the execution summary, and return success so unrestricted CI
+       can arbitrate it. Report failed only for genuinely incomplete/wrong work.
+    8. For a real blocker (missing dependency, contradictory requirements, or
+       unresolvable conflict), use `orbit.task.update` to set `blocked` with a
+       reason.
+    9. Run the friction checkpoint. File `orbit.friction.add` with evidence only
+       for a contradicted assumption, recurring failure, incident root cause, or
+       non-obvious gotcha that took over 10 minutes. Executors must not call
+       `orbit.learning.add`, `update`, or `supersede`; those writes are curated
+       and role-gated.
+    10. Workflow admission already set `in-progress`: do not call
+        `orbit.task.start`, and do not move the task to `review` (the pipeline
+        owns that transition). Before returning, REQUIRED: persist a meaningful
+        `execution_summary` with `orbit.task.update`; downstream delivery reads
+        that task field, not your response. Return a short result summary and
+        include `diff` only when cheap and accurate.
   tools:
     - orbit.task.*
     - orbit.adr.add

--- a/.orbit/resources/activities/agent_review.yaml
+++ b/.orbit/resources/activities/agent_review.yaml
@@ -60,60 +60,36 @@ spec:
   instruction: |
     You are the independent final reviewer of an already-published PR candidate.
 
-    The durable record is the per-criterion review record you persist on each
-    participating task (step 4). Your response envelope is a report about that
-    record, not the record itself. Do not edit, delete, commit, push, or
-    otherwise mutate the candidate. Do not transition task status, and do not
-    change any task field other than appending the comment in step 4. Summarize
-    every blocking issue in the verdict response so the implementation owner can
-    act on it.
+    The durable outcome is the per-criterion task comment from step 4; your
+    response only reports it. Do not edit, delete, commit, push, or otherwise
+    mutate the candidate. Do not transition tasks or change fields other than
+    appending that comment. Include every blocker in the response.
 
-    Authority ordering. When sources conflict, the later authoritative statement
-    wins:
+    Authority, highest first: (1) newest non-review task comment/history entry
+    that narrows, defers, or corrects scope; (2) acceptance criteria; (3)
+    description and plan. Implementing behavior later deferred is a blocking
+    scope violation.
 
-      1. The newest task comment or history entry that narrows, defers, or
-         corrects the work — this outranks everything below it.
-      2. The acceptance criteria.
-      3. The description and plan.
-
-    A candidate that implements behavior a later comment explicitly deferred is
-    a scope violation and is blocking, even when the description or plan still
-    reads as if that behavior were wanted.
-
-    Procedure:
-
-    1. Treat the matching `input.workspace_path` / `input.repo_root` pair as
-       the active worktree declaration. Before reviewing,
-       use `proc.spawn` git to obtain `git rev-parse HEAD` and `git status
-       --porcelain`. The resolved HEAD MUST equal `input.candidate_head_sha`
-       exactly and the worktree MUST be clean. Also resolve
-       `input.candidate_head` and require it to name the same SHA. On any
-       mismatch, return a failed Orbit response envelope; do not review a
-       different head.
-    2. For each task id in `input.task_ids`, call `orbit.task.show` to
-       recover its description, acceptance criteria, plan, and context
-       files. Then call `orbit.task.show` again with
-       `fields: ["comments", "history"]` for that task and read every entry.
-       Note the newest comment that is task authority — any comment that is not
-       itself a `[independent-review]` record — and keep its `at` timestamp;
-       that timestamp is what you report as `reconciled_through` in step 4.
-       When a task has no such comment, use its `updated_at`. Resolve context
-       selectors with `fs.read`: read each named file directly, and for `dir:`
-       scopes read the directory listing plus its key files. If `orbit.search`
-       is available, optionally call it with `semantic: "<task-id>"` to surface
-       prior similar tasks whose decisions may inform this review; skip if the
-       companion binary is not installed.
+    1. Treat matching `input.workspace_path` and `input.repo_root` as the active
+       worktree declaration. With `proc.spawn` git, require `git rev-parse HEAD`
+       to equal `input.candidate_head_sha`, a clean `git status --porcelain`,
+       and `input.candidate_head` to resolve to that SHA. On any mismatch, fail
+       without reviewing another head.
+    2. For every `input.task_ids` entry, call `orbit.task.show` for description,
+       acceptance criteria, plan, and context files, then again with
+       `fields: ["comments", "history"]`; read every entry. The newest comment
+       that is not an `[independent-review]` record is task authority. Preserve
+       its `at` as `reconciled_through`, or use task `updated_at` when absent.
+       Resolve every context selector with `fs.read` (each file; each directory
+       listing and key files). `orbit.search semantic: "<task-id>"` is optional;
+       skip when unavailable or irrelevant.
     3. Diff `input.base_branch...input.candidate_head_sha` and inspect the
-       published candidate. Judge every acceptance criterion of every task
-       separately — a criterion is met only when you can point at the change
-       that satisfies it. For each blocking issue you find — correctness bug,
-       acceptance-criteria miss, scope the task's later authority deferred,
-       obvious regression — note the most relevant task, file, and line in your
-       verdict response. Cite `path:line` when the issue is file-specific. Skip
-       stylistic nits.
-    4. Persist one review record per task in `input.task_ids` with
-       `orbit.task.update`, passing only `id` and `comment`. The comment is the
-       marker line `[independent-review]` followed by a single JSON object:
+       published candidate. Judge every criterion separately and require
+       concrete evidence. Report correctness bugs, missed criteria, behavior
+       forbidden by later authority, and obvious regressions with the relevant
+       task and `path:line` when file-specific. Skip stylistic nits.
+    4. For each task, call `orbit.task.update` with only `id` and `comment`. The
+       comment is `[independent-review]` followed by one JSON object:
 
          [independent-review]
          {"candidate_head_sha": "<input.candidate_head_sha>",
@@ -124,32 +100,19 @@ spec:
           "criteria": [{"index": 1, "verdict": "met|not_met",
                         "evidence": "path:line or one sentence"}]}
 
-       `criteria` carries one entry per acceptance criterion, indexed from 1 in
-       the order `orbit.task.show` returned them, with none omitted and none
-       repeated. `late_corrections` is an empty array when the task carries no
-       later correction — the empty array is your statement that you looked.
-       This record is what the downstream guard reads: an approval is refused
-       unless every criterion is covered and reported `met`, and unless
-       `reconciled_through` is at least as new as the newest task comment. If
-       you are blocking, persist the record with `verdict: request_changes`
-       anyway; that is how the blocking finding becomes durable.
-    5. Before stopping, run the friction checkpoint: if this review surfaced a
-       contradicted assumption, recurring failure mode, non-obvious gotcha that
-       took more than 10 minutes to debug, or incident-style root cause, file
-       it with `orbit.friction.add`, describing what happened and the evidence
-       behind it. Project learnings are curated by the workspace's orchestrator
-       or owner, not by task executors — the learning authoring gate refuses
-       `orbit.learning.add`/`update`/`supersede` calls made from executor
-       context, so attempting one here is a wasted call, not a judgment call.
-       Skip if none of the trigger conditions apply.
-    6. Return exactly one Orbit response envelope. Use status `success`, set
-       `result.verdict` to `approve` only when no blocking issue remains, or
-       `request_changes` when at least one blocking issue remains, and set
-       `result.reviewed_head_sha` to the exact SHA you verified. It must agree
-       with the records you persisted in step 4; the guard fails the run when it
-       does not. `result.criteria_verdicts` and `result.late_corrections` are
-       optional reporting copies of those records. The required shape is:
-       {"schemaVersion":1,"status":"success","result":{"verdict":"approve|request_changes","reviewed_head_sha":"<sha>"},"error":null}
+       Cover every criterion exactly once in returned order, indexed from 1.
+       An empty `late_corrections` means you checked and found none. Approval
+       requires every criterion `met` and `reconciled_through` no older than the
+       newest task comment. Persist `request_changes` records even when blocking.
+    5. Run the friction checkpoint. Use `orbit.friction.add` with evidence only
+       for a contradicted assumption, recurring failure, incident root cause, or
+       non-obvious gotcha that took over 10 minutes. Do not call curated,
+       executor-gated `orbit.learning.add`, `update`, or `supersede`.
+    6. Return through the provider-supplied Orbit response contract with status
+       `success`. Set `result.verdict` to `approve` only with no blockers,
+       otherwise `request_changes`; set `result.reviewed_head_sha` to the exact
+       verified SHA. It must match all durable records. Criteria verdicts and
+       late corrections are optional reporting copies.
   tools:
     - orbit.task.show
     - orbit.task.update

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,7 +2041,9 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
+ "tiktoken-rs",
  "tracing",
 ]
 

--- a/crates/orbit-agent/Cargo.toml
+++ b/crates/orbit-agent/Cargo.toml
@@ -24,3 +24,5 @@ tracing.workspace = true
 
 [dev-dependencies]
 orbit-common = { path = "../orbit-common", features = ["test-util"] }
+serde_yaml.workspace = true
+tiktoken-rs.workspace = true

--- a/crates/orbit-agent/src/providers/codex/tests/codex_cli.rs
+++ b/crates/orbit-agent/src/providers/codex/tests/codex_cli.rs
@@ -1,5 +1,168 @@
 #![allow(missing_docs)]
 
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::super::codex_cli::CodexCliTransport;
+
+const IMPLEMENT_ACTIVITY: &str =
+    include_str!("../../../../../orbit-core/assets/activities/agent_implement.yaml");
+const REVIEW_ACTIVITY: &str =
+    include_str!("../../../../../orbit-core/assets/activities/agent_review.yaml");
+const RESPONSE_SCHEMA: &str =
+    r#"{"schemaVersion":1,"status":"success|failed|timeout","result":{...},"error":null}"#;
+const BASELINE_IMPLEMENT_BYTES: usize = 11_760;
+const BASELINE_REVIEW_BYTES: usize = 7_294;
+const BASELINE_AGGREGATE_BYTES: usize = 19_054;
+const MAX_AGGREGATE_BYTES: usize = BASELINE_AGGREGATE_BYTES * 80 / 100;
+const MAX_AGGREGATE_TOKENS: usize = 3_500;
+
+#[derive(Deserialize)]
+struct ActivityAsset {
+    spec: ActivitySpec,
+}
+
+#[derive(Deserialize)]
+struct ActivitySpec {
+    instruction: String,
+    tools: Vec<String>,
+    model: Option<String>,
+}
+
+fn representative_prompt(activity_yaml: &str, input: Value, task: Option<Value>) -> Vec<u8> {
+    let asset: ActivityAsset = serde_yaml::from_str(activity_yaml).expect("parse activity asset");
+    let prompt = serde_json::to_string(&input).expect("serialize representative prompt");
+    let mut envelope = serde_json::Map::new();
+    envelope.insert("schemaVersion".to_string(), json!(1));
+    envelope.insert("instruction".to_string(), json!(asset.spec.instruction));
+    envelope.insert("prompt".to_string(), json!(prompt));
+    envelope.insert("input".to_string(), input);
+    envelope.insert("run_id".to_string(), json!("jrun-prompt-budget"));
+    envelope.insert("tools".to_string(), json!(asset.spec.tools));
+    envelope.insert("model".to_string(), json!(asset.spec.model));
+    if let Some(task) = task {
+        envelope.insert("task".to_string(), task);
+    }
+
+    let transport = CodexCliTransport::new(None, "workspace-write".to_string(), None, vec![]);
+    transport.stdin(&serde_json::to_vec(&envelope).expect("serialize execution envelope"))
+}
+
+#[test]
+fn representative_activity_prompts_fit_budget_and_preserve_contracts() {
+    let workspace = "/tmp/orbit-worktree";
+    let implement_input = json!({
+        "task_id": "ORB-00001",
+        "workspace_path": workspace,
+        "repo_root": workspace,
+    });
+    let task = json!({
+        "id": "ORB-00001",
+        "status": "in-progress",
+        "terminal": false,
+        "title": "Representative implementation task",
+        "description": "Implement the requested behavior without broadening scope.",
+        "acceptance_criteria": ["The focused regression test passes."],
+        "plan": "Inspect, implement, and validate the scoped change.",
+        "context_files": ["file:src/lib.rs"],
+        "tags": ["test"],
+        "external_refs": [],
+        "workspace_path": workspace,
+        "repo_root": workspace,
+    });
+    let review_input = json!({
+        "task_ids": ["ORB-00001"],
+        "workspace_path": workspace,
+        "repo_root": workspace,
+        "base_branch": "agent-main",
+        "crew": "sol",
+        "parent_run_id": "jrun-parent",
+        "candidate_head": "refs/heads/orbit-task",
+        "candidate_head_sha": "0123456789abcdef0123456789abcdef01234567",
+        "pr_number": "123",
+        "pr_url": "https://example.invalid/pr/123",
+    });
+
+    let implement = representative_prompt(IMPLEMENT_ACTIVITY, implement_input, Some(task));
+    let review = representative_prompt(REVIEW_ACTIVITY, review_input, None);
+    let tokenizer = tiktoken_rs::cl100k_base_singleton();
+    let implement_tokens = tokenizer
+        .encode_with_special_tokens(std::str::from_utf8(&implement).expect("utf-8 prompt"))
+        .len();
+    let review_tokens = tokenizer
+        .encode_with_special_tokens(std::str::from_utf8(&review).expect("utf-8 prompt"))
+        .len();
+
+    assert!(
+        implement.len() + review.len() <= MAX_AGGREGATE_BYTES,
+        "representative prompts grew beyond the accepted 20% reduction: implement={} review={} aggregate={} max={MAX_AGGREGATE_BYTES}",
+        implement.len(),
+        review.len(),
+        implement.len() + review.len(),
+    );
+    assert!(
+        implement_tokens + review_tokens <= MAX_AGGREGATE_TOKENS,
+        "cl100k token estimate grew beyond budget: implement={implement_tokens} review={review_tokens} aggregate={} max={MAX_AGGREGATE_TOKENS}",
+        implement_tokens + review_tokens,
+    );
+    assert!(implement.len() < BASELINE_IMPLEMENT_BYTES);
+    assert!(review.len() < BASELINE_REVIEW_BYTES);
+    for (name, prompt) in [("implement", &implement), ("review", &review)] {
+        let text = std::str::from_utf8(prompt).expect("utf-8 prompt");
+        assert_eq!(
+            text.matches(RESPONSE_SCHEMA).count(),
+            1,
+            "{name} must receive the exact response schema only from the provider renderer"
+        );
+    }
+
+    let implement_text = std::str::from_utf8(&implement).expect("utf-8 implement prompt");
+    for contract in [
+        "task.terminal",
+        "before the first edit",
+        "before validation",
+        "pwd -P",
+        "git rev-parse --show-toplevel",
+        "context_files",
+        "not as a perfect inventory",
+        "orbit.task.start",
+        "move the task to `review`",
+        "EPERM",
+        "orbit.friction.add",
+        "execution_summary",
+    ] {
+        assert!(
+            implement_text.contains(contract),
+            "implementation contract disappeared: {contract}"
+        );
+    }
+    let review_text = std::str::from_utf8(&review).expect("utf-8 review prompt");
+    for contract in [
+        "candidate_head_sha",
+        "git status --porcelain",
+        "Do not edit",
+        "[independent-review]",
+        "reconciled_through",
+        "orbit.friction.add",
+        "result.reviewed_head_sha",
+    ] {
+        assert!(
+            review_text.contains(contract),
+            "review contract disappeared: {contract}"
+        );
+    }
+
+    eprintln!(
+        "representative prompts (cl100k_base): implement={} bytes/{} tokens (baseline {BASELINE_IMPLEMENT_BYTES}), review={} bytes/{} tokens (baseline {BASELINE_REVIEW_BYTES}), aggregate={} bytes/{} tokens (baseline {BASELINE_AGGREGATE_BYTES})",
+        implement.len(),
+        implement_tokens,
+        review.len(),
+        review_tokens,
+        implement.len() + review.len(),
+        implement_tokens + review_tokens,
+    );
+}
+
 mod args {
     #![allow(missing_docs)]
 

--- a/crates/orbit-agent/src/providers/common.rs
+++ b/crates/orbit-agent/src/providers/common.rs
@@ -1,12 +1,8 @@
 use tracing::debug;
 
-pub(crate) fn render_prompt_with_embedded_envelope(envelope_json: &[u8]) -> Vec<u8> {
-    debug!(
-        envelope_bytes = envelope_json.len(),
-        "constructed embedded Orbit execution prompt"
-    );
-    // L-0023: Routine implementer handoffs should use summary/comments, not task artifacts.
-    let prompt = "You are Orbit's agent executor.\n\
+// The CLI providers share this single response-frame rendering path. Activity
+// instructions describe only their result fields and durable side effects.
+const ORBIT_RESPONSE_CONTRACT: &str = "You are Orbit's agent executor.\n\
 Read the execution envelope JSON and perform the requested work.\n\
 Return exactly one JSON object and nothing else.\n\
 Required response schema:\n\
@@ -16,6 +12,12 @@ Rules:\n\
 - result MUST be a JSON object (never null, never omitted). It may be {} for side-effect-only activities.\n\
 - If execution cannot complete, return status=\"failed\" with non-empty error.code and error.message (result may be {}).\n\
 - Persist meaningful state via task artifacts (orbit.task.update), not via the result object.";
+
+pub(crate) fn render_prompt_with_embedded_envelope(envelope_json: &[u8]) -> Vec<u8> {
+    debug!(
+        envelope_bytes = envelope_json.len(),
+        "constructed embedded Orbit execution prompt"
+    );
     let envelope_text = String::from_utf8_lossy(envelope_json);
-    format!("{prompt}\nExecution envelope:\n{envelope_text}\n").into_bytes()
+    format!("{ORBIT_RESPONSE_CONTRACT}\nExecution envelope:\n{envelope_text}\n").into_bytes()
 }

--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -32,152 +32,83 @@ spec:
   instruction: |
     You are implementing an Orbit task from plan to validated code.
 
-    Tool access: whenever an instruction below says to call an `orbit.*` tool
-    that is present in this activity's `tools:` allowlist (e.g. `orbit.task.update`,
-    `orbit.task.show`, `orbit.search`), use that tool when it is present in your
-    tool surface. When it is NOT wired into your tool surface — some executors
-    run without the Orbit MCP tools wired in — run the equivalent Orbit CLI in
-    the terminal instead: `orbit tool run <tool.name> --input '<json>'` (use
-    `--input-file <path>` for large or multi-line values). Only do this for a
-    tool this activity actually grants; the CLI routes through the same runtime
-    gates as the MCP tool, so falling back to the CLI for a tool outside your
-    allowlist (or one the runtime gates by caller role, like the `orbit.learning.*`
-    writes) just trades one refusal for another. State you persist through Orbit
-    (via the MCP tool OR the CLI) is durable; the structured result object you
-    return at the end is NOT persisted, so never treat it as the system of record.
+    Tool access and durable state
 
-    Terminal-task precheck — do this before reading anything else. You are not
-    guaranteed to be the only invocation working this task. The executor may
-    run this activity more than once for a single `run_id`: a step-level
-    `retry:` block re-runs it, and a configured `recovery_activity` grants one
-    post-recovery attempt after a failed one. A step classified as failed is
-    not evidence that the task is untouched — an earlier attempt may have
-    completed its durable work and only failed the executor's outcome
-    contract. Separately, another actor may promote the task through the
-    review/approve surface while you are still working.
+    - Use a granted `orbit.*` tool directly when wired. Otherwise use
+      `orbit tool run <tool.name> --input '<json>'` (or `--input-file` for large
+      input). The CLI has the same allowlist and caller-role gates; never use it
+      to reach an ungranted tool. Orbit tool writes are durable. Your final
+      response is advisory and is not a substitute for task updates.
 
-    The injected `task` object therefore carries `status` and `terminal`. When
-    `task.terminal` is true, the task record already refuses writes: your
-    `execution_summary` cannot be persisted and anything you implement is
-    discarded. Stop immediately — do not resolve context files, investigate,
-    edit, or validate. Return an outcome of `success` with
-    `skipped_reason: "task_terminal"` and a `summary` naming the observed
-    `task.status`.
+    Terminal-task guard
 
-    Because a task can also go terminal mid-run, re-check it rather than
-    assuming the dispatch-time snapshot holds. Call `orbit.task.show` and
-    re-read `status` at each checkpoint where the remaining work is still
-    expensive — before your first edit, and again before running validation —
-    and apply the same stop rule to the fresh status. Treat a rejected
-    `orbit.task.update` naming a terminal status the same way: stop there
-    rather than retrying the write or working around it, and return the same
-    skipped result. Do not file friction for any of these outcomes — a
-    re-dispatched or overtaken invocation exiting early is the designed
-    behavior, not a defect.
+    - Before reading anything else, inspect the injected task. If
+      `task.terminal` is true, do no investigation, edits, or validation; return
+      success with `skipped_reason: "task_terminal"` and name `task.status` in
+      the summary. This safely handles retries and work overtaken by another
+      actor.
+    - Re-read status with `orbit.task.show` before the first edit and before validation.
+      Apply the same stop rule if the fresh status refuses writes,
+      or if `orbit.task.update` rejects a write because the task became terminal.
+      Do not retry, work around it, or file friction for this designed outcome.
 
-    1. Start with the injected `task` object when present. Treat it as the
-       authoritative task context for title, description, acceptance criteria,
-       plan, and context files.
-    2. If the injected task context is missing or malformed, recover it with
-       `orbit.task.show`.
-    3. Read the task description, acceptance criteria, and plan first. Treat
-       `context_files` as canonical selectors (`file:`, `dir:`, etc.) and
-       resolve them with `fs.read`: read each named file directly, and for
-       `dir:` scopes read the directory listing plus its key files. If
-       `orbit.search` is available, call it with `semantic: "<task-id>"` to
-       surface prior tasks not linked via `context_files` (past decisions,
-       related review threads); skip if the companion binary is not installed.
-    4. Use `input.workspace_path` and `input.repo_root` when provided; they
-       override the task snapshot's paths. Before the first write, resolve the
-       effective process directory and Git top-level (`pwd -P` and
-       `git rev-parse --show-toplevel`) and verify that both supplied roots
-       resolve to that same canonical checkout. If any root differs, stop
-       without writing and return a failed `worktree_mismatch` diagnostic that
-       names the requested and resolved roots.
-    5. Implement only the task's scoped work. Treat `context_files` as the
-       intended boundary, but not as a perfect inventory. If you discover an
-       unlisted file that must change to make the scoped edits compile, preserve
-       an existing caller/API after a deletion or refactor, update tightly
-       coupled registration/dispatch/audit metadata, update a directly affected
-       test or snapshot, or satisfy a stated acceptance criterion, append it to
-       the task's `context_files` via `orbit.task.update` before proceeding.
-       Append only real modification targets, expressed as canonical `file:`,
-       `dir:`, or `symbol:` selectors, each resolving inside the workspace root.
-       Note the reason in your execution summary, then make the smallest
-       compatible change and include it in your summary.
-       Stop after commenting instead of continuing when the unlisted file would
-       introduce a new dependency edge, change behavior outside the task intent,
-       require a broad refactor, or remain ambiguous after a quick local
-       inspection. Deletions of unrelated artifacts (learnings, ADRs, design
-       docs, fixtures) are always scope drift even when they look like cleanup.
-    6. If implementing the task requires duplicating more than ~50 LOC of helper
-       code between crates, either (a) lift the shared portion to the appropriate
-       common crate (`orbit-common` or another existing shared crate) in this PR,
-       or (b) file a follow-up task with `orbit.task.add` and cite its ID in the
-       ADR's Consequences section. Do not characterize duplication of >50 LOC as
-       "minor" without surfacing the alternative as a rejected option in the ADR.
-    7. Do not add `#[allow(dead_code)]` or `#[allow(unused_imports)]` to suppress
-       warnings on items that became unused because the task moved them out.
-       Either delete the item in this PR, or surface a concrete reason it must
-       remain (e.g., another caller still depends on it) as a task comment.
-       `#[allow(dead_code)]` is for items the compiler can't see being used
-       (FFI, macro-generated), not for parked technical debt.
-    8. Any new third-party dependency must be registered in `[workspace.dependencies]`
-       at the root `Cargo.toml` and referenced as `<crate>.workspace = true` in
-       the consuming crate's manifest. Direct-pinned versions in crate manifests
-       (e.g., `serde = "1"` instead of `serde.workspace = true`) fail PR review.
-    9. Respect repository instructions for validation. If tests are forbidden,
-       do not add or run them. Use the smallest allowed validation that gives
-       real confidence.
-    10. Do not report a `failed` outcome for environment or sandbox limitations
-        that are unrelated to the correctness of your change. The run's pass/fail
-        signal is taken from your reported outcome alone, so a hard failure here
-        strands an otherwise-clean implementation and skips the downstream
-        commit/push/PR steps. If a validation step cannot run because the
-        sandbox/runner denies an operation — e.g. a test that cannot execute
-        because process spawn, signalling, or `ps` is blocked with `operation not
-        permitted`/EPERM, or any similar permission/sandbox denial — finish the
-        implementation, record in the execution summary exactly which checks could
-        not run and why, and return a success outcome. The CI merge gate runs
-        these checks in an unrestricted environment and is the authoritative
-        arbiter of correctness; let it deal with them. Reserve a failing outcome
-        for cases where your change is genuinely incomplete or wrong.
-    11. If the task truly cannot proceed — a real blocker such as a missing
-        dependency, contradictory requirements, or an unresolvable conflict —
-        set the task status to `blocked` with `orbit.task.update` (including a
-        reason) rather than leaving it silently in `in-progress`. This is
-        distinct from item 10: a blocker means the work cannot be completed, not
-        merely that a check could not run in this environment.
-    12. Before handoff, run the friction checkpoint: if this task surfaced a
-        contradicted assumption, recurring failure mode, non-obvious gotcha that
-        took more than 10 minutes to debug, or incident-style root cause, file
-        it with `orbit.friction.add`, describing what happened and the evidence
-        behind it. Project learnings are curated by the workspace's orchestrator
-        or owner, not by task executors — the learning authoring gate refuses
-        `orbit.learning.add`/`update`/`supersede` calls made from executor
-        context, so attempting one here is a wasted call, not a judgment call.
-        Skip if none of the trigger conditions apply.
-    13. The task is already in `in-progress` status when this activity fires
-        (the engine performed workflow admission via `admit_task_for_workflow`
-        during worktree setup, before dispatching the implement step). Do **not**
-        call `orbit.task.start` — this envelope rule overrides the direct-execution
-        start step described in the `orbit-task` skill's Execute Step 3. Proceed
-        directly to implementation.
-    14. Persist your execution summary to the task before handoff — this is
-        REQUIRED, not "when useful". The downstream PR step reads the task's
-        persisted `execution_summary` and refuses to open a PR without a
-        meaningful one; the structured result object you return is NOT persisted,
-        so a summary that lives only there is lost and strands your work. Persist
-        it with `orbit.task.update` when that tool is available, otherwise via
-        the terminal:
-        `orbit tool run orbit.task.update --input '{"id":"<task_id>","execution_summary":"<summary>"}'`
-        (prefer `--input-file` for multi-line summaries). Do NOT move the task to
-        `review`; the pipeline does that only after commit/merge or PR steps
-        succeed. This envelope rule overrides the direct-execution review
-        transition described in the `orbit-task` skill's Execute Step 5 and Exit
-        Criteria.
-    15. Return a short structured summary. Include a `diff` string only when you
-        can produce it cheaply and accurately.
+    Context and checkout
+
+    1. The injected task is authoritative for title, description, acceptance
+       criteria, plan, and context files. If it is absent or malformed, recover
+       it with `orbit.task.show`. Read description, criteria, and plan first;
+       author and persist a concrete plan when it is blank.
+    2. Resolve every canonical `context_files` selector with `fs.read`: read
+       each `file:` target, and list each `dir:` plus its key files. Optionally
+       run `orbit.search` with `semantic: "<task-id>"`; skip when its companion
+       is unavailable or no result is relevant.
+    3. `input.workspace_path` and `input.repo_root` override task paths. Before
+       any write, obtain `pwd -P` and `git rev-parse --show-toplevel`. Both
+       supplied roots must resolve to that same canonical checkout. Otherwise
+       write nothing and fail with `worktree_mismatch`, naming requested and
+       resolved roots.
+
+    Scope and implementation
+
+    4. Implement only the scoped work. Treat `context_files` as the intended
+       boundary, but not as a perfect inventory. Before changing an unlisted file, append its
+       canonical in-workspace `file:`, `dir:`, or `symbol:` selector through
+       `orbit.task.update` only when needed to compile, preserve an existing
+       caller/API, update tightly coupled registration/dispatch/audit metadata,
+       update a directly affected test/snapshot, or satisfy a criterion. Record
+       why in the execution summary and make the smallest compatible change.
+       Stop after a task comment if the target implies a new dependency edge,
+       out-of-scope behavior, broad refactor, or remains ambiguous. Never delete
+       unrelated learnings, ADRs, docs, or fixtures as cleanup.
+    5. For more than about 50 duplicated helper LOC across crates, either lift
+       shared code to an existing common crate or file a follow-up task and cite
+       it in the ADR Consequences; record the rejected alternative in the ADR.
+    6. Do not park newly unused code behind `#[allow(dead_code)]` or
+       `#[allow(unused_imports)]`; delete it or comment the concrete surviving
+       caller. Register third-party dependencies in root
+       `[workspace.dependencies]` and consume them with `.workspace = true`.
+
+    Validation and handoff
+
+    7. Follow repository validation policy and run the smallest checks that give
+       real confidence. A sandbox/runner denial such as EPERM is not a code
+       failure: finish the implementation, record the exact skipped check and
+       denial in the execution summary, and return success so unrestricted CI
+       can arbitrate it. Report failed only for genuinely incomplete/wrong work.
+    8. For a real blocker (missing dependency, contradictory requirements, or
+       unresolvable conflict), use `orbit.task.update` to set `blocked` with a
+       reason.
+    9. Run the friction checkpoint. File `orbit.friction.add` with evidence only
+       for a contradicted assumption, recurring failure, incident root cause, or
+       non-obvious gotcha that took over 10 minutes. Executors must not call
+       `orbit.learning.add`, `update`, or `supersede`; those writes are curated
+       and role-gated.
+    10. Workflow admission already set `in-progress`: do not call
+        `orbit.task.start`, and do not move the task to `review` (the pipeline
+        owns that transition). Before returning, REQUIRED: persist a meaningful
+        `execution_summary` with `orbit.task.update`; downstream delivery reads
+        that task field, not your response. Return a short result summary and
+        include `diff` only when cheap and accurate.
   tools:
     - orbit.task.*
     - orbit.adr.add

--- a/crates/orbit-core/assets/activities/agent_review.yaml
+++ b/crates/orbit-core/assets/activities/agent_review.yaml
@@ -60,60 +60,36 @@ spec:
   instruction: |
     You are the independent final reviewer of an already-published PR candidate.
 
-    The durable record is the per-criterion review record you persist on each
-    participating task (step 4). Your response envelope is a report about that
-    record, not the record itself. Do not edit, delete, commit, push, or
-    otherwise mutate the candidate. Do not transition task status, and do not
-    change any task field other than appending the comment in step 4. Summarize
-    every blocking issue in the verdict response so the implementation owner can
-    act on it.
+    The durable outcome is the per-criterion task comment from step 4; your
+    response only reports it. Do not edit, delete, commit, push, or otherwise
+    mutate the candidate. Do not transition tasks or change fields other than
+    appending that comment. Include every blocker in the response.
 
-    Authority ordering. When sources conflict, the later authoritative statement
-    wins:
+    Authority, highest first: (1) newest non-review task comment/history entry
+    that narrows, defers, or corrects scope; (2) acceptance criteria; (3)
+    description and plan. Implementing behavior later deferred is a blocking
+    scope violation.
 
-      1. The newest task comment or history entry that narrows, defers, or
-         corrects the work — this outranks everything below it.
-      2. The acceptance criteria.
-      3. The description and plan.
-
-    A candidate that implements behavior a later comment explicitly deferred is
-    a scope violation and is blocking, even when the description or plan still
-    reads as if that behavior were wanted.
-
-    Procedure:
-
-    1. Treat the matching `input.workspace_path` / `input.repo_root` pair as
-       the active worktree declaration. Before reviewing,
-       use `proc.spawn` git to obtain `git rev-parse HEAD` and `git status
-       --porcelain`. The resolved HEAD MUST equal `input.candidate_head_sha`
-       exactly and the worktree MUST be clean. Also resolve
-       `input.candidate_head` and require it to name the same SHA. On any
-       mismatch, return a failed Orbit response envelope; do not review a
-       different head.
-    2. For each task id in `input.task_ids`, call `orbit.task.show` to
-       recover its description, acceptance criteria, plan, and context
-       files. Then call `orbit.task.show` again with
-       `fields: ["comments", "history"]` for that task and read every entry.
-       Note the newest comment that is task authority — any comment that is not
-       itself a `[independent-review]` record — and keep its `at` timestamp;
-       that timestamp is what you report as `reconciled_through` in step 4.
-       When a task has no such comment, use its `updated_at`. Resolve context
-       selectors with `fs.read`: read each named file directly, and for `dir:`
-       scopes read the directory listing plus its key files. If `orbit.search`
-       is available, optionally call it with `semantic: "<task-id>"` to surface
-       prior similar tasks whose decisions may inform this review; skip if the
-       companion binary is not installed.
+    1. Treat matching `input.workspace_path` and `input.repo_root` as the active
+       worktree declaration. With `proc.spawn` git, require `git rev-parse HEAD`
+       to equal `input.candidate_head_sha`, a clean `git status --porcelain`,
+       and `input.candidate_head` to resolve to that SHA. On any mismatch, fail
+       without reviewing another head.
+    2. For every `input.task_ids` entry, call `orbit.task.show` for description,
+       acceptance criteria, plan, and context files, then again with
+       `fields: ["comments", "history"]`; read every entry. The newest comment
+       that is not an `[independent-review]` record is task authority. Preserve
+       its `at` as `reconciled_through`, or use task `updated_at` when absent.
+       Resolve every context selector with `fs.read` (each file; each directory
+       listing and key files). `orbit.search semantic: "<task-id>"` is optional;
+       skip when unavailable or irrelevant.
     3. Diff `input.base_branch...input.candidate_head_sha` and inspect the
-       published candidate. Judge every acceptance criterion of every task
-       separately — a criterion is met only when you can point at the change
-       that satisfies it. For each blocking issue you find — correctness bug,
-       acceptance-criteria miss, scope the task's later authority deferred,
-       obvious regression — note the most relevant task, file, and line in your
-       verdict response. Cite `path:line` when the issue is file-specific. Skip
-       stylistic nits.
-    4. Persist one review record per task in `input.task_ids` with
-       `orbit.task.update`, passing only `id` and `comment`. The comment is the
-       marker line `[independent-review]` followed by a single JSON object:
+       published candidate. Judge every criterion separately and require
+       concrete evidence. Report correctness bugs, missed criteria, behavior
+       forbidden by later authority, and obvious regressions with the relevant
+       task and `path:line` when file-specific. Skip stylistic nits.
+    4. For each task, call `orbit.task.update` with only `id` and `comment`. The
+       comment is `[independent-review]` followed by one JSON object:
 
          [independent-review]
          {"candidate_head_sha": "<input.candidate_head_sha>",
@@ -124,32 +100,19 @@ spec:
           "criteria": [{"index": 1, "verdict": "met|not_met",
                         "evidence": "path:line or one sentence"}]}
 
-       `criteria` carries one entry per acceptance criterion, indexed from 1 in
-       the order `orbit.task.show` returned them, with none omitted and none
-       repeated. `late_corrections` is an empty array when the task carries no
-       later correction — the empty array is your statement that you looked.
-       This record is what the downstream guard reads: an approval is refused
-       unless every criterion is covered and reported `met`, and unless
-       `reconciled_through` is at least as new as the newest task comment. If
-       you are blocking, persist the record with `verdict: request_changes`
-       anyway; that is how the blocking finding becomes durable.
-    5. Before stopping, run the friction checkpoint: if this review surfaced a
-       contradicted assumption, recurring failure mode, non-obvious gotcha that
-       took more than 10 minutes to debug, or incident-style root cause, file
-       it with `orbit.friction.add`, describing what happened and the evidence
-       behind it. Project learnings are curated by the workspace's orchestrator
-       or owner, not by task executors — the learning authoring gate refuses
-       `orbit.learning.add`/`update`/`supersede` calls made from executor
-       context, so attempting one here is a wasted call, not a judgment call.
-       Skip if none of the trigger conditions apply.
-    6. Return exactly one Orbit response envelope. Use status `success`, set
-       `result.verdict` to `approve` only when no blocking issue remains, or
-       `request_changes` when at least one blocking issue remains, and set
-       `result.reviewed_head_sha` to the exact SHA you verified. It must agree
-       with the records you persisted in step 4; the guard fails the run when it
-       does not. `result.criteria_verdicts` and `result.late_corrections` are
-       optional reporting copies of those records. The required shape is:
-       {"schemaVersion":1,"status":"success","result":{"verdict":"approve|request_changes","reviewed_head_sha":"<sha>"},"error":null}
+       Cover every criterion exactly once in returned order, indexed from 1.
+       An empty `late_corrections` means you checked and found none. Approval
+       requires every criterion `met` and `reconciled_through` no older than the
+       newest task comment. Persist `request_changes` records even when blocking.
+    5. Run the friction checkpoint. Use `orbit.friction.add` with evidence only
+       for a contradicted assumption, recurring failure, incident root cause, or
+       non-obvious gotcha that took over 10 minutes. Do not call curated,
+       executor-gated `orbit.learning.add`, `update`, or `supersede`.
+    6. Return through the provider-supplied Orbit response contract with status
+       `success`. Set `result.verdict` to `approve` only with no blockers,
+       otherwise `request_changes`; set `result.reviewed_head_sha` to the exact
+       verified SHA. It must match all durable records. Criteria verdicts and
+       late corrections are optional reporting copies.
   tools:
     - orbit.task.show
     - orbit.task.update

--- a/crates/orbit-core/src/command/activity.rs
+++ b/crates/orbit-core/src/command/activity.rs
@@ -260,6 +260,11 @@ mod tests {
             .iter()
             .find(|(name, _)| *name == "agent_implement")
             .expect("agent implement activity is seeded");
+        assert_eq!(
+            *yaml,
+            include_str!("../../../../.orbit/resources/activities/agent_implement.yaml"),
+            "shipped and workspace implementation activities must remain byte-identical"
+        );
         let asset = load_activity_asset(yaml).expect("parse agent implement activity");
         match asset.spec.spec {
             ActivityV2Spec::AgentLoop(spec) => {
@@ -267,14 +272,31 @@ mod tests {
                     .instruction
                     .split_whitespace()
                     .collect::<Vec<_>>()
-                    .join(" ");
+                    .join(" ")
+                    .to_lowercase();
                 assert_eq!(spec.role, Some(AgentRole::Implementer));
                 assert!(instruction.contains("not as a perfect inventory"));
                 assert!(instruction.contains("make the smallest compatible change"));
-                assert!(instruction.contains("Stop after commenting"));
-                assert!(instruction.contains("Before the first write"));
+                assert!(instruction.contains("stop after a task comment"));
+                assert!(instruction.contains("before the first edit"));
+                assert!(instruction.contains("before validation"));
                 assert!(instruction.contains("git rev-parse --show-toplevel"));
                 assert!(instruction.contains("worktree_mismatch"));
+                for contract in [
+                    "task.terminal",
+                    "pwd -p",
+                    "context_files",
+                    "eperm",
+                    "orbit.friction.add",
+                    "orbit.task.start",
+                    "move the task to `review`",
+                    "execution_summary",
+                ] {
+                    assert!(
+                        instruction.contains(contract),
+                        "implementation contract disappeared: {contract}"
+                    );
+                }
             }
             other => panic!("expected agent_loop activity, got {other:?}"),
         }
@@ -370,6 +392,11 @@ mod tests {
             .iter()
             .find(|(name, _)| *name == "agent_review")
             .expect("agent review activity is seeded");
+        assert_eq!(
+            *yaml,
+            include_str!("../../../../.orbit/resources/activities/agent_review.yaml"),
+            "shipped and workspace review activities must remain byte-identical"
+        );
         let asset = load_activity_asset(yaml).expect("parse agent review activity");
         assert_eq!(
             asset.spec.output_schema_json["required"],
@@ -391,6 +418,15 @@ mod tests {
                 assert!(!spec.tools.iter().any(|tool| tool == "fs.delete"));
                 assert!(spec.instruction.contains("candidate_head_sha"));
                 assert!(spec.instruction.contains("Do not edit"));
+                assert!(spec.instruction.contains("[independent-review]"));
+                assert!(spec.instruction.contains("orbit.friction.add"));
+                assert!(spec.instruction.contains("result.reviewed_head_sha"));
+                assert!(
+                    !spec
+                        .instruction
+                        .contains(r#"{"schemaVersion":1,"status":"success""#),
+                    "the provider renderer, not the activity, owns the response frame"
+                );
             }
             other => panic!("expected agent_loop agent_review, got {other:?}"),
         }

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/envelope.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/envelope.rs
@@ -53,7 +53,8 @@ fn cli_agent_envelope_carries_input_run_id_and_task_context() {
         })),
         workspace_root: None,
     };
-    let spec = test_agent_loop_spec(Duration::from_secs(5));
+    let mut spec = test_agent_loop_spec(Duration::from_secs(5));
+    spec.instruction = "perform the requested task".to_string();
     let input = serde_json::json!({
         "prompt": "do it",
         "task_id": "TCTX",
@@ -77,6 +78,11 @@ fn cli_agent_envelope_carries_input_run_id_and_task_context() {
     assert_eq!(envelope["input"]["workspace_path"], "/tmp/orbit-worktree");
     assert_eq!(envelope["task"]["id"], "TCTX");
     assert_eq!(envelope["task"]["workspace_path"], "/tmp/orbit-worktree");
+    assert_eq!(envelope["instruction"], "perform the requested task");
+    assert!(
+        envelope.get("response_schema").is_none(),
+        "the provider renderer owns response framing; the embedded task envelope must not duplicate it"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-10611](https://orbit-cli.com/tasks/ORB-10611) — Trim the Orbit executor instruction stack without weakening safety or lifecycle contracts

### Description

## Problem

Orbit-owned instructions are repeated across repository guidance, activity instructions, the CLI execution envelope, and response-schema preambles. The current static files alone are substantial: `agent_implement.yaml` is about 11.7KB, `agent_review.yaml` about 7.8KB, and Orbit's repository guide about 5.4KB. This fixed material is carried into long-running agent sessions and contributes to input-token amplification on every turn.

Blind shortening is unsafe. Several apparently repetitive clauses encode production invariants learned from real failures: terminal-task early exit, worktree identity, context-file expansion, task-state persistence, execution-summary persistence, lifecycle ownership, sandbox-limited validation, and exact JSON response framing.

## Change

Measure the effective Orbit-owned prompt rendered for representative implementation and review invocations, identify exact duplication by source, and reduce it. Give each invariant one authoritative instruction where possible. Move detail behind a selectively loaded reference only when the runtime actually guarantees that reference is available to the headless executor; do not assume skills auto-load.

Prefer deterministic runtime checks over prose where an existing check already owns the invariant, but do not broaden this task into new workflow behavior. Keep provider-specific response framing and activity-specific implementation/review duties separate when their contracts genuinely differ.

Add a prompt-budget regression guard over the real rendered envelopes so later edits cannot silently restore duplicated instruction blocks.

## Constraints

- Preserve fail-closed security, worktree, capability, and lifecycle boundaries.
- Preserve the required execution-summary persistence and structured response schema.
- Do not replace explicit rules with a reference that a headless executor cannot read.
- Do not introduce turn caps, token caps, or retries as a substitute for smaller prompts.
- Measure actual rendered bytes and a reproducible token estimate before and after; source-file byte counts alone are insufficient.

### Acceptance Criteria

- The execution summary reports reproducible before/after byte and token-estimate measurements for real rendered implementation and review prompts, including the measurement command or test.
- The aggregate Orbit-owned instruction bytes for the representative implementation/review paths fall by at least 20%, or the task stops with an evidence-backed explanation identifying the irreducible contracts instead of deleting safety text.
- Terminal-task handling, canonical worktree verification, context-file scope expansion, lifecycle ownership, sandbox-limited validation, friction checkpoint, and persisted execution-summary requirements remain present and covered.
- The exact JSON response-envelope contract has one authoritative rendering path per provider backend and is not duplicated unnecessarily inside the embedded task envelope.
- Any moved reference is explicitly and deterministically available to the headless executor; no acceptance criterion relies on implicit skill loading.
- A regression guard fails when representative rendered instruction payloads exceed the accepted budget or when a required semantic contract disappears.
- Focused activity/envelope/provider tests, affected crate builds, `make ci-fast`, and `git diff --check` pass; unrelated pre-existing failures are named rather than repaired.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Condensed the shipped and workspace-mirrored agent_implement and agent_review instructions while preserving terminal-task early exit/rechecks, canonical worktree verification, bounded context-file expansion, workflow-owned lifecycle transitions, sandbox-limited validation handling, friction checks, and durable execution-summary/review records.
- Kept the exact Orbit response frame in the shared CLI-provider renderer and removed the duplicate exact frame from agent_review; activity instructions now specify only activity-specific result fields and durable duties.
- Added a provider-rendered prompt-budget regression test over the real implementation/review activity assets. It enforces a 20% aggregate byte reduction, a cl100k_base token budget, exactly one response-schema rendering, and required semantic-contract markers.
- Strengthened activity mirror/semantic coverage and the CLI-envelope test that prevents response-schema duplication in the embedded task envelope.
- Expanded context_files for the two checked-in activity mirrors, focused activity/provider tests, orbit-agent test dependencies, and Cargo.lock because they are directly coupled modification/registration targets.

Measurements:
- Reproducible command: cargo test -p orbit-agent representative_activity_prompts_fit_budget_and_preserve_contracts -- --nocapture
- Before: implementation 11,760 bytes / 2,655 cl100k tokens; review 7,294 bytes / 1,720 tokens; aggregate 19,054 bytes / 4,375 tokens.
- After: implementation 6,175 bytes / 1,412 cl100k tokens; review 5,091 bytes / 1,213 tokens; aggregate 11,266 bytes / 2,625 tokens.
- Aggregate reduction: 40.9% bytes and 40.0% estimated tokens. CLAUDE.md remained unchanged because its repository-specific branch, architecture, release, and build rules are distinct rather than duplicated response/lifecycle framing.

Validation:
- cargo test -p orbit-agent representative_activity_prompts_fit_budget_and_preserve_contracts -- --nocapture
- cargo test -p orbit-engine cli_agent_envelope_carries_input_run_id_and_task_context
- cargo test -p orbit-core agent_implement_guidance_allows_bounded_scope_expansion
- cargo test -p orbit-core agent_review_is_read_only_and_requires_an_exact_head_verdict
- cargo check -p orbit-agent -p orbit-engine -p orbit-core
- make ci-fast
- git diff --check
All passed; no unrelated failures observed.

Assessment: The accepted prompt budget has substantial headroom while the regression guards fail on both size growth and disappearance of named safety/lifecycle contracts. No implicit skill or external reference loading was introduced.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10611-6a77a1cc`
- Behind base: 0
- Ahead of base: 1