### PR TITLE
Epic-owned worktree and continuous workspace drain

### DIFF
--- a/docs/design/resident-orchestrator/1_overview.md
+++ b/docs/design/resident-orchestrator/1_overview.md
@@ -15,10 +15,13 @@ related_artifacts: [ORB-10332, ORB-10775, ORB-10776, ORB-10779, ORB-10788, ORB-1
 
 # Resident Orchestrator — Overview
 
-> **Status: Draft.** This folder specifies the v2 contract ([ORB-10815]). The v1 sequencer it
-> replaces is still what ships: one auto tick takes one action, and an in-progress epic holds all
-> auto-ship. Each child task flips its own section's claims to live behavior in the PR that
-> implements it. [§9](./2_design.md#9-what-v1-did-and-why-it-changed) records what v1 did.
+> **Status: Draft, landing incrementally.** This folder specifies the v2 contract ([ORB-10815]).
+> The epic worktree and the sequential child drain are **live** ([ORB-10816]); the epic agent,
+> epic-scoped completion with inlined delivery, and the drain window are **not yet built**. Until
+> they are, one auto tick still takes one action and `decision: hold` still freezes auto-ship
+> behind an in-progress epic. Each child task flips its own section's claims to live behavior in
+> the PR that implements it — see the status column in [§3](#3-at-a-glance).
+> [§10](./2_design.md#10-what-v1-did-and-why-it-changed) records what v1 did.
 
 V1 is two Orbit jobs, not one command. V2 keeps that split and changes what each job *is*.
 
@@ -80,8 +83,10 @@ note. It is no longer `epic_pipeline`'s completion gate; it serves the workspace
 flushing the backlog. Absent or zero means one tick. The deadline stops *starting* new work; in-flight
 children finish on their own.
 
-**Conflict admission.** An in-progress epic holds one reservation over the union of its descendants'
-`context_files`. Loose leaves are admitted by the ordinary overlap check. There is no `hold`.
+**Conflict admission.** An `epic`-tagged root holds one reservation over the union of its
+descendants' `context_files` — live since [ORB-10816] via `lock_context_files_for_task`. Loose
+leaves are then admitted by the ordinary overlap check. Deleting `decision: hold` so that check is
+the *only* gate is [ORB-10819]; until then `hold` still short-circuits it.
 
 **Session log.** Workspace-scoped append-only notebook (`orbit.session_log`), kinds `status`,
 `note`, `check_later`. Unresolved `check_later` rows are a scan wake reason. This is the memory
@@ -95,19 +100,20 @@ and explicit ship of the root is refused.
 
 ## 3. At a Glance
 
-| Concern | Where | Task |
-|---------|-------|------|
-| This split | this folder | [ORB-10776] |
-| Epic tag = supervisor delegation signal | [Epic tag is a supervisor delegation signal, not the job predicate](./4_decisions.md#epic-tag-is-a-supervisor-delegation-signal-not-the-job-predicate) | [ORB-10776] |
-| Clock and supervisor stay outside Orbit | [The supervisor clock is not an Orbit primitive](./4_decisions.md#the-supervisor-clock-is-not-an-orbit-primitive) | [ORB-10776] |
-| `orbit.session_log` (notes / check-later / status) | workspace session-log store + tools | [ORB-10784] |
-| `scan_unresolved_work` + `epic_pipeline` v1 | catalog | [ORB-10779] |
-| Epic owns one worktree; children land sequentially | [An epic owns one worktree and one branch](./4_decisions.md#an-epic-owns-one-worktree-and-one-branch) | [ORB-10816] |
-| Epic agent edits the tree instead of dispatching | [The epic agent works in the worktree instead of dispatching](./4_decisions.md#the-epic-agent-works-in-the-worktree-instead-of-dispatching) | [ORB-10817] |
-| Epic-scoped completion + inlined delivery | [Epic completion is epic-scoped](./4_decisions.md#epic-completion-is-epic-scoped-not-workspace-scoped) | [ORB-10818] |
-| Drain window, no `hold`, detached epic dispatch | [Auto drains for a window instead of taking one action](./4_decisions.md#auto-drains-for-a-window-instead-of-taking-one-action) | [ORB-10819] |
-| Child delivery inside an epic | `task_local_pipeline` onto the epic branch | [ORB-10816] |
-| HTTP epic retirement | removed assets | [ORB-10332] |
+| Concern | Where | Task | Status |
+|---------|-------|------|--------|
+| This split | this folder | [ORB-10776] | live |
+| Epic tag = supervisor delegation signal | [Epic tag is a supervisor delegation signal, not the job predicate](./4_decisions.md#epic-tag-is-a-supervisor-delegation-signal-not-the-job-predicate) | [ORB-10776] | live |
+| Clock and supervisor stay outside Orbit | [The supervisor clock is not an Orbit primitive](./4_decisions.md#the-supervisor-clock-is-not-an-orbit-primitive) | [ORB-10776] | live |
+| `orbit.session_log` (notes / check-later / status) | workspace session-log store + tools | [ORB-10784] | live |
+| `scan_unresolved_work` + `epic_pipeline` v1 | catalog | [ORB-10779] | live |
+| Epic owns one worktree; children land sequentially | [An epic owns one worktree and one branch](./4_decisions.md#an-epic-owns-one-worktree-and-one-branch) | [ORB-10816] | live |
+| Epic reservation over the descendant context union | `lock_context_files_for_task` | [ORB-10816] | live |
+| Epic agent edits the tree instead of dispatching | [The epic agent works in the worktree instead of dispatching](./4_decisions.md#the-epic-agent-works-in-the-worktree-instead-of-dispatching) | [ORB-10817] | planned |
+| Epic-scoped completion + inlined delivery | [Epic completion is epic-scoped](./4_decisions.md#epic-completion-is-epic-scoped-not-workspace-scoped) | [ORB-10818] | planned |
+| Drain window, no `hold`, detached epic dispatch | [Auto drains for a window instead of taking one action](./4_decisions.md#auto-drains-for-a-window-instead-of-taking-one-action) | [ORB-10819] | planned |
+| Child delivery inside an epic | `task_local_pipeline` onto the epic branch | [ORB-10816] | live |
+| HTTP epic retirement | removed assets | [ORB-10332] | live |
 
 ## Task References
 

--- a/docs/design/resident-orchestrator/2_design.md
+++ b/docs/design/resident-orchestrator/2_design.md
@@ -15,22 +15,35 @@ related_artifacts: [ORB-10332, ORB-10775, ORB-10776, ORB-10779, ORB-10788, ORB-1
 
 # Resident Orchestrator — Design
 
-> **Status: Draft.** This is the v2 contract ([ORB-10815]); v1 is what currently ships. [§10](#10-what-v1-did-and-why-it-changed)
-> records the v1 shape and why each piece changed. It still does not add a resident server, an
-> Orbit routine, conversation resume, or a comment-typed decision protocol.
+> **Status: Draft, landing incrementally.** This is the v2 contract ([ORB-10815]).
+> [§10](#10-what-v1-did-and-why-it-changed) records the v1 shape and why each piece changed. It
+> still does not add a resident server, an Orbit routine, conversation resume, or a comment-typed
+> decision protocol.
+>
+> | Section | State |
+> |---|---|
+> | [§1 Epic worktree and sequential child drain](#1-epic-worktree-and-sequential-child-drain) | **live** ([ORB-10816]) |
+> | [§2 Epic agent](#2-epic-agent-epic_orchestrator) | planned ([ORB-10817]) — the shipped activity is still the v1 dispatcher |
+> | [§3 `epic_pipeline` job](#3-epic_pipeline-job) | partly live — §1's phases ship; the agent step, completion gate, and delivery are [ORB-10818] |
+> | [§4 Workspace drain](#4-workspace-drain-workspace_auto_pipeline) | planned ([ORB-10819]) — the epic reservation is live, but `decision: hold` and the one-action tick still ship |
+> | [§5](#5-unresolved-work-scan)–[§8](#8-authority-and-completion) | live |
 
 ## 1. Epic worktree and sequential child drain
+
+> **Live** since [ORB-10816].
 
 An epic is one body of work, so it produces one branch that a human reviews once ([An epic owns one worktree and one branch](./4_decisions.md#an-epic-owns-one-worktree-and-one-branch), [ORB-10816]).
 
 `epic_pipeline` opens a **stable** worktree for the epic root through `worktree_setup`, passing an
-explicit `run_id: epic-<ORB-id>` and `branch_prefix: epic`. `WorktreeIdentity` already derives the
+explicit `run_id: epic-<ORB-id>` and `branch_prefix: epic`. `WorktreeIdentity` derives the
 directory from those two inputs, so the same epic resolves to the same worktree and branch across
 runs and reattaches rather than forking a second one. The root moves to `in-progress` and stays
 there for the life of the run, which is also what keeps `worktree_gc` from reclaiming the directory.
 
-Non-terminal descendants are drained **one at a time**, in dependency then priority/age order,
-each through `task_local_pipeline`:
+The `list_epic_descendants` deterministic action returns the root's non-terminal descendants in
+dependency then priority/age order. The job's `drain` loop lands them **one at a time**, each
+through an `invoke_and_wait` on `task_local_pipeline` followed by a `pipeline_success_guard` so a
+failed child stops the drain instead of silently skipping:
 
 | Input | Value | Why |
 |---|---|---|
@@ -38,9 +51,12 @@ each through `task_local_pipeline`:
 | `base_sync` | `local` | the epic branch has no remote counterpart |
 | `auto_push` | `false` | only delivery publishes |
 | `landing_branch` | the real workspace base | ORB-10644 obsolescence gate fails closed once the epic lands |
+| `terminal_status` | `done` | the child is finished when it merges into the epic branch |
 
-A child reaches **`done`** on merge into the epic branch, not `review`. The epic root is the single
-review artifact; N children in `review` for one epic is the fragmentation this design removes.
+A child reaches **`done`** on merge into the epic branch, not `review`. `task_local_pipeline`
+defaults `terminal_status` to `review`, so only an epic drain opts into `done`; the epic root is
+then the single review artifact, and N children in `review` for one epic is the fragmentation this
+design removes.
 
 Sequential is a requirement, not a simplification. `merge_with_rebase_retry` lands a child branch
 with `git merge --ff-only` plus at most two rebases against the moved base. Sequential children
@@ -52,6 +68,10 @@ already provide.
 An epic with **no** children is normal and skips this phase entirely.
 
 ## 2. Epic agent (`epic_orchestrator`)
+
+> **Planned** ([ORB-10817]). The shipped `epic_orchestrator` is still the v1 no-code-change
+> workspace-drain dispatcher: its description forbids editing the repository, and `epic_pipeline`
+> does not invoke it. Everything below is the target contract.
 
 `epic_orchestrator` is an `agent_loop` / `backend: cli` activity that runs **inside the epic
 worktree**, after the children have merged ([The epic agent works in the worktree instead of dispatching](./4_decisions.md#the-epic-agent-works-in-the-worktree-instead-of-dispatching), [ORB-10817]).
@@ -78,6 +98,10 @@ Conversation resume across fires stays out of scope. Each invoke starts fresh fr
 `orbit.session_log.list`.
 
 ## 3. `epic_pipeline` job
+
+> **Partly live.** The shipped job runs `resolve_ship_input` → `worktree` → `descendants` → the
+> `drain` loop of §1, then stops. The agent step, the completion gate, and delivery are [ORB-10818];
+> until they land, an epic run assembles the branch but does not ship it.
 
 ```text
 worktree = worktree_setup(epic root, run_id: epic-<id>, branch_prefix: epic)
@@ -107,6 +131,11 @@ epic root -> review (pr) | done (local)
 
 ## 4. Workspace drain (`workspace_auto_pipeline`)
 
+> **Planned** ([ORB-10819]). `classify_workspace_auto_tasks` still returns the four-way
+> `ship`/`hold`/`epic`/`empty` decision and still short-circuits to `hold` whenever an epic root is
+> `in-progress`; there is no window. The epic reservation this section depends on is already live
+> (see below).
+
 `orbit run ship` is a leaf implementer. The logistics verb is a separate job; that split from v1
 stands. What changes is that a tick becomes a **window** ([Auto drains for a window instead of taking one action](./4_decisions.md#auto-drains-for-a-window-instead-of-taking-one-action), [ORB-10819]).
 
@@ -132,11 +161,14 @@ loop
 - An expired window with nothing left is a plain success. Fail-closed lives at the epic gate (§3),
   not here.
 
-**Conflict admission replaces `hold`.** An in-progress epic holds one reservation covering the
-union of its descendants' `context_files`. Loose leaves are then admitted or excluded by machinery
-that already exists — `active_task_lock_holders` / `task_overlap_conflicts` at discovery, and
-`reserve_locks` atomically at the gate. The four-way `ship`/`hold`/`epic`/`empty` decision collapses
-to an admissible set.
+**Conflict admission replaces `hold`.** An `epic`-tagged root holds one reservation covering the
+union of its descendants' `context_files`. That union is **live** since [ORB-10816]:
+`lock_context_files_for_task` walks `parent_id` to collect every descendant's declared files when
+the task carries `tag: epic`, and both `active_task_lock_holders` and `task_overlap_conflicts` read
+through it. So loose leaves are already admitted or excluded by machinery that exists —
+`task_overlap_conflicts` at discovery, `reserve_locks` atomically at the gate. What [ORB-10819]
+still owes is deleting the short-circuit above it, collapsing the four-way
+`ship`/`hold`/`epic`/`empty` decision to an admissible set.
 
 A task is in the **epic family** when it carries `tag: epic` or any ancestor does. Walk `parent_id`
 the same way `list_backlog_tasks` already walks it for lock grouping.
@@ -264,7 +296,8 @@ the job fails at the ceiling rather than lying.
 
 ## 10. What v1 did and why it changed
 
-Recorded so a reader of the shipped code can tell the two apart until [ORB-10815] lands.
+Recorded so a reader of the shipped code can tell the two apart while [ORB-10815] lands child by
+child. The banner table at the top says which rows below are already true of the shipped code.
 
 | v1 | v2 | Why |
 |---|---|---|

--- a/docs/design/resident-orchestrator/4_decisions.md
+++ b/docs/design/resident-orchestrator/4_decisions.md
@@ -164,7 +164,7 @@ epic-scoped gate instead of scoping the workspace scan.
 
 ## An epic owns one worktree and one branch
 
-**Recorded:** 2026-08 · [ORB-10816]
+**Recorded:** 2026-08 · [ORB-10816] · **Implemented** in [ORB-10816]
 
 ### Context
 
@@ -201,7 +201,7 @@ race that fast-forward.
 
 ## The epic agent works in the worktree instead of dispatching
 
-**Recorded:** 2026-08 · [ORB-10817]
+**Recorded:** 2026-08 · [ORB-10817] · **Not yet implemented**
 
 ### Context
 
@@ -230,7 +230,7 @@ to the drain phase when it does.
 
 ## Epic completion is epic-scoped, not workspace-scoped
 
-**Recorded:** 2026-08 · [ORB-10818]
+**Recorded:** 2026-08 · [ORB-10818] · **Not yet implemented**
 
 ### Context
 
@@ -259,7 +259,7 @@ worktree via its own `worktree_setup`.
 
 ## Auto drains for a window instead of taking one action
 
-**Recorded:** 2026-08 · [ORB-10819]
+**Recorded:** 2026-08 · [ORB-10819] · **Not yet implemented** (the epic reservation it relies on is live from [ORB-10816])
 
 ### Context
 


### PR DESCRIPTION
## Task

[ORB-10815](https://orbit-cli.com/tasks/ORB-10815) — Epic-owned worktree and continuous workspace drain

### Description

## Problem

`orbit run auto` (`workspace_auto_pipeline`) is a one-shot sequencer that is strictly less
useful than `orbit run ship` in the common case:

- One tick performs exactly one action — ship the loose leaves, or start one epic, or nothing.
- `decision: hold` freezes *all* auto-ship while any epic root is `in-progress`, including
  conflict-free chores that have nothing to do with the epic.
- Backlog membership is sampled once, at `classify` time. A task that enters `backlog` one
  second later is invisible until an external clock fires another tick.
- `epic_pipeline` drains a workspace-wide scan through a no-code-change orchestrator that can
  only create and dispatch tasks, so one epic's work spreads across N unrelated worktrees,
  N PRs, and N review items.

## Why It Matters

The unattended path (`ship-sweep-orbit` -> `workspace_ship_pipeline` -> `workspace_auto_pipeline`)
is the only thing that drains this workspace without a human. Today that path stalls on the
first epic and re-samples the backlog only every 30 minutes.

## What Changes

Four coupled changes, one per child task:

1. An epic run owns **one** worktree and **one** branch. Its children land into that branch
   sequentially in `local` mode and reach `done` on merge — not `review`.
2. `epic_orchestrator` stops being a dispatcher and becomes a code-editing finisher that works
   inside the epic worktree with subagents. Sub-task breakdown becomes optional: a human or a
   higher-up orchestrator decomposes an epic when useful; otherwise the epic agent does the
   whole body of work itself.
3. `workspace_auto_pipeline` gains a drain window (`orbit run auto --for <duration>`). It polls
   and re-lists the backlog until the window expires, so tasks created mid-window still ship.
4. The epic holds one reservation over the union of its descendants' `context_files`, and
   `epic_pipeline` is dispatched detached — so conflict-free loose leaves keep shipping while an
   epic runs. `decision: hold` is deleted.

## Constraints / Notes

- Sequential child execution is load-bearing, not just simpler: `git_merge` lands a child branch
  with `git merge --ff-only` plus at most two rebase retries. Parallel children onto one epic
  branch race that fast-forward.
- `landing_branch` (ORB-10644) already exists for exactly this stacked shape: children set it to
  the real base so delivery fails closed once the epic branch lands.
- Delivery must be **inlined** against the epic worktree. Invoking `task_pr_pipeline` would run
  its own `worktree_setup` and create a second worktree.
- `docs/design/resident-orchestrator/` is revised to `status: Draft` alongside this epic. Each
  child flips its own section's claims to live behavior in the same PR that implements it.
- Deliberately **not** tagged `epic` yet. `ship-sweep-orbit` is enabled on `dk-server-1` every 30
  minutes and routes to `workspace_auto_pipeline`; tagging this root today would hand it to the
  *old* epic pipeline. Tag it only after the first two children land.
- `orbit run ship --force` (override the context-lock gate for an explicitly named task) is
  parked, not in scope.

### Acceptance Criteria

- All four child tasks are `done`.
- `orbit run auto --for 30m` on a workspace holding one epic root with children plus two unrelated conflict-free backlog leaves ships the leaves, drains the epic into a single branch, and delivers one PR (or one local merge) for the epic.
- A task added to `backlog` after that run started is picked up before the window expires.
- No `workspace_auto_pipeline` run emits a classify output containing `decision: hold`; the enum no longer carries that value.

## Execution Summary

<details>
<summary>Click to expand</summary>

Reconciled the resident-orchestrator design folder with what ORB-10816 actually shipped. NO behavior change; Markdown only.

## Why this was in scope

This epic's own constraint is that each child "flips its own section's claims to live behavior in the same PR that implements it." ORB-10816 landed 18 files of code and touched zero docs, so the folder still declared the whole v2 contract unbuilt while §1 of it was live. The folder is this root's declared `context_files` boundary, so reconciling it is the root's own work.

## Verified against shipped code, not against the prose

Live (ORB-10816):
- `.orbit/resources/jobs/epic_pipeline.yaml`: `resolve_ship_input` -> `worktree` (`run_id: epic-<id>`, `branch_prefix: epic`) -> `descendants` (`list_epic_descendants`) -> serial `drain` loop of `invoke_and_wait task_local_pipeline` + `pipeline_success_guard`.
- Child inputs `base_sync: local`, `auto_push: false`, `landing_branch: <real base>`, and the new `terminal_status: done` (`task_local_pipeline` still defaults to `review`).
- `lock_context_files_for_task` (crates/orbit-core/src/runtime/task/locks.rs:414) unions an `epic`-tagged root's descendants' `context_files`; `active_task_lock_holders` / `task_overlap_conflicts` read through it.

Not live (confirmed by reading the assets, not assumed):
- `epic_orchestrator.yaml` is still the v1 no-code-change dispatcher and `epic_pipeline` never invokes it (ORB-10817).
- `epic_pipeline` stops after the drain loop: no agent step, no completion gate, no delivery (ORB-10818).
- `classify_workspace_auto_tasks` still emits `decision: "hold"` (workspace_auto.rs:41) and has no window (ORB-10819).

## Changes

- `1_overview.md`: fixed a broken cross-reference (`§9` -> `§10`, wrong anchor, would 404); banner now states what is live vs. planned; added a Status column to §3 At a Glance plus a row for the epic reservation; corrected the "There is no `hold`" claim, which was false.
- `2_design.md`: banner gained a per-section state table; §1 marked live and rewritten to name the shipped mechanism (`list_epic_descendants`, `pipeline_success_guard`, `terminal_status`); §2/§3/§4 gained accurate not-yet-built markers; §4 now credits the live epic reservation and narrows ORB-10819's remaining debt to deleting the `hold` short-circuit; §10 intro no longer says "until ORB-10815 lands" as if atomic.
- `4_decisions.md`: the ORB-10816 decision marked Implemented; the ORB-10817/10818/10819 decisions marked Not yet implemented.

## Validation

`make ci-fast` and `make ci-lint` both pass. All intra-folder anchors re-verified against actual headings.

## Root is NOT complete

Acceptance criterion 1 requires all four children `done`; only ORB-10816 is. ORB-10817, ORB-10818, and ORB-10819 are still `backlog`, so criteria 2-4 are unmet and undemonstrable. This root must not be closed when this PR merges. Per the description's tagging gate, tag it `epic` only after ORB-10817 lands, then drive the remainder through `epic_pipeline`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10815-6a80baff`
- Behind base: 0
- Ahead of base: 1