### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/task-artifacts/3_vision.md
+++ b/docs/design/task-artifacts/3_vision.md
@@ -4,6 +4,7 @@ type: design
 title: "Task Artifacts — Vision"
 owner: codex
 last_updated: 2026-08-15
+last_validated: 2026-08-16
 status: Draft
 feature: task-artifacts
 doc_role: vision
@@ -28,9 +29,9 @@ This document captures open questions for the task-artifacts reset, prior work t
 
 The v2 design picks the narrowest authority that serves the product surface being implemented. For OSS local-first, one machine-local allocator across all local workspaces is enough. For task sync, repository-registry-global is enough. Hosted Team may later introduce org-global or tenant-global allocation. A bare `ORB-00000` is therefore scoped by its authority; cross-authority references need registry or workspace context.
 
-### 1.2 What happens after `ORB-99999`?
+### 1.2 What happens beyond five digits?
 
-The v2 design deliberately keeps the initial format short: five decimal digits and flat task directories. Most local and team registries should never exhaust that range. If a registry reaches `ORB-99999`, the likely expansion path is to grow the decimal width (`ORB-100000`) while keeping the same flat layout, but that should be ratified by a later ADR rather than preloaded into the initial contract.
+The formatter uses five digits as a minimum display width, while task-id parsing accepts a wider decimal suffix and the allocator's numeric ceiling is `u32::MAX`. The open question is whether a hosted authority should impose a narrower policy cap while keeping the flat bundle layout.
 
 ### 1.3 How structured should acceptance criteria become?
 
@@ -48,7 +49,7 @@ The v2 artifact introduces append-only logs, but the envelope remains a snapshot
 
 ### 1.5 How much local execution context belongs in a task?
 
-`workspace_path` and `repo_root` are currently persisted in task YAML. In v2 they are local bindings, not task identity, and belong in the local task registry's workspace-binding table. The checkout points at that binding with `.orbit/config.yaml` and `workspace_id`. A future sync registry may add a portable workspace selector, but the task envelope should not carry machine-local paths.
+`workspace_path` and `repo_root` are local checkout bindings, not task identity, and belong in the local task registry's workspace-checkout table. The checkout points at that binding with `.orbit/config.yaml` and `workspace_id`. A future sync registry may add a portable workspace selector, but the task envelope should not carry machine-local paths.
 
 ### 1.6 Should old task IDs survive the reset?
 
@@ -56,7 +57,7 @@ No. Orbit is pre-release, so v2 should not carry old `T<YYYYMMDD>-<N>` IDs as su
 
 ### 1.7 Are review threads task artifacts or PR artifacts?
 
-Orbit currently stores review threads on tasks and can sync them with GitHub review comments. The v2 design moves them into task-local thread files. A future GitHub-native review mode may instead treat PR comments as the canonical source and task threads as a projection. The answer depends on whether Orbit remains the source of review truth or simply mirrors host review systems.
+Historical task records stored review threads on tasks. The current v2 contract treats legacy `review-threads/` directories as inert sidecars and the review-thread surface as retired. A future GitHub-native review mode may instead treat PR comments as the canonical source and task threads as a projection. The answer depends on whether Orbit remains the source of review truth or simply mirrors host review systems.
 
 ### 1.8 Should archived tasks be compacted?
 
@@ -78,7 +79,7 @@ The v2 design uses symlinks for `.orbit/tasks/<task-id>` so workspace-relative p
 
 ### 2.1 Orbit task store
 
-The existing `orbit-store::file::task_store` implementation is the baseline. It proves that directory-per-task bundles are inspectable, easy to back up, and easy for agents to reason about. Its main weakness is that it overuses `task.yaml` as both metadata envelope and append log.
+The pre-reset `orbit-store::file::task_store` implementation is the baseline. It proves that directory-per-task bundles are inspectable, easy to back up, and easy for agents to reason about. Its main weakness was that it overused `task.yaml` as both metadata envelope and append log.
 
 ### 2.2 Retired decision artifacts
 

--- a/docs/design/task-artifacts/4_decisions.md
+++ b/docs/design/task-artifacts/4_decisions.md
@@ -4,6 +4,7 @@ type: design
 title: "Task Artifacts — Decisions"
 owner: codex
 last_updated: 2026-08-11
+last_validated: 2026-08-16
 status: Draft
 feature: task-artifacts
 doc_role: decisions
@@ -26,14 +27,14 @@ The current `T<YYYYMMDD>-<N>` format is allocated by scanning one workspace's ta
 
 ### Decision
 
-Adopt `ORB-00000` as the canonical v2 task ID format: `ORB-` plus a five-digit decimal suffix allocated by an explicit authority. The ID is unique inside that authority, not across unrelated local registries. V2 task bundles do not preserve old `T...` identifiers as aliases.
+Adopt `ORB-00000` as the canonical v2 task ID example: `ORB-` plus a decimal suffix formatted with at least five digits and allocated by an explicit authority. The ID is unique inside that authority, not across unrelated local registries. V2 task bundles do not preserve old `T...` identifiers as aliases.
 
 ### Consequences
 
 - Task IDs become meaningful inside the scope of the configured allocator instead of implicitly workspace-local.
 - Local-only Orbit uses one allocator across all local workspaces, so one machine does not mint the same ID for two repositories.
 - Two unrelated local registries may both allocate the same bare ID; cross-registry references must carry registry, workspace, hosted tenant, or external-reference context.
-- Implementations must stop validating only `T<YYYYMMDD>-<N>` and must add numeric `ORB-\d{5}` validation.
+- Implementations must stop validating only `T<YYYYMMDD>-<N>` and must validate numeric `ORB-<digits>` task IDs, using five digits as the formatter's minimum width.
 - Existing local tasks need a cutover command, but the result is a clean v2 task store rather than a dual-ID store.
 - Cost: task creation now depends on an allocator outside the task directory scan. Sync and hosted modes need shared allocation before a task can be published.
 
@@ -44,7 +45,7 @@ Adopt `ORB-00000` as the canonical v2 task ID format: `ORB-` plus a five-digit d
 
 ### Context
 
-`task.yaml` currently stores metadata, long prose, acceptance criteria, comments, history, and review threads together. This makes simple tasks easy to inspect, but it turns every content edit or append into a YAML rewrite and makes Markdown-hostile fields harder for humans and agents to author.
+The pre-reset `task.yaml` stored metadata, long prose, acceptance criteria, comments, history, and review threads together. This made simple tasks easy to inspect, but it turned every content edit or append into a YAML rewrite and made Markdown-hostile fields harder for humans and agents to author.
 
 ### Decision
 
@@ -194,7 +195,7 @@ Each `Plan` is monotonically versioned within a single lineage. Cross-lineage re
 
 - The read path in `v2_bundle::read_bundle_at` goes through `task_migrations::envelope_plan().migrate(...)` before deserializing into `TaskEnvelopeV2`. Today the chain is empty; the next schema bump adds one `add_step(prev, fn)` call.
 - A new `OrbitError::Migration(String)` variant carries chain failures distinctly from `OrbitError::Store` so callers (and logs) can tell schema drift apart from IO/parse errors.
-- Other artifacts adopt the framework when their owners are ready; nothing is forced. Review-thread metadata and artifact manifest still go through `read_yaml_file` until they need a step.
+- Other artifacts adopt the framework when their owners are ready; nothing is forced. The artifact manifest still goes through `read_yaml_file` until it needs a step; retired review-thread sidecars are not part of bundle validity.
 - Cost: a single `Value` round-trip per envelope read (parse-to-`Value`, then `from_value::<T>`) replaces a direct `from_str::<T>`. Negligible for envelope-sized YAML; benchmark before extending to large lineages.
 - Cost: the framework lives in `orbit-common`, the most-depended-on crate. The surface is small (`Plan`, `Step`, `read_schema_version`) and depends only on `serde_yaml` and `OrbitError`, both already in `orbit-common`.
 
@@ -209,7 +210,7 @@ Task records already carry a typed `relations` array, but every relation type wa
 
 ### Decision
 
-Add two cross-artifact relation types to the task envelope: `produces` for artifacts created during execution and `resolves` for artifacts closed or superseded by the task. These two relation types accept task, friction, learning, and ADR ID shapes (`ORB-`, `FYYYY-MM-NNN`, `L-NNNN`, `ADR-NNNN+`). Existing relation types remain task-only. Friction auto-close is the only v1 side effect: when a task moves from Review to Done, `resolves -> F...` transitions the friction to `resolved` and records `resolved_by_task`.
+Add two cross-artifact relation types to the task envelope: `produces` for artifacts created during execution and `resolves` for artifacts closed or superseded by the task. These two relation types accept task, friction, and ADR ID shapes (`ORB-`, `FYYYY-MM-NNN`, `ADR-NNNN+`). Retired learning IDs are not valid relation targets. Existing relation types remain task-only. Friction auto-close is the only v1 side effect: when a task moves from Review to Done, `resolves -> F...` transitions the friction to `resolved` and records `resolved_by_task`.
 
 ### Consequences
 

--- a/docs/design/task-artifacts/references/glossary.md
+++ b/docs/design/task-artifacts/references/glossary.md
@@ -1,3 +1,10 @@
+---
+type: design
+summary: "Glossary: Task Artifacts"
+tags: ["task-artifacts"]
+last_validated: 2026-08-16
+---
+
 # Glossary: Task Artifacts
 
 This glossary covers Orbit-specific task artifact terms. Generic issue-tracker or version-control vocabulary is excluded unless Orbit gives the term a narrower meaning.

--- a/docs/design/task-artifacts/specs/task-bundle-v2.md
+++ b/docs/design/task-artifacts/specs/task-bundle-v2.md
@@ -1,3 +1,10 @@
+---
+type: design
+summary: "Spec: Task Bundle V2"
+tags: ["task-artifacts"]
+last_validated: 2026-08-16
+---
+
 # Spec: Task Bundle V2
 
 Task Bundle V2 defines the canonical on-disk contract for Orbit tasks after the schema reset. The contract is source-of-truth storage, not merely a rendering preference: implementations should expose the bundle shape below rather than maintaining long-lived compatibility with the previous task schema.
@@ -24,7 +31,7 @@ The workspace-local projection lives at:
 .orbit/tasks/<task-id> -> ~/.orbit/tasks/workspaces/<workspace-id>/<task-id>
 ```
 
-`<task-id>` must be the canonical ID inside the current allocation authority. The canonical v2 format is `ORB-` plus a five-digit decimal suffix (`ORB-00000` through `ORB-99999`). `<workspace-id>` is assigned once per workspace as `<slug>-<6char>` and stored in `.orbit/config.yaml`. Old `T<YYYYMMDD>-<N>` IDs are not valid v2 identifiers or lookup aliases.
+`<task-id>` must be the canonical ID inside the current allocation authority. The canonical v2 format is `ORB-` plus a decimal suffix formatted with at least five digits (for example, `ORB-00000`); parsers accept wider decimal suffixes and the allocator is bounded by `u32::MAX`. `<workspace-id>` is assigned once per workspace as `<slug>-<6char>` and stored in `.orbit/config.yaml`. Old `T<YYYYMMDD>-<N>` IDs are not valid v2 identifiers or lookup aliases.
 
 Required files:
 
@@ -199,6 +206,8 @@ Relations are directed entries stored in the task envelope. The initial relation
 - `regression_from`: source task tracks a regression introduced by target task.
 - `supersedes`: source task replaces target task.
 - `related_to`: source task is associated with target task without stronger semantics.
+- `produces`: source task created a task, friction, or ADR artifact.
+- `resolves`: source task closed or superseded a task, friction, or ADR artifact.
 
 Writers must validate the relation type set, reject self-edges, reject duplicate `(type, target)` entries on one source task, and reject cycles for hierarchy and blocking relation families. Relation types are source-implied: create-subtask writes only `child_of -> parent` on the child, and create-dependent-task writes only `blocked_by -> dependency` on the blocked task. Inverse lookup is generated from indexes, not stored as peer records.
 

--- a/docs/design/task-migration/1_overview.md
+++ b/docs/design/task-migration/1_overview.md
@@ -2,6 +2,7 @@
 title: Task Migration — Overview
 owner: claude
 last_updated: 2026-07-04
+last_validated: 2026-08-16
 status: Draft
 feature: task-migration
 doc_role: overview
@@ -38,8 +39,8 @@ machine a disjoint id range).
 ## 2. Core Concepts
 
 - **Canonical bundle** — the on-disk source of truth for one task (`task.yaml`
-  envelope + markdown bodies + `events`/`comments` JSONL + review-thread and
-  artifact sidecars). Export copies these verbatim.
+  envelope + markdown bodies + `events`/`comments` JSONL + legacy review-thread
+  and artifact sidecars). Export copies these verbatim.
 - **Manifest** — the single non-bundle entry in an archive: format/schema
   version, source workspace id + slug, task-id list, and `exported_at`.
 - **Global allocator** — one `local` authority in `allocator_state`. Task ids
@@ -112,9 +113,9 @@ The counter only moves forward — a lower `--task-id-start` is refused. For a
 sticky floor across a shared config, set `[tasks] id_start = 10000` in
 `config.toml` (see [../../CONFIG.md](../../CONFIG.md)); it is applied as a
 forward-only floor on every runtime build and never errors on an already-
-advanced counter. Both paths cap at `ORB_TASK_ID_MAX` (99999): a start near the
-ceiling shrinks the machine's usable range, and the range is exhausted once the
-allocator reaches `100000`.
+advanced counter. Both paths cap at the allocator's `ORB_TASK_ID_MAX`
+(`u32::MAX`): five-digit padding is a minimum display width, not an exhaustion
+boundary.
 
 ### Recovering a drifted index
 

--- a/docs/design/user-interface/1_overview.md
+++ b/docs/design/user-interface/1_overview.md
@@ -4,6 +4,7 @@ type: design
 title: "User Interface — Overview"
 owner: gemini
 last_updated: 2026-08-15
+last_validated: 2026-08-16
 status: Draft
 feature: user-interface
 doc_role: overview
@@ -38,7 +39,7 @@ Agent runs produce more state changes, logs, and diagnostics than a human can re
 | Dashboard assets and HTTP API | `crates/orbit-web/assets/dashboard/`, `crates/orbit-web/src/api/` | Runtime tabs, tables, tiles, logs, and diagnostics. |
 | CLI adapter | `crates/orbit-cli/src/command/web.rs` | Delegates `serve` and `connect` to `orbit-web`. |
 | Theme rules | `./specs/theme.md` | Canon Refined tokens and visual invariants. |
-| Current mechanisms | `./2_design.md` | Layout, telemetry, palette, typography, and known limitations. |
+| Dashboard implementation | [crates/orbit-web/src/lib.rs](../../../crates/orbit-web/src/lib.rs) | HTTP server, embedded dashboard assets, workspace state, and API routing. |
 
 ## Task References
 


### PR DESCRIPTION
## Task

[ORB-10882](https://orbit-cli.com/tasks/ORB-10882) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Selected exactly the six never-validated docs, ordered by path after the dated docs: docs/design/task-artifacts/3_vision.md, docs/design/task-artifacts/4_decisions.md, docs/design/task-artifacts/references/glossary.md, docs/design/task-artifacts/specs/task-bundle-v2.md, docs/design/task-migration/1_overview.md, and docs/design/user-interface/1_overview.md.
- Stamped all six with last_validated: 2026-08-16.
- Migrated schema-compatible frontmatter onto the two frontmatter-less docs using the existing inference contract: both classify as design; summaries are Glossary: Task Artifacts and Spec: Task Bundle V2; both receive the inferred task-artifacts tag.
- Corrected verified drift: task IDs use five-digit minimum formatting but accept wider decimal suffixes and are bounded by u32::MAX; retired learning IDs are not valid cross-artifact relation targets; the task-bundle spec now documents produces and resolves; and the UI overview links its implementation row to crates/orbit-web/src/lib.rs.
- Kept prose changes narrow: no new document or section, no prose reflow, and no formatting changes beyond frontmatter and the broken-link/table correction.

Verification evidence:
- Batch selection and frontmatter inventory: rg --files docs | sort plus the read-only frontmatter scan that ordered missing last_validated before dated values with path tie-break.
- Task-artifacts implementation: rg --files crates | rg task; rg checks across crates/orbit-common/src/types/task_artifacts.rs, task-store v2, task migration, registry, and tests; and direct reads of the bundle IO, migration, registry, and fixture code.
- Docs inference and schema: direct reads of crates/orbit-core/src/command/docs/frontmatter.rs, types.rs, migrate.rs, and migration tests.
- Migration commands and config: direct reads of the export, import, and reindex CLI adapters plus id_start and task-id-start searches across core, store, and CLI sources.
- UI claims and link: direct reads of crates/orbit-cli/src/command/web.rs, crates/orbit-web/src/lib.rs, dashboard asset tests, and the theme spec.
- make ci-fast passed; git diff --check passed; the final changed-file list contains only the six selected docs, with no forbidden-path changes.

Unvalidated claims left unchanged:
- Historical and external provenance in the selected design docs was not treated as current implementation: historical review-hook paths, external tracker references, the task-migration narrative about the Mac workspace, and historical T-ID references were not independently re-established from current code and remain unchanged.
- These claims do not affect the validated current behavior documented above.

Assessment: The bounded documentation rotation is complete and the repository gate passes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10882-6a81fee4`
- Behind base: 0
- Ahead of base: 1