### PR TITLE
Expose the prior blocking summary to a redispatched executor

### DIFF
--- a/crates/orbit-core/src/runtime/v2_host/task_context.rs
+++ b/crates/orbit-core/src/runtime/v2_host/task_context.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use orbit_common::types::{Task, TaskStatus, prune_missing_context_files};
-use orbit_engine::DispatchError;
+use orbit_common::types::{Task, TaskHistoryEntry, TaskStatus, prune_missing_context_files};
+use orbit_engine::{DispatchError, WORKFLOW_RUN_FAILED_EVENT};
 use serde_json::Value;
 
 use crate::OrbitRuntime;
@@ -50,14 +50,25 @@ pub(super) fn task_context_for_agent_input(
             "load task `{task_id}` for agent envelope: {err}"
         ))
     })?;
+    let task_history = runtime.get_task_history(task_id).map_err(|err| {
+        DispatchError::CliInvocationFailed(format!(
+            "load task `{task_id}` history for agent envelope: {err}"
+        ))
+    })?;
     Ok(Some(agent_task_context_json(
         &task,
+        &task_history,
         input,
         &runtime.paths().repo_root,
     )))
 }
 
-fn agent_task_context_json(task: &Task, input: &Value, fallback_repo_root: &Path) -> Value {
+fn agent_task_context_json(
+    task: &Task,
+    task_history: &[TaskHistoryEntry],
+    input: &Value,
+    fallback_repo_root: &Path,
+) -> Value {
     let workspace_path = input
         .get("workspace_path")
         .and_then(Value::as_str)
@@ -72,7 +83,7 @@ fn agent_task_context_json(task: &Task, input: &Value, fallback_repo_root: &Path
     let (kept_context_files, _dropped) =
         prune_missing_context_files(&prune_root, canonical_context_files);
 
-    serde_json::json!({
+    let mut context = serde_json::json!({
         "id": task.id.clone(),
         "status": task.status.cli_name(),
         "terminal": refuses_implementer_writes(task.status),
@@ -85,6 +96,33 @@ fn agent_task_context_json(task: &Task, input: &Value, fallback_repo_root: &Path
         "external_refs": task.external_refs.clone(),
         "workspace_path": workspace_path,
         "repo_root": repo_root,
+    })
+    .as_object()
+    .expect("agent task context is an object")
+    .clone();
+
+    if !task.execution_summary.trim().is_empty() {
+        context.insert(
+            "execution_summary".to_string(),
+            Value::String(task.execution_summary.clone()),
+        );
+    }
+    if let Some(status_note) = workflow_failure_status_note(task_history) {
+        context.insert(
+            "status_note".to_string(),
+            Value::String(status_note.to_string()),
+        );
+    }
+
+    Value::Object(context)
+}
+
+fn workflow_failure_status_note(task_history: &[TaskHistoryEntry]) -> Option<&str> {
+    task_history.iter().rev().find_map(|entry| {
+        (entry.event == WORKFLOW_RUN_FAILED_EVENT)
+            .then_some(entry.note.as_deref())
+            .flatten()
+            .filter(|note| !note.trim().is_empty())
     })
 }
 

--- a/crates/orbit-core/src/runtime/v2_host/tests/task_context.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/task_context.rs
@@ -1,5 +1,5 @@
 use orbit_common::types::TaskStatus;
-use orbit_engine::V2RuntimeHost;
+use orbit_engine::{TaskAutomationUpdate, TaskWriteHost, V2RuntimeHost, WORKFLOW_RUN_FAILED_EVENT};
 use serde_json::json;
 
 use crate::OrbitRuntime;
@@ -43,6 +43,52 @@ fn task_context_for_agent_input_embeds_canonical_task_with_input_overrides() {
     assert_eq!(context["repo_root"], "/override/repo");
     assert_eq!(context["status"], task.status.cli_name());
     assert_eq!(context["terminal"], false);
+    assert!(context.get("execution_summary").is_none());
+    assert!(context.get("status_note").is_none());
+
+    runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                execution_summary: Some("Prior attempt needs a missing capability.".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("record prior execution summary");
+    runtime
+        .apply_task_automation_update(
+            &task.id,
+            TaskAutomationUpdate {
+                status: Some(TaskStatus::Blocked),
+                status_event: Some(WORKFLOW_RUN_FAILED_EVENT.to_string()),
+                status_note: Some("workflow run failed: missing provider capability".to_string()),
+                ..TaskAutomationUpdate::default()
+            },
+        )
+        .expect("record workflow failure");
+    runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::InProgress),
+                ..Default::default()
+            },
+        )
+        .expect("redispatch task");
+
+    let redispatched_context = runtime
+        .task_context_for_agent_input(&json!({ "task_id": task.id.clone() }))
+        .expect("build redispatched task context")
+        .expect("task context present");
+
+    assert_eq!(
+        redispatched_context["execution_summary"],
+        "Prior attempt needs a missing capability."
+    );
+    assert_eq!(
+        redispatched_context["status_note"],
+        "workflow run failed: missing provider capability"
+    );
 }
 
 /// [ORB-10499]: `agent_implement` can be dispatched against a task that has


### PR DESCRIPTION
## Task

[ORB-10645](https://orbit-cli.com/tasks/ORB-10645) — Expose the prior blocking summary to a redispatched executor

### Description

## Problem

A task that was correctly blocked with a capability-gap summary was redispatched, and the next executor received no trace of why it had been blocked before. It reproduced the same blocked conclusion from scratch, with no new information.

## Evidence (verified against the current tree, 2026-08-08)

The agent envelope's `task` object is assembled by `agent_task_context_json` in `crates/orbit-core/src/runtime/v2_host/task_context.rs`. It carries id, status, terminal, title, description, acceptance_criteria, plan, context_files, tags, external_refs, workspace_path, repo_root.

Both places a blocking rationale can live are absent from that payload:

- an agent self-block records it on `execution_summary`
- a run-failure block records it as a status note (`blocked_workflow_failure_update` in `crates/orbit-engine/src/context/outcome.rs` sets `status_note` and leaves `execution_summary` at default)

The engine side needs no change: `cli_agent_envelope_json` clones whatever JSON the host returns.

## Why It Matters

Redispatch of a blocked task costs a full provider run to rediscover a conclusion the previous run already reached and recorded.

## Scope

**Scoped down from the original filing.** The originally proposed gate — rejecting any blocked-task reset that lacks a written reason — is deliberately **out of scope**. Resets are usually legitimate human overrides, and a mandatory-reason field taxes every one of them to catch a rare mistake. Do not add it.

The remaining goal is only that a redispatched executor can see the prior blocking rationale.

## Constraints / Notes

- Terminal-write guards and the implementer write refusal modeled in this file must remain unchanged.
- Do not widen the envelope beyond what a blocked-then-redispatched executor needs; envelope size is context budget on every run.
- Prior blocking evidence is advisory input to the executor, not a gate — it must not be made load-bearing for any decision.

### Acceptance Criteria

- A task carrying a prior `execution_summary` has that summary present in the agent envelope's task context.
- A task blocked by run failure exposes its status note in the same envelope, or the task records why that path is deliberately excluded.
- A test asserts the field is present when set and absent or empty when not, in the existing task-context test module.
- The terminal-write guard and implementer write refusal behavior are unchanged, asserted by the existing tests continuing to pass.
- No mandatory-reason gate on blocked-task reset is introduced.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added conditional `execution_summary` to agent task context so a redispatched executor receives a prior non-empty implementer summary.
- Added conditional `status_note` sourced only from the latest non-empty `workflow_run_failed` history entry, preserving the run-failure rationale without exposing full history.
- Extended the existing task-context test to cover absent fields and a blocked-then-redispatched task carrying both evidence fields.
Assessment: Scoped envelope-only change; terminal-write and reset behavior remain unchanged.
Validation:
- cargo test -p orbit-core runtime::v2_host::tests::task_context --lib
- make ci-fast
- git diff --check
Friction checkpoint: no qualifying friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10645-6a77fa27`
- Behind base: 0
- Ahead of base: 1