### PR TITLE
probe_bwrap-gated Linux sandbox tests report PASS instead of SKIP when bwrap is unavailable

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -11,8 +11,6 @@ use std::time::Duration;
 use crate::activity_job::{load_activity_asset, load_job_asset};
 use orbit_agent::loop_engine::audit::AuditSink;
 use orbit_common::test_fixtures::TEST_CODEX_MODEL;
-#[cfg(target_os = "linux")]
-use orbit_exec::probe_bwrap;
 use orbit_store::Store;
 use orbit_types::workflow::activity_job::{ActivityV2Spec, JobV2StepBody, V2AuditEventKind};
 use tempfile::{TempDir, tempdir};
@@ -962,11 +960,8 @@ fn run_cli_backend_records_resolved_cwd_in_started_event() {
 
 #[cfg(target_os = "linux")]
 #[test]
+#[ignore = "requires unprivileged user namespaces; bwrap cannot nest inside Orbit's sandbox"]
 fn linux_bwrap_failed_invocation_names_ungranted_write_path_and_deny() {
-    if !probe_bwrap().available {
-        return;
-    }
-
     let temp = tempdir().expect("tempdir");
     let workspace = temp.path().join("worktree");
     let orbit = workspace.join(".orbit");
@@ -1035,9 +1030,10 @@ fn linux_bwrap_failed_invocation_names_ungranted_write_path_and_deny() {
 }
 
 /// [ORB-10879] The composition rule behind the exit-0 attribution, asserted
-/// without Bubblewrap: a host whose kernel forbids unprivileged user namespaces
-/// skips every `probe_bwrap`-gated test in this file, so the message contract
-/// gets a check that always runs.
+/// without Bubblewrap: the spawn-boundary tests below are `#[ignore]`d because
+/// a host whose kernel forbids unprivileged user namespaces (including every
+/// nested Orbit sandbox) cannot run them, so the message contract gets a check
+/// that always runs.
 #[test]
 fn sandbox_write_attribution_rides_along_with_the_frame_classification() {
     let denial = "Orbit linux-bwrap policy denied the attempted write: \
@@ -1072,11 +1068,8 @@ fn sandbox_write_attribution_rides_along_with_the_frame_classification() {
 /// guess ("remount the filesystem") and no path or rule anywhere in the record.
 #[cfg(target_os = "linux")]
 #[test]
+#[ignore = "requires unprivileged user namespaces; bwrap cannot nest inside Orbit's sandbox"]
 fn linux_bwrap_exit_zero_without_an_envelope_still_names_the_denied_write() {
-    if !probe_bwrap().available {
-        return;
-    }
-
     let temp = tempdir().expect("tempdir");
     let workspace = temp.path().join("worktree");
     let orbit = workspace.join(".orbit");


### PR DESCRIPTION
## Task

[ORB-10903](https://orbit-cli.com/tasks/ORB-10903) — probe_bwrap-gated Linux sandbox tests report PASS instead of SKIP when bwrap is unavailable

### Description

## Problem
`crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs`'s `linux_bwrap_failed_invocation_names_ungranted_write_path_and_deny` and `linux_bwrap_exit_zero_without_an_envelope_still_names_the_denied_write` both open with `if !probe_bwrap().available { return; }` and no `#[ignore]`/skip marker. On any host without unprivileged user-namespace support — which includes every agent worktree run, since Orbit's own sandbox is already a bwrap namespace and bwrap cannot nest — this silently no-ops the whole test body, and `nextest` reports `PASS`, not `SKIP`.
## Why It Matters
A regression in the actual bwrap-invocation behavior these tests exist to catch would go completely undetected in exactly the environment (agent worktree runs) where the tests currently execute. Verified live: `cargo nextest run` reports `PASS [0.008s]` for a test that is supposed to spawn Bubblewrap, compile a filesystem profile, and run a shell script.
## Constraints / Notes
- Friction: F2026-08-083.
- ORB-10879 added host-independent tests against the pure helper functions as a mitigation but explicitly did not change the PASS/SKIP reporting behavior of these two gated tests.

### Acceptance Criteria

- When `probe_bwrap().available` is false, the two named tests report as skipped (e.g. via `#[ignore]` with a reason, or an equivalent nextest-visible skip signal) rather than PASS, so a test run distinguishes "not exercised here" from "passed."
- Running `cargo nextest run -p orbit-engine -E 'test(linux_bwrap_exit_zero_without_an_envelope_still_names_the_denied_write)'` on this sandbox (bwrap unavailable) now shows the test as skipped, not passed.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Marked `linux_bwrap_failed_invocation_names_ungranted_write_path_and_deny` and `linux_bwrap_exit_zero_without_an_envelope_still_names_the_denied_write` with `#[ignore = "requires unprivileged user namespaces; bwrap cannot nest inside Orbit's sandbox"]`.
- Removed the silent `if !probe_bwrap().available { return; }` guards (and the now-unused `probe_bwrap` import) so a forced `--run-ignored` run actually exercises the spawn body instead of reporting PASS while asserting nothing.
- Updated the ORB-10879 host-independent test comment to describe the ignore, not a silent skip.
Assessment: Small, scoped to the listed file. libtest/nextest have no runtime skip; `#[ignore]` is the nextest-visible signal the criteria asked for. Default nextest no longer reports these as PASS on this sandbox (bwrap unavailable).
Strategic decisions:
- Static `#[ignore]` rather than a compile-time cfg: a shared `target/` between host and nested sandbox would make a build.rs probe stale.
- Did not add `--run-ignored` to default CI. GitHub ubuntu-latest typically cannot nest bwrap either; forcing the tests would fail or resurrect a silent-PASS path. Unrestricted hosts run them with `cargo nextest run -p orbit-engine -E 'test(/linux_bwrap_(failed_invocation|exit_zero_without_an_envelope)/)' --run-ignored`. Host-independent coverage from ORB-10879 remains the always-on contract.
Validation:
- `cargo nextest run -p orbit-engine -E 'test(linux_bwrap_exit_zero_without_an_envelope_still_names_the_denied_write)'`: 0 passed, test not executed (nextest treats `#[ignore]` as unselected; exits 4 "no tests to run" when the filter matches only ignored tests). Not PASS.
- Same filter for `linux_bwrap_failed_invocation_names_ungranted_write_path_and_deny`: same skip, not PASS.
- `cargo nextest list -p orbit-engine --run-ignored ignored-only -E 'test(/linux_bwrap_(exit_zero_without_an_envelope_still_names_the_denied_write|failed_invocation_names_ungranted_write_path_and_deny)/)'` lists exactly those two tests.
- `cargo test -p orbit-engine --lib linux_bwrap_exit_zero_without_an_envelope_still_names_the_denied_write`: `ignored, requires unprivileged user namespaces; bwrap cannot nest inside Orbit's sandbox` (0 passed, 1 ignored).
- `make ci-fast`: exit 0.
- `make ci-lint` not run (attribute-only test change; workspace clippy is the pipeline's compile gate).
Friction checkpoint: none new. This task already `resolves` F2026-08-083.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10903-6a8253e4`
- Behind base: 0
- Ahead of base: 1