### PR TITLE
Remove dashboard tests that spawn live pipeline workers

### DIFF
--- a/crates/orbit-dashboard/src/api/tests/runs.rs
+++ b/crates/orbit-dashboard/src/api/tests/runs.rs
@@ -8,40 +8,21 @@ use axum::body::Body;
 use axum::http::{Method, Request, StatusCode, header};
 use axum::response::Response;
 use chrono::Utc;
-use orbit_common::types::{Workspace, WorkspaceCheckout, WorkspaceStatus};
 use orbit_common::utility::blob_store::BlobStore;
 use orbit_core::command::job::JobRunListParams;
 use orbit_core::command::task::TaskAddParams;
-use orbit_core::runtime::WorkspaceRuntimeBinding;
-use orbit_core::{JobRunState, OrbitRuntime, ShipMode, TaskStatus, V2AuditEventInsertParams};
-use orbit_remote::runtime::RemoteRuntimeFactory;
+use orbit_core::{JobRunState, OrbitRuntime, TaskStatus, V2AuditEventInsertParams};
 use serde_json::{Value, json};
 use tower::ServiceExt;
 
 use super::super::router;
 use super::super::runs::*;
-use super::test_support::{
-    body_json, seed_run, write_replay_job, write_replay_job_under, write_seeded_run,
-};
+use super::test_support::{body_json, seed_run, write_replay_job, write_seeded_run};
 
 async fn request_cancel(runtime: OrbitRuntime, run_id: &str, origin: Option<&str>) -> Response {
     let mut builder = Request::builder()
         .method(Method::POST)
         .uri(format!("/runs/{run_id}/cancel"));
-    if let Some(origin) = origin {
-        builder = builder.header(header::ORIGIN, origin);
-    }
-    router()
-        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
-        .oneshot(builder.body(Body::empty()).expect("request"))
-        .await
-        .expect("response")
-}
-
-async fn request_replay(runtime: OrbitRuntime, run_id: &str, origin: Option<&str>) -> Response {
-    let mut builder = Request::builder()
-        .method(Method::POST)
-        .uri(format!("/runs/{run_id}/replay"));
     if let Some(origin) = origin {
         builder = builder.header(header::ORIGIN, origin);
     }
@@ -473,154 +454,6 @@ async fn cancel_run_endpoint_applies_localhost_origin_guard() {
 }
 
 #[tokio::test]
-async fn replay_run_endpoint_returns_new_run_id_and_lineage() {
-    let runtime = OrbitRuntime::in_memory().expect("build runtime");
-    let job_path = write_replay_job(&runtime, "web_replay_success");
-    let source = runtime
-        .run_job_v2_from_yaml(&job_path, json!({ "seconds": 0 }), None)
-        .expect("source run succeeds");
-
-    let response = request_replay(
-        runtime.clone(),
-        &source.run_id,
-        Some("http://localhost:3000"),
-    )
-    .await;
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let payload = body_json(response).await;
-    let new_run_id = payload["run_id"].as_str().expect("new run id");
-    assert_ne!(new_run_id, source.run_id);
-    let stored = runtime.show_job_run(new_run_id).expect("show replay");
-    assert_eq!(stored.state, JobRunState::Success);
-    assert_eq!(
-        stored.retry_source_run_id.as_deref(),
-        Some(source.run_id.as_str())
-    );
-    let list_response = router()
-        .with_state(crate::state::DashboardState::single(Arc::new(
-            runtime.clone(),
-        )))
-        .oneshot(
-            Request::builder()
-                .uri("/job-runs?limit=10")
-                .body(Body::empty())
-                .expect("request"),
-        )
-        .await
-        .expect("list response");
-    assert_eq!(list_response.status(), StatusCode::OK);
-    let list_payload = body_json(list_response).await;
-    assert!(
-        list_payload
-            .as_array()
-            .expect("runs array")
-            .iter()
-            .any(|run| run["run_id"].as_str() == Some(new_run_id))
-    );
-
-    let detail = job_run_detail_to_json(&runtime, &stored);
-    assert_eq!(
-        detail["run"]["retry_source_run_id"].as_str(),
-        Some(source.run_id.as_str())
-    );
-}
-
-#[tokio::test]
-async fn replay_run_endpoint_returns_4xx_when_current_job_is_deleted() {
-    let runtime = OrbitRuntime::in_memory().expect("build runtime");
-    let job_path = write_replay_job(&runtime, "web_replay_deleted");
-    let source = runtime
-        .run_job_v2_from_yaml(&job_path, json!({ "seconds": 0 }), None)
-        .expect("source run succeeds");
-    std::fs::remove_file(&job_path).expect("delete job yaml");
-
-    let response = request_replay(
-        runtime.clone(),
-        &source.run_id,
-        Some("http://localhost:3000"),
-    )
-    .await;
-
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    let payload = body_json(response).await;
-    assert!(
-        payload["error"]
-            .as_str()
-            .is_some_and(|message| message.contains("job not found"))
-    );
-}
-
-/// [ORB-10470] Resume is a submission, not an execution: the response carries
-/// the new run id and its lineage as soon as the run is durable, and the
-/// resumed pipeline runs in a detached worker rather than on the request
-/// thread (F2026-07-122 defect 3).
-#[tokio::test]
-async fn resume_job_run_endpoint_submits_a_linked_run_without_executing_it_in_request() {
-    let runtime = OrbitRuntime::in_memory().expect("build runtime");
-    write_replay_job(&runtime, "web_resume_success");
-    let mut source = seed_run(
-        &runtime,
-        "jrun-web-resume-failed",
-        "web_resume_success",
-        JobRunState::Failed,
-    );
-    source.input = Some(json!({ "seconds": 0 }));
-    write_seeded_run(&runtime, &source);
-
-    let response = request_resume(
-        runtime.clone(),
-        &source.run_id,
-        Some("http://localhost:3000"),
-    )
-    .await;
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let payload = body_json(response).await;
-    let new_run_id = payload["run_id"].as_str().expect("new run id");
-    assert_ne!(new_run_id, source.run_id);
-    assert_eq!(payload["workflow"], "resume");
-    assert_eq!(payload["job_id"], "web_resume_success");
-    assert!(
-        matches!(payload["state"].as_str(), Some("submitted" | "queued")),
-        "resume returns a submission state, not a terminal one: {payload}",
-    );
-    assert_eq!(
-        payload["retry_source_run_id"].as_str(),
-        Some(source.run_id.as_str())
-    );
-    let stored = runtime.show_job_run(new_run_id).expect("show resumed run");
-    assert_eq!(
-        stored.retry_source_run_id.as_deref(),
-        Some(source.run_id.as_str())
-    );
-    assert_eq!(stored.attempt, source.attempt + 1);
-
-    // Run listing answers while the resumed run is outstanding.
-    let list_response = router()
-        .with_state(crate::state::DashboardState::single(Arc::new(
-            runtime.clone(),
-        )))
-        .oneshot(
-            Request::builder()
-                .uri("/job-runs?limit=10")
-                .body(Body::empty())
-                .expect("request"),
-        )
-        .await
-        .expect("list response");
-    assert_eq!(list_response.status(), StatusCode::OK);
-    let list_payload = body_json(list_response).await;
-    assert!(
-        list_payload
-            .as_array()
-            .expect("runs array")
-            .iter()
-            .any(|run| run["run_id"].as_str() == Some(new_run_id))
-    );
-}
-
-#[tokio::test]
 async fn resume_job_run_endpoint_rejects_non_terminal_run_with_guard_reason() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     let source = seed_run(
@@ -822,66 +655,6 @@ async fn request_ship(runtime: OrbitRuntime, body: Option<Value>) -> Response {
         .expect("response")
 }
 
-fn ship_runtime() -> (tempfile::TempDir, OrbitRuntime, String) {
-    let root = tempfile::tempdir().expect("tempdir");
-    let global_root = root.path().join("global");
-    let orbit_root = root.path().join("repo/.orbit");
-    std::fs::create_dir_all(&global_root).expect("create global root");
-    std::fs::create_dir_all(&orbit_root).expect("create orbit root");
-    std::fs::write(
-        orbit_root.join("config.toml"),
-        "[workflow]\nbase_branch = \"main\"\n",
-    )
-    .expect("write config");
-    write_replay_job_under(&global_root, "task_auto_pipeline");
-    let runtime = OrbitRuntime::from_roots(&global_root, &orbit_root).expect("build runtime");
-    let task_id = runtime
-        .add_task(TaskAddParams {
-            title: "ship endpoint fixture".to_string(),
-            description: "persist canonical ship input".to_string(),
-            plan: "submit only".to_string(),
-            status: Some(orbit_core::TaskStatus::Backlog),
-            ..TaskAddParams::default()
-        })
-        .expect("add ship fixture task")
-        .id;
-    (root, runtime, task_id)
-}
-
-#[tokio::test]
-async fn ship_endpoint_submits_task_auto_pipeline_run() {
-    let (_root, runtime, task_id) = ship_runtime();
-
-    let response = request_ship(
-        runtime.clone(),
-        Some(json!({
-            "task_ids": [task_id],
-            "mode": "pr",
-        })),
-    )
-    .await;
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let payload = body_json(response).await;
-    assert_eq!(payload["workflow"].as_str(), Some("ship"));
-    assert_eq!(payload["job_id"].as_str(), Some("task_auto_pipeline"));
-    assert!(matches!(
-        payload["state"].as_str(),
-        Some("queued" | "submitted")
-    ));
-    let run_id = payload["run_id"].as_str().expect("run id");
-    let stored = runtime.show_job_run(run_id).expect("stored ship run");
-    assert_eq!(stored.job_id, "task_auto_pipeline");
-    assert_eq!(
-        stored.input,
-        Some(json!({
-            "mode": "pr",
-            "base_branch": "main",
-            "task_ids": [task_id],
-        }))
-    );
-}
-
 #[tokio::test]
 async fn ship_endpoint_rejects_unknown_mode() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
@@ -895,45 +668,6 @@ async fn ship_endpoint_rejects_unknown_mode() {
             .as_str()
             .is_some_and(|message| message.contains("unknown ship mode"))
     );
-}
-
-/// Create an on-disk workspace under `base/<name>`, so global mode can build
-/// its runtime lazily via `from_roots`. Returns `(orbit_dir, repo_root)`. The
-/// `task_auto_pipeline` job asset itself is a *default* job resolved from the
-/// global orbit root — seed it there once via `write_replay_job_under`.
-fn seed_ship_workspace(
-    base: &std::path::Path,
-    name: &str,
-) -> (std::path::PathBuf, std::path::PathBuf) {
-    let repo_root = base.join(name);
-    let orbit_dir = repo_root.join(".orbit");
-    std::fs::create_dir_all(&orbit_dir).expect("create .orbit");
-    std::fs::write(orbit_dir.join("config.toml"), "").expect("write config");
-    std::fs::write(
-        orbit_dir.join("config.yaml"),
-        format!("schema_version: 1\nworkspace_id: ws_{name}\n"),
-    )
-    .expect("write workspace identity");
-    (orbit_dir, repo_root)
-}
-
-fn ship_workspace_entry(
-    id: &str,
-    repo_root: std::path::PathBuf,
-    orbit_dir: std::path::PathBuf,
-) -> crate::state::WsEntry {
-    crate::state::WsEntry {
-        id: id.to_string(),
-        name: id.to_string(),
-        binding: Some(WorkspaceRuntimeBinding {
-            workspace_id: format!("ws_{id}"),
-            repo_root: repo_root.clone(),
-            ship_mode: ShipMode::Local,
-        }),
-        repo_root,
-        orbit_dir,
-        active: true,
-    }
 }
 
 async fn request_ship_global(
@@ -954,60 +688,6 @@ async fn request_ship_global(
         )
         .await
         .expect("response")
-}
-
-/// ORB-10008: `POST /workflows/ship?workspace=<id>` in aggregate (global)
-/// mode submits the run into the selected workspace only. Drives the real
-/// submission path (job asset load, run insert, worker spawn) over on-disk
-/// temp workspaces; the job asset is the stub sleep workflow, so no git or
-/// agent machinery runs.
-#[tokio::test]
-async fn ship_endpoint_in_global_mode_targets_selected_workspace() {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let global_root = tmp.path().join("global");
-    std::fs::create_dir_all(&global_root).expect("create global root");
-    write_replay_job_under(&global_root, "task_auto_pipeline");
-    let (alpha_orbit, alpha_repo) = seed_ship_workspace(tmp.path(), "alpha");
-    let (beta_orbit, beta_repo) = seed_ship_workspace(tmp.path(), "beta");
-    let entries = vec![
-        ship_workspace_entry("alpha", alpha_repo, alpha_orbit.clone()),
-        ship_workspace_entry("beta", beta_repo, beta_orbit.clone()),
-    ];
-    let state = crate::state::DashboardState::global(
-        global_root.clone(),
-        entries,
-        Some("alpha".to_string()),
-    );
-
-    // Exercise the non-default `local` ship mode against the non-default
-    // workspace so both selection and mode parsing are load-bearing.
-    let response = request_ship_global(
-        state,
-        "/workflows/ship?workspace=beta",
-        json!({ "mode": "local" }),
-    )
-    .await;
-
-    let status = response.status();
-    let payload = body_json(response).await;
-    assert_eq!(status, StatusCode::OK, "unexpected response: {payload}");
-    assert_eq!(payload["workflow"].as_str(), Some("ship"));
-    assert_eq!(payload["job_id"].as_str(), Some("task_auto_pipeline"));
-    assert!(matches!(
-        payload["state"].as_str(),
-        Some("queued" | "submitted")
-    ));
-    let run_id = payload["run_id"].as_str().expect("run id");
-
-    // The run is persisted in beta...
-    let beta_runtime =
-        OrbitRuntime::from_roots(&global_root, &beta_orbit).expect("reopen beta workspace");
-    let stored = beta_runtime.show_job_run(run_id).expect("stored ship run");
-    assert_eq!(stored.job_id, "task_auto_pipeline");
-    // ...and nowhere else.
-    let alpha_runtime =
-        OrbitRuntime::from_roots(&global_root, &alpha_orbit).expect("reopen alpha workspace");
-    assert!(alpha_runtime.show_job_run(run_id).is_err());
 }
 
 /// ORB-10008: an unknown `?workspace=` on the ship endpoint is a clean 404
@@ -1033,95 +713,40 @@ async fn ship_endpoint_rejects_unknown_workspace_with_404_json() {
     );
 }
 
-#[tokio::test]
-async fn ship_endpoint_without_review_controls_persists_canonical_input() {
-    let runtime = OrbitRuntime::in_memory().expect("build runtime");
-    write_replay_job(&runtime, "task_auto_pipeline");
-
-    let response = request_ship(runtime.clone(), Some(json!({ "mode": "pr" }))).await;
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let payload = body_json(response).await;
-    let run_id = payload["run_id"].as_str().expect("run id");
-    let run = runtime
-        .list_job_runs(JobRunListParams::default())
-        .expect("list submitted runs")
-        .into_iter()
-        .find(|run| run.run_id == run_id)
-        .expect("submitted run exists");
-    let input = run.input.expect("persisted run input");
-    assert_eq!(input["mode"], "pr");
-}
-
-/// ORB-10444: the dashboard's one-click Ship posts nothing but the task id —
-/// no crew and no mode. The dispatch must carry that task id through, resolve
-/// the mode from the selected workspace's own binding (`local` here, not the
-/// endpoint's historical `pr` default), and leave crew resolution to the
-/// pipeline, which reads the task's own record.
-#[tokio::test]
-async fn ship_endpoint_without_overrides_uses_task_id_and_workspace_ship_mode() {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let global_root = tmp.path().join("global");
-    std::fs::create_dir_all(&global_root).expect("create global root");
-    write_replay_job_under(&global_root, "task_auto_pipeline");
-    let (beta_orbit, beta_repo) = seed_ship_workspace(tmp.path(), "beta");
-    let state = crate::state::DashboardState::global(
-        global_root.clone(),
-        vec![ship_workspace_entry("beta", beta_repo, beta_orbit.clone())],
-        Some("beta".to_string()),
-    );
-
-    // Exactly the body the Ship button sends: the task id and nothing else.
-    let response = request_ship_global(
-        state,
-        "/workflows/ship",
-        json!({ "task_ids": ["ORB-10444"] }),
-    )
-    .await;
-
-    let status = response.status();
-    let payload = body_json(response).await;
-    assert_eq!(status, StatusCode::OK, "unexpected response: {payload}");
-    let run_id = payload["run_id"].as_str().expect("run id");
-
-    let beta_runtime =
-        OrbitRuntime::from_roots(&global_root, &beta_orbit).expect("reopen beta workspace");
-    let input = beta_runtime
-        .show_job_run(run_id)
-        .expect("stored ship run")
-        .input
-        .expect("persisted run input");
-    assert_eq!(input["task_ids"], json!(["ORB-10444"]));
-    // The workspace entry is bound to `ShipMode::Local`, so an omitted `mode`
-    // resolves to `local` rather than the endpoint's legacy `pr` fallback.
-    assert_eq!(input["mode"], "local");
-    assert!(
-        input.get("crew").is_none(),
-        "one-click Ship must not send a crew override: {input}"
-    );
-}
-
 /// ORB-10444: Ship is a write against a live pipeline, so a second click while
 /// the task already has a run in flight must not create a duplicate run. The
 /// in-flight run is seeded as `pending` with no owner pid, which the run-owner
 /// reconciler leaves alone inside its unclaimed grace window — so the guard,
 /// not a reconciliation race, is what this asserts.
+///
+/// Explicit task ids are validated before the guard (shared `submit_ship_run`
+/// path), so the fixture seeds a real backlog task rather than a synthetic id.
+/// Refusal still happens before job submit, so no pipeline worker is spawned.
 #[tokio::test]
 async fn ship_endpoint_refuses_second_dispatch_while_task_run_is_in_flight() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     write_replay_job(&runtime, "task_auto_pipeline");
+    let task_id = runtime
+        .add_task(TaskAddParams {
+            title: "in-flight ship guard fixture".to_string(),
+            description: "seeded so explicit ship selection validates".to_string(),
+            status: Some(TaskStatus::Backlog),
+            ..TaskAddParams::default()
+        })
+        .expect("seed ship fixture task")
+        .id;
     let mut in_flight = seed_run(
         &runtime,
         "jrun-in-flight",
         "task_auto_pipeline",
         JobRunState::Pending,
     );
-    in_flight.input = Some(json!({ "mode": "local", "task_ids": ["ORB-10444"] }));
+    in_flight.input = Some(json!({ "mode": "local", "task_ids": [task_id] }));
     write_seeded_run(&runtime, &in_flight);
 
     let response = request_ship(
         runtime.clone(),
-        Some(json!({ "task_ids": ["ORB-10444"], "mode": "local" })),
+        Some(json!({ "task_ids": [task_id], "mode": "local" })),
     )
     .await;
 
@@ -1129,7 +754,7 @@ async fn ship_endpoint_refuses_second_dispatch_while_task_run_is_in_flight() {
     let payload = body_json(response).await;
     assert_eq!(payload["code"].as_str(), Some("ship_run_in_flight"));
     assert_eq!(payload["run_id"].as_str(), Some("jrun-in-flight"));
-    assert_eq!(payload["task_id"].as_str(), Some("ORB-10444"));
+    assert_eq!(payload["task_id"].as_str(), Some(task_id.as_str()));
 
     let runs = runtime
         .list_job_runs(JobRunListParams::default())
@@ -1139,59 +764,6 @@ async fn ship_endpoint_refuses_second_dispatch_while_task_run_is_in_flight() {
         1,
         "the rejected second click must not persist another run: {runs:?}"
     );
-}
-
-/// The in-flight guard keys on the task id, so a *different* task is still
-/// shippable while one run is in flight, and auto (no task ids) mode — which
-/// has nothing to key on — is untouched.
-#[tokio::test]
-async fn ship_endpoint_in_flight_guard_is_scoped_to_the_shipped_task() {
-    let runtime = OrbitRuntime::in_memory().expect("build runtime");
-    write_replay_job(&runtime, "task_auto_pipeline");
-    let mut in_flight = seed_run(
-        &runtime,
-        "jrun-other-task",
-        "task_auto_pipeline",
-        JobRunState::Pending,
-    );
-    in_flight.input = Some(json!({ "mode": "local", "task_ids": ["ORB-10001"] }));
-    write_seeded_run(&runtime, &in_flight);
-
-    let response = request_ship(
-        runtime.clone(),
-        Some(json!({ "task_ids": ["ORB-10444"], "mode": "local" })),
-    )
-    .await;
-
-    let status = response.status();
-    let payload = body_json(response).await;
-    assert_eq!(status, StatusCode::OK, "unexpected response: {payload}");
-}
-
-/// A terminal run holding the same task id is history, not contention: the
-/// guard must not wedge re-shipping a task whose previous run already finished.
-#[tokio::test]
-async fn ship_endpoint_allows_dispatch_after_the_previous_run_is_terminal() {
-    let runtime = OrbitRuntime::in_memory().expect("build runtime");
-    write_replay_job(&runtime, "task_auto_pipeline");
-    let mut finished = seed_run(
-        &runtime,
-        "jrun-finished",
-        "task_auto_pipeline",
-        JobRunState::Success,
-    );
-    finished.input = Some(json!({ "mode": "local", "task_ids": ["ORB-10444"] }));
-    write_seeded_run(&runtime, &finished);
-
-    let response = request_ship(
-        runtime.clone(),
-        Some(json!({ "task_ids": ["ORB-10444"], "mode": "local" })),
-    )
-    .await;
-
-    let status = response.status();
-    let payload = body_json(response).await;
-    assert_eq!(status, StatusCode::OK, "unexpected response: {payload}");
 }
 
 #[tokio::test]
@@ -1212,135 +784,4 @@ async fn ship_endpoint_rejects_duplicate_task_ids() {
             .as_str()
             .is_some_and(|message| message.contains("duplicate task id"))
     );
-}
-
-/// ORB-10540: the MCP `orbit.workflow.ship` tool and `POST /api/workflows/ship`
-/// are two front doors onto one irreversible operation, so they have to agree.
-///
-/// Both calls name the same explicit task ids and neither states a mode, so the
-/// resolved ship mode is derived rather than echoed — the workspace binding here
-/// is `local`, which is *not* the endpoint's historical `pr` fallback, so a
-/// surface that resolved the mode its own way would show up as a mismatch.
-///
-/// ORB-10544 made the duplicate-dispatch guard shared, so each surface now gets
-/// its own disjoint task selection and the call order carries no meaning: the
-/// tool goes first here — the reverse of the order this test was once forced
-/// into — and both surfaces dispatch. Equivalence is asserted on what the two
-/// surfaces *derive* (the resolved mode, the job) and on each having persisted
-/// its own selection verbatim.
-///
-/// `ORBIT_OPERATOR` is how this crate's tests reach an operator-authorized tool
-/// call: `run_tool_with_context_and_role` — the form a validated MCP operator
-/// session takes — is crate-private to `orbit-core`, and the session-capability
-/// spelling of these same tools is covered by the `orbit-core` tool-host tests.
-/// Both spellings resolve to `McpCapability::Operator` at the one chokepoint and
-/// then execute the identical tool.
-#[tokio::test]
-async fn mcp_ship_tool_and_http_ship_endpoint_produce_equivalent_runs() {
-    const TOOL_TASK_IDS: [&str; 2] = ["TST-00001", "TST-00002"];
-    const HTTP_TASK_IDS: [&str; 2] = ["TST-00003", "TST-00004"];
-
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let global_root = tmp.path().join("global");
-    std::fs::create_dir_all(&global_root).expect("create global root");
-    std::fs::write(
-        global_root.join("host.toml"),
-        "schema_version = 2\nmachine_id = \"hm_ship_parity\"\nhost_id = \"ship-parity\"\ntask_prefix = \"TST\"\n",
-    )
-    .expect("write fixture host identity");
-    write_replay_job_under(&global_root, "task_auto_pipeline");
-    let (orbit_dir, repo_root) = seed_ship_workspace(tmp.path(), "alpha");
-    let workspace = Workspace {
-        id: "alpha".to_string(),
-        name: "alpha".to_string(),
-        owner_machine_id: Some("hm_ship_parity".to_string()),
-        git_remote: None,
-        ship_mode: Some("local".to_string()),
-        base_branch: "main".to_string(),
-        status: WorkspaceStatus::Active,
-        created_at: Utc::now(),
-        updated_at: Utc::now(),
-    };
-    let checkout = WorkspaceCheckout::owner(workspace.id.clone(), repo_root, orbit_dir);
-    let runtime =
-        RemoteRuntimeFactory::open_registered_checkout(&global_root, &workspace, &checkout)
-            .expect("build bound runtime");
-
-    // Ship validates every explicit task id before creating a run. Seed those
-    // records through the same workspace-bound runtime that both front doors
-    // receive, rather than relying on synthetic ids that exist in no store.
-    let allocator_seed = runtime
-        .add_task(TaskAddParams {
-            title: "ship parity allocator seed".to_string(),
-            description: "Reserves the first synthetic task id.".to_string(),
-            status: Some(TaskStatus::Backlog),
-            ..TaskAddParams::default()
-        })
-        .expect("seed task allocator");
-    assert_eq!(allocator_seed.id, "TST-00000");
-    for task_id in TOOL_TASK_IDS.into_iter().chain(HTTP_TASK_IDS) {
-        let task = runtime
-            .add_task(TaskAddParams {
-                title: format!("ship parity fixture {task_id}"),
-                description: "Task selected by one ship parity front door.".to_string(),
-                status: Some(TaskStatus::Backlog),
-                ..TaskAddParams::default()
-            })
-            .expect("seed selected ship task");
-        assert_eq!(task.id, task_id);
-        assert_eq!(
-            runtime
-                .get_task(task_id)
-                .expect("seeded task is visible")
-                .id,
-            task_id
-        );
-    }
-
-    // Scoped to the synchronous tool call: the guard holds a process-wide lock,
-    // which must not span an `.await`.
-    let tool = {
-        let _env = orbit_common::test_env::scoped(
-            std::iter::once((
-                orbit_common::authorization::OPERATOR_OVERRIDE_ENV,
-                Some("1"),
-            ))
-            .chain(
-                orbit_common::test_env::MANAGED_RUN_ENV
-                    .iter()
-                    .map(|name| (*name, None)),
-            ),
-        );
-        runtime
-            .run_tool("orbit.workflow.ship", json!({ "task_ids": TOOL_TASK_IDS }))
-            .expect("operator ship through the tool surface")
-    };
-
-    let response = request_ship(runtime.clone(), Some(json!({ "task_ids": HTTP_TASK_IDS }))).await;
-    let status = response.status();
-    let http = body_json(response).await;
-    assert_eq!(status, StatusCode::OK, "unexpected ship response: {http}");
-
-    assert_eq!(tool["workflow"], http["workflow"]);
-    assert_eq!(tool["job_id"], http["job_id"]);
-    assert_eq!(tool["job_id"], json!("task_auto_pipeline"));
-
-    let run_input = |payload: &Value| {
-        runtime
-            .show_job_run(payload["run_id"].as_str().expect("run id"))
-            .expect("submitted run is persisted")
-            .input
-            .expect("persisted run input")
-    };
-    let http_input = run_input(&http);
-    let tool_input = run_input(&tool);
-
-    assert_ne!(
-        http["run_id"], tool["run_id"],
-        "the two surfaces must produce distinct runs to compare"
-    );
-    assert_eq!(http_input["mode"], json!("local"));
-    assert_eq!(tool_input["mode"], http_input["mode"]);
-    assert_eq!(http_input["task_ids"], json!(HTTP_TASK_IDS));
-    assert_eq!(tool_input["task_ids"], json!(TOOL_TASK_IDS));
 }


### PR DESCRIPTION
## Task

[ORB-10757](https://orbit-cli.com/tasks/ORB-10757) — Remove dashboard tests that spawn live pipeline workers

### Description

## Problem
Several `orbit-dashboard` API tests drive the real job-submit path (`run_job_v2_from_yaml`, successful `POST /workflows/ship`, replay, resume, MCP `orbit.workflow.ship`). Submit always calls `spawn_pipeline_worker`, which execs `current_exe()` as `job run-pipeline-worker`.

Under `cargo nextest --workspace` that executable is the debug test binary (`target/debug/deps/orbit_dashboard-<hash>`). Each test therefore forks a short-lived, unoptimized tokio process. On dk-server-1 (2026-08-13, during `jrun-20260813-0227-3` / ORB-10746) this showed up in `top` as many 50–100% CPU `orbit_dashboard` processes. Those were not the live `orbit-web` service.

## Why It Matters
Workspace test runs on this box fork-bomb the host with debug worker lookalikes. The tests do not exercise a real CLI worker (the child is the test harness), so they are expensive and misleading.

## Constraints / Notes
Remove the submit-path tests. Do not rewrite them with mocks in this task.

Delete these tests in `crates/orbit-dashboard/src/api/tests/runs.rs` (names as of agent-main):
- `replay_run_endpoint_returns_new_run_id_and_lineage`
- `replay_run_endpoint_returns_4xx_when_current_job_is_deleted`
- `resume_job_run_endpoint_submits_a_linked_run_without_executing_it_in_request`
- `ship_endpoint_submits_task_auto_pipeline_run`
- `ship_endpoint_in_global_mode_targets_selected_workspace`
- `ship_endpoint_without_review_controls_persists_canonical_input`
- `ship_endpoint_without_overrides_uses_task_id_and_workspace_ship_mode`
- `ship_endpoint_in_flight_guard_is_scoped_to_the_shipped_task`
- `ship_endpoint_allows_dispatch_after_the_previous_run_is_terminal`
- `mcp_ship_tool_and_http_ship_endpoint_produce_equivalent_runs`

Keep tests that never spawn a worker: seeded read/cancel/list/event tests, and 4xx/409 guards that reject before submit (`ship_endpoint_rejects_unknown_mode`, `ship_endpoint_rejects_unknown_workspace_with_404_json`, `ship_endpoint_rejects_duplicate_task_ids`, `ship_endpoint_refuses_second_dispatch_while_task_run_is_in_flight`, resume reject tests).

Do not touch `orbit-core` pipeline-worker unit tests or production spawn logic. If a helper becomes unused after the deletions, remove it.


### Acceptance Criteria

- `rg -n 'run_job_v2_from_yaml|request_ship\(|run_tool\("orbit.workflow.ship"' crates/orbit-dashboard` no longer hits a `#[tokio::test]` that takes the successful submit path (replay/resume/ship/MCP ship). Validation-only 4xx tests may remain.
- Helpers used only by the deleted tests (`ship_runtime`, `write_replay_job` / `write_replay_job_under` if unused, etc.) are removed; no leftover dead functions or unused imports.
- `cargo test -p orbit-dashboard --lib` passes. A debug `orbit_dashboard-*` process must not appear as `job run-pipeline-worker` while that command runs (check `pgrep -af 'orbit_dashboard-.*run-pipeline-worker'` stays empty).
- Production submit/spawn code (`spawn_pipeline_worker`, `/workflows/ship`, replay/resume handlers) is unchanged.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Summary
Removed orbit-dashboard API tests that took the real job-submit path and forked `current_exe()` as `job run-pipeline-worker` (debug test binary under cargo nextest/test). Production submit/spawn code was not touched.

## Changes
- Deleted 10 submit-path tests from `crates/orbit-dashboard/src/api/tests/runs.rs`:
  replay success + deleted-job, resume success submit, five successful ship cases, in-flight scope success, post-terminal re-dispatch success, MCP/HTTP ship parity.
- Removed helpers only those tests used: `request_replay`, `ship_runtime`, `seed_ship_workspace`, `ship_workspace_entry`, and unused imports (`Workspace*`, `RemoteRuntimeFactory`, `ShipMode`, `write_replay_job_under` import).
- Kept pre-submit 4xx/409 guards: unknown mode/workspace, duplicate task ids, in-flight second dispatch, resume reject/not-found; plus seeded read/cancel/list/event tests.
- Kept `write_replay_job` / `write_replay_job_under` (still used by remaining ship 4xx fixtures).
- Fixture fix on kept `ship_endpoint_refuses_second_dispatch_while_task_run_is_in_flight`: seed a real backlog task before explicit ship selection. Shared `submit_ship_run` validates task existence before the in-flight guard; synthetic `ORB-10444` returned 404. Still rejects before submit (409), no worker spawn.

## Validation
- `cargo test -p orbit-dashboard --lib`: 206 passed, 0 failed.
- During that run, process sampling found no `orbit_dashboard-* … run-pipeline-worker` children (WORKER_HITS=0).
- `rg -n 'run_job_v2_from_yaml|request_ship\(|run_tool\("orbit.workflow.ship"' crates/orbit-dashboard` only hits helper + remaining 4xx ship tests (no successful submit path).
- Diff limited to `crates/orbit-dashboard/src/api/tests/runs.rs` (production spawn/handlers unchanged).

## Notes
- Did not rewrite deleted tests with mocks (out of scope).
- Status left in-progress for pipeline-owned review transition.
- Friction checkpoint: none filed (fixture gap fixed in-scope; no tooling contradiction).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10757-6a7d35fa`
- Behind base: 0
- Ahead of base: 1