### PR TITLE
Include the Codex plugin manifest in release preparation

### DIFF
--- a/.orbit/auto_tasks/release-prep.yaml
+++ b/.orbit/auto_tasks/release-prep.yaml
@@ -63,7 +63,8 @@ template:
     type `chore`, and the candidate version and evidence in its description.
     Carry the release runbook context selectors
     `file:CHANGELOG.md`, `file:Cargo.toml`, `file:Cargo.lock`,
-    `file:plugin/.claude-plugin/plugin.json`, and
+    `file:plugin/.claude-plugin/plugin.json`,
+    `file:plugin/.codex-plugin/plugin.json`, and
     `file:plugin/npm/package.json` onto that canonical task.
     If one exists, update only that canonical task with the fresh candidate,
     survey evidence, and breaking-change candidates. Preserve the human review
@@ -72,7 +73,7 @@ template:
     `execution_summary`.
 
     The canonical task must instruct its executor to follow `RELEASING.md`,
-    including the release checklist and the four versioned release files. The
+    including the release checklist and all five versioned release files. The
     handoff stops after surveying, candidate semver analysis, and creating or
     updating that one task. It must not commit, tag, push, publish, promote or
     merge branches, bump versions, edit `CHANGELOG.md`, or ask for or record
@@ -101,6 +102,7 @@ template:
   - A blocked or no-release pass changes no repository or release state and completes with evidence in execution_summary.
   - An eligible pass records the latest reachable v* tag, commit survey, candidate semver bump, and breaking-change candidates with exact evidence.
   - An eligible pass creates or updates exactly one canonical Prepare v<X.Y.Z> release task carrying the release tag and reports its task ID.
+  - The canonical release task carries `file:plugin/.codex-plugin/plugin.json` alongside the other four version-bearing file selectors.
   - The canonical task stops before commits, tags, pushes, publishing, branch promotion, version bumps, CHANGELOG edits, or human confirmation of breaking-change classification, and points to RELEASING.md.
   - Repeated passes do not duplicate the open probe or the canonical release-preparation task.
   task_type: chore

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -103,13 +103,14 @@ Surface the breaking-change candidate list before drafting the final section. Sh
 
 ### 4. Bump versions
 
-Four files change every release:
+Five files change every release:
 
 | File | Field |
 |------|-------|
 | `Cargo.toml` | `[workspace.package].version` |
 | `Cargo.lock` | refresh via `cargo update --workspace` (no third-party drift) |
 | `plugin/.claude-plugin/plugin.json` | `version` |
+| `plugin/.codex-plugin/plugin.json` | `version` |
 | `plugin/npm/package.json` | `version` |
 
 The other `0.X.Y` matches in the repo (install-script doc comments, the website task pages, the Node engine pin in `website/package-lock.json`) are intentional — leave them.
@@ -133,10 +134,11 @@ context_files:
   - file:Cargo.toml
   - file:Cargo.lock
   - file:plugin/.claude-plugin/plugin.json
+  - file:plugin/.codex-plugin/plugin.json
   - file:plugin/npm/package.json
 ```
 
-Acceptance criteria: each of the four file bumps reports the new version, the CHANGELOG section is in place with the agreed structure, and every confirmed breaking change appears under Breaking Changes.
+Acceptance criteria: each of the five version-bearing file bumps reports the new version, the CHANGELOG section is in place with the agreed structure, and every confirmed breaking change appears under Breaking Changes.
 
 ### 7. Human approval
 


### PR DESCRIPTION
## Task

[ORB-10796](https://orbit-cli.com/tasks/ORB-10796) — Include the Codex plugin manifest in release preparation

### Description

## Problem
The newly merged `.orbit/auto_tasks/release-prep.yaml` and `RELEASING.md` enumerate only four release version files, but the detailed release runbook and `make release-check` require `plugin/.codex-plugin/plugin.json` as a fifth version-bearing manifest. A generated release task can therefore omit a required bump and fail the release gate.

## Required change
Add the Codex plugin manifest to the release-prep handoff selectors/instructions and to the authoritative release checklist without changing the human approval boundary or other release behavior. Keep the auto-task data-only and deterministic.

### Acceptance Criteria

- `.orbit/auto_tasks/release-prep.yaml` carries `file:plugin/.codex-plugin/plugin.json` alongside the other release version files in both its handoff instructions and observable criteria.
- `RELEASING.md` names all five required version-bearing files consistently with the detailed release runbook.
- `make release-check` and focused inspection agree that the generated release task cannot omit the Codex plugin manifest.
- `make ci-fast` and `git diff --check` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `file:plugin/.codex-plugin/plugin.json` to the release-prep handoff selectors and observable criteria, and changed the handoff to name all five version-bearing files.
- Updated `RELEASING.md` to list five release version files, including the Codex plugin manifest, in the bump table and canonical task context/acceptance guidance.
Validation:
- Focused inspection passed; both modified files contain the Codex selector and no longer describe four version-bearing files.
- `make ci-fast` passed.
- `git diff --check` passed.
- `make release-check` ran and reached the Codex manifest checks, but could not pass because the npm registry was unreachable and the current local manifests are 0.10.0 while the latest reachable GitHub release tag is 0.10.1. This is external/pre-tag release-state drift; no release version files were changed.
Assessment: Scoped data-only and runbook updates are complete; human approval and release-state boundaries remain unchanged.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10796-6a7ea342`
- Behind base: 0
- Ahead of base: 1