### PR TITLE
Reject unsupported task-update fields instead of discarding them silently

### DIFF
--- a/crates/orbit-core/src/command/task/params.rs
+++ b/crates/orbit-core/src/command/task/params.rs
@@ -71,6 +71,11 @@ pub struct TaskUpdateParams {
     pub execution_summary: Option<String>,
     pub comment: Option<String>,
     pub status: Option<TaskStatus>,
+    /// Replacement dispatch priority. `None` leaves the task's priority
+    /// untouched; the record layer has always been able to persist it
+    /// (ORB-10648 wired it through so a caller-supplied `priority` is applied
+    /// rather than discarded).
+    pub priority: Option<TaskPriority>,
     pub complexity: Option<TaskComplexity>,
     pub task_type: Option<TaskType>,
     pub source_task_id: Option<Option<String>>,
@@ -99,6 +104,7 @@ impl TaskUpdateParams {
             || self.plan.is_some()
             || self.execution_summary.is_some()
             || self.status.is_some()
+            || self.priority.is_some()
             || self.complexity.is_some()
             || self.task_type.is_some()
             || self.source_task_id.is_some()
@@ -129,6 +135,7 @@ impl From<TaskUpdateParams> for TaskRecordUpdateParams {
             plan: p.plan,
             execution_summary: p.execution_summary,
             status: p.status,
+            priority: p.priority,
             complexity: p.complexity,
             task_type: p.task_type,
             source_task_id: p.source_task_id,

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
@@ -303,6 +303,9 @@ pub(super) fn update(
             status: optional_string(&input, "status")?
                 .map(|value| parse_task_status("status", &value))
                 .transpose()?,
+            priority: optional_string(&input, "priority")?
+                .map(|value| parse_task_priority("priority", &value))
+                .transpose()?,
             complexity: optional_string(&input, "complexity")?
                 .map(|value| parse_task_complexity("complexity", &value))
                 .transpose()?,

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
@@ -474,6 +474,60 @@ fn task_add_and_show_tools_roundtrip_crew() {
     assert_eq!(shown.get("orchestrator"), Some(&json!("sol")));
 }
 
+/// ORB-10648: `priority` is an advertised and applied update field. The record
+/// layer could always persist it, but neither the tool schema nor the update
+/// handler read it, so a caller's re-prioritization was discarded while the
+/// tool answered with the unchanged task.
+#[test]
+fn task_update_tool_persists_priority() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let added = runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Priority update task",
+                "description": "Starts at the default priority and is raised on update.",
+                "workspace": ".",
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task add tool succeeds");
+    let task_id = added["id"].as_str().expect("task id");
+    assert_eq!(added.get("priority"), Some(&json!("medium")));
+
+    let updated = runtime
+        .execute_tool_command(
+            "orbit.task.update",
+            json!({ "id": task_id, "priority": "high" }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("priority update succeeds");
+    assert_eq!(updated.get("priority"), Some(&json!("high")));
+
+    let shown = runtime
+        .execute_tool_command(
+            "orbit.task.show",
+            json!({ "id": task_id }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task show succeeds");
+    assert_eq!(shown.get("priority"), Some(&json!("high")));
+
+    let message = invalid_input_message(runtime.execute_tool_command(
+        "orbit.task.update",
+        json!({ "id": task_id, "priority": "nonsense" }),
+        Some("codex".to_string()),
+        Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+    ));
+    assert!(
+        message.contains("priority"),
+        "an unparseable priority names the field: {message}"
+    );
+}
+
 #[test]
 fn task_update_tool_persists_complexity_without_adding_history() {
     let (_root, runtime, _repo_root) = test_runtime();

--- a/crates/orbit-dashboard/src/api/tasks.rs
+++ b/crates/orbit-dashboard/src/api/tasks.rs
@@ -16,7 +16,7 @@ use orbit_core::{
     TaskPriority, TaskStatus, TaskType,
 };
 use serde::{Deserialize, Deserializer};
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 
 use super::{bad_request, map_runtime_error, non_empty_string, server_error, validate_id};
 use crate::projections::{task_locks_json, task_to_json_with_sidecars};
@@ -104,15 +104,87 @@ pub(super) struct CreateTaskBody {
     crew: Option<String>,
     #[serde(default)]
     orchestrator: Option<String>,
+    /// Caller-supplied provenance, forwarded as the write's model identity the
+    /// same way `POST /api/adrs` and `POST /api/frictions` take it. Before
+    /// ORB-10648 this key was undeclared, so serde dropped it and the task was
+    /// attributed to the ambient identity while the caller was told `model` had
+    /// been applied.
+    #[serde(default)]
+    model: Option<String>,
+    /// Retired create input, declared so it stays *knowingly* tolerated rather
+    /// than falling into [`CreateTaskBody::unsupported`]. `comment` is one of
+    /// [`RETIRED_TASK_ADD_INPUT_FIELDS`](orbit_common::types::RETIRED_TASK_ADD_INPUT_FIELDS):
+    /// the native `orbit.task.add` tool strips it with a warning instead of
+    /// failing, and this endpoint keeps that contract. Comment on a task with
+    /// `POST /tasks/:id/comments`.
+    #[serde(default)]
+    comment: Option<String>,
+    /// Trap field (ORB-10648): attribution was consolidated to `model`-only, so
+    /// an `agent` key is a caller bug rather than a usable input. The native
+    /// tool surface rejects it outright (`reject_agent_field`); this body does
+    /// the same instead of dropping it.
+    #[serde(default)]
+    agent: Option<String>,
+    /// Every key this endpoint does not declare, captured rather than dropped.
+    /// See [`reject_unsupported_task_body_fields`].
+    #[serde(flatten)]
+    unsupported: Map<String, Value>,
 }
 
 fn default_priority() -> TaskPriority {
     TaskPriority::Medium
 }
 
+/// Reject a task body carrying keys the endpoint would otherwise discard.
+///
+/// ORB-10648: both task bodies derived a plain `Deserialize`, so any undeclared
+/// key (`priority` on update, an `agent` typo, a field only the native
+/// `orbit.task.update` tool declares) was silently dropped and the handler
+/// still answered `200` with the task JSON. A caller that reports per-field
+/// application — bridge's `orbit_task_update` write confirmation — then
+/// affirmatively reports a field as applied that was never persisted, and a
+/// false "applied" is worse than an error because nothing prompts a read-back.
+///
+/// The contract is all-or-nothing: an unsupported key fails the whole request,
+/// so no write lands partially. The keys are captured through
+/// `#[serde(flatten)]` rather than `#[serde(deny_unknown_fields)]` for the same
+/// reason [`CreateTaskBody::workspace`] is a declared trap field (ORB-00042):
+/// the diagnostic stays Orbit's own, naming every offending key and pointing at
+/// the surface that does accept it, instead of serde's opaque message.
+fn reject_unsupported_task_body_fields(
+    agent: Option<&String>,
+    unsupported: &Map<String, Value>,
+    endpoint: &str,
+) -> Option<Response> {
+    if agent.is_some() {
+        return Some(bad_request(format!(
+            "{endpoint} no longer accepts `agent`; use `model` with the agent \
+             family (codex, claude, gemini, or grok) for attribution"
+        )));
+    }
+    if unsupported.is_empty() {
+        return None;
+    }
+    let mut names = unsupported.keys().cloned().collect::<Vec<_>>();
+    names.sort();
+    let names = names
+        .iter()
+        .map(|name| format!("`{name}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(bad_request(format!(
+        "unsupported body field(s) {names}: {endpoint} does not apply them, so the \
+         request is rejected rather than reporting a write that would not land"
+    )))
+}
+
 /// Partial-update body for `PATCH /tasks/:id`. Each field is `Option<...>`;
 /// fields absent from the JSON body remain unchanged.
 ///
+/// Every key the caller sends is either applied or refused: unknown keys land
+/// in [`UpdateTaskBody::unsupported`] and fail the request
+/// ([`reject_unsupported_task_body_fields`], ORB-10648). Nothing is dropped in
+/// silence.
 #[derive(Deserialize, Default)]
 pub(super) struct UpdateTaskBody {
     #[serde(default)]
@@ -135,6 +207,11 @@ pub(super) struct UpdateTaskBody {
     comment: Option<String>,
     #[serde(default)]
     status: Option<TaskStatus>,
+    /// Replacement dispatch priority (ORB-10648). Previously undeclared here
+    /// even though the record layer could persist it, so an operator's
+    /// re-prioritization was dropped while the response reported success.
+    #[serde(default)]
+    priority: Option<TaskPriority>,
     #[serde(default)]
     complexity: Option<TaskComplexity>,
     #[serde(default)]
@@ -147,6 +224,17 @@ pub(super) struct UpdateTaskBody {
     crew: Option<Option<String>>,
     #[serde(default, deserialize_with = "deserialize_nullable_string_patch_field")]
     orchestrator: Option<Option<String>>,
+    /// Caller-supplied provenance, forwarded as the write's model identity.
+    /// See [`CreateTaskBody::model`].
+    #[serde(default)]
+    model: Option<String>,
+    /// Trap field. See [`CreateTaskBody::agent`].
+    #[serde(default)]
+    agent: Option<String>,
+    /// Every key this endpoint does not declare, captured rather than dropped.
+    /// See [`reject_unsupported_task_body_fields`].
+    #[serde(flatten)]
+    unsupported: Map<String, Value>,
 }
 
 fn deserialize_nullable_string_patch_field<'de, D>(
@@ -499,6 +587,21 @@ pub(super) async fn create_task_action(
                 .to_string(),
         );
     }
+    if let Some(response) = reject_unsupported_task_body_fields(
+        body.agent.as_ref(),
+        &body.unsupported,
+        "POST /api/tasks",
+    ) {
+        return response;
+    }
+    if body.comment.is_some() {
+        tracing::warn!(
+            target: "orbit.dashboard.tasks",
+            field = "comment",
+            "ignored retired POST /api/tasks field; comment with POST /api/tasks/:id/comments"
+        );
+    }
+    let model = body.model.as_deref().and_then(non_empty_string);
     let params = TaskAddParams {
         parent_id: body.parent_id,
         title: body.title,
@@ -521,7 +624,7 @@ pub(super) async fn create_task_action(
         crew: body.crew,
         orchestrator: body.orchestrator,
     };
-    match runtime.add_task_with_identity(params, None, None) {
+    match runtime.add_task_with_identity(params, None, model) {
         Ok(task) => match dashboard_status_index(&runtime) {
             Ok(status_by_id) => match task_to_json_with_sidecars(&runtime, &task, &status_by_id) {
                 Ok(value) => Json(value).into_response(),
@@ -533,6 +636,12 @@ pub(super) async fn create_task_action(
     }
 }
 
+/// `PATCH /tasks/:id` — apply a partial update to a task.
+///
+/// Every submitted key is applied or refused (ORB-10648): declared fields go
+/// into [`TaskUpdateParams`], `model` becomes the write's provenance, and any
+/// other key is a 400 from [`reject_unsupported_task_body_fields`]. A caller
+/// therefore never receives a `200` for a field this endpoint discarded.
 pub(super) async fn update_task_action(
     Ws(runtime): Ws,
     Path(id): Path<String>,
@@ -542,6 +651,14 @@ pub(super) async fn update_task_action(
         Ok(id) => id,
         Err(message) => return bad_request(message),
     };
+    if let Some(response) = reject_unsupported_task_body_fields(
+        body.agent.as_ref(),
+        &body.unsupported,
+        "PATCH /api/tasks/:id",
+    ) {
+        return response;
+    }
+    let model = body.model.as_deref().and_then(non_empty_string);
     let params = TaskUpdateParams {
         title: body.title,
         description: body.description,
@@ -553,6 +670,7 @@ pub(super) async fn update_task_action(
         execution_summary: body.execution_summary,
         comment: body.comment,
         status: body.status,
+        priority: body.priority,
         complexity: body.complexity,
         task_type: body.task_type,
         source_task_id: None,
@@ -565,7 +683,7 @@ pub(super) async fn update_task_action(
         context_files: body.context_files,
         upsert_artifacts: Vec::new(),
     };
-    match runtime.update_task_with_identity(id, params, None, None) {
+    match runtime.update_task_with_identity(id, params, None, model) {
         Ok(task) => match dashboard_status_index(&runtime) {
             Ok(status_by_id) => match task_to_json_with_sidecars(&runtime, &task, &status_by_id) {
                 Ok(value) => Json(value).into_response(),

--- a/crates/orbit-dashboard/src/api/tests/tasks.rs
+++ b/crates/orbit-dashboard/src/api/tests/tasks.rs
@@ -1571,6 +1571,220 @@ async fn task_comment_author_rejects_model_constants_but_keeps_human_names() {
     assert_eq!(stored[0].by, "operator");
 }
 
+async fn patch_task(runtime: Arc<OrbitRuntime>, task_id: &str, body: Value) -> Response {
+    router()
+        .with_state(crate::state::DashboardState::single(runtime))
+        .oneshot(patch_json(&format!("/tasks/{task_id}"), body))
+        .await
+        .expect("response")
+}
+
+async fn post_task(runtime: Arc<OrbitRuntime>, body: Value) -> Response {
+    router()
+        .with_state(crate::state::DashboardState::single(runtime))
+        .oneshot(post_json("/tasks", body))
+        .await
+        .expect("response")
+}
+
+/// ORB-10648: `priority` is now a declared update field. It was undeclared
+/// while the record layer could persist it, so a re-prioritization was dropped
+/// by serde and the endpoint still answered `200` with the old priority — the
+/// exact reproduction in the filing. It must be visible in the immediate PATCH
+/// response and on the next read.
+#[tokio::test]
+async fn update_task_applies_priority_and_reads_it_back() {
+    let runtime = Arc::new(OrbitRuntime::in_memory().expect("build runtime"));
+    let task = seed_backlog_task(&runtime, "Re-prioritized task");
+    assert_eq!(task.priority.to_string(), "medium", "fixture precondition");
+
+    let response = patch_task(runtime.clone(), &task.id, json!({ "priority": "high" })).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let patched = body_json(response).await;
+    assert_eq!(patched["priority"], json!("high"));
+    let fetched = body_json(request_shared(runtime, &format!("/tasks/{}", task.id)).await).await;
+    assert_eq!(fetched["priority"], json!("high"), "read-back agrees");
+}
+
+/// ORB-10648: every field a partial update reports back is genuinely persisted.
+/// This is the regression guard for the whole class — a field that the body
+/// deserializes but the handler never plumbs would show up here as a response
+/// value that the next read contradicts.
+#[tokio::test]
+async fn update_task_response_fields_survive_a_read_back() {
+    let runtime = Arc::new(OrbitRuntime::in_memory().expect("build runtime"));
+    let task = seed_backlog_task(&runtime, "Partially updated task");
+
+    let response = patch_task(
+        runtime.clone(),
+        &task.id,
+        json!({
+            "title": "Renamed by PATCH",
+            "plan": "1. land the fix",
+            "execution_summary": "not yet run",
+            "tags": ["alpha", "beta"],
+            "priority": "critical",
+            "complexity": "hard",
+            "task_type": "bug",
+            "context_files": ["file:src/lib.rs"],
+        }),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let patched = body_json(response).await;
+    // (submitted key, projected key, expected value)
+    let expected = [
+        ("title", "title", json!("Renamed by PATCH")),
+        ("plan", "plan", json!("1. land the fix")),
+        (
+            "execution_summary",
+            "execution_summary",
+            json!("not yet run"),
+        ),
+        ("tags", "tags", json!(["alpha", "beta"])),
+        ("priority", "priority", json!("critical")),
+        ("complexity", "complexity", json!("hard")),
+        ("task_type", "type", json!("bug")),
+        ("context_files", "context_files", json!(["file:src/lib.rs"])),
+    ];
+    let fetched = body_json(request_shared(runtime, &format!("/tasks/{}", task.id)).await).await;
+    for (submitted, projected, value) in expected {
+        assert_eq!(
+            patched[projected], value,
+            "`{submitted}` must be applied in the PATCH response"
+        );
+        assert_eq!(
+            fetched[projected], patched[projected],
+            "`{submitted}` must still be there on read-back"
+        );
+    }
+}
+
+/// ORB-10648: the previously-false-positive case. An undeclared key used to be
+/// discarded by serde while the endpoint answered `200` with the task JSON, so
+/// a caller comparing its request against that response could report the field
+/// as applied. It is now a 400 that names the key, and — the all-or-nothing
+/// half of the contract — the declared fields in the same body do not land
+/// either.
+#[tokio::test]
+async fn update_task_rejects_an_undeclared_body_field_without_partial_application() {
+    let runtime = Arc::new(OrbitRuntime::in_memory().expect("build runtime"));
+    let task = seed_backlog_task(&runtime, "Untouched task");
+
+    let response = patch_task(
+        runtime.clone(),
+        &task.id,
+        json!({ "title": "must not land", "urgency": "high" }),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let message = body_json(response).await["error"]
+        .as_str()
+        .expect("error message")
+        .to_string();
+    assert!(message.contains("urgency"), "names the offending key");
+    let fetched = body_json(request_shared(runtime, &format!("/tasks/{}", task.id)).await).await;
+    assert_eq!(
+        fetched["title"],
+        json!("Untouched task"),
+        "a rejected body applies nothing"
+    );
+}
+
+/// ORB-10648: the same contract on create — `POST /api/tasks` no longer absorbs
+/// keys it cannot apply. The tailored `workspace` diagnostic (ORB-00042) still
+/// wins for that key, since it is a declared trap field.
+#[tokio::test]
+async fn create_task_rejects_an_undeclared_body_field() {
+    let runtime = Arc::new(OrbitRuntime::in_memory().expect("build runtime"));
+
+    let response = post_task(
+        runtime.clone(),
+        json!({
+            "title": "undeclared input",
+            "description": "carries a key the endpoint cannot apply",
+            "assignee": "someone",
+        }),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let message = body_json(response).await["error"]
+        .as_str()
+        .expect("error message")
+        .to_string();
+    assert!(message.contains("assignee"), "names the offending key");
+    assert!(
+        runtime.list_tasks().expect("list tasks").is_empty(),
+        "a rejected create writes nothing"
+    );
+}
+
+/// ORB-10648 / L-0103: attribution is `model`-only. An `agent` key is a caller
+/// bug, so both task bodies refuse it the way the native tool surface does
+/// rather than dropping it and attributing the write to the ambient identity.
+#[tokio::test]
+async fn task_bodies_reject_the_retired_agent_attribution_key() {
+    let runtime = Arc::new(OrbitRuntime::in_memory().expect("build runtime"));
+    let task = seed_backlog_task(&runtime, "Attribution task");
+
+    for response in [
+        patch_task(
+            runtime.clone(),
+            &task.id,
+            json!({ "status": "someday", "agent": "codex" }),
+        )
+        .await,
+        post_task(
+            runtime.clone(),
+            json!({
+                "title": "agent attribution",
+                "description": "agent is not an accepted key",
+                "agent": "codex",
+            }),
+        )
+        .await,
+    ] {
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let message = body_json(response).await["error"]
+            .as_str()
+            .expect("error message")
+            .to_string();
+        assert!(message.contains("agent"), "names the offending key");
+        assert!(message.contains("model"), "points at the accepted field");
+    }
+}
+
+/// ORB-10648: `model` was forwarded by callers, deserialized by neither task
+/// body, and still reported as applied — an affirmative false "applied". It is
+/// now the write's provenance (as on `POST /api/adrs` and `POST /api/frictions`),
+/// so the report is true: the comment this update appends is authored by the
+/// supplied model rather than by the ambient identity.
+#[tokio::test]
+async fn update_task_applies_model_provenance() {
+    let runtime = Arc::new(OrbitRuntime::in_memory().expect("build runtime"));
+    let task = seed_backlog_task(&runtime, "Attributed task");
+
+    let response = patch_task(
+        runtime.clone(),
+        &task.id,
+        json!({ "comment": "attributed note", "model": TEST_CODEX_MODEL }),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let stored = runtime.get_task_comments(&task.id).expect("task comments");
+    assert_eq!(stored.len(), 1);
+    assert!(
+        stored[0].by.contains(TEST_CODEX_MODEL),
+        "supplied model must author the write, got `{}`",
+        stored[0].by
+    );
+}
+
 /// An empty (or whitespace-only) comment is a clean 400 rather than an empty
 /// row in the thread.
 #[tokio::test]

--- a/crates/orbit-tools/src/builtin/orbit/task/update.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/update.rs
@@ -61,6 +61,12 @@ impl Tool for OrbitTaskUpdateTool {
                 required: false,
             },
             ToolParam {
+                name: "priority".to_string(),
+                description: "New dispatch priority (low, medium, high, or critical)".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
                 name: "complexity".to_string(),
                 description: "Optional task complexity level (low, medium, or hard)".to_string(),
                 param_type: "string".to_string(),

--- a/docs/design/user-interface/4_decisions.md
+++ b/docs/design/user-interface/4_decisions.md
@@ -187,6 +187,18 @@ Rejected alternative: count `cancelled` as a failure, or round small-`n` rates i
 - The per-run fact read is capped at 200,000 rows and reports `truncated` when the cap binds; the UI warns rather than presenting a partial window as complete.
 - This adds the instrument; it does not assert the readings are stable. The standing measurement hold on efficiency baselines drawn from the current window is unaffected.
 
+## ADR-0334 — All-or-Nothing Rejection of Unsupported Task Body Fields
+
+**Status:** Proposed · 2026-08 · [ORB-10648]
+
+Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.show --input '{"id":"ADR-0334"}'`.
+
+Summary: `POST /api/tasks` and `PATCH /api/tasks/:id` no longer discard keys they
+do not declare. Unknown keys are captured with `#[serde(flatten)]` and refused
+with a 400 that names them, `priority` becomes a supported update field end to
+end, `model` becomes declared provenance, and `agent` is a trap field pointing at
+`model` — extending the ORB-00042 `workspace` trap shape to the whole body.
+
 ## Task References
 
 - [T20260427-29] introduced the Canon Refined UI direction.
@@ -200,5 +212,6 @@ Rejected alternative: count `cancelled` as a failure, or round small-`n` rates i
 - [ORB-00030] made the dashboard global/multi-workspace (workspace-keyed state, `Ws` extractor, serve-from-anywhere, aggregate endpoints).
 - [ORB-10444] retired the deprecated tab, folded Scoreboard under Diagnostics, pinned the Knowledge detail pane, and added task ship + comments.
 - [ORB-10588] added the Reliability subtab: job-run failure rate and recovery invocation rate from durable run state.
+- [ORB-10648] made the task create/update bodies reject unsupported fields instead of discarding them silently.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10648](https://orbit-cli.com/tasks/ORB-10648) — Reject unsupported task-update fields instead of discarding them silently

### Description

## Problem

A task update can report success, and affirmatively report a field as applied, while that field is discarded and never persisted.

## Evidence (verified against the current tree, 2026-08-08, and reproduced live)

**Reproduced during this batch**: two `orbit_task_update` calls passing `priority` returned `status: "applied"` with an empty `not_applied` map, and the returned record still carried the old priority. The field appears in neither the applied set nor the dropped set.

Verified mechanism:

- `TaskUpdateParams` in `crates/orbit-core/src/command/task/params.rs` has **no** `priority` field, though the add-params struct does. The update handler never reads it, and the native tool schema never advertises it.
- `UpdateTaskBody` in `crates/orbit-dashboard/src/api/tasks.rs` has no `priority` and derives plain `Deserialize` without `deny_unknown_fields`, so serde discards the key. The handler rejects only two specific keys; every other unknown key is ignored.
- **`model` is worse.** It is forwarded by the caller, deserialized by neither the create body nor the update body, and both handlers pass identity as `None` — yet the write confirmation reports it as applied. That is an affirmative false "applied", not merely a silent drop.

**Two claims in the original filing are wrong and should not be worked on**: `relations` is advertised and correctly applied end to end. `pr_status` and `orchestrator` are accepted end to end by the update path but are simply not declared by the calling surface — a missing capability, not a silent drop.

The audit of the native `orbit.task.update` surface found schema and handler in exact agreement: there is no advertised-but-dropped field. **The defect is unadvertised-and-silently-ignored input**, which is a different problem than the title of the original filing suggested.

## Why It Matters

Dispatch ordering can diverge from the operator's decision while every signal says the write landed. A false "applied" is worse than an error, because nothing prompts a read-back.

## Scope

This task covers the Rust surface only. The related field-selector inconsistency on the read path is a separate root cause in a different repository and is tracked separately — do not attempt it here.

## Constraints / Notes

- Choose all-or-nothing rejection or structured dropped-field reporting, and apply the same contract to every field. Never silently discard input that a caller passed.
- `deny_unknown_fields` would break tolerant callers. There is an existing precedent in this file — a field deserialized purely so it can be rejected loudly with a 400 — with a comment explaining exactly this tradeoff. Follow that shape.
- Decide explicitly whether `priority` becomes supported on update or stays unsupported-and-rejected. Either is acceptable; silence is not.
- CI on agent-main is advisory; build plus this change's own tests is the bar.

### Acceptance Criteria

- Passing an unsupported field to the task update path produces a typed diagnostic or a structured dropped-field report — never a success with the field absent from both the applied and the not-applied sets.
- `model` is no longer reported as applied when it is not deserialized or persisted.
- `priority` on update is either persisted and visible in the immediate result, or rejected with a diagnostic naming it as unsupported; the choice is stated in the execution summary.
- A regression test asserts read-back equality after a partial update: every field reported applied is present in a subsequent read.
- A test covers the previously-false-positive case, passing an undeclared field and asserting it is not reported as applied.

## Execution Summary

<details>
<summary>Click to expand</summary>

Chose all-or-nothing rejection (the task title's option), extending the ORB-00042 `workspace` trap shape from one key to the whole body. ADR-0334 (Proposed) records the decision and the rejected alternatives.

Contract now on `POST /api/tasks` and `PATCH /api/tasks/:id`:
- Unknown keys are captured with `#[serde(flatten)]` into an `unsupported` map and refused with a 400 naming every offending key. Not `deny_unknown_fields`: that gives serde's opaque message, cannot give a per-key hint, and cannot carve out a knowingly-tolerated retired key. A rejected body applies nothing (no partial write).
- `priority` is now SUPPORTED on update, not rejected (criterion 3). It is wired end to end: `TaskUpdateParams.priority` -> `TaskRecordUpdateParams.priority` (the record/document layer already persisted it), the native `orbit.task.update` schema + handler, and `UpdateTaskBody`. `has_non_comment_mutation` counts it. Reason: the record layer already supported it and re-prioritization is exactly the operator intent the silent drop was corrupting.
- `model` is now deserialized and forwarded as the write's model identity on both create and update, the same way `POST /api/adrs` and `POST /api/frictions` already accept it. That makes a caller's `applied: {model}` report true rather than making it false-by-rejection, and does not break bridge (which forwards `model` on both verbs). `POST /tasks/:id/comments` keeps its ORB-10444 human-identity floor untouched.
- `agent` is a declared trap field rejected with a pointer to `model` (L-0103, mirroring the native `reject_agent_field`).
- `comment` on create stays knowingly tolerated-and-ignored (now declared + warn-logged instead of falling into the unknown-key path). It is one of `RETIRED_TASK_ADD_INPUT_FIELDS`, which the native `orbit.task.add` strips with a warning; diverging from that contract was out of scope and an existing test pins the tolerance.

Deliberate scope boundary: the native `orbit.task.update` tool keeps its tolerant unknown-key handling. Rejecting there would need an allowlist covering the documented aliases (`context`, `tag`, `taskType`, `acceptanceCriteria`, `sourceTaskId`, ...) plus the `workspace` routing key the remote MCP host rewrites in place — wider blast radius than this defect justified. The one concrete unadvertised-and-dropped field there (`priority`) is now advertised and applied. Recorded as a Cost bullet in ADR-0334.

Tests (all new, all passing):
- `update_task_applies_priority_and_reads_it_back` — the reproduced case: PATCH priority is in the immediate response and on read-back.
- `update_task_response_fields_survive_a_read_back` — criterion 4: 8-field partial update; every field reported applied is present with the same value on a subsequent GET.
- `update_task_rejects_an_undeclared_body_field_without_partial_application` — criterion 5: undeclared key -> 400 naming it, and the declared `title` in the same body did not land.
- `create_task_rejects_an_undeclared_body_field`, `task_bodies_reject_the_retired_agent_attribution_key`, `update_task_applies_model_provenance` (supplied model authors the write).
- `task_update_tool_persists_priority` in orbit-core's tool-host tests (native surface + invalid-value diagnostic).

Validation: `make ci-fast` green; `cargo clippy -p orbit-dashboard -p orbit-core -p orbit-tools --all-targets` clean; `cargo test -p orbit-dashboard` 244/245 and `-p orbit-tools` all green; `cargo test -p orbit-core --lib` 759 pass / 7 fail. Every failure (`ship_endpoint_submits_task_auto_pipeline_run`, the two `v2_update_task_activity_*`, three `orchestrator_accounting_*`, two job `exec` tests) was verified to fail identically on an unmodified HEAD copy of the tree — retired-crew-config fixtures and env-dependent job tests, not this change. Tests were run with ORBIT_AGENT_*/ORBIT_MANAGED_RUN_CONTEXT/ORBIT_RUN_ID unset per L-0068.

Context files: appended the two test files and `docs/design/user-interface/4_decisions.md` (same-PR ADR index rule) to the four declared implementation files.

Not done here, by design: the bridge-side write confirmation that reported `priority` in neither the applied nor the not-applied set is a separate repo (`codebases/bridge`, `_task_write_confirmation` in `orbit_parity.py`) and remains its own fix; its `orbit_task_update` tool does not even declare `priority`, which is why the reproduction showed an empty `not_applied`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10648-6a77fa27`
- Behind base: 0
- Ahead of base: 1