### PR TITLE
orbit doctor: report orphaned skill directories left behind by a retired skill

### DIFF
--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -633,7 +633,7 @@ fn doctor_check_definition_artifacts(runtime: &OrbitRuntime) -> Vec<WorkspaceDoc
                     format!("no {} on disk yet", health.kind.as_str())
                 } else {
                     format!(
-                        "{} {} loaded, none stale, deprecated, or faulty",
+                        "{} {} loaded, none residual, stale, deprecated, or faulty",
                         health.scanned,
                         health.kind.as_str()
                     )

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -32,6 +32,16 @@ fn workspace_runtime(temp: &tempfile::TempDir) -> OrbitRuntime {
     OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime")
 }
 
+fn write_skill(root: &Path, id: &str, purpose: &str) {
+    let dir = root.join(id);
+    fs::create_dir_all(&dir).expect("create skill dir");
+    fs::write(
+        dir.join("SKILL.md"),
+        format!("---\nname: {id}\ndescription: test skill\n---\n\n# Purpose\n\n{purpose}\n"),
+    )
+    .expect("write skill");
+}
+
 fn split_root_runtime(temp: &tempfile::TempDir) -> OrbitRuntime {
     let global_root = temp.path().join("global");
     let shared_root = temp.path().join("main").join(".orbit");
@@ -118,6 +128,68 @@ fn every_warning_or_error_has_structured_remediation() {
             "actionable row needs remediation: {row:?}"
         );
     }
+}
+
+#[test]
+fn skill_residue_warns_and_names_the_directory() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let skills = temp.path().join("global/skills");
+    write_skill(&skills, "orbit", "healthy global skill");
+    let residue = skills.join("orbit-search");
+    fs::create_dir_all(residue.join("references")).expect("create residue references");
+    fs::write(residue.join("references/search.md"), "retired reference\n")
+        .expect("write residue reference");
+    let empty_residue = skills.join("orbit-task");
+    fs::create_dir(&empty_residue).expect("create empty residue");
+
+    let results = runtime.doctor_workspace().expect("doctor");
+    let row = status_of(&results, "artifacts-skills");
+    assert_eq!(row.status, WorkspaceDoctorStatus::Warning, "{row:?}");
+    assert!(row.message.contains("residual"), "{}", row.message);
+    assert!(
+        row.message.contains(residue.to_string_lossy().as_ref()),
+        "DETAILS must name the residue directory: {}",
+        row.message
+    );
+    assert!(
+        row.message
+            .contains(empty_residue.to_string_lossy().as_ref()),
+        "DETAILS must name the empty residue directory: {}",
+        row.message
+    );
+    assert_ne!(row.status, WorkspaceDoctorStatus::Error);
+}
+
+#[test]
+fn healthy_single_skill_and_workspace_shadow_keep_the_loaded_count() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    write_skill(&temp.path().join("global/skills"), "orbit", "global skill");
+
+    let global_only = runtime.doctor_workspace().expect("doctor global catalog");
+    let row = status_of(&global_only, "artifacts-skills");
+    assert_eq!(row.status, WorkspaceDoctorStatus::Ok, "{row:?}");
+    assert!(
+        row.message.starts_with("1 skills loaded"),
+        "{}",
+        row.message
+    );
+    assert!(row.message.contains("none residual"), "{}", row.message);
+
+    write_skill(
+        &temp.path().join("repo/.orbit/skills"),
+        "orbit",
+        "workspace override",
+    );
+    let shadowed = runtime.doctor_workspace().expect("doctor layered catalog");
+    let row = status_of(&shadowed, "artifacts-skills");
+    assert_eq!(row.status, WorkspaceDoctorStatus::Ok, "{row:?}");
+    assert!(
+        row.message.starts_with("1 skills loaded"),
+        "{}",
+        row.message
+    );
 }
 
 #[test]

--- a/crates/orbit-core/src/command/artifact_health.rs
+++ b/crates/orbit-core/src/command/artifact_health.rs
@@ -3,25 +3,28 @@
 //!
 //! `orbit doctor` already diagnoses infrastructure (config, database, disk,
 //! indexes, locks, runs). This module supplies the missing half: the
-//! definitions themselves, classified into three conditions.
+//! definitions themselves, classified into four conditions.
 //!
 //! - **Faulty** — the file fails to parse or validate, so its definition is
 //!   absent at dispatch time even though the file is still on disk.
+//! - **Residual** — an on-disk skill directory has no `SKILL.md` entry point,
+//!   so it cannot load but still occupies the catalog.
 //! - **Deprecated** — the managed manifest proves Orbit wrote this file for a
 //!   default that the running binary no longer ships.
 //! - **Stale** — the file is a managed copy of an *older* release of a default
 //!   this binary still ships, or an untracked file colliding with a bundled
 //!   default name.
 //!
-//! Every judgement is made from the per-kind managed manifest written by
-//! [`super::reconcile_managed_assets`] (ADR-0346, extended to all five kinds by
-//! ADR-0366), never from filename guessing. That matters for correctness as
-//! well as safety: precedence differs across kinds — skills merge
-//! workspace-over-global while activities keep shipped defaults authoritative
-//! over workspace copies — so a rule phrased in terms of "which copy wins"
-//! would misreport at least one kind. Provenance is a property of the file
-//! Orbit wrote, in the directory Orbit wrote it to, and is unaffected by which
-//! copy a loader later prefers.
+//! Provenance judgements are made from the per-kind managed manifest written by
+//! [`super::reconcile_managed_assets`]. Residual skill directories are the one
+//! condition discovered directly from the catalog layout because a deleted
+//! entry point cannot be represented by a successfully loaded skill. That
+//! matters for correctness as well as safety: precedence differs across kinds —
+//! skills merge workspace-over-global while activities keep shipped defaults
+//! authoritative over workspace copies — so a rule phrased in terms of "which
+//! copy wins" would misreport at least one kind. Provenance is a property of
+//! the file Orbit wrote, in the directory Orbit wrote it to, and is unaffected
+//! by which copy a loader later prefers.
 //!
 //! Repair ([`OrbitRuntime::remove_stale_definition_artifacts`]) is deliberately
 //! narrower than diagnosis: only a *deprecated* artifact whose digest still
@@ -114,6 +117,8 @@ impl ArtifactKind {
 pub enum ArtifactCondition {
     /// Fails to parse or validate — absent at dispatch time.
     Faulty,
+    /// A skill directory remains on disk without its `SKILL.md` entry point.
+    Residual,
     /// A managed default this binary no longer ships.
     Deprecated,
     /// Drifted from the current release, or colliding with a bundled name.
@@ -124,6 +129,7 @@ impl ArtifactCondition {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Faulty => "faulty",
+            Self::Residual => "residual",
             Self::Deprecated => "deprecated",
             Self::Stale => "stale",
         }
@@ -178,7 +184,7 @@ impl ArtifactFinding {
 #[derive(Debug, Clone)]
 pub struct ArtifactHealth {
     pub kind: ArtifactKind,
-    /// Artifact files inspected for this kind.
+    /// Artifact catalog entries inspected for this kind.
     pub scanned: usize,
     /// Unhealthy artifacts, deterministically ordered.
     pub findings: Vec<ArtifactFinding>,
@@ -490,7 +496,12 @@ fn finish_catalog_health(
                 && finding.condition == ArtifactCondition::Stale
                 && finding.provenance == ArtifactProvenance::OrbitWritten
         });
-        let remediation = if let Some(command) = fault.repair_command {
+        let remediation = if fault.condition == ArtifactCondition::Residual {
+            format!(
+                "Review the residual skill directory at `{}` and remove it manually if it is no longer needed.",
+                fault.path.display()
+            )
+        } else if let Some(command) = fault.repair_command {
             format!("Run `{command}`.")
         } else if stale_shipped_default {
             "Run `orbit init --refresh-defaults`.".to_string()
@@ -510,7 +521,7 @@ fn finish_catalog_health(
             kind,
             name: fault.name,
             path: fault.path,
-            condition: ArtifactCondition::Faulty,
+            condition: fault.condition,
             provenance,
             detail: fault.detail,
             remediation,
@@ -530,6 +541,7 @@ fn finish_catalog_health(
 struct LoadFault {
     name: String,
     path: PathBuf,
+    condition: ArtifactCondition,
     detail: String,
     repair_command: Option<&'static str>,
 }
@@ -539,6 +551,7 @@ impl From<ActivityCatalogFault> for LoadFault {
         Self {
             name: fault.name,
             path: fault.path,
+            condition: ArtifactCondition::Faulty,
             detail: fault.detail,
             repair_command: fault.repair_command,
         }
@@ -563,6 +576,7 @@ fn collect_faults(runtime: &OrbitRuntime, catalog: &ManagedCatalog) -> (usize, V
                 faults.push(LoadFault {
                     name: "<catalog>".to_string(),
                     path: catalog.dir.clone(),
+                    condition: ArtifactCondition::Faulty,
                     detail: format!("cannot enumerate skills: {error}"),
                     repair_command: None,
                 });
@@ -571,14 +585,26 @@ fn collect_faults(runtime: &OrbitRuntime, catalog: &ManagedCatalog) -> (usize, V
         };
         let scanned = rows.len();
         for row in rows {
-            if row.status == crate::skill_catalog::SkillCatalogDoctorStatus::Error {
-                let path = catalog.dir.join(&row.skill_id).join("SKILL.md");
-                faults.push(LoadFault {
-                    name: format!("{}/SKILL.md", row.skill_id),
-                    path,
-                    detail: row.message,
-                    repair_command: None,
-                });
+            match row.status {
+                crate::skill_catalog::SkillCatalogDoctorStatus::Ok => {}
+                crate::skill_catalog::SkillCatalogDoctorStatus::Warning => {
+                    faults.push(LoadFault {
+                        name: row.skill_id,
+                        path: row.path,
+                        condition: ArtifactCondition::Residual,
+                        detail: row.message,
+                        repair_command: None,
+                    });
+                }
+                crate::skill_catalog::SkillCatalogDoctorStatus::Error => {
+                    faults.push(LoadFault {
+                        name: format!("{}/SKILL.md", row.skill_id),
+                        path: row.path.join("SKILL.md"),
+                        condition: ArtifactCondition::Faulty,
+                        detail: row.message,
+                        repair_command: None,
+                    });
+                }
             }
         }
         return (scanned, faults);
@@ -599,6 +625,7 @@ fn collect_faults(runtime: &OrbitRuntime, catalog: &ManagedCatalog) -> (usize, V
             faults.push(LoadFault {
                 name,
                 path,
+                condition: ArtifactCondition::Faulty,
                 detail: error.message,
                 repair_command: None,
             });
@@ -633,6 +660,7 @@ fn collect_faults(runtime: &OrbitRuntime, catalog: &ManagedCatalog) -> (usize, V
             faults.push(LoadFault {
                 name,
                 path,
+                condition: ArtifactCondition::Faulty,
                 detail: "file is unreadable".to_string(),
                 repair_command: None,
             });
@@ -649,6 +677,7 @@ fn collect_faults(runtime: &OrbitRuntime, catalog: &ManagedCatalog) -> (usize, V
             faults.push(LoadFault {
                 name,
                 path,
+                condition: ArtifactCondition::Faulty,
                 detail,
                 repair_command: None,
             });

--- a/crates/orbit-core/src/command/skill.rs
+++ b/crates/orbit-core/src/command/skill.rs
@@ -207,6 +207,7 @@ impl OrbitRuntime {
                 skill_name: row.skill_id,
                 status: match row.status {
                     SkillCatalogDoctorStatus::Ok => SkillDoctorStatus::Ok,
+                    SkillCatalogDoctorStatus::Warning => SkillDoctorStatus::Warning,
                     SkillCatalogDoctorStatus::Error => SkillDoctorStatus::Error,
                 },
                 message: row.message,

--- a/crates/orbit-core/src/command/tests/managed_assets.rs
+++ b/crates/orbit-core/src/command/tests/managed_assets.rs
@@ -495,6 +495,105 @@ mod artifacts {
         }
     }
 
+    /// Skill directories remain visible to health checks after their entry
+    /// point disappears, regardless of whether the manifest still remembers
+    /// the deleted payload. Repair never treats the directory itself as proof
+    /// of Orbit authorship.
+    #[test]
+    fn skill_residue_is_reported_and_fix_preserves_unproven_content() {
+        let root = tempdir().expect("create tempdir");
+        let (global_root, workspace_root) = init_workspace(root.path());
+        let skills_dir = global_root.join("skills");
+
+        let untracked_dir = skills_dir.join("orbit-search");
+        let untracked_reference = untracked_dir.join("references/manual.md");
+        std::fs::create_dir_all(untracked_reference.parent().expect("reference parent"))
+            .expect("create untracked residue");
+        std::fs::write(&untracked_reference, "operator reference\n")
+            .expect("write untracked residue");
+
+        let tracked_dir = skills_dir.join("orbit-task");
+        let tracked_reference = tracked_dir.join("references/task.md");
+        std::fs::create_dir_all(tracked_reference.parent().expect("reference parent"))
+            .expect("create tracked residue");
+        let previous_reference = "previous Orbit reference\n";
+        let modified_reference = "operator-modified reference\n";
+        std::fs::write(&tracked_reference, modified_reference)
+            .expect("write locally modified tracked residue");
+        add_managed_manifest_entry(
+            &skills_dir,
+            "orbit-task/SKILL.md",
+            "deleted Orbit entry point\n",
+        );
+        add_managed_manifest_entry(
+            &skills_dir,
+            "orbit-task/references/task.md",
+            previous_reference,
+        );
+
+        let runtime =
+            OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+        let report = runtime
+            .inspect_definition_artifacts()
+            .expect("inspect artifacts");
+        let skill_health = health_of(&report, ArtifactKind::Skill);
+        assert_eq!(
+            skill_health.scanned, 3,
+            "one healthy skill plus two residues"
+        );
+        for residue in [&untracked_dir, &tracked_dir] {
+            let name = residue
+                .file_name()
+                .and_then(|name| name.to_str())
+                .expect("residue name");
+            let finding = skill_health
+                .findings
+                .iter()
+                .find(|finding| {
+                    finding.name == name && finding.condition == ArtifactCondition::Residual
+                })
+                .expect("residual skill directory is reported");
+            assert_eq!(finding.path, *residue);
+            assert_eq!(finding.provenance, ArtifactProvenance::UserAuthored);
+            assert!(
+                finding.detail.contains(residue.to_string_lossy().as_ref()),
+                "{}",
+                finding.detail
+            );
+            assert!(!finding.is_unloadable_shipped_default());
+        }
+
+        assert_eq!(
+            runtime
+                .remove_stale_definition_artifacts()
+                .expect("repair stale artifacts"),
+            1,
+            "only the manifest-tracked modified reference leaves the active catalog"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&untracked_reference).expect("untracked residue survives"),
+            "operator reference\n"
+        );
+        let preserved = global_root.join(".retired-managed/skills/orbit-task/references/task.md");
+        assert_eq!(
+            std::fs::read_to_string(&preserved).expect("modified residue is preserved"),
+            modified_reference
+        );
+
+        let after_fix = runtime
+            .inspect_definition_artifacts()
+            .expect("inspect after repair");
+        let remaining = health_of(&after_fix, ArtifactKind::Skill)
+            .findings
+            .iter()
+            .filter(|finding| finding.condition == ArtifactCondition::Residual)
+            .count();
+        assert_eq!(
+            remaining, 2,
+            "repair leaves residual directories for review"
+        );
+    }
+
     /// Criteria: deprecated artifacts are detected across the newly covered
     /// kinds; the fix flag removes only what Orbit provably wrote and
     /// preserves a locally modified one instead of deleting it.

--- a/crates/orbit-store/src/file/skill_store/mod.rs
+++ b/crates/orbit-store/src/file/skill_store/mod.rs
@@ -63,12 +63,14 @@ struct SkillFrontmatter {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub enum SkillCatalogDoctorStatus {
     Ok,
+    Warning,
     Error,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct SkillCatalogDoctorRow {
     pub skill_id: String,
+    pub path: PathBuf,
     pub status: SkillCatalogDoctorStatus,
     pub message: String,
 }
@@ -127,17 +129,27 @@ impl SkillCatalog {
         ids.sort();
         let mut rows = Vec::new();
         for id in ids {
+            let path = self.candidate_path(&id);
             match self.load(&id) {
                 Ok(_) => rows.push(SkillCatalogDoctorRow {
                     skill_id: id,
+                    path,
                     status: SkillCatalogDoctorStatus::Ok,
                     message: String::new(),
                 }),
-                Err(err) => rows.push(SkillCatalogDoctorRow {
-                    skill_id: id,
-                    status: SkillCatalogDoctorStatus::Error,
-                    message: err.to_string(),
-                }),
+                Err(err) => {
+                    let status = if path.is_dir() && !path.join("SKILL.md").exists() {
+                        SkillCatalogDoctorStatus::Warning
+                    } else {
+                        SkillCatalogDoctorStatus::Error
+                    };
+                    rows.push(SkillCatalogDoctorRow {
+                        skill_id: id,
+                        path,
+                        status,
+                        message: err.to_string(),
+                    });
+                }
             }
         }
         Ok(rows)
@@ -178,6 +190,17 @@ impl SkillCatalog {
         }
 
         Ok(ids)
+    }
+
+    fn candidate_path(&self, skill_id: &str) -> PathBuf {
+        let workspace = self.root.join(skill_id);
+        if workspace.exists() {
+            workspace
+        } else {
+            self.global_root
+                .as_ref()
+                .map_or(workspace, |global| global.join(skill_id))
+        }
     }
 }
 
@@ -222,8 +245,9 @@ fn load_skill_from_dir(skill_id: &str, dir: &Path) -> Result<LoadedSkill, OrbitE
     let skill_md_path = dir.join("SKILL.md");
     if !skill_md_path.exists() {
         return Err(OrbitError::SkillValidation(format!(
-            "missing SKILL.md for skill '{}'",
-            skill_id
+            "skill directory '{}' is missing SKILL.md for skill '{}'",
+            dir.display(),
+            skill_id,
         )));
     }
     let content = fs::read_to_string(&skill_md_path).map_err(|e| OrbitError::Io(e.to_string()))?;
@@ -273,9 +297,7 @@ fn collect_candidate_ids(root: &Path) -> Result<Vec<String>, OrbitError> {
         let Some(name) = path.file_name().and_then(|v| v.to_str()) else {
             continue;
         };
-        if path.join("SKILL.md").exists() {
-            ids.push(name.to_string());
-        }
+        ids.push(name.to_string());
     }
     Ok(ids)
 }

--- a/crates/orbit-store/src/file/skill_store/tests/skill_store.rs
+++ b/crates/orbit-store/src/file/skill_store/tests/skill_store.rs
@@ -40,6 +40,63 @@ fn layered_catalog_uses_merge_by_key_precedence() {
         .map(|skill| skill.id)
         .collect::<Vec<_>>();
     assert_eq!(ids, vec!["orbit", "orbit-search"]);
+
+    let rows = catalog.doctor().expect("doctor layered catalog");
+    assert_eq!(rows.len(), 2, "the workspace shadow is counted once");
+    assert!(
+        rows.iter()
+            .all(|row| row.status == SkillCatalogDoctorStatus::Ok),
+        "a valid workspace shadow must not make its global peer faulty: {rows:?}"
+    );
+}
+
+#[test]
+fn doctor_reports_skill_directories_without_skill_markdown() {
+    let root = tempdir().expect("catalog tempdir");
+    write_skill(root.path(), "orbit", "healthy skill");
+
+    let reference_residue = root.path().join("orbit-search");
+    fs::create_dir_all(reference_residue.join("references")).expect("create reference residue");
+    fs::write(
+        reference_residue.join("references/search.md"),
+        "retired reference\n",
+    )
+    .expect("write retired reference");
+    let empty_residue = root.path().join("orbit-task");
+    fs::create_dir(&empty_residue).expect("create empty residue");
+
+    let catalog = SkillCatalog::new(root.path().to_path_buf());
+    let rows = catalog.doctor().expect("doctor catalog");
+    assert_eq!(rows.len(), 3, "every immediate skill directory is scanned");
+    assert_eq!(
+        rows.iter()
+            .filter(|row| row.status == SkillCatalogDoctorStatus::Ok)
+            .count(),
+        1
+    );
+    for residue in [&reference_residue, &empty_residue] {
+        let id = residue
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("residue id");
+        let row = rows
+            .iter()
+            .find(|row| row.skill_id == id)
+            .expect("residue row");
+        assert_eq!(row.status, SkillCatalogDoctorStatus::Warning);
+        assert!(row.message.contains("missing SKILL.md"), "{}", row.message);
+        assert!(
+            row.message.contains(residue.to_string_lossy().as_ref()),
+            "the finding names the residue directory: {}",
+            row.message
+        );
+    }
+
+    assert_eq!(
+        catalog.list().expect("list healthy skills").len(),
+        1,
+        "residue is diagnosed but never loaded"
+    );
 }
 
 fn write_skill(root: &Path, id: &str, purpose: &str) {


### PR DESCRIPTION
## Task

[ORB-10862](https://orbit-cli.com/tasks/ORB-10862) — orbit doctor: report orphaned skill directories left behind by a retired skill

### Description

## Problem

After the four Orbit skills were consolidated into a single `orbit` skill, three
directories survived in the global catalog:

```
$ ls ~/.orbit/skills
 orbit   orbit-search   orbit-task   orbit-workflow
```

Each of `orbit-search`, `orbit-task`, and `orbit-workflow` held only a `references/`
subtree — no `SKILL.md`. `orbit doctor` reported the catalog as clean:

```
artifacts-skills  ok  1 skills loaded, none stale, deprecated, or faulty
```

Three dead directories, and the check that exists to find exactly this said `ok`.

### Root cause

Two independent blind spots line up, so the residue falls through both:

1. `collect_candidate_ids` in `crates/orbit-store/src/file/skill_store/mod.rs:261` only
   admits a directory when `path.join("SKILL.md").exists()`. A directory whose `SKILL.md`
   was deleted is not a broken skill to the catalog — it is not a skill at all. It never
   reaches `SkillCatalog::doctor`, so `scanned` counts 1 and no fault is raised.
2. `diagnose_catalog` in `crates/orbit-core/src/command/artifact_health.rs:386` detects
   deprecation by iterating the managed-asset manifest's `tracked` map, and skips any
   entry whose payload is unreadable (`let Some(on_disk) = read_artifact(&path) else {
   continue }`). In the observed case the manifest had already been rewritten to track
   only `orbit/**`, so the retired names were not in `tracked` either.

Nothing on either path enumerates on-disk catalog entries that are in neither the shipped
set nor the manifest. Deprecation is only ever detected through the manifest, so residue
that outlives its manifest entry is structurally invisible.

## Why It Matters

`orbit doctor` is the trusted answer to "is this install healthy." Reporting `ok` over
visible dead artifacts is worse than reporting nothing: it teaches operators that a clean
doctor run means a clean catalog. Stale skill directories are also live risk — a
resurrected `SKILL.md`, or a reference file loaded by path, can reintroduce guidance that
was deliberately retired.

## Constraints / Notes

- The three directories were cleaned up automatically during the session in which this
  was observed (something refreshed the catalog and rewrote
  `~/.orbit/skills/.orbit-managed-assets.json`). Reproduce by hand: create
  `~/.orbit/skills/<name>/references/x.md` with no sibling `SKILL.md`, then run
  `orbit doctor`. Worth a look at which code path did the cleanup — if a refresh already
  removes this residue, the doctor gap is still real but the severity is narrower.
- Suggested shape: have the skill catalog surface directory entries that look like a
  skill but do not load — no `SKILL.md`, or a `references/` tree with no payload — so
  `artifacts-skills` can raise them. A new `ArtifactCondition` (orphaned/residual) is
  probably cleaner than overloading `Deprecated`, which currently carries a specific
  manifest-tracked meaning.
- Respect the severity asymmetry documented at `doctor.rs:605` — warn, do not error.
  An operator's own half-authored skill directory must not turn CI red.
- Do not auto-delete. If `--fix-stale-artifacts` learns to retire this residue, it must
  keep the existing provenance rule: remove only content whose recorded digest proves
  Orbit wrote it, preserve anything locally modified.
- Check whether the sibling catalogs (jobs, activities, auto-tasks, routines) have the
  same manifest-only blind spot. Their layouts differ, but the deprecation loop is shared.

### Acceptance Criteria

- Given a global skill catalog containing a directory with a `references/` subtree and no `SKILL.md`, `orbit doctor` reports `artifacts-skills` as `warning` and names the offending directory path in DETAILS.
- The same case with an empty leftover directory (no `SKILL.md`, no `references/`) is also reported.
- A directory tracked in `.orbit-managed-assets.json` whose payload file was deleted is reported rather than silently skipped by the `read_artifact(...) else { continue }` branch in `diagnose_catalog`.
- A healthy catalog still reports `ok` with the correct loaded count — no false positive on a single-skill catalog, and none on a workspace-scoped skill that shadows a global one.
- Severity is `Warning`, never `Error`, for a locally-authored or unrecognized directory; `cargo test -p orbit-cmd` covers the severity choice.
- Unit coverage in `crates/orbit-store/src/file/skill_store/tests/skill_store.rs` for the new residue-detection path, using a temp dir rather than the operator's real `~/.orbit`.
- `orbit doctor --fix-stale-artifacts` either leaves the residue untouched or removes only entries whose recorded digest proves Orbit authorship; locally modified residue survives either way, asserted by a test.
- `cargo nextest run --workspace --locked` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Skill catalog diagnosis now enumerates every immediate skill directory, emits a warning row for directories missing SKILL.md, includes the selected workspace/global path, and preserves merge-by-key shadow semantics.
- Definition-artifact health maps those rows to a distinct residual condition. orbit doctor reports artifacts-skills as warning with each residue path, while healthy catalogs retain the correct loaded count and now explicitly state that no residual entries were found.
- Stale-artifact repair remains provenance-gated: untracked residue stays in place, deleted tracked payloads no longer disappear from diagnosis, and locally modified tracked reference content is preserved outside the active catalog.
- Added temp-directory coverage in orbit-store plus core and orbit-cmd regressions for reference-only and empty residue, deleted manifest-tracked payloads, warning severity, safe repair, healthy single-skill catalogs, and workspace shadows.
Assessment: The change uses the production skill loader and its existing merge boundary, adds no dependency edge, and keeps residual cleanup manual unless file digests independently prove Orbit authorship.
Validation:
- cargo test -p orbit-store file::skill_store::tests::skill_store
- cargo test -p orbit-core command::tests::managed_assets::artifacts
- cargo test -p orbit-cmd (54 passed)
- make ci-fast
- make ci-lint
- cargo nextest run --workspace --locked (2742 passed, 5 skipped)
Deviations from original plan:
- Expanded context to crates/orbit-core/src/command/skill.rs for the warning adapter, crates/orbit-cmd/src/doctor.rs for truthful healthy output, and the directly affected core/command tests. These were the smallest coupled changes needed to preserve public behavior and prove the acceptance criteria.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10862-6a812134`
- Behind base: 0
- Ahead of base: 1