### PR TITLE
Host identity v2: add task_prefix, remove mode (ADR-0355, ADR-0356)

### DIFF
--- a/crates/orbit-cli/src/command/host/register.rs
+++ b/crates/orbit-cli/src/command/host/register.rs
@@ -61,6 +61,7 @@ impl Execute for HostRegisterArgs {
                     schema_version: HOST_IDENTITY_SCHEMA_VERSION,
                     machine_id,
                     host_id,
+                    task_prefix: "ORB".to_string(),
                     // Mode is not persisted in the hub record; a declared remote
                     // host carries no local operating mode here.
                     mode: HostMode::Standalone,

--- a/crates/orbit-cli/src/command/init.rs
+++ b/crates/orbit-cli/src/command/init.rs
@@ -8,7 +8,8 @@ use orbit_core::config::agent_prompt::{
 use orbit_core::{OrbitError, OrbitRuntime};
 use orbit_remote::workspace_registry::global_orbit_dir;
 use orbit_remote::{
-    HostIdentityOutcome, HostMode, NewHostIdentity, ensure_host_identity, os_hostname,
+    HostIdentityOutcome, NewHostIdentity, ensure_host_identity, os_hostname,
+    validate_new_task_prefix,
 };
 use std::collections::BTreeMap;
 use std::io::{self, Write};
@@ -35,10 +36,11 @@ pub struct InitCommand {
     #[arg(long)]
     pub host_name: Option<String>,
 
-    /// Host operating mode for this machine's identity: standalone | hub |
-    /// spoke. Defaults to standalone. Used only on first init.
-    #[arg(long, value_name = "MODE")]
-    pub host_mode: Option<String>,
+    /// Immutable task-id namespace for this machine (2-5 uppercase ASCII
+    /// letters). Required on first init; reserved artifact namespaces cannot
+    /// be chosen.
+    #[arg(long, value_name = "PREFIX")]
+    pub task_prefix: Option<String>,
 }
 
 impl Execute for InitCommand {
@@ -83,7 +85,7 @@ impl InitCommand {
             root_override,
             self.non_interactive,
             self.host_name,
-            self.host_mode,
+            self.task_prefix,
         )?;
         let paths = reported_init_paths(root_override);
         print_init_result(InitOutput {
@@ -104,44 +106,46 @@ impl InitCommand {
     }
 }
 
-/// Create or migrate this machine's host identity. Host name and mode are only
+/// Create or migrate this machine's host identity. Host name and task prefix are only
 /// consulted when the identity is absent (a fresh create); a present identity
 /// is preserved unchanged and a legacy file is migrated without prompting.
 fn ensure_host_identity_for_init(
     root_override: Option<&Path>,
     non_interactive: bool,
     host_name: Option<String>,
-    host_mode: Option<String>,
+    task_prefix: Option<String>,
 ) -> Result<(), OrbitError> {
     let global_root = match root_override {
         Some(root) => root.to_path_buf(),
         None => global_orbit_dir()?,
     };
-    // Validate an explicit mode up front so an invalid value fails closed even
-    // when the identity already exists.
-    let requested_mode = match host_mode.as_deref() {
-        Some(mode) => Some(HostMode::parse(mode)?),
-        None => None,
-    };
-
     let outcome = ensure_host_identity(&global_root, move || {
         let host_id = match host_name {
             Some(name) => name,
             None if non_interactive => {
                 return Err(OrbitError::InvalidInput(
-                    "host identity is absent; pass --host-name (and optionally --host-mode) \
+                    "host identity is absent; pass --host-name and --task-prefix \
                      to initialize a fresh host non-interactively"
                         .to_string(),
                 ));
             }
             None => prompt_host_name()?,
         };
-        let mode = match requested_mode {
-            Some(mode) => mode,
-            None if non_interactive => HostMode::Standalone,
-            None => prompt_host_mode()?,
+        let task_prefix = match task_prefix {
+            Some(prefix) => validate_new_task_prefix(&prefix)?,
+            None if non_interactive => {
+                return Err(OrbitError::InvalidInput(
+                    "host identity is absent; pass --task-prefix <PREFIX> (2-5 uppercase ASCII letters) \
+                     to initialize a fresh host non-interactively"
+                        .to_string(),
+                ));
+            }
+            None => prompt_task_prefix()?,
         };
-        Ok(NewHostIdentity { host_id, mode })
+        Ok(NewHostIdentity {
+            host_id,
+            task_prefix,
+        })
     })?;
 
     report_host_identity(&outcome);
@@ -156,8 +160,8 @@ fn report_host_identity(outcome: &HostIdentityOutcome) {
         HostIdentityOutcome::Unchanged(_) => "unchanged",
     };
     println!(
-        "host identity ({verb}): host_id=\"{}\", machine_id={}, mode={}",
-        identity.host_id, identity.machine_id, identity.mode
+        "host identity ({verb}): host_id=\"{}\", machine_id={}, task_prefix={}",
+        identity.host_id, identity.machine_id, identity.task_prefix
     );
 }
 
@@ -181,14 +185,11 @@ fn prompt_host_name() -> Result<String, OrbitError> {
     }
 }
 
-fn prompt_host_mode() -> Result<HostMode, OrbitError> {
+fn prompt_task_prefix() -> Result<String, OrbitError> {
     loop {
-        let answer = read_line("Host mode (standalone/hub/spoke) [standalone]: ")?;
-        if answer.is_empty() {
-            return Ok(HostMode::Standalone);
-        }
-        match HostMode::parse(&answer) {
-            Ok(mode) => return Ok(mode),
+        let answer = read_line("Task prefix (2-5 uppercase ASCII letters): ")?;
+        match validate_new_task_prefix(&answer) {
+            Ok(prefix) => return Ok(prefix),
             Err(error) => println!("{error}"),
         }
     }

--- a/crates/orbit-cli/src/command/tests/init.rs
+++ b/crates/orbit-cli/src/command/tests/init.rs
@@ -74,7 +74,7 @@ fn non_interactive_init_against_non_global_root_leaves_home_skill_links_untouche
             force: false,
             non_interactive: true,
             host_name: Some("validation-host".to_string()),
-            host_mode: None,
+            task_prefix: Some("VA".to_string()),
         }
         .execute_without_runtime(Some(&validation_root.path().join(".orbit")))
     });
@@ -85,7 +85,7 @@ fn non_interactive_init_against_non_global_root_leaves_home_skill_links_untouche
     let host_toml = validation_root.path().join(".orbit").join("host.toml");
     let host_contents = fs::read_to_string(&host_toml).expect("read host.toml");
     assert!(
-        host_contents.contains("schema_version = 1"),
+        host_contents.contains("schema_version = 2"),
         "{host_contents}"
     );
     assert!(
@@ -93,9 +93,10 @@ fn non_interactive_init_against_non_global_root_leaves_home_skill_links_untouche
         "{host_contents}"
     );
     assert!(
-        host_contents.contains("mode = \"standalone\""),
+        host_contents.contains("task_prefix = \"VA\""),
         "{host_contents}"
     );
+    assert!(!host_contents.contains("mode ="), "{host_contents}");
 
     assert_discovery_sentinel(&agents_link, &agents_target);
     assert_discovery_sentinel(&claude_link, &claude_target);
@@ -194,31 +195,33 @@ fn non_interactive_init_against_non_global_root_leaves_home_skill_links_untouche
 fn init_host(
     root: &Path,
     host_name: Option<&str>,
-    host_mode: Option<&str>,
+    task_prefix: Option<&str>,
 ) -> Result<(), orbit_core::OrbitError> {
     InitCommand {
         force: false,
         non_interactive: true,
         host_name: host_name.map(str::to_string),
-        host_mode: host_mode.map(str::to_string),
+        task_prefix: task_prefix.map(str::to_string),
     }
     .execute_without_runtime(Some(root))
     .map(|_| ())
 }
 
-/// Non-interactive `--host-name` + `--host-mode` create the identity exactly
+/// Non-interactive `--host-name` + `--task-prefix` create the identity exactly
 /// once, and a repeat init preserves the generated machine_id unchanged.
 #[test]
-fn non_interactive_host_name_and_mode_create_then_repeat_is_stable() {
+fn non_interactive_host_name_and_task_prefix_create_then_repeat_is_stable() {
     let home = tempdir().expect("home tempdir");
     let _env = EnvGuard::acquire().home(home.path());
     let root = home.path().join(".orbit");
 
-    init_host(&root, Some("dk-mac"), Some("hub")).expect("first init");
+    init_host(&root, Some("dk-mac"), Some("DE")).expect("first init");
     let host_toml = root.join("host.toml");
     let first = fs::read_to_string(&host_toml).expect("read host.toml");
     assert!(first.contains("host_id = \"dk-mac\""), "{first}");
-    assert!(first.contains("mode = \"hub\""), "{first}");
+    assert!(first.contains("schema_version = 2"), "{first}");
+    assert!(first.contains("task_prefix = \"DE\""), "{first}");
+    assert!(!first.contains("mode ="), "{first}");
     let machine_line = first
         .lines()
         .find(|line| line.starts_with("machine_id = "))
@@ -227,27 +230,44 @@ fn non_interactive_host_name_and_mode_create_then_repeat_is_stable() {
     assert!(machine_line.contains("hm_"), "{machine_line}");
 
     // Repeated init: no prompt, no rewrite, identical machine_id.
-    init_host(&root, Some("ignored-on-repeat"), Some("spoke")).expect("repeat init");
+    init_host(&root, Some("ignored-on-repeat"), Some("ZZ")).expect("repeat init");
     let second = fs::read_to_string(&host_toml).expect("re-read host.toml");
     assert_eq!(first, second, "repeat init must not rewrite host.toml");
 }
 
-/// A legacy `host_id`-only file migrates in place on init.
+/// A schema-v1 identity with an existing task sequence migrates in place on init.
 #[test]
 fn init_migrates_legacy_host_toml() {
     let home = tempdir().expect("home tempdir");
     let _env = EnvGuard::acquire().home(home.path());
     let root = home.path().join(".orbit");
     fs::create_dir_all(&root).expect("mkdir .orbit");
-    fs::write(root.join("host.toml"), "host_id = \"legacy-host\"\n").expect("seed legacy");
+    fs::create_dir_all(root.join("tasks")).expect("mkdir tasks");
+    fs::write(root.join("tasks/index.sqlite"), []).expect("seed task sequence");
+    fs::write(
+        root.join("host.toml"),
+        "schema_version = 1\nmachine_id = \"hm_existing\"\nhost_id = \"legacy-host\"\nmode = \"hub\"\n",
+    )
+    .expect("seed legacy");
 
     // No --host-name needed: migration preserves the legacy name.
     init_host(&root, None, None).expect("migrating init");
     let migrated = fs::read_to_string(root.join("host.toml")).expect("read migrated");
-    assert!(migrated.contains("schema_version = 1"), "{migrated}");
+    assert!(migrated.contains("schema_version = 2"), "{migrated}");
+    assert!(
+        migrated.contains("machine_id = \"hm_existing\""),
+        "{migrated}"
+    );
     assert!(migrated.contains("host_id = \"legacy-host\""), "{migrated}");
-    assert!(migrated.contains("mode = \"standalone\""), "{migrated}");
-    assert!(migrated.contains("machine_id = \"hm_"), "{migrated}");
+    assert!(migrated.contains("task_prefix = \"ORB\""), "{migrated}");
+    assert!(!migrated.contains("mode ="), "{migrated}");
+
+    let before = fs::read(root.join("host.toml")).expect("read migrated bytes");
+    init_host(&root, None, None).expect("repeat init");
+    assert_eq!(
+        fs::read(root.join("host.toml")).expect("reread migrated bytes"),
+        before
+    );
 }
 
 /// A fresh host initialized non-interactively without --host-name fails closed.
@@ -257,7 +277,7 @@ fn non_interactive_missing_host_name_fails_closed() {
     let _env = EnvGuard::acquire().home(home.path());
     let root = home.path().join(".orbit");
 
-    let error = init_host(&root, None, None).expect_err("missing host name must fail closed");
+    let error = init_host(&root, None, Some("DE")).expect_err("missing host name must fail closed");
     assert!(error.to_string().contains("--host-name"), "{error}");
     assert!(
         !root.join("host.toml").exists(),
@@ -265,15 +285,27 @@ fn non_interactive_missing_host_name_fails_closed() {
     );
 }
 
-/// An invalid `--host-mode` fails closed before any identity is written.
+/// A fresh non-interactive init requires an explicit task prefix.
 #[test]
-fn invalid_host_mode_fails_closed() {
+fn non_interactive_missing_task_prefix_fails_closed() {
     let home = tempdir().expect("home tempdir");
     let _env = EnvGuard::acquire().home(home.path());
     let root = home.path().join(".orbit");
 
-    let error =
-        init_host(&root, Some("dk-mac"), Some("bogus")).expect_err("invalid mode must fail");
-    assert!(error.to_string().contains("unknown host mode"), "{error}");
+    let error = init_host(&root, Some("dk-mac"), None).expect_err("missing prefix must fail");
+    assert!(error.to_string().contains("--task-prefix"), "{error}");
     assert!(!root.join("host.toml").exists());
+}
+
+/// Reserved and malformed fresh task-prefix choices fail before identity write.
+#[test]
+fn invalid_task_prefixes_fail_closed() {
+    for prefix in ["ORB", "ADR", "L", "F", "de", "D", "ABCDEF", " DE"] {
+        let home = tempdir().expect("home tempdir");
+        let _env = EnvGuard::acquire().home(home.path());
+        let root = home.path().join(".orbit");
+
+        init_host(&root, Some("dk-mac"), Some(prefix)).expect_err("invalid prefix must fail");
+        assert!(!root.join("host.toml").exists(), "prefix {prefix}");
+    }
 }

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -461,6 +461,7 @@ fn hub_mcp_serve_is_checkoutless_frame_pure_and_audits_trusted_identity() {
                 schema_version: orbit_remote::HOST_IDENTITY_SCHEMA_VERSION,
                 machine_id: "hm_spoke".to_string(),
                 host_id: "spoke".to_string(),
+                task_prefix: "ORB".to_string(),
                 mode: orbit_remote::HostMode::Spoke,
             },
             BTreeSet::new(),

--- a/crates/orbit-dashboard/src/api/tests/routines.rs
+++ b/crates/orbit-dashboard/src/api/tests/routines.rs
@@ -3,7 +3,7 @@
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode};
 use orbit_core::{RoutineFireRecord, RoutineFireState};
-use orbit_remote::{HostMode, NewHostIdentity, ensure_host_identity};
+use orbit_remote::{NewHostIdentity, ensure_host_identity};
 use tower::ServiceExt;
 
 use super::super::router;
@@ -92,7 +92,7 @@ async fn routines_endpoint_returns_envelope_for_empty_host() {
     ensure_host_identity(temp.path(), || {
         Ok(NewHostIdentity {
             host_id: "dashboard-test".to_string(),
-            mode: HostMode::Standalone,
+            task_prefix: "DA".to_string(),
         })
     })
     .expect("seed host identity");

--- a/crates/orbit-remote/src/host_identity.rs
+++ b/crates/orbit-remote/src/host_identity.rs
@@ -1,11 +1,11 @@
-//! Host identity for this Orbit machine [ORB-10247].
+//! Host identity for this Orbit machine [ORB-10247, ORB-10721].
 //!
 //! `~/.orbit/host.toml` carries the one genuinely host-local datum: a versioned
 //! [`HostIdentity`] with a stable, generated `machine_id`, an operator-chosen
-//! `host_id` display name, and an operating `mode`. First-time creation lives in
-//! global `orbit init` (implemented by `orbit-core`); a legacy file that carried
-//! only `host_id` (the routines-v1 scheduling pin) is migrated in place, once,
-//! preserving its `host_id` and generating a `machine_id`.
+//! `host_id` display name, and an immutable task namespace. First-time creation
+//! lives in global `orbit init` (implemented by `orbit-core`); legacy identities
+//! are migrated in place once, preserving their existing machine identity and
+//! seeding the historical `ORB` task namespace.
 //!
 //! Loading is strict: after migration an absent, malformed, incomplete, blank,
 //! or future-schema file is a hard error with an actionable message — there is
@@ -25,11 +25,14 @@ pub const HOST_TOML_FILE: &str = "host.toml";
 
 /// Current on-disk schema version for [`HostIdentity`]. A file whose
 /// `schema_version` exceeds this fails closed (see [`inspect_host_identity`]).
-pub const HOST_IDENTITY_SCHEMA_VERSION: u32 = 1;
+pub const HOST_IDENTITY_SCHEMA_VERSION: u32 = 2;
 
 const MACHINE_ID_PREFIX: &str = "hm_";
+const LEGACY_TASK_PREFIX: &str = "ORB";
+const RESERVED_TASK_PREFIXES: [&str; 4] = ["ORB", "ADR", "L", "F"];
 
-/// Operating mode of this Orbit host.
+/// Legacy operating mode retained temporarily for callers being replaced by
+/// the per-workspace ownership model. It is not part of schema-v2 host.toml.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HostMode {
     /// Self-contained host (the standalone default; no registry/hub role).
@@ -41,7 +44,7 @@ pub enum HostMode {
 }
 
 impl HostMode {
-    /// The persisted string form (matches the `mode` values in `host.toml`).
+    /// The legacy string form used by compatibility callers.
     pub fn as_str(self) -> &'static str {
         match self {
             HostMode::Standalone => "standalone",
@@ -50,7 +53,7 @@ impl HostMode {
         }
     }
 
-    /// Parse an external (CLI / file) mode string, failing closed on anything
+    /// Parse a legacy external mode string, failing closed on anything
     /// outside the fixed vocabulary.
     pub fn parse(value: &str) -> Result<Self, OrbitError> {
         match value.trim() {
@@ -81,7 +84,12 @@ pub struct HostIdentity {
     /// Operator-chosen, renameable display name; matched against routine
     /// `hosts:` pins.
     pub host_id: String,
-    /// Host operating mode.
+    /// Immutable namespace for task ids minted by this machine.
+    pub task_prefix: String,
+    /// Transitional compatibility for callers removed by the ownership-model
+    /// follow-up. Schema v2 does not persist a machine-level mode; identities
+    /// loaded from disk therefore use `Standalone` until those callers are
+    /// replaced with per-workspace ownership checks.
     pub mode: HostMode,
 }
 
@@ -92,20 +100,45 @@ impl HostIdentity {
     /// a quote, backslash, or control character cannot corrupt the file.
     fn to_toml(&self) -> String {
         format!(
-            "# Machine identity for this Orbit host [ORB-10247]. Created by\n\
+            "# Machine identity for this Orbit host [ORB-10721]. Created by\n\
              # `orbit init`; `machine_id` is generated once and never edited.\n\
              # `host_id` is the operator-chosen display name matched against\n\
-             # routine `hosts:` pins.\n\
+             # routine `hosts:` pins; `task_prefix` is chosen once.\n\
              schema_version = {}\n\
              machine_id = \"{}\"\n\
              host_id = \"{}\"\n\
-             mode = \"{}\"\n",
+             task_prefix = \"{}\"\n",
             self.schema_version,
             toml_escape_basic(&self.machine_id),
             toml_escape_basic(&self.host_id),
-            self.mode.as_str(),
+            toml_escape_basic(&self.task_prefix),
         )
     }
+}
+
+/// Validate an operator's fresh task-prefix choice.
+///
+/// Persisted migration prefix `ORB` is intentionally accepted by the strict
+/// loader, but cannot be selected for a new machine.
+pub fn validate_new_task_prefix(value: &str) -> Result<String, OrbitError> {
+    if RESERVED_TASK_PREFIXES.contains(&value) {
+        return Err(OrbitError::InvalidInput(format!(
+            "task prefix '{value}' is reserved; choose 2-5 uppercase ASCII letters other than ORB, ADR, L, or F"
+        )));
+    }
+    if !(2..=5).contains(&value.len()) || !value.bytes().all(|byte| byte.is_ascii_uppercase()) {
+        return Err(OrbitError::InvalidInput(
+            "task prefix must be 2-5 uppercase ASCII letters".to_string(),
+        ));
+    }
+    Ok(value.to_string())
+}
+
+fn validate_stored_task_prefix(value: &str) -> Result<String, OrbitError> {
+    if value == LEGACY_TASK_PREFIX {
+        return Ok(value.to_string());
+    }
+    validate_new_task_prefix(value)
 }
 
 /// Escape a value for embedding inside a TOML basic (double-quoted) string,
@@ -137,10 +170,13 @@ fn toml_escape_basic(value: &str) -> String {
 pub enum HostIdentityState {
     /// A complete, current-schema identity.
     Present(HostIdentity),
-    /// A legacy pre-migration file carrying only `host_id`.
+    /// A legacy pre-migration identity (host-id-only or schema v1).
     Legacy {
         /// The preserved, non-blank legacy `host_id`.
         host_id: String,
+        /// A schema-v1 machine id, preserved when present. The oldest
+        /// host-id-only format has none and receives one during migration.
+        machine_id: Option<String>,
     },
     /// No `host.toml` exists yet.
     Absent,
@@ -151,7 +187,7 @@ impl HostIdentityState {
     pub fn host_id(&self) -> Option<&str> {
         match self {
             HostIdentityState::Present(identity) => Some(&identity.host_id),
-            HostIdentityState::Legacy { host_id } => Some(host_id),
+            HostIdentityState::Legacy { host_id, .. } => Some(host_id),
             HostIdentityState::Absent => None,
         }
     }
@@ -162,7 +198,7 @@ impl HostIdentityState {
 pub enum HostIdentityOutcome {
     /// A fresh identity was created from operator input.
     Created(HostIdentity),
-    /// A legacy `host_id`-only file was migrated to the current schema.
+    /// A legacy identity was migrated to the current schema.
     Migrated(HostIdentity),
     /// A complete current-schema identity already existed; nothing was written.
     Unchanged(HostIdentity),
@@ -184,8 +220,8 @@ impl HostIdentityOutcome {
 pub struct NewHostIdentity {
     /// Operator-chosen display name.
     pub host_id: String,
-    /// Operating mode.
-    pub mode: HostMode,
+    /// Operator-chosen task namespace.
+    pub task_prefix: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -193,7 +229,9 @@ struct RawHostToml {
     schema_version: Option<u32>,
     machine_id: Option<String>,
     host_id: Option<String>,
-    mode: Option<String>,
+    task_prefix: Option<String>,
+    #[serde(rename = "mode")]
+    _mode: Option<String>,
 }
 
 fn host_toml_path(global_root: &Path) -> PathBuf {
@@ -227,17 +265,44 @@ pub fn inspect_host_identity(global_root: &Path) -> Result<HostIdentityState, Or
     })?;
 
     match parsed.schema_version {
-        None => {
-            // Legacy files carried only `host_id`. A present, non-blank
-            // `host_id` migrates; anything else is unusable.
-            match non_blank(&parsed.host_id) {
-                Some(host_id) => Ok(HostIdentityState::Legacy { host_id }),
-                None => Err(OrbitError::InvalidInput(format!(
-                    "host identity '{}' is incomplete: no schema_version and no host_id; \
-                     run `orbit init` to create one",
-                    path.display()
-                ))),
+        None => match non_blank(&parsed.host_id) {
+            Some(host_id) => {
+                let machine_id =
+                    validated_optional_machine_id(&path, parsed.machine_id.as_deref())?;
+                Ok(HostIdentityState::Legacy {
+                    host_id,
+                    machine_id,
+                })
             }
+            None => Err(OrbitError::InvalidInput(format!(
+                "host identity '{}' is incomplete: no schema_version and no host_id; \
+                 run `orbit init` to create one",
+                path.display()
+            ))),
+        },
+        Some(1) => {
+            let machine_id = parsed.machine_id.as_deref().ok_or_else(|| {
+                OrbitError::InvalidInput(format!(
+                    "host identity '{}' is incomplete: missing or blank machine_id",
+                    path.display()
+                ))
+            })?;
+            validate_machine_id(machine_id).map_err(|error| {
+                OrbitError::InvalidInput(format!(
+                    "host identity '{}' has invalid machine_id: {error}",
+                    path.display()
+                ))
+            })?;
+            let host_id = non_blank(&parsed.host_id).ok_or_else(|| {
+                OrbitError::InvalidInput(format!(
+                    "host identity '{}' is incomplete: missing or blank host_id",
+                    path.display()
+                ))
+            })?;
+            Ok(HostIdentityState::Legacy {
+                host_id,
+                machine_id: Some(machine_id.to_string()),
+            })
         }
         Some(version) if version == HOST_IDENTITY_SCHEMA_VERSION => {
             let machine_id = parsed.machine_id.as_deref().ok_or_else(|| {
@@ -258,18 +323,24 @@ pub fn inspect_host_identity(global_root: &Path) -> Result<HostIdentityState, Or
                     path.display()
                 ))
             })?;
-            let mode = non_blank(&parsed.mode).ok_or_else(|| {
+            let task_prefix = parsed.task_prefix.as_deref().ok_or_else(|| {
                 OrbitError::InvalidInput(format!(
-                    "host identity '{}' is incomplete: missing or blank mode",
+                    "host identity '{}' is incomplete: missing or blank task_prefix",
                     path.display()
                 ))
             })?;
-            let mode = HostMode::parse(&mode)?;
+            let task_prefix = validate_stored_task_prefix(task_prefix).map_err(|error| {
+                OrbitError::InvalidInput(format!(
+                    "host identity '{}' has invalid task_prefix: {error}",
+                    path.display()
+                ))
+            })?;
             Ok(HostIdentityState::Present(HostIdentity {
                 schema_version: version,
                 machine_id: machine_id.to_string(),
                 host_id,
-                mode,
+                task_prefix,
+                mode: HostMode::Standalone,
             }))
         }
         Some(version) if version > HOST_IDENTITY_SCHEMA_VERSION => {
@@ -285,6 +356,22 @@ pub fn inspect_host_identity(global_root: &Path) -> Result<HostIdentityState, Or
             path.display()
         ))),
     }
+}
+
+fn validated_optional_machine_id(
+    path: &Path,
+    machine_id: Option<&str>,
+) -> Result<Option<String>, OrbitError> {
+    let Some(machine_id) = machine_id else {
+        return Ok(None);
+    };
+    validate_machine_id(machine_id).map_err(|error| {
+        OrbitError::InvalidInput(format!(
+            "host identity '{}' has invalid machine_id: {error}",
+            path.display()
+        ))
+    })?;
+    Ok(Some(machine_id.to_string()))
 }
 
 /// Strictly load a complete, current-schema identity. Absent and legacy files
@@ -307,8 +394,8 @@ pub fn load_host_identity(global_root: &Path) -> Result<HostIdentity, OrbitError
 
 /// Ensure a complete, current-schema identity exists, creating or migrating as
 /// needed and returning what happened. `new` supplies the operator's host name
-/// and mode and is invoked **only** when the identity is absent, so callers can
-/// defer prompting until a fresh create is actually required.
+/// and task prefix and is invoked **only** when the identity is absent, so
+/// callers can defer prompting until a fresh create is actually required.
 ///
 /// Idempotent: a present identity is returned `Unchanged` with no write. A
 /// malformed or future-schema file is never overwritten — the error propagates.
@@ -318,31 +405,42 @@ pub fn ensure_host_identity(
 ) -> Result<HostIdentityOutcome, OrbitError> {
     match inspect_host_identity(global_root)? {
         HostIdentityState::Present(identity) => Ok(HostIdentityOutcome::Unchanged(identity)),
-        HostIdentityState::Legacy { host_id } => {
-            // Migrate atomically: preserve host_id, generate machine_id, default
-            // to standalone. Rollback leaves the last valid file readable.
+        HostIdentityState::Legacy {
+            host_id,
+            machine_id,
+        } => {
+            // Migrate atomically: preserve an existing schema-v1 machine id,
+            // generate one only for the oldest host-id-only format, and retain
+            // the historical ORB namespace. Rollback leaves the last valid
+            // file readable.
             let identity = HostIdentity {
                 schema_version: HOST_IDENTITY_SCHEMA_VERSION,
-                machine_id: generate_machine_id(),
+                machine_id: machine_id.unwrap_or_else(generate_machine_id),
                 host_id,
+                task_prefix: LEGACY_TASK_PREFIX.to_string(),
                 mode: HostMode::Standalone,
             };
             write_host_identity(global_root, &identity)?;
             Ok(HostIdentityOutcome::Migrated(identity))
         }
         HostIdentityState::Absent => {
-            let NewHostIdentity { host_id, mode } = new()?;
+            let NewHostIdentity {
+                host_id,
+                task_prefix,
+            } = new()?;
             let host_id = host_id.trim().to_string();
             if host_id.is_empty() {
                 return Err(OrbitError::InvalidInput(
                     "host name must not be empty".to_string(),
                 ));
             }
+            let task_prefix = validate_new_task_prefix(&task_prefix)?;
             let identity = HostIdentity {
                 schema_version: HOST_IDENTITY_SCHEMA_VERSION,
                 machine_id: generate_machine_id(),
                 host_id,
-                mode,
+                task_prefix,
+                mode: HostMode::Standalone,
             };
             write_host_identity(global_root, &identity)?;
             Ok(HostIdentityOutcome::Created(identity))
@@ -381,7 +479,7 @@ fn stage_host_identity_toml(identity: &HostIdentity) -> Result<String, OrbitErro
     let round_trips = parsed.schema_version == Some(identity.schema_version)
         && non_blank(&parsed.machine_id).as_deref() == Some(identity.machine_id.as_str())
         && non_blank(&parsed.host_id).as_deref() == Some(identity.host_id.as_str())
-        && non_blank(&parsed.mode).as_deref() == Some(identity.mode.as_str());
+        && non_blank(&parsed.task_prefix).as_deref() == Some(identity.task_prefix.as_str());
     if !round_trips {
         return Err(OrbitError::InvalidInput(
             "staged host identity render does not round-trip to the intended identity; \
@@ -393,9 +491,9 @@ fn stage_host_identity_toml(identity: &HostIdentity) -> Result<String, OrbitErro
 }
 
 /// Rename the current machine's local `host.toml` in place, preserving
-/// `machine_id` and `mode`. The identity must already be `Present`; a legacy or
-/// absent file is a hard error (there is no local identity to rename). The new
-/// render is staged and reparsed before the atomic write, so quotes,
+/// `machine_id` and `task_prefix`. The identity must already be `Present`; a
+/// legacy or absent file is a hard error (there is no local identity to rename).
+/// The new render is staged and reparsed before the atomic write, so quotes,
 /// backslashes, and control characters either round-trip safely or fail before
 /// mutation and the last valid file is preserved. Renaming another machine must
 /// never call this — it only ever touches the local file.
@@ -427,6 +525,7 @@ where
         schema_version: current.schema_version,
         machine_id: current.machine_id.clone(),
         host_id: new_host_id.to_string(),
+        task_prefix: current.task_prefix.clone(),
         mode: current.mode,
     };
     let staged = stage_host_identity_toml(&candidate)?;

--- a/crates/orbit-remote/src/lib.rs
+++ b/crates/orbit-remote/src/lib.rs
@@ -45,7 +45,7 @@ pub use execution_profile_projection::{
 pub use host_identity::{
     HOST_IDENTITY_SCHEMA_VERSION, HOST_TOML_FILE, HostIdentity, HostIdentityOutcome,
     HostIdentityState, HostMode, NewHostIdentity, ensure_host_identity, inspect_host_identity,
-    load_host_identity, os_hostname, rename_current_host_identity,
+    load_host_identity, os_hostname, rename_current_host_identity, validate_new_task_prefix,
 };
 pub use host_registry::{HostRegistryService, WorkspaceLink, require_local_hub_identity};
 pub use knowledge::{HubKnowledgeSequenceService, scan_registered_knowledge_inventories};

--- a/crates/orbit-remote/src/mcp/hub.rs
+++ b/crates/orbit-remote/src/mcp/hub.rs
@@ -539,6 +539,7 @@ impl HubMcpHost {
             schema_version: HOST_IDENTITY_SCHEMA_VERSION,
             machine_id: request.identity.machine_id.clone(),
             host_id: request.identity.host_id.clone(),
+            task_prefix: "ORB".to_string(),
             mode: HostMode::Spoke,
         };
         let host = match service.register_identity(&spoke_identity, request.identity.labels) {

--- a/crates/orbit-remote/src/mcp/tests/e1.rs
+++ b/crates/orbit-remote/src/mcp/tests/e1.rs
@@ -231,6 +231,7 @@ fn spoke_route_requires_config_and_exact_non_hierarchical_membership() {
         schema_version: HOST_IDENTITY_SCHEMA_VERSION,
         machine_id: "hm_spoke".to_string(),
         host_id: "spoke".to_string(),
+        task_prefix: "ORB".to_string(),
         mode: HostMode::Spoke,
     };
     let missing = super::super::config::TrustedMcpConfig::default();
@@ -362,6 +363,7 @@ fn hub_crew_discovery_and_task_validation_read_the_owner_execution_profile() {
                 schema_version: HOST_IDENTITY_SCHEMA_VERSION,
                 machine_id: "hm_hub".to_string(),
                 host_id: "test-host".to_string(),
+                task_prefix: "ORB".to_string(),
                 mode: HostMode::Hub,
             },
             BTreeSet::new(),

--- a/crates/orbit-remote/src/mcp/tests/knowledge_allocation.rs
+++ b/crates/orbit-remote/src/mcp/tests/knowledge_allocation.rs
@@ -54,6 +54,7 @@ fn setup_hub(root: &Path) {
                 schema_version: HOST_IDENTITY_SCHEMA_VERSION,
                 machine_id: "hm_spoke".to_string(),
                 host_id: "spoke".to_string(),
+                task_prefix: "ORB".to_string(),
                 mode: HostMode::Spoke,
             },
             BTreeSet::new(),

--- a/crates/orbit-remote/src/mcp/tests/mod.rs
+++ b/crates/orbit-remote/src/mcp/tests/mod.rs
@@ -193,7 +193,7 @@ fn broker_with_context_requires_local_checkout_before_dispatch() {
 
 #[test]
 fn broker_spoke_with_context_fails_closed_before_local_resolution() {
-    use crate::{HostMode, NewHostIdentity, ensure_host_identity};
+    use crate::{NewHostIdentity, ensure_host_identity};
     use chrono::Utc;
     use orbit_common::types::{Workspace, WorkspaceRegistry, WorkspaceStatus};
 
@@ -201,7 +201,7 @@ fn broker_spoke_with_context_fails_closed_before_local_resolution() {
     ensure_host_identity(root.path(), || {
         Ok(NewHostIdentity {
             host_id: "spoke".to_string(),
-            mode: HostMode::Spoke,
+            task_prefix: "SP".to_string(),
         })
     })
     .expect("spoke identity");
@@ -247,7 +247,7 @@ fn broker_spoke_with_context_fails_closed_before_local_resolution() {
 
 #[test]
 fn broker_spoke_hub_denial_writes_no_local_coordination_state() {
-    use crate::{HostMode, NewHostIdentity, ensure_host_identity};
+    use crate::{NewHostIdentity, ensure_host_identity};
     use chrono::Utc;
     use orbit_common::types::{Workspace, WorkspaceRegistry, WorkspaceStatus};
 
@@ -255,7 +255,7 @@ fn broker_spoke_hub_denial_writes_no_local_coordination_state() {
     ensure_host_identity(root.path(), || {
         Ok(NewHostIdentity {
             host_id: "spoke".to_string(),
-            mode: HostMode::Spoke,
+            task_prefix: "SP".to_string(),
         })
     })
     .expect("spoke identity");

--- a/crates/orbit-remote/src/tests/execution_profile_projection.rs
+++ b/crates/orbit-remote/src/tests/execution_profile_projection.rs
@@ -24,6 +24,7 @@ fn identity(machine_id: &str, host_id: &str) -> HostIdentity {
         schema_version: HOST_IDENTITY_SCHEMA_VERSION,
         machine_id: machine_id.to_string(),
         host_id: host_id.to_string(),
+        task_prefix: "ORB".to_string(),
         mode: HostMode::Hub,
     }
 }

--- a/crates/orbit-remote/src/tests/host_identity.rs
+++ b/crates/orbit-remote/src/tests/host_identity.rs
@@ -1,18 +1,19 @@
 use crate::host_identity::{
-    HOST_IDENTITY_SCHEMA_VERSION, HostIdentityOutcome, HostIdentityState, HostMode,
-    NewHostIdentity, ensure_host_identity, inspect_host_identity, load_host_identity,
-    rename_current_host_identity, rename_current_host_identity_with_writer,
+    HOST_IDENTITY_SCHEMA_VERSION, HostIdentityOutcome, HostIdentityState, NewHostIdentity,
+    ensure_host_identity, inspect_host_identity, load_host_identity, rename_current_host_identity,
+    rename_current_host_identity_with_writer, validate_new_task_prefix,
 };
 
 fn requested(
     name: &str,
-    mode: HostMode,
+    task_prefix: &str,
 ) -> impl FnOnce() -> Result<NewHostIdentity, orbit_common::types::OrbitError> {
     let name = name.to_string();
+    let task_prefix = task_prefix.to_string();
     move || {
         Ok(NewHostIdentity {
             host_id: name,
-            mode,
+            task_prefix,
         })
     }
 }
@@ -20,13 +21,12 @@ fn requested(
 #[test]
 fn create_persists_current_schema_identity() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let outcome = ensure_host_identity(dir.path(), requested("dk-server-1", HostMode::Standalone))
-        .expect("create");
+    let outcome = ensure_host_identity(dir.path(), requested("dk-server-1", "DE")).expect("create");
     assert!(matches!(outcome, HostIdentityOutcome::Created(_)));
     let identity = outcome.identity();
     assert_eq!(identity.schema_version, HOST_IDENTITY_SCHEMA_VERSION);
     assert_eq!(identity.host_id, "dk-server-1");
-    assert_eq!(identity.mode, HostMode::Standalone);
+    assert_eq!(identity.task_prefix, "DE");
     assert!(identity.machine_id.starts_with("hm_"));
 
     let loaded = load_host_identity(dir.path()).expect("load");
@@ -36,8 +36,7 @@ fn create_persists_current_schema_identity() {
 #[test]
 fn repeated_init_is_unchanged_and_stable() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let created =
-        ensure_host_identity(dir.path(), requested("dk-server-1", HostMode::Hub)).expect("create");
+    let created = ensure_host_identity(dir.path(), requested("dk-server-1", "DK")).expect("create");
     let first_machine_id = created.identity().machine_id.clone();
     let before = std::fs::read_to_string(dir.path().join("host.toml")).expect("read");
 
@@ -47,7 +46,7 @@ fn repeated_init_is_unchanged_and_stable() {
         .expect("repeat init");
     assert!(matches!(again, HostIdentityOutcome::Unchanged(_)));
     assert_eq!(again.identity().machine_id, first_machine_id);
-    assert_eq!(again.identity().mode, HostMode::Hub);
+    assert_eq!(again.identity().task_prefix, "DK");
     let after = std::fs::read_to_string(dir.path().join("host.toml")).expect("read");
     assert_eq!(before, after, "repeat init must not rewrite host.toml");
 }
@@ -68,7 +67,7 @@ fn legacy_host_id_only_file_migrates_idempotently() {
     let identity = migrated.identity();
     assert_eq!(identity.schema_version, HOST_IDENTITY_SCHEMA_VERSION);
     assert_eq!(identity.host_id, "dk-server-1");
-    assert_eq!(identity.mode, HostMode::Standalone);
+    assert_eq!(identity.task_prefix, "ORB");
     let machine_id = identity.machine_id.clone();
 
     // Second initialization preserves the generated machine_id and rewrites
@@ -79,6 +78,36 @@ fn legacy_host_id_only_file_migrates_idempotently() {
     assert_eq!(again.identity().machine_id, machine_id);
     let after = std::fs::read_to_string(dir.path().join("host.toml")).expect("read");
     assert_eq!(before, after);
+}
+
+#[test]
+fn schema_v1_identity_with_existing_sequence_migrates_preserving_machine_id() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join("tasks")).expect("create task state");
+    std::fs::write(dir.path().join("tasks/index.sqlite"), []).expect("seed task sequence");
+    std::fs::write(
+        dir.path().join("host.toml"),
+        "schema_version = 1\nmachine_id = \"hm_existing\"\nhost_id = \"dk-server-1\"\nmode = \"hub\"\n",
+    )
+    .expect("seed schema v1 identity");
+
+    let migrated =
+        ensure_host_identity(dir.path(), || panic!("migration must not prompt")).expect("migrate");
+    assert!(matches!(migrated, HostIdentityOutcome::Migrated(_)));
+    assert_eq!(migrated.identity().machine_id, "hm_existing");
+    assert_eq!(migrated.identity().task_prefix, "ORB");
+
+    let path = dir.path().join("host.toml");
+    let before = std::fs::read(&path).expect("read migrated identity");
+    let text = std::str::from_utf8(&before).expect("host identity UTF-8");
+    assert!(text.contains("schema_version = 2"), "{text}");
+    assert!(text.contains("task_prefix = \"ORB\""), "{text}");
+    assert!(!text.contains("mode ="), "{text}");
+
+    let repeated =
+        ensure_host_identity(dir.path(), || panic!("repeat must not prompt")).expect("repeat");
+    assert!(matches!(repeated, HostIdentityOutcome::Unchanged(_)));
+    assert_eq!(std::fs::read(path).expect("reread"), before);
 }
 
 #[test]
@@ -112,7 +141,7 @@ fn incomplete_current_schema_file_is_rejected() {
     let dir = tempfile::tempdir().expect("tempdir");
     std::fs::write(
         dir.path().join("host.toml"),
-        "schema_version = 1\nhost_id = \"dk-server-1\"\nmode = \"standalone\"\n",
+        "schema_version = 2\nhost_id = \"dk-server-1\"\ntask_prefix = \"DE\"\n",
     )
     .expect("write");
     let error = inspect_host_identity(dir.path()).expect_err("missing machine_id must fail");
@@ -124,7 +153,7 @@ fn transport_shaped_machine_id_is_rejected_without_rewriting_host_identity() {
     for machine_id in ["dk1", "user@dk1", "ssh:dk1", "hm_ssh:dk1", "/tmp/hub"] {
         let dir = tempfile::tempdir().expect("tempdir");
         let body = format!(
-            "schema_version = 1\nmachine_id = \"{machine_id}\"\nhost_id = \"hub\"\nmode = \"hub\"\n"
+            "schema_version = 2\nmachine_id = \"{machine_id}\"\nhost_id = \"hub\"\ntask_prefix = \"DE\"\n"
         );
         let path = dir.path().join("host.toml");
         std::fs::write(&path, &body).expect("write hostile identity");
@@ -144,7 +173,7 @@ fn blank_field_is_rejected() {
     let dir = tempfile::tempdir().expect("tempdir");
     std::fs::write(
         dir.path().join("host.toml"),
-        "schema_version = 1\nmachine_id = \"hm_1\"\nhost_id = \"  \"\nmode = \"standalone\"\n",
+        "schema_version = 2\nmachine_id = \"hm_1\"\nhost_id = \"  \"\ntask_prefix = \"DE\"\n",
     )
     .expect("write");
     inspect_host_identity(dir.path()).expect_err("blank host_id must fail closed");
@@ -153,7 +182,7 @@ fn blank_field_is_rejected() {
 #[test]
 fn future_schema_version_fails_closed_without_rewrite() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let body = "schema_version = 2\nmachine_id = \"hm_future\"\nhost_id = \"dk-server-1\"\nmode = \"standalone\"\n";
+    let body = "schema_version = 3\nmachine_id = \"hm_future\"\nhost_id = \"dk-server-1\"\ntask_prefix = \"DE\"\n";
     std::fs::write(dir.path().join("host.toml"), body).expect("write");
     inspect_host_identity(dir.path()).expect_err("future schema must fail closed");
     // The file is left untouched (never rewritten by a read).
@@ -171,17 +200,20 @@ fn future_schema_version_fails_closed_without_rewrite() {
 }
 
 #[test]
-fn invalid_mode_is_rejected() {
-    assert!(HostMode::parse("standalone").is_ok());
-    assert!(HostMode::parse("hub").is_ok());
-    assert!(HostMode::parse("spoke").is_ok());
-    HostMode::parse("bogus").expect_err("invalid mode must fail");
+fn fresh_task_prefix_validation_rejects_reserved_and_malformed_values() {
+    for reserved in ["ORB", "ADR", "L", "F"] {
+        validate_new_task_prefix(reserved).expect_err("reserved prefix must fail");
+    }
+    for malformed in ["de", "D", "ABCDEF", " DE"] {
+        validate_new_task_prefix(malformed).expect_err("malformed prefix must fail");
+    }
+    assert_eq!(validate_new_task_prefix("DE").expect("valid prefix"), "DE");
 }
 
 #[test]
-fn rename_current_identity_preserves_machine_id_and_mode() {
+fn rename_current_identity_preserves_machine_id_and_task_prefix() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let created = ensure_host_identity(dir.path(), requested("old-name", HostMode::Hub))
+    let created = ensure_host_identity(dir.path(), requested("old-name", "DE"))
         .expect("create")
         .identity()
         .clone();
@@ -189,7 +221,7 @@ fn rename_current_identity_preserves_machine_id_and_mode() {
     let renamed = rename_current_host_identity(dir.path(), "new-name").expect("rename");
     assert_eq!(renamed.host_id, "new-name");
     assert_eq!(renamed.machine_id, created.machine_id);
-    assert_eq!(renamed.mode, HostMode::Hub);
+    assert_eq!(renamed.task_prefix, "DE");
 
     // The on-disk file reflects the rename and remains a complete identity.
     match inspect_host_identity(dir.path()).expect("inspect") {
@@ -204,7 +236,7 @@ fn rename_current_identity_preserves_machine_id_and_mode() {
 #[test]
 fn rename_current_identity_round_trips_quotes_and_rejects_absent_file() {
     let dir = tempfile::tempdir().expect("tempdir");
-    ensure_host_identity(dir.path(), requested("start", HostMode::Standalone)).expect("create");
+    ensure_host_identity(dir.path(), requested("start", "DE")).expect("create");
 
     // A quote-bearing name must round-trip through the TOML staging rather than
     // corrupt the file.
@@ -223,7 +255,7 @@ fn rename_current_identity_round_trips_quotes_and_rejects_absent_file() {
 #[test]
 fn rename_current_identity_classifies_preserved_and_durability_uncertain_errors() {
     let dir = tempfile::tempdir().expect("tempdir");
-    ensure_host_identity(dir.path(), requested("old", HostMode::Hub)).expect("create");
+    ensure_host_identity(dir.path(), requested("old", "DE")).expect("create");
     let before = std::fs::read(dir.path().join("host.toml")).expect("read before");
 
     let preserved = rename_current_host_identity_with_writer(dir.path(), "new", |_, _| {

--- a/crates/orbit-remote/src/tests/host_registry.rs
+++ b/crates/orbit-remote/src/tests/host_registry.rs
@@ -16,6 +16,7 @@ fn identity(machine_id: &str, host_id: &str, mode: HostMode) -> HostIdentity {
         schema_version: HOST_IDENTITY_SCHEMA_VERSION,
         machine_id: machine_id.to_string(),
         host_id: host_id.to_string(),
+        task_prefix: "ORB".to_string(),
         mode,
     }
 }

--- a/crates/orbit-remote/src/tests/knowledge.rs
+++ b/crates/orbit-remote/src/tests/knowledge.rs
@@ -30,6 +30,7 @@ fn configure_hub(root: &Path, machine_id: &str) {
                 schema_version: crate::HOST_IDENTITY_SCHEMA_VERSION,
                 machine_id: machine_id.to_string(),
                 host_id: "configured-hub".to_string(),
+                task_prefix: "ORB".to_string(),
                 mode: crate::HostMode::Hub,
             },
             BTreeSet::new(),


### PR DESCRIPTION
## Task

[ORB-10721](https://orbit-cli.com/tasks/ORB-10721) — Host identity v2: add task_prefix, remove mode (ADR-0355, ADR-0356)

### Description

## Problem
`~/.orbit/host.toml` carries a machine-level `mode = standalone | hub | spoke` field that the v1 per-machine coordination model removes, and lacks the `task_prefix` field that machine-scoped task-ID partitioning requires. Design: `docs/design/host-registry/2_design.md` §1; decisions ADR-0355 and ADR-0356 in `docs/design/host-registry/4_decisions.md`.

## Why It Matters
`task_prefix` is the substrate for global task-ID uniqueness without an allocator; every downstream task in this refactor depends on it. `mode` has no remaining consumer once ownership is per-workspace.

## Constraints / Notes
- `schema_version = 2`. A machine's role is derived per workspace from the local registry, never declared in host.toml.
- Prefix chosen once at global init, immutable after; validation refuses non-(2–5 uppercase ASCII) values and the reserved namespaces `ORB`, `ADR`, `L`, `F` as *new* choices.
- Migration is once and idempotent: a host with an existing task sequence seeds `task_prefix = "ORB"`; a legacy `mode` key is dropped on read and not rewritten; `machine_id` is never regenerated; write stays atomic (staged rename).
- Non-interactive init without `--host-name` or `--task-prefix` fails closed. `orbit routine init` still never owns the file.
- This task changes identity only — allocator/parsing changes are a separate dependent task.

### Acceptance Criteria

- Fresh non-interactive `orbit init` without `--task-prefix` fails closed with an actionable error; with `--task-prefix DE` it writes schema v2 host.toml containing task_prefix and no mode field
- Migrating a legacy host.toml (mode present, existing task sequence) yields task_prefix="ORB", preserved machine_id, no mode key; a repeated init writes nothing (file byte-stable)
- Prefix validation tests cover: reserved namespaces ORB/ADR/L/F refused for a fresh choice, lowercase/1-letter/6-letter refused, migration-seeded ORB accepted
- cargo build succeeds and the tests this change adds/modifies pass under nextest; pre-existing unrelated failures are out of scope

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Upgraded host identity persistence to schema v2 with immutable `task_prefix`; fresh choices require exactly 2-5 uppercase ASCII letters and reject ORB/ADR/L/F, while strict loading accepts migration-seeded ORB.
- Added once-only migration for host-id-only and schema-v1 identities. Schema-v1 migration preserves `machine_id`, seeds `task_prefix = "ORB"`, drops the legacy `mode` key, writes atomically, and repeated init is byte-stable.
- Replaced global init's `--host-mode` surface with `--task-prefix`; fresh non-interactive init now fails closed unless both host name and task prefix are supplied, while interactive init validates until it gets a usable prefix.
- Updated the public re-export and the smallest set of tightly coupled constructors/test fixtures needed for the additive `task_prefix` field to compile. These extra selectors were recorded before editing.
- Kept `HostMode` as an explicitly transitional, non-persisted compatibility field because dependent ownership/bridge/fleet tasks still compile against it. Schema-v2 loads never derive a role from host.toml; the later ORB-10724/ORB-10727/ORB-10730 work removes those compatibility callers.

Assessment: Acceptance criteria are met. The persisted identity has no mode key, migration preserves machine identity and historical IDs, validation distinguishes fresh reserved choices from migration ORB, and init behavior is covered at both unit and executable-command seams.

Validation:
- `cargo check -p orbit-remote -p orbit-cli -p orbit-dashboard --all-targets`: passed
- `cargo nextest run -p orbit-remote host_identity`: 15 passed
- `cargo nextest run -p orbit-cli command::tests::init`: 8 passed
- `cargo build`: passed
- `make ci-lint`: passed
- `cargo fmt --all -- --check` and `git diff --check`: passed
- Manual `target/debug/orbit init` smoke: missing `--task-prefix` failed with the actionable flag hint and wrote no host.toml; `--task-prefix DE` wrote schema v2 with task_prefix and no mode
- `make ci-fast`: stopped at the pre-existing generated-doc guard because `docs/INDEX.md` is stale at the unchanged baseline; no task file or generated index touched it. The constituent format check passed, and unrestricted CI can arbitrate the unrelated index state.

Friction checkpoint: no report filed; no qualifying recurring/tooling issue attributable to this task exceeded the reporting threshold.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10721-6a7a9f65`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*