### PR TITLE
fix: Close out ORB-10727 merge fallout; double agent_implement wall-clock [ORB-10737]

### DIFF
--- a/.orbit/resources/activities/agent_implement.yaml
+++ b/.orbit/resources/activities/agent_implement.yaml
@@ -128,4 +128,4 @@ spec:
     - rg
     - orbit
   on_denial: terminate
-  wall_clock_timeout_seconds: 5400
+  wall_clock_timeout_seconds: 10800

--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -126,4 +126,4 @@ spec:
     - rg
     - orbit
   on_denial: terminate
-  wall_clock_timeout_seconds: 5400
+  wall_clock_timeout_seconds: 10800

--- a/crates/orbit-core/src/command/tool/dispatch.rs
+++ b/crates/orbit-core/src/command/tool/dispatch.rs
@@ -446,7 +446,7 @@ pub fn trusted_mcp_audit_context() -> AuditContext {
             .filter(|value| !value.is_empty())
     }
 
-    let context = if managed_run_context() {
+    if managed_run_context() {
         AuditContext {
             task_id: env_str("ORBIT_TASK_ID"),
             job_run_id: env_str("ORBIT_RUN_ID"),
@@ -455,9 +455,7 @@ pub fn trusted_mcp_audit_context() -> AuditContext {
         }
     } else {
         AuditContext::default()
-    };
-
-    context
+    }
 }
 
 pub(super) fn reservation_owner_from_env() -> Option<ReservationOwnerContext> {

--- a/crates/orbit-remote/src/mcp/owner_link.rs
+++ b/crates/orbit-remote/src/mcp/owner_link.rs
@@ -235,7 +235,9 @@ pub(super) struct CallRequest {
 }
 
 pub(super) enum WorkerMessage {
-    Call(CallRequest),
+    /// Boxed so a queued call does not widen every `Shutdown` slot in the
+    /// bounded channel to the size of a full request.
+    Call(Box<CallRequest>),
     Shutdown,
 }
 
@@ -317,13 +319,13 @@ impl OwnerLinkPool {
             .ok_or_else(|| {
                 OrbitError::OwnerUnavailable("owner link pool is shutting down".to_string())
             })?
-            .try_send(WorkerMessage::Call(CallRequest {
+            .try_send(WorkerMessage::Call(Box::new(CallRequest {
                 capability,
                 name: name.to_string(),
                 input,
                 context,
                 response: response_tx,
-            }))
+            })))
             .map_err(|error| match error {
                 mpsc::TrySendError::Full(_) => OrbitError::OwnerUnavailable(
                     "owner link request queue is saturated before handoff".to_string(),

--- a/crates/orbit-remote/src/mcp/tests/discovery.rs
+++ b/crates/orbit-remote/src/mcp/tests/discovery.rs
@@ -74,7 +74,7 @@ fn remote_owns_the_exact_global_discovery_definitions() {
     );
 
     let canonical = canonical_mcp_tool_definitions().expect("canonical definitions");
-    assert_eq!(canonical.len(), 33, "the frozen production surface changed");
+    assert_eq!(canonical.len(), 29, "the frozen production surface changed");
     assert_eq!(
         canonical
             .iter()

--- a/crates/orbit-remote/src/mcp/tests/e1.rs
+++ b/crates/orbit-remote/src/mcp/tests/e1.rs
@@ -160,7 +160,7 @@ fn multiple_owner_entries_are_keyed_by_target_machine_id() {
         "operator must not imply agent"
     );
 
-    assert!(config.owners.get("hm_unlisted").is_none());
+    assert!(!config.owners.contains_key("hm_unlisted"));
     assert_eq!(
         config
             .routes()
@@ -381,10 +381,14 @@ fn owner_listing_uses_one_canonical_placement_and_capability_predicate() {
     // Crew discovery is admitted for agent (unlike the operator-only registry
     // discovery tool), proving capability is by placement, not a hierarchy.
     assert!(agent_names.contains("orbit.crew.list"));
-    // `orbit.adr.*` is owner-placed like the rest of the knowledge surface. Its
-    // MCP withdrawal is scheduled with the ADR-store migration, not here (see
-    // the conformance fixture's planned_withdrawals).
-    assert!(agent_names.contains("orbit.adr.add"));
+    // `orbit.adr.*` left the advertised surface with the ADR store (ORB-10726):
+    // ADRs are git-committed entries in each feature's `4_decisions.md`, so the
+    // owner endpoint has no ADR tool to place.
+    assert!(
+        !agent_names
+            .iter()
+            .any(|name| name.starts_with("orbit.adr."))
+    );
     assert!(
         !agent_names
             .iter()

--- a/crates/orbit-remote/src/mcp/tests/owner_link.rs
+++ b/crates/orbit-remote/src/mcp/tests/owner_link.rs
@@ -406,13 +406,13 @@ fn silent_peer_times_out_and_bounded_queue_saturates_before_handoff() {
     pool.tx
         .as_ref()
         .expect("pool sender")
-        .try_send(WorkerMessage::Call(CallRequest {
+        .try_send(WorkerMessage::Call(Box::new(CallRequest {
             capability: McpCapability::Agent,
             name: "orbit.task.show".to_string(),
             input: json!({}),
             context: context(McpCapability::Agent, "mcall-queued"),
             response: queued_tx,
-        }))
+        })))
         .expect("one bounded queue slot");
     clock.advance(Duration::from_secs(3));
     let saturated = pool

--- a/crates/orbit-tools/tests/mcp_definitions.rs
+++ b/crates/orbit-tools/tests/mcp_definitions.rs
@@ -29,7 +29,7 @@ impl Tool for TestTool {
 fn canonical_builtin_definitions_are_workspace_independent() {
     let definitions =
         canonical_builtin_mcp_tool_definitions().expect("builtin MCP definitions are valid");
-    assert_eq!(definitions.len(), 31);
+    assert_eq!(definitions.len(), 27);
     assert!(
         definitions
             .iter()

--- a/docs/design/mcp-bridge/references/conformance-v1.yaml
+++ b/docs/design/mcp-bridge/references/conformance-v1.yaml
@@ -90,11 +90,6 @@ tools:
   orbit.auto_task.update: { placement: owner, scope: workspace-required, allowed_capabilities: [agent, operator] }
   orbit.auto_task.toggle: { placement: owner, scope: workspace-required, allowed_capabilities: [agent, operator] }
   orbit.command.exec: { placement: local-derived, scope: workspace-required, allowed_capabilities: [operator] }
-  # Still advertised pending the ADR-store migration; see planned_withdrawals.
-  orbit.adr.add: { placement: owner, scope: workspace-required, allowed_capabilities: [agent, operator] }
-  orbit.adr.show: { placement: owner, scope: workspace-required, allowed_capabilities: [agent, operator] }
-  orbit.adr.supersede: { placement: owner, scope: workspace-required, allowed_capabilities: [agent, operator] }
-  orbit.adr.update: { placement: owner, scope: workspace-required, allowed_capabilities: [agent, operator] }
 
 # Absent from the advertised set today. The conformance test asserts this
 # directly, so a family cannot quietly return.
@@ -103,19 +98,13 @@ withdrawn_tools:
     reason: Deferred to v2 with execution placement and run leases (ADR-0358).
   - names: [orbit.host.list]
     reason: Already removed as unused in ORB-10332; the fleet inventory behind it is deferred to v2 (ADR-0358), so it has nothing to enumerate.
-
-# Decided and scheduled, but not yet absent from the advertised set. These are
-# NOT asserted as withdrawn: doing so would make the contract describe a surface
-# the code still serves.
-planned_withdrawals:
   - names: [orbit.adr.add, orbit.adr.show, orbit.adr.update, orbit.adr.supersede, orbit.adr.list]
-    reason: The ADR store is retired in favour of git-committed entries in each feature's 4_decisions.md (CONVENTIONS.md section 4).
-    blocked_on: >-
-      CONVENTIONS.md section 4b makes inlining the remaining pointer-only entries into each
-      feature's 4_decisions.md a prerequisite, and the orbit-knowledge skill still routes agents to
-      orbit.adr.add. ORB-10727 kept the family advertised rather than performing another feature's
-      cutover inside the bridge recomposition. orbit.adr.list and orbit.adr.restore are already
-      CLI-only.
+    reason: >-
+      The ADR store is retired in favour of git-committed entries in each feature's 4_decisions.md
+      (CONVENTIONS.md section 4). ORB-10726 performed the cutover; ORB-10727 was authored against
+      the pre-cutover surface and still carried the family here as a planned withdrawal, so this
+      entry closes that gap without advancing a revision — canonical_registry_revision 3 already
+      described a matrix without it.
 
 owner_schema_digest:
   domain_tag: orbit.mcp.owner-schema.v1


### PR DESCRIPTION
Task: `ORB-10737` (bug, source task `ORB-10727`)

PR #948 merged onto `agent-main` with a red tree. This closes it out and raises the timeout that caused the incomplete handoff in the first place.

## 1. Stale conformance surface

ORB-10727 was authored against the pre-ORB-10726 world and froze `orbit.adr.*` in the v1 fixture as a `planned_withdrawals` entry. ORB-10726 (#947) then retired the ADR store and tool surface and landed first, so the merged tree advertises 29 tools while the fixture and three test constants still demanded 33.

Four tests were failing:

- `orbit-remote mcp::tests::canonical_mcp_policy_conforms_to_frozen_v1_fixture`
- `orbit-remote mcp::tests::discovery::remote_owns_the_exact_global_discovery_definitions`
- `orbit-remote mcp::tests::e1::owner_listing_uses_one_canonical_placement_and_capability_predicate`
- `orbit-tools::mcp_definitions canonical_builtin_definitions_are_workspace_independent`

`canonical_registry_revision` stays at **3**. The fixture's own `revision_notes` already described revision 3 as *"the v1 tool matrix below — … and the orbit.adr.\*, orbit.run.\*, and orbit.host.list families withdrawn"*, so the tool table was contradicting the note it shipped with. This closes an internal inconsistency rather than changing the advertised surface — no digest or golden-vector change.

## 2. `make ci-lint` was never run

The implementing agent was killed at the 5400s wall-clock timeout before validation, leaving three clippy errors under `-D warnings` in code it wrote:

| Lint | Site | Cause |
|---|---|---|
| `let_and_return` | `orbit-core/src/command/tool/dispatch.rs` | residue of the removed `leased_run` reconciliation |
| `large_enum_variant` | `orbit-remote/src/mcp/owner_link.rs` | `WorkerMessage::Call` carried 304 bytes inline |
| `unnecessary_get_then_check` | `orbit-remote/src/mcp/tests/e1.rs` | `get(..).is_none()` |

## 3. `agent_implement` wall-clock 5400s → 10800s

Doubled in both `crates/orbit-core/assets/activities/agent_implement.yaml` and `.orbit/resources/activities/agent_implement.yaml` (asserted byte-identical).

## Validation

- `make ci-fast` — passes
- `make ci-lint` — passes (workspace-wide, warnings denied)
- `cargo nextest run --workspace` — 41 failures, versus **55 at base `3d34db04`**. Failure sets diffed: no test that passed at base regresses. The remaining 41 are pre-existing host-identity migration, redaction, workspace-registry, and ship-guard failures untouched here.

## Deferred to a cleanup pass

- The two ADR entries ORB-10727 planned — legacy `[hub]` fail-closed, and retaining `McpCapability::Runner` as a run-authorization grant — are still absent from `docs/design/mcp-bridge/4_decisions.md`. Both decisions are documented in prose in `2_design.md` §5.1 and in the `McpCapability::Runner` doc comment.
- `.orbit/resources/activities/{agent_implement,task_pilot}.yaml` still grant retired `orbit.adr.*` tools, drifting from the shipped assets (2 of the pre-existing failures). ORB-10726 fallout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)