### PR TITLE
test: keep routine reinit render inputs stable [ORB-10847]

### DIFF
--- a/crates/orbit-core/src/command/routine.rs
+++ b/crates/orbit-core/src/command/routine.rs
@@ -238,9 +238,11 @@ mod tests {
 
     #[test]
     fn plain_reinit_adds_a_new_missing_default_without_rewriting_existing_files() {
+        const HOST_ID: &str = "host-a";
+
         let root = tempdir().expect("create tempdir");
         let routines_dir = root.path().join("routines");
-        seed_default_routines(&routines_dir, "host-a", Some("workspace"), false)
+        seed_default_routines(&routines_dir, HOST_ID, Some("workspace"), false)
             .expect("first seed");
 
         let existing = routines_dir.join("task_triage.yaml");
@@ -248,7 +250,7 @@ mod tests {
         let missing = routines_dir.join("task_pilot.yaml");
         std::fs::remove_file(&missing).expect("remove newly introduced routine");
 
-        let seeded = seed_default_routines(&routines_dir, "host-b", Some("workspace"), false)
+        let seeded = seed_default_routines(&routines_dir, HOST_ID, Some("workspace"), false)
             .expect("plain re-init");
         assert_eq!(seeded.refreshed, 1, "only the missing default is created");
         assert_eq!(
@@ -261,7 +263,7 @@ mod tests {
             &std::fs::read_to_string(&missing).expect("read newly seeded task-pilot routine"),
         )
         .expect("newly seeded task-pilot routine parses");
-        assert_eq!(pilot.hosts, vec!["host-b".to_string()]);
+        assert_eq!(pilot.hosts, vec![HOST_ID.to_string()]);
         assert!(!pilot.enabled);
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request. Fill in the sections below so reviewers can
verify scope, run the same validation locally, and confirm docs were updated when needed.
-->

## Linked Orbit task(s)

<!--
Required. List the Orbit task ID(s) this PR implements, one per line.
Example: [ORB-NNNNN] — short title
If the task has a linked external tracker ref (Jira / Linear / GitHub issue),
include that tag too: [ORB-NNNNN] [ENG-1234] — short title
-->

- [ORB-NNNNN]

## Summary

<!--
What changed and why, in 1–3 sentences. Focus on intent, not a diff dump.
-->

## Test plan

<!--
Commands you actually ran, with results. At minimum:
-->

- [ ] `make ci` passes locally (runs fmt-check, build, clippy `-D warnings`, tests)
- [ ] Targeted tests for the affected crate(s) pass
- [ ] Manual verification steps (if applicable):

## Design docs

<!--
If this PR touches behavior described in `docs/design/*`, update the affected
docs in the SAME PR: flip ADR statuses, bump `**Last updated:**`, add new ADRs
for non-obvious decisions.
-->

- [ ] N/A — this PR does not touch any code referenced by `docs/design/*`

## Notes for reviewers

<!--
Optional. Call out risky areas, rollout plan, follow-ups deferred to other
Orbit tasks, or anything reviewers should look at first.
-->
