### PR TITLE
Make fd-launch regression portable and require QA to task breaking tests

### DIFF
--- a/crates/orbit-core/assets/auto_tasks/qa-sweep.yaml
+++ b/crates/orbit-core/assets/auto_tasks/qa-sweep.yaml
@@ -17,11 +17,24 @@ template:
     the Orbit MCP tools or the equivalent `orbit tool run orbit.task.add`
     command. Give it severity-appropriate priority, tag it `qa-sweep`, and put
     the relevant commits, observed evidence, and exact reproduction steps in
-    its description. Skip duplicates. Your narrative output is advisory; the
-    tasks you create are the durable side-effect channel.
+    its description. Skip duplicates.
+
+    A non-duplicate failing test that blocks the repository's
+    standard validation command must be filed as an Orbit task even when
+    the failure is sandbox-specific, platform-specific, or otherwise
+    environment-specific, including test-harness or portability defects.
+    Do not leave such a breaking test in narrative-only output. Distinguish
+    clearly between validation impact (the prescribed suite cannot complete)
+    and production impact (whether the failure demonstrates a production
+    defect). Include the failing command, the exact error, relevant
+    environment evidence, and a scope assessment.
+
+    Your narrative output is advisory; the tasks you create are the durable
+    side-effect channel.
   acceptance_criteria:
   - Recent changes were exercised through their real user-facing paths.
   - Real, non-duplicate issues were filed as Orbit tasks with evidence and reproduction steps.
+  - Non-duplicate failing tests that block the prescribed validation command were filed as Orbit tasks, with validation impact distinguished from production impact.
   task_type: chore
   tags:
   - qa-sweep

--- a/crates/orbit-core/src/auto_tasks/tests/shipped.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/shipped.rs
@@ -202,10 +202,37 @@ fn qa_sweep_default_preserves_hands_on_validation_contract() {
         "validate them hands-on",
         "exercise the affected",
         "skip duplicates",
+        "failing test",
+        "standard validation command",
+        "must be filed as an orbit task",
+        "environment-specific",
+        "test-harness",
+        "portability",
+        "narrative-only",
+        "validation impact",
+        "production impact",
+        "failing command",
+        "exact error",
+        "environment evidence",
+        "scope assessment",
     ] {
         assert!(
             body.contains(required),
             "template should retain '{required}'"
         );
     }
+    assert!(
+        definition
+            .template
+            .acceptance_criteria
+            .iter()
+            .any(|criterion| {
+                let criterion = criterion.to_lowercase();
+                criterion.contains("failing test")
+                    && criterion.contains("validation command")
+                    && criterion.contains("validation impact")
+                    && criterion.contains("production impact")
+            }),
+        "qa-sweep acceptance criteria must require filing breaking tests"
+    );
 }

--- a/crates/orbit-search/src/commands/tests/install.rs
+++ b/crates/orbit-search/src/commands/tests/install.rs
@@ -119,10 +119,14 @@ fn current_companion_freshness_hash_uses_open_descriptor() {
 }
 
 /// End-to-end coverage for the fexecve launch path on platforms that
-/// actually use it. Writes a mock companion that records its own marker on
-/// `--download-model`, opens it as a `ManagedCompanion`, swaps the binary at
-/// the install path, then drives the model download. The marker file proves
-/// the fd-held binary ran, not the path-swapped one.
+/// actually use it. Writes an ELF mock companion that records its own marker
+/// on `--download-model`, opens it as a `ManagedCompanion`, swaps the binary
+/// at the install path, then drives the model download. The marker file
+/// proves the fd-held binary ran, not the path-swapped one.
+///
+/// The mock must be a real ELF image: a shebang script executed via
+/// `execveat(fd, "", AT_EMPTY_PATH)` also needs the kernel to hand the
+/// interpreter `/proc/self/fd/<n>`, which fails when `/proc` is `noexec`.
 #[test]
 #[cfg(any(
     target_os = "linux",
@@ -146,8 +150,18 @@ fn fd_launch_executes_descriptor_not_path_after_swap() {
     let companion = ManagedCompanion::open_current(&fixture.paths.companion_path())
         .expect("current install should verify");
 
-    // Swap the binary at the install path. A path-based exec would now pick
-    // up the "swapped" variant; an fd-based exec must still run "original".
+    // Swap the install path so a path-based exec would pick up "swapped"
+    // while the fd-based launch must still run "original".
+    //
+    // Move the opened dentry aside before placing the replacement. A
+    // rename-over unlinks the fd's dentry, and `execveat(AT_EMPTY_PATH)`
+    // then fails with ENOENT when `/proc` is `noexec` — for ELF as well as
+    // shebang, because the kernel reconstructs the unlinked exe path via
+    // `/proc/self/fd`. Relocating the dentry keeps the descriptor's inode
+    // named without consulting `/proc`.
+    let held_path = fixture.paths.bin_dir.join("held-original-companion");
+    std::fs::rename(fixture.paths.companion_path(), &held_path)
+        .expect("move original companion dentry aside");
     let replacement_path = fixture.paths.bin_dir.join("replacement-companion");
     write_marker_companion(&replacement_path, env!("CARGO_PKG_VERSION"), "swapped");
     std::fs::rename(&replacement_path, fixture.paths.companion_path())
@@ -550,49 +564,160 @@ exit 0
     std::fs::set_permissions(path, permissions).expect("chmod companion");
 }
 
-/// A companion variant that records its identity to `<model_dir>/companion-identity.txt`
-/// on `--download-model`, used by the fd-launch end-to-end test. Argument parsing
-/// is minimal because the real companion accepts `--model X --model-path Y --download-model`.
+/// Token stamped into the compiled ELF so each fixture can carry a distinct
+/// identity without a second rustc invocation. Must stay the same length as
+/// the `ORB_MARKER` array in `marker_companion_source`.
 #[cfg(any(
     target_os = "linux",
     target_os = "android",
     target_os = "freebsd",
     target_os = "dragonfly"
 ))]
-fn write_marker_companion(path: &std::path::Path, version: &str, marker: &str) {
+const MARKER_TOKEN: &[u8; 32] = b"ORB10835_FD_LAUNCH_MARKER_______";
+
+/// A companion variant that records its identity to `<model_dir>/companion-identity.txt`
+/// on `--download-model`, used by the fd-launch end-to-end test. The fixture is
+/// a compiled ELF image so `fexecve` does not need a shebang interpreter lookup
+/// through `/proc/self/fd`. Argument parsing is minimal because the real
+/// companion accepts `--model X --model-path Y --download-model`.
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+fn write_marker_companion(path: &std::path::Path, _version: &str, marker: &str) {
     use std::os::unix::fs::PermissionsExt;
 
-    let script = format!(
-        r#"#!/bin/sh
-# marker-companion: {marker}
-model_path=""
-download=0
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --model-path)
-      shift
-      model_path="$1"
-      ;;
-    --download-model)
-      download=1
-      ;;
-  esac
-  shift
-done
-if [ "$1" = "--version-info" ] || [ "$2" = "--version-info" ]; then
-  printf '%s\n' '{{"id":0,"result":{{"model_id":"bge-small-en-v1.5","dim":0,"max_input_tokens":0,"version":"{version}"}}}}'
-  exit 0
-fi
-if [ "$download" = "1" ] && [ -n "$model_path" ]; then
-  printf '%s\n' '{marker}' > "$model_path/companion-identity.txt"
-fi
-exit 0
-"#
-    );
-    std::fs::write(path, script).expect("write marker companion");
+    let bytes = stamp_marker_companion(marker);
+    std::fs::write(path, bytes).expect("write marker companion");
     let mut permissions = std::fs::metadata(path).expect("metadata").permissions();
     permissions.set_mode(0o755);
     std::fs::set_permissions(path, permissions).expect("chmod marker companion");
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+fn stamp_marker_companion(marker: &str) -> Vec<u8> {
+    assert!(
+        marker.len() <= MARKER_TOKEN.len(),
+        "marker longer than ELF identity token"
+    );
+    let mut stamped = vec![b' '; MARKER_TOKEN.len()];
+    stamped[..marker.len()].copy_from_slice(marker.as_bytes());
+    let mut bytes = marker_companion_template().to_vec();
+    let mut replacements = 0usize;
+    let mut index = 0;
+    while index + MARKER_TOKEN.len() <= bytes.len() {
+        if bytes[index..index + MARKER_TOKEN.len()] == *MARKER_TOKEN {
+            bytes[index..index + MARKER_TOKEN.len()].copy_from_slice(&stamped);
+            replacements += 1;
+            index += MARKER_TOKEN.len();
+        } else {
+            index += 1;
+        }
+    }
+    assert!(
+        replacements > 0,
+        "compiled marker companion is missing the identity token"
+    );
+    bytes
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+fn marker_companion_template() -> &'static [u8] {
+    static TEMPLATE: OnceLock<Vec<u8>> = OnceLock::new();
+    TEMPLATE.get_or_init(compile_marker_companion_template)
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+fn compile_marker_companion_template() -> Vec<u8> {
+    let scratch = tempfile::tempdir().expect("marker companion scratch dir");
+    let src_path = scratch.path().join("marker_companion.rs");
+    let bin_path = scratch.path().join("marker_companion");
+    std::fs::write(&src_path, marker_companion_source()).expect("write marker companion source");
+
+    let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+    let output = std::process::Command::new(rustc)
+        .arg("--edition")
+        .arg("2021")
+        .arg("-C")
+        .arg("debuginfo=0")
+        .arg("-C")
+        .arg("strip=symbols")
+        .arg("-C")
+        .arg("opt-level=0")
+        .arg("-o")
+        .arg(&bin_path)
+        .arg(&src_path)
+        .output()
+        .expect("spawn rustc for marker companion");
+    assert!(
+        output.status.success(),
+        "rustc failed to build fd-launch marker companion: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let bytes = std::fs::read(&bin_path).expect("read compiled marker companion");
+    assert!(
+        bytes.starts_with(b"\x7fELF"),
+        "fd-launch fixture must be an ELF image, not a shebang script"
+    );
+    assert!(
+        bytes
+            .windows(MARKER_TOKEN.len())
+            .any(|window| window == MARKER_TOKEN),
+        "compiled marker companion is missing the identity token"
+    );
+    bytes
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+fn marker_companion_source() -> &'static str {
+    r#"
+#[used]
+#[no_mangle]
+static ORB_MARKER: [u8; 32] = *b"ORB10835_FD_LAUNCH_MARKER_______";
+
+fn main() {
+    let marker = core::str::from_utf8(&ORB_MARKER).unwrap_or("").trim();
+    let mut model_path = None;
+    let mut download = false;
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--model-path" => model_path = args.next(),
+            "--download-model" => download = true,
+            _ => {}
+        }
+    }
+    if download {
+        if let Some(dir) = model_path {
+            let path = std::path::Path::new(&dir).join("companion-identity.txt");
+            let _ = std::fs::write(path, format!("{marker}\n"));
+        }
+    }
+}
+"#
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Task

[ORB-10835](https://orbit-cli.com/tasks/ORB-10835) — Make fd-launch regression portable and require QA to task breaking tests

### Description

## Problem
`cargo test --workspace` cannot complete in a supported sandbox because `orbit-search::commands::tests::install::fd_launch_executes_descriptor_not_path_after_swap` uses a `#!/bin/sh` mock companion. After the test unlinks/swaps that script, Linux launches the retained descriptor with `execveat(fd, "", ..., AT_EMPTY_PATH)`; the interpreter path must then be resolved through `/proc/self/fd/<n>`, which fails with `ENOENT` when `/proc` is mounted `noexec`.

The failure does not demonstrate a production companion defect because the real companion is an ELF executable, but it is still a test-portability defect: it prevents the repository's standard validation command from completing in the agent sandbox. The QA sweep treated it as environment-specific and recorded it only in narrative output instead of creating durable follow-up work. The QA contract should require task creation for non-duplicate failing tests that break the standard validation path, including environment-specific test-harness or portability failures.

## Why It Matters
A regression test intended to protect descriptor-held execution should run in the environments used by agents without weakening its path-swap security assertion. Separately, QA findings that block the prescribed validation suite must not disappear merely because production impact is limited or hosted CI is green.

## Constraints / Notes
- Preserve the test's core invariant: after the installed path is swapped, execution must use the descriptor-held original, not the replacement at the path.
- Make the mock executable independent of a shebang/interpreter lookup through `/proc/self/fd`; do not solve this by skipping the test on `noexec` `/proc` or by relaxing the assertion.
- Avoid changing production companion-launch behavior unless implementation evidence demonstrates that a production change is required.
- Revise the checked-in `qa-sweep` instructions so a non-duplicate failing test that blocks the repository's standard validation command is filed as an Orbit task even when it is sandbox-, platform-, or environment-specific. The task should distinguish test-harness/portability impact from production impact and include the failing command, exact error, relevant environment evidence, and scope assessment.
- Preserve duplicate search and severity-appropriate prioritization.
- ORB-10795 last touched this test for an unrelated CI fix; this task is not asserting that ORB-10795 introduced the defect.

### Acceptance Criteria

- `orbit-search::commands::tests::install::fd_launch_executes_descriptor_not_path_after_swap` passes when `/proc` is mounted `noexec` and still proves that the descriptor-held original executable runs after the install path is swapped.
- The fd-launch regression is not skipped or conditionally ignored solely because `/proc` is `noexec`, and its test fixture no longer depends on executing an unlinked shebang script through `/proc/self/fd`.
- The checked-in `qa-sweep` instructions explicitly require filing a non-duplicate Orbit task for any failing test that blocks the prescribed validation command, including environment-specific test-harness or portability defects, while requiring a clear distinction between validation impact and production impact.
- QA-sweep contract tests assert the new breaking-test filing requirement so future asset changes cannot silently restore narrative-only handling.
- The focused `orbit-search` install tests and QA auto-task asset tests pass.
- `cargo test --workspace` completes successfully in the agent sandbox and in normal CI.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced the fd-launch shebang fixture in `crates/orbit-search/src/commands/tests/install.rs` with a rustc-compiled ELF mock. The binary is built once per test process, then stamped with a same-length identity token so `original` vs `swapped` stay distinct. The test asserts the fixture starts with `\x7fELF` and is not skipped when `/proc` is `noexec`.
- The path swap now moves the opened dentry aside before renaming the replacement into the install path. A rename-over unlinks the fd's dentry; on this sandbox `execveat(fd, "", AT_EMPTY_PATH)` then returns `ENOENT` for ELF as well as shebang because the kernel reconstructs the unlinked exe path via `/proc/self/fd`. Relocating the dentry keeps the descriptor-held inode named. After the swap, `download_model` still has to run the held original, not the replacement at the path.
- Production companion launch is unchanged. memfd clone was tried and rejected here: `memfd` `execveat` returns `EACCES` under this bwrap profile.
- Revised `crates/orbit-core/assets/auto_tasks/qa-sweep.yaml` so a non-duplicate failing test that blocks the repository's standard validation command must be filed as an Orbit task even when it is sandbox-, platform-, or environment-specific, including test-harness/portability defects. The task must include the failing command, exact error, environment evidence, and a validation-vs-production impact assessment. Duplicate search and severity-appropriate priority are unchanged.
- Extended `qa_sweep_default_preserves_hands_on_validation_contract` so those filing phrases and the matching acceptance criterion cannot regress to narrative-only handling.

Assessment: The fd-launch invariant is preserved and now runs in the agent sandbox (`/proc` is `noexec`). QA contract tests lock the new filing rule. Workspace tests passed.

Strategic decisions:
- ELF fixture instead of shebang, matching the real companion image type.
- Keep production `fexecve` as-is; the portable test swap is the smallest change that still proves descriptor-held execution after the install path is replaced.
- Keep qa-sweep wording workspace-generic ("standard validation command") rather than hard-coding `cargo test --workspace`.

Design weaknesses / risks:
- Severity: low. The test no longer exercises a fully unlinked inode. Mitigation: comments document why, and a true unlink still fail-closes in production (fexecve errors instead of running the replacement).
- Severity: low. The ELF mock depends on `RUSTC`/`rustc` at test time. Mitigation: `cargo test` already provides that compiler; compile failure is a loud assert.

Deviations from original plan:
- Plan assumed an ELF fixture alone would make rename-over work. Strace showed `execveat(AT_EMPTY_PATH)=ENOENT` on an unlinked ELF when `/proc` is `noexec`. Justification: change the test swap to relocate the opened dentry instead of changing production launch.

Validation:
- `cargo test -p orbit-search --lib commands::tests::install` — 19 passed, including `fd_launch_executes_descriptor_not_path_after_swap` with `/proc` mounted `noexec`.
- `cargo test -p orbit-core --lib auto_tasks::tests::shipped` — 5 passed.
- `cargo test --workspace` — passed (exit 0).
- Edited Rust files rustfmt-clean. `make ci-fast` still fails `cargo fmt --all -- --check` on pre-existing drift in `asset_loader.rs` and `activity.rs` (not in this diff). Remaining ci-fast guardrail scripts passed.

Unlisted files: none. Friction: none filed; the unlinked-`execveat` + `noexec` `/proc` finding is recorded here and in the test comment, not as Orbit tooling friction.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10835-6a80dab9`
- Behind base: 0
- Ahead of base: 1