### PR TITLE
Remove transitive js-yaml 4.3.0 from the website lockfile

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -4334,9 +4334,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/website/package.json
+++ b/website/package.json
@@ -27,7 +27,7 @@
   "overrides": {
     "yaml": "2.8.3",
     "esbuild": "0.28.1",
-    "js-yaml": "4.3.0",
+    "js-yaml": ">=4.3.1",
     "fast-uri": ">=3.1.5"
   }
 }


### PR DESCRIPTION
## Task

[ORB-10771](https://orbit-cli.com/tasks/ORB-10771) — Remove transitive js-yaml 4.3.0 from the website lockfile

### Description

## Problem

The Orbit website lockfile currently resolves transitive `js-yaml@4.3.0` via:

- `@astrojs/starlight` 0.41.4 → `js-yaml` 4.3.0
- `astro` 7.1.3 → `js-yaml` 4.3.0

`website/package.json` already has `overrides.js-yaml = "4.3.0"`, which is what forces that version. `4.3.0` is now the flagged release (Snyk reports a High on 4.3.0; `4.3.1` is published on the 4.x line).

## Why It Matters

A High on a YAML parser in the docs site build is a supply-chain / CI audit failure. The pin that closed the previous js-yaml advisory is now itself the problem.

## Constraints / Notes

- Stay on js-yaml 4.x (`>=4.3.1`) unless that line has no patched release. 5.x is a major and is out of scope for a luna dependency bump.
- Do not upgrade Starlight/Astro just to move js-yaml unless the override cannot be satisfied otherwise; prefer the existing `overrides` mechanism.
- Scope is the website package (`website/package.json` + `website/package-lock.json`). Leave `plugin/npm` alone if it does not contain `js-yaml@4.3.0`.
- No live network service tests; `npm ci` + `npm run check` in a website checkout is sufficient.

### Acceptance Criteria

- `npm ls js-yaml --prefix website` (or the equivalent lockfile inspection) shows no `js-yaml@4.3.0`. The version that remains is at least `4.3.1` (the current 4.x patch) unless a later compatible 4.x is required.
- `website/package.json` no longer pins the `overrides.js-yaml` field to `4.3.0`. Either bump that override to `>=4.3.1` (or the exact patched 4.x), or drop it if `@astrojs/starlight` / `astro` already resolve a patched version unaided. Do not jump to js-yaml 5.x unless a 4.x patch cannot be resolved.
- `website/package-lock.json` is updated in the same change so a clean `npm ci` in `website/` reproduces the patched tree.
- Validation in `website/`: `npm ci` and `npm run check` (or the repo's documented website CI target) succeed. Do not touch the Rust workspace or plugin/npm package unless a second lockfile also contains `js-yaml@4.3.0`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated website/package.json override from js-yaml 4.3.0 to >=4.3.1.
- Updated website/package-lock.json to resolve js-yaml 4.3.1 with the registry tarball and integrity.
Assessment: Lockfile JSON inspection confirms node_modules/js-yaml is 4.3.1 and no js-yaml 4.3.0 package entry remains; git diff --check passes. npm ci, npm run check, and npm ls could not run because npm is not installed in the executor environment (node is present). No Rust or plugin files were changed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10771-6a7e7e38`
- Behind base: 0
- Ahead of base: 1