### PR TITLE
Deliver the epic branch and gate completion on the epic's own descendants

### DIFF
--- a/.orbit/resources/jobs/epic_pipeline.yaml
+++ b/.orbit/resources/jobs/epic_pipeline.yaml
@@ -1,10 +1,13 @@
-# Epic branch assembly [ORB-10816 / ORB-10817].
+# Epic branch assembly and delivery [ORB-10816 / ORB-10818].
 #
 # One epic owns one stable worktree and branch. Unfinished descendants land
 # into that branch through serial local pipelines; the worktree finisher then
 # validates and completes the combined result. If the finisher authors a new
-# child, the assemble loop re-lists descendants and drains again. The epic
-# root remains in-progress; later stages deliver the assembled branch.
+# child, the assemble loop re-lists descendants and drains again.
+#
+# Completion is epic-scoped: leftover descendants at the iteration ceiling
+# fail the run closed. Delivery is inlined against the epic worktree — never
+# via `task_pr_pipeline`, which would open a second worktree.
 
 schemaVersion: 2
 kind: Job
@@ -100,3 +103,120 @@ spec:
               config: {}
             default_input:
               epic_task_id: "{{ input.epic_task_id }}"
+
+    - id: require_empty
+      spec:
+        type: deterministic
+        action: list_epic_descendants
+        config: {}
+      default_input:
+        epic_task_id: "{{ input.epic_task_id }}"
+        fail_if_nonempty: true
+
+    - id: commit_delivery
+      target: activity:git_commit
+      default_input:
+        job_run_id: "{{ steps.worktree.output.job_run_id }}"
+        scope: all
+        workspace_path: "{{ steps.worktree.output.workspace_path }}"
+        base_ref: "{{ steps.worktree.output.base_ref }}"
+        base_sha: "{{ steps.worktree.output.base_sha }}"
+        allow_empty: true
+        allow_moved_head: true
+
+    - id: prepare_branch
+      when: "{{ steps.resolve_ship_input.output.mode }} == pr && {{ steps.commit_delivery.output.skipped_no_diff_expected }} != true"
+      target: activity:pr_prepare
+      default_input:
+        job_run_id: "{{ steps.worktree.output.job_run_id }}"
+        base: "{{ steps.resolve_ship_input.output.base_branch }}"
+        base_sync: remote
+        completed_task_ids:
+          - "{{ input.epic_task_id }}"
+        workspace_path: "{{ steps.worktree.output.workspace_path }}"
+
+    - id: sync_base
+      when: "{{ steps.resolve_ship_input.output.mode }} == pr && {{ steps.commit_delivery.output.skipped_no_diff_expected }} != true"
+      target: activity:git_rebase
+      default_input:
+        job_run_id: "{{ steps.worktree.output.job_run_id }}"
+        completed_task_ids:
+          - "{{ input.epic_task_id }}"
+        workspace_path: "{{ steps.worktree.output.workspace_path }}"
+        head: "{{ steps.prepare_branch.output.head }}"
+        head_sha: "{{ steps.prepare_branch.output.head_sha }}"
+        base: "{{ steps.prepare_branch.output.base }}"
+        base_ref: "{{ steps.prepare_branch.output.base_ref }}"
+        base_sha: "{{ steps.prepare_branch.output.base_sha }}"
+        remote_sha: "{{ steps.prepare_branch.output.remote_sha }}"
+        commits_behind: "{{ steps.prepare_branch.output.commits_behind }}"
+        sync_required: "{{ steps.prepare_branch.output.sync_required }}"
+
+    - id: push
+      when: "{{ steps.resolve_ship_input.output.mode }} == pr && {{ steps.commit_delivery.output.skipped_no_diff_expected }} != true"
+      target: activity:git_push
+      default_input:
+        job_run_id: "{{ steps.worktree.output.job_run_id }}"
+        completed_task_ids:
+          - "{{ input.epic_task_id }}"
+        workspace_path: "{{ steps.worktree.output.workspace_path }}"
+        branch: "{{ steps.sync_base.output.head }}"
+        base: "{{ steps.sync_base.output.base }}"
+        base_ref: "{{ steps.sync_base.output.base_ref }}"
+        rewrite_performed: "{{ steps.sync_base.output.rewritten }}"
+        rewrite_head_before: "{{ steps.sync_base.output.head_sha_before }}"
+        expected_remote_sha: "{{ steps.sync_base.output.remote_sha_before }}"
+
+    - id: pr_open
+      when: "{{ steps.resolve_ship_input.output.mode }} == pr && {{ steps.commit_delivery.output.skipped_no_diff_expected }} != true"
+      target: activity:pr_open
+      default_input:
+        job_run_id: "{{ steps.worktree.output.job_run_id }}"
+        completed_task_ids:
+          - "{{ input.epic_task_id }}"
+        workspace_path: "{{ steps.worktree.output.workspace_path }}"
+        base: "{{ steps.sync_base.output.base }}"
+        base_ref: "{{ steps.sync_base.output.base_ref }}"
+        base_sha: "{{ steps.sync_base.output.base_sha }}"
+        base_sync: remote
+        head: "{{ steps.sync_base.output.head }}"
+
+    - id: promote_pr
+      when: "{{ steps.resolve_ship_input.output.mode }} == pr && {{ steps.commit_delivery.output.skipped_no_diff_expected }} != true"
+      target: activity:pr_promote
+      default_input:
+        job_run_id: "{{ steps.worktree.output.job_run_id }}"
+        completed_task_ids:
+          - "{{ input.epic_task_id }}"
+        workspace_path: "{{ steps.worktree.output.workspace_path }}"
+        head: "{{ steps.sync_base.output.head }}"
+        base: "{{ steps.sync_base.output.base }}"
+        base_ref: "{{ steps.sync_base.output.base_ref }}"
+        base_sha: "{{ steps.sync_base.output.base_sha }}"
+        base_sync: remote
+        pr_number: "{{ steps.pr_open.output.pr_number }}"
+        pr_url: "{{ steps.pr_open.output.pr_url }}"
+
+    - id: promote_pr_no_diff
+      when: "{{ steps.resolve_ship_input.output.mode }} == pr && {{ steps.commit_delivery.output.skipped_no_diff_expected }} == true"
+      target: activity:update_task
+      default_input:
+        task_id: "{{ input.epic_task_id }}"
+        status: review
+
+    - id: merge
+      when: "{{ steps.resolve_ship_input.output.mode }} == local"
+      target: activity:git_merge
+      default_input:
+        job_run_id: "{{ steps.worktree.output.job_run_id }}"
+        base: "{{ steps.resolve_ship_input.output.base_branch }}"
+        base_sync: local
+        strategy: fast_forward
+        workspace_path: "{{ steps.worktree.output.workspace_path }}"
+
+    - id: mark_done
+      when: "{{ steps.resolve_ship_input.output.mode }} == local"
+      target: activity:update_task
+      default_input:
+        task_id: "{{ input.epic_task_id }}"
+        status: done

--- a/crates/orbit-core/assets/activities/git_commit.yaml
+++ b/crates/orbit-core/assets/activities/git_commit.yaml
@@ -25,6 +25,18 @@ spec:
       base_sha:
         type: string
         description: Full commit id pinned by worktree_setup; HEAD must still equal it when this step begins.
+      allow_empty:
+        type: boolean
+        description: >
+          Treat a clean empty stage as `skipped_no_diff_expected` even when
+          the task does not carry the no-diff-expected tag. Used by
+          `epic_pipeline` so a no-op epic does not fail commit.
+      allow_moved_head:
+        type: boolean
+        description: >
+          Allow HEAD to have moved past the pinned `base_sha` (child merges
+          into an epic branch). A clean moved HEAD is `already_committed`
+          rather than `skipped_no_diff_expected`, so delivery still runs.
   output_schema_json:
     type: object
     properties:

--- a/crates/orbit-core/assets/activities/scan_unresolved_work.yaml
+++ b/crates/orbit-core/assets/activities/scan_unresolved_work.yaml
@@ -9,8 +9,9 @@ spec:
     `proposed` / `backlog` / `blocked`, job-runs in `failed` / `timeout`
     (excluding `epic_pipeline` itself), and unresolved `check_later`
     session-log ids. Empty is success. Optional `fail_if_nonempty`
-    fails the step when the set is still non-empty so `epic_pipeline`
-    can fail closed after its iteration cap.
+    fails the step when the set is still non-empty so a workspace
+    drain can fail closed after its iteration cap. `epic_pipeline`
+    no longer uses this activity as its completion gate.
   input_schema_json:
     type: object
     properties:

--- a/crates/orbit-core/assets/jobs/epic_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/epic_pipeline.yaml
@@ -1,10 +1,13 @@
-# Epic branch assembly [ORB-10816 / ORB-10817].
+# Epic branch assembly and delivery [ORB-10816 / ORB-10818].
 #
 # One epic owns one stable worktree and branch. Unfinished descendants land
 # into that branch through serial local pipelines; the worktree finisher then
 # validates and completes the combined result. If the finisher authors a new
-# child, the assemble loop re-lists descendants and drains again. The epic
-# root remains in-progress; later stages deliver the assembled branch.
+# child, the assemble loop re-lists descendants and drains again.
+#
+# Completion is epic-scoped: leftover descendants at the iteration ceiling
+# fail the run closed. Delivery is inlined against the epic worktree — never
+# via `task_pr_pipeline`, which would open a second worktree.
 
 schemaVersion: 2
 kind: Job
@@ -100,3 +103,120 @@ spec:
               config: {}
             default_input:
               epic_task_id: "{{ input.epic_task_id }}"
+
+    - id: require_empty
+      spec:
+        type: deterministic
+        action: list_epic_descendants
+        config: {}
+      default_input:
+        epic_task_id: "{{ input.epic_task_id }}"
+        fail_if_nonempty: true
+
+    - id: commit_delivery
+      target: activity:git_commit
+      default_input:
+        job_run_id: "{{ steps.worktree.output.job_run_id }}"
+        scope: all
+        workspace_path: "{{ steps.worktree.output.workspace_path }}"
+        base_ref: "{{ steps.worktree.output.base_ref }}"
+        base_sha: "{{ steps.worktree.output.base_sha }}"
+        allow_empty: true
+        allow_moved_head: true
+
+    - id: prepare_branch
+      when: "{{ steps.resolve_ship_input.output.mode }} == pr && {{ steps.commit_delivery.output.skipped_no_diff_expected }} != true"
+      target: activity:pr_prepare
+      default_input:
+        job_run_id: "{{ steps.worktree.output.job_run_id }}"
+        base: "{{ steps.resolve_ship_input.output.base_branch }}"
+        base_sync: remote
+        completed_task_ids:
+          - "{{ input.epic_task_id }}"
+        workspace_path: "{{ steps.worktree.output.workspace_path }}"
+
+    - id: sync_base
+      when: "{{ steps.resolve_ship_input.output.mode }} == pr && {{ steps.commit_delivery.output.skipped_no_diff_expected }} != true"
+      target: activity:git_rebase
+      default_input:
+        job_run_id: "{{ steps.worktree.output.job_run_id }}"
+        completed_task_ids:
+          - "{{ input.epic_task_id }}"
+        workspace_path: "{{ steps.worktree.output.workspace_path }}"
+        head: "{{ steps.prepare_branch.output.head }}"
+        head_sha: "{{ steps.prepare_branch.output.head_sha }}"
+        base: "{{ steps.prepare_branch.output.base }}"
+        base_ref: "{{ steps.prepare_branch.output.base_ref }}"
+        base_sha: "{{ steps.prepare_branch.output.base_sha }}"
+        remote_sha: "{{ steps.prepare_branch.output.remote_sha }}"
+        commits_behind: "{{ steps.prepare_branch.output.commits_behind }}"
+        sync_required: "{{ steps.prepare_branch.output.sync_required }}"
+
+    - id: push
+      when: "{{ steps.resolve_ship_input.output.mode }} == pr && {{ steps.commit_delivery.output.skipped_no_diff_expected }} != true"
+      target: activity:git_push
+      default_input:
+        job_run_id: "{{ steps.worktree.output.job_run_id }}"
+        completed_task_ids:
+          - "{{ input.epic_task_id }}"
+        workspace_path: "{{ steps.worktree.output.workspace_path }}"
+        branch: "{{ steps.sync_base.output.head }}"
+        base: "{{ steps.sync_base.output.base }}"
+        base_ref: "{{ steps.sync_base.output.base_ref }}"
+        rewrite_performed: "{{ steps.sync_base.output.rewritten }}"
+        rewrite_head_before: "{{ steps.sync_base.output.head_sha_before }}"
+        expected_remote_sha: "{{ steps.sync_base.output.remote_sha_before }}"
+
+    - id: pr_open
+      when: "{{ steps.resolve_ship_input.output.mode }} == pr && {{ steps.commit_delivery.output.skipped_no_diff_expected }} != true"
+      target: activity:pr_open
+      default_input:
+        job_run_id: "{{ steps.worktree.output.job_run_id }}"
+        completed_task_ids:
+          - "{{ input.epic_task_id }}"
+        workspace_path: "{{ steps.worktree.output.workspace_path }}"
+        base: "{{ steps.sync_base.output.base }}"
+        base_ref: "{{ steps.sync_base.output.base_ref }}"
+        base_sha: "{{ steps.sync_base.output.base_sha }}"
+        base_sync: remote
+        head: "{{ steps.sync_base.output.head }}"
+
+    - id: promote_pr
+      when: "{{ steps.resolve_ship_input.output.mode }} == pr && {{ steps.commit_delivery.output.skipped_no_diff_expected }} != true"
+      target: activity:pr_promote
+      default_input:
+        job_run_id: "{{ steps.worktree.output.job_run_id }}"
+        completed_task_ids:
+          - "{{ input.epic_task_id }}"
+        workspace_path: "{{ steps.worktree.output.workspace_path }}"
+        head: "{{ steps.sync_base.output.head }}"
+        base: "{{ steps.sync_base.output.base }}"
+        base_ref: "{{ steps.sync_base.output.base_ref }}"
+        base_sha: "{{ steps.sync_base.output.base_sha }}"
+        base_sync: remote
+        pr_number: "{{ steps.pr_open.output.pr_number }}"
+        pr_url: "{{ steps.pr_open.output.pr_url }}"
+
+    - id: promote_pr_no_diff
+      when: "{{ steps.resolve_ship_input.output.mode }} == pr && {{ steps.commit_delivery.output.skipped_no_diff_expected }} == true"
+      target: activity:update_task
+      default_input:
+        task_id: "{{ input.epic_task_id }}"
+        status: review
+
+    - id: merge
+      when: "{{ steps.resolve_ship_input.output.mode }} == local"
+      target: activity:git_merge
+      default_input:
+        job_run_id: "{{ steps.worktree.output.job_run_id }}"
+        base: "{{ steps.resolve_ship_input.output.base_branch }}"
+        base_sync: local
+        strategy: fast_forward
+        workspace_path: "{{ steps.worktree.output.workspace_path }}"
+
+    - id: mark_done
+      when: "{{ steps.resolve_ship_input.output.mode }} == local"
+      target: activity:update_task
+      default_input:
+        task_id: "{{ input.epic_task_id }}"
+        status: done

--- a/crates/orbit-core/src/command/job/tests/catalog.rs
+++ b/crates/orbit-core/src/command/job/tests/catalog.rs
@@ -1143,7 +1143,31 @@ fn epic_pipeline_opens_one_stable_worktree_and_drains_children_serially() {
     );
     let asset = load_job_asset(yaml).expect("epic pipeline parses");
     assert_eq!(asset.spec.max_active_runs, 1);
-    assert_eq!(asset.spec.steps.len(), 3);
+    assert_eq!(asset.spec.steps.len(), 13);
+    let root_step_ids = asset
+        .spec
+        .steps
+        .iter()
+        .map(|step| step.id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        root_step_ids,
+        [
+            "resolve_ship_input",
+            "worktree",
+            "assemble",
+            "require_empty",
+            "commit_delivery",
+            "prepare_branch",
+            "sync_base",
+            "push",
+            "pr_open",
+            "promote_pr",
+            "promote_pr_no_diff",
+            "merge",
+            "mark_done",
+        ]
+    );
 
     let JobV2StepBody::TargetRef(worktree) = &asset.spec.steps[1].body else {
         panic!("epic pipeline must set up its worktree before draining children");
@@ -1238,6 +1262,128 @@ fn epic_pipeline_opens_one_stable_worktree_and_drains_children_serially() {
         panic!("remaining descendant listing must be deterministic");
     };
     assert_eq!(remaining.action, "list_epic_descendants");
+
+    let require_empty = &asset.spec.steps[3];
+    assert_eq!(require_empty.id, "require_empty");
+    let JobV2StepBody::Target(require_empty_step) = &require_empty.body else {
+        panic!("post-loop gate must list descendants deterministically");
+    };
+    let ActivityV2Spec::Deterministic(require_empty_spec) = &require_empty_step.spec else {
+        panic!("post-loop descendant gate must be deterministic");
+    };
+    assert_eq!(require_empty_spec.action, "list_epic_descendants");
+    assert_eq!(
+        require_empty_step
+            .default_input
+            .as_ref()
+            .expect("require_empty input")["fail_if_nonempty"],
+        true
+    );
+
+    let commit_delivery = &asset.spec.steps[4];
+    let JobV2StepBody::TargetRef(commit_delivery) = &commit_delivery.body else {
+        panic!("delivery commit must reference git_commit");
+    };
+    assert_eq!(commit_delivery.target, "activity:git_commit");
+    let commit_input = commit_delivery
+        .default_input
+        .as_ref()
+        .expect("commit_delivery input");
+    assert_eq!(commit_input["allow_empty"], true);
+    assert_eq!(commit_input["allow_moved_head"], true);
+    assert_eq!(
+        commit_input["workspace_path"],
+        "{{ steps.worktree.output.workspace_path }}"
+    );
+
+    let pr_when = Some(
+        "{{ steps.resolve_ship_input.output.mode }} == pr && {{ steps.commit_delivery.output.skipped_no_diff_expected }} != true",
+    );
+    for (index, id) in [
+        "prepare_branch",
+        "sync_base",
+        "push",
+        "pr_open",
+        "promote_pr",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let step = &asset.spec.steps[5 + index];
+        assert_eq!(step.id, id);
+        assert_eq!(step.when.as_deref(), pr_when);
+        let JobV2StepBody::TargetRef(target) = &step.body else {
+            panic!("{id} must be an activity reference");
+        };
+        assert!(
+            !target.target.contains("task_pr_pipeline"),
+            "delivery must compose activities, not invoke task_pr_pipeline"
+        );
+        if let Some(input) = target.default_input.as_ref() {
+            if let Some(workspace_path) = input.get("workspace_path") {
+                assert_eq!(
+                    workspace_path, "{{ steps.worktree.output.workspace_path }}",
+                    "{id} must reuse the epic worktree"
+                );
+            }
+            assert!(
+                input.get("job_name") != Some(&json!("task_pr_pipeline")),
+                "{id} must not dispatch task_pr_pipeline"
+            );
+        }
+    }
+
+    let promote_no_diff = &asset.spec.steps[10];
+    assert_eq!(
+        promote_no_diff.when.as_deref(),
+        Some(
+            "{{ steps.resolve_ship_input.output.mode }} == pr && {{ steps.commit_delivery.output.skipped_no_diff_expected }} == true"
+        )
+    );
+    let JobV2StepBody::TargetRef(promote_no_diff) = &promote_no_diff.body else {
+        panic!("no-diff PR path must update the epic root");
+    };
+    assert_eq!(promote_no_diff.target, "activity:update_task");
+    assert_eq!(
+        promote_no_diff
+            .default_input
+            .as_ref()
+            .expect("no-diff input")["status"],
+        "review"
+    );
+
+    let merge = &asset.spec.steps[11];
+    assert_eq!(
+        merge.when.as_deref(),
+        Some("{{ steps.resolve_ship_input.output.mode }} == local")
+    );
+    let JobV2StepBody::TargetRef(merge) = &merge.body else {
+        panic!("local delivery must merge the epic branch");
+    };
+    assert_eq!(merge.target, "activity:git_merge");
+    let merge_input = merge.default_input.as_ref().expect("merge input");
+    assert_eq!(
+        merge_input["workspace_path"],
+        "{{ steps.worktree.output.workspace_path }}"
+    );
+    assert_eq!(
+        merge_input["base"],
+        "{{ steps.resolve_ship_input.output.base_branch }}"
+    );
+
+    let mark_done = &asset.spec.steps[12];
+    assert_eq!(
+        mark_done.when.as_deref(),
+        Some("{{ steps.resolve_ship_input.output.mode }} == local")
+    );
+    let JobV2StepBody::TargetRef(mark_done) = &mark_done.body else {
+        panic!("local delivery must mark the epic done");
+    };
+    assert_eq!(mark_done.target, "activity:update_task");
+    assert_eq!(
+        mark_done.default_input.as_ref().expect("mark_done input")["status"],
+        "done"
+    );
 }
 
 fn collect_agent_loop_step_ids<'a>(

--- a/crates/orbit-core/src/command/job/tests/exec.rs
+++ b/crates/orbit-core/src/command/job/tests/exec.rs
@@ -6,8 +6,8 @@ use std::sync::{Arc, Mutex};
 
 use chrono::Utc;
 use orbit_common::types::{
-    AuditEventStatus, ExecutorDef, ExecutorType, JobRunState, JobV2StepBody, TaskPriority,
-    TaskStatus, TaskType,
+    ActivityV2Spec, AuditEventStatus, ExecutorDef, ExecutorType, JobRunState, JobV2Step,
+    JobV2StepBody, TaskPriority, TaskStatus, TaskType,
 };
 use orbit_engine::{
     DispatchError, JobOutcome, ResolvedCliExecutor, RuntimeHost, V2AuditWriter,
@@ -652,6 +652,9 @@ struct ScriptedEpicHost<'a> {
     descendant_ids: Mutex<Vec<String>>,
     finish_authored_child: Option<String>,
     commit_on_finish: bool,
+    land_children: bool,
+    no_diff: bool,
+    ship_mode: &'static str,
     calls: Mutex<Vec<(String, Value)>>,
 }
 
@@ -662,6 +665,9 @@ impl<'a> ScriptedEpicHost<'a> {
             descendant_ids: Mutex::new(descendant_ids),
             finish_authored_child: None,
             commit_on_finish: false,
+            land_children: true,
+            no_diff: false,
+            ship_mode: "pr",
             calls: Mutex::new(Vec::new()),
         }
     }
@@ -673,6 +679,21 @@ impl<'a> ScriptedEpicHost<'a> {
 
     fn commit_on_finish(mut self) -> Self {
         self.commit_on_finish = true;
+        self
+    }
+
+    fn local_mode(mut self) -> Self {
+        self.ship_mode = "local";
+        self
+    }
+
+    fn no_diff(mut self) -> Self {
+        self.no_diff = true;
+        self
+    }
+
+    fn never_land_children(mut self) -> Self {
+        self.land_children = false;
         self
     }
 
@@ -699,13 +720,14 @@ impl RuntimeHost for ScriptedEpicHost<'_> {
         input: &Value,
         tool_context: ToolContext,
     ) -> Result<Value, DispatchError> {
+        let recorded = action.strip_prefix("scripted_").unwrap_or(action);
         self.calls
             .lock()
             .expect("call log")
-            .push((action.to_string(), input.clone()));
-        match action {
+            .push((recorded.to_string(), input.clone()));
+        match recorded {
             "resolve_workspace_ship_input" => Ok(json!({
-                "mode": "pr",
+                "mode": self.ship_mode,
                 "base_branch": "agent-main",
             })),
             "worktree_setup" => Ok(json!({
@@ -718,6 +740,20 @@ impl RuntimeHost for ScriptedEpicHost<'_> {
             })),
             "list_epic_descendants" => {
                 let descendant_ids = self.current_descendants();
+                let empty = descendant_ids.is_empty();
+                let fail_if_nonempty = input
+                    .get("fail_if_nonempty")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                if fail_if_nonempty && !empty {
+                    return Err(DispatchError::DeterministicActionFailed {
+                        action: action.to_string(),
+                        message: format!(
+                            "epic descendants remain after drain: tasks=[{}]",
+                            descendant_ids.join(", ")
+                        ),
+                    });
+                }
                 Ok(json!({
                     "epic_task_id": input
                         .get("epic_task_id")
@@ -725,14 +761,15 @@ impl RuntimeHost for ScriptedEpicHost<'_> {
                         .unwrap_or("ORB-EPIC"),
                     "task_count": descendant_ids.len(),
                     "task_ids": descendant_ids,
-                    "empty": descendant_ids.is_empty(),
+                    "empty": empty,
                 }))
             }
             "invoke_and_wait" => {
-                if let Some(task_ids) = input
-                    .get("run_input")
-                    .and_then(|value| value.get("task_ids"))
-                    .and_then(Value::as_array)
+                if self.land_children
+                    && let Some(task_ids) = input
+                        .get("run_input")
+                        .and_then(|value| value.get("task_ids"))
+                        .and_then(Value::as_array)
                 {
                     self.descendant_ids
                         .lock()
@@ -774,6 +811,71 @@ impl RuntimeHost for ScriptedEpicHost<'_> {
                 }
                 Ok(json!({ "summary": "finished" }))
             }
+            "git_commit" => Ok(json!({
+                "phase": "commit",
+                "decision": if self.no_diff {
+                    "skipped_no_diff_expected"
+                } else {
+                    "already_committed"
+                },
+                "committed": false,
+                "skipped_no_diff_expected": self.no_diff,
+            })),
+            "pr_prepare" => Ok(json!({
+                "phase": "prepare",
+                "decision": "already_fresh",
+                "head": "epic/ORB-EPIC",
+                "head_sha": "2222222222222222222222222222222222222222",
+                "base": "agent-main",
+                "base_ref": "origin/agent-main",
+                "base_sha": "1111111111111111111111111111111111111111",
+                "remote_sha": Value::Null,
+                "commits_behind": 0,
+                "commits_ahead": 1,
+                "sync_required": false,
+            })),
+            "git_rebase" => Ok(json!({
+                "phase": "rebase",
+                "decision": "skipped_current",
+                "head": "epic/ORB-EPIC",
+                "head_sha": "2222222222222222222222222222222222222222",
+                "head_sha_before": "2222222222222222222222222222222222222222",
+                "base": "agent-main",
+                "base_ref": "origin/agent-main",
+                "base_sha": "1111111111111111111111111111111111111111",
+                "remote_sha_before": Value::Null,
+                "rewritten": false,
+            })),
+            "git_push" => Ok(json!({
+                "phase": "push",
+                "decision": "performed",
+                "branch": "epic/ORB-EPIC",
+                "local_sha": "2222222222222222222222222222222222222222",
+                "force_with_lease": false,
+            })),
+            "pr_open" => Ok(json!({
+                "phase": "open",
+                "decision": "created",
+                "pr_created": true,
+                "pr_reused": false,
+                "pr_number": "42",
+                "pr_url": "https://example.test/pr/42",
+            })),
+            "pr_promote" => Ok(json!({
+                "phase": "promote",
+                "decision": "performed",
+                "performed_task_ids": ["ORB-EPIC"],
+                "reused_task_ids": [],
+            })),
+            "git_merge" => Ok(json!({
+                "base": "agent-main",
+                "workspace_path": self.runtime.paths().repo_root,
+                "workspace_branch": "epic/ORB-EPIC",
+            })),
+            "update_task" => Ok(json!({
+                "task_id": input.get("task_id"),
+                "status": input.get("status"),
+            })),
             "pipeline_success_guard" => <OrbitRuntime as RuntimeHost>::run_deterministic(
                 self.runtime,
                 action,
@@ -1138,6 +1240,173 @@ fn epic_pipeline_reenters_drain_when_finisher_authors_a_child() {
     assert_eq!(invokes[1]["run_input"]["task_ids"], json!(["ORB-AUTHORED"]));
     assert_eq!(host.inputs_for("test_epic_finish").len(), 2);
     assert!(host.current_descendants().is_empty());
+}
+
+fn retarget_engine_actions_for_scripted_host(job: &mut orbit_common::types::activity_job::JobV2) {
+    fn walk(step: &mut JobV2Step) {
+        match &mut step.body {
+            JobV2StepBody::Target(target) => {
+                if let ActivityV2Spec::Deterministic(spec) = &mut target.spec {
+                    match spec.action.as_str() {
+                        "worktree_setup" | "git_commit" | "git_rebase" | "git_push"
+                        | "git_merge" | "pr_prepare" | "pr_open" | "pr_promote" | "update_task" => {
+                            spec.action = format!("scripted_{}", spec.action);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            JobV2StepBody::Loop { loop_ } => {
+                for child in &mut loop_.steps {
+                    walk(child);
+                }
+            }
+            JobV2StepBody::Parallel { parallel } => {
+                for child in &mut parallel.branches {
+                    walk(child);
+                }
+            }
+            JobV2StepBody::FanOut { fan_out, .. } => walk(&mut fan_out.worker),
+            JobV2StepBody::TargetRef(_) => {}
+        }
+    }
+    for step in &mut job.steps {
+        walk(step);
+    }
+}
+
+fn try_execute_full_epic_job(
+    runtime: &OrbitRuntime,
+    repo_root: &Path,
+    host: &dyn RuntimeHost,
+    input: Value,
+    run_id: &str,
+) -> Result<JobOutcome, DispatchError> {
+    let mut job = resolved_job(runtime, "epic_pipeline");
+    retarget_engine_actions_for_scripted_host(&mut job);
+    try_execute_epic_job(runtime, repo_root, host, job, input, run_id)
+}
+
+#[test]
+fn epic_pipeline_pr_mode_delivers_one_pr_against_the_workspace_base() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    stub_epic_finisher(&global_root);
+    let host = ScriptedEpicHost::new(&runtime, vec!["ORB-CHILD-1".to_string()]);
+
+    let outcome = try_execute_full_epic_job(
+        &runtime,
+        &repo_root,
+        &host,
+        json!({ "epic_task_id": "ORB-EPIC" }),
+        "jrun-scripted-epic-pr",
+    )
+    .expect("execute epic pr delivery");
+
+    assert!(outcome.success);
+    assert_eq!(host.inputs_for("worktree_setup").len(), 1);
+    assert_eq!(host.inputs_for("pr_open").len(), 1);
+    assert_eq!(host.inputs_for("pr_promote").len(), 1);
+    assert!(host.inputs_for("git_merge").is_empty());
+    let prepare = &host.inputs_for("pr_prepare")[0];
+    assert_eq!(prepare["base"], "agent-main");
+    assert_eq!(
+        prepare["workspace_path"],
+        runtime.paths().repo_root.display().to_string()
+    );
+    assert_eq!(prepare["completed_task_ids"], json!(["ORB-EPIC"]));
+    assert!(
+        host.inputs_for("invoke_and_wait")
+            .iter()
+            .all(|input| input["job_name"] != "task_pr_pipeline"),
+        "delivery must not invoke task_pr_pipeline"
+    );
+    assert!(host.inputs_for("update_task").is_empty());
+}
+
+#[test]
+fn epic_pipeline_local_mode_merges_once_into_the_workspace_base() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    stub_epic_finisher(&global_root);
+    let host = ScriptedEpicHost::new(&runtime, vec!["ORB-CHILD-1".to_string()]).local_mode();
+
+    let outcome = try_execute_full_epic_job(
+        &runtime,
+        &repo_root,
+        &host,
+        json!({ "epic_task_id": "ORB-EPIC" }),
+        "jrun-scripted-epic-local",
+    )
+    .expect("execute epic local delivery");
+
+    assert!(outcome.success);
+    assert_eq!(host.inputs_for("worktree_setup").len(), 1);
+    assert!(host.inputs_for("pr_open").is_empty());
+    assert!(host.inputs_for("pr_promote").is_empty());
+    assert_eq!(host.inputs_for("git_merge").len(), 1);
+    let merge = &host.inputs_for("git_merge")[0];
+    assert_eq!(merge["base"], "agent-main");
+    assert_eq!(
+        merge["workspace_path"],
+        runtime.paths().repo_root.display().to_string()
+    );
+    let updates = host.inputs_for("update_task");
+    assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0]["task_id"], "ORB-EPIC");
+    assert_eq!(updates[0]["status"], "done");
+}
+
+#[test]
+fn epic_pipeline_no_diff_skips_empty_pr_and_promotes_the_root() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    stub_epic_finisher(&global_root);
+    let host = ScriptedEpicHost::new(&runtime, Vec::new()).no_diff();
+
+    let outcome = try_execute_full_epic_job(
+        &runtime,
+        &repo_root,
+        &host,
+        json!({ "epic_task_id": "ORB-EPIC" }),
+        "jrun-scripted-epic-no-diff",
+    )
+    .expect("execute no-diff epic");
+
+    assert!(outcome.success);
+    assert!(host.inputs_for("pr_prepare").is_empty());
+    assert!(host.inputs_for("pr_open").is_empty());
+    assert!(host.inputs_for("git_push").is_empty());
+    let updates = host.inputs_for("update_task");
+    assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0]["task_id"], "ORB-EPIC");
+    assert_eq!(updates[0]["status"], "review");
+}
+
+#[test]
+fn epic_pipeline_fails_closed_when_descendants_remain_and_names_them() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    stub_epic_finisher(&global_root);
+    let host = ScriptedEpicHost::new(&runtime, vec!["ORB-LEFT".to_string()]).never_land_children();
+
+    let err = try_execute_full_epic_job(
+        &runtime,
+        &repo_root,
+        &host,
+        json!({ "epic_task_id": "ORB-EPIC" }),
+        "jrun-scripted-epic-leftover",
+    )
+    .expect_err("leftover descendants must fail closed");
+
+    let message = err.to_string();
+    assert!(message.contains("ORB-LEFT"), "{message}");
+    assert!(
+        message.contains("epic descendants remain after drain"),
+        "{message}"
+    );
+    assert!(host.inputs_for("pr_open").is_empty());
+    assert!(host.inputs_for("git_merge").is_empty());
 }
 
 #[cfg(unix)]

--- a/crates/orbit-core/src/runtime/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/v2_host/dispatch.rs
@@ -234,8 +234,9 @@ pub(crate) fn run_deterministic(
         }
         // Workspace drain scan [ORB-10779]: proposed/backlog/blocked
         // tasks, failed/timeout job-runs, and unresolved check_later notes.
-        // Read-only; empty is success. Optional `fail_if_nonempty` is the
-        // post-loop fail-closed guard for `epic_pipeline`.
+        // Read-only; empty is success. Optional `fail_if_nonempty` fails
+        // closed for a workspace-wide leftover set; `epic_pipeline` now
+        // gates on `list_epic_descendants` instead [ORB-10818].
         CoreDeterministicAction::ScanUnresolvedWork => {
             scan_unresolved::scan_unresolved_work(runtime, action, input)
         }

--- a/crates/orbit-core/src/runtime/v2_host/scan_unresolved.rs
+++ b/crates/orbit-core/src/runtime/v2_host/scan_unresolved.rs
@@ -1,8 +1,10 @@
-//! Deterministic unresolved-work scan for `epic_pipeline` [ORB-10779].
+//! Deterministic unresolved-work scan [ORB-10779 / ORB-10818].
 //!
-//! Read-only. Wakes on `proposed` / `backlog` / `blocked` tasks, `failed` /
-//! `timeout` job-runs (except the drain job itself), and unresolved
-//! `check_later` session-log entries. Empty is success, not an error.
+//! Read-only workspace drain predicate. Wakes on `proposed` / `backlog` /
+//! `blocked` tasks, `failed` / `timeout` job-runs (except `epic_pipeline`
+//! itself), and unresolved `check_later` session-log entries. Empty is
+//! success, not an error. This is no longer `epic_pipeline`'s completion
+//! gate — that job uses `list_epic_descendants`.
 
 use orbit_common::types::{JobRunState, TaskStatus};
 use orbit_engine::DispatchError;

--- a/crates/orbit-core/src/runtime/v2_host/tests/workspace_auto.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/workspace_auto.rs
@@ -28,14 +28,41 @@ fn drain_window(runtime: &OrbitRuntime, input: Value) -> Value {
 }
 
 fn list_epic_descendants(runtime: &OrbitRuntime, epic_task_id: &str) -> Value {
+    list_epic_descendants_with(runtime, epic_task_id, json!({}))
+}
+
+fn list_epic_descendants_with(runtime: &OrbitRuntime, epic_task_id: &str, extra: Value) -> Value {
+    let mut input = extra;
+    if let Some(object) = input.as_object_mut() {
+        object.insert("epic_task_id".to_string(), json!(epic_task_id));
+    }
     runtime
         .run_deterministic(
             "list_epic_descendants",
             &json!({}),
-            &json!({ "epic_task_id": epic_task_id }),
+            &input,
             ToolContext::default(),
         )
         .expect("list epic descendants")
+}
+
+fn list_epic_descendants_err(
+    runtime: &OrbitRuntime,
+    epic_task_id: &str,
+    extra: Value,
+) -> orbit_engine::DispatchError {
+    let mut input = extra;
+    if let Some(object) = input.as_object_mut() {
+        object.insert("epic_task_id".to_string(), json!(epic_task_id));
+    }
+    runtime
+        .run_deterministic(
+            "list_epic_descendants",
+            &json!({}),
+            &input,
+            ToolContext::default(),
+        )
+        .expect_err("list epic descendants should fail")
 }
 
 #[test]
@@ -134,6 +161,89 @@ fn epic_with_no_descendants_has_an_empty_drain() {
     assert_eq!(output["task_ids"], json!([]));
     assert_eq!(output["task_count"], 0);
     assert_eq!(output["empty"], true);
+}
+
+#[test]
+fn leftover_descendants_fail_closed_and_name_the_ids() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let epic = runtime
+        .add_task(TaskAddParams {
+            title: "Epic root".to_string(),
+            description: "Epic fixture".to_string(),
+            acceptance_criteria: vec!["Supervised".to_string()],
+            tags: vec!["epic".to_string()],
+            plan: "Delegate children".to_string(),
+            status: Some(TaskStatus::InProgress),
+            ..Default::default()
+        })
+        .expect("seed epic root");
+    let leftover = runtime
+        .add_task(TaskAddParams {
+            parent_id: Some(epic.id.clone()),
+            title: "Still open".to_string(),
+            description: "Unfinished descendant".to_string(),
+            acceptance_criteria: vec!["Done".to_string()],
+            plan: "Implement".to_string(),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("seed leftover child");
+    let unrelated = seed_list_backlog_task(
+        &runtime,
+        "Unrelated chore",
+        TaskStatus::Backlog,
+        TaskPriority::Low,
+        TaskType::Chore,
+        None,
+        vec![],
+    );
+
+    let error = list_epic_descendants_err(&runtime, &epic.id, json!({ "fail_if_nonempty": true }));
+    match error {
+        orbit_engine::DispatchError::DeterministicActionFailed { action, message } => {
+            assert_eq!(action, "list_epic_descendants");
+            assert!(message.contains(&leftover.id), "{message}");
+            assert!(
+                message.contains("epic descendants remain after drain"),
+                "{message}"
+            );
+            assert!(
+                !message.contains(&unrelated.id),
+                "unrelated backlog must not appear in the epic fail-closed message: {message}"
+            );
+        }
+        other => panic!("expected leftover-descendant failure, got {other:?}"),
+    }
+}
+
+#[test]
+fn fail_if_nonempty_ignores_unrelated_backlog_when_the_epic_is_empty() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let epic = runtime
+        .add_task(TaskAddParams {
+            title: "Empty epic".to_string(),
+            description: "Epic fixture".to_string(),
+            acceptance_criteria: vec!["No children".to_string()],
+            tags: vec!["epic".to_string()],
+            plan: "No-op".to_string(),
+            status: Some(TaskStatus::InProgress),
+            ..Default::default()
+        })
+        .expect("seed empty epic");
+    seed_list_backlog_task(
+        &runtime,
+        "Unrelated chore",
+        TaskStatus::Backlog,
+        TaskPriority::Low,
+        TaskType::Chore,
+        None,
+        vec![],
+    );
+
+    let output =
+        list_epic_descendants_with(&runtime, &epic.id, json!({ "fail_if_nonempty": true }));
+    assert_eq!(output["empty"], true);
+    assert_eq!(output["task_ids"], json!([]));
 }
 
 #[test]

--- a/crates/orbit-core/src/runtime/v2_host/workspace_auto.rs
+++ b/crates/orbit-core/src/runtime/v2_host/workspace_auto.rs
@@ -332,11 +332,26 @@ pub(super) fn list_epic_descendants(
         }
     }
 
+    let empty = ordered.is_empty();
+    let fail_if_nonempty = input
+        .get("fail_if_nonempty")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if fail_if_nonempty && !empty {
+        return Err(DispatchError::DeterministicActionFailed {
+            action: action.to_string(),
+            message: format!(
+                "epic descendants remain after drain: tasks=[{}]",
+                ordered.join(", ")
+            ),
+        });
+    }
+
     Ok(json!({
         "epic_task_id": epic_task_id,
         "task_count": ordered.len(),
         "task_ids": ordered,
-        "empty": ordered.is_empty(),
+        "empty": empty,
     }))
 }
 

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
@@ -203,20 +203,31 @@ pub(super) fn commit_batch_changes<H: RuntimeHost + ?Sized>(
     // failing it. Read the tag before any gate so the carve-out is reachable
     // from every failure branch below, not just the empty-stage one (ORB-10380).
     let no_diff_expected = task.tags.iter().any(|tag| tag == NO_DIFF_EXPECTED_TAG);
+    let allow_empty = input
+        .get("allow_empty")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let allow_moved_head = input
+        .get("allow_moved_head")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
 
-    let base_sha = match validate_pinned_head(&workspace_path, input)? {
-        PinnedHead::Matched(base_sha) => Some(base_sha),
-        PinnedHead::Unpinned => None,
+    let (base_sha, head_moved) = match validate_pinned_head(&workspace_path, input)? {
+        PinnedHead::Matched(base_sha) => (Some(base_sha), false),
+        PinnedHead::Unpinned => (None, false),
         PinnedHead::Changed { base_sha, head_sha } => {
             if no_diff_expected {
                 return Ok(skipped_no_diff_expected_result(&task.id));
             }
-            return Err(changed_head_error(
-                &task.id,
-                &workspace_path,
-                &base_sha,
-                &head_sha,
-            ));
+            if !allow_moved_head {
+                return Err(changed_head_error(
+                    &task.id,
+                    &workspace_path,
+                    &base_sha,
+                    &head_sha,
+                ));
+            }
+            (Some(base_sha), true)
         }
     };
 
@@ -234,7 +245,12 @@ pub(super) fn commit_batch_changes<H: RuntimeHost + ?Sized>(
         // `git add --all` staged nothing here, so the index already matches
         // HEAD and the former `git reset HEAD` was both pointless and a
         // mutation performed while erroring.
-        if no_diff_expected {
+        if head_moved {
+            // Child pipelines already advanced HEAD. There is a diff to
+            // deliver; it just is not sitting uncommitted.
+            return Ok(already_committed_result(&task.id, base_sha.as_deref()));
+        }
+        if no_diff_expected || allow_empty {
             return Ok(skipped_no_diff_expected_result(&task.id));
         }
         return Err(empty_stage_error(
@@ -357,6 +373,20 @@ fn skipped_no_diff_expected_result(task_id: &str) -> Value {
         "skipped_no_diff_expected": true,
         "task_id": task_id,
     })
+}
+
+fn already_committed_result(task_id: &str, base_sha: Option<&str>) -> Value {
+    let mut result = json!({
+        "phase": "commit",
+        "decision": "already_committed",
+        "committed": false,
+        "skipped_no_diff_expected": false,
+        "task_id": task_id,
+    });
+    if let Some(base_sha) = base_sha {
+        result["base_sha"] = json!(base_sha);
+    }
+    result
 }
 
 /// The worktree carries no committable work. Reports only what was observed —

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/base_checkpoint.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/base_checkpoint.rs
@@ -265,3 +265,69 @@ fn no_diff_expected_task_skips_the_phase_even_when_its_base_is_unreachable() {
         "the skip creates no commit"
     );
 }
+
+#[test]
+fn allow_empty_skips_a_clean_stage_without_the_no_diff_tag() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+    let base_sha = git_output(workspace, &["rev-parse", "HEAD"]).expect("read checkpoint");
+    git_success(workspace, &["checkout", "-b", "orbit/T1"]).expect("create task branch");
+
+    let task = task_with_file("T1", "Empty epic", "src/missing.txt", "claude");
+    let host = CommitTestHost::new(vec![task], workspace.to_path_buf());
+    let mut input = batch_input(workspace, &base_sha);
+    input["allow_empty"] = json!(true);
+
+    let result = git_commit(&host, &input).expect("allow_empty skips a clean stage");
+    assert_eq!(result["skipped_no_diff_expected"], json!(true));
+    assert_eq!(result["decision"], "skipped_no_diff_expected");
+}
+
+#[test]
+fn allow_moved_head_reports_already_committed_when_children_advanced_head() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+    let base_sha = git_output(workspace, &["rev-parse", "HEAD"]).expect("read checkpoint");
+    git_success(workspace, &["checkout", "-b", "epic/ORB-EPIC"]).expect("create epic branch");
+    fs::write(workspace.join("child.txt"), "landed child\n").unwrap();
+    let head_after_child = commit_all(workspace, "child landed into epic");
+
+    let task = task_with_file("T1", "Epic root", "child.txt", "claude");
+    let host = CommitTestHost::new(vec![task], workspace.to_path_buf());
+    let mut input = batch_input(workspace, &base_sha);
+    input["allow_empty"] = json!(true);
+    input["allow_moved_head"] = json!(true);
+
+    let result = git_commit(&host, &input).expect("moved HEAD with no leftover work");
+    assert_eq!(result["skipped_no_diff_expected"], json!(false));
+    assert_eq!(result["decision"], "already_committed");
+    assert_eq!(
+        git_output(workspace, &["rev-parse", "HEAD"]).expect("read head after"),
+        head_after_child
+    );
+}
+
+#[test]
+fn allow_moved_head_commits_leftover_finisher_work() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+    let base_sha = git_output(workspace, &["rev-parse", "HEAD"]).expect("read checkpoint");
+    git_success(workspace, &["checkout", "-b", "epic/ORB-EPIC"]).expect("create epic branch");
+    fs::write(workspace.join("child.txt"), "landed child\n").unwrap();
+    commit_all(workspace, "child landed into epic");
+    fs::write(workspace.join("finisher.txt"), "leftover finisher work\n").unwrap();
+
+    let task = task_with_file("T1", "Epic root", "finisher.txt", "claude");
+    let host = CommitTestHost::new(vec![task], workspace.to_path_buf());
+    let mut input = batch_input(workspace, &base_sha);
+    input["allow_empty"] = json!(true);
+    input["allow_moved_head"] = json!(true);
+
+    let result = git_commit(&host, &input).expect("leftover finisher work is committed");
+    assert_eq!(result["committed"], json!(true));
+    assert_eq!(result["skipped_no_diff_expected"], json!(false));
+    assert!(
+        workspace.join("finisher.txt").exists(),
+        "finisher file remains after commit"
+    );
+}

--- a/docs/design/resident-orchestrator/2_design.md
+++ b/docs/design/resident-orchestrator/2_design.md
@@ -25,7 +25,7 @@ related_artifacts: [ORB-10332, ORB-10775, ORB-10776, ORB-10779, ORB-10788, ORB-1
 > |---|---|
 > | [§1 Epic worktree and sequential child drain](#1-epic-worktree-and-sequential-child-drain) | **live** ([ORB-10816]) |
 > | [§2 Epic agent](#2-epic-agent-epic_orchestrator) | planned ([ORB-10817]) — the shipped activity is still the v1 dispatcher |
-> | [§3 `epic_pipeline` job](#3-epic_pipeline-job) | partly live — §1's phases ship; the agent step, completion gate, and delivery are [ORB-10818] |
+> | [§3 `epic_pipeline` job](#3-epic_pipeline-job) | **live** ([ORB-10818]) — assemble, epic-scoped gate, and inlined delivery |
 > | [§4 Workspace drain](#4-workspace-drain-workspace_auto_pipeline) | **live** ([ORB-10819]) |
 > | [§5](#5-unresolved-work-scan)–[§8](#8-authority-and-completion) | live |
 
@@ -100,9 +100,8 @@ Conversation resume across fires stays out of scope. Each invoke starts fresh fr
 
 ## 3. `epic_pipeline` job
 
-> **Partly live.** The shipped job runs `resolve_ship_input` → `worktree` → `descendants` → the
-> `drain` loop of §1, then stops. The agent step, the completion gate, and delivery are [ORB-10818];
-> until they land, an epic run assembles the branch but does not ship it.
+> **Live** since [ORB-10818]. The shipped job assembles descendants into the epic worktree (§1),
+> invokes the finisher, fails closed on leftover descendants, and delivers the epic branch.
 
 ```text
 worktree = worktree_setup(epic root, run_id: epic-<id>, branch_prefix: epic)

--- a/docs/design/resident-orchestrator/4_decisions.md
+++ b/docs/design/resident-orchestrator/4_decisions.md
@@ -230,7 +230,7 @@ to the drain phase when it does.
 
 ## Epic completion is epic-scoped, not workspace-scoped
 
-**Recorded:** 2026-08 · [ORB-10818] · **Not yet implemented**
+**Recorded:** 2026-08 · [ORB-10818] · **Implemented** in [ORB-10818]
 
 ### Context
 


### PR DESCRIPTION
## Task

[ORB-10818](https://orbit-cli.com/tasks/ORB-10818) — Deliver the epic branch and gate completion on the epic's own descendants

### Description

## Problem

Two gaps once an epic owns a branch (ORB-10816):

1. Nothing delivers that branch. `epic_pipeline` today ends at `require_empty` and never opens a
   PR or merges — delivery only ever happened per-child.
2. `epic_pipeline`'s completion gate is `scan_unresolved_work` with `fail_if_nonempty`, which is
   **workspace-wide**. It fails an epic run because some unrelated chore is in `backlog`, and it
   succeeds an epic run whose own children are unfinished as long as the workspace happens to be
   quiet. The design doc's own §1 calls the scan "the only admission function for `epic_pipeline`";
   that is what changes here.

## Why It Matters

The workspace-wide drain does not disappear — it moves to the auto drain window (ORB-10819),
which is where it belonged. What `epic_pipeline` needs is an epic-scoped answer to "is this epic
finished", and a delivery step that produces the single artifact a human reviews.

## What To Build

1. **Epic-scoped completion gate.** A deterministic activity that returns the epic root's
   non-terminal descendants. The pipeline's drain -> finisher loop breaks when that set is empty
   and the finisher reported completion; a non-empty set at the iteration ceiling fails the run
   closed, exactly as `fail_if_nonempty` does today.
2. **Inlined delivery.** After the gate passes, deliver the epic worktree by mode:
   - `pr`: `pr_prepare` -> `git_rebase` -> `git_push` -> `pr_open` -> `pr_promote`, run directly
     against the epic worktree's `workspace_path`, with `base` the real workspace base.
   - `local`: `git_merge` of the epic branch into the workspace base.
3. The epic root lands in `review` (pr) or `done` (local), which releases its lock reservation and
   makes its worktree gc-eligible.

## Constraints / Notes

- Delivery **must not** invoke `task_pr_pipeline`: that job begins with its own `worktree_setup`
  and would create a second worktree instead of shipping the epic's. The individual delivery
  activities all accept `workspace_path`, so they compose directly.
- Children already carry `landing_branch: <real base>`, so their own obsolescence checks fail
  closed once the epic branch lands. Verify that interaction rather than assuming it.
- `scan_unresolved_work` keeps its workspace-wide shape and its `epic_pipeline`-run exclusion; it
  is simply no longer `epic_pipeline`'s completion gate. Do not delete it.
- The `commit.output.skipped_no_diff_expected` branch in `task_pr_pipeline` is the precedent for an
  epic that produced no diff — an epic whose children all no-op'd must not open an empty PR.

### Acceptance Criteria

- An epic run whose children all merged and whose finisher reported completion delivers exactly one PR against the workspace base in `pr` mode, and exactly one merge in `local` mode.
- Delivery reuses the epic worktree — `git worktree list` shows no additional worktree created by the delivery phase.
- An epic run fails closed when a descendant is still non-terminal at the iteration ceiling, and the failure message names the leftover descendants.
- An unrelated task sitting in `backlog` elsewhere in the workspace neither fails nor prolongs an otherwise-complete epic run.
- An epic that produced no diff completes without opening an empty PR.
- The epic root is `review` after `pr` delivery and `done` after `local` delivery, and its lock reservation is released either way.
- `cargo test -p orbit-core` passes and the shipped/workspace job assets stay byte-identical.
- `make ci-fast` and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- `list_epic_descendants` now accepts `fail_if_nonempty`. A leftover set fails closed and names the remaining descendant ids. Unrelated workspace `backlog` is ignored.
- `epic_pipeline` keeps the assemble loop, then gates on `require_empty` and delivers in place against the epic worktree. It never invokes `task_pr_pipeline`.
- PR delivery: `git_commit` (`allow_empty` + `allow_moved_head`) → `pr_prepare` → `git_rebase` → `git_push` → `pr_open` → `pr_promote`. No-diff skips the PR and `update_task`s the root to `review`.
- Local delivery: `git_merge --ff-only` of the epic branch into the workspace base, then `update_task` to `done`.
- `scan_unresolved_work` is unchanged in behavior; comments now say it is not `epic_pipeline`'s gate.
- Design §3 and the epic-scoped-completion decision are marked live.

Assessment: Acceptance criteria are covered by catalog shape tests, scripted full-job delivery tests (one PR, one local merge, no extra worktree_setup, leftover descendants fail closed, no empty PR), and unit tests for the gate and commit flags. Child `landing_branch` remains the real workspace base so obsolescence still fails closed once the epic lands.

Validation:
- `cargo test -p orbit-core --lib`: 765 passed; one pre-existing failure `dogfood_task_pilot_routine_matches_the_rendered_default_template` (workspace `.orbit/routines/task_pilot.yaml` is `enabled: true` vs the seeded `false`). Not touched by this change.
- `cargo test -p orbit-engine --lib executor::automation::vcs::commit`: 45 passed.
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- Shipped and workspace `epic_pipeline.yaml` remain byte-identical.

Strategic decisions:
- Reused `list_epic_descendants` as the fail-closed gate rather than inventing a second action.
- Added `allow_empty` / `allow_moved_head` on `git_commit` so delivery can commit leftover finisher work after children moved HEAD, and so a no-op epic does not fail commit or open an empty PR.

Recommended follow-ups: none required for this slice.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10818-6a80c80b`
- Behind base: 0
- Ahead of base: 1