### PR TITLE
docs: retire stale ADR and learning language from POSITIONING and seeded skills [ORB-10853]

### DIFF
--- a/crates/orbit-core/assets/skills/orbit-search/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orbit-search
-description: Search tasks, docs, ADRs, and frictions through the unified `orbit search` surface. Also covers the `orbit semantic` embedding companion and the human-authored docs corpus.
+description: Search tasks, docs, and frictions through the unified `orbit search` surface. Also covers the `orbit semantic` embedding companion and the human-authored docs corpus.
 ---
 
 # Orbit Search
@@ -17,11 +17,11 @@ orbit search "agent loop deadlock" --hybrid --kind task --limit 5 # lexical + co
 orbit search similar "<task-id>" --limit 5                        # MCP: {"semantic":"<task-id>"}
 ```
 
-**Applicability (`search path`)** resolves differently per corpus: tasks match by selector containment over `context_files`; ADRs match by glob containment over their decision scopes; docs are content-indexed and never match by path.
+**Applicability (`search path`) filters tasks only.** A task matches when one of its `context_files` selectors overlaps the query path — `file:`, `dir:`, and `symbol:<file>#<name>:<kind>` all collapse to a plain path first, and containment is bidirectional, so querying a parent directory matches every selector beneath it. Docs are content-indexed and never match by path; frictions carry no path scope at all. Both are absent from `search path` results regardless of `--kind`.
 
 **`--status` takes `kind:value` tokens** (`--status task:open,doc:active`). Bare tokens are rejected because statuses collide across corpora.
 
-**Index coverage:** lexical covers tasks, docs, ADRs, and frictions. Vector search covers task fields and docs once `orbit semantic index --kind <kind>` has run. Missing vectors under `--hybrid` fall back to lexical with a note rather than failing — and if the companion isn't installed at all, fall back to lexical and continue. Never run `orbit semantic install` without operator consent.
+**Index coverage:** lexical covers all three corpora — tasks, docs, and frictions. Vector search covers task fields and docs once `orbit semantic index --kind <kind>` has run; frictions are never embedded, so they stay lexical even under `--hybrid`. Missing vectors under `--hybrid` fall back to lexical with a note rather than failing — and if the companion isn't installed at all, fall back to lexical and continue. Never run `orbit semantic install` without operator consent.
 
 **Where it earns its keep:** a `--hybrid --kind task` dedup check before creating a task; `semantic: "<task-id>"` after `orbit.task.show` to surface prior decisions the author never linked; and "where did we decide X" as `--kind all`. For a brand-new task, use `--hybrid` on title and description — it may not have embeddings yet. For exact identifiers, paths, and error strings, plain lexical is cheaper and more predictable than semantic.
 
@@ -33,4 +33,4 @@ Results carry `mode`, `kind`, `notes`, and `results[]` with some of `id`/`path`/
 
 **Docs** are PR-reviewed Markdown under configured `[docs].roots` (default `docs/`) — designs, patterns, domain notes, glossaries, runbooks. Orbit walks the roots on demand and indexes anything with valid frontmatter. Authoring a doc, registering a root, or migrating legacy files: [references/docs-corpus.md](references/docs-corpus.md).
 
-**ADRs** are complete entries in the repository's designated decision docs. They are indexed as ordinary docs; use `--kind doc` and search by ID, title, or body text. The retired `--kind adr` is rejected.
+**Decision records** are titled entries inside a feature's decision doc, not a separate corpus. They are indexed as ordinary docs: use `--kind doc` and search by title or body text. There is no ADR store to query — the retired `--kind adr` is rejected.

--- a/crates/orbit-core/assets/skills/orbit-task/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-task/SKILL.md
@@ -34,7 +34,7 @@ Create a task another engineer or agent can execute without guessing: a crisp pr
 - `relations: [{"type": "resolves", "target": "F<YYYY>-<MM>-<NNN>"}]` — auto-resolves that friction when this task reaches `done`. Other types (`produces`, `blocked_by`, `child_of`, `spawned_from`, `regression_from`, `supersedes`, `related_to`) are tracked but inert. Only `produces`/`resolves` accept non-`ORB-` targets; the rest require `ORB-NNNNN`. A dangling target succeeds but emits a `TaskRelationDangling` audit event.
 - `parent_id`, `source_task_id` (the bug-introducing task; creation-time only — `update` silently drops it), `tags` (reuse existing before inventing new).
 
-**Quality bar.** Validation must not assume `.orbit/knowledge/` or uncommitted artifacts. File I/O checks use temp dirs or fakes. Behavior-changing work that touches external services, the filesystem, or time should ask for deterministic mock coverage in its acceptance criteria.
+**Quality bar.** Validation must not assume uncommitted artifacts or workspace-local runtime state under `.orbit/state/`. File I/O checks use temp dirs or fakes. Behavior-changing work that touches external services, the filesystem, or time should ask for deterministic mock coverage in its acceptance criteria.
 
 Description template:
 

--- a/crates/orbit-core/assets/skills/orbit-task/references/friction.md
+++ b/crates/orbit-core/assets/skills/orbit-task/references/friction.md
@@ -8,7 +8,7 @@ Search the corpus first — the point of filing is a record someone finds *befor
 
 ## Record shape
 
-Bodies are append-only markdown under `.orbit/frictions/`; triage metadata is mutable. New records start `open` and may become `triaged` or `resolved`.
+Records live in Orbit's store, keyed by `(workspace_id, friction_id)` — IDs are workspace-local and monthly (`F<YYYY>-<MM>-<NNN>`), so the same ID in two workspaces is two unrelated records. Reach them only through `orbit.friction.*`; any `.orbit/frictions/` markdown tree is legacy evidence, and editing a file there cannot change what a read returns. Bodies are append-only, triage metadata is mutable. New records start `open` and may become `triaged` or `resolved`.
 
 ```bash
 orbit tool run orbit.friction.add --input '{

--- a/crates/orbit-core/assets/skills/orbit/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit/SKILL.md
@@ -57,4 +57,4 @@ Use `blocked` when execution cannot safely continue. Provenance follows the surf
 
 - `orbit-task`: create, execute, and review tasks through the lifecycle; file self-reported tooling and skill-guidance friction.
 - `orbit-workflow`: task-pilot preflight, jobs, activities, routines, `orbit sweep`, and `orbit run`; diagnosing failed, stuck, or cancelled runs.
-- `orbit-search`: find tasks, docs, ADRs, and frictions by topic; docs-corpus admin.
+- `orbit-search`: find tasks, docs, and frictions by topic; docs-corpus admin. Decision records are searched as docs.

--- a/docs/POSITIONING.md
+++ b/docs/POSITIONING.md
@@ -12,7 +12,7 @@ This document names what Orbit is for, who it's for, and what it deliberately is
 
 **Applying engineering rigor to AI-assisted coding.**
 
-Coding agents are fast enough that the disciplines that keep code maintainable — planning before edits, decision records for load-bearing choices, audit trails, conflict-aware parallel execution — become tempting to skip. Orbit makes those disciplines cheap and enforces them by default: every change starts as a task, every load-bearing decision becomes an ADR, every tool call lands in a structured audit log, and parallel runs are dispatched into worktrees with file-level locks.
+Coding agents are fast enough that the disciplines that keep code maintainable — planning before edits, decision records for load-bearing choices, audit trails, conflict-aware parallel execution — become tempting to skip. Orbit makes those disciplines cheap and enforces them by default: every change starts as a task, every load-bearing decision is written into the design docs for the feature it governs, every tool call lands in a structured audit log, and parallel runs are dispatched into worktrees with file-level locks.
 
 The audience is the individual engineer driving multiple coding agents against real code and unwilling to trade engineering rigor for raw throughput. Agent vendors solve in-session execution; Orbit is the layer above that turns individual agent sessions into a coherent, traceable body of work.
 
@@ -20,7 +20,7 @@ The audience is the individual engineer driving multiple coding agents against r
 
 ## Who Orbit is for
 
-The AI-native engineer running multiple coding agents (Claude Code, Codex CLI, Gemini CLI, plus any OpenAI-compatible or Ollama-served model) heavily, who has outgrown the in-session model and wants engineering discipline around their AI-assisted work — tasks, ADRs, audit, sandboxing, parallel dispatch.
+The AI-native engineer running multiple coding agents (Claude Code, Codex CLI, Gemini CLI, plus any OpenAI-compatible or Ollama-served model) heavily, who has outgrown the in-session model and wants engineering discipline around their AI-assisted work — tasks, decision records, a searchable docs corpus, audit, sandboxing, parallel dispatch.
 
 Staff and principal engineers, tech leads, and founding engineers fit the same profile. If they bring Orbit into their team's workflow, that's a natural extension — but the project is not positioned for team conversion. Orbit optimizes for the individual engineer who refuses to vibe-code their way through agent-driven development.
 

--- a/plugin/skills/orbit-search/SKILL.md
+++ b/plugin/skills/orbit-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orbit-search
-description: Search tasks, docs, ADRs, and frictions through the unified `orbit search` surface. Also covers the `orbit semantic` embedding companion and the human-authored docs corpus.
+description: Search tasks, docs, and frictions through the unified `orbit search` surface. Also covers the `orbit semantic` embedding companion and the human-authored docs corpus.
 ---
 
 # Orbit Search
@@ -17,11 +17,11 @@ orbit search "agent loop deadlock" --hybrid --kind task --limit 5 # lexical + co
 orbit search similar "<task-id>" --limit 5                        # MCP: {"semantic":"<task-id>"}
 ```
 
-**Applicability (`search path`)** resolves differently per corpus: tasks match by selector containment over `context_files`; ADRs match by glob containment over their decision scopes; docs are content-indexed and never match by path.
+**Applicability (`search path`) filters tasks only.** A task matches when one of its `context_files` selectors overlaps the query path — `file:`, `dir:`, and `symbol:<file>#<name>:<kind>` all collapse to a plain path first, and containment is bidirectional, so querying a parent directory matches every selector beneath it. Docs are content-indexed and never match by path; frictions carry no path scope at all. Both are absent from `search path` results regardless of `--kind`.
 
 **`--status` takes `kind:value` tokens** (`--status task:open,doc:active`). Bare tokens are rejected because statuses collide across corpora.
 
-**Index coverage:** lexical covers tasks, docs, ADRs, and frictions. Vector search covers task fields and docs once `orbit semantic index --kind <kind>` has run. Missing vectors under `--hybrid` fall back to lexical with a note rather than failing — and if the companion isn't installed at all, fall back to lexical and continue. Never run `orbit semantic install` without operator consent.
+**Index coverage:** lexical covers all three corpora — tasks, docs, and frictions. Vector search covers task fields and docs once `orbit semantic index --kind <kind>` has run; frictions are never embedded, so they stay lexical even under `--hybrid`. Missing vectors under `--hybrid` fall back to lexical with a note rather than failing — and if the companion isn't installed at all, fall back to lexical and continue. Never run `orbit semantic install` without operator consent.
 
 **Where it earns its keep:** a `--hybrid --kind task` dedup check before creating a task; `semantic: "<task-id>"` after `orbit.task.show` to surface prior decisions the author never linked; and "where did we decide X" as `--kind all`. For a brand-new task, use `--hybrid` on title and description — it may not have embeddings yet. For exact identifiers, paths, and error strings, plain lexical is cheaper and more predictable than semantic.
 
@@ -33,4 +33,4 @@ Results carry `mode`, `kind`, `notes`, and `results[]` with some of `id`/`path`/
 
 **Docs** are PR-reviewed Markdown under configured `[docs].roots` (default `docs/`) — designs, patterns, domain notes, glossaries, runbooks. Orbit walks the roots on demand and indexes anything with valid frontmatter. Authoring a doc, registering a root, or migrating legacy files: [references/docs-corpus.md](references/docs-corpus.md).
 
-**ADRs** are complete entries in the repository's designated decision docs. They are indexed as ordinary docs; use `--kind doc` and search by ID, title, or body text. The retired `--kind adr` is rejected.
+**Decision records** are titled entries inside a feature's decision doc, not a separate corpus. They are indexed as ordinary docs: use `--kind doc` and search by title or body text. There is no ADR store to query — the retired `--kind adr` is rejected.

--- a/plugin/skills/orbit-task-pilot/SKILL.md
+++ b/plugin/skills/orbit-task-pilot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orbit-task-pilot
-description: Read-only preflight over a bounded partition of Orbit tasks — proposes canonical context_files, crew and complexity, dependencies, duplicate or already-landed evidence, and ADR conflicts, without promoting, dispatching, implementing, or mutating anything.
+description: Read-only preflight over a bounded partition of Orbit tasks — proposes canonical context_files, crew and complexity, dependencies, duplicate or already-landed evidence, and conflicts with recorded decisions, without promoting, dispatching, implementing, or mutating anything.
 ---
 
 # Orbit Task Pilot
@@ -12,7 +12,7 @@ Accept an explicit target workspace, target branch, and a partition of one to fi
 For each task:
 
 1. Read the complete record and preserve the current selector list exactly as `context_files_before`.
-2. Inspect the target branch, modification and deletion targets, related tasks, and relevant accepted ADRs using read-only tools.
+2. Inspect the target branch, modification and deletion targets, related tasks, and any decision entries governing the code in scope, using read-only tools. Decisions are titled sections in the feature's decision doc — reach them with `--kind doc`, not an ADR store.
 3. Return `context_files_after` using only canonical `file:`, `dir:`, or `symbol:` selectors whose anchors exist inside the target workspace. Modification and deletion targets only — never read-for-context files.
 4. Use disposition `selectors` for a non-empty proposal. An empty proposal is valid only with `verified_no_diff` or `host_operational`, plus concrete evidence.
 5. Report recommendations for crew, complexity, real blockers, duplicates, already-landed work, utility, and public surface — without applying them, and without silently picking an architecture alternative.
@@ -23,7 +23,7 @@ Never write: no editing, creating, moving, or deleting repository files; no task
 
 Never update an Orbit task.
 
-Never expand the partition beyond the supplied IDs, except to cite a concrete dependency, duplicate, or accepted ADR.
+Never expand the partition beyond the supplied IDs, except to cite a concrete dependency, duplicate, or recorded decision.
 
 Task-pilot is an operational role, not a crew, actor identity, or scheduler.
 

--- a/plugin/skills/orbit-task/SKILL.md
+++ b/plugin/skills/orbit-task/SKILL.md
@@ -34,7 +34,7 @@ Create a task another engineer or agent can execute without guessing: a crisp pr
 - `relations: [{"type": "resolves", "target": "F<YYYY>-<MM>-<NNN>"}]` — auto-resolves that friction when this task reaches `done`. Other types (`produces`, `blocked_by`, `child_of`, `spawned_from`, `regression_from`, `supersedes`, `related_to`) are tracked but inert. Only `produces`/`resolves` accept non-`ORB-` targets; the rest require `ORB-NNNNN`. A dangling target succeeds but emits a `TaskRelationDangling` audit event.
 - `parent_id`, `source_task_id` (the bug-introducing task; creation-time only — `update` silently drops it), `tags` (reuse existing before inventing new).
 
-**Quality bar.** Validation must not assume `.orbit/knowledge/` or uncommitted artifacts. File I/O checks use temp dirs or fakes. Behavior-changing work that touches external services, the filesystem, or time should ask for deterministic mock coverage in its acceptance criteria.
+**Quality bar.** Validation must not assume uncommitted artifacts or workspace-local runtime state under `.orbit/state/`. File I/O checks use temp dirs or fakes. Behavior-changing work that touches external services, the filesystem, or time should ask for deterministic mock coverage in its acceptance criteria.
 
 Description template:
 

--- a/plugin/skills/orbit-task/references/friction.md
+++ b/plugin/skills/orbit-task/references/friction.md
@@ -8,7 +8,7 @@ Search the corpus first — the point of filing is a record someone finds *befor
 
 ## Record shape
 
-Bodies are append-only markdown under `.orbit/frictions/`; triage metadata is mutable. New records start `open` and may become `triaged` or `resolved`.
+Records live in Orbit's store, keyed by `(workspace_id, friction_id)` — IDs are workspace-local and monthly (`F<YYYY>-<MM>-<NNN>`), so the same ID in two workspaces is two unrelated records. Reach them only through `orbit.friction.*`; any `.orbit/frictions/` markdown tree is legacy evidence, and editing a file there cannot change what a read returns. Bodies are append-only, triage metadata is mutable. New records start `open` and may become `triaged` or `resolved`.
 
 ```bash
 orbit tool run orbit.friction.add --input '{

--- a/plugin/skills/orbit/SKILL.md
+++ b/plugin/skills/orbit/SKILL.md
@@ -57,4 +57,4 @@ Use `blocked` when execution cannot safely continue. Provenance follows the surf
 
 - `orbit-task`: create, execute, and review tasks through the lifecycle; file self-reported tooling and skill-guidance friction.
 - `orbit-workflow`: task-pilot preflight, jobs, activities, routines, `orbit sweep`, and `orbit run`; diagnosing failed, stuck, or cancelled runs.
-- `orbit-search`: find tasks, docs, ADRs, and frictions by topic; docs-corpus admin.
+- `orbit-search`: find tasks, docs, and frictions by topic; docs-corpus admin. Decision records are searched as docs.


### PR DESCRIPTION
## Task

- [ORB-10853] Retire stale ADR and learning language from POSITIONING and the seeded skills

Follow-up to [ORB-10851] (#1028), which fixed the README. This covers the two surfaces that matter more at runtime: `docs/POSITIONING.md`, which step 7 of the shipped setup prompt tells an agent to read, and the seeded skills, which are injected into agent context at session start. A wrong claim there doesn't just mislead a human reader — it misroutes the agent's next tool call.

## Execution Summary

| File | Was | Now |
|---|---|---|
| `docs/POSITIONING.md` | "every load-bearing decision becomes an ADR"; audience wants "tasks, ADRs, audit…" | decisions written into the feature's design docs; audience gains the docs corpus |
| `orbit/SKILL.md` | routes `orbit-search` as covering "tasks, docs, ADRs, and frictions" | three corpora; decision records searched as docs |
| `orbit-search/SKILL.md` | ADRs as a fourth corpus in description, applicability, and index coverage | three corpora; applicability rewritten from source (below) |
| `orbit-task/SKILL.md` | quality bar forbids assuming `.orbit/knowledge/` | names `.orbit/state/` runtime state, which actually exists |
| `orbit-task/references/friction.md` | "Bodies are append-only markdown under `.orbit/frictions/`" | store-backed, keyed `(workspace_id, friction_id)`, reachable only via `orbit.friction.*` |
| `orbit-task-pilot/SKILL.md` | inspect "relevant accepted ADRs"; cite an "accepted ADR" | decision entries in the feature's decision doc, via `--kind doc` |

Two of these were wrong in a way that costs an agent real work, not just credibility:

- **The friction line pointed at a dead write path.** [ORB-10680] moved records to the store; the markdown tree is read-only rollback evidence, so an agent following the old instruction edits a file that cannot affect any read.
- **The applicability paragraph described a mechanism that never existed post-removal** — "ADRs match by glob containment over their decision scopes". Rewritten against `crates/orbit-core/src/command/search/path_match.rs`: `orbit search path` filters **tasks only**, by bidirectional containment over `context_files` selectors (`file:`/`dir:`/`symbol:` all collapse to a normalized path first). Docs are content-indexed and frictions carry no path scope, so both are absent from those results regardless of `--kind`.

## Validation

- `cargo test -p orbit-core --lib skill` — 10 passed, including `orbit_task_skill_matches_plugin_copy` and `embedded_assets_are_repository_agnostic`.
- `diff -r` over every skill name present in both `crates/orbit-core/assets/skills/` and `plugin/skills/` — byte-identical.
- `make ci-fast` — passes.
- Re-scanned both skill trees for `\badrs?\b|learning|\.orbit/frictions|\.orbit/knowledge`; every survivor is deliberate (each one now *explains* that decisions are ordinary docs, or warns that the legacy friction tree is inert).

> The portability guardrail earned its keep here: my first draft of the friction text used a concrete example ID, and `embedded_assets_are_repository_agnostic` rejected it as a workspace-local artifact id. Now `F<YYYY>-<MM>-<NNN>`.

## Deliberately not changed

- **`references/docs-corpus.md`** keeps `related_artifacts: ["<task-id>", "<adr-id>"]`. `crates/orbit-core/src/command/docs/artifact_ref.rs` still accepts `ADR-NNNN`, so historical citations remain valid — this one only *looks* stale.
- **The plugin-vs-assets skill asymmetry** (`plugin/skills/` ships `orbit-task-pilot`, the seeded assets ship `orbit-workflow`). I flagged this as possible drift on #1028; on inspection it is deliberate — `scripts/validate-codex-plugin.sh` explicitly requires the pilot in the plugin package. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)