### PR TITLE
Mitigate low-signal / gibberish content in recent history surfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ ci-fast:
 	./scripts/check-dependency-direction.sh
 	./scripts/check-cli-imports.sh
 	./scripts/check-terminal-state-guard.sh
+	./scripts/check-history-note-size.sh
 	./scripts/check-stability.sh
 	./scripts/check-learning-layout.sh
 	./scripts/check-artifact-redaction-guardrail.sh

--- a/crates/orbit-engine/src/context/outcome.rs
+++ b/crates/orbit-engine/src/context/outcome.rs
@@ -10,6 +10,21 @@ pub const AGENT_INVOCATION_FAILED: &str = "AGENT_INVOCATION_FAILED";
 pub const AGENT_TIMEOUT: &str = "AGENT_TIMEOUT";
 pub const WORKFLOW_RUN_FAILED_EVENT: &str = "workflow_run_failed";
 
+/// Maximum bytes of a run's `error_message` inlined verbatim into the
+/// `workflow_run_failed` history note. Beyond this the note keeps the leading
+/// bytes and points at the run record for the rest.
+///
+/// This is the only size threshold on the history-note surface and it is
+/// declared exactly once on purpose — `scripts/check-history-note-size.sh`
+/// fails the build if a second one appears, because a threshold copied into a
+/// second writer is a threshold that drifts.
+///
+/// 1000 was chosen from the real distribution of `job_run_steps.error_message`
+/// (497 recorded step errors, 2026-08-09): p50=183 B, p95=676 B, p99=14,720 B,
+/// max=80,939 B. It leaves the p95 message fully inline and elides 18 of 497
+/// (3.6%) — the genuine bulk only. [ORB-10343]
+pub const MAX_NOTE_ERROR_BYTES: usize = 1_000;
+
 pub fn workflow_failure_note(
     job_id: &str,
     run_id: &str,
@@ -24,10 +39,51 @@ pub fn workflow_failure_note(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or("-");
+    let error_message = elide_note_error(run_id, error_message);
 
     format!(
         "workflow run failed: job={job_id}, run_id={run_id}, error_code={error_code}, error={error_message}"
     )
+}
+
+/// Keep the head of an oversized `error_message` and replace the tail with the
+/// command that reads the full text back.
+///
+/// This is not lossy truncation. `job_run_steps.error_message` persists the
+/// whole message for the life of the run record, so the note was carrying a
+/// duplicate of an already-durable value; the elision drops the copy, not the
+/// original. The retrieval command is written into the note itself so a reader
+/// who hits the elision does not have to know where run records live.
+///
+/// A worktree-integrity failure serializes its entire `dirty_paths` list into
+/// this field, which is how one ORB-10332 note reached 85 KB — 8% of all task
+/// history bytes in the workspace, in a single entry. [ORB-10343]
+fn elide_note_error(run_id: &str, error_message: &str) -> String {
+    if error_message.len() <= MAX_NOTE_ERROR_BYTES {
+        return error_message.to_string();
+    }
+    let head = &error_message[..floor_char_boundary(error_message, MAX_NOTE_ERROR_BYTES)];
+    let total = error_message.len();
+    format!(
+        "{head}… [elided: error_message is {total} B; full text: \
+         `orbit run show {run_id} --json`, field .run.steps[].error_message]"
+    )
+}
+
+/// Largest index at or below `index` that splits `text` between characters.
+///
+/// Stands in for the unstable `str::floor_char_boundary`. Slicing an error
+/// message mid-codepoint would panic, and error text is arbitrary bytes from a
+/// failing subprocess.
+fn floor_char_boundary(text: &str, index: usize) -> usize {
+    if index >= text.len() {
+        return text.len();
+    }
+    let mut end = index;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
 }
 
 pub fn blocked_workflow_failure_update(

--- a/crates/orbit-engine/src/context/tests/mod.rs
+++ b/crates/orbit-engine/src/context/tests/mod.rs
@@ -1,1 +1,2 @@
 mod env;
+mod outcome;

--- a/crates/orbit-engine/src/context/tests/outcome.rs
+++ b/crates/orbit-engine/src/context/tests/outcome.rs
@@ -1,0 +1,111 @@
+//! Regression guard for the `workflow_run_failed` history note.
+//!
+//! Measurement over 845 task bundles (ORB-10343) found that every history entry
+//! over 2 KB was a `workflow_run_failed` note inlining a run's whole
+//! `error_message` — 9 entries carrying 16.6% of all history bytes. These tests
+//! pin the bound so that surface cannot silently return to inlining bulk.
+
+use crate::context::outcome::{
+    MAX_NOTE_ERROR_BYTES, WORKFLOW_RUN_FAILED_EVENT, blocked_workflow_failure_update,
+    workflow_failure_note,
+};
+
+const JOB_ID: &str = "task_pr_pipeline";
+const RUN_ID: &str = "jrun-20260720-0146-3";
+
+/// The overwhelming majority of real failures (p95 = 676 B) must read exactly
+/// as they did before the cap — an elision that fires on ordinary errors would
+/// cost more diagnostic value than the bulk it saves.
+#[test]
+fn short_error_message_is_inlined_verbatim() {
+    let error = "worktree integrity violation `worktree_integrity_ambiguous`";
+    let note = workflow_failure_note(JOB_ID, RUN_ID, Some("E_INTEGRITY"), Some(error));
+
+    assert_eq!(
+        note,
+        format!(
+            "workflow run failed: job={JOB_ID}, run_id={RUN_ID}, \
+             error_code=E_INTEGRITY, error={error}"
+        )
+    );
+    assert!(!note.contains("elided"));
+}
+
+/// A message exactly at the threshold is still inlined; the cap is inclusive so
+/// there is no off-by-one band that elides without need.
+#[test]
+fn error_message_at_threshold_is_inlined_verbatim() {
+    let error = "x".repeat(MAX_NOTE_ERROR_BYTES);
+    let note = workflow_failure_note(JOB_ID, RUN_ID, None, Some(&error));
+
+    assert!(note.ends_with(&error));
+    assert!(!note.contains("elided"));
+}
+
+/// The ORB-10332 shape: a worktree-integrity failure serializing its whole
+/// `dirty_paths` list. The note must stay small and must say where the rest is.
+#[test]
+fn oversized_error_message_is_elided_with_retrieval_path() {
+    let error = format!(
+        "execution failed: v2 job dispatch: worktree integrity violation: {}",
+        "\"crates/orbit-cli/src/command/task/command.rs\",".repeat(2_000)
+    );
+    assert!(
+        error.len() > 80_000,
+        "fixture must reproduce the real shape"
+    );
+
+    let note = workflow_failure_note(JOB_ID, RUN_ID, Some("-"), Some(&error));
+
+    // Bounded: threshold + a fixed pointer suffix + the short envelope. The
+    // real note this replaces was 85,005 B.
+    assert!(
+        note.len() < 2 * MAX_NOTE_ERROR_BYTES,
+        "note must stay bounded, got {} B",
+        note.len()
+    );
+    // The head is preserved, so the note is still self-explanatory at a glance.
+    assert!(note.contains("worktree integrity violation"));
+    // The retrieval path travels with the elision, not in separate docs.
+    assert!(note.contains(&format!("orbit run show {RUN_ID} --json")));
+    assert!(note.contains(".run.steps[].error_message"));
+    assert!(note.contains(&format!("error_message is {} B", error.len())));
+}
+
+/// Error text is arbitrary bytes from a failing subprocess. Slicing it
+/// mid-codepoint would panic inside the terminalization path that is meant to
+/// be best-effort.
+#[test]
+fn elision_boundary_is_utf8_safe() {
+    // A 4-byte character straddles the cap for every offset in 0..4.
+    for pad in 0..4 {
+        let error = format!(
+            "{}{}",
+            "a".repeat(MAX_NOTE_ERROR_BYTES - 1 + pad),
+            "🛰".repeat(200)
+        );
+        let note = workflow_failure_note(JOB_ID, RUN_ID, None, Some(&error));
+        assert!(note.contains("elided"), "pad={pad} must elide");
+        assert!(note.len() < 2 * MAX_NOTE_ERROR_BYTES, "pad={pad}");
+    }
+}
+
+/// The automation update that every failure path uses must go through the
+/// capped helper. A writer that assembled its own note would reintroduce the
+/// blob without any test noticing.
+#[test]
+fn blocked_update_routes_through_the_capped_note() {
+    let error = "y".repeat(50_000);
+    let update = blocked_workflow_failure_update(JOB_ID, RUN_ID, None, Some(&error));
+
+    assert_eq!(
+        update.status_event.as_deref(),
+        Some(WORKFLOW_RUN_FAILED_EVENT)
+    );
+    let note = update.status_note.expect("blocked update carries a note");
+    assert_eq!(
+        note,
+        workflow_failure_note(JOB_ID, RUN_ID, None, Some(&error))
+    );
+    assert!(note.len() < 2 * MAX_NOTE_ERROR_BYTES);
+}

--- a/docs/design/task-artifacts/4_decisions.md
+++ b/docs/design/task-artifacts/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Task Artifacts — Decisions"
 type: design
 title: "Task Artifacts — Decisions"
 owner: codex
-last_updated: 2026-07-26
+last_updated: 2026-08-09
 status: Draft
 feature: task-artifacts
 doc_role: decisions
@@ -107,9 +107,18 @@ Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.
 
 ---
 
+## ADR-0340 — History notes elide only what another record retains in full
+
+**Status:** Accepted · 2026-08 · [ORB-10343]
+
+Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.show --input '{"id":"ADR-0340"}'`.
+
+---
+
 ## Task References
 
 - ORB-00093
 - ORB-00273
+- ORB-10343
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/task-artifacts/specs/task-bundle-v2.md
+++ b/docs/design/task-artifacts/specs/task-bundle-v2.md
@@ -144,6 +144,30 @@ Convenience reads:
 
 Writers must not rewrite prior event lines except during explicit cutover or repair commands. Appends must write one JSON object plus newline, flush and sync the file before success, and preserve a valid prefix if the process crashes. Readers must tolerate a final unterminated or invalid JSON line as tail corruption; repair may truncate only that final corrupt tail.
 
+### Notes must not inline bulk
+
+`note` is a human-readable summary, not a payload channel. A writer must not
+inline a machine-generated blob — a serialized structure, a path list, a
+captured stream — into it. Because `events.jsonl` is append-only, an oversized
+note is permanent: it dilutes every downstream reader of that task (history
+scanning, memory distillation, triage, and the agent task context assembled in
+`v2_host/task_context.rs`) for the life of the record.
+
+A writer whose note would carry such a payload must instead keep a leading
+excerpt and name, **inside the note itself**, the command that reads the full
+text back. Eliding is only permitted where the full value is independently
+durable: the note carries a copy, and the copy is what gets dropped. Discarding
+a value that exists nowhere else is not permitted at write time — the note is a
+durable record and a lossy write cannot be undone later.
+
+The one such elision today is the `workflow_run_failed` note, whose
+`error_message` is retained in full by `job_run_steps.error_message` and read
+back with `orbit run show <run_id> --json` (field `.run.steps[].error_message`).
+Its size threshold is declared exactly once, in `orbit-engine`'s
+`context::outcome`, and `scripts/check-history-note-size.sh` fails the build if
+a second threshold or a second `workflow_run_failed` note producer appears.
+Re-measure the surface with `scripts/measure-history-signal.py`. [ORB-10343]
+
 ## Comments
 
 `comments.jsonl` is append-only. Each line is a JSON object with:
@@ -256,4 +280,4 @@ Cutover must be idempotent for interrupted local runs. A partially converted tas
 
 ## Agent Signature
 
-Last revised by `codex` on 2026-07-26 for [ORB-10466].
+Last revised by `claude` on 2026-08-09 for [ORB-10343].

--- a/scripts/check-history-note-size.sh
+++ b/scripts/check-history-note-size.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Task history notes must not inline bulk. [ORB-10343]
+#
+# Measurement over 845 task bundles found that every history entry above 2 KB
+# was a `workflow_run_failed` note carrying a run's whole `error_message` — 9
+# entries holding 16.6% of all history bytes in the workspace, one of them
+# 85 KB. Every reader of that task pays for the blob: Daniel scanning history,
+# memory distillation, triage, and every agent whose task context is built from
+# the same note (`v2_host/task_context.rs`).
+#
+# The fix is a single cap in `orbit-engine`'s `context::outcome`, which keeps the
+# head of the message and points at `orbit run show <run_id> --json` for the
+# rest. That is lossless because `job_run_steps.error_message` already persists
+# the full text — the note was a duplicate.
+#
+# This guard exists because the failure mode is silent: a new failure writer that
+# formats its own note, or a second copy of the threshold, reintroduces the blob
+# and nothing else notices until history is fat again. The runtime bound itself
+# is pinned by crates/orbit-engine/src/context/tests/outcome.rs; this script
+# pins the structural invariants that no unit test can see.
+#
+# Re-measure any time with: scripts/measure-history-signal.py
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "check-history-note-size: ripgrep (rg) is required; install it before running" >&2
+  exit 1
+fi
+
+owner="crates/orbit-engine/src/context/outcome.rs"
+failed=0
+
+if [[ ! -f "$owner" ]]; then
+  echo "check-history-note-size: expected the note owner at $owner" >&2
+  exit 1
+fi
+
+# 1. One threshold, one place. A second declaration is a threshold that drifts.
+threshold_sites="$(rg --no-heading --line-number --glob '*.rs' \
+  'const MAX_NOTE_ERROR_BYTES' crates || true)"
+threshold_count="$(printf '%s' "$threshold_sites" | rg -c . || true)"
+if [[ "$threshold_count" != "1" ]]; then
+  echo "the history-note size threshold must be declared exactly once; found ${threshold_count:-0}:"
+  printf '%s\n' "$threshold_sites"
+  failed=1
+elif ! printf '%s' "$threshold_sites" | rg -q "^$owner:"; then
+  echo "MAX_NOTE_ERROR_BYTES must live in $owner:"
+  printf '%s\n' "$threshold_sites"
+  failed=1
+fi
+
+# 2. One producer. A writer that assembles its own `workflow_run_failed` note
+#    bypasses the cap entirely, so only the owning module may emit that event.
+while IFS= read -r hit; do
+  [[ -z "$hit" ]] && continue
+  file="${hit%%:*}"
+  [[ "$file" == "$owner" ]] && continue
+  # Naming the pattern in prose is not emitting it. A doc comment has to be able
+  # to say which event this rule governs and why a call site stopped building it.
+  code="${hit#*:*:}"
+  if [[ "${code#"${code%%[![:space:]]*}"}" == //* ]]; then
+    continue
+  fi
+  echo "workflow_run_failed notes must be built by workflow_failure_note in $owner: $hit"
+  failed=1
+done < <(rg --no-heading --line-number --glob '*.rs' --glob '!**/tests/**' \
+  'status_event:\s*Some\(\s*WORKFLOW_RUN_FAILED_EVENT' crates || true)
+
+# 3. The elision must keep saying where the full text is. A pointer-free
+#    elision would turn a bounded note into a lossy one from the reader's side.
+if ! rg -q 'orbit run show \{run_id\} --json' "$owner"; then
+  echo "the elided note must carry its retrieval command (\`orbit run show <run_id> --json\`) in $owner"
+  failed=1
+fi
+if ! rg -q 'run\.steps\[\]\.error_message' "$owner"; then
+  echo "the elided note must name the field that holds the full text, in $owner"
+  failed=1
+fi
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "see docs/design/task-artifacts/specs/task-bundle-v2.md §Events for the rule" >&2
+  exit 1
+fi
+
+echo "history note size guard passed"

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -46,6 +46,7 @@ fi
 "$repo_root/scripts/check-dependency-direction.sh"
 "$repo_root/scripts/check-cli-imports.sh"
 "$repo_root/scripts/check-terminal-state-guard.sh"
+"$repo_root/scripts/check-history-note-size.sh"
 "$repo_root/scripts/check-stability.sh"
 "$repo_root/scripts/check-learning-layout.sh"
 "$repo_root/scripts/check-artifact-redaction-guardrail.sh"

--- a/scripts/measure-history-signal.py
+++ b/scripts/measure-history-signal.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Measure low-signal bulk across a workspace's task history surfaces.
+
+This is the method behind [ORB-10343]. It is committed rather than run ad hoc so
+the "which surface is actually the offender" question is answered with numbers
+that anyone can reproduce, and so the same numbers can be taken again after a
+mitigation lands.
+
+It reports, per surface (`events.jsonl` history rows and `comments.jsonl` rows):
+
+* bytes per entry — n, total, mean, p50, p95, max
+* boilerplate ratio — JSON envelope bytes (ids, timestamps, statuses) as a
+  fraction of total bytes, i.e. how much is structure rather than payload
+* embedded-blob frequency — entries whose free-text payload carries a
+  serialized JSON object or array rather than prose
+* a by-event-type breakdown of every entry over `--blob-threshold`, which is
+  what actually names the offender
+
+Usage:
+
+    scripts/measure-history-signal.py                     # this repo's .orbit/tasks
+    scripts/measure-history-signal.py path/to/.orbit/tasks
+    scripts/measure-history-signal.py --json              # machine-readable
+
+Nothing is written and nothing is mutated; it only reads task bundles.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from argparse import ArgumentParser
+from pathlib import Path
+
+# A payload is "blob-shaped" when it contains a JSON object/array opener
+# immediately followed by a quoted key, or repeats the `","` separator that a
+# serialized string list produces. Prose that merely mentions a brace does not
+# match.
+BLOB_SHAPE = re.compile(r'[\[{]"')
+BLOB_SEPARATOR_RUNS = 3
+
+
+def percentile(values: list[int], fraction: float) -> int:
+    """Nearest-rank percentile over an already-sorted list."""
+    if not values:
+        return 0
+    index = min(int(len(values) * fraction), len(values) - 1)
+    return values[index]
+
+
+def summarize(sizes: list[int]) -> dict:
+    if not sizes:
+        return {"n": 0, "total": 0, "mean": 0, "p50": 0, "p95": 0, "max": 0}
+    ordered = sorted(sizes)
+    return {
+        "n": len(ordered),
+        "total": sum(ordered),
+        "mean": round(sum(ordered) / len(ordered)),
+        "p50": percentile(ordered, 0.50),
+        "p95": percentile(ordered, 0.95),
+        "max": ordered[-1],
+    }
+
+
+def is_blob_shaped(payload: str) -> bool:
+    return bool(BLOB_SHAPE.search(payload)) or payload.count('","') > BLOB_SEPARATOR_RUNS
+
+
+def read_rows(path: Path) -> list[tuple[str, dict | None]]:
+    """Yield (raw_line, parsed_or_None) for each non-empty JSONL row.
+
+    A trailing corrupt line is tolerated: the bundle spec allows readers to see
+    an unterminated tail, and a measurement pass must not be the thing that
+    fails on one.
+    """
+    rows: list[tuple[str, dict | None]] = []
+    with path.open(encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            try:
+                rows.append((line, json.loads(line)))
+            except json.JSONDecodeError:
+                rows.append((line, None))
+    return rows
+
+
+def measure_surface(
+    tasks_root: Path, filename: str, payload_key: str, type_key: str | None, blob_threshold: int
+) -> dict:
+    sizes: list[int] = []
+    payload_bytes = 0
+    payloads = 0
+    blobs = 0
+    oversized: dict[str, dict] = {}
+
+    for bundle in sorted(tasks_root.iterdir()):
+        source = bundle / filename
+        if not bundle.is_dir() or not source.is_file():
+            continue
+        for line, parsed in read_rows(source):
+            size = len(line.encode("utf-8"))
+            sizes.append(size)
+            if parsed is None:
+                continue
+            payload = parsed.get(payload_key) or ""
+            if payload:
+                payloads += 1
+                payload_bytes += len(payload.encode("utf-8"))
+                if is_blob_shaped(payload):
+                    blobs += 1
+            if size > blob_threshold:
+                label = (parsed.get(type_key) if type_key else None) or "-"
+                entry = oversized.setdefault(label, {"count": 0, "bytes": 0, "examples": []})
+                entry["count"] += 1
+                entry["bytes"] += size
+                if len(entry["examples"]) < 3:
+                    entry["examples"].append({"task": bundle.name, "bytes": size})
+
+    stats = summarize(sizes)
+    total = stats["total"]
+    return {
+        "surface": filename,
+        "entries": stats,
+        "payload_bytes": payload_bytes,
+        "payload_entries": payloads,
+        "boilerplate_ratio": round((total - payload_bytes) / total, 3) if total else 0.0,
+        "blob_shaped_payloads": blobs,
+        "oversized_by_type": dict(
+            sorted(oversized.items(), key=lambda item: -item[1]["bytes"])
+        ),
+    }
+
+
+def render(report: dict, blob_threshold: int) -> str:
+    lines = [f"tasks_root: {report['tasks_root']}", f"bundles: {report['bundles']}", ""]
+    for surface in report["surfaces"]:
+        stats = surface["entries"]
+        lines.append(f"[{surface['surface']}]")
+        lines.append(
+            "  entries n={n} total={total} B mean={mean} p50={p50} p95={p95} max={max}".format(
+                **stats
+            )
+        )
+        lines.append(
+            f"  boilerplate ratio {surface['boilerplate_ratio']} "
+            f"(envelope {stats['total'] - surface['payload_bytes']} B / payload "
+            f"{surface['payload_bytes']} B)"
+        )
+        lines.append(
+            f"  blob-shaped payloads {surface['blob_shaped_payloads']}"
+            f"/{surface['payload_entries']}"
+        )
+        if surface["oversized_by_type"]:
+            lines.append(f"  entries over {blob_threshold} B, by type:")
+            for label, entry in surface["oversized_by_type"].items():
+                examples = ", ".join(
+                    f"{item['task']}:{item['bytes']}B" for item in entry["examples"]
+                )
+                share = entry["bytes"] / stats["total"] if stats["total"] else 0
+                lines.append(
+                    f"    {label}: count={entry['count']} bytes={entry['bytes']} "
+                    f"({share:.1%} of surface) [{examples}]"
+                )
+        else:
+            lines.append(f"  no entries over {blob_threshold} B")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "tasks_root",
+        nargs="?",
+        default=repo_root / ".orbit" / "tasks",
+        type=Path,
+        help="task bundle root (default: this repo's .orbit/tasks)",
+    )
+    parser.add_argument(
+        "--blob-threshold",
+        type=int,
+        default=2000,
+        help="entry size in bytes above which an entry is broken out by type (default: 2000)",
+    )
+    parser.add_argument("--json", action="store_true", help="emit the raw report as JSON")
+    args = parser.parse_args()
+
+    tasks_root: Path = args.tasks_root
+    if not tasks_root.is_dir():
+        parser.error(f"no task bundle root at {tasks_root}")
+
+    surfaces = [
+        measure_surface(tasks_root, "events.jsonl", "note", "type", args.blob_threshold),
+        measure_surface(tasks_root, "comments.jsonl", "body", None, args.blob_threshold),
+    ]
+    report = {
+        "tasks_root": str(tasks_root),
+        "bundles": sum(1 for entry in tasks_root.iterdir() if entry.is_dir()),
+        "blob_threshold": args.blob_threshold,
+        "surfaces": surfaces,
+    }
+
+    print(json.dumps(report, indent=2) if args.json else render(report, args.blob_threshold))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Task

[ORB-10343](https://orbit-cli.com/tasks/ORB-10343) — Mitigate low-signal / gibberish content in recent history surfaces

### Description

## Problem

History surfaces carry enough low-signal content that the signal downstream consumers need — Daniel reading a task, memory distillation, the almanac, triage, review — is diluted by machine-generated bulk. Reported by Daniel 2026-07-20.

The motivating instance: the ORB-10332 `workflow_run_failed` history note inlines the entire worktree `dirty_paths` list. A reader scanning that task's history to understand what happened pays for a multi-KB blob to learn one fact.

This has since been corroborated from the orchestrator side. Reading a single task through `orbit_task_show` routinely returns tens of KB dominated by history and comment bodies, and an unfiltered `orbit_task_list` over one workspace returned 331 KB. The cost is not only human attention: it is context budget for every agent that reads a task, on every run.

## What is not yet established

Which surface is actually the dominant offender. "History" is ambiguous across at least three candidates, and the fix differs for each:

- orbit task **history events** — verbose system notes, inline failure payloads
- agent **run/session transcripts** retained on-box that later feed distillation
- task **comments** carrying machine-generated dumps

Establish this with measurement before changing anything. A mitigation aimed at the wrong surface is worse than none, because it adds a truncation path that has to be maintained and still leaves the real bulk in place.

## Constraints

- **Detail must remain recoverable.** The failure payloads are diagnostic gold when a run goes wrong; today's incident review depended on reading exactly such a note. Moving a blob behind a reference is acceptable; discarding it is not.
- **Do not truncate at write time in a way that loses the original.** A history note is the durable record; a lossy write cannot be undone later when someone needs the detail.
- Whatever is added must not become a second thing that drifts. If a size threshold is introduced, it belongs in one place with a test, not spread across writers.
- Task history is largely an orbit concern, which is why this is filed here. If measurement shows the dominant offender is agent transcripts or bridge-side projection, re-route rather than fix it in the wrong repo — and note that the reroute-shaped run currently strands on the missing side-effect-only completion path (friction F2026-07-018), so raise it rather than absorbing a failed commit step.

## Acceptance criteria

1. The dominant low-signal source is identified with measurement, not impression — bytes per entry, boilerplate ratio, and embedded-blob frequency across the candidate surfaces, with the method stated so it can be re-run.
2. A mitigation is implemented for at least the top offender, and the improvement is demonstrated on a real before/after case rather than a synthetic one.
3. The full detail behind any elided content remains retrievable, and the retrieval path is documented where a reader of the elided note will find it.
4. A regression guard exists so the elided surface cannot silently return to inlining bulk.
5. If the measurement shows the offender is outside this workspace, the task is re-routed with the evidence instead of being patched here.

### Acceptance Criteria

- The dominant low-signal source is identified with measurement, not impression — bytes per entry, boilerplate ratio, and embedded-blob frequency across the candidate surfaces, with the method stated so it can be re-run.
- A mitigation is implemented for at least the top offender, and the improvement is demonstrated on a real before/after case rather than a synthetic one.
- The full detail behind any elided content remains retrievable, and the retrieval path is documented where a reader of the elided note will find it.
- A regression guard exists so the elided surface cannot silently return to inlining bulk.
- If the measurement shows the offender is outside this workspace, the task is re-routed with the evidence instead of being patched here.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Outcome

Measured the three candidate surfaces first, then mitigated the one the numbers
named. The offender is in this workspace, so AC5 (reroute) does not apply.
Decision recorded as **ADR-0340** (Accepted, ORB-10343).

## AC1 — Measurement, not impression

Method committed as `scripts/measure-history-signal.py` so it can be re-run:
walks every task bundle, reporting bytes-per-entry (n/total/mean/p50/p95/max),
boilerplate ratio (JSON envelope vs free-text payload), embedded-blob frequency
(payloads carrying serialized JSON rather than prose), and a by-event-type
breakdown of every entry over `--blob-threshold` (default 2 KB). Read-only.

```
$ scripts/measure-history-signal.py /home/daniel/workspace/constellation/codebases/orbit/.orbit/tasks
bundles: 847

[events.jsonl]
  entries n=5208 total=1027732 B mean=197 p50=160 p95=213 max=85005
  boilerplate ratio 0.755 (envelope 776253 B / payload 251479 B)
  blob-shaped payloads 9/987
  entries over 2000 B, by type:
    workflow_run_failed: count=9 bytes=170993 (16.6% of surface)

[comments.jsonl]
  entries n=1581 total=1069757 B mean=677 p50=461 p95=1662 max=26723
  boilerplate ratio 0.158 (envelope 168592 B / payload 901165 B)
  blob-shaped payloads 8/1581
  entries over 2000 B, by type:
    -: count=52 bytes=236597 (22.1% of surface)
```

**Dominant source: `workflow_run_failed` history notes.** Every history entry
above 2 KB is that one event type — 9 entries carrying 16.6% of all history
bytes in 0.17% of entries — and all 9 blob-shaped notes in the corpus are
exactly those. Cause: `workflow_failure_note` inlines the run's whole
`error_message`, and a worktree-integrity failure serializes its entire
`dirty_paths` list into that field.

Comments were ruled out deliberately, not by omission: 52 entries over 2 KB but
only 8 blob-shaped in 1,581, and a boilerplate ratio of 0.158 vs history's
0.755. That is human/agent prose — a fat middle, not machine bulk — and
truncating it would lose content held nowhere else.

## AC3 first — why eliding here is lossless

`job_run_steps.error_message` in `~/.orbit/orbit.db` persists the whole message
for the life of the run record. Verified against the motivating instance: run
`jrun-20260720-0146-3` step 0 still holds all **80,939 bytes** today. The
history note was carrying a *duplicate* of an already-durable value, so the
elision drops the copy, not the original.

Retrieval path: `orbit run show <run_id> --json`, field
`.run.steps[].error_message` — printed **inside the elided note itself**, so a
reader who hits the elision needs no external documentation. Also stated
normatively in `docs/design/task-artifacts/specs/task-bundle-v2.md` §Events.

Rejected: spilling the payload to `orbit-common::utility::blob_store`. That is
the shape the task anticipated, and measurement removed the need for it — it
would add a second copy of an existing record, a second retention lifetime, and
a retrieval path a reader has to be taught. Recorded in ADR-0340.

## AC2 — Mitigation, demonstrated on the real case

`crates/orbit-engine/src/context/outcome.rs`: one threshold,
`MAX_NOTE_ERROR_BYTES = 1000`, declared exactly once, plus a UTF-8-safe
`elide_note_error` (error text is arbitrary bytes from a failing subprocess;
slicing mid-codepoint would panic inside a best-effort terminalization path).
Threshold chosen from the real distribution of 497 recorded step errors —
p50 183 B, p95 676 B, p99 14,720 B, max 80,939 B — so the p95 message stays
inline verbatim and only 18/497 (3.6%) elide.

Real before/after, replaying the actual stored `error_message` for
`jrun-20260720-0146-3` (the ORB-10332 note) through both formats:

| | note bytes | `events.jsonl` row bytes |
|---|---|---|
| before | 81,031 | 85,020 |
| after | 1,221 | 1,466 |
| | **−98.5%** | **−98.3%** |

The retained head still reads `execution failed: v2 job dispatch: worktree
integrity violation \`worktree_integrity_ambiguous\`: {"assigned_after":
{"branch":"orbit/ORB-10332-6a5d7de6", …` — the one fact the reader was paying
85 KB to learn is still the first thing in the note.

Second-order win: `runtime/v2_host/task_context.rs` injects the most recent
`workflow_run_failed` note verbatim into the implementer's agent context, so
that 81 KB was being re-paid on every dispatch against a previously-failed task.

## AC4 — Regression guard

Two layers, because the failure mode is silent.

1. `scripts/check-history-note-size.sh` — wired into `make ci-fast` and
   `scripts/ci-guardrails.sh`. Fails on (a) a second `MAX_NOTE_ERROR_BYTES`
   declaration, (b) any `workflow_run_failed` note producer outside the owning
   module, (c) an elision that drops its retrieval command or field name. All
   three arms were negative-tested by introducing each violation and confirming
   a non-zero exit, then reverting.
2. `crates/orbit-engine/src/context/tests/outcome.rs` — 5 tests pinning the
   runtime bound on an 80 KB+ input, verbatim pass-through below and at the cap,
   UTF-8 safety across all four straddle offsets, and that
   `blocked_workflow_failure_update` routes through the capped helper.

## Validation

- `make ci-fast` — **pass** (after `cargo fmt --all`).
- `cargo clippy -p orbit-engine --all-targets -- -D warnings` — **pass**.
- `cargo test -p orbit-engine --lib` — **347 passed, 0 failed**.
- `./scripts/check-history-note-size.sh` — pass, and negative-tested.

`cargo test -p orbit-core --lib` shows **3 pre-existing failures on this
branch, not caused by this change** — confirmed by re-running against
`HEAD:crates/orbit-engine/src/context/{outcome.rs,tests/mod.rs}` restored, which
reproduces exactly the same 3:
`command::job::tests::exec::failed_pr_pipeline_dispatches_the_failure_handoff_and_keeps_the_original_error`
(fixture id `ORB-FAILURE-HANDOFF` rejected by ID validation),
`runtime::tests::authorization::a_run_retains_the_destruction_it_dispatches`,
`runtime::v2_host::tests::dispatch::shipped_activity_assets_only_name_registered_deterministic_actions`
(`independent_review_guard` missing from `REGISTERED_DETERMINISTIC_ACTIONS`).
Out of scope here; flagging for whoever owns them.

## Scope note

`context_files` was empty on arrival, so every touched file was appended after
the fact and is listed there now. Beyond the writer and its tests, the additions
are the measurement method (AC1 requires it be re-runnable), the guard plus its
two CI wirings (AC4), and the spec/ADR-index docs that CLAUDE.md requires to
change in the same PR.

## Not addressed, deliberately

History's boilerplate ratio is 0.755 — 776 KB of 1,028 KB is JSON envelope
(`schema_version`, `event_id`, timestamps, statuses). That is structural to the
append-only row format, not low-signal content; reducing it would be a
bundle-format change, not a writer change. Recorded in ADR-0340's Consequences.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10343-6a781fca`
- Behind base: 0
- Ahead of base: 1