### PR TITLE
Make gemini-3.7-flash the default Gemini crew model

### DIFF
--- a/crates/orbit-cli/src/command/tests/init.rs
+++ b/crates/orbit-cli/src/command/tests/init.rs
@@ -136,7 +136,7 @@ fn non_interactive_init_against_non_global_root_leaves_home_skill_links_untouche
         ("sol", "codex", "gpt-5.6-sol"),
         ("terra", "codex", "gpt-5.6-terra"),
         ("luna", "codex", "gpt-5.6-luna"),
-        ("gemini", "gemini", "pro"),
+        ("gemini", "gemini", "gemini-3.7-flash"),
         ("grok", "grok", "grok-4.6"),
         ("qa", "", ""),
     ];

--- a/crates/orbit-common/assets/model_prices.yaml
+++ b/crates/orbit-common/assets/model_prices.yaml
@@ -193,6 +193,32 @@ prices:
     cache_create_1h_per_million_usd: 1.5
     output_per_million_usd: 9.0
 
+  # Gemini 3.7 Flash (ORB-10813), released 2026-08-13. Introductory pricing
+  # through 2026-12-31 per ai.google.dev/gemini-api/docs/pricing: 0.75/3.75,
+  # cached input 0.075. No published per-token cache-write rate (Google bills
+  # cache storage separately, per-hour, which this schema has no field for),
+  # so cache_create/cache_create_1h use the full input rate — same convention
+  # as the gemini-3.5-flash row above.
+  - model: "gemini-3.7-flash"
+    effective_from: "2026-08-13T00:00:00Z"
+    effective_until: "2027-01-01T00:00:00Z"
+    input_per_million_usd: 0.75
+    cache_read_per_million_usd: 0.075
+    cache_create_per_million_usd: 0.75
+    cache_create_1h_per_million_usd: 0.75
+    output_per_million_usd: 3.75
+
+  # Standard pricing from 2027-01-01 per the same official pricing page:
+  # 1.50/7.50, cached input 0.15.
+  - model: "gemini-3.7-flash"
+    effective_from: "2027-01-01T00:00:00Z"
+    effective_until: null
+    input_per_million_usd: 1.5
+    cache_read_per_million_usd: 0.15
+    cache_create_per_million_usd: 1.5
+    cache_create_1h_per_million_usd: 1.5
+    output_per_million_usd: 7.5
+
   # ── xAI / Grok (crew: grok) ──────────────────────────────────────────────
   # grok-build is the historical coding/build string still present in older
   # fixtures. Leave this shipped row open-ended; do not rewrite its rates

--- a/crates/orbit-common/src/model_defaults.rs
+++ b/crates/orbit-common/src/model_defaults.rs
@@ -57,16 +57,16 @@ pub const CODEX_DEFAULT_MODEL: &str = CODEX_TERRA_MODEL;
 pub const CODEX_DEFAULT_WEAK: &str = "gpt-5.4-mini";
 
 /// Default gemini model for the provider-default map.
-pub const GEMINI_DEFAULT_MODEL: &str = "gemini-3-pro";
+pub const GEMINI_DEFAULT_MODEL: &str = "gemini-3.7-flash";
 
-/// Default gemini model seeded into crew roles (the `pro` CLI alias).
-pub const GEMINI_CREW_MODEL: &str = "pro";
+/// Default gemini model seeded into crew roles.
+pub const GEMINI_CREW_MODEL: &str = "gemini-3.7-flash";
 
 /// Default gemini "strong" model used by the executor model pair.
 pub const GEMINI_PAIR_STRONG: &str = "gemini-3.1-pro";
 
 /// Default gemini "weak" model used by the executor model pair.
-pub const GEMINI_PAIR_WEAK: &str = "gemini-3-flash";
+pub const GEMINI_PAIR_WEAK: &str = "gemini-3.7-flash";
 
 /// Default Grok Build model (the canonical model listed by `grok models`).
 pub const GROK_DEFAULT_MODEL: &str = "grok-4.6";

--- a/crates/orbit-core/assets/executors/gemini.yaml
+++ b/crates/orbit-core/assets/executors/gemini.yaml
@@ -16,6 +16,6 @@ spec:
   sandbox: macos-sandbox-exec
   model_pair_override:
     strong: gemini-3.1-pro
-    weak: gemini-3-flash
+    weak: gemini-3.7-flash
   model_flag: "-m"
   env: {}

--- a/crates/orbit-core/src/config/tests/bootstrap.rs
+++ b/crates/orbit-core/src/config/tests/bootstrap.rs
@@ -71,7 +71,7 @@ fn gemini_only_seeds_gemini_without_qa() {
     let parsed = parsed_config(&contents);
 
     assert_eq!(crew_names(&parsed), vec!["gemini"]);
-    assert_crew(&parsed, "gemini", "gemini", "pro");
+    assert_crew(&parsed, "gemini", "gemini", "gemini-3.7-flash");
     assert_default_crew(&parsed, Some("gemini"));
 }
 

--- a/crates/orbit-core/src/config/tests/runtime.rs
+++ b/crates/orbit-core/src/config/tests/runtime.rs
@@ -38,7 +38,7 @@ fn built_in_crews_use_standard_model_specific_names() {
         ("sol", "codex", "gpt-5.6-sol"),
         ("terra", "codex", "gpt-5.6-terra"),
         ("luna", "codex", "gpt-5.6-luna"),
-        ("gemini", "gemini", "pro"),
+        ("gemini", "gemini", "gemini-3.7-flash"),
         ("grok", "grok", "grok-4.6"),
     ] {
         let assignment = &crews.get(name).expect("built-in crew").assignment;

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -63,7 +63,7 @@ A **crew** is one provider-model assignment. Activities do not carry a model-sel
 
 | Field | Purpose | Values |
 |---|---|---|
-| `model` | Model identifier passed to the provider CLI | Provider-specific (e.g. `opus`, `sonnet`, `gpt-5.6-sol`, `pro`, `grok-4.6`) |
+| `model` | Model identifier passed to the provider CLI | Provider-specific (e.g. `opus`, `sonnet`, `gpt-5.6-sol`, `gemini-3.7-flash`, `grok-4.6`) |
 | `provider` | Agent family | `claude`, `codex`, `gemini`, `grok` (the CLI-executable families; see [Provider identity and resolution](#provider-identity-and-resolution) for the full canonical set) |
 | `description` | Optional human-facing crew summary | Any non-empty string after trimming |
 | `tags` | Optional discovery labels | Array of strings; normalized, sorted, and deduplicated |


### PR DESCRIPTION
## Task

[ORB-10813](https://orbit-cli.com/tasks/ORB-10813) — Make gemini-3.7-flash the default Gemini crew model

### Description

## Problem
Google released Gemini 3.7 Flash on 2026-08-13 (stable model id `gemini-3.7-flash`). Orbit still seeds the only Gemini crew as the unversioned `pro` alias, and the provider-default map still points at `gemini-3-pro`:

- `GEMINI_CREW_MODEL = "pro"` — what `[crews.gemini]` gets from `default_crews()` / `orbit init`
- `GEMINI_DEFAULT_MODEL = "gemini-3-pro"` — provider-default map
- `GEMINI_PAIR_WEAK = "gemini-3-flash"` — executor weak pin, also in `crates/orbit-core/assets/executors/gemini.yaml`

Daniel wants `gemini-3.7-flash` to be the default Gemini crew model.

## Why It Matters
New Gemini-only workspaces and any code path that reads the provider-default map will keep launching the older pro/flash pins until the constants move. The new Flash is Google's current workhorse for coding and agents, at a lower intro price than 3.6 Flash.

## Constraints / Notes
- Product defaults only. Do not rewrite existing workspace `[crews.gemini]` entries (including this machine's live `model = "pro"` crew). Operators keep their current pin until they edit config or re-init.
- Keep the crew **name** `gemini`. This is a model-id change, not a new crew.
- Use the official model id `gemini-3.7-flash`, not a short `flash` alias, unless the Gemini CLI rejects the official id and a live `gemini --help` / model list proves a required alias. Record that evidence in the execution summary.
- Do not change `GEMINI_PAIR_STRONG` (`gemini-3.1-pro`) or add extra Gemini crews.
- YAML assets cannot reference the Rust const; keep `model_defaults.rs` and `assets/executors/gemini.yaml` in lockstep. The existing executor asset↔const agreement test must stay green.
- Historical ADRs are not authority. Judge from current constants, bootstrap/runtime tests, and `docs/CONFIG.md`.
- Official model docs: https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash and https://blog.google/innovation-and-ai/models-and-research/gemini-models/introducing-gemini-3-7-flash/

### Acceptance Criteria

- `GEMINI_CREW_MODEL` and `GEMINI_DEFAULT_MODEL` are `gemini-3.7-flash`. Fresh `orbit init` / `default_crews()` seed the `gemini` crew with that model, not `pro`.
- `GEMINI_PAIR_WEAK` and `crates/orbit-core/assets/executors/gemini.yaml` `model_pair_override.weak` are `gemini-3.7-flash`. Leave `GEMINI_PAIR_STRONG` on the current pro pin unless a test or asset-const agreement forces a documented follow-up.
- Bootstrap and runtime tests that currently pin the Gemini crew to `pro` assert `gemini-3.7-flash`. `cargo test -p orbit-common -p orbit-core model_defaults config::tests::runtime config::tests::bootstrap config::tests::agent_detect` passes.
- `docs/CONFIG.md` no longer advertises `pro` as the default Gemini crew model. If Gemini is shown as an example, it uses `gemini-3.7-flash`.
- If `crates/orbit-common/assets/model_prices.yaml` is the live cost table for crew models, add a `gemini-3.7-flash` row from Google's published rates (intro $0.75 / $3.75 per 1M input/output through 2026-12-31, then the post-intro rates). Do not invent cache rates — copy them from the official model card or omit cache fields if the schema allows.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Bumped the default Gemini crew model from the unversioned `pro` alias to the
official `gemini-3.7-flash` id (released 2026-08-13), and the weak executor
pin from `gemini-3-flash` to the same id. `GEMINI_PAIR_STRONG` left on
`gemini-3.1-pro` per the constraint.

Changes:
- crates/orbit-common/src/model_defaults.rs: GEMINI_DEFAULT_MODEL,
  GEMINI_CREW_MODEL, GEMINI_PAIR_WEAK -> "gemini-3.7-flash".
- crates/orbit-core/assets/executors/gemini.yaml: model_pair_override.weak
  -> gemini-3.7-flash (kept in lockstep with the const per the asset<->const
  seam; the existing agreement test only covers `claude`, so no gemini
  variant to keep green there, but the shipped asset itself was in-scope).
- Tests pinning the old `pro` literal: crates/orbit-core/src/config/tests/
  runtime.rs (built_in_crews_use_standard_model_specific_names) and
  bootstrap.rs (gemini_only_seeds_gemini_without_qa) updated to
  gemini-3.7-flash.
- Also updated crates/orbit-cli/src/command/tests/init.rs (a third test
  hardcoding the same "pro" literal for the seeded gemini crew, found via
  repo-wide grep for the literal; not in the original context_files but
  directly broken by this change, so fixed and appended to context_files
  per the directly-affected-test allowance).
- docs/CONFIG.md: the `[crews.<name>].model` field example listed `pro`;
  swapped for `gemini-3.7-flash`.
- crates/orbit-common/assets/model_prices.yaml: added two `gemini-3.7-flash`
  rows (this is the live cost table keyed by exact InvocationRecord.model
  string, confirmed via crates/orbit-common/src/types/pricing.rs). Rates
  fetched live from https://ai.google.dev/gemini-api/docs/pricing:
  intro (2026-08-13 through 2026-12-31, exclusive-until 2027-01-01):
  input 0.75, output 3.75, cached input 0.075 per 1M tokens; standard
  (from 2027-01-01): input 1.50, output 7.50, cached input 0.15. The
  schema's cache_read/cache_create/cache_create_1h fields are all
  non-optional (no `#[serde(default)]` on the first two), so I could not
  omit them; cache_read uses the official "context caching" per-token rate,
  and cache_create/cache_create_1h use the full input rate (matching the
  existing gemini-3.5-flash row's convention) since Google bills cache
  writes as an ongoing per-hour storage fee this schema has no field for,
  not a per-token write rate.
- Left crates/orbit-common/src/types/tests/actor.rs untouched: its
  `gemini-3-pro` literal exercises generic prefix-matching
  (provider_from_model), unrelated to the default-model constants.
- Left .orbit/resources/executors/gemini.yaml (this worktree's own synced
  workspace resource) and this machine's live `[crews.gemini] model = "pro"`
  untouched per the "do not rewrite existing workspace entries" constraint.

Model-id verification: ran `gemini -m gemini-3.7-flash -p "..." -o json`
locally. It did not error, but the response stats show it actually served
`gemini-3.5-flash` — the installed Gemini CLI (0.55.1) silently substituted
rather than rejecting the id (confirmed a genuinely unknown id like
`bogus-model-xyz` does hard-error with `ModelNotFoundError`, so this is not
that case). This isn't a rejection of the official id requiring a
short-alias workaround per the task's exception clause, so I kept
`gemini-3.7-flash` as instructed; the substitution is most likely this local
CLI build/backend simply not yet knowing the id in this environment.

Validation:
- `cargo test -p orbit-common -p orbit-core model_defaults config::tests::runtime
  config::tests::bootstrap config::tests::agent_detect` — all pass (run as
  four separate `cargo test` invocations since cargo test only accepts one
  positional filter).
- `cargo test -p orbit-common pricing`, `cargo test -p orbit-common
  executor_def`, `cargo test -p orbit-cli command::tests::init::` — all pass
  (extra confidence checks beyond the acceptance-criteria list, covering the
  price table, the asset<->const seam, and the orbit-cli init literal fixed
  above).
- `make ci-fast` — passes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10813-6a80f027`
- Behind base: 0
- Ahead of base: 1