### PR TITLE
CLI tool execution silently ignores the workspace input instead of routing or failing

### DIFF
--- a/crates/orbit-cli/src/command/tool/run.rs
+++ b/crates/orbit-cli/src/command/tool/run.rs
@@ -1,5 +1,6 @@
 use clap::{Args, ValueEnum};
 use orbit_core::{OrbitError, OrbitRuntime};
+use orbit_remote::runtime::RemoteRuntimeFactory;
 use serde_json::{Map, Value};
 
 use crate::command::{CommandOut, CommandOutput, Execute, Payload};
@@ -49,7 +50,7 @@ pub struct ToolRunArgs {
 
 impl Execute for ToolRunArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
-        let input: Value = if let Some(path) = &self.input_file {
+        let mut input: Value = if let Some(path) = &self.input_file {
             let raw = std::fs::read_to_string(path).map_err(|e| {
                 OrbitError::InvalidInput(format!("cannot read input file '{path}': {e}"))
             })?;
@@ -62,6 +63,11 @@ impl Execute for ToolRunArgs {
                 None => Value::Object(Default::default()),
             }
         };
+
+        // ORB-10769: resolve `workspace` once above the tools, then bind or
+        // fail closed. MCP `McpHost::resolve_workspace` is a separate seam.
+        let bound = RemoteRuntimeFactory::bind_cli_tool_workspace(runtime, &mut input)?;
+        let runtime = bound.as_ref().unwrap_or(runtime);
 
         if self.dry_run {
             let result = runtime.run_tool_dry_run(&self.name, &input)?;

--- a/crates/orbit-remote/src/runtime.rs
+++ b/crates/orbit-remote/src/runtime.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use orbit_common::types::{
     OrbitError, Workspace, WorkspaceCheckout, WorkspaceCheckoutRole, WorkspaceRegistry,
+    WorkspaceStatus,
 };
 use orbit_core::runtime::{
     OrbitRuntimeRoots, ResolvedOrbitRoots, WorkspaceRootHint, WorkspaceRuntimeBinding,
@@ -11,6 +12,7 @@ use orbit_core::runtime::{
 use orbit_core::{OrbitRuntime, resolved_ship_mode};
 use orbit_store::sqlite::task_registry::{TaskRegistryStore, task_registry_path};
 use orbit_store::workspace_id_for_orbit_dir;
+use serde_json::Value;
 
 use crate::{HOST_TOML_FILE, load_host_identity, workspace_registry};
 
@@ -141,6 +143,178 @@ impl RemoteRuntimeFactory {
             binding,
         )
     }
+
+    /// Bind a CLI `orbit tool run` invocation to the workspace named in `input`.
+    ///
+    /// ORB-10769: this is the single CLI-path resolver above the tools. A
+    /// non-empty `workspace` either rebinds the runtime to that registered
+    /// checkout or fails closed naming the selector. MCP resolution
+    /// (`McpHost::resolve_workspace`) is a separate seam and still never
+    /// falls back to process cwd.
+    pub fn bind_cli_tool_workspace(
+        runtime: &OrbitRuntime,
+        input: &mut Value,
+    ) -> Result<Option<OrbitRuntime>, OrbitError> {
+        let Some(selector) = cli_workspace_selector(input)? else {
+            return Ok(None);
+        };
+        let global_root = runtime.global_root();
+        let registry = workspace_registry::load_registry_from(
+            &workspace_registry::registry_path_for(&global_root),
+        )?;
+        match resolve_cli_workspace_target(&registry, runtime, &selector)? {
+            CliWorkspaceTarget::CurrentRuntime => Ok(None),
+            CliWorkspaceTarget::Checkout {
+                workspace,
+                checkout,
+                rewrite_to_repo_root,
+            } => {
+                if workspace.status != WorkspaceStatus::Active {
+                    return Err(unsupported_cli_workspace(&selector));
+                }
+                if rewrite_to_repo_root {
+                    set_input_workspace(input, &checkout.repo_root)?;
+                }
+                if same_cli_checkout(runtime, checkout) {
+                    return Ok(None);
+                }
+                Self::open_registered_checkout(&global_root, workspace, checkout).map(Some)
+            }
+        }
+    }
+}
+
+enum CliWorkspaceTarget<'a> {
+    CurrentRuntime,
+    Checkout {
+        workspace: &'a Workspace,
+        checkout: &'a WorkspaceCheckout,
+        rewrite_to_repo_root: bool,
+    },
+}
+
+fn cli_workspace_selector(input: &Value) -> Result<Option<String>, OrbitError> {
+    match input.get("workspace") {
+        None => Ok(None),
+        Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                return Ok(None);
+            }
+            Ok(Some(trimmed.to_string()))
+        }
+        Some(_) => Err(OrbitError::InvalidInput(
+            "`workspace` must be a string".to_string(),
+        )),
+    }
+}
+
+fn resolve_cli_workspace_target<'a>(
+    registry: &'a WorkspaceRegistry,
+    runtime: &OrbitRuntime,
+    selector: &str,
+) -> Result<CliWorkspaceTarget<'a>, OrbitError> {
+    if selector_looks_like_path(selector) {
+        return resolve_cli_workspace_path(registry, runtime, selector);
+    }
+    let checkout = workspace_registry::find_checkout(registry, selector)
+        .ok_or_else(|| unsupported_cli_workspace(selector))?;
+    let workspace = workspace_registry::find_workspace(registry, &checkout.workspace_id)
+        .ok_or_else(|| unsupported_cli_workspace(selector))?;
+    Ok(CliWorkspaceTarget::Checkout {
+        workspace,
+        checkout,
+        rewrite_to_repo_root: true,
+    })
+}
+
+fn resolve_cli_workspace_path<'a>(
+    registry: &'a WorkspaceRegistry,
+    runtime: &OrbitRuntime,
+    selector: &str,
+) -> Result<CliWorkspaceTarget<'a>, OrbitError> {
+    let raw = Path::new(selector);
+    let candidate = if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(raw)
+    };
+    let canonical = candidate
+        .canonicalize()
+        .map_err(|_| unsupported_cli_workspace(selector))?;
+    if !canonical.is_dir() {
+        return Err(unsupported_cli_workspace(selector));
+    }
+    if let Some(checkout) = find_checkout_for_canonical_path(registry, &canonical) {
+        let workspace = workspace_registry::find_workspace(registry, &checkout.workspace_id)
+            .ok_or_else(|| unsupported_cli_workspace(selector))?;
+        return Ok(CliWorkspaceTarget::Checkout {
+            workspace,
+            checkout,
+            rewrite_to_repo_root: false,
+        });
+    }
+    if path_is_inside(&runtime.paths().repo_root, &canonical) {
+        return Ok(CliWorkspaceTarget::CurrentRuntime);
+    }
+    Err(unsupported_cli_workspace(selector))
+}
+
+fn find_checkout_for_canonical_path<'a>(
+    registry: &'a WorkspaceRegistry,
+    canonical: &Path,
+) -> Option<&'a WorkspaceCheckout> {
+    registry.checkouts.iter().find(|checkout| {
+        canonical_path(&checkout.repo_root) == canonical
+            || canonical_path(&checkout.orbit_dir) == canonical
+            || checkout
+                .path_overrides
+                .iter()
+                .any(|override_path| canonical_path(override_path) == canonical)
+    })
+}
+
+fn same_cli_checkout(runtime: &OrbitRuntime, checkout: &WorkspaceCheckout) -> bool {
+    canonical_path(&runtime.paths().repo_root) == canonical_path(&checkout.repo_root)
+}
+
+fn path_is_inside(parent: &Path, child: &Path) -> bool {
+    child.starts_with(canonical_path(parent))
+}
+
+fn canonical_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn selector_looks_like_path(selector: &str) -> bool {
+    let path = Path::new(selector);
+    path.is_absolute()
+        || selector == "."
+        || selector == ".."
+        || selector.contains('/')
+        || selector.contains('\\')
+}
+
+fn set_input_workspace(input: &mut Value, repo_root: &Path) -> Result<(), OrbitError> {
+    let Some(object) = input.as_object_mut() else {
+        return Err(OrbitError::InvalidInput(
+            "tool input must be a JSON object".to_string(),
+        ));
+    };
+    object.insert(
+        "workspace".to_string(),
+        Value::String(repo_root.to_string_lossy().into_owned()),
+    );
+    Ok(())
+}
+
+fn unsupported_cli_workspace(selector: &str) -> OrbitError {
+    OrbitError::InvalidInput(format!(
+        "unsupported workspace '{selector}'; pass a registered workspace name or ID, or a path to a registered local checkout"
+    ))
 }
 
 /// Project the host-owned task namespace into the neutral task allocator.

--- a/crates/orbit-remote/src/tests/runtime.rs
+++ b/crates/orbit-remote/src/tests/runtime.rs
@@ -1,11 +1,15 @@
+use std::path::{Path, PathBuf};
+
 use chrono::Utc;
 use orbit_common::types::{
     NotFoundKind, OrbitError, Workspace, WorkspaceCheckout, WorkspaceCheckoutRole, WorkspaceStatus,
 };
+use orbit_core::OrbitRuntime;
 use orbit_store::sqlite::task_registry::{WorkspaceConfig, write_workspace_config};
-use serde_json::json;
+use serde_json::{Value, json};
 
 use crate::runtime::{RemoteRuntimeFactory, resolved_workspace_binding, workspace_runtime_binding};
+use crate::workspace_registry::{registry_path_for, save_registry_to};
 
 fn workspace(id: &str, ship_mode: &str) -> Workspace {
     Workspace {
@@ -167,4 +171,237 @@ fn replica_runtime_refuses_task_writes_and_hides_coordination_reads() {
             .expect("empty replica task list")
             .is_empty()
     );
+}
+
+struct DualWorkspaceFixture {
+    _root: tempfile::TempDir,
+    alpha: OrbitRuntime,
+    beta_repo: PathBuf,
+    beta_task_id: String,
+}
+
+fn execute_cli_tool(
+    runtime: &OrbitRuntime,
+    name: &str,
+    mut input: Value,
+) -> Result<Value, OrbitError> {
+    let bound = RemoteRuntimeFactory::bind_cli_tool_workspace(runtime, &mut input)?;
+    bound.as_ref().unwrap_or(runtime).execute_tool_command(
+        name,
+        input,
+        Some("codex".to_string()),
+        Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+    )
+}
+
+fn dual_workspace_fixture() -> DualWorkspaceFixture {
+    use orbit_common::types::WorkspaceRegistry;
+
+    let root = tempfile::tempdir().expect("root");
+    let global = root.path().join("global");
+    std::fs::create_dir_all(&global).expect("global");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_cli_bind\"\nhost_id = \"cli-bind\"\ntask_prefix = \"ORB\"\n",
+    )
+    .expect("host identity");
+
+    let (ws_alpha, checkout_alpha) =
+        registered_workspace(root.path(), "ws_alpha", "alpha", "hm_cli_bind");
+    let (ws_beta, checkout_beta) =
+        registered_workspace(root.path(), "ws_beta", "beta", "hm_cli_bind");
+    save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![ws_alpha.clone(), ws_beta.clone()],
+            checkouts: vec![checkout_alpha.clone(), checkout_beta.clone()],
+            ..Default::default()
+        },
+        &registry_path_for(&global),
+    )
+    .expect("workspace registry");
+
+    let alpha = RemoteRuntimeFactory::open_registered_checkout(&global, &ws_alpha, &checkout_alpha)
+        .expect("alpha runtime");
+    let beta = RemoteRuntimeFactory::open_registered_checkout(&global, &ws_beta, &checkout_beta)
+        .expect("beta runtime");
+    let created = beta
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Beta-only task",
+                "description": "Lives in the beta workspace.",
+                "workspace": checkout_beta.repo_root
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("seed beta task");
+    DualWorkspaceFixture {
+        _root: root,
+        alpha,
+        beta_repo: checkout_beta.repo_root,
+        beta_task_id: created["id"].as_str().expect("created task id").to_string(),
+    }
+}
+
+fn registered_workspace(
+    root: &Path,
+    id: &str,
+    name: &str,
+    owner_machine_id: &str,
+) -> (Workspace, WorkspaceCheckout) {
+    let repo = root.join(name);
+    let orbit_dir = repo.join(".orbit");
+    std::fs::create_dir_all(&orbit_dir).expect("orbit dir");
+    write_workspace_config(
+        &orbit_dir,
+        &WorkspaceConfig {
+            schema_version: 1,
+            workspace_id: id.to_string(),
+        },
+    )
+    .expect("workspace config");
+    let workspace = Workspace {
+        id: id.to_string(),
+        name: name.to_string(),
+        owner_machine_id: Some(owner_machine_id.to_string()),
+        git_remote: None,
+        ship_mode: Some("local".to_string()),
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    let checkout = WorkspaceCheckout::owner(id.to_string(), repo, orbit_dir);
+    (workspace, checkout)
+}
+
+fn unsupported_workspace_message(error: OrbitError, selector: &str) -> String {
+    match error {
+        OrbitError::InvalidInput(message) => {
+            assert!(
+                message.contains(selector),
+                "error must name the rejected workspace '{selector}': {message}"
+            );
+            message
+        }
+        other => panic!("expected InvalidInput, got {other}"),
+    }
+}
+
+#[test]
+fn cli_tool_run_lists_the_named_workspace_not_the_cwd_runtime() {
+    let fixture = dual_workspace_fixture();
+    let cwd_list = execute_cli_tool(&fixture.alpha, "orbit.task.list", json!({ "limit": 10 }))
+        .expect("list without workspace stays on alpha");
+    assert!(
+        !task_ids(&cwd_list).contains(&fixture.beta_task_id),
+        "cwd-bound list must not silently return the other workspace: {cwd_list}"
+    );
+
+    let named = execute_cli_tool(
+        &fixture.alpha,
+        "orbit.task.list",
+        json!({ "workspace": "beta", "limit": 10 }),
+    )
+    .expect("list should rebind to the named workspace");
+    assert!(
+        task_ids(&named).contains(&fixture.beta_task_id),
+        "named workspace list must return beta tasks: {named}"
+    );
+
+    let by_path = execute_cli_tool(
+        &fixture.alpha,
+        "orbit.task.list",
+        json!({
+            "workspace": fixture.beta_repo,
+            "limit": 10
+        }),
+    )
+    .expect("list should rebind to the checkout path");
+    assert!(
+        task_ids(&by_path).contains(&fixture.beta_task_id),
+        "absolute checkout path must return beta tasks: {by_path}"
+    );
+}
+
+#[test]
+fn cli_tool_run_fails_closed_on_unresolvable_workspace_for_read_and_write() {
+    let fixture = dual_workspace_fixture();
+    const BOGUS: &str = "bogus-nonexistent-xyz";
+
+    let list_error = execute_cli_tool(
+        &fixture.alpha,
+        "orbit.task.list",
+        json!({ "workspace": BOGUS, "limit": 2 }),
+    )
+    .expect_err("unresolvable workspace must not list the cwd workspace");
+    unsupported_workspace_message(list_error, BOGUS);
+
+    let add_error = execute_cli_tool(
+        &fixture.alpha,
+        "orbit.task.add",
+        json!({
+            "title": "must not land in cwd",
+            "description": "unresolvable workspace must fail closed",
+            "workspace": BOGUS
+        }),
+    )
+    .expect_err("unresolvable workspace must not create a cwd task");
+    unsupported_workspace_message(add_error, BOGUS);
+
+    let after = execute_cli_tool(&fixture.alpha, "orbit.task.list", json!({ "limit": 10 }))
+        .expect("cwd list after failed add");
+    assert!(
+        task_ids(&after).is_empty(),
+        "failed write must not create a task in the cwd workspace: {after}"
+    );
+}
+
+#[test]
+fn cli_tool_run_write_rebounds_to_the_named_workspace() {
+    let fixture = dual_workspace_fixture();
+    let created = execute_cli_tool(
+        &fixture.alpha,
+        "orbit.task.add",
+        json!({
+            "title": "Filed onto beta by name",
+            "description": "CLI workspace selector must rebind writes.",
+            "workspace": "beta"
+        }),
+    )
+    .expect("add should rebind to the named workspace");
+    let created_id = created["id"].as_str().expect("created id").to_string();
+
+    let alpha_list = execute_cli_tool(&fixture.alpha, "orbit.task.list", json!({ "limit": 10 }))
+        .expect("alpha list");
+    assert!(
+        !task_ids(&alpha_list).contains(&created_id),
+        "named-workspace write must not land in the cwd workspace: {alpha_list}"
+    );
+
+    let beta_list = execute_cli_tool(
+        &fixture.alpha,
+        "orbit.task.list",
+        json!({ "workspace": "beta", "limit": 10 }),
+    )
+    .expect("beta list");
+    assert!(
+        task_ids(&beta_list).contains(&created_id),
+        "named-workspace write must be visible on the target workspace: {beta_list}"
+    );
+}
+
+fn task_ids(value: &Value) -> Vec<String> {
+    let Some(items) = value.as_array() else {
+        return Vec::new();
+    };
+    items
+        .iter()
+        .filter_map(|task| {
+            task.get("id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+        .collect()
 }

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -275,6 +275,8 @@ pub(super) fn resolve_workspace_argument(
     tool_name: &str,
 ) -> Result<String, OrbitError> {
     // MCP workspace defaults come from explicit session context, never process cwd.
+    // ORB-10769: CLI `orbit tool run` binds the runtime in
+    // `RemoteRuntimeFactory::bind_cli_tool_workspace`. Do not add per-tool callers.
     let explicit = optional_string_alias(input, &["workspace"])?;
     let session = ctx
         .session_context

--- a/docs/design/mcp-session-context/2_design.md
+++ b/docs/design/mcp-session-context/2_design.md
@@ -3,7 +3,7 @@ summary: "MCP Session Context — Design"
 type: design
 title: "MCP Session Context — Design"
 owner: codex
-last_updated: 2026-08-09
+last_updated: 2026-08-14
 last_validated: 2026-08-08
 status: Accepted
 feature: mcp-session-context
@@ -11,7 +11,7 @@ doc_role: design
 tags: ["mcp-session-context", "mcp", "workspace"]
 paths: ["crates/orbit-mcp/**", "crates/orbit-remote/src/mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool/**"]
 related_features: ["mcp-session-context", "task-artifacts"]
-related_artifacts: ["ORB-00256", "ORB-10228", "ORB-10262", "ORB-10319", "ORB-10448", "ORB-10690", "ADR-0181", "ADR-0199", "ADR-0149", "ADR-0348"]
+related_artifacts: ["ORB-00256", "ORB-10228", "ORB-10262", "ORB-10319", "ORB-10448", "ORB-10690", "ORB-10769", "ADR-0181", "ADR-0199", "ADR-0149", "ADR-0348"]
 ---
 
 # MCP Session Context — Design
@@ -60,6 +60,12 @@ Before that tool-level fallback, `crates/orbit-remote/src/mcp/host.rs` resolves 
 selector to a logical workspace and, when placement requires it, an exact checkout. That
 Remote preflight owns routing and authorization; it does not replace the builtin's
 explicit-over-session input contract. [ORB-10262], [ORB-10319]
+
+The CLI `orbit tool run` path is a separate seam. `RemoteRuntimeFactory::bind_cli_tool_workspace`
+in `crates/orbit-remote/src/runtime.rs` reads a non-empty input `workspace` *above* the tools
+and either rebinds the cwd-bootstrapped `OrbitRuntime` to that registered checkout or fails
+closed naming the selector. It never continues against cwd on a typo. MCP resolution order is
+unchanged and still never falls back to process cwd. [ORB-10769]
 
 ### 3a. The selector is advertised, not implied
 
@@ -117,5 +123,6 @@ The external channel carries a workspace address, not a trusted workspace ID. Th
 - [ORB-10319] moved broker/session resolution and MCP composition into the vertical `orbit-remote` feature crate while leaving runtime audit/dispatch in Core.
 - [ORB-10448] advertised the workspace selector on every workspace-scoped tool and routed hub-placement coordination reads by checkout identity, making the [ADR-0181] "clients that cannot send initialize metadata pass `workspace` explicitly" path reachable from a managed worktree activity.
 - [ORB-10690] added the TCP transport and moved session construction behind `McpSessionFactory` so concurrent clients cannot observe or overwrite each other's session context ([ADR-0348]).
+- [ORB-10769] bound CLI `orbit tool run` to the same fail-closed workspace selector above the tools; MCP resolution order is unchanged.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10769](https://orbit-cli.com/tasks/ORB-10769) — CLI tool execution silently ignores the workspace input instead of routing or failing

### Description

## Problem

The `workspace` input field is silently ignored on the CLI tool-execution path. It neither switches the runtime nor fails closed on a value that does not exist.

Observed from `/home/daniel/workspace/constellation/knowledgebase/polaris`:

```
polaris cwd, no workspace field           -> ORB-10750, ORB-10743   (polaris tasks)
polaris cwd, workspace="orbit"            -> ORB-10750, ORB-10743   (unchanged)
polaris cwd, workspace="/abs/path/orbit"  -> ORB-10750, ORB-10743   (unchanged)
orbit cwd,   workspace="polaris"          -> ORB-10766, ORB-10761   (orbit tasks)
orbit cwd,   workspace="bogus-nonexistent-xyz" -> ORB-10766, ORB-10761  (no error)
```

All via `orbit tool run orbit.task.list --input '{"model":"claude","workspace":"<value>","limit":2}'`.

Two distinct defects sit underneath:

1. **The runtime is already bound before the tool sees the argument.** The CLI bootstraps one `OrbitRuntime` from cwd / `--root` at process start and calls the tool directly. `McpHost` resolves a selector *above* the tool and binds the runtime to it (`resolve_workspace` in `crates/orbit-remote/src/mcp/host.rs`); the CLI path has no equivalent layer, so any `workspace` value in the input is inert.
2. **Only one tool of 38 reads the field at all.** `resolve_workspace_argument` (`crates/orbit-tools/src/builtin/orbit/mod.rs`) is called by exactly one caller — `orbit.task.add`. The other 37 orbit tools accept a `workspace` key and discard it. Where it *is* read, it only normalizes the string back into the input; it never selects a runtime.

## Why It Matters

This is a silent misroute, not a missing convenience. A caller that explicitly names a workspace gets another workspace's data back and no indication anything was wrong — the failure mode that produced ORB-10713, where filing a bug from a polaris cwd created a polaris task.

An unknown workspace not erroring is the worse half. Every other workspace-resolution path in Orbit fails closed and names the rejected value; this one accepts `bogus-nonexistent-xyz` and returns results, so a typo is indistinguishable from success.

Note that the MCP broker path is **not** affected: `McpHost::resolve_workspace` accepts a registered ID or an absolute path, refuses relative paths explicitly, and errors with `unknown logical workspace ID '<selector>'`. This bug is specific to CLI tool execution.

## Constraints / Notes

- Fail closed is the required behavior for an unresolvable selector, matching the MCP broker's existing errors. Silently continuing against cwd is what makes this dangerous.
- Decide deliberately whether the CLI path should *resolve and rebind* the runtime or *reject* an input `workspace` it cannot honor. Rejecting is smaller and already an improvement over silent misroute; rebinding is the better product. Either is acceptable, but a tool advertising a parameter it discards is not.
- Do not fix this by making the other 37 tools call `resolve_workspace_argument`. The resolution belongs in one place above the tools, mirroring how `McpHost` does it, not replicated 38 times.
- Do not change MCP resolution order or add an MCP cwd fallback (rejected by ADR-0149 / ADR-0181).
- `orbit.task.add`'s existing error text says the value "must be a filesystem path ... never a logical workspace id such as a bridge `ws_*` id", which contradicts the MCP schema description advertising registered IDs. Unifying that grammar is ORB-10758's scope, not this task's — but do not deepen the contradiction here.

### Acceptance Criteria

- From a checkout that is not the orbit workspace, orbit tool run orbit.task.list with workspace naming the orbit workspace either returns orbit-workspace tasks or fails with an error naming the unsupported selector — it never silently returns the cwd workspace.
- An unresolvable workspace value such as bogus-nonexistent-xyz fails closed with a message naming the rejected value, proven by a test; it never returns results from the cwd workspace.
- The behavior is consistent across orbit tools rather than special-cased per tool: a test covers at least one read tool and one write tool, not only orbit.task.add.
- Workspace resolution for the CLI path lives in one place above the tools; grep shows no per-tool duplication of resolve_workspace_argument beyond its existing caller.
- MCP resolution order is unchanged and still never falls back to process cwd, proven by the existing McpHost tests continuing to pass unmodified.
- make ci-fast and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Outcome
success

## Changes
- Added `RemoteRuntimeFactory::bind_cli_tool_workspace` in `crates/orbit-remote/src/runtime.rs`: the single CLI-path resolver above the tools. A non-empty input `workspace` rebinds the cwd-bootstrapped runtime to that registered checkout (name, ID, or checkout path) or fails closed naming the selector.
- `orbit tool run` (`crates/orbit-cli/src/command/tool/run.rs`) now calls the binder before dry-run and `execute_tool_command`. Logical name/ID selectors are rewritten to the checkout `repo_root` so `orbit.task.add` still receives a filesystem path (ORB-10758 owns advertised-grammar unification).
- Did not add per-tool callers of `resolve_workspace_argument` (still only `orbit.task.add`). MCP `McpHost::resolve_workspace` and its no-cwd-fallback contract are unchanged.
- Tests in `crates/orbit-remote/src/tests/runtime.rs` cover `orbit.task.list` (read) and `orbit.task.add` (write): named/path rebind returns the other workspace's tasks; `bogus-nonexistent-xyz` fails closed on both verbs and does not create a cwd task.
- Documented the CLI seam in `docs/design/mcp-session-context/2_design.md`.

## Assessment
The silent-misroute is gone: an explicit workspace either switches the runtime or names the rejected value. Resolution lives in one factory method, not 38 tools. Existing McpHost tests passed unmodified. `make ci-fast` and `make ci-lint` passed.

## Strategic decisions
- Rebind rather than reject-only: smaller reject-only would have satisfied AC1 via the error path, but rebinding is the better product and matches how McpHost already works.
- CLI accepts registered name or ID (via existing `find_workspace`) plus checkout paths. Relative paths that exist inside the already-bound repo stay on the current runtime so `orbit.task.add` `workspace_path` (e.g. `.`) is preserved.
- Did not mint an ADR (agent-authored ADRs are out of policy); the decision is recorded here and in the design-doc note.

## Design weaknesses / risks
- Severity: low. CLI name lookup is slightly broader than MCP (MCP matches IDs only). Mitigation: ORB-10758 owns unifying the advertised grammar; this change does not deepen the add-tool "never a logical id" contradiction because add still receives a filesystem path after rewrite.
- Severity: low. Opening a second runtime per `orbit tool run` is one-shot and not cached (MCP caches). Fine for CLI.

## Deviations from original plan
None material. Extra context files: `file:crates/orbit-remote/src/tests/runtime.rs` and `file:docs/design/mcp-session-context/2_design.md` (directly affected test + same-PR design note).

## Validation
- `cargo test -p orbit-remote --lib tests::runtime` — 8 passed (including 3 new CLI bind tests)
- `cargo test -p orbit-remote --lib mcp::tests` — 72 passed, unmodified
- `rg resolve_workspace_argument` — definition plus the existing `orbit.task.add` caller only
- `make ci-fast` — passed
- `make ci-lint` — passed

## Recommended follow-ups
- ORB-10758: unify CLI/MCP advertised workspace grammar (registered IDs vs filesystem paths on `orbit.task.add`).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10769-6a7e7c86`
- Behind base: 0
- Ahead of base: 1