### PR TITLE
make ci-fast does not run clippy, so executors keep landing lint failures that redden agent-main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Project instructions for agents working on Orbit (loaded as both `AGENTS.md` and
 
 ## Build / Lint
 
-`make ci-fast` (fmt-check + guardrail scripts; no compile) must pass before a task moves to `review`. The full `make ci` is the canonical merge gate via [`.github/workflows/ci.yml`](.github/workflows/ci.yml) on every PR — don't run it per task locally.
+`make ci-fast` (fmt-check + guardrail scripts; no compile) and `make ci-lint` (the same workspace-wide, all-target clippy pass as CI, with warnings denied) must both pass before a task moves to `review`. Each task therefore pays for one workspace clippy compile; cold runs can take several minutes, while warm runs reuse Cargo's incremental cache. The full `make ci` is the canonical merge gate via [`.github/workflows/ci.yml`](.github/workflows/ci.yml) on every PR — don't run it per task locally.
 
 
 ## Architecture

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build release run check test fmt fmt-check clippy clean install uninstall dev watch audit tree ci ci-fast stability release-check docs-index cleanup-branches
+.PHONY: help build release run check test fmt fmt-check clippy clean install uninstall dev watch audit tree ci ci-fast ci-lint stability release-check docs-index cleanup-branches
 
 # ------------------------------------------------------------
 # Config
@@ -49,6 +49,7 @@ help:
 	@echo "  make tree         Print dependency tree"
 	@echo "  make ci           Full CI pass (clippy + tests + doc + guardrails; also runs on PRs)"
 	@echo "  make ci-fast      Pre-handoff gate for agents (fmt-check + guardrail scripts; no compile)"
+	@echo "  make ci-lint      Pre-handoff clippy gate for agents (compiles all workspace targets)"
 	@echo "  make docs-index   Regenerate docs/INDEX.md"
 	@echo "  make stability    Verify per-crate stability tier markers"
 	@echo "  make release-check  Verify /plugin install orbit version lockstep (see docs/runbooks/release.md)"
@@ -127,6 +128,11 @@ ci-fast:
 	./scripts/check-orphan-modules.sh
 	./scripts/check-embedded-asset-portability.py
 	./scripts/test-validate-codex-plugin.sh
+
+# Compile-time pre-handoff gate for agents. Keep this invocation aligned with
+# the default workspace clippy pass in scripts/ci-guardrails.sh.
+ci-lint:
+	$(CARGO) clippy $(WORKSPACE) --all-targets -- -D warnings
 
 # Verify every workspace crate declares its stability tier
 stability:


### PR DESCRIPTION
## Task

[ORB-10678](https://orbit-cli.com/tasks/ORB-10678) — make ci-fast does not run clippy, so executors keep landing lint failures that redden agent-main

### Description

## Problem

The executor-side gate and the CI gate disagree, and the gap has a measured cost.

`make ci-fast` is fmt-check plus guardrail scripts — the repo's own CLAUDE.md describes it as "no compile". CI's `Check / Clippy / Test` runs clippy with `-D warnings`. The workspace sets several lints to `warn` (`Cargo.toml:35` `expect_used`, `:38` `unwrap_used`, plus the default clippy set), so a lint that is merely a warning locally is **fatal in CI** and completely invisible to the gate every executor is told to run.

The result: an executor validates honestly, reports "make ci-fast passed", moves the task to `review`, the pipeline merges it, and `agent-main` goes red.

## Evidence — twice in under two hours, from two different crews

1. **ORB-10645** (`efa24ab4`, 03:59) landed `.as_object().expect(...)` in `crates/orbit-core`. `Check / Clippy / Test` failed on **every** push to `agent-main` from 05:00 to 07:13 — PRs #899 through #909, roughly 14 merges — before anyone noticed. Fixed in `03b84d88` (ORB-10675).

2. **ORB-10633** (`b6d87067`, merged 07:21 as #911) removed the `V2RuntimeHost` trait but left its doc comment orphaned, tripping `clippy::empty_line_after_doc_comments` in `crates/orbit-engine`. This reddened `agent-main` again **within 8 minutes** of the previous fix landing. Fixed in `c727bd49`.

Both executions reported passing local validation. Neither was careless — the gate they were given cannot see this class of failure.

## Why this is worth fixing rather than absorbing

The failure is silent and delayed: it surfaces on the integration branch after merge, not on the PR the author is looking at. Worse, once the base is red, *every* subsequent task PR inherits a failing required check, so the gate stops carrying information and reviewers start ignoring it — which is exactly how case (1) survived 14 merges.

## Suggested direction (choose one, do not do all)

- Add a clippy pass to `make ci-fast` mirroring CI's invocation (`cargo clippy --workspace --all-targets -- -D warnings`). Straightforward and exact, but it makes `ci-fast` compile, which contradicts its documented "no compile" contract and slows every task.
- Add a separate `make ci-lint` target that executors are required to run before `review`, leaving `ci-fast` as-is. Keeps the fast path fast; needs the executor instructions updated to actually call it.
- Promote the workspace's `warn`-level lints to `deny` in `Cargo.toml` so local `cargo check`/`clippy` fails the same way CI does, without changing any make target.

Whichever is chosen, the acceptance test is the same: reproduce case (2) — reintroduce the orphaned doc comment — and confirm the local gate now fails.

## Related

- ORB-10675 — case (1), the `expect_used` denial.
- While fixing case (2) I noticed a second orphaned doc block: in `crates/orbit-engine/src/context/hosts.rs`, a "Resolved crew assignment from `config.toml`" doc comment sits directly above `RuntimeHost`'s own doc comment with no item between them, so it silently documents the wrong thing. Clippy does not catch it because there is no blank line. Not fixed here — noted so it is not lost.

### Acceptance Criteria

- A local gate exists that fails on the same clippy findings CI fails on, and the executor instructions name it as required before a task moves to `review`.
- Reintroducing the ORB-10633 orphaned doc comment causes the local gate to fail.
- Reintroducing the ORB-10645 `expect()` pattern causes the local gate to fail.
- The chosen approach's cost to per-task execution time is stated, and if `make ci-fast` gains a compile step its documented 'no compile' contract is updated to match.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a separate phony `make ci-lint` pre-handoff gate that runs `cargo clippy --workspace --all-targets -- -D warnings`, exactly matching the default workspace clippy pass in CI while preserving the no-compile contract of `make ci-fast`.
- Updated `CLAUDE.md` and its `AGENTS.md` symlink surface to require both gates before `review`, and documented the per-task workspace compile cost plus incremental-cache behavior.

Strategic decisions:
- Chose a separate lint target instead of adding compilation to `ci-fast`; this keeps the established fast/no-compile path intact while making the compile-time lint cost explicit.
- The cold `ci-lint` run in this worktree took 59.81 seconds; the final warm run took 9.56 seconds.

Validation:
- `make ci-fast` — pass on the final tree.
- `make ci-lint` — pass on the final tree with zero clippy findings.
- Temporarily restored the ORB-10633 orphaned dispatcher doc block: `make ci-lint` failed as expected with `clippy::empty_line_after_doc_comments`.
- Temporarily restored the ORB-10645 `.as_object().expect(...)` implementation: `make ci-lint` failed as expected with `clippy::expect_used`.
- Both negative-test source files were restored byte-for-byte to the baseline; only `Makefile` and `CLAUDE.md` remain modified.
- `git diff --check` — pass.

Assessment: The local pre-review instructions now expose the two measured CI failure classes without slowing the non-compiling guardrail target. Context expanded only to the two source files required for acceptance reproduction; neither retains a change.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10678-6a7830dd`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*