### PR TITLE
Add routine and sweep-clock operations to the dashboard

### DIFF
--- a/crates/orbit-common/src/authorization.rs
+++ b/crates/orbit-common/src/authorization.rs
@@ -62,6 +62,8 @@ pub enum OperationSurface {
     Tool,
     /// A CLI command that performs its destruction without a tool.
     CliCommand,
+    /// A typed state-changing dashboard action.
+    Dashboard,
 }
 
 /// One operation whose performance requires a capability.
@@ -101,6 +103,30 @@ impl GovernedOperation {
             .join(" or ")
     }
 }
+
+/// Versioned routine-definition toggle exposed by the dashboard.
+pub const DASHBOARD_ROUTINE_TOGGLE: GovernedOperation = GovernedOperation {
+    id: "routine.toggle",
+    surface: OperationSurface::Dashboard,
+    allowed: &[McpCapability::Operator],
+    rationale: "changing a versioned routine definition changes unattended execution",
+};
+
+/// Native sweep-clock start/stop action exposed by the dashboard.
+pub const DASHBOARD_CLOCK_SERVICE: GovernedOperation = GovernedOperation {
+    id: "clock.service",
+    surface: OperationSurface::Dashboard,
+    allowed: &[McpCapability::Operator],
+    rationale: "starting or stopping the host sweep clock changes unattended execution",
+};
+
+/// Native sweep-clock cadence action exposed by the dashboard.
+pub const DASHBOARD_CLOCK_CADENCE: GovernedOperation = GovernedOperation {
+    id: "clock.cadence",
+    surface: OperationSurface::Dashboard,
+    allowed: &[McpCapability::Operator],
+    rationale: "changing the host sweep cadence reloads the native clock service",
+};
 
 /// Every governed operation, declared exactly once.
 ///
@@ -211,6 +237,9 @@ pub const GOVERNED_OPERATIONS: &[GovernedOperation] = &[
         allowed: &[McpCapability::Operator, McpCapability::Runner],
         rationale: "collection force-removes worktrees and deletes their branches",
     },
+    DASHBOARD_ROUTINE_TOGGLE,
+    DASHBOARD_CLOCK_SERVICE,
+    DASHBOARD_CLOCK_CADENCE,
 ];
 
 /// Look up the governed tool operation for `tool_name`, if any.
@@ -229,6 +258,13 @@ pub fn governed_command(command: &str, subcommand: &str) -> Option<&'static Gove
                 .split_once(' ')
                 .is_some_and(|(head, tail)| head == command && tail == subcommand)
     })
+}
+
+/// Look up a governed dashboard operation by its stable typed action id.
+pub fn governed_dashboard(id: &str) -> Option<&'static GovernedOperation> {
+    GOVERNED_OPERATIONS
+        .iter()
+        .find(|operation| operation.surface == OperationSurface::Dashboard && operation.id == id)
 }
 
 /// Where a caller's capabilities came from.

--- a/crates/orbit-common/src/authorization/tests.rs
+++ b/crates/orbit-common/src/authorization/tests.rs
@@ -43,6 +43,11 @@ fn registry_declares_each_operation_once_with_a_capability() {
                 "command operation '{}' must be `<command> <subcommand>`",
                 operation.id
             ),
+            OperationSurface::Dashboard => assert!(
+                operation.id.split('.').count() == 2,
+                "dashboard operation '{}' must be `<domain>.<action>`",
+                operation.id
+            ),
         }
     }
 }
@@ -55,6 +60,10 @@ fn lookup_is_surface_scoped() {
     assert!(governed_command("orbit.task.delete", "").is_none());
     assert!(governed_tool("orbit.task.show").is_none());
     assert!(governed_command("workspace", "list").is_none());
+    assert!(governed_dashboard("routine.toggle").is_some());
+    assert!(governed_dashboard("clock.service").is_some());
+    assert!(governed_dashboard("clock.cadence").is_some());
+    assert!(governed_dashboard("routine.list").is_none());
 }
 
 #[test]
@@ -128,6 +137,23 @@ fn an_agent_is_denied_out_of_scope_destruction() {
             authorize(operation(id), &caller).is_err(),
             "agent must not reach '{id}'"
         );
+    }
+}
+
+#[test]
+fn dashboard_operations_require_an_operator() {
+    let agent = CallerCapabilities::resolve(&CallerEnvelope {
+        agent_declared: true,
+        ..envelope()
+    });
+    let operator = CallerCapabilities::resolve(&CallerEnvelope {
+        interactive_terminal: true,
+        ..envelope()
+    });
+    for id in ["routine.toggle", "clock.service", "clock.cadence"] {
+        let operation = governed_dashboard(id).expect("dashboard operation is declared");
+        assert!(authorize(operation, &agent).is_err());
+        assert!(authorize(operation, &operator).is_ok());
     }
 }
 

--- a/crates/orbit-core/src/routines/clock.rs
+++ b/crates/orbit-core/src/routines/clock.rs
@@ -149,12 +149,20 @@ pub struct ClockStatus {
     pub configured_cadence_seconds: u64,
     pub effective_cadence_seconds: Option<u64>,
     pub enabled: bool,
+    /// Whether the native manager reports the unit as loaded.
+    pub loaded: bool,
+    /// Whether the native timer is currently active/waiting, when exposed.
+    pub running: Option<bool>,
     /// Whether an enabled native clock has a future trigger. A paused clock is
     /// intentionally not schedulable and is not unhealthy.
     pub schedulable: bool,
     /// Actionable detail when an enabled clock cannot be shown to have a
     /// future trigger.
     pub health_issue: Option<String>,
+    /// Most recent native timer trigger, in the manager's display format.
+    pub last_tick_at: Option<String>,
+    /// Next native timer trigger, in the manager's display format.
+    pub next_tick_at: Option<String>,
     pub platform: &'static str,
 }
 
@@ -447,8 +455,11 @@ fn systemd_next_trigger_command() -> ManagerCommand {
             "--user".into(),
             "show".into(),
             format!("{SYSTEMD_UNIT}.timer"),
+            "--property=LoadState".into(),
+            "--property=ActiveState".into(),
             "--property=NextElapseUSecRealtime".into(),
             "--property=NextElapseUSecMonotonic".into(),
+            "--property=LastTriggerUSec".into(),
         ],
     }
 }
@@ -517,7 +528,7 @@ pub(super) fn set_clock_enabled_with(
         .unwrap_or(false);
     if current == enabled {
         return Ok(clock_status_from(
-            settings, enabled, enabled, platform, None,
+            settings, enabled, enabled, platform, None, None,
         ));
     }
     let command = manager_set_enabled_command(platform, enabled, home);
@@ -530,7 +541,7 @@ pub(super) fn set_clock_enabled_with(
         )));
     }
     Ok(clock_status_from(
-        settings, enabled, enabled, platform, None,
+        settings, enabled, enabled, platform, None, None,
     ))
 }
 
@@ -551,23 +562,35 @@ pub(super) fn clock_status_with(
     let enabled = runner
         .run(&manager_status_command(platform))
         .unwrap_or(false);
-    let (schedulable, health_issue) = if enabled && platform == ClockPlatform::Systemd {
+    let mut manager_details = None;
+    let (schedulable, health_issue) = if platform == ClockPlatform::Systemd {
         match runner.stdout(&systemd_next_trigger_command()) {
-            Ok(Some(output)) if systemd_output_has_future_trigger(&output) => (true, None),
-            Ok(Some(_)) => (
-                false,
-                Some(
-                    "systemd timer is enabled but has no future trigger; recovery: `orbit routine init --install-clock`"
-                        .to_string(),
-                ),
-            ),
-            Ok(None) | Err(_) => (
+            Ok(Some(output)) => {
+                let details = SystemdClockDetails::parse(&output);
+                let schedulable = enabled && details.next_tick_at.is_some();
+                manager_details = Some(details);
+                if !enabled {
+                    (false, None)
+                } else if schedulable {
+                    (true, None)
+                } else {
+                    (
+                        false,
+                        Some(
+                            "systemd timer is enabled but has no future trigger; recovery: `orbit routine init --install-clock`"
+                                .to_string(),
+                        ),
+                    )
+                }
+            }
+            Ok(None) | Err(_) if enabled => (
                 false,
                 Some(
                     "systemd timer is enabled but its next trigger could not be verified; recovery: `systemctl --user status orbit-sweep.timer`, then `orbit routine init --install-clock`"
                         .to_string(),
                 ),
             ),
+            Ok(None) | Err(_) => (false, None),
         }
     } else {
         (enabled, None)
@@ -578,18 +601,44 @@ pub(super) fn clock_status_with(
         schedulable,
         platform,
         health_issue,
+        manager_details,
     ))
 }
 
-fn systemd_output_has_future_trigger(output: &str) -> bool {
-    output.lines().any(|line| {
-        let value = line.split_once('=').map_or(line, |(_, value)| value).trim();
-        !value.is_empty()
-            && !matches!(
-                value.to_ascii_lowercase().as_str(),
-                "n/a" | "infinity" | "0"
-            )
-    })
+#[derive(Debug, Default)]
+struct SystemdClockDetails {
+    loaded: Option<bool>,
+    running: Option<bool>,
+    last_tick_at: Option<String>,
+    next_tick_at: Option<String>,
+}
+
+impl SystemdClockDetails {
+    fn parse(output: &str) -> Self {
+        let property = |name: &str| {
+            output.lines().find_map(|line| {
+                let (key, value) = line.split_once('=')?;
+                (key == name).then(|| useful_manager_value(value)).flatten()
+            })
+        };
+        Self {
+            loaded: property("LoadState").map(|value| value == "loaded"),
+            running: property("ActiveState").map(|value| value == "active"),
+            last_tick_at: property("LastTriggerUSec"),
+            next_tick_at: property("NextElapseUSecRealtime")
+                .or_else(|| property("NextElapseUSecMonotonic")),
+        }
+    }
+}
+
+fn useful_manager_value(raw: &str) -> Option<String> {
+    let value = raw.trim();
+    (!value.is_empty()
+        && !matches!(
+            value.to_ascii_lowercase().as_str(),
+            "n/a" | "infinity" | "0"
+        ))
+    .then(|| value.to_string())
 }
 
 fn clock_status_from(
@@ -598,13 +647,21 @@ fn clock_status_from(
     schedulable: bool,
     platform: ClockPlatform,
     health_issue: Option<String>,
+    manager_details: Option<SystemdClockDetails>,
 ) -> ClockStatus {
+    let details = manager_details.unwrap_or_default();
     ClockStatus {
         configured_cadence_seconds: settings.cadence_seconds,
         effective_cadence_seconds: (enabled && schedulable).then_some(settings.cadence_seconds),
         enabled,
+        loaded: details.loaded.unwrap_or(enabled),
+        running: details.running,
         schedulable,
         health_issue,
+        last_tick_at: details.last_tick_at,
+        next_tick_at: (enabled && schedulable)
+            .then_some(details.next_tick_at)
+            .flatten(),
         platform: platform.name(),
     }
 }

--- a/crates/orbit-core/src/routines/mod.rs
+++ b/crates/orbit-core/src/routines/mod.rs
@@ -31,8 +31,8 @@ pub use loader::{
     RoutineWorkspaceProvider, collect_routines,
 };
 pub use status::{
-    RoutineStatus, RoutineStatusReport, pause_routine, recent_fires, resume_routine,
-    routine_statuses_with_providers,
+    RoutineStatus, RoutineStatusReport, RoutineToggleOutcome, pause_routine, recent_fires,
+    resume_routine, routine_statuses_with_providers, set_routine_enabled,
 };
 pub use sweep::{
     RoutineSweepReport, SweepOptions, SweepOutcome, run_sweep_at_with_providers,

--- a/crates/orbit-core/src/routines/status.rs
+++ b/crates/orbit-core/src/routines/status.rs
@@ -6,7 +6,8 @@
 use std::path::Path;
 
 use chrono::{DateTime, Local, Utc};
-use orbit_common::types::OrbitError;
+use orbit_common::types::{OrbitError, parse_local_routine_yaml, parse_routine_yaml};
+use orbit_common::utility::fs::atomic_write_text;
 use orbit_store::RoutineFireRecord;
 
 use super::due::{parse_cron, truncate_to_minute};
@@ -27,6 +28,10 @@ pub struct RoutineStatus {
     pub validation: RoutinePinValidation,
     /// Host-local pause, when one is set (RFC 3339 pause timestamp).
     pub paused_at: Option<String>,
+    /// First scheduler observation on this host (RFC 3339).
+    pub first_observed_at: Option<String>,
+    /// Most recent scheduled slot consumed by the scheduler (RFC 3339).
+    pub last_evaluated_slot: Option<String>,
     /// Next scheduled slot (RFC 3339, host-local), when computable.
     pub next_due: Option<String>,
     /// Most recent fire attempt recorded on this host.
@@ -87,6 +92,7 @@ pub fn routine_statuses_with_providers(
             .and_then(|slot| truncate_to_minute(slot).ok())
             .map(|slot| slot.to_rfc3339());
         let last_fire = store.routine_latest_fire(&routine.definition.name)?;
+        let cursor = store.routine_cursor(&routine.definition.name)?;
         let paused_at = pauses
             .get(&routine.definition.name)
             .map(|pause| pause.paused_at.clone());
@@ -102,6 +108,8 @@ pub fn routine_statuses_with_providers(
             pinned_to_host,
             validation,
             paused_at,
+            first_observed_at: cursor.as_ref().map(|cursor| cursor.baseline_at.clone()),
+            last_evaluated_slot: cursor.and_then(|cursor| cursor.last_slot),
             next_due,
             last_fire,
         });
@@ -114,6 +122,107 @@ pub fn routine_statuses_with_providers(
         statuses,
         load_errors,
     })
+}
+
+/// Optimistic outcome for a versioned routine-definition toggle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoutineToggleOutcome {
+    /// The definition was atomically changed.
+    Changed,
+    /// The desired state already matched the current definition.
+    Unchanged,
+    /// The caller's expected state was stale, so no write occurred.
+    Conflict { actual_enabled: bool },
+}
+
+/// Change only the typed `enabled` field of a routine definition.
+///
+/// The path comes from a freshly loaded [`LoadedRoutine`], never from a
+/// transport payload. The surgical edit preserves comments and field ordering;
+/// the rewritten document is parsed and compared before the atomic rename so a
+/// toggle cannot accidentally alter any other routine behavior.
+pub fn set_routine_enabled(
+    routine: &LoadedRoutine,
+    local_host_id: &str,
+    expected_enabled: bool,
+    enabled: bool,
+) -> Result<RoutineToggleOutcome, OrbitError> {
+    let raw = std::fs::read_to_string(&routine.path)
+        .map_err(|error| OrbitError::Io(format!("read {}: {error}", routine.path.display())))?;
+    let current = parse_for_origin(&raw, routine.origin, local_host_id)?;
+    if current.name != routine.definition.name {
+        return Err(OrbitError::InvalidInput(format!(
+            "routine definition at {} changed identity from '{}' to '{}'",
+            routine.path.display(),
+            routine.definition.name,
+            current.name
+        )));
+    }
+    if current.enabled != expected_enabled {
+        return Ok(RoutineToggleOutcome::Conflict {
+            actual_enabled: current.enabled,
+        });
+    }
+    if current.enabled == enabled {
+        return Ok(RoutineToggleOutcome::Unchanged);
+    }
+
+    let rendered = rewrite_enabled_line(&raw, enabled)?;
+    let rewritten = parse_for_origin(&rendered, routine.origin, local_host_id)?;
+    let mut expected = current;
+    expected.enabled = enabled;
+    if rewritten != expected {
+        return Err(OrbitError::Execution(
+            "routine toggle validation changed fields other than enabled".to_string(),
+        ));
+    }
+    atomic_write_text(&routine.path, &rendered)
+        .map_err(|error| OrbitError::Io(format!("write {}: {error}", routine.path.display())))?;
+    Ok(RoutineToggleOutcome::Changed)
+}
+
+fn parse_for_origin(
+    raw: &str,
+    origin: super::loader::RoutineOrigin,
+    local_host_id: &str,
+) -> Result<orbit_common::types::RoutineDefinition, OrbitError> {
+    match origin {
+        super::loader::RoutineOrigin::Committed => parse_routine_yaml(raw),
+        super::loader::RoutineOrigin::Local => parse_local_routine_yaml(raw, local_host_id),
+    }
+}
+
+fn rewrite_enabled_line(raw: &str, enabled: bool) -> Result<String, OrbitError> {
+    let newline = if raw.contains("\r\n") { "\r\n" } else { "\n" };
+    let has_enabled = raw
+        .lines()
+        .any(|line| line.trim_end_matches('\r').starts_with("enabled:"));
+    let mut rendered = String::with_capacity(raw.len() + 16);
+    let mut replaced = false;
+    for line in raw.split_inclusive('\n') {
+        let content = line.trim_end_matches(['\r', '\n']);
+        let ending = &line[content.len()..];
+        if !replaced && content.starts_with("enabled:") {
+            let suffix = content
+                .split_once('#')
+                .map(|(_, comment)| format!(" # {}", comment.trim()))
+                .unwrap_or_default();
+            rendered.push_str(&format!("enabled: {enabled}{suffix}{ending}"));
+            replaced = true;
+        } else {
+            rendered.push_str(line);
+            if !has_enabled && !replaced && content.starts_with("name:") {
+                rendered.push_str(&format!("enabled: {enabled}{newline}"));
+                replaced = true;
+            }
+        }
+    }
+    if !replaced {
+        return Err(OrbitError::InvalidInput(
+            "routine definition has no canonical top-level `name:` or `enabled:` field".to_string(),
+        ));
+    }
+    Ok(rendered)
 }
 
 /// Pause a routine on this host (host-local, never synced). Returns `false`

--- a/crates/orbit-core/src/routines/tests/clock.rs
+++ b/crates/orbit-core/src/routines/tests/clock.rs
@@ -209,7 +209,7 @@ fn status_is_deterministic_for_each_manager_and_reports_configured_cadence() {
     let systemd = MockRunner::with_outputs(
         vec![Ok(true)],
         vec![Ok(Some(
-            "NextElapseUSecRealtime=\nNextElapseUSecMonotonic=5min".to_string(),
+            "LoadState=loaded\nActiveState=active\nNextElapseUSecRealtime=Sun 2026-08-16 04:30:00 UTC\nNextElapseUSecMonotonic=5min\nLastTriggerUSec=Sun 2026-08-16 04:29:00 UTC".to_string(),
         ))],
     );
     let status = clock_status_with(root.path(), ClockPlatform::Systemd, &systemd)
@@ -218,6 +218,16 @@ fn status_is_deterministic_for_each_manager_and_reports_configured_cadence() {
     assert!(status.schedulable);
     assert_eq!(status.effective_cadence_seconds, Some(60));
     assert!(status.health_issue.is_none());
+    assert!(status.loaded);
+    assert_eq!(status.running, Some(true));
+    assert_eq!(
+        status.last_tick_at.as_deref(),
+        Some("Sun 2026-08-16 04:29:00 UTC")
+    );
+    assert_eq!(
+        status.next_tick_at.as_deref(),
+        Some("Sun 2026-08-16 04:30:00 UTC")
+    );
     assert_eq!(status.platform, "systemd");
 }
 
@@ -244,9 +254,31 @@ fn enabled_systemd_timer_without_a_future_trigger_is_unhealthy() {
         runner.commands(),
         vec![
             "systemctl --user is-enabled orbit-sweep.timer",
-            "systemctl --user show orbit-sweep.timer --property=NextElapseUSecRealtime --property=NextElapseUSecMonotonic",
+            "systemctl --user show orbit-sweep.timer --property=LoadState --property=ActiveState --property=NextElapseUSecRealtime --property=NextElapseUSecMonotonic --property=LastTriggerUSec",
         ]
     );
+}
+
+#[test]
+fn disabled_systemd_timer_reports_loaded_state_without_becoming_schedulable() {
+    let root = tempdir().expect("create global root");
+    let runner = MockRunner::with_outputs(
+        vec![Ok(false)],
+        vec![Ok(Some(
+            "LoadState=loaded\nActiveState=inactive\nNextElapseUSecRealtime=Sun 2026-08-16 04:30:00 UTC"
+                .to_string(),
+        ))],
+    );
+
+    let status = clock_status_with(root.path(), ClockPlatform::Systemd, &runner)
+        .expect("read disabled timer status");
+
+    assert!(!status.enabled);
+    assert!(status.loaded);
+    assert_eq!(status.running, Some(false));
+    assert!(!status.schedulable);
+    assert_eq!(status.effective_cadence_seconds, None);
+    assert!(status.health_issue.is_none());
 }
 
 #[test]

--- a/crates/orbit-core/src/routines/tests/mod.rs
+++ b/crates/orbit-core/src/routines/tests/mod.rs
@@ -1,5 +1,6 @@
 mod clock;
 mod due;
 mod loader;
+mod status;
 mod sweep;
 mod validation;

--- a/crates/orbit-core/src/routines/tests/status.rs
+++ b/crates/orbit-core/src/routines/tests/status.rs
@@ -1,0 +1,96 @@
+use std::fs;
+
+use orbit_common::types::parse_routine_yaml;
+use tempfile::tempdir;
+
+use super::super::loader::{LoadedRoutine, RoutineOrigin};
+use super::super::status::{RoutineToggleOutcome, set_routine_enabled};
+
+fn loaded(path: std::path::PathBuf) -> LoadedRoutine {
+    let raw = fs::read_to_string(&path).expect("read fixture");
+    LoadedRoutine {
+        definition: parse_routine_yaml(&raw).expect("parse fixture"),
+        origin: RoutineOrigin::Committed,
+        source_workspace: "polaris".to_string(),
+        source_orbit_dir: path.parent().expect("fixture parent").to_path_buf(),
+        path,
+    }
+}
+
+#[test]
+fn routine_toggle_preserves_comments_and_every_field_but_enabled() {
+    let root = tempdir().expect("temp root");
+    let path = root.path().join("nightly.yaml");
+    fs::write(
+        &path,
+        "schemaVersion: 1\nname: nightly\ndescription: keep this text\nenabled: true # reviewed\nhosts: [host-a]\ntrigger:\n  cron: '0 2 * * *'\ntarget: job:nightly\n",
+    )
+    .expect("write fixture");
+    let routine = loaded(path.clone());
+
+    assert_eq!(
+        set_routine_enabled(&routine, "host-a", true, false).expect("disable"),
+        RoutineToggleOutcome::Changed
+    );
+    let changed = fs::read_to_string(&path).expect("read changed fixture");
+    assert!(changed.contains("enabled: false # reviewed"));
+    assert!(changed.contains("description: keep this text"));
+    assert!(!parse_routine_yaml(&changed).expect("parse changed").enabled);
+}
+
+#[test]
+fn routine_toggle_inserts_missing_default_and_rejects_stale_duplicate() {
+    let root = tempdir().expect("temp root");
+    let path = root.path().join("nightly.yaml");
+    fs::write(
+        &path,
+        "schemaVersion: 1\nname: nightly\nhosts: [host-a]\ntrigger:\n  cron: '0 2 * * *'\ntarget: job:nightly\n",
+    )
+    .expect("write fixture");
+    let routine = loaded(path.clone());
+
+    assert_eq!(
+        set_routine_enabled(&routine, "host-a", true, false).expect("first disable"),
+        RoutineToggleOutcome::Changed
+    );
+    let after_first = fs::read_to_string(&path).expect("read first result");
+    assert_eq!(
+        set_routine_enabled(&routine, "host-a", true, false).expect("stale duplicate"),
+        RoutineToggleOutcome::Conflict {
+            actual_enabled: false
+        }
+    );
+    assert_eq!(
+        fs::read_to_string(&path).expect("read duplicate result"),
+        after_first,
+        "stale duplicate must not rewrite the definition"
+    );
+}
+
+#[test]
+fn routine_toggle_reports_an_exact_noop_without_rewriting() {
+    let root = tempdir().expect("temp root");
+    let path = root.path().join("nightly.yaml");
+    fs::write(
+        &path,
+        "schemaVersion: 1\nname: nightly\nenabled: false\nhosts: [host-a]\ntrigger:\n  cron: '0 2 * * *'\ntarget: job:nightly\n",
+    )
+    .expect("write fixture");
+    let routine = loaded(path.clone());
+    let before = fs::metadata(&path)
+        .expect("fixture metadata")
+        .modified()
+        .expect("fixture mtime");
+
+    assert_eq!(
+        set_routine_enabled(&routine, "host-a", false, false).expect("noop"),
+        RoutineToggleOutcome::Unchanged
+    );
+    assert_eq!(
+        fs::metadata(&path)
+            .expect("fixture metadata after noop")
+            .modified()
+            .expect("fixture mtime after noop"),
+        before
+    );
+}

--- a/crates/orbit-web/assets/dashboard/app.js
+++ b/crates/orbit-web/assets/dashboard/app.js
@@ -11,6 +11,7 @@ import { renderDiagnostics, renderImplementOneCard as renderImplOne, } from './d
 import { renderMarkdown } from './markdown.js';
 import { initRouter, initTabs as iT, navigateToRun as nTR, setActiveTab as sAT, setRunDetailSubtab, } from './router.js';
 import { initRuns, mergeRunsWithFriction, renderRuns, runIsCancellable, buildCancelRunButton, buildReplayRunButton } from './runs.js';
+import { fetchAndRenderOperations, initOperations } from './operations.js';
 import {
   renderRunDetailEmpty,
   renderRunDetailMeta,
@@ -882,7 +883,11 @@ async function initWorkspaceSelector() {
   // Feed the shared aggregate-view predicate (common.js): multi-workspace mode
   // is what makes the "All workspaces" (no concrete workspace) view possible.
   setMultiWorkspace(dashboardWorkspaces.length > 1);
-  if (dashboardWorkspaces.length <= 1) return; // single mode: no selector
+  if (dashboardWorkspaces.length <= 1) {
+    const only = dashboardWorkspaces.find((workspace) => workspace.status === "active");
+    if (only) setWorkspace(only.id);
+    return; // single mode: selected implicitly, no selector needed
+  }
 
   // Default to the workspace flagged by the server (the cwd workspace, if the
   // server was launched inside one) so every tab works out of the box; else the
@@ -977,6 +982,11 @@ function activeRefreshJobs() {
 
   if (activeTab === "knowledge") {
     jobs.push(fetchAndRenderFrictions());
+    return jobs;
+  }
+
+  if (activeTab === "operations") {
+    jobs.push(fetchAndRenderOperations());
     return jobs;
   }
 
@@ -1238,6 +1248,7 @@ buildAuditChips(auditContext());
 wireAuditSearch(auditContext());
 $("refresh-btn").addEventListener("click", refreshDashboard);
 wireReliabilityWindowSelector();
+initOperations({ getWorkspaces: () => dashboardWorkspaces, formatAbsoluteTime: fmtAbsTime });
 
 initRuns(runsContext());
 initRunDetail(runDetailContext());

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -3592,3 +3592,75 @@
       .rel-role-step { color: var(--state-success); border-color: var(--state-success); }
       .rel-role-ambiguous { color: var(--priority-medium); border-color: var(--priority-medium); }
       .rel-role-unknown { color: var(--fg-dim); }
+
+      /* ORB-10875: routine definitions and the host clock deliberately use
+         separate cards and controls so one state cannot read as the other. */
+      .operations-layout {
+        grid-template-columns: minmax(0, 2fr) minmax(300px, 1fr);
+        align-items: start;
+      }
+      body.operations-active { height: auto; min-height: 100vh; overflow-y: auto; }
+      .operations-layout .panel { min-width: 0; }
+      .operation-feedback {
+        min-height: 30px; padding: 7px 14px; border-bottom: 1px solid var(--border);
+        color: var(--fg-dim); font: 11px/1.4 var(--font-mono);
+      }
+      .operation-feedback:empty { display: none; }
+      .operation-feedback.pending { color: var(--priority-medium); }
+      .operation-feedback.success { color: var(--state-success); }
+      .operation-feedback.error { color: var(--state-failed); }
+      #routines-body, #clock-body { padding: 12px; background: var(--bg); }
+      .operation-card {
+        padding: 12px; margin-bottom: 10px; border: 1px solid var(--border);
+        border-radius: 4px; background: var(--bg-elev);
+      }
+      .operation-card:last-child { margin-bottom: 0; }
+      .operation-card-title, .operation-clock-summary, .operation-clock-actions {
+        display: flex; align-items: center; justify-content: space-between; gap: 10px;
+      }
+      .operation-card-title > div, .operation-clock-summary { display: flex; align-items: center; gap: 8px; min-width: 0; }
+      .operation-card-title strong { overflow-wrap: anywhere; }
+      .operation-state {
+        padding: 2px 6px; border: 1px solid var(--border); border-radius: 999px;
+        color: var(--fg-dim); font: 10px var(--font-mono); text-transform: uppercase;
+      }
+      .operation-state.enabled, .operation-state.healthy { color: var(--state-success); border-color: var(--state-success); }
+      .operation-state.disabled, .operation-state.paused { color: var(--fg-dim); }
+      .operation-state.blocked, .operation-state.missed { color: var(--state-failed); border-color: var(--state-failed); }
+      .operation-target { margin: 8px 0 10px; color: var(--accent); overflow-wrap: anywhere; }
+      .operation-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px 14px; }
+      .operation-field { min-width: 0; }
+      .operation-field-label {
+        display: block; margin-bottom: 2px; color: var(--fg-dim); font: 9px var(--font-sans);
+        text-transform: uppercase; letter-spacing: .08em;
+      }
+      .operation-field-value { display: block; color: var(--fg); font: 11px/1.4 var(--font-mono); overflow-wrap: anywhere; }
+      .operation-description, .operation-control-note, .operations-readonly-note {
+        margin: 10px 0 0; color: var(--fg-dim); font: 11px/1.5 var(--font-sans);
+      }
+      .operations-readonly-note { margin: 0 0 12px; padding: 9px; border: 1px dashed var(--border); }
+      .operation-control-note.error { color: var(--state-failed); }
+      .operation-button, .operation-cadence {
+        min-height: 30px; padding: 5px 9px; border: 1px solid var(--border); border-radius: 3px;
+        background: var(--bg); color: var(--fg); font: 11px var(--font-mono);
+      }
+      .operation-button { cursor: pointer; white-space: nowrap; }
+      .operation-button:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+      .operation-button:disabled, .operation-cadence:disabled { opacity: .5; cursor: not-allowed; }
+      .operation-button.disable { color: var(--state-failed); }
+      .operation-button.enable { color: var(--state-success); }
+      .operation-clock-summary { justify-content: flex-start; margin-bottom: 14px; }
+      .operation-clock-actions { justify-content: flex-start; flex-wrap: wrap; margin-top: 14px; }
+
+      @media (max-width: 900px) {
+        .operations-layout { grid-template-columns: 1fr; }
+      }
+      @media (max-width: 600px) {
+        .operations-layout { display: block; padding: 8px; }
+        .operations-layout .panel { margin-bottom: 8px; }
+        .operation-grid { grid-template-columns: 1fr; }
+        .operation-card-title { align-items: flex-start; }
+        .operation-card-title > div { align-items: flex-start; flex-direction: column; }
+        .operation-clock-actions { align-items: stretch; }
+        .operation-clock-actions > * { flex: 1 1 100%; }
+      }

--- a/crates/orbit-web/assets/dashboard/index.html
+++ b/crates/orbit-web/assets/dashboard/index.html
@@ -36,6 +36,7 @@
       <button class="tab" data-tab="tasks" type="button">Tasks</button>
       <button class="tab" data-tab="audit" type="button">Audit</button>
       <button class="tab" data-tab="diagnostics" type="button">Diagnostics</button>
+      <button class="tab" data-tab="operations" type="button">Operations</button>
       <button class="tab" data-tab="knowledge" type="button">Knowledge</button>
     </nav>
     <section class="health-strip" id="health-strip" aria-label="Audit health summary">
@@ -299,6 +300,27 @@
         <section class="panel" id="scoreboard-insights-panel">
           <header><span>Insights</span><span class="count" id="scoreboard-insights-count">—</span></header>
           <div id="scoreboard-insights"></div>
+        </section>
+      </main>
+    </section>
+    <section class="tab-pane" data-tab="operations">
+      <main class="operations-layout">
+        <section class="panel" id="routines-panel">
+          <header>
+            <span>Scheduled Routines</span>
+            <span class="count" id="routines-count">-</span>
+          </header>
+          <div class="operation-feedback" id="routine-operation-feedback" role="status" aria-live="polite"></div>
+          <div class="body" id="routines-body">
+            <div class="skeleton-state"><div class="skeleton skeleton-row"></div></div>
+          </div>
+        </section>
+        <section class="panel" id="clock-panel">
+          <header><span>Host Sweep Clock</span><span class="count" id="clock-host">-</span></header>
+          <div class="operation-feedback" id="clock-operation-feedback" role="status" aria-live="polite"></div>
+          <div class="body" id="clock-body">
+            <div class="skeleton-state"><div class="skeleton skeleton-row"></div></div>
+          </div>
         </section>
       </main>
     </section>

--- a/crates/orbit-web/assets/dashboard/operations.js
+++ b/crates/orbit-web/assets/dashboard/operations.js
@@ -1,0 +1,224 @@
+// Routine-definition and host sweep-clock operations [ORB-10875].
+
+import { el, fetchJson, getWorkspace, postJson } from './common.js';
+
+const $ = (id) => document.getElementById(id);
+const pendingOperations = new Set();
+let lastOperations = null;
+let context = null;
+
+export function initOperations(nextContext) {
+  context = nextContext;
+}
+
+function selectedWorkspaceName() {
+  const selected = getWorkspace();
+  return context.getWorkspaces().find((workspace) => workspace.id === selected)?.name || null;
+}
+
+function feedback(id, kind, message) {
+  const node = $(id);
+  if (!node) return;
+  node.className = `operation-feedback ${kind || ""}`;
+  node.textContent = message || "";
+}
+
+function time(value) {
+  if (!value) return "Not observed";
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? String(value) : context.formatAbsoluteTime(value);
+}
+
+function field(label, value) {
+  return el("div", { class: "operation-field" }, [
+    el("span", { class: "operation-field-label", text: label }),
+    el("span", { class: "operation-field-value", text: value == null || value === "" ? "—" : String(value) }),
+  ]);
+}
+
+function controlReason(payload, routine) {
+  if (!getWorkspace()) return "Select one workspace before changing routine or clock state.";
+  if (!payload.controls_authorized) return "Controls require an authorized operator session.";
+  if (routine && !routine.pinned_to_host) return `Select pinned host ${payload.host_id} before changing this routine.`;
+  return "";
+}
+
+function routineButton(payload, routine) {
+  const nextEnabled = !routine.enabled;
+  const key = `routine:${routine.name}`;
+  const reason = controlReason(payload, routine);
+  const button = el("button", {
+    class: `operation-button ${nextEnabled ? "enable" : "disable"}`,
+    text: pendingOperations.has(key) ? "Pending…" : nextEnabled ? "Enable" : "Disable",
+    title: reason || `${nextEnabled ? "Enable" : "Disable"} ${routine.target}`,
+  });
+  button.type = "button";
+  button.disabled = Boolean(reason) || pendingOperations.has(key);
+  button.addEventListener("click", async () => {
+    if (pendingOperations.has(key)) return;
+    pendingOperations.add(key);
+    feedback("routine-operation-feedback", "pending", `${nextEnabled ? "Enabling" : "Disabling"} ${routine.name} → ${routine.target}…`);
+    renderOperations(payload);
+    try {
+      const result = await postJson("/api/routines/toggle", {
+        name: routine.name,
+        source: routine.source,
+        target: routine.target,
+        host_id: payload.host_id,
+        expected_enabled: routine.enabled,
+        enabled: nextEnabled,
+      });
+      feedback("routine-operation-feedback", "success", `${result.message}: ${routine.name} → ${routine.target}.`);
+      await fetchAndRenderOperations();
+    } catch (error) {
+      feedback("routine-operation-feedback", "error", `Routine change failed: ${error.message}`);
+    } finally {
+      pendingOperations.delete(key);
+      if (lastOperations) renderOperations(lastOperations);
+    }
+  });
+  return button;
+}
+
+function renderOperations(payload) {
+  lastOperations = payload;
+  const workspace = selectedWorkspaceName();
+  const routines = workspace
+    ? (payload.routines || []).filter((routine) => routine.source === workspace)
+    : [];
+  const body = $("routines-body");
+  body.textContent = "";
+  if (!workspace) {
+    body.appendChild(el("div", { class: "operations-readonly-note", text: `All-workspace mode is read-only. Select one workspace; this host is already resolved as ${payload.host_id}.` }));
+  }
+  if (routines.length === 0) {
+    body.appendChild(el("div", { class: "empty-state", text: workspace ? "No routines are defined by this workspace." : "Select a workspace to list its routines." }));
+  }
+  for (const routine of routines) {
+    const fire = routine.last_fire;
+    const state = routine.enabled ? (routine.effective ? "enabled" : "blocked") : "disabled";
+    const card = el("article", { class: "operation-card routine-card" });
+    card.append(
+      el("div", { class: "operation-card-title" }, [
+        el("div", {}, [el("strong", { text: routine.name }), el("span", { class: `operation-state ${state}`, text: state })]),
+        routineButton(payload, routine),
+      ]),
+      el("div", { class: "operation-target mono", text: routine.target }),
+      el("div", { class: "operation-grid" }, [
+        field("Source workspace", routine.source),
+        field("Schedule", routine.cron),
+        field("Host pin", (routine.hosts || []).join(", ") || "Local host"),
+        field("Last evaluation", time(routine.last_evaluated_slot || routine.first_observed_at)),
+        field("Next evaluation", time(routine.next_due)),
+        field("Last fire", fire ? time(fire.finished_at || fire.started_at) : "Never"),
+        field("Linked run / outcome", fire ? `${fire.run_id || "No run"} · ${fire.state}` : "No fire recorded"),
+      ]),
+    );
+    if (routine.description) card.appendChild(el("p", { class: "operation-description", text: routine.description }));
+    const reason = controlReason(payload, routine);
+    if (reason) card.appendChild(el("p", { class: "operation-control-note", text: reason }));
+    body.appendChild(card);
+  }
+  $("routines-count").textContent = workspace ? `${routines.length} · ${workspace}` : "read-only";
+  renderClock(payload);
+}
+
+function clockButton(payload, action, label) {
+  const key = "clock:service";
+  const reason = controlReason(payload);
+  const button = el("button", { class: "operation-button", text: pendingOperations.has(key) ? "Pending…" : label, title: reason });
+  button.type = "button";
+  button.disabled = Boolean(reason) || pendingOperations.has(key);
+  button.addEventListener("click", async () => {
+    if (pendingOperations.has(key)) return;
+    const verb = action === "enable" ? "Start" : "Stop";
+    if (!window.confirm(`${verb} the ${payload.clock.provider} sweep clock on ${payload.host_id}? This does not change any routine definition.`)) return;
+    pendingOperations.add(key);
+    feedback("clock-operation-feedback", "pending", `${action === "enable" ? "Starting" : "Stopping"} the host sweep clock…`);
+    renderClock(payload);
+    try {
+      const result = await postJson("/api/routines/clock", {
+        action,
+        host_id: payload.host_id,
+        expected_enabled: payload.clock.enabled,
+        expected_cadence_seconds: payload.clock.configured_cadence_seconds,
+      });
+      feedback("clock-operation-feedback", "success", `${result.message} on ${payload.host_id}.`);
+      await fetchAndRenderOperations();
+    } catch (error) {
+      feedback("clock-operation-feedback", "error", `Clock service change failed: ${error.message}`);
+    } finally {
+      pendingOperations.delete(key);
+      if (lastOperations) renderClock(lastOperations);
+    }
+  });
+  return button;
+}
+
+function renderClock(payload) {
+  const clock = payload.clock;
+  const body = $("clock-body");
+  body.textContent = "";
+  const reason = controlReason(payload);
+  if (reason) body.appendChild(el("div", { class: "operations-readonly-note", text: reason }));
+  body.append(
+    el("div", { class: "operation-clock-summary" }, [
+      el("span", { class: `operation-state ${clock.health}`, text: clock.health }),
+      el("span", { class: "mono", text: clock.provider }),
+      el("span", { text: clock.enabled ? "service enabled" : "service paused" }),
+    ]),
+    el("div", { class: "operation-grid" }, [
+      field("Configured cadence", `${clock.configured_cadence_seconds}s`),
+      field("Effective cadence", clock.effective_cadence_seconds ? `${clock.effective_cadence_seconds}s` : "Inactive"),
+      field("Loaded", clock.loaded ? "Yes" : "No"),
+      field("Running / waiting", clock.running == null ? "Provider does not expose" : clock.running ? "Yes" : "No"),
+      field("Last tick", clock.last_tick_at || "Provider does not expose"),
+      field("Next expected tick", clock.next_tick_at || (clock.schedulable ? "Armed; exact time unavailable" : "Not scheduled")),
+    ]),
+  );
+  if (clock.health_issue) body.appendChild(el("p", { class: "operation-control-note error", text: clock.health_issue }));
+  const actions = el("div", { class: "operation-clock-actions" });
+  actions.appendChild(clockButton(payload, clock.enabled ? "disable" : "enable", clock.enabled ? "Pause clock" : "Enable clock"));
+  const cadence = el("select", { class: "operation-cadence", title: "Clock cadence" });
+  for (const seconds of [60, 300, 900, 1800, 3600]) {
+    const option = el("option", { text: seconds === 60 ? "Every minute" : `Every ${seconds / 60} minutes` });
+    option.value = String(seconds);
+    option.selected = seconds === clock.configured_cadence_seconds;
+    cadence.appendChild(option);
+  }
+  cadence.disabled = Boolean(reason) || pendingOperations.has("clock:cadence");
+  const apply = el("button", { class: "operation-button secondary", text: pendingOperations.has("clock:cadence") ? "Pending…" : "Apply cadence", title: "Reload cadence without changing whether the clock is enabled" });
+  apply.type = "button";
+  apply.disabled = Boolean(reason) || pendingOperations.has("clock:cadence") || Number(cadence.value) === clock.configured_cadence_seconds;
+  cadence.addEventListener("change", () => { apply.disabled = Boolean(reason) || Number(cadence.value) === clock.configured_cadence_seconds; });
+  apply.addEventListener("click", async () => {
+    const key = "clock:cadence";
+    if (pendingOperations.has(key)) return;
+    pendingOperations.add(key);
+    feedback("clock-operation-feedback", "pending", `Changing cadence to ${cadence.value}s; clock service state remains separate…`);
+    renderClock(payload);
+    try {
+      const result = await postJson("/api/routines/clock", {
+        action: "set_cadence",
+        host_id: payload.host_id,
+        expected_enabled: clock.enabled,
+        expected_cadence_seconds: clock.configured_cadence_seconds,
+        cadence_seconds: Number(cadence.value),
+      });
+      feedback("clock-operation-feedback", "success", `${result.message}; service is ${result.clock.enabled ? "enabled" : "paused"}.`);
+      await fetchAndRenderOperations();
+    } catch (error) {
+      feedback("clock-operation-feedback", "error", `Cadence change failed: ${error.message}`);
+    } finally {
+      pendingOperations.delete(key);
+      if (lastOperations) renderClock(lastOperations);
+    }
+  });
+  actions.append(cadence, apply);
+  body.appendChild(actions);
+  $("clock-host").textContent = payload.host_id || "unknown host";
+}
+
+export function fetchAndRenderOperations() {
+  return fetchJson("/api/routines").then(renderOperations);
+}

--- a/crates/orbit-web/assets/dashboard/router.js
+++ b/crates/orbit-web/assets/dashboard/router.js
@@ -25,7 +25,7 @@ const $ = (id) => document.getElementById(id);
 // ORB-10444: the top-level nav is exactly these four tabs plus the hash-only
 // `run-detail` route. A deprecated tab was retired outright and `scoreboard`,
 // being diagnostics-shaped, now routes as `#diagnostics/scoreboard`.
-const TABS = ["tasks", "audit", "diagnostics", "knowledge", "run-detail"];
+const TABS = ["tasks", "audit", "diagnostics", "operations", "knowledge", "run-detail"];
 const DIAG_SUBTABS = ["runs", "metrics", "errors", "reliability", "scoreboard"];
 // ORB-10444/ORB-10588: subtabs that replace the two-column diagnostics layout
 // with their own full-width <main>, keyed by the element they reveal.
@@ -183,6 +183,7 @@ function setActiveTabImpl(ctx, raw, opts = {}) {
     top = "tasks";
   }
   ctx.setTab(top);
+  document.body.classList.toggle("operations-active", top === "operations");
   for (const tab of document.querySelectorAll(".tab")) {
     tab.classList.toggle("active", tab.dataset.tab === top);
   }

--- a/crates/orbit-web/src/api/mod.rs
+++ b/crates/orbit-web/src/api/mod.rs
@@ -412,6 +412,8 @@ pub(super) fn router() -> Router<crate::state::DashboardState> {
         .route("/log/stream", get(log::stream_log))
         .route("/audit/summary", get(audit::audit_summary))
         .route("/routines", get(routines::list_routine_health))
+        .route("/routines/toggle", post(routines::toggle_routine))
+        .route("/routines/clock", post(routines::control_clock))
         .route("/scoreboard", get(scoreboard::scoreboard))
         .route("/metrics/knowledge", get(metrics::knowledge_metrics))
         .route("/metrics/activity", get(metrics::activity_metrics))

--- a/crates/orbit-web/src/api/routines.rs
+++ b/crates/orbit-web/src/api/routines.rs
@@ -1,45 +1,340 @@
-//! Routine scheduler health for remote observability [ORB-10138].
-//!
-//! `GET /api/routines` surfaces every routine visible from the global registry
-//! with its last recorded fire (timestamp, outcome, duration) so a consumer can
-//! tell — without box ssh — whether the scheduled sweeps (`ship-sweep`,
-//! `auto-task-scheduler`) actually fired and succeeded. A stopped scheduler is visible as a
-//! stale `last_fire` relative to the routine's `cron` cadence.
-//!
-//! Named "routines", not "sweeps": in orbit's model the sweeps are routines and
-//! not every routine is a sweep (e.g. the default triage routine). Consumers
-//! filter by `name` for the sweeps they care about.
-//!
-//! This is a host-level view — routine fires live in the global store, not any
-//! one workspace runtime — so it reads `state.global_root()` directly and takes
-//! no `?workspace=` selector.
+//! Routine and host sweep-clock operations for the dashboard [ORB-10875].
 
-use axum::extract::State;
+use std::time::Instant;
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
 use chrono::{DateTime, Utc};
 use orbit_cmd::registry_routines::routine_statuses;
-use orbit_core::routines::{RoutineStatus, RoutineStatusReport};
-use orbit_core::{RoutineFireRecord, RoutineFireState};
+use orbit_common::authorization::{
+    AuthorizationDenial, CallerCapabilities, CallerEnvelope, DASHBOARD_CLOCK_CADENCE,
+    DASHBOARD_CLOCK_SERVICE, DASHBOARD_ROUTINE_TOGGLE, GovernedOperation, authorize,
+};
+use orbit_common::types::{AuditEventStatus, ToolSessionContext, audit_execution_id};
+use orbit_core::routines::{
+    ClockStatus, RoutineStatus, RoutineStatusReport, RoutineToggleOutcome, clock_status,
+    set_clock_cadence, set_clock_enabled, set_routine_enabled,
+};
+use orbit_core::{AuditEventInsertParams, OrbitRuntime, RoutineFireRecord, RoutineFireState};
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use super::map_runtime_error;
-use crate::state::DashboardState;
+use crate::state::{DashboardState, Ws};
 
-/// `GET /api/routines` — per-routine scheduler health for this host.
-pub(super) async fn list_routine_health(State(state): State<DashboardState>) -> Response {
-    match routine_statuses(state.global_root()) {
-        Ok(report) => Json(report_json(&report, Utc::now())).into_response(),
-        Err(e) => map_runtime_error(e),
-    }
+#[derive(Debug, Deserialize, Default)]
+pub(super) struct OperationsQuery {
+    workspace: Option<String>,
 }
 
-/// Project a status report into the wire JSON. `generated_at` is the server's
-/// clock at query time, so a consumer can measure `last_fire` staleness against
-/// a trusted reference rather than its own (possibly skewed) clock.
-pub(super) fn report_json(report: &RoutineStatusReport, generated_at: DateTime<Utc>) -> Value {
+#[derive(Debug, Deserialize)]
+pub(super) struct RoutineToggleRequest {
+    name: String,
+    source: String,
+    target: String,
+    host_id: String,
+    expected_enabled: bool,
+    enabled: bool,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum ClockAction {
+    Enable,
+    Disable,
+    SetCadence,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ClockControlRequest {
+    action: ClockAction,
+    host_id: String,
+    expected_enabled: bool,
+    expected_cadence_seconds: u64,
+    cadence_seconds: Option<u64>,
+}
+
+/// `GET /api/routines` — routine definition state and the independent host clock.
+pub(super) async fn list_routine_health(State(state): State<DashboardState>) -> Response {
+    let generated_at = Utc::now();
+    let report = match routine_statuses(state.global_root()) {
+        Ok(report) => report,
+        Err(error) => return map_runtime_error(error),
+    };
+    let clock = match clock_status(state.global_root()) {
+        Ok(clock) => clock,
+        Err(error) => return map_runtime_error(error),
+    };
+    Json(report_json(&report, &clock, generated_at)).into_response()
+}
+
+/// `POST /api/routines/toggle` — atomically change one selected workspace's
+/// versioned `enabled` field. Browser input never supplies a path.
+pub(super) async fn toggle_routine(
+    State(state): State<DashboardState>,
+    Query(query): Query<OperationsQuery>,
+    Ws(runtime): Ws,
+    Json(body): Json<RoutineToggleRequest>,
+) -> Response {
+    let workspace = match explicit_workspace(&query) {
+        Ok(workspace) => workspace,
+        Err(rejection) => return rejection.into_response(),
+    };
+    let caller = match authorized_caller(&DASHBOARD_ROUTINE_TOGGLE) {
+        Ok(caller) => caller,
+        Err(denial) => {
+            record_operation_audit(
+                &runtime,
+                workspace,
+                "routine.toggle",
+                &body.name,
+                &body.host_id,
+                &json!({"source": body.source, "target": body.target, "enabled": body.enabled}),
+                None,
+                Some(&denial),
+                None,
+                Instant::now(),
+            );
+            return authorization_denied(denial);
+        }
+    };
+    let started = Instant::now();
+    let report = match routine_statuses(state.global_root()) {
+        Ok(report) => report,
+        Err(error) => return map_runtime_error(error),
+    };
+    let Some(status) = report
+        .statuses
+        .iter()
+        .find(|status| status.routine.definition.name == body.name)
+    else {
+        return not_found_or_conflict(
+            "routine_not_found",
+            format!("routine '{}' was not found", body.name),
+        );
+    };
+    if status.routine.source_workspace != body.source
+        || status.routine.source_orbit_dir != runtime.shared_root()
+    {
+        return not_found_or_conflict(
+            "workspace_mismatch",
+            format!(
+                "select routine source workspace '{}' before changing '{}'",
+                status.routine.source_workspace, body.name
+            ),
+        );
+    }
+    if body.host_id != report.host_id || !status.pinned_to_host {
+        return not_found_or_conflict(
+            "host_mismatch",
+            format!(
+                "select pinned host '{}' before changing '{}'",
+                report.host_id, body.name
+            ),
+        );
+    }
+    let actual_target = status.routine.definition.target.as_ref_string();
+    if body.target != actual_target {
+        return not_found_or_conflict(
+            "target_mismatch",
+            format!("routine target changed; refresh and confirm '{actual_target}'"),
+        );
+    }
+
+    let outcome = match set_routine_enabled(
+        &status.routine,
+        &report.host_id,
+        body.expected_enabled,
+        body.enabled,
+    ) {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            let error_message = error.to_string();
+            record_operation_audit(
+                &runtime,
+                workspace,
+                "routine.toggle",
+                &body.name,
+                &body.host_id,
+                &json!({"source": body.source, "target": body.target, "enabled": body.enabled}),
+                Some(&caller),
+                None,
+                Some(&error_message),
+                started,
+            );
+            return map_runtime_error(error);
+        }
+    };
+    if let RoutineToggleOutcome::Conflict { actual_enabled } = outcome {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "error": "routine state changed while this action was pending; refresh before retrying",
+                "code": "stale_routine_state",
+                "actual_enabled": actual_enabled,
+            })),
+        )
+            .into_response();
+    }
+    record_operation_audit(
+        &runtime,
+        workspace,
+        "routine.toggle",
+        &body.name,
+        &body.host_id,
+        &json!({"source": body.source, "target": body.target, "enabled": body.enabled}),
+        Some(&caller),
+        None,
+        None,
+        started,
+    );
+    Json(json!({
+        "name": body.name,
+        "source": body.source,
+        "target": body.target,
+        "host_id": body.host_id,
+        "enabled": body.enabled,
+        "changed": outcome == RoutineToggleOutcome::Changed,
+        "message": if body.enabled { "Routine enabled" } else { "Routine disabled" },
+    }))
+    .into_response()
+}
+
+/// `POST /api/routines/clock` — typed native-service or cadence control.
+pub(super) async fn control_clock(
+    State(state): State<DashboardState>,
+    Query(query): Query<OperationsQuery>,
+    Ws(runtime): Ws,
+    Json(body): Json<ClockControlRequest>,
+) -> Response {
+    let workspace = match explicit_workspace(&query) {
+        Ok(workspace) => workspace,
+        Err(rejection) => return rejection.into_response(),
+    };
+    let governed = match body.action {
+        ClockAction::Enable | ClockAction::Disable => &DASHBOARD_CLOCK_SERVICE,
+        ClockAction::SetCadence => &DASHBOARD_CLOCK_CADENCE,
+    };
+    let operation = governed.id;
+    let caller = match authorized_caller(governed) {
+        Ok(caller) => caller,
+        Err(denial) => {
+            record_operation_audit(
+                &runtime,
+                workspace,
+                operation,
+                "sweep-clock",
+                &body.host_id,
+                &json!({"action": body.action, "cadence_seconds": body.cadence_seconds}),
+                None,
+                Some(&denial),
+                None,
+                Instant::now(),
+            );
+            return authorization_denied(denial);
+        }
+    };
+    let started = Instant::now();
+    let before = match clock_status(state.global_root()) {
+        Ok(status) => status,
+        Err(error) => return map_runtime_error(error),
+    };
+    let report = match routine_statuses(state.global_root()) {
+        Ok(report) => report,
+        Err(error) => return map_runtime_error(error),
+    };
+    if body.host_id != report.host_id {
+        return not_found_or_conflict(
+            "host_mismatch",
+            format!(
+                "select host '{}' before changing its sweep clock",
+                report.host_id
+            ),
+        );
+    }
+    if before.enabled != body.expected_enabled
+        || before.configured_cadence_seconds != body.expected_cadence_seconds
+    {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "error": "clock state changed while this action was pending; refresh before retrying",
+                "code": "stale_clock_state",
+                "actual_enabled": before.enabled,
+                "actual_cadence_seconds": before.configured_cadence_seconds,
+            })),
+        )
+            .into_response();
+    }
+
+    let mutation = match body.action {
+        ClockAction::Enable => set_clock_enabled(state.global_root(), true).map(|_| ()),
+        ClockAction::Disable => set_clock_enabled(state.global_root(), false).map(|_| ()),
+        ClockAction::SetCadence => body
+            .cadence_seconds
+            .ok_or_else(|| {
+                orbit_core::OrbitError::InvalidInput(
+                    "cadence_seconds is required for set_cadence".to_string(),
+                )
+            })
+            .and_then(|cadence| set_clock_cadence(state.global_root(), cadence).map(|_| ())),
+    };
+    if let Err(error) = mutation {
+        let error_message = error.to_string();
+        record_operation_audit(
+            &runtime,
+            workspace,
+            operation,
+            "sweep-clock",
+            &body.host_id,
+            &json!({"action": body.action, "cadence_seconds": body.cadence_seconds}),
+            Some(&caller),
+            None,
+            Some(&error_message),
+            started,
+        );
+        return map_runtime_error(error);
+    }
+    let after = match clock_status(state.global_root()) {
+        Ok(status) => status,
+        Err(error) => return map_runtime_error(error),
+    };
+    record_operation_audit(
+        &runtime,
+        workspace,
+        operation,
+        "sweep-clock",
+        &body.host_id,
+        &json!({"action": body.action, "cadence_seconds": body.cadence_seconds}),
+        Some(&caller),
+        None,
+        None,
+        started,
+    );
+    Json(json!({
+        "clock": clock_json(&after),
+        "changed": before != after,
+        "message": match body.action {
+            ClockAction::Enable => "Sweep clock enabled",
+            ClockAction::Disable => "Sweep clock paused",
+            ClockAction::SetCadence => "Sweep clock cadence updated",
+        },
+    }))
+    .into_response()
+}
+
+pub(super) fn report_json(
+    report: &RoutineStatusReport,
+    clock: &ClockStatus,
+    generated_at: DateTime<Utc>,
+) -> Value {
     json!({
         "generated_at": generated_at.to_rfc3339(),
         "host_id": report.host_id,
+        "machine_id": report.machine_id,
+        "controls_authorized": authorized_caller(&DASHBOARD_ROUTINE_TOGGLE).is_ok(),
+        "clock": clock_json(clock),
         "routines": report.statuses.iter().map(status_json).collect::<Vec<_>>(),
         "load_errors": report.load_errors.iter().map(|e| json!({
             "source_workspace": e.source_workspace,
@@ -53,20 +348,156 @@ fn status_json(status: &RoutineStatus) -> Value {
     let definition = &status.routine.definition;
     json!({
         "name": definition.name,
+        "description": definition.description,
         "source": status.routine.source_workspace,
         "target": definition.target.as_ref_string(),
         "enabled": definition.enabled,
+        "hosts": definition.hosts,
         "pinned_to_host": status.pinned_to_host,
         "paused_at": status.paused_at,
         "effective": status.effective(),
         "cron": definition.trigger.cron,
+        "first_observed_at": status.first_observed_at,
+        "last_evaluated_slot": status.last_evaluated_slot,
         "next_due": status.next_due,
         "last_fire": status.last_fire.as_ref().map(fire_json),
     })
 }
 
-/// One fire attempt, enriched with a coarse `ok` outcome and a wall-clock
-/// duration (intent → last state change) for terminal fires.
+pub(super) fn clock_json(clock: &ClockStatus) -> Value {
+    json!({
+        "provider": clock.platform,
+        "configured_cadence_seconds": clock.configured_cadence_seconds,
+        "effective_cadence_seconds": clock.effective_cadence_seconds,
+        "enabled": clock.enabled,
+        "loaded": clock.loaded,
+        "running": clock.running,
+        "schedulable": clock.schedulable,
+        "health": if !clock.enabled { "paused" } else if clock.schedulable { "healthy" } else { "missed" },
+        "health_issue": clock.health_issue,
+        "last_tick_at": clock.last_tick_at,
+        "next_tick_at": clock.next_tick_at,
+    })
+}
+
+fn explicit_workspace(query: &OperationsQuery) -> Result<&str, (StatusCode, Json<Value>)> {
+    query
+        .workspace
+        .as_deref()
+        .filter(|workspace| !workspace.trim().is_empty())
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "error": "select one concrete workspace before using Operations controls",
+                    "code": "workspace_required",
+                })),
+            )
+        })
+}
+
+fn authorized_caller(
+    operation: &'static GovernedOperation,
+) -> Result<CallerCapabilities, AuthorizationDenial> {
+    let caller = CallerCapabilities::resolve(&CallerEnvelope::from_process_env(
+        &ToolSessionContext::default(),
+    ));
+    authorize(operation, &caller)?;
+    Ok(caller)
+}
+
+fn authorization_denied(denial: AuthorizationDenial) -> Response {
+    (
+        StatusCode::FORBIDDEN,
+        Json(json!({
+            "error": denial.to_string(),
+            "code": "authorization_denied",
+            "operation": denial.operation.id,
+            "provenance": denial.provenance.to_string(),
+        })),
+    )
+        .into_response()
+}
+
+fn not_found_or_conflict(code: &'static str, message: String) -> Response {
+    (
+        StatusCode::CONFLICT,
+        Json(json!({"error": message, "code": code})),
+    )
+        .into_response()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn record_operation_audit(
+    runtime: &OrbitRuntime,
+    workspace: &str,
+    operation: &str,
+    target: &str,
+    host_id: &str,
+    arguments: &Value,
+    caller: Option<&CallerCapabilities>,
+    denial: Option<&AuthorizationDenial>,
+    failure: Option<&str>,
+    started: Instant,
+) {
+    let status = if denial.is_some() {
+        AuditEventStatus::Denied
+    } else if failure.is_some() {
+        AuditEventStatus::Failure
+    } else {
+        AuditEventStatus::Success
+    };
+    let capabilities = caller
+        .map(|caller| caller.grants().clone())
+        .unwrap_or_default();
+    let provenance = caller
+        .map(|caller| caller.provenance().to_string())
+        .or_else(|| denial.map(|denial| denial.provenance.to_string()));
+    let params = AuditEventInsertParams {
+        execution_id: audit_execution_id("dashboard-operations"),
+        command: "dashboard.operations".to_string(),
+        subcommand: provenance,
+        tool_name: None,
+        target_type: Some(operation.to_string()),
+        target_id: Some(target.to_string()),
+        role: "operator".to_string(),
+        status,
+        exit_code: i32::from(status != AuditEventStatus::Success),
+        duration_ms: i64::try_from(started.elapsed().as_millis()).unwrap_or(i64::MAX),
+        working_directory: runtime
+            .workspace_runtime_binding()
+            .map(|binding| binding.repo_root.display().to_string())
+            .unwrap_or_else(|| runtime.shared_root().display().to_string()),
+        arguments_json: serde_json::to_string(arguments).ok(),
+        stdout_truncated: None,
+        stderr_truncated: None,
+        error_message: denial
+            .map(ToString::to_string)
+            .or_else(|| failure.map(str::to_string)),
+        host: std::env::var("HOSTNAME").ok(),
+        pid: std::process::id(),
+        session_id: None,
+        workspace_id: Some(workspace.to_string()),
+        caller_machine_id: None,
+        caller_host_id: Some(host_id.to_string()),
+        process_machine_id: None,
+        process_host_id: Some(host_id.to_string()),
+        transport: None,
+        effective_capabilities: capabilities,
+        origin_session_id: None,
+        mcp_call_id: None,
+        lease_id: None,
+        task_id: None,
+        job_run_id: None,
+        activity_id: None,
+        step_index: None,
+    };
+    if let Err(error) = runtime.record_audit_event(&params) {
+        tracing::error!(operation, target, error = %error, "failed to persist dashboard operation audit");
+    }
+}
+
+/// One fire attempt, enriched with coarse outcome and wall-clock duration.
 pub(super) fn fire_json(fire: &RoutineFireRecord) -> Value {
     let finished = fire.state.is_terminal();
     json!({
@@ -82,8 +513,6 @@ pub(super) fn fire_json(fire: &RoutineFireRecord) -> Value {
     })
 }
 
-/// Coarse pass/fail for a fire state: `Some(true)` succeeded, `Some(false)`
-/// failed/timed-out/errored, `None` while still in flight (intent/dispatched).
 pub(super) fn fire_ok(state: RoutineFireState) -> Option<bool> {
     match state {
         RoutineFireState::Succeeded => Some(true),
@@ -94,8 +523,6 @@ pub(super) fn fire_ok(state: RoutineFireState) -> Option<bool> {
     }
 }
 
-/// Wall-clock duration (`created_at` → `updated_at`) in milliseconds for a
-/// terminal fire; `None` while in flight or if either timestamp fails to parse.
 pub(super) fn duration_ms(fire: &RoutineFireRecord) -> Option<i64> {
     if !fire.state.is_terminal() {
         return None;

--- a/crates/orbit-web/src/api/tests/routines.rs
+++ b/crates/orbit-web/src/api/tests/routines.rs
@@ -1,13 +1,16 @@
 //! Tests for the routine-health JSON API [ORB-10138].
 
+use std::sync::Arc;
+
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode};
-use orbit_core::{RoutineFireRecord, RoutineFireState};
+use orbit_core::routines::ClockStatus;
+use orbit_core::{OrbitRuntime, RoutineFireRecord, RoutineFireState};
 use orbit_registry::{NewHostIdentity, ensure_host_identity};
 use tower::ServiceExt;
 
 use super::super::router;
-use super::super::routines::{duration_ms, fire_json, fire_ok};
+use super::super::routines::{clock_json, duration_ms, fire_json, fire_ok};
 use super::test_support::body_json;
 use crate::state::DashboardState;
 
@@ -83,6 +86,42 @@ fn fire_json_omits_finish_while_in_flight() {
     assert!(json["duration_ms"].is_null());
 }
 
+#[test]
+fn clock_json_keeps_service_state_and_health_distinct() {
+    let healthy = clock_json(&ClockStatus {
+        configured_cadence_seconds: 300,
+        effective_cadence_seconds: Some(300),
+        enabled: true,
+        loaded: true,
+        running: Some(true),
+        schedulable: true,
+        health_issue: None,
+        last_tick_at: Some("previous".to_string()),
+        next_tick_at: Some("next".to_string()),
+        platform: "systemd",
+    });
+    assert_eq!(healthy["health"], "healthy");
+    assert_eq!(healthy["enabled"], true);
+    assert_eq!(healthy["running"], true);
+    assert_eq!(healthy["next_tick_at"], "next");
+
+    let missed = clock_json(&ClockStatus {
+        configured_cadence_seconds: 300,
+        effective_cadence_seconds: None,
+        enabled: true,
+        loaded: true,
+        running: Some(false),
+        schedulable: false,
+        health_issue: Some("no future trigger".to_string()),
+        last_tick_at: None,
+        next_tick_at: None,
+        platform: "systemd",
+    });
+    assert_eq!(missed["health"], "missed");
+    assert_eq!(missed["enabled"], true, "enabled is not health");
+    assert_eq!(missed["running"], false);
+}
+
 /// End-to-end: the endpoint resolves host-level routine state from the global
 /// root and returns a well-formed envelope even when no routines are
 /// configured (empty registry). Exercises the wiring, not fixture data.
@@ -114,6 +153,60 @@ async fn routines_endpoint_returns_envelope_for_empty_host() {
     let json = body_json(response).await;
     assert!(json["generated_at"].is_string());
     assert!(json["host_id"].is_string());
+    assert!(json["clock"]["provider"].is_string());
+    assert!(json["clock"]["configured_cadence_seconds"].is_number());
+    assert!(json["clock"]["enabled"].is_boolean());
     assert_eq!(json["routines"], serde_json::json!([]));
     assert_eq!(json["load_errors"], serde_json::json!([]));
+}
+
+#[tokio::test]
+async fn routine_mutation_denies_an_unidentified_dashboard_caller() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let state = DashboardState::single(Arc::new(runtime));
+    let response = router()
+        .with_state(state)
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/routines/toggle?workspace=default")
+                .header("origin", "http://localhost:7878")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"name":"nightly","source":"default","target":"job:nightly","host_id":"host-a","expected_enabled":true,"enabled":false}"#,
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let json = body_json(response).await;
+    assert_eq!(json["code"], "authorization_denied");
+    assert_eq!(json["operation"], "routine.toggle");
+}
+
+#[tokio::test]
+async fn operations_mutations_require_an_explicit_workspace() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let state = DashboardState::single(Arc::new(runtime));
+    let response = router()
+        .with_state(state)
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/routines/clock")
+                .header("origin", "http://localhost:7878")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"action":"disable","host_id":"host-a","expected_enabled":true,"expected_cadence_seconds":60}"#,
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = body_json(response).await;
+    assert_eq!(json["code"], "workspace_required");
 }

--- a/crates/orbit-web/src/lib.rs
+++ b/crates/orbit-web/src/lib.rs
@@ -55,6 +55,7 @@ const DIAGNOSTICS_JS: &str = include_str!("../assets/dashboard/diagnostics.js");
 const ROUTER_JS: &str = include_str!("../assets/dashboard/router.js");
 const RUNS_JS: &str = include_str!("../assets/dashboard/runs.js");
 const RUN_DETAIL_JS: &str = include_str!("../assets/dashboard/run-detail.js");
+const OPERATIONS_JS: &str = include_str!("../assets/dashboard/operations.js");
 const DASHBOARD_CSP: &str = concat!(
     "default-src 'self'; ",
     "script-src 'self'; ",
@@ -240,6 +241,7 @@ fn run_server(args: &ServeArgs, state: state::DashboardState) -> Result<(), Orbi
         .route("/static/router.js", get(serve_router_js))
         .route("/static/runs.js", get(serve_runs_js))
         .route("/static/run-detail.js", get(serve_run_detail_js))
+        .route("/static/operations.js", get(serve_operations_js))
         .route("/healthz", get(health::healthz))
         .nest("/api", api::router())
         .with_state(state);
@@ -364,6 +366,10 @@ async fn serve_runs_js() -> Response {
 
 async fn serve_run_detail_js() -> Response {
     dashboard_response("application/javascript; charset=utf-8", RUN_DETAIL_JS)
+}
+
+async fn serve_operations_js() -> Response {
+    dashboard_response("application/javascript; charset=utf-8", OPERATIONS_JS)
 }
 
 fn dashboard_response(content_type: &'static str, body: &'static str) -> Response {

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -4,9 +4,9 @@ use axum::response::Response;
 
 use crate::{
     DASHBOARD_CSP, serve_app_js, serve_audit_js, serve_common_js, serve_diagnostics_js,
-    serve_index, serve_log_tail_js, serve_markdown_js, serve_marked_js, serve_purify_js,
-    serve_reliability_js, serve_router_js, serve_run_detail_js, serve_runs_js, serve_scoreboard_js,
-    serve_tasks_js,
+    serve_index, serve_log_tail_js, serve_markdown_js, serve_marked_js, serve_operations_js,
+    serve_purify_js, serve_reliability_js, serve_router_js, serve_run_detail_js, serve_runs_js,
+    serve_scoreboard_js, serve_tasks_js,
 };
 
 #[tokio::test]
@@ -27,6 +27,7 @@ async fn dashboard_html_and_js_routes_emit_csp() {
         ("router", serve_router_js().await),
         ("runs", serve_runs_js().await),
         ("run_detail", serve_run_detail_js().await),
+        ("operations", serve_operations_js().await),
     ];
 
     for (name, response) in routes {
@@ -482,13 +483,13 @@ fn dashboard_task_detail_shows_orchestrator_as_attribution_not_execution_crew() 
     );
 }
 
-/// ORB-10444: the top-level nav is exactly Tasks, Audit, Diagnostics, Knowledge.
+/// ORB-10444/ORB-10875: the top-level nav includes the bounded Operations view.
 /// A deprecated tab was retired outright — nav entry, route and pane — and
 /// Scoreboard, being a diagnostics-shaped view, moved under Diagnostics. A route
 /// left behind in `TABS` would resolve to a pane that no longer exists, so the
 /// router's tab list is asserted alongside the markup.
 #[tokio::test]
-async fn dashboard_top_level_nav_is_the_four_operator_tabs() {
+async fn dashboard_top_level_nav_matches_the_operator_tabs() {
     let body = response_body(serve_index().await).await;
     let router = include_str!("../../assets/dashboard/router.js");
 
@@ -502,16 +503,26 @@ async fn dashboard_top_level_nav_is_the_four_operator_tabs() {
             }
         })
         .collect();
-    assert_eq!(nav, vec!["tasks", "audit", "diagnostics", "knowledge"]);
+    assert_eq!(
+        nav,
+        vec!["tasks", "audit", "diagnostics", "operations", "knowledge"]
+    );
 
     assert!(
         router.contains(
-            r#"const TABS = ["tasks", "audit", "diagnostics", "knowledge", "run-detail"];"#
+            r#"const TABS = ["tasks", "audit", "diagnostics", "operations", "knowledge", "run-detail"];"#
         ),
         "the router's tab list must match the nav (plus the hash-only run-detail route)"
     );
     // Every routable tab must still have a pane to render into.
-    for tab in ["tasks", "audit", "diagnostics", "knowledge", "run-detail"] {
+    for tab in [
+        "tasks",
+        "audit",
+        "diagnostics",
+        "operations",
+        "knowledge",
+        "run-detail",
+    ] {
         assert!(
             body.contains(&format!(r#"<section class="tab-pane" data-tab="{tab}">"#)),
             "routable tab `{tab}` must have a pane"
@@ -520,6 +531,32 @@ async fn dashboard_top_level_nav_is_the_four_operator_tabs() {
     assert!(
         !body.contains(r#"data-tab="scoreboard""#),
         "Scoreboard must no longer be a top-level tab or pane"
+    );
+}
+
+#[test]
+fn dashboard_operations_are_typed_guarded_and_responsive() {
+    let index = include_str!("../../assets/dashboard/index.html");
+    let operations = include_str!("../../assets/dashboard/operations.js");
+    let css = include_str!("../../assets/dashboard/dashboard.css");
+
+    for id in ["routines-body", "clock-body", "routine-operation-feedback"] {
+        assert!(index.contains(&format!(r#"id="{id}""#)));
+    }
+    assert!(operations.contains(r#"postJson("/api/routines/toggle""#));
+    assert!(operations.contains(r#"postJson("/api/routines/clock""#));
+    assert!(operations.contains("pendingOperations.has(key)"));
+    assert!(operations.contains("window.confirm("));
+    assert!(operations.contains("All-workspace mode is read-only"));
+    assert!(operations.contains("routine.target"));
+    assert!(operations.contains("last_evaluated_slot"));
+    assert!(operations.contains("next_tick_at"));
+    assert!(css.contains("@media (max-width: 600px)"));
+    assert!(css.contains(".operation-grid { grid-template-columns: 1fr; }"));
+    assert!(css.contains("body.operations-active"));
+    assert!(
+        include_str!("../../assets/dashboard/router.js")
+            .contains(r#"classList.toggle("operations-active", top === "operations")"#)
     );
 }
 
@@ -1049,6 +1086,10 @@ fn dashboard_assets_carry_no_project_specific_identifiers() {
         (
             "reliability.js",
             include_str!("../../assets/dashboard/reliability.js"),
+        ),
+        (
+            "operations.js",
+            include_str!("../../assets/dashboard/operations.js"),
         ),
     ];
     // Personal names and layout paths of the machine Orbit is developed on, plus

--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -41,6 +41,20 @@ unit identity. On an activation failure Orbit reports the concrete native recove
 command rather than claiming the clock is active. launchd and systemd user managers are
 the supported platforms; there is no resident Orbit daemon ([Host-local sweep clock configuration](./4_decisions.md#host-local-sweep-clock-configuration)).
 
+The dashboard Operations view projects the same typed status and control functions
+[ORB-10875]. Routine definitions remain workspace-scoped and show their versioned
+`enabled` value; the host clock remains one independent host-scoped card. A routine
+toggle resolves its file from a freshly loaded `LoadedRoutine`, validates the displayed
+workspace, host, target, and expected prior state, changes only the top-level `enabled`
+field, reparses the document, and uses an atomic rename. Clock requests are a closed
+typed action set (`enable`, `disable`, `set_cadence`) over the existing launchd/systemd
+abstraction. The browser never supplies paths, programs, arguments, or shell text.
+
+Both mutation families require an operator capability and write an audit event with the
+selected workspace, concrete host, target, typed arguments, and authorization
+provenance. Aggregate workspace views are read-only; stale expected state returns a
+conflict so delayed or duplicate submissions cannot overwrite newer state.
+
 ---
 
 ## 1. Routine Definition
@@ -320,5 +334,6 @@ out of v1 scope for this reason.
 - [ORB-10207] — added disabled-by-default seeding and workspace-local ship sweep.
 - [ORB-00374] — removed the `shell` activity variant and `run_shell` dispatch (fail-closed);
   routines inherit this constraint.
+- [ORB-10875] — added dashboard routine and host-clock status and controls.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/user-interface/2_design.md
+++ b/docs/design/user-interface/2_design.md
@@ -3,7 +3,7 @@ summary: "User Interface — Design"
 type: design
 title: "User Interface — Design"
 owner: gemini
-last_updated: 2026-08-13
+last_updated: 2026-08-16
 status: Draft
 feature: user-interface
 doc_role: design
@@ -48,7 +48,7 @@ Knowledge detail panels stay pinned while the artifact list scrolls after [ORB-1
 
 ## 6. Top-Level Navigation
 
-The top-level nav carries exactly the operator's four workflow surfaces — Tasks, Audit, Diagnostics, Knowledge — plus the hash-only `run-detail` route [ORB-10444] [Top-Level Dashboard Nav Is the Operator's Four Tabs](./4_decisions.md#top-level-dashboard-nav-is-the-operators-four-tabs). A deprecated review-threads tab was removed outright rather than hidden: nav entry, route, pane, refresh branch, and styles all went, so no dead asset ships and no route resolves to a missing pane. Scoreboard is diagnostics-shaped telemetry rather than a workflow surface, so it moved under Diagnostics as the `#diagnostics/scoreboard` sub-tab. Its markup moved verbatim, so every element `scoreboard.js` renders into — and therefore the `/api/scoreboard` response contract — is unchanged; the sub-tab swaps the diagnostics two-column layout for a full-width one while keeping the sub-tab nav reachable.
+The top-level nav carries five operator workflow surfaces — Tasks, Audit, Diagnostics, Operations, and Knowledge — plus the hash-only `run-detail` route [ORB-10444] [ORB-10875]. Operations owns routine and host-clock state; it is top-level because disabling unattended execution is an operational action rather than diagnostic telemetry. A deprecated review-threads tab was removed outright rather than hidden: nav entry, route, pane, refresh branch, and styles all went, so no dead asset ships and no route resolves to a missing pane. Scoreboard is diagnostics-shaped telemetry rather than a workflow surface, so it remains under Diagnostics as the `#diagnostics/scoreboard` sub-tab.
 
 ## 7. Task Write Actions
 
@@ -68,7 +68,15 @@ The Tasks count states what it means instead of an ambiguous `N/50`: it names th
 
 The active status filter and search query are represented in the `#tasks` hash (mirroring the Audit tab's own hash-encoded filters) and restated as plain text next to the count, so the current view survives a reload or the browser's back/forward button and is legible without reading each chip's color. The selected workspace is likewise mirrored into the page's `?workspace=` query parameter on every change [ORB-10874].
 
-## 9. Concerns & Honest Limitations
+## 9. Operations
+
+Operations renders routine-definition state separately from the host sweep clock [ORB-10875]. Each routine row names its source workspace, cron schedule, catalog target, host pins, last scheduler evaluation/fire, linked run outcome, and next due slot. Definition `enabled` is the versioned switch; the clock card independently reports its native provider, configured/effective cadence, loaded/active health, and native last/next tick values when available.
+
+Routine toggles and clock controls require one concrete workspace and the exact local host returned by the status response. All-workspace mode stays readable but has no active controls. Each mutation carries its displayed target plus expected prior state, so a delayed or duplicate click conflicts instead of overwriting a newer observation. The UI also holds an in-flight guard, renders pending state, and reports the server's exact success or failure. Starting/stopping the native service requires confirmation; cadence is a separate control and its feedback explicitly preserves the service-state distinction. The backend accepts typed actions only and resolves routine paths and native commands itself—browser input is never interpreted as shell text.
+
+The two-column desktop layout stacks below 900px, and routine/clock metadata collapses to one column below 600px so schedules, state labels, and controls remain scannable at 480–720px widths.
+
+## 10. Concerns & Honest Limitations
 
 Accessibility still needs a real WCAG pass; responsive behavior remains optimized for wide desktop viewports; raw HTML, CSS variables, and dashboard JavaScript keep the runtime simple but leave duplication across project surfaces.
 
@@ -85,5 +93,6 @@ Accessibility still needs a real WCAG pass; responsive behavior remains optimize
 - [ORB-00144] grouped scoreboard metrics and added knowledge counters.
 - [ORB-10444] retired a deprecated tab, folded Scoreboard under Diagnostics, pinned the Knowledge detail pane, and added task ship + comments.
 - [ORB-10874] clarified the Tasks count and filter state, made the log panel collapsible/resizable, and added pending/undo feedback and an aggregate-mode mutation guard to inline task edits.
+- [ORB-10875] added the Operations view and typed routine/clock controls.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10875](https://orbit-cli.com/tasks/ORB-10875) — Add routine and sweep-clock operations to the dashboard

### Description

## Problem
Orbit routines and the host sweep clock are operationally important but absent from the dashboard. Operators must leave the web surface to answer basic questions or make bounded changes: which routines are enabled, what their cadence and targets are, when they last fired, whether the host clock is healthy, and whether a routine or clock should be enabled or disabled.

## Why It Matters
Routines are the durable scheduling layer and the sweep clock is the host-local trigger. Hiding both makes automation state difficult to understand and encourages confusing the persisted routine toggle with the OS clock's enabled/running state.

## Constraints / Notes
- Present routine-definition state and host clock/service state as separate concepts.
- Mutations must use typed Orbit runtime/service operations with audit and authorization; never construct shell strings from browser input.
- Aggregate/all-workspace mode is read-only until a concrete workspace and host are selected.
- Clock behavior must remain portable across supported launchd/systemd hosts and be testable without changing real services.
- Related completed foundations: ORB-10021, ORB-10720, and ORB-10822.
- This is eventual work; leave proposed until explicitly promoted.

### Acceptance Criteria

- A dashboard Operations view lists routines for the selected workspace with name, enabled state, schedule/cadence, target, host pin when present, last evaluation/fire, last linked run/outcome, and next expected evaluation when derivable.
- The view separately reports the host sweep clock provider, configured cadence, enabled/loaded state, running/last-tick health, and next expected tick when the platform exposes it; routine enabled state is never conflated with clock state.
- An authorized operator can enable or disable a routine with an explicit target summary, pending state, exact success/failure feedback, duplicate-submission protection, and audit provenance.
- An authorized operator can perform the supported clock controls chosen by the implementation contract, with confirmation for service-state changes and a clear distinction between changing cadence and starting/stopping the clock.
- All-workspace and ambiguous-host views remain read-only and explain which concrete workspace/host selection is required before controls activate.
- The implementation is project-agnostic, uses typed arguments and existing runtime/service abstractions, and never executes browser-supplied shell text.
- Deterministic tests cover enabled/disabled routines, missed/healthy clock states, host pinning, authorization denial, duplicate clicks, launchd and systemd fakes, and no-op/rollback behavior.
- Rendered desktop and 480-720px validation confirms schedules, state labels, and controls remain scannable; focused tests and git diff --check pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: Implemented and validated the dashboard Operations surface for routines and the host sweep clock.

Changes:
- Added a selected-workspace Operations tab that lists routine definition state, schedule, target, host pin, evaluation/fire/run history, outcomes, and derivable next evaluation independently from host clock health.
- Added typed, operator-authorized routine toggle and clock service/cadence endpoints with explicit workspace, host, target, and expected-state guards; duplicate/no-op/conflict feedback; confirmations for service changes; and audit provenance for successes, denials, and failures.
- Extended routine status and systemd/launchd clock reporting so loaded/enabled/running/health/tick state remain distinct, while reusing the existing clock service abstractions and accepting no browser-supplied path, argv, or shell text.
- Added deterministic authorization, routine mutation, service-state, rollback/no-op, API, static-asset, and responsive UI tests, and updated the live routine and UI design docs.

Assessment:
- Acceptance criteria are satisfied. Aggregate/all-workspace, unauthorized, and unresolved-host states are read-only and explain the concrete selection required.
- Desktop and responsive Chromium renders at 1440, 720, 600, and 480 px showed no horizontal overflow; routine fields and controls fit, and the clock panel remains reachable and scannable.

Strategic decisions:
- Routine enablement edits only the authoritative routine YAML after reloading and validating its source/target plus the expected current state; the host clock remains an explicitly separate service concern.
- Clock service changes require confirmation, while cadence changes are separate operations and do not imply start/stop.
- Dashboard mutation arguments are closed typed enums and identifiers resolved server-side.

Context deviation:
- Added file:crates/orbit-web/src/lib.rs to context_files because the new operations.js module required embedded static-route registration. The module split keeps the existing dashboard app entry point focused and below the repository's file-size warning.

Validation:
- cargo test -p orbit-core routines::tests --no-fail-fast (46 passed)
- cargo test -p orbit-common authorization --no-fail-fast (12 passed)
- cargo test -p orbit-web api::tests::routines --no-fail-fast (9 passed)
- cargo test -p orbit-web tests::dashboard_assets --no-fail-fast (30 passed)
- node --check for app.js, operations.js, and router.js
- git diff --check
- make ci-fast
- make ci-lint

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10875-6a813a10`
- Behind base: 0
- Ahead of base: 1