### PR TITLE
Parse Claude structured-output envelopes that emit error as the string "null"

### DIFF
--- a/crates/orbit-agent/src/providers/claude/tests/claude_cli.rs
+++ b/crates/orbit-agent/src/providers/claude/tests/claude_cli.rs
@@ -44,6 +44,11 @@ fn transport_constrains_every_invocation_with_the_protocol_schema() {
         serde_json::json!(["success", "failed", "timeout"])
     );
     assert_eq!(schema["properties"]["result"]["type"], "object");
+    assert_eq!(schema["properties"]["error"]["type"], "object");
+    assert_eq!(
+        schema["properties"]["error"]["required"],
+        serde_json::json!(["code", "message"])
+    );
     assert_eq!(
         schema["required"],
         serde_json::json!(["schemaVersion", "status", "result"])
@@ -77,10 +82,9 @@ fn protocol_schema_leaves_the_status_error_correlation_to_the_rust_parser() {
     let args = ClaudeCliTransport::new(None).args(false);
     let schema = schema_arg(&args);
 
-    assert!(
-        schema["properties"]["error"].get("type").is_none(),
-        "error is untyped on purpose: it is null on success and an object on failure, \
-         and expressing that needs a conditional the provider subset rejects"
+    assert_eq!(
+        schema["properties"]["error"]["type"], "object",
+        "error is an object when present; omit it on success rather than emitting null"
     );
     assert!(
         !schema["required"]

--- a/crates/orbit-agent/src/types/response/envelope.rs
+++ b/crates/orbit-agent/src/types/response/envelope.rs
@@ -382,5 +382,24 @@ fn deserialize_envelope(value: &Value) -> Option<AgentResponseEnvelope> {
     if !object.contains_key("schemaVersion") || !object.contains_key("status") {
         return None;
     }
-    serde_json::from_value(value.clone()).ok()
+    // [ORB-10770] Claude's constrained decoder, given an untyped `error` and a
+    // description that said "null when status is success", emits the JSON
+    // *string* `"null"` (`jrun-20260813-0451-3`). `Option<AgentRunError>`
+    // cannot accept a string, so the finder used to miss a completed
+    // envelope. Treat `"null"` / `""` as absent; JSON null is already `None`
+    // via `#[serde(default)]`. This only makes a recognizable frame parse —
+    // it does not infer success from wrapper signals.
+    match object.get("error") {
+        Some(Value::String(token)) if is_absent_error_string(token) => {
+            let mut object = object.clone();
+            object.remove("error");
+            serde_json::from_value(Value::Object(object)).ok()
+        }
+        _ => serde_json::from_value(value.clone()).ok(),
+    }
+}
+
+fn is_absent_error_string(token: &str) -> bool {
+    let trimmed = token.trim();
+    trimmed.is_empty() || trimmed == "null"
 }

--- a/crates/orbit-agent/src/types/response/protocol_schema.rs
+++ b/crates/orbit-agent/src/types/response/protocol_schema.rs
@@ -43,10 +43,11 @@ pub const RESPONSE_ENVELOPE_STATUSES: [&str; 3] = ["success", "failed", "timeout
 /// schema subset, not a choice about where validation belongs — and it is why
 /// the Rust checks remain load-bearing rather than redundant.
 ///
-/// `error` is declared without a `type` on purpose: the contract admits
-/// `null` on success and an object on failure, and an untyped property is the
-/// widest thing the subset accepts without a conditional. `durationMs` is
-/// omitted entirely and rides through on unconstrained additional properties.
+/// `error` is typed as an object and omitted on success. The subset cannot
+/// express "object on failure, absent on success" without a top-level
+/// conditional, so this is the tightest type the provider will accept.
+/// `durationMs` is omitted entirely and rides through on unconstrained
+/// additional properties.
 pub fn response_envelope_json_schema() -> Value {
     json!({
         "type": "object",
@@ -69,9 +70,22 @@ pub fn response_envelope_json_schema() -> Value {
                      whose output is purely durable side effects.",
             },
             "error": {
+                "type": "object",
                 "description":
-                    "null when status is \"success\"; an object with non-empty \"code\" and \
-                     \"message\" when status is \"failed\" or \"timeout\".",
+                    "Present only when status is \"failed\" or \"timeout\". Object with \
+                     non-empty \"code\" and \"message\". Omit this field when status is \
+                     \"success\".",
+                "properties": {
+                    "code": {
+                        "type": "string",
+                        "description": "Stable machine-readable error code.",
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "Human-readable error message.",
+                    },
+                },
+                "required": ["code", "message"],
             },
         },
         "required": ["schemaVersion", "status", "result"],

--- a/crates/orbit-agent/src/types/tests/response.rs
+++ b/crates/orbit-agent/src/types/tests/response.rs
@@ -645,6 +645,94 @@ mod structured_output {
         .to_string()
     }
 
+    /// Live `jrun-20260813-0451-3` shape: Claude's constrained decoder emitted
+    /// the JSON *string* `"null"` for `error` in both `structured_output` and
+    /// the embedded `result` string. Wrapper signals are a normal completion
+    /// (`is_error=false`, `subtype=success`, `terminal_reason=completed`,
+    /// `stop_reason=tool_use`). On agent-main this missed the envelope; after
+    /// [ORB-10770] it must parse as success and keep the inner `result`.
+    fn claude_json_schema_wrapper_error_string_null() -> String {
+        let inner = serde_json::json!({
+            "schemaVersion": 1,
+            "status": "success",
+            "result": {
+                "task_id": "ORB-10761",
+                "summary": "narrowed the checkoutless-client guard"
+            },
+            "error": "null"
+        });
+        serde_json::json!({
+            "is_error": false,
+            "stop_reason": "tool_use",
+            "terminal_reason": "completed",
+            "subtype": "success",
+            "result": inner.to_string(),
+            "structured_output": {
+                "schemaVersion": 1,
+                "status": "success",
+                "result": {
+                    "task_id": "ORB-10761",
+                    "summary": "narrowed the checkoutless-client guard"
+                },
+                "error": "null"
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn claude_json_schema_wrapper_with_error_string_null_parses_as_success() {
+        let stdout = claude_json_schema_wrapper_error_string_null();
+        let (envelope, status, _) = parse_and_validate_response(&exec(&stdout, "", Some(0), true))
+            .expect("live jrun-20260813-0451-3 wrapper with error string \"null\" is an envelope");
+
+        assert_eq!(status, AgentResponseStatus::Success);
+        assert_eq!(envelope.status, "success");
+        assert!(envelope.error.is_none(), "string \"null\" is absent error");
+        let result = envelope.result.expect("inner result object is kept");
+        assert_eq!(result["task_id"], "ORB-10761");
+        assert_eq!(result["summary"], "narrowed the checkoutless-client guard");
+        response_envelope_protocol_check(&stdout)
+            .expect("string-null error still satisfies the frame");
+    }
+
+    /// Fail-closed: a `failed` envelope without a real error object is a
+    /// protocol violation, whether `error` is missing, JSON null, or the
+    /// string `"null"`. The [ORB-10770] coerce must not turn these into
+    /// success or synthesize a checkpointable failed envelope.
+    #[test]
+    fn failed_status_with_absent_error_tokens_is_a_protocol_violation() {
+        let mut envelopes = vec![serde_json::json!({
+            "schemaVersion": 1,
+            "status": "failed",
+            "result": {}
+        })];
+        for error in [serde_json::Value::Null, serde_json::json!("null")] {
+            envelopes.push(serde_json::json!({
+                "schemaVersion": 1,
+                "status": "failed",
+                "result": {},
+                "error": error
+            }));
+        }
+
+        for envelope in envelopes {
+            let stdout = envelope.to_string();
+            let error = parse_and_validate_response(&exec(&stdout, "", Some(1), false))
+                .expect_err("failed without an error object is a protocol violation");
+            assert!(
+                error
+                    .to_string()
+                    .contains("failed status requires error object"),
+                "envelope={envelope} error={error}"
+            );
+            assert!(
+                synthesize_response(&exec(&stdout, "", Some(1), false)).is_none(),
+                "must not synthesize a checkpointable failed envelope: {envelope}"
+            );
+        }
+    }
+
     #[test]
     fn claude_json_schema_wrapper_parses_and_keeps_its_trace_fields() {
         let stdout = claude_json_schema_wrapper();

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Design"
 type: design
 title: "Activity / Job — Design"
 owner: codex
-last_updated: 2026-08-13
+last_updated: 2026-08-14
 last_validated: 2026-07-26
 status: Draft
 feature: activity-job
@@ -393,9 +393,20 @@ requiring a non-empty `error.code` — is absent from the schema and stays in
 expressing it needs a conditional subschema, and Anthropic's structured-output
 subset rejects those outright with `input_schema does not support oneOf, allOf,
 or anyOf at the top level`. The rejection surfaces mid-run rather than at argv
-parse, so getting it wrong is expensive. `error` is therefore declared untyped
-(null on success, object on failure) and the Rust correlation checks remain
-load-bearing rather than redundant.
+parse, so getting it wrong is expensive. After [ORB-10770], `error` is typed
+as an object (`code` + `message`) and omitted on success — Serde's
+`#[serde(default)]` already treats a missing field as `None`. The schema
+still cannot express "require the object on `failed`, omit it on
+`success`", so the Rust correlation checks remain load-bearing rather than
+redundant.
+
+The earlier untyped property plus a description that said "null when status
+is success" made Claude's constrained decoder emit the JSON *string*
+`"null"` (`jrun-20260813-0451-3`). The parser accepts that token — and the
+empty string — as absent `error`, the same as JSON `null` or a missing
+field. A `status=failed` envelope with missing, JSON-null, or
+string-`"null"` `error` is still a protocol violation (`failed status
+requires error object`), not a synthesized success.
 
 **Two capability failures, two places.** A CLI that *lacks* `--json-schema`
 fails at argument parsing, before any agent work and any cost; the evidence is
@@ -718,6 +729,7 @@ Read-only history does not need the same dependencies as live execution. [T20260
 
 ## Task References
 
+- **[ORB-10770]** — Type the protocol schema's `error` as an object omitted on success, and accept the JSON string `"null"` as absent `error` so a completed Claude structured-output wrapper still counts as an envelope (see [§7.6b](#76b-structured-output-is-the-claude-prevention-layer)).
 - **[ORB-10746]** — Enforce the Orbit response envelope through Claude CLI structured output (`--json-schema`), read `structured_output` as the authoritative extraction source, and map abnormal exit-0 endings to a specific failed-envelope diagnostic (see [§7.6b](#76b-structured-output-is-the-claude-prevention-layer)).
 - **[ORB-10606]** — Supply the complete reviewer worktree pair and distinguish review startup failure from a reviewer rejection at the parent and task-history boundaries ([ADR-0328]).
 - **[ORB-10519]** — Restore one workflow-owned shipment commit, reject every provider-side HEAD change, and preserve dirty-work recovery plus process-scoped attribution ([ADR-0299], superseding [ADR-0294] and [ADR-0249]).


### PR DESCRIPTION
## Task

[ORB-10770](https://orbit-cli.com/tasks/ORB-10770) — Parse Claude structured-output envelopes that emit error as the string "null"

### Description

## Problem

`task_pr_pipeline` run `jrun-20260813-0451-3` blocked `ORB-10761` at `implement_one` with:

> the provider exited 0 but stdout carried no valid terminating Orbit response envelope (agent protocol violation: stdout does not contain an Orbit response envelope)

That diagnosis is wrong. The Claude `--output-format json --json-schema` wrapper **did** contain a terminating envelope, in both `structured_output` (object) and `result` (JSON string):

```json
{
  "schemaVersion": 1,
  "status": "success",
  "result": { "task_id": "ORB-10761", "...": "..." },
  "error": "null"
}
```

`error` is the **string** `"null"`, not JSON `null`. `deserialize_envelope` sees `schemaVersion` + `status` and then `serde_json::from_value` into `AgentResponseEnvelope` fails because `error: Option<AgentRunError>` cannot accept a string. The finder therefore reports “no envelope.” Wrapper diagnostics do not fire: `is_error=false`, `subtype=success`, `terminal_reason=completed` is treated as a normal completion.

The implementer had already finished: execution summary persisted, files changed, `make ci-fast` / `make ci-lint` green. The candidate was dumped to PR #966 by `pr_failure_handoff`. Cost: 71 turns, ~$5.76.

## Why It Matters

This is a regression from `526353f` / ORB-10746, which added `--json-schema` to stop prose endings (`jrun-20260812-0312-9`). The schema left `error` untyped because Anthropic rejects top-level `oneOf`. Combined with a description that says “null when status is success,” the constrained decoder emits the string `"null"`. ORB-10746’s fixture used real JSON `null`, so the tests never saw the live opus shape.

A completed, durable implement is now indistinguishable from an agent that yielded mid-work. Operators re-dispatch or hand-land PRs after paying a full Claude run.

## Reproduction

1. `orbit run logs jrun-20260813-0451-3 --json` — `structured_output.error` is the string `"null"`.
2. On current agent-main, `parse_and_validate_response` of that stdout returns `AgentProtocolViolation("stdout does not contain an Orbit response envelope")`.
3. The same wrapper with `"error": null` (JSON null) parses as success — that is the ORB-10746 test fixture, not the live shape.

## Proposed Fix Direction

Two complementary changes; do both.

1. **Schema.** Type `error` as an object (`code` + `message`) and omit it on success. Serde’s `#[serde(default)]` already treats a missing field as `None`. Do **not** reintroduce top-level `oneOf`/`anyOf` — that 400s mid-run (`input_schema does not support oneOf, allOf, or anyOf at the top level`).
2. **Parser.** Treat JSON string `"null"` / empty string as absent `error` so a live wrapper like `jrun-20260813-0451-3` still counts as an envelope. Prefer normalizing inside `deserialize_envelope` (or a field deserializer) rather than inferring success from wrapper signals.

Do **not** put the coerce on `AgentResponseEnvelope` in `orbit-common` unless a test proves other callers need it; if you do, add `file:crates/orbit-common/src/types/job.rs` to `context_files` via `orbit.task.update` before editing.

## Constraints / Notes

- Fail-closed stays fail-closed. Do not infer success from exit code, `is_error`, `subtype`, `terminal_reason`, `execution_summary`, no-diff, worktree state, or provider prose. ORB-10449 and ORB-10733 remain authoritative.
- `status=failed` with string `"null"` / missing / JSON-null `error` must still fail the protocol check, not become a success or a synthesized failed envelope that checkpoints.
- Do not silently drop `--json-schema` or add an unconstrained Claude fallback.
- Read-for-context (do not list unless you modify): `crates/orbit-common/src/types/job.rs` (`AgentResponseEnvelope`), `crates/orbit-agent/src/types/response/wrapper.rs`, `crates/orbit-agent/src/providers/claude/claude_cli.rs`, `docs/design/activity-job/4_decisions.md` (ORB-10746 note), live blob from `jrun-20260813-0451-3`.
- This ticket does **not** land ORB-10761 / PR #966 and does **not** teach `git_commit` to accept a verified no-op (that is ORB-10759).

## Rollback

Revert the parser/schema commit. Worst case returns to the current “completed work looks like a missing envelope” failure; it does not reopen the prose-ending hole ORB-10746 closed, because `--json-schema` stays on.

### Acceptance Criteria

- A new unit test that replays the live `jrun-20260813-0451-3` Claude wrapper — `structured_output.error` and the embedded `result` JSON both set to the string `"null"`, with `is_error=false`, `subtype=success`, `terminal_reason=completed`, `stop_reason=tool_use` — must make `parse_and_validate_response` return `status=success` and keep the inner `result` object. On current agent-main this fixture must fail for `stdout does not contain an Orbit response envelope` before the parser/schema change.
- The existing ORB-10746 capture (`error: null` as JSON null in both `structured_output` and `result`) still parses as success; `cargo test -p orbit-agent --lib types::tests::response::structured_output` stays green.
- The protocol schema no longer leaves `error` untyped. Type it as an object (omit on success) without introducing top-level `oneOf`/`allOf`/`anyOf`/`if`/`then`/`else`/`not`. `cargo test -p orbit-agent --lib providers::claude::tests::claude_cli` must still pass, including `protocol_schema_avoids_the_conditional_subschema_keywords_the_provider_rejects`.
- Fail-closed backstops stay fail-closed: (a) `status=failed` with `error` missing, JSON null, or the string `"null"` is still a protocol violation (`failed status requires error object`), not a synthesized success; (b) exit 0 with no `schemaVersion`/`status` envelope is still a missing-envelope failure; (c) no wrapper signal (`is_error`, `subtype`, `terminal_reason`, exit code, prose) may produce success.
- `docs/design/activity-job/2_design.md` §7.6b is updated so the documented schema contract matches the code (error is an object when present, omitted on success; string `"null"` is accepted by the parser as absent). Bump `last_updated`.
- Validation: `cargo test -p orbit-agent --lib types::tests::response` and `cargo test -p orbit-agent --lib providers::claude::tests::claude_cli`. File I/O checks stay in-process (no live Claude, no `.orbit/knowledge/`).

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Typed protocol schema `error` as an object (`code` + `message`) and omitted it from `required`, so success envelopes drop the field. No top-level `oneOf`/`allOf`/`anyOf`/`if`/`then`/`else`/`not`.
- Normalized JSON string `"null"` and empty string to absent `error` inside `deserialize_envelope` (not on `AgentResponseEnvelope` in orbit-common). Wrapper signals still cannot synthesize success.
- Added the live `jrun-20260813-0451-3` replay fixture (`error` string `"null"` in both `structured_output` and embedded `result`) and fail-closed coverage for `status=failed` with missing / JSON-null / string-`"null"` error.
- Updated §7.6b of `docs/design/activity-job/2_design.md` to match the schema/parser contract and bumped `last_updated`.
Assessment: Parser now recognizes the live opus wrapper as a success envelope and keeps the inner `result` object. Fail-closed backstops hold. Schema stays inside Anthropic's subset.
Validation:
- `cargo test -p orbit-agent --lib types::tests::response` — 37 passed
- `cargo test -p orbit-agent --lib providers::claude::tests::claude_cli` — 5 passed, including `protocol_schema_avoids_the_conditional_subschema_keywords_the_provider_rejects`
- `types::tests::response::structured_output` included in the 37 (ORB-10746 JSON-null fixture still green)
Strategic decisions: Coerce only in `deserialize_envelope` so other `AgentResponseEnvelope` callers are unchanged. Schema types `error` as object rather than leaving it untyped, which is what caused Claude to emit the string `"null"`.
Design weaknesses / risks:
- Severity: low. Existing providers that still emit JSON `null` for `error` remain accepted via serde `Option`. A future constrained decoder that emits some other sentinel string would still miss the envelope.
- Mitigation: parser accepts only `"null"` / empty; new live shapes need a fixture.
Deviations from original plan: none.
Recommended follow-ups: none for this ticket. ORB-10761 / PR #966 remain out of scope.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10770-6a7e7a28`
- Behind base: 0
- Ahead of base: 1