### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/orbit-search/1_overview.md
+++ b/docs/design/orbit-search/1_overview.md
@@ -4,6 +4,7 @@ type: design
 title: "Semantic Search — Overview"
 owner: claude
 last_updated: 2026-05-20
+last_validated: 2026-08-09
 status: Draft
 feature: orbit-search
 doc_role: overview
@@ -28,7 +29,7 @@ The task store is already growing past the point where lexical recall is suffici
 
 Lexical search via SQLite FTS5 (BM25) is part of the answer — it handles literal identifiers, error codes, and task IDs better than embeddings. But it misses the cases where the user's vocabulary doesn't match the document's. Semantic search via local embeddings handles that. The two are complementary, not competing, which is why phase 1 ships them together as a hybrid retrieval pipeline ([4_decisions.md ADR-004](./4_decisions.md)).
 
-The constraint that shapes every other decision: **the default `orbit` install is single-binary, no-daemon, and no cloud dependency**. That rules out hosted embedding APIs and rules out an always-on inference daemon. Phase 1 keeps the default `orbit` binary slim by moving fastembed-rs into a separate `orbit-embed-companion` binary that the user opts into via `orbit semantic install` ([4_decisions.md ADR-001](./4_decisions.md), [ADR-0117](./4_decisions.md)).
+The constraint that shapes every other decision: **the default `orbit` install is single-binary, no-daemon, and no cloud dependency**. That rules out hosted embedding APIs and rules out an always-on inference daemon. The `orbit-search` library keeps the main `orbit` binary slim by making fastembed-rs an optional companion-only dependency; users opt into inference via `orbit semantic install` ([4_decisions.md ADR-001](./4_decisions.md), [ADR-0117](./4_decisions.md)).
 
 ---
 
@@ -36,19 +37,19 @@ The constraint that shapes every other decision: **the default `orbit` install i
 
 ### 2.1 Embedding backend (companion-binary architecture)
 
-Two new crates land. `orbit-embed` is a small client library in the main `orbit` binary; it owns the `Embedder` trait, the JSON-RPC types, and a `SubprocessEmbedder` impl that talks to the companion. `orbit-embed-companion` is a separate binary built from its own crate; it depends on [fastembed-rs](https://github.com/Anush008/fastembed-rs) and ONNX Runtime and runs the actual inference. The main `orbit` binary has no fastembed dependency.
+The `orbit-search` crate owns the `Embedder` trait, JSON-RPC types, `SubprocessEmbedder`, vector storage, and command implementations. Its optional `orbit-search-companion` binary target depends on fastembed-rs and runs the actual inference; the main `orbit` binary uses the library without that optional feature and therefore does not link fastembed-rs.
 
-Users opt into semantic search by running `orbit semantic install [--model bge-small | minilm-l6 | nomic-v1.5]`, which downloads the platform-appropriate companion plus the chosen model into `~/.orbit/embed/`. Default model is BGE-small-en-v1.5 (384 dim, ~30MB). The trait abstraction exists so a future `orbit-embed-companion-candle` (or any other backend) can be swapped in without changing storage or retrieval. Airgapped operators have a manual-placement path described in [3_vision.md §1.2](./3_vision.md). The full backend selection rationale is in [4_decisions.md ADR-001](./4_decisions.md); the packaging decision is in [4_decisions.md ADR-005](./4_decisions.md).
+Users opt into semantic search by running `orbit semantic install [--model bge-small | minilm-l6 | nomic-v1.5]`, which downloads the platform-appropriate companion plus the chosen model into `~/.orbit/embed/`. Default model is BGE-small-en-v1.5 (384 dim, ~30MB). The trait abstraction leaves room for a future companion backend without changing storage or retrieval. Airgapped operators have a manual-placement path described in [3_vision.md §1.2](./3_vision.md). The full backend selection rationale is in [4_decisions.md ADR-001](./4_decisions.md); the packaging decision is in [4_decisions.md ADR-005](./4_decisions.md).
 
 ### 2.2 Vector store
 
-A new SQLite table `embeddings` stored alongside the existing task store. Each row holds `(source_kind, source_id, field, content_hash, model_id, dim, embedding BLOB)`. `source_kind` discriminates between rows that index task content and rows that will eventually index graph symbols; `field` distinguishes per-field embeddings within a task (one row each for `purpose`, `plan`, `comments_<idx>`, `review_<idx>`).
+A new SQLite table `embeddings` is stored in the workspace-local semantic database alongside the `corpus_fts` virtual table. Each row holds `(source_kind, source_id, field, chunk_idx, content_hash, model_id, dim, embedding BLOB)`. `source_kind` currently distinguishes task, doc, learning, and ADR rows; `field` distinguishes per-source fields and chunks.
 
-Phase 1 uses **brute-force cosine similarity** in Rust over the BLOBs. At task-corpus scale (low thousands of artifacts × small number of fields per task = tens of thousands of vectors at 384d), brute force is sub-millisecond per query and adds zero new dependencies. The on-disk format is forward-compatible with `sqlite-vec` should the graph corpus later push past brute-force scaling limits ([4_decisions.md ADR-002](./4_decisions.md)).
+The implementation uses **brute-force cosine similarity** in Rust over the BLOBs. At the current corpus scale (low thousands of artifacts × a small number of fields per source = tens of thousands of vectors at 384d), brute force is sub-millisecond per query and adds zero new dependencies. The on-disk format remains forward-compatible with `sqlite-vec` should future local corpus growth push past brute-force scaling limits ([4_decisions.md ADR-002](./4_decisions.md)).
 
 ### 2.3 Hybrid retrieval
 
-Queries run two retrievers in parallel: SQLite FTS5 (BM25) over a `tasks_fts` virtual table, and brute-force cosine over the `embeddings` table. The two ranked lists are fused via Reciprocal Rank Fusion (RRF, k=60) to produce the final ordering. RRF is an unweighted, parameter-light fuse that consistently outperforms either retriever alone in the published evaluation literature; it does not require either retriever's score to be calibrated to the other.
+Queries run two retrievers in parallel: SQLite FTS5 (BM25) over the `corpus_fts` virtual table, and brute-force cosine over the `embeddings` table. The two ranked lists are fused via Reciprocal Rank Fusion (RRF, k=60) to produce the final ordering. RRF is an unweighted, parameter-light fuse that consistently outperforms either retriever alone in the published evaluation literature; it does not require either retriever's score to be calibrated to the other.
 
 This is the single most important quality choice in the design. Pure semantic search loses on literal-identifier queries (function names, error codes, task IDs, file paths); pure lexical search loses on vocabulary-mismatch queries. RRF avoids picking one failure mode over the other ([4_decisions.md ADR-004](./4_decisions.md)).
 
@@ -58,7 +59,7 @@ A task is indexed as multiple rows, one per field: `purpose`, `summary`, `plan`,
 
 ### 2.5 Phase boundary
 
-Phase 1 covers tasks only. Phase 2 will add `source_kind = symbol` rows that embed graph nodes (module path + symbol name + docstring). The vector store schema is designed to accommodate this without migration, but phase 2 has its own design questions (which symbols, what to embed for them, how to keep embeddings fresh as code changes) that this folder does not pre-commit. Phase 2 lands as a separate task and a separate ADR cluster.
+The shipped index covers tasks plus explicitly indexed docs, learnings, and ADRs. The old graph-corpus proposal was retired by ADR-0291 / ORB-10491; no current implementation or roadmap depends on `source_kind = symbol` rows.
 
 ---
 
@@ -69,7 +70,7 @@ Phase 1 covers tasks only. Phase 2 will add `source_kind = symbol` rows that emb
 | Folder layout, frontmatter, ADR template | [docs/design/CONVENTIONS.md](../CONVENTIONS.md) | — |
 | Inference backend choice (fastembed-rs) | [2_design.md §2](./2_design.md), [4_decisions.md ADR-001](./4_decisions.md) | [T20260510-3] |
 | Companion-binary packaging + on-demand install | [2_design.md §2.2–§2.5](./2_design.md), [4_decisions.md ADR-005](./4_decisions.md) | [T20260510-3] |
-| `orbit-embed` and `orbit-embed-companion` crate placement | [2_design.md §1](./2_design.md) | [T20260510-9] |
+| `orbit-search` crate and `orbit-search-companion` binary placement | [2_design.md §1](./2_design.md) | [T20260510-9] |
 | Stdio JSON-RPC protocol | [2_design.md §2.3](./2_design.md) | [T20260510-9] |
 | `embeddings` SQLite table schema | [2_design.md §3](./2_design.md), [4_decisions.md ADR-002](./4_decisions.md) | [T20260510-9] |
 | Per-field embedding strategy | [2_design.md §4](./2_design.md), [4_decisions.md ADR-003](./4_decisions.md) | [T20260510-9] |

--- a/docs/design/orbit-search/2_design.md
+++ b/docs/design/orbit-search/2_design.md
@@ -4,6 +4,7 @@ type: design
 title: "Semantic Search — Design"
 owner: claude
 last_updated: 2026-07-26
+last_validated: 2026-08-09
 status: Accepted
 feature: orbit-search
 doc_role: design
@@ -12,27 +13,27 @@ tags: ["orbit-search"]
 
 # Semantic Search — Design
 
-This document specifies phase-1 semantic search: the two new `orbit-embed*` crates and their place in the architecture, the companion-binary inference model, the SQLite vector storage schema, the per-field embedding strategy, the hybrid (BM25 + cosine) retrieval pipeline, the MCP and CLI surface, the index-maintenance lifecycle, and the concerns the design deliberately leaves to follow-ups.
+This document specifies the semantic-search implementation: the `orbit-search` crate and its optional companion binary, the companion-binary inference model, the SQLite vector storage schema, the per-field embedding strategy, the hybrid (BM25 + cosine) retrieval pipeline, the MCP and CLI surface, the index-maintenance lifecycle, and the concerns the design deliberately leaves to follow-ups.
 
 ---
 
 ## 1. Architectural Placement
 
-Two new crates land:
+The `orbit-search` crate contains the library and the optional companion binary target:
 
-- **`orbit-embed`** — small client library. Owns the `Embedder` trait, the JSON-RPC request/response types, and `SubprocessEmbedder` (the trait impl that locates and talks to the companion). Depends only on `orbit-common`. **Does not depend on fastembed-rs**, so it adds negligible binary cost. Linked into the main `orbit` binary.
-- **`orbit-embed-companion`** — binary crate. Depends on `orbit-embed` (for the RPC types) and on fastembed-rs (for the actual ONNX inference). Produces the standalone `orbit-embed-companion` executable distributed via GitHub Releases per platform. **Not built into `orbit`**; users opt in by running `orbit semantic install`. Per [4_decisions.md ADR-005](./4_decisions.md).
+- **`orbit-search`** — small client and storage library. Owns the `Embedder` trait, the JSON-RPC request/response types, `SubprocessEmbedder`, vector storage, and the install/index/query commands. Its default feature does not enable fastembed-rs, so the main `orbit` binary remains slim.
+- **`orbit-search-companion`** — optional binary target behind the `companion` feature. It depends on fastembed-rs for ONNX inference and is distributed separately per platform. **Not built into `orbit`**; users opt in by running `orbit semantic install`. Per [4_decisions.md ADR-005](./4_decisions.md).
 
 Updated dependency graph:
 
 ```
-orbit-common → orbit-embed → orbit-store → ... (existing graph; orbit-embed has no fastembed dep)
-                          ↘ orbit-embed-companion (separate crate, separate binary, fastembed-rs lives here)
+orbit-common → orbit-search → orbit-core → orbit-cli
+                       ↘ orbit-search-companion (optional binary target, fastembed-rs lives here)
 ```
 
-`orbit-store` gains a new submodule `vector::` alongside the existing `file::` and `sqlite::` layers. `vector::` owns the `embeddings` table schema, write/upsert/delete API, and the brute-force cosine helper implementation. It depends on `orbit-embed` for the `Embedder` trait but treats the embedder as injected — tests pass a `NoopEmbedder` that returns deterministic vectors so unit tests never need the companion to be installed.
+`orbit-search::vector` owns the `embeddings` table schema, write/upsert/delete API, and the brute-force cosine helper implementation. It opens the workspace-local SQLite database directly and treats the embedder as injected — tests pass a `NoopEmbedder` that returns deterministic vectors so unit tests never need the companion to be installed.
 
-The vector SQLite store is workspace-local at `.orbit/state/semantic.db`, not in the global `~/.orbit/orbit.db` audit/tool database. This preserves the task scoping rule: task-derived embeddings and FTS rows do not leak across workspaces.
+The vector SQLite store is workspace-local at `.orbit/state/semantic.db`, not in the global `~/.orbit/orbit.db` audit/tool database. This preserves the workspace scoping rule: task, doc, learning, and ADR embeddings and FTS rows do not leak across workspaces.
 
 `orbit-tools` exposes `orbit.search` as the MCP query tool, and `orbit-cli` exposes `orbit search` for queries plus `orbit semantic` for companion lifecycle (`install`, `uninstall`, `stats`, `index`). These surfaces are thin shells over the shared search runtime.
 
@@ -42,7 +43,7 @@ The vector SQLite store is workspace-local at `.orbit/state/semantic.db`, not in
 
 ### 2.1 Trait
 
-Defined in `orbit-embed`:
+Defined in `orbit-search`:
 
 ```rust
 pub trait Embedder: Send + Sync {
@@ -58,18 +59,18 @@ Batch input is mandatory — fastembed-rs is meaningfully faster on batches than
 
 ### 2.2 Companion-binary architecture
 
-Phase 1 ships a single trait impl: `SubprocessEmbedder` (in `orbit-embed`). It does not perform inference itself — it spawns and talks to the `orbit-embed-companion` binary that the user installed with `orbit semantic install`. The arrangement looks like:
+The library ships a single production trait impl: `SubprocessEmbedder` (in `orbit-search`). It does not perform inference itself — it spawns and talks to the `orbit-search-companion` binary that the user installed with `orbit semantic install`. The arrangement looks like:
 
 ```
-orbit (main binary)                          orbit-embed-companion (installed binary)
+orbit (main binary)                          orbit-search-companion (installed binary)
 ├── SubprocessEmbedder                       ├── fastembed-rs
 │     ↕ stdio JSON-RPC                       │     ↕ ONNX Runtime
-└── orbit-store::vector                      └── BGE-small / MiniLM-L6 / Nomic-v1.5
+└── orbit-search::vector                     └── BGE-small / MiniLM-L6 / Nomic-v1.5
 ```
 
 Lifecycle:
 
-- `SubprocessEmbedder::new()` resolves the companion path under `~/.orbit/embed/bin/orbit-embed-companion-<platform>` and starts the subprocess. ~100–300ms cold-start latency for ORT init.
+- `SubprocessEmbedder::new()` resolves the companion path under `~/.orbit/embed/bin/orbit-search-companion-<platform>` and starts the subprocess. ~100–300ms cold-start latency for ORT init.
 - The subprocess stays alive for the duration of the parent process or until explicitly dropped. Indexing batches and multi-query interactive sessions reuse the same subprocess.
 - On process exit, the parent sends an `exit` RPC and waits up to 1s; if unresponsive, sends SIGTERM.
 
@@ -112,15 +113,14 @@ The three supported models per [3_vision.md §1](./3_vision.md):
 
 On first use of any embedder-touching path, `SubprocessEmbedder::new()` checks:
 
-1. `$ORBIT_EMBED_COMPANION` env var → explicit path override (used by tests and airgapped operators).
-2. `~/.orbit/embed/bin/orbit-embed-companion-<platform>` → standard install path.
-3. `$PATH` → fallback for unusual deployments.
+1. `~/.orbit/embed/bin/orbit-search-companion-<platform>` → standard managed-install path.
+2. `$ORBIT_SEARCH_COMPANION` → developer-only absolute path override when the explicit unsafe override gate is enabled.
 
 If none resolve, the embedder returns `OrbitError::CompanionNotInstalled` with a remediation message: `"Run \`orbit semantic install\` to enable semantic search."` Indexing-path callers log and skip (semantic search is not on the critical path of task mutation; see [§7.1](#71-on-mutation-indexing)). Query-path callers surface the error directly to the user.
 
 ### 2.6 Alternative backends
 
-The trait + RPC protocol make alternative companions viable without changing storage or retrieval. A future `orbit-embed-companion-candle` could speak the same protocol and ship as a separate downloadable. None ship in phase 1; the protocol exists to keep that door open. The full backend comparison is in [4_decisions.md ADR-001](./4_decisions.md); the packaging decision is in [4_decisions.md ADR-005](./4_decisions.md).
+The trait + RPC protocol make alternative companions viable without changing storage or retrieval. A future Candle-based companion could speak the same protocol and ship as a separate downloadable. None ship today; the protocol exists to keep that door open. The full backend comparison is in [4_decisions.md ADR-001](./4_decisions.md); the packaging decision is in [4_decisions.md ADR-005](./4_decisions.md).
 
 ---
 
@@ -132,8 +132,8 @@ A new SQLite table in the existing per-workspace store:
 
 ```sql
 CREATE TABLE embeddings (
-    source_kind TEXT NOT NULL,         -- "task" (phase 1); "symbol" (phase 2 reserved)
-    source_id   TEXT NOT NULL,         -- task ID or future symbol ID
+    source_kind TEXT NOT NULL,         -- "task", "doc", "learning", or "adr"
+    source_id   TEXT NOT NULL,         -- task ID or corpus-specific source ID
     field       TEXT NOT NULL,         -- "purpose", "plan", "comment_3", "review_1_msg_2", ...
     chunk_idx   INTEGER NOT NULL,      -- 0 for unchunked; >0 for splits of long fields
     content_hash TEXT NOT NULL,        -- BLAKE3 of the embedded text; cheap re-index gate
@@ -209,10 +209,11 @@ Token counting uses fastembed-rs's tokenizer for the active model — exact, not
 
 ### 5.1 FTS5 virtual table
 
-A second new table mirrors task content for lexical search:
+A virtual table mirrors corpus content for lexical search:
 
 ```sql
-CREATE VIRTUAL TABLE tasks_fts USING fts5(
+CREATE VIRTUAL TABLE corpus_fts USING fts5(
+    source_kind UNINDEXED,
     source_id UNINDEXED,
     field UNINDEXED,
     content,
@@ -254,16 +255,16 @@ orbit semantic uninstall [--model MODEL] [--all]
 orbit search <query> [--hybrid] [--kind task|doc|learning|adr|all] [--limit N]
 orbit search similar <task-id> [--limit N]
 orbit search path <path> [--kind task|doc|learning|adr|all] [--limit N]
-orbit semantic index     [--force] [--model MODEL]
+orbit semantic index     [--force] [--model MODEL] [--kind tasks|docs|adrs|learnings|all]
 orbit docs index         [--force] [--model MODEL]
 orbit semantic stats
 ```
 
-`install` is the gate that enables every other subcommand. It downloads the platform-appropriate `orbit-embed-companion` binary from the published release URL and the chosen model from HuggingFace, both into `~/.orbit/embed/`. Default model is `bge-small`; users can override per [§2.4](#24-default-model-and-install-time-model-selection). Re-running `install` with a different `--model` adds that model alongside existing ones. Re-running `install` after an Orbit upgrade also refreshes a stale companion automatically because the existing binary's `--version-info` output is compared to the current package version; `--force` is the explicit override for reinstalling the current version.
+`install` is the gate that enables every other subcommand. It downloads the platform-appropriate `orbit-search-companion` binary from the published release URL and the chosen model from HuggingFace, both into `~/.orbit/embed/`. Default model is `bge-small`; users can override per [§2.4](#24-default-model-and-install-time-model-selection). Re-running `install` with a different `--model` adds that model alongside the existing ones. Re-running `install` after an Orbit upgrade also refreshes a stale companion automatically because the existing binary's `--version-info` output is compared to the current package version; `--force` is the explicit override for reinstalling the current version.
 
 `uninstall` removes the companion binary and (by default) the currently active model. `--model M` removes only model M. `--all` removes the companion plus every installed model.
 
-`orbit search` defaults to lexical matching across tasks, docs, learnings, and ADRs. `--hybrid --kind task` runs the hybrid pipeline over task vectors; `--hybrid --kind doc` blends docs lexical scoring with cosine over rows built by `orbit docs index`; learnings and ADRs remain lexical. `orbit search similar <task-id>` embeds the target task's `purpose + summary` and runs cosine-only against other tasks (lexical fusion adds noise here). `orbit search path <path>` performs applicability lookup over path-scoped artifacts. `orbit semantic index` rebuilds task `embeddings` rows; `orbit docs index` rebuilds doc rows and sweeps stale doc paths. `--force` ignores `content_hash` and re-embeds everything. `stats` reports row counts, model distribution, stale-row count, and companion-install status.
+`orbit search` defaults to lexical matching across tasks, docs, learnings, and ADRs. `--hybrid` blends lexical scoring with cosine over the selected corpus; `orbit search similar <task-id>` embeds the target task and runs cosine-neighbor lookup against other tasks; `orbit search path <path>` performs applicability lookup over path-scoped artifacts. `orbit semantic index` rebuilds the selected corpus (`tasks` by default, or `docs`, `adrs`, `learnings`, `all` via `--kind`); `orbit docs index` is the docs-specific alias and sweeps stale doc paths. `--force` ignores `content_hash` and re-embeds everything. `stats` reports row counts, model distribution, stale-row count, and companion-install status.
 
 If the companion is not installed, task-hybrid search, `orbit search similar <task-id>`, `orbit semantic index`, and `orbit docs index` exit non-zero with: `"Semantic search not enabled. Run \`orbit semantic install\` to download the inference companion."` Doc-hybrid search is softer: it emits a warning/note and falls back to lexical doc results.
 

--- a/docs/design/orbit-search/3_vision.md
+++ b/docs/design/orbit-search/3_vision.md
@@ -4,6 +4,7 @@ type: design
 title: "Semantic Search — Vision"
 owner: claude
 last_updated: 2026-05-21
+last_validated: 2026-08-09
 status: Draft
 feature: orbit-search
 doc_role: vision
@@ -30,7 +31,7 @@ The cost of deferring: phase-1 ships with a default chosen on published benchmar
 
 ### 1.2 Airgapped install path
 
-The companion-binary architecture ([4_decisions.md ADR-005](./4_decisions.md)) makes airgapped install harder than a bundled design would have been: operators need to obtain *both* the platform-appropriate `orbit-embed-companion` binary *and* the chosen model files, neither of which is in the main `orbit` release. Options:
+The companion-binary architecture ([4_decisions.md ADR-005](./4_decisions.md)) makes airgapped install harder than a bundled design would have been: operators need to obtain *both* the platform-appropriate `orbit-search-companion` binary *and* the chosen model files, neither of which is in the main `orbit` release. Options:
 
 - **Documented manual placement.** Operator runs `orbit semantic install` on a connected machine, then copies `~/.orbit/embed/` (companion binary + models) onto the airgapped target. Requires documenting the exact file layout. Phase-1 default.
 - **`orbit semantic install --from <path>`.** Operator points the install command at a pre-staged tarball of companion + models. Removes the need to document the directory layout. Probably the right phase-2 ergonomic improvement.
@@ -137,11 +138,11 @@ Three properties separate this design from the prior art it draws on.
 
 ### 3.1 Single-binary local-only by construction
 
-Every published "hybrid retrieval" production system above runs as a service. Orbit's constraint inverts that: no daemon, no service, no API surface, no auth posture to defend. The design is small enough to fit in-process precisely because the corpus is small (tasks, not the whole web). The `Embedder` trait + brute-force cosine + FTS5 + RRF stack adds up to "hybrid retrieval" but ships as four files in two crates rather than four services.
+Every published "hybrid retrieval" production system above runs as a service. Orbit's constraint inverts that: no daemon, no service, no cloud API, no auth posture to defend. The design is small enough to fit in-process precisely because the corpus is local (tasks and other workspace artifacts, not the whole web). The `Embedder` trait + brute-force cosine + FTS5 + RRF stack adds up to "hybrid retrieval" while shipping as one library crate plus an optional companion binary target rather than four services.
 
-### 3.2 Forward compatibility with the graph corpus
+### 3.2 One vector store for multiple local corpora
 
-The schema's `source_kind` discriminator is not future-proofing for its own sake; it commits to a specific phase-2 path where graph symbols join the same vector store under a different `source_kind`. The brute-force ceiling and the `sqlite-vec` upgrade path are sized against that future corpus, not against today's task-only corpus. Most orbit-search-on-tasks projects assume tasks are the whole story; this one explicitly does not.
+The schema's `source_kind` discriminator is not future-proofing for its own sake; it lets tasks, docs, learnings, and ADRs share one workspace-local vector store while retaining corpus-specific indexing and filters. The brute-force implementation stays appropriate for the current corpus size, and the `sqlite-vec` upgrade path remains available if future local corpora make that necessary. Most orbit-search-on-tasks projects assume tasks are the whole story; this one explicitly does not.
 
 ### 3.3 Failure-mode honesty in the score breakdown
 

--- a/docs/design/orbit-search/4_decisions.md
+++ b/docs/design/orbit-search/4_decisions.md
@@ -4,6 +4,7 @@ type: design
 title: "Semantic Search — Decisions"
 owner: claude
 last_updated: 2026-08-01
+last_validated: 2026-08-09
 status: Accepted
 feature: orbit-search
 doc_role: decisions
@@ -14,7 +15,7 @@ tags: ["orbit-search"]
 
 ADR-style log of non-obvious orbit-search decisions. Each entry names the pressure, the choice, and the tradeoff. Entries are append-only and keyed by number; superseded entries are marked, not deleted.
 
-Format for each entry: **Status · Date · Task(s)**, then *Context → Decision → Consequences*. Every ADR names at least one cost. ADRs in this file carry status `Proposed` until the implementing task ships; they flip to `Accepted` with the implementing task ID at that point.
+Format for each entry: **Status · Date · Task(s)**, then *Context → Decision → Consequences*. Every ADR names at least one cost. Entries retain their recorded lifecycle status; implemented entries are `Accepted` and point to the task that shipped them.
 
 Historical note ([ORB-10458]): the entries listed below were authored with local IDs that had no record in the ADR store. They were allocated through `orbit.adr.add`, their narratives migrated into the store verbatim, and their headings rewritten to the allocated global ID. The original local IDs survive as `legacy_ids`, so prior citations still resolve via `orbit tool run orbit.adr.show --input '{"legacy_id":"<feature>/ADR-NNN"}'`. Backfilled here: `orbit-search/ADR-001` → ADR-0270, `orbit-search/ADR-002` → ADR-0271, `orbit-search/ADR-003` → ADR-0272, `orbit-search/ADR-004` → ADR-0273, `orbit-search/ADR-005` → ADR-0274, `orbit-search/ADR-006` → ADR-0275, `orbit-search/ADR-007` → ADR-0276, `orbit-search/ADR-008` → ADR-0277.
 
@@ -92,13 +93,13 @@ Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.
 
 **Context.** `orbit semantic` mixed embedding-companion lifecycle (`install`, `uninstall`, `stats`, `index`) with user query verbs (`search`, `related`). The phase-1 search engine now owns both lexical and vector ranking, so leaving queries under `semantic` would make users choose an implementation detail before they search.
 
-**Decision.** `orbit semantic` is only the lifecycle namespace for the local embedding companion. `orbit search` is the unified query surface; lexical ranking is the default, `--hybrid` opts into hybrid BM25 plus cosine for task vectors, and `--semantic <id>` performs cosine-neighbor lookup for indexed tasks.
+**Decision.** `orbit semantic` is only the lifecycle namespace for the local embedding companion. `orbit search` is the unified query surface; lexical ranking is the default, `--hybrid` opts into hybrid BM25 plus cosine for indexed corpora, and `orbit search similar <id>` performs cosine-neighbor lookup for indexed tasks.
 
 **Consequences.**
 - Establishes a precedent that lifecycle namespaces manage local subsystems while query namespaces describe what users are trying to do.
 - `orbit semantic search`, `orbit semantic related`, and `orbit semantic reindex` are hard breaks with no shim because there are no known external consumers yet.
-- Per-domain search commands stay untouched for phase 1; a later task decides whether they thin-wrap `orbit search`, demote to filters, or retire.
-- At this phase, docs, learnings, and ADRs used lexical matching even when `--hybrid` was set; ADR-0180 later adds opt-in doc vectors while keeping learnings and ADRs lexical.
+- Per-domain search commands were subsequently removed by ADR-0176; structural filters now live under the relevant `list` commands.
+- ADR-0180 and its follow-up indexing work extend hybrid retrieval to docs, learnings, and ADRs while retaining lexical fallback when vectors are unavailable.
 
 ---
 
@@ -112,19 +113,19 @@ Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.
 
 ## ADR-0176 — Consolidate per-domain search; cross-kind `--path` and `--tag` filters; learning list `--path` semantics flip
 
-**Status:** Proposed · 2026-05-20 · [ORB-00202]
+**Status:** Accepted · 2026-05-20 · [ORB-00202]
 
 **Context.** After [ADR-0174] and [ADR-0175] consolidated `orbit search` as the unified query surface, the per-domain `task`, `docs`, and `learning` `search` subcommands of `orbit` became redundant for content-similarity queries. The `learning` variant in particular bundled three unrelated operations under one verb: substring search (content), path-glob applicability lookup (structural), and tag filter (structural). Agents pre-edit also need a single cross-kind command that answers *"given this file path, what tasks / learnings / ADRs apply here?"* — the context-pack query.
 
-**Decision.** Hard-remove the per-domain `task`, `docs`, and `learning` `search` subcommands of `orbit` (CLI + MCP). Re-home their filters under the unified search surface: `--tag <T>` (AND semantics, repeatable, case-insensitive), `--all` (kind-aware status widener), `--status` (superseded by ADR-0179's `kind:value` syntax), and path applicability lookup (superseded by ADR-0179's `orbit search path <path>` CLI form; MCP keeps the `path` parameter). Add `orbit task list --path`; flip `orbit learning list --path` from exact-match to glob-containment. The old `--include-superseded` mental model from the retired per-domain doc surface is replaced by `orbit search --kind adr --all`. The structural-vs-content split — `search` for indexed content, `list` for structural filters — is enforced by the command layout.
+**Decision.** Hard-remove the per-domain `task`, `docs`, and `learning` `search` subcommands of `orbit` (CLI + MCP). Re-home their filters under the unified search surface: `--tag <T>` (AND semantics, repeatable, case-insensitive), `--all` (kind-aware status widener), `--status` (superseded by ADR-0179's `kind:value` syntax), and path applicability lookup (superseded by ADR-0179's `orbit search path <path>` CLI form; MCP keeps the `path` parameter). Add `orbit task list --path`; flip `orbit learning list --path` from exact-match to glob-containment. The old `--include-superseded` mental model from the retired per-domain doc surface is replaced by `orbit search --kind adr --all`. The structural-vs-content split — `search` for indexed content, `list` for structural filters — is enforced by the command layout. ORB-00203 subsequently made ADR tags and paths real filters rather than no-op branches.
 
 **Consequences.**
 - One mental model: `orbit search` queries indexed content, `orbit <kind> list` filters structural metadata.
 - The agent context-pack query collapses to a single command (`orbit search path <file> --kind all`).
 - Universal `--all` / `--status kind:value` vocabulary replaces the patchwork of kind-specific flags (`--include-superseded`).
-- ORB-00203 fills the ADR filter branches by adding ADR `tags` and `paths`, without changing the public search surface.
+- ORB-00203 filled the ADR filter branches by adding ADR `tags` and `paths`, without changing the public search surface.
 - Cost: the `learning list --path` semantics flip is the only observable behavior change. Scripts calling `orbit learning list --path 'src/auth/**'` expecting exact-match scoped lookups will now also see paths *inside* that glob. The migration target for ex-`learning search --path` callers is unchanged because the new semantics match what that deleted command already did.
-- Cost: during phase 2, ADR carried `--tag` and `--path` placeholders in two flag positions; ORB-00203 closes that gap by making those positions real filters.
+- Cost: ADR tag and path filters required a later schema/indexing follow-up (ORB-00203) before they could participate in the unified surface.
 - Cost: `AdrStatus` has no `Deprecated` variant, so `--all` adds `Superseded` only on ADRs. Asymmetric with task widening (which gets multiple terminal states); revisited if a deprecated state ever becomes load-bearing.
 - Audit-row granularity is preserved by mapping `--kind` onto the `subcommand` field. Before consolidation, `orbit task search` / `orbit docs search` / `orbit learning search` produced distinct `(command, subcommand)` rows; after consolidation, `orbit search --kind X` produces `(command="search", subcommand="<kind>")` so downstream audit queries can still distinguish task / doc / learning / adr searches. Free-text content vs. structural lookup is not currently captured in the audit schema and is out of scope for this ADR.
 
@@ -153,7 +154,7 @@ Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.
 
 **Context.** Doc search was lexical-only after [ORB-00202] unified the query surface, while the orbit-search store already had a `source_kind` discriminator that could hold docs. The alternatives were to keep semantic ranking deferred, add a separate docs search verb, or reuse the existing vector store behind the unified `orbit search --kind doc --hybrid` path.
 
-**Decision.** Use `orbit docs index` as the explicit admin verb that embeds configured docs roots into `source_kind = "doc"` rows, and keep retrieval opt-in through `orbit search <query> --kind doc --hybrid`. Lexical doc search remains the default, ADRs stay lifecycle-owned and lexical-only, and `[docs.search].semantic_weight` tunes the blend without adding another CLI flag.
+**Decision.** Use `orbit docs index` as the explicit admin verb that embeds configured docs roots into `source_kind = "doc"` rows, and keep retrieval opt-in through `orbit search <query> --kind doc --hybrid`. Lexical doc search remains the default, while the same companion and vector store now also support explicitly indexed learning and ADR corpora.
 
 **Consequences.**
 - `orbit docs index` shares the semantic companion, model catalog, and `embeddings` table with task vectors rather than creating a doc-specific store.

--- a/docs/design/policy-sandbox/1_overview.md
+++ b/docs/design/policy-sandbox/1_overview.md
@@ -4,6 +4,7 @@ type: design
 title: "Policy & Sandboxing — Overview"
 owner: claude
 last_updated: 2026-08-02
+last_validated: 2026-08-09
 status: Draft
 feature: policy-sandbox
 doc_role: overview

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -4,6 +4,7 @@ type: design
 title: "Policy & Sandboxing — Design"
 owner: claude
 last_updated: 2026-08-09
+last_validated: 2026-08-09
 status: Draft
 feature: policy-sandbox
 doc_role: design


### PR DESCRIPTION
## Task

[ORB-10673](https://orbit-cli.com/tasks/ORB-10673) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Batch selection:
- Inventory command: `rg --files docs -g '*.md' | rg -v '^docs/design/_archive/|^docs/changelogs/'`, followed by frontmatter extraction with `awk`.
- Selected exactly six documents with no `last_validated` key (the never-validated tier), ordered by stable path tie-break: `docs/design/orbit-search/1_overview.md`, `2_design.md`, `3_vision.md`, `4_decisions.md`, `docs/design/policy-sandbox/1_overview.md`, and `2_design.md`. Dated documents and template files were not eligible for this tier.
- All six already had valid Orbit Docs frontmatter with confident `type: design` and non-empty single-line `summary`; no frontmatter migration was needed.

Changes and verification:
- `docs/design/orbit-search/1_overview.md`: corrected the current `orbit-search` crate and `orbit-search-companion` binary ownership, workspace `embeddings`/`corpus_fts` storage, task/doc/learning/ADR source kinds, and retired graph-corpus boundary. Verified with `test -f` and `rg -n 'orbit-search-companion|corpus_fts|SOURCE_KIND_(TASK|DOC|LEARNING|ADR)|semantic_db' crates/orbit-search crates/orbit-core`.
- `docs/design/orbit-search/2_design.md`: corrected crate/dependency placement, companion path and gated `ORBIT_SEARCH_COMPANION` override, `corpus_fts` schema, supported corpus index kinds, and current CLI behavior. Verified with `Cargo.toml`, `crates/orbit-search/Cargo.toml`, companion/embedder/vector/schema sources, and `rg -n` over `crates/orbit-search`, `crates/orbit-core`, and `crates/orbit-cli`.
- `docs/design/orbit-search/3_vision.md`: corrected companion naming and replaced the obsolete graph-forward-compatibility description with the current multi-corpus boundary. Retired graph proposal and external/model benchmark claims were treated as historical or unverified and left unchanged where applicable. Verified against the companion source, source-kind constants, and ADR status via `orbit.adr.show`.
- `docs/design/orbit-search/4_decisions.md`: corrected current search forms, accepted status for ADR-0176, ADR tag/path follow-up state, and hybrid coverage for docs/learnings/ADRs. Verified with `orbit.adr.show` for ADR-0174, ADR-0176, ADR-0179, ADR-0180, and ADR-0276, plus current CLI/search/filter source.
- `docs/design/policy-sandbox/1_overview.md` and `2_design.md`: no factual or formatting edits were necessary after checking the referenced policy, tool, engine, runtime, executor, and supervision implementations; added only `last_validated: 2026-08-09`.

Validation:
- Added `last_validated: 2026-08-09` to every selected document only after verification.
- `git diff --check` passed; selected Markdown code-fence parity check passed.
- Protected-path check passed: no `.orbit/adrs/`, `CHANGELOG.md`, `docs/changelogs/`, `docs/design/_archive/`, task/graph/state, or generated files changed.
- `make ci-fast` passed, including formatting, doc-index, dependency-direction, CLI-import, stability, and guardrail checks.
- No selected document was frontmatter-less, so no metadata migration was performed. No new document, section, metadata field, sidecar, or validation system was introduced.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10673-6a78239f`
- Behind base: 0
- Ahead of base: 1