### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -2,6 +2,7 @@
 title: Routines — Design
 owner: claude
 last_updated: 2026-08-15
+last_validated: 2026-08-16
 status: Accepted
 feature: routines
 doc_role: design
@@ -97,8 +98,9 @@ as absent; it never degrades into "fire with defaults".
 
 ### Seeded defaults and ownership
 
-`orbit workspace init` seeds `auto_task_scheduler.yaml`, `task_triage.yaml`, and
-`ship_sweep.yaml` with a workspace-unique name, the resolved host pin, and
+`orbit workspace init` seeds `auto_task_scheduler.yaml`, `task_triage.yaml`,
+`task_pilot.yaml`, `ship_sweep.yaml`, and `worktree_gc.yaml` with a workspace-unique
+name, the resolved host pin, and
 `enabled: false`. The definition's versioned `enabled` field is the opt-in: changing it
 to `true` deliberately grants that scheduled capability in the workspace.
 

--- a/docs/design/routines/3_vision.md
+++ b/docs/design/routines/3_vision.md
@@ -2,6 +2,7 @@
 title: Routines — Vision
 owner: claude
 last_updated: 2026-08-15
+last_validated: 2026-08-16
 status: Draft
 feature: routines
 doc_role: vision

--- a/docs/design/routines/4_decisions.md
+++ b/docs/design/routines/4_decisions.md
@@ -2,13 +2,14 @@
 title: Routines — Decisions
 owner: claude
 last_updated: 2026-08-12
+last_validated: 2026-08-16
 status: Accepted
 feature: routines
 doc_role: decisions
 type: design
 summary: Decision log for the routines scheduler, including default seeding and workspace-local shipment.
 tags: [routines, scheduler]
-paths: ["crates/orbit-core/src/routines/**", "crates/orbit-remote/src/routines.rs"]
+paths: ["crates/orbit-core/src/routines/**", "crates/orbit-cmd/src/registry_routines.rs", "crates/orbit-cmd/src/registry_runtime.rs", "crates/orbit-registry/src/**"]
 related_features: [routines, activity-job, host-registry]
 related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ORB-10739]
 ---
@@ -174,9 +175,9 @@ Store the supported whole-minute cadence in host-local `~/.orbit/clock.toml` and
 - [ORB-10270] — completed [Committed-routine ownership with host-local cursors](../host-registry/4_decisions.md#committed-routine-ownership-with-host-local-cursors)'s runtime enforcement: committed pins resolve through
   current registry or classified spoke-cache data before scheduler mutation, diagnostics
   remain explicit under degradation, and reassignment starts with a fresh baseline.
-- [ORB-10319] — moved the Remote-specific providers that source identity, registry/cache,
-  workspace bindings, and runtimes into `orbit-remote`; the accepted routine decisions and
-  Core scheduler semantics are unchanged.
+- [ORB-10319] — moved the registry-specific providers that source identity, workspace
+  bindings, and runtimes into `orbit-cmd` over `orbit-registry`; the accepted routine
+  decisions and Core scheduler semantics are unchanged.
 - [ORB-10138] — exposed per-routine scheduler health over the dashboard HTTP API
   (`GET /api/routines`), realizing the single-host half of the §7 cross-host-visibility
   vision. Read-only projection of `routine_statuses`; no new ADR (no new architectural

--- a/docs/design/routines/references/glossary.md
+++ b/docs/design/routines/references/glossary.md
@@ -1,6 +1,7 @@
 ---
 type: glossary
 summary: Vocabulary for the routines scheduler feature.
+last_validated: 2026-08-16
 tags: [routines, scheduler]
 ---
 

--- a/docs/design/task-artifacts/1_overview.md
+++ b/docs/design/task-artifacts/1_overview.md
@@ -4,6 +4,7 @@ type: design
 title: "Task Artifacts — Overview"
 owner: codex
 last_updated: 2026-05-17
+last_validated: 2026-08-16
 status: Draft
 feature: task-artifacts
 doc_role: overview
@@ -31,8 +32,8 @@ The v2 artifact matches the work to its readers:
 
 - `task.yaml` is a small, mergeable envelope of metadata.
 - Markdown sidecars (`description.md`, `acceptance.md`, `plan.md`, `execution-summary.md`) hold prose and long-form human/agent reasoning.
-- Append-only logs (`events.jsonl`, `comments.jsonl`, `review-threads/`) carry events, comments, and review traffic without rewriting the envelope.
-- `ORB-00000` IDs are stable inside the configured allocation authority and explicitly scoped when tasks cross registries; bare task IDs remain local search keys, in line with the graph-attribution removal in [T20260506-11].
+- Append-only logs (`events.jsonl`, `comments.jsonl`) carry events and comments without rewriting the envelope.
+- The default `ORB-00000` format uses a five-digit minimum width inside the configured allocation authority and explicitly scopes tasks when they cross registries; bare task IDs remain local search keys, in line with the graph-attribution removal in [T20260506-11].
 - Workspace task bundles live in one canonical local store under `~/.orbit/tasks/workspaces/<workspace-id>/`; each checkout gets a lightweight `.orbit/tasks/` symlink projection.
 - Local execution bindings stay in `~/.orbit/tasks/index.sqlite` rather than leaking into synced task identity.
 
@@ -57,7 +58,6 @@ A task bundle is the complete on-disk representation of one task. The canonical 
         execution-summary.md
         events.jsonl
         comments.jsonl
-        review-threads/
         artifacts/
 
 .orbit/
@@ -91,7 +91,7 @@ V2 bundles do not carry `legacy_ids` and lookup surfaces do not resolve old `T<Y
 
 ### 2.5 Task event stream
 
-Lifecycle changes, comments, review messages, and automation updates are naturally append-heavy. The store keeps those out of YAML arrays in append-only JSON Lines files (`events.jsonl`, `comments.jsonl`) and per-thread records under `review-threads/`, so concurrent writes can be merged intentionally and audited without rewriting the envelope.
+Lifecycle changes, comments, and automation updates are naturally append-heavy. The store keeps those out of YAML arrays in append-only JSON Lines files (`events.jsonl`, `comments.jsonl`), so concurrent writes can be merged intentionally and audited without rewriting the envelope.
 
 ### 2.6 Typed relations
 

--- a/docs/design/task-artifacts/2_design.md
+++ b/docs/design/task-artifacts/2_design.md
@@ -4,6 +4,7 @@ type: design
 title: "Task Artifacts — Design"
 owner: codex
 last_updated: 2026-08-09
+last_validated: 2026-08-16
 status: Draft
 feature: task-artifacts
 doc_role: design
@@ -169,7 +170,7 @@ schema_version: 1
 workspace_id: orbit-a3f9c2
 ```
 
-`workspace_id` is assigned once as `<slug>-<6char>`, where the slug is human-readable and the suffix prevents collisions. It survives repo renames and moves because Orbit reads it from `.orbit/config.yaml`, not from the directory name, remote URL, or path hash.
+`workspace_id` is assigned once in canonical `ws_<name>` form; legacy installations may use `<slug>-<6char>`. It survives repo renames and moves because Orbit reads it from `.orbit/config.yaml`, not from the directory name, remote URL, or path hash.
 
 The workspace projection under `.orbit/tasks/<task-id>` is a symlink to the canonical bundle. Task writes through either the canonical path or the projection update the same files; there is no second writable copy and no bundle-level divergence protocol. If `.orbit/tasks/` is deleted, Orbit rebuilds the symlinks from `.orbit/config.yaml` and `index.sqlite`. If `.orbit/config.yaml` is lost, Orbit prompts to rebind by matching the current path, repo root, and optional remote fingerprints against `index.sqlite`; if no confident match exists, the user chooses or creates a workspace binding.
 


### PR DESCRIPTION
## Task

[ORB-10864](https://orbit-cli.com/tasks/ORB-10864) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Selected the exact six oldest in-scope documents with no `last_validated` key, ordered by stable path tie-break: `docs/design/routines/2_design.md`, `docs/design/routines/3_vision.md`, `docs/design/routines/4_decisions.md`, `docs/design/routines/references/glossary.md`, `docs/design/task-artifacts/1_overview.md`, and `docs/design/task-artifacts/2_design.md`. No dated document was selected.
- `routines/2_design.md`: verified the scheduler, clock, registry, store, and CLI claims with `test -e`, `rg`, and source reads; added `last_validated: 2026-08-16` and corrected the seeded-default list to the five defaults actually declared by `DEFAULT_ROUTINE_FILES` (`auto_task_scheduler`, `task_triage`, `task_pilot`, `ship_sweep`, `worktree_gc`).
- `routines/3_vision.md` and `routines/references/glossary.md`: verified the referenced routine loader/sweep/status/clock surfaces and stamped them; no prose changes were needed.
- `routines/4_decisions.md`: verified the current composition in `orbit-cmd` over `orbit-registry`; stamped the document, replaced the stale nonexistent `crates/orbit-remote/src/routines.rs` path, and corrected the ORB-10319 note to match the current code boundary.
- `task-artifacts/1_overview.md`: verified the v2 bundle constants/types, bundle layout writer, task registry, projection, and search surfaces; stamped it, removed retired `review-threads/` from the live layout/log description, and corrected task IDs to the current five-digit minimum-width behavior.
- `task-artifacts/2_design.md`: verified bundle IO, envelope/relation types, registry schema/indexes, allocator, projection, crash handling, and lexical/semantic search code; stamped it and corrected workspace identity to canonical `ws_<name>` with legacy `<slug>-<6char>` support.
- No selected document was frontmatter-less, so no metadata migration was performed. No selected doc or claim was left unvalidated.
Validation: `make ci-fast` passed (fmt check, generated doc index check, installer/security checks, dependency/import/terminal/history/stability/artifact/error/orphan/asset guards, and plugin validation). `git diff --check` passed. The final diff contains only the six selected docs; forbidden paths (`.orbit/adrs/`, `CHANGELOG.md`, `docs/changelogs/`, `docs/design/_archive/`, and generated state) were unchanged.
Assessment: bounded documentation upkeep completed with evidence-backed corrections only; no new sections, documents, metadata fields, sidecars, or validation-marker systems were introduced.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10864-6a812371`
- Behind base: 0
- Ahead of base: 1