### PR TITLE
Add auto-task inspection, toggle, and manual mint controls to the dashboard

### DIFF
--- a/crates/orbit-common/src/authorization.rs
+++ b/crates/orbit-common/src/authorization.rs
@@ -128,6 +128,22 @@ pub const DASHBOARD_CLOCK_CADENCE: GovernedOperation = GovernedOperation {
     rationale: "changing the host sweep cadence reloads the native clock service",
 };
 
+/// Versioned auto-task definition toggle exposed by the dashboard.
+pub const DASHBOARD_AUTO_TASK_TOGGLE: GovernedOperation = GovernedOperation {
+    id: "auto_task.toggle",
+    surface: OperationSurface::Dashboard,
+    allowed: &[McpCapability::Operator],
+    rationale: "changing a versioned auto-task definition changes unattended task minting",
+};
+
+/// Unconditional on-demand auto-task mint exposed by the dashboard.
+pub const DASHBOARD_AUTO_TASK_MINT: GovernedOperation = GovernedOperation {
+    id: "auto_task.mint",
+    surface: OperationSurface::Dashboard,
+    allowed: &[McpCapability::Operator],
+    rationale: "manual mint ignores schedule, enabled state, and scheduler dedupe",
+};
+
 /// Every governed operation, declared exactly once.
 ///
 /// This is the single enumerable place the required capability lives. A call
@@ -240,6 +256,8 @@ pub const GOVERNED_OPERATIONS: &[GovernedOperation] = &[
     DASHBOARD_ROUTINE_TOGGLE,
     DASHBOARD_CLOCK_SERVICE,
     DASHBOARD_CLOCK_CADENCE,
+    DASHBOARD_AUTO_TASK_TOGGLE,
+    DASHBOARD_AUTO_TASK_MINT,
 ];
 
 /// Look up the governed tool operation for `tool_name`, if any.

--- a/crates/orbit-common/src/authorization/tests.rs
+++ b/crates/orbit-common/src/authorization/tests.rs
@@ -63,6 +63,8 @@ fn lookup_is_surface_scoped() {
     assert!(governed_dashboard("routine.toggle").is_some());
     assert!(governed_dashboard("clock.service").is_some());
     assert!(governed_dashboard("clock.cadence").is_some());
+    assert!(governed_dashboard("auto_task.toggle").is_some());
+    assert!(governed_dashboard("auto_task.mint").is_some());
     assert!(governed_dashboard("routine.list").is_none());
 }
 
@@ -150,7 +152,13 @@ fn dashboard_operations_require_an_operator() {
         interactive_terminal: true,
         ..envelope()
     });
-    for id in ["routine.toggle", "clock.service", "clock.cadence"] {
+    for id in [
+        "routine.toggle",
+        "clock.service",
+        "clock.cadence",
+        "auto_task.toggle",
+        "auto_task.mint",
+    ] {
         let operation = governed_dashboard(id).expect("dashboard operation is declared");
         assert!(authorize(operation, &agent).is_err());
         assert!(authorize(operation, &operator).is_ok());

--- a/crates/orbit-web/assets/dashboard/app.js
+++ b/crates/orbit-web/assets/dashboard/app.js
@@ -77,6 +77,7 @@ let lastFrictionPayload = { stats: {}, tags: [], items: [] };
 let activeTab = "tasks";
 let activeDiagSubtab = "runs";
 let activeKnowledgeSubtab = "frictions";
+let activeOperationsSubtab = "routines";
 let isRefreshing = false;
 let activeFrictionId = null;
 let frictionSearchQuery = "";
@@ -147,6 +148,8 @@ function routerContext() {
     setDiagSubtab: (v) => { activeDiagSubtab = v; },
     getKnowledgeSubtab: () => activeKnowledgeSubtab,
     setKnowledgeSubtab: (v) => { activeKnowledgeSubtab = v; },
+    getOperationsSubtab: () => activeOperationsSubtab,
+    setOperationsSubtab: (v) => { activeOperationsSubtab = v; },
     getRunId: getActiveRunId,
     setRunId: setActiveRunId,
     getRunSubtab: getActiveRunSubtab,

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -3718,14 +3718,16 @@
       .rel-role-ambiguous { color: var(--priority-medium); border-color: var(--priority-medium); }
       .rel-role-unknown { color: var(--fg-dim); }
 
-      /* ORB-10875: routine definitions and the host clock deliberately use
-         separate cards and controls so one state cannot read as the other. */
+      /* ORB-10875 / ORB-10876: routine, clock, and auto-task cards stay
+         visually separate so one state cannot read as another. */
       .operations-layout {
         grid-template-columns: minmax(0, 2fr) minmax(300px, 1fr);
         align-items: start;
       }
+      .operations-auto-tasks-layout { grid-template-columns: minmax(0, 1fr); }
       body.operations-active { height: auto; min-height: 100vh; overflow-y: auto; }
       .operations-layout .panel { min-width: 0; }
+      .tab-pane[data-tab="operations"] .subtabs { border-bottom: 1px solid var(--border); }
       .operation-feedback {
         min-height: 30px; padding: 7px 14px; border-bottom: 1px solid var(--border);
         color: var(--fg-dim); font: 11px/1.4 var(--font-mono);
@@ -3734,15 +3736,16 @@
       .operation-feedback.pending { color: var(--priority-medium); }
       .operation-feedback.success { color: var(--state-success); }
       .operation-feedback.error { color: var(--state-failed); }
-      #routines-body, #clock-body { padding: 12px; background: var(--bg); }
+      #routines-body, #clock-body, #auto-tasks-body { padding: 12px; background: var(--bg); }
       .operation-card {
         padding: 12px; margin-bottom: 10px; border: 1px solid var(--border);
         border-radius: 4px; background: var(--bg-elev);
       }
       .operation-card:last-child { margin-bottom: 0; }
-      .operation-card-title, .operation-clock-summary, .operation-clock-actions {
+      .operation-card-title, .operation-clock-summary, .operation-clock-actions, .operation-card-actions {
         display: flex; align-items: center; justify-content: space-between; gap: 10px;
       }
+      .operation-card-actions { justify-content: flex-end; flex-wrap: wrap; }
       .operation-card-title > div, .operation-clock-summary { display: flex; align-items: center; gap: 8px; min-width: 0; }
       .operation-card-title strong { overflow-wrap: anywhere; }
       .operation-state {
@@ -3765,6 +3768,10 @@
       }
       .operations-readonly-note { margin: 0 0 12px; padding: 9px; border: 1px dashed var(--border); }
       .operation-control-note.error { color: var(--state-failed); }
+      .operation-mint-warning {
+        color: var(--priority-medium); border-left: 2px solid var(--priority-medium);
+        padding-left: 8px;
+      }
       .operation-button, .operation-cadence {
         min-height: 30px; padding: 5px 9px; border: 1px solid var(--border); border-radius: 3px;
         background: var(--bg); color: var(--fg); font: 11px var(--font-mono);
@@ -3780,14 +3787,20 @@
       @media (max-width: 900px) {
         .operations-layout { grid-template-columns: 1fr; }
       }
+      @media (max-width: 720px) {
+        .operation-grid { grid-template-columns: 1fr; }
+        .operation-card-title { align-items: flex-start; flex-wrap: wrap; }
+        .operation-card-actions { width: 100%; }
+        .operation-mint-warning { overflow-wrap: anywhere; }
+      }
       @media (max-width: 600px) {
         .operations-layout { display: block; padding: 8px; }
         .operations-layout .panel { margin-bottom: 8px; }
         .operation-grid { grid-template-columns: 1fr; }
         .operation-card-title { align-items: flex-start; }
         .operation-card-title > div { align-items: flex-start; flex-direction: column; }
-        .operation-clock-actions { align-items: stretch; }
-        .operation-clock-actions > * { flex: 1 1 100%; }
+        .operation-clock-actions, .operation-card-actions { align-items: stretch; }
+        .operation-clock-actions > *, .operation-card-actions > * { flex: 1 1 100%; }
       }
 
       /* ORB-10871: grouped failure incidents (Diagnostics → Incidents).

--- a/crates/orbit-web/assets/dashboard/index.html
+++ b/crates/orbit-web/assets/dashboard/index.html
@@ -307,7 +307,11 @@
       </main>
     </section>
     <section class="tab-pane" data-tab="operations">
-      <main class="operations-layout">
+      <nav class="subtabs" id="operations-subtabs">
+        <button class="subtab active" data-subtab="routines" type="button">Routines</button>
+        <button class="subtab" data-subtab="auto-tasks" type="button">Auto-tasks</button>
+      </nav>
+      <main class="operations-layout" id="operations-routines-main">
         <section class="panel" id="routines-panel">
           <header>
             <span>Scheduled Routines</span>
@@ -322,6 +326,18 @@
           <header><span>Host Sweep Clock</span><span class="count" id="clock-host">-</span></header>
           <div class="operation-feedback" id="clock-operation-feedback" role="status" aria-live="polite"></div>
           <div class="body" id="clock-body">
+            <div class="skeleton-state"><div class="skeleton skeleton-row"></div></div>
+          </div>
+        </section>
+      </main>
+      <main class="operations-layout operations-auto-tasks-layout" id="operations-auto-tasks-main" hidden>
+        <section class="panel" id="auto-tasks-panel">
+          <header>
+            <span>Auto-task Definitions</span>
+            <span class="count" id="auto-tasks-count">-</span>
+          </header>
+          <div class="operation-feedback" id="auto-task-operation-feedback" role="status" aria-live="polite"></div>
+          <div class="body" id="auto-tasks-body">
             <div class="skeleton-state"><div class="skeleton skeleton-row"></div></div>
           </div>
         </section>

--- a/crates/orbit-web/assets/dashboard/operations.js
+++ b/crates/orbit-web/assets/dashboard/operations.js
@@ -1,19 +1,37 @@
-// Routine-definition and host sweep-clock operations [ORB-10875].
+// Routine-definition, host sweep-clock, and auto-task operations [ORB-10875, ORB-10876].
 
 import { el, fetchJson, getWorkspace, postJson } from './common.js';
 
 const $ = (id) => document.getElementById(id);
 const pendingOperations = new Set();
+const UNCONDITIONAL_MINT_WARNING = "Manual mint ignores this definition's schedule, enabled flag, and scheduler dedupe policy.";
 let lastOperations = null;
+let lastAutoTasks = null;
 let context = null;
 
 export function initOperations(nextContext) {
   context = nextContext;
 }
 
-function selectedWorkspaceName() {
+function selectedWorkspace() {
   const selected = getWorkspace();
-  return context.getWorkspaces().find((workspace) => workspace.id === selected)?.name || null;
+  if (!selected) return null;
+  return context.getWorkspaces().find((workspace) => workspace.id === selected) || null;
+}
+
+function selectedWorkspaceName() {
+  return selectedWorkspace()?.name || null;
+}
+
+function workspaceReadOnlyReason() {
+  const selected = getWorkspace();
+  if (!selected) return "All-workspace mode is read-only. Select one workspace; auto-task definitions are workspace-scoped.";
+  const workspace = selectedWorkspace();
+  if (!workspace) return `Workspace ${selected} is not a concrete active selection.`;
+  if (workspace.status && workspace.status !== "active") {
+    return `Workspace ${workspace.name} is inactive; select an active workspace.`;
+  }
+  return "";
 }
 
 function feedback(id, kind, message) {
@@ -219,6 +237,178 @@ function renderClock(payload) {
   $("clock-host").textContent = payload.host_id || "unknown host";
 }
 
+function autoTaskControlReason(payload) {
+  const workspaceReason = workspaceReadOnlyReason();
+  if (workspaceReason) return workspaceReason;
+  if (payload && payload.read_only_reason) return payload.read_only_reason;
+  if (payload && payload.controls_authorized === false) return "Controls require an authorized operator session.";
+  return "";
+}
+
+function lastEvaluationText(definition) {
+  const evaluation = definition.last_evaluation;
+  if (!evaluation) return "Never evaluated";
+  if (evaluation.kind === "fired") {
+    const task = evaluation.last_task_id ? ` · ${evaluation.last_task_id}` : "";
+    return `${time(evaluation.last_fired_at || evaluation.last_slot)}${task}`;
+  }
+  return `Baselined ${time(evaluation.baseline_at)}; no fire yet`;
+}
+
+function autoTaskToggleButton(payload, definition) {
+  const nextEnabled = !definition.enabled;
+  const key = `auto-task-toggle:${definition.name}`;
+  const reason = autoTaskControlReason(payload);
+  const verb = nextEnabled ? "Enable" : "Disable";
+  const button = el("button", {
+    class: `operation-button ${nextEnabled ? "enable" : "disable"}`,
+    text: pendingOperations.has(key) ? "Pending…" : verb,
+    title: reason || `${verb} ${definition.name}`,
+  });
+  button.type = "button";
+  button.disabled = Boolean(reason) || pendingOperations.has(key);
+  button.addEventListener("click", async () => {
+    if (pendingOperations.has(key)) return;
+    const workspace = selectedWorkspace();
+    const summary = definition.template_summary || definition.template?.title || definition.name;
+    if (!window.confirm(`${verb} auto-task "${definition.name}" in workspace "${workspace?.name || workspace?.id}"?\n\nTarget: ${summary}\nThis writes the definition's enabled field.`)) return;
+    pendingOperations.add(key);
+    feedback("auto-task-operation-feedback", "pending", `${verb === "Enable" ? "Enabling" : "Disabling"} ${definition.name} (${summary})…`);
+    renderAutoTasks(payload);
+    try {
+      const result = await postJson("/api/auto-tasks/toggle", {
+        name: definition.name,
+        expected_enabled: definition.enabled,
+        enabled: nextEnabled,
+      });
+      feedback("auto-task-operation-feedback", "success", `${result.message}: ${definition.name}.`);
+      await fetchAndRenderAutoTasks();
+    } catch (error) {
+      feedback("auto-task-operation-feedback", "error", `Auto-task change failed: ${error.message}`);
+    } finally {
+      pendingOperations.delete(key);
+      if (lastAutoTasks) renderAutoTasks(lastAutoTasks);
+    }
+  });
+  return button;
+}
+
+function autoTaskMintButton(payload, definition) {
+  const key = `auto-task-mint:${definition.name}`;
+  const reason = autoTaskControlReason(payload);
+  const button = el("button", {
+    class: "operation-button secondary",
+    text: pendingOperations.has(key) ? "Pending…" : "Mint now",
+    title: reason || "Mint one task now, ignoring schedule, enabled, and dedupe",
+  });
+  button.type = "button";
+  button.disabled = Boolean(reason) || pendingOperations.has(key);
+  button.addEventListener("click", async () => {
+    if (pendingOperations.has(key)) return;
+    const workspace = selectedWorkspace();
+    const template = definition.template || {};
+    const duplicateLine = definition.may_create_open_duplicate
+      ? "An open instance already exists; this will create another open task."
+      : "No open instance is currently tagged for this definition.";
+    const confirmText = [
+      `Mint auto-task "${definition.name}" now in workspace "${workspace?.name || workspace?.id}"?`,
+      "",
+      `Resulting task: ${definition.template_summary || template.title || definition.name}`,
+      `Crew: ${template.crew || "none"} · Status: ${template.status || "backlog"} · Priority: ${template.priority || "medium"}`,
+      "",
+      `WARNING: ${payload.unconditional_mint_warning || UNCONDITIONAL_MINT_WARNING}`,
+      duplicateLine,
+    ].join("\n");
+    if (!window.confirm(confirmText)) return;
+    pendingOperations.add(key);
+    feedback("auto-task-operation-feedback", "pending", `Minting ${definition.name} now…`);
+    renderAutoTasks(payload);
+    try {
+      const result = await postJson("/api/auto-tasks/mint", {
+        name: definition.name,
+        acknowledge_unconditional: true,
+      });
+      feedback("auto-task-operation-feedback", "success", `${result.message}`);
+      await fetchAndRenderAutoTasks();
+    } catch (error) {
+      feedback("auto-task-operation-feedback", "error", `Manual mint failed: ${error.message}`);
+    } finally {
+      pendingOperations.delete(key);
+      if (lastAutoTasks) renderAutoTasks(lastAutoTasks);
+    }
+  });
+  return button;
+}
+
+function renderAutoTasks(payload) {
+  lastAutoTasks = payload;
+  const body = $("auto-tasks-body");
+  if (!body) return;
+  body.textContent = "";
+  const workspaceReason = workspaceReadOnlyReason();
+  const reason = workspaceReason || payload.read_only_reason || "";
+  const workspace = selectedWorkspace();
+  const definitions = workspace && !workspaceReason ? (payload.definitions || []) : [];
+  if (reason) {
+    body.appendChild(el("div", { class: "operations-readonly-note", text: reason }));
+  }
+  if (definitions.length === 0) {
+    body.appendChild(el("div", {
+      class: "empty-state",
+      text: workspace && !workspaceReason ? "No auto-task definitions are defined by this workspace." : "Select a workspace to list its auto-task definitions.",
+    }));
+  }
+  for (const definition of definitions) {
+    const state = definition.enabled ? "enabled" : "disabled";
+    const actions = el("div", { class: "operation-card-actions" }, [
+      autoTaskToggleButton(payload, definition),
+      autoTaskMintButton(payload, definition),
+    ]);
+    const card = el("article", { class: "operation-card auto-task-card" });
+    card.append(
+      el("div", { class: "operation-card-title" }, [
+        el("div", {}, [
+          el("strong", { text: definition.name }),
+          el("span", { class: `operation-state ${state}`, text: state }),
+        ]),
+        actions,
+      ]),
+      el("div", { class: "operation-target mono", text: definition.template_summary || definition.template?.title || "" }),
+      el("div", { class: "operation-grid" }, [
+        field("Schedule", definition.schedule_summary || "—"),
+        field("Dedupe", definition.dedupe === "always" ? "always fire" : "skip if open"),
+        field("Last evaluation / mint", lastEvaluationText(definition)),
+        field("Last minted task", definition.last_minted_task_id
+          ? `${definition.last_minted_task_id}${definition.last_minted_task_status ? ` · ${definition.last_minted_task_status}` : ""}`
+          : "None"),
+        field("Next evaluation", time(definition.next_evaluation)),
+        field("Open duplicate", definition.open_duplicate ? "Yes — mint will create another" : "No"),
+      ]),
+    );
+    if (definition.description) {
+      card.appendChild(el("p", { class: "operation-description", text: definition.description }));
+    }
+    card.appendChild(el("p", {
+      class: "operation-control-note operation-mint-warning",
+      text: payload.unconditional_mint_warning || UNCONDITIONAL_MINT_WARNING,
+    }));
+    const controlReason = autoTaskControlReason(payload);
+    if (controlReason) card.appendChild(el("p", { class: "operation-control-note", text: controlReason }));
+    body.appendChild(card);
+  }
+  const count = $("auto-tasks-count");
+  if (count) count.textContent = workspace && !workspaceReason ? `${definitions.length} · ${workspace.name}` : "read-only";
+}
+
+function fetchAndRenderAutoTasks() {
+  return fetchJson("/api/auto-tasks").then(renderAutoTasks);
+}
+
 export function fetchAndRenderOperations() {
-  return fetchJson("/api/routines").then(renderOperations);
+  return Promise.all([
+    fetchJson("/api/routines").then(renderOperations),
+    fetchAndRenderAutoTasks().catch((error) => {
+      feedback("auto-task-operation-feedback", "error", `Failed to load auto-tasks: ${error.message}`);
+    }),
+  ]);
 }

--- a/crates/orbit-web/assets/dashboard/router.js
+++ b/crates/orbit-web/assets/dashboard/router.js
@@ -41,6 +41,7 @@ function markWorkspaceSelectorScope(fleetWide) {
 // being diagnostics-shaped, now routes as `#diagnostics/scoreboard`.
 const TABS = ["tasks", "audit", "diagnostics", "operations", "knowledge", "run-detail"];
 const DIAG_SUBTABS = ["runs", "metrics", "errors", "incidents", "reliability", "scoreboard"];
+const OPERATIONS_SUBTABS = ["routines", "auto-tasks"];
 // ORB-10444/ORB-10588: subtabs that replace the two-column diagnostics layout
 // with their own full-width <main>, keyed by the element they reveal.
 const DIAG_FULL_WIDTH_MAINS = {
@@ -148,6 +149,18 @@ function setDiagSubtabImpl(ctx, name) {
   }
 }
 
+function setOperationsSubtabImpl(ctx, name) {
+  if (!OPERATIONS_SUBTABS.includes(name)) name = "routines";
+  ctx.setOperationsSubtab(name);
+  for (const btn of document.querySelectorAll("#operations-subtabs .subtab")) {
+    btn.classList.toggle("active", btn.dataset.subtab === name);
+  }
+  const routines = $("operations-routines-main");
+  const autoTasks = $("operations-auto-tasks-main");
+  if (routines) routines.hidden = name !== "routines";
+  if (autoTasks) autoTasks.hidden = name !== "auto-tasks";
+}
+
 function setKnowledgeSubtabImpl(ctx, name) {
   if (!KNOWLEDGE_SUBTABS.includes(name)) name = "frictions";
   ctx.setKnowledgeSubtab(name);
@@ -250,6 +263,10 @@ function setActiveTabImpl(ctx, raw, opts = {}) {
     const sub = KNOWLEDGE_SUBTABS.includes(segments[1]) ? segments[1] : ctx.getKnowledgeSubtab();
     setKnowledgeSubtabImpl(ctx, sub);
     hash = `#knowledge/${sub}`;
+  } else if (top === "operations") {
+    const sub = OPERATIONS_SUBTABS.includes(segments[1]) ? segments[1] : ctx.getOperationsSubtab();
+    setOperationsSubtabImpl(ctx, sub);
+    hash = `#operations/${sub}`;
   } else if (top === "tasks") {
     // ORB-10874: the status chips and search box are represented in the hash
     // (mirroring the audit tab) so they survive a reload or the browser's
@@ -308,6 +325,11 @@ function initTabsImpl(ctx) {
   for (const btn of document.querySelectorAll("#knowledge-subtabs .subtab")) {
     btn.addEventListener("click", () =>
       setActiveTabImpl(ctx, `knowledge/${btn.dataset.subtab}`, { refresh: false }),
+    );
+  }
+  for (const btn of document.querySelectorAll("#operations-subtabs .subtab")) {
+    btn.addEventListener("click", () =>
+      setActiveTabImpl(ctx, `operations/${btn.dataset.subtab}`, { refresh: false }),
     );
   }
   window.addEventListener("hashchange", () => {

--- a/crates/orbit-web/src/api/auto_tasks.rs
+++ b/crates/orbit-web/src/api/auto_tasks.rs
@@ -1,0 +1,493 @@
+//! Auto-task inspection, toggle, and manual mint for the dashboard [ORB-10876].
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Json, Response};
+use chrono::{DateTime, Duration, Local, Utc};
+use orbit_common::authorization::{
+    DASHBOARD_AUTO_TASK_MINT, DASHBOARD_AUTO_TASK_TOGGLE, OPERATOR_OVERRIDE_ENV,
+};
+use orbit_common::types::{
+    AutoTaskDefinition, AutoTaskSchedule, AutoTaskTemplate, DedupePolicy, TaskStatus, auto_task_tag,
+};
+use orbit_core::OrbitRuntime;
+use orbit_core::auto_tasks::{collect_auto_tasks, cursor_state_path, load_cursor_state};
+use orbit_core::routines::parse_cron;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::map_runtime_error;
+use super::routines::{
+    OperationsQuery, authorization_denied, authorized_caller, explicit_workspace,
+    not_found_or_conflict, record_operation_audit,
+};
+use crate::state::DashboardState;
+
+const UNCONDITIONAL_MINT_WARNING: &str = "Manual mint ignores this definition's schedule, \
+enabled flag, and scheduler dedupe policy. It does not read or write the host-local cursor.";
+
+#[derive(Debug, Deserialize)]
+pub(super) struct AutoTaskToggleRequest {
+    name: String,
+    expected_enabled: bool,
+    enabled: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct AutoTaskMintRequest {
+    name: String,
+    #[serde(default)]
+    acknowledge_unconditional: bool,
+}
+
+/// `GET /api/auto-tasks` — workspace-scoped definition state.
+pub(super) async fn list_auto_tasks(
+    State(state): State<DashboardState>,
+    Query(query): Query<OperationsQuery>,
+) -> Response {
+    let generated_at = Utc::now();
+    let Some(workspace) = query
+        .workspace
+        .as_deref()
+        .map(str::trim)
+        .filter(|workspace| !workspace.is_empty())
+    else {
+        return Json(read_only_envelope(
+            generated_at,
+            None,
+            "All-workspace mode is read-only. Select one concrete workspace; auto-task definitions are workspace-scoped.",
+        ))
+        .into_response();
+    };
+    match resolve_workspace(&state, workspace) {
+        Ok((workspace_name, runtime)) => Json(list_json(
+            &runtime,
+            workspace,
+            &workspace_name,
+            generated_at,
+        ))
+        .into_response(),
+        Err(reason) => {
+            Json(read_only_envelope(generated_at, Some(workspace), &reason)).into_response()
+        }
+    }
+}
+
+/// `POST /api/auto-tasks/toggle` — flip one definition's versioned `enabled` field.
+pub(super) async fn toggle_auto_task(
+    State(state): State<DashboardState>,
+    Query(query): Query<OperationsQuery>,
+    Json(body): Json<AutoTaskToggleRequest>,
+) -> Response {
+    let workspace = match explicit_workspace(&query) {
+        Ok(workspace) => workspace.to_string(),
+        Err(rejection) => return rejection.into_response(),
+    };
+    let runtime = match resolve_workspace(&state, &workspace) {
+        Ok((_, runtime)) => runtime,
+        Err(reason) => {
+            return not_found_or_conflict("workspace_mismatch", reason);
+        }
+    };
+    let caller = match authorized_caller(&DASHBOARD_AUTO_TASK_TOGGLE) {
+        Ok(caller) => caller,
+        Err(denial) => {
+            record_operation_audit(
+                &runtime,
+                &workspace,
+                "auto_task.toggle",
+                &body.name,
+                "",
+                &json!({"expected_enabled": body.expected_enabled, "enabled": body.enabled}),
+                None,
+                Some(&denial),
+                None,
+                Instant::now(),
+            );
+            return authorization_denied(denial);
+        }
+    };
+    let started = Instant::now();
+    let current = match runtime.auto_task_show(&body.name) {
+        Ok(Some(definition)) => definition,
+        Ok(None) => {
+            return not_found_or_conflict(
+                "auto_task_not_found",
+                format!("auto-task '{}' was not found", body.name),
+            );
+        }
+        Err(error) => return map_runtime_error(error),
+    };
+    if current.enabled != body.expected_enabled {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "error": "auto-task state changed while this action was pending; refresh before retrying",
+                "code": "stale_auto_task_state",
+                "actual_enabled": current.enabled,
+            })),
+        )
+            .into_response();
+    }
+    if current.enabled == body.enabled {
+        return Json(json!({
+            "name": body.name,
+            "enabled": body.enabled,
+            "changed": false,
+            "message": if body.enabled { "Auto-task already enabled" } else { "Auto-task already disabled" },
+        }))
+        .into_response();
+    }
+    let updated = match runtime.auto_task_toggle(&body.name, body.enabled) {
+        Ok(updated) => updated,
+        Err(error) => {
+            let error_message = error.to_string();
+            record_operation_audit(
+                &runtime,
+                &workspace,
+                "auto_task.toggle",
+                &body.name,
+                "",
+                &json!({"expected_enabled": body.expected_enabled, "enabled": body.enabled}),
+                Some(&caller),
+                None,
+                Some(&error_message),
+                started,
+            );
+            return map_runtime_error(error);
+        }
+    };
+    record_operation_audit(
+        &runtime,
+        &workspace,
+        "auto_task.toggle",
+        &body.name,
+        "",
+        &json!({"expected_enabled": body.expected_enabled, "enabled": body.enabled}),
+        Some(&caller),
+        None,
+        None,
+        started,
+    );
+    Json(json!({
+        "name": updated.name,
+        "enabled": updated.enabled,
+        "changed": true,
+        "message": if updated.enabled { "Auto-task enabled" } else { "Auto-task disabled" },
+    }))
+    .into_response()
+}
+
+/// `POST /api/auto-tasks/mint` — unconditional on-demand mint.
+pub(super) async fn mint_auto_task(
+    State(state): State<DashboardState>,
+    Query(query): Query<OperationsQuery>,
+    Json(body): Json<AutoTaskMintRequest>,
+) -> Response {
+    let workspace = match explicit_workspace(&query) {
+        Ok(workspace) => workspace.to_string(),
+        Err(rejection) => return rejection.into_response(),
+    };
+    let runtime = match resolve_workspace(&state, &workspace) {
+        Ok((_, runtime)) => runtime,
+        Err(reason) => {
+            return not_found_or_conflict("workspace_mismatch", reason);
+        }
+    };
+    if !body.acknowledge_unconditional {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": UNCONDITIONAL_MINT_WARNING,
+                "code": "unconditional_mint_not_acknowledged",
+            })),
+        )
+            .into_response();
+    }
+    let caller = match authorized_caller(&DASHBOARD_AUTO_TASK_MINT) {
+        Ok(caller) => caller,
+        Err(denial) => {
+            record_operation_audit(
+                &runtime,
+                &workspace,
+                "auto_task.mint",
+                &body.name,
+                "",
+                &json!({"acknowledge_unconditional": body.acknowledge_unconditional}),
+                None,
+                Some(&denial),
+                None,
+                Instant::now(),
+            );
+            return authorization_denied(denial);
+        }
+    };
+    let started = Instant::now();
+    let minted = match runtime.auto_task_mint(&body.name) {
+        Ok(task) => task,
+        Err(error) => {
+            let error_message = error.to_string();
+            record_operation_audit(
+                &runtime,
+                &workspace,
+                "auto_task.mint",
+                &body.name,
+                "",
+                &json!({"acknowledge_unconditional": true}),
+                Some(&caller),
+                None,
+                Some(&error_message),
+                started,
+            );
+            return map_runtime_error(error);
+        }
+    };
+    record_operation_audit(
+        &runtime,
+        &workspace,
+        "auto_task.mint",
+        &body.name,
+        "",
+        &json!({
+            "acknowledge_unconditional": true,
+            "task_id": minted.id.to_string(),
+        }),
+        Some(&caller),
+        None,
+        None,
+        started,
+    );
+    Json(json!({
+        "name": body.name,
+        "task_id": minted.id.to_string(),
+        "status": minted.status,
+        "message": format!("Minted {} ({})", minted.id, minted.status),
+    }))
+    .into_response()
+}
+
+fn resolve_workspace(
+    state: &DashboardState,
+    workspace: &str,
+) -> Result<(String, Arc<OrbitRuntime>), String> {
+    let pinned = state.pin();
+    let entry = pinned.entries().iter().find(|entry| entry.id == workspace);
+    match entry {
+        None => Err(format!(
+            "workspace '{workspace}' is not a concrete active selection"
+        )),
+        Some(entry) if !entry.active => Err(format!(
+            "workspace '{workspace}' is inactive; select an active workspace"
+        )),
+        Some(entry) => match pinned.runtime_for(workspace) {
+            Ok(runtime) => Ok((entry.name.clone(), runtime)),
+            Err(_) => Err(format!(
+                "workspace '{workspace}' is not a concrete active selection"
+            )),
+        },
+    }
+}
+
+fn read_only_envelope(generated_at: DateTime<Utc>, workspace: Option<&str>, reason: &str) -> Value {
+    json!({
+        "generated_at": generated_at.to_rfc3339(),
+        "workspace": workspace,
+        "controls_authorized": false,
+        "read_only_reason": reason,
+        "unconditional_mint_warning": UNCONDITIONAL_MINT_WARNING,
+        "definitions": [],
+        "load_errors": [],
+    })
+}
+
+fn list_json(
+    runtime: &OrbitRuntime,
+    workspace: &str,
+    workspace_name: &str,
+    generated_at: DateTime<Utc>,
+) -> Value {
+    let collection = collect_auto_tasks(&runtime.paths().local_dir);
+    let cursors = load_cursor_state(&cursor_state_path(&runtime.paths().state_dir));
+    let now = Utc::now();
+    let definitions = collection
+        .definitions
+        .iter()
+        .map(|loaded| {
+            definition_json(
+                runtime,
+                &loaded.definition,
+                cursors.definitions.get(&loaded.definition.name),
+                now,
+            )
+        })
+        .collect::<Vec<_>>();
+    let controls_authorized = authorized_caller(&DASHBOARD_AUTO_TASK_TOGGLE).is_ok()
+        && authorized_caller(&DASHBOARD_AUTO_TASK_MINT).is_ok();
+    json!({
+        "generated_at": generated_at.to_rfc3339(),
+        "workspace": workspace,
+        "workspace_name": workspace_name,
+        "controls_authorized": controls_authorized,
+        "read_only_reason": if controls_authorized {
+            Value::Null
+        } else {
+            Value::String(format!(
+                "Controls require an authorized operator session (set {OPERATOR_OVERRIDE_ENV} or use an interactive operator terminal)."
+            ))
+        },
+        "unconditional_mint_warning": UNCONDITIONAL_MINT_WARNING,
+        "definitions": definitions,
+        "load_errors": collection.errors.iter().map(|error| json!({
+            "path": error.path.as_ref().map(|path| path.display().to_string()),
+            "message": error.message,
+        })).collect::<Vec<_>>(),
+    })
+}
+
+fn definition_json(
+    runtime: &OrbitRuntime,
+    definition: &AutoTaskDefinition,
+    cursor: Option<&orbit_core::auto_tasks::AutoTaskCursor>,
+    now: DateTime<Utc>,
+) -> Value {
+    let minted = tagged_instances(runtime, &definition.name);
+    let open_duplicate = minted
+        .as_ref()
+        .is_ok_and(|tasks| tasks.iter().any(|task| is_open_status(task.status)));
+    let last_minted = minted.as_ref().ok().and_then(|tasks| tasks.first());
+    let last_minted_task_id = last_minted
+        .map(|task| task.id.to_string())
+        .or_else(|| cursor.and_then(|cursor| cursor.last_task_id.clone()));
+    let last_minted_task_status = last_minted.map(|task| task.status);
+    json!({
+        "name": definition.name,
+        "description": definition.description,
+        "enabled": definition.enabled,
+        "schedule": definition.schedule,
+        "schedule_summary": schedule_summary(&definition.schedule),
+        "template_summary": template_summary(&definition.template),
+        "template": {
+            "title": definition.template.title,
+            "crew": definition.template.crew,
+            "status": definition.template.status,
+            "priority": definition.template.priority,
+        },
+        "dedupe": match definition.dedupe {
+            DedupePolicy::SkipIfOpen => "skip_if_open",
+            DedupePolicy::Always => "always",
+        },
+        "last_evaluation": cursor.map(|cursor| json!({
+            "kind": if cursor.last_fired_at.is_some() { "fired" } else { "baselined" },
+            "baseline_at": cursor.baseline_at,
+            "last_slot": cursor.last_slot,
+            "last_fired_at": cursor.last_fired_at,
+            "last_task_id": cursor.last_task_id,
+        })),
+        "last_minted_task_id": last_minted_task_id,
+        "last_minted_task_status": last_minted_task_status,
+        "next_evaluation": next_evaluation(&definition.schedule, cursor, now),
+        "open_duplicate": open_duplicate,
+        "may_create_open_duplicate": open_duplicate,
+    })
+}
+
+fn tagged_instances(
+    runtime: &OrbitRuntime,
+    name: &str,
+) -> Result<Vec<orbit_core::Task>, orbit_core::OrbitError> {
+    let tag = auto_task_tag(name);
+    runtime.list_tasks_by_tags(std::slice::from_ref(&tag))
+}
+
+fn is_open_status(status: TaskStatus) -> bool {
+    !matches!(
+        status,
+        TaskStatus::Done | TaskStatus::Archived | TaskStatus::Rejected
+    )
+}
+
+fn schedule_summary(schedule: &AutoTaskSchedule) -> String {
+    match schedule {
+        AutoTaskSchedule::Cron { cron } => format!("cron {cron}"),
+        AutoTaskSchedule::Interval { every_minutes } if *every_minutes == 1 => {
+            "every 1 minute".to_string()
+        }
+        AutoTaskSchedule::Interval { every_minutes } => {
+            format!("every {every_minutes} minutes")
+        }
+    }
+}
+
+fn template_summary(template: &AutoTaskTemplate) -> String {
+    let title = if template.title.starts_with("[auto-task] ") {
+        template.title.clone()
+    } else {
+        format!("[auto-task] {}", template.title)
+    };
+    let mut parts = vec![title];
+    if let Some(crew) = template.crew.as_deref() {
+        parts.push(format!("crew {crew}"));
+    }
+    parts.push(format!("status {}", template.status));
+    parts.push(format!("priority {}", template.priority));
+    parts.join(" · ")
+}
+
+fn next_evaluation(
+    schedule: &AutoTaskSchedule,
+    cursor: Option<&orbit_core::auto_tasks::AutoTaskCursor>,
+    now: DateTime<Utc>,
+) -> Option<String> {
+    let cursor = cursor?;
+    match schedule {
+        AutoTaskSchedule::Cron { cron } => {
+            let parsed = parse_cron(cron).ok()?;
+            let now_local = now.with_timezone(&Local);
+            parsed
+                .find_next_occurrence(&now_local, false)
+                .ok()
+                .map(|slot| slot.with_timezone(&Utc).to_rfc3339())
+        }
+        AutoTaskSchedule::Interval { every_minutes } => {
+            next_interval(*every_minutes, cursor, now).map(|slot| slot.to_rfc3339())
+        }
+    }
+}
+
+fn next_interval(
+    every_minutes: u64,
+    cursor: &orbit_core::auto_tasks::AutoTaskCursor,
+    now: DateTime<Utc>,
+) -> Option<DateTime<Utc>> {
+    if every_minutes == 0 {
+        return None;
+    }
+    let baseline = DateTime::parse_from_rfc3339(&cursor.baseline_at)
+        .ok()?
+        .with_timezone(&Utc);
+    let last_slot = cursor
+        .last_slot
+        .as_deref()
+        .and_then(|slot| DateTime::parse_from_rfc3339(slot).ok())
+        .map(|slot| slot.with_timezone(&Utc));
+    let interval = Duration::minutes(i64::try_from(every_minutes).ok()?);
+    let floor = last_slot.unwrap_or(baseline);
+    if now < baseline {
+        return Some(baseline + interval);
+    }
+    let elapsed = now.signed_duration_since(baseline).num_minutes();
+    let period = i64::try_from(every_minutes).ok()?;
+    let mut periods = elapsed / period;
+    let mut next = baseline + Duration::minutes(period * periods);
+    if next <= floor || next <= now {
+        periods += 1;
+        next = baseline + Duration::minutes(period * periods);
+    }
+    if next <= now {
+        next += interval;
+    }
+    Some(next)
+}

--- a/crates/orbit-web/src/api/mod.rs
+++ b/crates/orbit-web/src/api/mod.rs
@@ -20,6 +20,7 @@ use serde_json::json;
 use url::Url;
 
 mod audit;
+mod auto_tasks;
 mod crews;
 mod denials;
 mod diagnostics;
@@ -416,6 +417,9 @@ pub(super) fn router() -> Router<crate::state::DashboardState> {
         .route("/routines", get(routines::list_routine_health))
         .route("/routines/toggle", post(routines::toggle_routine))
         .route("/routines/clock", post(routines::control_clock))
+        .route("/auto-tasks", get(auto_tasks::list_auto_tasks))
+        .route("/auto-tasks/toggle", post(auto_tasks::toggle_auto_task))
+        .route("/auto-tasks/mint", post(auto_tasks::mint_auto_task))
         .route("/scoreboard", get(scoreboard::scoreboard))
         .route("/metrics/knowledge", get(metrics::knowledge_metrics))
         .route("/metrics/activity", get(metrics::activity_metrics))

--- a/crates/orbit-web/src/api/routines.rs
+++ b/crates/orbit-web/src/api/routines.rs
@@ -25,7 +25,7 @@ use crate::state::{DashboardState, Ws};
 
 #[derive(Debug, Deserialize, Default)]
 pub(super) struct OperationsQuery {
-    workspace: Option<String>,
+    pub(super) workspace: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -380,7 +380,9 @@ pub(super) fn clock_json(clock: &ClockStatus) -> Value {
     })
 }
 
-fn explicit_workspace(query: &OperationsQuery) -> Result<&str, (StatusCode, Json<Value>)> {
+pub(super) fn explicit_workspace(
+    query: &OperationsQuery,
+) -> Result<&str, (StatusCode, Json<Value>)> {
     query
         .workspace
         .as_deref()
@@ -396,7 +398,7 @@ fn explicit_workspace(query: &OperationsQuery) -> Result<&str, (StatusCode, Json
         })
 }
 
-fn authorized_caller(
+pub(super) fn authorized_caller(
     operation: &'static GovernedOperation,
 ) -> Result<CallerCapabilities, AuthorizationDenial> {
     let caller = CallerCapabilities::resolve(&CallerEnvelope::from_process_env(
@@ -406,7 +408,7 @@ fn authorized_caller(
     Ok(caller)
 }
 
-fn authorization_denied(denial: AuthorizationDenial) -> Response {
+pub(super) fn authorization_denied(denial: AuthorizationDenial) -> Response {
     (
         StatusCode::FORBIDDEN,
         Json(json!({
@@ -419,7 +421,7 @@ fn authorization_denied(denial: AuthorizationDenial) -> Response {
         .into_response()
 }
 
-fn not_found_or_conflict(code: &'static str, message: String) -> Response {
+pub(super) fn not_found_or_conflict(code: &'static str, message: String) -> Response {
     (
         StatusCode::CONFLICT,
         Json(json!({"error": message, "code": code})),
@@ -428,7 +430,7 @@ fn not_found_or_conflict(code: &'static str, message: String) -> Response {
 }
 
 #[allow(clippy::too_many_arguments)]
-fn record_operation_audit(
+pub(super) fn record_operation_audit(
     runtime: &OrbitRuntime,
     workspace: &str,
     operation: &str,

--- a/crates/orbit-web/src/api/tests/auto_tasks.rs
+++ b/crates/orbit-web/src/api/tests/auto_tasks.rs
@@ -1,0 +1,368 @@
+//! Tests for the dashboard auto-task JSON API [ORB-10876].
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use orbit_common::authorization::OPERATOR_OVERRIDE_ENV;
+use orbit_common::types::{
+    AutoTaskSchedule, AutoTaskTemplate, DedupePolicy, TaskPriority, TaskStatus, TaskType,
+};
+use orbit_core::auto_tasks::cursor_state_path;
+use orbit_core::{AutoTaskAddParams, OrbitRuntime};
+use tower::ServiceExt;
+
+use super::super::router;
+use super::test_support::body_json;
+use crate::state::DashboardState;
+
+fn runtime() -> OrbitRuntime {
+    OrbitRuntime::in_memory().expect("build runtime")
+}
+
+fn chore_params(name: &str) -> AutoTaskAddParams {
+    AutoTaskAddParams {
+        name: name.to_string(),
+        description: format!("Definition {name}"),
+        schedule: AutoTaskSchedule::Interval { every_minutes: 60 },
+        template: AutoTaskTemplate {
+            title: format!("Chore {name}"),
+            description: "Recurring chore body.".to_string(),
+            acceptance_criteria: vec!["The chore is observable.".to_string()],
+            task_type: TaskType::Chore,
+            tags: vec![],
+            priority: TaskPriority::Medium,
+            crew: None,
+            status: TaskStatus::Backlog,
+        },
+        dedupe: DedupePolicy::SkipIfOpen,
+    }
+}
+
+fn state(runtime: OrbitRuntime) -> (DashboardState, Arc<OrbitRuntime>) {
+    let runtime = Arc::new(runtime);
+    (DashboardState::single(runtime.clone()), runtime)
+}
+
+async fn send(
+    state: DashboardState,
+    method: Method,
+    uri: &str,
+    body: Option<&str>,
+) -> axum::response::Response {
+    let mut builder = Request::builder().method(method.clone()).uri(uri);
+    if !matches!(method, Method::GET) {
+        builder = builder
+            .header("origin", "http://localhost:7878")
+            .header("content-type", "application/json");
+    }
+    router()
+        .with_state(state)
+        .oneshot(
+            builder
+                .body(Body::from(body.unwrap_or("").to_string()))
+                .expect("request"),
+        )
+        .await
+        .expect("response")
+}
+
+#[allow(clippy::await_holding_lock)]
+async fn as_operator<T>(fut: impl std::future::Future<Output = T>) -> T {
+    let _env = orbit_common::test_env::scoped([(OPERATOR_OVERRIDE_ENV, Some("1"))]);
+    fut.await
+}
+
+#[tokio::test]
+async fn list_requires_a_concrete_workspace_and_stays_read_only_without_one() {
+    let (state, _) = state(runtime());
+    let response = send(state, Method::GET, "/auto-tasks", None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(json["definitions"], serde_json::json!([]));
+    assert_eq!(json["controls_authorized"], false);
+    assert!(
+        json["read_only_reason"]
+            .as_str()
+            .expect("reason")
+            .contains("All-workspace mode is read-only"),
+        "{json}"
+    );
+}
+
+#[tokio::test]
+async fn list_reports_enabled_and_disabled_definitions() {
+    let runtime = runtime();
+    runtime.auto_task_add(chore_params("nightly")).expect("add");
+    runtime.auto_task_toggle("nightly", false).expect("disable");
+    runtime.auto_task_add(chore_params("hourly")).expect("add");
+    let path = cursor_state_path(&runtime.paths().state_dir);
+    std::fs::create_dir_all(path.parent().expect("state dir")).expect("mkdir");
+    std::fs::write(
+        path,
+        r#"{
+  "definitions": {
+    "hourly": {
+      "baseline_at": "2026-01-01T00:00:00+00:00",
+      "last_slot": "2026-01-01T01:00:00+00:00",
+      "last_fired_at": "2026-01-01T01:00:05+00:00",
+      "last_task_id": "ORB-00001"
+    }
+  }
+}"#,
+    )
+    .expect("write cursor");
+
+    let (state, _) = state(runtime);
+    let response = send(state, Method::GET, "/auto-tasks?workspace=default", None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let items = json["definitions"].as_array().expect("definitions");
+    assert_eq!(items.len(), 2, "{json}");
+    let nightly = items
+        .iter()
+        .find(|item| item["name"] == "nightly")
+        .expect("nightly");
+    let hourly = items
+        .iter()
+        .find(|item| item["name"] == "hourly")
+        .expect("hourly");
+    assert_eq!(nightly["enabled"], false);
+    assert_eq!(hourly["enabled"], true);
+    assert_eq!(hourly["dedupe"], "skip_if_open");
+    assert!(
+        hourly["template_summary"]
+            .as_str()
+            .expect("summary")
+            .contains("[auto-task] Chore hourly"),
+        "{hourly}"
+    );
+    assert_eq!(hourly["last_evaluation"]["kind"], "fired");
+    assert_eq!(hourly["last_evaluation"]["last_task_id"], "ORB-00001");
+    assert_eq!(hourly["last_minted_task_id"], "ORB-00001");
+    assert!(hourly["next_evaluation"].as_str().is_some(), "{hourly}");
+    assert_eq!(hourly["schedule_summary"], "every 60 minutes");
+    assert_eq!(nightly["last_evaluation"], serde_json::Value::Null);
+}
+
+#[tokio::test]
+async fn unknown_workspace_stays_read_only() {
+    let (state, _) = state(runtime());
+    let response = send(state, Method::GET, "/auto-tasks?workspace=missing", None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(json["definitions"], serde_json::json!([]));
+    assert_eq!(json["controls_authorized"], false);
+    assert!(
+        json["read_only_reason"]
+            .as_str()
+            .expect("reason")
+            .contains("not a concrete active selection"),
+        "{json}"
+    );
+}
+
+#[tokio::test]
+async fn toggle_requires_an_explicit_workspace() {
+    let (state, _) = state(runtime());
+    let response = send(
+        state,
+        Method::POST,
+        "/auto-tasks/toggle",
+        Some(r#"{"name":"nightly","expected_enabled":true,"enabled":false}"#),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = body_json(response).await;
+    assert_eq!(json["code"], "workspace_required");
+}
+
+#[tokio::test]
+async fn toggle_denies_an_unidentified_caller() {
+    let runtime = runtime();
+    runtime.auto_task_add(chore_params("nightly")).expect("add");
+    let (state, runtime) = state(runtime);
+    let response = send(
+        state,
+        Method::POST,
+        "/auto-tasks/toggle?workspace=default",
+        Some(r#"{"name":"nightly","expected_enabled":true,"enabled":false}"#),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let json = body_json(response).await;
+    assert_eq!(json["code"], "authorization_denied");
+    assert_eq!(json["operation"], "auto_task.toggle");
+    assert!(
+        runtime
+            .auto_task_show("nightly")
+            .expect("show")
+            .expect("present")
+            .enabled
+    );
+}
+
+#[tokio::test]
+async fn toggle_rolls_back_when_expected_state_is_stale() {
+    let runtime = runtime();
+    runtime.auto_task_add(chore_params("nightly")).expect("add");
+    runtime
+        .auto_task_toggle("nightly", false)
+        .expect("disable first");
+    let (state, runtime) = state(runtime);
+    let response = as_operator(send(
+        state,
+        Method::POST,
+        "/auto-tasks/toggle?workspace=default",
+        Some(r#"{"name":"nightly","expected_enabled":true,"enabled":false}"#),
+    ))
+    .await;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let json = body_json(response).await;
+    assert_eq!(json["code"], "stale_auto_task_state");
+    assert_eq!(json["actual_enabled"], false);
+    assert!(
+        !runtime
+            .auto_task_show("nightly")
+            .expect("show")
+            .expect("present")
+            .enabled
+    );
+}
+
+#[tokio::test]
+async fn authorized_toggle_disables_and_records_audit() {
+    let runtime = runtime();
+    runtime.auto_task_add(chore_params("nightly")).expect("add");
+    let (state, runtime) = state(runtime);
+    let response = as_operator(send(
+        state,
+        Method::POST,
+        "/auto-tasks/toggle?workspace=default",
+        Some(r#"{"name":"nightly","expected_enabled":true,"enabled":false}"#),
+    ))
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(json["enabled"], false);
+    assert_eq!(json["changed"], true);
+    assert_eq!(json["message"], "Auto-task disabled");
+    assert!(
+        !runtime
+            .auto_task_show("nightly")
+            .expect("show")
+            .expect("present")
+            .enabled
+    );
+    let events = runtime
+        .list_audit_events_with_kind(
+            None,
+            None,
+            Some("auto_task.toggle".to_string()),
+            None,
+            None,
+            20,
+        )
+        .expect("audit");
+    assert!(
+        events
+            .iter()
+            .any(|event| event.status.to_string() == "success"
+                && event.target_id.as_deref() == Some("nightly")),
+        "{events:?}"
+    );
+}
+
+#[tokio::test]
+async fn mint_requires_unconditional_acknowledgement() {
+    let runtime = runtime();
+    runtime.auto_task_add(chore_params("nightly")).expect("add");
+    let (state, runtime) = state(runtime);
+    let response = as_operator(send(
+        state,
+        Method::POST,
+        "/auto-tasks/mint?workspace=default",
+        Some(r#"{"name":"nightly"}"#),
+    ))
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = body_json(response).await;
+    assert_eq!(json["code"], "unconditional_mint_not_acknowledged");
+    assert!(
+        json["error"]
+            .as_str()
+            .expect("error")
+            .contains("ignores this definition's schedule"),
+        "{json}"
+    );
+    assert!(
+        runtime
+            .list_tasks_by_tags(&["auto-task:nightly".into()])
+            .expect("list")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn mint_denies_an_unidentified_caller() {
+    let runtime = runtime();
+    runtime.auto_task_add(chore_params("nightly")).expect("add");
+    let (state, _) = state(runtime);
+    let response = send(
+        state,
+        Method::POST,
+        "/auto-tasks/mint?workspace=default",
+        Some(r#"{"name":"nightly","acknowledge_unconditional":true}"#),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let json = body_json(response).await;
+    assert_eq!(json["code"], "authorization_denied");
+    assert_eq!(json["operation"], "auto_task.mint");
+}
+
+#[tokio::test]
+async fn mint_returns_the_created_task_id() {
+    let runtime = runtime();
+    runtime.auto_task_add(chore_params("nightly")).expect("add");
+    let (state, runtime) = state(runtime);
+    let response = as_operator(send(
+        state,
+        Method::POST,
+        "/auto-tasks/mint?workspace=default",
+        Some(r#"{"name":"nightly","acknowledge_unconditional":true}"#),
+    ))
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let task_id = json["task_id"].as_str().expect("task id");
+    assert!(!task_id.is_empty(), "{json}");
+    assert_eq!(json["status"], "backlog");
+    assert!(json["message"].as_str().expect("message").contains(task_id));
+    let tasks = runtime
+        .list_tasks_by_tags(&["auto-task:nightly".into()])
+        .expect("list");
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].id.to_string(), task_id);
+}
+
+#[tokio::test]
+async fn mint_returns_the_exact_server_error() {
+    let (state, _) = state(runtime());
+    let response = as_operator(send(
+        state,
+        Method::POST,
+        "/auto-tasks/mint?workspace=default",
+        Some(r#"{"name":"missing","acknowledge_unconditional":true}"#),
+    ))
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = body_json(response).await;
+    assert!(
+        json["error"]
+            .as_str()
+            .expect("error")
+            .contains("no such auto-task 'missing'"),
+        "{json}"
+    );
+}

--- a/crates/orbit-web/src/api/tests/mod.rs
+++ b/crates/orbit-web/src/api/tests/mod.rs
@@ -5,6 +5,7 @@
 mod test_support;
 
 mod audit;
+mod auto_tasks;
 mod denials;
 mod diagnostics;
 mod frictions;

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -541,26 +541,57 @@ async fn dashboard_top_level_nav_matches_the_operator_tabs() {
 fn dashboard_operations_are_typed_guarded_and_responsive() {
     let index = include_str!("../../assets/dashboard/index.html");
     let operations = include_str!("../../assets/dashboard/operations.js");
+    let router = include_str!("../../assets/dashboard/router.js");
     let css = include_str!("../../assets/dashboard/dashboard.css");
 
-    for id in ["routines-body", "clock-body", "routine-operation-feedback"] {
-        assert!(index.contains(&format!(r#"id="{id}""#)));
+    for id in [
+        "routines-body",
+        "clock-body",
+        "routine-operation-feedback",
+        "auto-tasks-body",
+        "auto-task-operation-feedback",
+        "operations-subtabs",
+    ] {
+        assert!(index.contains(&format!(r#"id="{id}""#)), "{id}");
     }
     assert!(operations.contains(r#"postJson("/api/routines/toggle""#));
     assert!(operations.contains(r#"postJson("/api/routines/clock""#));
+    assert!(operations.contains(r#"postJson("/api/auto-tasks/toggle""#));
+    assert!(operations.contains(r#"postJson("/api/auto-tasks/mint""#));
     assert!(operations.contains("pendingOperations.has(key)"));
     assert!(operations.contains("window.confirm("));
     assert!(operations.contains("All-workspace mode is read-only"));
     assert!(operations.contains("routine.target"));
     assert!(operations.contains("last_evaluated_slot"));
     assert!(operations.contains("next_tick_at"));
+    assert!(operations.contains("acknowledge_unconditional: true"));
+    assert!(operations.contains("UNCONDITIONAL_MINT_WARNING"));
+    assert!(operations.contains(
+        "Manual mint ignores this definition's schedule, enabled flag, and scheduler dedupe policy."
+    ));
+    assert!(
+        operations.contains("An open instance already exists; this will create another open task.")
+    );
+    assert!(operations.contains("Minted") || operations.contains("result.message"));
+    assert!(operations.contains("Auto-task change failed"));
+    assert!(operations.contains("Manual mint failed"));
+    assert!(operations.contains("fetchJson(\"/api/auto-tasks\")"));
+    assert!(
+        !operations.contains("postJson(\"/api/auto-tasks")
+            || operations.contains("addEventListener(\"click\"")
+    );
+    assert!(
+        !operations.contains("hashchange") && !operations.contains("location.reload"),
+        "refresh/back must not replay a toggle or mint POST"
+    );
+    assert!(router.contains(r#"const OPERATIONS_SUBTABS = ["routines", "auto-tasks"];"#));
+    assert!(router.contains(r#"hash = `#operations/${sub}`;"#));
+    assert!(css.contains("@media (max-width: 720px)"));
     assert!(css.contains("@media (max-width: 600px)"));
     assert!(css.contains(".operation-grid { grid-template-columns: 1fr; }"));
     assert!(css.contains("body.operations-active"));
-    assert!(
-        include_str!("../../assets/dashboard/router.js")
-            .contains(r#"classList.toggle("operations-active", top === "operations")"#)
-    );
+    assert!(css.contains(".operation-mint-warning"));
+    assert!(router.contains(r#"classList.toggle("operations-active", top === "operations")"#));
 }
 
 /// ORB-10444: Scoreboard content stays reachable after the move — as a

--- a/docs/design/auto-tasks/2_design.md
+++ b/docs/design/auto-tasks/2_design.md
@@ -1,17 +1,17 @@
 ---
 title: Auto-tasks — Design
 owner: claude
-last_updated: 2026-08-15
-last_validated: 2026-07-27
+last_updated: 2026-08-16
+last_validated: 2026-08-16
 status: Accepted
 feature: auto-tasks
 doc_role: design
 type: design
-summary: Current implementation of the auto-task record, due-math, host-local cursor, generic scheduler, CRUD surfaces, and the on-demand manual mint.
+summary: Current implementation of the auto-task record, due-math, host-local cursor, generic scheduler, CRUD surfaces, the on-demand manual mint, and the dashboard Operations surface.
 tags: [auto-tasks]
-paths: ["crates/orbit-core/src/auto_tasks/**"]
+paths: ["crates/orbit-core/src/auto_tasks/**", "crates/orbit-web/src/api/auto_tasks.rs", "crates/orbit-web/assets/dashboard/operations.js"]
 related_features: [auto-tasks]
-related_artifacts: [ORB-10149, ORB-10439, ORB-10441, ORB-10446, ORB-10472, ORB-10583, ORB-10800]
+related_artifacts: [ORB-10149, ORB-10439, ORB-10441, ORB-10446, ORB-10472, ORB-10583, ORB-10800, ORB-10876]
 ---
 
 # Auto-tasks — Design
@@ -154,6 +154,21 @@ both are registered at `McpToolScope::WorkspaceRequired`. The MCP tool is a thin
 adapter over the same `auto_task_mint`, so the mint stays unconditional and
 cursor-neutral on every surface.
 
+## 5c. Dashboard Operations surface [ORB-10876]
+
+The dashboard Operations tab exposes the same CRUD/mint runtime rather than a
+second scheduler. `#operations/auto-tasks` lists the selected workspace's
+definitions (name, enabled, schedule, template summary, dedupe, last
+evaluation/mint, last minted task id, next evaluation when the cursor makes
+that derivable). Enable/disable writes `enabled` through `auto_task_toggle`
+with `expected_enabled` compare-and-swap, operator authorization
+(`auto_task.toggle`), and a dashboard-operations audit row. `Mint now` calls
+`auto_task_mint` after the operator acknowledges the unconditional warning
+(`acknowledge_unconditional: true`); the request is refused without that
+disclosure. All-workspace and inactive/unknown workspace selections stay
+read-only. Refresh and hash navigation only GET — they never replay a toggle
+or mint.
+
 ## 6. Concerns & Honest Limitations
 
 The checked-in `qa-sweep` definition is the first concrete consumer. It files a
@@ -193,6 +208,7 @@ accurate.
 
 ## Task References
 
+- ORB-10876 — dashboard Operations inspection, toggle, and manual mint.
 - ORB-10149 — Auto-task primitive.
 - ORB-10439 — on-demand manual mint (renamed to `orbit auto-task mint <name>` by ORB-10446).
 - ORB-10441 — mint-time visible title provenance.


### PR DESCRIPTION
## Task

[ORB-10876](https://orbit-cli.com/tasks/ORB-10876) — Add auto-task inspection, toggle, and manual mint controls to the dashboard

### Description

## Problem
Auto-task definitions are durable scheduled-work records, but the dashboard does not expose their state or operations. Operators cannot see which definitions are enabled, understand their schedule/template/dedupe policy, disable or re-enable one, or manually mint an instance without leaving the dashboard.

## Why It Matters
Auto-tasks are the intended data-driven mechanism for recurring work. Their state and manual test path should be visible beside routine operations, with especially clear semantics because manual mint is unconditional and intentionally ignores schedule, enabled state, and scheduler dedupe.

## Constraints / Notes
- Reuse the existing auto-task runtime and record semantics; do not create a second scheduler or persistence model.
- Manual mint must explicitly disclose its unconditional behavior before submission.
- Mutations require a concrete workspace, authorization, audit provenance, exact feedback, and duplicate-click protection.
- Keep definitions and rendered task templates project-agnostic in shipped assets.
- Related completed foundations: ORB-10149, ORB-10439/ORB-10446, and ORB-10798.
- This is eventual work; leave proposed until explicitly promoted.

### Acceptance Criteria

- A dashboard Operations view lists auto-task definitions for the selected workspace with name, enabled state, schedule, task template summary, dedupe policy, last evaluation/mint outcome, last minted task ID when present, and next scheduled evaluation when derivable.
- An authorized operator can enable or disable a definition with an explicit target summary, pending state, exact success/failure feedback, audit provenance, and duplicate-submission protection.
- An authorized operator can mint one definition now and receives the created task ID/status or the exact error; the UI clearly warns immediately before submission that manual mint ignores the definition's schedule, enabled flag, and scheduler dedupe policy.
- Manual mint confirmation shows the concrete workspace, definition name, resulting task template summary, crew/status/priority when present, and whether an open duplicate may be created.
- All-workspace mode and ambiguous workspace state remain read-only and explain why a concrete workspace is required.
- Refresh/reload preserves the selected Operations subview and workspace without replaying a prior toggle or mint request.
- Deterministic API/UI tests cover enabled/disabled definitions, toggle authorization and rollback, unconditional mint disclosure, successful task-ID return, server failure, duplicate clicks, and no mutation on refresh/back navigation.
- Rendered desktop and 480-720px validation confirms schedules, dedupe/template summaries, warnings, and controls remain legible; focused tests and git diff --check pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added workspace-scoped GET /api/auto-tasks plus POST /api/auto-tasks/toggle and /mint that reuse OrbitRuntime::auto_task_list/toggle/mint, cursor state, and auto-task:<name> provenance. List returns enabled state, schedule/template/dedupe summaries, last evaluation/mint, last minted task id/status, next evaluation when derivable, and open-duplicate flags.
- Mutations require an explicit workspace, operator authorization (auto_task.toggle / auto_task.mint), expected_enabled CAS (stale 409 rollback), unconditional-mint acknowledgement, exact success/failure bodies, and dashboard-operations audit rows.
- Operations tab now has hash-backed subviews #operations/routines and #operations/auto-tasks. Auto-task cards expose enable/disable and Mint now with pending keys, confirm copy (workspace, template, crew/status/priority, open-duplicate risk), and a visible unconditional-mint warning immediately before submit. All-workspace / inactive / unknown workspace stays read-only. Refresh and hash navigation only GET.
- Governed operations registered in orbit-common. Design doc §5c updated. CSS wraps cards at 720px/600px.

Strategic decisions:
- Reused the existing CRUD/mint runtime instead of adding a scheduler or persistence model.
- GET without a concrete workspace returns a 200 read-only envelope rather than 400 so the UI can explain why controls are locked.
- Extra context_files: authorization.rs/.tests.rs (governed-operation registration), api/auto_tasks.rs and api/tests/auto_tasks.rs (new module + tests).

Assessment: Acceptance criteria covered by API tests (11) and dashboard asset tests (toggle/mint disclosure, pending protection, GET-only refresh, 720px layout). clippy -D warnings and git diff --check passed.

Validation:
- cargo test -p orbit-web --lib auto_task (11 passed)
- cargo test -p orbit-web --lib dashboard_ (35 passed)
- cargo test -p orbit-common --lib authorization::tests (12 passed)
- cargo clippy -p orbit-web -p orbit-common --all-targets -- -D warnings
- git diff --check

Design weaknesses / risks:
- Severity: low. Next-evaluation for cron is the next host-local occurrence from now, not a dry-run of catch-up collapse. Mitigation: field is labeled next evaluation and omitted when no cursor exists.

Friction checkpoint: none filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10876-6a8161a4`
- Behind base: 0
- Ahead of base: 1