### PR TITLE
orbit run job silently orphans the run when submitted with an explicit --root override

### DIFF
--- a/crates/orbit-cli/tests/worktree_resolution.rs
+++ b/crates/orbit-cli/tests/worktree_resolution.rs
@@ -5,6 +5,8 @@
 use std::fs;
 use std::path::Path;
 use std::process::Command as StdCommand;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use assert_cmd::Command as AssertCommand;
 use assert_cmd::cargo::cargo_bin_cmd;
@@ -78,6 +80,87 @@ fn config_show_reports_shared_and_local_roots_for_git_worktrees_and_overrides() 
     assert!(
         !linked_orbit.exists(),
         "resolution should not materialize a linked-worktree .orbit directory"
+    );
+}
+
+/// [ORB-10821] `orbit --root <custom> run job` must execute in that custom
+/// store. Before the fix the parent persisted the run under `--root` and
+/// reported `submitted`, then the detached worker rediscovered `$HOME/.orbit`
+/// and exited with `job run not found`, leaving the run pending forever.
+#[test]
+fn run_job_with_explicit_root_completes_instead_of_staying_pending() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let repo = temp.path().join("repo");
+    let custom_root = temp.path().join("custom-orbit");
+    fs::create_dir_all(&home).expect("create home");
+    fs::create_dir_all(&repo).expect("create repo");
+    init_git_repo(&repo);
+
+    run_orbit_success(
+        &repo,
+        &home,
+        &[
+            "--root",
+            custom_root.to_str().expect("utf8 custom root"),
+            "workspace",
+            "init",
+        ],
+        None,
+    );
+
+    let job_path = repo.join("root-override-smoke.yaml");
+    fs::write(
+        &job_path,
+        r#"schemaVersion: 2
+kind: Job
+metadata:
+  name: root_override_smoke
+spec:
+  state: enabled
+  kind: workflow
+  steps:
+    - id: nap
+      default_input:
+        seconds: 0
+      spec:
+        type: deterministic
+        action: sleep
+        config: {}
+"#,
+    )
+    .expect("write smoke job");
+
+    let custom_root_arg = custom_root.to_string_lossy().into_owned();
+    let job_path_arg = job_path.to_string_lossy().into_owned();
+    let submitted = run_orbit_json(
+        &repo,
+        &home,
+        &[
+            "--root",
+            &custom_root_arg,
+            "run",
+            "job",
+            &job_path_arg,
+            "--json",
+        ],
+        None,
+    );
+    let run_id = submitted["run_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("expected run_id in {submitted}"))
+        .to_string();
+    assert_eq!(submitted["state"].as_str(), Some("submitted"));
+
+    let shown = wait_for_run_terminal_state(&repo, &home, &custom_root_arg, &run_id);
+    let state = shown["run"]["state"].as_str().unwrap_or("missing");
+    let worker_log = custom_root
+        .join("state/logs")
+        .join(format!("{run_id}.worker.log"));
+    let worker_log_text = fs::read_to_string(&worker_log).unwrap_or_default();
+    assert_eq!(
+        state, "success",
+        "run {run_id} must complete under --root {custom_root_arg}; last show={shown}; worker log:\n{worker_log_text}"
     );
 }
 
@@ -168,6 +251,29 @@ fn assert_root_fields(value: &Value, shared_root: &Path, local_root: &Path) {
         value.get("selected_root").is_none(),
         "legacy `selected_root` alias must be removed from `config show --json` output (use `shared_root`)"
     );
+}
+
+fn wait_for_run_terminal_state(cwd: &Path, home: &Path, custom_root: &str, run_id: &str) -> Value {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let last = run_orbit_json(
+            cwd,
+            home,
+            &["--root", custom_root, "run", "show", run_id, "--json"],
+            None,
+        );
+        if last["run"]["state"]
+            .as_str()
+            .is_some_and(|state| state != "pending" && state != "running")
+        {
+            return last;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "run {run_id} stayed non-terminal under --root {custom_root}; last show={last}"
+        );
+        thread::sleep(Duration::from_millis(50));
+    }
 }
 
 fn string_field<'a>(value: &'a Value, field: &str) -> &'a str {

--- a/crates/orbit-core/src/command/job/pipeline.rs
+++ b/crates/orbit-core/src/command/job/pipeline.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use chrono::Utc;
 use orbit_common::types::{
     AuditEventStatus, JobRun, JobRunState, JobScheduleState, JobTargetType, NotFoundKind,
-    OrbitError, OrbitEvent, audit_execution_id,
+    OrbitError, OrbitEvent, WorkspacePaths, audit_execution_id,
 };
 use orbit_store::{AuditEventInsertParams, JobRunStepParams, TaskReservationReleaseReason};
 use serde::Serialize;
@@ -828,17 +828,25 @@ impl OrbitRuntime {
     }
 
     /// The program a detached worker runs: this same `orbit` binary, re-entered
-    /// at the hidden worker subcommand and discovered by cwd.
+    /// at the hidden worker subcommand. Workspace context is discovered by cwd;
+    /// an explicit parent `--root` is forwarded so the child opens the same
+    /// global store the parent used to persist the run [ORB-10821].
     fn pipeline_worker_command(&self, run_id: &str) -> Result<Command, OrbitError> {
+        let paths = self.paths();
         #[cfg(test)]
-        if let Some(command) = worker_command_override::command(&self.paths().repo_root, run_id) {
+        if let Some(command) = worker_command_override::command(&paths.repo_root, run_id) {
             return Ok(command);
         }
         let current_exe = std::env::current_exe().map_err(|error| {
             OrbitError::Execution(format!("resolve current orbit executable: {error}"))
         })?;
         let mut command = Command::new(resolve_pipeline_worker_executable(current_exe));
-        configure_pipeline_worker_command(&mut command, &self.paths().repo_root, run_id);
+        configure_pipeline_worker_command(
+            &mut command,
+            &paths.repo_root,
+            run_id,
+            pipeline_worker_root_override(paths),
+        );
         Ok(command)
     }
 
@@ -859,13 +867,13 @@ impl OrbitRuntime {
             });
         }
 
-        // Discover detached workers by registered cwd, never explicit --root.
         // Start the observer before the process so every successfully spawned
         // worker has a parent-side path that can terminalize a pre-claim exit.
-        // Passing `--root` here used to pin both the workspace and global roots
-        // to `.orbit/`, which disconnected the worker from the global registry
-        // database that contains the persisted run. Cwd discovery preserves
-        // the registered workspace context for top-level and nested workers.
+        // Cwd still carries the registered workspace. `--root` is forwarded
+        // only when the parent itself was pinned (see
+        // `pipeline_worker_root_override`); passing the workspace `.orbit`
+        // path here used to pin both roots and disconnect the worker from
+        // `$HOME/.orbit/orbit.db`.
         let (sender, receiver) = mpsc::sync_channel::<Child>(1);
         let runtime = self.clone();
         let run_id_for_observer = run_id.to_string();
@@ -1139,11 +1147,25 @@ pub(crate) fn resolve_pipeline_worker_executable(current_exe: PathBuf) -> PathBu
     current_exe
 }
 
+/// Forward `--root` only when the parent runtime is pinned to one directory
+/// (`global_dir == orbit_dir`). That is the `--root` flag's contract: it pins
+/// both the workspace and the global store. The default split-root layout
+/// (`$HOME/.orbit` vs workspace `.orbit`) must keep this `None` — an explicit
+/// `--root` would pin *both* roots and disconnect the worker from the global
+/// registry database that contains the persisted run.
+pub(crate) fn pipeline_worker_root_override(paths: &WorkspacePaths) -> Option<&Path> {
+    (paths.global_dir == paths.orbit_dir).then_some(paths.global_dir.as_path())
+}
+
 pub(crate) fn configure_pipeline_worker_command(
     command: &mut Command,
     workspace: &Path,
     run_id: &str,
+    root_override: Option<&Path>,
 ) {
+    if let Some(root) = root_override {
+        command.arg("--root").arg(root);
+    }
     command
         .arg("job")
         .arg("run-pipeline-worker")

--- a/crates/orbit-core/src/command/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/command/tests/job_pipeline.rs
@@ -1,11 +1,11 @@
 use std::ffi::OsStr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::thread;
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
-use orbit_common::types::{AuditEventStatus, JobRunState, OrbitError};
+use orbit_common::types::{AuditEventStatus, JobRunState, OrbitError, WorkspacePaths};
 use orbit_store::sqlite::migration::SUPPORTED_SCHEMA_VERSION;
 use tempfile::TempDir;
 
@@ -13,7 +13,7 @@ use crate::OrbitRuntime;
 use crate::command::job::JobRunListParams;
 use crate::command::job::pipeline::{
     configure_pipeline_worker_command, configure_pipeline_worker_stdio, pipeline_worker_log_path,
-    resolve_pipeline_worker_executable,
+    pipeline_worker_root_override, resolve_pipeline_worker_executable,
 };
 use crate::command::task::TaskAddParams;
 use crate::command::workflow::ShipMode;
@@ -45,7 +45,7 @@ fn pipeline_worker_command_discovers_registered_workspace_from_cwd() {
     let workspace = Path::new("/registered/workspace");
     let mut command = Command::new("orbit");
 
-    configure_pipeline_worker_command(&mut command, workspace, "jrun-child");
+    configure_pipeline_worker_command(&mut command, workspace, "jrun-child", None);
 
     assert_eq!(
         command.get_args().collect::<Vec<_>>(),
@@ -54,9 +54,54 @@ fn pipeline_worker_command_discovers_registered_workspace_from_cwd() {
             OsStr::new("run-pipeline-worker"),
             OsStr::new("jrun-child"),
         ],
-        "an explicit --root pins the worker to the wrong global store"
+        "an unpinned parent must not pass --root; that pins both roots and disconnects the worker from the global store"
     );
     assert_eq!(command.get_current_dir(), Some(workspace));
+}
+
+#[test]
+fn pipeline_worker_command_forwards_explicit_root_to_the_detached_worker() {
+    let workspace = Path::new("/registered/workspace");
+    let pinned_root = Path::new("/tmp/custom-orbit");
+    let mut command = Command::new("orbit");
+
+    configure_pipeline_worker_command(&mut command, workspace, "jrun-child", Some(pinned_root));
+
+    assert_eq!(
+        command.get_args().collect::<Vec<_>>(),
+        vec![
+            OsStr::new("--root"),
+            OsStr::new("/tmp/custom-orbit"),
+            OsStr::new("job"),
+            OsStr::new("run-pipeline-worker"),
+            OsStr::new("jrun-child"),
+        ],
+        "a parent constructed with --root must forward that same global store to the worker"
+    );
+    assert_eq!(command.get_current_dir(), Some(workspace));
+}
+
+#[test]
+fn pipeline_worker_root_override_is_none_in_the_default_split_root_layout() {
+    let paths = WorkspacePaths::new(
+        PathBuf::from("/repo"),
+        PathBuf::from("/repo/.orbit"),
+        PathBuf::from("/home/user/.orbit"),
+    );
+    assert_eq!(pipeline_worker_root_override(&paths), None);
+}
+
+#[test]
+fn pipeline_worker_root_override_forwards_a_pinned_global_store() {
+    let paths = WorkspacePaths::new(
+        PathBuf::from("/repo"),
+        PathBuf::from("/tmp/custom-orbit"),
+        PathBuf::from("/tmp/custom-orbit"),
+    );
+    assert_eq!(
+        pipeline_worker_root_override(&paths),
+        Some(Path::new("/tmp/custom-orbit"))
+    );
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Task

[ORB-10821](https://orbit-cli.com/tasks/ORB-10821) — orbit run job silently orphans the run when submitted with an explicit --root override

### Description

`orbit run job <job_id> --root <custom-root>` reports a successful submission (`State: submitted`) but the run never executes and stays `pending` forever with no visible error, because the detached pipeline worker process does not inherit the parent's `--root` flag.

**Root cause**

[ORB-10801] (commit fa44a710, "refactor: Make job runs asynchronous by default and retire agent backend selection") replaced the previous synchronous, in-process job execution (`runtime.run_job_v2_from_yaml`, which naturally honored whatever `--root` the parent process resolved) with an always-async model: `submit_job_run` persists the run and re-execs the same `orbit` binary as a detached worker (`crates/orbit-core/src/command/job/pipeline.rs::spawn_pipeline_worker` / `pipeline_worker_command` / `configure_pipeline_worker_command`, lines ~822-1153).

`configure_pipeline_worker_command` only sets `.current_dir(workspace)` on the child `Command` and appends `job run-pipeline-worker <run_id>` — it never forwards the parent's `--root` argument (see the comment at pipeline.rs:862-868: "Discover detached workers by registered cwd, never explicit --root"). The child process therefore falls back to its own default global-root resolution (`$HOME/.orbit`), which differs from the custom root the parent used to persist the run. The worker immediately exits with `error: job run not found: <run_id>` (visible only in `<orbit_root>/state/logs/<run_id>.worker.log`, which a normal user has no reason to check), while the parent CLI command already exited 0 and told the operator the run was submitted successfully.

Before ORB-10801, this composed fine because job execution happened synchronously in the same process instance that already had the correct `--root` resolved — there was no child-process re-exec step to lose the flag across.

**Reproduction (isolated environment, no production data touched)**

```
ORBIT_BIN=<path>/target/debug/orbit
TESTROOT=/tmp/orbit-qa-sweep-root
cd /tmp/orbit-qa-sweep-repo   # a git repo registered as a workspace under $TESTROOT via `orbit --root $TESTROOT workspace init`

$ORBIT_BIN --root $TESTROOT run job auto_task_scheduler_pipeline
# Job: auto_task_scheduler_pipeline
# Run ID: jrun-20260815-1901
# State: submitted

sleep 5
$ORBIT_BIN --root $TESTROOT run show jrun-20260815-1901
# State: pending   <-- stays pending forever, no error surfaced

cat $TESTROOT/state/logs/jrun-20260815-1901.worker.log
# error: job run not found: jrun-20260815-1901
```

For contrast, the same job submitted with the effective root communicated via `HOME` (which the child process *does* inherit) completes normally in ~29ms with `State: success`.

**Impact**

`--root` is a documented, top-level, "highest precedence" flag (`orbit --help`). Any real use of it for job submission (multi-tenant hosts, staging/test roots, CI harnesses that intentionally avoid `$HOME/.orbit`) now silently hangs every job run with a false-positive success message and no actionable error on the happy path. `--wait` would presumably also hang/timeout rather than surfacing the real cause.

**Suggested fix direction**

Either forward an explicit `--root` to the spawned worker command when the parent runtime was constructed with an explicit root override, or resolve/propagate root via an env var the child reliably inherits (mirroring how `HOME`-based resolution already works), and add an integration test pairing `--root` with `orbit run job` to lock in the fix.

### Acceptance Criteria

- configure_pipeline_worker_command emits `--root <global>` only when the parent runtime is pinned (global_dir == orbit_dir); the default split-root layout still has no `--root` on the worker argv
- cargo test -p orbit-core --lib command::tests::job_pipeline::pipeline_worker_command_discovers_registered_workspace_from_cwd and the new pinned-root argv test pass
- cargo test -p orbit-cli --test worktree_resolution run_job_with_explicit_root_completes_instead_of_staying_pending: orbit --root <custom> run job reaches a terminal success state rather than remaining pending

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Detached pipeline workers now inherit an explicit parent `--root`. `configure_pipeline_worker_command` emits `--root <global>` before `job run-pipeline-worker` when `pipeline_worker_root_override` sees a pinned runtime (`global_dir == orbit_dir`). The default split-root layout still uses cwd discovery only, so `$HOME/.orbit/orbit.db` is not abandoned.
- Unit tests lock both argv shapes (no `--root` vs forwarded `--root`) and the pin predicate.
- Integration test `run_job_with_explicit_root_completes_instead_of_staying_pending` submits a sleep-0 job via `orbit --root <custom> run job` from an isolated HOME and asserts the run reaches `success` instead of staying `pending`.

Strategic decisions:
- Infer the override from the existing pin invariant rather than adding a new `explicit_root` field on `OrbitRuntime`. `--root` is the only production path that sets `global_dir == orbit_dir`; `ORBIT_ROOT` still does not pin the global store and continues to work via env inheritance.

Assessment: Small, targeted fix at the spawn seam. The integration test exercises the real re-exec path that ORB-10801 lost.

Validation:
- `cargo test -p orbit-core --lib command::tests::job_pipeline` — 15 passed
- `cargo test -p orbit-cli --test worktree_resolution` — 3 passed
- `make ci-fast` — passed

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10821-6a80bd55`
- Behind base: 0
- Ahead of base: 1

*authored by: grok*