### PR TITLE
[BLOCKED] Add claim-gated remote command execution

### DIFF
--- a/crates/orbit-common/src/authorization.rs
+++ b/crates/orbit-common/src/authorization.rs
@@ -153,6 +153,12 @@ pub const GOVERNED_OPERATIONS: &[GovernedOperation] = &[
         rationale: "resuming a workflow creates another managed run",
     },
     GovernedOperation {
+        id: "orbit.command.exec",
+        surface: OperationSurface::Tool,
+        allowed: &[McpCapability::Operator],
+        rationale: "command execution reaches the machine's shell surface through an explicit argv, not a filtered allowlist",
+    },
+    GovernedOperation {
         id: "orbit.task.delete",
         surface: OperationSurface::Tool,
         allowed: &[McpCapability::Operator],

--- a/crates/orbit-core/src/runtime/command_exec.rs
+++ b/crates/orbit-core/src/runtime/command_exec.rs
@@ -1,0 +1,117 @@
+//! Claim-gated remote command execution [ADR-0351, ORB-10711].
+//!
+//! The shared entry point every submission surface (MCP `orbit.command.exec`,
+//! and any future in-process caller) funnels through, mirroring
+//! [`OrbitRuntime::submit_ship_run`]'s split between a thin tool-dispatch
+//! wrapper and the runtime method that owns the actual gate. `argv` is spawned
+//! directly via [`std::process::Command`] — no shell — so quoting and
+//! operator-precedence bugs cannot occur by construction, not by review.
+//! `orbit-core` spawns the child itself rather than reusing `orbit-exec`'s
+//! `run_process`: that crate is not a declared dependency of `orbit-core`
+//! ([`ARCHITECTURE.md`](../../../../../ARCHITECTURE.md) draws that edge only
+//! from `orbit-tools` and `orbit-engine`), and the one property it adds beyond
+//! `Command::output` — timeout supervision — is not part of this operation's
+//! contract.
+//!
+//! Operator capability is enforced uniformly across every entry point by the
+//! ORB-10453 governed-operation chokepoint before this method is ever reached;
+//! this method owns the second half of the gate the capability check cannot
+//! see — the workspace claim ([`OrbitRuntime::require_workspace_claim`]) — and
+//! the audit record naming what actually ran.
+
+use std::process::Command;
+use std::time::Instant;
+
+use orbit_common::types::{AuditEventStatus, ExecutionResult, OrbitError};
+use orbit_common::utility::redaction::is_sensitive_env_name;
+use serde_json::json;
+
+use super::task_locks::{CoordinationAuditEvent, record_coordination_audit_event};
+use crate::OrbitRuntime;
+
+const COMMAND_TOOL_NAME: &str = "orbit.command.exec";
+const COMMAND_TARGET_TYPE: &str = "command_exec";
+
+/// Parameters for [`OrbitRuntime::execute_remote_command`], already parsed and
+/// typed by the tool-dispatch layer.
+pub(crate) struct RemoteCommandParams {
+    pub(crate) argv: Vec<String>,
+    pub(crate) working_directory: String,
+    pub(crate) claim_token: Option<String>,
+    pub(crate) actor: String,
+}
+
+impl OrbitRuntime {
+    /// Run `params.argv` in `params.working_directory` after the workspace
+    /// claim admits the caller, and audit the attempt regardless of outcome.
+    pub(crate) fn execute_remote_command(
+        &self,
+        params: RemoteCommandParams,
+    ) -> Result<ExecutionResult, OrbitError> {
+        self.require_workspace_claim(COMMAND_TOOL_NAME, params.claim_token.as_deref())?;
+
+        let mut argv = params.argv.into_iter();
+        let program = argv
+            .next()
+            .ok_or_else(|| OrbitError::InvalidInput("`argv` must not be empty".to_string()))?;
+        let args: Vec<String> = argv.collect();
+        let full_argv: Vec<String> = std::iter::once(program.clone())
+            .chain(args.clone())
+            .collect();
+
+        let env_pairs = std::env::vars().filter(|(key, _)| !is_sensitive_env_name(key));
+
+        let started = Instant::now();
+        let result = Command::new(&program)
+            .args(&args)
+            .current_dir(&params.working_directory)
+            .env_clear()
+            .envs(env_pairs)
+            .output()
+            .map(|output| ExecutionResult {
+                success: output.status.success(),
+                stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+                exit_code: output.status.code(),
+                duration_ms: started.elapsed().as_millis() as u64,
+                output: None,
+            })
+            .map_err(|error| {
+                OrbitError::Execution(format!(
+                    "spawn '{program}' in '{}': {error}",
+                    params.working_directory
+                ))
+            });
+
+        let status = if result.is_ok() {
+            AuditEventStatus::Success
+        } else {
+            AuditEventStatus::Failure
+        };
+        if let Err(audit_error) = record_coordination_audit_event(
+            self,
+            CoordinationAuditEvent {
+                command: "command.exec",
+                tool_name: COMMAND_TOOL_NAME,
+                target_type: COMMAND_TARGET_TYPE,
+                target_id: None,
+                task_id: None,
+                status,
+                payload: json!({
+                    "argv": full_argv,
+                    "working_directory": params.working_directory,
+                    "caller": params.actor,
+                    "workspace": self.paths().repo_root.to_string_lossy(),
+                }),
+            },
+        ) {
+            tracing::error!(
+                target: "orbit.command.exec",
+                error = %audit_error,
+                "failed to persist command execution audit event"
+            );
+        }
+
+        result
+    }
+}

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -14,6 +14,7 @@
 pub mod audit;
 mod authorization;
 pub mod builder;
+mod command_exec;
 pub mod engine;
 pub mod event_bus;
 pub mod mutation;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/command_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/command_tools.rs
@@ -1,0 +1,78 @@
+use orbit_common::types::{
+    OrbitError, normalize_optional_attribution_label, optional_string, required_string,
+};
+use serde_json::Value;
+
+use crate::OrbitRuntime;
+use crate::runtime::command_exec::RemoteCommandParams;
+
+pub(super) fn exec(
+    runtime: &OrbitRuntime,
+    input: Value,
+    agent: Option<String>,
+    model: Option<String>,
+) -> Result<Value, OrbitError> {
+    let argv = required_argv(&input)?;
+    let working_directory = required_string(&input, &["working_directory"], "working_directory")?;
+    let claim_token = optional_string(&input, "claim_token")?;
+    let actor = normalize_optional_attribution_label(
+        model.as_deref().or(agent.as_deref()),
+        model.as_deref(),
+    )
+    .unwrap_or_else(|| runtime.actor_label().to_string());
+
+    let result = runtime.execute_remote_command(RemoteCommandParams {
+        argv,
+        working_directory,
+        claim_token,
+        actor,
+    })?;
+
+    serde_json::to_value(result)
+        .map_err(|error| OrbitError::Execution(format!("serialize command exec result: {error}")))
+}
+
+/// Reject anything but a non-empty JSON array of non-empty strings. A shell
+/// string (`argv: "ls -la"`) is the exact mistake this rejects: it would spawn
+/// a single, almost certainly nonexistent program named `"ls -la"` rather than
+/// silently gaining shell semantics, but the explicit rejection here means the
+/// caller learns why immediately instead of chasing a spawn failure.
+fn required_argv(input: &Value) -> Result<Vec<String>, OrbitError> {
+    match input.get("argv") {
+        None | Some(Value::Null) => Err(OrbitError::InvalidInput(
+            "missing `argv`; pass the command as a JSON array of argument strings, e.g. \
+             [\"git\", \"status\"]"
+                .to_string(),
+        )),
+        Some(Value::String(_)) => Err(OrbitError::InvalidInput(
+            "`argv` must be a JSON array of argument strings, never a shell string; command \
+             execution never interprets shell syntax"
+                .to_string(),
+        )),
+        Some(Value::Array(items)) => {
+            if items.is_empty() {
+                return Err(OrbitError::InvalidInput(
+                    "`argv` must not be empty; it must name at least the program to run"
+                        .to_string(),
+                ));
+            }
+            items
+                .iter()
+                .map(|item| {
+                    item.as_str()
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .map(str::to_string)
+                        .ok_or_else(|| {
+                            OrbitError::InvalidInput(
+                                "`argv` entries must be non-empty strings".to_string(),
+                            )
+                        })
+                })
+                .collect()
+        }
+        Some(_) => Err(OrbitError::InvalidInput(
+            "`argv` must be a JSON array of argument strings".to_string(),
+        )),
+    }
+}

--- a/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
@@ -30,6 +30,7 @@ pub(super) fn execute(
         OrbitBuiltinAction::AutoTaskShow => super::auto_task_tools::show(runtime, input),
         OrbitBuiltinAction::AutoTaskUpdate => super::auto_task_tools::update(runtime, input),
         OrbitBuiltinAction::AutoTaskToggle => super::auto_task_tools::toggle(runtime, input),
+        OrbitBuiltinAction::CommandExec => super::command_tools::exec(runtime, input, agent, model),
         OrbitBuiltinAction::DocsList => super::docs_tools::list(runtime, input),
         OrbitBuiltinAction::DocsShow => super::docs_tools::show(runtime, input),
         OrbitBuiltinAction::DocsAdd => super::docs_tools::add(runtime, input),

--- a/crates/orbit-core/src/runtime/orbit_tool_host/mod.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/mod.rs
@@ -1,6 +1,7 @@
 mod adr_tools;
 mod artifact_redaction;
 mod auto_task_tools;
+mod command_tools;
 mod dispatch;
 mod docs_tools;
 pub(crate) mod friction_tools;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/command_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/command_tools.rs
@@ -1,0 +1,184 @@
+//! [ORB-10711, ADR-0351] Claim-gated remote command execution.
+
+use orbit_common::types::OrbitError;
+use serde_json::{Value, json};
+
+use super::super::test_support::{
+    managed_tool_env_guard, run_tool_as_operator, test_runtime, unmanaged_tool_env_guard,
+};
+use crate::OrbitRuntime;
+
+/// Acquire the workspace claim as `actor` and return its token.
+fn acquire_claim(runtime: &OrbitRuntime, actor: &str) -> String {
+    let result = run_tool_as_operator(
+        runtime,
+        "orbit.workspace.claim.acquire",
+        json!({ "model": actor }),
+    )
+    .expect("acquire workspace claim");
+    assert_eq!(result["acquired"], json!(true));
+    result["claim_token"]
+        .as_str()
+        .expect("claim grant carries a token")
+        .to_string()
+}
+
+#[test]
+fn claim_holder_executes_and_receives_stdout_stderr_and_exit_status() {
+    let _env = unmanaged_tool_env_guard();
+    let (_root, runtime, repo_root) = test_runtime();
+    let token = acquire_claim(&runtime, "claude");
+
+    let result = run_tool_as_operator(
+        &runtime,
+        "orbit.command.exec",
+        json!({
+            "argv": ["echo", "hello-from-command-exec"],
+            "working_directory": repo_root.display().to_string(),
+            "claim_token": token,
+            "model": "claude",
+        }),
+    )
+    .expect("the claim holder must be able to execute a command");
+
+    assert_eq!(result["success"], json!(true));
+    assert_eq!(result["exit_code"], json!(0));
+    assert!(
+        result["stdout"]
+            .as_str()
+            .expect("stdout is a string")
+            .contains("hello-from-command-exec"),
+        "unexpected stdout: {result}"
+    );
+}
+
+#[test]
+fn operator_without_the_claim_is_refused() {
+    let _env = unmanaged_tool_env_guard();
+    let (_root, runtime, repo_root) = test_runtime();
+    acquire_claim(&runtime, "claude");
+
+    let error = run_tool_as_operator(
+        &runtime,
+        "orbit.command.exec",
+        json!({
+            "argv": ["echo", "hello"],
+            "working_directory": repo_root.display().to_string(),
+            "model": "codex",
+        }),
+    )
+    .expect_err("a caller without the holder's token must be refused");
+
+    let OrbitError::WorkspaceClaimHeld(claim) = &error else {
+        panic!("expected WorkspaceClaimHeld, got {error:?}");
+    };
+    assert_eq!(claim.operation, "orbit.command.exec");
+    assert_eq!(claim.holder, "claude");
+}
+
+#[test]
+fn shell_string_argv_is_rejected() {
+    let _env = unmanaged_tool_env_guard();
+    let (_root, runtime, repo_root) = test_runtime();
+
+    let error = run_tool_as_operator(
+        &runtime,
+        "orbit.command.exec",
+        json!({
+            "argv": "echo hello",
+            "working_directory": repo_root.display().to_string(),
+            "model": "codex",
+        }),
+    )
+    .expect_err("a shell string must be rejected, not spawned or interpreted");
+
+    let OrbitError::InvalidInput(message) = &error else {
+        panic!("expected InvalidInput, got {error:?}");
+    };
+    assert!(
+        message.contains("shell string"),
+        "unexpected message: {message}"
+    );
+}
+
+#[test]
+fn empty_argv_is_rejected() {
+    let _env = unmanaged_tool_env_guard();
+    let (_root, runtime, repo_root) = test_runtime();
+
+    let error = run_tool_as_operator(
+        &runtime,
+        "orbit.command.exec",
+        json!({
+            "argv": [],
+            "working_directory": repo_root.display().to_string(),
+            "model": "codex",
+        }),
+    )
+    .expect_err("an empty argv names no program to run");
+
+    assert!(matches!(error, OrbitError::InvalidInput(_)), "{error:?}");
+}
+
+#[test]
+fn managed_run_environment_denies_command_exec() {
+    let _env = managed_tool_env_guard("jrun-test-managed-command-exec");
+    let (_root, runtime, repo_root) = test_runtime();
+
+    let error = run_tool_as_operator(
+        &runtime,
+        "orbit.command.exec",
+        json!({
+            "argv": ["echo", "hello"],
+            "working_directory": repo_root.display().to_string(),
+            "model": "codex",
+        }),
+    )
+    .expect_err("a managed run must not execute remote commands");
+
+    assert!(
+        matches!(error, OrbitError::CapabilityDenied(_)),
+        "{error:?}"
+    );
+    assert!(error.to_string().contains("managed runs cannot execute"));
+}
+
+#[test]
+fn audit_record_carries_argv_working_directory_caller_and_workspace() {
+    let _env = unmanaged_tool_env_guard();
+    let (_root, runtime, repo_root) = test_runtime();
+    let token = acquire_claim(&runtime, "claude");
+
+    run_tool_as_operator(
+        &runtime,
+        "orbit.command.exec",
+        json!({
+            "argv": ["echo", "audited-command"],
+            "working_directory": repo_root.display().to_string(),
+            "claim_token": token,
+            "model": "claude",
+        }),
+    )
+    .expect("claim holder executes");
+
+    let events = runtime
+        .list_audit_events(None, None, None, None, 200)
+        .expect("read audit events");
+    let event = events
+        .iter()
+        .find(|event| event.command == "command.exec")
+        .expect("command execution is audited");
+    let payload: Value = event
+        .arguments_json
+        .as_deref()
+        .and_then(|raw| serde_json::from_str(raw).ok())
+        .expect("audit payload is recorded JSON");
+
+    assert_eq!(payload["argv"], json!(["echo", "audited-command"]));
+    assert_eq!(
+        payload["working_directory"],
+        json!(repo_root.display().to_string())
+    );
+    assert_eq!(payload["caller"], json!("claude"));
+    assert_eq!(payload["workspace"], json!(repo_root.display().to_string()));
+}

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/mod.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/mod.rs
@@ -1,4 +1,5 @@
 mod adr_tools;
+mod command_tools;
 mod friction_tools;
 mod learning_tools;
 mod state_tools;

--- a/crates/orbit-remote/src/mcp/tests/discovery.rs
+++ b/crates/orbit-remote/src/mcp/tests/discovery.rs
@@ -69,7 +69,7 @@ fn remote_owns_the_exact_global_discovery_definitions() {
     );
 
     let canonical = canonical_mcp_tool_definitions().expect("canonical definitions");
-    assert_eq!(canonical.len(), 32, "the frozen production surface changed");
+    assert_eq!(canonical.len(), 33, "the frozen production surface changed");
     assert_eq!(
         canonical
             .iter()

--- a/crates/orbit-tools/src/builtin/orbit/command.rs
+++ b/crates/orbit-tools/src/builtin/orbit/command.rs
@@ -1,0 +1,79 @@
+//! Claim-gated remote command execution [ADR-0351, ORB-10711].
+//!
+//! The one operation the owned tunnel (§5.3 of `docs/design/mcp-bridge/2_design.md`)
+//! adds beyond the existing read/write tool surface: an explicit argv plus an
+//! explicit working directory, never a shell string, so quoting and
+//! operator-precedence bugs are impossible by construction. It requires operator
+//! capability (enforced at the MCP policy layer and, uniformly across every
+//! entry point, at the governed-operation chokepoint in
+//! `orbit_common::authorization`) and the workspace claim (enforced in
+//! `OrbitRuntime::execute_remote_command`, the same chokepoint `orbit.workflow.ship`
+//! uses).
+//!
+//! The self-dispatch guard below mirrors `orbit.workflow.ship`/`run.resume`: a
+//! managed run's leaf agent must not reach a general command surface, which
+//! would let it bypass every tool-specific policy by invoking the CLI directly.
+
+use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
+use serde_json::Value;
+
+use crate::{OrbitBuiltinAction, Tool, ToolContext};
+
+pub struct OrbitCommandExecTool;
+
+impl Tool for OrbitCommandExecTool {
+    fn schema(&self) -> ToolSchema {
+        let mut parameters = vec![
+            ToolParam {
+                name: "argv".to_string(),
+                description: "The command as a JSON array of argv strings, program first (e.g. \
+                     [\"git\", \"status\"]). Never a shell string: no shell interprets this \
+                     input, so quoting and operator-precedence bugs cannot occur."
+                    .to_string(),
+                param_type: "string_list".to_string(),
+                required: true,
+            },
+            ToolParam {
+                name: "working_directory".to_string(),
+                description: "Explicit working directory the command runs in.".to_string(),
+                param_type: "string".to_string(),
+                required: true,
+            },
+            ToolParam {
+                name: "claim_token".to_string(),
+                description:
+                    "Token for this workspace's exclusive claim (ADR-0352), required when \
+                     another operator holds one. Falls back to `ORBIT_WORKSPACE_CLAIM_TOKEN`."
+                        .to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+        ];
+        parameters.extend(super::model_identity_params());
+        ToolSchema {
+            name: "orbit.command.exec".to_string(),
+            description:
+                "Execute a command as an explicit argv array in an explicit working directory \
+                 and return its stdout, stderr, and exit status. Requires operator capability \
+                 and the workspace claim; withheld from managed runs."
+                    .to_string(),
+            parameters,
+            builtin: true,
+        }
+    }
+
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        if ctx
+            .orbit_host
+            .as_ref()
+            .is_some_and(|host| host.task_scope().run_id.is_some())
+        {
+            return Err(OrbitError::CapabilityDenied(
+                "managed runs cannot execute remote commands; a leaf agent invoking the CLI \
+                 from inside a run would bypass the self-dispatch guard"
+                    .to_string(),
+            ));
+        }
+        super::execute_host_action(ctx, input, OrbitBuiltinAction::CommandExec)
+    }
+}

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -1,5 +1,6 @@
 pub mod adr;
 pub mod auto_task;
+pub mod command;
 pub mod docs;
 pub mod friction;
 pub mod learning;
@@ -107,6 +108,13 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register_inactive(workspace_claim::OrbitWorkspaceClaimAcquireTool);
     registry.register_inactive(workspace_claim::OrbitWorkspaceClaimReleaseTool);
     registry.register_inactive(workspace_claim::OrbitWorkspaceClaimShowTool);
+    // ORB-10711 [ADR-0351]: the one operation the owned tunnel adds beyond the
+    // existing read/write surface. Operator-only and claim-gated so a
+    // claim-holding operator can reach it, exactly like `orbit.workflow.ship`.
+    registry.register_mcp(
+        command::OrbitCommandExecTool,
+        McpToolPolicy::operator_only(McpToolPlacement::LocalDerived),
+    );
     registry.register_mcp(
         task::start::OrbitTaskStartTool,
         agent_operator(McpToolPlacement::Hub),

--- a/crates/orbit-tools/src/builtin/orbit/tests/command.rs
+++ b/crates/orbit-tools/src/builtin/orbit/tests/command.rs
@@ -1,0 +1,73 @@
+//! [ORB-10711, ADR-0351] The self-dispatch guard on `orbit.command.exec`.
+//!
+//! Mirrors `orbit.workflow.ship`'s guard test: a managed run's leaf agent must
+//! not reach this tool, because it could otherwise invoke the CLI to bypass
+//! every other tool-specific policy. The guard reads `task_scope().run_id`
+//! before the host is ever resolved, so a mock host is enough to prove it —
+//! no runtime, claim, or process spawn required.
+
+use orbit_common::types::OrbitError;
+use serde_json::json;
+use std::sync::Arc;
+
+use crate::builtin::orbit::command::OrbitCommandExecTool;
+use crate::{
+    OrbitBuiltinAction, OrbitTaskScope, OrbitToolHost, ReservationOwnerContext, Tool, ToolContext,
+};
+
+struct ManagedHost;
+
+impl OrbitToolHost for ManagedHost {
+    fn execute(
+        &self,
+        _action: OrbitBuiltinAction,
+        _input: serde_json::Value,
+        _agent: Option<String>,
+        _model: Option<String>,
+        _reservation_owner: Option<ReservationOwnerContext>,
+    ) -> Result<serde_json::Value, OrbitError> {
+        panic!("the guard must refuse before the host is ever reached");
+    }
+
+    fn task_scope(&self) -> OrbitTaskScope {
+        OrbitTaskScope {
+            run_id: Some("jrun-managed".to_string()),
+            ..OrbitTaskScope::default()
+        }
+    }
+}
+
+#[test]
+fn managed_run_rejects_command_exec_before_host_resolution() {
+    let context = ToolContext {
+        orbit_host: Some(Arc::new(ManagedHost)),
+        ..ToolContext::default()
+    };
+
+    let error = OrbitCommandExecTool
+        .execute(
+            &context,
+            json!({"argv": ["git", "status"], "working_directory": "/tmp"}),
+        )
+        .expect_err("managed run must not execute remote commands");
+
+    assert!(
+        matches!(error, OrbitError::CapabilityDenied(_)),
+        "{error:?}"
+    );
+    assert!(error.to_string().contains("managed runs cannot execute"));
+}
+
+#[test]
+fn schema_requires_argv_and_working_directory() {
+    let schema = OrbitCommandExecTool.schema();
+    let required: Vec<&str> = schema
+        .parameters
+        .iter()
+        .filter(|parameter| parameter.required)
+        .map(|parameter| parameter.name.as_str())
+        .collect();
+
+    assert!(required.contains(&"argv"));
+    assert!(required.contains(&"working_directory"));
+}

--- a/crates/orbit-tools/src/builtin/orbit/tests/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/tests/mod.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)]
 
 mod authorization;
+mod command;
 mod identity;
 mod search;

--- a/crates/orbit-tools/src/lib.rs
+++ b/crates/orbit-tools/src/lib.rs
@@ -89,6 +89,7 @@ pub enum OrbitBuiltinAction {
     AutoTaskShow,
     AutoTaskUpdate,
     AutoTaskToggle,
+    CommandExec,
     DocsList,
     DocsShow,
     DocsAdd,

--- a/crates/orbit-tools/tests/mcp_definitions.rs
+++ b/crates/orbit-tools/tests/mcp_definitions.rs
@@ -29,11 +29,30 @@ impl Tool for TestTool {
 fn canonical_builtin_definitions_are_workspace_independent() {
     let definitions =
         canonical_builtin_mcp_tool_definitions().expect("builtin MCP definitions are valid");
-    assert_eq!(definitions.len(), 30);
+    assert_eq!(definitions.len(), 31);
     assert!(
         definitions
             .iter()
             .all(|definition| definition.schema.builtin)
+    );
+}
+
+#[test]
+fn command_exec_is_local_derived_and_operator_only() {
+    let definitions =
+        canonical_builtin_mcp_tool_definitions().expect("builtin MCP definitions are valid");
+
+    let definition = definitions
+        .iter()
+        .find(|definition| definition.schema.name == "orbit.command.exec")
+        .expect("missing orbit.command.exec definition");
+    assert_eq!(
+        definition.policy.placement(),
+        McpToolPlacement::LocalDerived
+    );
+    assert_eq!(
+        definition.policy.allowed_capabilities(),
+        &std::collections::BTreeSet::from([orbit_common::types::McpCapability::Operator])
     );
 }
 

--- a/docs/design/mcp-bridge/references/conformance-v1.yaml
+++ b/docs/design/mcp-bridge/references/conformance-v1.yaml
@@ -83,6 +83,7 @@ tools:
   orbit.auto_task.show: { placement: owner, scope: workspace-required, allowed_capabilities: [agent, operator] }
   orbit.auto_task.update: { placement: owner, scope: workspace-required, allowed_capabilities: [agent, operator] }
   orbit.auto_task.toggle: { placement: owner, scope: workspace-required, allowed_capabilities: [agent, operator] }
+  orbit.command.exec: { placement: local-derived, scope: workspace-required, allowed_capabilities: [operator] }
 
 hub_schema_digest:
   domain_tag: orbit.mcp.hub-schema.v1


### PR DESCRIPTION
## Manual resolution required

Orbit preserved and pushed this task's pre-rebase candidate after the shipment pipeline stopped. This PR is intentionally blocked and must be reconciled manually before merge.

- Task: `ORB-10711`
- Run: `jrun-20260810-0521-5`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `9784681ea53079f6a46cc7ee2c1aaafa6f45adbd`
- Target base: `6f1edd7e7897da7abe2967c8cd2ea4fc7c5a58c9`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: agent step did not complete: the provider exited 0 but stdout carried no valid terminating Orbit response envelope (agent protocol violation: stdout does not contain an Orbit response envelope). The invocation ended without finishing its contract — typically an agent that yielded mid-work — so this step's work is incomplete and only what it persisted before stopping is durable.
```