### PR TITLE
Clarify the Tasks view and make live-log and inline edits safer

### DIFF
--- a/crates/orbit-web/assets/dashboard/app.js
+++ b/crates/orbit-web/assets/dashboard/app.js
@@ -2,7 +2,7 @@
 // Pure vanilla JS, split into ES modules with no build step.
 
 import { el, statusPill, stateCell, fetchJson, listItems, requestJson, postJson, patchJson, syncNodes, positiveIntParam, getWorkspace, setWorkspace, setMultiWorkspace, isAggregateView, renderPanelPlaceholder } from './common.js';
-import { buildChips, cacheCrewPayload, copyTaskIdWithNotice, hasCrewOptions, openVisibleTask, renderTasks, setPinnedExternalTask, wireSearch } from './tasks.js';
+import { buildChips, buildTasksHash, applyTasksHashQuery, cacheCrewPayload, copyTaskIdWithNotice, hasCrewOptions, openVisibleTask, renderTasks, setPinnedExternalTask, syncTaskControls, wireSearch } from './tasks.js';
 import { applyAuditHashQuery, buildAuditChips, buildAuditHash, fetchAndRenderAudit, fetchAndRenderPolicy, getActiveAuditSubtab, navigateToAuditExecution, renderAuditSummary, setActiveAuditSubtabFromButton, setAuditSubtab, syncAuditControls, wireAuditSearch, } from './audit.js';
 import { renderScoreboard } from './scoreboard.js';
 import { fetchAndRenderReliability, wireReliabilityWindowSelector } from './reliability.js';
@@ -49,6 +49,10 @@ const DEFAULT_INACTIVE_STATUSES = new Set(["someday"]);
 const STATUS_UPDATE_TARGETS = STATUS_ORDER
   .filter((status) => !["rejected", "archived"].includes(status))
   .concat(["done"]);
+// ORB-10874: the statuses shown when no `status` filter is represented in the
+// URL — a single source both the initial in-memory state and the hash-parsing
+// default (applyTasksHashQuery) read from, so they cannot drift apart.
+const DEFAULT_ACTIVE_STATUSES = STATUS_ORDER.filter((s) => !DEFAULT_INACTIVE_STATUSES.has(s));
 
 const JOB_RUN_LIMIT = positiveIntParam("runs", 25);
 const DIAG_LIMIT = positiveIntParam("diag", 50);
@@ -59,10 +63,13 @@ const FRICTION_STATUSES = ["open", "triaged", "resolved"];
 const $ = (id) => document.getElementById(id);
 
 let searchQuery = "";
-let activeStatuses = new Set(
-  STATUS_ORDER.filter((s) => !DEFAULT_INACTIVE_STATUSES.has(s)),
-);
+let activeStatuses = new Set(DEFAULT_ACTIVE_STATUSES);
 let lastTasks = [];
+// ORB-10874: paging metadata from the single-workspace `/api/tasks` envelope
+// (`{ items, total, limit, truncated }`) so the count can state a shown/total/
+// server-limit fact instead of an ambiguous `N/50`. Null for the aggregate
+// `/api/tasks/all` view, which answers a bare array with no such metadata.
+let lastTasksMeta = null;
 let lastRuns = [];
 let lastDiagnostics = { metrics: [], errors: [], implement_one: [] };
 let lastFrictionPayload = { stats: {}, tags: [], items: [] };
@@ -83,6 +90,7 @@ let dashboardWorkspaces = [];
 function taskContext() {
   return {
     getTasks: () => lastTasks,
+    getTasksMeta: () => lastTasksMeta,
     replaceTask: (updatedTask) => {
       const index = lastTasks.findIndex((task) => task.id === updatedTask.id);
       if (index >= 0) {
@@ -94,6 +102,7 @@ function taskContext() {
     getActiveStatuses: () => activeStatuses,
     setActiveStatuses: (statuses) => { activeStatuses = statuses; },
     statusOrder: STATUS_ORDER,
+    defaultActiveStatuses: DEFAULT_ACTIVE_STATUSES,
     statusUpdateTargets: STATUS_UPDATE_TARGETS,
     fmtAbsTime,
     refreshDashboard,
@@ -167,6 +176,13 @@ function routerContext() {
     setActiveAuditSubtabFromButton,
     buildAuditHash,
     syncAuditControls,
+
+    // ORB-10874: tasks pass-throughs (mirrors the audit ones above) so the
+    // status/search filters shown on the Tasks tab are represented in the
+    // hash and survive reload/back-navigation the same way audit's do.
+    applyTasksHashQuery: (query) => applyTasksHashQuery(query, taskContext()),
+    buildTasksHash: () => buildTasksHash(taskContext()),
+    syncTaskControls: () => syncTaskControls(taskContext()),
   };
 }
 
@@ -807,12 +823,27 @@ function fetchAndCacheCrews() {
   });
 }
 
+// ORB-10874: the single-workspace list endpoint filters server-side, so the
+// active status chips are sent as `?status=a,b` instead of over-fetching every
+// status and filtering client-side. That keeps the `total`/`limit`/`truncated`
+// envelope meaningful for the filter actually in effect (see formatTaskCount
+// in tasks.js). Omitted when every status (or none) is active, matching the
+// endpoint's own "status-neutral" default for the all-active case.
+function tasksListPath() {
+  const sp = new URLSearchParams();
+  if (activeStatuses.size > 0 && activeStatuses.size < STATUS_ORDER.length) {
+    sp.set("status", STATUS_ORDER.filter((s) => activeStatuses.has(s)).join(","));
+  }
+  const qs = sp.toString();
+  return qs ? `/api/tasks?${qs}` : "/api/tasks";
+}
+
 function fetchAndRenderTasks() {
   // In global mode with the aggregate ("All workspaces") view selected, pull
   // every workspace's tasks; otherwise the single/selected workspace's tasks
   // (the workspace query param is applied by fetchJson).
   const aggregate = isAggregateView();
-  const path = aggregate ? "/api/tasks/all" : "/api/tasks";
+  const path = aggregate ? "/api/tasks/all" : tasksListPath();
   // /api/crews is per-workspace and 400s without a concrete workspace, so in
   // aggregate mode skip the crew fetch and let the crew controls degrade to a
   // disabled "crew unavailable" fallback rather than rejecting the Promise.all
@@ -825,9 +856,13 @@ function fetchAndRenderTasks() {
     fetchJson(path),
     crews,
   ]).then(([payload]) => {
-    // /api/tasks answers `{ items, ... }` (ORB-10400); /api/tasks/all a bare array.
+    // /api/tasks answers `{ items, total, limit, truncated }` (ORB-10400);
+    // /api/tasks/all a bare array with no paging metadata.
     const tasks = listItems(payload);
     lastTasks = tasks;
+    lastTasksMeta = !aggregate && payload && !Array.isArray(payload)
+      ? { total: payload.total, limit: payload.limit, truncated: payload.truncated }
+      : null;
     renderTasks(tasks, taskContext());
   });
 }
@@ -883,11 +918,27 @@ function buildWorkspaceSelector() {
 
   select.addEventListener("change", () => {
     setWorkspace(select.value);
+    persistWorkspaceToUrl(select.value);
     refreshDashboard();
   });
 
   const meta = $("meta");
   meta.insertBefore(select, $("refresh-btn"));
+}
+
+// ORB-10874: the workspace selector only updated in-memory state, so a reload
+// or a copied link silently fell back to the server's default workspace
+// instead of the one the operator was actually looking at. `getWorkspace()`
+// already seeds from `?workspace=` on first load (common.js); this keeps that
+// query param in sync on every selection without a full navigation/reload.
+function persistWorkspaceToUrl(id) {
+  const url = new URL(window.location.href);
+  if (id) {
+    url.searchParams.set("workspace", id);
+  } else {
+    url.searchParams.delete("workspace");
+  }
+  history.replaceState(null, "", url);
 }
 
 function activeRefreshJobs() {

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -231,6 +231,10 @@
       
       #tasks-panel > .body {
         max-height: calc(100vh - 240px);
+        /* ORB-10874: floor so the task inventory stays usable (a few visible
+           rows) even on a short viewport or with the log panel expanded — it
+           never gets squeezed toward zero by the surrounding chrome. */
+        min-height: 240px;
         overflow-y: auto;
         overflow-x: auto;
         view-transition-name: task-list;
@@ -476,6 +480,59 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+      }
+
+      /* ORB-10874: inline pending/success/error feedback for the status/crew
+         selects. Never color-only — each state carries its own text, and
+         `success`/`error` additionally offer a bounded undo. */
+      .mutation-feedback {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        line-height: 1.25;
+      }
+      .mutation-feedback.pending { color: var(--fg-dim); font-style: italic; }
+      .mutation-feedback.success { color: var(--state-success); }
+      .mutation-feedback.error {
+        color: var(--state-failed);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .mutation-undo {
+        font: inherit;
+        color: var(--accent);
+        background: transparent;
+        border: 1px solid var(--accent);
+        border-radius: 2px;
+        padding: 0 5px;
+        cursor: pointer;
+        flex-shrink: 0;
+      }
+      .mutation-undo:hover { background: rgba(110, 159, 255, 0.1); }
+
+      /* ORB-10874: task/status controls must be usable without relying on
+         color alone — a visible focus ring on top of the existing
+         border-color change. */
+      .task-status-select:focus-visible,
+      .task-crew-select:focus-visible,
+      .chip:focus-visible,
+      .mutation-undo:focus-visible,
+      .log-panel-toggle:focus-visible,
+      .log-resize-handle:focus-visible {
+        outline: 2px solid var(--accent-hover);
+        outline-offset: 2px;
+      }
+
+      .filter-summary {
+        padding: 6px 16px;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--fg-dim);
+        border-bottom: 1px solid var(--border);
+        background: var(--bg);
       }
 
       .detail-side .complexity {
@@ -3196,6 +3253,23 @@
           grid-template-columns: minmax(0, 2fr) minmax(280px, 1.15fr) !important;
         }
       }
+      /* ORB-10874: below ~760px the two-column task/log layout has no room
+         left for either column, so stack them — the task list keeps its own
+         independently-scrolling, min-height-guaranteed body (below) and the
+         log panel follows underneath rather than both being squeezed into
+         slivers side by side. */
+      @media (max-width: 760px) {
+        main.tasks-layout {
+          grid-template-columns: 1fr !important;
+        }
+        .col-log {
+          min-height: auto;
+        }
+        #log-panel {
+          height: var(--log-panel-height, 260px);
+          max-height: var(--log-panel-height, 260px);
+        }
+      }
       .col-log {
         display: flex;
         flex-direction: column;
@@ -3279,9 +3353,59 @@
         white-space: nowrap;
       }
       #log-panel {
+        position: relative;
         height: var(--log-panel-height, calc(100dvh - 420px));
         max-height: var(--log-panel-height, calc(100dvh - 420px));
       }
+      /* ORB-10874: collapsed keeps only the header (with its toggle/filters
+         reachable via the header itself where relevant) so the operator can
+         still see the panel exists and re-expand it, without it occupying
+         the space a mid-height panel would. */
+      #log-panel.collapsed {
+        height: auto;
+        max-height: none;
+        flex: 0 0 auto;
+      }
+      #log-panel.collapsed .log-stream,
+      #log-panel.collapsed .log-foot {
+        display: none;
+      }
+      .log-resize-handle {
+        position: absolute;
+        top: -5px;
+        left: 0;
+        right: 0;
+        height: 10px;
+        cursor: row-resize;
+        z-index: 2;
+        touch-action: none;
+      }
+      .log-resize-handle::after {
+        content: "";
+        display: block;
+        margin: 4px auto 0;
+        width: 36px;
+        height: 3px;
+        border-radius: 2px;
+        background: var(--border);
+      }
+      .log-resize-handle:hover::after { background: var(--fg-dim); }
+      #log-panel.collapsed .log-resize-handle { cursor: default; pointer-events: none; }
+      .log-panel-toggle {
+        font: inherit;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--fg-dim);
+        background: var(--bg-elev);
+        border: 1px solid var(--border);
+        border-radius: 3px;
+        padding: 2px 8px;
+        cursor: pointer;
+        margin-left: 6px;
+      }
+      .log-panel-toggle:hover { color: var(--fg); border-color: var(--fg-dim); }
       .col-log .panel > header .title {
         display: flex; align-items: center; gap: 10px;
       }

--- a/crates/orbit-web/assets/dashboard/index.html
+++ b/crates/orbit-web/assets/dashboard/index.html
@@ -67,9 +67,10 @@
           <section class="panel" id="tasks-panel">
             <header><span>Tasks</span><span class="count" id="tasks-count">-</span></header>
             <div class="controls">
-              <input type="search" id="task-search" placeholder="Search ID or title..." autocomplete="off" spellcheck="false" />
-              <div id="task-filter"></div>
+              <input type="search" id="task-search" placeholder="Search ID or title..." autocomplete="off" spellcheck="false" aria-label="Search tasks by ID or title" />
+              <div id="task-filter" role="group" aria-label="Filter tasks by status"></div>
             </div>
+            <div class="filter-summary" id="task-filter-summary" role="status" aria-live="polite"></div>
             <div class="body" id="tasks-body">
               <div class="skeleton-state">
                 <div class="skeleton skeleton-row"></div>
@@ -85,11 +86,13 @@
             <div class="body" id="locks-body"></div>
           </section>
           <section class="panel" id="log-panel">
+            <div class="log-resize-handle" id="log-panel-resize" role="separator" aria-orientation="horizontal" aria-label="Resize log panel" tabindex="0" title="Drag or use arrow keys to resize"></div>
             <header class="head">
               <div class="title"><span class="live-dot"></span>orbit.log <span style="color: var(--fg-dim); font-family: var(--font-mono); font-weight: 400; letter-spacing: 0; text-transform: none;">— tail -F</span></div>
               <div class="actions">
                 <span class="count" id="log-count" style="background: var(--bg-elev); padding: 1px 8px; border: 1px solid var(--border); border-radius: 3px; font-family: var(--font-mono); font-size: 11px;">0</span>
                 <span class="count" id="log-buffered-count" style="display: none; cursor: pointer; background: var(--bg-elev); padding: 1px 8px; border: 1px solid var(--border); border-radius: 3px; font-family: var(--font-mono); font-size: 11px; margin-left: 6px;">0 buffered</span>
+                <button type="button" class="log-panel-toggle" id="log-panel-toggle" aria-expanded="true" aria-controls="logInner" title="Collapse or expand the log panel">collapse</button>
               </div>
             </header>
             <div class="log-stream">

--- a/crates/orbit-web/assets/dashboard/log-tail.js
+++ b/crates/orbit-web/assets/dashboard/log-tail.js
@@ -18,13 +18,134 @@ let logRows = []; // Keep track to enforce max 200 after 250 limit
 let activeLogFilters = new Set(["all"]);
 let logPanelResizeWired = false;
 
+// ORB-10874: the log pane can be collapsed and resized; both are local
+// presentation preferences (not shared/synced state), so they persist to
+// localStorage rather than the URL. `heightPx` is only present once the
+// operator has dragged the handle — until then the panel keeps auto-fitting
+// to the viewport exactly as before.
+const LOG_PANEL_PREFS_KEY = "orbit.dashboard.logPanel";
+const LOG_PANEL_MIN_HEIGHT = 160;
+
+function loadLogPanelPrefs() {
+  try {
+    const raw = window.localStorage.getItem(LOG_PANEL_PREFS_KEY);
+    const parsed = raw ? JSON.parse(raw) : {};
+    return {
+      collapsed: Boolean(parsed.collapsed),
+      heightPx: Number.isFinite(parsed.heightPx) ? parsed.heightPx : null,
+    };
+  } catch (_) {
+    return { collapsed: false, heightPx: null };
+  }
+}
+
+function saveLogPanelPrefs(prefs) {
+  try {
+    window.localStorage.setItem(LOG_PANEL_PREFS_KEY, JSON.stringify(prefs));
+  } catch (_) {
+    /* localStorage unavailable (private mode, quota) — presentation prefs are non-essential */
+  }
+}
+
+let logPanelPrefs = loadLogPanelPrefs();
+
+function maxLogPanelHeight() {
+  const panel = $("log-panel");
+  if (!panel) return Infinity;
+  const top = panel.getBoundingClientRect().top;
+  return Math.max(LOG_PANEL_MIN_HEIGHT, Math.floor(window.innerHeight - top - 24));
+}
+
 export function fitLogPanelToViewport() {
   const panel = $("log-panel");
   if (!panel) return;
-  const top = panel.getBoundingClientRect().top;
-  const available = Math.floor(window.innerHeight - top - 24);
-  if (available <= 0) return;
-  panel.style.setProperty("--log-panel-height", `${available}px`);
+  applyLogPanelCollapsedState();
+  if (logPanelPrefs.collapsed) return;
+  const cap = maxLogPanelHeight();
+  const height = logPanelPrefs.heightPx != null
+    ? Math.min(Math.max(logPanelPrefs.heightPx, LOG_PANEL_MIN_HEIGHT), cap)
+    : cap;
+  panel.style.setProperty("--log-panel-height", `${height}px`);
+}
+
+function applyLogPanelCollapsedState() {
+  const panel = $("log-panel");
+  const toggle = $("log-panel-toggle");
+  if (!panel) return;
+  panel.classList.toggle("collapsed", logPanelPrefs.collapsed);
+  if (toggle) {
+    toggle.setAttribute("aria-expanded", logPanelPrefs.collapsed ? "false" : "true");
+    toggle.textContent = logPanelPrefs.collapsed ? "expand" : "collapse";
+  }
+  if (logPanelPrefs.collapsed) {
+    panel.style.removeProperty("--log-panel-height");
+  }
+}
+
+function wireLogPanelToggle() {
+  const toggle = $("log-panel-toggle");
+  if (!toggle) return;
+  toggle.addEventListener("click", () => {
+    logPanelPrefs = { ...logPanelPrefs, collapsed: !logPanelPrefs.collapsed };
+    saveLogPanelPrefs(logPanelPrefs);
+    fitLogPanelToViewport();
+  });
+}
+
+// A pointer-driven drag handle on the log panel's top edge. Dragging sets an
+// explicit height (persisted), clamped so the panel can never be resized
+// smaller than LOG_PANEL_MIN_HEIGHT nor larger than the viewport allows —
+// the task list beside/above it keeps its own independent minimum height
+// (dashboard.css), so this clamp only protects the log panel itself.
+function wireLogPanelResizeHandle() {
+  const handle = $("log-panel-resize");
+  const panel = $("log-panel");
+  if (!handle || !panel) return;
+
+  let dragStartY = 0;
+  let dragStartHeight = 0;
+
+  const onPointerMove = (event) => {
+    const delta = event.clientY - dragStartY;
+    const cap = maxLogPanelHeight();
+    const next = Math.min(Math.max(dragStartHeight + delta, LOG_PANEL_MIN_HEIGHT), cap);
+    panel.style.setProperty("--log-panel-height", `${next}px`);
+  };
+
+  const onPointerUp = (event) => {
+    document.removeEventListener("pointermove", onPointerMove);
+    document.removeEventListener("pointerup", onPointerUp);
+    const rect = panel.getBoundingClientRect();
+    logPanelPrefs = { ...logPanelPrefs, heightPx: Math.round(rect.height), collapsed: false };
+    saveLogPanelPrefs(logPanelPrefs);
+    applyLogPanelCollapsedState();
+  };
+
+  handle.addEventListener("pointerdown", (event) => {
+    if (logPanelPrefs.collapsed) return;
+    event.preventDefault();
+    dragStartY = event.clientY;
+    dragStartHeight = panel.getBoundingClientRect().height;
+    document.addEventListener("pointermove", onPointerMove);
+    document.addEventListener("pointerup", onPointerUp);
+  });
+
+  // Keyboard resize (ArrowUp/ArrowDown) for operators who cannot drag.
+  handle.addEventListener("keydown", (event) => {
+    if (logPanelPrefs.collapsed) return;
+    const step = 32;
+    let delta = 0;
+    if (event.key === "ArrowUp") delta = -step;
+    else if (event.key === "ArrowDown") delta = step;
+    else return;
+    event.preventDefault();
+    const cap = maxLogPanelHeight();
+    const current = panel.getBoundingClientRect().height;
+    const next = Math.min(Math.max(current + delta, LOG_PANEL_MIN_HEIGHT), cap);
+    panel.style.setProperty("--log-panel-height", `${next}px`);
+    logPanelPrefs = { ...logPanelPrefs, heightPx: Math.round(next), collapsed: false };
+    saveLogPanelPrefs(logPanelPrefs);
+  });
 }
 
 function wireLogPanelResize() {
@@ -35,6 +156,9 @@ function wireLogPanelResize() {
   if (window.visualViewport) {
     window.visualViewport.addEventListener("resize", scheduleFit);
   }
+  wireLogPanelToggle();
+  wireLogPanelResizeHandle();
+  applyLogPanelCollapsedState();
 }
 
 function getLogClass(level, code) {

--- a/crates/orbit-web/assets/dashboard/router.js
+++ b/crates/orbit-web/assets/dashboard/router.js
@@ -223,6 +223,13 @@ function setActiveTabImpl(ctx, raw, opts = {}) {
     const sub = KNOWLEDGE_SUBTABS.includes(segments[1]) ? segments[1] : ctx.getKnowledgeSubtab();
     setKnowledgeSubtabImpl(ctx, sub);
     hash = `#knowledge/${sub}`;
+  } else if (top === "tasks") {
+    // ORB-10874: the status chips and search box are represented in the hash
+    // (mirroring the audit tab) so they survive a reload or the browser's
+    // back/forward navigation instead of resetting to the in-memory default.
+    if (ctx.applyTasksHashQuery) ctx.applyTasksHashQuery(query);
+    if (ctx.syncTaskControls) ctx.syncTaskControls();
+    hash = ctx.buildTasksHash ? ctx.buildTasksHash() : "#tasks";
   } else {
     hash = `#${top}`;
   }

--- a/crates/orbit-web/assets/dashboard/tasks.js
+++ b/crates/orbit-web/assets/dashboard/tasks.js
@@ -1,7 +1,7 @@
 // Orbit dashboard task-domain rendering and actions.
 // Pure vanilla JS, split into ES modules with no build step.
 
-import { el, statusPill, patchJson, postJson, syncNodes, withWorkspace } from './common.js';
+import { el, statusPill, patchJson, postJson, syncNodes, isAggregateView, withWorkspace } from './common.js';
 import { renderMarkdown, renderMarkdownInline } from './markdown.js';
 
 const $ = (id) => document.getElementById(id);
@@ -9,8 +9,15 @@ const $ = (id) => document.getElementById(id);
 let lastCrewPayload = { default_crew: null, crews: [] };
 let expandedTaskIds = new Set();
 let taskActionNotice = null;
-let crewUpdateErrors = new Map();
 let pinnedExternalTask = null;
+// ORB-10874: per-task inline-edit feedback for the status/crew selects. Each
+// entry is `{ kind: 'pending'|'success'|'error', text, undo }`, where `undo`
+// (when present) is `{ previousValue, expiresAt }` — a bounded window in which
+// the prior value can still be restored with one click. Cleared automatically
+// once that window lapses (see scheduleFeedbackExpiry).
+let statusFeedback = new Map();
+let crewFeedback = new Map();
+const MUTATION_UNDO_WINDOW_MS = 8000;
 // ORB-10444: task ids whose Ship dispatch this page has already issued. Ship is
 // a write against a live pipeline, so a second click must not launch a second
 // run: the id stays here for the life of the page once a dispatch succeeds (the
@@ -64,6 +71,81 @@ function refreshTasks(context) {
     : Promise.resolve();
 }
 
+function defaultActiveStatuses(context) {
+  return context && Array.isArray(context.defaultActiveStatuses)
+    ? context.defaultActiveStatuses
+    : statusOrder(context);
+}
+
+function tasksMeta(context) {
+  return context && typeof context.getTasksMeta === "function" ? context.getTasksMeta() : null;
+}
+
+// ORB-10874: explicit shown/total/server-limit language instead of the
+// ambiguous `N/50` shorthand — `50` could previously have meant a total, a
+// page size, or a hard cap with no way to tell which from the UI alone.
+export function formatTaskCount(filteredCount, fetchedCount, meta) {
+  if (meta && Number.isFinite(meta.total)) {
+    const base = filteredCount === fetchedCount
+      ? `${filteredCount} shown`
+      : `${filteredCount} shown (of ${fetchedCount} fetched)`;
+    return meta.truncated
+      ? `${base} · ${meta.total} total · server limit ${meta.limit}`
+      : `${base} · ${meta.total} total`;
+  }
+  return filteredCount === fetchedCount
+    ? `${fetchedCount} shown`
+    : `${filteredCount} shown of ${fetchedCount} fetched`;
+}
+
+// ORB-10874: aggregate ("All workspaces") mode has no ambient workspace to
+// scope a mutation to. A task fetched through /api/tasks/all carries its own
+// `workspace_id`, so that's an explicit, workspace-qualified target; anything
+// else is refused rather than silently applied to the wrong (or no) workspace.
+function canMutateTask(task) {
+  return !isAggregateView() || Boolean(task && task.workspace_id);
+}
+
+function taskMutationPath(task, suffix = "") {
+  const base = `/api/tasks/${encodeURIComponent(task.id)}${suffix}`;
+  if (isAggregateView() && task.workspace_id) {
+    const sep = base.includes("?") ? "&" : "?";
+    return `${base}${sep}workspace=${encodeURIComponent(task.workspace_id)}`;
+  }
+  return base;
+}
+
+function scheduleFeedbackExpiry(map, taskId, context, delay) {
+  setTimeout(() => {
+    const entry = map.get(taskId);
+    if (entry && entry.kind !== "pending") {
+      map.delete(taskId);
+      renderTasks(taskList(context), context);
+    }
+  }, delay);
+}
+
+// Renders the inline pending/success/error text next to a status or crew
+// select, plus a bounded "undo" button while `entry.undo` is still live. The
+// wrapper is a live region so screen-reader users get the same feedback a
+// sighted user reads from the text/color change.
+function buildMutationFeedback(entry, onUndo) {
+  if (!entry) return null;
+  const wrap = el("span", { class: `mutation-feedback ${entry.kind}`, text: entry.text });
+  wrap.setAttribute("role", "status");
+  wrap.setAttribute("aria-live", entry.kind === "error" ? "assertive" : "polite");
+  if (entry.undo) {
+    const undoBtn = el("button", { class: "mutation-undo", text: "undo" });
+    undoBtn.type = "button";
+    undoBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      onUndo();
+    });
+    wrap.appendChild(undoBtn);
+  }
+  return wrap;
+}
+
 export function normalizeCrewPayload(payload) {
   const crews = Array.isArray(payload && payload.crews)
     ? payload.crews
@@ -92,6 +174,15 @@ export function hasCrewOptions() {
 
 function crewOptionsSignature() {
   return JSON.stringify(lastCrewPayload);
+}
+
+// A stable string for a task's current mutation-feedback entry (or "" when
+// none), so a syncNodes row diff picks up pending/success/error/undo
+// transitions the same way it picks up any other task field change.
+function feedbackSignature(map, taskId) {
+  const entry = map.get(taskId);
+  if (!entry) return "";
+  return `${entry.kind}:${entry.text}:${entry.undo ? entry.undo.expiresAt : ""}`;
 }
 
 function explicitCrewValue(task) {
@@ -236,6 +327,63 @@ function refreshChips(context) {
     const allOn = activeStatuses.size === statusOrder(context).length;
     const on = isAll ? allOn : activeStatuses.has(status);
     chip.classList.toggle("active", on);
+    // ORB-10874: chip state must not rely on the active/inactive color
+    // difference alone — aria-pressed exposes it to assistive tech too.
+    chip.setAttribute("aria-pressed", on ? "true" : "false");
+  }
+}
+
+// ORB-10874: the status filter and search query are represented in the tasks
+// hash (`#tasks?status=a,b&q=...`), mirroring the audit tab's buildAuditHash/
+// applyAuditHashQuery pair, so a reload or the browser's back/forward button
+// restores the same filtered view instead of resetting to the default.
+export function buildTasksHash(context) {
+  const sp = new URLSearchParams();
+  const order = statusOrder(context);
+  const activeStatuses = activeStatusSet(context);
+  if (activeStatuses.size !== order.length) {
+    const selected = order.filter((s) => activeStatuses.has(s));
+    sp.set("status", selected.length > 0 ? selected.join(",") : "none");
+  }
+  const q = searchQueryValue(context);
+  if (q) sp.set("q", q);
+  const qs = sp.toString();
+  return qs ? `#tasks?${qs}` : "#tasks";
+}
+
+export function applyTasksHashQuery(query, context) {
+  const order = statusOrder(context);
+  const statusParam = query.get("status");
+  if (statusParam == null) {
+    setActiveStatuses(context, new Set(defaultActiveStatuses(context)));
+  } else if (statusParam === "none") {
+    setActiveStatuses(context, new Set());
+  } else {
+    const wanted = new Set(statusParam.split(",").map((s) => s.trim()).filter(Boolean));
+    setActiveStatuses(context, new Set(order.filter((s) => wanted.has(s))));
+  }
+  setSearchQuery(context, (query.get("q") || "").trim().toLowerCase());
+}
+
+// Re-syncs the search box and chip states from context after the hash (not a
+// direct user interaction with these controls) changed them — e.g. on load,
+// or after a back/forward navigation.
+export function syncTaskControls(context) {
+  const search = $("task-search");
+  if (search) {
+    const q = searchQueryValue(context);
+    if (search.value !== q) search.value = q;
+  }
+  refreshChips(context);
+}
+
+function navigateTasksHash(context) {
+  const hash = buildTasksHash(context);
+  if (window.location.hash !== hash) {
+    window.location.hash = hash;
+  } else {
+    refreshChips(context);
+    renderTasks(taskList(context), context);
   }
 }
 
@@ -243,15 +391,16 @@ export function buildChips(context) {
   const container = $("task-filter");
   container.innerHTML = "";
   const allChip = el("button", { class: "chip", text: "all" });
+  allChip.type = "button";
   allChip.dataset.role = "all";
   allChip.addEventListener("click", () => {
     setActiveStatuses(context, new Set(statusOrder(context)));
-    refreshChips(context);
-    renderTasks(taskList(context), context);
+    navigateTasksHash(context);
   });
   container.appendChild(allChip);
   for (const status of statusOrder(context)) {
     const chip = el("button", { class: "chip", text: status });
+    chip.type = "button";
     chip.dataset.status = status;
     chip.style.borderLeft = `2px solid var(--status-${status}, var(--border))`;
     chip.addEventListener("click", () => {
@@ -261,8 +410,7 @@ export function buildChips(context) {
       } else {
         activeStatuses.add(status);
       }
-      refreshChips(context);
-      renderTasks(taskList(context), context);
+      navigateTasksHash(context);
     });
     container.appendChild(chip);
   }
@@ -270,10 +418,34 @@ export function buildChips(context) {
 }
 
 export function wireSearch(context) {
-  $("task-search").addEventListener("input", (e) => {
+  const input = $("task-search");
+  let debounce = null;
+  input.addEventListener("input", (e) => {
     setSearchQuery(context, e.target.value.trim().toLowerCase());
-    renderTasks(taskList(context), context);
+    if (debounce) clearTimeout(debounce);
+    debounce = setTimeout(() => navigateTasksHash(context), 250);
   });
+}
+
+// ORB-10874: a compact, always-visible restatement of the filters currently
+// narrowing the list — the chips/search box already encode this, but not in a
+// form a screen reader announces or a glance confirms without reading each
+// control. Rendered next to the count so "why am I seeing this many" is
+// answered in the same place as "how many is this".
+function renderFilterSummary(context) {
+  const node = $("task-filter-summary");
+  if (!node) return;
+  const order = statusOrder(context);
+  const activeStatuses = activeStatusSet(context);
+  const parts = [];
+  if (activeStatuses.size === 0) {
+    parts.push("status: none selected");
+  } else if (activeStatuses.size < order.length) {
+    parts.push(`status: ${order.filter((s) => activeStatuses.has(s)).join(", ")}`);
+  }
+  const q = searchQueryValue(context);
+  if (q) parts.push(`search: "${q}"`);
+  node.textContent = parts.length > 0 ? `Filtering by ${parts.join(" · ")}` : "Showing all statuses";
 }
 
 function buildTagRow(tags) {
@@ -656,14 +828,18 @@ function buildStatusUpdateControl(task, context) {
   const cell = el("span", { class: "status-cell" });
   const targets = statusUpdateTargets(context).filter((status) => status !== task.status);
   const color = `var(--status-${task.status}, var(--fg))`;
+  const mutable = canMutateTask(task);
+  const feedback = statusFeedback.get(task.id);
+  const label = `Update status for ${task.id}`;
   const select = el("select", {
     class: "task-status-select mono",
-    title: `Update status for ${task.id}`,
+    title: mutable ? label : `${label} — select a specific workspace to change status in aggregate view`,
     style: {
       color,
       borderLeftColor: color,
     },
   });
+  select.setAttribute("aria-label", label);
   const placeholder = el("option", { text: task.status || "status" });
   placeholder.value = "";
   placeholder.disabled = true;
@@ -677,7 +853,7 @@ function buildStatusUpdateControl(task, context) {
     select.appendChild(option);
   }
 
-  if (targets.length === 0) {
+  if (targets.length === 0 || !mutable || (feedback && feedback.kind === "pending")) {
     select.disabled = true;
   }
 
@@ -687,18 +863,26 @@ function buildStatusUpdateControl(task, context) {
     event.stopPropagation();
     const targetStatus = select.value;
     if (!targetStatus) return;
-    updateTaskStatus(task, select, context);
+    applyTaskStatusChange(task, targetStatus, context);
   });
   cell.appendChild(select);
+  const feedbackNode = buildMutationFeedback(feedback, () => {
+    if (feedback && feedback.undo) applyTaskStatusChange(task, feedback.undo.previousValue, context);
+  });
+  if (feedbackNode) cell.appendChild(feedbackNode);
   return cell;
 }
 
 function buildCrewUpdateControl(task, context) {
   const cell = el("span", { class: "crew-cell" });
+  const mutable = canMutateTask(task);
+  const feedback = crewFeedback.get(task.id);
+  const label = `Update crew for ${task.id}`;
   const select = el("select", {
     class: "task-crew-select mono",
-    title: `Update crew for ${task.id}`,
+    title: mutable ? label : `${label} — select a specific workspace to change crew in aggregate view`,
   });
+  select.setAttribute("aria-label", label);
   const currentValue = explicitCrewValue(task);
   const staleCurrentValue = hasStaleExplicitCrew(task);
   select.dataset.currentValue = currentValue;
@@ -733,66 +917,72 @@ function buildCrewUpdateControl(task, context) {
     select.disabled = true;
     defaultOption.textContent = "crew unavailable";
   }
+  if (!mutable || (feedback && feedback.kind === "pending")) {
+    select.disabled = true;
+  }
 
   select.value = currentValue;
   stopRowInteraction(cell);
   stopRowInteraction(select);
   select.addEventListener("change", (event) => {
     event.stopPropagation();
-    updateTaskCrew(task, select, context);
+    applyTaskCrewChange(task, select.value || "", context);
   });
 
   cell.appendChild(select);
-  const error = crewUpdateErrors.get(task.id);
-  if (error) {
-    cell.appendChild(el("span", { class: "crew-error", text: error }));
-  }
+  const feedbackNode = buildMutationFeedback(feedback, () => {
+    if (feedback && feedback.undo) applyTaskCrewChange(task, feedback.undo.previousValue, context);
+  });
+  if (feedbackNode) cell.appendChild(feedbackNode);
   return cell;
 }
 
-async function updateTaskStatus(task, select, context) {
-  const nextStatus = select.value || "";
-  if (!nextStatus || nextStatus === task.status) return;
-
-  select.disabled = true;
+async function applyTaskStatusChange(task, nextStatus, context) {
+  if (!nextStatus || nextStatus === task.status || !canMutateTask(task)) return;
+  const previousValue = task.status;
+  statusFeedback.set(task.id, { kind: "pending", text: "saving…" });
+  renderTasks(taskList(context), context);
   try {
-    const updatedTask = await patchJson(`/api/tasks/${encodeURIComponent(task.id)}`, {
-      status: nextStatus,
-    });
+    const updatedTask = await patchJson(taskMutationPath(task), { status: nextStatus });
     applyUpdatedTask(updatedTask, context);
-    renderTasks(taskList(context), context);
+    statusFeedback.set(task.id, {
+      kind: "success",
+      text: "status saved",
+      undo: { previousValue, expiresAt: Date.now() + MUTATION_UNDO_WINDOW_MS },
+    });
   } catch (error) {
-    select.value = "";
-    select.disabled = false;
+    statusFeedback.set(task.id, {
+      kind: "error",
+      text: `status update failed: ${error.message || String(error)}`,
+    });
     console.error(error);
   }
+  renderTasks(taskList(context), context);
+  scheduleFeedbackExpiry(statusFeedback, task.id, context, MUTATION_UNDO_WINDOW_MS + 500);
 }
 
-async function updateTaskCrew(task, select, context) {
-  const previousValue = select.dataset.currentValue || "";
-  const nextValue = select.value || "";
-  if (nextValue === previousValue) return;
-
-  crewUpdateErrors.delete(task.id);
-  select.disabled = true;
+async function applyTaskCrewChange(task, nextValue, context) {
+  const previousValue = explicitCrewValue(task);
+  if (nextValue === previousValue || !canMutateTask(task)) return;
+  crewFeedback.set(task.id, { kind: "pending", text: "saving…" });
+  renderTasks(taskList(context), context);
   try {
-    const updatedTask = await patchJson(`/api/tasks/${encodeURIComponent(task.id)}`, {
-      crew: nextValue || null,
-    });
+    const updatedTask = await patchJson(taskMutationPath(task), { crew: nextValue || null });
     applyUpdatedTask(updatedTask, context);
-    crewUpdateErrors.delete(task.id);
-    renderTasks(taskList(context), context);
+    crewFeedback.set(task.id, {
+      kind: "success",
+      text: "crew saved",
+      undo: { previousValue, expiresAt: Date.now() + MUTATION_UNDO_WINDOW_MS },
+    });
   } catch (error) {
-    select.value = previousValue;
-    select.dataset.currentValue = previousValue;
-    select.disabled = false;
-    crewUpdateErrors.set(
-      task.id,
-      `crew update failed: ${error.message || String(error)}`,
-    );
-    renderTasks(taskList(context), context);
+    crewFeedback.set(task.id, {
+      kind: "error",
+      text: `crew update failed: ${error.message || String(error)}`,
+    });
     console.error(error);
   }
+  renderTasks(taskList(context), context);
+  scheduleFeedbackExpiry(crewFeedback, task.id, context, MUTATION_UNDO_WINDOW_MS + 500);
 }
 
 /* ORB-10444: one-click Ship. The dispatch carries only the task id — the
@@ -948,6 +1138,8 @@ function takeTaskActionNotice() {
   const notice = el("div", { class: "task-action-notice", text: taskActionNotice });
   notice.dataset.key = "task-action-notice";
   notice.dataset.hash = taskActionNotice;
+  notice.setAttribute("role", "status");
+  notice.setAttribute("aria-live", "polite");
   taskActionNotice = null;
   return notice;
 }
@@ -992,7 +1184,7 @@ export function renderTasks(tasks, context) {
       e.stopPropagation();
       if (navigator.clipboard) navigator.clipboard.writeText(ptask.id).catch(() => {});
     });
-    pRow.dataset.hash = `${ptask.id}-${ptask.title}-${ptask.status}-${ptask.crew || ""}-${ptask.resolved_crew || ""}-${crewOptionsSignature()}-${crewUpdateErrors.get(ptask.id) || ""}`;
+    pRow.dataset.hash = `${ptask.id}-${ptask.title}-${ptask.status}-${ptask.crew || ""}-${ptask.resolved_crew || ""}-${crewOptionsSignature()}-${feedbackSignature(statusFeedback, ptask.id)}-${feedbackSignature(crewFeedback, ptask.id)}`;
     const pDetail = buildTaskDetail(ptask, context);
     // Dismiss button to close the global detail without affecting chips
     const dismiss = el("button", { class: "action", text: "Close" });
@@ -1015,10 +1207,8 @@ export function renderTasks(tasks, context) {
   }
 
   const filtered = filterTasks(tasks, context);
-  $("tasks-count").textContent =
-    filtered.length === tasks.length
-      ? `${tasks.length}`
-      : `${filtered.length}/${tasks.length}`;
+  $("tasks-count").textContent = formatTaskCount(filtered.length, tasks.length, tasksMeta(context));
+  renderFilterSummary(context);
   if (filtered.length === 0 && frag.children.length === 0) {
     const defaultText = tasks.length === 0 ? "No tasks available." : "No tasks match filter.";
     const emptyState = el("div", { class: "empty-state" }, [
@@ -1086,7 +1276,7 @@ export function renderTasks(tasks, context) {
       ]);
       row.dataset.key = `task-${t.id}`;
       // Basic hash based on row presentation parameters + expanded state
-      row.dataset.hash = `${t.id}-${t.title}-${t.status}-${t.crew || ""}-${t.resolved_crew || ""}-${t.workspace_id || ""}-${crewOptionsSignature()}-${crewUpdateErrors.get(t.id) || ""}-${expandedTaskIds.has(t.id)}`;
+      row.dataset.hash = `${t.id}-${t.title}-${t.status}-${t.crew || ""}-${t.resolved_crew || ""}-${t.workspace_id || ""}-${crewOptionsSignature()}-${feedbackSignature(statusFeedback, t.id)}-${feedbackSignature(crewFeedback, t.id)}-${expandedTaskIds.has(t.id)}`;
       row.addEventListener("click", () => {
         const toggle = () => {
           if (expandedTaskIds.has(t.id)) expandedTaskIds.delete(t.id);

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -841,6 +841,165 @@ fn dashboard_task_write_actions_are_configuration_free() {
     );
 }
 
+/// ORB-10874: the Tasks count previously read an ambiguous `N/50` with no way
+/// to tell a total from a page size from a hard cap. It must now state which
+/// number means what, using the `/api/tasks` paging envelope
+/// (`{ items, total, limit, truncated }`, ORB-10400) when it is available.
+#[test]
+fn dashboard_task_count_states_shown_total_and_server_limit_explicitly() {
+    let tasks = include_str!("../../assets/dashboard/tasks.js");
+
+    assert!(
+        tasks.contains("export function formatTaskCount("),
+        "the count formatter must be a standalone, testable function"
+    );
+    assert!(
+        tasks.contains("shown") && tasks.contains("total") && tasks.contains("server limit"),
+        "the formatter must use explicit shown/total/server-limit language"
+    );
+    assert!(
+        !tasks.contains("filtered.length}/${tasks.length}"),
+        "the old ambiguous `N/M` shorthand must be gone"
+    );
+    assert!(
+        tasks.contains("$(\"tasks-count\").textContent = formatTaskCount("),
+        "the rendered count must go through the explicit formatter"
+    );
+}
+
+/// ORB-10874: the status chips and search box are represented in the tasks
+/// hash so a reload or the browser's back/forward button restores the same
+/// filtered view, mirroring the audit tab's existing buildAuditHash /
+/// applyAuditHashQuery pair. A visible summary line states the active filter
+/// in words, not just via chip color.
+#[test]
+fn dashboard_task_filters_are_represented_in_the_url_and_summarized() {
+    let tasks = include_str!("../../assets/dashboard/tasks.js");
+    let router = include_str!("../../assets/dashboard/router.js");
+    let index = include_str!("../../assets/dashboard/index.html");
+
+    assert!(
+        tasks.contains("export function buildTasksHash(")
+            && tasks.contains("export function applyTasksHashQuery(")
+            && tasks.contains("export function syncTaskControls("),
+        "tasks.js must expose a hash build/apply/sync trio like audit.js does"
+    );
+    assert!(
+        router.contains("ctx.applyTasksHashQuery(query)")
+            && router.contains("ctx.buildTasksHash()"),
+        "the router must apply and rebuild the tasks hash on every tasks-tab route"
+    );
+    assert!(
+        tasks.contains("function renderFilterSummary("),
+        "the active filter must be restated as text, not only via chip color"
+    );
+    assert!(
+        index.contains(r#"id="task-filter-summary""#) && index.contains(r#"aria-live="polite""#),
+        "the filter summary element must exist and announce updates to assistive tech"
+    );
+}
+
+/// ORB-10874: switching the workspace selector only updated in-memory state,
+/// so a reload silently fell back to the server's default workspace instead
+/// of the one the operator had selected.
+#[test]
+fn dashboard_workspace_selection_persists_to_the_url() {
+    let app = include_str!("../../assets/dashboard/app.js");
+
+    assert!(
+        app.contains("function persistWorkspaceToUrl(")
+            && app.contains("persistWorkspaceToUrl(select.value)"),
+        "the workspace selector must persist its choice to the URL on every change"
+    );
+}
+
+/// ORB-10874: the live `orbit.log` panel can now be collapsed and resized,
+/// and the presentation choice is remembered locally (not shared/synced
+/// state, so localStorage rather than the URL). The task list keeps an
+/// explicit minimum height so it can never be squeezed toward zero.
+#[test]
+fn dashboard_log_panel_is_collapsible_resizable_and_remembers_presentation() {
+    let log_tail = include_str!("../../assets/dashboard/log-tail.js");
+    let index = include_str!("../../assets/dashboard/index.html");
+    let css = include_str!("../../assets/dashboard/dashboard.css");
+
+    assert!(
+        log_tail.contains("orbit.dashboard.logPanel"),
+        "the log panel's collapsed/height preference must persist to localStorage"
+    );
+    assert!(
+        log_tail.contains("function wireLogPanelToggle(")
+            && log_tail.contains("function wireLogPanelResizeHandle("),
+        "the log panel must offer both a collapse toggle and a resize handle"
+    );
+    assert!(
+        index.contains(r#"id="log-panel-toggle""#) && index.contains(r#"id="log-panel-resize""#),
+        "the toggle and resize handle must exist in the markup"
+    );
+    assert!(
+        css.contains("#log-panel.collapsed") && css.contains(".log-resize-handle"),
+        "the collapsed state and the resize handle must be styled"
+    );
+    assert!(
+        css.contains("#tasks-panel > .body") && css.contains("min-height: 240px;"),
+        "the task list must keep a guaranteed minimum usable height regardless of log panel state"
+    );
+}
+
+/// ORB-10874: inline status/crew edits must show a pending state, refuse a
+/// second submission while one is in flight, report durable success/failure
+/// text (not just console.error), and offer a bounded undo while the prior
+/// value can still be safely restored.
+#[test]
+fn dashboard_inline_task_edits_report_pending_success_failure_and_offer_undo() {
+    let tasks = include_str!("../../assets/dashboard/tasks.js");
+
+    assert!(
+        tasks.contains(r#"{ kind: "pending", text: "saving…" }"#),
+        "a status/crew change must show a pending state"
+    );
+    assert!(
+        tasks.contains(r#"kind: "success""#) && tasks.contains(r#"kind: "error""#),
+        "a status/crew change must report durable success or failure feedback"
+    );
+    assert!(
+        tasks.contains("class: \"mutation-undo\", text: \"undo\""),
+        "a successful change must offer an undo control"
+    );
+    assert!(
+        tasks.contains("MUTATION_UNDO_WINDOW_MS") && tasks.contains("scheduleFeedbackExpiry("),
+        "undo must be bounded to a window, not offered indefinitely"
+    );
+    assert!(
+        tasks.contains("(feedback && feedback.kind === \"pending\")"),
+        "the control must disable itself while its own change is pending"
+    );
+}
+
+/// ORB-10874: in the aggregate ("All workspaces") view there is no ambient
+/// workspace to scope a status/crew mutation to. A task fetched through
+/// /api/tasks/all carries its own workspace_id (ORB-00037); mutation is
+/// refused unless that explicit, workspace-qualified target is available.
+#[test]
+fn dashboard_aggregate_view_guards_inline_task_mutations() {
+    let tasks = include_str!("../../assets/dashboard/tasks.js");
+
+    assert!(
+        tasks.contains("function canMutateTask(task) {")
+            && tasks.contains("!isAggregateView() || Boolean(task && task.workspace_id)"),
+        "mutation must be refused in aggregate mode unless the task names its own workspace"
+    );
+    assert!(
+        tasks.contains("function taskMutationPath(task"),
+        "an aggregate-mode mutation must target the task's own workspace explicitly, not the ambient one"
+    );
+    assert_eq!(
+        tasks.matches("!mutable").count(),
+        2,
+        "both the status and crew controls must be disabled when the task cannot be safely mutated"
+    );
+}
+
 /// ORB-10444: dashboard assets are a shipped, project-agnostic surface. A
 /// personal name, an Orbit/knowledge id, or a checkout path baked into them
 /// would ship to every install, so the served assets carry none.

--- a/docs/design/user-interface/2_design.md
+++ b/docs/design/user-interface/2_design.md
@@ -30,6 +30,8 @@ The UI uses layered dark surfaces instead of flat black: base canvas, elevated p
 
 Live processing is visible through pulsing dots, spinners, buffered-log counters, periodically refreshed tiles, and compact ticker-style values. The `orbit.log` panel is viewport-bounded; overflowing rows scroll inside the log stream so footer filters and follow-tail controls remain visible [T20260430-29]. Motion is functional: it points to active work without making the operator read raw logs first.
 
+The log panel can be collapsed to its header or resized by dragging (or, with focus, arrow-key nudging) its top edge, and the chosen presentation is remembered per browser via `localStorage` rather than the URL, since it is a local viewing preference rather than shared state [ORB-10874]. The task list beside it keeps an independent, guaranteed-minimum body height regardless of the log panel's state, and below ~760px the two-column Tasks layout stacks into one column instead of squeezing both into slivers.
+
 ## 5. Dashboard Telemetry Consistency
 
 Summary tiles and drill-down panels must agree. Audit > Policy is the detail view for the Denials 24h tile, so `/api/diagnostics/denials` combines v2 loop JSONL denial rows with SQLite `status = denied` audit events. SQLite filesystem boundary denials without an activity fsProfile use the stable `workspace-boundary` label [T20260428-13].
@@ -56,7 +58,17 @@ The Tasks tab is writable for the two actions that otherwise force a context swi
 
 **Comments** post to `POST /api/tasks/:id/comments`, which writes through the task's existing review-thread structure rather than adding a field to the task record, so a comment survives a reload like any other task history. Authorship is forced to a human identity: an absent, agent-family, or model-constant author collapses to the `human` label, because the dashboard process may itself run inside a managed Orbit run where the runtime's ambient actor is a model.
 
-## 8. Concerns & Honest Limitations
+Inline status/crew edits show a pending state on the control, refuse a duplicate submission while one is in flight, and report durable success or exact failure text next to the control (a live region, so the same feedback reaches assistive tech) rather than only logging to the console. A successful edit offers a bounded-window undo that restores the prior value with one click, expiring automatically once the window (or a further edit) makes restoring it unsafe [ORB-10874].
+
+In the aggregate ("All workspaces") view there is no ambient workspace to scope a mutation to, so status/crew edits are refused unless the task carries its own `workspace_id` (present on every `/api/tasks/all` row), in which case the mutation is sent explicitly qualified to that workspace rather than the currently-selected one [ORB-10874].
+
+## 8. Task Count, Filters, and the Tasks/Log Layout
+
+The Tasks count states what it means instead of an ambiguous `N/50`: it names the shown count, the filtered-to-fetched relationship when they differ, and — using the `/api/tasks` paging envelope (`{ items, total, limit, truncated }`, ORB-10400) — the true total and the server's page limit when the result was truncated. The active status chips are sent to the server as an explicit `status=` filter rather than fetched wholesale and narrowed client-side, so `total`/`truncated` describe the filter actually in effect [ORB-10874].
+
+The active status filter and search query are represented in the `#tasks` hash (mirroring the Audit tab's own hash-encoded filters) and restated as plain text next to the count, so the current view survives a reload or the browser's back/forward button and is legible without reading each chip's color. The selected workspace is likewise mirrored into the page's `?workspace=` query parameter on every change [ORB-10874].
+
+## 9. Concerns & Honest Limitations
 
 Accessibility still needs a real WCAG pass; responsive behavior remains optimized for wide desktop viewports; raw HTML, CSS variables, and dashboard JavaScript keep the runtime simple but leave duplication across project surfaces.
 
@@ -72,5 +84,6 @@ Accessibility still needs a real WCAG pass; responsive behavior remains optimize
 - [ORB-10736] removed the native learning curation surface while preserving friction triage.
 - [ORB-00144] grouped scoreboard metrics and added knowledge counters.
 - [ORB-10444] retired a deprecated tab, folded Scoreboard under Diagnostics, pinned the Knowledge detail pane, and added task ship + comments.
+- [ORB-10874] clarified the Tasks count and filter state, made the log panel collapsible/resizable, and added pending/undo feedback and an aggregate-mode mutation guard to inline task edits.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10874](https://orbit-cli.com/tasks/ORB-10874) — Clarify the Tasks view and make live-log and inline edits safer

### Description

## Problem
The Tasks view mixes task triage, mutable lifecycle controls, file locks, and a 50-line live log in one dense surface.

During live inspection on 2026-08-15:
- The result counter displayed `1/50` without explaining whether 50 was a total, page size, or cap.
- Status and crew are immediately mutable inline selects, but the list provides no persistent visible indication of pending/succeeded/failed changes or an undo path.
- The live log dominates the task list and interleaves warnings/errors from unrelated runs with the triage workflow.

## Why It Matters
The primary task surface should make current work easy to scan and consequential edits hard to misread or repeat. Operational logs are useful context, but they should not crowd out the task inventory.

## Constraints / Notes
- Preserve existing task status and crew semantics; this is not a lifecycle redesign.
- Keep raw logs available and preserve live-tail/filter behavior.
- Do not add project-specific labels or assumptions.
- Related completed information-architecture work: ORB-10444.

### Acceptance Criteria

- The task count uses explicit language such as shown results, matching total when known, and server limit/page size; no ambiguous N/50 shorthand remains.
- Active workspace, status, search, and other filters are visibly summarized and survive reload/back navigation when represented in the URL.
- The live log pane can be collapsed and resized, remembers its local presentation preference, and never reduces the task inventory below a usable minimum height at desktop or narrow widths.
- Inline status and crew changes expose a pending state, disable duplicate submission, show durable success or exact failure feedback, and offer a bounded undo action when the prior value can still be safely restored.
- Keyboard focus, labels, and live-region feedback make task controls usable without relying only on color or pointer interaction.
- Aggregate/all-workspace mode keeps unsafe mutations disabled or requires an explicit workspace-qualified target; task identity and selected workspace remain visible at mutation time.
- Rendered validation covers representative empty, one-result, many-result, mutation-pending/failure, collapsed-log, desktop, and 480-720px states; focused tests and git diff --check pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Implementation

Frontend-only change across the dashboard's Tasks view and shared log/router/app modules; no server-side changes were needed (the `/api/tasks` paging envelope and `workspace_id` tagging this relies on already existed).

- **Task count language** (`tasks.js: formatTaskCount`, `app.js: tasksListPath`): the count now reads e.g. `"50 shown · 137 total · server limit 50"` instead of `N/50`. Status chips are now sent server-side as `?status=a,b` (previously fetched wholesale and filtered client-side), so `total`/`truncated` from the `/api/tasks` envelope describe the filter actually in effect.
- **Filters visible + URL-persisted** (`tasks.js: buildTasksHash/applyTasksHashQuery/syncTaskControls/renderFilterSummary`, `router.js`, `app.js`): status/search filters are represented in the `#tasks?status=..&q=..` hash (mirroring the existing Audit tab pattern) and restated as plain text next to the count; survives reload and back/forward. Workspace selection is mirrored into `?workspace=` via `history.replaceState` on every change (`app.js: persistWorkspaceToUrl`).
- **Log panel collapse/resize** (`log-tail.js`, `index.html`, `dashboard.css`): a header toggle collapses the panel to its header; a top-edge handle (pointer-drag or arrow-key) resizes it. Both persist to `localStorage` (`orbit.dashboard.logPanel`), not the URL, since they're local presentation prefs. `#tasks-panel > .body` now has a `min-height: 240px` floor, and below 760px the two-column Tasks layout stacks to one column instead of squeezing both columns.
- **Inline edit safety** (`tasks.js`): status/crew selects now show pending state (disabled while saving), durable success/error text in an `aria-live` region (previously errors only went to `console.error`), and a bounded (~8s) undo restoring the prior value. `canMutateTask`/`taskMutationPath` refuse the mutation in aggregate ("All workspaces") view unless the task carries its own `workspace_id`, in which case the request is explicitly qualified to that workspace rather than the ambient selection.
- **Accessibility**: `aria-label` on status/crew selects, `aria-pressed` on filter chips, `aria-live` regions on task-action notices/mutation feedback/filter summary, `:focus-visible` rings on the new/existing controls, and a keyboard-operable resize handle.
- **Docs**: `docs/design/user-interface/2_design.md` updated in the same PR (live-status, task-write-actions, and a new §8 covering count/filter/layout behavior), per the repo's same-PR-docs rule.

## Validation

- `cargo test -p orbit-web --lib` — 217 passed, 0 failed (includes 6 new tests in `dashboard_assets.rs` pinning the new count/filter/log-panel/mutation-feedback/aggregate-guard behavior against the embedded asset sources — the dashboard has no JS test runner, matching this file's existing convention).
- `node --check` on every touched `.js` file — syntax valid.
- `make ci-fast` — clean (fmt-check + guardrail scripts).
- `make ci-lint` — clean (workspace clippy, warnings denied).
- `git diff --check` — clean.
- **Not performed**: actual browser rendering across the empty/one-result/many-result/pending-failure/collapsed-log/desktop/480-720px states named in the acceptance criteria. This headless execution environment has no browser/screenshot tool available, so that check could not be run here; it should be done interactively (`cargo run -p orbit-cli -- serve` or equivalent, then exercise the Tasks tab at those widths) before merge. All new logic and markup is covered by the automated source-assertion tests above instead.

## Scope

Touched exactly the files listed in `context_files` (`tasks.js`, `log-tail.js`, `app.js`, `router.js`, `index.html`, `dashboard.css`, `dashboard_assets.rs`, the design doc); `common.js` was read for its existing `isAggregateView`/`withWorkspace` exports but not modified. No new cross-crate dependency edges. No server/API changes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10874-6a8135e8`
- Behind base: 0
- Ahead of base: 1