### PR TITLE
Publish proposed ADR bundles: track the partition and make lifecycle precedence explicit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,9 +56,10 @@ benchmarks/**/tasks/**
 .orbit/*
 !.orbit/adrs/
 .orbit/adrs/index.sqlite*
-# Proposed ADR drafts are local-only until publication (ORB-10303). Accepted,
-# superseded, and deleted ADRs are published decision history and travel with
-# the repository (ADR-0302 / ORB-10545).
+# Every ADR lifecycle partition travels with the repository — proposed drafts
+# included, so the decision under review is visible in the PR that motivates it
+# (ORB-10669, amending ADR-0302 / ORB-10545). Only the rebuildable index above
+# and the lock files below are carved back out.
 # Project learnings travel with the repo (ADR-003 in docs/design/project-learnings/4_decisions.md).
 !.orbit/learnings/
 # Auto-task definitions are git-versioned records (ORB-10149); the host-local
@@ -67,7 +68,8 @@ benchmarks/**/tasks/**
 !.orbit/resources/
 !.orbit/routines/
 !.orbit/config.toml
-# Lock files inside the re-included partitions stay ignored (ORB-10303).
+# Lock files inside the re-included partitions stay ignored (ORB-10303); they
+# are host-local, not decision history.
 .orbit/**/*.lock
 .monodev/
 

--- a/crates/orbit-cli/src/command/workspace/support.rs
+++ b/crates/orbit-cli/src/command/workspace/support.rs
@@ -82,18 +82,17 @@ fn is_git_repo_root(path: &Path) -> bool {
 /// The Orbit-managed `.gitignore` block written by `orbit workspace init`.
 ///
 /// Blanket-ignores `.orbit/*`, then re-includes the artifact partitions that
-/// travel with the repo (accepted/deleted ADRs, learnings, auto-tasks,
-/// resources, routines, config). The `proposed/` and `superseded/` ADR
-/// partitions stay ignored — they are local-only until publication
-/// (ORB-10303). `.orbit/**/*.lock` keeps lock files out of the re-included
-/// directories. Order matters: the partition exclusions must follow the
-/// `!.orbit/adrs/` re-include, or git tracks them anyway.
+/// travel with the repo. Every ADR lifecycle partition is published decision
+/// history — proposed drafts included, so the decision under review is visible
+/// in the PR that motivates it (ORB-10669, amending ADR-0302). Only the
+/// rebuildable SQLite index and the lock files are carved back out:
+/// `.orbit/adrs/index.sqlite*` and `.orbit/**/*.lock`. Order matters: those
+/// exclusions must follow the `!.orbit/adrs/` re-include, or git tracks them
+/// anyway.
 const ORBIT_GITIGNORE_BLOCK: &[&str] = &[
     ".orbit/*",
     "!.orbit/adrs/",
     ".orbit/adrs/index.sqlite*",
-    ".orbit/adrs/proposed/",
-    ".orbit/adrs/superseded/",
     "!.orbit/learnings/",
     "!.orbit/auto_tasks/",
     "!.orbit/resources/",
@@ -101,6 +100,16 @@ const ORBIT_GITIGNORE_BLOCK: &[&str] = &[
     "!.orbit/config.toml",
     ".orbit/**/*.lock",
 ];
+
+/// Lines earlier managed blocks wrote that the current policy retires.
+///
+/// These must be stripped on re-init rather than merely left alone: git applies
+/// the *last* matching pattern, but `!.orbit/adrs/` re-includes only the `adrs`
+/// directory itself, so a lingering `.orbit/adrs/proposed/` above the appended
+/// block would still be the last pattern matching that subdirectory and would
+/// keep the partition ignored. Retiring them here is what makes re-init
+/// converge on the current policy instead of preserving the old one.
+const RETIRED_ORBIT_BLOCK_LINES: &[&str] = &[".orbit/adrs/proposed/", ".orbit/adrs/superseded/"];
 
 /// Legacy bare `.orbit` ignore lines written by earlier `orbit workspace init`
 /// versions. A bare `.orbit` ignores the whole directory, so no `!`-negation
@@ -125,19 +134,27 @@ fn write_orbit_gitignore_entry(gitignore_path: &Path) -> Result<(), OrbitError> 
         Err(error) => return Err(OrbitError::Io(error.to_string())),
     };
 
-    // Idempotent no-op: the full managed block is already present and no legacy
-    // bare `.orbit` line lingers (a bare line would defeat the re-includes).
-    if gitignore_has_managed_block(&content) && !gitignore_has_legacy_orbit_line(&content) {
+    // Idempotent no-op: the full managed block is already present and neither a
+    // legacy bare `.orbit` line (which would defeat the re-includes) nor a
+    // retired line from an older block lingers.
+    if gitignore_has_managed_block(&content)
+        && !gitignore_has_legacy_orbit_line(&content)
+        && !gitignore_has_retired_block_line(&content)
+    {
         return Ok(());
     }
 
-    // Rebuild: drop any legacy bare lines and any pre-existing managed-block
-    // lines (partial or full), preserving the operator's other content and
-    // order, then append the canonical block once at the end.
+    // Rebuild: drop any legacy bare lines, any line retired from an older
+    // managed block, and any pre-existing managed-block lines (partial or
+    // full), preserving the operator's other content and order, then append the
+    // canonical block once at the end.
     let mut next = String::new();
     for line in content.lines() {
         let trimmed = line.trim();
-        if LEGACY_ORBIT_LINES.contains(&trimmed) || ORBIT_GITIGNORE_BLOCK.contains(&trimmed) {
+        if LEGACY_ORBIT_LINES.contains(&trimmed)
+            || RETIRED_ORBIT_BLOCK_LINES.contains(&trimmed)
+            || ORBIT_GITIGNORE_BLOCK.contains(&trimmed)
+        {
             continue;
         }
         next.push_str(line);
@@ -158,4 +175,10 @@ fn gitignore_has_legacy_orbit_line(content: &str) -> bool {
     content
         .lines()
         .any(|line| LEGACY_ORBIT_LINES.contains(&line.trim()))
+}
+
+fn gitignore_has_retired_block_line(content: &str) -> bool {
+    content
+        .lines()
+        .any(|line| RETIRED_ORBIT_BLOCK_LINES.contains(&line.trim()))
 }

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -947,6 +947,80 @@ fn workspace_init_replaces_legacy_bare_orbit_gitignore_line_with_managed_block()
 }
 
 #[test]
+fn workspace_init_retires_older_managed_block_lines_for_published_adr_partitions() {
+    // ORB-10669 published the proposed partition (amending ADR-0302, which had
+    // already published superseded). A checkout carrying the older block still
+    // has those two ignore lines; because `!.orbit/adrs/` re-includes only the
+    // `adrs` directory itself, a surviving `.orbit/adrs/proposed/` would remain
+    // the last pattern matching that subdirectory and would keep the partition
+    // ignored even with the new block appended below it. Re-init must retire
+    // them.
+    let workspace = tempdir().expect("workspace tempdir");
+    let home = tempdir().expect("home tempdir");
+    std::fs::create_dir_all(workspace.path().join(".git")).expect("create .git");
+    let older_managed_block = concat!(
+        "target/\n",
+        ".orbit/*\n",
+        "!.orbit/adrs/\n",
+        ".orbit/adrs/index.sqlite*\n",
+        ".orbit/adrs/proposed/\n",
+        ".orbit/adrs/superseded/\n",
+        "!.orbit/learnings/\n",
+        "!.orbit/auto_tasks/\n",
+        "!.orbit/resources/\n",
+        "!.orbit/routines/\n",
+        "!.orbit/config.toml\n",
+        ".orbit/**/*.lock\n",
+    );
+    std::fs::write(workspace.path().join(".gitignore"), older_managed_block)
+        .expect("write .gitignore");
+
+    let _env = EnvGuard::acquire().home(home.path()).cwd(workspace.path());
+
+    let init = |force| WorkspaceInitArgs {
+        name: None,
+        base_branch: Some("main".to_string()),
+        ship_mode: None,
+        role: None,
+        owner: None,
+        task_id_start: None,
+        mcp: false,
+        inject_agent_rules: false,
+        refresh_defaults: false,
+        force,
+    };
+
+    init(false)
+        .execute_without_runtime(None)
+        .expect("workspace init");
+    let expected = format!("target/\n{}", orbit_gitignore_block());
+    assert_eq!(
+        std::fs::read_to_string(workspace.path().join(".gitignore")).expect("read .gitignore"),
+        expected,
+        "retired partition lines must be stripped, not stacked under a second block"
+    );
+
+    // Re-init converges: no duplicated block, no resurrected retired line.
+    init(true)
+        .execute_without_runtime(None)
+        .expect("workspace re-init");
+    let converged =
+        std::fs::read_to_string(workspace.path().join(".gitignore")).expect("read .gitignore");
+    assert_eq!(converged, expected, "re-init must converge on one block");
+    for retired in [".orbit/adrs/proposed/", ".orbit/adrs/superseded/"] {
+        assert!(
+            !converged.lines().any(|line| line.trim() == retired),
+            "published partition `{retired}` must not be ignored"
+        );
+    }
+    assert_eq!(
+        converged.matches(".orbit/*\n").count(),
+        1,
+        "the managed block must appear exactly once"
+    );
+}
+
+#[test]
 fn workspace_init_from_git_subdir_gitignores_repo_orbit_dir() {
     let repo = tempdir().expect("repo tempdir");
     let home = tempdir().expect("home tempdir");

--- a/crates/orbit-store/src/file/adr_store/api/mod.rs
+++ b/crates/orbit-store/src/file/adr_store/api/mod.rs
@@ -1,6 +1,8 @@
 // Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
+use std::collections::BTreeMap;
+use std::collections::btree_map::Entry;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -528,8 +530,15 @@ impl AdrFileStore {
         }))
     }
 
+    /// Lists every locally readable ADR, one entry per ID.
+    ///
+    /// An ID duplicated across partitions by a merge collapses to its
+    /// authoritative bundle under the same [`AdrStateDir::lifecycle_rank`]
+    /// precedence [`Self::locate_adr`] uses, so a stale draft can neither
+    /// double-count in a listing nor race the accepted row into the index
+    /// during a rebuild.
     pub(crate) fn list_adrs(&self) -> Result<Vec<Adr>, OrbitError> {
-        let mut adrs = Vec::new();
+        let mut by_id: BTreeMap<String, (AdrStateDir, Adr)> = BTreeMap::new();
         for state in AdrStateDir::all() {
             let dir = state_dir_path(&self.root, *state);
             if !dir.exists() {
@@ -541,11 +550,28 @@ impl AdrFileStore {
                 if !doc_path.is_file() {
                     continue;
                 }
-                let bundle = read_bundle_at(&adr_dir_path)?;
-                adrs.push(bundle_to_adr(bundle));
+                let adr = bundle_to_adr(read_bundle_at(&adr_dir_path)?);
+                match by_id.entry(adr.id.clone()) {
+                    Entry::Vacant(slot) => {
+                        slot.insert((*state, adr));
+                    }
+                    Entry::Occupied(mut slot) => {
+                        let kept_state = slot.get().0;
+                        let (winner, shadowed) =
+                            if state.lifecycle_rank() > kept_state.lifecycle_rank() {
+                                (*state, kept_state)
+                            } else {
+                                (kept_state, *state)
+                            };
+                        warn_shadowed_partition(&adr.id, winner, shadowed);
+                        if winner == *state {
+                            slot.insert((*state, adr));
+                        }
+                    }
+                }
             }
         }
-        Ok(adrs)
+        Ok(by_id.into_values().map(|(_, adr)| adr).collect())
     }
 
     /// Lists ADRs filtered by envelope fields.
@@ -912,17 +938,32 @@ impl AdrFileStore {
         })
     }
 
+    /// Finds the authoritative on-disk bundle for `id`.
+    ///
+    /// Scans every lifecycle partition rather than stopping at the first hit.
+    /// A merge can leave one ID in two partitions at once (see
+    /// [`AdrStateDir::lifecycle_rank`]); when it does, the most-advanced
+    /// lifecycle state wins by that documented precedence and the shadowed
+    /// copies are named in a warning, so the outcome is deterministic and the
+    /// leftover is visible instead of silently deciding the read.
     fn locate_adr(&self, id: &str) -> Result<Option<(AdrStateDir, PathBuf)>, OrbitError> {
+        let mut found: Vec<(AdrStateDir, PathBuf)> = Vec::new();
         for state in AdrStateDir::all() {
             let dir = adr_dir(&self.root, *state, id);
             if dir.is_dir() {
                 // A stray same-named dir without adr.yaml still counts as "located"
                 // here so the caller gets a sensible missing-ADR / corruption error
                 // from read_bundle_at.
-                return Ok(Some((*state, dir)));
+                found.push((*state, dir));
             }
         }
-        Ok(None)
+        let Some(winner_index) = index_of_authoritative_state(&found) else {
+            return Ok(None);
+        };
+        if found.len() > 1 {
+            warn_duplicate_partitions(id, &found, found[winner_index].0);
+        }
+        Ok(Some(found.swap_remove(winner_index)))
     }
 
     fn read_adr_allocation(&self, record: &IdAllocationRecord) -> Result<Option<Adr>, OrbitError> {
@@ -1105,6 +1146,44 @@ impl AdrFileStore {
         }
         Ok(ids)
     }
+}
+
+/// Index of the most-advanced lifecycle partition among `found`, or `None`
+/// when nothing was found.
+///
+/// Ties are impossible: each partition contributes at most one entry, and
+/// [`AdrStateDir::lifecycle_rank`] is injective.
+fn index_of_authoritative_state(found: &[(AdrStateDir, PathBuf)]) -> Option<usize> {
+    found
+        .iter()
+        .enumerate()
+        .max_by_key(|(_, (state, _))| state.lifecycle_rank())
+        .map(|(index, _)| index)
+}
+
+fn warn_duplicate_partitions(id: &str, found: &[(AdrStateDir, PathBuf)], winner: AdrStateDir) {
+    for (state, dir) in found {
+        if *state == winner {
+            continue;
+        }
+        orbit_common::tracing::warn!(
+            adr_id = id,
+            resolved_partition = winner.dir_name(),
+            shadowed_partition = state.dir_name(),
+            shadowed_path = %dir.display(),
+            "ADR exists in multiple lifecycle partitions; resolving to the most-advanced state \
+             and ignoring the stale bundle"
+        );
+    }
+}
+
+fn warn_shadowed_partition(id: &str, winner: AdrStateDir, shadowed: AdrStateDir) {
+    orbit_common::tracing::warn!(
+        adr_id = id,
+        resolved_partition = winner.dir_name(),
+        shadowed_partition = shadowed.dir_name(),
+        "ADR exists in multiple lifecycle partitions; listing only the most-advanced state"
+    );
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/orbit-store/src/file/adr_store/api/tests/api.rs
+++ b/crates/orbit-store/src/file/adr_store/api/tests/api.rs
@@ -722,6 +722,120 @@ fn list_adrs_returns_all_adrs_across_state_dirs() {
     );
 }
 
+/// Copies an ADR bundle directory verbatim, creating the destination.
+///
+/// Stands in for what git does when a branch that predates a lifecycle
+/// transition merges after it: the pre-transition partition directory and the
+/// post-transition one are unrelated paths, so both land without a conflict.
+fn copy_bundle_dir(source: &Path, target: &Path) {
+    fs::create_dir_all(target).expect("bundle dir");
+    for entry in fs::read_dir(source).expect("read bundle dir") {
+        let entry = entry.expect("bundle entry");
+        fs::copy(entry.path(), target.join(entry.file_name())).expect("copy bundle file");
+    }
+}
+
+#[test]
+fn merged_stale_proposed_bundle_does_not_mask_the_accepted_adr() {
+    // ORB-10669: every ADR partition is now tracked, so a branch cut before
+    // acceptance carries `proposed/<id>` and merging it re-adds that directory
+    // next to `accepted/<id>`. Resolution must follow the documented
+    // lifecycle precedence (most-advanced state wins) rather than partition
+    // declaration order, which would have read the stale draft.
+    let (dir, store) = store_with_index();
+    let root = dir.path();
+    let adr = store
+        .add_adr(create_params("Precedence", "Draft body"))
+        .expect("add");
+
+    // Snapshot the bundle exactly as the pre-acceptance branch has it.
+    let branch_snapshot = root.join("branch-snapshot");
+    copy_bundle_dir(&root.join("proposed").join(&adr.id), &branch_snapshot);
+
+    store
+        .update_adr_status(&adr.id, AdrStatus::Accepted)
+        .expect("accept");
+
+    // The merge re-adds the stale partition directory.
+    copy_bundle_dir(&branch_snapshot, &root.join("proposed").join(&adr.id));
+    assert!(root.join("proposed").join(&adr.id).is_dir());
+    assert!(root.join("accepted").join(&adr.id).is_dir());
+
+    let resolved = store.get_adr(&adr.id).expect("get").expect("adr present");
+    assert_eq!(
+        resolved.status,
+        AdrStatus::Accepted,
+        "the stale proposed bundle must not mask the accepted record"
+    );
+
+    let listed = store.list_adrs().expect("list");
+    assert_eq!(listed.len(), 1, "a duplicated ID must not double-count");
+    assert_eq!(listed[0].status, AdrStatus::Accepted);
+
+    store.rebuild_index().expect("rebuild index");
+    assert_eq!(count_index_rows(&store), 1);
+}
+
+#[test]
+fn duplicate_partition_precedence_holds_for_later_lifecycle_transitions() {
+    // The same merge shape applies to every other sanctioned forward
+    // transition: a merged `accepted/<id>` must not pull a superseded ADR back
+    // to accepted, and a merged `proposed/<id>` must not resurrect a deleted
+    // one.
+    let tempdir = tempdir().expect("tempdir");
+    let root = tempdir.path().to_path_buf();
+    let store = AdrFileStore::new(root.clone());
+
+    let superseded = store
+        .add_adr(create_params("Superseded", "Body"))
+        .expect("add");
+    store
+        .update_adr_status(&superseded.id, AdrStatus::Accepted)
+        .expect("accept");
+    let accepted_snapshot = root.join("accepted-snapshot");
+    copy_bundle_dir(
+        &root.join("accepted").join(&superseded.id),
+        &accepted_snapshot,
+    );
+    store
+        .update_adr_status(&superseded.id, AdrStatus::Superseded)
+        .expect("supersede");
+    copy_bundle_dir(
+        &accepted_snapshot,
+        &root.join("accepted").join(&superseded.id),
+    );
+
+    let deleted = store
+        .add_adr(create_params("Deleted", "Body"))
+        .expect("add");
+    let proposed_snapshot = root.join("proposed-snapshot");
+    copy_bundle_dir(&root.join("proposed").join(&deleted.id), &proposed_snapshot);
+    store
+        .update_adr_status(&deleted.id, AdrStatus::Deleted)
+        .expect("delete");
+    copy_bundle_dir(&proposed_snapshot, &root.join("proposed").join(&deleted.id));
+
+    assert_eq!(
+        store
+            .get_adr(&superseded.id)
+            .expect("get")
+            .expect("present")
+            .status,
+        AdrStatus::Superseded
+    );
+    assert_eq!(
+        store
+            .get_adr(&deleted.id)
+            .expect("get")
+            .expect("present")
+            .status,
+        AdrStatus::Deleted
+    );
+
+    let listed = store.list_adrs().expect("list");
+    assert_eq!(listed.len(), 2, "each ID must collapse to one entry");
+}
+
 // ----- Index-integration tests (Phase 3) -------------------------------
 
 fn store_with_index() -> (tempfile::TempDir, AdrFileStore) {

--- a/crates/orbit-store/src/file/adr_store/layout/mod.rs
+++ b/crates/orbit-store/src/file/adr_store/layout/mod.rs
@@ -29,6 +29,11 @@ impl AdrStateDir {
         }
     }
 
+    /// Scan order for the four partitions.
+    ///
+    /// This order carries no resolution meaning. When one ID exists in more
+    /// than one partition, use [`AdrStateDir::lifecycle_rank`] to pick the
+    /// authoritative one — never "first hit wins".
     pub(super) fn all() -> &'static [AdrStateDir] {
         &[
             AdrStateDir::Proposed,
@@ -36,6 +41,30 @@ impl AdrStateDir {
             AdrStateDir::Superseded,
             AdrStateDir::Deleted,
         ]
+    }
+
+    /// How far along the ADR lifecycle this partition sits, ascending.
+    ///
+    /// Every sanctioned transition moves an ADR forward (`proposed →
+    /// accepted → superseded`, and `→ deleted` as the terminal tombstone);
+    /// `accepted → proposed` is rejected outright. So when a single ID is
+    /// found in two partitions, the higher rank is the later — and therefore
+    /// the authoritative — state, and the lower one is a stale copy.
+    ///
+    /// The duplicate is reachable now that every partition is tracked
+    /// (ORB-10669): a branch cut before acceptance still carries
+    /// `proposed/<id>`, and merging it re-adds that directory alongside
+    /// `accepted/<id>` — two unrelated paths, so git merges both without
+    /// conflict. This ranking is the explicit precedence that resolves it,
+    /// replacing the implicit one that fell out of declaration order in
+    /// [`AdrStateDir::all`].
+    pub(super) fn lifecycle_rank(self) -> u8 {
+        match self {
+            AdrStateDir::Proposed => 0,
+            AdrStateDir::Accepted => 1,
+            AdrStateDir::Superseded => 2,
+            AdrStateDir::Deleted => 3,
+        }
     }
 
     pub(super) fn from_status(status: AdrStatus) -> Self {

--- a/docs/design/worktree-artifacts/2_design.md
+++ b/docs/design/worktree-artifacts/2_design.md
@@ -3,14 +3,14 @@ summary: "Worktree Artifacts - Design"
 type: design
 title: "Worktree Artifacts - Design"
 owner: codex
-last_updated: 2026-08-01
+last_updated: 2026-08-09
 status: Accepted
 feature: worktree-artifacts
 doc_role: design
 tags: ["worktree-artifacts"]
 paths: ["crates/orbit-remote/**", "crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-cli/**"]
 related_features: ["worktree-artifacts", "host-registry", "mcp-bridge"]
-related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10272", "ORB-10297", "ORB-10330", "ORB-10545", "ADR-0177", "ADR-0229", "ADR-0302"]
+related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10272", "ORB-10297", "ORB-10330", "ORB-10545", "ORB-10669", "ADR-0177", "ADR-0229", "ADR-0302", "ADR-0339"]
 ---
 
 # Worktree Artifacts - Design
@@ -148,11 +148,53 @@ destination changes. This is deliberately distinct from `adr restore`: restore
 authors a replacement only when no readable copy exists; reconciliation
 preserves a readable published bundle verbatim.
 
-## 6. Indexing Behavior
+## 6. Publication Policy and Duplicate Partitions
+
+Every ADR lifecycle partition — `proposed/`, `accepted/`, `superseded/`,
+`deleted/` — is tracked by git and travels with the repository [ORB-10669].
+Publishing `proposed/` puts the decision under review in the same PR as the
+change that motivates it, and means an ADR authored inside a managed job
+worktree lands on that run's branch instead of stranding on the box until an
+operator reconciles it. Only the rebuildable `adrs/index.sqlite*` and the
+host-local `*.lock` files stay ignored. The managed `.gitignore` block that
+`orbit workspace init` writes carries this policy to every workspace; re-init
+over an older block retires that block's `proposed/` and `superseded/` ignore
+lines rather than leaving them to out-rank the appended re-include.
+
+Publishing every partition makes a duplicate ID reachable. Acceptance is a
+directory rename, so a branch cut before acceptance still carries
+`proposed/<id>`; merging it re-adds that directory next to `accepted/<id>`, and
+git merges both without a conflict because the two paths are unrelated.
+Resolution follows one explicit precedence: **the most-advanced lifecycle state
+wins** (`proposed` < `accepted` < `superseded` < `deleted`), because every
+sanctioned transition moves forward and `accepted → proposed` is rejected
+outright — so the lower-ranked copy is always the stale one. `get_adr`, every
+mutation preflight, and `list_adrs` share that precedence, and each shadowed
+partition is named in a `warn` log with its path, so the leftover is visible and
+removable rather than silently deciding the read. This replaces the implicit
+precedence that fell out of partition declaration order. `orbit adr reconcile`
+keeps its stricter contract: a source checkout holding more than one lifecycle
+artifact for an ID is refused, not resolved.
+
+### 6.1 Managed job-worktree drafts
+
+A managed job-run worktree scaffolds a real `.orbit/adrs/proposed` for its run.
+Drafts written there are now tracked, so the on-box auto-commit sweeps them into
+the run's branch. That is the intended disposition for work that ships: the
+draft rides its PR and merges with the code. For a run that is abandoned or
+whose PR is rejected, the disposition is that **the draft dies with the branch**
+— no operator cleanup step, no reconciliation. Nothing reaches `agent-main`
+unless the branch merges, and the ID allocation left behind is an ordinary valid
+gap (§2). Deleting the worktree removes the only copy; that is expected and is
+not the orphaned-allocation condition ORB-10501 repairs. An operator who instead
+wants to keep a draft from a discarded branch pulls it over with
+`orbit adr reconcile` before the worktree is reaped.
+
+## 7. Indexing Behavior
 
 Learning reindex and docs/ADR search operate on locally readable bodies. Remote-only allocation rows are skipped without error; once the recorded worktree is present and readable again, the same list/reindex path can read and index the body.
 
-## 7. Concerns & Honest Limitations
+## 8. Concerns & Honest Limitations
 
 Remote stubs are intentionally envelope-poor. They expose allocation metadata, not the artifact title, summary, or body, because those fields live in the unreadable body file. Filters that require body fields can only apply to locally readable artifacts.
 
@@ -174,5 +216,8 @@ The `worktree_root` column preserves historical rows from earlier phases, so old
   before allocation. Public creation stays on the compatibility path until F3.
 - [ORB-10545] added exact-bundle reconciliation and made superseded ADR bodies
   repository-published decision history under [ADR-0302].
+- [ORB-10669] published the remaining partitions (§6) under [ADR-0339], made the
+  managed `.gitignore` block retire its own superseded lines, and replaced
+  first-hit-wins ADR resolution with the explicit lifecycle precedence.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/worktree-artifacts/4_decisions.md
+++ b/docs/design/worktree-artifacts/4_decisions.md
@@ -3,14 +3,14 @@ summary: "Worktree Artifacts - Decisions"
 type: design
 title: "Worktree Artifacts - Decisions"
 owner: codex
-last_updated: 2026-08-01
+last_updated: 2026-08-09
 status: Accepted
 feature: worktree-artifacts
 doc_role: decisions
 tags: ["worktree-artifacts"]
 paths: ["crates/orbit-remote/**", "crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-engine/**", "crates/orbit-cli/**"]
 related_features: ["worktree-artifacts", "host-registry", "mcp-bridge"]
-related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10272", "ORB-10297", "ORB-10330", "ORB-10501", "ORB-10535", "ORB-10545", "ADR-0177", "ADR-0229", "ADR-0296", "ADR-0302"]
+related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10272", "ORB-10297", "ORB-10330", "ORB-10501", "ORB-10535", "ORB-10545", "ORB-10669", "ADR-0177", "ADR-0229", "ADR-0296", "ADR-0302", "ADR-0339"]
 ---
 
 # Worktree Artifacts - Decisions
@@ -84,6 +84,24 @@ allocating a new ID or changing lifecycle/allocation metadata. Narrative and
 the explicit rejected alternatives live in the ADR store; retrieve them with
 `orbit tool run orbit.adr.show --input '{"id":"ADR-0302"}'`.
 
+## ADR-0339 - Publish every ADR lifecycle partition and resolve duplicates by explicit precedence
+
+**Status:** Proposed - 2026-08 - [ORB-10669]
+
+Amends [ADR-0302]. Every ADR lifecycle partition — proposed included — travels
+with the repository, so the decision under review is visible in the PR that
+motivates it and a draft authored in a managed job worktree lands on that run's
+branch instead of stranding on the box. Only the rebuildable index and the
+host-local lock files stay ignored. The managed `.gitignore` block that
+`orbit workspace init` writes carries the policy to every workspace and retires
+the `proposed/` and `superseded/` ignore lines older blocks wrote, so re-init
+converges instead of preserving the old policy. Publishing every partition makes
+a duplicate ID reachable through an ordinary merge; it resolves by one explicit
+precedence — the most-advanced lifecycle state wins — with each shadowed
+partition named in a warning. Narrative and the explicit rejected alternatives
+live in the ADR store; retrieve them with
+`orbit tool run orbit.adr.show --input '{"id":"ADR-0339"}'`.
+
 ## Task References
 
 - [ORB-00199] introduced shared/local root resolution.
@@ -104,5 +122,9 @@ the explicit rejected alternatives live in the ADR store; retrieve them with
   creating that orphaned state when the target still holds the unique body.
 - [ORB-10545] added federated ADR reconciliation, published superseded bodies,
   and resolved the guarded-cleanup deadlock under [ADR-0302].
+- [ORB-10669] published the remaining ADR partitions, made the shipped
+  `.gitignore` block retire its own superseded lines so re-init converges, and
+  replaced first-hit-wins resolution with the explicit lifecycle precedence
+  under [ADR-0339].
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10669](https://orbit-cli.com/tasks/ORB-10669) — Publish proposed ADR bundles: track the partition and make lifecycle precedence explicit

### Description

## Problem

Proposed ADR bundles are git-ignored (ADR-0302, ORB-10303), so the decision under review is invisible in the PR that motivates it, and every ADR authored inside a managed job worktree is stranded on the box until an operator reconciles it. Daniel has reversed that policy: the proposed partition should travel with the repository.

The reversal is not a one-line `.gitignore` edit, because the ignore policy is generated, not hand-maintained, and because tracking the partition makes a latent resolution ambiguity reachable.

- `ORBIT_GITIGNORE_BLOCK` in `crates/orbit-cli/src/command/workspace/support.rs` is the managed block `orbit workspace init` writes and rewrites; it still ignores `.orbit/adrs/proposed/`, so a hand-edited `.gitignore` is reverted on the next init/re-register and every other workspace keeps the old policy. That same constant still ignores `.orbit/adrs/superseded/`, which ADR-0302 already decided should travel — this repo's `.gitignore` dropped that line but the shipped block did not.
- Acceptance is a directory rename from `proposed/<id>` to `accepted/<id>`. With both partitions tracked, a branch cut before acceptance still carries the proposed bundle, and merging it re-adds that directory next to the accepted one — git sees two unrelated paths and merges both without conflict. `locate_adr` (`crates/orbit-store/src/file/adr_store/api/mod.rs`) then resolves by scanning `AdrStateDir::all()` in declaration order, proposed first, returning the first hit with no duplicate detection: the stale draft masks the accepted record and the ADR silently reads as proposed again.
- Managed job worktrees create a real `.orbit/adrs/proposed` for their runs (`crates/orbit-core/src/runtime/v2_host/sandbox.rs`). Tracked, those drafts become dirty files in the run's branch and are swept up by the on-box auto-commit, so abandoned and rejected runs can leave draft bundles in branch history.

## Constraints

- The managed `.gitignore` block is a shipped surface that seeds every workspace: it must stay project-agnostic, and the change must be idempotent against existing checkouts that already carry an older block (including the hand-edited one on this box).
- Federated reconciliation and the worktree locality guard keep their current behavior; this task changes publication policy, not artifact ownership or the `artifact_not_local` contract.
- The SQLite index and lock files stay ignored — they are rebuildable and must not become tracked as a side effect of re-including the partition.
- Whatever resolves duplicate IDs must be deterministic and observable; a silently-won race between two partitions is the defect being fixed, so a mismatch should be either resolved by an explicit documented precedence or surfaced as an error, not left implicit in enum declaration order.

## Acceptance criteria

- A newly initialized workspace tracks proposed ADR bundles, and re-running init over a checkout with an older managed block converges without duplicating or stacking blocks.
- The shipped block matches the accepted publication policy for every partition, including superseded.
- Merging a branch that carries a stale proposed bundle for an ID that is already accepted does not cause the ADR to read as proposed; a regression test covers the duplicate-partition case directly against the resolution path.
- Drafts left behind by managed worktree runs have a defined disposition, documented wherever an operator would look for it.
- `cargo build` succeeds and the change's own tests pass; CI on agent-main is advisory.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented on `orbit/ORB-10669-6a781fca`. 8 files, +419/-31. ADR-0339 authored (proposed) with the narrative and rejected alternatives.

**Publication policy (shipped block).** `ORBIT_GITIGNORE_BLOCK` (`crates/orbit-cli/src/command/workspace/support.rs`) drops `.orbit/adrs/proposed/` and `.orbit/adrs/superseded/`; only `.orbit/adrs/index.sqlite*` and `.orbit/**/*.lock` remain carved out of the `!.orbit/adrs/` re-include, so every partition travels with the repo and the block finally matches ADR-0302 for superseded. Added `RETIRED_ORBIT_BLOCK_LINES` plus `gitignore_has_retired_block_line`: the rebuild strips those two lines and the idempotent-no-op check refuses to short-circuit while one lingers. This is load-bearing, not cosmetic — `!.orbit/adrs/` re-includes only the `adrs` directory itself, so a surviving `.orbit/adrs/proposed/` above the appended block would still be the last pattern matching that subdirectory and would keep the partition ignored on every already-initialized checkout.

**Duplicate-partition precedence.** Added `AdrStateDir::lifecycle_rank` (`layout/mod.rs`, proposed < accepted < superseded < deleted) and documented `AdrStateDir::all()` as scan order with no resolution meaning. `locate_adr` (`api/mod.rs`) now collects every partition hit and returns the highest-ranked one instead of the first; `list_adrs` accumulates through a `BTreeMap` keyed by ID and collapses duplicates under the same rule, so a stale draft cannot double-count in a listing or race the accepted row into `rebuild_index`. Every shadowed partition is named with its path in a `tracing::warn`. Chose precedence over erroring because an error would brick `orbit adr show` exactly after a merge; `orbit adr reconcile` keeps its stricter multiple-artifact refusal, unchanged. Federation, ownership, and the `artifact_not_local` contract are untouched.

**Managed job-worktree drafts.** Documented disposition (`docs/design/worktree-artifacts/2_design.md` §6.1): tracked drafts ride the run's branch and merge with the PR; a draft from an abandoned or rejected run dies with the branch — no operator cleanup, no reconciliation, and the unused allocation is an ordinary valid gap rather than the ORB-10501 orphan condition. `sandbox.rs` needed no change.

**Tests.** `merged_stale_proposed_bundle_does_not_mask_the_accepted_adr` reproduces the merge by snapshotting the pre-acceptance bundle and re-adding the directory after acceptance, then asserts `get_adr` reads accepted, `list_adrs` returns one entry, and `rebuild_index` writes one row. `duplicate_partition_precedence_holds_for_later_lifecycle_transitions` covers accepted+superseded and proposed+deleted (superseded→deleted is not a sanctioned transition, so that pair is unreachable). `workspace_init_retires_older_managed_block_lines_for_published_adr_partitions` initializes over a literal older block and asserts one converged block with no retired line, twice.

**Docs.** New `## 6. Publication Policy and Duplicate Partitions` in `2_design.md` (Indexing/Concerns renumbered 7/8), ADR-0339 heading + task reference in `4_decisions.md`, `last_updated` and `related_artifacts` bumped on both, and the stale ORB-10303 comment in the repo `.gitignore` replaced.

**Validation.** `make ci-fast` passes. `cargo build --workspace` succeeds. `cargo test -p orbit-store` 331 passed; `cargo test -p orbit-cli --bin orbit` 303 passed, including all 23 workspace-init tests. Clippy on both crates is clean (the one warning is pre-existing in `orbit-core`). Four `orbit-cli` integration failures (`docs::cli_orbit_search_kind_adr_all_includes_superseded`, `docs::cli_semantic_index_adrs_is_idempotent_status_agnostic_and_sweeps_stale`, `mcp_roundtrip::mcp_serve_tools_list_matches_production_snapshot`, `output_goldens::plain_and_json_forms_match_their_goldens`) reproduce identically on a stashed clean tree — pre-existing under this managed run, whose policy denies `adr accept` (`policy_denied: managed-run executors cannot transition ADR lifecycle status`). Not caused by this change; unrestricted CI arbitrates.

**Note for review.** The ADR-0339 bundle was written by the bridge into the canonical checkout (`/home/daniel/workspace/constellation/codebases/orbit`, branch `agent-main`), not into this worktree, so it is not in the PR diff even though this change is what makes such bundles publishable. Left as-is rather than hand-moving `.orbit/` state; `4_decisions.md` in the diff carries the citation.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10669-6a781fca`
- Behind base: 0
- Ahead of base: 1