### PR TITLE
orbit-web auto-task authorization tests race on ORBIT_OPERATOR in managed runs

### DIFF
--- a/crates/orbit-web/src/api/tests/auto_tasks.rs
+++ b/crates/orbit-web/src/api/tests/auto_tasks.rs
@@ -66,10 +66,49 @@ async fn send(
         .expect("response")
 }
 
+/// Pin the process signals `CallerCapabilities::resolve` reads, for the whole
+/// request rather than just its construction.
+///
+/// The guard in `orbit_common::test_env` is process-wide, so it serializes two
+/// tests only when *both* take it. Every case whose expected status depends on
+/// caller identity therefore goes through this helper — a case that merely
+/// reads `ORBIT_OPERATOR` without holding the guard can observe the override a
+/// sibling set concurrently and turn an expected 403 into a 200 [ORB-10894].
 #[allow(clippy::await_holding_lock)]
-async fn as_operator<T>(fut: impl std::future::Future<Output = T>) -> T {
-    let _env = orbit_common::test_env::scoped([(OPERATOR_OVERRIDE_ENV, Some("1"))]);
+async fn with_caller_env<'a, T>(
+    vars: impl IntoIterator<Item = (&'a str, Option<&'a str>)>,
+    fut: impl std::future::Future<Output = T>,
+) -> T {
+    let _env = orbit_common::test_env::scoped(vars);
     fut.await
+}
+
+/// Resolve as an explicit operator. The override outranks every other signal,
+/// so nothing else needs pinning to reach `Operator`.
+async fn as_operator<T>(fut: impl std::future::Future<Output = T>) -> T {
+    with_caller_env([(OPERATOR_OVERRIDE_ENV, Some("1"))], fut).await
+}
+
+/// Resolve as an agent: override cleared, agent envelope declared.
+///
+/// The envelope is *set* rather than cleared on purpose. With nothing declared,
+/// resolution falls through to its interactive-terminal probe, and `cargo test`
+/// run from a terminal inherits both handles — the caller would resolve to
+/// `Operator` and the denial assertion would fail for a reason that has nothing
+/// to do with the code under test. Declaring the agent stops resolution one
+/// rule earlier, so the expected 403 holds in CI, in a managed run, and in an
+/// interactive shell alike. The unidentified-caller branch is covered without
+/// process state in `orbit_common::governance::tests::authorization`.
+async fn as_agent<T>(fut: impl std::future::Future<Output = T>) -> T {
+    with_caller_env(
+        [
+            (OPERATOR_OVERRIDE_ENV, None),
+            ("ORBIT_AGENT_NAME", Some("orbit-web-test")),
+            ("ORBIT_AGENT_MODEL", Some("orbit-web-test")),
+        ],
+        fut,
+    )
+    .await
 }
 
 #[tokio::test]
@@ -177,16 +216,16 @@ async fn toggle_requires_an_explicit_workspace() {
 }
 
 #[tokio::test]
-async fn toggle_denies_an_unidentified_caller() {
+async fn toggle_denies_a_caller_without_operator_capability() {
     let runtime = runtime();
     runtime.auto_task_add(chore_params("nightly")).expect("add");
     let (state, runtime) = state(runtime);
-    let response = send(
+    let response = as_agent(send(
         state,
         Method::POST,
         "/auto-tasks/toggle?workspace=default",
         Some(r#"{"name":"nightly","expected_enabled":true,"enabled":false}"#),
-    )
+    ))
     .await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     let json = body_json(response).await;
@@ -303,16 +342,16 @@ async fn mint_requires_unconditional_acknowledgement() {
 }
 
 #[tokio::test]
-async fn mint_denies_an_unidentified_caller() {
+async fn mint_denies_a_caller_without_operator_capability() {
     let runtime = runtime();
     runtime.auto_task_add(chore_params("nightly")).expect("add");
     let (state, _) = state(runtime);
-    let response = send(
+    let response = as_agent(send(
         state,
         Method::POST,
         "/auto-tasks/mint?workspace=default",
         Some(r#"{"name":"nightly","acknowledge_unconditional":true}"#),
-    )
+    ))
     .await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     let json = body_json(response).await;

--- a/crates/orbit-web/src/api/tests/diagnostics.rs
+++ b/crates/orbit-web/src/api/tests/diagnostics.rs
@@ -283,7 +283,10 @@ fn seed_task(
             title: title.to_string(),
             description: format!("Fixture task: {title}."),
             status: Some(status),
-            complexity,
+            // `TaskAddParams::complexity` became required at create time
+            // [ORB-10892]; `None` here is the fixture's "nothing was assessed",
+            // which that surface spells `Unassessed`.
+            complexity: complexity.unwrap_or(TaskComplexity::Unassessed),
             workspace_path: Some(".".to_string()),
             ..Default::default()
         })


### PR DESCRIPTION
## Task

[ORB-10894](https://orbit-cli.com/tasks/ORB-10894) — orbit-web auto-task authorization tests race on ORBIT_OPERATOR in managed runs

### Description

## Problem

The orbit-web unit suite is not reliable when run inside a managed Orbit executor. The auto-task dashboard authorization tests mutate the process-global ORBIT_OPERATOR environment variable in one async test while sibling tests read it without taking the shared test-env lock. This creates a false authorization result under the exact environment used by task executors.

## Evidence

Relevant code was added by ORB-10876 and is present after the recent refactor series through HEAD 808b1253 (including ORB-10884).

With the executor environment inherited:

ORBIT_AGENT_NAME=codex
ORBIT_AGENT_MODEL=gpt-5.6-luna
ORBIT_MANAGED_RUN_CONTEXT=1
cargo test -p orbit-web --lib

Observed failure:

api::tests::auto_tasks::toggle_denies_an_unidentified_caller
assertion failed: left 200, right 403

The failing test is crates/orbit-web/src/api/tests/auto_tasks.rs:180. The same full suite run reported 245 passed and 1 failed. Running the isolated test passes, and running the 11 auto-task tests with the inherited environment also passed on a subsequent run, confirming process-global scheduling sensitivity rather than a stable product response. Scrubbing ORBIT_AGENT_NAME, ORBIT_AGENT_MODEL, ORBIT_MANAGED_RUN_CONTEXT, and ORBIT_OPERATOR makes the 11 focused tests pass consistently.

The expected product behavior is still correct: an unidentified/agent caller must receive HTTP 403 for POST /auto-tasks/toggle?workspace=default; the issue is that the test can accidentally inherit the operator override set by as_operator in a concurrent sibling.

## Reproduction

1. From this checkout, keep the managed-run variables above exported (the normal Orbit executor environment).
2. Run cargo test -p orbit-web --lib repeatedly.
3. Observe intermittent toggle_denies_an_unidentified_caller failures with HTTP 200 instead of 403.
4. Compare with cargo test -p orbit-web --lib api::tests::auto_tasks::toggle_denies_an_unidentified_caller -- --exact, which passes when no sibling is concurrently setting ORBIT_OPERATOR.

## Suggested direction

Make these tests deterministic under managed execution by using the existing orbit_common::test_env guard for every assertion that depends on the operator/agent environment, or otherwise serialize the environment-sensitive cases. Preserve the authorization assertions and audit coverage; do not relax the expected 403. This is related to ORB-10436's ambient-environment test audit but is a distinct uncovered dashboard test group.

### Acceptance Criteria

- cargo test -p orbit-web --lib passes when run with the managed Orbit executor environment inherited.
- The auto-task authorization tests deterministically return 403 for unidentified or agent callers and 200 only for explicit operator callers.
- The fix preserves the existing authorization and audit assertions without weakening them.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Outcome

The auto-task dashboard authorization tests are now deterministic under managed execution. All 11 `api::tests::auto_tasks` tests pass repeatedly with the executor environment inherited, and — stronger than the original requirement — they also pass with an ambient `ORBIT_OPERATOR=1` exported, which is exactly the state a concurrent sibling used to create.

## Root cause

`orbit_common::test_env::scoped` guards a process-wide mutex, so it serializes two tests only when *both* take it. `as_operator` took the guard while setting `ORBIT_OPERATOR`; `toggle_denies_an_unidentified_caller` and `mint_denies_an_unidentified_caller` read that variable through `CallerCapabilities::resolve` without taking it. Under the threaded test runner a denial case could observe a sibling's override and resolve to `Operator`, returning 200 where 403 was asserted.

## Change (crates/orbit-web/src/api/tests/auto_tasks.rs)

- Extracted `with_caller_env`, which holds the shared guard across the whole request rather than just construction, and rebuilt `as_operator` on it (behavior unchanged: the override outranks every other signal).
- Added `as_agent`, which clears `ORBIT_OPERATOR` and *declares* an agent envelope, and routed both denial cases through it.
- Renamed the two cases to `toggle_denies_a_caller_without_operator_capability` / `mint_denies_a_caller_without_operator_capability` to match what they now pin.

The agent envelope is set rather than cleared deliberately. With nothing declared, resolution falls through to its interactive-terminal probe, and `cargo test` run from a terminal inherits both handles — the caller would resolve to `Operator` and the 403 assertion would fail for a reason unrelated to the code under test. Declaring the agent stops resolution one rule earlier. The unidentified-caller (empty-grants) branch stays covered without process state by `an_unidentified_caller_is_denied` in `orbit_common::governance::tests::authorization`, so no coverage was lost.

No authorization or audit assertion was weakened: the expected statuses, `authorization_denied` codes, operation ids, unchanged-definition checks, and the audit-event assertion are all byte-identical.

## Validation

- `cargo test -p orbit-web --lib api::tests::auto_tasks` with the managed env: 11 passed, 5 consecutive runs.
- Same with `ORBIT_OPERATOR=1` additionally exported: 11 passed, 3 consecutive runs.
- Same with all four variables scrubbed: 11 passed.
- Negative control against HEAD's version of the file under `ORBIT_OPERATOR=1`: both denial tests FAIL, confirming the new tests are not passing vacuously.
- `make ci-fast`: pass. `make ci-lint`: pass (clean workspace clippy).
- Full `cargo test -p orbit-web --lib`: 249 passed, 1 failed — the one failure is pre-existing and unrelated (see below).

## Out-of-scope breakage found, and what I did about it

`cargo test -p orbit-web --lib` did not compile on HEAD at all, so the acceptance criterion was unverifiable as written. ORB-10891 added a `seed_task` fixture passing `Option<TaskComplexity>` into `TaskAddParams.complexity`; ORB-10892 concurrently made that field required. I applied the minimal compile fix in `crates/orbit-web/src/api/tests/diagnostics.rs` (`complexity.unwrap_or(TaskComplexity::Unassessed)`) — appended to `context_files` — solely because the crate must build for this task to be validated at all.

That leaves one assertion still failing, and I deliberately did not touch it: `completion_by_complexity_keeps_unset_and_shows_denominators` expects an `unset` bucket, but `add.rs` persists `Some(Unassessed)`, which indexes as the string `unassessed`, while `labeled_or_unset` maps only NULL/empty to `UNSET_BUCKET`. Every new task therefore lands in an `unassessed` bucket and `unset` now holds only legacy rows — two labels for one concept. Choosing between folding `Unassessed` into `UNSET_BUCKET` and adopting `unassessed` as the live label is a product decision owned by that feature, not something to paper over by retargeting an assertion string. Filed as **ORB-10895** with both options and the exact call sites. Friction record filed on the merge hazard (a required-field migration is invisible to git merge, so both PRs were green against their own bases).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10894-6a823b42`
- Behind base: 0
- Ahead of base: 1