### PR TITLE
fix: plugin-install smoke needs host identity flags [ORB-10849]

### DIFF
--- a/scripts/smoke-plugin-install.sh
+++ b/scripts/smoke-plugin-install.sh
@@ -57,6 +57,9 @@ mkdir -p "$npm_config_cache"
 SMOKE_HOME="$TMPDIR_ROOT/home"
 mkdir -p "$SMOKE_HOME"
 export HOME="$SMOKE_HOME"
+# A caller-exported ORBIT_ROOT would bypass the HOME sandbox and write
+# host identity / workspace state outside the throwaway tree.
+unset ORBIT_ROOT
 
 # Pick a timeout binary. macOS runners ship neither `timeout` nor `gtimeout`
 # unless coreutils is installed; fall back to perl, which is preinstalled on
@@ -140,8 +143,14 @@ echo "--- step 2: orbit init + workspace init ---"
 # OrbitRuntime::try_initialize_existing) — so without these two commands the
 # MCP server attaches but serves an empty tool surface. Initializing first
 # matches the documented /plugin install orbit flow.
-if ! npx -y "$NPM_PKG@latest" init --non-interactive >"$TMPDIR_ROOT/init.out" 2>"$TMPDIR_ROOT/init.err"; then
+# Fresh-host non-interactive init requires host identity (ORB-10721): a
+# host name plus a 2-5 letter task prefix that is not ORB/ADR/L/F.
+if ! npx -y "$NPM_PKG@latest" init --non-interactive \
+     --host-name smoke-plugin-install --task-prefix SMK \
+     >"$TMPDIR_ROOT/init.out" 2>"$TMPDIR_ROOT/init.err"; then
   echo "FAIL: orbit init exited non-zero" >&2
+  echo "--- stdout ---" >&2
+  cat "$TMPDIR_ROOT/init.out" >&2
   echo "--- stderr ---" >&2
   cat "$TMPDIR_ROOT/init.err" >&2
   exit 1


### PR DESCRIPTION
## Task

[ORB-10849](https://orbit-cli.com/tasks/ORB-10849) — Plugin-install smoke fails orbit init without host identity flags

## What

`smoke-plugin-install.sh` still ran `orbit init --non-interactive` with no host flags. After `@orbit-tools/cli@0.11.0` that fails:

```
host identity is absent; pass --host-name and --task-prefix
```

This PR passes `--host-name smoke-plugin-install --task-prefix SMK` (not a reserved prefix) and dumps init stdout on failure. Also unsets `ORBIT_ROOT` so a caller-exported root cannot escape the HOME sandbox.

## Why not a new npm publish

The smoke script is what CI checks out. npm 0.11.0 is already correct. After merge, re-run `smoke-plugin-install.yml` via `workflow_dispatch` against this commit (not the `v0.11.0` tag).