### PR TITLE
Foreign-prefix relation targets: store unvalidated with marker; local misses stay hard errors (ADR-0356)

### DIFF
--- a/crates/orbit-cli/src/command/task/output.rs
+++ b/crates/orbit-cli/src/command/task/output.rs
@@ -3,7 +3,9 @@ use std::fmt::Write as _;
 
 use chrono::{DateTime, Utc};
 use orbit_common::types::{ArtifactManifestFileV2, TaskArtifact};
-use orbit_core::{OrbitError, OrbitRuntime, TaskStatus, resolve_task_dependencies};
+use orbit_core::{
+    OrbitError, OrbitRuntime, TaskStatus, resolve_task_dependencies, resolve_task_relations,
+};
 use serde_json::{Value, json};
 
 use crate::output::color::Domain;
@@ -52,7 +54,7 @@ pub(crate) fn task_to_json(
         "type": task.task_type.to_string(),
         "pr_status": task.pr_status,
         "external_refs": task.external_refs,
-        "relations": task.relations,
+        "relations": resolve_task_relations(task, status_by_id),
         "source_task_id": task.source_task_id(),
         "job_run_id": task.job_run_id,
         "crew": task.crew,

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -153,13 +153,14 @@ pub use spoke_registration::{
 };
 pub use task::{
     DEFAULT_TASK_LIST_LIMIT, DependencyDeadEnd, ExternalRef, GITHUB_PR_EXTERNAL_REF_SYSTEM,
-    NO_DIFF_EXPECTED_TAG, ResolvedTaskDependency, Task, TaskArtifact, TaskComment, TaskComplexity,
+    NO_DIFF_EXPECTED_TAG, ResolvedTaskDependency, ResolvedTaskRelation,
+    TASK_REFERENCE_NOT_VERIFIABLE_HERE, Task, TaskArtifact, TaskComment, TaskComplexity,
     TaskCreateStatus, TaskHistoryEntry, TaskPriority, TaskStatus, TaskType,
     UnsatisfiableTaskDependency, build_task_status_index, media_type_for_artifact_path,
     normalize_task_dependencies, normalize_task_tags, prune_missing_context_files,
-    push_external_ref_if_missing, resolve_task_dependencies, task_dependencies_ready,
-    task_matches_tags, unmet_task_dependencies, unsatisfiable_task_dependencies,
-    validate_task_dependencies,
+    push_external_ref_if_missing, resolve_task_dependencies, resolve_task_relations,
+    task_dependencies_ready, task_matches_tags, task_reference_is_not_verifiable_here,
+    unmet_task_dependencies, unsatisfiable_task_dependencies, validate_task_dependencies,
 };
 pub use task_artifacts::{
     ArtifactManifestFileV2, ArtifactManifestV2, ORB_TASK_ID_MAX, ORB_TASK_ID_PREFIX,

--- a/crates/orbit-common/src/types/task.rs
+++ b/crates/orbit-common/src/types/task.rs
@@ -42,13 +42,17 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::types::task_artifacts::{TaskRelation, TaskRelationType};
-use crate::types::{OrbitError, OrbitId};
+use crate::types::{OrbitError, OrbitId, is_valid_orb_task_id, task_id_prefix};
 use crate::utility::selector::exists_in_workspace;
 
 /// Tasks carrying this tag may complete successfully without producing a
 /// repository diff. Their durable side effects live outside git (for example,
 /// QA validation tasks file follow-up Orbit tasks).
 pub const NO_DIFF_EXPECTED_TAG: &str = "no-diff-expected";
+
+/// Operator-facing projection for a valid task reference whose prefix is not
+/// represented in this machine's coordination registry.
+pub const TASK_REFERENCE_NOT_VERIFIABLE_HERE: &str = "not verifiable here";
 
 /// Default maximum number of tasks a status-neutral task listing returns
 /// (ORB-10310). Every discovery surface — the `orbit task list` CLI, the
@@ -477,6 +481,21 @@ pub struct ResolvedTaskDependency {
     pub status: String,
 }
 
+/// Read projection of a typed relation. Persisted relations remain only the
+/// relation type and target; verification is derived from the local status
+/// projection so a foreign target can become locally verifiable later.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ResolvedTaskRelation {
+    /// Canonical typed edge kind.
+    #[serde(rename = "type")]
+    pub relation_type: TaskRelationType,
+    /// Referenced task or artifact ID.
+    pub target: OrbitId,
+    /// Local verification limitation, present only for a foreign task prefix.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification: Option<String>,
+}
+
 impl ResolvedTaskDependency {
     pub fn label(&self) -> String {
         format!("{} [{}]", self.id, self.status)
@@ -836,9 +855,61 @@ pub fn resolve_task_dependencies(
             status: status_by_id
                 .get(&dependency_id)
                 .map(|status| status.to_string())
-                .unwrap_or_else(|| "missing".to_string()),
+                .unwrap_or_else(|| {
+                    if task_reference_is_not_verifiable_here(task, &dependency_id, status_by_id) {
+                        TASK_REFERENCE_NOT_VERIFIABLE_HERE.to_string()
+                    } else {
+                        "missing".to_string()
+                    }
+                }),
         })
         .collect()
+}
+
+/// Project typed relations with a marker on unresolved foreign-prefix task
+/// targets. Resolvable and locally missing targets retain their stored shape.
+pub fn resolve_task_relations(
+    task: &Task,
+    status_by_id: &BTreeMap<OrbitId, TaskStatus>,
+) -> Vec<ResolvedTaskRelation> {
+    task.relations
+        .iter()
+        .map(|relation| ResolvedTaskRelation {
+            relation_type: relation.relation_type,
+            target: relation.target.clone(),
+            verification: task_reference_is_not_verifiable_here(
+                task,
+                &relation.target,
+                status_by_id,
+            )
+            .then(|| TASK_REFERENCE_NOT_VERIFIABLE_HERE.to_string()),
+        })
+        .collect()
+}
+
+/// Whether a missing valid task target belongs to a prefix this status
+/// projection cannot verify. The source prefix is always local for its task;
+/// prefixes on projected task IDs cover additional locally registered legacy
+/// or migrated partitions.
+pub fn task_reference_is_not_verifiable_here(
+    task: &Task,
+    target: &str,
+    status_by_id: &BTreeMap<OrbitId, TaskStatus>,
+) -> bool {
+    if status_by_id.contains_key(target) || !is_valid_orb_task_id(target) {
+        return false;
+    }
+    let Some(target_prefix) = task_id_prefix(target) else {
+        return false;
+    };
+    let mut known_prefixes = status_by_id
+        .keys()
+        .filter_map(|id| task_id_prefix(id))
+        .collect::<BTreeSet<_>>();
+    if let Some(source_prefix) = task_id_prefix(&task.id) {
+        known_prefixes.insert(source_prefix);
+    }
+    !known_prefixes.contains(target_prefix)
 }
 
 pub fn task_dependencies_ready(task: &Task, status_by_id: &BTreeMap<OrbitId, TaskStatus>) -> bool {
@@ -846,6 +917,7 @@ pub fn task_dependencies_ready(task: &Task, status_by_id: &BTreeMap<OrbitId, Tas
         status_by_id
             .get(dependency_id)
             .is_some_and(|status| status.satisfies_dependency())
+            || task_reference_is_not_verifiable_here(task, dependency_id, status_by_id)
     })
 }
 
@@ -856,9 +928,10 @@ pub fn unmet_task_dependencies(
     resolve_task_dependencies(task, status_by_id)
         .into_iter()
         .filter(|dependency| {
-            status_by_id
-                .get(&dependency.id)
-                .is_none_or(|status| !status.satisfies_dependency())
+            !task_reference_is_not_verifiable_here(task, &dependency.id, status_by_id)
+                && status_by_id
+                    .get(&dependency.id)
+                    .is_none_or(|status| !status.satisfies_dependency())
         })
         .collect()
 }
@@ -875,6 +948,9 @@ pub fn unsatisfiable_task_dependencies(
     task.dependencies()
         .into_iter()
         .filter_map(|dependency_id| {
+            if task_reference_is_not_verifiable_here(task, &dependency_id, status_by_id) {
+                return None;
+            }
             let (status, reason) = match status_by_id.get(&dependency_id) {
                 None => ("missing".to_string(), DependencyDeadEnd::Missing),
                 Some(status) => (status.to_string(), status.dependency_dead_end()?),

--- a/crates/orbit-common/src/types/tests/task.rs
+++ b/crates/orbit-common/src/types/tests/task.rs
@@ -236,7 +236,8 @@ updated_at: 2026-01-01T00:00:00Z
 
 mod dependency_satisfaction {
     use super::super::super::task::{
-        DependencyDeadEnd, Task, TaskStatus, unmet_task_dependencies,
+        DependencyDeadEnd, TASK_REFERENCE_NOT_VERIFIABLE_HERE, Task, TaskStatus,
+        resolve_task_dependencies, task_dependencies_ready, unmet_task_dependencies,
         unsatisfiable_task_dependencies,
     };
     use std::collections::BTreeMap;
@@ -364,6 +365,20 @@ relations:
         assert_eq!(unsatisfiable[0].dependency_id, "ORB-404");
         assert_eq!(unsatisfiable[0].status, "missing");
         assert_eq!(unsatisfiable[0].reason, DependencyDeadEnd::Missing);
+    }
+
+    #[test]
+    fn foreign_dependency_is_marked_ready_and_not_a_dead_end() {
+        let task = task_with_dependencies("ORB-2", &["DK-404"]);
+        let statuses = status_index(&[("ORB-2", TaskStatus::Backlog)]);
+
+        assert_eq!(
+            resolve_task_dependencies(&task, &statuses)[0].status,
+            TASK_REFERENCE_NOT_VERIFIABLE_HERE
+        );
+        assert!(task_dependencies_ready(&task, &statuses));
+        assert!(unmet_task_dependencies(&task, &statuses).is_empty());
+        assert!(unsatisfiable_task_dependencies(&task, &statuses).is_empty());
     }
 
     #[test]

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -85,7 +85,7 @@ pub use orbit_common::types::{
     LearningStatus, ProjectionFreshness, SanitizedExecutionProfile, SanitizedWorkspacePresence,
     StoredExecutionProfile, Task, TaskComplexity, TaskCreateStatus, TaskPriority, TaskStatus,
     TaskType, WorkspaceOwnership, WorkspacePresenceDeclaration, resolve_task_dependencies,
-    task_dependencies_ready,
+    resolve_task_relations, task_dependencies_ready,
 };
 pub use orbit_common::types::{MissedRunPolicy, NotFoundKind, OrbitError, OverlapPolicy};
 pub use orbit_common::utility::redaction::redact_sensitive_env_text;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/json.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/json.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use orbit_common::types::{
     Learning, OrbitError, Task, TaskArtifact, TaskComment, TaskHistoryEntry, TaskStatus,
-    resolve_task_dependencies,
+    resolve_task_dependencies, resolve_task_relations,
 };
 use serde_json::{Map, Value, json};
 
@@ -65,7 +65,7 @@ pub(super) fn task_to_json(task: &Task, status_by_id: &BTreeMap<String, TaskStat
         "type": task.task_type.to_string(),
         "pr_status": task.pr_status,
         "external_refs": task.external_refs,
-        "relations": task.relations,
+        "relations": resolve_task_relations(task, status_by_id),
         "source_task_id": task.source_task_id(),
         "job_run_id": task.job_run_id,
         "crew": task.crew,

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
@@ -666,6 +666,66 @@ fn task_show_tool_includes_empty_tags_array() {
 }
 
 #[test]
+fn foreign_task_references_are_marked_and_do_not_block_readiness() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let foreign_id = "DK-00042";
+    let created = runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Coordinate with a foreign task",
+                "description": "The target is owned by another machine.",
+                "workspace": ".",
+                "relations": [
+                    {"type": "blocked_by", "target": foreign_id},
+                    {"type": "related_to", "target": foreign_id}
+                ],
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("foreign-prefix task references are accepted");
+    let task_id = created["id"].as_str().expect("created task id");
+
+    let shown = runtime
+        .execute_tool_command(
+            "orbit.task.show",
+            json!({"id": task_id}),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("show foreign-prefix task");
+    assert_eq!(
+        shown["resolved_dependencies"],
+        json!(["DK-00042 [not verifiable here]"])
+    );
+    let related_to = shown["relations"]
+        .as_array()
+        .expect("relations array")
+        .iter()
+        .find(|relation| relation["type"] == "related_to")
+        .expect("related_to relation");
+    assert_eq!(related_to["verification"], json!("not verifiable here"));
+
+    let ready = runtime
+        .execute_tool_command(
+            "orbit.task.list",
+            json!({"ready": true}),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("list ready tasks");
+    assert!(
+        ready
+            .as_array()
+            .expect("ready task array")
+            .iter()
+            .any(|task| task["id"] == task_id),
+        "foreign dependencies do not gate readiness"
+    );
+}
+
+#[test]
 fn task_show_tool_with_context_includes_related_docs() {
     let (_root, runtime, repo_root) = test_runtime();
     fs::create_dir_all(repo_root.join("docs")).expect("docs dir");

--- a/crates/orbit-dashboard/src/projections.rs
+++ b/crates/orbit-dashboard/src/projections.rs
@@ -199,7 +199,7 @@ pub(crate) fn task_to_json(task: &Task, status_by_id: &BTreeMap<String, TaskStat
         "type": task.task_type.to_string(),
         "pr_status": task.pr_status,
         "external_refs": task.external_refs,
-        "relations": task.relations,
+        "relations": orbit_common::types::resolve_task_relations(task, status_by_id),
         "source_task_id": task.source_task_id(),
         "job_run_id": task.job_run_id,
         "crew": task.crew,

--- a/crates/orbit-store/src/backend/factory/tests/factory.rs
+++ b/crates/orbit-store/src/backend/factory/tests/factory.rs
@@ -179,6 +179,22 @@ fn coordination_backends_create_and_schedule_across_checkoutless_workspaces() {
         allocator_before
     );
     assert_eq!(alpha.task.list_tasks().expect("alpha list after").len(), 1);
+
+    let mut foreign = task_params("Foreign dependency", TaskStatus::Backlog);
+    foreign.dependencies = vec!["DK-00042".into()];
+    foreign.relations.push(TaskRelation {
+        relation_type: TaskRelationType::RelatedTo,
+        target: "DK-00042".into(),
+    });
+    let foreign = alpha
+        .task
+        .create_task(foreign)
+        .expect("foreign-prefix references are stored unverified");
+    let statuses = alpha.task.task_status_index().expect("global statuses");
+    assert!(
+        task_dependencies_ready(&foreign, &statuses),
+        "foreign dependencies cannot gate on state this machine cannot see"
+    );
 }
 
 #[test]

--- a/crates/orbit-store/src/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/store.rs
@@ -309,27 +309,7 @@ impl TaskRegistryStore {
             .conn
             .lock()
             .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
-        let active: String = conn
-            .query_row(
-                "SELECT task_prefix FROM allocator_state WHERE authority = 'local'",
-                [],
-                |row| row.get(0),
-            )
-            .map_err(|e| OrbitError::Store(e.to_string()))?;
-        let mut prefixes = BTreeSet::from([active]);
-        let mut statement = conn
-            .prepare("SELECT task_id FROM task_bundle_bindings")
-            .map_err(|e| OrbitError::Store(e.to_string()))?;
-        let ids = statement
-            .query_map([], |row| row.get::<_, String>(0))
-            .map_err(|e| OrbitError::Store(e.to_string()))?;
-        for id in ids {
-            let id = id.map_err(|e| OrbitError::Store(e.to_string()))?;
-            if let Some(prefix) = task_id_prefix(&id) {
-                prefixes.insert(prefix.to_string());
-            }
-        }
-        Ok(prefixes)
+        known_task_prefixes(&conn)
     }
 
     pub fn canonical_task_bundle_path(
@@ -740,12 +720,20 @@ impl TaskRegistryStore {
             .map_err(|e| OrbitError::Store(e.to_string()))?;
 
         let mut dangling = Vec::new();
+        let known_prefixes = known_task_prefixes(&conn)?;
         for row in rows {
             let (workspace_id, source_task_id, relation_type, target_task_id) =
                 row.map_err(|e| OrbitError::Store(e.to_string()))?;
-            // The validator only rejects `ORB-` targets; non-`ORB-` targets
-            // (friction / learning / ADR) are allowed to dangle, so skip them.
+            // Non-task artifact targets and foreign-prefix task references are
+            // both allowed to remain unresolved here. Only a locally known
+            // prefix can be a dangling relation in this registry.
             if !is_valid_orb_task_id(&target_task_id) {
+                continue;
+            }
+            let Some(prefix) = task_id_prefix(&target_task_id) else {
+                continue;
+            };
+            if !known_prefixes.contains(prefix) {
                 continue;
             }
             dangling.push(DanglingRelationTarget {
@@ -1210,11 +1198,18 @@ fn validate_relation_targets_exist(
             source_workspace_id.to_string(),
         ));
     }
+    let known_prefixes = known_task_prefixes(conn)?;
     for relation in relations {
         if is_valid_orb_task_id(&relation.target)
             && source_task_id != Some(relation.target.as_str())
             && task_bundle_by_id(conn, &relation.target)?.is_none()
         {
+            let Some(prefix) = task_id_prefix(&relation.target) else {
+                continue;
+            };
+            if !known_prefixes.contains(prefix) {
+                continue;
+            }
             return Err(OrbitError::InvalidInput(format!(
                 "task relation target '{}' from workspace '{}' does not resolve in the coordination registry",
                 relation.target, source_workspace_id
@@ -1222,6 +1217,30 @@ fn validate_relation_targets_exist(
         }
     }
     Ok(())
+}
+
+fn known_task_prefixes(conn: &Connection) -> Result<BTreeSet<String>, OrbitError> {
+    let active: String = conn
+        .query_row(
+            "SELECT task_prefix FROM allocator_state WHERE authority = 'local'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|e| OrbitError::Store(e.to_string()))?;
+    let mut prefixes = BTreeSet::from([active]);
+    let mut statement = conn
+        .prepare("SELECT task_id FROM task_bundle_bindings")
+        .map_err(|e| OrbitError::Store(e.to_string()))?;
+    let ids = statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(|e| OrbitError::Store(e.to_string()))?;
+    for id in ids {
+        let id = id.map_err(|e| OrbitError::Store(e.to_string()))?;
+        if let Some(prefix) = task_id_prefix(&id) {
+            prefixes.insert(prefix.to_string());
+        }
+    }
+    Ok(prefixes)
 }
 
 fn task_relation_edges(envelope: &TaskEnvelopeV2) -> Vec<TaskRelationEdge> {

--- a/crates/orbit-store/src/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/tests/mod.rs
@@ -622,6 +622,50 @@ fn checkoutless_workspaces_coordinate_cross_workspace_relations_without_paths() 
             .expect("relation after rejected update"),
         vec![target_id]
     );
+
+    let foreign_target = "DK-00042";
+    store
+        .validate_new_task_relation_targets(
+            &first.workspace_id,
+            &[TaskRelation {
+                relation_type: TaskRelationType::BlockedBy,
+                target: foreign_target.into(),
+            }],
+        )
+        .expect("foreign-prefix target cannot be verified locally");
+    store
+        .replace_task_index(
+            &first.workspace_id,
+            &envelope(
+                &source_id,
+                TaskStatus::Review,
+                Vec::new(),
+                vec![
+                    TaskRelation {
+                        relation_type: TaskRelationType::BlockedBy,
+                        target: foreign_target.into(),
+                    },
+                    TaskRelation {
+                        relation_type: TaskRelationType::RelatedTo,
+                        target: foreign_target.into(),
+                    },
+                ],
+            ),
+        )
+        .expect("index foreign-prefix relations");
+    assert_eq!(
+        store
+            .indexed_relation_targets(&first.workspace_id, &source_id, TaskRelationType::RelatedTo)
+            .expect("foreign relation target"),
+        vec![foreign_target.to_string()]
+    );
+    assert!(
+        store
+            .dangling_relation_targets(Some(&first.workspace_id))
+            .expect("audit foreign target")
+            .is_empty(),
+        "allowed foreign references are not locally dangling"
+    );
 }
 
 #[test]

--- a/crates/orbit-store/src/sqlite/task_registry/types.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/types.rs
@@ -64,7 +64,7 @@ pub struct TaskIndexFilter {
     pub tags: Vec<String>,
 }
 
-/// A relation edge whose target is a valid `ORB-` task id that does not
+/// A relation edge whose target uses a locally known task prefix but does not
 /// resolve to any registered task bundle in the coordination registry — the
 /// exact condition
 /// [`validate_relation_targets_exist`](crate::sqlite::task_registry::TaskRegistryStore)
@@ -73,9 +73,9 @@ pub struct TaskIndexFilter {
 /// scan (see ORB-10305).
 ///
 /// `relation_type` carries the canonical snake_case name as stored in the
-/// registry (`related_to`, `blocked_by`, …); non-`ORB-` targets (friction /
-/// learning / ADR ids that `produces`/`resolves` edges legitimately allow to
-/// dangle) are never reported here.
+/// registry (`related_to`, `blocked_by`, …); non-task artifact targets and
+/// foreign-prefix task references that legitimately remain unresolved are
+/// never reported here.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DanglingRelationTarget {
     pub workspace_id: String,

--- a/docs/design/host-registry/4_decisions.md
+++ b/docs/design/host-registry/4_decisions.md
@@ -11,7 +11,7 @@ summary: Decision record for host identity, per-machine coordination, prefix-par
 tags: [host-registry, mcp-bridge, multi-host, ownership]
 paths: ["crates/orbit-remote/**", "crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**"]
 related_features: [host-registry, mcp-bridge]
-related_artifacts: [ORB-00424, ORB-10245, ORB-10248, ORB-10249, ORB-10255, ORB-10257, ORB-10267, ORB-10258, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ORB-10330, ORB-10332, ORB-10709, ORB-10723, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240, ADR-0352, ADR-0355, ADR-0356, ADR-0357, ADR-0358]
+related_artifacts: [ORB-00424, ORB-10245, ORB-10248, ORB-10249, ORB-10255, ORB-10257, ORB-10267, ORB-10258, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ORB-10330, ORB-10332, ORB-10709, ORB-10723, ORB-10728, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240, ADR-0352, ADR-0355, ADR-0356, ADR-0357, ADR-0358]
 ---
 
 # Host Registry — Decisions
@@ -410,9 +410,9 @@ rather than removed.
 
 ## ADR-0356 — Machine-scoped task-id prefix instead of a global allocator
 
-**Status:** Accepted · 2026-08 · [ORB-10723] implemented prefix- and width-agnostic parsing, host-prefix minting, and registry-constrained text scanning.
+**Status:** Accepted · 2026-08 · [ORB-10723] implemented prefix- and width-agnostic parsing, host-prefix minting, and registry-constrained text scanning; [ORB-10728] implemented foreign-prefix relation storage and local-only validation.
 **Scope:** task ID minting, ID parsing, cross-machine references
-**Code anchors:** `crates/orbit-common/src/types/task_artifacts.rs`, `crates/orbit-store/src/sqlite/task_registry/store.rs::parse_orb_task_number`, `crates/orbit-core/src/command/docs/artifact_ref.rs`
+**Code anchors:** `crates/orbit-common/src/types/task_artifacts.rs`, `crates/orbit-common/src/types/task.rs::task_reference_is_not_verifiable_here`, `crates/orbit-store/src/sqlite/task_registry/store.rs::parse_orb_task_number`, `crates/orbit-core/src/command/docs/artifact_ref.rs`
 
 ### Context
 
@@ -439,6 +439,9 @@ a human-scale choice, not a coordinated allocation. Reject `ORB`, `ADR`, `L`, an
   This is what makes deferring registration ([ADR-0358]) safe, so the two decisions
   hold each other up and neither should be adopted alone.
 - Moving a workspace between owners becomes a row copy rather than an ID rewrite.
+- An unresolved target under a locally known prefix remains invalid. An unresolved
+  foreign-prefix target is stored and rendered as `not verifiable here`; a foreign
+  dependency is non-gating because this machine cannot observe its lifecycle state.
 - Cost: prefix collisions are possible and silent. Nothing detects two machines
   choosing the same prefix until their records meet, and v1 adds no lint.
 - Cost: cross-machine chronology is destroyed. `ORB-10601` was visibly later than
@@ -546,6 +549,9 @@ would leave a silent, unrecoverable ID collision.
 - [ORB-10723] — implemented ADR-0356: task parsing accepts registered machine
   prefixes and wider numeric suffixes, while allocation retains one monotonic
   machine sequence and formats it with the immutable host prefix.
+- [ORB-10728] — stores unresolved foreign-prefix task relations with an explicit
+  `not verifiable here` projection, keeps locally prefixed misses as hard errors,
+  and treats foreign dependencies as non-gating for local readiness.
 - [ORB-10248] — implemented the versioned logical-workspace/local-checkout split.
 - [ORB-10249] — implemented path-free task coordination and global task-relation/readiness lookup.
 - [ORB-10255] — implemented ADR-0227's append-only SQLite host/alias core with


### PR DESCRIPTION
## Task

[ORB-10728](https://orbit-cli.com/tasks/ORB-10728) — Foreign-prefix relation targets: store unvalidated with marker; local misses stay hard errors (ADR-0356)

### Description

## Problem
The task store rejects unresolvable dependency and typed-relation targets outright. Under prefix-partitioned IDs that behavior makes a legitimate cross-machine reference impossible to record: a target owned by another machine cannot be validated here. Design: `docs/design/host-registry/2_design.md` §3 ("Relation targets resolve only within one coordinating machine").

## Why It Matters
Cross-machine references are the one place v1 must accept a weaker guarantee — but only where the stronger one is unobtainable; weakening local validation too would reintroduce silent dangling references everywhere.

## Constraints / Notes
- A target with a **foreign prefix** (not registered locally) is stored as an unvalidated reference and rendered with a "not verifiable here" marker in show/list output.
- A target under a **local prefix** that does not resolve stays a hard error naming both the target ID and the source workspace — unchanged.
- Dependency-readiness semantics for foreign targets follow the design (they cannot gate on state this machine cannot see); state the chosen behavior explicitly in the execution summary.
- Honest limitation, by design: a typo in a foreign reference is indistinguishable from a legitimate one. Do not add speculative cross-machine verification.

### Acceptance Criteria

- Creating a task with a foreign-prefix dependency or relation target succeeds, and task show renders the not-verifiable-here marker (test)
- A local-prefix unresolvable target is still rejected naming target ID and source workspace (existing behavior covered by regression test)
- Readiness/status projection behavior for foreign targets is deterministic and covered by a test
- cargo build succeeds and the tests this change adds/modifies pass under nextest; pre-existing unrelated failures are out of scope

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Relation validation now derives locally known prefixes from the active allocator plus registered task bundles. Unresolved local-prefix targets remain hard errors naming the target and source workspace; unresolved foreign-prefix dependency and typed-relation targets are stored.
- Read projections label foreign unresolved dependencies and relations as `not verifiable here` across tool, CLI JSON, and dashboard JSON surfaces.
- Foreign dependencies are deliberately non-gating locally: readiness treats them as satisfied for admission and excludes them from unmet/dead-end projections because this machine cannot observe their lifecycle. No synthetic status is inserted into the global status index.
- Registry auditing excludes allowed foreign references from locally dangling targets. ADR-0356 now records the implemented validation and readiness contract.
- Expanded context beyond the registry directory only for shared dependency semantics, read projections, directly affected tests, and the coupled ADR implementation record.
Validation:
- cargo nextest run -p orbit-common -p orbit-store -p orbit-core foreign_ --no-fail-fast (6 passed)
- cargo nextest run -p orbit-store checkoutless_workspaces_coordinate_cross_workspace_relations_without_paths (1 passed)
- cargo nextest run -p orbit-store coordination_backends_create_and_schedule_across_checkoutless_workspaces (1 passed)
- cargo build (passed)
- make ci-fast (passed)
- make ci-lint (passed)
Assessment: The change keeps strict validation wherever the local registry has authority, weakens it only for genuinely foreign prefixes, and covers create, show, readiness, local rejection, index, and audit behavior with deterministic tests.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10728-6a7ab4d7`
- Behind base: 0
- Ahead of base: 1