### PR TITLE
Seed task-pilot as a disabled default routine

### DIFF
--- a/.orbit/routines/task_pilot.yaml
+++ b/.orbit/routines/task_pilot.yaml
@@ -1,0 +1,29 @@
+# Default task-pilot routine [ORB-10739]. Seeded into `.orbit/routines/` on
+# `orbit init` with the routine name and host pin resolved at seed time. It is
+# intentionally disabled: enabling scheduled task preflight is an explicit,
+# versioned workspace decision.
+#
+# This routine supplies no inputs. `prepare_task_pilot` owns zero-input
+# discovery: it selects only proposed/backlog tasks with empty context_files,
+# excluding `no-diff-needed` and `no-diff-expected` tasks. Explicit task-ID
+# runs remain available for any workspace task and do not use this gate.
+#
+# The four-hour cadence bounds unattended agent work. At most 50 tasks form
+# five-task partitions; five Luna reviewers run concurrently, so two 30-minute
+# waves plus deterministic preparation/apply fit inside the 90-minute timeout.
+schemaVersion: 1
+name: task-pilot-orbit
+description: >
+  Preflight unscoped proposed/backlog tasks through the bounded task-pilot
+  pipeline. Disabled by default; set enabled to true in this versioned
+  definition to opt this workspace into scheduled task preflight.
+enabled: false
+hosts:
+  - dk-server-1
+trigger:
+  cron: "45 */4 * * *"
+  missed_run: skip
+target: job:task_pilot_pipeline
+policy:
+  timeout_minutes: 90
+  overlap: forbid

--- a/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
@@ -1,8 +1,10 @@
-# Invoked-only task-pilot pipeline [ORB-10510].
+# Schedulable task-pilot pipeline [ORB-10510, ORB-10739].
 #
-# Automatic mode (task_ids empty) discovers only proposed/backlog tasks in the
-# active workspace with empty context_files, excluding no-diff tasks. Explicit
-# mode audits exactly the named workspace tasks, including non-empty selectors.
+# Scheduled and other zero-input runs leave discovery entirely to
+# `prepare_task_pilot`: automatic mode (task_ids empty) discovers only
+# proposed/backlog tasks in the active workspace with empty context_files,
+# excluding no-diff tasks. Explicit mode audits exactly the named workspace
+# tasks, including non-empty selectors.
 # Preparation never promotes or dispatches a task. Each read-only Luna-backed
 # pilot receives at most five tasks. The all-join makes any failed partition
 # fail the run before the context-only deterministic apply step can execute.

--- a/crates/orbit-core/assets/routines/task_pilot.yaml
+++ b/crates/orbit-core/assets/routines/task_pilot.yaml
@@ -1,0 +1,29 @@
+# Default task-pilot routine [ORB-10739]. Seeded into `.orbit/routines/` on
+# `orbit init` with the routine name and host pin resolved at seed time. It is
+# intentionally disabled: enabling scheduled task preflight is an explicit,
+# versioned workspace decision.
+#
+# This routine supplies no inputs. `prepare_task_pilot` owns zero-input
+# discovery: it selects only proposed/backlog tasks with empty context_files,
+# excluding `no-diff-needed` and `no-diff-expected` tasks. Explicit task-ID
+# runs remain available for any workspace task and do not use this gate.
+#
+# The four-hour cadence bounds unattended agent work. At most 50 tasks form
+# five-task partitions; five Luna reviewers run concurrently, so two 30-minute
+# waves plus deterministic preparation/apply fit inside the 90-minute timeout.
+schemaVersion: 1
+name: __ORBIT_ROUTINE_NAME__
+description: >
+  Preflight unscoped proposed/backlog tasks through the bounded task-pilot
+  pipeline. Disabled by default; set enabled to true in this versioned
+  definition to opt this workspace into scheduled task preflight.
+enabled: false
+hosts:
+  - __ORBIT_HOST_ID__
+trigger:
+  cron: "45 */4 * * *"
+  missed_run: skip
+target: job:task_pilot_pipeline
+policy:
+  timeout_minutes: 90
+  overlap: forbid

--- a/crates/orbit-core/src/command/job/tests/catalog.rs
+++ b/crates/orbit-core/src/command/job/tests/catalog.rs
@@ -301,8 +301,12 @@ fn task_pilot_pipeline_defaults_to_luna_and_bounded_all_join_partitions() {
     assert_eq!(apply_input["prepared"], "{{ steps.prepare.output }}");
     assert_eq!(apply_input["results"], "{{ steps.pilot_results.output }}");
     assert!(
-        yaml.contains("Invoked-only"),
-        "task pilot must remain an explicitly invoked workflow"
+        yaml.contains("Schedulable task-pilot pipeline"),
+        "task pilot must document scheduled zero-input support"
+    );
+    assert!(
+        !yaml.contains("Invoked-only"),
+        "task pilot is no longer restricted to explicit invocation"
     );
 
     let mut resolved = load_job_asset(yaml).expect("task pilot pipeline parses for resolution");

--- a/crates/orbit-core/src/command/routine.rs
+++ b/crates/orbit-core/src/command/routine.rs
@@ -38,6 +38,10 @@ pub(crate) const DEFAULT_ROUTINE_FILES: &[(&str, &str)] = &[
         include_str!("../../assets/routines/task_triage.yaml"),
     ),
     (
+        "task_pilot",
+        include_str!("../../assets/routines/task_pilot.yaml"),
+    ),
+    (
         "ship_sweep",
         include_str!("../../assets/routines/ship_sweep.yaml"),
     ),
@@ -136,6 +140,7 @@ mod tests {
         for (stem, target) in [
             ("auto_task_scheduler", "auto_task_scheduler_pipeline"),
             ("task_triage", "task_triage_pipeline"),
+            ("task_pilot", "task_pilot_pipeline"),
             ("ship_sweep", "workspace_ship_pipeline"),
             ("worktree_gc", "worktree_gc_pipeline"),
         ] {
@@ -159,6 +164,21 @@ mod tests {
         let triage = parse_routine_yaml(&triage).expect("triage routine parses");
         assert_eq!(triage.trigger.cron, "15 * * * *");
         parse_cron(&triage.trigger.cron).expect("seeded cron parses");
+
+        // Task-pilot may run up to ten five-task partitions in two waves,
+        // each agent bounded to 30 minutes. Its 90-minute timeout covers
+        // that maximum automatic batch plus deterministic preparation/apply.
+        let pilot = std::fs::read_to_string(routines_dir.join("task_pilot.yaml"))
+            .expect("read task-pilot routine");
+        let pilot = parse_routine_yaml(&pilot).expect("task-pilot routine parses");
+        assert_eq!(pilot.trigger.cron, "45 */4 * * *");
+        assert_eq!(
+            pilot.trigger.missed_run,
+            orbit_common::types::MissedRunPolicy::Skip
+        );
+        assert_eq!(pilot.policy.timeout_minutes, 90);
+        assert_eq!(pilot.policy.overlap, OverlapPolicy::Forbid);
+        parse_cron(&pilot.trigger.cron).expect("task-pilot cron parses");
 
         let ship = std::fs::read_to_string(routines_dir.join("ship_sweep.yaml"))
             .expect("read ship routine");
@@ -204,6 +224,47 @@ mod tests {
             RoutineTarget::Job("worktree_gc_pipeline".to_string())
         );
         assert!(!definition.enabled);
+    }
+
+    #[test]
+    fn plain_reinit_adds_a_new_missing_default_without_rewriting_existing_files() {
+        let root = tempdir().expect("create tempdir");
+        let routines_dir = root.path().join("routines");
+        seed_default_routines(&routines_dir, "host-a", Some("workspace"), false)
+            .expect("first seed");
+
+        let existing = routines_dir.join("task_triage.yaml");
+        let original = std::fs::read(&existing).expect("read existing routine bytes");
+        let missing = routines_dir.join("task_pilot.yaml");
+        std::fs::remove_file(&missing).expect("remove newly introduced routine");
+
+        let seeded = seed_default_routines(&routines_dir, "host-b", Some("workspace"), false)
+            .expect("plain re-init");
+        assert_eq!(seeded, 1, "only the missing default is created");
+        assert_eq!(
+            std::fs::read(&existing).expect("read existing routine bytes"),
+            original,
+            "plain re-init must preserve existing routines byte-for-byte"
+        );
+
+        let pilot = parse_routine_yaml(
+            &std::fs::read_to_string(&missing).expect("read newly seeded task-pilot routine"),
+        )
+        .expect("newly seeded task-pilot routine parses");
+        assert_eq!(pilot.hosts, vec!["host-b".to_string()]);
+        assert!(!pilot.enabled);
+    }
+
+    #[test]
+    fn dogfood_task_pilot_routine_matches_the_rendered_default_template() {
+        let rendered = include_str!("../../assets/routines/task_pilot.yaml")
+            .replace(ROUTINE_NAME_PLACEHOLDER, "task-pilot-orbit")
+            .replace(HOST_ID_PLACEHOLDER, "dk-server-1");
+        assert_eq!(
+            rendered,
+            include_str!("../../../../.orbit/routines/task_pilot.yaml"),
+            "dogfood task-pilot routine must stay aligned with the seeded template"
+        );
     }
 
     #[test]

--- a/crates/orbit-core/src/runtime/v2_host/tests/task_pilot.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/task_pilot.rs
@@ -92,11 +92,18 @@ fn automatic_discovery_filters_status_context_and_no_diff_tags_then_partitions()
     let active = seed_task(&runtime, "active", TaskStatus::InProgress, &[], &[]);
     let review = seed_task(&runtime, "review", TaskStatus::Review, &[], &[]);
     let terminal = seed_task(&runtime, "terminal", TaskStatus::Done, &[], &[]);
-    let no_diff = seed_task(
+    let no_diff_needed = seed_task(
         &runtime,
-        "no-diff",
+        "no-diff-needed",
         TaskStatus::Backlog,
         &["no-diff-needed"],
+        &[],
+    );
+    let no_diff_expected = seed_task(
+        &runtime,
+        "no-diff-expected",
+        TaskStatus::Proposed,
+        &["no-diff-expected"],
         &[],
     );
     let scoped = seed_task(
@@ -141,11 +148,13 @@ fn automatic_discovery_filters_status_context_and_no_diff_tags_then_partitions()
             entry["task_id"] == task.id && entry["reason"] == "status_not_eligible"
         }));
     }
-    assert!(
-        excluded
-            .iter()
-            .any(|entry| { entry["task_id"] == no_diff.id && entry["reason"] == "no_diff_task" })
-    );
+    for task in [no_diff_needed, no_diff_expected] {
+        assert!(
+            excluded
+                .iter()
+                .any(|entry| { entry["task_id"] == task.id && entry["reason"] == "no_diff_task" })
+        );
+    }
     assert!(excluded.iter().any(|entry| {
         entry["task_id"] == scoped.id && entry["reason"] == "context_files_not_empty"
     }));

--- a/docs/design/routines/1_overview.md
+++ b/docs/design/routines/1_overview.md
@@ -1,7 +1,7 @@
 ---
 title: Routines — Overview
 owner: claude
-last_updated: 2026-07-18
+last_updated: 2026-08-12
 status: Accepted
 feature: routines
 doc_role: overview
@@ -10,7 +10,7 @@ summary: Durable, git-versioned scheduler primitive that fires catalog jobs/acti
 tags: [routines, scheduler]
 paths: ["crates/orbit-cli/src/command/routine/**", "crates/orbit-core/src/routines/**", "crates/orbit-remote/src/routines.rs", "crates/orbit-store/src/sqlite/routine_store/**"]
 related_features: [routines, activity-job, host-registry]
-related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ADR-0223]
+related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ORB-10739, ADR-0223]
 ---
 
 # Routines — Overview
@@ -30,11 +30,12 @@ is host-local and never synced. [2_design.md](./2_design.md) is the v1 contract;
 > registry-neutral scheduler, validation, and dispatch kernels. [ORB-10319]
 
 `orbit workspace init` creates the complete default set (`auto_task_scheduler`,
-`task_triage`, and `ship_sweep`) under `.orbit/routines/`. Every default is
-`enabled: false`: scheduled execution is an explicit, versioned opt-in made by changing
-the reviewed definition to `enabled: true`. Re-init creates newly introduced missing
-defaults but never rewrites existing routine files; those files belong to the workspace
-after seeding. A destructive force initialization recreates templates from defaults.
+`task_triage`, `task_pilot`, `ship_sweep`, and `worktree_gc`) under
+`.orbit/routines/`. Every default is `enabled: false`: scheduled execution is an explicit,
+versioned opt-in made by changing the reviewed definition to `enabled: true`. Re-init
+creates newly introduced missing defaults but never rewrites existing routine files; those
+files belong to the workspace after seeding. A destructive force initialization recreates
+templates from defaults. [ORB-10739]
 
 ---
 
@@ -112,6 +113,8 @@ fragmentation this feature exists to end.
   observation and starts at the next natural slot without backfill.
 - [ORB-10319] — moved Remote-specific identity, registry/cache, and workspace-runtime
   composition out of Core without changing scheduler behavior.
+- [ORB-10739] — added the disabled `task_pilot` default routine; its zero-input target
+  leaves eligibility and bounded partitioning to `prepare_task_pilot`.
 - [ORB-00374] — removed the `shell` activity variant and `run_shell` dispatch (fail-closed);
   routines inherit this constraint.
 

--- a/docs/design/routines/4_decisions.md
+++ b/docs/design/routines/4_decisions.md
@@ -1,7 +1,7 @@
 ---
 title: Routines — Decisions
 owner: claude
-last_updated: 2026-08-11
+last_updated: 2026-08-12
 status: Accepted
 feature: routines
 doc_role: decisions
@@ -10,7 +10,7 @@ summary: ADR log for the routines scheduler, including default seeding and works
 tags: [routines, scheduler]
 paths: ["crates/orbit-core/src/routines/**", "crates/orbit-remote/src/routines.rs"]
 related_features: [routines, activity-job, host-registry]
-related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ADR-0223]
+related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ORB-10739, ADR-0223]
 ---
 
 # Routines — Decisions
@@ -149,16 +149,16 @@ Routine YAML definitions live in routine-source workspaces and converge via git 
 **Status:** Accepted · 2026-07-11 21:51:20.761360Z · [ORB-10129], [ORB-10207]
 **Owner:** claude
 **Created:** 2026-07-11 21:51:13.196368Z
-**Last updated:** 2026-07-15 22:19:13.397683Z
+**Last updated:** 2026-08-12
 **Related features:** `routines`
-**Tags:** `routines`, `default-assets`, `triage`, `ship-sweep`
+**Tags:** `routines`, `default-assets`, `triage`, `task-pilot`, `ship-sweep`
 **Paths:** `crates/orbit-core/assets/routines/**`, `crates/orbit-core/src/command/routine.rs`, `crates/orbit-core/src/command/init.rs`
 
 ### Context
 ORB-10129 ships the triage pipeline as a default, but routines have no global directory: discovery reads `.orbit/routines/*.yaml` from `[routines] role = "source"` workspaces, v1 requires explicit host pinning (no "any host"), and routine names must be unique across all sources on a host — so a static shipped YAML cannot work. The real alternatives were leaving defaults workspace-authored from scratch or adding a global routines directory (a discovery-model change ADR-0205 deliberately avoided).
 
 ### Decision
-`orbit init` (workspace branch) seeds `DEFAULT_ROUTINE_FILES` templates into `.orbit/routines/`, resolving `__ORBIT_HOST_ID__` via `resolve_host_id` and `__ORBIT_ROUTINE_NAME__` from a workspace-directory slug, validating each rendered document fail-closed before writing. Every default is disabled. Plain re-init creates missing defaults while preserving existing definitions byte-for-byte; destructive `--force` recreates templates. A routine fires only after the workspace is a routine source and its versioned `enabled` field is set true.
+`orbit init` (workspace branch) seeds `DEFAULT_ROUTINE_FILES` templates into `.orbit/routines/`, resolving `__ORBIT_HOST_ID__` via `resolve_host_id` and `__ORBIT_ROUTINE_NAME__` from a workspace-directory slug, validating each rendered document fail-closed before writing. Every default is disabled. The complete set is `auto_task_scheduler`, `task_triage`, `task_pilot`, `ship_sweep`, and `worktree_gc`. Plain re-init creates missing defaults while preserving existing definitions byte-for-byte; destructive `--force` recreates templates. A routine fires only after the workspace is a routine source and its versioned `enabled` field is set true. [ORB-10739]
 
 ### Consequences
 - Fresh workspaces get reviewable routine definitions without silently granting scheduled execution.


### PR DESCRIPTION
## Task

[ORB-10739](https://orbit-cli.com/tasks/ORB-10739) — Seed task-pilot as a disabled default routine

### Description

## Problem
Orbit ships `task_pilot_pipeline`, but `orbit init` does not seed a routine that can run it automatically. Workspaces therefore need a hand-authored routine or a remembered manual invocation before proposed/backlog tasks with missing `context_files` are preflighted.

Add `task_pilot_pipeline` to Orbit's default routine set as a reviewable, disabled-by-default definition.

## Why It Matters
The pipeline already has the correct automatic eligibility gate: with its default empty `task_ids`, `prepare_task_pilot` selects only `proposed` or `backlog` tasks whose `context_files` is empty, while excluding `no-diff-needed` and `no-diff-expected` tasks. A default routine makes that maintenance path discoverable and opt-in without broadening the pilot's mutation scope.

## Constraints / Notes
- Seed a new `task_pilot` routine through `DEFAULT_ROUTINE_FILES`, with the standard host and workspace-unique name placeholders and `enabled: false`.
- Target `job:task_pilot_pipeline` with no explicit inputs so its existing automatic discovery contract remains authoritative; do not duplicate task selection in the scheduler or routine.
- Use a documented, bounded cadence appropriate for an agent-backed scan, `missed_run: skip`, `overlap: forbid`, and a timeout that covers up to the job's existing 50-task/5-worker bounds. The routine remains inert until a routine-source workspace explicitly enables it.
- Remove or revise the shipped job comment/test that calls the pipeline "invoked-only"; scheduled routine invocation becomes supported, while explicit task-ID invocation must continue to work.
- Add the live `.orbit/routines/task_pilot.yaml` mirror and keep it aligned with the compiled routine asset according to the repository's asset conventions.
- Update the routines design documentation to list the complete default set and record this extension under the existing default-seeding decision; no new scheduling mechanism is introduced.
- Preserve plain re-init semantics: create the newly introduced missing routine but never overwrite an existing workspace-authored file. Preserve destructive force-init behavior.
- This task is proposed only. Do not dispatch or implement it as part of creation.


### Acceptance Criteria

- A fresh `orbit init` seeds `.orbit/routines/task_pilot.yaml` alongside the other defaults, and the parsed routine is disabled, pinned to the resolved host, named with the workspace-unique suffix, and targets `job:task_pilot_pipeline`.
- The routine uses a documented bounded cron cadence, `missed_run: skip`, `overlap: forbid`, and an explicit timeout suitable for the pipeline's existing maximum automatic batch; `orbit routine list/show` and `orbit sweep --dry-run` accept it without load errors.
- A routine-triggered zero-input run leaves task discovery to `prepare_task_pilot`: only proposed/backlog tasks with empty `context_files` are selected automatically, and tasks with non-empty selectors, ineligible statuses, or `no-diff-needed`/`no-diff-expected` tags are excluded.
- The scheduled path preserves the existing pilot bounds and safety contract: at most 50 tasks, partitions of at most five, Luna/reviewer execution, all-partition validation before apply, and mutations limited to validated `context_files` replacements.
- Explicit `task_ids` invocation continues to assess exactly the named tasks, including tasks with non-empty selectors or non-proposed/backlog statuses; no eligibility regression is introduced.
- Plain re-init creates a missing newly introduced task-pilot routine without changing any existing routine file byte-for-byte; force initialization recreates the current default template.
- The compiled and live task-pilot routine assets follow the repository's parity convention, and stale `invoked-only` wording/assertions are removed or revised everywhere the now-schedulable job is described.
- The routines overview/decision documentation lists the complete default routine set, states that every default remains disabled until explicit versioned opt-in, and links this task to the existing default-seeding decision.
- Validation passes `cargo fmt --check`, `make ci-fast`, targeted default-routine seeding tests, task-pilot catalog/runtime tests, routine loader/due tests, and `scripts/validate-codex-plugin.sh`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added disabled `task_pilot` to `DEFAULT_ROUTINE_FILES`, with a four-hour `missed_run: skip` cadence, `overlap: forbid`, and a 90-minute timeout sized for the 50-task, five-reviewer automatic batch.
- Added matching compiled and dogfood routine assets; a test locks the live asset to the host/name-rendered template.
- Preserved the zero-input automatic gate and explicit-ID behavior, expanded coverage to both no-diff exclusion tags, and revised the job from invoked-only to schedulable wording.
- Added plain-reinit coverage proving a newly missing default is created while existing routine bytes are preserved; documented the complete disabled default set and updated ADR-0215 with [ORB-10739].

Assessment: The routine delegates all discovery to the existing bounded `prepare_task_pilot` contract and adds no scheduler-side selection or mutation behavior.

Validation:
- Passed `cargo fmt --check`, `make ci-fast`, `make ci-lint`, and `scripts/validate-codex-plugin.sh`.
- Passed focused routine seeding/parity, task-pilot catalog/runtime, and routine loader/due tests.
- `orbit routine list --root .orbit --json` and `orbit sweep --root .orbit --dry-run --verbose --json` could not run in this activity: the installed CLI returned `io_error: Read-only file system (os error 30)` before loading routines. Parser, seeding, catalog, loader, and due coverage passed instead.
- A broad `cargo test -p orbit-core task_pilot --lib` additionally exposed a pre-existing unrelated parity failure between `crates/orbit-core/assets/activities/task_pilot.yaml` and `.orbit/resources/activities/task_pilot.yaml`; this task did not modify either file.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10739-6a7be4b9`
- Behind base: 0
- Ahead of base: 1