### PR TITLE
Align Orbit Grok default model string with live Grok Build CLI

### DIFF
--- a/crates/orbit-agent/src/providers/grok/tests/grok_cli.rs
+++ b/crates/orbit-agent/src/providers/grok/tests/grok_cli.rs
@@ -7,8 +7,8 @@ mod args {
 
     #[test]
     fn grok_args_pass_model_with_long_flag() {
-        let transport = GrokCliTransport::new(Some("grok-build".to_string()));
+        let transport = GrokCliTransport::new(Some("grok-4.5".to_string()));
 
-        assert_eq!(transport.args(), vec!["--model", "grok-build"]);
+        assert_eq!(transport.args(), vec!["--model", "grok-4.5"]);
     }
 }

--- a/crates/orbit-cli/src/command/tests/init.rs
+++ b/crates/orbit-cli/src/command/tests/init.rs
@@ -137,7 +137,7 @@ fn non_interactive_init_against_non_global_root_leaves_home_skill_links_untouche
         ("terra", "codex", "gpt-5.6-terra"),
         ("luna", "codex", "gpt-5.6-luna"),
         ("gemini", "gemini", "pro"),
-        ("grok", "grok", "grok-build"),
+        ("grok", "grok", "grok-4.5"),
         ("qa", "", ""),
     ];
     if let Some(crews) = crews {

--- a/crates/orbit-common/src/model_defaults.rs
+++ b/crates/orbit-common/src/model_defaults.rs
@@ -68,8 +68,8 @@ pub const GEMINI_PAIR_STRONG: &str = "gemini-3.1-pro";
 /// Default gemini "weak" model used by the executor model pair.
 pub const GEMINI_PAIR_WEAK: &str = "gemini-3-flash";
 
-/// Default grok model (single value used everywhere grok defaults appear).
-pub const GROK_DEFAULT_MODEL: &str = "grok-build";
+/// Default Grok Build model (the canonical model listed by `grok models`).
+pub const GROK_DEFAULT_MODEL: &str = "grok-4.5";
 
 /// Cheap Claude model used by the orbit-agent HTTP examples.
 ///

--- a/crates/orbit-core/assets/executors/grok.yaml
+++ b/crates/orbit-core/assets/executors/grok.yaml
@@ -16,7 +16,7 @@ spec:
   stdout_format: envelope
   sandbox: macos-sandbox-exec
   model_pair_override:
-    strong: grok-build
-    weak: grok-build
+    strong: grok-4.5
+    weak: grok-4.5
   model_flag: "-m"
   env: {}

--- a/crates/orbit-core/src/config/tests/bootstrap.rs
+++ b/crates/orbit-core/src/config/tests/bootstrap.rs
@@ -82,7 +82,7 @@ fn grok_only_seeds_grok_without_qa() {
     let parsed = parsed_config(&contents);
 
     assert_eq!(crew_names(&parsed), vec!["grok"]);
-    assert_crew(&parsed, "grok", "grok", "grok-build");
+    assert_crew(&parsed, "grok", "grok", "grok-4.5");
     assert_default_crew(&parsed, Some("grok"));
 }
 
@@ -130,7 +130,7 @@ fn multi_provider_seed_includes_each_available_family_and_excludes_unavailable()
     assert_crew(&parsed, "sol", "codex", "gpt-5.6-sol");
     assert_crew(&parsed, "terra", "codex", "gpt-5.6-terra");
     assert_crew(&parsed, "luna", "codex", "gpt-5.6-luna");
-    assert_crew(&parsed, "grok", "grok", "grok-build");
+    assert_crew(&parsed, "grok", "grok", "grok-4.5");
     assert_crew(&parsed, "qa", "codex", "gpt-5.6-terra");
     for crew in crews(&parsed).values() {
         assert_eq!(

--- a/crates/orbit-core/src/config/tests/runtime.rs
+++ b/crates/orbit-core/src/config/tests/runtime.rs
@@ -40,7 +40,7 @@ fn built_in_crews_use_standard_model_specific_names() {
         ("terra", "codex", "gpt-5.6-terra"),
         ("luna", "codex", "gpt-5.6-luna"),
         ("gemini", "gemini", "pro"),
-        ("grok", "grok", "grok-build"),
+        ("grok", "grok", "grok-4.5"),
     ] {
         let assignment = &crews.get(name).expect("built-in crew").assignment;
         assert_eq!(assignment.provider, provider);

--- a/crates/orbit-core/tests/grok_cli_backend_smoke.rs
+++ b/crates/orbit-core/tests/grok_cli_backend_smoke.rs
@@ -60,7 +60,7 @@ fn installed_grok_cli_backend_smoke_captures_stdout_artifact() {
         orbit_store::Store::open_in_memory().expect("audit store"),
         "ws_test",
         "grok-installed-smoke",
-        "grok:grok-build".to_string(),
+        "grok:grok-4.5".to_string(),
         None,
     )
     .expect("build audit writer");
@@ -68,7 +68,7 @@ fn installed_grok_cli_backend_smoke_captures_stdout_artifact() {
         instruction: "Return the requested Orbit response envelope.".to_string(),
         tools: Vec::new(),
         on_denial: OnDenial::Terminate,
-        model: Some("grok-build".to_string()),
+        model: Some("grok-4.5".to_string()),
         max_iterations: 1,
         backend: Backend::Cli,
         provider: Provider::Grok,
@@ -118,5 +118,5 @@ fn installed_grok_cli_backend_smoke_captures_stdout_artifact() {
         .as_ref()
         .expect("well-formed grok stdout should parse invocation trace");
     assert_eq!(invocation.provider, "grok");
-    assert_eq!(invocation.model.as_deref(), Some("grok-build"));
+    assert_eq!(invocation.model.as_deref(), Some("grok-4.5"));
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -63,7 +63,7 @@ A **crew** is one provider-model-backend assignment. Activities do not carry a m
 
 | Field | Purpose | Values |
 |---|---|---|
-| `model` | Model identifier passed to the provider CLI | Provider-specific (e.g. `opus`, `sonnet`, `gpt-5.6-sol`, `pro`, `grok-build`) |
+| `model` | Model identifier passed to the provider CLI | Provider-specific (e.g. `opus`, `sonnet`, `gpt-5.6-sol`, `pro`, `grok-4.5`) |
 | `provider` | Agent family | `claude`, `codex`, `gemini`, `grok` (the CLI-executable families; see [Provider identity and resolution](#provider-identity-and-resolution) for the full canonical set) |
 | `backend` | How Orbit dispatches the agent | `cli` (today the only supported value for crew dispatch) |
 | `description` | Optional human-facing crew summary | Any non-empty string after trimming |
@@ -79,6 +79,17 @@ backend = "cli"
 description = "Systems implementation"
 tags = ["implementation", "review"]
 ```
+
+Example — the standard Grok crew:
+
+```toml
+[crews.grok]
+model = "grok-4.5"
+provider = "grok"
+backend = "cli"
+```
+
+The current Grok Build CLI lists `grok-4.5` as its default from `grok models`, so Orbit uses that live menu id. The older `grok-build` string is not retained as a default or alias.
 
 Fresh `orbit init` configuration advertises only detected provider CLIs. Claude seeds `opus`, `sonnet`, and `fable`; Codex seeds `sol`, `terra`, and `luna`; Gemini seeds `gemini`; and Grok seeds `grok`. When Codex or Claude is available, `qa` uses Terra or Sonnet respectively. Every generated entry uses the CLI backend. If no supported provider CLI is detected, init leaves both the crew registry and `workflow.default_crew` unset instead of writing an unusable provider.
 


### PR DESCRIPTION
## Task

[ORB-10741](https://orbit-cli.com/tasks/ORB-10741) — Align Orbit Grok default model string with live Grok Build CLI

### Description

## Problem
Orbit seeds and documents Grok crew model as `grok-build` (`GROK_DEFAULT_MODEL` in `orbit-common`, workspace `[crews.grok] model = "grok-build"`, CONFIG.md examples). On dk-server-1 (2026-08-12), `grok models` lists default **`grok-4.5`**, and a headless JSON smoke reported `modelUsage` key **`grok-4.5-build`**.

Risk: ship/dispatch with `crew=grok` may pass a stale or non-menu model id to the CLI even when the binary is installed.

## Why It Matters
Grok end-to-end ship and any workspace that dispatches `[crews.grok]` need a model string the installed CLI accepts. Silent mismatch is hard to diagnose (looks like provider failure).

## Constraints / Notes
- Confirm whether `grok-build` still aliases; if yes, document that; if no, change default + seed + docs.
- Prefer one canonical default used by `orbit init` seed and `GROK_DEFAULT_MODEL`.
- Do not invent multi-tier Grok crews unless models truly differ in product tiers; single `grok` crew is fine for v1.
- Workspace config.toml files on box may need a follow-up refresh after binary deploy of orbit defaults — note in execution summary.

### Acceptance Criteria

- Documented decision: either prove `grok-build` is accepted by current Grok Build CLI as a model id/alias, or change `GROK_DEFAULT_MODEL` (and seed/docs) to the live canonical id.
- Unit/config tests or docs for default model stay consistent with the chosen id.
- `docs/CONFIG.md` Grok example matches the chosen default.
- A one-line note in the execution summary lists which workspace configs (if any) still pin a divergent model and need operator refresh.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Switched `GROK_DEFAULT_MODEL`, the shipped Grok executor model pair, init/config expectations, provider argument coverage, and the ignored backend smoke fixture to `grok-4.5`, the model listed as the current Grok CLI default.
- Added the Grok crew example and decision rationale to `docs/CONFIG.md`; retained historical `grok-build` pricing and unrelated explicit-model fixtures.
Assessment: The canonical default, seeded crews, executor fallback, docs, and focused tests now agree; `grok models` confirmed `grok-4.5` is the live installed CLI model.
Validation: `cargo test` focused Grok/config/provider tests passed; the backend smoke test compiled and remains ignored because it requires authenticated network access; `cargo fmt --all -- --check`, `make ci-fast`, and `make ci-lint` passed.
Workspace refresh note: `.orbit/config.toml` and `.orbit/resources/executors/grok.yaml` still pin `grok-build` and need operator refresh after the binary/default deploy.
Recommended follow-up: refresh those workspace-local pins when deploying the new default.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10741-6a7bec47`
- Behind base: 0
- Ahead of base: 1