### PR TITLE
Explicit JSON array elements are comma-split; acceptance_criteria prose gets shredded

### DIFF
--- a/crates/orbit-common/src/types/tests/tool_input.rs
+++ b/crates/orbit-common/src/types/tests/tool_input.rs
@@ -75,7 +75,10 @@ fn optional_string_list_falls_back_for_recovered_empty_strings() {
 }
 
 #[test]
-fn optional_csv_or_string_list_recovers_json_encoded_selectors() {
+fn optional_csv_or_string_list_preserves_mcp_encoded_selectors() {
+    // MCP clients may serialize an array as a scalar JSON string. This is a
+    // real compatibility shape, so the decoded elements must still be kept as
+    // separate selectors rather than treated as CSV input.
     let recovered = optional_csv_or_string_list_alias(
         &json!({"context_files": "[\"file:src/lib.rs\", \"file:src/main.rs\"]"}),
         &["context_files"],
@@ -91,7 +94,9 @@ fn optional_csv_or_string_list_recovers_json_encoded_selectors() {
 }
 
 #[test]
-fn optional_csv_or_string_list_recovers_single_encoded_array_element() {
+fn optional_csv_or_string_list_preserves_single_mcp_encoded_array_element() {
+    // This is the corresponding single-element-array shape emitted by some
+    // MCP clients; it also guards JSON-array recovery rather than CSV parsing.
     let recovered = optional_csv_or_string_list_alias(
         &json!({"context_files": ["[\"file:src/lib.rs\", \"file:src/main.rs\"]"]}),
         &["context_files"],
@@ -103,5 +108,34 @@ fn optional_csv_or_string_list_recovers_single_encoded_array_element() {
             "file:src/lib.rs".to_string(),
             "file:src/main.rs".to_string()
         ])
+    );
+}
+
+#[test]
+fn optional_csv_or_string_list_preserves_commas_in_explicit_array() {
+    let recovered = optional_csv_or_string_list_alias(
+        &json!({"values": ["first, with a comma", "second"]}),
+        &["values"],
+    )
+    .unwrap();
+
+    assert_eq!(
+        recovered,
+        Some(vec![
+            "first, with a comma".to_string(),
+            "second".to_string()
+        ])
+    );
+}
+
+#[test]
+fn optional_csv_or_string_list_splits_scalar_csv() {
+    let recovered =
+        optional_csv_or_string_list_alias(&json!({"values": "first, second"}), &["values"])
+            .unwrap();
+
+    assert_eq!(
+        recovered,
+        Some(vec!["first".to_string(), "second".to_string()])
     );
 }

--- a/crates/orbit-common/src/types/tool_input.rs
+++ b/crates/orbit-common/src/types/tool_input.rs
@@ -175,14 +175,20 @@ pub fn optional_csv_or_string_list_alias(
     input: &Value,
     keys: &[&str],
 ) -> Result<Option<Vec<String>>, OrbitError> {
-    optional_string_list_alias(input, keys).map(|values| {
-        values.map(|items| {
-            items
+    for key in keys {
+        let Some(value) = input.get(*key) else {
+            continue;
+        };
+        let values = optional_string_list_alias(input, &[*key])?;
+        return Ok(values.map(|items| match value {
+            Value::String(raw) if decode_json_string_array(raw.trim()).is_none() => items
                 .into_iter()
                 .flat_map(|item| split_csv(&item))
-                .collect::<Vec<_>>()
-        })
-    })
+                .collect(),
+            _ => items,
+        }));
+    }
+    Ok(None)
 }
 
 pub fn split_csv(raw: &str) -> Vec<String> {

--- a/crates/orbit-core/src/runtime/orbit_tool_host/host.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/host.rs
@@ -8,8 +8,8 @@ use orbit_common::types::{
     FrictionStatus, NotFoundKind, OrbitError, Task, TaskComment, TaskPriority, TaskStatus,
     TaskType, ToolSessionContext, is_valid_friction_id, normalize_optional_attribution_label,
     normalize_task_dependencies, normalize_task_tags, optional_csv_or_string_list_alias,
-    optional_raw_string, optional_string, optional_string_alias, required_string,
-    resolve_task_dependencies, task_dependencies_ready, task_matches_tags,
+    optional_raw_string, optional_string, optional_string_alias, optional_string_list_alias,
+    required_string, resolve_task_dependencies, task_dependencies_ready, task_matches_tags,
     validate_task_dependencies,
 };
 use orbit_common::utility::redaction::redact_all;
@@ -218,7 +218,7 @@ impl HubCoordinationExecutor {
             .unwrap_or(TaskType::Feature);
         let title = redact_all(&required_string(&input, &["title"], "title")?);
         let description = redact_all(&required_string(&input, &["description"], "description")?);
-        let acceptance_criteria = optional_csv_or_string_list_alias(
+        let acceptance_criteria = optional_string_list_alias(
             &input,
             &[
                 "acceptance_criteria",
@@ -409,7 +409,7 @@ impl HubCoordinationExecutor {
                 actor: actor.clone(),
                 title: optional_string(&input, "title")?.map(|value| redact_all(&value)),
                 description,
-                acceptance_criteria: optional_csv_or_string_list_alias(
+                acceptance_criteria: optional_string_list_alias(
                     &input,
                     &[
                         "acceptance_criteria",

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
@@ -846,6 +846,60 @@ fn task_add_tool_recovers_mcp_encoded_acceptance_and_context_arrays() {
 }
 
 #[test]
+fn task_add_tool_preserves_commas_in_acceptance_criteria_array() {
+    let (_root, runtime, _repo_root) = test_runtime();
+
+    let output = runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Comma-safe criteria",
+                "description": "Exercise explicit acceptance criteria arrays.",
+                "workspace": ".",
+                "acceptance_criteria": [
+                    "first criterion, with a comma",
+                    "second criterion"
+                ],
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task add tool succeeds");
+
+    assert_eq!(
+        output.get("acceptance_criteria"),
+        Some(&json!([
+            "first criterion, with a comma",
+            "second criterion"
+        ]))
+    );
+}
+
+#[test]
+fn task_add_tool_keeps_scalar_acceptance_criteria_as_one_value() {
+    let (_root, runtime, _repo_root) = test_runtime();
+
+    let output = runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Scalar criterion",
+                "description": "Exercise scalar acceptance criteria input.",
+                "workspace": ".",
+                "acceptance_criteria": "one criterion, with a comma",
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task add tool succeeds");
+
+    assert_eq!(
+        output.get("acceptance_criteria"),
+        Some(&json!(["one criterion, with a comma"]))
+    );
+}
+
+#[test]
 fn task_add_tool_infers_agent_from_model_only_input() {
     let _env =
         orbit_common::test_env::unset(orbit_common::test_env::AGENT_IDENTITY_ENV.iter().copied());
@@ -1748,6 +1802,72 @@ fn task_update_tool_recovers_mcp_encoded_acceptance_array() {
     assert_eq!(
         output.get("acceptance_criteria"),
         Some(&json!(["Criterion A", "Criterion B"]))
+    );
+}
+
+#[test]
+fn task_update_tool_preserves_commas_in_acceptance_criteria_array() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let task = create_task(
+        &runtime,
+        &repo_root,
+        "Update comma-safe criteria",
+        "Exercise explicit acceptance criteria replacement.",
+        TaskStatus::Backlog,
+        &[],
+    );
+
+    let output = runtime
+        .execute_tool_command(
+            "orbit.task.update",
+            json!({
+                "id": task.id,
+                "acceptance_criteria": [
+                    "updated criterion, with a comma",
+                    "another updated criterion"
+                ],
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task update tool succeeds");
+
+    assert_eq!(
+        output.get("acceptance_criteria"),
+        Some(&json!([
+            "updated criterion, with a comma",
+            "another updated criterion"
+        ]))
+    );
+}
+
+#[test]
+fn task_update_tool_keeps_scalar_acceptance_criteria_as_one_value() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let task = create_task(
+        &runtime,
+        &repo_root,
+        "Update scalar criterion",
+        "Exercise scalar acceptance criteria replacement.",
+        TaskStatus::Backlog,
+        &[],
+    );
+
+    let output = runtime
+        .execute_tool_command(
+            "orbit.task.update",
+            json!({
+                "id": task.id,
+                "acceptance_criteria": "updated criterion, with a comma",
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task update tool succeeds");
+
+    assert_eq!(
+        output.get("acceptance_criteria"),
+        Some(&json!(["updated criterion, with a comma"]))
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-10799](https://orbit-cli.com/tasks/ORB-10799) — Explicit JSON array elements are comma-split; acceptance_criteria prose gets shredded

### Description

`orbit.task.add` and `orbit.task.update` destroy `acceptance_criteria` that contain
commas. A caller passing a well-formed JSON array of 9 criteria gets back 21
fragments — each comma inside a criterion becomes a list boundary.

## Observed

Authoring ORB-10798 with a proper JSON array whose first element was:

```
"`orbit.auto_task.add`, `.show`, `.update`, and `.toggle` are registered via
`register_inactive` and no longer appear in MCP `tools/list`, while remaining
reachable through `orbit tool run` and their existing CLI subcommands"
```

stored four separate criteria: `` `orbit.auto_task.add` ``, `` `.show` ``,
`` `.update` ``, and the remaining clause. The damage is silent — the call
returns success and the mangled list looks plausible until read closely.

The `acceptance_criteria` parameter is documented as accepting "a string or array
of strings". An explicit array is already a list; nothing in the contract says
its elements will be re-parsed.

## Root cause

`optional_string_list_alias` (`crates/orbit-common/src/types/tool_input.rs:125`)
is correct — the `Value::Array` arm at lines 144-164 preserves elements verbatim.

The defect is in its wrapper `optional_csv_or_string_list_alias` (same file,
lines 174-186), which `flat_map`s `split_csv` across **every** element
unconditionally:

```rust
optional_string_list_alias(input, keys).map(|values| {
    values.map(|items| {
        items.into_iter().flat_map(|item| split_csv(&item)).collect()
    })
})
```

CSV recovery exists for the scalar convenience form (`tags: "a,b,c"`). Applying
it to elements that arrived as a genuine JSON array second-guesses a caller who
already expressed the list structure explicitly.

`acceptance_criteria` reaches this wrapper at
`crates/orbit-core/src/runtime/orbit_tool_host/host.rs:221`.

## Blast radius

The same helper backs `context_files`, `tags`, `status`/`statuses`, `fields`, and
`dependencies` across `task_tools.rs`, `search_tools.rs`, and `friction_tools.rs`.
For those fields the values are short tokens where a comma is not legitimate
content, so the bug is latent rather than active. `acceptance_criteria` is the
one field whose values are prose — commas are expected there — which is why it
corrupts in practice.

## Suggested fix

Two changes; the second does not subsume the first.

1. **Stop splitting explicit arrays.** Apply `split_csv` only on the
   scalar-string path so array input is preserved verbatim. This fixes the whole
   class and keeps the `tags: "a,b,c"` convenience intact.

2. **Take `acceptance_criteria` off the CSV path entirely** — switch
   `host.rs:221` to `optional_string_list_alias`. Needed independently of (1):
   criteria supplied as a single scalar string are still prose and must not split
   on their commas.

Note that `crates/orbit-common/src/types/tests/tool_input.rs:79` and `:95` assert
the current split-across-array behavior. Those tests encode the defect and need
revisiting rather than preserving — check whether either was protecting a real
client shape before deleting.

## Note

ORB-10798's acceptance criteria are written comma-free purely to route around
this bug. They can be restored to natural prose once this lands and make a decent
end-to-end verification case.

### Acceptance Criteria

- `orbit.task.add` and `orbit.task.update` preserve every element of an explicit JSON `acceptance_criteria` array verbatim — a 9-element array with commas inside elements stores exactly 9 criteria
- `acceptance_criteria` supplied as a single scalar string is stored as one criterion and is not split on its commas
- The scalar CSV convenience for `tags` still works — a scalar string of comma-separated tokens expands to one tag per token — while a single-element array whose element contains a comma is preserved as given rather than split
- `context_files` / `status` / `fields` / `dependencies` keep their current behavior for scalar CSV input across `task_tools.rs` / `search_tools.rs` / `friction_tools.rs`
- The existing assertions at `crates/orbit-common/src/types/tests/tool_input.rs:79` and `:95` are re-evaluated rather than preserved — with a note in the PR on whether either guarded a real client shape
- Regression coverage exists for an array element containing a comma at both the helper level and through `orbit.task.add`
- `make ci-fast` and `make ci-lint` both pass

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated `optional_csv_or_string_list_alias` so scalar strings retain CSV splitting while explicit arrays preserve each element, including commas; MCP JSON-encoded array recovery remains intact.
- Switched task `acceptance_criteria` parsing in `orbit.task.add` and `orbit.task.update` to the non-CSV helper, so scalar prose and explicit arrays are stored as single/list values without comma shredding.
- Re-evaluated the tests formerly at tool_input.rs lines 79 and 95: both guard real MCP compatibility shapes (JSON-encoded scalar arrays and single-element encoded arrays), so they remain with clarifying comments. Added helper and task-tool regressions for comma-containing arrays, scalar prose, and scalar CSV tags behavior.
Assessment: Focused orbit-common and orbit-core regression tests passed. `make ci-fast` and `make ci-lint` passed; ci-fast emitted existing missing-path warnings from the artifact-redaction guard but exited successfully. No new dependencies or out-of-scope files were needed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10799-6a7fdf18`
- Behind base: 0
- Ahead of base: 1