### PR TITLE
system_crew:true marker never reaches the dispatched activity input

### DIFF
--- a/crates/orbit-engine/src/activity_job/job_executor/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/target.rs
@@ -10,6 +10,10 @@ pub(super) fn run_target(
 ) -> Result<StepOutcome, DispatchError> {
     let tctx = ctx.template_ctx();
     let rendered_input = render_input(t.default_input.as_ref(), &ctx.input, &tctx)?;
+    // [ORB-10902] Rebind before dispatch so `system_crew: true` reaches the
+    // activity input, not only the local copy used to resolve crew settings.
+    // Recovery does the same; injection is independent of target spec type.
+    let rendered_input = inject_system_crew_input(ctx.host, &rendered_input)?;
 
     // A rendered activity `crew` selects a non-default assignment; otherwise
     // dispatch inherits the run's resolved crew.

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
@@ -13,6 +13,7 @@ use super::crew_overridden_spec;
 struct CrewHost {
     config: HashMap<String, CrewConfig>,
     observed: Mutex<Vec<String>>,
+    system_crew: Option<String>,
 }
 
 impl CrewHost {
@@ -23,7 +24,13 @@ impl CrewHost {
                 .map(|(name, config)| (name.to_string(), config))
                 .collect(),
             observed: Mutex::new(Vec::new()),
+            system_crew: None,
         }
+    }
+
+    fn with_system_crew(mut self, name: impl Into<String>) -> Self {
+        self.system_crew = Some(name.into());
+        self
     }
 
     fn observed(&self) -> Vec<String> {
@@ -80,6 +87,10 @@ impl RuntimeHost for CrewHost {
             .cloned()
             .map(Some)
             .ok_or_else(|| DispatchError::JobValidation(format!("test crew `{name}` is unknown")))
+    }
+
+    fn system_crew_for_dispatch(&self) -> Option<String> {
+        self.system_crew.clone()
     }
 }
 
@@ -189,6 +200,300 @@ fn crew_resolution_does_not_apply_to_deterministic_specs() {
             .is_none()
     );
     assert!(host.observed().is_empty());
+}
+
+#[test]
+fn system_crew_marker_routes_to_the_configured_system_crew() {
+    let host = CrewHost::new([
+        ("run-default", config(Provider::Claude, "run-model")),
+        ("system", config(Provider::Codex, "system-model")),
+    ])
+    .with_system_crew("system");
+    let ctx = exec_ctx(&host);
+    let target = target_step(ActivityV2Spec::AgentLoop(inline_agent_loop_spec()));
+
+    let overridden = crew_overridden_spec(&target, &ctx, &json!({ "system_crew": true }))
+        .expect("resolve injected system crew")
+        .expect("configured host returns an override");
+    assert_eq!(overridden.provider, Provider::Codex);
+    assert_eq!(overridden.model.as_deref(), Some("system-model"));
+    assert_eq!(host.observed(), vec!["system"]);
+}
+
+// ----- [ORB-10902] Dispatched input carries the injected crew ----------
+
+struct SystemCrewDispatchHost {
+    system_crew: String,
+    config: HashMap<String, CrewConfig>,
+    cli_program: Option<String>,
+    deterministic_inputs: Mutex<Vec<Value>>,
+    persisted_inputs: Mutex<Vec<Value>>,
+}
+
+impl SystemCrewDispatchHost {
+    fn new(
+        system_crew: &str,
+        config: impl IntoIterator<Item = (&'static str, CrewConfig)>,
+    ) -> Self {
+        Self {
+            system_crew: system_crew.to_string(),
+            config: config
+                .into_iter()
+                .map(|(name, config)| (name.to_string(), config))
+                .collect(),
+            cli_program: None,
+            deterministic_inputs: Mutex::new(Vec::new()),
+            persisted_inputs: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn with_cli_program(mut self, program: impl Into<String>) -> Self {
+        self.cli_program = Some(program.into());
+        self
+    }
+
+    fn deterministic_inputs(&self) -> Vec<Value> {
+        self.deterministic_inputs
+            .lock()
+            .expect("deterministic inputs")
+            .clone()
+    }
+
+    fn persisted_inputs(&self) -> Vec<Value> {
+        self.persisted_inputs
+            .lock()
+            .expect("persisted inputs")
+            .clone()
+    }
+}
+
+impl RuntimeHost for SystemCrewDispatchHost {
+    fn run_deterministic(
+        &self,
+        action: &str,
+        _config: &Value,
+        input: &Value,
+        _tool_context: orbit_tools::ToolContext,
+    ) -> Result<Value, DispatchError> {
+        self.deterministic_inputs
+            .lock()
+            .expect("deterministic inputs")
+            .push(input.clone());
+        Ok(json!({ "action": action }))
+    }
+
+    fn resolve_cli_executor(
+        &self,
+        _provider: &str,
+    ) -> Result<super::super::super::dispatcher::ResolvedCliExecutor, DispatchError> {
+        match &self.cli_program {
+            Some(command) => Ok(super::super::super::dispatcher::ResolvedCliExecutor {
+                command: command.clone(),
+                args: Vec::new(),
+            }),
+            None => Err(DispatchError::CliInvocationFailed(
+                "system-crew dispatch host: no CLI mapping".into(),
+            )),
+        }
+    }
+
+    fn tool_context_for_activity(
+        &self,
+        _run_id: Option<&str>,
+        _fs_profile: Option<&str>,
+        _fs_audit: Option<std::sync::Arc<dyn orbit_tools::FsAuditLogger>>,
+        _proc_allowed_programs: Option<&[String]>,
+    ) -> orbit_tools::ToolContext {
+        orbit_tools::ToolContext::default()
+    }
+
+    fn system_crew_for_dispatch(&self) -> Option<String> {
+        Some(self.system_crew.clone())
+    }
+
+    fn agent_crew_config_for_input(
+        &self,
+        input: &Value,
+    ) -> Result<Option<CrewConfig>, DispatchError> {
+        let name = input
+            .get("crew")
+            .and_then(Value::as_str)
+            .unwrap_or("run-default");
+        self.config
+            .get(name)
+            .cloned()
+            .map(Some)
+            .ok_or_else(|| DispatchError::JobValidation(format!("test crew `{name}` is unknown")))
+    }
+
+    fn persist_invocation_trace(
+        &self,
+        _job_run_id: &str,
+        _activity_id: &str,
+        _provider: &str,
+        _model: Option<&str>,
+        input: &Value,
+        _trace: &orbit_types::telemetry::InvocationTrace,
+    ) -> Result<(), DispatchError> {
+        self.persisted_inputs
+            .lock()
+            .expect("persisted inputs")
+            .push(input.clone());
+        Ok(())
+    }
+}
+
+fn system_crew_default_input() -> Value {
+    json!({ "system_crew": true })
+}
+
+fn assert_injected_system_crew(input: &Value, crew: &str) {
+    assert_eq!(
+        input.get("crew").and_then(Value::as_str),
+        Some(crew),
+        "dispatched input must carry the injected crew: {input}"
+    );
+    assert_eq!(
+        input.get("crew_config_key").and_then(Value::as_str),
+        Some("workflow.system_crew"),
+        "dispatched input must name the system-crew config key: {input}"
+    );
+    assert_eq!(
+        input.get("system_crew").and_then(Value::as_bool),
+        Some(true),
+        "dispatched input must retain the system_crew marker: {input}"
+    );
+}
+
+fn dump_stdin_provider(
+    dir: &std::path::Path,
+    envelope_out: &std::path::Path,
+) -> std::path::PathBuf {
+    let script = dir.join("claude");
+    std::fs::write(
+        &script,
+        format!(
+            "#!/bin/sh\ncat > '{}'\nprintf '%s\\n' '{{\"schemaVersion\":1,\"status\":\"success\",\"result\":{{}},\"error\":null}}'\n",
+            envelope_out.display()
+        ),
+    )
+    .expect("write fake provider");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script).expect("stat").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script, perms).expect("chmod");
+    }
+    script
+}
+
+fn envelope_input_from_cli_stdin(stdin: &str) -> Value {
+    let json = stdin
+        .split("Execution envelope:\n")
+        .nth(1)
+        .expect("cli stdin should embed the execution envelope");
+    let envelope: Value = serde_json::from_str(json.trim()).expect("envelope json");
+    envelope
+        .get("input")
+        .cloned()
+        .expect("execution envelope input")
+}
+
+fn agent_loop_step_with_system_crew() -> JobV2Step {
+    JobV2Step {
+        id: "pilot".to_string(),
+        when: None,
+        retry: None,
+        recovery_activity: None,
+        resolved_recovery_activity: None,
+        body: JobV2StepBody::Target(TargetStep {
+            spec: ActivityV2Spec::AgentLoop(inline_agent_loop_spec()),
+            activity_name: None,
+            fs_profile: None,
+            default_input: Some(system_crew_default_input()),
+            timeout_seconds: 0,
+            session: None,
+        }),
+    }
+}
+
+fn deterministic_step_with_system_crew() -> JobV2Step {
+    JobV2Step {
+        id: "apply".to_string(),
+        when: None,
+        retry: None,
+        recovery_activity: None,
+        resolved_recovery_activity: None,
+        body: JobV2StepBody::Target(TargetStep {
+            spec: ActivityV2Spec::Deterministic(DeterministicSpec {
+                action: "apply".to_string(),
+                config: Value::Null,
+            }),
+            activity_name: None,
+            fs_profile: None,
+            default_input: Some(system_crew_default_input()),
+            timeout_seconds: 0,
+            session: None,
+        }),
+    }
+}
+
+#[test]
+fn system_crew_true_is_injected_into_dispatched_agent_loop_input() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let envelope_out = temp.path().join("stdin.json");
+    let script = dump_stdin_provider(temp.path(), &envelope_out);
+    let host = SystemCrewDispatchHost::new(
+        "system",
+        [("system", config(Provider::Claude, TEST_CLAUDE_MODEL))],
+    )
+    .with_cli_program(script.display().to_string());
+    let job = job_with_steps(vec![agent_loop_step_with_system_crew()]);
+    let writer = std::sync::Arc::new(test_writer("run-system-crew-agent"));
+
+    let outcome = execute_job(
+        &job,
+        json!({ "crew": "run-default" }),
+        "run-system-crew-agent",
+        writer,
+        &host,
+    )
+    .expect("execute_job ok");
+    assert!(outcome.success, "{:?}", outcome.message);
+
+    let stdin = std::fs::read_to_string(&envelope_out).expect("cli stdin dump");
+    let dispatched = envelope_input_from_cli_stdin(&stdin);
+    assert_injected_system_crew(&dispatched, "system");
+
+    let persisted = host.persisted_inputs();
+    if let Some(input) = persisted.first() {
+        assert_injected_system_crew(input, "system");
+    }
+}
+
+#[test]
+fn system_crew_true_is_injected_into_dispatched_deterministic_input() {
+    let host = SystemCrewDispatchHost::new(
+        "system",
+        [("system", config(Provider::Claude, TEST_CLAUDE_MODEL))],
+    );
+    let job = job_with_steps(vec![deterministic_step_with_system_crew()]);
+    let writer = std::sync::Arc::new(test_writer("run-system-crew-det"));
+
+    let outcome = execute_job(
+        &job,
+        json!({ "crew": "run-default" }),
+        "run-system-crew-det",
+        writer,
+        &host,
+    )
+    .expect("execute_job ok");
+    assert!(outcome.success, "{:?}", outcome.message);
+
+    let inputs = host.deterministic_inputs();
+    assert_eq!(inputs.len(), 1, "deterministic action should dispatch once");
+    assert_injected_system_crew(&inputs[0], "system");
 }
 
 // ----- Telemetry persistence is non-fatal (ORB-10367) -----------------


### PR DESCRIPTION
## Task

[ORB-10902](https://orbit-cli.com/tasks/ORB-10902) — system_crew:true marker never reaches the dispatched activity input

### Description

## Problem
In `crates/orbit-engine/src/activity_job/job_executor/target.rs`, `crew_overridden_spec` (~lines 86-102) computes an injected input via `inject_system_crew_input` but only uses that local copy to pick crew settings (`resolve_crew_settings`) — the value actually dispatched (`input: rendered_input.clone()`) is the pre-injection copy, so a step marked `system_crew: true` never actually sends a `crew` key to the agent. Separately, `crew_overridden_spec` returns `Ok(None)` early unless the target is `ActivityV2Spec::AgentLoop`, so `system_crew: true` on a deterministic step is silently discarded entirely, and `validate_step` (`crates/orbit-engine/src/activity_job/job_executor/validate.rs`) doesn't reject either case. The parallel `recovery.rs` code path does this correctly (rebinds the outer `input` before dispatch), confirming the bug is localized to `target.rs`.
## Why It Matters
A step author relying on `system_crew: true` gets silent no-op behavior instead of the intended crew override, discoverable only by reading dispatch internals — cost over 10 minutes to establish per the filing friction. ORB-10877 worked around the practical blast radius for shipped pipeline assets by reverting them to literal `crew: system`, but the dispatch bug and missing validation guard remain.
## Constraints / Notes
- Friction: F2026-08-082.
- Verified 2026-08-16: both the shadowing bug and the AgentLoop-only early-return are still present in the current tree.

### Acceptance Criteria

- A step marked `system_crew: true` results in the agent actually receiving the injected `crew` key in its dispatched input, for both `AgentLoop` and non-`AgentLoop`/deterministic targets (or `validate_step` rejects `system_crew: true` on a target type where it cannot apply, with a clear error, if supporting it for all target types is not the right fix).
- A regression test exercises dispatch of a `system_crew: true` step and asserts the dispatched input actually contains the injected crew value.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `run_target` now rebinds `rendered_input` through `inject_system_crew_input` before `crew_overridden_spec` and `dispatch_v2_activity`, matching the recovery path. A step marked `system_crew: true` therefore dispatches with `crew` and `crew_config_key` on both AgentLoop and deterministic targets.
- `crew_overridden_spec` remains AgentLoop-only for provider/model override; that is spec-type-specific and not the silent-discard bug.
- `validate_step` is unchanged: supporting injection for all target types is the chosen fix, not rejecting the marker on deterministic steps.
- Regression tests in `job_executor/tests/target.rs` dispatch a `system_crew: true` AgentLoop (CLI stdin envelope) and a deterministic action and assert the dispatched input contains the injected crew.
Assessment: Small, localized fix at the dispatch seam that recovery already got right. Tests observe the actual dispatched payload rather than only `crew_overridden_spec` settings, which is what hid the shadowing bug.
Strategic decisions:
- Support all target types instead of adding a validate_step rejection. `inject_system_crew_input` is input-level; the AgentLoop-only early return is only about spec override.
- Appended `file:crates/orbit-engine/src/activity_job/job_executor/tests/target.rs` because the acceptance criterion requires a dispatch-level regression test.
Design weaknesses / risks:
- Severity: low. Hosts without `system_crew_for_dispatch` still fail closed when the marker is set (existing contract).
Validation:
- `cargo test -p orbit-engine --lib activity_job::job_executor::tests::target`: 8 passed
- `make ci-fast`: passed
Friction checkpoint: no new friction. F2026-08-082 already records this dispatch gap.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10902-6a8253e3`
- Behind base: 0
- Ahead of base: 1