### PR TITLE
Job show emits human-readable step rows before JSON output

### DIFF
--- a/crates/orbit-cli/src/command/job/show.rs
+++ b/crates/orbit-cli/src/command/job/show.rs
@@ -3,7 +3,7 @@ use orbit_core::OrbitRuntime;
 
 use crate::command::{CommandOut, Execute, Payload};
 
-use super::support::{job_catalog_to_json_with_last_run, print_v2_step};
+use super::support::{job_catalog_to_json_with_last_run, write_v2_step};
 
 #[derive(Args)]
 pub struct JobShowArgs {
@@ -43,7 +43,7 @@ impl Execute for JobShowArgs {
         let _ = writeln!(out, "{} {}", bold("Steps:"), job.spec.steps.len());
         for (i, step) in job.spec.steps.iter().enumerate() {
             let _ = writeln!(out, "  {}:", bold(&format!("Step {}", i + 1)));
-            print_v2_step(step, 4);
+            write_v2_step(step, 4, &mut out);
         }
         Ok(Payload::detail(doc, out).into())
     }

--- a/crates/orbit-cli/src/command/job/support.rs
+++ b/crates/orbit-cli/src/command/job/support.rs
@@ -120,68 +120,94 @@ fn job_v2_step_to_json(step: &JobV2Step) -> Value {
     value
 }
 
-pub(super) fn print_v2_step(step: &JobV2Step, indent: usize) {
+pub(super) fn write_v2_step(step: &JobV2Step, indent: usize, out: &mut String) {
     use crate::output::color::bold;
+    use std::fmt::Write as _;
 
     let pad = " ".repeat(indent);
-    println!("{pad}{} {}", bold("ID:"), step.id.as_str());
+    let _ = writeln!(out, "{pad}{} {}", bold("ID:"), step.id.as_str());
     if let Some(when) = &step.when {
-        println!("{pad}{} {}", bold("When:"), when);
+        let _ = writeln!(out, "{pad}{} {}", bold("When:"), when);
     }
     if let Some(retry) = &step.retry {
-        println!("{pad}{} {:?}", bold("Retry:"), retry);
+        let _ = writeln!(out, "{pad}{} {:?}", bold("Retry:"), retry);
     }
     match &step.body {
         JobV2StepBody::TargetRef(target) => {
-            println!("{pad}{} {}", bold("Target Ref:"), target.target.as_str());
+            let _ = writeln!(
+                out,
+                "{pad}{} {}",
+                bold("Target Ref:"),
+                target.target.as_str()
+            );
             if let Some(session) = &target.session {
-                println!("{pad}{} {}", bold("Session:"), session);
+                let _ = writeln!(out, "{pad}{} {}", bold("Session:"), session);
             }
-            println!("{pad}{} {}", bold("Timeout (s):"), target.timeout_seconds);
+            let _ = writeln!(
+                out,
+                "{pad}{} {}",
+                bold("Timeout (s):"),
+                target.timeout_seconds
+            );
         }
         JobV2StepBody::Target(target) => {
             match &target.spec {
                 ActivityV2Spec::AgentLoop(spec) => {
-                    println!("{pad}{} agent_loop", bold("Activity Type:"));
-                    println!("{pad}{} {}", bold("Provider:"), spec.provider.as_str());
-                    println!("{pad}{} {}", bold("Backend:"), spec.backend.as_str());
+                    let _ = writeln!(out, "{pad}{} agent_loop", bold("Activity Type:"));
+                    let _ = writeln!(out, "{pad}{} {}", bold("Provider:"), spec.provider.as_str());
+                    let _ = writeln!(out, "{pad}{} {}", bold("Backend:"), spec.backend.as_str());
                     if let Some(model) = &spec.model {
-                        println!("{pad}{} {}", bold("Model:"), model);
+                        let _ = writeln!(out, "{pad}{} {}", bold("Model:"), model);
                     }
                 }
                 ActivityV2Spec::Deterministic(spec) => {
-                    println!("{pad}{} deterministic", bold("Activity Type:"));
-                    println!("{pad}{} {}", bold("Action:"), spec.action.as_str());
+                    let _ = writeln!(out, "{pad}{} deterministic", bold("Activity Type:"));
+                    let _ = writeln!(out, "{pad}{} {}", bold("Action:"), spec.action.as_str());
                 }
             }
             if let Some(session) = &target.session {
-                println!("{pad}{} {}", bold("Session:"), session);
+                let _ = writeln!(out, "{pad}{} {}", bold("Session:"), session);
             }
-            println!("{pad}{} {}", bold("Timeout (s):"), target.timeout_seconds);
+            let _ = writeln!(
+                out,
+                "{pad}{} {}",
+                bold("Timeout (s):"),
+                target.timeout_seconds
+            );
         }
         JobV2StepBody::Parallel { parallel } => {
-            println!("{pad}{} parallel", bold("Body:"));
-            println!("{pad}{} {:?}", bold("Join:"), parallel.join);
-            println!("{pad}{} {}", bold("Branches:"), parallel.branches.len());
+            let _ = writeln!(out, "{pad}{} parallel", bold("Body:"));
+            let _ = writeln!(out, "{pad}{} {:?}", bold("Join:"), parallel.join);
+            let _ = writeln!(
+                out,
+                "{pad}{} {}",
+                bold("Branches:"),
+                parallel.branches.len()
+            );
             for branch in &parallel.branches {
-                print_v2_step(branch, indent + 2);
+                write_v2_step(branch, indent + 2, out);
             }
         }
         JobV2StepBody::FanOut { fan_out, fan_in } => {
-            println!("{pad}{} fan_out", bold("Body:"));
-            println!("{pad}{} {}", bold("Items:"), fan_out.items.as_str());
-            println!("{pad}{} {}", bold("Max Workers:"), fan_out.max_workers);
-            println!("{pad}{} {:?}", bold("Fan In:"), fan_in);
-            print_v2_step(&fan_out.worker, indent + 2);
+            let _ = writeln!(out, "{pad}{} fan_out", bold("Body:"));
+            let _ = writeln!(out, "{pad}{} {}", bold("Items:"), fan_out.items.as_str());
+            let _ = writeln!(out, "{pad}{} {}", bold("Max Workers:"), fan_out.max_workers);
+            let _ = writeln!(out, "{pad}{} {:?}", bold("Fan In:"), fan_in);
+            write_v2_step(&fan_out.worker, indent + 2, out);
         }
         JobV2StepBody::Loop { loop_ } => {
-            println!("{pad}{} loop", bold("Body:"));
-            println!("{pad}{} {}", bold("Max Iterations:"), loop_.max_iterations);
+            let _ = writeln!(out, "{pad}{} loop", bold("Body:"));
+            let _ = writeln!(
+                out,
+                "{pad}{} {}",
+                bold("Max Iterations:"),
+                loop_.max_iterations
+            );
             if let Some(break_when) = &loop_.break_when {
-                println!("{pad}{} {}", bold("Break When:"), break_when);
+                let _ = writeln!(out, "{pad}{} {}", bold("Break When:"), break_when);
             }
             for nested in &loop_.steps {
-                print_v2_step(nested, indent + 2);
+                write_v2_step(nested, indent + 2, out);
             }
         }
     }

--- a/crates/orbit-cli/tests/table_rendering.rs
+++ b/crates/orbit-cli/tests/table_rendering.rs
@@ -57,6 +57,28 @@ fn task_list_renders_one_line_per_task() {
     assert_both_forms(&workspace, &["task", "list"], 3, "orbit task list");
 }
 
+#[test]
+fn job_show_json_contains_no_human_step_rows() {
+    let workspace = TestWorkspace::new();
+
+    let json = workspace.run(
+        &["job", "show", "epic_pipeline", "--format", "json"],
+        "job show JSON",
+    );
+    let document: Value = serde_json::from_slice(&json.stdout).expect("job show JSON");
+    assert!(document.is_object(), "job show returned {document}");
+    assert!(
+        !String::from_utf8_lossy(&json.stdout).contains("ID:"),
+        "JSON output contained human step rows: {}",
+        String::from_utf8_lossy(&json.stdout)
+    );
+
+    let human = workspace.run(&["job", "show", "epic_pipeline"], "job show human output");
+    let human_stdout = String::from_utf8_lossy(&human.stdout);
+    assert!(human_stdout.contains("Steps:"), "{human_stdout}");
+    assert!(human_stdout.contains("ID:"), "{human_stdout}");
+}
+
 /// ORB-10571: the same property, for the other two commands covered by
 /// `tests/output_goldens.rs`'s golden-file coverage. Both are seeded by
 /// `orbit workspace init` itself (a default policy, a default skill


### PR DESCRIPTION
## Task

[ORB-10791](https://orbit-cli.com/tasks/ORB-10791) — Job show emits human-readable step rows before JSON output

### Description

## Problem
`orbit --format json job show epic_pipeline` emits human-readable step rows before the JSON document, so the advertised JSON output is not parseable by JSON consumers.

## Evidence
- Observed at commit `9bb5713a` (recent changes include [ORB-10779] `epic_pipeline`).
- `target/debug/orbit --format json job list | jq -e .` exits 0.
- `target/debug/orbit --format json job show epic_pipeline | jq -e .` prints `jq: parse error: Invalid numeric literal at line 1, column 7` and exits 5.
- The command output begins with rows such as `ID: drain` and `Body: loop`, followed by a JSON object.

## Reproduction
1. Build the CLI: `cargo build -p orbit-cli --bin orbit`.
2. Run `target/debug/orbit --format json job show epic_pipeline | jq -e .`.
3. Observe the parse failure caused by non-JSON step rows preceding the JSON object.

## Expected
When `--format json` is selected, `job show` must emit exactly one valid JSON document and no human-readable rows.

### Acceptance Criteria

- `target/debug/orbit --format json job show epic_pipeline | jq -e .` exits 0 and emits no non-JSON prefix.
- The default human-readable `job show` output remains available when JSON is not requested.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Buffered schemaVersion 2 job step details into the existing human-view payload instead of printing them directly from command execution.
- JSON rendering now receives only the serialized job document, while the default human rendering retains the job metadata and step details.
- Added an integration regression test covering JSON parseability/no `ID:` prefix and human step visibility.
Validation:
- `cargo fmt --all -- --check` passed.
- `cargo test -p orbit-cli --test table_rendering job_show_json_contains_no_human_step_rows -- --exact` passed (1 test).
- `target/debug/orbit --format json job show epic_pipeline | jq -e .` passed with exit 0.
- Default `target/debug/orbit job show epic_pipeline` passed and contained `Steps:` and step `ID:` rows.
- `make ci-fast` passed.
- `make ci-lint` passed.
Assessment: Small, localized fix preserving the central output-rendering contract and both output modes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10791-6a7e9dcd`
- Behind base: 0
- Ahead of base: 1