### PR TITLE
Serve MCP over a network transport with per-session isolation

### DIFF
--- a/crates/orbit-mcp/src/adapter/dispatch.rs
+++ b/crates/orbit-mcp/src/adapter/dispatch.rs
@@ -156,13 +156,16 @@ impl OrbitToolServer {
         }
     }
 
-    pub(super) fn replace_session_context(&self, session_context: ToolSessionContext) {
+    // Crate-visible so the session-isolation tests can observe and overwrite
+    // exactly the state `initialize` mutates, from the crate-root module that
+    // owns per-session construction.
+    pub(crate) fn replace_session_context(&self, session_context: ToolSessionContext) {
         if let Ok(mut guard) = self.session_context.write() {
             *guard = session_context;
         }
     }
 
-    pub(super) fn session_context(&self) -> ToolSessionContext {
+    pub(crate) fn session_context(&self) -> ToolSessionContext {
         self.session_context
             .read()
             .map(|guard| guard.clone())

--- a/crates/orbit-mcp/src/lib.rs
+++ b/crates/orbit-mcp/src/lib.rs
@@ -16,12 +16,18 @@
 //! domain policy belongs in higher-level composition crates.
 //!
 //! # Transport
-//! Only stdio is supported in this cut. HTTP/SSE/streamable-http transports
-//! are follow-up work once authentication is in scope.
+//! Stdio and TCP are supported. The protocol handler performs no IO, so the
+//! two transports share framing, dispatch, and capability filtering unchanged;
+//! they differ only in how a byte stream arrives and in how many sessions one
+//! server process owns. HTTP/SSE/streamable-http remain follow-up work.
+//! Authenticating a network endpoint is the deployment's concern, not this
+//! crate's — see [`McpTcpServer`].
 
 mod adapter;
 mod client;
 mod error;
+mod session;
+mod tcp;
 
 use std::future::Future;
 use std::pin::Pin;
@@ -38,6 +44,8 @@ pub use adapter::OrbitToolServer;
 pub use client::{
     McpClientInitialization, McpClientRequestError, McpToolResponse, RawOrbitMcpClient,
 };
+pub use session::McpSessionFactory;
+pub use tcp::{McpTcpServer, serve_tcp_with_context_and_composition};
 
 /// Complete JSON input schema advertised for one MCP tool.
 pub type McpInputSchema = Map<String, Value>;
@@ -454,6 +462,10 @@ pub trait McpHost: Send + Sync + 'static {
 /// Runs until the client disconnects or the server encounters a fatal
 /// transport error. The function is async and expects to be driven by a tokio
 /// runtime (see `tokio::runtime::Runtime::block_on`).
+///
+/// A stdio process serves exactly one client for its lifetime, so these entry
+/// points build one server and keep it. Use [`McpTcpServer`] when more than one
+/// client can arrive, since that server must not be shared.
 pub async fn serve_stdio(host: Arc<dyn McpHost>) -> Result<(), OrbitError> {
     serve_stdio_with_context(host, ToolSessionContext::trusted_local(None, None, None)).await
 }

--- a/crates/orbit-mcp/src/session.rs
+++ b/crates/orbit-mcp/src/session.rs
@@ -1,0 +1,78 @@
+//! Per-session server construction for transports that serve more than one
+//! client from a single listener.
+
+use std::sync::Arc;
+
+use orbit_common::types::ToolSessionContext;
+
+use crate::{McpHost, McpServerComposition, OrbitToolServer};
+
+/// Builds one independent [`OrbitToolServer`] per MCP session.
+///
+/// # Why sessions are not shared
+///
+/// The adapter's session state is mutable and is written during `initialize`:
+/// the client's announced workspace selector is installed on the server
+/// instance that handled the request, and every later `tools/list` and
+/// `tools/call` on that instance reads it back. A stdio server has exactly one
+/// client for its lifetime, so a single instance is correct there. A listener
+/// does not: two clients sharing one instance would race on that selector, and
+/// the loser would receive a successful response computed against the other
+/// client's workspace. That is silent wrong data, not an error, so isolation is
+/// established by construction rather than defended after the fact — a session
+/// is handed a server nobody else holds.
+///
+/// # Capability
+///
+/// The effective capability set is whatever the caller placed in
+/// `trusted_context`; this type neither supplies nor widens one. Nothing a
+/// client sends can change it: `initialize` overwrites only the legacy
+/// workspace selector, and the per-call resolver derives its context from the
+/// session's trusted values.
+///
+/// Cloning is cheap — the host is shared behind an `Arc`, and a composition
+/// holds `Arc`-shaped registrations — so building a session per connection is
+/// an accept-path-appropriate cost.
+#[derive(Clone)]
+pub struct McpSessionFactory {
+    host: Arc<dyn McpHost>,
+    trusted_context: ToolSessionContext,
+    composition: McpServerComposition,
+}
+
+impl McpSessionFactory {
+    /// Capture the host, trusted session template, and composition every
+    /// session is built from.
+    pub fn new(
+        host: Arc<dyn McpHost>,
+        trusted_context: ToolSessionContext,
+        composition: McpServerComposition,
+    ) -> Self {
+        Self {
+            host,
+            trusted_context,
+            composition,
+        }
+    }
+
+    /// Construct a server owned by exactly one session.
+    ///
+    /// The trusted template is copied rather than shared, and the correlation
+    /// identifiers are cleared so the adapter mints a fresh origin session id
+    /// per session: a listener-wide id would collapse concurrent clients into
+    /// one audit identity.
+    pub fn build_session(&self) -> OrbitToolServer {
+        let mut context = self.trusted_context.clone();
+        context.origin_session_id = None;
+        context.mcp_call_id = None;
+        OrbitToolServer::new_with_context_and_composition(
+            Arc::clone(&self.host),
+            context,
+            self.composition.clone(),
+        )
+    }
+}
+
+#[cfg(test)]
+#[path = "tests/session.rs"]
+mod tests;

--- a/crates/orbit-mcp/src/tcp.rs
+++ b/crates/orbit-mcp/src/tcp.rs
@@ -1,0 +1,116 @@
+//! TCP listener transport for the MCP kernel.
+//!
+//! The protocol handler performs no IO of its own, so serving it over a socket
+//! is only a question of where the byte stream comes from and who owns the
+//! session behind it. Framing, dispatch, capability filtering, and the trusted
+//! session envelope are shared verbatim with stdio.
+
+use std::io::ErrorKind;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use orbit_common::types::{OrbitError, ToolSessionContext};
+use rmcp::ServiceExt;
+use tokio::net::{TcpListener, TcpStream};
+
+use crate::session::McpSessionFactory;
+use crate::{McpHost, McpServerComposition, OrbitToolServer};
+
+/// A bound MCP endpoint that serves each accepted connection as its own
+/// session.
+///
+/// The endpoint carries no authentication of its own: it serves the trusted
+/// local session context it was constructed with to whoever reaches the socket,
+/// so restricting who can reach it (loopback bind, unix-level firewalling, an
+/// authenticating proxy) is the deployment's responsibility. Bind to loopback
+/// unless the deployment has taken that on.
+pub struct McpTcpServer {
+    listener: TcpListener,
+    factory: McpSessionFactory,
+}
+
+impl McpTcpServer {
+    /// Bind the endpoint without accepting anything yet.
+    ///
+    /// Binding is separated from accepting so a caller can learn the assigned
+    /// address (notably when binding port 0) before connections start arriving.
+    pub async fn bind(addr: SocketAddr, factory: McpSessionFactory) -> Result<Self, OrbitError> {
+        let listener = TcpListener::bind(addr)
+            .await
+            .map_err(|error| OrbitError::Execution(format!("mcp tcp bind {addr}: {error}")))?;
+        Ok(Self { listener, factory })
+    }
+
+    /// The address actually bound, including the kernel-assigned port.
+    pub fn local_addr(&self) -> Result<SocketAddr, OrbitError> {
+        self.listener
+            .local_addr()
+            .map_err(|error| OrbitError::Execution(format!("mcp tcp local address: {error}")))
+    }
+
+    /// Accept connections until the listener fails.
+    ///
+    /// Each connection is served on its own task with its own server instance,
+    /// so one client's initialize, workspace selection, and name map are
+    /// unreachable from another's. A session that dies takes nothing else down
+    /// with it.
+    pub async fn serve(self) -> Result<(), OrbitError> {
+        loop {
+            let (stream, peer) = match self.listener.accept().await {
+                Ok(accepted) => accepted,
+                // A connection that died between the SYN and our accept is the
+                // remote's problem, not the listener's; anything else means the
+                // listener itself is no longer usable and spinning on it would
+                // just burn the accept loop.
+                Err(error) if is_transient_accept_error(&error) => {
+                    tracing::warn!(error = %error, "mcp tcp accept skipped a connection");
+                    continue;
+                }
+                Err(error) => {
+                    return Err(OrbitError::Execution(format!("mcp tcp accept: {error}")));
+                }
+            };
+            let server = self.factory.build_session();
+            tokio::spawn(serve_connection(server, stream, peer));
+        }
+    }
+}
+
+/// Bind and serve MCP over TCP from a complete generic server composition.
+///
+/// The trusted session context — including its effective capability set — is
+/// the caller's to choose; there is deliberately no capability-free convenience
+/// form of this entry point.
+pub async fn serve_tcp_with_context_and_composition(
+    addr: SocketAddr,
+    host: Arc<dyn McpHost>,
+    trusted_context: ToolSessionContext,
+    composition: McpServerComposition,
+) -> Result<(), OrbitError> {
+    let factory = McpSessionFactory::new(host, trusted_context, composition);
+    McpTcpServer::bind(addr, factory).await?.serve().await
+}
+
+async fn serve_connection(server: OrbitToolServer, stream: TcpStream, peer: SocketAddr) {
+    let running = match server.serve(stream).await {
+        Ok(running) => running,
+        Err(error) => {
+            tracing::warn!(peer = %peer, error = %error, "mcp tcp session did not start");
+            return;
+        }
+    };
+    if let Err(error) = running.waiting().await {
+        tracing::warn!(peer = %peer, error = %error, "mcp tcp session ended with an error");
+    }
+}
+
+fn is_transient_accept_error(error: &std::io::Error) -> bool {
+    matches!(
+        error.kind(),
+        ErrorKind::ConnectionAborted | ErrorKind::ConnectionReset | ErrorKind::Interrupted
+    )
+}
+
+#[cfg(test)]
+#[path = "tests/tcp.rs"]
+mod tests;

--- a/crates/orbit-mcp/src/tests/session.rs
+++ b/crates/orbit-mcp/src/tests/session.rs
@@ -1,0 +1,89 @@
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use orbit_common::types::{McpCapability, McpToolDefinition, OrbitError, ToolSessionContext};
+use serde_json::Value;
+
+use crate::{McpHost, McpServerComposition, McpSessionFactory};
+
+struct SilentHost;
+
+impl McpHost for SilentHost {
+    fn list_mcp_tool_definitions(&self) -> Result<Vec<McpToolDefinition>, OrbitError> {
+        Ok(Vec::new())
+    }
+
+    fn call_tool(
+        &self,
+        _name: &str,
+        _input: Value,
+        _session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
+        Ok(Value::Null)
+    }
+}
+
+fn factory(trusted: ToolSessionContext) -> McpSessionFactory {
+    McpSessionFactory::new(
+        Arc::new(SilentHost) as Arc<dyn McpHost>,
+        trusted,
+        McpServerComposition::new(),
+    )
+}
+
+#[test]
+fn one_session_workspace_selection_is_invisible_to_another() {
+    let factory = factory(ToolSessionContext::trusted_local(None, None, None));
+
+    let first = factory.build_session();
+    let second = factory.build_session();
+
+    // This is exactly what `initialize` writes: the announced legacy selector,
+    // installed on the server handling that request.
+    let mut announced = first.session_context();
+    announced.workspace = Some("/tmp/first-workspace".to_string());
+    first.replace_session_context(announced);
+
+    assert_eq!(
+        first.session_context().workspace.as_deref(),
+        Some("/tmp/first-workspace")
+    );
+    assert_eq!(second.session_context().workspace, None);
+}
+
+#[test]
+fn every_session_gets_its_own_origin_session_id() {
+    let mut trusted = ToolSessionContext::trusted_local(None, None, None);
+    // A listener-wide correlation id must not survive into per-session state,
+    // or concurrent clients would share one audit identity.
+    trusted.origin_session_id = Some("listener-wide".to_string());
+    let factory = factory(trusted);
+
+    let first = factory.build_session().session_context();
+    let second = factory.build_session().session_context();
+
+    assert!(first.origin_session_id.is_some());
+    assert!(second.origin_session_id.is_some());
+    assert_ne!(first.origin_session_id, second.origin_session_id);
+    assert_ne!(
+        first.origin_session_id.as_deref(),
+        Some("listener-wide"),
+        "the template's correlation id must not be reused per session"
+    );
+    assert_eq!(first.mcp_call_id, None);
+}
+
+#[test]
+fn sessions_carry_the_caller_selected_capability_set_verbatim() {
+    let mut trusted = ToolSessionContext::trusted_local(None, None, None);
+    trusted.effective_capabilities = BTreeSet::from([McpCapability::Runner]);
+    let factory = factory(trusted);
+
+    let session = factory.build_session().session_context();
+
+    assert_eq!(
+        session.effective_capabilities,
+        BTreeSet::from([McpCapability::Runner]),
+        "the factory neither supplies nor widens a capability set"
+    );
+}

--- a/crates/orbit-mcp/src/tests/tcp.rs
+++ b/crates/orbit-mcp/src/tests/tcp.rs
@@ -1,0 +1,63 @@
+use std::io::{Error, ErrorKind};
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use orbit_common::types::{McpToolDefinition, OrbitError, ToolSessionContext};
+use serde_json::Value;
+
+use super::{McpTcpServer, is_transient_accept_error};
+use crate::{McpHost, McpServerComposition, McpSessionFactory};
+
+struct SilentHost;
+
+impl McpHost for SilentHost {
+    fn list_mcp_tool_definitions(&self) -> Result<Vec<McpToolDefinition>, OrbitError> {
+        Ok(Vec::new())
+    }
+
+    fn call_tool(
+        &self,
+        _name: &str,
+        _input: Value,
+        _session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
+        Ok(Value::Null)
+    }
+}
+
+fn factory() -> McpSessionFactory {
+    McpSessionFactory::new(
+        Arc::new(SilentHost) as Arc<dyn McpHost>,
+        ToolSessionContext::trusted_local(None, None, None),
+        McpServerComposition::new(),
+    )
+}
+
+#[tokio::test]
+async fn bind_reports_the_kernel_assigned_port() {
+    let requested = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+    let server = McpTcpServer::bind(requested, factory())
+        .await
+        .expect("bind loopback");
+
+    let bound = server.local_addr().expect("bound address");
+
+    assert_eq!(bound.ip(), requested.ip());
+    assert_ne!(bound.port(), 0, "an ephemeral bind must resolve to a port");
+}
+
+#[test]
+fn only_per_connection_accept_failures_are_transient() {
+    for kind in [
+        ErrorKind::ConnectionAborted,
+        ErrorKind::ConnectionReset,
+        ErrorKind::Interrupted,
+    ] {
+        assert!(is_transient_accept_error(&Error::new(kind, "peer")));
+    }
+    // A listener-level failure must end the accept loop rather than spin on it.
+    assert!(!is_transient_accept_error(&Error::new(
+        ErrorKind::InvalidInput,
+        "listener"
+    )));
+}

--- a/crates/orbit-mcp/tests/mcp_tcp_transport.rs
+++ b/crates/orbit-mcp/tests/mcp_tcp_transport.rs
@@ -1,0 +1,399 @@
+//! Wire-level proof that the TCP transport isolates sessions and advertises
+//! the same surface stdio does.
+#![allow(missing_docs)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::BTreeSet;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::{Arc, Mutex};
+
+use orbit_common::types::{
+    McpCapability, McpToolDefinition, McpToolPlacement, McpToolPolicy, OrbitError, ToolParam,
+    ToolSchema, ToolSessionContext,
+};
+use orbit_mcp::{
+    McpHost, McpServerComposition, McpServerMetadata, McpSessionFactory, McpTcpServer,
+    OrbitToolServer,
+};
+use rmcp::ServiceExt;
+use rmcp::model::{CallToolRequestParams, CallToolResult, ClientInfo, Meta, Tool};
+use serde_json::{Map, Value, json};
+use tokio::io::duplex;
+use tokio::net::TcpStream;
+
+const CONTRACT_INSTRUCTIONS: &str = "Orbit hub contract v1. Call tools/list before dispatching.";
+
+/// A host with one agent-visible tool and one operator-only tool, so a session
+/// holding only the agent capability exercises both the hidden-from-listing and
+/// the refused-on-call paths.
+struct CapabilityHost {
+    contexts: Mutex<Vec<ToolSessionContext>>,
+}
+
+impl CapabilityHost {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            contexts: Mutex::new(Vec::new()),
+        })
+    }
+
+    fn observed_workspaces(&self) -> Vec<Option<String>> {
+        self.contexts
+            .lock()
+            .expect("observed contexts")
+            .iter()
+            .map(|context| context.workspace.clone())
+            .collect()
+    }
+}
+
+fn definition(name: &str, capability: McpCapability) -> McpToolDefinition {
+    McpToolDefinition::new(
+        ToolSchema {
+            name: name.to_string(),
+            description: "Fixture tool.".to_string(),
+            parameters: vec![ToolParam {
+                name: "value".to_string(),
+                description: "Value to echo.".to_string(),
+                param_type: "string".to_string(),
+                required: true,
+            }],
+            builtin: false,
+        },
+        McpToolPolicy::new(McpToolPlacement::LocalDerived, [capability]).expect("fixture policy"),
+    )
+    .expect("fixture definition")
+}
+
+impl McpHost for CapabilityHost {
+    fn list_mcp_tool_definitions(&self) -> Result<Vec<McpToolDefinition>, OrbitError> {
+        Ok(vec![
+            definition("demo.echo", McpCapability::Agent),
+            definition("demo.operate", McpCapability::Operator),
+        ])
+    }
+
+    fn call_tool(
+        &self,
+        name: &str,
+        input: Value,
+        context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
+        if !matches!(name, "demo.echo" | "demo.operate") {
+            return Err(OrbitError::not_found(
+                orbit_common::types::NotFoundKind::Tool,
+                name.to_string(),
+            ));
+        }
+        self.contexts
+            .lock()
+            .expect("observed contexts")
+            .push(context.clone());
+        Ok(json!({
+            "tool": name,
+            "echo": input.get("value"),
+            "workspace": context.workspace,
+            "capabilities": context
+                .effective_capabilities
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+        }))
+    }
+}
+
+fn composition() -> McpServerComposition {
+    McpServerComposition::new()
+        .with_metadata(McpServerMetadata::default().with_instructions(CONTRACT_INSTRUCTIONS))
+}
+
+fn trusted_context(capability: McpCapability) -> ToolSessionContext {
+    let mut context = ToolSessionContext::trusted_local(None, None, None);
+    context.effective_capabilities = BTreeSet::from([capability]);
+    context
+}
+
+fn factory(host: Arc<CapabilityHost>, capability: McpCapability) -> McpSessionFactory {
+    McpSessionFactory::new(host, trusted_context(capability), composition())
+}
+
+/// Bind a listener on an ephemeral loopback port and start accepting.
+async fn start_endpoint(
+    host: Arc<CapabilityHost>,
+    capability: McpCapability,
+) -> (SocketAddr, tokio::task::JoinHandle<Result<(), OrbitError>>) {
+    let server = McpTcpServer::bind(
+        SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+        factory(host, capability),
+    )
+    .await
+    .expect("bind loopback endpoint");
+    let addr = server.local_addr().expect("bound address");
+    (addr, tokio::spawn(server.serve()))
+}
+
+fn client_info(meta: Option<Value>) -> ClientInfo {
+    let mut info = ClientInfo::default();
+    info.meta = meta.map(|meta| {
+        Meta(
+            meta.as_object()
+                .expect("initialize metadata is an object")
+                .clone(),
+        )
+    });
+    info
+}
+
+fn workspace_meta(workspace: &str) -> Value {
+    json!({ "orbit": { "workspace": workspace } })
+}
+
+fn call(name: &str, args: Value) -> CallToolRequestParams {
+    let arguments: Map<String, Value> = args
+        .as_object()
+        .expect("tool arguments are an object")
+        .clone();
+    CallToolRequestParams::new(name.to_string()).with_arguments(arguments)
+}
+
+fn advertised(tools: &[Tool]) -> Vec<(String, Value)> {
+    let mut surface = tools
+        .iter()
+        .map(|tool| {
+            (
+                tool.name.to_string(),
+                Value::Object((*tool.input_schema).clone()),
+            )
+        })
+        .collect::<Vec<_>>();
+    surface.sort_by(|left, right| left.0.cmp(&right.0));
+    surface
+}
+
+fn error_payload(result: &CallToolResult) -> Value {
+    assert_eq!(result.is_error, Some(true), "expected a refusal");
+    result
+        .structured_content
+        .clone()
+        .expect("structured error payload")
+}
+
+#[tokio::test]
+async fn concurrent_tcp_clients_never_observe_another_session_workspace() {
+    let host = CapabilityHost::new();
+    let (addr, endpoint) = start_endpoint(Arc::clone(&host), McpCapability::Agent).await;
+
+    // Both clients complete `initialize` before either calls a tool. On a
+    // server whose session state is shared across connections, the second
+    // initialize overwrites the first client's workspace selection and the
+    // first client's call then succeeds against the wrong workspace — wrong
+    // data returned as a success, which is what this ordering catches.
+    let alpha = client_info(Some(workspace_meta("/tmp/alpha")))
+        .serve(TcpStream::connect(addr).await.expect("connect alpha"))
+        .await
+        .expect("initialize alpha");
+    let beta = client_info(Some(workspace_meta("/tmp/beta")))
+        .serve(TcpStream::connect(addr).await.expect("connect beta"))
+        .await
+        .expect("initialize beta");
+
+    let alpha_result = alpha
+        .peer()
+        .call_tool(call("demo_echo", json!({ "value": "a" })))
+        .await
+        .expect("alpha tools/call");
+    let beta_result = beta
+        .peer()
+        .call_tool(call("demo_echo", json!({ "value": "b" })))
+        .await
+        .expect("beta tools/call");
+
+    assert_eq!(
+        alpha_result.structured_content.as_ref().unwrap()["workspace"],
+        json!("/tmp/alpha")
+    );
+    assert_eq!(
+        beta_result.structured_content.as_ref().unwrap()["workspace"],
+        json!("/tmp/beta")
+    );
+
+    let mut observed = host.observed_workspaces();
+    observed.sort();
+    assert_eq!(
+        observed,
+        vec![
+            Some("/tmp/alpha".to_string()),
+            Some("/tmp/beta".to_string())
+        ]
+    );
+
+    endpoint.abort();
+}
+
+#[tokio::test]
+async fn tcp_advertises_and_refuses_exactly_as_stdio_does() {
+    let host = CapabilityHost::new();
+    let (addr, endpoint) = start_endpoint(Arc::clone(&host), McpCapability::Agent).await;
+
+    // The stdio entry points construct this server and hand it the process's
+    // standard streams; only the byte source differs from the socket below.
+    let stdio_server = OrbitToolServer::new_with_context_and_composition(
+        Arc::clone(&host) as Arc<dyn McpHost>,
+        trusted_context(McpCapability::Agent),
+        composition(),
+    );
+    let (client_io, server_io) = duplex(64 * 1024);
+    let stdio_task = tokio::spawn(async move {
+        let service = stdio_server.serve(server_io).await.expect("serve stdio");
+        service.waiting().await.expect("stdio session");
+    });
+
+    let over_tcp = client_info(Some(workspace_meta("/tmp/parity")))
+        .serve(TcpStream::connect(addr).await.expect("connect tcp"))
+        .await
+        .expect("initialize over tcp");
+    let over_stdio = client_info(Some(workspace_meta("/tmp/parity")))
+        .serve(client_io)
+        .await
+        .expect("initialize over stdio");
+
+    let tcp_tools = over_tcp
+        .peer()
+        .list_tools(Default::default())
+        .await
+        .expect("tcp tools/list");
+    let stdio_tools = over_stdio
+        .peer()
+        .list_tools(Default::default())
+        .await
+        .expect("stdio tools/list");
+
+    assert_eq!(advertised(&tcp_tools.tools), advertised(&stdio_tools.tools));
+    assert_eq!(
+        advertised(&tcp_tools.tools)
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect::<Vec<_>>(),
+        vec!["demo_echo".to_string()],
+        "the operator-only tool is filtered out of an agent session's listing"
+    );
+
+    // Hidden by capability: reached by name, refused identically on both.
+    let tcp_denied = over_tcp
+        .peer()
+        .call_tool(call("demo_operate", json!({ "value": "x" })))
+        .await
+        .expect("tcp refusal is a structured result");
+    let stdio_denied = over_stdio
+        .peer()
+        .call_tool(call("demo_operate", json!({ "value": "x" })))
+        .await
+        .expect("stdio refusal is a structured result");
+    assert_eq!(error_payload(&tcp_denied), error_payload(&stdio_denied));
+    assert_eq!(
+        error_payload(&tcp_denied)["code"],
+        json!("capability_denied")
+    );
+
+    // Not a tool at all: same classification on both.
+    let tcp_missing = over_tcp
+        .peer()
+        .call_tool(call("demo_absent", json!({})))
+        .await
+        .expect("tcp unknown-name result");
+    let stdio_missing = over_stdio
+        .peer()
+        .call_tool(call("demo_absent", json!({})))
+        .await
+        .expect("stdio unknown-name result");
+    assert_eq!(error_payload(&tcp_missing), error_payload(&stdio_missing));
+    assert_eq!(error_payload(&tcp_missing)["code"], json!("tool_not_found"));
+
+    assert_eq!(
+        over_tcp
+            .peer_info()
+            .expect("tcp initialize result")
+            .instructions
+            .as_deref(),
+        Some(CONTRACT_INSTRUCTIONS),
+        "composition instructions survive the network initialize"
+    );
+    assert_eq!(
+        over_tcp
+            .peer_info()
+            .expect("tcp initialize result")
+            .instructions,
+        over_stdio
+            .peer_info()
+            .expect("stdio initialize result")
+            .instructions
+    );
+
+    endpoint.abort();
+    stdio_task.abort();
+}
+
+#[tokio::test]
+async fn client_announced_metadata_cannot_widen_session_capability() {
+    let host = CapabilityHost::new();
+    let (addr, endpoint) = start_endpoint(Arc::clone(&host), McpCapability::Agent).await;
+
+    let escalating = client_info(Some(json!({
+        "orbit": {
+            "workspace": "/tmp/escalate",
+            "capabilities": ["operator", "runner"],
+            "effective_capabilities": ["operator"],
+            "caller_machine_id": "attacker-machine",
+            "transport": "hub",
+        },
+        "orbit.capabilities": ["operator"],
+    })))
+    .serve(TcpStream::connect(addr).await.expect("connect"))
+    .await
+    .expect("initialize");
+
+    let listed = escalating
+        .peer()
+        .list_tools(Default::default())
+        .await
+        .expect("tools/list");
+    assert_eq!(
+        listed
+            .tools
+            .iter()
+            .map(|tool| tool.name.to_string())
+            .collect::<Vec<_>>(),
+        vec!["demo_echo".to_string()]
+    );
+
+    let denied = escalating
+        .peer()
+        .call_tool(call("demo_operate", json!({ "value": "x" })))
+        .await
+        .expect("structured refusal");
+    assert_eq!(error_payload(&denied)["code"], json!("capability_denied"));
+
+    let permitted = escalating
+        .peer()
+        .call_tool(call("demo_echo", json!({ "value": "x" })))
+        .await
+        .expect("tools/call");
+    let observed = permitted.structured_content.expect("structured result");
+    assert_eq!(observed["capabilities"], json!(["agent"]));
+    assert_eq!(
+        observed["workspace"],
+        json!("/tmp/escalate"),
+        "the announced workspace selector is the only field a client controls"
+    );
+
+    let recorded = host.contexts.lock().expect("observed contexts");
+    let context = recorded.last().expect("one recorded call");
+    assert_eq!(context.caller_machine_id, None);
+    assert_eq!(
+        context.transport,
+        ToolSessionContext::trusted_local(None, None, None).transport
+    );
+
+    drop(recorded);
+    endpoint.abort();
+}

--- a/docs/design/mcp-session-context/2_design.md
+++ b/docs/design/mcp-session-context/2_design.md
@@ -3,7 +3,7 @@ summary: "MCP Session Context — Design"
 type: design
 title: "MCP Session Context — Design"
 owner: codex
-last_updated: 2026-07-26
+last_updated: 2026-08-09
 last_validated: 2026-08-08
 status: Accepted
 feature: mcp-session-context
@@ -11,7 +11,7 @@ doc_role: design
 tags: ["mcp-session-context", "mcp", "workspace"]
 paths: ["crates/orbit-mcp/**", "crates/orbit-remote/src/mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool/**"]
 related_features: ["mcp-session-context", "task-artifacts"]
-related_artifacts: ["ORB-00256", "ORB-10228", "ORB-10262", "ORB-10319", "ORB-10448", "ADR-0181", "ADR-0199", "ADR-0149"]
+related_artifacts: ["ORB-00256", "ORB-10228", "ORB-10262", "ORB-10319", "ORB-10448", "ORB-10690", "ADR-0181", "ADR-0199", "ADR-0149", "ADR-0348"]
 ---
 
 # MCP Session Context — Design
@@ -38,7 +38,9 @@ Clients announce workspace with:
 
 ## 2. Storage And Thread-Through
 
-`OrbitToolServer` stores a `ToolSessionContext` in an `RwLock` for the lifetime of the stdio session. Each `tools/call` snapshots that context, generates exactly one unique `mcp_call_id` before name/exposure preflight, and passes the same snapshot through registry-backed dispatch.
+`OrbitToolServer` stores a `ToolSessionContext` in an `RwLock` for the lifetime of one session. Each `tools/call` snapshots that context, generates exactly one unique `mcp_call_id` before name/exposure preflight, and passes the same snapshot through registry-backed dispatch.
+
+That state is per session, not per process. A stdio server serves exactly one client for its lifetime, so the two coincide there; a listener does not. `McpSessionFactory::build_session` therefore constructs one `OrbitToolServer` per session, and `McpTcpServer` hands each accepted connection its own. Sharing one server across connections would let the last client to `initialize` overwrite every other client's workspace selector and return another workspace's data as a success. [ADR-0348], [ORB-10690]
 
 The Remote-owned `BrokerMcpHost` resolves and validates the logical workspace plus any exact local checkout before constructing or selecting an `OrbitRuntime`, then forwards the trusted context into `OrbitRuntime::execute_tool_command_dispatch_with_session_context`, which places it on `ToolContext` and audit. Unknown/unexposed denial and runtime success/failure retain the same per-call context. `orbit-cli` only delegates `mcp serve` into this composition. Graph commands have no MCP or CLI surface as of ORB-10357.
 
@@ -103,7 +105,7 @@ The trusted context carries the entire effective capability set. [ORB-10262] tes
 
 ## 6. Concerns & Honest Limitations
 
-The session context currently covers stdio sessions; future HTTP or multi-session transports must preserve the same per-session isolation rather than promoting the value to process-global state.
+The session context covers stdio and TCP sessions. [ORB-10690] established per-session isolation for the multi-client case; any future HTTP transport must go through the same session-construction seam rather than promoting the value to process-global state. The TCP endpoint carries no authentication of its own — reachability is the deployment's concern — and its capability set is chosen by the caller that starts it, never by the client.
 
 The external channel carries a workspace address, not a trusted workspace ID. The local broker validates an absolute path against Git common-directory identity, `.orbit/config.yaml`, the logical registry, local role, and owner before separately populating `workspace_id`. Process cwd and `ORBIT_ROOT` are not fallbacks. Hub-link negotiation remains a later MCP Bridge unit.
 
@@ -114,5 +116,6 @@ The external channel carries a workspace address, not a trusted workspace ID. Th
 - [ORB-10262] implemented exact-checkout workspace resolution, placement preflight, capability enforcement, and runtime caching by exact binding.
 - [ORB-10319] moved broker/session resolution and MCP composition into the vertical `orbit-remote` feature crate while leaving runtime audit/dispatch in Core.
 - [ORB-10448] advertised the workspace selector on every workspace-scoped tool and routed hub-placement coordination reads by checkout identity, making the [ADR-0181] "clients that cannot send initialize metadata pass `workspace` explicitly" path reachable from a managed worktree activity.
+- [ORB-10690] added the TCP transport and moved session construction behind `McpSessionFactory` so concurrent clients cannot observe or overwrite each other's session context ([ADR-0348]).
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-session-context/4_decisions.md
+++ b/docs/design/mcp-session-context/4_decisions.md
@@ -3,7 +3,7 @@ summary: "MCP Session Context — Decisions"
 type: design
 title: "MCP Session Context — Decisions"
 owner: codex
-last_updated: 2026-08-01
+last_updated: 2026-08-09
 last_validated: 2026-08-08
 status: Accepted
 feature: mcp-session-context
@@ -11,7 +11,7 @@ doc_role: decisions
 tags: ["mcp-session-context", "mcp", "workspace"]
 paths: ["crates/orbit-mcp/**", "crates/orbit-remote/src/mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool/**"]
 related_features: ["mcp-session-context", "task-artifacts"]
-related_artifacts: ["ORB-00256", "ORB-00406", "ORB-10228", "ORB-10262", "ORB-10319", "ORB-10448", "ADR-0181", "ADR-0199", "ADR-0149"]
+related_artifacts: ["ORB-00256", "ORB-00406", "ORB-10228", "ORB-10262", "ORB-10319", "ORB-10448", "ORB-10690", "ADR-0181", "ADR-0199", "ADR-0149", "ADR-0348"]
 ---
 
 # MCP Session Context — Decisions
@@ -34,10 +34,17 @@ Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.
 
 Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.show --input '{"id":"ADR-0199"}'`.
 
+## ADR-0348 — Serve MCP over TCP with one server instance per session
+
+**Status:** Proposed · 2026-08 · [ORB-10690]
+
+Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.show --input '{"id":"ADR-0348"}'`.
+
 ## Task References
 
 - [ORB-00256] implemented MCP ambient workspace session context.
 - [ORB-00406] proposes workspace_path-addressable host tools ([ADR-0199]).
+- [ORB-10690] added the MCP TCP transport with per-session server construction ([ADR-0348]).
 - [ORB-10228] accepted and implemented the trusted-provenance amendment to [ADR-0181].
 - [ORB-10262] accepted and implemented ADR-0199 through the exact-checkout local broker.
 - [ORB-10319] consolidated the broker/session implementation in `orbit-remote`; it does not change ADR-0181 or ADR-0199 semantics.


### PR DESCRIPTION
## Task

[ORB-10690](https://orbit-cli.com/tasks/ORB-10690) — Serve MCP over a network transport with per-session isolation

### Description

Orbit's MCP protocol handling is transport-agnostic — the server handler performs no IO — but the crate binds only stdio. A client that is not a local child process therefore cannot reach the MCP surface at all, and remote consumers enter through the dashboard HTTP API instead, which sits below both MCP capability filtering and the governed-operation role check. Operator-classified tools end up simultaneously unreachable by their intended caller and unenforced on the path actually in use.

Add a network transport to the MCP crate alongside stdio. ADR-0347 records the decision and the rejected alternatives.

Constraints:

- Session state currently lives on the shared server struct and is mutated during initialize. A network listener serves concurrent clients, so this state must not be shared between them: one client's workspace selection must never be observable to, or overwritable by, another. This is a correctness precondition and must be designed in — the failure mode is wrong data returned successfully, not an error. The server composition is cheap to clone, so per-session construction should be inexpensive.
- The protocol and dispatch layers should not need restructuring. If they do, the seam chosen is probably the wrong one.
- Hub/spoke remote-session semantics are out of scope. Do not add a transport discriminant variant and do not accept client-asserted caller identity; the endpoint serves trusted-local session context. Note that existing transport checks compare the discriminant by equality rather than exhaustively, so a new variant would compile cleanly while behaving wrong.
- Network authentication is the deployment's concern, not this crate's.
- Capability is selected by the caller that starts the server and must not default to the most privileged value.

Known pre-existing condition: do not attempt to repair unrelated failing tests encountered in these crates.

### Acceptance Criteria

- Two concurrent clients that announce different workspace selectors each observe only their own selection; neither can affect the other's.
- For a given capability, the advertised tool surface is identical between stdio and the network transport, and a tool that is hidden or not permitted produces the same refusal on both.
- The contract instructions carried at initialize survive the new transport intact.
- Capability cannot be escalated by anything the client sends.
- The crate builds and the change carries its own tests, including a concurrency test that fails against shared session state.
- No new crate dependency edge is introduced.

## Execution Summary

<details>
<summary>Click to expand</summary>

Added a TCP listener transport to `orbit-mcp` alongside stdio, seamed at session construction so the protocol and dispatch layers are untouched. ADR-0348 (proposed) records the decision and rejected alternatives — note the allocator returned 0348, not the 0347 named in the task description; the allocation is authority per CONVENTIONS §4.

**Implementation**

- `crates/orbit-mcp/src/session.rs` (new) — `McpSessionFactory` holds the host, a trusted `ToolSessionContext` template, and the cloneable `McpServerComposition`; `build_session()` returns an owned `OrbitToolServer` per session. It clears `origin_session_id`/`mcp_call_id` from the template so the adapter mints a fresh origin id per session rather than collapsing concurrent clients into one audit identity.
- `crates/orbit-mcp/src/tcp.rs` (new) — `McpTcpServer::bind`/`local_addr`/`serve` plus `serve_tcp_with_context_and_composition`. Bind is separate from accept so a caller (and the tests) can read the assigned port. Each accepted connection gets its own server on its own task. Per-connection accept failures (`ConnectionAborted`/`ConnectionReset`/`Interrupted`) are logged and skipped; any other accept error ends the loop instead of spinning on it.
- `crates/orbit-mcp/src/lib.rs` — module wiring, `McpSessionFactory`/`McpTcpServer`/`serve_tcp_with_context_and_composition` re-exports, and updated crate + stdio transport docs.
- `crates/orbit-mcp/src/adapter/dispatch.rs` — the only dispatch-layer change: `session_context`/`replace_session_context` widened from `pub(super)` to `pub(crate)` so the crate-root isolation tests can observe and write exactly the state `initialize` mutates. No behavior change.

**Constraints honored**

- No transport discriminant variant added; sessions stay `trusted_local`. No client-asserted caller identity is accepted — `initialize` still overwrites only the legacy `workspace` selector.
- Capability is taken verbatim from the caller-supplied trusted context. There is deliberately no capability-free network entry point, so nothing defaults to a privileged value.
- No new crate dependency edge: only `orbit-common` + `rmcp` as before. `tokio::net` was already enabled by the workspace tokio features, and rmcp's existing `transport-io` feature supplies `IntoTransport` for `TcpStream` directly. `check-dependency-direction.sh` passes.

**Tests**

- `crates/orbit-mcp/tests/mcp_tcp_transport.rs` (new, 3 tests): concurrent-client isolation over real sockets; stdio/TCP surface + refusal parity (identical `tools/list` output, byte-identical `capability_denied` and `tool_not_found` payloads, matching initialize instructions); and a capability-escalation attempt via initialize `_meta` that leaves the session at `{agent}` with only the workspace selector applied.
- `crates/orbit-mcp/src/tests/session.rs`, `src/tests/tcp.rs` (new, 5 tests): per-session context independence, fresh origin ids, verbatim capability set, ephemeral bind, accept-error classification.
- The concurrency test was verified to actually catch the regression: with `session_context` temporarily backed by a process-shared `Arc<RwLock<..>>`, `concurrent_tcp_clients_never_observe_another_session_workspace` fails with the first client receiving `/tmp/beta` instead of `/tmp/alpha` — a successful response carrying another session's workspace, which is the exact failure mode. The temporary change was reverted.

**Docs** — `docs/design/mcp-session-context/2_design.md` §2 now states the per-session (not per-process) rule and §6 replaces the stale "stdio only" limitation; `4_decisions.md` carries the ADR-0348 pointer. Frontmatter `last_updated`/`related_artifacts` bumped on both.

**Validation** — `cargo test -p orbit-mcp` 48 passed / 0 failed; `make ci-fast` clean; `make ci-lint` clean (exit 0). `make ci-fast` initially aborted because `node`, `rg`, and `cargo` were not on the runner's default PATH; re-run with them on PATH and it passes fully.

**Runner denial (not a code failure)** — every local `orbit` CLI invocation fails in this worktree with `write managed activity asset manifest '~/.orbit/resources/activities/.orbit-managed-assets.json': Read-only file system (os error 30)`, because the runner leaves `~/.orbit/resources` read-only while `reconcile_managed_assets` hard-fails at command startup. This blocks reads too, and disabling the agent sandbox does not change it. ADR allocation, this update, and friction filing went through the bridge MCP surface instead. Filed as F2026-08-055 with a suggested fail-open fix.

**Not done (out of scope)** — no CLI/`orbit-remote` entry point wires the endpoint yet; no acceptance criterion asked for one and adding a serving surface with deployment-level auth implications is a separate decision. The crate API is the deliverable.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10690-6a78fe8c`
- Behind base: 0
- Ahead of base: 1