### PR TITLE
Decouple the skill_list output golden from bundled skill content hashes

### DIFF
--- a/crates/orbit-cli/tests/output_goldens.rs
+++ b/crates/orbit-cli/tests/output_goldens.rs
@@ -188,6 +188,59 @@ fn redact(text: &str, home: &Path) -> String {
     text.replace(&home.display().to_string(), "<HOME>")
 }
 
+/// `skill list`'s `content_hash` column is a SHA-256 digest over the bundled
+/// skill's own `SKILL.md` (`crates/orbit-core/src/command/skill.rs`'s
+/// `DEFAULT_SKILL_FILES`), so it changes whenever unrelated skill prose is
+/// edited even though no rendering code did. Redact it like `<TIMESTAMP>`/
+/// `<HOME>` above — but scoped to `skill_list` only, so the other three
+/// commands (which carry no content-derived field; see sibling goldens)
+/// still pin their output byte-for-byte.
+///
+/// Extracts the true hash(es) from the `--json` form first and asserts each
+/// is a well-formed 64-char lowercase hex digest, so this redaction cannot
+/// silently swallow a malformed or missing field. It also cross-checks that
+/// the plain form's 10-char `HASH` column is a genuine prefix of that same
+/// digest before redacting it, so the truncation performed by
+/// `crates/orbit-cli/src/command/skill/list.rs`'s rendering path stays
+/// covered rather than becoming a no-op once the hash itself is redacted.
+fn redact_skill_content_hash(json_text: &str, plain_text: &str) -> (String, String) {
+    static FULL_HASH: OnceLock<Regex> = OnceLock::new();
+    let full_hash = FULL_HASH
+        .get_or_init(|| Regex::new(r#""content_hash": "([0-9a-f]{64})""#).expect("valid regex"));
+
+    let hashes: Vec<String> = full_hash
+        .captures_iter(json_text)
+        .map(|caps| caps[1].to_string())
+        .collect();
+    assert!(
+        !hashes.is_empty(),
+        "no content_hash field found in skill_list.json output:\n{json_text}"
+    );
+    for hash in &hashes {
+        assert!(
+            hash.len() == 64
+                && hash
+                    .chars()
+                    .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+            "content_hash is not a well-formed 64-char lowercase hex digest: {hash}"
+        );
+    }
+
+    let mut plain_redacted = plain_text.to_string();
+    let mut json_redacted = json_text.to_string();
+    for hash in &hashes {
+        let short = &hash[..10];
+        assert!(
+            plain_text.contains(short),
+            "plain form's truncated HASH column ({short}) is not a prefix of the json form's \
+             content_hash ({hash}); truncation rendering coverage would be lost by redaction"
+        );
+        plain_redacted = plain_redacted.replace(short, "<CONTENT_HASH>");
+        json_redacted = json_redacted.replace(hash.as_str(), "<CONTENT_HASH>");
+    }
+    (json_redacted, plain_redacted)
+}
+
 fn golden_path(file_name: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/output_goldens")
@@ -225,13 +278,21 @@ fn plain_and_json_forms_match_their_goldens() {
 
     for command in COMMANDS {
         let plain = fixture.run(command.args, &[]);
-        let plain_stdout = fixture.redact(&String::from_utf8_lossy(&plain.stdout));
-        assert_golden(&format!("{}.plain.txt", command.name), &plain_stdout);
+        let mut plain_stdout = fixture.redact(&String::from_utf8_lossy(&plain.stdout));
 
         let mut json_args = command.args.to_vec();
         json_args.push("--json");
         let json = fixture.run(&json_args, &[]);
-        let json_stdout = fixture.redact(&String::from_utf8_lossy(&json.stdout));
+        let mut json_stdout = fixture.redact(&String::from_utf8_lossy(&json.stdout));
+
+        if command.name == "skill_list" {
+            let (redacted_json, redacted_plain) =
+                redact_skill_content_hash(&json_stdout, &plain_stdout);
+            json_stdout = redacted_json;
+            plain_stdout = redacted_plain;
+        }
+
+        assert_golden(&format!("{}.plain.txt", command.name), &plain_stdout);
         assert_golden(&format!("{}.json", command.name), &json_stdout);
     }
 }

--- a/crates/orbit-cli/tests/output_goldens/skill_list.json
+++ b/crates/orbit-cli/tests/output_goldens/skill_list.json
@@ -1,6 +1,6 @@
 [
   {
-    "content_hash": "f4695c39887be297d40bc66c002a627c2fdb6c8f44432366fb63a6eb42f4bdd5",
+    "content_hash": "<CONTENT_HASH>",
     "id": "orbit",
     "meta": null,
     "path": "<HOME>/.orbit/skills/orbit"

--- a/crates/orbit-cli/tests/output_goldens/skill_list.plain.txt
+++ b/crates/orbit-cli/tests/output_goldens/skill_list.plain.txt
@@ -1,1 +1,1 @@
-orbit	f4695c3988	0	
+orbit	<CONTENT_HASH>	0	


### PR DESCRIPTION
## Task

[ORB-10861](https://orbit-cli.com/tasks/ORB-10861) — Decouple the skill_list output golden from bundled skill content hashes

### Description

## Problem

`orbit-cli::output_goldens plain_and_json_forms_match_their_goldens` is failing in CI:

```
crates/orbit-cli/tests/output_goldens/skill_list.plain.txt drifted from its golden.
  left: "orbit\t384e4ab57b\norbit-search\t4cd5b13178\norbit-task\ta7c67abfa6\norbit-workflow\t2384d0e65b\n"
 right: "orbit\t5687224c6f\norbit-search\tb9e81b8fb3\norbit-task\t4828d77a48\norbit-workflow\t2384d0e65b\n"
```

Three of the four rows drifted; `orbit-workflow` is unchanged. The drifting column is
the per-skill `content_hash` (visible in full in `skill_list.json`, e.g.
`"content_hash": "f4695c3988..."` for `<HOME>/.orbit/skills/orbit`). The fixture calls
`orbit workspace init`, which seeds the default skill catalog, and `skill list` renders a
SHA-256 over each seeded skill's own markdown.

So the golden fails whenever the bundled skill markdown for `orbit`, `orbit-search`, or
`orbit-task` is edited — exactly the pattern here, where the untouched `orbit-workflow`
row held steady. The rendering under test did not change; only the seed content did.

## Why It Matters

This suite exists to catch *rendering* regressions in the plain/json output modes
(ORB-10571). Coupling it to skill-catalog content makes it fire on unrelated prose edits,
which trains everyone to reflexively run
`ORBIT_UPDATE_OUTPUT_GOLDENS=1 cargo test -p orbit-cli --test output_goldens` — the exact
reflex the test's own module doc warns against ("Regenerating is a deliberate act, not a
fix for a failing test"). A golden that cries wolf stops catching the real regression.
Right now it is also blocking the whole workspace test run: nextest reports
`1247/2738 tests were not run due to test failure`.

## Constraints / Notes

- Preferred fix: make the digest deterministic for this fixture rather than re-pinning
  content. Either seed a fixed, test-owned skill catalog instead of relying on
  `workspace init`'s default seed, or redact the hash the way `redact()` already handles
  timestamps and `<HOME>` — a `<CONTENT_HASH>` placeholder alongside `<TIMESTAMP>`.
  If the hash is redacted, keep a separate assertion that it is a well-formed digest, so
  the column is not silently dropped from coverage.
- Do not "fix" this by regenerating goldens alone. That restores green until the next
  skill-prose edit and leaves the coupling in place.
- Sweep all three `skill_list.*` goldens (`plain.txt`, `json`, `table.txt`) — the JSON
  form carries the full 64-char hash and the table form is generated from
  `crates/orbit-cli/src/output/tests/table.rs`, so both drift for the same reason.
- Check whether the sibling `tool_list` / `policy_list` / `task_list` goldens carry any
  similarly content-derived field; fix them the same way if so.
- No [REDACTED_ENV]-facing CLI behavior should change: `skill list` must still print the real
  content hash in normal use.

### Acceptance Criteria

- `cargo test -p orbit-cli --test output_goldens` passes on a clean checkout with no `ORBIT_UPDATE_OUTPUT_GOLDENS=1` regeneration step.
- Editing the body of a bundled skill markdown file (e.g. add a line to the `orbit-task` skill) and re-running `cargo test -p orbit-cli --test output_goldens` still passes — the golden no longer tracks skill content.
- Editing an actual rendering path (e.g. change a column separator or header in the plain sink) still fails the suite, proving coverage was not weakened into a no-op.
- If the content hash is redacted rather than pinned, a test asserts the redacted field was a well-formed 64-char lowercase hex digest before substitution.
- `cargo nextest run --workspace --locked` completes the full run with no failure in `orbit-cli::output_goldens`.
- `skill list` and `skill list --json` run by hand against a real workspace still print the true per-skill content hash (unchanged [REDACTED_ENV]-facing behavior).

## Execution Summary

<details>
<summary>Click to expand</summary>

Decoupled the skill_list output golden from bundled skill markdown content.

Root cause: `content_hash` in `skill list`/`skill list --json` is a SHA-256 over
each seeded skill's own SKILL.md (crates/orbit-core/src/command/skill.rs's
DEFAULT_SKILL_FILES, computed in crates/orbit-store/src/file/skill_store/mod.rs's
load_skill_from_dir). `output_goldens.rs` seeds via `orbit workspace init` (the
real bundled catalog), so any prose edit to the shipped skill markdown drifted
the goldens even though no rendering code changed.

Fix (redaction, per the task's preferred option): added
`redact_skill_content_hash()` to crates/orbit-cli/tests/output_goldens.rs,
applied only to the skill_list command's plain/json outputs (the other three
commands carry no content-derived field - verified). It extracts the true
content_hash(es) from the --json output via regex, asserts each is a
well-formed 64-char lowercase hex digest, cross-checks the plain form's
10-char HASH column is a genuine prefix of that digest (so the truncation
in command/skill/list.rs stays covered), then replaces both with a
`<CONTENT_HASH>` placeholder before comparing to the golden - same pattern as
the existing `<TIMESTAMP>`/`<HOME>` redaction.

Updated goldens: skill_list.plain.txt and skill_list.json now carry
`<CONTENT_HASH>` instead of the pinned hash. skill_list.table.txt
(crates/orbit-cli/src/output/tests/table.rs) needed no change - its
skill_list() fixture is fully synthetic hardcoded test data, never derived
from the real skill catalog, so it was never coupled to content in the first
place (confirmed by reading the source and by table_form_matches_goldens_at_a_pinned_width
passing unchanged). Swept task_list/tool_list/policy_list goldens too: none
carry a content-derived/hash field.

No production code changed; skill list / skill list --json still print the
true content_hash in normal use (verified by hand against a fresh workspace).

Verified against all acceptance criteria:
- cargo test -p orbit-cli --test output_goldens passes clean.
- Appended a line to crates/orbit-core/assets/skills/orbit/SKILL.md and
  reran the suite (recompiled orbit-core) - still passes; reverted after.
- Temporarily renamed the JSON "path" field to "route" in
  command/skill/list.rs - suite failed as expected (rendering regressions
  still caught); reverted after.
- Added an explicit assert! that each extracted content_hash is 64 lowercase
  hex chars before substitution.
- cargo nextest run -p orbit-cli --locked: 377/377 passed, including
  output_goldens::plain_and_json_forms_match_their_goldens.
- make ci-fast and make ci-lint (workspace clippy, -D warnings) both pass.

Scope: only the three context_files that needed edits were touched
(output_goldens.rs, skill_list.plain.txt, skill_list.json); skill_list.table.txt
was inspected but required no change.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10861-6a812134`
- Behind base: 0
- Ahead of base: 1