### PR TITLE
[BLOCKED] Make the Orbit sweep clock cadence configurable and controllable

### DIFF
--- a/.orbit/adrs/proposed/ADR-0355/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0355/adr.yaml
@@ -1,0 +1,23 @@
+schema_version: 2
+id: ADR-0355
+title: Host-local sweep clock configuration
+status: proposed
+owner: codex
+created_at: 2026-08-11T03:19:18.858604213Z
+last_updated: 2026-08-11T03:19:25.292253007Z
+related_features:
+- routines
+related_tasks:
+- ORB-10720
+tags:
+- routines
+- clock
+- scheduler
+paths:
+- crates/orbit-core/src/routines/**
+- crates/orbit-cli/src/command/routine/**
+- docs/design/routines/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/proposed/ADR-0355/body.md
+++ b/.orbit/adrs/proposed/ADR-0355/body.md
@@ -1,0 +1,9 @@
+## Context
+The OS sweep clock is shared host infrastructure but previously had a hard-coded minutely cadence and only native-manager controls. The alternatives were a workspace routine setting, which would make one workspace own host infrastructure, or a host-local configuration plus Orbit CLI controls.
+
+## Decision
+Store the supported whole-minute cadence in host-local `~/.orbit/clock.toml` and expose it through `orbit routine clock`. Native launchd/systemd user services remain the authority for enabled state; routine pauses and manual `orbit sweep` remain separate.
+
+## Consequences
+- Clock status reports configured and effective cadence, and native-manager failures include recovery commands.
+- Cost: the host-local setting intentionally does not travel with a workspace, so operators configure each host separately.

--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -397,6 +397,7 @@ impl Commands {
                     RoutineSubcommand::Show(_) => "show",
                     RoutineSubcommand::Pause(_) => "pause",
                     RoutineSubcommand::Resume(_) => "resume",
+                    RoutineSubcommand::Clock(_) => "clock",
                     RoutineSubcommand::Init(_) => "init",
                 };
                 CommandOperation::new(

--- a/crates/orbit-cli/src/command/routine/clock.rs
+++ b/crates/orbit-cli/src/command/routine/clock.rs
@@ -1,0 +1,69 @@
+use clap::{Args, Subcommand};
+use orbit_core::routines::{clock_status, set_clock_cadence, set_clock_enabled};
+use orbit_remote::workspace_registry;
+
+use crate::command::{CommandOut, CommandOutput};
+
+#[derive(Args)]
+#[command(
+    after_help = "This controls the host-wide OS clock that invokes `orbit sweep`; it does not change `orbit routine pause <name>` state or prevent a manual `orbit sweep`."
+)]
+pub struct RoutineClockArgs {
+    #[command(subcommand)]
+    command: RoutineClockSubcommand,
+}
+
+#[derive(Subcommand)]
+enum RoutineClockSubcommand {
+    /// Show configured cadence and native manager state
+    Status,
+    /// Disable scheduled sweep invocations; manual `orbit sweep` remains available
+    Pause,
+    /// Enable scheduled sweep invocations using the configured cadence
+    Enable,
+    /// Persist a whole-minute cadence and reload the installed clock unit
+    Set {
+        #[arg(long)]
+        cadence_seconds: u64,
+    },
+}
+
+impl RoutineClockArgs {
+    pub fn execute_without_runtime(self) -> CommandOut {
+        let global_root = workspace_registry::global_orbit_dir()?;
+        match self.command {
+            RoutineClockSubcommand::Status => {
+                let status = clock_status(&global_root)?;
+                println!(
+                    "clock: {} | configured cadence: {}s | effective cadence: {} | platform: {}",
+                    if status.enabled { "enabled" } else { "paused" },
+                    status.configured_cadence_seconds,
+                    status
+                        .effective_cadence_seconds
+                        .map(|value| format!("{value}s"))
+                        .unwrap_or_else(|| "inactive".to_string()),
+                    status.platform
+                );
+            }
+            RoutineClockSubcommand::Pause => {
+                let status = set_clock_enabled(&global_root, false)?;
+                println!(
+                    "host sweep clock paused ({}); manual `orbit sweep` remains available",
+                    status.platform
+                );
+            }
+            RoutineClockSubcommand::Enable => {
+                let status = set_clock_enabled(&global_root, true)?;
+                println!(
+                    "host sweep clock enabled: runs every {} seconds ({})",
+                    status.configured_cadence_seconds, status.platform
+                );
+            }
+            RoutineClockSubcommand::Set { cadence_seconds } => {
+                set_clock_cadence(&global_root, cadence_seconds)?;
+                println!("host sweep clock cadence set to {cadence_seconds} seconds and reloaded");
+            }
+        }
+        Ok(CommandOutput::Silent)
+    }
+}

--- a/crates/orbit-cli/src/command/routine/command.rs
+++ b/crates/orbit-cli/src/command/routine/command.rs
@@ -6,6 +6,7 @@
 
 use clap::{Args, Subcommand};
 
+use super::clock::RoutineClockArgs;
 use super::init::RoutineInitArgs;
 use super::list::RoutineListArgs;
 use super::pause::RoutinePauseArgs;
@@ -45,6 +46,8 @@ pub enum RoutineSubcommand {
     Pause(RoutinePauseArgs),
     /// Clear a host-local pause
     Resume(RoutineResumeArgs),
+    /// Show, pause, enable, or configure the host OS sweep clock
+    Clock(RoutineClockArgs),
     /// Read this host's identity and optionally install the OS clock unit
     Init(RoutineInitArgs),
 }
@@ -56,6 +59,7 @@ impl RoutineSubcommand {
             Self::Show(args) => args.execute_without_runtime(),
             Self::Pause(args) => args.execute_without_runtime(),
             Self::Resume(args) => args.execute_without_runtime(),
+            Self::Clock(args) => args.execute_without_runtime(),
             Self::Init(args) => args.execute_without_runtime(),
         }
     }

--- a/crates/orbit-cli/src/command/routine/mod.rs
+++ b/crates/orbit-cli/src/command/routine/mod.rs
@@ -1,3 +1,4 @@
+mod clock;
 mod command;
 mod init;
 mod list;

--- a/crates/orbit-core/assets/clock/com.orbit.sweep.plist
+++ b/crates/orbit-core/assets/clock/com.orbit.sweep.plist
@@ -14,7 +14,7 @@
         <string>sweep</string>
     </array>
     <key>StartInterval</key>
-    <integer>60</integer>
+    <integer>{{CADENCE_SECONDS}}</integer>
     <key>RunAtLoad</key>
     <true/>
     <key>StandardOutPath</key>

--- a/crates/orbit-core/assets/clock/orbit-sweep.timer
+++ b/crates/orbit-core/assets/clock/orbit-sweep.timer
@@ -1,11 +1,11 @@
-# Minutely timer for `orbit sweep` [ORB-10021] / ADR-0204.
+# Configured timer for `orbit sweep` [ORB-10720] / ADR-0204.
 # Persistent=true covers host downtime at the OS layer; per-routine
 # `missed_run` policy decides whether a covered gap produces a make-up fire.
 [Unit]
-Description=Run orbit sweep every minute
+Description=Run orbit sweep every {{CADENCE_SECONDS}} seconds
 
 [Timer]
-OnCalendar=*:*:00
+OnUnitActiveSec={{CADENCE_SECONDS}}s
 Persistent=true
 AccuracySec=5s
 

--- a/crates/orbit-core/src/routines/clock.rs
+++ b/crates/orbit-core/src/routines/clock.rs
@@ -9,6 +9,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use orbit_common::types::OrbitError;
+use orbit_common::utility::fs::atomic_write_text;
+use serde::{Deserialize, Serialize};
 
 const LAUNCHD_PLIST_TEMPLATE: &str = include_str!("../../assets/clock/com.orbit.sweep.plist");
 const SYSTEMD_SERVICE_TEMPLATE: &str = include_str!("../../assets/clock/orbit-sweep.service");
@@ -18,6 +20,101 @@ const SYSTEMD_TIMER_TEMPLATE: &str = include_str!("../../assets/clock/orbit-swee
 pub const LAUNCHD_LABEL: &str = "com.orbit.sweep";
 /// systemd unit base name (Linux).
 pub const SYSTEMD_UNIT: &str = "orbit-sweep";
+pub const DEFAULT_CLOCK_CADENCE_SECONDS: u64 = 60;
+const MIN_CLOCK_CADENCE_SECONDS: u64 = 60;
+const MAX_CLOCK_CADENCE_SECONDS: u64 = 3_600;
+
+/// Host-local settings for the OS clock. This deliberately lives beside the
+/// host database rather than in a workspace config: every registered workspace
+/// shares one clock.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ClockSettings {
+    pub cadence_seconds: u64,
+}
+
+impl Default for ClockSettings {
+    fn default() -> Self {
+        Self {
+            cadence_seconds: DEFAULT_CLOCK_CADENCE_SECONDS,
+        }
+    }
+}
+
+impl ClockSettings {
+    pub fn validate(self) -> Result<Self, OrbitError> {
+        if !(MIN_CLOCK_CADENCE_SECONDS..=MAX_CLOCK_CADENCE_SECONDS).contains(&self.cadence_seconds)
+            || self.cadence_seconds % 60 != 0
+        {
+            return Err(OrbitError::InvalidInput(format!(
+                "clock cadence_seconds must be a whole minute from {MIN_CLOCK_CADENCE_SECONDS} to {MAX_CLOCK_CADENCE_SECONDS} (got {})",
+                self.cadence_seconds
+            )));
+        }
+        Ok(self)
+    }
+}
+
+pub fn clock_settings_path(global_root: &Path) -> PathBuf {
+    global_root.join("clock.toml")
+}
+
+pub fn load_clock_settings(global_root: &Path) -> Result<ClockSettings, OrbitError> {
+    let path = clock_settings_path(global_root);
+    if !path.exists() {
+        return Ok(ClockSettings::default());
+    }
+    let raw = fs::read_to_string(&path)
+        .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
+    toml::from_str::<ClockSettings>(&raw)
+        .map_err(|error| {
+            OrbitError::InvalidInput(format!(
+                "invalid clock configuration {}: {error}",
+                path.display()
+            ))
+        })?
+        .validate()
+}
+
+pub fn save_clock_settings(global_root: &Path, settings: ClockSettings) -> Result<(), OrbitError> {
+    let settings = settings.validate()?;
+    let rendered = toml::to_string(&settings).map_err(|error| {
+        OrbitError::Execution(format!("serialize clock configuration: {error}"))
+    })?;
+    atomic_write_text(&clock_settings_path(global_root), &rendered)
+        .map_err(|error| OrbitError::Io(format!("write clock configuration: {error}")))
+}
+
+/// Change cadence transactionally from the operator's perspective: the
+/// persisted setting is restored if the reloaded native unit cannot activate.
+pub fn set_clock_cadence(
+    global_root: &Path,
+    cadence_seconds: u64,
+) -> Result<ClockInstallReport, OrbitError> {
+    let previous = load_clock_settings(global_root)?;
+    save_clock_settings(global_root, ClockSettings { cadence_seconds })?;
+    match install_clock(global_root) {
+        Ok(report) if report.activated => Ok(report),
+        Ok(report) => {
+            save_clock_settings(global_root, previous)?;
+            Err(OrbitError::Execution(format!(
+                "clock update was not activated; restored the previous configured cadence; recovery: {}",
+                report.manual_steps.join("; ")
+            )))
+        }
+        Err(error) => {
+            save_clock_settings(global_root, previous)?;
+            Err(error)
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClockStatus {
+    pub configured_cadence_seconds: u64,
+    pub effective_cadence_seconds: Option<u64>,
+    pub enabled: bool,
+    pub platform: &'static str,
+}
 
 /// Path launchd redirects `orbit sweep` stdout/stderr to on macOS, and the
 /// file `run_sweep` rotates so it stays bounded on an always-on host. Single
@@ -50,14 +147,19 @@ pub fn install_clock(global_root: &Path) -> Result<ClockInstallReport, OrbitErro
         .map_err(|error| OrbitError::Io(format!("resolve current orbit executable: {error}")))?;
     let orbit_bin = orbit_bin.to_string_lossy().to_string();
 
+    let settings = load_clock_settings(global_root)?;
     if cfg!(target_os = "macos") {
-        install_launchd(global_root, &orbit_bin)
+        install_launchd(global_root, &orbit_bin, settings)
     } else {
-        install_systemd(&orbit_bin)
+        install_systemd(&orbit_bin, settings)
     }
 }
 
-fn install_launchd(global_root: &Path, orbit_bin: &str) -> Result<ClockInstallReport, OrbitError> {
+fn install_launchd(
+    global_root: &Path,
+    orbit_bin: &str,
+    settings: ClockSettings,
+) -> Result<ClockInstallReport, OrbitError> {
     let home = home_dir()?;
     let log_path = sweep_log_path(global_root);
     if let Some(parent) = log_path.parent() {
@@ -65,6 +167,7 @@ fn install_launchd(global_root: &Path, orbit_bin: &str) -> Result<ClockInstallRe
     }
     let plist = LAUNCHD_PLIST_TEMPLATE
         .replace("{{ORBIT_BIN}}", orbit_bin)
+        .replace("{{CADENCE_SECONDS}}", &settings.cadence_seconds.to_string())
         .replace("{{LOG_PATH}}", &log_path.to_string_lossy());
 
     let agents_dir = home.join("Library/LaunchAgents");
@@ -101,20 +204,24 @@ fn install_launchd(global_root: &Path, orbit_bin: &str) -> Result<ClockInstallRe
     })
 }
 
-fn install_systemd(orbit_bin: &str) -> Result<ClockInstallReport, OrbitError> {
+fn install_systemd(
+    orbit_bin: &str,
+    settings: ClockSettings,
+) -> Result<ClockInstallReport, OrbitError> {
     let home = home_dir()?;
     let unit_dir = home.join(".config/systemd/user");
     fs::create_dir_all(&unit_dir).map_err(|error| OrbitError::Io(error.to_string()))?;
 
     let service_path = unit_dir.join(format!("{SYSTEMD_UNIT}.service"));
     let timer_path = unit_dir.join(format!("{SYSTEMD_UNIT}.timer"));
-    fs::write(&service_path, render_systemd_service(orbit_bin)).map_err(|error| {
+    atomic_write_text(&service_path, &render_systemd_service(orbit_bin)).map_err(|error| {
         OrbitError::Io(format!(
             "failed to write '{}': {error}",
             service_path.display()
         ))
     })?;
-    fs::write(&timer_path, SYSTEMD_TIMER_TEMPLATE).map_err(|error| {
+    let timer = render_systemd_timer(settings);
+    atomic_write_text(&timer_path, &timer).map_err(|error| {
         OrbitError::Io(format!(
             "failed to write '{}': {error}",
             timer_path.display()
@@ -156,6 +263,110 @@ fn install_systemd(orbit_bin: &str) -> Result<ClockInstallReport, OrbitError> {
 /// Render the systemd service independently of the user manager environment.
 pub(super) fn render_systemd_service(orbit_bin: &str) -> String {
     SYSTEMD_SERVICE_TEMPLATE.replace("{{ORBIT_BIN}}", orbit_bin)
+}
+
+pub(super) fn render_systemd_timer(settings: ClockSettings) -> String {
+    SYSTEMD_TIMER_TEMPLATE.replace("{{CADENCE_SECONDS}}", &settings.cadence_seconds.to_string())
+}
+
+/// Enable or pause the native per-user clock. This does not touch the routine
+/// store, so manual `orbit sweep` and per-routine pause state remain available.
+pub fn set_clock_enabled(global_root: &Path, enabled: bool) -> Result<ClockStatus, OrbitError> {
+    let settings = load_clock_settings(global_root)?;
+    let (program, args, recovery): (&str, Vec<String>, String) = if cfg!(target_os = "macos") {
+        let home = home_dir()?;
+        let plist = home
+            .join("Library/LaunchAgents")
+            .join(format!("{LAUNCHD_LABEL}.plist"));
+        if enabled {
+            (
+                "launchctl",
+                vec!["load".into(), plist.display().to_string()],
+                format!("launchctl load {}", plist.display()),
+            )
+        } else {
+            (
+                "launchctl",
+                vec!["unload".into(), plist.display().to_string()],
+                format!("launchctl unload {}", plist.display()),
+            )
+        }
+    } else if enabled {
+        (
+            "systemctl",
+            vec![
+                "--user".into(),
+                "enable".into(),
+                "--now".into(),
+                format!("{SYSTEMD_UNIT}.timer"),
+            ],
+            format!("systemctl --user enable --now {SYSTEMD_UNIT}.timer"),
+        )
+    } else {
+        (
+            "systemctl",
+            vec![
+                "--user".into(),
+                "disable".into(),
+                "--now".into(),
+                format!("{SYSTEMD_UNIT}.timer"),
+            ],
+            format!("systemctl --user disable --now {SYSTEMD_UNIT}.timer"),
+        )
+    };
+    let output = Command::new(program)
+        .args(&args)
+        .output()
+        .map_err(|error| {
+            OrbitError::Execution(format!("run {program}: {error}; recovery: {recovery}"))
+        })?;
+    if !output.status.success() {
+        return Err(OrbitError::Execution(format!(
+            "{program} {} failed; recovery: {recovery}",
+            args.join(" ")
+        )));
+    }
+    Ok(ClockStatus {
+        configured_cadence_seconds: settings.cadence_seconds,
+        effective_cadence_seconds: Some(settings.cadence_seconds),
+        enabled,
+        platform: if cfg!(target_os = "macos") {
+            "launchd"
+        } else {
+            "systemd"
+        },
+    })
+}
+
+pub fn clock_status(global_root: &Path) -> Result<ClockStatus, OrbitError> {
+    let settings = load_clock_settings(global_root)?;
+    let (program, args) = if cfg!(target_os = "macos") {
+        ("launchctl", vec!["list".into(), LAUNCHD_LABEL.into()])
+    } else {
+        (
+            "systemctl",
+            vec![
+                "--user".into(),
+                "is-enabled".into(),
+                format!("{SYSTEMD_UNIT}.timer"),
+            ],
+        )
+    };
+    let enabled = Command::new(program)
+        .args(&args)
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false);
+    Ok(ClockStatus {
+        configured_cadence_seconds: settings.cadence_seconds,
+        effective_cadence_seconds: enabled.then_some(settings.cadence_seconds),
+        enabled,
+        platform: if cfg!(target_os = "macos") {
+            "launchd"
+        } else {
+            "systemd"
+        },
+    })
 }
 
 fn home_dir() -> Result<PathBuf, OrbitError> {

--- a/crates/orbit-core/src/routines/mod.rs
+++ b/crates/orbit-core/src/routines/mod.rs
@@ -21,7 +21,10 @@ pub mod status;
 pub mod sweep;
 pub mod validation;
 
-pub use clock::{ClockInstallReport, install_clock};
+pub use clock::{
+    ClockInstallReport, ClockSettings, ClockStatus, DEFAULT_CLOCK_CADENCE_SECONDS, clock_status,
+    install_clock, load_clock_settings, save_clock_settings, set_clock_cadence, set_clock_enabled,
+};
 pub use due::{DueDecision, due_decision, parse_cron};
 pub use loader::{
     DiscoveredWorkspaces, LoadedRoutine, RoutineCollection, RoutineLoadError, RoutineOrigin,

--- a/crates/orbit-core/src/routines/tests/clock.rs
+++ b/crates/orbit-core/src/routines/tests/clock.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use tempfile::tempdir;
 
-use super::super::clock::render_systemd_service;
+use super::super::clock::{ClockSettings, render_systemd_service, render_systemd_timer};
 
 fn service_path(rendered: &str) -> &str {
     rendered
@@ -56,4 +56,40 @@ fn rendered_systemd_service_discovers_local_provider_launchers() {
     assert!(rendered.contains("Type=oneshot"));
     assert!(rendered.contains("KillMode=process"));
     assert!(rendered.contains("ExecStart=/opt/orbit/bin/orbit sweep"));
+}
+
+#[test]
+fn systemd_timer_renders_default_and_configured_cadence() {
+    assert!(render_systemd_timer(ClockSettings::default()).contains("OnUnitActiveSec=60s"));
+    assert!(
+        render_systemd_timer(ClockSettings {
+            cadence_seconds: 300
+        })
+        .contains("OnUnitActiveSec=300s")
+    );
+}
+
+#[test]
+fn clock_cadence_rejects_subminute_and_out_of_range_values() {
+    assert!(
+        ClockSettings {
+            cadence_seconds: 30
+        }
+        .validate()
+        .is_err()
+    );
+    assert!(
+        ClockSettings {
+            cadence_seconds: 90
+        }
+        .validate()
+        .is_err()
+    );
+    assert!(
+        ClockSettings {
+            cadence_seconds: 3_660
+        }
+        .validate()
+        .is_err()
+    );
 }

--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -1,7 +1,7 @@
 ---
 title: Routines — Design
 owner: claude
-last_updated: 2026-07-18
+last_updated: 2026-08-11
 status: Accepted
 feature: routines
 doc_role: design
@@ -10,7 +10,7 @@ summary: Proposed contract for routine definitions, sweep dispatch, host-local s
 tags: [routines, scheduler]
 paths: ["crates/orbit-cli/src/command/routine/**", "crates/orbit-core/src/routines/**", "crates/orbit-remote/src/routines.rs", "crates/orbit-store/src/sqlite/routine_store/**"]
 related_features: [routines, activity-job, host-registry]
-related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ADR-0223]
+related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ADR-0223, ADR-0355]
 ---
 
 # Routines — Design
@@ -19,6 +19,24 @@ This doc is the v1 contract as shipped in [ORB-10021]: the routine definition sc
 how definitions are discovered, what `orbit sweep` does on each invocation, where state
 lives, and how the OS clock drives it. Cross-host coordination, event triggers, and everything else deferred is
 in [3_vision.md](./3_vision.md). Decision rationale lives in [4_decisions.md](./4_decisions.md).
+
+## OS sweep clock controls
+
+There are two independent scheduling layers. The per-user OS clock wakes Orbit and
+invokes the stateless `orbit sweep` pass; each versioned routine's cron expression then
+decides whether that pass fires work. The OS clock is host-local infrastructure, not a
+routine definition. Its durable configuration is `~/.orbit/clock.toml`, defaults to a
+60-second cadence, and accepts only whole-minute values from 60 through 3600 seconds.
+
+`orbit routine clock status` reports both configured cadence and the native manager's
+effective enabled state. `orbit routine clock pause` disables only launchd/systemd
+scheduled invocations (surviving logout/reboot through the native per-user manager);
+it preserves routine cursors, fire history, and per-routine pauses, and a deliberate
+`orbit sweep` is still available. `enable` resumes with the configured cadence, while
+`set --cadence-seconds N` atomically rewrites the host setting and reloads the existing
+unit identity. On an activation failure Orbit reports the concrete native recovery
+command rather than claiming the clock is active. launchd and systemd user managers are
+the supported platforms; there is no resident Orbit daemon ([ADR-0355]).
 
 ---
 


### PR DESCRIPTION
## Manual resolution required

Orbit preserved and pushed this task's pre-rebase candidate after the shipment pipeline stopped. This PR is intentionally blocked and must be reconciled manually before merge.

- Task: `ORB-10720`
- Run: `jrun-20260811-0312-3`
- Failed step: `commit`
- Error code: `pipeline_step_failed`
- Original base: `31cee2c06228076aaead375720ff449e336a54e7`
- Target base: `31cee2c06228076aaead375720ff449e336a54e7`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
deterministic action `git_commit` failed: execution failed: task 'ORB-10720' cannot be delivered: its persisted execution_summary begins with 'Outcome: failed'; durable delivery fails closed when the task record reports failure
```