### PR TITLE
orbit workspace init leaves dangling ~/.claude/skills and ~/.agents/skills symlinks for skills retired by ORB-10860

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ codex plugin add orbit@orbit
 
 ## Agent Skills
 
-`orbit workspace init` seeds skill files under `~/.orbit/skills/` and symlinks them into `~/.claude/skills/` and `~/.agents/skills/`, so Claude Code, Codex, and Gemini CLI discover them at session start with no per-agent configuration.
+`orbit workspace init` seeds skill files under `~/.orbit/skills/` and symlinks them into `~/.claude/skills/` and `~/.agents/skills/`, so Claude Code, Codex, and Gemini CLI discover them at session start with no per-agent configuration. The same pass removes dangling Orbit-owned links for skill IDs that left the default set (a leftover custom skill directory or a live custom symlink is left alone).
 
 Orbit ships one skill, `orbit`. Its `SKILL.md` is a router — the tool-invocation surface, the lifecycle, and a table of references that load on demand:
 
@@ -257,7 +257,7 @@ Orbit ships one skill, `orbit`. Its `SKILL.md` is a router — the tool-invocati
 
 First-time onboarding (`.orbit/` absent) and "what is orbit" tour requests are handled by the same skill, via its bundled setup references.
 
-`orbit skill doctor` flags drift between the local copy and the upstream definition. Edit any seeded `SKILL.md` to customize behavior for your team.
+`orbit skill doctor` flags drift between the local copy and the upstream definition, and reports dangling or orphaned symlinks under the client skill link directories. Edit any seeded `SKILL.md` to customize behavior for your team.
 
 ---
 

--- a/crates/orbit-core/src/command/init.rs
+++ b/crates/orbit-core/src/command/init.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -465,6 +465,8 @@ fn ensure_global_dirs(paths: &WorkspacePaths) -> Result<(), OrbitError> {
     Ok(())
 }
 
+/// Add or repair links for `skill_ids`, then reap Orbit-owned dangling
+/// leftovers whose IDs left the current default set.
 fn ensure_skill_links(
     skills_root: &Path,
     skill_ids: &[&str],
@@ -518,17 +520,7 @@ fn ensure_skill_links(
 
         if let Ok(link_meta) = fs::symlink_metadata(&link_path) {
             if link_meta.file_type().is_symlink() {
-                let target_path =
-                    fs::read_link(&link_path).map_err(|e| OrbitError::Io(e.to_string()))?;
-                let resolved_target = if target_path.is_absolute() {
-                    target_path
-                } else {
-                    link_path
-                        .parent()
-                        .unwrap_or(Path::new("."))
-                        .join(target_path)
-                        .to_path_buf()
-                };
+                let resolved_target = resolve_symlink_target(&link_path)?;
                 let canonical_expected = canonical_skills_root.join(skill_id);
                 if let Ok(canonical_existing) = resolved_target.canonicalize()
                     && canonical_existing == canonical_expected
@@ -557,6 +549,82 @@ fn ensure_skill_links(
         changed = true;
     }
 
+    changed |= reap_stale_skill_links(
+        skills_root,
+        &canonical_skills_root,
+        skill_ids,
+        skills_links_dir,
+    )?;
+
+    Ok(changed)
+}
+
+/// Resolve a symlink to the path it names without requiring the target to exist.
+fn resolve_symlink_target(link_path: &Path) -> Result<PathBuf, OrbitError> {
+    let target_path = fs::read_link(link_path).map_err(|e| OrbitError::Io(e.to_string()))?;
+    if target_path.is_absolute() {
+        Ok(target_path)
+    } else {
+        Ok(link_path
+            .parent()
+            .unwrap_or(Path::new("."))
+            .join(target_path))
+    }
+}
+
+fn is_orbit_skill_link_target(
+    resolved: &Path,
+    skills_root: &Path,
+    canonical_skills_root: &Path,
+    skill_id: &str,
+) -> bool {
+    resolved == skills_root.join(skill_id) || resolved == canonical_skills_root.join(skill_id)
+}
+
+/// Drop client-dir symlinks for skill IDs that left `default_skill_ids()`
+/// and whose Orbit-owned target has already been reaped.
+///
+/// A leftover is removed only when it is a symlink, its name is not a
+/// current default, it points at `{skills_root}/{name}` (the path Orbit
+/// itself writes), and that target no longer exists. User custom skill
+/// directories and custom symlinks that still resolve — or that point
+/// outside the Orbit skills root — are left alone.
+fn reap_stale_skill_links(
+    skills_root: &Path,
+    canonical_skills_root: &Path,
+    skill_ids: &[&str],
+    skills_links_dir: &Path,
+) -> Result<bool, OrbitError> {
+    if !skills_links_dir.exists() {
+        return Ok(false);
+    }
+
+    let current: BTreeSet<&str> = skill_ids.iter().copied().collect();
+    let mut changed = false;
+    let entries = fs::read_dir(skills_links_dir).map_err(|e| OrbitError::Io(e.to_string()))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| OrbitError::Io(e.to_string()))?;
+        let path = entry.path();
+        let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        if current.contains(name.as_str()) {
+            continue;
+        }
+        let meta = fs::symlink_metadata(&path).map_err(|e| OrbitError::Io(e.to_string()))?;
+        if !meta.file_type().is_symlink() {
+            continue;
+        }
+        let resolved = resolve_symlink_target(&path)?;
+        if !is_orbit_skill_link_target(&resolved, skills_root, canonical_skills_root, &name) {
+            continue;
+        }
+        if path.exists() {
+            continue;
+        }
+        fs::remove_file(&path).map_err(|e| OrbitError::Io(e.to_string()))?;
+        changed = true;
+    }
     Ok(changed)
 }
 
@@ -1082,6 +1150,110 @@ mod tests {
         }
         assert!(!contents.contains("[crews."));
         assert!(!contents.contains("default_crew"));
+    }
+
+    fn retired_skill_ids() -> [&'static str; 5] {
+        [
+            "orbit-knowledge",
+            "orbit-search",
+            "orbit-task",
+            "orbit-task-pilot",
+            "orbit-workflow",
+        ]
+    }
+
+    fn write_skill_dir(dir: &Path) {
+        fs::create_dir_all(dir).expect("create skill dir");
+        fs::write(dir.join("SKILL.md"), "# skill\n").expect("write SKILL.md");
+    }
+
+    fn seed_orbit_owned_link(skills_root: &Path, links_dir: &Path, skill_id: &str) -> PathBuf {
+        let target = skills_root.join(skill_id);
+        let link = links_dir.join(skill_id);
+        fs::create_dir_all(links_dir).expect("create links dir");
+        create_dir_symlink(&target, &link).expect("create orbit-owned skill link");
+        link
+    }
+
+    #[test]
+    fn ensure_skill_links_reaps_dangling_retired_orbit_owned_links() {
+        let temp = tempdir().expect("tempdir");
+        let skills_root = temp.path().join("skills");
+        let links_dir = temp.path().join("client").join("skills");
+        write_skill_dir(&skills_root.join("orbit"));
+
+        let mut retired_links = Vec::new();
+        for id in retired_skill_ids() {
+            retired_links.push(seed_orbit_owned_link(&skills_root, &links_dir, id));
+        }
+        seed_orbit_owned_link(&skills_root, &links_dir, "orbit");
+
+        let changed = ensure_skill_links(&skills_root, &["orbit"], &links_dir, false)
+            .expect("reconcile skill links");
+        assert!(changed, "reaping retired dangling links is a change");
+
+        assert_skill_link_exists(links_dir.join("orbit"));
+        for link in retired_links {
+            assert!(
+                fs::symlink_metadata(&link).is_err(),
+                "retired dangling Orbit link must be reaped: {}",
+                link.display()
+            );
+        }
+    }
+
+    #[test]
+    fn ensure_skill_links_leaves_live_custom_and_non_orbit_entries() {
+        let temp = tempdir().expect("tempdir");
+        let skills_root = temp.path().join("skills");
+        let links_dir = temp.path().join("client").join("skills");
+        write_skill_dir(&skills_root.join("orbit"));
+
+        let custom_target = temp.path().join("custom-skill");
+        write_skill_dir(&custom_target);
+        let custom_link = links_dir.join("my-custom");
+        fs::create_dir_all(&links_dir).expect("create links dir");
+        create_dir_symlink(&custom_target, &custom_link).expect("create custom skill link");
+
+        let live_retired_target = skills_root.join("orbit-task");
+        write_skill_dir(&live_retired_target);
+        let live_retired_link = seed_orbit_owned_link(&skills_root, &links_dir, "orbit-task");
+
+        let foreign_dangling = links_dir.join("foreign-broken");
+        create_dir_symlink(&temp.path().join("does-not-exist"), &foreign_dangling)
+            .expect("create foreign dangling link");
+
+        let real_dir = links_dir.join("operator-dir");
+        write_skill_dir(&real_dir);
+
+        ensure_skill_links(&skills_root, &["orbit"], &links_dir, false)
+            .expect("reconcile skill links");
+
+        assert_skill_link_exists(links_dir.join("orbit"));
+        assert_eq!(
+            fs::read_link(&custom_link).expect("read custom link"),
+            custom_target
+        );
+        assert!(
+            custom_link.join("SKILL.md").exists(),
+            "live custom skill symlink must be left untouched"
+        );
+        assert_eq!(
+            fs::read_link(&live_retired_link).expect("read live retired link"),
+            live_retired_target,
+            "Orbit-owned link whose target still exists must be left"
+        );
+        assert!(
+            fs::symlink_metadata(&foreign_dangling)
+                .expect("foreign dangling metadata")
+                .file_type()
+                .is_symlink(),
+            "dangling symlink that does not point at the Orbit skills root stays"
+        );
+        assert!(
+            real_dir.join("SKILL.md").exists(),
+            "operator-owned skill directory must be left untouched"
+        );
     }
 
     fn assert_skill_link_exists(path: PathBuf) {

--- a/crates/orbit-core/src/command/skill.rs
+++ b/crates/orbit-core/src/command/skill.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use orbit_common::types::OrbitError;
 
@@ -201,7 +201,7 @@ impl OrbitRuntime {
 
     pub fn doctor_file_skills(&self) -> Result<Vec<SkillDoctorResult>, OrbitError> {
         let rows = self.skill_catalog().doctor()?;
-        Ok(rows
+        let mut results: Vec<SkillDoctorResult> = rows
             .into_iter()
             .map(|row| SkillDoctorResult {
                 skill_name: row.skill_id,
@@ -212,8 +212,57 @@ impl OrbitRuntime {
                 },
                 message: row.message,
             })
-            .collect())
+            .collect();
+        if let Some(home) = crate::paths::home_dir() {
+            results.extend(doctor_client_skill_links(&super::init::skill_link_roots(
+                &home,
+            ))?);
+        }
+        Ok(results)
     }
+}
+
+/// Report dangling/orphaned client skill symlinks under the agent
+/// discovery directories (`~/.claude/skills`, `~/.agents/skills`).
+///
+/// Catalog doctor only walks seeded skill trees. Client CLIs discover
+/// skills through these link dirs, so a leftover after a default-set
+/// shrink is invisible unless this pass inspects them.
+pub(crate) fn doctor_client_skill_links(
+    skills_links_dirs: &[PathBuf],
+) -> Result<Vec<SkillDoctorResult>, OrbitError> {
+    let mut rows = Vec::new();
+    for dir in skills_links_dirs {
+        if !dir.exists() {
+            continue;
+        }
+        let mut paths = Vec::new();
+        for entry in std::fs::read_dir(dir).map_err(|e| OrbitError::Io(e.to_string()))? {
+            paths.push(entry.map_err(|e| OrbitError::Io(e.to_string()))?.path());
+        }
+        paths.sort();
+        for path in paths {
+            let meta =
+                std::fs::symlink_metadata(&path).map_err(|e| OrbitError::Io(e.to_string()))?;
+            if !meta.file_type().is_symlink() {
+                continue;
+            }
+            if path.exists() {
+                continue;
+            }
+            let skill_name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("?")
+                .to_string();
+            rows.push(SkillDoctorResult {
+                skill_name,
+                status: SkillDoctorStatus::Error,
+                message: format!("dangling skill link at {} (target missing)", path.display()),
+            });
+        }
+    }
+    Ok(rows)
 }
 
 #[cfg(test)]
@@ -861,6 +910,59 @@ mod tests {
              artifact id (ORB-10208):\n{}",
             failures.len(),
             failures.join("\n"),
+        );
+    }
+
+    #[test]
+    fn doctor_client_skill_links_reports_dangling_and_ignores_live_targets() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let claude = root.path().join(".claude").join("skills");
+        let agents = root.path().join(".agents").join("skills");
+        std::fs::create_dir_all(&claude).expect("create claude skills dir");
+        std::fs::create_dir_all(&agents).expect("create agents skills dir");
+
+        let live_target = root.path().join("custom");
+        std::fs::create_dir_all(&live_target).expect("create custom skill");
+        std::fs::write(live_target.join("SKILL.md"), "# custom\n").expect("write custom skill");
+        orbit_common::utility::fs::create_dir_symlink(&live_target, &claude.join("my-custom"))
+            .expect("create live custom link");
+
+        orbit_common::utility::fs::create_dir_symlink(
+            &root.path().join("missing-orbit-task"),
+            &claude.join("orbit-task"),
+        )
+        .expect("create dangling claude link");
+        orbit_common::utility::fs::create_dir_symlink(
+            &root.path().join("missing-orbit-search"),
+            &agents.join("orbit-search"),
+        )
+        .expect("create dangling agents link");
+
+        let real_dir = claude.join("operator-dir");
+        std::fs::create_dir_all(&real_dir).expect("create operator dir");
+
+        let rows = doctor_client_skill_links(&[claude, agents]).expect("inspect client links");
+        assert_eq!(
+            rows.len(),
+            2,
+            "only dangling symlinks are reported: {rows:?}"
+        );
+        assert!(
+            rows.iter()
+                .all(|row| row.status == SkillDoctorStatus::Error),
+            "dangling client links are errors: {rows:?}"
+        );
+        let names: BTreeSet<&str> = rows.iter().map(|row| row.skill_name.as_str()).collect();
+        assert_eq!(
+            names,
+            BTreeSet::from(["orbit-search", "orbit-task"]),
+            "reported names: {rows:?}"
+        );
+        assert!(
+            rows.iter()
+                .all(|row| row.message.contains("dangling skill link")
+                    && row.message.contains("target missing")),
+            "messages name the dangling-link condition: {rows:?}"
         );
     }
 }

--- a/website/src/content/docs/getting-started/install.md
+++ b/website/src/content/docs/getting-started/install.md
@@ -72,7 +72,7 @@ cd <repo>
 orbit workspace init
 ```
 
-`orbit init` seeds default skills under `~/.orbit/skills` and links them into `~/.agents/skills` and `~/.claude/skills`. Workspace skills are optional overrides by skill name.
+`orbit init` seeds default skills under `~/.orbit/skills` and links them into `~/.agents/skills` and `~/.claude/skills`. The same reconcile removes dangling Orbit-owned links for retired default skill IDs; a leftover custom skill is left in place. Workspace skills are optional overrides by skill name.
 
 Pass `--mcp` to also auto-detect and set up MCP client integrations during workspace initialization:
 


### PR DESCRIPTION
## Task

[ORB-10869](https://orbit-cli.com/tasks/ORB-10869) — orbit workspace init leaves dangling ~/.claude/skills and ~/.agents/skills symlinks for skills retired by ORB-10860

### Description

## Problem

ORB-10860 (`ed1331be`, "Collapse the Orbit skill tree into one router skill", merged into `agent-main` at `80240256`) reduced `default_skill_ids()` from five skills (`orbit`, `orbit-task`, `orbit-search`, `orbit-workflow`, `orbit-task-pilot`; `orbit-knowledge` was already retired earlier) down to one (`orbit`). The task's own plan explicitly claims this is safe: "unmodified seeded copies of the three dropped skills are reaped on the next init."

Hands-on validation shows the reap is incomplete: `seed_default_skills` (`crates/orbit-core/src/command/skill.rs`) correctly retires the unmodified skill directories under `~/.orbit/skills/` via managed-asset reconciliation (confirmed: after `orbit workspace init`, `~/.orbit/skills/` contains only `orbit/`). But `ensure_skill_links` / `link_skills` (`crates/orbit-core/src/command/init.rs:468-605`) only ever *adds or repairs* links for IDs currently in `default_skill_ids()`; nothing removes a symlink whose ID has left the default set. `unlink_skills` exists but is only invoked wholesale at workspace teardown, never selectively during init/reconcile. `orbit skill doctor` (`doctor_file_skills` in `crates/orbit-core/src/command/skill.rs:202`) only walks the current skill catalog and never inspects `~/.claude/skills/` or `~/.agents/skills/` for orphaned entries, so it reports "All skills healthy" even with dangling links present.

Net effect: every pre-existing Orbit install that upgrades across ORB-10860 keeps 5 dangling symlinks in *each* of `~/.claude/skills/` and `~/.agents/skills/` (10 total) forever: `orbit-knowledge`, `orbit-search`, `orbit-task`, `orbit-task-pilot`, `orbit-workflow`. Claude Code, Codex, and Gemini CLI all discover skills through these directories per README.md's "Agent Skills" section, so every one of those clients sees broken/dangling skill entries after the upgrade, and `orbit skill doctor` gives a false-clean bill of health.

## Evidence / Reproduction

On commit `80240256` (current `agent-main` tip, worktree `.orbit/state/worktrees/orbit-jrun-20260816-0241-6`):

```
$ ls ~/.orbit/skills/
orbit  .orbit-managed-assets.json          # only the surviving skill, as expected

$ ls ~/.claude/skills/
orbit  orbit-knowledge  orbit-search  orbit-task  orbit-task-pilot  orbit-workflow

$ for l in orbit-knowledge orbit-search orbit-task orbit-task-pilot orbit-workflow; do
    test -e ~/.claude/skills/$l && echo "$l OK" || echo "$l DANGLING"
  done
orbit-knowledge DANGLING
orbit-search DANGLING
orbit-task DANGLING
orbit-task-pilot DANGLING
orbit-workflow DANGLING
# same 5 dangling links under ~/.agents/skills/

$ ./target/debug/orbit skill doctor
orbit	ok	
All skills healthy.       # false clean bill of health; does not see the 10 dangling links
```

Ran a fresh `./target/debug/orbit workspace init --root /tmp/orbit-qa-10863` (built from this checkout) immediately before the above `ls`/`test -e` checks; it re-seeded `~/.orbit/skills/orbit` (mtime bumped) but did not touch the stale symlinks, confirming init does not reconcile them.

## Suggested fix

Have `ensure_skill_links` (or a sibling reconcile step called from the same init path that seeds/reaps `~/.orbit/skills/`) remove any symlink under each `skills_links_dir` whose name is not in the current `default_skill_ids()` and whose target has been reaped (mirroring the content-provenance reap already used for `~/.orbit/skills/` itself, so a user's own custom skill directories/symlinks are left alone). Extend `orbit skill doctor` to flag orphaned/dangling entries in `~/.claude/skills/` and `~/.agents/skills/` so this class of drift is detectable without manual `ls`.

### Acceptance Criteria

- After `orbit workspace init` (or an equivalent reconcile path) runs on a workspace that previously had the five pre-consolidation skills linked, no dangling symlinks for retired skill IDs (`orbit-knowledge`, `orbit-search`, `orbit-task`, `orbit-task-pilot`, `orbit-workflow`) remain under `~/.claude/skills/` or `~/.agents/skills/`.
- A symlink whose target skill directory still exists (e.g. a user's own custom skill) is left untouched by the same reconcile pass.
- `orbit skill doctor` detects and reports a dangling/orphaned symlink under the client skill link directories instead of reporting "All skills healthy".

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `ensure_skill_links` now reaps Orbit-owned dangling client-dir symlinks whose IDs left `default_skill_ids()` and whose stored target is `{skills_root}/{name}` with the directory already gone. Live custom skill directories, live custom symlinks, and dangling links that point outside the Orbit skills root are left alone. The same path runs from `orbit workspace init` (global root + refresh), `orbit init`, and `orbit skill link`.
- `orbit skill doctor` appends one Error row per dangling symlink under `~/.claude/skills` and `~/.agents/skills`, so leftover client-dir orphans no longer yield "All skills healthy."
- README Agent Skills and the install page document the reconcile and doctor coverage.
Assessment: Acceptance criteria are met at the `ensure_skill_links` / `doctor_file_skills` seams. Reap is conservative (Orbit-owned target only) so a user's dangling custom skill link is not deleted; doctor still reports it.
Validation: cargo test -p orbit-core --lib (ensure_skill_links reap/preserve + existing global/workspace link tests + doctor_client_skill_links) passed; make ci-fast passed; make ci-lint passed.
Unlisted files edited: file:README.md and file:website/src/content/docs/getting-started/install.md — same-PR docs for the new reconcile/doctor behavior (appended to context_files).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10869-6a8125c5`
- Behind base: 0
- Ahead of base: 1