### PR TITLE
chore: prepare v0.12.0 release [ORB-10870]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.12.0
+
+### Breaking Changes
+
+- **Seeded skill directories retired**: `orbit-task`, `orbit-search`, `orbit-workflow`, and the plugin `orbit-task-pilot` skill are gone — use the `orbit` router skill and its `references/`. ([ORB-10860])
+
+### Highlights
+
+- **One Orbit skill**: four seeded skills collapsed into a single `orbit` router with on-demand references. ([ORB-10860])
+- **Stale skill links cleaned on upgrade**: `workspace init` removes dangling Claude/Codex skill symlinks left after skill retirement. ([ORB-10869])
+- **Doctor reports leftover skill directories**: orphaned skill dirs without SKILL.md are a warning, not a clean bill of health. ([ORB-10862])
+- **Safer artifact redaction**: env-value redaction no longer silently eats ordinary words in task prose. ([ORB-10867])
+
 ## 0.11.0
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbit-agent"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -2132,7 +2132,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cmd"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-common"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "croner",
@@ -2203,7 +2203,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-engine"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -2226,7 +2226,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-exec"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "libc",
  "orbit-common",
@@ -2237,7 +2237,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-mcp"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-policy"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2264,7 +2264,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-registry"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "hostname",
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-search"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-store"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2319,7 +2319,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-tools"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-web"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 license = "MIT"
 # MSRV [ORB-10010]: edition 2024 requires >= 1.85; the highest `rust-version`

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface, skills, and orchestration subagents to Claude Code.",
   "author": {
     "name": "danieljhkim",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP task and knowledge surface plus workflow skills to Codex.",
   "author": {
     "name": "danieljhkim",

--- a/plugin/npm/package.json
+++ b/plugin/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbit-tools/cli",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "npm proxy for the Orbit CLI. Downloads the matching native binary from GitHub Releases on install and forwards all invocations.",
   "bin": {
     "orbit": "bin/orbit.js"


### PR DESCRIPTION
Prepare v0.12.0.

- CHANGELOG `## 0.12.0` with the confirmed breaking change (ORB-10860) and four Highlights.
- Five version files bumped in lockstep: Cargo.toml, Cargo.lock, both plugin manifests, npm package.
- `cargo update --workspace` moved only workspace members. `make build` is clean.
- Pre-tag `make release-check` reports only the expected local 0.12.0 > remote 0.11.0 drift.

After this lands on `agent-main`, tag `v0.12.0` and follow RELEASING.md §10–11.