### PR TITLE
fix: Restore green CI on agent-main — retired replay feature and PATH-dependent crew seeding

### DIFF
--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -39,6 +39,30 @@ struct McpWorkspace {
     work: PathBuf,
 }
 
+/// Write an executable no-op named `name` into `bin`, standing in for an agent
+/// CLI during detection. Nothing in these tests dispatches an agent, so the
+/// stub only has to exist and be executable.
+fn plant_agent_cli_stub(bin: &Path, name: &str) {
+    std::fs::create_dir_all(bin).expect("create stub CLI directory");
+    let stub = bin.join(name);
+    std::fs::write(&stub, "#!/bin/sh\nexit 0\n").expect("write stub agent CLI");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755))
+            .expect("mark the stub agent CLI executable");
+    }
+}
+
+/// `PATH` with the fixture's stub directory first, so agent detection sees the
+/// stubs regardless of what the host has installed.
+fn stub_first_path(bin: &Path) -> std::ffi::OsString {
+    let inherited = std::env::var_os("PATH").unwrap_or_default();
+    let mut entries = vec![bin.to_path_buf()];
+    entries.extend(std::env::split_paths(&inherited));
+    std::env::join_paths(entries).expect("join PATH entries")
+}
+
 impl McpWorkspace {
     fn init() -> Self {
         let temp = tempdir().expect("tempdir");
@@ -46,6 +70,13 @@ impl McpWorkspace {
         let work = temp.path().join("work");
         std::fs::create_dir_all(&home).expect("create home");
         std::fs::create_dir_all(&work).expect("create work");
+
+        // `orbit init` freezes crew seeding to the agent CLIs it finds on
+        // `PATH` (ADR-0193), so the fixture plants a stub `codex` before it
+        // runs. Without one, a host with no agent CLI installed — every CI
+        // runner — seeds an empty `[crews]` table, and any task naming a crew
+        // is rejected with `crew '<name>' is not defined in [crews.*]`.
+        plant_agent_cli_stub(&Self::stub_bin_dir(&home), "codex");
 
         let output = Command::new("git")
             .args(["init", "--quiet"])
@@ -92,10 +123,17 @@ impl McpWorkspace {
         }
     }
 
+    /// Directory holding the fixture's stub agent CLIs, derived from `home` so
+    /// every `orbit` invocation resolves the same one.
+    fn stub_bin_dir(home: &Path) -> PathBuf {
+        home.join("stub-bin")
+    }
+
     fn orbit_command(work: &Path, home: &Path) -> Command {
         let mut command = Command::new(env!("CARGO_BIN_EXE_orbit"));
         command
             .current_dir(work)
+            .env("PATH", stub_first_path(&Self::stub_bin_dir(home)))
             .env("HOME", home)
             .env("USERPROFILE", home)
             .env_remove("ORBIT_ROOT")

--- a/crates/orbit-cli/tests/worktree_resolution.rs
+++ b/crates/orbit-cli/tests/worktree_resolution.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command as StdCommand;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -287,6 +287,10 @@ fn run_orbit_success(cwd: &Path, home: &Path, args: &[&str], orbit_root: Option<
     let mut command = cargo_bin_cmd!("orbit");
     command
         .current_dir(cwd)
+        .env(
+            "PATH",
+            stub_first_path(&plant_agent_cli_stub(home, "codex")),
+        )
         .env("HOME", home)
         .env("USERPROFILE", home)
         .args(args);
@@ -298,6 +302,10 @@ fn run_orbit_json(cwd: &Path, home: &Path, args: &[&str], orbit_root: Option<&Pa
     let mut command = cargo_bin_cmd!("orbit");
     command
         .current_dir(cwd)
+        .env(
+            "PATH",
+            stub_first_path(&plant_agent_cli_stub(home, "codex")),
+        )
         .env("HOME", home)
         .env("USERPROFILE", home)
         .args(args);
@@ -325,6 +333,39 @@ fn set_orbit_root_env(command: &mut AssertCommand, orbit_root: Option<&Path>) {
             command.env_remove("ORBIT_ROOT");
         }
     }
+}
+
+/// Write an executable no-op named `name` into `<home>/stub-bin`, standing in
+/// for an agent CLI during detection, and return that directory.
+///
+/// `orbit workspace init` freezes crew seeding to the agent CLIs it finds on
+/// `PATH`, so a host with none installed — every CI runner — seeds an empty
+/// `[crews]` table and leaves `[workflow].default_crew` unset. Any run that has
+/// to resolve a crew then dies with `no crew selected`. Planting on every
+/// invocation keeps the stub in place before `init` runs, whatever order the
+/// tests call the helpers in; nothing here dispatches an agent, so the stub only
+/// has to exist and be executable.
+fn plant_agent_cli_stub(home: &Path, name: &str) -> PathBuf {
+    let bin = home.join("stub-bin");
+    fs::create_dir_all(&bin).expect("create stub CLI directory");
+    let stub = bin.join(name);
+    fs::write(&stub, "#!/bin/sh\nexit 0\n").expect("write stub agent CLI");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&stub, fs::Permissions::from_mode(0o755))
+            .expect("mark the stub agent CLI executable");
+    }
+    bin
+}
+
+/// `PATH` with the fixture's stub directory first, so agent detection sees the
+/// stubs regardless of what the host has installed.
+fn stub_first_path(bin: &Path) -> std::ffi::OsString {
+    let inherited = std::env::var_os("PATH").unwrap_or_default();
+    let mut entries = vec![bin.to_path_buf()];
+    entries.extend(std::env::split_paths(&inherited));
+    std::env::join_paths(entries).expect("join PATH entries")
 }
 
 fn run_git(cwd: &Path, args: &[&str]) {

--- a/crates/orbit-core/src/command/routine.rs
+++ b/crates/orbit-core/src/command/routine.rs
@@ -312,15 +312,36 @@ mod tests {
         assert_eq!(rehosted.refreshed, DEFAULT_ROUTINE_FILES.len());
     }
 
+    /// Rewrite the top-level `enabled:` line to a fixed marker so a workspace's
+    /// own opt-in decision does not read as template drift.
+    fn ignoring_enabled(routine: &str) -> String {
+        routine
+            .lines()
+            .map(|line| {
+                if line.starts_with("enabled:") {
+                    "enabled: <workspace decision>"
+                } else {
+                    line
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// This workspace's own routine may differ from the template in exactly one
+    /// field. The asset documents flipping `enabled` as "an explicit, versioned
+    /// workspace decision", so comparing it too would fail the moment a
+    /// workspace does the thing the template invites. Everything else — cadence,
+    /// host pin, target, policy, the rationale comments — must stay aligned.
     #[test]
     fn dogfood_task_pilot_routine_matches_the_rendered_default_template() {
         let rendered = include_str!("../../assets/routines/task_pilot.yaml")
             .replace(ROUTINE_NAME_PLACEHOLDER, "task-pilot-orbit")
             .replace(HOST_ID_PLACEHOLDER, "dk-server-1");
         assert_eq!(
-            rendered,
-            include_str!("../../../../.orbit/routines/task_pilot.yaml"),
-            "dogfood task-pilot routine must stay aligned with the seeded template"
+            ignoring_enabled(&rendered),
+            ignoring_enabled(include_str!("../../../../.orbit/routines/task_pilot.yaml")),
+            "dogfood task-pilot routine must stay aligned with the seeded template outside `enabled`"
         );
     }
 

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -14,21 +14,11 @@ fi
 
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
-# The replay smokes require an explicit feature, so the default workspace
-# clippy pass skips them. Keep that opt-in path compiled and linted too.
-# orbit-core rides along: its replay-backed v2_host test needs the same
-# transport, and `orbit-core/replay` forwards to `orbit-engine/replay`, so one
-# pass covers both crates' opt-in configuration. [ORB-10414] [ORB-10434]
-cargo clippy -p orbit-engine -p orbit-core --all-targets --features orbit-core/replay -- -D warnings
-# The converted v2 integration tests are included in the default test surface;
-# exercise the replay-gated cases separately so both configurations run.
 if cargo nextest --version >/dev/null 2>&1; then
   cargo nextest run --workspace --lib --bins --tests
-  cargo nextest run -p orbit-engine -p orbit-core --features orbit-core/replay --lib --bins --tests
 else
   echo "cargo-nextest not found; falling back to cargo test" >&2
   cargo test --workspace --lib --bins --tests
-  cargo test -p orbit-engine -p orbit-core --features orbit-core/replay --lib --bins --tests
 fi
 cargo test --workspace --doc
 RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace


### PR DESCRIPTION
## Problem

CI on `agent-main` has been red since 2026-07-19 (last green run `29700543296`, sha `62de9c74`). Three independent breakages were stacked behind each other — each one aborted the pipeline before the next became visible. None were caused by this branch.

**1. `Check / Clippy / Test` — a cargo feature that no longer exists.** [ORB-10801] removed the `replay` feature from `orbit-core` and `orbit-engine` but left three `--features orbit-core/replay` invocations in `scripts/ci-guardrails.sh`. The job died on the first with `error: none of the selected packages contains this feature: orbit-core/replay`, before a single test ran.

**2. `Coverage (informational)` — PATH-dependent crew seeding.** Two integration fixtures call `orbit workspace init`, which freezes crew seeding to the agent CLIs it detects on `PATH`. A host with none installed — every CI runner — seeds an empty `[crews]` table and leaves `[workflow].default_crew` unset, so any run that has to resolve a crew fails:

- `crates/orbit-cli/tests/mcp_roundtrip.rs` — `crew 'sol' is not defined in [crews.*]`
- `crates/orbit-cli/tests/worktree_resolution.rs` ([ORB-10821]) — `no crew selected; set [workflow].default_crew, task.crew, or pass crew`

Both pass on developer machines, where `claude`/`codex` are on `PATH`, and can never pass on a stock runner. They are invisible to `make ci-fast`.

**3. Both jobs — a test that forbids its own documented opt-in.** `dogfood_task_pilot_routine_matches_the_rendered_default_template` asserted byte-equality between this repo's `.orbit/routines/task_pilot.yaml` and the rendered [ORB-10739] template. The template's description reads "set enabled to true in this versioned definition to opt this workspace into scheduled task preflight" — so the test fails the moment a workspace does what the asset invites. `93a18b59` (2026-08-14) flipped this workspace's copy to `enabled: true`, and the test has failed ever since.

## Change

- **`scripts/ci-guardrails.sh`** — drop the replay-feature clippy pass and the second nextest/`cargo test` invocation. No `cfg(feature = "replay")` remains anywhere in the tree, so the opt-in configuration has nothing left to cover; the default `cargo clippy --workspace --all-targets` and workspace nextest run already lint and exercise both crates.
- **`crates/orbit-cli/tests/mcp_roundtrip.rs`, `crates/orbit-cli/tests/worktree_resolution.rs`** — each fixture plants an executable no-op `codex` under its temp `HOME` and puts that directory first on `PATH` for every `orbit` invocation, so detection resolves the same way on every host. Nothing in either file dispatches an agent, so the stub only has to exist and be executable.
- **`crates/orbit-core/src/command/routine.rs`** — normalize the top-level `enabled:` line on both sides of the comparison. Cadence, host pin, target, policy, and the rationale comments the test exists to protect are still compared byte for byte, so genuine template drift still fails.

Test-only and CI-script-only. No production code touched.

The workspace's `.orbit/routines/task_pilot.yaml` is deliberately left as it is — it schedules unattended agent work every four hours on `dk-server-1`, and turning it off to satisfy a test would be an operational change, not a test fix.

The two stub helpers are duplicated across the CLI fixtures because `orbit-cli` has no shared integration-test support module; a third copy should become one.

## Validation

- `env PATH=<cargo-bin>:/usr/bin:/bin cargo test -p orbit-cli --test worktree_resolution` — 3/3 (2/3 before).
- `env PATH=<cargo-bin>:/usr/bin:/bin cargo test -p orbit-cli --test mcp_roundtrip` — 9/9.
- Both files under the normal PATH — 12/12.
- `cargo test -p orbit-core --lib command::routine` — 6/6 (5/6 before).
- `bash -n scripts/ci-guardrails.sh`, `make ci-fast`, `cargo fmt --check`, `cargo clippy -p orbit-cli --tests`, `cargo clippy -p orbit-core --all-targets` — clean.

## Note

The guardrail script fails fast, so each fix exposes the next stage of the pipeline for the first time in weeks. The previous run got as far as 2696 nextest cases with one failure, which is the deepest CI has reached since July. Further failures may still surface behind this one.