### PR TITLE
Add delivery highlights and honest, accessible semantics to the Scoreboard

### DIFF
--- a/crates/orbit-core/src/runtime/engine/summary.rs
+++ b/crates/orbit-core/src/runtime/engine/summary.rs
@@ -56,6 +56,9 @@ impl OrbitRuntime {
         let friction_reported = crate::runtime::orbit_tool_host::friction_tools::store_for(self)?
             .reported_by_model(since_window)?;
 
+        // Notable completions and coverage notes are projected inside
+        // generate_summary_with_inputs from this same `tasks` slice — no extra
+        // store read, and no model inference (ORB-10873).
         let summary = orbit_store::scoreboard_summary::generate_summary_with_inputs(
             &self.paths().scoreboard_dir,
             &tasks,

--- a/crates/orbit-store/src/file/scoreboard/scoreboard_summary/highlights.rs
+++ b/crates/orbit-store/src/file/scoreboard/scoreboard_summary/highlights.rs
@@ -1,0 +1,190 @@
+//! Deterministic delivery highlights and coverage notes for the scoreboard.
+//!
+//! Highlights are a reading aid built only from durable task fields. They are
+//! not an impact rank, quality score, or model-inferred summary.
+
+use chrono::{DateTime, Utc};
+use orbit_common::types::{Task, TaskPriority, TaskStatus};
+use serde::{Deserialize, Serialize};
+
+/// Maximum notable completions shown for one window.
+pub const NOTABLE_COMPLETIONS_LIMIT: usize = 5;
+/// Maximum characters kept from a task's `execution_summary`.
+pub const SUMMARY_EXCERPT_MAX_CHARS: usize = 180;
+/// Stable sort key advertised to API/UI consumers.
+pub const NOTABLE_SELECTION_METHOD: &str = "priority_then_completion_recency";
+/// Operator-facing description of the sort. Not a quality claim.
+pub const NOTABLE_SELECTION_LABEL: &str = "Ordered by priority, then most recently completed. This is a reading order, not a quality score.";
+
+/// One completed task selected for the Notable completions list.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NotableCompletion {
+    pub task_id: String,
+    pub title: String,
+    pub priority: String,
+    pub task_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub impact_tag: Option<String>,
+    /// RFC3339 completion timestamp (`updated_at` for done/archived tasks).
+    pub completed_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary_excerpt: Option<String>,
+}
+
+/// Bounded highlight list plus the documented selection rule.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NotableCompletions {
+    pub method: String,
+    pub label: String,
+    pub limit: usize,
+    pub items: Vec<NotableCompletion>,
+}
+
+/// Whether a scoreboard section's source can be attributed to the selected window.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CoverageAvailability {
+    Observed,
+    Unavailable,
+}
+
+/// Honest source note for one scoreboard section.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CoverageNote {
+    pub availability: CoverageAvailability,
+    pub detail: String,
+}
+
+/// Per-section coverage for sources that are not uniformly windowable.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScoreboardCoverage {
+    pub review: CoverageNote,
+    pub snapshot_metrics: CoverageNote,
+}
+
+impl Default for NotableCompletions {
+    fn default() -> Self {
+        Self {
+            method: NOTABLE_SELECTION_METHOD.to_string(),
+            label: NOTABLE_SELECTION_LABEL.to_string(),
+            limit: NOTABLE_COMPLETIONS_LIMIT,
+            items: Vec::new(),
+        }
+    }
+}
+
+impl Default for ScoreboardCoverage {
+    fn default() -> Self {
+        snapshot_coverage(false)
+    }
+}
+
+/// Build the windowed highlight list. Candidates are `done`/`archived` tasks
+/// whose completion timestamp falls in `since..`. `since == None` is lifetime.
+pub fn select_notable_completions(
+    tasks: &[Task],
+    since: Option<DateTime<Utc>>,
+) -> NotableCompletions {
+    let mut candidates: Vec<&Task> = tasks
+        .iter()
+        .filter(|task| matches!(task.status, TaskStatus::Done | TaskStatus::Archived))
+        .filter(|task| match since {
+            None => true,
+            Some(cut) => task.updated_at >= cut,
+        })
+        .collect();
+
+    candidates.sort_by(|a, b| {
+        priority_rank(b.priority)
+            .cmp(&priority_rank(a.priority))
+            .then_with(|| b.updated_at.cmp(&a.updated_at))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    candidates.truncate(NOTABLE_COMPLETIONS_LIMIT);
+
+    NotableCompletions {
+        method: NOTABLE_SELECTION_METHOD.to_string(),
+        label: NOTABLE_SELECTION_LABEL.to_string(),
+        limit: NOTABLE_COMPLETIONS_LIMIT,
+        items: candidates.into_iter().map(notable_from_task).collect(),
+    }
+}
+
+/// Snapshot-sourced review/token columns have no per-event timestamp, so a
+/// finite window cannot honestly report them as "no activity".
+pub fn snapshot_coverage(windowed: bool) -> ScoreboardCoverage {
+    if windowed {
+        let detail = "Lifetime snapshot with no per-event timestamps; omitted from this window rather than shown as zero activity.".to_string();
+        ScoreboardCoverage {
+            review: CoverageNote {
+                availability: CoverageAvailability::Unavailable,
+                detail: detail.clone(),
+            },
+            snapshot_metrics: CoverageNote {
+                availability: CoverageAvailability::Unavailable,
+                detail,
+            },
+        }
+    } else {
+        ScoreboardCoverage {
+            review: CoverageNote {
+                availability: CoverageAvailability::Observed,
+                detail: "PR comment counts come from the lifetime snapshot. A zero means no observed review comments, not missing coverage.".to_string(),
+            },
+            snapshot_metrics: CoverageNote {
+                availability: CoverageAvailability::Observed,
+                detail: "Token and PR snapshot counters are lifetime totals for this view.".to_string(),
+            },
+        }
+    }
+}
+
+pub fn excerpt_execution_summary(raw: &str) -> Option<String> {
+    let collapsed: String = raw.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.is_empty() {
+        return None;
+    }
+    if collapsed.chars().count() <= SUMMARY_EXCERPT_MAX_CHARS {
+        return Some(collapsed);
+    }
+    let mut excerpt: String = collapsed.chars().take(SUMMARY_EXCERPT_MAX_CHARS).collect();
+    if let Some(last_space) = excerpt.rfind(' ') {
+        if last_space >= SUMMARY_EXCERPT_MAX_CHARS / 2 {
+            excerpt.truncate(last_space);
+        }
+    }
+    excerpt.push('…');
+    Some(excerpt)
+}
+
+fn notable_from_task(task: &Task) -> NotableCompletion {
+    NotableCompletion {
+        task_id: task.id.to_string(),
+        title: task.title.clone(),
+        priority: task.priority.to_string(),
+        task_type: task.task_type.to_string(),
+        impact_tag: explicit_impact_tag(&task.tags),
+        completed_at: task.updated_at.to_rfc3339(),
+        summary_excerpt: excerpt_execution_summary(&task.execution_summary),
+    }
+}
+
+/// First tag that starts with `impact:` (case-insensitive). Other tags are
+/// ignored so we never invent an impact label from type, priority, or prose.
+fn explicit_impact_tag(tags: &[String]) -> Option<String> {
+    tags.iter()
+        .find(|tag| {
+            tag.get(..7)
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case("impact:"))
+        })
+        .cloned()
+}
+
+fn priority_rank(priority: TaskPriority) -> u8 {
+    match priority {
+        TaskPriority::Critical => 3,
+        TaskPriority::High => 2,
+        TaskPriority::Medium => 1,
+        TaskPriority::Low => 0,
+    }
+}

--- a/crates/orbit-store/src/file/scoreboard/scoreboard_summary/mod.rs
+++ b/crates/orbit-store/src/file/scoreboard/scoreboard_summary/mod.rs
@@ -15,6 +15,13 @@ use crate::friction_store::FrictionReportedCount;
 use crate::{AuditToolCallCountsByRole, AuditToolCallCountsBySurfaceAndRole, AuditTopToolCall};
 use orbit_common::utility::fs::atomic_write_text_volatile as write_atomic;
 
+mod highlights;
+
+pub use highlights::{
+    CoverageAvailability, CoverageNote, NotableCompletion, NotableCompletions, ScoreboardCoverage,
+    select_notable_completions, snapshot_coverage,
+};
+
 const SUMMARY_FILENAME: &str = "summary.json";
 // v2 adds `task_review.threads`; v3 adds tasks_created/tasks_planned,
 // per-(role, surface) tool call counts, top-level workflows_run, and a
@@ -29,7 +36,10 @@ const SUMMARY_FILENAME: &str = "summary.json";
 // without folding it into execution-agent/model scoreboard rows.
 // v8 removes retired competition projections. Older readers ignore
 // unknown fields and maintained consumers treat absent fields as empty.
-const CURRENT_SCHEMA_VERSION: u32 = 8;
+// v9 ([ORB-10873]) adds `notable_completions` (priority then recency
+// reading order, not a quality score) and `coverage` notes that distinguish
+// observed zeros from snapshot sources that cannot be windowed.
+const CURRENT_SCHEMA_VERSION: u32 = 9;
 pub const ORCHESTRATION_SCHEMA_VERSION: u32 = 2;
 const RECENT_WINDOW_DAYS: i64 = 7;
 
@@ -299,6 +309,13 @@ pub struct ScoreboardSummary {
     /// window is `All` (lifetime). v6+.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub window_since: Option<String>,
+    /// Compact delivery highlights for the selected window. v9+.
+    #[serde(default)]
+    pub notable_completions: NotableCompletions,
+    /// Distinguishes observed empty sections from sources that cannot be
+    /// attributed to a finite window. v9+.
+    #[serde(default)]
+    pub coverage: ScoreboardCoverage,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -346,7 +363,7 @@ pub struct ScoreboardInputs<'a> {
     /// Friction counts per reporting model label, already windowed by the
     /// caller with the same cutoff this module derives from `now`/`window`.
     /// Populates per-family `friction.reported` counts (so the dashboard
-    /// `frict r` column and `orbit.friction.stats` agree, without using tool
+    /// friction column and `orbit.friction.stats` agree, without using tool
     /// call surface counts). ORB-10680 replaced the full record slice with
     /// this aggregate so scoreboard memory tracks distinct models, not corpus
     /// size.
@@ -540,6 +557,8 @@ pub fn generate_summary_with_inputs(
         orchestration: inputs.orchestration.clone(),
         window: inputs.window.as_str().to_string(),
         window_since: since.map(|t| t.to_rfc3339()),
+        notable_completions: select_notable_completions(tasks, since),
+        coverage: snapshot_coverage(windowed),
     })
 }
 

--- a/crates/orbit-store/src/file/scoreboard/scoreboard_summary/tests/highlights.rs
+++ b/crates/orbit-store/src/file/scoreboard/scoreboard_summary/tests/highlights.rs
@@ -1,0 +1,265 @@
+use chrono::{Duration, TimeZone, Utc};
+use orbit_common::types::{Task, TaskPriority, TaskStatus, TaskType};
+
+use super::super::highlights::{
+    NOTABLE_COMPLETIONS_LIMIT, NOTABLE_SELECTION_LABEL, NOTABLE_SELECTION_METHOD,
+    SUMMARY_EXCERPT_MAX_CHARS, excerpt_execution_summary,
+};
+use super::super::*;
+
+fn task_at(
+    id: &str,
+    status: TaskStatus,
+    priority: TaskPriority,
+    completed_at: chrono::DateTime<Utc>,
+    summary: &str,
+    tags: &[&str],
+) -> Task {
+    Task {
+        id: id.to_string(),
+        title: format!("title {id}"),
+        description: String::new(),
+        acceptance_criteria: Vec::new(),
+        tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
+        plan: String::new(),
+        execution_summary: summary.to_string(),
+        context_files: Vec::new(),
+        created_by: None,
+        planned_by: None,
+        implemented_by: None,
+        status,
+        priority,
+        complexity: None,
+        task_type: TaskType::Chore,
+        pr_status: None,
+        external_refs: Vec::new(),
+        relations: Vec::new(),
+        job_run_id: None,
+        crew: None,
+        orchestrator: None,
+        created_at: completed_at,
+        updated_at: completed_at,
+    }
+}
+
+#[test]
+fn notable_completions_order_by_priority_then_recency_then_id() {
+    let t0 = Utc.with_ymd_and_hms(2026, 8, 1, 12, 0, 0).unwrap();
+    let tasks = vec![
+        task_at(
+            "ORB-3",
+            TaskStatus::Done,
+            TaskPriority::High,
+            t0 + Duration::hours(1),
+            "later high",
+            &[],
+        ),
+        task_at(
+            "ORB-1",
+            TaskStatus::Done,
+            TaskPriority::Critical,
+            t0,
+            "older critical",
+            &["impact:cleanup"],
+        ),
+        task_at(
+            "ORB-2",
+            TaskStatus::Done,
+            TaskPriority::High,
+            t0 + Duration::hours(2),
+            "newest high",
+            &[],
+        ),
+        task_at(
+            "ORB-4",
+            TaskStatus::Done,
+            TaskPriority::High,
+            t0 + Duration::hours(2),
+            "tie recency, later id",
+            &[],
+        ),
+        task_at(
+            "ORB-skip",
+            TaskStatus::Backlog,
+            TaskPriority::Critical,
+            t0 + Duration::hours(3),
+            "not completed",
+            &[],
+        ),
+    ];
+
+    let selected = select_notable_completions(&tasks, None);
+    assert_eq!(selected.method, NOTABLE_SELECTION_METHOD);
+    assert_eq!(selected.label, NOTABLE_SELECTION_LABEL);
+    assert_eq!(selected.limit, NOTABLE_COMPLETIONS_LIMIT);
+    let ids: Vec<&str> = selected
+        .items
+        .iter()
+        .map(|item| item.task_id.as_str())
+        .collect();
+    assert_eq!(ids, vec!["ORB-1", "ORB-2", "ORB-4", "ORB-3"]);
+    assert_eq!(
+        selected.items[0].impact_tag.as_deref(),
+        Some("impact:cleanup")
+    );
+    assert_eq!(selected.items[0].priority, "critical");
+    assert_eq!(selected.items[0].task_type, "chore");
+}
+
+#[test]
+fn notable_completions_truncate_to_limit_and_bound_excerpt() {
+    let t0 = Utc.with_ymd_and_hms(2026, 8, 2, 0, 0, 0).unwrap();
+    let long = "word ".repeat(80);
+    let mut tasks = Vec::new();
+    for index in 0..(NOTABLE_COMPLETIONS_LIMIT + 3) {
+        tasks.push(task_at(
+            &format!("ORB-{index:02}"),
+            TaskStatus::Done,
+            TaskPriority::Medium,
+            t0 + Duration::minutes(index as i64),
+            &long,
+            &[],
+        ));
+    }
+
+    let selected = select_notable_completions(&tasks, None);
+    assert_eq!(selected.items.len(), NOTABLE_COMPLETIONS_LIMIT);
+    let first = &selected.items[0];
+    let excerpt = first.summary_excerpt.as_deref().expect("excerpt present");
+    assert!(excerpt.ends_with('…'));
+    assert!(excerpt.chars().count() <= SUMMARY_EXCERPT_MAX_CHARS + 1);
+    assert!(!excerpt.contains("  "));
+}
+
+#[test]
+fn notable_completions_omit_missing_summary_and_non_impact_tags() {
+    let t0 = Utc.with_ymd_and_hms(2026, 8, 3, 0, 0, 0).unwrap();
+    let tasks = vec![task_at(
+        "ORB-empty",
+        TaskStatus::Archived,
+        TaskPriority::Low,
+        t0,
+        "   \n\t  ",
+        &["dashboard", "ImpactIgnored", "impact"],
+    )];
+
+    let selected = select_notable_completions(&tasks, None);
+    assert_eq!(selected.items.len(), 1);
+    assert!(selected.items[0].summary_excerpt.is_none());
+    assert!(
+        selected.items[0].impact_tag.is_none(),
+        "only an explicit impact: prefix is an impact tag"
+    );
+}
+
+#[test]
+fn notable_completions_honor_window_cutoff() {
+    let now = Utc.with_ymd_and_hms(2026, 8, 10, 0, 0, 0).unwrap();
+    let inside = now - Duration::hours(2);
+    let outside = now - Duration::hours(48);
+    let tasks = vec![
+        task_at(
+            "ORB-in",
+            TaskStatus::Done,
+            TaskPriority::Low,
+            inside,
+            "inside",
+            &[],
+        ),
+        task_at(
+            "ORB-out",
+            TaskStatus::Done,
+            TaskPriority::Critical,
+            outside,
+            "outside",
+            &[],
+        ),
+    ];
+
+    let selected = select_notable_completions(&tasks, Some(now - Duration::hours(24)));
+    let ids: Vec<&str> = selected
+        .items
+        .iter()
+        .map(|item| item.task_id.as_str())
+        .collect();
+    assert_eq!(ids, vec!["ORB-in"]);
+}
+
+#[test]
+fn coverage_distinguishes_windowed_snapshot_from_observed_lifetime() {
+    let windowed = snapshot_coverage(true);
+    assert_eq!(
+        windowed.review.availability,
+        CoverageAvailability::Unavailable
+    );
+    assert!(windowed.review.detail.contains("omitted from this window"));
+    assert_eq!(
+        windowed.snapshot_metrics.availability,
+        CoverageAvailability::Unavailable
+    );
+
+    let lifetime = snapshot_coverage(false);
+    assert_eq!(lifetime.review.availability, CoverageAvailability::Observed);
+    assert!(
+        lifetime
+            .review
+            .detail
+            .contains("no observed review comments")
+    );
+}
+
+#[test]
+fn generate_summary_includes_highlights_and_windowed_coverage() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let now = Utc.with_ymd_and_hms(2026, 8, 16, 12, 0, 0).unwrap();
+    let tasks = vec![
+        task_at(
+            "ORB-keep",
+            TaskStatus::Done,
+            TaskPriority::High,
+            now - Duration::hours(1),
+            "Outcome: success Changes: structural cleanup Assessment: landed",
+            &["impact:maintenance"],
+        ),
+        task_at(
+            "ORB-old",
+            TaskStatus::Done,
+            TaskPriority::Critical,
+            now - Duration::days(10),
+            "old",
+            &[],
+        ),
+    ];
+
+    let summary = generate_summary_with_inputs(
+        temp.path(),
+        &tasks,
+        &ScoreboardInputs {
+            now: Some(now),
+            window: ScoreboardWindow::Day,
+            ..ScoreboardInputs::default()
+        },
+    )
+    .expect("generate summary");
+
+    assert_eq!(summary.schema_version, 9);
+    assert_eq!(summary.notable_completions.items.len(), 1);
+    assert_eq!(summary.notable_completions.items[0].task_id, "ORB-keep");
+    assert_eq!(
+        summary.notable_completions.items[0].impact_tag.as_deref(),
+        Some("impact:maintenance")
+    );
+    assert_eq!(
+        summary.coverage.review.availability,
+        CoverageAvailability::Unavailable
+    );
+}
+
+#[test]
+fn excerpt_collapses_whitespace_and_keeps_short_text() {
+    assert_eq!(
+        excerpt_execution_summary("  Outcome: success \n\n landed  "),
+        Some("Outcome: success landed".to_string())
+    );
+    assert_eq!(excerpt_execution_summary(" \n "), None);
+}

--- a/crates/orbit-store/src/file/scoreboard/scoreboard_summary/tests/mod.rs
+++ b/crates/orbit-store/src/file/scoreboard/scoreboard_summary/tests/mod.rs
@@ -1,1 +1,2 @@
+mod highlights;
 mod scoreboard_summary;

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -74,12 +74,13 @@ pub mod pr_scoreboard {
 
 pub mod scoreboard_summary {
     pub use crate::file::scoreboard::scoreboard_summary::{
-        AgentSummary, FrictionSummary, NormalizedTokenSummary, ORCHESTRATION_SCHEMA_VERSION,
+        AgentSummary, CoverageAvailability, CoverageNote, FrictionSummary, NormalizedTokenSummary,
+        NotableCompletion, NotableCompletions, ORCHESTRATION_SCHEMA_VERSION,
         OrchestrationBucketKind, OrchestrationBucketSummary, OrchestrationModelSummary,
-        OrchestrationSummary, PrSummary, RecentSummary, ScoreboardInputs, ScoreboardSummary,
-        ScoreboardWindow, TokenSummary, TopToolCall, WorkflowRunCount, generate_summary,
-        generate_summary_with_audit_tool_calls, generate_summary_with_inputs, summary_path,
-        write_summary,
+        OrchestrationSummary, PrSummary, RecentSummary, ScoreboardCoverage, ScoreboardInputs,
+        ScoreboardSummary, ScoreboardWindow, TokenSummary, TopToolCall, WorkflowRunCount,
+        generate_summary, generate_summary_with_audit_tool_calls, generate_summary_with_inputs,
+        summary_path, write_summary,
     };
 }
 

--- a/crates/orbit-web/assets/dashboard/common.js
+++ b/crates/orbit-web/assets/dashboard/common.js
@@ -94,6 +94,19 @@ export function persistScopeToUrl() {
   }
 }
 
+function windowTabs(selector) {
+  return Array.from(selector.querySelectorAll(".scoreboard-window-seg"));
+}
+
+function syncWindowTabState(selector, target) {
+  for (const tab of windowTabs(selector)) {
+    const on = tab.dataset.window === target;
+    tab.classList.toggle("on", on);
+    tab.setAttribute("aria-selected", on ? "true" : "false");
+    tab.tabIndex = on ? 0 : -1;
+  }
+}
+
 export function syncWindowSelectors() {
   const selected = currentWindow;
   const rel = reliabilityWindowFor(selected);
@@ -103,10 +116,17 @@ export function syncWindowSelectors() {
   ]) {
     const selector = document.getElementById(id);
     if (!selector) continue;
-    for (const seg of selector.querySelectorAll(".scoreboard-window-seg")) {
-      seg.classList.toggle("on", seg.dataset.window === target);
-    }
+    syncWindowTabState(selector, target);
   }
+}
+
+function activateWindowTab(tab, allowed) {
+  const next = tab && tab.dataset.window;
+  if (!next || !allowed.includes(next) || next === currentWindow) return;
+  setWindow(next);
+  persistScopeToUrl();
+  syncWindowSelectors();
+  notifyScopeChange();
 }
 
 export function wireWindowSelector(selectorId, opts = {}) {
@@ -115,14 +135,26 @@ export function wireWindowSelector(selectorId, opts = {}) {
   selector.dataset.wired = "true";
   const allowed = opts.allowAll === false ? RELIABILITY_WINDOWS : DASHBOARD_WINDOWS;
   selector.addEventListener("click", (event) => {
-    const seg = event.target && event.target.closest(".scoreboard-window-seg");
-    if (!seg || !selector.contains(seg)) return;
-    const next = seg.dataset.window;
-    if (!allowed.includes(next) || next === currentWindow) return;
-    setWindow(next);
-    persistScopeToUrl();
-    syncWindowSelectors();
-    notifyScopeChange();
+    const tab = event.target && event.target.closest(".scoreboard-window-seg");
+    if (!tab || !selector.contains(tab)) return;
+    activateWindowTab(tab, allowed);
+  });
+  selector.addEventListener("keydown", (event) => {
+    const tab = event.target && event.target.closest(".scoreboard-window-seg");
+    if (!tab || !selector.contains(tab)) return;
+    const tabs = windowTabs(selector);
+    const index = tabs.indexOf(tab);
+    if (index < 0) return;
+    let nextIndex = null;
+    if (event.key === "ArrowRight") nextIndex = (index + 1) % tabs.length;
+    else if (event.key === "ArrowLeft") nextIndex = (index - 1 + tabs.length) % tabs.length;
+    else if (event.key === "Home") nextIndex = 0;
+    else if (event.key === "End") nextIndex = tabs.length - 1;
+    if (nextIndex == null) return;
+    event.preventDefault();
+    const nextTab = tabs[nextIndex];
+    nextTab.focus();
+    activateWindowTab(nextTab, allowed);
   });
 }
 

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -1606,16 +1606,29 @@
         cursor: not-allowed;
       }
       .scoreboard-window-seg {
+        appearance: none;
         padding: 4px 10px;
         color: var(--fg-dim);
         background: transparent;
+        border: 0;
         border-right: 1px solid var(--border);
+        border-radius: 0;
+        font: inherit;
+        letter-spacing: inherit;
+        text-transform: inherit;
+        cursor: pointer;
         user-select: none;
       }
       .scoreboard-window-seg:last-child { border-right: none; }
       .scoreboard-window-seg.on {
         color: var(--fg);
         background: var(--bg);
+      }
+      .scoreboard-window-seg:focus-visible {
+        outline: 2px solid var(--accent-hover);
+        outline-offset: -2px;
+        z-index: 1;
+        position: relative;
       }
 
       .scoreboard-controls {
@@ -1662,6 +1675,90 @@
       .scoreboard-insights .ag-tag.gemini { color: var(--ag-gemini); background: var(--ag-gemini-low); }
       .scoreboard-narrative .ag-tag.grok,
       .scoreboard-insights .ag-tag.grok { color: var(--ag-grok); background: var(--ag-grok-low); }
+
+      .scoreboard-highlights-host {
+        border-bottom: 1px solid var(--border);
+        background: var(--bg);
+        min-width: 0;
+      }
+      .scoreboard-highlights-host:empty { display: none; }
+      .scoreboard-highlights {
+        padding: 12px 16px 14px;
+        display: grid;
+        gap: 10px;
+        min-width: 0;
+      }
+      .scoreboard-highlights-heading {
+        display: grid;
+        gap: 4px;
+        min-width: 0;
+      }
+      .scoreboard-highlights-title {
+        margin: 0;
+        font-family: var(--font-sans);
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--fg);
+      }
+      .scoreboard-highlights-rule {
+        margin: 0;
+        font-size: 12px;
+        line-height: 1.45;
+        color: var(--fg-dim);
+        overflow-wrap: anywhere;
+      }
+      .scoreboard-highlights-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 8px;
+        min-width: 0;
+      }
+      .scoreboard-highlight {
+        display: grid;
+        gap: 4px;
+        min-width: 0;
+        padding: 8px 10px;
+        border: 1px solid var(--border);
+        border-radius: 2px;
+        background: var(--bg-elev, #111);
+      }
+      .scoreboard-highlight-head,
+      .scoreboard-highlight-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px 12px;
+        align-items: baseline;
+        min-width: 0;
+      }
+      .scoreboard-highlight-id {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--accent-hover, var(--accent));
+      }
+      .scoreboard-highlight-title {
+        font-size: 13px;
+        color: var(--fg);
+        overflow-wrap: anywhere;
+        min-width: 0;
+      }
+      .scoreboard-highlight-meta {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--fg-dim);
+      }
+      .scoreboard-highlight-excerpt {
+        margin: 0;
+        font-size: 12.5px;
+        line-height: 1.45;
+        color: var(--fg);
+        overflow-wrap: anywhere;
+      }
+      .scoreboard-highlight-excerpt.missing {
+        color: var(--fg-dim);
+        font-style: italic;
+      }
 
       .scoreboard-agent-strip {
         border-bottom: 1px solid var(--border);
@@ -1765,6 +1862,19 @@
       @media (max-width: 1000px) {
         .scoreboard-agent-strip-inner {
           grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+      @media (max-width: 720px) {
+        table.sb2-matrix col.metric { width: 132px; }
+        table.sb2-matrix tr.group td,
+        table.sb2-matrix td.m-label {
+          white-space: normal;
+          overflow-wrap: anywhere;
+        }
+        table.sb2-matrix tr.group td .badge {
+          display: block;
+          margin-left: 0;
+          margin-top: 4px;
         }
       }
       @media (max-width: 620px) {

--- a/crates/orbit-web/assets/dashboard/index.html
+++ b/crates/orbit-web/assets/dashboard/index.html
@@ -225,12 +225,12 @@
           <div class="scoreboard-controls" id="reliability-controls">
             <div class="scoreboard-control-group">
               <span class="scoreboard-control-label">window</span>
-              <span class="scoreboard-window-selector" id="reliability-window-selector" title="window scope">
-                <span class="scoreboard-window-seg" data-window="1h">1h</span>
-                <span class="scoreboard-window-seg" data-window="24h">24h</span>
-                <span class="scoreboard-window-seg on" data-window="7d">7d</span>
-                <span class="scoreboard-window-seg" data-window="30d">30d</span>
-              </span>
+              <div class="scoreboard-window-selector" id="reliability-window-selector" role="tablist" aria-label="Reliability time window">
+                <button type="button" role="tab" class="scoreboard-window-seg" data-window="1h" aria-selected="false" tabindex="-1">1h</button>
+                <button type="button" role="tab" class="scoreboard-window-seg" data-window="24h" aria-selected="false" tabindex="-1">24h</button>
+                <button type="button" role="tab" class="scoreboard-window-seg on" data-window="7d" aria-selected="true" tabindex="0">7d</button>
+                <button type="button" role="tab" class="scoreboard-window-seg" data-window="30d" aria-selected="false" tabindex="-1">30d</button>
+              </div>
             </div>
             <span class="scoreboard-controls-spacer"></span>
             <span class="scoreboard-controls-meta" id="reliability-meta">-</span>
@@ -268,19 +268,20 @@
               <span class="scoreboard-control-label">window</span>
               <!-- Window selector — click a segment to refetch the
                    scoreboard scoped to that window. Wired in ORB-00337. -->
-              <span class="scoreboard-window-selector" id="scoreboard-window-selector" title="window scope">
-                <span class="scoreboard-window-seg" data-window="1h">1h</span>
-                <span class="scoreboard-window-seg on" data-window="24h">24h</span>
-                <span class="scoreboard-window-seg" data-window="7d">7d</span>
-                <span class="scoreboard-window-seg" data-window="30d">30d</span>
-                <span class="scoreboard-window-seg" data-window="all">all</span>
-              </span>
+              <div class="scoreboard-window-selector" id="scoreboard-window-selector" role="tablist" aria-label="Scoreboard time window">
+                <button type="button" role="tab" class="scoreboard-window-seg" data-window="1h" aria-selected="false" tabindex="-1">1h</button>
+                <button type="button" role="tab" class="scoreboard-window-seg on" data-window="24h" aria-selected="true" tabindex="0">24h</button>
+                <button type="button" role="tab" class="scoreboard-window-seg" data-window="7d" aria-selected="false" tabindex="-1">7d</button>
+                <button type="button" role="tab" class="scoreboard-window-seg" data-window="30d" aria-selected="false" tabindex="-1">30d</button>
+                <button type="button" role="tab" class="scoreboard-window-seg" data-window="all" aria-selected="false" tabindex="-1">all</button>
+              </div>
             </div>
             <span class="scoreboard-controls-spacer"></span>
             <span class="scoreboard-controls-meta" id="scoreboard-meta">-</span>
           </div>
           <div id="scoreboard-narrative" class="scoreboard-narrative"></div>
           <div id="scoreboard-agent-strip" class="scoreboard-agent-strip"></div>
+          <section id="scoreboard-highlights" class="scoreboard-highlights-host" aria-label="Notable completions"></section>
           <div class="body scoreboard-table-wrap" id="scoreboard-body">
             <div class="skeleton-state">
               <div class="skeleton skeleton-row"></div>

--- a/crates/orbit-web/assets/dashboard/scoreboard.js
+++ b/crates/orbit-web/assets/dashboard/scoreboard.js
@@ -75,7 +75,12 @@ const DELIVERY_SCOREBOARD_COLUMNS = [
 
 const PR_REVIEW_COLUMNS = [
   { key: "agent", label: "agent", num: false },
-  { key: "pr.review_comments", label: "pr rev", num: true },
+  {
+    key: "pr.review_comments",
+    label: "pr rev",
+    num: true,
+    title: "pull-request review comments from the lifetime snapshot",
+  },
 ];
 
 const OPERATIONS_SCOREBOARD_COLUMNS = [
@@ -92,7 +97,7 @@ const OPERATIONS_SCOREBOARD_COLUMNS = [
     label: "task calls",
     num: true,
     compute: (agent) => agent?.tool_calls_by_surface?.task ?? 0,
-    title: "orbit.task.* calls",
+    title: "orbit.task.* tool-call count",
   },
   {
     key: "tools",
@@ -101,7 +106,7 @@ const OPERATIONS_SCOREBOARD_COLUMNS = [
     format: "pair",
     left: "failed_tool_calls",
     right: "tool_calls",
-    title: "raw failed tool calls / total tool calls",
+    title: "raw failed tool calls over total tool calls",
     help: "raw events",
   },
   // ORB-10871: the same failures, grouped. A repeated burst is one incident
@@ -118,7 +123,12 @@ const OPERATIONS_SCOREBOARD_COLUMNS = [
     title: "grouped failure incidents / raw failed events they collapsed",
     help: "grouped",
   },
-  { key: "friction.reported", label: "frict r", num: true },
+  {
+    key: "friction.reported",
+    label: "friction",
+    num: true,
+    title: "append-only friction reports filed by this agent",
+  },
 ];
 
 function allScoreboardSections() {
@@ -163,6 +173,7 @@ function renderScoreboard(summary) {
   const body = $("scoreboard-body");
   const narrativeHost = $("scoreboard-narrative");
   const agentStrip = $("scoreboard-agent-strip");
+  const highlightsHost = $("scoreboard-highlights");
   const meta = $("scoreboard-meta");
   const insightsHost = $("scoreboard-insights");
   const insightsCount = $("scoreboard-insights-count");
@@ -180,6 +191,7 @@ function renderScoreboard(summary) {
     ])]);
     if (narrativeHost) syncNodes(narrativeHost, []);
     if (agentStrip) syncNodes(agentStrip, []);
+    if (highlightsHost) syncNodes(highlightsHost, [renderNotableCompletions(summary?.notable_completions)]);
     if (meta) meta.textContent = "-";
     if (insightsHost) syncNodes(insightsHost, []);
     if (insightsCount) insightsCount.textContent = "—";
@@ -196,8 +208,12 @@ function renderScoreboard(summary) {
   if (agentStrip) {
     syncNodes(agentStrip, [renderAgentStrip(canonicalRows)]);
   }
+  if (highlightsHost) {
+    syncNodes(highlightsHost, [renderNotableCompletions(summary?.notable_completions)]);
+  }
   const matrix = buildLeaderboardMatrix(canonicalRows, allScoreboardSections(), {
     showSectionDividers: true,
+    coverage: summary?.coverage,
   });
   syncNodes(body, [el("div", { class: "scoreboard-sections" }, [matrix])]);
 
@@ -530,7 +546,7 @@ function buildLeaderboardMatrix(rows, sectionList, opts = {}) {
       .filter((candidate) => metricHasActivity(rows, candidate));
     if (showSectionDividers) {
       const badge = metrics.length === 0
-        ? "no activity this window"
+        ? emptySectionBadge(section.title, opts.coverage)
         : section.badge;
       tbody.appendChild(sectionDividerRow(section.title, badge, columnCount));
     }
@@ -538,13 +554,15 @@ function buildLeaderboardMatrix(rows, sectionList, opts = {}) {
       const rowMax = rowMaxValue(rows, col);
       const tr = el("tr", { class: "metric" });
       tr.dataset.key = `scoreboard-${section.title}-${col.key}`;
-      tr.appendChild(el("td", {
+      const metricLabel = el("td", {
         class: "m-label",
         title: col.title || col.label,
       }, [
         document.createTextNode(col.label),
         ...(col.help ? [el("span", { class: "help", text: col.help })] : []),
-      ]));
+      ]);
+      metricLabel.setAttribute("aria-label", col.title || col.label);
+      tr.appendChild(metricLabel);
       for (const [name, agent] of rows) {
         const value = scoreboardColumnValue(agent, col);
         const isLeader = rowMax > 0 && value === rowMax;
@@ -643,7 +661,76 @@ function scoreboardCellNode(name, value, rowMax, isLeader, opts = {}) {
 }
 
 function leaderBadge() {
-  return el("span", { class: "lead-mark", text: "▲", title: "row leader" });
+  const mark = el("span", {
+    class: "lead-mark",
+    text: "▲",
+    title: "Highest count in this row. Not a quality score.",
+  });
+  mark.setAttribute("aria-label", "Highest count in this row. Not a quality score.");
+  return mark;
+}
+
+function emptySectionBadge(title, coverage) {
+  if (title === "Review") {
+    if (coverage?.review?.availability === "unavailable") {
+      return coverage.review.detail
+        || "review snapshot is not windowed; this is missing coverage, not zero activity";
+    }
+    return "no observed review comments in this source";
+  }
+  if (title === "Delivery") return "no observed task events this window";
+  if (title === "Operations") return "no observed tool calls or friction this window";
+  return "no observed events this window";
+}
+
+function formatHighlightTime(raw) {
+  if (!raw) return "completion time unknown";
+  const parsed = Date.parse(raw);
+  if (Number.isNaN(parsed)) return raw;
+  return new Date(parsed).toISOString().replace("T", " ").replace(/\.\d+Z$/, " UTC");
+}
+
+function renderHighlightItem(item) {
+  const bits = [item.priority, item.task_type, item.impact_tag].filter(Boolean);
+  const excerpt = item.summary_excerpt
+    ? el("p", { class: "scoreboard-highlight-excerpt", text: item.summary_excerpt })
+    : el("p", {
+      class: "scoreboard-highlight-excerpt missing",
+      text: "No completion summary recorded.",
+    });
+  const time = el("time", { class: "scoreboard-highlight-time", text: formatHighlightTime(item.completed_at) });
+  if (item.completed_at) time.setAttribute("datetime", item.completed_at);
+  return el("li", { class: "scoreboard-highlight" }, [
+    el("div", { class: "scoreboard-highlight-head" }, [
+      el("span", { class: "scoreboard-highlight-id", text: item.task_id || "unknown id" }),
+      el("span", { class: "scoreboard-highlight-title", text: item.title || "(untitled)" }),
+    ]),
+    el("div", { class: "scoreboard-highlight-meta" }, [
+      el("span", { class: "scoreboard-highlight-tags", text: bits.join(" · ") || "no priority or type" }),
+      time,
+    ]),
+    excerpt,
+  ]);
+}
+
+function renderNotableCompletions(block) {
+  const items = Array.isArray(block?.items) ? block.items : [];
+  const label = block?.label
+    || "Ordered by priority, then most recently completed. This is a reading order, not a quality score.";
+  const children = [
+    el("div", { class: "scoreboard-highlights-heading" }, [
+      el("h3", { class: "scoreboard-highlights-title", text: "Notable completions" }),
+      el("p", { class: "scoreboard-highlights-rule", text: label }),
+    ]),
+  ];
+  if (items.length === 0) {
+    children.push(el("div", { class: "empty-state compact" }, [
+      el("div", { class: "text", text: "No completed tasks observed in this window." }),
+    ]));
+  } else {
+    children.push(el("ul", { class: "scoreboard-highlights-list" }, items.map(renderHighlightItem)));
+  }
+  return el("section", { class: "scoreboard-highlights" }, children);
 }
 
 function emptyScoreboardNode() {

--- a/crates/orbit-web/src/api/tests/scoreboard.rs
+++ b/crates/orbit-web/src/api/tests/scoreboard.rs
@@ -6,8 +6,8 @@
 // - `?window=1h` round-trips into the serialized payload + populates
 //   `window_since`
 // - unknown values produce HTTP 400 (not a 500)
-// - schema_version is the post-retirement v8 value with its separately-versioned
-//   managed-execution orchestration section
+// - schema_version is the v9 value (notable completions + coverage) with its
+//   separately-versioned managed-execution orchestration section
 
 use std::sync::Arc;
 
@@ -38,14 +38,29 @@ async fn get_scoreboard(runtime: OrbitRuntime, query: Option<&str>) -> axum::res
 }
 
 #[tokio::test]
-async fn scoreboard_default_returns_lifetime_window_and_v8_schema() {
+async fn scoreboard_default_returns_lifetime_window_and_v9_schema() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     let response = get_scoreboard(runtime, None).await;
 
     assert_eq!(response.status(), StatusCode::OK);
     let body = body_json(response).await;
-    assert_eq!(body["schema_version"].as_u64(), Some(8));
+    assert_eq!(body["schema_version"].as_u64(), Some(9));
     assert_eq!(body["window"].as_str(), Some("all"));
+    assert_eq!(
+        body["coverage"]["review"]["availability"].as_str(),
+        Some("observed")
+    );
+    assert_eq!(
+        body["notable_completions"]["method"].as_str(),
+        Some("priority_then_completion_recency")
+    );
+    assert!(
+        body["notable_completions"]["label"]
+            .as_str()
+            .expect("selection label")
+            .contains("not a quality score")
+    );
+    assert!(body["notable_completions"]["items"].as_array().is_some());
     assert!(
         body["window_since"].is_null(),
         "window_since is null for lifetime, got {:?}",
@@ -82,8 +97,18 @@ async fn scoreboard_query_window_1h_populates_window_and_since() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let body = body_json(response).await;
-    assert_eq!(body["schema_version"].as_u64(), Some(8));
+    assert_eq!(body["schema_version"].as_u64(), Some(9));
     assert_eq!(body["window"].as_str(), Some("1h"));
+    assert_eq!(
+        body["coverage"]["review"]["availability"].as_str(),
+        Some("unavailable")
+    );
+    assert!(
+        body["coverage"]["review"]["detail"]
+            .as_str()
+            .expect("coverage detail")
+            .contains("omitted from this window")
+    );
     assert!(body["orchestration"]["previous_normalized_tokens"].is_object());
     let since = body["window_since"]
         .as_str()

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -628,6 +628,7 @@ async fn dashboard_scoreboard_is_reachable_under_diagnostics() {
         "scoreboard-insights",
         "scoreboard-orchestration",
         "scoreboard-orchestration-count",
+        "scoreboard-highlights",
     ] {
         assert!(body.contains(&format!(r#"id="{id}""#)), "{id} must survive");
     }
@@ -1354,6 +1355,89 @@ fn dashboard_failure_metrics_are_incident_aware_and_state_their_denominators() {
             && css[responsive_at..].contains(".incident-evidence"),
         "the incident expansion must reflow rather than clip below 720px"
     );
+}
+
+/// ORB-10873: Scoreboard delivery highlights, honest empty-section coverage,
+/// accessible window tabs, and labeled abbreviations. Assets stay
+/// project-agnostic.
+#[test]
+fn dashboard_scoreboard_highlights_are_accessible_and_honest() {
+    let index = include_str!("../../assets/dashboard/index.html");
+    let scoreboard = include_str!("../../assets/dashboard/scoreboard.js");
+    let common = include_str!("../../assets/dashboard/common.js");
+    let css = include_str!("../../assets/dashboard/dashboard.css");
+
+    assert!(
+        index.contains(r#"id="scoreboard-window-selector" role="tablist" aria-label="Scoreboard time window""#)
+            && index.contains(r#"id="reliability-window-selector" role="tablist" aria-label="Reliability time window""#),
+        "window controls must be semantic tablists"
+    );
+    assert!(
+        index.contains(
+            r#"role="tab" class="scoreboard-window-seg on" data-window="24h" aria-selected="true""#
+        ) && common.contains("setAttribute(\"aria-selected\"")
+            && common.contains("ArrowRight")
+            && common.contains("ArrowLeft")
+            && common.contains("Home")
+            && common.contains("End"),
+        "window tabs must expose selected state and keyboard navigation"
+    );
+    assert!(
+        css.contains(".scoreboard-window-seg:focus-visible"),
+        "window tabs must have a visible focus ring"
+    );
+
+    assert!(
+        scoreboard.contains("Notable completions")
+            && scoreboard.contains("not a quality score")
+            && scoreboard.contains("No completion summary recorded.")
+            && scoreboard.contains("function renderNotableCompletions("),
+        "highlights must name the reading order and missing summaries"
+    );
+    assert!(
+        !scoreboard.contains("quality score") || scoreboard.contains("not a quality score"),
+        "the UI must not claim an objective quality score"
+    );
+    assert!(
+        scoreboard.contains("no observed review comments in this source")
+            && scoreboard.contains("coverage?.review?.availability === \"unavailable\"")
+            && scoreboard.contains("missing coverage, not zero activity"),
+        "empty Review must distinguish no events from incomplete coverage"
+    );
+    assert!(
+        scoreboard.contains("orbit.task.* tool-call count")
+            && scoreboard.contains("raw failed tool calls over total tool calls")
+            && scoreboard.contains("append-only friction reports filed by this agent")
+            && scoreboard.contains("Highest count in this row. Not a quality score."),
+        "abbreviated metrics and the leader mark need plain-language definitions"
+    );
+    assert!(
+        !scoreboard.contains("frict r"),
+        "the unexplained frict r abbreviation must be gone"
+    );
+
+    assert!(
+        css.contains(".scoreboard-highlights")
+            && css.contains(".scoreboard-highlight-excerpt")
+            && css.contains("overflow-wrap: anywhere;"),
+        "highlights must wrap instead of clipping"
+    );
+    let scoreboard_720 = css
+        .find("table.sb2-matrix col.metric { width: 132px; }")
+        .expect("narrow scoreboard metric column");
+    assert!(
+        css[..scoreboard_720].contains("@media (max-width: 720px)"),
+        "matrix labels must wrap at 480–720px"
+    );
+
+    for banned in ["constellation", "dk-server", "polaris", "SpaceX"] {
+        assert!(
+            !scoreboard
+                .to_ascii_lowercase()
+                .contains(&banned.to_ascii_lowercase()),
+            "scoreboard assets must stay project-agnostic; found {banned}"
+        );
+    }
 }
 
 async fn response_body(response: Response) -> String {

--- a/docs/design/user-interface/2_design.md
+++ b/docs/design/user-interface/2_design.md
@@ -16,7 +16,9 @@ This document describes the current Orbit UI implementation: the local dashboard
 
 ## 1. Dense Layout
 
-The dashboard favors wide, dense tables and panels over narrative screens. Tight spacing, small radii, and expandable sunken detail rows preserve hierarchy without hiding root lists. The scoreboard groups per-agent metrics into Delivery, Review, Knowledge, Operations, and Attribution Cleanup sections so task attribution, review work, tool reliability, and knowledge artifacts are scanned separately. Compact pair cells stay local to the sections where they add context: `tool fail/all` is failed over total tool calls [T20260428-15] [ORB-00144] [Grouped Scoreboard Sections](./4_decisions.md#grouped-scoreboard-sections).
+The dashboard favors wide, dense tables and panels over narrative screens. Tight spacing, small radii, and expandable sunken detail rows preserve hierarchy without hiding root lists. The scoreboard groups per-agent metrics into Delivery, Review, Knowledge, Operations, and Attribution Cleanup sections so task attribution, review work, tool reliability, and knowledge artifacts are scanned separately. Compact pair cells stay local to the sections where they add context: `tool fail/all` is failed over total tool calls, and every abbreviated metric or leader mark has a plain-language title or accessible name [T20260428-15] [ORB-00144] [ORB-10873] [Grouped Scoreboard Sections](./4_decisions.md#grouped-scoreboard-sections).
+
+The selected window also includes a compact Notable completions list built only from durable task fields (id, title, priority, type, optional `impact:*` tag, completion timestamp, bounded `execution_summary` excerpt). Selection is priority then completion recency, labeled as a reading order rather than a quality score. Empty Review and other snapshot-backed sections distinguish no observed events from unavailable windowed coverage: PR comments come from a lifetime snapshot with no per-event timestamps, so a finite window reports that limitation instead of "no activity". Window selectors are `role="tablist"` buttons with `aria-selected`, keyboard movement, and a visible focus ring [ORB-10873].
 
 ## 2. Layered Palette
 
@@ -102,5 +104,6 @@ Accessibility still needs a real WCAG pass; responsive behavior remains optimize
 - [ORB-10875] added the Operations view and typed routine/clock controls.
 - [ORB-10872] made workspace and time window one dashboard scope across Scoreboard, Audit, Reliability, and Managed Execution.
 - [ORB-10871] made dashboard failure metrics incident-aware: grouped incidents and raw failed events are reported side by side with their denominators and window.
+- [ORB-10873] added Scoreboard notable completions, honest coverage language, labeled abbreviations, and accessible window tabs.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10873](https://orbit-cli.com/tasks/ORB-10873) — Add delivery highlights and honest, accessible semantics to the Scoreboard

### Description

## Problem
The Scoreboard measures task-event volume but does not show what was delivered. A week containing a substantial structural cleanup is reduced to counts such as created, planned, and completed, so high-impact maintenance work is invisible.

Several labels are also ambiguous: `task calls`, `tool fail/all`, `frict r`, and the ▲ marker lack definitions. `Review no activity this window` does not distinguish a true absence from missing attribution or telemetry coverage. The window selectors are clickable `span` elements rather than semantic buttons/tabs with selected state.

## Why It Matters
A scorecard should support a fair qualitative reading without inventing a subjective quality score. Operators need traceable delivery evidence, honest coverage language, keyboard navigation, and assistive-technology support.

## Constraints / Notes
- Build highlights only from durable task fields and explicit metadata; do not ask a model to infer importance from prose.
- Prefer deterministic ordering such as priority then completion recency, with a clear label, rather than claiming an objective impact rank.
- Keep the shipped dashboard project-agnostic.
- Related completed presentation work: ORB-10589 and ORB-10444.

### Acceptance Criteria

- The selected Scoreboard window includes a compact Notable completions section showing task ID, title, priority/type or explicit impact tag when available, completion timestamp, and a bounded completion-summary excerpt.
- Highlight selection is deterministic, documented, and traceable to durable task data; the UI does not claim that recency, priority, task count, or text length is an objective quality score.
- Every abbreviated metric and symbol, including task-call counts, failure numerator/denominator, friction count, and leader/trend markers, has a plain-language label or accessible definition.
- Review and other empty sections distinguish no observed events from incomplete attribution/coverage, and display the relevant coverage or source limitation when known.
- The 1h/24h/7d/30d/all controls use semantic buttons or tabs with keyboard navigation, visible focus, and aria-selected or equivalent selected-state exposure.
- Cards, tables, tooltips/disclosures, and highlights retain a readable hierarchy at desktop and 480-720px widths without clipping or horizontal overflow.
- Deterministic API/UI tests cover highlight ordering and truncation, missing summaries/coverage, accessible window controls, and project-agnostic asset guards; focused tests and git diff --check pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Scoreboard schema v9 projects a Notable completions list from durable task fields (id, title, priority, type, optional impact:* tag, updated_at, bounded execution_summary excerpt). Sort is priority then completion recency then id, capped at 5, labeled as a reading order not a quality score.
- Added coverage.review / coverage.snapshot_metrics so windowed views say snapshot metrics are unavailable rather than “no activity”.
- Window selectors are tablist buttons with aria-selected, roving tabindex, arrow/home/end keys, and a visible focus ring (shared scoreboard + reliability control).
- Metric abbreviations and the ▲ marker have plain-language titles/aria-labels; frict r is now friction.
- Tests cover highlight ordering/truncation/missing excerpts, API v9 + coverage, and asset accessibility/project-agnostic guards. Design doc updated.
- Extra context: file:crates/orbit-web/assets/dashboard/common.js (shared window control) and file:crates/orbit-store/src/lib.rs (type re-exports).
Assessment: Acceptance criteria are met with deterministic store/API/asset tests. Live 480–720px viewport was not opened; layout is covered by CSS wrap rules and asset tests.
Strategic decisions:
- Highlights live in a sibling highlights.rs module so scoreboard_summary/mod.rs does not grow further.
- Impact tags are only explicit `impact:` prefixes; priority/type are shown separately.
- Completion time reuses the existing updated_at convention.
Design weaknesses / risks:
- Severity: low. updated_at is a best-effort done timestamp if a later edit occurs. Mitigation: documented as existing scoreboard convention; no new history scan.
Validation: cargo test -p orbit-store --lib file::scoreboard::scoreboard_summary (25 ok); cargo test -p orbit-web --lib scoreboard/dashboard_scoreboard* (10 ok); git diff --check; make ci-fast.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10873-6a81655f`
- Behind base: 0
- Ahead of base: 1