### PR TITLE
Move generic coordination auditing out of runtime task locks

### DIFF
--- a/crates/orbit-core/src/runtime/command_exec.rs
+++ b/crates/orbit-core/src/runtime/command_exec.rs
@@ -26,7 +26,7 @@ use orbit_common::types::{AuditEventStatus, ExecutionResult, OrbitError};
 use orbit_common::utility::redaction::is_sensitive_env_name;
 use serde_json::json;
 
-use super::task::locks::{CoordinationAuditEvent, record_coordination_audit_event};
+use super::coordination_audit::{CoordinationAuditEvent, record_coordination_audit_event};
 use crate::OrbitRuntime;
 
 const COMMAND_TOOL_NAME: &str = "orbit.command.exec";

--- a/crates/orbit-core/src/runtime/coordination_audit.rs
+++ b/crates/orbit-core/src/runtime/coordination_audit.rs
@@ -1,0 +1,101 @@
+//! Neutral coordination-hold audit seam.
+//!
+//! Task locks, workspace claims, and command execution all persist the same
+//! audit shape. The types live here so that generic coordination infrastructure
+//! is not owned by the task-lock module.
+
+use orbit_common::types::{AuditEventStatus, OrbitError, audit_execution_id};
+use serde_json::Value;
+
+use crate::OrbitRuntime;
+
+/// One coordination-hold audit event, before it is widened into the full
+/// `AuditEventInsertParams`.
+///
+/// [ORB-10709] `target_type` is carried here rather than fixed as a constant
+/// because the workspace claim is a second coordination dimension over the same
+/// table and must be distinguishable in the trail — a force-release has to be
+/// legible as a claim event, not as a reservation event.
+pub(crate) struct CoordinationAuditEvent<'a> {
+    pub(crate) command: &'a str,
+    pub(crate) tool_name: &'a str,
+    pub(crate) target_type: &'a str,
+    pub(crate) target_id: Option<&'a str>,
+    pub(crate) task_id: Option<&'a str>,
+    pub(crate) status: AuditEventStatus,
+    pub(crate) payload: Value,
+}
+
+/// Record one coordination-hold event (file reservation or workspace claim).
+pub(crate) fn record_coordination_audit_event(
+    runtime: &OrbitRuntime,
+    event: CoordinationAuditEvent<'_>,
+) -> Result<(), OrbitError> {
+    let CoordinationAuditEvent {
+        command,
+        tool_name,
+        target_type,
+        target_id,
+        task_id,
+        status,
+        payload,
+    } = event;
+    let execution_id_prefix = format!("audit-{}", command.replace('.', "-"));
+    let job_run_id = owner_run_id_from_payload(&payload)
+        .or_else(|| std::env::var("ORBIT_RUN_ID").ok().filter(|s| !s.is_empty()));
+    runtime.record_audit_event(&crate::AuditEventInsertParams {
+        execution_id: audit_execution_id(&execution_id_prefix),
+        command: command.to_string(),
+        subcommand: None,
+        tool_name: Some(tool_name.to_string()),
+        target_type: Some(target_type.to_string()),
+        target_id: target_id.map(ToOwned::to_owned),
+        role: "admin".to_string(),
+        status,
+        exit_code: if status == AuditEventStatus::Denied {
+            1
+        } else {
+            0
+        },
+        duration_ms: 0,
+        working_directory: runtime.paths().repo_root.to_string_lossy().into_owned(),
+        arguments_json: Some(
+            serde_json::to_string(&payload).map_err(|error| {
+                OrbitError::Execution(format!("serialize audit payload: {error}"))
+            })?,
+        ),
+        stdout_truncated: None,
+        stderr_truncated: None,
+        error_message: None,
+        host: std::env::var("HOSTNAME").ok(),
+        pid: std::process::id(),
+        session_id: None,
+        workspace_id: None,
+        caller_machine_id: None,
+        caller_host_id: None,
+        process_machine_id: None,
+        process_host_id: None,
+        transport: None,
+        effective_capabilities: Default::default(),
+        origin_session_id: None,
+        mcp_call_id: None,
+        lease_id: None,
+        task_id: task_id.map(ToOwned::to_owned),
+        job_run_id,
+        activity_id: std::env::var("ORBIT_ACTIVITY_ID")
+            .ok()
+            .filter(|s| !s.is_empty()),
+        step_index: std::env::var("ORBIT_STEP_INDEX")
+            .ok()
+            .and_then(|s| s.parse().ok()),
+    })
+}
+
+fn owner_run_id_from_payload(payload: &Value) -> Option<String> {
+    payload
+        .get("owner_run_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -15,6 +15,7 @@ pub mod audit;
 mod authorization;
 pub mod builder;
 mod command_exec;
+mod coordination_audit;
 pub mod engine;
 pub mod event_bus;
 pub mod mutation;

--- a/crates/orbit-core/src/runtime/task/locks.rs
+++ b/crates/orbit-core/src/runtime/task/locks.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 use orbit_common::types::{
-    AuditEventStatus, NotFoundKind, OrbitError, Task, TaskStatus, audit_execution_id,
+    AuditEventStatus, NotFoundKind, OrbitError, Task, TaskStatus,
     normalize_optional_attribution_label, optional_string_list_alias, optional_u32_alias,
     prune_missing_context_files, required_string,
 };
@@ -21,6 +21,7 @@ use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
 use crate::command::task::canonicalize_context_files_for_read;
+use crate::runtime::coordination_audit::{CoordinationAuditEvent, record_coordination_audit_event};
 
 pub(in crate::runtime) fn list(runtime: &OrbitRuntime) -> Result<Value, OrbitError> {
     let workspace_id = workspace_task_reservation_id(runtime)?;
@@ -569,99 +570,8 @@ fn record_task_lock_audit_event(
     )
 }
 
-/// One coordination-hold audit event, before it is widened into the full
-/// `AuditEventInsertParams`.
-///
-/// [ORB-10709] `target_type` is carried here rather than fixed as a constant
-/// because the workspace claim is a second coordination dimension over the same
-/// table and must be distinguishable in the trail — a force-release has to be
-/// legible as a claim event, not as a reservation event.
-pub(crate) struct CoordinationAuditEvent<'a> {
-    pub(crate) command: &'a str,
-    pub(crate) tool_name: &'a str,
-    pub(crate) target_type: &'a str,
-    pub(crate) target_id: Option<&'a str>,
-    pub(crate) task_id: Option<&'a str>,
-    pub(crate) status: AuditEventStatus,
-    pub(crate) payload: Value,
-}
-
-/// Record one coordination-hold event (file reservation or workspace claim).
-pub(crate) fn record_coordination_audit_event(
-    runtime: &OrbitRuntime,
-    event: CoordinationAuditEvent<'_>,
-) -> Result<(), OrbitError> {
-    let CoordinationAuditEvent {
-        command,
-        tool_name,
-        target_type,
-        target_id,
-        task_id,
-        status,
-        payload,
-    } = event;
-    let execution_id_prefix = format!("audit-{}", command.replace('.', "-"));
-    let job_run_id = owner_run_id_from_payload(&payload)
-        .or_else(|| std::env::var("ORBIT_RUN_ID").ok().filter(|s| !s.is_empty()));
-    runtime.record_audit_event(&crate::AuditEventInsertParams {
-        execution_id: audit_execution_id(&execution_id_prefix),
-        command: command.to_string(),
-        subcommand: None,
-        tool_name: Some(tool_name.to_string()),
-        target_type: Some(target_type.to_string()),
-        target_id: target_id.map(ToOwned::to_owned),
-        role: "admin".to_string(),
-        status,
-        exit_code: if status == AuditEventStatus::Denied {
-            1
-        } else {
-            0
-        },
-        duration_ms: 0,
-        working_directory: runtime.paths().repo_root.to_string_lossy().into_owned(),
-        arguments_json: Some(
-            serde_json::to_string(&payload).map_err(|error| {
-                OrbitError::Execution(format!("serialize audit payload: {error}"))
-            })?,
-        ),
-        stdout_truncated: None,
-        stderr_truncated: None,
-        error_message: None,
-        host: std::env::var("HOSTNAME").ok(),
-        pid: std::process::id(),
-        session_id: None,
-        workspace_id: None,
-        caller_machine_id: None,
-        caller_host_id: None,
-        process_machine_id: None,
-        process_host_id: None,
-        transport: None,
-        effective_capabilities: Default::default(),
-        origin_session_id: None,
-        mcp_call_id: None,
-        lease_id: None,
-        task_id: task_id.map(ToOwned::to_owned),
-        job_run_id,
-        activity_id: std::env::var("ORBIT_ACTIVITY_ID")
-            .ok()
-            .filter(|s| !s.is_empty()),
-        step_index: std::env::var("ORBIT_STEP_INDEX")
-            .ok()
-            .and_then(|s| s.parse().ok()),
-    })
-}
-
 fn first_task_id(task_ids: &[String]) -> Option<&str> {
     task_ids.first().map(String::as_str)
-}
-
-fn owner_run_id_from_payload(payload: &Value) -> Option<String> {
-    payload
-        .get("owner_run_id")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned)
 }
 
 fn task_lock_to_json(task: &Task) -> Value {

--- a/crates/orbit-core/src/runtime/workspace_claim.rs
+++ b/crates/orbit-core/src/runtime/workspace_claim.rs
@@ -36,10 +36,8 @@ use orbit_store::{
 };
 use serde_json::{Value, json};
 
-use super::task::locks::{
-    CoordinationAuditEvent, record_coordination_audit_event, workspace_orbit_dir,
-    workspace_task_reservation_id,
-};
+use super::coordination_audit::{CoordinationAuditEvent, record_coordination_audit_event};
+use super::task::locks::{workspace_orbit_dir, workspace_task_reservation_id};
 use crate::OrbitRuntime;
 
 /// Environment fallback for the holder's token, so an operator shell does not


### PR DESCRIPTION
## Task

[ORB-10808](https://orbit-cli.com/tasks/ORB-10808) — Move generic coordination auditing out of runtime task locks

### Description

## Problem
`runtime/task/locks.rs` owns `CoordinationAuditEvent` and `record_coordination_audit_event`, but non-task runtime modules such as command execution and workspace claims import them. This makes generic coordination infrastructure appear task-specific and creates an ownership inversion.

## Why It Matters
A neutral ownership boundary makes the runtime easier to navigate and keeps the task-lock module focused on task locking.

## Constraints / Notes
- Extract one neutral runtime coordination/audit seam.
- Keep task-specific lock and workspace identity behavior in the task module.
- Update all consumers to depend on the neutral module directly.
- Preserve audit record contents and failure behavior; this is structural cleanup, not a schema or policy change.

### Acceptance Criteria

- `command_exec.rs` and `workspace_claim.rs` no longer import generic coordination audit helpers from `runtime::task::locks`.
- `runtime::task::locks` retains only task-lock-specific behavior and uses the neutral coordination audit seam where needed.
- Existing coordination audit fields, statuses, and error handling remain behaviorally unchanged.
- Focused task-lock, command execution, and workspace-claim tests pass.
- `cargo clippy -p orbit-core --all-targets -- -D warnings` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Extracted `CoordinationAuditEvent`, `record_coordination_audit_event`, and `owner_run_id_from_payload` from `runtime/task/locks.rs` into a new `runtime/coordination_audit.rs` seam.
- `command_exec.rs` and `workspace_claim.rs` now import the generic audit helpers from that module; they no longer take them from `runtime::task::locks`.
- `locks.rs` keeps task-lock-specific behavior (`record_task_lock_audit_event`, reservation identity helpers) and records through the new seam.
- Extra context files: `file:crates/orbit-core/src/runtime/mod.rs` (module declaration) and `file:crates/orbit-core/src/runtime/coordination_audit.rs` (new seam).
Assessment: Structural move only. Audit fields, Denied exit_code, job_run_id extraction, and error handling are unchanged. Focused lock/claim/command-exec tests (32) and `cargo clippy -p orbit-core --all-targets -- -D warnings` passed.
Strategic decisions: New sibling module rather than the empty `runtime/audit.rs`, which is reserved for audit-normalization hooks.
Recommended follow-ups: none

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10808-6a809e23`
- Behind base: 0
- Ahead of base: 1