### PR TITLE
Persist structured liveness-interrupt error codes

### DIFF
--- a/crates/orbit-core/src/command/job/pipeline.rs
+++ b/crates/orbit-core/src/command/job/pipeline.rs
@@ -474,6 +474,7 @@ impl OrbitRuntime {
             run,
             started_at,
             finished_at,
+            None,
             message,
             JobRunState::Failed,
         )
@@ -486,6 +487,7 @@ impl OrbitRuntime {
         run: &JobRun,
         started_at: chrono::DateTime<Utc>,
         finished_at: chrono::DateTime<Utc>,
+        error_code: Option<&str>,
         message: &str,
         state: JobRunState,
     ) -> Result<(), OrbitError> {
@@ -521,7 +523,7 @@ impl OrbitRuntime {
             exit_code: None,
             agent_response_json: None,
             state,
-            error_code: None,
+            error_code: error_code.map(str::to_string),
             error_message: Some(message.to_string()),
         };
         let _ = self
@@ -757,6 +759,7 @@ impl OrbitRuntime {
             run,
             run.scheduled_at,
             finished_at,
+            None,
             message,
             JobRunState::Interrupted,
         )?;

--- a/crates/orbit-core/src/command/job/run/owner.rs
+++ b/crates/orbit-core/src/command/job/run/owner.rs
@@ -261,6 +261,18 @@ pub(super) enum PendingStaleReason {
     NeverClaimed,
 }
 
+impl PendingStaleReason {
+    /// Stable machine-readable vocabulary persisted in interrupted pipeline
+    /// steps. The diagnostic message may evolve independently of these codes.
+    pub(super) const fn error_code(self) -> &'static str {
+        match self {
+            #[cfg(unix)]
+            Self::Owner(identity) => owner_identity_error_code(Some(identity)),
+            Self::NeverClaimed => "never_claimed",
+        }
+    }
+}
+
 /// Returns `Some(reason)` only when a `pending` run is conclusively orphaned:
 /// its claimed owner process is gone (Mismatch/Missing), or it was never
 /// claimed and is older than [`PENDING_RUN_UNCLAIMED_GRACE_MINUTES`].
@@ -303,24 +315,7 @@ fn pending_run_unclaimed_past_grace(run: &JobRun) -> bool {
 /// Builds the diagnostic message recorded in the interrupted step when an
 /// orphaned `pending` run is reconciled.
 pub(super) fn stale_pending_run_message(run: &JobRun, reason: PendingStaleReason) -> String {
-    let reason_str = match reason {
-        #[cfg(unix)]
-        PendingStaleReason::Owner(OwnerIdentity::Mismatch) => "token_mismatch",
-        #[cfg(unix)]
-        PendingStaleReason::Owner(OwnerIdentity::Missing) => "process_not_found",
-        // Verified / LegacyLiveUnverified / ProbeUnavailable never reach the
-        // stale path; keep them tagged so a future caller is never silently
-        // wrong (mirrors `stale_job_run_message`).
-        #[cfg(unix)]
-        PendingStaleReason::Owner(OwnerIdentity::Verified) => "verified",
-        #[cfg(unix)]
-        PendingStaleReason::Owner(OwnerIdentity::LegacyLiveUnverified) => "legacy_live_unverified",
-        #[cfg(unix)]
-        PendingStaleReason::Owner(OwnerIdentity::ProbeUnavailable) => "probe_unavailable",
-        #[cfg(unix)]
-        PendingStaleReason::Owner(OwnerIdentity::ForeignPidNamespace) => "foreign_pid_namespace",
-        PendingStaleReason::NeverClaimed => "never_claimed",
-    };
+    let reason_str = reason.error_code();
     format!(
         "queued job run marked interrupted because no live worker process owns it (reason={}, pid={}, pid_start_time={}, created_at={}, unclaimed_grace_minutes={})",
         reason_str,
@@ -527,7 +522,20 @@ pub(crate) fn run_owner_liveness(_run: &JobRun) -> RunOwnerLiveness {
 /// owner causes a Running run to be reconciled to Failed.
 #[cfg(unix)]
 pub(super) fn stale_job_run_message(run: &JobRun, reason: Option<OwnerIdentity>) -> String {
-    let reason_str = match reason {
+    let reason_str = owner_identity_error_code(reason);
+    format!(
+        "job run marked interrupted because recorded worker process is no longer alive (reason={}, pid={}, pid_start_time={})",
+        reason_str,
+        run.pid
+            .map(|pid| pid.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        run.pid_start_time.as_deref().unwrap_or("-")
+    )
+}
+
+#[cfg(unix)]
+pub(super) const fn owner_identity_error_code(reason: Option<OwnerIdentity>) -> &'static str {
+    match reason {
         Some(OwnerIdentity::Mismatch) => "token_mismatch",
         Some(OwnerIdentity::Missing) => "process_not_found",
         // ProbeUnavailable / Verified / LegacyLiveUnverified never reach the
@@ -538,15 +546,12 @@ pub(super) fn stale_job_run_message(run: &JobRun, reason: Option<OwnerIdentity>)
         Some(OwnerIdentity::LegacyLiveUnverified) => "legacy_live_unverified",
         Some(OwnerIdentity::ForeignPidNamespace) => "foreign_pid_namespace",
         None => "unknown",
-    };
-    format!(
-        "job run marked interrupted because recorded worker process is no longer alive (reason={}, pid={}, pid_start_time={})",
-        reason_str,
-        run.pid
-            .map(|pid| pid.to_string())
-            .unwrap_or_else(|| "-".to_string()),
-        run.pid_start_time.as_deref().unwrap_or("-")
-    )
+    }
+}
+
+#[cfg(not(unix))]
+pub(super) const fn owner_identity_error_code(_reason: Option<()>) -> &'static str {
+    "unknown"
 }
 
 #[cfg(not(unix))]

--- a/crates/orbit-core/src/command/job/run/reconcile.rs
+++ b/crates/orbit-core/src/command/job/run/reconcile.rs
@@ -7,8 +7,8 @@ use orbit_store::TaskReservationReleaseReason;
 use crate::OrbitRuntime;
 
 use super::owner::{
-    pending_run_stale_reason, running_run_owner_is_stale, running_run_owner_stale_reason,
-    stale_job_run_message, stale_pending_run_message,
+    owner_identity_error_code, pending_run_stale_reason, running_run_owner_is_stale,
+    running_run_owner_stale_reason, stale_job_run_message, stale_pending_run_message,
 };
 
 impl OrbitRuntime {
@@ -96,20 +96,33 @@ impl OrbitRuntime {
         // or never claimed past the grace window) finalize exactly like
         // orphaned running runs.
         if let Some(reason) = pending_run_stale_reason(run) {
-            return self.finalize_orphaned_job_run(run, &stale_pending_run_message(run, reason));
+            return self.finalize_orphaned_job_run(
+                run,
+                reason.error_code(),
+                &stale_pending_run_message(run, reason),
+            );
         }
         if !running_run_owner_is_stale(run) {
             return Ok(false);
         }
         let stale_reason = running_run_owner_stale_reason(run);
-        self.finalize_orphaned_job_run(run, &stale_job_run_message(run, stale_reason))
+        self.finalize_orphaned_job_run(
+            run,
+            owner_identity_error_code(stale_reason),
+            &stale_job_run_message(run, stale_reason),
+        )
     }
 
     /// [ORB-10002] Orphaned runs (owner process conclusively gone) become
     /// `interrupted`, not `failed`: the job did not fail, its worker died.
     /// Interrupted runs are resumable from their step checkpoints via
     /// `orbit job resume <run_id>`.
-    fn finalize_orphaned_job_run(&self, run: &JobRun, message: &str) -> Result<bool, OrbitError> {
+    fn finalize_orphaned_job_run(
+        &self,
+        run: &JobRun,
+        error_code: &str,
+        message: &str,
+    ) -> Result<bool, OrbitError> {
         let finished_at = self.orphaned_run_finished_at(run);
         let duration_ms = run.started_at.map(|started_at| {
             finished_at
@@ -140,6 +153,7 @@ impl OrbitRuntime {
             run,
             step_started_at,
             finished_at,
+            Some(error_code),
             message,
             JobRunState::Interrupted,
         );

--- a/crates/orbit-core/src/command/job/run/tests/reconcile.rs
+++ b/crates/orbit-core/src/command/job/run/tests/reconcile.rs
@@ -24,6 +24,7 @@ fn show_job_run_reconciles_stale_running_owner() {
     assert!(shown.duration_ms.is_some_and(|value| value > 0));
     assert!(shown.steps.iter().any(|step| {
         step.state == JobRunState::Interrupted
+            && step.error_code.as_deref() == Some("process_not_found")
             && step.error_message.as_deref().is_some_and(|message| {
                 message.contains("recorded worker process is no longer alive")
             })
@@ -142,6 +143,7 @@ fn workspace_open_reconciles_orphaned_pending_children_of_interrupted_parent() {
         let shown = reopened.show_job_run(&child.run_id).expect("show child");
         assert!(shown.steps.iter().any(|step| {
             step.state == JobRunState::Interrupted
+                && step.error_code.as_deref() == Some("never_claimed")
                 && step
                     .error_message
                     .as_deref()
@@ -316,9 +318,10 @@ fn sweep_still_condemns_a_run_whose_owner_died_in_this_pid_namespace() {
     let shown = runtime.show_job_run(&run.run_id).expect("show run");
     assert_eq!(shown.state, JobRunState::Interrupted);
     assert!(shown.steps.iter().any(|step| {
-        step.error_message
-            .as_deref()
-            .is_some_and(|message| message.contains("reason=process_not_found"))
+        step.error_code.as_deref() == Some("process_not_found")
+            && step.error_message.as_deref().is_some_and(|message| {
+                message.contains("recorded worker process is no longer alive")
+            })
     }));
 }
 


### PR DESCRIPTION
## Task

[ORB-10646](https://orbit-cli.com/tasks/ORB-10646) — Persist structured liveness-interrupt error codes

### Description

## Problem

Interrupted job-run step rows always leave `error_code` empty, so distinguishing one interrupt cause from another requires regex-parsing the human-readable `error_message`.

## Evidence (verified against the current tree, 2026-08-08)

The reason token is only ever formatted *into the message string*. `stale_pending_run_message` and `stale_job_run_message` in `crates/orbit-core/src/command/job/run/owner.rs` interpolate a reason token into prose. Both are passed as a bare message into `finalize_orphaned_job_run` in `reconcile.rs`, which calls `record_pipeline_diagnostic_step`.

That helper's signature has **no** `error_code` parameter at all and hardcodes `error_code: None`. All three diagnostic-step writers go through it, so every interrupted step row is affected — which matches the 60-run audit exactly.

**The store is innocent.** `crates/orbit-store/src/sqlite/job_run_store/mod.rs` already binds and upserts `error_code` correctly end to end; the only `None` there is a unit-test fixture. It is reference-only, not a modification target.

The parsing burden is already in-tree: an existing reconcile test asserts on `message.contains("reason=process_not_found")`. Two downstream consumers already read `step.error_code` and always receive `None`.

## Why It Matters

Dashboards and audits depend on brittle prose parsing, which silently breaks whenever a diagnostic message is reworded.

## Constraints / Notes

- Keep the human-readable diagnostic. This adds a machine-readable code alongside it; it does not replace it.
- `record_pipeline_diagnostic_step` is shared by three callers — a stable code vocabulary matters more than covering every cause in this pass. Name the vocabulary in the execution summary.
- **Dispatch ordering:** sequenced behind the job/pipeline restructuring chain *and* behind the sibling flaky-test task, because both edit the same helper. Re-derive anchors against the post-chain tree.
- Interrupted pipeline history must remain inspectable after the change.

### Acceptance Criteria

- Reconciliation writes a stable machine-readable code into the interrupted step's `error_code` for at least the process-not-found and never-claimed causes.
- The code is reachable from CLI and API JSON without parsing `error_message`.
- Tests cover both causes and assert on the code rather than on a message substring — including updating the existing test that asserts a `reason=` substring.
- The human-readable diagnostic message is retained alongside the code.
- Interrupted pipeline history from before the change remains inspectable.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Reconciliation now persists the stale-owner cause into the interrupted diagnostic step's existing `error_code` field while retaining `error_message`.
- The shared diagnostic-step writer accepts an optional code, so unrelated failure and worker-startup diagnostics preserve their prior behavior.
- Stable reconciliation vocabulary: `process_not_found`, `never_claimed`, `token_mismatch`, `probe_unavailable`, `verified`, `legacy_live_unverified`, `foreign_pid_namespace`, and `unknown`. Message reason tokens are derived from the same vocabulary to prevent drift.
- Updated reconciliation regressions for process-not-found and never-claimed causes to assert `error_code`; retained separate human-readable message assertions. The existing process-not-found reason-substring test now asserts the structured code.
- Extended context_files with `file:crates/orbit-core/src/command/job/run/tests/reconcile.rs` because the directly affected regression tests are required by the acceptance criteria.
- Existing history remains compatible: no schema or read-path change was needed, and older steps with a null `error_code` remain serializable and inspectable. Existing CLI and dashboard/API JSON projections already expose `JobRunStep.error_code`.

Validation:
- `cargo test -p orbit-core command::job::run::tests::reconcile --lib` (12 passed)
- `cargo test -p orbit-core command::job::run::tests --lib` (41 passed)
- `make ci-fast` (passed)
- `make ci-lint` (passed)
- `git diff --check` (passed)

Assessment: Focused, backward-compatible implementation with structured cause data added at the reconciliation writer boundary and no persisted-format migration.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10646-6a78d66f`
- Behind base: 0
- Ahead of base: 1