### PR TITLE
Add a guarded release-prep auto-task for Orbit

### DIFF
--- a/.orbit/auto_tasks/release-prep.yaml
+++ b/.orbit/auto_tasks/release-prep.yaml
@@ -1,0 +1,117 @@
+schemaVersion: 1
+name: release-prep
+description: Guarded workspace-local release preparation probe
+enabled: true
+schedule:
+  # Poll hourly; the generic scheduler collapses missed slots and preserves
+  # the pending slot while an equivalent probe is still open.
+  every_minutes: 60
+template:
+  title: Check whether the next Orbit release is ready to prepare
+  description: |
+    You are the release-preparation probe for this workspace. This is a
+    report-first gate. The probe may read Orbit tasks, Git history, tags, and
+    RELEASING.md, and may create or update one canonical release-preparation
+    task only after the workspace is eligible. It must never edit repository
+    files or release state during the gate.
+
+    ## 1. Deterministic unfinished-work gate
+
+    Query all tasks in `backlog`, `in-progress`, and `review` through the Orbit
+    task surface. Sort the resulting IDs lexicographically before reporting
+    them. Treat a task as exempt only when its tags contain the exact
+    provenance tag `auto-task:release-prep`; this exempts this probe and any
+    equivalent open instance from this same definition. Do not exempt tasks
+    merely because they have a `release`, `release-prep`, or another
+    `auto-task:<name>` tag.
+
+    If any non-exempt task remains, record the complete sorted list of blocking
+    task IDs in this probe's `execution_summary`, state that release
+    preparation is blocked, and stop successfully. Do not create or update a
+    release task, change task statuses, modify files, write release metadata,
+    commit, tag, push, publish, merge, or promote a branch. A later scheduler
+    slot must be able to retry the same gate.
+
+    ## 2. Deterministic no-release gate
+
+    Find the latest reachable release tag with the equivalent of
+    `git tag --merged HEAD --list 'v*' --sort=-version:refname | head -n 1`.
+    Use that tag as the exclusive survey boundary. If there is no reachable
+    `v*` tag, report that no release baseline is available and stop without
+    release changes. Otherwise inspect commits in `<latest-tag>..HEAD` using
+    the no-merge survey prescribed by `RELEASING.md`. If the range is empty,
+    record the exact tag and the fact that there is nothing to release in this
+    probe's `execution_summary`, then stop successfully without creating or
+    updating a release task or changing repository or release state.
+
+    ## 3. Eligible preparation handoff
+
+    When the two gates pass, record exact evidence in the probe's
+    `execution_summary`: the sorted task query and its empty blocker result,
+    the latest reachable tag, the surveyed commit IDs and subjects, referenced
+    Orbit task IDs, the candidate semver bump, and every breaking-change
+    candidate with the commit/task evidence that caused it to be flagged.
+    Apply Orbit's pre-1.0 policy from `RELEASING.md`: a candidate patch bump
+    for non-breaking work and a candidate minor bump for breaking candidates.
+    The candidate is not a human-confirmed classification.
+
+    Then locate the canonical open release-preparation task by the exact
+    title pattern `Prepare v<X.Y.Z> release` and the `release` tag. Search
+    deterministically and select the lexicographically smallest matching task
+    ID if more than one already exists; never create a second canonical task.
+    If none exists, create exactly one task with that title, the `release` tag,
+    type `chore`, and the candidate version and evidence in its description.
+    Carry the release runbook context selectors
+    `file:CHANGELOG.md`, `file:Cargo.toml`, `file:Cargo.lock`,
+    `file:plugin/.claude-plugin/plugin.json`, and
+    `file:plugin/npm/package.json` onto that canonical task.
+    If one exists, update only that canonical task with the fresh candidate,
+    survey evidence, and breaking-change candidates. Preserve the human review
+    boundary and do not change it to done. Report the selected or newly-created
+    task ID, and any pre-existing duplicate candidates, in this probe's
+    `execution_summary`.
+
+    The canonical task must instruct its executor to follow `RELEASING.md`,
+    including the release checklist and the four versioned release files. The
+    handoff stops after surveying, candidate semver analysis, and creating or
+    updating that one task. It must not commit, tag, push, publish, promote or
+    merge branches, bump versions, edit `CHANGELOG.md`, or ask for or record
+    human confirmation that a breaking-change candidate is accepted. Those
+    actions require the later human-approved release task.
+
+    ## Deterministic validation scenarios
+
+    The execution summary must make clear which scenario ran:
+
+    - With another unfinished task, report its ID and make no release-state or
+      repository changes; only exact `auto-task:release-prep` instances are
+      excluded.
+    - With no other unfinished task and no commits after the latest reachable
+      `v*` tag, report the tag and "nothing to release" and make no release
+      changes.
+    - With an eligible commit range, record the survey, candidate bump, and
+      breaking candidates, then create or update exactly one canonical
+      `release` task.
+
+    A repeated pass must reuse the open `release-prep` probe via
+    `skip_if_open` and reuse the one canonical release task rather than
+    creating duplicates.
+  acceptance_criteria:
+  - The unfinished-work gate reports sorted blocking task IDs and exempts only open tasks carrying the exact auto-task:release-prep provenance tag.
+  - A blocked or no-release pass changes no repository or release state and completes with evidence in execution_summary.
+  - An eligible pass records the latest reachable v* tag, commit survey, candidate semver bump, and breaking-change candidates with exact evidence.
+  - An eligible pass creates or updates exactly one canonical Prepare v<X.Y.Z> release task carrying the release tag and reports its task ID.
+  - The canonical task stops before commits, tags, pushes, publishing, branch promotion, version bumps, CHANGELOG edits, or human confirmation of breaking-change classification, and points to RELEASING.md.
+  - Repeated passes do not duplicate the open probe or the canonical release-preparation task.
+  task_type: chore
+  tags:
+  - release-prep
+  - no-diff-expected
+  priority: high
+  crew: luna
+  status: backlog
+dedupe: skip_if_open
+created_by: codex
+created_at: 2026-08-14T04:40:00Z
+updated_by: codex
+updated_at: 2026-08-14T04:40:00Z


### PR DESCRIPTION
## Task

[ORB-10790](https://orbit-cli.com/tasks/ORB-10790) — Add a guarded release-prep auto-task for Orbit

### Description

## Problem
Orbit release preparation currently depends on an operator noticing that the delivery backlog has drained and manually starting the release runbook. Add a workspace-local auto-task definition that periodically mints a release-prep probe and starts preparation only when Orbit has no other unfinished delivery work.

## Why It Matters
For a quick release, the handoff from shipping the final backlog item to surveying and preparing the next version should be reliable without requiring an operator to watch the queue continuously.

## Constraints / Notes
- Implement this as a checked-in Orbit auto-task definition using the existing auto-task primitive; do not add a bespoke scheduler or provider-specific code.
- Use an enabled, bounded polling interval and dedupe policy `skip_if_open`.
- The minted task must treat itself and equivalent open instances from the same auto-task as exempt when evaluating the gate. All other backlog, in-progress, or review work blocks release preparation.
- If blocked, make no repository or release-state changes, report the blocking task IDs, and complete cleanly so a later scheduled slot can retry.
- If no commits exist after the latest reachable `v*` release tag, make no release changes and report that there is nothing to release.
- When eligible, begin the preparation portion of `RELEASING.md`: survey commits since the latest tag, identify the candidate semantic version and breaking-change candidates, and create or update one canonical release-preparation task. Do not commit, tag, push, publish, merge to `main`, or classify breaking changes as human-confirmed.
- Reuse the `release` tag and include exact evidence in the execution summary so an orchestrator can continue the release safely.
- The definition should be workspace-specific; do not add it to Orbit defaults seeded into unrelated workspaces.

## Rollback
The operator can disable the definition with `orbit.auto_task.toggle` without deleting its history.

### Acceptance Criteria

- `orbit auto-task show release-prep --json` succeeds and reports an enabled workspace-local definition with a bounded cron or interval schedule and `dedupe: skip_if_open`.
- A deterministic validation with at least one other task in backlog, in-progress, or review shows that the minted probe performs no release-state or repository changes and reports the blocking task IDs while excluding only its own auto-task instances.
- A deterministic validation with no other unfinished tasks but no commits since the latest reachable `v*` tag performs no release changes and reports that there is nothing to release.
- An eligible validation run surveys commits since the latest reachable release tag, records a candidate semver bump and breaking-change candidates, and creates or updates exactly one canonical release-preparation task tagged `release`.
- The generated task instructions stop before commit, tag, push, publish, branch promotion, or human confirmation of breaking-change classification, and point to `RELEASING.md` as the execution contract.
- Repeated scheduler passes do not create duplicate open `release-prep` tasks or duplicate canonical release-preparation tasks.
- The change is limited to the Orbit workspace definition and does not alter the default auto-task catalog for other workspaces.
- `make ci-fast` passes and the definition can be parsed by the installed Orbit CLI.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `.orbit/auto_tasks/release-prep.yaml`, the only workspace-local change. It is enabled, polls every 60 minutes, uses `skip_if_open`, and carries `release-prep` plus `no-diff-expected` template tags.
- The template defines the exact unfinished-work exemption (`auto-task:release-prep` only), sorted blocker reporting, no-release/no-commit behavior, latest reachable `v*` tag surveying, candidate pre-1.0 semver analysis, breaking-change evidence, and deterministic create-or-update of one `Prepare v<X.Y.Z> release` task tagged `release`.
- The canonical handoff carries `file:CHANGELOG.md`, `file:Cargo.toml`, `file:Cargo.lock`, `file:plugin/.claude-plugin/plugin.json`, and `file:plugin/npm/package.json`, points to `RELEASING.md`, and stops before version bumps, CHANGELOG edits, commit, tag, push, publish, branch promotion, merge, or human confirmation of breaking-change classification.
Validation:
- `orbit auto-task show release-prep --json` succeeded and parsed the definition as enabled with `schedule.every_minutes: 60`, `dedupe: skip_if_open`, and the expected template; explicit field checks passed.
- `make ci-fast` passed.
- `git diff --check` passed for the new definition; the worktree contains only the untracked definition file.
Assessment: The scoped data-only implementation reuses the existing generic auto-task scheduler and keeps release preparation workspace-local. No code, default catalog, scheduler, or release-state behavior was changed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10790-6a7e9bed`
- Behind base: 0
- Ahead of base: 1