### PR TITLE
Upgrading the orbit binary leaves seeded managed assets stale, breaking the activity catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,6 +2144,7 @@ dependencies = [
  "orbit-store",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tempfile",
  "toml",
  "tracing",

--- a/crates/orbit-cmd/Cargo.toml
+++ b/crates/orbit-cmd/Cargo.toml
@@ -29,4 +29,5 @@ libc.workspace = true
 
 [dev-dependencies]
 orbit-common = { path = "../orbit-common", features = ["test-util"] }
+sha2.workspace = true
 tempfile = "3"

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -6,8 +6,10 @@ use std::path::Path;
 use chrono::Utc;
 use fs2::FileExt;
 use orbit_common::types::{JobRun, JobRunState};
+use sha2::{Digest, Sha256};
 
 use orbit_core::OrbitRuntime;
+use orbit_core::runtime::OrbitRuntimeRoots;
 use orbit_store::TaskReservationReserveParams;
 
 use crate::doctor::{
@@ -689,5 +691,52 @@ fn workspace_retired_backend_warns_artifacts_activities_with_repair_command() {
         status_of(&after, "artifacts-activities").status,
         WorkspaceDoctorStatus::Ok,
         "{after:?}"
+    );
+}
+
+#[test]
+fn stale_shipped_activity_default_names_the_refresh_remediation() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let workspace_root = temp.path().join("repo/.orbit");
+    let runtime = OrbitRuntime::initialize_from_resolved_roots(
+        OrbitRuntimeRoots {
+            global_root: global_root.clone(),
+            shared_root: workspace_root.clone(),
+            local_root: workspace_root,
+        },
+        None,
+    )
+    .expect("initialize runtime with defaults");
+    let activities_dir = global_root.join("resources/activities");
+    let path = activities_dir.join("agent_implement.yaml");
+    let current = fs::read_to_string(&path).expect("read current activity");
+    let stale = current.replacen("  tools:\n", "  tools:\n    - fs.read\n", 1);
+    assert_ne!(stale, current, "fixture must contain the retired tool");
+    fs::write(&path, &stale).expect("write stale activity");
+
+    let manifest_path = activities_dir.join(".orbit-managed-assets.json");
+    let mut manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&manifest_path).expect("read managed manifest"))
+            .expect("parse managed manifest");
+    manifest["assets"]["agent_implement"] =
+        serde_json::Value::String(format!("{:x}", Sha256::digest(stale.as_bytes())));
+    fs::write(
+        &manifest_path,
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&manifest).expect("serialize managed manifest")
+        ),
+    )
+    .expect("write stale managed manifest");
+
+    let results = runtime.doctor_workspace().expect("doctor");
+    let row = status_of(&results, "artifacts-activities");
+    assert_eq!(row.status, WorkspaceDoctorStatus::Error, "{row:?}");
+    assert!(row.message.contains("stale"), "{}", row.message);
+    assert!(row.message.contains("older release"), "{}", row.message);
+    assert_eq!(
+        row.remediation.as_deref(),
+        Some("Run `orbit init --refresh-defaults`.")
     );
 }

--- a/crates/orbit-core/src/command/artifact_health.rs
+++ b/crates/orbit-core/src/command/artifact_health.rs
@@ -438,8 +438,8 @@ fn diagnose_catalog(runtime: &OrbitRuntime, catalog: &ManagedCatalog) -> Artifac
                     condition: ArtifactCondition::Stale,
                     provenance: ArtifactProvenance::OrbitWritten,
                     detail: format!(
-                        "`{name}` is an Orbit-written copy of an older release of this bundled \
-                         default and has drifted from the content this binary ships"
+                        "`{name}` is a stale shipped default: an Orbit-written copy of an older \
+                         release that has drifted from the content this binary ships"
                     ),
                     remediation: "Run `orbit init --refresh-defaults`.".to_string(),
                 }),
@@ -485,8 +485,15 @@ fn finish_catalog_health(
         let provenance = read_artifact(&fault.path)
             .map(|on_disk| provenance(tracked.get(&fault.name), &on_disk))
             .unwrap_or(ArtifactProvenance::UserAuthored);
+        let stale_shipped_default = findings.iter().any(|finding| {
+            finding.name == fault.name
+                && finding.condition == ArtifactCondition::Stale
+                && finding.provenance == ArtifactProvenance::OrbitWritten
+        });
         let remediation = if let Some(command) = fault.repair_command {
             format!("Run `{command}`.")
+        } else if stale_shipped_default {
+            "Run `orbit init --refresh-defaults`.".to_string()
         } else if provenance == ArtifactProvenance::OrbitWritten {
             format!(
                 "A shipped {} default failed to load — reinstall or upgrade orbit, then run `orbit init --refresh-defaults`.",

--- a/crates/orbit-core/src/command/mod.rs
+++ b/crates/orbit-core/src/command/mod.rs
@@ -166,7 +166,27 @@ pub(crate) fn reconcile_managed_assets<'a>(
                 let Some(previous_digest) = previous_digest else {
                     continue;
                 };
-                next_assets.insert((*name).to_string(), previous_digest.clone());
+                let existing = fs::read_to_string(&path).map_err(|error| {
+                    OrbitError::Io(format!(
+                        "read existing {asset_kind} '{}': {error}",
+                        path.display()
+                    ))
+                })?;
+
+                // A digest match proves this is an unedited file Orbit wrote.
+                // Refresh it during ordinary bootstrap when a newer binary
+                // ships different content; otherwise a removed tool or schema
+                // value can leave the runtime unable to load its own catalog.
+                // Any mismatch is a local edit and must remain untouched.
+                if sha256_hex(existing.as_bytes()) == *previous_digest
+                    && previous_digest != &rendered_digest
+                {
+                    write_text_with_parent(&path, &rendered)?;
+                    next_assets.insert((*name).to_string(), rendered_digest);
+                    result.refreshed += 1;
+                } else {
+                    next_assets.insert((*name).to_string(), previous_digest.clone());
+                }
                 continue;
             }
 

--- a/crates/orbit-core/src/command/tests/managed_assets.rs
+++ b/crates/orbit-core/src/command/tests/managed_assets.rs
@@ -15,6 +15,7 @@ use super::super::job::seed_default_jobs;
 use crate::OrbitRuntime;
 use crate::command::job::JobCatalogFilter;
 use crate::config::agent_detect::DetectedAgents;
+use crate::runtime::OrbitRuntimeRoots;
 
 fn init_global(root: &Path) -> InitResult {
     init_workspace_at_root(
@@ -209,6 +210,69 @@ fn refresh_writes_asset_and_manifest_when_embedded_digest_changed() {
     assert_eq!(
         manifest["assets"]["sleep"].as_str().expect("sleep digest"),
         sha256(&original)
+    );
+}
+
+#[test]
+fn runtime_bootstrap_refreshes_orbit_written_stale_activity_before_catalog_load() {
+    let root = tempdir().expect("create tempdir");
+    let global_root = root.path().join("global");
+    let workspace_root = root.path().join("repo/.orbit");
+    init_global(&global_root);
+
+    let activities_dir = global_root.join("resources/activities");
+    let path = activities_dir.join("agent_implement.yaml");
+    let current = std::fs::read_to_string(&path).expect("read current activity");
+    let stale = current.replacen("  tools:\n", "  tools:\n    - fs.read\n", 1);
+    assert_ne!(stale, current, "fixture must contain the retired tool");
+    std::fs::write(&path, &stale).expect("write stale activity");
+    add_managed_manifest_entry(&activities_dir, "agent_implement", &stale);
+
+    let runtime = OrbitRuntime::initialize_from_resolved_roots(
+        OrbitRuntimeRoots {
+            global_root: global_root.clone(),
+            shared_root: workspace_root.clone(),
+            local_root: workspace_root.clone(),
+        },
+        None,
+    )
+    .expect("bootstrap refreshes the Orbit-written stale activity");
+    runtime
+        .v2_activity_catalog()
+        .expect("the current binary loads the refreshed catalog");
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("read refreshed activity"),
+        current
+    );
+}
+
+#[test]
+fn runtime_bootstrap_preserves_locally_modified_stale_managed_activity() {
+    let root = tempdir().expect("create tempdir");
+    let global_root = root.path().join("global");
+    let workspace_root = root.path().join("repo/.orbit");
+    init_global(&global_root);
+
+    let activities_dir = global_root.join("resources/activities");
+    let path = activities_dir.join("agent_implement.yaml");
+    let current = std::fs::read_to_string(&path).expect("read current activity");
+    let stale = current.replacen("  tools:\n", "  tools:\n    - fs.read\n", 1);
+    let locally_modified = format!("{stale}# operator edit\n");
+    std::fs::write(&path, &locally_modified).expect("write locally modified stale activity");
+    add_managed_manifest_entry(&activities_dir, "agent_implement", &stale);
+
+    OrbitRuntime::initialize_from_resolved_roots(
+        OrbitRuntimeRoots {
+            global_root: global_root.clone(),
+            shared_root: workspace_root.clone(),
+            local_root: workspace_root,
+        },
+        None,
+    )
+    .expect("bootstrap preserves a locally modified managed activity");
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("read preserved activity"),
+        locally_modified
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-10843](https://orbit-cli.com/tasks/ORB-10843) — Upgrading the orbit binary leaves seeded managed assets stale, breaking the activity catalog

### Description

## Problem

Managed defaults under `~/.orbit` (activities, jobs, skills) are only refreshed when
`reconcile_managed_assets` is called with `overwrite = true`
([`crates/orbit-core/src/command/mod.rs:165`](crates/orbit-core/src/command/mod.rs)), and
`overwrite` is derived solely from `options.force || options.refresh_defaults`
([`crates/orbit-core/src/command/init.rs:145`](crates/orbit-core/src/command/init.rs)) — i.e.
only from an explicit `orbit init`. Installing a new binary (`cargo install`, Homebrew, npm)
never reseeds. Ordinary runtime bootstrap passes `overwrite = false` and silently keeps
whatever YAML is already on disk.

That makes any change to an embedded asset's *contract* a latent break for every existing
install. ORB-10828 ("Remove the fs.read and fs.delete builtin tools and every reference")
removed those builtins from the tool registry and from the shipped activity YAML. On a Mac
that upgraded the binary without re-running `orbit init`, the new binary met the old YAML and
the whole v2 activity catalog stopped loading:

```
$ orbit activity list
error: store error: v2 activity catalog: activity `agent_implement`
tool allowlist invalid: unknown tool name in allowlist entry `fs.read`
```

Five shipped activities were stale against the binary's embedded copies — `agent_implement`,
`epic_orchestrator`, `step_failure_recovery`, `triage_failed_runs` (all listing `fs.read` and
`fs.delete`) and `task_pilot` (`fs.read`). Every one had a SHA-256 exactly matching
`.orbit-managed-assets.json`, proving Orbit itself wrote them and that nothing was
locally modified — the reconciler had every signal it needed to know these were safe to
refresh, and simply was never asked to.

Because `agent_implement` is a shipped default, `ArtifactFinding::is_unloadable_shipped_default`
([`crates/orbit-core/src/command/artifact_health.rs:171`](crates/orbit-core/src/command/artifact_health.rs))
escalated it to the one artifact fault that fails `orbit doctor` with a nonzero exit. The
operator saw only `1 failure(s), 2 warning(s)` (see the companion doctor-output task) and had
no path from that message to the real cause.

`orbit doctor --fix-stale-artifacts` does not help here: it retires *deprecated* artifacts —
ones dropped from the catalog — while these are still-current names whose content drifted.
The only recovery is `orbit init --non-interactive`, which nothing tells the operator to run.

## Why It Matters

Removing or renaming anything an embedded asset references — a builtin tool, an activity
field, a schema value — silently bricks the activity catalog on every already-installed box.
The catalog is what dispatch runs on, so this is not a cosmetic drift: agent execution stops.
It fails at the worst moment, immediately after an upgrade, with an error naming a tool the
operator never configured.

## Constraints / Notes

- Never clobber locally modified assets. The manifest already distinguishes `OrbitWritten`
  from `LocallyModified` and `UserAuthored`; a refresh should act only on a digest match.
  Note that today's `overwrite = true` path at `mod.rs:184` overwrites a *tracked* asset even
  when its on-disk content has drifted from the manifest — worth confirming that is intended
  before widening who calls it.
- Possible directions, not a prescription: detect the version/digest gap at runtime and
  refresh Orbit-written assets automatically; or leave the data alone but make `orbit doctor`
  name this condition distinctly ("shipped default is stale — run `orbit init`") instead of
  surfacing it as a generic unloadable-artifact error. The current failure mode is bad
  primarily because it is undiagnosable, and a precise remediation string may be the smaller
  correct fix.
- Whatever the mechanism, a read-only global resources mount must not be broken by it — the
  existing "avoid touching the asset" comment at `mod.rs:173-177` exists for that reason.
- Reproduce by writing a pre-ORB-10828 `agent_implement.yaml` plus a matching manifest digest
  into a temp root, then loading the catalog with the current binary.

### Acceptance Criteria

- A regression test seeds a managed activity whose content predates a tool removal, with a manifest digest matching that stale content, and asserts the current binary no longer leaves the v2 activity catalog unloadable — either the asset is refreshed or the condition is reported as a distinct, actionable diagnosis.
- In that same stale-asset workspace, `orbit doctor` names the stale-shipped-default condition and its remediation explicitly, rather than reporting only `unknown tool name in allowlist entry`.
- A test asserts a locally modified managed asset (on-disk digest differing from the manifest) is not silently overwritten by whatever refresh path this task adds, and that its content is still present afterward.
- `orbit activity list` succeeds against a workspace seeded with pre-ORB-10828 activity YAML using the current binary.
- `make ci-fast` and `make ci-lint` both pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Ordinary managed-asset reconciliation now refreshes a bundled asset only when its on-disk digest still matches the manifest, preventing stale Orbit-written defaults from breaking catalog loading while preserving local edits.
- Doctor now labels an unloadable, stale Orbit-written default as a stale shipped default and gives the exact refresh remediation.
- Added regression coverage for runtime catalog recovery, local-edit preservation, and doctor output.
- Added the existing workspace `sha2` dependency as an orbit-cmd test dependency for manifest-digest fixtures.
Validation:
- `cargo test -p orbit-core command::tests::managed_assets -- --nocapture`
- `cargo test -p orbit-cmd stale_shipped_activity_default_names_the_refresh_remediation -- --nocapture`
- `make ci-fast`
- `make ci-lint`
Assessment: focused change; auto-refresh requires manifest provenance and does not overwrite locally modified content.
Scope note: added the doctor sibling test and its existing workspace test dependency to context because they directly satisfy the doctor acceptance criterion.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10843-6a80f027`
- Behind base: 0
- Ahead of base: 1