### PR TITLE
Fail open when managed-asset reconciliation cannot write a read-only manifest

### DIFF
--- a/crates/orbit-core/src/command/mod.rs
+++ b/crates/orbit-core/src/command/mod.rs
@@ -13,6 +13,7 @@
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 
 use orbit_common::types::OrbitError;
@@ -209,7 +210,13 @@ pub(crate) fn reconcile_managed_assets<'a>(
         assets: next_assets,
     };
     if previous.as_ref() != Some(&manifest) {
-        write_managed_asset_manifest(&manifest_path, &manifest)?;
+        let encoded = encode_managed_asset_manifest(&manifest)?;
+        record_managed_manifest_write(
+            &manifest_path,
+            asset_kind,
+            atomic_write_text(&manifest_path, &encoded),
+            &mut result.warnings,
+        )?;
     }
 
     for warning in &result.warnings {
@@ -226,10 +233,21 @@ pub(crate) fn reconcile_managed_assets<'a>(
 
 /// Persist one managed-asset manifest. Callers compare against the previous
 /// manifest first so a steady-state bootstrap performs no write at all.
+///
+/// Explicit repair paths (`orbit doctor --fix-stale-artifacts`) use this
+/// fail-closed helper. Reconciliation uses [`record_managed_manifest_write`]
+/// so a read-only global root does not fail a later read-only command.
 fn write_managed_asset_manifest(
     manifest_path: &Path,
     manifest: &ManagedAssetManifest,
 ) -> Result<(), OrbitError> {
+    let encoded = encode_managed_asset_manifest(manifest)?;
+    atomic_write_text(manifest_path, &encoded).map_err(|error| {
+        managed_asset_manifest_io_error(manifest_path, &manifest.asset_kind, error)
+    })
+}
+
+fn encode_managed_asset_manifest(manifest: &ManagedAssetManifest) -> Result<String, OrbitError> {
     let asset_kind = &manifest.asset_kind;
     let mut encoded = serde_json::to_string_pretty(manifest).map_err(|error| {
         OrbitError::Store(format!(
@@ -237,12 +255,65 @@ fn write_managed_asset_manifest(
         ))
     })?;
     encoded.push('\n');
-    atomic_write_text(manifest_path, &encoded).map_err(|error| {
-        OrbitError::Io(format!(
-            "write managed {asset_kind} asset manifest '{}': {error}",
-            manifest_path.display()
-        ))
-    })
+    Ok(encoded)
+}
+
+/// Read-only / permission denials on a needed manifest write are a
+/// deployment shape (immutable global root, sandboxed runner), not a
+/// reason to refuse a later read-only command.
+pub(crate) fn managed_manifest_write_is_skippable(error: &io::Error) -> bool {
+    match error.kind() {
+        io::ErrorKind::PermissionDenied | io::ErrorKind::ReadOnlyFilesystem => true,
+        _ => error
+            .raw_os_error()
+            .is_some_and(is_readonly_or_access_errno),
+    }
+}
+
+#[cfg(unix)]
+fn is_readonly_or_access_errno(code: i32) -> bool {
+    code == libc::EROFS || code == libc::EACCES
+}
+
+#[cfg(not(unix))]
+fn is_readonly_or_access_errno(_code: i32) -> bool {
+    false
+}
+
+fn managed_asset_manifest_io_error(
+    manifest_path: &Path,
+    asset_kind: &str,
+    error: io::Error,
+) -> OrbitError {
+    OrbitError::Io(format!(
+        "write managed {asset_kind} asset manifest '{}': {error}",
+        manifest_path.display()
+    ))
+}
+
+/// Record a needed manifest write, warning (instead of failing closed) when
+/// the destination is EROFS/EACCES. Other I/O failures stay fatal.
+pub(crate) fn record_managed_manifest_write(
+    manifest_path: &Path,
+    asset_kind: &str,
+    write_result: Result<(), io::Error>,
+    warnings: &mut Vec<String>,
+) -> Result<(), OrbitError> {
+    match write_result {
+        Ok(()) => Ok(()),
+        Err(error) if managed_manifest_write_is_skippable(&error) => {
+            warnings.push(format!(
+                "could not write managed {asset_kind} asset manifest '{}': {error}; continuing without updating it",
+                manifest_path.display()
+            ));
+            Ok(())
+        }
+        Err(error) => Err(managed_asset_manifest_io_error(
+            manifest_path,
+            asset_kind,
+            error,
+        )),
+    }
 }
 
 fn load_managed_asset_manifest(

--- a/crates/orbit-core/src/command/tests/managed_asset_manifest.rs
+++ b/crates/orbit-core/src/command/tests/managed_asset_manifest.rs
@@ -1,0 +1,228 @@
+use std::io;
+use std::path::Path;
+
+use orbit_common::types::OrbitError;
+use tempfile::tempdir;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+use super::super::MANAGED_ASSET_MANIFEST_FILE;
+use super::super::activity::seed_default_activities;
+use super::super::init::{InitOptions, init_workspace_at_root};
+use super::super::{managed_manifest_write_is_skippable, record_managed_manifest_write};
+use crate::OrbitRuntime;
+use crate::command::job::JobCatalogFilter;
+use crate::config::agent_detect::DetectedAgents;
+
+fn init_global(root: &Path) {
+    init_workspace_at_root(
+        root,
+        InitOptions {
+            global_only: true,
+            refresh_defaults: true,
+            detected: Some(DetectedAgents::default()),
+            ..Default::default()
+        },
+    )
+    .expect("initialize global defaults");
+}
+
+#[cfg(unix)]
+fn make_read_only(path: &Path) {
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o555))
+        .expect("make managed asset directory read-only");
+}
+
+#[cfg(unix)]
+fn make_writable(path: &Path) {
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+        .expect("restore managed asset directory permissions");
+}
+
+fn assert_invalid_input(error: OrbitError, needles: &[&str]) {
+    match error {
+        OrbitError::InvalidInput(message) => {
+            for needle in needles {
+                assert!(
+                    message.contains(needle),
+                    "expected `{needle}` in `{message}`"
+                );
+            }
+        }
+        other => panic!("expected InvalidInput, got {other}"),
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn needed_manifest_write_on_readonly_dir_warns_and_continues() {
+    let root = tempdir().expect("create tempdir");
+    let global_root = root.path().join("global");
+    init_global(&global_root);
+
+    let activities_dir = global_root.join("resources/activities");
+    let jobs_dir = global_root.join("resources/jobs");
+    let manifest = activities_dir.join(MANAGED_ASSET_MANIFEST_FILE);
+    std::fs::remove_file(&manifest).expect("drop manifest to force a write");
+
+    make_read_only(&activities_dir);
+    make_read_only(&jobs_dir);
+    let seeded = seed_default_activities(&activities_dir, true);
+    let workspace_root = root.path().join("repo/.orbit");
+    let runtime = OrbitRuntime::from_roots(&global_root, &workspace_root)
+        .and_then(|runtime| runtime.list_job_catalog_with_last_run(true, JobCatalogFilter::All));
+    make_writable(&activities_dir);
+    make_writable(&jobs_dir);
+
+    let seeded = seeded.expect("EROFS/EACCES on a needed manifest write must not fail the command");
+    assert!(
+        seeded.warnings.iter().any(|warning| {
+            warning.contains("could not write managed activity asset manifest")
+                && warning.contains(MANAGED_ASSET_MANIFEST_FILE)
+        }),
+        "expected a recorded warning, got {:?}",
+        seeded.warnings
+    );
+    assert!(
+        !manifest.exists(),
+        "a skipped read-only write must leave the missing manifest missing"
+    );
+    runtime.expect("read-only runtime bootstrap succeeds after a skipped manifest write");
+}
+
+#[test]
+fn malformed_manifest_fails_closed_with_repair_message() {
+    let root = tempdir().expect("create tempdir");
+    let global_root = root.path().join("global");
+    init_global(&global_root);
+
+    let activities_dir = global_root.join("resources/activities");
+    std::fs::write(
+        activities_dir.join(MANAGED_ASSET_MANIFEST_FILE),
+        "{not-json\n",
+    )
+    .expect("write malformed manifest");
+
+    let error = seed_default_activities(&activities_dir, true)
+        .expect_err("malformed manifest must fail closed");
+    assert_invalid_input(
+        error,
+        &[
+            "is invalid:",
+            "repair it or move it aside only after reviewing the managed YAML files",
+        ],
+    );
+}
+
+#[test]
+fn unexpected_manifest_asset_kind_fails_closed() {
+    let root = tempdir().expect("create tempdir");
+    let global_root = root.path().join("global");
+    init_global(&global_root);
+
+    let activities_dir = global_root.join("resources/activities");
+    let manifest_path = activities_dir.join(MANAGED_ASSET_MANIFEST_FILE);
+    let raw = std::fs::read_to_string(&manifest_path).expect("read manifest");
+    let mut manifest: serde_json::Value = serde_json::from_str(&raw).expect("parse manifest");
+    manifest["assetKind"] = serde_json::Value::String("job".to_string());
+    std::fs::write(
+        &manifest_path,
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&manifest).expect("serialize manifest")
+        ),
+    )
+    .expect("write wrong-kind manifest");
+
+    let error = seed_default_activities(&activities_dir, true)
+        .expect_err("unexpected asset_kind must fail closed");
+    assert_invalid_input(error, &["is for `job`", "expected `activity`"]);
+}
+
+#[cfg(unix)]
+#[test]
+fn stubbed_erofs_and_eacces_are_skippable() {
+    for errno in [libc::EROFS, libc::EACCES] {
+        let error = io::Error::from_raw_os_error(errno);
+        assert!(
+            managed_manifest_write_is_skippable(&error),
+            "{error} should be skippable"
+        );
+        let mut warnings = Vec::new();
+        record_managed_manifest_write(
+            Path::new("/tmp/.orbit-managed-assets.json"),
+            "activity",
+            Err(io::Error::from_raw_os_error(errno)),
+            &mut warnings,
+        )
+        .expect("skippable write must not fail closed");
+        assert_eq!(warnings.len(), 1, "{errno}");
+        assert!(
+            warnings[0].contains("could not write managed activity asset manifest"),
+            "{}",
+            warnings[0]
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn stubbed_enospc_and_eio_fail_closed() {
+    for errno in [libc::ENOSPC, libc::EIO] {
+        let error = io::Error::from_raw_os_error(errno);
+        assert!(
+            !managed_manifest_write_is_skippable(&error),
+            "{error} must stay fatal"
+        );
+        let mut warnings = Vec::new();
+        let mapped = record_managed_manifest_write(
+            Path::new("/tmp/.orbit-managed-assets.json"),
+            "activity",
+            Err(io::Error::from_raw_os_error(errno)),
+            &mut warnings,
+        )
+        .expect_err("non-permission write must fail closed");
+        assert!(warnings.is_empty(), "{warnings:?}");
+        match mapped {
+            OrbitError::Io(message) => {
+                assert!(
+                    message.contains("write managed activity asset manifest"),
+                    "{message}"
+                );
+            }
+            other => panic!("expected OrbitError::Io, got {other}"),
+        }
+    }
+}
+
+#[test]
+fn constructed_storage_full_and_other_errors_fail_closed() {
+    for error in [
+        io::Error::new(io::ErrorKind::StorageFull, "no space left"),
+        io::Error::other("input/output error"),
+    ] {
+        assert!(
+            !managed_manifest_write_is_skippable(&error),
+            "{error} must stay fatal"
+        );
+        let mut warnings = Vec::new();
+        let mapped = record_managed_manifest_write(
+            Path::new("/tmp/.orbit-managed-assets.json"),
+            "activity",
+            Err(error),
+            &mut warnings,
+        )
+        .expect_err("non-permission write must fail closed");
+        assert!(warnings.is_empty(), "{warnings:?}");
+        match mapped {
+            OrbitError::Io(message) => {
+                assert!(
+                    message.contains("write managed activity asset manifest"),
+                    "{message}"
+                );
+            }
+            other => panic!("expected OrbitError::Io, got {other}"),
+        }
+    }
+}

--- a/crates/orbit-core/src/command/tests/managed_assets.rs
+++ b/crates/orbit-core/src/command/tests/managed_assets.rs
@@ -8,7 +8,6 @@ use tempfile::tempdir;
 use std::os::unix::fs::PermissionsExt;
 
 use super::super::MANAGED_ASSET_MANIFEST_FILE;
-#[cfg(unix)]
 use super::super::activity::seed_default_activities;
 use super::super::init::{InitOptions, InitResult, init_workspace_at_root};
 #[cfg(unix)]
@@ -175,6 +174,42 @@ fn runtime_bootstrap_reads_seeded_global_assets_without_write_access() {
     make_writable(&jobs_dir);
 
     result.expect("ordinary read-only runtime operation succeeds");
+}
+
+#[test]
+fn refresh_writes_asset_and_manifest_when_embedded_digest_changed() {
+    let root = tempdir().expect("create tempdir");
+    let global_root = root.path().join("global");
+    init_global(&global_root);
+
+    let activities_dir = global_root.join("resources/activities");
+    let path = activities_dir.join("sleep.yaml");
+    let original = std::fs::read_to_string(&path).expect("read seeded sleep activity");
+    let stale = format!("{original}# stale digest\n");
+    std::fs::write(&path, &stale).expect("materialize drifted bundled asset");
+    add_managed_manifest_entry(&activities_dir, "sleep", &stale);
+
+    let refreshed =
+        seed_default_activities(&activities_dir, true).expect("refresh drifted bundled asset");
+    assert!(
+        refreshed.refreshed >= 1,
+        "a digest change must rewrite the asset, got {refreshed:?}"
+    );
+    assert!(refreshed.warnings.is_empty(), "{:?}", refreshed.warnings);
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("read refreshed sleep activity"),
+        original
+    );
+
+    let manifest: Value = serde_json::from_str(
+        &std::fs::read_to_string(activities_dir.join(MANAGED_ASSET_MANIFEST_FILE))
+            .expect("read refreshed manifest"),
+    )
+    .expect("parse refreshed manifest");
+    assert_eq!(
+        manifest["assets"]["sleep"].as_str().expect("sleep digest"),
+        sha256(&original)
+    );
 }
 
 #[test]

--- a/crates/orbit-core/src/command/tests/mod.rs
+++ b/crates/orbit-core/src/command/tests/mod.rs
@@ -1,4 +1,5 @@
 mod executor;
 mod job_pipeline;
 mod job_submission;
+mod managed_asset_manifest;
 mod managed_assets;

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -132,7 +132,14 @@ Refresh applies the same reconciliation to activities and jobs:
   as managed; other YAML remains in place and `orbit init` warns with the paths
   plus the manual remedy to move or delete a stale legacy file;
 - the new manifest contains only current assets whose managed ownership is
-  established, so repeating refresh is idempotent.
+  established, so repeating refresh is idempotent;
+- a needed manifest write that hits EROFS/EACCES (immutable or shared global
+  root, sandboxed runner) records a warning and continues. Read-only commands
+  such as `orbit task show` must not fail closed on that maintenance write.
+  Malformed manifests, unexpected `asset_kind`, and non-permission write
+  failures (ENOSPC, EIO) stay rejected. A writable directory whose embedded
+  digest changed still refreshes the asset and writes the manifest
+  ([ORB-10840]).
 
 This means a manifest-aware upgrade cannot leave a retired managed activity
 with removed tool grants—or a retired managed job with removed actions—in the


### PR DESCRIPTION
## Task

[ORB-10840](https://orbit-cli.com/tasks/ORB-10840) — Fail open when managed-asset reconciliation cannot write a read-only manifest

### Description

## Problem
`reconcile_managed_assets` (`crates/orbit-core/src/command/mod.rs`) still fail-closes the entire CLI when writing `.orbit-managed-assets.json` hits EROFS/EACCES. ORB-10759 / ORB-10732 skip the write when the manifest is already current, so a steady-state read-only global root no longer dies on every invocation. A refresh that actually needs a write (new embedded asset, digest change, first manifest) still returns `io error: write managed activity asset manifest '...': Read-only file system` before the subcommand runs — including pure reads such as `orbit task show`.

F2026-08-055 (canonical; F2026-08-060 resolved as a duplicate) was filed from jrun-20260809-2226-3 / ORB-10690 when every `orbit` invocation failed this way under a runner that bind-mounts `~/.orbit/resources` read-only.

## Why It Matters
A read-only bundled-asset directory is a legitimate deployment shape (immutable/shared global root, sandboxed runner). Reconciliation is maintenance, not a precondition for reading a task. The current error names an activity-asset manifest, so agents misdiagnose it as an activity/job problem.

## Constraints / Notes
This widens a fail-closed I/O path. Neighboring rejection guarantees that MUST remain rejected, each with a test or command-level evidence:
- Wrong workspace / unreadable manifest that is not a permission error (malformed JSON, unexpected `asset_kind`) still fails closed with the existing invalid-input diagnostic.
- Genuine write failures that are not EROFS/EACCES (ENOSPC, EIO, unexpected errno) still fail closed.
- A writable resources directory that needs a refresh still writes the manifest and assets (no silent skip).
- Stale or mixed-scope user-authored collisions still emit the existing warnings rather than being deleted.
- Re-homing/re-authoring of user YAML is unchanged: locally modified retired assets are still preserved, not overwritten.

Do not make the sandbox mount writable as the fix.

## Evidence
- F2026-08-055 open; F2026-08-060 resolved as duplicate by ORB-10837
- `write_managed_asset_manifest` at `crates/orbit-core/src/command/mod.rs:228-246` maps any write error to `OrbitError::Io`
- No-op skip already exists at lines 172-180 and 211-213; it does not cover EROFS on a needed write

### Acceptance Criteria

- When the managed-asset manifest path is EROFS or EACCES, `orbit task show` (or an equivalent read-only command) succeeds and does not return a hard `OrbitError::Io` for the manifest write; a warning is recorded.
- A writable resources directory whose embedded digest changed still refreshes the asset and writes the manifest (positive write path unchanged).
- A malformed existing manifest still fails closed with the current invalid-input repair message (not a silent skip).
- A non-permission write failure (for example a stubbed ENOSPC/EIO) still fails closed.
- Tests or a documented command transcript exist for each preserved rejection above, not only the EROFS success path.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `reconcile_managed_assets` now inspects the `io::Error` from a needed `.orbit-managed-assets.json` write before wrapping it. EROFS/EACCES (`ErrorKind::ReadOnlyFilesystem` / `PermissionDenied`, plus `raw_os_error` for those errnos) record a warning and continue so a read-only global root no longer fails `orbit task show` / runtime bootstrap.
- `write_managed_asset_manifest` stays fail-closed for `orbit doctor --fix-stale-artifacts`.
- Added sibling tests in `crates/orbit-core/src/command/tests/managed_asset_manifest.rs`: chmod EACCES on a needed first-manifest write + runtime bootstrap; malformed JSON still `InvalidInput` with the repair message; unexpected `assetKind` still fail-closed; stubbed EROFS/EACCES skip; stubbed ENOSPC/EIO and constructed StorageFull/Other stay `OrbitError::Io`.
- Added `refresh_writes_asset_and_manifest_when_embedded_digest_changed` so the writable digest-change path still rewrites the asset and manifest.
- Documented the fail-open in `docs/design/activity-job/2_design.md` §4.1.

Why extra context_files: `tests/managed_asset_manifest.rs` and `tests/mod.rs` are the new sibling tests; `tests/managed_assets.rs` holds the digest-change positive path; `2_design.md` is the live behavior doc.

Assessment: scoped to the manifest write only. Asset-file writes and retirement on a fully read-only directory still fail closed (out of AC). Doctor --fix still fail-closes.

Validation:
- `cargo test -p orbit-core --lib managed_asset`: 19 passed
- `cargo clippy -p orbit-core --lib --tests -- -D warnings`: pass
- `make ci-fast`: pass
- `make ci-lint` not run (workspace-wide; targeted clippy used instead)

Friction checkpoint: none filed. No contradicted assumption, recurring failure, or >10min gotcha.

Strategic decisions: fail-open lives in reconciliation only, not the shared doctor write helper.
Design weaknesses / risks:
- Severity: low. A digest change that also needs an asset rewrite on a fully read-only directory still fails on `write_text_with_parent`. Mitigation: that is outside this task's manifest-path AC; the remaining F2026-08-055 case is a needed *manifest* write (first manifest / stale provenance) on an otherwise current catalog.
Deviations from original plan: none material.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10840-6a80e3b2`
- Behind base: 0
- Ahead of base: 1