### PR TITLE
Attach to an already-running remote server instead of always starting one

### DIFF
--- a/crates/orbit-dashboard/src/connect.rs
+++ b/crates/orbit-dashboard/src/connect.rs
@@ -8,10 +8,16 @@
 //!
 //! `connect` automates exactly that workflow and nothing more: it delegates
 //! authentication to SSH, keeps the loopback bind guard intact, and adds no new
-//! attack surface. It runs `orbit web serve` on the remote over a single `ssh`
-//! invocation that also forwards a local port, waits for the remote server to
-//! answer `/healthz`, opens a browser, and — on Ctrl-C — tears the tunnel down
-//! so no orphaned remote `orbit web serve` process is left behind.
+//! attack surface. It first opens a bare port forward (no remote command) and
+//! probes `/healthz` through it — if a dashboard is already listening on the
+//! remote port (another user's tunnel, or a long-lived remote listener), it
+//! attaches to that instead of spawning a second one. Only when nothing
+//! answers does it fall back to running `orbit web serve` on the remote over a
+//! fresh `ssh` invocation that also forwards the local port. Either way it
+//! waits for the remote server to answer `/healthz`, opens a browser, and — on
+//! Ctrl-C — tears down only the `ssh` process this invocation started: a
+//! spawned remote `orbit web serve` is never orphaned, and an attached,
+//! pre-existing one is never touched.
 //!
 //! Unlike [`crate::serve`], this command reads no local `.orbit/` state: the
 //! workspace lives on the remote, so it needs no [`orbit_core::OrbitRuntime`].
@@ -35,6 +41,13 @@ const POLL_INTERVAL: Duration = Duration::from_millis(250);
 
 /// Per-probe TCP connect/read/write timeout for the `/healthz` check.
 const PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// How long to wait, when first probing for an already-running remote
+/// dashboard through a bare port forward, before concluding nothing is
+/// listening and falling back to spawning one ourselves. Short: it only needs
+/// to cover `ssh` handshake plus a couple of probe round trips, not a remote
+/// process boot (that is what [`READINESS_TIMEOUT`] is for).
+const ATTACH_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Grace period between SIGTERM and SIGKILL when tearing the tunnel down.
 #[cfg(unix)]
@@ -72,32 +85,36 @@ pub struct ConnectArgs {
     pub no_open: bool,
 }
 
-/// Establish the tunnel, wait for readiness, open the browser, and block until
-/// Ctrl-C / SIGTERM — then tear everything down cleanly.
+/// Establish the tunnel — attaching to an already-running remote dashboard
+/// when one answers, spawning one otherwise — wait for readiness, open the
+/// browser, and block until Ctrl-C / SIGTERM — then tear down only what this
+/// invocation started.
 pub fn connect(args: ConnectArgs) -> Result<(), OrbitError> {
     let local_port = select_local_port(args.port)?;
-    let ssh_args = build_ssh_args(&args, local_port);
-
-    // Force a pty (`-tt`) so that when we kill the local `ssh`, the remote
-    // `orbit web serve` receives SIGHUP and exits — no orphan. `stdin` is null
-    // so Ctrl-C is delivered to *us* (the foreground process) rather than being
-    // forwarded down the pty to the remote.
-    let child = Command::new("ssh")
-        .args(&ssh_args)
-        .stdin(Stdio::null())
-        .spawn()
-        .map_err(|e| OrbitError::Io(format!("failed to launch ssh: {e}")))?;
 
     // From here on, every exit path (error, panic, normal) tears the tunnel
-    // down via `SshTunnel`'s `Drop`.
-    let mut tunnel = SshTunnel::new(child);
+    // down via `SshTunnel`'s `Drop` — whichever branch below produced it.
+    let (mut tunnel, attached) = match probe_attach(&args, local_port)? {
+        Some(tunnel) => (tunnel, true),
+        None => {
+            // Force a pty (`-tt`) so that when we kill the local `ssh`, the
+            // remote `orbit web serve` receives SIGHUP and exits — no orphan.
+            let child = spawn_ssh(&build_ssh_args(&args, local_port))?;
+            let mut tunnel = SshTunnel::new(child);
+            wait_until_ready(&mut tunnel, local_port)?;
+            (tunnel, false)
+        }
+    };
 
     let url = format!("http://localhost:{local_port}");
-    wait_until_ready(&mut tunnel, local_port)?;
 
     #[allow(clippy::print_stdout)]
     {
-        println!("Dashboard tunnel ready: {url}  (Ctrl-C to disconnect)");
+        if attached {
+            println!("Attached to already-running remote dashboard: {url}  (Ctrl-C to disconnect)");
+        } else {
+            println!("Dashboard tunnel ready: {url}  (Ctrl-C to disconnect)");
+        }
     }
 
     if !args.no_open {
@@ -106,6 +123,41 @@ pub fn connect(args: ConnectArgs) -> Result<(), OrbitError> {
 
     wait_for_shutdown(&mut tunnel);
     Ok(())
+}
+
+/// Spawn `ssh` with the given argument vector. `stdin` is null so Ctrl-C is
+/// delivered to *us* (the foreground process) rather than being forwarded
+/// down a pty to the remote.
+fn spawn_ssh(ssh_args: &[String]) -> Result<Child, OrbitError> {
+    Command::new("ssh")
+        .args(ssh_args)
+        .stdin(Stdio::null())
+        .spawn()
+        .map_err(|e| OrbitError::Io(format!("failed to launch ssh: {e}")))
+}
+
+/// Probe for an already-running remote dashboard on `cfg.remote_port` by
+/// opening a bare port forward (`ssh -N`, no remote command) and polling
+/// `/healthz` through it. A tunnel can come up healthy while nothing is
+/// listening behind it, so readiness is decided by the `/healthz` probe, not
+/// by `ssh`'s own exit code (that still surfaces separately — see
+/// [`classify_ssh_exit`] — when `ssh` itself fails, e.g. a bad host).
+///
+/// Returns the still-live probe tunnel on success — it becomes the session's
+/// tunnel — or `None` after tearing the probe down, so the caller falls back
+/// to spawning a fresh remote server. Because a bare `-N` forward never
+/// invokes anything remotely, tearing it down on disconnect cannot orphan or
+/// kill a pre-existing remote process; it only closes the forward.
+fn probe_attach(cfg: &ConnectArgs, local_port: u16) -> Result<Option<SshTunnel>, OrbitError> {
+    let child = spawn_ssh(&build_probe_ssh_args(cfg, local_port))?;
+    let mut tunnel = SshTunnel::new(child);
+
+    if poll_until_ready(&mut tunnel, local_port, ATTACH_PROBE_TIMEOUT)? {
+        Ok(Some(tunnel))
+    } else {
+        tunnel.shutdown();
+        Ok(None)
+    }
 }
 
 // Visibility note: the pure helpers below are `pub(crate)` so the sibling
@@ -175,6 +227,21 @@ pub(crate) fn build_ssh_args(cfg: &ConnectArgs, local_port: u16) -> Vec<String> 
     ]
 }
 
+/// Build the argument vector for a bare probe forward: the same `-L` port
+/// forward as [`build_ssh_args`] but with no remote command at all (`-N`), so
+/// nothing is invoked on the far side. Used to test whether a remote
+/// dashboard is already listening before deciding whether to spawn one.
+pub(crate) fn build_probe_ssh_args(cfg: &ConnectArgs, local_port: u16) -> Vec<String> {
+    vec![
+        "-N".to_string(),
+        "-o".to_string(),
+        "ExitOnForwardFailure=yes".to_string(),
+        "-L".to_string(),
+        format!("{local_port}:localhost:{}", cfg.remote_port),
+        cfg.ssh_host.clone(),
+    ]
+}
+
 /// The remote shell command line:
 /// `orbit web serve --no-open --port N [--global] [--root P]`.
 ///
@@ -200,22 +267,39 @@ pub(crate) fn shell_quote(value: &str) -> String {
 }
 
 /// Poll `/healthz` until the remote dashboard answers, or fail if `ssh` exits
-/// first (misconfigured host, `orbit` not on PATH, …) or the timeout elapses.
+/// first (misconfigured host, `orbit` not on PATH, …) or [`READINESS_TIMEOUT`]
+/// elapses.
 fn wait_until_ready(tunnel: &mut SshTunnel, local_port: u16) -> Result<(), OrbitError> {
-    let deadline = Instant::now() + READINESS_TIMEOUT;
+    if poll_until_ready(tunnel, local_port, READINESS_TIMEOUT)? {
+        Ok(())
+    } else {
+        Err(OrbitError::Execution(format!(
+            "timed out after {}s waiting for the remote dashboard at \
+             http://localhost:{local_port}/healthz to become ready",
+            READINESS_TIMEOUT.as_secs()
+        )))
+    }
+}
+
+/// Poll `/healthz` through `tunnel`'s forward until it answers or `timeout`
+/// elapses. Returns `Ok(true)` on a ready response, `Ok(false)` on a plain
+/// timeout (the forward is still up; nothing has answered yet), or `Err` if
+/// `ssh` exited before either happened.
+pub(crate) fn poll_until_ready(
+    tunnel: &mut SshTunnel,
+    local_port: u16,
+    timeout: Duration,
+) -> Result<bool, OrbitError> {
+    let deadline = Instant::now() + timeout;
     loop {
         if let Some(status) = tunnel.try_wait()? {
             return Err(classify_ssh_exit(status));
         }
         if healthz_ok(local_port) {
-            return Ok(());
+            return Ok(true);
         }
         if Instant::now() >= deadline {
-            return Err(OrbitError::Execution(format!(
-                "timed out after {}s waiting for the remote dashboard at \
-                 http://localhost:{local_port}/healthz to become ready",
-                READINESS_TIMEOUT.as_secs()
-            )));
+            return Ok(false);
         }
         std::thread::sleep(POLL_INTERVAL);
     }
@@ -321,8 +405,12 @@ fn wait_for_shutdown(tunnel: &mut SshTunnel) {
     });
 }
 
-/// RAII owner of the `ssh` child that guarantees teardown of the tunnel (and,
-/// via the remote pty's SIGHUP, the remote `orbit web serve`) on drop.
+/// RAII owner of the `ssh` child that guarantees teardown of the tunnel on
+/// drop. When this invocation spawned the remote `orbit web serve` (`-tt`
+/// plus a remote command), closing `ssh` also delivers SIGHUP to the remote
+/// pty and stops that process. When it only attached via a bare `-N` forward,
+/// there is no remote command tied to this session, so teardown just closes
+/// the forward and leaves any pre-existing remote process running.
 pub(crate) struct SshTunnel {
     child: Option<Child>,
 }

--- a/crates/orbit-dashboard/src/tests/connect.rs
+++ b/crates/orbit-dashboard/src/tests/connect.rs
@@ -1,15 +1,19 @@
 //! Unit tests for `orbit web connect` helpers (port selection, ssh arg
-//! construction, and tunnel teardown). No real `ssh` process is spawned.
+//! construction, readiness polling, and tunnel teardown). No real `ssh`
+//! process is spawned — a `sleep`/`true` child stands in wherever a live
+//! `SshTunnel` is needed.
 
+use std::io::{Read, Write};
 use std::net::{Ipv4Addr, TcpListener};
 use std::process::Command;
+use std::time::Duration;
 
 use orbit_core::OrbitError;
 
 use super::super::DEFAULT_DASHBOARD_PORT;
 use super::super::connect::{
-    ConnectArgs, build_ssh_args, ephemeral_port, probe_bindable, remote_serve_command,
-    select_local_port, shell_quote,
+    ConnectArgs, SshTunnel, build_probe_ssh_args, build_ssh_args, ephemeral_port, poll_until_ready,
+    probe_bindable, remote_serve_command, select_local_port, shell_quote,
 };
 
 /// Minimal args builder so each test states only what it cares about.
@@ -146,6 +150,109 @@ fn remote_command_combines_global_and_root() {
 fn shell_quote_escapes_embedded_single_quotes() {
     assert_eq!(shell_quote("plain"), "'plain'");
     assert_eq!(shell_quote("a'b"), "'a'\\''b'");
+}
+
+// ── probe (attach) argument construction ──────────────────────────────────
+
+#[test]
+fn build_probe_ssh_args_has_no_remote_command() {
+    // A probe forward must never invoke anything remotely (`-N`, and no
+    // trailing command arg) — that is what keeps attaching to an
+    // already-running remote server from ever starting a second one, and
+    // keeps disconnecting from it from ever touching that process.
+    let got = build_probe_ssh_args(&args("box", 7878, None), 9999);
+    assert_eq!(
+        got,
+        vec![
+            "-N".to_string(),
+            "-o".to_string(),
+            "ExitOnForwardFailure=yes".to_string(),
+            "-L".to_string(),
+            "9999:localhost:7878".to_string(),
+            "box".to_string(),
+        ]
+    );
+    assert!(
+        !got.iter().any(|a| a.contains("orbit web serve")),
+        "probe args must not carry a remote command: {got:?}"
+    );
+}
+
+#[test]
+fn build_probe_ssh_args_forwards_distinct_local_and_remote_ports() {
+    let got = build_probe_ssh_args(&args("user@host", 9000, None), 7000);
+    assert!(got.contains(&"7000:localhost:9000".to_string()));
+}
+
+// ── readiness polling (attach vs. spawn decision) ─────────────────────────
+
+/// Spawn a background thread that accepts one connection on `listener` and
+/// replies with a 200 `/healthz` response, simulating an already-running
+/// remote dashboard answering through the forward.
+fn serve_one_healthz_ok(listener: TcpListener) {
+    std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut buf = [0u8; 256];
+            let _ = stream.read(&mut buf);
+            let _ = stream.write_all(b"HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n");
+        }
+    });
+}
+
+/// A `sleep`-backed stand-in for a live `ssh` child: alive but never exits on
+/// its own within a test's lifetime.
+fn fake_live_tunnel() -> SshTunnel {
+    let child = Command::new("sleep")
+        .arg("30")
+        .spawn()
+        .expect("spawn sleep");
+    SshTunnel::new(child)
+}
+
+#[test]
+fn poll_until_ready_true_when_something_already_answers() {
+    // This is the "attach" path: a forward with nothing spawned on our side,
+    // but something already listening behind it.
+    let port = ephemeral_port().expect("ephemeral port");
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, port)).expect("bind");
+    serve_one_healthz_ok(listener);
+
+    let mut tunnel = fake_live_tunnel();
+    let ready =
+        poll_until_ready(&mut tunnel, port, Duration::from_secs(2)).expect("poll should not error");
+    assert!(ready, "must report ready once /healthz answers 200");
+}
+
+#[test]
+fn poll_until_ready_false_on_timeout_when_nothing_answers() {
+    // This is the "nothing running yet" path: the forward is up (tunnel still
+    // alive) but nobody answers /healthz, so the caller must fall back to
+    // spawning a remote server rather than erroring outright.
+    let port = ephemeral_port().expect("ephemeral port — left unbound");
+
+    let mut tunnel = fake_live_tunnel();
+    let ready = poll_until_ready(&mut tunnel, port, Duration::from_millis(600))
+        .expect("timeout is not an error");
+    assert!(!ready, "must report not-ready when nothing answers");
+    assert!(
+        tunnel.try_wait().expect("try_wait").is_none(),
+        "the forward itself must still be alive after a plain timeout"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn poll_until_ready_errors_when_ssh_exits_early() {
+    // If the underlying `ssh` process dies (bad host, auth failure, ...)
+    // before either a ready answer or the timeout, that must surface as an
+    // error rather than being silently treated as "nothing running yet".
+    let port = ephemeral_port().expect("ephemeral port");
+    let child = Command::new("false").spawn().expect("spawn false");
+    let mut tunnel = SshTunnel::new(child);
+
+    let err = poll_until_ready(&mut tunnel, port, Duration::from_secs(2))
+        .expect_err("an early ssh exit must be an error, not a timeout");
+    assert!(matches!(err, OrbitError::Execution(_)));
 }
 
 // ── ssh exit classification ───────────────────────────────────────────────

--- a/docs/design/remote-access/1_overview.md
+++ b/docs/design/remote-access/1_overview.md
@@ -1,7 +1,7 @@
 ---
 title: "Remote Access — Overview"
 owner: claude
-last_updated: 2026-07-26
+last_updated: 2026-08-10
 status: Accepted
 feature: remote-access
 doc_role: overview
@@ -10,7 +10,7 @@ summary: "How an operator views Orbit across every local workspace and across ma
 tags: [remote-access]
 paths: ["crates/orbit-dashboard/**", "crates/orbit-remote/src/runtime.rs", "crates/orbit-remote/src/workspace_registry.rs", "crates/orbit-cli/src/command/web.rs", "crates/orbit-cli/src/command/operation.rs"]
 related_features: [remote-access, user-interface, host-registry]
-related_artifacts: [ORB-00029, ORB-00030, ORB-00360, ORB-10029, ORB-10200, ORB-10310, ORB-10319, ORB-10400, ADR-0200, ADR-0201]
+related_artifacts: [ORB-00029, ORB-00030, ORB-00360, ORB-10029, ORB-10200, ORB-10310, ORB-10319, ORB-10400, ORB-10708, ADR-0200, ADR-0201, ADR-0353]
 ---
 
 # Remote Access — Overview
@@ -44,7 +44,7 @@ The dashboard's axum state is a workspace-keyed, lazily-built runtime map ([`Das
 
 ### 2.3 SSH-tunnel connect
 
-`orbit web connect <ssh-host>` runs `orbit web serve --no-open` on the remote over a single `ssh` invocation that also forwards a local port, waits for `/healthz`, opens a browser, and tears the tunnel (and the remote serve process) down on Ctrl-C. `--root` is forwarded to the remote serve; `--global` is also forwarded but is a no-op against a post-[ORB-10029] remote (global is always on) and matters only against an older remote binary. Introduced by [ORB-00029]; the transport decision is [4_decisions.md ADR-0201](./4_decisions.md).
+`orbit web connect <ssh-host>` forwards a local port over a single `ssh` invocation and waits for `/healthz`. It probes first: if a remote dashboard already answers through a bare forward, it attaches to that and never spawns anything ([ORB-10708], [4_decisions.md ADR-0353](./4_decisions.md)). Only when nothing answers does it run `orbit web serve --no-open` on the remote instead. Either way it opens a browser once ready, and tears the tunnel down on Ctrl-C — reaping the remote serve process only if this invocation spawned one; an attached, pre-existing one is left running. `--root` and `--global` are forwarded to the remote serve in spawn mode only (`--global` is a no-op against a post-[ORB-10029] remote; it matters only against an older remote binary). Introduced by [ORB-00029]; the transport decision is [4_decisions.md ADR-0201](./4_decisions.md).
 
 ### 2.4 Viewing is not sync
 
@@ -73,6 +73,7 @@ Remote access shows what already exists on a machine that is online and reachabl
 ## Task References
 
 - [ORB-00029] — Added `orbit web connect <ssh-host>`: SSH-tunnel viewing of a remote machine's dashboard, later extended to forward `--global`.
+- [ORB-10708] — Made `connect` probe for and attach to an already-running remote dashboard instead of always spawning one; see [ADR-0353].
 - [ORB-00030] — Made the dashboard global/multi-workspace: workspace-keyed state, `Ws` extractor, serve-from-anywhere, aggregate endpoints.
 - [ORB-00360] — Restricted the dashboard to loopback binds only and fixed stored XSS; the security floor remote access builds on.
 - [ORB-10029] — Made global mode the default and only mode for `orbit web serve`; `--global` is now a deprecated no-op retained for `connect` passthrough.

--- a/docs/design/remote-access/2_design.md
+++ b/docs/design/remote-access/2_design.md
@@ -1,16 +1,16 @@
 ---
 title: "Remote Access — Design"
 owner: claude
-last_updated: 2026-07-26
+last_updated: 2026-08-10
 status: Accepted
 feature: remote-access
 doc_role: design
 type: design
-summary: "The two shipped surfaces — global multi-workspace serve (the only mode since ORB-10029) and SSH-tunnel connect — their state model, the dashboard task-list endpoint contract, and how they compose."
+summary: "The two shipped surfaces — global multi-workspace serve (the only mode since ORB-10029) and SSH-tunnel connect (attach-if-already-running since ORB-10708) — their state model, the dashboard task-list endpoint contract, and how they compose."
 tags: [remote-access]
 paths: ["crates/orbit-dashboard/**", "crates/orbit-remote/src/runtime.rs", "crates/orbit-remote/src/workspace_registry.rs", "crates/orbit-cli/src/command/web.rs", "crates/orbit-cli/src/command/operation.rs"]
 related_features: [remote-access, user-interface, host-registry]
-related_artifacts: [ORB-00029, ORB-00030, ORB-00360, ORB-10029, ORB-10200, ORB-10294, ORB-10310, ORB-10319, ORB-10400, ADR-0200, ADR-0201, ADR-0234]
+related_artifacts: [ORB-00029, ORB-00030, ORB-00360, ORB-10029, ORB-10200, ORB-10294, ORB-10310, ORB-10319, ORB-10400, ORB-10708, ADR-0200, ADR-0201, ADR-0234, ADR-0353]
 ---
 
 # Remote Access — Design
@@ -86,10 +86,10 @@ Consumers accept either shape (`items` when present, else the array) — the `/a
 [`connect`](../../../crates/orbit-dashboard/src/connect.rs) automates the manual `ssh -L 7878:localhost:7878 <host> "orbit web serve --no-open"` dance and nothing more. Given `orbit web connect <ssh-host>`:
 
 1. **Local port.** `select_local_port` prefers the conventional `7878`, falling back to an OS-assigned ephemeral port if it is busy; an explicit `--port` is honored or fails loudly.
-2. **Remote command.** `remote_serve_command` builds `orbit web serve --no-open --port <remote_port> [--global] [--root <p>]`. `--no-open` is always present (the remote must never open a browser); `--root` is shell-quoted; `--global` is forwarded when set — a no-op against a post-[ORB-10029] remote binary (global is always on), kept so `connect` still works against an older remote that still gates on the flag.
-3. **Tunnel.** `build_ssh_args` produces `ssh -tt -o ExitOnForwardFailure=yes -L <local>:localhost:<remote> <host> <remote-command>`. `-tt` forces a pty so the remote serve receives SIGHUP when the tunnel drops; `ExitOnForwardFailure=yes` fails fast rather than running the remote with no working forward; stdin is null so Ctrl-C reaches *us*.
-4. **Readiness.** `wait_until_ready` polls `GET /healthz` over the forwarded port until it answers `200`, the `ssh` child exits early (classified into an actionable error — `127` = orbit not on remote PATH, `255` = ssh connect failure), or a 30s timeout elapses.
-5. **Teardown.** `SshTunnel` is an RAII owner of the `ssh` child; on Ctrl-C / SIGTERM / remote exit, `Drop` sends SIGTERM then SIGKILL after a grace period. Closing `ssh` drops the connection, SIGHUP reaps the remote serve — no orphan.
+2. **Attach probe ([ORB-10708], [ADR-0353]).** Before spawning anything, `probe_attach` opens a bare forward with no remote command (`build_probe_ssh_args`: `ssh -N -o ExitOnForwardFailure=yes -L <local>:localhost:<remote> <host>`) and polls `GET /healthz` over it (`poll_until_ready`) for `ATTACH_PROBE_TIMEOUT` (5s). If something already answers `200` — another session's tunnel, or a long-lived remote listener — that bare forward *is* the session's tunnel from here on: no remote command is ever sent, so the pre-existing remote process is never touched by this invocation, on connect or on later disconnect. If nothing answers before the probe timeout, the probe forward is torn down and `connect` falls through to spawn mode (steps 3–4) unchanged. An early `ssh` exit during the probe (bad host, auth failure) is not swallowed — it is classified and surfaced immediately, the same as in spawn mode.
+3. **Remote command (spawn mode only).** `remote_serve_command` builds `orbit web serve --no-open --port <remote_port> [--global] [--root <p>]`. `--no-open` is always present (the remote must never open a browser); `--root` is shell-quoted; `--global` is forwarded when set — a no-op against a post-[ORB-10029] remote binary (global is always on), kept so `connect` still works against an older remote that still gates on the flag.
+4. **Tunnel (spawn mode only).** `build_ssh_args` produces `ssh -tt -o ExitOnForwardFailure=yes -L <local>:localhost:<remote> <host> <remote-command>`. `-tt` forces a pty so the remote serve receives SIGHUP when the tunnel drops; `ExitOnForwardFailure=yes` fails fast rather than running the remote with no working forward; stdin is null so Ctrl-C reaches *us*. `wait_until_ready` (built on the same `poll_until_ready` the attach probe uses) polls `/healthz` until it answers `200`, the `ssh` child exits early (classified into an actionable error — `127` = orbit not on remote PATH, `255` = ssh connect failure), or the full 30s `READINESS_TIMEOUT` elapses.
+5. **Teardown.** `SshTunnel` is an RAII owner of whichever `ssh` child this invocation is holding (the attach probe's bare forward, or the spawn-mode tunnel); on Ctrl-C / SIGTERM / remote exit, `Drop` sends SIGTERM then SIGKILL after a grace period. In spawn mode, closing `ssh` drops the connection and SIGHUP reaps the remote serve — no orphan. In attach mode there is no remote command tied to the session, so closing `ssh` only closes the forward — the pre-existing remote process it attached to keeps running.
 
 ## 4. CLI dispatch from anywhere
 
@@ -108,6 +108,8 @@ Neither surface touches the loopback-only bind guard from [ORB-00360]: `check_bi
 - **Aggregate reopens stores per request.** `GET /api/tasks/all` opens each workspace's store on every call — there is no cross-workspace caching of task lists yet.
 - **Unauthenticated on the wire it does reach.** On the loopback interface (local, or the forwarded port), the API is unauthenticated by design; anyone with local access or a foothold on the forwarded port has full dashboard access. The mitigation is the bind guard + SSH, not in-app auth.
 - **Port selection is racy (TOCTOU).** `select_local_port` probes then hands the port to `ssh`; another process can claim it in between. Acceptable for a developer convenience — `ssh -L` fails loudly if so.
+- **The attach-vs-spawn decision is racy too ([ADR-0353]).** Two `connect` invocations starting within the same `ATTACH_PROBE_TIMEOUT` window can both see nothing answering and both fall back to spawning; the second spawn simply fails to bind the remote port and surfaces via the existing exit-code classification. Not eliminated — accepted for a developer convenience command, same posture as the port-selection race above.
+- **Every connect pays a probe round trip.** `probe_attach` runs before any spawn decision, so even the common "nothing running yet" case waits up to `ATTACH_PROBE_TIMEOUT` (5s) before falling through to the original spawn-and-wait flow.
 
 ---
 
@@ -122,5 +124,6 @@ Neither surface touches the loopback-only bind guard from [ORB-00360]: `check_bi
 - [ORB-10310] — Made every task-listing surface status-neutral and bounded by `DEFAULT_TASK_LIST_LIMIT`.
 - [ORB-10319] — Moved logical-workspace catalog and registered-checkout runtime construction into `orbit-remote`; dashboard behavior is unchanged.
 - [ORB-10400] — Gave `GET /api/tasks` server-side status/tag/type filters applied before the limit, plus the `{ items, total, limit, truncated }` page envelope (§2.2). Prerequisite for Bridge's `orbit_task_list` (ws_bridge ORB-10398), which could previously only filter an already-truncated array client-side.
+- [ORB-10708] — Made `orbit web connect` probe for and attach to an already-running remote dashboard instead of always spawning one (§3 step 2). See [ADR-0353](./4_decisions.md).
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/remote-access/4_decisions.md
+++ b/docs/design/remote-access/4_decisions.md
@@ -1,7 +1,7 @@
 ---
 title: "Remote Access — Decisions"
 owner: claude
-last_updated: 2026-07-18
+last_updated: 2026-08-10
 status: Accepted
 feature: remote-access
 doc_role: decisions
@@ -10,7 +10,7 @@ summary: "ADR log: why live viewing supersedes a git-sync registry, why remote a
 tags: [remote-access]
 paths: ["crates/orbit-dashboard/**", "crates/orbit-remote/src/runtime.rs", "crates/orbit-remote/src/workspace_registry.rs"]
 related_features: [remote-access, host-registry]
-related_artifacts: [ADR-0200, ADR-0201, ADR-0234, ORB-00029, ORB-00030, ORB-00360, ORB-10294, ORB-10319]
+related_artifacts: [ADR-0200, ADR-0201, ADR-0234, ADR-0353, ORB-00029, ORB-00030, ORB-00360, ORB-10294, ORB-10319, ORB-10708]
 ---
 
 # Remote Access — Decisions
@@ -69,6 +69,22 @@ The workspace-keyed-state machinery (the `Ws` extractor vs. path-prefixed routes
 
 ---
 
+## ADR-0353 — `orbit web connect` attaches to an already-running remote dashboard instead of always spawning one
+
+**Status:** Accepted · 2026-08 · [ORB-10708]
+
+**Context.** `connect` always appended `orbit web serve` as the trailing remote command on its `ssh -tt` tunnel, assuming nothing was already listening on `remote_port`. A second connect against a remote that already had a dashboard running — another engineer's still-attached tunnel, or a long-lived remote listener meant to be reused — had no way to share it: the remote command it carried simply failed to bind.
+
+**Decision.** Extend the existing readiness probing (`healthz_ok` / the readiness poll loop) rather than add a parallel mechanism. `connect` first opens a bare `-N` port forward with no remote command and polls `/healthz` through it with a short probe timeout; if something answers, that forward becomes the session's tunnel and no remote command is ever sent (attach mode). Only if nothing answers does it fall back to the original flow: a fresh `ssh -tt` session that also carries `orbit web serve`, with the existing full-length readiness wait (spawn mode). Teardown (`SshTunnel::Drop`) is unchanged in shape either way; it just has nothing remote to reap when no remote command was ever sent.
+
+**Consequences.**
+- A remote dashboard can now be shared by concurrent `connect` sessions; only the first one spawns it.
+- Disconnecting from an attached session never touches the process it didn't start.
+- Cost: every `connect` now pays a probe round trip (up to the probe timeout) before it can fall back to spawning, in the common case where nothing is listening yet.
+- Cost: the attach-vs-spawn decision stays racy (TOCTOU) — two invocations starting within the same probe window can both miss and both attempt to spawn; the second spawn fails to bind and surfaces via the existing ssh-exit-code classification. See [ORB-10708] and the store record for the full narrative.
+
+---
+
 ## Task References
 
 - [ORB-00029] — Added `orbit web connect <ssh-host>` and forwarded `--global` to the remote serve.
@@ -77,5 +93,6 @@ The workspace-keyed-state machinery (the `Ws` extractor vs. path-prefixed routes
 - [ORB-10029] — Made global mode the default and only mode for `orbit web serve` (single mode is no longer reachable from the CLI); `--global` is now a deprecated no-op kept for `connect` passthrough compatibility. Does not change either ADR above — the security posture and viewing-not-sync boundary are unaffected — but evolves the `web serve --global` behavior both describe.
 - [ORB-10294] — Live per-request registry refresh for `orbit web serve` ([ADR-0234]): native workspace add/remove/rebind without a restart.
 - [ORB-10319] — Moved the dashboard's catalog/runtime dependencies into `orbit-remote`; this is an implementation-ownership change, not a new remote-access decision.
+- [ORB-10708] — Made `orbit web connect` probe for and attach to an already-running remote dashboard instead of always spawning one ([ADR-0353]).
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/remote-access/specs/ssh-tunnel.md
+++ b/docs/design/remote-access/specs/ssh-tunnel.md
@@ -1,28 +1,32 @@
 # Spec: SSH-Tunnel Connect
 
-`orbit web connect <ssh-host>` establishes a foreground SSH tunnel to a remote machine's loopback dashboard, guarantees the local endpoint answers `/healthz` before returning control, and guarantees the remote `orbit web serve` process is reaped when the tunnel ends. It adds no authentication of its own.
+`orbit web connect <ssh-host>` establishes a foreground SSH tunnel to a remote machine's loopback dashboard, attaching to an already-running remote dashboard when one answers and spawning one only when nothing does ([ORB-10708], [ADR-0353]). It guarantees the local endpoint answers `/healthz` before returning control, and guarantees a remote `orbit web serve` process this invocation spawned is reaped when the tunnel ends — while an attached, pre-existing remote process is never touched. It adds no authentication of its own.
 
 ## Why This Exists
 
-The dashboard binds loopback-only ([ORB-00360]) because it is unauthenticated. Viewing it from another machine therefore requires an authenticated tunnel. Done by hand (`ssh -L 7878:localhost:7878 host "orbit web serve --no-open"`) this leaks orphan remote processes on disconnect and gives no readiness signal. This spec is the contract `connect` upholds so the automated path is safe.
+The dashboard binds loopback-only ([ORB-00360]) because it is unauthenticated. Viewing it from another machine therefore requires an authenticated tunnel. Done by hand (`ssh -L 7878:localhost:7878 host "orbit web serve --no-open"`) this leaks orphan remote processes on disconnect, gives no readiness signal, and cannot share an already-running remote server — a second manual tunnel just fails to bind. This spec is the contract `connect` upholds so the automated path is safe and reusable.
 
 ## Invariants
 
 - **Loopback only, both ends.** The remote serve binds loopback; the forwarded local port binds loopback. `connect` never binds or requests a routable interface.
 - **No Orbit auth.** Authentication and encryption are SSH's. `connect` adds no token, ACL, or session.
+- **Attach before spawn.** `probe_attach` always opens a bare `-N` forward (no remote command) and polls `/healthz` through it before deciding anything. Readiness is decided by the `/healthz` response, never by `ssh`'s own exit code, because a forward can be healthy while nothing is listening behind it. Only a probe timeout with no answer triggers spawn mode.
+- **A spawn never happens behind an already-answering forward.** If the attach probe gets a `200`, no remote command is ever sent for that session — this is what keeps a second `connect` against a live remote dashboard from starting (or failing to start) a second one.
 - **Remote never opens a browser.** `remote_serve_command` always includes `--no-open`; only the local side may open a browser (suppressed by local `--no-open`).
 - **`--root` is shell-quoted.** Any value forwarded to the remote shell that may contain spaces is POSIX single-quoted.
-- **`--global` / `--root` are passthrough only.** They change the remote serve's workspace scope, never the tunnel's security posture.
-- **No orphan remote process.** The tunnel uses a pty (`ssh -tt`); dropping the local `ssh` delivers SIGHUP to the remote session, stopping the remote serve. `SshTunnel::Drop` enforces local teardown (SIGTERM then SIGKILL after a grace period) on every exit path.
-- **Fail fast on forward failure.** `ExitOnForwardFailure=yes` — if the local port cannot be forwarded, `ssh` exits rather than running the remote command with a dead tunnel.
+- **`--global` / `--root` are passthrough only.** They change the remote serve's workspace scope, never the tunnel's security posture. They apply only in spawn mode — attach mode sends no remote command at all, so they have no effect on an attached session.
+- **No orphan spawned process; no touching an attached one.** In spawn mode the tunnel uses a pty (`ssh -tt`); dropping the local `ssh` delivers SIGHUP to the remote session, stopping the remote serve this invocation started. In attach mode the tunnel carries no remote command, so dropping it only closes the forward — a pre-existing remote process is never signalled. `SshTunnel::Drop` enforces local teardown (SIGTERM then SIGKILL after a grace period) on every exit path in both modes.
+- **Fail fast on forward failure.** `ExitOnForwardFailure=yes` on both the probe and the spawn-mode tunnel — if the local port cannot be forwarded, `ssh` exits rather than running (or waiting to run) a remote command with a dead tunnel.
 
 ## Failure Modes
 
-- **`orbit` not on remote PATH** → remote shell exits `127` → actionable error naming the non-interactive-PATH cause.
-- **SSH cannot connect** (bad host, auth, network) → `ssh` exits `255` → actionable error.
-- **Remote serve exits before ready** → classified by exit code; readiness loop returns the error rather than hanging.
-- **Readiness timeout** (default 30s covering SSH connect + remote spawn) → explicit timeout error against `http://localhost:<port>/healthz`.
+- **`orbit` not on remote PATH** (spawn mode) → remote shell exits `127` → actionable error naming the non-interactive-PATH cause.
+- **SSH cannot connect** (bad host, auth, network) → `ssh` exits `255` → actionable error. Surfaces identically whether it happens during the attach probe or the spawn-mode wait.
+- **Remote serve exits before ready** (spawn mode) → classified by exit code; readiness loop returns the error rather than hanging.
+- **Attach probe timeout** (`ATTACH_PROBE_TIMEOUT`, 5s) → not an error: nothing answered, so `connect` tears down the probe forward and falls back to spawn mode.
+- **Readiness timeout** (spawn mode; default 30s covering SSH connect + remote spawn) → explicit timeout error against `http://localhost:<port>/healthz`.
 - **Local port race (TOCTOU)** → `select_local_port` probes then hands the port to `ssh`; if another process claims it in between, `ssh -L` fails loudly on startup. Acceptable for a developer convenience command.
+- **Attach-vs-spawn race (TOCTOU)** → two `connect` invocations starting within the same probe window can both see nothing answering and both fall back to spawning; the second spawn fails to bind the remote port and surfaces via the same exit-code classification as any other spawn-mode bind failure. Not eliminated by this spec; accepted for a developer convenience command.
 
 ## Migration / Compatibility
 
@@ -30,4 +34,4 @@ The dashboard binds loopback-only ([ORB-00360]) because it is unauthenticated. V
 
 ## Agent Signature
 
-Authored by claude for [ORB-00029] (initial command + `--global` passthrough), 2026-07.
+Authored by claude for [ORB-00029] (initial command + `--global` passthrough), 2026-07. Extended by claude for [ORB-10708] (attach-before-spawn probing), 2026-08.


### PR DESCRIPTION
## Task

[ORB-10708](https://orbit-cli.com/tasks/ORB-10708) — Attach to an already-running remote server instead of always starting one

### Description

The SSH-tunnel connect command always appends a remote serve command to its ssh invocation, assuming nothing is listening on the far side. When a server is already running on the remote port, that spawn cannot bind. A second person connecting therefore either fails or leaves a dead remote process behind, and a long-lived remote listener cannot be reused at all.

Make the command attach to what is already there, and start a remote process only when nothing answers.

Constraints:

- Probe readiness through the forward before deciding. Do not infer from exit codes alone; a tunnel can be healthy while the remote command has failed.
- Tear down only what this invocation started. Disconnecting from an attached session must leave a pre-existing remote process running, and must never orphan a process this invocation spawned.
- The loopback-only posture is unchanged; this alters process lifecycle, not exposure.
- Readiness probing, port selection, and teardown classification already exist here. Extend them rather than adding a parallel implementation.

Known pre-existing condition: do not attempt to repair unrelated failing tests encountered in this crate.

### Acceptance Criteria

- Connecting while a remote server is already running succeeds and does not start a second one.
- Connecting while nothing is running starts one and tears it down on exit.
- Disconnecting from an attached session leaves the pre-existing remote process running.
- A spawned remote process is not orphaned on any exit path, including error and interrupt.
- The crate builds and the change carries its own tests.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented attach-before-spawn in `orbit web connect` (crates/orbit-dashboard/src/connect.rs).

What changed:
- New `probe_attach(cfg, local_port)`: opens a bare `ssh -N` port forward (no remote command, via new `build_probe_ssh_args`) and polls `/healthz` through it for `ATTACH_PROBE_TIMEOUT` (5s, via new `poll_until_ready`, which `wait_until_ready` now also delegates to). A 200 within the window means something is already listening remotely — that bare forward becomes the session's `SshTunnel` outright and no remote command is ever sent (attach mode). A timeout tears the probe down and falls through to the original flow: a fresh `ssh -tt` session carrying `orbit web serve` as the trailing remote command, with the existing 30s `READINESS_TIMEOUT` (spawn mode).
- `connect()` now branches on `probe_attach`'s result instead of unconditionally building the spawn-mode args.
- Readiness is decided by the actual `/healthz` response, never by `ssh`'s exit code alone, in both modes (constraint from the task description) — `poll_until_ready` still classifies an early `ssh` exit (bad host/auth) as an error via the existing `classify_ssh_exit`, whether that happens during the probe or the spawn-mode wait.
- Teardown is unchanged in shape (`SshTunnel::Drop` → SIGTERM then SIGKILL after a grace period) and satisfies the lifecycle constraints for free: attach mode never ties a remote command to the session, so dropping it only closes the forward and never touches the pre-existing remote process; spawn mode still uses `-tt` so dropping it delivers SIGHUP and reaps exactly the process this invocation started. This holds on every exit path (`?`-propagated errors, Ctrl-C, normal exit) because the tunnel is always a local `Drop`-owning variable regardless of which branch produced it.

Tests added (crates/orbit-dashboard/src/tests/connect.rs), all passing, no real `ssh` spawned (a `sleep`/`false` child stands in for the tunnel's ssh process, matching the file's existing convention):
- `build_probe_ssh_args_has_no_remote_command`, `build_probe_ssh_args_forwards_distinct_local_and_remote_ports` — pure arg-construction checks (mirrors the existing `build_ssh_args` tests).
- `poll_until_ready_true_when_something_already_answers` — a background thread answers `/healthz` 200 through a real TCP listener; asserts `Ok(true)`.
- `poll_until_ready_false_on_timeout_when_nothing_answers` — nothing bound on the port; asserts `Ok(false)` and that the (fake) tunnel is still alive.
- `poll_until_ready_errors_when_ssh_exits_early` (unix) — child is `false` (exits immediately); asserts `Err(OrbitError::Execution)`.

Validation:
- `cargo build -p orbit-dashboard` — clean.
- `cargo test -p orbit-dashboard` — 232 passed, 16 failed. All 22 `tests::connect::*` (including the 6 new ones) pass. The 16 failures are pre-existing and unrelated (`api::tests::adrs::*`, `api::tests::runs::*` — task-store/ship-endpoint wiring, no connection to connect.rs); the task description explicitly names this as a known pre-existing condition not to repair.
- `make ci-fast` — clean (fmt-check + all guardrail scripts).
- `make ci-lint` — clean (`cargo clippy --workspace --all-targets -- -D warnings`, no warnings).

Scope note: touched only the two context_files (connect.rs; lib.rs was read but not modified — no change was needed there since `pub use connect::{ConnectArgs, connect}` already covers the unchanged public surface). Also updated docs/design/remote-access/{1_overview,2_design,4_decisions}.md and specs/ssh-tunnel.md in the same PR per the repo's same-PR-doc-update convention, and authored ADR-0353 (Accepted, ws_orbit workspace) for the attach-before-spawn decision, since a real alternative existed (always spawn), it's a forward constraint (readiness probing must stay ssh-exit-code-independent), and it has a non-trivial, named cost (the probe adds up to 5s to every connect, and the attach-vs-spawn decision remains TOCTOU-racy).

Self-caught mistake: my first `orbit.adr.add` call omitted the `workspace` param and landed in the bridge's default `ws_polaris` workspace instead of `ws_orbit`. I voided that stray record (ADR-0004 in ws_polaris, retitled/tagged void/agent-error, cleared its paths/related_tasks/related_features) and recreated the real one correctly in `ws_orbit` as ADR-0353. My first `orbit.task.update` call for this summary hit the same default-workspace miss ("task not found: ORB-10708") until I passed `workspace: "ws_orbit"` explicitly — the bridge's orbit parity tools do not infer workspace from repo_root/cwd, so every write here needs an explicit `workspace` argument when not operating against the bridge's default.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10708-6a793e1a`
- Behind base: 0
- Ahead of base: 1