### PR TITLE
One workspace selector grammar across CLI and MCP

### DIFF
--- a/crates/orbit-cli/src/audit_middleware.rs
+++ b/crates/orbit-cli/src/audit_middleware.rs
@@ -105,7 +105,10 @@ impl Drop for AuditGuard<'_> {
             host: std::env::var("HOSTNAME").ok(),
             pid: std::process::id(),
             session_id: None,
-            workspace_id: None,
+            workspace_id: self
+                .runtime
+                .workspace_runtime_binding()
+                .map(|binding| binding.workspace_id.clone()),
             caller_machine_id: None,
             caller_host_id: None,
             process_machine_id: None,

--- a/crates/orbit-cli/src/command/mod.rs
+++ b/crates/orbit-cli/src/command/mod.rs
@@ -121,6 +121,12 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub root: Option<PathBuf>,
 
+    /// Select a workspace by registered name, logical ID (`ws_*`), or absolute
+    /// checkout path. Distinct from `--root`, which overrides the Orbit data
+    /// directory.
+    #[arg(long, value_name = "SELECTOR")]
+    pub workspace: Option<String>,
+
     #[command(subcommand)]
     pub command: Commands,
 }

--- a/crates/orbit-cli/src/command/tests/mod.rs
+++ b/crates/orbit-cli/src/command/tests/mod.rs
@@ -33,6 +33,49 @@ fn assert_cli_rejects(args: &[&str], kind: ErrorKind, expected: &str) {
 }
 
 #[test]
+fn cli_help_advertises_workspace_selector_distinct_from_root() {
+    let help = match Cli::try_parse_from(["orbit", "--help"]) {
+        Ok(_) => panic!("--help exits before parsing"),
+        Err(error) => error.to_string(),
+    };
+    assert!(
+        help.contains("--workspace <SELECTOR>"),
+        "orbit --help must show a global --workspace selector: {help}"
+    );
+    assert!(
+        help.contains("--root <ROOT>"),
+        "orbit --help must keep --root as a data-dir override: {help}"
+    );
+    assert!(
+        help.contains("logical ID") || help.contains("ws_*"),
+        "orbit --help must describe the shared selector grammar: {help}"
+    );
+    assert!(
+        !help.contains("--root <SELECTOR>"),
+        "--root must not become a workspace selector: {help}"
+    );
+}
+
+#[test]
+fn cli_parses_top_level_workspace_selector_before_subcommand() {
+    let cli = Cli::parse_from([
+        "orbit",
+        "--workspace",
+        "orbit",
+        "task",
+        "list",
+        "--limit",
+        "1",
+    ]);
+    assert_eq!(cli.workspace.as_deref(), Some("orbit"));
+    assert!(cli.root.is_none());
+    match cli.command {
+        Commands::Task(_) => {}
+        _ => panic!("expected task command"),
+    }
+}
+
+#[test]
 fn cli_parses_doctor_stale_lock_cleanup() {
     let cli = Cli::parse_from([
         "orbit",

--- a/crates/orbit-cli/src/main.rs
+++ b/crates/orbit-cli/src/main.rs
@@ -24,7 +24,8 @@
 //!
 //! # Key responsibilities
 //! - Parse the top-level CLI surface and route subcommands to their handlers
-//! - Bootstrap the runtime, including optional `--root` overrides for worktrees
+//! - Bootstrap the runtime, including optional `--root` data-dir overrides and
+//!   `--workspace` selectors (registered name, logical id, or checkout path)
 //! - Emit machine-readable JSON or human-readable table output
 //! - Wrap command execution in audit logging so human and agent actions are recorded
 //!
@@ -179,6 +180,7 @@ fn main() {
         "resolved output sink"
     );
     let root_override = cli.root.clone();
+    let workspace_selector = cli.workspace.clone();
     let actor = ActorIdentity::from_env();
     let CommandOperation {
         runtime_need,
@@ -205,18 +207,20 @@ fn main() {
         return;
     }
 
-    let runtime =
-        match RemoteRuntimeFactory::initialize_with_root_override(root_override.as_deref()) {
-            Ok(runtime) => runtime,
-            Err(err) => {
-                if suppress_errors {
-                    return;
-                }
-                print_error(&err, &sink, json_error_preference);
-                std::process::exit(1);
+    let runtime = match RemoteRuntimeFactory::initialize_with_overrides(
+        root_override.as_deref(),
+        workspace_selector.as_deref(),
+    ) {
+        Ok(runtime) => runtime,
+        Err(err) => {
+            if suppress_errors {
+                return;
             }
+            print_error(&err, &sink, json_error_preference);
+            std::process::exit(1);
         }
-        .with_actor(actor);
+    }
+    .with_actor(actor);
 
     let context = DispatchContext::with_runtime(&runtime, root_override.as_deref());
     // ORB-10453: the CLI's single authorization chokepoint. Every command

--- a/crates/orbit-cli/tests/workspace_selector.rs
+++ b/crates/orbit-cli/tests/workspace_selector.rs
@@ -1,0 +1,235 @@
+#![allow(missing_docs)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::fs;
+use std::path::Path;
+use std::process::Command as StdCommand;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
+use tempfile::tempdir;
+
+#[test]
+fn global_workspace_flag_selects_by_name_and_id_from_a_foreign_checkout() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let orbit_repo = temp.path().join("orbit");
+    let other_repo = temp.path().join("other");
+    let elsewhere = temp.path().join("elsewhere");
+    fs::create_dir_all(&home).expect("home");
+    fs::create_dir_all(&elsewhere).expect("elsewhere");
+
+    init_git_repo(&orbit_repo);
+    init_git_repo(&other_repo);
+
+    run_orbit(
+        &orbit_repo,
+        &home,
+        &[
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "selector-host",
+            "--task-prefix",
+            "SEL",
+        ],
+    )
+    .success();
+    run_orbit(
+        &orbit_repo,
+        &home,
+        &["workspace", "init", "--name", "orbit"],
+    )
+    .success();
+    run_orbit(
+        &other_repo,
+        &home,
+        &["workspace", "init", "--name", "other"],
+    )
+    .success();
+
+    let created = run_orbit_json(
+        &orbit_repo,
+        &home,
+        &[
+            "task",
+            "add",
+            "--title",
+            "Orbit-only task",
+            "--description",
+            "Must stay in the orbit workspace",
+            "--json",
+        ],
+    );
+    let orbit_task_id = created["id"].as_str().expect("created id").to_string();
+
+    let by_name = run_orbit_json(
+        &elsewhere,
+        &home,
+        &[
+            "--workspace",
+            "orbit",
+            "task",
+            "list",
+            "--limit",
+            "10",
+            "--json",
+        ],
+    );
+    assert!(
+        task_ids(&by_name).contains(&orbit_task_id),
+        "name selector from a foreign cwd must list orbit tasks: {by_name}"
+    );
+
+    let by_id = run_orbit_json(
+        &elsewhere,
+        &home,
+        &[
+            "--workspace",
+            "ws_orbit",
+            "task",
+            "list",
+            "--limit",
+            "10",
+            "--json",
+        ],
+    );
+    assert!(
+        task_ids(&by_id).contains(&orbit_task_id),
+        "logical id selector from a foreign cwd must list orbit tasks: {by_id}"
+    );
+
+    let by_path = run_orbit_json(
+        &elsewhere,
+        &home,
+        &[
+            "--workspace",
+            orbit_repo.to_str().expect("utf8"),
+            "task",
+            "list",
+            "--limit",
+            "10",
+            "--json",
+        ],
+    );
+    assert!(
+        task_ids(&by_path).contains(&orbit_task_id),
+        "absolute checkout path must list orbit tasks: {by_path}"
+    );
+
+    let other_cwd = run_orbit_json(
+        &other_repo,
+        &home,
+        &["task", "list", "--limit", "10", "--json"],
+    );
+    assert!(
+        !task_ids(&other_cwd).contains(&orbit_task_id),
+        "cwd discovery without --workspace must keep binding the other checkout: {other_cwd}"
+    );
+}
+
+#[test]
+fn global_workspace_flag_fails_closed_on_unknown_selector() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let repo = temp.path().join("repo");
+    fs::create_dir_all(&home).expect("home");
+    init_git_repo(&repo);
+    run_orbit(
+        &repo,
+        &home,
+        &[
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "selector-host",
+            "--task-prefix",
+            "SEL",
+        ],
+    )
+    .success();
+    run_orbit(&repo, &home, &["workspace", "init", "--name", "orbit"]).success();
+
+    let assert = run_orbit(
+        &repo,
+        &home,
+        &[
+            "--workspace",
+            "no-such-workspace",
+            "task",
+            "list",
+            "--limit",
+            "1",
+        ],
+    )
+    .failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("no-such-workspace"),
+        "unknown selector must be named: {stderr}"
+    );
+}
+
+fn task_ids(value: &Value) -> Vec<String> {
+    let items = value
+        .as_array()
+        .cloned()
+        .or_else(|| value.get("tasks").and_then(Value::as_array).cloned())
+        .unwrap_or_default();
+    items
+        .iter()
+        .filter_map(|task| {
+            task.get("id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+        .collect()
+}
+
+fn run_orbit(cwd: &Path, home: &Path, args: &[&str]) -> assert_cmd::assert::Assert {
+    let mut command = cargo_bin_cmd!("orbit");
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env_remove("ORBIT_ROOT")
+        .env_remove("ORBIT_AGENT_NAME")
+        .env_remove("ORBIT_AGENT_MODEL")
+        .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
+        .env_remove("ORBIT_RUN_ID")
+        .args(args);
+    command.assert()
+}
+
+fn run_orbit_json(cwd: &Path, home: &Path, args: &[&str]) -> Value {
+    let assert = run_orbit(cwd, home, args).success();
+    serde_json::from_slice(&assert.get_output().stdout).expect("orbit json output")
+}
+
+fn init_git_repo(repo: &Path) {
+    fs::create_dir_all(repo).expect("create repo");
+    run_git(repo, &["init"]);
+    run_git(repo, &["config", "user.name", "Orbit Test"]);
+    run_git(repo, &["config", "user.email", "orbit-test@example.com"]);
+    run_git(repo, &["config", "commit.gpgsign", "false"]);
+    fs::write(repo.join("README.md"), "# repo\n").expect("write readme");
+    run_git(repo, &["add", "README.md"]);
+    run_git(repo, &["commit", "-m", "initial"]);
+}
+
+fn run_git(cwd: &Path, args: &[&str]) {
+    let output = StdCommand::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git -C {} {} failed\nstdout:\n{}\nstderr:\n{}",
+        cwd.display(),
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/orbit-mcp/src/adapter/schema.rs
+++ b/crates/orbit-mcp/src/adapter/schema.rs
@@ -15,10 +15,10 @@ pub(super) fn schema_to_tool(schema: ToolSchema, input_schema: JsonObject) -> To
 /// Canonical name of the broker's workspace-routing argument.
 pub(crate) const WORKSPACE_SELECTOR_PARAM: &str = "workspace";
 
-const WORKSPACE_SELECTOR_DESCRIPTION: &str = "Workspace selector for broker routing: a registered logical workspace ID or an absolute \
-     path to a local checkout (a linked Git worktree resolves to its registered checkout). \
-     Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never \
-     inferred from process cwd.";
+const WORKSPACE_SELECTOR_DESCRIPTION: &str = "Workspace selector for broker routing: a registered workspace name, a logical workspace \
+     ID (`ws_*`), or an absolute path to a local checkout (a linked Git worktree resolves to \
+     its registered checkout). Optional when the MCP session announced `_meta.orbit.workspace` \
+     at initialize; never inferred from process cwd.";
 
 /// Advertise the workspace selector on every workspace-scoped tool.
 ///

--- a/crates/orbit-mcp/src/adapter/tests/schema.rs
+++ b/crates/orbit-mcp/src/adapter/tests/schema.rs
@@ -187,6 +187,14 @@ fn workspace_scoped_tool_advertises_the_broker_workspace_selector() {
         .and_then(Value::as_str)
         .expect("selector carries routing guidance");
     assert!(
+        description.contains("registered workspace name"),
+        "selector must document the registered-name form: {description}"
+    );
+    assert!(
+        description.contains("ws_*"),
+        "selector must document logical ws_* ids: {description}"
+    );
+    assert!(
         description.contains("absolute path to a local checkout"),
         "selector must document the checkout-path form: {description}"
     );

--- a/crates/orbit-remote/src/mcp/host.rs
+++ b/crates/orbit-remote/src/mcp/host.rs
@@ -308,6 +308,9 @@ impl BrokerMcpHost {
     /// Resolve a selector to its logical workspace ID and, when this machine
     /// holds one, its validated exact local checkout.
     ///
+    /// ADR-0361: name, logical id, and absolute checkout path are the shared
+    /// grammar with CLI `--workspace`. Relative paths still fail closed.
+    ///
     /// The binding is always attached when it exists — placement preflight, not
     /// this lookup, decides whether a call may proceed without one. A workspace
     /// registered here with no local checkout resolves to `(id, None)`.
@@ -328,10 +331,17 @@ impl BrokerMcpHost {
 
         let registry_path = crate::workspace_registry::registry_path_for(&self.global_root);
         let registry = crate::workspace_registry::load_registry_from(&registry_path)?;
-        let workspace = registry
-            .workspaces
-            .iter()
-            .find(|workspace| workspace.id == selector);
+        // ADR-0361: registered name and logical id share one fail-closed lookup.
+        let workspace =
+            match crate::workspace_registry::resolve_logical_workspace(&registry, selector) {
+                Ok(workspace) => Some(workspace),
+                Err(error)
+                    if crate::workspace_registry::is_ambiguous_workspace_selector(&error) =>
+                {
+                    return Err(error);
+                }
+                Err(_) => None,
+            };
         if workspace.is_none() {
             for checkout in &registry.checkouts {
                 let identity_path = checkout.orbit_dir.join("config.yaml");
@@ -344,11 +354,8 @@ impl BrokerMcpHost {
                 }
             }
         }
-        let workspace = workspace.ok_or_else(|| {
-                OrbitError::InvalidInput(format!(
-                    "unknown logical workspace ID '{selector}'; pass a registered workspace ID or an absolute local checkout path"
-                ))
-            })?;
+        let workspace = workspace
+            .ok_or_else(|| crate::workspace_registry::unknown_workspace_selector(selector))?;
         if workspace.status != WorkspaceStatus::Active {
             return Err(OrbitError::InvalidInput(format!(
                 "logical workspace ID '{}' is not active",

--- a/crates/orbit-remote/src/mcp/tests/mod.rs
+++ b/crates/orbit-remote/src/mcp/tests/mod.rs
@@ -11,6 +11,7 @@ mod proxy;
 mod schema;
 mod serve;
 mod transport;
+mod workspace_selector;
 
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/crates/orbit-remote/src/mcp/tests/workspace_selector.rs
+++ b/crates/orbit-remote/src/mcp/tests/workspace_selector.rs
@@ -1,0 +1,247 @@
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use chrono::Utc;
+use orbit_common::types::{
+    McpCapability, ToolSessionContext, Workspace, WorkspaceRegistry, WorkspaceStatus,
+};
+use orbit_core::runtime::HubCoordinationExecutor;
+use orbit_mcp::McpHost;
+use serde_json::json;
+
+use super::super::host::BrokerMcpHost;
+
+fn write_identity(root: &Path) {
+    std::fs::write(
+        root.join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_hub\"\nhost_id = \"hub\"\ntask_prefix = \"ORB\"\n",
+    )
+    .expect("host identity");
+}
+
+fn save_named_workspaces(root: &Path, names: &[(&str, &str)]) {
+    let now = Utc::now();
+    let workspaces = names
+        .iter()
+        .map(|(id, name)| Workspace {
+            id: (*id).to_string(),
+            name: (*name).to_string(),
+            owner_machine_id: Some("hm_hub".to_string()),
+            git_remote: None,
+            ship_mode: None,
+            base_branch: "agent-main".to_string(),
+            status: WorkspaceStatus::Active,
+            created_at: now,
+            updated_at: now,
+        })
+        .collect();
+    crate::workspace_registry::save_registry_to(
+        &WorkspaceRegistry {
+            workspaces,
+            ..Default::default()
+        },
+        &crate::workspace_registry::registry_path_for(root),
+    )
+    .expect("workspace registry");
+    for (id, name) in names {
+        HubCoordinationExecutor::register_workspace(root, *id, *name).expect("task workspace");
+    }
+}
+
+fn operator_context(workspace: Option<&str>, call_id: &str) -> ToolSessionContext {
+    let mut context = ToolSessionContext::trusted_local(
+        None,
+        Some("hm_hub".to_string()),
+        Some("hub".to_string()),
+    );
+    context.workspace = workspace.map(ToOwned::to_owned);
+    context.effective_capabilities = BTreeSet::from([McpCapability::Operator]);
+    context.mcp_call_id = Some(call_id.to_string());
+    context
+}
+
+fn audit_workspace_id(root: &Path, call_id: &str) -> Option<String> {
+    let audit_path = orbit_core::config::resolved_audit_db_path(root, root).expect("audit path");
+    let connection = rusqlite::Connection::open(audit_path).expect("audit store");
+    connection
+        .query_row(
+            "SELECT workspace_id FROM audit_events WHERE mcp_call_id = ?1",
+            [call_id],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .expect("audit row")
+}
+
+#[test]
+fn mcp_accepts_registered_name_and_logical_id_and_audits_resolved_id() {
+    let root = tempfile::tempdir().expect("global root");
+    write_identity(root.path());
+    save_named_workspaces(root.path(), &[("ws_orbit", "orbit"), ("ws_other", "other")]);
+    let host = BrokerMcpHost::new(root.path().to_path_buf());
+
+    let by_name = host
+        .call_tool(
+            "orbit.task.add",
+            json!({
+                "workspace": "orbit",
+                "title": "Named",
+                "description": "Created via registered name",
+                "model": "codex"
+            }),
+            operator_context(None, "mcall-name"),
+        )
+        .expect("name selector");
+    assert_eq!(by_name["title"], "Named");
+    assert_eq!(
+        audit_workspace_id(root.path(), "mcall-name").as_deref(),
+        Some("ws_orbit")
+    );
+
+    let listed = host
+        .call_tool(
+            "orbit.task.list",
+            json!({ "workspace": "ws_orbit", "limit": 5 }),
+            operator_context(None, "mcall-id"),
+        )
+        .expect("logical id selector");
+    let ids = listed
+        .as_array()
+        .expect("task list")
+        .iter()
+        .filter_map(|task| task.get("id").and_then(|id| id.as_str()))
+        .collect::<Vec<_>>();
+    assert!(
+        ids.contains(&by_name["id"].as_str().expect("created id")),
+        "logical id must route to the same workspace: {listed}"
+    );
+    assert_eq!(
+        audit_workspace_id(root.path(), "mcall-id").as_deref(),
+        Some("ws_orbit")
+    );
+}
+
+#[test]
+fn mcp_unknown_and_ambiguous_selectors_fail_closed_naming_the_value() {
+    let root = tempfile::tempdir().expect("global root");
+    write_identity(root.path());
+    save_named_workspaces(
+        root.path(),
+        &[("ws_shared", "alpha"), ("ws_other", "ws_shared")],
+    );
+    let host = BrokerMcpHost::new(root.path().to_path_buf());
+
+    let unknown = host
+        .call_tool(
+            "orbit.task.list",
+            json!({ "workspace": "no-such-ws", "limit": 1 }),
+            operator_context(None, "mcall-unknown"),
+        )
+        .expect_err("unknown selector");
+    let unknown_message = unknown.to_string();
+    assert!(unknown_message.contains("no-such-ws"), "{unknown_message}");
+
+    let ambiguous = host
+        .call_tool(
+            "orbit.task.list",
+            json!({ "workspace": "ws_shared", "limit": 1 }),
+            operator_context(None, "mcall-ambiguous"),
+        )
+        .expect_err("ambiguous selector");
+    let ambiguous_message = ambiguous.to_string();
+    assert!(
+        ambiguous_message.contains("ws_shared"),
+        "{ambiguous_message}"
+    );
+    assert!(
+        ambiguous_message.contains("ambiguous"),
+        "{ambiguous_message}"
+    );
+}
+
+#[test]
+fn mcp_explicit_selector_wins_over_session_and_never_uses_process_cwd() {
+    let root = tempfile::tempdir().expect("global root");
+    write_identity(root.path());
+    save_named_workspaces(root.path(), &[("ws_alpha", "alpha"), ("ws_beta", "beta")]);
+    let host = BrokerMcpHost::new(root.path().to_path_buf());
+
+    host.call_tool(
+        "orbit.task.add",
+        json!({
+            "workspace": "alpha",
+            "title": "Alpha only",
+            "description": "Lives in alpha",
+            "model": "codex"
+        }),
+        operator_context(None, "mcall-seed-alpha"),
+    )
+    .expect("seed alpha");
+
+    let listed = host
+        .call_tool(
+            "orbit.task.list",
+            json!({ "workspace": "alpha", "limit": 10 }),
+            operator_context(Some("beta"), "mcall-explicit-wins"),
+        )
+        .expect("explicit selector wins");
+    let titles: Vec<_> = listed
+        .as_array()
+        .expect("list")
+        .iter()
+        .filter_map(|task| task.get("title").and_then(|title| title.as_str()))
+        .collect();
+    assert!(
+        titles.contains(&"Alpha only"),
+        "explicit alpha must beat session beta: {listed}"
+    );
+
+    let session_only = host
+        .call_tool(
+            "orbit.task.list",
+            json!({ "limit": 10 }),
+            operator_context(Some("alpha"), "mcall-session"),
+        )
+        .expect("session selector");
+    let session_titles: Vec<_> = session_only
+        .as_array()
+        .expect("list")
+        .iter()
+        .filter_map(|task| task.get("title").and_then(|title| title.as_str()))
+        .collect();
+    assert!(
+        session_titles.contains(&"Alpha only"),
+        "session _meta must bind when the call omits workspace: {session_only}"
+    );
+
+    let missing = host
+        .call_tool(
+            "orbit.task.list",
+            json!({ "limit": 1 }),
+            operator_context(None, "mcall-no-cwd"),
+        )
+        .expect_err("MCP must not fall back to process cwd");
+    let message = missing.to_string();
+    assert!(
+        message.contains("requires a workspace selector"),
+        "{message}"
+    );
+}
+
+#[test]
+fn mcp_relative_path_selector_is_rejected() {
+    let root = tempfile::tempdir().expect("global root");
+    write_identity(root.path());
+    save_named_workspaces(root.path(), &[("ws_orbit", "orbit")]);
+    let host = BrokerMcpHost::new(root.path().to_path_buf());
+
+    let error = host
+        .call_tool(
+            "orbit.task.list",
+            json!({ "workspace": "./relative", "limit": 1 }),
+            operator_context(None, "mcall-relative"),
+        )
+        .expect_err("relative path");
+    let message = error.to_string();
+    assert!(message.contains("./relative"), "{message}");
+    assert!(message.contains("must be absolute"), "{message}");
+}

--- a/crates/orbit-remote/src/runtime.rs
+++ b/crates/orbit-remote/src/runtime.rs
@@ -88,13 +88,45 @@ impl RemoteRuntimeFactory {
     pub fn initialize_with_root_override(
         root_override: Option<&Path>,
     ) -> Result<OrbitRuntime, OrbitError> {
-        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        let roots = Self::resolve_roots_for_cwd(&cwd, root_override)?;
-        sync_task_prefix(&roots.global_root)?;
-        let binding = binding_for_roots(&roots)?;
-        let replica_owner = replica_owner_for_roots(&roots)?;
-        OrbitRuntime::initialize_from_resolved_roots(roots, binding)
-            .map(|runtime| runtime.with_coordination_write_owner(replica_owner))
+        Self::initialize_with_overrides(root_override, None)
+    }
+
+    /// Bootstrap a CLI runtime from `--root` and/or `--workspace`.
+    ///
+    /// ADR-0361: `--workspace` is the workspace selector (name, `ws_*` id, or
+    /// absolute checkout path). `--root` stays a data-directory override and
+    /// is never overloaded as a selector. Omitting `--workspace` keeps today's
+    /// cwd walk.
+    pub fn initialize_with_overrides(
+        root_override: Option<&Path>,
+        workspace_selector: Option<&str>,
+    ) -> Result<OrbitRuntime, OrbitError> {
+        let selector = workspace_selector
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let Some(selector) = selector else {
+            let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            let roots = Self::resolve_roots_for_cwd(&cwd, root_override)?;
+            sync_task_prefix(&roots.global_root)?;
+            let binding = binding_for_roots(&roots)?;
+            let replica_owner = replica_owner_for_roots(&roots)?;
+            return OrbitRuntime::initialize_from_resolved_roots(roots, binding)
+                .map(|runtime| runtime.with_coordination_write_owner(replica_owner));
+        };
+
+        let global_root = match root_override {
+            Some(root) => root.to_path_buf(),
+            None => workspace_registry::global_orbit_dir()?,
+        };
+        sync_task_prefix(&global_root)?;
+        let registry = workspace_registry::load_registry_from(
+            &workspace_registry::registry_path_for(&global_root),
+        )?;
+        let (workspace, checkout) = resolve_cli_workspace_binding(&registry, selector)?;
+        if workspace.status != WorkspaceStatus::Active {
+            return Err(unsupported_cli_workspace(selector));
+        }
+        Self::open_registered_checkout(&global_root, workspace, checkout)
     }
 
     pub fn open_resolved_roots(roots: OrbitRuntimeRoots) -> Result<OrbitRuntime, OrbitError> {
@@ -216,12 +248,9 @@ fn resolve_cli_workspace_target<'a>(
     selector: &str,
 ) -> Result<CliWorkspaceTarget<'a>, OrbitError> {
     if selector_looks_like_path(selector) {
-        return resolve_cli_workspace_path(registry, runtime, selector);
+        return resolve_cli_workspace_path(registry, Some(runtime), selector);
     }
-    let checkout = workspace_registry::find_checkout(registry, selector)
-        .ok_or_else(|| unsupported_cli_workspace(selector))?;
-    let workspace = workspace_registry::find_workspace(registry, &checkout.workspace_id)
-        .ok_or_else(|| unsupported_cli_workspace(selector))?;
+    let (workspace, checkout) = resolve_named_cli_checkout(registry, selector)?;
     Ok(CliWorkspaceTarget::Checkout {
         workspace,
         checkout,
@@ -229,9 +258,45 @@ fn resolve_cli_workspace_target<'a>(
     })
 }
 
+fn resolve_cli_workspace_binding<'a>(
+    registry: &'a WorkspaceRegistry,
+    selector: &str,
+) -> Result<(&'a Workspace, &'a WorkspaceCheckout), OrbitError> {
+    match if selector_looks_like_path(selector) {
+        resolve_cli_workspace_path(registry, None, selector)?
+    } else {
+        let (workspace, checkout) = resolve_named_cli_checkout(registry, selector)?;
+        CliWorkspaceTarget::Checkout {
+            workspace,
+            checkout,
+            rewrite_to_repo_root: true,
+        }
+    } {
+        CliWorkspaceTarget::Checkout {
+            workspace,
+            checkout,
+            ..
+        } => Ok((workspace, checkout)),
+        CliWorkspaceTarget::CurrentRuntime => Err(unsupported_cli_workspace(selector)),
+    }
+}
+
+fn resolve_named_cli_checkout<'a>(
+    registry: &'a WorkspaceRegistry,
+    selector: &str,
+) -> Result<(&'a Workspace, &'a WorkspaceCheckout), OrbitError> {
+    let workspace = workspace_registry::resolve_logical_workspace(registry, selector)?;
+    let checkout = registry
+        .checkouts
+        .iter()
+        .find(|checkout| checkout.workspace_id == workspace.id)
+        .ok_or_else(|| unsupported_cli_workspace(selector))?;
+    Ok((workspace, checkout))
+}
+
 fn resolve_cli_workspace_path<'a>(
     registry: &'a WorkspaceRegistry,
-    runtime: &OrbitRuntime,
+    runtime: Option<&OrbitRuntime>,
     selector: &str,
 ) -> Result<CliWorkspaceTarget<'a>, OrbitError> {
     let raw = Path::new(selector);
@@ -248,7 +313,9 @@ fn resolve_cli_workspace_path<'a>(
     if !canonical.is_dir() {
         return Err(unsupported_cli_workspace(selector));
     }
-    if let Some(checkout) = find_checkout_for_canonical_path(registry, &canonical) {
+    if let Some(checkout) = find_checkout_for_canonical_path(registry, &canonical)
+        .or_else(|| find_checkout_for_git_common_dir(registry, &canonical))
+    {
         let workspace = workspace_registry::find_workspace(registry, &checkout.workspace_id)
             .ok_or_else(|| unsupported_cli_workspace(selector))?;
         return Ok(CliWorkspaceTarget::Checkout {
@@ -257,7 +324,9 @@ fn resolve_cli_workspace_path<'a>(
             rewrite_to_repo_root: false,
         });
     }
-    if path_is_inside(&runtime.paths().repo_root, &canonical) {
+    if let Some(runtime) = runtime
+        && path_is_inside(&runtime.paths().repo_root, &canonical)
+    {
         return Ok(CliWorkspaceTarget::CurrentRuntime);
     }
     Err(unsupported_cli_workspace(selector))
@@ -275,6 +344,36 @@ fn find_checkout_for_canonical_path<'a>(
                 .iter()
                 .any(|override_path| canonical_path(override_path) == canonical)
     })
+}
+
+fn find_checkout_for_git_common_dir<'a>(
+    registry: &'a WorkspaceRegistry,
+    selected: &Path,
+) -> Option<&'a WorkspaceCheckout> {
+    let selected_common = git_common_dir(selected)?;
+    let mut matches = registry.checkouts.iter().filter(|checkout| {
+        git_common_dir(&checkout.repo_root).is_some_and(|common| common == selected_common)
+    });
+    let first = matches.next()?;
+    matches.next().is_none().then_some(first)
+}
+
+fn git_common_dir(path: &Path) -> Option<PathBuf> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8(output.stdout).ok()?;
+    let trimmed = raw.lines().next()?.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(canonical_path(Path::new(trimmed)))
 }
 
 fn same_cli_checkout(runtime: &OrbitRuntime, checkout: &WorkspaceCheckout) -> bool {
@@ -313,7 +412,7 @@ fn set_input_workspace(input: &mut Value, repo_root: &Path) -> Result<(), OrbitE
 
 fn unsupported_cli_workspace(selector: &str) -> OrbitError {
     OrbitError::InvalidInput(format!(
-        "unsupported workspace '{selector}'; pass a registered workspace name or ID, or a path to a registered local checkout"
+        "unknown workspace selector '{selector}'; pass a registered workspace name, a logical workspace ID, or an absolute local checkout path"
     ))
 }
 

--- a/crates/orbit-remote/src/tests/runtime.rs
+++ b/crates/orbit-remote/src/tests/runtime.rs
@@ -323,6 +323,17 @@ fn cli_tool_run_lists_the_named_workspace_not_the_cwd_runtime() {
         task_ids(&by_path).contains(&fixture.beta_task_id),
         "absolute checkout path must return beta tasks: {by_path}"
     );
+
+    let by_id = execute_cli_tool(
+        &fixture.alpha,
+        "orbit.task.list",
+        json!({ "workspace": "ws_beta", "limit": 10 }),
+    )
+    .expect("list should rebind to the logical id");
+    assert!(
+        task_ids(&by_id).contains(&fixture.beta_task_id),
+        "logical workspace id must return beta tasks: {by_id}"
+    );
 }
 
 #[test]
@@ -390,6 +401,35 @@ fn cli_tool_run_write_rebounds_to_the_named_workspace() {
         task_ids(&beta_list).contains(&created_id),
         "named-workspace write must be visible on the target workspace: {beta_list}"
     );
+}
+
+#[test]
+fn initialize_with_workspace_selector_binds_the_named_checkout() {
+    let fixture = dual_workspace_fixture();
+    let global = fixture.alpha.global_root();
+    let runtime = RemoteRuntimeFactory::initialize_with_overrides(Some(&global), Some("beta"))
+        .expect("selector should bind beta");
+    let listed = runtime
+        .execute_tool_command(
+            "orbit.task.list",
+            json!({ "limit": 10 }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("list beta");
+    assert!(
+        task_ids(&listed).contains(&fixture.beta_task_id),
+        "initialize --workspace beta must open the beta checkout: {listed}"
+    );
+
+    let unknown = match RemoteRuntimeFactory::initialize_with_overrides(
+        Some(&global),
+        Some("no-such-workspace"),
+    ) {
+        Ok(_) => panic!("unknown selector must fail closed"),
+        Err(error) => error,
+    };
+    unsupported_workspace_message(unknown, "no-such-workspace");
 }
 
 fn task_ids(value: &Value) -> Vec<String> {

--- a/crates/orbit-remote/src/tests/workspace_registry.rs
+++ b/crates/orbit-remote/src/tests/workspace_registry.rs
@@ -12,7 +12,7 @@ use tempfile::tempdir;
 use crate::workspace_registry::{
     assign_checkout_role, find_checkout_by_path, find_workspace, find_workspace_by_path,
     load_registry_from, load_registry_from_with_writer, rename_local_owner_host_id,
-    save_registry_to,
+    resolve_logical_workspace, save_registry_to,
 };
 
 fn timestamp() -> chrono::DateTime<Utc> {
@@ -364,6 +364,54 @@ fn identity_lookup_is_path_independent_and_path_lookup_is_checkout_only() {
         Some("ws_inner")
     );
     assert!(find_workspace_by_path(&registry, Path::new("/remote/ws_remote")).is_none());
+}
+
+#[test]
+fn resolve_logical_workspace_accepts_name_or_id_and_fails_closed() {
+    let mut registry = WorkspaceRegistry {
+        workspaces: vec![
+            logical_workspace("ws_orbit", Some("hm_owner")),
+            logical_workspace("ws_other", Some("hm_owner")),
+        ],
+        ..Default::default()
+    };
+    registry.workspaces[0].name = "orbit".to_string();
+    registry.workspaces[1].name = "other".to_string();
+
+    assert_eq!(
+        resolve_logical_workspace(&registry, "orbit")
+            .expect("name")
+            .id,
+        "ws_orbit"
+    );
+    assert_eq!(
+        resolve_logical_workspace(&registry, "ws_orbit")
+            .expect("id")
+            .id,
+        "ws_orbit"
+    );
+
+    let unknown = resolve_logical_workspace(&registry, "missing").expect_err("unknown");
+    match unknown {
+        OrbitError::InvalidInput(message) => {
+            assert!(message.contains("missing"), "{message}");
+            assert!(message.contains("unknown workspace selector"), "{message}");
+        }
+        other => panic!("expected InvalidInput, got {other}"),
+    }
+
+    registry.workspaces[1].name = "orbit".to_string();
+    let ambiguous = resolve_logical_workspace(&registry, "orbit").expect_err("ambiguous");
+    match ambiguous {
+        OrbitError::InvalidInput(message) => {
+            assert!(message.contains("orbit"), "{message}");
+            assert!(
+                message.contains("ambiguous workspace selector"),
+                "{message}"
+            );
+        }
+        other => panic!("expected InvalidInput, got {other}"),
+    }
 }
 
 #[test]

--- a/crates/orbit-remote/src/workspace_registry.rs
+++ b/crates/orbit-remote/src/workspace_registry.rs
@@ -280,6 +280,43 @@ pub fn find_workspace<'a>(
         .find(|w| w.id == id_or_name || w.name == id_or_name)
 }
 
+/// Resolve a logical selector (registered name or `ws_*` id) to exactly one workspace.
+///
+/// ADR-0361: the same fail-closed name/id grammar is used by the CLI
+/// `--workspace` flag and MCP `resolve_workspace`. First-match is not
+/// enough — two workspaces sharing a name must not silently pick one.
+pub fn resolve_logical_workspace<'a>(
+    registry: &'a WorkspaceRegistry,
+    selector: &str,
+) -> Result<&'a Workspace, OrbitError> {
+    let matches: Vec<&Workspace> = registry
+        .workspaces
+        .iter()
+        .filter(|workspace| workspace.id == selector || workspace.name == selector)
+        .collect();
+    match matches.as_slice() {
+        [workspace] => Ok(workspace),
+        [] => Err(unknown_workspace_selector(selector)),
+        _ => Err(ambiguous_workspace_selector(selector)),
+    }
+}
+
+pub(crate) fn unknown_workspace_selector(selector: &str) -> OrbitError {
+    OrbitError::InvalidInput(format!(
+        "unknown workspace selector '{selector}'; pass a registered workspace name, a logical workspace ID, or an absolute local checkout path"
+    ))
+}
+
+pub(crate) fn ambiguous_workspace_selector(selector: &str) -> OrbitError {
+    OrbitError::InvalidInput(format!(
+        "ambiguous workspace selector '{selector}'; it matches more than one registered workspace"
+    ))
+}
+
+pub(crate) fn is_ambiguous_workspace_selector(error: &OrbitError) -> bool {
+    matches!(error, OrbitError::InvalidInput(message) if message.starts_with("ambiguous workspace selector "))
+}
+
 /// Finds the local checkout for a workspace ID or name.
 pub fn find_checkout<'a>(
     registry: &'a WorkspaceRegistry,

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -309,10 +309,9 @@ pub(super) fn resolve_workspace_argument(
             Ok(workspace)
         }
         (None, None) => Err(OrbitError::InvalidInput(
-            "missing `workspace`; it must be a filesystem path to an existing directory inside \
-             the repository (e.g. the repository root), never a logical workspace id such as a \
-             bridge `ws_*` id — provide that path explicitly or initialize the MCP session with \
-             `_meta.orbit.workspace` set to the same path"
+            "missing `workspace`; pass a registered workspace name, a logical workspace ID \
+             (`ws_*`), or an absolute local checkout path, or initialize the MCP session with \
+             `_meta.orbit.workspace`"
                 .to_string(),
         )),
     }

--- a/crates/orbit-tools/src/builtin/orbit/task/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add.rs
@@ -28,10 +28,10 @@ impl Tool for OrbitTaskAddTool {
             ToolParam {
                 name: "workspace".to_string(),
                 description:
-                    "Filesystem path to an existing directory inside the target repository \
-                     (e.g. the repository root). This is a repository path, never a logical/bridge \
-                     workspace id (such as a `ws_*` id). Falls back to the MCP session's \
-                     `_meta.orbit.workspace` when omitted."
+                    "Workspace selector: a registered workspace name, a logical workspace ID \
+                     (`ws_*`), or an absolute path to a local checkout (a linked Git worktree \
+                     resolves to its registered checkout). Falls back to the MCP session's \
+                     `_meta.orbit.workspace` when omitted; never inferred from process cwd."
                         .to_string(),
                 param_type: "string".to_string(),
                 required: false,

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
@@ -421,12 +421,12 @@ fn add_call_missing_workspace_without_session_context_returns_clear_error() {
             assert!(message.contains("missing `workspace`"), "{message}");
             assert!(message.contains("MCP session"), "{message}");
             assert!(
-                message.contains("filesystem path"),
-                "error must state the accepted form is a filesystem path: {message}"
+                message.contains("registered workspace name"),
+                "error must state the accepted name form: {message}"
             );
             assert!(
-                message.contains("logical workspace id"),
-                "error must call out that a logical/bridge id is not accepted: {message}"
+                message.contains("ws_*"),
+                "error must state that a logical ws_* id is accepted: {message}"
             );
         }
         other => panic!("unexpected error for missing workspace: {other}"),
@@ -438,7 +438,7 @@ fn add_call_missing_workspace_without_session_context_returns_clear_error() {
 }
 
 #[test]
-fn schema_workspace_param_documents_a_filesystem_path_not_a_logical_id() {
+fn schema_workspace_param_documents_the_shared_selector_grammar() {
     let schema = OrbitTaskAddTool.schema();
     let workspace = schema
         .parameters
@@ -447,13 +447,23 @@ fn schema_workspace_param_documents_a_filesystem_path_not_a_logical_id() {
         .expect("workspace param");
 
     assert!(
-        workspace.description.contains("Filesystem path"),
-        "workspace param must document the accepted path form: {}",
+        workspace.description.contains("registered workspace name"),
+        "workspace param must document the registered-name form: {}",
         workspace.description
     );
     assert!(
-        workspace.description.contains("never a logical/bridge"),
-        "workspace param must rule out logical/bridge ids: {}",
+        workspace.description.contains("ws_*"),
+        "workspace param must document logical ws_* ids: {}",
+        workspace.description
+    );
+    assert!(
+        workspace.description.contains("absolute path"),
+        "workspace param must document the checkout-path form: {}",
+        workspace.description
+    );
+    assert!(
+        !workspace.description.contains("never a logical"),
+        "workspace param must not forbid logical ids: {}",
         workspace.description
     );
 }

--- a/docs/design/mcp-session-context/2_design.md
+++ b/docs/design/mcp-session-context/2_design.md
@@ -11,7 +11,7 @@ doc_role: design
 tags: ["mcp-session-context", "mcp", "workspace"]
 paths: ["crates/orbit-mcp/**", "crates/orbit-remote/src/mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool/**"]
 related_features: ["mcp-session-context", "task-artifacts"]
-related_artifacts: ["ORB-00256", "ORB-10228", "ORB-10262", "ORB-10319", "ORB-10448", "ORB-10690", "ORB-10769", "ADR-0181", "ADR-0199", "ADR-0149", "ADR-0348"]
+related_artifacts: ["ORB-00256", "ORB-10228", "ORB-10262", "ORB-10319", "ORB-10448", "ORB-10690", "ORB-10758", "ORB-10769", "ADR-0181", "ADR-0199", "ADR-0149", "ADR-0348", "ADR-0361"]
 ---
 
 # MCP Session Context — Design
@@ -66,6 +66,14 @@ in `crates/orbit-remote/src/runtime.rs` reads a non-empty input `workspace` *abo
 and either rebinds the cwd-bootstrapped `OrbitRuntime` to that registered checkout or fails
 closed naming the selector. It never continues against cwd on a typo. MCP resolution order is
 unchanged and still never falls back to process cwd. [ORB-10769]
+
+### 3c. One selector grammar
+
+CLI `--workspace` and MCP workspace-scoped tools accept the same three forms: a registered
+workspace name, a logical `ws_*` id, or an absolute checkout path. A linked worktree path
+resolves to its registered checkout. Ambiguous names fail closed. `--root` is not a selector;
+it remains a data-directory override. There is no stateful `switch_workspace` MCP tool —
+per-call `workspace` and `--workspace` are the override. [ADR-0361], [ORB-10758]
 
 ### 3a. The selector is advertised, not implied
 
@@ -124,5 +132,6 @@ The external channel carries a workspace address, not a trusted workspace ID. Th
 - [ORB-10448] advertised the workspace selector on every workspace-scoped tool and routed hub-placement coordination reads by checkout identity, making the [ADR-0181] "clients that cannot send initialize metadata pass `workspace` explicitly" path reachable from a managed worktree activity.
 - [ORB-10690] added the TCP transport and moved session construction behind `McpSessionFactory` so concurrent clients cannot observe or overwrite each other's session context ([ADR-0348]).
 - [ORB-10769] bound CLI `orbit tool run` to the same fail-closed workspace selector above the tools; MCP resolution order is unchanged.
+- [ORB-10758] added `orbit --workspace` and made MCP accept the same name / `ws_*` id / absolute-path grammar ([ADR-0361]).
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-session-context/4_decisions.md
+++ b/docs/design/mcp-session-context/4_decisions.md
@@ -3,15 +3,15 @@ summary: "MCP Session Context — Decisions"
 type: design
 title: "MCP Session Context — Decisions"
 owner: codex
-last_updated: 2026-08-13
+last_updated: 2026-08-14
 last_validated: 2026-08-08
 status: Accepted
 feature: mcp-session-context
 doc_role: decisions
 tags: ["mcp-session-context", "mcp", "workspace"]
-paths: ["crates/orbit-mcp/**", "crates/orbit-remote/src/mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool/**"]
+paths: ["crates/orbit-mcp/**", "crates/orbit-remote/src/mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool/**", "crates/orbit-cli/src/**"]
 related_features: ["mcp-session-context", "task-artifacts"]
-related_artifacts: ["ORB-00256", "ORB-00406", "ORB-10228", "ORB-10262", "ORB-10319", "ORB-10448", "ORB-10690", "ADR-0181", "ADR-0199", "ADR-0149", "ADR-0348"]
+related_artifacts: ["ORB-00256", "ORB-00406", "ORB-10228", "ORB-10262", "ORB-10319", "ORB-10448", "ORB-10690", "ORB-10758", "ORB-10769", "ADR-0181", "ADR-0199", "ADR-0149", "ADR-0348", "ADR-0361"]
 ---
 
 # MCP Session Context — Decisions
@@ -132,6 +132,33 @@ Mount a stateful Streamable HTTP MCP service at `/mcp` on the dashboard Axum lis
 - Reverse proxies remain responsible for authentication and may buffer otherwise-correct origin streaming; deployment-path streaming needs separate verification.
 - Cost: the dashboard process now owns MCP availability, so dashboard restarts interrupt MCP sessions and shutdown wiring must coordinate both transports.
 
+## ADR-0361 — One workspace selector grammar on CLI and MCP
+
+**Status:** Accepted · 2026-08 · [ORB-10758]
+**Code anchors:** `crates/orbit-remote/src/workspace_registry.rs::resolve_logical_workspace`, `crates/orbit-remote/src/runtime.rs::initialize_with_overrides`, `crates/orbit-remote/src/mcp/host.rs::resolve_workspace`, `crates/orbit-cli/src/command/mod.rs::Cli`
+
+### Context
+
+MCP `resolve_workspace` already accepted a logical workspace ID or an absolute checkout path and never inherited process cwd ([ADR-0149], [ADR-0181], [ADR-0199]). The CLI had no equivalent: `orbit --help` exposed only `--root` (a data-directory override), and `orbit.task.add --workspace` rejected `ws_*` ids while the MCP schema advertised them. Two grammars for one concept meant guidance that was correct on one surface was wrong on the other.
+
+### Decision
+
+Every workspace-routing surface accepts the same three selector forms: a registered workspace name (`orbit`), a logical ID (`ws_orbit`), or an absolute checkout path (a linked Git worktree resolves to its registered checkout). Ambiguous or unknown selectors fail closed and name the rejected value.
+
+Resolution order is unchanged: explicit per-call / `--workspace` selector, then MCP initialize `_meta.orbit.workspace`, then CLI cwd discovery. MCP never falls back to process cwd. `--root` stays a data-directory override; the new top-level `orbit --workspace <selector>` is the CLI selector and is not clap-global so it does not collide with `task add --workspace` (a repository-relative task path). A routed audit event records the resolved `workspace_id`, not only the raw selector.
+
+### Rejected alternatives
+
+- *MCP cwd fallback.* Already rejected by [ADR-0149] / [ADR-0181]: a worktree cwd can bind a different `workspace_id` than the caller named.
+- *Overloading `--root` as a workspace selector.* `--root` is the data-directory escape hatch and already pins the global registry root; making it also mean "this checkout" would collapse two independent overrides.
+- *A stateful `switch_workspace` MCP tool.* Mutating session context mid-connection is how TCP sessions already go wrong ([ADR-0348]); per-call `workspace` and CLI `--workspace` are the dynamic path.
+
+### Consequences
+
+- Agents can name a workspace the same way on `orbit --workspace` and on every workspace-scoped MCP tool.
+- `orbit.task.add`'s advertised `workspace` parameter matches the grammar the broker actually accepts.
+- Cost: name collisions across registered workspaces become hard errors instead of first-match; operators with duplicate names must disambiguate by id or path.
+
 ## Task References
 
 - [ORB-00256] implemented MCP ambient workspace session context.
@@ -141,5 +168,7 @@ Mount a stateful Streamable HTTP MCP service at `/mcp` on the dashboard Axum lis
 - [ORB-10262] accepted and implemented ADR-0199 through the exact-checkout local broker.
 - [ORB-10319] consolidated the broker/session implementation in `orbit-remote`; it does not change ADR-0181 or ADR-0199 semantics.
 - [ORB-10448] made both ADRs reachable from a managed worktree activity: the `workspace` selector is now advertised on every workspace-scoped tool, and hub-placement coordination reads address the checkout-identity partition. Neither changes ADR-0181 or ADR-0199 semantics; see [2_design.md §3a–3b](./2_design.md). The advertised-selector contract is a breaking `tools/list` schema change (RELEASING.md) and may warrant its own allocated ADR — this task's activity was not granted `orbit.adr.add`, so no global ID was allocated.
+- [ORB-10758] unified the workspace selector grammar across the CLI `--workspace` flag and MCP workspace-scoped tools ([ADR-0361]).
+- [ORB-10769] bound CLI `orbit tool run` to the same fail-closed workspace selector above the tools.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10758](https://orbit-cli.com/tasks/ORB-10758) — One workspace selector grammar across CLI and MCP

### Description

## Problem

Orbit has one workspace-selector grammar in the MCP broker and a different, narrower one on the CLI. A caller cannot name a workspace the same way on both surfaces.

**MCP resolution works and is not in question.** `McpHost::resolve_workspace` (`crates/orbit-remote/src/mcp/host.rs`) takes a per-call selector, accepts a registered logical workspace ID or an absolute checkout path, refuses relative paths explicitly, and fails closed with `unknown logical workspace ID '<selector>'`. Explicit call argument wins, then session `_meta.orbit.workspace`, never process cwd (ADR-0149 / ADR-0181).

What is missing is on the CLI, and in the text describing the contract:

- **No global `--workspace`.** `orbit --help` exposes only `--root`, which is a data-directory override, not a workspace selector. There is no `orbit --workspace orbit task list`. Selecting a workspace means changing directory.
- **The per-subcommand flag uses a different grammar.** `orbit task add --workspace` accepts a filesystem path and rejects logical IDs: `--workspace ws_constellation` fails with "must be a filesystem path to an existing directory inside the repository ... never a logical workspace id". The MCP schema advertises registered IDs as valid for the same field.
- **`orbit.task.add`'s own parameter text encodes the narrower rule**, so an agent reading the tool description is told the opposite of what the MCP broker accepts.

## Why It Matters

Two grammars for one concept means guidance that is correct on one surface is wrong on the other, and an agent that learns the CLI rule writes MCP calls that contradict the advertised schema. The cost is documentation drift and rejected calls rather than data loss.

## Constraints / Notes

- **Scoped to grammar and the CLI selector.** The silent-misroute defect on CLI tool execution is ORB-10769 and is a prerequisite: this task should not re-fix routing, only make the selector nameable and consistently described.
- **Keep today's defaults.** CLI: cwd walk to `.orbit`. MCP: initialize `_meta.orbit.workspace`, then per-call `workspace`. Do not add an MCP cwd fallback (rejected by ADR-0149 / ADR-0181).
- **One selector grammar on every surface:** registered workspace name (`orbit`), logical ID (`ws_orbit`), or absolute checkout path, with a linked worktree resolving to its registered checkout. Ambiguous names fail closed.
- **Do not overload `--root`.** It stays a data-directory override; add `--workspace` alongside it.
- **No stateful `switch_workspace` MCP tool.** Per-call and `--workspace` override is the dynamic path; mutating session context mid-connection is how TCP sessions already go wrong (ADR-0348).
- Do not implement Bridge changes. Bridge is being decommissioned wholesale (ORB-10768), so its divergent `workspace` parameter resolves itself and is no longer a motivation for this work.
- Record the decision in `docs/design/mcp-session-context/4_decisions.md` (not the retired `.orbit/adrs/` store).
- Learning and ADR *tool families* are deprecated (ORB-10726, ORB-10736). Do not add routing special-cases for those nouns.

### Acceptance Criteria

- orbit --help shows a global --workspace <selector> distinct from --root; --root remains a data-dir override and does not become a workspace selector.
- From a checkout that is not the orbit workspace, orbit --workspace orbit task list --limit 1 and orbit --workspace ws_orbit task list --limit 1 both return orbit-workspace tasks; without --workspace, cwd discovery still binds as it does today.
- The same three selector forms — registered name, logical ws_* id, absolute checkout path — are accepted on both the CLI flag and MCP workspace-scoped tools, covered by tests on each surface.
- orbit.task.add's workspace parameter description no longer forbids ws_* ids, and matches the grammar the MCP broker actually accepts.
- An ambiguous or unknown selector fails closed on both surfaces with a message naming the rejected value.
- Resolution order is unchanged and tested: explicit selector wins, then MCP initialize _meta.orbit.workspace, then CLI cwd discovery; MCP never falls back to process cwd.
- An audit event for a routed call records the resolved workspace_id, not only the raw selector string.
- A new or amended ADR in docs/design/mcp-session-context/4_decisions.md records the shared selector grammar and the rejected alternatives (MCP cwd fallback; overloading --root; a stateful switch-workspace MCP tool).

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added top-level `orbit --workspace <SELECTOR>` (not clap-global, so it does not collide with `task add --workspace`). `--root` remains a data-directory override.
- `RemoteRuntimeFactory::initialize_with_overrides` binds a registered checkout from name, `ws_*` id, or absolute path; omitted selector keeps cwd discovery.
- Shared fail-closed logical lookup `resolve_logical_workspace` (name or id; unknown/ambiguous name the rejected value). MCP `resolve_workspace` now accepts registered names; relative paths still fail closed with no cwd fallback.
- Aligned advertised grammar on `orbit.task.add`, MCP workspace-scoped schema, and the missing-workspace error so `ws_*` ids are no longer forbidden.
- Routed CLI audit rows now record the bound runtime `workspace_id`. MCP already recorded the resolved logical id; tests assert name/id routing writes `ws_*` not the raw selector.
- ADR-0361 in `docs/design/mcp-session-context/4_decisions.md` records the shared grammar and the rejected alternatives (MCP cwd fallback; overloading `--root`; stateful switch-workspace MCP tool). `2_design.md` §3c documents the grammar.
Assessment: Acceptance criteria are covered by unit, MCP host, and CLI binary tests. Extra context_files were added for tightly coupled registry/audit/test/doc files required to compile and prove the grammar.
Strategic decisions: `--workspace` is top-level only (before the subcommand) to keep `task add --workspace` as a repository-relative task path. Duplicate registered names are already refused at registry write; MCP ambiguity is proven via a name-vs-id collision.
Validation: `make ci-fast` passed. Targeted tests: orbit-remote selector/MCP/runtime, orbit-tools schema, orbit-mcp advertised selector, orbit-cli parse/help, `cargo test -p orbit-cli --test workspace_selector`. Clippy -D warnings on orbit-remote, orbit-tools, orbit-mcp, orbit-cli --all-targets passed. Workspace-wide `make ci-lint` was not re-run (policy: one compile-heavy clippy pass is enough per task; these four crates are the change set).
Friction: none filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10758-6a7e806c`
- Behind base: 0
- Ahead of base: 1