### PR TITLE
Expose the MCP TCP listener through the CLI with a loopback bind guard

### DIFF
--- a/crates/orbit-cli/src/command/mcp/command.rs
+++ b/crates/orbit-cli/src/command/mcp/command.rs
@@ -1,3 +1,4 @@
+use std::net::SocketAddr;
 use std::path::Path;
 
 use clap::{Args, Subcommand};
@@ -58,6 +59,13 @@ pub struct ServeArgs {
     /// Exact non-hierarchical capability for this broker or hub session.
     #[arg(long, value_name = "CAPABILITY")]
     pub capabilities: Option<McpCapability>,
+    /// Serve over TCP at this loopback address instead of stdio. A
+    /// non-loopback address is refused before the socket is opened, since the
+    /// listener carries no authentication of its own; reach it through an
+    /// authenticated SSH tunnel (ADR-0350). Stdio remains the default when
+    /// this is omitted.
+    #[arg(long, value_name = "ADDR")]
+    pub listen: Option<SocketAddr>,
 }
 
 impl ServeArgs {
@@ -68,9 +76,10 @@ impl ServeArgs {
                     .to_string(),
             ));
         }
-        {
-            orbit_remote::serve_mcp_stdio(self.hub, self.capabilities)?;
-            Ok(CommandOutput::Silent)
+        match self.listen {
+            Some(addr) => orbit_remote::serve_mcp_tcp(addr, self.hub, self.capabilities)?,
+            None => orbit_remote::serve_mcp_stdio(self.hub, self.capabilities)?,
         }
+        Ok(CommandOutput::Silent)
     }
 }

--- a/crates/orbit-remote/src/lib.rs
+++ b/crates/orbit-remote/src/lib.rs
@@ -51,6 +51,7 @@ pub use host_registry::{HostRegistryService, WorkspaceLink, require_local_hub_id
 pub use knowledge::{HubKnowledgeSequenceService, scan_registered_knowledge_inventories};
 pub use mcp::{
     canonical_mcp_tool_definitions, register_local_spoke, safe_mcp_tool_names, serve_mcp_stdio,
+    serve_mcp_tcp,
 };
 pub use persistence::RemoteStore;
 pub use profile::build_execution_profile_v1;

--- a/crates/orbit-remote/src/mcp/mod.rs
+++ b/crates/orbit-remote/src/mcp/mod.rs
@@ -16,6 +16,7 @@ mod transport;
 mod tests;
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use orbit_common::types::{McpCapability, ToolSessionContext};
@@ -45,11 +46,92 @@ pub fn serve_mcp_stdio(
     hub: bool,
     requested_capability: Option<McpCapability>,
 ) -> Result<(), OrbitError> {
+    let (host, trusted_context, composition) = build_mcp_session(hub, requested_capability)?;
+    let tokio_runtime = build_tokio_runtime()?;
+    tokio_runtime.block_on(orbit_mcp::serve_stdio_with_context_and_composition(
+        host,
+        trusted_context,
+        composition,
+    ))
+}
+
+/// Serve the local broker or fixed coordination hub over MCP-over-TCP.
+///
+/// The endpoint carries no authentication of its own (see
+/// [`orbit_mcp::McpTcpServer`]); ADR-0350 authenticates it by requiring an SSH
+/// tunnel to reach it rather than by anything Orbit adds. That posture only
+/// holds if the listener itself refuses a routable bind, so the loopback
+/// check runs before the socket opens — the same guard
+/// `orbit-dashboard::check_bindable_host` applies, reused here rather than
+/// re-derived because both guards protect an unauthenticated listener the
+/// same way.
+pub fn serve_mcp_tcp(
+    addr: SocketAddr,
+    hub: bool,
+    requested_capability: Option<McpCapability>,
+) -> Result<(), OrbitError> {
+    check_bindable_mcp_host(addr)?;
+    let (host, trusted_context, composition) = build_mcp_session(hub, requested_capability)?;
+    let tokio_runtime = build_tokio_runtime()?;
+    tokio_runtime.block_on(orbit_mcp::serve_tcp_with_context_and_composition(
+        addr,
+        host,
+        trusted_context,
+        composition,
+    ))
+}
+
+/// Reject binding the MCP TCP listener to anything other than a loopback
+/// address, before the socket is opened.
+///
+/// SECURITY: the listener carries no authentication of its own. A non-loopback
+/// bind would turn it into unauthenticated remote control of the machine, so
+/// this refuses eagerly rather than documenting the risk. For remote access,
+/// bind loopback and reach it through an authenticated tunnel (e.g. `ssh -L`),
+/// which is exactly the posture ADR-0350 commits to.
+fn check_bindable_mcp_host(addr: SocketAddr) -> Result<(), OrbitError> {
+    if addr.ip().is_loopback() {
+        return Ok(());
+    }
+    Err(OrbitError::InvalidInput(format!(
+        "refusing to bind the MCP TCP listener to non-loopback address {addr}: the listener is \
+         unauthenticated and relies on an SSH tunnel for access control (ADR-0350). Bind a \
+         loopback address (127.0.0.1 or ::1) and use an authenticated tunnel/reverse proxy \
+         (e.g. `ssh -L {port}:localhost:{port} <host>`) for remote access.",
+        port = addr.port()
+    )))
+}
+
+/// Resolve the effective capability for a session that did not request one.
+///
+/// A deployment that says nothing must not become an operator: [`McpCapability::Agent`]
+/// is the capability nothing else grants on its own (see
+/// `orbit_common::authorization`'s governed-operation table, which never lists
+/// `Agent` alone), so it is the floor every unspecified session gets — for
+/// both stdio and TCP.
+fn least_privileged_mcp_capability(requested: Option<McpCapability>) -> McpCapability {
+    requested.unwrap_or(McpCapability::Agent)
+}
+
+fn build_tokio_runtime() -> Result<tokio::runtime::Runtime, OrbitError> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| OrbitError::Execution(format!("tokio runtime: {error}")))
+}
+
+/// Build the trusted host, session template, and server composition shared by
+/// every MCP transport. The effective capability is resolved here so stdio
+/// and TCP agree on the same least-privileged default.
+fn build_mcp_session(
+    hub: bool,
+    requested_capability: Option<McpCapability>,
+) -> Result<(Arc<dyn McpHost>, ToolSessionContext, McpServerComposition), OrbitError> {
     let global_root = resolve_global_root()?;
     // Parse the trusted file, when present, before constructing either server
     // host. Workspace/cwd config never participates in this load.
     let trusted_config = load_trusted_mcp_config(&global_root)?;
-    let capability = requested_capability.unwrap_or(McpCapability::Agent);
+    let capability = least_privileged_mcp_capability(requested_capability);
     let (host, mut trusted_context, composition): (
         Arc<dyn McpHost>,
         ToolSessionContext,
@@ -109,15 +191,7 @@ pub fn serve_mcp_stdio(
     };
     trusted_context.effective_capabilities = BTreeSet::from([capability]);
 
-    let tokio_runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| OrbitError::Execution(format!("tokio runtime: {error}")))?;
-    tokio_runtime.block_on(orbit_mcp::serve_stdio_with_context_and_composition(
-        host,
-        trusted_context,
-        composition,
-    ))
+    Ok((host, trusted_context, composition))
 }
 
 fn broker_server_composition(host: Arc<BrokerMcpHost>) -> McpServerComposition {

--- a/crates/orbit-remote/src/mcp/tests/mod.rs
+++ b/crates/orbit-remote/src/mcp/tests/mod.rs
@@ -10,6 +10,7 @@ mod hub_link;
 mod knowledge_allocation;
 mod learning;
 mod schema;
+mod serve;
 mod support;
 mod transport;
 

--- a/crates/orbit-remote/src/mcp/tests/serve.rs
+++ b/crates/orbit-remote/src/mcp/tests/serve.rs
@@ -1,0 +1,54 @@
+#![allow(missing_docs)]
+
+use std::net::SocketAddr;
+
+use orbit_common::types::McpCapability;
+
+use super::super::{check_bindable_mcp_host, least_privileged_mcp_capability};
+
+#[test]
+fn loopback_addresses_pass_the_bind_guard() {
+    let v4: SocketAddr = "127.0.0.1:0".parse().expect("v4 loopback");
+    let v6: SocketAddr = "[::1]:0".parse().expect("v6 loopback");
+
+    assert!(check_bindable_mcp_host(v4).is_ok());
+    assert!(check_bindable_mcp_host(v6).is_ok());
+}
+
+#[test]
+fn non_loopback_addresses_are_refused_by_the_pure_guard() {
+    let routable: SocketAddr = "0.0.0.0:4000".parse().expect("non-loopback");
+
+    let error = check_bindable_mcp_host(routable).expect_err("non-loopback must be refused");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("non-loopback"),
+        "message should name the refusal: {message}"
+    );
+    assert!(
+        message.contains("4000"),
+        "message should carry the requested port for the suggested tunnel command: {message}"
+    );
+}
+
+#[test]
+fn an_unspecified_capability_resolves_to_the_least_privileged_default() {
+    assert_eq!(
+        least_privileged_mcp_capability(None),
+        McpCapability::Agent,
+        "a deployment that says nothing must not become an operator"
+    );
+}
+
+#[test]
+fn an_explicit_capability_request_is_never_widened() {
+    assert_eq!(
+        least_privileged_mcp_capability(Some(McpCapability::Operator)),
+        McpCapability::Operator
+    );
+    assert_eq!(
+        least_privileged_mcp_capability(Some(McpCapability::Runner)),
+        McpCapability::Runner
+    );
+}


### PR DESCRIPTION
## Task

[ORB-10707](https://orbit-cli.com/tasks/ORB-10707) — Expose the MCP TCP listener through the CLI with a loopback bind guard

### Description

The MCP crate already implements a TCP listener with one server instance per connection, but nothing outside that crate references it. It has no CLI surface, so it cannot be started, and the transport is unreachable in practice.

Give it one. `orbit mcp serve` gains an explicit listen address; the endpoint is reached through an SSH tunnel, which is what authenticates it (ADR-0350).

Constraints:

- The listener carries no authentication of its own. Binding a routable address turns it into unauthenticated remote control of the machine, so a non-loopback bind must be refused before the socket opens — the same posture the dashboard server already applies — rather than discouraged in documentation.
- Capability is chosen by whoever starts the server, never by the client, and must not default to the most privileged value. A deployment that says nothing must not become an operator.
- Serving over stdio stays the default and is unchanged. This adds an alternative binding, not a replacement.
- Per-connection session isolation already exists in the crate; use it rather than reconstructing it. Two clients must not be able to observe or overwrite each other's workspace selection.

Known pre-existing condition: do not attempt to repair unrelated failing tests encountered in these crates.

### Acceptance Criteria

- Started with an explicit loopback address, the listener serves MCP: a client completes initialize, tool listing, and a tool call.
- A non-loopback bind is refused before the socket is opened, demonstrated by test.
- Starting without an explicit capability yields the least-privileged surface.
- Two concurrent connections announcing different workspace selectors each observe only their own.
- Serving over stdio is unchanged.
- The crates build and the change carries its own tests.

## Execution Summary

<details>
<summary>Click to expand</summary>

Wired the existing orbit-mcp TCP transport (built in ORB-10690, previously unreachable) into `orbit mcp serve` with a loopback bind guard.

Changes:
- `crates/orbit-remote/src/mcp/mod.rs`: extracted the host/trusted-context/composition construction shared by every transport into a private `build_mcp_session(hub, requested_capability)` helper (previously inlined in `serve_mcp_stdio`, behavior unchanged). Added `pub fn serve_mcp_tcp(addr, hub, requested_capability)` that calls a new `check_bindable_mcp_host(addr)` guard *before* building any session state or opening a socket, refusing non-loopback addresses with a message mirroring `orbit-dashboard::check_bindable_host` (same posture, suggests an `ssh -L` tunnel per ADR-0350). Extracted `least_privileged_mcp_capability` (`requested.unwrap_or(McpCapability::Agent)`) so stdio and TCP resolve the same least-privileged default when the operator specifies no capability.
- `crates/orbit-remote/src/lib.rs`: re-exported `serve_mcp_tcp`.
- `crates/orbit-cli/src/command/mcp/command.rs`: added `ServeArgs::listen: Option<SocketAddr>` (`--listen ADDR`). When set, dispatches to `serve_mcp_tcp`; when absent, stdio is unchanged (still the default, per constraint). No `command/operation.rs` change needed — the existing "mcp serve" audit arm is generic over `ServeArgs`.
- Tests: `crates/orbit-remote/src/mcp/tests/serve.rs` (new, registered in `tests/mod.rs`) unit-tests `check_bindable_mcp_host` (loopback v4/v6 pass; a routable address is refused, message names the address and port) and `least_privileged_mcp_capability` (None -> Agent; explicit request passed through unwidened) — both pure, hermetic, no dependency on `~/.orbit` state. Criteria 1 and 4 (full initialize/list/call round trip over TCP; two concurrent connections isolated) were already covered by the existing `crates/orbit-mcp/tests/mcp_tcp_transport.rs` suite added in ORB-10690, which exercises the same `McpTcpServer`/`serve_tcp_with_context_and_composition` this task now reaches from the CLI — re-verified passing, unchanged.

Manual verification: `orbit mcp serve --listen 0.0.0.0:PORT` returns the refusal error before any bind attempt; `orbit mcp serve --listen 127.0.0.1:PORT` starts and stays listening (killed after 1s). `orbit mcp serve --help` shows the new `--listen` flag.

Validation: `make ci-fast` and `make ci-lint` (workspace clippy, `-D warnings`) both pass. `cargo test -p orbit-remote -p orbit-mcp -p orbit-cli` passes except one pre-existing, unrelated failure: `orbit-cli command::run::tests::ship::interactive_ship_inherits_the_shared_in_flight_guard` (task-id-format panic in `command/run/tests/ship.rs`, untouched by this change) — confirmed failing identically on the pre-change tree via `git stash`, consistent with the task's "known pre-existing condition" note. No new cross-crate dependency edges (orbit-cli -> orbit-remote -> orbit-mcp already existed); `check-dependency-direction.sh` passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10707-6a793e1a`
- Behind base: 0
- Ahead of base: 1