### PR TITLE
Route system-activity crews through configuration instead of the task's crew

### DIFF
--- a/.orbit/resources/activities/step_failure_recovery.yaml
+++ b/.orbit/resources/activities/step_failure_recovery.yaml
@@ -30,6 +30,10 @@ spec:
       max_attempts:
         type: integer
         minimum: 1
+      # Injected by the recovery dispatcher only. It records that this system
+      # activity must resolve workflow.system_crew into its crew input.
+      system_crew:
+        type: boolean
   # Advisory reporting surface only — never a contract anything depends on.
   #
   # Nothing consumes these fields. A step's `recovery_activity` has no step id,
@@ -201,9 +205,8 @@ spec:
     - orbit
     - rg
   on_denial: terminate
-  # The reviewer role remains a prompt and telemetry label. The executor
-  # resolves this named recovery activity through the failed run's durable
-  # provider lane: Codex -> terra and Claude -> sonnet.
+  # The reviewer role remains a prompt and telemetry label. Dispatch supplies
+  # the configured workflow.system_crew as an explicit crew input.
   role: reviewer
   # One hour accommodates provider startup plus networked git/PR operations
   # and a resumed pipeline while retaining a hard terminal bound. This bound is

--- a/.orbit/resources/activities/triage_failed_runs.yaml
+++ b/.orbit/resources/activities/triage_failed_runs.yaml
@@ -48,6 +48,8 @@ spec:
               type: number
             max_rebacklogs:
               type: number
+      system_crew:
+        type: boolean
   output_schema_json:
     type: object
     required: [dispositions]

--- a/.orbit/resources/jobs/task_triage_pipeline.yaml
+++ b/.orbit/resources/jobs/task_triage_pipeline.yaml
@@ -58,6 +58,9 @@ spec:
       target: activity:triage_failed_runs
       default_input:
         candidates: "{{ steps.list_candidates.output.candidates }}"
+        # Causes dispatch to resolve workflow.system_crew into the explicit
+        # crew input, rather than letting the reviewer label inherit a run crew.
+        system_crew: true
 
     - id: apply_dispositions
       when: "{{ steps.list_candidates.output.candidate_count }} != 0"

--- a/crates/orbit-core/assets/activities/step_failure_recovery.yaml
+++ b/crates/orbit-core/assets/activities/step_failure_recovery.yaml
@@ -30,6 +30,10 @@ spec:
       max_attempts:
         type: integer
         minimum: 1
+      # Injected by the recovery dispatcher only. It records that this system
+      # activity must resolve workflow.system_crew into its crew input.
+      system_crew:
+        type: boolean
   # Advisory reporting surface only — never a contract anything depends on.
   #
   # Nothing consumes these fields. A step's `recovery_activity` has no step id,
@@ -201,9 +205,8 @@ spec:
     - orbit
     - rg
   on_denial: terminate
-  # The reviewer role remains a prompt and telemetry label. The executor
-  # resolves this named recovery activity through the failed run's durable
-  # provider lane: Codex -> terra and Claude -> sonnet.
+  # The reviewer role remains a prompt and telemetry label. Dispatch supplies
+  # the configured workflow.system_crew as an explicit crew input.
   role: reviewer
   # One hour accommodates provider startup plus networked git/PR operations
   # and a resumed pipeline while retaining a hard terminal bound. This bound is

--- a/crates/orbit-core/assets/activities/triage_failed_runs.yaml
+++ b/crates/orbit-core/assets/activities/triage_failed_runs.yaml
@@ -48,6 +48,8 @@ spec:
               type: number
             max_rebacklogs:
               type: number
+      system_crew:
+        type: boolean
   output_schema_json:
     type: object
     required: [dispositions]

--- a/crates/orbit-core/assets/config/default-config.toml
+++ b/crates/orbit-core/assets/config/default-config.toml
@@ -29,6 +29,9 @@ enabled = true
 # Default base branch for `orbit run ship`.
 # Override per-invocation with `--base <branch>`.
 base_branch = "main"
+# Crew used by bounded system activities such as recovery and failed-run triage.
+# `orbit init` seeds the default `qa` crew whenever it detects a supported CLI.
+system_crew = "qa"
 
 [runtime]
 # `backend` selects the v2 `agent_loop` execution backend: "cli" | "http" | "auto".

--- a/crates/orbit-core/assets/jobs/task_triage_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_triage_pipeline.yaml
@@ -58,6 +58,9 @@ spec:
       target: activity:triage_failed_runs
       default_input:
         candidates: "{{ steps.list_candidates.output.candidates }}"
+        # Causes dispatch to resolve workflow.system_crew into the explicit
+        # crew input, rather than letting the reviewer label inherit a run crew.
+        system_crew: true
 
     - id: apply_dispositions
       when: "{{ steps.list_candidates.output.candidate_count }} != 0"

--- a/crates/orbit-core/src/config/registry.rs
+++ b/crates/orbit-core/src/config/registry.rs
@@ -21,6 +21,7 @@ use serde_json::{Value as JsonValue, json};
 
 const DEFAULT_WORKFLOW_BASE_BRANCH: &str = "main";
 const DEFAULT_WORKFLOW_CREW: &str = "opus";
+const DEFAULT_WORKFLOW_SYSTEM_CREW: &str = "qa";
 const LEGACY_DEFAULT_WORKFLOW_CREW: &str = "claude";
 const CONSTELLATION_DEFAULT_PROVIDER_ENV: &str = "CONSTELLATION_DEFAULT_PROVIDER";
 
@@ -175,6 +176,11 @@ define_config_settings! {
         key: "workflow.default_crew", value_type: "string",
         description: "Named crew used when a task does not declare `crew` and no CLI override is given.",
         resolve: |raw: Option<String>| resolve_optional_non_empty(raw, "workflow.default_crew"),
+    },
+    workflow_system_crew: String => String {
+        key: "workflow.system_crew", value_type: "string",
+        description: "Named crew used by system activities such as step-failure recovery and failed-run triage.",
+        resolve: |raw: Option<String>| resolve_non_empty(raw, DEFAULT_WORKFLOW_SYSTEM_CREW, "workflow.system_crew"),
     },
 }
 

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -106,6 +106,7 @@ pub(crate) struct RuntimeConfig {
     /// Named provider-model assignments from `[crews.<name>]`.
     pub(crate) crews: BTreeMap<String, Crew>,
     pub(crate) default_crew: Option<String>,
+    pub(crate) system_crew: String,
     /// Optional floor for the local task-id allocator (`[tasks] id_start`).
     /// Applied forward-only on runtime build so machines can hold disjoint id
     /// ranges. `None` leaves the allocator untouched.
@@ -135,6 +136,7 @@ impl RuntimeConfig {
             routines_source: snapshot.routines_role.as_deref() == Some("source"),
             crews: default_crews(),
             default_crew: snapshot.workflow_default_crew.clone(),
+            system_crew: snapshot.workflow_system_crew.clone(),
             tasks_id_start: snapshot.tasks_id_start,
             snapshot,
         }
@@ -221,6 +223,7 @@ impl RuntimeConfig {
             routines_source: snapshot.routines_role.as_deref() == Some("source"),
             crews,
             default_crew: snapshot.workflow_default_crew.clone(),
+            system_crew: snapshot.workflow_system_crew.clone(),
             tasks_id_start: snapshot.tasks_id_start,
             snapshot,
         })
@@ -242,6 +245,13 @@ impl RuntimeConfig {
 
     pub(crate) fn workflow_auto_ship(&self) -> bool {
         self.workflow_auto_ship
+    }
+
+    /// Configured crew for system activities. Resolution of the named crew is
+    /// deliberately deferred to dispatch so a bad system crew does not stop
+    /// unrelated activity execution.
+    pub(crate) fn system_crew(&self) -> &str {
+        &self.system_crew
     }
 
     pub(crate) fn routines_source(&self) -> bool {

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -258,6 +258,7 @@ pub(crate) struct OrbitRuntimeSettings {
     routines_source: bool,
     crews: std::collections::BTreeMap<String, Crew>,
     default_crew: Option<String>,
+    system_crew: String,
 }
 
 impl OrbitRuntimeSettings {
@@ -273,6 +274,7 @@ impl OrbitRuntimeSettings {
         routines_source: bool,
         crews: std::collections::BTreeMap<String, Crew>,
         default_crew: Option<String>,
+        system_crew: String,
     ) -> Self {
         Self {
             persistence,
@@ -285,6 +287,7 @@ impl OrbitRuntimeSettings {
             routines_source,
             crews,
             default_crew,
+            system_crew,
         }
     }
 
@@ -314,6 +317,10 @@ impl OrbitRuntimeSettings {
 
     pub(crate) fn default_crew(&self) -> Option<&str> {
         self.default_crew.as_deref()
+    }
+
+    pub(crate) fn system_crew(&self) -> &str {
+        &self.system_crew
     }
 }
 

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -150,6 +150,7 @@ pub(crate) fn build_context_from_roots(
     let routines_source = runtime_config.routines_source();
     let crews = runtime_config.crews.clone();
     let default_crew = runtime_config.default_crew.clone();
+    let system_crew = runtime_config.system_crew().to_string();
 
     Ok(OrbitContext::new(
         paths,
@@ -186,6 +187,7 @@ pub(crate) fn build_context_from_roots(
             routines_source,
             crews,
             default_crew,
+            system_crew,
         ),
     ))
 }

--- a/crates/orbit-core/src/runtime/v2_host/mod.rs
+++ b/crates/orbit-core/src/runtime/v2_host/mod.rs
@@ -26,10 +26,10 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
-use orbit_common::types::activity_job::{AgentRole, Backend, Provider};
+use orbit_common::types::activity_job::AgentRole;
 use orbit_common::types::{
-    InvocationTrace, LearningInjectionCaps, LearningInjectionState, LearningReminder, RoleSlot,
-    UNRESTRICTED_FS_PROFILE, resolve_crew,
+    InvocationTrace, LearningInjectionCaps, LearningInjectionState, LearningReminder,
+    UNRESTRICTED_FS_PROFILE,
 };
 use orbit_engine::{AgentRoleConfig, EnvironmentHost};
 use orbit_engine::{DispatchError, ResolvedCliExecutor, ResolvedSandbox, V2RuntimeHost};
@@ -296,76 +296,8 @@ impl V2RuntimeHost for OrbitRuntime {
         )
     }
 
-    fn recovery_agent_crew_config(&self, run_id: &str) -> Result<AgentRoleConfig, DispatchError> {
-        let run = self.get_job_run_backend(run_id).map_err(|error| {
-            DispatchError::JobExecution(format!(
-                "read persisted provider lane for step_failure_recovery run `{run_id}`: {error}"
-            ))
-        })?
-        .ok_or_else(|| {
-            DispatchError::JobValidation(format!(
-                "step_failure_recovery requires a persisted provider lane for run `{run_id}`; no run record was found"
-            ))
-        })?;
-
-        let source_crew_name = run
-            .resolved_crew
-            .as_deref()
-            .map(str::trim)
-            .filter(|crew| !crew.is_empty())
-            .ok_or_else(|| {
-                DispatchError::JobValidation(format!(
-                    "step_failure_recovery requires a persisted resolved crew for run `{run_id}`; no provider lane is available"
-                ))
-            })?;
-        let source_crew = resolve_crew(source_crew_name, self.context.settings().crews()).map_err(
-            |error| {
-                DispatchError::JobValidation(format!(
-                    "step_failure_recovery cannot resolve persisted crew `{source_crew_name}` for run `{run_id}`: {error}; refusing to select a provider from ambient CLI availability"
-                ))
-            },
-        )?;
-        let provider = Provider::parse(&source_crew.assignment.provider).map_err(|error| {
-            DispatchError::JobValidation(format!(
-                "step_failure_recovery cannot determine the persisted provider lane from crew `{source_crew_name}` for run `{run_id}`: {error}"
-            ))
-        })?;
-        let required_crew = match provider {
-            Provider::Codex => "terra",
-            Provider::Claude => "sonnet",
-            other => {
-                return Err(DispatchError::JobValidation(format!(
-                    "step_failure_recovery has no configured middleweight crew for persisted provider `{}` on run `{run_id}`; required crew mapping is codex -> terra or claude -> sonnet",
-                    other.as_str()
-                )));
-            }
-        };
-        let recovery_crew = resolve_crew(required_crew, self.context.settings().crews()).map_err(
-            |error| {
-                DispatchError::JobValidation(format!(
-                    "step_failure_recovery requires provider `{}` crew `{required_crew}` for run `{run_id}`, but it is unavailable or invalid: {error}",
-                    provider.as_str()
-                ))
-            },
-        )?;
-        let config = crate::runtime::engine::environment_host::typed_role_config_from_assignment(
-            AgentRole::Reviewer,
-            &recovery_crew.assignment,
-        );
-        let usable = config.provider == Some(provider)
-            && config
-                .model
-                .as_deref()
-                .is_some_and(|model| !model.trim().is_empty())
-            && config.backend == Some(Backend::Cli);
-        if !usable {
-            return Err(DispatchError::JobValidation(format!(
-                "step_failure_recovery requires provider `{}` crew `{required_crew}` with provider `{}`, a non-empty model, and backend `cli` for run `{run_id}`; configured crew is unusable",
-                provider.as_str(),
-                provider.as_str(),
-            )));
-        }
-        Ok(config)
+    fn system_crew_for_dispatch(&self) -> Option<String> {
+        Some(self.context.settings().system_crew().to_string())
     }
 
     fn explicit_agent_crew_config_for_input(
@@ -380,11 +312,31 @@ impl V2RuntimeHost for OrbitRuntime {
         else {
             return Ok(None);
         };
+        let config_key = input
+            .get("crew_config_key")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let (crew_name, config_key) = match config_key {
+            Some("workflow.system_crew") => (
+                self.context.settings().system_crew(),
+                Some("workflow.system_crew"),
+            ),
+            Some(other) => {
+                return Err(DispatchError::JobValidation(format!(
+                    "explicit activity crew `{explicit}` names unsupported configuration key `{other}`"
+                )));
+            }
+            None => (explicit, None),
+        };
         let crew = self
-            .resolve_crew_for_task(Some(explicit), None)
+            .resolve_crew_for_task(Some(crew_name), None)
             .map_err(|error| {
+                let source = config_key
+                    .map(|key| format!("configured by `{key}`"))
+                    .unwrap_or_else(|| "from activity input".to_string());
                 DispatchError::JobValidation(format!(
-                    "explicit activity crew '{explicit}' cannot be resolved: {error}"
+                    "explicit activity crew `{crew_name}` ({source}) cannot be resolved or used: {error}"
                 ))
             })?;
         Ok(Some(

--- a/crates/orbit-core/src/runtime/v2_host/tests/v2_host.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/v2_host.rs
@@ -1,7 +1,6 @@
 //! Sibling tests for `mod.rs` (the v2_host module root; migrated per ORB-10387 /
 //! docs/design-patterns/test_layout.md).
 
-use orbit_common::types::activity_job::Provider;
 use orbit_common::types::{InvocationTrace, JobRunState, TokenUsage, ToolCallTrace};
 use orbit_store::InvocationQuery;
 
@@ -34,98 +33,42 @@ fn runtime_with_recovery_config(config: &str) -> (tempfile::TempDir, OrbitRuntim
 }
 
 #[test]
-fn recovery_crew_maps_persisted_codex_and_claude_lanes_to_middleweight_models() {
-    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
-
-    for (source_crew, expected_provider, expected_model) in [
-        ("sol", Provider::Codex, "gpt-5.6-terra"),
-        ("terra", Provider::Codex, "gpt-5.6-terra"),
-        ("luna", Provider::Codex, "gpt-5.6-terra"),
-        ("opus", Provider::Claude, "sonnet"),
-        ("sonnet", Provider::Claude, "sonnet"),
-        ("fable", Provider::Claude, "sonnet"),
-    ] {
-        let run_id = seed_running_job_run(&runtime, "recovery_lane_job");
-        runtime
-            .record_run_crew_from_input(&run_id, &serde_json::json!({ "crew": source_crew }))
-            .expect("persist source crew");
-
-        let config = V2RuntimeHost::recovery_agent_crew_config(&runtime, &run_id)
-            .expect("resolve lane-local middleweight recovery crew");
-        assert_eq!(
-            config.provider,
-            Some(expected_provider),
-            "source {source_crew}"
-        );
-        assert_eq!(
-            config.model.as_deref(),
-            Some(expected_model),
-            "source {source_crew}"
-        );
-    }
-}
-
-#[test]
-fn recovery_crew_missing_or_cross_provider_config_is_an_actionable_error() {
-    let missing_terra = r#"
+fn system_crew_dispatch_uses_configuration_and_records_selected_provider_model() {
+    let config = r#"
 [workflow]
 default_crew = "sol"
-
-[crews.sol]
-model = "gpt-5.6-sol"
-provider = "codex"
-backend = "cli"
-"#;
-    let (_root, runtime) = runtime_with_recovery_config(missing_terra);
-    let run_id = seed_running_job_run(&runtime, "recovery_missing_crew");
-    runtime
-        .record_run_crew_from_input(&run_id, &serde_json::json!({ "crew": "sol" }))
-        .expect("persist source crew");
-    let err = V2RuntimeHost::recovery_agent_crew_config(&runtime, &run_id)
-        .expect_err("missing terra must not fall back to another provider or model");
-    assert!(err.to_string().contains("provider `codex` crew `terra`"));
-
-    let malformed_terra = r#"
-[workflow]
-default_crew = "sol"
+system_crew = "qa"
 
 [crews.sol]
 model = "gpt-5.6-sol"
 provider = "codex"
 backend = "cli"
 
-[crews.terra]
-model = "sonnet"
-provider = "claude"
+[crews.qa]
+model = "gpt-5.6-terra"
+provider = "codex"
 backend = "cli"
 "#;
-    let (_root, runtime) = runtime_with_recovery_config(malformed_terra);
-    let run_id = seed_running_job_run(&runtime, "recovery_malformed_crew");
-    runtime
-        .record_run_crew_from_input(&run_id, &serde_json::json!({ "crew": "sol" }))
-        .expect("persist source crew");
-    let err = V2RuntimeHost::recovery_agent_crew_config(&runtime, &run_id)
-        .expect_err("cross-provider terra must fail closed");
-    assert!(err.to_string().contains("provider `codex` crew `terra`"));
-}
-
-#[test]
-fn recovery_invocation_persists_the_selected_middleweight_provider_and_model() {
-    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let (_root, runtime) = runtime_with_recovery_config(config);
     let run_id = seed_running_job_run(&runtime, "recovery_telemetry_job");
-    runtime
-        .record_run_crew_from_input(&run_id, &serde_json::json!({ "crew": "sol" }))
-        .expect("persist source crew");
-    let recovery = V2RuntimeHost::recovery_agent_crew_config(&runtime, &run_id)
-        .expect("resolve terra recovery crew");
+    assert_eq!(
+        V2RuntimeHost::system_crew_for_dispatch(&runtime).as_deref(),
+        Some("qa")
+    );
+    let recovery = V2RuntimeHost::explicit_agent_crew_config_for_input(
+        &runtime,
+        &serde_json::json!({ "crew": "qa", "crew_config_key": "workflow.system_crew" }),
+    )
+    .expect("resolve configured system crew")
+    .expect("configured system crew exists");
 
     V2RuntimeHost::persist_invocation_trace(
         &runtime,
         &run_id,
         "step_failure_recovery",
-        recovery.provider.expect("validated provider").as_str(),
+        recovery.provider.expect("configured provider").as_str(),
         recovery.model.as_deref(),
-        &serde_json::json!({ "task_id": "ORB-10615" }),
+        &serde_json::json!({ "task_id": "ORB-10621" }),
         &InvocationTrace::default(),
     )
     .expect("persist recovery invocation");

--- a/crates/orbit-engine/src/activity_job/agent_role.rs
+++ b/crates/orbit-engine/src/activity_job/agent_role.rs
@@ -17,6 +17,7 @@
 //! typo'd config does not silently coerce dispatch onto a wrong runtime.
 
 use orbit_common::types::activity_job::{AgentLoopSpec, AgentRole, Backend, Provider};
+use serde_json::Value;
 
 use crate::context::AgentRoleConfig;
 
@@ -44,20 +45,6 @@ pub fn resolve_agent_settings(
     resolve_from_config(config.as_ref(), inline)
 }
 
-/// Resolve the explicit middleweight crew for `step_failure_recovery`.
-///
-/// Unlike ordinary role resolution, recovery must not inherit the task crew:
-/// its host derives the failed run's persisted provider lane and validates the
-/// configured lane-local recovery crew before this fallback merge occurs.
-pub fn resolve_recovery_agent_settings(
-    host: &dyn V2RuntimeHost,
-    run_id: &str,
-    inline: &AgentLoopSpec,
-) -> Result<ResolvedAgentSettings, DispatchError> {
-    let config = host.recovery_agent_crew_config(run_id)?;
-    Ok(resolve_from_config(Some(&config), inline))
-}
-
 /// Resolve the flat crew selected explicitly by a rendered activity input.
 /// Returns `None` only when the input did not select a crew, leaving untagged
 /// activities on their inline baseline. A selected crew that the host cannot
@@ -71,6 +58,37 @@ pub fn resolve_explicit_crew_settings(
         return Ok(None);
     };
     Ok(Some(resolve_from_config(Some(&config), inline)))
+}
+
+/// Add the configured system crew to an activity input that explicitly opts
+/// into the system route. The marker is asset data, while the crew is read
+/// from the runtime host for each dispatch.
+pub fn inject_system_crew_input(
+    host: &dyn V2RuntimeHost,
+    input: &Value,
+) -> Result<Value, DispatchError> {
+    if input.get("system_crew").and_then(Value::as_bool) != Some(true) {
+        return Ok(input.clone());
+    }
+    let crew = host.system_crew_for_dispatch().ok_or_else(|| {
+        DispatchError::JobValidation(
+            "system activity requests `workflow.system_crew`, but this runtime host does not provide that configuration"
+                .to_string(),
+        )
+    })?;
+    let mut input = input.clone();
+    let object = input.as_object_mut().ok_or_else(|| {
+        DispatchError::JobValidation(
+            "system activity requests `workflow.system_crew`, but its input must be an object"
+                .to_string(),
+        )
+    })?;
+    object.insert("crew".to_string(), Value::String(crew));
+    object.insert(
+        "crew_config_key".to_string(),
+        Value::String("workflow.system_crew".to_string()),
+    );
+    Ok(input)
 }
 
 /// Pure helper used by both the host-driven path and the unit tests so the

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -217,14 +217,12 @@ pub trait V2RuntimeHost: Send + Sync {
         self.agent_role_config(role)
     }
 
-    /// Resolve the dedicated, provider-lane-preserving crew for the bounded
-    /// `step_failure_recovery` activity. Implementations must derive the lane
-    /// from the persisted run identity, rather than current CLI availability
-    /// or the activity's inline defaults.
-    fn recovery_agent_crew_config(&self, run_id: &str) -> Result<AgentRoleConfig, DispatchError> {
-        Err(DispatchError::JobValidation(format!(
-            "step_failure_recovery requires a durable provider lane for run `{run_id}`, but this runtime host does not provide recovery crew resolution"
-        )))
+    /// Return the configured system crew for a dispatch. The engine injects
+    /// this value into system-activity input immediately before resolving its
+    /// explicit `crew`, rather than deriving a crew from a role or provider.
+    /// Hosts without a configuration layer return `None`.
+    fn system_crew_for_dispatch(&self) -> Option<String> {
+        None
     }
 
     /// Resolve a flat crew selected explicitly by the rendered activity

--- a/crates/orbit-engine/src/activity_job/job_executor/mod.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/mod.rs
@@ -46,8 +46,8 @@ use crate::template::{self, TemplateContext};
 
 use super::agent_loop_driver::drive_agent_loop_with_session;
 use super::agent_role::{
-    apply_resolved_settings, resolve_agent_settings, resolve_explicit_crew_settings,
-    resolve_recovery_agent_settings,
+    apply_resolved_settings, inject_system_crew_input, resolve_agent_settings,
+    resolve_explicit_crew_settings,
 };
 use super::audit_writer::{V2AuditWriter, WriteError};
 use super::dispatcher::{

--- a/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
@@ -46,14 +46,42 @@ pub(super) fn attempt_recovery_activity(
     attempt: u32,
     max_attempts: u32,
 ) -> bool {
-    let input = serde_json::json!({
+    let mut input = serde_json::json!({
         "failed_step_id": step.id,
         "activity_name": step_activity_name(step),
         "error_message": original_err.to_string(),
         "attempt": attempt,
         "max_attempts": max_attempts,
     });
-    let role_overridden_spec = match role_overridden_recovery_spec(recovery, ctx) {
+    if recovery.name == "step_failure_recovery"
+        && let Some(object) = input.as_object_mut()
+    {
+        object.insert("system_crew".to_string(), Value::Bool(true));
+    }
+    let input = match inject_system_crew_input(ctx.host, &input) {
+        Ok(input) => input,
+        Err(error) => {
+            tracing::warn!(
+                target: "orbit.engine.job_executor",
+                run_id = %ctx.run_id,
+                failed_step_id = %step.id,
+                recovery_activity = %recovery.name,
+                error = %error,
+                "step recovery crew resolution failed; preserving original step outcome"
+            );
+            emit_job_event_lossy(
+                &ctx.audit,
+                ctx.task_id(),
+                V2AuditEventKind::StepRecoveryAttempted {
+                    step_id: step.id.clone(),
+                    recovery_activity: recovery.name.clone(),
+                    recovery_succeeded: false,
+                },
+            );
+            return false;
+        }
+    };
+    let role_overridden_spec = match role_overridden_recovery_spec(recovery, ctx, &input) {
         Ok(spec) => spec,
         Err(error) => {
             tracing::warn!(
@@ -187,18 +215,21 @@ pub(super) fn attempt_failure_activity(
 pub(super) fn role_overridden_recovery_spec(
     recovery: &ResolvedRecoveryActivity,
     ctx: &ExecCtx<'_>,
+    input: &Value,
 ) -> Result<Option<ActivityV2Spec>, DispatchError> {
     let ActivityV2Spec::AgentLoop(inline_spec) = &recovery.spec else {
         return Ok(None);
     };
-    let resolved = if recovery.name == "step_failure_recovery" {
-        resolve_recovery_agent_settings(ctx.host, &ctx.run_id, inline_spec)?
-    } else {
-        let Some(role) = inline_spec.role else {
-            return Ok(None);
+    let input = inject_system_crew_input(ctx.host, input)?;
+    let resolved =
+        if let Some(resolved) = resolve_explicit_crew_settings(ctx.host, inline_spec, &input)? {
+            resolved
+        } else {
+            let Some(role) = inline_spec.role else {
+                return Ok(None);
+            };
+            resolve_agent_settings(role, ctx.host, inline_spec, &ctx.input)
         };
-        resolve_agent_settings(role, ctx.host, inline_spec, &ctx.input)
-    };
     let mut spec = inline_spec.clone();
     apply_resolved_settings(&mut spec, &resolved);
     Ok(Some(ActivityV2Spec::AgentLoop(spec)))

--- a/crates/orbit-engine/src/activity_job/job_executor/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/target.rs
@@ -203,9 +203,8 @@ pub(super) fn run_agent_loop_outcome(
     })
 }
 
-/// Build a crew-overridden clone of an [`AgentLoopSpec`]. A declared activity
-/// role uses the role-labelled path; otherwise an explicit rendered `crew`
-/// input may select the modern flat crew assignment without inventing a role.
+/// Build a crew-overridden clone of an [`AgentLoopSpec`]. An explicit rendered
+/// `crew` always wins over a descriptive role label.
 pub(super) fn role_overridden_spec(
     t: &TargetStep,
     ctx: &ExecCtx<'_>,
@@ -214,18 +213,16 @@ pub(super) fn role_overridden_spec(
     let ActivityV2Spec::AgentLoop(inline_spec) = &t.spec else {
         return Ok(None);
     };
-    let resolved = match t.role.or(inline_spec.role) {
-        Some(effective_role) => {
-            resolve_agent_settings(effective_role, ctx.host, inline_spec, &ctx.input)
-        }
-        None => {
-            let Some(resolved) =
-                resolve_explicit_crew_settings(ctx.host, inline_spec, rendered_input)?
-            else {
-                return Ok(None);
-            };
-            resolved
-        }
+    let rendered_input = inject_system_crew_input(ctx.host, rendered_input)?;
+    let resolved = if let Some(resolved) =
+        resolve_explicit_crew_settings(ctx.host, inline_spec, &rendered_input)?
+    {
+        resolved
+    } else {
+        let Some(effective_role) = t.role.or(inline_spec.role) else {
+            return Ok(None);
+        };
+        resolve_agent_settings(effective_role, ctx.host, inline_spec, &ctx.input)
     };
     let mut spec = inline_spec.clone();
     apply_resolved_settings(&mut spec, &resolved);

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
@@ -227,7 +227,7 @@ fn recovery_agent_loop_uses_reviewer_role_config() {
         None,
     ));
 
-    let overridden = role_overridden_recovery_spec(&recovery, &ctx)
+    let overridden = role_overridden_recovery_spec(&recovery, &ctx, &json!({}))
         .expect("generic recovery role resolution should succeed")
         .expect("role-tagged recovery should resolve");
 
@@ -251,7 +251,7 @@ fn recovery_agent_loop_without_reviewer_config_keeps_inline_defaults() {
         None,
     ));
 
-    let overridden = role_overridden_recovery_spec(&recovery, &ctx)
+    let overridden = role_overridden_recovery_spec(&recovery, &ctx, &json!({}))
         .expect("generic recovery inline fallback should succeed")
         .expect("role-tagged recovery should still produce dispatch spec");
 
@@ -283,9 +283,13 @@ fn step_failure_recovery_uses_the_lane_middleweight_config() {
             Some("inline-model"),
         ));
 
-        let overridden = role_overridden_recovery_spec(&recovery, &ctx)
-            .expect("middleweight recovery config should resolve")
-            .expect("agent loop recovery should produce a dispatch spec");
+        let overridden = role_overridden_recovery_spec(
+            &recovery,
+            &ctx,
+            &json!({ "crew": "qa", "crew_config_key": "workflow.system_crew" }),
+        )
+        .expect("middleweight recovery config should resolve")
+        .expect("agent loop recovery should produce a dispatch spec");
         let ActivityV2Spec::AgentLoop(spec) = overridden else {
             panic!("expected agent_loop recovery spec");
         };
@@ -307,10 +311,10 @@ fn step_failure_recovery_requires_a_middleweight_config() {
         Some("gpt-5.6-sol"),
     ));
 
-    let err = role_overridden_recovery_spec(&recovery, &ctx)
+    let err = role_overridden_recovery_spec(&recovery, &ctx, &json!({ "system_crew": true }))
         .expect_err("step recovery must not fall back to its implementation crew");
 
-    assert!(err.to_string().contains("durable provider lane"));
+    assert!(err.to_string().contains("workflow.system_crew"));
 }
 
 #[test]
@@ -931,15 +935,25 @@ impl V2RuntimeHost for RecoveryHost {
             .cloned()
     }
 
-    fn recovery_agent_crew_config(&self, _run_id: &str) -> Result<AgentRoleConfig, DispatchError> {
+    fn system_crew_for_dispatch(&self) -> Option<String> {
+        Some("qa".to_string())
+    }
+
+    fn explicit_agent_crew_config_for_input(
+        &self,
+        input: &Value,
+    ) -> Result<Option<AgentRoleConfig>, DispatchError> {
+        if input.get("crew").and_then(Value::as_str).is_none() {
+            return Ok(None);
+        }
         self.recovery_config
             .lock()
             .expect("recovery config lock")
             .clone()
+            .map(Some)
             .ok_or_else(|| {
                 DispatchError::JobValidation(
-                    "step_failure_recovery requires a durable provider lane in this test host"
-                        .to_string(),
+                    "workflow.system_crew test crew is unavailable".to_string(),
                 )
             })
     }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -48,10 +48,12 @@ The workspace identity file `.orbit/config.yaml` is a separate artifact (it stor
 [workflow]
 base_branch = "main"        # default merge-base for ship
 default_crew = "sol"        # fallback crew when a task has no `crew` set
+system_crew = "qa"           # recovery and failed-run-triage crew
 ```
 
 - **`base_branch`** — the branch `orbit run ship` rebases against and targets with PRs. Override per-invocation with `--base <branch>`. If your repo uses a two-branch pattern like this repo does (`main` = release, `agent-main` = dev integration), set `base_branch = "agent-main"`.
 - **`default_crew`** — name of the crew under `[crews.<name>]` used for any task whose own `crew` field is unset. Must match a defined crew or config load fails. See [Per-task crew override](#per-task-crew-override) for how individual tasks select a different crew.
+- **`system_crew`** — name of the crew for `step_failure_recovery` and `triage_failed_runs`; defaults to `qa`, which `orbit init` seeds when it can configure an agent. It is resolved at every dispatch through the activities' explicit crew input, so it does not inherit a failed task's crew or the workspace default. A missing or unusable crew leaves the original failed step failed and emits a diagnostic naming `workflow.system_crew` and the configured crew.
 
 ---
 
@@ -81,24 +83,6 @@ tags = ["implementation", "review"]
 Fresh `orbit init` configuration advertises only detected provider CLIs. Claude seeds `opus`, `sonnet`, and `fable`; Codex seeds `sol`, `terra`, and `luna`; Gemini seeds `gemini`; and Grok seeds `grok`. When Codex or Claude is available, `qa` uses Terra or Sonnet respectively. Every generated entry uses the CLI backend. If no supported provider CLI is detected, init leaves both the crew registry and `workflow.default_crew` unset instead of writing an unusable provider.
 
 You can define any number of crews. Set the workspace-wide fallback with `workflow.default_crew`; assign a specific crew to individual tasks via the [per-task crew override](#per-task-crew-override). Crews are validated at load time: each crew must have non-empty `model`, `provider`, and `backend`; `workflow.default_crew` must name a defined crew.
-
-### Step-failure recovery crews
-
-`step_failure_recovery` is intentionally cheaper than a normal implementation
-attempt. It keeps the failed run's persisted provider lane and selects the
-configured middleweight crew in that lane: Codex runs recovery through
-`terra`; Claude runs it through `sonnet`. This mapping applies even if the
-failed task used `sol`, `opus`, or a lower-tier crew. The reviewer role on the
-activity remains a prompt and telemetry label; it does not select the recovery
-model.
-
-Both mapped crews must exist and remain usable for their own provider
-(`provider`, non-empty `model`, and `backend = "cli"`). A missing or
-cross-provider `terra`/`sonnet` fails recovery with an actionable diagnostic;
-Orbit preserves the original failed-step outcome and never changes provider
-families or escalates back to the implementation model. The recovery
-invocation trace records the selected provider and model separately for token
-and cost attribution.
 
 Crew metadata is canonical runtime data, not display-only TOML. Orbit trims
 `description` (blank becomes absent), trims each tag, drops blank tags, and stores


### PR DESCRIPTION
## Task

[ORB-10621](https://orbit-cli.com/tasks/ORB-10621) — Route system-activity crews through configuration instead of the task's crew

### Description

## Problem

`step_failure_recovery` and `triage_failed_runs` are system activities that carry `role: reviewer`. Since ADR-0213 flattened crews, that label selects nothing: both resolve to the run's crew, which is the failed task's crew on a single-task ship and the workspace default crew otherwise. A recovery after a heavyweight implementation therefore pays the heavyweight rate again for what is a bounded diagnostic and repair mandate, and an operator has no way to say otherwise.

A previous attempt (PR #881) fixed the cost by hardcoding a provider-to-crew map into engine code. That is rejected: a specific deployment's crew names must not be baked into a shipped surface, and an operator cannot retune it without a release.

There is a trap in the dispatch chain. A declared role currently pre-empts the explicit-crew branch, so adding a `crew` input to an activity that still declares a role changes nothing. The recovery dispatch path is worse: it reads only the inline spec's role and has no explicit-crew branch at all, so a crew input in that asset would never be read. Making the configured route actually win is part of this task, not something a later task can assume.

## Change

Give these system activities a configured crew rather than an inherited or hardcoded one. Introduce configuration that names the crew they run on, defaulting to the `qa` crew that `orbit init` already seeds, and make the dispatch chain honor it — including on the recovery path, which needs a route it does not have today.

This task owns whatever asset and dispatch-seam changes are required to make the configured crew take effect for these two activities. Retiring the role concept globally is a separate task that must find these two already routed.

## Constraints

- No provider-to-crew mapping, and no deployment-specific crew or model name, may be hardcoded in engine or core code. The mapping from activity to crew must be readable and changeable from configuration; naming the default fallback crew in code is expected and is not what this forbids.
- Never select a provider family by probing which CLI answers first.
- Recovery keeps its existing repair and delivery authority, safety gates, budgets, tool allowlists, and instruction semantics, and keeps the bounded single post-recovery attempt.
- When the configured crew is missing or unusable, preserve the original failed-step outcome and emit a diagnostic naming the crew and the configuration key, rather than escalating to a heavyweight crew or falling back to an unrelated inline model.
- Seeded and deployed activity assets must stay behaviorally aligned.
- Do not change which crew any other activity runs on.

## Acceptance Criteria

- A step recovery dispatches on the configured system crew regardless of which crew implemented the failed task, verified for a single-task ship after a heavyweight implementation, a single-task ship after a lightweight one, and a multi-task ship.
- `triage_failed_runs` dispatches on the configured system crew rather than the workspace default crew.
- Both activities route through a mechanism that is actually consulted at dispatch; a test must fail if the configured crew is ignored because a role took precedence or because the path never reads a crew input.
- The configured crew is resolved from configuration on every dispatch; no test can be made to pass by a provider-name-to-crew mapping in code.
- A missing, malformed, or unusable configured crew produces an actionable diagnostic naming the crew and configuration key, preserves the original failed-step outcome, and does not escalate.
- The recovery invocation record identifies the provider and model actually used, so cost dashboards can attribute it separately from implementation.
- Implementation crew selection, task `crew` persistence, review routing, failure handoff, and the one-post-recovery-attempt contract are unchanged, and no other shipped activity changes crew.
- Configuration documentation describes the new key and its default.
- Affected crates build and the recovery and catalog test suites pass; name any pre-existing unrelated failures rather than repairing them.

### Acceptance Criteria

- A step recovery dispatches on the configured system crew regardless of which crew implemented the failed task, verified for a single-task ship after a heavyweight implementation, a single-task ship after a lightweight one, and a multi-task ship.
- `triage_failed_runs` dispatches on the configured system crew rather than the workspace default crew.
- Both activities route through a mechanism that is actually consulted at dispatch; a test must fail if the configured crew is ignored because a role took precedence or because the path never reads a crew input.
- The configured crew is resolved from configuration on every dispatch; no test can be made to pass by a provider-name-to-crew mapping in code.
- A missing, malformed, or unusable configured crew produces an actionable diagnostic naming the crew and configuration key, preserves the original failed-step outcome, and does not escalate.
- The recovery invocation record identifies the provider and model actually used, so cost dashboards can attribute it separately from implementation.
- Implementation crew selection, task `crew` persistence, review routing, failure handoff, and the one-post-recovery-attempt contract are unchanged, and no other shipped activity changes crew.
- Configuration documentation describes the new key and its default.
- Affected crates build and the recovery and catalog test suites pass; name any pre-existing unrelated failures rather than repairing them.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `workflow.system_crew` (default `qa`) to the admitted runtime configuration, seeded config, and user documentation.
- Marked the two system paths to inject that configured value as an explicit `crew` input at dispatch; explicit crew now takes precedence over a descriptive role label.
- Replaced provider-to-crew recovery mapping with per-dispatch configuration resolution, retaining original failed-step outcomes when system-crew resolution fails and preserving invocation provider/model attribution.
- Kept seeded and deployed recovery/triage assets aligned and added focused runtime/recovery coverage.
Assessment: Targeted recovery, target-routing, catalog, formatting, diff, and ci-fast checks pass. The broader v2-host test selection retains one pre-existing unrelated failure: `run_planning_duel` remains in a shipped activity asset after ORB-10627 removed its registered deterministic action.
Validation:
- `cargo check -p orbit-engine -p orbit-core`
- `cargo test -p orbit-engine job_executor::tests::recovery --no-fail-fast`
- `cargo test -p orbit-engine job_executor::tests::target --no-fail-fast`
- `cargo test -p orbit-core command::job::tests::catalog --no-fail-fast`
- `make ci-fast`
- `cargo fmt --check`
- `git diff --check`

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10621-6a77f1e4`
- Behind base: 0
- Ahead of base: 1