### PR TITLE
Give an epic run one worktree and land its children into it sequentially

### DIFF
--- a/.orbit/resources/jobs/epic_pipeline.yaml
+++ b/.orbit/resources/jobs/epic_pipeline.yaml
@@ -1,11 +1,9 @@
-# Workspace drain [ORB-10779].
+# Epic branch assembly [ORB-10816].
 #
-# Loop a deterministic unresolved-work scan and a no-code-change
-# orchestrator until the scan is empty. First-scan empty is a successful
-# no-op (zero orchestrator invokes). A leftover scan after
-# `max_iterations` fails closed via `fail_if_nonempty`.
-#
-# The fire clock is external (ADR-0362). Do not seed a routine.
+# One epic owns one stable worktree and branch. Its unfinished descendants are
+# ordered once, then landed into that branch through serial local pipelines.
+# The epic root remains in-progress; later stages finish and deliver the
+# assembled branch.
 
 schemaVersion: 2
 kind: Job
@@ -15,26 +13,59 @@ spec:
   state: enabled
   kind: workflow
   max_active_runs: 1
+  default_input:
+    epic_task_id: ""
 
   steps:
+    - id: resolve_ship_input
+      target: activity:resolve_workspace_ship_input
+      default_input: {}
+
+    - id: worktree
+      target: activity:worktree_setup
+      retry:
+        max_attempts: 4
+        initial_backoff_ms: 200
+        backoff_cap_ms: 2000
+        backoff_strategy: exponential
+      default_input:
+        task_ids:
+          - "{{ input.epic_task_id }}"
+        run_id: "epic-{{ input.epic_task_id }}"
+        branch_prefix: epic
+        base: "{{ steps.resolve_ship_input.output.base_branch }}"
+        base_sync: remote
+
+    - id: descendants
+      spec:
+        type: deterministic
+        action: list_epic_descendants
+        config: {}
+      default_input:
+        epic_task_id: "{{ input.epic_task_id }}"
+
     - id: drain
       loop:
-        max_iterations: 8
-        break_when: "{{ steps.scan.output.empty }} == true"
+        items: "{{ steps.descendants.output.task_ids }}"
+        max_iterations: 256
         steps:
-          - id: scan
-            target: activity:scan_unresolved_work
-            default_input: {}
-
-          - id: orchestrate
-            when: "{{ steps.scan.output.empty }} == false"
-            target: activity:epic_orchestrator
+          - id: land_child
+            target: activity:invoke_and_wait
             timeout_seconds: 7200
             default_input:
-              scan: "{{ steps.scan.output }}"
-              system_crew: true
+              job_name: task_local_pipeline
+              run_input:
+                task_ids:
+                  - "{{ item }}"
+                base_branch: "{{ steps.worktree.output.head_ref }}"
+                base_sync: local
+                auto_push: false
+                landing_branch: "{{ steps.resolve_ship_input.output.base_branch }}"
+                terminal_status: done
+              timeout_seconds: 7200
 
-    - id: require_empty
-      target: activity:scan_unresolved_work
-      default_input:
-        fail_if_nonempty: true
+          - id: require_child_success
+            target: activity:pipeline_success_guard
+            default_input:
+              context: epic child local pipeline
+              result: "{{ steps.land_child.output }}"

--- a/.orbit/resources/jobs/task_local_pipeline.yaml
+++ b/.orbit/resources/jobs/task_local_pipeline.yaml
@@ -4,7 +4,7 @@
 # - `implement_bundle` runs one task at a time in the shared worktree.
 # - If `implement_one` fails, pending changes remain in the shared worktree for inspection.
 # - If all implementations succeed, `commit` snapshots the bundle branch before merge.
-# - Tasks move to `review` only after the full bundle commits and merges cleanly.
+# - Tasks move to `terminal_status` only after the full bundle commits and merges cleanly.
 #
 schemaVersion: 2
 kind: Job
@@ -19,6 +19,8 @@ spec:
     auto_push: false
     base_branch: main
     base_sync: remote
+    landing_branch: ""
+    terminal_status: review
   
   steps:
     - id: worktree
@@ -79,7 +81,7 @@ spec:
             target: activity:update_task
             default_input:
               task_id: "{{ item }}"
-              status: review
+              status: "{{ input.terminal_status }}"
 
     - id: push
       when: "{{ input.auto_push }} == true"

--- a/crates/orbit-common/src/types/activity_job/mod.rs
+++ b/crates/orbit-common/src/types/activity_job/mod.rs
@@ -24,6 +24,7 @@ macro_rules! deterministic_action_catalog {
                 GateStarvationFail => "gate_starvation_fail",
                 InvokeAndWait => "invoke_and_wait",
                 ListBacklogTasks => "list_backlog_tasks",
+                ListEpicDescendants => "list_epic_descendants",
                 ListTriageCandidates => "list_triage_candidates",
                 OrbitToolCall => "orbit_tool_call",
                 PipelineSuccessGuard => "pipeline_success_guard",

--- a/crates/orbit-core/assets/jobs/epic_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/epic_pipeline.yaml
@@ -1,11 +1,9 @@
-# Workspace drain [ORB-10779].
+# Epic branch assembly [ORB-10816].
 #
-# Loop a deterministic unresolved-work scan and a no-code-change
-# orchestrator until the scan is empty. First-scan empty is a successful
-# no-op (zero orchestrator invokes). A leftover scan after
-# `max_iterations` fails closed via `fail_if_nonempty`.
-#
-# The fire clock is external (ADR-0362). Do not seed a routine.
+# One epic owns one stable worktree and branch. Its unfinished descendants are
+# ordered once, then landed into that branch through serial local pipelines.
+# The epic root remains in-progress; later stages finish and deliver the
+# assembled branch.
 
 schemaVersion: 2
 kind: Job
@@ -15,26 +13,59 @@ spec:
   state: enabled
   kind: workflow
   max_active_runs: 1
+  default_input:
+    epic_task_id: ""
 
   steps:
+    - id: resolve_ship_input
+      target: activity:resolve_workspace_ship_input
+      default_input: {}
+
+    - id: worktree
+      target: activity:worktree_setup
+      retry:
+        max_attempts: 4
+        initial_backoff_ms: 200
+        backoff_cap_ms: 2000
+        backoff_strategy: exponential
+      default_input:
+        task_ids:
+          - "{{ input.epic_task_id }}"
+        run_id: "epic-{{ input.epic_task_id }}"
+        branch_prefix: epic
+        base: "{{ steps.resolve_ship_input.output.base_branch }}"
+        base_sync: remote
+
+    - id: descendants
+      spec:
+        type: deterministic
+        action: list_epic_descendants
+        config: {}
+      default_input:
+        epic_task_id: "{{ input.epic_task_id }}"
+
     - id: drain
       loop:
-        max_iterations: 8
-        break_when: "{{ steps.scan.output.empty }} == true"
+        items: "{{ steps.descendants.output.task_ids }}"
+        max_iterations: 256
         steps:
-          - id: scan
-            target: activity:scan_unresolved_work
-            default_input: {}
-
-          - id: orchestrate
-            when: "{{ steps.scan.output.empty }} == false"
-            target: activity:epic_orchestrator
+          - id: land_child
+            target: activity:invoke_and_wait
             timeout_seconds: 7200
             default_input:
-              scan: "{{ steps.scan.output }}"
-              system_crew: true
+              job_name: task_local_pipeline
+              run_input:
+                task_ids:
+                  - "{{ item }}"
+                base_branch: "{{ steps.worktree.output.head_ref }}"
+                base_sync: local
+                auto_push: false
+                landing_branch: "{{ steps.resolve_ship_input.output.base_branch }}"
+                terminal_status: done
+              timeout_seconds: 7200
 
-    - id: require_empty
-      target: activity:scan_unresolved_work
-      default_input:
-        fail_if_nonempty: true
+          - id: require_child_success
+            target: activity:pipeline_success_guard
+            default_input:
+              context: epic child local pipeline
+              result: "{{ steps.land_child.output }}"

--- a/crates/orbit-core/assets/jobs/task_local_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_local_pipeline.yaml
@@ -4,7 +4,7 @@
 # - `implement_bundle` runs one task at a time in the shared worktree.
 # - If `implement_one` fails, pending changes remain in the shared worktree for inspection.
 # - If all implementations succeed, `commit` snapshots the bundle branch before merge.
-# - Tasks move to `review` only after the full bundle commits and merges cleanly.
+# - Tasks move to `terminal_status` only after the full bundle commits and merges cleanly.
 #
 schemaVersion: 2
 kind: Job
@@ -19,6 +19,8 @@ spec:
     auto_push: false
     base_branch: main
     base_sync: remote
+    landing_branch: ""
+    terminal_status: review
   
   steps:
     - id: worktree
@@ -79,7 +81,7 @@ spec:
             target: activity:update_task
             default_input:
               task_id: "{{ item }}"
-              status: review
+              status: "{{ input.terminal_status }}"
 
     - id: push
       when: "{{ input.auto_push }} == true"

--- a/crates/orbit-core/src/command/job/tests/catalog.rs
+++ b/crates/orbit-core/src/command/job/tests/catalog.rs
@@ -383,6 +383,11 @@ fn local_task_pipeline_commits_before_merge_and_reconciles_with_local_base() {
         .iter()
         .find_map(|(name, yaml)| (*name == "task_local_pipeline").then_some(*yaml))
         .expect("task local pipeline default exists");
+    assert_eq!(
+        yaml,
+        include_str!("../../../../../../.orbit/resources/jobs/task_local_pipeline.yaml"),
+        "shipped and workspace task_local_pipeline resources must remain byte-identical"
+    );
     let asset = load_job_asset(yaml).expect("parse task local pipeline");
     let root_step_ids = asset
         .spec
@@ -417,6 +422,27 @@ fn local_task_pipeline_commits_before_merge_and_reconciles_with_local_base() {
     assert_eq!(
         merge_input["base_sync"], "local",
         "an unpublished earlier merge must be a valid base for the next local merge"
+    );
+
+    assert_eq!(
+        asset.spec.default_input.as_ref().unwrap()["terminal_status"],
+        "review"
+    );
+    let mark_review = asset
+        .spec
+        .steps
+        .iter()
+        .find(|step| step.id == "mark_review")
+        .expect("task local pipeline has terminal task update loop");
+    let JobV2StepBody::Loop { loop_ } = &mark_review.body else {
+        panic!("task local terminal update must be a loop");
+    };
+    let JobV2StepBody::TargetRef(update) = &loop_.steps[0].body else {
+        panic!("task local terminal update must reference update_task");
+    };
+    assert_eq!(
+        update.default_input.as_ref().unwrap()["status"],
+        "{{ input.terminal_status }}"
     );
 }
 
@@ -562,6 +588,11 @@ fn gate_pipeline_releases_reservation_before_child_success_guard() {
         .iter()
         .find_map(|(name, yaml)| (*name == "task_gate_pipeline").then_some(*yaml))
         .expect("task gate pipeline default exists");
+    assert_eq!(
+        yaml,
+        include_str!("../../../../../../.orbit/resources/jobs/task_gate_pipeline.yaml"),
+        "shipped and workspace task_gate_pipeline resources must remain byte-identical"
+    );
     let asset = load_job_asset(yaml).expect("parse task gate pipeline");
     let root_step_ids = asset
         .spec
@@ -1014,7 +1045,7 @@ fn orchestration_jobs_do_not_enable_generic_recovery() {
 }
 
 #[test]
-fn epic_pipeline_loops_scan_then_fail_closes_on_leftover_work() {
+fn epic_pipeline_opens_one_stable_worktree_and_drains_children_serially() {
     let yaml = DEFAULT_JOB_FILES
         .iter()
         .find_map(|(name, yaml)| (*name == "epic_pipeline").then_some(*yaml))
@@ -1024,44 +1055,52 @@ fn epic_pipeline_loops_scan_then_fail_closes_on_leftover_work() {
         include_str!("../../../../../../.orbit/resources/jobs/epic_pipeline.yaml"),
         "shipped and workspace epic_pipeline resources must remain byte-identical"
     );
-    assert!(!yaml.contains("routines/"));
-    assert!(!yaml.contains("session:"));
     let asset = load_job_asset(yaml).expect("epic pipeline parses");
     assert_eq!(asset.spec.max_active_runs, 1);
-    assert_eq!(asset.spec.steps.len(), 2);
+    assert_eq!(asset.spec.steps.len(), 4);
 
-    let JobV2StepBody::Loop { loop_ } = &asset.spec.steps[0].body else {
-        panic!("epic pipeline must loop the drain");
+    let JobV2StepBody::TargetRef(worktree) = &asset.spec.steps[1].body else {
+        panic!("epic pipeline must set up its worktree before draining children");
     };
-    assert_eq!(loop_.max_iterations, 8);
+    assert_eq!(worktree.target, "activity:worktree_setup");
+    let worktree_input = worktree.default_input.as_ref().expect("worktree input");
+    assert_eq!(worktree_input["run_id"], "epic-{{ input.epic_task_id }}");
+    assert_eq!(worktree_input["branch_prefix"], "epic");
+    assert_eq!(worktree_input["base_sync"], "remote");
+
+    let JobV2StepBody::Target(descendants) = &asset.spec.steps[2].body else {
+        panic!("epic pipeline must list descendants deterministically");
+    };
+    let ActivityV2Spec::Deterministic(descendants) = &descendants.spec else {
+        panic!("epic descendant listing must be deterministic");
+    };
+    assert_eq!(descendants.action, "list_epic_descendants");
+
+    let JobV2StepBody::Loop { loop_ } = &asset.spec.steps[3].body else {
+        panic!("epic pipeline must drain descendants through a sequential loop");
+    };
     assert_eq!(
-        loop_.break_when.as_deref(),
-        Some("{{ steps.scan.output.empty }} == true")
+        loop_.items.as_deref(),
+        Some("{{ steps.descendants.output.task_ids }}")
     );
+    assert_eq!(loop_.max_iterations, 256);
     assert_eq!(loop_.steps.len(), 2);
-    let JobV2StepBody::TargetRef(scan) = &loop_.steps[0].body else {
-        panic!("first loop body must scan");
+    let JobV2StepBody::TargetRef(land_child) = &loop_.steps[0].body else {
+        panic!("first loop body must invoke one child pipeline");
     };
-    assert_eq!(scan.target, "activity:scan_unresolved_work");
-    let JobV2StepBody::TargetRef(orchestrate) = &loop_.steps[1].body else {
-        panic!("second loop body must invoke the orchestrator");
-    };
-    assert_eq!(orchestrate.target, "activity:epic_orchestrator");
+    assert_eq!(land_child.target, "activity:invoke_and_wait");
+    let child_input = &land_child.default_input.as_ref().expect("child input")["run_input"];
     assert_eq!(
-        loop_.steps[1].when.as_deref(),
-        Some("{{ steps.scan.output.empty }} == false")
+        child_input["base_branch"],
+        "{{ steps.worktree.output.head_ref }}"
     );
-    assert_eq!(orchestrate.timeout_seconds, 7200);
-
-    let JobV2StepBody::TargetRef(require_empty) = &asset.spec.steps[1].body else {
-        panic!("post-loop step must re-scan fail-closed");
-    };
-    assert_eq!(require_empty.target, "activity:scan_unresolved_work");
-    let require_input = require_empty
-        .default_input
-        .as_ref()
-        .expect("require_empty input");
-    assert_eq!(require_input["fail_if_nonempty"], json!(true));
+    assert_eq!(child_input["base_sync"], "local");
+    assert_eq!(child_input["auto_push"], false);
+    assert_eq!(child_input["terminal_status"], "done");
+    assert_eq!(
+        child_input["landing_branch"],
+        "{{ steps.resolve_ship_input.output.base_branch }}"
+    );
 }
 
 fn collect_agent_loop_step_ids<'a>(

--- a/crates/orbit-core/src/command/job/tests/exec.rs
+++ b/crates/orbit-core/src/command/job/tests/exec.rs
@@ -5,7 +5,8 @@ use std::sync::{Arc, Mutex};
 
 use chrono::Utc;
 use orbit_common::types::{
-    AuditEventStatus, ExecutorDef, ExecutorType, JobRunState, TaskPriority, TaskStatus, TaskType,
+    AuditEventStatus, ExecutorDef, ExecutorType, JobRunState, JobV2StepBody, TaskPriority,
+    TaskStatus, TaskType,
 };
 use orbit_engine::{
     DispatchError, JobOutcome, ResolvedCliExecutor, RuntimeHost, V2AuditWriter,
@@ -139,6 +140,51 @@ fn try_execute_named_job(
         runtime
             .workspace_id()
             .map_err(|err| DispatchError::JobExecution(format!("resolve workspace id: {err}")))?,
+        run_id,
+        SYSTEM_AUDIT_IDENTITY,
+        Some(repo_root),
+    )
+    .expect("audit writer");
+    execute_job_with_resume(&job, input, run_id, writer, host, None)
+}
+
+fn try_execute_epic_drain_job(
+    runtime: &OrbitRuntime,
+    repo_root: &Path,
+    host: &dyn RuntimeHost,
+    input: Value,
+    run_id: &str,
+) -> Result<JobOutcome, DispatchError> {
+    let mut job = resolved_job(runtime, "epic_pipeline");
+    job.steps.drain(..2);
+    let JobV2StepBody::Loop { loop_ } = &mut job.steps[1].body else {
+        panic!("epic drain step");
+    };
+    let JobV2StepBody::Target(land_child) = &mut loop_.steps[0].body else {
+        panic!("resolved epic child step");
+    };
+    let run_input = land_child
+        .default_input
+        .as_mut()
+        .and_then(|value| value.get_mut("run_input"))
+        .and_then(Value::as_object_mut)
+        .expect("epic child run input");
+    run_input.insert(
+        "base_branch".to_string(),
+        Value::String("epic/ORB-EPIC".to_string()),
+    );
+    run_input.insert(
+        "landing_branch".to_string(),
+        Value::String("agent-main".to_string()),
+    );
+    let writer = V2AuditWriter::with_disk_sinks(
+        &runtime.paths().audit_dir,
+        runtime
+            .sqlite_store()
+            .map_err(|error| DispatchError::JobExecution(format!("open audit store: {error}")))?,
+        runtime.workspace_id().map_err(|error| {
+            DispatchError::JobExecution(format!("resolve workspace id: {error}"))
+        })?,
         run_id,
         SYSTEM_AUDIT_IDENTITY,
         Some(repo_root),
@@ -445,6 +491,101 @@ impl RuntimeHost for ScriptedGateHost<'_> {
     }
 }
 
+struct ScriptedEpicHost<'a> {
+    runtime: &'a OrbitRuntime,
+    descendant_ids: Vec<String>,
+    calls: Mutex<Vec<(String, Value)>>,
+}
+
+impl<'a> ScriptedEpicHost<'a> {
+    fn new(runtime: &'a OrbitRuntime, descendant_ids: Vec<String>) -> Self {
+        Self {
+            runtime,
+            descendant_ids,
+            calls: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn inputs_for(&self, action: &str) -> Vec<Value> {
+        self.calls
+            .lock()
+            .expect("call log")
+            .iter()
+            .filter(|(recorded, _)| recorded == action)
+            .map(|(_, input)| input.clone())
+            .collect()
+    }
+}
+
+impl RuntimeHost for ScriptedEpicHost<'_> {
+    fn run_deterministic(
+        &self,
+        action: &str,
+        config: &Value,
+        input: &Value,
+        tool_context: ToolContext,
+    ) -> Result<Value, DispatchError> {
+        self.calls
+            .lock()
+            .expect("call log")
+            .push((action.to_string(), input.clone()));
+        match action {
+            "resolve_workspace_ship_input" => Ok(json!({
+                "mode": "pr",
+                "base_branch": "agent-main",
+            })),
+            "worktree_setup" => Ok(json!({
+                "job_run_id": "epic-ORB-EPIC",
+                "batch_id": "epic-ORB-EPIC",
+                "workspace_path": self.runtime.paths().repo_root,
+                "head_ref": "epic/ORB-EPIC",
+                "base_ref": "origin/agent-main",
+                "base_sha": "1111111111111111111111111111111111111111",
+            })),
+            "list_epic_descendants" => Ok(json!({
+                "epic_task_id": "ORB-EPIC",
+                "task_count": self.descendant_ids.len(),
+                "task_ids": self.descendant_ids,
+                "empty": self.descendant_ids.is_empty(),
+            })),
+            "invoke_and_wait" => Ok(json!({
+                "run_id": "jrun-scripted-epic-child",
+                "status": "succeeded",
+            })),
+            "pipeline_success_guard" => <OrbitRuntime as RuntimeHost>::run_deterministic(
+                self.runtime,
+                action,
+                config,
+                input,
+                tool_context,
+            ),
+            other => Err(DispatchError::DeterministicActionNotRegistered(
+                other.to_string(),
+            )),
+        }
+    }
+
+    fn resolve_cli_executor(&self, provider: &str) -> Result<ResolvedCliExecutor, DispatchError> {
+        <OrbitRuntime as RuntimeHost>::resolve_cli_executor(self.runtime, provider)
+    }
+
+    fn tool_context_for_activity(
+        &self,
+        run_id: Option<&str>,
+        fs_profile: Option<&str>,
+        fs_audit: Option<Arc<dyn FsAuditLogger>>,
+        proc_allowed_programs: Option<&[String]>,
+    ) -> ToolContext {
+        <OrbitRuntime as RuntimeHost>::tool_context_for_activity(
+            self.runtime,
+            run_id,
+            fs_profile,
+            fs_audit,
+            proc_allowed_programs,
+        )
+    }
+}
+
 fn write_job(path: &Path, name: &str, action: &str) {
     let yaml = format!(
         r#"schemaVersion: 2
@@ -656,6 +797,62 @@ fn task_gate_child_failure_still_fails_success_guard() {
     );
     assert!(message.contains("jrun-scripted-child"), "{message}");
     assert!(message.contains("status failed"), "{message}");
+}
+
+#[test]
+fn epic_pipeline_dispatches_three_children_serially_without_push_or_pr_inputs() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    let child_ids = vec![
+        "ORB-CHILD-1".to_string(),
+        "ORB-CHILD-2".to_string(),
+        "ORB-CHILD-3".to_string(),
+    ];
+    let host = ScriptedEpicHost::new(&runtime, child_ids.clone());
+
+    let outcome = try_execute_epic_drain_job(
+        &runtime,
+        &repo_root,
+        &host,
+        json!({ "epic_task_id": "ORB-EPIC" }),
+        "jrun-scripted-epic",
+    )
+    .expect("execute epic pipeline");
+
+    assert!(outcome.success);
+    let invokes = host.inputs_for("invoke_and_wait");
+    assert_eq!(invokes.len(), 3);
+    for (invoke, child_id) in invokes.iter().zip(child_ids) {
+        assert_eq!(invoke["job_name"], "task_local_pipeline");
+        assert_eq!(invoke["run_input"]["task_ids"], json!([child_id]));
+        assert_eq!(invoke["run_input"]["base_branch"], "epic/ORB-EPIC");
+        assert_eq!(invoke["run_input"]["base_sync"], "local");
+        assert_eq!(invoke["run_input"]["auto_push"], false);
+        assert_eq!(invoke["run_input"]["terminal_status"], "done");
+        assert_eq!(invoke["run_input"]["landing_branch"], "agent-main");
+    }
+    assert!(host.inputs_for("git_push").is_empty());
+    assert!(host.inputs_for("pr_open").is_empty());
+}
+
+#[test]
+fn epic_pipeline_with_no_children_runs_no_child_pipeline() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    let host = ScriptedEpicHost::new(&runtime, Vec::new());
+
+    let outcome = try_execute_epic_drain_job(
+        &runtime,
+        &repo_root,
+        &host,
+        json!({ "epic_task_id": "ORB-EMPTY-EPIC" }),
+        "jrun-scripted-empty-epic",
+    )
+    .expect("execute empty epic pipeline");
+
+    assert!(outcome.success);
+    assert!(host.inputs_for("invoke_and_wait").is_empty());
+    assert!(host.inputs_for("pipeline_success_guard").is_empty());
 }
 
 #[cfg(unix)]

--- a/crates/orbit-core/src/runtime/task/locks.rs
+++ b/crates/orbit-core/src/runtime/task/locks.rs
@@ -1,7 +1,7 @@
 //! Task reservation and file-lock operations.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::PathBuf;
+use std::path::Path;
 
 use orbit_common::types::{
     AuditEventStatus, NotFoundKind, OrbitError, Task, TaskStatus,
@@ -31,8 +31,13 @@ pub(in crate::runtime) fn list(runtime: &OrbitRuntime) -> Result<Value, OrbitErr
         .list_active_task_reservations(&workspace_orbit_dir(runtime), workspace_id.as_deref())?;
     emit_expired_reservation_events(runtime, &reservation_result.expired_reservations)?;
 
-    let mut tasks: Vec<_> = runtime
-        .list_tasks()?
+    let all_tasks = runtime.list_tasks()?;
+    let task_lookup = all_tasks
+        .iter()
+        .cloned()
+        .map(|task| (task.id.clone(), task))
+        .collect::<BTreeMap<_, _>>();
+    let mut tasks: Vec<_> = all_tasks
         .into_iter()
         .filter(|task| matches!(task.status, TaskStatus::InProgress | TaskStatus::Review))
         .collect();
@@ -46,7 +51,9 @@ pub(in crate::runtime) fn list(runtime: &OrbitRuntime) -> Result<Value, OrbitErr
 
     let locked_files: BTreeSet<String> = tasks
         .iter()
-        .flat_map(|task| existing_context_files(runtime, task))
+        .flat_map(|task| {
+            lock_context_files_for_task(task, &task_lookup, runtime.paths().repo_root.as_path())
+        })
         .chain(
             reservation_result
                 .reservations
@@ -74,7 +81,19 @@ pub(in crate::runtime) fn list(runtime: &OrbitRuntime) -> Result<Value, OrbitErr
 
     Ok(json!({
         "locked_files": locked_files.iter().cloned().collect::<Vec<_>>(),
-        "by_task": tasks.iter().map(task_lock_to_json).collect::<Vec<_>>(),
+        "by_task": tasks
+            .iter()
+            .map(|task| {
+                task_lock_to_json(
+                    task,
+                    lock_context_files_for_task(
+                        task,
+                        &task_lookup,
+                        runtime.paths().repo_root.as_path(),
+                    ),
+                )
+            })
+            .collect::<Vec<_>>(),
         "by_reservation": by_reservation,
         "total_locked": locked_files.len(),
         "total_tasks": tasks.len(),
@@ -387,16 +406,58 @@ pub(crate) fn workspace_task_reservation_id(
     }
 }
 
-fn task_workspace_root(runtime: &OrbitRuntime, task: &Task) -> PathBuf {
-    let _ = task;
-    runtime.paths().repo_root.clone()
+/// Return the effective lock surface for one task.
+///
+/// An active epic root owns the union of every descendant's declared files so
+/// conflict admission can keep unrelated work moving while excluding only
+/// leaves that overlap the epic's actual family.
+pub(crate) fn lock_context_files_for_task(
+    task: &Task,
+    task_lookup: &BTreeMap<String, Task>,
+    workspace_root: &Path,
+) -> Vec<String> {
+    let mut files = existing_context_files_at_root(task, workspace_root)
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    if task.tags.iter().any(|tag| tag == "epic") {
+        for candidate in task_lookup.values() {
+            if task_is_descendant_of(candidate, &task.id, task_lookup) {
+                files.extend(existing_context_files_at_root(candidate, workspace_root));
+            }
+        }
+    }
+    files.into_iter().collect()
 }
 
-fn existing_context_files(runtime: &OrbitRuntime, task: &Task) -> Vec<String> {
-    let workspace_root = task_workspace_root(runtime, task);
-    let canonical = canonicalize_context_files_for_read(&task.context_files, &workspace_root);
-    let (kept, _dropped) = prune_missing_context_files(&workspace_root, canonical);
+fn existing_context_files_at_root(task: &Task, workspace_root: &Path) -> Vec<String> {
+    let canonical = canonicalize_context_files_for_read(&task.context_files, workspace_root);
+    let (kept, _dropped) = prune_missing_context_files(workspace_root, canonical);
     kept
+}
+
+fn task_is_descendant_of(
+    task: &Task,
+    ancestor_id: &str,
+    task_lookup: &BTreeMap<String, Task>,
+) -> bool {
+    let mut visited = BTreeSet::from([task.id.clone()]);
+    let mut next_parent_id = task.parent_id();
+    for _ in 0..32 {
+        let Some(parent_id) = next_parent_id else {
+            return false;
+        };
+        if parent_id == ancestor_id {
+            return true;
+        }
+        if !visited.insert(parent_id.to_string()) {
+            return false;
+        }
+        let Some(parent) = task_lookup.get(parent_id) else {
+            return false;
+        };
+        next_parent_id = parent.parent_id();
+    }
+    false
 }
 
 pub(crate) fn requested_task_files(
@@ -414,7 +475,11 @@ pub(crate) fn requested_task_files(
         let task = task_map
             .get(task_id)
             .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, task_id.clone()))?;
-        requested_files.extend(existing_context_files(runtime, task));
+        requested_files.extend(lock_context_files_for_task(
+            task,
+            &task_map,
+            runtime.paths().repo_root.as_path(),
+        ));
     }
 
     Ok(requested_files.into_iter().collect())
@@ -431,10 +496,13 @@ pub(crate) fn task_lock_conflicts(
         return Ok(Vec::new());
     }
 
-    let mut tasks: Vec<Task> = runtime
-        .stores()
-        .tasks()
-        .list_tasks()?
+    let all_tasks = runtime.stores().tasks().list_tasks()?;
+    let task_lookup = all_tasks
+        .iter()
+        .cloned()
+        .map(|task| (task.id.clone(), task))
+        .collect::<BTreeMap<_, _>>();
+    let mut tasks: Vec<Task> = all_tasks
         .into_iter()
         .filter(|task| {
             matches!(task.status, TaskStatus::InProgress | TaskStatus::Review)
@@ -451,7 +519,8 @@ pub(crate) fn task_lock_conflicts(
 
     let mut conflicts = Vec::new();
     for task in tasks {
-        let held_files = existing_context_files(runtime, &task);
+        let held_files =
+            lock_context_files_for_task(&task, &task_lookup, runtime.paths().repo_root.as_path());
         for requested_file in &requested_files {
             if held_files
                 .iter()
@@ -574,7 +643,7 @@ fn first_task_id(task_ids: &[String]) -> Option<&str> {
     task_ids.first().map(String::as_str)
 }
 
-fn task_lock_to_json(task: &Task) -> Value {
+fn task_lock_to_json(task: &Task, context_files: Vec<String>) -> Value {
     json!({
         "id": task.id,
         "title": task.title,
@@ -582,7 +651,7 @@ fn task_lock_to_json(task: &Task) -> Value {
         "job_run_id": task.job_run_id,
         "crew": task.crew,
         "orchestrator": task.orchestrator,
-        "context_files": task.context_files,
+        "context_files": context_files,
     })
 }
 

--- a/crates/orbit-core/src/runtime/task/tests/locks.rs
+++ b/crates/orbit-core/src/runtime/task/tests/locks.rs
@@ -4,6 +4,7 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::OrbitRuntime;
+use crate::command::task::TaskAddParams;
 
 use super::super::locks::{
     TaskLockReservationScope, parse_task_lock_reservation_scope, requested_task_files,
@@ -138,6 +139,67 @@ fn requested_task_files_prune_missing_context_entries() {
     let requested =
         requested_task_files(&runtime, &[task.id]).expect("collect requested task files");
     assert_eq!(requested, vec!["file:docs/design/groundhog.md".to_string()]);
+}
+
+#[test]
+fn active_epic_root_holds_union_of_descendant_context_files() {
+    let _env = unmanaged_tool_env_guard();
+    let (_root, runtime, repo_root) = test_runtime();
+    for path in ["src/root.rs", "src/one.rs", "src/two.rs"] {
+        let full_path = repo_root.join(path);
+        std::fs::create_dir_all(full_path.parent().expect("fixture parent"))
+            .expect("create fixture directory");
+        std::fs::write(full_path, "fixture\n").expect("write fixture");
+    }
+    let epic = runtime
+        .add_task(TaskAddParams {
+            title: "Epic root".to_string(),
+            description: "Epic fixture".to_string(),
+            acceptance_criteria: vec!["assembled".to_string()],
+            tags: vec!["epic".to_string()],
+            plan: "drain children".to_string(),
+            context_files: vec!["file:src/root.rs".to_string()],
+            status: Some(TaskStatus::InProgress),
+            ..Default::default()
+        })
+        .expect("create epic");
+    for (title, path) in [("one", "src/one.rs"), ("two", "src/two.rs")] {
+        runtime
+            .add_task(TaskAddParams {
+                parent_id: Some(epic.id.clone()),
+                title: title.to_string(),
+                description: "Child fixture".to_string(),
+                acceptance_criteria: vec!["done".to_string()],
+                plan: "implement".to_string(),
+                context_files: vec![format!("file:{path}")],
+                status: Some(TaskStatus::Backlog),
+                ..Default::default()
+            })
+            .expect("create epic child");
+    }
+
+    assert_eq!(
+        requested_task_files(&runtime, std::slice::from_ref(&epic.id))
+            .expect("collect epic lock surface"),
+        vec![
+            "file:src/one.rs".to_string(),
+            "file:src/root.rs".to_string(),
+            "file:src/two.rs".to_string(),
+        ]
+    );
+    let locks = runtime
+        .run_tool("orbit.task.locks", json!({}))
+        .expect("list task locks");
+    let epic_lock = locks["by_task"]
+        .as_array()
+        .expect("task locks")
+        .iter()
+        .find(|entry| entry["id"] == epic.id)
+        .expect("epic lock entry");
+    assert_eq!(
+        epic_lock["context_files"],
+        json!(["file:src/one.rs", "file:src/root.rs", "file:src/two.rs"])
+    );
 }
 
 #[test]

--- a/crates/orbit-core/src/runtime/v2_host/backlog_exclusion.rs
+++ b/crates/orbit-core/src/runtime/v2_host/backlog_exclusion.rs
@@ -1,14 +1,14 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use orbit_common::types::{Task, TaskStatus, prune_missing_context_files, task_dependencies_ready};
+use orbit_common::types::{Task, TaskStatus, task_dependencies_ready};
 use orbit_common::utility::path::workspace_relative_paths_overlap;
-use orbit_common::utility::selector::canonical_selector_in_workspace;
 use orbit_engine::DispatchError;
 use serde::Serialize;
 use serde_json::Value;
 
 use crate::OrbitRuntime;
+use crate::runtime::task::locks::lock_context_files_for_task;
 
 const MAX_TASK_PARENT_CHAIN_DEPTH: usize = 32;
 
@@ -40,14 +40,14 @@ struct BacklogTaskConflict {
     locking_task_id: String,
 }
 
-fn active_task_lock_holders<'a>(
-    tasks: impl IntoIterator<Item = &'a Task>,
+fn active_task_lock_holders(
+    tasks: &BTreeMap<String, Task>,
     workspace_root: &Path,
 ) -> BTreeMap<String, Vec<String>> {
     let mut holders: BTreeMap<String, Vec<String>> = BTreeMap::new();
-    for task in tasks {
+    for task in tasks.values() {
         if matches!(task.status, TaskStatus::InProgress | TaskStatus::Review) {
-            for file in existing_lock_context_files(task, workspace_root) {
+            for file in lock_context_files_for_task(task, tasks, workspace_root) {
                 holders.entry(file).or_default().push(task.id.clone());
             }
         }
@@ -61,11 +61,12 @@ fn active_task_lock_holders<'a>(
 
 fn task_overlap_conflicts(
     task: &Task,
+    task_lookup: &BTreeMap<String, Task>,
     holders: &BTreeMap<String, Vec<String>>,
     workspace_root: &Path,
 ) -> Vec<BacklogTaskConflict> {
     let mut conflicts = Vec::new();
-    for requested_file in existing_lock_context_files(task, workspace_root) {
+    for requested_file in lock_context_files_for_task(task, task_lookup, workspace_root) {
         for (held_file, locking_task_ids) in holders {
             if workspace_relative_paths_overlap(&requested_file, held_file) {
                 for locking_task_id in locking_task_ids {
@@ -80,16 +81,6 @@ fn task_overlap_conflicts(
     conflicts.sort();
     conflicts.dedup();
     conflicts
-}
-
-fn existing_lock_context_files(task: &Task, workspace_root: &Path) -> Vec<String> {
-    let canonical = task
-        .context_files
-        .iter()
-        .filter_map(|entry| canonical_selector_in_workspace(entry, workspace_root).ok())
-        .collect::<Vec<_>>();
-    let (kept, _dropped) = prune_missing_context_files(workspace_root, canonical);
-    kept
 }
 
 pub(super) fn list_backlog_tasks(
@@ -130,7 +121,7 @@ pub(super) fn list_backlog_tasks(
             }
         })?;
         let workspace_root = runtime.paths().repo_root.as_path();
-        let lock_holders = active_task_lock_holders(task_lookup.values(), workspace_root);
+        let lock_holders = active_task_lock_holders(&task_lookup, workspace_root);
         let mut backlog: Vec<Task> = all_tasks
             .into_iter()
             .filter(|task| {
@@ -157,7 +148,8 @@ pub(super) fn list_backlog_tasks(
             let direct_conflicts: BTreeMap<String, Vec<BacklogTaskConflict>> = backlog
                 .iter()
                 .filter_map(|task| {
-                    let conflicts = task_overlap_conflicts(task, &lock_holders, workspace_root);
+                    let conflicts =
+                        task_overlap_conflicts(task, &task_lookup, &lock_holders, workspace_root);
                     (!conflicts.is_empty()).then(|| (task.id.clone(), conflicts))
                 })
                 .collect();

--- a/crates/orbit-core/src/runtime/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/v2_host/dispatch.rs
@@ -213,6 +213,12 @@ pub(crate) fn run_deterministic(
         CoreDeterministicAction::ListBacklogTasks => {
             backlog_exclusion::list_backlog_tasks(runtime, action, input)
         }
+        // Resolve one epic's unfinished descendants once, in a deterministic
+        // dependency-first order, so the enclosing workflow can drain them
+        // with an ordinary sequential loop.
+        CoreDeterministicAction::ListEpicDescendants => {
+            workspace_auto::list_epic_descendants(runtime, action, input)
+        }
         // Materialize blocked tasks attributable to a terminally-failed job
         // run for the triage pipeline [ORB-10129]. Human-blocked tasks (no
         // `job_run_id`, or a non-failed run) never appear; tasks whose

--- a/crates/orbit-core/src/runtime/v2_host/tests/backlog_exclusion.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/backlog_exclusion.rs
@@ -324,6 +324,58 @@ fn list_backlog_tasks_reports_direct_context_lock_conflicts() {
 }
 
 #[test]
+fn active_epic_excludes_only_loose_tasks_overlapping_descendant_union() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "crates/epic/src/lib.rs");
+    write_workspace_file(&repo_root, "crates/loose/src/lib.rs");
+    let epic = runtime
+        .add_task(TaskAddParams {
+            title: "Active epic".to_string(),
+            description: "Epic fixture".to_string(),
+            acceptance_criteria: vec!["Assembled".to_string()],
+            tags: vec!["epic".to_string()],
+            plan: "Drain children".to_string(),
+            status: Some(TaskStatus::InProgress),
+            ..Default::default()
+        })
+        .expect("seed active epic");
+    seed_list_backlog_task(
+        &runtime,
+        "Epic child",
+        TaskStatus::Backlog,
+        TaskPriority::High,
+        TaskType::Chore,
+        Some(epic.id.clone()),
+        vec!["file:crates/epic/src/lib.rs"],
+    );
+    let overlapping = seed_list_backlog_task(
+        &runtime,
+        "Overlapping loose leaf",
+        TaskStatus::Backlog,
+        TaskPriority::High,
+        TaskType::Chore,
+        None,
+        vec!["file:crates/epic/src/lib.rs"],
+    );
+    let unrelated = seed_list_backlog_task(
+        &runtime,
+        "Unrelated loose leaf",
+        TaskStatus::Backlog,
+        TaskPriority::Medium,
+        TaskType::Chore,
+        None,
+        vec!["file:crates/loose/src/lib.rs"],
+    );
+
+    let output = list_backlog_tasks(&runtime, json!({}));
+
+    assert_eq!(output_task_ids(&output), vec![unrelated.id]);
+    let excluded = excluded_entry(&output, &overlapping.id);
+    assert_eq!(excluded["reason"], "context_lock_conflict");
+    assert_eq!(excluded["conflicts"][0]["locking_task_id"], epic.id);
+}
+
+#[test]
 fn list_backlog_tasks_reports_group_member_conflicts_with_trigger_conflicts() {
     let (_root, runtime, repo_root) = runtime_with_workspace_layout();
     write_workspace_file(&repo_root, "docs/parent.md");

--- a/crates/orbit-core/src/runtime/v2_host/tests/workspace_auto.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/workspace_auto.rs
@@ -20,6 +20,115 @@ fn classify(runtime: &OrbitRuntime) -> Value {
         .expect("classify workspace auto tasks")
 }
 
+fn list_epic_descendants(runtime: &OrbitRuntime, epic_task_id: &str) -> Value {
+    runtime
+        .run_deterministic(
+            "list_epic_descendants",
+            &json!({}),
+            &json!({ "epic_task_id": epic_task_id }),
+            ToolContext::default(),
+        )
+        .expect("list epic descendants")
+}
+
+#[test]
+fn epic_descendants_are_dependency_then_priority_ordered_and_terminal_tasks_are_skipped() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let epic = runtime
+        .add_task(TaskAddParams {
+            title: "Epic root".to_string(),
+            description: "Epic fixture".to_string(),
+            acceptance_criteria: vec!["Supervised".to_string()],
+            tags: vec!["epic".to_string()],
+            plan: "Delegate children".to_string(),
+            status: Some(TaskStatus::InProgress),
+            ..Default::default()
+        })
+        .expect("seed epic root");
+    let foundation = runtime
+        .add_task(TaskAddParams {
+            parent_id: Some(epic.id.clone()),
+            title: "Foundation".to_string(),
+            description: "Foundation fixture".to_string(),
+            acceptance_criteria: vec!["Done".to_string()],
+            plan: "Implement".to_string(),
+            priority: TaskPriority::Low,
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("seed foundation");
+    let dependent = runtime
+        .add_task(TaskAddParams {
+            parent_id: Some(epic.id.clone()),
+            title: "Dependent".to_string(),
+            description: "Dependent fixture".to_string(),
+            acceptance_criteria: vec!["Done".to_string()],
+            dependencies: vec![foundation.id.clone()],
+            plan: "Implement".to_string(),
+            priority: TaskPriority::High,
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("seed dependent");
+    let independent = runtime
+        .add_task(TaskAddParams {
+            parent_id: Some(epic.id.clone()),
+            title: "Independent".to_string(),
+            description: "Independent fixture".to_string(),
+            acceptance_criteria: vec!["Done".to_string()],
+            plan: "Implement".to_string(),
+            priority: TaskPriority::Critical,
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("seed independent");
+    let done = runtime
+        .add_task(TaskAddParams {
+            parent_id: Some(epic.id.clone()),
+            title: "Already done".to_string(),
+            description: "Done fixture".to_string(),
+            acceptance_criteria: vec!["Done".to_string()],
+            plan: "Implemented".to_string(),
+            status: Some(TaskStatus::Done),
+            ..Default::default()
+        })
+        .expect("seed done child");
+
+    let output = list_epic_descendants(&runtime, &epic.id);
+    assert_eq!(
+        output["task_ids"],
+        json!([independent.id, foundation.id, dependent.id])
+    );
+    assert_eq!(output["task_count"], 3);
+    assert!(
+        !output["task_ids"]
+            .as_array()
+            .expect("task ids")
+            .contains(&json!(done.id))
+    );
+}
+
+#[test]
+fn epic_with_no_descendants_has_an_empty_drain() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let epic = runtime
+        .add_task(TaskAddParams {
+            title: "Empty epic".to_string(),
+            description: "Epic fixture".to_string(),
+            acceptance_criteria: vec!["No children".to_string()],
+            tags: vec!["epic".to_string()],
+            plan: "No-op".to_string(),
+            status: Some(TaskStatus::InProgress),
+            ..Default::default()
+        })
+        .expect("seed empty epic");
+
+    let output = list_epic_descendants(&runtime, &epic.id);
+    assert_eq!(output["task_ids"], json!([]));
+    assert_eq!(output["task_count"], 0);
+    assert_eq!(output["empty"], true);
+}
+
 #[test]
 fn two_loose_tasks_win_before_one_epic_and_three_children() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();

--- a/crates/orbit-core/src/runtime/v2_host/workspace_auto.rs
+++ b/crates/orbit-core/src/runtime/v2_host/workspace_auto.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use orbit_common::types::{Task, TaskStatus, task_dependencies_ready};
 use orbit_engine::DispatchError;
@@ -87,4 +87,112 @@ pub(super) fn classify_workspace_auto_tasks(
         "loose_task_ids": [],
         "epic_task_id": null,
     }))
+}
+
+pub(super) fn list_epic_descendants(
+    runtime: &OrbitRuntime,
+    action: &str,
+    input: &Value,
+) -> Result<Value, DispatchError> {
+    let epic_task_id = input
+        .get("epic_task_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| DispatchError::DeterministicActionFailed {
+            action: action.to_string(),
+            message: "missing `epic_task_id`".to_string(),
+        })?;
+    let all_tasks = runtime.stores().tasks().list_tasks().map_err(|error| {
+        DispatchError::DeterministicActionFailed {
+            action: action.to_string(),
+            message: format!("list tasks: {error}"),
+        }
+    })?;
+    let task_lookup = all_tasks
+        .iter()
+        .cloned()
+        .map(|task| (task.id.clone(), task))
+        .collect::<BTreeMap<_, _>>();
+    let epic =
+        task_lookup
+            .get(epic_task_id)
+            .ok_or_else(|| DispatchError::DeterministicActionFailed {
+                action: action.to_string(),
+                message: format!("epic task `{epic_task_id}` was not found"),
+            })?;
+    if !epic.tags.iter().any(|tag| tag == "epic") {
+        return Err(DispatchError::DeterministicActionFailed {
+            action: action.to_string(),
+            message: format!("task `{epic_task_id}` is not tagged `epic`"),
+        });
+    }
+
+    let mut remaining = all_tasks
+        .into_iter()
+        .filter(|task| {
+            is_descendant_of(task, epic_task_id, &task_lookup)
+                && !matches!(
+                    task.status,
+                    TaskStatus::Done | TaskStatus::Rejected | TaskStatus::Archived
+                )
+        })
+        .map(|task| (task.id.clone(), task))
+        .collect::<BTreeMap<_, _>>();
+    let mut ordered = Vec::with_capacity(remaining.len());
+
+    while !remaining.is_empty() {
+        let remaining_ids = remaining.keys().cloned().collect::<BTreeSet<_>>();
+        let mut ready = remaining
+            .values()
+            .filter(|task| {
+                task.dependencies()
+                    .iter()
+                    .all(|dependency_id| !remaining_ids.contains(dependency_id))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if ready.is_empty() {
+            return Err(DispatchError::DeterministicActionFailed {
+                action: action.to_string(),
+                message: format!(
+                    "epic `{epic_task_id}` has a dependency cycle among unfinished descendants: {}",
+                    remaining_ids.into_iter().collect::<Vec<_>>().join(", ")
+                ),
+            });
+        }
+        sort_tasks_by_priority_age(&mut ready);
+        for task in ready {
+            remaining.remove(&task.id);
+            ordered.push(task.id);
+        }
+    }
+
+    Ok(json!({
+        "epic_task_id": epic_task_id,
+        "task_count": ordered.len(),
+        "task_ids": ordered,
+        "empty": ordered.is_empty(),
+    }))
+}
+
+fn is_descendant_of(task: &Task, ancestor_id: &str, task_lookup: &BTreeMap<String, Task>) -> bool {
+    let mut visited = BTreeSet::from([task.id.clone()]);
+    let mut next_parent_id = task.parent_id();
+    for _ in 0..32 {
+        let Some(parent_id) = next_parent_id else {
+            return false;
+        };
+        if parent_id == ancestor_id {
+            return true;
+        }
+        if !visited.insert(parent_id.to_string()) {
+            return false;
+        }
+        let Some(parent) = task_lookup.get(parent_id) else {
+            return false;
+        };
+        next_parent_id = parent.parent_id();
+    }
+    false
 }

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/merge.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/merge.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use orbit_common::types::OrbitError;
 use serde_json::{Value, json};
@@ -37,12 +37,13 @@ pub(in crate::executor::automation) fn merge_batch_worktree_into_base<H: Runtime
         ));
     }
 
-    ensure_clean_checkout(&repo_root, "base branch checkout")?;
-
     let base = input_string_field(input, "base").unwrap_or_else(|| DEFAULT_BASE.to_string());
     let base_sync_mode = base_sync_mode_from_input(input)?;
+    let base_checkout = checkout_holding_branch(&repo_root, &base)?.unwrap_or(repo_root.clone());
+    ensure_clean_checkout(&base_checkout, "base branch checkout")?;
     merge_with_rebase_retry(
         &repo_root,
+        &base_checkout,
         &workspace_path,
         &base,
         &workspace_branch,
@@ -79,6 +80,7 @@ fn checkout_base_branch(
 
 fn merge_with_rebase_retry(
     repo_root: &Path,
+    base_checkout: &Path,
     workspace_path: &Path,
     base: &str,
     workspace_branch: &str,
@@ -86,8 +88,22 @@ fn merge_with_rebase_retry(
 ) -> Result<(), OrbitError> {
     for attempt in 0..=MAX_REBASE_RETRY_ATTEMPTS {
         let start_point = resolve_worktree_start_point(repo_root, base, base_sync_mode)?;
-        checkout_base_branch(repo_root, base, &start_point, base_sync_mode)?;
-        if git_command_success(repo_root, &["merge", "--ff-only", workspace_branch])? {
+        if base_checkout == repo_root {
+            checkout_base_branch(repo_root, base, &start_point, base_sync_mode)?;
+        } else {
+            let checked_out = git_output(base_checkout, &["rev-parse", "--abbrev-ref", "HEAD"])?;
+            if checked_out.trim() != base {
+                return Err(OrbitError::Execution(format!(
+                    "linked base worktree '{}' moved from branch '{base}' to '{}'",
+                    base_checkout.display(),
+                    checked_out.trim()
+                )));
+            }
+            if base_sync_mode == BaseSyncMode::Remote {
+                fast_forward_local_base_to_remote(base_checkout, base, &start_point)?;
+            }
+        }
+        if git_command_success(base_checkout, &["merge", "--ff-only", workspace_branch])? {
             return Ok(());
         }
         if attempt == MAX_REBASE_RETRY_ATTEMPTS {
@@ -106,6 +122,28 @@ fn merge_with_rebase_retry(
     }
 
     Ok(())
+}
+
+/// Locate the linked worktree that already has `base` checked out. Git refuses
+/// to check the same branch out in the primary checkout, so stacked local
+/// pipelines must merge directly in the owning worktree (the epic worktree in
+/// particular).
+fn checkout_holding_branch(repo_root: &Path, base: &str) -> Result<Option<PathBuf>, OrbitError> {
+    let listing = git_output(repo_root, &["worktree", "list", "--porcelain"])?;
+    let expected_branch = format!("refs/heads/{base}");
+    let mut current_path = None;
+    for line in listing.lines().chain(std::iter::once("")) {
+        if let Some(path) = line.strip_prefix("worktree ") {
+            current_path = Some(PathBuf::from(path));
+        } else if let Some(branch) = line.strip_prefix("branch ")
+            && branch == expected_branch
+        {
+            return Ok(current_path);
+        } else if line.is_empty() {
+            current_path = None;
+        }
+    }
+    Ok(None)
 }
 
 fn fast_forward_local_base_to_remote(

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
@@ -75,7 +75,7 @@ pub(in crate::executor::automation) fn setup_worktree<H: RuntimeHost + ?Sized>(
 
     let worktree_path = identity.path(repo_root)?;
 
-    ensure_worktree(repo_root, &worktree_path, &base_sha, &branch_name)?;
+    let branch_name = ensure_worktree(repo_root, &worktree_path, &base_sha, &branch_name)?;
 
     // ORB-10602: mount-anchor materialization deliberately does *not* happen
     // here any more. Setup only ever saw a snapshot of the task's context files
@@ -140,7 +140,7 @@ pub(crate) fn ensure_worktree(
     worktree_path: &Path,
     start_point: &str,
     branch_name: &str,
-) -> Result<(), OrbitError> {
+) -> Result<String, OrbitError> {
     let target = git_output(
         repo_root,
         &[
@@ -152,9 +152,12 @@ pub(crate) fn ensure_worktree(
 
     if worktree_path.exists() {
         if git_command_success(worktree_path, &["rev-parse", "--is-inside-work-tree"])? {
-            git_success(worktree_path, &["checkout", "-B", branch_name, &target])?;
+            let attached_branch = git_output(
+                worktree_path,
+                &["symbolic-ref", "--quiet", "--short", "HEAD"],
+            )?;
             git_success(worktree_path, &["clean", "-fd"])?;
-            return Ok(());
+            return Ok(attached_branch);
         }
 
         if is_empty_dir(worktree_path)? {
@@ -183,17 +186,26 @@ pub(crate) fn ensure_worktree(
 
     git_success(repo_root, &["worktree", "prune"])?;
     let worktree_path_arg = worktree_path.to_string_lossy();
-    git_success(
-        repo_root,
-        &[
-            "worktree",
-            "add",
-            "-B",
-            branch_name,
-            &worktree_path_arg,
-            &target,
-        ],
-    )
+    let branch_ref = format!("refs/heads/{branch_name}");
+    if git_command_success(repo_root, &["show-ref", "--verify", "--quiet", &branch_ref])? {
+        git_success(
+            repo_root,
+            &["worktree", "add", &worktree_path_arg, branch_name],
+        )?;
+    } else {
+        git_success(
+            repo_root,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                branch_name,
+                &worktree_path_arg,
+                &target,
+            ],
+        )?;
+    }
+    Ok(branch_name.to_string())
 }
 
 fn is_empty_dir(path: &Path) -> Result<bool, OrbitError> {

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/merge.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/merge.rs
@@ -89,6 +89,60 @@ fn unpublished_first_merge_does_not_cascade_into_second_local_merge() {
     );
 }
 
+#[test]
+fn child_pipeline_merges_into_an_epic_branch_checked_out_in_another_worktree() {
+    let temp = tempdir().unwrap();
+    let primary = temp.path().join("primary");
+    let epic_worktree = temp.path().join("epic-worktree");
+    let child_worktree = temp.path().join("child-worktree");
+    init_repo(&primary);
+    commit_file(&primary, "base.txt", "base");
+    git(
+        &primary,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "epic/ORB-10000",
+            path(&epic_worktree),
+            BASE_BRANCH,
+        ],
+    );
+    configure_identity(&epic_worktree);
+    git(
+        &primary,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "orbit/child",
+            path(&child_worktree),
+            "epic/ORB-10000",
+        ],
+    );
+    configure_identity(&child_worktree);
+    let child_commit = commit_file(&child_worktree, "child.txt", "child change");
+    let host = MergeTestHost::new(&primary, temp.path());
+
+    merge_batch_worktree_into_base(
+        &host,
+        &json!({
+            "run_id": "child-run",
+            "workspace_path": child_worktree,
+            "base": "epic/ORB-10000",
+            "base_sync": "local",
+        }),
+    )
+    .unwrap();
+
+    assert_eq!(git(&epic_worktree, &["rev-parse", "HEAD"]), child_commit);
+    assert_eq!(
+        fs::read_to_string(epic_worktree.join("child.txt")).unwrap(),
+        "child change"
+    );
+    assert!(!primary.join("child.txt").exists());
+}
+
 fn merge_input(run_id: &str, workspace_path: &Path, base_sync: &str) -> Value {
     json!({
         "run_id": run_id,

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/setup.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/setup.rs
@@ -11,20 +11,26 @@ use serde_json::json;
 use super::super::setup::{ensure_worktree, worktree_setup_output};
 
 #[test]
-fn ensure_worktree_resets_existing_checkout_to_supplied_start_point() {
+fn ensure_worktree_reattaches_existing_checkout_without_resetting_its_branch() {
     let temp = tempdir().unwrap();
     let repo = temp.path().join("repo");
     let worktree = temp.path().join("worktree");
     init_repo(&repo, "agent-main");
     let first_base = commit_file(&repo, "base.txt", "v1");
 
-    ensure_worktree(&repo, &worktree, &first_base, "orbit/test").unwrap();
+    assert_eq!(
+        ensure_worktree(&repo, &worktree, &first_base, "orbit/test").unwrap(),
+        "orbit/test"
+    );
     assert_eq!(git(&worktree, &["rev-parse", "HEAD"]), first_base);
 
-    let second_base = commit_file(&repo, "base.txt", "v2");
-    ensure_worktree(&repo, &worktree, &second_base, "orbit/test").unwrap();
+    let epic_commit = commit_file(&worktree, "child.txt", "landed");
 
-    assert_eq!(git(&worktree, &["rev-parse", "HEAD"]), second_base);
+    let second_base = commit_file(&repo, "base.txt", "v2");
+    let reattached = ensure_worktree(&repo, &worktree, &second_base, "orbit/new-name").unwrap();
+
+    assert_eq!(reattached, "orbit/test");
+    assert_eq!(git(&worktree, &["rev-parse", "HEAD"]), epic_commit);
 }
 
 #[test]
@@ -39,7 +45,7 @@ fn ensure_worktree_reuses_orphan_branch_from_failed_attempt() {
     let second_base = commit_file(&repo, "base.txt", "v2");
     ensure_worktree(&repo, &worktree, &second_base, "orbit/test").unwrap();
 
-    assert_eq!(git(&worktree, &["rev-parse", "HEAD"]), second_base);
+    assert_eq!(git(&worktree, &["rev-parse", "HEAD"]), first_base);
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-10816](https://orbit-cli.com/tasks/ORB-10816) — Give an epic run one worktree and land its children into it sequentially

### Description

## Problem

`epic_pipeline` has no worktree of its own. Its orchestrator dispatches children through
`task_gate_pipeline`, so each child gets a separate worktree, branches off the workspace base,
and lands independently. One epic therefore produces N branches, N PRs, and N `review` items,
and nothing ever sees the epic's combined result before it reaches the base branch.

## Why It Matters

An epic is one body of work. It should produce one branch that a human reviews once. It also
needs a place where the finisher agent (ORB-10817) can validate the *merged* result of every
child before delivery.

## What To Build

1. `epic_pipeline` opens a stable worktree for the epic root via `worktree_setup` with an
   explicit `run_id: epic-<ORB-id>` and `branch_prefix: epic`. `WorktreeIdentity` already reads
   `run_id`/`branch_prefix` from the activity input, so the directory and branch are stable and
   reattachable across runs of the same epic — verify `ensure_worktree` reattaches to the
   existing branch instead of recreating it.
2. Non-terminal descendants of the epic root are drained **one at a time, in dependency then
   priority/age order**, each through `task_local_pipeline` with:
   `base_branch: <epic branch>`, `base_sync: local`, `auto_push: false`,
   `landing_branch: <real workspace base>`.
3. A child reaches `done` on merge into the epic branch, not `review`. `task_local_pipeline`'s
   `mark_review` step becomes an input-driven terminal status (default stays `review` for every
   existing caller).
4. `task_gate_pipeline` hardcodes `auto_push: true` at `dispatch_child`. Epic children must not
   push the epic branch. Either plumb `auto_push` as a gate input or have epic children bypass
   the gate — the epic run's own sequencing is already the serialization, so the gate's
   reserve/wait loop is pure latency for siblings that overlap by construction.
5. The epic root holds one lock reservation covering the **union** of its descendants'
   `context_files`, so unrelated backlog leaves are excluded by the conflict machinery that
   already exists (`active_task_lock_holders` / `task_overlap_conflicts`) rather than by a
   blanket hold.

## Constraints / Notes

- Sequential is required, not just simpler. `merge_with_rebase_retry` lands the child branch
  with `git merge --ff-only` and at most `MAX_REBASE_RETRY_ATTEMPTS` rebases against the moved
  base. Sequential children rebase onto the advanced epic branch and fast-forward cleanly;
  parallel children race that fast-forward and exhaust the retry budget.
- `worktree_gc` only deletes on `done`/`rejected`/`archived` (`task_status_permits_deletion`), so
  child worktrees become reclaimable as soon as they merge into the epic branch — correct, but it
  means a child's worktree is gone before anything lands on the workspace base.
- The epic root stays `in-progress` for the whole run, which keeps its own worktree retained.
- Shipped `crates/orbit-core/assets/jobs/*.yaml` and `.orbit/resources/jobs/*.yaml` must stay
  byte-identical; `crates/orbit-core/src/command/job/tests/catalog.rs` asserts it.
- An epic with zero children is valid and must skip the drain phase entirely.

### Acceptance Criteria

- An `epic_pipeline` run over an epic root with three children produces exactly one worktree for the epic plus one transient worktree per child, and exactly one branch that carries all three children's commits.
- Re-running `epic_pipeline` on the same epic root reattaches the existing epic worktree and branch rather than creating a second one.
- Each child is `done` — not `review` — once its commits are on the epic branch, and no child run pushed the epic branch or opened a PR.
- An epic root with no children completes the drain phase with zero child pipeline runs.
- `orbit tool run orbit.task.locks.list` shows the epic root holding the union of its descendants' existing context files while the run is live.
- A backlog leaf whose context files do not overlap that union is still admitted by `list_backlog_tasks` during the epic run; one that does overlap is excluded with a `context_lock_conflict` reason.
- `cargo test -p orbit-core` passes, including the catalog byte-identity assertions.
- `make ci-fast` and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Rebuilt epic_pipeline around one stable epic worktree and a deterministic dependency-first descendant drain. Each descendant runs serially through task_local_pipeline against the epic branch with local base sync, no push, and terminal status done.
- Made task_local_pipeline terminal status input-driven while preserving review as the default for every existing caller.
- Reattached existing worktrees without resetting their accumulated branch, and taught local fast-forward merge to target a linked worktree that already owns the base branch.
- Expanded active epic lock surfaces to the union of descendant context files and reused that authoritative surface in backlog conflict admission.
- Added catalog byte-identity checks plus focused execution, lock, backlog, ordering, zero-child, worktree reattachment, and linked-base merge coverage.
Assessment: The epic assembly path is sequential by construction, preserves one accumulated epic branch across reruns, and does not route children through the push and PR gate.
Scope expansion: Added the deterministic action catalog and runtime dispatch files to enumerate epic descendants; added backlog admission files to consume the shared epic lock surface; added worktree setup and merge files because stable reattachment and merging into a branch checked out in the epic worktree are required for the acceptance criteria.
Validation:
- make ci-fast: passed.
- make ci-lint: passed.
- cargo test -p orbit-engine child_pipeline_merges_into_an_epic_branch_checked_out_in_another_worktree: passed.
- cargo test -p orbit-core with the unrelated dogfood routine identity test skipped: 749 passed, 0 failed; all epic and catalog assertions passed.
- The exact cargo test -p orbit-core command has one pre-existing baseline failure: .orbit/routines/task_pilot.yaml is enabled at HEAD while the shipped template is disabled. The mismatch is unrelated to this task and was left unchanged because disabling a scheduled dogfood routine is out of scope.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10816-6a80b5fe`
- Behind base: 0
- Ahead of base: 1