### PR TITLE
Stabilize detached-worker startup diagnostic persistence

### DIFF
--- a/crates/orbit-core/src/command/job/pipeline.rs
+++ b/crates/orbit-core/src/command/job/pipeline.rs
@@ -750,6 +750,16 @@ impl OrbitRuntime {
         }
 
         let finished_at = Utc::now();
+        // Persist the diagnostic step before terminalizing the run: an observer
+        // polling for a terminal state must never be able to see one without its
+        // startup diagnostic already durable.
+        self.record_pipeline_diagnostic_step(
+            run,
+            run.scheduled_at,
+            finished_at,
+            message,
+            JobRunState::Interrupted,
+        )?;
         let changed = self.finalize_job_run_with_reservation_cleanup(
             &run.run_id,
             JobRunState::Interrupted,
@@ -758,13 +768,6 @@ impl OrbitRuntime {
             TaskReservationReleaseReason::RunTerminal,
         )?;
         if changed {
-            self.record_pipeline_diagnostic_step(
-                run,
-                run.scheduled_at,
-                finished_at,
-                message,
-                JobRunState::Interrupted,
-            )?;
             self.record_event(OrbitEvent::JobRunCompleted {
                 job_id: run.job_id.clone(),
                 run_id: run.run_id.clone(),

--- a/crates/orbit-core/src/command/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/command/tests/job_pipeline.rs
@@ -103,17 +103,19 @@ fn worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic() {
     assert!(durable_output.contains("worker stdout context"));
     assert!(durable_output.contains("action registration missing: routine_dispatch"));
 
-    let audits = runtime
-        .list_audit_events(None, None, Some(AuditEventStatus::Failure), None, 20)
-        .expect("list startup failure audit");
-    assert!(audits.iter().any(|audit| {
-        audit.tool_name.as_deref() == Some("pipeline.worker.startup")
-            && audit.target_id.as_deref() == Some(run.run_id.as_str())
-            && audit
-                .error_message
-                .as_deref()
-                .is_some_and(|error| error.contains("before claiming"))
-    }));
+    wait_for_pipeline_audit_event(
+        &runtime,
+        Some(AuditEventStatus::Failure),
+        "startup failure audit",
+        |audit| {
+            audit.tool_name.as_deref() == Some("pipeline.worker.startup")
+                && audit.target_id.as_deref() == Some(run.run_id.as_str())
+                && audit
+                    .error_message
+                    .as_deref()
+                    .is_some_and(|error| error.contains("before claiming"))
+        },
+    );
 }
 
 #[cfg(unix)]
@@ -154,23 +156,10 @@ fn routine_style_detached_worker_is_claimed_within_ownership_window() {
         "detached routine worker exceeded ownership window"
     );
 
-    let deadline = Instant::now() + Duration::from_secs(2);
-    loop {
-        let audits = runtime
-            .list_audit_events(None, None, None, None, 20)
-            .expect("list claimed-worker audit");
-        if audits.iter().any(|audit| {
-            audit.tool_name.as_deref() == Some("pipeline.worker.claimed")
-                && audit.target_id.as_deref() == Some(run.run_id.as_str())
-        }) {
-            break;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "ownership observer did not persist a claimed audit"
-        );
-        thread::sleep(Duration::from_millis(10));
-    }
+    wait_for_pipeline_audit_event(&runtime, None, "claimed-worker audit", |audit| {
+        audit.tool_name.as_deref() == Some("pipeline.worker.claimed")
+            && audit.target_id.as_deref() == Some(run.run_id.as_str())
+    });
 
     assert_eq!(
         log_path,
@@ -193,6 +182,31 @@ fn wait_for_worker_ownership_outcome(
         assert!(
             Instant::now() < deadline,
             "worker remained pending and unclaimed beyond ownership window"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+/// Retry a pipeline audit lookup instead of asserting on a single snapshot:
+/// the audit event is written after the run's terminal state and diagnostic
+/// step, so an observer that only waits for those can still race the audit.
+fn wait_for_pipeline_audit_event(
+    runtime: &OrbitRuntime,
+    status: Option<AuditEventStatus>,
+    description: &str,
+    predicate: impl Fn(&orbit_common::types::AuditEvent) -> bool,
+) -> orbit_common::types::AuditEvent {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let audits = runtime
+            .list_audit_events(None, None, status, None, 20)
+            .expect("list pipeline audit events");
+        if let Some(audit) = audits.into_iter().find(|audit| predicate(audit)) {
+            return audit;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "expected {description} was not persisted within the window"
         );
         thread::sleep(Duration::from_millis(10));
     }


### PR DESCRIPTION
## Task

[ORB-10641](https://orbit-cli.com/tasks/ORB-10641) — Stabilize detached-worker startup diagnostic persistence

### Description

## Problem

The worker-startup diagnostic test is flaky: a terminal run can be observed before its startup diagnostic step has been persisted, so an assertion on the last step panics on an empty list.

## Evidence (verified against the current tree, 2026-08-08)

There are **two** independent races in this one test, and fixing either alone leaves the other firing.

1. **Write-ordering.** `finalize_pipeline_worker_startup_failure` in `crates/orbit-core/src/command/job/pipeline.rs` terminalizes the run first, then records the diagnostic step, then records the audit event — three separate writes. The test helper `wait_for_worker_ownership_outcome` in `crates/orbit-core/src/command/tests/job_pipeline.rs` returns as soon as the run has a pid or a non-pending state, so a poll landing between the first and second write returns a terminal run with no steps.

2. **Unretried audit assertion.** The audit event is written *after* the step, but the test asserts on it with a single non-retrying lookup. The sibling detached-worker test does loop for its audit; this one does not.

## Why It Matters

CI cannot distinguish this race from a real regression in job ownership or startup-failure handling, so the signal from that test is worthless in both directions.

## Constraints / Notes

- **Dispatch ordering:** this task is deliberately sequenced behind the job/pipeline restructuring chain. The two symbols it must edit are the same ones the run-finalization dedup rewrites, and several fixtures in the target test file are deleted by the review-subsystem removal. Re-derive anchors against the post-chain tree rather than trusting the line references above.
- Prefer a deterministic synchronization or an ordering change over a sleep or a retry-with-timeout on the primary assertion.
- Existing worker-startup failure and success semantics must not change — this is a correctness-of-observation fix, not a behavior change.

### Acceptance Criteria

- Repeated isolated runs of the worker-startup diagnostic test pass without an empty-steps panic — state the repetition count used in the execution summary.
- The same test passes repeatedly under the full job-pipeline filter, not only in isolation.
- A terminal startup failure cannot be observed before its diagnostic step is durable, enforced by write ordering or an explicit synchronization rather than by timing.
- The audit assertion no longer depends on a single unretried lookup.
- Existing worker-startup failure and success paths retain their current semantics, asserted by the surrounding tests continuing to pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed both races described in the task, confirmed against the post-restructuring tree (anchors re-derived; symbols matched task description exactly, no drift).

**Race 1 — write ordering** (`crates/orbit-core/src/command/job/pipeline.rs`, `finalize_pipeline_worker_startup_failure`): moved the `record_pipeline_diagnostic_step` call to *before* `finalize_job_run_with_reservation_cleanup`. Previously the run was terminalized first and the diagnostic step wrote after, so a poll landing between those two writes saw a terminal run with an empty `steps` list. `complete_job_run_step` (the step write's backing store call) has no run-state precondition — it only requires the run to exist — so writing the step while the run is still `Pending` is legitimate, and `record_pipeline_diagnostic_step`'s own `already_has_error` check keeps it idempotent regardless of call order. This also closes a latent gap: previously a crash between the two writes could leave a terminal run permanently missing its diagnostic (the early-return guard blocks retries once the run is no longer `Pending`); now a mid-way crash leaves the run `Pending` with an already-recorded step, so retry is safe.

**Race 2 — unretried audit lookup** (`crates/orbit-core/src/command/tests/job_pipeline.rs`): the audit event for `pipeline.worker.startup` is written after the diagnostic step and run finalization, so waiting only for run-terminal state (via `wait_for_worker_ownership_outcome`) doesn't guarantee the audit event is durable yet. Replaced the single non-retrying `list_audit_events` + `assert!` in `worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic` with a new shared retry helper `wait_for_pipeline_audit_event` (2s deadline, 10ms poll, same pattern the sibling `routine_style_detached_worker_is_claimed_within_ownership_window` test already used for its own audit wait). Also refactored that sibling test's inline duplicate loop to use the same helper, removing ~15 lines of duplicated polling logic — no context_files update needed since it's the same test file already in scope, tightly coupled to the same audit-wait concern.

No behavior change to worker-startup failure/success semantics — only write order and observation/synchronization changed.

Validation:
- `worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic` run in isolation 30/30 times (`cargo test -p orbit-core --lib worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic`), all passed.
- Full `command::tests::job_pipeline` module (9 tests) run 20/20 times (`cargo test -p orbit-core --lib command::tests::job_pipeline::`), all passed, including `routine_style_detached_worker_is_claimed_within_ownership_window`.
- `cargo build -p orbit-core --tests` and `cargo clippy -p orbit-core --tests -- -D warnings`: clean.
- `make ci-fast`: passed.
- Full `cargo test -p orbit-core --lib` (745 tests): 1 pre-existing unrelated failure (`runtime::tests::authorization::a_run_retains_the_destruction_it_dispatches`, a reservation-id format assertion in an unrelated module), confirmed present on the unmodified tree via `git stash` before any edits. Not caused by or related to this change.

Scope: only the two context_files listed on the task were touched; no additional files needed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10641-6a7830dd`
- Behind base: 0
- Ahead of base: 1