### PR TITLE
Prefix- and width-agnostic task IDs; allocator mints <task_prefix>-NNNNN (ADR-0356)

### DIFF
--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -173,8 +173,9 @@ pub use task_artifacts::{
     TASK_COMMENTS_FILE_NAME, TASK_DESCRIPTION_FILE_NAME, TASK_ENVELOPE_FILE_NAME,
     TASK_EVENTS_FILE_NAME, TASK_EXECUTION_SUMMARY_FILE_NAME, TASK_PLAN_FILE_NAME, TaskCommentRowV2,
     TaskEnvelopeV2, TaskEventRowV2, TaskRelation, TaskRelationEdge, TaskRelationType,
-    format_orb_task_id, is_valid_orb_task_id, validate_orb_task_id,
-    validate_relative_artifact_path, validate_task_relations_for_source,
+    format_orb_task_id, format_task_id, is_valid_orb_task_id, is_valid_task_id_prefix,
+    parse_task_number, task_id_prefix, validate_orb_task_id, validate_relative_artifact_path,
+    validate_task_relations_for_source,
 };
 pub use task_plan::{TaskPlan, TaskPlanCheckpoint, TaskPlanSuccessCriterion, parse_task_plan};
 pub use tool::{

--- a/crates/orbit-common/src/types/task_artifacts.rs
+++ b/crates/orbit-common/src/types/task_artifacts.rs
@@ -10,9 +10,13 @@ use crate::types::{
 };
 
 pub const TASK_ARTIFACT_SCHEMA_VERSION: u32 = 1;
+/// Historical task prefix retained for source compatibility. Task parsing is
+/// prefix-agnostic; new ids should be formatted with [`format_task_id`].
 pub const ORB_TASK_ID_PREFIX: &str = "ORB-";
+/// Minimum numeric width used when minting task ids. Parsers accept wider ids.
 pub const ORB_TASK_ID_WIDTH: usize = 5;
-pub const ORB_TASK_ID_MAX: u32 = 99_999;
+/// Maximum representable allocator value, no longer the five-digit boundary.
+pub const ORB_TASK_ID_MAX: u32 = u32::MAX;
 
 pub const TASK_ENVELOPE_FILE_NAME: &str = "task.yaml";
 pub const TASK_DESCRIPTION_FILE_NAME: &str = "description.md";
@@ -26,10 +30,30 @@ pub const TASK_ARTIFACT_MANIFEST_FILE_NAME: &str = "manifest.yaml";
 pub const TASK_ARTIFACT_FILES_DIR_NAME: &str = "files";
 
 pub fn is_valid_orb_task_id(id: &str) -> bool {
-    let Some(suffix) = id.strip_prefix(ORB_TASK_ID_PREFIX) else {
+    let Some((prefix, suffix)) = id.split_once('-') else {
         return false;
     };
-    suffix.len() == ORB_TASK_ID_WIDTH && suffix.chars().all(|character| character.is_ascii_digit())
+    is_valid_task_id_prefix(prefix)
+        && !suffix.is_empty()
+        && suffix.chars().all(|character| character.is_ascii_digit())
+}
+
+/// Validate a stored task-id prefix. `ORB` remains valid for migrated hosts;
+/// other artifact namespaces cannot be interpreted as tasks.
+pub fn is_valid_task_id_prefix(prefix: &str) -> bool {
+    (2..=5).contains(&prefix.len())
+        && prefix.bytes().all(|byte| byte.is_ascii_uppercase())
+        && !matches!(prefix, "ADR" | "L" | "F")
+}
+
+pub fn task_id_prefix(id: &str) -> Option<&str> {
+    is_valid_orb_task_id(id).then(|| id.split_once('-').map(|(prefix, _)| prefix))?
+}
+
+pub fn parse_task_number(id: &str) -> Option<u32> {
+    is_valid_orb_task_id(id)
+        .then(|| id.split_once('-').map(|(_, suffix)| suffix))?
+        .and_then(|suffix| suffix.parse().ok())
 }
 
 pub fn validate_orb_task_id(id: &str) -> Result<(), OrbitError> {
@@ -37,17 +61,21 @@ pub fn validate_orb_task_id(id: &str) -> Result<(), OrbitError> {
         return Ok(());
     }
     Err(OrbitError::InvalidInput(format!(
-        "task id '{id}' must match ORB-00000"
+        "task id '{id}' must match <2-5 uppercase-letter prefix>-<digits>"
     )))
 }
 
 pub fn format_orb_task_id(value: u32) -> Result<String, OrbitError> {
-    if value > ORB_TASK_ID_MAX {
+    format_task_id("ORB", value)
+}
+
+pub fn format_task_id(prefix: &str, value: u32) -> Result<String, OrbitError> {
+    if !is_valid_task_id_prefix(prefix) {
         return Err(OrbitError::InvalidInput(format!(
-            "task id value {value} exceeds maximum {ORB_TASK_ID_MAX}"
+            "task id prefix '{prefix}' must be 2-5 uppercase ASCII letters and must not use a reserved artifact namespace"
         )));
     }
-    Ok(format!("{ORB_TASK_ID_PREFIX}{value:0ORB_TASK_ID_WIDTH$}"))
+    Ok(format!("{prefix}-{value:0ORB_TASK_ID_WIDTH$}"))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/orbit-common/src/types/tests/task_artifacts.rs
+++ b/crates/orbit-common/src/types/tests/task_artifacts.rs
@@ -172,15 +172,22 @@ mod ids {
     use super::super::super::task_artifacts::*;
 
     #[test]
-    fn validates_and_formats_orb_task_ids() {
+    fn validates_and_formats_prefix_and_width_agnostic_task_ids() {
         assert!(is_valid_orb_task_id("ORB-00000"));
         assert!(is_valid_orb_task_id("ORB-99999"));
-        assert!(!is_valid_orb_task_id("ORB-100000"));
+        assert!(is_valid_orb_task_id("ORB-100000"));
+        assert!(is_valid_orb_task_id("DE-7"));
+        assert!(is_valid_orb_task_id("ALPHA-123456789"));
         assert!(!is_valid_orb_task_id("orb-00001"));
+        assert!(!is_valid_orb_task_id("A-00001"));
+        assert!(!is_valid_orb_task_id("ADR-0001"));
         assert_eq!(format_orb_task_id(42).unwrap(), "ORB-00042");
-        assert!(format_orb_task_id(100_000).is_err());
+        assert_eq!(format_orb_task_id(100_000).unwrap(), "ORB-100000");
+        assert_eq!(format_task_id("DE", 42).unwrap(), "DE-00042");
+        assert_eq!(task_id_prefix("DE-00042"), Some("DE"));
+        assert_eq!(parse_task_number("ORB-100000"), Some(100_000));
         assert!(validate_orb_task_id("ORB-12345").is_ok());
-        assert!(validate_orb_task_id("ORB-1234").is_err());
+        assert!(validate_orb_task_id("ORB-1234").is_ok());
     }
 }
 

--- a/crates/orbit-core/src/command/docs/artifact_ref.rs
+++ b/crates/orbit-core/src/command/docs/artifact_ref.rs
@@ -1,3 +1,4 @@
+use orbit_common::types::is_valid_orb_task_id;
 use serde::Deserialize;
 
 use super::types::ArtifactRef;
@@ -17,14 +18,12 @@ pub(super) fn parse_artifact_ref(raw: &str) -> Result<ArtifactRef, String> {
         return Ok(ArtifactRef::Adr(trimmed.to_string()));
     }
     Err(format!(
-        "unknown related_artifacts reference `{trimmed}`; expected ORB-NNNNN, L-NNNN, FYYYY-MM-NNN, or ADR-NNNN"
+        "unknown related_artifacts reference `{trimmed}`; expected PREFIX-NNNNN, L-NNNN, FYYYY-MM-NNN, or ADR-NNNN"
     ))
 }
 
 pub(super) fn is_task_ref(value: &str) -> bool {
-    value.len() == 9
-        && value.starts_with("ORB-")
-        && value[4..].chars().all(|ch| ch.is_ascii_digit())
+    is_valid_orb_task_id(value)
 }
 
 pub(super) fn is_learning_ref(value: &str) -> bool {

--- a/crates/orbit-core/src/command/docs/tests/artifact_ref.rs
+++ b/crates/orbit-core/src/command/docs/tests/artifact_ref.rs
@@ -1,2 +1,16 @@
-// No dedicated unit tests for artifact_ref parsing; exercised transitively through
-// frontmatter and docs command paths (ORB-00250).
+use super::super::artifact_ref::{is_task_ref, parse_artifact_ref};
+use super::super::types::ArtifactRef;
+
+#[test]
+fn task_related_artifacts_accept_legacy_and_partitioned_ids() {
+    assert_eq!(
+        parse_artifact_ref("ORB-00042").expect("legacy task id"),
+        ArtifactRef::Task("ORB-00042".to_string())
+    );
+    assert_eq!(
+        parse_artifact_ref("DE-100000").expect("partitioned wide task id"),
+        ArtifactRef::Task("DE-100000".to_string())
+    );
+    assert!(is_task_ref("ORB-7"));
+    assert!(!is_task_ref("ADR-0001"));
+}

--- a/crates/orbit-core/src/command/skill.rs
+++ b/crates/orbit-core/src/command/skill.rs
@@ -481,7 +481,7 @@ mod tests {
     /// that would become dangling references in a consumer workspace. Placeholder
     /// forms (`ORB-NNNN`, `L-NNNN`, `ADR-NNNN`, `<task-id>`) use non-digit
     /// stand-ins and are intentionally *not* matched.
-    fn find_artifact_ids(content: &str) -> Vec<String> {
+    fn find_artifact_ids(content: &str, task_prefixes: &BTreeSet<String>) -> Vec<String> {
         let b = content.as_bytes();
         let n = b.len();
         let boundary = |i: usize| i == 0 || !b[i - 1].is_ascii_alphanumeric();
@@ -499,11 +499,20 @@ mod tests {
         let mut i = 0;
         while i < n {
             if boundary(i) {
-                // ORB-<digit...> (task ids). ORB-NNNN / ORB-NNNNN placeholders
-                // have a non-digit after the dash and are skipped.
-                if starts(i, b"ORB-") && is_digit(i + 4) {
-                    let d = digit_run(i + 4);
-                    out.push(String::from_utf8_lossy(&b[i..i + 4 + d]).into_owned());
+                // <registered-prefix>-<digit...> (task ids). Prefixes that only
+                // look task-shaped are deliberately ignored: accepting every
+                // uppercase token is too weak against ordinary prose.
+                for prefix in task_prefixes {
+                    let prefix_bytes = prefix.as_bytes();
+                    let dash = i + prefix_bytes.len();
+                    let digits = dash + 1;
+                    if starts(i, prefix_bytes) && dash < n && b[dash] == b'-' && is_digit(digits) {
+                        let d = digit_run(digits);
+                        let end = digits + d;
+                        if end == n || !b[end].is_ascii_alphanumeric() {
+                            out.push(String::from_utf8_lossy(&b[i..end]).into_owned());
+                        }
+                    }
                 }
                 // ADR-<digit...> (decision-record ids). ADR ids are allocated
                 // per workspace, so a concrete one resolves to a different
@@ -575,7 +584,10 @@ mod tests {
     const PRIVATE_PERSONAL_NAMES: &[&str] = &["Daniel"];
 
     /// Every reason `content` is not repository-agnostic. Empty == portable.
-    fn portability_violations(content: &str) -> Vec<String> {
+    fn portability_violations_with_task_prefixes(
+        content: &str,
+        task_prefixes: &BTreeSet<String>,
+    ) -> Vec<String> {
         let mut hits = Vec::new();
 
         // Unguarded Orbit source paths (crate tree only exists in a source clone).
@@ -618,11 +630,33 @@ mod tests {
         }
 
         // Workspace-local artifact IDs.
-        for id in find_artifact_ids(content) {
+        for id in find_artifact_ids(content, task_prefixes) {
             hits.push(format!("workspace-local artifact id `{id}`"));
         }
 
         hits
+    }
+
+    fn portability_violations(content: &str) -> Vec<String> {
+        portability_violations_with_task_prefixes(content, &BTreeSet::from(["ORB".to_string()]))
+    }
+
+    #[test]
+    fn task_id_scanner_matches_only_prefixes_known_to_the_local_registry() {
+        let root = tempfile::tempdir().expect("registry root");
+        let registry = orbit_store::sqlite::task_registry::TaskRegistryStore::open(
+            &orbit_store::sqlite::task_registry::task_registry_path(root.path()),
+        )
+        .expect("open task registry");
+        registry
+            .set_task_prefix("DE")
+            .expect("register task prefix");
+        let prefixes = registry.known_task_prefixes().expect("known task prefixes");
+
+        assert_eq!(
+            find_artifact_ids("known DE-100000 but unknown XY-12345", &prefixes),
+            vec!["DE-100000"]
+        );
     }
 
     #[test]

--- a/crates/orbit-core/src/config/registry.rs
+++ b/crates/orbit-core/src/config/registry.rs
@@ -11,9 +11,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
-use orbit_common::types::{
-    Crew, CrewAssignment, ORB_TASK_ID_MAX, OrbitError, activity_job::Provider, resolve_crew,
-};
+use orbit_common::types::{Crew, CrewAssignment, OrbitError, activity_job::Provider, resolve_crew};
 use orbit_common::utility::log_rotation::LogRotationConfig;
 use orbit_common::utility::redaction::redact_home_dir;
 use serde::de::DeserializeOwned;
@@ -159,8 +157,8 @@ define_config_settings! {
     },
     tasks_id_start: Option<u32> => u32 {
         key: "tasks.id_start", value_type: "integer",
-        description: "Floor for the local task-id allocator on this machine (forward-only; lets machines hold disjoint id ranges). Capped by ORB_TASK_ID_MAX.",
-        resolve: |raw: Option<u32>| resolve_tasks_id_start(raw),
+        description: "Floor for the local task-id allocator on this machine (forward-only; lets machines hold disjoint id ranges).",
+        resolve: |raw: Option<u32>| Ok::<_, OrbitError>(raw),
     },
     workflow_auto_ship: bool => bool {
         key: "workflow.auto_ship", value_type: "bool",
@@ -315,16 +313,6 @@ fn resolve_optional_non_empty(
         }
     })
     .transpose()
-}
-
-fn resolve_tasks_id_start(raw: Option<u32>) -> Result<Option<u32>, OrbitError> {
-    if raw.is_some_and(|start| start > ORB_TASK_ID_MAX) {
-        return Err(OrbitError::InvalidInput(format!(
-            "tasks.id_start {} exceeds maximum task id {ORB_TASK_ID_MAX}",
-            raw.unwrap_or_default()
-        )));
-    }
-    Ok(raw)
 }
 
 pub(super) fn resolve_default_crew(

--- a/crates/orbit-remote/src/mcp/host.rs
+++ b/crates/orbit-remote/src/mcp/host.rs
@@ -786,13 +786,15 @@ impl BrokerMcpHost {
             }
             let legacy_root = self.legacy_friction_root(&workspace_id, binding.as_ref());
             let task_partition_id = self.coordination_workspace_id(&workspace_id, binding.as_ref());
-            let result = HubCoordinationExecutor::new_with_task_partition(
-                &self.global_root,
-                workspace_id,
-                task_partition_id,
-                legacy_root,
-            )
-            .and_then(|executor| executor.execute_tool(name, input, context.clone()));
+            let result = crate::runtime::sync_task_prefix(&self.global_root).and_then(|()| {
+                HubCoordinationExecutor::new_with_task_partition(
+                    &self.global_root,
+                    workspace_id,
+                    task_partition_id,
+                    legacy_root,
+                )
+                .and_then(|executor| executor.execute_tool(name, input, context.clone()))
+            });
             self.record_coordination_outcome(name, &context, &result);
             return result;
         }

--- a/crates/orbit-remote/src/mcp/hub.rs
+++ b/crates/orbit-remote/src/mcp/hub.rs
@@ -37,6 +37,7 @@ pub(super) struct HubMcpHost {
 impl HubMcpHost {
     pub(super) fn new(global_root: PathBuf, capability: McpCapability) -> Result<Self, OrbitError> {
         let identity = load_host_identity(&global_root)?;
+        crate::runtime::sync_task_prefix(&global_root)?;
         if identity.mode != HostMode::Hub {
             return Err(OrbitError::InvalidInput(format!(
                 "orbit mcp serve --hub requires host.toml mode 'hub'; machine '{}' ({}) is '{}'",

--- a/crates/orbit-remote/src/runtime.rs
+++ b/crates/orbit-remote/src/runtime.rs
@@ -9,9 +9,10 @@ use orbit_core::runtime::{
     OrbitRuntimeRoots, ResolvedOrbitRoots, WorkspaceRootHint, WorkspaceRuntimeBinding,
 };
 use orbit_core::{OrbitRuntime, resolved_ship_mode};
+use orbit_store::sqlite::task_registry::{TaskRegistryStore, task_registry_path};
 use orbit_store::workspace_id_for_orbit_dir;
 
-use crate::workspace_registry;
+use crate::{HOST_TOML_FILE, load_host_identity, workspace_registry};
 
 /// Remote workspace metadata keeps the logical catalog ID distinct from the
 /// task/runtime ID stored in `.orbit/config.yaml`.
@@ -87,11 +88,13 @@ impl RemoteRuntimeFactory {
     ) -> Result<OrbitRuntime, OrbitError> {
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
         let roots = Self::resolve_roots_for_cwd(&cwd, root_override)?;
+        sync_task_prefix(&roots.global_root)?;
         let binding = binding_for_roots(&roots)?;
         OrbitRuntime::initialize_from_resolved_roots(roots, binding)
     }
 
     pub fn open_resolved_roots(roots: OrbitRuntimeRoots) -> Result<OrbitRuntime, OrbitError> {
+        sync_task_prefix(&roots.global_root)?;
         let binding = binding_for_roots(&roots)?;
         match binding {
             Some(binding) => OrbitRuntime::from_resolved_roots_with_binding(
@@ -113,6 +116,7 @@ impl RemoteRuntimeFactory {
         workspace: &Workspace,
         checkout: &WorkspaceCheckout,
     ) -> Result<OrbitRuntime, OrbitError> {
+        sync_task_prefix(global_root)?;
         let binding = workspace_runtime_binding(workspace, checkout)?;
         OrbitRuntime::from_roots_with_binding(global_root, &checkout.orbit_dir, binding)
     }
@@ -123,6 +127,7 @@ impl RemoteRuntimeFactory {
         local_root: &Path,
         binding: WorkspaceRuntimeBinding,
     ) -> Result<OrbitRuntime, OrbitError> {
+        sync_task_prefix(global_root)?;
         OrbitRuntime::from_resolved_roots_with_binding(
             global_root,
             shared_root,
@@ -130,6 +135,18 @@ impl RemoteRuntimeFactory {
             binding,
         )
     }
+}
+
+/// Project the host-owned task namespace into the neutral task allocator.
+/// Custom/legacy roots without host.toml retain the historical ORB default;
+/// once an identity exists, malformed or conflicting state fails closed.
+pub(crate) fn sync_task_prefix(global_root: &Path) -> Result<(), OrbitError> {
+    if !global_root.join(HOST_TOML_FILE).is_file() {
+        return Ok(());
+    }
+    let identity = load_host_identity(global_root)?;
+    let registry = TaskRegistryStore::open(&task_registry_path(global_root))?;
+    registry.set_task_prefix(&identity.task_prefix)
 }
 
 fn workspace_root_hint(cwd: &Path) -> Option<WorkspaceRootHint> {

--- a/crates/orbit-remote/src/tests/runtime.rs
+++ b/crates/orbit-remote/src/tests/runtime.rs
@@ -84,3 +84,44 @@ fn registered_checkout_opens_a_bound_runtime() {
         })
     ));
 }
+
+#[test]
+fn registered_checkout_task_creation_uses_host_task_prefix() {
+    let root = tempfile::tempdir().expect("root");
+    let global = root.path().join("global");
+    let repo = root.path().join("repo");
+    let orbit_dir = repo.join(".orbit");
+    std::fs::create_dir_all(&global).expect("global");
+    std::fs::create_dir_all(&orbit_dir).expect("orbit dir");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_runtime_test\"\nhost_id = \"runtime-test\"\ntask_prefix = \"DE\"\n",
+    )
+    .expect("host identity");
+    write_workspace_config(
+        &orbit_dir,
+        &WorkspaceConfig {
+            schema_version: 1,
+            workspace_id: "ws_prefixed_runtime".to_string(),
+        },
+    )
+    .expect("workspace config");
+    let workspace = workspace("logical-prefixed", "local");
+    let checkout = WorkspaceCheckout::owner(workspace.id.clone(), repo, orbit_dir);
+    let runtime = RemoteRuntimeFactory::open_registered_checkout(&global, &workspace, &checkout)
+        .expect("bound runtime");
+
+    let task = runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Prefix-aware task",
+                "description": "Mint through the normal task creation surface.",
+                "workspace": "."
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task creation");
+    assert_eq!(task["id"], "DE-00000");
+}

--- a/crates/orbit-store/src/sqlite/task_registry/mod.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/mod.rs
@@ -20,7 +20,7 @@ mod workspace_config;
 mod workspace_id;
 
 const CONFIG_SCHEMA_VERSION: u32 = 1;
-const REGISTRY_SCHEMA_VERSION: u32 = 4;
+const REGISTRY_SCHEMA_VERSION: u32 = 5;
 
 pub use store::TaskRegistryStore;
 pub(crate) use store::parse_orb_task_number;

--- a/crates/orbit-store/src/sqlite/task_registry/schema.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/schema.rs
@@ -6,11 +6,13 @@ use super::util::now_string;
 
 pub(super) fn apply_schema(conn: &Connection) -> Result<(), OrbitError> {
     migrate_path_coupled_workspace_bindings(conn)?;
+    migrate_allocator_state_v5(conn)?;
     conn.execute_batch(
         "
         CREATE TABLE IF NOT EXISTS allocator_state (
             authority TEXT PRIMARY KEY,
-            next_number INTEGER NOT NULL CHECK(next_number >= 0 AND next_number <= 100000),
+            next_number INTEGER NOT NULL CHECK(next_number >= 0),
+            task_prefix TEXT NOT NULL,
             updated_at TEXT NOT NULL
         );
 
@@ -116,14 +118,42 @@ pub(super) fn apply_schema(conn: &Connection) -> Result<(), OrbitError> {
     .map_err(|e| OrbitError::Store(e.to_string()))?;
 
     conn.execute(
-        "INSERT OR IGNORE INTO allocator_state(authority, next_number, updated_at)
-         VALUES ('local', 0, ?1)",
+        "INSERT OR IGNORE INTO allocator_state(authority, next_number, task_prefix, updated_at)
+         VALUES ('local', 0, 'ORB', ?1)",
         [now_string()],
     )
     .map_err(|e| OrbitError::Store(e.to_string()))?;
     conn.pragma_update(None, "user_version", i64::from(REGISTRY_SCHEMA_VERSION))
         .map_err(|e| OrbitError::Store(format!("failed to set registry user_version: {e}")))?;
     Ok(())
+}
+
+/// Schema v5 stores the machine's immutable minting prefix alongside its one
+/// monotonic allocator and removes the obsolete five-digit ceiling.
+fn migrate_allocator_state_v5(conn: &Connection) -> Result<(), OrbitError> {
+    if !table_has_column(conn, "allocator_state", "next_number")?
+        || table_has_column(conn, "allocator_state", "task_prefix")?
+    {
+        return Ok(());
+    }
+
+    conn.execute_batch(
+        "
+        BEGIN IMMEDIATE;
+        CREATE TABLE allocator_state_v5 (
+            authority TEXT PRIMARY KEY,
+            next_number INTEGER NOT NULL CHECK(next_number >= 0),
+            task_prefix TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        INSERT INTO allocator_state_v5(authority, next_number, task_prefix, updated_at)
+        SELECT authority, next_number, 'ORB', updated_at FROM allocator_state;
+        DROP TABLE allocator_state;
+        ALTER TABLE allocator_state_v5 RENAME TO allocator_state;
+        COMMIT;
+        ",
+    )
+    .map_err(|error| OrbitError::Store(format!("migrate task allocator to v5: {error}")))
 }
 
 /// Schema v4 splits stable coordination identity from machine-local checkout

--- a/crates/orbit-store/src/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/store.rs
@@ -5,10 +5,11 @@ use std::sync::{Arc, Mutex};
 
 use orbit_common::types::{
     NotFoundKind, ORB_TASK_ID_MAX, OrbitError, TaskEnvelopeV2, TaskRelation, TaskRelationEdge,
-    TaskRelationType, TaskStatus, format_orb_task_id, is_valid_orb_task_id, normalize_task_tags,
-    validate_orb_task_id, validate_task_relations_for_source,
+    TaskRelationType, TaskStatus, format_task_id, is_valid_orb_task_id, is_valid_task_id_prefix,
+    normalize_task_tags, parse_task_number, task_id_prefix, validate_orb_task_id,
+    validate_task_relations_for_source,
 };
-use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params, params_from_iter};
+use rusqlite::{Connection, TransactionBehavior, params, params_from_iter};
 
 use super::projection::create_projection_symlink;
 use super::queries::{
@@ -235,11 +236,11 @@ impl TaskRegistryStore {
             return Err(OrbitError::not_found(NotFoundKind::Workspace, workspace_id));
         }
 
-        let next: i64 = tx
+        let (next, task_prefix): (i64, String) = tx
             .query_row(
-                "SELECT next_number FROM allocator_state WHERE authority = 'local'",
+                "SELECT next_number, task_prefix FROM allocator_state WHERE authority = 'local'",
                 [],
-                |row| row.get(0),
+                |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .map_err(|e| OrbitError::Store(e.to_string()))?;
         if next > i64::from(ORB_TASK_ID_MAX) {
@@ -253,7 +254,82 @@ impl TaskRegistryStore {
         tx.commit().map_err(|e| OrbitError::Store(e.to_string()))?;
 
         let next = u32::try_from(next).map_err(|e| OrbitError::Store(e.to_string()))?;
-        format_orb_task_id(next)
+        format_task_id(&task_prefix, next)
+    }
+
+    /// Bind the allocator to the immutable prefix from this machine's host
+    /// identity. A pristine legacy-default row may adopt the configured prefix;
+    /// an allocator that has minted anything cannot be renamed.
+    pub fn set_task_prefix(&self, task_prefix: &str) -> Result<(), OrbitError> {
+        if !is_valid_task_id_prefix(task_prefix) {
+            return Err(OrbitError::InvalidInput(format!(
+                "task prefix '{task_prefix}' must be 2-5 uppercase ASCII letters and must not use a reserved artifact namespace"
+            )));
+        }
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let (current, next): (String, i64) = tx
+            .query_row(
+                "SELECT task_prefix, next_number FROM allocator_state WHERE authority = 'local'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        if current == task_prefix {
+            tx.commit().map_err(|e| OrbitError::Store(e.to_string()))?;
+            return Ok(());
+        }
+        let task_count: i64 = tx
+            .query_row("SELECT COUNT(*) FROM task_bundle_bindings", [], |row| {
+                row.get(0)
+            })
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        if current != "ORB" || next != 0 || task_count != 0 {
+            return Err(OrbitError::InvalidInput(format!(
+                "task prefix is immutable after allocation begins (registry uses '{current}', host identity requests '{task_prefix}')"
+            )));
+        }
+        tx.execute(
+            "UPDATE allocator_state SET task_prefix = ?1, updated_at = ?2 WHERE authority = 'local'",
+            params![task_prefix, now_string()],
+        )
+        .map_err(|e| OrbitError::Store(e.to_string()))?;
+        tx.commit().map_err(|e| OrbitError::Store(e.to_string()))
+    }
+
+    /// Prefixes recognized by the local registry: the active minting prefix
+    /// plus every prefix already present in registered task bundles.
+    pub fn known_task_prefixes(&self) -> Result<BTreeSet<String>, OrbitError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+        let active: String = conn
+            .query_row(
+                "SELECT task_prefix FROM allocator_state WHERE authority = 'local'",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let mut prefixes = BTreeSet::from([active]);
+        let mut statement = conn
+            .prepare("SELECT task_id FROM task_bundle_bindings")
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let ids = statement
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        for id in ids {
+            let id = id.map_err(|e| OrbitError::Store(e.to_string()))?;
+            if let Some(prefix) = task_id_prefix(&id) {
+                prefixes.insert(prefix.to_string());
+            }
+        }
+        Ok(prefixes)
     }
 
     pub fn canonical_task_bundle_path(
@@ -987,30 +1063,28 @@ impl TaskRegistryStore {
             .conn
             .lock()
             .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
-        let raw: Option<String> = conn
-            .query_row(
-                "SELECT task_id FROM task_bundle_bindings
-                 ORDER BY task_id DESC LIMIT 1",
-                [],
-                |row| row.get(0),
-            )
-            .optional()
+        let mut statement = conn
+            .prepare("SELECT task_id FROM task_bundle_bindings")
             .map_err(|e| OrbitError::Store(e.to_string()))?;
-        Ok(raw.as_deref().and_then(parse_orb_task_number))
+        let ids = statement
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let mut max = None;
+        for id in ids {
+            let id = id.map_err(|e| OrbitError::Store(e.to_string()))?;
+            if let Some(number) = parse_orb_task_number(&id) {
+                max = Some(max.map_or(number, |current: u32| current.max(number)));
+            }
+        }
+        Ok(max)
     }
 
     /// Seed the allocator so the next allocated id is `start`.
     ///
     /// Only ever moves the counter *forward*: if `start` is below the current
     /// `next_number` the call is refused, so two machines can be handed disjoint
-    /// id ranges without risk of silently rewinding a live counter. `start` must
-    /// not exceed [`ORB_TASK_ID_MAX`].
+    /// id ranges without risk of silently rewinding a live counter.
     pub fn seed_allocator_start(&self, start: u32) -> Result<AllocatorSeedOutcome, OrbitError> {
-        if start > ORB_TASK_ID_MAX {
-            return Err(OrbitError::InvalidInput(format!(
-                "tasks.id_start {start} exceeds maximum task id {ORB_TASK_ID_MAX}"
-            )));
-        }
         let mut conn = self
             .conn
             .lock()
@@ -1037,12 +1111,10 @@ impl TaskRegistryStore {
     }
 
     /// Ensure the allocator will not hand out any id `< min_next`. Never lowers
-    /// the counter. Values above the exhausted ceiling saturate at
-    /// `ORB_TASK_ID_MAX + 1`. Used after import/reindex to move `next_number`
-    /// past the highest landed id.
+    /// the counter. Used after import/reindex to move `next_number` past the
+    /// highest landed id.
     pub fn bump_allocator_to_at_least(&self, min_next: u32) -> Result<(), OrbitError> {
-        let ceiling = ORB_TASK_ID_MAX + 1;
-        let target = min_next.min(ceiling);
+        let target = min_next;
         let mut conn = self
             .conn
             .lock()
@@ -1165,10 +1237,7 @@ fn task_relation_edges(envelope: &TaskEnvelopeV2) -> Vec<TaskRelationEdge> {
         .collect()
 }
 
-/// Parse the numeric suffix of a canonical `ORB-00000` task id.
+/// Parse the numeric suffix of any canonical task id.
 pub(crate) fn parse_orb_task_number(task_id: &str) -> Option<u32> {
-    task_id
-        .strip_prefix("ORB-")
-        .filter(|suffix| suffix.len() == 5 && suffix.bytes().all(|b| b.is_ascii_digit()))
-        .and_then(|suffix| suffix.parse::<u32>().ok())
+    parse_task_number(task_id)
 }

--- a/crates/orbit-store/src/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/tests/mod.rs
@@ -139,6 +139,26 @@ fn allocator_returns_monotonic_orb_ids() {
 }
 
 #[test]
+fn allocator_uses_host_prefix_and_expands_past_five_digits() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    store.set_task_prefix("DE").expect("set host prefix");
+    store
+        .seed_allocator_start(99_999)
+        .expect("seed near width boundary");
+    let workspace = bind(&store, temp.path());
+
+    assert_eq!(
+        store.allocate_task_id(&workspace.workspace_id).expect("id"),
+        "DE-99999"
+    );
+    assert_eq!(
+        store.allocate_task_id(&workspace.workspace_id).expect("id"),
+        "DE-100000"
+    );
+}
+
+#[test]
 fn open_creates_registry_parent_and_workspaces_dir() {
     let temp = TempDir::new().expect("tempdir");
     let path = registry_path(&temp);
@@ -335,6 +355,12 @@ fn open_migrates_path_coupled_registry_once_without_changing_coordination_state(
     assert_eq!(statuses.get("ORB-00041"), Some(&TaskStatus::Done));
     assert_eq!(migrated.allocator_next_number().expect("allocator"), 42);
     assert_eq!(
+        migrated
+            .allocate_task_id("legacy-workspace-aaaaaa")
+            .expect("continue migrated allocator"),
+        "ORB-00042"
+    );
+    assert_eq!(
         fs::read_to_string(canonical_path.join("payload.sentinel")).expect("read payload"),
         "preserve-me"
     );
@@ -376,7 +402,7 @@ fn open_migrates_path_coupled_registry_once_without_changing_coordination_state(
             .expect("status projection"),
         statuses
     );
-    assert_eq!(reopened.allocator_next_number().expect("allocator"), 42);
+    assert_eq!(reopened.allocator_next_number().expect("allocator"), 43);
 }
 
 #[test]
@@ -1374,16 +1400,6 @@ fn seed_allocator_start_refuses_to_lower() {
         .expect_err("must refuse lowering");
     assert!(matches!(err, OrbitError::InvalidInput(_)));
     assert_eq!(store.allocator_next_number().expect("read"), 5_000);
-}
-
-#[test]
-fn seed_allocator_start_rejects_above_max() {
-    let temp = TempDir::new().expect("tempdir");
-    let store = store(&temp);
-    let err = store
-        .seed_allocator_start(ORB_TASK_ID_MAX + 1)
-        .expect_err("must reject above max");
-    assert!(matches!(err, OrbitError::InvalidInput(_)));
 }
 
 #[test]

--- a/docs/design/host-registry/4_decisions.md
+++ b/docs/design/host-registry/4_decisions.md
@@ -1,8 +1,8 @@
 ---
 title: Host Registry — Decisions
 owner: claude
-last_updated: 2026-08-10
-last_validated: 2026-08-10
+last_updated: 2026-08-11
+last_validated: 2026-08-11
 status: Draft
 feature: host-registry
 doc_role: decisions
@@ -11,7 +11,7 @@ summary: Decision record for host identity, per-machine coordination, prefix-par
 tags: [host-registry, mcp-bridge, multi-host, ownership]
 paths: ["crates/orbit-remote/**", "crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**"]
 related_features: [host-registry, mcp-bridge]
-related_artifacts: [ORB-00424, ORB-10245, ORB-10248, ORB-10249, ORB-10255, ORB-10257, ORB-10267, ORB-10258, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ORB-10330, ORB-10332, ORB-10709, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240, ADR-0352, ADR-0355, ADR-0356, ADR-0357, ADR-0358]
+related_artifacts: [ORB-00424, ORB-10245, ORB-10248, ORB-10249, ORB-10255, ORB-10257, ORB-10267, ORB-10258, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ORB-10330, ORB-10332, ORB-10709, ORB-10723, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240, ADR-0352, ADR-0355, ADR-0356, ADR-0357, ADR-0358]
 ---
 
 # Host Registry — Decisions
@@ -410,7 +410,7 @@ rather than removed.
 
 ## ADR-0356 — Machine-scoped task-id prefix instead of a global allocator
 
-**Status:** Accepted · 2026-08
+**Status:** Accepted · 2026-08 · [ORB-10723] implemented prefix- and width-agnostic parsing, host-prefix minting, and registry-constrained text scanning.
 **Scope:** task ID minting, ID parsing, cross-machine references
 **Code anchors:** `crates/orbit-common/src/types/task_artifacts.rs`, `crates/orbit-store/src/sqlite/task_registry/store.rs::parse_orb_task_number`, `crates/orbit-core/src/command/docs/artifact_ref.rs`
 
@@ -543,6 +543,9 @@ would leave a silent, unrecoverable ID collision.
 - [ORB-10245] — accepted the coupled contract and recorded this ADR set.
 - [ORB-10709] — shipped the exclusive TTL'd workspace claim and gated workflow
   dispatch on it at the shared run-submission path (ADR-0352).
+- [ORB-10723] — implemented ADR-0356: task parsing accepts registered machine
+  prefixes and wider numeric suffixes, while allocation retains one monotonic
+  machine sequence and formats it with the immutable host prefix.
 - [ORB-10248] — implemented the versioned logical-workspace/local-checkout split.
 - [ORB-10249] — implemented path-free task coordination and global task-relation/readiness lookup.
 - [ORB-10255] — implemented ADR-0227's append-only SQLite host/alias core with


### PR DESCRIPTION
## Task

[ORB-10723](https://orbit-cli.com/tasks/ORB-10723) — Prefix- and width-agnostic task IDs; allocator mints <task_prefix>-NNNNN (ADR-0356)

### Description

## Problem
Task-ID minting and parsing hardcode the `ORB` prefix and a fixed width. Under ADR-0356 each machine mints `<task_prefix>-NNNNN` against its own monotonic sequence, so parsing must become prefix- and width-agnostic. Design: `docs/design/host-registry/2_design.md` §1 and §3 ("Task IDs stay globally unique, by partition rather than by allocator").

## Why It Matters
This is the mechanism that buys global uniqueness with no allocator, no reconciliation, and no machine that must be reachable to file a task; it also makes divergent-ownership repair a union.

## Constraints / Notes
- Declaration site is `ORB_TASK_ID_PREFIX` / `ORB_TASK_ID_WIDTH` in `crates/orbit-common/src/types/task_artifacts.rs`; the design names `is_valid_orb_task_id`, `parse_orb_task_number` (task_registry store), the `artifact_ref.rs` predicates, and the byte-scanner in `crates/orbit-core/src/command/skill.rs` as the sites that hardcode the constant today.
- The prose/text scanner must match only prefixes known to the local registry, never any `[A-Z]{2,5}-[0-9]+` shape — a loose pattern is too weak against prose (design §1).
- Existing `ORB-` IDs, citations, and stored records must parse and resolve unchanged; no migration touches an ID.
- Cross-machine chronology is destroyed by design: nothing may infer ordering from comparing IDs; `created_at` is the ordering key.
- Foreign-prefix relation-target handling is a separate dependent task — out of scope here.

### Acceptance Criteria

- With host task_prefix=DE, task creation mints DE-prefixed IDs from a monotonic per-machine sequence, verified by test; with the migrated ORB prefix the next minted ID continues the existing sequence
- Existing ORB-prefixed IDs in tasks, relations, and related_artifacts parse and resolve unchanged (regression tests over the named parse sites)
- A scanner test proves an ID-shaped token with a prefix absent from the local registry is not matched, and one with a registered prefix is
- cargo build succeeds and the tests this change adds/modifies pass under nextest; pre-existing unrelated failures are out of scope

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Generalized the legacy task-ID validation surface to accept valid 2–5-letter machine prefixes and arbitrary numeric widths while preserving ORB IDs; minting retains five-digit minimum padding and expands naturally past 99999.
- Migrated the task registry to schema v5, persisting one immutable machine task_prefix beside the existing monotonic sequence, removing the obsolete SQLite five-digit ceiling, preserving migrated ORB allocator continuity, and exposing registered prefixes for constrained scanners.
- Wired host.toml task_prefix projection into local runtime, hub, and checkoutless MCP task creation paths without adding a cross-crate dependency edge.
- Updated related_artifacts parsing and the shipped-asset byte scanner; the scanner now matches task tokens only for prefixes known to the local registry.
- Added regression coverage for ORB compatibility, DE-prefixed creation, six-digit expansion, allocator migration continuity, related artifacts, and registered-vs-unknown scanner prefixes. Updated ADR-0356 implementation provenance.
Assessment: The scoped implementation is complete and validated. Existing ORB tasks/relations/artifact references remain valid; allocation remains one forward-only per-machine sequence and no code infers chronology from ID ordering.

Validation:
- cargo build — passed.
- make ci-fast — passed.
- make ci-lint — passed (workspace/all-target clippy with warnings denied).
- Targeted nextest coverage passed for common ID parsing/formatting, store allocator and migration, docs related_artifacts parsing, registry-constrained scanner behavior, and Remote runtime DE-prefixed task creation.
- A broad four-package nextest run reached 369 passing tests before three unrelated existing orbit-remote MCP tests failed (broker_spoke_with_context_fails_closed_before_local_resolution, canonical_mcp_policy_conforms_to_frozen_v1_fixture, broker_spoke_hub_denial_writes_no_local_coordination_state); targeted changed-path tests all pass.

Deviations from original plan:
- Expanded context to the common export/tests, Core allocator config, Remote runtime/hub/broker composition, and ADR file because these are tightly coupled registration, validation, and documentation surfaces required to preserve the public API and route host identity into the neutral store. No new dependency edge was added.

Friction checkpoint: no qualifying tooling/workflow friction found.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10723-6a7aaa57`
- Behind base: 0
- Ahead of base: 1