### PR TITLE
Record empty fan-out collection outputs before downstream templating

### DIFF
--- a/crates/orbit-engine/src/activity_job/job_executor/fan_out.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/fan_out.rs
@@ -32,9 +32,14 @@ pub(super) fn run_fan_out(
                 failed: 0,
             },
         );
+        let collected_value = Value::Array(Vec::new());
+        if let Some(collect_key) = &fan_in.collect {
+            record_pipeline(ctx, collect_key, collected_value.clone());
+        }
+        record_pipeline(ctx, &step.id, collected_value.clone());
         return Ok(StepOutcome {
             success: true,
-            output: Value::Array(Vec::new()),
+            output: collected_value,
             message: None,
         });
     }

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/fanout.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/fanout.rs
@@ -49,6 +49,28 @@ fn fanout_empty_items_emits_dispatched_zero_and_joined_zero() {
         })
         .expect("FaninJoined event");
     assert_eq!(joined, (0, 0));
+
+    let pipeline = outcome.pipeline.as_object().expect("pipeline obj");
+    assert_eq!(pipeline.get("scatter"), Some(&json!([])));
+}
+
+#[test]
+fn fanout_empty_items_records_collect_alias() {
+    let host = ScriptedHost::new([("worker_action", vec![])]);
+    let job = job_with_steps(vec![fanout_step(
+        "scatter",
+        "{{ input.items }}",
+        4,
+        target_step("worker", "worker_action"),
+        JoinMode::All,
+        Some("results"),
+    )]);
+    let outcome = run_job(&host, &job, json!({"items": []}), "run-fanout-empty-alias");
+
+    assert!(outcome.success);
+    let pipeline = outcome.pipeline.as_object().expect("pipeline obj");
+    assert_eq!(pipeline.get("scatter"), Some(&json!([])));
+    assert_eq!(pipeline.get("results"), Some(&json!([])));
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-10826](https://orbit-cli.com/tasks/ORB-10826) — Record empty fan-out collection outputs before downstream templating

### Description

## Problem
`jrun-20260815-1859` failed in the `task_pilot_pipeline` apply step after preparation found no eligible tasks. The empty-items branch in `run_fan_out` returns a successful empty-array outcome immediately, but unlike the non-empty path it does not call `record_pipeline` for either the fan-in `collect` alias or the fan-out step ID. The following apply step therefore cannot render `{{ steps.pilot_results.output }}` and aborts with `no data recorded for step 'pilot_results'`.

## Why It Matters
A zero-candidate task-pilot run is an expected no-op, especially for its enabled periodic routine. Treating that state as a failed run creates false incidents and causes every empty scheduled cycle to fail. The defect also affects any v2 job whose downstream steps consume the output of an empty fan-out.

## Constraints / Notes
- Preserve the existing `FanoutDispatched` and `FaninJoined` audit events for zero items.
- Preserve join semantics; the empty `all` join remains successful.
- Fix the generic v2 fan-out executor rather than special-casing `task_pilot_pipeline`.
- Add regression coverage for both the step-ID pipeline entry and an explicit `fan_in.collect` alias.
- Incident evidence: `.orbit/state/logs/jrun-20260815-1859.worker.log` at 2026-08-15T18:59:30Z.
- Likely implementation: construct the empty collected value, record the optional collect alias and step ID, then return the successful outcome.
- Rollback is the task-scoped engine/test commit if the change alters non-empty fan-out behavior unexpectedly.

### Acceptance Criteria

- An empty fan-out with `join: all` succeeds and records `[]` under the fan-out step ID in the pipeline context.
- When `fan_in.collect` is configured, the same empty fan-out also records `[]` under that collection alias, so a later `{{ steps.<alias>.output }}` reference renders successfully.
- The existing zero-item audit behavior remains intact: dispatched worker count 0 and joined collected/failed counts 0/0.
- A zero-candidate `task_pilot_pipeline` completes as a successful no-op rather than failing in `apply` with a missing `pilot_results` step.
- Focused regression tests pass, including `cargo test -p orbit-engine fanout_empty_items` and relevant task-pilot pipeline tests in `orbit-core`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated the generic empty `run_fan_out` branch to record `[]` under the optional `fan_in.collect` alias and the fan-out step ID before returning success.
- Extended fan-out regression coverage to assert the step-ID output, collect-alias output, and existing zero-item audit counts.
Assessment: The fix is scoped to the empty-items path, preserves `FanoutDispatched`/`FaninJoined` behavior and all-join success semantics, and leaves the non-empty collection path unchanged.
Validation:
- `cargo test -p orbit-engine fanout_empty_items` — 2 passed.
- `cargo test -p orbit-engine fanout` — 9 passed.
- `cargo test -p orbit-core task_pilot` — 9 passed, including task-pilot catalog and deterministic action tests.
- `make ci-fast` — passed.
- `make ci-lint` — passed.
- `git diff --check` — passed.
No friction was identified.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10826-6a80ce37`
- Behind base: 0
- Ahead of base: 1