### PR TITLE
[BLOCKED] Reconcile the checkoutless-client guard with the read-mirror clone the design permits

### DIFF
--- a/crates/orbit-remote/src/mcp/proxy.rs
+++ b/crates/orbit-remote/src/mcp/proxy.rs
@@ -10,7 +10,8 @@
 //! Orbit's other cross-machine MCP path is the spoke→hub link, which exists
 //! because a spoke *has* a checkout: its graph, docs, and search must resolve
 //! against the branch its agent is working on, and placement routing guarantees
-//! that. A **checkoutless client** — an off-box orchestrator whose every
+//! that. A **checkoutless client** — an off-box orchestrator that owns no
+//! workspace, whose clone (if it keeps one) is a read mirror, and whose every
 //! workspace lives on the remote machine — does not fit that shape. Placement
 //! routing protects nothing for it and only makes the canonical surface
 //! unreachable.
@@ -28,12 +29,12 @@
 //! compile cleanly while quietly failing every one of them.
 
 use std::net::{Ipv4Addr, SocketAddr, TcpStream};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::time::Duration;
 
 use orbit_common::types::{McpCapability, OrbitError, WorkspaceRegistry};
 use orbit_common::utility::ssh_tunnel::{self, TunnelOrigin, TunnelSpec};
-use orbit_core::runtime::{is_global_orbit_root, resolve_global_root};
+use orbit_core::runtime::resolve_global_root;
 
 /// Loopback port the remote `orbit mcp serve --listen` is expected on when the
 /// operator does not name one. Adjacent to the dashboard's 7878 so the two
@@ -70,7 +71,7 @@ pub struct RemoteProxyArgs {
 
 /// Serve a checkoutless client by relaying its stdio to a remote listener.
 ///
-/// Refuses on a machine that has its own Orbit checkout, establishes or
+/// Refuses on a machine that owns an Orbit checkout, establishes or
 /// attaches to one tunnel, opens one connection through it, and relays until
 /// the session ends. The tunnel is torn down on every exit path by
 /// [`ssh_tunnel::SshTunnel`]'s `Drop`.
@@ -180,7 +181,7 @@ fn listener_answers(local_port: u16, timeout: Duration) -> bool {
     }
 }
 
-/// Refuse to run the proxy on a machine that has its own Orbit checkout.
+/// Refuse to run the proxy on a machine that owns an Orbit checkout.
 ///
 /// This guard is load-bearing rather than a convenience. Without it a spoke
 /// could register the mode and receive another machine's branch state as its
@@ -192,62 +193,77 @@ fn ensure_checkoutless_client(ssh_host: &str) -> Result<(), OrbitError> {
             let path = crate::workspace_registry::registry_path_for(&global_root);
             crate::workspace_registry::load_registry_from(&path)?
         }
-        // No global root means no registry to consult; the cwd walk below is
-        // still meaningful, so this is not fatal on its own.
+        // No global root means no registry to consult, and the registry is the
+        // only thing this guard reads: a machine with nowhere to record a
+        // checkout binding owns none.
         Err(_) => WorkspaceRegistry::default(),
     };
     let cwd = std::env::current_dir().ok();
-    let discovered = cwd.as_deref().and_then(find_workspace_orbit_dir);
 
-    match local_checkout_evidence(&registry, discovered.as_deref()) {
+    match local_checkout_evidence(&registry, cwd.as_deref()) {
         None => Ok(()),
-        Some(evidence) => Err(OrbitError::InvalidInput(format!(
-            "refusing to start `orbit mcp serve --mode remote {ssh_host}`: this machine has a \
-             local Orbit checkout ({evidence}). The remote mode resolves every workspace on \
-             '{ssh_host}', so a machine with its own checkout would receive that machine's \
-             branch state as its own — wrong answers rather than an error (ADR-0350). Register \
-             the ordinary local broker (`orbit mcp serve`) here instead, and use the remote mode \
-             only from a client with no checkout."
-        ))),
+        Some(evidence) => Err(owned_checkout_refusal(ssh_host, &evidence)),
     }
 }
 
-/// Describe the first evidence that this machine holds a checkout, or `None`
-/// when it holds none.
+/// The refusal an owning machine gets: what was found, why it disqualifies the
+/// mode, and the surface to register instead.
+pub(super) fn owned_checkout_refusal(ssh_host: &str, evidence: &str) -> OrbitError {
+    OrbitError::InvalidInput(format!(
+        "refusing to start `orbit mcp serve --mode remote {ssh_host}`: this machine owns a local \
+         Orbit checkout ({evidence}). The remote mode resolves every workspace on '{ssh_host}', \
+         so a machine with its own checkout would receive that machine's branch state as its own \
+         — wrong answers rather than an error (ADR-0350). Register the ordinary local broker \
+         (`orbit mcp serve`) here instead, and use the remote mode only from a client that owns \
+         no checkout."
+    ))
+}
+
+/// Describe the first evidence that this machine *owns* a checkout, or `None`
+/// when it owns none.
 ///
-/// Two independent signals, because either alone can miss: a registered
-/// checkout that still exists on disk, and a workspace `.orbit/` reachable by
-/// walking up from the working directory (a checkout that was never
-/// registered). A registry entry whose `repo_root` is gone is stale rather than
-/// evidence — refusing on it would strand a client over a checkout that no
-/// longer exists.
+/// Two ordered signals, both registry-sourced: a checkout binding the directory
+/// we are standing in — which includes an explicit `path_overrides` entry whose
+/// `repo_root` may live elsewhere — and, failing that, any registered checkout
+/// still present on disk. A registry entry whose `repo_root` is gone is stale
+/// rather than evidence: refusing on it would strand a client over a checkout
+/// that no longer exists.
+// ADR-0360 — ownership, not filesystem shape, is the discriminator, which is
+// why a `.orbit/` directory sitting above `cwd` is not consulted at all. That
+// directory is deliberately committed in repos that version their Orbit
+// workspace, so it arrives with `git clone` and describes a read mirror just as
+// well as a working tree. This machine's workspace registry is the only
+// machine-local record of what it coordinates, and it is what the local broker
+// itself demands — `McpHost::resolve_exact_checkout` binds a session only to a
+// registered checkout — so an unregistered `.orbit/` leaves no local-derived
+// state for this guard to protect.
 pub(super) fn local_checkout_evidence(
     registry: &WorkspaceRegistry,
-    discovered_orbit_dir: Option<&Path>,
+    cwd: Option<&Path>,
 ) -> Option<String> {
-    if let Some((workspace, checkout)) = crate::workspace_registry::local_workspaces(registry)
-        .find(|(_, checkout)| checkout.repo_root.exists())
+    if let Some(cwd) = cwd
+        && let Some(checkout) = crate::workspace_registry::find_checkout_by_path(registry, cwd)
     {
+        // Name the registered path that actually claims `cwd`, which is the
+        // repository root unless an override binds a directory outside it.
+        let bound = std::iter::once(&checkout.repo_root)
+            .chain(&checkout.path_overrides)
+            .filter(|candidate| cwd.starts_with(candidate))
+            .max_by_key(|candidate| candidate.as_os_str().len())
+            .unwrap_or(&checkout.repo_root);
         return Some(format!(
-            "workspace '{}' is checked out at {}",
-            workspace.id,
-            checkout.repo_root.display()
+            "workspace '{}' is registered at {}, which contains the working directory",
+            checkout.workspace_id,
+            bound.display()
         ));
     }
-    discovered_orbit_dir.map(|orbit_dir| format!("a workspace exists at {}", orbit_dir.display()))
-}
-
-/// Walk up from `start` for the first workspace `.orbit/` directory, ignoring
-/// the global `$HOME/.orbit` — which is machine state every host has, checkout
-/// or not, and would otherwise refuse every client.
-fn find_workspace_orbit_dir(start: &Path) -> Option<PathBuf> {
-    let mut current = Some(start);
-    while let Some(directory) = current {
-        let candidate = directory.join(".orbit");
-        if candidate.is_dir() && !is_global_orbit_root(&candidate) {
-            return Some(candidate);
-        }
-        current = directory.parent();
-    }
-    None
+    crate::workspace_registry::local_workspaces(registry)
+        .find(|(_, checkout)| checkout.repo_root.exists())
+        .map(|(workspace, checkout)| {
+            format!(
+                "workspace '{}' is checked out at {}",
+                workspace.id,
+                checkout.repo_root.display()
+            )
+        })
 }

--- a/crates/orbit-remote/src/mcp/tests/proxy.rs
+++ b/crates/orbit-remote/src/mcp/tests/proxy.rs
@@ -9,8 +9,8 @@ use orbit_common::types::{
 };
 
 use super::super::proxy::{
-    DEFAULT_REMOTE_MCP_PORT, RemoteProxyArgs, local_checkout_evidence, remote_listen_command,
-    tunnel_spec,
+    DEFAULT_REMOTE_MCP_PORT, RemoteProxyArgs, local_checkout_evidence, owned_checkout_refusal,
+    remote_listen_command, tunnel_spec,
 };
 
 fn args(ssh_host: &str, capability: Option<McpCapability>) -> RemoteProxyArgs {
@@ -45,6 +45,19 @@ fn checkout(id: &str, repo_root: PathBuf) -> WorkspaceCheckout {
         owner_machine_id: None,
         path_overrides: Vec::new(),
     }
+}
+
+/// Lay down what a `git clone` of a repository that versions its Orbit
+/// workspace delivers: an `.orbit/` directory holding the committed partitions
+/// and `config.toml`, and nothing machine-local. This is the read mirror
+/// [ADR-0360] admits — the shape is identical to a working checkout's, which is
+/// exactly why the filesystem cannot be the discriminator.
+fn read_mirror(root: &Path) {
+    let orbit_dir = root.join(".orbit");
+    for partition in ["learnings", "auto_tasks", "resources", "routines"] {
+        std::fs::create_dir_all(orbit_dir.join(partition)).expect("mirror partition");
+    }
+    std::fs::write(orbit_dir.join("config.toml"), "[workflow]\n").expect("mirror config");
 }
 
 // ── the checkout guard ────────────────────────────────────────────────────
@@ -110,15 +123,83 @@ fn a_checkoutless_catalog_entry_alone_is_not_evidence() {
 }
 
 #[test]
-fn an_unregistered_workspace_under_the_cwd_refuses() {
-    // Second signal: a checkout that was never registered is still a checkout.
-    let discovered = Path::new("/srv/project/.orbit");
-    let evidence = local_checkout_evidence(&WorkspaceRegistry::default(), Some(discovered))
-        .expect("a discovered workspace must refuse");
+fn a_read_mirror_clone_is_admitted() {
+    // The client class this mode exists for [ORB-10761]. A repository that
+    // versions its `.orbit/` delivers the whole directory through `git clone`,
+    // so an unregistered one describes a read mirror, not ownership. Refusing
+    // on it would lock every mirror-carrying orchestrator out of the mode.
+    let mirror = tempfile::tempdir().expect("mirror root");
+    read_mirror(mirror.path());
+
+    let evidence = local_checkout_evidence(&WorkspaceRegistry::default(), Some(mirror.path()));
     assert!(
-        evidence.contains("/srv/project/.orbit"),
-        "the refusal must name what it discovered: {evidence}"
+        evidence.is_none(),
+        "a tracked `.orbit/` this machine's registry does not bind is not ownership: {evidence:?}"
     );
+}
+
+#[test]
+fn the_same_shape_refuses_once_the_registry_binds_it() {
+    // The other direction, over an identical filesystem: what changes the
+    // verdict is the machine-local registry entry, nothing on disk.
+    let repo = tempfile::tempdir().expect("repo root");
+    read_mirror(repo.path());
+    let registry = WorkspaceRegistry {
+        workspaces: vec![workspace("ws_owned")],
+        checkouts: vec![checkout("ws_owned", repo.path().to_path_buf())],
+        ..Default::default()
+    };
+
+    let evidence = local_checkout_evidence(&registry, Some(repo.path()))
+        .expect("an owned checkout must refuse");
+    assert!(
+        evidence.contains("ws_owned"),
+        "the refusal must name the owning workspace: {evidence}"
+    );
+    assert!(
+        evidence.contains(&repo.path().display().to_string()),
+        "the refusal must name where it is checked out: {evidence}"
+    );
+}
+
+#[test]
+fn an_override_path_binding_the_cwd_is_ownership() {
+    // A checkout can claim a directory outside its `repo_root` through an
+    // explicit override; standing in one is still standing in a workspace this
+    // machine coordinates.
+    let elsewhere = tempfile::tempdir().expect("override root");
+    let mut bound = checkout("ws_override", Path::new("/nonexistent/repo").to_path_buf());
+    bound.path_overrides = vec![elsewhere.path().to_path_buf()];
+    let registry = WorkspaceRegistry {
+        workspaces: vec![workspace("ws_override")],
+        checkouts: vec![bound],
+        ..Default::default()
+    };
+
+    let evidence = local_checkout_evidence(&registry, Some(elsewhere.path()))
+        .expect("a registered override path must refuse");
+    assert!(
+        evidence.contains("ws_override"),
+        "the refusal must name the owning workspace: {evidence}"
+    );
+    assert!(
+        evidence.contains(&elsewhere.path().display().to_string()),
+        "the refusal must name the registered path that claims the cwd, not an absent \
+         repository root: {evidence}"
+    );
+}
+
+#[test]
+fn the_refusal_names_the_evidence_and_the_local_broker() {
+    // An operator who hits this needs both halves: what disqualified the
+    // machine, and the surface to register in its place.
+    let refusal =
+        owned_checkout_refusal("my-box", "workspace 'ws_owned' is checked out at /srv/ws")
+            .to_string();
+    assert!(refusal.contains("ws_owned"), "{refusal}");
+    assert!(refusal.contains("/srv/ws"), "{refusal}");
+    assert!(refusal.contains("`orbit mcp serve`"), "{refusal}");
+    assert!(refusal.contains("my-box"), "{refusal}");
 }
 
 // ── the remote listener command ───────────────────────────────────────────

--- a/docs/design/mcp-bridge/2_design.md
+++ b/docs/design/mcp-bridge/2_design.md
@@ -11,7 +11,7 @@ summary: Target design for a local Orbit MCP broker with an SSH owner route, own
 tags: [mcp, remote-access, host-registry, bridge, ssh, routing]
 paths: ["crates/orbit-remote/**", "crates/orbit-mcp/**", "crates/orbit-core/**", "crates/orbit-tools/**", "crates/orbit-store/**", "crates/orbit-common/**"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access, orbit-search]
-related_artifacts: [ORB-00424, ORB-10257, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ORB-10330, ORB-10332, ORB-10534, ORB-10540, ORB-10544, ORB-10690, ORB-10710, ORB-10725, ORB-10727, ORB-10729, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240, ADR-0303, ADR-0348, ADR-0350, ADR-0351, ADR-0354, ADR-0355, ADR-0356, ADR-0357, ADR-0358]
+related_artifacts: [ORB-00424, ORB-10257, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ORB-10330, ORB-10332, ORB-10534, ORB-10540, ORB-10544, ORB-10690, ORB-10710, ORB-10725, ORB-10727, ORB-10729, ORB-10761, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240, ADR-0303, ADR-0348, ADR-0350, ADR-0351, ADR-0354, ADR-0355, ADR-0356, ADR-0357, ADR-0358, ADR-0360]
 ---
 
 # Orbit MCP Bridge — Design
@@ -507,12 +507,16 @@ a client has graph, docs, and search that must resolve against the branch its ag
 is working on, and placement (§4) exists to guarantee that.
 
 A second client class does not fit that shape. A **checkoutless client** is an MCP
-client with no local checkout that participates in this design — an off-box
-orchestrator whose clone, if it has one, is a read mirror, and whose every
-workspace lives on the remote machine. It owns no workspace and holds no
-local-derived state. Placement routing therefore protects nothing for it and only
-makes the canonical surface unreachable, which is what forces the re-declared
-parity layer §10 retires.
+client that owns no workspace this machine coordinates — an off-box orchestrator
+whose clone, if it has one, is a read mirror, and whose every workspace lives on
+the remote machine. "Owns no workspace" is a statement about this machine's
+workspace registry, not about the filesystem: a mirror carries a full `.orbit/`
+directory, because a repository that versions its Orbit workspace commits
+`config.toml` and the `learnings/`, `auto_tasks/`, `resources/`, and `routines/`
+partitions, and `git clone` delivers all of it. Holding that directory is
+therefore not holding local-derived state. Placement routing protects nothing for
+such a client and only makes the canonical surface unreachable, which is what
+forces the re-declared parity layer §10 retires.
 
 For this client, **reachability is the scarce resource, not tool schemas**. An
 orchestrator that cannot execute on the machine routes trivial reads through full
@@ -570,10 +574,23 @@ Every placement class resolves on the remote, which is correct precisely because
 the client holds no local-derived state. This narrows the placement rule to clients
 that hold local-derived state; owner-machine routing is defined in §4.2.
 
-**The mode refuses to start where a local checkout exists.** Without that guard a
-machine with a checkout could register it and receive another machine's branch state
-as its own, surfacing as wrong answers rather than as an error. The guard is the
-load-bearing half of the decision, not a convenience.
+**The mode refuses to start on a machine that owns a checkout.** Without that guard
+a machine with a checkout could register it and receive another machine's branch
+state as its own, surfacing as wrong answers rather than as an error. The guard is
+the load-bearing half of the decision, not a convenience.
+
+Ownership is read from this machine's workspace registry alone ([ADR-0360]): a
+checkout binding the working directory — including through an explicit path
+override — or any registered checkout whose repository root still exists. A stale
+registry row pointing at a deleted tree is history, not a checkout. An `.orbit/`
+directory the registry does not bind is **not** evidence and is not consulted,
+because it is exactly what a read mirror carries; the same rule the local broker
+already applies, since a session binds only to a registered checkout (§4.2) and an
+unregistered directory yields no local-derived state to protect. The refusal names
+the owning workspace, its path, and `orbit mcp serve` as the surface to register
+instead. The residual gap is a machine that develops in a checkout it never
+registered: it is admitted, and the mode will answer from the remote's branch state
+while a local tree sits under it.
 
 Nothing re-declares a schema or reshapes a response: both ends are the same build,
 so the drift §1 attributes to Bridge is structurally absent rather than tested
@@ -1215,5 +1232,9 @@ Required validation:
   refused off-owner naming the owning machine (§4.2, §6.1). It also moved crew
   discovery and task-crew validation onto the owner machine's local crew config
   and deleted the execution-profile projection service (§8.1).
+- [ORB-10761] — reconciled §5.3's checkoutless-client definition with the guard
+  that enforces it: ownership now comes from this machine's workspace registry
+  alone, so a read-mirror clone carrying a tracked `.orbit/` directory starts the
+  proxy while a registered on-disk checkout is still refused ([ADR-0360]).
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-bridge/4_decisions.md
+++ b/docs/design/mcp-bridge/4_decisions.md
@@ -1,17 +1,17 @@
 ---
 title: Orbit MCP Bridge — Decisions
 owner: claude
-last_updated: 2026-08-11
+last_updated: 2026-08-13
 last_validated: 2026-08-02
 status: Draft
 feature: mcp-bridge
 doc_role: decisions
 type: design
-summary: ADR log for mcp-bridge, including the retired singular-hub contract and its v1 ownership-model replacement, the evolving implementation boundary, and the owned tunnel for checkoutless clients.
+summary: ADR log for mcp-bridge, including the retired singular-hub contract and its v1 ownership-model replacement, the evolving implementation boundary, the owned tunnel for checkoutless clients, and the registry-ownership rule that admits a read-mirror clone.
 tags: [mcp, remote-access, host-registry, bridge]
 paths: ["crates/orbit-remote/**", "crates/orbit-mcp/**", "crates/orbit-core/**", "crates/orbit-tools/**", "crates/orbit-store/**"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access]
-related_artifacts: [ORB-00424, ORB-10245, ORB-10708, ORB-10710, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ORB-10330, ORB-10332, ORB-10690, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240, ADR-0348, ADR-0350, ADR-0351, ADR-0352, ADR-0354, ADR-0355, ADR-0356, ADR-0357, ADR-0358]
+related_artifacts: [ORB-00424, ORB-10245, ORB-10708, ORB-10710, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ORB-10330, ORB-10332, ORB-10690, ORB-10761, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240, ADR-0348, ADR-0350, ADR-0351, ADR-0352, ADR-0354, ADR-0355, ADR-0356, ADR-0357, ADR-0358, ADR-0360]
 ---
 
 # Orbit MCP Bridge — Decisions
@@ -508,6 +508,86 @@ Alternatives considered and rejected:
 - **Cost:** the server process gains a second protocol surface, and its availability now matters to work dispatch rather than only to the UI. Its failure modes are correspondingly more expensive.
 - The ungated HTTP API remains a bypass. This decision reduces what depends on it; it does not close it. That remains separately owned.
 
+## ADR-0360 — Workspace-registry ownership, not an `.orbit/` directory, disqualifies a checkoutless client
+
+**Status:** Accepted · 2026-08 · [ORB-10761]
+**Code anchors:** `crates/orbit-remote/src/mcp/proxy.rs::local_checkout_evidence`
+
+### Context
+
+[ADR-0350] makes the refuse-when-a-checkout-exists guard the load-bearing half
+of the remote proxy: without it a machine that coordinates its own workspaces
+could register the mode and receive another machine's branch state as its own,
+surfacing as wrong answers rather than as an error.
+
+The first implementation read two signals — a registered checkout still present
+on disk, and any `.orbit/` directory found by walking up from the working
+directory. The second signal cannot do the job asked of it. Orbit treats a
+directory as an initialized workspace when it contains `config.toml`
+(`orbit-core/src/runtime/resolve.rs::is_initialized_orbit_root`), and a
+repository that versions its Orbit workspace commits exactly that file
+alongside `learnings/`, `auto_tasks/`, `resources/`, and `routines/`. Those
+paths arrive through `git clone`: this repository tracks 567 files under
+`.orbit/`, and the constellation repository — the one the blocked clients mirror
+— tracks 54.
+
+So the walk fires on the read mirror [2_design.md §5.3](./2_design.md) explicitly admits —
+"an off-box orchestrator whose clone, if it has one, **is a read mirror**" — and
+the clients Phase 6 exists to cut over are precisely the ones carrying that
+mirror. The filesystem shape of a working checkout and of a mirror are
+identical, because the shape is what git delivers.
+
+### Decision
+
+This machine's workspace registry (`~/.orbit/workspaces.json`) is the sole
+authority for the guard. Evidence is a checkout binding the working directory —
+including through an explicit `path_overrides` entry — or, failing that, any
+registered checkout whose `repo_root` still exists. An `.orbit/` directory that
+the registry does not bind is not evidence and is no longer consulted; the
+cwd walk is deleted rather than reordered.
+
+Ownership is the right discriminator because it is what the rest of the system
+already means by "has a checkout". `McpHost::resolve_exact_checkout` binds a
+session only to a registered checkout and refuses anything else with *register
+or repair the checkout binding*, so an unregistered `.orbit/` produces no
+local-derived state — nothing the guard protects exists for it. A machine that
+genuinely coordinates or develops in a workspace has run `orbit workspace init`
+and carries the binding; that machine is still refused, and the refusal still
+names both the owning workspace and `orbit mcp serve` as the alternative.
+
+### Consequences
+
+- A client whose only checkout evidence is a tracked `.orbit/` directory starts
+  the proxy, which unblocks the Phase 6 cutover for the orchestrators that hold
+  a constellation mirror.
+- The guard's verdict is now decided by machine-local state that a clone cannot
+  carry, so it no longer depends on how a repository chooses to gitignore
+  `.orbit/`.
+- The refusal message gains a "which contains the working directory" clause when
+  the operator is standing inside an owned checkout, which is the case an
+  operator is most likely to hit and previously the least specific.
+- **Cost:** a machine that develops in an Orbit checkout it never registered is
+  now admitted. Orbit's own CLI would resolve that tree by cwd walk, so the
+  operator can hold a local workspace the guard no longer sees. The mode will
+  answer from the remote's branch state while a local tree sits under them —
+  the exact confusion the guard exists to prevent, narrowed to a machine that
+  declined to register.
+- **Rejected: keep the cwd walk but require the discovered `.orbit/` to belong
+  to a workspace the registry owns.** It states the rule in the place a reader
+  looks for it, but it decides nothing the first branch has not already decided:
+  a registered checkout containing the cwd exists on disk by construction. Two
+  branches computing one verdict is worse than one.
+- **Rejected: an explicit operator opt-out flag.** It moves a security-relevant
+  judgement to whoever is currently blocked by it, and the flag would be pasted
+  into every client registration that ever hit the refusal — including the
+  machines the guard is for.
+- **Rejected: discriminate on machine-local runtime state inside the discovered
+  `.orbit/`** (`state/`, `tasks/`, the abandoned workspace-local `orbit.db`).
+  It keeps a second signal that catches the unregistered-but-active checkout the
+  cost above concedes, but it keys the guard on a directory-name inventory that
+  drifts with layout, and it reads a mirror as owned the moment anyone runs one
+  Orbit command inside it.
+
 ## Task References
 
 - [ORB-00424] — completed design proposal for canonical Orbit MCP and Bridge parity retirement.
@@ -580,6 +660,10 @@ Alternatives considered and rejected:
   validation reads the owner machine's local config instead ([ADR-0358]). The two
   digests and `build_execution_profile_v1` survive as transport-independent
   construction.
+- [ORB-10761] — narrowed the checkoutless-client guard to registry ownership
+  ([ADR-0360]), so a client whose only evidence is a tracked `.orbit/` directory
+  starts the proxy while a machine with a registered on-disk checkout is still
+  refused.
 - [ORB-10332] — removed the `orbit.host.list` MCP discovery tool as unused; the
   `orbit.workspace.list` / `orbit.crew.list` MCP discovery tools remain. The
   `orbit host list` CLI command it deferred to is itself withdrawn with the fleet


### PR DESCRIPTION
## Manual resolution required

Orbit preserved and pushed this task's pre-rebase candidate after the shipment pipeline stopped. This PR is intentionally blocked and must be reconciled manually before merge.

- Task: `ORB-10761`
- Run: `jrun-20260813-0451-3`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `120ca3e255288ddee99d4c7c91e9a923a8840a1e`
- Target base: `120ca3e255288ddee99d4c7c91e9a923a8840a1e`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: agent step did not complete: the provider exited 0 but stdout carried no valid terminating Orbit response envelope (agent protocol violation: stdout does not contain an Orbit response envelope). The invocation ended without finishing its contract — typically an agent that yielded mid-work — so this step's work is incomplete and only what it persisted before stopping is durable.
```