### PR TITLE
Fix task-pilot Linux read-only sandbox regression

### DIFF
--- a/crates/orbit-core/src/runtime/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/runtime/v2_host/sandbox.rs
@@ -68,8 +68,24 @@ pub(super) fn resolve_executor_sandbox(
                             "resolve fsProfile for linux-bwrap: {err}"
                         ))
                     })?;
-                append_codex_side_write_roots(runtime, provider, &mut resolved)?;
-                append_linux_runtime_write_roots(runtime, subprocess_cwd, &mut resolved)?;
+                // Runtime and provider conveniences must not turn an activity
+                // profile with an empty modify surface into a workspace writer.
+                // Besides violating that profile, workspace re-allows make a
+                // direct Bubblewrap invocation unable to enforce global
+                // non-subtree denies such as `**/.env` for paths created after
+                // spawn. Provider state and global Orbit runtime roots remain
+                // available below; neither overlaps workspace-relative denies.
+                let grants_workspace_modify =
+                    resolved.modify.iter().any(|rule| !rule.starts_with('!'));
+                if grants_workspace_modify {
+                    append_codex_side_write_roots(runtime, provider, &mut resolved)?;
+                }
+                append_linux_runtime_write_roots(
+                    runtime,
+                    subprocess_cwd,
+                    grants_workspace_modify,
+                    &mut resolved,
+                )?;
                 append_linux_provider_state_roots(&mut resolved)?;
                 let managed_worktree = subprocess_cwd
                     .and_then(|cwd| active_worktree_subpath(runtime, cwd))
@@ -231,6 +247,7 @@ fn append_unique_modify_root(resolved: &mut ResolvedFsProfile, root: String) {
 fn append_linux_runtime_write_roots(
     runtime: &OrbitRuntime,
     subprocess_cwd: Option<&Path>,
+    grants_workspace_modify: bool,
     resolved: &mut ResolvedFsProfile,
 ) -> Result<(), DispatchError> {
     let global = runtime
@@ -244,9 +261,25 @@ fn append_linux_runtime_write_roots(
         .canonicalize()
         .unwrap_or_else(|_| runtime.paths().orbit_dir.clone());
 
+    for directory in [global.join("state/logs"), global.join("tasks")] {
+        ensure_owned_directory(&directory)?;
+        append_unique_modify_root(resolved, directory.display().to_string());
+    }
+    for file in [
+        global.join("orbit.db"),
+        global.join("orbit.db-wal"),
+        global.join("orbit.db-shm"),
+    ] {
+        if file.exists() {
+            append_unique_modify_root(resolved, file.display().to_string());
+        }
+    }
+
+    if !grants_workspace_modify {
+        return Ok(());
+    }
+
     for directory in [
-        global.join("state/logs"),
-        global.join("tasks"),
         workspace.join("tasks"),
         workspace.join("learnings"),
         workspace.join("frictions"),
@@ -258,9 +291,6 @@ fn append_linux_runtime_write_roots(
         append_unique_modify_root(resolved, directory.display().to_string());
     }
     for file in [
-        global.join("orbit.db"),
-        global.join("orbit.db-wal"),
-        global.join("orbit.db-shm"),
         workspace.join("state/.id_alloc.lock"),
         workspace.join("state/semantic.db"),
         workspace.join("state/semantic.db-wal"),

--- a/crates/orbit-core/src/runtime/v2_host/tests/sandbox.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/sandbox.rs
@@ -40,6 +40,65 @@ fn resolve_executor_sandbox_returns_linux_descriptor_with_absolute_mounts() {
 
 #[cfg(target_os = "linux")]
 #[test]
+fn direct_reviewer_profile_does_not_gain_workspace_runtime_writes() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    seed_executor(
+        &runtime,
+        "claude",
+        Some(orbit_common::types::ExecutorSandboxKind::LinuxBwrap),
+    );
+
+    let reviewer = runtime
+        .resolve_executor_sandbox("claude", Some("reviewer"), Some(&repo_root))
+        .expect("resolve reviewer sandbox")
+        .expect("descriptor");
+    assert!(!reviewer.managed_worktree);
+    let canonical_repo = repo_root.canonicalize().expect("canonical repo");
+    assert!(
+        reviewer
+            .fs_profile
+            .modify
+            .iter()
+            .filter(|rule| !rule.starts_with('!'))
+            .all(|rule| !rule.starts_with(&canonical_repo.display().to_string())),
+        "read-only activity profile must not gain workspace runtime writes: {:?}",
+        reviewer.fs_profile.modify
+    );
+    assert!(
+        reviewer
+            .fs_profile
+            .read
+            .iter()
+            .any(|rule| rule.starts_with('!') && rule.ends_with("/**/*.env")),
+        "global denyRead rules must remain in the resolved profile: {:?}",
+        reviewer.fs_profile.read
+    );
+    compile_linux_bwrap_argv(
+        &reviewer.fs_profile,
+        "/bin/true",
+        &[],
+        Some(&canonical_repo),
+        reviewer.managed_worktree,
+    )
+    .expect("direct reviewer sandbox must compile with default dotenv denies");
+
+    let writer = runtime
+        .resolve_executor_sandbox("claude", None, Some(&repo_root))
+        .expect("resolve write-capable sandbox")
+        .expect("descriptor");
+    let error = compile_linux_bwrap_argv(
+        &writer.fs_profile,
+        "/bin/true",
+        &[],
+        Some(&canonical_repo),
+        writer.managed_worktree,
+    )
+    .expect_err("a direct write-capable sandbox must still fail closed");
+    assert!(error.to_string().contains("non-subtree denyModify"));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
 fn resolve_executor_sandbox_marks_only_specific_orbit_worktree_managed() {
     let (_root, runtime, repo_root) = runtime_with_workspace_layout();
     seed_executor(

--- a/crates/orbit-exec/tests/linux_sandbox.rs
+++ b/crates/orbit-exec/tests/linux_sandbox.rs
@@ -426,6 +426,26 @@ fn argv_reallows_only_narrow_existing_paths_after_orbit_deny() {
 }
 
 #[test]
+fn direct_invocation_allows_non_subtree_denies_without_writable_roots() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("create workspace");
+    let resolved = profile(vec![
+        format!("!{}/**/.env", workspace.display()),
+        format!("!{}/**/*.env", workspace.display()),
+    ]);
+
+    let plan = compile_linux_bwrap_argv(&resolved, "/bin/true", &[], None, false)
+        .expect("a read-only direct invocation needs no mount-based write exclusion");
+
+    assert!(
+        !plan.args.iter().any(|arg| arg == "--bind"),
+        "a no-modify profile must not gain a writable bind: {:?}",
+        plan.args
+    );
+}
+
+#[test]
 fn direct_invocation_fails_closed_for_overlapping_non_subtree_deny() {
     let temp = tempfile::tempdir().expect("tempdir");
     let workspace = temp.path().join("workspace");


### PR DESCRIPTION
## Task

[ORB-10654](https://orbit-cli.com/tasks/ORB-10654) — Fix task-pilot Linux read-only sandbox regression

### Description

## Problem

ORB-10584 added `fsProfile: reviewer` to `task_pilot`, intending to make its direct Linux invocation read-only and avoid the non-subtree dotenv `denyModify` failure. The deployed activity matches that asset, but the regression remains live.

Authoritative MAX-mode run `jrun-20260809-0310` used the ws_orbit checkout with global root `/home/daniel/.orbit`, the complete crew catalog, explicit Luna crew, and eight exact task IDs. Preparation succeeded and both pilot partitions failed immediately with:

`policy denied: linux-bwrap cannot enforce non-subtree denyModify /home/daniel/workspace/constellation/codebases/orbit/**/.env for a direct invocation; use a managed worktree`

The deterministic apply step did not run and no task context was changed. Earlier run `jrun-20260809-0213` showed the same failure. A managed-worktree workaround is not valid: task-pilot is a direct read-only preflight over the registered primary checkout, and an earlier attempt (`jrun-20260802-2221`) was rejected because the worktree path did not match the active workspace.

## Required direction

Repair Linux sandbox compilation so an effective no-modify profile can execute directly even when the global policy contains non-subtree `denyModify` globs. The compiler should not require a mount-based write exclusion for a profile whose effective write surface is already empty. Preserve all read denies and preserve fail-closed behavior for profiles that can write.

## Constraints

- Do not disable Linux Bubblewrap globally or remove dotenv deny rules.
- Do not add a task-pilot-only, provider-name, or crew-name bypass.
- Do not weaken write-capable activity enforcement.
- Keep the task-pilot activity, tools, process allowlist, and deterministic apply contract unchanged.
- Validate with the real ws_orbit pilot after deployment, not only a synthetic unit test.

## Operational context

The ws_orbit operational config was also repaired during diagnosis: its workspace override now retains the complete crew catalog and uses `sol` as `workflow.default_crew`. Timestamped backups exist under `.orbit/state/config.toml.worker-backup-20260809T025042Z` and `.orbit/state/config.toml.worker-backup-20260809T025259Z`.

### Acceptance Criteria

- A direct Linux `agent_loop` activity using `fsProfile: reviewer` and the default global dotenv deny rules dispatches successfully without a managed worktree; a regression test reproduces the task-pilot failure shape.
- The fix is structural: when the effective filesystem profile grants no modification surface, non-subtree `denyModify` globs do not make Linux sandbox compilation fail, while `denyRead` and all write-capable profile restrictions remain enforced.
- A direct write-capable activity with the same non-subtree deny rules is still rejected unless it runs in an enforceable managed worktree; a test proves the fail-closed boundary did not weaken.
- The deployed `task_pilot` remains on `fsProfile: reviewer` with its existing read-only tools and process allowlist; no executor-wide sandbox disable or provider-specific bypass is introduced.
- The exact explicit eight-task `task_pilot_pipeline` invocation for ORB-10621, ORB-10622, ORB-10628, ORB-10629, ORB-10630, ORB-10631, ORB-10632, and ORB-10633 reaches a successful apply step on dk-server-1 after the fix.
- Affected sandbox and task-pilot tests pass; name unrelated pre-existing failures rather than repairing them.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Preserved the Linux reviewer profile's empty workspace modification surface by withholding workspace runtime roots and configured Codex side-write roots when the resolved activity profile has no positive modify rule; provider state and global Orbit runtime roots remain available.
- Added a resolver-level regression using the default reviewer policy and direct primary checkout that proves dotenv denyRead rules remain present, Bubblewrap compilation succeeds without a managed worktree, and the unrestricted/write-capable counterpart still fails closed on the same non-subtree denyModify shape.
- Added a compiler-level regression proving a no-modify profile emits no writable bind while retaining the existing write-capable direct-invocation rejection.
- Expanded context_files to include the tightly coupled Linux resolver and its sibling tests because the live defect came from post-resolution workspace write-root injection, not the already-correct compiler overlap test.
Assessment: The fix is structural and profile-capability-based; it does not inspect task-pilot, crew, or provider identity and leaves the task_pilot activity/tool/process contract unchanged.
Validation:
- cargo test -p orbit-exec --test linux_sandbox (passed: 15)
- cargo test -p orbit-core runtime::v2_host::tests::sandbox --lib (passed: 7)
- cargo test -p orbit-engine task_pilot_reviewer_profile_starts_direct_linux_invocation_with_env_denies --lib (passed: 1)
- git diff --check (passed)
- make ci-fast reached an unrelated pre-existing failure in scripts/test-validate-codex-plugin.sh: orbit-task-pilot is missing the contract marker 'Never update an Orbit task'. ORB-10640 already addresses that asset on a separate branch; it was not changed here.
Deviations from original plan:
- The implementation changed crates/orbit-core/src/runtime/v2_host/sandbox.rs rather than weakening crates/orbit-exec's correct fail-closed overlap check. The live reviewer profile was becoming write-capable only after the resolver appended workspace runtime roots.
Recommended follow-ups:
- After this change is built and deployed to dk-server-1, rerun the exact eight-task task_pilot_pipeline invocation for ORB-10621, ORB-10622, ORB-10628, ORB-10629, ORB-10630, ORB-10631, ORB-10632, and ORB-10633; deployment and authoritative apply-step validation are downstream of this implementation worktree.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10654-6a77f0ed`
- Behind base: 0
- Ahead of base: 1