### PR TITLE
Make context_files the worker's lock obligation; keep reservation system-owned

### DIFF
--- a/crates/orbit-core/assets/skills/orbit-task/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-task/SKILL.md
@@ -61,6 +61,8 @@ Carry a task from intent to verified implementation with explicit lifecycle trac
 
 **Step 4 — Implement and validate.** Follow the plan, inspecting files with `fs.read`. Verify transitive impact with `rg` or by reading callers directly. Run the repo-approved verification commands, honoring repo instructions if tests are forbidden.
 
+If implementation surfaces a file outside the original `context_files`, append its canonical selector via `orbit.task.update` as soon as you discover it — don't wait until handoff. Reservation itself is the system's job, not yours: there is no worker-callable lock tool, and none should be reached for. Keeping `context_files` current is how a worker excludes others from files it owns, since conflict detection reads live from in-flight tasks, not only from reservation records. One caveat: an added entry only binds reservations requested *after* the update — it does not retroactively revoke a reservation a concurrent run already holds.
+
 In a linked pipeline worktree, never use positional `git stash` / `git stash pop`: refs and the stash list are repository-global, so a positional pop can restore another session's work. Record the worktree's initial `git rev-parse HEAD` and compare against that explicit baseline with `git diff <baseline-sha> -- <paths>`.
 
 **Step 5 — Summarize and hand off.** Persist `execution_summary` via `orbit.task.update` first. Then consider friction: if the task surfaced a contradicted assumption, a recurring failure mode, a non-obvious gotcha, or an incident root cause, file it (see [references/friction.md](references/friction.md)). Do not reach for `orbit.learning.add` here — the authoring gate refuses learnings from executor context, so the call is wasted rather than a judgment call. Then:

--- a/plugin/skills/orbit-task/SKILL.md
+++ b/plugin/skills/orbit-task/SKILL.md
@@ -61,6 +61,8 @@ Carry a task from intent to verified implementation with explicit lifecycle trac
 
 **Step 4 — Implement and validate.** Follow the plan, inspecting files with `fs.read`. Verify transitive impact with `rg` or by reading callers directly. Run the repo-approved verification commands, honoring repo instructions if tests are forbidden.
 
+If implementation surfaces a file outside the original `context_files`, append its canonical selector via `orbit.task.update` as soon as you discover it — don't wait until handoff. Reservation itself is the system's job, not yours: there is no worker-callable lock tool, and none should be reached for. Keeping `context_files` current is how a worker excludes others from files it owns, since conflict detection reads live from in-flight tasks, not only from reservation records. One caveat: an added entry only binds reservations requested *after* the update — it does not retroactively revoke a reservation a concurrent run already holds.
+
 In a linked pipeline worktree, never use positional `git stash` / `git stash pop`: refs and the stash list are repository-global, so a positional pop can restore another session's work. Record the worktree's initial `git rev-parse HEAD` and compare against that explicit baseline with `git diff <baseline-sha> -- <paths>`.
 
 **Step 5 — Summarize and hand off.** Persist `execution_summary` via `orbit.task.update` first. Then consider friction: if the task surfaced a contradicted assumption, a recurring failure mode, a non-obvious gotcha, or an incident root cause, file it (see [references/friction.md](references/friction.md)). Do not reach for `orbit.learning.add` here — the authoring gate refuses learnings from executor context, so the call is wasted rather than a judgment call. Then:


### PR DESCRIPTION
## Task

[ORB-10650](https://orbit-cli.com/tasks/ORB-10650) — Make context_files the worker's lock obligation; keep reservation system-owned

### Description

## Problem

The worker's standing claim-lock rule tells an executor to reserve a task before writing, but no worker-callable reservation exists. All three lock tools are inactive on the agent MCP surface, the CLI exposes only `list` and `release` (both through the admin `runtime.run_tool` bypass), and there is no `reserve` subcommand at all. An executor following the rule correctly stops, so the instruction reliably converts into a blocked run.

## Decision (2026-08-09)

Reservation stays system-owned. The lock tools remain off the agent toolset. The workflow gate reserves at admin role before fan-out and the reservation auto-releases with the run, so a worker's files are already reserved before it starts. Workers get no claim path.

The worker's obligation is metadata instead: keep the task's `context_files` complete and accurate, adding any file it discovers it must edit.

That is sufficient because conflict detection reads live from tasks in `in_progress`/`review`, not only from reservation rows — a file listed on an active task's `context_files` conflicts against any reservation requested afterward. Writing `context_files` through the ordinary task-update surface is therefore how a worker excludes others from files it owns. One caveat the guidance should state: this binds reservations taken *after* the update; a reservation already granted to a concurrent run is not retroactively revoked.

## Scope of this task

Documentation only, in both shipped copies of the orbit-task skill: state during execution that a worker keeps `context_files` current through the task-update surface when it discovers a file it must edit, and that lock reservation is the system's job, not the agent's.

## Out of scope

- No new agent-callable reservation path, and no change to the lock tools' inactive status on the public surface.
- The misleading rule text itself lives in the worker's memory layer, in a different repository and workspace, and is tracked separately. Note the original `context_files` on this task pointed only at the skill assets, which never mentioned locks at all — editing them alone would not have removed the blocked-run cause.

## Constraints / Notes

- Authorization stays fail-closed. Unauthorized callers stay rejected and administrative repair stays protected; the existing public-tool-surface test already asserts the lock tools are inactive.
- The module path is counterintuitive: the command is `orbit task locks` but the module sits directly under the CLI command directory, not under a `task/` subdirectory, and the lock logic is not in the task tool host module.
- **Shipped skill assets exist in two trees that must stay identical.** Nothing machine-enforces parity — the test older notes reference no longer exists. Edit both.
- **Shipped assets must stay project-agnostic.** The portability check rejects literal crate paths, personal or project names, and concrete task/ADR/learning/friction ids in the assets tree. Do not copy this task's wording or ids into the skill text.

### Acceptance Criteria

- The orbit-task skill's execution guidance states that a worker keeps context_files current through the task-update surface whenever it discovers a file it must edit, and that lock reservation is performed by the system rather than by the agent.
- The guidance notes that adding a file binds reservations requested afterward and does not revoke a reservation already granted to a concurrent run.
- No new agent-callable reservation path is added; the lock tools remain inactive on the public tool surface, unauthorized callers remain rejected, and administrative repair remains protected, asserted by the existing surface test.
- Shipped assets remain project-agnostic: no literal crate paths, personal or project names, or concrete task/ADR/learning/friction ids.
- Both shipped copies of the orbit-task skill remain byte-identical after the change, verified by a diff stated in the execution summary.
- The chosen model is stated in the execution summary with its rationale.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a paragraph to "Step 4 — Implement and validate" in both crates/orbit-core/assets/skills/orbit-task/SKILL.md and plugin/skills/orbit-task/SKILL.md: a worker appends any newly-discovered edit target's canonical selector to context_files via orbit.task.update as soon as it's discovered (not deferred to handoff); reservation is the system's job — no worker-callable lock tool exists and none should be reached for; context_files is how a worker excludes others from files it owns, since conflict detection reads live in-flight tasks, not only reservation records; and the caveat that a new entry only binds reservations requested after the update, not retroactively revoking one already held by a concurrent run.
- Both copies edited identically and verified byte-identical via `diff` (no output, exit 0) after the change.
- No code touched: the lock tools' inactive status on the public MCP/CLI surface is unchanged, and crates/orbit-tools/tests/public_tool_surface.rs (which asserts that inactivity) was not modified.
- Ran scripts/check-embedded-asset-portability.py against the worktree; it passed silently (no violations reported), confirming the new prose contains no crate paths, personal/project names, or concrete task/ADR/learning/friction ids.

Model: claude (Sonnet 5) — chosen because this is a small, precisely-scoped documentation edit to existing prose (two files, one paragraph each, must stay byte-identical and project-agnostic); no architectural judgment, code generation, or long-horizon planning is required, so the lighter default model is sufficient and keeps the change auditable.

Assessment: Minimal, targeted doc change that directly satisfies the acceptance criteria without touching the lock-tool surface or its test. Both shipped skill copies remain identical; portability check passes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10650-6a78d4dd`
- Behind base: 0
- Ahead of base: 1