### PR TITLE
Restore orbit-task-pilot contract marker required by plugin validation

### DIFF
--- a/crates/orbit-core/assets/skills/orbit-task-pilot/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-task-pilot/SKILL.md
@@ -21,6 +21,8 @@ For each task:
 
 Never write: no editing, creating, moving, or deleting repository files; no task updates or lifecycle transitions; no promotion, dispatch, implementation, pipeline invocation, commit, push, merge, PR, or approval.
 
+Never update an Orbit task.
+
 Never expand the partition beyond the supplied IDs, except to cite a concrete dependency, duplicate, or accepted ADR.
 
 Task-pilot is an operational role, not a crew, actor identity, or scheduler.

--- a/plugin/skills/orbit-task-pilot/SKILL.md
+++ b/plugin/skills/orbit-task-pilot/SKILL.md
@@ -21,6 +21,8 @@ For each task:
 
 Never write: no editing, creating, moving, or deleting repository files; no task updates or lifecycle transitions; no promotion, dispatch, implementation, pipeline invocation, commit, push, merge, PR, or approval.
 
+Never update an Orbit task.
+
 Never expand the partition beyond the supplied IDs, except to cite a concrete dependency, duplicate, or accepted ADR.
 
 Task-pilot is an operational role, not a crew, actor identity, or scheduler.


### PR DESCRIPTION
## Task

[ORB-10640](https://orbit-cli.com/tasks/ORB-10640) — Restore orbit-task-pilot contract marker required by plugin validation

### Description

## Problem

Commit `d461964f` (`chore: condense agent instructions`) removed the exact hard-bound sentence `Never update an Orbit task` from both shipped copies of the `orbit-task-pilot` skill. The repository's Codex plugin validation contract still requires that marker, so the merged commit makes the required fast CI gate fail.

## Evidence

On `d461964f` in worktree `~/workspace/constellation/codebases/orbit/.orbit/state/worktrees/orbit-jrun-20260809-0257-8`, `make ci-fast` failed at `./scripts/test-validate-codex-plugin.sh` with:

```text
validate-codex-plugin: failed
- orbit-task-pilot skill is missing contract marker 'Never update an Orbit task'
make: *** [Makefile:128: ci-fast] Error 1
```

The validator checks the packaged plugin skill, while the runtime source asset is also missing the same contract wording. No open `qa-sweep` task covered this issue.

## Reproduction

1. Check out commit `d461964f`.
2. Run `make ci-fast`.
3. Observe the validator failure above.
4. Confirm neither `crates/orbit-core/assets/skills/orbit-task-pilot/SKILL.md` nor `plugin/skills/orbit-task-pilot/SKILL.md` contains the exact marker.

## Required Change

Restore the validator-required hard-bound marker in both shipped skill copies without weakening the read-only task-pilot contract, then rerun `make ci-fast` and the focused plugin validation script.

### Acceptance Criteria

- Both `crates/orbit-core/assets/skills/orbit-task-pilot/SKILL.md` and `plugin/skills/orbit-task-pilot/SKILL.md` contain the exact hard-bound marker `Never update an Orbit task` in the read-only contract.
- `./scripts/test-validate-codex-plugin.sh` and `make ci-fast` pass on the fixed commit.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented the scoped contract restoration in both shipped copies: added the exact hard-bound sentence `Never update an Orbit task.` to `crates/orbit-core/assets/skills/orbit-task-pilot/SKILL.md` and `plugin/skills/orbit-task-pilot/SKILL.md`. Verified pwd and git top-level both resolve to the requested worktree, and confirmed the two files remain byte-for-byte identical. Validation passed: `./scripts/test-validate-codex-plugin.sh` and `make ci-fast` (including fmt, docs, guardrail, and plugin checks). `git diff --check` also passed. No dependency changes, unrelated files, commit, or lifecycle transition was made.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10640-6a77f108`
- Behind base: 0
- Ahead of base: 1