### PR TITLE
Make Linux routine scheduling reboot-safe and recover orphaned overlaps

### DIFF
--- a/crates/orbit-cli/src/command/routine/clock.rs
+++ b/crates/orbit-cli/src/command/routine/clock.rs
@@ -34,9 +34,16 @@ impl RoutineClockArgs {
         match self.command {
             RoutineClockSubcommand::Status => {
                 let status = clock_status(&global_root)?;
+                let state = if !status.enabled {
+                    "paused"
+                } else if status.schedulable {
+                    "enabled"
+                } else {
+                    "unhealthy"
+                };
                 println!(
                     "clock: {} | configured cadence: {}s | effective cadence: {} | platform: {}",
-                    if status.enabled { "enabled" } else { "paused" },
+                    state,
                     status.configured_cadence_seconds,
                     status
                         .effective_cadence_seconds
@@ -44,6 +51,9 @@ impl RoutineClockArgs {
                         .unwrap_or_else(|| "inactive".to_string()),
                     status.platform
                 );
+                if let Some(issue) = status.health_issue {
+                    println!("clock health: {issue}");
+                }
             }
             RoutineClockSubcommand::Pause => {
                 let status = set_clock_enabled(&global_root, false)?;

--- a/crates/orbit-core/assets/clock/orbit-sweep.timer
+++ b/crates/orbit-core/assets/clock/orbit-sweep.timer
@@ -1,12 +1,15 @@
-# Configured timer for `orbit sweep` [ORB-10720] / ADR-0204.
-# Persistent=true covers host downtime at the OS layer; per-routine
-# `missed_run` policy decides whether a covered gap produces a make-up fire.
+# Configured timer for `orbit sweep` [ORB-10720].
+# OnStartupSec arms the first sweep in every fresh user-manager session (and
+# fires immediately when a re-install happens after that deadline). Subsequent
+# sweeps are measured from the last service activation. Monotonic timers do not
+# replay missed timer events; each routine's `missed_run` policy decides what a
+# sweep after downtime does with missed cron slots.
 [Unit]
 Description=Run orbit sweep every {{CADENCE_SECONDS}} seconds
 
 [Timer]
+OnStartupSec={{CADENCE_SECONDS}}s
 OnUnitActiveSec={{CADENCE_SECONDS}}s
-Persistent=true
 AccuracySec=5s
 
 [Install]

--- a/crates/orbit-core/src/routines/clock.rs
+++ b/crates/orbit-core/src/routines/clock.rs
@@ -149,6 +149,12 @@ pub struct ClockStatus {
     pub configured_cadence_seconds: u64,
     pub effective_cadence_seconds: Option<u64>,
     pub enabled: bool,
+    /// Whether an enabled native clock has a future trigger. A paused clock is
+    /// intentionally not schedulable and is not unhealthy.
+    pub schedulable: bool,
+    /// Actionable detail when an enabled clock cannot be shown to have a
+    /// future trigger.
+    pub health_issue: Option<String>,
     pub platform: &'static str,
 }
 
@@ -192,6 +198,7 @@ impl ManagerCommand {
 
 pub(super) trait ClockCommandRunner {
     fn run(&self, command: &ManagerCommand) -> Result<bool, OrbitError>;
+    fn stdout(&self, command: &ManagerCommand) -> Result<Option<String>, OrbitError>;
 }
 
 struct NativeClockCommandRunner;
@@ -202,6 +209,19 @@ impl ClockCommandRunner for NativeClockCommandRunner {
             .args(&command.args)
             .output()
             .map(|output| output.status.success())
+            .map_err(|error| OrbitError::Execution(format!("run {}: {error}", command.display())))
+    }
+
+    fn stdout(&self, command: &ManagerCommand) -> Result<Option<String>, OrbitError> {
+        Command::new(command.program)
+            .args(&command.args)
+            .output()
+            .map(|output| {
+                output
+                    .status
+                    .success()
+                    .then(|| String::from_utf8_lossy(&output.stdout).into_owned())
+            })
             .map_err(|error| OrbitError::Execution(format!("run {}: {error}", command.display())))
     }
 }
@@ -343,16 +363,36 @@ fn install_systemd(
         program: "systemctl",
         args: vec!["--user".into(), "daemon-reload".into()],
     };
-    let enable = systemd_enable_command();
+    let enable = ManagerCommand {
+        program: "systemctl",
+        args: vec![
+            "--user".into(),
+            "enable".into(),
+            format!("{SYSTEMD_UNIT}.timer"),
+        ],
+    };
+    let restart = ManagerCommand {
+        program: "systemctl",
+        args: vec![
+            "--user".into(),
+            "restart".into(),
+            format!("{SYSTEMD_UNIT}.timer"),
+        ],
+    };
     let reloaded = runner.run(&reload).unwrap_or(false);
-    let activated = reloaded && runner.run(&enable).unwrap_or(false);
+    let enabled = reloaded && runner.run(&enable).unwrap_or(false);
+    // `enable --now` is a no-op for an already-active timer, including the
+    // broken `active (elapsed)` state this installer must repair. An explicit
+    // restart re-arms the rendered timer on both fresh installs and upgrades.
+    let activated = enabled && runner.run(&restart).unwrap_or(false);
 
     let manual_steps = if activated {
         Vec::new()
     } else {
         vec![
             "systemctl --user daemon-reload".to_string(),
-            format!("systemctl --user enable --now {SYSTEMD_UNIT}.timer"),
+            format!("systemctl --user enable {SYSTEMD_UNIT}.timer"),
+            format!("systemctl --user restart {SYSTEMD_UNIT}.timer"),
         ]
     };
     Ok(ClockInstallReport {
@@ -397,6 +437,19 @@ fn manager_status_command(platform: ClockPlatform) -> ManagerCommand {
                 format!("{SYSTEMD_UNIT}.timer"),
             ],
         },
+    }
+}
+
+fn systemd_next_trigger_command() -> ManagerCommand {
+    ManagerCommand {
+        program: "systemctl",
+        args: vec![
+            "--user".into(),
+            "show".into(),
+            format!("{SYSTEMD_UNIT}.timer"),
+            "--property=NextElapseUSecRealtime".into(),
+            "--property=NextElapseUSecMonotonic".into(),
+        ],
     }
 }
 
@@ -463,7 +516,9 @@ pub(super) fn set_clock_enabled_with(
         .run(&manager_status_command(platform))
         .unwrap_or(false);
     if current == enabled {
-        return Ok(clock_status_from(settings, enabled, platform));
+        return Ok(clock_status_from(
+            settings, enabled, enabled, platform, None,
+        ));
     }
     let command = manager_set_enabled_command(platform, enabled, home);
     let succeeded = runner.run(&command)?;
@@ -474,7 +529,9 @@ pub(super) fn set_clock_enabled_with(
             command.display()
         )));
     }
-    Ok(clock_status_from(settings, enabled, platform))
+    Ok(clock_status_from(
+        settings, enabled, enabled, platform, None,
+    ))
 }
 
 pub fn clock_status(global_root: &Path) -> Result<ClockStatus, OrbitError> {
@@ -494,18 +551,60 @@ pub(super) fn clock_status_with(
     let enabled = runner
         .run(&manager_status_command(platform))
         .unwrap_or(false);
-    Ok(clock_status_from(settings, enabled, platform))
+    let (schedulable, health_issue) = if enabled && platform == ClockPlatform::Systemd {
+        match runner.stdout(&systemd_next_trigger_command()) {
+            Ok(Some(output)) if systemd_output_has_future_trigger(&output) => (true, None),
+            Ok(Some(_)) => (
+                false,
+                Some(
+                    "systemd timer is enabled but has no future trigger; recovery: `orbit routine init --install-clock`"
+                        .to_string(),
+                ),
+            ),
+            Ok(None) | Err(_) => (
+                false,
+                Some(
+                    "systemd timer is enabled but its next trigger could not be verified; recovery: `systemctl --user status orbit-sweep.timer`, then `orbit routine init --install-clock`"
+                        .to_string(),
+                ),
+            ),
+        }
+    } else {
+        (enabled, None)
+    };
+    Ok(clock_status_from(
+        settings,
+        enabled,
+        schedulable,
+        platform,
+        health_issue,
+    ))
+}
+
+fn systemd_output_has_future_trigger(output: &str) -> bool {
+    output.lines().any(|line| {
+        let value = line.split_once('=').map_or(line, |(_, value)| value).trim();
+        !value.is_empty()
+            && !matches!(
+                value.to_ascii_lowercase().as_str(),
+                "n/a" | "infinity" | "0"
+            )
+    })
 }
 
 fn clock_status_from(
     settings: ClockSettings,
     enabled: bool,
+    schedulable: bool,
     platform: ClockPlatform,
+    health_issue: Option<String>,
 ) -> ClockStatus {
     ClockStatus {
         configured_cadence_seconds: settings.cadence_seconds,
-        effective_cadence_seconds: enabled.then_some(settings.cadence_seconds),
+        effective_cadence_seconds: (enabled && schedulable).then_some(settings.cadence_seconds),
         enabled,
+        schedulable,
+        health_issue,
         platform: platform.name(),
     }
 }

--- a/crates/orbit-core/src/routines/sweep.rs
+++ b/crates/orbit-core/src/routines/sweep.rs
@@ -622,6 +622,24 @@ fn sync_unresolved_fires(
                     Some(JobRunState::Cancelled) => {
                         Some((RoutineFireState::Failed, Some("run cancelled")))
                     }
+                    // A persisted in-flight state is not enough to hold an
+                    // overlap slot after a restart. If the recorded owner is
+                    // conclusively gone, no work can still be executing and
+                    // the fire can be reconciled immediately. Alive and
+                    // unknown owners remain protected until their terminal
+                    // state or the normal policy timeout.
+                    Some(JobRunState::Running | JobRunState::Retrying) => {
+                        let liveness = run_id.map_or(RunOwnerLiveness::Unknown, |run_id| {
+                            dispatch.run_owner_liveness(&routine.source_orbit_dir, run_id)
+                        });
+                        match liveness {
+                            RunOwnerLiveness::Stopped => Some((
+                                RoutineFireState::Failed,
+                                Some("run owner stopped before recording a terminal outcome"),
+                            )),
+                            RunOwnerLiveness::Alive | RunOwnerLiveness::Unknown => timed_out(),
+                        }
+                    }
                     // [ORB-10597] Resolving a fire is what releases the
                     // `overlap:forbid` slot, and for `interrupted` alone the
                     // terminal state is not evidence that the work stopped:

--- a/crates/orbit-core/src/routines/tests/clock.rs
+++ b/crates/orbit-core/src/routines/tests/clock.rs
@@ -8,12 +8,13 @@ use orbit_common::types::OrbitError;
 
 use super::super::clock::{
     ClockCommandRunner, ClockPlatform, ClockSettings, ManagerCommand, clock_status_with,
-    load_clock_settings, render_systemd_service, render_systemd_timer, set_clock_cadence_with,
-    set_clock_enabled_with,
+    install_clock_with, load_clock_settings, render_systemd_service, render_systemd_timer,
+    set_clock_cadence_with, set_clock_enabled_with,
 };
 
 struct MockRunner {
     results: Mutex<Vec<Result<bool, OrbitError>>>,
+    outputs: Mutex<Vec<Result<Option<String>, OrbitError>>>,
     commands: Mutex<Vec<String>>,
 }
 
@@ -21,6 +22,18 @@ impl MockRunner {
     fn new(results: Vec<Result<bool, OrbitError>>) -> Self {
         Self {
             results: Mutex::new(results.into_iter().rev().collect()),
+            outputs: Mutex::new(Vec::new()),
+            commands: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn with_outputs(
+        results: Vec<Result<bool, OrbitError>>,
+        outputs: Vec<Result<Option<String>, OrbitError>>,
+    ) -> Self {
+        Self {
+            results: Mutex::new(results.into_iter().rev().collect()),
+            outputs: Mutex::new(outputs.into_iter().rev().collect()),
             commands: Mutex::new(Vec::new()),
         }
     }
@@ -41,6 +54,18 @@ impl ClockCommandRunner for MockRunner {
             .expect("test result queue lock")
             .pop()
             .expect("test configured a result for every manager command")
+    }
+
+    fn stdout(&self, command: &ManagerCommand) -> Result<Option<String>, OrbitError> {
+        self.commands
+            .lock()
+            .expect("test command log lock")
+            .push(command.display());
+        self.outputs
+            .lock()
+            .expect("test output queue lock")
+            .pop()
+            .expect("test configured output for every manager query")
     }
 }
 
@@ -99,13 +124,49 @@ fn rendered_systemd_service_discovers_local_provider_launchers() {
 
 #[test]
 fn systemd_timer_renders_default_and_configured_cadence() {
-    assert!(render_systemd_timer(ClockSettings::default()).contains("OnUnitActiveSec=60s"));
-    assert!(
-        render_systemd_timer(ClockSettings {
-            cadence_seconds: 300
-        })
-        .contains("OnUnitActiveSec=300s")
+    let default_timer = render_systemd_timer(ClockSettings::default());
+    assert!(default_timer.contains("OnStartupSec=60s"));
+    assert!(default_timer.contains("OnUnitActiveSec=60s"));
+    assert!(!default_timer.contains("Persistent=true"));
+
+    let configured_timer = render_systemd_timer(ClockSettings {
+        cadence_seconds: 300,
+    });
+    assert!(configured_timer.contains("OnStartupSec=300s"));
+    assert!(configured_timer.contains("OnUnitActiveSec=300s"));
+}
+
+#[test]
+fn systemd_install_arms_a_fresh_manager_and_recurs_at_configured_cadence() {
+    let root = tempdir().expect("create global root");
+    let home = tempdir().expect("create home");
+    let runner = MockRunner::new(vec![Ok(true), Ok(true), Ok(true)]);
+
+    let report = install_clock_with(
+        root.path(),
+        "/opt/orbit/bin/orbit",
+        ClockSettings {
+            cadence_seconds: 300,
+        },
+        ClockPlatform::Systemd,
+        &runner,
+        home.path(),
+    )
+    .expect("install systemd clock");
+
+    assert!(report.activated);
+    assert_eq!(
+        runner.commands(),
+        vec![
+            "systemctl --user daemon-reload",
+            "systemctl --user enable orbit-sweep.timer",
+            "systemctl --user restart orbit-sweep.timer",
+        ]
     );
+    let timer = fs::read_to_string(home.path().join(".config/systemd/user/orbit-sweep.timer"))
+        .expect("read installed timer");
+    assert!(timer.contains("OnStartupSec=300s"));
+    assert!(timer.contains("OnUnitActiveSec=300s"));
 }
 
 #[test]
@@ -136,17 +197,56 @@ fn clock_cadence_rejects_subminute_and_out_of_range_values() {
 #[test]
 fn status_is_deterministic_for_each_manager_and_reports_configured_cadence() {
     let root = tempdir().expect("create global root");
-    for (platform, manager) in [
-        (ClockPlatform::Launchd, "launchd"),
-        (ClockPlatform::Systemd, "systemd"),
-    ] {
-        let runner = MockRunner::new(vec![Ok(true)]);
-        let status = clock_status_with(root.path(), platform, &runner).expect("read status");
-        assert!(status.enabled);
-        assert_eq!(status.configured_cadence_seconds, 60);
-        assert_eq!(status.effective_cadence_seconds, Some(60));
-        assert_eq!(status.platform, manager);
-    }
+    let launchd = MockRunner::new(vec![Ok(true)]);
+    let status = clock_status_with(root.path(), ClockPlatform::Launchd, &launchd)
+        .expect("read launchd status");
+    assert!(status.enabled);
+    assert!(status.schedulable);
+    assert_eq!(status.configured_cadence_seconds, 60);
+    assert_eq!(status.effective_cadence_seconds, Some(60));
+    assert_eq!(status.platform, "launchd");
+
+    let systemd = MockRunner::with_outputs(
+        vec![Ok(true)],
+        vec![Ok(Some(
+            "NextElapseUSecRealtime=\nNextElapseUSecMonotonic=5min".to_string(),
+        ))],
+    );
+    let status = clock_status_with(root.path(), ClockPlatform::Systemd, &systemd)
+        .expect("read systemd status");
+    assert!(status.enabled);
+    assert!(status.schedulable);
+    assert_eq!(status.effective_cadence_seconds, Some(60));
+    assert!(status.health_issue.is_none());
+    assert_eq!(status.platform, "systemd");
+}
+
+#[test]
+fn enabled_systemd_timer_without_a_future_trigger_is_unhealthy() {
+    let root = tempdir().expect("create global root");
+    let runner = MockRunner::with_outputs(
+        vec![Ok(true)],
+        vec![Ok(Some(
+            "NextElapseUSecRealtime=\nNextElapseUSecMonotonic=0".to_string(),
+        ))],
+    );
+
+    let status = clock_status_with(root.path(), ClockPlatform::Systemd, &runner)
+        .expect("read elapsed timer status");
+
+    assert!(status.enabled);
+    assert!(!status.schedulable);
+    assert_eq!(status.effective_cadence_seconds, None);
+    assert!(status.health_issue.as_deref().is_some_and(|issue| {
+        issue.contains("no future trigger") && issue.contains("orbit routine init --install-clock")
+    }));
+    assert_eq!(
+        runner.commands(),
+        vec![
+            "systemctl --user is-enabled orbit-sweep.timer",
+            "systemctl --user show orbit-sweep.timer --property=NextElapseUSecRealtime --property=NextElapseUSecMonotonic",
+        ]
+    );
 }
 
 #[test]
@@ -225,7 +325,14 @@ fn manager_failures_include_exact_recovery_command() {
 fn cadence_reload_failure_restores_config_and_reactivates_previous_systemd_unit() {
     let root = tempdir().expect("create global root");
     let home = tempdir().expect("create home");
-    let runner = MockRunner::new(vec![Ok(true), Ok(false), Ok(true), Ok(true)]);
+    let runner = MockRunner::new(vec![
+        Ok(true),
+        Ok(true),
+        Ok(false),
+        Ok(true),
+        Ok(true),
+        Ok(true),
+    ]);
     let error = set_clock_cadence_with(
         root.path(),
         300,
@@ -253,9 +360,11 @@ fn cadence_reload_failure_restores_config_and_reactivates_previous_systemd_unit(
         runner.commands(),
         vec![
             "systemctl --user daemon-reload",
-            "systemctl --user enable --now orbit-sweep.timer",
+            "systemctl --user enable orbit-sweep.timer",
+            "systemctl --user restart orbit-sweep.timer",
             "systemctl --user daemon-reload",
-            "systemctl --user enable --now orbit-sweep.timer",
+            "systemctl --user enable orbit-sweep.timer",
+            "systemctl --user restart orbit-sweep.timer",
         ]
     );
 }

--- a/crates/orbit-core/src/routines/tests/sweep.rs
+++ b/crates/orbit-core/src/routines/tests/sweep.rs
@@ -459,6 +459,95 @@ fn interrupted_run_with_unprobeable_owner_is_reclaimed_at_the_policy_timeout() {
     assert_eq!(seeded.state, RoutineFireState::TimedOut);
 }
 
+#[test]
+fn running_run_orphaned_by_restart_releases_the_forbid_slot_immediately() {
+    let store = store();
+    let dispatch = FakeDispatch::default();
+    let coll = collection(vec![routine("job", "* * * * *", true, "forbid", 0)]);
+    store
+        .routine_record_baseline("job", &ts(2026, 1, 1, 0, 0, 0).to_rfc3339())
+        .unwrap();
+    let slot = ts(2026, 1, 1, 0, 5, 0).to_rfc3339();
+    store
+        .routine_record_fire_intent(&RoutineFireIntentParams {
+            routine_name: "job".to_string(),
+            slot: slot.clone(),
+            attempt: 1,
+            source_workspace: "polaris".to_string(),
+        })
+        .unwrap();
+    store
+        .routine_mark_fire_dispatched("job", &slot, 1, "orphaned")
+        .unwrap();
+    dispatch.set_state("orphaned", JobRunState::Running);
+    dispatch.set_liveness("orphaned", RunOwnerLiveness::Stopped);
+
+    let reports = run_sweep_core(
+        &store,
+        HOST,
+        &coll,
+        &dispatch,
+        SweepOptions::default(),
+        ts(2026, 1, 1, 0, 6, 20),
+    )
+    .unwrap();
+
+    assert_eq!(reports[0].action, "fired");
+    assert_eq!(dispatch.submit_count(), 1);
+    let orphaned = fires(&store, "job")
+        .into_iter()
+        .find(|fire| fire.slot == slot)
+        .unwrap();
+    assert_eq!(orphaned.state, RoutineFireState::Failed);
+    assert_eq!(
+        orphaned.detail.as_deref(),
+        Some("run owner stopped before recording a terminal outcome")
+    );
+}
+
+#[test]
+fn running_run_with_a_live_owner_keeps_the_forbid_slot() {
+    let store = store();
+    let dispatch = FakeDispatch::default();
+    let coll = collection(vec![routine("job", "* * * * *", true, "forbid", 0)]);
+    store
+        .routine_record_baseline("job", &ts(2026, 1, 1, 0, 0, 0).to_rfc3339())
+        .unwrap();
+    let slot = ts(2026, 1, 1, 0, 5, 0).to_rfc3339();
+    store
+        .routine_record_fire_intent(&RoutineFireIntentParams {
+            routine_name: "job".to_string(),
+            slot: slot.clone(),
+            attempt: 1,
+            source_workspace: "polaris".to_string(),
+        })
+        .unwrap();
+    store
+        .routine_mark_fire_dispatched("job", &slot, 1, "live")
+        .unwrap();
+    dispatch.set_state("live", JobRunState::Running);
+    dispatch.set_liveness("live", RunOwnerLiveness::Alive);
+
+    let reports = run_sweep_core(
+        &store,
+        HOST,
+        &coll,
+        &dispatch,
+        SweepOptions::default(),
+        ts(2026, 1, 1, 0, 6, 20),
+    )
+    .unwrap();
+
+    assert_eq!(reports[0].action, "skipped");
+    assert_eq!(reports[0].reason.as_deref(), Some("overlap_in_flight"));
+    assert_eq!(dispatch.submit_count(), 0);
+    let live = fires(&store, "job")
+        .into_iter()
+        .find(|fire| fire.slot == slot)
+        .unwrap();
+    assert_eq!(live.state, RoutineFireState::Dispatched);
+}
+
 // ---- outcome sync / staleness horizon -------------------------------------
 
 #[test]

--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -28,8 +28,10 @@ decides whether that pass fires work. The OS clock is host-local infrastructure,
 routine definition. Its durable configuration is `~/.orbit/clock.toml`, defaults to a
 60-second cadence, and accepts only whole-minute values from 60 through 3600 seconds.
 
-`orbit routine clock status` reports both configured cadence and the native manager's
-effective enabled state. `orbit routine clock pause` disables only launchd/systemd
+`orbit routine clock status` reports configured cadence, native-manager enabled state,
+and whether an enabled Linux timer has a finite next trigger. An enabled timer with no
+future trigger is `unhealthy`, has no effective cadence, and reports the reinstall command
+that restores the generated unit. `orbit routine clock pause` disables only launchd/systemd
 scheduled invocations (surviving logout/reboot through the native per-user manager);
 it preserves routine cursors, fire history, and per-routine pauses, and a deliberate
 `orbit sweep` is still available. `enable` resumes with the configured cadence, while
@@ -191,10 +193,12 @@ Per pass:
    cache age, or remote registry state participate.
 4. Filter to routines where `enabled`, validation says this machine owns the pin, and no
    local pause.
-5. Sync unresolved fires against actual run state, reclaiming entries older than the
-   routine's `timeout_minutes` (the staleness horizon — a sweep that crashed between
-   intent and dispatch must not block `overlap: forbid` forever). Fires for a routine that
-   is no longer assigned to this machine are deliberately untouched.
+5. Sync unresolved fires against actual run state. A dispatched `running`/`retrying` run
+   whose recorded owner is conclusively stopped is failed immediately, including after a
+   host restart; an alive or unprobeable owner keeps its overlap slot. Other unresolved
+   entries are reclaimed after the routine's `timeout_minutes` staleness horizon, so a
+   sweep that crashed between intent and dispatch cannot block `overlap: forbid` forever.
+   Fires for a routine that is no longer assigned to this machine are deliberately untouched.
 6. For each, compute due-ness from the cron expression and the persisted cursor
    (last slot, else the first-observation baseline — a routine never fires for slots that
    predate its registration on this host; the first sweep records the baseline and fires
@@ -251,9 +255,13 @@ renders and installs the platform unit:
 
 - **macOS** — a launchd agent (`com.orbit.sweep`) with `StartInterval` 60s. launchd also
   fires on wake, which pairs with `missed_run: catch_up_once` for laptop sleep gaps.
-- **Linux** — `orbit-sweep.timer` (`OnCalendar=*:*:00`, `Persistent=true`) plus a oneshot
-  service. `Persistent=true` covers downtime at the OS layer; per-routine `missed_run`
-  still decides whether the covered gap produces a make-up fire.
+- **Linux** — `orbit-sweep.timer` combines `OnStartupSec=<cadence>` with
+  `OnUnitActiveSec=<cadence>` plus a oneshot service. A fresh user manager therefore arms a
+  finite first sweep; a reinstall after the startup deadline fires immediately; successful
+  service activations schedule subsequent sweeps at the configured cadence. These monotonic
+  triggers deliberately do not replay timer events missed while the manager or host was
+  down. The first sweep after restart evaluates each routine's cursor, so `catch_up_once`
+  collapses missed cron slots to one fire and `skip` waits for the next natural slot.
 
 There is no resident Orbit daemon. Sub-minute triggers and event triggers are explicitly
 out of v1 scope for this reason.
@@ -291,7 +299,8 @@ out of v1 scope for this reason.
   records it as `failed` — retryable under `policy.retries` like a run-level failure; a crashed
   sweep's reclaimed stale intent is *ambiguous* (a worker may have partially started), so the
   outcome sync records it as `error` — terminal, never re-fired, so a make-up fire cannot race
-  an orphaned run.
+  an orphaned run. A dispatched in-flight run is released before that timeout only when its
+  recorded owner is conclusively stopped; live and unprobeable owners remain protected.
 - **Routines carry no input payload.** v1 dispatches every target with an empty input
   object; jobs meant for routines must run with defaults. Parameterized fires would be a
   schema addition.

--- a/docs/design/routines/3_vision.md
+++ b/docs/design/routines/3_vision.md
@@ -67,9 +67,9 @@ task, implementation, and validation evidence, not by drifting in.
 - **cron / anacron** — the trigger vocabulary (5-field expressions) and the missed-run
   problem anacron exists to solve; routines adopt the vocabulary and make missed-run policy
   per-definition instead of system-wide.
-- **systemd timers / launchd** — v1's actual clock. `Persistent=true` and launchd wake
-  behavior are load-bearing; routines deliberately delegate "when does the machine wake"
-  to them.
+- **systemd timers / launchd** — v1's actual clock. launchd wake behavior and systemd's
+  monotonic startup/post-activation triggers guarantee another sweep without replaying
+  every missed clock tick; routine cursors and `missed_run` own cron-gap semantics.
 
 ### Workflow engines
 - **Temporal / Cadence schedules** — durable schedules attached to durable executions,
@@ -110,7 +110,7 @@ Orbit-internal:
   relevant to what scheduled targets may do.
 
 External:
-- systemd.timer(5), launchd.plist(5) — persistence and wake semantics.
+- systemd.timer(5), launchd.plist(5) — monotonic restart and wake semantics.
 - Temporal "Schedules" documentation — overlap/catch-up policy vocabulary.
 - Kubernetes CronJob documentation — concurrency and missed-fire edge cases.
 

--- a/docs/design/routines/4_decisions.md
+++ b/docs/design/routines/4_decisions.md
@@ -30,12 +30,12 @@ Something must wake the scheduler. Alternatives: a resident `orbit schedulerd` o
 
 ### Decision
 
-launchd (`StartInterval` 60s) and a systemd timer (`OnCalendar=*:*:00`, `Persistent=true`) invoke `orbit sweep` every minute; sweep is stateless-in, durable-out. Missed-fire semantics split between the OS layer (wake/persistence behavior) and per-routine `missed_run` policy. There is no resident Orbit daemon.
+launchd (`StartInterval` 60s) and a systemd timer (`OnStartupSec` plus `OnUnitActiveSec`) invoke `orbit sweep`; sweep is stateless-in, durable-out. The systemd timer arms itself in every fresh user-manager session and recurs after service activation. Missed cron-slot semantics belong to each routine's `missed_run` policy. There is no resident Orbit daemon.
 
 ### Consequences
 
 - No process supervision, crash recovery, or memory-leak surface; a wedged pass affects one minute, not the scheduler.
-- launchd wake behavior and `Persistent=true` pair with `missed_run: catch_up_once` to cover laptop sleep and host downtime.
+- launchd wake behavior and systemd's first sweep after a fresh manager session pair with `missed_run: catch_up_once` to cover laptop sleep and host downtime without replaying every missed clock tick.
 - Cost: minute granularity is a hard floor and event triggers are structurally impossible in v1; correct behavior depends on two platform-specific unit files that must be kept in parity and tested on both platforms.
 
 ## Routine discovery via the workspace registry and a versioned [routines] role=source config key
@@ -161,6 +161,8 @@ Store the supported whole-minute cadence in host-local `~/.orbit/clock.toml` and
 
 ### Consequences
 - Clock status reports configured and effective cadence, and native-manager failures include recovery commands.
+- On Linux, enabled state is insufficient for health: status reports an effective cadence only when systemd also exposes a finite next trigger, and an elapsed or unscheduled timer reports the clock reinstall recovery command.
+- Linux uses monotonic startup and post-activation triggers. A fresh user-manager session always gains an initial trigger; missed timer ticks are not replayed, leaving catch-up versus skip behavior to each routine's persisted cursor and `missed_run` policy.
 - Cost: the host-local setting intentionally does not travel with a workspace, so operators configure each host separately.
 
 ## Task References

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -129,12 +129,29 @@ monitoring at the detailed form.
 ## Check the routine clock
 
 Routines are Orbit's scheduling surface. Install or refresh the host clock with
-`orbit routine init --install-clock`. Inspect due work and recent fires through:
+`orbit routine init --install-clock`. Verify the native clock separately from routine due
+state:
 
 ```sh
+orbit routine clock status
 orbit routine list
 orbit sweep --json
 ```
+
+On Linux, a healthy enabled status includes a finite next systemd trigger and an effective
+cadence. `clock: unhealthy` with an inactive effective cadence means the timer is enabled but
+elapsed, unscheduled, or could not be probed; follow the printed diagnostic and reinstall the
+generated units with `orbit routine init --install-clock`. The generated timer schedules its
+first sweep from each systemd user-manager startup and then recurs from service activation.
+It does not replay every tick missed during host or manager downtime: on the next sweep,
+routine `missed_run: catch_up_once` fires once for a gap while `skip` waits for the next natural
+cron slot.
+
+If an `overlap: forbid` routine remains `overlap_in_flight` after a restart, run one explicit
+`orbit sweep --json` and inspect the referenced run. Sweep releases a dispatched in-flight
+fire immediately only when the recorded owner process is conclusively gone; a live or
+unprobeable owner remains protected until terminal or until the routine timeout. Use
+`orbit doctor` and the stuck-job-run runbook below when the run itself remains orphaned.
 
 The dashboard also exposes `GET /api/routines`. Auto-task definitions such as
 `qa-sweep` and `artifact-deprecation-review` are ordinary workspace data under


### PR DESCRIPTION
## Task

[ORB-10822](https://orbit-cli.com/tasks/ORB-10822) — Make Linux routine scheduling reboot-safe and recover orphaned overlaps

### Description

## Problem
The Linux Orbit sweep clock can remain enabled but permanently unscheduled after a reboot or [REDACTED_ENV]-manager restart. The cadence change introduced by ORB-10720 replaced the calendar trigger with only `OnUnitActiveSec`; without a prior service activation in the new manager session, systemd reports the timer as `active (elapsed)` with no next trigger. `Persistent=true` does not repair this because systemd applies it only to calendar timers.

Orbit currently masks the failure: `orbit routine clock status` checks only whether the timer is enabled, so it reports a healthy effective cadence even when systemd has no future elapse. The incident also left `auto_task_scheduler` blocked as `overlap_in_flight` after reboot despite no live Orbit process, indicating orphaned dispatched/in-flight state is not reconciled.

## Why It Matters
All enabled routines can silently stop for days across normal host restarts while routine listings continue to show plausible future due times. After the clock is restored, individual routines may still remain permanently blocked by stale overlap state.

## Constraints / Notes
- Preserve configurable whole-minute cadences and the intended missed-run semantics.
- Keep macOS launchd behavior unchanged.
- Treat systemd enabled state and actual schedulability as separate health signals.
- Use deterministic manager/process/time fakes for automated coverage; tests must not depend on a live [REDACTED_ENV] systemd session.
- Align current routine documentation and generated unit comments with the implemented contract.

### Acceptance Criteria

- - Starting or reinstalling the Linux clock in a fresh systemd [REDACTED_ENV]-manager session produces a finite next trigger and invokes the first sweep without requiring a manual service start.
- Subsequent sweeps recur at both the default cadence and a configured cadence, and the selected trigger mechanism has tested/documented restart and missed-run behavior.
- `orbit routine clock status` does not report an effective healthy cadence for an enabled timer that is elapsed or has no future trigger; CLI output clearly identifies the unhealthy state and an actionable recovery path.
- A routine whose last dispatched/in-flight run lost its owning process during restart is deterministically reconciled so `overlap: forbid` does not block it forever, without clearing genuinely live work.
- Deterministic automated tests reproduce the fresh-manager timer failure and orphaned-overlap case and pass after the fix.
- Current routine design/runbook documentation matches Linux timer, health-reporting, and recovery behavior; macOS clock behavior remains unchanged.
- `make ci-fast` and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced the Linux timer with restart-safe monotonic OnStartupSec plus OnUnitActiveSec triggers, removed ineffective Persistent=true, and made installation explicitly enable then restart the timer so an already-active elapsed unit is re-armed.
- Added a systemd next-trigger probe. Clock status now distinguishes enabled from schedulable, withholds effective cadence for elapsed/unverifiable timers, prints an unhealthy state, and supplies concrete recovery commands. launchd behavior is unchanged.
- Reconciled dispatched running/retrying routine fires immediately when the recorded owner is conclusively stopped, while preserving overlap protection for live or unprobeable owners.
- Added deterministic clock manager/render/install/status tests and orphaned-versus-live overlap tests. Updated routine design, vision, decision, and health runbook documentation for restart, missed-run, health, and recovery behavior.
Assessment: The implementation keeps the timer and overlap changes at their existing ownership boundaries, uses fail-safe liveness classification, and covers default/configured cadence plus the observed failure states deterministically.
Validation:
- cargo test -p orbit-core routines::tests (42 passed)
- cargo test -p orbit-core routines::tests::clock (10 passed after the final installer re-arm change)
- cargo test -p orbit-cli (360 unit/integration tests passed)
- make ci-fast (passed)
- make ci-lint (passed)
- git diff --check (passed)
Deviations from original plan:
- Added file:docs/design/routines/3_vision.md to context_files because its current systemd persistence description was directly invalidated by the timer fix.
- An initial cargo test -p orbit-cli --lib invocation was inapplicable because orbit-cli has no library target; the correct package-wide cargo test -p orbit-cli passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10822-6a80ce37`
- Behind base: 0
- Ahead of base: 1