### PR TITLE
Reconcile MCP tool advertisement with capability enforcement for operator-only tools

### DIFF
--- a/crates/orbit-common/src/authorization.rs
+++ b/crates/orbit-common/src/authorization.rs
@@ -17,6 +17,33 @@
 //! The goal is narrower and achievable: unintended destruction fails loudly
 //! and leaves a record.
 //!
+//! # Placement is not permission
+//!
+//! Orbit has two independent axes, and this module owns exactly one of them.
+//!
+//! *Placement* is [`crate::operation::OperationSpec::mcp_scope`] and its
+//! registry counterparts (`register_mcp` versus `register_inactive`): which
+//! surfaces *list* a tool. It is an audience decision — what an agent reading
+//! `tools/list` is pointed at — and it authorizes nothing. `tools/list` does no
+//! capability filtering, and the tool registry's `execute` never consults
+//! availability, so an unadvertised tool is still reachable through
+//! `orbit tool run`.
+//!
+//! *Permission* is [`GOVERNED_OPERATIONS`], resolved by [`authorize`] at one
+//! chokepoint per surface. This is the only authorization statement Orbit
+//! makes about a tool, and it is surface-independent: the same answer for an
+//! MCP call, a CLI `tool run`, the dashboard, and the deterministic dispatcher.
+//!
+//! The two therefore need not agree, and deliberately do not. A tool may be
+//! advertised and governed (the operator MCP surface: an operator session sees
+//! and performs it, an agent session sees and is refused), or unadvertised and
+//! ungoverned (`orbit friction show` — kept off the agent MCP surface because
+//! `list` already returns what an agent needs, but freely readable from any
+//! CLI). What must never happen is for a pairing to change by accident. The
+//! guardrail that pins every governed tool's placement is
+//! `crates/orbit-tools/src/builtin/orbit/tests/authorization.rs`, which lives
+//! in the lowest crate that can see both axes at once [ORB-10478].
+//!
 //! # Layering
 //!
 //! The kernel lives in the leaf crate for the same reason the operations-as-data

--- a/crates/orbit-common/src/operation.rs
+++ b/crates/orbit-common/src/operation.rs
@@ -179,6 +179,11 @@ pub struct OperationSpec<V: 'static> {
     pub rejects_agent_field: bool,
     /// MCP scope when advertised. `None` keeps the operation off MCP while it
     /// remains reachable through its other registered surfaces.
+    ///
+    /// This is placement, not permission: it decides who is *shown* the verb,
+    /// never who may perform it. Authorization is
+    /// [`crate::authorization::GOVERNED_OPERATIONS`] alone — see that module's
+    /// "Placement is not permission" section.
     pub mcp_scope: Option<McpToolScope>,
     /// Whether the CLI subcommand offers `--json`.
     pub cli_json_flag: bool,

--- a/crates/orbit-tools/src/builtin/orbit/tests/authorization.rs
+++ b/crates/orbit-tools/src/builtin/orbit/tests/authorization.rs
@@ -1,19 +1,93 @@
-//! Guardrail: the governed-operation registry names real tools [ORB-10453].
+//! Guardrail: the governed-operation registry names real tools [ORB-10453],
+//! and every governed tool's MCP placement is declared [ORB-10478].
 //!
 //! `GOVERNED_OPERATIONS` is declared in `orbit-common`, which sits below the
 //! tool registry and so cannot check itself against it. The registry is keyed by
 //! string, so a renamed or deleted tool would silently stop being governed —
 //! the failure mode is a *disappearing* guard, which no behavioural test
 //! notices because nothing starts failing. This is the test that does.
+//!
+//! It is also the one place both axes are visible at once. Placement (which
+//! surfaces list a tool) lives in the tool registry; permission (who may
+//! perform it) lives in `orbit_common::authorization`. Neither crate can check
+//! the pairing alone, so the invariant is asserted here rather than left to a
+//! reader holding two files open. `orbit-tools` is the lowest crate that sees
+//! both, so this needs no new dependency edge.
 
-use orbit_common::authorization::{GOVERNED_OPERATIONS, OperationSurface};
+use std::collections::BTreeSet;
+
+use orbit_common::authorization::{GOVERNED_OPERATIONS, GovernedOperation, OperationSurface};
+use orbit_common::types::McpCapability;
 
 use crate::ToolRegistry;
+
+/// Whether MCP advertises a governed tool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Placement {
+    /// Listed by `tools/list`, and refused at the chokepoint to any session
+    /// that does not hold the capability the registry names. Legitimate — it
+    /// is how the operator MCP surface is expressed — but never accidental.
+    Advertised,
+    /// Kept off MCP entirely, and reached through the CLI or the dashboard.
+    Unadvertised,
+}
+
+/// Every governed tool operation, paired with the placement it is meant to
+/// have.
+///
+/// Advertisement authorizes nothing, so the two axes are free to disagree —
+/// see `orbit_common::authorization`'s "Placement is not permission" section.
+/// What this table forbids is *silent* disagreement. Advertising a governed
+/// tool, governing an advertised one, or dropping either half fails this test
+/// until the table is updated, which is the moment the decision gets made on
+/// purpose instead of noticed later.
+const GOVERNED_TOOL_PLACEMENT: &[(&str, Placement)] = &[
+    // The operator MCP surface [ORB-10534, ORB-10711]: advertised so an
+    // operator session can drive dispatch over MCP, governed so an agent
+    // session holding only `agent` is refused.
+    ("orbit.command.exec", Placement::Advertised),
+    ("orbit.workflow.run.list", Placement::Advertised),
+    ("orbit.workflow.run.resume", Placement::Advertised),
+    ("orbit.workflow.run.show", Placement::Advertised),
+    ("orbit.workflow.ship", Placement::Advertised),
+    // Destructive administration: off MCP, and governed so that being off MCP
+    // is not the only thing standing between an agent and the operation
+    // [ORB-10453].
+    ("orbit.semantic.uninstall", Placement::Unadvertised),
+    ("orbit.task.delete", Placement::Unadvertised),
+    ("orbit.task.locks.release", Placement::Unadvertised),
+    ("orbit.task.reject", Placement::Unadvertised),
+    ("orbit.workspace.claim.release", Placement::Unadvertised),
+];
+
+/// Reads an agent performs as ordinary work, which must stay ungoverned.
+///
+/// Governing these would refuse an agent `orbit friction list` / `show` from
+/// the CLI. That is the regression the capability chokepoint declined to ship
+/// [ORB-10453], and it is the reason enforcement is not derived from placement
+/// [ORB-10478].
+const AGENT_REACHABLE_FRICTION_READS: &[&str] = &["orbit.friction.list", "orbit.friction.show"];
 
 fn builtin_registry() -> ToolRegistry {
     let mut registry = ToolRegistry::new();
     registry.register_builtins();
     registry
+}
+
+fn governed_tool_operations() -> impl Iterator<Item = &'static GovernedOperation> {
+    GOVERNED_OPERATIONS
+        .iter()
+        .filter(|operation| operation.surface == OperationSurface::Tool)
+}
+
+/// Canonical names MCP advertises, from the same source the server enumerates.
+fn advertised_tool_names(registry: &ToolRegistry) -> BTreeSet<String> {
+    registry
+        .mcp_tool_definitions()
+        .expect("the builtin registry composes valid MCP definitions")
+        .into_iter()
+        .map(|definition| definition.schema.name)
+        .collect()
 }
 
 #[test]
@@ -53,6 +127,71 @@ fn the_destructive_builtins_this_task_closed_are_still_governed() {
         assert!(
             governed.contains(&expected),
             "'{expected}' must stay governed; currently governed: {governed:?}"
+        );
+    }
+}
+
+#[test]
+fn every_governed_tool_declares_the_mcp_placement_it_actually_has() {
+    let registry = builtin_registry();
+    let advertised = advertised_tool_names(&registry);
+
+    let mut observed: Vec<(&str, Placement)> = governed_tool_operations()
+        .map(|operation| {
+            let placement = if advertised.contains(operation.id) {
+                Placement::Advertised
+            } else {
+                Placement::Unadvertised
+            };
+            (operation.id, placement)
+        })
+        .collect();
+    observed.sort();
+
+    let mut declared = GOVERNED_TOOL_PLACEMENT.to_vec();
+    declared.sort();
+
+    assert_eq!(
+        observed, declared,
+        "the governed tools' MCP placement drifted from what this table declares. \
+         Advertisement authorizes nothing, so a mismatch is not automatically a bug — \
+         but it is a decision, so record it here and in \
+         docs/design/operations-as-data/4_decisions.md rather than letting the two \
+         axes diverge unobserved"
+    );
+}
+
+#[test]
+fn an_advertised_governed_tool_is_deliberately_out_of_reach_for_an_agent_session() {
+    let registry = builtin_registry();
+    let advertised = advertised_tool_names(&registry);
+
+    for operation in governed_tool_operations().filter(|op| advertised.contains(op.id)) {
+        assert!(
+            !operation.allowed.contains(&McpCapability::Agent),
+            "'{}' is advertised to every MCP session and governed, yet lists `agent` among its \
+             allowed capabilities — governing an operation the ordinary MCP caller already \
+             holds the capability for buys nothing and hides the entries that do refuse",
+            operation.id
+        );
+    }
+}
+
+#[test]
+fn the_agent_reachable_friction_reads_stay_ungoverned() {
+    // These were left ungoverned on purpose [ORB-10453] and ORB-10478 confirms
+    // the choice: the chokepoint is surface-independent, so governing a read
+    // here would refuse `orbit friction list` to an agent on the CLI, not just
+    // on MCP.
+    let governed: Vec<&str> = governed_tool_operations()
+        .map(|operation| operation.id)
+        .collect();
+
+    for read in AGENT_REACHABLE_FRICTION_READS {
+        assert!(
+            !governed.contains(read),
+            "'{read}' became governed, which refuses an agent an ordinary friction read from \
+             any surface; currently governed: {governed:?}"
         );
     }
 }

--- a/docs/design/operations-as-data/4_decisions.md
+++ b/docs/design/operations-as-data/4_decisions.md
@@ -1,17 +1,17 @@
 ---
 title: Operations as Data — Decisions
 owner: claude
-last_updated: 2026-08-13
-last_validated: 2026-08-09
+last_updated: 2026-08-16
+last_validated: 2026-08-16
 status: Accepted
 feature: operations-as-data
 doc_role: decisions
 type: design
 summary: Decision log for the operations-as-data registry — the split spec/handler table, what stayed hand-written, and the touch-it-move-it ratchet.
 tags: [operations-as-data, architecture, adr-0209]
-paths: ["crates/orbit-common/src/operation.rs", "crates/orbit-common/src/friction/**"]
+paths: ["crates/orbit-common/src/operation.rs", "crates/orbit-common/src/authorization.rs", "crates/orbit-common/src/friction/**", "crates/orbit-tools/src/builtin/orbit/tests/authorization.rs"]
 related_features: [operations-as-data]
-related_artifacts: [ORB-10358]
+related_artifacts: [ORB-10358, ORB-10453, ORB-10478]
 ---
 
 # Operations as Data — Decisions
@@ -27,6 +27,8 @@ the ratchet.
 - **[Split spec/handler table joined by a typed verb enum](#split-spechandler-table-joined-by-a-typed-verb-enum) — Split spec/handler table joined by a typed verb enum** — Accepted.
 - **[Renderers and HTTP routes stay hand-written](#renderers-and-http-routes-stay-hand-written) — Renderers and HTTP routes stay hand-written** — Accepted.
 - **[Freeze the pre-migration surface as fixtures before migrating](#freeze-the-pre-migration-surface-as-fixtures-before-migrating) — Freeze the pre-migration surface as fixtures before migrating** — Accepted.
+- **[Capability chokepoint for destructive operations outside MCP](#capability-chokepoint-for-destructive-operations-outside-mcp) — Capability chokepoint for destructive operations outside MCP** — Accepted.
+- **[MCP advertisement is placement; the capability chokepoint is permission](#mcp-advertisement-is-placement-the-capability-chokepoint-is-permission) — MCP advertisement is placement; the capability chokepoint is permission** — Accepted.
 
 ## Split spec/handler table joined by a typed verb enum
 
@@ -175,7 +177,7 @@ This is an **accident guard, not a security boundary**. Agents on a development 
 - **Per-subcommand guards.** Rejected: `orbit tool run` and every future entry point reopen the hole. This is the failure mode the task was filed against.
 - **A credential, password, or keychain gate.** Rejected on the framing above — no protection, and it would misrepresent the boundary.
 - **Making `ToolRegistry::execute` consult `ToolAvailability`.** Rejected: availability is an MCP advertisement concept, and enforcing it there would refuse operator callers the CLI legitimately serves, deepening rather than resolving the advertisement/enforcement conflation.
-- **Converting the `register_inactive` builtins to `operator_only` policies.** Attractive — advertisement would then derive from the same declaration — but it changes what operator MCP sessions can see, and the capability chokepoint closes the actual bypass without that blast radius. Filed as ORB-10478, which also owns the residual gap noted in Consequences.
+- **Converting the `register_inactive` builtins to `operator_only` policies.** Attractive — advertisement would then derive from the same declaration — but it changes what operator MCP sessions can see, and the capability chokepoint closes the actual bypass without that blast radius. Filed as ORB-10478, which also owns the residual gap noted in Consequences. Settled by [MCP advertisement is placement; the capability chokepoint is permission](#mcp-advertisement-is-placement-the-capability-chokepoint-is-permission): the two declarations stay separate, and a guardrail test pins their pairing.
 
 ### Consequences
 
@@ -184,8 +186,48 @@ This is an **accident guard, not a security boundary**. Agents on a development 
 - Cost: a non-interactive caller with no session grant and no agent envelope — a shell script, a cron entry, a test binary — is now refused governed operations and must set `ORBIT_OPERATOR=1`. This is a real behavior change for automation that previously worked silently, and it landed as churn in three CLI integration tests. It is the intended trade: an unidentified caller performing destruction is precisely the accident being guarded against.
 - Cost: the escape hatch is an environment variable an agent can set, so a *determined* agent is not stopped. That is by construction, not oversight — see the framing. The value delivered is the loud failure and the record, not prevention.
 - Cost: the `governed_when` predicate for flag-gated commands (`--confirm`) lives in the `Commands::operation` arm, so a new destructive CLI command must say that it is one. The requirement itself still lives only in the registry, but the invocation-to-operation mapping is a second thing to remember. The compiler cannot catch a missing mapping.
-- Residual gap, tracked as **ORB-10478**: tools declared `McpExposure::OperatorOnly` (`orbit.friction.list` / `show` / `update`) are refused by the hub MCP *call* path (`admitted()` in `crates/orbit-remote/src/mcp/hub.rs`) but are absent from the registry, so `orbit tool run` still performs them for any caller. They are left ungoverned deliberately: `OperatorOnly` currently encodes audience/placement rather than destructiveness, two of the three are non-destructive reads, and enforcing MCP `allowed_capabilities()` at the tool chokepoint would refuse agents ordinary `orbit friction list` reads — a regression, not a fix. Closing it means separating "who may see this" from "who may perform this", which is ORB-10478's job.
+- Residual gap, formerly tracked as **ORB-10478**, now closed: tools declared `McpExposure::OperatorOnly` (`orbit.friction.list` / `show` / `update`) were refused by the hub MCP *call* path (`admitted()`) but were absent from the registry, so `orbit tool run` still performed them for any caller. They were left ungoverned deliberately, because `OperatorOnly` encoded audience/placement rather than destructiveness and governing a read would have refused agents ordinary `orbit friction list`. See [MCP advertisement is placement; the capability chokepoint is permission](#mcp-advertisement-is-placement-the-capability-chokepoint-is-permission) for the resolution: `McpExposure` and `admitted()` no longer exist, the friction reads stay ungoverned on purpose, and the surviving pairing is pinned by a test.
 - The registry is intentionally small and opt-in. It names the operations whose accidental invocation destroys something, not every mutating tool; broadening it is a judgment call to be made deliberately, per operation.
+
+## MCP advertisement is placement; the capability chokepoint is permission
+
+**Recorded:** 2026-08 · [ORB-10478] · **Implemented** in [ORB-10478]
+**Paths:** `crates/orbit-common/src/authorization.rs`, `crates/orbit-common/src/operation.rs`, `crates/orbit-tools/src/builtin/orbit/tests/authorization.rs`
+
+### Context
+
+[Capability chokepoint for destructive operations outside MCP](#capability-chokepoint-for-destructive-operations-outside-mcp) closed the `orbit tool run` bypass but left one narrower question open, and ORB-10478 was filed to answer it: tools declared `McpExposure::OperatorOnly` were denied at the owner MCP *call* path by `admitted()`, yet were absent from `GOVERNED_OPERATIONS`, so the CLI performed them for any caller. Two surfaces encoded overlapping things, and one of them was acting as an authorization statement without being written as one.
+
+Between the filing and this decision, most of that shape was deleted rather than reconciled. `McpExposure`, `allowed_capabilities()`, `admitted()`, and the `orbit-remote` crate that hosted them are all gone with the owner-route recomposition and the MCP v1 ownership cleanup. What is left is two axes and no overlap between their declarations:
+
+- **Placement** — `OperationSpec::mcp_scope`, and `ToolRegistry::register_mcp` versus `register_inactive`. Decides which surfaces *list* a tool. `tools/list` performs no capability filtering, and `ToolRegistry::execute` never consults availability, so an unadvertised tool remains reachable through `orbit tool run`.
+- **Permission** — `GOVERNED_OPERATIONS`, evaluated by `authorize` at `OrbitRuntime::authorize_tool_operation`, which every tool caller traverses.
+
+The gap the earlier entry named has therefore closed by deletion, not by a fix: `orbit.friction.list` / `show` / `update` are ungoverned, no MCP path denies them, and an agent reads them from the CLI as before. What replaced it is the inverse pairing. `orbit.workflow.ship`, `orbit.workflow.run.{show,list,resume}` ([ORB-10534]) and `orbit.command.exec` ([ORB-10711]) are advertised to every MCP session and governed `operator` at the chokepoint, so an agent session is listed five tools it cannot perform.
+
+### Decision
+
+1. **Placement is not permission, and the two declarations stay separate.** MCP advertisement is an audience decision — what an agent reading `tools/list` is pointed at. It authorizes nothing. `GOVERNED_OPERATIONS` is the only authorization statement Orbit makes about a tool, and it is surface-independent by construction: the same answer for an MCP call, `orbit tool run`, the dashboard, and the deterministic dispatcher. This is stated once, in `orbit_common::authorization`'s module documentation, with a one-line pointer from the placement field so neither axis can be read as the whole story.
+
+2. **A disagreeing pairing is legitimate, but never accidental.** Advertised-and-governed is how the operator MCP surface is expressed; unadvertised-and-ungoverned is how `orbit friction show` is kept off the agent surface without being taken away from anyone. Both are fine. Silent drift into either is not, so `crates/orbit-tools/src/builtin/orbit/tests/authorization.rs` declares the placement of every governed tool operation as a table and asserts it against the live registry in both directions. Advertising a governed tool, governing an advertised one, or dropping either half fails the test until the table is updated. `orbit-tools` is the lowest crate that can see both axes, so the check needs no new dependency edge.
+
+3. **The agent-reachable friction reads stay ungoverned, and that is now a test.** Because the chokepoint is surface-independent, governing `orbit.friction.list` / `show` would refuse an agent the CLI read as well as the MCP one. A pin asserts they stay off the registry.
+
+4. **An advertised governed tool must not list `agent` among its allowed capabilities.** Governing an operation the ordinary MCP caller already holds the capability for buys nothing and dilutes the entries that do refuse. A second assertion enforces it.
+
+### Rejected alternatives
+
+- **Give the exposure declaration a second axis — "which surface advertises" versus "which capability may perform" — and derive chokepoint enforcement from the second** (ORB-10478 option 1). Rejected: there is no longer a second advertisement axis to split. `McpExposure` is gone and `mcp_scope` is a plain placement decision, so this would mean *introducing* a policy framework to unify two declarations that already have one enforcement point between them — speculative v2 machinery for a drift that a ten-line table catches.
+- **Narrow `OperatorOnly` to performable-only-by-operator, move the read-only friction triage tools to an agent exposure, and enforce `allowed_capabilities()` at the tool chokepoint** (option 2). Rejected: `OperatorOnly` no longer exists to narrow, and the chokepoint already enforces capabilities from a single declaration. The remaining content of the option — deriving enforcement from placement — would govern `orbit friction show` because it is unadvertised, which is precisely the CLI regression the earlier entry declined to ship.
+- **Reconsidering the owner-path `admitted()` denial** (option 3's own follow-through). Not rejected but already satisfied: that denial was removed with the owner route, so MCP placement no longer acts as an authorization statement anywhere and there is nothing left to reconsider.
+- **Leaving the pairing to a reader.** Rejected: it is exactly what the filing complained about — the relationship was true but only discoverable by holding two crates open, which is how it drifted in the first place.
+
+### Consequences
+
+- The question "may this caller perform this?" has one answer and one place to look, on every surface. "Will this caller be shown it?" is a different question with a different owner, and neither now implies the other by accident.
+- An agent MCP session still sees five tools it cannot call. This is the accepted cost of a single advertised tool list plus per-call capability enforcement, and it is recorded rather than papered over. Filtering `tools/list` by session capability would remove it, but that is an MCP-server change with its own surface implications and no current demand; it is deliberately not bundled here.
+- Cost: adding a governed tool now requires one more line — its placement — in the guardrail table. That is the intended friction: the line is where the advertise-or-not decision gets made explicitly.
+- Local MCP sessions are constructed with `agent` (`ToolSessionContext::trusted_local`), and session grants outrank the `ORBIT_OPERATOR` override, so the operator MCP surface is reachable only by a session that asserts `operator` at initialize. Nothing here changes that; it is noted so the next reader does not mistake the advertised-and-governed pairing for a live operator path over the local adapter.
 
 ## Task References
 


### PR DESCRIPTION
## Task

[ORB-10478](https://orbit-cli.com/tasks/ORB-10478) — Reconcile MCP tool advertisement with capability enforcement for operator-only tools

### Description

## Problem

ORB-10453 (ADR-0260) added the capability chokepoint and closed the bypass its acceptance criteria named: `orbit tool run orbit.task.delete` and the other destructive `register_inactive` builtins are now governed by `GOVERNED_OPERATIONS`.

One narrower form of "advertisement and enforcement agree" is still open. Tools whose MCP exposure is `McpExposure::OperatorOnly` are denied at the owner MCP *call* path (`crates/orbit-remote/src/mcp/owner.rs`, `admitted()` gates both `tools/list` and `tools/call`), but they are not in `GOVERNED_OPERATIONS`, so `orbit tool run <name>` executes them for any caller.

**Live OperatorOnly set (as of 2026-08-13), not the July filing:**

- `orbit.friction.list` / `show` / `update` — two of these are non-destructive reads
- `orbit.workflow.ship` / `run.show` / `run.list` / `run.resume`
- `orbit.command.exec` (claim-gated, LocalDerived)

ADR-0260 deliberately deferred this (rejected alternative "Converting the `register_inactive` builtins to `operator_only` policies"): the two surfaces encode different things today. `OperatorOnly` currently means *audience/placement* — "keep this off the agent MCP surface" — not "destructive". Enforcing `allowed_capabilities()` at the tool chokepoint would refuse agents ordinary `orbit friction list` / `show` reads from the CLI, which is a regression, not a fix.

## Deprecated surfaces — do not touch

- **ADRs:** the native ADR store and `orbit.adr.*` tools are retired (ORB-10726). Decisions live in each feature's `4_decisions.md`. Do not restore `.orbit/adrs/` as a live target; ADR-0260's governed text is `docs/design/operations-as-data/4_decisions.md`.
- **Learnings:** the native project-learning subsystem is being removed (ORB-10736). Do not add `orbit.learning.*` to GOVERNED_OPERATIONS, new MCP exposure, or this task's tests. If those tools still exist at pickup, leave them to 10736.

## What to decide

Pick one and make the model say it out loud:

1. **Split the concepts.** Give `McpExposure` a separate axis for "which surface advertises this" versus "which capability may perform it", then derive tool-chokepoint enforcement from the second. Advertisement and enforcement then cannot drift, because both read one declaration.
2. **Narrow `OperatorOnly` to mean performable-only-by-operator**, move the read-only friction triage tools to `AgentOperator` (or to a new hub-placement-only exposure), and enforce `allowed_capabilities()` at the tool chokepoint.
3. **Accept the divergence explicitly** and document that MCP placement is not an authorization statement — in which case the owner-path `admitted()` call-path denial is the thing to reconsider, since it currently *is* acting as one.

Prerequisite: **ORB-10758** (shared CLI/MCP workspace selector). Do not implement this until a caller can name the workspace without `cd`.

## Notes

- Hold from 2026-07-26/08-01 still applies: Daniel confirms the minimal placement-versus-permission model before promotion. This update does not lift that hold.
- Guardrail from ORB-10453: `crates/orbit-tools/src/builtin/orbit/tests/authorization.rs` asserts every governed tool id names a really-registered tool. Extend that file rather than adding a parallel one.
- `admitted()` moved from `hub.rs` (deleted in the owner-route recomposition) to `crates/orbit-remote/src/mcp/owner.rs`.

### Acceptance Criteria

- The relationship between MCP advertisement and tool-chokepoint enforcement is stated in one place (ADR-0260 or a successor entry in docs/design/operations-as-data/4_decisions.md) and checked by a test rather than by reading two crates.
- No agent-reachable read regresses: `orbit friction list` / `orbit friction show` keep working from an agent CLI context, or the change is deliberate and called out in the ADR.
- If enforcement is derived from exposure, a tool cannot be advertised to a capability that may not perform it (or vice versa) without a test failing. Extend crates/orbit-tools/src/builtin/orbit/tests/authorization.rs rather than adding a parallel file.
- The live OperatorOnly set this task reconciles is friction list/show/update, orbit.workflow.*, and orbit.command.exec. Retired learning and ADR tool families are out of scope: do not re-advertise them, add them to GOVERNED_OPERATIONS, or restore `.orbit/adrs/` as a context target.
- ADR-0260's rejected-alternative / residual-gap note is updated in docs/design/operations-as-data/4_decisions.md (not .orbit/adrs/accepted/ADR-0260/body.md) with whichever option is taken.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Outcome

Took **option 3** — accept the placement/permission divergence explicitly — and
made it stated once and test-enforced. No runtime behavior changed; the work is
a decision, a doc comment that owns it, and a guardrail that keeps the two axes
from drifting silently.

## Why option 3, and what had already changed

The filing's premise no longer compiles. `McpExposure::OperatorOnly`,
`allowed_capabilities()`, `admitted()`, and the whole `orbit-remote` crate were
deleted by the owner-route recomposition and the MCP v1 ownership cleanup
(88070ffb). There are now exactly two axes with no overlapping declaration:

- **Placement** — `OperationSpec::mcp_scope` / `register_mcp` vs
  `register_inactive`. `tools/list` does no capability filtering and
  `ToolRegistry::execute` never consults availability, so an unadvertised tool
  is still `orbit tool run`-able.
- **Permission** — `GOVERNED_OPERATIONS`, enforced once at
  `OrbitRuntime::authorize_tool_operation`, which every tool caller traverses.

So the residual gap closed by deletion: friction list/show/update are
ungoverned and no MCP path denies them. What replaced it is the inverse
pairing — `orbit.workflow.ship`, `orbit.workflow.run.{show,list,resume}`
[ORB-10534] and `orbit.command.exec` [ORB-10711] are advertised to every MCP
session yet `operator`-governed. That is deliberate (the operator MCP surface),
so the fix is to pin it, not to unwind it.

Option 1 was rejected as speculative v2 machinery: there is no second
advertisement axis left to split, so it would mean *introducing* a policy
framework to unify declarations that already share one enforcement point.
Option 2 was rejected because deriving enforcement from placement would govern
`orbit friction show` (unadvertised), which is the CLI regression ORB-10453
declined to ship. Option 3's own follow-through — "reconsider the owner-path
`admitted()` denial" — is already satisfied: that denial was deleted, so MCP
placement no longer acts as an authorization statement anywhere.

## Changes

- `crates/orbit-common/src/authorization.rs` — new "Placement is not
  permission" module-doc section. This is the authoritative statement: what
  each axis decides, why they may disagree, and which test pins the pairing.
- `crates/orbit-common/src/operation.rs` — `mcp_scope` doc gains a three-line
  pointer, so the placement field names its counterpart instead of leaving a
  reader to infer the relationship.
- `crates/orbit-tools/src/builtin/orbit/tests/authorization.rs` — **extended,
  not duplicated**, per the ORB-10453 guardrail note. Adds:
  - `GOVERNED_TOOL_PLACEMENT`, a declared table of all 10 governed tool
    operations paired with `Advertised` / `Unadvertised`, asserted against the
    live registry via `mcp_tool_definitions()` with an exact `assert_eq!`.
    Advertising a governed tool, governing an advertised one, or dropping
    either half fails until the table is updated.
  - `an_advertised_governed_tool_is_deliberately_out_of_reach_for_an_agent_session`
    — an advertised governed tool must not list `agent` among `allowed`.
  - `the_agent_reachable_friction_reads_stay_ungoverned` — pins criterion 2.
  `orbit-tools` is the lowest crate that sees both axes, so no new dependency
  edge (ARCHITECTURE.md unaffected).
- `docs/design/operations-as-data/4_decisions.md` — new entry "MCP
  advertisement is placement; the capability chokepoint is permission" with all
  three options recorded as decision/rejected-alternatives; the earlier
  chokepoint entry's residual-gap bullet rewritten from open-and-pointing-at-a-
  deleted-path to closed-and-pointing-at-the-successor; its rejected-alternative
  bullet now links the resolution. Frontmatter `paths` / `related_artifacts`
  / dates refreshed, and the stale entry index at the top completed.

## Scope notes

No files were touched outside `context_files`, so no selector additions were
needed. Retired learning and ADR tool families were left alone (criterion 4):
nothing was re-advertised, added to `GOVERNED_OPERATIONS`, or restored under
`.orbit/adrs/`; the decision text lives only in `4_decisions.md`. Per the
repo's ADR rule, the new prose links decision entries by heading rather than by
ADR number.

Deliberately **not** bundled: filtering MCP `tools/list` by session capability
would remove the five dead entries an agent session sees, but it is an
MCP-server surface change with its own implications and no current demand. It
is recorded as a consequence instead.

## Validation

- `cargo test -p orbit-common -p orbit-tools` — all green (332 + 42 + 15 + 6 +
  3 + 1 + 1 passed); the 5 tests in the extended guardrail file pass.
- `cargo clippy -p orbit-common -p orbit-tools --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean. `make ci-fast` — exit 0.
- `cargo doc -p orbit-common --no-deps` — no intra-doc link warnings.
- Criterion 2 verified empirically as well as by test: under
  `ORBIT_AGENT_NAME=claude ORBIT_TASK_ACTOR_KIND=agent`, both
  `orbit friction list` and `orbit tool run orbit.friction.list` return records
  (exit 0).
- **`make ci-lint` fails on a pre-existing base defect, not on this change:**
  `clippy::collapsible_if` in
  `crates/orbit-store/src/file/scoreboard/scoreboard_summary/highlights.rs:151`,
  a file this task does not touch and a crate that does not depend on anything
  changed here. Scoped clippy over the two edited crates is clean; left for the
  owner of that crate rather than fixed as drive-by.

## Hold

The 2026-07-26/08-01 hold still applies and is **not** lifted: Daniel confirms
the minimal placement-versus-permission model before promotion. This change
writes that model down and locks it with a test; it does not claim the
confirmation.

## Friction

F2026-08-087 (docs) — decision-doc residual-gap notes name code paths that a
later refactor deletes, and no guard detects it, so the follow-up task inherits
a premise that no longer compiles. ~25 min lost reconciling the described model
against the code. Proposes a `docs/design/**/4_decisions.md` path-resolution
guardrail alongside the existing orphan-module ratchet.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10478-6a81fee4`
- Behind base: 0
- Ahead of base: 1