### PR TITLE
Make PR the default workspace ship mode

### DIFF
--- a/crates/orbit-cli/src/command/run/ship.rs
+++ b/crates/orbit-cli/src/command/run/ship.rs
@@ -40,7 +40,7 @@ pub struct ShipCommand {
     pub task_ids: Vec<String>,
     /// Pipeline mode for selected or auto-discovered task bundles. When omitted,
     /// the mode is resolved from the current workspace's registry entry
-    /// (explicit `ship_mode`, else defaults to `local`).
+    /// (explicit `ship_mode`, else defaults to `pr`).
     #[arg(short = 'm', long, value_enum)]
     pub mode: Option<ShipMode>,
     /// Base branch for shipment. Defaults to
@@ -94,9 +94,8 @@ impl Execute for ShipCommand {
 ///
 /// An explicit `--mode` wins. Otherwise the mode is resolved from the current
 /// workspace's registry entry (matched by `orbit_dir`): explicit `ship_mode`,
-/// else the `local` default. If the current workspace isn't found in the
-/// registry, fall back to `local` (the safe default — a repo without an explicit
-/// `pr` mode should never attempt a PR that could fail structurally).
+/// else the `pr` default. If the current workspace isn't found in the registry,
+/// fall back to `pr` so omitted configuration still uses reviewable delivery.
 fn resolve_ship_mode(
     args: &ShipCommand,
     runtime: &OrbitRuntime,
@@ -114,7 +113,7 @@ fn resolve_ship_mode(
             orbit_registry::workspace_registry::find_workspace(&registry, &checkout.workspace_id)
         })
         .map(orbit_core::resolved_ship_mode)
-        .unwrap_or(orbit_core::ShipMode::Local);
+        .unwrap_or(orbit_core::ShipMode::Pr);
     Ok(mode)
 }
 

--- a/crates/orbit-cli/src/command/run/sweep.rs
+++ b/crates/orbit-cli/src/command/run/sweep.rs
@@ -29,7 +29,7 @@ use crate::command::{CommandOut, CommandOutput};
 pub struct ShipSweepCommand {
     /// Override the pipeline mode for every dispatched ship run. When omitted,
     /// each workspace's mode is resolved from its registry entry
-    /// (explicit `ship_mode`, else defaults to `local`).
+    /// (explicit `ship_mode`, else defaults to `pr`).
     #[arg(short = 'm', long, value_enum)]
     pub mode: Option<ShipMode>,
     /// Report what would be dispatched without submitting any run.
@@ -167,9 +167,8 @@ fn sweep_workspace(
     }
     // An explicit `--mode` override wins for every workspace; otherwise resolve
     // per-workspace from its registry entry (explicit `ship_mode`, else the
-    // `local` default). This keeps direct-commit workspaces on the `local`
-    // pipeline instead of failing `pr_open` — only workspaces that carry an
-    // explicit `ship_mode = "pr"` ship via PR.
+    // `pr` default). Workspaces that deliberately ship in-place must carry an
+    // explicit `ship_mode = "local"`.
     let mode = mode_override.unwrap_or_else(|| orbit_core::resolved_ship_mode(ws));
     sweep_active_workspace(global_root, ws, checkout, mode, dry_run).unwrap_or_else(|error| {
         SweepReport {

--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -31,7 +31,7 @@ pub struct WorkspaceInitArgs {
     #[arg(long)]
     pub base_branch: Option<String>,
     /// Ship-pipeline mode for this workspace: `pr` or `local`. When omitted, the
-    /// effective mode defaults to `local` (only PR-gated workspaces set `pr`).
+    /// effective mode defaults to `pr`; pass `--ship-mode local` for in-place delivery.
     #[arg(long, value_name = "MODE")]
     pub ship_mode: Option<String>,
     /// Explicit local checkout role. Omit for the compatible local-owner

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -55,6 +55,29 @@ fn workspace_reinit_requires_force_and_force_reconciles_matching_registration() 
         .into_iter()
         .next()
         .expect("registered workspace");
+    assert_eq!(original.ship_mode, None);
+    assert_eq!(
+        orbit_core::resolved_ship_mode(&original).as_input_value(),
+        "pr",
+        "an omitted ship mode must preserve the PR delivery default"
+    );
+
+    init(None, Some("local"), true)
+        .execute_without_runtime(None)
+        .expect("re-init with explicit local mode");
+    let after_local_registry = workspace_registry::load_registry_from(&registry_path)
+        .expect("load registry after local mode update");
+    let after_local_mode = after_local_registry
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == original.id)
+        .expect("registered workspace");
+    assert_eq!(after_local_mode.ship_mode.as_deref(), Some("local"));
+    assert_eq!(
+        orbit_core::resolved_ship_mode(after_local_mode).as_input_value(),
+        "local",
+        "an explicit local ship mode must retain in-place delivery"
+    );
     let authored_routine = r#"schemaVersion: 1
 name: custom-ship-sweep
 description: operator-authored routine

--- a/crates/orbit-common/src/types/workspace.rs
+++ b/crates/orbit-common/src/types/workspace.rs
@@ -48,8 +48,8 @@ pub struct Workspace {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub git_remote: Option<String>,
     /// Explicit ship-pipeline mode for this workspace: `"pr"` or `"local"`.
-    /// When unset, the effective mode is derived from `git_remote`
-    /// (see `orbit_core::resolved_ship_mode`). Stored on the registry entry
+    /// When unset, the effective mode is `"pr"` (see
+    /// `orbit_core::resolved_ship_mode`). Stored on the registry entry
     /// rather than `config.toml` because per-workspace `[workflow]` config
     /// is stripped by task-mutation commands.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/orbit-core/src/command/workflow.rs
+++ b/crates/orbit-core/src/command/workflow.rs
@@ -61,18 +61,15 @@ impl ShipMode {
 /// Resolve the effective ship mode for a workspace registry entry.
 ///
 /// An explicit `ship_mode` on the entry wins; otherwise the mode defaults to
-/// `local`. The default is deliberately NOT derived from `git_remote`: several
-/// direct-commit workspaces (e.g. `worker`, `bridge`) still have GitHub remotes,
-/// so a "github → pr" heuristic would wrongly attempt PRs for them. Only the
-/// PR-gated workspaces (`orbit`, `sextant`) carry an explicit `ship_mode = "pr"`.
-/// Defaulting to `local` means a sweep never accidentally attempts a PR.
+/// `pr`. The default is deliberately NOT derived from `git_remote`: an omitted
+/// mode consistently preserves the review boundary, regardless of the remote.
 ///
-/// An unparseable explicit `ship_mode` falls back to `local` rather than
+/// An unparseable explicit `ship_mode` falls back to `pr` rather than
 /// erroring, so a malformed registry entry can never wedge a sweep.
 pub fn resolved_ship_mode(workspace: &orbit_common::types::Workspace) -> ShipMode {
     match workspace.ship_mode.as_deref() {
-        Some(explicit) => ShipMode::parse(explicit).unwrap_or(ShipMode::Local),
-        None => ShipMode::Local,
+        Some(explicit) => ShipMode::parse(explicit).unwrap_or(ShipMode::Pr),
+        None => ShipMode::Pr,
     }
 }
 
@@ -213,27 +210,26 @@ mod ship_mode_resolution_tests {
     }
 
     #[test]
-    fn unset_ship_mode_defaults_to_local_regardless_of_remote() {
-        // Direct-commit workspaces (worker, bridge) also have GitHub remotes,
-        // so the default must NOT be derived from the remote — it is always local.
+    fn unset_ship_mode_defaults_to_pr_regardless_of_remote() {
+        // The default is independent of the remote and preserves the review
+        // boundary for every workspace configured without a ship mode.
         assert_eq!(
             resolved_ship_mode(&workspace(Some("https://github.com/acme/worker.git"), None)),
-            ShipMode::Local
+            ShipMode::Pr
         );
         assert_eq!(
             resolved_ship_mode(&workspace(Some("git@github.com:acme/bridge.git"), None)),
-            ShipMode::Local
+            ShipMode::Pr
         );
         assert_eq!(
             resolved_ship_mode(&workspace(Some("/home/daniel/git/polaris.git"), None)),
-            ShipMode::Local
+            ShipMode::Pr
         );
-        assert_eq!(resolved_ship_mode(&workspace(None, None)), ShipMode::Local);
+        assert_eq!(resolved_ship_mode(&workspace(None, None)), ShipMode::Pr);
     }
 
     #[test]
     fn explicit_pr_wins_over_github_remote() {
-        // The PR-gated repos (orbit, sextant) carry an explicit ship_mode = "pr".
         let ws = workspace(Some("https://github.com/acme/orbit.git"), Some("pr"));
         assert_eq!(resolved_ship_mode(&ws), ShipMode::Pr);
     }
@@ -245,8 +241,8 @@ mod ship_mode_resolution_tests {
     }
 
     #[test]
-    fn unparseable_explicit_mode_falls_back_to_local() {
+    fn unparseable_explicit_mode_falls_back_to_pr() {
         let ws = workspace(Some("https://github.com/acme/orbit.git"), Some("bogus"));
-        assert_eq!(resolved_ship_mode(&ws), ShipMode::Local);
+        assert_eq!(resolved_ship_mode(&ws), ShipMode::Pr);
     }
 }

--- a/crates/orbit-web/src/api/tests/workspaces.rs
+++ b/crates/orbit-web/src/api/tests/workspaces.rs
@@ -732,7 +732,7 @@ async fn refresh_rebuilds_runtime_for_ship_mode_only_change() {
     let global_root = tmp.path().join("global");
     std::fs::create_dir_all(&global_root).expect("create global root");
     let (_alpha_orbit, alpha_repo) = seed_workspace(&global_root, tmp.path(), "alpha");
-    write_registry_with_ship_modes(&global_root, &[("alpha", &alpha_repo, None)]);
+    write_registry_with_ship_modes(&global_root, &[("alpha", &alpha_repo, Some("local"))]);
     let state = registry_state(&global_root);
 
     assert_eq!(route_status(&state, "alpha").await, StatusCode::OK);


### PR DESCRIPTION
## Task

[ORB-10829](https://orbit-cli.com/tasks/ORB-10829) — Make PR the default workspace ship mode

### Description

## Problem
Orbit currently documents and resolves an omitted workspace `--ship-mode` as `local`. The safe default should instead be `pr`; `local` should require an explicit choice.

## Why It Matters
Defaulting to local delivery can bypass the review boundary when a workspace is configured without an explicit ship mode. A PR-by-default posture makes the safer, reviewable path automatic while preserving local delivery for workspaces that deliberately opt into it.

## Constraints / Notes
- Change the effective default everywhere it is defined or described, including CLI help, configuration resolution, persisted/default workspace behavior, examples, and fixtures.
- Preserve both accepted values: `pr` and `local`.
- An explicit `--ship-mode local` must continue to select local delivery.
- Audit call sites and tests that relied on an omitted value meaning `local`; make that intent explicit rather than retaining an implicit compatibility fallback.
- Do not silently rewrite workspaces that already persist an explicit ship mode.

### Acceptance Criteria

- When workspace setup or registration omits `--ship-mode`, the resulting effective ship mode is `pr`, demonstrated by deterministic unit or integration coverage of the default-resolution path.
- Passing `--ship-mode local` still produces effective mode `local`, and passing `--ship-mode pr` still produces effective mode `pr`; both cases have regression coverage.
- CLI help and maintained user-facing documentation describe `pr` as the default and contain no remaining claim that omission defaults to `local`.
- Fixtures and internal callers that genuinely require local delivery specify `local` explicitly, with no fallback elsewhere that changes an omitted ship mode back to `local`.
- The relevant focused test suites and `cargo test --workspace` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Changed registry and no-registry ship-mode resolution to PR, while preserving explicit local and PR choices.
- Updated workspace-init and ship/sweep CLI help plus workspace type docs to describe PR as the omitted default.
- Added workspace-init regression assertions for omitted PR resolution and explicit local delivery; made the web runtime-refresh fixture declare local explicitly.
Assessment: Focused core, CLI, and web tests pass; formatting, fast CI checks, and workspace clippy pass. cargo test --workspace was attempted but is blocked by a reproducible unrelated orbit-search test failure: commands::tests::install::fd_launch_executes_descriptor_not_path_after_swap reports search companion failed to download model test-model.
Validation:
- cargo fmt --all -- --check: passed
- cargo test -p orbit-core ship_mode_resolution_tests: passed (4)
- cargo test -p orbit-cli workspace_reinit_requires_force_and_force_reconciles_matching_registration: passed
- cargo test -p orbit-web refresh_rebuilds_runtime_for_ship_mode_only_change: passed
- make ci-fast: passed
- make ci-lint: passed
- cargo test --workspace: failed only at the unrelated reproducible orbit-search test named above.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10829-6a80d467`
- Behind base: 0
- Ahead of base: 1