### PR TITLE
Recover session logs from an interrupted final JSONL append

### DIFF
--- a/crates/orbit-store/src/file/session_log_store/persistence.rs
+++ b/crates/orbit-store/src/file/session_log_store/persistence.rs
@@ -1,7 +1,11 @@
 //! Locked JSONL persistence for [`super::SessionLogStore`].
+//!
+//! Every read and mutation holds `.session-log.jsonl.lock`. While that lock is
+//! held, a malformed unterminated final row is truncated so a torn append cannot
+//! wedge later list/resolve/append. Newline-terminated corrupt rows still fail.
 
 use std::fs::{self, OpenOptions};
-use std::io::{BufRead, BufReader, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use chrono::Utc;
@@ -144,25 +148,115 @@ fn read_entries(path: &Path) -> Result<Vec<SessionLogEntry>, OrbitError> {
     if !path.exists() {
         return Ok(Vec::new());
     }
-    let file = fs::File::open(path)
+    let raw = fs::read(path)
         .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
+    let scan = scan_entries(path, &raw)?;
+    persist_scan_repair(path, raw.len(), &scan)?;
+    Ok(scan.entries)
+}
+
+struct SessionLogScan {
+    entries: Vec<SessionLogEntry>,
+    truncate_at: usize,
+    missing_newline: bool,
+}
+
+fn scan_entries(path: &Path, raw: &[u8]) -> Result<SessionLogScan, OrbitError> {
     let mut entries = Vec::new();
-    for (line_number, line) in BufReader::new(file).lines().enumerate() {
-        let line =
-            line.map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
-        if line.trim().is_empty() {
-            continue;
+    let mut last_good = 0usize;
+    let mut offset = 0usize;
+    for (line_number, chunk) in raw.split_inclusive(|byte| *byte == b'\n').enumerate() {
+        let next_offset = offset + chunk.len();
+        let terminated = chunk.ends_with(b"\n");
+        let line_bytes = trim_jsonl_terminator(chunk);
+        if line_bytes.iter().all(u8::is_ascii_whitespace) {
+            if terminated {
+                last_good = next_offset;
+                offset = next_offset;
+                continue;
+            }
+            return Ok(recovered_scan(entries, last_good));
         }
-        let entry = serde_json::from_str(&line).map_err(|error| {
-            OrbitError::Execution(format!(
-                "parse {} line {}: {error}",
-                path.display(),
-                line_number + 1
-            ))
-        })?;
-        entries.push(entry);
+
+        let line = match std::str::from_utf8(line_bytes) {
+            Ok(line) => line,
+            Err(_) if !terminated => return Ok(recovered_scan(entries, last_good)),
+            Err(error) => return Err(parse_error(path, line_number + 1, error)),
+        };
+
+        match serde_json::from_str::<SessionLogEntry>(line) {
+            Ok(entry) => {
+                entries.push(entry);
+                last_good = next_offset;
+                offset = next_offset;
+            }
+            Err(_) if !terminated => return Ok(recovered_scan(entries, last_good)),
+            Err(error) => return Err(parse_error(path, line_number + 1, error)),
+        }
     }
-    Ok(entries)
+
+    Ok(SessionLogScan {
+        entries,
+        truncate_at: last_good,
+        missing_newline: !raw.is_empty() && !raw.ends_with(b"\n"),
+    })
+}
+
+fn recovered_scan(entries: Vec<SessionLogEntry>, truncate_at: usize) -> SessionLogScan {
+    SessionLogScan {
+        entries,
+        truncate_at,
+        missing_newline: false,
+    }
+}
+
+fn trim_jsonl_terminator(chunk: &[u8]) -> &[u8] {
+    let without_lf = chunk.strip_suffix(b"\n").unwrap_or(chunk);
+    without_lf.strip_suffix(b"\r").unwrap_or(without_lf)
+}
+
+fn parse_error(path: &Path, line_number: usize, error: impl std::fmt::Display) -> OrbitError {
+    OrbitError::Execution(format!(
+        "parse {} line {}: {error}",
+        path.display(),
+        line_number
+    ))
+}
+
+fn persist_scan_repair(
+    path: &Path,
+    raw_len: usize,
+    scan: &SessionLogScan,
+) -> Result<(), OrbitError> {
+    if scan.truncate_at < raw_len {
+        truncate_log(path, scan.truncate_at)
+    } else if scan.missing_newline {
+        append_trailing_newline(path)
+    } else {
+        Ok(())
+    }
+}
+
+fn truncate_log(path: &Path, truncate_at: usize) -> Result<(), OrbitError> {
+    let file = OpenOptions::new()
+        .write(true)
+        .open(path)
+        .map_err(|error| OrbitError::Io(format!("open {}: {error}", path.display())))?;
+    file.set_len(truncate_at as u64)
+        .map_err(|error| OrbitError::Io(format!("truncate {}: {error}", path.display())))?;
+    file.sync_all()
+        .map_err(|error| OrbitError::Io(format!("sync {}: {error}", path.display())))
+}
+
+fn append_trailing_newline(path: &Path) -> Result<(), OrbitError> {
+    let mut file = OpenOptions::new()
+        .append(true)
+        .open(path)
+        .map_err(|error| OrbitError::Io(format!("open {}: {error}", path.display())))?;
+    file.write_all(b"\n")
+        .map_err(|error| OrbitError::Io(format!("append {}: {error}", path.display())))?;
+    file.sync_data()
+        .map_err(|error| OrbitError::Io(format!("sync {}: {error}", path.display())))
 }
 
 fn replace_entries(path: &Path, entries: &[SessionLogEntry]) -> Result<(), OrbitError> {

--- a/crates/orbit-store/src/file/session_log_store/tests/persistence.rs
+++ b/crates/orbit-store/src/file/session_log_store/tests/persistence.rs
@@ -1,11 +1,22 @@
 //! Persistence behavior and concurrency coverage.
 
 use std::collections::BTreeSet;
-use std::sync::{Arc, Barrier};
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Barrier, mpsc};
+use std::thread;
+use std::time::Duration;
 
 use tempfile::tempdir;
 
+use crate::file_lock::acquire_exclusive;
+
 use super::super::{SessionLogAppendParams, SessionLogFilter, SessionLogKind, SessionLogStore};
+
+const LOG_FILE_NAME: &str = "session-log.jsonl";
+const LOCK_FILE_NAME: &str = ".session-log.jsonl.lock";
 
 fn append_params(kind: SessionLogKind, body: impl Into<String>) -> SessionLogAppendParams {
     SessionLogAppendParams {
@@ -190,4 +201,165 @@ fn concurrent_append_and_resolve_preserve_every_record_and_resolution() {
             .expect("seed record preserved");
         assert!(entry.resolved_at.is_some(), "{id} was not resolved");
     }
+}
+
+#[test]
+fn recovers_unterminated_final_fragment_without_losing_valid_records() {
+    let root = tempdir().expect("tempdir");
+    let orbit_dir = root.path().join(".orbit");
+    let store = SessionLogStore::new(&orbit_dir);
+
+    store
+        .append(append_params(SessionLogKind::Status, "first complete row"))
+        .expect("status");
+    store
+        .append(append_params(
+            SessionLogKind::CheckLater,
+            "revisit after torn append",
+        ))
+        .expect("check_later");
+
+    append_raw_bytes(
+        &orbit_dir.join(LOG_FILE_NAME),
+        br#"{"id":"SL-0003","at":"2026-08-15T18:00:00Z","kind":"note","body":"torn"#,
+    );
+
+    let recovered = store
+        .list(SessionLogFilter::default())
+        .expect("list after torn tail");
+    assert_eq!(
+        recovered
+            .iter()
+            .map(|entry| entry.id.as_str())
+            .collect::<Vec<_>>(),
+        ["SL-0001", "SL-0002"]
+    );
+
+    let raw = fs::read_to_string(orbit_dir.join(LOG_FILE_NAME)).expect("read repaired log");
+    assert!(
+        raw.ends_with('\n'),
+        "recovery must leave a record-boundary newline"
+    );
+    assert!(
+        !raw.contains(r#""id":"SL-0003""#),
+        "malformed tail must be truncated, not rewritten in place: {raw}"
+    );
+
+    let next = store
+        .append(append_params(SessionLogKind::Note, "after recovery"))
+        .expect("append after recovery");
+    assert_eq!(next.id, "SL-0003");
+
+    let resolved = store.resolve("SL-0002").expect("resolve after recovery");
+    assert!(resolved.resolved_at.is_some());
+
+    let listed = store
+        .list(SessionLogFilter::default())
+        .expect("list after append and resolve");
+    assert_eq!(
+        listed
+            .iter()
+            .map(|entry| entry.id.as_str())
+            .collect::<Vec<_>>(),
+        ["SL-0001", "SL-0002", "SL-0003"]
+    );
+    let resolved_row = listed
+        .iter()
+        .find(|entry| entry.id == "SL-0002")
+        .expect("resolved row present");
+    assert!(resolved_row.resolved_at.is_some());
+    assert_eq!(listed[2].body, "after recovery");
+}
+
+#[test]
+fn malformed_newline_terminated_rows_still_fail_to_parse() {
+    let root = tempdir().expect("tempdir");
+    let orbit_dir = root.path().join(".orbit");
+    let store = SessionLogStore::new(&orbit_dir);
+    store
+        .append(append_params(SessionLogKind::Note, "kept prefix"))
+        .expect("seed");
+    let prefix = fs::read_to_string(orbit_dir.join(LOG_FILE_NAME)).expect("read prefix");
+
+    fs::write(orbit_dir.join(LOG_FILE_NAME), format!("{prefix}not-json\n"))
+        .expect("write terminated junk tail");
+    let terminated_tail = store
+        .list(SessionLogFilter::default())
+        .expect_err("terminated junk must not be discarded");
+    assert!(
+        terminated_tail.to_string().contains("parse"),
+        "expected parse error, got {terminated_tail}"
+    );
+    assert_eq!(
+        fs::read_to_string(orbit_dir.join(LOG_FILE_NAME)).expect("reread terminated junk"),
+        format!("{prefix}not-json\n"),
+        "failed parse must not rewrite the log"
+    );
+
+    fs::write(
+        orbit_dir.join(LOG_FILE_NAME),
+        format!("{prefix}not-json\n{prefix}"),
+    )
+    .expect("write malformed middle");
+    let malformed_middle = store
+        .list(SessionLogFilter::default())
+        .expect_err("middle junk must not be discarded");
+    assert!(
+        malformed_middle.to_string().contains("parse"),
+        "expected parse error, got {malformed_middle}"
+    );
+}
+
+#[test]
+fn recovery_waits_for_existing_session_log_lock() {
+    let root = tempdir().expect("tempdir");
+    let orbit_dir = root.path().join(".orbit");
+    let store = SessionLogStore::new(&orbit_dir);
+    store
+        .append(append_params(SessionLogKind::Note, "lock coverage"))
+        .expect("seed");
+    append_raw_bytes(&orbit_dir.join(LOG_FILE_NAME), b"{\"id\":\"SL-");
+
+    let _guard = acquire_exclusive(&orbit_dir.join(LOCK_FILE_NAME), "session-log test hold")
+        .expect("hold lock");
+    let started = Arc::new(AtomicBool::new(false));
+    let started_for_thread = Arc::clone(&started);
+    let (tx, rx) = mpsc::channel();
+    let recover_orbit_dir = orbit_dir.clone();
+    let handle = thread::spawn(move || {
+        started_for_thread.store(true, Ordering::SeqCst);
+        let store = SessionLogStore::new(recover_orbit_dir);
+        let result = store.list(SessionLogFilter::default());
+        tx.send(()).expect("signal completion");
+        result
+    });
+
+    while !started.load(Ordering::SeqCst) {
+        thread::yield_now();
+    }
+    thread::sleep(Duration::from_millis(80));
+    assert!(
+        rx.try_recv().is_err(),
+        "list/recovery must block on the existing session-log lock"
+    );
+    drop(_guard);
+
+    rx.recv_timeout(Duration::from_secs(2))
+        .expect("list should finish after lock release");
+    let recovered = handle
+        .join()
+        .expect("recover thread")
+        .expect("recovered list");
+    assert_eq!(recovered.len(), 1);
+    assert_eq!(recovered[0].id, "SL-0001");
+}
+
+fn append_raw_bytes(path: &Path, bytes: &[u8]) {
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .expect("open log for raw append");
+    file.write_all(bytes).expect("write raw tail");
+    file.flush().expect("flush raw tail");
 }


### PR DESCRIPTION
## Task

[ORB-10807](https://orbit-cli.com/tasks/ORB-10807) — Recover session logs from an interrupted final JSONL append

### Description

## Problem
`SessionLogStore` serializes concurrent append, list, and resolve operations with a sidecar lock, but an interrupted or space-exhausted append can leave a partial final JSONL row. The strict reader then rejects the file, wedging every later operation.

## Why It Matters
A single torn tail should not make an otherwise valid append-only operational log permanently unusable.

## Constraints / Notes
- Perform detection and recovery while holding the existing session-log lock.
- Preserve every complete valid row.
- Recover only a malformed, unterminated final row; malformed earlier rows or malformed newline-terminated rows must still fail clearly.
- Keep ID allocation monotonic and collision-free after recovery.
- Use the established file durability helpers and avoid duplicating generic Store file primitives.

### Acceptance Criteria

- A deterministic regression test writes valid records followed by a partial final JSON fragment and proves the store can recover without losing valid records.
- After recovery, append allocates the correct next `SL-*` ID and the new entry can be listed and resolved normally.
- Malformed non-tail data and malformed newline-terminated records still return a clear parse error instead of being silently discarded.
- Recovery and all related reads/writes occur under the existing `.session-log.jsonl.lock` discipline.
- `cargo test -p orbit-store session_log` and relevant orbit-core session-log tests pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Outcome: success

## Changes
- `read_entries` now scans the session log as bytes under the existing `.session-log.jsonl.lock` and persists a tail repair before returning.
- A malformed unterminated final fragment is truncated (`set_len` + `sync_all`) so valid prefix rows survive; a valid unterminated final row is kept and given a trailing newline so a later append cannot concatenate onto it.
- Newline-terminated corrupt rows, including a junk last line, still return `OrbitError::Execution` (`parse <path> line N`) and are not rewritten.
- Added regression coverage: torn-tail recovery + next `SL-*` allocation + resolve, rejected terminated/middle junk, and recovery blocking behind the sidecar lock.

## Assessment
Acceptance criteria are met in `orbit-store` persistence tests. Recovery is confined to the already-locked read path; no new crate edges or generic Store JSONL primitive.

## Strategic decisions
- Did not reuse `task_store` `scan_jsonl_tail`: that helper also discards a malformed *newline-terminated* last row, which this task forbids.
- Did not lift a shared JSONL scanner: the recovery rule is session-log specific and well under the shared-helper threshold.

## Validation
- `cargo test -p orbit-store session_log` — 6 passed
- `cargo test -p orbit-core session_log` — 1 passed
- `cargo clippy -p orbit-store --all-targets -- -D warnings` — passed
- `make ci-fast` — passed

## Deviations from original plan
None.

## Recommended follow-ups
None.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10807-6a80b2af`
- Behind base: 0
- Ahead of base: 1

*authored by: grok*