### PR TITLE
Make dashboard failure metrics incident-aware instead of counting repeated events as independent failures

### DIFF
--- a/crates/orbit-core/src/command/audit_event.rs
+++ b/crates/orbit-core/src/command/audit_event.rs
@@ -5,6 +5,7 @@ use orbit_common::types::{
 use orbit_store::{
     AuditEventFilter, AuditEventInsertParams, AuditRoleAggregate, AuditToolAggregate,
     AuditToolCallCountsByRole, AuditToolCallCountsBySurfaceAndRole, AuditTopToolCall,
+    FailureIncidentQuery, FailureIncidentReport,
 };
 
 use crate::OrbitRuntime;
@@ -243,6 +244,19 @@ impl OrbitRuntime {
         self.stores()
             .audit_events()
             .get_audit_event_aggregates_by_role(since)
+    }
+
+    /// Failure incidents grouped from the raw failed/denied audit rows in
+    /// `query`'s window [ORB-10871]. The report carries both the incident
+    /// list and the raw event denominators it was derived from, so a caller
+    /// never has to infer one count from the other. Raw rows are neither
+    /// mutated nor withheld — `list_audit_events_filtered` remains the
+    /// authority on evidence.
+    pub fn audit_failure_incidents(
+        &self,
+        query: &FailureIncidentQuery,
+    ) -> Result<FailureIncidentReport, OrbitError> {
+        self.stores().audit_events().get_failure_incidents(query)
     }
 
     /// Sorted `duration_ms` values for audit events with NULL `tool_name`

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -86,6 +86,12 @@ pub use orbit_store::{
     AuditEventFilter, AuditEventInsertParams, AuditToolAggregate, V2AuditEventFilter,
     V2AuditEventInsertParams,
 };
+// Failure-incident grouping over the raw audit rows [ORB-10871]; consumed by
+// the dashboard's incident, audit-summary, and scoreboard surfaces.
+pub use orbit_store::{
+    CASCADE_WINDOW_SECS, FailureClass, FailureIncident, FailureIncidentQuery,
+    FailureIncidentReport, IncidentEventRef, PropagationLink,
+};
 // Routine fire records surfaced by the dashboard's routine-health JSON API.
 pub use orbit_store::{RoutineFireRecord, RoutineFireState};
 pub use runtime::engine::ResolvedCrewProjection;

--- a/crates/orbit-store/src/backend/contracts/traits.rs
+++ b/crates/orbit-store/src/backend/contracts/traits.rs
@@ -10,6 +10,7 @@ use std::collections::BTreeMap;
 
 use super::params::*;
 
+use crate::sqlite::audit_event_store::incident::{FailureIncidentQuery, FailureIncidentReport};
 use crate::sqlite::audit_event_store::{
     AuditEventFilter, AuditEventInsertParams, AuditRoleAggregate, AuditToolAggregate,
     AuditToolCallCountsByRole, AuditToolCallCountsBySurfaceAndRole, AuditTopToolCall,
@@ -292,6 +293,13 @@ pub trait AuditEventStoreBackend: Send + Sync {
         &self,
         since: &DateTime<Utc>,
     ) -> Result<Vec<AuditRoleAggregate>, OrbitError>;
+    /// Failure incidents grouped from the raw failed/denied rows in `query`'s
+    /// window [ORB-10871]. A derived view: it neither mutates nor withholds
+    /// any row that `list_audit_events` would return.
+    fn get_failure_incidents(
+        &self,
+        query: &FailureIncidentQuery,
+    ) -> Result<FailureIncidentReport, OrbitError>;
     fn prune_audit_events(&self, older_than: &DateTime<Utc>) -> Result<usize, OrbitError>;
 }
 

--- a/crates/orbit-store/src/backend/sqlite_backends.rs
+++ b/crates/orbit-store/src/backend/sqlite_backends.rs
@@ -138,6 +138,13 @@ impl AuditEventStoreBackend for SqliteAuditEventStoreBackend {
         self.store.get_audit_event_aggregates_by_role(since)
     }
 
+    fn get_failure_incidents(
+        &self,
+        query: &crate::FailureIncidentQuery,
+    ) -> Result<crate::FailureIncidentReport, OrbitError> {
+        self.store.get_failure_incidents(query)
+    }
+
     fn prune_audit_events(&self, older_than: &DateTime<Utc>) -> Result<usize, OrbitError> {
         self.store.prune_audit_events(older_than)
     }

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -113,6 +113,13 @@ pub use file::session_log_store::{
 };
 pub use file_lock::{LockHolderInfo, read_lock_holder};
 pub use json_schema::{validate_instance_against_schema, validate_schema_document};
+pub use sqlite::audit_event_store::incident::{
+    CASCADE_WINDOW_SECS, DEFAULT_SCAN_LIMIT as FAILURE_INCIDENT_SCAN_LIMIT, FailureClass,
+    FailureIncident, FailureIncidentQuery, FailureIncidentReport, IncidentEventRef,
+    PropagationLink, build_report as build_failure_incident_report, classify as classify_failure,
+    group_failure_incidents, normalize_message as normalize_failure_message,
+    signature_for as failure_signature_for,
+};
 pub use sqlite::audit_event_store::{
     AuditEventFilter, AuditEventInsertParams, AuditRoleAggregate, AuditToolAggregate,
     AuditToolCallCountsByRole, AuditToolCallCountsBySurfaceAndRole, AuditTopToolCall,

--- a/crates/orbit-store/src/sqlite/audit_event_store/incident.rs
+++ b/crates/orbit-store/src/sqlite/audit_event_store/incident.rs
@@ -1,0 +1,717 @@
+//! Failure-incident grouping over raw audit events [ORB-10871].
+//!
+//! A raw failed audit event is forensic evidence, not an incident. One burst
+//! of the same refusal repeated hundreds of times is one problem, and one
+//! failed pipeline run that propagates its failure up through its enclosing
+//! steps is one root cause with a chain hanging off it. Counting the raw rows
+//! as independent failures overstates both.
+//!
+//! This module derives an incident view *on top of* the audit rows without
+//! consuming or rewriting them: every incident carries its raw `event_count`
+//! and the ids of the rows it collapsed, so the raw Audit view and any export
+//! stay the authority on evidence.
+//!
+//! The contract is deliberately project-agnostic — it reads only durable
+//! audit columns (status, role, tool/command, error message, run/task ids,
+//! timestamps). No tool name, agent, workspace, or task id is special-cased.
+//!
+//! Grouping runs in three passes:
+//!
+//! 1. **Classify** each failed row as [`FailureClass::Denied`],
+//!    [`FailureClass::Expected`], or [`FailureClass::Unexpected`] so a policy
+//!    refusal and a caller's invalid input stay distinguishable from a genuine
+//!    unexpected failure.
+//! 2. **Cluster** rows by `(run scope, signature)`, where the signature is
+//!    `class | role | surface | normalized message`. Volatile tokens (paths,
+//!    numbers, ids, timestamps, hashes, quoted literals) are replaced with
+//!    placeholders, so a repeated failure whose only difference is its operand
+//!    collapses into one cluster.
+//! 3. **Collapse cascades** within a single job run: clusters of the same
+//!    class whose time ranges are within [`CASCADE_WINDOW_SECS`] of each other
+//!    are one incident, rooted at the earliest cluster, with the later ones
+//!    recorded as its propagation chain. A failure later in the same run,
+//!    beyond that window, stays an independent incident.
+
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Duration, Utc};
+use orbit_common::types::{AuditEvent, AuditEventStatus, OrbitError};
+use serde::{Deserialize, Serialize};
+
+use super::{AUDIT_EVENT_COLUMNS, audit_event_from_row};
+use crate::Store;
+
+/// Maximum gap between one cluster's last event and the next cluster's first
+/// event for the two to be treated as one cascade within a job run. Failure
+/// propagation up a pipeline's enclosing steps is effectively immediate; a
+/// minute of slack absorbs step teardown without swallowing a genuinely
+/// separate failure later in the same run.
+pub const CASCADE_WINDOW_SECS: i64 = 60;
+
+/// Per-incident cap on the sampled raw events echoed back to callers. The
+/// full population is always reachable through the raw Audit view; this bound
+/// keeps one burst of thousands from dominating a response body.
+const MAX_SAMPLE_EVENTS: usize = 20;
+
+/// Longest normalized message retained in a signature. Long enough to keep
+/// distinct failures distinct, short enough that a multi-kilobyte error body
+/// cannot become a grouping key.
+const MAX_SIGNATURE_MESSAGE_CHARS: usize = 160;
+
+/// How an audit failure should be read by an operator.
+///
+/// The three classes are kept separate at every layer: an incident never
+/// merges rows of different classes, so a policy denial can never be counted
+/// as an unexpected failure (or hide one).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureClass {
+    /// The call was refused by policy or capability before it ran.
+    Denied,
+    /// The call ran and failed on a documented negative path — invalid input,
+    /// a missing record, a validation refusal. The system behaved correctly.
+    Expected,
+    /// Everything else: a failure that is not a known negative path.
+    Unexpected,
+}
+
+impl FailureClass {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FailureClass::Denied => "denied",
+            FailureClass::Expected => "expected",
+            FailureClass::Unexpected => "unexpected",
+        }
+    }
+
+    /// Operator-facing label. Rendered next to the count so "12 denied" is
+    /// never mistaken for "12 things broke".
+    pub fn label(self) -> &'static str {
+        match self {
+            FailureClass::Denied => "policy denial",
+            FailureClass::Expected => "expected negative path",
+            FailureClass::Unexpected => "unexpected failure",
+        }
+    }
+}
+
+/// Message fragments that mark a documented negative path. Each mirrors an
+/// `OrbitError` variant's `Display` rendering in `orbit-common`, which every
+/// surface funnels its errors through before they reach `error_message`.
+/// Matching is lowercase substring, so a wrapped/prefixed message still
+/// classifies.
+const EXPECTED_FAILURE_MARKERS: &[&str] = &[
+    "invalid input",
+    "not found",
+    "already exists",
+    "validation failed",
+    "sensitive input rejected",
+    "invalid status transition",
+    "unsupported",
+    "not local to the current worktree",
+    "artifact unavailable",
+];
+
+/// Message fragments that mark a refusal rather than a failure. A refusal
+/// recorded with `status = failure` (some surfaces translate late) still
+/// classifies as a denial so the two populations do not blur.
+const DENIAL_MARKERS: &[&str] = &["policy denied", "capability denied", "permission denied"];
+
+/// One raw audit row referenced by an incident. Enough to identify the exact
+/// underlying evidence and jump to it in the raw Audit view.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IncidentEventRef {
+    pub id: i64,
+    pub ts: DateTime<Utc>,
+    pub execution_id: String,
+    pub status: String,
+    pub role: String,
+    pub surface: String,
+    pub run_id: Option<String>,
+    pub task_id: Option<String>,
+    pub activity_id: Option<String>,
+    pub message: Option<String>,
+}
+
+/// One downstream link of a cascade: a distinct failure signature that
+/// followed the incident's root within the same run and cascade window.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PropagationLink {
+    pub signature: String,
+    /// Surface (tool name, or `command`/`subcommand`) that reported it.
+    pub surface: String,
+    /// Enclosing activity/step id when the audit row carried one.
+    pub activity_id: Option<String>,
+    pub event_count: u64,
+    pub first_ts: DateTime<Utc>,
+    pub last_ts: DateTime<Utc>,
+    pub message: Option<String>,
+    pub sample_events: Vec<IncidentEventRef>,
+}
+
+/// A grouped failure incident: one root cause, its raw event population, and
+/// the propagation chain it triggered.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FailureIncident {
+    /// Deterministic id derived from the grouping key. Stable across repeated
+    /// aggregation of the same rows; never a database identifier.
+    pub incident_id: String,
+    /// Human-readable grouping key. Shown in the UI so an operator can see
+    /// *why* these rows were grouped.
+    pub signature: String,
+    pub class: FailureClass,
+    pub role: String,
+    pub surface: String,
+    pub activity_id: Option<String>,
+    pub message: Option<String>,
+    /// Raw audit rows collapsed into this incident, including its
+    /// propagation chain. This is the forensic count.
+    pub event_count: u64,
+    /// Raw audit rows matching the root signature alone.
+    pub root_event_count: u64,
+    pub first_ts: DateTime<Utc>,
+    pub last_ts: DateTime<Utc>,
+    pub run_ids: Vec<String>,
+    pub task_ids: Vec<String>,
+    /// Bounded sample of the root's raw rows, newest first.
+    pub sample_events: Vec<IncidentEventRef>,
+    /// Downstream failures collapsed beneath the root, in occurrence order.
+    pub propagation: Vec<PropagationLink>,
+}
+
+impl FailureIncident {
+    /// Raw rows attributed to the propagation chain only.
+    pub fn propagated_event_count(&self) -> u64 {
+        self.event_count.saturating_sub(self.root_event_count)
+    }
+}
+
+/// Window and scope for a failure-incident aggregation.
+#[derive(Debug, Clone, Default)]
+pub struct FailureIncidentQuery {
+    pub since: Option<DateTime<Utc>>,
+    pub until: Option<DateTime<Utc>>,
+    pub role: Option<String>,
+    pub workspace_id: Option<String>,
+    /// Cap on raw rows scanned. `0` applies [`DEFAULT_SCAN_LIMIT`].
+    pub max_events: usize,
+}
+
+/// Default cap on raw failure rows scanned for one aggregation.
+pub const DEFAULT_SCAN_LIMIT: usize = 20_000;
+
+/// Result of one aggregation: the incidents plus the raw denominators they
+/// were derived from, so no surface has to re-derive (or guess) them.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FailureIncidentReport {
+    pub incidents: Vec<FailureIncident>,
+    /// Raw failed audit rows considered (all classes).
+    pub raw_failed_events: u64,
+    /// Raw rows per class, keyed by [`FailureClass::as_str`].
+    pub raw_events_by_class: BTreeMap<String, u64>,
+    /// Incident count per class.
+    pub incidents_by_class: BTreeMap<String, u64>,
+    /// True when the scan hit `max_events` and older rows were not read.
+    pub truncated: bool,
+}
+
+impl FailureIncidentReport {
+    pub fn incident_count(&self) -> u64 {
+        self.incidents.len() as u64
+    }
+}
+
+impl Store {
+    /// Failure incidents over the audit rows matching `query`.
+    ///
+    /// Reads only `status IN ('failure', 'denied')` rows; success rows are
+    /// never touched, and no row is mutated or hidden.
+    pub fn get_failure_incidents(
+        &self,
+        query: &FailureIncidentQuery,
+    ) -> Result<FailureIncidentReport, OrbitError> {
+        let max_events = if query.max_events == 0 {
+            DEFAULT_SCAN_LIMIT
+        } else {
+            query.max_events
+        };
+
+        let conn = self.read()?;
+        let mut conditions = vec!["status != 'success'".to_string()];
+        let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        if let Some(since) = query.since {
+            conditions.push(format!("timestamp >= ?{}", param_values.len() + 1));
+            param_values.push(Box::new(since.to_rfc3339()));
+        }
+        if let Some(until) = query.until {
+            conditions.push(format!("timestamp <= ?{}", param_values.len() + 1));
+            param_values.push(Box::new(until.to_rfc3339()));
+        }
+        if let Some(role) = query.role.as_deref().filter(|role| !role.is_empty()) {
+            conditions.push(format!("role = ?{}", param_values.len() + 1));
+            param_values.push(Box::new(role.to_string()));
+        }
+        if let Some(workspace_id) = query
+            .workspace_id
+            .as_deref()
+            .filter(|workspace_id| !workspace_id.is_empty())
+        {
+            conditions.push(format!("workspace_id = ?{}", param_values.len() + 1));
+            param_values.push(Box::new(workspace_id.to_string()));
+        }
+
+        let sql = format!(
+            "SELECT {AUDIT_EVENT_COLUMNS} FROM audit_events WHERE {} \
+             ORDER BY id DESC LIMIT ?{}",
+            conditions.join(" AND "),
+            param_values.len() + 1
+        );
+        param_values.push(Box::new(max_events as i64));
+
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            param_values.iter().map(|value| value.as_ref()).collect();
+        let failures = stmt
+            .query_map(param_refs.as_slice(), audit_event_from_row)
+            .map_err(|e| OrbitError::Store(e.to_string()))?
+            .collect::<Result<Vec<AuditEvent>, _>>()
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        let truncated = failures.len() >= max_events;
+        Ok(build_report(&failures, truncated))
+    }
+}
+
+/// Groups already-filtered failure rows into a report. Split out from the
+/// store call so the contract is testable without a database.
+pub fn build_report(failures: &[AuditEvent], truncated: bool) -> FailureIncidentReport {
+    let incidents = group_failure_incidents(failures);
+
+    let mut raw_events_by_class: BTreeMap<String, u64> = BTreeMap::new();
+    for event in failures {
+        *raw_events_by_class
+            .entry(classify(event).as_str().to_string())
+            .or_insert(0) += 1;
+    }
+    let mut incidents_by_class: BTreeMap<String, u64> = BTreeMap::new();
+    for incident in &incidents {
+        *incidents_by_class
+            .entry(incident.class.as_str().to_string())
+            .or_insert(0) += 1;
+    }
+
+    FailureIncidentReport {
+        raw_failed_events: failures.len() as u64,
+        raw_events_by_class,
+        incidents_by_class,
+        incidents,
+        truncated,
+    }
+}
+
+/// Classifies one failed audit row. Denial status wins outright; otherwise the
+/// `OrbitError`-derived markers decide whether this was a documented negative
+/// path. Anything unmatched is treated as unexpected — the conservative
+/// direction, since under-reporting a real failure is the costlier mistake.
+pub fn classify(event: &AuditEvent) -> FailureClass {
+    if matches!(event.status, AuditEventStatus::Denied) {
+        return FailureClass::Denied;
+    }
+    let message = event
+        .error_message
+        .as_deref()
+        .unwrap_or_default()
+        .to_lowercase();
+    if message.is_empty() {
+        return FailureClass::Unexpected;
+    }
+    if DENIAL_MARKERS.iter().any(|marker| message.contains(marker)) {
+        return FailureClass::Denied;
+    }
+    if EXPECTED_FAILURE_MARKERS
+        .iter()
+        .any(|marker| message.contains(marker))
+    {
+        return FailureClass::Expected;
+    }
+    FailureClass::Unexpected
+}
+
+/// The reporting surface of an audit row: its tool name when it has one,
+/// otherwise its `command`/`subcommand` pair. Never empty.
+fn surface_of(event: &AuditEvent) -> String {
+    if let Some(tool) = event.tool_name.as_deref().filter(|name| !name.is_empty()) {
+        return tool.to_string();
+    }
+    match event.subcommand.as_deref().filter(|sub| !sub.is_empty()) {
+        Some(sub) if !event.command.is_empty() => format!("{} {sub}", event.command),
+        Some(sub) => sub.to_string(),
+        None if !event.command.is_empty() => event.command.clone(),
+        None => "unknown".to_string(),
+    }
+}
+
+/// Replaces volatile tokens in an error message so that the same failure over
+/// different operands collapses to one signature.
+///
+/// The rules are shape-based only — no vocabulary from any project, tool, or
+/// agent appears here.
+pub fn normalize_message(raw: &str) -> String {
+    let mut out = String::new();
+    for token in raw.split_whitespace() {
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(&normalize_token(token));
+        if out.chars().count() >= MAX_SIGNATURE_MESSAGE_CHARS {
+            break;
+        }
+    }
+    if out.chars().count() > MAX_SIGNATURE_MESSAGE_CHARS {
+        out = out.chars().take(MAX_SIGNATURE_MESSAGE_CHARS).collect();
+    }
+    out
+}
+
+fn normalize_token(token: &str) -> Cow<'_, str> {
+    let trimmed = token.trim_matches(['"', '\'', '`', '(', ')', ',']);
+    if trimmed.is_empty() {
+        return Cow::Borrowed(token);
+    }
+    // Order matters: the most specific shapes are tested first so a token that
+    // satisfies several rules gets its most informative placeholder.
+    if looks_like_timestamp(trimmed) {
+        return Cow::Borrowed("<ts>");
+    }
+    if looks_like_uuid(trimmed) {
+        return Cow::Borrowed("<uuid>");
+    }
+    if looks_like_prefixed_id(trimmed) {
+        return Cow::Borrowed("<id>");
+    }
+    if looks_like_path(trimmed) {
+        return Cow::Borrowed("<path>");
+    }
+    if looks_like_hex(trimmed) {
+        return Cow::Borrowed("<hex>");
+    }
+    if looks_like_number(trimmed) {
+        return Cow::Borrowed("<num>");
+    }
+    Cow::Owned(trimmed.to_string())
+}
+
+/// `2026-08-15T06:34:00Z` and friends: leading four digits, a `-`, and a
+/// digit-dominated body.
+fn looks_like_timestamp(token: &str) -> bool {
+    let bytes = token.as_bytes();
+    bytes.len() >= 10
+        && bytes[..4].iter().all(u8::is_ascii_digit)
+        && bytes[4] == b'-'
+        && token.chars().filter(char::is_ascii_digit).count() >= 8
+}
+
+fn looks_like_uuid(token: &str) -> bool {
+    let groups: Vec<&str> = token.split('-').collect();
+    groups.len() == 5
+        && [8_usize, 4, 4, 4, 12]
+            .iter()
+            .zip(&groups)
+            .all(|(len, group)| group.len() == *len && group.chars().all(|c| c.is_ascii_hexdigit()))
+}
+
+/// `ABC-1234`, `T20260428-7`, `jrun-20260816-0634-8`: an alphanumeric stem
+/// joined to a digit run. Covers generated record ids of any project without
+/// naming one.
+fn looks_like_prefixed_id(token: &str) -> bool {
+    let Some((head, tail)) = token.split_once('-') else {
+        return false;
+    };
+    if head.is_empty() || !head.chars().all(|c| c.is_ascii_alphanumeric()) {
+        return false;
+    }
+    if !head.chars().any(|c| c.is_ascii_alphabetic()) {
+        return false;
+    }
+    let rest: String = tail.chars().filter(|c| *c != '-').collect();
+    !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit())
+}
+
+fn looks_like_path(token: &str) -> bool {
+    token.contains('/') || token.starts_with('~') || token.contains('\\')
+}
+
+fn looks_like_hex(token: &str) -> bool {
+    token.len() >= 8
+        && token.chars().all(|c| c.is_ascii_hexdigit())
+        && token.chars().any(|c| c.is_ascii_alphabetic())
+}
+
+fn looks_like_number(token: &str) -> bool {
+    let stripped = token.trim_end_matches(['.', ':', ';']);
+    !stripped.is_empty()
+        && stripped
+            .chars()
+            .all(|c| c.is_ascii_digit() || matches!(c, '.' | ',' | '_' | '-' | '+'))
+        && stripped.chars().any(|c| c.is_ascii_digit())
+}
+
+/// The grouping signature for one failed row: class, actor, surface, and the
+/// normalized message. Rendered as a readable string so the UI can show the
+/// operator exactly what was collapsed.
+pub fn signature_for(event: &AuditEvent) -> String {
+    let class = classify(event);
+    let message = normalize_message(event.error_message.as_deref().unwrap_or_default());
+    format!(
+        "{}|role={}|surface={}|msg={}",
+        class.as_str(),
+        if event.role.is_empty() {
+            "unknown"
+        } else {
+            event.role.as_str()
+        },
+        surface_of(event),
+        if message.is_empty() {
+            format!("exit={}", event.exit_code)
+        } else {
+            message
+        }
+    )
+}
+
+/// Deterministic 64-bit FNV-1a over the grouping key, rendered as hex. Used
+/// only as a stable client-side handle for an incident — never persisted, and
+/// never a security boundary.
+fn incident_id(run_scope: &str, signature: &str, first_ts: DateTime<Utc>) -> String {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    let key = format!(
+        "{run_scope}\u{1f}{signature}\u{1f}{}",
+        first_ts.to_rfc3339()
+    );
+    for byte in key.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("inc-{hash:016x}")
+}
+
+/// One `(run scope, signature)` bucket before cascade collapsing.
+#[derive(Debug, Clone)]
+struct Cluster {
+    signature: String,
+    class: FailureClass,
+    role: String,
+    surface: String,
+    activity_id: Option<String>,
+    message: Option<String>,
+    event_count: u64,
+    first_ts: DateTime<Utc>,
+    last_ts: DateTime<Utc>,
+    run_ids: Vec<String>,
+    task_ids: Vec<String>,
+    sample_events: Vec<IncidentEventRef>,
+}
+
+impl Cluster {
+    fn absorb(&mut self, event: &AuditEvent) {
+        self.event_count += 1;
+        self.first_ts = self.first_ts.min(event.timestamp);
+        self.last_ts = self.last_ts.max(event.timestamp);
+        if self.activity_id.is_none() {
+            self.activity_id.clone_from(&event.activity_id);
+        }
+        if self.message.is_none() {
+            self.message.clone_from(&event.error_message);
+        }
+        push_unique(&mut self.run_ids, event.job_run_id.as_deref());
+        push_unique(&mut self.task_ids, event.task_id.as_deref());
+        if self.sample_events.len() < MAX_SAMPLE_EVENTS {
+            self.sample_events.push(event_ref(event));
+        }
+    }
+
+    fn into_link(mut self) -> PropagationLink {
+        sort_samples(&mut self.sample_events);
+        PropagationLink {
+            signature: self.signature,
+            surface: self.surface,
+            activity_id: self.activity_id,
+            event_count: self.event_count,
+            first_ts: self.first_ts,
+            last_ts: self.last_ts,
+            message: self.message,
+            sample_events: self.sample_events,
+        }
+    }
+}
+
+fn push_unique(target: &mut Vec<String>, value: Option<&str>) {
+    let Some(value) = value.filter(|value| !value.is_empty()) else {
+        return;
+    };
+    if !target.iter().any(|existing| existing == value) {
+        target.push(value.to_string());
+    }
+}
+
+fn event_ref(event: &AuditEvent) -> IncidentEventRef {
+    IncidentEventRef {
+        id: event.id,
+        ts: event.timestamp,
+        execution_id: event.execution_id.clone(),
+        status: event.status.to_string(),
+        role: event.role.clone(),
+        surface: surface_of(event),
+        run_id: event.job_run_id.clone(),
+        task_id: event.task_id.clone(),
+        activity_id: event.activity_id.clone(),
+        message: event.error_message.clone(),
+    }
+}
+
+/// Newest raw evidence first, ties broken by id so a page is stable.
+fn sort_samples(samples: &mut [IncidentEventRef]) {
+    samples.sort_by(|a, b| b.ts.cmp(&a.ts).then_with(|| b.id.cmp(&a.id)));
+}
+
+/// Groups failed audit rows into incidents. Pure and order-independent: the
+/// same rows in any input order produce the same incidents.
+pub fn group_failure_incidents(failures: &[AuditEvent]) -> Vec<FailureIncident> {
+    // Pass 1+2 — cluster by (run scope, signature).
+    let mut clusters: BTreeMap<(String, String), Cluster> = BTreeMap::new();
+    for event in failures {
+        let signature = signature_for(event);
+        let run_scope = event
+            .job_run_id
+            .clone()
+            .filter(|run| !run.is_empty())
+            .unwrap_or_default();
+        clusters
+            .entry((run_scope, signature.clone()))
+            .and_modify(|cluster| cluster.absorb(event))
+            .or_insert_with(|| {
+                let mut cluster = Cluster {
+                    signature,
+                    class: classify(event),
+                    role: event.role.clone(),
+                    surface: surface_of(event),
+                    activity_id: None,
+                    message: None,
+                    event_count: 0,
+                    first_ts: event.timestamp,
+                    last_ts: event.timestamp,
+                    run_ids: Vec::new(),
+                    task_ids: Vec::new(),
+                    sample_events: Vec::new(),
+                };
+                cluster.absorb(event);
+                cluster
+            });
+    }
+
+    // Pass 3 — collapse same-run, same-class cascades onto their earliest
+    // cluster. Clusters with no run id cannot be attributed to a pipeline, so
+    // each stays its own incident (still deduplicated by signature above).
+    let mut by_scope: BTreeMap<String, Vec<Cluster>> = BTreeMap::new();
+    let mut incidents = Vec::new();
+    for ((run_scope, _), cluster) in clusters {
+        if run_scope.is_empty() {
+            incidents.push(incident_from(&run_scope, cluster, Vec::new()));
+        } else {
+            by_scope.entry(run_scope).or_default().push(cluster);
+        }
+    }
+
+    let cascade_window = Duration::seconds(CASCADE_WINDOW_SECS);
+    for (run_scope, scope_clusters) in by_scope {
+        for (_, mut class_clusters) in partition_by_class(scope_clusters) {
+            class_clusters.sort_by(|a, b| {
+                a.first_ts
+                    .cmp(&b.first_ts)
+                    .then_with(|| a.signature.cmp(&b.signature))
+            });
+            let mut iter = class_clusters.into_iter();
+            let Some(mut root) = iter.next() else {
+                continue;
+            };
+            let mut chain: Vec<Cluster> = Vec::new();
+            let mut chain_end = root.last_ts;
+            for cluster in iter {
+                if cluster.first_ts - chain_end <= cascade_window {
+                    chain_end = chain_end.max(cluster.last_ts);
+                    chain.push(cluster);
+                    continue;
+                }
+                incidents.push(incident_from(&run_scope, root, std::mem::take(&mut chain)));
+                chain_end = cluster.last_ts;
+                root = cluster;
+            }
+            incidents.push(incident_from(&run_scope, root, chain));
+        }
+    }
+
+    // Newest incident first; the deterministic id breaks ties so two incidents
+    // sharing a last-seen timestamp never swap places between renders.
+    incidents.sort_by(|a, b| {
+        b.last_ts
+            .cmp(&a.last_ts)
+            .then_with(|| a.incident_id.cmp(&b.incident_id))
+    });
+    incidents
+}
+
+fn partition_by_class(clusters: Vec<Cluster>) -> BTreeMap<FailureClass, Vec<Cluster>> {
+    let mut out: BTreeMap<FailureClass, Vec<Cluster>> = BTreeMap::new();
+    for cluster in clusters {
+        out.entry(cluster.class).or_default().push(cluster);
+    }
+    out
+}
+
+fn incident_from(run_scope: &str, root: Cluster, chain: Vec<Cluster>) -> FailureIncident {
+    let mut root = root;
+    sort_samples(&mut root.sample_events);
+    let mut event_count = root.event_count;
+    let mut last_ts = root.last_ts;
+    let mut run_ids = root.run_ids.clone();
+    let mut task_ids = root.task_ids.clone();
+
+    let mut propagation: Vec<PropagationLink> = Vec::with_capacity(chain.len());
+    for cluster in chain {
+        event_count += cluster.event_count;
+        last_ts = last_ts.max(cluster.last_ts);
+        for run_id in &cluster.run_ids {
+            push_unique(&mut run_ids, Some(run_id));
+        }
+        for task_id in &cluster.task_ids {
+            push_unique(&mut task_ids, Some(task_id));
+        }
+        propagation.push(cluster.into_link());
+    }
+    propagation.sort_by(|a, b| {
+        a.first_ts
+            .cmp(&b.first_ts)
+            .then_with(|| a.signature.cmp(&b.signature))
+    });
+
+    FailureIncident {
+        incident_id: incident_id(run_scope, &root.signature, root.first_ts),
+        signature: root.signature,
+        class: root.class,
+        role: root.role,
+        surface: root.surface,
+        activity_id: root.activity_id,
+        message: root.message,
+        event_count,
+        root_event_count: root.event_count,
+        first_ts: root.first_ts,
+        last_ts,
+        run_ids,
+        task_ids,
+        sample_events: root.sample_events,
+        propagation,
+    }
+}

--- a/crates/orbit-store/src/sqlite/audit_event_store/mod.rs
+++ b/crates/orbit-store/src/sqlite/audit_event_store/mod.rs
@@ -13,6 +13,19 @@ use rusqlite::params;
 
 use crate::{Store, StoreTx, now_string, parse_timestamp};
 
+pub mod incident;
+
+/// Canonical `SELECT` column list for a full [`AuditEvent`] row, in the order
+/// [`audit_event_from_row`] indexes. Shared by every query that hydrates whole
+/// events so a schema column can only be added in one place.
+pub(super) const AUDIT_EVENT_COLUMNS: &str = "id, execution_id, timestamp, command, subcommand, \
+     tool_name, target_type, target_id, role, status, exit_code, duration_ms, \
+     working_directory, arguments_json, stdout_truncated, stderr_truncated, \
+     error_message, host, pid, session_id, workspace_id, caller_machine_id, \
+     caller_host_id, process_machine_id, process_host_id, transport, \
+     capabilities_json, origin_session_id, mcp_call_id, lease_id, task_id, \
+     job_run_id, activity_id, step_index, trace_id, caller_ip";
+
 #[derive(Debug, Clone)]
 pub struct AuditEventInsertParams {
     pub execution_id: String,
@@ -391,13 +404,7 @@ impl Store {
         };
 
         let sql = format!(
-            "SELECT id, execution_id, timestamp, command, subcommand, tool_name, \
-             target_type, target_id, role, status, exit_code, duration_ms, \
-             working_directory, arguments_json, stdout_truncated, stderr_truncated, \
-             error_message, host, pid, session_id, workspace_id, caller_machine_id, \
-             caller_host_id, process_machine_id, process_host_id, transport, \
-             capabilities_json, origin_session_id, mcp_call_id, lease_id, task_id, \
-             job_run_id, activity_id, step_index, trace_id, caller_ip \
+            "SELECT {AUDIT_EVENT_COLUMNS} \
              FROM audit_events {where_clause} ORDER BY id DESC LIMIT ?{}",
             param_values.len() + 1
         );
@@ -423,16 +430,9 @@ impl Store {
         let conn = self.read()?;
 
         let mut stmt = conn
-            .prepare(
-                "SELECT id, execution_id, timestamp, command, subcommand, tool_name, \
-                 target_type, target_id, role, status, exit_code, duration_ms, \
-                 working_directory, arguments_json, stdout_truncated, stderr_truncated, \
-                 error_message, host, pid, session_id, workspace_id, caller_machine_id, \
-                 caller_host_id, process_machine_id, process_host_id, transport, \
-                 capabilities_json, origin_session_id, mcp_call_id, lease_id, task_id, \
-                 job_run_id, activity_id, step_index, trace_id, caller_ip \
-                 FROM audit_events WHERE id = ?1",
-            )
+            .prepare(&format!(
+                "SELECT {AUDIT_EVENT_COLUMNS} FROM audit_events WHERE id = ?1"
+            ))
             .map_err(|e| OrbitError::Store(e.to_string()))?;
 
         let result = stmt

--- a/crates/orbit-store/src/sqlite/audit_event_store/tests/incident.rs
+++ b/crates/orbit-store/src/sqlite/audit_event_store/tests/incident.rs
@@ -1,0 +1,505 @@
+//! Failure-incident grouping contract [ORB-10871].
+//!
+//! Every fixture below is synthetic: tool names, roles, run ids, and messages
+//! are generic placeholders, so the contract these tests pin is the grouping
+//! *shape*, never a value observed in one workspace.
+
+use std::collections::BTreeSet;
+
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use orbit_common::types::{AuditEvent, AuditEventStatus};
+
+use crate::Store;
+use crate::sqlite::audit_event_store::incident::{
+    CASCADE_WINDOW_SECS, FailureClass, FailureIncidentQuery, build_report, group_failure_incidents,
+    normalize_message, signature_for,
+};
+
+use super::super::AuditEventInsertParams;
+
+fn base_ts() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2031, 3, 4, 5, 0, 0)
+        .single()
+        .expect("fixed test timestamp")
+}
+
+struct FailureFixture {
+    id: i64,
+    offset_secs: i64,
+    tool: &'static str,
+    role: &'static str,
+    status: AuditEventStatus,
+    message: Option<String>,
+    run_id: Option<&'static str>,
+    activity_id: Option<&'static str>,
+}
+
+impl FailureFixture {
+    fn new(id: i64, offset_secs: i64, tool: &'static str) -> Self {
+        Self {
+            id,
+            offset_secs,
+            tool,
+            role: "actor-one",
+            status: AuditEventStatus::Failure,
+            message: Some("operation failed".to_string()),
+            run_id: None,
+            activity_id: None,
+        }
+    }
+
+    fn role(mut self, role: &'static str) -> Self {
+        self.role = role;
+        self
+    }
+
+    fn status(mut self, status: AuditEventStatus) -> Self {
+        self.status = status;
+        self
+    }
+
+    fn message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+
+    fn run(mut self, run_id: &'static str, activity_id: &'static str) -> Self {
+        self.run_id = Some(run_id);
+        self.activity_id = Some(activity_id);
+        self
+    }
+
+    fn build(self) -> AuditEvent {
+        AuditEvent {
+            id: self.id,
+            execution_id: format!("exec-{}", self.id),
+            timestamp: base_ts() + Duration::seconds(self.offset_secs),
+            command: "tool".to_string(),
+            subcommand: Some("run".to_string()),
+            tool_name: Some(self.tool.to_string()),
+            target_type: Some("tool".to_string()),
+            target_id: Some(self.tool.to_string()),
+            role: self.role.to_string(),
+            status: self.status,
+            exit_code: 1,
+            duration_ms: 5,
+            working_directory: "/workdir".to_string(),
+            arguments_json: None,
+            stdout_truncated: None,
+            stderr_truncated: None,
+            error_message: self.message,
+            host: None,
+            pid: 1,
+            session_id: None,
+            workspace_id: Some("ws-one".to_string()),
+            caller_machine_id: None,
+            caller_host_id: None,
+            process_machine_id: None,
+            process_host_id: None,
+            transport: None,
+            effective_capabilities: BTreeSet::new(),
+            origin_session_id: None,
+            mcp_call_id: None,
+            trace_id: None,
+            caller_ip: None,
+            lease_id: None,
+            task_id: Some("REC-1".to_string()),
+            job_run_id: self.run_id.map(str::to_string),
+            activity_id: self.activity_id.map(str::to_string),
+            step_index: None,
+        }
+    }
+}
+
+#[test]
+fn burst_of_identical_failures_collapses_into_one_incident_carrying_its_raw_count() {
+    // 300 refusals of the same shape, differing only in the operand path — the
+    // exact pattern that made a single burst read as hundreds of failures.
+    let failures: Vec<AuditEvent> = (0..300)
+        .map(|index| {
+            FailureFixture::new(index, index, "surface.alpha")
+                .message(format!("could not remove /work/dir-{index}/file.txt"))
+                .build()
+        })
+        .collect();
+
+    let report = build_report(&failures, false);
+
+    assert_eq!(report.incident_count(), 1, "one burst is one incident");
+    assert_eq!(report.raw_failed_events, 300, "no raw evidence is dropped");
+    let incident = &report.incidents[0];
+    assert_eq!(incident.event_count, 300);
+    assert_eq!(incident.root_event_count, 300);
+    assert_eq!(incident.first_ts, base_ts());
+    assert_eq!(incident.last_ts, base_ts() + Duration::seconds(299));
+    assert!(
+        incident.signature.contains("<path>"),
+        "the volatile operand must be normalized out of the signature: {}",
+        incident.signature
+    );
+    assert!(
+        incident.sample_events.len() <= 20 && !incident.sample_events.is_empty(),
+        "a bounded sample of the underlying rows must be reachable"
+    );
+}
+
+#[test]
+fn unrelated_failures_remain_separate_incidents() {
+    let failures = vec![
+        FailureFixture::new(1, 0, "surface.alpha")
+            .message("could not remove /work/a.txt")
+            .build(),
+        FailureFixture::new(2, 1, "surface.beta")
+            .message("connection reset by peer")
+            .build(),
+        FailureFixture::new(3, 2, "surface.alpha")
+            .role("actor-two")
+            .message("could not remove /work/b.txt")
+            .build(),
+    ];
+
+    let report = build_report(&failures, false);
+
+    assert_eq!(
+        report.incident_count(),
+        3,
+        "different surface, message, or actor must not be merged"
+    );
+    assert!(report.incidents.iter().all(|i| i.event_count == 1));
+}
+
+#[test]
+fn cascading_run_failures_expose_one_root_with_the_chain_collapsed_beneath_it() {
+    // One failed run whose failure propagates up three enclosing steps. Each
+    // layer writes its own audit row; only the first is a root cause.
+    let failures = vec![
+        FailureFixture::new(1, 0, "step.inner")
+            .message("child step returned a nonzero status")
+            .run("run-one", "step-inner")
+            .build(),
+        FailureFixture::new(2, 1, "step.middle")
+            .message("bundle aborted after a child failure")
+            .run("run-one", "step-middle")
+            .build(),
+        FailureFixture::new(3, 2, "step.gate")
+            .message("gate refused to advance")
+            .run("run-one", "step-gate")
+            .build(),
+    ];
+
+    let report = build_report(&failures, false);
+
+    assert_eq!(report.incident_count(), 1, "one failed run is one incident");
+    let incident = &report.incidents[0];
+    assert_eq!(
+        incident.surface, "step.inner",
+        "the earliest failure is the root, not the outermost wrapper"
+    );
+    assert_eq!(incident.event_count, 3, "raw rows stay counted");
+    assert_eq!(incident.root_event_count, 1);
+    assert_eq!(incident.propagated_event_count(), 2);
+    let chain: Vec<&str> = incident
+        .propagation
+        .iter()
+        .map(|link| link.surface.as_str())
+        .collect();
+    assert_eq!(
+        chain,
+        vec!["step.middle", "step.gate"],
+        "the propagation chain is ordered by occurrence"
+    );
+    assert_eq!(incident.run_ids, vec!["run-one".to_string()]);
+}
+
+#[test]
+fn a_later_unrelated_failure_in_the_same_run_is_not_folded_into_the_cascade() {
+    let failures = vec![
+        FailureFixture::new(1, 0, "step.inner")
+            .message("child step returned a nonzero status")
+            .run("run-one", "step-inner")
+            .build(),
+        FailureFixture::new(2, 1, "step.middle")
+            .message("bundle aborted after a child failure")
+            .run("run-one", "step-middle")
+            .build(),
+        FailureFixture::new(3, CASCADE_WINDOW_SECS * 3, "step.later")
+            .message("unrelated downstream problem")
+            .run("run-one", "step-later")
+            .build(),
+    ];
+
+    let report = build_report(&failures, false);
+
+    assert_eq!(
+        report.incident_count(),
+        2,
+        "a failure beyond the cascade window is its own root cause"
+    );
+    let cascade = report
+        .incidents
+        .iter()
+        .find(|incident| incident.surface == "step.inner")
+        .expect("cascade incident");
+    assert_eq!(cascade.event_count, 2);
+    let later = report
+        .incidents
+        .iter()
+        .find(|incident| incident.surface == "step.later")
+        .expect("independent incident");
+    assert!(later.propagation.is_empty());
+}
+
+#[test]
+fn denials_expected_negative_paths_and_unexpected_failures_never_merge() {
+    let failures = vec![
+        FailureFixture::new(1, 0, "surface.alpha")
+            .status(AuditEventStatus::Denied)
+            .message("policy denied: write outside the allowed scope")
+            .run("run-one", "step-one")
+            .build(),
+        FailureFixture::new(2, 1, "surface.alpha")
+            .message("invalid input: field must not be empty")
+            .run("run-one", "step-one")
+            .build(),
+        FailureFixture::new(3, 2, "surface.alpha")
+            .message("internal channel closed unexpectedly")
+            .run("run-one", "step-one")
+            .build(),
+    ];
+
+    let report = build_report(&failures, false);
+
+    assert_eq!(report.incident_count(), 3);
+    let classes: BTreeSet<FailureClass> = report
+        .incidents
+        .iter()
+        .map(|incident| incident.class)
+        .collect();
+    assert_eq!(
+        classes,
+        BTreeSet::from([
+            FailureClass::Denied,
+            FailureClass::Expected,
+            FailureClass::Unexpected
+        ]),
+        "same run and same surface must not blur the three failure classes"
+    );
+    assert_eq!(report.raw_events_by_class.get("denied"), Some(&1));
+    assert_eq!(report.raw_events_by_class.get("expected"), Some(&1));
+    assert_eq!(report.raw_events_by_class.get("unexpected"), Some(&1));
+    assert_eq!(report.incidents_by_class.get("unexpected"), Some(&1));
+}
+
+#[test]
+fn a_denial_recorded_with_failure_status_still_classifies_as_a_denial() {
+    let failures = vec![
+        FailureFixture::new(1, 0, "surface.alpha")
+            .message("capability denied: caller lacks the required capability")
+            .build(),
+    ];
+
+    let report = build_report(&failures, false);
+
+    assert_eq!(report.incidents[0].class, FailureClass::Denied);
+}
+
+#[test]
+fn grouping_is_order_independent_and_ids_are_stable() {
+    let mut failures = vec![
+        FailureFixture::new(1, 0, "surface.alpha")
+            .message("could not remove /work/a.txt")
+            .build(),
+        FailureFixture::new(2, 5, "surface.beta")
+            .message("connection reset by peer")
+            .run("run-one", "step-one")
+            .build(),
+        FailureFixture::new(3, 6, "surface.gamma")
+            .message("aborting after upstream failure")
+            .run("run-one", "step-two")
+            .build(),
+    ];
+
+    let first = group_failure_incidents(&failures);
+    failures.reverse();
+    let second = group_failure_incidents(&failures);
+
+    assert_eq!(first, second, "input order must not change the grouping");
+    assert!(
+        first
+            .iter()
+            .all(|incident| incident.incident_id.starts_with("inc-")),
+        "every incident carries a deterministic handle"
+    );
+}
+
+#[test]
+fn message_normalization_replaces_volatile_tokens_only() {
+    assert_eq!(
+        normalize_message("could not remove /work/dir-9/file.txt after 4 tries"),
+        "could not remove <path> after <num> tries"
+    );
+    assert_eq!(
+        normalize_message("run REC-42 at 2031-03-04T05:00:00Z failed"),
+        "run <id> at <ts> failed"
+    );
+    assert_eq!(
+        normalize_message("digest 0a1b2c3d4e5f6789 mismatch"),
+        "digest <hex> mismatch"
+    );
+    assert_eq!(
+        normalize_message("session 123e4567-e89b-12d3-a456-426614174000 expired"),
+        "session <uuid> expired"
+    );
+}
+
+#[test]
+fn a_failure_without_a_message_groups_on_its_exit_code() {
+    let event = FailureFixture::new(1, 0, "surface.alpha");
+    let mut event = event.build();
+    event.error_message = None;
+
+    let signature = signature_for(&event);
+
+    assert!(
+        signature.contains("exit=1"),
+        "an empty message must still yield a usable signature: {signature}"
+    );
+}
+
+#[test]
+fn the_store_query_groups_failures_without_hiding_any_audit_row() {
+    let store = Store::open_in_memory().expect("open store");
+    let insert = |execution_id: &str, status: AuditEventStatus, message: Option<&str>| {
+        store
+            .insert_audit_event_record(&AuditEventInsertParams {
+                execution_id: execution_id.to_string(),
+                command: "tool".to_string(),
+                subcommand: Some("run".to_string()),
+                tool_name: Some("surface.alpha".to_string()),
+                target_type: Some("tool".to_string()),
+                target_id: Some("surface.alpha".to_string()),
+                role: "actor-one".to_string(),
+                status,
+                exit_code: if matches!(status, AuditEventStatus::Success) {
+                    0
+                } else {
+                    1
+                },
+                duration_ms: 3,
+                working_directory: "/workdir".to_string(),
+                arguments_json: None,
+                stdout_truncated: None,
+                stderr_truncated: None,
+                error_message: message.map(str::to_string),
+                host: None,
+                pid: 1,
+                session_id: None,
+                workspace_id: Some("ws-one".to_string()),
+                caller_machine_id: None,
+                caller_host_id: None,
+                process_machine_id: None,
+                process_host_id: None,
+                transport: None,
+                effective_capabilities: BTreeSet::new(),
+                origin_session_id: None,
+                mcp_call_id: None,
+                lease_id: None,
+                task_id: None,
+                job_run_id: None,
+                activity_id: None,
+                step_index: None,
+            })
+            .expect("insert audit event");
+    };
+
+    insert("exec-ok", AuditEventStatus::Success, None);
+    for index in 0..5 {
+        insert(
+            &format!("exec-fail-{index}"),
+            AuditEventStatus::Failure,
+            Some(&format!("could not remove /work/dir-{index}/file.txt")),
+        );
+    }
+    insert(
+        "exec-denied",
+        AuditEventStatus::Denied,
+        Some("policy denied: write outside the allowed scope"),
+    );
+
+    let report = store
+        .get_failure_incidents(&FailureIncidentQuery::default())
+        .expect("failure incidents");
+
+    assert_eq!(report.raw_failed_events, 6, "success rows are not counted");
+    assert_eq!(
+        report.incident_count(),
+        2,
+        "the burst collapses; the denial stays separate"
+    );
+    assert!(!report.truncated);
+
+    let all_rows = store
+        .list_audit_events(&super::super::AuditEventFilter {
+            limit: 100,
+            ..Default::default()
+        })
+        .expect("raw audit rows");
+    assert_eq!(
+        all_rows.len(),
+        7,
+        "grouping must not remove anything from the raw audit view"
+    );
+}
+
+#[test]
+fn a_truncated_scan_is_reported_rather_than_silently_capped() {
+    let store = Store::open_in_memory().expect("open store");
+    for index in 0..3 {
+        store
+            .insert_audit_event_record(&AuditEventInsertParams {
+                execution_id: format!("exec-{index}"),
+                command: "tool".to_string(),
+                subcommand: Some("run".to_string()),
+                tool_name: Some("surface.alpha".to_string()),
+                target_type: Some("tool".to_string()),
+                target_id: Some("surface.alpha".to_string()),
+                role: "actor-one".to_string(),
+                status: AuditEventStatus::Failure,
+                exit_code: 1,
+                duration_ms: 3,
+                working_directory: "/workdir".to_string(),
+                arguments_json: None,
+                stdout_truncated: None,
+                stderr_truncated: None,
+                error_message: Some("operation failed".to_string()),
+                host: None,
+                pid: 1,
+                session_id: None,
+                workspace_id: None,
+                caller_machine_id: None,
+                caller_host_id: None,
+                process_machine_id: None,
+                process_host_id: None,
+                transport: None,
+                effective_capabilities: BTreeSet::new(),
+                origin_session_id: None,
+                mcp_call_id: None,
+                lease_id: None,
+                task_id: None,
+                job_run_id: None,
+                activity_id: None,
+                step_index: None,
+            })
+            .expect("insert audit event");
+    }
+
+    let report = store
+        .get_failure_incidents(&FailureIncidentQuery {
+            max_events: 2,
+            ..Default::default()
+        })
+        .expect("failure incidents");
+
+    assert!(report.truncated, "a capped scan must say so");
+    assert_eq!(report.raw_failed_events, 2);
+}

--- a/crates/orbit-store/src/sqlite/audit_event_store/tests/mod.rs
+++ b/crates/orbit-store/src/sqlite/audit_event_store/tests/mod.rs
@@ -1,1 +1,2 @@
 mod audit_event_store;
+mod incident;

--- a/crates/orbit-web/assets/dashboard/app.js
+++ b/crates/orbit-web/assets/dashboard/app.js
@@ -72,7 +72,7 @@ let lastTasks = [];
 // `/api/tasks/all` view, which answers a bare array with no such metadata.
 let lastTasksMeta = null;
 let lastRuns = [];
-let lastDiagnostics = { metrics: [], errors: [], implement_one: [] };
+let lastDiagnostics = { metrics: [], errors: [], incidents: null, implement_one: [] };
 let lastFrictionPayload = { stats: {}, tags: [], items: [] };
 let activeTab = "tasks";
 let activeDiagSubtab = "runs";
@@ -129,6 +129,9 @@ function diagnosticsContext() {
     getActiveDiagSubtab: () => activeDiagSubtab,
     fmtRelative,
     fmtDuration,
+    // ORB-10871: incident expansion states exact first/last timestamps, not
+    // just "3h ago" — the raw evidence has to be locatable in the Audit view.
+    fmtAbsTime,
     truncate,
     setActiveTab: sAT,
     navigateToRun: nTR,
@@ -1059,6 +1062,17 @@ function activeRefreshJobs() {
       jobs.push(
         fetchJson(`/api/diagnostics/errors?limit=${DIAG_LIMIT}`).then((rows) => {
           lastDiagnostics.errors = rows;
+          renderDiagnostics(diagnosticsContext());
+        })
+      );
+    } else if (activeDiagSubtab === "incidents") {
+      // ORB-10871: grouped failure incidents. Scoped to the shared dashboard
+      // window so the incident count and the raw failed-event count it states
+      // its denominator against are read off the same cutoff.
+      const selectedWindow = getWindow();
+      jobs.push(
+        fetchJson(`/api/audit/incidents?since=${encodeURIComponent(selectedWindow)}&limit=${DIAG_LIMIT}`).then((payload) => {
+          lastDiagnostics.incidents = payload;
           renderDiagnostics(diagnosticsContext());
         })
       );

--- a/crates/orbit-web/assets/dashboard/audit.js
+++ b/crates/orbit-web/assets/dashboard/audit.js
@@ -745,6 +745,10 @@ function navigateToDrilldown(opts = {}, ctx) {
   auditFilter.role = opts.role || null;
   auditFilter.metric = opts.metric || null;
   auditFilter.status = opts.status || null;
+  // ORB-10871: an incident names one surface, so its "open raw events" link
+  // lands on exactly the rows the incident collapsed rather than every failure
+  // by that actor.
+  auditFilter.tool = opts.tool || null;
   if (opts.window) auditFilter.since = opts.window === "all" ? null : opts.window;
   activeAuditSubtab = "events";
   syncAuditControls();

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -3789,3 +3789,95 @@
         .operation-clock-actions { align-items: stretch; }
         .operation-clock-actions > * { flex: 1 1 100%; }
       }
+
+      /* ORB-10871: grouped failure incidents (Diagnostics → Incidents).
+         Every count renders next to what it is out of, and the class chips
+         keep denials, expected negative paths, and unexpected failures
+         visually separate. */
+      .incident-summary {
+        display: flex; flex-direction: column; gap: 8px;
+        padding: 12px 14px; border-bottom: 1px solid var(--border); background: var(--bg-alt, var(--bg));
+      }
+      .incident-summary-head { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px 12px; }
+      .incident-summary-headline { color: var(--fg); font: 13px var(--font-mono); }
+      .incident-summary-denominator { color: var(--fg-dim); font: 11px/1.5 var(--font-sans); }
+      .incident-summary-window {
+        padding: 2px 7px; border: 1px solid var(--border); border-radius: 999px;
+        color: var(--fg-dim); font: 10px var(--font-mono); white-space: nowrap;
+      }
+      .incident-class-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+      .incident-class-chip {
+        padding: 2px 8px; border: 1px solid var(--border); border-left-width: 2px; border-radius: 3px;
+        color: var(--fg-dim); font: 10px var(--font-mono); white-space: nowrap;
+      }
+      .incident-class-chip.unexpected { border-left-color: var(--state-failed); }
+      .incident-class-chip.expected { border-left-color: var(--fg-dim); }
+      .incident-class-chip.denied { border-left-color: var(--state-warn, var(--accent)); }
+      .incident-truncation-note { margin: 0; color: var(--state-warn, var(--fg-dim)); font: 11px/1.5 var(--font-sans); }
+
+      .incident-list { display: flex; flex-direction: column; }
+      .incident-row { border-bottom: 1px solid var(--border); padding: 10px 14px; }
+      .incident-row.unexpected { border-left: 2px solid var(--state-failed); }
+      .incident-row.expected { border-left: 2px solid var(--fg-dim); }
+      .incident-row.denied { border-left: 2px solid var(--state-warn, var(--accent)); }
+      .incident-head {
+        display: flex; flex-wrap: wrap; align-items: center; gap: 6px 10px; width: 100%;
+        padding: 0; border: 0; background: none; color: var(--fg); text-align: left; cursor: pointer;
+      }
+      .incident-caret { color: var(--fg-dim); font: 10px var(--font-mono); }
+      .incident-class { font: 10px var(--font-mono); text-transform: lowercase; }
+      .incident-class.unexpected { color: var(--state-failed); }
+      .incident-class.expected { color: var(--fg-dim); }
+      .incident-class.denied { color: var(--state-warn, var(--accent)); }
+      .incident-surface { font: 12px var(--font-mono); overflow-wrap: anywhere; }
+      .incident-actor { color: var(--fg-dim); font: 11px var(--font-sans); }
+      .incident-count { margin-left: auto; color: var(--fg); font: 11px var(--font-mono); white-space: nowrap; }
+      .incident-when { color: var(--fg-dim); font: 10px var(--font-mono); white-space: nowrap; }
+      .incident-message {
+        margin-top: 4px; color: var(--fg-dim); font: 11px/1.5 var(--font-mono); overflow-wrap: anywhere;
+      }
+      .incident-detail {
+        display: flex; flex-direction: column; gap: 12px; margin-top: 10px;
+        padding: 10px; border: 1px solid var(--border); border-radius: 3px; overflow-x: auto;
+      }
+      .incident-facts {
+        display: grid; grid-template-columns: minmax(0, 9rem) minmax(0, 1fr); gap: 4px 12px; margin: 0;
+      }
+      .incident-facts dt { color: var(--fg-dim); font: 10px var(--font-sans); }
+      .incident-facts dd { margin: 0; color: var(--fg); font: 11px var(--font-mono); overflow-wrap: anywhere; }
+      .incident-section-title { color: var(--fg-dim); font: 10px var(--font-sans); }
+      .incident-propagation { display: flex; flex-direction: column; gap: 4px; }
+      .incident-propagation-link {
+        display: flex; flex-wrap: wrap; align-items: baseline; gap: 4px 8px;
+        padding-left: 10px; border-left: 1px dashed var(--border);
+      }
+      .incident-propagation-link .chain-mark { color: var(--fg-dim); }
+      .incident-propagation-link .chain-surface { font: 11px var(--font-mono); }
+      .incident-propagation-link .chain-count { color: var(--fg-dim); font: 10px var(--font-mono); }
+      .incident-propagation-link .chain-message {
+        flex: 1 1 12rem; color: var(--fg-dim); font: 10px/1.5 var(--font-mono); overflow-wrap: anywhere;
+      }
+      .incident-evidence { width: 100%; border-collapse: collapse; }
+      .incident-evidence th, .incident-evidence td {
+        padding: 4px 8px; border-bottom: 1px solid var(--border); text-align: left; vertical-align: top;
+      }
+      .incident-evidence th { color: var(--fg-dim); font: 10px var(--font-sans); }
+      .incident-evidence td { font: 10px/1.5 var(--font-mono); overflow-wrap: anywhere; }
+      .incident-actions { display: flex; flex-wrap: wrap; gap: 8px; }
+
+      /* Narrow viewports: the incident summary and its expansion have to stay
+         scannable without clipping between 480 and 720px. */
+      @media (max-width: 720px) {
+        .incident-summary { padding: 10px; }
+        .incident-count { margin-left: 0; }
+        .incident-facts { grid-template-columns: minmax(0, 1fr); gap: 2px; }
+        .incident-facts dt { margin-top: 6px; }
+        .incident-evidence { display: block; overflow-x: auto; white-space: nowrap; }
+        .incident-evidence td.stderr { white-space: normal; min-width: 14rem; }
+      }
+      @media (max-width: 520px) {
+        .incident-row { padding: 10px; }
+        .incident-head { align-items: flex-start; }
+        .incident-surface { flex: 1 1 100%; }
+        .incident-actions > * { flex: 1 1 100%; }
+      }

--- a/crates/orbit-web/assets/dashboard/diagnostics.js
+++ b/crates/orbit-web/assets/dashboard/diagnostics.js
@@ -18,9 +18,15 @@
 // No behavior change. All original column shapes, truncation, click wiring,
 // and side-card rendering preserved exactly.
 
-import { el, syncNodes } from './common.js';
+import { el, syncNodes, getWindow } from './common.js';
+import { navigateToDrilldown } from './audit.js';
 
 const $ = (id) => document.getElementById(id);
+
+// ORB-10871: which incidents the operator has expanded. Module-scoped (like
+// audit.js's expandedAuditIds) so a refresh tick does not collapse the row
+// someone is reading.
+const expandedIncidents = new Set();
 
 function hasCtx(ctx, key) {
   return ctx && typeof ctx[key] === "function";
@@ -142,9 +148,243 @@ function renderDiagnosticsTable(rows, columns, ctx) {
   syncNodes(tbody, Array.from(frag.children));
 }
 
+// ===== ORB-10871: grouped failure incidents.
+//
+// The Errors view above lists raw failed events — that stays, because it is the
+// forensic record. This view answers the different question "how many distinct
+// problems happened", and every number it renders states what it is out of and
+// which window it was measured over. Nothing is hidden: each incident expands
+// to the exact audit rows it collapsed, and links out to the raw Audit view.
+
+function asCount(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function eventCountLabel(value) {
+  const count = asCount(value);
+  return `${count} event${count === 1 ? "" : "s"}`;
+}
+
+const INCIDENT_CLASS_ORDER = ["unexpected", "expected", "denied"];
+
+function incidentSummaryNode(payload) {
+  const incidents = asCount(payload.incident_count);
+  const failed = asCount(payload.raw_failed_events);
+  const total = asCount(payload.total_events);
+  const window = payload.window || getWindow();
+
+  const head = el("div", { class: "incident-summary-head" }, [
+    el("strong", { class: "incident-summary-headline", text: `${incidents} incidents` }),
+    el("span", {
+      class: "incident-summary-denominator",
+      text: `grouped from ${failed} failed events of ${total} audited events`,
+    }),
+    el("span", { class: "incident-summary-window", text: `window ${window}` }),
+  ]);
+
+  const byClass = payload.incidents_by_class || {};
+  const eventsByClass = payload.raw_events_by_class || {};
+  const labels = payload.class_labels || {};
+  const chips = el("div", { class: "incident-class-chips" });
+  for (const key of INCIDENT_CLASS_ORDER) {
+    const count = asCount(byClass[key]);
+    const events = asCount(eventsByClass[key]);
+    if (count === 0 && events === 0) continue;
+    chips.appendChild(el("span", {
+      class: `incident-class-chip ${key}`,
+      title: `${labels[key] || key}: ${count} incidents from ${events} raw events (window ${window})`,
+      text: `${labels[key] || key} ${count}/${events}`,
+    }));
+  }
+
+  const children = [head];
+  if (chips.childNodes.length > 0) children.push(chips);
+  if (payload.truncated) {
+    children.push(el("p", {
+      class: "incident-truncation-note",
+      text: "Scan limit reached — older failed events in this window were not grouped. Narrow the window for a complete count.",
+    }));
+  }
+  return el("section", { class: "incident-summary" }, children);
+}
+
+function incidentEvidenceTable(events, ctx) {
+  const table = el("table", { class: "incident-evidence" });
+  const thead = el("thead");
+  const headRow = el("tr");
+  for (const label of ["event", "time", "status", "actor", "surface", "run", "task", "message"]) {
+    headRow.appendChild(el("th", { text: label }));
+  }
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+  const tbody = el("tbody");
+  for (const event of events) {
+    const tr = el("tr");
+    tr.appendChild(el("td", { class: "mono", text: event.id == null ? "-" : `#${event.id}` }));
+    tr.appendChild(el("td", { text: ctx.fmtAbsTime ? ctx.fmtAbsTime(event.ts) : (event.ts || "-") }));
+    tr.appendChild(el("td", { text: event.status || "-" }));
+    tr.appendChild(el("td", { text: event.actor || "-" }));
+    tr.appendChild(el("td", { class: "mono", text: event.surface || "-" }));
+    tr.appendChild(el("td", { class: "mono", text: event.run_id || "-" }));
+    tr.appendChild(el("td", { class: "mono", text: event.task_id || "-" }));
+    const message = el("td", { class: "stderr", text: truncateValue(ctx, event.message || "", 160) });
+    message.title = event.message || "";
+    tr.appendChild(message);
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  return table;
+}
+
+function incidentDetailNode(incident, ctx) {
+  const detail = el("div", { class: "incident-detail" });
+
+  const facts = el("dl", { class: "incident-facts" });
+  const fact = (label, value) => {
+    facts.appendChild(el("dt", { text: label }));
+    facts.appendChild(el("dd", { class: "mono", text: value }));
+  };
+  fact("grouping signature", incident.signature || "-");
+  fact("classification", incident.class_label || incident.class || "-");
+  fact("actor", incident.actor || "-");
+  fact("surface", incident.surface || "-");
+  if (incident.activity_id) fact("step", incident.activity_id);
+  fact("first seen", ctx.fmtAbsTime ? ctx.fmtAbsTime(incident.first_ts) : incident.first_ts || "-");
+  fact("last seen", ctx.fmtAbsTime ? ctx.fmtAbsTime(incident.last_ts) : incident.last_ts || "-");
+  fact(
+    "raw events",
+    `${asCount(incident.event_count)} (${asCount(incident.root_event_count)} root · ${asCount(incident.propagated_event_count)} propagated)`,
+  );
+  const runIds = Array.isArray(incident.run_ids) ? incident.run_ids : [];
+  const taskIds = Array.isArray(incident.task_ids) ? incident.task_ids : [];
+  fact("runs", runIds.length ? runIds.join(" · ") : "none recorded");
+  fact("tasks", taskIds.length ? taskIds.join(" · ") : "none recorded");
+  detail.appendChild(facts);
+
+  const propagation = Array.isArray(incident.propagation) ? incident.propagation : [];
+  if (propagation.length > 0) {
+    const chain = el("div", { class: "incident-propagation" });
+    chain.appendChild(el("div", {
+      class: "incident-section-title",
+      text: `Propagation from this root (${propagation.length} downstream failures, not independent root causes)`,
+    }));
+    for (const link of propagation) {
+      chain.appendChild(el("div", { class: "incident-propagation-link" }, [
+        el("span", { class: "chain-mark", text: "↳" }),
+        el("span", { class: "chain-surface mono", text: link.surface || "-" }),
+        el("span", { class: "chain-count", text: eventCountLabel(link.event_count) }),
+        el("span", { class: "chain-message", text: truncateValue(ctx, link.message || link.signature || "", 140) }),
+      ]));
+    }
+    detail.appendChild(chain);
+  }
+
+  const samples = Array.isArray(incident.sample_events) ? incident.sample_events : [];
+  if (samples.length > 0) {
+    detail.appendChild(el("div", {
+      class: "incident-section-title",
+      text: `Underlying audit events (${samples.length} of ${asCount(incident.root_event_count)} shown)`,
+    }));
+    detail.appendChild(incidentEvidenceTable(samples, ctx));
+  }
+
+  const actions = el("div", { class: "incident-actions" });
+  const rawButton = el("button", {
+    class: "chip",
+    text: "Open raw audit events",
+    title: "Every underlying event stays in the raw Audit view",
+  });
+  rawButton.type = "button";
+  rawButton.addEventListener("click", () => navigateToDrilldown({
+    role: incident.actor || null,
+    tool: incident.surface || null,
+    status: incident.class === "denied" ? "denied" : "failure",
+  }));
+  actions.appendChild(rawButton);
+  if (runIds.length > 0 && hasCtx(ctx, "setActiveTab")) {
+    const runButton = el("button", { class: "chip", text: `Open run ${runIds[0]}` });
+    runButton.type = "button";
+    runButton.addEventListener("click", () => ctx.setActiveTab(`runs/${encodeURIComponent(runIds[0])}`));
+    actions.appendChild(runButton);
+  }
+  detail.appendChild(actions);
+
+  return detail;
+}
+
+function incidentRowNode(incident, ctx) {
+  const key = incident.incident_id || incident.signature || "";
+  const expanded = expandedIncidents.has(key);
+  const article = el("article", {
+    class: `incident-row ${incident.class || "unexpected"} ${expanded ? "open" : ""}`,
+  });
+  article.dataset.key = `incident-${key}`;
+  // Expansion is part of the row's identity: without it a keyed diff would
+  // reuse the collapsed node and swallow the click that opened it.
+  article.dataset.hash = JSON.stringify([incident.event_count, incident.last_ts, expanded]);
+
+  const header = el("button", {
+    class: "incident-head",
+    title: "Show the exact audit events behind this incident",
+  }, [
+    el("span", { class: "incident-caret", text: expanded ? "▾" : "▸" }),
+    el("span", { class: `incident-class ${incident.class || "unexpected"}`, text: incident.class_label || incident.class || "failure" }),
+    el("span", { class: "incident-surface mono", text: incident.surface || "-" }),
+    el("span", { class: "incident-actor", text: incident.actor || "unknown actor" }),
+    el("span", {
+      class: "incident-count",
+      title: `${asCount(incident.event_count)} raw audit events collapsed into this incident`,
+      text: eventCountLabel(incident.event_count),
+    }),
+    el("span", { class: "incident-when", text: fmtRelativeValue(ctx, incident.last_ts) }),
+  ]);
+  header.type = "button";
+  header.setAttribute("aria-expanded", expanded ? "true" : "false");
+  header.addEventListener("click", () => {
+    if (expandedIncidents.has(key)) expandedIncidents.delete(key);
+    else expandedIncidents.add(key);
+    renderDiagnostics(ctx);
+  });
+  article.appendChild(header);
+  article.appendChild(el("div", {
+    class: "incident-message",
+    text: truncateValue(ctx, incident.message || incident.signature || "", 220),
+  }));
+  if (expanded) article.appendChild(incidentDetailNode(incident, ctx));
+  return article;
+}
+
+function renderIncidents(payload, ctx) {
+  const body = $("diag-body");
+  const incidents = Array.isArray(payload && payload.incidents) ? payload.incidents : [];
+  const summary = incidentSummaryNode(payload || {});
+  if (incidents.length === 0) {
+    syncNodes(body, [summary, el("div", { class: "empty-state" }, [
+      el("div", { class: "icon", text: "✧" }),
+      el("div", { class: "text", text: "No failure incidents in this window." }),
+    ])]);
+    return;
+  }
+  const list = el("div", { class: "incident-list" });
+  for (const incident of incidents) list.appendChild(incidentRowNode(incident, ctx));
+  syncNodes(body, [summary, list]);
+}
+
 function renderDiagnostics(ctx = {}) {
   const sub = ctx.getActiveDiagSubtab ? ctx.getActiveDiagSubtab() : "metrics";
-  const last = ctx.getLastDiagnostics ? ctx.getLastDiagnostics() : { metrics: [], errors: [], implement_one: [] };
+  const last = ctx.getLastDiagnostics ? ctx.getLastDiagnostics() : { metrics: [], errors: [], incidents: null, implement_one: [] };
+
+  if (sub === "incidents") {
+    const payload = last.incidents || {};
+    // Both counts in the header: grouped incidents, and the raw failed events
+    // they were derived from. Neither is inferable from the other.
+    $("diag-count").textContent =
+      `${asCount(payload.incident_count)} incidents / ${asCount(payload.raw_failed_events)} failed events`;
+    renderIncidents(payload, ctx);
+    renderDiagnosticsSideCard(last, ctx);
+    return;
+  }
+
   const rows = last[sub] || [];
   $("diag-count").textContent = `${rows.length}`;
   const columns =
@@ -157,6 +397,10 @@ function renderDiagnostics(ctx = {}) {
     ctx,
   );
 
+  renderDiagnosticsSideCard(last, ctx);
+}
+
+function renderDiagnosticsSideCard(last, ctx) {
   const sidePanel = $("diagnostics-side-panel");
   if (sidePanel) {
     renderImplementOneCard($("diag-implement-one-body"), last.implement_one || [], ctx);

--- a/crates/orbit-web/assets/dashboard/index.html
+++ b/crates/orbit-web/assets/dashboard/index.html
@@ -185,6 +185,7 @@
               <button class="subtab" data-subtab="runs" type="button">Recent Runs</button>
               <button class="subtab" data-subtab="metrics" type="button">Metrics</button>
               <button class="subtab" data-subtab="errors" type="button">Errors</button>
+              <button class="subtab" data-subtab="incidents" type="button">Incidents</button>
               <button class="subtab" data-subtab="reliability" type="button">Reliability</button>
               <button class="subtab" data-subtab="scoreboard" type="button">Scoreboard</button>
             </nav>

--- a/crates/orbit-web/assets/dashboard/router.js
+++ b/crates/orbit-web/assets/dashboard/router.js
@@ -40,7 +40,7 @@ function markWorkspaceSelectorScope(fleetWide) {
 // `run-detail` route. A deprecated tab was retired outright and `scoreboard`,
 // being diagnostics-shaped, now routes as `#diagnostics/scoreboard`.
 const TABS = ["tasks", "audit", "diagnostics", "operations", "knowledge", "run-detail"];
-const DIAG_SUBTABS = ["runs", "metrics", "errors", "reliability", "scoreboard"];
+const DIAG_SUBTABS = ["runs", "metrics", "errors", "incidents", "reliability", "scoreboard"];
 // ORB-10444/ORB-10588: subtabs that replace the two-column diagnostics layout
 // with their own full-width <main>, keyed by the element they reveal.
 const DIAG_FULL_WIDTH_MAINS = {

--- a/crates/orbit-web/assets/dashboard/scoreboard.js
+++ b/crates/orbit-web/assets/dashboard/scoreboard.js
@@ -101,16 +101,40 @@ const OPERATIONS_SCOREBOARD_COLUMNS = [
     format: "pair",
     left: "failed_tool_calls",
     right: "tool_calls",
-    title: "failed / total tool calls",
+    title: "raw failed tool calls / total tool calls",
+    help: "raw events",
+  },
+  // ORB-10871: the same failures, grouped. A repeated burst is one incident
+  // with its raw event count beside it, so the left number answers "how many
+  // things went wrong" and the right one "how much evidence there is".
+  {
+    key: "failure_incidents",
+    label: "fail inc/events",
+    num: true,
+    format: "pair",
+    left: "failure_incidents",
+    right: "failure_incident_events",
+    tone: "warn",
+    title: "grouped failure incidents / raw failed events they collapsed",
+    help: "grouped",
   },
   { key: "friction.reported", label: "frict r", num: true },
 ];
 
-const ALL_SCOREBOARD_SECTIONS = [
-  { title: "Delivery", badge: "tasks created · planned · completed", columns: DELIVERY_SCOREBOARD_COLUMNS },
-  { title: "Review", badge: "review threads · PR comments", columns: PR_REVIEW_COLUMNS },
-  { title: "Operations", badge: "tool calls · failures · friction", columns: OPERATIONS_SCOREBOARD_COLUMNS },
-];
+function allScoreboardSections() {
+  // Badges name the window so a count is never read against an unstated
+  // cutoff; the Operations badge also states that its failures are grouped.
+  const window = getWindow();
+  return [
+    { title: "Delivery", badge: `tasks created · planned · completed · window ${window}`, columns: DELIVERY_SCOREBOARD_COLUMNS },
+    { title: "Review", badge: `review threads · PR comments · window ${window}`, columns: PR_REVIEW_COLUMNS },
+    {
+      title: "Operations",
+      badge: `tool calls · raw failed events and the incidents they group into · friction · window ${window}`,
+      columns: OPERATIONS_SCOREBOARD_COLUMNS,
+    },
+  ];
+}
 
 function readPath(obj, path) {
   let cur = obj;
@@ -172,7 +196,7 @@ function renderScoreboard(summary) {
   if (agentStrip) {
     syncNodes(agentStrip, [renderAgentStrip(canonicalRows)]);
   }
-  const matrix = buildLeaderboardMatrix(canonicalRows, ALL_SCOREBOARD_SECTIONS, {
+  const matrix = buildLeaderboardMatrix(canonicalRows, allScoreboardSections(), {
     showSectionDividers: true,
   });
   syncNodes(body, [el("div", { class: "scoreboard-sections" }, [matrix])]);
@@ -534,7 +558,9 @@ function buildLeaderboardMatrix(rows, sectionList, opts = {}) {
         td.addEventListener("click", () => navigateToDrilldown({
           role: name,
           metric: col.key,
-          status: col.key === "tools" || col.key === "failed_tool_calls" ? "failure" : null,
+          status: ["tools", "failed_tool_calls", "failure_incidents"].includes(col.key)
+            ? "failure"
+            : null,
         }));
         tr.appendChild(td);
       }

--- a/crates/orbit-web/src/api/audit.rs
+++ b/crates/orbit-web/src/api/audit.rs
@@ -10,13 +10,15 @@ use chrono::{DateTime, Duration, Utc};
 use orbit_common::types::{McpCapability, McpTransport};
 use orbit_core::command::job::JobRunListParams;
 use orbit_core::{
-    AuditEventFilter, AuditEventStatus, AuditToolAggregate, JobRunState, OrbitError, OrbitRuntime,
+    AuditEventFilter, AuditEventStatus, AuditToolAggregate, FailureIncidentQuery, JobRunState,
+    OrbitError, OrbitRuntime,
 };
 use serde_json::{Value, json};
 
 use super::denials::{
     collect_denial_rows, denials_by_reason_summary, denials_by_tool_summary, scan_v2_loop_denials,
 };
+use super::incidents::ROLLUP_SCAN_LIMIT;
 use super::{
     AuditQuery, AuditSummaryQuery, DEFAULT_SUMMARY_WINDOW, HISTORY_DEFAULT_LIMIT,
     HISTORY_MAX_LIMIT, bad_request, bounded_limit, map_runtime_error, server_error,
@@ -218,6 +220,14 @@ pub(super) async fn audit_summary(Ws(runtime): Ws, Query(q): Query<AuditSummaryQ
         "denials": denials,
         "denials_sql": bundle.sql_denied,
         "denials_v2": bundle.v2_denials,
+        // ORB-10871: raw failed rows and grouped incidents are reported as two
+        // separate numbers over the same window, so neither is mistaken for
+        // the other. `failed_events` is the forensic count; `failure_incidents`
+        // is how many distinct problems those rows represent.
+        "failed_events": bundle.failed_events,
+        "failure_incidents": bundle.failure_incidents,
+        "failure_incidents_by_class": bundle.failure_incidents_by_class,
+        "failed_events_by_class": bundle.failed_events_by_class,
         "failed_runs": bundle.failed_runs,
         "active_long_runs": bundle.active_long_runs,
         "sparkline": sparkline,
@@ -239,6 +249,10 @@ struct AuditSummaryBundle {
     total: i64,
     sql_denied: i64,
     v2_denials: i64,
+    failed_events: u64,
+    failure_incidents: u64,
+    failure_incidents_by_class: BTreeMap<String, u64>,
+    failed_events_by_class: BTreeMap<String, u64>,
     failed_runs: i64,
     active_long_runs: i64,
     buckets: Vec<(String, i64)>,
@@ -263,6 +277,15 @@ fn compute_audit_summary_bundle(
     let sql_denied = stats.denied_count;
 
     let v2_denials = scan_v2_loop_denials(runtime, Some(since), None, None)?.len() as i64;
+
+    // ORB-10871: the same window, grouped. Reported next to `total` so the
+    // header tiles can state both counts with their denominators.
+    let incidents = runtime.audit_failure_incidents(&FailureIncidentQuery {
+        since: Some(since),
+        max_events: ROLLUP_SCAN_LIMIT,
+        ..Default::default()
+    })?;
+
     let failed_runs = count_failed_runs(runtime, since)?;
     let active_long_runs = count_active_long_runs(runtime, since)?;
     let buckets = runtime.audit_event_hourly_buckets(&since)?;
@@ -376,6 +399,10 @@ fn compute_audit_summary_bundle(
         total,
         sql_denied,
         v2_denials,
+        failed_events: incidents.raw_failed_events,
+        failure_incidents: incidents.incident_count(),
+        failure_incidents_by_class: incidents.incidents_by_class,
+        failed_events_by_class: incidents.raw_events_by_class,
         failed_runs,
         active_long_runs,
         buckets,

--- a/crates/orbit-web/src/api/incidents.rs
+++ b/crates/orbit-web/src/api/incidents.rs
@@ -1,0 +1,294 @@
+//! `GET /api/audit/incidents` — grouped failure incidents [ORB-10871].
+//!
+//! The dashboard used to read raw failed audit rows as a failure count, so one
+//! repeated refusal burst rendered as hundreds of independent quality
+//! failures. This endpoint reports the incident view *alongside* its raw
+//! denominators — never instead of them — so a scorecard can say "N incidents
+//! collapsed from M failed events of T events in the last 24h" without either
+//! number being inferred.
+//!
+//! Every incident carries the ids of the raw rows it grouped, so the raw Audit
+//! view and its exports stay the authority on evidence; nothing here filters,
+//! rewrites, or hides a row.
+
+use std::collections::BTreeMap;
+
+use axum::extract::Query;
+use axum::response::{IntoResponse, Json, Response};
+use chrono::{DateTime, Utc};
+use orbit_common::types::{infer_agent_family_from_model, normalize_attribution_label};
+use orbit_common::utility::redaction::redact_all;
+use orbit_core::{
+    FailureClass, FailureIncident, FailureIncidentQuery, FailureIncidentReport, IncidentEventRef,
+    OrbitError, PropagationLink,
+};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::{
+    DEFAULT_SUMMARY_WINDOW, HISTORY_MAX_LIMIT, bad_request, bounded_limit, map_runtime_error,
+    server_error,
+};
+use crate::parse::parse_since;
+use crate::state::Ws;
+
+/// Default number of incidents returned. Incidents are already a collapsed
+/// view, so a page this size covers far more raw evidence than the same number
+/// of audit rows would.
+const INCIDENTS_DEFAULT_LIMIT: usize = 50;
+
+/// `?since=<24h|7d|RFC3339>&class=<denied|expected|unexpected>&limit=`.
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct IncidentsQuery {
+    #[serde(default)]
+    pub(super) since: Option<String>,
+    #[serde(default)]
+    pub(super) class: Option<String>,
+    #[serde(default)]
+    pub(super) role: Option<String>,
+    #[serde(default)]
+    pub(super) limit: Option<usize>,
+}
+
+pub(super) async fn list_failure_incidents(
+    Ws(runtime): Ws,
+    Query(query): Query<IncidentsQuery>,
+) -> Response {
+    let raw_since = query
+        .since
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_SUMMARY_WINDOW)
+        .to_string();
+    // `all` is the shared dashboard window's lifetime setting; it is a valid
+    // scope here (no cutoff), not a malformed duration.
+    let since = if raw_since == "all" {
+        None
+    } else {
+        match parse_since(&raw_since) {
+            Ok(since) => Some(since),
+            Err(e) => return map_runtime_error(e),
+        }
+    };
+    let class_filter = match query
+        .class
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(value) => match parse_class(value) {
+            Some(class) => Some(class),
+            None => {
+                return bad_request(format!(
+                    "unknown failure class: {value} (expected denied, expected, or unexpected)"
+                ));
+            }
+        },
+        None => None,
+    };
+    let limit = bounded_limit(query.limit, INCIDENTS_DEFAULT_LIMIT);
+    let role = query.role.filter(|role| !role.is_empty());
+
+    let runtime_clone = runtime.clone();
+    let incident_query = FailureIncidentQuery {
+        since,
+        role: role.clone(),
+        ..Default::default()
+    };
+    // Both the grouping scan and the total-event count are synchronous SQLite
+    // reads; keep them off the async executor.
+    let bundle = match tokio::task::spawn_blocking(move || {
+        let report = runtime_clone.audit_failure_incidents(&incident_query)?;
+        let total_events = runtime_clone.audit_event_stats(since, None)?.total;
+        Ok::<_, OrbitError>((report, total_events))
+    })
+    .await
+    {
+        Ok(Ok(bundle)) => bundle,
+        Ok(Err(e)) => return server_error(e),
+        Err(join_err) => {
+            return server_error(OrbitError::Execution(format!(
+                "failure incident aggregation panicked: {join_err}"
+            )));
+        }
+    };
+    let (report, total_events) = bundle;
+
+    Json(incidents_payload(
+        &report,
+        &raw_since,
+        since,
+        total_events,
+        class_filter,
+        limit,
+        role.as_deref(),
+    ))
+    .into_response()
+}
+
+fn parse_class(raw: &str) -> Option<FailureClass> {
+    match raw {
+        "denied" => Some(FailureClass::Denied),
+        "expected" => Some(FailureClass::Expected),
+        "unexpected" => Some(FailureClass::Unexpected),
+        _ => None,
+    }
+}
+
+/// Projects a report into the dashboard payload.
+///
+/// Widened to `pub(super)` so `api/tests/incidents.rs` can pin the projection
+/// (denominators, class labels, evidence refs) without a live SQLite runtime.
+pub(super) fn incidents_payload(
+    report: &FailureIncidentReport,
+    window: &str,
+    since: Option<DateTime<Utc>>,
+    total_events: i64,
+    class_filter: Option<FailureClass>,
+    limit: usize,
+    role: Option<&str>,
+) -> Value {
+    let selected: Vec<&FailureIncident> = report
+        .incidents
+        .iter()
+        .filter(|incident| class_filter.is_none_or(|class| incident.class == class))
+        .collect();
+    let shown: Vec<Value> = selected
+        .iter()
+        .take(limit)
+        .map(|incident| incident_to_json(incident))
+        .collect();
+
+    json!({
+        "window": window,
+        "since": since.map(|since| since.to_rfc3339()),
+        "role": role,
+        "class": class_filter.map(FailureClass::as_str),
+        // Denominators. Every count the UI renders states what it is out of:
+        // incidents collapse failed events, failed events sit inside all
+        // events, and all of it is scoped to `window`.
+        "total_events": total_events,
+        "raw_failed_events": report.raw_failed_events,
+        "incident_count": report.incident_count(),
+        "matching_incident_count": selected.len(),
+        "shown_incident_count": shown.len(),
+        "limit": limit,
+        "raw_events_by_class": report.raw_events_by_class,
+        "incidents_by_class": report.incidents_by_class,
+        "class_labels": {
+            FailureClass::Denied.as_str(): FailureClass::Denied.label(),
+            FailureClass::Expected.as_str(): FailureClass::Expected.label(),
+            FailureClass::Unexpected.as_str(): FailureClass::Unexpected.label(),
+        },
+        "truncated": report.truncated,
+        "incidents": shown,
+    })
+}
+
+fn incident_to_json(incident: &FailureIncident) -> Value {
+    json!({
+        "incident_id": incident.incident_id,
+        "signature": redact_all(&incident.signature),
+        "class": incident.class.as_str(),
+        "class_label": incident.class.label(),
+        "actor": incident.role,
+        "surface": incident.surface,
+        "activity_id": incident.activity_id,
+        "message": incident.message.as_deref().map(redact_all),
+        "event_count": incident.event_count,
+        "root_event_count": incident.root_event_count,
+        "propagated_event_count": incident.propagated_event_count(),
+        "first_ts": incident.first_ts.to_rfc3339(),
+        "last_ts": incident.last_ts.to_rfc3339(),
+        "run_ids": incident.run_ids,
+        "task_ids": incident.task_ids,
+        "sample_events": incident
+            .sample_events
+            .iter()
+            .map(event_ref_to_json)
+            .collect::<Vec<_>>(),
+        "propagation": incident
+            .propagation
+            .iter()
+            .map(propagation_to_json)
+            .collect::<Vec<_>>(),
+    })
+}
+
+fn event_ref_to_json(event: &IncidentEventRef) -> Value {
+    json!({
+        "id": event.id,
+        "ts": event.ts.to_rfc3339(),
+        "execution_id": event.execution_id,
+        "status": event.status,
+        "actor": event.role,
+        "surface": event.surface,
+        "run_id": event.run_id,
+        "task_id": event.task_id,
+        "activity_id": event.activity_id,
+        "message": event.message.as_deref().map(redact_all),
+    })
+}
+
+fn propagation_to_json(link: &PropagationLink) -> Value {
+    json!({
+        "signature": redact_all(&link.signature),
+        "surface": link.surface,
+        "activity_id": link.activity_id,
+        "event_count": link.event_count,
+        "first_ts": link.first_ts.to_rfc3339(),
+        "last_ts": link.last_ts.to_rfc3339(),
+        "message": link.message.as_deref().map(redact_all),
+        "sample_events": link
+            .sample_events
+            .iter()
+            .map(event_ref_to_json)
+            .collect::<Vec<_>>(),
+    })
+}
+
+/// Incident counts per agent family, plus the raw failed-event total they
+/// collapsed. Both are needed: the scoreboard renders them as a labeled pair
+/// rather than a bare failure number.
+#[derive(Debug, Clone, Copy, Default)]
+pub(super) struct ActorFailureRollup {
+    pub(super) incidents: i64,
+    pub(super) events: i64,
+    pub(super) unexpected_incidents: i64,
+}
+
+/// Rolls a report up by agent family, using the same label normalization the
+/// scoreboard's own audit overlays use, so the incident counts land on the
+/// same row as `tool_calls` / `failed_tool_calls` instead of on a parallel
+/// model-named key. Kept here (rather than in `scoreboard.rs`) so the incident
+/// contract has one owner.
+pub(super) fn rollup_by_actor(
+    report: &FailureIncidentReport,
+) -> BTreeMap<String, ActorFailureRollup> {
+    let mut out: BTreeMap<String, ActorFailureRollup> = BTreeMap::new();
+    for incident in &report.incidents {
+        let family = agent_family_key(&incident.role);
+        if family.is_empty() {
+            continue;
+        }
+        let entry = out.entry(family).or_default();
+        entry.incidents += 1;
+        entry.events += incident.event_count as i64;
+        if incident.class == FailureClass::Unexpected {
+            entry.unexpected_incidents += 1;
+        }
+    }
+    out
+}
+
+/// Maps a free-form audit `role` onto a canonical agent family.
+pub(super) fn agent_family_key(role: &str) -> String {
+    let normalized = normalize_attribution_label(role, None);
+    infer_agent_family_from_model(&normalized).unwrap_or(normalized)
+}
+
+/// Scan cap for the summary/scoreboard rollups, which only need counts. Held
+/// well below the store default so a header tile can never become the slowest
+/// query on the page.
+pub(super) const ROLLUP_SCAN_LIMIT: usize = HISTORY_MAX_LIMIT * 50;

--- a/crates/orbit-web/src/api/mod.rs
+++ b/crates/orbit-web/src/api/mod.rs
@@ -24,6 +24,7 @@ mod crews;
 mod denials;
 mod diagnostics;
 mod frictions;
+mod incidents;
 mod jobs;
 mod log;
 mod metrics;
@@ -411,6 +412,7 @@ pub(super) fn router() -> Router<crate::state::DashboardState> {
         .route("/log", get(log::get_log))
         .route("/log/stream", get(log::stream_log))
         .route("/audit/summary", get(audit::audit_summary))
+        .route("/audit/incidents", get(incidents::list_failure_incidents))
         .route("/routines", get(routines::list_routine_health))
         .route("/routines/toggle", post(routines::toggle_routine))
         .route("/routines/clock", post(routines::control_clock))

--- a/crates/orbit-web/src/api/scoreboard.rs
+++ b/crates/orbit-web/src/api/scoreboard.rs
@@ -8,11 +8,12 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
 use chrono::{Duration, Utc};
 use orbit_cmd::DiagnosticsCommands;
-use orbit_core::OrbitRuntime;
 use orbit_core::scoreboard_summary::ScoreboardWindow;
+use orbit_core::{FailureIncidentQuery, OrbitRuntime};
 use serde::Deserialize;
 use serde_json::json;
 
+use super::incidents::{ActorFailureRollup, ROLLUP_SCAN_LIMIT, agent_family_key, rollup_by_actor};
 use super::server_error;
 
 /// Query-string shape for `GET /api/scoreboard`.
@@ -62,6 +63,20 @@ pub(super) async fn scoreboard(Ws(runtime): Ws, Query(query): Query<ScoreboardQu
         .unwrap_or_default();
     let denial_map: BTreeMap<String, i64> = denials_by_role.into_iter().collect();
 
+    // ORB-10871: a repeated failure burst is one incident, not one failure per
+    // raw row. The scoreboard keeps `failed_tool_calls` (the raw count) and
+    // gains the grouped counts beside it, over the same window, so an operator
+    // reads "how many things went wrong" and "how much evidence there is" as
+    // two distinct numbers.
+    let failure_rollup = runtime
+        .audit_failure_incidents(&FailureIncidentQuery {
+            since: since_window,
+            max_events: ROLLUP_SCAN_LIMIT,
+            ..Default::default()
+        })
+        .map(|report| rollup_by_actor(&report))
+        .unwrap_or_default();
+
     if let Some(agents) = value.get_mut("agents").and_then(|v| v.as_object_mut()) {
         // Collect all agent keys upfront so we can also surface metrics rows
         // that have no scoreboard counterpart yet.
@@ -72,6 +87,7 @@ pub(super) async fn scoreboard(Ws(runtime): Ws, Query(query): Query<ScoreboardQu
                 .cloned()
                 .unwrap_or_default();
             let denials = lookup_denials_for_agent(&denial_map, key);
+            let failures = lookup_failures_for_agent(&failure_rollup, key);
             if let Some(obj) = agents.get_mut(key.as_str()).and_then(|v| v.as_object_mut()) {
                 obj.insert(
                     "avg_step_duration_ms".to_string(),
@@ -83,6 +99,15 @@ pub(super) async fn scoreboard(Ws(runtime): Ws, Query(query): Query<ScoreboardQu
                     json!(extras.p95_duration_ms),
                 );
                 obj.insert("denials".to_string(), json!(denials));
+                obj.insert("failure_incidents".to_string(), json!(failures.incidents));
+                obj.insert(
+                    "unexpected_failure_incidents".to_string(),
+                    json!(failures.unexpected_incidents),
+                );
+                obj.insert(
+                    "failure_incident_events".to_string(),
+                    json!(failures.events),
+                );
             }
         }
         // Surface metrics-only agents so retries/durations show even when no
@@ -92,6 +117,7 @@ pub(super) async fn scoreboard(Ws(runtime): Ws, Query(query): Query<ScoreboardQu
                 continue;
             }
             let denials = lookup_denials_for_agent(&denial_map, key);
+            let failures = lookup_failures_for_agent(&failure_rollup, key);
             agents.insert(
                 key.clone(),
                 json!({
@@ -106,6 +132,9 @@ pub(super) async fn scoreboard(Ws(runtime): Ws, Query(query): Query<ScoreboardQu
                     "retries": extras.retry_count,
                     "p95_wall_clock_ms": extras.p95_duration_ms,
                     "denials": denials,
+                    "failure_incidents": failures.incidents,
+                    "unexpected_failure_incidents": failures.unexpected_incidents,
+                    "failure_incident_events": failures.events,
                 }),
             );
         }
@@ -190,6 +219,22 @@ fn compute_metrics_extras(
         });
     }
     Ok(out)
+}
+
+/// Looks up an agent's grouped failure counts. The rollup is already keyed by
+/// canonical agent family, so a scoreboard key that is itself a model label
+/// (metrics-only rows can be) is normalized the same way before matching.
+fn lookup_failures_for_agent(
+    rollup: &BTreeMap<String, ActorFailureRollup>,
+    agent_key: &str,
+) -> ActorFailureRollup {
+    if let Some(found) = rollup.get(agent_key) {
+        return *found;
+    }
+    rollup
+        .get(&agent_family_key(agent_key))
+        .copied()
+        .unwrap_or_default()
 }
 
 /// Looks up the SQLite per-role denials for a scoreboard agent key. The audit

--- a/crates/orbit-web/src/api/tests/audit.rs
+++ b/crates/orbit-web/src/api/tests/audit.rs
@@ -294,3 +294,54 @@ async fn audit_rejects_non_numeric_limit_without_500() {
     // error, never a 500/panic.
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
+
+/// ORB-10871: the header summary reports the raw failed-event count and the
+/// grouped incident count as two distinct fields over the same window, so a
+/// repeated burst can no longer be read as many independent failures.
+#[tokio::test]
+async fn audit_summary_separates_raw_failed_events_from_grouped_incidents() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    for index in 0..12 {
+        seed_audit_event(
+            &runtime,
+            &format!("exec-burst-{index}"),
+            "surface.alpha",
+            AuditEventStatus::Failure,
+            "actor-one",
+            Some(&format!("could not remove /work/dir-{index}/file.txt")),
+        );
+    }
+    seed_audit_event(
+        &runtime,
+        "exec-denied-one",
+        "surface.beta",
+        AuditEventStatus::Denied,
+        "actor-one",
+        Some("policy denied: write outside the allowed scope"),
+    );
+
+    let response = request_audit(runtime, "/audit/summary?since=24h").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+
+    assert_eq!(body["window"], "24h", "both counts state their window");
+    assert_eq!(body["events"].as_u64(), Some(13), "all-events denominator");
+    assert_eq!(
+        body["failed_events"].as_u64(),
+        Some(13),
+        "raw failed rows stay counted in full"
+    );
+    assert_eq!(
+        body["failure_incidents"].as_u64(),
+        Some(2),
+        "the burst collapses to one incident; the denial stays its own"
+    );
+    assert_eq!(
+        body["failure_incidents_by_class"]["denied"].as_u64(),
+        Some(1)
+    );
+    assert_eq!(
+        body["failed_events_by_class"]["unexpected"].as_u64(),
+        Some(12)
+    );
+}

--- a/crates/orbit-web/src/api/tests/incidents.rs
+++ b/crates/orbit-web/src/api/tests/incidents.rs
@@ -1,0 +1,327 @@
+//! Endpoint tests for `GET /audit/incidents` [ORB-10871].
+//!
+//! The endpoint's job is to report *two* numbers over one window — how many
+//! distinct problems occurred, and how much raw evidence they collapsed —
+//! without either being inferable from the other and without removing any row
+//! from the raw audit surface. Fixtures below are synthetic; no observed actor,
+//! tool, workspace, task, or event id appears.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use orbit_core::{AuditEventInsertParams, AuditEventStatus, OrbitRuntime};
+use serde_json::Value;
+use tower::ServiceExt;
+
+use super::super::router;
+use super::test_support::body_json;
+
+#[allow(clippy::too_many_arguments)]
+fn seed(
+    runtime: &OrbitRuntime,
+    execution_id: &str,
+    tool_name: &str,
+    status: AuditEventStatus,
+    role: &str,
+    error_message: Option<&str>,
+    job_run_id: Option<&str>,
+) {
+    runtime
+        .record_audit_event(&AuditEventInsertParams {
+            execution_id: execution_id.to_string(),
+            command: "tool".to_string(),
+            subcommand: Some("run".to_string()),
+            tool_name: Some(tool_name.to_string()),
+            target_type: Some("tool".to_string()),
+            target_id: Some(tool_name.to_string()),
+            role: role.to_string(),
+            status,
+            exit_code: match status {
+                AuditEventStatus::Success => 0,
+                _ => 1,
+            },
+            duration_ms: 4,
+            working_directory: "/tmp/fixture".to_string(),
+            arguments_json: None,
+            stdout_truncated: None,
+            stderr_truncated: None,
+            error_message: error_message.map(str::to_string),
+            host: None,
+            pid: std::process::id(),
+            session_id: None,
+            workspace_id: None,
+            caller_machine_id: None,
+            caller_host_id: None,
+            process_machine_id: None,
+            process_host_id: None,
+            transport: None,
+            effective_capabilities: Default::default(),
+            origin_session_id: None,
+            mcp_call_id: None,
+            lease_id: None,
+            task_id: None,
+            job_run_id: job_run_id.map(str::to_string),
+            activity_id: None,
+            step_index: None,
+        })
+        .expect("seed audit event");
+}
+
+async fn request(runtime: OrbitRuntime, uri: &str) -> axum::response::Response {
+    router()
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(uri)
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response")
+}
+
+/// One burst plus one unrelated failure plus one success: the incident count,
+/// the raw failed count, and the all-events denominator must each be reported
+/// on their own.
+#[tokio::test]
+async fn incidents_report_grouped_and_raw_counts_against_stated_denominators() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    for index in 0..40 {
+        seed(
+            &runtime,
+            &format!("exec-burst-{index}"),
+            "surface.alpha",
+            AuditEventStatus::Failure,
+            "actor-one",
+            Some(&format!("could not remove /work/dir-{index}/file.txt")),
+            None,
+        );
+    }
+    seed(
+        &runtime,
+        "exec-other",
+        "surface.beta",
+        AuditEventStatus::Failure,
+        "actor-one",
+        Some("connection reset by peer"),
+        None,
+    );
+    seed(
+        &runtime,
+        "exec-ok",
+        "surface.alpha",
+        AuditEventStatus::Success,
+        "actor-one",
+        None,
+        None,
+    );
+
+    let response = request(runtime, "/audit/incidents?since=24h").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+
+    assert_eq!(body["window"], "24h", "the selected window is echoed back");
+    assert!(body["since"].is_string());
+    assert_eq!(body["incident_count"].as_u64(), Some(2));
+    assert_eq!(
+        body["raw_failed_events"].as_u64(),
+        Some(41),
+        "raw failure evidence is preserved, not collapsed away"
+    );
+    assert_eq!(
+        body["total_events"].as_u64(),
+        Some(42),
+        "the failed count states what it is out of"
+    );
+
+    let incidents = body["incidents"].as_array().expect("incidents array");
+    let burst = incidents
+        .iter()
+        .find(|incident| incident["surface"] == "surface.alpha")
+        .expect("burst incident");
+    assert_eq!(burst["event_count"].as_u64(), Some(40));
+    assert_eq!(burst["class"], "unexpected");
+    assert_eq!(burst["class_label"], "unexpected failure");
+    assert!(
+        burst["signature"]
+            .as_str()
+            .is_some_and(|s| s.contains("<path>")),
+        "the grouping signature is exposed so the collapse is explainable"
+    );
+    assert!(
+        !burst["sample_events"]
+            .as_array()
+            .expect("sample events")
+            .is_empty(),
+        "the exact underlying rows must be reachable from the incident"
+    );
+    let sample = &burst["sample_events"].as_array().expect("samples")[0];
+    for field in ["id", "ts", "execution_id", "status", "actor", "surface"] {
+        assert!(!sample[field].is_null(), "sample event must carry {field}");
+    }
+}
+
+/// A cascade in one run is one incident with its chain attached; the raw rows
+/// of every link stay counted and addressable.
+#[tokio::test]
+async fn a_run_cascade_is_one_incident_with_its_propagation_chain() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    for (execution_id, surface, message) in [
+        (
+            "exec-inner",
+            "step.inner",
+            "child step returned a nonzero status",
+        ),
+        (
+            "exec-middle",
+            "step.middle",
+            "bundle aborted after a child failure",
+        ),
+        ("exec-gate", "step.gate", "gate refused to advance"),
+    ] {
+        seed(
+            &runtime,
+            execution_id,
+            surface,
+            AuditEventStatus::Failure,
+            "actor-one",
+            Some(message),
+            Some("run-alpha"),
+        );
+    }
+
+    let response = request(runtime, "/audit/incidents?since=24h").await;
+    let body = body_json(response).await;
+
+    assert_eq!(
+        body["incident_count"].as_u64(),
+        Some(1),
+        "one failed run must not read as three independent root causes"
+    );
+    assert_eq!(body["raw_failed_events"].as_u64(), Some(3));
+    let incident = &body["incidents"].as_array().expect("incidents")[0];
+    assert_eq!(incident["event_count"].as_u64(), Some(3));
+    assert_eq!(incident["root_event_count"].as_u64(), Some(1));
+    assert_eq!(incident["propagated_event_count"].as_u64(), Some(2));
+    assert_eq!(incident["run_ids"][0], "run-alpha");
+    let chain: Vec<&str> = incident["propagation"]
+        .as_array()
+        .expect("propagation")
+        .iter()
+        .filter_map(|link| link["surface"].as_str())
+        .collect();
+    assert_eq!(chain, vec!["step.middle", "step.gate"]);
+}
+
+/// Denials, expected negative paths, and unexpected failures are counted and
+/// labeled separately, and every class stays selectable.
+#[tokio::test]
+async fn failure_classes_are_reported_separately_and_are_filterable() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    seed(
+        &runtime,
+        "exec-denied",
+        "surface.alpha",
+        AuditEventStatus::Denied,
+        "actor-one",
+        Some("policy denied: write outside the allowed scope"),
+        None,
+    );
+    seed(
+        &runtime,
+        "exec-expected",
+        "surface.alpha",
+        AuditEventStatus::Failure,
+        "actor-one",
+        Some("invalid input: field must not be empty"),
+        None,
+    );
+    seed(
+        &runtime,
+        "exec-unexpected",
+        "surface.alpha",
+        AuditEventStatus::Failure,
+        "actor-one",
+        Some("internal channel closed unexpectedly"),
+        None,
+    );
+
+    let body = body_json(request(runtime.clone(), "/audit/incidents?since=24h").await).await;
+    assert_eq!(body["incident_count"].as_u64(), Some(3));
+    assert_eq!(body["incidents_by_class"]["denied"].as_u64(), Some(1));
+    assert_eq!(body["incidents_by_class"]["expected"].as_u64(), Some(1));
+    assert_eq!(body["incidents_by_class"]["unexpected"].as_u64(), Some(1));
+    assert_eq!(body["raw_events_by_class"]["denied"].as_u64(), Some(1));
+    assert_eq!(
+        body["class_labels"]["expected"], "expected negative path",
+        "each class must carry an operator-facing label"
+    );
+
+    let filtered =
+        body_json(request(runtime, "/audit/incidents?since=24h&class=unexpected").await).await;
+    assert_eq!(
+        filtered["matching_incident_count"].as_u64(),
+        Some(1),
+        "class filtering narrows the list"
+    );
+    assert_eq!(
+        filtered["incident_count"].as_u64(),
+        Some(3),
+        "the unfiltered total stays visible so nothing looks dropped"
+    );
+    assert_eq!(
+        filtered["incidents"].as_array().expect("incidents").len(),
+        1
+    );
+}
+
+/// Grouping is a derived view: the raw audit listing keeps every row.
+#[tokio::test]
+async fn grouping_does_not_remove_rows_from_the_raw_audit_view() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    for index in 0..6 {
+        seed(
+            &runtime,
+            &format!("exec-{index}"),
+            "surface.alpha",
+            AuditEventStatus::Failure,
+            "actor-one",
+            Some("operation failed"),
+            None,
+        );
+    }
+
+    let grouped = body_json(request(runtime.clone(), "/audit/incidents?since=24h").await).await;
+    assert_eq!(grouped["incident_count"].as_u64(), Some(1));
+
+    let raw: Value = body_json(request(runtime, "/audit?limit=100").await).await;
+    assert_eq!(
+        raw.as_array().expect("raw audit rows").len(),
+        6,
+        "the raw Audit view still returns every underlying event"
+    );
+}
+
+#[tokio::test]
+async fn the_lifetime_window_is_a_valid_scope() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    let response = request(runtime, "/audit/incidents?since=all").await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    assert_eq!(body["window"], "all");
+    assert!(
+        body["since"].is_null(),
+        "a lifetime window has no cutoff to state"
+    );
+}
+
+#[tokio::test]
+async fn an_unknown_failure_class_is_a_client_error() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    let response = request(runtime, "/audit/incidents?since=24h&class=bogus").await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}

--- a/crates/orbit-web/src/api/tests/mod.rs
+++ b/crates/orbit-web/src/api/tests/mod.rs
@@ -9,6 +9,7 @@ mod denials;
 mod diagnostics;
 mod frictions;
 mod handlers;
+mod incidents;
 mod log;
 mod metrics;
 mod reliability;

--- a/crates/orbit-web/src/api/tests/scoreboard.rs
+++ b/crates/orbit-web/src/api/tests/scoreboard.rs
@@ -190,3 +190,71 @@ async fn scoreboard_query_window_all_round_trips_explicitly() {
     assert_eq!(body["window"].as_str(), Some("all"));
     assert!(body["window_since"].is_null());
 }
+
+/// ORB-10871: the per-agent row carries the grouped incident count next to the
+/// raw `failed_tool_calls` it collapsed, scoped to the requested window, so the
+/// leaderboard cannot present one burst as many quality failures.
+#[tokio::test]
+async fn scoreboard_reports_failure_incidents_beside_raw_failed_tool_calls() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    for index in 0..9 {
+        runtime
+            .record_audit_event(&orbit_core::AuditEventInsertParams {
+                execution_id: format!("exec-{index}"),
+                command: "tool".to_string(),
+                subcommand: Some("run".to_string()),
+                tool_name: Some("orbit.surface.alpha".to_string()),
+                target_type: Some("tool".to_string()),
+                target_id: Some("orbit.surface.alpha".to_string()),
+                role: "claude".to_string(),
+                status: orbit_core::AuditEventStatus::Failure,
+                exit_code: 1,
+                duration_ms: 3,
+                working_directory: "/tmp/fixture".to_string(),
+                arguments_json: None,
+                stdout_truncated: None,
+                stderr_truncated: None,
+                error_message: Some(format!("could not remove /work/dir-{index}/file.txt")),
+                host: None,
+                pid: std::process::id(),
+                session_id: None,
+                workspace_id: None,
+                caller_machine_id: None,
+                caller_host_id: None,
+                process_machine_id: None,
+                process_host_id: None,
+                transport: None,
+                effective_capabilities: Default::default(),
+                origin_session_id: None,
+                mcp_call_id: None,
+                lease_id: None,
+                task_id: None,
+                job_run_id: None,
+                activity_id: None,
+                step_index: None,
+            })
+            .expect("seed audit event");
+    }
+
+    let response = get_scoreboard(runtime, Some("window=24h")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+
+    let agent = &body["agents"]["claude"];
+    assert_eq!(
+        agent["failed_tool_calls"].as_u64(),
+        Some(9),
+        "the raw failed-call count is preserved"
+    );
+    assert_eq!(
+        agent["failure_incidents"].as_u64(),
+        Some(1),
+        "nine identical failures are one incident"
+    );
+    assert_eq!(
+        agent["failure_incident_events"].as_u64(),
+        Some(9),
+        "the incident states how much raw evidence it collapsed"
+    );
+    assert_eq!(agent["unexpected_failure_incidents"].as_u64(), Some(1));
+}

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -375,6 +375,8 @@ fn dashboard_guards_diagnostics_and_detail_panels_in_aggregate_view() {
     for fetch in [
         "/api/diagnostics/metrics",
         "/api/diagnostics/errors",
+        // ORB-10871: the incidents subtab is per-workspace too (`Ws` extractor).
+        "/api/audit/incidents",
         "/api/diagnostics/implement_one",
         "fetchAndRenderRuns()",
     ] {
@@ -601,7 +603,7 @@ async fn dashboard_scoreboard_is_reachable_under_diagnostics() {
     // ORB-10588 appended `reliability` to the same list.
     assert!(
         router.contains(
-            r#"const DIAG_SUBTABS = ["runs", "metrics", "errors", "reliability", "scoreboard"];"#
+            r#"const DIAG_SUBTABS = ["runs", "metrics", "errors", "incidents", "reliability", "scoreboard"];"#
         ),
         "the scoreboard must route as a diagnostics subtab"
     );
@@ -1204,6 +1206,122 @@ fn dashboard_scope_is_shared_labeled_and_url_backed() {
             && css.contains(".scope-chip-v")
             && css.contains("max-width: 10ch"),
         "scope badges and filter chips must stay legible at 480–720px"
+    );
+}
+
+/// ORB-10871: a repeated failure burst is one incident, not hundreds of
+/// independent quality failures. The dashboard must therefore (a) show the
+/// grouped count and the raw failed-event count side by side, each with its
+/// denominator and the selected window, (b) let an operator expand an incident
+/// down to the exact audit rows, actor, surfaces, run/task ids, first/last
+/// timestamps, and grouping signature, and (c) never imply that a propagated
+/// pipeline failure is its own root cause. All three live in the assets; this
+/// pins them so a later edit cannot quietly go back to counting raw rows.
+#[test]
+fn dashboard_failure_metrics_are_incident_aware_and_state_their_denominators() {
+    let index = include_str!("../../assets/dashboard/index.html");
+    let app = include_str!("../../assets/dashboard/app.js");
+    let router = include_str!("../../assets/dashboard/router.js");
+    let diagnostics = include_str!("../../assets/dashboard/diagnostics.js");
+    let scoreboard = include_str!("../../assets/dashboard/scoreboard.js");
+    let audit = include_str!("../../assets/dashboard/audit.js");
+    let css = include_str!("../../assets/dashboard/dashboard.css");
+
+    // Routed as a diagnostics subtab, fetched against the shared window.
+    assert!(
+        index.contains(r#"<button class="subtab" data-subtab="incidents" type="button">"#),
+        "Incidents must be offered as a diagnostics subtab"
+    );
+    assert!(
+        router.contains(r#""incidents""#),
+        "the incidents subtab must be routable"
+    );
+    assert!(
+        app.contains(r#"if (activeDiagSubtab === "incidents")"#)
+            && app.contains("/api/audit/incidents?since=${encodeURIComponent(selectedWindow)}"),
+        "the incidents fetch must hang off the diagnostics subtab branch and honor the shared window"
+    );
+
+    // Both counts, both denominators, and the window are rendered — never one
+    // number standing in for the other.
+    assert!(
+        diagnostics.contains("${asCount(payload.incident_count)} incidents / ${asCount(payload.raw_failed_events)} failed events"),
+        "the panel count must show grouped incidents and raw failed events together"
+    );
+    assert!(
+        diagnostics.contains("grouped from ${failed} failed events of ${total} audited events"),
+        "the incident count must state what it is out of"
+    );
+    assert!(
+        diagnostics.contains("`window ${window}`"),
+        "the incident summary must name the window it was measured over"
+    );
+    assert!(
+        diagnostics.contains("incident-class-chip") && diagnostics.contains("INCIDENT_CLASS_ORDER"),
+        "denials, expected negative paths, and unexpected failures must stay distinguishable"
+    );
+
+    // Expansion exposes the underlying evidence.
+    for needle in [
+        "grouping signature",
+        "first seen",
+        "last seen",
+        "\"actor\"",
+        "\"runs\"",
+        "\"tasks\"",
+        "Underlying audit events",
+    ] {
+        assert!(
+            diagnostics.contains(needle),
+            "incident expansion must reveal `{needle}`"
+        );
+    }
+    assert!(
+        diagnostics.contains("downstream failures, not independent root causes"),
+        "a propagation chain must be labeled as a chain, not as separate root causes"
+    );
+    assert!(
+        diagnostics.contains("navigateToDrilldown(")
+            && diagnostics.contains("Open raw audit events"),
+        "an incident must link out to the raw audit rows it collapsed"
+    );
+    assert!(
+        audit.contains("auditFilter.tool = opts.tool || null;"),
+        "the drill-down must carry the incident's surface into the raw Audit filter"
+    );
+
+    // Scoreboard keeps the raw failure column and gains the grouped one.
+    assert!(
+        scoreboard.contains(r#"left: "failed_tool_calls""#)
+            && scoreboard.contains(r#"right: "tool_calls""#),
+        "the raw failed/total tool-call pair must survive"
+    );
+    assert!(
+        scoreboard.contains(r#"key: "failure_incidents""#)
+            && scoreboard.contains(r#"left: "failure_incidents""#)
+            && scoreboard.contains(r#"right: "failure_incident_events""#),
+        "the scoreboard must show grouped incidents against the raw events they collapsed"
+    );
+    assert!(
+        scoreboard.contains("function allScoreboardSections()")
+            && scoreboard.contains("window ${window}"),
+        "every scoreboard section badge must name the selected window"
+    );
+
+    // Narrow-viewport presentation hooks (480–720px).
+    assert!(
+        css.contains(".incident-summary")
+            && css.contains(".incident-facts")
+            && css.contains(".incident-evidence"),
+        "the incident summary and its expansion need their own presentation hooks"
+    );
+    let responsive_at = css
+        .rfind("@media (max-width: 720px)")
+        .expect("a 720px breakpoint must exist");
+    assert!(
+        css[responsive_at..].contains(".incident-facts { grid-template-columns: minmax(0, 1fr);")
+            && css[responsive_at..].contains(".incident-evidence"),
+        "the incident expansion must reflow rather than clip below 720px"
     );
 }
 

--- a/docs/design/user-interface/2_design.md
+++ b/docs/design/user-interface/2_design.md
@@ -42,6 +42,10 @@ Run Detail > Steps now includes compact per-step agent log expanders for CLI-bac
 
 Diagnostics has an Errors sub-tab after [T20260508-14]. It renders recent backend error rows independently of Metrics and Policy, combining Orbit process ERROR events with structured agent stderr rows. Rows with `job_run` provenance route back to the owning Run Detail step so error triage stays connected to workflow context.
 
+Diagnostics has an Incidents sub-tab after [ORB-10871]. A raw failed audit row is evidence, not an incident: one refusal repeated in a burst is one problem, and one failed run that propagates its failure up through its enclosing steps is one root cause with a chain beneath it. `/api/audit/incidents` groups the window's failed and denied audit rows by `(job run, signature)`, where the signature is `class | actor | surface | normalized message` and volatile tokens (paths, ids, numbers, timestamps, hashes) are replaced with placeholders; same-run clusters of the same class within a 60s cascade window collapse onto their earliest cluster, which becomes the incident root, with the rest recorded as its propagation chain. Grouping reads only durable audit columns, so no tool, agent, workspace, or task is special-cased.
+
+Both counts are always rendered together with their denominators and the selected window — the panel header reads `N incidents / M failed events`, and the summary states `grouped from M failed events of T audited events · window <w>`. Failures stay classified as policy denials, expected negative paths (an `OrbitError`-derived caller-input refusal), or unexpected failures; classes are counted separately and never merged into one incident. The scoreboard keeps its raw `tool fail/all` pair and gains a `fail inc/events` pair beside it, so a burst can no longer inflate an agent's apparent failure rate. Nothing is dropped: an incident expands to its grouping signature, actor, surface, run/task ids, first/last timestamps, and the exact underlying audit rows, and links back into the raw Audit view — which still returns every event.
+
 Diagnostics no longer has a Friction sub-tab after [ORB-00060]. The Friction name is reserved for append-only `.orbit/frictions/` artifacts, while audit-derived negative run signals stay visible in Recent Runs. Recent Runs joins `/api/job-runs` with `/api/diagnostics/friction` client-side by run id (`run_id`/`job_run`) and keeps the table sortable across `denials`, `tool fails`, and `duration`; the duration cell can carry the long-run flag when the diagnostics source supplies one. This preserves column continuity with the existing compact dashboard telemetry direction from [T20260428-15].
 
 Knowledge is a top-level dashboard tab for friction triage. The retired native learning panels, routes, metrics, and mutations were removed by [ORB-10736].
@@ -97,5 +101,6 @@ Accessibility still needs a real WCAG pass; responsive behavior remains optimize
 - [ORB-10874] clarified the Tasks count and filter state, made the log panel collapsible/resizable, and added pending/undo feedback and an aggregate-mode mutation guard to inline task edits.
 - [ORB-10875] added the Operations view and typed routine/clock controls.
 - [ORB-10872] made workspace and time window one dashboard scope across Scoreboard, Audit, Reliability, and Managed Execution.
+- [ORB-10871] made dashboard failure metrics incident-aware: grouped incidents and raw failed events are reported side by side with their denominators and window.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10871](https://orbit-cli.com/tasks/ORB-10871) — Make dashboard failure metrics incident-aware instead of counting repeated events as independent failures

### Description

## Problem
The dashboard's scorecard flattens raw failed audit events into an agent reliability number. In the live Orbit view on 2026-08-15, Codex showed 446 failed calls out of 1,113, but the Audit drill-down showed that 422 of those failures were one repeated `fs.delete` pattern clustered at roughly the same time. The UI therefore presented one burst as hundreds of apparently independent quality failures.

The Errors view also renders propagation layers such as `implement_one`, `implement_bundle`, `require_child_success`, and `require_gate_success` as separate errors even when they originate from one failed run.

## Why It Matters
Raw event volume is useful for forensics, but treating it as incident count produces misleading scorecards and poor operational decisions. Operators need both the exact raw evidence and a root-cause-oriented view.

## Constraints / Notes
- Preserve raw event counts and access to every underlying audit record.
- Add a deterministic, project-agnostic incident/grouping contract based on durable metadata and error signatures; do not hardcode `fs.delete`, Codex, a workspace, or the observed counts.
- Do not silently discard expected negative-path, policy-denial, or propagated failure evidence. Classify and label it.
- Related completed work: ORB-10588 (pipeline reliability surface).

### Acceptance Criteria

- Scoreboard and diagnostics distinguish raw failed events from grouped failure incidents, and both counts are visibly labeled with their denominators and selected window.
- A synthetic burst of hundreds of identical failures is shown as one grouped incident with its raw event count, while unrelated failures remain separate incidents.
- Cascading pipeline errors from one run expose one root failure with the downstream propagation chain collapsed beneath it rather than implying independent root causes.
- Clicking an incident reveals the exact underlying audit events, actor, tool, run/task identifiers when present, first/last timestamps, and grouping signature.
- Expected negative-path failures, denials, and genuine unexpected failures remain distinguishable; no evidence is dropped from raw Audit views or exports.
- Grouping is project-agnostic and covered by deterministic store/API/UI tests with no hardcoded observed actor, tool, workspace, task, or event IDs.
- Rendered validation at desktop and a 480-720px viewport confirms the incident summary and expansion remain scannable without clipping, and focused tests plus git diff --check pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Made dashboard failure metrics incident-aware while keeping every raw audit row intact.

## Grouping contract (orbit-store)
New `crates/orbit-store/src/sqlite/audit_event_store/incident.rs` owns the whole contract, reading only durable audit columns:
- **Classification** — `denied` (status, or a `policy denied` / `capability denied` / `permission denied` message), `expected` (an `OrbitError`-derived caller-input negative path: invalid input, not found, validation failed, ...), otherwise `unexpected`. Classes never merge into one incident, so denials and expected negative paths stay separable from genuine failures.
- **Signature** — `class | role | surface | normalized message`, where `normalize_message` replaces volatile tokens by *shape* (`<path>`, `<num>`, `<id>`, `<uuid>`, `<hex>`, `<ts>`); a message-less failure falls back to its exit code. Nothing names a tool, agent, workspace, or task.
- **Clustering** — by `(job run, signature)`, so a burst of hundreds of identical refusals is one cluster carrying its raw `event_count` and a bounded sample of the exact rows.
- **Cascade collapse** — within one run, same-class clusters within `CASCADE_WINDOW_SECS` (60s) of each other collapse onto the earliest cluster (the root); the rest become its ordered `propagation` chain. A failure later in the same run, beyond that window, stays its own incident.
Output is deterministic and order-independent; `incident_id` is an FNV-1a hex handle over the grouping key.

`Store::get_failure_incidents` queries only `status != 'success'` rows and reports `raw_failed_events`, per-class raw/incident counts, and a `truncated` flag instead of silently capping. Added to `AuditEventStoreBackend` + the SQLite backend, exposed as `OrbitRuntime::audit_failure_incidents`. Refactored the three whole-row audit queries onto one shared `AUDIT_EVENT_COLUMNS` const rather than adding a fourth copy.

## API (orbit-web)
- New `api/incidents.rs` + `GET /api/audit/incidents?since=&class=&role=&limit=`: incidents with signature, class + label, actor, surface, first/last timestamps, run/task ids, propagation chain, and sample raw events — alongside the denominators (`total_events`, `raw_failed_events`, `incident_count`, per-class maps) and the echoed `window`. `since=all` is a valid lifetime scope; an unknown class is a 400. Messages and signatures pass through `redact_all`.
- `/api/audit/summary` gained `failed_events`, `failure_incidents`, and per-class breakdowns over the same window.
- `/api/scoreboard` gained per-agent `failure_incidents`, `failure_incident_events`, `unexpected_failure_incidents`, rolled up by canonical agent family (same normalization the existing audit overlays use) and honoring the selected window. `failed_tool_calls` / `tool_calls` are untouched.

## Dashboard
- Diagnostics gains an **Incidents** subtab (routed, aggregate-guarded, fetched against the shared dashboard window). Header reads `N incidents / M failed events`; the summary reads `grouped from M failed events of T audited events · window <w>`, with per-class chips showing `incidents/raw events`. A truncated scan says so.
- An incident expands to its grouping signature, classification, actor, surface, step, first/last timestamps, run/task ids, the propagation chain (labeled "downstream failures, not independent root causes"), and a table of the exact underlying audit events — plus buttons into the raw Audit view (now carrying the surface as a `tool` filter) and the owning run.
- Scoreboard keeps `tool fail/all` and adds a `fail inc/events` pair; every section badge names the selected window.
- CSS adds incident styling with 720px/520px reflow so the summary and expansion stay scannable without clipping.

## Validation
- `cargo test -p orbit-store --lib` 284 passed (11 new grouping tests: burst collapse, unrelated failures stay separate, cascade root + chain, post-window failure stays independent, three classes never merge, late-translated denial, order independence, normalization, exit-code fallback, store query preserves the raw view, truncation reported).
- `cargo test -p orbit-web --lib` 234 passed (6 new incidents endpoint tests, plus new audit-summary and scoreboard tests and a new `dashboard_assets` test pinning the UI contract). `cargo test -p orbit-core --lib` 795 passed.
- `make ci-fast` and `make ci-lint` both pass; `git diff --check` clean.
- Rendered validation: no browser engine is available in this runner, so pixel-level checking was not possible. Instead the real renderer was driven offline against a fixture payload through a minimal DOM shim — collapsed and expanded incident trees render correctly with all required fields and no errors — and the 480–720px reflow rules are asserted against `dashboard.css` in `dashboard_assets.rs`, matching the repo's existing convention for this class of AC (see `dashboard_managed_execution_cost_panel_has_responsive_presentation_hooks`). Unrestricted CI can arbitrate anything beyond that.

## Out-of-scope files touched
`crates/orbit-store/src/backend/{contracts/traits.rs,sqlite_backends.rs}` (the backend trait the runtime dispatches through — required to reach the new store query), `crates/orbit-core/src/{lib.rs,command/audit_event.rs}` (runtime method + re-exports), `crates/orbit-web/src/api/mod.rs` (route + module), and `crates/orbit-web/src/api/tests/reliability.rs` (pre-existing rustfmt violation in the base that `make ci-fast` rejects; formatting-only).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10871-6a815a05`
- Behind base: 0
- Ahead of base: 1