### PR TITLE
Ownership write enforcement at the shared chokepoint; replica visibility rules (ADR-0355)

### DIFF
--- a/crates/orbit-cli/src/command/workspace/list.rs
+++ b/crates/orbit-cli/src/command/workspace/list.rs
@@ -7,7 +7,11 @@ use serde_json::{Value, json};
 use crate::command::{CommandOut, Execute, Payload};
 
 #[derive(Args)]
-pub struct WorkspaceListArgs {}
+pub struct WorkspaceListArgs {
+    /// Include local replica checkouts, marked with their declared owner.
+    #[arg(long)]
+    pub all: bool,
+}
 
 impl Execute for WorkspaceListArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
@@ -21,8 +25,8 @@ impl Execute for WorkspaceListArgs {
             workspace_registry::save_registry_to(&registry, &registry_path)?;
         }
         Ok(Payload::detail(
-            workspace_list_json(&registry),
-            format_workspace_list(&registry),
+            workspace_list_json(&registry, self.all),
+            format_workspace_list(&registry, self.all),
         )
         .into())
     }
@@ -31,11 +35,16 @@ impl Execute for WorkspaceListArgs {
 /// `workspace list` had no machine-readable form either; one record per
 /// registered workspace, carrying the same fields the text columns show
 /// (ORB-10586).
-pub(super) fn workspace_list_json(registry: &WorkspaceRegistry) -> Value {
+pub(super) fn workspace_list_json(registry: &WorkspaceRegistry, include_replicas: bool) -> Value {
     Value::Array(
         registry
             .workspaces
             .iter()
+            .filter(|workspace| {
+                include_replicas
+                    || workspace_registry::find_checkout(registry, &workspace.id)
+                        .is_none_or(|checkout| checkout.role != Some(orbit_common::types::WorkspaceCheckoutRole::Replica))
+            })
             .map(|workspace| {
                 let checkout = workspace_registry::find_checkout(registry, &workspace.id);
                 json!({
@@ -52,13 +61,27 @@ pub(super) fn workspace_list_json(registry: &WorkspaceRegistry) -> Value {
     )
 }
 
-pub(super) fn format_workspace_list(registry: &WorkspaceRegistry) -> String {
-    if registry.workspaces.is_empty() {
+pub(super) fn format_workspace_list(
+    registry: &WorkspaceRegistry,
+    include_replicas: bool,
+) -> String {
+    let workspaces: Vec<_> = registry
+        .workspaces
+        .iter()
+        .filter(|workspace| {
+            include_replicas
+                || workspace_registry::find_checkout(registry, &workspace.id).is_none_or(
+                    |checkout| {
+                        checkout.role != Some(orbit_common::types::WorkspaceCheckoutRole::Replica)
+                    },
+                )
+        })
+        .collect();
+    if workspaces.is_empty() {
         return "no workspaces registered\n".to_string();
     }
 
-    let id_width = registry
-        .workspaces
+    let id_width = workspaces
         .iter()
         .map(|workspace| workspace.id.chars().count())
         .max()
@@ -74,7 +97,7 @@ pub(super) fn format_workspace_list(registry: &WorkspaceRegistry) -> String {
         "ROLE",
         id_width = id_width
     );
-    for workspace in &registry.workspaces {
+    for workspace in workspaces {
         let checkout = workspace_registry::find_checkout(registry, &workspace.id);
         let root = checkout
             .map(|checkout| checkout.repo_root.display().to_string())

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -2,15 +2,15 @@ use tempfile::tempdir;
 
 use chrono::Utc;
 use orbit_common::types::{
-    OverlapPolicy, RoutineTarget, Workspace, WorkspaceCheckout, WorkspaceRegistry, WorkspaceStatus,
-    parse_routine_yaml,
+    OverlapPolicy, RoutineTarget, Workspace, WorkspaceCheckout, WorkspaceCheckoutRole,
+    WorkspaceRegistry, WorkspaceStatus, parse_routine_yaml,
 };
 use orbit_remote::workspace_registry;
 
 use crate::tests::env_isolation::EnvGuard;
 
 use super::super::init::{WorkspaceInitArgs, canonical_workspace_id};
-use super::super::list::format_workspace_list;
+use super::super::list::{format_workspace_list, workspace_list_json};
 use super::super::role::CliCheckoutRole;
 use super::super::show::format_workspace_show;
 use super::super::support::orbit_gitignore_block;
@@ -626,7 +626,7 @@ fn workspace_list_and_show_report_effective_ship_mode() {
         ..Default::default()
     };
 
-    let list = format_workspace_list(&registry);
+    let list = format_workspace_list(&registry, false);
     assert!(list.contains("SHIP MODE"), "{list}");
     assert!(list.contains("pr"), "{list}");
     let mut lines = list.lines();
@@ -639,6 +639,68 @@ fn workspace_list_and_show_report_effective_ship_mode() {
 
     let show = format_workspace_show(&workspace, &registry.checkouts[0]);
     assert!(show.contains("ship_mode:   pr"), "{show}");
+}
+
+#[test]
+fn workspace_list_hides_replicas_unless_all_and_marks_their_owner() {
+    let now = Utc::now();
+    let owner = Workspace {
+        id: "ws_owner".to_string(),
+        name: "owner".to_string(),
+        owner_machine_id: Some("hm_local".to_string()),
+        git_remote: None,
+        ship_mode: None,
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: now,
+        updated_at: now,
+    };
+    let replica = Workspace {
+        id: "ws_replica".to_string(),
+        name: "replica".to_string(),
+        owner_machine_id: Some("hm_owner".to_string()),
+        git_remote: None,
+        ship_mode: None,
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: now,
+        updated_at: now,
+    };
+    let registry = WorkspaceRegistry {
+        workspaces: vec![owner.clone(), replica.clone()],
+        checkouts: vec![
+            WorkspaceCheckout::owner(
+                owner.id.clone(),
+                "/work/owner".into(),
+                "/work/owner/.orbit".into(),
+            ),
+            WorkspaceCheckout {
+                workspace_id: replica.id.clone(),
+                repo_root: "/work/replica".into(),
+                orbit_dir: "/work/replica/.orbit".into(),
+                role: Some(WorkspaceCheckoutRole::Replica),
+                owner_machine_id: Some("hm_owner".to_string()),
+                path_overrides: Vec::new(),
+            },
+        ],
+        ..Default::default()
+    };
+
+    assert_eq!(
+        workspace_list_json(&registry, false)
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert!(!format_workspace_list(&registry, false).contains("replica"));
+
+    let all = workspace_list_json(&registry, true);
+    assert_eq!(all.as_array().unwrap().len(), 2);
+    assert_eq!(all[1]["owner_machine_id"], "hm_owner");
+    let text = format_workspace_list(&registry, true);
+    assert!(text.contains("replica"));
+    assert!(text.contains("hm_owner"));
 }
 
 #[test]

--- a/crates/orbit-core/src/command/task/add.rs
+++ b/crates/orbit-core/src/command/task/add.rs
@@ -26,6 +26,7 @@ impl OrbitRuntime {
         agent: Option<String>,
         model: Option<String>,
     ) -> Result<Task, OrbitError> {
+        self.ensure_coordination_task_write_permitted()?;
         // [ORB-00417] Redact secrets at the single task-creation choke point
         // (shared by the dashboard POST, CLI `task add`, and the MCP task tool)
         // so a pasted key never lands in the task registry or the audit trail.

--- a/crates/orbit-core/src/command/task/query.rs
+++ b/crates/orbit-core/src/command/task/query.rs
@@ -57,6 +57,9 @@ impl OrbitRuntime {
     }
 
     pub fn list_tasks(&self) -> Result<Vec<Task>, OrbitError> {
+        if !self.coordination_task_reads_visible() {
+            return Ok(Vec::new());
+        }
         self.stores().tasks().list_tasks()
     }
 
@@ -65,10 +68,16 @@ impl OrbitRuntime {
     pub fn task_status_index(
         &self,
     ) -> Result<BTreeMap<String, orbit_common::types::TaskStatus>, OrbitError> {
+        if !self.coordination_task_reads_visible() {
+            return Ok(BTreeMap::new());
+        }
         self.stores().tasks().task_status_index()
     }
 
     pub fn list_tasks_by_tags(&self, tags: &[String]) -> Result<Vec<Task>, OrbitError> {
+        if !self.coordination_task_reads_visible() {
+            return Ok(Vec::new());
+        }
         self.stores().tasks().list_tasks_by_tags(tags)
     }
 
@@ -112,6 +121,9 @@ impl OrbitRuntime {
         external_ref: Option<&ExternalRef>,
         has_external_ref_system: Option<&str>,
     ) -> Result<Vec<Task>, OrbitError> {
+        if !self.coordination_task_reads_visible() {
+            return Ok(Vec::new());
+        }
         self.stores().tasks().list_tasks_filtered(
             status,
             priority,
@@ -123,6 +135,9 @@ impl OrbitRuntime {
     }
 
     pub fn search_tasks(&self, query: &str) -> Result<Vec<Task>, OrbitError> {
+        if !self.coordination_task_reads_visible() {
+            return Ok(Vec::new());
+        }
         self.stores().tasks().search_tasks(query)
     }
 
@@ -131,6 +146,9 @@ impl OrbitRuntime {
         query: &str,
         tags: &[String],
     ) -> Result<Vec<Task>, OrbitError> {
+        if !self.coordination_task_reads_visible() {
+            return Ok(Vec::new());
+        }
         self.stores().tasks().search_tasks_filtered(query, tags)
     }
 }

--- a/crates/orbit-core/src/command/task/transitions.rs
+++ b/crates/orbit-core/src/command/task/transitions.rs
@@ -46,6 +46,7 @@ impl OrbitRuntime {
         agent: Option<String>,
         model: Option<String>,
     ) -> Result<Task, OrbitError> {
+        self.ensure_coordination_task_write_permitted()?;
         let (canonical_agent, canonical_model) =
             self.try_canonical_agent_model_identity(agent.as_deref(), model.as_deref())?;
         let task = self.get_task(id)?;
@@ -242,6 +243,7 @@ impl OrbitRuntime {
         id: &str,
         options: StartTaskOptions,
     ) -> Result<Task, OrbitError> {
+        self.ensure_coordination_task_write_permitted()?;
         let StartTaskOptions {
             note,
             comment,
@@ -415,6 +417,7 @@ impl OrbitRuntime {
         id: &str,
         workflow: &str,
     ) -> Result<Task, OrbitError> {
+        self.ensure_coordination_task_write_permitted()?;
         let workflow = workflow.trim();
         let workflow = if workflow.is_empty() {
             "workflow"
@@ -494,6 +497,7 @@ impl OrbitRuntime {
         source_run_id: &str,
         resumed_run_id: &str,
     ) -> Result<Option<Task>, OrbitError> {
+        self.ensure_coordination_task_write_permitted()?;
         let task = self.get_task(id)?;
         let readmit = task.status == TaskStatus::Blocked;
         let restamp = batch_run_id
@@ -554,6 +558,7 @@ impl OrbitRuntime {
         agent: Option<String>,
         model: Option<String>,
     ) -> Result<Task, OrbitError> {
+        self.ensure_coordination_task_write_permitted()?;
         let (canonical_agent, canonical_model) =
             self.try_canonical_agent_model_identity(agent.as_deref(), model.as_deref())?;
         let task = self.get_task(id)?;
@@ -662,6 +667,7 @@ impl OrbitRuntime {
     }
 
     pub fn archive_task(&self, id: &str) -> Result<(), OrbitError> {
+        self.ensure_coordination_task_write_permitted()?;
         let task = self.get_task(id)?;
 
         if task.status == TaskStatus::Archived {
@@ -686,6 +692,7 @@ impl OrbitRuntime {
     }
 
     pub fn delete_task(&self, id: &str) -> Result<(), OrbitError> {
+        self.ensure_coordination_task_write_permitted()?;
         self.with_mutation(|| {
             let deleted = self.stores().task_records().delete(id)?;
             if !deleted {

--- a/crates/orbit-core/src/command/task/update.rs
+++ b/crates/orbit-core/src/command/task/update.rs
@@ -30,6 +30,7 @@ impl OrbitRuntime {
         agent: Option<String>,
         model: Option<String>,
     ) -> Result<Task, OrbitError> {
+        self.ensure_coordination_task_write_permitted()?;
         self.update_task_with_status_note_and_identity(id, params, None, agent, model)
     }
 

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -69,6 +69,10 @@ pub(crate) use task_records::TaskRecordUpdateParams;
 pub struct OrbitRuntime {
     context: OrbitContext,
     workspace_binding: Option<Arc<WorkspaceRuntimeBinding>>,
+    /// A higher-level registry may mark this local checkout as a replica. Core
+    /// stays registry-neutral; it only carries the refusal supplied by that
+    /// owner so every task-record writer shares one fail-closed gate.
+    coordination_write_owner: Option<Arc<str>>,
     pub event_log: event_bus::EventLog,
     /// Outcome of the [ORB-10012] workspace-layout pre-flight that ran when
     /// this runtime opened (empty `applied` when the layout was already
@@ -253,6 +257,7 @@ impl OrbitRuntime {
         let runtime = Self {
             context,
             workspace_binding: binding.map(Arc::new),
+            coordination_write_owner: None,
             event_log: event_bus::EventLog::default(),
             layout_report: Arc::new(layout_report),
             _temp_dir: None,
@@ -278,6 +283,7 @@ impl OrbitRuntime {
         Ok(Self {
             context,
             workspace_binding: None,
+            coordination_write_owner: None,
             event_log: event_bus::EventLog::default(),
             layout_report: Arc::new(orbit_store::layout::LayoutUpgradeReport::default()),
             _temp_dir: Some(Arc::new(temp_dir)),
@@ -293,6 +299,26 @@ impl OrbitRuntime {
     pub fn with_actor(mut self, actor: ActorIdentity) -> Self {
         self.context.set_actor(actor);
         self
+    }
+
+    /// Attach the declared remote owner for a replica checkout. This is set by
+    /// the registry-owning composition layer, never inferred by Core.
+    pub fn with_coordination_write_owner(mut self, owner_machine_id: Option<String>) -> Self {
+        self.coordination_write_owner = owner_machine_id.map(Arc::from);
+        self
+    }
+
+    pub(crate) fn ensure_coordination_task_write_permitted(&self) -> Result<(), OrbitError> {
+        let Some(owner_machine_id) = self.coordination_write_owner.as_deref() else {
+            return Ok(());
+        };
+        Err(OrbitError::InvalidInput(format!(
+            "coordination writes are refused in this replica checkout; workspace is owned by machine '{owner_machine_id}'"
+        )))
+    }
+
+    pub(crate) fn coordination_task_reads_visible(&self) -> bool {
+        self.coordination_write_owner.is_none()
     }
 
     /// Returns in-process events recorded during this session only. Not persisted across process

--- a/crates/orbit-remote/src/mcp/host.rs
+++ b/crates/orbit-remote/src/mcp/host.rs
@@ -567,6 +567,30 @@ impl BrokerMcpHost {
             .unwrap_or_else(|| workspace_id.to_string())
     }
 
+    /// Return the declared owner only when this machine's binding is explicitly
+    /// a replica. This reads the machine-local registry; it never infers an
+    /// owner from the process, path, or transport.
+    fn replica_owner_machine_id(
+        &self,
+        workspace_id: &str,
+        binding: Option<&ExactCheckoutBinding>,
+    ) -> Option<String> {
+        if let Some(binding) = binding
+            && binding.role == WorkspaceCheckoutRole::Replica
+        {
+            return binding.owner_machine_id.clone();
+        }
+        let registry_path = crate::workspace_registry::registry_path_for(&self.global_root);
+        let registry = crate::workspace_registry::load_registry_from(&registry_path).ok()?;
+        let checkout = registry
+            .checkouts
+            .iter()
+            .find(|checkout| checkout.workspace_id == workspace_id)?;
+        (checkout.role == Some(WorkspaceCheckoutRole::Replica))
+            .then(|| checkout.owner_machine_id.clone())
+            .flatten()
+    }
+
     fn legacy_friction_root(
         &self,
         workspace_id: &str,
@@ -749,6 +773,22 @@ impl BrokerMcpHost {
             self.record_preflight_denial(name, &input, &context, &error);
             return Err(error);
         }
+        if let Some(owner_machine_id) =
+            self.replica_owner_machine_id(&workspace_id, binding.as_ref())
+        {
+            if is_coordination_record_write(name) {
+                let error = OrbitError::InvalidInput(format!(
+                    "coordination write '{name}' is refused in this replica checkout; workspace is owned by machine '{owner_machine_id}'"
+                ));
+                self.record_preflight_denial(name, &input, &context, &error);
+                return Err(error);
+            }
+            if is_coordination_record_read(name) {
+                let result = Ok(Value::Array(Vec::new()));
+                self.record_coordination_outcome(name, &context, &result);
+                return result;
+            }
+        }
         if definition.policy.placement() == McpToolPlacement::Hub
             && !with_context
             && !local_workflow_execution
@@ -834,6 +874,27 @@ impl BrokerMcpHost {
             None => audited_mcp_call_with_session_context(&runtime, name, input, context),
         }
     }
+}
+
+/// The coordination-record mutators all pass the broker before either the
+/// checkout-local runtime or the checkoutless coordinator can open a store.
+/// Keep this explicit and test it against the registered MCP surface so a new
+/// mutator cannot silently create a replica-local fork.
+pub(super) fn is_coordination_record_write(name: &str) -> bool {
+    matches!(
+        name,
+        "orbit.task.add"
+            | "orbit.task.approve"
+            | "orbit.task.artifact.put"
+            | "orbit.task.start"
+            | "orbit.task.update"
+            | "orbit.friction.add"
+            | "orbit.friction.update"
+    )
+}
+
+fn is_coordination_record_read(name: &str) -> bool {
+    matches!(name, "orbit.task.list" | "orbit.friction.list")
 }
 
 impl McpHost for BrokerMcpHost {

--- a/crates/orbit-remote/src/mcp/tests/mod.rs
+++ b/crates/orbit-remote/src/mcp/tests/mod.rs
@@ -143,6 +143,84 @@ fn broker_checkoutless_task_call_uses_stable_id_and_one_trusted_audit() {
 }
 
 #[test]
+fn broker_replica_refuses_registered_coordination_writes_and_hides_task_reads() {
+    use chrono::Utc;
+    use orbit_common::types::{Workspace, WorkspaceCheckout, WorkspaceRegistry, WorkspaceStatus};
+
+    let root = tempfile::tempdir().expect("global root");
+    crate::ensure_host_identity(root.path(), || {
+        Ok(crate::NewHostIdentity {
+            host_id: "replica".to_string(),
+            task_prefix: "RP".to_string(),
+        })
+    })
+    .expect("host identity");
+    let workspace = Workspace {
+        id: "ws_replica".to_string(),
+        name: "Replica".to_string(),
+        owner_machine_id: Some("hm_owner".to_string()),
+        git_remote: None,
+        ship_mode: None,
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    crate::workspace_registry::save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![workspace.clone()],
+            checkouts: vec![WorkspaceCheckout {
+                workspace_id: workspace.id.clone(),
+                repo_root: root.path().join("checkout"),
+                orbit_dir: root.path().join("checkout/.orbit"),
+                role: Some(orbit_common::types::WorkspaceCheckoutRole::Replica),
+                owner_machine_id: Some("hm_owner".to_string()),
+                path_overrides: Vec::new(),
+            }],
+            ..Default::default()
+        },
+        &crate::workspace_registry::registry_path_for(root.path()),
+    )
+    .expect("replica registry");
+    let host = BrokerMcpHost::new(root.path().to_path_buf());
+    let context = ToolSessionContext::trusted_local(
+        Some(workspace.id.clone()),
+        Some("hm_replica".to_string()),
+        Some("replica".to_string()),
+    );
+
+    for definition in canonical_mcp_tool_definitions().expect("registered tools") {
+        let name = definition.schema.name;
+        if !super::host::is_coordination_record_write(&name) {
+            continue;
+        }
+        let mut call_context = context.clone();
+        call_context.effective_capabilities = BTreeSet::from([*definition
+            .policy
+            .allowed_capabilities()
+            .first()
+            .expect("coordination writer capability")]);
+        let error = host
+            .call_tool(
+                &name,
+                json!({"workspace": workspace.id, "model": "codex"}),
+                call_context,
+            )
+            .expect_err("every registered coordination mutation must be refused");
+        assert!(error.to_string().contains("hm_owner"), "{name}: {error}");
+    }
+
+    let listed = host
+        .call_tool(
+            "orbit.task.list",
+            json!({"workspace": workspace.id}),
+            context,
+        )
+        .expect("replica coordination read is empty");
+    assert_eq!(listed, json!([]));
+}
+
+#[test]
 fn broker_merged_search_tags_duplicate_ids_with_their_workspace() {
     use std::process::Command;
 

--- a/crates/orbit-remote/src/runtime.rs
+++ b/crates/orbit-remote/src/runtime.rs
@@ -88,12 +88,15 @@ impl RemoteRuntimeFactory {
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
         let roots = Self::resolve_roots_for_cwd(&cwd, root_override)?;
         let binding = binding_for_roots(&roots)?;
+        let replica_owner = replica_owner_for_roots(&roots)?;
         OrbitRuntime::initialize_from_resolved_roots(roots, binding)
+            .map(|runtime| runtime.with_coordination_write_owner(replica_owner))
     }
 
     pub fn open_resolved_roots(roots: OrbitRuntimeRoots) -> Result<OrbitRuntime, OrbitError> {
         let binding = binding_for_roots(&roots)?;
-        match binding {
+        let replica_owner = replica_owner_for_roots(&roots)?;
+        let runtime = match binding {
             Some(binding) => OrbitRuntime::from_resolved_roots_with_binding(
                 &roots.global_root,
                 &roots.shared_root,
@@ -105,7 +108,8 @@ impl RemoteRuntimeFactory {
                 &roots.shared_root,
                 &roots.local_root,
             ),
-        }
+        }?;
+        Ok(runtime.with_coordination_write_owner(replica_owner))
     }
 
     pub fn open_registered_checkout(
@@ -114,7 +118,9 @@ impl RemoteRuntimeFactory {
         checkout: &WorkspaceCheckout,
     ) -> Result<OrbitRuntime, OrbitError> {
         let binding = workspace_runtime_binding(workspace, checkout)?;
-        OrbitRuntime::from_roots_with_binding(global_root, &checkout.orbit_dir, binding)
+        OrbitRuntime::from_roots_with_binding(global_root, &checkout.orbit_dir, binding).map(
+            |runtime| runtime.with_coordination_write_owner(replica_owner_for_checkout(checkout)),
+        )
     }
 
     pub fn open_resolved_checkout(
@@ -130,6 +136,26 @@ impl RemoteRuntimeFactory {
             binding,
         )
     }
+}
+
+fn replica_owner_for_checkout(checkout: &WorkspaceCheckout) -> Option<String> {
+    (checkout.role == Some(WorkspaceCheckoutRole::Replica))
+        .then(|| checkout.owner_machine_id.clone())
+        .flatten()
+}
+
+fn replica_owner_for_roots(roots: &OrbitRuntimeRoots) -> Result<Option<String>, OrbitError> {
+    let registry_path = workspace_registry::registry_path_for(&roots.global_root);
+    let registry = workspace_registry::load_registry_from(&registry_path)?;
+    let shared =
+        std::fs::canonicalize(&roots.shared_root).unwrap_or_else(|_| roots.shared_root.clone());
+    Ok(registry.checkouts.iter().find_map(|checkout| {
+        let registered = std::fs::canonicalize(&checkout.orbit_dir)
+            .unwrap_or_else(|_| checkout.orbit_dir.clone());
+        (registered == shared)
+            .then(|| replica_owner_for_checkout(checkout))
+            .flatten()
+    }))
 }
 
 fn workspace_root_hint(cwd: &Path) -> Option<WorkspaceRootHint> {

--- a/crates/orbit-remote/src/tests/runtime.rs
+++ b/crates/orbit-remote/src/tests/runtime.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use orbit_common::types::{
-    NotFoundKind, OrbitError, Workspace, WorkspaceCheckout, WorkspaceStatus,
+    NotFoundKind, OrbitError, Workspace, WorkspaceCheckout, WorkspaceCheckoutRole, WorkspaceStatus,
 };
 use orbit_store::sqlite::task_registry::{WorkspaceConfig, write_workspace_config};
 use serde_json::json;
@@ -83,4 +83,47 @@ fn registered_checkout_opens_a_bound_runtime() {
             ..
         })
     ));
+}
+
+#[test]
+fn replica_runtime_refuses_task_writes_and_hides_coordination_reads() {
+    let root = tempfile::tempdir().expect("root");
+    let global = root.path().join("global");
+    let repo = root.path().join("replica");
+    let orbit_dir = repo.join(".orbit");
+    std::fs::create_dir_all(&global).expect("global");
+    std::fs::create_dir_all(&orbit_dir).expect("orbit directory");
+    write_workspace_config(
+        &orbit_dir,
+        &WorkspaceConfig {
+            schema_version: 1,
+            workspace_id: "ws_runtime".to_string(),
+        },
+    )
+    .expect("workspace config");
+    let workspace = workspace("logical-replica", "local");
+    let checkout = WorkspaceCheckout {
+        workspace_id: workspace.id.clone(),
+        repo_root: repo,
+        orbit_dir,
+        role: Some(WorkspaceCheckoutRole::Replica),
+        owner_machine_id: Some("hm_owner".to_string()),
+        path_overrides: Vec::new(),
+    };
+    let runtime = RemoteRuntimeFactory::open_registered_checkout(&global, &workspace, &checkout)
+        .expect("replica runtime");
+
+    let error = runtime
+        .add_task(orbit_core::command::task::TaskAddParams {
+            title: "must not fork".to_string(),
+            ..Default::default()
+        })
+        .expect_err("replica task write must fail closed");
+    assert!(error.to_string().contains("hm_owner"), "{error}");
+    assert!(
+        runtime
+            .list_tasks()
+            .expect("empty replica task list")
+            .is_empty()
+    );
 }

--- a/crates/orbit-remote/src/workspace_registry.rs
+++ b/crates/orbit-remote/src/workspace_registry.rs
@@ -12,7 +12,7 @@ use orbit_common::utility::fs::atomic_write_text;
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::host_identity::{HostIdentityState, HostMode, inspect_host_identity};
+use crate::host_identity::{HostIdentityState, inspect_host_identity};
 
 /// Returns the global Orbit directory: `~/.orbit/`.
 pub fn global_orbit_dir() -> Result<PathBuf, OrbitError> {
@@ -381,7 +381,6 @@ pub fn validate_workspaces(registry: &mut WorkspaceRegistry) {
 
 #[derive(Debug, Clone)]
 struct RegistryHostContext {
-    mode: HostMode,
     machine_id: Option<String>,
 }
 
@@ -394,14 +393,12 @@ fn registry_host_context(path: &Path) -> Result<RegistryHostContext, OrbitError>
     })?;
     match inspect_host_identity(global_root)? {
         HostIdentityState::Present(identity) => Ok(RegistryHostContext {
-            mode: identity.mode,
             machine_id: Some(identity.machine_id),
         }),
         // Pre-host-identity installations are the legacy standalone case.
-        HostIdentityState::Legacy { .. } | HostIdentityState::Absent => Ok(RegistryHostContext {
-            mode: HostMode::Standalone,
-            machine_id: None,
-        }),
+        HostIdentityState::Legacy { .. } | HostIdentityState::Absent => {
+            Ok(RegistryHostContext { machine_id: None })
+        }
     }
 }
 
@@ -523,13 +520,13 @@ fn validate_registry(
         }
 
         if checkout.role.is_none() {
-            if context.mode == HostMode::Standalone {
+            if context.machine_id.is_none() {
                 checkout.role = Some(WorkspaceCheckoutRole::Owner);
                 changed = true;
             } else {
                 return Err(invalid_registry(format!(
-                    "workspace '{}' is missing a local checkout role in {} mode",
-                    checkout.workspace_id, context.mode
+                    "workspace '{}' is missing a local checkout role; run `orbit workspace role` to declare owner or replica",
+                    checkout.workspace_id
                 )));
             }
         }
@@ -550,30 +547,24 @@ fn validate_registry(
                                 checkout.workspace_id
                             )));
                         }
-                        None if context.mode == HostMode::Standalone => {
+                        None if context.machine_id.is_none() => {
                             workspace.owner_machine_id = Some(machine_id.to_string());
                             changed = true;
                         }
                         None => {
                             return Err(invalid_registry(format!(
-                                "workspace '{}' declares local owner role but has no declared \
-                                 owner_machine_id in {} mode",
-                                checkout.workspace_id, context.mode
+                                "workspace '{}' declares local owner role but has no declared owner_machine_id",
+                                checkout.workspace_id
                             )));
                         }
                         Some(_) => {}
                     }
-                } else if context.mode != HostMode::Standalone {
-                    return Err(invalid_registry(format!(
-                        "workspace '{}' cannot validate owner role without a local machine_id",
-                        checkout.workspace_id
-                    )));
                 }
             }
             Some(WorkspaceCheckoutRole::Replica) => {
-                if context.mode == HostMode::Standalone {
+                if context.machine_id.is_none() {
                     return Err(invalid_registry(format!(
-                        "workspace '{}' cannot use replica role in standalone mode",
+                        "workspace '{}' cannot validate replica role without a local machine_id",
                         checkout.workspace_id
                     )));
                 }
@@ -616,12 +607,12 @@ fn validate_registry(
         checkout.path_overrides.dedup();
         changed |= checkout.path_overrides.len() != before;
     }
-    if context.mode != HostMode::Standalone {
+    if context.machine_id.is_some() {
         for workspace in &registry.workspaces {
             if workspace.owner_machine_id.is_none() {
                 return Err(invalid_registry(format!(
-                    "workspace '{}' is missing owner_machine_id in {} mode",
-                    workspace.id, context.mode
+                    "workspace '{}' is missing owner_machine_id",
+                    workspace.id
                 )));
             }
         }
@@ -696,10 +687,12 @@ fn migrate_legacy_registry(
             workspace_id: workspace_id.clone(),
             repo_root: legacy_workspace.root,
             orbit_dir: legacy_workspace.orbit_dir,
-            // Only standalone mode has a compatibility rule for legacy
-            // checkouts that predate explicit roles. Multi-host modes must
-            // fail closed instead of inferring ownership from a local path.
-            role: (context.mode == HostMode::Standalone).then_some(WorkspaceCheckoutRole::Owner),
+            // Only installations without a host identity may use the legacy
+            // owner default. Identity-bearing machines must declare a role.
+            role: context
+                .machine_id
+                .is_none()
+                .then_some(WorkspaceCheckoutRole::Owner),
             owner_machine_id: None,
             path_overrides: overrides_by_workspace
                 .remove(&workspace_id)


### PR DESCRIPTION
## Task

[ORB-10724](https://orbit-cli.com/tasks/ORB-10724) — Ownership write enforcement at the shared chokepoint; replica visibility rules (ADR-0355)

### Description

## Problem
With coordination following ownership, a machine that is not a workspace's declared owner must not write that workspace's coordination records — but today nothing refuses such writes, and `orbit workspace list` does not distinguish owned workspaces from replica checkouts. Design: `docs/design/host-registry/2_design.md` §2–§3 (single enforcement rule, "Coordination writes in a non-owned checkout fail closed").

## Why It Matters
A read-side filter alone would let `orbit task add` mint a local record for a non-owned workspace, splitting the task set across two stores — the exact silent-fork failure the model exists to prevent.

## Constraints / Notes
- One rule, decided entirely from the machine's own workspace entry, no remote call, works offline: non-owner coordination writes are refused at the shared submission chokepoint so every surface (CLI and MCP) inherits it; the error names the owning `machine_id` and the configured route if one exists.
- Replica checkouts stay in the local registry (path resolution and the local-derived tier must keep working) but are hidden from `orbit workspace list` except under `--all`, where they are visibly marked with their owner.
- Coordination reads in a non-owned checkout return empty; local-derived reads (docs search, graph) are unaffected.
- Never forward the call to the owner automatically — refusal only, in v1.
- The design's §7 concern "Enforcement is per-surface plumbing... needs a test that walks the registered tool surface" is in scope: add that walk-the-mutating-surface test.
- Existing workspace_registry invariants (owner/replica contradiction rejection, replicas require non-local owner) carry over unchanged.

### Acceptance Criteria

- In a replica checkout, coordination writes via both CLI and MCP are refused with an error naming the owner machine_id; verified by tests at the shared chokepoint, not per-tool patches
- orbit workspace list omits replica checkouts by default and shows them owner-marked under --all; path resolution and docs search still work inside a replica checkout (tests)
- Coordination reads (e.g. task list) in a non-owned checkout return empty rather than erroring (test)
- A test walks the registered mutating tool surface and asserts every coordination-record mutation is covered by the ownership refusal
- cargo build succeeds and the tests this change adds/modifies pass under nextest; pre-existing unrelated failures are out of scope

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a registry-injected replica ownership refusal to the Core task-record paths, so native CLI task writes fail closed and coordination task reads are empty while local-derived features retain their runtime.
- Updated Remote runtime composition and the MCP broker to determine replica status solely from the local workspace binding; all registered task/friction coordination mutators are rejected before store dispatch, naming the owner machine ID.
- Updated registry validation for host-identity v2 to use the presence of a local machine ID rather than the retired machine-level mode, preserving explicit owner/replica invariants.
- Made `orbit workspace list` hide replica checkouts by default and include their owner/role under `--all`.
- Added coverage for CLI-runtime refusal/read behavior, MCP registered mutator refusal, and list visibility.
Assessment: targeted tests, cargo build, ci-fast, and ci-lint pass. `cargo nextest run -p orbit-remote` still has two pre-existing failures (`broker_spoke_with_context_fails_closed_before_local_resolution` and `broker_spoke_hub_denial_writes_no_local_coordination_state`) caused by legacy schema-v1 host fixtures expecting retired spoke-mode routing; the targeted replica tests pass.
Validation:
- cargo build
- cargo nextest run -p orbit-remote -p orbit-cli replica_runtime_refuses_task_writes_and_hides_coordination_reads workspace_list_hides_replicas_unless_all_and_marks_their_owner broker_replica_refuses_registered_coordination_writes_and_hides_task_reads
- make ci-fast
- make ci-lint

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10724-6a7aaa57`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*