### PR TITLE
Expose the MCP network endpoint from the long-running server process

### DIFF
--- a/.orbit/adrs/proposed/ADR-0349/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0349/adr.yaml
@@ -1,0 +1,23 @@
+schema_version: 2
+id: ADR-0349
+title: Host Streamable HTTP MCP on the dashboard listener
+status: proposed
+owner: codex
+created_at: 2026-08-09T22:58:44.842499189Z
+last_updated: 2026-08-09T22:58:44.842499189Z
+related_features:
+- mcp-session-context
+related_tasks:
+- ORB-10691
+tags:
+- mcp
+- transport
+- dashboard
+paths:
+- crates/orbit-dashboard/src/**/*.rs
+- crates/orbit-remote/src/mcp/**/*.rs
+- crates/orbit-mcp/src/**/*.rs
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/proposed/ADR-0349/body.md
+++ b/.orbit/adrs/proposed/ADR-0349/body.md
@@ -1,0 +1,10 @@
+## Context
+Orbit needs a network MCP endpoint with incremental streaming and graceful session shutdown. The existing dashboard is the only long-running HTTP process and already owns loopback binding, Axum routing, and shutdown; alternatives were a second daemon or a separate raw-TCP port in the dashboard process.
+
+## Decision
+Mount a stateful Streamable HTTP MCP service at `/mcp` on the dashboard Axum listener. Keep it outside the `/api` router browser-origin middleware, retain loopback-only binding and MCP Host validation, select one trusted capability at process start, and cancel all MCP sessions before Axum drains HTTP connections.
+
+## Consequences
+- MCP and dashboard traffic share one listener and lifecycle while retaining separate request middleware.
+- Reverse proxies remain responsible for authentication and may buffer otherwise-correct origin streaming; deployment-path streaming needs separate verification.
+- Cost: the dashboard process now owns MCP availability, so dashboard restarts interrupt MCP sessions and shutdown wiring must coordinate both transports.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,8 +1134,20 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2159,6 +2182,7 @@ dependencies = [
  "orbit-common",
  "orbit-core",
  "orbit-remote",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2555,6 +2579,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2572,6 +2602,17 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2611,6 +2652,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -2792,18 +2839,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
 dependencies = [
  "async-trait",
+ "bytes",
  "chrono",
  "futures",
+ "http",
+ "http-body",
+ "http-body-util",
  "pastey",
  "pin-project-lite",
+ "rand 0.10.2",
  "schemars",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -3205,6 +3260,19 @@ dependencies = [
  "nom 7.1.3",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3867,6 +3935,7 @@ version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/crates/orbit-cli/src/command/mcp/command.rs
+++ b/crates/orbit-cli/src/command/mcp/command.rs
@@ -31,7 +31,7 @@ pub enum McpSubcommand {
     Init(InitArgs),
     /// Remove MCP client integration for the current workspace
     Remove(RemoveArgs),
-    /// Serve the Orbit tool registry over Model Context Protocol
+    /// Serve the Orbit tool registry over Model Context Protocol on stdio
     Serve(ServeArgs),
 }
 
@@ -50,7 +50,7 @@ impl Execute for McpSubcommand {
 }
 
 #[derive(Args)]
-#[command(about = "Serve the Orbit tool registry over Model Context Protocol")]
+#[command(about = "Serve the Orbit tool registry over Model Context Protocol on stdio")]
 pub struct ServeArgs {
     /// Serve only checkoutless coordination tools as the fixed local hub.
     #[arg(long)]

--- a/crates/orbit-cli/src/command/tests/mod.rs
+++ b/crates/orbit-cli/src/command/tests/mod.rs
@@ -155,10 +155,12 @@ fn cli_parses_broker_capability_and_rejects_unknown_values() {
 
 #[test]
 fn cli_parses_web_serve() {
-    let cli = Cli::parse_from(["orbit", "web", "serve"]);
+    let cli = Cli::parse_from(["orbit", "web", "serve", "--capabilities", "operator"]);
     match cli.command {
         Commands::Web(command) => match command.command {
-            WebSubcommand::Serve(_) => {}
+            WebSubcommand::Serve(args) => {
+                assert_eq!(args.capabilities, Some(McpCapability::Operator));
+            }
             WebSubcommand::Connect(_) => panic!("expected serve"),
         },
         _ => panic!("expected top-level web command"),

--- a/crates/orbit-dashboard/Cargo.toml
+++ b/crates/orbit-dashboard/Cargo.toml
@@ -29,6 +29,7 @@ url.workspace = true
 
 [dev-dependencies]
 orbit-common = { path = "../orbit-common", features = ["test-util"] }
+reqwest.workspace = true
 serde_yaml.workspace = true
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/orbit-dashboard/src/lib.rs
+++ b/crates/orbit-dashboard/src/lib.rs
@@ -1,4 +1,4 @@
-//! `orbit-dashboard` — read-only web dashboard and JSON API server.
+//! `orbit-dashboard` — dashboard, JSON API, and network MCP server.
 //!
 //! This crate isolates the axum-based dashboard (HTML/JS assets + `/api/*`
 //! handlers) from orbit-cli so that CLI changes do not force rebuilds of the
@@ -27,15 +27,16 @@ pub use connect::{ConnectArgs, connect};
 use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::{future::Future, io};
 
 use axum::Router;
 use axum::http::{HeaderValue, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use clap::Args;
-use orbit_common::types::{WorkspaceRegistry, WorkspaceStatus};
+use orbit_common::types::{McpCapability, WorkspaceRegistry, WorkspaceStatus};
 use orbit_core::{OrbitError, OrbitRuntime};
-use orbit_remote::workspace_registry;
+use orbit_remote::{McpHttpServerControl, mcp_http_service, workspace_registry};
 
 const INDEX_HTML: &str = include_str!("../assets/dashboard/index.html");
 const DASHBOARD_CSS: &str = include_str!("../assets/dashboard/dashboard.css");
@@ -73,7 +74,7 @@ pub(crate) const DEFAULT_DASHBOARD_PORT: u16 = 7878;
 
 /// Arguments for `orbit web serve` (and the library entry point).
 #[derive(Args, Clone)]
-#[command(about = "Run the Orbit dashboard")]
+#[command(about = "Run the Orbit dashboard and network MCP endpoint")]
 pub struct ServeArgs {
     /// Host or IP to bind to. Defaults to loopback for safety.
     #[arg(long, default_value = "127.0.0.1")]
@@ -94,6 +95,11 @@ pub struct ServeArgs {
     /// — removing it would break tunnels against an old/new binary mix.
     #[arg(long)]
     pub global: bool,
+
+    /// Exact non-hierarchical capability exposed by the MCP endpoint.
+    /// Defaults to the least-privileged agent surface.
+    #[arg(long, value_name = "CAPABILITY")]
+    pub capabilities: Option<McpCapability>,
 }
 
 /// Boot the dashboard for a single, already-built runtime and block until
@@ -220,27 +226,7 @@ fn run_server(args: &ServeArgs, state: state::DashboardState) -> Result<(), Orbi
     let addr = SocketAddr::new(args.host, args.port);
     let url = format!("http://{addr}");
     let no_open = args.no_open;
-
-    let app = Router::new()
-        .route("/", get(serve_index))
-        .route("/static/dashboard.css", get(serve_dashboard_css))
-        .route("/static/marked.umd.js", get(serve_marked_js))
-        .route("/static/purify.min.js", get(serve_purify_js))
-        .route("/static/app.js", get(serve_app_js))
-        .route("/static/common.js", get(serve_common_js))
-        .route("/static/markdown.js", get(serve_markdown_js))
-        .route("/static/tasks.js", get(serve_tasks_js))
-        .route("/static/audit.js", get(serve_audit_js))
-        .route("/static/scoreboard.js", get(serve_scoreboard_js))
-        .route("/static/reliability.js", get(serve_reliability_js))
-        .route("/static/log-tail.js", get(serve_log_tail_js))
-        .route("/static/diagnostics.js", get(serve_diagnostics_js))
-        .route("/static/router.js", get(serve_router_js))
-        .route("/static/runs.js", get(serve_runs_js))
-        .route("/static/run-detail.js", get(serve_run_detail_js))
-        .route("/healthz", get(health::healthz))
-        .nest("/api", api::router())
-        .with_state(state);
+    let (app, mcp_control) = build_app(state, args.capabilities)?;
 
     let tokio_runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -261,13 +247,63 @@ fn run_server(args: &ServeArgs, state: state::DashboardState) -> Result<(), Orbi
             open_browser(&url);
         }
 
-        axum::serve(listener, app)
-            .with_graceful_shutdown(shutdown_signal())
-            .await
-            .map_err(|e| OrbitError::Execution(format!("serve: {e}")))?;
-
-        Ok::<(), OrbitError>(())
+        serve_listener(listener, app, mcp_control, shutdown_signal()).await
     })
+}
+
+fn build_app(
+    state: state::DashboardState,
+    capability: Option<McpCapability>,
+) -> Result<(Router, McpHttpServerControl), OrbitError> {
+    let (mcp_service, mcp_control) =
+        mcp_http_service(state.global_root().to_path_buf(), capability)?;
+    let app = Router::new()
+        .route("/", get(serve_index))
+        .route("/static/dashboard.css", get(serve_dashboard_css))
+        .route("/static/marked.umd.js", get(serve_marked_js))
+        .route("/static/purify.min.js", get(serve_purify_js))
+        .route("/static/app.js", get(serve_app_js))
+        .route("/static/common.js", get(serve_common_js))
+        .route("/static/markdown.js", get(serve_markdown_js))
+        .route("/static/tasks.js", get(serve_tasks_js))
+        .route("/static/audit.js", get(serve_audit_js))
+        .route("/static/scoreboard.js", get(serve_scoreboard_js))
+        .route("/static/reliability.js", get(serve_reliability_js))
+        .route("/static/log-tail.js", get(serve_log_tail_js))
+        .route("/static/diagnostics.js", get(serve_diagnostics_js))
+        .route("/static/router.js", get(serve_router_js))
+        .route("/static/runs.js", get(serve_runs_js))
+        .route("/static/run-detail.js", get(serve_run_detail_js))
+        .route("/healthz", get(health::healthz))
+        // ADR-0349: MCP clients are not browser API callers. Keep this route
+        // outside `/api` so it never inherits browser-origin middleware.
+        .nest_service("/mcp", mcp_service)
+        .nest("/api", api::router())
+        .with_state(state);
+    Ok((app, mcp_control))
+}
+
+async fn serve_listener<F>(
+    listener: tokio::net::TcpListener,
+    app: Router,
+    mcp_control: McpHttpServerControl,
+    shutdown: F,
+) -> Result<(), OrbitError>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let shutdown_control = mcp_control.clone();
+    let result = axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            shutdown.await;
+            // Cancel sessions before Axum waits for open response bodies to
+            // drain, or a long-lived MCP SSE stream can stall shutdown.
+            shutdown_control.cancel();
+        })
+        .await;
+    // Also cancel if the listener itself exits before the shutdown signal.
+    mcp_control.cancel();
+    result.map_err(|e: io::Error| OrbitError::Execution(format!("serve: {e}")))
 }
 
 /// Reject binding the dashboard to anything other than a loopback address.

--- a/crates/orbit-dashboard/src/state.rs
+++ b/crates/orbit-dashboard/src/state.rs
@@ -373,6 +373,7 @@ impl DashboardState {
     /// used by [`crate::serve`] and by every handler test (which builds an
     /// in-memory runtime and wants a trivial single-workspace harness).
     pub(crate) fn single(runtime: Arc<OrbitRuntime>) -> Self {
+        let global_root = runtime.global_root().to_path_buf();
         let entry = WsEntry {
             id: SINGLE_WORKSPACE_ID.to_string(),
             name: SINGLE_WORKSPACE_ID.to_string(),
@@ -400,7 +401,7 @@ impl DashboardState {
             },
         );
         Self::from_parts(
-            PathBuf::new(),
+            global_root,
             SnapshotData {
                 entries: vec![entry],
                 default_workspace: Some(SINGLE_WORKSPACE_ID.to_string()),
@@ -485,10 +486,10 @@ impl DashboardState {
         self.inner.snapshot().entries.clone()
     }
 
-    /// Global orbit root (`~/.orbit`) this server was launched against. Empty
-    /// in single mode ([`DashboardState::single`]). Host-level views (routine
-    /// scheduler health) read from here rather than any one workspace runtime,
-    /// because routine fires live in the global store.
+    /// Global orbit root (`~/.orbit`) this server was launched against.
+    /// Host-level views (routine scheduler health and MCP composition) read
+    /// from here rather than any one workspace runtime, because their state
+    /// lives in the global store.
     pub(crate) fn global_root(&self) -> &std::path::Path {
         &self.inner.global_root
     }

--- a/crates/orbit-dashboard/src/tests/mcp.rs
+++ b/crates/orbit-dashboard/src/tests/mcp.rs
@@ -1,0 +1,278 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::time::Duration;
+
+use chrono::Utc;
+use orbit_common::types::{McpCapability, Workspace, WorkspaceRegistry, WorkspaceStatus};
+use orbit_remote::workspace_registry;
+use reqwest::header::{ACCEPT, CONTENT_TYPE, HeaderMap, ORIGIN};
+use serde_json::{Value, json};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+
+use super::super::{build_app, serve_listener};
+use crate::state::DashboardState;
+
+const EXTERNAL_ORIGIN: &str = "https://mcp-client.example";
+const MCP_ACCEPT: &str = "application/json, text/event-stream";
+const WORKSPACE_ID: &str = "mcp-dashboard-test";
+
+struct TestServer {
+    _root: tempfile::TempDir,
+    base_url: String,
+    shutdown: Option<oneshot::Sender<()>>,
+    task: JoinHandle<Result<(), orbit_core::OrbitError>>,
+}
+
+impl TestServer {
+    async fn start(capability: Option<McpCapability>) -> Self {
+        let root = tempfile::tempdir().expect("temp root");
+        let global_root = root.path().join("global");
+        std::fs::create_dir_all(&global_root).expect("global root");
+        workspace_registry::save_registry_to(
+            &WorkspaceRegistry {
+                workspaces: vec![Workspace {
+                    id: WORKSPACE_ID.to_string(),
+                    name: "MCP dashboard test".to_string(),
+                    owner_machine_id: None,
+                    git_remote: None,
+                    ship_mode: None,
+                    base_branch: "agent-main".to_string(),
+                    status: WorkspaceStatus::Active,
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                }],
+                ..WorkspaceRegistry::default()
+            },
+            &workspace_registry::registry_path_for(&global_root),
+        )
+        .expect("workspace registry");
+        let state = DashboardState::global(global_root, Vec::new(), None);
+        let (app, mcp_control) = build_app(state, capability).expect("dashboard app");
+        let listener =
+            tokio::net::TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+                .await
+                .expect("bind test listener");
+        let addr = listener.local_addr().expect("listener address");
+        let (shutdown, shutdown_rx) = oneshot::channel();
+        let task = tokio::spawn(serve_listener(listener, app, mcp_control, async move {
+            let _ = shutdown_rx.await;
+        }));
+        Self {
+            _root: root,
+            base_url: format!("http://{addr}"),
+            shutdown: Some(shutdown),
+            task,
+        }
+    }
+
+    fn signal_shutdown(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+    }
+
+    async fn wait(mut self) {
+        self.signal_shutdown();
+        timeout(Duration::from_secs(2), self.task)
+            .await
+            .expect("server stops promptly")
+            .expect("server task joins")
+            .expect("server exits cleanly");
+    }
+}
+
+async fn post_mcp(
+    client: &reqwest::Client,
+    base_url: &str,
+    session_id: Option<&str>,
+    message: Value,
+) -> (HeaderMap, Value) {
+    let mut request = client
+        .post(format!("{base_url}/mcp"))
+        .header(ACCEPT, MCP_ACCEPT)
+        .header(CONTENT_TYPE, "application/json")
+        .header(ORIGIN, EXTERNAL_ORIGIN)
+        .json(&message);
+    if let Some(session_id) = session_id {
+        request = request.header("mcp-session-id", session_id);
+    }
+    let response = request.send().await.expect("MCP response");
+    assert!(
+        response.status().is_success(),
+        "status: {}",
+        response.status()
+    );
+    let headers = response.headers().clone();
+    let body = response.text().await.expect("MCP response body");
+    let message = body
+        .lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .find_map(|data| serde_json::from_str(data).ok())
+        .unwrap_or_else(|| panic!("MCP SSE response contained no JSON message: {body}"));
+    (headers, message)
+}
+
+async fn initialize(client: &reqwest::Client, base_url: &str) -> String {
+    let (headers, response) = post_mcp(
+        client,
+        base_url,
+        None,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "orbit-dashboard-test", "version": "1"},
+                "_meta": {"orbit": {"workspace": WORKSPACE_ID}}
+            }
+        }),
+    )
+    .await;
+    assert_eq!(response["id"], 1);
+    let session_id = headers
+        .get("mcp-session-id")
+        .and_then(|value| value.to_str().ok())
+        .expect("initialize session id")
+        .to_string();
+
+    let response = client
+        .post(format!("{base_url}/mcp"))
+        .header(ACCEPT, MCP_ACCEPT)
+        .header(CONTENT_TYPE, "application/json")
+        .header(ORIGIN, EXTERNAL_ORIGIN)
+        .header("mcp-session-id", &session_id)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        }))
+        .send()
+        .await
+        .expect("initialized notification");
+    assert!(response.status().is_success());
+    session_id
+}
+
+#[tokio::test]
+async fn network_mcp_round_trip_keeps_origin_policy_and_default_capability_isolated() {
+    let server = TestServer::start(None).await;
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("HTTP client");
+    let session_id = initialize(&client, &server.base_url).await;
+
+    let (_, listed) = post_mcp(
+        &client,
+        &server.base_url,
+        Some(&session_id),
+        json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}),
+    )
+    .await;
+    let names = listed["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .filter_map(|tool| tool["name"].as_str())
+        .collect::<Vec<_>>();
+    assert!(names.contains(&"orbit_friction_tags"));
+    assert!(
+        !names.contains(&"orbit_workspace_list"),
+        "no explicit capability must not expose operator-only tools"
+    );
+
+    let (_, called) = post_mcp(
+        &client,
+        &server.base_url,
+        Some(&session_id),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "orbit_friction_tags", "arguments": {}}
+        }),
+    )
+    .await;
+    assert_eq!(called["id"], 3);
+    assert_eq!(called["result"]["isError"], false);
+    assert!(called["result"]["structuredContent"].is_object());
+
+    let api_response = client
+        .post(format!("{}/api/tasks", server.base_url))
+        .header(ORIGIN, EXTERNAL_ORIGIN)
+        .json(&json!({}))
+        .send()
+        .await
+        .expect("API response");
+    assert_eq!(api_response.status(), reqwest::StatusCode::FORBIDDEN);
+
+    server.wait().await;
+}
+
+#[tokio::test]
+async fn explicit_operator_capability_changes_the_advertised_surface() {
+    let server = TestServer::start(Some(McpCapability::Operator)).await;
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("HTTP client");
+    let session_id = initialize(&client, &server.base_url).await;
+    let (_, listed) = post_mcp(
+        &client,
+        &server.base_url,
+        Some(&session_id),
+        json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}),
+    )
+    .await;
+    let names = listed["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .filter_map(|tool| tool["name"].as_str())
+        .collect::<Vec<_>>();
+    assert!(names.contains(&"orbit_workspace_list"));
+    server.wait().await;
+}
+
+#[tokio::test]
+async fn mcp_stream_arrives_before_completion_and_shutdown_closes_the_session() {
+    let mut server = TestServer::start(Some(McpCapability::Agent)).await;
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("HTTP client");
+    let session_id = initialize(&client, &server.base_url).await;
+
+    let mut stream = client
+        .get(format!("{}/mcp", server.base_url))
+        .header(ACCEPT, "text/event-stream")
+        .header(ORIGIN, EXTERNAL_ORIGIN)
+        .header("mcp-session-id", &session_id)
+        .send()
+        .await
+        .expect("open MCP stream");
+    assert!(stream.status().is_success());
+    let first = timeout(Duration::from_secs(1), stream.chunk())
+        .await
+        .expect("stream emits before completion")
+        .expect("stream read")
+        .expect("priming chunk");
+    assert!(
+        !first.is_empty(),
+        "an open response must yield an incremental SSE frame"
+    );
+
+    server.signal_shutdown();
+    timeout(Duration::from_secs(2), async {
+        while stream.chunk().await.expect("stream read").is_some() {}
+    })
+    .await
+    .expect("MCP stream closes during shutdown");
+    timeout(Duration::from_secs(2), server.task)
+        .await
+        .expect("server stops with an MCP session open")
+        .expect("server task joins")
+        .expect("server exits cleanly");
+}

--- a/crates/orbit-dashboard/src/tests/mod.rs
+++ b/crates/orbit-dashboard/src/tests/mod.rs
@@ -4,6 +4,7 @@ mod connect;
 mod dashboard_assets;
 mod health;
 mod log_format;
+mod mcp;
 mod parse;
 mod serve;
 mod state;

--- a/crates/orbit-dashboard/src/tests/state.rs
+++ b/crates/orbit-dashboard/src/tests/state.rs
@@ -37,8 +37,10 @@ fn checkout(id: &str, root: &str) -> WorkspaceCheckout {
 #[test]
 fn single_mode_exposes_one_default_workspace() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let global_root = runtime.global_root().to_path_buf();
     let state = DashboardState::single(Arc::new(runtime));
 
+    assert_eq!(state.global_root(), global_root);
     assert_eq!(state.entries().len(), 1);
     assert_eq!(state.default_workspace().as_deref(), Some("default"));
     assert!(state.runtime_for("default").is_ok());

--- a/crates/orbit-mcp/Cargo.toml
+++ b/crates/orbit-mcp/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 orbit-common = { path = "../orbit-common" }
-rmcp = { version = "1.5", default-features = false, features = ["client", "server", "transport-io"] }
+rmcp = { version = "1.5", default-features = false, features = ["client", "server", "transport-io", "transport-streamable-http-server"] }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/orbit-mcp/src/http.rs
+++ b/crates/orbit-mcp/src/http.rs
@@ -1,0 +1,51 @@
+//! Streamable HTTP service construction for an embedding HTTP server.
+
+use std::sync::Arc;
+
+use rmcp::transport::streamable_http_server::{
+    StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+};
+
+use crate::{McpSessionFactory, OrbitToolServer};
+
+/// Tower service implementing stateful MCP Streamable HTTP.
+pub type McpStreamableHttpService = StreamableHttpService<OrbitToolServer, LocalSessionManager>;
+
+/// Cancellation handle for every session owned by one HTTP service.
+///
+/// The embedding server must cancel this before waiting for its HTTP listener
+/// to drain. Otherwise an open MCP SSE stream can keep graceful shutdown alive
+/// indefinitely.
+#[derive(Clone)]
+pub struct McpHttpServerControl {
+    cancel: Arc<dyn Fn() + Send + Sync>,
+}
+
+impl McpHttpServerControl {
+    /// Stop accepting MCP requests and terminate every active session.
+    pub fn cancel(&self) {
+        (self.cancel)();
+    }
+}
+
+/// Build a stateful Streamable HTTP service with one isolated MCP server per
+/// session and a handle that participates in the embedding server's shutdown.
+///
+/// The rmcp default retains DNS-rebinding protection by accepting only
+/// loopback `Host` authorities. Origin policy is deliberately left to the
+/// embedding router: MCP clients are not browsers and may send any `Origin`.
+pub fn streamable_http_service(
+    factory: McpSessionFactory,
+) -> (McpStreamableHttpService, McpHttpServerControl) {
+    let config = StreamableHttpServerConfig::default();
+    let cancellation_token = config.cancellation_token.clone();
+    let control = McpHttpServerControl {
+        cancel: Arc::new(move || cancellation_token.cancel()),
+    };
+    let service = StreamableHttpService::new(
+        move || Ok(factory.build_session()),
+        Arc::new(LocalSessionManager::default()),
+        config,
+    );
+    (service, control)
+}

--- a/crates/orbit-mcp/src/lib.rs
+++ b/crates/orbit-mcp/src/lib.rs
@@ -16,16 +16,17 @@
 //! domain policy belongs in higher-level composition crates.
 //!
 //! # Transport
-//! Stdio and TCP are supported. The protocol handler performs no IO, so the
-//! two transports share framing, dispatch, and capability filtering unchanged;
-//! they differ only in how a byte stream arrives and in how many sessions one
-//! server process owns. HTTP/SSE/streamable-http remain follow-up work.
+//! Stdio, TCP, and Streamable HTTP are supported. The protocol handler performs
+//! no IO, so the transports share framing, dispatch, and capability filtering
+//! unchanged; they differ only in how a byte stream arrives and in how many
+//! sessions one server process owns.
 //! Authenticating a network endpoint is the deployment's concern, not this
-//! crate's — see [`McpTcpServer`].
+//! crate's — see [`McpTcpServer`] and [`McpStreamableHttpService`].
 
 mod adapter;
 mod client;
 mod error;
+mod http;
 mod session;
 mod tcp;
 
@@ -44,6 +45,7 @@ pub use adapter::OrbitToolServer;
 pub use client::{
     McpClientInitialization, McpClientRequestError, McpToolResponse, RawOrbitMcpClient,
 };
+pub use http::{McpHttpServerControl, McpStreamableHttpService, streamable_http_service};
 pub use session::McpSessionFactory;
 pub use tcp::{McpTcpServer, serve_tcp_with_context_and_composition};
 

--- a/crates/orbit-remote/src/lib.rs
+++ b/crates/orbit-remote/src/lib.rs
@@ -50,8 +50,10 @@ pub use host_identity::{
 pub use host_registry::{HostRegistryService, WorkspaceLink, require_local_hub_identity};
 pub use knowledge::{HubKnowledgeSequenceService, scan_registered_knowledge_inventories};
 pub use mcp::{
-    canonical_mcp_tool_definitions, register_local_spoke, safe_mcp_tool_names, serve_mcp_stdio,
+    canonical_mcp_tool_definitions, mcp_http_service, register_local_spoke, safe_mcp_tool_names,
+    serve_mcp_stdio,
 };
+pub use orbit_mcp::{McpHttpServerControl, McpStreamableHttpService};
 pub use persistence::RemoteStore;
 pub use profile::build_execution_profile_v1;
 pub use registry_cache::{RegistryCacheOutcome, RegistryCacheService, RegistryCacheState};

--- a/crates/orbit-remote/src/mcp/mod.rs
+++ b/crates/orbit-remote/src/mcp/mod.rs
@@ -16,6 +16,7 @@ mod transport;
 mod tests;
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use orbit_common::types::{McpCapability, ToolSessionContext};
@@ -37,6 +38,22 @@ use self::transport::{PrivateHubRequestHandler, RemoteCallContextResolver};
 pub use self::host::{canonical_mcp_tool_definitions, safe_mcp_tool_names};
 pub use self::registration::register_local_spoke;
 
+struct McpEndpointComposition {
+    host: Arc<dyn McpHost>,
+    trusted_context: ToolSessionContext,
+    composition: McpServerComposition,
+}
+
+impl McpEndpointComposition {
+    fn session_factory(&self) -> orbit_mcp::McpSessionFactory {
+        orbit_mcp::McpSessionFactory::new(
+            Arc::clone(&self.host),
+            self.trusted_context.clone(),
+            self.composition.clone(),
+        )
+    }
+}
+
 /// Serve the local broker or fixed coordination hub over MCP stdio.
 ///
 /// This is intentionally independent of Clap so alternate front ends can
@@ -46,6 +63,46 @@ pub fn serve_mcp_stdio(
     requested_capability: Option<McpCapability>,
 ) -> Result<(), OrbitError> {
     let global_root = resolve_global_root()?;
+    let endpoint = compose_mcp_endpoint(global_root, hub, requested_capability)?;
+
+    let tokio_runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| OrbitError::Execution(format!("tokio runtime: {error}")))?;
+    tokio_runtime.block_on(orbit_mcp::serve_stdio_with_context_and_composition(
+        endpoint.host,
+        endpoint.trusted_context,
+        endpoint.composition,
+    ))
+}
+
+/// Build the local broker as an embeddable stateful Streamable HTTP service.
+///
+/// `global_root` is explicit so the dashboard and tests use the same authority
+/// as their already-resolved state rather than consulting process cwd. The
+/// service keeps rmcp's loopback Host validation, and a missing capability is
+/// the least-privileged agent surface.
+pub fn mcp_http_service(
+    global_root: PathBuf,
+    requested_capability: Option<McpCapability>,
+) -> Result<
+    (
+        orbit_mcp::McpStreamableHttpService,
+        orbit_mcp::McpHttpServerControl,
+    ),
+    OrbitError,
+> {
+    let endpoint = compose_mcp_endpoint(global_root, false, requested_capability)?;
+    Ok(orbit_mcp::streamable_http_service(
+        endpoint.session_factory(),
+    ))
+}
+
+fn compose_mcp_endpoint(
+    global_root: PathBuf,
+    hub: bool,
+    requested_capability: Option<McpCapability>,
+) -> Result<McpEndpointComposition, OrbitError> {
     // Parse the trusted file, when present, before constructing either server
     // host. Workspace/cwd config never participates in this load.
     let trusted_config = load_trusted_mcp_config(&global_root)?;
@@ -109,15 +166,11 @@ pub fn serve_mcp_stdio(
     };
     trusted_context.effective_capabilities = BTreeSet::from([capability]);
 
-    let tokio_runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| OrbitError::Execution(format!("tokio runtime: {error}")))?;
-    tokio_runtime.block_on(orbit_mcp::serve_stdio_with_context_and_composition(
+    Ok(McpEndpointComposition {
         host,
         trusted_context,
         composition,
-    ))
+    })
 }
 
 fn broker_server_composition(host: Arc<BrokerMcpHost>) -> McpServerComposition {

--- a/docs/design/mcp-session-context/2_design.md
+++ b/docs/design/mcp-session-context/2_design.md
@@ -9,9 +9,9 @@ status: Accepted
 feature: mcp-session-context
 doc_role: design
 tags: ["mcp-session-context", "mcp", "workspace"]
-paths: ["crates/orbit-mcp/**", "crates/orbit-remote/src/mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool/**"]
+paths: ["crates/orbit-mcp/**", "crates/orbit-remote/src/mcp/**", "crates/orbit-dashboard/src/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool/**"]
 related_features: ["mcp-session-context", "task-artifacts"]
-related_artifacts: ["ORB-00256", "ORB-10228", "ORB-10262", "ORB-10319", "ORB-10448", "ORB-10690", "ADR-0181", "ADR-0199", "ADR-0149", "ADR-0348"]
+related_artifacts: ["ORB-00256", "ORB-10228", "ORB-10262", "ORB-10319", "ORB-10448", "ORB-10690", "ORB-10691", "ADR-0181", "ADR-0199", "ADR-0149", "ADR-0348", "ADR-0349"]
 ---
 
 # MCP Session Context — Design
@@ -40,7 +40,7 @@ Clients announce workspace with:
 
 `OrbitToolServer` stores a `ToolSessionContext` in an `RwLock` for the lifetime of one session. Each `tools/call` snapshots that context, generates exactly one unique `mcp_call_id` before name/exposure preflight, and passes the same snapshot through registry-backed dispatch.
 
-That state is per session, not per process. A stdio server serves exactly one client for its lifetime, so the two coincide there; a listener does not. `McpSessionFactory::build_session` therefore constructs one `OrbitToolServer` per session, and `McpTcpServer` hands each accepted connection its own. Sharing one server across connections would let the last client to `initialize` overwrite every other client's workspace selector and return another workspace's data as a success. [ADR-0348], [ORB-10690]
+That state is per session, not per process. A stdio server serves exactly one client for its lifetime, so the two coincide there; a listener does not. `McpSessionFactory::build_session` therefore constructs one `OrbitToolServer` per session. `McpTcpServer` hands each accepted connection its own, while the stateful Streamable HTTP session manager invokes the same factory for each initialized HTTP session. Sharing one server across sessions would let the last client to `initialize` overwrite every other client's workspace selector and return another workspace's data as a success. [ADR-0348], [ORB-10690], [ADR-0349], [ORB-10691]
 
 The Remote-owned `BrokerMcpHost` resolves and validates the logical workspace plus any exact local checkout before constructing or selecting an `OrbitRuntime`, then forwards the trusted context into `OrbitRuntime::execute_tool_command_dispatch_with_session_context`, which places it on `ToolContext` and audit. Unknown/unexposed denial and runtime success/failure retain the same per-call context. `orbit-cli` only delegates `mcp serve` into this composition. Graph commands have no MCP or CLI surface as of ORB-10357.
 
@@ -105,7 +105,9 @@ The trusted context carries the entire effective capability set. [ORB-10262] tes
 
 ## 6. Concerns & Honest Limitations
 
-The session context covers stdio and TCP sessions. [ORB-10690] established per-session isolation for the multi-client case; any future HTTP transport must go through the same session-construction seam rather than promoting the value to process-global state. The TCP endpoint carries no authentication of its own — reachability is the deployment's concern — and its capability set is chosen by the caller that starts it, never by the client.
+The session context covers stdio, TCP, and stateful Streamable HTTP sessions. [ORB-10690] established per-session isolation for the multi-client case; [ORB-10691] routes the HTTP session manager through that same construction seam and mounts `/mcp` on the dashboard listener. The MCP route is outside the dashboard `/api` origin middleware because non-browser MCP clients may legitimately present a non-localhost `Origin`. Loopback-only binding and rmcp's loopback `Host` validation remain in force. The endpoint carries no authentication of its own — reverse-proxy reachability and authentication are the deployment's concern — and its single effective capability is chosen at process start, defaulting to `agent` and never accepted from client metadata. [ADR-0349]
+
+Streamable HTTP emits SSE frames incrementally at the origin. An intermediary can still buffer a correct stream, so deployment-path streaming requires separate verification. Graceful shutdown cancels MCP sessions before Axum drains HTTP connections; without that ordering an open SSE session could keep the process alive indefinitely.
 
 The external channel carries a workspace address, not a trusted workspace ID. The local broker validates an absolute path against Git common-directory identity, `.orbit/config.yaml`, the logical registry, local role, and owner before separately populating `workspace_id`. Process cwd and `ORBIT_ROOT` are not fallbacks. Hub-link negotiation remains a later MCP Bridge unit.
 
@@ -117,5 +119,6 @@ The external channel carries a workspace address, not a trusted workspace ID. Th
 - [ORB-10319] moved broker/session resolution and MCP composition into the vertical `orbit-remote` feature crate while leaving runtime audit/dispatch in Core.
 - [ORB-10448] advertised the workspace selector on every workspace-scoped tool and routed hub-placement coordination reads by checkout identity, making the [ADR-0181] "clients that cannot send initialize metadata pass `workspace` explicitly" path reachable from a managed worktree activity.
 - [ORB-10690] added the TCP transport and moved session construction behind `McpSessionFactory` so concurrent clients cannot observe or overwrite each other's session context ([ADR-0348]).
+- [ORB-10691] mounted stateful Streamable HTTP at the dashboard `/mcp` route, isolated its middleware, defaulted it to the agent capability, and coupled MCP session cancellation to HTTP graceful shutdown ([ADR-0349]).
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-session-context/4_decisions.md
+++ b/docs/design/mcp-session-context/4_decisions.md
@@ -9,9 +9,9 @@ status: Accepted
 feature: mcp-session-context
 doc_role: decisions
 tags: ["mcp-session-context", "mcp", "workspace"]
-paths: ["crates/orbit-mcp/**", "crates/orbit-remote/src/mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool/**"]
+paths: ["crates/orbit-mcp/**", "crates/orbit-remote/src/mcp/**", "crates/orbit-dashboard/src/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool/**"]
 related_features: ["mcp-session-context", "task-artifacts"]
-related_artifacts: ["ORB-00256", "ORB-00406", "ORB-10228", "ORB-10262", "ORB-10319", "ORB-10448", "ORB-10690", "ADR-0181", "ADR-0199", "ADR-0149", "ADR-0348"]
+related_artifacts: ["ORB-00256", "ORB-00406", "ORB-10228", "ORB-10262", "ORB-10319", "ORB-10448", "ORB-10690", "ORB-10691", "ADR-0181", "ADR-0199", "ADR-0149", "ADR-0348", "ADR-0349"]
 ---
 
 # MCP Session Context — Decisions
@@ -40,11 +40,18 @@ Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.
 
 Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.show --input '{"id":"ADR-0348"}'`.
 
+## ADR-0349 — Host Streamable HTTP MCP on the dashboard listener
+
+**Status:** Proposed · 2026-08 · [ORB-10691]
+
+Narrative lives in the ADR store — retrieve it with `orbit tool run orbit.adr.show --input '{"id":"ADR-0349"}'`.
+
 ## Task References
 
 - [ORB-00256] implemented MCP ambient workspace session context.
 - [ORB-00406] proposes workspace_path-addressable host tools ([ADR-0199]).
 - [ORB-10690] added the MCP TCP transport with per-session server construction ([ADR-0348]).
+- [ORB-10691] hosts stateful Streamable HTTP on the dashboard listener and coordinates MCP cancellation with HTTP shutdown ([ADR-0349]).
 - [ORB-10228] accepted and implemented the trusted-provenance amendment to [ADR-0181].
 - [ORB-10262] accepted and implemented ADR-0199 through the exact-checkout local broker.
 - [ORB-10319] consolidated the broker/session implementation in `orbit-remote`; it does not change ADR-0181 or ADR-0199 semantics.


### PR DESCRIPTION
## Task

[ORB-10691](https://orbit-cli.com/tasks/ORB-10691) — Expose the MCP network endpoint from the long-running server process

### Description

The network MCP transport needs a listener. Orbit's only long-running HTTP service is the dashboard server, which already runs the same web framework, already ships a streaming endpoint, already handles graceful shutdown, and already has the dependency edge to the MCP crate. ADR-0347 records the decision to host the endpoint there rather than introduce a second daemon, and the alternatives rejected.

Constraints:

- The API router carries origin middleware that rejects any request presenting a non-localhost origin. Applied to the MCP route this would break every non-browser client. Confirm by test that the MCP route does not inherit it, rather than reasoning from how the layer appears to be scoped.
- The loopback-only bind restriction stays. Network exposure is the reverse proxy's concern, not orbit's, and deployment configuration is out of scope for this task.
- Graceful shutdown must cover in-flight MCP sessions, not only HTTP requests.
- Capability must be selectable by whoever starts the server, and must not silently default to the most privileged value. A deployment that says nothing must not become an operator.
- No new crate dependency edge; a boundary test pins the permitted set.
- Streamed responses must leave the origin incrementally. Note for the record that an intermediary can still buffer a stream that is correct at the origin; proving the end-to-end path is a separate deployment concern, not part of this task.

Known pre-existing condition: do not attempt to repair unrelated failing tests encountered in these crates.

### Acceptance Criteria

- An MCP client completes initialize, tool listing, and a tool call against a running server over the network transport.
- A streamed response is observed incrementally by the client rather than only at completion.
- A request presenting a non-localhost origin is served on the MCP route and still rejected on the API route, demonstrated by test.
- Starting the server without an explicit capability yields the least-privileged surface.
- Shutdown completes cleanly with an MCP session open.
- The crates build and the change carries its own tests.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a stateful MCP Streamable HTTP service in `orbit-mcp`, constructed from the existing per-session factory and paired with an explicit cancellation handle.
- Refactored `orbit-remote` MCP composition so stdio and HTTP share the same trusted host, capability, schema, and learning composition without adding an internal crate dependency edge.
- Mounted `/mcp` on the dashboard listener outside the `/api` browser-origin middleware, retained loopback bind and rmcp Host validation, and canceled MCP sessions before Axum drains HTTP connections.
- Added `orbit web serve --capabilities <agent|operator|runner>`; omission resolves to the agent surface. Clarified that `orbit mcp serve` is the stdio endpoint.
- Preserved the runtime global root in single-workspace dashboard state so embedded `serve(runtime, ...)` builds MCP against the correct authority.
- Added real-network tests for initialize, tools/list, successful tools/call, external-Origin isolation between MCP and API, default and explicit capability surfaces, incremental SSE delivery, and shutdown with an open MCP session.
- Added proposed ADR-0349 and updated MCP session-context design docs. The task text named ADR-0347, but that ID was not present and the global allocator assigned ADR-0349; ADR-0348 belongs to dependency ORB-10690.

Strategic decisions:
- Used stateful Streamable HTTP at `/mcp` rather than the raw TCP listener from ORB-10690 because the acceptance criteria require HTTP route middleware isolation and incremental SSE behavior.
- Kept dashboard -> remote -> mcp dependency direction. Extra files outside the initial selectors were added to task context because the generic HTTP service, remote composition seam, lockfile, single-mode state fix, focused tests, CLI parser coverage, and same-change design documentation were required for a complete implementation.
- Retained origin streaming semantics at the server and documented that reverse proxies may still buffer the stream.

Validation:
- `cargo test -p orbit-dashboard tests::mcp --no-fail-fast`: 3 passed.
- `cargo test -p orbit-dashboard tests::state::single_mode_exposes_one_default_workspace -- --exact`: passed.
- `cargo test -p orbit-cli command::tests::cli_parses_web_serve -- --exact`: passed.
- `cargo test -p orbit-mcp -p orbit-remote -p orbit-dashboard --no-fail-fast`: orbit-mcp 48 passed including integration tests; orbit-remote 177 passed including dependency boundary; dashboard 230 passed and 16 known unrelated tests failed. The failures are the task-described pre-existing class: managed-run ADR lifecycle policy rejects test-only acceptance and stale ship fixtures reference missing or legacy task IDs. The new MCP tests all passed.
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed.
- The default Cargo registry cache is read-only in this runner and initially denied a newly enabled rmcp feature download. Validation completed successfully with `CARGO_HOME=/tmp/orbit-cargo-home-10691`; this was a runner filesystem denial, not a code failure.

Assessment: The endpoint is implemented end to end with route-level policy proof, per-session isolation inherited from the shared factory, explicit least-privilege defaults, coordinated graceful shutdown, dependency-direction coverage, and focused network tests.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10691-6a7904d2`
- Behind base: 0
- Ahead of base: 1