### PR TITLE
Add workspace_auto_pipeline sequencer for leaf-then-one-epic auto dispatch

### DIFF
--- a/.orbit/resources/activities/classify_workspace_auto_tasks.yaml
+++ b/.orbit/resources/activities/classify_workspace_auto_tasks.yaml
@@ -1,0 +1,36 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: classify_workspace_auto_tasks
+spec:
+  type: deterministic
+  description: >
+    Classify one workspace logistics tick. An in-progress epic root holds the
+    tick, including late-arriving loose work. Otherwise eligible loose backlog
+    leaves win and are returned in list_backlog priority/age order, then the
+    first eligible backlog epic root is selected. Epic children are never
+    selected.
+  input_schema_json:
+    type: object
+    properties:
+      max_tasks:
+        type: number
+        minimum: 1
+        maximum: 500
+  output_schema_json:
+    type: object
+    required: [decision, loose_task_ids, epic_task_id]
+    properties:
+      decision:
+        type: string
+        enum: [ship, hold, epic, empty]
+      loose_task_ids:
+        type: array
+        items:
+          type: string
+      epic_task_id:
+        oneOf:
+          - type: string
+          - type: "null"
+  action: classify_workspace_auto_tasks
+  config: {}

--- a/.orbit/resources/activities/list_backlog_tasks.yaml
+++ b/.orbit/resources/activities/list_backlog_tasks.yaml
@@ -7,11 +7,12 @@ spec:
   description: >
     Materialize the current workspace backlog as an ordered task list for
     the auto-pipeline. In automatic mode it filters to `status: backlog` with
-    all task dependencies satisfied and
+    all task dependencies satisfied, excludes `epic`-tagged roots and every
+    descendant of such a root (`epic_root` / `epic_child`), and
     drops any backlog parent/subtask group whose `context_files` overlap the
     active task-lock surface from `in-progress` or `review` tasks. Automatic
-    mode includes an `excluded` array that attributes those pre-gate lock
-    exclusions; it does not report status-based admission or `max_tasks`
+    mode includes an `excluded` array that attributes epic-family and pre-gate
+    lock exclusions; it does not report status-based admission or `max_tasks`
     truncation. Explicit `task_ids` input is treated as an override, skips
     conflict filtering, and omits `excluded`.
     Sorts critical → high → medium → low, then by `created_at` ascending so
@@ -78,7 +79,7 @@ spec:
               type: string
             reason:
               type: string
-              enum: [context_lock_conflict, group_member_conflict]
+              enum: [context_lock_conflict, epic_child, epic_root, group_member_conflict]
             conflicts:
               type: array
               items:

--- a/.orbit/resources/jobs/workspace_auto_pipeline.yaml
+++ b/.orbit/resources/jobs/workspace_auto_pipeline.yaml
@@ -1,0 +1,58 @@
+# Workspace logistics sequencer [ORB-10788 / ADR-0365].
+#
+# One tick drains eligible loose leaves first, holds while an epic root is
+# active, otherwise starts exactly one backlog epic root. Hold and empty are
+# successful no-ops. The external clock owns repeated ticks.
+
+schemaVersion: 2
+kind: Job
+metadata:
+  name: workspace_auto_pipeline
+spec:
+  state: enabled
+  kind: workflow
+  max_active_runs: 1
+  default_input:
+    max_tasks: 50
+
+  steps:
+    - id: resolve_ship_input
+      target: activity:resolve_workspace_ship_input
+      default_input: {}
+
+    - id: classify
+      target: activity:classify_workspace_auto_tasks
+      default_input:
+        max_tasks: "{{ input.max_tasks }}"
+
+    - id: ship_leaves
+      when: "{{ steps.classify.output.decision }} == ship"
+      target: activity:invoke_and_wait
+      default_input:
+        job_name: task_auto_pipeline
+        run_input:
+          task_ids: "{{ steps.classify.output.loose_task_ids }}"
+          mode: "{{ steps.resolve_ship_input.output.mode }}"
+          base_branch: "{{ steps.resolve_ship_input.output.base_branch }}"
+
+    - id: require_leaf_success
+      when: "{{ steps.classify.output.decision }} == ship"
+      target: activity:pipeline_success_guard
+      default_input:
+        context: workspace auto leaf ship
+        result: "{{ steps.ship_leaves.output }}"
+
+    - id: run_epic
+      when: "{{ steps.classify.output.decision }} == epic"
+      target: activity:invoke_and_wait
+      default_input:
+        job_name: epic_pipeline
+        run_input:
+          epic_task_id: "{{ steps.classify.output.epic_task_id }}"
+
+    - id: require_epic_success
+      when: "{{ steps.classify.output.decision }} == epic"
+      target: activity:pipeline_success_guard
+      default_input:
+        context: workspace auto epic run
+        result: "{{ steps.run_epic.output }}"

--- a/.orbit/resources/jobs/workspace_ship_pipeline.yaml
+++ b/.orbit/resources/jobs/workspace_ship_pipeline.yaml
@@ -1,11 +1,8 @@
-# Workspace-local ship wrapper.
+# Workspace-local unattended wrapper.
 #
-# The routine supplies no input. The first deterministic step resolves the
-# active runtime's ship mode and configured base branch; the second invokes
-# and waits for the existing task_auto_pipeline with no explicit task IDs.
-# Waiting keeps this wrapper active for the full shipment, so the routine's
-# `overlap: forbid` covers the child run. Empty backlog is the child's existing
-# clean no-op path.
+# Existing sweeps retain this stable job name while delegating one tick to the
+# workspace sequencer. Waiting keeps this wrapper active for the full child
+# run, so the routine's `overlap: forbid` covers leaf or epic dispatch.
 schemaVersion: 2
 kind: Job
 metadata:
@@ -15,18 +12,14 @@ spec:
   kind: workflow
   max_active_runs: 1
   steps:
-    - id: resolve_ship_input
-      target: activity:resolve_workspace_ship_input
-      default_input: {}
-
-    - id: ship
+    - id: auto
       target: activity:invoke_and_wait
       default_input:
-        job_name: task_auto_pipeline
-        run_input: "{{ steps.resolve_ship_input.output }}"
+        job_name: workspace_auto_pipeline
+        run_input: {}
 
-    - id: require_ship_success
+    - id: require_auto_success
       target: activity:pipeline_success_guard
       default_input:
-        context: workspace ship pipeline
-        result: "{{ steps.ship.output }}"
+        context: workspace auto pipeline
+        result: "{{ steps.auto.output }}"

--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -285,6 +285,12 @@ impl Commands {
             Commands::Run(command) => {
                 use super::run::RunSubcommand;
                 let (subcommand, target_type, target_id, runtime_need) = match &command.command {
+                    RunSubcommand::Auto(_) => (
+                        "auto",
+                        Some("workflow"),
+                        Some("auto"),
+                        RuntimeNeed::Required,
+                    ),
                     RunSubcommand::Ship(_) => (
                         "ship",
                         Some("workflow"),

--- a/crates/orbit-cli/src/command/run/auto.rs
+++ b/crates/orbit-cli/src/command/run/auto.rs
@@ -1,0 +1,47 @@
+//! `orbit run auto` workspace logistics entrypoint.
+
+use clap::Args;
+use orbit_core::OrbitRuntime;
+
+use crate::command::{CommandOut, CommandOutput, Execute};
+
+use super::support::{WorkflowDispatchResult, print_workflow_dispatch_results};
+
+pub(super) const AUTO_WORKFLOW: &str = "auto";
+
+#[derive(Args)]
+#[command(
+    about = "Run one workspace logistics tick (loose leaves, then one epic)",
+    override_usage = "orbit run auto [OPTIONS]",
+    after_help = "Inspect submitted runs with `orbit run history -j workspace_auto_pipeline` and `orbit run show <RUN_ID>`."
+)]
+pub struct AutoCommand {
+    /// Output as JSON.
+    #[arg(long)]
+    pub json: bool,
+    /// Token for this workspace's exclusive claim, when another operator holds
+    /// one. Falls back to `ORBIT_WORKSPACE_CLAIM_TOKEN`.
+    #[arg(long)]
+    pub claim_token: Option<String>,
+}
+
+impl Execute for AutoCommand {
+    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        let invoke = runtime.submit_workspace_auto_run(None, self.claim_token.as_deref())?;
+        let run = WorkflowDispatchResult {
+            workflow_alias: AUTO_WORKFLOW,
+            job_id: invoke.job_name,
+            run_id: invoke.run_id,
+            state: if invoke.queued {
+                "queued".to_string()
+            } else {
+                "submitted".to_string()
+            },
+            attempt: 1,
+            error_code: None,
+            error_message: None,
+        };
+        print_workflow_dispatch_results(AUTO_WORKFLOW, &[run], self.json)?;
+        Ok(CommandOutput::Silent)
+    }
+}

--- a/crates/orbit-cli/src/command/run/command.rs
+++ b/crates/orbit-cli/src/command/run/command.rs
@@ -3,6 +3,7 @@ use orbit_core::OrbitRuntime;
 
 use crate::command::{CommandOut, Execute};
 
+use super::auto;
 use super::cancel::RunCancelArgs;
 use super::events::RunEventsArgs;
 use super::history::RunHistoryArgs;
@@ -16,6 +17,7 @@ use super::triage;
 
 const RUN_AFTER_HELP: &str = "\
 Workflow entrypoints:
+  orbit run auto
   orbit run ship [task_id ...]
   orbit run ship-sweep [--dry-run] [--json]
   orbit run triage [task_id ...]
@@ -46,6 +48,7 @@ Maintenance:
 {usage-heading} {usage}
 
 Workflows:
+  auto        Run one workspace logistics tick (loose leaves, then one epic)
   ship        Ship backlog or explicitly selected tasks through the gated task pipeline
   ship-sweep  Dispatch ship runs in every registered workspace with ready backlog tasks
   triage      Triage tasks blocked by failed runs; re-backlog environmental failures
@@ -78,6 +81,8 @@ impl Execute for RunCommand {
 
 #[derive(Subcommand)]
 pub enum RunSubcommand {
+    /// Run one workspace logistics tick (loose leaves, then one epic)
+    Auto(auto::AutoCommand),
     /// Ship backlog or explicitly selected tasks through the gated task pipeline
     Ship(ship::ShipCommand),
     /// Deprecated alias for `orbit run ship --mode local`
@@ -107,6 +112,7 @@ pub enum RunSubcommand {
 impl Execute for RunSubcommand {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
         match self {
+            RunSubcommand::Auto(command) => command.execute(runtime),
             RunSubcommand::Ship(command) => command.execute(runtime),
             RunSubcommand::ShipLocal(command) => command.execute(runtime),
             // Normally dispatched before runtime init (see main.rs); the

--- a/crates/orbit-cli/src/command/run/mod.rs
+++ b/crates/orbit-cli/src/command/run/mod.rs
@@ -1,3 +1,4 @@
+pub mod auto;
 mod cancel;
 mod command;
 mod events;

--- a/crates/orbit-cli/src/command/run/ship.rs
+++ b/crates/orbit-cli/src/command/run/ship.rs
@@ -182,7 +182,7 @@ fn legacy_ship_form(value: &str) -> Option<&'static str> {
         }
         "pr" => Some("`orbit run ship pr` was replaced by `orbit run ship --mode pr <TASK_ID>`"),
         "auto" | "ship-auto" => Some(
-            "`orbit run ship auto` was replaced by `orbit run ship` (auto mode runs when no task ids are supplied)",
+            "`orbit run ship auto` was replaced by `orbit run auto`; `orbit run ship` remains leaf-only auto shipment when no task ids are supplied",
         ),
         "list" | "show" => Some(
             "`orbit run ship list/show` was removed; use `orbit run history -j <JOB_ID>` and `orbit run show <RUN_ID>` for run inspection",

--- a/crates/orbit-cli/src/command/run/tests/mod.rs
+++ b/crates/orbit-cli/src/command/run/tests/mod.rs
@@ -114,6 +114,18 @@ fn parses_ship_auto_mode_defaults() {
 }
 
 #[test]
+fn parses_workspace_auto_defaults() {
+    let command = parse_run(&["orbit", "run", "auto"]);
+    match command.command {
+        RunSubcommand::Auto(args) => {
+            assert!(!args.json);
+            assert!(args.claim_token.is_none());
+        }
+        _ => panic!("expected auto"),
+    }
+}
+
+#[test]
 fn parses_explicit_ship_defaults() {
     let command = parse_run(&["orbit", "run", "ship", "T1", "T2"]);
     match command.command {

--- a/crates/orbit-cli/src/command/run/tests/ship.rs
+++ b/crates/orbit-cli/src/command/run/tests/ship.rs
@@ -137,7 +137,7 @@ fn ship_rejects_removed_auto_positional_form() {
     let err = build_plan(&ship_args(&["auto"], ShipMode::Pr, None), "agent-main")
         .expect_err("legacy auto form should fail");
     assert!(
-        err.to_string().contains("orbit run ship"),
+        err.to_string().contains("orbit run auto"),
         "unexpected error: {err}"
     );
 }

--- a/crates/orbit-common/src/types/activity_job/mod.rs
+++ b/crates/orbit-common/src/types/activity_job/mod.rs
@@ -19,6 +19,7 @@ macro_rules! deterministic_action_catalog {
             core {
                 ApplyTriageDispositions => "apply_triage_dispositions",
                 ApplyTaskPilotResults => "apply_task_pilot_results",
+                ClassifyWorkspaceAutoTasks => "classify_workspace_auto_tasks",
                 ContextConflictCheck => "context_conflict_check",
                 GateStarvationFail => "gate_starvation_fail",
                 InvokeAndWait => "invoke_and_wait",

--- a/crates/orbit-core/assets/activities/classify_workspace_auto_tasks.yaml
+++ b/crates/orbit-core/assets/activities/classify_workspace_auto_tasks.yaml
@@ -1,0 +1,36 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: classify_workspace_auto_tasks
+spec:
+  type: deterministic
+  description: >
+    Classify one workspace logistics tick. An in-progress epic root holds the
+    tick, including late-arriving loose work. Otherwise eligible loose backlog
+    leaves win and are returned in list_backlog priority/age order, then the
+    first eligible backlog epic root is selected. Epic children are never
+    selected.
+  input_schema_json:
+    type: object
+    properties:
+      max_tasks:
+        type: number
+        minimum: 1
+        maximum: 500
+  output_schema_json:
+    type: object
+    required: [decision, loose_task_ids, epic_task_id]
+    properties:
+      decision:
+        type: string
+        enum: [ship, hold, epic, empty]
+      loose_task_ids:
+        type: array
+        items:
+          type: string
+      epic_task_id:
+        oneOf:
+          - type: string
+          - type: "null"
+  action: classify_workspace_auto_tasks
+  config: {}

--- a/crates/orbit-core/assets/activities/list_backlog_tasks.yaml
+++ b/crates/orbit-core/assets/activities/list_backlog_tasks.yaml
@@ -7,11 +7,12 @@ spec:
   description: >
     Materialize the current workspace backlog as an ordered task list for
     the auto-pipeline. In automatic mode it filters to `status: backlog` with
-    all task dependencies satisfied and
+    all task dependencies satisfied, excludes `epic`-tagged roots and every
+    descendant of such a root (`epic_root` / `epic_child`), and
     drops any backlog parent/subtask group whose `context_files` overlap the
     active task-lock surface from `in-progress` or `review` tasks. Automatic
-    mode includes an `excluded` array that attributes those pre-gate lock
-    exclusions; it does not report status-based admission or `max_tasks`
+    mode includes an `excluded` array that attributes epic-family and pre-gate
+    lock exclusions; it does not report status-based admission or `max_tasks`
     truncation. Explicit `task_ids` input is treated as an override, skips
     conflict filtering, and omits `excluded`.
     Sorts critical → high → medium → low, then by `created_at` ascending so
@@ -78,7 +79,7 @@ spec:
               type: string
             reason:
               type: string
-              enum: [context_lock_conflict, group_member_conflict]
+              enum: [context_lock_conflict, epic_child, epic_root, group_member_conflict]
             conflicts:
               type: array
               items:

--- a/crates/orbit-core/assets/jobs/workspace_auto_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/workspace_auto_pipeline.yaml
@@ -1,0 +1,58 @@
+# Workspace logistics sequencer [ORB-10788 / ADR-0365].
+#
+# One tick drains eligible loose leaves first, holds while an epic root is
+# active, otherwise starts exactly one backlog epic root. Hold and empty are
+# successful no-ops. The external clock owns repeated ticks.
+
+schemaVersion: 2
+kind: Job
+metadata:
+  name: workspace_auto_pipeline
+spec:
+  state: enabled
+  kind: workflow
+  max_active_runs: 1
+  default_input:
+    max_tasks: 50
+
+  steps:
+    - id: resolve_ship_input
+      target: activity:resolve_workspace_ship_input
+      default_input: {}
+
+    - id: classify
+      target: activity:classify_workspace_auto_tasks
+      default_input:
+        max_tasks: "{{ input.max_tasks }}"
+
+    - id: ship_leaves
+      when: "{{ steps.classify.output.decision }} == ship"
+      target: activity:invoke_and_wait
+      default_input:
+        job_name: task_auto_pipeline
+        run_input:
+          task_ids: "{{ steps.classify.output.loose_task_ids }}"
+          mode: "{{ steps.resolve_ship_input.output.mode }}"
+          base_branch: "{{ steps.resolve_ship_input.output.base_branch }}"
+
+    - id: require_leaf_success
+      when: "{{ steps.classify.output.decision }} == ship"
+      target: activity:pipeline_success_guard
+      default_input:
+        context: workspace auto leaf ship
+        result: "{{ steps.ship_leaves.output }}"
+
+    - id: run_epic
+      when: "{{ steps.classify.output.decision }} == epic"
+      target: activity:invoke_and_wait
+      default_input:
+        job_name: epic_pipeline
+        run_input:
+          epic_task_id: "{{ steps.classify.output.epic_task_id }}"
+
+    - id: require_epic_success
+      when: "{{ steps.classify.output.decision }} == epic"
+      target: activity:pipeline_success_guard
+      default_input:
+        context: workspace auto epic run
+        result: "{{ steps.run_epic.output }}"

--- a/crates/orbit-core/assets/jobs/workspace_ship_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/workspace_ship_pipeline.yaml
@@ -1,11 +1,8 @@
-# Workspace-local ship wrapper.
+# Workspace-local unattended wrapper.
 #
-# The routine supplies no input. The first deterministic step resolves the
-# active runtime's ship mode and configured base branch; the second invokes
-# and waits for the existing task_auto_pipeline with no explicit task IDs.
-# Waiting keeps this wrapper active for the full shipment, so the routine's
-# `overlap: forbid` covers the child run. Empty backlog is the child's existing
-# clean no-op path.
+# Existing sweeps retain this stable job name while delegating one tick to the
+# workspace sequencer. Waiting keeps this wrapper active for the full child
+# run, so the routine's `overlap: forbid` covers leaf or epic dispatch.
 schemaVersion: 2
 kind: Job
 metadata:
@@ -15,18 +12,14 @@ spec:
   kind: workflow
   max_active_runs: 1
   steps:
-    - id: resolve_ship_input
-      target: activity:resolve_workspace_ship_input
-      default_input: {}
-
-    - id: ship
+    - id: auto
       target: activity:invoke_and_wait
       default_input:
-        job_name: task_auto_pipeline
-        run_input: "{{ steps.resolve_ship_input.output }}"
+        job_name: workspace_auto_pipeline
+        run_input: {}
 
-    - id: require_ship_success
+    - id: require_auto_success
       target: activity:pipeline_success_guard
       default_input:
-        context: workspace ship pipeline
-        result: "{{ steps.ship.output }}"
+        context: workspace auto pipeline
+        result: "{{ steps.auto.output }}"

--- a/crates/orbit-core/src/command/activity.rs
+++ b/crates/orbit-core/src/command/activity.rs
@@ -27,6 +27,10 @@ pub(crate) const DEFAULT_ACTIVITY_FILES: &[(&str, &str)] = &[
         include_str!("../../assets/activities/apply_task_pilot_results.yaml"),
     ),
     (
+        "classify_workspace_auto_tasks",
+        include_str!("../../assets/activities/classify_workspace_auto_tasks.yaml"),
+    ),
+    (
         "epic_orchestrator",
         include_str!("../../assets/activities/epic_orchestrator.yaml"),
     ),

--- a/crates/orbit-core/src/command/job/catalog.rs
+++ b/crates/orbit-core/src/command/job/catalog.rs
@@ -56,6 +56,10 @@ const DEFAULT_JOB_FILES: &[(&str, &str)] = &[
         include_str!("../../../assets/jobs/workspace_ship_pipeline.yaml"),
     ),
     (
+        "workspace_auto_pipeline",
+        include_str!("../../../assets/jobs/workspace_auto_pipeline.yaml"),
+    ),
+    (
         "worktree_gc_pipeline",
         include_str!("../../../assets/jobs/worktree_gc_pipeline.yaml"),
     ),

--- a/crates/orbit-core/src/command/job/pipeline.rs
+++ b/crates/orbit-core/src/command/job/pipeline.rs
@@ -101,12 +101,30 @@ impl OrbitRuntime {
         // pipeline record. Auto mode intentionally carries no task ids: the
         // worker discovers eligible backlog tasks after it starts.
         for task_id in task_ids {
-            self.get_task(task_id)?;
+            let task = self.get_task(task_id)?;
+            if task.tags.iter().any(|tag| tag == "epic") {
+                return Err(OrbitError::InvalidInput(format!(
+                    "task '{task_id}' is an epic root and cannot be shipped as a leaf; use `orbit run auto` or `orbit run job epic_pipeline`"
+                )));
+            }
         }
         if let Some(conflict) = self.in_flight_ship_run_for_tasks(task_ids)? {
             return Err(conflict);
         }
         self.submit_pipeline_run(workflow.job_id, input, None, actor)
+    }
+
+    /// Submit one workspace logistics tick (`workspace_auto_pipeline`).
+    pub fn submit_workspace_auto_run(
+        &self,
+        actor: Option<&str>,
+        claim_token: Option<&str>,
+    ) -> Result<PipelineInvokeResult, OrbitError> {
+        self.require_workspace_claim("orbit.workflow.auto", claim_token)?;
+        let workflow =
+            crate::command::workflow::find_workflow(crate::command::workflow::AUTO_WORKFLOW_ALIAS)
+                .ok_or_else(|| OrbitError::InvalidInput("unknown workflow 'auto'".to_string()))?;
+        self.submit_pipeline_run(workflow.job_id, json!({}), None, actor)
     }
 
     /// The duplicate-dispatch refusal for the newest non-terminal run already

--- a/crates/orbit-core/src/command/job/tests/catalog.rs
+++ b/crates/orbit-core/src/command/job/tests/catalog.rs
@@ -53,6 +53,10 @@ const DEFAULT_JOB_FILES: &[(&str, &str)] = &[
         include_str!("../../../../assets/jobs/workspace_ship_pipeline.yaml"),
     ),
     (
+        "workspace_auto_pipeline",
+        include_str!("../../../../assets/jobs/workspace_auto_pipeline.yaml"),
+    ),
+    (
         "worktree_gc_pipeline",
         include_str!("../../../../assets/jobs/worktree_gc_pipeline.yaml"),
     ),
@@ -787,38 +791,27 @@ fn triage_pipeline_is_single_flight_and_gates_on_candidates() {
 }
 
 #[test]
-fn workspace_ship_pipeline_resolves_then_waits_for_normal_auto_ship() {
+fn workspace_ship_pipeline_waits_for_workspace_auto_sequencer() {
     let yaml = DEFAULT_JOB_FILES
         .iter()
         .find_map(|(name, yaml)| (*name == "workspace_ship_pipeline").then_some(*yaml))
         .expect("workspace ship pipeline default exists");
     let asset = load_job_asset(yaml).expect("parse workspace ship pipeline");
     assert_eq!(asset.spec.max_active_runs, 1);
-    assert_eq!(asset.spec.steps.len(), 3);
-    assert_eq!(asset.spec.steps[0].id, "resolve_ship_input");
-    assert_eq!(asset.spec.steps[1].id, "ship");
-    assert_eq!(asset.spec.steps[2].id, "require_ship_success");
+    assert_eq!(asset.spec.steps.len(), 2);
+    assert_eq!(asset.spec.steps[0].id, "auto");
+    assert_eq!(asset.spec.steps[1].id, "require_auto_success");
 
     match &asset.spec.steps[0].body {
         JobV2StepBody::TargetRef(target) => {
-            assert_eq!(target.target, "activity:resolve_workspace_ship_input");
-        }
-        other => panic!("expected resolver target ref, got {other:?}"),
-    }
-    match &asset.spec.steps[1].body {
-        JobV2StepBody::TargetRef(target) => {
             assert_eq!(target.target, "activity:invoke_and_wait");
             let input = target.default_input.as_ref().expect("ship input");
-            assert_eq!(input["job_name"], "task_auto_pipeline");
-            assert_eq!(
-                input["run_input"],
-                Value::String("{{ steps.resolve_ship_input.output }}".to_string())
-            );
-            assert!(input.get("task_ids").is_none());
+            assert_eq!(input["job_name"], "workspace_auto_pipeline");
+            assert_eq!(input["run_input"], json!({}));
         }
         other => panic!("expected invoke-and-wait target ref, got {other:?}"),
     }
-    match &asset.spec.steps[2].body {
+    match &asset.spec.steps[1].body {
         JobV2StepBody::TargetRef(target) => {
             assert_eq!(target.target, "activity:pipeline_success_guard");
         }
@@ -827,6 +820,57 @@ fn workspace_ship_pipeline_resolves_then_waits_for_normal_auto_ship() {
     assert!(!yaml.contains("auto_ship"));
     assert!(!yaml.contains("ship-sweep"));
     assert!(!yaml.contains("type: shell"));
+}
+
+#[test]
+fn workspace_auto_pipeline_is_single_flight_and_conditionally_dispatches() {
+    let yaml = DEFAULT_JOB_FILES
+        .iter()
+        .find_map(|(name, yaml)| (*name == "workspace_auto_pipeline").then_some(*yaml))
+        .expect("workspace auto pipeline exists");
+    assert_eq!(
+        yaml,
+        include_str!("../../../../../../.orbit/resources/jobs/workspace_auto_pipeline.yaml"),
+        "shipped and workspace workspace_auto_pipeline resources must remain byte-identical"
+    );
+    let asset = load_job_asset(yaml).expect("workspace auto pipeline parses");
+    assert_eq!(asset.spec.max_active_runs, 1);
+    assert_eq!(asset.spec.steps[0].id, "resolve_ship_input");
+    assert_eq!(asset.spec.steps[1].id, "classify");
+    let JobV2StepBody::TargetRef(classify) = &asset.spec.steps[1].body else {
+        panic!("classify step must use the deterministic activity");
+    };
+    assert_eq!(classify.target, "activity:classify_workspace_auto_tasks");
+
+    let ship = &asset.spec.steps[2];
+    assert_eq!(ship.id, "ship_leaves");
+    assert_eq!(
+        ship.when.as_deref(),
+        Some("{{ steps.classify.output.decision }} == ship")
+    );
+    let JobV2StepBody::TargetRef(ship_target) = &ship.body else {
+        panic!("ship step must invoke and wait");
+    };
+    assert_eq!(ship_target.target, "activity:invoke_and_wait");
+    assert_eq!(
+        ship_target.default_input.as_ref().expect("ship input")["job_name"],
+        "task_auto_pipeline"
+    );
+
+    let epic = &asset.spec.steps[4];
+    assert_eq!(epic.id, "run_epic");
+    assert_eq!(
+        epic.when.as_deref(),
+        Some("{{ steps.classify.output.decision }} == epic")
+    );
+    let JobV2StepBody::TargetRef(epic_target) = &epic.body else {
+        panic!("epic step must invoke and wait");
+    };
+    assert_eq!(epic_target.target, "activity:invoke_and_wait");
+    assert_eq!(
+        epic_target.default_input.as_ref().expect("epic input")["job_name"],
+        "epic_pipeline"
+    );
 }
 
 #[test]
@@ -953,6 +997,7 @@ fn orchestration_jobs_do_not_enable_generic_recovery() {
         "task_gate_pipeline",
         "task_triage_pipeline",
         "workspace_ship_pipeline",
+        "workspace_auto_pipeline",
     ] {
         let yaml = DEFAULT_JOB_FILES
             .iter()

--- a/crates/orbit-core/src/command/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/command/tests/job_pipeline.rs
@@ -486,6 +486,59 @@ fn ship_submission_refuses_a_missing_explicit_task_before_persisting_a_run() {
 }
 
 #[test]
+fn ship_submission_refuses_an_epic_root_but_allows_its_child() {
+    let (_root, runtime) = test_runtime();
+    let epic = runtime
+        .add_task(TaskAddParams {
+            title: "Epic root".to_string(),
+            description: "Supervisor-owned fixture".to_string(),
+            tags: vec!["epic".to_string()],
+            ..Default::default()
+        })
+        .expect("create epic root");
+    let child = runtime
+        .add_task(TaskAddParams {
+            parent_id: Some(epic.id.clone()),
+            title: "Epic child".to_string(),
+            description: "Leaf fixture".to_string(),
+            ..Default::default()
+        })
+        .expect("create epic child");
+
+    let error = runtime
+        .submit_ship_run(
+            ShipMode::Local,
+            Some("main"),
+            std::slice::from_ref(&epic.id),
+            Some("test"),
+            None,
+        )
+        .expect_err("epic root must be refused before dispatch");
+    assert!(matches!(error, OrbitError::InvalidInput(message) if message.contains("epic root")));
+    assert!(
+        runtime
+            .list_job_runs(JobRunListParams::default())
+            .expect("list job runs")
+            .is_empty(),
+        "root refusal must happen before pipeline persistence"
+    );
+
+    let child_error = runtime
+        .submit_ship_run(
+            ShipMode::Local,
+            Some("main"),
+            std::slice::from_ref(&child.id),
+            Some("test"),
+            None,
+        )
+        .expect_err("fixture intentionally has no deployed job asset");
+    assert!(
+        matches!(child_error, OrbitError::NotFound { .. }),
+        "epic child must pass leaf admission and reach job lookup: {child_error:?}"
+    );
+}
+
+#[test]
 fn ship_submission_mixed_explicit_selection_identifies_the_missing_task() {
     let (_root, runtime) = test_runtime();
     let existing_id = add_backlog_task(&runtime);

--- a/crates/orbit-core/src/command/workflow.rs
+++ b/crates/orbit-core/src/command/workflow.rs
@@ -9,6 +9,10 @@ pub struct Workflow {
 
 pub const WORKFLOWS: &[Workflow] = &[
     Workflow {
+        alias: "auto",
+        job_id: "workspace_auto_pipeline",
+    },
+    Workflow {
         alias: "ship",
         job_id: "task_auto_pipeline",
     },
@@ -24,6 +28,7 @@ pub fn find_workflow(name: &str) -> Option<&'static Workflow> {
 
 /// Canonical alias of the gated ship workflow (`task_auto_pipeline`).
 pub const SHIP_WORKFLOW_ALIAS: &str = "ship";
+pub const AUTO_WORKFLOW_ALIAS: &str = "auto";
 
 /// Pipeline mode for the `ship` workflow: open a PR or apply locally.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -130,6 +135,13 @@ mod tests {
         assert!(find_workflow("ship-auto").is_none());
         assert!(find_workflow("ship-local").is_none());
         assert!(find_workflow("review-pr").is_none());
+    }
+
+    #[test]
+    fn auto_workflow_routes_to_workspace_sequencer() {
+        let workflow = find_workflow("auto").expect("auto workflow");
+
+        assert_eq!(workflow.job_id, "workspace_auto_pipeline");
     }
 
     #[test]

--- a/crates/orbit-core/src/runtime/v2_host/backlog_exclusion.rs
+++ b/crates/orbit-core/src/runtime/v2_host/backlog_exclusion.rs
@@ -23,7 +23,15 @@ struct BacklogTaskExclusion {
 #[serde(rename_all = "snake_case")]
 enum BacklogTaskExclusionReason {
     ContextLockConflict,
+    EpicChild,
+    EpicRoot,
     GroupMemberConflict,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum EpicFamilyMembership {
+    Child,
+    Root,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize)]
@@ -129,18 +137,22 @@ pub(super) fn list_backlog_tasks(
                 task.status == TaskStatus::Backlog && task_dependencies_ready(task, &status_by_id)
             })
             .collect();
-        backlog.sort_by(|a, b| {
-            let rank = |p: orbit_common::types::TaskPriority| match p {
-                orbit_common::types::TaskPriority::Critical => 0,
-                orbit_common::types::TaskPriority::High => 1,
-                orbit_common::types::TaskPriority::Medium => 2,
-                orbit_common::types::TaskPriority::Low => 3,
-            };
-            rank(a.priority)
-                .cmp(&rank(b.priority))
-                .then(a.created_at.cmp(&b.created_at))
-        });
+        sort_tasks_by_priority_age(&mut backlog);
         let mut excluded = Vec::new();
+        backlog.retain(|task| {
+            let Some(membership) = epic_family_membership(task, &task_lookup) else {
+                return true;
+            };
+            excluded.push(BacklogTaskExclusion {
+                id: task.id.clone(),
+                reason: match membership {
+                    EpicFamilyMembership::Root => BacklogTaskExclusionReason::EpicRoot,
+                    EpicFamilyMembership::Child => BacklogTaskExclusionReason::EpicChild,
+                },
+                conflicts: Vec::new(),
+            });
+            false
+        });
         if !lock_holders.is_empty() {
             let direct_conflicts: BTreeMap<String, Vec<BacklogTaskConflict>> = backlog
                 .iter()
@@ -182,10 +194,10 @@ pub(super) fn list_backlog_tasks(
                         kept.push(task);
                     }
                 }
-                excluded.sort_by(|a, b| a.id.cmp(&b.id));
                 backlog = kept;
             }
         }
+        excluded.sort_by(|a, b| a.id.cmp(&b.id));
         (backlog, Some(excluded))
     } else {
         let tasks = explicit_task_ids
@@ -236,6 +248,45 @@ pub(super) fn list_backlog_tasks(
         );
     }
     Ok(Value::Object(payload))
+}
+
+pub(super) fn sort_tasks_by_priority_age(tasks: &mut [Task]) {
+    let rank = |priority: orbit_common::types::TaskPriority| match priority {
+        orbit_common::types::TaskPriority::Critical => 0,
+        orbit_common::types::TaskPriority::High => 1,
+        orbit_common::types::TaskPriority::Medium => 2,
+        orbit_common::types::TaskPriority::Low => 3,
+    };
+    tasks.sort_by(|left, right| {
+        rank(left.priority)
+            .cmp(&rank(right.priority))
+            .then(left.created_at.cmp(&right.created_at))
+    });
+}
+
+pub(super) fn epic_family_membership(
+    task: &Task,
+    task_lookup: &BTreeMap<String, Task>,
+) -> Option<EpicFamilyMembership> {
+    if task.tags.iter().any(|tag| tag == "epic") {
+        return Some(EpicFamilyMembership::Root);
+    }
+
+    let mut visited = vec![task.id.clone()];
+    let mut next_parent_id = task.parent_id().map(ToOwned::to_owned);
+    for _ in 0..MAX_TASK_PARENT_CHAIN_DEPTH {
+        let parent_id = next_parent_id?;
+        if visited.iter().any(|task_id| task_id == &parent_id) {
+            return None;
+        }
+        let parent = task_lookup.get(&parent_id)?;
+        if parent.tags.iter().any(|tag| tag == "epic") {
+            return Some(EpicFamilyMembership::Child);
+        }
+        visited.push(parent.id.clone());
+        next_parent_id = parent.parent_id().map(ToOwned::to_owned);
+    }
+    None
 }
 
 fn task_root_id(task: &Task, task_lookup: &BTreeMap<String, Task>) -> String {

--- a/crates/orbit-core/src/runtime/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/v2_host/dispatch.rs
@@ -16,7 +16,9 @@ use crate::runtime::task_locks::{
     requested_task_files, task_lock_conflicts, workspace_orbit_dir, workspace_task_reservation_id,
 };
 
-use super::{backlog_exclusion, pipeline_actions, scan_unresolved, task_pilot, triage};
+use super::{
+    backlog_exclusion, pipeline_actions, scan_unresolved, task_pilot, triage, workspace_auto,
+};
 
 /// Whether `action` is dispatchable by this runtime — the capability probe
 /// behind `RuntimeHost::has_deterministic_action` [ORB-10385].
@@ -189,6 +191,12 @@ pub(crate) fn run_deterministic(
                     message: error.to_string(),
                 }
             })
+        }
+        // One workspace logistics tick [ORB-10788 / ADR-0365]: ship eligible
+        // loose leaves first, hold while an epic root is active, otherwise
+        // select one ordered backlog epic root for the supervisor pipeline.
+        CoreDeterministicAction::ClassifyWorkspaceAutoTasks => {
+            workspace_auto::classify_workspace_auto_tasks(runtime, action, input)
         }
         // ADR-0223: scheduled shipment resolves only the active runtime's
         // canonical ship input; cross-workspace enumeration stays in the

--- a/crates/orbit-core/src/runtime/v2_host/mod.rs
+++ b/crates/orbit-core/src/runtime/v2_host/mod.rs
@@ -20,6 +20,7 @@ mod test_support;
 #[cfg(test)]
 mod tests;
 pub(super) mod triage;
+pub(super) mod workspace_auto;
 
 #[cfg(test)]
 use crate::OrbitRuntime;

--- a/crates/orbit-core/src/runtime/v2_host/tests/backlog_exclusion.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/backlog_exclusion.rs
@@ -467,3 +467,59 @@ fn list_backlog_tasks_omits_excluded_for_explicit_task_ids() {
     assert_eq!(output["task_ids"], json!([backlog.id]));
     assert!(output.get("excluded").is_none());
 }
+
+#[test]
+fn list_backlog_tasks_excludes_epic_roots_and_descendants_with_reasons() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let loose_one = seed_list_backlog_task(
+        &runtime,
+        "Loose one",
+        TaskStatus::Backlog,
+        TaskPriority::High,
+        TaskType::Chore,
+        None,
+        vec![],
+    );
+    let loose_two = seed_list_backlog_task(
+        &runtime,
+        "Loose two",
+        TaskStatus::Backlog,
+        TaskPriority::Medium,
+        TaskType::Chore,
+        None,
+        vec![],
+    );
+    let epic = runtime
+        .add_task(TaskAddParams {
+            title: "Epic root".to_string(),
+            description: "Epic fixture".to_string(),
+            acceptance_criteria: vec!["Supervised".to_string()],
+            tags: vec!["epic".to_string()],
+            plan: "Delegate children".to_string(),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("seed epic root");
+    let children = (0..3)
+        .map(|index| {
+            seed_list_backlog_task(
+                &runtime,
+                &format!("Epic child {index}"),
+                TaskStatus::Backlog,
+                TaskPriority::Medium,
+                TaskType::Chore,
+                Some(epic.id.clone()),
+                vec![],
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let output = list_backlog_tasks(&runtime, json!({}));
+    assert_eq!(output_task_ids(&output), vec![loose_one.id, loose_two.id]);
+    assert_eq!(excluded_entry(&output, &epic.id)["reason"], "epic_root");
+    assert_eq!(excluded_entry(&output, &epic.id)["conflicts"], json!([]));
+    for child in children {
+        assert_eq!(excluded_entry(&output, &child.id)["reason"], "epic_child");
+        assert_eq!(excluded_entry(&output, &child.id)["conflicts"], json!([]));
+    }
+}

--- a/crates/orbit-core/src/runtime/v2_host/tests/mod.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/mod.rs
@@ -8,6 +8,7 @@ mod task_context;
 mod task_pilot;
 mod triage;
 mod v2_host;
+mod workspace_auto;
 // Replay-transport-backed cases; default-off per [ORB-10414]. [ORB-10434]
 #[cfg(feature = "replay")]
 mod v2_host_replay;

--- a/crates/orbit-core/src/runtime/v2_host/tests/workspace_auto.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/workspace_auto.rs
@@ -1,0 +1,122 @@
+use orbit_common::types::{TaskPriority, TaskStatus, TaskType};
+use orbit_engine::RuntimeHost;
+use orbit_tools::ToolContext;
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+use crate::command::task::{TaskAddParams, TaskUpdateParams};
+use crate::runtime::v2_host::test_support::{
+    runtime_with_workspace_layout, seed_list_backlog_task,
+};
+
+fn classify(runtime: &OrbitRuntime) -> Value {
+    runtime
+        .run_deterministic(
+            "classify_workspace_auto_tasks",
+            &json!({}),
+            &json!({}),
+            ToolContext::default(),
+        )
+        .expect("classify workspace auto tasks")
+}
+
+#[test]
+fn two_loose_tasks_win_before_one_epic_and_three_children() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let loose_one = seed_list_backlog_task(
+        &runtime,
+        "Loose high",
+        TaskStatus::Backlog,
+        TaskPriority::High,
+        TaskType::Chore,
+        None,
+        vec![],
+    );
+    let loose_two = seed_list_backlog_task(
+        &runtime,
+        "Loose medium",
+        TaskStatus::Backlog,
+        TaskPriority::Medium,
+        TaskType::Chore,
+        None,
+        vec![],
+    );
+    let epic = runtime
+        .add_task(TaskAddParams {
+            title: "Epic root".to_string(),
+            description: "Epic fixture".to_string(),
+            acceptance_criteria: vec!["Supervised".to_string()],
+            tags: vec!["epic".to_string()],
+            plan: "Delegate children".to_string(),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("seed epic root");
+    for index in 0..3 {
+        seed_list_backlog_task(
+            &runtime,
+            &format!("Epic child {index}"),
+            TaskStatus::Backlog,
+            TaskPriority::Medium,
+            TaskType::Chore,
+            Some(epic.id.clone()),
+            vec![],
+        );
+    }
+
+    let first = classify(&runtime);
+    assert_eq!(first["decision"], "ship");
+    assert_eq!(first["loose_task_ids"], json!([loose_one.id, loose_two.id]));
+    assert_eq!(first["epic_task_id"], Value::Null);
+
+    for loose in [&loose_one, &loose_two] {
+        runtime
+            .update_task(
+                &loose.id,
+                TaskUpdateParams {
+                    status: Some(TaskStatus::Done),
+                    ..Default::default()
+                },
+            )
+            .expect("complete loose task");
+    }
+    let second = classify(&runtime);
+    assert_eq!(second["decision"], "epic");
+    assert_eq!(second["epic_task_id"], epic.id);
+    assert_eq!(second["loose_task_ids"], json!([]));
+}
+
+#[test]
+fn in_progress_epic_holds_and_empty_workspace_succeeds() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let epic = runtime
+        .add_task(TaskAddParams {
+            title: "Active epic".to_string(),
+            description: "Epic fixture".to_string(),
+            acceptance_criteria: vec!["Supervised".to_string()],
+            tags: vec!["epic".to_string()],
+            plan: "Delegate children".to_string(),
+            status: Some(TaskStatus::InProgress),
+            ..Default::default()
+        })
+        .expect("seed active epic");
+    seed_list_backlog_task(
+        &runtime,
+        "Late loose task",
+        TaskStatus::Backlog,
+        TaskPriority::Critical,
+        TaskType::Chore,
+        None,
+        vec![],
+    );
+
+    let held = classify(&runtime);
+    assert_eq!(held["decision"], "hold");
+    assert_eq!(held["epic_task_id"], epic.id);
+
+    let (_empty_root, empty_runtime, _empty_repo_root) = runtime_with_workspace_layout();
+    let empty = classify(&empty_runtime);
+    assert_eq!(empty["decision"], "empty");
+    assert_eq!(empty["loose_task_ids"], json!([]));
+    assert_eq!(empty["epic_task_id"], Value::Null);
+}

--- a/crates/orbit-core/src/runtime/v2_host/workspace_auto.rs
+++ b/crates/orbit-core/src/runtime/v2_host/workspace_auto.rs
@@ -1,0 +1,90 @@
+use std::collections::BTreeMap;
+
+use orbit_common::types::{Task, TaskStatus, task_dependencies_ready};
+use orbit_engine::DispatchError;
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+
+use super::backlog_exclusion::{
+    EpicFamilyMembership, epic_family_membership, list_backlog_tasks, sort_tasks_by_priority_age,
+};
+
+pub(super) fn classify_workspace_auto_tasks(
+    runtime: &OrbitRuntime,
+    action: &str,
+    input: &Value,
+) -> Result<Value, DispatchError> {
+    let all_tasks = runtime.stores().tasks().list_tasks().map_err(|err| {
+        DispatchError::DeterministicActionFailed {
+            action: action.to_string(),
+            message: format!("list tasks: {err}"),
+        }
+    })?;
+    let task_lookup: BTreeMap<String, Task> = all_tasks
+        .iter()
+        .cloned()
+        .map(|task| (task.id.clone(), task))
+        .collect();
+
+    let mut in_progress_epics = all_tasks
+        .iter()
+        .filter(|task| {
+            task.status == TaskStatus::InProgress
+                && epic_family_membership(task, &task_lookup) == Some(EpicFamilyMembership::Root)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    sort_tasks_by_priority_age(&mut in_progress_epics);
+    if let Some(epic) = in_progress_epics.first() {
+        return Ok(json!({
+            "decision": "hold",
+            "loose_task_ids": [],
+            "epic_task_id": epic.id,
+        }));
+    }
+
+    let backlog = list_backlog_tasks(runtime, action, input)?;
+    let loose_task_ids = backlog
+        .get("task_ids")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if !loose_task_ids.is_empty() {
+        return Ok(json!({
+            "decision": "ship",
+            "loose_task_ids": loose_task_ids,
+            "epic_task_id": null,
+        }));
+    }
+
+    let status_by_id =
+        runtime
+            .task_status_index()
+            .map_err(|err| DispatchError::DeterministicActionFailed {
+                action: action.to_string(),
+                message: format!("load global task status projection: {err}"),
+            })?;
+    let mut backlog_epics = all_tasks
+        .into_iter()
+        .filter(|task| {
+            task.status == TaskStatus::Backlog
+                && epic_family_membership(task, &task_lookup) == Some(EpicFamilyMembership::Root)
+                && task_dependencies_ready(task, &status_by_id)
+        })
+        .collect::<Vec<_>>();
+    sort_tasks_by_priority_age(&mut backlog_epics);
+    if let Some(epic) = backlog_epics.first() {
+        return Ok(json!({
+            "decision": "epic",
+            "loose_task_ids": [],
+            "epic_task_id": epic.id,
+        }));
+    }
+
+    Ok(json!({
+        "decision": "empty",
+        "loose_task_ids": [],
+        "epic_task_id": null,
+    }))
+}


### PR DESCRIPTION
## Task

[ORB-10788](https://orbit-cli.com/tasks/ORB-10788) — Add workspace_auto_pipeline sequencer for leaf-then-one-epic auto dispatch

### Description

## Problem
`orbit run ship` auto (`task_auto_pipeline` / `list_backlog_tasks`) treats an `epic`-tagged root as a leaf. Shipping ORB-10775 produced an empty worktree and a false `blocked` flip. Epic children in `backlog` would also race the epic orchestrator if both auto-ship and `epic_pipeline` run on the same workspace.

## Why It Matters
Auto mode should own workspace logistics: drain non-epic leaves first then start exactly one epic job. Leaf ship must stay a leaf implementer. The two dispatchers cannot share a candidate set.

## Constraints / Notes
- Design: `docs/design/resident-orchestrator/` (ADR-0365). Do not fold the sequencer into `task_auto_pipeline`.
- Job name: `workspace_auto_pipeline`. Operator verb: `orbit run auto`. Do not change the meaning of `orbit run ship` / explicit `task_ids`.
- Heuristic (v1 refine later):
  1. Loose leaves (no `epic` ancestor) exist → invoke existing ship on those ids.
  2. Else an epic root is `in-progress` → no-op. Block other auto-ship until that epic leaves `in-progress`.
  3. Else one or more epic roots are in `backlog` and nothing else is shippable → pick one (same priority/age order as `list_backlog`) and `invoke_and_wait` `epic_pipeline`.
  4. Epic children never enter auto ship. The orchestrator ships them with explicit ids.
- `list_backlog_tasks` auto mode must exclude `tag: epic` roots and any descendant of such a root. Attribute `excluded` with `epic_root` / `epic_child`.
- Explicit `orbit run ship <epic-root>` refuses (not a leaf). Explicit ship of an epic child remains allowed.
- Do not seed an Orbit routine (ADR-0362). Optionally retarget `workspace_ship_pipeline` at the sequencer so existing unattended sweeps get the heuristic.
- Do not make `scan_unresolved_work` epic-scoped in this task.
- Parked for weekend. Do not ship until Daniel asks.

## Rollback
Revert catalog YAML CLI verb and `list_backlog` filters. Existing `epic_pipeline` and explicit ship stay usable.

### Acceptance Criteria

- Auto list_backlog excludes tag-epic roots and their descendants and reports excluded reasons epic_root or epic_child.
- Explicit orbit run ship of an epic root is refused before worktree setup. Explicit ship of an epic child still admits.
- workspace_auto_pipeline is registered in the packaged catalog and workspace resource copies with max_active_runs 1.
- Sequencer tick: loose leaves invoke task_auto_pipeline; in-progress epic is a successful no-op; else one backlog epic root invokes epic_pipeline; first-tick empty is success.
- orbit run auto submits workspace_auto_pipeline. orbit run ship with no ids still submits task_auto_pipeline and no longer admits the epic family.
- Unit tests cover the 2-loose-plus-1-epic-plus-3-children fixture the in-progress hold and explicit-root refuse. make ci-fast (or catalog plus targeted rust tests) passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added epic-family classification to automatic backlog discovery. Epic-tagged roots and all descendants are excluded with epic_root or epic_child attribution, while explicit selection remains available to epic children.
- Added shared explicit ship admission that refuses epic roots before creating a pipeline run or worktree.
- Added the classify_workspace_auto_tasks deterministic activity and single-flight workspace_auto_pipeline in both packaged and workspace resource catalogs. The sequencer holds while an epic root is in progress, otherwise ships ordered loose leaves first, then invokes epic_pipeline for one ordered backlog epic root; empty ticks succeed without child runs.
- Added orbit run auto submission for workspace_auto_pipeline and kept no-id orbit run ship routed to task_auto_pipeline. Retargeted workspace_ship_pipeline to the sequencer so existing unattended sweeps use the new logistics policy.
- Added focused fixture, hold, empty, catalog, CLI routing, and explicit-root refusal tests.

Validation:
- make ci-fast (passed)
- make ci-lint (passed)
- cargo test -p orbit-core command::job::tests::catalog (27 passed)
- cargo test -p orbit-core runtime::v2_host::tests::backlog_exclusion (10 passed)
- cargo test -p orbit-core runtime::v2_host::tests::workspace_auto (2 passed)
- cargo test -p orbit-core command::tests::job_pipeline::ship_submission (5 passed)
- cargo test -p orbit-cli command::run::tests (42 passed)
- Packaged/workspace activity and job resource copies compared byte-identical; git diff --check passed.

Assessment: The implementation follows ADR-0365 without changing scan_unresolved_work or seeding a routine. No new dependency edge was added.

Deviations from original plan:
- No design-doc edit was needed because the accepted resident-orchestrator design and ADR-0365 already contained the final contract.
- Retargeted workspace_ship_pipeline as the task explicitly allowed, preserving existing sweep entrypoints while centralizing workspace logistics in workspace_auto_pipeline.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10788-6a7e9bed`
- Behind base: 0
- Ahead of base: 1