### PR TITLE
Document task_pilot_pipeline invoke path in Orbit skills

### DIFF
--- a/crates/orbit-core/assets/skills/orbit-task-pilot/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-task-pilot/SKILL.md
@@ -27,6 +27,18 @@ Never expand the partition beyond the supplied IDs, except to cite a concrete de
 
 Task-pilot is an operational role, not a crew, actor identity, or scheduler.
 
+## Orchestrator handoff
+
+The Luna worker described here is read-only. It must not update tasks or invoke
+the pipeline. When ship traffic is high, the orchestrator should run
+`orbit job show task_pilot_pipeline` and then `orbit run job task_pilot_pipeline`
+so the apply step can persist validated selectors and reduce file-collision
+risk. Do not fill `context_files` inline under traffic. The zero-input job mode
+discovers eligible proposed/backlog tasks with empty selectors; explicit
+`task_ids` audits exactly the named tasks. An enabled workspace routine may
+already run the zero-input job on a schedule, but orchestrators can invoke an
+extra run before reservation or conflict checks.
+
 ## Result
 
 Return one partition object with the exact `partition_index` and `task_ids`, one assessment per supplied ID, and a short summary. Each assessment carries:

--- a/crates/orbit-core/assets/skills/orbit-task/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-task/SKILL.md
@@ -49,6 +49,23 @@ Description template:
 
 Exit: the task exists with a strong description, clear acceptance criteria, and — when filled — `context_files` naming only real modification targets.
 
+### Preparing selectors under traffic
+
+An empty `context_files` list is valid while a task is being authored. When an
+orchestrator needs selectors prepared before reservation or conflict checks,
+use the existing task-pilot job rather than filling the list inline:
+
+```bash
+orbit job show task_pilot_pipeline
+orbit run job task_pilot_pipeline
+```
+
+The zero-input mode discovers only proposed/backlog tasks with empty
+`context_files`; pass explicit `task_ids` to audit exactly named tasks. Its
+apply step persists only validated selectors, reducing file-collision risk. An
+enabled workspace routine may already run the zero-input job, but an extra run
+is appropriate when ship traffic is high.
+
 ## 2. Execute
 
 Carry a task from intent to verified implementation with explicit lifecycle tracking.

--- a/crates/orbit-core/assets/skills/orbit-workflow/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-workflow/SKILL.md
@@ -24,6 +24,29 @@ orbit run history --json
 orbit run show <run_id> --json
 ```
 
+### Task-pilot pipeline
+
+When an orchestrator needs task selectors prepared before ship traffic, inspect
+the job with `orbit job show task_pilot_pipeline`, then invoke it with:
+
+```bash
+orbit run job task_pilot_pipeline
+```
+
+With no input, the job discovers only `proposed`/`backlog` tasks in the
+invoking workspace whose `context_files` is empty. To audit specific tasks,
+pass their IDs explicitly; this mode audits exactly those tasks, including
+tasks that already have selectors:
+
+```bash
+orbit run job task_pilot_pipeline --input task_ids=ORB-12345,ORB-12346
+```
+
+Use this job before reservation or conflict checks when ship traffic is high.
+Do not fill `context_files` inline: the job's apply step writes only validated
+selectors, reducing file-collision risk. An enabled workspace routine may
+already run the zero-input job on a schedule; invoke an extra run when needed.
+
 ## Routines & scheduling
 
 1. **Host identity** — `orbit routine init --host-id <id>` (defaults to hostname); add `--install-clock` to install the per-user OS clock unit that runs `orbit sweep` every minute.

--- a/plugin/skills/orbit-task-pilot/SKILL.md
+++ b/plugin/skills/orbit-task-pilot/SKILL.md
@@ -27,6 +27,18 @@ Never expand the partition beyond the supplied IDs, except to cite a concrete de
 
 Task-pilot is an operational role, not a crew, actor identity, or scheduler.
 
+## Orchestrator handoff
+
+The Luna worker described here is read-only. It must not update tasks or invoke
+the pipeline. When ship traffic is high, the orchestrator should run
+`orbit job show task_pilot_pipeline` and then `orbit run job task_pilot_pipeline`
+so the apply step can persist validated selectors and reduce file-collision
+risk. Do not fill `context_files` inline under traffic. The zero-input job mode
+discovers eligible proposed/backlog tasks with empty selectors; explicit
+`task_ids` audits exactly the named tasks. An enabled workspace routine may
+already run the zero-input job on a schedule, but orchestrators can invoke an
+extra run before reservation or conflict checks.
+
 ## Result
 
 Return one partition object with the exact `partition_index` and `task_ids`, one assessment per supplied ID, and a short summary. Each assessment carries:

--- a/plugin/skills/orbit-task/SKILL.md
+++ b/plugin/skills/orbit-task/SKILL.md
@@ -49,6 +49,23 @@ Description template:
 
 Exit: the task exists with a strong description, clear acceptance criteria, and — when filled — `context_files` naming only real modification targets.
 
+### Preparing selectors under traffic
+
+An empty `context_files` list is valid while a task is being authored. When an
+orchestrator needs selectors prepared before reservation or conflict checks,
+use the existing task-pilot job rather than filling the list inline:
+
+```bash
+orbit job show task_pilot_pipeline
+orbit run job task_pilot_pipeline
+```
+
+The zero-input mode discovers only proposed/backlog tasks with empty
+`context_files`; pass explicit `task_ids` to audit exactly named tasks. Its
+apply step persists only validated selectors, reducing file-collision risk. An
+enabled workspace routine may already run the zero-input job, but an extra run
+is appropriate when ship traffic is high.
+
 ## 2. Execute
 
 Carry a task from intent to verified implementation with explicit lifecycle tracking.


### PR DESCRIPTION
## Task

[ORB-10786](https://orbit-cli.com/tasks/ORB-10786) — Document task_pilot_pipeline invoke path in Orbit skills

### Description

## Problem
`task_pilot_pipeline` already exists (ORB-10510) and a default `task_pilot` routine seeds on `orbit init` (ORB-10739). Daniel has enabled that routine on `ws_orbit` (hourly-ish) so empty `context_files` get filled before ship traffic collides on the same files.

Orchestrators can also invoke the job on demand. None of that is in the shipped Orbit skills.

Current gap:
- `orbit-task-pilot` is only the *worker* contract (read-only partition of 1–5 tasks; never mutate; never invoke a pipeline).
- `orbit-workflow` names `task_pilot` as an activity in a list and does not mention `job:task_pilot_pipeline`, zero-input vs explicit `task_ids`, or when an orchestrator should fire it.
- `orbit-task` says empty `context_files` is valid, but not that the pipeline is how they get filled under traffic.
- `orbit` router points at the role skill, not the job.

## Why It Matters
Without this, orchestrators either fill `context_files` inline (slow, collision-prone) or invent a luna task-pilot run instead of calling the existing job. The hourly routine is invisible to anyone reading skills.

## Constraints / Notes
- Docs only. Do not change job, activity, or routine YAML.
- Keep the worker contract intact: luna *inside* `activity:task_pilot` still must not invoke the pipeline or write tasks. Apply stays `apply_task_pilot_results`.
- Add an orchestrator-facing section: run `job:task_pilot_pipeline` (zero-input = discover proposed/backlog with empty `context_files`; explicit `task_ids` = audit those tasks). Use it when ship traffic is high so selectors exist before reservation/conflict checks. The workspace routine may already be doing this on a cron; invoke extra runs as needed.
- Touch both shipped copies where they exist (`crates/orbit-core/assets/skills/` and `plugin/skills/`). `orbit-workflow` is assets-only today.
- Cite `orbit job show task_pilot_pipeline` / `orbit run job task_pilot_pipeline` rather than inventing a second invoke surface.

### Acceptance Criteria

- orbit-workflow names job task_pilot_pipeline and how to run it with orbit run job task_pilot_pipeline. Zero-input mode only preflights proposed/backlog tasks with empty context_files. Explicit task_ids audits those tasks.
- An orchestrator-facing note (orbit router and/or orbit-task and/or a labeled section in orbit-task-pilot) says: do not fill context_files inline under traffic; invoke the job so apply writes selectors and reduces file-collision risk. Mention the optional enabled workspace routine.
- The luna worker contract in orbit-task-pilot stays read-only: never update tasks and never invoke the pipeline.
- Both shipped skill trees stay in sync where a skill exists in both (crates/orbit-core/assets/skills/ and plugin/skills/).

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Documented `orbit job show task_pilot_pipeline` and `orbit run job task_pilot_pipeline` in the assets-only `orbit-workflow` skill, including zero-input discovery, explicit `task_ids` audits, high-traffic timing, and the optional enabled workspace routine.
- Added matching orchestrator handoff guidance to both shipped `orbit-task-pilot` copies and both shipped `orbit-task` copies. The guidance keeps the Luna worker read-only, directs orchestrators away from inline `context_files` edits, and explains that the apply step persists validated selectors.
Assessment: Documentation-only change is scoped to the five declared skill files; shared skill copies are byte-identical and the worker prohibition on task updates and pipeline invocation remains explicit.
Validation:
- Passed `make ci-lint`.
- Passed `scripts/validate-codex-plugin.sh`, `git diff --check`, parity checks, and targeted acceptance-text checks.
- `make ci-fast` was attempted but failed at the repository-wide `cargo fmt --check` because of pre-existing formatting differences in unrelated Rust files (`crates/orbit-core/src/runtime/mod.rs`, `runtime/orbit_tool_host/session_log_tools.rs`, `runtime/session_log.rs`, and `runtime/tests/mod.rs`); the worktree contains no changes to those files.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10786-6a7e8edf`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*