### PR TITLE
Fix role-split aggregate: count and surface columns use different denominators

### DIFF
--- a/crates/orbit-store/src/contracts/audit.rs
+++ b/crates/orbit-store/src/contracts/audit.rs
@@ -96,9 +96,17 @@ pub struct AuditToolAggregate {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuditRoleAggregate {
     pub role: String,
+    /// All audit events in the window, regardless of subcommand. Equal to
+    /// `mcp + cli + other + no_subcommand`.
     pub total: i64,
+    /// Tool invocations via MCP (`subcommand = 'run-mcp'`).
     pub mcp: i64,
+    /// Tool invocations via CLI (`subcommand = 'run'`).
     pub cli: i64,
+    /// Non-tool CLI subcommands (e.g. `show`, `list`) — present and not `run`/`run-mcp`.
+    pub other: i64,
+    /// Internal/system events with no subcommand at all (e.g. lock reservations).
+    pub no_subcommand: i64,
 }
 
 /// Per-canonical-actor aggregate of audit events (ORB-10888).

--- a/crates/orbit-store/src/contracts/traits.rs
+++ b/crates/orbit-store/src/contracts/traits.rs
@@ -30,9 +30,9 @@ use super::v2_audit::{V2AuditEventFilter, V2AuditEventInsertParams, V2AuditEvent
 
 use crate::contracts::incident::{FailureIncidentQuery, FailureIncidentReport};
 use crate::contracts::{
-    AuditEventFilter, AuditEventInsertParams, AuditRoleAggregate, AuditToolAggregate,
-    AuditToolCallCountsByRole, AuditToolCallCountsBySurfaceAndRole, AuditTopToolCall,
-    TaskCompletionByComplexity,
+    AuditActorAggregate, AuditEventFilter, AuditEventInsertParams, AuditRoleAggregate,
+    AuditToolAggregate, AuditToolCallCountsByRole, AuditToolCallCountsBySurfaceAndRole,
+    AuditTopToolCall, TaskCompletionByComplexity,
 };
 
 pub trait TaskStoreBackend: Send + Sync {

--- a/crates/orbit-store/src/driver/sqlite/audit_event_store/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/audit_event_store/mod.rs
@@ -779,8 +779,14 @@ impl Store {
     }
 
     /// Per-role aggregate of audit events with `timestamp >= since`, including
-    /// the MCP-vs-CLI surface split. Rows where `subcommand` is neither `'run'`
-    /// nor `'run-mcp'` still count toward `total` but neither `mcp` nor `cli`.
+    /// the MCP-vs-CLI surface split. Every row where `subcommand` is neither
+    /// `'run'` nor `'run-mcp'` is still counted toward `total`, and lands in
+    /// exactly one of `other` (a different non-null subcommand) or
+    /// `no_subcommand` (subcommand is `NULL`, e.g. internal lock traffic) —
+    /// so `mcp + cli + other + no_subcommand == total` for every row
+    /// (ORB-10889). `other` uses `subcommand IS NOT NULL AND ... NOT IN`
+    /// rather than a bare `NOT IN`, since SQL's `NULL NOT IN (...)` evaluates
+    /// to `NULL`/false and would silently drop the `no_subcommand` bucket.
     pub fn get_audit_event_aggregates_by_role(
         &self,
         since: &DateTime<Utc>,
@@ -790,7 +796,9 @@ impl Store {
         let sql = "SELECT role, \
                    COUNT(*), \
                    COALESCE(SUM(CASE WHEN subcommand = 'run-mcp' THEN 1 ELSE 0 END), 0), \
-                   COALESCE(SUM(CASE WHEN subcommand = 'run' THEN 1 ELSE 0 END), 0) \
+                   COALESCE(SUM(CASE WHEN subcommand = 'run' THEN 1 ELSE 0 END), 0), \
+                   COALESCE(SUM(CASE WHEN subcommand IS NOT NULL AND subcommand NOT IN ('run-mcp', 'run') THEN 1 ELSE 0 END), 0), \
+                   COALESCE(SUM(CASE WHEN subcommand IS NULL THEN 1 ELSE 0 END), 0) \
                    FROM audit_events WHERE timestamp >= ?1 \
                    GROUP BY role ORDER BY COUNT(*) DESC, role ASC";
 
@@ -805,6 +813,8 @@ impl Store {
                     total: row.get(1)?,
                     mcp: row.get(2)?,
                     cli: row.get(3)?,
+                    other: row.get(4)?,
+                    no_subcommand: row.get(5)?,
                 })
             })
             .map_err(|e| OrbitError::Store(e.to_string()))?;

--- a/crates/orbit-store/src/driver/sqlite/audit_event_store/tests/audit_event_store.rs
+++ b/crates/orbit-store/src/driver/sqlite/audit_event_store/tests/audit_event_store.rs
@@ -635,6 +635,13 @@ fn audit_event_aggregates_by_role_splits_subcommand_surface() {
         .insert_audit_event_record(&codex_other)
         .expect("insert");
 
+    let mut codex_internal =
+        sample_params_with("exec-codex-internal", "codex", AuditEventStatus::Success);
+    codex_internal.subcommand = None;
+    store
+        .insert_audit_event_record(&codex_internal)
+        .expect("insert");
+
     let mut human = sample_params_with("exec-human", "human", AuditEventStatus::Success);
     human.subcommand = Some("run".to_string());
     store.insert_audit_event_record(&human).expect("insert");
@@ -644,12 +651,24 @@ fn audit_event_aggregates_by_role_splits_subcommand_surface() {
         .expect("aggregates by role");
 
     let codex = rows.iter().find(|r| r.role == "codex").expect("codex row");
-    assert_eq!(codex.total, 3);
+    assert_eq!(codex.total, 4);
     assert_eq!(codex.mcp, 1);
     assert_eq!(codex.cli, 1);
+    assert_eq!(codex.other, 1);
+    assert_eq!(codex.no_subcommand, 1);
+    assert_eq!(
+        codex.mcp + codex.cli + codex.other + codex.no_subcommand,
+        codex.total
+    );
 
     let human = rows.iter().find(|r| r.role == "human").expect("human row");
     assert_eq!(human.total, 1);
     assert_eq!(human.mcp, 0);
     assert_eq!(human.cli, 1);
+    assert_eq!(human.other, 0);
+    assert_eq!(human.no_subcommand, 0);
+    assert_eq!(
+        human.mcp + human.cli + human.other + human.no_subcommand,
+        human.total
+    );
 }

--- a/crates/orbit-web/assets/dashboard/audit.js
+++ b/crates/orbit-web/assets/dashboard/audit.js
@@ -369,7 +369,7 @@ function renderAuditSummary(data, ctx) {
       const table = el("table", { class: "summary-table" });
       const thead = el("thead");
       const tr = el("tr");
-      for (const c of cols) tr.appendChild(el("th", { class: c.num ? "num" : "", text: c.label }));
+      for (const c of cols) tr.appendChild(el("th", { class: c.num ? "num" : "", text: c.label, title: c.title }));
       thead.appendChild(tr);
       table.appendChild(thead);
 
@@ -454,7 +454,14 @@ function renderAuditSummary(data, ctx) {
   if (data.role_split) {
     container.appendChild(createCard("Role split", renderTable(
       data.role_split,
-      [{ key: "label", label: "role" }, { key: "count", label: "count", num: true }, { key: "mcp", label: "mcp", num: true }, { key: "cli", label: "cli", num: true }],
+      [
+        { key: "label", label: "role" },
+        { key: "count", label: "events", num: true, title: "All audit events in the window" },
+        { key: "mcp", label: "mcp", num: true, title: "Tool calls via MCP (subcommand = run-mcp)" },
+        { key: "cli", label: "cli", num: true, title: "Tool calls via CLI (subcommand = run)" },
+        { key: "other", label: "other", num: true, title: "Other CLI subcommands (non-tool, e.g. show/list)" },
+        { key: "no_subcommand", label: "internal", num: true, title: "Internal/system events with no subcommand (e.g. lock reservations)" },
+      ],
       (item) => {
         auditFilter.role = auditFilter.role === item.label ? null : item.label;
         syncAuditControls();

--- a/crates/orbit-web/src/api/audit.rs
+++ b/crates/orbit-web/src/api/audit.rs
@@ -386,6 +386,8 @@ fn compute_audit_summary_bundle(
                 "count": r.total,
                 "mcp": r.mcp,
                 "cli": r.cli,
+                "other": r.other,
+                "no_subcommand": r.no_subcommand,
             })
         })
         .collect();


### PR DESCRIPTION
## Task

[ORB-10889](https://orbit-cli.com/tasks/ORB-10889) — Fix role-split aggregate: count and surface columns use different denominators

### Description

## Problem

The Role Split card renders `count`, `mcp`, and `cli` columns that cannot be reconciled by a reader:
`mcp + cli` is far smaller than `count` on almost every row, with no indication of where the
remainder went.

Cause is a denominator mismatch in `get_audit_event_aggregates_by_role`
(`crates/orbit-store/src/sqlite/audit_event_store/mod.rs:880`):

- `count` is `COUNT(*)` over **all** audit events in the window
- `mcp` counts only `subcommand = 'run-mcp'`
- `cli` counts only `subcommand = 'run'`

Everything else falls into an invisible remainder, and it is large. Measured over 30d:

- `admin`: 19476 total = 9677 `run` + 3143 other non-null subcommands + **6656 with `subcommand IS NULL`**
- `unknown`: 7715 total, of which only 28 are `run`

The NULL-subcommand bucket is dominated by lock traffic — `task.locks.reserve.requested` 3007,
`.denied` 2460, `.granted` 547, `.released` 546. Note that `SUM(subcommand NOT IN (...))` does not
catch these, since NULL comparisons yield NULL, so a naive "other" column would still not close the gap.

The one row that does reconcile is `unverified` (1373 = 1373 mcp + 0 cli), because an unauthenticated
MCP client can only reach the tool dispatch path — which incidentally confirms the diagnosis.

## Scope

Make the card's columns sum to its total, by whichever framing is more honest:

- restrict `count` to the same predicate as the surface columns and label it as tool calls, or
- keep `count` as all events and add explicit columns for the remaining buckets (non-tool commands,
  and internal/lock events with a NULL subcommand)

Whichever is chosen, NULL subcommands must be counted explicitly rather than falling through a
`NOT IN` predicate.

## Acceptance criteria

- For every row in the Role Split card, the displayed component columns sum to the displayed total.
- NULL-subcommand events are counted in a named bucket, not silently dropped.
- The column headers state what is being counted (all audit events vs tool invocations).
- Existing card behavior for drill-down filtering by role is preserved.
- `make ci-fast` and `make ci-lint` pass.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

## Fix

Denominator mismatch in `get_audit_event_aggregates_by_role` (orbit-store) fixed by adding
two explicit buckets to the SQL aggregate and threading them through to the dashboard:

- `other`: subcommand present but not `run`/`run-mcp` (non-tool CLI commands, e.g. `show`).
- `no_subcommand`: subcommand IS NULL (internal/system events, e.g. lock reservations) --
  counted via an explicit `IS NULL` branch rather than folded into `other` through a bare
  `NOT IN`, since SQL's `NULL NOT IN (...)` evaluates to NULL/false and would silently drop
  this bucket (exactly the bug the task description warned about).

Now `mcp + cli + other + no_subcommand == total` for every role row.

Files touched:
- `crates/orbit-store/src/contracts/audit.rs`: added `other`/`no_subcommand` fields to
  `AuditRoleAggregate`, with doc comments stating the reconciliation invariant.
- `crates/orbit-store/src/driver/sqlite/audit_event_store/mod.rs`: extended the aggregate SQL
  and `query_map` with the two new columns.
- `crates/orbit-store/.../tests/audit_event_store.rs`: extended
  `audit_event_aggregates_by_role_splits_subcommand_surface` with a NULL-subcommand row and
  explicit reconciliation assertions (`mcp + cli + other + no_subcommand == total`).
- `crates/orbit-web/src/api/audit.rs`: role_split JSON now includes `other`/`no_subcommand`.
- `crates/orbit-web/assets/dashboard/audit.js`: Role split card gained `other`/`internal`
  columns; `count` column relabeled "events" with a tooltip ("All audit events in the
  window"); mcp/cli/other/internal columns each carry a tooltip stating what they count.
  `renderTable`'s header renderer now passes through an optional `title` for the tooltip.
  Existing role-filter drill-down (click a row to filter `/api/diagnostics/audit` by role)
  is untouched.

## Scope note

`context_files` originally listed only `audit.rs`/`audit.js`, but the root cause (per the task
description itself) is in orbit-store's aggregate query, not the web layer, so I added
`orbit-store/.../mod.rs`, `contracts/audit.rs`, and the directly affected unit test file via
`orbit.task.update` before editing (see task comment).

## Unrelated pre-existing breakage encountered (see friction F2026-08-090)

`agent-main` HEAD had two unrelated compile breaks from recent merges (PR #1058 ORB-10888,
PR #1059 ORB-10892):
1. `orbit-store`'s `traits.rs` was missing an `AuditActorAggregate` import, breaking
   `cargo build -p orbit-store` entirely. Fixed as a one-line necessary-to-compile change
   (unrelated to this task's logic, but nothing compiles without it).
2. `orbit-web/src/api/tests/diagnostics.rs`'s `seed_task` test helper no longer matches
   `TaskAddParams.complexity`'s new non-`Option` type (ORB-10892 "require complexity at
   creation"). This is a real semantic decision for that test fixture, not a one-line fix,
   so I left it alone as out of scope. This blocks `cargo test -p orbit-web` and full
   `make ci-lint`.

## Validation

- `cargo build -p orbit-store -p orbit-web`: clean (after the import fix above).
- `cargo test -p orbit-store` (35 tests incl. the updated aggregate test): all pass.
- `cargo clippy -p orbit-store --all-targets --all-features -- -D warnings`: clean.
- `cargo clippy -p orbit-web --lib --all-features -- -D warnings`: clean (test target
  excluded -- see unrelated breakage above).
- `make ci-fast`: passes.
- `make ci-lint`: fails only on the pre-existing unrelated `diagnostics.rs` compile error
  (item 2 above); no warnings/errors from any file this task touched.
- `node --check` on the edited JS files: passes (no JS test harness exists in this repo).
- Did not test in a browser (no running dashboard instance in this environment); the JS
  change is a straightforward column/label addition mirroring the existing `mcp`/`cli`
  column pattern.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10889-6a823547`
- Behind base: 0
- Ahead of base: 1