### PR TITLE
Document the /tmp scratch-root pattern for orbit init/workspace init in the executor sandbox

### DIFF
--- a/crates/orbit-core/assets/auto_tasks/qa-sweep.yaml
+++ b/crates/orbit-core/assets/auto_tasks/qa-sweep.yaml
@@ -12,6 +12,19 @@ template:
     feature paths as a user would; do not treat re-running the existing test
     suite as sufficient validation.
 
+    When those paths include `orbit init` or `orbit workspace init` and you
+    are inside the Cowork/agent-executor sandbox, `/` and `~/.orbit` are
+    mounted read-only. Do not init against the real home Orbit root — that
+    fails with EROFS. Put the Orbit root and any scratch git checkouts
+    under `/tmp` and use:
+
+        orbit --root /tmp/<scratch> init --non-interactive --host-name <name> --task-prefix <XXXX>
+        orbit --root /tmp/<scratch> workspace init
+
+    Root `init` hangs on stdin without `--non-interactive`. `workspace init`
+    does not need that flag and does not prompt non-interactively in
+    practice.
+
     Before filing anything, search open Orbit tasks tagged `qa-sweep`. For each
     real issue that is not already filed, create an Orbit task yourself through
     the Orbit MCP tools or the equivalent `orbit tool run orbit.task.add`


### PR DESCRIPTION
## Task

[ORB-10910](https://orbit-cli.com/tasks/ORB-10910) — Document the /tmp scratch-root pattern for orbit init/workspace init in the executor sandbox

### Description

## Problem
In the Cowork/agent-executor sandbox, `/` and `~/.orbit` are mounted read-only, so `orbit init`/`workspace init` against the real `~/.orbit` fail with EROFS. The working pattern -- `--root /tmp/<scratch>/root` with the git checkout(s) under `/tmp` too, plus `orbit init --non-interactive --host-name <name> --task-prefix <XXXX>` (root `init` hangs on stdin without `--non-interactive`; `workspace init` doesn't need the flag and doesn't prompt non-interactively in practice) -- is not documented anywhere a QA-sweep agent would find it before hitting the failure.

This is intentional, already-correct CLI behavior (verified: `orbit init --help` documents `--non-interactive`/`--host-name`/`--task-prefix`/`--root` exactly as needed) -- the only gap is discoverability.

The closest existing home for this guidance is the QA-sweep auto-task's own template: `crates/orbit-core/assets/auto_tasks/qa-sweep.yaml`. Its `template.description` already instructs the dispatched agent to "Build and run the changed software, then exercise the affected CLI, API, and feature paths as a user would" -- a QA-sweep agent exercising changes to `orbit init`/`workspace init` inside this sandbox is exactly the agent that needs the `/tmp` scratch-root pattern spelled out before it burns time rediscovering the workaround. (A search of this repo's `CLAUDE.md` and `crates/orbit-core/assets/skills/` turned up no other section that owns sandbox-hands-on testing guidance; `crates/orbit-core/assets/skills/orbit/references/setup/first-run.md` documents `orbit init --non-interactive --host-name --task-prefix` for normal onboarding but says nothing about the read-only-sandbox `--root /tmp/<scratch>` case.)

## Why It Matters
Multiple agents (per this friction and ORB-10759's execution_summary) have independently rediscovered the same workaround ad hoc, costing real time each time.

## Constraints / Notes
- Friction: F2026-08-079 (point 2 only -- point 1, the read-only-mount observation itself, is tracked as a duplicate of the canonical F2026-08-045).
- This is a documentation-only task; no code changes are implied or wanted.
- Whoever picks this up should confirm whether `crates/orbit-core/assets/auto_tasks/qa-sweep.yaml`'s template description is the right place versus `crates/orbit-core/assets/skills/orbit/references/setup/first-run.md` (or another skill reference) -- either is acceptable as long as a QA-sweep agent actually encounters it before attempting `orbit init`/`workspace init` in this sandbox.

### Acceptance Criteria

- The QA-sweep task template or CLAUDE.md (whichever governs sandbox-hands-on testing guidance) documents the `--root /tmp/<scratch> --non-interactive --host-name <name> --task-prefix <XXXX>` pattern for exercising a real orbit init/workspace init from inside the read-only executor sandbox.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Documented the executor-sandbox scratch-root pattern in `crates/orbit-core/assets/auto_tasks/qa-sweep.yaml` `template.description`, immediately after the existing hands-on CLI exercise instruction.
- The minted QA-sweep task now tells the agent that `/` and `~/.orbit` are read-only, that real-home `orbit init`/`workspace init` fail with EROFS, and to use `--root /tmp/<scratch>` with `init --non-interactive --host-name <name> --task-prefix <XXXX>` plus `workspace init` (no `--non-interactive` needed). Scratch git checkouts stay under `/tmp` too.
Assessment: Docs-only, scoped to the file a QA-sweep agent actually reads first. YAML still parses; existing required phrases in `qa_sweep_default_preserves_hands_on_validation_contract` are unchanged. `orbit init --help` still documents `--root`, `--non-interactive`, `--host-name`, and `--task-prefix`. `make ci-fast` passed.
Strategic decisions:
- Home is the QA-sweep auto-task template, not `first-run.md` or `CLAUDE.md`. QA-sweep agents read the minted task description before any skill/reference; first-run is normal onboarding and easy to skip; CLAUDE.md is this repo's agent guide, not the sandbox-hands-on owner for every workspace a QA sweep can run in.
Deviations from original plan: none.
Recommended follow-ups: none. Existing workspaces keep their previously seeded copy until `orbit init --refresh-defaults` (unmodified Orbit-written assets) or a manual merge.
Friction checkpoint: no new friction. This task documents F2026-08-079 point 2; nothing here contradicted that assumption.
Validation:
- `python3` YAML parse of the updated asset: ok
- `orbit init --help`: flags match
- `make ci-fast`: passed

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10910-6a8255b9`
- Behind base: 0
- Ahead of base: 1

*authored by: grok*