### PR TITLE
Stop comma-splitting orbit task add acceptance criteria

### DIFF
--- a/crates/orbit-cli/src/command/task/add.rs
+++ b/crates/orbit-cli/src/command/task/add.rs
@@ -19,8 +19,8 @@ pub struct TaskAddArgs {
     /// Task description
     #[arg(long, default_value = "")]
     pub description: String,
-    /// Acceptance criteria. Repeat or comma-separate for multiple criteria.
-    #[arg(long = "acceptance-criteria", action = ArgAction::Append, value_delimiter = ',')]
+    /// Acceptance criteria. Repeat the flag for multiple criteria.
+    #[arg(long = "acceptance-criteria", action = ArgAction::Append)]
     pub acceptance_criteria: Vec<String>,
     /// Dependency task IDs. Repeat or comma-separate for multiple dependencies.
     #[arg(long, alias = "dependency", action = ArgAction::Append, value_delimiter = ',')]

--- a/crates/orbit-cli/src/command/task/tests/add.rs
+++ b/crates/orbit-cli/src/command/task/tests/add.rs
@@ -20,9 +20,9 @@ fn task_add_parses_repeat_and_comma_delimited_lists() {
         "--type",
         "bug",
         "--acceptance-criteria",
-        "first,second",
+        "first",
         "--acceptance-criteria",
-        "third",
+        "second",
         "--tag",
         "cli,surface",
         "--tag",
@@ -44,7 +44,7 @@ fn task_add_parses_repeat_and_comma_delimited_lists() {
         panic!("expected task add command");
     };
 
-    assert_eq!(args.acceptance_criteria, ["first", "second", "third"]);
+    assert_eq!(args.acceptance_criteria, ["first", "second"]);
     assert_eq!(args.tags, ["cli", "surface", "test"]);
     assert_eq!(args.dependencies, ["ORB-00001", "ORB-00002", "ORB-00003"]);
     assert_eq!(args.context, ["file:one.rs", "file:two.rs", "dir:three"]);
@@ -52,6 +52,33 @@ fn task_add_parses_repeat_and_comma_delimited_lists() {
     assert_eq!(args.plan, "Plain plan");
     assert_eq!(args.priority, orbit_core::TaskPriority::High);
     assert_eq!(args.task_type, Some(orbit_core::TaskType::Bug));
+}
+
+#[test]
+fn task_add_acceptance_criteria_does_not_split_on_commas() {
+    let cli = Cli::parse_from([
+        "orbit",
+        "task",
+        "add",
+        "--title",
+        "Comma criteria",
+        "--acceptance-criteria",
+        "given X, then Y",
+        "--acceptance-criteria",
+        "given A, then B",
+    ]);
+
+    let Commands::Task(task) = cli.command else {
+        panic!("expected task command");
+    };
+    let TaskSubcommand::Add(args) = task.command else {
+        panic!("expected task add command");
+    };
+
+    assert_eq!(
+        args.acceptance_criteria,
+        ["given X, then Y", "given A, then B"]
+    );
 }
 
 #[test]

--- a/crates/orbit-cli/src/command/task/tests/update.rs
+++ b/crates/orbit-cli/src/command/task/tests/update.rs
@@ -33,6 +33,33 @@ fn task_update_accepts_context_files_alias() {
 }
 
 #[test]
+fn task_update_acceptance_criteria_does_not_split_on_commas() {
+    let cli = Cli::try_parse_from([
+        "orbit",
+        "task",
+        "update",
+        "ORB-00001",
+        "--acceptance-criteria",
+        "given X, then Y",
+        "--acceptance-criteria",
+        "given A, then B",
+    ])
+    .expect("parse task update acceptance criteria");
+
+    let Commands::Task(task) = cli.command else {
+        panic!("expected task command");
+    };
+    let TaskSubcommand::Update(args) = task.command else {
+        panic!("expected task update command");
+    };
+
+    assert_eq!(
+        args.acceptance_criteria,
+        ["given X, then Y", "given A, then B"]
+    );
+}
+
+#[test]
 fn task_update_complexity_uses_add_spellings() {
     for complexity in ["low", "medium", "hard"] {
         let cli = Cli::try_parse_from([


### PR DESCRIPTION
## Task

[ORB-10839](https://orbit-cli.com/tasks/ORB-10839) — Stop comma-splitting orbit task add acceptance criteria

### Description

## Problem
`orbit task add --acceptance-criteria` comma-splits each value (`value_delimiter = ','` in `crates/orbit-cli/src/command/task/add.rs:23`). `orbit task update --acceptance-criteria` does not (`crates/orbit-cli/src/command/task/update.rs:21-22`). Passing the same repeated flags stores different data: a criterion containing a comma is silently cut in half on create.

Reproduced in F2026-08-070: six repeated `--acceptance-criteria` values stored ten fragments (ORB-10763, ORB-10767, ORB-10768, ORB-10769 all needed a follow-up `update` to repair). `task add` reports success; the damage is only visible on read-back.

## Why It Matters
Well-written criteria attract commas ("given X, then Y", file lists, "proven by Z"). The better the criterion, the more likely it is mangled. The `orbit-task` skill's create exit condition looks satisfied because the task exists.

## Constraints / Notes
- Prefer `update`'s behavior: each flag occurrence is one whole criterion.
- If the comma-separated shorthand is kept, split only when the flag is given exactly once, and report the resulting criterion count at creation.
- Adjacent observation in the friction (no `--priority` on `update`) is out of scope unless it is the same clap surface change.
- Do not change MCP `orbit.task.add` `string_list` parsing unless it shares the same splitter.

## Evidence
- F2026-08-070 (open)
- `crates/orbit-cli/src/command/task/add.rs:22-24` has `ArgAction::Append, value_delimiter = ','`
- `crates/orbit-cli/src/command/task/update.rs:20-22` has no `value_delimiter`

### Acceptance Criteria

- A task created with two repeated `--acceptance-criteria` values that each contain a comma stores exactly two criteria; `orbit task show <id> --json` (or `orbit.task.show`) returns both strings intact.
- A single `--acceptance-criteria` value that contains a comma is stored as one criterion, or, if the one-shot comma shorthand is deliberately kept, the create response reports the resulting criterion count so a split is visible.
- `orbit task add` and `orbit task update` treat repeated `--acceptance-criteria` flags the same way; a focused CLI test covers the previously mangled "given X, then Y" shape.
- Existing tasks that were not created in this change are left untouched.

## Execution Summary

<details>
<summary>Click to expand</summary>

Removed value_delimiter = ',' from --acceptance-criteria in crates/orbit-cli/src/command/task/add.rs so each repeated flag occurrence stores one whole criterion, matching task update's existing behavior (ArgAction::Append only, doc comment reworded to match update.rs's "Repeat the flag for multiple criteria."). No comma-shorthand splitting was kept, so a single value containing a comma is stored as one criterion with no separate count-reporting needed.

Tests: updated the existing task_add_parses_repeat_and_comma_delimited_lists test (it previously asserted comma-splitting for acceptance-criteria; now asserts two repeated flags stay two items) and added a focused regression test on both add and update — task_add_acceptance_criteria_does_not_split_on_commas / task_update_acceptance_criteria_does_not_split_on_commas — covering the "given X, then Y" shape from F2026-08-070 with two repeated flags each containing a comma, asserting both criteria come back intact and the commas are preserved.

Scope: only crates/orbit-cli/src/command/task/add.rs and its sibling tests/add.rs and tests/update.rs changed (both in original context_files or their direct sibling test files); update.rs's parsing logic itself was untouched since it already had the correct behavior. MCP orbit.task.add string_list parsing was not touched per the task's explicit constraint. Existing tasks are unaffected — this is a CLI argument-parsing change only, no data migration or rewrite of stored criteria.

Validation: cargo test -p orbit-cli --bin orbit task:: — 19/19 passed. make ci-fast passed. make ci-lint / cargo clippy -p orbit-cli --all-targets -D warnings failed, but only in crates/orbit-web/src/api/denials.rs (map_identity + question_mark lints), a pre-existing failure unrelated to this change (confirmed via git diff --stat showing no orbit-web files touched, and git log on that file predating this task). Recording as a skipped/pre-existing check per validation policy rather than fixing out-of-scope code.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10839-6a80e4b1`
- Behind base: 0
- Ahead of base: 1