### PR TITLE
Reject legacy crew role sub-tables at config load

### DIFF
--- a/crates/orbit-core/src/config/raw.rs
+++ b/crates/orbit-core/src/config/raw.rs
@@ -48,13 +48,14 @@ pub struct RawCrewEntry {
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
-    /// Legacy three-role fields retained for compatibility. Runtime loading
-    /// selects `implementer` and warns when the discarded roles diverge.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Retired role tables are retained only to reject stale configuration
+    /// with rewrite guidance at load time. They are not part of the crew
+    /// schema and never participate in assignment resolution or serialization.
+    #[serde(default, skip_serializing)]
     pub planner: Option<RawAgentRoleConfig>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing)]
     pub implementer: Option<RawAgentRoleConfig>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing)]
     pub reviewer: Option<RawAgentRoleConfig>,
 }
 

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -347,7 +347,6 @@ fn load_layered_runtime(
                 set_value_at_path(&mut merged, descriptor.key, value.clone());
             }
         }
-        reconcile_layered_crew_shapes(&mut merged, global.as_ref(), workspace_document);
         for key in WORKSPACE_REPLACE_ONLY_KEYS {
             if value_at_path(&workspace_document.value, key).is_none() {
                 remove_value_at_path(&mut merged, key);
@@ -372,65 +371,6 @@ fn load_layered_runtime(
         global,
         workspace,
     })
-}
-
-fn reconcile_layered_crew_shapes(
-    merged: &mut toml::Value,
-    global: Option<&ConfigDocument>,
-    workspace: &ConfigDocument,
-) {
-    let Some(workspace_crews) = value_at_path(&workspace.value, "crews").and_then(|v| v.as_table())
-    else {
-        return;
-    };
-    let Some(merged_crews) = value_at_path_mut(merged, "crews").and_then(|v| v.as_table_mut())
-    else {
-        return;
-    };
-
-    for (name, workspace_crew) in workspace_crews {
-        let Some(workspace_crew) = workspace_crew.as_table() else {
-            continue;
-        };
-        let has_flat = ["model", "provider", "backend"]
-            .iter()
-            .any(|field| workspace_crew.contains_key(*field));
-        let has_legacy = ["planner", "implementer", "reviewer"]
-            .iter()
-            .any(|field| workspace_crew.contains_key(*field));
-        // Preserve the normal validation error when one physical entry mixes
-        // both schemas. Only reconcile a shape boundary between two layers.
-        if has_flat == has_legacy {
-            continue;
-        }
-        let Some(merged_crew) = merged_crews.get_mut(name).and_then(|v| v.as_table_mut()) else {
-            continue;
-        };
-        if has_flat {
-            // A partial flat workspace entry may inherit missing assignment
-            // fields from a legacy global entry's implementer assignment.
-            if let Some(global_implementer) = global
-                .and_then(|document| crew_entry(&document.value, name))
-                .and_then(|crew| crew.get("implementer"))
-                .and_then(|value| value.as_table())
-            {
-                for field in ["model", "provider", "backend"] {
-                    if !merged_crew.contains_key(field)
-                        && let Some(value) = global_implementer.get(field)
-                    {
-                        merged_crew.insert(field.to_string(), value.clone());
-                    }
-                }
-            }
-            for field in ["planner", "implementer", "reviewer"] {
-                merged_crew.remove(field);
-            }
-        } else {
-            for field in ["model", "provider", "backend"] {
-                merged_crew.remove(field);
-            }
-        }
-    }
 }
 
 fn read_config_document(path: &Path) -> Result<Option<ConfigDocument>, OrbitError> {
@@ -479,14 +419,6 @@ fn value_at_path<'a>(document: &'a toml::Value, key: &str) -> Option<&'a toml::V
     let mut value = document;
     for segment in key.split('.') {
         value = value.as_table()?.get(segment)?;
-    }
-    Some(value)
-}
-
-fn value_at_path_mut<'a>(document: &'a mut toml::Value, key: &str) -> Option<&'a mut toml::Value> {
-    let mut value = document;
-    for segment in key.split('.') {
-        value = value.as_table_mut()?.get_mut(segment)?;
     }
     Some(value)
 }
@@ -626,11 +558,7 @@ fn source_for_crew_field(
     ] {
         if let Some(document) = document
             && let Some(entry) = crew_entry(&document.value, crew)
-            && (entry.contains_key(field)
-                || entry
-                    .get("implementer")
-                    .and_then(|value| value.as_table())
-                    .is_some_and(|implementer| implementer.contains_key(field)))
+            && entry.contains_key(field)
         {
             return file_source(kind, &document.path);
         }
@@ -747,60 +675,16 @@ fn crew_assignment_from_raw(
     crew: &str,
     raw: &RawCrewEntry,
 ) -> Result<CrewRoleAssignment, OrbitError> {
-    let has_flat = raw.model.is_some() || raw.provider.is_some() || raw.backend.is_some();
     let has_legacy = raw.planner.is_some() || raw.implementer.is_some() || raw.reviewer.is_some();
-    if has_flat && has_legacy {
+    if has_legacy {
         return Err(OrbitError::InvalidInput(format!(
-            "[crews.{crew}] mixes the flat {{ model, provider, backend }} shape with legacy planner/implementer/reviewer assignments"
+            "[crews.{crew}] uses retired planner/implementer/reviewer role tables; rewrite it with flat `model`, `provider`, and `backend` fields only"
         )));
     }
-    if has_flat {
-        return Ok(CrewRoleAssignment {
-            model: required_crew_field(crew, "model", raw.model.as_deref())?,
-            provider: required_crew_field(crew, "provider", raw.provider.as_deref())?,
-            backend: required_crew_field(crew, "backend", raw.backend.as_deref())?,
-        });
-    }
-
-    let implementer = required_legacy_assignment(crew, "implementer", raw.implementer.as_ref())?;
-    let planner = required_legacy_assignment(crew, "planner", raw.planner.as_ref())?;
-    let reviewer = required_legacy_assignment(crew, "reviewer", raw.reviewer.as_ref())?;
-    if planner != implementer || reviewer != implementer {
-        tracing::warn!(
-            target: "orbit.config.crew",
-            crew,
-            "legacy three-role crew assignments diverge; using implementer for every role — rewrite [crews.<name>] with flat model/provider/backend fields",
-        );
-    }
-    Ok(implementer)
-}
-
-fn required_legacy_assignment(
-    crew: &str,
-    role: &str,
-    raw: Option<&RawAgentRoleConfig>,
-) -> Result<CrewRoleAssignment, OrbitError> {
-    let raw = raw.ok_or_else(|| {
-        OrbitError::InvalidInput(format!(
-            "[crews.{crew}] must define {role} = {{ model, provider, backend }}"
-        ))
-    })?;
     Ok(CrewRoleAssignment {
-        model: required_legacy_field(crew, role, "model", raw.model.as_deref())?,
-        provider: required_legacy_field(crew, role, "provider", raw.provider.as_deref())?,
-        backend: required_legacy_field(crew, role, "backend", raw.backend.as_deref())?,
-    })
-}
-
-fn required_legacy_field(
-    crew: &str,
-    role: &str,
-    field: &str,
-    value: Option<&str>,
-) -> Result<String, OrbitError> {
-    let value = value.map(str::trim).filter(|value| !value.is_empty());
-    value.map(ToOwned::to_owned).ok_or_else(|| {
-        OrbitError::InvalidInput(format!("[crews.{crew}].{role}.{field} must not be empty"))
+        model: required_crew_field(crew, "model", raw.model.as_deref())?,
+        provider: required_crew_field(crew, "provider", raw.provider.as_deref())?,
+        backend: required_crew_field(crew, "backend", raw.backend.as_deref())?,
     })
 }
 

--- a/crates/orbit-core/src/config/tests/runtime.rs
+++ b/crates/orbit-core/src/config/tests/runtime.rs
@@ -343,6 +343,22 @@ default_crew = "codex"
 }
 
 #[test]
+fn absent_crews_use_built_in_defaults() {
+    let config = load_config("[scoring]\nenabled = true\n").expect("config without crews loads");
+
+    assert_eq!(config.crews, default_crews());
+    assert_eq!(config.default_crew.as_deref(), Some("opus"));
+}
+
+#[test]
+fn explicitly_empty_crews_preserve_an_empty_registry() {
+    let config = load_config("[crews]\n").expect("empty crew registry loads");
+
+    assert!(config.crews.is_empty());
+    assert_eq!(config.default_crew, None);
+}
+
+#[test]
 fn default_crew_must_reference_defined_crew() {
     let global = tempdir().expect("global tempdir");
     let workspace = tempdir().expect("workspace tempdir");
@@ -468,8 +484,8 @@ provider = "codex"
 }
 
 #[test]
-fn legacy_divergent_crew_uses_implementer_assignment() {
-    let config = load_config(
+fn legacy_role_tables_fail_with_flat_shape_rewrite_guidance() {
+    let error = load_config(
         r#"
 [crews.legacy]
 planner = { model = "planner-model", provider = "claude", backend = "cli" }
@@ -480,11 +496,49 @@ reviewer = { model = "reviewer-model", provider = "gemini", backend = "cli" }
 default_crew = "legacy"
 "#,
     )
-    .expect("legacy crew loads");
+    .expect_err("legacy role tables must fail config load");
+    let message = error.to_string();
 
-    let crew = config.crews.get("legacy").expect("legacy crew");
-    assert_eq!(crew.assignment.model, "implementer-model");
-    assert_eq!(crew.assignment.provider, "codex");
+    for expected in [
+        "[crews.legacy]",
+        "planner/implementer/reviewer",
+        "model",
+        "provider",
+        "backend",
+    ] {
+        assert!(
+            message.contains(expected),
+            "expected {message:?} to contain {expected:?}"
+        );
+    }
+}
+
+#[test]
+fn flat_crew_mixed_with_role_tables_fails_with_flat_shape_rewrite_guidance() {
+    let error = load_config(
+        r#"
+[crews.mixed]
+model = "gpt-test"
+provider = "codex"
+backend = "cli"
+implementer = { model = "gpt-test", provider = "codex", backend = "cli" }
+"#,
+    )
+    .expect_err("mixed crew shape must fail config load");
+    let message = error.to_string();
+
+    for expected in [
+        "[crews.mixed]",
+        "planner/implementer/reviewer",
+        "model",
+        "provider",
+        "backend",
+    ] {
+        assert!(
+            message.contains(expected),
+            "expected {message:?} to contain {expected:?}"
+        );
+    }
 }
 
 #[test]
@@ -621,7 +675,7 @@ model = "workspace-model"
 }
 
 #[test]
-fn flat_workspace_crew_can_layer_over_legacy_global_crew() {
+fn layered_config_rejects_legacy_global_crew_before_flat_workspace_override() {
     let global = tempdir().expect("global tempdir");
     let workspace = tempdir().expect("workspace tempdir");
     write_config(
@@ -644,13 +698,15 @@ model = "new-model"
 "#,
     );
 
-    let config = RuntimeConfig::load_layered(global.path(), workspace.path())
-        .expect("cross-shape layered crew config loads");
-    let build = config.crews.get("build").expect("build crew");
+    let error = RuntimeConfig::load_layered(global.path(), workspace.path())
+        .expect_err("legacy global crew must not be masked by workspace fields");
+    let message = error.to_string();
 
-    assert_eq!(build.assignment.model, "new-model");
-    assert_eq!(build.assignment.provider, "codex");
-    assert_eq!(build.assignment.backend, "cli");
+    assert!(message.contains("[crews.build]"), "{message}");
+    assert!(
+        message.contains("planner/implementer/reviewer"),
+        "{message}"
+    );
 }
 
 #[test]
@@ -712,11 +768,26 @@ model = "workspace-model"
         values["crews.build.provider"].source.kind(),
         ConfigValueSourceKind::Global
     );
+    assert_eq!(
+        values["crews.build.backend"].source.kind(),
+        ConfigValueSourceKind::Global
+    );
     let workspace_config_path = workspace.path().join("config.toml");
     assert_eq!(
         values["scoring.enabled"].source.path(),
         Some(workspace_config_path.as_path())
     );
+    let global_config_path = global.path().join("config.toml");
+    assert_eq!(
+        values["crews.build.model"].source.path(),
+        Some(workspace_config_path.as_path())
+    );
+    for key in ["crews.build.provider", "crews.build.backend"] {
+        assert_eq!(
+            values[key].source.path(),
+            Some(global_config_path.as_path())
+        );
+    }
 }
 
 #[test]

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -84,13 +84,15 @@ You can define any number of crews. Set the workspace-wide fallback with `workfl
 
 Crew metadata is canonical runtime data, not display-only TOML. Orbit trims
 `description` (blank becomes absent), trims each tag, drops blank tags, and stores
-tags in sorted deduplicated order. Legacy crew entries without these fields
-normalize to no description and an empty tag list. Owner execution-profile
-publication carries this complete projection to the hub; publication is stricter
-than legacy dispatch compatibility and fails closed if provider or backend cannot
-be canonicalized to a concrete executable combination.
+tags in sorted deduplicated order. Owner execution-profile publication carries
+this complete projection to the hub and fails closed if provider or backend
+cannot be canonicalized to a concrete executable combination.
 
-> **Legacy compatibility.** Orbit still accepts the former `planner` / `implementer` / `reviewer` inline-table shape. It uses the `implementer` assignment for every role and logs an `orbit.config.crew` warning when planner or reviewer differs. Rewrite legacy crews to the flat shape above; cross-provider comparison belongs in the duel system.
+> **Retired crew shape.** `planner`, `implementer`, and `reviewer` sub-tables
+> are no longer accepted in a crew entry. A workspace using that old shape must
+> rewrite every `[crews.<name>]` entry to set flat `model`, `provider`, and
+> `backend` fields before Orbit can load its configuration. Use the duel system
+> for cross-provider comparison.
 
 > **Note.** Earlier Orbit versions used `[agent.<role>]` tables. That schema was removed in [ORB-00058](../.orbit/) — config load now hard-errors if `[agent.*]` is present. Migrate to `[crews.<name>]` + `workflow.default_crew`.
 

--- a/docs/design/agent-families/2_design.md
+++ b/docs/design/agent-families/2_design.md
@@ -3,7 +3,7 @@ summary: "Agent Families — Design"
 type: design
 title: "Agent Families — Design"
 owner: human
-last_updated: 2026-07-27
+last_updated: 2026-08-09
 last_validated: 2026-07-27
 status: Draft
 feature: agent-families
@@ -27,7 +27,7 @@ Adding a family is still a cross-cutting change: executor assets, sandbox behavi
 
 Workspace config defines one concrete assignment under each `[crews.<name>]`: flat `model`, `provider`, and `backend` fields. Activity roles remain labels, but all resolve through the same assignment.
 
-`crates/orbit-core/src/config/raw.rs` owns the TOML shape, and `crates/orbit-core/src/config/runtime.rs` materializes it into `Crew` values from `orbit-common`. Runtime loading rejects incomplete crews and rejects `[workflow].default_crew` when it does not name a defined crew.
+`crates/orbit-core/src/config/raw.rs` owns the TOML shape, and `crates/orbit-core/src/config/runtime.rs` materializes it into `Crew` values from `orbit-common`. Runtime loading rejects incomplete crews, retired `planner`/`implementer`/`reviewer` role sub-tables with guidance to write flat `model`, `provider`, and `backend` fields, and `[workflow].default_crew` values that do not name a defined crew.
 
 The built-in runtime registry uses model-specific standard crews: Claude provides `opus`, `sonnet`, and `fable`; Codex provides `sol`, `terra`, and `luna`; Gemini provides `gemini`; and Grok provides `grok`. Fresh `orbit init` config filters that registry by detected provider CLIs, always writes `backend = "cli"`, and chooses the first emitted standard crew as `[workflow].default_crew` (`opus`, `sol`, `gemini`, or `grok`). It adds `qa` on Terra when Codex is available, otherwise on Sonnet when Claude is available. With no supported provider CLI, initialization emits neither crews nor a dangling default.
 
@@ -72,5 +72,6 @@ Task-level per-role overrides were deferred; today a task picks an entire crew, 
 - ORB-00058: Introduce per-task crew override for agent model selection.
 - ORB-00072: Make duel-plan agent pool and per-family model configurable via `[duel]`.
 - ORB-10315: Seed model-specific crews only for providers available during initialization.
+- ORB-10620: Reject retired crew role sub-tables during config load.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/agent-families/4_decisions.md
+++ b/docs/design/agent-families/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Agent Families — Decisions"
 type: design
 title: "Agent Families — Decisions"
 owner: grok
-last_updated: 2026-08-01
+last_updated: 2026-08-09
 last_validated: 2026-07-27
 status: Draft
 feature: agent-families
@@ -106,17 +106,18 @@ Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.
 
 ## ADR-0213 — Flatten crews to one provider-model assignment
 
-**Status:** Accepted · 2026-07-11 · [ORB-10130] · supersedes ADR-0154
+**Status:** Accepted · 2026-07-11 · [ORB-10130] · amended by ADR-0330 and [ORB-10620] · supersedes ADR-0154
 
 **Context.** Named crews carried separate planner, implementer, and reviewer assignments, but production crews were homogeneous and only implementer was on the primary ship path. Role labels still matter for prompts and telemetry; three independent model-selection slots added configuration and persistence complexity without selecting distinct behavior.
 
-**Decision.** A crew is one provider-model-backend assignment. Every activity role resolves to it; role labels remain descriptive, duel participant selection stays independent, and legacy three-role config is accepted by choosing implementer while warning when discarded roles diverge.
+**Decision.** A crew is one provider-model-backend assignment. Every activity role resolves to it and duel participant selection stays independent. ADR-0330 retires the former three-role crew tables: config loading rejects them with guidance to write the flat `model`, `provider`, and `backend` fields.
 
 **Consequences.**
 - Per-task and default crew selection directly choose one provider-model binding.
 - Run records and projections expose one crew model; legacy SQLite role columns remain nullable for compatibility.
-- Existing homogeneous legacy crew configuration continues to load without behavior changes.
-- Cost: deliberately heterogeneous legacy crews collapse to their implementer assignment and require a warning-guided config rewrite; cross-provider review must use duel machinery or a future explicit mechanism.
+- Cost: workspaces using the retired role-table schema must rewrite their crew entries before config can load; cross-provider review must use duel machinery or a future explicit mechanism.
+
+- **ADR-0330 — Retire crew role slots and role-based model resolution** — Proposed.
 
 ## Task References
 
@@ -125,5 +126,6 @@ Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.
 - ORB-00072: Make duel-plan agent pool and per-family model configurable via `[duel]`.
 - ORB-00080: Collapse agent identity to family; isolate model strings to invocation surface.
 - ORB-10130: Flatten each crew to one provider-model assignment.
+- ORB-10620: Reject legacy crew role sub-tables at config load.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10620](https://orbit-cli.com/tasks/ORB-10620) — Reject legacy crew role sub-tables at config load

### Description

## Problem

Crew configuration still parses per-role `planner`/`implementer`/`reviewer` sub-tables that ADR-0213 rendered meaningless. A legacy crew must supply all three, and load keeps the implementer assignment while discarding the other two behind a warn-level log when they diverge — so a workspace that deliberately configured a heterogeneous crew loses two of its three assignments without failing. The layering and provenance paths carry matching dual-shape logic to keep the dead schema working across global and workspace config files.

ADR-0330 decides that crew configuration accepts flat `provider`/`model`/`backend` only, and that the legacy shape is rejected at load with rewrite guidance.

## Change

Make the flat shape the only accepted crew entry schema, and turn the legacy shape into a load-time error that names the offending crew and tells the operator what to write instead. Config layering, provenance reporting for `orbit config show`, and the seeded config template should all stop reasoning about two possible crew shapes.

The repo already has a precedent for rejecting a retired config schema with actionable guidance rather than migrating it silently; follow that pattern rather than inventing a second one.

## Constraints

- Flat-shape configuration, crew defaults, `workflow.default_crew` admission, and default-crew resolution keep their current behavior exactly.
- The error must name the crew and the required flat fields; an operator should be able to fix their config from the message alone without reading source.
- Do not write a migration that rewrites the operator's config file in place.
- Scope is the crew entry schema only. `AgentRole` and role-based resolution are retired separately and must keep compiling until then.

## Acceptance Criteria

- A crew entry using `planner`/`implementer`/`reviewer` fails config load with an error naming the crew and the flat fields it needs.
- A crew entry mixing flat fields with role sub-tables continues to fail, with the same class of error; this behavior exists today and the criterion is a regression guard.
- Flat-shape crews, absent `[crews]` falling back to defaults, and an explicitly empty `[crews]` table all behave as they do today, with tests covering each.
- Global-plus-workspace crew layering resolves against a single shape, and `orbit config show` reports the correct source file for `model`, `provider`, and `backend`.
- Config documentation no longer describes the legacy shape as supported, and states what a workspace on the old shape must do.
- Affected crates build and the config test suite passes; name any pre-existing unrelated failures rather than repairing them.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Rejected any `[crews.<name>]` entry containing retired `planner`, `implementer`, or `reviewer` role tables with a crew-naming rewrite message requiring flat `model`, `provider`, and `backend` fields.
- Removed legacy-shape reconciliation and legacy implementer provenance from layered config resolution; flat crew fields now layer and report their own source only.
- Added regression coverage for legacy and mixed entries, absent and explicitly empty crew registries, layered legacy rejection, and all assignment-field provenance.
- Updated configuration and agent-family documentation to require the flat crew shape; generated config remains flat.
Assessment: The focused config suite and repository fast CI both pass.
Validation:
- `cargo test -p orbit-core config::tests --lib` (90 passed)
- `make ci-fast` (passed)
Friction checkpoint: no qualifying tooling or workflow friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10620-6a77e25c`
- Behind base: 0
- Ahead of base: 1