### PR TITLE
Add direct tests for command task records and parameter routing

### DIFF
--- a/crates/orbit-core/src/command/task/tests/mod.rs
+++ b/crates/orbit-core/src/command/task/tests/mod.rs
@@ -1,7 +1,9 @@
 #![allow(missing_docs)]
 
 mod add;
+mod params;
 mod paths;
+mod records;
 mod update;
 
 use crate::OrbitRuntime;

--- a/crates/orbit-core/src/command/task/tests/params.rs
+++ b/crates/orbit-core/src/command/task/tests/params.rs
@@ -1,0 +1,80 @@
+use orbit_common::types::{TaskComplexity, TaskPriority, TaskStatus, TaskType};
+
+use super::super::params::{TaskAddParams, TaskRecordUpdateParams, TaskUpdateParams};
+
+#[test]
+fn task_add_params_preserve_workspace_routing_and_defaults() {
+    let defaults = TaskAddParams::default();
+    assert_eq!(defaults.workspace_path, None);
+    assert_eq!(defaults.priority, TaskPriority::Medium);
+    assert!(defaults.acceptance_criteria.is_empty());
+
+    let params = TaskAddParams {
+        title: "Workspace-scoped task".to_string(),
+        workspace_path: Some("packages/orbit".to_string()),
+        ..defaults
+    };
+    assert_eq!(params.title, "Workspace-scoped task");
+    assert_eq!(params.workspace_path.as_deref(), Some("packages/orbit"));
+}
+
+#[test]
+fn task_update_params_route_document_history_and_artifact_fields() {
+    let params = TaskUpdateParams {
+        title: Some("Updated title".to_string()),
+        description: Some("Updated description".to_string()),
+        acceptance_criteria: Some(vec!["criterion".to_string()]),
+        dependencies: Some(vec!["ORB-00042".to_string()]),
+        tags: Some(vec!["focused".to_string()]),
+        plan: Some("1. Update".to_string()),
+        execution_summary: Some("Verified".to_string()),
+        status: Some(TaskStatus::Review),
+        priority: Some(TaskPriority::High),
+        complexity: Some(TaskComplexity::Medium),
+        task_type: Some(TaskType::Refactor),
+        planned_by: Some(Some("codex".to_string())),
+        implemented_by: Some(None),
+        pr_status: Some(Some("approved".to_string())),
+        job_run_id: Some(Some("jrun-123".to_string())),
+        crew: Some(Some("implementer".to_string())),
+        orchestrator: Some(None),
+        context_files: Some(vec!["file:src/lib.rs".to_string()]),
+        upsert_artifacts: vec![orbit_common::types::TaskArtifact::from_text(
+            "report.txt",
+            "verified",
+        )],
+        ..Default::default()
+    };
+
+    assert!(params.has_any_mutation());
+    assert!(params.has_non_comment_mutation());
+
+    let record = TaskRecordUpdateParams::from(params);
+    assert_eq!(record.title.as_deref(), Some("Updated title"));
+    assert_eq!(record.dependencies, Some(vec!["ORB-00042".to_string()]));
+    assert_eq!(record.status, Some(TaskStatus::Review));
+    assert_eq!(record.priority, Some(TaskPriority::High));
+    assert_eq!(record.complexity, Some(TaskComplexity::Medium));
+    assert_eq!(record.task_type, Some(TaskType::Refactor));
+    assert_eq!(record.planned_by, Some(Some("codex".to_string())));
+    assert_eq!(record.implemented_by, Some(None));
+    assert_eq!(record.pr_status, Some(Some("approved".to_string())));
+    assert_eq!(record.job_run_id, Some(Some("jrun-123".to_string())));
+    assert_eq!(record.crew, Some(Some("implementer".to_string())));
+    assert_eq!(record.orchestrator, Some(None));
+    assert!(record.has_document_changes());
+    assert!(record.has_history_changes());
+    assert!(record.has_artifact_changes());
+    assert_eq!(record.upsert_artifacts[0].text_content(), Some("verified"));
+}
+
+#[test]
+fn empty_task_update_is_rejected_by_mutation_routing() {
+    let params = TaskUpdateParams::default();
+    assert!(!params.has_any_mutation());
+
+    let record = TaskRecordUpdateParams::from(params);
+    assert!(!record.has_document_changes());
+    assert!(!record.has_history_changes());
+    assert!(!record.has_artifact_changes());
+}

--- a/crates/orbit-core/src/command/task/tests/records.rs
+++ b/crates/orbit-core/src/command/task/tests/records.rs
@@ -1,0 +1,127 @@
+use chrono::Utc;
+use orbit_common::types::{
+    TaskArtifact, TaskComment, TaskHistoryEntry, TaskPriority, TaskStatus, TaskType,
+};
+use orbit_store::TaskCreateParams;
+
+use super::super::params::TaskRecordUpdateParams;
+use super::test_runtime;
+
+fn create_params(runtime: &crate::OrbitRuntime) -> TaskCreateParams {
+    TaskCreateParams {
+        actor: "test".to_string(),
+        parent_id: None,
+        title: "Stored task".to_string(),
+        description: "Initial description".to_string(),
+        acceptance_criteria: vec!["initial criterion".to_string()],
+        dependencies: Vec::new(),
+        relations: Vec::new(),
+        tags: vec!["initial".to_string()],
+        plan: "Initial plan".to_string(),
+        execution_summary: String::new(),
+        context_files: vec!["file:src/lib.rs".to_string()],
+        workspace_path: Some(runtime.paths().repo_root.to_string_lossy().into_owned()),
+        repo_root: None,
+        created_by: Some("test".to_string()),
+        planned_by: None,
+        implemented_by: None,
+        status: TaskStatus::Backlog,
+        priority: TaskPriority::Medium,
+        complexity: None,
+        task_type: TaskType::Chore,
+        external_refs: Vec::new(),
+        source_task_id: None,
+        crew: None,
+        orchestrator: None,
+        comments: Vec::new(),
+    }
+}
+
+#[test]
+fn task_records_round_trip_document_history_and_artifact_updates() {
+    let (_root, runtime) = test_runtime();
+    let service = runtime.stores().task_records();
+    let task = service
+        .create(create_params(&runtime))
+        .expect("create task record");
+
+    let updated = service
+        .update(
+            &task.id,
+            TaskRecordUpdateParams {
+                actor: "codex".to_string(),
+                title: Some("Updated title".to_string()),
+                description: Some("Updated description".to_string()),
+                tags: Some(vec!["updated".to_string()]),
+                priority: Some(TaskPriority::High),
+                status: Some(TaskStatus::Review),
+                status_event: Some("status_changed".to_string()),
+                status_note: Some("Ready for review".to_string()),
+                append_history: vec![TaskHistoryEntry {
+                    at: Utc::now(),
+                    by: "codex".to_string(),
+                    event: "verified".to_string(),
+                    note: Some("record conversion".to_string()),
+                    from_status: None,
+                    to_status: None,
+                }],
+                append_comments: vec![TaskComment {
+                    at: Utc::now(),
+                    by: "codex".to_string(),
+                    message: "Stored comment".to_string(),
+                }],
+                upsert_artifacts: vec![TaskArtifact::from_text("reports/result.txt", "passed")],
+                ..Default::default()
+            },
+        )
+        .expect("update task record");
+
+    assert_eq!(updated.title, "Updated title");
+    assert_eq!(updated.description, "Updated description");
+    assert_eq!(updated.tags, vec!["updated"]);
+    assert_eq!(updated.priority, TaskPriority::High);
+    assert_eq!(updated.status, TaskStatus::Review);
+
+    let persisted = runtime.get_task(&task.id).expect("read persisted task");
+    assert_eq!(persisted.title, "Updated title");
+    assert!(
+        runtime
+            .get_task_history(&task.id)
+            .expect("read task history")
+            .iter()
+            .any(|entry| entry.event == "verified"
+                && entry.note.as_deref() == Some("record conversion"))
+    );
+    assert!(
+        runtime
+            .get_task_comments(&task.id)
+            .expect("read task comments")
+            .iter()
+            .any(|comment| comment.message == "Stored comment")
+    );
+    assert_eq!(
+        runtime
+            .get_task_artifacts(&task.id)
+            .expect("read task artifacts")
+            .iter()
+            .find(|artifact| artifact.path == "reports/result.txt")
+            .and_then(TaskArtifact::text_content),
+        Some("passed")
+    );
+}
+
+#[test]
+fn task_records_delete_reports_presence_and_removes_persisted_task() {
+    let (_root, runtime) = test_runtime();
+    let service = runtime.stores().task_records();
+    let task = service
+        .create(create_params(&runtime))
+        .expect("create task record");
+
+    assert!(service.delete(&task.id).expect("delete existing task"));
+    assert!(!service.delete(&task.id).expect("delete missing task"));
+    let error = runtime
+        .get_task(&task.id)
+        .expect_err("deleted task should not be readable");
+    assert!(error.to_string().contains(&task.id), "{error}");
+}


### PR DESCRIPTION
## Task

[ORB-10809](https://orbit-cli.com/tasks/ORB-10809) — Add direct tests for command task records and parameter routing

### Description

## Problem
`command/task/records.rs` and the routing helpers in `command/task/params.rs` currently receive only transitive coverage. Their module-level contracts can regress without a focused failure pointing to the responsible boundary.

## Why It Matters
Sibling tests make record conversion and parameter-routing behavior explicit and keep the command/task module aligned with `docs/design-patterns/test_layout.md`.

## Constraints / Notes
- Add focused sibling test modules rather than moving production logic unnecessarily.
- Test externally meaningful transformations and routing decisions, not private implementation trivia.
- Do not change production behavior solely to accommodate tests.

### Acceptance Criteria

- `command/task/tests/records.rs` directly covers the meaningful record conversion and serialization contracts owned by `records.rs`.
- `command/task/tests/params.rs` directly covers workspace/task parameter routing, including representative valid and invalid inputs.
- The sibling test module declarations follow the repository test-layout convention.
- Existing command task tests and `cargo test -p orbit-core command::task` pass with no production behavior regression.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added sibling tests for command/task parameter routing in `tests/params.rs`, covering workspace-path/default routing, full update-to-record conversion, optional clearing, and the no-mutation case.
- Added sibling tests for task record creation, document/history/artifact persistence round trips, and deletion in `tests/records.rs`.
- Registered both sibling modules from `tests/mod.rs`; production code was unchanged.
Assessment: Focused tests exercise the existing command/task seams and persisted record behavior without widening production APIs or introducing new dependencies.
Validation:
- `cargo fmt --all -- --check` passed.
- `cargo test -p orbit-core command::task` passed (30 tests).
- `make ci-fast` passed.
- `make ci-lint` passed.
- `git diff --check` passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10809-6a809e23`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*