### PR TITLE
Drop dead .orbit/frictions/ path from friction tool descriptions

### DIFF
--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -61,7 +61,7 @@
   {
     "active": true,
     "builtin": true,
-    "description": "Append an Orbit friction report under .orbit/frictions/",
+    "description": "Append an Orbit friction report to the Orbit store via orbit.friction.*",
     "enabled": true,
     "name": "orbit.friction.add",
     "parameters": [
@@ -101,7 +101,7 @@
   {
     "active": true,
     "builtin": true,
-    "description": "List Orbit friction records from .orbit/frictions/",
+    "description": "List Orbit friction records from the Orbit store via orbit.friction.*",
     "enabled": true,
     "name": "orbit.friction.list",
     "parameters": [

--- a/crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
@@ -1,8 +1,8 @@
 orbit.auto_task.list	-	List every auto-task definition in this workspace.
 orbit.auto_task.mint	name:string	Mint one task now from an auto-task definition. Unconditional: the schedule, dedupe policy, and enabled flag are ignored, and the scheduler's own cursor is left untouched.
 orbit.command.exec	argv:string|string[], working_directory:string	Execute a command as an explicit argv array in an explicit working directory and return its stdout, stderr, and exit status. Requires operator capability and the workspace claim; withheld from managed runs.
-orbit.friction.add	body:string, model:string	Append an Orbit friction report under .orbit/frictions/
-orbit.friction.list	-	List Orbit friction records from .orbit/frictions/
+orbit.friction.add	body:string, model:string	Append an Orbit friction report to the Orbit store via orbit.friction.*
+orbit.friction.list	-	List Orbit friction records from the Orbit store via orbit.friction.*
 orbit.friction.update	id:string	Update triage metadata for an Orbit friction record
 orbit.pipeline.invoke	job_name:string, input:object	Submit a durable pipeline run and return immediately with its run ID.
 orbit.pipeline.wait	run_ids:string|string[]	Block until the supplied pipeline runs reach terminal state or timeout.

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -99,7 +99,7 @@
     "name": "orbit_crew_list"
   },
   {
-    "description": "Append an Orbit friction report under .orbit/frictions/",
+    "description": "Append an Orbit friction report to the Orbit store via orbit.friction.*",
     "inputSchema": {
       "additionalProperties": true,
       "properties": {
@@ -153,7 +153,7 @@
     "name": "orbit_friction_add"
   },
   {
-    "description": "List Orbit friction records from .orbit/frictions/",
+    "description": "List Orbit friction records from the Orbit store via orbit.friction.*",
     "inputSchema": {
       "additionalProperties": true,
       "properties": {

--- a/crates/orbit-common/src/friction/operations.rs
+++ b/crates/orbit-common/src/friction/operations.rs
@@ -81,7 +81,7 @@ const ADD: FrictionOperation = FrictionOperation {
     verb: FrictionVerb::Add,
     name: "add",
     tool_name: "orbit.friction.add",
-    tool_description: "Append an Orbit friction report under .orbit/frictions/",
+    tool_description: "Append an Orbit friction report to the Orbit store via orbit.friction.*",
     cli_about: "Append an Orbit friction report",
     params: &[
         ParamSpec {
@@ -154,7 +154,7 @@ const LIST: FrictionOperation = FrictionOperation {
     verb: FrictionVerb::List,
     name: "list",
     tool_name: "orbit.friction.list",
-    tool_description: "List Orbit friction records from .orbit/frictions/",
+    tool_description: "List Orbit friction records from the Orbit store via orbit.friction.*",
     cli_about: "List Orbit friction records",
     params: &[
         text_param("model", "Optional model filter"),
@@ -201,7 +201,7 @@ const STATS: FrictionOperation = FrictionOperation {
     verb: FrictionVerb::Stats,
     name: "stats",
     tool_name: "orbit.friction.stats",
-    tool_description: "Compute friction rates from .orbit/frictions/ and the task store",
+    tool_description: "Compute friction rates from the Orbit and task stores via orbit.friction.*",
     cli_about: "Compute friction rates",
     params: &[],
     rejects_agent_field: false,

--- a/crates/orbit-tools/src/builtin/orbit/friction/tests/derived_schema.rs
+++ b/crates/orbit-tools/src/builtin/orbit/friction/tests/derived_schema.rs
@@ -65,7 +65,7 @@ fn add_schema_matches_the_shipped_contract() {
     assert_eq!(schema.name, "orbit.friction.add");
     assert_eq!(
         schema.description,
-        "Append an Orbit friction report under .orbit/frictions/"
+        "Append an Orbit friction report to the Orbit store via orbit.friction.*"
     );
     assert!(schema.builtin);
     assert_eq!(
@@ -121,7 +121,7 @@ fn list_schema_matches_the_shipped_contract() {
     assert_eq!(schema.name, "orbit.friction.list");
     assert_eq!(
         schema.description,
-        "List Orbit friction records from .orbit/frictions/"
+        "List Orbit friction records from the Orbit store via orbit.friction.*"
     );
     assert_eq!(
         param_shape(&schema),
@@ -170,6 +170,11 @@ fn aggregate_verbs_take_no_parameters() {
     for verb in [FrictionVerb::Stats, FrictionVerb::Tags] {
         assert!(schema_for(verb).parameters.is_empty());
     }
+
+    assert_eq!(
+        schema_for(FrictionVerb::Stats).description,
+        "Compute friction rates from the Orbit and task stores via orbit.friction.*"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-10855](https://orbit-cli.com/tasks/ORB-10855) — Drop dead .orbit/frictions/ path from friction tool descriptions

### Description

## Problem

ORB-10853 fixed `orbit-task/references/friction.md` so it no longer tells agents that friction bodies live under `.orbit/frictions/`. The MCP/CLI tool descriptions — the next layer down, and the one `tools/list` serves — still do.

`crates/orbit-common/src/friction/operations.rs`:
- L84 `orbit.friction.add`: "Append an Orbit friction report under .orbit/frictions/"
- L157 `orbit.friction.list`: "List Orbit friction records from .orbit/frictions/"
- L204 `orbit.friction.stats`: "Compute friction rates from .orbit/frictions/ and the task store"

Those strings are the `tool_description` fields the derived MCP schema copies. Tests lock them in `crates/orbit-tools/src/builtin/orbit/friction/tests/derived_schema.rs:68` and `:124`. CLI goldens (`tool_list.plain.txt`, `tool_list.json`, `mcp_tools_list.json`) snapshot the same lies.

ORB-10680 moved live records to SQLite keyed `(workspace_id, friction_id)`. The markdown tree is read-only rollback evidence; a write there cannot change what a read returns.

## Why It Matters

Same dead-path problem the skill already fixed, one layer down. Agents that skip the skill and trust `tools/list` will still aim writes at an inert tree.

## Constraints / Notes

- Follow-up to ORB-10853 / the store migration in ORB-10680.
- Do not change friction verbs, params, or MCP scope. Description strings and the tests/goldens that quote them only.
- CLI `cli_about` lines already omit the path ("Append an Orbit friction report"); keep that split unless a single wording is clearly better.

### Acceptance Criteria

- `rg -n '\.orbit/frictions' crates/orbit-common/src/friction/operations.rs` returns no matches.
- `orbit.friction.add` / `list` / `stats` tool descriptions from `orbit tool list` do not mention `.orbit/frictions/`.
- `derived_schema.rs` asserts the new descriptions; the add/list/stats contract tests still pass.
- CLI goldens/snapshots that embed the old descriptions are regenerated: `crates/orbit-cli/tests/output_goldens/tool_list.plain.txt`, `tool_list.json`, `snapshots/mcp_tools_list.json`.
- Descriptions state that records live in the Orbit store and are reached through `orbit.friction.*`, consistent with the ORB-10853 skill wording.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Reworded the add, list, and stats friction tool descriptions to direct callers to the Orbit store through `orbit.friction.*`, without changing verbs, parameters, or MCP scope.
- Updated derived-schema contracts, including an explicit stats description assertion, and regenerated the affected CLI and MCP tool-list snapshots.
- Added the three directly affected golden/snapshot files to context_files because they snapshot the changed public description contract.
Validation:
- `cargo test -p orbit-tools derived_schema` (8 passed)
- `ORBIT_UPDATE_OUTPUT_GOLDENS=1 cargo test -p orbit-cli --test output_goldens` (2 passed; restored unrelated skill-list hash changes generated by the local skill fixture)
- `ORBIT_MCP_UPDATE_SNAPSHOT=1 cargo test -p orbit-cli --test mcp_roundtrip` (10 passed)
- `cargo test -p orbit-cli --test mcp_roundtrip` (10 passed)
- `rg -n \"\\.orbit/frictions\" crates/orbit-common/src/friction/operations.rs` (no matches)
- `make ci-fast` (passed)
Assessment: the tool discovery surfaces now match the SQLite-backed source of truth.
Friction checkpoint: no report filed; no contradicted assumption, recurring failure, incident root cause, or non-obvious gotcha meeting the filing threshold.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10855-6a811a0a`
- Behind base: 0
- Ahead of base: 1