### PR TITLE
Three pre-existing orbit-core --lib test failures, independently reported by two executions and never filed

### DIFF
--- a/crates/orbit-core/src/runtime/tests/authorization.rs
+++ b/crates/orbit-core/src/runtime/tests/authorization.rs
@@ -117,7 +117,7 @@ fn a_run_retains_the_destruction_it_dispatches() {
     let released = runtime
         .run_tool_with_context_and_role(
             "orbit.task.locks.release",
-            json!({ "reservation_id": "no-such-reservation" }),
+            json!({ "reservation_id": "reservation-no-such-reservation" }),
             Role::Admin,
             context_with([McpCapability::Runner]),
         )


### PR DESCRIPTION
## Task

[ORB-10677](https://orbit-cli.com/tasks/ORB-10677) — Three pre-existing orbit-core --lib test failures, independently reported by two executions and never filed

### Description

## Problem

`cargo test -p orbit-core --lib` has three failures on `agent-main` that no task owns. Two separate executions hit them, each labelled them out-of-scope and pre-existing, and each moved on — so the signal has been sitting in execution summaries where nothing acts on it.

These are currently *masked* in CI: the `Check / Clippy / Test` job dies at the clippy stage (ORB-10675) before tests run. **Fixing ORB-10675 will very likely expose these as the next CI blocker**, so they should be handled as part of getting `agent-main` green rather than discovered afterwards.

## The three failures

1. `command::job::tests::exec::failed_pr_pipeline_dispatches_the_failure_handoff_and_keeps_the_original_error`
   — fixture task ID `ORB-FAILURE-HANDOFF` is rejected by current task-ID validation.
2. `runtime::tests::authorization::a_run_retains_the_destruction_it_dispatches`
   — fixture reservation ID `no-such-reservation` is rejected by current reservation-ID validation.
3. `runtime::v2_host::tests::dispatch::shipped_activity_assets_only_name_registered_deterministic_actions`
   — `independent_review_guard` is absent from `REGISTERED_DETERMINISTIC_ACTIONS`.

## Evidence

- **ORB-10630's execution summary** reports (1) and (2): "two pre-existing unrelated failures … Their focused reruns reproduce the same input-validation failures."
- **ORB-10343's execution summary** reports all three, and — importantly — verified causation: re-ran with its own changes reverted (`HEAD:crates/orbit-engine/src/context/{outcome.rs,tests/mod.rs}` restored) and "reproduces exactly the same 3". So these are not that task's fallout.

Two independent confirmations, one with a controlled revert. Worth a direct re-run to confirm all three are still live at current tip before implementing, since both reports predate several merges.

## Likely causes (unverified — confirm before fixing)

- (1) and (2) look like fixture data that predates tightened ID validation. If so the fix is fixture-side: use IDs that satisfy current validation, or make the tests construct records through the validating path. Do not loosen production validation to satisfy a fixture.
- (3) looks like fallout from the independent-review removal (ORB-10628) meeting the new single-source action registry (ORB-10630). `independent_review_guard` is a *removed* activity, so the likely correct fix is that the shipped asset naming it should be gone — related to the orphaned-asset family in ORB-10670 and ORB-10674, though distinct from both (this one is about tracked shipped assets and the registry, not materialized `.orbit/resources` or global `~/.orbit/resources`).

## Why file rather than absorb

Both executions did the right thing by not silently widening scope. The gap is that "pre-existing, out of scope" was the end of the line — no task, no owner. This entry exists so the third executor to hit these does not spend the same diagnosis time again.

### Acceptance Criteria

- All three named tests pass under `cargo test -p orbit-core --lib` on `agent-main`.
- Each failure's root cause is stated, and fixture-only fixes are distinguished from production-code fixes.
- No production-side ID validation is weakened solely to make a test fixture pass.
- If any of the three no longer reproduces at current tip, that is recorded with the commit that fixed it rather than silently dropped.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated the authorization test fixture reservation ID from no-such-reservation to reservation-no-such-reservation. The fixture remains intentionally unknown, but now satisfies production reservation-ID syntax so the test reaches the runner-capability behavior it owns.
- Expanded context_files to include file:crates/orbit-core/src/runtime/tests/authorization.rs because the only live failure was in this directly affected sibling test; no production file changed.

Root-cause assessment:
- failed_pr_pipeline_dispatches_the_failure_handoff_and_keeps_the_original_error was fixture-side: ORB-FAILURE-HANDOFF did not satisfy tightened task-ID validation. It no longer reproduces at current tip. Commit b6d870677bd86c7b1e23c9960e0615dc76884437 (ORB-10633) isolated the synthetic worktree failure behind test_worktree_setup during the RuntimeHost collapse, and the named test now passes without weakening task-ID validation.
- a_run_retains_the_destruction_it_dispatches was fixture-side: no-such-reservation no longer satisfied the required reservation-<id> shape, so parsing failed before authorization was exercised. The fixture now uses a valid-shaped nonexistent ID. Production validation is unchanged.
- shipped_activity_assets_only_name_registered_deterministic_actions no longer exists at current tip. Commit 8b289bb94e7a99e19455a7973f0701de66b91520 (ORB-10628) removed the retired independent-review subsystem, including the shipped orbit-core activity and the old registry test. The current replacement coverage, default_jobs_only_reference_registered_deterministic_actions, passes. No obsolete production asset was reintroduced or validation weakened.

Validation:
- Focused failed-PR pipeline test: pass.
- Focused runner-destruction authorization test: pass.
- Historical shipped-asset test filter: 0 tests, confirming removal; current replacement registry test: pass.
- cargo test -p orbit-core --lib: pass, 744 passed, 0 failed, 1 ignored.
- make ci-fast: pass.
- git diff --check: pass.
- One first full-suite rerun transiently failed the unrelated worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic test; its immediate focused rerun passed and the subsequent complete suite passed.

Assessment: One fixture-only line changed. All live owned failures are resolved, historical non-reproductions are attributed to commits, and production ID validation remains intact.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10677-6a7830dd`
- Behind base: 0
- Ahead of base: 1