### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/POSITIONING.md
+++ b/docs/POSITIONING.md
@@ -1,3 +1,9 @@
+---
+type: context
+summary: "Orbit Positioning"
+last_validated: 2026-08-13
+---
+
 # Orbit Positioning
 
 This document names what Orbit is for, who it's for, and what it deliberately isn't. Use it as a decision lens — when a design debate feels like it's really about *what Orbit is for*, reference this doc instead of re-litigating case by case.

--- a/docs/design/project-learnings/1_overview.md
+++ b/docs/design/project-learnings/1_overview.md
@@ -4,6 +4,7 @@ type: design
 title: "Project Learnings — Overview"
 owner: claude
 last_updated: 2026-08-10
+last_validated: 2026-08-13
 status: Draft
 feature: project-learnings
 doc_role: overview
@@ -14,7 +15,7 @@ tags: ["project-learnings"]
 
 Project learnings is a system for preserving and surfacing non-obvious project knowledge — gotchas, root causes from incidents, validated approaches, hard-won workflow insights — so agents can retrieve and apply them when they are relevant. Delivery combines push and pull: engine pre-prompt injection and an MCP sidecar decorator push scope-matched learnings into every agent run automatically (source locations: [4_decisions.md ADR-0108 amendment](./4_decisions.md)), and agents can also pull with `orbit search` and open the full record with `orbit learning show`. Point-of-use reference comments make the relevant artifact discoverable in the code as a lighter-weight locator alongside both.
 
-Phase 1 ships the native primitive (`learning` resource type alongside `task`), the pull surface, and the reference-comment convention. Phase 2, deferred until [docs/design/orbit-search/](../orbit-search/) reaches Accepted, layers semantic-similarity ranking on top of the path-glob scoping that phase 1 uses.
+Phase 1 ships the native primitive (`learning` resource type alongside `task`), the pull surface, and the reference-comment convention. The unified search surface now also supports opt-in semantic-similarity ranking for indexed learnings; symbol-aware scope remains future work.
 
 This document is the entry point. [2_design.md](./2_design.md) specifies the storage schema, pull-delivery mechanism, lifecycle, and surface; [3_vision.md](./3_vision.md) names open questions and prior art; [4_decisions.md](./4_decisions.md) is the ADR log.
 
@@ -41,7 +42,7 @@ The hard constraint that shapes the design: **the system must be discoverable ac
 A first-class Orbit resource, parallel to `task`. Each record carries:
 
 - `id` — `L-NNNN`, allocated per workspace by the owning machine. Unique within `(workspace_id, id)`, not globally, and unlike task IDs it carries no machine prefix.
-- `scope` — what triggers the learning. Phase 1: path globs + tags. Phase 2 will layer semantic similarity on top ([4_decisions.md ADR-004](./4_decisions.md)).
+- `scope` — what triggers the learning: path globs + tags. The unified search surface can add opt-in semantic similarity after learnings are indexed; symbol-aware scope remains future work.
 - `summary` — one-line rule of thumb displayed in a concise search result.
 - `body` — multi-line markdown: the rule, the reason, how to apply it.
 - `evidence` — commit SHAs, task IDs, or external refs that produced the learning.
@@ -50,7 +51,7 @@ A first-class Orbit resource, parallel to `task`. Each record carries:
 - `supersedes` — back-reference when a newer learning replaces an older one.
 - `created_by`, `created_at`, `updated_at` — provenance.
 
-Records persist as YAML on disk under `.orbit/learnings/<id>/learning.yaml`, with sidecars such as `votes.jsonl` living beside the YAML. Workspace-scoped per the Scoping Rules table in [CLAUDE.md](../../../CLAUDE.md), and checked into git so learnings travel with the repo ([4_decisions.md ADR-003](./4_decisions.md)).
+Records persist as YAML on disk under `.orbit/learnings/<id>/learning.yaml`, with no per-learning sidecar in the common layout. Workspace-scoped per the Scoping Rules table in [CLAUDE.md](../../../CLAUDE.md), and checked into git so learnings travel with the repo ([4_decisions.md ADR-003](./4_decisions.md)).
 
 ### 2.2 Pull-based discovery and reference comments
 
@@ -68,11 +69,11 @@ is human-or-agent-driven; the system does not auto-delete.
 
 | Phase | Scope axis | Ranking | Discovery |
 |-------|-----------|---------|-----------|
-| **Phase 1** | path globs + tags | manual priority + recency | `orbit search` / `orbit learning show` + reference comments |
-| **Phase 2** | path globs + tags | + semantic similarity (orbit-search) | improved pull ranking |
+| **Current** | path globs + tags | lexical priority + recency, or optional lexical/semantic hybrid | `orbit search` / `orbit learning show` + reference comments |
+| **Future** | path globs + tags + symbol IDs | improved symbol-aware retrieval | symbol-aware scope |
 
-Phase 2 is gated on [docs/design/orbit-search/](../orbit-search/) reaching
-Accepted because the relevance-ranking layer wants real semantic similarity.
+Symbol-aware scope remains gated on a future design because the current learning
+index has no live symbol resolver.
 
 ---
 

--- a/docs/design/project-learnings/2_design.md
+++ b/docs/design/project-learnings/2_design.md
@@ -4,6 +4,7 @@ type: design
 title: "Project Learnings — Design"
 owner: claude
 last_updated: 2026-08-10
+last_validated: 2026-08-13
 status: Draft
 feature: project-learnings
 doc_role: design
@@ -12,9 +13,9 @@ tags: ["project-learnings"]
 
 # Project Learnings — Design
 
-This document specifies phase-1 project-learnings: the placement of learning storage in `orbit-store`, the schema of a learning record plus sidecars, the phase-1 scope-matching algorithm (path globs + tags), pull-based discovery through search and show, the reference-comment convention, the curation lifecycle, and the concerns the design deliberately leaves to follow-ups.
+This document specifies project-learnings: the placement of learning storage in `orbit-store`, the schema of a learning record, path-glob and tag scope matching, pull-based discovery through search and show, optional hybrid semantic ranking, the reference-comment convention, the curation lifecycle, and the concerns the design deliberately leaves to follow-ups.
 
-Phase 2 (semantic ranking, symbol-aware scope) is out of scope for this document and is captured in [3_vision.md §1.2](./3_vision.md). The schema in [§2](#2-learning-record-schema) is forward-compatible with phase 2.
+Symbol-aware scope remains out of scope and is captured in [3_vision.md §1.1](./3_vision.md). The schema in [§2](#2-learning-record-schema) remains forward-compatible with it; semantic ranking is available through opt-in hybrid search.
 
 ---
 
@@ -28,10 +29,10 @@ orbit-store/
 │   ├── task_store/        # existing
 │   └── learning_store/    # new — YAML + index, mirrors task_store
 └── sqlite/
-    └── learnings.rs       # new — index for fast scope-glob lookups
+    └── learning_index.rs  # index for fast scope-glob lookups
 ```
 
-`orbit-tools` gains a `learning::` submodule that exposes `orbit.learning.add | list | search | show | update | supersede | upvote` as MCP tools. `orbit-cli` exposes the corresponding `orbit learning <subcommand>` shell surface.
+`orbit-tools` exposes the active learning tools `orbit.learning.add | show | update | supersede | archive`; the registered `list`, `prune`, and `sync` tools are inactive on the agent-facing surface and remain available through the CLI for operator workflows. `orbit-cli` exposes the corresponding `orbit learning <subcommand>` shell surface.
 
 `orbit.search` and `orbit.learning.show` are the delivery surface. Search returns candidate records without expanding their bodies; `show` returns the authoritative body and records a passive `learning_shown` usage event. Code and workflow boundaries can point to a relevant record with a concise reference comment, keeping the rationale close to use without copying durable content into the source.
 
@@ -43,7 +44,7 @@ No cross-crate dependencies that violate the architecture diagram in [CLAUDE.md]
 
 ### 2.1 On-disk format
 
-Each learning owns a directory under `.orbit/learnings/<id>/`, mirroring the task bundle layout. The source-of-truth YAML lives at `.orbit/learnings/<id>/learning.yaml`; per-learning sidecars such as `votes.jsonl` live beside it without polluting the root:
+Each learning owns a directory under `.orbit/learnings/<id>/`, mirroring the task bundle layout. The source-of-truth YAML lives at `.orbit/learnings/<id>/learning.yaml`; the common layout has no per-learning sidecar:
 
 ```yaml
 id: L-0001
@@ -119,7 +120,7 @@ Query path: filter to the runtime's own `workspace_id` and `status = 'active'`, 
 
 The YAML files are the source of truth. The index is rebuildable from them via `orbit learning sync`.
 
-Vote rows are source-of-truth sidecars, not SQLite projections in v1. `orbit learning sync` still walks every per-learning `votes.jsonl` and fails on invalid JSONL, so cache rebuilds do not silently ignore corrupted vote files.
+The SQLite index is a projection, not the source of truth. `orbit learning sync` rebuilds it from the YAML records.
 
 ### 2.3 ID format
 
@@ -186,8 +187,8 @@ orbit learning show <id>                  # loads the full body; emits a learnin
 orbit learning update <id> [--summary ...] [--body-file ...] [--scope ...]
 orbit learning supersede <id> --with <new-id>
 orbit learning archive <id>               # retire a single learning without a replacement [ORB-10469]
-orbit learning upvote --id <id> --model <agent-family> --task <task-id>
 orbit learning sync                       # reconcile SQLite index from YAML
+orbit learning migrate-layout [--confirm]  # migrate legacy flat YAML files
 orbit learning prune [--stale-only]       # report or delete stale learnings
 orbit learning stats [--since 30d]        # per-learning injected/shown usage rollup (see §5.5)
 
@@ -196,7 +197,7 @@ orbit search <text> --kind learning [--tag T] [--all] [--status learning:active]
 orbit search path <path> --kind learning [--tag T] [--all] [--status learning:active]
 ```
 
-`add`, `update`, and `supersede` write the YAML and update the index atomically. `upvote` appends to the learning's `votes.jsonl` sidecar and is idempotent for `(learning_id, voter_model, task_id)`. `orbit learning list --path/--tag` and `orbit search --kind learning` are the indexed read paths used for pull discovery.
+`add`, `update`, `supersede`, and `archive` write the YAML and update the index atomically. `orbit learning list --path/--tag` and `orbit search --kind learning` are the indexed read paths used for pull discovery; `orbit search --hybrid --kind learning` can add semantic ranking after the learning vector index is built.
 
 **Authoring is role-gated ([ADR-0250], [ORB-10364]; extended to `archive` by [ORB-10469]).** `add`, `update`, `supersede`, and `archive` — and only those four — refuse callers running in an agent-executor context, returning a `policy denied` error that names `orbit friction add` as the correct channel and echoes the attempted content so the observation is not lost. The role comes from the `ORBIT_AGENT_NAME` / `ORBIT_AGENT_MODEL` identity pair the audit middleware already reads: present ⇒ agent, absent ⇒ human. An orchestrator that dispatches curation work *as* an agent opts in deliberately with `ORBIT_LEARNING_AUTHOR=1`. Every read surface, plus `sync`, `prune`, and `stats`, is unaffected in every context.
 
@@ -205,15 +206,13 @@ orbit search path <path> --kind learning [--tag T] [--all] [--status learning:ac
 | Tool | Inputs | Outputs |
 |------|--------|---------|
 | `orbit.learning.add` | `summary`, `scope`, `body?`, `evidence?` | `{ id, created_at }` |
-| `orbit.learning.list` | `status?`, `tag?`, `path?` (glob-containment) | `{ learnings: [...] }` |
 | `orbit.search` (`kind: "learning"`) | `query?`, `tag?`, `path?`, `limit?`, `all?`, `status?` | ranked list with `kind: "learning"` hits |
-| `orbit.learning.show` | `id` | full record plus vote summary |
+| `orbit.learning.show` | `id` | full record |
 | `orbit.learning.update` | `id`, fields | updated record |
 | `orbit.learning.supersede` | `id`, `with` | both records updated |
 | `orbit.learning.archive` | `id` | retired record; idempotent on an already-superseded `id` ([ORB-10469]) |
-| `orbit.learning.upvote` | `id`, `model`, `task?` | vote summary |
 
-`orbit.learning.list` and `orbit.search` are the primary discovery paths; both must stay sub-10ms at expected scale. The standalone per-domain learning-search MCP tool (phase-1 surface) was retired by [ORB-00202] in favor of `orbit.search` with `kind: "learning"`.
+The CLI `orbit learning list` and unified `orbit.search` are the primary discovery paths; the sidecar uses the registered list operation for path applicability. Both indexed paths must stay sub-10ms at expected scale. The standalone per-domain learning-search MCP tool was retired by [ORB-00202] in favor of `orbit.search` with `kind: "learning"`.
 
 `orbit.learning.add`, `orbit.learning.update`, `orbit.learning.supersede`, and `orbit.learning.archive` carry the same [ADR-0250] caller-role gate as their CLI counterparts — the check lives on the shared `OrbitRuntime::author_learning*` surface, so the two entry points cannot drift. A refused tool call returns `{"code": "policy_denied", "error": ...}` and writes nothing.
 
@@ -235,31 +234,9 @@ orbit search path <path> --kind learning [--tag T] [--all] [--status learning:ac
 
 `matched_by` is exposed deliberately: agents can see which scope axis triggered the match, which feeds back into both human curation (is the path glob right?) and future ranking work.
 
-### 5.4 Re-validation votes
+### 5.4 Re-validation and correction
 
-When an agent finds an existing learning that covers a duplicate concern, it records a re-validation signal instead of authoring a competing record:
-
-```jsonc
-{
-  "learning_id": "L-0001",
-  "voter_model": "claude",
-  "voted_at": "2026-05-17T12:00:00Z",
-  "task_id": "ORB-00095"
-}
-```
-
-Rows append to `.orbit/learnings/<id>/votes.jsonl` using `O_APPEND`; each learning has its own file and lock, so cross-learning contention is zero. V1 rejects free-floating votes without `task_id` to keep the signal anchored to a concrete work context. Duplicate rows with the same `(learning_id, voter_model, task_id)` are treated as one vote, preserving the earliest timestamp for that key.
-
-`orbit.learning.show` reports derived vote fields: `vote_count` and `last_voted_at`. `orbit.learning.list` and `orbit.search` (with `kind: "learning"`) keep their envelope output shape unchanged.
-
-Search ranking remains scope-filtered first. Within the matched set, rows sort by:
-
-1. decay-weighted vote score, default half-life 180 days;
-2. manual `priority`;
-3. `updated_at` desc;
-4. `id` asc.
-
-`ORBIT_LEARNING_VOTE_HALF_LIFE_DAYS=0` disables decay and uses raw vote count. Vote files are scanned at query time in v1; a SQLite vote-summary mirror is a follow-up only if measured matched-set sizes make the per-file scan visible.
+The former task-anchored vote and comment sidecars were removed by ADR-0210. Agents retrieve a candidate with `orbit learning show`, and corrections go through `orbit learning update` or `orbit learning supersede` with structured evidence; executor observations belong in `orbit friction add`.
 
 ### 5.5 Usage instrumentation and feedback
 
@@ -276,11 +253,11 @@ Two audit event kinds in the host-global `~/.orbit/orbit.db` describe historical
 
 ## 6. Pull Surface
 
-### 6.1 `orbit-learnings` skill
+### 6.1 Knowledge and search skills
 
-A skill at `.claude/skills/orbit-learnings/` (and the equivalent location for other agent vendors) exists for the active-query path. Trigger phrases include "what should I know about", "are there learnings for", "is there context I'm missing on". The skill body documents how to call `orbit.search` (with `kind: "learning"`) and how to interpret results.
+The bundled `orbit-search` skill documents the active-query path, including `orbit.search` with `kind: "learning"` and `--hybrid` retrieval. The bundled `orbit-knowledge` skill covers learning authoring and curation. Trigger phrases include "what should I know about", "are there learnings for", and "is there context I'm missing on".
 
-The skill is the primary delivery path for agents that need guidance at task start or while reviewing an unfamiliar area. A nearby reference comment supplies the same pointer at a specific code or workflow boundary.
+These skills support agents that need guidance at task start or while reviewing an unfamiliar area. A nearby reference comment supplies the same pointer at a specific code or workflow boundary.
 
 ### 6.2 Direct tool use
 
@@ -304,7 +281,7 @@ The dashboard is a pull and curation surface. It lets operators scan stale or du
 
 Learnings are authored by:
 
-- Agents at the end of a task — when an agent recognizes "this is the kind of correction that will keep happening." The `orbit-learnings` skill covers the `orbit.learning.add` flow.
+- Agents at the end of a task — when an agent recognizes "this is the kind of correction that will keep happening." The `orbit-knowledge` skill covers the `orbit.learning.add` flow.
 - Humans during code review or after incidents — same surface, manual invocation.
 
 The bar for authoring: the knowledge must be **non-obvious** (otherwise it lives in code), **not-feature-scoped** (otherwise it's an ADR), and **load-bearing across more than one task** (otherwise it's a comment in a single PR).
@@ -357,11 +334,11 @@ This is distinct from `orbit learning archive` ([§7.2.1](#721-archival-retireme
 
 ### 7.4 Conflict resolution
 
-Two agents (or two humans) may author overlapping learnings concurrently. Phase 1 does not auto-merge; the curation answer is "humans review and supersede one with the other when the duplication surfaces." `orbit learning list --tag <tag>` is the manual surface for spotting duplicates. Phase 2's semantic-similarity ranking can surface near-duplicates during search.
+Two agents (or two humans) may author overlapping learnings concurrently. The system does not auto-merge; the curation answer is "humans review and supersede one with the other when the duplication surfaces." `orbit learning list --tag <tag>` is the manual surface for spotting duplicates. Hybrid search can also surface semantically related records when the learning index is available.
 
 ### 7.5 Re-validation without re-authoring
 
-When a duplicate concern is already covered by an active learning, the agent should upvote the existing record instead of creating a near-duplicate. The vote says "this learning is still load-bearing in a new task context" and improves search ranking without changing the learning body or `updated_at`.
+When a duplicate concern is already covered by an active learning, the agent should reference the existing record rather than create a near-duplicate. If the guidance is wrong or materially changed, use `orbit learning update` or `orbit learning supersede` with evidence; there is no vote or comment sidecar.
 
 ### 7.6 Recurring deprecation review (auto-task)
 
@@ -389,7 +366,7 @@ The definition is ordinary workspace data (`no-diff-expected` + `artifact-deprec
 
 ### 8.1 Authoring discipline is the bottleneck
 
-The system can be perfect at storing learnings and still fail if no one writes or discovers them. The `orbit-learnings` skill, reference comments, and the agent-self-authoring flow are the primary remediations, but none is automatic. If authoring lags, the store stays sparse.
+The system can be perfect at storing learnings and still fail if no one writes or discovers them. The `orbit-knowledge` and `orbit-search` skills, reference comments, and the agent-self-authoring flow are the primary remediations, but none is automatic. If authoring lags, the store stays sparse.
 
 This is acknowledged, not fixed. Phase 2's auto-extraction from review threads or postmortems may help; phase 1 ships with manual authoring and accepts the discipline cost.
 
@@ -401,11 +378,9 @@ The mitigation is operational: when a refactor moves files, run
 `orbit learning prune --stale-only` and update or supersede affected records as
 part of the refactor task.
 
-### 8.3 Vote ranking still depends on agent discipline
+### 8.3 Hybrid ranking depends on optional indexing
 
-Phase 1 ranks matched learnings by decayed upvotes before falling back to manual priority and recency. This is better than recency-only ranking, but it depends on agents recording votes only when they have genuinely evaluated a duplicate concern. Over-eager upvoting would make the signal noisy. The v1 mitigations are task-anchored idempotency and time decay, not a full abuse-prevention system.
-
-Phase 2's semantic-similarity ranking from orbit-search may complement or replace parts of this formula; vote score is a load-bearing signal, not the whole relevance model.
+The indexed lexical path ranks learnings by priority, recency, and stable ID. Opt-in hybrid search adds semantic similarity after `orbit semantic index --kind learnings`; it depends on the local companion and available vectors, and falls back to lexical results when semantic retrieval is unavailable.
 
 ### 8.4 Pull delivery requires a useful locator
 

--- a/docs/design/project-learnings/3_vision.md
+++ b/docs/design/project-learnings/3_vision.md
@@ -4,6 +4,7 @@ type: design
 title: "Project Learnings — Vision"
 owner: claude
 last_updated: 2026-08-10
+last_validated: 2026-08-13
 status: Draft
 feature: project-learnings
 doc_role: vision
@@ -33,29 +34,29 @@ symbol resolver. Reasons the field remains inactive:
 
 **Cost of deferring:** every refactor that moves files requires manual `orbit learning prune` or `update` calls. At low learning volume that's tolerable; at higher volume it becomes drag.
 
-### 1.2 Semantic-similarity ranking (deferred to phase 2)
+### 1.2 Semantic-similarity ranking and remaining gaps
 
-Phase 1 ranks matched learnings by `updated_at` desc, with optional manual `priority` tagging ([2_design.md §8.3](./2_design.md)). This is wrong in predictable ways:
+The indexed lexical path ranks matched learnings by priority and recency, while opt-in hybrid search can add semantic similarity after learnings are indexed ([2_design.md §8.3](./2_design.md)). The remaining gaps are predictable:
 
 - An old, important learning loses to a recent, marginal one.
-- A query that's semantically related to a learning but doesn't match its path globs gets nothing.
-- Multiple matched learnings with the same path scope all rank by date, with no signal about which is most relevant to the *current* edit.
+- A query that's semantically related to a learning gets no semantic result unless the learning vector index has been built.
+- Lexical and semantic candidates can still differ in quality for the *current* query, especially when the local companion or vectors are unavailable.
 
-[docs/design/orbit-search/](../orbit-search/) builds the infrastructure that resolves all three: per-field embeddings, brute-force cosine, RRF fusion. Phase 2 of project-learnings layers on top of that:
+[docs/design/orbit-search/](../orbit-search/) provides per-field embeddings, cosine retrieval, and hybrid fusion. The current learning search path uses that infrastructure:
 
 - Each learning's `summary` and `body` are embedded under the same `embeddings` table orbit-search uses (`source_kind = "learning"`).
-- Search-time ranking unions path-glob matches with cosine matches against the query and selected path context, fused via RRF.
-- Manual `priority` becomes a soft signal in fusion, not a hard tier.
+- Search-time ranking combines lexical candidates with cosine matches against the query, then applies the requested path and tag filters.
+- Manual `priority` orders the lexical store results; hybrid ranking blends normalized lexical and semantic scores.
 
-The phase-2 design lands as its own task once orbit-search reaches Accepted. The schema reservation in phase 1 is a `scope.semantic_seed` field — short text describing what the learning is "about" — that becomes the embedding source for phase 2.
+The remaining follow-up is symbol-aware scope. `scope.semantic_seed` remains a forward-compatible field, while current learning embeddings use the summary, body sections, and tags.
 
-**Cost of deferring:** the phase-1 ranking is a placeholder. Users will likely hit the recency-blindness failure mode before phase 2 ships, and the documented mitigation is "use `--limit 5` and let humans curate."
+**Cost of the remaining gap:** semantic retrieval requires an explicit local index and companion, while symbol-aware scope would add resolver and lifecycle complexity. Lexical search remains the fallback when semantic retrieval is unavailable.
 
 ### 1.3 Authoring incentives and lag
 
 The whole system depends on someone writing the learnings. Phase 1 ships:
 
-- An `orbit-learnings` skill that walks an agent through authoring at task close.
+- The bundled `orbit-knowledge` skill for learning authoring and curation, alongside `orbit-search` for retrieval.
 - A CLI/MCP surface for direct invocation.
 - A hand-curation expectation: humans write learnings during PR review or after incidents.
 
@@ -176,12 +177,12 @@ indexer.
 ### 4.1 Orbit-internal
 
 - [docs/design/CONVENTIONS.md](../CONVENTIONS.md) — folder layout, frontmatter, ADR template.
-- [docs/design/orbit-search/](../orbit-search/) — phase 2 dependency for semantic-similarity ranking.
+- [docs/design/orbit-search/](../orbit-search/) — local semantic-index and hybrid-ranking implementation used by learning search.
 - [docs/design/_archive/knowledge-graph/](../_archive/knowledge-graph/) —
   historical context for the retired symbol-aware proposal.
 - [docs/design/_archive/task-sync/](../_archive/task-sync/1_overview.md) — relevant for whether learnings should sync across machines (decision: yes, via the same checked-in path tasks use). Archived; superseded by [remote-access](../remote-access/1_overview.md).
 - [CLAUDE.md](../../../CLAUDE.md) — friction-reports section is the closest existing precedent for agent-authored project artifacts.
-- `orbit-create-task` skill (`~/.claude/skills/orbit-create-task/`) — the authoring shape `orbit-learnings` will mirror.
+- `orbit-knowledge` skill — the bundled authoring shape for durable project learnings.
 
 ### 4.2 External
 

--- a/docs/design/project-learnings/4_decisions.md
+++ b/docs/design/project-learnings/4_decisions.md
@@ -4,6 +4,7 @@ type: design
 title: "Project Learnings — Decisions"
 owner: claude
 last_updated: 2026-08-11
+last_validated: 2026-08-13
 status: Draft
 feature: project-learnings
 doc_role: decisions

--- a/docs/design/project-learnings/references/glossary.md
+++ b/docs/design/project-learnings/references/glossary.md
@@ -1,3 +1,9 @@
+---
+type: glossary
+summary: "Glossary: Project Learnings"
+last_validated: 2026-08-13
+---
+
 # Glossary: Project Learnings
 
 Project-specific vocabulary used in [1_overview.md](../1_overview.md), [2_design.md](../2_design.md), [3_vision.md](../3_vision.md), and [4_decisions.md](../4_decisions.md). Standard industry terms (glob, YAML, SQLite, MCP) are excluded unless this feature gives them a specific meaning.


### PR DESCRIPTION
## Task

[ORB-10735](https://orbit-cli.com/tasks/ORB-10735) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Batch selection: the six never-validated in-scope docs sorted first by missing `last_validated`, with stable path tie-break: `docs/POSITIONING.md`, `docs/design/project-learnings/1_overview.md`, `docs/design/project-learnings/2_design.md`, `docs/design/project-learnings/3_vision.md`, `docs/design/project-learnings/4_decisions.md`, and `docs/design/project-learnings/references/glossary.md). The other in-scope docs were dated, so none was selected.
- `docs/POSITIONING.md`: verified its positioning and OSS/self-hosted claims against the document itself and repository structure with `sed -n '1,260p' docs/POSITIONING.md`, `rg --files docs`, and `git diff --check`. Added schema-compatible inferred `context` frontmatter with summary `Orbit Positioning` and stamped `last_validated: 2026-08-13`; no factual prose change was needed.
- `docs/design/project-learnings/1_overview.md`: verified storage layout and active delivery anchors with `rg --files crates/orbit-{cli,core,remote,search,store,tools}`, `rg -n` over learning/search sources, and the current skill files. Corrected stale sidecar and semantic-ranking statements, and stamped 2026-08-13.
- `docs/design/project-learnings/2_design.md`: verified current store filename/layout, CLI help, active/inactive MCP registration, semantic search implementation, bundled skills, and current learning types with `sed`, `rg`, `orbit learning --help`, and source reads of `crates/orbit-core/src/command/docs/frontmatter.rs`, `crates/orbit-core/src/command/docs/types.rs`, `crates/orbit-store/src/file/learning_store/layout/mod.rs`, `crates/orbit-store/src/file/learning_store/constants.rs`, `crates/orbit-core/src/command/learning.rs`, `crates/orbit-core/src/command/search/mod.rs`, `crates/orbit-core/src/command/search/hybrid.rs`, `crates/orbit-search/src/commands/learning_search.rs`, `crates/orbit-search/src/vector/learning_fields.rs`, `crates/orbit-tools/src/builtin/orbit/mod.rs`, and `crates/orbit-cli/src/command/learning/command.rs`. Removed obsolete vote/comment surface details, corrected the SQLite filename and skill/tool descriptions, documented hybrid search and migration, and stamped 2026-08-13.
- `docs/design/project-learnings/3_vision.md`: verified semantic-search scope and current bundled skills against `docs/design/orbit-search/1_overview.md`, `crates/orbit-core/src/command/search/mod.rs`, `crates/orbit-core/src/command/search/hybrid.rs`, `crates/orbit-search/src/commands/learning_search.rs`, and the two bundled skills. Updated the semantic-search section and skill reference to distinguish current hybrid retrieval from the remaining symbol-scope follow-up; stamped 2026-08-13.
- `docs/design/project-learnings/4_decisions.md`: read ADR-0210 and the corresponding accepted/superseded bodies under `.orbit/adrs/`, plus current source registrations, to verify the historical decision log. No historical ADR prose was rewritten; added only `last_validated`.
- `docs/design/project-learnings/references/glossary.md`: inferred `type: glossary` and summary `Glossary: Project Learnings` from the existing tolerant inference contract in `crates/orbit-core/src/command/docs/frontmatter.rs` and `types.rs`; verified all terms by reading the selected design docs and current source; added schema-compatible frontmatter and stamped 2026-08-13.
- No selected doc or claim was left unvalidated. No new document, section, metadata field, sidecar, or generated state was authored. No forbidden path changed.
Validation:
- `make ci-fast` passed (including fmt check, doc-index check, installer/security, dependency/import/terminal/stability/layout/redaction/changelog/error/orphan/asset/plugin guards). The redaction guard emitted expected missing-path warnings for removed ADR tool paths but exited successfully.
- `git diff --check` passed. Final diff contains only the six selected docs.
Assessment: success; changes are bounded to the selected rotation batch and align the project-learnings docs with the current implementation.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10735-6a7d2bcc`
- Behind base: 0
- Ahead of base: 1