### PR TITLE
Document root cause of 10-21x token-total disagreement between worker run store and orbit invocations

### DIFF
--- a/crates/orbit-agent/src/types/response/usage.rs
+++ b/crates/orbit-agent/src/types/response/usage.rs
@@ -50,6 +50,13 @@ fn collect_usage(
                 .and_then(Value::as_object)
                 .and_then(|tokens| usage_from_map(tokens, UsageKeyMode::TokenBlock))
                 .is_some();
+            // Claude CLI result docs put the same billed session totals on
+            // `usage` and again on `modelUsage`. Summing both doubled
+            // cache_read (ORB-10906 / F2026-08-031). Prefer the `usage`
+            // rollup so the cache-creation TTL split is kept; skip the
+            // sibling map. Sidecar-only tokens stay in `modelUsage` and
+            // are still collected when no sibling rollup is present.
+            let skip_model_usage = sibling_usage_rollup_present(map);
 
             for &key in USAGE_CHILD_KEYS {
                 if let Some(mode) = usage_key_mode(key)
@@ -63,6 +70,7 @@ fn collect_usage(
                 if key != "tool_calls"
                     && usage_key_mode(key).is_none()
                     && !(has_model_token_usage && key == "roles")
+                    && !(skip_model_usage && key == "modelUsage")
                 {
                     let allow_child = allow_direct_usage
                         || matches!(
@@ -101,6 +109,18 @@ fn add_usage(usage: &mut TokenUsage, found: TokenUsage) {
     usage.cache_create = usage.cache_create.saturating_add(found.cache_create);
     usage.cache_create_1h = usage.cache_create_1h.saturating_add(found.cache_create_1h);
     usage.output = usage.output.saturating_add(found.output);
+}
+
+fn sibling_usage_rollup_present(map: &JsonMap) -> bool {
+    USAGE_CHILD_KEYS.iter().any(|&key| {
+        let Some(mode) = usage_key_mode(key) else {
+            return false;
+        };
+        map.get(key)
+            .and_then(Value::as_object)
+            .and_then(|child| usage_from_map(child, mode))
+            .is_some()
+    })
 }
 
 fn usage_key_mode(key: &str) -> Option<UsageKeyMode> {

--- a/crates/orbit-agent/src/types/tests/response.rs
+++ b/crates/orbit-agent/src/types/tests/response.rs
@@ -403,6 +403,87 @@ mod sum {
     }
 
     #[test]
+    fn claude_model_usage_is_not_added_on_top_of_sibling_usage() {
+        // Live shape from jrun-20260720-0150-3 (Claude `--output-format json`).
+        // `usage` and `modelUsage` describe the same billed session; summing
+        // both used to persist 2x cache_read (ORB-10906). The usage rollup
+        // also carries the cache-creation TTL split that modelUsage lacks.
+        let documents = vec![json!({
+            "type": "result",
+            "num_turns": 107,
+            "usage": {
+                "input_tokens": 212,
+                "output_tokens": 46_418,
+                "cache_read_input_tokens": 11_470_771,
+                "cache_creation_input_tokens": 148_874,
+                "cache_creation": {
+                    "ephemeral_5m_input_tokens": 51,
+                    "ephemeral_1h_input_tokens": 148_823,
+                }
+            },
+            "modelUsage": {
+                "claude-haiku-4-5-20251001": {
+                    "inputTokens": 3856,
+                    "outputTokens": 17,
+                    "cacheReadInputTokens": 0,
+                    "cacheCreationInputTokens": 0,
+                    "costUSD": 0.003941,
+                },
+                "claude-sonnet-5": {
+                    "inputTokens": 212,
+                    "outputTokens": 46_418,
+                    "cacheReadInputTokens": 11_470_771,
+                    "cacheCreationInputTokens": 148_874,
+                    "costUSD": 5.031381,
+                }
+            }
+        })];
+
+        assert_eq!(
+            sum_usage(&documents),
+            TokenUsage {
+                input: 212,
+                cache_read: 11_470_771,
+                cache_create: 51,
+                cache_create_1h: 148_823,
+                output: 46_418,
+            }
+        );
+    }
+
+    #[test]
+    fn claude_model_usage_is_collected_when_usage_rollup_is_absent() {
+        let documents = vec![json!({
+            "type": "result",
+            "modelUsage": {
+                "claude-haiku-4-5-20251001": {
+                    "inputTokens": 100,
+                    "outputTokens": 10,
+                    "cacheReadInputTokens": 20,
+                    "cacheCreationInputTokens": 5,
+                },
+                "claude-sonnet-5": {
+                    "inputTokens": 200,
+                    "outputTokens": 30,
+                    "cacheReadInputTokens": 400,
+                    "cacheCreationInputTokens": 15,
+                }
+            }
+        })];
+
+        assert_eq!(
+            sum_usage(&documents),
+            TokenUsage {
+                input: 300,
+                cache_read: 420,
+                cache_create: 20,
+                cache_create_1h: 0,
+                output: 40,
+            }
+        );
+    }
+
+    #[test]
     fn cache_creation_without_a_ttl_split_remains_five_minute_usage() {
         let documents = vec![json!({
             "usage": {

--- a/crates/orbit-store/src/repository/token_scoreboard.rs
+++ b/crates/orbit-store/src/repository/token_scoreboard.rs
@@ -9,6 +9,11 @@ use crate::contracts::InvocationStoreBackend;
 
 use orbit_common::fs::io::{atomic_write_text_volatile as write_atomic, with_exclusive_file_lock};
 
+/// Writes `tokens.json` from the invocation store.
+///
+/// The `known_limitations` payload documents how these totals relate to the
+/// external supervisor worker run store (F2026-08-031 / ORB-10906): they are
+/// not interchangeable denominators.
 pub fn write_token_scoreboard(
     scoreboard_dir: &Path,
     store: &dyn InvocationStoreBackend,
@@ -26,7 +31,10 @@ pub fn write_token_scoreboard(
                 "cache_read_tokens are reported separately from input_tokens.",
                 "Multi-task invocations are fully attributed to every tagged task.",
                 "Legacy agent invocations without a resolved model are omitted from the activities and agents sections.",
-                "Providers without structured usage metadata may emit zero traces."
+                "Providers without structured usage metadata may emit zero traces.",
+                "Claude CLI result documents repeat the same billed session totals on `usage` and `modelUsage`. Ingest now keeps the `usage` rollup (including the cache-creation TTL split) and does not add sibling `modelUsage`. Already-persisted invocation rows are not rewritten, so historical Claude cache_read is typically ~2x the CLI result.",
+                "The supervisor worker run store (~/.local/share/supervisor/runs/*.json) and this scoreboard's `invocations` table are not one ledger: no shared run id, different populations (all supervisor CLIs vs pipeline activities), and worker top-level `usage` is often absent. The F2026-08-031 10-21x per-run comparison mixed those sets and treated missing worker fields as 0. Do not mix the stores for cost-per-token or tokens-per-minute.",
+                "Use `invocations` / this scoreboard for pipeline activity token accounting (post-fix rows only). Use a worker run's result.usage / result.modelUsage for that CLI process's billed totals. provider_cost_usd and the worker's total_cost_usd agree and are the monthly reconciliation figure."
             ]
         });
 


### PR DESCRIPTION
## Task

[ORB-10906](https://orbit-cli.com/tasks/ORB-10906) — Document root cause of 10-21x token-total disagreement between worker run store and orbit invocations

### Description

## Problem
`cache_read` and turn-count totals for the same claude runs disagree by ~10-21x between the external worker run store (`~/.local/share/supervisor/runs/*.json`) and orbit's own `invocations` table, for the same actor/window (evidence: claude/sonnet 996,207 vs 10,397,627; claude/opus 856,630 vs 18,245,363; window 2026-07-02 to 08-01). Relative comparisons within each store are self-consistent; only absolute scale disagrees. No documented source of truth exists for which store to trust.
## Why It Matters
Any cost-per-token or tokens-per-minute model built on either store alone is currently unusable — the answer changes by an order of magnitude depending which store is read, and the failure is invisible in normal use (each store returns plausible numbers on its own).
## Constraints / Notes
- Friction: F2026-08-031.
- Root cause is not yet established — what each field actually counts (per-turn snapshot vs cumulative-across-run, sub-agent/sidecar folding, retry double-counting) needs investigation before a code fix can be scoped. This task's acceptance bar is investigation + documentation, not a guaranteed reconciliation fix.
- A related known gap (`invocations.tool_call_count` is 0 for all claude rows) is explicitly out of scope per the friction body — do not fold it in here.

### Acceptance Criteria

- The token-accounting design doc or token_scoreboard.rs's known_limitations list documents this discrepancy (what's measured, why it's not yet reconciled, which store's use is currently recommended for which purpose) so future readers of either store don't draw contradictory conclusions silently.
- If the investigation identifies a concrete, scoped root cause fixable in this repo (e.g. a double-counting bug in orbit's own invocation recording), it is fixed and covered by a test; otherwise the documentation from the first criterion stands as the deliverable.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Investigated F2026-08-031 against live `~/.orbit/orbit.db` and `~/.local/share/supervisor/runs/*.json` for window 2026-07-02..08-01. The cited per-run figures reproduce exactly: implement_one AVG(cache_read_tokens) is 10,397,626 (claude/sonnet n=20) and 18,245,363 (claude/opus n=47); worker-store `usage.cache_read` / run-count is 996,207 (71,726,895 / 72) and 856,630 (71,100,275 / 83).
- Root-cause split (not a single 10-21x ingest multiplier):
  1. Concrete in-repo ingest bug: Claude `--output-format json` repeats the same billed session totals on `usage` and `modelUsage`. `sum_usage` walked both, so persisted `cache_read` is usage+modelUsage. Checked five implement_one stdout blobs (e.g. jrun-20260720-0150-3: CLI 11,470,771 vs stored 22,941,542 = 2.000). Historical rows are not rewritten.
  2. The remaining gap is incommensurable queries: no join key (worker uuid vs `jrun-*`), worker population is all supervisor CLIs while orbit numbers are implement_one-only, and the worker average treated missing top-level `usage` as 0 (sonnet 47/72 and opus 17/83 had that field).
- Fixed ingest: skip sibling `modelUsage` when a parseable `usage` rollup is present (keeps the cache-creation TTL split). `modelUsage` is still summed when no rollup exists. Covered by two `orbit-agent` tests (live 2x shape + modelUsage-only).
- Documented what's measured, why it is not fully reconciled, and which store to use for which purpose on `token_scoreboard.rs` `known_limitations` (and a rustdoc pointer). `invocations.tool_call_count == 0` for Claude left untouched.
- context_files expanded for the ingest fix and its sibling test: `file:crates/orbit-agent/src/types/response/usage.rs`, `file:crates/orbit-agent/src/types/tests/response.rs`.
Assessment: Acceptance met. The 2x bug is fixed going forward; the published 10-21x comparison is mostly population/missing-field, so documentation is the remaining deliverable. Cost fields were already consistent and stay the reconciliation figure.
Strategic decisions: Prefer the `usage` rollup over `modelUsage` so 5m/1h cache-create split is not dropped. Sidecar-only tokens remain available when `usage` is absent.
Design weaknesses / risks:
- Severity: medium — already-persisted Claude rows stay ~2x; scoreboard totals will not snap to CLI billed amounts until those rows age out. Mitigation: known_limitations says post-fix rows only.
- Severity: low — haiku sidecar tokens that appear only in `modelUsage` are omitted when `usage` is present (typically thousands of input tokens, cache_read 0). Mitigation: documented; smaller than the 2x overcount.
Recommended follow-ups: optional backfill/recompute of historical invocation token columns from retained `pipeline_state_json` stdout; do not build rates on mixed stores.
Validation: `cargo test -p orbit-agent --lib types::tests::response` 39 passed (incl. 2 new); `cargo clippy -p orbit-agent -p orbit-store --all-targets -- -D warnings` clean; `make ci-fast` passed.
Friction checkpoint: none filed (F2026-08-031 already records this discrepancy; this task is the coverage).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10906-6a8253e4`
- Behind base: 0
- Ahead of base: 1