### PR TITLE
Bump default Grok model from grok-4.5 to grok-4.6

### DIFF
--- a/.orbit/config.toml
+++ b/.orbit/config.toml
@@ -54,7 +54,7 @@ provider = "gemini"
 
 [crews.grok]
 backend = "cli"
-model = "grok-4.5"
+model = "grok-4.6"
 provider = "grok"
 
 [crews.qa]

--- a/crates/orbit-agent/src/providers/grok/tests/grok_cli.rs
+++ b/crates/orbit-agent/src/providers/grok/tests/grok_cli.rs
@@ -7,8 +7,8 @@ mod args {
 
     #[test]
     fn grok_args_pass_model_with_long_flag() {
-        let transport = GrokCliTransport::new(Some("grok-4.5".to_string()));
+        let transport = GrokCliTransport::new(Some("grok-4.6".to_string()));
 
-        assert_eq!(transport.args(), vec!["--model", "grok-4.5"]);
+        assert_eq!(transport.args(), vec!["--model", "grok-4.6"]);
     }
 }

--- a/crates/orbit-cli/src/command/tests/init.rs
+++ b/crates/orbit-cli/src/command/tests/init.rs
@@ -137,7 +137,7 @@ fn non_interactive_init_against_non_global_root_leaves_home_skill_links_untouche
         ("terra", "codex", "gpt-5.6-terra"),
         ("luna", "codex", "gpt-5.6-luna"),
         ("gemini", "gemini", "pro"),
-        ("grok", "grok", "grok-4.5"),
+        ("grok", "grok", "grok-4.6"),
         ("qa", "", ""),
     ];
     if let Some(crews) = crews {

--- a/crates/orbit-common/src/model_defaults.rs
+++ b/crates/orbit-common/src/model_defaults.rs
@@ -69,7 +69,7 @@ pub const GEMINI_PAIR_STRONG: &str = "gemini-3.1-pro";
 pub const GEMINI_PAIR_WEAK: &str = "gemini-3-flash";
 
 /// Default Grok Build model (the canonical model listed by `grok models`).
-pub const GROK_DEFAULT_MODEL: &str = "grok-4.5";
+pub const GROK_DEFAULT_MODEL: &str = "grok-4.6";
 
 /// Cheap Claude model used by the orbit-agent HTTP examples.
 ///

--- a/crates/orbit-core/assets/executors/grok.yaml
+++ b/crates/orbit-core/assets/executors/grok.yaml
@@ -16,7 +16,7 @@ spec:
   stdout_format: envelope
   sandbox: macos-sandbox-exec
   model_pair_override:
-    strong: grok-4.5
-    weak: grok-4.5
+    strong: grok-4.6
+    weak: grok-4.6
   model_flag: "-m"
   env: {}

--- a/crates/orbit-core/src/config/tests/bootstrap.rs
+++ b/crates/orbit-core/src/config/tests/bootstrap.rs
@@ -82,7 +82,7 @@ fn grok_only_seeds_grok_without_qa() {
     let parsed = parsed_config(&contents);
 
     assert_eq!(crew_names(&parsed), vec!["grok"]);
-    assert_crew(&parsed, "grok", "grok", "grok-4.5");
+    assert_crew(&parsed, "grok", "grok", "grok-4.6");
     assert_default_crew(&parsed, Some("grok"));
 }
 
@@ -130,7 +130,7 @@ fn multi_provider_seed_includes_each_available_family_and_excludes_unavailable()
     assert_crew(&parsed, "sol", "codex", "gpt-5.6-sol");
     assert_crew(&parsed, "terra", "codex", "gpt-5.6-terra");
     assert_crew(&parsed, "luna", "codex", "gpt-5.6-luna");
-    assert_crew(&parsed, "grok", "grok", "grok-4.5");
+    assert_crew(&parsed, "grok", "grok", "grok-4.6");
     assert_crew(&parsed, "qa", "codex", "gpt-5.6-terra");
     for crew in crews(&parsed).values() {
         assert_eq!(

--- a/crates/orbit-core/src/config/tests/runtime.rs
+++ b/crates/orbit-core/src/config/tests/runtime.rs
@@ -40,7 +40,7 @@ fn built_in_crews_use_standard_model_specific_names() {
         ("terra", "codex", "gpt-5.6-terra"),
         ("luna", "codex", "gpt-5.6-luna"),
         ("gemini", "gemini", "pro"),
-        ("grok", "grok", "grok-4.5"),
+        ("grok", "grok", "grok-4.6"),
     ] {
         let assignment = &crews.get(name).expect("built-in crew").assignment;
         assert_eq!(assignment.provider, provider);

--- a/crates/orbit-core/tests/grok_cli_backend_smoke.rs
+++ b/crates/orbit-core/tests/grok_cli_backend_smoke.rs
@@ -60,7 +60,7 @@ fn installed_grok_cli_backend_smoke_captures_stdout_artifact() {
         orbit_store::Store::open_in_memory().expect("audit store"),
         "ws_test",
         "grok-installed-smoke",
-        "grok:grok-4.5".to_string(),
+        "grok:grok-4.6".to_string(),
         None,
     )
     .expect("build audit writer");
@@ -68,7 +68,7 @@ fn installed_grok_cli_backend_smoke_captures_stdout_artifact() {
         instruction: "Return the requested Orbit response envelope.".to_string(),
         tools: Vec::new(),
         on_denial: OnDenial::Terminate,
-        model: Some("grok-4.5".to_string()),
+        model: Some("grok-4.6".to_string()),
         max_iterations: 1,
         backend: Backend::Cli,
         provider: Provider::Grok,
@@ -118,5 +118,5 @@ fn installed_grok_cli_backend_smoke_captures_stdout_artifact() {
         .as_ref()
         .expect("well-formed grok stdout should parse invocation trace");
     assert_eq!(invocation.provider, "grok");
-    assert_eq!(invocation.model.as_deref(), Some("grok-4.5"));
+    assert_eq!(invocation.model.as_deref(), Some("grok-4.6"));
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -63,7 +63,7 @@ A **crew** is one provider-model-backend assignment. Activities do not carry a m
 
 | Field | Purpose | Values |
 |---|---|---|
-| `model` | Model identifier passed to the provider CLI | Provider-specific (e.g. `opus`, `sonnet`, `gpt-5.6-sol`, `pro`, `grok-4.5`) |
+| `model` | Model identifier passed to the provider CLI | Provider-specific (e.g. `opus`, `sonnet`, `gpt-5.6-sol`, `pro`, `grok-4.6`) |
 | `provider` | Agent family | `claude`, `codex`, `gemini`, `grok` (the CLI-executable families; see [Provider identity and resolution](#provider-identity-and-resolution) for the full canonical set) |
 | `backend` | How Orbit dispatches the agent | `cli` (today the only supported value for crew dispatch) |
 | `description` | Optional human-facing crew summary | Any non-empty string after trimming |
@@ -84,12 +84,12 @@ Example — the standard Grok crew:
 
 ```toml
 [crews.grok]
-model = "grok-4.5"
+model = "grok-4.6"
 provider = "grok"
 backend = "cli"
 ```
 
-The current Grok Build CLI lists `grok-4.5` as its default from `grok models`, so Orbit uses that live menu id. The older `grok-build` string is not retained as a default or alias.
+The current Grok Build CLI lists `grok-4.6` as its default from `grok models`, so Orbit uses that live menu id. The older `grok-build` string is not retained as a default or alias.
 
 Fresh `orbit init` configuration advertises only detected provider CLIs. Claude seeds `opus`, `sonnet`, and `fable`; Codex seeds `sol`, `terra`, and `luna`; Gemini seeds `gemini`; and Grok seeds `grok`. When Codex or Claude is available, `qa` uses Terra or Sonnet respectively. Every generated entry uses the CLI backend. If no supported provider CLI is detected, init leaves both the crew registry and `workflow.default_crew` unset instead of writing an unusable provider.
 


### PR DESCRIPTION
## Task

[ORB-10756](https://orbit-cli.com/tasks/ORB-10756) — Bump default Grok model from grok-4.5 to grok-4.6

### Description

## Problem
Orbit still pins the Grok default to `grok-4.5` — `GROK_DEFAULT_MODEL` in `orbit-common`, the shipped Grok executor model pair, `orbit init` / config tests, the workspace `[crews.grok]` entry, and `docs/CONFIG.md`. On dk-server-1 (2026-08-13), `grok models` lists **`grok-4.6` as the default** (menu also still offers `grok-4.5`).

This is the same class of pin bump as ORB-10741 (`grok-build` → `grok-4.5`).

## Why It Matters
`crew=grok` and any path that falls through `GROK_DEFAULT_MODEL` currently pass a stale menu id. Fresh `orbit init` would keep seeding `grok-4.5` after the CLI default moved.

## Constraints / Notes
- Confirm the live `grok models` default on the executor host before editing. Canonical id is `grok-4.6` as of 2026-08-13 (`grok 1.0.3`).
- Keep one canonical default: `GROK_DEFAULT_MODEL`, the executor asset pair, init seed, workspace crew, and CONFIG.md must agree.
- Do not invent multi-tier Grok crews. Do not revive `grok-build` as a default or alias.
- Do not expand into pricing tables unless a test actually requires a `grok-4.6` price row.
- Workspace config pins outside this repo are handled separately (constellation + polaris tracked configs; other workspaces gitignore `.orbit/config.toml`).
- Follow the existing ORB-10741 change set; do not refactor provider resolution.


### Acceptance Criteria

- `grok models` on the executor host still lists `grok-4.6` as the default menu id before the pin is changed; if the live default differs, stop and record the actual id.
- `GROK_DEFAULT_MODEL` in `crates/orbit-common/src/model_defaults.rs` is `grok-4.6`.
- `crates/orbit-core/assets/executors/grok.yaml` model pair (`strong` and `weak`) is `grok-4.6`.
- Workspace `.orbit/config.toml` `[crews.grok].model` is `grok-4.6`.
- `docs/CONFIG.md` Grok example, table, and `grok models` note say `grok-4.6` (keep the existing note that `grok-build` is not a default or alias).
- Hardcoded `grok-4.5` fixtures in init/bootstrap/runtime/provider/smoke tests are updated so they stay consistent with `GROK_DEFAULT_MODEL`.
- Targeted tests covering those fixtures pass (or the exact sandbox/CI skip is recorded if the runner cannot compile).

## Execution Summary

<details>
<summary>Click to expand</summary>

## Outcome
success

## Changes
- Confirmed live `grok models` default on executor host is `grok-4.6` (menu still offers `grok-4.5`).
- Bumped `GROK_DEFAULT_MODEL` to `grok-4.6` in `crates/orbit-common/src/model_defaults.rs`.
- Bumped shipped Grok executor model pair (`strong`/`weak`) in `crates/orbit-core/assets/executors/grok.yaml`.
- Bumped workspace `.orbit/config.toml` `[crews.grok].model` to `grok-4.6`.
- Updated `docs/CONFIG.md` table, Grok example, and `grok models` note to `grok-4.6` (kept note that `grok-build` is not a default/alias).
- Updated hardcoded `grok-4.5` fixtures in init/bootstrap/runtime/provider/smoke tests to `grok-4.6`.

## Validation
- `cargo test -p orbit-agent --lib providers::grok::tests::grok_cli` — pass (1)
- `cargo test -p orbit-core --lib bootstrap` — pass (includes grok crew seed assertions)
- `cargo test -p orbit-core --lib config::tests` — pass (79; includes runtime built-in crew defaults)
- `cargo test -p orbit-cli --bin orbit command::tests::init` — pass (8)
- Integration smoke `grok_cli_backend_smoke` not executed (fixture strings updated only; live end-to-end CLI smoke left to CI/optional runs)
- Unrelated pre-existing workspace-init routine seed failures observed under broader `orbit-cli init` filter; not caused by this pin bump

## Assessment
Scoped pin bump matching ORB-10741 pattern. Canonical default, executor asset, workspace crew, docs, and listed fixtures now agree on `grok-4.6`. No provider-resolution refactor, no pricing-table expansion, no multi-tier Grok crews.

## Friction
None filed — no contradicted assumptions or tooling gotchas beyond expected compile time.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10756-6a7d35fa`
- Behind base: 0
- Ahead of base: 1