### PR TITLE
CI: checkout pins a deletable branch name, and the failure hook crashes instead of filing a task

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -42,7 +42,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          # PR head SHA, not the branch name GitHub deletes on merge, and
+          # not github.sha (the ephemeral merge commit).
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-05-07)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          # PR head SHA, not the branch name GitHub deletes on merge, and
+          # not github.sha (the ephemeral merge commit).
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-05-07)
@@ -75,7 +77,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          # PR head SHA, not the branch name GitHub deletes on merge, and
+          # not github.sha (the ephemeral merge commit).
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-05-07)
@@ -129,7 +133,9 @@ jobs:
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          # PR head SHA, not the branch name GitHub deletes on merge, and
+          # not github.sha (the ephemeral merge commit).
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-05-07)
@@ -210,7 +216,9 @@ jobs:
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          # PR head SHA, not the branch name GitHub deletes on merge, and
+          # not github.sha (the ephemeral merge commit).
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-05-07)
@@ -275,22 +283,81 @@ jobs:
           WORKFLOW: ${{ format('{0}', github.workflow) }}
           PR_NUMBER: ${{ format('{0}', github.event.pull_request.number) }}
           BRANCH: ${{ format('{0}', github.head_ref) }}
-          SHA: ${{ format('{0}', github.sha) }}
+          SHA: ${{ format('{0}', github.event.pull_request.head.sha) }}
           RUN_ID: ${{ format('{0}', github.run_id) }}
         run: |
-          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}"
+          # This step must never fail the job. A missing checkout, a merged PR,
+          # or a missing orbit binary are skip conditions, not new reds.
+          set +e
+          report() { echo "Create orbit task on CI failure: $*"; }
+
+          if [ ! -f Cargo.toml ]; then
+            report "skipping because no checkout is present"
+            exit 0
+          fi
+
+          if [ -n "${PR_NUMBER:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ] && command -v gh >/dev/null 2>&1; then
+            merged="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .merged 2>/dev/null)"
+            if [ "$merged" = "true" ]; then
+              report "skipping because PR #${PR_NUMBER} is already merged"
+              exit 0
+            fi
+          fi
+
+          orbit_bin=""
+          if command -v orbit >/dev/null 2>&1; then
+            orbit_bin="$(command -v orbit)"
+          elif [ -x "${HOME}/.orbit/bin/orbit" ]; then
+            orbit_bin="${HOME}/.orbit/bin/orbit"
+          elif [ -x target/debug/orbit ]; then
+            orbit_bin="$(pwd)/target/debug/orbit"
+          elif [ -x target/release/orbit ]; then
+            orbit_bin="$(pwd)/target/release/orbit"
+          fi
+          if [ -z "$orbit_bin" ]; then
+            report "skipping because orbit CLI is not available (will not compile from source)"
+            exit 0
+          fi
+
+          workspace="${GITHUB_WORKSPACE:-}"
+          case "$workspace" in
+            /*) ;;
+            *) workspace="$(pwd -P)" ;;
+          esac
+
+          run_url="${GITHUB_SERVER_URL:-}/${GITHUB_REPOSITORY:-}/actions/runs/${RUN_ID:-}"
+          description="$(printf '%s\n' \
+            "## Problem" \
+            "CI failed on PR #${PR_NUMBER} (\`${BRANCH}\`)." \
+            "" \
+            "Commit: \`${SHA}\`" \
+            "Run: ${run_url}")"
+
           payload="$(jq -n \
-            --arg title "CI failure: $WORKFLOW on PR #$PR_NUMBER" \
-            --arg description "## Problem\nCI failed on PR #$PR_NUMBER (\`$BRANCH\`).\n\nCommit: \`$SHA\`\nRun: $run_url" \
-            --arg branch "$BRANCH" \
+            --arg title "CI failure: ${WORKFLOW} on PR #${PR_NUMBER}" \
+            --arg description "$description" \
+            --arg branch "${BRANCH:-}" \
+            --arg workspace "$workspace" \
             '{
               title: $title,
               description: $description,
               acceptance_criteria: ["CI passes on branch \($branch)"],
-              context: ".github/workflows/ci.yml",
-              workspace: ".",
+              context_files: ["file:.github/workflows/ci.yml"],
+              workspace: $workspace,
               priority: "high",
-              type: "bug"
+              type: "bug",
+              model: "github-actions",
+              tags: ["ci"]
             }'
           )"
-          cargo run -p orbit-cli --bin orbit -- tool run orbit.task.add --input "$payload"
+          if [ -z "$payload" ]; then
+            report "skipping because payload construction failed"
+            exit 0
+          fi
+
+          "$orbit_bin" tool run orbit.task.add --input "$payload"
+          status=$?
+          if [ "$status" -ne 0 ]; then
+            report "orbit.task.add failed with exit ${status}; not failing the job"
+          fi
+          exit 0


### PR DESCRIPTION
## Task

[ORB-10865](https://orbit-cli.com/tasks/ORB-10865) — CI: checkout pins a deletable branch name, and the failure hook crashes instead of filing a task

### Description

## Problem

Run [31921691900](https://github.com/danieljhkim/orbit/actions/runs/31921691900) (`CI`, PR #1034, branch `orbit/ORB-10856-6a811e17`) went red and produced no usable signal: the `ci` job could not check out, and the failure handler whose whole job is to file an Orbit task then crashed on its own.

Sequence, from the run logs and the PR record:

- `02:21:04` — `ci` job starts and runs `Free up runner disk space` (68s).
- `02:21:39` — PR #1034 merges; GitHub deletes the head branch `orbit/ORB-10856-6a811e17`.
- `02:22:14` — `actions/checkout` runs, pinned to `ref: github.head_ref` — a branch *name*. It fetches `+refs/heads/orbit/ORB-10856-6a811e17*`, which no longer exists. Three attempts, each `The process '/usr/bin/git' failed with exit code 1`.
- Every downstream step is skipped. `Create orbit task on CI failure` fires on `if: failure()`, runs `cargo run -p orbit-cli` in an empty workspace, and dies with `error: could not find Cargo.toml in /home/runner/work/orbit/orbit` (exit 101).

Two independent defects.

### 1. PR checkouts pin a mutable branch name

All five checkout steps use `ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}` — [ci.yml:46](.github/workflows/ci.yml), `:78`, `:132`, `:213`, and [ci-macos.yml:45](.github/workflows/ci-macos.yml).

`github.head_ref` is a branch name that can vanish mid-run. Delete-branch-on-merge makes that routine, and any slow pre-checkout step widens the window: the `ci` job spends 68s reclaiming disk before checking out, which is exactly why it alone failed — `linux-sandbox` checked out at `02:21:06`, 33 seconds before the merge, and passed. `github.event.pull_request.head.sha` names identical content immutably and cannot be deleted out from under a run.

### 2. The failure handler is unguarded and self-defeating

[ci.yml:272-296](.github/workflows/ci.yml) fires on `if: failure() && github.event_name == 'pull_request'` — any failed step, including a failed checkout — and then depends on the checkout it cannot assume, via `cargo run -p orbit-cli --bin orbit -- tool run orbit.task.add`. With an empty tree it exits 101, so the one mechanism meant to make a red PR visible stays silent precisely when the job died early. Building `orbit-cli` from source inside a failure handler is a weak dependency in its own right: on a cold cache that is minutes of compiling after a job that already failed, and it inherits every build breakage the handler is supposed to report.

The payload has separate problems, visible by reading it against the current `orbit.task.add` schema in `crates/orbit-tools/src/builtin/orbit/task/add.rs`:

- `context: ".github/workflows/ci.yml"` — `context` is not a parameter. The field is `context_files`.
- `workspace: "."` — the selector takes a registered name, a `ws_*` id, or an absolute path. `.` is none of those.
- `description` is assembled with `jq --arg` from a string containing `\n`. `--arg` binds a raw string, so the task receives literal backslash-n rather than line breaks.
- No `model`, so anything it files carries no agent provenance.

A lexical search of the task store for this hook's own description text (`CI failed on PR ...`) returns nothing, which suggests it has never successfully filed a task.

## Why It Matters

Both halves attack the same feedback loop. Defect 1 manufactures red runs that carry no information — a PR that merged cleanly leaves behind a failed required check, and repeated noise like that is how a genuinely broken gate gets waved through. Defect 2 means the automated reporting path is dead: the periodic `[auto-task] Remediate current GitHub Actions failures` task (ORB-10823, ORB-10795, ORB-10638, ORB-10517) is explicitly written to treat this hook as an input and coverage signal, so a hook that never fires quietly removes a leg from that remediation loop.

## Constraints / Notes

- Prefer resolving to an immutable SHA over adding retries or `continue-on-error` to checkout. Keep the non-PR branch behavior (`github.ref_name`) as it is.
- The current `head_ref` pin is presumably deliberate — it checks out the PR head rather than the ephemeral merge commit `actions/checkout` would use by default. Preserve that intent; `github.event.pull_request.head.sha` is the same commit by an immutable name. Note that `github.sha` on a `pull_request` event is the *merge* commit, not the head, so it is not a drop-in substitute (the handler already exports it as `SHA`, which is worth correcting in the same pass).
- The failure handler must never itself fail the job or mask the real cause. It should be reachable only when there is a checkout to work with, and should degrade to a clear log line otherwise.
- Consider whether a red run on an already-merged PR should file a task at all. Filing a high-priority bug for a PR that merged 35 seconds earlier is noise; detecting that state and exiting cleanly is a legitimate outcome.
- Whether `cargo run -p orbit-cli` remains the right invocation is open. A prebuilt binary, a `gh api` call, or simply skipping the build are all reasonable; the requirement is that the reporting path not depend on the workspace compiling.
- `.github/workflows/release.yml` and `smoke-plugin-install.yml` use `github.ref_name` only, on tag/push events — out of scope, verified.
- Do not weaken any gate to get green. Nothing here justifies `continue-on-error` on a real check.

## Acceptance Criteria Notes

Criterion 2 needs a live PR run to observe; the PR carrying this fix is the natural place to check it.

### Acceptance Criteria

- `rg 'github\.head_ref' .github/workflows/` returns no match in any `ref:` position across ci.yml and ci-macos.yml; each pull_request checkout resolves an immutable commit SHA instead.
- In the CI run for the PR carrying this fix, the `Fetching the repository` log line references a commit SHA rather than `+refs/heads/<branch>*`, and the checked-out `HEAD` equals `github.event.pull_request.head.sha`. Paste both log lines into the execution summary.
- The `Create orbit task on CI failure` step cannot fail its job: with no checkout present it exits 0 and logs why it is skipping. Demonstrate by running the step's script in an empty directory with the run's env vars set (`WORKFLOW`, `PR_NUMBER`, `BRANCH`, `SHA`, `RUN_ID`, `GITHUB_SERVER_URL`, `GITHUB_REPOSITORY`) and showing exit status 0.
- The constructed payload contains only parameters accepted by `orbit.task.add` as defined in `crates/orbit-tools/src/builtin/orbit/task/add.rs` — no `context` key — and names a workspace selector the schema accepts (a registered name, a `ws_*` id, or an absolute path such as `$GITHUB_WORKSPACE`).
- The description carries real line breaks: `jq -r .description <<<"$payload" | wc -l` reports more than 1, and no literal backslash-n survives (`jq -r .description <<<"$payload" | rg -q '\\\\n'` exits non-zero).
- The payload sets `model` so a filed task carries agent provenance.
- The happy path still works: with a real checkout present, running the step's script end to end files a task whose description renders with headings and line breaks. Record the created task ID in the execution summary, or state explicitly how it was verified without writing to the store.
- The `SHA` exported to the handler identifies the commit CI actually tested, not the pull_request merge commit; state in the execution summary which context expression was chosen and why.
- `make ci-fast` passes, and CI is green on the PR carrying the change.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- All five PR `actions/checkout` `ref:` values (ci.yml ×4, ci-macos.yml ×1) now resolve `github.event.pull_request.head.sha` instead of `github.head_ref`. Non-PR events still use `github.ref_name`.
- `Create orbit task on CI failure` no longer runs `cargo run`. It always exits 0. It skips with a log line when `Cargo.toml` is missing, when `gh` reports the PR already merged, or when no `orbit` binary is on PATH / `~/.orbit/bin` / `target/{debug,release}`.
- Payload keys match `orbit.task.add`: `context_files` (not `context`), absolute `workspace` (`$GITHUB_WORKSPACE`), `model: github-actions`, and a `description` built with `printf` so `jq --arg` stores real newlines.
- Handler `SHA` env is `github.event.pull_request.head.sha`.

Strategic decisions:
- SHA expression: `github.event.pull_request.head.sha`. Same tree `github.head_ref` named, but immutable after branch delete. `github.sha` on `pull_request` is the merge commit, which is not what CI tests once `ref:` is the head SHA.
- Did not add `continue-on-error` on checkout or on real checks. The handler degrades in-script (`set +e` + `exit 0`).
- Did not extract a new script file; kept the handler inline so `context_files` stayed the intended boundary.

Validation:
- `rg 'github\.head_ref' .github/workflows/` hits only `BRANCH: ${{ format('{0}', github.head_ref) }}` in ci.yml (not a `ref:`). Every `ref:` uses `github.event.pull_request.head.sha`.
- Empty-dir handler run (env: WORKFLOW, PR_NUMBER, BRANCH, SHA, RUN_ID, GITHUB_SERVER_URL, GITHUB_REPOSITORY): logged `Create orbit task on CI failure: skipping because no checkout is present` and exited 0.
- Constructed payload keys: title, description, acceptance_criteria, context_files, workspace (absolute), priority, type, model, tags. No `context`.
- `jq -r .description | wc -l` = 5; `jq -r .description | rg -q '\\n'` exited 1.
- Happy path on this checkout filed ORB-10868 (`CI failure: ORB-10865-hook-verify on PR #10865`). Description renders as `## Problem` plus blank-line-separated commit/run lines. Rejected immediately as a verification artifact.
- `make ci-fast`: pass.
- Criterion 2 (live `Fetching the repository` / checked-out HEAD SHA log lines) and the CI-green half of criterion 9 cannot be pasted until the carrying PR runs on GitHub. Not a code gap.

Assessment: Both defects are fixed in the workflow files the incident named. The handler can no longer turn a checkout miss into a second red. Live checkout-log evidence is a follow-up observation on the PR CI run, not remaining implementation work.

Design weaknesses / risks:
- Severity: low. On github-hosted runners `orbit` is usually absent, so the handler will skip rather than file unless a prebuilt or just-built `target/*/orbit` exists. That is the intended trade-off vs compiling in a failure handler. Mitigation: skip is logged; local happy path proved filing works when `orbit` is present.

Deviations from original plan: none.

Recommended follow-ups:
- After the carrying PR's CI run, paste the `Fetching the repository` line and the checked-out HEAD SHA into this summary (criterion 2).
- Related someday task ORB-10264 covers the same checkout race; consider superseding it once this lands.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10865-6a812371`
- Behind base: 0
- Ahead of base: 1

*authored by: grok*