### PR TITLE
Re-scope epic_orchestrator to a code-editing finisher in the epic worktree

### DIFF
--- a/.orbit/resources/activities/epic_orchestrator.yaml
+++ b/.orbit/resources/activities/epic_orchestrator.yaml
@@ -5,71 +5,148 @@ metadata:
 spec:
   type: agent_loop
   description: >
-    No-code-change workspace drain agent. Shrinks the
-    `scan_unresolved_work` set by creating or triaging tasks, shipping
-    explicit ids through existing gate/auto pipelines, resuming or
-    cancelling failed runs, and writing the workspace session log.
-    It must not edit the repository or merge PRs reserved for the human
+    Epic worktree finisher. After children have merged into the epic branch,
+    validate the combined result, close integration gaps, and finish remaining
+    work in the assigned epic worktree. May author further children when
+    decomposition is warranted. Must not merge PRs reserved for the human
     merge authority.
   input_schema_json:
     type: object
+    required: [task_id]
     properties:
-      scan:
-        type: object
-      system_crew:
-        type: boolean
+      task_id:
+        type: string
+      workspace_path:
+        type: string
+      repo_root:
+        type: string
   output_schema_json:
     type: object
     properties:
       summary:
         type: string
+      diff:
+        type: string
+      skipped_reason:
+        type: string
   instruction: |
-    You are Orbit's workspace drain orchestrator.
+    You are Orbit's epic worktree finisher.
 
-    Input may include `scan` from the last `scan_unresolved_work` step
-    (`empty`, `task_ids`, `run_ids`, `check_later_ids`). Treat that as a
-    hint. Re-read live Orbit state before you act.
+    Tool access and durable state
 
-    Mandate: shrink the scan set. Do not edit repository files. Do not
-    merge pull requests reserved for the human merge authority. Do not invent approval
-    policy. Do not treat silence as new product authority.
+    - Use a granted `orbit.*` tool directly when wired. Otherwise use
+      `orbit tool run <tool.name> --input '<json>'` (or `--input-file` for large
+      input). The CLI has the same allowlist and caller-role gates; never use it
+      to reach an ungranted tool. Orbit tool writes are durable. Your final
+      response is advisory and is not a substitute for task updates.
 
-    Typical moves
-    - `orbit.task.show` / `orbit.task.list` / `orbit.search` to understand
-      leftover work.
-    - `orbit.session_log.list` (`unresolved_only: true`) at the start of
-      every fire. Append `status` or `note` as you go. File `check_later`
-      only when the next fire must wake on a reminder; `resolve` when the
-      reminder is done.
-    - Create children with `orbit.task.add`. Promote or reject `proposed`
-      only when the existing task already carries that decision.
-    - Ship explicit task ids. Prefer `orbit.workflow.ship`. If that tool
-      is denied because this invoke is a managed run, ship through
-      `orbit.pipeline.invoke` of `task_gate_pipeline` (or
-      `task_auto_pipeline` when no explicit ids need a gate) — do not
-      invent a second implement pipeline.
-    - Inspect failed or timeout runs with `orbit.workflow.run.show` /
-      `orbit.workflow.run.list`. Resume with `orbit.workflow.run.resume`
-      when that is safe; otherwise leave a precise `blocked` reason and
-      a `check_later` note.
+    Terminal-task guard
+
+    - Before reading anything else, inspect the injected task. If
+      `task.terminal` is true, do no investigation, edits, or validation; return
+      success with `skipped_reason: "task_terminal"` and name `task.status` in
+      the summary. This safely handles retries and work overtaken by another
+      actor.
+    - Re-read status with `orbit.task.show` before the first edit and before
+      validation. Apply the same stop rule if the fresh status refuses writes,
+      or if `orbit.task.update` rejects a write because the task became
+      terminal. Do not retry, work around it, or file friction for this
+      designed outcome.
+
+    Context and checkout
+
+    1. The injected epic root is authoritative for title, description,
+       acceptance criteria, plan, and context files. If it is absent or
+       malformed, recover it with `orbit.task.show`. Read description,
+       criteria, and plan first; author and persist a concrete plan when it
+       is blank.
+    2. Resolve every canonical `context_files` selector: read each `file:`
+       target with `fs.read`. For each `dir:` selector, do not call `fs.read`
+       on the directory; after verifying it resolves beneath the workspace
+       root, use `rg --files <directory>` to list it, then use `fs.read` for
+       its key files. Optionally run `orbit.search` with
+       `semantic: "<task-id>"`; skip when its companion is unavailable or no
+       result is relevant.
+    3. `input.workspace_path` and `input.repo_root` override task paths.
+       Before any write, obtain `pwd -P` and `git rev-parse --show-toplevel`.
+       Both supplied roots must resolve to that same canonical checkout.
+       Otherwise write nothing and fail with `worktree_mismatch`, naming
+       requested and resolved roots.
+
+    Mandate
+
+    4. You run inside the epic worktree after every current child has merged
+       into the epic branch — or immediately, when the epic has no children.
+       Validate the merged result, resolve conflicts and integration gaps,
+       finish whatever the children did not cover, and bring the epic to the
+       state its acceptance criteria describe.
+    5. Delegate chunks to subagents when useful. The CLI runner spawns the
+       provider CLI directly, so subagents are a provider capability, not new
+       Orbit machinery.
+    6. Author additional children with `orbit.task.add` (parent = this epic
+       root) only when decomposition is genuinely warranted. Do not ship,
+       dispatch, or wait on those children; the pipeline re-enters the drain
+       phase after you return. Do not call `orbit.workflow.ship` or
+       `orbit.pipeline.invoke`.
+    7. Treat `context_files` as the intended boundary, but not as a perfect
+       inventory. Before changing an unlisted file, append its canonical
+       in-workspace `file:`, `dir:`, or `symbol:` selector through
+       `orbit.task.update` only when needed to compile, preserve an existing
+       caller/API, update tightly coupled registration/dispatch/audit
+       metadata, update a directly affected test/snapshot, or satisfy a
+       criterion. Stop after a task comment if the target implies a new
+       dependency edge, out-of-scope behavior, broad refactor, or remains
+       ambiguous.
+    8. Do not park newly unused code behind `#[allow(dead_code)]` or
+       `#[allow(unused_imports)]`. Register third-party dependencies in root
+       `[workspace.dependencies]` and consume them with `.workspace = true`.
+
+    Session log
+
+    9. `orbit.session_log.list` (`unresolved_only: true`) at the start of
+       every invoke. Append `status` or `note` as you go. File `check_later`
+       only when the next fire must wake on a reminder; `resolve` when the
+       reminder is done. Conversation resume is out of v1.
 
     Hard bounds
-    - No git write, no worktree edit, no `agent_implement`, no filesystem
-      writes, no PR merge.
-    - Conversation resume is out of v1. Start from Orbit state plus the
-      session log.
-    - Return a short `summary` of what you shipped, resumed, created, or
-      left blocked. The job re-scans after you exit; that scan is
-      authoritative.
+
+    - No PR merge reserved for the human merge authority, no second
+      workspace, no invented approval policy, no writes outside this
+      epic worktree.
+    - Do not treat silence as new product authority.
+    - Do not `git commit`, push, or merge into the workspace base. Leave
+      finished edits in the worktree; the pipeline commits them. The
+      engine rejects a provider that moves HEAD.
+
+    Validation and handoff
+
+    10. Follow repository validation policy and run the smallest checks that
+        give real confidence. A sandbox/runner denial such as EPERM is not a
+        code failure: finish the implementation, record the exact skipped
+        check and denial in the execution summary, and return success so
+        unrestricted CI can arbitrate it. Report failed only for genuinely
+        incomplete/wrong work.
+    11. For a real blocker (missing dependency, contradictory requirements,
+        or an unresolvable conflict), use `orbit.task.update` to set
+        `blocked` with a reason.
+    12. The pipeline owns the epic root's lifecycle. Do not call
+        `orbit.task.start`, and do not move the epic to `review` or `done`.
+        Before returning, REQUIRED: persist a meaningful `execution_summary`
+        with `orbit.task.update`; downstream delivery reads that task field,
+        not your response. Return a short `summary` and include `diff` only
+        when cheap and accurate.
   tools:
     - orbit.task.*
     - orbit.session_log.*
     - orbit.search
-    - orbit.workflow.ship
-    - orbit.workflow.run.show
-    - orbit.workflow.run.list
-    - orbit.workflow.run.resume
-    - orbit.pipeline.invoke
-    - orbit.pipeline.wait
+    - fs.read
+    - fs.delete
+    - proc.spawn
+  proc_allowed_programs:
+    - git
+    - make
+    - cargo
+    - rg
+    - orbit
   on_denial: terminate
-  wall_clock_timeout_seconds: 7200
+  wall_clock_timeout_seconds: 10800

--- a/.orbit/resources/jobs/epic_pipeline.yaml
+++ b/.orbit/resources/jobs/epic_pipeline.yaml
@@ -1,9 +1,10 @@
-# Epic branch assembly [ORB-10816].
+# Epic branch assembly [ORB-10816 / ORB-10817].
 #
-# One epic owns one stable worktree and branch. Its unfinished descendants are
-# ordered once, then landed into that branch through serial local pipelines.
-# The epic root remains in-progress; later stages finish and deliver the
-# assembled branch.
+# One epic owns one stable worktree and branch. Unfinished descendants land
+# into that branch through serial local pipelines; the worktree finisher then
+# validates and completes the combined result. If the finisher authors a new
+# child, the assemble loop re-lists descendants and drains again. The epic
+# root remains in-progress; later stages deliver the assembled branch.
 
 schemaVersion: 2
 kind: Job
@@ -36,36 +37,66 @@ spec:
         base: "{{ steps.resolve_ship_input.output.base_branch }}"
         base_sync: remote
 
-    - id: descendants
-      spec:
-        type: deterministic
-        action: list_epic_descendants
-        config: {}
-      default_input:
-        epic_task_id: "{{ input.epic_task_id }}"
-
-    - id: drain
+    - id: assemble
       loop:
-        items: "{{ steps.descendants.output.task_ids }}"
-        max_iterations: 256
+        max_iterations: 8
+        break_when: "{{ steps.remaining.output.empty }} == true"
         steps:
-          - id: land_child
-            target: activity:invoke_and_wait
-            timeout_seconds: 7200
+          - id: descendants
+            spec:
+              type: deterministic
+              action: list_epic_descendants
+              config: {}
             default_input:
-              job_name: task_local_pipeline
-              run_input:
-                task_ids:
-                  - "{{ item }}"
-                base_branch: "{{ steps.worktree.output.head_ref }}"
-                base_sync: local
-                auto_push: false
-                landing_branch: "{{ steps.resolve_ship_input.output.base_branch }}"
-                terminal_status: done
-              timeout_seconds: 7200
+              epic_task_id: "{{ input.epic_task_id }}"
 
-          - id: require_child_success
-            target: activity:pipeline_success_guard
+          - id: drain
+            loop:
+              items: "{{ steps.descendants.output.task_ids }}"
+              max_iterations: 256
+              steps:
+                - id: land_child
+                  target: activity:invoke_and_wait
+                  timeout_seconds: 7200
+                  default_input:
+                    job_name: task_local_pipeline
+                    run_input:
+                      task_ids:
+                        - "{{ item }}"
+                      base_branch: "{{ steps.worktree.output.head_ref }}"
+                      base_sync: local
+                      auto_push: false
+                      landing_branch: "{{ steps.resolve_ship_input.output.base_branch }}"
+                      terminal_status: done
+                    timeout_seconds: 7200
+
+                - id: require_child_success
+                  target: activity:pipeline_success_guard
+                  default_input:
+                    context: epic child local pipeline
+                    result: "{{ steps.land_child.output }}"
+
+          - id: finish
+            target: activity:epic_orchestrator
             default_input:
-              context: epic child local pipeline
-              result: "{{ steps.land_child.output }}"
+              task_id: "{{ input.epic_task_id }}"
+              workspace_path: "{{ steps.worktree.output.workspace_path }}"
+              repo_root: "{{ steps.worktree.output.workspace_path }}"
+
+          - id: commit_finish
+            when: "{{ steps.descendants.output.empty }} == true"
+            target: activity:git_commit
+            default_input:
+              job_run_id: "{{ steps.worktree.output.job_run_id }}"
+              scope: all
+              workspace_path: "{{ steps.worktree.output.workspace_path }}"
+              base_ref: "{{ steps.worktree.output.base_ref }}"
+              base_sha: "{{ steps.worktree.output.base_sha }}"
+
+          - id: remaining
+            spec:
+              type: deterministic
+              action: list_epic_descendants
+              config: {}
+            default_input:
+              epic_task_id: "{{ input.epic_task_id }}"

--- a/crates/orbit-core/assets/activities/epic_orchestrator.yaml
+++ b/crates/orbit-core/assets/activities/epic_orchestrator.yaml
@@ -5,71 +5,148 @@ metadata:
 spec:
   type: agent_loop
   description: >
-    No-code-change workspace drain agent. Shrinks the
-    `scan_unresolved_work` set by creating or triaging tasks, shipping
-    explicit ids through existing gate/auto pipelines, resuming or
-    cancelling failed runs, and writing the workspace session log.
-    It must not edit the repository or merge PRs reserved for the human
+    Epic worktree finisher. After children have merged into the epic branch,
+    validate the combined result, close integration gaps, and finish remaining
+    work in the assigned epic worktree. May author further children when
+    decomposition is warranted. Must not merge PRs reserved for the human
     merge authority.
   input_schema_json:
     type: object
+    required: [task_id]
     properties:
-      scan:
-        type: object
-      system_crew:
-        type: boolean
+      task_id:
+        type: string
+      workspace_path:
+        type: string
+      repo_root:
+        type: string
   output_schema_json:
     type: object
     properties:
       summary:
         type: string
+      diff:
+        type: string
+      skipped_reason:
+        type: string
   instruction: |
-    You are Orbit's workspace drain orchestrator.
+    You are Orbit's epic worktree finisher.
 
-    Input may include `scan` from the last `scan_unresolved_work` step
-    (`empty`, `task_ids`, `run_ids`, `check_later_ids`). Treat that as a
-    hint. Re-read live Orbit state before you act.
+    Tool access and durable state
 
-    Mandate: shrink the scan set. Do not edit repository files. Do not
-    merge pull requests reserved for the human merge authority. Do not invent approval
-    policy. Do not treat silence as new product authority.
+    - Use a granted `orbit.*` tool directly when wired. Otherwise use
+      `orbit tool run <tool.name> --input '<json>'` (or `--input-file` for large
+      input). The CLI has the same allowlist and caller-role gates; never use it
+      to reach an ungranted tool. Orbit tool writes are durable. Your final
+      response is advisory and is not a substitute for task updates.
 
-    Typical moves
-    - `orbit.task.show` / `orbit.task.list` / `orbit.search` to understand
-      leftover work.
-    - `orbit.session_log.list` (`unresolved_only: true`) at the start of
-      every fire. Append `status` or `note` as you go. File `check_later`
-      only when the next fire must wake on a reminder; `resolve` when the
-      reminder is done.
-    - Create children with `orbit.task.add`. Promote or reject `proposed`
-      only when the existing task already carries that decision.
-    - Ship explicit task ids. Prefer `orbit.workflow.ship`. If that tool
-      is denied because this invoke is a managed run, ship through
-      `orbit.pipeline.invoke` of `task_gate_pipeline` (or
-      `task_auto_pipeline` when no explicit ids need a gate) — do not
-      invent a second implement pipeline.
-    - Inspect failed or timeout runs with `orbit.workflow.run.show` /
-      `orbit.workflow.run.list`. Resume with `orbit.workflow.run.resume`
-      when that is safe; otherwise leave a precise `blocked` reason and
-      a `check_later` note.
+    Terminal-task guard
+
+    - Before reading anything else, inspect the injected task. If
+      `task.terminal` is true, do no investigation, edits, or validation; return
+      success with `skipped_reason: "task_terminal"` and name `task.status` in
+      the summary. This safely handles retries and work overtaken by another
+      actor.
+    - Re-read status with `orbit.task.show` before the first edit and before
+      validation. Apply the same stop rule if the fresh status refuses writes,
+      or if `orbit.task.update` rejects a write because the task became
+      terminal. Do not retry, work around it, or file friction for this
+      designed outcome.
+
+    Context and checkout
+
+    1. The injected epic root is authoritative for title, description,
+       acceptance criteria, plan, and context files. If it is absent or
+       malformed, recover it with `orbit.task.show`. Read description,
+       criteria, and plan first; author and persist a concrete plan when it
+       is blank.
+    2. Resolve every canonical `context_files` selector: read each `file:`
+       target with `fs.read`. For each `dir:` selector, do not call `fs.read`
+       on the directory; after verifying it resolves beneath the workspace
+       root, use `rg --files <directory>` to list it, then use `fs.read` for
+       its key files. Optionally run `orbit.search` with
+       `semantic: "<task-id>"`; skip when its companion is unavailable or no
+       result is relevant.
+    3. `input.workspace_path` and `input.repo_root` override task paths.
+       Before any write, obtain `pwd -P` and `git rev-parse --show-toplevel`.
+       Both supplied roots must resolve to that same canonical checkout.
+       Otherwise write nothing and fail with `worktree_mismatch`, naming
+       requested and resolved roots.
+
+    Mandate
+
+    4. You run inside the epic worktree after every current child has merged
+       into the epic branch — or immediately, when the epic has no children.
+       Validate the merged result, resolve conflicts and integration gaps,
+       finish whatever the children did not cover, and bring the epic to the
+       state its acceptance criteria describe.
+    5. Delegate chunks to subagents when useful. The CLI runner spawns the
+       provider CLI directly, so subagents are a provider capability, not new
+       Orbit machinery.
+    6. Author additional children with `orbit.task.add` (parent = this epic
+       root) only when decomposition is genuinely warranted. Do not ship,
+       dispatch, or wait on those children; the pipeline re-enters the drain
+       phase after you return. Do not call `orbit.workflow.ship` or
+       `orbit.pipeline.invoke`.
+    7. Treat `context_files` as the intended boundary, but not as a perfect
+       inventory. Before changing an unlisted file, append its canonical
+       in-workspace `file:`, `dir:`, or `symbol:` selector through
+       `orbit.task.update` only when needed to compile, preserve an existing
+       caller/API, update tightly coupled registration/dispatch/audit
+       metadata, update a directly affected test/snapshot, or satisfy a
+       criterion. Stop after a task comment if the target implies a new
+       dependency edge, out-of-scope behavior, broad refactor, or remains
+       ambiguous.
+    8. Do not park newly unused code behind `#[allow(dead_code)]` or
+       `#[allow(unused_imports)]`. Register third-party dependencies in root
+       `[workspace.dependencies]` and consume them with `.workspace = true`.
+
+    Session log
+
+    9. `orbit.session_log.list` (`unresolved_only: true`) at the start of
+       every invoke. Append `status` or `note` as you go. File `check_later`
+       only when the next fire must wake on a reminder; `resolve` when the
+       reminder is done. Conversation resume is out of v1.
 
     Hard bounds
-    - No git write, no worktree edit, no `agent_implement`, no filesystem
-      writes, no PR merge.
-    - Conversation resume is out of v1. Start from Orbit state plus the
-      session log.
-    - Return a short `summary` of what you shipped, resumed, created, or
-      left blocked. The job re-scans after you exit; that scan is
-      authoritative.
+
+    - No PR merge reserved for the human merge authority, no second
+      workspace, no invented approval policy, no writes outside this
+      epic worktree.
+    - Do not treat silence as new product authority.
+    - Do not `git commit`, push, or merge into the workspace base. Leave
+      finished edits in the worktree; the pipeline commits them. The
+      engine rejects a provider that moves HEAD.
+
+    Validation and handoff
+
+    10. Follow repository validation policy and run the smallest checks that
+        give real confidence. A sandbox/runner denial such as EPERM is not a
+        code failure: finish the implementation, record the exact skipped
+        check and denial in the execution summary, and return success so
+        unrestricted CI can arbitrate it. Report failed only for genuinely
+        incomplete/wrong work.
+    11. For a real blocker (missing dependency, contradictory requirements,
+        or an unresolvable conflict), use `orbit.task.update` to set
+        `blocked` with a reason.
+    12. The pipeline owns the epic root's lifecycle. Do not call
+        `orbit.task.start`, and do not move the epic to `review` or `done`.
+        Before returning, REQUIRED: persist a meaningful `execution_summary`
+        with `orbit.task.update`; downstream delivery reads that task field,
+        not your response. Return a short `summary` and include `diff` only
+        when cheap and accurate.
   tools:
     - orbit.task.*
     - orbit.session_log.*
     - orbit.search
-    - orbit.workflow.ship
-    - orbit.workflow.run.show
-    - orbit.workflow.run.list
-    - orbit.workflow.run.resume
-    - orbit.pipeline.invoke
-    - orbit.pipeline.wait
+    - fs.read
+    - fs.delete
+    - proc.spawn
+  proc_allowed_programs:
+    - git
+    - make
+    - cargo
+    - rg
+    - orbit
   on_denial: terminate
-  wall_clock_timeout_seconds: 7200
+  wall_clock_timeout_seconds: 10800

--- a/crates/orbit-core/assets/jobs/epic_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/epic_pipeline.yaml
@@ -1,9 +1,10 @@
-# Epic branch assembly [ORB-10816].
+# Epic branch assembly [ORB-10816 / ORB-10817].
 #
-# One epic owns one stable worktree and branch. Its unfinished descendants are
-# ordered once, then landed into that branch through serial local pipelines.
-# The epic root remains in-progress; later stages finish and deliver the
-# assembled branch.
+# One epic owns one stable worktree and branch. Unfinished descendants land
+# into that branch through serial local pipelines; the worktree finisher then
+# validates and completes the combined result. If the finisher authors a new
+# child, the assemble loop re-lists descendants and drains again. The epic
+# root remains in-progress; later stages deliver the assembled branch.
 
 schemaVersion: 2
 kind: Job
@@ -36,36 +37,66 @@ spec:
         base: "{{ steps.resolve_ship_input.output.base_branch }}"
         base_sync: remote
 
-    - id: descendants
-      spec:
-        type: deterministic
-        action: list_epic_descendants
-        config: {}
-      default_input:
-        epic_task_id: "{{ input.epic_task_id }}"
-
-    - id: drain
+    - id: assemble
       loop:
-        items: "{{ steps.descendants.output.task_ids }}"
-        max_iterations: 256
+        max_iterations: 8
+        break_when: "{{ steps.remaining.output.empty }} == true"
         steps:
-          - id: land_child
-            target: activity:invoke_and_wait
-            timeout_seconds: 7200
+          - id: descendants
+            spec:
+              type: deterministic
+              action: list_epic_descendants
+              config: {}
             default_input:
-              job_name: task_local_pipeline
-              run_input:
-                task_ids:
-                  - "{{ item }}"
-                base_branch: "{{ steps.worktree.output.head_ref }}"
-                base_sync: local
-                auto_push: false
-                landing_branch: "{{ steps.resolve_ship_input.output.base_branch }}"
-                terminal_status: done
-              timeout_seconds: 7200
+              epic_task_id: "{{ input.epic_task_id }}"
 
-          - id: require_child_success
-            target: activity:pipeline_success_guard
+          - id: drain
+            loop:
+              items: "{{ steps.descendants.output.task_ids }}"
+              max_iterations: 256
+              steps:
+                - id: land_child
+                  target: activity:invoke_and_wait
+                  timeout_seconds: 7200
+                  default_input:
+                    job_name: task_local_pipeline
+                    run_input:
+                      task_ids:
+                        - "{{ item }}"
+                      base_branch: "{{ steps.worktree.output.head_ref }}"
+                      base_sync: local
+                      auto_push: false
+                      landing_branch: "{{ steps.resolve_ship_input.output.base_branch }}"
+                      terminal_status: done
+                    timeout_seconds: 7200
+
+                - id: require_child_success
+                  target: activity:pipeline_success_guard
+                  default_input:
+                    context: epic child local pipeline
+                    result: "{{ steps.land_child.output }}"
+
+          - id: finish
+            target: activity:epic_orchestrator
             default_input:
-              context: epic child local pipeline
-              result: "{{ steps.land_child.output }}"
+              task_id: "{{ input.epic_task_id }}"
+              workspace_path: "{{ steps.worktree.output.workspace_path }}"
+              repo_root: "{{ steps.worktree.output.workspace_path }}"
+
+          - id: commit_finish
+            when: "{{ steps.descendants.output.empty }} == true"
+            target: activity:git_commit
+            default_input:
+              job_run_id: "{{ steps.worktree.output.job_run_id }}"
+              scope: all
+              workspace_path: "{{ steps.worktree.output.workspace_path }}"
+              base_ref: "{{ steps.worktree.output.base_ref }}"
+              base_sha: "{{ steps.worktree.output.base_sha }}"
+
+          - id: remaining
+            spec:
+              type: deterministic
+              action: list_epic_descendants
+              config: {}
+            default_input:
+              epic_task_id: "{{ input.epic_task_id }}"

--- a/crates/orbit-core/src/command/activity.rs
+++ b/crates/orbit-core/src/command/activity.rs
@@ -211,7 +211,7 @@ backend = "cli"
 
         let expected = BTreeMap::from([
             ("agent_implement", ("codex", "gpt-5.6-sol".to_string())),
-            ("epic_orchestrator", ("codex", "gpt-5.6-terra".to_string())),
+            ("epic_orchestrator", ("codex", "gpt-5.6-sol".to_string())),
             (
                 "step_failure_recovery",
                 ("codex", "gpt-5.6-terra".to_string()),
@@ -229,7 +229,7 @@ backend = "cli"
             };
             let activity_input = match *name {
                 "task_pilot" => json!({ "crew": "luna" }),
-                "epic_orchestrator" | "step_failure_recovery" | "triage_failed_runs" => {
+                "step_failure_recovery" | "triage_failed_runs" => {
                     inject_system_crew_input(&runtime, &json!({ "system_crew": true }))
                         .expect("inject configured system crew")
                 }
@@ -577,7 +577,7 @@ backend = "cli"
     }
 
     #[test]
-    fn epic_orchestrator_is_cli_with_orbit_catalog_not_leaf_allowlist() {
+    fn epic_orchestrator_is_a_worktree_finisher_not_a_dispatcher() {
         let (_, yaml) = DEFAULT_ACTIVITY_FILES
             .iter()
             .find(|(name, _)| *name == "epic_orchestrator")
@@ -587,27 +587,74 @@ backend = "cli"
             include_str!("../../../../.orbit/resources/activities/epic_orchestrator.yaml"),
             "shipped and workspace epic_orchestrator activities must remain byte-identical"
         );
+        let lowered = yaml.to_ascii_lowercase();
+        for stale in [
+            "no-code-change",
+            "no code change",
+            "must not edit the repository",
+            "do not edit repository files",
+            "no git write",
+            "no worktree edit",
+            "no `agent_implement`",
+        ] {
+            assert!(
+                !lowered.contains(stale),
+                "stale dispatcher language remains: {stale}"
+            );
+        }
         let asset = load_activity_asset(yaml).expect("parse epic orchestrator");
+        assert_eq!(asset.spec.fs_profile.as_deref(), None);
         match asset.spec.spec {
             ActivityV2Spec::AgentLoop(spec) => {
-                assert_eq!(spec.wall_clock_timeout_seconds, 7200);
+                assert_eq!(spec.wall_clock_timeout_seconds, 10800);
                 assert_eq!(spec.on_denial, OnDenial::Terminate);
                 assert!(tool_allowed("orbit.task.add", &spec.tools));
+                assert!(tool_allowed("orbit.task.update", &spec.tools));
                 assert!(tool_allowed("orbit.session_log.append", &spec.tools));
                 assert!(tool_allowed("orbit.search", &spec.tools));
-                assert!(tool_allowed("orbit.workflow.ship", &spec.tools));
-                assert!(tool_allowed("orbit.workflow.run.resume", &spec.tools));
-                assert!(tool_allowed("orbit.pipeline.invoke", &spec.tools));
-                for denied in ["fs.write", "fs.patch", "fs.delete", "fs.read", "proc.spawn"] {
+                assert!(tool_allowed("fs.read", &spec.tools));
+                assert!(tool_allowed("fs.delete", &spec.tools));
+                assert!(tool_allowed("proc.spawn", &spec.tools));
+                for denied in [
+                    "orbit.workflow.ship",
+                    "orbit.workflow.run.resume",
+                    "orbit.pipeline.invoke",
+                    "orbit.pipeline.wait",
+                    "fs.write",
+                    "fs.patch",
+                ] {
                     assert!(
                         !tool_allowed(denied, &spec.tools),
-                        "orchestrator must not inherit the leaf implementer allowlist: {denied}"
+                        "finisher must not keep dispatcher or raw-write surfaces: {denied}"
                     );
                 }
-                assert!(spec.instruction.contains("shrink the scan set"));
-                assert!(spec.instruction.contains("human merge authority"));
-                assert!(!spec.instruction.contains("session resume"));
-                assert!(spec.proc_allowed_programs.is_none());
+                let instruction = spec
+                    .instruction
+                    .split_whitespace()
+                    .collect::<Vec<_>>()
+                    .join(" ")
+                    .to_lowercase();
+                assert!(instruction.contains("epic worktree finisher"));
+                assert!(instruction.contains("git rev-parse --show-toplevel"));
+                assert!(instruction.contains("worktree_mismatch"));
+                assert!(instruction.contains("pwd -p"));
+                assert!(instruction.contains("human merge authority"));
+                assert!(instruction.contains("execution_summary"));
+                assert!(instruction.contains("move the epic to `review`"));
+                assert!(!instruction.contains("session resume"));
+                assert!(!instruction.contains("shrink the scan set"));
+                assert_eq!(
+                    spec.proc_allowed_programs.as_deref(),
+                    Some(
+                        &[
+                            "git".to_string(),
+                            "make".to_string(),
+                            "cargo".to_string(),
+                            "rg".to_string(),
+                            "orbit".to_string(),
+                        ][..]
+                    )
+                );
             }
             other => panic!("expected agent_loop epic_orchestrator, got {other:?}"),
         }

--- a/crates/orbit-core/src/command/job/tests/catalog.rs
+++ b/crates/orbit-core/src/command/job/tests/catalog.rs
@@ -1057,7 +1057,7 @@ fn epic_pipeline_opens_one_stable_worktree_and_drains_children_serially() {
     );
     let asset = load_job_asset(yaml).expect("epic pipeline parses");
     assert_eq!(asset.spec.max_active_runs, 1);
-    assert_eq!(asset.spec.steps.len(), 4);
+    assert_eq!(asset.spec.steps.len(), 3);
 
     let JobV2StepBody::TargetRef(worktree) = &asset.spec.steps[1].body else {
         panic!("epic pipeline must set up its worktree before draining children");
@@ -1068,25 +1068,35 @@ fn epic_pipeline_opens_one_stable_worktree_and_drains_children_serially() {
     assert_eq!(worktree_input["branch_prefix"], "epic");
     assert_eq!(worktree_input["base_sync"], "remote");
 
-    let JobV2StepBody::Target(descendants) = &asset.spec.steps[2].body else {
-        panic!("epic pipeline must list descendants deterministically");
+    let JobV2StepBody::Loop { loop_ } = &asset.spec.steps[2].body else {
+        panic!("epic pipeline must assemble descendants and the finisher in one loop");
+    };
+    assert_eq!(loop_.max_iterations, 8);
+    assert_eq!(
+        loop_.break_when.as_deref(),
+        Some("{{ steps.remaining.output.empty }} == true")
+    );
+    assert_eq!(loop_.steps.len(), 5);
+
+    let JobV2StepBody::Target(descendants) = &loop_.steps[0].body else {
+        panic!("assemble loop must list descendants deterministically");
     };
     let ActivityV2Spec::Deterministic(descendants) = &descendants.spec else {
         panic!("epic descendant listing must be deterministic");
     };
     assert_eq!(descendants.action, "list_epic_descendants");
 
-    let JobV2StepBody::Loop { loop_ } = &asset.spec.steps[3].body else {
-        panic!("epic pipeline must drain descendants through a sequential loop");
+    let JobV2StepBody::Loop { loop_: drain } = &loop_.steps[1].body else {
+        panic!("assemble loop must drain descendants through a sequential loop");
     };
     assert_eq!(
-        loop_.items.as_deref(),
+        drain.items.as_deref(),
         Some("{{ steps.descendants.output.task_ids }}")
     );
-    assert_eq!(loop_.max_iterations, 256);
-    assert_eq!(loop_.steps.len(), 2);
-    let JobV2StepBody::TargetRef(land_child) = &loop_.steps[0].body else {
-        panic!("first loop body must invoke one child pipeline");
+    assert_eq!(drain.max_iterations, 256);
+    assert_eq!(drain.steps.len(), 2);
+    let JobV2StepBody::TargetRef(land_child) = &drain.steps[0].body else {
+        panic!("first drain body must invoke one child pipeline");
     };
     assert_eq!(land_child.target, "activity:invoke_and_wait");
     let child_input = &land_child.default_input.as_ref().expect("child input")["run_input"];
@@ -1101,6 +1111,47 @@ fn epic_pipeline_opens_one_stable_worktree_and_drains_children_serially() {
         child_input["landing_branch"],
         "{{ steps.resolve_ship_input.output.base_branch }}"
     );
+
+    let JobV2StepBody::TargetRef(finish) = &loop_.steps[2].body else {
+        panic!("assemble loop must invoke the epic finisher");
+    };
+    assert_eq!(finish.target, "activity:epic_orchestrator");
+    let finish_input = finish.default_input.as_ref().expect("finish input");
+    assert_eq!(finish_input["task_id"], "{{ input.epic_task_id }}");
+    for field in ["workspace_path", "repo_root"] {
+        assert_eq!(
+            finish_input[field], "{{ steps.worktree.output.workspace_path }}",
+            "epic finisher must pin {field} to the assigned epic worktree"
+        );
+    }
+
+    let commit_finish = &loop_.steps[3];
+    assert_eq!(commit_finish.id, "commit_finish");
+    assert_eq!(
+        commit_finish.when.as_deref(),
+        Some("{{ steps.descendants.output.empty }} == true")
+    );
+    let JobV2StepBody::TargetRef(commit_finish) = &commit_finish.body else {
+        panic!("empty-descendant finish must commit through git_commit");
+    };
+    assert_eq!(commit_finish.target, "activity:git_commit");
+    let commit_input = commit_finish.default_input.as_ref().expect("commit input");
+    assert_eq!(
+        commit_input["workspace_path"],
+        "{{ steps.worktree.output.workspace_path }}"
+    );
+    assert_eq!(
+        commit_input["base_sha"],
+        "{{ steps.worktree.output.base_sha }}"
+    );
+
+    let JobV2StepBody::Target(remaining) = &loop_.steps[4].body else {
+        panic!("assemble loop must re-list descendants after the finisher");
+    };
+    let ActivityV2Spec::Deterministic(remaining) = &remaining.spec else {
+        panic!("remaining descendant listing must be deterministic");
+    };
+    assert_eq!(remaining.action, "list_epic_descendants");
 }
 
 fn collect_agent_loop_step_ids<'a>(

--- a/crates/orbit-core/src/command/job/tests/exec.rs
+++ b/crates/orbit-core/src/command/job/tests/exec.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -148,16 +149,22 @@ fn try_execute_named_job(
     execute_job_with_resume(&job, input, run_id, writer, host, None)
 }
 
-fn try_execute_epic_drain_job(
-    runtime: &OrbitRuntime,
-    repo_root: &Path,
-    host: &dyn RuntimeHost,
-    input: Value,
-    run_id: &str,
-) -> Result<JobOutcome, DispatchError> {
-    let mut job = resolved_job(runtime, "epic_pipeline");
-    job.steps.drain(..2);
-    let JobV2StepBody::Loop { loop_ } = &mut job.steps[1].body else {
+fn epic_assemble_steps(
+    job: &orbit_common::types::activity_job::JobV2,
+) -> &[orbit_common::types::activity_job::JobV2Step] {
+    let assemble = job
+        .steps
+        .iter()
+        .find(|step| step.id == "assemble")
+        .expect("epic assemble step");
+    let JobV2StepBody::Loop { loop_ } = &assemble.body else {
+        panic!("epic assemble step");
+    };
+    &loop_.steps
+}
+
+fn patch_epic_child_run_input(drain: &mut orbit_common::types::activity_job::JobV2Step) {
+    let JobV2StepBody::Loop { loop_ } = &mut drain.body else {
         panic!("epic drain step");
     };
     let JobV2StepBody::Target(land_child) = &mut loop_.steps[0].body else {
@@ -177,6 +184,80 @@ fn try_execute_epic_drain_job(
         "landing_branch".to_string(),
         Value::String("agent-main".to_string()),
     );
+}
+
+fn stub_epic_finisher(global_root: &Path) {
+    std::fs::write(
+        global_root.join("resources/activities/epic_orchestrator.yaml"),
+        r#"schemaVersion: 2
+kind: Activity
+metadata:
+  name: epic_orchestrator
+spec:
+  type: deterministic
+  description: Test stub for the epic worktree finisher.
+  input_schema_json:
+    type: object
+  output_schema_json:
+    type: object
+  action: test_epic_finish
+  config: {}
+"#,
+    )
+    .expect("stub epic finisher activity");
+}
+
+fn git_in(path: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .current_dir(path)
+        .args(args)
+        .output()
+        .unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn init_git_repo(path: &Path) {
+    git_in(path, &["init"]);
+    git_in(path, &["config", "user.name", "Orbit Test"]);
+    git_in(
+        path,
+        &["config", "user.email", "orbit-test@example.invalid"],
+    );
+    std::fs::write(path.join("README.md"), "base\n").expect("write initial file");
+    git_in(path, &["add", "README.md"]);
+    git_in(path, &["commit", "-m", "initial"]);
+    git_in(path, &["checkout", "-b", "epic/ORB-EMPTY-EPIC"]);
+}
+
+fn git_subject(path: &Path) -> String {
+    let output = Command::new("git")
+        .current_dir(path)
+        .args(["log", "-1", "--format=%s"])
+        .output()
+        .expect("git log");
+    assert!(
+        output.status.success(),
+        "git log failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("git subject utf8")
+        .trim()
+        .to_string()
+}
+
+fn try_execute_epic_job(
+    runtime: &OrbitRuntime,
+    repo_root: &Path,
+    host: &dyn RuntimeHost,
+    job: orbit_common::types::activity_job::JobV2,
+    input: Value,
+    run_id: &str,
+) -> Result<JobOutcome, DispatchError> {
     let writer = V2AuditWriter::with_disk_sinks(
         &runtime.paths().audit_dir,
         runtime
@@ -191,6 +272,81 @@ fn try_execute_epic_drain_job(
     )
     .expect("audit writer");
     execute_job_with_resume(&job, input, run_id, writer, host, None)
+}
+
+fn try_execute_epic_drain_job(
+    runtime: &OrbitRuntime,
+    repo_root: &Path,
+    host: &dyn RuntimeHost,
+    input: Value,
+    run_id: &str,
+) -> Result<JobOutcome, DispatchError> {
+    let mut job = resolved_job(runtime, "epic_pipeline");
+    let assemble_steps = epic_assemble_steps(&job);
+    let descendants = assemble_steps
+        .iter()
+        .find(|step| step.id == "descendants")
+        .cloned()
+        .expect("descendants");
+    let mut drain = assemble_steps
+        .iter()
+        .find(|step| step.id == "drain")
+        .cloned()
+        .expect("drain");
+    patch_epic_child_run_input(&mut drain);
+    job.steps = vec![descendants, drain];
+    try_execute_epic_job(runtime, repo_root, host, job, input, run_id)
+}
+
+fn patch_assemble_for_scripted_host(
+    assemble: &mut orbit_common::types::activity_job::JobV2Step,
+    workspace: &Path,
+) {
+    let JobV2StepBody::Loop { loop_ } = &mut assemble.body else {
+        panic!("epic assemble step");
+    };
+    loop_.steps.retain(|step| step.id != "commit_finish");
+    for step in &mut loop_.steps {
+        match step.id.as_str() {
+            "drain" => patch_epic_child_run_input(step),
+            "finish" => {
+                let JobV2StepBody::Target(finish) = &mut step.body else {
+                    panic!("resolved epic finish step");
+                };
+                let input = finish
+                    .default_input
+                    .as_mut()
+                    .and_then(Value::as_object_mut)
+                    .expect("finish input");
+                let workspace = workspace.display().to_string();
+                input.insert(
+                    "workspace_path".to_string(),
+                    Value::String(workspace.clone()),
+                );
+                input.insert("repo_root".to_string(), Value::String(workspace));
+            }
+            _ => {}
+        }
+    }
+}
+
+fn try_execute_epic_assemble_job(
+    runtime: &OrbitRuntime,
+    repo_root: &Path,
+    host: &dyn RuntimeHost,
+    input: Value,
+    run_id: &str,
+) -> Result<JobOutcome, DispatchError> {
+    let mut job = resolved_job(runtime, "epic_pipeline");
+    let mut assemble = job
+        .steps
+        .iter()
+        .find(|step| step.id == "assemble")
+        .cloned()
+        .expect("assemble");
+    patch_assemble_for_scripted_host(&mut assemble, repo_root);
+    job.steps = vec![assemble];
+    try_execute_epic_job(runtime, repo_root, host, job, input, run_id)
 }
 
 const WORKTREE_FIXTURE_FAILURE: &str = "fixture: worktree setup exploded";
@@ -493,7 +649,9 @@ impl RuntimeHost for ScriptedGateHost<'_> {
 
 struct ScriptedEpicHost<'a> {
     runtime: &'a OrbitRuntime,
-    descendant_ids: Vec<String>,
+    descendant_ids: Mutex<Vec<String>>,
+    finish_authored_child: Option<String>,
+    commit_on_finish: bool,
     calls: Mutex<Vec<(String, Value)>>,
 }
 
@@ -501,9 +659,21 @@ impl<'a> ScriptedEpicHost<'a> {
     fn new(runtime: &'a OrbitRuntime, descendant_ids: Vec<String>) -> Self {
         Self {
             runtime,
-            descendant_ids,
+            descendant_ids: Mutex::new(descendant_ids),
+            finish_authored_child: None,
+            commit_on_finish: false,
             calls: Mutex::new(Vec::new()),
         }
+    }
+
+    fn author_child_on_first_finish(mut self, child_id: impl Into<String>) -> Self {
+        self.finish_authored_child = Some(child_id.into());
+        self
+    }
+
+    fn commit_on_finish(mut self) -> Self {
+        self.commit_on_finish = true;
+        self
     }
 
     fn inputs_for(&self, action: &str) -> Vec<Value> {
@@ -514,6 +684,10 @@ impl<'a> ScriptedEpicHost<'a> {
             .filter(|(recorded, _)| recorded == action)
             .map(|(_, input)| input.clone())
             .collect()
+    }
+
+    fn current_descendants(&self) -> Vec<String> {
+        self.descendant_ids.lock().expect("descendant ids").clone()
     }
 }
 
@@ -542,16 +716,64 @@ impl RuntimeHost for ScriptedEpicHost<'_> {
                 "base_ref": "origin/agent-main",
                 "base_sha": "1111111111111111111111111111111111111111",
             })),
-            "list_epic_descendants" => Ok(json!({
-                "epic_task_id": "ORB-EPIC",
-                "task_count": self.descendant_ids.len(),
-                "task_ids": self.descendant_ids,
-                "empty": self.descendant_ids.is_empty(),
-            })),
-            "invoke_and_wait" => Ok(json!({
-                "run_id": "jrun-scripted-epic-child",
-                "status": "succeeded",
-            })),
+            "list_epic_descendants" => {
+                let descendant_ids = self.current_descendants();
+                Ok(json!({
+                    "epic_task_id": input
+                        .get("epic_task_id")
+                        .and_then(Value::as_str)
+                        .unwrap_or("ORB-EPIC"),
+                    "task_count": descendant_ids.len(),
+                    "task_ids": descendant_ids,
+                    "empty": descendant_ids.is_empty(),
+                }))
+            }
+            "invoke_and_wait" => {
+                if let Some(task_ids) = input
+                    .get("run_input")
+                    .and_then(|value| value.get("task_ids"))
+                    .and_then(Value::as_array)
+                {
+                    self.descendant_ids
+                        .lock()
+                        .expect("descendant ids")
+                        .retain(|id| {
+                            !task_ids
+                                .iter()
+                                .any(|value| value.as_str() == Some(id.as_str()))
+                        });
+                }
+                Ok(json!({
+                    "run_id": "jrun-scripted-epic-child",
+                    "status": "succeeded",
+                }))
+            }
+            "test_epic_finish" => {
+                let finish_count = self.inputs_for("test_epic_finish").len();
+                if finish_count == 1
+                    && let Some(child_id) = &self.finish_authored_child
+                {
+                    self.descendant_ids
+                        .lock()
+                        .expect("descendant ids")
+                        .push(child_id.clone());
+                }
+                if self.commit_on_finish {
+                    let workspace = input
+                        .get("workspace_path")
+                        .and_then(Value::as_str)
+                        .expect("finisher workspace_path");
+                    let workspace = Path::new(workspace);
+                    std::fs::write(workspace.join("finisher.txt"), "finisher work\n")
+                        .expect("write finisher file");
+                    git_in(workspace, &["add", "finisher.txt"]);
+                    git_in(
+                        workspace,
+                        &["commit", "-m", "finisher: close remaining epic work"],
+                    );
+                }
+                Ok(json!({ "summary": "finished" }))
+            }
             "pipeline_success_guard" => <OrbitRuntime as RuntimeHost>::run_deterministic(
                 self.runtime,
                 action,
@@ -853,6 +1075,69 @@ fn epic_pipeline_with_no_children_runs_no_child_pipeline() {
     assert!(outcome.success);
     assert!(host.inputs_for("invoke_and_wait").is_empty());
     assert!(host.inputs_for("pipeline_success_guard").is_empty());
+}
+
+#[test]
+fn epic_pipeline_with_no_children_runs_finisher_and_keeps_its_commits() {
+    let (_root, runtime, _repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    stub_epic_finisher(&global_root);
+    init_git_repo(&runtime.paths().repo_root);
+    let host = ScriptedEpicHost::new(&runtime, Vec::new()).commit_on_finish();
+
+    let outcome = try_execute_epic_assemble_job(
+        &runtime,
+        &runtime.paths().repo_root,
+        &host,
+        json!({ "epic_task_id": "ORB-EMPTY-EPIC" }),
+        "jrun-scripted-empty-epic-finish",
+    )
+    .expect("execute empty epic pipeline");
+
+    assert!(outcome.success);
+    assert!(host.inputs_for("invoke_and_wait").is_empty());
+    let finishes = host.inputs_for("test_epic_finish");
+    assert_eq!(finishes.len(), 1);
+    assert_eq!(
+        finishes[0]["workspace_path"],
+        runtime.paths().repo_root.display().to_string()
+    );
+    assert_eq!(finishes[0]["repo_root"], finishes[0]["workspace_path"]);
+    assert_eq!(
+        git_subject(&runtime.paths().repo_root),
+        "finisher: close remaining epic work"
+    );
+    assert_eq!(
+        std::fs::read_to_string(runtime.paths().repo_root.join("finisher.txt"))
+            .expect("read finisher file"),
+        "finisher work\n"
+    );
+}
+
+#[test]
+fn epic_pipeline_reenters_drain_when_finisher_authors_a_child() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    stub_epic_finisher(&global_root);
+    let host = ScriptedEpicHost::new(&runtime, vec!["ORB-CHILD-1".to_string()])
+        .author_child_on_first_finish("ORB-AUTHORED");
+
+    let outcome = try_execute_epic_assemble_job(
+        &runtime,
+        &repo_root,
+        &host,
+        json!({ "epic_task_id": "ORB-EPIC" }),
+        "jrun-scripted-epic-reenter",
+    )
+    .expect("execute epic pipeline with authored child");
+
+    assert!(outcome.success);
+    let invokes = host.inputs_for("invoke_and_wait");
+    assert_eq!(invokes.len(), 2);
+    assert_eq!(invokes[0]["run_input"]["task_ids"], json!(["ORB-CHILD-1"]));
+    assert_eq!(invokes[1]["run_input"]["task_ids"], json!(["ORB-AUTHORED"]));
+    assert_eq!(host.inputs_for("test_epic_finish").len(), 2);
+    assert!(host.current_descendants().is_empty());
 }
 
 #[cfg(unix)]

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -10,7 +10,9 @@ use std::time::Duration;
 
 use orbit_agent::loop_engine::audit::AuditSink;
 use orbit_common::test_fixtures::TEST_CODEX_MODEL;
-use orbit_common::types::activity_job::{JobV2StepBody, V2AuditEventKind, load_job_asset};
+use orbit_common::types::activity_job::{
+    ActivityV2Spec, JobV2StepBody, V2AuditEventKind, load_activity_asset, load_job_asset,
+};
 #[cfg(target_os = "linux")]
 use orbit_exec::probe_bwrap;
 use orbit_store::Store;
@@ -1117,6 +1119,10 @@ const TASK_LOCAL_PIPELINE_YAML: &str =
     include_str!("../../../../../../.orbit/resources/jobs/task_local_pipeline.yaml");
 const TASK_PR_PIPELINE_YAML: &str =
     include_str!("../../../../../../.orbit/resources/jobs/task_pr_pipeline.yaml");
+const EPIC_PIPELINE_YAML: &str =
+    include_str!("../../../../../../.orbit/resources/jobs/epic_pipeline.yaml");
+const EPIC_ORCHESTRATOR_YAML: &str =
+    include_str!("../../../../../../.orbit/resources/activities/epic_orchestrator.yaml");
 
 #[test]
 fn actual_ship_pipeline_implementers_run_for_each_provider_and_stay_in_the_worktree() {
@@ -1177,6 +1183,88 @@ printf '%s\n' '{{"schemaVersion":1,"status":"success","result":{{}},"error":null
         ]),
         "the matrix must load and render both committed shipment assets"
     );
+}
+
+#[test]
+fn epic_orchestrator_finisher_writes_stay_in_the_epic_worktree() {
+    let fixture = linked_worktree_fixture();
+    let assigned = fixture.assigned.display().to_string();
+    let script = fixture.root().join("codex");
+    write_executable(
+        &script,
+        &format!(
+            r#"#!/bin/sh
+cat > /dev/null
+test "$(pwd -P)" = '{assigned}' || exit 41
+test "$(git rev-parse --show-toplevel)" = '{assigned}' || exit 42
+printf '%s\n' 'finisher work' > finisher.txt
+printf '%s\n' '{{"schemaVersion":1,"status":"success","result":{{}},"error":null}}'
+"#
+        ),
+    );
+    let mut host = TestHost::with_command(script.display().to_string());
+    host.workspace_root = Some(fixture.primary.clone());
+    let input = rendered_finish_input_from_epic_pipeline(&fixture.assigned, "ORB-EPIC-FINISH");
+    let spec = epic_orchestrator_spec(Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "run-epic-finisher",
+        test_audit("run-epic-finisher", "codex"),
+        &input,
+        None,
+    )
+    .expect("epic finisher invocation");
+
+    assert!(outcome.success);
+    assert_eq!(
+        fs::read_to_string(fixture.assigned.join("finisher.txt")).expect("assigned finisher write"),
+        "finisher work\n"
+    );
+    assert!(
+        !fixture.primary.join("finisher.txt").exists(),
+        "finisher must not write the registered primary checkout"
+    );
+}
+
+#[test]
+fn epic_orchestrator_declared_root_mismatch_fails_before_provider_spawn() {
+    let fixture = linked_worktree_fixture();
+    let marker = fixture.root().join("provider-started");
+    let script = fixture.root().join("codex");
+    write_executable(
+        &script,
+        &format!(
+            "#!/bin/sh\nprintf started > '{}'\nexit 0\n",
+            marker.display()
+        ),
+    );
+    let mut host = TestHost::with_command(script.display().to_string());
+    host.workspace_root = Some(fixture.primary.clone());
+    let mut input =
+        rendered_finish_input_from_epic_pipeline(&fixture.assigned, "ORB-EPIC-MISMATCH");
+    input["repo_root"] = serde_json::json!(fixture.primary);
+    let spec = epic_orchestrator_spec(Duration::from_secs(5));
+    let audit = test_audit("run-epic-finisher-mismatch", "codex");
+
+    let error = run_cli_backend(
+        &host,
+        &spec,
+        "run-epic-finisher-mismatch",
+        audit.clone(),
+        &input,
+        None,
+    )
+    .expect_err("mismatched epic finisher roots must fail closed");
+
+    assert_worktree_mismatch(
+        &error,
+        "ORB-EPIC-MISMATCH",
+        "run-epic-finisher-mismatch",
+        "different Git checkouts",
+    );
+    assert_pre_spawn_failure(&audit, &marker);
 }
 
 #[test]
@@ -2557,6 +2645,68 @@ fn rendered_implement_input_from_asset(
     assert_eq!(rendered["workspace_path"], assigned);
     assert_eq!(rendered["repo_root"], assigned);
     (asset.name, rendered)
+}
+
+fn rendered_finish_input_from_epic_pipeline(
+    assigned_root: &Path,
+    task_id: &str,
+) -> serde_json::Value {
+    let asset = load_job_asset(EPIC_PIPELINE_YAML).expect("epic pipeline parses");
+    let assemble = asset
+        .spec
+        .steps
+        .iter()
+        .find(|step| step.id == "assemble")
+        .expect("epic pipeline has assemble");
+    let JobV2StepBody::Loop { loop_ } = &assemble.body else {
+        panic!("epic assemble must be a loop");
+    };
+    let finish = loop_
+        .steps
+        .iter()
+        .find(|step| step.id == "finish")
+        .expect("epic assemble has finish");
+    let JobV2StepBody::TargetRef(finish) = &finish.body else {
+        panic!("epic finish must reference epic_orchestrator");
+    };
+    assert_eq!(finish.target, "activity:epic_orchestrator");
+    let template_input = finish
+        .default_input
+        .as_ref()
+        .expect("epic_orchestrator default input");
+    for field in ["workspace_path", "repo_root"] {
+        assert_eq!(
+            template_input[field], "{{ steps.worktree.output.workspace_path }}",
+            "epic finisher must source {field} from the assigned worktree"
+        );
+    }
+
+    let assigned = assigned_root.display().to_string();
+    let mut steps = HashMap::new();
+    steps.insert(
+        "worktree".to_string(),
+        serde_json::json!({ "output": { "workspace_path": assigned } }),
+    );
+    let context = TemplateContext {
+        input: serde_json::json!({ "epic_task_id": task_id }),
+        steps,
+        ..TemplateContext::default()
+    };
+    let rendered = render_asset_value(template_input, &context);
+    assert_eq!(rendered["task_id"], task_id);
+    assert_eq!(rendered["workspace_path"], assigned);
+    assert_eq!(rendered["repo_root"], assigned);
+    rendered
+}
+
+fn epic_orchestrator_spec(timeout: Duration) -> orbit_common::types::activity_job::AgentLoopSpec {
+    let asset = load_activity_asset(EPIC_ORCHESTRATOR_YAML).expect("parse epic orchestrator");
+    let ActivityV2Spec::AgentLoop(mut spec) = asset.spec.spec else {
+        panic!("epic_orchestrator must be an agent_loop");
+    };
+    spec.wall_clock_timeout_seconds = timeout.as_secs();
+    spec.provider = orbit_common::types::activity_job::Provider::Codex;
+    spec
 }
 
 fn render_asset_value(value: &serde_json::Value, context: &TemplateContext) -> serde_json::Value {


### PR DESCRIPTION
## Task

[ORB-10817](https://orbit-cli.com/tasks/ORB-10817) — Re-scope epic_orchestrator to a code-editing finisher in the epic worktree

### Description

## Problem

`epic_orchestrator` is a no-code-change dispatcher: its allowlist is task/workflow/search/session-log
and its instruction forbids git writes, worktree edits, and `agent_implement`. Every code change it
wants must be routed through a child task and a separate pipeline. That was the right shape when the
epic had no worktree of its own; it is now the constraint that makes an epic slower and more
fragmented than doing the work directly.

## Why It Matters

Sub-task breakdown becomes **optional** under this design. A human or a higher-up orchestrator
decomposes an epic when the decomposition is genuinely useful. Otherwise the epic is a single root
with no children, and the finisher does the entire body of work itself with subagents. An agent that
can only file and dispatch tasks cannot do that.

## What To Build

Rewrite the `epic_orchestrator` activity to run **inside the epic worktree** created by ORB-10816,
after every child has merged into the epic branch:

- Grant it worktree-scoped write access and process execution on the same footing as
  `agent_implement` (`fs.read`, `fs.delete`, `proc.spawn` with the repo's allowed programs), plus
  the existing `orbit.task.*` / `orbit.search` / `orbit.session_log.*` surface.
- Instruction: validate the merged result of the children, resolve conflicts and integration gaps,
  finish whatever the children did not cover, and bring the epic to the state its acceptance
  criteria describe. Delegate chunks to subagents when useful — the CLI runner spawns the provider
  CLI directly, so subagents are a provider capability, not new Orbit machinery.
- It may author additional children when decomposition is genuinely warranted; the pipeline loops
  back to the drain phase when it does.
- Keep the hard bounds that still apply: no PR merge, no second workspace, no approval-policy
  invention, and no writes outside the epic worktree.

## Constraints / Notes

- The worktree-mismatch guard in `agent_implement` (compare `pwd -P` and
  `git rev-parse --show-toplevel` against the supplied roots before any write) is the pattern to
  copy — the finisher must refuse to write outside its epic worktree.
- Sandbox mount anchors are derived from the effective policy profile at spawn time
  (`spawn_linux_bwrap`), not from `worktree_setup`; confirm the epic worktree is actually writable
  under the resolved profile before assuming the grant works.
- The task's own lifecycle transitions stay owned by the pipeline. The finisher persists an
  `execution_summary` and returns; it must not move the epic root to `review`/`done` itself.
- `wall_clock_timeout_seconds` needs re-tuning for a working agent rather than a dispatcher.

### Acceptance Criteria

- An epic root with no children runs to a delivered branch carrying the finisher's own commits.
- The finisher's writes land in the epic worktree; an attempted write outside it fails the activity with a worktree-mismatch style error rather than succeeding.
- A finisher run that authors a new child task causes the pipeline to re-enter the drain phase and land that child before delivery.
- The activity's `tools` allowlist and instruction no longer claim it cannot edit the repository, and no stale 'no-code-change' language remains in the asset or in `docs/design/resident-orchestrator/2_design.md` §2.
- A denied tool call still terminates the activity (`on_denial: terminate` preserved).
- `cargo test -p orbit-core` passes and the shipped/workspace activity assets stay byte-identical.
- `make ci-fast` and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Rewrote `epic_orchestrator` from a no-code-change dispatcher into a worktree-scoped finisher on the same footing as `agent_implement` (`fs.read`/`fs.delete`/`proc.spawn` plus `orbit.task.*`/`orbit.search`/`orbit.session_log.*`). Dropped `orbit.workflow.*`/`orbit.pipeline.*`. Timeout 10800s. `on_denial: terminate` kept. Run crew, not system_crew.
- Instruction now validates merged children, finishes remaining work, may `orbit.task.add` further children, and copies the `pwd -P` / `git rev-parse --show-toplevel` worktree-mismatch guard. It must not merge PRs, write outside the epic worktree, or move the epic to review/done.
- `epic_pipeline` now wraps drain + finish in an `assemble` loop that re-lists descendants after the finisher (`break_when` remaining.empty). Finish is pinned to `steps.worktree.output.workspace_path` for both roots. A `commit_finish` `git_commit` step runs only when the iteration started with no children (HEAD still equals the setup checkpoint).
- Tests: activity allowlist/byte-identity; pipeline assemble/re-entry; no-child finisher commits; engine writes stay in the assigned worktree and a mismatched pair fails `worktree_mismatch` before spawn.
- `docs/design/resident-orchestrator/2_design.md` §2 already described this shape; no stale no-code-change language remained there.
Assessment: Acceptance criteria are met at the activity, pipeline, and engine-guard layers. Delivery (PR/local merge, leftover fail-closed) stays with ORB-10818.
Strategic decisions:
- Do not let the CLI agent `git commit`. The runner treats HEAD movement as `worktree_content_conflict` (F2026-08-076). The pipeline commits no-child leftover work; child-then-finish diffs wait for delivery.
- Extra files (`epic_pipeline` + tests) were added so a no-child epic can actually run the finisher and so an authored child re-enters drain.
Design weaknesses / risks:
- Severity: medium. `commit_finish` only covers the no-child iteration. After children land, HEAD != setup `base_sha`, so leftover finisher edits are uncommitted until ORB-10818. Mitigation: documented in the friction record and execution summary.
- Severity: low. A no-child finisher that only authors a child and writes nothing will fail `git_commit`'s empty-stage gate. Mitigation: that path is not an acceptance case; typical author-child happens after an existing drain (`descendants` non-empty, commit skipped).
Deviations from original plan:
- Pipeline `git_commit` added after discovering the CLI cannot commit. Justification: otherwise AC1 cannot hold on the real runner.
Recommended follow-ups:
- ORB-10818 should decide how to commit leftover finisher edits after children have already advanced HEAD.
Validation:
- `cargo test -p orbit-core --lib epic_ …` and related catalog/routing tests passed.
- `cargo test -p orbit-engine --lib epic_orchestrator` passed.
- Full `cargo test -p orbit-core`: 751 passed; 1 unrelated pre-existing failure (`dogfood_task_pilot_routine_matches_the_rendered_default_template`: workspace routine `enabled: true` vs seeded `false`). Not caused by this change.
- `make ci-fast` and `make ci-lint` passed.
- Shipped and workspace activity/job YAML stay byte-identical.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10817-6a80bd55`
- Behind base: 0
- Ahead of base: 1