### PR TITLE
Make orbit task show resolve globally by task ID

### DIFF
--- a/crates/orbit-cli/src/command/mcp/server.rs
+++ b/crates/orbit-cli/src/command/mcp/server.rs
@@ -10,14 +10,19 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use orbit_cmd::registry_runtime::{RegisteredRuntimeFactory, ResolvedWorkspaceSelection};
+use orbit_cmd::task_owner;
 use orbit_common::types::{
-    McpToolDefinition, McpToolScope, NotFoundKind, OrbitError, ToolSessionContext,
+    McpToolDefinition, McpToolScope, NotFoundKind, OrbitError, ToolSessionContext, required_string,
 };
 use orbit_core::OrbitRuntime;
 use orbit_core::command::tool::{ToolEntryPoint, execute_global_in_process_tool_dispatch};
 use orbit_core::runtime::resolve_global_root;
 use orbit_mcp::{ListenerExposure, McpHost, McpListener};
 use serde_json::Value;
+
+/// The one tool whose target is a machine-global primary key, and therefore the
+/// one whose default binding follows the ID instead of the session [ORB-10797].
+const TASK_SHOW_TOOL: &str = "orbit.task.show";
 
 pub(super) fn serve_mcp_stdio(remote_caller_machine_id: Option<String>) -> Result<(), OrbitError> {
     let (host, session_context) = compose_server(remote_caller_machine_id)?;
@@ -93,9 +98,7 @@ impl ServerMcpHost {
         input: &'a Value,
         context: &'a ToolSessionContext,
     ) -> Option<&'a str> {
-        input
-            .get("workspace")
-            .and_then(Value::as_str)
+        call_workspace_selector(input)
             .or(context.workspace.as_deref())
             .map(str::trim)
             .filter(|selector| !selector.is_empty())
@@ -144,16 +147,35 @@ impl ServerMcpHost {
         input: &Value,
         context: &ToolSessionContext,
     ) -> Result<(OrbitRuntime, ResolvedWorkspaceSelection), OrbitError> {
-        let selector = Self::workspace_selector(input, context)
-            .ok_or_else(|| self.workspace_required(name))?;
-        let selected =
-            RegisteredRuntimeFactory::resolve_workspace_selector(&self.global_root, selector)?;
+        let selected = self.workspace_selection(name, input, context)?;
         let runtime = RegisteredRuntimeFactory::open_registered_checkout(
             &self.global_root,
             &selected.workspace,
             &selected.checkout,
         )?;
         Ok((runtime, selected))
+    }
+
+    /// Which registered workspace this call lands in.
+    ///
+    /// `orbit.task.show` follows the globally unique task ID unless the call
+    /// itself passes `workspace` [ORB-10797]: the session's announced workspace
+    /// is ambient, like cwd, and is the right default for authoring but the
+    /// wrong one for addressing an ID. An explicit per-call `workspace` stays a
+    /// filter on every tool, so a task owned elsewhere is not found there.
+    fn workspace_selection(
+        &self,
+        name: &str,
+        input: &Value,
+        context: &ToolSessionContext,
+    ) -> Result<ResolvedWorkspaceSelection, OrbitError> {
+        if name == TASK_SHOW_TOOL && call_workspace_selector(input).is_none() {
+            let task_id = required_string(input, &["id"], "id")?;
+            return task_owner::resolve_task_owner(&self.global_root, &task_id);
+        }
+        let selector = Self::workspace_selector(input, context)
+            .ok_or_else(|| self.workspace_required(name))?;
+        RegisteredRuntimeFactory::resolve_workspace_selector(&self.global_root, selector)
     }
 
     fn audit_global_failure(
@@ -246,6 +268,13 @@ impl McpHost for ServerMcpHost {
         }
         self.call_workspace_tool(name, input, context)
     }
+}
+
+/// The selector the call itself passed, untrimmed. Distinguishing "the caller
+/// named a workspace" from "the session announced one" is what makes an
+/// explicit selector a filter and the ambient one a default.
+fn call_workspace_selector(input: &Value) -> Option<&str> {
+    input.get("workspace").and_then(Value::as_str)
 }
 
 fn execute_core_tool(

--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -26,10 +26,20 @@ pub struct CommandMeta {
     pub job_run_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeNeed {
     Required,
     Forbidden,
+    /// Bind the workspace that owns this task ID rather than the one the cwd
+    /// or `--workspace` walk would pick [ORB-10797].
+    ///
+    /// Task IDs are a machine-global primary key, so `task show` is the one
+    /// verb whose target is addressable without knowing its workspace. A
+    /// `--workspace` selector still wins and still filters: the bootstrap
+    /// binds that workspace, and a task owned elsewhere is simply not found.
+    TaskOwner {
+        task_id: String,
+    },
 }
 
 pub struct DispatchContext<'a> {
@@ -452,8 +462,17 @@ impl Commands {
                     ),
                     TaskSubcommand::Reindex(_) => ("reindex", None, None),
                 };
+                let runtime_need = match &command.command {
+                    TaskSubcommand::Show(args) => RuntimeNeed::TaskOwner {
+                        task_id: args.id.clone(),
+                    },
+                    // Every other task verb keeps cwd (or `--workspace`) as its
+                    // binding: only a read addressed by a globally unique ID can
+                    // be routed from the ID alone.
+                    _ => RuntimeNeed::Required,
+                };
                 CommandOperation::new(
-                    RuntimeNeed::Required,
+                    runtime_need,
                     Some(admin_meta("task", Some(subcommand), target_type, target_id)),
                     None,
                     false,

--- a/crates/orbit-cli/src/command/task/command.rs
+++ b/crates/orbit-cli/src/command/task/command.rs
@@ -38,7 +38,8 @@ pub enum TaskSubcommand {
     Locks(LocksCommand),
     /// List tasks with optional filters
     List(TaskListArgs),
-    /// Show detailed information about a task
+    /// Show detailed information about a task, found by ID in any registered
+    /// workspace unless `--workspace` narrows the search
     Show(TaskShowArgs),
     /// Lint tasks for stale paths and vague acceptance criteria; `--fix` prunes stale context files
     Lint(TaskLintArgs),

--- a/crates/orbit-cli/src/command/task/show.rs
+++ b/crates/orbit-cli/src/command/task/show.rs
@@ -1,6 +1,7 @@
 use clap::Args;
+use orbit_cmd::task_owner::{WorkspaceIdentity, bound_workspace_identity};
 use orbit_core::{OrbitError, OrbitRuntime, TaskRelatedDoc};
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use crate::command::{Block, CommandOut, CommandOutput, Execute, Payload};
 
@@ -64,7 +65,13 @@ impl Execute for TaskShowArgs {
         } else {
             Vec::new()
         };
+        // The task may have been reached through the global registry rather
+        // than the cwd, so every full projection names where it was read from.
+        let owner = bound_workspace_identity(runtime);
         let mut doc = task_to_json_for_runtime(runtime, &task)?;
+        if let Some(owner) = &owner {
+            insert_workspace_identity(&mut doc, owner)?;
+        }
         if self.with_context {
             insert_related_docs(&mut doc, related_docs.clone())?;
         }
@@ -76,6 +83,9 @@ impl Execute for TaskShowArgs {
             let mut out = String::new();
             use crate::output::color::{Domain, bold, dimmed, text};
             let _ = writeln!(out, "{} {}", bold("ID:"), task.id);
+            if let Some(owner) = &owner {
+                let _ = writeln!(out, "{} {}", bold("Workspace:"), owner.label());
+            }
             if let Some(parent_id) = task.parent_id() {
                 let _ = writeln!(out, "{} {}", bold("Parent Task:"), parent_id);
             }
@@ -229,6 +239,23 @@ impl Execute for TaskShowArgs {
             Ok(Payload::blocks(doc, blocks).into())
         }
     }
+}
+
+/// Name the owning workspace in the machine-readable projection, in the same
+/// `(name, logical id)` shape the human line prints, so a follow-up write can
+/// address it with `--workspace`.
+fn insert_workspace_identity(
+    value: &mut Value,
+    owner: &WorkspaceIdentity,
+) -> Result<(), OrbitError> {
+    let object = value.as_object_mut().ok_or_else(|| {
+        OrbitError::Execution("task JSON projection did not produce an object".to_string())
+    })?;
+    object.insert(
+        "workspace".to_string(),
+        json!({ "id": owner.id, "name": owner.name }),
+    );
+    Ok(())
 }
 
 fn insert_related_docs(

--- a/crates/orbit-cli/src/main.rs
+++ b/crates/orbit-cli/src/main.rs
@@ -191,26 +191,34 @@ fn main() {
         governed,
     } = cli.command.operation().attribute_to(&actor);
 
-    if matches!(runtime_need, RuntimeNeed::Forbidden) {
-        // A runtime-forbidden command has no store to authorize or audit
-        // against. None is governed; `Commands::operation` is exhaustive, so a
-        // future one that is would have to resolve this first.
-        debug_assert!(
-            governed.is_none(),
-            "a governed operation must be able to reach the authorization chokepoint"
-        );
-        let result = dispatch(
-            cli.command,
-            DispatchContext::without_runtime(root_override.as_deref()),
-        );
-        finish_command(result, &sink, suppress_errors, json_error_preference);
-        return;
-    }
+    let bootstrapped = match &runtime_need {
+        RuntimeNeed::Forbidden => {
+            // A runtime-forbidden command has no store to authorize or audit
+            // against. None is governed; `Commands::operation` is exhaustive, so
+            // a future one that is would have to resolve this first.
+            debug_assert!(
+                governed.is_none(),
+                "a governed operation must be able to reach the authorization chokepoint"
+            );
+            let result = dispatch(
+                cli.command,
+                DispatchContext::without_runtime(root_override.as_deref()),
+            );
+            finish_command(result, &sink, suppress_errors, json_error_preference);
+            return;
+        }
+        RuntimeNeed::Required => RegisteredRuntimeFactory::initialize_with_overrides(
+            root_override.as_deref(),
+            workspace_selector.as_deref(),
+        ),
+        RuntimeNeed::TaskOwner { task_id } => orbit_cmd::task_owner::initialize_for_task_show(
+            root_override.as_deref(),
+            workspace_selector.as_deref(),
+            task_id,
+        ),
+    };
 
-    let runtime = match RegisteredRuntimeFactory::initialize_with_overrides(
-        root_override.as_deref(),
-        workspace_selector.as_deref(),
-    ) {
+    let runtime = match bootstrapped {
         Ok(runtime) => runtime,
         Err(err) => {
             if suppress_errors {

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -488,8 +488,18 @@ fn mcp_serve_lists_the_canonical_surface_outside_any_checkout() {
         .collect::<Vec<_>>();
     assert!(names.contains(&"orbit_task_show"));
 
+    // `task show` needs no selector — it follows the ID — so a server outside
+    // any checkout reports the ID as unknown rather than as unaddressable.
     let missing = client.call_tool_err("orbit_task_show", json!({ "id": "ORB-00001" }));
-    assert!(missing["message"].as_str().is_some_and(|message| {
+    assert!(
+        missing["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("ORB-00001")),
+        "an unregistered id must be reported as not found: {missing}"
+    );
+    // Every other workspace-scoped tool still requires one.
+    let unscoped = client.call_tool_err("orbit_task_list", json!({}));
+    assert!(unscoped["message"].as_str().is_some_and(|message| {
         message.contains("requires a workspace selector")
             && message.contains("MCP initialize metadata")
     }));
@@ -1111,6 +1121,79 @@ fn worktree_backed_activity_routes_task_and_search_by_advertised_workspace_argum
     let shown: Value = serde_json::from_slice(&output.stdout).expect("parse CLI task show");
     assert_eq!(shown["id"], json!(task_id));
     assert_eq!(shown["execution_summary"], "Routed from a linked worktree");
+}
+
+/// ORB-10797: the constellation-orchestrator shape.
+///
+/// An agent sits in one workspace's MCP session and holds a task ID from
+/// another. The session's announced workspace is ambient, like cwd, so a
+/// `{id}`-only `orbit.task.show` follows the ID to its owner; an explicit
+/// per-call `workspace` stays a filter and 404s.
+#[test]
+fn mcp_task_show_follows_the_global_id_and_explicit_workspace_stays_a_filter() {
+    let workspace = McpWorkspace::init();
+
+    let elsewhere = workspace.home.join("elsewhere");
+    std::fs::create_dir_all(&elsewhere).expect("create the second checkout");
+    let output = Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(&elsewhere)
+        .output()
+        .expect("initialize the second Git checkout");
+    assert!(output.status.success(), "git init failed: {output:?}");
+    let output = McpWorkspace::orbit_command(&elsewhere, &workspace.home)
+        .args(["workspace", "init", "--name", "mcp-elsewhere"])
+        .output()
+        .expect("register the second workspace");
+    assert!(
+        output.status.success(),
+        "second workspace init failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let add_input = json!({
+        "title": "Owned by the other workspace",
+        "description": "Addressed by ID from a session bound elsewhere",
+        "workspace": elsewhere.to_str().expect("utf8 checkout path"),
+        "model": "codex",
+    })
+    .to_string();
+    let output = McpWorkspace::orbit_command(&elsewhere, &workspace.home)
+        .args(["tool", "run", "orbit.task.add", "--input", &add_input])
+        .output()
+        .expect("author a task in the second workspace");
+    assert!(
+        output.status.success(),
+        "task add failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let created: Value = serde_json::from_slice(&output.stdout).expect("parse created task");
+    let task_id = created["id"].as_str().expect("task id").to_string();
+
+    // The session announces the *first* workspace at initialize.
+    let mut client = workspace.serve();
+
+    let shown = client.call_tool_ok("orbit_task_show", json!({ "id": task_id }));
+    assert_eq!(
+        shown["id"],
+        json!(task_id),
+        "an id-only show must follow the id past the session workspace: {shown}"
+    );
+    assert_eq!(shown["title"], "Owned by the other workspace");
+
+    let session_workspace = workspace.work.to_str().expect("utf8 session workspace");
+    let missed = client.call_tool_err(
+        "orbit_task_show",
+        json!({ "id": task_id, "workspace": session_workspace }),
+    );
+    assert!(
+        missed["message"]
+            .as_str()
+            .is_some_and(|message| message.contains(&task_id)),
+        "an explicit workspace must filter rather than follow the id: {missed}"
+    );
 }
 
 /// Commit the checkout and attach a linked worktree, mirroring how the engine

--- a/crates/orbit-cli/tests/workspace_selector.rs
+++ b/crates/orbit-cli/tests/workspace_selector.rs
@@ -170,6 +170,102 @@ fn global_workspace_flag_fails_closed_on_unknown_selector() {
     );
 }
 
+/// `task show` is the one verb whose target is a machine-global primary key, so
+/// omitting `--workspace` follows the ID instead of the cwd [ORB-10797].
+#[test]
+fn task_show_follows_the_global_task_id_and_explicit_workspace_stays_a_filter() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let orbit_repo = temp.path().join("orbit");
+    let other_repo = temp.path().join("other");
+    let elsewhere = temp.path().join("elsewhere");
+    fs::create_dir_all(&home).expect("home");
+    fs::create_dir_all(&elsewhere).expect("elsewhere");
+
+    init_git_repo(&orbit_repo);
+    init_git_repo(&other_repo);
+
+    run_orbit(
+        &orbit_repo,
+        &home,
+        &[
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "selector-host",
+            "--task-prefix",
+            "SEL",
+        ],
+    )
+    .success();
+    run_orbit(
+        &orbit_repo,
+        &home,
+        &["workspace", "init", "--name", "orbit"],
+    )
+    .success();
+    run_orbit(
+        &other_repo,
+        &home,
+        &["workspace", "init", "--name", "other"],
+    )
+    .success();
+
+    let created = run_orbit_json(
+        &orbit_repo,
+        &home,
+        &[
+            "task",
+            "add",
+            "--title",
+            "Globally addressable task",
+            "--description",
+            "Reachable by ID from anywhere",
+            "--json",
+        ],
+    );
+    let task_id = created["id"].as_str().expect("created id").to_string();
+
+    // A foreign checkout, and a directory that is no workspace at all.
+    for cwd in [&other_repo, &elsewhere] {
+        let shown = run_orbit_json(cwd, &home, &["task", "show", &task_id, "--json"]);
+        assert_eq!(
+            shown["id"],
+            Value::String(task_id.clone()),
+            "task show from {} must follow the id: {shown}",
+            cwd.display()
+        );
+        assert_eq!(shown["workspace"]["name"], "orbit");
+        assert_eq!(shown["workspace"]["id"], "ws_orbit");
+    }
+
+    let human = run_orbit(&elsewhere, &home, &["task", "show", &task_id]).success();
+    let stdout = String::from_utf8_lossy(&human.get_output().stdout).into_owned();
+    assert!(
+        stdout.contains("Workspace: orbit (ws_orbit)"),
+        "human output must name the owning workspace: {stdout}"
+    );
+
+    // An explicit selector is a filter: the task is not in `other`, so the read
+    // fails closed rather than falling back to the owner.
+    let missed = run_orbit(
+        &elsewhere,
+        &home,
+        &["--workspace", "other", "task", "show", &task_id],
+    )
+    .failure();
+    let missed_stdout = String::from_utf8_lossy(&missed.get_output().stdout);
+    assert!(
+        !missed_stdout.contains("Globally addressable task"),
+        "a foreign task must not be printed under `--workspace other`: {missed_stdout}"
+    );
+    let missed_stderr = String::from_utf8_lossy(&missed.get_output().stderr);
+    assert!(
+        missed_stderr.contains(&task_id),
+        "the miss must name the task it looked for: {missed_stderr}"
+    );
+}
+
 fn task_ids(value: &Value) -> Vec<String> {
     let items = value
         .as_array()

--- a/crates/orbit-cmd/src/lib.rs
+++ b/crates/orbit-cmd/src/lib.rs
@@ -27,6 +27,7 @@ pub mod doctor;
 pub mod migrate;
 pub mod registry_routines;
 pub mod registry_runtime;
+pub mod task_owner;
 
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-cmd/src/registry_runtime.rs
+++ b/crates/orbit-cmd/src/registry_runtime.rs
@@ -27,6 +27,7 @@ pub struct ResolvedWorkspaceBinding {
 
 /// One server-local workspace selected from the registry, before Core opens a
 /// runtime for it.
+#[derive(Debug, Clone)]
 pub struct ResolvedWorkspaceSelection {
     pub workspace: Workspace,
     pub checkout: WorkspaceCheckout,
@@ -115,10 +116,7 @@ impl RegisteredRuntimeFactory {
                 .map(|runtime| runtime.with_coordination_write_owner(replica_owner));
         };
 
-        let global_root = match root_override {
-            Some(root) => root.to_path_buf(),
-            None => workspace_registry::global_orbit_dir()?,
-        };
+        let global_root = global_root_for(root_override)?;
         let selected = Self::resolve_workspace_selector(&global_root, selector)?;
         Self::open_registered_checkout(&global_root, &selected.workspace, &selected.checkout)
     }
@@ -228,6 +226,16 @@ impl RegisteredRuntimeFactory {
                 Self::open_registered_checkout(&global_root, workspace, checkout).map(Some)
             }
         }
+    }
+}
+
+/// The host data directory a registry lookup reads: the `--root` override when
+/// one was passed, and `~/.orbit` otherwise. Never derived from cwd, so a
+/// registry-first command works from any directory.
+pub(crate) fn global_root_for(root_override: Option<&Path>) -> Result<PathBuf, OrbitError> {
+    match root_override {
+        Some(root) => Ok(root.to_path_buf()),
+        None => workspace_registry::global_orbit_dir(),
     }
 }
 

--- a/crates/orbit-cmd/src/task_owner.rs
+++ b/crates/orbit-cmd/src/task_owner.rs
@@ -1,0 +1,153 @@
+//! Which registered workspace owns a globally unique task ID.
+//!
+//! Task IDs are a machine-global primary key in the coordination task registry,
+//! so `task show` follows the ID instead of the caller's cwd or MCP session
+//! [ORB-10797]. This module is the single owner of that lookup and of the
+//! registry identity (`orbit (ws_orbit)`) the command reports; the CLI
+//! subcommand and the authoritative MCP server both call it rather than
+//! repeating the join.
+//!
+//! Scope is deliberately `task show`. Every other verb keeps cwd or the
+//! announced session workspace as its default, because only a read addressed
+//! by a globally unique ID can be routed from the ID alone.
+
+use std::path::Path;
+
+use orbit_common::types::{NotFoundKind, OrbitError, Workspace, WorkspaceStatus};
+use orbit_core::OrbitRuntime;
+use orbit_registry::workspace_registry;
+use orbit_store::sqlite::task_registry::{
+    TaskRegistryStore, read_workspace_config_optional, task_registry_path,
+};
+
+use crate::registry_runtime::{
+    RegisteredRuntimeFactory, ResolvedWorkspaceSelection, global_root_for,
+};
+
+/// How `task show` names the workspace a task landed in.
+///
+/// The logical ID is the half a later write addresses (`orbit --workspace
+/// ws_orbit task update ...`); the name is the half a human recognizes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceIdentity {
+    pub id: String,
+    pub name: String,
+}
+
+impl WorkspaceIdentity {
+    fn of(workspace: &Workspace) -> Self {
+        Self {
+            id: workspace.id.clone(),
+            name: workspace.name.clone(),
+        }
+    }
+
+    /// `orbit (ws_orbit)` — the rendering both the human line and the error
+    /// messages below use.
+    pub fn label(&self) -> String {
+        format!("{} ({})", self.name, self.id)
+    }
+}
+
+/// Bootstrap the runtime `orbit task show <id>` must read.
+///
+/// With `--workspace`, the selector is a filter: this is the ordinary
+/// registered bootstrap, and a task owned elsewhere simply is not found there.
+/// Without one, the task registry — not the cwd walk — names the owner, so the
+/// command works from a foreign checkout and from a directory that is no
+/// workspace at all.
+pub fn initialize_for_task_show(
+    root_override: Option<&Path>,
+    workspace_selector: Option<&str>,
+    task_id: &str,
+) -> Result<OrbitRuntime, OrbitError> {
+    let selector = workspace_selector
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if selector.is_some() {
+        return RegisteredRuntimeFactory::initialize_with_overrides(root_override, selector);
+    }
+    let global_root = global_root_for(root_override)?;
+    let selected = resolve_task_owner(&global_root, task_id)?;
+    RegisteredRuntimeFactory::open_registered_checkout(
+        &global_root,
+        &selected.workspace,
+        &selected.checkout,
+    )
+}
+
+/// Resolve the registered checkout that owns `task_id`.
+///
+/// An ID the registry has never seen is a plain not-found — the registry is the
+/// index, and `orbit task reindex` is what repairs a bundle missing from it. An
+/// ID it knows whose owning checkout is gone, unreadable, or inactive is *not*
+/// a not-found: those name the owning workspace, because "unknown task" would
+/// send the caller looking for the wrong problem.
+pub fn resolve_task_owner(
+    global_root: &Path,
+    task_id: &str,
+) -> Result<ResolvedWorkspaceSelection, OrbitError> {
+    let tasks = TaskRegistryStore::open(&task_registry_path(global_root))?;
+    let binding = tasks
+        .find_task_binding(task_id)?
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, task_id.to_string()))?;
+    let partition = binding.workspace_id;
+
+    let registry = workspace_registry::load_registry_from(&workspace_registry::registry_path_for(
+        global_root,
+    ))?;
+    let owner = workspace_registry::local_workspaces(&registry).find(|(_, checkout)| {
+        checkout_identity(&checkout.orbit_dir).is_some_and(|identity| identity == partition)
+    });
+    let Some((workspace, checkout)) = owner else {
+        // The task registry keeps the partition's slug even when no checkout
+        // answers to it, so the caller still learns which workspace to repair.
+        let slug = tasks
+            .find_workspace_binding(&partition)
+            .ok()
+            .flatten()
+            .map(|binding| binding.slug)
+            .unwrap_or_else(|| partition.clone());
+        return Err(OrbitError::WorkspaceError(format!(
+            "task {task_id} is owned by workspace '{slug}' ({partition}), which has no readable local checkout on this machine; restore or re-register that checkout"
+        )));
+    };
+    if workspace.status != WorkspaceStatus::Active {
+        return Err(OrbitError::WorkspaceError(format!(
+            "task {task_id} is owned by workspace {}, which is {} on this machine",
+            WorkspaceIdentity::of(workspace).label(),
+            workspace.status
+        )));
+    }
+    Ok(ResolvedWorkspaceSelection {
+        workspace: workspace.clone(),
+        checkout: checkout.clone(),
+    })
+}
+
+/// Registry identity of the workspace `runtime` is bound to, when its checkout
+/// is registered on this machine.
+///
+/// Reported by `task show` on every path — cwd, `--workspace`, and registry
+/// ownership alike — so the output always names where the record was read from.
+/// An unregistered checkout (a bare `orbit init` directory) simply has no
+/// registry identity to report.
+pub fn bound_workspace_identity(runtime: &OrbitRuntime) -> Option<WorkspaceIdentity> {
+    let registry = workspace_registry::load_registry_from(&workspace_registry::registry_path_for(
+        &runtime.global_root(),
+    ))
+    .ok()?;
+    workspace_registry::find_workspace_by_path(&registry, &runtime.paths().repo_root)
+        .map(WorkspaceIdentity::of)
+}
+
+/// Checkout identity recorded in `<orbit_dir>/config.yaml`, which is the key
+/// the task registry partitions by (L-0098: it may differ from the logical
+/// registry ID). A checkout that has been deleted or never initialized has
+/// none, and is simply not a candidate owner.
+fn checkout_identity(orbit_dir: &Path) -> Option<String> {
+    read_workspace_config_optional(orbit_dir)
+        .ok()
+        .flatten()
+        .map(|config| config.workspace_id)
+}

--- a/crates/orbit-cmd/src/tests/mod.rs
+++ b/crates/orbit-cmd/src/tests/mod.rs
@@ -6,3 +6,4 @@ mod doctor;
 mod migrate;
 mod registry_routines;
 mod registry_runtime;
+mod task_owner;

--- a/crates/orbit-cmd/src/tests/task_owner.rs
+++ b/crates/orbit-cmd/src/tests/task_owner.rs
@@ -1,0 +1,195 @@
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use orbit_common::types::{
+    NotFoundKind, OrbitError, Workspace, WorkspaceCheckout, WorkspaceRegistry, WorkspaceStatus,
+};
+use orbit_core::OrbitRuntime;
+use orbit_registry::workspace_registry::{registry_path_for, save_registry_to};
+use orbit_store::sqlite::task_registry::{
+    WorkspaceConfig, workspace_config_path, write_workspace_config,
+};
+use serde_json::json;
+use tempfile::TempDir;
+
+use crate::registry_runtime::RegisteredRuntimeFactory;
+use crate::task_owner::{bound_workspace_identity, initialize_for_task_show, resolve_task_owner};
+
+/// Two registered workspaces holding one task, with the checkout identity the
+/// task registry partitions by deliberately different from the logical registry
+/// ID (L-0098) — the join `resolve_task_owner` has to get right.
+struct OwnerFixture {
+    _root: TempDir,
+    global: PathBuf,
+    alpha: OrbitRuntime,
+    beta_repo: PathBuf,
+    beta_orbit_dir: PathBuf,
+    beta_task_id: String,
+}
+
+fn owner_fixture() -> OwnerFixture {
+    let root = tempfile::tempdir().expect("root");
+    let global = root.path().join("global");
+    std::fs::create_dir_all(&global).expect("global");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_owner_test\"\nhost_id = \"owner-test\"\ntask_prefix = \"ORB\"\n",
+    )
+    .expect("host identity");
+
+    let (ws_alpha, checkout_alpha) =
+        registered_workspace(root.path(), "ws_alpha", "alpha", "alpha-a1b2c3");
+    let (ws_beta, checkout_beta) =
+        registered_workspace(root.path(), "ws_beta", "beta", "beta-d4e5f6");
+    save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![ws_alpha.clone(), ws_beta.clone()],
+            checkouts: vec![checkout_alpha.clone(), checkout_beta.clone()],
+            ..Default::default()
+        },
+        &registry_path_for(&global),
+    )
+    .expect("workspace registry");
+
+    let alpha =
+        RegisteredRuntimeFactory::open_registered_checkout(&global, &ws_alpha, &checkout_alpha)
+            .expect("alpha runtime");
+    let beta =
+        RegisteredRuntimeFactory::open_registered_checkout(&global, &ws_beta, &checkout_beta)
+            .expect("beta runtime");
+    let created = beta
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Beta-only task",
+                "description": "Filed in beta; addressable from anywhere by ID.",
+                "workspace": checkout_beta.repo_root
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("seed beta task");
+
+    OwnerFixture {
+        _root: root,
+        global,
+        alpha,
+        beta_repo: checkout_beta.repo_root,
+        beta_orbit_dir: checkout_beta.orbit_dir,
+        beta_task_id: created["id"].as_str().expect("created task id").to_string(),
+    }
+}
+
+fn registered_workspace(
+    root: &Path,
+    logical_id: &str,
+    name: &str,
+    checkout_identity: &str,
+) -> (Workspace, WorkspaceCheckout) {
+    let repo = root.join(name);
+    let orbit_dir = repo.join(".orbit");
+    std::fs::create_dir_all(&orbit_dir).expect("orbit dir");
+    write_workspace_config(
+        &orbit_dir,
+        &WorkspaceConfig {
+            schema_version: 1,
+            workspace_id: checkout_identity.to_string(),
+        },
+    )
+    .expect("workspace config");
+    let workspace = Workspace {
+        id: logical_id.to_string(),
+        name: name.to_string(),
+        owner_machine_id: Some("hm_owner_test".to_string()),
+        git_remote: None,
+        ship_mode: Some("local".to_string()),
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    let checkout = WorkspaceCheckout::owner(logical_id.to_string(), repo, orbit_dir);
+    (workspace, checkout)
+}
+
+#[test]
+fn global_lookup_resolves_the_owning_workspace_by_task_id() {
+    let fixture = owner_fixture();
+    let selection =
+        resolve_task_owner(&fixture.global, &fixture.beta_task_id).expect("registry owns the id");
+    assert_eq!(selection.workspace.id, "ws_beta");
+    assert_eq!(selection.workspace.name, "beta");
+    assert_eq!(selection.checkout.repo_root, fixture.beta_repo);
+}
+
+#[test]
+fn implicit_task_show_bootstrap_binds_the_owner_and_explicit_workspace_still_filters() {
+    let fixture = owner_fixture();
+
+    let owner = initialize_for_task_show(Some(&fixture.global), None, &fixture.beta_task_id)
+        .expect("implicit bootstrap follows the id");
+    assert_eq!(owner.paths().repo_root, fixture.beta_repo);
+    assert_eq!(
+        owner
+            .get_task(&fixture.beta_task_id)
+            .expect("owner runtime reads the task")
+            .title,
+        "Beta-only task"
+    );
+
+    // `--workspace alpha` is a filter, not a hint: the bootstrap binds alpha and
+    // beta's task is simply not there.
+    let filtered =
+        initialize_for_task_show(Some(&fixture.global), Some("alpha"), &fixture.beta_task_id)
+            .expect("explicit selector binds the named workspace");
+    assert_eq!(filtered.paths().repo_root, fixture.alpha.paths().repo_root);
+    assert!(matches!(
+        filtered.get_task(&fixture.beta_task_id),
+        Err(OrbitError::NotFound {
+            kind: NotFoundKind::Task,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn an_unregistered_task_id_is_a_plain_not_found() {
+    let fixture = owner_fixture();
+    assert!(matches!(
+        resolve_task_owner(&fixture.global, "ORB-99999"),
+        Err(OrbitError::NotFound {
+            kind: NotFoundKind::Task,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn a_stale_owning_checkout_names_the_workspace_instead_of_the_task_id() {
+    let fixture = owner_fixture();
+    // The registry still knows the ID; the checkout it points at no longer
+    // identifies itself.
+    std::fs::remove_file(workspace_config_path(&fixture.beta_orbit_dir))
+        .expect("drop the owning checkout identity");
+
+    let error = resolve_task_owner(&fixture.global, &fixture.beta_task_id)
+        .expect_err("a stale owner must fail rather than resolve");
+    let message = error.to_string();
+    assert!(
+        message.contains("beta") && message.contains(&fixture.beta_task_id),
+        "stale owner must name the workspace and the task: {message}"
+    );
+    assert!(
+        !matches!(error, OrbitError::NotFound { .. }),
+        "a stale checkout must not be reported as an unknown task id: {message}"
+    );
+}
+
+#[test]
+fn bound_workspace_identity_reports_the_registry_name_and_logical_id() {
+    let fixture = owner_fixture();
+    let identity = bound_workspace_identity(&fixture.alpha).expect("alpha is registered");
+    assert_eq!(identity.id, "ws_alpha");
+    assert_eq!(identity.name, "alpha");
+    assert_eq!(identity.label(), "alpha (ws_alpha)");
+}

--- a/docs/design/host-registry/2_design.md
+++ b/docs/design/host-registry/2_design.md
@@ -126,7 +126,7 @@ RegisteredRuntimeFactory also carries replica ownership into Core's coordination
 
 ### CLI
 
-The main CLI opens ordinary runtimes through RegisteredRuntimeFactory using cwd, --root and optional --workspace. Workspace init, role, list, show, remove and teardown call orbit-registry directly for catalog operations. The only active host command is local rename.
+The main CLI opens ordinary runtimes through RegisteredRuntimeFactory using cwd, --root and optional --workspace. `task show` is the one exception: without --workspace it opens the checkout the coordination task registry names as the task ID's owner, so it works from a foreign checkout and from a directory that is no workspace at all, and it reports the owning workspace name and logical ID. With --workspace it is the ordinary registered bootstrap, and the selector filters. Workspace init, role, list, show, remove and teardown call orbit-registry directly for catalog operations. The only active host command is local rename.
 
 There is no active v1 CLI surface for fleet host registration, enumeration or retirement, and no workspace owner-link command.
 

--- a/docs/design/mcp-session-context/2_design.md
+++ b/docs/design/mcp-session-context/2_design.md
@@ -55,6 +55,8 @@ Process cwd is not an MCP fallback. The server resolves the selector against its
 
 Global tools do not require a workspace selector.
 
+orbit.task.show is the one exception to the precedence above. Task IDs are a machine-global primary key in the coordination task registry, so a call carrying only {id} resolves the owning workspace from that registry and ignores the workspace announced at initialize — the announced workspace is ambient, like cwd, and is the right default for authoring but the wrong one for addressing an ID. A workspace passed in the tool input still wins and still filters: the call binds that workspace, and a task owned elsewhere is not found there. When the registry knows the ID but its owning checkout is unreadable or inactive, the error names that workspace rather than reporting the ID as unknown.
+
 ## 4. Adapter and tool surface
 
 OrbitToolServer holds one context for its stdio session. Initialize may replace only the workspace selector. For every tools/call, the adapter clones the session context and mints one fresh trace_id without writing it back.


### PR DESCRIPTION
## Task

[ORB-10797](https://orbit-cli.com/tasks/ORB-10797) — Make orbit task show resolve globally by task ID

### Description

## Problem

`orbit task show <id>` binds one `OrbitRuntime` from cwd (or `--workspace`) and looks up the ID only in that workspace. Task IDs are already a machine-global primary key (`TaskRegistryStore::find_task_binding` maps `ORB-*` → workspace), so a valid ID 404s whenever the caller is not standing in the owning checkout. `--workspace all` is the wrong spelling for this verb: the default should follow the ID.

## Why It Matters

Operators and agents constantly have an `ORB-*` and not the workspace. The constellation orchestrator lives in polaris sessions and still needs to show orbit/worker/sextant tasks. Cwd and MCP session workspace are the right default for list/add/search; they are the wrong default for a globally unique ID.

## Constraints / Notes

- **Scope is `task show` only** (CLI `orbit task show` and the `orbit.task.show` tool/MCP). Do not change list, update, start, archive, search, or friction. Do not add `--workspace all`.
- **Default (no `--workspace` / no `workspace` argument):** resolve via the global task registry, then open the owning checkout and reuse the existing show path. Works from any directory, including outside a workspace. CLI bootstrap cannot require a cwd workspace for this command.
- **Explicit `--workspace <selector>` / `workspace:` is a filter**, not a hint. If the task is not in that workspace, not-found. This preserves ADR-0361 fail-closed naming.
- **MCP session `_meta.orbit.workspace` is ambient**, like cwd. Omit-workspace show must global-resolve even inside a polaris session. Only an explicit per-call `workspace` scopes the lookup.
- **Output must name the landing workspace** (human line + JSON). `--with-context`, comments, history, and artifacts come from the owning workspace after rebind, not from cwd.
- **Stale/inactive owning checkout:** name the workspace and fail; do not pretend the ID does not exist.
- **Implementation sketch:** `find_task_binding` already exists. Special-case `task show` so it can start from `~/.orbit` + the task registry, then `open_registered_checkout` for the owner. `--workspace` stays top-level (`orbit --workspace polaris task show ORB-...`), not a clap-global flag (it would collide with `task add --workspace`).
- Related: [ORB-10758] / ADR-0361 (selector grammar). This task does not change the selector forms; it changes when show consults the registry instead of the bound runtime.

### Acceptance Criteria

- `orbit task show ORB-<id>` from a foreign checkout and from a directory that is not a workspace prints that task without requiring `--workspace`.
- `orbit --workspace <selector> task show ORB-<id>` is fail-closed: a task owned by a different workspace exits not-found and does not print the foreign task.
- Human `orbit task show` output includes the owning workspace name and logical id (example: `Workspace: orbit (ws_orbit)`). JSON output includes the same identity so a later write can address it.
- `orbit.task.show` with only `{id}` (no `workspace` argument) returns the owning workspace task even when the MCP session is bound to another workspace. An explicit `workspace` argument remains a filter and 404s when the task is not in that workspace.
- Do not add `--workspace all`. Do not change `task list` `task update` `task start` or any other verb.
- If the registry knows the ID but the owning checkout is stale or inactive the error names that workspace and does not report the ID as unknown.
- Tests cover foreign-cwd show; no-workspace-cwd show; explicit `--workspace` miss; MCP/tool show without workspace; and a stale-checkout error. File I/O uses temp dirs or fakes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- New `orbit-cmd::task_owner` owns the whole feature: it maps a globally unique task ID to the registered checkout that owns it, bootstraps the `task show` runtime, and reports the owning workspace identity. Both surfaces call it, so the CLI and the MCP server share one implementation rather than each carrying its own registry join (the duplication that got github-pr:987 rejected).
- The registry join matches the checkout identity in `<orbit_dir>/config.yaml` against the task registry's partition key, so it is correct for workspaces whose logical registry ID and checkout identity diverged (L-0098) - verified against the real machine registry (`orbit-5c61b3` -> `orbit (ws_orbit)`).
- CLI: `RuntimeNeed::TaskOwner { task_id }` in the operation registry declares that `task show` binds the ID's owner rather than the cwd walk; `main.rs` bootstraps from it. `--workspace` still wins and still filters. No other verb changed; no `--workspace all`.
- MCP: `ServerMcpHost::workspace_selection` global-resolves `orbit.task.show` when the call omits `workspace`, so an omit-workspace show works inside a session bound elsewhere. An explicit per-call `workspace` remains a filter on every tool. Extracted `call_workspace_selector` so "the caller named a workspace" stays distinguishable from "the session announced one".
- Output: `orbit task show` prints `Workspace: orbit (ws_orbit)` and its JSON carries `workspace: {id, name}` on every path (cwd, `--workspace`, registry ownership). Field projections are unchanged.
- Stale/inactive owner: named as that workspace, never as an unknown ID.
- Docs updated in the same change: `docs/design/mcp-session-context/2_design.md` section 3 (the selector-precedence exception) and `docs/design/host-registry/2_design.md` (CLI bootstrap).

Assessment: One shared resolver in `orbit-cmd`, no new crate dependency edges (orbit-cmd already depends on orbit-core/registry/store; orbit-cli already depends on orbit-cmd), no new third-party dependency, no ADR needed. `orbit tool run orbit.task.show` was deliberately left on the cwd binding: the task scopes the change to the CLI verb and the MCP tool, and routing the generic `tool run` bootstrap would widen the blast radius to every tool.

Validation:
- cargo test -p orbit-cmd -p orbit-cli (all suites green, including 5 new `task_owner` unit tests, the new CLI `workspace_selector` integration test covering foreign-cwd, non-workspace-cwd, and explicit `--workspace` miss, and the new MCP roundtrip test covering an id-only show from a session bound elsewhere plus explicit-workspace filtering)
- make ci-fast: pass
- cargo clippy -p orbit-cmd --all-targets -- -D warnings: pass; cargo clippy -p orbit-cli --all-targets --no-deps -- -D warnings: pass
- make ci-lint: FAILS, but only on a pre-existing defect this task did not touch - `crates/orbit-web/src/api/denials.rs:413-416` (clippy::map_identity and clippy::question_mark), introduced by d925a364 [ORB-10828] and still present on origin/agent-main. Left unfixed to keep this PR scoped; it needs its own task or the workspace lint gate stays red for every branch.
- Manual end-to-end against the real machine registry: `orbit task show ORB-10797` and `orbit task show ORB-00001` from /tmp both resolve and name their owning workspace; `orbit --workspace polaris task show ORB-10797` fails closed with "task not found".

Friction checkpoint: no qualifying friction (the orbit-web lint break is an ordinary code bug, recorded above and in a task comment, not an Orbit tooling or guidance problem).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10797-6a80e3b1`
- Behind base: 0
- Ahead of base: 1

*authored by: claude*