### PR TITLE
Env-value redaction silently corrupts artifact prose when a sensitive-named variable holds a short common word

### DIFF
--- a/crates/orbit-common/src/utility/redaction.rs
+++ b/crates/orbit-common/src/utility/redaction.rs
@@ -46,6 +46,8 @@ static HIGH_CONFIDENCE_SINGLE_TOKEN_PATTERNS: OnceLock<Vec<Regex>> = OnceLock::n
 ///
 /// "Sensitive" is matched against the var *name* — anything containing
 /// SECRET / TOKEN / PASSWORD / API_KEY / etc. See [`is_sensitive_env_name`].
+/// Only values that pass `is_redactable_value` are substituted, so an
+/// ordinary word held by a sensitive-named variable is left untouched.
 pub fn redact_sensitive_env_text(raw: &str) -> String {
     let mut redacted = raw.to_string();
     for secret in sensitive_env_values() {
@@ -529,8 +531,28 @@ pub(crate) fn os_login_name() -> Option<String> {
     std::env::var("USERNAME").ok().filter(|s| !s.is_empty())
 }
 
-fn is_redactable_value(value: &str) -> bool {
-    value.trim().len() >= 4
+/// Decide whether a sensitive-named env value is eligible for substitution
+/// by [`redact_sensitive_env_text`].
+///
+/// A value is eligible only when, after trim, it is at least 4 characters
+/// **and** it contains at least one non-letter (digit or punctuation).
+/// All-letter values are treated as ordinary words (`user`, `true`, `none`,
+/// `root`, `main`, `test`, `prod`, `local`, `auto`) and are never
+/// substituted, even when a sensitive-looking variable name happens to
+/// hold them. This is a shape gate, not a raised length floor: a short
+/// secret such as `a1b2` remains eligible.
+///
+/// Eligible values are still matched with a bare substring replace so
+/// embedded tokens in URLs and concatenated log fragments stay scrubbed.
+///
+/// False-negative accepted: an all-letter secret or passphrase with no
+/// digits or punctuation (a dictionary word, or concatenated words with
+/// no separators) is not env-substituted. Pattern-based redaction still
+/// independently catches provider-shaped tokens (`ghp_…`, `sk-…`).
+// pub(crate) for sibling-layout tests in utility/tests/redaction.rs.
+pub(crate) fn is_redactable_value(value: &str) -> bool {
+    let trimmed = value.trim();
+    trimmed.len() >= 4 && trimmed.chars().any(|c| !c.is_alphabetic())
 }
 
 pub fn is_sensitive_env_name(name: &str) -> bool {

--- a/crates/orbit-common/src/utility/tests/redaction.rs
+++ b/crates/orbit-common/src/utility/tests/redaction.rs
@@ -1,8 +1,10 @@
 use std::ffi::{OsStr, OsString};
+use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use super::super::redaction::{
     backfill_login_identity, credential_safe_location, is_high_confidence_single_token_credential,
-    is_sensitive_env_name, os_login_name, redact_all,
+    is_redactable_value, is_sensitive_env_name, os_login_name, redact_all,
+    redact_sensitive_env_text,
 };
 
 fn values_for(vars: &[(OsString, OsString)], key: &str) -> Vec<OsString> {
@@ -300,4 +302,107 @@ fn redact_all_error_sanitizes_artifact_origin_locations() {
 
     assert_eq!(origin.worktree_root, "[REDACTED_LOCATION]");
     assert_eq!(origin.branch.as_deref(), Some("[REDACTED_LOCATION]"));
+}
+
+// [ORB-10867] Ordinary-word env values must not be eligible for substitution.
+
+#[test]
+fn ordinary_words_are_not_redactable_env_values() {
+    for word in [
+        "user", "true", "none", "root", "main", "test", "prod", "local", "auto", "User", "USER",
+    ] {
+        assert!(
+            !is_redactable_value(word),
+            "{word} looks like an ordinary word and must not be substituted"
+        );
+    }
+    assert!(
+        !is_redactable_value("  user  "),
+        "trim must not promote an ordinary word into a secret"
+    );
+    assert!(
+        !is_redactable_value("abc"),
+        "values shorter than 4 characters stay ineligible"
+    );
+}
+
+#[test]
+fn secret_shaped_env_values_remain_redactable() {
+    for secret in [
+        "a1b2",
+        "orbit-redaction-secret-value",
+        "orbit-friction-secret-value",
+        "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcd123456",
+    ] {
+        assert!(
+            is_redactable_value(secret),
+            "{secret} is secret-shaped and must stay eligible"
+        );
+    }
+}
+
+#[test]
+fn common_word_env_value_is_not_substituted_even_as_a_token_or_substring() {
+    let _env = EnvVarGuard::set("GITHUB_TOKEN", "user");
+
+    assert_eq!(
+        redact_sensitive_env_text("No user-facing CLI behavior should change."),
+        "No user-facing CLI behavior should change."
+    );
+    assert_eq!(
+        redact_sensitive_env_text("superuser username users"),
+        "superuser username users"
+    );
+}
+
+#[test]
+fn secret_shaped_env_value_is_still_replaced_as_a_substring() {
+    // Pin: eligible (non-letter-containing) values keep bare substring
+    // matching. Mid-word occurrences of a short secret-shaped value are
+    // substituted; ordinary words are the other side of the line.
+    let _env = EnvVarGuard::set("GITHUB_TOKEN", "a1b2");
+
+    assert_eq!(redact_sensitive_env_text("xa1b2y"), "x[REDACTED_ENV]y");
+    assert_eq!(
+        redact_sensitive_env_text("leaked a1b2 token"),
+        "leaked [REDACTED_ENV] token"
+    );
+}
+
+struct EnvVarGuard {
+    _lock: MutexGuard<'static, ()>,
+    name: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(name: &'static str, value: &str) -> Self {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let lock = LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous = std::env::var(name).ok();
+        // SAFETY: this test guard serializes environment mutation and restores on drop.
+        unsafe {
+            std::env::set_var(name, value);
+        }
+        Self {
+            _lock: lock,
+            name,
+            previous,
+        }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: the guard holds the serialization lock for the full mutation window.
+        unsafe {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
+            }
+        }
+    }
 }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/artifact_redaction.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/artifact_redaction.rs
@@ -698,6 +698,33 @@ mod tests {
     }
 
     #[test]
+    fn dispatch_preserves_common_word_github_token_in_task_description() {
+        let word = "user";
+        let _env = EnvVarGuard::set("GITHUB_TOKEN", word);
+        let (_root, runtime, _repo_root) = test_runtime();
+        let description = format!("No {word}-facing CLI behavior should change.");
+
+        let output = runtime
+            .execute_tool_command(
+                "orbit.task.add",
+                json!({
+                    "title": "plain",
+                    "description": description,
+                    "workspace": ".",
+                }),
+                Some("codex".to_string()),
+                Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+            )
+            .expect("task add succeeds");
+
+        assert_eq!(output["redactions_applied"], false);
+        assert_eq!(output["description"], description);
+        let id = output["id"].as_str().expect("task id");
+        let task = runtime.get_task(id).expect("task persisted");
+        assert_eq!(task.description, description);
+    }
+
+    #[test]
     fn dispatch_redacts_live_github_token_before_task_persistence_and_audits() {
         let token = "orbit-redaction-secret-value";
         let _env = EnvVarGuard::set("GITHUB_TOKEN", token);


### PR DESCRIPTION
## Task

[ORB-10867](https://orbit-cli.com/tasks/ORB-10867) — Env-value redaction silently corrupts artifact prose when a sensitive-named variable holds a short common word

### Description

## Problem

Creating ORB-10861 through `orbit.task.add` silently mangled its prose. Two fields came back with an ordinary English word replaced by `[REDACTED_ENV]`:

- description: `No [REDACTED_ENV]-facing CLI behavior should change: skill list must still print the real content hash in normal use.`
- acceptance criterion 6: `... still print the true per-skill content hash (unchanged [REDACTED_ENV]-facing behavior).`

The response reported `redactions_applied: true`, `redaction_kinds: ["env"]`, `redaction_classes: ["sensitive_environment_value"]`.

The substituted word is the ordinary four-letter English term for a person operating a system, spelled `u-s-e-r`. It is hyphenated here — and written as "operator" everywhere else in this task — because writing it plainly would trigger the same substitution and damage this task the same way. That workaround is itself the evidence: authoring an Orbit artifact currently requires knowing which everyday words the local environment happens to have poisoned.

### Mechanism

Three pieces in `crates/orbit-common/src/utility/redaction.rs` combine into it:

1. `is_sensitive_env_name` (:536) matches on a broad substring list — `SECRET`, `TOKEN`, `PASSWORD`, `PASSWD`, `PASSCODE`, `API_KEY`, `*_KEY`, `PRIVATE`, `CREDENTIAL`, `COOKIE`, `SESSION`, `BEARER`, `AUTH`. Plenty of ordinary variables match.
2. `sensitive_env_values` (:415) collects the *values* of every matching variable, keeping any that passes `is_redactable_value` (:532) — which is only `value.trim().len() >= 4`.
3. `redact_sensitive_env_text` (:49) then does a bare `String::replace` of each collected value against the artifact text — no word boundary, no shape check, no entropy floor.

So any variable with a sensitive-looking *name* whose *value* happens to be a common word of four or more characters converts that word into `[REDACTED_ENV]` throughout every free-text field of every artifact created on that machine, including mid-word. Four characters is a very low bar: `true`, `none`, `root`, `main`, `test`, `prod`, `local`, `auto`, and the word above all clear it.

I did not identify which variable on this Mac holds the offending value — inspecting environment values for that is exactly the kind of sweep that should not be run casually, and the attempt was blocked. Determining it is a reasonable first step for whoever picks this up, but the defect is legible from the code without it.

### Why it is silent

`sanitize_tool_input` (`crates/orbit-core/src/runtime/orbit_tool_host/artifact_redaction.rs:85`) runs before persistence, so the store never holds the original text. The only signal is the `redactions` array in the tool response, which names the field path, kind, and class — but not what was substituted or how many times. Unless the caller re-reads the artifact and notices the marker in running prose, the damage is permanent and unremarked. Both ORB-10861 fields still carry it.

## Why It Matters

The scrubber currently serves two corpora with very different characteristics through one code path. Its callers are `crates/orbit-exec/src/supervision/tee.rs`, `crates/orbit-cli/src/audit_middleware.rs`, `crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs`, `crates/orbit-core/src/command/tool/dispatch.rs`, and `artifact_redaction.rs`. For captured subprocess output, logs, and argv, aggressive substring matching is correct — a leaked secret there is a real incident, and mangling a log line is cheap. For deliberately authored artifact prose (task descriptions, acceptance criteria, execution summaries, ADR bodies, friction reports), the trade runs the other way: a false positive quietly corrupts a durable record that other agents and engineers will act on, and every free-text surface listed in `policy_for_action` is exposed.

The failure also erodes trust in the sanitizer itself. Once authors learn that ordinary words vanish, the rational response is to route around it — which is what happened here.

## Constraints / Notes

- Do not weaken true-positive coverage. `dispatch_redacts_live_github_token_before_task_persistence_and_audits` and `friction_body_update_is_sanitized_but_tags_are_verbatim` pin the behavior that matters; both must keep passing unchanged.
- Length alone is the wrong axis — a genuinely secret value can be short. Consider instead: word-boundary or delimiter-anchored matching rather than naked substring replace; a shape or entropy gate that declines to match values which look like ordinary words; an explicit never-redact list of common values; or a raised floor combined with one of those. The choice, and the false-negative risk accepted with it, belongs in the execution summary and in a comment next to whichever function ends up owning the rule.
- Decide explicitly whether the fix applies to every caller or only to the artifact free-text path. Both are defensible — captured process output may reasonably keep the aggressive behavior — but the split must be deliberate and documented rather than incidental.
- Worth considering as a smaller companion improvement: make the `redactions` response entry carry enough for a caller to notice a bad substitution (a count, or the matched span), so a false positive is detectable without re-reading the artifact.
- ORB-10861's description and acceptance criterion 6 still hold the corrupted text. Repair them with `orbit.task.update` — never by editing the task files by hand. That repair is not blocked on this fix, but a repair performed on an unfixed machine will simply be corrupted again, so do it after.

## Rollback

The change is confined to the redaction predicate and its callers; reverting the commit restores current behavior with no persisted-format or migration impact.

### Acceptance Criteria

- A regression test in `crates/orbit-common/src/utility/tests/redaction.rs` or the `artifact_redaction.rs` test module proves the reported case: with a sensitive-named variable (for example `GITHUB_TOKEN`, set through the existing `EnvVarGuard`) holding the four-letter common word described in the problem statement, an `orbit.task.add` whose description contains that word followed by `-facing` persists the description byte-identical, and the response reports `redactions_applied: false`.
- A test covers the mid-word case: a sensitive env value that occurs only as a substring inside a longer word is not substituted, or — if the chosen design keeps substring matching for secret-shaped values — a test pins explicitly which side of the line each case lands on.
- `dispatch_redacts_live_github_token_before_task_persistence_and_audits` in `crates/orbit-core/src/runtime/orbit_tool_host/artifact_redaction.rs` still passes with its existing assertions unmodified, confirming a real high-entropy env secret is still redacted before persistence and still emits its `artifact_redaction` audit event.
- `friction_body_update_is_sanitized_but_tags_are_verbatim` still passes unmodified, confirming the friction free-text path retains true-positive coverage.
- The rule that decides whether an env value is eligible for substitution is documented in a comment at its definition site, stating the heuristic and the false-negative risk it accepts.
- The execution summary enumerates every caller of `redact_sensitive_env_text` (`tee.rs`, `audit_middleware.rs`, `cli_runner/orchestrator.rs`, `command/tool/dispatch.rs`, `artifact_redaction.rs`) and states for each whether its behavior changes and why.
- `cargo nextest run -p orbit-common -p orbit-core --locked` passes with no failure in any redaction test.
- `make ci-fast` and `make ci-lint` both pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Tightened `is_redactable_value` in `crates/orbit-common/src/utility/redaction.rs` so a sensitive-named env value is substituted only when, after trim, it is at least 4 characters **and** contains a non-letter (digit or punctuation). All-letter values (the four-letter operator word, `true`, `none`, `root`, `main`, `test`, `prod`, `local`, `auto`) are declined.
- Documented the heuristic and the accepted false-negative at the predicate definition site.
- Added unit tests in `crates/orbit-common/src/utility/tests/redaction.rs` for the predicate, the reported `word-facing` / mid-word ordinary-word cases, and an explicit pin that secret-shaped values still use bare substring replace (`a1b2` inside `xa1b2y`).
- Added `dispatch_preserves_common_word_github_token_in_task_description` in `artifact_redaction.rs`: `GITHUB_TOKEN` set via `EnvVarGuard` to the four-letter operator word, `orbit.task.add` description containing that word followed by `-facing` persists byte-identical with `redactions_applied: false`.
- Left `dispatch_redacts_live_github_token_before_task_persistence_and_audits` and `friction_body_update_is_sanitized_but_tags_are_verbatim` unmodified; both still pass.

Strategic decisions:
- Applied the gate at the shared predicate, not only on the artifact free-text path. Every caller of `redact_sensitive_env_text` inherits it. Deliberate: hyphenated `word-facing` is already delimiter-anchored, so word-boundary matching alone does not fix the reported case; splitting artifact vs log policy would add a second rule without changing the outcome for ordinary words.
- Kept substring `String::replace` for values that pass the gate so embedded tokens in URLs and concatenated log fragments stay scrubbed.
- Rejected a never-redact list (incomplete) and a raised length floor (a real secret can be short).

Caller impact (`redact_sensitive_env_text`):
- `crates/orbit-exec/src/supervision/tee.rs` — captured subprocess stdout/stderr. Behavior changes only for all-letter env values (no longer replaced in debug/capture streams). High-entropy secrets still redacted. Same gate, cheaper false-positive rate in logs.
- `crates/orbit-cli/src/audit_middleware.rs` — CLI audit error messages. Same: all-letter values no longer scrubbed from persisted audit error text; secret-shaped values unchanged.
- `crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs` — argv/error/stdout diagnostics. Same inherited gate; provider-shaped tokens still caught by `PatternRedactor` in the same functions.
- `crates/orbit-core/src/command/tool/dispatch.rs` — tool-dispatch audit error strings. Same inherited gate; denied/failure messages no longer lose ordinary words.
- `crates/orbit-core/src/runtime/orbit_tool_host/artifact_redaction.rs` — artifact free-text sanitizer (the reported surface). Primary beneficiary: task/ADR/friction prose is no longer corrupted when a sensitive-named variable holds an ordinary word. True-positive high-entropy env secrets still redact before persistence and still emit `artifact_redaction` audit events.

Internal inheritors (`redact_sensitive_env_option` / `_json` / `_error` / `redact_all`) use the same predicate; no separate policy.

False-negative accepted: an all-letter secret or passphrase with no digits or punctuation is not env-substituted. Pattern redaction still independently catches provider-shaped tokens (`ghp_…`, `sk-…`).

Assessment: Small, local change at the existing eligibility boundary. Tests pin both sides of the line (ordinary word vs secret-shaped substring). No new dependency edges. Scope stayed inside the three listed context files.

Deviations from original plan: none.

Recommended follow-ups:
- ORB-10861 description and acceptance criterion 6 still hold `[REDACTED_ENV]-facing`. Repair via `orbit.task.update` was attempted after the code fix; the live tool refused the write because ORB-10861 is `done` (terminal). A later human or a restore/un-archive path must repair those two fields once the task is writable again. Do not hand-edit task files.
- Optional companion (called out in the problem statement, not done here): put a substitution count or matched span on the `redactions` response entry so a false positive is visible without re-reading the artifact.

Validation:
- `cargo nextest run -p orbit-common -p orbit-core --locked` — 1128 passed, 1 skipped.
- `make ci-fast` — pass.
- `make ci-lint` — pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10867-6a81252f`
- Behind base: 0
- Ahead of base: 1