### PR TITLE
Make job-run owner liveness and cancellation reliable on macOS

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -1,4 +1,4 @@
-name: macOS Sandbox
+name: macOS Platform
 
 # The orbit-exec macOS sandbox tests (`#[cfg(target_os = "macos")]`, gated on
 # `sandbox_exec_can_apply()`) compile generated SBPL profiles through the real
@@ -19,6 +19,13 @@ on:
       - "crates/orbit-policy/**"
       - "crates/orbit-common/src/types/policy_def.rs"
       - "crates/orbit-common/src/utility/glob.rs"
+      # [ORB-10682] Darwin owner/cancellation liveness uses native libproc
+      # state so unreaped zombies do not look like surviving work.
+      - "crates/orbit-common/src/utility/process_identity.rs"
+      - "crates/orbit-common/src/utility/tests/process_identity.rs"
+      - "crates/orbit-core/src/command/job/run/owner.rs"
+      - "crates/orbit-core/src/command/job/run/tests/actions.rs"
+      - "crates/orbit-core/src/command/job/run/tests/owner.rs"
       - "Cargo.lock"
       - ".github/workflows/ci-macos.yml"
 
@@ -57,3 +64,11 @@ jobs:
       # apply-time tests rather than failing — never worse than the Linux gate.
       - name: Run orbit-exec sandbox tests (real sandbox-exec)
         run: cargo test -p orbit-exec --locked
+
+      # Linux cannot exercise Darwin's libproc zombie/group semantics. Keep
+      # these filters aligned with the owner/liveness path triggers above.
+      - name: Run process identity and job-run owner tests
+        run: |
+          cargo test -p orbit-common --locked process_identity -- --nocapture
+          cargo test -p orbit-core --locked command::job::run::tests::owner -- --nocapture
+          cargo test -p orbit-core --locked command::job::run::tests::actions -- --nocapture

--- a/crates/orbit-common/src/utility/process_identity.rs
+++ b/crates/orbit-common/src/utility/process_identity.rs
@@ -315,11 +315,44 @@ pub fn probe_process_liveness(_pid: u32, _pid_start_time: Option<&str>) -> Proce
     ProcessLiveness::Unknown
 }
 
+/// Kernel-level activity state for a PID or process group.
+///
+/// `Unknown` is deliberately distinct from `Exited`: callers which make a
+/// safety decision must preserve the possibility that work is still running.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KernelLiveness {
+    Alive,
+    Exited,
+    Unknown,
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SignalPresence {
+    Present,
+    Missing,
+    Unknown,
+}
+
+#[cfg(unix)]
+fn signal_presence(target: libc::pid_t) -> SignalPresence {
+    // Safety: signal 0 performs existence/permission checking only.
+    let rc = unsafe { libc::kill(target, 0) };
+    if rc == 0 {
+        return SignalPresence::Present;
+    }
+    match std::io::Error::last_os_error().raw_os_error() {
+        Some(libc::EPERM) => SignalPresence::Present,
+        Some(libc::ESRCH) => SignalPresence::Missing,
+        _ => SignalPresence::Unknown,
+    }
+}
+
 /// True when `pid` names a process that can still run.
 ///
-/// Linux keeps unreaped zombies visible to `kill(pid, 0)`; they are reported
-/// dead here because they can no longer do work. `EPERM` counts as alive: the
-/// process exists, we merely may not signal it.
+/// Linux and macOS keep unreaped zombies visible to `kill(pid, 0)`; native
+/// state probes report those processes dead here because they can no longer do
+/// work. An unavailable native probe and `EPERM` remain conservatively alive.
 #[cfg(unix)]
 pub fn process_is_alive(pid: u32) -> bool {
     if pid == 0 || pid > i32::MAX as u32 {
@@ -329,12 +362,11 @@ pub fn process_is_alive(pid: u32) -> bool {
     if matches!(linux_process_state(pid), Some(('Z', _))) {
         return false;
     }
-    // Safety: signal 0 performs existence/permission checking only.
-    let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
-    if rc == 0 {
-        return true;
+    #[cfg(target_os = "macos")]
+    if let Some((is_zombie, _)) = darwin_process_state(pid) {
+        return !is_zombie;
     }
-    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+    !matches!(signal_presence(pid as libc::pid_t), SignalPresence::Missing)
 }
 
 #[cfg(not(unix))]
@@ -355,4 +387,160 @@ pub fn linux_process_state(pid: u32) -> Option<(char, libc::pid_t)> {
     let _parent_pid = fields.next()?;
     let process_group = fields.next()?.parse().ok()?;
     Some((state, process_group))
+}
+
+/// Native Darwin process state and process-group id.
+///
+/// `proc_pidinfo(PROC_PIDTBSDINFO)` is a syscall-backed libproc query, so the
+/// 50 ms cancellation poll never spawns `ps`. A failed query is inconclusive;
+/// callers retain `kill(..., 0)` as a conservative existence/permission probe.
+#[cfg(target_os = "macos")]
+fn darwin_process_state(pid: u32) -> Option<(bool, libc::pid_t)> {
+    use std::mem::{MaybeUninit, size_of};
+
+    let mut info = MaybeUninit::<libc::proc_bsdinfo>::uninit();
+    let expected = i32::try_from(size_of::<libc::proc_bsdinfo>()).ok()?;
+    // Safety: `info` points to `expected` writable bytes and is initialized
+    // only when libproc reports that it filled the complete structure.
+    let written = unsafe {
+        libc::proc_pidinfo(
+            pid as libc::pid_t,
+            libc::PROC_PIDTBSDINFO,
+            0,
+            info.as_mut_ptr().cast(),
+            expected,
+        )
+    };
+    if written != expected {
+        return None;
+    }
+    // Safety: the full structure was written above.
+    let info = unsafe { info.assume_init() };
+    let process_group = libc::pid_t::try_from(info.pbi_pgid).ok()?;
+    Some((info.pbi_status == libc::SZOMB, process_group))
+}
+
+/// Probe whether a process group contains at least one process that can still
+/// run. Zombie-only groups are `Exited`; failures to enumerate or inspect an
+/// existing member are `Unknown`, never evidence of death.
+#[cfg(unix)]
+pub fn probe_process_group_liveness(pgid: libc::pid_t) -> KernelLiveness {
+    if pgid <= 1 {
+        return KernelLiveness::Exited;
+    }
+    #[cfg(target_os = "linux")]
+    if let Some(liveness) = linux_process_group_liveness(pgid) {
+        return liveness;
+    }
+    #[cfg(target_os = "macos")]
+    if let Some(liveness) = darwin_process_group_liveness(pgid) {
+        return liveness;
+    }
+    match signal_presence(-pgid) {
+        SignalPresence::Present => KernelLiveness::Alive,
+        SignalPresence::Missing => KernelLiveness::Exited,
+        SignalPresence::Unknown => KernelLiveness::Unknown,
+    }
+}
+
+#[cfg(not(unix))]
+pub fn probe_process_group_liveness(_pgid: libc::pid_t) -> KernelLiveness {
+    KernelLiveness::Unknown
+}
+
+/// Linux `/proc` group scan which distinguishes zombie-only groups from live
+/// groups without changing the generic fail-safe behavior when `/proc` is
+/// unavailable or incomplete.
+#[cfg(target_os = "linux")]
+fn linux_process_group_liveness(pgid: libc::pid_t) -> Option<KernelLiveness> {
+    let entries = std::fs::read_dir("/proc").ok()?;
+    let mut found_group_member = false;
+    for entry in entries.flatten() {
+        let Ok(pid) = entry.file_name().to_string_lossy().parse::<u32>() else {
+            continue;
+        };
+        let Some((state, member_pgid)) = linux_process_state(pid) else {
+            continue;
+        };
+        if member_pgid != pgid {
+            continue;
+        }
+        found_group_member = true;
+        if state != 'Z' {
+            return Some(KernelLiveness::Alive);
+        }
+    }
+    found_group_member.then_some(KernelLiveness::Exited)
+}
+
+/// Darwin libproc group scan. The buffer is retried when libproc fills it,
+/// avoiding a truncated scan being mistaken for a zombie-only group.
+#[cfg(target_os = "macos")]
+fn darwin_process_group_liveness(pgid: libc::pid_t) -> Option<KernelLiveness> {
+    use std::ffi::c_void;
+    use std::mem::size_of;
+
+    // Safety: a null/zero probe asks the wrapper for the required PID count.
+    // Unlike `proc_listpids`, `proc_listpgrppids` divides the kernel's byte
+    // count by `sizeof(int)` before returning.
+    let required = unsafe { libc::proc_listpgrppids(pgid, std::ptr::null_mut(), 0) };
+    if required <= 0 {
+        return match signal_presence(-pgid) {
+            SignalPresence::Missing => Some(KernelLiveness::Exited),
+            SignalPresence::Present | SignalPresence::Unknown => None,
+        };
+    }
+
+    let pid_size = size_of::<libc::pid_t>();
+    let mut slots = usize::try_from(required).ok()?.saturating_mul(2).max(16);
+    for _ in 0..3 {
+        let mut pids = vec![0 as libc::pid_t; slots];
+        let buffer_size = i32::try_from(pids.len().saturating_mul(pid_size)).ok()?;
+        // Safety: `pids` is writable for exactly `buffer_size` bytes.
+        let written_count = unsafe {
+            libc::proc_listpgrppids(pgid, pids.as_mut_ptr().cast::<c_void>(), buffer_size)
+        };
+        if written_count < 0 {
+            return None;
+        }
+        let written_count = usize::try_from(written_count).ok()?;
+        if written_count == pids.len() {
+            slots = slots.saturating_mul(2);
+            continue;
+        }
+        pids.truncate(written_count);
+        return Some(darwin_group_liveness_from_pids(pgid, &pids));
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn darwin_group_liveness_from_pids(pgid: libc::pid_t, pids: &[libc::pid_t]) -> KernelLiveness {
+    let mut found_zombie = false;
+    let mut unknown_member = false;
+    for &pid in pids.iter().filter(|pid| **pid > 0) {
+        let Ok(pid_u32) = u32::try_from(pid) else {
+            unknown_member = true;
+            continue;
+        };
+        match darwin_process_state(pid_u32) {
+            Some((false, member_pgid)) if member_pgid == pgid => return KernelLiveness::Alive,
+            Some((true, member_pgid)) if member_pgid == pgid => found_zombie = true,
+            Some(_) => {}
+            None => match signal_presence(pid) {
+                SignalPresence::Missing => {}
+                SignalPresence::Present | SignalPresence::Unknown => unknown_member = true,
+            },
+        }
+    }
+    if unknown_member {
+        KernelLiveness::Unknown
+    } else if found_zombie {
+        KernelLiveness::Exited
+    } else {
+        match signal_presence(-pgid) {
+            SignalPresence::Missing => KernelLiveness::Exited,
+            SignalPresence::Present | SignalPresence::Unknown => KernelLiveness::Unknown,
+        }
+    }
 }

--- a/crates/orbit-common/src/utility/tests/process_identity.rs
+++ b/crates/orbit-common/src/utility/tests/process_identity.rs
@@ -92,4 +92,71 @@ mod liveness {
         assert_eq!(ProcessLiveness::Exited.as_str(), "exited");
         assert_eq!(ProcessLiveness::Unknown.as_str(), "unknown");
     }
+
+    #[test]
+    fn live_and_missing_process_groups_are_distinguished() {
+        let own_group = unsafe { libc::getpgrp() };
+        assert_eq!(
+            probe_process_group_liveness(own_group),
+            KernelLiveness::Alive
+        );
+        assert_eq!(
+            probe_process_group_liveness(i32::MAX),
+            KernelLiveness::Exited
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn darwin_native_probes_classify_an_unreaped_zombie_and_its_group_as_exited() {
+        use std::os::unix::process::CommandExt;
+        use std::process::{Command, Stdio};
+        use std::time::{Duration, Instant};
+
+        struct ReapingChild(std::process::Child);
+
+        impl Drop for ReapingChild {
+            fn drop(&mut self) {
+                if self.0.try_wait().ok().flatten().is_none() {
+                    let _ = self.0.kill();
+                }
+                let _ = self.0.wait();
+            }
+        }
+
+        let mut command = Command::new("/bin/sh");
+        command
+            .arg("-c")
+            .arg("exit 0")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        // Safety: the child has not spawned yet; setsid isolates the process
+        // group queried by this test from the test runner's group.
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let mut child = ReapingChild(command.spawn().expect("spawn isolated child"));
+        let pid = child.0.id();
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while process_is_alive(pid) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        assert!(
+            !process_is_alive(pid),
+            "unreaped Darwin zombie must not count as live"
+        );
+        assert_eq!(
+            probe_process_group_liveness(pid as libc::pid_t),
+            KernelLiveness::Exited,
+            "a zombie-only Darwin group must be stopped"
+        );
+        child.0.wait().expect("reap isolated zombie");
+    }
 }

--- a/crates/orbit-core/src/command/job/run/owner.rs
+++ b/crates/orbit-core/src/command/job/run/owner.rs
@@ -4,8 +4,6 @@
 
 use orbit_common::types::OrbitError;
 use orbit_common::types::{JobRun, JobRunState};
-#[cfg(target_os = "linux")]
-use orbit_common::utility::process_identity::linux_process_state;
 /// Re-exported so the historical `owner::process_is_alive` path keeps working
 /// for this module's callers and sibling tests; the probe itself now lives in
 /// `orbit-common` so other run surfaces can share it [ORB-10496].
@@ -13,8 +11,9 @@ use orbit_common::utility::process_identity::linux_process_state;
 pub(super) use orbit_common::utility::process_identity::process_is_alive;
 #[cfg(unix)]
 use orbit_common::utility::process_identity::{
-    PidNamespaceScope, ProbeOutcome, is_stable_token, legacy_lstart_matches, pid_namespace_scope,
-    probe_process_start_identity, stable_tokens_match,
+    KernelLiveness, PidNamespaceScope, ProbeOutcome, is_stable_token, legacy_lstart_matches,
+    pid_namespace_scope, probe_process_group_liveness, probe_process_start_identity,
+    stable_tokens_match,
 };
 #[cfg(unix)]
 use std::thread;
@@ -172,44 +171,7 @@ fn wait_for_process_group_exit(pgid: libc::pid_t, timeout: Duration) -> bool {
 
 #[cfg(unix)]
 fn process_group_is_alive(pgid: libc::pid_t) -> bool {
-    if pgid <= 1 {
-        return false;
-    }
-    #[cfg(target_os = "linux")]
-    if let Some(alive) = linux_process_group_is_alive(pgid) {
-        return alive;
-    }
-    let rc = unsafe { libc::kill(-pgid, 0) };
-    if rc == 0 {
-        return true;
-    }
-    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
-}
-
-/// Linux keeps unreaped processes visible to `kill(..., 0)`, even though they
-/// can no longer run or receive signals. Treat a group consisting solely of
-/// zombies as terminated so a parent which reaps after cancellation does not
-/// make a successful cancellation look incomplete.
-#[cfg(target_os = "linux")]
-fn linux_process_group_is_alive(pgid: libc::pid_t) -> Option<bool> {
-    let entries = std::fs::read_dir("/proc").ok()?;
-    let mut found_group_member = false;
-    for entry in entries.flatten() {
-        let Ok(pid) = entry.file_name().to_string_lossy().parse::<u32>() else {
-            continue;
-        };
-        let Some((state, member_pgid)) = linux_process_state(pid) else {
-            continue;
-        };
-        if member_pgid != pgid {
-            continue;
-        }
-        found_group_member = true;
-        if state != 'Z' {
-            return Some(true);
-        }
-    }
-    found_group_member.then_some(false)
+    !matches!(probe_process_group_liveness(pgid), KernelLiveness::Exited)
 }
 
 #[cfg(unix)]

--- a/crates/orbit-core/src/command/job/run/tests/actions.rs
+++ b/crates/orbit-core/src/command/job/run/tests/actions.rs
@@ -14,6 +14,34 @@ use std::process::{Command, Stdio};
 use std::time::{Duration as StdDuration, Instant as StdInstant};
 use tempfile::tempdir;
 
+#[cfg(unix)]
+struct ReapingChild(std::process::Child);
+
+#[cfg(unix)]
+impl ReapingChild {
+    fn id(&self) -> u32 {
+        self.0.id()
+    }
+
+    fn wait(&mut self) -> std::io::Result<std::process::ExitStatus> {
+        self.0.wait()
+    }
+
+    fn kill(&mut self) -> std::io::Result<()> {
+        self.0.kill()
+    }
+}
+
+#[cfg(unix)]
+impl Drop for ReapingChild {
+    fn drop(&mut self) {
+        if self.0.try_wait().ok().flatten().is_none() {
+            let _ = self.0.kill();
+        }
+        let _ = self.0.wait();
+    }
+}
+
 #[test]
 fn cancel_job_run_marks_pending_cancelled_without_signal() {
     let (_root, runtime) = test_runtime();
@@ -194,13 +222,15 @@ fn cancel_job_run_does_not_signal_reused_pid_identity_mismatch() {
 
     let (_root, runtime) = test_runtime();
     let run = insert_pending_run(&runtime, "qa_cancel_reused_pid");
-    let mut sentinel = Command::new("sleep")
-        .arg("30")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn sentinel");
+    let mut sentinel = ReapingChild(
+        Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sentinel"),
+    );
     let sentinel_pid = sentinel.id();
     let started_at = Utc::now() - Duration::seconds(1);
     runtime
@@ -259,7 +289,7 @@ fn cancel_job_run_kills_term_resistant_process_group() {
             Ok(())
         });
     }
-    let mut owner = owner.spawn().expect("spawn owner");
+    let mut owner = ReapingChild(owner.spawn().expect("spawn owner"));
     let mut pid_pair = None;
     assert!(
         wait_until(StdDuration::from_secs(2), || {
@@ -294,17 +324,57 @@ fn cancel_job_run_kills_term_resistant_process_group() {
 
 #[cfg(unix)]
 #[test]
+fn cancel_job_run_terminates_cooperative_process_group() {
+    use std::os::unix::process::CommandExt;
+
+    let (_root, runtime) = test_runtime();
+    let run = insert_pending_run(&runtime, "qa_cancel_term_process_group");
+    let mut owner = Command::new("sleep");
+    owner
+        .arg("30")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    unsafe {
+        owner.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut owner = ReapingChild(owner.spawn().expect("spawn cooperative owner"));
+    let owner_pid = owner.id();
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, Utc::now(), owner_pid)
+        .expect("mark running");
+
+    let result = runtime.cancel_job_run(&run.run_id).expect("cancel run");
+    owner.wait().expect("reap cooperative owner");
+
+    assert_eq!(
+        result.signal_outcome.as_deref(),
+        Some("terminated_process_group")
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn cancellation_of_an_already_exited_process_group_is_successful() {
     let (_root, runtime) = test_runtime();
     let run = insert_pending_run(&runtime, "qa_cancel_exited_group");
-    let mut owner = Command::new("/bin/sh")
-        .arg("-c")
-        .arg("exit 0")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn exited owner");
+    let mut owner = ReapingChild(
+        Command::new("/bin/sh")
+            .arg("-c")
+            .arg("exit 0")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn exited owner"),
+    );
     let owner_pid = owner.id();
     owner.wait().expect("reap exited owner");
     runtime

--- a/crates/orbit-core/src/command/job/run/tests/owner.rs
+++ b/crates/orbit-core/src/command/job/run/tests/owner.rs
@@ -7,7 +7,7 @@ use super::super::JobRunListParams;
 #[cfg(unix)]
 use super::super::owner::{
     OwnerIdentity, classify_run_owner_with_probes, pending_run_stale_reason,
-    running_run_owner_stale_reason, stale_job_run_message,
+    running_run_owner_stale_reason, stale_job_run_message, verify_owner_termination,
 };
 use chrono::{Duration, Utc};
 use orbit_common::types::JobRunState;
@@ -20,6 +20,34 @@ use orbit_common::utility::process_identity::{
 };
 #[cfg(unix)]
 use std::process::{Command, Stdio};
+
+#[cfg(unix)]
+struct ReapingChild(std::process::Child);
+
+#[cfg(unix)]
+impl ReapingChild {
+    fn id(&self) -> u32 {
+        self.0.id()
+    }
+
+    fn kill(&mut self) -> std::io::Result<()> {
+        self.0.kill()
+    }
+
+    fn wait(&mut self) -> std::io::Result<std::process::ExitStatus> {
+        self.0.wait()
+    }
+}
+
+#[cfg(unix)]
+impl Drop for ReapingChild {
+    fn drop(&mut self) {
+        if self.0.try_wait().ok().flatten().is_none() {
+            let _ = self.0.kill();
+        }
+        let _ = self.0.wait();
+    }
+}
 
 static TZ_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
@@ -54,14 +82,56 @@ impl Drop for TzGuard {
 }
 
 #[cfg(unix)]
-fn spawn_sentinel() -> std::process::Child {
-    Command::new("sleep")
+fn spawn_sentinel() -> ReapingChild {
+    ReapingChild(
+        Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sentinel"),
+    )
+}
+
+#[cfg(unix)]
+#[test]
+fn live_isolated_group_returns_typed_cancellation_evidence() {
+    use std::os::unix::process::CommandExt;
+
+    let mut command = Command::new("sleep");
+    command
         .arg("30")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn sentinel")
+        .stderr(Stdio::null());
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut survivor = ReapingChild(command.spawn().expect("spawn isolated survivor"));
+    let pid = survivor.id();
+
+    let error = verify_owner_termination(pid, Some(pid as libc::pid_t), true, true)
+        .expect_err("a genuine survivor must remain non-terminal");
+    assert!(matches!(
+        error,
+        orbit_common::types::OrbitError::RunCancellationIncomplete {
+            pid: error_pid,
+            pgid: Some(error_pgid),
+            term_sent: true,
+            kill_sent: true,
+            leader_alive: true,
+            group_alive: true,
+        } if error_pid == pid && error_pgid == pid as libc::pid_t
+    ));
+
+    survivor.kill().expect("kill isolated survivor");
+    survivor.wait().expect("reap isolated survivor");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Task

[ORB-10682](https://orbit-cli.com/tasks/ORB-10682) — Make job-run owner liveness and cancellation reliable on macOS

### Description

## Problem
Orbit's job-run owner code is nominally Unix-wide, but its post-signal liveness verification is only zombie-aware on Linux. On macOS, `process_is_alive` and process-group liveness fall back to `kill(..., 0)`; an unreaped process still appears present after SIGKILL, so a successful termination can be reported as `RunCancellationIncomplete`.

This is a confirmed regression from ORB-10476, which added strict post-signal verification and a Linux-only `/proc` zombie exception.

## Evidence
Verified on Darwin 25.5.0 arm64 / macOS 26.5.2 from current `agent-main`:

- `cargo test -p orbit-common process_identity -- --nocapture`: 7 passed.
- `cargo test -p orbit-core command::job::run::tests::owner -- --nocapture`: 17 passed.
- `cargo test -p orbit-core command::job::run::tests::actions -- --nocapture`: 8 passed, 1 failed.
- The failing test is `cancel_job_run_kills_term_resistant_process_group`. After TERM and KILL it returns:
  `RunCancellationIncomplete { term_sent: true, kill_sent: true, leader_alive: true, group_alive: true }`.

The implementation special-cases zombie processes and zombie-only groups under `#[cfg(target_os = "linux")]`, while macOS uses the generic Unix `kill(pid, 0)` / `kill(-pgid, 0)` fallback. The macOS CI workflow currently runs only `orbit-exec`, so it does not execute these `orbit-common` or `orbit-core` tests.

## Why It Matters
Cancellation is an operator safety boundary. Orbit must neither claim a surviving process was killed nor reject a successful kill merely because the process has not yet been reaped. The same owner/liveness helpers also drive stale-run reconciliation and provider-process status, so platform mistakes can cascade into stuck runs, false interrupts, incorrect overlap decisions, or unsafe retries.

## Scope
Fix the confirmed macOS cancellation defect and audit the complete macOS behavior of the job-run owner/liveness path, including every Linux-only branch and generic-Unix fallback reachable from:

- owner identity capture and comparison;
- PID and process-group liveness;
- TERM/KILL cancellation and post-signal verification;
- detached worker `setsid` / process-group assumptions;
- stale running and claimed-pending reconciliation;
- provider-process liveness projections.

The audit is bounded to process ownership/liveness and cancellation. It is not a general rewrite of all macOS support.

## Constraints / Notes
- Preserve ORB-10476's fail-closed rule: a genuinely surviving leader or group must return typed evidence and must not be finalized as cancelled.
- Preserve PID-reuse protection, `EPERM` handling, legacy start tokens, and ORB-10594's foreign-PID-namespace safety.
- Distinguish running processes from zombies on Darwin without making an unavailable probe evidence of death.
- Avoid spawning an external command on every 50 ms cancellation poll when a reliable native Darwin process API can provide the needed state.
- Tests may signal only process trees they create and must always reap/clean them on success and failure.
- Record every audited Linux-specific assumption and its macOS disposition in the execution summary, including items that require no code change.
- No unrelated platform cleanup.

### Acceptance Criteria

- On a real macOS runner, `cargo test -p orbit-core cancel_job_run_kills_term_resistant_process_group -- --nocapture` passes: a TERM-resistant test group is killed, zombie-only residue is classified as stopped, and cancellation returns `killed_process_group` rather than `RunCancellationIncomplete`.
- Darwin-aware PID and process-group probes distinguish live members, zombie-only groups, absent processes, and permission-denied-but-existing processes while preserving conservative `Unknown`/alive behavior when identity cannot be established.
- Focused deterministic tests cover macOS owner identity capture, PID reuse mismatch, already-exited owners, TERM success, KILL escalation, zombie leader/group handling, and a genuine survivor that remains non-terminal with typed liveness evidence; tests signal only their own isolated process groups and reap them reliably.
- Every `target_os = "linux"`, `/proc`, PID-namespace, `ps`, `kill`, `getpgid`, and `setsid` assumption reachable from job-run owner/liveness behavior is inventoried in the execution summary with one of: portable as-is, fixed for Darwin, deliberately unsupported with fail-safe behavior, or tracked by a named follow-up.
- Stale-run reconciliation and provider-process liveness use the corrected shared semantics on macOS: live work is not interrupted, dead or PID-reused owners are detected, and foreign PID namespaces remain non-adjudicable.
- The macOS CI workflow is path-triggered for the affected owner/liveness files and runs focused `orbit-common` plus `orbit-core` owner/cancellation tests on a real macOS runner, so the confirmed regression fails before merge.
- `cargo test -p orbit-common process_identity -- --nocapture`, the focused `orbit-core` owner/actions suites, `make ci-fast`, and `make ci-lint` pass; Linux behavior and existing Linux tests remain green.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added shared `KernelLiveness` and process-group probing in `orbit-common`. Linux retains its `/proc` state scan; macOS now uses native `proc_pidinfo(PROC_PIDTBSDINFO)` for PID state and `proc_listpgrppids` plus BSD process info for group membership/state. Zombie PIDs and zombie-only groups are `Exited`; enumeration/info failures and non-ESRCH signal errors stay `Unknown`/conservatively alive; EPERM remains evidence that a target exists.
- Routed job-run cancellation polling and final verification through the shared process-group semantics, removing the core-local Linux-only group scanner. Genuine live leaders/groups still produce typed `RunCancellationIncomplete` evidence.
- Added isolated, reaping test-process guards and focused coverage for cooperative TERM, KILL escalation, already-exited owners, PID identity mismatch, genuine survivors, process-group live/absent states, and a macOS-only unreaped-zombie leader/group case. Existing owner identity tests cover Darwin token capture, stable tokens, PID reuse, and stale/live owner behavior.
- Expanded `.github/workflows/ci-macos.yml` path triggers to the owner/liveness implementation and tests, and added real-macOS focused `orbit-common` process-identity plus `orbit-core` owner/actions suites.
- No files outside the original context selectors were modified.

Platform-assumption audit:
- `#[cfg(target_os = "linux")]` + `/proc/<pid>/stat` PID zombie detection — fixed for Darwin with native `proc_pidinfo`; Linux behavior retained.
- `#[cfg(target_os = "linux")]` + `/proc` process-group enumeration — fixed for Darwin with `proc_listpgrppids`, whose wrapper count semantics and inclusion of the XNU zombie list were verified against current XNU sources; unknown/permission-limited observations remain fail-closed.
- `/proc/self/ns/pid` and Linux PID-namespace inode tokens — deliberately unsupported with fail-safe behavior on Darwin: Darwin writes `pidns=-`, classifies namespace scope as `Unknown` (never falsely `Foreign`), and uses ordinary same-host probes. Linux foreign namespaces remain non-adjudicable.
- `ps -o lstart= -p <pid>` identity capture and legacy comparison — portable as-is on Darwin; one-shot capture remains locale/TZ-stabilized and is not used in the 50 ms cancellation poll.
- `kill(pid, 0)` / `kill(-pgid, 0)` existence and permission checks — portable as-is; ESRCH means absent, EPERM means existing, and other failures are conservative `Unknown`.
- TERM/KILL delivery with `kill(pid, signal)` / `kill(-pgid, signal)` — portable as-is; ESRCH is handled as an exit race and all successful outcomes still undergo post-signal verification.
- `getpgid(pid)` ownership lookup and the current-process-group refusal — portable as-is on Darwin.
- `setsid()` detached worker/process-group creation in `pipeline.rs` and isolated tests — portable as-is on Darwin; cancellation continues to target only the worker-created group.
- The Linux-only deleted-executable path normalization in `pipeline.rs` is launch-path hygiene, not owner/liveness adjudication; deliberately unsupported on Darwin because Darwin does not expose Linux's ` (deleted)` procfs executable path shape.
- Stale running/pending reconciliation and routine overlap projections consume `classify_run_owner` / `run_owner_liveness`; provider-process projections consume shared `probe_process_liveness`. Both therefore inherit corrected Darwin zombie/PID-reuse semantics without parallel platform logic.

Validation:
- `cargo test -p orbit-common process_identity -- --nocapture` — passed (8 tests).
- `cargo test -p orbit-core command::job::run::tests::owner -- --nocapture` — passed (18 tests).
- `cargo test -p orbit-core command::job::run::tests::actions -- --nocapture` — passed (10 tests, including the exact TERM-resistant cancellation regression).
- `cargo test -p orbit-core runtime::tests::run_audit -- --nocapture` — passed (7 tests).
- `cargo test -p orbit-core command::job::run::tests::reconcile -- --nocapture` — passed (12 tests).
- `cargo test -p orbit-core routines::tests::sweep -- --nocapture` — passed (11 tests).
- `make ci-fast` — passed.
- `make ci-lint` — passed.
- `git diff --check` — passed.
- Apple-target local check was attempted with `rustup target add aarch64-apple-darwin` but the runner denied the target install: `error opening file for download: cleaning up cached downloads: Read-only file system (os error 30)`. Per the activity policy this runner limitation is not a code failure; the updated real-macOS CI leg is the authoritative Darwin compile/runtime gate.

Assessment: The confirmed false-incomplete cancellation path is fixed without weakening survivor detection, PID reuse protection, EPERM handling, or foreign-PID-namespace safety. Linux focused suites and repository gates remain green; real Darwin execution is intentionally enforced by the path-triggered macOS workflow.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10682-6a78ec98`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*