### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/orbit-docs-plugin/1_scope.md
+++ b/docs/design/orbit-docs-plugin/1_scope.md
@@ -1,3 +1,10 @@
+---
+type: design
+summary: "Scope: extract docs + search into a plugin-style feature crate"
+tags: [orbit-docs-plugin]
+last_validated: 2026-08-09
+---
+
 # Scope: extract docs + search into a plugin-style feature crate
 
 Status: draft (uncommitted) — scoping for the docs+search pluginization pilot.

--- a/docs/design/orbit-docs/1_overview.md
+++ b/docs/design/orbit-docs/1_overview.md
@@ -10,15 +10,16 @@ summary: "Orbit Docs — what the human-authored docs corpus is, why it exists a
 tags: [orbit-docs]
 related_features: [orbit-docs]
 related_artifacts: [ORB-00163, ORB-00206, ORB-10319, ADR-0169, ADR-0170, ADR-0171, ADR-0180]
+last_validated: 2026-08-09
 ---
 
 # Orbit Docs — Overview
 
-Orbit Docs is the human-authored knowledge corpus for an Orbit workspace. It indexes the Markdown a team writes for itself — design narratives, reusable code patterns, runbooks, glossaries — and exposes CLI/admin verbs under `orbit docs` plus agent retrieval through the unified `orbit.search` MCP tool. It deliberately does not own the corpus's storage shape: docs are PR-reviewed files under a configurable `docs/` root, and Orbit's only on-disk artifact is the `[docs].roots` entry in `.orbit/config.toml`.
+Orbit Docs is the human-authored knowledge corpus for an Orbit workspace. It indexes the Markdown a team writes for itself — design narratives, reusable code patterns, runbooks, glossaries — and exposes CLI/admin verbs under `orbit docs` plus agent retrieval through the unified `orbit.search` MCP tool. It deliberately does not own a tool-managed copy of the corpus: docs remain PR-reviewed files under configurable `[docs].roots` entries.
 
-The system is **pull-first**: agents call `orbit search --kind doc` (or `--kind all` for federated doc+ADR) or `orbit docs show` when they need context. Push-style injection (PreToolUse hook surfaces, `task show --with-context`) is a downstream feature, designed but not yet wired ([ORB-00166], [ORB-00167]).
+The system is **pull-first**: agents call `orbit search --kind doc` (or `--kind all` for federated doc+ADR) or `orbit docs show` when they need context. Task-time related-doc injection is available through `task show --with-context`; PreToolUse hook surfaces remain downstream work ([ORB-00166], [ORB-00167]).
 
-Phase 1 ships the corpus, the locked frontmatter schema, the six-verb surface, the `orbit-docs` skill, doc-corpus embeddings via `orbit docs index`, and a one-shot migrator that backfills legacy `docs/design/<feature>/` and `docs/design-patterns/` files. [2_design.md](./2_design.md) specifies the schema, walker, surface, tolerant indexer, and hybrid search path; [3_vision.md](./3_vision.md) names open questions and the remaining roadmap (ADR folding, hook integration); [4_decisions.md](./4_decisions.md) is the ADR log.
+Phase 1 ships the corpus, the locked frontmatter schema, the six-verb surface, the `orbit-docs` skill, doc-corpus embeddings via `orbit docs index`, and a one-shot migrator that backfills legacy `docs/design/<feature>/` and `docs/design-patterns/` files. [2_design.md](./2_design.md) specifies the schema, walker, surface, tolerant indexer, and hybrid search path; [3_vision.md](./3_vision.md) names open questions and the remaining roadmap (hook integration, ADR folding); [4_decisions.md](./4_decisions.md) is the ADR log.
 
 ---
 
@@ -51,8 +52,8 @@ Six fields, two required, four optional:
 | `type` | yes | enum: `design \| pattern \| context \| glossary \| runbook` | Coarse classifier for filtering. |
 | `summary` | yes | non-empty single line | One-line retrieval hook; what the doc is about. |
 | `tags` | no | string list | Free-form labels; used by `orbit docs list --tag`. |
-| `paths` | no | glob string list | File-scope patterns this doc applies to (e.g. `crates/orbit-cli/**`). Used by hook-time injection. |
-| `related_features` | no | string list | Feature slugs this doc covers; join key with task `related_features`. |
+| `paths` | no | glob string list | File-scope patterns this doc applies to (e.g. `crates/orbit-cli/**`). Used by task-context matching and planned hook-time injection. |
+| `related_features` | no | string list | Feature slugs this doc covers; join key with normalized task tags used as feature selectors. |
 | `related_artifacts` | no | string list | Cross-references to other Orbit artifacts via [ADR-0171] ID-prefix dispatch. |
 
 Schema rationale and the closed-by-default choice: [ADR-0169]. Why ID-prefix dispatch over object-shape references: [ADR-0171].
@@ -109,9 +110,9 @@ If you find yourself wanting to write "rule: do X because Y" in a doc, that's a 
 | Backfill migrator | `orbit docs migrate` | [ORB-00163] |
 | Internal hardening (real diff, robust YAML edit, batched gitignore) | [crates/orbit-core/src/command/docs/](../../../crates/orbit-core/src/command/docs/) | [ORB-00164] |
 | Retire `orbit-design` skill | [crates/orbit-core/assets/skills/orbit-design/](../../../crates/orbit-core/assets/skills/orbit-design/) | [ORB-00165] |
-| Inject into `task show --with-context` | [crates/orbit-cli/src/command/task/](../../../crates/orbit-cli/src/command/task/) | [ORB-00166] |
+| Inject into `task show --with-context` | [crates/orbit-cli/src/command/task/](../../../crates/orbit-cli/src/command/task/) | [ORB-00166] (shipped) |
 | Extend PreToolUse hook to surface docs | [crates/orbit-cmd/src/learning_hook.rs](../../../crates/orbit-cmd/src/learning_hook.rs) | [ORB-00167] |
-| Semantic embeddings ranker (v2) | [crates/orbit-core/src/command/semantic.rs](../../../crates/orbit-core/src/command/semantic.rs) | [ORB-00168] |
+| Doc semantic embeddings and hybrid ranker | [crates/orbit-core/src/command/semantic.rs](../../../crates/orbit-core/src/command/semantic.rs) | [ORB-00206] (shipped) |
 | Fold `.orbit/adrs/` into corpus (v2 design) | [.orbit/adrs/](../../../.orbit/adrs/) | [ORB-00169] |
 
 ---

--- a/docs/design/orbit-docs/2_design.md
+++ b/docs/design/orbit-docs/2_design.md
@@ -11,6 +11,7 @@ tags: [orbit-docs]
 paths: ["crates/orbit-core/src/command/docs/**", "crates/orbit-core/src/runtime/orbit_tool_host/docs_tools.rs", "crates/orbit-tools/src/builtin/orbit/docs.rs", "crates/orbit-remote/src/mcp/host.rs", "crates/orbit-cli/src/command/docs.rs"]
 related_features: [orbit-docs]
 related_artifacts: [ORB-00163, ORB-00206, ORB-10319, ADR-0169, ADR-0170, ADR-0171, ADR-0180]
+last_validated: 2026-08-09
 ---
 
 # Orbit Docs — Design
@@ -56,13 +57,13 @@ The tolerant indexer populates `tags` with the feature slug for design docs (e.g
 
 ### 1.4 `paths` (optional)
 
-Glob string list. Names file paths the doc applies to. This is the join key for hook-time scoping ([ORB-00167]): when an agent is about to Edit / Read / Write a file, the hook can surface docs whose `paths` glob matches.
+Glob string list. Names file paths the doc applies to. This is the join key for task-context scoping and planned hook-time scoping ([ORB-00167]): task context can surface docs whose `paths` glob matches, and a future hook can do the same for Edit / Read / Write operations.
 
 Not used by `orbit search --kind doc` ranking in v1; the field exists for the injection wiring.
 
 ### 1.5 `related_features` (optional)
 
-Free-form string list. The join key for task-time scoping ([ORB-00166]): when an agent runs `task show <id> --with-context`, the renderer can surface docs whose `related_features` overlaps with the task's `related_features`.
+Free-form string list. The join key for task-time scoping ([ORB-00166]): when an agent runs `task show <id> --with-context`, the renderer can surface docs whose `related_features` overlaps with the task's normalized tags, which currently act as feature selectors.
 
 ### 1.6 `related_artifacts` (optional)
 
@@ -192,7 +193,7 @@ Default limit is 20. `--limit N` (CLI) or `limit` field (MCP) caps results. v1 d
 ### 5.4 What's missing
 
 - No body-text scoring. The whole point of frontmatter is that the body is unstructured; ranking against arbitrary Markdown adds noise without semantic ranking.
-- No semantic embeddings. Deferred to [ORB-00168].
+- Semantic embeddings are opt-in through `orbit docs index` and `orbit search --hybrid`; lexical search remains the default.
 - No `paths` or `related_features` scoring. These fields exist for *injection-time* scoping (hook + task.show), not for direct search.
 
 ---
@@ -272,10 +273,8 @@ When the section is absent or the file is empty, the default root is `["docs/"]`
 ## 9. Concerns & Honest Limitations
 
 - **Lexical search is still frontmatter-only.** Plain `orbit search --kind doc` scores summary + tags + type only. Body-level concept recall requires `orbit docs index` plus `orbit search --kind doc --hybrid`.
-- **`migration_diff` is not a real diff.** It prints the first 12 lines of `before` and first 16 lines of `after` glued together with `@@` markers. Misleading label. [ORB-00164] tracks the fix.
-- **`update_existing_frontmatter` hand-edits YAML by line.** Works for simple `key: scalar` legacy headers. Will misbehave on multi-line block scalars (`description: |`) and quoted values containing colons. [ORB-00164] tracks the round-trip-through-`serde_yaml` fix.
-- **`is_git_ignored` shells out per file.** Acceptable at ~100 docs. Will degrade at thousands. [ORB-00164] tracks the batched-stdin or `ignore`-crate fix.
-- **No hook-time or task-time injection yet.** The retrieval primitive ships in v1; injection is [ORB-00166] and [ORB-00167].
+- **Migration uses a generated line diff.** The migrator now compares the complete before/after documents, while YAML frontmatter updates are round-tripped through `serde_yaml`.
+- **Hook-time injection is not wired yet.** Task-time related-doc injection is available through `task show --with-context`; PreToolUse hook integration remains [ORB-00167].
 - **Doc semantic freshness is explicit.** Task writes enqueue background embeddings, but docs require `orbit docs index` until a future watcher/background indexer exists.
 - **ADRs are not in the corpus.** [ORB-00169] is the design question.
 

--- a/docs/design/orbit-docs/3_vision.md
+++ b/docs/design/orbit-docs/3_vision.md
@@ -10,11 +10,12 @@ summary: "Orbit Docs — open questions, the remaining roadmap (injection, ADR f
 tags: [orbit-docs]
 related_features: [orbit-docs]
 related_artifacts: [ORB-00164, ORB-00165, ORB-00166, ORB-00167, ORB-00168, ORB-00169, ORB-00206, ADR-0180]
+last_validated: 2026-08-09
 ---
 
 # Orbit Docs — Vision
 
-The v1 from [ORB-00163] is the corpus and the retrieval primitive; [ORB-00206] adds doc embeddings and opt-in hybrid ranking. Injection wiring and the ADR-folding question remain future work. This document names the open questions, the planned follow-up work, the prior art that shaped the design, and the dimensions on which orbit-docs differs from sibling tools.
+The v1 from [ORB-00163] is the corpus and the retrieval primitive; [ORB-00206] adds doc embeddings and opt-in hybrid ranking. Task-time related-doc injection is shipped; PreToolUse hook integration and the ADR-folding question remain future work. This document names the open questions, the planned follow-up work, the prior art that shaped the design, and the dimensions on which orbit-docs differs from sibling tools.
 
 ---
 
@@ -22,7 +23,7 @@ The v1 from [ORB-00163] is the corpus and the retrieval primitive; [ORB-00206] a
 
 ### 1.1 Should `orbit-design` retire on the same cadence as orbit-docs adoption?
 
-[ORB-00165] is filed but deliberately gated on three pre-flight conditions: at least two PRs using `orbit docs`, hook + task.show injection wired, and explicit team agreement that the 4-numbered layout is a recommendation rather than a rule. Retiring `orbit-design` too early forces a flag-day for authors who learned the old convention; retiring it too late leaves a duplicated retrieval surface (`orbit design list/show` vs `orbit docs list/show`) and a "which mental model do I use?" friction for new agents.
+[ORB-00165] is filed but deliberately gated on three pre-flight conditions: at least two PRs using `orbit docs`, PreToolUse hook injection wired, and explicit team agreement that the 4-numbered layout is a recommendation rather than a rule. Task-time `task.show --with-context` injection is already wired. Retiring `orbit-design` too early forces a flag-day for authors who learned the old convention; retiring it too late leaves a duplicated retrieval surface (`orbit design list/show` vs `orbit docs list/show`) and a "which mental model do I use?" friction for new agents.
 
 The harder sub-question: does `orbit-design` carry anything load-bearing that orbit-docs doesn't? Two candidates:
 
@@ -43,11 +44,11 @@ The author's current bias is toward path 2 — keep the lifecycles separate, but
 
 ### 1.3 When do semantic embeddings start paying off?
 
-[ORB-00168] is filed but priority-low. With ~100 docs today, BM25-ish substring + tag-exact matches the corpus shape well: most queries are "find the doc about RAII" (exact concept name) rather than "find the doc that explains anything resembling X" (semantic similarity).
+[ORB-00168] is filed, and [ORB-00206] has since shipped doc embeddings and opt-in hybrid ranking. With ~100 docs today, BM25-ish substring + tag-exact matches the corpus shape well: most queries are "find the doc about RAII" (exact concept name) rather than "find the doc that explains anything resembling X" (semantic similarity).
 
 The break-even point is roughly the size at which agents stop knowing the exact phrase they're looking for. Empirically, that's around 500 docs in our experience with similar systems, but the threshold is corpus-shape-dependent, not just count-dependent. A team that writes prose-heavy designs hits orbit-search payoff sooner than a team whose docs are mostly bullet lists and tables.
 
-The right trigger is *retrieval-quality complaint*: when agents start saying "I can't find the doc I know exists," that's the signal to land [ORB-00168]. Not before.
+The remaining question is when hybrid ranking should become the default. A retrieval-quality complaint — agents saying "I can't find the doc I know exists" — is a useful signal to revisit the default, while keeping the explicit `orbit docs index` freshness step visible.
 
 ### 1.4 What does injection latency cost the hook?
 
@@ -71,7 +72,7 @@ The tradeoff is straightforward: stability of cross-references vs. human-authore
 
 ### 2.1 Orbit project learnings
 
-[docs/design/project-learnings/](../project-learnings/) is the closest internal sibling. Both surfaces aim to elevate knowledge above per-agent memory into a shared queryable artifact, and both are intended for push-style injection eventually. They differ on:
+[docs/design/project-learnings/](../project-learnings/) is the closest internal sibling. Both surfaces aim to elevate knowledge above per-agent memory into a shared queryable artifact. Learnings are push-first; Orbit Docs supports pull retrieval plus task-time context injection, while hook-time injection remains future work. They differ on:
 
 | Dimension | Learnings | Orbit Docs |
 |-----------|-----------|------------|
@@ -79,7 +80,7 @@ The tradeoff is straightforward: stability of cross-references vs. human-authore
 | Storage | `.orbit/learnings/<id>.yaml` + SQLite index | `docs/**/*.md`, no on-disk store |
 | Allocation | `orbit.learning.add` mints `L-NNNN` IDs | Author writes a file; no ID allocation |
 | Lifecycle | `update`, `supersede`, `prune`, `upvote` | `add` a root, write files; no supersede flow |
-| Discovery | Push-first (scope-glob injection) | Pull-first (search / show); push is downstream |
+| Discovery | Push-first (scope-glob injection) | Pull-first (search / show), with task-time context injection |
 | Cross-references | `related_features`, `evidence` | `related_features`, `related_artifacts`, `paths` |
 
 The boundary (rule-with-failure-mode vs. explanatory-context) is the load-bearing decision. Both surfaces being separate, with explicit cross-references via `related_artifacts: [L-NNNN]`, is the v1 shape.
@@ -90,7 +91,7 @@ The boundary (rule-with-failure-mode vs. explanatory-context) is the load-bearin
 
 ### 2.3 Semantic search
 
-[docs/design/orbit-search/](../orbit-search/) covers the embeddings infrastructure that orbit-search uses for tasks. [ORB-00168] extends that infrastructure to cover docs. The model and vector store stay the same; the index is a sibling of the task index.
+[docs/design/orbit-search/](../orbit-search/) covers the embeddings infrastructure that orbit-search uses for tasks. [ORB-00206] extends that infrastructure to cover docs. The model and vector store stay the same; the index is a sibling of the task index.
 
 ### 2.4 Retired graph design
 

--- a/docs/design/orbit-docs/4_decisions.md
+++ b/docs/design/orbit-docs/4_decisions.md
@@ -10,6 +10,7 @@ summary: "Orbit Docs — accepted ADRs: locked frontmatter schema, `.orbit/` vs 
 tags: [orbit-docs]
 related_features: [orbit-docs]
 related_artifacts: [ADR-0169, ADR-0170, ADR-0171, ADR-0180, ORB-00163, ORB-00206]
+last_validated: 2026-08-09
 ---
 
 # Orbit Docs — Decisions


### PR DESCRIPTION
## Task

[ORB-10655](https://orbit-cli.com/tasks/ORB-10655) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Batch selection: inventory of all in-scope prose under docs/ found six never-validated documents, which sort before dated documents and were selected by stable path order: docs/POSITIONING.md; docs/design/orbit-docs-plugin/1_scope.md; docs/design/orbit-docs/1_overview.md; docs/design/orbit-docs/2_design.md; docs/design/orbit-docs/3_vision.md; and docs/design/orbit-docs/4_decisions.md.
- docs/POSITIONING.md was selected but left completely unchanged and unstamped because its product positioning, audience, commercial, and roadmap claims are intent-level assertions not verifiable against repository implementation.
- docs/design/orbit-docs-plugin/1_scope.md was verified against the current docs/search module paths, Cargo manifests, and the existing inference contract in crates/orbit-core/src/command/docs/frontmatter.rs. Its frontmatter was migrated with type=design, summary="Scope: extract docs + search into a plugin-style feature crate", tags=[orbit-docs-plugin], and last_validated: 2026-08-09. The proposed extraction, open questions, and future-state claims were retained as draft planning content.
- docs/design/orbit-docs/1_overview.md was checked against the current docs CLI/core/tool/MCP surfaces, task.show related-doc path, semantic indexing, and config parser. Corrected stale wording that task-time injection and doc embeddings were future work, clarified that hook-time injection remains future work, updated the task-tag feature join, and stamped last_validated: 2026-08-09.
- docs/design/orbit-docs/2_design.md was checked against frontmatter, walker, migration, config, task-related-doc, semantic-index, hybrid-search, and MCP registration sources. Corrected the stale related_features join description, updated semantic embeddings to their shipped opt-in state, and replaced obsolete migration-diff, YAML-edit, gitignore, and injection limitations; stamped last_validated: 2026-08-09.
- docs/design/orbit-docs/3_vision.md was checked against task.show --with-context, hook source coverage, semantic indexing/hybrid search, and current docs-search behavior. Updated the roadmap to distinguish shipped task-time injection and embeddings from future hook integration, and stamped last_validated: 2026-08-09. Open questions, estimates, historical references, and future proposals that are not code-verifiable were left unchanged.
- docs/design/orbit-docs/4_decisions.md was checked with orbit.adr.show for ADR-0169, ADR-0170, ADR-0171, and ADR-0180 plus the current parser/walker/search/config sources; no prose drift was found, and last_validated: 2026-08-09 was added.
- No new document, section, sidecar, or metadata system was introduced. No forbidden ADR, changelog, archive, task, graph, or generated-state file changed.
Assessment: Five selected docs were verified and refreshed; the one selected positioning document was deliberately left unvalidated because its claims are not code-observable.
Validation:
- make ci-fast: passed, including scripts/generate-doc-indexes.sh --check and all guardrails.
- git diff --check: passed; forbidden-path diff check: passed.
- cargo test -p orbit-core command::docs --lib: could not compile because of the pre-existing unrelated unresolved import orbit_common::types::RoleSlot at crates/orbit-core/src/runtime/v2_host/mod.rs:31; no files in that runtime area were changed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10655-6a77f4eb`
- Behind base: 0
- Ahead of base: 1