### PR TITLE
Diagnose the doc-duties EROFS blocker and make sandbox write denials attributable in the task record

### DIFF
--- a/crates/orbit-core/src/runtime/task/tests/block_on_run_failure.rs
+++ b/crates/orbit-core/src/runtime/task/tests/block_on_run_failure.rs
@@ -97,6 +97,10 @@ fn insert_running_pipeline_run(runtime: &OrbitRuntime) -> JobRun {
 /// Record the single job-level diagnostic step the pipeline emits when
 /// `implement_one` fails, so the block note has real error context to surface.
 fn record_failing_step(runtime: &OrbitRuntime, run_id: &str) {
+    record_failing_step_with_message(runtime, run_id, FAILING_STEP_MESSAGE);
+}
+
+fn record_failing_step_with_message(runtime: &OrbitRuntime, run_id: &str, message: &str) {
     let now = Utc::now();
     runtime
         .stores()
@@ -114,7 +118,7 @@ fn record_failing_step(runtime: &OrbitRuntime, run_id: &str) {
                 agent_response_json: None,
                 state: JobRunState::Failed,
                 error_code: Some("STEP_FAILED".to_string()),
-                error_message: Some(FAILING_STEP_MESSAGE.to_string()),
+                error_message: Some(message.to_string()),
             },
         )
         .expect("record failing step");
@@ -171,6 +175,62 @@ fn failed_pipeline_run_blocks_coupled_in_progress_task() {
         "note names the failing step: {note}"
     );
     assert_eq!(entries[0].to_status, Some(TaskStatus::Blocked));
+}
+
+/// [ORB-10879] A sandbox write denial must be recoverable from the task record
+/// alone. ORB-10878 reached its operator as the model's own narrative ("remount
+/// the filesystem") with an empty `artifacts` array and no comments, so the one
+/// piece of text that names the attempted path and the shadowing rule has to
+/// survive run terminalization into the task's history — which is what
+/// `orbit task show` renders.
+#[test]
+fn sandbox_write_denial_is_recoverable_from_the_blocked_task_record() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let task_id = create_backlog_task(&runtime, &repo_root, "denied-write");
+    let run = insert_running_pipeline_run(&runtime);
+    couple_task(&runtime, &task_id, &run.run_id, TaskStatus::InProgress);
+
+    // The real attribution text, produced by the helper the runner uses — not a
+    // re-spelling of it, so a change to that format fails this test too.
+    let worktree = std::path::Path::new("/tmp/orbit-jrun-doc-duties");
+    let profile = orbit_common::types::ResolvedFsProfile {
+        name: "unrestricted".to_string(),
+        read: vec![format!("{}/**", worktree.display())],
+        modify: vec![
+            format!("{}/**", worktree.display()),
+            format!("!{}/.orbit/**", worktree.display()),
+        ],
+    };
+    let denied = worktree.join(".orbit/state/orbit.db");
+    let diagnostic = orbit_exec::linux_bwrap_write_grant_diagnostic(&profile, &denied)
+        .expect("grant diagnostic")
+        .expect("the path is denied by this profile");
+    record_failing_step_with_message(
+        &runtime,
+        &run.run_id,
+        &format!("{FAILING_STEP_MESSAGE} {diagnostic}"),
+    );
+
+    assert!(finalize_failed(&runtime, &run.run_id));
+
+    let task = runtime.get_task(&task_id).expect("task after failure");
+    assert_eq!(task.status, TaskStatus::Blocked);
+
+    let entries = failure_history_entries(&runtime, &task_id);
+    assert_eq!(entries.len(), 1, "exactly one workflow-run-failed event");
+    let note = entries[0].note.as_deref().unwrap_or_default();
+    assert!(
+        note.contains(&denied.display().to_string()),
+        "note must name the attempted path: {note}"
+    );
+    assert!(
+        note.contains("denyModify rule"),
+        "note must name the shadowing rule: {note}"
+    );
+    assert!(
+        note.contains(&format!("!{}/.orbit/**", worktree.display())),
+        "note must quote the exact deny: {note}"
+    );
 }
 
 #[test]

--- a/crates/orbit-core/src/runtime/v2_host/tests/sandbox.rs
+++ b/crates/orbit-core/src/runtime/v2_host/tests/sandbox.rs
@@ -1,6 +1,8 @@
 use orbit_engine::RuntimeHost;
 #[cfg(target_os = "linux")]
-use orbit_exec::{compile_linux_bwrap_argv, prepare_linux_bwrap_write_grants};
+use orbit_exec::{
+    compile_linux_bwrap_argv, linux_bwrap_write_grant_diagnostic, prepare_linux_bwrap_write_grants,
+};
 
 use crate::runtime::v2_host::test_support::seeded_runtime_with_executor;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -149,6 +151,90 @@ fn resolve_executor_sandbox_marks_only_specific_orbit_worktree_managed() {
         .expect("resolve direct")
         .expect("descriptor");
     assert!(!direct.managed_worktree);
+}
+
+/// [ORB-10879] The doc-duties shape: `agent_implement` declares no `fsProfile`,
+/// so it resolves to the unrestricted profile, and its cwd is a managed
+/// worktree. ORB-10878 parked itself in `blocked` claiming this configuration
+/// could not write `docs/**`. It can.
+///
+/// The assertion runs entirely against the resolved profile and the compiled
+/// argv, so it holds on any host — a test that probed a real write would be
+/// reporting the runner's mount table rather than Orbit's policy.
+#[cfg(target_os = "linux")]
+#[test]
+fn managed_worktree_without_an_fs_profile_can_write_under_docs() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    seed_executor(
+        &runtime,
+        "claude",
+        Some(orbit_common::types::ExecutorSandboxKind::LinuxBwrap),
+    );
+    let worktree = runtime
+        .paths()
+        .orbit_dir
+        .join("state/worktrees/orbit-jrun-doc-duties");
+    std::fs::create_dir_all(worktree.join("docs/design/task-artifacts"))
+        .expect("create worktree docs fixture");
+
+    // `None` is exactly what agent_implement passes: no fsProfile declared.
+    let resolved = runtime
+        .resolve_executor_sandbox("claude", None, Some(&worktree))
+        .expect("resolve doc-duties sandbox")
+        .expect("descriptor");
+    assert!(
+        resolved.managed_worktree,
+        "a jrun worktree cwd must be recognized as managed"
+    );
+
+    let canonical_worktree = worktree.canonicalize().expect("canonical worktree");
+    for relative in [
+        "docs/design/task-artifacts/3_vision.md",
+        "docs/design/task-migration/1_overview.md",
+        "docs/runbooks/release.md",
+    ] {
+        let target = canonical_worktree.join(relative);
+        let denial = linux_bwrap_write_grant_diagnostic(&resolved.fs_profile, &target)
+            .expect("grant diagnostic");
+        assert!(
+            denial.is_none(),
+            "doc-duties must be able to stamp {relative} in its own worktree: {denial:?}"
+        );
+    }
+
+    // The worktree's own Orbit store stays denied — this test must not pass by
+    // having widened the grant set.
+    let store = canonical_worktree.join(".orbit/state/orbit.db");
+    assert!(
+        linux_bwrap_write_grant_diagnostic(&resolved.fs_profile, &store)
+            .expect("grant diagnostic")
+            .is_some(),
+        "the worktree Orbit store must remain unwritable: {:?}",
+        resolved.fs_profile.modify
+    );
+
+    // Every grant this profile declares is mountable for that worktree, so the
+    // pre-spawn check has nothing to reject and no EROFS can surface mid-turn.
+    let prepared = prepare_linux_bwrap_write_grants(&resolved.fs_profile, &worktree)
+        .expect("prepare doc-duties grants");
+    assert!(
+        prepared.unsatisfied.is_empty(),
+        "doc-duties grants must all be mountable: {:?}",
+        prepared.unsatisfied
+    );
+    let plan = compile_linux_bwrap_argv(
+        &resolved.fs_profile,
+        "/bin/true",
+        &[],
+        Some(&worktree),
+        resolved.managed_worktree,
+    )
+    .expect("compile doc-duties sandbox");
+    assert!(
+        plan.dropped_grants.is_empty(),
+        "doc-duties grants must not be dropped: {:?}",
+        plan.dropped_grants
+    );
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -314,23 +314,24 @@ pub fn run_cli_backend(
     // and diagnostics, but only make them authoritative when the activity
     // explicitly declares that downstream templates require them.
     let exit_success = !timed_out && matches!(exit_code, Some(0));
-    let sandbox_write_diagnostic = if exit_success {
-        None
-    } else {
-        match sandbox {
-            Some(sandbox)
-                if sandbox.kind == orbit_common::types::ExecutorSandboxKind::LinuxBwrap =>
-            {
-                linux_bwrap_failed_write_diagnostic(
-                    &sandbox.fs_profile,
-                    stderr.protocol_bytes(),
-                    subprocess_cwd.as_deref(),
-                )
-                .map_err(|error| DispatchError::CliInvocationPermanent(error.to_string()))?
-                .map(|diagnostic| bounded_diagnostic(&diagnostic, &redaction))
-            }
-            _ => None,
+    // Attribution is deliberately not gated on the exit code. An agent that
+    // hits a policy-denied write mid-turn can still exit 0 — it narrates the
+    // denial and stops without emitting a terminating envelope — and that
+    // exit-0 shape is precisely the one that reached an operator with no path
+    // and no rule. Deriving the diagnostic here costs a substring scan of
+    // stderr (the helper skips any line without an EROFS marker) and keeps the
+    // Orbit-owned attribution available to every failure branch below.
+    let sandbox_write_diagnostic = match sandbox {
+        Some(sandbox) if sandbox.kind == orbit_common::types::ExecutorSandboxKind::LinuxBwrap => {
+            linux_bwrap_failed_write_diagnostic(
+                &sandbox.fs_profile,
+                stderr.protocol_bytes(),
+                subprocess_cwd.as_deref(),
+            )
+            .map_err(|error| DispatchError::CliInvocationPermanent(error.to_string()))?
+            .map(|diagnostic| bounded_diagnostic(&diagnostic, &redaction))
         }
+        _ => None,
     };
     // A truncated capture retains the final complete JSONL events separately
     // from its diagnostic prefix. Protocol parsing must use that tail so a
@@ -414,19 +415,26 @@ pub fn run_cli_backend(
     } else if (spec.require_completion_envelope || spec.require_response_envelope)
         && matches!(envelope_status.as_deref(), Some("failed") | Some("timeout"))
     {
-        Some(format!(
-            "cli subprocess reported declared envelope status={:?} despite exit 0",
-            envelope_status.as_deref().unwrap_or("unknown")
+        Some(with_sandbox_write_attribution(
+            format!(
+                "cli subprocess reported declared envelope status={:?} despite exit 0",
+                envelope_status.as_deref().unwrap_or("unknown")
+            ),
+            sandbox_write_diagnostic.as_deref(),
         ))
     } else if spec.require_response_envelope {
-        response_envelope_error.clone()
+        response_envelope_error
+            .clone()
+            .map(|error| with_sandbox_write_attribution(error, sandbox_write_diagnostic.as_deref()))
     } else if completion_protocol_violation {
         // Ordered last on purpose: an activity that opted into the content
         // contract already produced a strictly more specific diagnostic above,
         // and the two conditions largely overlap. This branch is what the
         // remaining activities — the ones that only ever had the advisory
         // parse — now report instead of silently checkpointing success.
-        completion_envelope_error.clone()
+        completion_envelope_error
+            .clone()
+            .map(|error| with_sandbox_write_attribution(error, sandbox_write_diagnostic.as_deref()))
     } else {
         None
     };
@@ -534,6 +542,28 @@ pub fn run_cli_backend(
             trace,
         }),
     })
+}
+
+/// Append the Orbit-owned write-denial attribution to a step message that was
+/// classified from the protocol frame alone.
+///
+/// A provider that exits 0 after a policy-denied write yields a frame-shaped
+/// message ("no terminating envelope") that says nothing about *why* the agent
+/// stopped. The sandbox diagnostic is the only text in the system that names
+/// the attempted path and the rule that shadowed it, so it rides along rather
+/// than replacing the frame classification — the step still failed for the
+/// protocol reason, and the denial is the cause worth acting on.
+///
+/// `diagnostic` is already the `linux_bwrap_write_grant_diagnostic` string
+/// (bounded and redacted); this deliberately does not reformat it, so operators
+/// and greps see one message format for a write denial regardless of which
+/// branch surfaced it.
+// pub(super) widened for tests/ layout under ORB-00225; test reaches via exposed surface.
+pub(super) fn with_sandbox_write_attribution(message: String, diagnostic: Option<&str>) -> String {
+    match diagnostic {
+        Some(diagnostic) => format!("{message} {diagnostic}"),
+        None => message,
+    }
 }
 
 fn response_diagnostic(error: &str, redactor: &PatternRedactor) -> String {

--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -380,17 +380,7 @@ fn spawn_linux_bwrap(
         sandbox.managed_worktree,
     )
     .map_err(|error| SpawnError::permanent(error.to_string()))?;
-    // Inside a managed worktree, preparation should have satisfied every grant.
-    // Anything still unmountable is a defect in the grant set, and failing here
-    // — before the provider starts — keeps the denial attributable to a path
-    // and a rule instead of surfacing as an EROFS mid-turn.
-    if sandbox.managed_worktree && !plan.dropped_grants.is_empty() {
-        return Err(SpawnError::permanent(format!(
-            "linux-bwrap could not apply {} policy write grant(s): {}",
-            plan.dropped_grants.len(),
-            describe_grants(&plan.dropped_grants)
-        )));
-    }
+    reject_unsatisfiable_managed_grants(sandbox.managed_worktree, &plan.dropped_grants)?;
     report_unsatisfied_grants(&plan.dropped_grants);
     let child = spawn_under_linux_bwrap(LinuxBwrapSpawnRequest {
         plan: &plan,
@@ -405,6 +395,30 @@ fn spawn_linux_bwrap(
         child,
         _profile_temp: None,
     })
+}
+
+/// Inside a managed worktree, preparation should have satisfied every grant.
+/// Anything still unmountable is a defect in the grant set, and failing here —
+/// before the provider starts — keeps the denial attributable to a path and a
+/// rule instead of surfacing as an EROFS mid-turn.
+///
+/// Split out of the spawn path so the rejection is provable without launching
+/// Bubblewrap: the guarantee this check carries is that an unsatisfiable grant
+/// can never reach the provider, and a test that has to spawn a real sandbox to
+/// observe it would silently skip on any host without bwrap.
+// pub(crate) widened for tests/ layout under ORB-00225; test reaches via exposed surface.
+pub(crate) fn reject_unsatisfiable_managed_grants(
+    managed_worktree: bool,
+    dropped_grants: &[UnsatisfiedWriteGrant],
+) -> Result<(), SpawnError> {
+    if !managed_worktree || dropped_grants.is_empty() {
+        return Ok(());
+    }
+    Err(SpawnError::permanent(format!(
+        "linux-bwrap could not apply {} policy write grant(s): {}",
+        dropped_grants.len(),
+        describe_grants(dropped_grants)
+    )))
 }
 
 /// Host-owned anchors outside the managed worktree are the host's to create,

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -1035,6 +1035,135 @@ fn linux_bwrap_failed_invocation_names_ungranted_write_path_and_deny() {
     assert!(!blocked_path.exists());
 }
 
+/// [ORB-10879] The composition rule behind the exit-0 attribution, asserted
+/// without Bubblewrap: a host whose kernel forbids unprivileged user namespaces
+/// skips every `probe_bwrap`-gated test in this file, so the message contract
+/// gets a check that always runs.
+#[test]
+fn sandbox_write_attribution_rides_along_with_the_frame_classification() {
+    let denial = "Orbit linux-bwrap policy denied the attempted write: \
+                  `/w/.orbit/x` is not writable inside the sandbox: denyModify rule `!/w/.orbit/**` shadows it";
+
+    let composed = super::super::orchestrator::with_sandbox_write_attribution(
+        "agent step did not complete".to_string(),
+        Some(denial),
+    );
+    assert!(
+        composed.starts_with("agent step did not complete"),
+        "the frame classification stays the head of the message: {composed}"
+    );
+    assert!(
+        composed.ends_with(denial),
+        "the denial text is appended verbatim, not reformatted: {composed}"
+    );
+
+    assert_eq!(
+        super::super::orchestrator::with_sandbox_write_attribution(
+            "agent step did not complete".to_string(),
+            None,
+        ),
+        "agent step did not complete",
+        "a step that hit no write denial keeps its message unchanged"
+    );
+}
+
+/// [ORB-10879] ORB-10878's exact shape: the agent hits a policy-denied write,
+/// narrates it, and exits 0 without a terminating envelope. Attribution used to
+/// be gated on a nonzero exit, so this run reached its operator with the model's
+/// guess ("remount the filesystem") and no path or rule anywhere in the record.
+#[cfg(target_os = "linux")]
+#[test]
+fn linux_bwrap_exit_zero_without_an_envelope_still_names_the_denied_write() {
+    if !probe_bwrap().available {
+        return;
+    }
+
+    let temp = tempdir().expect("tempdir");
+    let workspace = temp.path().join("worktree");
+    let orbit = workspace.join(".orbit");
+    fs::create_dir_all(&orbit).expect("denied Orbit root");
+    let script = workspace.join("codex");
+    // Exit 0 with no envelope on stdout — the provider "completed" cleanly.
+    write_executable(
+        &script,
+        "#!/bin/sh\ncat > /dev/null\ntouch \"$PWD/.orbit/ungranted\"\nexit 0\n",
+    );
+    let blocked_path = orbit.join("ungranted");
+    let profile = orbit_common::types::ResolvedFsProfile {
+        name: "unrestricted".to_string(),
+        read: vec![format!("{}/**", workspace.display())],
+        modify: vec![
+            format!("{}/**", workspace.display()),
+            format!("!{}/**", orbit.display()),
+        ],
+    };
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-linux-exit-zero-denial",
+        "claude:test",
+        sink_for_writer,
+    ));
+    let host = TestHost {
+        command: script.display().to_string(),
+        executor_args: Vec::new(),
+        provider_config: HashMap::new(),
+        sandbox: Some(ResolvedSandbox {
+            kind: orbit_common::types::ExecutorSandboxKind::LinuxBwrap,
+            fs_profile: profile,
+            allow_fallback: false,
+            managed_worktree: true,
+        }),
+        task_context: Some(serde_json::json!({
+            "workspace_path": workspace.display().to_string()
+        })),
+        workspace_root: None,
+    };
+    let spec = test_agent_loop_spec(Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-linux-exit-zero-denial",
+        audit,
+        &serde_json::json!({"prompt": "attempt the write"}),
+        None,
+    )
+    .expect("the invocation outcome should be classified");
+
+    assert!(
+        !outcome.success,
+        "an agent that stopped mid-turn must not checkpoint success"
+    );
+    assert_eq!(outcome.output["exit_code"], serde_json::json!(0));
+    let diagnostic = outcome.output["sandbox_write_diagnostic"]
+        .as_str()
+        .expect("exit 0 must not suppress the write-denial attribution");
+    assert!(
+        diagnostic.contains(&blocked_path.display().to_string()),
+        "diagnostic must name the attempted path: {diagnostic}"
+    );
+    assert!(
+        diagnostic.contains("denyModify rule"),
+        "diagnostic must name the shadowing deny: {diagnostic}"
+    );
+
+    // The step message is what becomes `job_run_steps.error_message` and then
+    // the task's `workflow_run_failed` note, so the attribution has to be in it.
+    let message = outcome.message.expect("failed step carries a message");
+    assert!(
+        message.contains("did not complete"),
+        "the frame classification must survive: {message}"
+    );
+    assert!(
+        message.contains(&blocked_path.display().to_string())
+            && message.contains("denyModify rule"),
+        "the persisted step message must carry the denial attribution: {message}"
+    );
+    assert!(!blocked_path.exists());
+}
+
 #[test]
 fn run_cli_backend_emits_provider_pid_between_the_started_and_finished_events() {
     let temp = tempdir().expect("tempdir");

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
@@ -8,10 +8,128 @@ use tempfile::tempdir;
 
 use super::super::super::dispatcher::ResolvedSandbox;
 use super::super::spawn::{
-    SpawnError, SpawnedChild, orbit_tool_env_with, prepare_linux_sandbox_for_dispatch_with_probe,
+    SpawnError, SpawnedChild, linux_bwrap_failed_write_diagnostic, orbit_tool_env_with,
+    prepare_linux_sandbox_for_dispatch_with_probe, reject_unsatisfiable_managed_grants,
     resolve_provider_launcher_with, spawn_bare, spawn_macos_sandboxed_with,
 };
 use super::test_support::{sandbox_for_test, sh_args};
+
+/// A profile shaped like a managed-worktree implementer: the worktree is
+/// writable, its `.orbit` store is not.
+fn worktree_profile(worktree: &std::path::Path) -> orbit_common::types::ResolvedFsProfile {
+    orbit_common::types::ResolvedFsProfile {
+        name: "unrestricted".to_string(),
+        read: vec![format!("{}/**", worktree.display())],
+        modify: vec![
+            format!("{}/**", worktree.display()),
+            format!("!{}/.orbit/**", worktree.display()),
+        ],
+    }
+}
+
+/// [ORB-10879] The attribution path an operator actually depends on, exercised
+/// without Bubblewrap and without consulting the host's mount table: a child
+/// that reported EROFS gets a denial naming the attempted path and the rule
+/// that shadowed it.
+#[test]
+fn failed_write_diagnostic_names_attempted_path_and_shadowing_rule() {
+    let worktree = std::path::Path::new("/tmp/orbit-jrun-attribution");
+    let profile = worktree_profile(worktree);
+    let stderr = b"touch: cannot touch '/tmp/orbit-jrun-attribution/.orbit/state/x': Read-only file system\n";
+
+    let diagnostic = linux_bwrap_failed_write_diagnostic(&profile, stderr, Some(worktree))
+        .expect("diagnostic derivation succeeds")
+        .expect("a denied write must be attributable");
+
+    assert!(
+        diagnostic.contains("/tmp/orbit-jrun-attribution/.orbit/state/x"),
+        "diagnostic must name the attempted path: {diagnostic}"
+    );
+    assert!(
+        diagnostic.contains("denyModify rule"),
+        "diagnostic must name the shadowing rule: {diagnostic}"
+    );
+    assert!(
+        diagnostic.contains(&format!("!{}/.orbit/**", worktree.display())),
+        "diagnostic must quote the exact deny that shadows the path: {diagnostic}"
+    );
+    // The wrapper prefix is Orbit's, but the explanation body is verbatim
+    // `linux_bwrap_write_grant_diagnostic` output — one message format.
+    let expected =
+        orbit_exec::linux_bwrap_write_grant_diagnostic(&profile, &worktree.join(".orbit/state/x"))
+            .expect("grant diagnostic")
+            .expect("path is denied");
+    assert!(
+        diagnostic.ends_with(&expected),
+        "diagnostic must reuse the existing grant-diagnostic text: {diagnostic}"
+    );
+}
+
+/// A path the profile *does* grant is not reported as a denial, so the
+/// diagnostic cannot manufacture an attribution for an unrelated EROFS.
+#[test]
+fn failed_write_diagnostic_stays_silent_for_a_granted_path() {
+    let worktree = std::path::Path::new("/tmp/orbit-jrun-attribution");
+    let profile = worktree_profile(worktree);
+    let stderr =
+        b"touch: cannot touch '/tmp/orbit-jrun-attribution/docs/x.md': Read-only file system\n";
+
+    let diagnostic = linux_bwrap_failed_write_diagnostic(&profile, stderr, Some(worktree))
+        .expect("diagnostic derivation succeeds");
+
+    assert!(
+        diagnostic.is_none(),
+        "a granted path must not be attributed to policy: {diagnostic:?}"
+    );
+}
+
+/// [ORB-10879] Regression guard for the managed-worktree pre-spawn check. Its
+/// whole purpose is that an unsatisfiable grant fails *before* the provider
+/// starts rather than surfacing as an EROFS mid-turn, so the rejection is
+/// asserted directly instead of through a spawn that would skip without bwrap.
+#[test]
+fn unsatisfiable_grant_in_a_managed_worktree_fails_before_the_provider_starts() {
+    let dropped = vec![orbit_exec::UnsatisfiedWriteGrant {
+        rule: "/tmp/orbit-jrun-attribution/.orbit/routines/**".to_string(),
+        anchor: std::path::PathBuf::from("/tmp/orbit-jrun-attribution/.orbit/routines"),
+        reason: "anchor is absent".to_string(),
+    }];
+
+    let error = reject_unsatisfiable_managed_grants(true, &dropped)
+        .expect_err("an unsatisfiable grant must not reach the provider");
+
+    assert!(
+        error.permanent,
+        "an unmountable grant set is deterministic config, not a transient fault"
+    );
+    assert!(
+        error.message.contains(".orbit/routines"),
+        "rejection must name the grant that could not be applied: {}",
+        error.message
+    );
+    assert!(
+        error
+            .message
+            .contains("could not apply 1 policy write grant"),
+        "rejection must count the dropped grants: {}",
+        error.message
+    );
+}
+
+/// Outside a managed worktree the same grant is host-owned, so it is reported
+/// rather than fatal — widening this check would fail runs the host can fix.
+#[test]
+fn unsatisfiable_grant_outside_a_managed_worktree_is_not_fatal() {
+    let dropped = vec![orbit_exec::UnsatisfiedWriteGrant {
+        rule: "/var/host-owned/**".to_string(),
+        anchor: std::path::PathBuf::from("/var/host-owned"),
+        reason: "anchor is absent".to_string(),
+    }];
+
+    reject_unsatisfiable_managed_grants(false, &dropped)
+        .expect("host-owned anchors stay reported, not fatal");
+    reject_unsatisfiable_managed_grants(true, &[]).expect("a fully satisfied grant set must spawn");
+}
 
 #[test]
 fn spawn_bare_runs_program_in_provided_cwd() {

--- a/crates/orbit-web/src/api/tests/reliability.rs
+++ b/crates/orbit-web/src/api/tests/reliability.rs
@@ -193,14 +193,12 @@ async fn reliability_7d_window_is_a_half_open_week() {
     assert_eq!(response.status(), StatusCode::OK);
     let body = body_json(response).await;
     assert_eq!(body["window"]["label"], "7d");
-    let since = chrono::DateTime::parse_from_rfc3339(
-        body["window"]["since"].as_str().expect("since"),
-    )
-    .expect("parse since");
-    let until = chrono::DateTime::parse_from_rfc3339(
-        body["window"]["until"].as_str().expect("until"),
-    )
-    .expect("parse until");
+    let since =
+        chrono::DateTime::parse_from_rfc3339(body["window"]["since"].as_str().expect("since"))
+            .expect("parse since");
+    let until =
+        chrono::DateTime::parse_from_rfc3339(body["window"]["until"].as_str().expect("until"))
+            .expect("parse until");
     let span = until.signed_duration_since(since);
     assert!(
         span >= chrono::Duration::days(7) - chrono::Duration::seconds(2)

--- a/crates/orbit-web/src/api/tests/scoreboard.rs
+++ b/crates/orbit-web/src/api/tests/scoreboard.rs
@@ -146,9 +146,7 @@ async fn scoreboard_query_window_7d_is_not_a_24h_payload() {
         "a 7d request must not report a 24h window"
     );
     let since = chrono::DateTime::parse_from_rfc3339(
-        body["window_since"]
-            .as_str()
-            .expect("window_since for 7d"),
+        body["window_since"].as_str().expect("window_since for 7d"),
     )
     .expect("parse window_since");
     let orch_since = chrono::DateTime::parse_from_rfc3339(
@@ -163,19 +161,23 @@ async fn scoreboard_query_window_7d_is_not_a_24h_payload() {
             .expect("orchestration until"),
     )
     .expect("parse until");
-    assert_eq!(since, orch_since, "scoreboard and managed-execution cutoffs must match");
+    assert_eq!(
+        since, orch_since,
+        "scoreboard and managed-execution cutoffs must match"
+    );
     let span = until.signed_duration_since(orch_since);
     assert!(
         span >= chrono::Duration::days(7) - chrono::Duration::seconds(2)
             && span <= chrono::Duration::days(7) + chrono::Duration::seconds(2),
         "7d orchestration span must be ~7 days, got {span}"
     );
-    assert!(until <= chrono::DateTime::parse_from_rfc3339(
-        body["orchestration"]["as_of"]
-            .as_str()
-            .expect("as_of"),
-    )
-    .expect("parse as_of"));
+    assert!(
+        until
+            <= chrono::DateTime::parse_from_rfc3339(
+                body["orchestration"]["as_of"].as_str().expect("as_of"),
+            )
+            .expect("parse as_of")
+    );
 }
 
 #[tokio::test]

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -607,7 +607,9 @@ async fn dashboard_scoreboard_is_reachable_under_diagnostics() {
     );
     assert!(
         app.contains(r#"if (activeDiagSubtab === "scoreboard")"#)
-            && app.contains(r#"fetchJson(`/api/scoreboard?window=${encodeURIComponent(selectedWindow)}`)"#),
+            && app.contains(
+                r#"fetchJson(`/api/scoreboard?window=${encodeURIComponent(selectedWindow)}`)"#
+            ),
         "the scoreboard fetch must hang off the diagnostics subtab branch and honor the shared window"
     );
 }
@@ -945,8 +947,7 @@ fn dashboard_workspace_selection_persists_to_the_url() {
     let app = include_str!("../../assets/dashboard/app.js");
 
     assert!(
-        app.contains("function persistWorkspaceToUrl(")
-            && app.contains("persistScopeToUrl()"),
+        app.contains("function persistWorkspaceToUrl(") && app.contains("persistScopeToUrl()"),
         "the workspace selector must persist its choice to the URL on every change"
     );
 }
@@ -1191,7 +1192,8 @@ fn dashboard_scope_is_shared_labeled_and_url_backed() {
         "actor/metric drill-down must show removable actor/workspace/window/status/metric chips"
     );
     assert!(
-        router.contains(r#"hash = `#diagnostics/${sub}?window=${encodeURIComponent(getWindow())}`"#)
+        router
+            .contains(r#"hash = `#diagnostics/${sub}?window=${encodeURIComponent(getWindow())}`"#)
             && common.contains(r#"url.searchParams.set("window", currentWindow)"#)
             && audit.contains("sp.set(\"metric\", auditFilter.metric)"),
         "workspace, diagnostics subview, window, and drill-down filters must live in the URL"


### PR DESCRIPTION
## Task

[ORB-10879](https://orbit-cli.com/tasks/ORB-10879) — Diagnose the doc-duties EROFS blocker and make sandbox write denials attributable in the task record

### Description

## Problem

ORB-10878 (doc-duties, `agent_implement` via `worktree_setup` admission) parked itself in `blocked` after 108 seconds with this execution summary:

> File system is mounted read-only (EROFS — kernel error 30). Cannot persist last_validated timestamps.
> - Worktree environment has ro mounts preventing write operations
> - Requires host-side write access or remount to complete

Two separate defects sit behind that, and the second is the one that holds no matter how the first resolves.

### 1. A write that should have been permitted appears to have been denied

`assets/activities/agent_implement.yaml` declares **no `fsProfile`**. Per the comment in `assets/activities/task_pilot.yaml`, omitting it falls back to unrestricted workspace writes, so `docs/**` inside a managed worktree should be writable. Something made it not so.

**Do not assume the reported EROFS is real.** The same summary claims six design docs (~63KB, including a 26KB decisions log and a 15KB spec) were each verified against code inside a 108-second run that also covered worktree setup and agent startup — a claim the wall clock does not support. A summary that unreliable is weak evidence for its own blocker. Establish from run logs whether an EROFS actually occurred and against which absolute path *before* changing any policy code.

Candidate causes, to be confirmed or eliminated with evidence:

- The attempted write targeted a path outside the managed worktree (the original checkout, `$HOME`, or a temp dir), in which case the denial is correct and the defect is entirely #2.
- `sandbox.managed_worktree` was false, so the pre-spawn grant check at `orbit-engine/src/activity_job/cli_runner/spawn.rs:386-393` never ran. That check exists precisely so an unsatisfiable grant fails before the provider starts, "instead of surfacing as an EROFS mid-turn" — a mid-turn EROFS inside a managed worktree means it did not fire.
- No EROFS occurred and the model confabulated a plausible infrastructure blocker.

### 2. The denial reached the operator with no path and no rule

`linux_bwrap_failed_write_diagnostic` (`spawn.rs:431`) exists to turn a child-reported EROFS into `Orbit linux-bwrap policy denied the attempted write: <diagnostic>`, and `linux_bwrap_write_grant_diagnostic` (`orbit-exec/src/linux_sandbox.rs:188`) names the deny rule that shadows the path plus the exception that would be needed. None of that reached the task. ORB-10878 has an empty `artifacts` array, no comments, and an execution summary whose only actionable content is the model's own guess — "remount" — which is the wrong remedy for a policy denial.

So an agent can park a task in `blocked` on an infrastructure claim, and the operator gets the model's narrative instead of the attribution the code already computes. That is a defect independent of the root cause of #1, and it is what made this run cost a manual investigation.

## Why It Matters

`agent_implement` is the shared implementation activity, so an unattributed write denial in it is not specific to doc-duties. And a blocked-on-infrastructure task is the case where operator trust in the summary matters most, because there is no diff to review — the narrative is the entire artifact.

## Constraints / Notes

- Diagnosis precedes any change. Cite the run log line and the absolute attempted path in the execution summary; if no EROFS is found in the logs, say so and close out #1 as unreproduced rather than hardening code speculatively.
- If the denial turns out to be correct policy, do **not** widen the grant set to make the run pass. Fix the attribution instead and, if doc-duties genuinely needs a path it is not granted, state which path and why in the summary for a separate decision.
- Do not add a new sandbox profile, grant mechanism, or blocked-reason taxonomy. The attribution helpers already exist; the gap is that their output does not reach the persisted record.
- `.orbit/auto_tasks/doc-duties.yaml` is a local definition, not a shipped asset — it is not a modification target here, and its `crew: luna` pin is out of scope (see ORB-10877 for the shipped-asset crew rule).
- `context_files` is deliberately empty: the modification targets depend on which candidate cause survives step 1. Populate it via `orbit.task.update` once the diagnosis lands, before implementing.

### Acceptance Criteria

- The execution summary states, with the run-log line quoted, whether ORB-10878's run actually attempted a write that returned EROFS and the absolute path it targeted — or states that no such write appears in the logs and that the reported blocker was unreproduced.
- The surviving candidate cause is named and the other two are explicitly eliminated with evidence, not left open.
- A test proves that a write denied by the resolved fs profile produces an operator-visible diagnostic naming both the attempted path and the shadowing rule, using the existing `linux_bwrap_write_grant_diagnostic` output rather than a new message format.
- A test proves that a sandbox write denial surviving into a terminal task state is persisted on the task record (artifact, comment, or summary field — whichever the diagnosis shows is the right owner), so the attribution is recoverable from `orbit.task.show` without reading run logs.
- A regression test covers the `managed_worktree` pre-spawn grant check at `spawn.rs:386-393` firing for an unsatisfiable grant, so an unsatisfiable grant cannot reach the provider and surface as a mid-turn EROFS.
- A doc-duties-shaped run (agent_implement, no `fsProfile`, managed worktree) can write a file under `docs/` in its worktree, demonstrated by a test that does not depend on the host's real mount table.
- No sandbox write grant was widened to make the failing case pass; if the diagnosis shows a genuinely missing grant, it is reported for a separate decision rather than added here.
- `cargo nextest run -p orbit-exec -p orbit-engine -p orbit-core --locked` passes.
- `make ci-fast` and `make ci-lint` both pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

# Diagnosis: no EROFS occurred. ORB-10878's blocker was confabulated.

## 1. The run-log evidence

ORB-10878 ran as `jrun-20260816-0416-3` (task history: created 04:16:38, admitted 04:16:51, self-blocked by `haiku` at 04:18:39). Its provider stdout is the only new audit blob written in that window:

    .orbit/state/audit/blobs/87/873b2719ac77739a90e9240b01d3a696abe5b3c5f26b27c245f8ccd0fd99ee8e  (04:18:50)

That blob is the Claude Code SDK result envelope, quoted verbatim in the relevant fields:

    "is_error":false, "terminal_reason":"completed", "subtype":"success",
    "permission_denials":[], "duration_ms":114912, "num_turns":36,
    "modelUsage":{"claude-haiku-4-5-20251001":{...}}

**There is no EROFS in it, and no attempted path.** The string "read-only" appears exactly once in the whole run record — inside the model's own narrative `result` field:

    "**Blocker encountered**: The worktree file system is mounted read-only
     (EROFS kernel error 30), preventing write operations to persist the
     `last_validated: 2026-08-16` timestamps."

That sentence is the model asserting a blocker, not a kernel reporting one.

Corroborating negatives, each checked directly:

- **stderr was empty.** The run's stderr blob deduped to the pre-existing zero-byte blob `e3b0c442…855` (`ls`: 0 bytes, dated Jul 6 — i.e. it was not written by this run). A child that hit EROFS writes to stderr; this one wrote nothing.
- **No EROFS in any worker log.** `grep -riE "erofs|read-only file system|os error 30"` over `.orbit/state/logs/jrun-20260816-0416*.worker.log` returns nothing. Those logs contain only the step-failure chain, whose leaf is:

      step `implement_one`: agent step did not complete: the provider exited 0
      but stdout carried no valid terminating Orbit response envelope

- **The only real EROFS on the box that day belongs to a different run.** `jrun-20260816-0418` hit `npm error path ~/.npm/_cacache/tmp/***` — a write to `$HOME`, outside any worktree, correctly denied.
- **ORB-10878's worktree is clean.** `orbit-jrun-20260816-0416-3` still exists; `git status --short` is empty and none of the six docs it claimed to validate carry a `last_validated` key. No partial write, no failed write.

**Answer to the acceptance criterion: no EROFS appears in the logs for ORB-10878's run, and the reported blocker is unreproduced.** The wall-clock objection in the task description holds — 36 turns and 114.9s of API time for six docs totalling ~63KB, plus worktree setup and startup.

## 2. Candidate causes: one survives, two eliminated

**Eliminated — "the write targeted a path outside the managed worktree."** Had that happened, the tool would have reported a denial to stderr; stderr was empty and `permission_denials` is `[]`. Nothing in the record shows any write being attempted at all.

I did, however, reproduce this mechanism live and twice during this task, which is why it is worth naming precisely rather than merely dismissing. Running `cargo` with cwd set to the *original* checkout instead of my worktree:

    $ cd ~/workspace/constellation/codebases/orbit && cargo fmt --all
    Error writing files: io error:
      ~/.../crates/orbit-web/src/api/tests/reliability.rs:
      Read-only file system (os error 30)

That is what a genuine out-of-worktree denial looks like: a real path in a real error. ORB-10878's record contains no such line. So this cause is real and reachable — it just is not what happened here.

**Eliminated — "`sandbox.managed_worktree` was false, so the pre-spawn grant check never ran."** Two independent reasons:

1. The check at `spawn.rs` fails the spawn **permanently, before the provider starts**. ORB-10878's provider ran 36 turns over 114.9s and exited 0, so no spawn rejection occurred.
2. `agent_implement` declares no `fsProfile`, which resolves to `UNRESTRICTED_FS_PROFILE` (`sandbox.rs`). An unrestricted profile inside a managed worktree produces no unsatisfiable grants, so the check has nothing to reject. Admission was `worktree_setup` and the worktree directory exists, so `managed_worktree` was in fact true.

**Surviving cause — the model confabulated a plausible infrastructure blocker.** It is the only explanation consistent with: exit 0, `is_error:false`, `terminal_reason:"completed"`, empty stderr, empty `permission_denials`, a clean worktree, and an EROFS claim that exists only inside the model's own prose. The same response also claims "I have already called the StructuredOutput tool in my previous response" — it had not; that is why the step failed the envelope protocol check. Two fabricated claims in one response.

Per the task's constraint, **no grant was widened**, and doc-duties needs no path it is not already granted — see §4.

## 3. The defect that was real, and the fix

`orchestrator.rs` computed the write-denial attribution only when the provider exited nonzero:

    let sandbox_write_diagnostic = if exit_success { None } else { ... };

ORB-10878's shape is **exit 0 plus a protocol violation**. So on precisely this path — an agent that hits a denied write, narrates it, and stops without emitting a terminating envelope — a genuine EROFS on stderr was discarded before `linux_bwrap_failed_write_diagnostic` ever saw it. The operator got the model's guess ("remount") instead of the path and rule the code already knows how to compute.

Changes, both in `crates/orbit-engine/src/activity_job/cli_runner/`:

- **`orchestrator.rs`** — derive `sandbox_write_diagnostic` regardless of exit status (the helper already skips any stderr line without an EROFS marker, so the cost is a substring scan), and attach it to the three exit-0 failure branches via a new `with_sandbox_write_attribution` helper. The diagnostic is appended verbatim, never reformatted, so a write denial reads identically no matter which branch surfaced it. This is what carries the attribution into `job_run_steps.error_message` → `blocked_workflow_failure_update` → the task's `workflow_run_failed` history note → `orbit task show`.
- **`spawn.rs`** — extract the `managed_worktree` + `dropped_grants` rejection into `reject_unsatisfiable_managed_grants` so the guarantee ("an unsatisfiable grant cannot reach the provider") is provable without launching Bubblewrap.

No new sandbox profile, grant mechanism, or blocked-reason taxonomy was added, and no grant was widened.

## 4. Tests

Host-independent (these run everywhere, including agent worktrees):

- `spawn::failed_write_diagnostic_names_attempted_path_and_shadowing_rule` — a denied write yields a diagnostic naming the attempted path and the shadowing `denyModify` rule, and `ends_with` the exact `linux_bwrap_write_grant_diagnostic` output, so the existing message format is asserted rather than re-spelled.
- `spawn::failed_write_diagnostic_stays_silent_for_a_granted_path` — an EROFS on a granted path is not attributed to policy.
- `spawn::unsatisfiable_grant_in_a_managed_worktree_fails_before_the_provider_starts` and `…outside_a_managed_worktree_is_not_fatal` — the pre-spawn check fires (permanently) inside a managed worktree and stays non-fatal for host-owned anchors.
- `sandbox::managed_worktree_without_an_fs_profile_can_write_under_docs` — **the doc-duties shape**: `agent_implement`'s `None` fsProfile plus a managed worktree cwd leaves `docs/design/…`, `docs/runbooks/…` writable, asserted through the resolved profile and compiled argv rather than the host's mount table. It also asserts the worktree's own `.orbit` store stays denied, so the test cannot pass by having widened the grant set.
- `block_on_run_failure::sandbox_write_denial_is_recoverable_from_the_blocked_task_record` — a step whose `error_message` carries real `linux_bwrap_write_grant_diagnostic` output survives run terminalization into the task's `workflow_run_failed` history note, which is what `orbit task show` renders. **This is the criterion's "right owner": the task history note, not an artifact or comment** — it is the only surface the existing terminalization path already writes, it is rendered by `task show`, and it needed no new mechanism.
- `orchestrator::sandbox_write_attribution_rides_along_with_the_frame_classification` — the frame classification stays the head of the message and the denial is appended verbatim.

Bubblewrap-gated (full spawn boundary): `orchestrator::linux_bwrap_exit_zero_without_an_envelope_still_names_the_denied_write` reproduces ORB-10878's exact shape end-to-end.

**Caveat, stated plainly:** that last test does not execute on this runner. Orbit's own sandbox is a bwrap namespace and bwrap does not nest, so `bwrap` reports "No permissions to create new namespace" and the test's `if !probe_bwrap().available { return; }` guard makes it report PASS in ~9ms while asserting nothing. The same is true of the pre-existing `linux_bwrap_failed_invocation_names_ungranted_write_path_and_deny`. It will run in unrestricted CI. Every contract above is therefore *also* covered by a host-independent test that does run here. Filed as friction F2026-08-084's sibling F2026-08-083.

## 5. Validation

- `cargo nextest run -p orbit-exec -p orbit-engine -p orbit-core --locked` — **1217 passed, 1 skipped**.
- `cargo nextest run -p orbit-web --locked` — **225 passed** (run because §6 reformatted its test files).
- `make ci-fast` — **exit 0**.
- `make ci-lint` — **exit 0**.

## 6. Out-of-scope change, called out

`make ci-fast` was **already red on HEAD** before this task made any edit. `cargo fmt --all -- --check` failed on three `orbit-web` test files that were byte-identical to HEAD (`git diff --quiet HEAD -- <file>` clean on all three); `git log -1` attributes them to `9c04bb76` (ORB-10872), HEAD's parent. Since the handoff gate cannot pass while they are unformatted, I ran `cargo fmt --all`, which reformatted:

- `crates/orbit-web/src/api/tests/reliability.rs`
- `crates/orbit-web/src/api/tests/scoreboard.rs`
- `crates/orbit-web/src/tests/dashboard_assets.rs`

These are rustfmt-only line-wrapping changes with no behavior change, added to `context_files` and recorded in friction F2026-08-084. **They are not this task's work** — a reviewer should read them as unrelated diff noise inherited from the integration branch, and if a concurrent task fixes the same files, drop these hunks.

## 7. Left open, for a separate decision

Nothing about doc-duties' grant set needs changing — it can write `docs/**` in its worktree today, proven by test. Two observations surfaced by the investigation that are *not* fixed here because they are out of this task's stated scope:

1. **An agent self-blocking preempts the automated failure note.** `task_is_blockable_on_run_failure` skips tasks already in `Blocked`, so when haiku set `blocked` itself at 04:18:39, the run's own `workflow_run_failed` note — the one carrying the real step error — was never written. ORB-10878 therefore kept only the model's narrative. The attribution fix above makes that note carry the right content; it does not change who wins when the agent has already blocked the task first.
2. **ORB-10878 is currently `done`.** An `unknown` actor moved it at 04:20:17, 98 seconds after it self-blocked, despite its run having failed. Worth someone's attention independently of this task.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10879-6a815a05`
- Behind base: 0
- Ahead of base: 1