### PR TITLE
Enforce Orbit response envelopes through Claude CLI structured output

### DIFF
--- a/crates/orbit-agent/src/lib.rs
+++ b/crates/orbit-agent/src/lib.rs
@@ -61,3 +61,7 @@ pub use types::{AgentInvocationSpec, AgentOperation, AgentRequest, AgentResponse
 pub use types::{
     is_timeout, parse_and_validate_response, peek_response_status, response_envelope_protocol_check,
 };
+pub use types::{
+    provider_invocation_diagnostic, response_envelope_json_schema,
+    response_envelope_json_schema_arg,
+};

--- a/crates/orbit-agent/src/providers/claude/claude_cli.rs
+++ b/crates/orbit-agent/src/providers/claude/claude_cli.rs
@@ -1,4 +1,5 @@
 use crate::providers::common::render_prompt_with_embedded_envelope;
+use crate::types::response_envelope_json_schema_arg;
 
 fn claude_cli_model_arg(model: &str) -> String {
     let trimmed = model.trim();
@@ -24,6 +25,20 @@ impl ClaudeCliTransport {
     // only adds per-request toggles.
     pub(crate) fn args(&self, verbose: bool) -> Vec<String> {
         let mut args = Vec::new();
+
+        // [ORB-10746] Structured output is what actually enforces the Orbit
+        // response envelope; the prompt contract is guidance the model may
+        // ignore, and in `jrun-20260812-0312-9` did.
+        //
+        // Emitted here rather than added to the two `claude.yaml` copies on
+        // purpose: the schema is generated from one protocol definition, so a
+        // per-request flag cannot drift between the packaged asset and the
+        // installed workspace resource the way two hand-edited arg lists can.
+        // A CLI without the flag rejects it at argv parse, before any agent
+        // work runs — the failure Orbit wants, and the reason there is no
+        // unconstrained fallback.
+        args.push("--json-schema".to_string());
+        args.push(response_envelope_json_schema_arg());
 
         if verbose {
             args.push("--verbose".to_string());

--- a/crates/orbit-agent/src/providers/claude/mod.rs
+++ b/crates/orbit-agent/src/providers/claude/mod.rs
@@ -2,3 +2,6 @@ mod claude_cli;
 mod claude_runtime;
 
 pub(crate) use claude_runtime::ClaudeFactory;
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-agent/src/providers/claude/tests/claude_cli.rs
+++ b/crates/orbit-agent/src/providers/claude/tests/claude_cli.rs
@@ -1,0 +1,131 @@
+#![allow(missing_docs)]
+
+use serde_json::Value;
+
+use super::super::claude_cli::ClaudeCliTransport;
+
+/// Both packaged executor definitions Orbit ships for claude. The transport's
+/// per-request flags and these static arg lists are compiled and read from
+/// different places, which is exactly how they drift.
+const PACKAGED_EXECUTOR: &str =
+    include_str!("../../../../../orbit-core/assets/executors/claude.yaml");
+const WORKSPACE_EXECUTOR: &str =
+    include_str!("../../../../../../.orbit/resources/executors/claude.yaml");
+
+fn schema_arg(args: &[String]) -> Value {
+    let index = args
+        .iter()
+        .position(|arg| arg == "--json-schema")
+        .expect("transport emits --json-schema");
+    serde_json::from_str(&args[index + 1]).expect("schema argument is valid JSON")
+}
+
+fn static_args(executor_yaml: &str) -> Vec<String> {
+    let asset: Value = serde_yaml::from_str(executor_yaml).expect("parse executor asset");
+    asset["spec"]["args"]
+        .as_array()
+        .expect("executor declares args")
+        .iter()
+        .map(|arg| arg.as_str().expect("arg is a string").to_string())
+        .collect()
+}
+
+/// [ORB-10746] The prevention layer. Prompt text is guidance a model may
+/// ignore — `jrun-20260812-0312-9` ignored it after 89 turns and $3.17 — so
+/// the envelope frame has to reach the CLI as a machine constraint.
+#[test]
+fn transport_constrains_every_invocation_with_the_protocol_schema() {
+    let args = ClaudeCliTransport::new(Some("sonnet".to_string())).args(false);
+    let schema = schema_arg(&args);
+
+    assert_eq!(schema["properties"]["schemaVersion"]["const"], 1);
+    assert_eq!(
+        schema["properties"]["status"]["enum"],
+        serde_json::json!(["success", "failed", "timeout"])
+    );
+    assert_eq!(schema["properties"]["result"]["type"], "object");
+    assert_eq!(
+        schema["required"],
+        serde_json::json!(["schemaVersion", "status", "result"])
+    );
+}
+
+/// The schema must stay inside Anthropic's structured-output subset. A
+/// top-level `oneOf`/`allOf`/`anyOf` is rejected with
+/// `input_schema does not support oneOf, allOf, or anyOf at the top level`,
+/// and that rejection only surfaces mid-run, after the request reaches the
+/// API — the most expensive place to learn about a schema mistake.
+#[test]
+fn protocol_schema_avoids_the_conditional_subschema_keywords_the_provider_rejects() {
+    let args = ClaudeCliTransport::new(None).args(false);
+    let schema = schema_arg(&args);
+    let object = schema.as_object().expect("schema is an object");
+
+    for keyword in ["oneOf", "allOf", "anyOf", "if", "then", "else", "not"] {
+        assert!(
+            !object.contains_key(keyword),
+            "top-level `{keyword}` is outside the provider's schema subset"
+        );
+    }
+}
+
+/// The status/error correlation is deliberately absent from the schema and
+/// lives in `parse_json_envelope` instead. Pinning that here keeps a future
+/// reader from "fixing" the omission and reintroducing the 400.
+#[test]
+fn protocol_schema_leaves_the_status_error_correlation_to_the_rust_parser() {
+    let args = ClaudeCliTransport::new(None).args(false);
+    let schema = schema_arg(&args);
+
+    assert!(
+        schema["properties"]["error"].get("type").is_none(),
+        "error is untyped on purpose: it is null on success and an object on failure, \
+         and expressing that needs a conditional the provider subset rejects"
+    );
+    assert!(
+        !schema["required"]
+            .as_array()
+            .expect("required is an array")
+            .iter()
+            .any(|field| field == "error"),
+        "requiring `error` unconditionally would break every success envelope"
+    );
+}
+
+/// The flag rides on the per-request transport precisely so it cannot drift
+/// between the two static definitions. If someone later moves it into one
+/// YAML, this fails and points at the other copy.
+#[test]
+fn neither_packaged_executor_copy_declares_the_flag_the_transport_owns() {
+    let packaged = static_args(PACKAGED_EXECUTOR);
+    let workspace = static_args(WORKSPACE_EXECUTOR);
+
+    assert_eq!(
+        packaged, workspace,
+        "the packaged asset and the workspace resource must declare identical static args"
+    );
+    for args in [&packaged, &workspace] {
+        assert!(
+            !args.iter().any(|arg| arg == "--json-schema"),
+            "--json-schema is emitted per-request by the transport; declaring it statically \
+             creates a second copy that can drift"
+        );
+    }
+    // The static args the schema depends on: structured output is only
+    // meaningful when the wrapper itself is JSON.
+    assert!(packaged.iter().any(|arg| arg == "--output-format"));
+    assert!(packaged.iter().any(|arg| arg == "json"));
+}
+
+#[test]
+fn per_request_toggles_still_compose_with_the_schema_flag() {
+    let args = ClaudeCliTransport::new(Some("opus-5".to_string())).args(true);
+
+    assert!(args.iter().any(|arg| arg == "--json-schema"));
+    assert!(args.iter().any(|arg| arg == "--verbose"));
+    let model_index = args
+        .iter()
+        .position(|arg| arg == "--model")
+        .expect("model flag");
+    assert_eq!(args[model_index + 1], "claude-opus-5");
+}

--- a/crates/orbit-agent/src/providers/claude/tests/mod.rs
+++ b/crates/orbit-agent/src/providers/claude/tests/mod.rs
@@ -1,0 +1,1 @@
+mod claude_cli;

--- a/crates/orbit-agent/src/types/mod.rs
+++ b/crates/orbit-agent/src/types/mod.rs
@@ -6,6 +6,10 @@ pub use response::{AgentInvocationSpec, AgentResponseStatus};
 pub use response::{
     is_timeout, parse_and_validate_response, peek_response_status, response_envelope_protocol_check,
 };
+pub use response::{
+    provider_invocation_diagnostic, response_envelope_json_schema,
+    response_envelope_json_schema_arg,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-agent/src/types/response.rs
+++ b/crates/orbit-agent/src/types/response.rs
@@ -2,6 +2,10 @@
 // Visible to sibling-layout tests for this file-rooted module without
 // reintroducing a nested `response/tests` tree.
 pub(in crate::types) mod envelope;
+#[path = "response/protocol_schema.rs"]
+// Visible to sibling-layout tests for this file-rooted module without
+// reintroducing a nested `response/tests` tree.
+pub(in crate::types) mod protocol_schema;
 #[path = "response/tool_calls.rs"]
 mod tool_calls;
 #[path = "response/trace.rs"]
@@ -10,6 +14,10 @@ mod trace;
 // Visible to sibling-layout tests for this file-rooted module without
 // reintroducing a nested `response/tests` tree.
 pub(in crate::types) mod usage;
+#[path = "response/wrapper.rs"]
+// Visible to sibling-layout tests for this file-rooted module without
+// reintroducing a nested `response/tests` tree.
+pub(in crate::types) mod wrapper;
 
 use orbit_common::types::{OrbitError, ToolCallTrace};
 use serde_json::Value;
@@ -17,6 +25,8 @@ use serde_json::Value;
 pub use envelope::{
     is_timeout, parse_and_validate_response, peek_response_status, response_envelope_protocol_check,
 };
+pub use protocol_schema::{response_envelope_json_schema, response_envelope_json_schema_arg};
+pub use wrapper::provider_invocation_diagnostic;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentInvocationSpec {

--- a/crates/orbit-agent/src/types/response/envelope.rs
+++ b/crates/orbit-agent/src/types/response/envelope.rs
@@ -4,6 +4,8 @@ use orbit_common::types::{
 use serde::Deserialize;
 use serde_json::{Deserializer, Value};
 
+use super::protocol_schema::{RESPONSE_ENVELOPE_SCHEMA_VERSION, RESPONSE_ENVELOPE_STATUSES};
+use super::wrapper::wrapper_signals;
 use super::{AgentResponseStatus, ResponseParseResult, trace::extract_invocation_trace};
 
 pub fn parse_and_validate_response(exec_result: &ExecutionResult) -> ResponseParseResult {
@@ -70,24 +72,43 @@ pub fn response_envelope_protocol_check(stdout: &str) -> Result<(), OrbitError> 
             .find_map(find_agent_response_envelope),
         Err(_) => find_agent_response_envelope_in_string(stdout),
     };
-    let envelope = envelope.ok_or_else(|| {
-        OrbitError::AgentProtocolViolation(
-            "stdout does not contain an Orbit response envelope".to_string(),
-        )
-    })?;
-    if envelope.schema_version != 1 {
+    let envelope = envelope
+        .ok_or_else(|| OrbitError::AgentProtocolViolation(missing_envelope_message(stdout)))?;
+    if envelope.schema_version != RESPONSE_ENVELOPE_SCHEMA_VERSION {
         return Err(OrbitError::AgentProtocolViolation(format!(
             "unsupported schemaVersion: {}",
             envelope.schema_version
         )));
     }
-    if !matches!(envelope.status.as_str(), "success" | "failed" | "timeout") {
+    if !RESPONSE_ENVELOPE_STATUSES.contains(&envelope.status.as_str()) {
         return Err(OrbitError::AgentProtocolViolation(format!(
             "unknown status: {}",
             envelope.status
         )));
     }
     Ok(())
+}
+
+/// The invariant the [ORB-10449] completion guard is built on. Kept verbatim
+/// as the prefix of every missing-envelope diagnostic so the failure stays
+/// recognizable while [ORB-10746] appends a cause when one is available.
+const MISSING_ENVELOPE_MESSAGE: &str = "stdout does not contain an Orbit response envelope";
+
+/// [ORB-10746] Explain *why* a run ended without an envelope when the
+/// provider's own wrapper says the ending was abnormal.
+///
+/// A turn-limit or otherwise-errored ending exits 0 with no envelope, exactly
+/// like an agent that answered in prose, and used to be indistinguishable from
+/// it. This changes only the message: the decision to fail was already made by
+/// the caller, and no wrapper signal can reverse it.
+fn missing_envelope_message(stdout: &str) -> String {
+    let Some(diagnostic) = parse_json_documents(stdout)
+        .ok()
+        .and_then(|documents| wrapper_signals(&documents).terminal_ending_diagnostic())
+    else {
+        return MISSING_ENVELOPE_MESSAGE.to_string();
+    };
+    format!("{MISSING_ENVELOPE_MESSAGE}: {diagnostic}")
 }
 
 fn parse_json_documents(stdout: &str) -> Result<Vec<Value>, OrbitError> {
@@ -144,13 +165,11 @@ fn parse_json_envelope(exec_result: &ExecutionResult) -> ResponseParseResult {
         .rev()
         .find_map(find_agent_response_envelope)
         .ok_or_else(|| {
-            OrbitError::AgentProtocolViolation(
-                "stdout does not contain an Orbit response envelope".to_string(),
-            )
+            OrbitError::AgentProtocolViolation(missing_envelope_message(&exec_result.stdout))
         })?;
     let trace = extract_invocation_trace(&documents, exec_result.duration_ms);
 
-    if envelope.schema_version != 1 {
+    if envelope.schema_version != RESPONSE_ENVELOPE_SCHEMA_VERSION {
         return Err(OrbitError::AgentProtocolViolation(format!(
             "unsupported schemaVersion: {}",
             envelope.schema_version
@@ -207,25 +226,74 @@ pub(in crate::types) fn synthesize_response(
         ));
     }
 
+    // [ORB-10746] An exit-0 ending the provider itself flagged as abnormal —
+    // a turn limit, an errored terminal reason — carries no envelope, so the
+    // guard above would have returned `None` and the run would surface only
+    // the generic missing-envelope text. Synthesize the failure it plainly is,
+    // with the provider's own reason attached.
+    //
+    // This is the only new synthesis path, and it is failure-only by
+    // construction: no combination of `is_error`, `subtype`, `terminal_reason`,
+    // exit code, or provider prose can produce a `success` envelope here.
+    if let Some(diagnostic) = exit_zero_terminal_failure(exec_result) {
+        return Some(synthesized_failure(
+            exec_result,
+            "AGENT_TERMINAL_ENDING",
+            diagnostic,
+        ));
+    }
+
     if exec_result.exit_code.unwrap_or(1) == 0 || !exec_result.stdout.trim().is_empty() {
         return None;
     }
 
-    Some((
+    Some(synthesized_failure(
+        exec_result,
+        "AGENT_INVOCATION_FAILED",
+        synthetic_error_message(exec_result),
+    ))
+}
+
+fn synthesized_failure(
+    exec_result: &ExecutionResult,
+    code: &str,
+    message: String,
+) -> (AgentResponseEnvelope, AgentResponseStatus, InvocationTrace) {
+    (
         AgentResponseEnvelope {
-            schema_version: 1,
+            schema_version: RESPONSE_ENVELOPE_SCHEMA_VERSION,
             status: "failed".to_string(),
             result: None,
             error: Some(AgentRunError {
-                code: "AGENT_INVOCATION_FAILED".to_string(),
-                message: synthetic_error_message(exec_result),
+                code: code.to_string(),
+                message,
                 details: Value::Null,
             }),
             duration_ms: Some(exec_result.duration_ms),
         },
         AgentResponseStatus::Failed,
         synthesize_trace(exec_result),
-    ))
+    )
+}
+
+/// A clean exit whose wrapper nonetheless reports an abnormal ending, with no
+/// envelope anywhere in stdout.
+///
+/// Requires the absence of an envelope: a real envelope is the authoritative
+/// outcome whatever its status, and must never be displaced by a synthesized
+/// one — that would let wrapper prose overrule the protocol.
+fn exit_zero_terminal_failure(exec_result: &ExecutionResult) -> Option<String> {
+    if exec_result.exit_code.unwrap_or(1) != 0 {
+        return None;
+    }
+    let documents = parse_json_documents(&exec_result.stdout).ok()?;
+    if documents
+        .iter()
+        .any(|document| find_agent_response_envelope(document).is_some())
+    {
+        return None;
+    }
+    wrapper_signals(&documents).terminal_ending_diagnostic()
 }
 
 // Best-effort trace extraction for the fallback path. Provider CLIs (e.g.
@@ -267,6 +335,14 @@ fn find_agent_response_envelope(value: &Value) -> Option<AgentResponseEnvelope> 
         Value::Array(items) => items.iter().rev().find_map(find_agent_response_envelope),
         Value::Object(map) => {
             for key in [
+                // [ORB-10746] `structured_output` first: with `--json-schema`
+                // in play it is the schema-validated object the provider
+                // committed to, and Claude duplicates it into `result` only as
+                // a JSON-encoded string. `result` is null on several terminal
+                // paths where `structured_output` still holds the envelope, so
+                // probing it first is the difference between reading the
+                // authoritative field and parsing a copy by luck.
+                "structured_output",
                 "result",
                 "response",
                 "message",

--- a/crates/orbit-agent/src/types/response/protocol_schema.rs
+++ b/crates/orbit-agent/src/types/response/protocol_schema.rs
@@ -1,0 +1,86 @@
+//! The single canonical definition of Orbit's agent response envelope frame.
+//!
+//! [ORB-10746] Two consumers must agree on this frame: the Rust parser in
+//! [`super::envelope`], and any provider transport able to *enforce* it at the
+//! output boundary (today Claude's `--json-schema` structured output). Before
+//! this module the frame existed only as prose in
+//! `crate::providers::common::ORBIT_RESPONSE_CONTRACT`, so compliance was a
+//! matter of model obedience — `jrun-20260812-0312-9` spent ~11.5 minutes and
+//! $3.17 on completed work that ended in a prose summary and was rejected at
+//! the completion guard.
+//!
+//! The prose contract stays as human-readable guidance. This module is what
+//! actually binds the shape.
+
+use serde_json::{Value, json};
+
+/// The only protocol version Orbit speaks. Shared with [`super::envelope`] so
+/// the schema handed to a provider and the parser that validates the reply
+/// cannot disagree about what version means.
+pub const RESPONSE_ENVELOPE_SCHEMA_VERSION: u32 = 1;
+
+/// The recognized `status` tokens. All three *terminate* the protocol; which
+/// of them may checkpoint a step is a control-plane decision owned by the CLI
+/// runner ([ORB-10733]), not by this frame.
+pub const RESPONSE_ENVELOPE_STATUSES: [&str; 3] = ["success", "failed", "timeout"];
+
+/// Orbit's response envelope as a JSON Schema, for providers that can
+/// constrain their own output.
+///
+/// # What this deliberately does not express
+///
+/// The status/error correlation — `failed` requiring a non-empty `error.code`
+/// — is *not* here, and cannot be. Expressing it needs a conditional
+/// subschema, and Anthropic's structured-output schema subset rejects those:
+///
+/// ```text
+/// API Error: 400 tools.0.custom.input_schema: input_schema does not support
+/// oneOf, allOf, or anyOf at the top level
+/// ```
+///
+/// That correlation therefore stays where it already was, in
+/// [`super::envelope`]'s parse checks. This is a constraint of the provider's
+/// schema subset, not a choice about where validation belongs — and it is why
+/// the Rust checks remain load-bearing rather than redundant.
+///
+/// `error` is declared without a `type` on purpose: the contract admits
+/// `null` on success and an object on failure, and an untyped property is the
+/// widest thing the subset accepts without a conditional. `durationMs` is
+/// omitted entirely and rides through on unconstrained additional properties.
+pub fn response_envelope_json_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "schemaVersion": {
+                "const": RESPONSE_ENVELOPE_SCHEMA_VERSION,
+                "description": "Orbit response protocol version. Always 1.",
+            },
+            "status": {
+                "type": "string",
+                "enum": RESPONSE_ENVELOPE_STATUSES,
+                "description":
+                    "Terminal outcome of the invocation. Use \"failed\" when the work could \
+                     not be completed; do not report \"success\" for partial work.",
+            },
+            "result": {
+                "type": "object",
+                "description":
+                    "Result payload. Always an object, never null — use {} for activities \
+                     whose output is purely durable side effects.",
+            },
+            "error": {
+                "description":
+                    "null when status is \"success\"; an object with non-empty \"code\" and \
+                     \"message\" when status is \"failed\" or \"timeout\".",
+            },
+        },
+        "required": ["schemaVersion", "status", "result"],
+    })
+}
+
+/// The schema serialized for use as a CLI argument value.
+pub fn response_envelope_json_schema_arg() -> String {
+    // The schema is a closed literal above, so this cannot fail; serializing a
+    // `Value` only errors on non-string map keys or a custom `Serialize` impl.
+    response_envelope_json_schema().to_string()
+}

--- a/crates/orbit-agent/src/types/response/wrapper.rs
+++ b/crates/orbit-agent/src/types/response/wrapper.rs
@@ -1,0 +1,181 @@
+//! Signals a provider CLI carries in the wrapper document *around* the Orbit
+//! response envelope.
+//!
+//! [ORB-10746] Structured output removes the common cause of an exit-0 ending
+//! with no envelope (a model answering in prose), but not the category. A
+//! turn-limit ending still exits 0 with `is_error: true`,
+//! `subtype: "error_max_turns"`, `terminal_reason: "max_turns"`, and both
+//! `result` and `structured_output` null. Those runs used to collapse into the
+//! generic [ORB-10449] "stdout does not contain an Orbit response envelope"
+//! message, which tells an operator nothing about why a full-cost run ended.
+//!
+//! Everything here is diagnostic only. These signals may sharpen a failure
+//! *message*; they may never produce or imply a success. Provider exit status,
+//! `is_error`, `subtype`, `terminal_reason`, and free-form prose are all
+//! untrusted for that purpose — the envelope frame remains the sole authority
+//! on whether an invocation completed its contract.
+
+use serde_json::{Deserializer, Value};
+
+/// Upper bound on provider prose quoted into a diagnostic. The CLI runner
+/// bounds and redacts again at its own boundary; this keeps the string sane
+/// for consumers that do not.
+const QUOTED_PROSE_LIMIT_CHARS: usize = 400;
+
+/// The wrapper fields Orbit reads for diagnostics. Deliberately a small,
+/// named set: anything not listed here is not consulted when explaining a
+/// failure.
+#[derive(Debug, Default)]
+pub(super) struct WrapperSignals {
+    is_error: bool,
+    subtype: Option<String>,
+    terminal_reason: Option<String>,
+    result_text: Option<String>,
+}
+
+/// Collect wrapper signals from the last document that carries any of them.
+///
+/// Providers emit the wrapper as their final document, so a reverse scan
+/// finds the terminal record rather than an intermediate streaming event.
+pub(super) fn wrapper_signals(documents: &[Value]) -> WrapperSignals {
+    documents
+        .iter()
+        .rev()
+        .find_map(|document| {
+            let object = document.as_object()?;
+            let carries_signal = ["is_error", "subtype", "terminal_reason"]
+                .iter()
+                .any(|key| object.contains_key(*key));
+            if !carries_signal {
+                return None;
+            }
+            Some(WrapperSignals {
+                is_error: object
+                    .get("is_error")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+                subtype: non_empty_string(object.get("subtype")),
+                terminal_reason: non_empty_string(object.get("terminal_reason")),
+                result_text: non_empty_string(object.get("result")),
+            })
+        })
+        .unwrap_or_default()
+}
+
+fn non_empty_string(value: Option<&Value>) -> Option<String> {
+    let text = value?.as_str()?.trim();
+    (!text.is_empty()).then(|| text.to_string())
+}
+
+fn quote_bounded(text: &str) -> String {
+    let bounded: String = text.chars().take(QUOTED_PROSE_LIMIT_CHARS).collect();
+    if bounded.chars().count() < text.chars().count() {
+        format!("{bounded}…")
+    } else {
+        bounded
+    }
+}
+
+impl WrapperSignals {
+    /// Name a terminal ending the provider itself flagged as abnormal.
+    ///
+    /// Returns `None` when the wrapper reports an ordinary completion, so a
+    /// run that merely failed to emit an envelope keeps the generic
+    /// [ORB-10449] message rather than gaining a misleading cause.
+    pub(super) fn terminal_ending_diagnostic(&self) -> Option<String> {
+        let mut reasons = Vec::new();
+        if self.is_error {
+            reasons.push("is_error=true".to_string());
+        }
+        if let Some(subtype) = self.subtype.as_deref().filter(|value| *value != "success") {
+            reasons.push(format!("subtype={subtype:?}"));
+        }
+        if let Some(reason) = self
+            .terminal_reason
+            .as_deref()
+            .filter(|value| *value != "completed")
+        {
+            reasons.push(format!("terminal_reason={reason:?}"));
+        }
+        if reasons.is_empty() {
+            return None;
+        }
+
+        let mut diagnostic = format!(
+            "the provider reported an abnormal terminal ending ({}) and emitted no Orbit \
+             response envelope",
+            reasons.join(", ")
+        );
+        if let Some(prose) = self.result_text.as_deref() {
+            diagnostic.push_str(&format!("; provider message: {}", quote_bounded(prose)));
+        }
+        Some(diagnostic)
+    }
+
+    /// Detect a provider that rejected the request outright — most relevantly
+    /// Orbit's structured-output schema.
+    ///
+    /// Keys on `is_error` plus the wrapper's own prose. It deliberately does
+    /// **not** key on `subtype`: in the observed schema-rejection shape
+    /// (exit 1, `structured_output: null`, `result` = `API Error: 400
+    /// tools.0.custom.input_schema: ...`) `subtype` still reads `"success"`,
+    /// so treating it as an outcome discriminator would misclassify.
+    fn request_rejection_diagnostic(&self) -> Option<String> {
+        let prose = self.result_text.as_deref()?;
+        if !self.is_error || !prose.contains("API Error") {
+            return None;
+        }
+        if prose.contains("input_schema") {
+            return Some(format!(
+                "the provider rejected Orbit's response-envelope schema passed via \
+                 --json-schema, so the invocation could not be constrained to the response \
+                 protocol: {}",
+                quote_bounded(prose)
+            ));
+        }
+        Some(format!(
+            "the provider returned an API error before completing the invocation: {}",
+            quote_bounded(prose)
+        ))
+    }
+}
+
+/// Explain a *non-zero* provider exit in terms of the structured-output
+/// contract, when the evidence supports a specific cause.
+///
+/// Two distinct failure shapes, distinguishable only by where they surface:
+///
+/// - A CLI that **lacks** `--json-schema` never starts work. Its argument
+///   parser rejects the unknown option, so the evidence is on stderr and the
+///   run costs nothing. This is the pre-flight capability failure.
+/// - A CLI that **rejects** the schema fails mid-run, after the request
+///   reaches the API. There is nothing wrong with the argv, so the evidence is
+///   in the response wrapper.
+///
+/// Returns `None` when neither shape matches, leaving the caller's generic
+/// exit-code message in place.
+pub fn provider_invocation_diagnostic(stdout: &str, stderr: &str) -> Option<String> {
+    if stderr.contains("unknown option") && stderr.contains("--json-schema") {
+        return Some(format!(
+            "the configured agent CLI does not support --json-schema and rejected it at argument \
+             parsing, so no agent work ran: {}. Orbit enforces the response envelope through \
+             structured output; upgrade the CLI or point the executor at a build that supports \
+             it rather than running unconstrained.",
+            quote_bounded(stderr.trim())
+        ));
+    }
+
+    let documents = parse_documents(stdout)?;
+    wrapper_signals(&documents).request_rejection_diagnostic()
+}
+
+/// Lenient re-parse for the diagnostic path. Unlike the protocol parser this
+/// tolerates trailing junk: a best-effort explanation is worth more than
+/// strictness on a stream that already failed.
+fn parse_documents(stdout: &str) -> Option<Vec<Value>> {
+    let documents: Vec<Value> = Deserializer::from_str(stdout)
+        .into_iter::<Value>()
+        .map_while(Result::ok)
+        .collect();
+    (!documents.is_empty()).then_some(documents)
+}

--- a/crates/orbit-agent/src/types/tests/response.rs
+++ b/crates/orbit-agent/src/types/tests/response.rs
@@ -578,3 +578,296 @@ mod sum {
         );
     }
 }
+
+/// [ORB-10746] The `--output-format json --json-schema` wrapper shape, and the
+/// terminal endings structured output does not eliminate.
+mod structured_output {
+    #![allow(missing_docs)]
+
+    use orbit_common::types::ExecutionResult;
+
+    use super::super::super::response::AgentResponseStatus;
+    use super::super::super::response::envelope::*;
+    use super::super::super::response::wrapper::provider_invocation_diagnostic;
+
+    fn exec(stdout: &str, stderr: &str, exit_code: Option<i32>, success: bool) -> ExecutionResult {
+        ExecutionResult {
+            success,
+            stdout: stdout.to_string(),
+            stderr: stderr.to_string(),
+            exit_code,
+            duration_ms: 96_110,
+            output: None,
+        }
+    }
+
+    /// Captured from Claude Code 2.1.220 invoked exactly the way the transport
+    /// now invokes it. Two details matter and both are load-bearing:
+    ///
+    /// - the validated envelope appears in `structured_output` as an object
+    ///   *and* in `result` as a JSON-encoded string, so a parser that only
+    ///   knows `result` works by luck rather than by contract;
+    /// - `stop_reason` is `tool_use`, i.e. a tool-using run that would
+    ///   previously have ended in prose was constrained into the envelope.
+    ///   That is the ORB-10734 failure shape, prevented.
+    fn claude_json_schema_wrapper() -> String {
+        serde_json::json!({
+            "is_error": false,
+            "duration_api_ms": 96110,
+            "num_turns": 20,
+            "stop_reason": "tool_use",
+            "session_id": "44a7dbc8-333e-4852-aaf5-b61d8f4db174",
+            "total_cost_usd": 0.24556440000000002,
+            "usage": {
+                "input_tokens": 154,
+                "cache_creation_input_tokens": 19922,
+                "cache_read_input_tokens": 714235,
+                "output_tokens": 3372,
+                "service_tier": "standard"
+            },
+            "modelUsage": {
+                "claude-haiku-4-5-20251001": {
+                    "costUSD": 0.24556440000000002,
+                    "canonicalModel": "claude-haiku-4-5"
+                }
+            },
+            "terminal_reason": "completed",
+            "subtype": "success",
+            "api_error_status": null,
+            "result": "{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"summary\":\"done\"},\"error\":null}",
+            "structured_output": {
+                "schemaVersion": 1,
+                "status": "success",
+                "result": {"summary": "done"},
+                "error": null
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn claude_json_schema_wrapper_parses_and_keeps_its_trace_fields() {
+        let stdout = claude_json_schema_wrapper();
+        let (envelope, status, trace) =
+            parse_and_validate_response(&exec(&stdout, "", Some(0), true))
+                .expect("structured-output wrapper parses as an Orbit envelope");
+
+        assert_eq!(status, AgentResponseStatus::Success);
+        assert_eq!(envelope.schema_version, 1);
+        assert_eq!(envelope.result.expect("result")["summary"], "done");
+
+        assert_eq!(trace.usage.input, 154);
+        assert_eq!(trace.usage.output, 3372);
+        assert_eq!(trace.usage.cache_read, 714_235);
+        assert_eq!(trace.usage.cache_create, 19922);
+        let cost = trace.provider_cost_usd.expect("provider cost");
+        assert!((cost - 0.245_564_4).abs() < 1e-9, "{cost}");
+        assert_eq!(
+            trace.provider_model.as_deref(),
+            Some("claude-haiku-4-5-20251001")
+        );
+        assert_eq!(trace.duration_ms, 96_110);
+        // The provider's own `session_id` is preserved in the recorded stdout
+        // blob; `InvocationTrace` has no field for it, and adding one would be
+        // a new persisted artifact rather than part of this fix.
+        assert!(stdout.contains("44a7dbc8-333e-4852-aaf5-b61d8f4db174"));
+    }
+
+    /// `structured_output` is the authoritative field, not a convenience copy.
+    /// Here `result` carries prose instead of the envelope — the shape the old
+    /// key-probe order could not survive.
+    #[test]
+    fn structured_output_outranks_the_result_string() {
+        let stdout = serde_json::json!({
+            "is_error": false,
+            "subtype": "success",
+            "terminal_reason": "completed",
+            "result": "Here is a summary of what I did, in prose.",
+            "structured_output": {
+                "schemaVersion": 1,
+                "status": "success",
+                "result": {"authoritative": true},
+                "error": null
+            }
+        })
+        .to_string();
+
+        let (envelope, status, _) = parse_and_validate_response(&exec(&stdout, "", Some(0), true))
+            .expect("structured_output is read ahead of result");
+        assert_eq!(status, AgentResponseStatus::Success);
+        assert_eq!(envelope.result.expect("result")["authoritative"], true);
+        assert!(response_envelope_protocol_check(&stdout).is_ok());
+    }
+
+    /// Captured `error_max_turns` ending: exit 0, no envelope anywhere, and
+    /// both `result` and `structured_output` null. Structured output removes
+    /// the *prose* cause of an exit-0 ending without an envelope, not the
+    /// category — so this still has to fail, but with a usable reason.
+    fn max_turns_wrapper() -> String {
+        serde_json::json!({
+            "is_error": true,
+            "subtype": "error_max_turns",
+            "terminal_reason": "max_turns",
+            "num_turns": 200,
+            "total_cost_usd": 4.17,
+            "result": Option::<String>::None,
+            "structured_output": Option::<String>::None
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn a_turn_limit_ending_synthesizes_a_failed_envelope_naming_the_cause() {
+        let stdout = max_turns_wrapper();
+        let (envelope, status, trace) =
+            parse_and_validate_response(&exec(&stdout, "", Some(0), true))
+                .expect("an abnormal exit-0 ending synthesizes a failed envelope");
+
+        assert_eq!(status, AgentResponseStatus::Failed);
+        assert_eq!(envelope.status, "failed");
+        let error = envelope.error.expect("synthesized error");
+        assert_eq!(error.code, "AGENT_TERMINAL_ENDING");
+        assert!(
+            error.message.contains("error_max_turns"),
+            "{}",
+            error.message
+        );
+        assert!(error.message.contains("max_turns"), "{}", error.message);
+        assert!(error.message.contains("is_error=true"), "{}", error.message);
+        // Cost of the burnt run is still recovered for the scoreboard.
+        assert_eq!(trace.provider_cost_usd, Some(4.17));
+    }
+
+    /// The completion guard's decision is unchanged; only its message improves.
+    #[test]
+    fn the_completion_guard_still_fails_and_now_names_the_terminal_reason() {
+        let stdout = max_turns_wrapper();
+        let error = response_envelope_protocol_check(&stdout)
+            .expect_err("a run with no envelope must still fail the completion guard");
+        let message = error.to_string();
+
+        assert!(
+            message.contains("does not contain an Orbit response envelope"),
+            "the ORB-10449 invariant must stay recognizable: {message}"
+        );
+        assert!(message.contains("error_max_turns"), "{message}");
+        assert!(message.contains("max_turns"), "{message}");
+    }
+
+    /// The ORB-10734 shape itself: an ordinary completion that simply answered
+    /// in prose. The wrapper reports nothing abnormal, so no cause is invented
+    /// and the generic message stands.
+    #[test]
+    fn an_ordinary_prose_ending_keeps_the_generic_message_and_synthesizes_nothing() {
+        let stdout = serde_json::json!({
+            "type": "result",
+            "subtype": "success",
+            "is_error": false,
+            "terminal_reason": "completed",
+            "stop_reason": "end_turn",
+            "result": "QA sweep complete. Summary: no defects found."
+        })
+        .to_string();
+
+        let error = response_envelope_protocol_check(&stdout).expect_err("no envelope");
+        assert!(
+            error
+                .to_string()
+                .ends_with("stdout does not contain an Orbit response envelope"),
+            "a normal completion must not gain a fabricated cause: {error}"
+        );
+        assert!(
+            synthesize_response(&exec(&stdout, "", Some(0), true)).is_none(),
+            "a clean ending with no abnormal signal stays a hard parse failure"
+        );
+    }
+
+    /// A CLI without the flag never starts work: commander rejects the unknown
+    /// option at argv parse. The point of failing here is that it costs
+    /// nothing, so the diagnostic has to be specific enough to act on.
+    #[test]
+    fn a_cli_lacking_the_flag_is_reported_as_a_capability_failure() {
+        let diagnostic =
+            provider_invocation_diagnostic("", "error: unknown option '--json-schema'\n")
+                .expect("missing flag is diagnosable from stderr");
+
+        assert!(
+            diagnostic.contains("does not support --json-schema"),
+            "{diagnostic}"
+        );
+        assert!(diagnostic.contains("no agent work ran"), "{diagnostic}");
+        assert!(
+            diagnostic.contains("rather than running unconstrained"),
+            "{diagnostic}"
+        );
+    }
+
+    /// A CLI that *has* the flag but whose API rejects the schema fails
+    /// mid-run instead, so the evidence is in the wrapper. Note `subtype`
+    /// still reads `"success"` here — keying on it would misclassify this as
+    /// a clean run.
+    #[test]
+    fn a_rejected_schema_is_diagnosed_from_the_wrapper_not_from_argv() {
+        let stdout = serde_json::json!({
+            "is_error": true,
+            "subtype": "success",
+            "structured_output": Option::<String>::None,
+            "result": "API Error: 400 tools.0.custom.input_schema: input_schema does not support \
+                       oneOf, allOf, or anyOf at the top level"
+        })
+        .to_string();
+
+        assert!(
+            provider_invocation_diagnostic("", "").is_none(),
+            "nothing is wrong with the argv, so stderr cannot explain this"
+        );
+        let diagnostic =
+            provider_invocation_diagnostic(&stdout, "").expect("wrapper explains the rejection");
+        assert!(
+            diagnostic.contains("rejected Orbit's response-envelope schema"),
+            "{diagnostic}"
+        );
+        assert!(diagnostic.contains("input_schema"), "{diagnostic}");
+    }
+
+    /// The safety invariant, stated as a test: the wrapper fields this task
+    /// introduced are diagnostic only. No combination of them — and no exit
+    /// code — may manufacture a success.
+    #[test]
+    fn no_wrapper_signal_combination_can_synthesize_a_success() {
+        for is_error in [true, false] {
+            for subtype in ["success", "error_max_turns", "error_during_execution"] {
+                for terminal_reason in ["completed", "max_turns", "cancelled"] {
+                    let stdout = serde_json::json!({
+                        "is_error": is_error,
+                        "subtype": subtype,
+                        "terminal_reason": terminal_reason,
+                        "result": "durable work was persisted and the task looks done"
+                    })
+                    .to_string();
+
+                    for exit_code in [Some(0), Some(1)] {
+                        let synthesized = synthesize_response(&exec(
+                            &stdout,
+                            "",
+                            exit_code,
+                            exit_code == Some(0),
+                        ));
+                        if let Some((envelope, status, _)) = synthesized {
+                            assert_eq!(
+                                status,
+                                AgentResponseStatus::Failed,
+                                "is_error={is_error} subtype={subtype} \
+                                 terminal_reason={terminal_reason} exit={exit_code:?}"
+                            );
+                            assert_eq!(envelope.status, "failed");
+                        }
+                        // The completion guard never passes without an
+                        // envelope, whatever the wrapper claims.
+                        assert!(response_envelope_protocol_check(&stdout).is_err());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use chrono::Utc;
 use orbit_agent::{
     Agent, AgentConfig, AgentOperation, AgentRequest, peek_response_status,
-    response_envelope_protocol_check,
+    provider_invocation_diagnostic, response_envelope_protocol_check,
 };
 use orbit_common::types::activity_job::{AgentLoopSpec, V2AuditEventKind};
 use orbit_common::types::{LearningInjectionCaps, LearningInjectionState, prepend_reminder_block};
@@ -407,6 +407,17 @@ pub fn run_cli_backend(
         Some(
             sandbox_write_diagnostic
                 .clone()
+                // [ORB-10746] A bare exit code cannot distinguish "this CLI
+                // has no --json-schema" from "the provider rejected Orbit's
+                // schema" from any other nonzero exit, and the first two are
+                // configuration faults an operator can act on immediately.
+                .or_else(|| {
+                    provider_invocation_diagnostic(
+                        stdout_text.as_ref(),
+                        String::from_utf8_lossy(stderr.protocol_bytes()).as_ref(),
+                    )
+                    .map(|diagnostic| bounded_diagnostic(&diagnostic, &redaction))
+                })
                 .unwrap_or_else(|| format!("cli subprocess exited with code {:?}", exit_code)),
         )
     } else if (spec.require_completion_envelope || spec.require_response_envelope)

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -3214,3 +3214,223 @@ fn run_cli_backend_redacts_token_shaped_argv_in_audit() {
         "argv should carry a redaction placeholder: {joined}"
     );
 }
+
+/// [ORB-10746] The `error_max_turns` ending: exit 0, `is_error: true`, no
+/// envelope in either `result` or `structured_output`. Structured output stops
+/// a model from *answering in prose*; it cannot stop a run from hitting its
+/// turn limit. The step must still fail — and must now say why, instead of
+/// leaving an operator to explain a full-cost run from the generic message.
+#[test]
+fn run_cli_backend_names_the_terminal_reason_on_an_exit_zero_error_ending() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("claude");
+    let stdout = serde_json::json!({
+        "is_error": true,
+        "subtype": "error_max_turns",
+        "terminal_reason": "max_turns",
+        "num_turns": 200,
+        "total_cost_usd": 4.17,
+        "result": Option::<String>::None,
+        "structured_output": Option::<String>::None
+    })
+    .to_string();
+    write_executable(
+        &script,
+        &format!("#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{stdout}'\n"),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-max-turns",
+        "claude:sonnet",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let spec = test_agent_loop_spec_for("claude", Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-max-turns",
+        audit,
+        &serde_json::json!({"task_id": "ORB-10746"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    // The decision is unchanged from ORB-10449; only the message improves.
+    assert!(!outcome.success, "a turn-limit ending must not checkpoint");
+    assert_eq!(outcome.output["exit_code"], 0);
+    assert_eq!(outcome.output["completion_envelope_satisfied"], false);
+    let message = outcome.message.expect("terminal ending message");
+    assert!(message.contains("agent step did not complete"), "{message}");
+    assert!(message.contains("error_max_turns"), "{message}");
+    assert!(message.contains("max_turns"), "{message}");
+}
+
+/// A claude build without `--json-schema` rejects it at argument parsing, so
+/// the run fails before any agent work — and before any cost. The whole point
+/// of failing this early is lost if the operator only sees an exit code.
+#[test]
+fn run_cli_backend_reports_a_missing_json_schema_flag_as_a_capability_failure() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("claude");
+    write_executable(
+        &script,
+        "#!/bin/sh\ncat > /dev/null\n\
+         printf '%s\\n' \"error: unknown option '--json-schema'\" >&2\nexit 1\n",
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-missing-flag",
+        "claude:sonnet",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let spec = test_agent_loop_spec_for("claude", Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-missing-flag",
+        audit,
+        &serde_json::json!({"task_id": "ORB-10746"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(!outcome.success);
+    let message = outcome.message.expect("capability message");
+    assert!(
+        message.contains("does not support --json-schema"),
+        "{message}"
+    );
+    assert!(message.contains("no agent work ran"), "{message}");
+}
+
+/// The other half of the capability story: a CLI that accepts the flag but
+/// whose API rejects the schema fails mid-run, with the evidence in the
+/// response wrapper rather than on stderr. `subtype` still reads `"success"`
+/// in this shape, so nothing may key on it.
+#[test]
+fn run_cli_backend_reports_a_rejected_schema_from_the_response_wrapper() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("claude");
+    let stdout = serde_json::json!({
+        "is_error": true,
+        "subtype": "success",
+        "structured_output": Option::<String>::None,
+        "result": "API Error: 400 tools.0.custom.input_schema: input_schema does not support \
+                   oneOf, allOf, or anyOf at the top level"
+    })
+    .to_string();
+    let stdout_file = temp.path().join("stdout.json");
+    fs::write(&stdout_file, &stdout).expect("write rejection fixture");
+    write_executable(
+        &script,
+        &format!(
+            "#!/bin/sh\ncat > /dev/null\ncat '{}'\nexit 1\n",
+            stdout_file.display()
+        ),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-rejected-schema",
+        "claude:sonnet",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let spec = test_agent_loop_spec_for("claude", Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-rejected-schema",
+        audit,
+        &serde_json::json!({"task_id": "ORB-10746"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(!outcome.success);
+    let message = outcome.message.expect("schema rejection message");
+    assert!(
+        message.contains("rejected Orbit's response-envelope schema"),
+        "{message}"
+    );
+    assert!(message.contains("input_schema"), "{message}");
+}
+
+/// [ORB-10746] The prevented shape, end to end: a tool-using run that would
+/// once have ended in prose now terminates with the schema-validated envelope
+/// in `structured_output`, and the step checkpoints. Verified against Claude
+/// Code 2.1.220, whose reply carried `stop_reason: "tool_use"` — the exact
+/// condition under which ORB-10734 produced prose.
+#[test]
+fn run_cli_backend_accepts_a_structured_output_envelope_from_a_tool_using_run() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("claude");
+    let stdout = serde_json::json!({
+        "is_error": false,
+        "stop_reason": "tool_use",
+        "num_turns": 20,
+        "session_id": "44a7dbc8-333e-4852-aaf5-b61d8f4db174",
+        "total_cost_usd": 0.2455644,
+        "usage": {
+            "input_tokens": 154,
+            "cache_creation_input_tokens": 19922,
+            "cache_read_input_tokens": 714235,
+            "output_tokens": 3372
+        },
+        "terminal_reason": "completed",
+        "subtype": "success",
+        // Claude emits the validated envelope in both places; the object is
+        // the authoritative one.
+        "result": "{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"summary\":\"done\"},\"error\":null}",
+        "structured_output": {
+            "schemaVersion": 1,
+            "status": "success",
+            "result": {"summary": "done"},
+            "error": null
+        }
+    })
+    .to_string();
+    let stdout_file = temp.path().join("stdout.json");
+    fs::write(&stdout_file, &stdout).expect("write structured-output fixture");
+    write_executable(
+        &script,
+        &format!(
+            "#!/bin/sh\ncat > /dev/null\ncat '{}'\n",
+            stdout_file.display()
+        ),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-structured-output",
+        "claude:sonnet",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let spec = test_agent_loop_spec_for("claude", Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-structured-output",
+        audit,
+        &serde_json::json!({"task_id": "ORB-10734"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(outcome.success, "{:?}", outcome.message);
+    assert_eq!(outcome.output["completion_envelope_satisfied"], true);
+    assert_eq!(outcome.output["response_envelope_status"], "success");
+}

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Design"
 type: design
 title: "Activity / Job — Design"
 owner: codex
-last_updated: 2026-08-12
+last_updated: 2026-08-13
 last_validated: 2026-07-26
 status: Draft
 feature: activity-job
@@ -364,6 +364,70 @@ refused.
 absence must stop the pipeline, so the empty opt-out list is pinned by a test
 and any future exception requires a deliberate edit with a stated reason.
 
+### 7.6b Structured output is the Claude prevention layer
+
+§7.6a is a *detector*, and by [ORB-10746] it was the only thing standing behind
+a machine protocol that was otherwise enforced by asking a model nicely.
+`jrun-20260812-0312-9` is the bill for that: a QA sweep on [ORB-10734] ran 89
+turns over ~11.5 minutes for $3.17, finished its work, persisted a meaningful
+`execution_summary` — and then answered in prose. `stop_reason: end_turn`,
+`terminal_reason: completed`, `subtype: success`, empty stderr, exit 0, and no
+envelope. The guard correctly refused to checkpoint it, and the task blocked.
+Detection was working; prevention did not exist.
+
+The installed Claude CLI exposes `--json-schema`, so the frame can be a
+constraint rather than a request. `crates/orbit-agent/src/types/response/protocol_schema.rs`
+is the single protocol definition: the Rust parser and the schema handed to the
+provider are generated from the same constants, so they cannot disagree about
+what `schemaVersion: 1` or the status token set means.
+`ClaudeCliTransport::args` emits the flag per request rather than adding it to
+the two `claude.yaml` copies — the packaged asset and the installed workspace
+resource are edited independently, and a per-request flag has no second copy to
+drift from. The prompt contract
+(`render_prompt_with_embedded_envelope`) stays as human-readable guidance; it is
+no longer the enforcement mechanism.
+
+**What the schema cannot say.** The status/error correlation — `failed`
+requiring a non-empty `error.code` — is absent from the schema and stays in
+`parse_json_envelope`'s Rust checks. This is a constraint, not a preference:
+expressing it needs a conditional subschema, and Anthropic's structured-output
+subset rejects those outright with `input_schema does not support oneOf, allOf,
+or anyOf at the top level`. The rejection surfaces mid-run rather than at argv
+parse, so getting it wrong is expensive. `error` is therefore declared untyped
+(null on success, object on failure) and the Rust correlation checks remain
+load-bearing rather than redundant.
+
+**Two capability failures, two places.** A CLI that *lacks* `--json-schema`
+fails at argument parsing, before any agent work and any cost; the evidence is
+`error: unknown option '--json-schema'` on stderr. A CLI that *rejects* the
+schema fails mid-run, after the request reaches the API; the evidence is in the
+response wrapper (exit 1, `is_error: true`, `structured_output: null`, and a
+prose `result` of `API Error: 400 tools.0.custom.input_schema: ...`). Note that
+`subtype` still reads `"success"` in that second shape, so no classification
+logic may key on it. `provider_invocation_diagnostic` reports each specifically;
+neither falls back to an unconstrained invocation.
+
+**What structured output does not fix.** It removes the prose cause of an
+exit-0 ending without an envelope, not the category. A turn-limit ending still
+exits 0 with `is_error: true`, `subtype: "error_max_turns"`,
+`terminal_reason: "max_turns"`, and both `result` and `structured_output` null.
+Those endings now map to a synthesized `failed` envelope naming the provider's
+own reason, instead of collapsing into the generic [ORB-10449] missing-envelope
+text after a full-cost run.
+
+**The backstops stay provider-neutral and fail-closed.** Every addition here can
+only improve a failure *message*; none can change a failure *decision*. Success
+is never synthesized from exit code, `is_error`, `subtype`, `terminal_reason`,
+persisted `execution_summary`, no-diff tags, task state, worktree state, or
+provider prose — a pinned test enumerates the wrapper-signal matrix and asserts
+no combination yields anything but `failed`. §7.6a's frame check and the
+[ORB-10733] status handling remain authoritative for every provider, including
+those with no structured-output mechanism at all; Codex, Gemini, Grok, and mock
+fixtures parse unchanged. Extraction now reads the wrapper's top-level
+`structured_output` object ahead of the `result` string, because Claude emits
+the validated envelope in both places and `result` is null on several terminal
+paths where `structured_output` is not.
+
 After [T20260426-2313], stdout/stderr readers emit line-level `tracing::info!` events while the child runs, carrying `provider`, `stream`, `job_run_id`, `task_id`, and `line`. After [T20260508-8], those events also carry `cwd` when the CLI subprocess has a resolved cwd. After [T20260426-2349], the default tracing subscriber redacts formatted output. The readers still retain original bytes for the existing audit/blob path, so run logs follow blob refs rather than the live feed.
 
 Executor args are prepended before provider runtime args. For seeded Codex, the subprocess starts as `codex exec --json ...`, not the interactive TUI. [T20260423-0114] exposed the earlier command-only boundary.
@@ -654,6 +718,7 @@ Read-only history does not need the same dependencies as live execution. [T20260
 
 ## Task References
 
+- **[ORB-10746]** — Enforce the Orbit response envelope through Claude CLI structured output (`--json-schema`), read `structured_output` as the authoritative extraction source, and map abnormal exit-0 endings to a specific failed-envelope diagnostic (see [§7.6b](#76b-structured-output-is-the-claude-prevention-layer)).
 - **[ORB-10606]** — Supply the complete reviewer worktree pair and distinguish review startup failure from a reviewer rejection at the parent and task-history boundaries ([ADR-0328]).
 - **[ORB-10519]** — Restore one workflow-owned shipment commit, reject every provider-side HEAD change, and preserve dirty-work recovery plus process-scoped attribution ([ADR-0299], superseding [ADR-0294] and [ADR-0249]).
 - **[ORB-10468]** — Introduce run-keyed dirty integrity recovery plus the now-superseded provider-commit admission policy ([ADR-0294], superseded by [ADR-0299]).

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Decisions"
 type: design
 title: "Activity / Job — Decisions"
 owner: codex
-last_updated: 2026-08-11
+last_updated: 2026-08-13
 last_validated: 2026-07-26
 status: Draft
 feature: activity-job
@@ -1746,6 +1746,7 @@ Persist a per-resource-kind managed manifest containing the SHA-256 digest last 
 - **[ORB-10363]** — Rebase task candidates after concurrent base advances and publish blocked PRs instead of stranding failed work.
 - **[ORB-10332]** — Remove the unused Groundhog activity kind and the epic/parallel pipeline layer (`task_epic_pipeline`, `epic_orchestrator`, `pipeline_wait`, legacy parallel-batch executor).
 - **[ORB-10449]** — Split step-completion protocol from response content so a stalled agent-loop step fails where it happened ([ADR-0258], amending [ADR-0224]; see [§7.6a of `2_design.md`](./2_design.md)).
+- **[ORB-10746]** — Add the prevention layer behind [ADR-0258]'s detector: Claude CLI invocations are constrained by a canonical response-envelope JSON Schema via `--json-schema`, generated from one protocol definition. The status/error correlation stays in Rust because Anthropic's structured-output subset rejects top-level conditional subschemas — a constraint, not a choice — and the completion/status checks remain provider-neutral fail-closed backstops that no wrapper signal can turn into a success. Narrative in [§7.6b of `2_design.md`](./2_design.md); no new ADR was allocated, since this decides nothing ADR-0258 left open.
 - **[ORB-10464]** — Refuse workflow admission when a done dependency's work is not in the base the worktree would be cut from ([ADR-0290], resolving [F2026-07-038]).
 - **[ORB-10604]** — Split remote worktree construction from local merge reconciliation so post-merge failures do not cascade through a shipment session.
 


### PR DESCRIPTION
## Task

[ORB-10746](https://orbit-cli.com/tasks/ORB-10746) — Enforce Orbit response envelopes through Claude CLI structured output

### Description

## Problem

`task_pr_pipeline` run `jrun-20260812-0312-9` blocked QA-sweep task `ORB-10734` at `implement_one` because Claude exited 0 without a terminating Orbit response envelope.

The bounded run log shows this was not an unfinished implementation:

- provider `claude`, crew/model `sonnet`
- 89 turns, 693,541 ms provider duration, `$3.1702431` reported cost
- `stop_reason: end_turn`, `terminal_reason: completed`, `subtype: success`, empty stderr
- the provider persisted a meaningful execution summary on `ORB-10734`
- Claude's `--output-format json` wrapper put an ordinary prose QA summary in its `result` string instead of the required `{"schemaVersion":1,...}` Orbit envelope

Orbit's ORB-10449 completion guard correctly rejected that stdout and kept the step from checkpointing as success. ORB-10733 likewise correctly rejects explicit `failed` or `timeout` envelopes. The remaining defect is that the Claude transport relies on prompt compliance for a machine protocol even though the installed Claude CLI exposes `--json-schema` structured-output enforcement.

## Why It Matters

A successfully completed, durable no-diff QA sweep consumed about 11.5 minutes and $3.17, then became blocked solely because its final prose did not satisfy the transport frame. Manual re-dispatch repeats expensive work and leaves operators deciding whether durable side effects are safe to trust. The strict completion guard must remain fail-closed; prevention belongs at the provider output boundary.

## Proposed Fix Direction

- Give Claude CLI invocations a canonical JSON Schema for Orbit's response envelope via `--json-schema`, generated from one protocol definition rather than a second hand-maintained prose contract.
- Require `schemaVersion: 1`, a recognized `status`, an object `result`, and status-appropriate `error` fields. Preserve the current control-plane rule that `failed` and `timeout` terminate the protocol but fail the activity.
- Parse and validate the actual Claude `--output-format json --json-schema` wrapper shape while preserving existing usage, cost, session, and model trace extraction.
- Keep prompt instructions as human-readable guidance, but make structured output—not model obedience—the normal Claude enforcement path.
- If a configured Claude CLI does not support or rejects structured output, fail early with a concrete capability/argument diagnostic; do not silently fall back to an unconstrained invocation that can spend a full run and fail at termination.
- Do not infer success from exit code, task status, `execution_summary`, no-diff tags, prose, or worktree state. The ORB-10449 missing-envelope guard and ORB-10733 failed/timeout handling remain authoritative backstops.
- Keep other provider transports unchanged unless shared protocol-schema extraction is needed to avoid duplication.

## Reproduction Evidence

1. Run `ORB-10734` through `task_pr_pipeline` with crew `sonnet` (`jrun-20260812-0312-9`).
2. Claude completes the QA work and persists the task execution summary.
3. Its outer JSON reports success but contains `result: "QA sweep complete. Summary: ..."`.
4. `response_envelope_protocol_check` finds no embedded Orbit envelope; `implement_one` fails and the task moves to `blocked`.

Related completed work: ORB-10449 and ORB-10733. This task fixes recurrence without weakening either safety invariant.


### Acceptance Criteria

- Claude CLI activity invocations pass a canonical JSON Schema via `--json-schema`, generated from one protocol definition, constraining the Orbit response envelope's shape: `schemaVersion` const 1, `status` enum of the recognized values, and `result` as an object. The schema does NOT attempt to express the status/error correlation (see next criterion).
- The status-appropriate `error` correlation stays enforced in Rust at the existing `parse_response` checks (`crates/orbit-agent/src/types/response/envelope.rs`), not in the schema: Anthropic's structured-output schema subset rejects conditional subschemas (`input_schema does not support oneOf, allOf, or anyOf at the top level`), so `failed` requiring a non-empty `error.code` cannot be schema-expressed.
- Envelope extraction reads the wrapper's top-level `structured_output` object as the authoritative source, ahead of the `result` string. Claude emits the validated envelope in BOTH places (`structured_output` as an object, `result` as a JSON-encoded string); today's key-probe list in `find_agent_response_envelope` omits `structured_output` and only parses this by accident via `result`, which is `null` on several terminal paths.
- A captured fixture matching Claude's current `--output-format json --json-schema` response shape parses as an Orbit envelope and preserves usage, cache, cost, session, model, and duration trace fields.
- A tool-using Claude invocation that would otherwise end with a prose final answer is constrained into the structured envelope path; a targeted integration or opt-in live smoke demonstrates that the `ORB-10734` failure shape no longer reaches `implement_one` without an envelope. (Verified manually: a tool-using run with `stop_reason: "tool_use"` still returned a schema-valid envelope.)
- A Claude binary that LACKS `--json-schema` fails before expensive agent work: the CLI rejects the unknown option at argv parse, and Orbit surfaces a specific capability diagnostic rather than silently retrying an unconstrained prompt-only path.
- A Claude binary that REJECTS the schema fails mid-run, not pre-flight, and must be diagnosed from the response wrapper — not from argv validation. The observed shape is exit 1, `is_error: true`, `structured_output: null`, and a prose `result` of `API Error: 400 tools.0.custom.input_schema: ...`. Note `subtype` reads `"success"` in this case, so no logic may key on `subtype` to decide success.
- Terminal endings that produce exit 0 with no envelope are mapped to a synthesized `failed` envelope carrying a specific diagnostic drawn from `is_error`, `terminal_reason`, and `subtype`, instead of collapsing into the generic ORB-10449 missing-envelope message. Structured output removes the prose cause of exit-0-without-envelope but not the category: a turn-limit ending yields exit 0, `is_error: true`, `subtype: "error_max_turns"`, `terminal_reason: "max_turns"`, `result: null`, `structured_output: null`. Without this, the run still burns full cost and blocks with an unhelpful reason. `synthesize_response` currently returns `None` whenever stdout is non-empty, which is what flattens these cases.
- Existing ORB-10449 coverage remains green: exit 0 with genuinely missing or malformed envelope stdout still fails at `implement_one`, does not checkpoint success, and does not run downstream delivery steps. The added diagnostics change the failure MESSAGE, never the failure DECISION.
- Existing ORB-10733 coverage remains green: valid `failed` and `timeout` envelopes fail the activity, while `success` can proceed; envelope result/error prose remains advisory.
- No success path is synthesized from provider exit 0, `is_error`, `subtype`, `terminal_reason`, persisted `execution_summary`, no-diff tags, task state, worktree state, or free-form provider prose. The new wrapper fields may only ever produce a FAILED envelope with a better message.
- The `--json-schema` flag is added to the static executor definition in both `crates/orbit-core/assets/executors/claude.yaml` and the mirrored `.orbit/resources/executors/claude.yaml`, or is emitted per-request by `ClaudeCliTransport::args`; the two copies do not drift.
- The Claude transport's compiled behavior and live executor/resource conventions remain aligned, and provider-neutral response parsing continues to accept existing Codex, Gemini, Grok, and mock fixtures.
- The activity-job design/decision documentation records structured-output enforcement as the Claude prevention layer, the Rust-side status/error correlation as a schema-subset constraint rather than a choice, and the completion/status checks as provider-neutral fail-closed backstops.
- Validation passes `cargo fmt --check`, focused `orbit-agent` and CLI-runner tests under nextest, `make ci-fast`, and any existing provider smoke test that can run without embedding credentials in fixtures.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented on `orbit/ORB-10746-6a7d2b95` in worktree `orbit-jrun-20260813-0227-3`. Prevention now lives at the Claude output boundary; every ORB-10449 / ORB-10733 backstop is unchanged in behavior.

## What changed

**Single protocol definition** — new `crates/orbit-agent/src/types/response/protocol_schema.rs` holds `RESPONSE_ENVELOPE_SCHEMA_VERSION`, `RESPONSE_ENVELOPE_STATUSES`, and the canonical JSON Schema (`schemaVersion` const 1, `status` enum, `result` object). `envelope.rs` now validates against those same constants instead of inline literals, so the schema handed to a provider and the parser that checks the reply cannot drift.

**Enforcement** — `ClaudeCliTransport::args` emits `--json-schema <schema>` per request. Chosen over editing the two `claude.yaml` copies (criterion 12's second option) precisely because a per-request flag has no second copy to drift from. A test asserts both YAMLs remain identical in `spec.args` and that neither declares the flag.

**Schema-subset constraint** — the status/error correlation is deliberately NOT in the schema and stays in `parse_json_envelope`. Anthropic rejects top-level `oneOf`/`allOf`/`anyOf` (`input_schema does not support oneOf, allOf, or anyOf at the top level`), so `error` is declared untyped. A test pins the absence of every conditional keyword so nobody "fixes" the omission and reintroduces the 400.

**Authoritative extraction** — `structured_output` added at the head of the key-probe list, ahead of `result`.

**Diagnostics (message-only, never decision)** — new `response/wrapper.rs` reads `is_error`, `subtype`, `terminal_reason`, and wrapper prose:
- missing-envelope failures keep the exact ORB-10449 string as a prefix and append the provider's own reason when the ending was abnormal;
- `synthesize_response` maps an exit-0 abnormal ending (e.g. `error_max_turns`) to a synthesized FAILED envelope with code `AGENT_TERMINAL_ENDING` instead of returning `None`; it refuses to displace a real envelope;
- `provider_invocation_diagnostic` separates a CLI LACKING `--json-schema` (argv parse, stderr, zero cost) from one REJECTING it (mid-run, wrapper, exit 1). It never keys on `subtype`, which reads `"success"` in the rejection shape. The orchestrator consults it in the non-zero-exit message branch only.

**Docs** — `docs/design/activity-job/2_design.md` gains section 7.6b recording structured output as the Claude prevention layer, the Rust-side correlation as a subset constraint rather than a choice, and the provider-neutral fail-closed backstops. `4_decisions.md` gains a Task References entry pointing at it.

## Live verification against Claude Code 2.1.220

The schema was probed against the installed CLI before being wired in. It is accepted, and the reply carried `stop_reason: "tool_use"` with a schema-valid envelope in `structured_output` — the exact tool-using condition under which ORB-10734 produced prose now yields an envelope (criterion 5). That captured shape is the test fixture. `error: unknown option '--json-schema'` was confirmed as the argv-rejection text.

## Validation

`cargo fmt --check`, `make ci-fast`, and `make ci-lint` all pass. `cargo nextest run -p orbit-agent -p orbit-engine`: 417/417 pass, including every pre-existing ORB-10449 and ORB-10733 guard test and the Codex/Gemini/Grok/mock fixtures.

Full-workspace nextest shows 25 failures, all in crates this task does not touch (orbit-cli, orbit-core, orbit-mcp, orbit-search, orbit-dashboard); orbit-agent and orbit-engine are clean. Verified pre-existing rather than regressions:
- three `orbit-dashboard` ship-endpoint tests reproduced identically on a pristine `HEAD` tree extracted with `git archive`;
- `orbit-core ... agent_implement_guidance_allows_bounded_scope_expansion` fails on drift between the shipped and workspace `agent_implement.yaml` (`tools:` lists disagree); `git show HEAD:` confirms the workspace copy is byte-identical to HEAD, so the drift predates this task.

A broader baseline comparison was cut short when the sandbox tmpfs filled during the baseline build; the per-test evidence above stands in its place. `git stash` and `git worktree add` are both unusable here — `.git` is read-only in this sandbox (`fatal: could not create directory ... Read-only file system`), which is why baselining went through `git archive`.

## Scope notes

- Beyond the declared `context_files`, three new sibling files were added inside already-listed modules (`types/response/protocol_schema.rs`, `types/response/wrapper.rs`, `providers/claude/tests/`). Registering and exporting them required touching `types/response.rs`, `types/mod.rs`, `lib.rs`, and `providers/claude/mod.rs` — module wiring needed to compile, nothing behavioral.
- Criterion 4 asks that "session" survive as a trace field. `InvocationTrace` has no session field, and adding one would be a new persisted artifact (an ARCHITECTURE-level change) rather than part of this fix. Usage, cache, cost, model, and duration are asserted; the provider `session_id` survives in the recorded stdout blob, and the test documents the gap explicitly.
- NO ADR WAS ALLOCATED. `agent_implement`'s grant excludes `orbit.adr.*`, and reaching it through another surface is forbidden by the same instruction. The decision narrative is fully recorded in `2_design.md` section 7.6b instead. Filed as friction F2026-08-069, together with the shipped/workspace `agent_implement.yaml` disagreement about whether implementers may write ADRs at all — a reviewer should decide and reconcile both copies.
- Nothing was committed; awaiting human approval per the repo rule.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10746-6a7d2b95`
- Behind base: 0
- Ahead of base: 1