### PR TITLE
Distinguish SQLITE_FULL from a genuine schema-migration fault

### DIFF
--- a/crates/orbit-store/src/sqlite/migration/ledger.rs
+++ b/crates/orbit-store/src/sqlite/migration/ledger.rs
@@ -20,7 +20,7 @@
 //!   no-op that then records version 1.
 
 use orbit_common::types::OrbitError;
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, ErrorCode, params};
 
 /// One entry in the migration registry.
 pub(crate) struct Migration {
@@ -219,7 +219,12 @@ fn apply_one(conn: &Connection, migration: &Migration) -> Result<(), OrbitError>
         ))
     })?;
 
-    (migration.apply)(&tx)?;
+    (migration.apply)(&tx).map_err(|error| {
+        OrbitError::Migration(format!(
+            "failed to apply migration v{} ({}): {error}",
+            migration.version, migration.name
+        ))
+    })?;
 
     tx.execute(
         "INSERT INTO schema_meta(key, value, updated_at) VALUES (?1, ?2, ?3)
@@ -237,12 +242,8 @@ fn apply_one(conn: &Connection, migration: &Migration) -> Result<(), OrbitError>
         ))
     })?;
 
-    tx.commit().map_err(|e| {
-        OrbitError::Migration(format!(
-            "failed to commit migration v{} ({}): {e}",
-            migration.version, migration.name
-        ))
-    })?;
+    tx.commit()
+        .map_err(|error| commit_migration_error(migration, error))?;
 
     orbit_common::tracing::info!(
         target: "orbit.store.sqlite",
@@ -251,6 +252,24 @@ fn apply_one(conn: &Connection, migration: &Migration) -> Result<(), OrbitError>
         "applied store schema migration",
     );
     Ok(())
+}
+
+pub(super) fn commit_migration_error(migration: &Migration, error: rusqlite::Error) -> OrbitError {
+    if matches!(
+        &error,
+        rusqlite::Error::SqliteFailure(sqlite_error, _)
+            if sqlite_error.code == ErrorCode::DiskFull
+    ) {
+        return OrbitError::Store(format!(
+            "SQLITE_FULL / ENOSPC while committing migration v{} ({}): {error}",
+            migration.version, migration.name
+        ));
+    }
+
+    OrbitError::Migration(format!(
+        "failed to commit migration v{} ({}): {error}",
+        migration.version, migration.name
+    ))
 }
 
 fn ensure_schema_meta_table(conn: &Connection) -> Result<(), OrbitError> {

--- a/crates/orbit-store/src/sqlite/migration/tests/ledger.rs
+++ b/crates/orbit-store/src/sqlite/migration/tests/ledger.rs
@@ -1,6 +1,6 @@
 // ORB-10003: versioned schema-migration ledger.
 use orbit_common::types::OrbitError;
-use rusqlite::Connection;
+use rusqlite::{Connection, Error as SqliteError, ffi};
 
 use super::super::ledger::{self, Migration};
 use super::super::*;
@@ -453,11 +453,11 @@ fn migration_v1_marker(conn: &Connection) -> Result<(), OrbitError> {
 }
 
 fn migration_v2_fails_midway(conn: &Connection) -> Result<(), OrbitError> {
-    conn.execute_batch("CREATE TABLE ledger_test_half_applied (x INTEGER)")
+    conn.execute_batch(
+        "CREATE TABLE ledger_test_half_applied (x INTEGER);\n         this is not valid migration SQL",
+    )
         .map_err(|e| OrbitError::Store(e.to_string()))?;
-    Err(OrbitError::Migration(
-        "intentional mid-migration failure".to_string(),
-    ))
+    Ok(())
 }
 
 #[test]
@@ -478,6 +478,8 @@ fn failed_migration_rolls_back_schema_and_ledger() {
 
     let err = ledger::run_migrations(&conn, &registry).expect_err("v2 must fail");
     assert!(matches!(err, OrbitError::Migration(_)), "got {err:?}");
+    let message = err.to_string();
+    assert!(message.contains("v2 (fails-midway)"), "got {message}");
 
     // v1 committed; v2 rolled back completely — no half-applied schema,
     // no ledger row.
@@ -501,6 +503,23 @@ fn failed_migration_rolls_back_schema_and_ledger() {
     ];
     ledger::run_migrations(&conn, &fixed).expect("resume after fix");
     assert_eq!(current_schema_version(&conn).expect("current version"), 2);
+}
+
+#[test]
+fn sqlite_full_commit_error_is_a_store_resource_error() {
+    let migration = Migration {
+        version: 42,
+        name: "disk-full-test",
+        apply: migration_v1_marker,
+    };
+    let error = SqliteError::SqliteFailure(ffi::Error::new(ffi::SQLITE_FULL), None);
+
+    let mapped = ledger::commit_migration_error(&migration, error);
+
+    assert!(matches!(mapped, OrbitError::Store(_)), "got {mapped:?}");
+    let message = mapped.to_string();
+    assert!(message.contains("SQLITE_FULL"), "got {message}");
+    assert!(message.contains("v42 (disk-full-test)"), "got {message}");
 }
 
 fn migration_v1_marker_v2(conn: &Connection) -> Result<(), OrbitError> {


### PR DESCRIPTION
## Task

[ORB-10841](https://orbit-cli.com/tasks/ORB-10841) — Distinguish SQLITE_FULL from a genuine schema-migration fault

### Description

## Problem
When the host `/tmp` tmpfs fills, in-memory Orbit runtimes fail with `Migration("failed to commit migration vN (name): database or disk is full")`. SQLite maps `SQLITE_FULL` onto whichever statement is running; the first statement each in-memory runtime runs is the newest migration, so the error names that migration even when the migration SQL is fine.

Filed as F2026-08-054 during ORB-10680: 182 of 746 orbit-core tests failed with the v12 friction_records_sqlite commit error while `df -h /tmp` showed a 14G tmpfs at 100% (11,259 leftover `orbit-in-memory-*` dirs). After reclaiming space, the same suite passed with no code change.

Current wrapper is unchanged: `crates/orbit-store/src/sqlite/migration/ledger.rs:240-245` still formats every `tx.commit()` error as a migration fault.

## Why It Matters
Agents treat the named migration as their own regression and spend a long time debugging a green SQL change. Disk-full is an environment condition and should say so.

## Constraints / Notes
- Do not change migration semantics or hide a real SQL failure.
- `OrbitRuntime::in_memory()` already uses a `tempfile::TempDir` (`crates/orbit-core/src/runtime/builder.rs:242-251`); leftover directories from killed suites are a host-ops concern, not this task's primary fix.
- Keep the migration name/version in the message so a genuine commit failure is still attributable.

## Evidence
- F2026-08-054 (open)
- `ledger.rs:240-245` `failed to commit migration v{} ({}): {e}`

### Acceptance Criteria

- A SQLITE_FULL / "database or disk is full" failure from `tx.commit()` (or the equivalent apply/record step) is reported as a disk-full / resource error that names SQLITE_FULL or ENOSPC, not solely as a broken migration.
- A genuine migration SQL or schema_meta failure still surfaces as `OrbitError::Migration` and still names the version and migration name.
- A unit or integration test covers the disk-full mapping without requiring a real 14G tmpfs, and a separate test still covers a real migration fault.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Classified a `rusqlite::ErrorCode::DiskFull` commit failure as `OrbitError::Store` with an explicit `SQLITE_FULL / ENOSPC` resource message while retaining the migration version and name.
- Wrapped migration-apply failures as `OrbitError::Migration` with the version and migration name, preserving rollback semantics and attribution for genuine SQL failures.
- Added deterministic tests for the synthetic SQLite disk-full error and a real invalid-SQL migration fault.
Assessment: Targeted change; no migration semantics or dependency edges changed.
Validation:
- `cargo test -p orbit-store sqlite::migration::tests::ledger` (14 passed)
- `cargo test -p orbit-store` (272 passed, 4 ignored)
- `make ci-fast` (passed)
- `make ci-lint` was attempted but is blocked by two pre-existing, unrelated `orbit-web/src/api/denials.rs` clippy findings (`map_identity` and `question_mark`); the changed crates passed clippy compilation before that workspace failure.
Friction checkpoint: no new friction filed; the unrelated lint failure was immediately identifiable and did not meet the evidence/time threshold.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10841-6a80e3b1`
- Behind base: 0
- Ahead of base: 1