### PR TITLE
Fix dashboard ship parity test losing seeded task under CI

### DIFF
--- a/crates/orbit-dashboard/src/api/tests/runs.rs
+++ b/crates/orbit-dashboard/src/api/tests/runs.rs
@@ -8,11 +8,13 @@ use axum::body::Body;
 use axum::http::{Method, Request, StatusCode, header};
 use axum::response::Response;
 use chrono::Utc;
+use orbit_common::types::{Workspace, WorkspaceCheckout, WorkspaceStatus};
 use orbit_common::utility::blob_store::BlobStore;
 use orbit_core::command::job::JobRunListParams;
 use orbit_core::command::task::TaskAddParams;
 use orbit_core::runtime::WorkspaceRuntimeBinding;
-use orbit_core::{JobRunState, OrbitRuntime, ShipMode, V2AuditEventInsertParams};
+use orbit_core::{JobRunState, OrbitRuntime, ShipMode, TaskStatus, V2AuditEventInsertParams};
+use orbit_remote::runtime::RemoteRuntimeFactory;
 use serde_json::{Value, json};
 use tower::ServiceExt;
 
@@ -1241,18 +1243,59 @@ async fn mcp_ship_tool_and_http_ship_endpoint_produce_equivalent_runs() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let global_root = tmp.path().join("global");
     std::fs::create_dir_all(&global_root).expect("create global root");
+    std::fs::write(
+        global_root.join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_ship_parity\"\nhost_id = \"ship-parity\"\ntask_prefix = \"TST\"\n",
+    )
+    .expect("write fixture host identity");
     write_replay_job_under(&global_root, "task_auto_pipeline");
     let (orbit_dir, repo_root) = seed_ship_workspace(tmp.path(), "alpha");
-    let runtime = OrbitRuntime::from_roots_with_binding(
-        &global_root,
-        &orbit_dir,
-        WorkspaceRuntimeBinding {
-            workspace_id: "ws_alpha".to_string(),
-            repo_root,
-            ship_mode: ShipMode::Local,
-        },
-    )
-    .expect("build bound runtime");
+    let workspace = Workspace {
+        id: "alpha".to_string(),
+        name: "alpha".to_string(),
+        owner_machine_id: Some("hm_ship_parity".to_string()),
+        git_remote: None,
+        ship_mode: Some("local".to_string()),
+        base_branch: "main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    let checkout = WorkspaceCheckout::owner(workspace.id.clone(), repo_root, orbit_dir);
+    let runtime =
+        RemoteRuntimeFactory::open_registered_checkout(&global_root, &workspace, &checkout)
+            .expect("build bound runtime");
+
+    // Ship validates every explicit task id before creating a run. Seed those
+    // records through the same workspace-bound runtime that both front doors
+    // receive, rather than relying on synthetic ids that exist in no store.
+    let allocator_seed = runtime
+        .add_task(TaskAddParams {
+            title: "ship parity allocator seed".to_string(),
+            description: "Reserves the first synthetic task id.".to_string(),
+            status: Some(TaskStatus::Backlog),
+            ..TaskAddParams::default()
+        })
+        .expect("seed task allocator");
+    assert_eq!(allocator_seed.id, "TST-00000");
+    for task_id in TOOL_TASK_IDS.into_iter().chain(HTTP_TASK_IDS) {
+        let task = runtime
+            .add_task(TaskAddParams {
+                title: format!("ship parity fixture {task_id}"),
+                description: "Task selected by one ship parity front door.".to_string(),
+                status: Some(TaskStatus::Backlog),
+                ..TaskAddParams::default()
+            })
+            .expect("seed selected ship task");
+        assert_eq!(task.id, task_id);
+        assert_eq!(
+            runtime
+                .get_task(task_id)
+                .expect("seeded task is visible")
+                .id,
+            task_id
+        );
+    }
 
     // Scoped to the synchronous tool call: the guard holds a process-wide lock,
     // which must not span an `.await`.


### PR DESCRIPTION
## Task

[ORB-10752](https://orbit-cli.com/tasks/ORB-10752) — Fix dashboard ship parity test losing seeded task under CI

### Description

## Problem

The `Check / Clippy / Test` check associated with PR #955 failed in `api::tests::runs::mcp_ship_tool_and_http_ship_endpoint_produce_equivalent_runs`: the tool-surface ship path returned `NotFound { kind: Task, id: "TST-00001" }` after the test seeded that task. The same targeted test reproduces on the current clean `agent-main` (`792f31d66b0a`) after ORB-10747 was merged and deployed.

This is not attributable to ORB-10747: that change touched agent CLI spawning, host-identity tests, and the upgrade runbook, while the failing test is in the dashboard ship parity fixture. PR #955's other substantive checks passed; informational coverage also failed separately during collection.

Evidence: https://github.com/danieljhkim/orbit/actions/runs/31568213673/job/94024418304

### Acceptance Criteria

- The targeted dashboard parity test passes reliably in isolation and in the full nextest CI run.
- The fixture's seeded TST-00001 task is visible to both MCP tool-surface and HTTP ship paths.
- Regression coverage explains and prevents the workspace/store mismatch or fixture-lifetime defect that caused NotFound.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Rebuilt the ship-parity fixture through `RemoteRuntimeFactory` with a deterministic `TST` host prefix and the selected workspace binding.
- Seeded `TST-00001` through `TST-00004` as backlog tasks in that exact runtime, and asserted each is readable before either MCP or HTTP dispatch. This prevents the former phantom-task fixture from returning `NotFound`.
- Kept both parity calls on clones of the same bound runtime, so their selected tasks and persisted runs share one store.
Assessment: The targeted regression now passes and directly verifies the workspace/store invariant.
Validation:
- Passed: `cargo nextest run -p orbit-dashboard mcp_ship_tool_and_http_ship_endpoint_produce_equivalent_runs` (1 passed).
- Passed: `cargo clippy -p orbit-dashboard --tests -- -D warnings`.
- Passed: `make ci-fast` (two pre-existing missing-path notices from `check-artifact-redaction-guardrail.sh` did not fail the target).
- Attempted twice: `cargo nextest run --workspace --lib --bins --tests`. Both attempts stalled for several minutes while `api::tests::runs::list_run_events_returns_payload_too_large_when_scan_budget_exceeded` repeatedly spawned detached `job run-pipeline-worker` processes; no test result was emitted. Stopped the local runs and their test-only workers. This is outside the parity fixture change; CI remains the arbiter for the full workspace run.
Friction checkpoint: no new friction filed; the stalled full-suite behavior was observed twice but is outside this task scope and had no diagnosed root cause.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10752-6a7d2bcc`
- Behind base: 0
- Ahead of base: 1