### PR TITLE
Make orbit doctor detect and repair catalog-invalid activity definitions

### DIFF
--- a/crates/orbit-cli/src/command/doctor.rs
+++ b/crates/orbit-cli/src/command/doctor.rs
@@ -29,6 +29,10 @@ pub struct DoctorCommand {
     /// Retire deprecated skills, jobs, activities, auto-tasks, and routines that Orbit itself wrote. Locally modified ones are preserved, not deleted.
     #[arg(long)]
     pub fix_stale_artifacts: bool,
+
+    /// Remove known retired `spec.backend` values (`http`, `auto`) from schemaVersion 2 agent-loop activities. Unknown backends and unrelated parse failures are left untouched.
+    #[arg(long)]
+    pub fix_retired_activity_backends: bool,
 }
 
 impl Execute for DoctorCommand {
@@ -55,6 +59,22 @@ impl Execute for DoctorCommand {
             let removed = runtime.remove_stale_definition_artifacts()?;
             if !self.json {
                 println!("Retired {removed} deprecated definition artifact(s).");
+            }
+        }
+        if self.fix_retired_activity_backends {
+            let report = runtime.repair_retired_activity_backends()?;
+            if !self.json {
+                println!(
+                    "Removed retired spec.backend from {} activity file(s).",
+                    report.repaired.len()
+                );
+                for skipped in &report.skipped {
+                    println!(
+                        "Left untouched {}: {}",
+                        skipped.path.display(),
+                        skipped.reason
+                    );
+                }
             }
         }
         let results = runtime.doctor_workspace()?;

--- a/crates/orbit-cli/src/command/tests/mod.rs
+++ b/crates/orbit-cli/src/command/tests/mod.rs
@@ -138,6 +138,7 @@ fn cli_parses_doctor_stale_task_lock_repair_without_blanket_fix() {
         Commands::Doctor(command) => {
             assert!(command.fix_stale_task_locks);
             assert!(!command.fix_stale_locks);
+            assert!(!command.fix_retired_activity_backends);
         }
         _ => panic!("expected top-level doctor command"),
     }
@@ -147,6 +148,24 @@ fn cli_parses_doctor_stale_task_lock_repair_without_blanket_fix() {
         ErrorKind::UnknownArgument,
         "unexpected argument '--fix'",
     );
+}
+
+#[test]
+fn cli_parses_doctor_retired_activity_backend_repair() {
+    let cli = Cli::parse_from([
+        "orbit",
+        "doctor",
+        "--fix-retired-activity-backends",
+        "--json",
+    ]);
+    match cli.command {
+        Commands::Doctor(command) => {
+            assert!(command.fix_retired_activity_backends);
+            assert!(!command.fix_stale_artifacts);
+            assert!(command.json);
+        }
+        _ => panic!("expected top-level doctor command"),
+    }
 }
 
 #[test]

--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 use fs2::FileExt;
 use orbit_common::types::{OrbitError, WorkspacePaths};
 use orbit_core::OrbitRuntime;
-use orbit_core::command::artifact_health::ArtifactFinding;
+use orbit_core::command::artifact_health::{ArtifactFinding, RetiredActivityBackendRepair};
 use orbit_store::sqlite::migration::SUPPORTED_SCHEMA_VERSION;
 use serde::Serialize;
 
@@ -119,6 +119,11 @@ pub trait DoctorCommands {
     /// catalog. Faulty and user-authored artifacts are never touched.
     fn remove_stale_definition_artifacts(&self) -> Result<usize, OrbitError>;
 
+    /// Remove known retired `spec.backend` values from schemaVersion 2
+    /// agent-loop activities. Unknown backends and unrelated malformed
+    /// files are left untouched.
+    fn repair_retired_activity_backends(&self) -> Result<RetiredActivityBackendRepair, OrbitError>;
+
     /// Cheap store write probe for health endpoints: open the store and
     /// acquire + roll back the write lock without mutating anything.
     fn health_check_store_writable(&self) -> Result<String, OrbitError>;
@@ -156,6 +161,10 @@ impl DoctorCommands for OrbitRuntime {
 
     fn remove_stale_definition_artifacts(&self) -> Result<usize, OrbitError> {
         OrbitRuntime::remove_stale_definition_artifacts(self)
+    }
+
+    fn repair_retired_activity_backends(&self) -> Result<RetiredActivityBackendRepair, OrbitError> {
+        OrbitRuntime::repair_retired_activity_backends(self)
     }
 
     fn remove_retired_graph_state(&self) -> Result<usize, OrbitError> {

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -630,3 +630,64 @@ fn retired_graph_cleanup_unlinks_boundaries_without_following_them() {
     assert!(fs::symlink_metadata(local_graph).is_err());
     assert!(fs::symlink_metadata(shared_graph).is_err());
 }
+
+#[test]
+fn workspace_retired_backend_warns_artifacts_activities_with_repair_command() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let activities = temp
+        .path()
+        .join("repo")
+        .join(".orbit")
+        .join("resources")
+        .join("activities");
+    fs::create_dir_all(&activities).expect("create workspace activities");
+    let path = activities.join("epic_orchestrator.yaml");
+    fs::write(
+        &path,
+        "schemaVersion: 2\nkind: Activity\nmetadata:\n  name: epic_orchestrator\nspec:\n  type: agent_loop\n  description: fixture\n  instruction: do the work\n  backend: http\n",
+    )
+    .expect("write retired backend activity");
+
+    let results = runtime.doctor_workspace().expect("doctor");
+    let row = status_of(&results, "artifacts-activities");
+    assert_eq!(row.status, WorkspaceDoctorStatus::Warning, "{row:?}");
+    assert!(
+        row.message.contains("epic_orchestrator.yaml"),
+        "{}",
+        row.message
+    );
+    assert!(
+        row.message.contains("spec.backend: http"),
+        "{}",
+        row.message
+    );
+    assert!(
+        row.message.contains("schemaVersion 2 parse failed"),
+        "{}",
+        row.message
+    );
+    assert_eq!(
+        row.remediation.as_deref(),
+        Some("Run `orbit doctor --fix-retired-activity-backends`.")
+    );
+
+    let repaired = runtime
+        .repair_retired_activity_backends()
+        .expect("repair retired backends");
+    assert_eq!(repaired.repaired, vec![path.clone()]);
+    assert!(repaired.skipped.is_empty(), "{repaired:?}");
+    assert!(
+        !fs::read_to_string(&path)
+            .expect("read repaired activity")
+            .contains("backend:"),
+        "repair must remove only the backend key"
+    );
+
+    let after = runtime.doctor_workspace().expect("doctor after repair");
+    assert_eq!(
+        status_of(&after, "artifacts-activities").status,
+        WorkspaceDoctorStatus::Ok,
+        "{after:?}"
+    );
+}

--- a/crates/orbit-common/src/types/activity_job/catalog.rs
+++ b/crates/orbit-common/src/types/activity_job/catalog.rs
@@ -22,7 +22,7 @@ use thiserror::Error;
 use crate::types::OrbitError;
 
 use super::activity_v2::ActivityV2;
-use super::asset_loader::{AssetLoadError, load_activity_asset, load_job_asset};
+use super::asset_loader::{ActivityAsset, AssetLoadError, load_activity_asset, load_job_asset};
 use super::job_v2::{JobV2, JobV2Step, JobV2StepBody, LoopBlock, TargetRef, TargetStep};
 use super::tool_allowlist::{
     ToolAllowlistError, validate_activity_tool_allowlist_against_registered_tools,
@@ -399,21 +399,54 @@ impl CatalogAdapter for ActivityCatalogAdapter {
         yaml: &str,
         skipped: &mut Vec<PathBuf>,
     ) -> Result<Option<LoadedCatalogAsset<Self::Asset>>, CatalogError> {
-        match load_activity_asset(yaml) {
-            Ok(asset) => Ok(Some(LoadedCatalogAsset {
+        match load_activity_catalog_asset(path, yaml, self.skip_retired)? {
+            Some(asset) => Ok(Some(LoadedCatalogAsset {
                 name: asset.name,
                 spec: asset.spec,
             })),
-            Err(AssetLoadError::RetiredVersion(_)) if self.skip_retired => {
+            None => {
                 skipped.push(path.to_path_buf());
                 Ok(None)
             }
-            Err(source) => Err(CatalogError::Parse {
-                path: path.to_path_buf(),
-                source,
-            }),
         }
     }
+}
+
+/// Load one activity YAML with the same parse and retired-schema rules the
+/// catalog uses while walking a directory. `Ok(None)` is the skipped
+/// schemaVersion 1 case when `skip_retired` is set; every other load
+/// failure is [`CatalogError::Parse`].
+pub fn load_activity_catalog_asset(
+    path: &Path,
+    yaml: &str,
+    skip_retired: bool,
+) -> Result<Option<ActivityAsset>, CatalogError> {
+    match load_activity_asset(yaml) {
+        Ok(asset) => Ok(Some(asset)),
+        Err(AssetLoadError::RetiredVersion(_)) if skip_retired => Ok(None),
+        Err(source) => Err(CatalogError::Parse {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+/// Validate one loaded activity's tool allowlist the same way
+/// [`V2ActivityCatalog::validate_tool_allowlists`] does for a full catalog.
+pub fn validate_catalog_activity_tools<'a, I>(
+    name: &str,
+    activity: &ActivityV2,
+    registered_tools: I,
+) -> Result<(), CatalogError>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    validate_activity_tool_allowlist_against_registered_tools(activity, registered_tools).map_err(
+        |source| CatalogError::ToolAllowlist {
+            name: name.to_string(),
+            source,
+        },
+    )
 }
 
 struct JobCatalogAdapter;

--- a/crates/orbit-common/src/types/activity_job/mod.rs
+++ b/crates/orbit-common/src/types/activity_job/mod.rs
@@ -138,7 +138,8 @@ pub use audit_envelope::{
 };
 pub use catalog::{
     ACTIVITY_REF_PREFIX, CatalogDirectory, CatalogDirectoryList, CatalogError, ResolveError,
-    V2ActivityCatalog, V2JobCatalog, catalog_error_to_orbit, resolve_job_target_refs,
+    V2ActivityCatalog, V2JobCatalog, catalog_error_to_orbit, load_activity_catalog_asset,
+    resolve_job_target_refs, validate_catalog_activity_tools,
 };
 pub use job_v2::{
     BackoffStrategy, FanInSpec, FanOutBlock, JobKind, JobV2, JobV2Step, JobV2StepBody, JoinMode,

--- a/crates/orbit-common/src/types/activity_job/tests/catalog.rs
+++ b/crates/orbit-common/src/types/activity_job/tests/catalog.rs
@@ -2,7 +2,11 @@ use std::path::Path;
 
 use tempfile::tempdir;
 
-use super::super::catalog::{CatalogDirectoryList, V2ActivityCatalog, V2JobCatalog};
+use super::super::catalog::{
+    CatalogDirectoryList, V2ActivityCatalog, V2JobCatalog, load_activity_catalog_asset,
+    validate_catalog_activity_tools,
+};
+use super::super::load_activity_asset;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Layer {
@@ -79,4 +83,49 @@ fn typed_catalog_adapters_share_first_wins_layering() {
         jobs.get("layered").map(|(_, job)| job.max_active_runs),
         Some(9)
     );
+}
+
+fn agent_loop_yaml(name: &str, extra_spec_line: &str) -> String {
+    format!(
+        "schemaVersion: 2\nkind: Activity\nmetadata:\n  name: {name}\nspec:\n  type: agent_loop\n  description: test\n  instruction: do the work\n{extra_spec_line}"
+    )
+}
+
+#[test]
+fn catalog_load_and_shared_loader_reject_retired_http_backend() {
+    let root = tempdir().expect("create tempdir");
+    let dir = root.path().join("activities");
+    let path = dir.join("epic_orchestrator.yaml");
+    write(
+        &path,
+        &agent_loop_yaml("epic_orchestrator", "  backend: http\n"),
+    );
+
+    let mut catalog = V2ActivityCatalog::new();
+    let load_err = catalog
+        .load_dir_skipping_retired(&dir)
+        .expect_err("retired backend must fail catalog construction");
+    let load_text = load_err.to_string();
+    assert!(load_text.contains("epic_orchestrator.yaml"), "{load_text}");
+    assert!(load_text.contains("backend: http"), "{load_text}");
+    assert!(
+        load_text.contains("schemaVersion 2 parse failed"),
+        "{load_text}"
+    );
+
+    let yaml = std::fs::read_to_string(&path).expect("read fixture");
+    let shared_err = load_activity_catalog_asset(&path, &yaml, true)
+        .expect_err("shared loader must reject the same file");
+    assert_eq!(shared_err.to_string(), load_text);
+}
+
+#[test]
+fn catalog_tool_allowlist_validation_rejects_unknown_tools() {
+    let yaml = agent_loop_yaml("constellation_survey", "  tools:\n    - orbit.state.get\n");
+    let asset = load_activity_asset(&yaml).expect("syntax-valid allowlist still loads");
+    let error = validate_catalog_activity_tools(&asset.name, &asset.spec, ["orbit.task.show"])
+        .expect_err("unknown tool must fail catalog tool validation");
+    let text = error.to_string();
+    assert!(text.contains("constellation_survey"), "{text}");
+    assert!(text.contains("orbit.state.get"), "{text}");
 }

--- a/crates/orbit-core/src/command/activity_catalog_health.rs
+++ b/crates/orbit-core/src/command/activity_catalog_health.rs
@@ -1,0 +1,411 @@
+//! Production activity-catalog validation and the opt-in retired-backend
+//! repair used by `orbit doctor` [ORB-10838].
+//!
+//! Definition-artifact health already parsed each managed activity file with
+//! `load_activity_asset`, but that walk never saw workspace-local files and
+//! never ran the registry tool-allowlist check. Catalog construction does
+//! both, so a workspace `spec.backend: http` (or a removed tool name) could
+//! fail every job run while doctor reported the activity catalog healthy.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use orbit_common::types::OrbitError;
+use orbit_common::types::activity_job::{
+    load_activity_catalog_asset, validate_catalog_activity_tools,
+};
+
+use crate::OrbitRuntime;
+
+/// The single opt-in repair command named by retired-backend findings.
+pub const FIX_RETIRED_ACTIVITY_BACKENDS_CMD: &str = "orbit doctor --fix-retired-activity-backends";
+
+/// Known retired `spec.backend` values that this repair may delete.
+const REPAIRABLE_BACKENDS: &[&str] = &["http", "auto"];
+
+/// Outcome of one `--fix-retired-activity-backends` pass.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RetiredActivityBackendRepair {
+    pub repaired: Vec<PathBuf>,
+    pub skipped: Vec<RetiredActivityBackendSkip>,
+}
+
+/// A catalog activity the repair refused to rewrite.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetiredActivityBackendSkip {
+    pub path: PathBuf,
+    pub reason: String,
+}
+
+/// One catalog-invalid activity file, ready to become an [`super::artifact_health::ArtifactFinding`].
+#[derive(Debug, Clone)]
+pub(crate) struct ActivityCatalogFault {
+    pub name: String,
+    pub path: PathBuf,
+    pub detail: String,
+    /// When set, this is a known retired backend and names the repair command.
+    pub repair_command: Option<&'static str>,
+}
+
+/// Inspect every production catalog directory with the same load + tool
+/// validation catalog construction uses. Missing directories are skipped.
+pub(crate) fn collect_activity_catalog_faults(
+    runtime: &OrbitRuntime,
+) -> (usize, Vec<ActivityCatalogFault>) {
+    let registered_tools = runtime.allowlist_known_tool_names();
+    let registered: Vec<&str> = registered_tools.iter().map(String::as_str).collect();
+    let paths = activity_catalog_yaml_files(runtime);
+    let scanned = paths.len();
+    let mut faults = Vec::new();
+    for path in paths {
+        let name = file_stem_name(&path);
+        let Some(raw) = read_text(&path) else {
+            faults.push(ActivityCatalogFault {
+                name,
+                path,
+                detail: "file is unreadable".to_string(),
+                repair_command: None,
+            });
+            continue;
+        };
+        match inspect_activity_file(&path, &raw, &registered) {
+            ActivityInspection::Healthy | ActivityInspection::RetiredSkipped => {}
+            ActivityInspection::Fault(fault) => faults.push(fault),
+        }
+    }
+    (scanned, faults)
+}
+
+/// Remove `spec.backend` only when it is a known retired value on a
+/// schemaVersion 2 agent-loop activity. Everything else is left untouched
+/// and, when it would fail catalog construction, reported for a manual edit.
+pub(crate) fn repair_retired_activity_backends(
+    runtime: &OrbitRuntime,
+) -> Result<RetiredActivityBackendRepair, OrbitError> {
+    let registered_tools = runtime.allowlist_known_tool_names();
+    let registered: Vec<&str> = registered_tools.iter().map(String::as_str).collect();
+    let mut report = RetiredActivityBackendRepair::default();
+    for path in activity_catalog_yaml_files(runtime) {
+        let Some(raw) = read_text(&path) else {
+            report.skipped.push(RetiredActivityBackendSkip {
+                path,
+                reason: "file is unreadable".to_string(),
+            });
+            continue;
+        };
+        match classify_backend_repair(&raw) {
+            BackendRepairClass::AlreadyClean => {}
+            BackendRepairClass::Repairable { value } => match remove_spec_backend_key(&raw, &value)
+            {
+                Ok(next) => {
+                    std::fs::write(&path, next).map_err(|error| {
+                        OrbitError::Io(format!(
+                            "remove retired spec.backend from {}: {error}",
+                            path.display()
+                        ))
+                    })?;
+                    report.repaired.push(path);
+                }
+                Err(reason) => report
+                    .skipped
+                    .push(RetiredActivityBackendSkip { path, reason }),
+            },
+            BackendRepairClass::UnknownBackend { value } => {
+                report.skipped.push(RetiredActivityBackendSkip {
+                    path,
+                    reason: format!(
+                        "unknown spec.backend value `{value}`; remove or replace it manually"
+                    ),
+                });
+            }
+            BackendRepairClass::UnrelatedMalformed => {
+                if !matches!(
+                    inspect_activity_file(&path, &raw, &registered),
+                    ActivityInspection::Healthy | ActivityInspection::RetiredSkipped
+                ) {
+                    report.skipped.push(RetiredActivityBackendSkip {
+                        path,
+                        reason: "unrelated malformed activity; repair the definition manually"
+                            .to_string(),
+                    });
+                }
+            }
+        }
+    }
+    Ok(report)
+}
+
+#[derive(Debug)]
+enum ActivityInspection {
+    Healthy,
+    RetiredSkipped,
+    Fault(ActivityCatalogFault),
+}
+
+fn inspect_activity_file(path: &Path, raw: &str, registered_tools: &[&str]) -> ActivityInspection {
+    match load_activity_catalog_asset(path, raw, true) {
+        Ok(None) => ActivityInspection::RetiredSkipped,
+        Ok(Some(asset)) => {
+            if let Err(error) = validate_catalog_activity_tools(
+                &asset.name,
+                &asset.spec,
+                registered_tools.iter().copied(),
+            ) {
+                return ActivityInspection::Fault(ActivityCatalogFault {
+                    name: asset.name,
+                    path: path.to_path_buf(),
+                    detail: format!("`{}` — {error}", path.display()),
+                    repair_command: None,
+                });
+            }
+            ActivityInspection::Healthy
+        }
+        Err(error) => {
+            let backend = spec_backend_value(raw);
+            let (detail, repair_command) = match backend.as_deref() {
+                Some(value) => (
+                    format!("`{}` spec.backend: {value} — {error}", path.display()),
+                    repairable_backend(value).then_some(FIX_RETIRED_ACTIVITY_BACKENDS_CMD),
+                ),
+                None => (format!("`{}` — {error}", path.display()), None),
+            };
+            ActivityInspection::Fault(ActivityCatalogFault {
+                name: file_stem_name(path),
+                path: path.to_path_buf(),
+                detail,
+                repair_command,
+            })
+        }
+    }
+}
+
+#[derive(Debug)]
+enum BackendRepairClass {
+    AlreadyClean,
+    Repairable { value: String },
+    UnknownBackend { value: String },
+    UnrelatedMalformed,
+}
+
+fn classify_backend_repair(raw: &str) -> BackendRepairClass {
+    let Some(document) = parse_mapping(raw) else {
+        return BackendRepairClass::UnrelatedMalformed;
+    };
+    if !is_schema_v2_activity(&document) {
+        return BackendRepairClass::UnrelatedMalformed;
+    }
+    let Some(spec) = mapping_get(&document, "spec") else {
+        return BackendRepairClass::UnrelatedMalformed;
+    };
+    if mapping_str(spec, "type") != Some("agent_loop") {
+        return BackendRepairClass::UnrelatedMalformed;
+    }
+    match mapping_scalar(spec, "backend") {
+        None => BackendRepairClass::AlreadyClean,
+        Some(value) if repairable_backend(&value) => BackendRepairClass::Repairable { value },
+        Some(value) if value == "cli" => BackendRepairClass::AlreadyClean,
+        Some(value) => BackendRepairClass::UnknownBackend { value },
+    }
+}
+
+fn spec_backend_value(raw: &str) -> Option<String> {
+    let document = parse_mapping(raw)?;
+    mapping_scalar(mapping_get(&document, "spec")?, "backend")
+}
+
+fn is_schema_v2_activity(document: &serde_yaml::Value) -> bool {
+    let version = mapping_get(document, "schemaVersion")
+        .and_then(serde_yaml::Value::as_u64)
+        .or_else(|| {
+            mapping_get(document, "schemaVersion")
+                .and_then(serde_yaml::Value::as_i64)
+                .and_then(|value| u64::try_from(value).ok())
+        });
+    version == Some(2) && mapping_str(document, "kind") == Some("Activity")
+}
+
+fn repairable_backend(value: &str) -> bool {
+    REPAIRABLE_BACKENDS.contains(&value)
+}
+
+/// Delete the unique block-style `spec.backend` line whose value is `backend`.
+/// Refuses flow-style mappings and ambiguous duplicates so unrelated YAML
+/// is never rewritten.
+pub(crate) fn remove_spec_backend_key(raw: &str, backend: &str) -> Result<String, String> {
+    let had_trailing_newline = raw.ends_with('\n');
+    let lines: Vec<&str> = raw.lines().collect();
+    let spec_idx = find_block_key(&lines, 0, 0, "spec")
+        .ok_or_else(|| "could not find a block-style `spec:` mapping to edit".to_string())?;
+    let spec_indent = leading_spaces(lines[spec_idx]);
+    let child_indent = first_child_indent(&lines, spec_idx, spec_indent).ok_or_else(|| {
+        "could not find block-style keys under `spec:`; flow-style mappings are left untouched"
+            .to_string()
+    })?;
+    let mut matches = Vec::new();
+    let mut idx = spec_idx + 1;
+    while idx < lines.len() {
+        let line = lines[idx];
+        let indent = leading_spaces(line);
+        if !is_blank_or_comment(line) && indent <= spec_indent {
+            break;
+        }
+        if indent == child_indent && is_key_with_scalar(line, indent, "backend", backend) {
+            matches.push(idx);
+        }
+        idx += 1;
+    }
+    match matches.as_slice() {
+        [only] => {
+            let mut next: Vec<&str> = Vec::with_capacity(lines.len() - 1);
+            next.extend(lines.iter().take(*only).copied());
+            next.extend(lines.iter().skip(*only + 1).copied());
+            let mut rendered = next.join("\n");
+            if had_trailing_newline {
+                rendered.push('\n');
+            }
+            Ok(rendered)
+        }
+        [] => Err(format!(
+            "could not uniquely locate block-style `spec.backend: {backend}`"
+        )),
+        _ => Err("multiple `spec.backend` lines; refusing to guess which to remove".to_string()),
+    }
+}
+
+fn find_block_key(lines: &[&str], start: usize, indent: usize, key: &str) -> Option<usize> {
+    lines
+        .iter()
+        .enumerate()
+        .skip(start)
+        .find_map(|(idx, line)| {
+            (leading_spaces(line) == indent && is_bare_block_key(line, indent, key)).then_some(idx)
+        })
+}
+
+fn first_child_indent(lines: &[&str], parent_idx: usize, parent_indent: usize) -> Option<usize> {
+    for line in lines.iter().skip(parent_idx + 1) {
+        if is_blank_or_comment(line) {
+            continue;
+        }
+        let indent = leading_spaces(line);
+        if indent <= parent_indent {
+            return None;
+        }
+        return Some(indent);
+    }
+    None
+}
+
+fn is_bare_block_key(line: &str, indent: usize, key: &str) -> bool {
+    let rest = line.get(indent..).unwrap_or("");
+    let Some(after) = rest
+        .strip_prefix(key)
+        .and_then(|value| value.strip_prefix(':'))
+    else {
+        return false;
+    };
+    after.trim().is_empty() || after.trim_start().starts_with('#')
+}
+
+fn is_key_with_scalar(line: &str, indent: usize, key: &str, expected: &str) -> bool {
+    let rest = line.get(indent..).unwrap_or("");
+    let Some(after) = rest
+        .strip_prefix(key)
+        .and_then(|value| value.strip_prefix(':'))
+    else {
+        return false;
+    };
+    let value = after.split('#').next().unwrap_or(after).trim();
+    let unquoted = value
+        .strip_prefix('"')
+        .and_then(|inner| inner.strip_suffix('"'))
+        .or_else(|| {
+            value
+                .strip_prefix('\'')
+                .and_then(|inner| inner.strip_suffix('\''))
+        })
+        .unwrap_or(value);
+    unquoted == expected
+}
+
+fn leading_spaces(line: &str) -> usize {
+    line.chars().take_while(|ch| *ch == ' ').count()
+}
+
+fn is_blank_or_comment(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.is_empty() || trimmed.starts_with('#')
+}
+
+fn activity_catalog_yaml_files(runtime: &OrbitRuntime) -> Vec<PathBuf> {
+    let mut files = BTreeSet::new();
+    for dir in runtime.v2_activity_catalog_paths() {
+        if dir.is_dir() {
+            collect_yaml_files(&dir, &mut files);
+        }
+    }
+    files.into_iter().collect()
+}
+
+fn collect_yaml_files(dir: &Path, files: &mut BTreeSet<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_yaml_files(&path, files);
+            continue;
+        }
+        let is_yaml = path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| {
+                extension.eq_ignore_ascii_case("yaml") || extension.eq_ignore_ascii_case("yml")
+            });
+        if is_yaml {
+            files.insert(path);
+        }
+    }
+}
+
+fn file_stem_name(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn read_text(path: &Path) -> Option<String> {
+    std::fs::read_to_string(path).ok()
+}
+
+fn parse_mapping(raw: &str) -> Option<serde_yaml::Value> {
+    let value: serde_yaml::Value = serde_yaml::from_str(raw).ok()?;
+    value.as_mapping()?;
+    Some(value)
+}
+
+fn mapping_get<'a>(value: &'a serde_yaml::Value, key: &str) -> Option<&'a serde_yaml::Value> {
+    value
+        .as_mapping()?
+        .get(serde_yaml::Value::String(key.to_string()))
+}
+
+fn mapping_str<'a>(value: &'a serde_yaml::Value, key: &str) -> Option<&'a str> {
+    mapping_get(value, key).and_then(serde_yaml::Value::as_str)
+}
+
+fn mapping_scalar(value: &serde_yaml::Value, key: &str) -> Option<String> {
+    let field = mapping_get(value, key)?;
+    if let Some(text) = field.as_str() {
+        return Some(text.to_string());
+    }
+    if let Some(boolean) = field.as_bool() {
+        return Some(boolean.to_string());
+    }
+    if let Some(number) = field.as_i64() {
+        return Some(number.to_string());
+    }
+    None
+}

--- a/crates/orbit-core/src/command/artifact_health.rs
+++ b/crates/orbit-core/src/command/artifact_health.rs
@@ -32,8 +32,17 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
-use orbit_common::types::activity_job::{load_activity_asset, load_job_asset};
+use orbit_common::types::activity_job::load_job_asset;
 use orbit_common::types::{OrbitError, parse_routine_yaml};
+
+use super::activity_catalog_health::{
+    ActivityCatalogFault, collect_activity_catalog_faults,
+    repair_retired_activity_backends as repair_activity_backends,
+};
+
+pub use super::activity_catalog_health::{
+    FIX_RETIRED_ACTIVITY_BACKENDS_CMD, RetiredActivityBackendRepair, RetiredActivityBackendSkip,
+};
 
 use crate::OrbitRuntime;
 use crate::auto_tasks::{auto_tasks_dir, collect_auto_tasks};
@@ -296,6 +305,15 @@ impl OrbitRuntime {
         }
         Ok(removed)
     }
+
+    /// Remove known retired `spec.backend` values from schemaVersion 2
+    /// agent-loop activities. Unknown backends and unrelated malformed
+    /// files are left untouched and listed for a manual edit.
+    pub fn repair_retired_activity_backends(
+        &self,
+    ) -> Result<RetiredActivityBackendRepair, OrbitError> {
+        repair_activity_backends(self)
+    }
 }
 
 /// Read one artifact file, treating an unreadable file as absent.
@@ -319,11 +337,16 @@ fn diagnose_catalog(runtime: &OrbitRuntime, catalog: &ManagedCatalog) -> Artifac
     let mut findings = Vec::new();
 
     if !catalog.dir.is_dir() {
-        return ArtifactHealth {
-            kind,
-            scanned: 0,
-            findings,
-        };
+        // Activities also live in workspace / env catalog dirs. A missing
+        // managed directory must not hide those production-path faults.
+        if kind != ArtifactKind::Activity {
+            return ArtifactHealth {
+                kind,
+                scanned: 0,
+                findings,
+            };
+        }
+        return finish_catalog_health(runtime, catalog, findings, &BTreeMap::new());
     }
 
     let manifest_path = catalog.dir.join(MANAGED_ASSET_MANIFEST_FILE);
@@ -447,13 +470,24 @@ fn diagnose_catalog(runtime: &OrbitRuntime, catalog: &ManagedCatalog) -> Artifac
         }
     }
 
-    // Faulty: whatever is on disk now, does it still load?
+    finish_catalog_health(runtime, catalog, findings, &tracked)
+}
+
+fn finish_catalog_health(
+    runtime: &OrbitRuntime,
+    catalog: &ManagedCatalog,
+    mut findings: Vec<ArtifactFinding>,
+    tracked: &BTreeMap<String, String>,
+) -> ArtifactHealth {
+    let kind = catalog.kind;
     let (scanned, faults) = collect_faults(runtime, catalog);
-    for (name, path, message) in faults {
-        let provenance = read_artifact(&path)
-            .map(|on_disk| provenance(tracked.get(&name), &on_disk))
+    for fault in faults {
+        let provenance = read_artifact(&fault.path)
+            .map(|on_disk| provenance(tracked.get(&fault.name), &on_disk))
             .unwrap_or(ArtifactProvenance::UserAuthored);
-        let remediation = if provenance == ArtifactProvenance::OrbitWritten {
+        let remediation = if let Some(command) = fault.repair_command {
+            format!("Run `{command}`.")
+        } else if provenance == ArtifactProvenance::OrbitWritten {
             format!(
                 "A shipped {} default failed to load — reinstall or upgrade orbit, then run `orbit init --refresh-defaults`.",
                 kind.singular()
@@ -462,16 +496,16 @@ fn diagnose_catalog(runtime: &OrbitRuntime, catalog: &ManagedCatalog) -> Artifac
             format!(
                 "Fix the {} definition at `{}` (or move it aside), then rerun `orbit doctor`.",
                 kind.singular(),
-                path.display()
+                fault.path.display()
             )
         };
         findings.push(ArtifactFinding {
             kind,
-            name,
-            path,
+            name: fault.name,
+            path: fault.path,
             condition: ArtifactCondition::Faulty,
             provenance,
-            detail: message,
+            detail: fault.detail,
             remediation,
         });
     }
@@ -486,24 +520,45 @@ fn diagnose_catalog(runtime: &OrbitRuntime, catalog: &ManagedCatalog) -> Artifac
     }
 }
 
+struct LoadFault {
+    name: String,
+    path: PathBuf,
+    detail: String,
+    repair_command: Option<&'static str>,
+}
+
+impl From<ActivityCatalogFault> for LoadFault {
+    fn from(fault: ActivityCatalogFault) -> Self {
+        Self {
+            name: fault.name,
+            path: fault.path,
+            detail: fault.detail,
+            repair_command: fault.repair_command,
+        }
+    }
+}
+
 /// Load every artifact of one kind through its real loader, returning
 /// `(inspected count, failures)`. Using the production loader is the point:
 /// doctor must report exactly what dispatch would find, not a parallel parse.
-fn collect_faults(
-    runtime: &OrbitRuntime,
-    catalog: &ManagedCatalog,
-) -> (usize, Vec<(String, PathBuf, String)>) {
+fn collect_faults(runtime: &OrbitRuntime, catalog: &ManagedCatalog) -> (usize, Vec<LoadFault>) {
+    if catalog.kind == ArtifactKind::Activity {
+        let (scanned, faults) = collect_activity_catalog_faults(runtime);
+        return (scanned, faults.into_iter().map(LoadFault::from).collect());
+    }
+
     let mut faults = Vec::new();
 
     if catalog.kind == ArtifactKind::Skill {
         let rows = match runtime.skill_catalog().doctor() {
             Ok(rows) => rows,
             Err(error) => {
-                faults.push((
-                    "<catalog>".to_string(),
-                    catalog.dir.clone(),
-                    format!("cannot enumerate skills: {error}"),
-                ));
+                faults.push(LoadFault {
+                    name: "<catalog>".to_string(),
+                    path: catalog.dir.clone(),
+                    detail: format!("cannot enumerate skills: {error}"),
+                    repair_command: None,
+                });
                 return (0, faults);
             }
         };
@@ -511,7 +566,12 @@ fn collect_faults(
         for row in rows {
             if row.status == crate::skill_catalog::SkillCatalogDoctorStatus::Error {
                 let path = catalog.dir.join(&row.skill_id).join("SKILL.md");
-                faults.push((format!("{}/SKILL.md", row.skill_id), path, row.message));
+                faults.push(LoadFault {
+                    name: format!("{}/SKILL.md", row.skill_id),
+                    path,
+                    detail: row.message,
+                    repair_command: None,
+                });
             }
         }
         return (scanned, faults);
@@ -529,7 +589,12 @@ fn collect_faults(
                 .and_then(|stem| stem.to_str())
                 .unwrap_or_default()
                 .to_string();
-            faults.push((name, path, error.message));
+            faults.push(LoadFault {
+                name,
+                path,
+                detail: error.message,
+                repair_command: None,
+            });
         }
         return (scanned, faults);
     }
@@ -558,21 +623,28 @@ fn collect_faults(
             .unwrap_or_default()
             .to_string();
         let Some(raw) = read_artifact(&path) else {
-            faults.push((name, path, "file is unreadable".to_string()));
+            faults.push(LoadFault {
+                name,
+                path,
+                detail: "file is unreadable".to_string(),
+                repair_command: None,
+            });
             continue;
         };
         let outcome = match catalog.kind {
-            ArtifactKind::Activity => load_activity_asset(&raw)
-                .map(|_| ())
-                .map_err(|e| e.to_string()),
             ArtifactKind::Job => load_job_asset(&raw).map(|_| ()).map_err(|e| e.to_string()),
             ArtifactKind::Routine => parse_routine_yaml(&raw)
                 .map(|_| ())
                 .map_err(|e| e.to_string()),
-            ArtifactKind::Skill | ArtifactKind::AutoTask => Ok(()),
+            ArtifactKind::Activity | ArtifactKind::Skill | ArtifactKind::AutoTask => Ok(()),
         };
-        if let Err(message) = outcome {
-            faults.push((name, path, message));
+        if let Err(detail) = outcome {
+            faults.push(LoadFault {
+                name,
+                path,
+                detail,
+                repair_command: None,
+            });
         }
     }
     (scanned, faults)

--- a/crates/orbit-core/src/command/mod.rs
+++ b/crates/orbit-core/src/command/mod.rs
@@ -504,6 +504,7 @@ fn sha256_hex(content: &[u8]) -> String {
 }
 
 pub(crate) mod activity;
+pub(crate) mod activity_catalog_health;
 pub mod artifact_health;
 pub mod audit_event;
 pub(crate) mod docs;

--- a/crates/orbit-core/src/command/tests/artifact_health.rs
+++ b/crates/orbit-core/src/command/tests/artifact_health.rs
@@ -1,0 +1,252 @@
+use std::path::{Path, PathBuf};
+
+use tempfile::tempdir;
+
+use crate::OrbitRuntime;
+use crate::command::activity_catalog_health::remove_spec_backend_key;
+use crate::command::artifact_health::{
+    ArtifactCondition, ArtifactHealth, ArtifactKind, FIX_RETIRED_ACTIVITY_BACKENDS_CMD,
+};
+
+fn workspace_runtime(root: &Path) -> (OrbitRuntime, PathBuf, PathBuf) {
+    let global_root = root.join("global");
+    let workspace_root = root.join("repo/.orbit");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    let runtime = OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+    let activities = workspace_root.join("resources/activities");
+    std::fs::create_dir_all(&activities).expect("create workspace activities");
+    (runtime, workspace_root, activities)
+}
+
+fn agent_loop_yaml(name: &str, extra_spec: &str) -> String {
+    format!(
+        "schemaVersion: 2\nkind: Activity\nmetadata:\n  name: {name}\nspec:\n  type: agent_loop\n  description: workspace fixture\n  instruction: do the work\n  # keep this comment\n{extra_spec}"
+    )
+}
+
+fn health_of(report: &[ArtifactHealth], kind: ArtifactKind) -> &ArtifactHealth {
+    report
+        .iter()
+        .find(|health| health.kind == kind)
+        .unwrap_or_else(|| panic!("missing artifact health for {kind:?}"))
+}
+
+#[test]
+fn workspace_http_backend_is_a_catalog_fault_and_named_repair() {
+    let root = tempdir().expect("tempdir");
+    let (runtime, _workspace, activities) = workspace_runtime(root.path());
+    let path = activities.join("epic_orchestrator.yaml");
+    std::fs::write(
+        &path,
+        agent_loop_yaml("epic_orchestrator", "  backend: http\n"),
+    )
+    .expect("write fixture");
+
+    let catalog_err = runtime
+        .v2_activity_catalog()
+        .expect_err("production catalog must reject spec.backend: http");
+    let catalog_text = catalog_err.to_string();
+    assert!(
+        catalog_text.contains("epic_orchestrator.yaml"),
+        "{catalog_text}"
+    );
+    assert!(catalog_text.contains("backend: http"), "{catalog_text}");
+
+    let report = runtime
+        .inspect_definition_artifacts()
+        .expect("inspect artifacts");
+    let finding = health_of(&report, ArtifactKind::Activity)
+        .findings
+        .iter()
+        .find(|finding| finding.name == "epic_orchestrator")
+        .expect("workspace activity must be reported");
+    assert_eq!(finding.condition, ArtifactCondition::Faulty);
+    assert!(
+        finding.detail.contains(path.to_string_lossy().as_ref()),
+        "{}",
+        finding.detail
+    );
+    assert!(
+        finding.detail.contains("spec.backend: http"),
+        "{}",
+        finding.detail
+    );
+    assert!(
+        finding.detail.contains("schemaVersion 2 parse failed"),
+        "{}",
+        finding.detail
+    );
+    assert!(
+        finding.detail.contains("backend: http"),
+        "{}",
+        finding.detail
+    );
+    assert!(
+        finding
+            .remediation
+            .contains(FIX_RETIRED_ACTIVITY_BACKENDS_CMD),
+        "{}",
+        finding.remediation
+    );
+}
+
+#[test]
+fn unknown_tool_cannot_pass_doctor_while_failing_catalog() {
+    let root = tempdir().expect("tempdir");
+    let (runtime, _workspace, activities) = workspace_runtime(root.path());
+    std::fs::write(
+        activities.join("constellation_survey.yaml"),
+        agent_loop_yaml(
+            "constellation_survey",
+            "  tools:\n    - orbit.not_a_real_tool\n",
+        ),
+    )
+    .expect("write fixture");
+
+    let catalog_err = runtime
+        .v2_activity_catalog()
+        .expect_err("removed tool must fail catalog construction");
+    let catalog_text = catalog_err.to_string();
+    assert!(
+        catalog_text.contains("orbit.not_a_real_tool"),
+        "{catalog_text}"
+    );
+
+    let report = runtime
+        .inspect_definition_artifacts()
+        .expect("inspect artifacts");
+    let finding = health_of(&report, ArtifactKind::Activity)
+        .findings
+        .iter()
+        .find(|finding| finding.name == "constellation_survey")
+        .expect("doctor must surface the same catalog fault");
+    assert_eq!(finding.condition, ArtifactCondition::Faulty);
+    assert!(
+        finding.detail.contains("orbit.not_a_real_tool"),
+        "{}",
+        finding.detail
+    );
+    assert!(
+        !finding
+            .remediation
+            .contains(FIX_RETIRED_ACTIVITY_BACKENDS_CMD),
+        "unknown tools are not the backend repair: {}",
+        finding.remediation
+    );
+}
+
+#[test]
+fn repair_removes_only_known_backends_across_files_and_is_idempotent() {
+    let root = tempdir().expect("tempdir");
+    let (runtime, _workspace, activities) = workspace_runtime(root.path());
+    let http_path = activities.join("epic_orchestrator.yaml");
+    let auto_path = activities.join("agent_review.yaml");
+    let unknown_path = activities.join("custom_loop.yaml");
+    let malformed_path = activities.join("broken.yaml");
+    let comment_marker = "# keep this comment";
+    let http_body = agent_loop_yaml("epic_orchestrator", "  backend: http\n  model: grok\n");
+    let auto_body = agent_loop_yaml("agent_review", "  backend: auto\n");
+    let unknown_body = agent_loop_yaml("custom_loop", "  backend: weave\n");
+    let malformed_body = "schemaVersion: 2\nkind: Activity\nmetadata:\n  name: broken\nspec: [\n";
+    std::fs::write(&http_path, &http_body).expect("write http fixture");
+    std::fs::write(&auto_path, &auto_body).expect("write auto fixture");
+    std::fs::write(&unknown_path, &unknown_body).expect("write unknown fixture");
+    std::fs::write(&malformed_path, malformed_body).expect("write malformed fixture");
+
+    let report = runtime
+        .repair_retired_activity_backends()
+        .expect("repair pass");
+    assert_eq!(report.repaired.len(), 2, "{report:?}");
+    assert!(report.repaired.contains(&http_path), "{report:?}");
+    assert!(report.repaired.contains(&auto_path), "{report:?}");
+    assert_eq!(report.skipped.len(), 2, "{report:?}");
+    assert!(
+        report
+            .skipped
+            .iter()
+            .any(|skip| skip.path == unknown_path && skip.reason.contains("weave")),
+        "{report:?}"
+    );
+    assert!(
+        report
+            .skipped
+            .iter()
+            .any(|skip| skip.path == malformed_path && skip.reason.contains("malformed")),
+        "{report:?}"
+    );
+
+    let http_after = std::fs::read_to_string(&http_path).expect("read repaired http");
+    assert!(!http_after.contains("backend:"), "{http_after}");
+    assert!(http_after.contains("model: grok"), "{http_after}");
+    assert!(http_after.contains(comment_marker), "{http_after}");
+    let auto_after = std::fs::read_to_string(&auto_path).expect("read repaired auto");
+    assert!(!auto_after.contains("backend:"), "{auto_after}");
+    assert_eq!(
+        std::fs::read_to_string(&unknown_path).expect("unknown file survives"),
+        unknown_body
+    );
+    assert_eq!(
+        std::fs::read_to_string(&malformed_path).expect("malformed file survives"),
+        malformed_body
+    );
+
+    let after_repair = runtime
+        .inspect_definition_artifacts()
+        .expect("inspect after repair");
+    let leftovers = health_of(&after_repair, ArtifactKind::Activity)
+        .findings
+        .iter()
+        .map(|finding| finding.name.as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        leftovers.contains(&"custom_loop") && leftovers.contains(&"broken"),
+        "{leftovers:?}"
+    );
+    assert!(
+        !leftovers.contains(&"epic_orchestrator") && !leftovers.contains(&"agent_review"),
+        "{leftovers:?}"
+    );
+
+    let second = runtime
+        .repair_retired_activity_backends()
+        .expect("second repair pass");
+    assert!(second.repaired.is_empty(), "{second:?}");
+    assert_eq!(second.skipped.len(), 2, "{second:?}");
+
+    std::fs::remove_file(&unknown_path).expect("remove unknown backend fixture");
+    std::fs::remove_file(&malformed_path).expect("remove malformed fixture");
+    runtime
+        .v2_activity_catalog()
+        .expect("catalog loads after known backends are removed");
+    assert!(
+        health_of(
+            &runtime
+                .inspect_definition_artifacts()
+                .expect("inspect healthy workspace"),
+            ArtifactKind::Activity,
+        )
+        .findings
+        .is_empty()
+    );
+}
+
+#[test]
+fn remove_spec_backend_key_preserves_unrelated_bytes() {
+    let raw = "schemaVersion: 2\nkind: Activity\nmetadata:\n  name: demo\nspec:\n  type: agent_loop\n  backend: http  # retired\n  instruction: stay\n";
+    let next = remove_spec_backend_key(raw, "http").expect("remove backend");
+    assert_eq!(
+        next,
+        "schemaVersion: 2\nkind: Activity\nmetadata:\n  name: demo\nspec:\n  type: agent_loop\n  instruction: stay\n"
+    );
+}
+
+#[test]
+fn remove_spec_backend_key_refuses_flow_style() {
+    let raw = "schemaVersion: 2\nkind: Activity\nmetadata:\n  name: demo\nspec: {type: agent_loop, backend: http, instruction: stay}\n";
+    let error = remove_spec_backend_key(raw, "http").expect_err("flow style is not rewritten");
+    assert!(
+        error.contains("flow-style") || error.contains("block-style"),
+        "{error}"
+    );
+}

--- a/crates/orbit-core/src/command/tests/mod.rs
+++ b/crates/orbit-core/src/command/tests/mod.rs
@@ -1,3 +1,4 @@
+mod artifact_health;
 mod executor;
 mod job_pipeline;
 mod job_submission;

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -512,6 +512,16 @@ impl OrbitRuntime {
             .collect()
     }
 
+    /// Production activity-catalog directories in load order. Doctor reuses
+    /// this list so a workspace file that fails catalog construction cannot
+    /// be reported healthy.
+    pub(crate) fn v2_activity_catalog_paths(&self) -> Vec<PathBuf> {
+        self.v2_activity_catalog_dirs()
+            .into_iter()
+            .map(|dir| dir.path().to_path_buf())
+            .collect()
+    }
+
     fn v2_activity_catalog_dirs(&self) -> Vec<CatalogDirectory<V2ActivityCatalogDirKind>> {
         let mut dirs = CatalogDirectoryList::default();
 

--- a/crates/orbit-web/src/api/denials.rs
+++ b/crates/orbit-web/src/api/denials.rs
@@ -410,10 +410,7 @@ fn extract_denied_for_path(message: &str) -> Option<String> {
     let prefix = &message[..marker_idx];
     // Historical policy messages used `fs.<op> denied for \`...\``. Match any
     // `fs.*` prefix so stored traces from retired builtins still parse.
-    let last_token = prefix.rsplit_once('.').map(|(head, op)| (head, op));
-    let Some((head, op)) = last_token else {
-        return None;
-    };
+    let (head, op) = prefix.rsplit_once('.')?;
     if !head.ends_with("fs") || op.is_empty() {
         return None;
     }

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -172,12 +172,20 @@ across kinds (§4 above): skills merge workspace-over-global while activities
 keep shipped defaults authoritative. Provenance of the file Orbit wrote is the
 same question for every kind.
 
+Activity *fault* detection is the exception: it walks every production catalog
+directory (env override, global managed tree, workspace `.orbit/resources/activities/`)
+and applies the same `load_activity_asset` + tool-allowlist validation catalog
+construction uses, so a workspace file that fails `orbit activity list` or job
+dispatch cannot be reported healthy. Retired `spec.backend: http|auto` findings
+name `orbit doctor --fix-retired-activity-backends`, which deletes only that
+key from schemaVersion 2 agent-loop activities.
+
 `orbit doctor --fix-stale-artifacts` retires only deprecated artifacts whose
 digest still proves Orbit wrote them, preserving locally modified ones under
 `.retired-managed/` rather than deleting them. Faulty and user-authored files
-are reported and never touched. A workspace-authored fault is a `Warning`; only
-an unloadable *shipped default* is an `Error`, which keeps the `orbit doctor`
-exit code stable for existing cron and CI callers.
+are reported and never touched by that flag. A workspace-authored fault is a
+`Warning`; only an unloadable *shipped default* is an `Error`, which keeps the
+`orbit doctor` exit code stable for existing cron and CI callers.
 
 Direct single-activity runtime helpers:
 

--- a/docs/design/activity-job/specs/backend-resolution.md
+++ b/docs/design/activity-job/specs/backend-resolution.md
@@ -51,6 +51,13 @@ needs through its step inputs instead.
 Every refusal carries the same instruction: remove the setting; agent execution
 runs through the CLI agent path.
 
+`orbit doctor` applies that same activity-asset refusal on every production
+catalog directory, including workspace-local files. For the known retired
+values `http` and `auto` it names one opt-in repair,
+`orbit doctor --fix-retired-activity-backends`, which deletes only
+`spec.backend` and leaves unknown values or unrelated parse failures
+untouched.
+
 ## Invariants
 
 - `target: activity:<name>` resolution happens before job execution begins, so

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -28,6 +28,7 @@ aborting unless the store itself cannot open.
 | `task-reservations` | active reservations whose owner run or terminal task association proves the reservation stale |
 | `task-relations` | unresolved relation/dependency targets that would block a task-index rebuild |
 | `id-allocations` | learning/ADR ids pinned to a worktree that no longer exists, with no readable body |
+| `artifacts-*` | skills, jobs, activities, auto-tasks, and routines on disk: stale, deprecated, or catalog-invalid |
 
 Example:
 
@@ -80,8 +81,24 @@ This is distinct from `--fix-stale-locks`, which handles dead-holder filesystem 
 
 There is deliberately no blanket `--fix` or resolve-all option. Configuration repair, database
 recovery, job cancellation, graph cleanup, id-allocation retirement, filesystem lock deletion,
-and task-reservation release have different evidence and safety gates, so each repair remains
-explicit and safety-scoped.
+task-reservation release, and retired activity-backend cleanup have different evidence and
+safety gates, so each repair remains explicit and safety-scoped.
+
+### Repair retired activity backends
+
+`artifacts-activities` uses the same load and tool-allowlist path as production activity
+catalog construction, including workspace-local `.orbit/resources/activities/` files. A
+schemaVersion 2 `agent_loop` activity that still declares `spec.backend: http` or
+`spec.backend: auto` is a warning that names the file, the rejected field/value, the catalog
+parse error, and one opt-in repair:
+
+```sh
+orbit doctor --fix-retired-activity-backends
+```
+
+The repair deletes only that obsolete `spec.backend` key, leaves unknown backend values and
+unrelated malformed activities untouched (and reports them for a manual edit), and is
+idempotent across every activity catalog directory in the workspace.
 
 An `id-allocations` warning means an id was allocated inside a worktree that has since been
 reaped, before its body was merged: the body is unrecoverable and the row would otherwise stay

--- a/website/src/content/docs/concepts/activities-jobs.md
+++ b/website/src/content/docs/concepts/activities-jobs.md
@@ -13,7 +13,7 @@ Supported activity types:
 
 | Type | Use |
 |------|-----|
-| `agent_loop` | Run an agent with an instruction, provider, backend, and tool allowlist. The default backend is `cli`; `http` and `auto` are also accepted. |
+| `agent_loop` | Run an agent with an instruction, provider, and tool allowlist. Agent execution uses the CLI path only; `spec.backend: http` and `auto` fail catalog load. Remove a leftover backend with `orbit doctor --fix-retired-activity-backends`. |
 | `deterministic` | Run a registered deterministic action. |
 
 ## Job
@@ -40,7 +40,7 @@ schemaVersion: 2
 kind: Activity
 name: analyze_code
 spec:
-  backend: cli
+  type: agent_loop
   provider: gemini
   model: gemini-3.1-pro
   instruction: "Analyze the provided code."

--- a/website/src/content/docs/reference/activity-job-yaml.md
+++ b/website/src/content/docs/reference/activity-job-yaml.md
@@ -30,7 +30,7 @@ spec:
 
 | Type | Required fields | Notes |
 |------|-----------------|-------|
-| `agent_loop` | `instruction`; optional `tools`, `provider`, `backend`, `model`, `max_iterations`, `wall_clock_timeout_seconds` | The backend defaults to `cli`; `http` and `auto` are also accepted. `max_iterations` applies only to HTTP loops, while `wall_clock_timeout_seconds` bounds CLI invocations. |
+| `agent_loop` | `instruction`; optional `tools`, `provider`, `model`, `wall_clock_timeout_seconds` | Agent execution uses the CLI path only. `backend: cli` still parses and is ignored; `http` and `auto` fail catalog load. `orbit doctor --fix-retired-activity-backends` removes those retired keys. `max_iterations` is inert. |
 | `deterministic` | `action`; optional `config` | Runs a registered deterministic action. |
 
 ## Job Envelope


### PR DESCRIPTION
## Task

[ORB-10838](https://orbit-cli.com/tasks/ORB-10838) — Make orbit doctor detect and repair catalog-invalid activity definitions

### Description

## Problem

After the CLI-only agent execution migration, an existing schemaVersion 2 activity containing `spec.backend: http` makes the production activity catalog fail to build. `jrun-20260815-2144` failed at step 0 with:

`build activity catalog: ... epic_orchestrator.yaml: schemaVersion 2 parse failed: spec: backend: http is no longer supported ... remove the backend setting`

However, running the same installed binary's `orbit doctor --json` in that workspace reported:

`artifacts-activities: 35 activities loaded, none stale, deprecated, or faulty`

This is a validation-path mismatch: doctor accepts an activity that the job runner rejects. ORB-10800 added definition-artifact health checks, but its activity inspection is not exercising the production catalog validation that rejects retired backend selection.

## Why It Matters

A workspace can pass `orbit doctor` and still have every workflow fail before task discovery or agent execution. Operators receive no preflight warning and must manually edit every affected YAML file after an outage.

## Required Behavior

- Doctor must apply the same schema and semantic validation used when building the production activity catalog, so catalog-invalid activities cannot be reported healthy.
- The finding must identify the exact file, rejected field/value, and the same actionable cause surfaced by catalog construction.
- Doctor must provide an explicit opt-in repair path for this retired setting. The repair may only remove the obsolete `spec.backend` key from schemaVersion 2 agent-loop activities where the value is a known retired/ignored backend value; it must not rewrite unrelated YAML or broadly repair arbitrary user-authored parse failures.
- The repair must be idempotent and safe across workspace activity catalogs, including more than one affected file.

## Incident Evidence

- Run: `jrun-20260815-2144` in `ws_polaris`
- Affected file: `.orbit/resources/activities/epic_orchestrator.yaml`
- Current workaround: remove `spec.backend: http` manually
- Related completed work: ORB-10800

### Acceptance Criteria

- A regression fixture with a schemaVersion 2 agent-loop activity containing `spec.backend: http` causes `orbit doctor --json` to return a non-ok `artifacts-activities` finding that names the file, field/value, and production catalog validation error.
- The doctor activity-health implementation shares or directly invokes the production activity validation path; a test prevents a definition from passing doctor while failing job/activity catalog construction.
- Doctor output for the retired backend finding names one explicit opt-in repair command.
- Running the repair command removes only the obsolete `spec.backend` entry from affected schemaVersion 2 agent-loop activity files, preserves all unrelated content, and makes both `orbit doctor --json` and `orbit job list --json` succeed.
- The repair handles multiple affected activity files in one workspace and is idempotent on a second run.
- The repair refuses or leaves untouched unknown backend values and unrelated malformed user-authored activities, reporting them for manual intervention instead.
- Targeted doctor/catalog tests plus `make ci-fast` and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Doctor activity health now walks every production catalog directory (env, global, workspace) and validates each YAML with `load_activity_catalog_asset` plus `validate_catalog_activity_tools` — the same parse and registry allowlist path `v2_activity_catalog()` uses. Workspace `spec.backend: http` (and unknown tools / retired `role`) can no longer be reported healthy while catalog construction fails.
- Retired-backend findings name the file, `spec.backend: <value>`, the catalog parse error, and one opt-in command: `orbit doctor --fix-retired-activity-backends`.
- That repair deletes only a block-style `spec.backend: http|auto` key from schemaVersion 2 agent-loop activities, preserves unrelated bytes, handles multiple files, is idempotent, and reports unknown backends / unrelated malformed activities for a manual edit.
- Docs and website pages no longer advertise `http`/`auto` as accepted; they describe the doctor finding and the repair flag.
- Extra context file `file:crates/orbit-web/src/api/denials.rs`: two-line pre-existing clippy fix (`map_identity` / `question_mark`) so workspace `make ci-lint` could pass. Not part of the doctor/catalog behavior change.

Strategic decisions:
- Shared the production loader functions rather than calling `v2_activity_catalog()` as a whole, so doctor still reports every faulty file instead of failing fast on the first.
- Repair is mechanically narrow (known retired backend values only). Retired `role` and removed tool names are now *detected* by doctor but left for a follow-up; acceptance criteria require the repair to remove only `spec.backend`.

Assessment: Acceptance criteria are covered by catalog, artifact-health, doctor, and CLI tests. `make ci-fast` and `make ci-lint` passed after the unrelated orbit-web clippy unblock.

Validation:
- orbit-common catalog tests: 4 passed
- orbit-core artifact_health tests: 5 passed
- orbit-core managed_assets tests: 12 passed
- orbit-cmd doctor workspace_retired_backend test: passed
- orbit-cli cli_parses_doctor* tests: 3 passed
- make ci-fast: passed
- make ci-lint: passed

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10838-6a80e3b1`
- Behind base: 0
- Ahead of base: 1