### PR TITLE
Stop advertising ADRs on the orbit.search tool surface

### DIFF
--- a/crates/orbit-cli/src/command/mod.rs
+++ b/crates/orbit-cli/src/command/mod.rs
@@ -92,7 +92,7 @@ Operate:
   friction    Report, list, and triage friction records
 
 Observe:
-  search      Search tasks, docs, ADRs, and frictions
+  search      Search tasks, docs, and frictions
   audit       Query the audit event log
   log         Tail the unified Orbit log feed
   doctor      Diagnose workspace health (config, database, disk, indexes)

--- a/crates/orbit-cli/src/command/search.rs
+++ b/crates/orbit-cli/src/command/search.rs
@@ -5,7 +5,7 @@ use crate::command::{CommandOut, Execute, Payload};
 
 #[derive(Args)]
 #[command(
-    about = "Search tasks, docs, ADRs, and frictions",
+    about = "Search tasks, docs, and frictions",
     subcommand_precedence_over_arg = true,
     after_help = "Forms:\n  orbit search <query>\n  orbit search similar <id>\n  orbit search path <path>"
 )]
@@ -196,8 +196,8 @@ struct SearchInput {
 
 fn search_table(results: &[GlobalSearchHit]) -> crate::output::table::Table {
     use crate::output::table::{Column, Table};
-    // Each hit's kind names its own detail command (`orbit task show`,
-    // `orbit docs show` or the corresponding ADR entry).
+    // Each hit's kind names its own detail command (`orbit task show`
+    // or `orbit docs show`).
     let mut table = Table::new(vec![
         Column::new("KIND").fixed(),
         Column::new("SOURCE").fixed(),

--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -285,7 +285,7 @@
   {
     "active": true,
     "builtin": true,
-    "description": "Search tasks, docs, ADRs, and frictions. ADR entries are retrieved through the docs corpus; hybrid vector ranking applies to indexed tasks and docs.",
+    "description": "Search tasks, docs, and frictions. Decision records are indexed as ordinary docs; hybrid vector ranking applies to indexed tasks and docs.",
     "enabled": true,
     "name": "orbit.search",
     "parameters": [
@@ -308,7 +308,7 @@
         "required": false
       },
       {
-        "description": "Corpus kind: task, doc, adr, friction, or all. Default: all.",
+        "description": "Corpus kind: task, doc, friction, or all. Default: all.",
         "name": "kind",
         "param_type": "string",
         "required": false
@@ -320,7 +320,7 @@
         "required": false
       },
       {
-        "description": "AND-filter by tag. Repeat or pass an array. Applies to task, doc, friction, and ADR.",
+        "description": "AND-filter by tag. Repeat or pass an array. Applies to task, doc, and friction.",
         "name": "tag",
         "param_type": "string_list",
         "required": false

--- a/crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
@@ -6,7 +6,7 @@ orbit.friction.list	-	List Orbit friction records from the Orbit store via orbit
 orbit.friction.update	id:string	Update triage metadata for an Orbit friction record
 orbit.pipeline.invoke	job_name:string, input:object	Submit a durable pipeline run and return immediately with its run ID.
 orbit.pipeline.wait	run_ids:string|string[]	Block until the supplied pipeline runs reach terminal state or timeout.
-orbit.search	-	Search tasks, docs, ADRs, and frictions. ADR entries are retrieved through the docs corpus; hybrid vector ranking applies to indexed tasks and docs.
+orbit.search	-	Search tasks, docs, and frictions. Decision records are indexed as ordinary docs; hybrid vector ranking applies to indexed tasks and docs.
 orbit.session_log.append	kind:string, body:string	Append a workspace session-log entry (status, note, or check_later). Bodies are immutable; check_later rows wake the drain scan until resolved.
 orbit.session_log.list	-	List workspace session-log entries. Filter by kind, unresolved check_later rows, or entries at/after `since` (RFC3339).
 orbit.session_log.resolve	id:string	Mark a check_later session-log entry resolved. Other kinds cannot be resolved; bodies are never edited.

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -256,7 +256,7 @@
     "name": "orbit_friction_update"
   },
   {
-    "description": "Search tasks, docs, ADRs, and frictions. ADR entries are retrieved through the docs corpus; hybrid vector ranking applies to indexed tasks and docs.",
+    "description": "Search tasks, docs, and frictions. Decision records are indexed as ordinary docs; hybrid vector ranking applies to indexed tasks and docs.",
     "inputSchema": {
       "additionalProperties": true,
       "properties": {
@@ -269,7 +269,7 @@
           "type": "boolean"
         },
         "kind": {
-          "description": "Corpus kind: task, doc, adr, friction, or all. Default: all.",
+          "description": "Corpus kind: task, doc, friction, or all. Default: all.",
           "type": "string"
         },
         "limit": {
@@ -324,7 +324,7 @@
               "type": "string"
             }
           ],
-          "description": "AND-filter by tag. Repeat or pass an array. Applies to task, doc, friction, and ADR."
+          "description": "AND-filter by tag. Repeat or pass an array. Applies to task, doc, and friction."
         },
         "workspace": {
           "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",

--- a/crates/orbit-tools/src/builtin/orbit/search.rs
+++ b/crates/orbit-tools/src/builtin/orbit/search.rs
@@ -35,7 +35,7 @@ impl Tool for OrbitSearchTool {
             },
             ToolParam {
                 name: "kind".to_string(),
-                description: "Corpus kind: task, doc, adr, friction, or all. Default: all."
+                description: "Corpus kind: task, doc, friction, or all. Default: all."
                     .to_string(),
                 param_type: "string".to_string(),
                 required: false,
@@ -49,7 +49,7 @@ impl Tool for OrbitSearchTool {
             ToolParam {
                 name: "tag".to_string(),
                 description:
-                    "AND-filter by tag. Repeat or pass an array. Applies to task, doc, friction, and ADR."
+                    "AND-filter by tag. Repeat or pass an array. Applies to task, doc, and friction."
                         .to_string(),
                 param_type: "string_list".to_string(),
                 required: false,
@@ -83,7 +83,7 @@ impl Tool for OrbitSearchTool {
         ToolSchema {
             name: "orbit.search".to_string(),
             description:
-                "Search tasks, docs, ADRs, and frictions. ADR entries are retrieved through the docs corpus; hybrid vector ranking applies to indexed tasks and docs."
+                "Search tasks, docs, and frictions. Decision records are indexed as ordinary docs; hybrid vector ranking applies to indexed tasks and docs."
                     .to_string(),
             parameters,
             builtin: true,


### PR DESCRIPTION
## Task

[ORB-10857](https://orbit-cli.com/tasks/ORB-10857) — Stop advertising ADRs on the orbit.search tool surface

### Description

## Problem

ORB-10853 removed ADRs from the seeded skills. The surface agents actually trust — MCP `tools/list` and `orbit search --help` — still advertises them.

`crates/orbit-tools/src/builtin/orbit/search.rs`:
- L86 tool description: "Search tasks, docs, ADRs, and frictions. ADR entries are retrieved through the docs corpus…"
- L38 `kind` parameter: "Corpus kind: task, doc, adr, friction, or all." — `kind: adr` is rejected; `GlobalSearchKind::from_str("adr")` errors with "ADR corpus was retired" (`crates/orbit-core/src/command/search/tests/global.rs`).
- L52 `tag` parameter: "Applies to task, doc, friction, and ADR."

`crates/orbit-cli/src/command/search.rs:8` clap `about`: "Search tasks, docs, ADRs, and frictions".
`crates/orbit-cli/src/command/mod.rs:95` Observe-group blurb repeats the same line.

The clap `--kind` enum is already correct (`Task | Doc | Friction | All`). Only the advertised strings are stale. Agents copy `kind` values from the tool schema, so fixing skills alone still sends them into a rejected kind.

## Why It Matters

Agents read tool descriptions from `tools/list` more often than they re-read SKILL.md. A schema that lists `adr` as a valid `kind` is a live footgun, not leftover prose.

## Constraints / Notes

- Follow-up to ORB-10853. Do not restore an ADR search kind.
- Decision records remain ordinary docs (`--kind doc`). The description may say that once, the way the skill now does; it must not list `adr` as a kind.
- Goldens that snapshot `orbit tool list` / MCP tools/list will need a refresh. Do not hand-edit them to a different contract than the schema.

### Acceptance Criteria

- `orbit.search` tool description from `orbit tool list` / MCP `tools/list` does not mention ADRs as a searchable corpus or as a `--kind` value.
- `kind` parameter description lists only `task`, `doc`, `friction`, and `all` — not `adr`.
- `tag` parameter description no longer claims the filter applies to ADRs.
- `orbit search --help` and the Observe-group line in `crates/orbit-cli/src/command/mod.rs` describe tasks, docs, and frictions only.
- `GlobalSearchKind::from_str("adr")` still errors (ADR corpus stays retired); this task does not restore `--kind adr`.
- CLI goldens/snapshots that embed these strings are regenerated: `crates/orbit-cli/tests/output_goldens/tool_list.plain.txt`, `tool_list.json`, `snapshots/mcp_tools_list.json`.
- `make ci-fast` passes, including the tool-list goldens and search kind tests.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Summary
Removed stale ADR mentions from the `orbit.search` tool/CLI surface (ORB-10853 follow-up).

## Changes
- `crates/orbit-tools/src/builtin/orbit/search.rs`: tool description now "Search tasks, docs,
  and frictions. Decision records are indexed as ordinary docs; hybrid vector ranking applies to
  indexed tasks and docs."; `kind` param description drops `adr` ("Corpus kind: task, doc,
  friction, or all."); `tag` param description drops ADR ("Applies to task, doc, and friction.").
- `crates/orbit-cli/src/command/search.rs`: clap `about` → "Search tasks, docs, and frictions";
  fixed a stale doc-comment on `search_table` that still described a non-existent "ADR entry"
  detail command.
- `crates/orbit-cli/src/command/mod.rs`: Observe-group `--help` line → "search Search tasks,
  docs, and frictions".
- Regenerated goldens: `crates/orbit-cli/tests/output_goldens/tool_list.{json,plain.txt}` and
  `crates/orbit-cli/tests/snapshots/mcp_tools_list.json` via
  `ORBIT_UPDATE_OUTPUT_GOLDENS=1 cargo test -p orbit-cli --test output_goldens` and
  `ORBIT_MCP_UPDATE_SNAPSHOT=1 cargo test -p orbit-cli --test mcp_roundtrip`, diff reviewed —
  only the ADR-text lines changed.
- `GlobalSearchKind::from_str("adr")` untouched — still rejected (verified via
  `adr_search_kind_is_rejected` test), no ADR search kind restored.

## Out of scope (flagged, not fixed)
Regenerating goldens also touched `skill_list.json` / `skill_list.plain.txt` (stale
`content_hash` values for the `orbit`/`orbit-search`/`orbit-task` skills). Confirmed via
`sha256sum` that this drift is pre-existing — caused by ORB-10853's SKILL.md edits never being
followed by a golden regen — and is unrelated to this task's diff. Reverted those two files to
keep this change scoped to the search surface; filed friction F2026-08-080 with repro/root-cause
so a follow-up can regenerate them.

## Validation
- `make ci-fast`: pass.
- `cargo fmt --all -- --check`: pass.
- `cargo clippy -p orbit-cli -p orbit-tools --all-targets -- -D warnings`: pass.
- `cargo test -p orbit-cli --test output_goldens plain_and_json_forms_match_their_goldens`: pass
  (after reverting the unrelated skill_list drift).
- `cargo test -p orbit-cli --test mcp_roundtrip mcp_serve_tools_list_matches_production_snapshot`: pass.
- `cargo test -p orbit-core adr_search_kind_is_rejected`: pass.
- Manually ran `orbit search --help` — confirms "Search tasks, docs, and frictions" and no ADR
  mention.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10857-6a811a0a`
- Behind base: 0
- Ahead of base: 1