### PR TITLE
Deduplicate run finalization and resume seeding

### DIFF
--- a/crates/orbit-core/src/command/job/exec.rs
+++ b/crates/orbit-core/src/command/job/exec.rs
@@ -38,6 +38,31 @@ pub struct V2JobRunResult {
     pub resolved_backend: Backend,
 }
 
+/// Path-specific durable records retained while finalizing a v2 run.
+///
+/// The foreground path predates per-step checkpointing, so its legacy summary
+/// row and synthetic success step remain observable API. Detached workers
+/// already persist their authoritative per-step checkpoints and must not add a
+/// synthetic step 0 that can obscure them. Keeping that distinction explicit
+/// lets both paths share the terminal-state, reservation, and event sequence.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct V2RunFinalizationOptions {
+    write_legacy_summary_step: bool,
+    record_synthetic_success_step: bool,
+}
+
+impl V2RunFinalizationOptions {
+    pub(crate) const DIRECT: Self = Self {
+        write_legacy_summary_step: true,
+        record_synthetic_success_step: true,
+    };
+
+    pub(crate) const DETACHED_WORKER: Self = Self {
+        write_legacy_summary_step: false,
+        record_synthetic_success_step: false,
+    };
+}
+
 impl OrbitRuntime {
     /// Execute a v2 Job from a YAML file. Returns a structural result. The
     /// file must declare `schemaVersion: 2` and `kind: Job`; v1 files are
@@ -120,21 +145,7 @@ impl OrbitRuntime {
             Some(input.clone()),
             retry_source_run_id.clone(),
         )?;
-        // [ORB-10002] A resumed run starts from the source run's checkpoint
-        // state (re-keyed to the new run) instead of a blank pipeline.
-        let initial_state = match resume.and_then(|plan| plan.resume_state.as_ref()) {
-            Some(source_state) => seeded_resume_state(source_state, &run),
-            None => PipelineState::new(run.run_id.clone(), run.job_id.clone(), input.clone()),
-        };
-        self.stores()
-            .jobs()
-            .write_run_state(&run.run_id, &initial_state)?;
-        // [ORB-10470] Re-admit and re-claim this lineage's tasks before the
-        // first step runs, so a resume of a failed run is not gated by the
-        // block that same failure applied.
-        if let Some(plan) = resume {
-            self.reconcile_resume_task_ownership(plan, &run.run_id)?;
-        }
+        self.seed_v2_pipeline_run(&run, &input, resume)?;
 
         let started_at = chrono::Utc::now();
         let changed = self.stores().jobs().mark_job_run_running(
@@ -161,65 +172,16 @@ impl OrbitRuntime {
             resume.and_then(|plan| plan.resume_state.as_ref()),
         );
         let finished_at = chrono::Utc::now();
-        let duration_ms = Some(
-            finished_at
-                .signed_duration_since(started_at)
-                .num_milliseconds()
-                .max(0) as u64,
-        );
 
-        match outcome {
-            Ok(result) => {
-                let final_state = if result.success {
-                    JobRunState::Success
-                } else {
-                    JobRunState::Failed
-                };
-                self.persist_direct_v2_run_state(&run, &input, &result, final_state)?;
-                if result.success {
-                    self.record_direct_v2_success_step(&run, started_at, finished_at, &result)?;
-                } else {
-                    let fallback = "job completed with success=false but emitted no failure detail";
-                    let message = result.message.as_deref().unwrap_or(fallback);
-                    let _ =
-                        self.record_pipeline_failure_step(&run, started_at, finished_at, message);
-                }
-                self.finalize_job_run_with_reservation_cleanup(
-                    &run.run_id,
-                    final_state,
-                    finished_at,
-                    duration_ms,
-                    TaskReservationReleaseReason::RunTerminal,
-                )?;
-                self.record_event(OrbitEvent::JobRunCompleted {
-                    job_id: run.job_id.clone(),
-                    run_id: run.run_id.clone(),
-                    state: final_state.to_string(),
-                })?;
-                Ok(result)
-            }
-            Err(error) => {
-                let _ = self.record_pipeline_failure_step(
-                    &run,
-                    started_at,
-                    finished_at,
-                    &error.to_string(),
-                );
-                self.finalize_job_run_with_reservation_cleanup(
-                    &run.run_id,
-                    JobRunState::Failed,
-                    finished_at,
-                    duration_ms,
-                    TaskReservationReleaseReason::RunTerminal,
-                )?;
-                self.record_event(OrbitEvent::JobRunCompleted {
-                    job_id: run.job_id.clone(),
-                    run_id: run.run_id.clone(),
-                    state: JobRunState::Failed.to_string(),
-                })?;
-                Err(error)
-            }
-        }
+        self.finalize_v2_pipeline_run(
+            &run,
+            &input,
+            started_at,
+            finished_at,
+            outcome.as_ref(),
+            V2RunFinalizationOptions::DIRECT,
+        )?;
+        outcome
     }
 
     pub fn run_job_v2_from_yaml_with_run_id(
@@ -361,12 +323,91 @@ impl OrbitRuntime {
         }
     }
 
-    fn persist_direct_v2_run_state(
+    /// Seed a persisted run before either the foreground or detached path
+    /// executes it. A resume re-keys checkpoints and reconciles the failed
+    /// lineage's task ownership before admission evaluates the first step.
+    pub(crate) fn seed_v2_pipeline_run(
+        &self,
+        run: &JobRun,
+        input: &Value,
+        resume: Option<&ResumePlan>,
+    ) -> Result<(), OrbitError> {
+        let initial_state = match resume.and_then(|plan| plan.resume_state.as_ref()) {
+            Some(source_state) => seeded_resume_state(source_state, run),
+            None => PipelineState::new(run.run_id.clone(), run.job_id.clone(), input.clone()),
+        };
+        self.stores()
+            .jobs()
+            .write_run_state(&run.run_id, &initial_state)?;
+        if let Some(plan) = resume {
+            self.reconcile_resume_task_ownership(plan, &run.run_id)?;
+        }
+        Ok(())
+    }
+
+    /// Persist the common terminal lifecycle for foreground and detached v2
+    /// execution without changing their established checkpoint conventions.
+    pub(crate) fn finalize_v2_pipeline_run(
+        &self,
+        run: &JobRun,
+        input: &Value,
+        started_at: chrono::DateTime<chrono::Utc>,
+        finished_at: chrono::DateTime<chrono::Utc>,
+        outcome: Result<&V2JobRunResult, &OrbitError>,
+        options: V2RunFinalizationOptions,
+    ) -> Result<(), OrbitError> {
+        let duration_ms = Some(
+            finished_at
+                .signed_duration_since(started_at)
+                .num_milliseconds()
+                .max(0) as u64,
+        );
+        let final_state = match outcome {
+            Ok(result) if result.success => {
+                self.persist_v2_run_state(run, input, result, JobRunState::Success, options)?;
+                if options.record_synthetic_success_step {
+                    self.record_synthetic_v2_success_step(run, started_at, finished_at, result)?;
+                }
+                JobRunState::Success
+            }
+            Ok(result) => {
+                self.persist_v2_run_state(run, input, result, JobRunState::Failed, options)?;
+                let fallback = "job completed with success=false but emitted no failure detail";
+                let message = result.message.as_deref().unwrap_or(fallback);
+                let _ = self.record_pipeline_failure_step(run, started_at, finished_at, message);
+                JobRunState::Failed
+            }
+            Err(error) => {
+                let _ = self.record_pipeline_failure_step(
+                    run,
+                    started_at,
+                    finished_at,
+                    &error.to_string(),
+                );
+                JobRunState::Failed
+            }
+        };
+        self.finalize_job_run_with_reservation_cleanup(
+            &run.run_id,
+            final_state,
+            finished_at,
+            duration_ms,
+            TaskReservationReleaseReason::RunTerminal,
+        )?;
+        self.record_event(OrbitEvent::JobRunCompleted {
+            job_id: run.job_id.clone(),
+            run_id: run.run_id.clone(),
+            state: final_state.to_string(),
+        })
+    }
+
+    fn persist_v2_run_state(
         &self,
         run: &JobRun,
         input: &Value,
         result: &V2JobRunResult,
         final_state: JobRunState,
+        options: V2RunFinalizationOptions,
     ) -> Result<(), OrbitError> {
         let mut state = self.read_run_state(&run.run_id)?.unwrap_or_else(|| {
             PipelineState::new(run.run_id.clone(), run.job_id.clone(), input.clone())
@@ -376,13 +417,13 @@ impl OrbitRuntime {
         // this run; only fall back to the legacy single-summary step record
         // when no checkpoint was ever written, so a later `resume` never sees
         // a whole-run summary clobbering step 0's real checkpoint.
-        if state.step_states.is_empty() {
+        if options.write_legacy_summary_step && state.step_states.is_empty() {
             state.record_step(0, final_state, Some(result.pipeline.clone()), None);
         }
         self.stores().jobs().write_run_state(&run.run_id, &state)
     }
 
-    fn record_direct_v2_success_step(
+    fn record_synthetic_v2_success_step(
         &self,
         run: &JobRun,
         started_at: chrono::DateTime<chrono::Utc>,

--- a/crates/orbit-core/src/command/job/pipeline.rs
+++ b/crates/orbit-core/src/command/job/pipeline.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use chrono::Utc;
 use orbit_common::types::{
     AuditEventStatus, JobRun, JobRunState, JobScheduleState, JobTargetType, NotFoundKind,
-    OrbitError, OrbitEvent, PipelineState, audit_execution_id,
+    OrbitError, OrbitEvent, audit_execution_id,
 };
 use orbit_store::{AuditEventInsertParams, JobRunStepParams, TaskReservationReleaseReason};
 use serde::Serialize;
@@ -17,6 +17,7 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
 use crate::OrbitRuntime;
+use crate::command::job::exec::V2RunFinalizationOptions;
 use crate::command::job::resume::ResumePlan;
 
 #[cfg(unix)]
@@ -214,16 +215,7 @@ impl OrbitRuntime {
                 Some(input.clone()),
                 resume.map(|plan| plan.source.run_id.clone()),
             )?;
-            let initial_state = match resume.and_then(|plan| plan.resume_state.as_ref()) {
-                Some(source_state) => super::exec::seeded_resume_state(source_state, &run),
-                None => PipelineState::new(run.run_id.clone(), run.job_id.clone(), input.clone()),
-            };
-            self.stores()
-                .jobs()
-                .write_run_state(&run.run_id, &initial_state)?;
-            if let Some(plan) = resume {
-                self.reconcile_resume_task_ownership(plan, &run.run_id)?;
-            }
+            self.seed_v2_pipeline_run(&run, &input, resume)?;
 
             self.reconcile_stale_job_runs(Some(job_name))?;
             let active_runs = self
@@ -460,66 +452,15 @@ impl OrbitRuntime {
             resume.as_ref(),
         );
         let finished_at = Utc::now();
-        let duration_ms = Some(
-            finished_at
-                .signed_duration_since(started_at)
-                .num_milliseconds()
-                .max(0) as u64,
-        );
-
-        match outcome {
-            Ok(result) => {
-                let mut state = self.read_run_state(&run.run_id)?.unwrap_or_else(|| {
-                    PipelineState::new(run.run_id.clone(), run.job_id.clone(), input)
-                });
-                state.sync_pipeline(result.pipeline.clone());
-                self.stores().jobs().write_run_state(&run.run_id, &state)?;
-
-                let final_state = if result.success {
-                    JobRunState::Success
-                } else {
-                    let fallback = "job completed with success=false but emitted no failure detail";
-                    let message = result.message.as_deref().unwrap_or(fallback);
-                    let _ =
-                        self.record_pipeline_failure_step(run, started_at, finished_at, message);
-                    JobRunState::Failed
-                };
-                self.finalize_job_run_with_reservation_cleanup(
-                    &run.run_id,
-                    final_state,
-                    finished_at,
-                    duration_ms,
-                    TaskReservationReleaseReason::RunTerminal,
-                )?;
-                self.record_event(OrbitEvent::JobRunCompleted {
-                    job_id: run.job_id.clone(),
-                    run_id: run.run_id.clone(),
-                    state: final_state.to_string(),
-                })?;
-                Ok(())
-            }
-            Err(error) => {
-                let _ = self.record_pipeline_failure_step(
-                    run,
-                    started_at,
-                    finished_at,
-                    &error.to_string(),
-                );
-                self.finalize_job_run_with_reservation_cleanup(
-                    &run.run_id,
-                    JobRunState::Failed,
-                    finished_at,
-                    duration_ms,
-                    TaskReservationReleaseReason::RunTerminal,
-                )?;
-                self.record_event(OrbitEvent::JobRunCompleted {
-                    job_id: run.job_id.clone(),
-                    run_id: run.run_id.clone(),
-                    state: JobRunState::Failed.to_string(),
-                })?;
-                Err(error)
-            }
-        }
+        self.finalize_v2_pipeline_run(
+            run,
+            &input,
+            started_at,
+            finished_at,
+            outcome.as_ref(),
+            V2RunFinalizationOptions::DETACHED_WORKER,
+        )?;
+        outcome.map(|_| ())
     }
 
     pub(crate) fn record_pipeline_failure_step(


### PR DESCRIPTION
## Task

[ORB-10632](https://orbit-cli.com/tasks/ORB-10632) — Deduplicate run finalization and resume seeding

### Description

## Problem

Two of the most consequential sequences in the run lifecycle are each written twice, in two modules, in near-identical form.

Run finalization — match the execution outcome, sync pipeline state, record a failure step, finalize the run with reservation cleanup, emit the completion event — appears once on the detached-worker path and once on the direct-execution path. The two differ only in whether a success step is recorded, and nothing states whether that difference is intentional.

Resume seeding — seed state from checkpoints, construct fresh pipeline state, write run state, reconcile task ownership — likewise appears in both, in identical form.

The consequence is that any change to when a run is considered terminal, what gets cleaned up, or what a resumed run inherits must be made twice and correctly. The two copies are exactly the kind of thing that drifts silently, because a divergence produces a wrong terminal state rather than a compile error.

## Change

Give each of these sequences one implementation used by both paths. Where the two copies currently differ, establish whether the difference is deliberate and either preserve it explicitly as a parameter of the shared implementation or eliminate it — but do not paper over it by defaulting to one copy's behavior without deciding.

## Constraints

- Behavior-preserving, and this matters more here than elsewhere: terminal state, reservation cleanup, and emitted events are what other parts of the system read to decide whether a run is safe to resume or its tasks are safe to re-dispatch.
- The success-step difference between the two finalization copies must be resolved deliberately and the reasoning recorded, not silently normalized.
- First-writer-wins terminal state and the conflict-recording behavior around orphan detection are correct as they are and must not change.
- Resume must continue to reconcile task ownership so a resumed run can pass admission for tasks its own failed predecessor blocked.
- Do not restructure the modules these sequences live in beyond what deduplication requires; splitting those modules is separate work.

## Acceptance Criteria

- Run finalization has one implementation, reached by both the detached-worker and direct-execution paths.
- Resume seeding has one implementation, reached by both paths.
- The success-step divergence is resolved, and the change states which behavior now applies to both paths and why.
- A run that fails, a run that succeeds, and a run that is resumed after failure each produce the same stored state, reservation outcome, and event sequence as before the change, on both paths, covered by tests.
- A resumed run still passes admission for tasks blocked by its failed predecessor.
- Affected crates build and the run-lifecycle, resume, and pipeline test suites pass; name any pre-existing unrelated failures rather than repairing them.

### Acceptance Criteria

- Run finalization has one implementation, reached by both the detached-worker and direct-execution paths.
- Resume seeding has one implementation, reached by both paths.
- The success-step divergence is resolved, and the change states which behavior now applies to both paths and why.
- A run that fails, a run that succeeds, and a run that is resumed after failure each produce the same stored state, reservation outcome, and event sequence as before the change, on both paths, covered by tests.
- A resumed run still passes admission for tasks blocked by its failed predecessor.
- Affected crates build and the run-lifecycle, resume, and pipeline test suites pass; name any pre-existing unrelated failures rather than repairing them.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Extracted one v2 run-seeding implementation used by foreground execution and detached pipeline submission; it re-keys resume checkpoints, persists initial state, and reconciles retry-lineage task ownership before admission.
- Extracted one v2 run-finalization implementation used by both execution paths; it synchronizes pipeline state, records failure diagnostics, finalizes with reservation cleanup, and emits the completion event.
- Preserved the deliberate success-record divergence explicitly: foreground execution retains its legacy summary and synthetic success step for compatibility, while detached workers retain authoritative per-step checkpoints without adding a synthetic step 0 that could obscure them.

Assessment: terminal state, first-writer-wins finalization, reservation cleanup, completion events, checkpoint state, and resume ownership reconciliation retain prior path-specific behavior while their shared lifecycle sequence now has one implementation.

Validation:
- cargo fmt --check passed.
- Focused direct success/failure and detached-worker/resume-admission tests passed.
- cargo test -p orbit-core command::job::tests::resume -- --nocapture: 6 passed.
- make ci-fast passed.
- cargo test -p orbit-core command::job::tests::exec -- --nocapture: 14 passed; 2 pre-existing unrelated failures: explicit crew qa missing from test configuration in task_triage_pipeline_applies_multiple_cli_envelope_dispositions, and invalid fixture ID ORB-FAILURE-HANDOFF in failed_pr_pipeline_dispatches_the_failure_handoff_and_keeps_the_original_error.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10632-6a7815a7`
- Behind base: 0
- Ahead of base: 1