### PR TITLE
Make orbit task show resolve globally by task ID

### DIFF
--- a/crates/orbit-cli/src/command/task/show.rs
+++ b/crates/orbit-cli/src/command/task/show.rs
@@ -1,5 +1,6 @@
 use clap::Args;
 use orbit_core::{OrbitError, OrbitRuntime, TaskRelatedDoc};
+use orbit_remote::runtime::RemoteRuntimeFactory;
 use serde_json::Value;
 
 use crate::command::{Block, CommandOut, CommandOutput, Execute, Payload};
@@ -65,6 +66,19 @@ impl Execute for TaskShowArgs {
             Vec::new()
         };
         let mut doc = task_to_json_for_runtime(runtime, &task)?;
+        let workspace = RemoteRuntimeFactory::workspace_identity_for_runtime(runtime)?;
+        if let Some(workspace) = &workspace {
+            let object = doc.as_object_mut().ok_or_else(|| {
+                OrbitError::Execution("task JSON projection did not produce an object".to_string())
+            })?;
+            object.insert(
+                "workspace".to_string(),
+                serde_json::json!({
+                    "name": workspace.name.clone(),
+                    "id": workspace.id.clone()
+                }),
+            );
+        }
         if self.with_context {
             insert_related_docs(&mut doc, related_docs.clone())?;
         }
@@ -76,6 +90,15 @@ impl Execute for TaskShowArgs {
             let mut out = String::new();
             use crate::output::color::{Domain, bold, dimmed, text};
             let _ = writeln!(out, "{} {}", bold("ID:"), task.id);
+            if let Some(workspace) = &workspace {
+                let _ = writeln!(
+                    out,
+                    "{} {} ({})",
+                    bold("Workspace:"),
+                    workspace.name,
+                    workspace.id
+                );
+            }
             if let Some(parent_id) = task.parent_id() {
                 let _ = writeln!(out, "{} {}", bold("Parent Task:"), parent_id);
             }

--- a/crates/orbit-cli/src/main.rs
+++ b/crates/orbit-cli/src/main.rs
@@ -181,6 +181,7 @@ fn main() {
     );
     let root_override = cli.root.clone();
     let workspace_selector = cli.workspace.clone();
+    let implicit_task_show_id = implicit_task_show_id(&cli.command, workspace_selector.as_deref());
     let actor = ActorIdentity::from_env();
     let CommandOperation {
         runtime_need,
@@ -207,10 +208,23 @@ fn main() {
         return;
     }
 
-    let runtime = match RemoteRuntimeFactory::initialize_with_overrides(
-        root_override.as_deref(),
-        workspace_selector.as_deref(),
-    ) {
+    let runtime_result = match implicit_task_show_id {
+        Some(task_id) => {
+            let global_root = match root_override.as_deref() {
+                Some(root) => Ok(root.to_path_buf()),
+                None => orbit_remote::workspace_registry::global_orbit_dir(),
+            };
+            global_root.and_then(|global_root| {
+                RemoteRuntimeFactory::open_task_owner(&global_root, task_id)
+                    .map(|owner| owner.runtime)
+            })
+        }
+        None => RemoteRuntimeFactory::initialize_with_overrides(
+            root_override.as_deref(),
+            workspace_selector.as_deref(),
+        ),
+    };
+    let runtime = match runtime_result {
         Ok(runtime) => runtime,
         Err(err) => {
             if suppress_errors {
@@ -250,6 +264,25 @@ fn main() {
     };
 
     finish_command(result, &sink, suppress_errors, json_error_preference);
+}
+
+/// `task show` is the only CLI verb whose identifier is globally unique.
+/// An explicit selector remains a fail-closed workspace filter; only the
+/// omitted-selector spelling follows the task registry to its owning checkout.
+fn implicit_task_show_id<'a>(
+    command: &'a command::Commands,
+    workspace_selector: Option<&str>,
+) -> Option<&'a str> {
+    if workspace_selector.is_some_and(|selector| !selector.trim().is_empty()) {
+        return None;
+    }
+    let command::Commands::Task(task) = command else {
+        return None;
+    };
+    let command::task::TaskSubcommand::Show(show) = &task.command else {
+        return None;
+    };
+    Some(&show.id)
 }
 
 /// Render what the command returned, or report why it failed.

--- a/crates/orbit-cli/tests/workspace_selector.rs
+++ b/crates/orbit-cli/tests/workspace_selector.rs
@@ -126,6 +126,40 @@ fn global_workspace_flag_selects_by_name_and_id_from_a_foreign_checkout() {
         !task_ids(&other_cwd).contains(&orbit_task_id),
         "cwd discovery without --workspace must keep binding the other checkout: {other_cwd}"
     );
+
+    let shown_from_foreign_checkout = run_orbit_json(
+        &other_repo,
+        &home,
+        &["task", "show", &orbit_task_id, "--json"],
+    );
+    assert_eq!(shown_from_foreign_checkout["id"], orbit_task_id);
+    assert_eq!(shown_from_foreign_checkout["workspace"]["name"], "orbit");
+    assert_eq!(shown_from_foreign_checkout["workspace"]["id"], "ws_orbit");
+
+    let shown_outside_a_workspace = run_orbit_json(
+        &elsewhere,
+        &home,
+        &["task", "show", &orbit_task_id, "--json"],
+    );
+    assert_eq!(shown_outside_a_workspace["id"], orbit_task_id);
+
+    let explicit_miss = run_orbit(
+        &elsewhere,
+        &home,
+        &[
+            "--workspace",
+            "other",
+            "task",
+            "show",
+            &orbit_task_id,
+            "--json",
+        ],
+    )
+    .failure();
+    assert!(
+        !String::from_utf8_lossy(&explicit_miss.get_output().stdout).contains("Orbit-only task"),
+        "an explicit foreign workspace must not disclose the task"
+    );
 }
 
 #[test]

--- a/crates/orbit-remote/src/mcp/host.rs
+++ b/crates/orbit-remote/src/mcp/host.rs
@@ -346,6 +346,89 @@ impl BrokerMcpHost {
             })
     }
 
+    /// Only a per-call argument scopes task show. Session workspace metadata is
+    /// ambient (like a process cwd) and must not hide a globally unique task.
+    fn has_explicit_workspace(input: &Value) -> bool {
+        input
+            .get("workspace")
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    }
+
+    fn attach_task_workspace_identity(
+        mut value: Value,
+        workspace: &crate::runtime::TaskWorkspaceIdentity,
+    ) -> Result<Value, OrbitError> {
+        let object = value.as_object_mut().ok_or_else(|| {
+            OrbitError::Execution("task JSON projection did not produce an object".to_string())
+        })?;
+        object.insert(
+            "workspace".to_string(),
+            json!({ "name": workspace.name.clone(), "id": workspace.id.clone() }),
+        );
+        Ok(value)
+    }
+
+    fn workspace_identity(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Option<crate::runtime::TaskWorkspaceIdentity>, OrbitError> {
+        let registry = crate::workspace_registry::load_registry_from(
+            &crate::workspace_registry::registry_path_for(&self.global_root),
+        )?;
+        Ok(registry
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.id == workspace_id)
+            .map(|workspace| crate::runtime::TaskWorkspaceIdentity {
+                id: workspace.id.clone(),
+                name: workspace.name.clone(),
+            }))
+    }
+
+    fn implicit_task_show(
+        &self,
+        name: &str,
+        input: Value,
+        mut context: ToolSessionContext,
+        in_process: Option<&mut dyn FnMut(Value, ToolSessionContext) -> Result<Value, OrbitError>>,
+    ) -> Result<Value, OrbitError> {
+        let id = input
+            .get("id")
+            .and_then(Value::as_str)
+            .ok_or_else(|| OrbitError::InvalidInput("`id` must be a string".to_string()))?;
+        let owner = match RemoteRuntimeFactory::open_task_owner(&self.global_root, id) {
+            Ok(owner) => owner,
+            Err(error) => {
+                self.record_preflight_denial(name, &input, &context, &error);
+                return Err(error);
+            }
+        };
+        context.workspace_id = Some(owner.workspace.id.clone());
+        context.workspace = Some(
+            owner
+                .runtime
+                .paths()
+                .repo_root
+                .to_string_lossy()
+                .into_owned(),
+        );
+        let result = match in_process {
+            Some(dispatch) => owner
+                .runtime
+                .execute_in_process_tool_dispatch(
+                    name,
+                    input,
+                    ToolEntryPoint::Mcp,
+                    context.clone(),
+                    |input| dispatch(input, context.clone()),
+                )
+                .map(|outcome| outcome.value),
+            None => audited_mcp_call_with_session_context(&owner.runtime, name, input, context),
+        };
+        result.and_then(|value| Self::attach_task_workspace_identity(value, &owner.workspace))
+    }
+
     /// Resolve a selector to its logical workspace ID and, when this machine
     /// holds one, its validated exact local checkout.
     ///
@@ -959,6 +1042,10 @@ impl BrokerMcpHost {
             return result;
         }
 
+        if name == "orbit.task.show" && !Self::has_explicit_workspace(&input) {
+            return self.implicit_task_show(name, input, context, in_process);
+        }
+
         // `all: true` without a workspace selector is the broker's explicit
         // cross-workspace search mode. Supplying a workspace (directly or in
         // session metadata) retains the established per-workspace meaning of
@@ -1150,13 +1237,20 @@ impl BrokerMcpHost {
             let result = crate::runtime::sync_task_prefix(&self.global_root).and_then(|()| {
                 HubCoordinationExecutor::new_with_task_partition(
                     &self.global_root,
-                    workspace_id,
+                    workspace_id.clone(),
                     task_partition_id,
                     legacy_root,
                 )
                 .and_then(|executor| executor.execute_tool(name, input, context.clone()))
             });
             self.record_coordination_outcome(name, &context, &result);
+            if name == "orbit.task.show" {
+                return match self.workspace_identity(&workspace_id)? {
+                    Some(workspace) => result
+                        .and_then(|value| Self::attach_task_workspace_identity(value, &workspace)),
+                    None => result,
+                };
+            }
             return result;
         }
         let binding = match binding {
@@ -1184,7 +1278,7 @@ impl BrokerMcpHost {
                 return Err(error);
             }
         };
-        match in_process {
+        let result = match in_process {
             Some(dispatch) => runtime
                 .execute_in_process_tool_dispatch(
                     name,
@@ -1195,7 +1289,17 @@ impl BrokerMcpHost {
                 )
                 .map(|outcome| outcome.value),
             None => audited_mcp_call_with_session_context(&runtime, name, input, context),
+        };
+        if name == "orbit.task.show" {
+            let workspace = RemoteRuntimeFactory::workspace_identity_for_runtime(&runtime)?;
+            return match workspace {
+                Some(workspace) => {
+                    result.and_then(|value| Self::attach_task_workspace_identity(value, &workspace))
+                }
+                None => result,
+            };
         }
+        result
     }
 }
 

--- a/crates/orbit-remote/src/mcp/tests/workspace_selector.rs
+++ b/crates/orbit-remote/src/mcp/tests/workspace_selector.rs
@@ -1,15 +1,19 @@
 use std::collections::BTreeSet;
 use std::path::Path;
+use std::process::Command;
 
 use chrono::Utc;
 use orbit_common::types::{
-    McpCapability, ToolSessionContext, Workspace, WorkspaceRegistry, WorkspaceStatus,
+    McpCapability, ToolSessionContext, Workspace, WorkspaceCheckout, WorkspaceRegistry,
+    WorkspaceStatus,
 };
 use orbit_core::runtime::HubCoordinationExecutor;
 use orbit_mcp::McpHost;
+use orbit_store::sqlite::task_registry::{WorkspaceConfig, write_workspace_config};
 use serde_json::json;
 
 use super::super::host::BrokerMcpHost;
+use crate::runtime::RemoteRuntimeFactory;
 
 fn write_identity(root: &Path) {
     std::fs::write(
@@ -70,6 +74,41 @@ fn audit_workspace_id(root: &Path, call_id: &str) -> Option<String> {
             |row| row.get::<_, Option<String>>(0),
         )
         .expect("audit row")
+}
+
+fn registered_workspace(root: &Path, id: &str, name: &str) -> (Workspace, WorkspaceCheckout) {
+    let repo = root.join(name);
+    let orbit_dir = repo.join(".orbit");
+    std::fs::create_dir_all(&repo).expect("checkout root");
+    let status = Command::new("git")
+        .arg("init")
+        .arg(&repo)
+        .status()
+        .expect("initialize checkout repository");
+    assert!(status.success(), "initialize checkout repository");
+    std::fs::create_dir_all(&orbit_dir).expect("checkout orbit directory");
+    write_workspace_config(
+        &orbit_dir,
+        &WorkspaceConfig {
+            schema_version: 1,
+            workspace_id: id.to_string(),
+        },
+    )
+    .expect("workspace config");
+    (
+        Workspace {
+            id: id.to_string(),
+            name: name.to_string(),
+            owner_machine_id: Some("hm_hub".to_string()),
+            git_remote: None,
+            ship_mode: Some("local".to_string()),
+            base_branch: "agent-main".to_string(),
+            status: WorkspaceStatus::Active,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        },
+        WorkspaceCheckout::owner(id.to_string(), repo, orbit_dir),
+    )
 }
 
 #[test]
@@ -244,4 +283,58 @@ fn mcp_relative_path_selector_is_rejected() {
     let message = error.to_string();
     assert!(message.contains("./relative"), "{message}");
     assert!(message.contains("must be absolute"), "{message}");
+}
+
+#[test]
+fn mcp_task_show_follows_the_global_id_and_explicit_workspace_stays_a_filter() {
+    let root = tempfile::tempdir().expect("global root");
+    write_identity(root.path());
+    let (alpha, alpha_checkout) = registered_workspace(root.path(), "ws_alpha", "alpha");
+    let (beta, beta_checkout) = registered_workspace(root.path(), "ws_beta", "beta");
+    crate::workspace_registry::save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![alpha.clone(), beta],
+            checkouts: vec![alpha_checkout.clone(), beta_checkout],
+            ..Default::default()
+        },
+        &crate::workspace_registry::registry_path_for(root.path()),
+    )
+    .expect("workspace registry");
+    let alpha_runtime =
+        RemoteRuntimeFactory::open_registered_checkout(root.path(), &alpha, &alpha_checkout)
+            .expect("alpha runtime");
+    let task = alpha_runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "workspace": alpha_checkout.repo_root,
+                "title": "Alpha-only task",
+                "description": "The global task id identifies alpha."
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("seed task");
+    let id = task["id"].as_str().expect("task id");
+    let host = BrokerMcpHost::new(root.path().to_path_buf());
+
+    let shown = host
+        .call_tool(
+            "orbit.task.show",
+            json!({ "id": id }),
+            operator_context(Some("beta"), "mcall-global-task-show"),
+        )
+        .expect("session workspace must not scope a global task show");
+    assert_eq!(shown["title"], "Alpha-only task");
+    assert_eq!(shown["workspace"]["name"], "alpha");
+    assert_eq!(shown["workspace"]["id"], "ws_alpha");
+
+    let explicit_miss = host
+        .call_tool(
+            "orbit.task.show",
+            json!({ "id": id, "workspace": "beta" }),
+            operator_context(None, "mcall-explicit-task-show-miss"),
+        )
+        .expect_err("explicit beta selector must not reveal alpha task");
+    assert!(explicit_miss.to_string().contains(id), "{explicit_miss}");
 }

--- a/crates/orbit-remote/src/runtime.rs
+++ b/crates/orbit-remote/src/runtime.rs
@@ -26,6 +26,19 @@ pub struct ResolvedWorkspaceBinding {
     pub owner_machine_id: Option<String>,
 }
 
+/// The registry identity attached to a runtime opened for a task lookup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskWorkspaceIdentity {
+    pub id: String,
+    pub name: String,
+}
+
+/// A runtime rebound to the checkout that owns a globally registered task.
+pub struct TaskOwnerRuntime {
+    pub runtime: OrbitRuntime,
+    pub workspace: TaskWorkspaceIdentity,
+}
+
 /// Build Core's authoritative runtime binding for a registered checkout.
 /// The runtime ID deliberately comes from config.yaml rather than the logical
 /// registry record because legacy installations may validly differ (L-0098).
@@ -57,6 +70,102 @@ pub fn resolved_workspace_binding(
 pub struct RemoteRuntimeFactory;
 
 impl RemoteRuntimeFactory {
+    /// Open the active registered checkout that owns `task_id`.
+    ///
+    /// Task IDs are globally unique in the task registry, but their documents
+    /// and sidecars remain checkout-local. A missing or inactive checkout is
+    /// therefore an actionable owner-state error, not a task-not-found error.
+    pub fn open_task_owner(
+        global_root: &Path,
+        task_id: &str,
+    ) -> Result<TaskOwnerRuntime, OrbitError> {
+        sync_task_prefix(global_root)?;
+        let task_registry = TaskRegistryStore::open(&task_registry_path(global_root))?;
+        let task_binding = task_registry.find_task_binding(task_id)?.ok_or_else(|| {
+            orbit_common::types::OrbitError::not_found(
+                orbit_common::types::NotFoundKind::Task,
+                task_id.to_string(),
+            )
+        })?;
+        let registry = workspace_registry::load_registry_from(
+            &workspace_registry::registry_path_for(global_root),
+        )?;
+        let (workspace, checkout) = registry
+            .checkouts
+            .iter()
+            .find_map(|checkout| {
+                let workspace = registry
+                    .workspaces
+                    .iter()
+                    .find(|workspace| workspace.id == checkout.workspace_id)?;
+                if workspace.id == task_binding.workspace_id {
+                    return Some((workspace, checkout));
+                }
+                let runtime_workspace_id = workspace_id_for_orbit_dir(&checkout.orbit_dir).ok()?;
+                (runtime_workspace_id == task_binding.workspace_id).then_some((workspace, checkout))
+            })
+            .ok_or_else(|| {
+                OrbitError::InvalidInput(format!(
+                    "task '{task_id}' belongs to registered workspace '{}' but that workspace has no usable local checkout",
+                    task_binding.workspace_id
+                ))
+            })?;
+        let identity = TaskWorkspaceIdentity {
+            id: workspace.id.clone(),
+            name: workspace.name.clone(),
+        };
+        if workspace.status != WorkspaceStatus::Active {
+            return Err(OrbitError::InvalidInput(format!(
+                "task '{task_id}' belongs to inactive workspace '{} ({})'",
+                identity.name, identity.id
+            )));
+        }
+        if !checkout.repo_root.is_dir() || !checkout.orbit_dir.is_dir() {
+            return Err(OrbitError::InvalidInput(format!(
+                "task '{task_id}' belongs to workspace '{} ({})', but its registered checkout '{}' is unavailable",
+                identity.name,
+                identity.id,
+                checkout.repo_root.display()
+            )));
+        }
+        Self::open_registered_checkout(global_root, workspace, checkout)
+            .map(|runtime| TaskOwnerRuntime {
+                runtime,
+                workspace: identity.clone(),
+            })
+            .map_err(|error| {
+                OrbitError::InvalidInput(format!(
+                    "task '{task_id}' belongs to workspace '{} ({}), but its registered checkout could not be opened: {error}",
+                    identity.name, identity.id
+                ))
+            })
+    }
+
+    /// Find the registered logical workspace behind an already-bound runtime.
+    pub fn workspace_identity_for_runtime(
+        runtime: &OrbitRuntime,
+    ) -> Result<Option<TaskWorkspaceIdentity>, OrbitError> {
+        let registry = workspace_registry::load_registry_from(
+            &workspace_registry::registry_path_for(&runtime.global_root()),
+        )?;
+        let repo_root = canonical_path(&runtime.paths().repo_root);
+        Ok(registry
+            .checkouts
+            .iter()
+            .find_map(|checkout| {
+                (canonical_path(&checkout.repo_root) == repo_root).then(|| {
+                    registry
+                        .workspaces
+                        .iter()
+                        .find(|workspace| workspace.id == checkout.workspace_id)
+                        .map(|workspace| TaskWorkspaceIdentity {
+                            id: workspace.id.clone(),
+                            name: workspace.name.clone(),
+                        })
+                })
+            })
+            .flatten())
+    }
     pub fn resolve_roots_for_cwd(
         cwd: &Path,
         root_override: Option<&Path>,

--- a/crates/orbit-remote/src/tests/runtime.rs
+++ b/crates/orbit-remote/src/tests/runtime.rs
@@ -370,6 +370,22 @@ fn cli_tool_run_fails_closed_on_unresolvable_workspace_for_read_and_write() {
 }
 
 #[test]
+fn global_task_lookup_names_the_owner_when_its_checkout_is_stale() {
+    let fixture = dual_workspace_fixture();
+    let global = fixture.alpha.global_root();
+    std::fs::remove_dir_all(fixture.beta_repo.join(".orbit")).expect("stale beta checkout");
+
+    let error = match RemoteRuntimeFactory::open_task_owner(&global, &fixture.beta_task_id) {
+        Ok(_) => panic!("a known task must not become not-found when its checkout is stale"),
+        Err(error) => error,
+    };
+    let message = error.to_string();
+    assert!(message.contains("beta"), "{message}");
+    assert!(message.contains("ws_beta"), "{message}");
+    assert!(message.contains("unavailable"), "{message}");
+}
+
+#[test]
 fn cli_tool_run_write_rebounds_to_the_named_workspace() {
     let fixture = dual_workspace_fixture();
     let created = execute_cli_tool(


### PR DESCRIPTION
## Task

[ORB-10797](https://orbit-cli.com/tasks/ORB-10797) — Make orbit task show resolve globally by task ID

### Description

## Problem

`orbit task show <id>` binds one `OrbitRuntime` from cwd (or `--workspace`) and looks up the ID only in that workspace. Task IDs are already a machine-global primary key (`TaskRegistryStore::find_task_binding` maps `ORB-*` → workspace), so a valid ID 404s whenever the caller is not standing in the owning checkout. `--workspace all` is the wrong spelling for this verb: the default should follow the ID.

## Why It Matters

Operators and agents constantly have an `ORB-*` and not the workspace. The constellation orchestrator lives in polaris sessions and still needs to show orbit/worker/sextant tasks. Cwd and MCP session workspace are the right default for list/add/search; they are the wrong default for a globally unique ID.

## Constraints / Notes

- **Scope is `task show` only** (CLI `orbit task show` and the `orbit.task.show` tool/MCP). Do not change list, update, start, archive, search, or friction. Do not add `--workspace all`.
- **Default (no `--workspace` / no `workspace` argument):** resolve via the global task registry, then open the owning checkout and reuse the existing show path. Works from any directory, including outside a workspace. CLI bootstrap cannot require a cwd workspace for this command.
- **Explicit `--workspace <selector>` / `workspace:` is a filter**, not a hint. If the task is not in that workspace, not-found. This preserves ADR-0361 fail-closed naming.
- **MCP session `_meta.orbit.workspace` is ambient**, like cwd. Omit-workspace show must global-resolve even inside a polaris session. Only an explicit per-call `workspace` scopes the lookup.
- **Output must name the landing workspace** (human line + JSON). `--with-context`, comments, history, and artifacts come from the owning workspace after rebind, not from cwd.
- **Stale/inactive owning checkout:** name the workspace and fail; do not pretend the ID does not exist.
- **Implementation sketch:** `find_task_binding` already exists. Special-case `task show` so it can start from `~/.orbit` + the task registry, then `open_registered_checkout` for the owner. `--workspace` stays top-level (`orbit --workspace polaris task show ORB-...`), not a clap-global flag (it would collide with `task add --workspace`).
- Related: [ORB-10758] / ADR-0361 (selector grammar). This task does not change the selector forms; it changes when show consults the registry instead of the bound runtime.

### Acceptance Criteria

- `orbit task show ORB-<id>` from a foreign checkout and from a directory that is not a workspace prints that task without requiring `--workspace`.
- `orbit --workspace <selector> task show ORB-<id>` is fail-closed: a task owned by a different workspace exits not-found and does not print the foreign task.
- Human `orbit task show` output includes the owning workspace name and logical id (example: `Workspace: orbit (ws_orbit)`). JSON output includes the same identity so a later write can address it.
- `orbit.task.show` with only `{id}` (no `workspace` argument) returns the owning workspace task even when the MCP session is bound to another workspace. An explicit `workspace` argument remains a filter and 404s when the task is not in that workspace.
- Do not add `--workspace all`. Do not change `task list` `task update` `task start` or any other verb.
- If the registry knows the ID but the owning checkout is stale or inactive the error names that workspace and does not report the ID as unknown.
- Tests cover foreign-cwd show; no-workspace-cwd show; explicit `--workspace` miss; MCP/tool show without workspace; and a stale-checkout error. File I/O uses temp dirs or fakes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Made implicit CLI `orbit task show <id>` open the task registry owner checkout, so it works from foreign and non-workspace directories while an explicit `--workspace` remains fail-closed.
- Made MCP `orbit.task.show` ignore ambient session workspace when the call omits `workspace`, rebind to the registry owner, and preserve explicit workspace filtering.
- Added owning workspace identity to human and JSON task-show output; stale checkout failures name the owning workspace.
- Added CLI, MCP, and stale-checkout regression coverage using temporary directories/checkouts.
Assessment: Focused task-show-only change with registry ownership resolution centralized in `orbit-remote`; no new dependencies or ADR needed.
Validation:
- cargo test -p orbit-cli --test workspace_selector
- cargo test -p orbit-remote mcp_task_show_follows_the_global_id_and_explicit_workspace_stays_a_filter
- cargo test -p orbit-remote global_task_lookup_names_the_owner_when_its_checkout_is_stale
- make ci-fast
- make ci-lint
Friction checkpoint: no qualifying friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10797-6a7fe48b`
- Behind base: 0
- Ahead of base: 1