### PR TITLE
Report mid-rebase state on a sync-base re-attempt instead of a misleading branch error

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/freshness.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/freshness.rs
@@ -8,7 +8,8 @@ use crate::context::{DeterministicActionHost, TaskHost};
 use super::super::input::{input_string_field, required_input_string};
 use super::git::{BaseSyncMode, git_command_success, git_output, resolve_worktree_start_point};
 use super::handoff::{
-    FailedHandoffPhase, HandoffContext, load_handoff_context, record_failed_handoff,
+    FailedHandoffPhase, HandoffContext, load_handoff_context, rebase_in_progress,
+    record_failed_handoff,
 };
 
 #[derive(Debug, Clone)]
@@ -134,6 +135,12 @@ fn rebase_pr_branch_inner(input: &Value, context: &HandoffContext) -> Result<Val
         &context.workspace_path,
         &["rev-parse", "--abbrev-ref", "HEAD"],
     )?;
+    if rebase_in_progress(&context.workspace_path)? {
+        return Err(rebase_conflict_error(
+            &context.workspace_path,
+            "rebase remains stopped with unresolved conflicts",
+        )?);
+    }
     if current_branch.trim() != head {
         return Err(OrbitError::Execution(format!(
             "git_rebase: prepared branch '{head}' is not checked out (found '{}')",

--- a/crates/orbit-engine/src/executor/automation/vcs/handoff.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/handoff.rs
@@ -162,8 +162,15 @@ pub(super) fn record_failed_handoff<H: TaskHost + ?Sized>(
     let base_ref = input_string_field(input, "base_ref")
         .map(|value| format!("Base checkpoint: {value}\n"))
         .unwrap_or_default();
+    let recovery = if matches!(phase, FailedHandoffPhase::Rebase)
+        && rebase_in_progress(&context.workspace_path).unwrap_or(false)
+    {
+        "Worktree state: rebase stopped with unresolved conflicts.\n\nRecovery:\n  Resolve the conflicting paths in this worktree, stage them, run `git rebase --continue`, then resume the same job step. Later handoff phases have not been replayed."
+    } else {
+        "Recovery:\n  Reconcile the recorded phase in this worktree, then resume the same job step. Later handoff phases have not been replayed."
+    };
     let message = format!(
-        "{header}\n\nHead branch: {head}\nWorktree: {worktree}\nBase branch: {base}\n{base_ref}Failing phase: {phase}\nError: {error}\n\nRecovery:\n  Reconcile the recorded phase in this worktree, then resume the same job step. Later handoff phases have not been replayed.",
+        "{header}\n\nHead branch: {head}\nWorktree: {worktree}\nBase branch: {base}\n{base_ref}Failing phase: {phase}\nError: {error}\n\n{recovery}",
         worktree = context.workspace_path.display(),
         phase = phase.label(),
     );
@@ -189,6 +196,24 @@ pub(super) fn record_failed_handoff<H: TaskHost + ?Sized>(
         )?;
     }
     Ok(())
+}
+
+pub(super) fn rebase_in_progress(workspace_path: &Path) -> Result<bool, OrbitError> {
+    for state_dir in ["rebase-merge", "rebase-apply"] {
+        let path = PathBuf::from(super::git::git_output(
+            workspace_path,
+            &["rev-parse", "--git-path", state_dir],
+        )?);
+        let path = if path.is_absolute() {
+            path
+        } else {
+            workspace_path.join(path)
+        };
+        if path.is_dir() {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn current_branch(workspace_path: &Path) -> Option<String> {

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/handoff.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/handoff.rs
@@ -130,6 +130,38 @@ fn recovered_rebase_continues_remaining_handoff_phases_without_replay() {
     assert_eq!(prepared["decision"], json!("rebase_required"));
     let rebase_input = rebase_input(&input, &prepared);
     rebase_pr_branch(&host, &rebase_input).expect_err("first rebase conflicts");
+    let retry_error =
+        rebase_pr_branch(&host, &rebase_input).expect_err("retry reports the still-stopped rebase");
+    let retry_message = retry_error.to_string();
+    assert!(
+        retry_message.contains("rebase remains stopped with unresolved conflicts"),
+        "{retry_message}"
+    );
+    assert!(
+        retry_message.contains("conflicting paths: src/lib.rs"),
+        "{retry_message}"
+    );
+    assert!(
+        !retry_message.contains("prepared branch"),
+        "stopped rebase must not be misclassified as a checkout mismatch: {retry_message}"
+    );
+    let failure_comment = host
+        .comments_for(task_id)
+        .into_iter()
+        .find(|comment| comment.message.contains("[phase=rebase]"))
+        .expect("rebase failure handoff comment");
+    assert!(
+        failure_comment
+            .message
+            .contains("Worktree state: rebase stopped with unresolved conflicts."),
+        "{}",
+        failure_comment.message
+    );
+    assert!(
+        failure_comment.message.contains("`git rebase --continue`"),
+        "{}",
+        failure_comment.message
+    );
 
     fs::write(
         workspace.repo.join("src/lib.rs"),
@@ -198,6 +230,39 @@ fn recovered_rebase_continues_remaining_handoff_phases_without_replay() {
     let task = host.get_task(task_id).expect("task");
     assert_eq!(task.status, TaskStatus::Review);
     assert_eq!(task.github_pr_number(), Some("42"));
+}
+
+#[test]
+fn rebase_retry_distinguishes_wrong_branch_from_stopped_rebase() {
+    let workspace = rebase_conflict_pr_workspace();
+    let task_id = "ORB-WRONG-BRANCH";
+    let host = PrOpenTestHost::new(
+        vec![batch_task(
+            task_id,
+            "Reject wrong branch",
+            "Outcome: success\nChanges:\n- Candidate is ready.",
+        )],
+        workspace.repo.clone(),
+    );
+    let input = json!({
+        "workspace_path": workspace.repo,
+        "job_run_id": "batch-1",
+        "completed_task_ids": [task_id],
+        "base": "agent-main",
+        "base_sync": "local",
+    });
+    let prepared = prepare_pr_handoff(&host, &input).expect("prepare branch checkpoint");
+    git(&workspace.repo, &["checkout", "agent-main"]);
+
+    let error = rebase_pr_branch(&host, &rebase_input(&input, &prepared))
+        .expect_err("genuine wrong branch remains rejected");
+    let message = error.to_string();
+    assert!(
+        message
+            .contains("prepared branch 'orbit/test-batch' is not checked out (found 'agent-main')"),
+        "{message}"
+    );
+    assert!(!message.contains("rebase remains stopped"), "{message}");
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-10642](https://orbit-cli.com/tasks/ORB-10642) — Report mid-rebase state on a sync-base re-attempt instead of a misleading branch error

### Description

## Problem

After a `git_rebase` conflict during sync_base, the recovery re-attempt reports a branch-checkout error that names neither the mid-rebase state nor any conflicting path, so the real situation has to be inferred.

## Evidence (verified against the current tree, 2026-08-08)

**Half the original filing is already false and the spec has been narrowed accordingly.**

- Conflicting paths **are** already surfaced. `rebase_pr_branch` in `crates/orbit-engine/src/executor/automation/vcs/freshness.rs` builds its error via a `diff --name-only --diff-filter=U` probe and appends `conflicting paths: ...` on both failure branches.
- The worktree is **not** permanently stranded. The PR pipeline sets a failure handoff activity; `crates/orbit-engine/src/executor/automation/vcs/failure.rs` collects unmerged paths, then aborts the rebase, then publishes a blocked PR naming them. Existing coverage asserts HEAD returns to the pre-rebase sha.

The narrow residual defect is the window between the rebase failure and terminalization. sync_base carries a recovery activity, so an agent plus one re-attempt run against a still-mid-rebase worktree. On that re-attempt, the branch-checkout guard fires **before** the unmerged-paths check: during a stopped rebase HEAD is detached, so the resolved branch reads as `HEAD` and the error becomes "prepared branch is not checked out (found 'HEAD')". The failed-handoff record likewise says only "reconcile the recorded phase in this worktree", with no mid-rebase indication.

## Why It Matters

The re-attempt's error misdirects diagnosis toward branch preparation when the actual state is a stopped rebase with known conflicting paths.

## Scope

**Scoped down from the original filing.** Automatic union-merging of additive conflicts is deliberately **out of scope** — it is a standing maintenance burden for a conflict class the handoff already resolves. Do not implement it.

## Constraints / Notes

- **An unconditional `rebase --abort` at the failure site would break a designed path.** The reused-recovery decision exists precisely so a recovery agent can resolve in place and run `rebase --continue`; existing coverage asserts that flow. If any abort is introduced it must be conditional on no recovery activity running, and the condition must be stated explicitly.
- Semantic conflicts stay fail-closed.
- The CLI operation-match and parent-command enum files named in the original filing are collision victims, not modification targets — they are out of scope here.

### Acceptance Criteria

- A re-attempt against a worktree left mid-rebase reports the mid-rebase state and the conflicting paths, rather than a branch-not-checked-out error.
- The detached-HEAD condition during a stopped rebase is distinguished from a genuine wrong-branch condition, asserted by a test.
- The existing recover-then-continue flow still works: coverage asserting a recovery agent can resolve in place and continue the rebase still passes.
- Semantic conflicts remain fail-closed and still route to the blocked-PR handoff.
- Any newly introduced abort is conditional, and the condition is named in the execution summary.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Detect per-worktree Git rebase state before the prepared-branch checkout guard, so a sync-base retry reports that the rebase remains stopped and includes the unmerged paths instead of misclassifying detached HEAD as a wrong branch.
- Make the durable failed-handoff comment name the stopped-rebase state and direct recovery to resolve, stage, and run git rebase --continue.
- Added regression coverage for the mid-rebase retry diagnostics and the genuine wrong-branch distinction while preserving the existing recover-then-continue and semantic-conflict blocked-PR flows.
Assessment: High confidence. The implementation uses the rebase-merge and rebase-apply state directories rather than the persistent REBASE_HEAD pseudo-ref, which preserves successful post-continue retries.

Validation:
- cargo test -p orbit-engine rebase_ -- --nocapture: passed with 3 tests.
- make ci-fast: passed.
- cargo test -p orbit-engine: all 343 library tests passed; the unrelated existing v2_cli_backend integration scenario then failed at crates/orbit-engine/tests/v2_cli_backend.rs line 235 because the fixture produced step assess while the assertion expects review. That out-of-scope operation-match fixture was not modified.

Scope:
- Added file:crates/orbit-engine/src/executor/automation/vcs/pr/tests/handoff.rs to context_files because directly affected regression coverage was required.
- No abort was introduced; recovery remains in-place, and the existing terminal failure handoff retains ownership of its conditional abort behavior.
- Friction checkpoint considered; no qualifying Orbit tooling or workflow friction was encountered.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10642-6a781fca`
- Behind base: 0
- Ahead of base: 1