### PR TITLE
workspace init/show misresolve checkouts under a shared --root (orbit_dir treated as per-checkout fingerprint)

### DIFF
--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -184,8 +184,16 @@ impl WorkspaceInitArgs {
         let existing_checkout = registry
             .checkouts
             .iter()
-            .find(|checkout| checkout.repo_root == cwd || checkout.orbit_dir == orbit_dir);
+            .find(|checkout| checkout.repo_root == cwd);
         let reconciling_existing = existing_workspace.is_some() || existing_checkout.is_some();
+        let registered_shared_root = global_root == orbit_dir
+            && registry
+                .checkouts
+                .iter()
+                .any(|checkout| checkout.orbit_dir == orbit_dir);
+        if registered_shared_root {
+            validate_shared_root_identity(orbit_dir)?;
+        }
 
         if reconciling_existing && !self.force {
             return Err(OrbitError::WorkspaceError(format!(
@@ -203,8 +211,11 @@ impl WorkspaceInitArgs {
                 orbit_dir,
                 &id,
             )?;
-            validate_workspace_identity(orbit_dir, &id)?;
-        } else if let Some(identity) = read_workspace_identity(orbit_dir)?
+            if !registered_shared_root {
+                validate_workspace_identity(orbit_dir, &id)?;
+            }
+        } else if !registered_shared_root
+            && let Some(identity) = read_workspace_identity(orbit_dir)?
             && identity.workspace_id != id
         {
             // A checkout can carry an identity the registry never recorded:
@@ -325,7 +336,7 @@ impl WorkspaceInitArgs {
             }
         }
         workspace_registry::save_registry_to(&registry, registry_path)?;
-        if !reconciling_existing {
+        if !reconciling_existing && !registered_shared_root {
             write_workspace_identity(orbit_dir, &id)?;
         }
         orbit_core::runtime::HubCoordinationExecutor::register_workspace(global_root, &id, &name)?;
@@ -444,6 +455,23 @@ fn validate_workspace_identity(orbit_dir: &Path, workspace_id: &str) -> Result<(
     if identity.schema_version != 1 || identity.workspace_id != workspace_id {
         return Err(OrbitError::WorkspaceError(format!(
             "cannot reconcile workspace '{workspace_id}': checkout identity '{}' does not match",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_shared_root_identity(orbit_dir: &Path) -> Result<(), OrbitError> {
+    let path = orbit_dir.join("config.yaml");
+    let identity = read_workspace_identity(orbit_dir)?.ok_or_else(|| {
+        OrbitError::WorkspaceError(format!(
+            "cannot use registered shared root: runtime identity '{}' is missing",
+            path.display()
+        ))
+    })?;
+    if identity.schema_version != 1 || identity.workspace_id.trim().is_empty() {
+        return Err(OrbitError::WorkspaceError(format!(
+            "cannot use registered shared root: runtime identity '{}' is invalid",
             path.display()
         )));
     }

--- a/crates/orbit-cli/src/command/workspace/show.rs
+++ b/crates/orbit-cli/src/command/workspace/show.rs
@@ -1,5 +1,7 @@
+use std::path::Path;
+
 use clap::Args;
-use orbit_common::types::{Workspace, WorkspaceCheckout};
+use orbit_common::types::{Workspace, WorkspaceCheckout, WorkspaceRegistry};
 use orbit_core::OrbitRuntime;
 use orbit_registry::workspace_registry;
 use serde_json::{Value, json};
@@ -12,22 +14,18 @@ pub struct WorkspaceShowArgs {}
 impl Execute for WorkspaceShowArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
         let data_root = runtime.data_root();
-        let data_root_canonical = std::fs::canonicalize(&data_root).unwrap_or(data_root.clone());
         let global_root = runtime.global_root();
         let registry_path = workspace_registry::registry_path_for(&global_root);
         let registry = workspace_registry::load_registry_from(&registry_path)?;
 
-        // Find workspace whose orbit_dir matches the current runtime's data root
-        let checkout = registry.checkouts.iter().find(|checkout| {
-            let ws_canonical = std::fs::canonicalize(&checkout.orbit_dir)
-                .unwrap_or_else(|_| checkout.orbit_dir.clone());
-            ws_canonical == data_root_canonical
-        });
+        // The runtime factory resolves the current checkout from cwd (or an
+        // explicit --workspace selector). `orbit_dir` is not checkout identity:
+        // every checkout under an explicit shared root has the same value.
+        let repo_root = runtime
+            .workspace_runtime_binding()
+            .map(|binding| binding.repo_root.as_path());
 
-        match checkout.and_then(|checkout| {
-            workspace_registry::find_workspace(&registry, &checkout.workspace_id)
-                .map(|workspace| (workspace, checkout))
-        }) {
+        match registered_workspace_for_repo_root(&registry, repo_root) {
             Some((workspace, checkout)) => Ok(Payload::detail(
                 workspace_show_json(workspace, checkout),
                 format_workspace_show(workspace, checkout),
@@ -50,6 +48,20 @@ impl Execute for WorkspaceShowArgs {
             .into()),
         }
     }
+}
+
+pub(super) fn registered_workspace_for_repo_root<'a>(
+    registry: &'a WorkspaceRegistry,
+    repo_root: Option<&Path>,
+) -> Option<(&'a Workspace, &'a WorkspaceCheckout)> {
+    let checkout = repo_root.and_then(|repo_root| {
+        registry
+            .checkouts
+            .iter()
+            .find(|checkout| checkout.repo_root == repo_root)
+    })?;
+    workspace_registry::find_workspace(registry, &checkout.workspace_id)
+        .map(|workspace| (workspace, checkout))
 }
 
 /// `workspace show` had no machine-readable form; this is the record behind

--- a/crates/orbit-cli/src/command/workspace/tests/mod.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/mod.rs
@@ -1,1 +1,2 @@
 mod init;
+mod shared_root;

--- a/crates/orbit-cli/src/command/workspace/tests/shared_root.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/shared_root.rs
@@ -1,0 +1,72 @@
+use orbit_registry::workspace_registry;
+use tempfile::tempdir;
+
+use crate::tests::env_isolation::EnvGuard;
+
+use super::super::init::WorkspaceInitArgs;
+use super::super::show::registered_workspace_for_repo_root;
+
+fn init_args(name: &str) -> WorkspaceInitArgs {
+    WorkspaceInitArgs {
+        name: Some(name.to_string()),
+        base_branch: None,
+        ship_mode: None,
+        role: None,
+        owner: None,
+        task_id_start: None,
+        mcp: false,
+        inject_agent_rules: false,
+        refresh_defaults: false,
+        force: false,
+    }
+}
+
+#[test]
+fn shared_root_registers_each_checkout_and_show_resolves_by_repo_root() {
+    let fixture = tempdir().expect("fixture");
+    let home = fixture.path().join("home");
+    let shared_root = fixture.path().join("shared-orbit");
+    let repo_alpha = fixture.path().join("repo-alpha");
+    let repo_beta = fixture.path().join("repo-beta");
+    let unregistered = fixture.path().join("repo-unregistered");
+    for directory in [&home, &repo_alpha, &repo_beta, &unregistered] {
+        std::fs::create_dir_all(directory).expect("fixture directory");
+    }
+
+    let _env = EnvGuard::acquire().home(&home).cwd(&repo_alpha);
+    init_args("alpha")
+        .execute_without_runtime(Some(&shared_root))
+        .expect("first shared-root workspace init");
+
+    std::env::set_current_dir(&repo_beta).expect("enter second repo");
+    init_args("beta")
+        .execute_without_runtime(Some(&shared_root))
+        .expect("second shared-root workspace init");
+    let mut beta_reinit = init_args("beta");
+    beta_reinit.force = true;
+    beta_reinit
+        .execute_without_runtime(Some(&shared_root))
+        .expect("shared-root workspace reconciliation");
+
+    let registry = workspace_registry::load_registry_from(&workspace_registry::registry_path_for(
+        &shared_root,
+    ))
+    .expect("shared registry");
+    assert_eq!(registry.workspaces.len(), 2);
+    assert_eq!(registry.checkouts.len(), 2);
+    assert!(registry.checkouts.iter().all(|checkout| {
+        checkout.orbit_dir == shared_root
+            && (checkout.repo_root == repo_alpha || checkout.repo_root == repo_beta)
+    }));
+
+    let (workspace, checkout) = registered_workspace_for_repo_root(&registry, Some(&repo_beta))
+        .expect("beta checkout resolves");
+    assert_eq!(workspace.id, "ws_beta");
+    assert_eq!(checkout.repo_root, repo_beta);
+    assert!(registered_workspace_for_repo_root(&registry, Some(&unregistered)).is_none());
+
+    let identity =
+        std::fs::read_to_string(shared_root.join("config.yaml")).expect("shared runtime identity");
+    assert!(identity.contains("workspace_id: ws_alpha"), "{identity}");
+    assert!(!identity.contains("workspace_id: ws_beta"), "{identity}");
+}

--- a/crates/orbit-cmd/src/registry_runtime.rs
+++ b/crates/orbit-cmd/src/registry_runtime.rs
@@ -110,8 +110,16 @@ impl RegisteredRuntimeFactory {
             let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
             let roots = Self::resolve_roots_for_cwd(&cwd, root_override)?;
             sync_task_prefix(&roots.global_root)?;
-            let binding = binding_for_roots(&roots)?;
-            let replica_owner = replica_owner_for_roots(&roots)?;
+            let selection = select_workspace_for_cwd_and_roots(&cwd, &roots)?;
+            let binding = selection
+                .as_ref()
+                .map(|selection| {
+                    workspace_runtime_binding(&selection.workspace, &selection.checkout)
+                })
+                .transpose()?;
+            let replica_owner = selection
+                .as_ref()
+                .and_then(|selection| replica_owner_for_checkout(&selection.checkout));
             return OrbitRuntime::initialize_from_resolved_roots(roots, binding)
                 .map(|runtime| runtime.with_coordination_write_owner(replica_owner));
         };
@@ -491,6 +499,52 @@ fn binding_for_roots(
     let registry_path = workspace_registry::registry_path_for(&roots.global_root);
     let registry = workspace_registry::load_registry_from(&registry_path)?;
     binding_for_registry_roots(&registry, &roots.shared_root)
+}
+
+/// Resolve the registered checkout represented by this cwd/root pair.
+///
+/// Cwd is authoritative when several checkouts deliberately share one
+/// explicit root. The historical orbit-dir fallback remains for ordinary and
+/// linked-worktree roots, where the shared root is still a checkout identity.
+pub(crate) fn select_workspace_for_cwd_and_roots(
+    cwd: &Path,
+    roots: &OrbitRuntimeRoots,
+) -> Result<Option<ResolvedWorkspaceSelection>, OrbitError> {
+    let registry_path = workspace_registry::registry_path_for(&roots.global_root);
+    let registry = workspace_registry::load_registry_from(&registry_path)?;
+    let shared = canonical_or_original(&roots.shared_root);
+
+    if let Some(checkout) = workspace_registry::find_checkout_by_path(&registry, cwd)
+        && canonical_or_original(&checkout.orbit_dir) == shared
+        && let Some(workspace) =
+            workspace_registry::find_workspace(&registry, &checkout.workspace_id)
+    {
+        return Ok(Some(ResolvedWorkspaceSelection {
+            workspace: workspace.clone(),
+            checkout: checkout.clone(),
+        }));
+    }
+
+    // An explicit --root pins global_root to shared_root. In that mode an
+    // orbit-dir-only fallback would silently select the first unrelated
+    // checkout registered under the shared data directory.
+    if canonical_or_original(&roots.global_root) == shared {
+        return Ok(None);
+    }
+
+    for (workspace, checkout) in workspace_registry::local_workspaces(&registry) {
+        if canonical_or_original(&checkout.orbit_dir) == shared {
+            return Ok(Some(ResolvedWorkspaceSelection {
+                workspace: workspace.clone(),
+                checkout: checkout.clone(),
+            }));
+        }
+    }
+    Ok(None)
+}
+
+fn canonical_or_original(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 fn binding_for_registry_roots(

--- a/crates/orbit-cmd/src/tests/registry_runtime.rs
+++ b/crates/orbit-cmd/src/tests/registry_runtime.rs
@@ -2,16 +2,19 @@ use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 use orbit_common::types::{
-    NotFoundKind, OrbitError, Workspace, WorkspaceCheckout, WorkspaceCheckoutRole, WorkspaceStatus,
+    NotFoundKind, OrbitError, Workspace, WorkspaceCheckout, WorkspaceCheckoutRole,
+    WorkspaceRegistry, WorkspaceStatus,
 };
 use orbit_core::OrbitRuntime;
+use orbit_core::runtime::OrbitRuntimeRoots;
 use orbit_store::sqlite::task_registry::{WorkspaceConfig, write_workspace_config};
 use serde_json::{Value, json};
 
 use orbit_registry::workspace_registry::{registry_path_for, save_registry_to};
 
 use crate::registry_runtime::{
-    RegisteredRuntimeFactory, resolved_workspace_binding, workspace_runtime_binding,
+    RegisteredRuntimeFactory, resolved_workspace_binding, select_workspace_for_cwd_and_roots,
+    workspace_runtime_binding,
 };
 
 fn workspace(id: &str, ship_mode: &str) -> Workspace {
@@ -91,6 +94,67 @@ fn registered_checkout_opens_a_bound_runtime() {
             ..
         })
     ));
+}
+
+#[test]
+fn explicit_shared_root_selects_checkout_by_cwd_and_does_not_fall_back() {
+    let root = tempfile::tempdir().expect("root");
+    let shared = root.path().join("shared");
+    let alpha_repo = root.path().join("alpha");
+    let beta_repo = root.path().join("beta");
+    let unregistered_repo = root.path().join("unregistered");
+    for directory in [&shared, &alpha_repo, &beta_repo, &unregistered_repo] {
+        std::fs::create_dir_all(directory).expect("fixture directory");
+    }
+    write_workspace_config(
+        &shared,
+        &WorkspaceConfig {
+            schema_version: 1,
+            workspace_id: "ws_shared_runtime".to_string(),
+        },
+    )
+    .expect("workspace config");
+
+    let mut alpha = workspace("ws_alpha", "pr");
+    alpha.name = "alpha".to_string();
+    let mut beta = workspace("ws_beta", "local");
+    beta.name = "beta".to_string();
+    let alpha_checkout = WorkspaceCheckout::owner(alpha.id.clone(), alpha_repo, shared.clone());
+    let beta_checkout =
+        WorkspaceCheckout::owner(beta.id.clone(), beta_repo.clone(), shared.clone());
+    save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![alpha, beta],
+            checkouts: vec![alpha_checkout, beta_checkout],
+            ..Default::default()
+        },
+        &registry_path_for(&shared),
+    )
+    .expect("shared registry");
+    let roots = OrbitRuntimeRoots {
+        global_root: shared.clone(),
+        shared_root: shared.clone(),
+        local_root: shared,
+    };
+
+    let selected = select_workspace_for_cwd_and_roots(&beta_repo, &roots)
+        .expect("select beta")
+        .expect("registered beta");
+    assert_eq!(selected.workspace.id, "ws_beta");
+    assert_eq!(selected.checkout.repo_root, beta_repo);
+    assert_eq!(
+        workspace_runtime_binding(&selected.workspace, &selected.checkout)
+            .expect("runtime binding")
+            .workspace_id,
+        "ws_shared_runtime"
+    );
+
+    assert!(
+        select_workspace_for_cwd_and_roots(&unregistered_repo, &roots)
+            .expect("unregistered selection")
+            .is_none(),
+        "a shared orbit_dir must not select the first registered checkout"
+    );
 }
 
 #[test]

--- a/crates/orbit-registry/src/tests/workspace_registry.rs
+++ b/crates/orbit-registry/src/tests/workspace_registry.rs
@@ -11,8 +11,8 @@ use tempfile::tempdir;
 
 use crate::workspace_registry::{
     assign_checkout_role, find_checkout_by_path, find_workspace, find_workspace_by_path,
-    load_registry_from, load_registry_from_with_writer, rename_local_owner_host_id,
-    resolve_logical_workspace, save_registry_to,
+    load_registry_from, load_registry_from_with_writer, register_checkout,
+    rename_local_owner_host_id, resolve_logical_workspace, save_registry_to,
 };
 
 fn timestamp() -> chrono::DateTime<Utc> {
@@ -364,6 +364,35 @@ fn identity_lookup_is_path_independent_and_path_lookup_is_checkout_only() {
         Some("ws_inner")
     );
     assert!(find_workspace_by_path(&registry, Path::new("/remote/ws_remote")).is_none());
+}
+
+#[test]
+fn checkout_registration_allows_distinct_repos_to_share_an_orbit_root() {
+    let shared_root = PathBuf::from("/srv/orbit");
+    let mut registry = WorkspaceRegistry {
+        workspaces: vec![
+            logical_workspace("ws_alpha", None),
+            logical_workspace("ws_beta", None),
+        ],
+        checkouts: vec![WorkspaceCheckout::owner(
+            "ws_alpha".to_string(),
+            PathBuf::from("/repos/alpha"),
+            shared_root.clone(),
+        )],
+        ..Default::default()
+    };
+
+    register_checkout(
+        &mut registry,
+        WorkspaceCheckout::owner(
+            "ws_beta".to_string(),
+            PathBuf::from("/repos/beta"),
+            shared_root,
+        ),
+    )
+    .expect("shared Orbit root is not checkout identity");
+
+    assert_eq!(registry.checkouts.len(), 2);
 }
 
 #[test]

--- a/crates/orbit-registry/src/workspace_registry/catalog.rs
+++ b/crates/orbit-registry/src/workspace_registry/catalog.rs
@@ -58,9 +58,11 @@ pub fn register_checkout(
             checkout.workspace_id
         )));
     }
-    if let Some(existing) = registry.checkouts.iter().find(|existing| {
-        existing.repo_root == checkout.repo_root || existing.orbit_dir == checkout.orbit_dir
-    }) {
+    if let Some(existing) = registry
+        .checkouts
+        .iter()
+        .find(|existing| existing.repo_root == checkout.repo_root)
+    {
         return Err(OrbitError::WorkspaceError(format!(
             "checkout path '{}' is already registered to workspace '{}'",
             checkout.repo_root.display(),


### PR DESCRIPTION
## Task

[ORB-10846](https://orbit-cli.com/tasks/ORB-10846) — workspace init/show misresolve checkouts under a shared --root (orbit_dir treated as per-checkout fingerprint)

### Description

Found during hands-on QA sweep (ORB-10844) exercising a multi-workspace `--root`
setup (isolated Orbit root, two independently registered git checkouts sharing
it — the same pattern `--root`/`ORBIT_ROOT` exists to support, e.g. a shared
CI/agent-host data directory).

## Repro

```
orbit --root /tmp/scratch/root init --non-interactive --host-name h --task-prefix QAX

cd /tmp/scratch/repo1 && git init -q && ...
orbit --root /tmp/scratch/root workspace init          # OK, registers ws_repo1

cd /tmp/scratch/repo2 && git init -q && ...             # a second, unrelated checkout
orbit --root /tmp/scratch/root workspace init
```

Expected: `repo2` registers as a new workspace (`ws_repo2`), exactly as it does
when pointed at a *fresh* `--root` with nothing registered yet (verified this
works).

Actual:

```
error: workspace error: workspace registration already exists for 'ws_repo2' or '/tmp/scratch/repo2'; rerun with --force to reconcile it
```

`workspaces.json` under the shared root proves this is a false positive — it
contains only `ws_repo1`, no `ws_repo2` entry and no checkout for
`/tmp/scratch/repo2` anywhere.

Worse: before the failed `init`, running `workspace show` from `repo2`'s cwd
against the same `--root` silently prints **`repo1`'s** workspace data
(`ws_repo1`, `repo_root: /tmp/scratch/repo1`) instead of reporting that
`repo2` is unregistered — a silent misdirection to the wrong workspace, not
just a rejected write.

## Root cause

Both bugs share one identity bug: `orbit_dir` (`data_root`/`shared_root`) is
treated as a per-checkout fingerprint, but when `--root`/`ORBIT_ROOT` is
explicit it is **not** per-checkout — every workspace registered under that
root gets the identical literal `orbit_dir` value. The per-checkout-`.orbit`
default mode (no `--root`; verified against the real `~/.orbit/workspaces.json`
on this host, which has 11 checkouts each with its own `<repo_root>/.orbit`)
does not hit this, because `orbit_dir` differs per checkout there — the bug is
specific to the shared-root mode the `--root`/`ORBIT_ROOT` flags exist for.

- `crates/orbit-cli/src/command/workspace/init.rs:184-188` (`execute_at_path`):
  ```rust
  let existing_checkout = registry
      .checkouts
      .iter()
      .find(|checkout| checkout.repo_root == cwd || checkout.orbit_dir == orbit_dir);
  ```
  matches **any** existing checkout sharing the root, regardless of
  `repo_root`, because `checkout.orbit_dir == orbit_dir` is true for every
  checkout once `--root` is explicit.

- `crates/orbit-cli/src/command/workspace/show.rs:14-25`:
  ```rust
  let checkout = registry.checkouts.iter().find(|checkout| {
      let ws_canonical = std::fs::canonicalize(&checkout.orbit_dir)
          .unwrap_or_else(|_| checkout.orbit_dir.clone());
      ws_canonical == data_root_canonical
  });
  ```
  same collapse: matches the first/only registered checkout under the shared
  root regardless of whether cwd corresponds to it.

- Explicit `--root` pins `global_root == shared_root` for every checkout via
  `roots_from_resolved` (`crates/orbit-core/src/runtime/mod.rs:204-214`,
  `has_explicit_root_override` at `mod.rs:634-637`), and `resolve_roots`
  (`crates/orbit-core/src/runtime/resolve.rs:117-132`) returns
  `ResolvedOrbitRoots::pinned(root)` verbatim with no per-cwd derivation.

Neither `init.rs` nor `show.rs` does a real path-containment check
(`checkout.repo_root` against cwd) or a checkout-local identity fingerprint;
`orbit_dir` alone is the wrong discriminator once it's shared.

## Impact

- Blocks registering more than one workspace under a shared `--root` at all
  (every second+ `workspace init` false-positives as "already exists").
- `workspace show` (and likely any other cwd-resolved command sharing this
  matching logic) can silently report/operate against the wrong workspace
  when cwd is an unregistered checkout under a root that already has
  something registered — a correctness/data-integrity risk, not just a
  rejected write.

Not caused by any of the 12 commits landed since the last QA sweep (ORB-10834,
21:01 UTC) — `git log` on both files shows the conflict-check logic predates
this window; ORB-10829 touched `init.rs` today but only changed the
`--ship-mode` default/doc comment, not this matching logic.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Removed orbit_dir from checkout uniqueness checks in both workspace init and the registry boundary, so distinct repo roots can intentionally share one explicit Orbit root.
- Preserved and validated the shared runtime config identity when additional logical workspaces register or reconcile under that root.
- Made cwd-aware runtime bootstrap select the matching registered checkout and refuse first-entry orbit_dir fallback when global_root equals shared_root. workspace show now reports only the runtime-bound repo checkout, so an unregistered cwd reports registered=false.
- Added focused registry, runtime-selection, init/reconciliation, and show-resolution regression coverage.
Assessment: The fix moves checkout identity to repo_root/cwd while retaining orbit_dir as shared data placement. Explicit --workspace selection remains on its existing authoritative path, and ordinary/linked-worktree roots retain their compatibility fallback. No new dependency edge or persisted format change was introduced.
Validation:
- cargo test -p orbit-registry -p orbit-cmd -p orbit-cli (all passed: orbit-cli 315 unit tests plus integrations, orbit-cmd 52, orbit-registry 33)
- make ci-fast (passed)
- make ci-lint (passed, workspace all-target clippy with warnings denied)
Deviations from original plan:
- Added the orbit-registry registration boundary and its tests after the end-to-end regression exposed a second orbit_dir uniqueness check there. This was required for the requested second-checkout registration behavior and keeps the invariant fixed at its owner.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10846-6a80fa1b`
- Behind base: 0
- Ahead of base: 1