### PR TITLE
Reconcile retired managed activity and job assets without deleting user-authored resources

### DIFF
--- a/.orbit/adrs/proposed/ADR-0346/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0346/adr.yaml
@@ -1,0 +1,24 @@
+schema_version: 2
+id: ADR-0346
+title: Track bundled activity and job ownership by content digest before retirement
+status: proposed
+owner: codex
+created_at: 2026-08-09T21:45:18.671118036Z
+last_updated: 2026-08-09T21:45:18.671118036Z
+related_features:
+- activity-job
+- orbit-core
+related_tasks:
+- ORB-10684
+tags:
+- managed-assets
+- upgrade-safety
+paths:
+- crates/orbit-core/src/command/mod.rs
+- crates/orbit-core/src/command/activity.rs
+- crates/orbit-core/src/command/job/catalog.rs
+- crates/orbit-core/src/command/init.rs
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/proposed/ADR-0346/body.md
+++ b/.orbit/adrs/proposed/ADR-0346/body.md
@@ -1,0 +1,11 @@
+## Context
+Embedded activity and job assets are materialized into the global resource catalog, but an additive refresh cannot distinguish a retired bundled file from an operator-authored file by name alone. Filename-only pruning would deactivate stale shipped subsystems, but it could also destroy legitimate local resources on legacy installations.
+
+## Decision
+Persist a per-resource-kind managed manifest containing the SHA-256 digest last written for each bundled activity or job. Refresh removes retired files only when their bytes still match that digest, moves locally modified retired managed files into a non-catalog backup area, preserves untracked legacy YAML in place, and emits actionable recovery warnings; the same reconciliation implementation governs both resource kinds.
+
+## Consequences
+- A current release can retire assets seeded by an earlier manifest-aware release without leaving them active in catalog construction.
+- Existing installations without a manifest migrate safely: exact current bundled bytes gain provenance, while untracked YAML remains active and is named in a manual-recovery warning.
+- Locally modified retired assets remain recoverable outside active catalog directories instead of breaking unrelated catalog/list operations.
+- Cost: managed manifests and preserved-retirement backups add local state and make the first legacy refresh potentially require operator review before an ambiguous stale file can be removed.

--- a/crates/orbit-cli/src/command/init.rs
+++ b/crates/orbit-cli/src/command/init.rs
@@ -93,7 +93,10 @@ impl InitCommand {
             config_path: paths.config_path,
             created_config: result.created_config,
             refreshed_default_activities: result.refreshed_default_activities,
+            retired_default_activities: result.retired_default_activities,
             refreshed_default_jobs: result.refreshed_default_jobs,
+            retired_default_jobs: result.retired_default_jobs,
+            managed_asset_warnings: result.managed_asset_warnings,
             refreshed_default_executors: result.refreshed_default_executors,
             refreshed_default_policies: result.refreshed_default_policies,
         });
@@ -247,20 +250,25 @@ fn resolve_config_path(root_override: Option<&Path>) -> Result<PathBuf, OrbitErr
 
 fn print_init_result(output: InitOutput) {
     println!(
-        "skills: root={}, refreshed={}, symlink_created={}; config: path={}, created={}; default_activities_refreshed={}; default_jobs_refreshed={}; default_executors_refreshed={}; default_policies_refreshed={}",
+        "skills: root={}, refreshed={}, symlink_created={}; config: path={}, created={}; default_activities_refreshed={}, retired={}; default_jobs_refreshed={}, retired={}; default_executors_refreshed={}; default_policies_refreshed={}",
         output.skills_root,
         output.refreshed_skill_files,
         output.created_skills_symlink,
         output.config_path,
         output.created_config,
         output.refreshed_default_activities,
+        output.retired_default_activities,
         output.refreshed_default_jobs,
+        output.retired_default_jobs,
         output.refreshed_default_executors,
         output.refreshed_default_policies,
     );
+    for warning in output.managed_asset_warnings {
+        eprintln!("warning: {warning}");
+    }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct InitOutput {
     skills_root: &'static str,
     refreshed_skill_files: usize,
@@ -268,7 +276,10 @@ struct InitOutput {
     config_path: &'static str,
     created_config: bool,
     refreshed_default_activities: usize,
+    retired_default_activities: usize,
     refreshed_default_jobs: usize,
+    retired_default_jobs: usize,
+    managed_asset_warnings: Vec<String>,
     refreshed_default_executors: usize,
     refreshed_default_policies: usize,
 }

--- a/crates/orbit-core/src/command/activity.rs
+++ b/crates/orbit-core/src/command/activity.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use orbit_common::types::OrbitError;
 
-use super::seed_embedded_assets;
+use super::{ManagedAssetReconciliation, reconcile_managed_assets};
 
 /// Shippable default activity assets, seeded under
 /// `<orbit_root>/resources/activities/<name>.yaml` on `orbit init`. Keep this
@@ -140,9 +140,10 @@ pub(crate) const DEFAULT_ACTIVITY_FILES: &[(&str, &str)] = &[
 pub(crate) fn seed_default_activities(
     activities_dir: &Path,
     overwrite: bool,
-) -> Result<usize, OrbitError> {
-    seed_embedded_assets(
+) -> Result<ManagedAssetReconciliation, OrbitError> {
+    reconcile_managed_assets(
         activities_dir,
+        "activity",
         DEFAULT_ACTIVITY_FILES,
         overwrite,
         |_, content| Ok(Cow::Borrowed(content)),

--- a/crates/orbit-core/src/command/init.rs
+++ b/crates/orbit-core/src/command/init.rs
@@ -32,7 +32,10 @@ pub struct InitResult {
     pub created_skills_symlink: bool,
     pub created_config: bool,
     pub refreshed_default_activities: usize,
+    pub retired_default_activities: usize,
     pub refreshed_default_jobs: usize,
+    pub retired_default_jobs: usize,
+    pub managed_asset_warnings: Vec<String>,
     pub refreshed_default_executors: usize,
     pub refreshed_default_policies: usize,
     pub refreshed_default_routines: usize,
@@ -172,7 +175,10 @@ pub fn init_workspace_at_root(
     let mut seeded_default_auto_tasks = 0usize;
     let (
         refreshed_default_activities,
+        retired_default_activities,
         refreshed_default_jobs,
+        retired_default_jobs,
+        managed_asset_warnings,
         refreshed_default_executors,
         refreshed_default_policies,
         scoring_enabled,
@@ -182,12 +188,16 @@ pub fn init_workspace_at_root(
         let refreshed_default_executors =
             seed_default_executors(executor_store.as_ref(), overwrite)?;
         let refreshed_default_policies = seed_default_policies(policy_store.as_ref(), overwrite)?;
-        let refreshed_default_activities =
-            seed_default_activities(&layout.activities_dir, overwrite)?;
-        let refreshed_default_jobs = seed_default_jobs(&layout.jobs_dir, overwrite)?;
+        let activity_reconciliation = seed_default_activities(&layout.activities_dir, overwrite)?;
+        let job_reconciliation = seed_default_jobs(&layout.jobs_dir, overwrite)?;
+        let mut managed_asset_warnings = activity_reconciliation.warnings;
+        managed_asset_warnings.extend(job_reconciliation.warnings);
         (
-            refreshed_default_activities,
-            refreshed_default_jobs,
+            activity_reconciliation.refreshed,
+            activity_reconciliation.retired,
+            job_reconciliation.refreshed,
+            job_reconciliation.retired,
+            managed_asset_warnings,
             refreshed_default_executors,
             refreshed_default_policies,
             false,
@@ -232,7 +242,10 @@ pub fn init_workspace_at_root(
         seeded_default_auto_tasks = seed_default_auto_tasks(&orbit_root)?;
         (
             global_result.refreshed_default_activities,
+            global_result.retired_default_activities,
             global_result.refreshed_default_jobs,
+            global_result.retired_default_jobs,
+            global_result.managed_asset_warnings,
             global_result.refreshed_default_executors,
             global_result.refreshed_default_policies,
             RuntimeConfig::load_layered(&global_root, &orbit_root)?.scoring_enabled,
@@ -251,7 +264,10 @@ pub fn init_workspace_at_root(
         created_skills_symlink,
         created_config,
         refreshed_default_activities,
+        retired_default_activities,
         refreshed_default_jobs,
+        retired_default_jobs,
+        managed_asset_warnings,
         refreshed_default_executors,
         refreshed_default_policies,
         refreshed_default_routines,

--- a/crates/orbit-core/src/command/job/catalog.rs
+++ b/crates/orbit-core/src/command/job/catalog.rs
@@ -8,7 +8,7 @@ use orbit_common::types::{JobKind, JobRun, JobScheduleState, JobV2, NotFoundKind
 use serde_json::Value;
 
 use crate::OrbitRuntime;
-use crate::command::seed_embedded_assets;
+use crate::command::{ManagedAssetReconciliation, reconcile_managed_assets};
 
 /// Shippable default workflow assets, seeded under
 /// `<orbit_root>/resources/jobs/<name>.yaml` on `orbit init`. The entries
@@ -274,8 +274,15 @@ fn matches_job_filter(kind: JobKind, filter: JobCatalogFilter) -> bool {
 ///
 /// When `overwrite` is false, existing files are preserved — users who've
 /// edited a previously-seeded workflow won't lose their changes on re-init.
-pub(crate) fn seed_default_jobs(jobs_dir: &Path, overwrite: bool) -> Result<usize, OrbitError> {
-    seed_embedded_assets(jobs_dir, DEFAULT_JOB_FILES, overwrite, |_, content| {
-        Ok(Cow::Borrowed(content))
-    })
+pub(crate) fn seed_default_jobs(
+    jobs_dir: &Path,
+    overwrite: bool,
+) -> Result<ManagedAssetReconciliation, OrbitError> {
+    reconcile_managed_assets(
+        jobs_dir,
+        "job",
+        DEFAULT_JOB_FILES,
+        overwrite,
+        |_, content| Ok(Cow::Borrowed(content)),
+    )
 }

--- a/crates/orbit-core/src/command/mod.rs
+++ b/crates/orbit-core/src/command/mod.rs
@@ -11,10 +11,14 @@
 //! at compile time via `include_str!` and seeded to disk on first `orbit init`.
 
 use std::borrow::Cow;
-use std::path::Path;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
 
 use orbit_common::types::OrbitError;
-use orbit_common::utility::fs::write_text_with_parent;
+use orbit_common::utility::fs::{atomic_write_text, write_text_with_parent};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 /// Audit identity used for system-initiated (non-agent) mutations.
 /// `pub` because the direct v2 activity runner moved to `orbit-cmd`
@@ -43,6 +47,307 @@ pub(crate) fn seed_embedded_assets<'a>(
         count += 1;
     }
     Ok(count)
+}
+
+const MANAGED_ASSET_MANIFEST_FILE: &str = ".orbit-managed-assets.json";
+const MANAGED_ASSET_MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ManagedAssetReconciliation {
+    pub refreshed: usize,
+    pub retired: usize,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ManagedAssetManifest {
+    schema_version: u32,
+    asset_kind: String,
+    assets: BTreeMap<String, String>,
+}
+
+/// Materialize the current embedded resource set and reconcile assets retired
+/// since the previous manifest-aware seed.
+///
+/// The manifest records the digest Orbit last wrote for each managed file.
+/// Retired files that still match that digest are deleted. Locally modified
+/// retired files are moved outside the recursively loaded catalog tree, so
+/// their content survives without keeping a removed subsystem active. A
+/// legacy directory without a manifest is migrated conservatively: exact
+/// current defaults gain provenance, while every other YAML file stays in
+/// place and produces an actionable warning.
+// ADR-0346: content provenance, rather than filenames, authorizes retirement.
+pub(crate) fn reconcile_managed_assets<'a>(
+    dir: &Path,
+    asset_kind: &str,
+    files: &'a [(&'a str, &'a str)],
+    overwrite: bool,
+    mut render: impl FnMut(&'a str, &'a str) -> Result<Cow<'a, str>, OrbitError>,
+) -> Result<ManagedAssetReconciliation, OrbitError> {
+    validate_managed_asset_name(asset_kind, "asset kind")?;
+    for (name, _) in files {
+        validate_managed_asset_name(name, "embedded asset")?;
+    }
+
+    let manifest_path = dir.join(MANAGED_ASSET_MANIFEST_FILE);
+    let previous = load_managed_asset_manifest(&manifest_path, asset_kind)?;
+    let current_names: BTreeSet<&str> = files.iter().map(|(name, _)| *name).collect();
+    let mut result = ManagedAssetReconciliation::default();
+
+    if let Some(previous) = &previous {
+        for (name, managed_digest) in &previous.assets {
+            if current_names.contains(name.as_str()) {
+                continue;
+            }
+            let path = dir.join(format!("{name}.yaml"));
+            if !path.exists() {
+                continue;
+            }
+            let content = fs::read_to_string(&path).map_err(|error| {
+                OrbitError::Io(format!(
+                    "read retired managed {asset_kind} '{}': {error}",
+                    path.display()
+                ))
+            })?;
+            if sha256_hex(content.as_bytes()) == *managed_digest {
+                fs::remove_file(&path).map_err(|error| {
+                    OrbitError::Io(format!(
+                        "retire managed {asset_kind} '{}': {error}",
+                        path.display()
+                    ))
+                })?;
+            } else {
+                let preserved = preserve_modified_retired_asset(dir, asset_kind, name, &path)?;
+                result.warnings.push(format!(
+                    "retired managed {asset_kind} `{name}` was locally modified; Orbit removed it from the active catalog and preserved it at '{}'. Review that file, then migrate it under a new user-authored name or delete it",
+                    preserved.display()
+                ));
+            }
+            result.retired += 1;
+        }
+    }
+
+    let mut next_assets = BTreeMap::new();
+    for (name, embedded) in files {
+        let path = dir.join(format!("{name}.yaml"));
+        let rendered = render(name, embedded)?;
+        let rendered_digest = sha256_hex(rendered.as_bytes());
+
+        if path.exists() {
+            let previous_digest = previous
+                .as_ref()
+                .and_then(|manifest| manifest.assets.get(*name));
+            if previous_digest.is_none() {
+                let existing = fs::read_to_string(&path).map_err(|error| {
+                    OrbitError::Io(format!(
+                        "read existing {asset_kind} '{}': {error}",
+                        path.display()
+                    ))
+                })?;
+                if sha256_hex(existing.as_bytes()) == rendered_digest {
+                    next_assets.insert((*name).to_string(), rendered_digest);
+                } else if previous.is_some() {
+                    result.warnings.push(format!(
+                        "untracked user-authored {asset_kind} '{}' collides with bundled default `{name}` and was preserved in place. Move or rename it, then rerun `orbit init` to install the bundled default",
+                        path.display()
+                    ));
+                }
+                continue;
+            }
+
+            if !overwrite {
+                let Some(previous_digest) = previous_digest else {
+                    continue;
+                };
+                next_assets.insert((*name).to_string(), previous_digest.clone());
+                continue;
+            }
+        }
+
+        write_text_with_parent(&path, &rendered)?;
+        next_assets.insert((*name).to_string(), rendered_digest);
+        result.refreshed += 1;
+    }
+
+    if previous.is_none() {
+        let ambiguous = ambiguous_legacy_yaml_files(dir, &next_assets)?;
+        if !ambiguous.is_empty() {
+            result.warnings.push(format!(
+                "untracked {asset_kind} YAML assets have no managed provenance and were preserved in place: {}. If any came from an older Orbit release, move or delete them manually before retrying catalog/list commands",
+                ambiguous
+                    .iter()
+                    .map(|path| format!("'{}'", path.display()))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+    }
+
+    let manifest = ManagedAssetManifest {
+        schema_version: MANAGED_ASSET_MANIFEST_SCHEMA_VERSION,
+        asset_kind: asset_kind.to_string(),
+        assets: next_assets,
+    };
+    let mut encoded = serde_json::to_string_pretty(&manifest).map_err(|error| {
+        OrbitError::Store(format!(
+            "serialize managed {asset_kind} asset manifest: {error}"
+        ))
+    })?;
+    encoded.push('\n');
+    atomic_write_text(&manifest_path, &encoded).map_err(|error| {
+        OrbitError::Io(format!(
+            "write managed {asset_kind} asset manifest '{}': {error}",
+            manifest_path.display()
+        ))
+    })?;
+
+    for warning in &result.warnings {
+        tracing::warn!(
+            target: "orbit.core.managed_assets",
+            asset_kind,
+            warning,
+            "managed asset reconciliation requires operator attention"
+        );
+    }
+
+    Ok(result)
+}
+
+fn load_managed_asset_manifest(
+    path: &Path,
+    expected_kind: &str,
+) -> Result<Option<ManagedAssetManifest>, OrbitError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(path).map_err(|error| {
+        OrbitError::Io(format!(
+            "read managed asset manifest '{}': {error}",
+            path.display()
+        ))
+    })?;
+    let manifest: ManagedAssetManifest = serde_json::from_str(&raw).map_err(|error| {
+        OrbitError::InvalidInput(format!(
+            "managed asset manifest '{}' is invalid: {error}; repair it or move it aside only after reviewing the managed YAML files",
+            path.display()
+        ))
+    })?;
+    if manifest.schema_version != MANAGED_ASSET_MANIFEST_SCHEMA_VERSION {
+        return Err(OrbitError::InvalidInput(format!(
+            "managed asset manifest '{}' uses unsupported schemaVersion {}; expected {}",
+            path.display(),
+            manifest.schema_version,
+            MANAGED_ASSET_MANIFEST_SCHEMA_VERSION
+        )));
+    }
+    if manifest.asset_kind != expected_kind {
+        return Err(OrbitError::InvalidInput(format!(
+            "managed asset manifest '{}' is for `{}`, expected `{expected_kind}`",
+            path.display(),
+            manifest.asset_kind
+        )));
+    }
+    for name in manifest.assets.keys() {
+        validate_managed_asset_name(name, "manifest asset")?;
+    }
+    Ok(Some(manifest))
+}
+
+fn validate_managed_asset_name(name: &str, source: &str) -> Result<(), OrbitError> {
+    if name.is_empty()
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+    {
+        return Err(OrbitError::InvalidInput(format!(
+            "{source} name `{name}` is not a safe managed asset file stem"
+        )));
+    }
+    Ok(())
+}
+
+fn preserve_modified_retired_asset(
+    active_dir: &Path,
+    asset_kind: &str,
+    name: &str,
+    source: &Path,
+) -> Result<PathBuf, OrbitError> {
+    let backup_dir = active_dir
+        .parent()
+        .unwrap_or(active_dir)
+        .join(".retired-managed")
+        .join(managed_asset_kind_directory(asset_kind));
+    fs::create_dir_all(&backup_dir).map_err(|error| {
+        OrbitError::Io(format!(
+            "create retired managed asset backup '{}': {error}",
+            backup_dir.display()
+        ))
+    })?;
+
+    let mut suffix = 0usize;
+    loop {
+        let file_name = if suffix == 0 {
+            format!("{name}.yaml")
+        } else {
+            format!("{name}.{suffix}.yaml")
+        };
+        let destination = backup_dir.join(file_name);
+        if !destination.exists() {
+            fs::rename(source, &destination).map_err(|error| {
+                OrbitError::Io(format!(
+                    "preserve modified retired {asset_kind} '{}' as '{}': {error}",
+                    source.display(),
+                    destination.display()
+                ))
+            })?;
+            return Ok(destination);
+        }
+        suffix += 1;
+    }
+}
+
+fn managed_asset_kind_directory(asset_kind: &str) -> String {
+    match asset_kind {
+        "activity" => "activities".to_string(),
+        "job" => "jobs".to_string(),
+        other => format!("{other}s"),
+    }
+}
+
+fn ambiguous_legacy_yaml_files(
+    dir: &Path,
+    managed_assets: &BTreeMap<String, String>,
+) -> Result<Vec<PathBuf>, OrbitError> {
+    let mut ambiguous = Vec::new();
+    let entries = fs::read_dir(dir).map_err(|error| {
+        OrbitError::Io(format!(
+            "inspect legacy managed asset directory '{}': {error}",
+            dir.display()
+        ))
+    })?;
+    for entry in entries {
+        let path = entry
+            .map_err(|error| OrbitError::Io(error.to_string()))?
+            .path();
+        let is_yaml = path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension == "yaml" || extension == "yml");
+        if !is_yaml {
+            continue;
+        }
+        let stem = path.file_stem().and_then(|stem| stem.to_str());
+        if stem.is_none_or(|stem| !managed_assets.contains_key(stem)) {
+            ambiguous.push(path);
+        }
+    }
+    ambiguous.sort();
+    Ok(ambiguous)
+}
+
+fn sha256_hex(content: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(content))
 }
 
 pub(crate) mod activity;

--- a/crates/orbit-core/src/command/tests/managed_assets.rs
+++ b/crates/orbit-core/src/command/tests/managed_assets.rs
@@ -1,0 +1,292 @@
+use std::path::Path;
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use tempfile::tempdir;
+
+use super::super::MANAGED_ASSET_MANIFEST_FILE;
+use super::super::init::{InitOptions, InitResult, init_workspace_at_root};
+use crate::OrbitRuntime;
+use crate::command::job::JobCatalogFilter;
+use crate::config::agent_detect::DetectedAgents;
+
+fn init_global(root: &Path) -> InitResult {
+    init_workspace_at_root(
+        root,
+        InitOptions {
+            global_only: true,
+            refresh_defaults: true,
+            detected: Some(DetectedAgents::default()),
+            ..Default::default()
+        },
+    )
+    .expect("initialize global defaults")
+}
+
+fn sha256(content: &str) -> String {
+    format!("{:x}", Sha256::digest(content.as_bytes()))
+}
+
+fn add_managed_manifest_entry(dir: &Path, name: &str, content: &str) {
+    let manifest_path = dir.join(MANAGED_ASSET_MANIFEST_FILE);
+    let raw = std::fs::read_to_string(&manifest_path).expect("read managed manifest");
+    let mut manifest: Value = serde_json::from_str(&raw).expect("parse managed manifest");
+    manifest["assets"]
+        .as_object_mut()
+        .expect("manifest assets object")
+        .insert(name.to_string(), Value::String(sha256(content)));
+    std::fs::write(
+        manifest_path,
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&manifest).expect("serialize managed manifest")
+        ),
+    )
+    .expect("write previous managed manifest");
+}
+
+fn activity_yaml(name: &str, tool: Option<&str>) -> String {
+    match tool {
+        Some(tool) => format!(
+            r#"schemaVersion: 2
+kind: Activity
+metadata:
+  name: {name}
+spec:
+  type: agent_loop
+  description: retired test activity
+  input_schema_json: {{type: object}}
+  output_schema_json: {{type: object}}
+  instruction: retired
+  tools: [{tool}]
+  max_iterations: 1
+"#
+        ),
+        None => format!(
+            r#"schemaVersion: 2
+kind: Activity
+metadata:
+  name: {name}
+spec:
+  type: deterministic
+  description: operator activity
+  input_schema_json: {{type: object}}
+  output_schema_json: {{type: object}}
+  action: sleep
+  config: {{}}
+"#
+        ),
+    }
+}
+
+fn job_yaml(name: &str, action: Option<&str>) -> String {
+    let steps = action.map_or_else(
+        || "  steps: []\n".to_string(),
+        |action| {
+            format!(
+                r#"  steps:
+    - id: removed
+      spec:
+        type: deterministic
+        action: {action}
+        config: {{}}
+"#
+            )
+        },
+    );
+    format!(
+        r#"schemaVersion: 2
+kind: Job
+metadata:
+  name: {name}
+spec:
+  state: enabled
+  kind: workflow
+  max_active_runs: 1
+{steps}"#
+    )
+}
+
+#[test]
+fn refresh_retires_managed_activity_and_job_assets_and_is_idempotent() {
+    let root = tempdir().expect("create tempdir");
+    let global_root = root.path().join("global");
+    let workspace_root = root.path().join("repo/.orbit");
+    init_global(&global_root);
+
+    let activities_dir = global_root.join("resources/activities");
+    let jobs_dir = global_root.join("resources/jobs");
+    let clean_activity_name = "retired_activity_clean";
+    let modified_activity_name = "retired_activity_modified";
+    let clean_job_name = "retired_job_clean";
+    let modified_job_name = "retired_job_modified";
+    let clean_activity = activity_yaml(clean_activity_name, Some("removed.tool"));
+    let original_modified_activity = activity_yaml(modified_activity_name, Some("removed.tool"));
+    let clean_job = job_yaml(clean_job_name, Some("removed_action"));
+    let original_modified_job = job_yaml(modified_job_name, Some("removed_action"));
+
+    for (dir, name, content) in [
+        (
+            &activities_dir,
+            clean_activity_name,
+            clean_activity.as_str(),
+        ),
+        (
+            &activities_dir,
+            modified_activity_name,
+            original_modified_activity.as_str(),
+        ),
+        (&jobs_dir, clean_job_name, clean_job.as_str()),
+        (&jobs_dir, modified_job_name, original_modified_job.as_str()),
+    ] {
+        add_managed_manifest_entry(dir, name, content);
+        std::fs::write(dir.join(format!("{name}.yaml")), content)
+            .expect("materialize previous managed asset");
+    }
+
+    let modified_activity = activity_yaml(modified_activity_name, Some("still.removed"));
+    let modified_job = job_yaml(modified_job_name, Some("still_removed"));
+    std::fs::write(
+        activities_dir.join(format!("{modified_activity_name}.yaml")),
+        &modified_activity,
+    )
+    .expect("locally modify retired activity");
+    std::fs::write(
+        jobs_dir.join(format!("{modified_job_name}.yaml")),
+        &modified_job,
+    )
+    .expect("locally modify retired job");
+
+    let reconciled = init_global(&global_root);
+    assert_eq!(reconciled.retired_default_activities, 2);
+    assert_eq!(reconciled.retired_default_jobs, 2);
+    assert_eq!(reconciled.managed_asset_warnings.len(), 2);
+    for warning in &reconciled.managed_asset_warnings {
+        assert!(warning.contains("locally modified"));
+        assert!(warning.contains("preserved"));
+        assert!(warning.contains("migrate"));
+    }
+
+    assert!(
+        !activities_dir
+            .join(format!("{clean_activity_name}.yaml"))
+            .exists()
+    );
+    assert!(!jobs_dir.join(format!("{clean_job_name}.yaml")).exists());
+    assert_eq!(
+        std::fs::read_to_string(global_root.join(format!(
+            "resources/.retired-managed/activities/{modified_activity_name}.yaml"
+        )))
+        .expect("read preserved modified activity"),
+        modified_activity
+    );
+    assert_eq!(
+        std::fs::read_to_string(global_root.join(format!(
+            "resources/.retired-managed/jobs/{modified_job_name}.yaml"
+        )))
+        .expect("read preserved modified job"),
+        modified_job
+    );
+
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    let runtime =
+        OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build reconciled runtime");
+    let activity_catalog = runtime
+        .v2_activity_catalog()
+        .expect("load activity catalog");
+    for retired in [clean_activity_name, modified_activity_name] {
+        assert!(
+            !activity_catalog.names().any(|name| name == retired),
+            "retired activity `{retired}` must not remain active"
+        );
+    }
+    let jobs = runtime
+        .list_job_catalog_with_last_run(true, JobCatalogFilter::All)
+        .expect("list reconciled jobs");
+    for retired in [clean_job_name, modified_job_name] {
+        assert!(
+            !jobs.iter().any(|(entry, _)| entry.job_id == retired),
+            "retired job `{retired}` must not remain active"
+        );
+    }
+
+    let repeated = init_global(&global_root);
+    assert_eq!(repeated.retired_default_activities, 0);
+    assert_eq!(repeated.retired_default_jobs, 0);
+    assert!(repeated.managed_asset_warnings.is_empty());
+}
+
+#[test]
+fn first_manifest_preserves_user_assets_and_warns_about_ambiguous_legacy_yaml() {
+    let root = tempdir().expect("create tempdir");
+    let global_root = root.path().join("global");
+    let workspace_root = root.path().join("repo/.orbit");
+    let activities_dir = global_root.join("resources/activities");
+    let jobs_dir = global_root.join("resources/jobs");
+    std::fs::create_dir_all(&activities_dir).expect("create legacy activity dir");
+    std::fs::create_dir_all(&jobs_dir).expect("create legacy job dir");
+
+    let user_activity_name = "operator_activity";
+    let user_job_name = "operator_job";
+    let user_activity = activity_yaml(user_activity_name, None);
+    let user_job = job_yaml(user_job_name, None);
+    let colliding_activity = activity_yaml("sleep", None);
+    let colliding_job = job_yaml("worktree_gc_pipeline", None);
+    std::fs::write(
+        activities_dir.join(format!("{user_activity_name}.yaml")),
+        &user_activity,
+    )
+    .expect("write user activity");
+    std::fs::write(jobs_dir.join(format!("{user_job_name}.yaml")), &user_job)
+        .expect("write user job");
+    std::fs::write(activities_dir.join("sleep.yaml"), &colliding_activity)
+        .expect("write user activity colliding with a bundled name");
+    std::fs::write(jobs_dir.join("worktree_gc_pipeline.yaml"), &colliding_job)
+        .expect("write user job colliding with a bundled name");
+
+    let migrated = init_global(&global_root);
+    assert_eq!(migrated.managed_asset_warnings.len(), 2);
+    for warning in &migrated.managed_asset_warnings {
+        assert!(warning.contains("no managed provenance"));
+        assert!(warning.contains("preserved in place"));
+        assert!(warning.contains("move or delete"));
+    }
+    assert_eq!(
+        std::fs::read_to_string(activities_dir.join(format!("{user_activity_name}.yaml")))
+            .expect("read preserved user activity"),
+        user_activity
+    );
+    assert_eq!(
+        std::fs::read_to_string(jobs_dir.join(format!("{user_job_name}.yaml")))
+            .expect("read preserved user job"),
+        user_job
+    );
+    assert_eq!(
+        std::fs::read_to_string(activities_dir.join("sleep.yaml"))
+            .expect("read preserved colliding user activity"),
+        colliding_activity
+    );
+    assert_eq!(
+        std::fs::read_to_string(jobs_dir.join("worktree_gc_pipeline.yaml"))
+            .expect("read preserved colliding user job"),
+        colliding_job
+    );
+
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    let runtime =
+        OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build migrated runtime");
+    assert!(
+        runtime
+            .v2_activity_catalog()
+            .expect("load activity catalog")
+            .names()
+            .any(|name| name == user_activity_name)
+    );
+    assert!(
+        runtime
+            .list_job_catalog_with_last_run(true, JobCatalogFilter::All)
+            .expect("list jobs")
+            .iter()
+            .any(|(entry, _)| entry.job_id == user_job_name)
+    );
+}

--- a/crates/orbit-core/src/command/tests/mod.rs
+++ b/crates/orbit-core/src/command/tests/mod.rs
@@ -1,3 +1,4 @@
 mod executor;
 mod job_pipeline;
 mod learning_authoring;
+mod managed_assets;

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -113,6 +113,34 @@ Activity resolution is likewise execution-oriented, but its directory order is e
 
 This is an intentional default-shadowing asymmetry: job *listing* is workspace-preferred, while named job execution and activity resolution keep shipped defaults authoritative over workspace resources. The split follows [L-0060] and its originating security fix [ORB-00356]: display/catalog override semantics must not make checked-in workspace YAML executable in place of a trusted shipped default. That learning is the rationale; the runtime and job catalog code are authoritative for the exact loading behavior.
 
+### 4.1 Managed materialization and retirement
+
+Global activity and job defaults materialized by `orbit init` are managed
+resources, not merely additive examples. After [ORB-10684] / [ADR-0346], each
+resource directory carries a hidden `.orbit-managed-assets.json` manifest. Its
+entry for a bundled file is the SHA-256 digest of the content Orbit last wrote;
+the manifest is therefore the ownership authority for later retirement, while
+the YAML filename alone never authorizes deletion.
+
+Refresh applies the same reconciliation to activities and jobs:
+
+- a previously managed name absent from the current embedded list is deleted
+  when its bytes still match the recorded digest;
+- a locally modified retired managed file is moved to
+  `resources/.retired-managed/{activities,jobs}/`, preserving its content while
+  keeping recursively loaded catalogs from activating it;
+- an installation without a manifest adopts only exact current bundled bytes
+  as managed; other YAML remains in place and `orbit init` warns with the paths
+  plus the manual remedy to move or delete a stale legacy file;
+- the new manifest contains only current assets whose managed ownership is
+  established, so repeating refresh is idempotent.
+
+This means a manifest-aware upgrade cannot leave a retired managed activity
+with removed tool grants—or a retired managed job with removed actions—in the
+catalog. Legacy files whose history cannot be proven remain operator-owned:
+Orbit will not guess from their names, and the warning is the recovery contract
+for installations predating managed provenance.
+
 Direct single-activity runtime helpers:
 
 1. Read YAML from disk.

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -866,8 +866,42 @@ Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.
 
 ---
 
+## ADR-0346 — Track bundled activity and job ownership by content digest before retirement
+
+**Status:** Proposed · 2026-08 · [ORB-10684]
+
+**Context.** Embedded activity and job assets are materialized into the global
+resource catalog, but an additive refresh cannot distinguish a retired bundled
+file from an operator-authored file by name alone. Filename-only pruning would
+deactivate stale shipped subsystems, but it could also destroy legitimate local
+resources on legacy installations.
+
+**Decision.** Persist a per-resource-kind managed manifest containing the
+SHA-256 digest last written for each bundled activity or job. Refresh removes
+retired files only when their bytes still match that digest, moves locally
+modified retired managed files into a non-catalog backup area, preserves
+untracked legacy YAML in place, and emits actionable recovery warnings; the
+same reconciliation implementation governs both resource kinds.
+
+**Consequences.**
+- A current release can retire assets seeded by an earlier manifest-aware
+  release without leaving them active in catalog construction.
+- Existing installations without a manifest migrate safely: exact current
+  bundled bytes gain provenance, while untracked YAML remains active and is
+  named in a manual-recovery warning.
+- Locally modified retired assets remain recoverable outside active catalog
+  directories instead of breaking unrelated catalog/list operations.
+- Cost: managed manifests and preserved-retirement backups add local state and
+  make the first legacy refresh potentially require operator review before an
+  ambiguous stale file can be removed.
+
+---
+
 ## Task References
 
+- **[ORB-10684]** — Reconcile retired managed activity and job assets by
+  content provenance while preserving modified and ambiguous legacy files
+  ([ADR-0346], Proposed).
 - **[ORB-10644]** — Refuse to open or promote a PR against a base branch that is gone from `origin` or has already landed on the declared landing branch ([ADR-0336], extending [ADR-0290]'s marker rule to the base itself).
 - **[ORB-10593]** — Fail dispatch immediately when a `blocked_by` target is archived, rejected, or dangling, naming the blocker ([ADR-0319]).
 - **[ORB-10544]** — Move the ship in-flight duplicate-dispatch guard into `submit_ship_run` so HTTP and MCP are thin projections of one typed conflict ([ADR-0303], correcting the surface-local check from [ADR-0257]).

--- a/docs/runbooks/state-and-backup.md
+++ b/docs/runbooks/state-and-backup.md
@@ -49,7 +49,8 @@ precedence). Path layout is defined in
 | `orbit.db` (+ `-wal`, `-shm`) | **the** store DB: audit events (`audit_events`, `v2_audit_events`), job runs + checkpoints (`job_runs`, `job_run_steps`), task reservations, ADR/learning indexes, host registry (`hosts`, `host_aliases`, `workspace_ownership`, `host_workspace_presence`, `workspace_execution_profiles`, `hub_registry_metadata`), `schema_meta` migration ledger | **authoritative** (history is not derivable) |
 | `tasks/index.sqlite` | global task-ID allocator + registry index | regenerable (`orbit task reindex`) |
 | `tasks/workspaces/<ws-id>/<task-id>/` | canonical task bundles (survive repo moves) | **authoritative** |
-| `resources/`, `skills/` | default activity/job/executor/policy defs, skills | regenerable (`orbit init` reseeds) |
+| `resources/activities/`, `resources/jobs/` | managed defaults plus operator-authored activity/job YAML; hidden manifests retain managed content provenance | mixed: current defaults are regenerable, but untracked YAML and `resources/.retired-managed/` backups are **authoritative until reviewed** |
+| other `resources/`, `skills/` | default executor/policy defs and skills | regenerable (`orbit init` reseeds) |
 | `state/logs/orbit.jsonl` (+ rotated archives) | unified JSONL log sink for all Orbit processes | disposable |
 | `embed/` | semantic-search companion binary + models | regenerable (`orbit semantic install`) |
 | `bin/` | installed Orbit binary (when installed via `install.sh`) | reinstallable |
@@ -68,6 +69,16 @@ precedence). Path layout is defined in
 > parses again. A malformed registry present *at server startup* is still fatal — fix the file
 > before launching. See [remote-access design §2.1](../design/remote-access/2_design.md) and
 > [ADR-0234](../design/remote-access/4_decisions.md).
+
+> **Managed activity/job refresh (ORB-10684 / ADR-0346).** `orbit init` records
+> the digest it wrote for each bundled activity and job in the resource
+> directory's `.orbit-managed-assets.json`. A later refresh deletes a retired
+> file only when it still matches that digest. Locally modified retired files
+> move to `resources/.retired-managed/{activities,jobs}/`, outside active
+> catalogs; back up and review those files as operator data. On a legacy root
+> with no manifest, non-matching YAML stays in place and init names it in a
+> warning. Move or delete only the named stale file after confirming it came
+> from an older release, then rerun `orbit init` and the affected list command.
 
 ### Retired graph state and task selectors
 
@@ -111,7 +122,8 @@ in git use a selective pattern instead, keeping DBs, locks, and runtime state ou
   `graph/` and `knowledge/graph/` locations. If the repo commits ADRs and learnings through the
   selective gitignore, git already backs those up.
 - **Global root:** `~/.orbit/config.toml`, `workspaces.json`, `tasks/` (canonical bundles),
-  and `orbit.db`. The database holds non-derivable audit and run history.
+  `orbit.db`, and `resources/` whenever it contains operator-authored YAML or
+  `.retired-managed/` recovery copies. The database holds non-derivable audit and run history.
 - **Safe to lose or regenerate:** retired `graph/` and `knowledge/graph/`, `state/semantic.db`,
   `tasks/index.sqlite`, `~/.orbit/embed/`, `~/.orbit/state/logs/`, scoreboard counters.
 


### PR DESCRIPTION
## Task

[ORB-10684](https://orbit-cli.com/tasks/ORB-10684) — Reconcile retired managed activity and job assets without deleting user-authored resources

### Description

## Problem

`seed_embedded_assets` is additive: it writes current bundled activity/job YAML but never retires previously materialized managed files that were removed from the embedded lists. Removed subsystems therefore remain live after upgrade, and stale assets can make unrelated catalog construction fail when they reference tools that no longer exist.

## Why It Matters

Source-level subsystem deletion does not take effect on initialized installations. Manual point deletion regresses when later refreshes re-seed stale materialized state, while an unsafe filename-only prune could destroy legitimate operator-authored resources.

## Constraints / Notes

- Reconcile only resources whose managed/bundled provenance is unambiguous; preserve user-authored and locally modified files.
- The solution must be safe for existing installations that lack any new provenance metadata.
- Apply the contract consistently to activity and job assets and document any warning/manual-recovery path for ambiguous legacy files.
- Use deterministic temporary-directory tests; do not rely on a developer's live `.orbit` state.
- The source defect was originally filed as Polaris coordination task ORB-10670; this is the owning-workspace successor.

### Acceptance Criteria

- A deterministic upgrade test proves that a previously managed activity/job asset removed from the embedded list is no longer active after the supported refresh/init path.
- Deterministic tests prove that user-authored assets and locally modified former bundled assets are preserved unless managed ownership is unambiguous; ambiguous legacy files produce an actionable warning or documented manual-recovery result.
- The reconciliation is idempotent and applies consistently to both activity and job resources.
- After reconciliation, catalog construction and list commands do not load a retired managed asset that references a removed tool.
- The managed-asset ownership/provenance and retirement behavior is documented in the relevant design or operator documentation.
- `make ci-fast`, focused orbit-core tests for seeding/reconciliation, and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added one shared SHA-256 managed-asset manifest and reconciliation path for embedded activities and jobs. Refresh now removes byte-identical retired managed files, moves locally modified retired managed files to `resources/.retired-managed/{activities,jobs}/`, preserves untracked/user-authored YAML, and emits actionable warnings for ambiguous legacy provenance or bundled-name collisions.
- Propagated refreshed/retired counts and warnings through `InitResult` and the `orbit init` CLI so operators can see automated retirements and manual-recovery paths.
- Added deterministic temp-directory upgrade coverage for activity and job retirement, modified-file preservation, untracked and bundled-name-colliding user assets, idempotence, and post-refresh activity/job catalog exclusion of assets that reference removed capabilities.
- Documented ownership, retirement, backup, and legacy recovery behavior in the Activity/Job design and state/backup runbook. Allocated ADR-0346 for the content-provenance decision; it remains Proposed because managed-run executors are intentionally denied ADR lifecycle transitions.

Strategic decisions:
- Content digests, never filenames alone, authorize destructive retirement. Modified managed assets are preserved outside recursively loaded catalog roots so they cannot keep a removed subsystem active.
- Legacy roots adopt only exact current bundled bytes as managed; ambiguous YAML remains operator-owned and requires the warning's manual review path.

Deviations from original plan:
- Expanded scope to `command/init.rs`, the CLI init projection, a sibling managed-assets test module, the Activity/Job decision log, and the state/backup runbook. Justification: these are the tightly coupled refresh result, operator warning, deterministic acceptance coverage, ADR citation, and backup semantics required by the change.

Validation:
- `cargo test -p orbit-core managed_assets -- --nocapture` (2 passed)
- `cargo test -p orbit-core seeded_deterministic_activities_match_actions` (passed)
- `cargo test -p orbit-core default_job_target_refs_resolve_against_default_activities` (passed)
- `make ci-fast` (passed after final documentation edits)
- `make ci-lint` (workspace/all-target clippy passed with warnings denied)
- `git diff --check 1db64748791a68af29eb20c43c598eb2b4eb7be1` (passed)

Assessment: The implementation is symmetric for activities/jobs, safe for manifest-aware and legacy installations, idempotent, and prevents retired managed resources from entering catalog/list construction while preserving operator content.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10684-6a78f3e5`
- Behind base: 0
- Ahead of base: 1