### PR TITLE
Fix Orbit host.toml schema_version=2 rejection under sandboxed implement (F2026-08-068)

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -29,7 +29,8 @@ use super::envelope::{
     task_id_from_input,
 };
 use super::spawn::{
-    linux_bwrap_failed_write_diagnostic, prepare_sandbox_for_dispatch, resolve_provider_launcher,
+    linux_bwrap_failed_write_diagnostic, orbit_tool_env, prepare_sandbox_for_dispatch,
+    resolve_provider_launcher,
 };
 use super::supervisor::{
     DEFAULT_WALL_CLOCK_TIMEOUT_SECONDS, SpawnTraceContext, SpawnWithTimeoutRequest,
@@ -213,7 +214,7 @@ pub fn run_cli_backend(
     // ADR-0182: external CLI agents get the same active-task hook binding as
     // direct-agent executions. The AGENT_* fields preserve ORB-10342's
     // commit-telemetry contract and omit unknown model/task values.
-    let child_env = provenance_env(ProvenanceEnv {
+    let mut child_env = provenance_env(ProvenanceEnv {
         orbit_run_id: Some(run_id),
         orbit_managed_run_context: true,
         orbit_agent_name: tool_ctx.agent_name.as_deref(),
@@ -225,6 +226,9 @@ pub fn run_cli_backend(
         agent_model: model.as_deref(),
         agent_task_id: task_id,
     });
+    child_env.extend(
+        orbit_tool_env().map_err(|error| DispatchError::CliInvocationPermanent(error.message))?,
+    );
     // [ORB-10496] Record the provider child's PID the moment it exists. Emitted
     // through the same writer, so it is persisted (and therefore readable by
     // `orbit run show` / the run-status API) while the invocation is still

--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -15,6 +15,8 @@ use tempfile::NamedTempFile;
 
 use super::super::dispatcher::ResolvedSandbox;
 
+const ORBIT_BIN_ENV: &str = "ORBIT_BIN";
+
 /// Typed spawn failure with a retryability classification (ORB-10006).
 ///
 /// `permanent: true` marks failures that retrying cannot fix — the step
@@ -161,6 +163,73 @@ pub(crate) fn resolve_provider_launcher(
     let path = std::env::var_os("PATH");
     let home = std::env::var_os("HOME").map(PathBuf::from);
     resolve_provider_launcher_with(provider, program, path.as_deref(), home.as_deref(), cwd)
+}
+
+/// Pin tools invoked by an agent to the Orbit build that dispatched it.
+///
+/// Long-lived services may retain a `PATH` whose first `orbit` is an older
+/// Cargo install even after the operator deploys `~/.orbit/bin/orbit`. Export
+/// the selected binary for hook scripts and put its directory first for bare
+/// `orbit tool ...` invocations inside the provider (including Bubblewrap).
+pub(crate) fn orbit_tool_env() -> Result<Vec<(String, String)>, SpawnError> {
+    let current_exe = std::env::current_exe().map_err(|error| {
+        SpawnError::permanent(format!(
+            "resolve dispatching Orbit executable for agent tool environment: {error}"
+        ))
+    })?;
+    let configured = std::env::var_os(ORBIT_BIN_ENV);
+    let inherited_path = std::env::var_os("PATH");
+    orbit_tool_env_with(
+        configured.as_deref(),
+        &current_exe,
+        inherited_path.as_deref(),
+    )
+}
+
+// pub(crate) widened for sibling tests under the repository's enforced test layout.
+pub(crate) fn orbit_tool_env_with(
+    configured: Option<&OsStr>,
+    current_exe: &Path,
+    inherited_path: Option<&OsStr>,
+) -> Result<Vec<(String, String)>, SpawnError> {
+    let selected = configured
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| current_exe.to_path_buf());
+    let selected_text = selected.to_string_lossy().into_owned();
+
+    let Some(bin_dir) = selected
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    else {
+        return Ok(vec![(ORBIT_BIN_ENV.to_string(), selected_text)]);
+    };
+
+    let mut path_entries = vec![bin_dir.to_path_buf()];
+    if let Some(inherited_path) = inherited_path {
+        path_entries.extend(
+            std::env::split_paths(inherited_path).filter(|entry| entry.as_path() != bin_dir),
+        );
+    }
+    let pinned_path = std::env::join_paths(path_entries)
+        .map_err(|error| {
+            SpawnError::permanent(format!(
+                "construct agent PATH pinned to `{}`: {error}",
+                selected.display()
+            ))
+        })?
+        .into_string()
+        .map_err(|_| {
+            SpawnError::permanent(format!(
+                "agent PATH pinned to `{}` is not valid Unicode",
+                selected.display()
+            ))
+        })?;
+
+    Ok(vec![
+        (ORBIT_BIN_ENV.to_string(), selected_text),
+        ("PATH".to_string(), pinned_path),
+    ])
 }
 
 // pub(crate) widened for sibling tests under the repository's enforced test layout.

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
@@ -8,7 +8,7 @@ use tempfile::tempdir;
 
 use super::super::super::dispatcher::ResolvedSandbox;
 use super::super::spawn::{
-    SpawnError, SpawnedChild, prepare_linux_sandbox_for_dispatch_with_probe,
+    SpawnError, SpawnedChild, orbit_tool_env_with, prepare_linux_sandbox_for_dispatch_with_probe,
     resolve_provider_launcher_with, spawn_bare, spawn_macos_sandboxed_with,
 };
 use super::test_support::{sandbox_for_test, sh_args};
@@ -234,6 +234,65 @@ fn missing_provider_launcher_error_names_provider_and_searched_locations() {
             error.message
         );
     }
+}
+
+#[test]
+fn agent_tool_environment_prefers_dispatching_orbit_over_stale_path_entry() {
+    let inherited = std::env::join_paths(["/home/test/.cargo/bin", "/usr/bin"])
+        .expect("construct inherited PATH");
+    let env = orbit_tool_env_with(
+        None,
+        std::path::Path::new("/home/test/.orbit/bin/orbit"),
+        Some(&inherited),
+    )
+    .expect("pin dispatching Orbit");
+
+    assert_eq!(
+        env[0],
+        (
+            "ORBIT_BIN".to_string(),
+            "/home/test/.orbit/bin/orbit".to_string()
+        )
+    );
+    let pinned = env
+        .iter()
+        .find(|(name, _)| name == "PATH")
+        .map(|(_, value)| value)
+        .expect("PATH override");
+    assert_eq!(
+        std::env::split_paths(std::ffi::OsStr::new(pinned)).collect::<Vec<_>>(),
+        vec![
+            std::path::PathBuf::from("/home/test/.orbit/bin"),
+            std::path::PathBuf::from("/home/test/.cargo/bin"),
+            std::path::PathBuf::from("/usr/bin"),
+        ]
+    );
+}
+
+#[test]
+fn configured_orbit_bin_wins_and_its_path_entry_is_deduplicated() {
+    let inherited = std::env::join_paths(["/home/test/.cargo/bin", "/opt/orbit/bin", "/usr/bin"])
+        .expect("construct inherited PATH");
+    let env = orbit_tool_env_with(
+        Some(std::ffi::OsStr::new("/opt/orbit/bin/orbit")),
+        std::path::Path::new("/home/test/.orbit/bin/orbit"),
+        Some(&inherited),
+    )
+    .expect("pin configured Orbit");
+
+    assert_eq!(
+        env[0],
+        ("ORBIT_BIN".to_string(), "/opt/orbit/bin/orbit".to_string())
+    );
+    let pinned = &env[1].1;
+    assert_eq!(
+        std::env::split_paths(std::ffi::OsStr::new(pinned)).collect::<Vec<_>>(),
+        vec![
+            std::path::PathBuf::from("/opt/orbit/bin"),
+            std::path::PathBuf::from("/home/test/.cargo/bin"),
+            std::path::PathBuf::from("/usr/bin"),
+        ]
+    );
 }
 
 #[test]

--- a/crates/orbit-remote/src/tests/host_identity.rs
+++ b/crates/orbit-remote/src/tests/host_identity.rs
@@ -149,6 +149,23 @@ fn incomplete_current_schema_file_is_rejected() {
 }
 
 #[test]
+fn schema_v2_identity_is_accepted_as_the_current_on_disk_format() {
+    assert_eq!(HOST_IDENTITY_SCHEMA_VERSION, 2);
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_current\"\nhost_id = \"dk-server-1\"\ntask_prefix = \"DE\"\n",
+    )
+    .expect("write schema-v2 identity");
+
+    let identity = load_host_identity(dir.path()).expect("schema v2 must load");
+    assert_eq!(identity.schema_version, 2);
+    assert_eq!(identity.machine_id, "hm_current");
+    assert_eq!(identity.host_id, "dk-server-1");
+    assert_eq!(identity.task_prefix, "DE");
+}
+
+#[test]
 fn transport_shaped_machine_id_is_rejected_without_rewriting_host_identity() {
     for machine_id in ["dk1", "user@dk1", "ssh:dk1", "hm_ssh:dk1", "/tmp/hub"] {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -184,7 +201,13 @@ fn future_schema_version_fails_closed_without_rewrite() {
     let dir = tempfile::tempdir().expect("tempdir");
     let body = "schema_version = 3\nmachine_id = \"hm_future\"\nhost_id = \"dk-server-1\"\ntask_prefix = \"DE\"\n";
     std::fs::write(dir.path().join("host.toml"), body).expect("write");
-    inspect_host_identity(dir.path()).expect_err("future schema must fail closed");
+    let error = inspect_host_identity(dir.path())
+        .expect_err("future schema must fail closed")
+        .to_string();
+    assert!(error.contains("unsupported schema_version 3"), "{error}");
+    assert!(error.contains("supports up to 2"), "{error}");
+    assert!(error.contains("Upgrade Orbit"), "{error}");
+    assert!(error.contains("file is left unchanged"), "{error}");
     // The file is left untouched (never rewritten by a read).
     assert_eq!(
         std::fs::read_to_string(dir.path().join("host.toml")).expect("read"),

--- a/docs/runbooks/upgrades.md
+++ b/docs/runbooks/upgrades.md
@@ -84,5 +84,20 @@ After reviewing the dry run:
 4. Run `orbit doctor` and require all relevant checks to pass.
 5. Restart any independently managed dashboard process after swapping the binary.
 
+Agent subprocesses inherit an `ORBIT_BIN` pinned to the Orbit executable that dispatched
+them, and that executable's directory is placed first on their `PATH`. An operator-set
+`ORBIT_BIN` takes precedence. After replacing `~/.orbit/bin/orbit`, restart long-lived Orbit
+services and pipeline workers so newly dispatched agents inherit the replacement build. Verify
+both the explicit path and the ordinary command resolve the same tool-capable binary:
+
+```sh
+~/.orbit/bin/orbit tool run orbit.task.show --input '{"id":"<real-task-id>","model":"codex"}'
+command -v orbit
+orbit tool run orbit.task.show --input '{"id":"<real-task-id>","model":"codex"}'
+```
+
+If `~/.orbit/host.toml` uses a schema newer than an installed binary supports, upgrade and
+restart that binary. Never edit `schema_version` downward to bypass the guard.
+
 See [Check Orbit health](./health-checks.md) for `orbit doctor` and dashboard-readiness
 semantics. If verification fails, stop writers and restore the backups before further recovery.


### PR DESCRIPTION
## Task

[ORB-10747](https://orbit-cli.com/tasks/ORB-10747) — Fix Orbit host.toml schema_version=2 rejection under sandboxed implement (F2026-08-068)

### Description

## Problem
Sandboxed ship implement (and some CLI paths) fail `orbit tool run` with:

```
host identity '~/.orbit/host.toml' has unsupported schema_version 2;
this build supports up to 1. Upgrade Orbit; the file is left unchanged
```

On dk-server-1, `~/.orbit/host.toml` correctly has `schema_version = 2` (ORB-10721 machine identity). Source on `agent-main` already sets `HOST_IDENTITY_SCHEMA_VERSION = 2` in `orbit-remote` host identity. Agents then fail closed (`orbit_tool_unavailable`) instead of implementing tasks.

Durable record: **F2026-08-068** (filed 2026-08-12; Opus co-signed CLI-side corroboration). Bridge implementer also claimed F2026-08-004 for the same class but that id did not land in the friction store.

### Evidence (2026-08-12 Grok compatibility wave)
- ORB-10740 `jrun-20260812-0345-3`: codex under bwrap; first `orbit tool` failed schema 2 vs supports-up-to-1; implement envelope failed. Stdout blob `aee3313dc6ccf91f464815903d9f8829521fb145971f5690df31bbd271cf37f1`.
- ORB-10743 polaris: same error once, recovered via full-path `~/.orbit/bin/orbit` (path/binary selection sensitive).
- Outside sandbox, the same installed binary can accept schema 2 (normal tool errors), so this is **not** "host.toml is wrong" — it is **which Orbit binary / env the sandboxed process sees**.

### Observed host state at report time
- `~/.orbit/host.toml`: schema_version = 2
- `~/.orbit/bin/orbit` ↔ `codebases/orbit/target/release/orbit` byte-identical, `orbit 0.10.0`
- Still saw "supports up to 1" inside bwrap implement — implies stale/alternate binary on PATH, wrong ORBIT_BIN/HOME, or a code path not using the deployed binary

## Why It Matters
Fleet gate: every sandboxed implement that needs Orbit tools can fail closed or thrash. Cost on one wave: failed first ships, re-ships, shepherd out-of-band completion. Routing around (hand-edit tasks, ad-hoc checkout binaries) hides the gate.

## Constraints / Notes
- **Do not** "fix" by downgrading `host.toml` to schema_version 1 without an explicit migration ADR/decision — schema 2 is intentional.
- Prefer reconciling **deployed + sandboxed** Orbit so schema 2 is accepted end-to-end.
- Diagnose before coding: prove which `orbit` binary and which host.toml path bwrap implement actually uses (argv audit, `which orbit`, file identity).
- If the product binary already supports schema 2, the fix may be primarily deploy/sandbox PATH wiring plus a regression test that would have caught the fleet failure mode.
- If a residual code path still clamps to schema 1, fix and test that path.
- Deploy via the constellation Orbit update path after merge (not only a local `cargo build`); record post-deploy proof on dk-server-1.
- Resolves F2026-08-068 when done.

## Out of scope
- Changing task pipeline semantics unrelated to host identity / binary selection
- Broad sandbox redesign unless required to fix binary/host resolution

### Acceptance Criteria

- Root cause documented in the execution summary: which binary path + host.toml path sandboxed `orbit tool` used when the "supports up to 1" error fired (or proof the error is no longer reproducible after the fix).
- After the fix (and deploy of the fixed Orbit to the box), a sandboxed or ship-equivalent `orbit tool run orbit.task.show` (or minimal equivalent) against a real task id succeeds without host-identity schema rejection when `~/.orbit/host.toml` has schema_version = 2.
- No "fix" that permanently downgrades host.toml to schema_version 1; schema 2 remains the supported on-disk format.
- Regression coverage: unit and/or integration test that a schema_version=2 host identity is accepted by the build that ships, and that a future-schema version still fails closed with the upgrade message.
- If the failure was deploy/PATH/ORBIT_BIN under bwrap: the sandbox or executor wiring is corrected so implement agents resolve the same Orbit binary operators expect (`~/.orbit/bin/orbit` or the configured ORBIT_BIN), with a short note in docs or runbook if operators must redeploy.
- F2026-08-068 is resolved (via task relation or explicit friction update) with a pointer to the fix commit/PR and deploy evidence.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Root cause proved: inside this implement environment, `command -v orbit` selected stale `~/.cargo/bin/orbit` (SHA-256 `a489ebdf6cb95fa06c0f4e8296eb48b1a40fed88c6bed328f4ff3ecf25be24be`, mtime 2026-08-11T03:12:13Z). That binary read `~/.orbit/host.toml` and reproduced `schema_version 2 ... supports up to 1`. The operator binary `~/.orbit/bin/orbit` (SHA-256 `7d405ca3d2bbda9856a581c0435cb2a6c35f11d5276b90914082ddc5017bef40`, mtime 2026-08-12T05:41:30Z) successfully ran `orbit.task.show` against ORB-10747 with the same schema-v2 host identity.
- Agent CLI dispatch now exports `ORBIT_BIN` as the dispatching Orbit executable, or honors an explicit parent `ORBIT_BIN`, and prepends that binary directory to child `PATH`. This reaches bare and linux-bwrap spawn paths through the existing child environment.
- Added regression tests for stale-PATH correction, explicit ORBIT_BIN precedence and PATH deduplication, literal schema-v2 acceptance, and the future-schema fail-closed upgrade message.
- Updated the upgrade runbook with restart and binary-resolution verification guidance; schema 2 remains the supported on-disk format and no migration/downgrade was introduced.
- Added a `resolves` relation from ORB-10747 to F2026-08-068; it will auto-resolve when delivery marks the task done.

Assessment: The fix is narrow to agent subprocess binary selection and preserves the existing host-identity schema guard. All modified files are recorded in context_files.

Validation:
- `cargo test -p orbit-engine activity_job::cli_runner::tests::spawn -- --nocapture`: 13 passed.
- `cargo test -p orbit-remote host_identity -- --nocapture`: 16 passed.
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- Built `target/debug/orbit`, then ran a ship-equivalent pinned environment with `PATH=<worktree>/target/debug:...` and `ORBIT_BIN=<worktree>/target/debug/orbit`; bare `orbit tool run orbit.task.show` succeeded for ORB-10747 against `~/.orbit/host.toml` schema 2.
- A manual Bubblewrap equivalent was attempted but the host denied namespace creation: `bwrap: No permissions to create new namespace, likely because the kernel does not allow non-privileged user namespaces.` Per execution policy this is a runner denial, not a code failure; unrestricted/deployed verification remains for delivery.
- `git diff --check`: passed.

Deviations from original plan:
- No source change was needed in `host_identity.rs`; it already supports schema 2. Only its sibling regression test changed.
- Deployment, commit/PR pointer, and post-deploy service restart evidence are intentionally pending the pipeline delivery stages because this executor is not authorized to commit or deploy.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10747-6a7c07d5`
- Behind base: 0
- Ahead of base: 1