### PR TITLE
Add versioned price rows for live Grok model strings (grok-4.6 / grok-4.5)

### DIFF
--- a/crates/orbit-common/assets/model_prices.yaml
+++ b/crates/orbit-common/assets/model_prices.yaml
@@ -194,8 +194,10 @@ prices:
     output_per_million_usd: 9.0
 
   # ── xAI / Grok (crew: grok) ──────────────────────────────────────────────
-  # grok-build is the string the crew config carries; xAI's coding/build model
-  # (grok-build-0.1) is 1.00/2.00 with a 75%-off cached input rate.
+  # grok-build is the historical coding/build string still present in older
+  # fixtures. Leave this shipped row open-ended; do not rewrite its rates
+  # in place. Official docs now list `grok-build-0.1` (a different key) at
+  # $1.00 / $0.20 cached / $2.00 — that is not this row.
   - model: "grok-build"
     effective_from: "2026-07-17T00:00:00Z"
     effective_until: null
@@ -204,3 +206,32 @@ prices:
     cache_create_per_million_usd: 1.0
     cache_create_1h_per_million_usd: 1.0
     output_per_million_usd: 2.0
+
+  # Live Grok lane strings. Retrieved 2026-08-14T03:45:16Z from
+  # https://docs.x.ai/developers/models/grok-4.6,
+  # https://docs.x.ai/developers/models/grok-4.5, and
+  # https://docs.x.ai/developers/pricing. Standard short-context (<200k
+  # prompt) rates only. Official docs also publish a ≥200k long-context
+  # tier and a 2x Priority Processing premium; those are not distinct
+  # `InvocationRecord.model` keys, so they are not separate rows.
+  # xAI has no 1h-TTL cache-create tier; cache_create / cache_create_1h
+  # equal the input rate so a malformed nonzero 1h count is not free.
+  # effective_from is the first Orbit live-default date for each string
+  # (ORB-10741 grok-4.5 on 2026-08-12; ORB-10756 grok-4.6 on 2026-08-13).
+  - model: "grok-4.5"
+    effective_from: "2026-08-12T00:00:00Z"
+    effective_until: null
+    input_per_million_usd: 2.0
+    cache_read_per_million_usd: 0.3
+    cache_create_per_million_usd: 2.0
+    cache_create_1h_per_million_usd: 2.0
+    output_per_million_usd: 6.0
+
+  - model: "grok-4.6"
+    effective_from: "2026-08-13T00:00:00Z"
+    effective_until: null
+    input_per_million_usd: 2.0
+    cache_read_per_million_usd: 0.5
+    cache_create_per_million_usd: 2.0
+    cache_create_1h_per_million_usd: 2.0
+    output_per_million_usd: 6.0

--- a/crates/orbit-common/src/types/tests/pricing.rs
+++ b/crates/orbit-common/src/types/tests/pricing.rs
@@ -162,6 +162,8 @@ fn every_fleet_model_string_is_priced() {
         "gpt-5.6-luna",
         "gemini-3.5-flash",
         "grok-build",
+        "grok-4.5",
+        "grok-4.6",
     ];
     // A nonzero split so a zero-rate row would still yield Some (we assert
     // coverage, not a specific figure).
@@ -170,9 +172,10 @@ fn every_fleet_model_string_is_priced() {
         output: 1_000,
         ..TokenUsage::default()
     };
-    // 2026-07-24 (not 07-19): must be on/after claude-opus-5's effective_from
-    // so its row is in range too, while still covering every other row below.
-    let at = dt("2026-07-24T00:00:00Z");
+    // 2026-08-13 (not 07-24): must be on/after grok-4.6's effective_from so
+    // its row is in range too, while still covering every other open-ended
+    // row (claude-opus-5 from 07-24, grok-4.5 from 08-12).
+    let at = dt("2026-08-13T00:00:00Z");
     for model in FLEET_MODELS {
         assert!(
             derive_cost_usd(model, at, &usage).is_some(),
@@ -333,6 +336,54 @@ fn malformed_openai_one_hour_writes_are_not_priced_as_free() {
     let cost = derive_cost_usd("gpt-5.6-sol", dt("2026-07-30T00:00:00Z"), &usage)
         .expect("nonzero fallback rate prices malformed 1h data");
     assert!((cost - 5.125).abs() < 1e-12, "cost was {cost}");
+}
+
+#[test]
+fn ground_truth_grok_4_6_uses_official_short_context_rates() {
+    // Official short-context rates retrieved 2026-08-14T03:45:16Z from
+    // https://docs.x.ai/developers/models/grok-4.6 and
+    // https://docs.x.ai/developers/pricing: $2.00 input / $0.50 cached /
+    // $6.00 output per 1M. 1M of each split → 2.0 + 0.5 + 6.0 = 8.5.
+    let usage = TokenUsage {
+        input: 1_000_000,
+        cache_read: 1_000_000,
+        cache_create: 0,
+        cache_create_1h: 0,
+        output: 1_000_000,
+    };
+    let cost = derive_cost_usd("grok-4.6", dt("2026-08-14T00:00:00Z"), &usage)
+        .expect("grok-4.6 is priced in the shipped table");
+    assert!((cost - 8.5).abs() < f64::EPSILON, "cost was {cost}");
+}
+
+#[test]
+fn grok_4_5_uses_official_short_context_rates() {
+    // Official short-context rates retrieved 2026-08-14T03:45:16Z from
+    // https://docs.x.ai/developers/models/grok-4.5 and
+    // https://docs.x.ai/developers/pricing: $2.00 input / $0.30 cached /
+    // $6.00 output per 1M. 1M of each split → 2.0 + 0.3 + 6.0 = 8.3.
+    let usage = TokenUsage {
+        input: 1_000_000,
+        cache_read: 1_000_000,
+        cache_create: 0,
+        cache_create_1h: 0,
+        output: 1_000_000,
+    };
+    let cost = derive_cost_usd("grok-4.5", dt("2026-08-14T00:00:00Z"), &usage)
+        .expect("grok-4.5 is priced in the shipped table");
+    assert!((cost - 8.3).abs() < f64::EPSILON, "cost was {cost}");
+}
+
+#[test]
+fn grok_malformed_one_hour_writes_are_not_priced_as_free() {
+    let usage = TokenUsage {
+        input: 1_000_000,
+        cache_create_1h: 100_000,
+        ..TokenUsage::default()
+    };
+    let cost = derive_cost_usd("grok-4.6", dt("2026-08-14T00:00:00Z"), &usage)
+        .expect("nonzero fallback rate prices malformed 1h data");
+    assert!((cost - 2.2).abs() < 1e-12, "cost was {cost}");
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-10772](https://orbit-cli.com/tasks/ORB-10772) — Add versioned price rows for live Grok model strings (grok-4.6 / grok-4.5)

### Description

## Problem

The versioned price table (`crates/orbit-common/assets/model_prices.yaml`, ORB-10338 / ADR-0245) has an xAI section, but it only prices `grok-build` (1.00/2.00, the old coding/build string). The Grok lane now defaults to `grok-4.6` (`GROK_DEFAULT_MODEL`, shipped executor, `[crews.grok].model`). Fleet cost lookup keys `InvocationRecord.model` exactly, so live Grok runs are unpriced.

## Why It Matters

Grok is a first-class orchestrator/provider lane (ORB-10742). Unpriced invocations silently drop out of derived-cost reporting. A `main` release today will ship the 4.6 default without a matching table row.

## Official starting point (re-verify; do not ship from this comment alone)

As of 2026-08-14, xAI docs list grok-4.6 short-context at $2.00 / 1M input, $0.50 / 1M cached, $6.00 / 1M output (https://docs.x.ai/developers/models/grok-4.6, https://docs.x.ai/developers/pricing). Long context ≥200k is a separate higher tier. Re-fetch those pages at implementation time.

## Constraints / Notes

- Append-only: new row + `effective_from`; close superseded current rows with `effective_until`. Never edit a shipped rate in place.
- Confirm exact telemetry strings (worker `modelUsage` keys / orbit `invocations.model`) before choosing the `model:` key. `grok`, `grok-build`, and `grok-4.6` are not interchangeable.
- xAI has no 1h cache tier in the Claude sense; follow the file's existing xAI/OpenAI pattern so a malformed nonzero 1h count is not priced as free.
- Do not invent Fast-tier or long-context rows from memory. Flag them in the execution_summary if official docs publish them and fleet usage does not yet need a separate key.
- The weekly report-only auto-task `model-price-audit` (cron `0 6 * * 1`, currently minted as ORB-10716) already exists and is enabled. This ticket seeds the missing Grok rows; it does not replace or duplicate that audit.

## Rollback

Revert the yaml/test commit. Lookup falls back to the previous table (`grok-build` only).

### Acceptance Criteria

- `crates/orbit-common/assets/model_prices.yaml` has an open-ended row keyed by each exact `InvocationRecord.model` string currently used for the Grok lane (at minimum `grok-4.6`; also `grok-4.5` if telemetry or crew/executor history still carries it). Rows are keyed by those strings, never by the crew name `grok`.
- Every new rate is copied from xAI's official pricing pages at retrieval time (https://docs.x.ai/developers/models/grok-4.6 and https://docs.x.ai/developers/pricing), with the source URL and retrieval timestamp recorded in the file comment or execution_summary. Training memory and third-party aggregators are not evidence.
- The existing `grok-build` row is not rewritten. If that string is no longer the current rate, close it with `effective_until` and append a new row; do not delete history.
- Standard short-context rates stay on the base row. Long-context (≥200k) or Fast-tier premiums are not folded into the base rates; add a distinct `model[…]` row only if the lookup contract requires it and official docs publish a distinct rate.
- `cargo test -p orbit-common --lib types::tests::pricing` passes, including any new ground-truth case keyed to the live Grok string and official rates. No live network, no `.orbit/knowledge/`.
- The weekly `model-price-audit` auto-task is left in place (do not add a second pricing auto-task). After the table includes the live Grok strings, the next audit covers them.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Appended open-ended `grok-4.6` and `grok-4.5` short-context rows to `crates/orbit-common/assets/model_prices.yaml`, keyed by those exact telemetry strings (never `grok`). Official rates retrieved 2026-08-14T03:45:16Z from https://docs.x.ai/developers/models/grok-4.6, https://docs.x.ai/developers/models/grok-4.5, and https://docs.x.ai/developers/pricing: grok-4.6 is $2.00 / $0.50 cached / $6.00 output per 1M; grok-4.5 is $2.00 / $0.30 cached / $6.00 output per 1M. xAI cache_create / cache_create_1h equal the input rate so a malformed 1h count is not free.
- Left the existing `grok-build` rate row untouched (still 1.00 / 0.25 cached / 2.00, open-ended). Comment only updated to note it is historical and that official `grok-build-0.1` is a different key.
- Added fleet-coverage entries plus ground-truth tests for both live strings in `crates/orbit-common/src/types/tests/pricing.rs`; moved the coverage timestamp to 2026-08-13 so grok-4.6's `effective_from` is in range.
Assessment: Live Grok invocations keyed `grok-4.6` (current `GROK_DEFAULT_MODEL` / executor / `[crews.grok].model` / `grok 1.0.3` default) and historical `grok-4.5` (ORB-10741 default; CLI menu still lists it) now derive cost. Scope stayed on the two context_files.
Validation: `cargo test -p orbit-common --lib types::tests::pricing` — 20 passed, 0 failed.
Strategic decisions:
- Did not add `grok-4.6[200k]` / Fast / Priority rows. Official docs publish ≥200k ($4.00 / $1.00 cached / $12.00 for 4.6; $4.00 / $0.60 cached / $12.00 for 4.5) and 2x Priority Processing, but those are not distinct `InvocationRecord.model` keys. Next `model-price-audit` (ORB-10716, left in place; no second pricing auto-task) can revisit if fleet usage starts emitting a suffix.
- Did not key `grok-4.5-build` (ORB-10741 smoke mention). Current requested/smoke identity is `grok-4.6`; constellation has no live `*-build` usage key.
- Did not close or rewrite `grok-build` even though official `grok-build-0.1` cached input is now $0.20 vs the shipped $0.25.
Design weaknesses / risks:
- Severity: low. Long-context Grok requests still derive at short-context base rates because lookup is by model string, not prompt size. Mitigation: flag for model-price-audit; add a distinct row only if telemetry starts emitting a suffix the lookup contract can match.
Deviations from original plan: none.
Recommended follow-ups: none required. Weekly model-price-audit will cover the new strings on its next run.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10772-6a7e8ed3`
- Behind base: 0
- Ahead of base: 1