### PR TITLE
Spawned CLI-runner agents don't get ORBIT_ROOT injected, and their PATH never backfills ~/.cargo/bin

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -220,6 +220,16 @@ pub fn run_cli_backend(
     child_env.extend(
         orbit_tool_env().map_err(|error| DispatchError::CliInvocationPermanent(error.message))?,
     );
+    // Spawned CLI agents resolve the Orbit registry from $HOME unless
+    // ORBIT_ROOT is set. A dispatching run already knows its root; inject
+    // it the same way `RuntimeHost::execution_environment_mode` does so a
+    // provider whose HOME is a tool-specific directory (e.g. ~/.codex)
+    // can still reach `orbit tool run`. [ORB-10909]
+    if let Some(orbit_root) = host.orbit_root()
+        && !child_env.iter().any(|(key, _)| key == "ORBIT_ROOT")
+    {
+        child_env.push(("ORBIT_ROOT".to_string(), orbit_root));
+    }
     // [ORB-10496] Record the provider child's PID the moment it exists. Emitted
     // through the same writer, so it is persisted (and therefore readable by
     // `orbit run show` / the run-status API) while the invocation is still

--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -19,6 +19,12 @@ use super::super::dispatcher::ResolvedSandbox;
 
 const ORBIT_BIN_ENV: &str = "ORBIT_BIN";
 
+/// Conventional `$HOME` bin directories searched when a provider launcher
+/// is not on the inherited `PATH`, and backfilled into a spawned agent's
+/// `PATH` when those entries are absent. Keep this list shared so lookup
+/// and child-env construction cannot drift. [ORB-10909]
+const CONVENTIONAL_HOME_BIN_DIRS: &[&str] = &[".local/bin", ".orbit/bin", ".cargo/bin", "bin"];
+
 /// Typed spawn failure with a retryability classification (ORB-10006).
 ///
 /// `permanent: true` marks failures that retrying cannot fix — the step
@@ -181,10 +187,12 @@ pub(crate) fn orbit_tool_env() -> Result<Vec<(String, String)>, SpawnError> {
     })?;
     let configured = std::env::var_os(ORBIT_BIN_ENV);
     let inherited_path = std::env::var_os("PATH");
+    let home = std::env::var_os("HOME").map(PathBuf::from);
     orbit_tool_env_with(
         configured.as_deref(),
         &current_exe,
         inherited_path.as_deref(),
+        home.as_deref(),
     )
 }
 
@@ -193,6 +201,7 @@ pub(crate) fn orbit_tool_env_with(
     configured: Option<&OsStr>,
     current_exe: &Path,
     inherited_path: Option<&OsStr>,
+    home: Option<&Path>,
 ) -> Result<Vec<(String, String)>, SpawnError> {
     let selected = configured
         .filter(|value| !value.is_empty())
@@ -208,10 +217,25 @@ pub(crate) fn orbit_tool_env_with(
     };
 
     let mut path_entries = vec![bin_dir.to_path_buf()];
+    let mut seen = HashSet::new();
+    seen.insert(bin_dir.to_path_buf());
     if let Some(inherited_path) = inherited_path {
-        path_entries.extend(
-            std::env::split_paths(inherited_path).filter(|entry| entry.as_path() != bin_dir),
-        );
+        for entry in std::env::split_paths(inherited_path) {
+            if seen.insert(entry.clone()) {
+                path_entries.push(entry);
+            }
+        }
+    }
+    // Service/routine dispatch often inherits a PATH that omits cargo and
+    // other login-shell bins. Backfill the same conventional home dirs
+    // `resolve_provider_launcher_with` already searches so `cargo test`
+    // inside the spawned agent is not "command not found". [ORB-10909]
+    if let Some(home) = home {
+        for dir in conventional_home_bin_dirs(home) {
+            if seen.insert(dir.clone()) {
+                path_entries.push(dir);
+            }
+        }
     }
     let pinned_path = std::env::join_paths(path_entries)
         .map_err(|error| {
@@ -232,6 +256,12 @@ pub(crate) fn orbit_tool_env_with(
         (ORBIT_BIN_ENV.to_string(), selected_text),
         ("PATH".to_string(), pinned_path),
     ])
+}
+
+fn conventional_home_bin_dirs(home: &Path) -> impl Iterator<Item = PathBuf> + '_ {
+    CONVENTIONAL_HOME_BIN_DIRS
+        .iter()
+        .map(|relative| home.join(relative))
 }
 
 // pub(crate) widened for sibling tests under the repository's enforced test layout.
@@ -262,8 +292,7 @@ pub(crate) fn resolve_provider_launcher_with(
         }
     }
     if let Some(home) = home {
-        for relative in [".local/bin", ".orbit/bin", ".cargo/bin", "bin"] {
-            let dir = home.join(relative);
+        for dir in conventional_home_bin_dirs(home) {
             if seen.insert(dir.clone()) {
                 search_dirs.push(dir);
             }

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/envelope.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/envelope.rs
@@ -52,6 +52,7 @@ fn cli_agent_envelope_carries_input_run_id_and_task_context() {
             "plan": "implement it"
         })),
         workspace_root: None,
+        orbit_root: None,
     };
     let mut spec = test_agent_loop_spec(Duration::from_secs(5));
     spec.instruction = "perform the requested task".to_string();

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -876,6 +876,7 @@ fn run_cli_backend_returns_error_when_declared_workspace_path_missing() {
             "workspace_path": missing.display().to_string()
         })),
         workspace_root: None,
+        orbit_root: None,
     };
     let spec = test_agent_loop_spec(Duration::from_secs(5));
     let input = serde_json::json!({
@@ -935,6 +936,7 @@ fn run_cli_backend_records_resolved_cwd_in_started_event() {
             "workspace_path": workspace_string.clone()
         })),
         workspace_root: None,
+        orbit_root: None,
     };
     let spec = test_agent_loop_spec(Duration::from_secs(5));
 
@@ -1007,6 +1009,7 @@ fn linux_bwrap_failed_invocation_names_ungranted_write_path_and_deny() {
             "workspace_path": workspace.display().to_string()
         })),
         workspace_root: None,
+        orbit_root: None,
     };
     let spec = test_agent_loop_spec(Duration::from_secs(5));
 
@@ -1118,6 +1121,7 @@ fn linux_bwrap_exit_zero_without_an_envelope_still_names_the_denied_write() {
             "workspace_path": workspace.display().to_string()
         })),
         workspace_root: None,
+        orbit_root: None,
     };
     let spec = test_agent_loop_spec(Duration::from_secs(5));
 
@@ -1186,6 +1190,7 @@ fn run_cli_backend_emits_provider_pid_between_the_started_and_finished_events() 
         sandbox: None,
         task_context: None,
         workspace_root: None,
+        orbit_root: None,
     };
     let spec = test_agent_loop_spec(Duration::from_secs(5));
 
@@ -2985,6 +2990,7 @@ fn run_cli_backend_passes_provider_config_to_codex_runtime_args() {
         sandbox: None,
         task_context: None,
         workspace_root: None,
+        orbit_root: None,
     };
     let spec = test_agent_loop_spec(Duration::from_secs(5));
 
@@ -3057,6 +3063,7 @@ fn run_cli_backend_passes_model_to_grok_and_captures_well_formed_stdout() {
         sandbox: None,
         task_context: None,
         workspace_root: None,
+        orbit_root: None,
     };
     let mut spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
     spec.model = Some("grok-build".to_string());
@@ -3133,6 +3140,7 @@ fi
         sandbox: None,
         task_context: None,
         workspace_root: None,
+        orbit_root: None,
     };
     let mut spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
     spec.model = Some("grok-build".to_string());
@@ -3186,6 +3194,7 @@ fi
         sandbox: None,
         task_context: None,
         workspace_root: None,
+        orbit_root: None,
     };
     let mut spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
     spec.model = Some("grok-build".to_string());
@@ -3196,6 +3205,59 @@ fi
         "job-grok-telemetry",
         audit,
         &serde_json::json!({"prompt": "hi", "task_id": "ORB-10342"}),
+        None,
+    )
+    .expect("run succeeds");
+
+    assert!(outcome.success);
+    assert_eq!(outcome.output["provider"], "grok");
+}
+
+/// [ORB-10909] CLI-runner dispatch must inject ORBIT_ROOT from the host so a
+/// spawned agent whose HOME does not contain the Orbit registry can still
+/// resolve `orbit tool run` against the dispatching run's root.
+#[test]
+fn run_cli_backend_injects_orbit_root_from_host() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("grok");
+    write_executable(
+        &script,
+        r#"#!/bin/sh
+cat > /dev/null
+if [ "$ORBIT_ROOT" = "/resolved/orbit/root" ]; then
+  printf '%s\n' '{"schemaVersion":1,"status":"success","result":{"identity":"ok"},"error":null}'
+else
+  printf '%s\n' '{"schemaVersion":1,"status":"failed","error":{"code":"orbit_root_missing","message":"ORBIT_ROOT was not injected","details":null}}'
+  exit 1
+fi
+"#,
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-grok-orbit-root",
+        "grok:grok-build",
+        sink_for_writer,
+    ));
+    let host = TestHost {
+        command: script.display().to_string(),
+        executor_args: Vec::new(),
+        provider_config: HashMap::new(),
+        sandbox: None,
+        task_context: None,
+        workspace_root: None,
+        orbit_root: Some("/resolved/orbit/root".to_string()),
+    };
+    let mut spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
+    spec.model = Some("grok-build".to_string());
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-grok-orbit-root",
+        audit,
+        &serde_json::json!({"prompt": "hi"}),
         None,
     )
     .expect("run succeeds");

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_macos.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_macos.rs
@@ -45,6 +45,7 @@ fn run_cli_backend_audit_argv_starts_with_sandbox_exec_for_each_provider() {
             sandbox: Some(sandbox_for_test()),
             task_context: None,
             workspace_root: None,
+            orbit_root: None,
         };
         let spec = test_agent_loop_spec_for(provider_name, Duration::from_secs(5));
 
@@ -119,6 +120,7 @@ fn run_cli_backend_pins_codex_sandbox_under_outer_wrapper() {
         sandbox: Some(sandbox_for_test()),
         task_context: None,
         workspace_root: None,
+        orbit_root: None,
     };
     let spec = test_agent_loop_spec_for("codex", Duration::from_secs(5));
 
@@ -192,6 +194,7 @@ fn run_cli_backend_drops_gemini_sandbox_flag_under_outer_wrapper() {
         sandbox: Some(sandbox_for_test()),
         task_context: None,
         workspace_root: None,
+        orbit_root: None,
     };
     let spec = test_agent_loop_spec_for("gemini", Duration::from_secs(5));
 
@@ -258,6 +261,7 @@ fn run_cli_backend_drops_grok_sandbox_flag_under_outer_wrapper() {
         sandbox: Some(sandbox_for_test()),
         task_context: None,
         workspace_root: None,
+        orbit_root: None,
     };
     let spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
 
@@ -324,6 +328,7 @@ fn run_cli_backend_leaves_claude_argv_suffix_unchanged_under_sandbox() {
         sandbox: Some(sandbox_for_test()),
         task_context: None,
         workspace_root: None,
+        orbit_root: None,
     };
     let spec = test_agent_loop_spec_for("claude", Duration::from_secs(5));
 

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
@@ -362,6 +362,7 @@ fn agent_tool_environment_prefers_dispatching_orbit_over_stale_path_entry() {
         None,
         std::path::Path::new("/home/test/.orbit/bin/orbit"),
         Some(&inherited),
+        None,
     )
     .expect("pin dispatching Orbit");
 
@@ -395,6 +396,7 @@ fn configured_orbit_bin_wins_and_its_path_entry_is_deduplicated() {
         Some(std::ffi::OsStr::new("/opt/orbit/bin/orbit")),
         std::path::Path::new("/home/test/.orbit/bin/orbit"),
         Some(&inherited),
+        None,
     )
     .expect("pin configured Orbit");
 
@@ -409,6 +411,35 @@ fn configured_orbit_bin_wins_and_its_path_entry_is_deduplicated() {
             std::path::PathBuf::from("/opt/orbit/bin"),
             std::path::PathBuf::from("/home/test/.cargo/bin"),
             std::path::PathBuf::from("/usr/bin"),
+        ]
+    );
+}
+
+#[test]
+fn agent_tool_environment_backfills_conventional_home_bin_dirs_missing_from_path() {
+    let inherited = std::env::join_paths(["/usr/bin"]).expect("construct inherited PATH");
+    let home = std::path::Path::new("/home/test");
+    let env = orbit_tool_env_with(
+        None,
+        std::path::Path::new("/home/test/.orbit/bin/orbit"),
+        Some(&inherited),
+        Some(home),
+    )
+    .expect("pin dispatching Orbit");
+
+    let pinned = env
+        .iter()
+        .find(|(name, _)| name == "PATH")
+        .map(|(_, value)| value)
+        .expect("PATH override");
+    assert_eq!(
+        std::env::split_paths(std::ffi::OsStr::new(pinned)).collect::<Vec<_>>(),
+        vec![
+            std::path::PathBuf::from("/home/test/.orbit/bin"),
+            std::path::PathBuf::from("/usr/bin"),
+            std::path::PathBuf::from("/home/test/.local/bin"),
+            std::path::PathBuf::from("/home/test/.cargo/bin"),
+            std::path::PathBuf::from("/home/test/bin"),
         ]
     );
 }

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
@@ -241,6 +241,7 @@ pub(in crate::activity_job::cli_runner) struct TestHost {
     pub(in crate::activity_job::cli_runner) sandbox: Option<ResolvedSandbox>,
     pub(in crate::activity_job::cli_runner) task_context: Option<Value>,
     pub(in crate::activity_job::cli_runner) workspace_root: Option<PathBuf>,
+    pub(in crate::activity_job::cli_runner) orbit_root: Option<String>,
 }
 
 impl TestHost {
@@ -252,6 +253,7 @@ impl TestHost {
             sandbox: None,
             task_context: None,
             workspace_root: None,
+            orbit_root: None,
         }
     }
 }
@@ -316,6 +318,10 @@ impl RuntimeHost for TestHost {
             workspace_root: self.workspace_root.clone(),
             ..ToolContext::default()
         }
+    }
+
+    fn orbit_root(&self) -> Option<String> {
+        self.orbit_root.clone()
     }
 }
 


### PR DESCRIPTION
## Task

[ORB-10909](https://orbit-cli.com/tasks/ORB-10909) — Spawned CLI-runner agents don't get ORBIT_ROOT injected, and their PATH never backfills ~/.cargo/bin

### Description

## Problem
Two related env-injection gaps in `crates/orbit-engine/src/activity_job/cli_runner/`:

1. `orchestrator.rs`'s `run_cli_backend` spawns the CLI agent for a job run. Its `child_env` assembly (`provenance_env(...)` at line ~208, extended with `orbit_tool_env()` at line ~220-222) never sets `ORBIT_ROOT` for the spawned agent. If the spawned process's `$HOME` doesn't match the repo's actual `.orbit` registry (observed: HOME was `~/.codex` while the registry was under `~/.orbit`), `orbit tool run orbit.task.show` returns `task_not_found` even though `ORBIT_ROOT` -- already a documented "escape hatch" in `crates/orbit-core/src/runtime/resolve.rs` -- would have avoided it entirely.

   Note for whoever picks this up: `run_cli_backend` already receives `host: &dyn RuntimeHost`, and `RuntimeHost` (`crates/orbit-engine/src/context/hosts.rs`) already has an `orbit_root(&self) -> Option<String>` accessor (line ~206) plus a working backfill pattern for a *different* dispatch path -- `execution_environment_mode` (lines ~227-239) calls `self.orbit_root()` and pushes `("ORBIT_ROOT", orbit_root)` into the env if not already present. The `cli_runner` orchestrator's `child_env` construction does not go through that path and should mirror it directly (call `host.orbit_root()` and push `ORBIT_ROOT` into `child_env` alongside the existing `provenance_env`/`orbit_tool_env` entries).

2. `orbit_tool_env_with` (`crates/orbit-engine/src/activity_job/cli_runner/spawn.rs`, line ~192) builds the spawned agent's PATH as `[orbit_bin_dir] + inherited PATH` without backfilling `~/.cargo/bin`/`~/.local/bin` when absent from the inherited PATH -- unlike the sibling `resolve_provider_launcher_with` in the same file (line ~238), which already searches `.local/bin`, `.orbit/bin`, `.cargo/bin`, and `bin` under `$HOME` (lines ~264-271), and unlike `orbit-sweep.service`'s systemd unit (`crates/orbit-core/assets/clock/orbit-sweep.service`), which already has this fallback for the identical class of problem.

## Why It Matters
A task-capable binary can appear unable to read its own assigned task, or `cargo`-based validation commands fail with "command not found," purely because of an environment mismatch the spawning code already has enough information to prevent.

## Constraints / Notes
- Frictions: F2026-08-064 (HOME/PATH mismatch, ORB-10720) and F2026-07-167 (PATH-omits-cargo sub-claim only -- its separate harness exit-code-reporting sub-claim is out of scope for this repo and stays tracked on that friction).
- Precedent for backfilling child-env values generically: `crates/orbit-common/src/security/redaction.rs`'s `backfill_login_identity` (ORB-00409, USER/LOGNAME), around line 457.
- Verified 2026-08-16: both `crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs` and `spawn.rs` still exist with `orbit_tool_env_with` (spawn.rs line ~192) and `resolve_provider_launcher_with` (spawn.rs line ~238) present as described.

### Acceptance Criteria

- The CLI-runner's spawned agent child_env includes ORBIT_ROOT set to the dispatching run's resolved Orbit root.
- orbit_tool_env_with's PATH backfills ~/.cargo/bin (and other conventional bin dirs already used by resolve_provider_launcher_with) when absent from the inherited PATH, mirroring the existing fallback pattern.
- Tests cover both: a spawned agent's env contains ORBIT_ROOT matching the run's root, and the constructed PATH includes ~/.cargo/bin even when the inherited PATH lacks it.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `run_cli_backend` injects `ORBIT_ROOT` from `host.orbit_root()` when absent, matching `RuntimeHost::execution_environment_mode`.
- `orbit_tool_env_with` now takes injectable `HOME` and appends the same conventional home bin dirs (`.local/bin`, `.orbit/bin`, `.cargo/bin`, `bin`) when they are missing from the inherited PATH. `resolve_provider_launcher_with` consumes the same `CONVENTIONAL_HOME_BIN_DIRS` list so lookup and child-env construction cannot drift.
- Tests: `run_cli_backend_injects_orbit_root_from_host` asserts a spawned child's env matches the host root; `agent_tool_environment_backfills_conventional_home_bin_dirs_missing_from_path` asserts `~/.cargo/bin` appears when the inherited PATH omits it.

Unlisted files (needed to compile / cover criteria; appended to context_files):
- `file:crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs` — `TestHost.orbit_root` seam for the spawned-agent test.
- `file:crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs` — spawned-agent ORBIT_ROOT test.
- `file:crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs` — PATH backfill test and `orbit_tool_env_with` signature update.
- `file:crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_macos.rs` and `file:crates/orbit-engine/src/activity_job/cli_runner/tests/envelope.rs` — `orbit_root: None` so existing TestHost literals compile.

Assessment: Small, local env-injection fix that reuses existing host and launcher fallbacks. No new crate edges.
Strategic decisions: do not overwrite a pre-set ORBIT_ROOT; backfill conventional PATH dirs at the end so inherited entries keep precedence.
Design weaknesses / risks: none beyond the existing HOME-dependent launcher lookup; mitigated by sharing the dir list.
Deviations from original plan: none.
Recommended follow-ups: none in this repo. F2026-07-167 harness exit-code reporting remains out of scope.

Validation:
- `cargo test -p orbit-engine --lib activity_job::cli_runner`: 107 passed (including both new tests)
- `make ci-fast`: passed
- `make ci-lint`: passed
Friction checkpoint: no new friction. Implementation matched the authored plan; F2026-08-064 remains the existing HOME/PATH record.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10909-6a8253e4`
- Behind base: 0
- Ahead of base: 1