### PR TITLE
MCP: forward explicit workspace selectors to the remote instead of validating against the local registry

### DIFF
--- a/crates/orbit-remote/src/mcp/host.rs
+++ b/crates/orbit-remote/src/mcp/host.rs
@@ -141,6 +141,47 @@ struct WorkspaceIdentityDocument {
     workspace_id: String,
 }
 
+/// Why a workspace selector did not resolve on this machine, and whether an
+/// owner machine could still answer for it.
+///
+/// ORB-10787: the local registry is authoritative only for what this machine
+/// coordinates. A checkoutless client's registry is legitimately empty, so
+/// "this machine has no record of that selector" is not evidence the selector
+/// is wrong — it is evidence this machine cannot be the one to judge it. That
+/// distinction is carried as a flag rather than re-derived from the message,
+/// because only [`Self::deferrable`] refusals may cross an owner route.
+struct SelectorRefusal {
+    error: OrbitError,
+    deferrable: bool,
+}
+
+impl SelectorRefusal {
+    /// A refusal about the selector itself, or about locally-known state:
+    /// relative-path grammar, an ambiguous registered name, an inactive
+    /// workspace, an unreadable registry. No owner can overturn it.
+    fn local(error: OrbitError) -> Self {
+        Self {
+            error,
+            deferrable: false,
+        }
+    }
+
+    /// A refusal that only says *this machine* has no usable record of the
+    /// selector. The owner machine holds the registry that answers.
+    fn unresolved_here(error: OrbitError) -> Self {
+        Self {
+            error,
+            deferrable: true,
+        }
+    }
+}
+
+impl From<SelectorRefusal> for OrbitError {
+    fn from(refusal: SelectorRefusal) -> Self {
+        refusal.error
+    }
+}
+
 /// Checkout-independent local MCP broker.
 ///
 /// Listing is sourced exclusively from the canonical schema-plus-policy
@@ -314,23 +355,34 @@ impl BrokerMcpHost {
     /// The binding is always attached when it exists — placement preflight, not
     /// this lookup, decides whether a call may proceed without one. A workspace
     /// registered here with no local checkout resolves to `(id, None)`.
+    ///
+    /// A failure is classified (ORB-10787): a grammar or locally-known-state
+    /// refusal is final, while "this machine's registry has no usable record of
+    /// it" leaves the selector open for an owner machine to judge.
     fn resolve_workspace(
         &self,
         selector: &str,
-    ) -> Result<(String, Option<ExactCheckoutBinding>), OrbitError> {
+    ) -> Result<(String, Option<ExactCheckoutBinding>), SelectorRefusal> {
         let path = Path::new(selector);
         if path.is_absolute() {
-            let binding = self.resolve_exact_checkout(path)?;
-            return Ok((binding.logical_workspace_id.clone(), Some(binding)));
+            // A path this registry already binds is local business: a checkout
+            // that no longer validates needs repair here, and its message says
+            // how. Any other path is one this machine simply does not hold.
+            return match self.resolve_exact_checkout(path) {
+                Ok(binding) => Ok((binding.logical_workspace_id.clone(), Some(binding))),
+                Err(error) if self.registry_claims_path(path) => Err(SelectorRefusal::local(error)),
+                Err(error) => Err(SelectorRefusal::unresolved_here(error)),
+            };
         }
         if selector.contains('/') || selector == "." || selector == ".." {
-            return Err(OrbitError::InvalidInput(format!(
+            return Err(SelectorRefusal::local(OrbitError::InvalidInput(format!(
                 "workspace path selector '{selector}' must be absolute; the MCP broker never resolves paths from process cwd"
-            )));
+            ))));
         }
 
         let registry_path = crate::workspace_registry::registry_path_for(&self.global_root);
-        let registry = crate::workspace_registry::load_registry_from(&registry_path)?;
+        let registry = crate::workspace_registry::load_registry_from(&registry_path)
+            .map_err(SelectorRefusal::local)?;
         // ADR-0361: registered name and logical id share one fail-closed lookup.
         let workspace =
             match crate::workspace_registry::resolve_logical_workspace(&registry, selector) {
@@ -338,7 +390,10 @@ impl BrokerMcpHost {
                 Err(error)
                     if crate::workspace_registry::is_ambiguous_workspace_selector(&error) =>
                 {
-                    return Err(error);
+                    // Two local records answer to this selector. Sending it
+                    // elsewhere would resolve a third meaning; make the operator
+                    // disambiguate instead.
+                    return Err(SelectorRefusal::local(error));
                 }
                 Err(_) => None,
             };
@@ -349,18 +404,25 @@ impl BrokerMcpHost {
                     continue;
                 };
                 if identity.workspace_id == selector {
-                    let binding = self.resolve_exact_checkout(&checkout.repo_root)?;
+                    // The selector matched a checkout registered here, so a
+                    // validation failure is this machine's to repair.
+                    let binding = self
+                        .resolve_exact_checkout(&checkout.repo_root)
+                        .map_err(SelectorRefusal::local)?;
                     return Ok((binding.logical_workspace_id.clone(), Some(binding)));
                 }
             }
         }
-        let workspace = workspace
-            .ok_or_else(|| crate::workspace_registry::unknown_workspace_selector(selector))?;
+        let workspace = workspace.ok_or_else(|| {
+            SelectorRefusal::unresolved_here(crate::workspace_registry::unknown_workspace_selector(
+                selector,
+            ))
+        })?;
         if workspace.status != WorkspaceStatus::Active {
-            return Err(OrbitError::InvalidInput(format!(
+            return Err(SelectorRefusal::local(OrbitError::InvalidInput(format!(
                 "logical workspace ID '{}' is not active",
                 workspace.id
-            )));
+            ))));
         }
         let Some(checkout) = registry
             .checkouts
@@ -378,6 +440,81 @@ impl BrokerMcpHost {
             Ok(binding) => Ok((binding.logical_workspace_id.clone(), Some(binding))),
             Err(_) => Ok((workspace.id.clone(), None)),
         }
+    }
+
+    /// Whether this machine's registry already binds `path` to one of its own
+    /// checkouts, by the same longest-prefix rule the CLI uses.
+    fn registry_claims_path(&self, path: &Path) -> bool {
+        let registry_path = crate::workspace_registry::registry_path_for(&self.global_root);
+        crate::workspace_registry::load_registry_from(&registry_path).is_ok_and(|registry| {
+            crate::workspace_registry::find_checkout_by_path(&registry, path).is_some()
+        })
+    }
+
+    /// The one owner route that may validate a selector this machine could not
+    /// resolve, or `None` when this session has no such route and the local
+    /// refusal stands.
+    ///
+    /// ORB-10787: a broker with no `[[owner]]` route is a purely local server —
+    /// there is no other party to defer to, so it keeps its fail-closed
+    /// behaviour unchanged. With routes configured, only the task surface may
+    /// cross one (`crosses_owner_route`), so nothing else defers either.
+    ///
+    /// The route must be unambiguous. Ownership normally comes from the local
+    /// registry, and an unresolved selector is exactly the case where that
+    /// answer is missing, so a second qualifying route would make Orbit *guess*
+    /// which machine the caller meant — and a task write to the wrong owner is
+    /// not recoverable by retrying. Refuse by name instead.
+    fn owner_route_for_unresolved_selector(
+        &self,
+        name: &str,
+        selector: &str,
+        placement: McpToolPlacement,
+        context: &ToolSessionContext,
+    ) -> Result<Option<String>, OrbitError> {
+        if self.owner_routes.is_empty()
+            || placement != McpToolPlacement::Owner
+            || !crosses_owner_route(name)
+        {
+            return Ok(None);
+        }
+        // A session without a scalar capability is refused for that reason a few
+        // lines later; do not convert it into a routing failure here.
+        let Ok(capability) = Self::scalar_capability(context) else {
+            return Ok(None);
+        };
+        let mut candidates = self
+            .owner_routes
+            .iter()
+            .filter(|(_, route)| route.allowed_capabilities.contains(&capability))
+            .map(|(machine_id, _)| machine_id.as_str());
+        let Some(first) = candidates.next() else {
+            return Ok(None);
+        };
+        let rest = candidates.collect::<Vec<_>>();
+        if rest.is_empty() {
+            return Ok(Some(first.to_string()));
+        }
+        let mut machines = vec![first];
+        machines.extend(rest);
+        Err(OrbitError::InvalidInput(format!(
+            "workspace selector '{selector}' is not registered on this machine and this session has \
+             routes to more than one owner machine ({}), so Orbit cannot tell which one owns it. \
+             Register the workspace locally with its owner machine, or use a session configured \
+             with a single owner route",
+            machines.join(", ")
+        )))
+    }
+
+    /// Rewrite an input frame that cannot cross a machine boundary as-is.
+    ///
+    /// Only `orbit.task.artifact.put` qualifies: its `source_path` names a file
+    /// on the caller's disk, so the caller-side frame carries the bytes instead.
+    fn prepared_owner_route_input(name: &str, input: Value) -> Result<Value, OrbitError> {
+        if name != "orbit.task.artifact.put" {
+            return Ok(input);
+        }
+        orbit_core::prepare_remote_task_artifact_put(input, std::env::current_dir().ok().as_deref())
     }
 
     fn local_checkout_unavailable(&self, workspace_id: &str) -> OrbitError {
@@ -836,7 +973,7 @@ impl BrokerMcpHost {
         }
 
         let selector = match Self::selector(&input, &context) {
-            Some(selector) => selector,
+            Some(selector) => selector.to_string(),
             None => {
                 let error = OrbitError::InvalidInput(format!(
                     "tool '{name}' requires a workspace selector; pass a non-empty `workspace` argument or initialize with `_meta.orbit.workspace`"
@@ -846,12 +983,77 @@ impl BrokerMcpHost {
             }
         };
         let placement = definition.policy.placement();
+        let with_context = name == "orbit.task.show"
+            && input
+                .get("with_context")
+                .or_else(|| input.get("withContext"))
+                .or_else(|| input.get("with-context"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
 
         // Resolve the workspace without demanding a checkout first: whether one
         // is required depends on where the workspace is owned.
-        let (workspace_id, binding) = match self.resolve_workspace(selector) {
+        let (workspace_id, binding) = match self.resolve_workspace(&selector) {
             Ok(resolved) => resolved,
-            Err(error) => {
+            Err(refusal) => {
+                // ORB-10787: this machine's registry is not authoritative for a
+                // workspace it does not coordinate. When the selector names
+                // nothing here and exactly one owner route can carry the call,
+                // forward the caller's selector verbatim and let the owner —
+                // which holds the registry that answers — validate it. Its
+                // rejection reaches the caller unchanged.
+                if refusal.deferrable && !with_context {
+                    match self
+                        .owner_route_for_unresolved_selector(name, &selector, placement, &context)
+                    {
+                        Ok(Some(owner_machine_id)) => {
+                            tracing::info!(
+                                tool = name,
+                                owner_machine_id = owner_machine_id.as_str(),
+                                local_refusal = %refusal.error,
+                                "forwarding an unresolved workspace selector to its owner machine"
+                            );
+                            let mut input = match Self::prepared_owner_route_input(name, input) {
+                                Ok(input) => input,
+                                Err(error) => {
+                                    self.record_preflight_denial(
+                                        name,
+                                        &Value::Null,
+                                        &context,
+                                        &error,
+                                    );
+                                    return Err(error);
+                                }
+                            };
+                            // The selector crosses as ordinary tool input, which
+                            // the owner validates, and never as session
+                            // provenance: those fields carry *validated*
+                            // workspace identity, and this machine has none to
+                            // offer. A selector announced only in session
+                            // metadata is made explicit here so the owner sees
+                            // what the caller named.
+                            if let Some(object) = input.as_object_mut() {
+                                object.insert(
+                                    "workspace".to_string(),
+                                    Value::String(selector.clone()),
+                                );
+                            }
+                            return self.remote_owner_call(
+                                name,
+                                input,
+                                context,
+                                &owner_machine_id,
+                                None,
+                            );
+                        }
+                        Ok(None) => {}
+                        Err(error) => {
+                            self.record_preflight_denial(name, &input, &context, &error);
+                            return Err(error);
+                        }
+                    }
+                }
+                let error = OrbitError::from(refusal);
                 self.record_preflight_denial(name, &input, &context, &error);
                 return Err(error);
             }
@@ -865,13 +1067,6 @@ impl BrokerMcpHost {
         };
         let owner_is_local = matches!(owner, OwnerResolution::Local);
 
-        let with_context = name == "orbit.task.show"
-            && input
-                .get("with_context")
-                .or_else(|| input.get("withContext"))
-                .or_else(|| input.get("with-context"))
-                .and_then(Value::as_bool)
-                .unwrap_or(false);
         if with_context && !owner_is_local {
             let error = OrbitError::InvalidInput(
                 "remote `orbit.task.show` cannot provide `with_context`; checkout-derived enrichment is local-only and local coordination fallback is forbidden"
@@ -927,18 +1122,13 @@ impl BrokerMcpHost {
                 object.insert("workspace".to_string(), Value::String(workspace_id.clone()));
             }
             if let OwnerResolution::Remote(owner_machine_id) = &owner {
-                if name == "orbit.task.artifact.put" {
-                    input = match orbit_core::prepare_remote_task_artifact_put(
-                        input,
-                        std::env::current_dir().ok().as_deref(),
-                    ) {
-                        Ok(prepared) => prepared,
-                        Err(error) => {
-                            self.record_preflight_denial(name, &Value::Null, &context, &error);
-                            return Err(error);
-                        }
-                    };
-                }
+                input = match Self::prepared_owner_route_input(name, input) {
+                    Ok(prepared) => prepared,
+                    Err(error) => {
+                        self.record_preflight_denial(name, &Value::Null, &context, &error);
+                        return Err(error);
+                    }
+                };
                 return self.remote_owner_call(
                     name,
                     input,

--- a/crates/orbit-remote/src/mcp/owner.rs
+++ b/crates/orbit-remote/src/mcp/owner.rs
@@ -10,7 +10,8 @@
 //!
 //! The endpoint re-reads local `host.toml` before listing and every call; it filters the
 //! canonical registry by exactly one placement class and one scalar capability;
-//! it accepts only stable logical workspace IDs, never caller paths; it invokes
+//! it resolves the caller's selector against its own registry and never against
+//! the filesystem ([ORB-10787]); it invokes
 //! the checkout-independent coordination executor without constructing
 //! `OrbitRuntime` or opening any connector; and it never opens another MCP/SSH
 //! connection.
@@ -176,33 +177,53 @@ impl OwnerMcpHost {
             })
     }
 
-    /// Resolve a stable logical workspace ID that this machine actually owns.
+    /// Resolve a workspace this machine actually owns from the caller's
+    /// selector.
     ///
     /// Refusing a non-owned workspace by name is what keeps the topology a
     /// star per workspace: a client that reached the wrong owner is told which
     /// machine to open a route to rather than being silently relayed there.
+    ///
+    /// ORB-10787: the selector grammar is [ADR-0361]'s — registered name,
+    /// logical ID, or absolute checkout path — because a checkoutless client
+    /// has no registry with which to pre-translate one form into another, and
+    /// this endpoint is the only party that can. Every form resolves against
+    /// *this machine's* registry: the endpoint stays checkoutless, consults no
+    /// filesystem, and never treats a caller path as a directory to open. A
+    /// path that names no registered checkout here is refused like any other
+    /// unknown selector.
     fn resolve_owned_workspace(&self, selector: &str) -> Result<String, OrbitError> {
-        if Path::new(selector).is_absolute()
-            || selector.contains('/')
-            || selector == "."
-            || selector == ".."
-        {
+        let path = Path::new(selector);
+        if !path.is_absolute() && (selector.contains('/') || selector == "." || selector == "..") {
             return Err(OrbitError::InvalidInput(format!(
-                "owner MCP workspace selector '{selector}' must be a stable logical workspace ID, never a checkout path"
+                "owner MCP workspace selector '{selector}' must be a registered workspace name, a stable logical workspace ID, or an absolute checkout path on the owner machine"
             )));
         }
         let registry_path = crate::workspace_registry::registry_path_for(&self.global_root);
         let registry = crate::workspace_registry::load_registry_from(&registry_path)?;
-        let workspace = registry
-            .workspaces
-            .into_iter()
-            .find(|workspace| workspace.id == selector)
-            .ok_or_else(|| {
-                OrbitError::InvalidInput(format!(
-                    "unknown logical workspace ID '{selector}' on owner machine '{}'",
-                    self.identity.machine_id
-                ))
-            })?;
+        let workspace = if path.is_absolute() {
+            crate::workspace_registry::find_workspace_by_path(&registry, path)
+                .cloned()
+                .ok_or_else(|| {
+                    OrbitError::InvalidInput(format!(
+                        "checkout path '{selector}' names no registered workspace on owner machine '{}'",
+                        self.identity.machine_id
+                    ))
+                })?
+        } else {
+            crate::workspace_registry::resolve_logical_workspace(&registry, selector)
+                .map_err(|error| {
+                    if crate::workspace_registry::is_ambiguous_workspace_selector(&error) {
+                        error
+                    } else {
+                        OrbitError::InvalidInput(format!(
+                            "unknown workspace selector '{selector}' on owner machine '{}'",
+                            self.identity.machine_id
+                        ))
+                    }
+                })?
+                .clone()
+        };
         if workspace.status != WorkspaceStatus::Active {
             return Err(OrbitError::InvalidInput(format!(
                 "logical workspace ID '{}' is not active",

--- a/crates/orbit-remote/src/mcp/tests/owner_link.rs
+++ b/crates/orbit-remote/src/mcp/tests/owner_link.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 
 use chrono::Utc;
 use orbit_common::types::{
-    AuditEventStatus, McpCapability, OrbitError, ToolSessionContext, Workspace, WorkspaceRegistry,
-    WorkspaceStatus,
+    AuditEventStatus, McpCapability, OrbitError, ToolSessionContext, Workspace, WorkspaceCheckout,
+    WorkspaceRegistry, WorkspaceStatus,
 };
 use orbit_mcp::{McpHost, OrbitToolServer};
 use rmcp::ServiceExt;
@@ -438,6 +438,209 @@ fn silent_peer_times_out_and_bounded_queue_saturates_before_handoff() {
     );
 }
 
+/// ORB-10787: a client that coordinates nothing still drives the task surface.
+///
+/// The client's `workspaces.json` is `{"workspaces": [], "checkouts": []}`, so
+/// no selector form can resolve against it. Every explicit selector — logical
+/// ID, registered name, and absolute checkout path — crosses the one configured
+/// owner route verbatim and is validated by the owner's registry, and the
+/// owner's rejection of an unknown selector reaches the caller unchanged.
+#[test]
+fn empty_client_registry_forwards_every_selector_form_to_the_owner() {
+    let owner = tempfile::tempdir().expect("owner root");
+    let client = tempfile::tempdir().expect("client root");
+    let owner_checkout = tempfile::tempdir().expect("owner checkout");
+    write_canary_identity(owner.path(), "hm_owner", "owner");
+    write_canary_identity(client.path(), "hm_client", "client");
+
+    let mut workspace = canary_workspace();
+    workspace.name = "canary".to_string();
+    save_canary_registry(
+        owner.path(),
+        &WorkspaceRegistry {
+            workspaces: vec![workspace],
+            checkouts: vec![WorkspaceCheckout::owner(
+                "ws_canary".to_string(),
+                owner_checkout.path().to_path_buf(),
+                owner_checkout.path().join(".orbit"),
+            )],
+            ..WorkspaceRegistry::default()
+        },
+    );
+    save_canary_registry(client.path(), &WorkspaceRegistry::default());
+    orbit_core::runtime::HubCoordinationExecutor::register_workspace(
+        owner.path(),
+        "ws_canary",
+        "canary",
+    )
+    .expect("owner coordination workspace");
+
+    let factory = Arc::new(RmcpOwnerFactory::new(owner.path().to_path_buf()));
+    let broker = BrokerMcpHost::new_with_owner_routes(
+        client.path().to_path_buf(),
+        BTreeMap::from([(
+            "hm_owner".to_string(),
+            OwnerRoute {
+                allowed_capabilities: BTreeSet::from([McpCapability::Agent]),
+                pool: Arc::new(canary_pool(
+                    Arc::clone(&factory) as Arc<dyn OwnerPeerFactory>,
+                    "hm_owner",
+                )),
+            },
+        )]),
+    );
+
+    let selectors = [
+        ("mcall-empty-id", "ws_canary".to_string()),
+        ("mcall-empty-name", "canary".to_string()),
+        (
+            "mcall-empty-path",
+            owner_checkout.path().to_string_lossy().into_owned(),
+        ),
+    ];
+    for (call_id, selector) in &selectors {
+        let created = broker
+            .call_tool(
+                "orbit.task.add",
+                json!({
+                    "workspace": selector,
+                    "title": format!("Created via {selector}"),
+                    "description": "The client registry knows nothing about this workspace",
+                    "model": "codex"
+                }),
+                canary_context(McpCapability::Agent, call_id),
+            )
+            .unwrap_or_else(|error| panic!("selector '{selector}' must reach the owner: {error}"));
+        assert_eq!(created["title"], format!("Created via {selector}"));
+    }
+
+    let listed = broker
+        .call_tool(
+            "orbit.task.list",
+            json!({"workspace": "ws_canary", "limit": 10}),
+            canary_context(McpCapability::Agent, "mcall-empty-list"),
+        )
+        .expect("task list through the owner route");
+    assert_eq!(
+        listed["items"].as_array().expect("task items").len(),
+        selectors.len(),
+        "every forwarded selector resolved to the same owner-side workspace: {listed}"
+    );
+
+    // The owner, not the client, judges an unknown selector — and its refusal
+    // is what the caller sees.
+    let unknown = broker
+        .call_tool(
+            "orbit.task.list",
+            json!({"workspace": "no-such-ws", "limit": 1}),
+            canary_context(McpCapability::Agent, "mcall-empty-unknown"),
+        )
+        .expect_err("the owner rejects a selector it does not know");
+    let unknown_message = unknown.to_string();
+    assert!(
+        unknown_message.contains("on owner machine 'hm_owner'"),
+        "the owner's own rejection must reach the caller: {unknown_message}"
+    );
+
+    // Every selector form, including the path, crossed the route unchanged.
+    let wire_calls = factory.wire_calls.lock().expect("wire calls");
+    let forwarded = wire_calls
+        .iter()
+        .filter_map(|(_, input, _)| {
+            input
+                .get("workspace")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+        .collect::<Vec<_>>();
+    for (_, selector) in &selectors {
+        assert!(
+            forwarded.contains(selector),
+            "selector '{selector}' must cross verbatim: {forwarded:?}"
+        );
+    }
+}
+
+/// The same empty registry, without any owner route, is an ordinary local
+/// server: there is no other party to defer to, so it still fails closed.
+#[test]
+fn empty_client_registry_without_a_route_still_fails_closed() {
+    let client = tempfile::tempdir().expect("client root");
+    write_canary_identity(client.path(), "hm_client", "client");
+    save_canary_registry(client.path(), &WorkspaceRegistry::default());
+    let broker = BrokerMcpHost::new(client.path().to_path_buf());
+
+    let refused = broker
+        .call_tool(
+            "orbit.task.list",
+            json!({"workspace": "ws_canary", "limit": 1}),
+            canary_context(McpCapability::Agent, "mcall-local-only"),
+        )
+        .expect_err("a local-only broker keeps validating against its own registry");
+    assert!(
+        refused.to_string().contains("ws_canary"),
+        "the local refusal names the rejected selector: {refused}"
+    );
+}
+
+/// With two usable routes, ownership is a guess — and a task write to the wrong
+/// owner cannot be undone by retrying. Refuse, naming both candidates.
+#[test]
+fn unresolved_selector_with_two_owner_routes_is_refused_before_any_call() {
+    let client = tempfile::tempdir().expect("client root");
+    write_canary_identity(client.path(), "hm_client", "client");
+    save_canary_registry(client.path(), &WorkspaceRegistry::default());
+
+    let factories = ["hm_owner", "hm_second"].map(|machine_id| {
+        let factory = Arc::new(FakeFactory::default());
+        let pool = OwnerLinkPool::with_factory(
+            "unused-hermetic-alias".to_string(),
+            machine_id.to_string(),
+            BTreeMap::from([(McpCapability::Agent, "agent-digest".to_string())]),
+            Arc::clone(&factory) as Arc<dyn OwnerPeerFactory>,
+            OwnerLinkLimits::default(),
+            Arc::new(MonotonicClock::default()),
+        )
+        .expect("owner link pool");
+        (
+            machine_id.to_string(),
+            factory,
+            OwnerRoute {
+                allowed_capabilities: BTreeSet::from([McpCapability::Agent]),
+                pool: Arc::new(pool),
+            },
+        )
+    });
+    let connect_logs = factories
+        .iter()
+        .map(|(_, factory, _)| Arc::clone(&factory.connects))
+        .collect::<Vec<_>>();
+    let broker = BrokerMcpHost::new_with_owner_routes(
+        client.path().to_path_buf(),
+        factories
+            .into_iter()
+            .map(|(machine_id, _, route)| (machine_id, route))
+            .collect(),
+    );
+
+    let refused = broker
+        .call_tool(
+            "orbit.task.list",
+            json!({"workspace": "ws_canary", "limit": 1}),
+            canary_context(McpCapability::Agent, "mcall-ambiguous-owner"),
+        )
+        .expect_err("Orbit must not guess which owner holds the workspace");
+    let message = refused.to_string();
+    assert!(message.contains("hm_owner"), "{message}");
+    assert!(message.contains("hm_second"), "{message}");
+    for connects in &connect_logs {
+        assert!(
+            connects.lock().expect("connects").is_empty(),
+            "no route may be opened while ownership is ambiguous"
+        );
+    }
+}
+
 fn write_canary_identity(root: &Path, machine_id: &str, host_id: &str) {
     std::fs::write(
         root.join("host.toml"),
@@ -460,6 +663,29 @@ fn canary_workspace() -> Workspace {
         created_at: Utc::now(),
         updated_at: Utc::now(),
     }
+}
+
+/// A link pool whose negotiated schema digests are the real ones, so the
+/// duplex owner endpoint accepts the handshake.
+fn canary_pool(factory: Arc<dyn OwnerPeerFactory>, owner_machine_id: &str) -> OwnerLinkPool {
+    let definitions = canonical_mcp_tool_definitions().expect("canonical definitions");
+    let digests = [McpCapability::Agent, McpCapability::Operator]
+        .into_iter()
+        .map(|capability| {
+            super::super::contract::owner_schema_digest(&definitions, capability)
+                .map(|digest| (capability, digest))
+        })
+        .collect::<Result<BTreeMap<_, _>, _>>()
+        .expect("owner schema digests");
+    OwnerLinkPool::with_factory(
+        "unused-hermetic-alias".to_string(),
+        owner_machine_id.to_string(),
+        digests,
+        factory,
+        OwnerLinkLimits::default(),
+        Arc::new(MonotonicClock::default()),
+    )
+    .expect("owner link pool")
 }
 
 fn save_canary_registry(root: &Path, registry: &WorkspaceRegistry) {

--- a/docs/design/mcp-bridge/2_design.md
+++ b/docs/design/mcp-bridge/2_design.md
@@ -1,7 +1,7 @@
 ---
 title: Orbit MCP Bridge — Design
 owner: claude
-last_updated: 2026-08-13
+last_updated: 2026-08-14
 last_validated: 2026-08-02
 status: Draft
 feature: mcp-bridge
@@ -11,7 +11,7 @@ summary: Target design for a local Orbit MCP broker with an SSH owner route, own
 tags: [mcp, remote-access, host-registry, bridge, ssh, routing]
 paths: ["crates/orbit-remote/**", "crates/orbit-mcp/**", "crates/orbit-core/**", "crates/orbit-tools/**", "crates/orbit-store/**", "crates/orbit-common/**"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access, orbit-search]
-related_artifacts: [ORB-00424, ORB-10257, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ORB-10330, ORB-10332, ORB-10534, ORB-10540, ORB-10544, ORB-10690, ORB-10710, ORB-10725, ORB-10727, ORB-10729, ORB-10761, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240, ADR-0303, ADR-0348, ADR-0350, ADR-0351, ADR-0354, ADR-0355, ADR-0356, ADR-0357, ADR-0358, ADR-0360]
+related_artifacts: [ORB-00424, ORB-10257, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ORB-10330, ORB-10332, ORB-10534, ORB-10540, ORB-10544, ORB-10690, ORB-10710, ORB-10725, ORB-10727, ORB-10729, ORB-10761, ORB-10787, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240, ADR-0303, ADR-0348, ADR-0350, ADR-0351, ADR-0354, ADR-0355, ADR-0356, ADR-0357, ADR-0358, ADR-0360]
 ---
 
 # Orbit MCP Bridge — Design
@@ -181,7 +181,9 @@ outright ([ORB-10727]).
 
 The owner-machine endpoint:
 
-- accepts registered workspace IDs, not caller filesystem paths;
+- resolves the caller's selector — registered name, logical ID, or absolute
+  checkout path — against **its own** registry, never against the filesystem
+  ([§3.1](#31-route-resolution-preserves-identity-and-checkout), [ORB-10787]);
 - executes coordination tools for the workspaces it owns;
 - refuses any other workspace with the owner named;
 - never opens another MCP/SSH connection; and
@@ -272,8 +274,49 @@ Composite tools declare their local prerequisites as well: `orbit.search
 kind=doc|all` requires a local checkout even though some of its branches could
 execute on the owner machine (§7).
 
-Only `workspace_id` crosses the owner route. Local absolute paths, replica paths,
-and worktree roots never do.
+Only a validated `workspace_id` crosses the owner route **as session
+provenance**. Local absolute paths, replica paths, and worktree roots are never
+presented as identity: those fields say "Orbit resolved this", and audit reads
+them as such.
+
+#### Deferred selector validation ([ORB-10787])
+
+The lookup above is authoritative only for what this machine coordinates. A
+checkoutless client's `workspaces.json` is legitimately empty, so *every*
+selector fails there — and a client-side registry miss can only produce false
+negatives for a workspace owned elsewhere. The refusal is therefore classified
+at the point it is raised:
+
+| Refusal | Meaning | Deferrable |
+| --- | --- | --- |
+| relative path, `.`, `..` | grammar; no registry can make it valid | no |
+| ambiguous registered name | two local records answer to it | no |
+| inactive workspace | locally known, deliberately not serving | no |
+| unreadable local registry | this machine is broken | no |
+| unknown name/ID, or a path this registry does not bind | this machine has no record of it | **yes** |
+
+A path the local registry *does* bind stays local even when it fails to
+validate: that is a checkout to repair here, and its message says how.
+
+A deferrable refusal is forwarded when *all* of the following hold: the session
+has at least one `[[owner]]` route (a broker with none is a purely local server
+and keeps failing closed, unchanged), the tool is on the task surface that may
+cross a route ([§4.2](#42-owner-preflight) rule 3), and exactly one configured
+route grants the session's capability. Two usable routes make ownership a guess,
+and a task write to the wrong owner is not undone by retrying, so that case is
+refused by name.
+
+The forwarded selector travels as ordinary **tool input**, which the owner
+validates against its own registry, and the session workspace fields stay empty:
+the client has no validated identity to offer and must not manufacture one. The
+owner's acceptance or rejection is what the caller sees — so an operator who
+mistypes a workspace is told so by the machine that would know.
+
+Cost: a path is machine-scoped, so a client naming a path that exists only on
+the client resolves nothing and is refused by the owner rather than locally. The
+refusal is one round trip slower and names the owner machine instead of the
+client, which is the honest answer — the client was never the authority — but it
+is a longer path to the same "unknown workspace" conclusion.
 
 ### 3.2 Session metadata extension
 

--- a/docs/design/mcp-bridge/4_decisions.md
+++ b/docs/design/mcp-bridge/4_decisions.md
@@ -1,7 +1,7 @@
 ---
 title: Orbit MCP Bridge — Decisions
 owner: claude
-last_updated: 2026-08-13
+last_updated: 2026-08-14
 last_validated: 2026-08-02
 status: Draft
 feature: mcp-bridge
@@ -11,7 +11,7 @@ summary: ADR log for mcp-bridge, including the retired singular-hub contract and
 tags: [mcp, remote-access, host-registry, bridge]
 paths: ["crates/orbit-remote/**", "crates/orbit-mcp/**", "crates/orbit-core/**", "crates/orbit-tools/**", "crates/orbit-store/**"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access]
-related_artifacts: [ORB-00424, ORB-10245, ORB-10708, ORB-10710, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ORB-10330, ORB-10332, ORB-10690, ORB-10761, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240, ADR-0348, ADR-0350, ADR-0351, ADR-0352, ADR-0354, ADR-0355, ADR-0356, ADR-0357, ADR-0358, ADR-0360]
+related_artifacts: [ORB-00424, ORB-10245, ORB-10708, ORB-10710, ORB-10262, ORB-10267, ORB-10268, ORB-10269, ORB-10271, ORB-10272, ORB-10276, ORB-10302, ORB-10319, ORB-10330, ORB-10332, ORB-10690, ORB-10761, ORB-10787, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232, ADR-0235, ADR-0240, ADR-0348, ADR-0350, ADR-0351, ADR-0352, ADR-0354, ADR-0355, ADR-0356, ADR-0357, ADR-0358, ADR-0360]
 ---
 
 # Orbit MCP Bridge — Decisions
@@ -664,6 +664,19 @@ names both the owning workspace and `orbit mcp serve` as the alternative.
   ([ADR-0360]), so a client whose only evidence is a tracked `.orbit/` directory
   starts the proxy while a machine with a registered on-disk checkout is still
   refused.
+- [ORB-10787] — made the client-side registry lookup non-authoritative for a
+  workspace owned elsewhere ([2_design.md §3.1](./2_design.md#31-route-resolution-preserves-identity-and-checkout)).
+  A broker classifies each selector refusal: grammar, ambiguity, inactive
+  workspace, and a broken local registry stay local, while "this machine has no
+  record of it" is forwarded verbatim over the single qualifying owner route for
+  the owner to validate. The owner endpoint therefore accepts [ADR-0361]'s full
+  selector grammar against its own registry rather than logical IDs alone, and
+  the selector crosses as tool input rather than as session provenance. A broker
+  with no `[[owner]]` route is unchanged. This is a behaviour change to a
+  documented invariant and warrants its own allocated ADR; the executing
+  activity was not granted `orbit.adr.add`, so the decision is recorded here and
+  in the design doc without a global ID (same treatment as [ORB-10448] in
+  [../mcp-session-context/4_decisions.md](../mcp-session-context/4_decisions.md)).
 - [ORB-10332] — removed the `orbit.host.list` MCP discovery tool as unused; the
   `orbit.workspace.list` / `orbit.crew.list` MCP discovery tools remain. The
   `orbit host list` CLI command it deferred to is itself withdrawn with the fleet

--- a/docs/design/mcp-session-context/4_decisions.md
+++ b/docs/design/mcp-session-context/4_decisions.md
@@ -11,7 +11,7 @@ doc_role: decisions
 tags: ["mcp-session-context", "mcp", "workspace"]
 paths: ["crates/orbit-mcp/**", "crates/orbit-remote/src/mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool/**", "crates/orbit-cli/src/**"]
 related_features: ["mcp-session-context", "task-artifacts"]
-related_artifacts: ["ORB-00256", "ORB-00406", "ORB-10228", "ORB-10262", "ORB-10319", "ORB-10448", "ORB-10690", "ORB-10758", "ORB-10769", "ADR-0181", "ADR-0199", "ADR-0149", "ADR-0348", "ADR-0361"]
+related_artifacts: ["ORB-00256", "ORB-00406", "ORB-10228", "ORB-10262", "ORB-10319", "ORB-10448", "ORB-10690", "ORB-10758", "ORB-10769", "ORB-10787", "ADR-0181", "ADR-0199", "ADR-0149", "ADR-0348", "ADR-0361"]
 ---
 
 # MCP Session Context — Decisions
@@ -170,5 +170,6 @@ Resolution order is unchanged: explicit per-call / `--workspace` selector, then 
 - [ORB-10448] made both ADRs reachable from a managed worktree activity: the `workspace` selector is now advertised on every workspace-scoped tool, and hub-placement coordination reads address the checkout-identity partition. Neither changes ADR-0181 or ADR-0199 semantics; see [2_design.md §3a–3b](./2_design.md). The advertised-selector contract is a breaking `tools/list` schema change (RELEASING.md) and may warrant its own allocated ADR — this task's activity was not granted `orbit.adr.add`, so no global ID was allocated.
 - [ORB-10758] unified the workspace selector grammar across the CLI `--workspace` flag and MCP workspace-scoped tools ([ADR-0361]).
 - [ORB-10769] bound CLI `orbit tool run` to the same fail-closed workspace selector above the tools.
+- [ORB-10787] extended [ADR-0361]'s grammar to the owner MCP endpoint, which previously accepted logical IDs alone, so a checkoutless client that cannot pre-translate a selector can name a workspace the same way everywhere; the broker forwards a selector its own registry cannot resolve instead of refusing it ([../mcp-bridge/2_design.md §3.1](../mcp-bridge/2_design.md#31-route-resolution-preserves-identity-and-checkout)).
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10787](https://orbit-cli.com/tasks/ORB-10787) — MCP: forward explicit workspace selectors to the remote instead of validating against the local registry

### Description

An MCP client that proxies to a remote Orbit still resolves an explicit
`workspace` selector against the *local* machine's registry, so a caller that
names a workspace unambiguously is refused before the request ever reaches the
machine that owns the checkout.

`resolve_workspace` in `crates/orbit-remote/src/mcp/host.rs:317` takes an
absolute path selector straight into `resolve_exact_checkout` (line 322-325),
which loads this machine's `workspaces.json` and requires exactly one matching
registered checkout (line 405-422). On a client machine with an empty registry
that is always zero matches:

    orbit_task_list(workspace: "/Users/daniel/workspace/constellation")
    -> invalid_input: workspace path '/Users/daniel/workspace/constellation'
       does not resolve to exactly one registered local checkout (matched 0);
       register or repair the checkout binding before retrying

The check itself is not wrong — it is wrong to run it *here*. When the session
proxies to a remote Orbit, the far side is the only party that can say whether
a selector names a real checkout, and it holds the registry that answers.
A client-side registry lookup can only produce false negatives.

Wanted: in a remote/broker session, forward an explicit workspace selector to
the remote and let it validate, rather than failing closed against a local
registry that is not authoritative for that call. Local-mode serving should
keep today's behaviour.

Reported by Daniel from a Mac client (host_id `Daniels-Mac-mini.local`,
machine_id `hm_7e92ce9bbdb2165f`) whose registry is empty
(`{"workspaces": [], "checkouts": []}`) while `.orbit/` exists in the checkout.

Caveat on the repro: the error above was produced by a *local* stdio serve
(`orbit mcp serve --capabilities operator`, no SSH host), where refusing is
arguably correct since there is no remote to defer to. The behaviour change
targets the `--mode remote` / broker path (ADR-0350); confirm the same selector
fails there before implementing, and decide explicitly whether a local-only
serve should keep failing closed.

### Acceptance Criteria

- A remote/broker MCP session accepts an explicit workspace selector (absolute checkout path
- registered name
- or ws_* id) without consulting the client machine's workspace registry
- Validation of that selector happens on the remote/owner side
- and its rejection is surfaced to the caller unchanged
- Local-mode (non-remote) serving keeps today's fail-closed behaviour
- with the intended split documented
- Regression coverage: a client with an empty workspaces.json can drive a task-level tool against a remote-owned workspace

## Execution Summary

<details>
<summary>Click to expand</summary>

Explicit workspace selectors now reach the machine that owns the checkout instead of being
refused by a client registry that is not authoritative for the call.

**Repro check first.** `orbit mcp serve --mode remote <host>` (proxy.rs) relays raw stdio to
the far side and performs no local resolution, so the reported failure cannot occur there.
The path that does fail is the **broker with `[[owner]]` routes**: it must map the selector to
a `workspace_id` via `workspaces.json` before it can find the owner, so a client with an empty
registry can never reach a configured route at all. That is the surface changed here. A broker
with no `[[owner]]` route is a purely local server and is deliberately left fail-closed.

**Broker (`crates/orbit-remote/src/mcp/host.rs`).** `resolve_workspace` now returns a
classified `SelectorRefusal` instead of a bare `OrbitError`. Non-deferrable: relative-path
grammar, an ambiguous registered name, an inactive workspace, an unreadable local registry, and
an absolute path this registry *does* bind but that fails to validate (a local repair, whose
message says how). Deferrable: an unknown name/ID, and a path this registry does not bind. A
deferrable refusal is forwarded when the session has `[[owner]]` routes, the tool is on the
task surface that may cross a route (`crosses_owner_route`), and exactly one configured route
grants the session capability; two qualifying routes are refused by name, because ownership
would be a guess and a task write to the wrong owner is not undone by retrying. The selector
crosses as ordinary tool input — the session workspace/workspace_id fields stay empty, so a
caller path is never presented as validated identity and `validate_remote_call_context`'s
"paths are forbidden" invariant is untouched. A selector announced only via
`_meta.orbit.workspace` is made explicit in the input frame so the owner sees what was named.
`with_context` still refuses locally. The `orbit.task.artifact.put` source_path→bytes rewrite
was factored into `prepared_owner_route_input` and now covers both remote dispatch paths.

**Owner (`crates/orbit-remote/src/mcp/owner.rs`).** `resolve_owned_workspace` accepts
ADR-0361's full grammar (registered name, `ws_*` ID, absolute checkout path) resolved against
*its own* registry — a checkoutless client has no registry with which to pre-translate one form
into another, and the owner is the only party that can. It stays checkoutless: the path form is
a registry lookup (`find_workspace_by_path`), never a directory it opens. Ownership, status and
"owned by another machine" refusals are unchanged, and the owner's rejection is what the caller
sees.

**Coverage** (`crates/orbit-remote/src/mcp/tests/owner_link.rs`, real duplex RMCP owner peer):
a client whose `workspaces.json` is `{"workspaces": [], "checkouts": []}` drives
`orbit.task.add`/`orbit.task.list` against a remote-owned workspace by ID, by registered name,
and by the owner's absolute checkout path; each selector is asserted to cross the wire verbatim.
An unknown selector is refused by the owner ("on owner machine 'hm_owner'"). The same empty
registry with no route still fails closed. Two qualifying routes refuse before any link opens.

**Docs.** mcp-bridge/2_design.md §2.2 and §3.1 (new "Deferred selector validation" subsection
with the refusal table, the tool-input-not-provenance split, and the cost), plus task references
in mcp-bridge/4_decisions.md and mcp-session-context/4_decisions.md. This changes a documented
invariant and warrants its own ADR ID; the activity was not granted `orbit.adr.add`, so the
decision is recorded in the design doc and decisions log without a global ID (same treatment as
ORB-10448) — allocate one at review if wanted.

**Validation.** `make ci-fast` and `make ci-lint` pass. `cargo test -p orbit-remote`: 172 pass,
2 fail — `mcp::tests::canonical_mcp_policy_conforms_to_frozen_v1_fixture` and
`mcp::tests::discovery::remote_owns_the_exact_global_discovery_definitions` — and
`orbit-cli --test mcp_roundtrip::mcp_serve_tools_list_matches_production_snapshot` also fails.
All three are pre-existing on this base: ORB-10784 (139bd3f9) added `orbit.session_log.*` tools
without updating the frozen conformance fixture or the tools/list snapshot. This task touches no
tool definitions.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10787-6a7e98a0`
- Behind base: 0
- Ahead of base: 1