### PR TITLE
completion-by-complexity unset bucket is unreachable after complexity became required at create

### DIFF
--- a/crates/orbit-store/src/contracts/task_registry.rs
+++ b/crates/orbit-store/src/contracts/task_registry.rs
@@ -97,7 +97,9 @@ pub struct AllocatorSeedOutcome {
 }
 
 /// Status distribution for one complexity bucket, including the explicit
-/// [`orbit_types::task::UNSET_BUCKET`] for tasks with no complexity set.
+/// [`orbit_types::task::UNSET_BUCKET`] for tasks with no assessed complexity
+/// (unindexed, empty, or `unassessed` — see
+/// [`orbit_types::task::complexity_bucket`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TaskCompletionByComplexity {
     pub complexity: String,

--- a/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
@@ -6,9 +6,9 @@ use std::sync::{Arc, Mutex};
 use orbit_common::{NotFoundKind, OrbitError};
 use orbit_types::task::{
     ORB_TASK_ID_MAX, TaskEnvelopeV2, TaskRelation, TaskRelationEdge, TaskRelationType, TaskStatus,
-    complexity_bucket_ord, format_task_id, is_valid_orb_task_id, is_valid_task_id_prefix,
-    labeled_or_unset, normalize_task_tags, parse_task_number, task_id_prefix, validate_orb_task_id,
-    validate_task_relations_for_source,
+    complexity_bucket, complexity_bucket_ord, format_task_id, is_valid_orb_task_id,
+    is_valid_task_id_prefix, normalize_task_tags, parse_task_number, task_id_prefix,
+    validate_orb_task_id, validate_task_relations_for_source,
 };
 use rusqlite::{Connection, TransactionBehavior, params, params_from_iter};
 
@@ -653,8 +653,9 @@ impl TaskRegistryStore {
         Ok(exists != 0)
     }
 
-    /// Status counts grouped by complexity bucket. `NULL` and empty index
-    /// values both become the named `unset` bucket.
+    /// Status counts grouped by complexity bucket. `NULL`, empty, and
+    /// `unassessed` index values all become the named `unset` bucket — see
+    /// [`complexity_bucket`].
     pub fn completion_by_complexity(
         &self,
         workspace_id: &str,
@@ -686,7 +687,7 @@ impl TaskRegistryStore {
         for row in rows {
             let (raw_complexity, status, count) =
                 row.map_err(|e| OrbitError::Store(e.to_string()))?;
-            let bucket = labeled_or_unset(raw_complexity.as_deref()).to_string();
+            let bucket = complexity_bucket(raw_complexity.as_deref()).to_string();
             *by_bucket
                 .entry(bucket)
                 .or_default()
@@ -712,6 +713,8 @@ impl TaskRegistryStore {
     }
 
     /// `task_id →` complexity bucket for every indexed task in the workspace.
+    /// Buckets match [`Self::completion_by_complexity`], so an `unassessed`
+    /// task reports `unset` here too.
     pub fn complexity_by_task_id(
         &self,
         workspace_id: &str,
@@ -736,7 +739,7 @@ impl TaskRegistryStore {
         let mut map = BTreeMap::new();
         for row in rows {
             let (task_id, raw) = row.map_err(|e| OrbitError::Store(e.to_string()))?;
-            map.insert(task_id, labeled_or_unset(raw.as_deref()).to_string());
+            map.insert(task_id, complexity_bucket(raw.as_deref()).to_string());
         }
         Ok(map)
     }

--- a/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
@@ -1451,7 +1451,7 @@ fn completion_by_complexity_keeps_unset_as_its_own_bucket() {
     let store = store(&temp);
     let workspace = bind(&store, temp.path());
 
-    for task_id in ["ORB-00000", "ORB-00001", "ORB-00002"] {
+    for task_id in ["ORB-00000", "ORB-00001", "ORB-00002", "ORB-00003"] {
         let bundle_dir = create_canonical_bundle(&store, &workspace, task_id);
         store
             .register_task_bundle(task_id, &workspace.workspace_id, &bundle_dir)
@@ -1477,6 +1477,14 @@ fn completion_by_complexity_keeps_unset_as_its_own_bucket() {
         )
         .expect("index unset");
 
+    // An explicitly `unassessed` task is the same "nobody assessed this"
+    // concept as an unindexed one and shares its bucket [ORB-10895].
+    let mut unassessed_backlog = envelope("ORB-00003", TaskStatus::Backlog, Vec::new(), Vec::new());
+    unassessed_backlog.complexity = Some(TaskComplexity::Unassessed);
+    store
+        .replace_task_index(&workspace.workspace_id, &unassessed_backlog)
+        .expect("index unassessed");
+
     let rows = store
         .completion_by_complexity(&workspace.workspace_id)
         .expect("aggregate");
@@ -1491,8 +1499,9 @@ fn completion_by_complexity_keeps_unset_as_its_own_bucket() {
         .iter()
         .find(|row| row.complexity == UNSET_BUCKET)
         .unwrap();
-    assert_eq!(unset.total, 1);
+    assert_eq!(unset.total, 2);
     assert_eq!(unset.by_status.get("archived").copied(), Some(1));
+    assert_eq!(unset.by_status.get("backlog").copied(), Some(1));
 
     let hard = rows.iter().find(|row| row.complexity == "hard").unwrap();
     assert_eq!(hard.total, 1);
@@ -1503,6 +1512,7 @@ fn completion_by_complexity_keeps_unset_as_its_own_bucket() {
         .expect("map");
     assert_eq!(map.get("ORB-00000").map(String::as_str), Some("hard"));
     assert_eq!(map.get("ORB-00002").map(String::as_str), Some(UNSET_BUCKET));
+    assert_eq!(map.get("ORB-00003").map(String::as_str), Some(UNSET_BUCKET));
 }
 
 #[test]

--- a/crates/orbit-types/src/task/mod.rs
+++ b/crates/orbit-types/src/task/mod.rs
@@ -25,10 +25,11 @@ pub use model::{
     NO_DIFF_EXPECTED_TAG, ResolvedTaskDependency, ResolvedTaskRelation,
     TASK_REFERENCE_NOT_VERIFIABLE_HERE, Task, TaskArtifact, TaskComment, TaskComplexity,
     TaskCreateStatus, TaskHistoryEntry, TaskPriority, TaskStatus, TaskType, UNSET_BUCKET,
-    UnsatisfiableTaskDependency, build_task_status_index, complexity_bucket_ord, labeled_or_unset,
-    media_type_for_artifact_path, normalize_task_dependencies, normalize_task_tags,
-    push_external_ref_if_missing, resolve_task_dependencies, resolve_task_relations,
-    task_dependencies_ready, task_matches_tags, task_reference_is_not_verifiable_here,
-    unmet_task_dependencies, unsatisfiable_task_dependencies, validate_task_dependencies,
+    UnsatisfiableTaskDependency, build_task_status_index, complexity_bucket, complexity_bucket_ord,
+    labeled_or_unset, media_type_for_artifact_path, normalize_task_dependencies,
+    normalize_task_tags, push_external_ref_if_missing, resolve_task_dependencies,
+    resolve_task_relations, task_dependencies_ready, task_matches_tags,
+    task_reference_is_not_verifiable_here, unmet_task_dependencies,
+    unsatisfiable_task_dependencies, validate_task_dependencies,
 };
 pub use plan::{TaskPlan, TaskPlanCheckpoint, TaskPlanSuccessCriterion};

--- a/crates/orbit-types/src/task/model.rs
+++ b/crates/orbit-types/src/task/model.rs
@@ -83,6 +83,24 @@ pub fn labeled_or_unset(value: Option<&str>) -> &str {
     }
 }
 
+/// Map an indexed complexity label onto a display bucket.
+///
+/// [`TaskComplexity::Unassessed`] is the stored spelling of "nobody assessed
+/// this" ([`TaskComplexity::is_assessed`] is `false`), and rows indexed before
+/// the column existed spell the same thing as `NULL`. Reporting surfaces get
+/// one bucket for that concept — [`UNSET_BUCKET`] — rather than splitting the
+/// unlabeled set across `unset` and `unassessed` (ORB-10895). The fold happens
+/// here, at read time: the persisted and indexed value stays the literal
+/// `unassessed` so provenance and `NULL`-backfill detection remain honest.
+pub fn complexity_bucket(value: Option<&str>) -> &str {
+    let label = labeled_or_unset(value);
+    if label == TaskComplexity::Unassessed.as_str() {
+        UNSET_BUCKET
+    } else {
+        label
+    }
+}
+
 /// Stable display order: `unset`, then `low` / `medium` / `hard`, then any
 /// unexpected label alphabetically.
 pub fn complexity_bucket_ord(label: &str) -> (u8, &str) {

--- a/crates/orbit-types/src/task/tests/task.rs
+++ b/crates/orbit-types/src/task/tests/task.rs
@@ -423,7 +423,7 @@ relations:
 }
 
 mod unlabeled_bucket {
-    use crate::task::{UNSET_BUCKET, complexity_bucket_ord, labeled_or_unset};
+    use crate::task::{UNSET_BUCKET, complexity_bucket, complexity_bucket_ord, labeled_or_unset};
 
     #[test]
     fn empty_and_missing_labels_become_unset() {
@@ -434,8 +434,17 @@ mod unlabeled_bucket {
     }
 
     #[test]
+    fn unassessed_and_missing_complexity_share_one_bucket() {
+        assert_eq!(complexity_bucket(None), UNSET_BUCKET);
+        assert_eq!(complexity_bucket(Some("")), UNSET_BUCKET);
+        assert_eq!(complexity_bucket(Some("unassessed")), UNSET_BUCKET);
+        assert_eq!(complexity_bucket(Some("hard")), "hard");
+    }
+
+    #[test]
     fn unexpected_labels_are_not_folded_into_a_known_band() {
         assert_eq!(labeled_or_unset(Some("extreme")), "extreme");
+        assert_eq!(complexity_bucket(Some("extreme")), "extreme");
         assert!(complexity_bucket_ord("unset") < complexity_bucket_ord("low"));
         assert!(complexity_bucket_ord("hard") < complexity_bucket_ord("extreme"));
     }

--- a/crates/orbit-web/src/api/tests/diagnostics.rs
+++ b/crates/orbit-web/src/api/tests/diagnostics.rs
@@ -285,7 +285,8 @@ fn seed_task(
             status: Some(status),
             // `TaskAddParams::complexity` became required at create time
             // [ORB-10892]; `None` here is the fixture's "nothing was assessed",
-            // which that surface spells `Unassessed`.
+            // which that surface spells `Unassessed` and which the reporting
+            // buckets fold into `unset` [ORB-10895].
             complexity: complexity.unwrap_or(TaskComplexity::Unassessed),
             workspace_path: Some(".".to_string()),
             ..Default::default()


### PR DESCRIPTION
## Task

[ORB-10895](https://orbit-cli.com/tasks/ORB-10895) — completion-by-complexity unset bucket is unreachable after complexity became required at create

### Description

## Problem

Two changes merged independently and left `cargo test -p orbit-web --lib` red on HEAD.

1. ORB-10891 added the `seed_task` fixture in `crates/orbit-web/src/api/tests/diagnostics.rs`, which passed `Option<TaskComplexity>` straight into `TaskAddParams.complexity`.
2. ORB-10892 made `TaskAddParams.complexity` a required `TaskComplexity`.

The result did not compile at all (`E0308`, expected `TaskComplexity`, found `Option<TaskComplexity>`), so the whole orbit-web lib suite was unrunnable. ORB-10894 applied the minimal compile fix (`complexity.unwrap_or(TaskComplexity::Unassessed)`) because it needed the crate to build in order to validate its own change.

## What is still broken

The underlying semantic conflict is unresolved and is a product decision, so ORB-10894 deliberately left it alone:

`completion_by_complexity_keeps_unset_and_shows_denominators` asserts an `unset` bucket, but that bucket is no longer reachable through `add_task`:

- `crates/orbit-core/src/application/task/add.rs:104` persists `complexity: Some(params.complexity)`, so a task created as `Unassessed` indexes the literal string `unassessed`.
- `completion_by_complexity` buckets via `labeled_or_unset(raw_complexity)` (`crates/orbit-store/src/driver/sqlite/task_registry/store.rs:689`), which maps only NULL/empty to `UNSET_BUCKET`.

So every newly created task lands in an `unassessed` bucket, while `unset` now only holds legacy rows indexed before the column existed. The dashboard therefore has two distinct labels for the same concept.

## Decision needed

Either fold `Unassessed` into `UNSET_BUCKET` at index or aggregation time (one bucket, and the existing assertion passes unchanged), or accept `unassessed` as the live label and update the fixture assertion plus any UI that renders the bucket. Pick one deliberately — do not just retarget the assertion string.

## Reproduction

`cargo test -p orbit-web --lib api::tests::diagnostics::completion_by_complexity_keeps_unset_and_shows_denominators`

Fails at `crates/orbit-web/src/api/tests/diagnostics.rs:345` with `unset bucket`.

### Acceptance Criteria

- A single documented bucket represents a task with no assessed complexity, and the choice between folding Unassessed into unset or adopting unassessed as the label is stated in the code.
- cargo test -p orbit-web --lib passes with no failing diagnostics assertions.
- Any dashboard surface rendering the complexity bucket agrees with the chosen label.

## Execution Summary

<details>
<summary>Click to expand</summary>

Decision: fold `unassessed` into the single `unset` reporting bucket (option 1). Rationale recorded in code: `TaskComplexity::Unassessed` is the stored spelling of "nobody assessed this" (`is_assessed()` is false), and legacy rows indexed before the complexity column spell the same concept as NULL — one concept must get one bucket. Adopting `unassessed` as the live label was rejected because it would leave legacy NULL rows in `unset` forever, i.e. still two labels for one concept.

The fold happens at read/aggregation time, not at index time, so the persisted and indexed value stays the literal `unassessed`: index-time folding would write NULL and poison `workspace_index_has_null_complexity` (the one-time backfill detector in `repository/task/v2/index.rs`) and lose provenance on the per-task complexity field.

Changes:
- `crates/orbit-types/src/task/model.rs`: new `complexity_bucket(Option<&str>)` layered over the generic `labeled_or_unset`; maps NULL/empty/`unassessed` -> `UNSET_BUCKET`, leaves unknown labels their own band. Doc comment states the decision and why the fold is at read time. Exported from `task/mod.rs`.
- `crates/orbit-store/src/driver/sqlite/task_registry/store.rs`: `completion_by_complexity` and `complexity_by_task_id` now bucket via `complexity_bucket` so both aggregation surfaces agree; doc comments updated.
- `crates/orbit-store/src/contracts/task_registry.rs`: `TaskCompletionByComplexity` doc names the folded bucket.
- Tests: new orbit-types unit test `unassessed_and_missing_complexity_share_one_bucket`; sqlite registry test `completion_by_complexity_keeps_unset_as_its_own_bucket` extended with an explicitly `Unassessed` task (ORB-00003) that joins the `unset` bucket (total 2) and maps to `UNSET_BUCKET`; fixture comment in `crates/orbit-web/src/api/tests/diagnostics.rs` updated. The orbit-web assertion `completion_by_complexity_keeps_unset_and_shows_denominators` passes unchanged, as required — no assertion string was retargeted.

Dashboard: `assets/dashboard/diagnostics.js` `complexityLabel()` renders `unset` as "unset (unlabeled)" and is already correct — no `unassessed` bucket can now reach it, so no UI change was needed. The per-task complexity column in `tasks.js` still shows the raw stored value (`unassessed`), which is intentional: that column reports what was persisted, not the reporting bucket.

Out-of-scope files touched beyond `context_files`, each required by a criterion: `crates/orbit-types/src/task/model.rs` + `mod.rs` (the bucket rule's authoritative owner), its sibling test file, the sqlite registry sibling test, and the store contract doc for the changed type.

Validation (all green, no denials): `cargo test -p orbit-web --lib` 250 passed / 0 failed; `cargo test -p orbit-types --lib` 140 passed; `cargo test -p orbit-store --lib` 309 passed / 4 ignored; `make ci-fast` and `make ci-lint` both pass (ran `cargo fmt --all` after an import-ordering diff).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10895-6a82440f`
- Behind base: 0
- Ahead of base: 1