### PR TITLE
Fail fast before ship submission when an explicit task ID does not exist

### DIFF
--- a/crates/orbit-core/src/command/job/pipeline.rs
+++ b/crates/orbit-core/src/command/job/pipeline.rs
@@ -87,6 +87,12 @@ impl OrbitRuntime {
                 .ok_or_else(|| OrbitError::InvalidInput("unknown workflow 'ship'".to_string()))?;
         let base = base_branch.unwrap_or_else(|| self.workflow_base_branch());
         let input = crate::command::workflow::build_ship_input(mode, base, task_ids)?;
+        // Validate explicit selections before inspecting runs or creating a
+        // pipeline record. Auto mode intentionally carries no task ids: the
+        // worker discovers eligible backlog tasks after it starts.
+        for task_id in task_ids {
+            self.get_task(task_id)?;
+        }
         if let Some(conflict) = self.in_flight_ship_run_for_tasks(task_ids)? {
             return Err(conflict);
         }

--- a/crates/orbit-core/src/command/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/command/tests/job_pipeline.rs
@@ -15,6 +15,7 @@ use crate::command::job::pipeline::{
     configure_pipeline_worker_command, configure_pipeline_worker_stdio, pipeline_worker_log_path,
     resolve_pipeline_worker_executable,
 };
+use crate::command::task::TaskAddParams;
 use crate::command::workflow::ShipMode;
 
 fn test_runtime() -> (TempDir, OrbitRuntime) {
@@ -26,6 +27,17 @@ fn test_runtime() -> (TempDir, OrbitRuntime) {
     let runtime =
         OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build test runtime");
     (root, runtime)
+}
+
+fn add_backlog_task(runtime: &OrbitRuntime) -> String {
+    runtime
+        .add_task(TaskAddParams {
+            title: "Ship submission fixture".to_string(),
+            description: "A task selected by a ship-submission test.".to_string(),
+            ..Default::default()
+        })
+        .expect("create backlog task")
+        .id
 }
 
 #[test]
@@ -350,6 +362,7 @@ fn deleted_current_executable_resolves_to_replaced_installed_path() {
 #[test]
 fn ship_submission_refuses_a_task_already_carried_by_a_non_terminal_run() {
     let (_root, runtime) = test_runtime();
+    let selected_task_id = add_backlog_task(&runtime);
     let in_flight = runtime
         .stores()
         .jobs()
@@ -357,7 +370,7 @@ fn ship_submission_refuses_a_task_already_carried_by_a_non_terminal_run() {
             "task_auto_pipeline",
             1,
             Utc::now(),
-            Some(serde_json::json!({"mode": "local", "task_ids": ["TST-00001"]})),
+            Some(serde_json::json!({"mode": "local", "task_ids": [selected_task_id]})),
             None,
         )
         .expect("insert in-flight run");
@@ -367,15 +380,19 @@ fn ship_submission_refuses_a_task_already_carried_by_a_non_terminal_run() {
         .submit_ship_run(
             ShipMode::Local,
             Some("main"),
-            &["TST-00001".to_string()],
+            std::slice::from_ref(&selected_task_id),
             Some("test"),
         )
         .expect_err("a task with a run in flight must not dispatch a second run");
 
-    let OrbitError::ShipRunInFlight { task_id, run_id } = &error else {
+    let OrbitError::ShipRunInFlight {
+        task_id: guarded_task_id,
+        run_id,
+    } = &error
+    else {
         panic!("expected ShipRunInFlight, got {error:?}");
     };
-    assert_eq!(task_id, "TST-00001");
+    assert_eq!(guarded_task_id, &selected_task_id);
     assert_eq!(run_id, &in_flight.run_id);
 
     let runs = runtime
@@ -399,6 +416,8 @@ fn ship_submission_refuses_a_task_already_carried_by_a_non_terminal_run() {
 #[test]
 fn ship_submission_guard_is_scoped_to_the_selected_tasks() {
     let (_root, runtime) = test_runtime();
+    let in_flight_task_id = add_backlog_task(&runtime);
+    let unrelated_task_id = add_backlog_task(&runtime);
     runtime
         .stores()
         .jobs()
@@ -406,13 +425,13 @@ fn ship_submission_guard_is_scoped_to_the_selected_tasks() {
             "task_auto_pipeline",
             1,
             Utc::now(),
-            Some(serde_json::json!({"mode": "local", "task_ids": ["TST-00001"]})),
+            Some(serde_json::json!({"mode": "local", "task_ids": [in_flight_task_id]})),
             None,
         )
         .expect("insert in-flight run");
 
     for (label, task_ids) in [
-        ("an unrelated explicit task", vec!["TST-00002".to_string()]),
+        ("an unrelated explicit task", vec![unrelated_task_id]),
         ("auto discovery", Vec::new()),
     ] {
         let error = runtime
@@ -427,4 +446,68 @@ fn ship_submission_guard_is_scoped_to_the_selected_tasks() {
             "{label} must fail on the missing job asset instead: {error:?}"
         );
     }
+}
+
+/// Explicit task validation belongs in the shared runtime path, ahead of
+/// pipeline persistence, so every submission surface reports a typo directly
+/// and cannot leave an orphaned worker/run behind.
+#[test]
+fn ship_submission_refuses_a_missing_explicit_task_before_persisting_a_run() {
+    let (_root, runtime) = test_runtime();
+    let missing_id = "ORB-99999".to_string();
+
+    let error = runtime
+        .submit_ship_run(
+            ShipMode::Local,
+            Some("main"),
+            std::slice::from_ref(&missing_id),
+            Some("test"),
+        )
+        .expect_err("a missing explicit task must be rejected before dispatch");
+
+    assert!(matches!(
+        error,
+        OrbitError::NotFound {
+            kind: orbit_common::types::NotFoundKind::Task,
+            id,
+        } if id == missing_id
+    ));
+    assert!(
+        runtime
+            .list_job_runs(JobRunListParams::default())
+            .expect("list job runs")
+            .is_empty(),
+        "the refusal must not persist a run or spawn a worker"
+    );
+}
+
+#[test]
+fn ship_submission_mixed_explicit_selection_identifies_the_missing_task() {
+    let (_root, runtime) = test_runtime();
+    let existing_id = add_backlog_task(&runtime);
+    let missing_id = "ORB-99999".to_string();
+
+    let error = runtime
+        .submit_ship_run(
+            ShipMode::Local,
+            Some("main"),
+            &[existing_id, missing_id.clone()],
+            Some("test"),
+        )
+        .expect_err("mixed selections must refuse their missing task before dispatch");
+
+    assert!(matches!(
+        error,
+        OrbitError::NotFound {
+            kind: orbit_common::types::NotFoundKind::Task,
+            id,
+        } if id == missing_id
+    ));
+    assert!(
+        runtime
+            .list_job_runs(JobRunListParams::default())
+            .expect("list job runs")
+            .is_empty(),
+        "mixed-selection refusal must not persist a run"
+    );
 }


### PR DESCRIPTION
## Task

[ORB-10683](https://orbit-cli.com/tasks/ORB-10683) — Fail fast before ship submission when an explicit task ID does not exist

### Description

## Problem

The shared `OrbitRuntime::submit_ship_run` path builds and persists a real `task_auto_pipeline` job run for explicit task IDs that do not exist. The worker then exits before useful logs are recorded, leaving an opaque interrupted/process-not-found run instead of a typed task-selection error. This affects every adapter consolidated onto the shared ship-submission path.

## Why It Matters

A typo consumes a worker/run slot, pollutes durable run history, and presents an infrastructure-looking failure instead of identifying the invalid task ID.

## Constraints / Notes

- Validate in the shared runtime submission path so CLI, dashboard, MCP, and routine callers cannot bypass the guard.
- Auto-discovery mode (an empty explicit task list) must remain valid.
- Refusal must happen before any job-run record or worker process is created.
- Preserve the existing duplicate-selection and in-flight-run guards and their errors.
- The source defect was originally filed as Polaris coordination task ORB-10671; this is the owning-workspace successor.

### Acceptance Criteria

- A shared-path test calls `submit_ship_run` with one nonexistent explicit task ID and asserts a typed error naming that ID.
- The nonexistent-ID refusal leaves job-run history unchanged and does not spawn a worker.
- Tests cover mixed explicit selections containing both existing and missing IDs, and the error identifies every missing ID or deterministically identifies the first missing ID.
- Auto-discovery mode and an explicit existing backlog task still pass task-existence validation; existing duplicate-selection and in-flight-run guard tests remain green.
- `make ci-fast`, focused orbit-core/CLI tests for ship submission, and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added shared `submit_ship_run` validation of every explicit task ID after malformed-input checks and before in-flight inspection, pipeline persistence, or worker spawn.
- Added missing-ID and mixed-selection shared-path tests, and updated in-flight/scoping fixtures to use real backlog tasks.
Assessment: Explicit typo failures now return `OrbitError::NotFound { kind: Task, id }` without creating job-run history; auto-discovery, existing explicit selections, duplicate selection validation, and in-flight guards remain covered.
Validation:
- cargo fmt --check
- cargo test -p orbit-core ship_submission -- --nocapture (4 passed)
- make ci-fast
- make ci-lint
Friction checkpoint: no qualifying friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10683-6a78f3e9`
- Behind base: 0
- Ahead of base: 1