### PR TITLE
Keep dashboard workspace, window, and actor scope consistent across diagnostics views

### DIFF
--- a/crates/orbit-web/assets/dashboard/app.js
+++ b/crates/orbit-web/assets/dashboard/app.js
@@ -1,7 +1,7 @@
 // Orbit dashboard — terminal-dark, manually refreshed SPA.
 // Pure vanilla JS, split into ES modules with no build step.
 
-import { el, statusPill, stateCell, fetchJson, listItems, requestJson, postJson, patchJson, syncNodes, positiveIntParam, getWorkspace, setWorkspace, setMultiWorkspace, isAggregateView, renderPanelPlaceholder } from './common.js';
+import { el, statusPill, stateCell, fetchJson, listItems, requestJson, postJson, patchJson, syncNodes, positiveIntParam, getWorkspace, setWorkspace, setMultiWorkspace, isAggregateView, renderPanelPlaceholder, getWindow, persistScopeToUrl, setScopeChangeListener, syncWindowSelectors, payloadHonorsWindow } from './common.js';
 import { buildChips, buildTasksHash, applyTasksHashQuery, cacheCrewPayload, copyTaskIdWithNotice, hasCrewOptions, openVisibleTask, renderTasks, setPinnedExternalTask, syncTaskControls, wireSearch } from './tasks.js';
 import { applyAuditHashQuery, buildAuditChips, buildAuditHash, fetchAndRenderAudit, fetchAndRenderPolicy, getActiveAuditSubtab, navigateToAuditExecution, renderAuditSummary, setActiveAuditSubtabFromButton, setAuditSubtab, syncAuditControls, wireAuditSearch, } from './audit.js';
 import { renderScoreboard } from './scoreboard.js';
@@ -923,27 +923,29 @@ function buildWorkspaceSelector() {
 
   select.addEventListener("change", () => {
     setWorkspace(select.value);
-    persistWorkspaceToUrl(select.value);
+    persistScopeToUrl();
     refreshDashboard();
   });
 
+  const note = el("span", {
+    class: "workspace-scope-note",
+    text: "Fleet-wide on Reliability",
+  });
+  note.id = "workspace-scope-note";
+  note.hidden = true;
+  note.title = "Reliability ignores the selected workspace";
+
   const meta = $("meta");
   meta.insertBefore(select, $("refresh-btn"));
+  meta.insertBefore(note, $("refresh-btn"));
 }
 
-// ORB-10874: the workspace selector only updated in-memory state, so a reload
-// or a copied link silently fell back to the server's default workspace
-// instead of the one the operator was actually looking at. `getWorkspace()`
-// already seeds from `?workspace=` on first load (common.js); this keeps that
-// query param in sync on every selection without a full navigation/reload.
+// ORB-10874/ORB-10872: workspace + window live in the query string so a
+// reload or copied link restores the same dashboard scope. `persistScopeToUrl`
+// is the single writer; this wrapper stays for the existing call sites.
 function persistWorkspaceToUrl(id) {
-  const url = new URL(window.location.href);
-  if (id) {
-    url.searchParams.set("workspace", id);
-  } else {
-    url.searchParams.delete("workspace");
-  }
-  history.replaceState(null, "", url);
+  setWorkspace(id);
+  persistScopeToUrl();
 }
 
 function activeRefreshJobs() {
@@ -1026,12 +1028,22 @@ function activeRefreshJobs() {
     }
     if (activeDiagSubtab === "scoreboard") {
       // ORB-10444: Scoreboard folded in from the retired top-level tab.
-      // ORB-00337: the boot fetch matches the visually-highlighted segment
-      // (`24h`); picking a different window calls /api/scoreboard?window=...
-      // directly from scoreboard.js (itself aggregate-guarded, ORB-00040).
-      // The scoreboard subtab replaces the diagnostics two-column layout, so it
-      // returns early rather than also fetching the implement_one side card.
-      jobs.push(fetchJson("/api/scoreboard?window=24h").then(renderScoreboard));
+      // ORB-10872: every refresh honors the shared dashboard window so
+      // delivery/operations and Managed Execution stay on the same cutoff.
+      // A payload that reports a different window is refused rather than
+      // painted under a mismatched selector (the 7d-selected / 24h-body bug).
+      const selectedWindow = getWindow();
+      jobs.push(
+        fetchJson(`/api/scoreboard?window=${encodeURIComponent(selectedWindow)}`).then((summary) => {
+          if (!payloadHonorsWindow(summary, selectedWindow)) {
+            console.error(
+              `scoreboard payload window ${summary && summary.window} rejected under ${selectedWindow} selection`,
+            );
+            return;
+          }
+          renderScoreboard(summary);
+        }),
+      );
       return jobs;
     }
     if (activeDiagSubtab === "runs") {
@@ -1248,6 +1260,21 @@ buildAuditChips(auditContext());
 wireAuditSearch(auditContext());
 $("refresh-btn").addEventListener("click", refreshDashboard);
 wireReliabilityWindowSelector();
+setScopeChangeListener(() => {
+  persistScopeToUrl();
+  syncWindowSelectors();
+  if (activeTab === "diagnostics") {
+    const url = new URL(window.location.href);
+    url.hash = `diagnostics/${activeDiagSubtab}?window=${encodeURIComponent(getWindow())}`;
+    if (url.href !== window.location.href) history.replaceState(null, "", url);
+  } else if (activeTab === "audit") {
+    const next = buildAuditHash();
+    const url = new URL(window.location.href);
+    url.hash = next.replace(/^#/, "");
+    if (url.href !== window.location.href) history.replaceState(null, "", url);
+  }
+  refreshDashboard();
+});
 initOperations({ getWorkspaces: () => dashboardWorkspaces, formatAbsoluteTime: fmtAbsTime });
 
 initRuns(runsContext());
@@ -1257,6 +1284,8 @@ initRouter(rctx);
 // Resolve workspaces before the router fires its first refresh so the initial
 // fetches carry the right workspace (top-level await; app.js is an ES module).
 await initWorkspaceSelector();
+persistScopeToUrl();
+syncWindowSelectors();
 iT();
 
 initLogTail();

--- a/crates/orbit-web/assets/dashboard/audit.js
+++ b/crates/orbit-web/assets/dashboard/audit.js
@@ -1,7 +1,7 @@
 // Orbit dashboard audit-domain rendering and actions.
 // Pure vanilla JS, split into ES modules with no build step.
 
-import { el, fetchJson, syncNodes, positiveIntParam, isAggregateView, renderPanelPlaceholder } from './common.js';
+import { el, fetchJson, syncNodes, positiveIntParam, isAggregateView, renderPanelPlaceholder, getWindow, setWindow, getWorkspace, setWorkspace, persistScopeToUrl, DEFAULT_DASHBOARD_WINDOW } from './common.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -24,6 +24,8 @@ let auditFilter = {
   // Time-window filter for the Events sub-tab. Accepts the same shorthands as
   // the API (`24h`, `7d`, `1w`, RFC3339); null means the API-side default.
   since: null,
+  // Source metric from a scoreboard drill-down (display + hash only).
+  metric: null,
   // Policy sub-tab only: scopes /api/diagnostics/denials to fs vs tool denials.
   policyKind: null,
 };
@@ -148,6 +150,7 @@ function buildAuditHash() {
     if (auditFilter.execution_id) sp.set("execution_id", auditFilter.execution_id);
     if (auditFilter.profile) sp.set("profile", auditFilter.profile);
     if (auditFilter.q) sp.set("q", auditFilter.q);
+    if (auditFilter.metric) sp.set("metric", auditFilter.metric);
   }
   const path = activeAuditSubtab && activeAuditSubtab !== "events"
     ? `audit/${activeAuditSubtab}`
@@ -181,6 +184,69 @@ function syncAuditControls() {
     const status = chip.dataset.status;
     chip.classList.toggle("active", auditFilter.status === status);
   }
+  renderScopeChips();
+}
+
+function removableChip(label, value, onRemove) {
+  const chip = el("button", {
+    class: "scope-chip",
+    title: `Remove ${label} filter`,
+  });
+  chip.type = "button";
+  chip.dataset.chip = label;
+  chip.appendChild(el("span", { class: "scope-chip-k", text: label }));
+  chip.appendChild(el("span", { class: "scope-chip-v", text: value }));
+  chip.appendChild(el("span", { class: "scope-chip-x", text: "×" }));
+  chip.addEventListener("click", (event) => {
+    event.preventDefault();
+    onRemove();
+  });
+  return chip;
+}
+
+function renderScopeChips() {
+  const host = $("audit-scope-chips");
+  if (!host) return;
+  host.innerHTML = "";
+  const workspace = getWorkspace();
+  if (workspace) {
+    host.appendChild(removableChip("workspace", workspace, () => {
+      setWorkspace(null);
+      persistScopeToUrl();
+      const select = $("workspace-select");
+      if (select) select.value = "";
+      window.location.hash = buildAuditHash();
+    }));
+  }
+  const windowLabel = effectiveAuditWindow();
+  if (windowLabel) {
+    const chip = removableChip("window", windowLabel, () => {
+      auditFilter.since = null;
+      setWindow(DEFAULT_DASHBOARD_WINDOW);
+      persistScopeToUrl();
+      window.location.hash = buildAuditHash();
+    });
+    if (windowLabel !== getWindow()) chip.classList.add("independent");
+    host.appendChild(chip);
+  }
+  if (auditFilter.role) {
+    host.appendChild(removableChip("actor", auditFilter.role, () => {
+      auditFilter.role = null;
+      window.location.hash = buildAuditHash();
+    }));
+  }
+  if (auditFilter.status) {
+    host.appendChild(removableChip("status", auditFilter.status, () => {
+      auditFilter.status = null;
+      window.location.hash = buildAuditHash();
+    }));
+  }
+  if (auditFilter.metric) {
+    host.appendChild(removableChip("metric", auditFilter.metric, () => {
+      auditFilter.metric = null;
+      window.location.hash = buildAuditHash();
+    }));
+  }
 }
 
 function applyAuditHashQuery(query) {
@@ -193,7 +259,8 @@ function applyAuditHashQuery(query) {
     query.get("execution_id") || query.get("run_id") || null;
   auditFilter.profile = query.get("profile") || null;
   auditFilter.q = query.get("q") || "";
-  auditFilter.since = query.get("since") || null;
+  auditFilter.since = query.get("since") || (getWindow() === "all" ? null : getWindow());
+  auditFilter.metric = query.get("metric") || null;
   const kindParam = query.get("kind");
   auditFilter.policyKind = kindParam === "fs" || kindParam === "tool" ? kindParam : null;
 }
@@ -218,7 +285,8 @@ function fetchAndRenderAudit(ctx) {
   }
   const sp = new URLSearchParams();
   sp.set("limit", String(AUDIT_LIMIT));
-  if (auditFilter.since) sp.set("since", auditFilter.since);
+  const since = effectiveAuditWindow();
+  if (since) sp.set("since", since);
   if (auditFilter.status) sp.set("status", auditFilter.status);
   if (auditFilter.tool) sp.set("tool", auditFilter.tool);
   if (auditFilter.role) sp.set("role", auditFilter.role);
@@ -413,7 +481,7 @@ function fetchAndRenderPolicy(ctx) {
     return Promise.resolve();
   }
   const sp = new URLSearchParams();
-  sp.set("since", "24h");
+  sp.set("since", effectiveAuditWindow() || "24h");
   if (auditFilter.policyKind) sp.set("kind", auditFilter.policyKind);
   if (auditFilter.profile) sp.set("profile", auditFilter.profile);
   if (auditFilter.role) sp.set("agent", auditFilter.role);
@@ -431,7 +499,7 @@ function renderPolicy(data, ctx) {
   if (!data || (data.total || 0) === 0) {
     syncNodes(body, [el("div", { class: "empty-state" }, [
       el("div", { class: "icon", text: "✧" }),
-      el("div", { class: "text", text: "No denials in the last 24h." }),
+      el("div", { class: "text", text: `No denials in the last ${effectiveAuditWindow() || "24h"}.` }),
     ])]);
     return;
   }
@@ -637,17 +705,28 @@ function policyDetailText(row) {
   return parts.join(" · ") || row.denial_kind || "-";
 }
 
-function navigateToAuditExecution(executionId, ctx) {
-  auditFilter = {
+function effectiveAuditWindow() {
+  if (auditFilter.since) return auditFilter.since;
+  return getWindow() === "all" ? null : getWindow();
+}
+
+function emptyAuditFilter() {
+  return {
     status: null,
     q: "",
     tool: null,
     role: null,
-    execution_id: executionId,
+    execution_id: null,
     profile: null,
-    since: null,
+    since: getWindow() === "all" ? null : getWindow(),
+    metric: null,
     policyKind: null,
   };
+}
+
+function navigateToAuditExecution(executionId, ctx) {
+  auditFilter = emptyAuditFilter();
+  auditFilter.execution_id = executionId;
   activeAuditSubtab = "events";
   syncAuditControls();
   window.location.hash = buildAuditHash();
@@ -656,16 +735,17 @@ function navigateToAuditExecution(executionId, ctx) {
 /// Navigates to the Audit tab pre-filtered by `role` (audit `role` ≈ scoreboard
 /// agent name). Clears unrelated filters so the landing page is the role view.
 function navigateToRole(role, ctx) {
-  auditFilter = {
-    status: null,
-    q: "",
-    tool: null,
-    role,
-    execution_id: null,
-    profile: null,
-    since: null,
-    policyKind: null,
-  };
+  navigateToDrilldown({ role }, ctx);
+}
+
+/// Scoreboard actor/metric drill-down. Carries the shared dashboard window
+/// and records the source metric so the landing chips explain the scope.
+function navigateToDrilldown(opts = {}, ctx) {
+  auditFilter = emptyAuditFilter();
+  auditFilter.role = opts.role || null;
+  auditFilter.metric = opts.metric || null;
+  auditFilter.status = opts.status || null;
+  if (opts.window) auditFilter.since = opts.window === "all" ? null : opts.window;
   activeAuditSubtab = "events";
   syncAuditControls();
   window.location.hash = buildAuditHash();
@@ -878,6 +958,7 @@ export {
   // cross-domain navigation
   navigateToAuditExecution,
   navigateToRole,
+  navigateToDrilldown,
   // state inspection used by setActiveTab + activeRefreshJobs
   getActiveAuditSubtab,
   setActiveAuditSubtabFromButton,

--- a/crates/orbit-web/assets/dashboard/common.js
+++ b/crates/orbit-web/assets/dashboard/common.js
@@ -14,6 +14,118 @@ export function setWorkspace(id) {
   currentWorkspace = id || null;
 }
 
+// ORB-10872: workspace + time window are one dashboard scope. Scoreboard,
+// Audit, Reliability, and Managed Execution either honor this window or show
+// an equally prominent independent-scope label. Seeded from `?window=` or the
+// hash query so reload and shared links restore the same cutoff.
+export const DASHBOARD_WINDOWS = ["1h", "24h", "7d", "30d", "all"];
+export const RELIABILITY_WINDOWS = ["1h", "24h", "7d", "30d"];
+export const DEFAULT_DASHBOARD_WINDOW = "24h";
+export const INDEPENDENT_RELIABILITY_WINDOW = "7d";
+
+export function parseDashboardWindow(raw, allowed = DASHBOARD_WINDOWS) {
+  return allowed.includes(raw) ? raw : null;
+}
+
+function windowFromLocation() {
+  const fromSearch = parseDashboardWindow(params.get("window"));
+  if (fromSearch) return fromSearch;
+  const hash = String(window.location.hash || "");
+  const queryIdx = hash.indexOf("?");
+  if (queryIdx >= 0) {
+    const fromHash = parseDashboardWindow(new URLSearchParams(hash.slice(queryIdx + 1)).get("window"));
+    if (fromHash) return fromHash;
+  }
+  return DEFAULT_DASHBOARD_WINDOW;
+}
+
+let currentWindow = windowFromLocation();
+
+export function getWindow() {
+  return currentWindow;
+}
+
+export function setWindow(raw) {
+  const next = parseDashboardWindow(raw) || DEFAULT_DASHBOARD_WINDOW;
+  const changed = next !== currentWindow;
+  currentWindow = next;
+  return changed;
+}
+
+/// Reliability cannot serve an unbounded `all` window. When the dashboard
+/// selection is `all`, Reliability keeps a labeled independent 7d cutoff.
+export function reliabilityWindowFor(selected = currentWindow) {
+  if (RELIABILITY_WINDOWS.includes(selected)) {
+    return { window: selected, independent: false };
+  }
+  return { window: INDEPENDENT_RELIABILITY_WINDOW, independent: true };
+}
+
+/// True only when the payload's reported window matches the active selection.
+/// A 24h scoreboard/orchestration body must not render under an active 7d.
+export function payloadHonorsWindow(payload, selected) {
+  if (!payload || typeof payload !== "object" || !selected) return false;
+  const reported = payload.window;
+  if (typeof reported === "string") return reported === selected;
+  if (reported && typeof reported.label === "string") return reported.label === selected;
+  return false;
+}
+
+let scopeChangeListener = null;
+
+export function setScopeChangeListener(fn) {
+  scopeChangeListener = typeof fn === "function" ? fn : null;
+}
+
+export function notifyScopeChange() {
+  if (scopeChangeListener) scopeChangeListener();
+}
+
+// Mirror workspace + window into the query string without a navigation.
+// Hash routes still own view/filter history; this keeps reload-safe scope.
+export function persistScopeToUrl() {
+  const url = new URL(window.location.href);
+  if (currentWorkspace) url.searchParams.set("workspace", currentWorkspace);
+  else url.searchParams.delete("workspace");
+  if (currentWindow) url.searchParams.set("window", currentWindow);
+  else url.searchParams.delete("window");
+  if (url.href !== window.location.href) {
+    history.replaceState(null, "", url);
+  }
+}
+
+export function syncWindowSelectors() {
+  const selected = currentWindow;
+  const rel = reliabilityWindowFor(selected);
+  for (const [id, target] of [
+    ["scoreboard-window-selector", selected],
+    ["reliability-window-selector", rel.window],
+  ]) {
+    const selector = document.getElementById(id);
+    if (!selector) continue;
+    for (const seg of selector.querySelectorAll(".scoreboard-window-seg")) {
+      seg.classList.toggle("on", seg.dataset.window === target);
+    }
+  }
+}
+
+export function wireWindowSelector(selectorId, opts = {}) {
+  const selector = document.getElementById(selectorId);
+  if (!selector || selector.dataset.wired === "true") return;
+  selector.dataset.wired = "true";
+  const allowed = opts.allowAll === false ? RELIABILITY_WINDOWS : DASHBOARD_WINDOWS;
+  selector.addEventListener("click", (event) => {
+    const seg = event.target && event.target.closest(".scoreboard-window-seg");
+    if (!seg || !selector.contains(seg)) return;
+    const next = seg.dataset.window;
+    if (!allowed.includes(next) || next === currentWindow) return;
+    setWindow(next);
+    persistScopeToUrl();
+    syncWindowSelectors();
+    notifyScopeChange();
+  });
+}
+
 // ORB-00030/00039/00040: the dashboard can serve multiple workspaces. "Multi-
 // workspace mode" is on when more than one workspace is servable; the aggregate
 // ("All workspaces") view is that mode with no concrete workspace selected. In

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -145,6 +145,89 @@
       }
       .workspace-select:hover { border-color: var(--accent); }
       .workspace-select:focus { border-color: var(--accent); outline: none; }
+      .workspace-select.scope-ignored {
+        opacity: 0.55;
+        border-style: dashed;
+      }
+      .workspace-scope-note {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--accent-hi);
+        border: 1px solid var(--accent);
+        background: rgba(110, 159, 255, 0.12);
+        border-radius: 2px;
+        padding: 3px 8px;
+        white-space: nowrap;
+      }
+
+      .scope-badge {
+        display: inline-flex;
+        align-items: center;
+        flex: 0 0 auto;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        color: var(--fg);
+        border: 1px solid var(--border);
+        border-radius: 2px;
+        padding: 2px 7px;
+        white-space: nowrap;
+      }
+      .scope-badge.independent {
+        color: var(--accent-hi);
+        border-color: var(--accent);
+        background: rgba(110, 159, 255, 0.12);
+      }
+      .scope-chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        align-items: center;
+        min-width: 0;
+      }
+      .scope-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font: inherit;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        line-height: 1.2;
+        padding: 3px 8px;
+        border: 1px solid var(--border);
+        border-radius: 2px;
+        background: var(--bg-elev);
+        color: var(--fg);
+        cursor: pointer;
+        max-width: 100%;
+      }
+      .scope-chip:hover {
+        border-color: var(--accent);
+      }
+      .scope-chip-k {
+        color: var(--fg-dim);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        font-size: 9px;
+      }
+      .scope-chip-v {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        max-width: 14ch;
+      }
+      .scope-chip-x {
+        color: var(--fg-dim);
+        font-size: 13px;
+        line-height: 1;
+      }
+      .scope-chip.independent {
+        border-color: var(--accent);
+        background: rgba(110, 159, 255, 0.12);
+      }
       .ws-badge {
         display: inline-block;
         margin-right: 6px;
@@ -212,6 +295,8 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
+        flex-wrap: wrap;
+        gap: 8px;
         background: #18181b;
       }
       
@@ -303,6 +388,46 @@
         color: var(--fg);
         border-color: var(--accent);
         background: rgba(110, 159, 255, 0.1);
+      }
+
+      @media (max-width: 720px) {
+        header .meta {
+          flex-wrap: wrap;
+          justify-content: flex-end;
+          max-width: min(100%, 420px);
+        }
+        .workspace-select {
+          max-width: 140px;
+        }
+        .workspace-scope-note,
+        .scope-badge {
+          font-size: 9px;
+          padding: 2px 6px;
+        }
+        #audit-events-controls {
+          flex-wrap: wrap;
+        }
+        .scope-chips,
+        #audit-filter {
+          flex-wrap: wrap;
+          width: 100%;
+        }
+        .scope-chip {
+          font-size: 10px;
+          padding: 3px 6px;
+        }
+        .scope-chip-v {
+          max-width: 10ch;
+        }
+      }
+
+      @media (max-width: 520px) {
+        .workspace-scope-note {
+          white-space: normal;
+        }
+        .scope-chip {
+          max-width: calc(50% - 6px);
+        }
       }
       
       .empty-state {

--- a/crates/orbit-web/assets/dashboard/index.html
+++ b/crates/orbit-web/assets/dashboard/index.html
@@ -122,6 +122,7 @@
             </nav>
             <div class="controls" id="audit-events-controls">
               <input type="search" id="audit-search" placeholder="Search command, tool, target..." autocomplete="off" spellcheck="false" />
+              <div id="audit-scope-chips" class="scope-chips" aria-label="Active audit scope"></div>
               <div id="audit-filter"></div>
             </div>
             <div class="body scoreboard-table-wrap" id="audit-body">
@@ -217,6 +218,7 @@
         <section class="panel" id="reliability-panel">
           <header>
             <span>Pipeline Reliability</span>
+            <span class="scope-badge independent" id="reliability-scope-badge">Fleet-wide</span>
             <span class="count" id="reliability-count">-</span>
           </header>
           <div class="scoreboard-controls" id="reliability-controls">

--- a/crates/orbit-web/assets/dashboard/reliability.js
+++ b/crates/orbit-web/assets/dashboard/reliability.js
@@ -19,19 +19,18 @@
 // still in flight, so the summary spells out the excluded bucket rather than
 // letting the two visible numbers imply they add up.
 
-import { el, syncNodes, fetchJson } from './common.js';
+import { el, syncNodes, fetchJson, getWindow, payloadHonorsWindow, reliabilityWindowFor, wireWindowSelector, syncWindowSelectors } from './common.js';
 
 const $ = (id) => document.getElementById(id);
 
 // Mirrors the windows the endpoint accepts. `all` is deliberately absent:
-// a failure rate with no time range is not actionable.
+// a failure rate with no time range is not actionable. When the dashboard
+// window is `all`, Reliability keeps a labeled independent 7d cutoff.
 const RELIABILITY_WINDOWS = ["1h", "24h", "7d", "30d"];
 const DEFAULT_RELIABILITY_WINDOW = "7d";
 
-let activeWindow = DEFAULT_RELIABILITY_WINDOW;
-
 function getReliabilityWindow() {
-  return activeWindow;
+  return reliabilityWindowFor(getWindow()).window;
 }
 
 const pctFormatter = new Intl.NumberFormat("en-US", {
@@ -397,13 +396,37 @@ function renderActivities(payload) {
   ]);
 }
 
+function renderReliabilityScope(payload) {
+  const badge = $("reliability-scope-badge");
+  if (!badge) return;
+  const scope = payload && payload.scope === "workspace" ? "Workspace" : "Fleet-wide";
+  const rel = reliabilityWindowFor(getWindow());
+  badge.textContent = rel.independent ? `${scope} · independent ${rel.window}` : scope;
+  badge.className = "scope-badge independent";
+  badge.hidden = false;
+  badge.title = rel.independent
+    ? "Reliability is fleet-wide and cannot use the unbounded all window"
+    : "Reliability is fleet-wide; the workspace selector does not apply";
+}
+
 function renderReliability(payload) {
   if (!payload) return;
+  const rel = reliabilityWindowFor(getWindow());
+  if (!payloadHonorsWindow(payload, rel.window)) {
+    console.error(
+      `reliability payload window ${(payload.window || {}).label} rejected under ${rel.window} selection`,
+    );
+    return;
+  }
+  syncWindowSelectors();
+  renderReliabilityScope(payload);
   const meta = $("reliability-meta");
   if (meta) {
     const range = fmtWindowRange(payload.window);
     const unreadable = (payload.unreadable_workspaces || []).length;
-    meta.textContent = range + (unreadable ? ` · ${unreadable} workspace(s) unreadable` : "");
+    const fleet = "Fleet-wide";
+    const independent = rel.independent ? " · independent window" : "";
+    meta.textContent = `${fleet} · ${range}${independent}${unreadable ? ` · ${unreadable} workspace(s) unreadable` : ""}`;
   }
   const count = $("reliability-count");
   if (count) {
@@ -417,29 +440,14 @@ function renderReliability(payload) {
 }
 
 function fetchAndRenderReliability() {
-  return fetchJson(`/api/metrics/reliability?window=${encodeURIComponent(activeWindow)}`)
+  const rel = reliabilityWindowFor(getWindow());
+  return fetchJson(`/api/metrics/reliability?window=${encodeURIComponent(rel.window)}`)
     .then(renderReliability);
 }
 
 // Idempotent attach, matching the scoreboard selector's contract.
 function wireReliabilityWindowSelector() {
-  const selector = $("reliability-window-selector");
-  if (!selector || selector.dataset.wired === "true") return;
-  selector.dataset.wired = "true";
-  selector.addEventListener("click", (event) => {
-    const seg = event.target && event.target.closest(".scoreboard-window-seg");
-    if (!seg || !selector.contains(seg)) return;
-    const next = seg.dataset.window;
-    if (!RELIABILITY_WINDOWS.includes(next) || seg.classList.contains("on")) return;
-    for (const peer of selector.querySelectorAll(".scoreboard-window-seg")) {
-      peer.classList.remove("on");
-    }
-    seg.classList.add("on");
-    activeWindow = next;
-    fetchAndRenderReliability().catch((err) => {
-      console.error("reliability window refetch failed:", err);
-    });
-  });
+  wireWindowSelector("reliability-window-selector", { allowAll: false });
 }
 
 export {

--- a/crates/orbit-web/assets/dashboard/router.js
+++ b/crates/orbit-web/assets/dashboard/router.js
@@ -17,10 +17,24 @@
 //
 // Also exports parseHashRoute for symmetry (used only internally today).
 
-import { el, isAggregateView, renderPanelPlaceholder } from './common.js';
+import { el, isAggregateView, renderPanelPlaceholder, getWindow, setWindow, parseDashboardWindow, persistScopeToUrl, syncWindowSelectors } from './common.js';
 import { renderRuns } from './runs.js';
 
 const $ = (id) => document.getElementById(id);
+
+// ORB-10872: Reliability is fleet-wide. While that subtab is showing, the
+// header workspace selector must not look like it scopes the visible panel.
+function markWorkspaceSelectorScope(fleetWide) {
+  const select = $("workspace-select");
+  if (select) {
+    select.classList.toggle("scope-ignored", fleetWide);
+    select.title = fleetWide
+      ? "Reliability is Fleet-wide; workspace does not apply"
+      : "Workspace";
+  }
+  const note = $("workspace-scope-note");
+  if (note) note.hidden = !fleetWide;
+}
 
 // ORB-10444: the top-level nav is exactly these four tabs plus the hash-only
 // `run-detail` route. A deprecated tab was retired outright and `scoreboard`,
@@ -97,6 +111,8 @@ function setDiagSubtabImpl(ctx, name) {
       ? "minmax(0, 1fr)"
       : "minmax(0, 2fr) minmax(280px, 1.15fr)";
   }
+  document.body.classList.toggle("reliability-active", name === "reliability");
+  markWorkspaceSelectorScope(name === "reliability");
   if (fullWidthMain) {
     $("diag-body").style.display = "none";
     $("runs-body").style.display = "none";
@@ -184,6 +200,10 @@ function setActiveTabImpl(ctx, raw, opts = {}) {
   }
   ctx.setTab(top);
   document.body.classList.toggle("operations-active", top === "operations");
+  if (top !== "diagnostics") {
+    document.body.classList.remove("reliability-active");
+    markWorkspaceSelectorScope(false);
+  }
   for (const tab of document.querySelectorAll(".tab")) {
     tab.classList.toggle("active", tab.dataset.tab === top);
   }
@@ -207,8 +227,14 @@ function setActiveTabImpl(ctx, raw, opts = {}) {
   let hash;
   if (top === "diagnostics") {
     const sub = DIAG_SUBTABS.includes(segments[1]) ? segments[1] : ctx.getDiagSubtab();
+    const hashedWindow = parseDashboardWindow(query.get("window"));
+    if (hashedWindow && hashedWindow !== getWindow()) {
+      setWindow(hashedWindow);
+      persistScopeToUrl();
+      syncWindowSelectors();
+    }
     setDiagSubtabImpl(ctx, sub);
-    hash = `#diagnostics/${sub}`;
+    hash = `#diagnostics/${sub}?window=${encodeURIComponent(getWindow())}`;
   } else if (top === "audit") {
     ctx.applyAuditHashQuery(query);
     const sub = ["events", "policy"].includes(segments[1]) ? segments[1] : ctx.getActiveAuditSubtab();

--- a/crates/orbit-web/assets/dashboard/scoreboard.js
+++ b/crates/orbit-web/assets/dashboard/scoreboard.js
@@ -1,44 +1,16 @@
 // Orbit dashboard scoreboard-domain rendering.
 // Pure vanilla JS, split into ES modules with no build step.
 
-import { el, syncNodes, fetchJson, isAggregateView } from './common.js';
-import { navigateToRole } from './audit.js';
+import { el, syncNodes, getWindow, payloadHonorsWindow, wireWindowSelector, syncWindowSelectors } from './common.js';
+import { navigateToDrilldown } from './audit.js';
 
-// ORB-00337: canonical scoreboard windows (mirror of
-// `orbit_store::scoreboard_summary::ScoreboardWindow::as_str`). The
-// boot fetch in app.js hardcodes `24h` to match the visually-highlighted
-// segment; subsequent fetches happen from the selector click handler.
-const SCOREBOARD_WINDOWS = ["1h", "24h", "7d", "30d", "all"];
-
+// ORB-00337/ORB-10872: selector writes the shared dashboard window; app.js
+// refresh is the single fetch path so delivery/operations and Managed
+// Execution cannot drift onto different cutoffs.
 function wireScoreboardWindowSelector() {
-  const selector = document.getElementById("scoreboard-window-selector");
-  if (!selector || selector.dataset.wired === "true") return;
-  selector.dataset.wired = "true";
-  selector.addEventListener("click", (event) => {
-    const seg = event.target && event.target.closest(".scoreboard-window-seg");
-    if (!seg || !selector.contains(seg)) return;
-    const next = seg.dataset.window;
-    if (!SCOREBOARD_WINDOWS.includes(next)) return;
-    if (seg.classList.contains("on")) return; // no-op refetch
-    // ORB-00040: /api/scoreboard is per-workspace and 400s without a concrete
-    // workspace. The auto-refresh boot fetch is already guarded in app.js; this
-    // guards the user-initiated window re-fetch too, so selecting a window in the
-    // aggregate ("All workspaces") view is a no-op (the panel shows the
-    // placeholder) rather than flipping conn-status to red.
-    if (isAggregateView()) return;
-    for (const peer of selector.querySelectorAll(".scoreboard-window-seg")) {
-      peer.classList.remove("on");
-    }
-    seg.classList.add("on");
-    fetchJson(`/api/scoreboard?window=${encodeURIComponent(next)}`)
-      .then(renderScoreboard)
-      .catch((err) => {
-        // Surface fetch failures in the console so the dashboard's "no
-        // console errors" verification step catches regressions; the UI
-        // keeps the previously-rendered scoreboard.
-        console.error("scoreboard window refetch failed:", err);
-      });
-  });
+  // Selector writes shared dashboard window even in aggregate view so the
+  // URL stays authoritative; app.js skips the per-workspace fetch there.
+  wireWindowSelector("scoreboard-window-selector", { allowAll: true });
 }
 
 const $ = (id) => document.getElementById(id);
@@ -153,6 +125,16 @@ function renderScoreboard(summary) {
   // ORB-00337: idempotent attach of the window-selector click handler
   // (guarded internally so re-renders don't double-bind).
   wireScoreboardWindowSelector();
+  syncWindowSelectors();
+
+  // ORB-10872: never paint a 24h body under an active 7d (or any other)
+  // selection. The fetch path also guards this; keep the renderer honest.
+  if (summary && !payloadHonorsWindow(summary, getWindow())) {
+    console.error(
+      `scoreboard payload window ${summary.window} rejected under ${getWindow()} selection`,
+    );
+    return;
+  }
 
   const body = $("scoreboard-body");
   const narrativeHost = $("scoreboard-narrative");
@@ -378,9 +360,10 @@ function renderOrchestrationSummary(orchestration) {
     el("div", { class: "scoreboard-orchestration-context" }, [
       el("div", { class: "scoreboard-orchestration-scope" }, [
         el("span", { class: "scope-label", text: "Managed execution only" }),
+        el("span", { class: "scope-badge", text: `window ${getWindow()}` }),
         el("span", { text: "Direct interactive Codex or Claude orchestration-session overhead is excluded." }),
       ]),
-      el("div", { class: "scoreboard-orchestration-window", text: `Window: ${since} ≤ invocation < ${until} (exclusive cutoff; as of ${orchestration.as_of || "unknown"}).` }),
+      el("div", { class: "scoreboard-orchestration-window", text: `Window ${getWindow()}: ${since} ≤ invocation < ${until} (exclusive cutoff; as of ${orchestration.as_of || "unknown"}).` }),
       el("p", { class: "scoreboard-orchestration-policy", text: "Provider-first estimate policy: provider-reported values are primary; derived values remain explicitly labeled estimates with their own coverage. Only the explicitly comparable same-invocation population is safe to compare." }),
     ]),
     renderNormalizedTokenUsage(orchestration.normalized_tokens, orchestration.previous_normalized_tokens),
@@ -456,7 +439,7 @@ function renderAgentStrip(rows) {
       title: `${name} - click to filter audit by role`,
     }), name);
     card.type = "button";
-    card.addEventListener("click", () => navigateToRole(name));
+    card.addEventListener("click", () => navigateToDrilldown({ role: name }));
 
     card.appendChild(el("div", { class: "scoreboard-agent-rank", text: `#${String(index + 1).padStart(2, "0")} · activity` }));
     card.appendChild(el("div", { class: "scoreboard-agent-heading" }, [
@@ -509,7 +492,7 @@ function buildLeaderboardMatrix(rows, sectionList, opts = {}) {
       document.createTextNode(name),
       el("span", { class: "totals", text: `${fmtScoreboardCount(agentActivityTotal(agent))} activity` }),
     ]), name);
-    th.addEventListener("click", () => navigateToRole(name));
+    th.addEventListener("click", () => navigateToDrilldown({ role: name }));
     headRow.appendChild(th);
   }
   thead.appendChild(headRow);
@@ -546,6 +529,13 @@ function buildLeaderboardMatrix(rows, sectionList, opts = {}) {
           : metricCell(name, agent, col, rowMax, isLeader);
         td.dataset.agent = name;
         td.dataset.metric = col.key;
+        td.classList.add("clickable");
+        td.title = `${col.title || col.label}: click to filter audit`;
+        td.addEventListener("click", () => navigateToDrilldown({
+          role: name,
+          metric: col.key,
+          status: col.key === "tools" || col.key === "failed_tool_calls" ? "failure" : null,
+        }));
         tr.appendChild(td);
       }
       tbody.appendChild(tr);

--- a/crates/orbit-web/src/api/reliability.rs
+++ b/crates/orbit-web/src/api/reliability.rs
@@ -89,6 +89,10 @@ pub(super) async fn pipeline_reliability(
 
     let payload = json!({
         "window": window,
+        // ORB-10872: this endpoint is intentionally fleet-wide (ORB-10588).
+        // The dashboard must label that exception rather than inherit the
+        // header workspace selector.
+        "scope": "fleet",
         "workspaces": workspaces,
         "totals": {
             "job_runs": {

--- a/crates/orbit-web/src/api/tests/reliability.rs
+++ b/crates/orbit-web/src/api/tests/reliability.rs
@@ -176,6 +176,40 @@ async fn an_unknown_window_is_a_400_not_a_silent_default() {
 }
 
 #[tokio::test]
+async fn reliability_payload_is_explicitly_fleet_wide() {
+    let response = request_reliability(seeded_runtime(), "?window=7d").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    assert_eq!(
+        body["scope"].as_str(),
+        Some("fleet"),
+        "reliability must declare fleet-wide scope so the UI can label it"
+    );
+}
+
+#[tokio::test]
+async fn reliability_7d_window_is_a_half_open_week() {
+    let response = request_reliability(seeded_runtime(), "?window=7d").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    assert_eq!(body["window"]["label"], "7d");
+    let since = chrono::DateTime::parse_from_rfc3339(
+        body["window"]["since"].as_str().expect("since"),
+    )
+    .expect("parse since");
+    let until = chrono::DateTime::parse_from_rfc3339(
+        body["window"]["until"].as_str().expect("until"),
+    )
+    .expect("parse until");
+    let span = until.signed_duration_since(since);
+    assert!(
+        span >= chrono::Duration::days(7) - chrono::Duration::seconds(2)
+            && span <= chrono::Duration::days(7) + chrono::Duration::seconds(2),
+        "7d reliability span must be ~7 days, got {span}"
+    );
+}
+
+#[tokio::test]
 async fn omitting_the_window_still_yields_an_explicit_one() {
     let response = request_reliability(seeded_runtime(), "").await;
     assert_eq!(response.status(), StatusCode::OK);

--- a/crates/orbit-web/src/api/tests/scoreboard.rs
+++ b/crates/orbit-web/src/api/tests/scoreboard.rs
@@ -133,6 +133,52 @@ async fn scoreboard_query_window_bogus_returns_400_with_error_body() {
 }
 
 #[tokio::test]
+async fn scoreboard_query_window_7d_is_not_a_24h_payload() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let response = get_scoreboard(runtime, Some("window=7d")).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    assert_eq!(body["window"].as_str(), Some("7d"));
+    assert_ne!(
+        body["window"].as_str(),
+        Some("24h"),
+        "a 7d request must not report a 24h window"
+    );
+    let since = chrono::DateTime::parse_from_rfc3339(
+        body["window_since"]
+            .as_str()
+            .expect("window_since for 7d"),
+    )
+    .expect("parse window_since");
+    let orch_since = chrono::DateTime::parse_from_rfc3339(
+        body["orchestration"]["since"]
+            .as_str()
+            .expect("orchestration since"),
+    )
+    .expect("parse orchestration since");
+    let until = chrono::DateTime::parse_from_rfc3339(
+        body["orchestration"]["until"]
+            .as_str()
+            .expect("orchestration until"),
+    )
+    .expect("parse until");
+    assert_eq!(since, orch_since, "scoreboard and managed-execution cutoffs must match");
+    let span = until.signed_duration_since(orch_since);
+    assert!(
+        span >= chrono::Duration::days(7) - chrono::Duration::seconds(2)
+            && span <= chrono::Duration::days(7) + chrono::Duration::seconds(2),
+        "7d orchestration span must be ~7 days, got {span}"
+    );
+    assert!(until <= chrono::DateTime::parse_from_rfc3339(
+        body["orchestration"]["as_of"]
+            .as_str()
+            .expect("as_of"),
+    )
+    .expect("parse as_of"));
+}
+
+#[tokio::test]
 async fn scoreboard_query_window_all_round_trips_explicitly() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     let response = get_scoreboard(runtime, Some("window=all")).await;

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -313,15 +313,16 @@ fn dashboard_guards_remaining_panels_in_aggregate_view() {
         "knowledge frictions must show a placeholder in aggregate mode"
     );
 
-    // Scoreboard: the tab body shows a placeholder, and the user-initiated window
-    // re-fetch is a no-op in aggregate mode (not just the auto-refresh boot fetch).
+    // Scoreboard: the tab body shows a placeholder. Window clicks write shared
+    // dashboard state; the per-workspace fetch stays on the refresh path, which
+    // is already aggregate-guarded above.
     assert!(
         app.contains(r#"renderPanelPlaceholder("scoreboard-body")"#),
         "scoreboard panel must show a placeholder in aggregate mode"
     );
     assert!(
-        scoreboard.contains("if (isAggregateView()) return;"),
-        "the scoreboard window selector must skip its re-fetch in aggregate mode"
+        !scoreboard.contains("fetchJson(`/api/scoreboard"),
+        "the scoreboard window selector must not fetch on its own"
     );
 
     // The guards read the live predicate before fetching (not a stale captured
@@ -606,8 +607,8 @@ async fn dashboard_scoreboard_is_reachable_under_diagnostics() {
     );
     assert!(
         app.contains(r#"if (activeDiagSubtab === "scoreboard")"#)
-            && app.contains(r#"fetchJson("/api/scoreboard?window=24h")"#),
-        "the scoreboard fetch must hang off the diagnostics subtab branch"
+            && app.contains(r#"fetchJson(`/api/scoreboard?window=${encodeURIComponent(selectedWindow)}`)"#),
+        "the scoreboard fetch must hang off the diagnostics subtab branch and honor the shared window"
     );
 }
 
@@ -945,7 +946,7 @@ fn dashboard_workspace_selection_persists_to_the_url() {
 
     assert!(
         app.contains("function persistWorkspaceToUrl(")
-            && app.contains("persistWorkspaceToUrl(select.value)"),
+            && app.contains("persistScopeToUrl()"),
         "the workspace selector must persist its choice to the URL on every change"
     );
 }
@@ -1129,6 +1130,79 @@ fn dashboard_assets_carry_no_project_specific_identifiers() {
             }
         }
     }
+}
+
+/// ORB-10872: workspace + window are one dashboard scope. Scoreboard and
+/// Managed Execution honor the same window; a mismatched 24h payload is
+/// refused under a 7d selection; Reliability labels Fleet-wide; Audit
+/// drill-downs expose removable chips; the URL restores the scope.
+#[test]
+fn dashboard_scope_is_shared_labeled_and_url_backed() {
+    let common = include_str!("../../assets/dashboard/common.js");
+    let app = include_str!("../../assets/dashboard/app.js");
+    let router = include_str!("../../assets/dashboard/router.js");
+    let scoreboard = include_str!("../../assets/dashboard/scoreboard.js");
+    let reliability = include_str!("../../assets/dashboard/reliability.js");
+    let audit = include_str!("../../assets/dashboard/audit.js");
+    let index = include_str!("../../assets/dashboard/index.html");
+    let css = include_str!("../../assets/dashboard/dashboard.css");
+
+    assert!(
+        common.contains("export function getWindow(")
+            && common.contains("export function setWindow(")
+            && common.contains("export function payloadHonorsWindow(")
+            && common.contains("export function persistScopeToUrl(")
+            && common.contains("export function reliabilityWindowFor("),
+        "common.js must own the shared dashboard window and payload-window guard"
+    );
+    assert!(
+        common.contains("if (typeof reported === \"string\") return reported === selected;")
+            && common.contains("reported.label === selected"),
+        "payloadHonorsWindow must reject a 24h body under an active 7d selection"
+    );
+    assert!(
+        app.contains("if (!payloadHonorsWindow(summary, selectedWindow))")
+            && scoreboard.contains("if (summary && !payloadHonorsWindow(summary, getWindow()))"),
+        "the scoreboard fetch and renderer must refuse a mismatched window payload"
+    );
+    assert!(
+        reliability.contains("Fleet-wide")
+            && index.contains(r#"id="reliability-scope-badge""#)
+            && index.contains("Fleet-wide")
+            && reliability.contains(r#"payload.scope === "workspace""#),
+        "Reliability must label Fleet-wide when it ignores the selected workspace"
+    );
+    assert!(
+        router.contains("markWorkspaceSelectorScope")
+            && router.contains("Reliability is Fleet-wide; workspace does not apply")
+            && css.contains(".workspace-select.scope-ignored")
+            && css.contains(".scope-badge.independent"),
+        "the workspace selector must not imply a scope Reliability does not use"
+    );
+    assert!(
+        audit.contains("function navigateToDrilldown(")
+            && audit.contains("function renderScopeChips(")
+            && audit.contains(r#"removableChip("actor""#)
+            && audit.contains(r#"removableChip("workspace""#)
+            && audit.contains(r#"removableChip("window""#)
+            && audit.contains(r#"removableChip("status""#)
+            && audit.contains(r#"removableChip("metric""#)
+            && index.contains(r#"id="audit-scope-chips""#),
+        "actor/metric drill-down must show removable actor/workspace/window/status/metric chips"
+    );
+    assert!(
+        router.contains(r#"hash = `#diagnostics/${sub}?window=${encodeURIComponent(getWindow())}`"#)
+            && common.contains(r#"url.searchParams.set("window", currentWindow)"#)
+            && audit.contains("sp.set(\"metric\", auditFilter.metric)"),
+        "workspace, diagnostics subview, window, and drill-down filters must live in the URL"
+    );
+    assert!(
+        css.contains("@media (max-width: 720px)")
+            && css.contains("@media (max-width: 520px)")
+            && css.contains(".scope-chip-v")
+            && css.contains("max-width: 10ch"),
+        "scope badges and filter chips must stay legible at 480–720px"
+    );
 }
 
 async fn response_body(response: Response) -> String {

--- a/docs/design/user-interface/2_design.md
+++ b/docs/design/user-interface/2_design.md
@@ -36,6 +36,8 @@ The log panel can be collapsed to its header or resized by dragging (or, with fo
 
 Summary tiles and drill-down panels must agree. Audit > Policy is the detail view for the Denials 24h tile, so `/api/diagnostics/denials` combines v2 loop JSONL denial rows with SQLite `status = denied` audit events. SQLite filesystem boundary denials without an activity fsProfile use the stable `workspace-boundary` label [T20260428-13].
 
+Workspace and time window are one dashboard scope after [ORB-10872]. `?workspace=` and `?window=` plus the diagnostics hash (`#diagnostics/scoreboard?window=7d`) are the source of truth. Scoreboard delivery/operations and the Managed Execution cost/token panel share that window: a 7d selection fetches one `/api/scoreboard?window=7d` payload, and a 24h body is refused rather than painted under a 7d selector. Audit Events honor the same window as `since` and open from an actor or metric click with removable chips for actor, workspace, window, outcome/status, and source metric. Reliability stays fleet-wide (ORB-10588) and labels that exception — `scope: "fleet"` plus a Fleet-wide badge — so the header workspace selector cannot imply it applies; if the dashboard window is unbounded `all`, Reliability keeps an independent labeled 7d cutoff because a rate without a range is not actionable. Half-open cutoffs (`since ≤ t < until`) from ORB-10609 are unchanged.
+
 Run Detail > Steps now includes compact per-step agent log expanders for CLI-backed activity steps [T20260508-14]. The UI renders bounded stdout and stderr previews from `/api/runs/:id/logs`, distinguishes stderr blocks from stdout blocks, highlights structured `ERROR <target>:` lines, and keeps blob references behind the API so operators do not need to resolve content hashes manually.
 
 Diagnostics has an Errors sub-tab after [T20260508-14]. It renders recent backend error rows independently of Metrics and Policy, combining Orbit process ERROR events with structured agent stderr rows. Rows with `job_run` provenance route back to the owning Run Detail step so error triage stays connected to workflow context.
@@ -94,5 +96,6 @@ Accessibility still needs a real WCAG pass; responsive behavior remains optimize
 - [ORB-10444] retired a deprecated tab, folded Scoreboard under Diagnostics, pinned the Knowledge detail pane, and added task ship + comments.
 - [ORB-10874] clarified the Tasks count and filter state, made the log panel collapsible/resizable, and added pending/undo feedback and an aggregate-mode mutation guard to inline task edits.
 - [ORB-10875] added the Operations view and typed routine/clock controls.
+- [ORB-10872] made workspace and time window one dashboard scope across Scoreboard, Audit, Reliability, and Managed Execution.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10872](https://orbit-cli.com/tasks/ORB-10872) — Keep dashboard workspace, window, and actor scope consistent across diagnostics views

### Description

## Problem
Dashboard scope is inconsistent across panels and drill-downs.

During live inspection on 2026-08-15:
- The Scoreboard `7d` segment was visibly selected, but Managed Execution displayed a bounded interval from 2026-08-15 to 2026-08-16 (24 hours).
- The global workspace selector showed `orbit`, while Reliability rendered fleet-wide workspace attribution without an explicit global-scope label.
- Clicking the Codex scorecard card opened Audit on a 24-hour view without visible chips explaining which actor, workspace, status, and time-window filters were preserved or changed.

## Why It Matters
An operator cannot safely compare delivery, reliability, failures, and cost when adjacent panels silently use different populations. Scope changes must be explicit and reproducible.

## Constraints / Notes
- A panel may intentionally be fleet-wide or use an independent window, but that exception must be visibly labeled and must not inherit styling that implies the global scope applies.
- Preserve half-open bounded-window semantics and explicit coverage/unknown handling from ORB-10609.
- Preserve the intentionally cross-workspace attribution design from ORB-10588 while making its scope unambiguous.

### Acceptance Criteria

- The selected workspace and time window are represented as explicit dashboard state and every scoped Scoreboard, Audit, Reliability, and Managed Execution request either honors them or displays an equally prominent independent-scope label.
- Selecting 7d produces the same bounded 7-day cutoff in Scoreboard delivery/operations and Managed Execution cost/token panels; an automated test rejects a 24-hour payload under an active 7d selection.
- Reliability clearly states Fleet-wide when it intentionally ignores a selected workspace, or filters to the selected workspace consistently; the workspace selector never visually implies a scope the panel does not use.
- Clicking an actor or metric opens a drill-down with visible, removable chips for actor, workspace, window, outcome/status, and source metric as applicable.
- Back/forward navigation and reload preserve the selected workspace, diagnostics subview, time window, and drill-down filters in the URL without triggering duplicate requests or mutations.
- API and UI tests cover scope propagation, independent-scope labeling, half-open cutoff boundaries, and navigation state.
- Rendered validation at desktop and a 480-720px viewport confirms scope labels and filter chips remain legible without crowding, and focused tests plus git diff --check pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Shared dashboard window state now lives next to workspace in `common.js` (`getWindow`/`setWindow`/`persistScopeToUrl`). Scoreboard refresh no longer hardcodes `?window=24h`; delivery/operations and Managed Execution share one `/api/scoreboard?window=` payload.
- A 24h payload is refused under an active 7d selection (`payloadHonorsWindow` in the fetch path and renderer). API test asserts a 7d request returns `window=7d` and a ~7-day half-open orchestration cutoff.
- Reliability stays fleet-wide (ORB-10588) but now declares `scope: "fleet"`, renders a Fleet-wide badge, and dims the workspace selector while that subtab is visible. Unbounded `all` keeps a labeled independent 7d reliability window.
- Actor/metric clicks open Audit with removable chips for actor, workspace, window, status, and source metric, carrying the selected window as `since`. Diagnostics hash includes `?window=`.
- CSS wraps scope badges and chips at 720px/520px. Design doc §5 records the scope contract.
Assessment: Fixes the live 7d-selected / 24h-managed-execution mismatch at the refresh chokepoint rather than with a second fetch. Fleet-wide labeling preserves ORB-10588 instead of silently filtering Reliability. Focused orbit-web dashboard + scoreboard/reliability API tests passed; `git diff --check` is clean. No browser was available in this worktree, so 480–720px layout was checked via CSS rules and asset tests, not a live viewport.
Strategic decisions:
- Keep Reliability fleet-wide and label it, per ORB-10588, rather than adding a workspace filter.
- Window selector writes shared state + URL; refresh is the single fetch so Scoreboard and Managed Execution cannot drift.
- Window-selector updates use replaceState (no extra hashchange) to avoid duplicate requests.
Design weaknesses / risks:
- Severity: low. Health-strip tiles remain independently labeled 24h (out of the Scoreboard/Audit/Reliability/Managed Execution scope). Mitigation: existing tile labels already say 24h.
- Severity: low. Narrow-viewport chip layout was not exercised in a real browser. Mitigation: wrap + 10ch ellipsis rules; CI can catch markup regressions.
Deviations from original plan: none material.
Recommended follow-ups: none.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10872-6a8140d8`
- Behind base: 0
- Ahead of base: 1