### PR TITLE
Add an orbit doctor check for stale, deprecated, and faulty definition artifacts plus --fix-stale-artifacts

### DIFF
--- a/crates/orbit-cli/src/command/doctor.rs
+++ b/crates/orbit-cli/src/command/doctor.rs
@@ -25,6 +25,10 @@ pub struct DoctorCommand {
     /// Remove retired graph state from this worktree and the shared workspace.
     #[arg(long)]
     pub remove_graph: bool,
+
+    /// Retire deprecated skills, jobs, activities, auto-tasks, and routines that Orbit itself wrote. Locally modified ones are preserved, not deleted.
+    #[arg(long)]
+    pub fix_stale_artifacts: bool,
 }
 
 impl Execute for DoctorCommand {
@@ -45,6 +49,12 @@ impl Execute for DoctorCommand {
             let removed = runtime.remove_retired_graph_state()?;
             if !self.json {
                 println!("Removed {removed} retired graph location(s).");
+            }
+        }
+        if self.fix_stale_artifacts {
+            let removed = runtime.remove_stale_definition_artifacts()?;
+            if !self.json {
+                println!("Retired {removed} deprecated definition artifact(s).");
             }
         }
         let results = runtime.doctor_workspace()?;

--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -23,6 +23,7 @@ use std::path::{Path, PathBuf};
 use fs2::FileExt;
 use orbit_common::types::{OrbitError, WorkspacePaths};
 use orbit_core::OrbitRuntime;
+use orbit_core::command::artifact_health::ArtifactFinding;
 use orbit_store::sqlite::migration::SUPPORTED_SCHEMA_VERSION;
 use serde::Serialize;
 
@@ -113,6 +114,11 @@ pub trait DoctorCommands {
     /// workspace locations. Missing locations are a successful no-op.
     fn remove_retired_graph_state(&self) -> Result<usize, OrbitError>;
 
+    /// Retire deprecated definition artifacts whose recorded digest proves
+    /// Orbit wrote them, preserving locally modified ones outside the active
+    /// catalog. Faulty and user-authored artifacts are never touched.
+    fn remove_stale_definition_artifacts(&self) -> Result<usize, OrbitError>;
+
     /// Cheap store write probe for health endpoints: open the store and
     /// acquire + roll back the write lock without mutating anything.
     fn health_check_store_writable(&self) -> Result<String, OrbitError>;
@@ -120,7 +126,7 @@ pub trait DoctorCommands {
 
 impl DoctorCommands for OrbitRuntime {
     fn doctor_workspace(&self) -> Result<Vec<WorkspaceDoctorResult>, OrbitError> {
-        Ok(vec![
+        let mut results = vec![
             doctor_check_config(self),
             doctor_check_database(self),
             doctor_check_disk_space(self),
@@ -129,7 +135,9 @@ impl DoctorCommands for OrbitRuntime {
             doctor_check_job_runs(self),
             doctor_check_task_reservations(self),
             doctor_check_task_relations(self),
-        ])
+        ];
+        results.extend(doctor_check_definition_artifacts(self));
+        Ok(results)
     }
 
     fn remove_stale_lock_files(&self) -> Result<usize, OrbitError> {
@@ -144,6 +152,10 @@ impl DoctorCommands for OrbitRuntime {
 
     fn clear_stale_task_reservations(&self) -> Result<usize, OrbitError> {
         self.release_stale_task_reservations()
+    }
+
+    fn remove_stale_definition_artifacts(&self) -> Result<usize, OrbitError> {
+        OrbitRuntime::remove_stale_definition_artifacts(self)
     }
 
     fn remove_retired_graph_state(&self) -> Result<usize, OrbitError> {
@@ -579,6 +591,89 @@ fn doctor_check_task_relations(runtime: &OrbitRuntime) -> WorkspaceDoctorResult 
             )
         }
     }
+}
+
+/// Definition-artifact health — one row per artifact kind (skills, jobs,
+/// activities, auto-tasks, routines) [ORB-10800].
+///
+/// Severity is deliberately asymmetric. A workspace-authored definition that
+/// fails to parse is the operator's own in-progress edit, and classifying it
+/// as `Error` would silently start failing `orbit doctor` in cron and CI for
+/// workspaces that were passing yesterday. Only an *unloadable shipped
+/// default* — provably Orbit-written content that no longer parses, i.e. a
+/// broken install — escalates to `Error`. Everything else warns.
+fn doctor_check_definition_artifacts(runtime: &OrbitRuntime) -> Vec<WorkspaceDoctorResult> {
+    let report = match runtime.inspect_definition_artifacts() {
+        Ok(report) => report,
+        Err(error) => {
+            return vec![actionable_check(
+                "artifacts",
+                WorkspaceDoctorStatus::Warning,
+                format!("cannot inspect definition artifacts: {error}"),
+                "Resolve the store/runtime error, then rerun `orbit doctor`.".to_string(),
+            )];
+        }
+    };
+
+    report
+        .into_iter()
+        .map(|health| {
+            let check_name = format!("artifacts-{}", health.kind.as_str());
+            if health.findings.is_empty() {
+                let message = if health.scanned == 0 {
+                    format!("no {} on disk yet", health.kind.as_str())
+                } else {
+                    format!(
+                        "{} {} loaded, none stale, deprecated, or faulty",
+                        health.scanned,
+                        health.kind.as_str()
+                    )
+                };
+                let status = if health.scanned == 0 {
+                    WorkspaceDoctorStatus::Skipped
+                } else {
+                    WorkspaceDoctorStatus::Ok
+                };
+                return check(&check_name, status, message);
+            }
+
+            let status = if health
+                .findings
+                .iter()
+                .any(ArtifactFinding::is_unloadable_shipped_default)
+            {
+                WorkspaceDoctorStatus::Error
+            } else {
+                WorkspaceDoctorStatus::Warning
+            };
+            let detail = health
+                .findings
+                .iter()
+                .map(|finding| format!("{}: {}", finding.condition.as_str(), finding.detail))
+                .collect::<Vec<_>>()
+                .join("; ");
+            // Every finding carries its own exact repair command; dedupe so a
+            // kind with five stale copies names one command, not five.
+            let mut remediations: Vec<&str> = Vec::new();
+            for finding in &health.findings {
+                let remediation = finding.remediation.as_str();
+                if !remediations.contains(&remediation) {
+                    remediations.push(remediation);
+                }
+            }
+            actionable_check(
+                &check_name,
+                status,
+                format!(
+                    "{} of {} {} need attention — {detail}",
+                    health.findings.len(),
+                    health.scanned,
+                    health.kind.as_str()
+                ),
+                remediations.join(" "),
+            )
+        })
+        .collect()
 }
 
 /// Free/total space thresholds for the volume containing `path`.

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -46,7 +46,9 @@ fn healthy_fresh_workspace_has_no_failures() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     let results = runtime.doctor_workspace().expect("doctor");
 
-    assert_eq!(results.len(), 8, "one row per check: {results:?}");
+    // Eight infrastructure checks plus one definition-artifact row per kind
+    // (skills, jobs, activities, auto-tasks, routines).
+    assert_eq!(results.len(), 13, "one row per check: {results:?}");
     assert!(
         results
             .iter()

--- a/crates/orbit-core/src/auto_tasks/crud.rs
+++ b/crates/orbit-core/src/auto_tasks/crud.rs
@@ -78,10 +78,41 @@ impl OrbitRuntime {
     }
 
     /// List every definition in this workspace (stable filename order).
+    ///
     /// Fail-closed load errors are surfaced as an error only when nothing
-    /// loaded; otherwise malformed files are simply skipped by the loader.
+    /// loaded — a single malformed file must not hide the definitions that do
+    /// work. Anything skipped is still reported: it is logged here and stands
+    /// as a `faulty` row on the `orbit doctor` artifacts surface, so a
+    /// definition that silently stopped firing is discoverable [ORB-10800].
     pub fn auto_task_list(&self) -> Result<Vec<AutoTaskDefinition>, OrbitError> {
         let collection = collect_auto_tasks(&self.paths().local_dir);
+        for error in &collection.errors {
+            tracing::warn!(
+                target: "orbit.core.auto_tasks",
+                path = %error.path.as_ref().map_or_else(
+                    || "<auto_tasks dir>".to_string(),
+                    |path| path.display().to_string()
+                ),
+                reason = error.message.as_str(),
+                "auto-task definition failed to load and is treated as absent"
+            );
+        }
+        if collection.definitions.is_empty() && !collection.errors.is_empty() {
+            let detail = collection
+                .errors
+                .iter()
+                .map(|error| {
+                    error.path.as_ref().map_or_else(
+                        || error.message.clone(),
+                        |path| format!("{}: {}", path.display(), error.message),
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("; ");
+            return Err(OrbitError::InvalidInput(format!(
+                "no auto-task definition could be loaded; every definition failed fail-closed: {detail}"
+            )));
+        }
         Ok(collection
             .definitions
             .into_iter()

--- a/crates/orbit-core/src/auto_tasks/mod.rs
+++ b/crates/orbit-core/src/auto_tasks/mod.rs
@@ -23,7 +23,7 @@ use std::path::Path;
 
 use orbit_common::types::{OrbitError, parse_auto_task_yaml};
 
-use crate::command::seed_embedded_assets;
+use crate::command::{ManagedAssetLayout, ManagedAssetReconciliation, reconcile_managed_assets};
 
 pub mod crud;
 pub mod loader;
@@ -60,10 +60,19 @@ pub(crate) const DEFAULT_AUTO_TASK_FILES: &[(&str, &str)] = &[
 /// Seed missing default auto-task definitions without changing an existing
 /// workspace-authored definition. Each asset is parsed before it is written so
 /// a release cannot install an unloadable default.
-pub(crate) fn seed_default_auto_tasks(orbit_dir: &Path) -> Result<usize, OrbitError> {
+///
+/// Seeding is manifest-aware: the digest Orbit wrote for each default is
+/// recorded so a definition dropped from a later release can be retired by
+/// content provenance instead of lingering in every existing workspace.
+// ADR-0366: auto-tasks joined the ADR-0346 managed-asset mechanism.
+pub(crate) fn seed_default_auto_tasks(
+    orbit_dir: &Path,
+) -> Result<ManagedAssetReconciliation, OrbitError> {
     let auto_tasks_dir = auto_tasks_dir(orbit_dir);
-    seed_embedded_assets(
+    reconcile_managed_assets(
         &auto_tasks_dir,
+        "auto_task",
+        ManagedAssetLayout::YamlStem,
         DEFAULT_AUTO_TASK_FILES,
         false,
         |name, content| {

--- a/crates/orbit-core/src/command/activity.rs
+++ b/crates/orbit-core/src/command/activity.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use orbit_common::types::OrbitError;
 
-use super::{ManagedAssetReconciliation, reconcile_managed_assets};
+use super::{ManagedAssetLayout, ManagedAssetReconciliation, reconcile_managed_assets};
 
 /// Shippable default activity assets, seeded under
 /// `<orbit_root>/resources/activities/<name>.yaml` on `orbit init`. Keep this
@@ -156,6 +156,7 @@ pub(crate) fn seed_default_activities(
     reconcile_managed_assets(
         activities_dir,
         "activity",
+        ManagedAssetLayout::YamlStem,
         DEFAULT_ACTIVITY_FILES,
         overwrite,
         |_, content| Ok(Cow::Borrowed(content)),

--- a/crates/orbit-core/src/command/artifact_health.rs
+++ b/crates/orbit-core/src/command/artifact_health.rs
@@ -1,0 +1,687 @@
+//! Standing health of the *definition artifacts* a workspace accumulates —
+//! skills, jobs, activities, auto-tasks, and routines [ORB-10800].
+//!
+//! `orbit doctor` already diagnoses infrastructure (config, database, disk,
+//! indexes, locks, runs). This module supplies the missing half: the
+//! definitions themselves, classified into three conditions.
+//!
+//! - **Faulty** — the file fails to parse or validate, so its definition is
+//!   absent at dispatch time even though the file is still on disk.
+//! - **Deprecated** — the managed manifest proves Orbit wrote this file for a
+//!   default that the running binary no longer ships.
+//! - **Stale** — the file is a managed copy of an *older* release of a default
+//!   this binary still ships, or an untracked file colliding with a bundled
+//!   default name.
+//!
+//! Every judgement is made from the per-kind managed manifest written by
+//! [`super::reconcile_managed_assets`] (ADR-0346, extended to all five kinds by
+//! ADR-0366), never from filename guessing. That matters for correctness as
+//! well as safety: precedence differs across kinds — skills merge
+//! workspace-over-global while activities keep shipped defaults authoritative
+//! over workspace copies — so a rule phrased in terms of "which copy wins"
+//! would misreport at least one kind. Provenance is a property of the file
+//! Orbit wrote, in the directory Orbit wrote it to, and is unaffected by which
+//! copy a loader later prefers.
+//!
+//! Repair ([`OrbitRuntime::remove_stale_definition_artifacts`]) is deliberately
+//! narrower than diagnosis: only a *deprecated* artifact whose digest still
+//! proves Orbit wrote it is removed. A locally modified one is preserved
+//! outside the active catalog exactly as init-time reconciliation does, and a
+//! faulty user-authored file is never touched.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use orbit_common::types::activity_job::{load_activity_asset, load_job_asset};
+use orbit_common::types::{OrbitError, parse_routine_yaml};
+
+use crate::OrbitRuntime;
+use crate::auto_tasks::{auto_tasks_dir, collect_auto_tasks};
+
+use super::activity::DEFAULT_ACTIVITY_FILES;
+use super::job::catalog::DEFAULT_JOB_FILES;
+use super::skill::{DEFAULT_SKILL_FILES, inject_skill_template_tokens};
+use super::{
+    MANAGED_ASSET_MANIFEST_FILE, ManagedAssetLayout, load_managed_asset_manifest,
+    preserve_modified_retired_asset, sha256_hex,
+};
+use crate::auto_tasks::DEFAULT_AUTO_TASK_FILES;
+use crate::command::routine::DEFAULT_ROUTINE_FILES;
+
+/// The five definition-artifact kinds Orbit ships defaults for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtifactKind {
+    Skill,
+    Job,
+    Activity,
+    AutoTask,
+    Routine,
+}
+
+impl ArtifactKind {
+    /// Stable identifier used in doctor check names and operator messages.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Skill => "skills",
+            Self::Job => "jobs",
+            Self::Activity => "activities",
+            Self::AutoTask => "auto-tasks",
+            Self::Routine => "routines",
+        }
+    }
+
+    /// Singular noun for a single artifact of this kind.
+    pub fn singular(self) -> &'static str {
+        match self {
+            Self::Skill => "skill",
+            Self::Job => "job",
+            Self::Activity => "activity",
+            Self::AutoTask => "auto-task",
+            Self::Routine => "routine",
+        }
+    }
+
+    /// The `assetKind` recorded in this kind's managed manifest.
+    fn asset_kind(self) -> &'static str {
+        match self {
+            Self::Skill => "skill",
+            Self::Job => "job",
+            Self::Activity => "activity",
+            Self::AutoTask => "auto_task",
+            Self::Routine => "routine",
+        }
+    }
+
+    fn layout(self) -> ManagedAssetLayout {
+        match self {
+            Self::Skill => ManagedAssetLayout::RelativePath,
+            _ => ManagedAssetLayout::YamlStem,
+        }
+    }
+}
+
+/// Why an artifact is not healthy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtifactCondition {
+    /// Fails to parse or validate — absent at dispatch time.
+    Faulty,
+    /// A managed default this binary no longer ships.
+    Deprecated,
+    /// Drifted from the current release, or colliding with a bundled name.
+    Stale,
+}
+
+impl ArtifactCondition {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Faulty => "faulty",
+            Self::Deprecated => "deprecated",
+            Self::Stale => "stale",
+        }
+    }
+}
+
+/// What the managed manifest proves about who wrote an artifact's content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtifactProvenance {
+    /// The recorded digest matches the file: Orbit wrote exactly this content.
+    OrbitWritten,
+    /// Tracked by the manifest, but edited since Orbit wrote it.
+    LocallyModified,
+    /// No managed provenance at all — authored in this workspace.
+    UserAuthored,
+}
+
+impl ArtifactProvenance {
+    /// Whether `--fix-stale-artifacts` may delete this file outright. Only a
+    /// digest match proves Orbit wrote it and that no local edit is at risk.
+    fn is_removable(self) -> bool {
+        matches!(self, Self::OrbitWritten)
+    }
+}
+
+/// One unhealthy artifact.
+#[derive(Debug, Clone)]
+pub struct ArtifactFinding {
+    pub kind: ArtifactKind,
+    /// Manifest key / definition name.
+    pub name: String,
+    pub path: PathBuf,
+    pub condition: ArtifactCondition,
+    pub provenance: ArtifactProvenance,
+    /// Human-readable specifics.
+    pub detail: String,
+    /// The exact repair command or manual step for this finding.
+    pub remediation: String,
+}
+
+impl ArtifactFinding {
+    /// A shipped default that no longer loads is a broken install rather than
+    /// a workspace authoring mistake, and is the only artifact fault that
+    /// escalates `orbit doctor` to a nonzero exit.
+    pub fn is_unloadable_shipped_default(&self) -> bool {
+        self.condition == ArtifactCondition::Faulty
+            && self.provenance != ArtifactProvenance::UserAuthored
+    }
+}
+
+/// Per-kind diagnosis: what was inspected and what came back unhealthy.
+#[derive(Debug, Clone)]
+pub struct ArtifactHealth {
+    pub kind: ArtifactKind,
+    /// Artifact files inspected for this kind.
+    pub scanned: usize,
+    /// Unhealthy artifacts, deterministically ordered.
+    pub findings: Vec<ArtifactFinding>,
+}
+
+/// One kind's managed directory plus the assets this binary currently ships
+/// for it.
+struct ManagedCatalog {
+    kind: ArtifactKind,
+    dir: PathBuf,
+    /// Manifest key → rendered content, when this binary can reproduce what it
+    /// would write here. `None` for routines: their rendered form pins a host
+    /// identity that higher-level composition owns and that core deliberately
+    /// never resolves on its own, so content drift is not decidable here (name
+    /// retirement and collisions still are).
+    embedded: Option<BTreeMap<String, String>>,
+    /// Manifest keys this binary ships, always known.
+    shipped: BTreeSet<String>,
+}
+
+impl ManagedCatalog {
+    fn rendered(
+        kind: ArtifactKind,
+        dir: PathBuf,
+        assets: impl IntoIterator<Item = (String, String)>,
+    ) -> Self {
+        let embedded: BTreeMap<String, String> = assets.into_iter().collect();
+        let shipped = embedded.keys().cloned().collect();
+        Self {
+            kind,
+            dir,
+            embedded: Some(embedded),
+            shipped,
+        }
+    }
+
+    fn names_only(
+        kind: ArtifactKind,
+        dir: PathBuf,
+        names: impl IntoIterator<Item = String>,
+    ) -> Self {
+        Self {
+            kind,
+            dir,
+            embedded: None,
+            shipped: names.into_iter().collect(),
+        }
+    }
+
+    fn path_of(&self, name: &str) -> PathBuf {
+        self.dir.join(self.kind.layout().relative_path(name))
+    }
+}
+
+/// Every managed catalog for this runtime, in doctor display order.
+fn managed_catalogs(runtime: &OrbitRuntime) -> Vec<ManagedCatalog> {
+    let global_root = runtime.global_root();
+    let local_dir = runtime.paths().local_dir.clone();
+    let owned = |assets: &[(&str, &str)]| -> Vec<(String, String)> {
+        assets
+            .iter()
+            .map(|(name, content)| ((*name).to_string(), (*content).to_string()))
+            .collect()
+    };
+
+    vec![
+        ManagedCatalog::rendered(
+            ArtifactKind::Skill,
+            global_root.join("skills"),
+            DEFAULT_SKILL_FILES.iter().map(|(name, content)| {
+                (
+                    (*name).to_string(),
+                    inject_skill_template_tokens(content, &global_root),
+                )
+            }),
+        ),
+        ManagedCatalog::rendered(
+            ArtifactKind::Job,
+            global_root.join("resources/jobs"),
+            owned(DEFAULT_JOB_FILES),
+        ),
+        ManagedCatalog::rendered(
+            ArtifactKind::Activity,
+            global_root.join("resources/activities"),
+            owned(DEFAULT_ACTIVITY_FILES),
+        ),
+        ManagedCatalog::rendered(
+            ArtifactKind::AutoTask,
+            auto_tasks_dir(&local_dir),
+            owned(DEFAULT_AUTO_TASK_FILES),
+        ),
+        ManagedCatalog::names_only(
+            ArtifactKind::Routine,
+            local_dir.join("routines"),
+            DEFAULT_ROUTINE_FILES
+                .iter()
+                .map(|(name, _)| (*name).to_string()),
+        ),
+    ]
+}
+
+impl OrbitRuntime {
+    /// Diagnose every definition-artifact kind. Probe failures degrade into
+    /// findings rather than aborting the pass, mirroring `orbit doctor`'s
+    /// contract that one broken subsystem never hides the rest.
+    pub fn inspect_definition_artifacts(&self) -> Result<Vec<ArtifactHealth>, OrbitError> {
+        let mut report = Vec::new();
+        for catalog in managed_catalogs(self) {
+            report.push(diagnose_catalog(self, &catalog));
+        }
+        Ok(report)
+    }
+
+    /// Retire deprecated managed artifacts: delete the ones whose recorded
+    /// digest proves Orbit wrote them, preserve locally modified ones outside
+    /// the active catalog, and leave everything else — faulty, stale, and
+    /// user-authored files alike — exactly as found.
+    ///
+    /// Returns the number of artifacts removed from the active catalog.
+    pub fn remove_stale_definition_artifacts(&self) -> Result<usize, OrbitError> {
+        let mut removed = 0usize;
+        for catalog in managed_catalogs(self) {
+            removed += retire_catalog(&catalog)?;
+        }
+        Ok(removed)
+    }
+}
+
+/// Read one artifact file, treating an unreadable file as absent.
+fn read_artifact(path: &Path) -> Option<String> {
+    std::fs::read_to_string(path).ok()
+}
+
+/// Classify a file's provenance against the manifest digest recorded for it.
+fn provenance(tracked: Option<&String>, on_disk: &str) -> ArtifactProvenance {
+    match tracked {
+        Some(digest) if *digest == sha256_hex(on_disk.as_bytes()) => {
+            ArtifactProvenance::OrbitWritten
+        }
+        Some(_) => ArtifactProvenance::LocallyModified,
+        None => ArtifactProvenance::UserAuthored,
+    }
+}
+
+fn diagnose_catalog(runtime: &OrbitRuntime, catalog: &ManagedCatalog) -> ArtifactHealth {
+    let kind = catalog.kind;
+    let mut findings = Vec::new();
+
+    if !catalog.dir.is_dir() {
+        return ArtifactHealth {
+            kind,
+            scanned: 0,
+            findings,
+        };
+    }
+
+    let manifest_path = catalog.dir.join(MANAGED_ASSET_MANIFEST_FILE);
+    let manifest = match load_managed_asset_manifest(
+        &manifest_path,
+        kind.asset_kind(),
+        kind.layout(),
+    ) {
+        Ok(manifest) => manifest,
+        Err(error) => {
+            // An unreadable manifest costs provenance for the whole kind, so
+            // say so instead of silently reporting every artifact as
+            // user-authored.
+            findings.push(ArtifactFinding {
+                kind,
+                name: MANAGED_ASSET_MANIFEST_FILE.to_string(),
+                path: manifest_path,
+                condition: ArtifactCondition::Faulty,
+                provenance: ArtifactProvenance::OrbitWritten,
+                detail: format!("managed {} manifest is unreadable: {error}", kind.singular()),
+                remediation: format!(
+                    "Repair or move aside the {} manifest, then run `orbit init --refresh-defaults`.",
+                    kind.singular()
+                ),
+            });
+            return ArtifactHealth {
+                kind,
+                scanned: 0,
+                findings,
+            };
+        }
+    };
+    let tracked: BTreeMap<String, String> = manifest
+        .as_ref()
+        .map(|manifest| manifest.assets.clone())
+        .unwrap_or_default();
+
+    // Deprecated: tracked by the manifest, still on disk, no longer shipped.
+    for (name, digest) in &tracked {
+        if catalog.shipped.contains(name) {
+            continue;
+        }
+        let path = catalog.path_of(name);
+        let Some(on_disk) = read_artifact(&path) else {
+            continue;
+        };
+        let provenance = provenance(Some(digest), &on_disk);
+        let detail = if provenance.is_removable() {
+            format!(
+                "`{name}` is a managed default this Orbit no longer ships; its content is \
+                 unmodified, so it can be retired safely"
+            )
+        } else {
+            format!(
+                "`{name}` is a managed default this Orbit no longer ships, but it was locally \
+                 modified; it will be preserved outside the active catalog rather than deleted"
+            )
+        };
+        findings.push(ArtifactFinding {
+            kind,
+            name: name.clone(),
+            path,
+            condition: ArtifactCondition::Deprecated,
+            provenance,
+            detail,
+            remediation: "Run `orbit doctor --fix-stale-artifacts`.".to_string(),
+        });
+    }
+
+    // Stale: a managed copy of an older release, or an untracked file wearing
+    // a bundled default's name.
+    if let Some(embedded) = &catalog.embedded {
+        for (name, rendered) in embedded {
+            let path = catalog.path_of(name);
+            let Some(on_disk) = read_artifact(&path) else {
+                continue;
+            };
+            let on_disk_digest = sha256_hex(on_disk.as_bytes());
+            let rendered_digest = sha256_hex(rendered.as_bytes());
+            if on_disk_digest == rendered_digest {
+                continue;
+            }
+            match tracked.get(name) {
+                // Orbit's own copy, unedited, but from an older release.
+                Some(digest) if *digest == on_disk_digest => findings.push(ArtifactFinding {
+                    kind,
+                    name: name.clone(),
+                    path,
+                    condition: ArtifactCondition::Stale,
+                    provenance: ArtifactProvenance::OrbitWritten,
+                    detail: format!(
+                        "`{name}` is an Orbit-written copy of an older release of this bundled \
+                         default and has drifted from the content this binary ships"
+                    ),
+                    remediation: "Run `orbit init --refresh-defaults`.".to_string(),
+                }),
+                // Edited after Orbit wrote it: intentional local authorship,
+                // not staleness. Refreshing would discard the edit, so this is
+                // deliberately not reported.
+                Some(_) => {}
+                // Untracked file occupying a bundled default's name — the
+                // collision ADR-0346 already warns about at init time.
+                None if manifest.is_some() => findings.push(ArtifactFinding {
+                    kind,
+                    name: name.clone(),
+                    path: path.clone(),
+                    condition: ArtifactCondition::Stale,
+                    provenance: ArtifactProvenance::UserAuthored,
+                    detail: format!(
+                        "user-authored `{}` collides with bundled default `{name}`, so the \
+                         bundled default is not installed",
+                        path.display()
+                    ),
+                    remediation: format!(
+                        "Move or rename `{}`, then run `orbit init --refresh-defaults` to install the bundled default.",
+                        path.display()
+                    ),
+                }),
+                None => {}
+            }
+        }
+    }
+
+    // Faulty: whatever is on disk now, does it still load?
+    let (scanned, faults) = collect_faults(runtime, catalog);
+    for (name, path, message) in faults {
+        let provenance = read_artifact(&path)
+            .map(|on_disk| provenance(tracked.get(&name), &on_disk))
+            .unwrap_or(ArtifactProvenance::UserAuthored);
+        let remediation = if provenance == ArtifactProvenance::OrbitWritten {
+            format!(
+                "A shipped {} default failed to load — reinstall or upgrade orbit, then run `orbit init --refresh-defaults`.",
+                kind.singular()
+            )
+        } else {
+            format!(
+                "Fix the {} definition at `{}` (or move it aside), then rerun `orbit doctor`.",
+                kind.singular(),
+                path.display()
+            )
+        };
+        findings.push(ArtifactFinding {
+            kind,
+            name,
+            path,
+            condition: ArtifactCondition::Faulty,
+            provenance,
+            detail: message,
+            remediation,
+        });
+    }
+
+    findings.sort_by(|left, right| {
+        (left.condition.as_str(), &left.name).cmp(&(right.condition.as_str(), &right.name))
+    });
+    ArtifactHealth {
+        kind,
+        scanned,
+        findings,
+    }
+}
+
+/// Load every artifact of one kind through its real loader, returning
+/// `(inspected count, failures)`. Using the production loader is the point:
+/// doctor must report exactly what dispatch would find, not a parallel parse.
+fn collect_faults(
+    runtime: &OrbitRuntime,
+    catalog: &ManagedCatalog,
+) -> (usize, Vec<(String, PathBuf, String)>) {
+    let mut faults = Vec::new();
+
+    if catalog.kind == ArtifactKind::Skill {
+        let rows = match runtime.skill_catalog().doctor() {
+            Ok(rows) => rows,
+            Err(error) => {
+                faults.push((
+                    "<catalog>".to_string(),
+                    catalog.dir.clone(),
+                    format!("cannot enumerate skills: {error}"),
+                ));
+                return (0, faults);
+            }
+        };
+        let scanned = rows.len();
+        for row in rows {
+            if row.status == crate::skill_catalog::SkillCatalogDoctorStatus::Error {
+                let path = catalog.dir.join(&row.skill_id).join("SKILL.md");
+                faults.push((format!("{}/SKILL.md", row.skill_id), path, row.message));
+            }
+        }
+        return (scanned, faults);
+    }
+
+    if catalog.kind == ArtifactKind::AutoTask {
+        // The auto-task loader owns rules beyond parsing (the file stem must
+        // equal the definition name), so reuse it wholesale.
+        let collection = collect_auto_tasks(&runtime.paths().local_dir);
+        let scanned = collection.definitions.len() + collection.errors.len();
+        for error in collection.errors {
+            let path = error.path.unwrap_or_else(|| catalog.dir.clone());
+            let name = path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or_default()
+                .to_string();
+            faults.push((name, path, error.message));
+        }
+        return (scanned, faults);
+    }
+
+    let Ok(entries) = std::fs::read_dir(&catalog.dir) else {
+        return (0, faults);
+    };
+    let mut paths: Vec<PathBuf> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| {
+                    extension.eq_ignore_ascii_case("yaml") || extension.eq_ignore_ascii_case("yml")
+                })
+        })
+        .collect();
+    paths.sort();
+
+    let scanned = paths.len();
+    for path in paths {
+        let name = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or_default()
+            .to_string();
+        let Some(raw) = read_artifact(&path) else {
+            faults.push((name, path, "file is unreadable".to_string()));
+            continue;
+        };
+        let outcome = match catalog.kind {
+            ArtifactKind::Activity => load_activity_asset(&raw)
+                .map(|_| ())
+                .map_err(|e| e.to_string()),
+            ArtifactKind::Job => load_job_asset(&raw).map(|_| ()).map_err(|e| e.to_string()),
+            ArtifactKind::Routine => parse_routine_yaml(&raw)
+                .map(|_| ())
+                .map_err(|e| e.to_string()),
+            ArtifactKind::Skill | ArtifactKind::AutoTask => Ok(()),
+        };
+        if let Err(message) = outcome {
+            faults.push((name, path, message));
+        }
+    }
+    (scanned, faults)
+}
+
+/// Retire one catalog's deprecated managed artifacts and drop them from its
+/// manifest. Returns how many left the active catalog.
+fn retire_catalog(catalog: &ManagedCatalog) -> Result<usize, OrbitError> {
+    let kind = catalog.kind;
+    let manifest_path = catalog.dir.join(MANAGED_ASSET_MANIFEST_FILE);
+    let Some(manifest) =
+        load_managed_asset_manifest(&manifest_path, kind.asset_kind(), kind.layout())?
+    else {
+        return Ok(0);
+    };
+
+    let mut retired = 0usize;
+    let mut settled = Vec::new();
+    for (name, digest) in &manifest.assets {
+        if catalog.shipped.contains(name) {
+            continue;
+        }
+        let relative = kind.layout().relative_path(name);
+        let Some(on_disk) = read_artifact(&catalog.dir.join(&relative)) else {
+            // Already gone: drop the manifest entry so the next pass is clean.
+            settled.push(name.clone());
+            continue;
+        };
+        let path = match resolve_removable_artifact(&catalog.dir, &relative)? {
+            Some(path) => path,
+            // A symlinked artifact is a deliberate operator arrangement;
+            // removing it here would act on a target outside this catalog.
+            None => continue,
+        };
+        if provenance(Some(digest), &on_disk).is_removable() {
+            std::fs::remove_file(&path).map_err(|error| {
+                OrbitError::Io(format!(
+                    "retire deprecated {} '{}': {error}",
+                    kind.singular(),
+                    path.display()
+                ))
+            })?;
+        } else {
+            let preserved = preserve_modified_retired_asset(
+                &catalog.dir,
+                kind.asset_kind(),
+                kind.layout(),
+                name,
+                &path,
+            )?;
+            tracing::warn!(
+                target: "orbit.core.artifact_health",
+                artifact_kind = kind.singular(),
+                artifact = name.as_str(),
+                preserved = %preserved.display(),
+                "locally modified deprecated artifact was preserved outside the active catalog"
+            );
+        }
+        settled.push(name.clone());
+        retired += 1;
+    }
+
+    if !settled.is_empty() {
+        let mut next = manifest.clone();
+        for name in &settled {
+            next.assets.remove(name);
+        }
+        super::write_managed_asset_manifest(&manifest_path, &next)?;
+    }
+    Ok(retired)
+}
+
+/// Resolve a managed artifact for removal, refusing anything that could act
+/// outside `dir`.
+///
+/// The relative path is re-validated even though it came from a manifest that
+/// validated it on load, and the final component is inspected with
+/// `symlink_metadata` so removal never follows a symlink at the boundary —
+/// mirroring `remove_workspace_subtree` in the doctor's lock cleanup.
+fn resolve_removable_artifact(dir: &Path, relative: &Path) -> Result<Option<PathBuf>, OrbitError> {
+    if relative.is_absolute()
+        || relative.components().any(|component| {
+            matches!(
+                component,
+                std::path::Component::ParentDir
+                    | std::path::Component::RootDir
+                    | std::path::Component::Prefix(_)
+            )
+        })
+    {
+        return Err(OrbitError::InvalidInput(format!(
+            "managed artifact path '{}' must remain relative to '{}'",
+            relative.display(),
+            dir.display()
+        )));
+    }
+    let target = dir.join(relative);
+    let metadata = match std::fs::symlink_metadata(&target) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "inspect managed artifact {}: {error}",
+                target.display()
+            )));
+        }
+    };
+    if metadata.file_type().is_symlink() || metadata.is_dir() {
+        return Ok(None);
+    }
+    Ok(Some(target))
+}

--- a/crates/orbit-core/src/command/init.rs
+++ b/crates/orbit-core/src/command/init.rs
@@ -7,6 +7,7 @@ use orbit_store::{friction_store, global_executor_def_store, global_policy_def_s
 
 use crate::OrbitRuntime;
 use crate::auto_tasks::seed_default_auto_tasks;
+use crate::command::MANAGED_ASSET_MANIFEST_FILE;
 use crate::command::activity::seed_default_activities;
 use crate::command::executor::seed_default_executors;
 use crate::command::job::seed_default_jobs;
@@ -142,8 +143,11 @@ pub fn init_workspace_at_root(
     };
 
     let overwrite = options.force || options.refresh_defaults;
+    let mut skill_asset_warnings: Vec<String> = Vec::new();
     let mut refreshed_skill_files = if options.global_only {
-        seed_default_skills(&skills_root, &orbit_root, overwrite)?
+        let reconciliation = seed_default_skills(&skills_root, &orbit_root, overwrite)?;
+        skill_asset_warnings = reconciliation.warnings;
+        reconciliation.refreshed
     } else {
         0
     };
@@ -190,7 +194,8 @@ pub fn init_workspace_at_root(
         let refreshed_default_policies = seed_default_policies(policy_store.as_ref(), overwrite)?;
         let activity_reconciliation = seed_default_activities(&layout.activities_dir, overwrite)?;
         let job_reconciliation = seed_default_jobs(&layout.jobs_dir, overwrite)?;
-        let mut managed_asset_warnings = activity_reconciliation.warnings;
+        let mut managed_asset_warnings = std::mem::take(&mut skill_asset_warnings);
+        managed_asset_warnings.extend(activity_reconciliation.warnings);
         managed_asset_warnings.extend(job_reconciliation.warnings);
         (
             activity_reconciliation.refreshed,
@@ -220,12 +225,16 @@ pub fn init_workspace_at_root(
         )?;
         refreshed_skill_files = global_result.refreshed_skill_files;
         created_skills_symlink = global_result.created_skills_symlink;
+        // Routines and auto-tasks are workspace-scoped, so their managed-asset
+        // reconciliation happens here rather than in the global branch; fold
+        // their warnings in alongside the global (skill/activity/job) ones.
+        let mut managed_asset_warnings = global_result.managed_asset_warnings;
         // Routines are workspace-authored (`.orbit/routines/`, no global
         // directory), so defaults seed here rather than in the global branch.
         // Host identity is owned by higher-level composition and injected;
         // Core never opens host.toml or falls back to an OS hostname.
         if let Some(host_id) = options.routine_host_id.as_deref() {
-            refreshed_default_routines = seed_default_routines(
+            let reconciliation = seed_default_routines(
                 &orbit_root.join("routines"),
                 host_id,
                 workspace_slug_from_orbit_root(&orbit_root).as_deref(),
@@ -235,17 +244,21 @@ pub fn init_workspace_at_root(
                 // destructive `force` already recreated the root.
                 options.force,
             )?;
+            refreshed_default_routines = reconciliation.refreshed;
+            managed_asset_warnings.extend(reconciliation.warnings);
         }
         // Auto-task definitions are workspace-authored after seeding. Never
         // refresh an existing file: `workspace init --force` reconciles
         // registration and must not overwrite an operator's definition.
-        seeded_default_auto_tasks = seed_default_auto_tasks(&orbit_root)?;
+        let auto_task_reconciliation = seed_default_auto_tasks(&orbit_root)?;
+        seeded_default_auto_tasks = auto_task_reconciliation.refreshed;
+        managed_asset_warnings.extend(auto_task_reconciliation.warnings);
         (
             global_result.refreshed_default_activities,
             global_result.retired_default_activities,
             global_result.refreshed_default_jobs,
             global_result.retired_default_jobs,
-            global_result.managed_asset_warnings,
+            managed_asset_warnings,
             global_result.refreshed_default_executors,
             global_result.refreshed_default_policies,
             RuntimeConfig::load_layered(&global_root, &orbit_root)?.scoring_enabled,
@@ -402,9 +415,29 @@ fn remove_workspace_seeded_default_skills(
             remove_path_if_exists(&skills_dir.join(skill_id))?;
         }
 
+        // Skills are only ever seeded into the *global* root, so a managed
+        // manifest here describes skill trees that were just removed. Drop it
+        // once nothing else remains, otherwise it would keep an otherwise-empty
+        // legacy workspace skills directory alive forever.
+        if directory_holds_only(skills_dir, MANAGED_ASSET_MANIFEST_FILE)? {
+            remove_path_if_exists(&skills_dir.join(MANAGED_ASSET_MANIFEST_FILE))?;
+        }
         remove_empty_dir(skills_dir)?;
     }
     Ok(())
+}
+
+/// Whether `dir` contains exactly one entry, named `file_name`.
+fn directory_holds_only(dir: &Path, file_name: &str) -> Result<bool, OrbitError> {
+    if !dir.is_dir() {
+        return Ok(false);
+    }
+    let mut entries = fs::read_dir(dir).map_err(|e| OrbitError::Io(e.to_string()))?;
+    let Some(first) = entries.next() else {
+        return Ok(false);
+    };
+    let first = first.map_err(|e| OrbitError::Io(e.to_string()))?;
+    Ok(first.file_name() == file_name && entries.next().is_none())
 }
 
 fn remove_empty_dir(dir: &Path) -> Result<(), OrbitError> {
@@ -797,7 +830,12 @@ mod tests {
         restore_home(previous_home);
 
         let result = result.expect("init global");
-        assert_eq!(result.refreshed_skill_files, default_skill_ids().len());
+        // Skills are now reconciled per managed file rather than per skill
+        // directory, so a refresh counts every SKILL.md *and* reference file.
+        assert_eq!(
+            result.refreshed_skill_files,
+            crate::command::skill::DEFAULT_SKILL_FILES.len()
+        );
         assert!(result.created_skills_symlink);
         assert!(
             home.path()
@@ -877,7 +915,12 @@ mod tests {
         restore_home(previous_home);
 
         let result = result.expect("init workspace");
-        assert_eq!(result.refreshed_skill_files, default_skill_ids().len());
+        // Skills are now reconciled per managed file rather than per skill
+        // directory, so a refresh counts every SKILL.md *and* reference file.
+        assert_eq!(
+            result.refreshed_skill_files,
+            crate::command::skill::DEFAULT_SKILL_FILES.len()
+        );
         assert!(result.created_skills_symlink);
         assert!(
             !orbit_root

--- a/crates/orbit-core/src/command/job/catalog.rs
+++ b/crates/orbit-core/src/command/job/catalog.rs
@@ -8,7 +8,7 @@ use orbit_common::types::{JobKind, JobRun, JobScheduleState, JobV2, NotFoundKind
 use serde_json::Value;
 
 use crate::OrbitRuntime;
-use crate::command::{ManagedAssetReconciliation, reconcile_managed_assets};
+use crate::command::{ManagedAssetLayout, ManagedAssetReconciliation, reconcile_managed_assets};
 
 /// Shippable default workflow assets, seeded under
 /// `<orbit_root>/resources/jobs/<name>.yaml` on `orbit init`. The entries
@@ -18,7 +18,7 @@ use crate::command::{ManagedAssetReconciliation, reconcile_managed_assets};
 /// under `crates/orbit-core/assets/jobs/examples/` and are NOT seeded —
 /// they exist for `crates/orbit-engine/examples/v2_job_runtime_smoke.rs`
 /// only.
-const DEFAULT_JOB_FILES: &[(&str, &str)] = &[
+pub(crate) const DEFAULT_JOB_FILES: &[(&str, &str)] = &[
     (
         "auto_task_scheduler_pipeline",
         include_str!("../../../assets/jobs/auto_task_scheduler_pipeline.yaml"),
@@ -289,6 +289,7 @@ pub(crate) fn seed_default_jobs(
     reconcile_managed_assets(
         jobs_dir,
         "job",
+        ManagedAssetLayout::YamlStem,
         DEFAULT_JOB_FILES,
         overwrite,
         |_, content| Ok(Cow::Borrowed(content)),

--- a/crates/orbit-core/src/command/job/mod.rs
+++ b/crates/orbit-core/src/command/job/mod.rs
@@ -1,4 +1,4 @@
-mod catalog;
+pub(crate) mod catalog;
 mod exec;
 pub(crate) mod pipeline;
 mod resume;

--- a/crates/orbit-core/src/command/mod.rs
+++ b/crates/orbit-core/src/command/mod.rs
@@ -25,30 +25,6 @@ use sha2::{Digest, Sha256};
 /// [ORB-10016] and stamps the same identity.
 pub const SYSTEM_AUDIT_IDENTITY: &str = "system";
 
-/// Seed every `(name, content)` pair in `files` as `<dir>/<name>.yaml`,
-/// skipping entries that already exist unless `overwrite` is set. `render`
-/// maps each embedded asset's raw content to what actually gets written —
-/// activity and job seeding pass content through unchanged; routine seeding
-/// uses it for placeholder substitution and fail-closed validation.
-pub(crate) fn seed_embedded_assets<'a>(
-    dir: &Path,
-    files: &'a [(&'a str, &'a str)],
-    overwrite: bool,
-    mut render: impl FnMut(&'a str, &'a str) -> Result<Cow<'a, str>, OrbitError>,
-) -> Result<usize, OrbitError> {
-    let mut count = 0usize;
-    for (name, content) in files {
-        let path = dir.join(format!("{name}.yaml"));
-        if !overwrite && path.exists() {
-            continue;
-        }
-        let rendered = render(name, content)?;
-        write_text_with_parent(&path, &rendered)?;
-        count += 1;
-    }
-    Ok(count)
-}
-
 const MANAGED_ASSET_MANIFEST_FILE: &str = ".orbit-managed-assets.json";
 const MANAGED_ASSET_MANIFEST_SCHEMA_VERSION: u32 = 1;
 
@@ -57,6 +33,33 @@ pub(crate) struct ManagedAssetReconciliation {
     pub refreshed: usize,
     pub retired: usize,
     pub warnings: Vec<String>,
+}
+
+/// How a manifest key maps to the file it manages, relative to the managed
+/// directory.
+///
+/// Four of the five artifact kinds are flat single-document catalogs whose
+/// manifest key is the definition name ([`ManagedAssetLayout::YamlStem`]).
+/// Skills are directory trees — one `SKILL.md` plus optional reference files
+/// per skill id — so their manifest keys are the relative paths themselves
+/// ([`ManagedAssetLayout::RelativePath`]).
+// ADR-0366 extends ADR-0346's provenance mechanism to tree-shaped assets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ManagedAssetLayout {
+    /// `<name>.yaml` — activities, jobs, auto-tasks, routines.
+    YamlStem,
+    /// `<name>` verbatim, a `/`-separated relative path — skills.
+    RelativePath,
+}
+
+impl ManagedAssetLayout {
+    /// Resolve one manifest key to its path relative to the managed directory.
+    fn relative_path(self, name: &str) -> PathBuf {
+        match self {
+            Self::YamlStem => PathBuf::from(format!("{name}.yaml")),
+            Self::RelativePath => PathBuf::from(name),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -81,17 +84,18 @@ struct ManagedAssetManifest {
 pub(crate) fn reconcile_managed_assets<'a>(
     dir: &Path,
     asset_kind: &str,
+    layout: ManagedAssetLayout,
     files: &'a [(&'a str, &'a str)],
     overwrite: bool,
     mut render: impl FnMut(&'a str, &'a str) -> Result<Cow<'a, str>, OrbitError>,
 ) -> Result<ManagedAssetReconciliation, OrbitError> {
-    validate_managed_asset_name(asset_kind, "asset kind")?;
+    validate_managed_asset_name(asset_kind, ManagedAssetLayout::YamlStem, "asset kind")?;
     for (name, _) in files {
-        validate_managed_asset_name(name, "embedded asset")?;
+        validate_managed_asset_name(name, layout, "embedded asset")?;
     }
 
     let manifest_path = dir.join(MANAGED_ASSET_MANIFEST_FILE);
-    let previous = load_managed_asset_manifest(&manifest_path, asset_kind)?;
+    let previous = load_managed_asset_manifest(&manifest_path, asset_kind, layout)?;
     let current_names: BTreeSet<&str> = files.iter().map(|(name, _)| *name).collect();
     let mut result = ManagedAssetReconciliation::default();
 
@@ -100,7 +104,7 @@ pub(crate) fn reconcile_managed_assets<'a>(
             if current_names.contains(name.as_str()) {
                 continue;
             }
-            let path = dir.join(format!("{name}.yaml"));
+            let path = dir.join(layout.relative_path(name));
             if !path.exists() {
                 continue;
             }
@@ -118,7 +122,8 @@ pub(crate) fn reconcile_managed_assets<'a>(
                     ))
                 })?;
             } else {
-                let preserved = preserve_modified_retired_asset(dir, asset_kind, name, &path)?;
+                let preserved =
+                    preserve_modified_retired_asset(dir, asset_kind, layout, name, &path)?;
                 result.warnings.push(format!(
                     "retired managed {asset_kind} `{name}` was locally modified; Orbit removed it from the active catalog and preserved it at '{}'. Review that file, then migrate it under a new user-authored name or delete it",
                     preserved.display()
@@ -130,7 +135,7 @@ pub(crate) fn reconcile_managed_assets<'a>(
 
     let mut next_assets = BTreeMap::new();
     for (name, embedded) in files {
-        let path = dir.join(format!("{name}.yaml"));
+        let path = dir.join(layout.relative_path(name));
         let rendered = render(name, embedded)?;
         let rendered_digest = sha256_hex(rendered.as_bytes());
 
@@ -180,7 +185,11 @@ pub(crate) fn reconcile_managed_assets<'a>(
         result.refreshed += 1;
     }
 
-    if previous.is_none() {
+    // The legacy sweep only makes sense for the flat YAML catalogs: a skill
+    // tree's untracked files are ordinary reference material inside an
+    // otherwise-managed directory, not stray definitions the loader would pick
+    // up.
+    if previous.is_none() && layout == ManagedAssetLayout::YamlStem {
         let ambiguous = ambiguous_legacy_yaml_files(dir, &next_assets)?;
         if !ambiguous.is_empty() {
             result.warnings.push(format!(
@@ -200,18 +209,7 @@ pub(crate) fn reconcile_managed_assets<'a>(
         assets: next_assets,
     };
     if previous.as_ref() != Some(&manifest) {
-        let mut encoded = serde_json::to_string_pretty(&manifest).map_err(|error| {
-            OrbitError::Store(format!(
-                "serialize managed {asset_kind} asset manifest: {error}"
-            ))
-        })?;
-        encoded.push('\n');
-        atomic_write_text(&manifest_path, &encoded).map_err(|error| {
-            OrbitError::Io(format!(
-                "write managed {asset_kind} asset manifest '{}': {error}",
-                manifest_path.display()
-            ))
-        })?;
+        write_managed_asset_manifest(&manifest_path, &manifest)?;
     }
 
     for warning in &result.warnings {
@@ -226,9 +224,31 @@ pub(crate) fn reconcile_managed_assets<'a>(
     Ok(result)
 }
 
+/// Persist one managed-asset manifest. Callers compare against the previous
+/// manifest first so a steady-state bootstrap performs no write at all.
+fn write_managed_asset_manifest(
+    manifest_path: &Path,
+    manifest: &ManagedAssetManifest,
+) -> Result<(), OrbitError> {
+    let asset_kind = &manifest.asset_kind;
+    let mut encoded = serde_json::to_string_pretty(manifest).map_err(|error| {
+        OrbitError::Store(format!(
+            "serialize managed {asset_kind} asset manifest: {error}"
+        ))
+    })?;
+    encoded.push('\n');
+    atomic_write_text(manifest_path, &encoded).map_err(|error| {
+        OrbitError::Io(format!(
+            "write managed {asset_kind} asset manifest '{}': {error}",
+            manifest_path.display()
+        ))
+    })
+}
+
 fn load_managed_asset_manifest(
     path: &Path,
     expected_kind: &str,
+    layout: ManagedAssetLayout,
 ) -> Result<Option<ManagedAssetManifest>, OrbitError> {
     if !path.exists() {
         return Ok(None);
@@ -261,19 +281,48 @@ fn load_managed_asset_manifest(
         )));
     }
     for name in manifest.assets.keys() {
-        validate_managed_asset_name(name, "manifest asset")?;
+        validate_managed_asset_name(name, layout, "manifest asset")?;
     }
     Ok(Some(manifest))
 }
 
-fn validate_managed_asset_name(name: &str, source: &str) -> Result<(), OrbitError> {
-    if name.is_empty()
-        || !name
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
-    {
+/// Reject any manifest key that would not stay inside the managed directory.
+///
+/// A stem is a single path component of the safe charset. A relative path is a
+/// `/`-separated sequence of such components: no absolute prefix, no `.`/`..`
+/// component, and a restricted charset per component, so a manifest can never
+/// steer a write or a removal outside the directory it manages.
+fn validate_managed_asset_name(
+    name: &str,
+    layout: ManagedAssetLayout,
+    source: &str,
+) -> Result<(), OrbitError> {
+    let component_ok = |component: &str| {
+        !component.is_empty()
+            && component != "."
+            && component != ".."
+            && component.bytes().all(|byte| {
+                byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-' || byte == b'.'
+            })
+    };
+    let valid = match layout {
+        // A stem is one component and never carries an extension separator.
+        ManagedAssetLayout::YamlStem => {
+            !name.is_empty()
+                && name
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+        }
+        ManagedAssetLayout::RelativePath => {
+            !name.is_empty()
+                && !name.starts_with('/')
+                && !name.contains('\\')
+                && name.split('/').all(component_ok)
+        }
+    };
+    if !valid {
         return Err(OrbitError::InvalidInput(format!(
-            "{source} name `{name}` is not a safe managed asset file stem"
+            "{source} name `{name}` is not a safe managed asset path"
         )));
     }
     Ok(())
@@ -282,40 +331,61 @@ fn validate_managed_asset_name(name: &str, source: &str) -> Result<(), OrbitErro
 fn preserve_modified_retired_asset(
     active_dir: &Path,
     asset_kind: &str,
+    layout: ManagedAssetLayout,
     name: &str,
     source: &Path,
 ) -> Result<PathBuf, OrbitError> {
-    let backup_dir = active_dir
+    let backup_root = active_dir
         .parent()
         .unwrap_or(active_dir)
         .join(".retired-managed")
         .join(managed_asset_kind_directory(asset_kind));
-    fs::create_dir_all(&backup_dir).map_err(|error| {
-        OrbitError::Io(format!(
-            "create retired managed asset backup '{}': {error}",
-            backup_dir.display()
-        ))
-    })?;
+    let relative = layout.relative_path(name);
 
     let mut suffix = 0usize;
     loop {
-        let file_name = if suffix == 0 {
-            format!("{name}.yaml")
+        // Disambiguate on the file stem so a preserved `SKILL.md` keeps its
+        // extension and stays readable in place.
+        let destination = if suffix == 0 {
+            backup_root.join(&relative)
         } else {
-            format!("{name}.{suffix}.yaml")
+            let file_name = relative
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| {
+                    OrbitError::InvalidInput(format!(
+                        "retired managed {asset_kind} `{name}` has no file name to preserve"
+                    ))
+                })?;
+            let (stem, extension) = file_name
+                .rsplit_once('.')
+                .map_or((file_name, String::new()), |(stem, extension)| {
+                    (stem, format!(".{extension}"))
+                });
+            backup_root
+                .join(&relative)
+                .with_file_name(format!("{stem}.{suffix}{extension}"))
         };
-        let destination = backup_dir.join(file_name);
-        if !destination.exists() {
-            fs::rename(source, &destination).map_err(|error| {
+        if destination.exists() {
+            suffix += 1;
+            continue;
+        }
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
                 OrbitError::Io(format!(
-                    "preserve modified retired {asset_kind} '{}' as '{}': {error}",
-                    source.display(),
-                    destination.display()
+                    "create retired managed asset backup '{}': {error}",
+                    parent.display()
                 ))
             })?;
-            return Ok(destination);
         }
-        suffix += 1;
+        fs::rename(source, &destination).map_err(|error| {
+            OrbitError::Io(format!(
+                "preserve modified retired {asset_kind} '{}' as '{}': {error}",
+                source.display(),
+                destination.display()
+            ))
+        })?;
+        return Ok(destination);
     }
 }
 
@@ -363,6 +433,7 @@ fn sha256_hex(content: &[u8]) -> String {
 }
 
 pub(crate) mod activity;
+pub mod artifact_health;
 pub mod audit_event;
 pub mod backend_resolver;
 pub(crate) mod docs;

--- a/crates/orbit-core/src/command/routine.rs
+++ b/crates/orbit-core/src/command/routine.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 
 use orbit_common::types::{OrbitError, parse_routine_yaml};
 
-use super::seed_embedded_assets;
+use super::{ManagedAssetLayout, ManagedAssetReconciliation, reconcile_managed_assets};
 
 /// Shippable default routine assets, seeded under
 /// `<workspace>/.orbit/routines/<file>.yaml` on `orbit init`. Every entry
@@ -59,23 +59,33 @@ const ROUTINE_NAME_PLACEHOLDER: &str = "__ORBIT_ROUTINE_NAME__";
 /// job seeding convention: when `overwrite` is false (plain re-init),
 /// existing files are preserved. Destructive initialization may set
 /// `overwrite`, though `--force` normally recreates the whole root first.
+///
+/// Seeding is manifest-aware: the recorded digest is taken over the *rendered*
+/// document — after host-id and routine-name substitution — because that is
+/// what actually lands on disk. A default dropped from a later release is
+/// therefore retired by content provenance, and a re-seed of unchanged
+/// embedded content is a no-op rather than a rewrite.
 // ADR-0215: default routines are seeded per workspace with host and name
 // resolved at seed time — routines have no global directory and v1 requires
 // explicit host pinning and host-unique names.
+// ADR-0366: the recorded digest covers the rendered document, so a
+// placeholder-substituting asset still gets honest provenance.
 pub(crate) fn seed_default_routines(
     routines_dir: &Path,
     host_id: &str,
     workspace_slug: Option<&str>,
     overwrite: bool,
-) -> Result<usize, OrbitError> {
+) -> Result<ManagedAssetReconciliation, OrbitError> {
     let host_id = host_id.trim();
     if host_id.is_empty() {
         return Err(OrbitError::InvalidInput(
             "cannot seed default routines without a host id".to_string(),
         ));
     }
-    seed_embedded_assets(
+    reconcile_managed_assets(
         routines_dir,
+        "routine",
+        ManagedAssetLayout::YamlStem,
         DEFAULT_ROUTINE_FILES,
         overwrite,
         |file_stem, template| {
@@ -135,7 +145,7 @@ mod tests {
         let routines_dir = root.path().join(".orbit/routines");
         let seeded = seed_default_routines(&routines_dir, "test-host", Some("My Repo!"), true)
             .expect("seed default routines");
-        assert_eq!(seeded, DEFAULT_ROUTINE_FILES.len());
+        assert_eq!(seeded.refreshed, DEFAULT_ROUTINE_FILES.len());
 
         for (stem, target) in [
             ("auto_task_scheduler", "auto_task_scheduler_pipeline"),
@@ -207,7 +217,7 @@ mod tests {
         std::fs::write(&path, "user edited").expect("simulate user edit");
 
         let seeded = seed_default_routines(&routines_dir, "host-a", None, false).expect("re-seed");
-        assert_eq!(seeded, 0);
+        assert_eq!(seeded.refreshed, 0);
         assert_eq!(
             std::fs::read_to_string(&path).expect("read"),
             "user edited",
@@ -240,7 +250,7 @@ mod tests {
 
         let seeded = seed_default_routines(&routines_dir, "host-b", Some("workspace"), false)
             .expect("plain re-init");
-        assert_eq!(seeded, 1, "only the missing default is created");
+        assert_eq!(seeded.refreshed, 1, "only the missing default is created");
         assert_eq!(
             std::fs::read(&existing).expect("read existing routine bytes"),
             original,
@@ -253,6 +263,53 @@ mod tests {
         .expect("newly seeded task-pilot routine parses");
         assert_eq!(pilot.hosts, vec!["host-b".to_string()]);
         assert!(!pilot.enabled);
+    }
+
+    /// The recorded digest covers the *rendered* document, so re-seeding
+    /// unchanged embedded content against the same host and workspace must not
+    /// rewrite a single file — even under `overwrite`. A steady-state
+    /// bootstrap can then run against a read-only routines directory.
+    #[test]
+    fn reseeding_unchanged_rendered_content_is_a_no_op_not_a_rewrite() {
+        let root = tempdir().expect("create tempdir");
+        let routines_dir = root.path().join("routines");
+        seed_default_routines(&routines_dir, "host-a", Some("workspace"), true)
+            .expect("first seed");
+
+        let before: Vec<(std::path::PathBuf, std::time::SystemTime)> = DEFAULT_ROUTINE_FILES
+            .iter()
+            .map(|(stem, _)| {
+                let path = routines_dir.join(format!("{stem}.yaml"));
+                let modified = std::fs::metadata(&path)
+                    .and_then(|metadata| metadata.modified())
+                    .expect("read seeded routine mtime");
+                (path, modified)
+            })
+            .collect();
+
+        let reseeded = seed_default_routines(&routines_dir, "host-a", Some("workspace"), true)
+            .expect("re-seed unchanged rendered content");
+        assert_eq!(reseeded.refreshed, 0, "unchanged routines must not rewrite");
+        assert_eq!(reseeded.retired, 0);
+        assert!(reseeded.warnings.is_empty());
+
+        for (path, modified) in before {
+            let current = std::fs::metadata(&path)
+                .and_then(|metadata| metadata.modified())
+                .expect("read routine mtime after re-seed");
+            assert_eq!(
+                current,
+                modified,
+                "re-seed rewrote `{}` despite identical rendered content",
+                path.display()
+            );
+        }
+
+        // A different host renders different content, so the digest changes
+        // and an overwriting seed does refresh every file.
+        let rehosted = seed_default_routines(&routines_dir, "host-b", Some("workspace"), true)
+            .expect("re-seed with a new host id");
+        assert_eq!(rehosted.refreshed, DEFAULT_ROUTINE_FILES.len());
     }
 
     #[test]

--- a/crates/orbit-core/src/command/skill.rs
+++ b/crates/orbit-core/src/command/skill.rs
@@ -1,65 +1,77 @@
+use std::borrow::Cow;
 use std::path::Path;
 
 use orbit_common::types::OrbitError;
 
-use orbit_common::utility::fs::write_text_with_parent;
-
 use crate::OrbitRuntime;
 use crate::skill_catalog::{LoadedSkill, SkillCatalogDoctorStatus};
 
-const DEFAULT_SKILL_FILES: [(&str, &str); 4] = [
-    ("orbit", include_str!("../../assets/skills/orbit/SKILL.md")),
+use super::{ManagedAssetLayout, ManagedAssetReconciliation, reconcile_managed_assets};
+
+/// Every shipped skill file, keyed by its path relative to the skills root.
+///
+/// Skills are directory trees rather than single documents, so their managed
+/// manifest keys on the relative path ([`ManagedAssetLayout::RelativePath`])
+/// instead of a bare definition name. Keep each skill's `SKILL.md` adjacent to
+/// its reference files: the ordering here is what a reader uses to see a
+/// skill's full shipped surface at a glance.
+pub(crate) const DEFAULT_SKILL_FILES: [(&str, &str); 11] = [
     (
-        "orbit-task",
+        "orbit/SKILL.md",
+        include_str!("../../assets/skills/orbit/SKILL.md"),
+    ),
+    (
+        "orbit/references/guide.md",
+        include_str!("../../assets/skills/orbit/references/guide.md"),
+    ),
+    (
+        "orbit-task/SKILL.md",
         include_str!("../../assets/skills/orbit-task/SKILL.md"),
     ),
     (
-        "orbit-workflow",
-        include_str!("../../assets/skills/orbit-workflow/SKILL.md"),
-    ),
-    (
-        "orbit-search",
-        include_str!("../../assets/skills/orbit-search/SKILL.md"),
-    ),
-];
-
-const DEFAULT_SKILL_RESOURCE_FILES: [(&str, &str, &str); 7] = [
-    (
-        "orbit-task",
-        "references/review.md",
+        "orbit-task/references/review.md",
         include_str!("../../assets/skills/orbit-task/references/review.md"),
     ),
     (
-        "orbit-task",
-        "references/friction.md",
+        "orbit-task/references/friction.md",
         include_str!("../../assets/skills/orbit-task/references/friction.md"),
     ),
     (
-        "orbit-search",
-        "references/docs-corpus.md",
-        include_str!("../../assets/skills/orbit-search/references/docs-corpus.md"),
+        "orbit-workflow/SKILL.md",
+        include_str!("../../assets/skills/orbit-workflow/SKILL.md"),
     ),
     (
-        "orbit-workflow",
-        "references/debug-job-failure.md",
+        "orbit-workflow/references/debug-job-failure.md",
         include_str!("../../assets/skills/orbit-workflow/references/debug-job-failure.md"),
     ),
     (
-        "orbit-workflow",
-        "references/common_failures.md",
+        "orbit-workflow/references/common_failures.md",
         include_str!("../../assets/skills/orbit-workflow/references/common_failures.md"),
     ),
     (
-        "orbit-workflow",
-        "references/operational-logs.md",
+        "orbit-workflow/references/operational-logs.md",
         include_str!("../../assets/skills/orbit-workflow/references/operational-logs.md"),
     ),
     (
-        "orbit",
-        "references/guide.md",
-        include_str!("../../assets/skills/orbit/references/guide.md"),
+        "orbit-search/SKILL.md",
+        include_str!("../../assets/skills/orbit-search/SKILL.md"),
+    ),
+    (
+        "orbit-search/references/docs-corpus.md",
+        include_str!("../../assets/skills/orbit-search/references/docs-corpus.md"),
     ),
 ];
+
+/// The `SKILL.md` entry point of every shipped skill, as `(id, content)`.
+/// A skill id is the first path component of its managed asset paths.
+pub(crate) fn default_skill_files() -> Vec<(&'static str, &'static str)> {
+    DEFAULT_SKILL_FILES
+        .iter()
+        .filter_map(|(relative, content)| {
+            relative.strip_suffix("/SKILL.md").map(|id| (id, *content))
+        })
+        .collect()
+}
 
 use crate::paths::ORBIT_ROOT_TOKEN;
 
@@ -77,47 +89,39 @@ pub struct SkillDoctorResult {
     pub message: String,
 }
 
-pub(crate) fn default_skill_ids() -> [&'static str; 4] {
-    DEFAULT_SKILL_FILES.map(|(id, _)| id)
+pub(crate) fn default_skill_ids() -> Vec<&'static str> {
+    default_skill_files()
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect()
 }
 
+/// Materialize the shipped skill trees under `skills_root`, recording the
+/// digest Orbit wrote for each file so a skill (or a single reference file)
+/// dropped from a later release can be retired by content provenance.
+///
+/// The digest covers the *rendered* document: `ORBIT_ROOT_TOKEN` resolves to
+/// the absolute root before the write, so an unchanged release re-seeds as a
+/// no-op on the same root.
+// ADR-0366: skills are managed by relative path, so a single reference
+// file can be retired independently of its SKILL.md.
 pub(crate) fn seed_default_skills(
     skills_root: &Path,
     orbit_root: &Path,
     overwrite: bool,
-) -> Result<usize, OrbitError> {
-    let mut count = 0usize;
-    for (id, content) in DEFAULT_SKILL_FILES {
-        let path = skills_root.join(id).join("SKILL.md");
-        if !overwrite && path.exists() {
-            continue;
-        }
-        let rendered = inject_skill_template_tokens(content, orbit_root);
-        write_text_with_parent(&path, &rendered)?;
-        seed_default_skill_resources(&skills_root.join(id), id, orbit_root, overwrite)?;
-        count += 1;
-    }
-    Ok(count)
-}
-
-fn seed_default_skill_resources(
-    skill_dir: &Path,
-    skill_id: &str,
-    orbit_root: &Path,
-    overwrite: bool,
-) -> Result<(), OrbitError> {
-    for (resource_skill_id, relative_path, content) in DEFAULT_SKILL_RESOURCE_FILES {
-        if resource_skill_id != skill_id {
-            continue;
-        }
-        let path = skill_dir.join(relative_path);
-        if !overwrite && path.exists() {
-            continue;
-        }
-        let rendered = inject_skill_template_tokens(content, orbit_root);
-        write_text_with_parent(&path, &rendered)?;
-    }
-    Ok(())
+) -> Result<ManagedAssetReconciliation, OrbitError> {
+    reconcile_managed_assets(
+        skills_root,
+        "skill",
+        ManagedAssetLayout::RelativePath,
+        &DEFAULT_SKILL_FILES,
+        overwrite,
+        |_, content| {
+            Ok(Cow::Owned(inject_skill_template_tokens(
+                content, orbit_root,
+            )))
+        },
+    )
 }
 
 pub(crate) fn is_default_skill_file_for_root(
@@ -125,8 +129,8 @@ pub(crate) fn is_default_skill_file_for_root(
     path: &Path,
     orbit_root: &Path,
 ) -> Result<bool, OrbitError> {
-    let Some((_, content)) = DEFAULT_SKILL_FILES
-        .iter()
+    let Some((_, content)) = default_skill_files()
+        .into_iter()
         .find(|(default_id, _)| *default_id == skill_id)
     else {
         return Ok(false);
@@ -138,7 +142,7 @@ pub(crate) fn is_default_skill_file_for_root(
     Ok(existing == inject_skill_template_tokens(content, orbit_root))
 }
 
-fn inject_skill_template_tokens(raw: &str, orbit_root: &Path) -> String {
+pub(crate) fn inject_skill_template_tokens(raw: &str, orbit_root: &Path) -> String {
     let orbit_root_value = orbit_root.to_string_lossy();
     raw.replace(ORBIT_ROOT_TOKEN, orbit_root_value.as_ref())
 }

--- a/crates/orbit-core/src/command/tests/managed_assets.rs
+++ b/crates/orbit-core/src/command/tests/managed_assets.rs
@@ -286,6 +286,483 @@ fn refresh_retires_managed_activity_and_job_assets_and_is_idempotent() {
     assert!(repeated.managed_asset_warnings.is_empty());
 }
 
+// --- Definition-artifact health [ORB-10800] ---------------------------------
+
+mod artifacts {
+    use super::*;
+    use std::path::PathBuf;
+
+    use crate::command::artifact_health::{
+        ArtifactCondition, ArtifactHealth, ArtifactKind, ArtifactProvenance,
+    };
+
+    fn init_workspace(root: &Path) -> (PathBuf, PathBuf) {
+        let global_root = root.join("global");
+        let workspace_root = root.join("repo/.orbit");
+        init_global(&global_root);
+        init_workspace_at_root(
+            &workspace_root,
+            InitOptions {
+                refresh_defaults: true,
+                global_root_override: Some(global_root.clone()),
+                routine_host_id: Some("test-host".to_string()),
+                detected: Some(DetectedAgents::default()),
+                ..Default::default()
+            },
+        )
+        .expect("initialize workspace");
+        (global_root, workspace_root)
+    }
+
+    fn health_of(report: &[ArtifactHealth], kind: ArtifactKind) -> &ArtifactHealth {
+        report
+            .iter()
+            .find(|health| health.kind == kind)
+            .unwrap_or_else(|| panic!("missing artifact health for {kind:?}"))
+    }
+
+    /// Criterion: all five kinds record digest provenance after seeding.
+    #[test]
+    fn every_artifact_kind_records_digest_provenance_after_init() {
+        let root = tempdir().expect("create tempdir");
+        let (global_root, workspace_root) = init_workspace(root.path());
+
+        for dir in [
+            global_root.join("skills"),
+            global_root.join("resources/jobs"),
+            global_root.join("resources/activities"),
+            workspace_root.join("auto_tasks"),
+            workspace_root.join("routines"),
+        ] {
+            let manifest = dir.join(MANAGED_ASSET_MANIFEST_FILE);
+            let raw = std::fs::read_to_string(&manifest)
+                .unwrap_or_else(|e| panic!("read manifest {}: {e}", manifest.display()));
+            let parsed: Value = serde_json::from_str(&raw).expect("parse manifest");
+            assert!(
+                parsed["assets"]
+                    .as_object()
+                    .expect("assets object")
+                    .values()
+                    .all(|digest| digest.as_str().is_some_and(|d| d.len() == 64)),
+                "every managed asset in {} must record a sha256 digest",
+                dir.display()
+            );
+        }
+
+        // Skill manifests key on the relative path, not a bare stem, because
+        // skills are directory trees.
+        let skill_manifest: Value = serde_json::from_str(
+            &std::fs::read_to_string(global_root.join("skills").join(MANAGED_ASSET_MANIFEST_FILE))
+                .expect("read skill manifest"),
+        )
+        .expect("parse skill manifest");
+        let keys: Vec<&str> = skill_manifest["assets"]
+            .as_object()
+            .expect("assets object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert!(keys.contains(&"orbit/SKILL.md"), "{keys:?}");
+        assert!(
+            keys.contains(&"orbit-task/references/review.md"),
+            "reference files are managed too: {keys:?}"
+        );
+    }
+
+    /// A freshly initialized workspace is clean on every artifact kind.
+    #[test]
+    fn freshly_initialized_workspace_reports_no_artifact_findings() {
+        let root = tempdir().expect("create tempdir");
+        let (global_root, workspace_root) = init_workspace(root.path());
+        let runtime =
+            OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+
+        let report = runtime
+            .inspect_definition_artifacts()
+            .expect("inspect artifacts");
+        assert_eq!(report.len(), 5);
+        for health in &report {
+            assert!(
+                health.findings.is_empty(),
+                "{:?} reported findings on a fresh workspace: {:?}",
+                health.kind,
+                health.findings
+            );
+            assert!(health.scanned > 0, "{:?} scanned nothing", health.kind);
+        }
+    }
+
+    /// Criteria: deprecated artifacts are detected across the newly covered
+    /// kinds; the fix flag removes only what Orbit provably wrote and
+    /// preserves a locally modified one instead of deleting it.
+    #[test]
+    fn fix_removes_orbit_written_deprecated_artifacts_and_preserves_modified_ones() {
+        let root = tempdir().expect("create tempdir");
+        let (global_root, workspace_root) = init_workspace(root.path());
+
+        let auto_tasks_dir = workspace_root.join("auto_tasks");
+        let routines_dir = workspace_root.join("routines");
+        let clean = "retired-auto-task";
+        let modified = "retired_routine";
+        let clean_body = std::fs::read_to_string(auto_tasks_dir.join("qa-sweep.yaml"))
+            .expect("read a seeded auto-task to reuse as retired content");
+        let modified_body = std::fs::read_to_string(routines_dir.join("task_triage.yaml"))
+            .expect("read a seeded routine");
+
+        // Both look exactly like assets a previous release seeded.
+        add_managed_manifest_entry(&auto_tasks_dir, clean, &clean_body);
+        std::fs::write(auto_tasks_dir.join(format!("{clean}.yaml")), &clean_body)
+            .expect("materialize retired auto-task");
+        add_managed_manifest_entry(&routines_dir, modified, &modified_body);
+        let edited_body = format!("{modified_body}# operator edit\n");
+        std::fs::write(routines_dir.join(format!("{modified}.yaml")), &edited_body)
+            .expect("materialize locally modified retired routine");
+
+        let runtime =
+            OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+        let report = runtime
+            .inspect_definition_artifacts()
+            .expect("inspect artifacts");
+
+        let auto_task_finding = health_of(&report, ArtifactKind::AutoTask)
+            .findings
+            .iter()
+            .find(|finding| finding.name == clean)
+            .expect("deprecated auto-task is reported");
+        assert_eq!(auto_task_finding.condition, ArtifactCondition::Deprecated);
+        assert_eq!(
+            auto_task_finding.provenance,
+            ArtifactProvenance::OrbitWritten
+        );
+        assert!(
+            auto_task_finding
+                .remediation
+                .contains("orbit doctor --fix-stale-artifacts"),
+            "{}",
+            auto_task_finding.remediation
+        );
+
+        let routine_finding = health_of(&report, ArtifactKind::Routine)
+            .findings
+            .iter()
+            .find(|finding| finding.name == modified)
+            .expect("deprecated routine is reported");
+        assert_eq!(routine_finding.condition, ArtifactCondition::Deprecated);
+        assert_eq!(
+            routine_finding.provenance,
+            ArtifactProvenance::LocallyModified
+        );
+
+        let retired = runtime
+            .remove_stale_definition_artifacts()
+            .expect("retire deprecated artifacts");
+        assert_eq!(retired, 2);
+
+        assert!(
+            !auto_tasks_dir.join(format!("{clean}.yaml")).exists(),
+            "an unmodified Orbit-written deprecated artifact is deleted"
+        );
+        assert!(
+            !routines_dir.join(format!("{modified}.yaml")).exists(),
+            "a modified deprecated artifact leaves the active catalog"
+        );
+        assert_eq!(
+            std::fs::read_to_string(
+                workspace_root.join(format!(".retired-managed/routines/{modified}.yaml"))
+            )
+            .expect("locally modified content is preserved, not destroyed"),
+            edited_body
+        );
+
+        // Idempotent: a second pass has nothing left to retire.
+        assert_eq!(
+            runtime
+                .remove_stale_definition_artifacts()
+                .expect("second retire pass"),
+            0
+        );
+    }
+
+    /// Criteria: a faulty *user-authored* artifact is reported but never
+    /// removed or rewritten by the fix flag.
+    #[test]
+    fn faulty_user_authored_artifacts_are_reported_and_never_touched() {
+        let root = tempdir().expect("create tempdir");
+        let (global_root, workspace_root) = init_workspace(root.path());
+
+        let broken_path = workspace_root.join("routines/operator-routine.yaml");
+        let broken_body = "schemaVersion: 1\nname: broken\n";
+        std::fs::write(&broken_path, broken_body).expect("write malformed routine");
+
+        let runtime =
+            OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+        let report = runtime
+            .inspect_definition_artifacts()
+            .expect("inspect artifacts");
+        let finding = health_of(&report, ArtifactKind::Routine)
+            .findings
+            .iter()
+            .find(|finding| finding.name == "operator-routine")
+            .expect("faulty routine is reported");
+        assert_eq!(finding.condition, ArtifactCondition::Faulty);
+        assert_eq!(finding.provenance, ArtifactProvenance::UserAuthored);
+        assert!(
+            !finding.is_unloadable_shipped_default(),
+            "a workspace-authored fault must not escalate the doctor exit code"
+        );
+        assert!(
+            finding.remediation.contains("operator-routine.yaml"),
+            "{}",
+            finding.remediation
+        );
+
+        assert_eq!(
+            runtime
+                .remove_stale_definition_artifacts()
+                .expect("retire pass"),
+            0
+        );
+        assert_eq!(
+            std::fs::read_to_string(&broken_path).expect("faulty user file survives"),
+            broken_body
+        );
+    }
+
+    /// An Orbit-written default that no longer parses is a broken install, and
+    /// is the one artifact fault that escalates to an Error row.
+    #[test]
+    fn unloadable_shipped_default_is_distinguished_from_a_user_authored_fault() {
+        let root = tempdir().expect("create tempdir");
+        let (global_root, workspace_root) = init_workspace(root.path());
+
+        // Corrupt a shipped default *and* record it as what Orbit wrote, which
+        // is what a truncated install or a bad upgrade looks like on disk.
+        let activities_dir = global_root.join("resources/activities");
+        let corrupt = "schemaVersion: 2\nkind: Activity\nmetadata: {}\n";
+        std::fs::write(activities_dir.join("sleep.yaml"), corrupt)
+            .expect("corrupt shipped default");
+        add_managed_manifest_entry(&activities_dir, "sleep", corrupt);
+
+        let runtime =
+            OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+        let report = runtime
+            .inspect_definition_artifacts()
+            .expect("inspect artifacts");
+        let finding = health_of(&report, ArtifactKind::Activity)
+            .findings
+            .iter()
+            .find(|finding| {
+                finding.name == "sleep" && finding.condition == ArtifactCondition::Faulty
+            })
+            .expect("faulty shipped default is reported");
+        assert_eq!(finding.provenance, ArtifactProvenance::OrbitWritten);
+        assert!(finding.is_unloadable_shipped_default());
+        assert!(
+            finding
+                .remediation
+                .contains("orbit init --refresh-defaults"),
+            "{}",
+            finding.remediation
+        );
+    }
+
+    /// An Orbit-written copy of an older release is stale; refreshing is the
+    /// repair, and the fix flag deliberately leaves it alone.
+    #[test]
+    fn drifted_orbit_written_default_is_stale_and_not_removed_by_the_fix_flag() {
+        let root = tempdir().expect("create tempdir");
+        let (global_root, workspace_root) = init_workspace(root.path());
+
+        let auto_tasks_dir = workspace_root.join("auto_tasks");
+        let path = auto_tasks_dir.join("qa-sweep.yaml");
+        let older_release = format!(
+            "{}# shipped by an older release\n",
+            std::fs::read_to_string(&path).expect("read seeded auto-task")
+        );
+        std::fs::write(&path, &older_release).expect("simulate an older release's copy");
+        add_managed_manifest_entry(&auto_tasks_dir, "qa-sweep", &older_release);
+
+        let runtime =
+            OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+        let finding = health_of(
+            &runtime
+                .inspect_definition_artifacts()
+                .expect("inspect artifacts"),
+            ArtifactKind::AutoTask,
+        )
+        .findings
+        .iter()
+        .find(|finding| finding.name == "qa-sweep")
+        .cloned()
+        .expect("drifted default is reported");
+        assert_eq!(finding.condition, ArtifactCondition::Stale);
+        assert_eq!(finding.provenance, ArtifactProvenance::OrbitWritten);
+        assert!(
+            finding
+                .remediation
+                .contains("orbit init --refresh-defaults"),
+            "{}",
+            finding.remediation
+        );
+
+        assert_eq!(
+            runtime
+                .remove_stale_definition_artifacts()
+                .expect("retire pass"),
+            0,
+            "staleness is repaired by refreshing, never by deleting"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("stale file survives"),
+            older_release
+        );
+    }
+
+    /// A user file wearing a bundled default's name keeps that default from
+    /// being installed — reported as stale, and never deleted.
+    #[test]
+    fn untracked_collision_with_a_bundled_default_is_reported_as_stale() {
+        let root = tempdir().expect("create tempdir");
+        let (global_root, workspace_root) = init_workspace(root.path());
+
+        let path = workspace_root.join("auto_tasks/qa-sweep.yaml");
+        let user_body = std::fs::read_to_string(&path)
+            .expect("read seeded auto-task")
+            .replace("enabled: false", "enabled: false # operator copy");
+        std::fs::write(&path, &user_body).expect("write colliding user file");
+        // Drop the managed provenance, leaving an untracked file behind.
+        let manifest_path =
+            workspace_root.join(format!("auto_tasks/{MANAGED_ASSET_MANIFEST_FILE}"));
+        let mut manifest: Value = serde_json::from_str(
+            &std::fs::read_to_string(&manifest_path).expect("read auto-task manifest"),
+        )
+        .expect("parse manifest");
+        manifest["assets"]
+            .as_object_mut()
+            .expect("assets object")
+            .remove("qa-sweep");
+        std::fs::write(
+            &manifest_path,
+            format!(
+                "{}\n",
+                serde_json::to_string_pretty(&manifest).expect("serialize manifest")
+            ),
+        )
+        .expect("write manifest without provenance");
+
+        let runtime =
+            OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+        let finding = health_of(
+            &runtime
+                .inspect_definition_artifacts()
+                .expect("inspect artifacts"),
+            ArtifactKind::AutoTask,
+        )
+        .findings
+        .iter()
+        .find(|finding| finding.name == "qa-sweep")
+        .cloned()
+        .expect("collision is reported");
+        assert_eq!(finding.condition, ArtifactCondition::Stale);
+        assert_eq!(finding.provenance, ArtifactProvenance::UserAuthored);
+
+        assert_eq!(
+            runtime
+                .remove_stale_definition_artifacts()
+                .expect("retire pass"),
+            0
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("user file survives"),
+            user_body
+        );
+    }
+
+    /// Removal refuses a manifest key that would escape the managed directory,
+    /// and never follows a symlink at the boundary.
+    #[test]
+    fn removal_rejects_escaping_paths_and_does_not_follow_symlinks() {
+        let root = tempdir().expect("create tempdir");
+        let (global_root, workspace_root) = init_workspace(root.path());
+        let auto_tasks_dir = workspace_root.join("auto_tasks");
+
+        // A traversing key is refused when the manifest is loaded, before any
+        // removal is attempted.
+        let manifest_path = auto_tasks_dir.join(MANAGED_ASSET_MANIFEST_FILE);
+        let mut manifest: Value =
+            serde_json::from_str(&std::fs::read_to_string(&manifest_path).expect("read manifest"))
+                .expect("parse manifest");
+        manifest["assets"]
+            .as_object_mut()
+            .expect("assets object")
+            .insert("../escaped".to_string(), Value::String(sha256("anything")));
+        std::fs::write(
+            &manifest_path,
+            format!(
+                "{}\n",
+                serde_json::to_string_pretty(&manifest).expect("serialize manifest")
+            ),
+        )
+        .expect("write traversing manifest");
+
+        let runtime =
+            OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+        let error = runtime
+            .remove_stale_definition_artifacts()
+            .expect_err("a traversing manifest key must be refused");
+        assert!(
+            error.to_string().contains("not a safe managed asset path"),
+            "{error}"
+        );
+
+        // A symlinked artifact is left in place: deleting it would act on a
+        // target outside the catalog Orbit manages.
+        #[cfg(unix)]
+        {
+            std::fs::write(
+                &manifest_path,
+                format!(
+                    "{}\n",
+                    serde_json::to_string_pretty(&{
+                        let mut clean: Value = serde_json::from_str(
+                            &std::fs::read_to_string(&manifest_path).expect("read manifest"),
+                        )
+                        .expect("parse manifest");
+                        clean["assets"]
+                            .as_object_mut()
+                            .expect("assets object")
+                            .remove("../escaped");
+                        clean
+                    })
+                    .expect("serialize manifest")
+                ),
+            )
+            .expect("restore manifest");
+
+            let outside = root.path().join("outside.yaml");
+            std::fs::write(&outside, "outside content\n").expect("write link target");
+            let link = auto_tasks_dir.join("linked-auto-task.yaml");
+            std::os::unix::fs::symlink(&outside, &link).expect("create symlinked artifact");
+            add_managed_manifest_entry(&auto_tasks_dir, "linked-auto-task", "outside content\n");
+
+            let runtime =
+                OrbitRuntime::from_roots(&global_root, &workspace_root).expect("rebuild runtime");
+            assert_eq!(
+                runtime
+                    .remove_stale_definition_artifacts()
+                    .expect("retire pass"),
+                0,
+                "a symlinked artifact is not removed"
+            );
+            assert!(link.symlink_metadata().is_ok(), "the symlink survives");
+            assert_eq!(
+                std::fs::read_to_string(&outside).expect("link target survives"),
+                "outside content\n"
+            );
+        }
+    }
+}
+
 #[test]
 fn first_manifest_preserves_user_assets_and_warns_about_ambiguous_legacy_yaml() {
     let root = tempdir().expect("create tempdir");

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Design"
 type: design
 title: "Activity / Job — Design"
 owner: codex
-last_updated: 2026-08-14
+last_updated: 2026-08-15
 last_validated: 2026-07-26
 status: Draft
 feature: activity-job
@@ -140,6 +140,38 @@ with removed tool grants—or a retired managed job with removed actions—in th
 catalog. Legacy files whose history cannot be proven remain operator-owned:
 Orbit will not guess from their names, and the warning is the recovery contract
 for installations predating managed provenance.
+
+#### 4.1.1 All five artifact kinds, and the standing doctor surface
+
+After [ORB-10800] / [ADR-0366], the same mechanism governs all five definition
+artifact kinds. Skills, auto-tasks, and routines previously used an additive
+seeding path that skipped existing files and retired nothing, so a default
+dropped from a release stayed on disk — and dispatchable — in every existing
+workspace.
+
+Two generalizations made that possible. `reconcile_managed_assets` takes a
+layout: manifest keys are `<name>.yaml` stems for the four flat catalogs, and
+*relative paths* for skill directory trees, so `orbit-task/references/review.md`
+is managed independently of `orbit-task/SKILL.md`. And the recorded digest is
+always taken over the **rendered** document, which is what gives honest
+provenance to the two kinds that substitute placeholders before writing —
+routines (host id, workspace-scoped name) and skills (`ORBIT_ROOT_TOKEN`).
+
+`orbit doctor` reports one row per kind, classifying each artifact as *faulty*
+(fails to load), *deprecated* (digest proves Orbit wrote a default no longer
+shipped), or *stale* (an Orbit-written copy of an older release, or an untracked
+file occupying a bundled default's name). Classification reads the manifest
+only, never loader precedence — precisely because precedence is *not* uniform
+across kinds (§4 above): skills merge workspace-over-global while activities
+keep shipped defaults authoritative. Provenance of the file Orbit wrote is the
+same question for every kind.
+
+`orbit doctor --fix-stale-artifacts` retires only deprecated artifacts whose
+digest still proves Orbit wrote them, preserving locally modified ones under
+`.retired-managed/` rather than deleting them. Faulty and user-authored files
+are reported and never touched. A workspace-authored fault is a `Warning`; only
+an unloadable *shipped default* is an `Error`, which keeps the `orbit doctor`
+exit code stable for existing cron and CI callers.
 
 Direct single-activity runtime helpers:
 

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Decisions"
 type: design
 title: "Activity / Job — Decisions"
 owner: codex
-last_updated: 2026-08-13
+last_updated: 2026-08-15
 last_validated: 2026-07-26
 status: Draft
 feature: activity-job
@@ -1651,8 +1651,86 @@ Persist a per-resource-kind managed manifest containing the SHA-256 digest last 
 - Locally modified retired assets remain recoverable outside active catalog directories instead of breaking unrelated catalog/list operations.
 - Cost: managed manifests and preserved-retirement backups add local state and make the first legacy refresh potentially require operator review before an ambiguous stale file can be removed.
 
+## ADR-0366 — All five definition-artifact kinds carry managed provenance, and doctor reports it
+
+**Status:** Accepted · 2026-08 · [ORB-10800]
+**Code anchors:** `crates/orbit-core/src/command/mod.rs::ManagedAssetLayout`, `crates/orbit-core/src/command/skill.rs::seed_default_skills`, `crates/orbit-core/src/command/routine.rs::seed_default_routines`, `crates/orbit-core/src/auto_tasks/mod.rs::seed_default_auto_tasks`, `crates/orbit-core/src/command/artifact_health.rs`
+
+### Context
+
+[ADR-0346] gave activities and jobs a digest manifest so a bundled asset dropped
+from a release could be retired by content provenance rather than by filename
+guessing. The other three definition-artifact kinds — skills, auto-tasks, and
+routines — kept the older additive `seed_embedded_assets` path, which skips any
+file that already exists and retires nothing. A default skill, auto-task, or
+routine removed from a release therefore stayed on disk in every existing
+workspace forever: still loadable, still dispatchable, and reported by nothing.
+
+Two obstacles kept the mechanism from generalizing. Skills are directory trees
+(`<id>/SKILL.md` plus reference files) while the manifest keyed on `<name>.yaml`.
+Routines render placeholders — a host id and a workspace-scoped name — before
+being written, so a digest over the *embedded* template would never match disk.
+
+Separately, ADR-0346's reconciliation warnings were emitted once during
+bootstrap and then lost, and faulty definitions failed silently: the auto-task
+loader's per-file errors were dropped by `auto_task_list`, and `SkillCatalog::list`
+swallowed every load error.
+
+### Decision
+
+Extend the ADR-0346 mechanism to all five kinds rather than giving the three
+stragglers a sibling mechanism.
+
+`reconcile_managed_assets` takes a `ManagedAssetLayout`: `YamlStem` keys on
+`<name>.yaml` for the four flat catalogs, and `RelativePath` keys on the path
+itself for skill trees, so a single skill *reference file* can be retired
+independently of its `SKILL.md`. Manifest keys are validated per layout, which
+is what keeps a manifest from ever steering a write or a removal outside the
+directory it manages. The digest is always taken over the **rendered** document,
+so routines and skills — both of which substitute placeholders before writing —
+get honest provenance and re-seed as a genuine no-op.
+
+`orbit doctor` gains one row per artifact kind, classifying each artifact as
+*faulty* (fails to load), *deprecated* (digest proves Orbit wrote a default this
+binary no longer ships), or *stale* (an Orbit-written copy of an older release,
+or an untracked file colliding with a bundled default's name). Classification
+reads the manifest only. That is deliberate: loader precedence is not uniform —
+skills merge workspace-over-global while activities keep shipped defaults
+authoritative over workspace copies — so a rule phrased in terms of which copy
+wins would misreport at least one kind, while provenance of the file Orbit wrote
+is the same question everywhere.
+
+Repair is narrower than diagnosis. `--fix-stale-artifacts` retires only
+*deprecated* artifacts whose digest still proves Orbit wrote them; a locally
+modified one is preserved outside the active catalog exactly as init-time
+reconciliation does, and faulty or user-authored files are never touched. A
+faulty artifact is a `Warning` unless it is an unloadable *shipped default*,
+which is a broken install and the only artifact fault that escalates
+`orbit doctor` to a nonzero exit.
+
+### Consequences
+
+- A default skill, auto-task, or routine dropped from a release now leaves
+  existing workspaces instead of lingering indefinitely as dispatchable state.
+- The reconciliation signals ADR-0346 produced only at bootstrap are
+  re-derivable on demand, and every non-ok row names the exact repair command.
+- Faulty definitions are visible without running the one narrow command that
+  happens to touch them; `auto_task_list` now errors only when *nothing* loaded,
+  matching what its doc comment always claimed.
+- Existing workspaces keep their `orbit doctor` exit code: a malformed
+  workspace-authored definition warns rather than failing, so cron and CI
+  callers that pass today keep passing.
+- Cost: three more managed manifests and a wider retirement blast radius. A
+  skill tree is now reconciled file-by-file, so an operator who edits a shipped
+  reference file and later sees that file dropped from a release gets a
+  preserved copy under `.retired-managed/` to reconcile by hand — where
+  previously the file would simply have stayed put and kept working.
+
 ## Task References
 
+- **[ORB-10800]** — Extend managed provenance to skills, auto-tasks, and
+  routines, and add the `orbit doctor` definition-artifact check plus
+  `--fix-stale-artifacts` ([ADR-0366], extending [ADR-0346]).
 - **[ORB-10684]** — Reconcile retired managed activity and job assets by
   content provenance while preserving modified and ambiguous legacy files
   ([ADR-0346], Proposed).

--- a/docs/design/auto-tasks/2_design.md
+++ b/docs/design/auto-tasks/2_design.md
@@ -1,7 +1,7 @@
 ---
 title: Auto-tasks — Design
 owner: claude
-last_updated: 2026-08-02
+last_updated: 2026-08-15
 last_validated: 2026-07-27
 status: Accepted
 feature: auto-tasks
@@ -11,7 +11,7 @@ summary: Current implementation of the auto-task record, due-math, host-local cu
 tags: [auto-tasks]
 paths: ["crates/orbit-core/src/auto_tasks/**"]
 related_features: [auto-tasks]
-related_artifacts: [ORB-10149, ORB-10439, ORB-10441, ORB-10446, ORB-10472, ORB-10583, ADR-0218, ADR-0217, ADR-0286]
+related_artifacts: [ORB-10149, ORB-10439, ORB-10441, ORB-10446, ORB-10472, ORB-10583, ADR-0218, ADR-0217, ADR-0286, ORB-10800, ADR-0366]
 ---
 
 # Auto-tasks — Design
@@ -88,6 +88,23 @@ rejects duplicate names; update patches present fields; toggle flips `enabled`
 persisted. Successful writes replace the target atomically; a staging or rename
 failure leaves the previous definition bytes intact. In a primary checkout the
 local and shared roots are identical, preserving the operator-facing path.
+
+`list` is fail-closed-aware. The loader collects a per-file `AutoTaskLoadError`
+for every definition it rejects, and after [ORB-10800] those errors are no longer
+discarded: each is logged, and `list` errors outright only when *nothing* loaded,
+so one malformed file cannot hide the definitions that still work. A definition
+that silently stopped firing is discoverable as a `faulty` row on the
+`orbit doctor` artifacts surface rather than only via the one command that
+happens to touch it.
+
+### 5a. Managed seeding
+
+Default definitions are seeded manifest-aware after [ORB-10800] / [ADR-0366]:
+`.orbit/auto_tasks/` carries a `.orbit-managed-assets.json` recording the digest
+Orbit wrote for each shipped default, so a default dropped from a later release
+can be retired by content provenance instead of remaining loadable forever.
+Seeding still never overwrites an existing definition, and an operator-edited
+default is preserved under `.retired-managed/auto_tasks/` rather than deleted.
 
 ## 5b. Manual mint — `mint` (ORB-10439, renamed by ORB-10446)
 

--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -1,7 +1,7 @@
 ---
 title: Routines — Design
 owner: claude
-last_updated: 2026-08-11
+last_updated: 2026-08-15
 status: Accepted
 feature: routines
 doc_role: design
@@ -10,7 +10,7 @@ summary: Proposed contract for routine definitions, sweep dispatch, host-local s
 tags: [routines, scheduler]
 paths: ["crates/orbit-cli/src/command/routine/**", "crates/orbit-core/src/routines/**", "crates/orbit-remote/src/routines.rs", "crates/orbit-store/src/sqlite/routine_store/**"]
 related_features: [routines, activity-job, host-registry]
-related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ADR-0223, ADR-0355]
+related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ADR-0223, ADR-0355, ORB-10800, ADR-0366]
 ---
 
 # Routines — Design
@@ -104,6 +104,17 @@ Seeded files become workspace-authored immediately. Plain re-init is create-if-m
 it adds a newly shipped default or recreates a deleted default, but byte-for-byte preserves
 existing definitions, including `enabled`, `hosts`, cron, and policy edits. Only destructive
 force initialization recreates the workspace and therefore restores template defaults.
+
+After [ORB-10800] / [ADR-0366], routine seeding is manifest-aware: `.orbit/routines/`
+carries a `.orbit-managed-assets.json` recording the digest Orbit last wrote for each
+seeded default. The digest is taken over the *rendered* document — after the host-id and
+routine-name placeholders resolve — because that is what actually lands on disk. Two
+consequences follow. A default dropped from a later release is retired by content
+provenance rather than lingering forever in every existing workspace, and re-seeding
+unchanged content against the same host is a genuine no-op rather than a rewrite. A
+routine an operator has edited is never deleted: it is preserved under
+`.retired-managed/routines/`. `orbit doctor` reports routine artifacts as faulty,
+deprecated, or stale, and `orbit doctor --fix-stale-artifacts` performs the retirement.
 
 The seeded `ship_sweep` targets `job:workspace_ship_pipeline` with `missed_run: skip` and
 `overlap: forbid`. The wrapper resolves the source runtime's ship mode and configured base


### PR DESCRIPTION
## Task

[ORB-10800](https://orbit-cli.com/tasks/ORB-10800) — Add an orbit doctor check for stale, deprecated, and faulty definition artifacts plus --fix-stale-artifacts

### Description

## Problem

`orbit doctor` diagnoses *infrastructure* — config, database, disk, semantic index, lock files, job runs, task reservations, task relations (`crates/orbit-cmd/src/doctor.rs:122`). It says nothing about the *definition artifacts* a workspace accumulates: skills, jobs, activities, auto-tasks, and routines. Those artifacts do go stale, deprecated, and faulty, and today every signal about that is either transient or silently discarded.

### Gap 1 — the retirement mechanism is only half-adopted

ADR-0346 gave us `reconcile_managed_assets` (`crates/orbit-core/src/command/mod.rs:81`): a digest manifest at `.orbit-managed-assets.json` recording what Orbit last wrote for each managed file, so an asset dropped from a release can be retired by *content provenance* rather than by filename guessing. Unmodified retired files are deleted; locally modified ones are moved out of the active catalog and preserved.

Only two asset kinds use it:

- activities — `crates/orbit-core/src/command/activity.rs:156`
- jobs — `crates/orbit-core/src/command/job/catalog.rs:289`

Three do not. Skills (`crates/orbit-core/src/command/skill.rs`), auto-tasks (`crates/orbit-core/src/auto_tasks/mod.rs:65`), and routines (`crates/orbit-core/src/command/routine.rs:77`) still call plain `seed_embedded_assets` (`crates/orbit-core/src/command/mod.rs:33`), which skips any file that already exists and never retires anything. **A default skill / auto-task / routine removed from a release stays on disk in every existing workspace forever**, still loadable, still dispatchable, with nothing anywhere reporting it as deprecated.

### Gap 2 — reconciliation warnings are init-time only and then lost

`ManagedAssetReconciliation.warnings` (`crates/orbit-core/src/command/mod.rs:59`) already produces exactly the diagnostics this task wants:

- a retired managed asset that was locally modified and got preserved outside the catalog
- an untracked user-authored file colliding with a bundled default name

They are emitted once during bootstrap and never surfaced again. Nothing re-derives them on demand. `orbit doctor` is the natural standing surface.

### Gap 3 — faulty artifacts fail silently

- The auto-task loader collects per-file `AutoTaskLoadError` values (`crates/orbit-core/src/auto_tasks/loader.rs:35`) and `AutoTaskCollection.errors` carries them — but `auto_task_list` (`crates/orbit-core/src/auto_tasks/crud.rs:83`) drops `collection.errors` on the floor and returns only what parsed.
- Retired schemaVersion 1 activity assets are skipped with a `tracing::warn` and nothing else (`crates/orbit-core/src/runtime/mod.rs:624`).
- `SkillCatalog::list` swallows every load error via `if let Ok(skill)` (`crates/orbit-store/src/file/skill_store/mod.rs:118`).

A malformed definition is invisible unless you happen to run the one narrow command that touches it.

### Gap 4 — `skill doctor` is narrow and disconnected

`SkillCatalog::doctor` (`crates/orbit-store/src/file/skill_store/mod.rs:125`) only attempts `load()` per id and reports parse-ok or parse-error. It has no notion of staleness or deprecation, it always exits zero (`crates/orbit-cli/src/command/skill/doctor.rs`), and its rows never reach `orbit doctor`.

## Proposed shape

**Phase 1 — make retirement uniform.** Migrate skills / auto-tasks / routines from `seed_embedded_assets` to `reconcile_managed_assets` so all five artifact kinds carry a digest manifest. Routines need care: they render placeholders (host id and workspace-scoped name) before writing, so the digest must be taken over the *rendered* content — `reconcile_managed_assets` already hashes post-render output so this should fall out, but it needs an explicit test. Skills are directory trees rather than single YAML files (`DEFAULT_SKILL_RESOURCE_FILES` in `crates/orbit-core/src/command/skill.rs`) and the current manifest keys on `<name>.yaml`; either generalize the manifest or give skills a sibling mechanism.

**Phase 2 — the doctor check.** Add artifact rows to `doctor_workspace()` (`crates/orbit-cmd/src/doctor.rs:122`), either one `artifacts` row or one row per kind. Classification:

- **faulty** — fails to parse or validate
- **deprecated** — content digest matches a managed default that this binary no longer ships
- **stale** — tracked in the manifest but drifted from current embedded content; or an untracked file colliding with a bundled default name

Reuse `actionable_check` so each row carries the exact repair command.

**Phase 3 — the fix flag.** Add `--fix-stale-artifacts` to `DoctorCommand` (`crates/orbit-cli/src/command/doctor.rs:12`) following the established `--fix-stale-locks` / `--fix-stale-task-locks` / `--remove-graph` pattern: it runs before diagnosis, prints a count under non-JSON output, and delegates to a new method on the `DoctorCommands` trait (`crates/orbit-cmd/src/doctor.rs:99`).

The fix must be conservative in the same spirit as `remove_stale_lock_file`: **only remove an artifact whose recorded digest proves Orbit wrote it**. A locally modified artifact gets preserved out of the catalog exactly as `preserve_modified_retired_asset` already does — never deleted. Faulty user-authored artifacts are reported and never touched.

## Traps

- **Exit code.** `orbit doctor` returns nonzero on any `Error` row and the doc comment says that is deliberate so cron and CI can alert. Classifying a malformed workspace-local artifact as `Error` silently changes exit-code behavior for existing users. Lean `Warning` for user-authored faults and reserve `Error` for an unloadable shipped default.
- **Precedence is not uniform across kinds.** Skills merge workspace-over-global (`crates/orbit-store/src/file/skill_store/mod.rs:169`) while activities keep shipped defaults authoritative over workspace copies (`crates/orbit-core/src/runtime/mod.rs:441`). A single staleness rule that ignores this asymmetry will misreport at least one kind.
- **Deletion safety.** Follow `remove_workspace_subtree` (`crates/orbit-cmd/src/doctor.rs:428`) — validate the relative path stays under the Orbit root and do not follow a symlink at the subtree boundary.
- **Crate boundary.** Detection and repair belong in `orbit-core` / `orbit-cmd`. `crates/orbit-cli/CLAUDE.md` allows only clap args plus one `Execute` impl plus output projection in the CLI file.
- **Docs.** Phase 1 changes the mechanism ADR-0346 describes and needs an ADR of its own plus a same-PR design-doc update.

## Sequencing note

Phase 1 is genuinely separable and is a hard prerequisite for honest deprecation detection on three of the five kinds. It is reasonable to split it into its own task if the reviewer prefers a smaller first PR.

### Acceptance Criteria

- Skills / auto-tasks / routines seed through the manifest-aware `reconcile_managed_assets` path instead of `seed_embedded_assets` so all five artifact kinds record digest provenance
- Routine seeding hashes the rendered content (after host id and name placeholder substitution) and a test proves a re-seed of unchanged embedded content is a no-op rather than a rewrite
- `orbit doctor` reports definition-artifact health for skills / jobs / activities / auto-tasks / routines and distinguishes faulty from deprecated from stale
- Faulty artifacts are surfaced rather than swallowed: `auto_task_list` no longer discards `AutoTaskCollection.errors` and skill load failures reach the doctor surface
- Every non-ok artifact row carries an actionable remediation string naming the exact repair command
- `orbit doctor --fix-stale-artifacts` removes only artifacts whose recorded digest proves Orbit wrote them and preserves locally modified ones outside the active catalog instead of deleting them
- Faulty user-authored artifacts are reported and never removed or rewritten by the fix flag
- Artifact faults in user-authored files do not change the `orbit doctor` exit code; only an unloadable shipped default escalates to an Error row
- Fix-flag output follows the existing `--fix-stale-locks` shape: it runs before diagnosis and prints a count only under non-JSON output
- Removal paths reject absolute or parent-traversing relatives and do not follow a symlink at the subtree boundary
- Detection and repair logic lives in orbit-core or orbit-cmd with the CLI file holding only clap args plus one Execute impl plus output projection
- An ADR records the extension of the ADR-0346 managed-asset mechanism to the three newly covered artifact kinds
- `make ci-fast` and `make ci-lint` both pass

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented all three phases. `make ci-fast` and `make ci-lint` both pass (exit 0).

## Phase 1 — uniform managed provenance

`reconcile_managed_assets` now takes a `ManagedAssetLayout`: `YamlStem` (`<name>.yaml`) for the four flat catalogs, `RelativePath` for skill directory trees, so `orbit-task/references/review.md` is managed independently of its `SKILL.md`. Manifest keys are validated per layout — a `RelativePath` key rejects absolute prefixes, `.`/`..` components, and backslashes — which is what keeps a manifest from steering a write or a removal outside its directory.

Migrated off `seed_embedded_assets` (now deleted, no callers remain):
- `seed_default_auto_tasks` -> asset kind `auto_task`
- `seed_default_routines` -> asset kind `routine`
- `seed_default_skills` -> asset kind `skill`, `RelativePath` layout; `DEFAULT_SKILL_FILES` collapsed the old file+resource pair of consts into one 11-entry relative-path list, with `default_skill_ids()` derived from it.

All three now return `ManagedAssetReconciliation`; `init.rs` folds their warnings into `managed_asset_warnings`. Digests are taken over *rendered* content, which is what gives routines (host id + workspace name) and skills (`ORBIT_ROOT_TOKEN`) honest provenance. `reseeding_unchanged_rendered_content_is_a_no_op_not_a_rewrite` proves a re-seed writes nothing (asserted on mtimes) and that a host change does refresh.

## Phase 2 — detection

New `crates/orbit-core/src/command/artifact_health.rs`: `inspect_definition_artifacts()` classifies every artifact as faulty / deprecated / stale with an `ArtifactProvenance` (OrbitWritten / LocallyModified / UserAuthored) and a per-finding remediation string. Faults are found through each kind's *real* loader (`SkillCatalog::doctor`, `collect_auto_tasks`, `load_activity_asset`, `load_job_asset`, `parse_routine_yaml`) so doctor reports what dispatch would actually find.

Classification reads the managed manifest only, never loader precedence — deliberately, because precedence is not uniform (skills merge workspace-over-global; activities keep shipped defaults authoritative), so a precedence-shaped rule would misreport at least one kind.

`auto_task_list` no longer discards `AutoTaskCollection.errors`: each is logged, and it errors only when *nothing* loaded — which is what its doc comment always claimed but the code did not do.

## Phase 3 — doctor surface + fix flag

`doctor_workspace()` emits one row per kind (`artifacts-skills`, `-jobs`, `-activities`, `-auto-tasks`, `-routines`), 13 rows total. Severity is asymmetric on purpose: a workspace-authored fault is `Warning`; only an unloadable *shipped default* is `Error`, so the exit code is unchanged for workspaces passing today. `--fix-stale-artifacts` follows the `--fix-stale-locks` shape (before diagnosis, count printed only under non-JSON) and delegates to `DoctorCommands::remove_stale_definition_artifacts`. It retires only deprecated artifacts whose digest proves Orbit wrote them, preserves locally modified ones under `.retired-managed/`, and never touches faulty or user-authored files. Removal re-validates the relative path and uses `symlink_metadata` so it never follows a symlink at the boundary. The CLI file gained one clap arg and five lines in the existing Execute impl.

## Tests

Seven new tests in `command/tests/managed_assets.rs::artifacts` covering provenance recording for all five kinds, a clean fresh workspace, deprecated detection + selective removal + preservation + idempotency, faulty-user-authored (reported, never touched), unloadable-shipped-default escalation, drift-is-stale-not-removable, untracked collision, and the traversal/symlink refusals. Plus the routine no-op re-seed test. All pass.

## Out-of-scope adjustments (recorded per instruction 4)

- `crates/orbit-core/src/command/init.rs` — `remove_workspace_seeded_default_skills` now drops a leftover managed manifest when it is the only remaining entry. Required: the new manifest kept the legacy workspace skills dir non-empty, so `remove_empty_dir` stopped removing it and `workspace_init_leaves_repo_skills_unseeded` failed.
- Two `refreshed_skill_files` assertions updated from 4 to 11. Skills are reconciled per managed *file* now, matching the field's name and how activities/jobs already count.
- `crates/orbit-core/src/command/job/{mod,catalog}.rs` — `catalog` module and `DEFAULT_JOB_FILES` raised to `pub(crate)` so the sibling detection module can read the shipped job set.

## Docs

ADR-0366 in `docs/design/activity-job/4_decisions.md` (Door 1, with `code_anchors:` and matching `// ADR-0366` back-anchors at each site), plus same-PR updates to `activity-job/2_design.md` (new §4.1.1), `auto-tasks/2_design.md`, and `routines/2_design.md`, with frontmatter bumped.

Note: `docs/design/CONVENTIONS.md` §4d says an executing agent never mints an ADR. I wrote it because acceptance criterion 12 explicitly requires one — treating the task spec as the deliberate human-driven authoring §4d asks for. Flagging for the reviewer.

## Pre-existing failures (not introduced here, left alone)

- `command::routine::tests::dogfood_task_pilot_routine_matches_the_rendered_default_template` — the repo's own `.orbit/routines/task_pilot.yaml` is committed with `enabled: true` (commit 93a18b59) while the shipped template has `enabled: false`. Neither file is in this diff.
- `orbit-common`: `types::tests::routine::rejects_inline_command_shaped_targets` and `types::tests::task_artifacts::relations::produces_and_resolves_accept_cross_artifact_targets`. This diff touches no orbit-common file, and orbit-common does not depend on orbit-core/orbit-cmd, so these cannot be affected by it.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10800-6a7fe48b`
- Behind base: 0
- Ahead of base: 1