### PR TITLE
chore: retire obsolete learning records [ORB-10661]

### DIFF
--- a/.orbit/learnings/L-0017/learning.yaml
+++ b/.orbit/learnings/L-0017/learning.yaml
@@ -1,8 +1,6 @@
 schema_version: 1
 id: L-0017
-legacy_ids:
-- L20260519-1
-status: active
+status: superseded
 scope:
   paths:
   - .codex/config.toml
@@ -16,5 +14,7 @@ body: Codex CLI hook command output is not Claude-compatible plaintext for PreTo
 evidence:
 - kind: task
   reference: ORB-00159
+legacy_ids:
+- L20260519-1
 created_at: 2026-05-19T02:49:42.769233Z
-updated_at: 2026-05-19T02:49:42.769233Z
+updated_at: 2026-08-09T03:46:08.643861Z

--- a/.orbit/learnings/L-0018/learning.yaml
+++ b/.orbit/learnings/L-0018/learning.yaml
@@ -1,8 +1,6 @@
 schema_version: 1
 id: L-0018
-legacy_ids:
-- L20260519-2
-status: active
+status: superseded
 scope:
   paths:
   - .gitignore
@@ -17,5 +15,7 @@ body: |
 evidence:
 - kind: task
   reference: ORB-00162
+legacy_ids:
+- L20260519-2
 created_at: 2026-05-19T04:48:07.323530Z
-updated_at: 2026-05-19T04:48:07.323530Z
+updated_at: 2026-08-09T03:46:11.880258Z

--- a/.orbit/learnings/L-0045/learning.yaml
+++ b/.orbit/learnings/L-0045/learning.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 id: L-0045
-status: active
+status: superseded
 scope:
   paths:
   - crates/orbit-graph/src/extract/languages/config.rs
@@ -17,6 +17,6 @@ body: |-
   Recurring gotcha for any extension-based file classifier (loaders, syntax highlighters, graph extractors). Evidence: task ORB-00305, L-0015 (worktree root notes).
 evidence: []
 created_at: 2026-05-24T22:20:25.052607Z
-updated_at: 2026-07-26T22:23:56.961442945Z
+updated_at: 2026-08-09T03:46:16.680503Z
 created_by: grok
 priority: 80

--- a/.orbit/learnings/L-0046/learning.yaml
+++ b/.orbit/learnings/L-0046/learning.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 id: L-0046
-status: active
+status: superseded
 scope:
   paths:
   - crates/orbit-graph/src/extract/languages/**
@@ -11,5 +11,5 @@ evidence:
 - kind: task
   reference: ORB-00302
 created_at: 2026-05-24T22:28:45.718895Z
-updated_at: 2026-07-26T22:24:01.887197761Z
+updated_at: 2026-08-09T03:46:19.470830Z
 created_by: codex

--- a/.orbit/learnings/L-0048/learning.yaml
+++ b/.orbit/learnings/L-0048/learning.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 id: L-0048
-status: active
+status: superseded
 scope:
   paths:
   - crates/orbit-graph/src/sync/**/*.rs
@@ -14,6 +14,6 @@ evidence:
 - kind: task
   reference: ORB-00309
 created_at: 2026-05-25T01:53:27.242036Z
-updated_at: 2026-05-25T01:53:27.242036Z
+updated_at: 2026-08-09T03:46:22.419840Z
 created_by: codex
 priority: 120

--- a/.orbit/learnings/L-0049/learning.yaml
+++ b/.orbit/learnings/L-0049/learning.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 id: L-0049
-status: active
+status: superseded
 scope:
   paths:
   - crates/orbit-graph/src/sync/**/*.rs
@@ -13,6 +13,6 @@ evidence:
 - kind: task
   reference: ORB-00310
 created_at: 2026-05-25T02:21:55.353496Z
-updated_at: 2026-05-25T02:21:55.353496Z
+updated_at: 2026-08-09T03:46:25.276234Z
 created_by: codex
 priority: 120

--- a/.orbit/learnings/L-0050/learning.yaml
+++ b/.orbit/learnings/L-0050/learning.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 id: L-0050
-status: active
+status: superseded
 scope:
   paths:
   - crates/orbit-graph/src/sync/tests/pass2.rs
@@ -15,5 +15,5 @@ evidence:
 - kind: task
   reference: ORB-00311
 created_at: 2026-05-25T02:39:44.048602Z
-updated_at: 2026-07-26T22:24:07.867815530Z
+updated_at: 2026-08-09T03:46:33.531880Z
 priority: 100

--- a/.orbit/learnings/L-0051/learning.yaml
+++ b/.orbit/learnings/L-0051/learning.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 id: L-0051
-status: active
+status: superseded
 scope:
   paths:
   - crates/orbit-graph/src/sync/**/*.rs
@@ -14,5 +14,5 @@ evidence:
 - kind: task
   reference: ORB-00312
 created_at: 2026-05-25T02:49:53.244444Z
-updated_at: 2026-05-25T02:49:53.244444Z
+updated_at: 2026-08-09T03:46:36.701336Z
 priority: 100

--- a/.orbit/learnings/L-0052/learning.yaml
+++ b/.orbit/learnings/L-0052/learning.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 id: L-0052
-status: active
+status: superseded
 scope:
   paths:
   - crates/orbit-graph/src/**/*.rs
@@ -14,6 +14,6 @@ evidence:
 - kind: task
   reference: ORB-00313
 created_at: 2026-05-25T03:39:50.772363Z
-updated_at: 2026-05-25T03:39:50.772363Z
+updated_at: 2026-08-09T03:46:39.694960Z
 created_by: codex
 priority: 120

--- a/.orbit/learnings/L-0053/learning.yaml
+++ b/.orbit/learnings/L-0053/learning.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 id: L-0053
-status: active
+status: superseded
 scope:
   paths:
   - crates/orbit-mcp/**/*.rs
@@ -14,6 +14,6 @@ evidence:
 - kind: task
   reference: ORB-00319
 created_at: 2026-05-25T05:20:06.606881Z
-updated_at: 2026-05-25T05:20:06.606881Z
+updated_at: 2026-08-09T03:46:46.306528Z
 created_by: codex
 priority: 120

--- a/.orbit/learnings/L-0055/learning.yaml
+++ b/.orbit/learnings/L-0055/learning.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 id: L-0055
-status: active
+status: superseded
 scope:
   paths:
   - crates/orbit-graph/src/sync/**/*.rs
@@ -16,6 +16,6 @@ evidence:
 - kind: task
   reference: ORB-00325
 created_at: 2026-05-25T07:20:57.247686Z
-updated_at: 2026-05-25T07:20:57.247686Z
+updated_at: 2026-08-09T03:46:49.457176Z
 created_by: codex
 priority: 120

--- a/.orbit/learnings/L-0056/learning.yaml
+++ b/.orbit/learnings/L-0056/learning.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 id: L-0056
-status: active
+status: superseded
 scope:
   paths:
   - crates/orbit-graph/src/sync/pass1.rs
@@ -16,5 +16,5 @@ evidence:
 - kind: task
   reference: ORB-00330
 created_at: 2026-05-25T17:50:38.298139Z
-updated_at: 2026-07-26T22:24:16.780537086Z
+updated_at: 2026-08-09T03:46:52.371606Z
 created_by: codex

--- a/.orbit/learnings/L-0058/learning.yaml
+++ b/.orbit/learnings/L-0058/learning.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 id: L-0058
-status: active
+status: superseded
 scope:
   paths:
   - crates/orbit-mcp/src/adapter/**/*.rs
@@ -15,5 +15,5 @@ evidence:
   reference: ORB-00344
 supersedes: L-0057
 created_at: 2026-05-25T21:43:07.688365Z
-updated_at: 2026-05-25T21:43:37.064615Z
+updated_at: 2026-08-09T03:46:55.717346Z
 priority: 120


### PR DESCRIPTION
## Summary

- archive 13 obsolete learning records through Orbit's governed lifecycle command
- preserve IDs and bodies while changing lifecycle status to superseded
- leave source code, ADR bodies, tasks, frictions, and unrelated knowledge untouched

## Validation

- all 13 archive operations returned success
- git diff --check
- staged diff is limited to the 13 task-scoped learning records

Task: ORB-10661