### PR TITLE
Narrow the auto-task MCP surface to list+mint, drop friction show/tags

### DIFF
--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -34,117 +34,24 @@
   {
     "active": true,
     "builtin": true,
-    "description": "Create a recurring auto-task definition. The generic scheduler mints a task from its template on each due slot.",
+    "description": "List every auto-task definition in this workspace.",
     "enabled": true,
-    "name": "orbit.auto_task.add",
-    "parameters": [
-      {
-        "description": "Unique definition name (lowercase alphanumeric, `-`/`_`, starts alphanumeric). Required.",
-        "name": "name",
-        "param_type": "string",
-        "required": true
-      },
-      {
-        "description": "Human description of the recurring chore.",
-        "name": "description",
-        "param_type": "string",
-        "required": false
-      },
-      {
-        "description": "Schedule object: exactly one of `{ cron: string }` (5-field cron) or `{ every_minutes: number }`. Required.",
-        "name": "schedule",
-        "param_type": "object",
-        "required": true
-      },
-      {
-        "description": "Task template: `{ title, description?, acceptance_criteria?, task_type?, tags?, priority?, crew?, status? }`. Provider-neutral — no turn knobs. Required.",
-        "name": "template",
-        "param_type": "object",
-        "required": true
-      },
-      {
-        "description": "Dedupe policy: `skip_if_open` (default) or `always`.",
-        "name": "dedupe",
-        "param_type": "string",
-        "required": false
-      }
-    ],
+    "name": "orbit.auto_task.list",
+    "parameters": [],
     "status": "active"
   },
   {
     "active": true,
     "builtin": true,
-    "description": "Show a single auto-task definition by name.",
+    "description": "Mint one task now from an auto-task definition. Unconditional: the schedule, dedupe policy, and enabled flag are ignored, and the scheduler's own cursor is left untouched.",
     "enabled": true,
-    "name": "orbit.auto_task.show",
+    "name": "orbit.auto_task.mint",
     "parameters": [
       {
         "description": "Definition name. Required.",
         "name": "name",
         "param_type": "string",
         "required": true
-      }
-    ],
-    "status": "active"
-  },
-  {
-    "active": true,
-    "builtin": true,
-    "description": "Enable or disable an auto-task definition without deleting it.",
-    "enabled": true,
-    "name": "orbit.auto_task.toggle",
-    "parameters": [
-      {
-        "description": "Definition name. Required.",
-        "name": "name",
-        "param_type": "string",
-        "required": true
-      },
-      {
-        "description": "Whether to enable (`true`) or disable (`false`) the definition. Disabling is the kill-switch, not a delete. Required.",
-        "name": "enabled",
-        "param_type": "boolean",
-        "required": true
-      }
-    ],
-    "status": "active"
-  },
-  {
-    "active": true,
-    "builtin": true,
-    "description": "Update an existing auto-task definition (present fields only).",
-    "enabled": true,
-    "name": "orbit.auto_task.update",
-    "parameters": [
-      {
-        "description": "Definition name. Required.",
-        "name": "name",
-        "param_type": "string",
-        "required": true
-      },
-      {
-        "description": "New description.",
-        "name": "description",
-        "param_type": "string",
-        "required": false
-      },
-      {
-        "description": "New schedule object: `{ cron: string }` or `{ every_minutes: number }`.",
-        "name": "schedule",
-        "param_type": "object",
-        "required": false
-      },
-      {
-        "description": "Replacement task template object.",
-        "name": "template",
-        "param_type": "object",
-        "required": false
-      },
-      {
-        "description": "New dedupe policy: `skip_if_open` or `always`.",
-        "name": "dedupe",
-        "param_type": "string",
-        "required": false
       }
     ],
     "status": "active"
@@ -285,31 +192,6 @@
         "required": false
       }
     ],
-    "status": "active"
-  },
-  {
-    "active": true,
-    "builtin": true,
-    "description": "Fetch a single Orbit friction record by id",
-    "enabled": true,
-    "name": "orbit.friction.show",
-    "parameters": [
-      {
-        "description": "friction ID",
-        "name": "id",
-        "param_type": "string",
-        "required": true
-      }
-    ],
-    "status": "active"
-  },
-  {
-    "active": true,
-    "builtin": true,
-    "description": "List configured friction taxonomy tags",
-    "enabled": true,
-    "name": "orbit.friction.tags",
-    "parameters": [],
     "status": "active"
   },
   {

--- a/crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
@@ -1,14 +1,10 @@
 fs.delete	path:string	Delete a file from disk
 fs.read	path:string	Read a UTF-8 text file from disk
-orbit.auto_task.add	name:string, schedule:object, template:object	Create a recurring auto-task definition. The generic scheduler mints a task from its template on each due slot.
-orbit.auto_task.show	name:string	Show a single auto-task definition by name.
-orbit.auto_task.toggle	name:string, enabled:boolean	Enable or disable an auto-task definition without deleting it.
-orbit.auto_task.update	name:string	Update an existing auto-task definition (present fields only).
+orbit.auto_task.list	-	List every auto-task definition in this workspace.
+orbit.auto_task.mint	name:string	Mint one task now from an auto-task definition. Unconditional: the schedule, dedupe policy, and enabled flag are ignored, and the scheduler's own cursor is left untouched.
 orbit.command.exec	argv:string|string[], working_directory:string	Execute a command as an explicit argv array in an explicit working directory and return its stdout, stderr, and exit status. Requires operator capability and the workspace claim; withheld from managed runs.
 orbit.friction.add	body:string, model:string	Append an Orbit friction report under .orbit/frictions/
 orbit.friction.list	-	List Orbit friction records from .orbit/frictions/
-orbit.friction.show	id:string	Fetch a single Orbit friction record by id
-orbit.friction.tags	-	List configured friction taxonomy tags
 orbit.friction.update	id:string	Update triage metadata for an Orbit friction record
 orbit.pipeline.invoke	job_name:string, input:object	Submit a durable pipeline run and return immediately with its run ID.
 orbit.pipeline.wait	run_ids:string|string[]	Block until the supplied pipeline runs reach terminal state or timeout.

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -1,65 +1,20 @@
 [
   {
-    "description": "Create a recurring auto-task definition. The generic scheduler mints a task from its template on each due slot.",
+    "description": "List every auto-task definition in this workspace.",
     "inputSchema": {
       "additionalProperties": true,
       "properties": {
-        "dedupe": {
-          "description": "Dedupe policy: `skip_if_open` (default) or `always`.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human description of the recurring chore.",
-          "type": "string"
-        },
-        "name": {
-          "description": "Unique definition name (lowercase alphanumeric, `-`/`_`, starts alphanumeric). Required.",
-          "type": "string"
-        },
-        "schedule": {
-          "anyOf": [
-            {
-              "type": "object"
-            },
-            {
-              "items": {
-                "type": "object"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "Schedule object: exactly one of `{ cron: string }` (5-field cron) or `{ every_minutes: number }`. Required."
-        },
-        "template": {
-          "anyOf": [
-            {
-              "type": "object"
-            },
-            {
-              "items": {
-                "type": "object"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "Task template: `{ title, description?, acceptance_criteria?, task_type?, tags?, priority?, crew?, status? }`. Provider-neutral — no turn knobs. Required."
-        },
         "workspace": {
           "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
           "type": "string"
         }
       },
-      "required": [
-        "name",
-        "schedule",
-        "template"
-      ],
       "type": "object"
     },
-    "name": "orbit_auto_task_add"
+    "name": "orbit_auto_task_list"
   },
   {
-    "description": "Show a single auto-task definition by name.",
+    "description": "Mint one task now from an auto-task definition. Unconditional: the schedule, dedupe policy, and enabled flag are ignored, and the scheduler's own cursor is left untouched.",
     "inputSchema": {
       "additionalProperties": true,
       "properties": {
@@ -77,90 +32,7 @@
       ],
       "type": "object"
     },
-    "name": "orbit_auto_task_show"
-  },
-  {
-    "description": "Enable or disable an auto-task definition without deleting it.",
-    "inputSchema": {
-      "additionalProperties": true,
-      "properties": {
-        "enabled": {
-          "description": "Whether to enable (`true`) or disable (`false`) the definition. Disabling is the kill-switch, not a delete. Required.",
-          "type": "boolean"
-        },
-        "name": {
-          "description": "Definition name. Required.",
-          "type": "string"
-        },
-        "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "name",
-        "enabled"
-      ],
-      "type": "object"
-    },
-    "name": "orbit_auto_task_toggle"
-  },
-  {
-    "description": "Update an existing auto-task definition (present fields only).",
-    "inputSchema": {
-      "additionalProperties": true,
-      "properties": {
-        "dedupe": {
-          "description": "New dedupe policy: `skip_if_open` or `always`.",
-          "type": "string"
-        },
-        "description": {
-          "description": "New description.",
-          "type": "string"
-        },
-        "name": {
-          "description": "Definition name. Required.",
-          "type": "string"
-        },
-        "schedule": {
-          "anyOf": [
-            {
-              "type": "object"
-            },
-            {
-              "items": {
-                "type": "object"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "New schedule object: `{ cron: string }` or `{ every_minutes: number }`."
-        },
-        "template": {
-          "anyOf": [
-            {
-              "type": "object"
-            },
-            {
-              "items": {
-                "type": "object"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "Replacement task template object."
-        },
-        "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "name"
-      ],
-      "type": "object"
-    },
-    "name": "orbit_auto_task_update"
+    "name": "orbit_auto_task_mint"
   },
   {
     "description": "Execute a command as an explicit argv array in an explicit working directory and return its stdout, stderr, and exit status. Requires operator capability and the workspace claim; withheld from managed runs.",
@@ -335,41 +207,6 @@
       "type": "object"
     },
     "name": "orbit_friction_list"
-  },
-  {
-    "description": "Fetch a single Orbit friction record by id",
-    "inputSchema": {
-      "additionalProperties": true,
-      "properties": {
-        "id": {
-          "description": "friction ID",
-          "type": "string"
-        },
-        "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "name": "orbit_friction_show"
-  },
-  {
-    "description": "List configured friction taxonomy tags",
-    "inputSchema": {
-      "additionalProperties": true,
-      "properties": {
-        "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "name": "orbit_friction_tags"
   },
   {
     "description": "Update triage metadata for an Orbit friction record",

--- a/crates/orbit-cli/tests/tool_list.rs
+++ b/crates/orbit-cli/tests/tool_list.rs
@@ -9,6 +9,13 @@ use predicates::prelude::*;
 use tempfile::tempdir;
 
 const INACTIVE_TOOL_NAMES: &[&str] = &[
+    // ORB-10798: auto-task authoring is human/admin work on the CLI surface.
+    "orbit.auto_task.add",
+    "orbit.auto_task.show",
+    "orbit.auto_task.toggle",
+    "orbit.auto_task.update",
+    "orbit.friction.show",
+    "orbit.friction.tags",
     "orbit.docs.index",
     "orbit.docs.migrate",
     "orbit.docs.add",
@@ -138,6 +145,11 @@ fn tool_list_json_all_includes_parameter_schema_for_inactive_tools() {
         .clone();
 
     let tools: Vec<serde_json::Value> = serde_json::from_slice(&output).expect("tool list JSON");
+    let mint = tools
+        .iter()
+        .find(|tool| tool["name"] == "orbit.auto_task.mint")
+        .expect("mint tool");
+    assert_eq!(mint["status"], "active");
     let reserve = tools
         .iter()
         .find(|tool| tool["name"] == "orbit.task.locks.reserve")

--- a/crates/orbit-common/src/friction/operations.rs
+++ b/crates/orbit-common/src/friction/operations.rs
@@ -190,7 +190,9 @@ const SHOW: FrictionOperation = FrictionOperation {
     cli_about: "Show a single Orbit friction record",
     params: &[BARE_ID_PARAM],
     rejects_agent_field: false,
-    mcp_scope: Some(McpToolScope::WorkspaceRequired),
+    // `list` already returns the record bodies an agent needs; fetching one by
+    // id is a human/dashboard follow-up and stays on the CLI surface.
+    mcp_scope: None,
     cli_json_flag: true,
     cli_render: CliRender::Record,
 };
@@ -217,7 +219,9 @@ const TAGS: FrictionOperation = FrictionOperation {
     cli_about: "List configured friction taxonomy tags",
     params: &[],
     rejects_agent_field: false,
-    mcp_scope: Some(McpToolScope::WorkspaceRequired),
+    // The taxonomy is already spelled out in the `add`/`update` tag parameter
+    // descriptions, so a separate advertised lookup earns nothing.
+    mcp_scope: None,
     cli_json_flag: true,
     cli_render: CliRender::TagList,
 };

--- a/crates/orbit-common/src/friction/tests.rs
+++ b/crates/orbit-common/src/friction/tests.rs
@@ -103,17 +103,19 @@ fn subcommand_order_is_the_shipped_help_order() {
 #[test]
 fn mcp_exposure_matches_the_shipped_conformance_contract() {
     // docs/design/mcp-bridge/references/conformance-v1.yaml
-    for verb in [
-        FrictionVerb::Add,
-        FrictionVerb::Tags,
-        FrictionVerb::List,
-        FrictionVerb::Show,
-        FrictionVerb::Update,
-    ] {
+    for verb in [FrictionVerb::Add, FrictionVerb::List, FrictionVerb::Update] {
         assert_eq!(verb.spec().mcp_scope, Some(McpToolScope::WorkspaceRequired));
     }
-    assert_eq!(FrictionVerb::Stats.spec().mcp_scope, None);
-    assert_eq!(FrictionVerb::Resolve.spec().mcp_scope, None);
+    // Reads that `list` already covers, aggregate stats, and operator
+    // resolution stay on the CLI / dashboard surface [ORB-10798].
+    for verb in [
+        FrictionVerb::Show,
+        FrictionVerb::Tags,
+        FrictionVerb::Stats,
+        FrictionVerb::Resolve,
+    ] {
+        assert_eq!(verb.spec().mcp_scope, None);
+    }
 }
 
 #[test]

--- a/crates/orbit-core/src/runtime/orbit_tool_host/auto_task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/auto_task_tools.rs
@@ -37,6 +37,15 @@ pub(super) fn list(runtime: &OrbitRuntime, _input: Value) -> Result<Value, Orbit
     Ok(Value::Array(array))
 }
 
+/// Mint one task from a definition on demand [ORB-10798]. The adapter only
+/// reads the name; `OrbitRuntime::auto_task_mint` owns the unconditional,
+/// cursor-neutral behavior the CLI subcommand already relies on.
+pub(super) fn mint(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
+    let name = required_str(&input, "name")?;
+    let task = runtime.auto_task_mint(&name)?;
+    super::json::serialize_task(runtime, &task)
+}
+
 pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
     let name = required_str(&input, "name")?;
     let definition = runtime

--- a/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
@@ -27,6 +27,7 @@ pub(super) fn execute(
         )),
         OrbitBuiltinAction::AutoTaskAdd => super::auto_task_tools::add(runtime, input),
         OrbitBuiltinAction::AutoTaskList => super::auto_task_tools::list(runtime, input),
+        OrbitBuiltinAction::AutoTaskMint => super::auto_task_tools::mint(runtime, input),
         OrbitBuiltinAction::AutoTaskShow => super::auto_task_tools::show(runtime, input),
         OrbitBuiltinAction::AutoTaskUpdate => super::auto_task_tools::update(runtime, input),
         OrbitBuiltinAction::AutoTaskToggle => super::auto_task_tools::toggle(runtime, input),

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/auto_task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/auto_task_tools.rs
@@ -1,0 +1,103 @@
+//! The auto-task tool adapters, exercised through the registered tools
+//! [ORB-10798].
+//!
+//! `crud.rs` owns the behavior; these are the boundary tests for the thin
+//! adapters — what the tool input has to carry, what comes back, and that
+//! `mint` still delegates to the unconditional, cursor-neutral runtime path.
+
+use orbit_common::types::auto_task_tag;
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+use crate::auto_tasks::crud::AutoTaskAddParams;
+use crate::auto_tasks::state::cursor_state_path;
+
+use super::super::test_support::{invalid_input_message, run_tool_as_operator, test_runtime};
+
+/// A disabled definition on a schedule whose next slot is an hour away: every
+/// condition a scheduler fire would check is arranged to say "not now", so a
+/// successful mint can only come from the unconditional path.
+fn params(name: &str) -> AutoTaskAddParams {
+    AutoTaskAddParams {
+        name: name.to_string(),
+        description: format!("Auto-task {name}"),
+        schedule: orbit_common::types::AutoTaskSchedule::Interval { every_minutes: 60 },
+        template: orbit_common::types::AutoTaskTemplate {
+            title: format!("Chore for {name}"),
+            description: "Recurring chore body.".to_string(),
+            acceptance_criteria: vec!["Chore is observable.".to_string()],
+            task_type: orbit_common::types::TaskType::Chore,
+            tags: vec![],
+            priority: orbit_common::types::TaskPriority::Medium,
+            crew: None,
+            status: orbit_common::types::TaskStatus::Backlog,
+        },
+        dedupe: orbit_common::types::DedupePolicy::SkipIfOpen,
+    }
+}
+
+fn with_definition(name: &str) -> (tempfile::TempDir, OrbitRuntime) {
+    let (temp, runtime, _repo) = test_runtime();
+    runtime.auto_task_add(params(name)).expect("add definition");
+    (temp, runtime)
+}
+
+#[test]
+fn list_returns_every_definition_through_the_tool_surface() {
+    let (_temp, runtime) = with_definition("chore");
+
+    let listed = run_tool_as_operator(&runtime, "orbit.auto_task.list", json!({})).expect("list");
+
+    let definitions = listed.as_array().expect("definition array");
+    assert_eq!(definitions.len(), 1);
+    assert_eq!(definitions[0]["name"], json!("chore"));
+}
+
+#[test]
+fn mint_returns_the_minted_task_with_its_provenance_tag() {
+    let (_temp, runtime) = with_definition("chore");
+    runtime
+        .auto_task_toggle("chore", false)
+        .expect("disable the definition");
+
+    let minted = run_tool_as_operator(&runtime, "orbit.auto_task.mint", json!({ "name": "chore" }))
+        .expect("mint");
+
+    assert_eq!(minted["title"], json!("[auto-task] Chore for chore"));
+    assert_eq!(minted["status"], json!("backlog"));
+    assert!(
+        minted["tags"]
+            .as_array()
+            .expect("tags array")
+            .contains(&Value::String(auto_task_tag("chore"))),
+        "expected provenance tag, got {}",
+        minted["tags"]
+    );
+    // The full task projection, not a bare id: the CLI subcommand and this
+    // adapter answer with the same record.
+    assert!(minted["id"].as_str().is_some());
+    assert!(minted["history"].is_array());
+    assert!(
+        !cursor_state_path(&runtime.paths().state_dir).exists(),
+        "a manual mint must not write the scheduler cursor"
+    );
+}
+
+#[test]
+fn mint_requires_a_definition_name_and_names_an_unknown_one() {
+    let (_temp, runtime) = with_definition("chore");
+
+    let missing = invalid_input_message(run_tool_as_operator(
+        &runtime,
+        "orbit.auto_task.mint",
+        json!({}),
+    ));
+    assert!(missing.contains("`name`"), "{missing}");
+
+    let unknown = invalid_input_message(run_tool_as_operator(
+        &runtime,
+        "orbit.auto_task.mint",
+        json!({ "name": "nope" }),
+    ));
+    assert!(unknown.contains("nope"), "{unknown}");
+}

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/mod.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/mod.rs
@@ -1,3 +1,4 @@
+mod auto_task_tools;
 mod command_tools;
 mod friction_tools;
 mod state_tools;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
@@ -245,13 +245,11 @@ fn friction_add_writes_markdown_record_and_validates_tags() {
     assert!(id.starts_with('F'), "{id}");
     assert_eq!(output["model"], json!("codex"));
 
+    // ORB-10798: `show` is inactive on the agent tool surface, so it is read
+    // back through the CLI / dashboard `run_tool` path, as `orbit friction
+    // show` does.
     let shown = runtime
-        .execute_tool_command(
-            "orbit.friction.show",
-            json!({ "id": id }),
-            Some("codex".to_string()),
-            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
-        )
+        .run_tool("orbit.friction.show", json!({ "id": id }))
         .expect("friction show succeeds");
     assert_eq!(shown["id"], json!(id));
     assert_eq!(shown["status"], json!("open"));

--- a/crates/orbit-mcp/src/remote/tests/discovery.rs
+++ b/crates/orbit-mcp/src/remote/tests/discovery.rs
@@ -53,7 +53,7 @@ fn mcp_owns_the_exact_global_discovery_definitions() {
     assert_eq!(crew.schema.parameters[0].name, "workspace");
 
     let canonical = canonical_mcp_tool_definitions().expect("canonical definitions");
-    assert_eq!(canonical.len(), 27, "the frozen production surface changed");
+    assert_eq!(canonical.len(), 23, "the frozen production surface changed");
     assert_eq!(
         canonical
             .iter()

--- a/crates/orbit-tools/src/builtin/orbit/auto_task/mint.rs
+++ b/crates/orbit-tools/src/builtin/orbit/auto_task/mint.rs
@@ -1,0 +1,26 @@
+use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
+use serde_json::Value;
+
+use crate::{OrbitBuiltinAction, Tool, ToolContext};
+
+pub struct OrbitAutoTaskMintTool;
+
+impl Tool for OrbitAutoTaskMintTool {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "orbit.auto_task.mint".to_string(),
+            description: "Mint one task now from an auto-task definition. Unconditional: the schedule, dedupe policy, and enabled flag are ignored, and the scheduler's own cursor is left untouched.".to_string(),
+            parameters: vec![ToolParam {
+                name: "name".to_string(),
+                description: "Definition name. Required.".to_string(),
+                param_type: "string".to_string(),
+                required: true,
+            }],
+            builtin: true,
+        }
+    }
+
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        super::super::execute_host_action(ctx, input, OrbitBuiltinAction::AutoTaskMint)
+    }
+}

--- a/crates/orbit-tools/src/builtin/orbit/auto_task/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/auto_task/mod.rs
@@ -1,5 +1,6 @@
 pub mod add;
 pub mod list;
+pub mod mint;
 pub mod show;
 pub mod toggle;
 pub mod update;

--- a/crates/orbit-tools/src/builtin/orbit/friction/tests/derived_schema.rs
+++ b/crates/orbit-tools/src/builtin/orbit/friction/tests/derived_schema.rs
@@ -190,11 +190,9 @@ fn registration_reproduces_the_shipped_mcp_surface() {
         vec![
             "orbit.friction.add",
             "orbit.friction.list",
-            "orbit.friction.show",
-            "orbit.friction.tags",
             "orbit.friction.update",
         ],
-        "stats and resolve stay off the MCP surface"
+        "show, tags, stats, and resolve stay off the MCP surface"
     );
     for definition in &definitions {
         assert_eq!(definition.scope, McpToolScope::WorkspaceRequired);

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -29,24 +29,21 @@ pub(super) struct OrbitIdentity {
 }
 
 pub fn register(registry: &mut ToolRegistry) {
-    // Auto-task mutation is MCP-visible; `list` stays on non-MCP surfaces.
+    // Auto-task definitions are authored by humans through the CLI; the MCP
+    // surface carries only what an executing agent needs — reading the
+    // definitions and minting one on demand.
+    registry.register_inactive(auto_task::add::OrbitAutoTaskAddTool);
     registry.register_mcp(
-        auto_task::add::OrbitAutoTaskAddTool,
-        McpToolScope::WorkspaceRequired,
-    );
-    registry.register_inactive(auto_task::list::OrbitAutoTaskListTool);
-    registry.register_mcp(
-        auto_task::show::OrbitAutoTaskShowTool,
-        McpToolScope::WorkspaceRequired,
-    );
-    registry.register_mcp(
-        auto_task::update::OrbitAutoTaskUpdateTool,
+        auto_task::list::OrbitAutoTaskListTool,
         McpToolScope::WorkspaceRequired,
     );
     registry.register_mcp(
-        auto_task::toggle::OrbitAutoTaskToggleTool,
+        auto_task::mint::OrbitAutoTaskMintTool,
         McpToolScope::WorkspaceRequired,
     );
+    registry.register_inactive(auto_task::show::OrbitAutoTaskShowTool);
+    registry.register_inactive(auto_task::update::OrbitAutoTaskUpdateTool);
+    registry.register_inactive(auto_task::toggle::OrbitAutoTaskToggleTool);
     registry.register_inactive(docs::OrbitDocsListTool);
     registry.register_inactive(docs::OrbitDocsShowTool);
     registry.register_inactive(docs::OrbitDocsAddTool);

--- a/crates/orbit-tools/src/lib.rs
+++ b/crates/orbit-tools/src/lib.rs
@@ -86,6 +86,7 @@ pub enum OrbitBuiltinAction {
     AdrSupersede,
     AutoTaskAdd,
     AutoTaskList,
+    AutoTaskMint,
     AutoTaskShow,
     AutoTaskUpdate,
     AutoTaskToggle,

--- a/crates/orbit-tools/tests/mcp_definitions.rs
+++ b/crates/orbit-tools/tests/mcp_definitions.rs
@@ -33,15 +33,11 @@ fn canonical_builtin_definitions_preserve_the_exact_workspace_surface() {
             .map(|definition| definition.schema.name.as_str())
             .collect::<Vec<_>>(),
         [
-            "orbit.auto_task.add",
-            "orbit.auto_task.show",
-            "orbit.auto_task.toggle",
-            "orbit.auto_task.update",
+            "orbit.auto_task.list",
+            "orbit.auto_task.mint",
             "orbit.command.exec",
             "orbit.friction.add",
             "orbit.friction.list",
-            "orbit.friction.show",
-            "orbit.friction.tags",
             "orbit.friction.update",
             "orbit.search",
             "orbit.session_log.append",

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -23,6 +23,12 @@ const RETIRED_AGENT_TOOL_NAMES: &[&str] = &[
 ];
 
 const INACTIVE_TOOL_NAMES: &[&str] = &[
+    // ORB-10798: auto-task definitions are authored by humans; the agent
+    // surface keeps only `list` and `mint`.
+    "orbit.auto_task.add",
+    "orbit.auto_task.show",
+    "orbit.auto_task.toggle",
+    "orbit.auto_task.update",
     "orbit.docs.index",
     "orbit.docs.migrate",
     "orbit.docs.add",
@@ -246,8 +252,6 @@ fn friction_surface_supports_artifact_triage() {
     for retained in [
         "orbit.friction.add",
         "orbit.friction.list",
-        "orbit.friction.show",
-        "orbit.friction.tags",
         "orbit.friction.update",
     ] {
         assert!(
@@ -263,8 +267,14 @@ fn friction_surface_supports_artifact_triage() {
         );
     }
 
-    // Destructive resolution and aggregate stats remain CLI / dashboard only.
-    for cli_only in ["orbit.friction.resolve", "orbit.friction.stats"] {
+    // Single-record reads `list` already covers, the tag taxonomy, destructive
+    // resolution, and aggregate stats remain CLI / dashboard only [ORB-10798].
+    for cli_only in [
+        "orbit.friction.show",
+        "orbit.friction.tags",
+        "orbit.friction.resolve",
+        "orbit.friction.stats",
+    ] {
         assert!(
             !active.contains(cli_only),
             "{cli_only} must stay hidden from the default registry surface"
@@ -274,6 +284,34 @@ fn friction_surface_supports_artifact_triage() {
             "{cli_only} must remain reachable via `runtime.run_tool`"
         );
     }
+}
+
+#[test]
+fn auto_task_surface_exposes_only_list_and_mint() {
+    let mut registry = ToolRegistry::new();
+    registry.register_builtins();
+    let active: BTreeSet<String> = registry
+        .schemas()
+        .into_iter()
+        .map(|schema| schema.name)
+        .collect();
+
+    let auto_task: BTreeSet<&str> = active
+        .iter()
+        .map(String::as_str)
+        .filter(|name| name.starts_with("orbit.auto_task."))
+        .collect();
+    assert_eq!(
+        auto_task,
+        BTreeSet::from(["orbit.auto_task.list", "orbit.auto_task.mint"])
+    );
+
+    let mint = registry
+        .get_schema("orbit.auto_task.mint")
+        .expect("orbit.auto_task.mint schema");
+    assert_eq!(mint.parameters.len(), 1);
+    assert_eq!(mint.parameters[0].name, "name");
+    assert!(mint.parameters[0].required);
 }
 
 #[test]

--- a/docs/design/auto-tasks/1_overview.md
+++ b/docs/design/auto-tasks/1_overview.md
@@ -75,7 +75,7 @@ becomes just the first definition.
 | Host-local cursor | `crates/orbit-core/src/auto_tasks/state.rs` | ORB-10149 |
 | Scheduler pass | `crates/orbit-core/src/auto_tasks/scheduler.rs` | ORB-10149 |
 | CRUD (CLI + MCP shared) | `crates/orbit-core/src/auto_tasks/crud.rs` | ORB-10149 |
-| Manual mint (`mint`, CLI-only) | `crates/orbit-core/src/auto_tasks/crud.rs` | ORB-10439 |
+| Manual mint (`mint`, CLI + MCP) | `crates/orbit-core/src/auto_tasks/crud.rs` | ORB-10439, ORB-10798 |
 | Deterministic action | `crates/orbit-core/src/runtime/v2_host/dispatch.rs` | ORB-10149 |
 | Seeded assets | `crates/orbit-core/assets/{activities,jobs,routines}/…` | ORB-10149 |
 | Default auto-task catalog | `crates/orbit-core/assets/auto_tasks/…` | ORB-10549, ORB-10550 |

--- a/docs/design/auto-tasks/2_design.md
+++ b/docs/design/auto-tasks/2_design.md
@@ -81,7 +81,7 @@ minutely). Because it is a routine, its fires flow to `GET /api/routines`.
 ## 5. CRUD surfaces
 
 `crud.rs` is the single choke point behind both the CLI (`orbit auto-task
-add/list/show/update/toggle`) and the MCP tools (`orbit.auto_task.*`). Add
+add/list/show/update/toggle`) and the registry tools (`orbit.auto_task.*`). Add
 rejects duplicate names; update patches present fields; toggle flips `enabled`
 (disabling is preserved, never a delete). Both surfaces validate the schedule
 (cron parse / interval > 0) and crew at write time, so a bad definition is never
@@ -145,9 +145,14 @@ scheduler pass and defers that fire, exactly as an open fired instance does. The
 cursor does not advance, so the deferred occurrence fires once when the queue
 drains. This is the behavior the hand-copy workaround could not provide.
 
-`mint` is CLI-only. Per the mcp-bridge design (`docs/design/mcp-bridge/2_design.md`,
-auto_task placement row) the auto_task MCP tools manage the Git-versioned
-definition and do not mint tasks; no MCP tool was added.
+Advertisement follows who does the work [ORB-10798]. Authoring a Git-versioned
+definition (`add`, `show`, `update`, `toggle`) is human/admin work: those tools
+are `register_inactive`, reachable through their `orbit auto-task` subcommands
+but absent from MCP `tools/list`. Reading the definitions (`list`) and minting
+one on demand (`orbit.auto_task.mint`) are what an executing agent needs, so
+both are registered at `McpToolScope::WorkspaceRequired`. The MCP tool is a thin
+adapter over the same `auto_task_mint`, so the mint stays unconditional and
+cursor-neutral on every surface.
 
 ## 6. Concerns & Honest Limitations
 


### PR DESCRIPTION
## Task

[ORB-10798](https://orbit-cli.com/tasks/ORB-10798) — Narrow the auto-task MCP surface to list+mint, drop friction show/tags

### Description

## Problem
Orbit MCP v1 now exposes one scope-only tool surface: tools are either registered for MCP with `McpToolScope::WorkspaceRequired` or kept off MCP with `register_inactive`. The current 27-tool MCP surface still advertises four auto-task mutation tools and two friction helpers that do not earn their place in the agent-facing contract, while the useful auto-task `list` and `mint` operations are absent.

## Why It Matters
The MCP surface should contain the operations agents need during execution, while human/admin authoring remains available through the CLI and the broader `orbit tool run` registry. Narrowing advertisement reduces tool-selection noise without deleting functionality or inventing a client-side authorization layer.

## Desired Surface
Change the current registrations as follows:

| Tool | Current | Intended |
|---|---|---|
| `orbit.auto_task.add` | MCP, workspace-required | inactive on MCP |
| `orbit.auto_task.show` | MCP, workspace-required | inactive on MCP |
| `orbit.auto_task.update` | MCP, workspace-required | inactive on MCP |
| `orbit.auto_task.toggle` | MCP, workspace-required | inactive on MCP |
| `orbit.auto_task.list` | inactive on MCP | MCP, workspace-required |
| `orbit.auto_task.mint` | runtime/CLI behavior exists; no registry tool | MCP, workspace-required |
| `orbit.friction.show` | MCP, workspace-required | inactive on MCP |
| `orbit.friction.tags` | MCP, workspace-required | inactive on MCP |

These are advertisement changes, not authorization rules. `McpToolScope` only describes global versus workspace-required routing; it must not grow capability, placement, owner, or client-preflight semantics.

## Existing Implementation to Reuse
`OrbitRuntime::auto_task_mint` already implements unconditional minting in `crates/orbit-core/src/auto_tasks/crud.rs`, with focused coverage in `crates/orbit-core/src/auto_tasks/tests/mint.rs`. Preserve that behavior exactly: schedule due-math, `dedupe`, and `enabled` remain ignored, and the host-local auto-task cursor remains untouched.

The missing work is a thin tool adapter:
- add the builtin action and schema under `crates/orbit-tools/src/builtin/orbit/auto_task/`;
- register it with `McpToolScope::WorkspaceRequired`;
- dispatch it through the existing Core Orbit tool host;
- update the exact MCP and broad tool-list snapshots.

Friction exposure is owned by `mcp_scope: Option<McpToolScope>` in `crates/orbit-common/src/friction/operations.rs`; set `show` and `tags` to `None`.

## Constraints / Notes
- Do not reintroduce `McpToolPolicy`, placement matrices, capability-filtered advertisement, owner routing, or `orbit-remote`.
- `register_inactive` tools remain available through the CLI and `orbit tool run`.
- Keep every MCP call on the existing orbit-mcp -> accepting CLI host -> Core execution/audit path.
- Update live documentation only if it explicitly enumerates this surface. Do not create, consult, or update ADRs.
- Review generated snapshots rather than accepting unrelated surface drift.

### Acceptance Criteria

- `orbit.auto_task.add`, `.show`, `.update`, and `.toggle` use `register_inactive`; they are absent from MCP `tools/list` and remain reachable through the CLI and `orbit tool run`.
- `orbit.auto_task.list` is MCP-registered with `McpToolScope::WorkspaceRequired`.
- A new `orbit.auto_task.mint` tool is MCP-registered with `McpToolScope::WorkspaceRequired`, delegates to the existing `OrbitRuntime::auto_task_mint`, and preserves its unconditional, cursor-neutral behavior.
- `orbit.friction.show` and `orbit.friction.tags` have `mcp_scope: None`; they are absent from MCP `tools/list` while their CLI commands still work.
- No MCP capability, placement, owner-routing, or client-preflight metadata is introduced.
- The MCP production snapshot contains exactly 23 tools: the intended six removals and two additions produce no unrelated wire drift.
- The broad `orbit tool list` fixtures retain inactive tools and include `orbit.auto_task.mint`.
- Focused orbit-tools surface tests, friction derived-schema tests, Core auto-task dispatch tests, orbit-mcp tests, and orbit-cli MCP roundtrip tests pass.
- `make ci-fast`, affected-crate clippy with the repository lint policy, and `git diff --check` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Narrowed the MCP auto-task surface to list+mint and dropped friction show/tags [ORB-10798].

Registration changes (advertisement only; no capability, placement, owner-routing, or client-preflight metadata introduced):
- crates/orbit-tools/src/builtin/orbit/mod.rs: `orbit.auto_task.add/.show/.update/.toggle` now use `register_inactive`; `orbit.auto_task.list` and the new `orbit.auto_task.mint` register at `McpToolScope::WorkspaceRequired`.
- crates/orbit-common/src/friction/operations.rs: SHOW and TAGS set `mcp_scope: None` (the derived registration path already maps None -> register_inactive).

New mint tool (thin adapter, no new behavior):
- crates/orbit-tools/src/builtin/orbit/auto_task/mint.rs: `OrbitAutoTaskMintTool`, one required `name` param.
- crates/orbit-tools/src/lib.rs: `OrbitBuiltinAction::AutoTaskMint`.
- crates/orbit-core/src/runtime/orbit_tool_host/{auto_task_tools.rs,dispatch.rs}: `mint` reads `name` and delegates to the existing `OrbitRuntime::auto_task_mint`, returning the same full task projection (`serialize_task`) the CLI subcommand renders. Schedule due-math, `dedupe`, and `enabled` stay ignored and the host-local cursor is untouched - a new dispatch test asserts the cursor file is never written and that a disabled definition still mints.

Wire surface: the MCP production snapshot moved 27 -> 23 tools. The only diff is the six intended removals (orbit_auto_task_add/show/toggle/update, orbit_friction_show/tags) and the two additions (orbit_auto_task_list, orbit_auto_task_mint); no unrelated schema drift. crates/orbit-mcp/src/remote/tests/discovery.rs frozen count updated 27 -> 23.

Tests: new crates/orbit-core/src/runtime/orbit_tool_host/tests/auto_task_tools.rs (list/mint dispatch, cursor neutrality, missing/unknown name); new `auto_task_surface_exposes_only_list_and_mint` in the orbit-tools surface test; the four auto-task authoring tools added to the inactive-name lists in public_tool_surface.rs and tool_list.rs; friction show/tags moved from the active-surface assertion to the CLI-only assertion; mcp_definitions.rs, derived_schema.rs, and orbit-common/src/friction/tests.rs updated to the new exposure.

Files touched beyond the listed context, and why: tests/task_tools.rs (its friction show read now goes through `run_tool`, the same ungated CLI/dashboard path `orbit friction show` uses, because `execute_tool_command` gates on `ensure_tool_agent_facing`); tests/mod.rs plus the new sibling test file; orbit-mcp/src/remote/tests/discovery.rs (frozen production count); docs/design/auto-tasks/1_overview.md and 2_design.md (both explicitly enumerated this surface - the design doc still claimed "mint is CLI-only ... no MCP tool was added" and cited an mcp-bridge placement row that no longer exists).

Reachability note, correcting one clause of the acceptance criteria: register_inactive tools stay reachable through their dedicated CLI subcommands (`orbit auto-task add/show/update/toggle`, `orbit friction show/tags` - the derived friction CLI dispatches via the ungated runtime.run_tool) and via runtime.run_tool, but `orbit tool run` deliberately refuses them through the pre-existing ensure_tool_agent_facing gate, exactly as it already does for orbit.friction.stats and orbit.task.delete. Existing designed behavior, not a regression; smoke-verified end to end against the built binary.

Validation: cargo test -p orbit-tools -p orbit-common, -p orbit-mcp, -p orbit-cli (mcp_roundtrip, tool_list, output_goldens, docs, task_trimmed_surface, table_rendering), and -p orbit-core --lib (741 pass) all green. MCP snapshot and CLI output goldens regenerated with their documented env vars and diffs reviewed line by line. `git diff --check` clean; all 15 ci-fast guardrail scripts pass; clippy over orbit-tools/orbit-common/orbit-core/orbit-mcp/orbit-cli --all-targets is clean for every file this task touched.

Pre-existing failures at this base, untouched and unrelated (two from commit 60a91aa5 [ORB-10812], one workspace-state file):
1. `cargo fmt --all --check` fails only in crates/orbit-common/src/utility/tests/selector.rs (import ordering + assert! wrapping), so `make ci-fast` exits non-zero on its first step.
2. `cargo clippy -p orbit-common` warns clippy::while_let_loop at crates/orbit-common/src/utility/selector.rs:546, which `make ci-lint` would deny.
3. orbit-core test command::routine::tests::dogfood_task_pilot_routine_matches_the_rendered_default_template fails because the checked-in .orbit/routines/task_pilot.yaml has `enabled: true` while the seeded asset renders `enabled: false`.
Left alone rather than mixing unrelated fixes into this diff.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10798-6a80a201`
- Behind base: 0
- Ahead of base: 1