### PR TITLE
orbit doctor discards its check table when any check fails

### DIFF
--- a/crates/orbit-cli/src/audit_middleware.rs
+++ b/crates/orbit-cli/src/audit_middleware.rs
@@ -6,6 +6,7 @@ use orbit_core::{
     AuditEventInsertParams, AuditEventStatus, OrbitError, OrbitRuntime, redact_sensitive_env_text,
 };
 
+use crate::command::CommandOut;
 #[cfg(test)]
 use crate::command::Commands;
 pub use crate::command::operation::CommandMeta;
@@ -52,6 +53,23 @@ impl<'a> AuditGuard<'a> {
         self.status = AuditEventStatus::Success;
         self.exit_code = 0;
         self.error_message = None;
+    }
+
+    /// Classify the command's complete outcome, including rendered payloads
+    /// that deliberately request a nonzero process exit.
+    pub fn mark_result(&mut self, result: &CommandOut) {
+        match result {
+            Ok(output) if output.exit_code() != 0 => {
+                self.status = AuditEventStatus::Failure;
+                self.exit_code = output.exit_code();
+                self.error_message = None;
+            }
+            Ok(_) => self.mark_success(),
+            Err(OrbitError::PolicyDenied(msg) | OrbitError::CapabilityDenied(msg)) => {
+                self.mark_denied(msg);
+            }
+            Err(err) => self.mark_failure(err),
+        }
     }
 
     pub fn mark_failure(&mut self, error: &OrbitError) {

--- a/crates/orbit-cli/src/command/doctor.rs
+++ b/crates/orbit-cli/src/command/doctor.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 use orbit_cmd::{DoctorCommands, WorkspaceDoctorResult, WorkspaceDoctorStatus};
-use orbit_core::{OrbitError, OrbitRuntime};
+use orbit_core::OrbitRuntime;
 use serde_json::{Value, json};
 
 use crate::command::{Block, CommandOut, Execute, Payload};
@@ -102,7 +102,7 @@ impl Execute for DoctorCommand {
                 table.add_row(vec![
                     Cell::new(&row.check_name),
                     crate::output::color::cell(status_label(row.status), Domain::DoctorStatus),
-                    Cell::new(human_detail(row)),
+                    Cell::new(human_detail(row).replace('\n', " | ")),
                 ]);
             }
             blocks.push(Block::table(table));
@@ -119,12 +119,10 @@ impl Execute for DoctorCommand {
 
         // Unlike `skill doctor` / `tool doctor`, a failed check exits nonzero
         // so unattended callers (cron, CI, systemd) can alert on it.
-        if failures > 0 {
-            return Err(OrbitError::Execution(format!(
-                "{failures} doctor check(s) failed"
-            )));
-        }
-        Ok(Payload::blocks(Value::Array(values), blocks).into())
+        let exit_code = i32::from(failures > 0);
+        Ok(Payload::blocks(Value::Array(values), blocks)
+            .with_exit_code(exit_code)
+            .into())
     }
 }
 

--- a/crates/orbit-cli/src/command/tests/doctor.rs
+++ b/crates/orbit-cli/src/command/tests/doctor.rs
@@ -1,6 +1,8 @@
 use orbit_cmd::{WorkspaceDoctorResult, WorkspaceDoctorStatus};
+use orbit_core::OrbitRuntime;
 
 use super::super::doctor::{doctor_row_json, human_detail};
+use super::super::{CommandOutput, Execute};
 
 #[test]
 fn doctor_warning_renders_structured_and_human_remediation() {
@@ -35,4 +37,76 @@ fn healthy_doctor_row_has_null_remediation_and_no_action_line() {
 
     assert!(doctor_row_json(&row)["remediation"].is_null());
     assert_eq!(human_detail(&row), "none stale");
+}
+
+#[test]
+fn failing_workspace_renders_diagnostics_and_exits_nonzero() {
+    let runtime = OrbitRuntime::in_memory().expect("build in-memory runtime");
+    std::fs::write(runtime.global_root().join("config.toml"), "[").expect("write invalid config");
+
+    let output = super::super::doctor::DoctorCommand {
+        json: false,
+        fix_stale_locks: false,
+        fix_stale_task_locks: false,
+        remove_graph: false,
+        fix_stale_artifacts: false,
+        fix_retired_activity_backends: false,
+    }
+    .execute(&runtime)
+    .expect("doctor should render a failing report");
+
+    let CommandOutput::Payload(payload) = output else {
+        panic!("doctor should return its report payload");
+    };
+    assert_eq!(payload.exit_code(), 1);
+    let (_, view) = payload.into_view();
+    let crate::output::payload::View::Blocks(blocks) = view else {
+        panic!("doctor should render table blocks");
+    };
+    let crate::output::payload::Block::Table(table) = &blocks[0] else {
+        panic!("doctor should render a table first");
+    };
+    let rendered = table.render_at(None, false, false).body;
+    assert!(rendered.contains("config"), "{rendered}");
+    assert!(
+        rendered.contains("Action: Address the condition named in the diagnostic details"),
+        "{rendered}"
+    );
+}
+
+#[test]
+fn warning_only_workspace_keeps_zero_exit_and_structured_rows() {
+    let runtime = OrbitRuntime::in_memory().expect("build in-memory runtime");
+    let lock_path = runtime.paths().state_dir.join("doctor-test.lock");
+    std::fs::write(
+        lock_path,
+        r#"{"pid":0,"acquired_at":"2026-08-15T23:00:00Z","label":"test"}"#,
+    )
+    .expect("write stale lock metadata");
+
+    let output = super::super::doctor::DoctorCommand {
+        json: false,
+        fix_stale_locks: false,
+        fix_stale_task_locks: false,
+        remove_graph: false,
+        fix_stale_artifacts: false,
+        fix_retired_activity_backends: false,
+    }
+    .execute(&runtime)
+    .expect("doctor should render a warning report");
+
+    let CommandOutput::Payload(payload) = output else {
+        panic!("doctor should return its report payload");
+    };
+    assert_eq!(payload.exit_code(), 0);
+    let (document, _) = payload.into_view();
+    assert_eq!(
+        document
+            .as_array()
+            .expect("doctor rows")
+            .iter()
+            .find(|row| row["check"] == "stale-locks")
+            .expect("stale-locks row")["status"],
+        "warning"
+    );
 }

--- a/crates/orbit-cli/src/main.rs
+++ b/crates/orbit-cli/src/main.rs
@@ -272,6 +272,14 @@ fn finish_command(
     suppress_errors: bool,
     json_error_preference: Option<bool>,
 ) {
+    let exit_code = result
+        .as_ref()
+        .ok()
+        .and_then(|output| match output {
+            command::CommandOutput::Payload(payload) => Some(payload.exit_code()),
+            command::CommandOutput::Silent => None,
+        })
+        .unwrap_or(0);
     let rendered = result.and_then(|output| output::render::emit(output, sink));
     if let Err(err) = rendered {
         if suppress_errors {
@@ -279,6 +287,9 @@ fn finish_command(
         }
         print_error(&err, sink, json_error_preference);
         std::process::exit(1);
+    }
+    if exit_code != 0 {
+        std::process::exit(exit_code);
     }
 }
 

--- a/crates/orbit-cli/src/main.rs
+++ b/crates/orbit-cli/src/main.rs
@@ -244,14 +244,7 @@ fn main() {
         Some(meta) => {
             let mut guard = audit_middleware::AuditGuard::new(&runtime, meta);
             let result = authorize(&runtime).and_then(|()| dispatch(cli.command, context));
-            match &result {
-                Ok(_) => guard.mark_success(),
-                Err(
-                    orbit_core::OrbitError::PolicyDenied(msg)
-                    | orbit_core::OrbitError::CapabilityDenied(msg),
-                ) => guard.mark_denied(msg),
-                Err(err) => guard.mark_failure(err),
-            }
+            guard.mark_result(&result);
             result
         }
         None => authorize(&runtime).and_then(|()| dispatch(cli.command, context)),
@@ -274,11 +267,7 @@ fn finish_command(
 ) {
     let exit_code = result
         .as_ref()
-        .ok()
-        .and_then(|output| match output {
-            command::CommandOutput::Payload(payload) => Some(payload.exit_code()),
-            command::CommandOutput::Silent => None,
-        })
+        .map(command::CommandOutput::exit_code)
         .unwrap_or(0);
     let rendered = result.and_then(|output| output::render::emit(output, sink));
     if let Err(err) = rendered {

--- a/crates/orbit-cli/src/output/payload.rs
+++ b/crates/orbit-cli/src/output/payload.rs
@@ -83,6 +83,8 @@ pub struct Payload {
     doc: Value,
     /// How `table` and plain mode render the same records.
     view: View,
+    /// The process exit code to use after the payload has been rendered.
+    exit_code: i32,
 }
 
 /// One piece of a human view. A detail command is usually prose with a grid
@@ -141,6 +143,7 @@ impl Payload {
         Self {
             doc: Value::Array(records),
             view: View::Blocks(vec![Block::table(table)]),
+            exit_code: 0,
         }
     }
 
@@ -161,7 +164,15 @@ impl Payload {
         Self {
             doc,
             view: View::Blocks(blocks),
+            exit_code: 0,
         }
+    }
+
+    /// Set the process exit code after this payload is rendered.
+    #[must_use]
+    pub fn with_exit_code(mut self, exit_code: i32) -> Self {
+        self.exit_code = exit_code;
+        self
     }
 
     /// A payload with no human form of its own: rendered as its document in
@@ -170,6 +181,7 @@ impl Payload {
         Self {
             doc,
             view: View::Document,
+            exit_code: 0,
         }
     }
 
@@ -180,11 +192,16 @@ impl Payload {
         Self {
             doc,
             view: View::Stream(stream),
+            exit_code: 0,
         }
     }
 
     /// The human rendering, consumed by the renderer.
     pub(crate) fn into_view(self) -> (Value, View) {
         (self.doc, self.view)
+    }
+
+    pub(crate) fn exit_code(&self) -> i32 {
+        self.exit_code
     }
 }

--- a/crates/orbit-cli/src/output/payload.rs
+++ b/crates/orbit-cli/src/output/payload.rs
@@ -76,6 +76,16 @@ impl From<Payload> for CommandOutput {
     }
 }
 
+impl CommandOutput {
+    /// The process exit code to use after this output has been rendered.
+    pub(crate) fn exit_code(&self) -> i32 {
+        match self {
+            Self::Silent => 0,
+            Self::Payload(payload) => payload.exit_code(),
+        }
+    }
+}
+
 /// A document and its human rendering.
 pub struct Payload {
     /// The `json`-mode document: an array for a list, an object for a detail

--- a/crates/orbit-cli/src/tests/audit_middleware.rs
+++ b/crates/orbit-cli/src/tests/audit_middleware.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use orbit_common::types::AuditEvent;
 use serde_json::{Value, json};
 
-use crate::command::Cli;
+use crate::command::{Cli, Payload};
 
 use super::super::audit_middleware::*;
 use orbit_common::test_env::{self, AGENT_IDENTITY_ENV};
@@ -52,6 +52,25 @@ fn audit_event_for_actor(actor: ActorIdentity) -> AuditEvent {
         .into_iter()
         .next()
         .expect("single audit event")
+}
+
+#[test]
+fn nonzero_payload_exit_is_audited_as_failure() {
+    let runtime = OrbitRuntime::in_memory().expect("build in-memory runtime");
+    {
+        let mut guard = AuditGuard::new(&runtime, meta_for(&["orbit", "doctor"]));
+        let result = Ok(Payload::document(json!({"status": "error"}))
+            .with_exit_code(1)
+            .into());
+        guard.mark_result(&result);
+    }
+
+    let events = runtime
+        .list_audit_events(None, None, Some(AuditEventStatus::Failure), None, 8)
+        .expect("list audit events");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].command, "doctor");
+    assert_eq!(events[0].exit_code, 1);
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-10842](https://orbit-cli.com/tasks/ORB-10842) — orbit doctor discards its check table when any check fails

### Description

## Problem

`orbit doctor` builds the full CHECK/STATUS/DETAILS table into `blocks`, then returns
`Err(OrbitError::Execution)` at [`crates/orbit-cli/src/command/doctor.rs:122`](crates/orbit-cli/src/command/doctor.rs)
before ever reaching `Ok(Payload::blocks(...))` on the last line. The moment one check
reports `Error`, every row is dropped — including the `remediation` string each finding
carries specifically to tell the operator what to do.

Observed on a real workspace (Opus 5 session, 2026-08-15). The entire output was:

```
1 failure(s), 2 warning(s).
error: execution failed: 1 doctor check(s) failed
```

No check name, no message, no remediation, in `--format table`, under a pty, and with
`--json` / `--format ndjson`. The JSON surface is the worst case: it emits only
`{"code":"execution_failed","error":"..."}`, so an unattended caller gets a nonzero exit
with zero diagnostics. That directly contradicts the comment above the `Err` return, which
justifies the nonzero exit as being *for* unattended callers (cron, CI, systemd).

Diagnosing the underlying failure required reading the source and hand-probing each check
subsystem (`orbit activity list`, `orbit semantic stats`, `df`, `sqlite3 PRAGMA quick_check`)
to rediscover what the discarded table already knew. The warning rows remain unreadable.

## Why It Matters

The failing case is exactly when the report is most needed. As shipped, a failing `orbit doctor`
tells the operator only that something is wrong, never what — turning a self-diagnostic command
into a dead end, on the terminal and in automation alike.

## Constraints / Notes

- Keep the nonzero exit code. The bug is the discarded output, not the exit status.
- The fix must cover both the human table and the machine-readable surfaces
  (`--json`, `--format ndjson`); today all three lose the rows.
- `doctor_row_json` already produces the per-row JSON (`values`) that is likewise discarded.
- Consider whether other commands share this shape — an `Err` return after building `blocks`.
- Related, found in the same session: the underlying failure was stale seeded activity YAML
  after a binary upgrade (see the companion reseed task).

### Acceptance Criteria

- Running `orbit doctor` in a workspace where at least one check reports Error prints the full CHECK/STATUS/DETAILS table, including the `remediation` line for each failing row, and still exits nonzero.
- Running `orbit doctor --json` in that same failing workspace emits the per-row array produced by `doctor_row_json` (check/status/message/remediation for every check), not only an `execution_failed` error object.
- `orbit doctor --format ndjson` in the failing workspace emits one JSON document per check row rather than a single error document.
- A test in `crates/orbit-cli/src/command/tests/doctor.rs` constructs a workspace with a failing check and asserts both that the rendered output contains that check's name and remediation text and that the exit is nonzero; it fails against the current `Err`-before-render code.
- Warning-only and all-Ok workspaces keep their current output and exit-zero behavior, covered by an existing or added test.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Changed workspace doctor to always return its complete table/document payload, flattening remediation into the DETAILS cell so it survives the single-line table renderer.
- Added payload exit-status plumbing through the CLI so doctor renders table/JSON/NDJSON rows before exiting 1 when any check is Error; healthy and warning-only reports remain exit 0.
- Added a canonical `CommandOutput` exit-status accessor shared by rendering and audit classification.
- Updated `AuditGuard` to record nonzero rendered payloads as failures with the actual process exit code.
- Added focused tests for failing diagnostics, warning-only behavior, and persisted audit failure classification.
Assessment: Diagnostic records now reach every output mode, the process still exits nonzero on Error rows, and the corresponding audit record reports failure instead of success.
Validation:
- `cargo test -p orbit-cli command::tests::doctor` (4 passed)
- `cargo test -p orbit-cli tests::audit_middleware` (18 passed)
- `make ci-fast` (passed)
- `make ci-lint` (passed)
- `cargo fmt --all -- --check` (passed)
- `git diff --check` (passed)
- Revision commit: `1fb355d8`

</details>

## Validation

- `cargo test -p orbit-cli command::tests::doctor`
- `cargo test -p orbit-cli tests::audit_middleware`
- `make ci-fast`
- `make ci-lint`
- `cargo fmt --all -- --check`
- `git diff --check`

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10842-6a80f027`
- Behind base: 0
- Ahead of base: 2
