### PR TITLE
Align directory context reads with the executor fs.read contract

### DIFF
--- a/.orbit/resources/activities/agent_implement.yaml
+++ b/.orbit/resources/activities/agent_implement.yaml
@@ -58,10 +58,12 @@ spec:
        criteria, plan, and context files. If it is absent or malformed, recover
        it with `orbit.task.show`. Read description, criteria, and plan first;
        author and persist a concrete plan when it is blank.
-    2. Resolve every canonical `context_files` selector with `fs.read`: read
-       each `file:` target, and list each `dir:` plus its key files. Optionally
-       run `orbit.search` with `semantic: "<task-id>"`; skip when its companion
-       is unavailable or no result is relevant.
+    2. Resolve every canonical `context_files` selector: read each `file:`
+       target with `fs.read`. For each `dir:` selector, do not call `fs.read`
+       on the directory; after verifying it resolves beneath the workspace root,
+       use `rg --files <directory>` to list it, then use `fs.read` for its key
+       files. Optionally run `orbit.search` with `semantic: "<task-id>"`; skip
+       when its companion is unavailable or no result is relevant.
     3. `input.workspace_path` and `input.repo_root` override task paths. Before
        any write, obtain `pwd -P` and `git rev-parse --show-toplevel`. Both
        supplied roots must resolve to that same canonical checkout. Otherwise

--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -58,10 +58,12 @@ spec:
        criteria, plan, and context files. If it is absent or malformed, recover
        it with `orbit.task.show`. Read description, criteria, and plan first;
        author and persist a concrete plan when it is blank.
-    2. Resolve every canonical `context_files` selector with `fs.read`: read
-       each `file:` target, and list each `dir:` plus its key files. Optionally
-       run `orbit.search` with `semantic: "<task-id>"`; skip when its companion
-       is unavailable or no result is relevant.
+    2. Resolve every canonical `context_files` selector: read each `file:`
+       target with `fs.read`. For each `dir:` selector, do not call `fs.read`
+       on the directory; after verifying it resolves beneath the workspace root,
+       use `rg --files <directory>` to list it, then use `fs.read` for its key
+       files. Optionally run `orbit.search` with `semantic: "<task-id>"`; skip
+       when its companion is unavailable or no result is relevant.
     3. `input.workspace_path` and `input.repo_root` override task paths. Before
        any write, obtain `pwd -P` and `git rev-parse --show-toplevel`. Both
        supplied roots must resolve to that same canonical checkout. Otherwise

--- a/crates/orbit-core/assets/skills/orbit-task/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-task/SKILL.md
@@ -53,7 +53,7 @@ Exit: the task exists with a strong description, clear acceptance criteria, and 
 
 Carry a task from intent to verified implementation with explicit lifecycle tracking.
 
-**Step 1 — Load.** `orbit.task.show`, then extract `description`/`acceptance_criteria` (the required outcome), `plan` (author one if blank or placeholder), `context_files` (resolve each with `fs.read`; for a `dir:` scope read the listing plus its key files), and `status`. Then `orbit.search` with `semantic: "<task-id>"`, `limit: 5` to surface prior related decisions — non-blocking, skip it if nothing is relevant. No ID yet? Clarify intent with the human, then use Create above.
+**Step 1 — Load.** `orbit.task.show`, then extract `description`/`acceptance_criteria` (the required outcome), `plan` (author one if blank or placeholder), `context_files`, and `status`. Read each `file:` target with `fs.read`. For a `dir:` selector, do not call `fs.read` on the directory: after verifying it resolves beneath the workspace root, use `rg --files <directory>` to list it, then use `fs.read` only for its key files. Then `orbit.search` with `semantic: "<task-id>"`, `limit: 5` to surface prior related decisions — non-blocking, skip it if nothing is relevant. No ID yet? Clarify intent with the human, then use Create above.
 
 **Step 2 — Plan.** `orbit.task.update` with a concrete markdown `plan` — target files, validation commands, risks — if one doesn't exist.
 

--- a/crates/orbit-core/src/command/activity.rs
+++ b/crates/orbit-core/src/command/activity.rs
@@ -315,6 +315,31 @@ backend = "cli"
     }
 
     #[test]
+    fn agent_implement_context_loading_reads_files_and_lists_directories() {
+        let (_, yaml) = DEFAULT_ACTIVITY_FILES
+            .iter()
+            .find(|(name, _)| *name == "agent_implement")
+            .expect("agent implement activity is seeded");
+        let asset = load_activity_asset(yaml).expect("parse agent implement activity");
+        let ActivityV2Spec::AgentLoop(spec) = asset.spec.spec else {
+            panic!("expected agent_loop activity");
+        };
+        let instruction = spec
+            .instruction
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .to_lowercase();
+
+        assert!(instruction.contains("each `file:` target with `fs.read`"));
+        assert!(instruction.contains("each `dir:` selector"));
+        assert!(instruction.contains("do not call `fs.read` on the directory"));
+        assert!(instruction.contains("resolves beneath the workspace root"));
+        assert!(instruction.contains("`rg --files <directory>`"));
+        assert!(!instruction.contains("is a directory"));
+    }
+
+    #[test]
     fn agent_implement_grants_allocate_then_update_adr() {
         let (_, yaml) = DEFAULT_ACTIVITY_FILES
             .iter()

--- a/crates/orbit-core/src/command/skill.rs
+++ b/crates/orbit-core/src/command/skill.rs
@@ -276,6 +276,15 @@ mod tests {
     }
 
     #[test]
+    fn orbit_task_skill_matches_plugin_copy() {
+        assert_eq!(
+            include_str!("../../assets/skills/orbit-task/SKILL.md"),
+            include_str!("../../../../plugin/skills/orbit-task/SKILL.md"),
+            "the embedded and plugin copies of orbit-task must remain byte-identical"
+        );
+    }
+
+    #[test]
     fn plugin_package_configuration_is_valid() {
         let repo = repo_root();
         let claude_mcp_path = repo.join("plugin/.mcp.json");

--- a/plugin/skills/orbit-task/SKILL.md
+++ b/plugin/skills/orbit-task/SKILL.md
@@ -53,7 +53,7 @@ Exit: the task exists with a strong description, clear acceptance criteria, and 
 
 Carry a task from intent to verified implementation with explicit lifecycle tracking.
 
-**Step 1 — Load.** `orbit.task.show`, then extract `description`/`acceptance_criteria` (the required outcome), `plan` (author one if blank or placeholder), `context_files` (resolve each with `fs.read`; for a `dir:` scope read the listing plus its key files), and `status`. Then `orbit.search` with `semantic: "<task-id>"`, `limit: 5` to surface prior related decisions — non-blocking, skip it if nothing is relevant. No ID yet? Clarify intent with the human, then use Create above.
+**Step 1 — Load.** `orbit.task.show`, then extract `description`/`acceptance_criteria` (the required outcome), `plan` (author one if blank or placeholder), `context_files`, and `status`. Read each `file:` target with `fs.read`. For a `dir:` selector, do not call `fs.read` on the directory: after verifying it resolves beneath the workspace root, use `rg --files <directory>` to list it, then use `fs.read` only for its key files. Then `orbit.search` with `semantic: "<task-id>"`, `limit: 5` to surface prior related decisions — non-blocking, skip it if nothing is relevant. No ID yet? Clarify intent with the human, then use Create above.
 
 **Step 2 — Plan.** `orbit.task.update` with a concrete markdown `plan` — target files, validation commands, risks — if one doesn't exist.
 


### PR DESCRIPTION
## Task

[ORB-10652](https://orbit-cli.com/tasks/ORB-10652) — Align directory context reads with the executor fs.read contract

### Description

## Problem

The executor envelope instructs an agent to resolve each `dir:` context selector with `fs.read`, but `fs.read` accepts files only and returns "Is a directory" for a directory path. The mandated context-loading step cannot be performed as written.

## Evidence

Two directory reads returned `io error: Is a directory`, and the executor fell back to a file listing to proceed. The instruction and the tool contract disagree.

## Why It Matters

An agent following the instruction literally hits an error on a required step, and has to invent an unbounded fallback to continue. Different executors will invent different ones.

## Constraints / Notes

- Either the tool gains directory listing or the instructions name the supported bounded fallback — decide which, and say why in the execution summary. Do not leave both surfaces describing different contracts.
- Any fallback must stay bounded to the workspace root.
- **Shipped skill assets exist in two trees that must stay identical**: `crates/orbit-core/assets/skills/orbit-task/SKILL.md` and `plugin/skills/orbit-task/SKILL.md`. They are byte-identical today and **nothing machine-enforces that** — the parity test referenced by older notes no longer exists in the tree. Edit both.
- **Shipped assets must stay project-agnostic.** A portability check rejects, in the assets tree, literal `crates/` paths, personal or project names, and concrete task/ADR/learning/friction ids. Placeholders and `.orbit/...` runtime paths are allowed. Do not copy this task's wording, ids, or paths into the SKILL.md text. The checker does not scan `plugin/skills/`, so a leak landing only there is caught by nothing.

### Acceptance Criteria

- The skill instructions and the `fs.read` tool contract describe the same handling for `file:` and `dir:` selectors — no remaining instruction to call `fs.read` on a path it rejects.
- A regression check exercises both selector kinds and does not treat 'Is a directory' as an implementation failure.
- Any fallback named in the instructions is bounded to the workspace root, asserted by a test or by the tool's existing bounds.
- Both shipped copies of the orbit-task skill remain byte-identical after the change, verified by a diff stated in the execution summary.
- The portability check passes against the edited assets tree.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Aligned the shipped orbit-task skill copies and the agent_implement activity: `file:` selectors use `fs.read`; `dir:` selectors must not call it on the directory and instead use `rg --files <directory>` only after confirming the directory resolves beneath the workspace root, then read selected files with `fs.read`.
- Updated the workspace-seeded agent_implement activity in lockstep with the embedded asset.
- Added regression coverage for both selector forms and the bounded-directory fallback, plus a byte-parity assertion for the two shipped skill copies. The added command source and seeded activity resource were appended to context_files because they are the direct regression and generated-mirror surfaces.

Strategic decision: retain the file-only fs.read contract rather than expanding the tool API. `rg --files` is already allowed to the executor and the instructions explicitly bind its directory argument beneath the workspace root.

Validation:
- `cargo fmt --all -- --check`
- `cargo test -p orbit-core agent_implement_context_loading_reads_files_and_lists_directories --quiet`
- `cargo test -p orbit-core orbit_task_skill_matches_plugin_copy --quiet`
- `./scripts/check-embedded-asset-portability.py`
- `cmp -s crates/orbit-core/assets/skills/orbit-task/SKILL.md plugin/skills/orbit-task/SKILL.md` (byte-identical)
- `make ci-fast`

Assessment: all targeted checks and the repository fast gate pass; no friction record was warranted.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10652-6a7830dd`
- Behind base: 0
- Ahead of base: 1