### PR TITLE
Managed asset reconciliation must be a no-op when the manifest is unchanged

### DIFF
--- a/crates/orbit-core/src/command/mod.rs
+++ b/crates/orbit-core/src/command/mod.rs
@@ -59,7 +59,7 @@ pub(crate) struct ManagedAssetReconciliation {
     pub warnings: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct ManagedAssetManifest {
     schema_version: u32,
@@ -163,6 +163,16 @@ pub(crate) fn reconcile_managed_assets<'a>(
                 next_assets.insert((*name).to_string(), previous_digest.clone());
                 continue;
             }
+
+            // The manifest records the last embedded content written for this
+            // asset. If it already matches the current embedded content, this
+            // bootstrap has nothing to refresh. Avoid touching the asset so a
+            // steady-state runtime can operate with global resources mounted
+            // read-only.
+            if previous_digest == Some(&rendered_digest) {
+                next_assets.insert((*name).to_string(), rendered_digest);
+                continue;
+            }
         }
 
         write_text_with_parent(&path, &rendered)?;
@@ -189,18 +199,20 @@ pub(crate) fn reconcile_managed_assets<'a>(
         asset_kind: asset_kind.to_string(),
         assets: next_assets,
     };
-    let mut encoded = serde_json::to_string_pretty(&manifest).map_err(|error| {
-        OrbitError::Store(format!(
-            "serialize managed {asset_kind} asset manifest: {error}"
-        ))
-    })?;
-    encoded.push('\n');
-    atomic_write_text(&manifest_path, &encoded).map_err(|error| {
-        OrbitError::Io(format!(
-            "write managed {asset_kind} asset manifest '{}': {error}",
-            manifest_path.display()
-        ))
-    })?;
+    if previous.as_ref() != Some(&manifest) {
+        let mut encoded = serde_json::to_string_pretty(&manifest).map_err(|error| {
+            OrbitError::Store(format!(
+                "serialize managed {asset_kind} asset manifest: {error}"
+            ))
+        })?;
+        encoded.push('\n');
+        atomic_write_text(&manifest_path, &encoded).map_err(|error| {
+            OrbitError::Io(format!(
+                "write managed {asset_kind} asset manifest '{}': {error}",
+                manifest_path.display()
+            ))
+        })?;
+    }
 
     for warning in &result.warnings {
         tracing::warn!(

--- a/crates/orbit-core/src/command/tests/managed_assets.rs
+++ b/crates/orbit-core/src/command/tests/managed_assets.rs
@@ -4,8 +4,15 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 use tempfile::tempdir;
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 use super::super::MANAGED_ASSET_MANIFEST_FILE;
+#[cfg(unix)]
+use super::super::activity::seed_default_activities;
 use super::super::init::{InitOptions, InitResult, init_workspace_at_root};
+#[cfg(unix)]
+use super::super::job::seed_default_jobs;
 use crate::OrbitRuntime;
 use crate::command::job::JobCatalogFilter;
 use crate::config::agent_detect::DetectedAgents;
@@ -105,6 +112,69 @@ spec:
   max_active_runs: 1
 {steps}"#
     )
+}
+
+#[cfg(unix)]
+fn make_read_only(path: &Path) {
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o555))
+        .expect("make managed asset directory read-only");
+}
+
+#[cfg(unix)]
+fn make_writable(path: &Path) {
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+        .expect("restore managed asset directory permissions");
+}
+
+#[cfg(unix)]
+#[test]
+fn steady_state_reconcile_skips_asset_and_manifest_writes() {
+    let root = tempdir().expect("create tempdir");
+    let global_root = root.path().join("global");
+    init_global(&global_root);
+
+    let activities_dir = global_root.join("resources/activities");
+    let jobs_dir = global_root.join("resources/jobs");
+    make_read_only(&activities_dir);
+    make_read_only(&jobs_dir);
+
+    let activities = seed_default_activities(&activities_dir, true);
+    let jobs = seed_default_jobs(&jobs_dir, true);
+
+    make_writable(&activities_dir);
+    make_writable(&jobs_dir);
+
+    let activities = activities.expect("unchanged activities do not require write access");
+    let jobs = jobs.expect("unchanged jobs do not require write access");
+
+    assert_eq!(activities.refreshed, 0);
+    assert_eq!(activities.retired, 0);
+    assert!(activities.warnings.is_empty());
+    assert_eq!(jobs.refreshed, 0);
+    assert_eq!(jobs.retired, 0);
+    assert!(jobs.warnings.is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn runtime_bootstrap_reads_seeded_global_assets_without_write_access() {
+    let root = tempdir().expect("create tempdir");
+    let global_root = root.path().join("global");
+    let workspace_root = root.path().join("repo/.orbit");
+    init_global(&global_root);
+
+    let activities_dir = global_root.join("resources/activities");
+    let jobs_dir = global_root.join("resources/jobs");
+    make_read_only(&activities_dir);
+    make_read_only(&jobs_dir);
+
+    let result = OrbitRuntime::from_roots(&global_root, &workspace_root)
+        .and_then(|runtime| runtime.list_job_catalog_with_last_run(true, JobCatalogFilter::All));
+
+    make_writable(&activities_dir);
+    make_writable(&jobs_dir);
+
+    result.expect("ordinary read-only runtime operation succeeds");
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-10732](https://orbit-cli.com/tasks/ORB-10732) — Managed asset reconciliation must be a no-op when the manifest is unchanged

### Description

## Problem

Commit `77d50ab6c2480fa61b88cfeffac8cd92bfd137fa` (`ORB-10684`) changed activity/job default seeding to `reconcile_managed_assets`. That function unconditionally serializes and atomically rewrites `.orbit-managed-assets.json`, even when the previous manifest and current embedded asset set are identical and no asset was refreshed or retired.

`ensure_orbit_root_initialized` runs global-only initialization during every `OrbitRuntime` bootstrap, so every Orbit command now requires write access to `~/.orbit/resources/activities` and `~/.orbit/resources/jobs`. Managed executor worktrees intentionally mount those global resources read-only. Consequently even read operations such as `orbit tool run orbit.task.show` fail with:

`write managed activity asset manifest ... Read-only file system (os error 30)`

This directly blocked `ORB-10722` run `jrun-20260811-0404-6` and was independently reproduced by QA run `ORB-10717`.

A task describing the bug was mistakenly created in the Polaris workspace as `ORB-10713`; it is not authoritative Orbit implementation work. This task is the correctly scoped `ws_orbit` fix record.

## Why It Matters

The regression breaks the task executor's own required lifecycle reads, adds unnecessary writes to every CLI invocation, and creates avoidable concurrent writers on a machine-global manifest.

## Constraints / Notes

- In steady state, unchanged managed assets and an equivalent existing manifest must cause no filesystem mutation.
- Initial seeding, changed embedded assets, retired clean assets, and preservation of modified retired assets must keep their current provenance-safe behavior.
- Do not make global resources writable in the executor sandbox as a workaround; the startup path must earn each write.
- Use deterministic temporary-directory coverage and verify the real runtime-bootstrap path, not only a helper comparison.
- Evidence: `ORB-10722`, `jrun-20260811-0404-6`, `ORB-10717`, introducing commit `77d50ab6`.

### Acceptance Criteria

- A steady-state reconcile with an equivalent existing manifest performs no manifest or asset write and succeeds when the managed activity/job directories are read-only.
- A runtime-bootstrap regression test proves an ordinary read-only Orbit operation succeeds after initial global seeding without requiring write access to global resources.
- Initial manifest creation, embedded asset refresh, clean retirement, and preservation of locally modified retired assets retain their existing behavior and coverage.
- The fix does not broaden executor sandbox write grants or bypass managed-asset provenance validation.
- Focused orbit-core managed-asset tests pass under nextest and make ci-fast passes; unrelated pre-existing failures are recorded rather than folded into this fix.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Reconciliation now skips default asset rewrites when their recorded digest already matches the embedded content.
- Manifest writes are skipped when the computed manifest is semantically unchanged.
- Added Unix read-only directory regression coverage for direct steady-state activity/job reconciliation and the real `OrbitRuntime::from_roots` bootstrap plus job-catalog read path.
- Existing initial seeding, refresh, retirement, and modified-retired preservation coverage remains in the focused managed-assets suite.

Assessment: The no-op path retains provenance validation and performs no sandbox-grant or dependency changes.

Validation:
- `cargo nextest run -p orbit-core managed_assets` — passed (4 tests).
- `make ci-fast` — passed.
- `make ci-lint` — passed.
- `git diff --check` — passed.

Friction checkpoint: no report filed; no qualifying recurring or non-obvious workflow issue exceeded the threshold.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10732-6a7aa6af`
- Behind base: 0
- Ahead of base: 1