### PR TITLE
docs: Accept resident-orchestrator and claim owner grok [ORB-10776]

### DIFF
--- a/docs/design/resident-orchestrator/1_overview.md
+++ b/docs/design/resident-orchestrator/1_overview.md
@@ -1,8 +1,8 @@
 ---
 title: Resident Orchestrator — Overview
-owner: codex
-last_updated: 2026-08-09
-status: Draft
+owner: grok
+last_updated: 2026-08-14
+status: Accepted
 feature: resident-orchestrator
 doc_role: overview
 type: design
@@ -10,7 +10,7 @@ summary: Workspace-addressed epic delegation to a resumable CLI orchestrator tha
 tags: [resident-orchestrator, epic, routines, cli, decision-gates]
 paths: [".orbit/resources/activities/**", ".orbit/resources/jobs/**", ".orbit/routines/**", "crates/orbit-core/assets/**"]
 related_features: [resident-orchestrator, activity-job, routines, agent-families]
-related_artifacts: []
+related_artifacts: [ORB-10775, ORB-10776, ORB-10777, ORB-10778, ORB-10779, ORB-10780, ORB-10781, ORB-10782, ADR-0361]
 ---
 
 # Resident Orchestrator — Overview
@@ -83,18 +83,27 @@ conflict/finding resolution, merge verification, child closure, and finally pare
 
 | Concern | File | Task |
 |---------|------|------|
-| Resident CLI identity | workspace `.orbit/resources/activities/resident_orchestrator.yaml` | Not allocated |
-| Epic selection and resume | proposed deterministic `select_resident_epic` activity | Not allocated |
-| Bounded ownership cycle | proposed `resident_epic_cycle` job | Not allocated |
-| Conversation continuity | proposed CLI session capture and resume adapter | Not allocated |
-| Supervisor/human decision path | structured parent-task request and answer comments | Not allocated |
-| Scheduled pickup | workspace `.orbit/routines/resident_epic.yaml` | Not allocated |
+| Design acceptance and Grok feature-lead | this folder | [ORB-10776] |
+| Epic selection and resume | proposed deterministic `select_resident_epic` activity | [ORB-10777] |
+| Supervisor/human decision path | structured parent-task request and answer comments | [ORB-10778] |
+| Resident CLI identity | workspace `.orbit/resources/activities/resident_orchestrator.yaml` | [ORB-10779] |
+| Bounded ownership cycle | proposed `resident_epic_cycle` job | [ORB-10779] |
+| Conversation continuity | Grok CLI session capture and resume adapter | [ORB-10780] |
+| Scheduled pickup | workspace `.orbit/routines/resident-epic-orbit` (disabled until canary) | [ORB-10781] |
+| `ws_orbit` grok canary | activity binding + routine enable after dry-run | [ORB-10782] |
 | Child delivery | existing `task_gate_pipeline` / explicit-ID shipment workflows | Existing mechanism |
 | HTTP epic retirement | former `task_epic_pipeline` and `epic_orchestrator` assets (removed in [ORB-10332]) | [ORB-10332] |
 
 ## Task References
 
 - **[ORB-10332]** — Remove the unused HTTP epic pipeline assets (`task_epic_pipeline`, `epic_orchestrator`) this design supersedes.
-- Further implementation tasks will be allocated after this Draft is accepted.
+- **[ORB-10775]** — Epic: resident orchestrator v1 (workspace-addressed CLI epic cycles).
+- **[ORB-10776]** — Accept this folder and claim `owner: grok`.
+- **[ORB-10777]** — Deterministic `select_resident_epic`.
+- **[ORB-10778]** — Checkpoint and decision comment protocol.
+- **[ORB-10779]** — `resident_orchestrator` activity and `resident_epic_cycle` job.
+- **[ORB-10780]** — Grok CLI conversation capture/resume.
+- **[ORB-10781]** — Disabled `resident-epic-orbit` routine.
+- **[ORB-10782]** — `ws_orbit` grok canary.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/resident-orchestrator/1_overview.md
+++ b/docs/design/resident-orchestrator/1_overview.md
@@ -6,104 +6,83 @@ status: Accepted
 feature: resident-orchestrator
 doc_role: overview
 type: design
-summary: Workspace-addressed epic delegation to a resumable CLI orchestrator that decomposes, clarifies, and shepherds work without a resident server.
-tags: [resident-orchestrator, epic, routines, cli, decision-gates]
-paths: [".orbit/resources/activities/**", ".orbit/resources/jobs/**", ".orbit/routines/**", "crates/orbit-core/assets/**"]
-related_features: [resident-orchestrator, activity-job, routines, agent-families]
-related_artifacts: [ORB-10775, ORB-10776, ORB-10777, ORB-10778, ORB-10779, ORB-10780, ORB-10781, ORB-10782, ADR-0361]
+summary: V1 is one catalog job — scan unresolved work, then run a long-lived orchestrator with full Orbit MCP until the scan is empty. The clock that fires it lives outside Orbit.
+tags: [resident-orchestrator, epic, jobs, mcp]
+paths: [".orbit/resources/jobs/**", "crates/orbit-core/assets/jobs/**", "crates/orbit-core/assets/activities/**"]
+related_features: [resident-orchestrator, activity-job]
+related_artifacts: [ORB-10775, ORB-10776, ORB-10779, ADR-0361, ADR-0362]
 ---
 
 # Resident Orchestrator — Overview
 
-A **resident orchestrator** is a specialized agent bound to one Orbit workspace. The workspace is
-its address, a root task tagged `epic` is its durable work order, and a workspace-local routine
-wakes a bounded `backend: cli` ownership cycle. The resident decomposes the epic into normal child
-tasks, ships explicit child task IDs through the existing delivery workflows, and shepherds the
-whole tree to a verified terminal state. No per-agent server, inbox pump, or retained HTTP agent
-session is required. Bounded CLI processes may resume an opaque provider conversation between
-cycles, while Orbit remains the durable source of truth.
+V1 is one Orbit job, `epic_pipeline`.
+
+A **deterministic scan** looks at the workspace for (1) tasks in `proposed`, `backlog`, or
+`blocked`, or (2) failed job-runs. If the scan is empty, the job succeeds as a no-op. If
+anything is present, the job invokes a **long-running orchestrator activity** with the full
+Orbit MCP tool surface. That agent works the set until a later scan is empty. The job loops
+scan → orchestrate until drain or a bounded iteration/time ceiling.
+
+The **clock** that fires this job is not an Orbit routine. A cron (or a human, or a front-door
+session) on a separate knowledgebase checkout, with Orbit MCP wired in, calls
+`orbit run job epic_pipeline`. Selection, decomposition, and "should we run now?" live there.
+
+This supersedes the unused HTTP `task_epic_pipeline` ([ORB-10332]) and the first draft's
+in-Orbit resident (session resume, JSON comment protocol, `select_resident_epic`, seeded
+routine). Those are not v1.
 
 ## 1. Motivation
 
-The constellation currently has two useful but insufficient levels of delegation:
+Leaf pipelines ship one task. A front-door orchestrator can already speak MCP. What Orbit
+lacked is a single, callable "there is unfinished work — stay on it until it is gone"
+primitive. Putting the supervisor *inside* Orbit (a 2-hour CLI resident, session resume,
+decision-comment protocol, workspace routine) duplicates the orchestrators we already run.
 
-1. A front-door orchestrator can make cross-workspace decisions.
-2. A one-shot runner can execute one scoped leaf mandate.
-
-What is missing is durable, codebase-local ownership between those levels. A single front door
-cannot retain deep context for several codebases while also following every task, workflow run,
-review, merge conflict, and acceptance criterion to completion. Repeated generic runner calls do
-not solve that problem: the front door remains the shepherd and must reconstruct the codebase's
-state on every turn.
-
-Orbit already provides the durable pieces needed for a smaller solution: workspace routing,
-tagged tasks, parent/child task relationships, dependencies, CLI agent activities, jobs, routines,
-and explicit-ID shipment workflows. The missing mechanism is a convention and a thin pickup cycle
-that hand ownership of a high-level task to the workspace's specialized orchestrator.
-
-The former `task_epic_pipeline` was not that mechanism. It assumed child tasks already existed,
-used an HTTP agent loop with retained session state, and treated `review` as the end of automated
-shipment. Orbit v1 supports CLI agent invocation; the resident must also own decomposition and the
-post-review delivery loop. This design supersedes the HTTP epic path, which was removed as unused
-in [ORB-10332], rather than porting it.
+The useful Orbit piece is the drain loop. The useful outside piece is the cron that decides
+when to start one.
 
 ## 2. Core Concepts
 
-**Resident workspace.** One Orbit workspace is the durable address for one specialized
-orchestrator. For example, an Orbit systems agent receives work in the Orbit codebase workspace;
-no separate agent queue is required.
+**Unresolved work.** A workspace-local set: every task whose status is `proposed`,
+`backlog`, or `blocked`, plus every job-run in `failed` or `timeout`. `in-progress` and
+`review` are live or waiting on a human; the scan does not treat them as wake reasons.
+`cancelled` runs are intentional and are not wake reasons.
 
-**Epic assignment.** A root task with no `parent_id` and the tag `epic`. Creating that task in a
-workspace is the act of delegation. Its description and acceptance criteria define the outcome;
-the resident authors the execution plan after pickup.
+**Scan.** Deterministic activity `scan_unresolved_work`. Read-only. Returns the set (ids +
+counts). Empty set is a successful no-op input to the job.
 
-**Resident activity.** A workspace-local `agent_loop` activity using `backend: cli`. It explicitly
-binds the provider, model, and identity-loading instruction for that workspace's resident agent.
-Different workspaces can use different resident agents without a new invocation service.
+**Orchestrator activity.** `epic_orchestrator`: one `backend: cli` agent_loop with the
+full Orbit tool catalog (task, workflow/run, search — not a leaf implementer allowlist).
+Its mandate is to shrink the scan set: triage `proposed`, unblock or re-dispatch
+`blocked`, ship or decompose `backlog`, resume or otherwise close failed/timeout runs.
+It must not merge PRs that policy reserves for Daniel.
 
-**Ownership cycle.** One bounded resident invocation. It resumes an active epic before selecting a
-new one, advances as much of its task tree as current state permits, persists every decision in
-Orbit, records a compatible provider conversation reference, and exits. A later routine fire may
-resume that conversation for continuity, but must reconstruct the safe action from durable state.
+**Epic job.** `epic_pipeline`: loop { scan; break if empty; invoke orchestrator } until
+empty, iteration cap, or wall clock. A leftover scan after the cap fails the job
+fail-closed; success is never inferred from agent prose.
 
-**Decision gate.** A structured question recorded on the parent epic when consequential ambiguity
-or missing authority makes further work disproportionately risky. The resident exits while the
-question is pending; the next bounded cycle resumes with the matched supervisor or human answer.
-V1 has no live mid-turn steering or managed interactive terminal.
+**External clock.** Cron / knowledgebase supervisor / front door. Not a seeded Orbit
+routine in v1.
 
-**Child task.** A normal task created with `parent_id` pointing to the epic. Child tasks use the
-ordinary lifecycle, dependency, crew, validation, review, and PR machinery; the `epic` tag does not
-create a second execution model.
-
-**Shepherding.** The resident's responsibility for the entire workspace-local delivery loop:
-decomposition, explicit dispatch, run observation, failure recovery,
-conflict/finding resolution, merge verification, child closure, and finally parent closure.
+**Epic tag.** Still the supervisor's delegation convention for a root body of work
+(ADR-0361). The job predicate is status + failed runs, not the tag.
 
 ## 3. At a Glance
 
-| Concern | File | Task |
-|---------|------|------|
-| Design acceptance and Grok feature-lead | this folder | [ORB-10776] |
-| Epic selection and resume | proposed deterministic `select_resident_epic` activity | [ORB-10777] |
-| Supervisor/human decision path | structured parent-task request and answer comments | [ORB-10778] |
-| Resident CLI identity | workspace `.orbit/resources/activities/resident_orchestrator.yaml` | [ORB-10779] |
-| Bounded ownership cycle | proposed `resident_epic_cycle` job | [ORB-10779] |
-| Conversation continuity | Grok CLI session capture and resume adapter | [ORB-10780] |
-| Scheduled pickup | workspace `.orbit/routines/resident-epic-orbit` (disabled until canary) | [ORB-10781] |
-| `ws_orbit` grok canary | activity binding + routine enable after dry-run | [ORB-10782] |
-| Child delivery | existing `task_gate_pipeline` / explicit-ID shipment workflows | Existing mechanism |
-| HTTP epic retirement | former `task_epic_pipeline` and `epic_orchestrator` assets (removed in [ORB-10332]) | [ORB-10332] |
+| Concern | Where | Task |
+|---------|-------|------|
+| This split | this folder | [ORB-10776] |
+| Epic tag = supervisor delegation signal | ADR-0361 | [ORB-10776] |
+| Clock and supervisor stay outside Orbit | ADR-0362 | [ORB-10776] |
+| `scan_unresolved_work` + `epic_orchestrator` + `epic_pipeline` | catalog | [ORB-10779] |
+| Child delivery while draining | existing `task_gate_pipeline` / `task_pr_pipeline` | Existing |
+| HTTP epic retirement | removed assets | [ORB-10332] |
 
 ## Task References
 
-- **[ORB-10332]** — Remove the unused HTTP epic pipeline assets (`task_epic_pipeline`, `epic_orchestrator`) this design supersedes.
-- **[ORB-10775]** — Epic: resident orchestrator v1 (workspace-addressed CLI epic cycles).
-- **[ORB-10776]** — Accept this folder and claim `owner: grok`.
-- **[ORB-10777]** — Deterministic `select_resident_epic`.
-- **[ORB-10778]** — Checkpoint and decision comment protocol.
-- **[ORB-10779]** — `resident_orchestrator` activity and `resident_epic_cycle` job.
-- **[ORB-10780]** — Grok CLI conversation capture/resume.
-- **[ORB-10781]** — Disabled `resident-epic-orbit` routine.
-- **[ORB-10782]** — `ws_orbit` grok canary.
+- **[ORB-10332]** — Remove the unused HTTP epic pipeline.
+- **[ORB-10775]** — Epic: drain job in Orbit; supervisor clock stays external.
+- **[ORB-10776]** — Accept this contract; ADR-0361 and ADR-0362.
+- **[ORB-10779]** — Ship the scan, the orchestrator activity, and `epic_pipeline`.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/resident-orchestrator/1_overview.md
+++ b/docs/design/resident-orchestrator/1_overview.md
@@ -6,11 +6,11 @@ status: Accepted
 feature: resident-orchestrator
 doc_role: overview
 type: design
-summary: V1 is one catalog job — scan unresolved work, then run a long-lived orchestrator with full Orbit MCP until the scan is empty. The clock that fires it lives outside Orbit.
+summary: V1 is a drain job — scan unresolved work, then an orchestrator that only creates/ships tasks and writes a session log until the scan is empty. It does not edit code. The fire clock lives outside Orbit.
 tags: [resident-orchestrator, epic, jobs, mcp]
 paths: [".orbit/resources/jobs/**", "crates/orbit-core/assets/jobs/**", "crates/orbit-core/assets/activities/**"]
 related_features: [resident-orchestrator, activity-job]
-related_artifacts: [ORB-10775, ORB-10776, ORB-10779, ADR-0361, ADR-0362]
+related_artifacts: [ORB-10775, ORB-10776, ORB-10779, ADR-0361, ADR-0362, ADR-0363]
 ---
 
 # Resident Orchestrator — Overview
@@ -19,9 +19,10 @@ V1 is one Orbit job, `epic_pipeline`.
 
 A **deterministic scan** looks at the workspace for (1) tasks in `proposed`, `backlog`, or
 `blocked`, or (2) failed job-runs. If the scan is empty, the job succeeds as a no-op. If
-anything is present, the job invokes a **long-running orchestrator activity** with the full
-Orbit MCP tool surface. That agent works the set until a later scan is empty. The job loops
-scan → orchestrate until drain or a bounded iteration/time ceiling.
+anything is present, the job invokes a **long-running orchestrator activity**. That agent
+**does not edit the repository**. It creates and ships tasks, inspects runs, and writes a
+workspace **session log** (notes, check-later items, status). The job loops scan →
+orchestrate until a later scan is empty or a bounded ceiling.
 
 The **clock** that fires this job is not an Orbit routine. A cron (or a human, or a front-door
 session) on a separate knowledgebase checkout, with Orbit MCP wired in, calls
@@ -51,11 +52,16 @@ when to start one.
 **Scan.** Deterministic activity `scan_unresolved_work`. Read-only. Returns the set (ids +
 counts). Empty set is a successful no-op input to the job.
 
-**Orchestrator activity.** `epic_orchestrator`: one `backend: cli` agent_loop with the
-full Orbit tool catalog (task, workflow/run, search — not a leaf implementer allowlist).
-Its mandate is to shrink the scan set: triage `proposed`, unblock or re-dispatch
-`blocked`, ship or decompose `backlog`, resume or otherwise close failed/timeout runs.
-It must not merge PRs that policy reserves for Daniel.
+**Orchestrator activity.** `epic_orchestrator`: one `backend: cli` agent_loop. It
+**does not change code**. Allowlist is Orbit task + workflow/run + search +
+`orbit.session_log.*` — no git write, no worktree edit, no `agent_implement`. It
+shrinks the scan set by creating tasks, shipping explicit ids, and resuming or
+cancelling failed runs. It must not merge PRs reserved for Daniel.
+
+**Session log.** Workspace-scoped append-only notebook (`orbit.session_log`). Entry
+kinds: `status`, `note`, `check_later`. Unresolved `check_later` rows are a scan
+wake reason, so "look at this next time" actually wakes the next fire. This is the
+memory between invokes; conversation resume stays out of v1.
 
 **Epic job.** `epic_pipeline`: loop { scan; break if empty; invoke orchestrator } until
 empty, iteration cap, or wall clock. A leftover scan after the cap fails the job
@@ -74,6 +80,7 @@ routine in v1.
 | This split | this folder | [ORB-10776] |
 | Epic tag = supervisor delegation signal | ADR-0361 | [ORB-10776] |
 | Clock and supervisor stay outside Orbit | ADR-0362 | [ORB-10776] |
+| `orbit.session_log` (notes / check-later / status) | workspace session-log store + tools | [ORB-10784] |
 | `scan_unresolved_work` + `epic_orchestrator` + `epic_pipeline` | catalog | [ORB-10779] |
 | Child delivery while draining | existing `task_gate_pipeline` / `task_pr_pipeline` | Existing |
 | HTTP epic retirement | removed assets | [ORB-10332] |
@@ -84,5 +91,6 @@ routine in v1.
 - **[ORB-10775]** — Epic: drain job in Orbit; supervisor clock stays external.
 - **[ORB-10776]** — Accept this contract; ADR-0361 and ADR-0362.
 - **[ORB-10779]** — Ship the scan, the orchestrator activity, and `epic_pipeline`.
+- **[ORB-10784]** — `orbit.session_log` (status / note / check_later).
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/resident-orchestrator/2_design.md
+++ b/docs/design/resident-orchestrator/2_design.md
@@ -6,420 +6,128 @@ status: Accepted
 feature: resident-orchestrator
 doc_role: design
 type: design
-summary: Bounded, resumable CLI cycles for workspace-resident orchestration, durable decision gates, decomposition, and shepherding.
-tags: [resident-orchestrator, epic, routines, cli, decision-gates]
-paths: [".orbit/resources/activities/**", ".orbit/resources/jobs/**", ".orbit/routines/**", "crates/orbit-core/assets/**"]
-related_features: [resident-orchestrator, activity-job, routines, agent-families, host-registry]
-related_artifacts: [ORB-10332, ORB-10775, ORB-10776, ADR-0352, ADR-0361]
+summary: epic_pipeline loops a deterministic unresolved-work scan and a full-MCP orchestrator activity until the scan is empty. The fire clock is external.
+tags: [resident-orchestrator, epic, jobs, mcp]
+paths: [".orbit/resources/jobs/**", "crates/orbit-core/assets/jobs/**", "crates/orbit-core/assets/activities/**"]
+related_features: [resident-orchestrator, activity-job]
+related_artifacts: [ORB-10332, ORB-10775, ORB-10776, ORB-10779, ADR-0361, ADR-0362]
 ---
 
 # Resident Orchestrator — Design
 
-This document specifies the accepted resident-orchestrator contract. It covers how a high-level
-assignment is addressed, selected, resumed, clarified, decomposed, dispatched, and closed using
-Orbit's CLI backend, a resumable provider conversation, and durable task state. It does not change
-leaf implementation pipelines or introduce a general distributed workflow engine.
+This is the v1 contract. It specifies the scan, the orchestrator activity, the job loop,
+and what Orbit deliberately does not own. It does not add a resident server, an Orbit
+routine, conversation resume, or a comment-typed decision protocol.
 
-The v1 hierarchy is human → front-door supervisor → workspace resident orchestrator → leaf
-executor. The resident minimizes the supervisor's workspace-local surface area, but it is not the
-product owner: product scope, material tradeoffs, and merge authority stay at the supervisor or
-human layer. V1 uses bounded headless CLI processes. It deliberately excludes managed PTYs,
-terminal attachment, and live mid-turn steering.
+## 1. Unresolved-work scan
 
-## 1. Addressing Work Through the Workspace
+`scan_unresolved_work` is a deterministic activity. It reads the source workspace only.
 
-The destination workspace is the agent address. The front-door orchestrator delegates by creating
-one task in that workspace with:
+It includes:
 
-- no `parent_id`;
-- tag `epic`;
-- an outcome-oriented description;
-- observable epic-level acceptance criteria;
-- the appropriate priority; and
-- `proposed` or `backlog` status under the workspace's normal approval policy.
+- every task with status `proposed`, `backlog`, or `blocked`;
+- every job-run whose state is `failed` or `timeout`.
 
-There is no required `assignee` field. In v1, a workspace has at most one configured resident
-orchestrator, so workspace routing plus the `epic` tag is unambiguous. The task remains a normal
-Orbit task: it can be searched, blocked, rejected, archived, related to other artifacts, and
-inspected by any operator.
+It excludes:
 
-The `epic` tag is deliberately behavioral only at the resident pickup boundary. It does not alter
-the task schema or create a new task type. Child tasks are recognized by `parent_id`, not by a
-special child tag.
+- `in-progress` tasks (a run is already live);
+- `review` and `done` / `rejected` / `archived` / `someday` tasks;
+- `cancelled` job-runs (operator-intentional);
+- runs still `pending` / `running` / `retrying`.
 
-This differs from the former `task_epic_pipeline`, whose `load_epic` path recognized a root by
-`TaskType::Feature`. That HTTP epic pipeline was removed as unused in [ORB-10332], so the resident's
-`epic` tag is now the only epic selector; the earlier plan to keep the two selectors disjoint by
-workspace during a staged retirement no longer applies. The marker choice is named in
-[4_decisions.md](./4_decisions.md).
+Output is a structured object: `task_ids`, `run_ids`, counts, and a boolean `empty`.
+No task or run is mutated. An empty scan is success, not an error.
 
-## 2. Workspace-Local Resident Identity
+The scan is the only admission function. The job does not select by `epic` tag, assignee,
+or priority. Those filters belong to the external supervisor if it wants them (it can
+decline to fire the job).
 
-Each participating workspace owns an activity named `resident_orchestrator`. The activity is the
-declarative invocation profile for that workspace's specialized agent:
+## 2. Orchestrator activity
 
-```yaml
-schemaVersion: 2
-kind: Activity
-metadata:
-  name: resident_orchestrator
-spec:
-  type: agent_loop
-  description: Run one bounded ownership cycle for this workspace's resident orchestrator.
-  backend: cli
-  provider: codex
-  model: gpt-5.6-sol
-  wall_clock_timeout_seconds: 7200
-  instruction: |
-    Read the resident identity and active rules before acting.
-    You own one bounded epic-shepherding cycle in this workspace.
-```
+`epic_orchestrator` is an `agent_loop` / `backend: cli` activity.
 
-The example values are illustrative; each workspace chooses its own provider, model, and identity
-instruction. The resolved provider/model must be explicit and must match the named resident's
-identity. Defaults or role overrides that silently change the resolved identity are invalid for a
-resident activity.
+- **Tools:** the full Orbit MCP/CLI tool catalog for that workspace (task lifecycle,
+  workflow run inspect/resume/ship, search). It is not a leaf `agent_implement` allowlist
+  and it is not a new tool surface.
+- **Mandate:** shrink the scan set. Typical moves: promote or reject `proposed`, re-dispatch
+  or re-block with a precise reason, create children and `workflow_ship` explicit ids,
+  `workflow_run_resume` a failed run whose cause is fixed, cancel a run that should stay
+  dead and move the coupled task out of `blocked`.
+- **Must not:** merge PRs reserved for Daniel; edit a second workspace; treat silence as
+  new product authority.
+- **Bound:** a wall-clock timeout on the activity (suggested 2 hours). The *job* is what
+  retries the scan after the process exits. The agent is instructed to drain, but the
+  scan after return is authoritative.
 
-`AgentLoopSpec.max_iterations` in `activity_v2.rs` bounds turns in Orbit's HTTP loop. The CLI
-dispatcher launches one provider process and does not apply that field to provider turns, so the
-resident example omits it: a full shepherd cycle is bounded by the 7,200-second wall clock, while
-provider turn knobs remain provider/harness policy rather than Orbit activity configuration.
+Conversation resume across fires is out of v1. Each invoke starts fresh from Orbit state.
 
-Identity memory remains outside Orbit's task store. The activity instruction points the CLI agent
-to its versioned memory layer, and the CLI harness loads the workspace's normal repository
-instructions. Orbit owns invocation, task state, and audit evidence; it does not become an agent
-memory service.
-
-Using a normal activity asset is intentional. It reuses the existing CLI executor and lets every
-workspace version its own resident binding without adding an identity registry or another server.
-
-The resident activity also supports an opaque provider conversation reference. The first cycle
-starts a new conversation and records its reference; later cycles resume it when the workspace,
-provider, model, and resident identity still match. Conversation continuity reduces repeated
-orientation cost and preserves the semantic thread across decisions, but it grants no authority
-and is never the source of truth for task or workflow state.
-
-The first Constellation canary is `ws_orbit`, bound explicitly to crew `grok` (Grok Build /
-the workspace Grok default model) [ORB-10782]. The resident loads its versioned memory layer
-before each cycle and owns decomposition, shipment, review-wait, and closure inside `ws_orbit`.
-The front door still owns cross-workspace routing, product priority, and any independent
-oversight required by live policy. The earlier Hohmann / Codex Sol binding was an illustrative
-example and is not the canary.
-
-## 3. The Resident Epic Cycle
-
-A new `resident_epic_cycle` job performs one bounded ownership cycle:
-
-1. **Select.** A deterministic `select_resident_epic` activity searches the source workspace.
-2. **Rehydrate.** The job loads the latest durable epic state and any compatible provider
-   conversation reference. An unresolved decision request without an answer returns a successful
-   no-op before provider invocation.
-3. **Invoke.** The job starts one headless CLI process. It either creates a provider conversation or
-   resumes the compatible conversation with the fresh parent snapshot, child summaries, relevant
-   run pointers, and any newly recorded decision answer.
-4. **Record.** The CLI agent performs task and workflow operations through Orbit's managed tool
-   surface. The provider adapter captures the conversation reference from the provider stream, and
-   the job writes a concise checkpoint containing that reference and the cycle outcome.
-5. **Exit.** The job ends. It does not sleep while a child workflow or human decision is pending,
-   and no provider process remains running between fires.
-
-The retained object is a resumable conversation reference, not a resident process. If that
-reference is missing, expired, incompatible, or cannot be resumed, the job starts a new provider
-conversation from durable Orbit state and records the replacement. Loss of provider conversation
-history may increase reorientation cost, but it must not change the safe next action.
-
-Selection order is deterministic:
-
-1. resume the oldest `in-progress`, root, `epic` task;
-2. otherwise select the highest-priority ready `backlog` root epic, then creation order;
-3. otherwise return a successful no-op.
-
-V1 does not pick up `proposed` epics. A human or upstream authority must approve one into `backlog`
-before the resident can claim it; a future policy surface for proposed pickup remains an open
-question in [3_vision.md](./3_vision.md).
-
-The first version permits one active epic per workspace. The routine uses `overlap: forbid`, pins
-one host, and the selector always resumes active ownership before admitting new work. These three
-constraints avoid a new lease or assignee subsystem. A concurrent manual lifecycle transition is
-resolved by the task store's existing status validation; the losing cycle refreshes instead of
-forcing state.
-
-> **Revised by [ADR-0352].** The three constraints above bound concurrent *automated* routine
-> fires; they do not arbitrate between interactive operator sessions, which can now reach one
-> workspace from several places at once. Workflow dispatch is additionally gated on an exclusive
-> workspace claim — see
-> [host-registry/2_design.md §3.2](../host-registry/2_design.md). The reasoning here stands for
-> what it covers; it is no longer the whole story.
-
-`overlap: forbid` prevents concurrent fires of this routine, not a manual invocation of the same
-activity. Status validation is the admission backstop: only one contender can transition the
-selected backlog epic to `in-progress`; a loser refreshes, while contenders resuming an already
-active epic are made dispatch-safe by the authoritative task/run lookup in Section 4.
-
-## 4. Resident Cycle Contract
-
-The resident is an orchestrator within one workspace, not a leaf implementer, global supervisor,
-or product owner. During each cycle it must:
-
-1. load the parent task, its plan, acceptance criteria, children, dependencies, review threads,
-   artifacts, and active workflow runs;
-2. before decomposition, make the objective, constraints, non-goals, acceptance evidence, and
-   material unresolved assumptions explicit in the parent plan;
-3. ask for a decision rather than committing substantial work when competing interpretations
-   would produce materially different outcomes or require new authority;
-4. start the parent when it accepts ownership;
-5. create independently shippable child tasks with `parent_id`, strong acceptance criteria,
-   precise `context_files`, dependencies, priority, complexity, and crew;
-6. dispatch only explicit ready child IDs through the workspace's normal shipment workflow;
-7. query the authoritative run-list projection by each ready child task ID before dispatching;
-   observe any non-terminal matching run instead of submitting another shipment;
-8. treat waiting for human review/merge approval as an explicit gate: record the pending PR and
-   required approver evidence, then exit until that evidence exists;
-9. resolve failures, review findings, merge conflicts, and stale branches within its workspace;
-10. verify landed commits and child lifecycle state rather than trusting agent prose or a PR merge
-   button; and
-11. complete the parent only after every required child is terminal and the parent-level acceptance
-    criteria have been verified as an integrated outcome.
-
-The resident may decide reversible, workspace-local execution details already implied by the epic.
-It must surface decisions that change product scope, acceptance criteria, architecture boundaries,
-external behavior, material cost, security posture, or delivery authority. The front-door
-supervisor may answer within authority explicitly delegated to it; otherwise it routes the request
-to the human. The resident never treats silence as expanded authority.
-
-Shipment submission takes explicit child task IDs. Before a Run becomes dispatchable, the shipment
-path must persist those IDs on the Run in the same transaction as Run creation; the run-list
-projection indexed by task ID is therefore the authoritative run↔task association. Comments,
-execution summaries, and resident checkpoints may point to that association, but are never its
-source of truth. This makes the pre-dispatch query reliable even if the resident crashes immediately
-after submission and before writing its own checkpoint.
-
-For the `ws_orbit` canary, the review gate is Daniel's human merge approval. Planner, implementer,
-and reviewer crew labels are activity labels on one resolved provider/model/backend assignment. The resident may prepare
-and repair the candidate, but it must enter the human-approval wait state rather than approving or
-merging on Daniel's behalf.
-
-The resident may inspect adjacent workspaces to understand an interface, but it must not silently
-edit or dispatch into them. A cross-workspace dependency becomes a separate epic assignment in the
-destination workspace, related from the source task with explicit workspace and task pointers.
-The front-door orchestrator remains the authority for cross-workspace priority and product scope.
-
-## 5. Durable Checkpoints, Decisions, and Resumption
-
-No correctness may depend on CLI conversation history. The recovery state is the Orbit graph:
-
-- the parent task's status, plan, comments, execution summary, and acceptance criteria;
-- child tasks connected by `parent_id`;
-- child `dependencies` and relations;
-- workflow Runs whose transactionally stored task IDs are exposed by the run-list projection;
-- review threads and structured verdicts; and
-- repository/PR state verified during the cycle.
-
-The resident writes a concise cycle checkpoint to the parent before exiting. At minimum it records
-what changed, which children or runs remain active, the next safe action, and any blocker requiring
-new authority. It also records the opaque provider conversation reference and the provider, model,
-workspace, and resident identity to which that reference is bound. Checkpoints are pointers, not
-copied logs.
-
-### 5.1 Progressive clarification
-
-Upfront planning and mid-execution questions are complementary. Before dispatching the first child,
-the resident resolves ambiguity that can be discovered cheaply from the epic, repository, existing
-ADRs, and supervisor context. Later it asks when new evidence creates a consequential fork.
-
-The escalation heuristic is:
+## 3. `epic_pipeline` job
 
 ```text
-ask when P(wrong branch | current evidence) × remaining rework cost
-         > question cost + expected delay cost
+loop
+  scan = scan_unresolved_work
+  break if scan.empty
+  invoke epic_orchestrator
+until empty or max_iterations or job wall clock
+if scan not empty: fail
+else: succeed
 ```
 
-This is a judgment aid, not a mechanically calculated policy. Low-cost reversible choices remain
-with the resident. The point is to prevent long epics from accumulating expensive work behind an
-unstated assumption while avoiding human involvement in routine execution details.
+- Empty first scan: success, zero orchestrator invokes.
+- The loop is how "work until resolved" is enforced. Agent prose cannot mark the job
+  successful while `proposed`/`backlog`/`blocked` or failed/timeout runs remain.
+- `max_iterations` and the job timeout are fail-closed ceilings, not "close enough."
+- `overlap: forbid` at whatever *external* clock fires the job; the job itself should
+  set `max_active_runs: 1` so two overlapping fires do not double-orchestrate.
 
-### 5.2 V1 decision exchange
+Input is workspace-scoped (the runtime workspace). No `epic_id` is required. A supervisor
+that wants to drain one epic only does so by not leaving other tasks in the scanned
+statuses, or by running in a workspace that only holds that work.
 
-V1 represents checkpoints and the exchange as structured parent-task comments rather than
-introducing a new message store. Each machine-readable comment body is one JSON object with
-`schema_version: 1` and one of three `kind` values: `resident_cycle_checkpoint`,
-`resident_decision_request`, or `resident_decision_answer`. Ordinary prose comments remain valid
-and are ignored by the resident-state parser. At most one unresolved decision request may exist
-for an epic. A request records:
+## 4. External clock (not an Orbit routine)
 
-- a stable request ID and epic ID;
-- the exact question and why it blocks safe progress now;
-- the viable options and material tradeoffs;
-- the resident's recommendation, when it has one;
-- the smallest safe work that may continue without the answer;
-- the current checkpoint and provider conversation reference; and
-- the authority required to answer.
+v1 does not seed `resident-epic-orbit` or any other routine. A knowledgebase checkout
+(or the front-door orchestrator) fires:
 
-The resident writes the request, records a `waiting_decision` cycle outcome, and exits. The parent
-remains `in-progress`; `blocked` is reserved for an external dependency or authority gap that
-cannot be resolved through this bounded exchange. While the request is unanswered, the selector
-returns a successful no-op without paying for another provider invocation.
-
-The supervisor or human answers through Orbit with a `resident_decision_answer` comment that names
-the request ID, the chosen direction, the answering authority, and any changed constraints or
-acceptance criteria. Only a matching answer from sufficient authority resolves the request;
-duplicate or mismatched answers remain visible but do not create a second decision. The next
-routine fire supplies the resolved answer and fresh Orbit state to the resumed provider
-conversation. V1 does not inject messages into a running turn and does not keep a process alive
-while waiting.
-
-For the Grok canary, a new cycle resumes the saved session through the Grok Build CLI's
-non-interactive resume surface [ORB-10780]. Other providers (for example Codex's
-[CLI resume](https://developers.openai.com/codex/cli/reference)) keep their own argv; that
-shape is a provider adapter detail rather than an Orbit task invariant. A resume failure falls
-back to a new conversation after recording the failure; the unanswered or answered decision
-remains durable in Orbit either way.
-
-### 5.3 Crash and restart behavior
-
-Crash behavior follows from where the failure occurs:
-
-| Failure point | Durable result | Next fire |
-|---------------|----------------|-----------|
-| Before selection | No task mutation | Select normally |
-| After selection, before start | Parent remains proposed/backlog | Re-evaluate and retry |
-| After parent start | Parent remains `in-progress` | Resume it before new work |
-| After child creation | Children remain attached | Continue decomposition/dispatch |
-| After workflow submit, before resident checkpoint | Run already contains the child task ID and appears in the task-indexed run-list projection | Observe the matching run; do not redispatch |
-| After decision request, before answer | Parent has one unresolved request | Return a no-op without provider invocation |
-| After decision answer, before resume | Parent has a matched answer | Resume the compatible conversation with the answer and fresh state |
-| Provider conversation cannot be resumed | Orbit graph and decision records remain intact | Start a new conversation and continue from the durable checkpoint |
-| While waiting for agent review or CI evidence | Parent remains active with the pending gate recorded | Recheck only the required gate |
-| While waiting for human review/merge approval | Parent remains active with the PR and required approval evidence recorded | Recheck human approval/merge evidence; do not redispatch or complete |
-| Unresolvable product-authority blocker | Parent moves to `blocked` with exact missing authority | Stop automatic retries |
-
-## 6. Routine Contract
-
-Each resident workspace may enable a versioned routine targeting `job:resident_epic_cycle`:
-
-```yaml
-schemaVersion: 1
-name: resident-epic-orbit
-enabled: true
-hosts: [dk-server-1]
-trigger: { cron: "*/5 * * * *", missed_run: skip }
-target: job:resident_epic_cycle
-policy:
-  timeout_minutes: 135
-  overlap: forbid
+```text
+orbit run job epic_pipeline
 ```
 
-The routine is only a clock and admission boundary. It must not discover or ship ordinary backlog
-tasks. An `epic` root was deliberately placed in this workspace by an upstream orchestrator or
-human, so pickup is explicit delegation rather than blind auto-dispatch.
+via MCP or CLI, on a cron it owns. That process may also create `epic`-tagged roots,
+author children, and answer humans. None of that is a catalog asset in this repo.
 
-The routine is also the v1 wake mechanism for answered questions. No event bus or live channel is
-required: an unanswered decision is filtered before provider invocation, while a matching answer
-makes the next cycle runnable. The polling interval therefore bounds response latency without
-creating idle model cost.
+## 5. Authority and completion
 
-Routine definitions remain disabled by default when seeded. Enabling a resident is a versioned
-workspace decision, and the activity must resolve to a valid CLI provider/model on the pinned host
-before enablement.
+Daniel's merge authority is unchanged. `review` is not a wake reason: a task waiting on
+human merge must not keep the drain loop alive by itself. If the only leftovers are
+`review` + healthy runs, the scan is empty and the job succeeds.
 
-The routine timeout must be strictly greater than the resident activity wall clock plus job and
-checkpoint overhead. For the 120-minute activity example, the routine reserves 15 minutes of
-headroom (`135` minutes total), so routine-level expiry cannot preempt the activity supervisor's
-shutdown and final durable checkpoint. Workspaces that change the activity wall clock must increase
-the routine timeout by at least the same delta while retaining explicit headroom.
+A failed child pipeline that flipped its task to `blocked` *is* a wake reason (status
+`blocked` and/or run `failed`). The orchestrator is expected to diagnose and either
+resume, recast the task, or leave a precise block reason and — if it cannot progress —
+exit so the next scan still sees the item and the job fails at the ceiling rather than
+lying.
 
-## 7. Child Shipment and Completion
+## 6. Concerns & Honest Limitations
 
-The resident reuses existing leaf delivery workflows. It does not implement code inside the epic
-cycle unless the workspace's delivery policy explicitly treats a bounded change as direct work.
-Normally it promotes ready children and invokes shipment with explicit task IDs, selected mode,
-crew and base branch.
-
-An epic may have sequential and parallel children. Ordering is expressed durably by creating
-`BlockedBy` relations on child tasks; `dependencies` is the read projection of those relations, not
-a stored scalar field. Disjoint ready children may be shipped concurrently within the workspace's
-normal run and lock limits. Dependency inference that exists only in a model's reasoning is
-incomplete — the resident must create the relations before dispatch.
-
-The parent does not become `done` merely because all children reached `review`. Completion requires:
-
-- every required child is `done`, `rejected`, or explicitly accepted as out of scope;
-- no open blocking review thread remains;
-- every required PR has the human review/merge approval evidence required by workspace policy;
-- required PRs are merged and candidate commits are on the integration branch;
-- parent-level integration checks pass; and
-- the parent execution summary contains a structured final verdict and evidence pointers.
-
-## 8. Phasing Out the HTTP Epic Pipeline
-
-`task_epic_pipeline` and its `epic_orchestrator` activity were removed as unused in [ORB-10332];
-they were never converted in place because their contract differed materially from the resident
-path:
-
-| Former HTTP epic path | Resident CLI path |
-|----------------|-------------------|
-| Required pre-existing children | Owns decomposition and child creation |
-| Used `backend: http` and a retained `session:` loop | Uses bounded `backend: cli` processes with an optional resumable provider conversation |
-| Kept progress partly in provider conversation state | Keeps correctness in Orbit; conversation continuity only reduces reorientation cost |
-| Dispatched child gates | Shepherds dispatch, review, merge, and closure |
-| Treated `review` as shipped/terminal | Requires verified task and integration completion |
-
-Because [ORB-10332] already removed the legacy epic-pipeline assets, the resident path can be built
-greenfield without the earlier planned disjoint-selector migration:
-
-1. ship the resident selector, resumable CLI activity contract, decision exchange, cycle job, and
-   disabled routine;
-2. canary one workspace and verify question/answer resumption, lost-session recovery,
-   duplicate-dispatch prevention, review repair, and final parent closure; and
-3. enable the routine per workspace as the resident capability proves out.
-
-Historical run records for the removed pipeline remain readable after that catalog retirement.
-
-## 9. Security and Authority
-
-`backend: cli` delegates tool enforcement to the provider harness, so the resident activity is a
-trusted workspace capability. The routine therefore requires the same review boundary as any
-versioned automation asset, and the CLI run must retain Orbit's managed run identity and audit
-envelope.
-
-The resident's authority is bounded by the source workspace and live repository instructions.
-It may exercise routine lifecycle operations needed to shepherd already-authorized work, but it
-must block and surface a precise question when completion needs new product authority or a material
-scope expansion.
-
-Conversation references are opaque continuity pointers, not credentials or authorization grants.
-Every resumed cycle starts under Orbit's current run identity, sandbox, workspace claim, provider
-binding, and repository instructions. Decision answers retain their recorded human or supervisor
-provenance. Resuming an old conversation must never restore superseded permissions or bypass a
-newer durable task constraint.
-
-## 10. Concerns & Honest Limitations
-
-- **Workspace ownership is singular in v1.** Multiple resident orchestrators in one workspace need
-  an explicit routing or lease design; tags alone are not enough.
-- **Polling adds latency.** A five-minute cadence is simple and robust but delays pickup, answered
-  decisions, and resumption. Event triggers remain outside routines v1.
-- **Conversation continuity is best effort.** A provider may expire, reject, or become unable to
-  resume a session. Durable state prevents correctness loss, but a replacement conversation pays
-  the full reorientation cost.
-- **Every cycle still refreshes authority and facts.** Resuming a conversation does not eliminate
-  the cost of rereading current task, run, review, and repository state.
-- **There is no live intervention in v1.** A human cannot steer an in-flight turn. Urgent control
-  uses the existing run cancellation boundary; ordinary guidance is applied on the next cycle.
-- **Cross-workspace epics are not one graph.** Each workspace owns its own task tree; the front door
-  must relate and observe multiple parent tasks when one product outcome spans codebases.
-- **Provider harness trust is real.** CLI activities do not receive the HTTP backend's builtin tool
-  allowlist enforcement. Host sandboxing and provider policy remain part of the security boundary.
-- **A resident can still make poor decomposition choices.** Deterministic selection and durable
-  state, explicit assumptions, and decision gates make those choices inspectable and recoverable;
-  they do not eliminate judgment risk.
-- **Structured comments are intentionally narrow.** One pending decision per epic keeps v1 simple,
-  but it is not a general mailbox, chat system, or multi-party negotiation log.
+- **Workspace-wide drain.** One `blocked` chore anywhere wakes the orchestrator for the
+  whole workspace. Supervisors that want isolation should use separate workspaces or
+  keep unrelated work out of `proposed`/`backlog`/`blocked`.
+- **`proposed` is in the scan.** That is a deliberate reversal of the first draft (which
+  refused proposed pickup). The orchestrator may triage; it still must not invent
+  approval policy.
+- **No conversation continuity.** Every fire re-reads Orbit. Cheap if the scan is empty;
+  expensive if the cron is aggressive and the set is large.
+- **Full MCP is trusted.** This activity is a workspace-admin loop, not a sandboxed leaf.
+  The external clock is part of the security boundary.
+- **Ceilings can fail a job with work left.** That is correct. The next cron fire tries
+  again. Do not weaken the post-loop scan.
 
 ## Task References
 
-- **[ORB-10332]** — Removed the unused HTTP epic pipeline assets that this design supersedes.
-- **[ORB-10775]** — Implementation epic (children ORB-10776–ORB-10782).
-- **[ADR-0361]** — The `epic` tag is the sole resident pickup selector.
+- **[ORB-10332]** — Removed HTTP epic pipeline.
+- **[ORB-10775]** — Implementation epic.
+- **[ORB-10776]** — This contract and ADRs.
+- **[ORB-10779]** — Scan, orchestrator activity, `epic_pipeline`.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/resident-orchestrator/2_design.md
+++ b/docs/design/resident-orchestrator/2_design.md
@@ -1,8 +1,8 @@
 ---
 title: Resident Orchestrator — Design
-owner: codex
-last_updated: 2026-08-09
-status: Draft
+owner: grok
+last_updated: 2026-08-14
+status: Accepted
 feature: resident-orchestrator
 doc_role: design
 type: design
@@ -10,12 +10,12 @@ summary: Bounded, resumable CLI cycles for workspace-resident orchestration, dur
 tags: [resident-orchestrator, epic, routines, cli, decision-gates]
 paths: [".orbit/resources/activities/**", ".orbit/resources/jobs/**", ".orbit/routines/**", "crates/orbit-core/assets/**"]
 related_features: [resident-orchestrator, activity-job, routines, agent-families, host-registry]
-related_artifacts: [ORB-10332, ADR-0352]
+related_artifacts: [ORB-10332, ORB-10775, ORB-10776, ADR-0352, ADR-0361]
 ---
 
 # Resident Orchestrator — Design
 
-This document specifies the proposed resident-orchestrator contract. It covers how a high-level
+This document specifies the accepted resident-orchestrator contract. It covers how a high-level
 assignment is addressed, selected, resumed, clarified, decomposed, dispatched, and closed using
 Orbit's CLI backend, a resumable provider conversation, and durable task state. It does not change
 leaf implementation pipelines or introduce a general distributed workflow engine.
@@ -99,11 +99,12 @@ provider, model, and resident identity still match. Conversation continuity redu
 orientation cost and preserves the semantic thread across decisions, but it grants no authority
 and is never the source of truth for task or workflow state.
 
-The first Constellation canary is `ws_orbit`: Hohmann is bound explicitly to Codex Sol and loads
-its versioned memory layer before each cycle. Adopting this design changes Hohmann from a leaf that
-returns review/merge/closure to the front door into a codebase-bounded orchestrator that owns those
-steps inside `ws_orbit`. The front door still owns cross-workspace routing, product priority, and
-any independent oversight required by live policy.
+The first Constellation canary is `ws_orbit`, bound explicitly to crew `grok` (Grok Build /
+the workspace Grok default model) [ORB-10782]. The resident loads its versioned memory layer
+before each cycle and owns decomposition, shipment, review-wait, and closure inside `ws_orbit`.
+The front door still owns cross-workspace routing, product priority, and any independent
+oversight required by live policy. The earlier Hohmann / Codex Sol binding was an illustrative
+example and is not the canary.
 
 ## 3. The Resident Epic Cycle
 
@@ -267,12 +268,12 @@ routine fire supplies the resolved answer and fresh Orbit state to the resumed p
 conversation. V1 does not inject messages into a running turn and does not keep a process alive
 while waiting.
 
-For the Codex canary, a new cycle resumes the saved session through the non-interactive CLI resume
-surface documented in the
-[Codex CLI command reference](https://developers.openai.com/codex/cli/reference). That command
-shape is a provider adapter detail rather than an Orbit task invariant. A resume failure falls back
-to a new conversation after recording the failure; the unanswered or answered decision remains
-durable in Orbit either way.
+For the Grok canary, a new cycle resumes the saved session through the Grok Build CLI's
+non-interactive resume surface [ORB-10780]. Other providers (for example Codex's
+[CLI resume](https://developers.openai.com/codex/cli/reference)) keep their own argv; that
+shape is a provider adapter detail rather than an Orbit task invariant. A resume failure falls
+back to a new conversation after recording the failure; the unanswered or answered decision
+remains durable in Orbit either way.
 
 ### 5.3 Crash and restart behavior
 
@@ -418,6 +419,7 @@ newer durable task constraint.
 ## Task References
 
 - **[ORB-10332]** — Removed the unused HTTP epic pipeline assets that this design supersedes.
-- Further implementation tasks will be allocated after this Draft is accepted.
+- **[ORB-10775]** — Implementation epic (children ORB-10776–ORB-10782).
+- **[ADR-0361]** — The `epic` tag is the sole resident pickup selector.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/resident-orchestrator/2_design.md
+++ b/docs/design/resident-orchestrator/2_design.md
@@ -6,11 +6,11 @@ status: Accepted
 feature: resident-orchestrator
 doc_role: design
 type: design
-summary: epic_pipeline loops a deterministic unresolved-work scan and a full-MCP orchestrator activity until the scan is empty. The fire clock is external.
-tags: [resident-orchestrator, epic, jobs, mcp]
+summary: epic_pipeline loops a deterministic unresolved-work scan and a no-code-change orchestrator (create/ship/log) until the scan is empty. Session log is the memory between fires.
+tags: [resident-orchestrator, epic, jobs, session-log]
 paths: [".orbit/resources/jobs/**", "crates/orbit-core/assets/jobs/**", "crates/orbit-core/assets/activities/**"]
 related_features: [resident-orchestrator, activity-job]
-related_artifacts: [ORB-10332, ORB-10775, ORB-10776, ORB-10779, ADR-0361, ADR-0362]
+related_artifacts: [ORB-10332, ORB-10775, ORB-10776, ORB-10779, ADR-0361, ADR-0362, ADR-0363]
 ---
 
 # Resident Orchestrator — Design
@@ -26,7 +26,8 @@ routine, conversation resume, or a comment-typed decision protocol.
 It includes:
 
 - every task with status `proposed`, `backlog`, or `blocked`;
-- every job-run whose state is `failed` or `timeout`.
+- every job-run whose state is `failed` or `timeout`;
+- every unresolved session-log entry with `kind: check_later` (ADR-0363).
 
 It excludes:
 
@@ -35,8 +36,9 @@ It excludes:
 - `cancelled` job-runs (operator-intentional);
 - runs still `pending` / `running` / `retrying`.
 
-Output is a structured object: `task_ids`, `run_ids`, counts, and a boolean `empty`.
-No task or run is mutated. An empty scan is success, not an error.
+Output is a structured object: `task_ids`, `run_ids`, `check_later_ids`, counts, and a
+boolean `empty`. No task, run, or log row is mutated. An empty scan is success, not an
+error.
 
 The scan is the only admission function. The job does not select by `epic` tag, assignee,
 or priority. Those filters belong to the external supervisor if it wants them (it can
@@ -46,20 +48,22 @@ decline to fire the job).
 
 `epic_orchestrator` is an `agent_loop` / `backend: cli` activity.
 
-- **Tools:** the full Orbit MCP/CLI tool catalog for that workspace (task lifecycle,
-  workflow run inspect/resume/ship, search). It is not a leaf `agent_implement` allowlist
-  and it is not a new tool surface.
-- **Mandate:** shrink the scan set. Typical moves: promote or reject `proposed`, re-dispatch
-  or re-block with a precise reason, create children and `workflow_ship` explicit ids,
-  `workflow_run_resume` a failed run whose cause is fixed, cancel a run that should stay
-  dead and move the coupled task out of `blocked`.
-- **Must not:** merge PRs reserved for Daniel; edit a second workspace; treat silence as
-  new product authority.
-- **Bound:** a wall-clock timeout on the activity (suggested 2 hours). The *job* is what
-  retries the scan after the process exits. The agent is instructed to drain, but the
-  scan after return is authoritative.
+- **Tools (allowlist):** `orbit.task.*` (add/update/show/list — not a license to edit
+  files), workflow run inspect / resume / ship, `orbit.search`, `orbit.session_log.*`.
+- **Not on the allowlist:** git write, worktree edit, `agent_implement`, `fs` writes
+  into the repository, PR merge. A child pipeline makes the code change. If the
+  orchestrator needs a patch, it files a task and ships it.
+- **Mandate:** shrink the scan set. Typical moves: create children, `workflow_ship`
+  explicit ids, promote or reject `proposed`, resume or cancel a failed run, append
+  session-log status, file or resolve `check_later` notes.
+- **Must not:** merge PRs reserved for Daniel; edit a second workspace; treat silence
+  as new product authority; "just fix the file."
+- **Bound:** a wall-clock timeout on the activity (suggested 2 hours). The *job*
+  re-scans after the process exits. The agent is instructed to drain; the scan after
+  return is authoritative.
 
-Conversation resume across fires is out of v1. Each invoke starts fresh from Orbit state.
+Conversation resume across fires is out of v1. Each invoke starts fresh from Orbit
+state plus `orbit.session_log.list`.
 
 ## 3. `epic_pipeline` job
 
@@ -84,7 +88,43 @@ Input is workspace-scoped (the runtime workspace). No `epic_id` is required. A s
 that wants to drain one epic only does so by not leaving other tasks in the scanned
 statuses, or by running in a workspace that only holds that work.
 
-## 4. External clock (not an Orbit routine)
+## 4. Session log
+
+The orchestrator has no retained CLI conversation. It needs a notebook that survives a
+fresh invoke: status of the last fire, notes to self, and "check this later."
+
+That is `orbit.session_log`, a **workspace-scoped, append-only** store. It is not a
+task, not a comment thread, and not a knowledgebase markdown file (the drain runs in
+the *target* workspace; the cron repo is the wrong disk).
+
+Each entry:
+
+| Field | Rule |
+|---|---|
+| `id` | allocated, stable |
+| `at` | timestamp |
+| `kind` | `status` \| `note` \| `check_later` |
+| `body` | markdown |
+| `related_task_ids` / `related_run_ids` | optional |
+| `resolved_at` | set only on `check_later` via `resolve` |
+
+Tools:
+
+- `orbit.session_log.append`
+- `orbit.session_log.list` (filters: `kind`, `unresolved_only`, `since`)
+- `orbit.session_log.resolve` (`check_later` id)
+
+`status` and `note` never wake the scan. Unresolved `check_later` **does** — that is
+how "remind me" works without session resume. Resolving a check-later is how the
+orchestrator tells the next scan the reminder is done.
+
+Rejected shapes: stuffing JSON into task comments (rejected with ORB-10778); a standing
+`backlog` "log task" (it would wake the drain forever); a file in the knowledgebase
+cron repo (wrong workspace).
+
+Do not rewrite history. Append or resolve; never edit a body in place.
+
+## 5. External clock (not an Orbit routine)
 
 v1 does not seed `resident-epic-orbit` or any other routine. A knowledgebase checkout
 (or the front-door orchestrator) fires:
@@ -96,11 +136,12 @@ orbit run job epic_pipeline
 via MCP or CLI, on a cron it owns. That process may also create `epic`-tagged roots,
 author children, and answer humans. None of that is a catalog asset in this repo.
 
-## 5. Authority and completion
+## 6. Authority and completion
 
 Daniel's merge authority is unchanged. `review` is not a wake reason: a task waiting on
 human merge must not keep the drain loop alive by itself. If the only leftovers are
-`review` + healthy runs, the scan is empty and the job succeeds.
+`review` + healthy runs and no unresolved `check_later` notes, the scan is empty and
+the job succeeds.
 
 A failed child pipeline that flipped its task to `blocked` *is* a wake reason (status
 `blocked` and/or run `failed`). The orchestrator is expected to diagnose and either
@@ -108,7 +149,7 @@ resume, recast the task, or leave a precise block reason and — if it cannot pr
 exit so the next scan still sees the item and the job fails at the ceiling rather than
 lying.
 
-## 6. Concerns & Honest Limitations
+## 7. Concerns & Honest Limitations
 
 - **Workspace-wide drain.** One `blocked` chore anywhere wakes the orchestrator for the
   whole workspace. Supervisors that want isolation should use separate workspaces or
@@ -116,10 +157,11 @@ lying.
 - **`proposed` is in the scan.** That is a deliberate reversal of the first draft (which
   refused proposed pickup). The orchestrator may triage; it still must not invent
   approval policy.
-- **No conversation continuity.** Every fire re-reads Orbit. Cheap if the scan is empty;
-  expensive if the cron is aggressive and the set is large.
-- **Full MCP is trusted.** This activity is a workspace-admin loop, not a sandboxed leaf.
-  The external clock is part of the security boundary.
+- **No conversation continuity.** Every fire re-reads Orbit and the session log. Cheap
+  if the scan is empty; expensive if the cron is aggressive and the set is large.
+- **Allowlist is trusted but narrow.** The orchestrator can create and ship work; it
+  cannot patch the tree. A wedged child that "only needs a one-line fix" stays wedged
+  until a shipped child lands. That is the point.
 - **Ceilings can fail a job with work left.** That is correct. The next cron fire tries
   again. Do not weaken the post-loop scan.
 
@@ -129,5 +171,6 @@ lying.
 - **[ORB-10775]** — Implementation epic.
 - **[ORB-10776]** — This contract and ADRs.
 - **[ORB-10779]** — Scan, orchestrator activity, `epic_pipeline`.
+- **[ORB-10784]** — `orbit.session_log`.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/resident-orchestrator/3_vision.md
+++ b/docs/design/resident-orchestrator/3_vision.md
@@ -6,90 +6,53 @@ status: Accepted
 feature: resident-orchestrator
 doc_role: vision
 type: design
-summary: Forward-looking questions for multi-resident routing, event-driven wakeups, and cross-workspace epic observability.
-tags: [resident-orchestrator, epic, routines, cli]
-paths: [".orbit/resources/activities/**", ".orbit/resources/jobs/**", ".orbit/routines/**"]
-related_features: [resident-orchestrator, routines, host-registry, mcp-bridge]
-related_artifacts: [ORB-10775, ADR-0361]
+summary: After the drain job exists, later work may add an Orbit-owned clock, epic-scoped scans, or conversation resume — none of that is v1.
+tags: [resident-orchestrator, epic, jobs]
+paths: [".orbit/resources/jobs/**"]
+related_features: [resident-orchestrator, routines]
+related_artifacts: [ORB-10775, ADR-0362]
 ---
 
 # Resident Orchestrator — Vision
 
-This document records directions that are intentionally outside the first CLI-backed resident
-cycle. The first release should prove that one workspace, one resident, one active epic, and
-durable task state are sufficient before adding routing or coordination machinery.
+V1 proves that a scan-and-drain job plus an external clock is enough. The items below stay
+out of [ORB-10775].
 
 ## 1. Open Questions
 
-1. **Should pickup become event-driven?** Routines v1 deliberately use an OS clock and have no
-   event triggers. A future task-created event could reduce latency, but it would introduce a
-   resident process, webhook, or durable event consumer that the first design avoids.
-2. **Can one workspace support several residents?** Multiple specialists would require an explicit
-   routing key, capability declaration, and lease/claim semantics. Workspace plus `epic` is only
-   unambiguous while ownership is singular.
-3. **How should cross-workspace outcomes roll up?** A product epic spanning several repositories may
-   need a top-level constellation task that relates workspace-local epics without pretending their
-   local `parent_id` trees share one store.
-4. **Should resident health become first-class?** Operators may eventually need last successful
-   cycle, current epic, stalled duration, and identity/config mismatch surfaced alongside routine
-   health.
-5. **What is the right checkpoint artifact?** Parent comments are sufficient for v1. A structured
-   resident-cycle artifact could improve dashboards and replay, but risks duplicating task and run
-   state.
-6. **Should identity be promoted beyond an activity asset?** If many products need resident agents,
-   a typed resident profile may become worthwhile. It should be justified by repeated configuration
-   drift, not introduced before the activity-based canary.
-7. **Should residents pick up proposed epics?** V1 requires an upstream authority to move an epic
-   to `backlog`; it deliberately has no implicit proposed-work authority. A future version could
-   add an explicit policy block to the routine or workspace configuration, but only once its
-   approval provenance and operator visibility are defined.
+1. **Should Orbit grow a routine that fires `epic_pipeline`?** Only after the job is
+   boring in production. A seeded routine is how this becomes a resident server by
+   accident.
+2. **Should the scan be epic-scoped?** A `parent_id` / `epic` tag filter would let one
+   workspace hold several bodies of work. That needs a selector policy the first draft
+   tried to invent inside Orbit; keep it in the supervisor until the drain job is real.
+3. **Conversation resume?** Useful once drains are long and frequent. Not a correctness
+   dependency; fail-open to a fresh invoke.
+4. **Event-driven wake?** A task-created or run-failed hook would cut cron latency. Routines
+   v1 have no event trigger; do not add one for this feature.
+5. **Multiple orchestrator identities per workspace?** Requires a routing key. Tags alone
+   are not enough.
 
 ## 2. Prior Work
 
-### Orbit routines and jobs
-
-Routines already establish the desired scheduler boundary: the OS owns the clock, Orbit performs a
-stateless sweep, and a versioned routine targets a catalog job. Activity / Job provides CLI agent
-invocation and deterministic control flow. Resident orchestration composes those primitives rather
-than adding another scheduler.
-
-### Actor and queue systems
-
-Actor mailboxes and work queues demonstrate that an address plus a durable message can decouple
-senders from owners. The resident design borrows that separation but keeps the address at workspace
-granularity and the message as an ordinary Orbit task, avoiding another queue schema.
-
-### Hierarchical planning agents
-
-Planner/executor systems commonly decompose goals into leaf work. Orbit's distinction is intended
-to be operational rather than algorithmic: decomposition becomes parent/child tasks and
-dependencies, while shipment, review, and merge remain independently auditable workflows.
+The first draft of this folder specified an in-Orbit resident (CLI session, decision
+comments, `select_resident_epic`, seeded routine). Polar is `orchestrator/reconciler.md`
+already argued the opposite: a stateless tick over Orbit + runs, no second store. V1 takes
+the tick (the scan + loop) and leaves the clock outside.
 
 ## 3. What May Be Distinctive
 
-The individual ingredients are conventional. The potentially useful combination is that agent
-delegation, durable ownership, decomposition, and delivery evidence all reuse the repository's
-existing task and workflow model. The resident has a durable home and a specialized identity, but
-there is still no resident agent server. A CLI process can disappear after every cycle without
-losing the meaning or current state of the assignment.
+The drain predicate is boring on purpose: three task statuses and two run states. The
+orchestrator is a normal CLI agent with tools it already has. The only new contract is
+that the job, not the model, decides whether work remains.
 
 ## 4. References
 
-**Orbit-internal**
-
-- [Resident Orchestrator design](./2_design.md)
-- [Activity / Job overview](../activity-job/1_overview.md)
-- [Routines design](../routines/2_design.md)
-- [Host Registry design](../host-registry/2_design.md)
-- [MCP Bridge design](../mcp-bridge/2_design.md)
-
-**External**
-
-- [The Actor Model](https://www.microsoft.com/en-us/research/publication/actors-a-model-of-concurrent-computation-in-distributed-systems/)
-- [Temporal durable execution](https://docs.temporal.io/temporal)
+- [Design](./2_design.md)
+- Polar is `design/orchestrator/reconciler.md` (constellation tree; not an Orbit ADR)
 
 ## Task References
 
-- **[ORB-10775]** — v1 implementation epic. Items in §1 stay out of that epic.
+- **[ORB-10775]** — v1 epic. Items in §1 stay out.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/resident-orchestrator/3_vision.md
+++ b/docs/design/resident-orchestrator/3_vision.md
@@ -26,8 +26,8 @@ out of [ORB-10775].
 2. **Should the scan be epic-scoped?** A `parent_id` / `epic` tag filter would let one
    workspace hold several bodies of work. That needs a selector policy the first draft
    tried to invent inside Orbit; keep it in the supervisor until the drain job is real.
-3. **Conversation resume?** Useful once drains are long and frequent. Not a correctness
-   dependency; fail-open to a fresh invoke.
+3. **Conversation resume?** Session log is v1 memory. Resume is still allowed later as
+   a fail-open optimization, never as the notebook.
 4. **Event-driven wake?** A task-created or run-failed hook would cut cron latency. Routines
    v1 have no event trigger; do not add one for this feature.
 5. **Multiple orchestrator identities per workspace?** Requires a routing key. Tags alone

--- a/docs/design/resident-orchestrator/3_vision.md
+++ b/docs/design/resident-orchestrator/3_vision.md
@@ -1,8 +1,8 @@
 ---
 title: Resident Orchestrator — Vision
-owner: codex
-last_updated: 2026-07-18
-status: Draft
+owner: grok
+last_updated: 2026-08-14
+status: Accepted
 feature: resident-orchestrator
 doc_role: vision
 type: design
@@ -10,7 +10,7 @@ summary: Forward-looking questions for multi-resident routing, event-driven wake
 tags: [resident-orchestrator, epic, routines, cli]
 paths: [".orbit/resources/activities/**", ".orbit/resources/jobs/**", ".orbit/routines/**"]
 related_features: [resident-orchestrator, routines, host-registry, mcp-bridge]
-related_artifacts: []
+related_artifacts: [ORB-10775, ADR-0361]
 ---
 
 # Resident Orchestrator — Vision
@@ -90,6 +90,6 @@ losing the meaning or current state of the assignment.
 
 ## Task References
 
-- None yet — implementation tasks will be allocated after this Draft is accepted.
+- **[ORB-10775]** — v1 implementation epic. Items in §1 stay out of that epic.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/resident-orchestrator/4_decisions.md
+++ b/docs/design/resident-orchestrator/4_decisions.md
@@ -11,7 +11,7 @@ summary: ADR log for the drain job and the rule that the supervisor clock is not
 tags: [resident-orchestrator, epic, jobs]
 paths: [".orbit/resources/jobs/**", "crates/orbit-core/assets/jobs/**"]
 related_features: [resident-orchestrator, activity-job]
-related_artifacts: [ORB-10332, ORB-10775, ORB-10776, ADR-0361, ADR-0362]
+related_artifacts: [ORB-10332, ORB-10775, ORB-10776, ADR-0361, ADR-0362, ADR-0363]
 ---
 
 # Resident Orchestrator — Decisions
@@ -67,6 +67,31 @@ front-door) process that calls `orbit run job epic_pipeline`.
   `.orbit/routines/`.
 - Cost: no first-class resident health in `orbit routine list`; operators debug the
   external cron and the job-run log instead.
+
+## ADR-0363 — Session log is the orchestrator's memory, not a CLI session
+
+**Status:** Accepted · 2026-08 · [ORB-10776]
+**Scope:** how `epic_orchestrator` remembers work across invokes; scan wake reasons
+
+### Context
+
+Each drain fire is a new CLI process. Conversation resume is out of v1. The orchestrator
+still needs to leave itself status, notes, and "check this later," and to see new notes
+on the next fire. Task comments are a human thread. A standing `backlog` log task would
+wake the scan forever. A file in the knowledgebase cron repo is the wrong workspace.
+
+### Decision
+
+Give the workspace an append-only `orbit.session_log` with kinds `status`, `note`, and
+`check_later`. Unresolved `check_later` entries are a `scan_unresolved_work` wake reason.
+`status`/`note` are not. Resolve is the only mutation besides append. The orchestrator
+does not edit repository files; code changes are child tasks it creates and ships.
+
+### Consequences
+
+- Next fire starts with `session_log.list` + the task/run scan, not a provider session id.
+- Cost: another noun and three tools. Reminders the orchestrator forgets to `resolve`
+  will keep waking the drain until someone does.
 
 ## Task References
 

--- a/docs/design/resident-orchestrator/4_decisions.md
+++ b/docs/design/resident-orchestrator/4_decisions.md
@@ -1,8 +1,9 @@
 ---
 title: Resident Orchestrator — Decisions
-owner: codex
-last_updated: 2026-07-20
-status: Draft
+owner: grok
+last_updated: 2026-08-14
+last_validated: 2026-08-14
+status: Accepted
 feature: resident-orchestrator
 doc_role: decisions
 type: design
@@ -10,37 +11,51 @@ summary: ADR log for workspace-addressed epic delegation and CLI-backed resident
 tags: [resident-orchestrator, epic, routines, cli]
 paths: [".orbit/resources/activities/**", ".orbit/resources/jobs/**", ".orbit/routines/**"]
 related_features: [resident-orchestrator, activity-job, routines]
-related_artifacts: [ORB-10332]
+related_artifacts: [ORB-10332, ORB-10775, ORB-10776, ADR-0361]
 ---
 
 # Resident Orchestrator — Decisions
 
-ADR log for Resident Orchestrator. Entries are append-only and ordered by ascending global ID.
-Allocate every `ADR-NNNN` through `orbit.adr.add` before adding its heading. The store remains the
-source of truth for status, owner, related features, and related tasks.
+Decision record for resident-orchestrator, in ascending number order. This file is the
+authoritative body — there is no ADR store behind it. Numbering is repo-local:
+take the next unused number with `grep -rho 'ADR-[0-9]\{4\}' docs/ | sort -u | tail -1`.
 
-This folder is still Draft and has no allocated ADR. The candidate choices described in
-[2_design.md](./2_design.md)—workspace-addressed `epic` tasks, bounded CLI ownership cycles, and
-replacement rather than conversion of the HTTP epic pipeline—remain proposals until the design is
-accepted and implementation tasks are allocated. The HTTP epic pipeline this design supersedes was
-itself removed as unused in [ORB-10332].
+An entry is admitted through exactly one of two doors: it explains a specific
+code site that would otherwise look wrong (Door 1, carries `code_anchors:`), or
+it states a standing rule that decides future tradeoffs (Door 2, carries
+`scope:`). Everything else is design prose and belongs in `2_design.md`. See
+[CONVENTIONS.md §4](../CONVENTIONS.md#4-adrs-strict).
 
-## Candidate Decision: Epic Marker and Legacy Coexistence
+## ADR-0361 — Epic tag is the sole resident pickup selector
 
-**Proposal.** Resident orchestration selects root tasks by the `epic` tag rather than changing or
-depending on `TaskType`. The former `task_epic_pipeline` identified epics by `TaskType::Feature`;
-[ORB-10332] removed that pipeline, so the `epic` tag is now the sole epic selector.
+**Status:** Accepted · 2026-08 · [ORB-10776]
+**Scope:** resident epic selection and pickup (`select_resident_epic` and any successor)
 
-**Coexistence rule (obsolete).** The original proposal kept the two paths disjoint by workspace
-capability during a staged retirement. With the legacy pipeline removed in [ORB-10332], there is no
-second claimant to exclude, so this rule no longer applies.
+### Context
 
-**Why this proposal.** A tag is an explicit delegation signal that does not overload the broad
-`feature` type. This remains a candidate decision, not an allocated ADR.
+The former `task_epic_pipeline` treated a root `TaskType::Feature` as an epic. That pipeline
+was removed as unused in [ORB-10332]. A resident still needs an explicit delegation signal
+that does not overload the broad `feature` type, and that future pickup code will not
+reintroduce a second selector "just this once."
+
+### Decision
+
+Resident orchestration selects only root tasks tagged `epic`. The tag is a pickup
+boundary, not a new task type and not a change to `TaskType`. Child work is recognized
+by `parent_id`. `proposed` epics are never selected in v1.
+
+### Consequences
+
+- Creating a root `epic` in a workspace is the act of delegation.
+- A later impulse to key pickup on `type: feature`, assignee, or folder path is out of
+  contract unless this ADR is superseded.
+- Cost: an untagged large feature is invisible to the resident even if a human thinks of
+  it as an epic; pickup cannot be inferred from type or title.
 
 ## Task References
 
 - **[ORB-10332]** — Remove the unused HTTP epic pipeline (`task_epic_pipeline`, `epic_orchestrator`).
-- Further implementation tasks will be allocated after this Draft is accepted.
+- **[ORB-10775]** — v1 implementation epic.
+- **[ORB-10776]** — Accept this folder and record ADR-0361.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/resident-orchestrator/4_decisions.md
+++ b/docs/design/resident-orchestrator/4_decisions.md
@@ -7,55 +7,71 @@ status: Accepted
 feature: resident-orchestrator
 doc_role: decisions
 type: design
-summary: ADR log for workspace-addressed epic delegation and CLI-backed resident orchestration.
-tags: [resident-orchestrator, epic, routines, cli]
-paths: [".orbit/resources/activities/**", ".orbit/resources/jobs/**", ".orbit/routines/**"]
-related_features: [resident-orchestrator, activity-job, routines]
-related_artifacts: [ORB-10332, ORB-10775, ORB-10776, ADR-0361]
+summary: ADR log for the drain job and the rule that the supervisor clock is not an Orbit primitive.
+tags: [resident-orchestrator, epic, jobs]
+paths: [".orbit/resources/jobs/**", "crates/orbit-core/assets/jobs/**"]
+related_features: [resident-orchestrator, activity-job]
+related_artifacts: [ORB-10332, ORB-10775, ORB-10776, ADR-0361, ADR-0362]
 ---
 
 # Resident Orchestrator — Decisions
 
-Decision record for resident-orchestrator, in ascending number order. This file is the
-authoritative body — there is no ADR store behind it. Numbering is repo-local:
-take the next unused number with `grep -rho 'ADR-[0-9]\{4\}' docs/ | sort -u | tail -1`.
+Decision record for resident-orchestrator. This file is the authoritative body.
 
-An entry is admitted through exactly one of two doors: it explains a specific
-code site that would otherwise look wrong (Door 1, carries `code_anchors:`), or
-it states a standing rule that decides future tradeoffs (Door 2, carries
-`scope:`). Everything else is design prose and belongs in `2_design.md`. See
-[CONVENTIONS.md §4](../CONVENTIONS.md#4-adrs-strict).
-
-## ADR-0361 — Epic tag is the sole resident pickup selector
+## ADR-0361 — Epic tag is a supervisor delegation signal, not the job predicate
 
 **Status:** Accepted · 2026-08 · [ORB-10776]
-**Scope:** resident epic selection and pickup (`select_resident_epic` and any successor)
+**Scope:** how a body of work is marked for a supervisor; not `epic_pipeline` admission
 
 ### Context
 
-The former `task_epic_pipeline` treated a root `TaskType::Feature` as an epic. That pipeline
-was removed as unused in [ORB-10332]. A resident still needs an explicit delegation signal
-that does not overload the broad `feature` type, and that future pickup code will not
-reintroduce a second selector "just this once."
+The removed `task_epic_pipeline` treated `TaskType::Feature` as an epic. A later draft made
+the `epic` tag the *job's* pickup selector. The v1 job instead wakes on
+`proposed`/`backlog`/`blocked` plus failed/timeout runs, or it would miss ordinary chores
+and failed pipelines that are not tagged.
 
 ### Decision
 
-Resident orchestration selects only root tasks tagged `epic`. The tag is a pickup
-boundary, not a new task type and not a change to `TaskType`. Child work is recognized
-by `parent_id`. `proposed` epics are never selected in v1.
+`epic` on a root task means "a supervisor owns this outcome." Catalog code must not require
+the tag to drain work. Adding a second pickup key (`type: feature`, assignee, folder) for
+the *job* is out of contract unless this ADR is superseded.
 
 ### Consequences
 
-- Creating a root `epic` in a workspace is the act of delegation.
-- A later impulse to key pickup on `type: feature`, assignee, or folder path is out of
-  contract unless this ADR is superseded.
-- Cost: an untagged large feature is invisible to the resident even if a human thinks of
-  it as an epic; pickup cannot be inferred from type or title.
+- Supervisors can still create `epic` roots and children as they do today (ORB-10775).
+- Cost: a workspace with leftover `backlog` chores will wake the drain job even when no
+  epic exists; isolation is a workspace-layout problem, not a tag filter.
+
+## ADR-0362 — The supervisor clock is not an Orbit primitive
+
+**Status:** Accepted · 2026-08 · [ORB-10776]
+**Scope:** routines, activities, and jobs that would schedule or select work for `epic_pipeline`
+
+### Context
+
+The first draft specified `resident_orchestrator`, `select_resident_epic`, a JSON comment
+protocol, conversation resume, and a seeded `resident-epic-orbit` routine. That rebuilds
+an orchestrator inside Orbit next to Cowork / Grok / a knowledgebase cron that already
+speak MCP.
+
+### Decision
+
+Orbit v1 ships only `scan_unresolved_work`, `epic_orchestrator`, and `epic_pipeline`.
+Do not add an Orbit routine, selector activity, session-resume requirement, or
+comment-typed mailbox for this feature. The fire clock lives in a knowledgebase (or
+front-door) process that calls `orbit run job epic_pipeline`.
+
+### Consequences
+
+- A future "make it a routine" PR needs to supersede this ADR, not sneak a YAML into
+  `.orbit/routines/`.
+- Cost: no first-class resident health in `orbit routine list`; operators debug the
+  external cron and the job-run log instead.
 
 ## Task References
 
-- **[ORB-10332]** — Remove the unused HTTP epic pipeline (`task_epic_pipeline`, `epic_orchestrator`).
+- **[ORB-10332]** — Remove the unused HTTP epic pipeline.
 - **[ORB-10775]** — v1 implementation epic.
-- **[ORB-10776]** — Accept this folder and record ADR-0361.
+- **[ORB-10776]** — Record this split.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task
ORB-10776 (child of epic ORB-10775)

## Execution Summary
Accept the resident-orchestrator design folder and record Grok as feature lead.

- `owner: grok`, `status: Accepted` on all four numbered docs
- ADR-0361: the `epic` tag is the sole resident pickup selector
- First canary is `ws_orbit` + crew `grok` (not Hohmann/Codex Sol)
- Task references cite ORB-10775–ORB-10782

## Validation
Docs-only. No catalog or runtime change. Folder-local `rg` for leftover Draft/codex owner and retired `orbit.adr.add` language.

## Branch Freshness
Branched from current `origin/agent-main` (17c4da5a).