### PR TITLE
Merged cross-workspace search results must carry the workspace field (ADR-0357 precondition)

### DIFF
--- a/crates/orbit-remote/src/mcp/host.rs
+++ b/crates/orbit-remote/src/mcp/host.rs
@@ -30,7 +30,7 @@ use orbit_core::{
 };
 use orbit_mcp::McpHost;
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use crate::runtime::RemoteRuntimeFactory;
 use crate::{HostIdentityState, HostMode, inspect_host_identity};
@@ -609,6 +609,58 @@ impl BrokerMcpHost {
         }
     }
 
+    /// Merge an unscoped `orbit.search` request over every active local
+    /// workspace. A merged row carries the logical workspace selector needed
+    /// to feed its otherwise workspace-local ID back into a follow-up call.
+    fn merged_search(&self, input: Value) -> Result<Value, OrbitError> {
+        let registry_path = crate::workspace_registry::registry_path_for(&self.global_root);
+        let registry = crate::workspace_registry::load_registry_from(&registry_path)?;
+        let mut results = Vec::new();
+        let mut notes = Vec::new();
+        let mut mode = None;
+        let mut kind = None;
+
+        for (workspace, checkout) in crate::workspace_registry::local_workspaces(&registry) {
+            if workspace.status != WorkspaceStatus::Active {
+                continue;
+            }
+            let binding = self.resolve_exact_checkout(&checkout.repo_root)?;
+            let runtime = self.runtime_for(&binding)?;
+            let response = runtime.run_tool("orbit.search", input.clone())?;
+            let response = response.as_object().ok_or_else(|| {
+                OrbitError::Execution(
+                    "serialize merged search response: expected object".to_string(),
+                )
+            })?;
+            mode.get_or_insert_with(|| response.get("mode").cloned().unwrap_or(Value::Null));
+            kind.get_or_insert_with(|| response.get("kind").cloned().unwrap_or(Value::Null));
+
+            if let Some(workspace_notes) = response.get("notes").and_then(Value::as_array) {
+                notes.extend(workspace_notes.iter().cloned());
+            }
+            if let Some(rows) = response.get("results").and_then(Value::as_array) {
+                for row in rows {
+                    let mut row = row.clone();
+                    let object = row.as_object_mut().ok_or_else(|| {
+                        OrbitError::Execution(
+                            "serialize merged search response: result row is not an object"
+                                .to_string(),
+                        )
+                    })?;
+                    object.insert("workspace".to_string(), Value::String(workspace.id.clone()));
+                    results.push(row);
+                }
+            }
+        }
+
+        Ok(json!({
+            "mode": mode.unwrap_or_else(|| Value::String("lexical".to_string())),
+            "kind": kind.unwrap_or_else(|| input.get("kind").cloned().unwrap_or_else(|| Value::String("all".to_string()))),
+            "results": results,
+            "notes": notes,
+        }))
+    }
+
     fn resolved_call(
         &self,
         name: &str,
@@ -627,6 +679,19 @@ impl BrokerMcpHost {
                 return self.remote_hub_call(name, input, context, None);
             }
             let result = self.global_call(name);
+            self.record_coordination_outcome(name, &context, &result);
+            return result;
+        }
+
+        // `all: true` without a workspace selector is the broker's explicit
+        // cross-workspace search mode. Supplying a workspace (directly or in
+        // session metadata) retains the established per-workspace meaning of
+        // `all` and its unchanged response shape.
+        if name == "orbit.search"
+            && input.get("all").and_then(Value::as_bool) == Some(true)
+            && Self::selector(&input, &context).is_none()
+        {
+            let result = self.merged_search(input);
             self.record_coordination_outcome(name, &context, &result);
             return result;
         }

--- a/crates/orbit-remote/src/mcp/tests/mod.rs
+++ b/crates/orbit-remote/src/mcp/tests/mod.rs
@@ -143,6 +143,160 @@ fn broker_checkoutless_task_call_uses_stable_id_and_one_trusted_audit() {
 }
 
 #[test]
+fn broker_merged_search_tags_duplicate_ids_with_their_workspace() {
+    use std::process::Command;
+
+    use chrono::Utc;
+    use orbit_common::types::{
+        LearningScope, Workspace, WorkspaceCheckout, WorkspaceRegistry, WorkspaceStatus,
+    };
+    use orbit_store::LearningCreateParams;
+    use orbit_store::sqlite::task_registry::{WorkspaceConfig, write_workspace_config};
+
+    let root = tempfile::tempdir().expect("test root");
+    let global_root = root.path().join("global");
+    std::fs::create_dir_all(&global_root).expect("global root");
+    let mut workspaces = Vec::new();
+    let mut checkouts = Vec::new();
+    let mut learning_ids = Vec::new();
+
+    for id in ["alpha", "beta"] {
+        let repo_root = root.path().join(id);
+        let initialized = Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(root.path())
+            .arg(&repo_root)
+            .status()
+            .expect("initialize workspace repository");
+        assert!(initialized.success(), "git init failed for {id}");
+        let orbit_dir = repo_root.join(".orbit");
+        std::fs::create_dir_all(&orbit_dir).expect("orbit directory");
+        write_workspace_config(
+            &orbit_dir,
+            &WorkspaceConfig {
+                schema_version: 1,
+                workspace_id: format!("ws_{id}"),
+            },
+        )
+        .expect("workspace config");
+        let workspace = Workspace {
+            id: id.to_string(),
+            name: id.to_string(),
+            owner_machine_id: None,
+            git_remote: None,
+            ship_mode: None,
+            base_branch: "agent-main".to_string(),
+            status: WorkspaceStatus::Active,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let checkout = WorkspaceCheckout::owner(id.to_string(), repo_root, orbit_dir);
+        let runtime = crate::runtime::RemoteRuntimeFactory::open_registered_checkout(
+            &global_root,
+            &workspace,
+            &checkout,
+        )
+        .expect("workspace runtime");
+        let learning = runtime
+            .create_learning(LearningCreateParams {
+                summary: "shared merged search needle".to_string(),
+                scope: LearningScope::default(),
+                body: "same learning ID in each workspace".to_string(),
+                evidence: Vec::new(),
+                created_by: Some("codex".to_string()),
+                priority: None,
+            })
+            .expect("seed learning");
+        learning_ids.push(learning.id);
+        workspaces.push(workspace);
+        checkouts.push(checkout);
+    }
+    assert_eq!(
+        learning_ids[0], learning_ids[1],
+        "fixture must duplicate the learning ID"
+    );
+    crate::workspace_registry::save_registry_to(
+        &WorkspaceRegistry {
+            workspaces,
+            checkouts,
+            ..Default::default()
+        },
+        &crate::workspace_registry::registry_path_for(&global_root),
+    )
+    .expect("workspace registry");
+
+    let host = BrokerMcpHost::new(global_root);
+    let merged = host
+        .call_tool(
+            "orbit.search",
+            json!({ "query": "shared merged search needle", "all": true }),
+            ToolSessionContext::trusted_local(
+                None,
+                Some("hm_local".to_string()),
+                Some("local".to_string()),
+            ),
+        )
+        .expect("merged search");
+    let rows = merged["results"].as_array().expect("merged rows");
+    let matching = rows
+        .iter()
+        .filter(|row| row["id"].as_str() == Some(learning_ids[0].as_str()))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        matching.len(),
+        2,
+        "both duplicate learning IDs must be returned"
+    );
+    let result_workspaces = matching
+        .iter()
+        .map(|row| row["workspace"].as_str().expect("workspace field"))
+        .collect::<BTreeSet<_>>();
+    assert_eq!(result_workspaces, BTreeSet::from(["alpha", "beta"]));
+    assert!(
+        rows.iter().all(|row| row["workspace"].is_string()),
+        "every merged result row must identify its owning workspace: {merged}"
+    );
+    for workspace in ["alpha", "beta"] {
+        let shown = host
+            .call_tool(
+                "orbit.learning.show",
+                json!({ "id": learning_ids[0], "workspace": workspace }),
+                ToolSessionContext::trusted_local(
+                    None,
+                    Some("hm_local".to_string()),
+                    Some("local".to_string()),
+                ),
+            )
+            .expect("merged row remains addressable through its workspace");
+        assert_eq!(shown["id"], learning_ids[0]);
+    }
+
+    let scoped = host
+        .call_tool(
+            "orbit.search",
+            json!({
+                "query": "shared merged search needle",
+                "all": true,
+                "workspace": "alpha"
+            }),
+            ToolSessionContext::trusted_local(
+                None,
+                Some("hm_local".to_string()),
+                Some("local".to_string()),
+            ),
+        )
+        .expect("workspace-scoped search");
+    assert!(
+        scoped["results"]
+            .as_array()
+            .expect("scoped rows")
+            .iter()
+            .all(|row| row.get("workspace").is_none()),
+        "workspace-scoped search shape must stay unchanged: {scoped}"
+    );
+}
+
+#[test]
 fn broker_with_context_requires_local_checkout_before_dispatch() {
     use chrono::Utc;
     use orbit_common::types::{Workspace, WorkspaceRegistry, WorkspaceStatus};


### PR DESCRIPTION
## Task

[ORB-10722](https://orbit-cli.com/tasks/ORB-10722) — Merged cross-workspace search results must carry the workspace field (ADR-0357 precondition)

### Description

## Problem
Merged cross-workspace search (`orbit_search all:true` and any surface that aggregates records across workspaces) returns rows whose IDs are only unique per workspace — frictions and run IDs already, learnings and every knowledge type once ADR-0357 lands — without a `workspace` field. A bare ID taken from such a result is not addressable: fed to a workspace-scoped read or write it silently hits the wrong record or none.

## Why It Matters
ADR-0357 (`docs/design/host-registry/4_decisions.md`) names this fix as a **precondition** of workspace-scoped knowledge keying, not a follow-up: the change widens an existing, operationally observed footgun from frictions to every knowledge type. The keying task is blocked on this one.

## Constraints / Notes
- Every merged/cross-workspace result row, for every kind, must carry the owning workspace identifier; workspace-scoped queries may keep their current shape.
- Design references: `docs/design/host-registry/2_design.md` §5 notes; `docs/design/mcp-bridge/2_design.md` §12.
- Deterministic test coverage: two records with the same ID in two workspaces must be distinguishable in merged output.

### Acceptance Criteria

- A merged search (all:true) response includes a workspace field on every result row for every kind it returns, verified by a test that seeds identically-numbered records in two workspaces and asserts both are distinguishable and addressable
- Workspace-scoped (non-merged) search output shape is unchanged, covered by existing or updated tests
- cargo build succeeds and the tests this change adds/modifies pass under nextest; pre-existing unrelated failures are out of scope

## Execution Summary

<details>
<summary>Click to expand</summary>

Execution summary derived by Orbit for ORB-10722 from the change delivered by run jrun-20260811-0415-3; no execution summary was persisted by the implementing agent.

Changed files (2):
- modified: crates/orbit-remote/src/mcp/host.rs
- modified: crates/orbit-remote/src/mcp/tests/mod.rs

This restates the worktree change the delivery commit contains and asserts nothing beyond it. Re-check it with `git show --stat` on the delivery commit.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10722-6a7aa1ea`
- Behind base: 0
- Ahead of base: 1