### PR TITLE
check-error-translation.sh has no rg-availability guard, unlike its sibling guardrail scripts

### DIFF
--- a/scripts/check-error-translation.sh
+++ b/scripts/check-error-translation.sh
@@ -32,6 +32,11 @@ set -euo pipefail
 repo_root="${1:-${ORBIT_REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}}"
 crates_dir="$repo_root/crates"
 
+if ! command -v rg >/dev/null 2>&1; then
+  echo "check-error-translation: ripgrep (rg) is required; install it before running" >&2
+  exit 1
+fi
+
 fail=0
 
 # --- Registry: boundary error type -> owning crate -> translator name. ---


### PR DESCRIPTION
## Task

[ORB-10907](https://orbit-cli.com/tasks/ORB-10907) — check-error-translation.sh has no rg-availability guard, unlike its sibling guardrail scripts

### Description

## Problem
`scripts/check-error-translation.sh` has no `command -v rg` guard. When `rg` is absent from PATH, it silently emits fabricated architectural-violation text (e.g. "crate X defines boundary error Y but exports no translator") interleaved with a bare `rg: command not found`, and exits 0 — indistinguishable from a real violation until a human notices the tool-missing line. Sibling guardrail scripts run by the same `make ci-fast` gate (`check-orphan-modules.sh`, `check-terminal-state-guard.sh`) already have this guard.
## Why It Matters
`make ci-fast` is the mandated pre-review gate (CLAUDE.md). A misleading false-positive "architectural violation" costs real diagnosis time and erodes trust in the gate.
## Constraints / Notes
- Friction: F2026-08-040 (point 1 of a 3-point friction; points 2 and 3 are handled separately — see the friction's curation notes).
- Verified 2026-08-16 by stripping `rg` from PATH and re-running the script directly.
- `scripts/check-orphan-modules.sh` and `scripts/check-terminal-state-guard.sh` already have the guard pattern to copy: a `command -v rg >/dev/null 2>&1` check near the top that prints a clear "ripgrep (rg) is required" message to stderr and exits 1 before any substantive check output.

### Acceptance Criteria

- scripts/check-error-translation.sh fails fast with a clear "rg not found" message (matching the pattern already used by check-orphan-modules.sh/check-terminal-state-guard.sh) when rg is absent from PATH, instead of emitting fabricated violation text.
- Running the script with rg stripped from PATH demonstrates the new guard fires before any substantive check output is produced.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a fail-fast `command -v rg` guard to `scripts/check-error-translation.sh` immediately after repo-root resolution and before the registry/scan loops, matching `check-orphan-modules.sh` and `check-terminal-state-guard.sh`.
- When `rg` is absent, the script now prints `check-error-translation: ripgrep (rg) is required; install it before running` to stderr and exits 1, instead of emitting fabricated `error-translation:` violation text and exiting 0.
Assessment: Small, scoped copy of an existing sibling pattern. No new files, no dependency edges, no behavior change when `rg` is present.
Validation:
- Re-read `orbit.task.show` before edit and before validation: status remained `in-progress` (writable).
- `PATH=/usr/bin:/bin bash scripts/check-error-translation.sh` (rg confirmed absent): exit 1, empty stdout, stderr is only the required message; no `error-translation:` violation lines.
- Normal PATH: exit 0, `error translation guard passed`.
Friction checkpoint: none filed. The existing F2026-08-040 relation already covers this missing-rg false-positive; this run did not hit a new contradicted assumption, recurring failure, or >10-minute gotcha.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10907-6a8255c6`
- Behind base: 0
- Ahead of base: 1