### PR TITLE
Make embedded-asset portability checking robust to binary files

### DIFF
--- a/crates/orbit-core/src/command/skill.rs
+++ b/crates/orbit-core/src/command/skill.rs
@@ -661,22 +661,60 @@ mod tests {
         }
     }
 
-    /// Every portability violation in `root`, each prefixed with its path
-    /// relative to `crates/orbit-core/assets/` for a readable failure report.
-    fn portability_failures_under(label: &str, root: &Path) -> Vec<String> {
+    /// Portability violations and visibly skipped non-text files under `root`.
+    #[derive(Debug, PartialEq, Eq)]
+    struct PortabilityScan {
+        failures: Vec<String>,
+        skipped: Vec<String>,
+    }
+
+    /// Scan `root`, prefixing each result with its path relative to
+    /// `crates/orbit-core/assets/` for a readable failure report.
+    fn portability_scan_under(label: &str, root: &Path) -> PortabilityScan {
         let files = collect_relative_files(root)
             .unwrap_or_else(|e| panic!("collect_relative_files({}): {e}", root.display()));
 
         let mut failures = Vec::new();
+        let mut skipped = Vec::new();
         for relative in files {
             let path = root.join(&relative);
-            let content = std::fs::read_to_string(&path)
-                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            let content = match std::fs::read_to_string(&path) {
+                Ok(content) => content,
+                Err(error) if error.kind() == std::io::ErrorKind::InvalidData => {
+                    skipped.push(format!(
+                        "  {label}/{}: skipped non-UTF-8 file",
+                        relative.display()
+                    ));
+                    continue;
+                }
+                Err(error) => panic!("read {}: {error}", path.display()),
+            };
             for violation in portability_violations(&content) {
                 failures.push(format!("  {label}/{}: {violation}", relative.display()));
             }
         }
-        failures
+        PortabilityScan { failures, skipped }
+    }
+
+    #[test]
+    fn portability_checker_skips_non_utf8_files_without_hiding_text_violations() {
+        let root = tempfile::tempdir().expect("create temporary assets root");
+        std::fs::write(
+            root.path().join("bad.md"),
+            "See ORB-10530 before handoff.\n",
+        )
+        .expect("write text fixture");
+        std::fs::write(root.path().join("binary.dat"), [0xff, 0xfe]).expect("write binary fixture");
+
+        let scan = portability_scan_under("skills", root.path());
+        assert_eq!(
+            scan.failures,
+            vec!["  skills/bad.md: workspace-local artifact id `ORB-10530`"]
+        );
+        assert_eq!(
+            scan.skipped,
+            vec!["  skills/binary.dat: skipped non-UTF-8 file"]
+        );
     }
 
     #[test]
@@ -688,11 +726,10 @@ mod tests {
         // Activities were outside this check until a task description's own
         // wording — a maintainer's name plus a concrete ADR id — was copied
         // verbatim into `agent_implement.yaml` (PR #702).
-        let mut failures = portability_failures_under("skills", &assets_skills_dir());
-        failures.extend(portability_failures_under(
-            "activities",
-            &assets_activities_dir(),
-        ));
+        let skills = portability_scan_under("skills", &assets_skills_dir());
+        let activities = portability_scan_under("activities", &assets_activities_dir());
+        let mut failures = skills.failures;
+        failures.extend(activities.failures);
 
         assert!(
             failures.is_empty(),

--- a/scripts/check-embedded-asset-portability.py
+++ b/scripts/check-embedded-asset-portability.py
@@ -52,17 +52,25 @@ def violations(content: str) -> list[str]:
     return found
 
 
-def failures_under(label: str, root: Path) -> list[str]:
+def failures_under(label: str, root: Path) -> tuple[list[str], list[str]]:
     failures: list[str] = []
+    skipped: list[str] = []
     for path in sorted(candidate for candidate in root.rglob("*") if candidate.is_file()):
         relative = path.relative_to(root)
-        for violation in violations(path.read_text(encoding="utf-8")):
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            skipped.append(f"{label}/{relative}: skipped non-UTF-8 file")
+            continue
+        for violation in violations(content):
             failures.append(f"{label}/{relative}: {violation}")
-    return failures
+    return failures, skipped
 
 
-def check_assets(root: Path) -> list[str]:
-    return failures_under("skills", root / "skills") + failures_under("activities", root / "activities")
+def check_assets(root: Path) -> tuple[list[str], list[str]]:
+    skill_failures, skill_skipped = failures_under("skills", root / "skills")
+    activity_failures, activity_skipped = failures_under("activities", root / "activities")
+    return skill_failures + activity_failures, skill_skipped + activity_skipped
 
 
 def verify_fixture_reporting() -> None:
@@ -72,14 +80,22 @@ def verify_fixture_reporting() -> None:
         fixture = assets / "skills" / "fixture.md"
         fixture.parent.mkdir()
         fixture.write_text("See ORB-10530 before handoff.\n", encoding="utf-8")
+        binary_fixture = assets / "skills" / "binary.dat"
+        binary_fixture.write_bytes(b"\xff\xfe")
         (assets / "activities").mkdir()
 
         expected = "skills/fixture.md: workspace-local artifact id `ORB-10530`"
-        failures = check_assets(assets)
+        expected_skip = "skills/binary.dat: skipped non-UTF-8 file"
+        failures, skipped = check_assets(assets)
         if failures != [expected]:
             raise RuntimeError(
                 "temporary fixture did not report its relative path and violation: "
                 f"expected {expected!r}, got {failures!r}"
+            )
+        if skipped != [expected_skip]:
+            raise RuntimeError(
+                "temporary binary fixture was not visibly skipped: "
+                f"expected {expected_skip!r}, got {skipped!r}"
             )
 
 
@@ -96,10 +112,13 @@ def main() -> int:
 
     try:
         verify_fixture_reporting()
-        failures = check_assets(assets)
+        failures, skipped = check_assets(assets)
     except (OSError, RuntimeError) as error:
         print(f"embedded-asset-portability: {error}", file=sys.stderr)
         return 2
+
+    for skipped_file in skipped:
+        print(f"embedded-asset-portability: {skipped_file}", file=sys.stderr)
 
     if failures:
         print(


### PR DESCRIPTION
## Task

[ORB-10649](https://orbit-cli.com/tasks/ORB-10649) — Make embedded-asset portability checking robust to binary files

### Description

## Problem

The embedded-asset portability guardrail crashes with a traceback when an undecodable file exists under the scanned skills or activity asset roots.

## Evidence (verified against the current tree, 2026-08-08)

The rule is implemented **twice**, and both copies have the defect:

- `scripts/check-embedded-asset-portability.py` — `failures_under` reads every regular file with `read_text(encoding="utf-8")`. `main()` guards with `except (OSError, RuntimeError)`, but `UnicodeDecodeError` subclasses `ValueError`, so it escapes the guard entirely rather than producing the intended exit code.
- `crates/orbit-core/src/command/skill.rs` — `portability_failures_under` calls `read_to_string(...).unwrap_or_else(|e| panic!(...))`, and `collect_relative_files` admits every `is_file() || is_symlink()` entry. This panics on the same input.

Both reproduce today: a `.DS_Store` exists under the scanned assets root on macOS. It is gitignored, so **GitHub CI stays green while the local guardrail fails** — the same CI-blind shape as the managed-run env leak.

## Why It Matters

A guardrail traceback is easy to misdiagnose as a tool failure and waive. It also blocks anyone editing shipped skill assets from getting a real portability verdict, which is why this task should land before the other asset-editing work.

## Constraints / Notes

- Undecodable files must be reported or skipped visibly — never silently ignored in a way that could hide a real violation.
- The two implementations are duplicate encodings of one rule and have already drifted in detail (whitespace handling before the model-string check). Do not add a third. If unifying them is out of scope, say so in the execution summary rather than fixing only one.
- CI on agent-main is advisory; do not treat unrelated pre-existing failures as this task's problem.

### Acceptance Criteria

- A non-UTF-8 file under the scanned roots produces a clear skip or report instead of a traceback or panic, in both the Python script and the Rust check.
- `cargo nextest run -p orbit-core -E 'test(embedded_assets_are_repository_agnostic)'` passes on a checkout containing a binary file under the assets skills root.
- Running `scripts/check-embedded-asset-portability.py` directly on that same checkout exits cleanly rather than raising.
- Real project-specific violations in text assets are still reported — covered by a fixture that asserts a known-bad string is caught after the change.
- New coverage exists for the undecodable-file case in both implementations.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated the Python portability guard to collect and print a clear `skipped non-UTF-8 file` report while continuing to report text-asset violations.
- Extended its deterministic temporary fixture to assert that an undecodable file is skipped and a known workspace-local ID in text is still caught.
- Updated the Rust portability scan to return both failures and visible non-UTF-8 skip records, avoiding the prior panic; added matching binary/text fixture coverage.
Assessment: Both existing encodings now safely handle binary assets. Kept the two implementation-specific checks rather than adding a third shared implementation; cross-language unification is out of scope for this narrowly scoped robustness fix.
Validation:
- `python3 scripts/check-embedded-asset-portability.py` — passed.
- `cargo nextest run -p orbit-core -E 'test(portability_checker_skips_non_utf8_files_without_hiding_text_violations)'` — passed.
- `cargo nextest run -p orbit-core -E 'test(embedded_assets_are_repository_agnostic)'` — passed.
- `make ci-fast` — passed.
- `git diff --check` — passed.
Friction checkpoint: no new tooling or workflow friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10649-6a77fa27`
- Behind base: 0
- Ahead of base: 1