### PR TITLE
No attributable diagnostic when the executor sandbox's read-only Orbit-state mount causes an EROFS write failure

### DIFF
--- a/crates/orbit-common/src/error.rs
+++ b/crates/orbit-common/src/error.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -315,6 +317,23 @@ impl OrbitError {
             _ => None,
         }
     }
+
+    /// Translate a filesystem write failure.
+    ///
+    /// EROFS/EACCES name `path` and hint that this is likely a sandbox or
+    /// environment mount, not a store defect — the outer-sandbox counterpart
+    /// to `linux_bwrap_write_grant_diagnostic`. Other I/O stays a bare
+    /// [`Self::Io`] so read and capacity failures keep their existing text.
+    pub fn from_write_io(path: &Path, err: std::io::Error) -> Self {
+        if crate::fs::io::is_readonly_or_access_error(&err) {
+            Self::Io(format!(
+                "`{}` is not writable: {err}; this is likely a sandbox or environment condition, not an Orbit store defect",
+                path.display()
+            ))
+        } else {
+            Self::Io(err.to_string())
+        }
+    }
 }
 
 impl From<std::io::Error> for OrbitError {
@@ -388,3 +407,7 @@ impl From<RecordError> for OrbitError {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "tests/error.rs"]
+mod tests;

--- a/crates/orbit-common/src/fs/io.rs
+++ b/crates/orbit-common/src/fs/io.rs
@@ -373,3 +373,27 @@ fn set_private_file_permissions(path: &Path) -> io::Result<()> {
 fn set_private_file_permissions(_path: &Path) -> io::Result<()> {
     Ok(())
 }
+
+/// True when `error` is a read-only filesystem or access denial.
+///
+/// Matches both [`io::ErrorKind`] and the raw Unix errno so callers do not
+/// have to re-derive EROFS/EACCES classification. Used to distinguish a
+/// sandbox or environment mount from a store defect.
+pub fn is_readonly_or_access_error(error: &io::Error) -> bool {
+    match error.kind() {
+        io::ErrorKind::PermissionDenied | io::ErrorKind::ReadOnlyFilesystem => true,
+        _ => error
+            .raw_os_error()
+            .is_some_and(is_readonly_or_access_errno),
+    }
+}
+
+#[cfg(unix)]
+fn is_readonly_or_access_errno(code: i32) -> bool {
+    code == libc::EROFS || code == libc::EACCES
+}
+
+#[cfg(not(unix))]
+fn is_readonly_or_access_errno(_code: i32) -> bool {
+    false
+}

--- a/crates/orbit-common/src/tests/error.rs
+++ b/crates/orbit-common/src/tests/error.rs
@@ -1,0 +1,85 @@
+use std::io;
+use std::path::Path;
+
+use super::OrbitError;
+
+fn assert_sandbox_write_message(message: &str, path: &str) {
+    assert!(
+        message.contains(path),
+        "expected path `{path}` in `{message}`"
+    );
+    assert!(
+        message.contains("is not writable"),
+        "expected writable attribution in `{message}`"
+    );
+    assert!(
+        message.contains("sandbox or environment"),
+        "expected sandbox/environment hint in `{message}`"
+    );
+    assert!(
+        message.contains("not an Orbit store defect"),
+        "expected store-defect negation in `{message}`"
+    );
+}
+
+#[test]
+fn from_write_io_names_path_for_readonly_filesystem_kind() {
+    let path = Path::new("/tmp/.orbit/tasks/ORB-00000/plan.md");
+    let error = OrbitError::from_write_io(
+        path,
+        io::Error::new(io::ErrorKind::ReadOnlyFilesystem, "Read-only file system"),
+    );
+    match error {
+        OrbitError::Io(message) => {
+            assert_sandbox_write_message(&message, &path.display().to_string());
+            assert!(message.contains("Read-only file system"), "{message}");
+        }
+        other => panic!("expected Io, got {other}"),
+    }
+}
+
+#[test]
+fn from_write_io_names_path_for_permission_denied() {
+    let path = Path::new("/readonly/.orbit/frictions/tags.yaml");
+    let error = OrbitError::from_write_io(
+        path,
+        io::Error::new(io::ErrorKind::PermissionDenied, "permission denied"),
+    );
+    match error {
+        OrbitError::Io(message) => {
+            assert_sandbox_write_message(&message, &path.display().to_string())
+        }
+        other => panic!("expected Io, got {other}"),
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn from_write_io_classifies_raw_erofs_and_eacces() {
+    let path = Path::new("/mnt/ro/.orbit/state/tasks/ORB-00000/envelope.yaml");
+    for errno in [libc::EROFS, libc::EACCES] {
+        let error = OrbitError::from_write_io(path, io::Error::from_raw_os_error(errno));
+        match error {
+            OrbitError::Io(message) => {
+                assert_sandbox_write_message(&message, &path.display().to_string())
+            }
+            other => panic!("expected Io for errno {errno}, got {other}"),
+        }
+    }
+}
+
+#[test]
+fn from_write_io_leaves_other_io_failures_bare() {
+    let path = Path::new("/tmp/.orbit/tasks/ORB-00000/plan.md");
+    let error = OrbitError::from_write_io(
+        path,
+        io::Error::new(io::ErrorKind::StorageFull, "no space left"),
+    );
+    match error {
+        OrbitError::Io(message) => {
+            assert_eq!(message, "no space left");
+            assert!(!message.contains("sandbox or environment"), "{message}");
+        }
+        other => panic!("expected Io, got {other}"),
+    }
+}

--- a/crates/orbit-core/src/application/mod.rs
+++ b/crates/orbit-core/src/application/mod.rs
@@ -17,7 +17,9 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use orbit_common::OrbitError;
-use orbit_common::fs::io::{atomic_write_text, write_text_with_parent};
+use orbit_common::fs::io::{
+    atomic_write_text, is_readonly_or_access_error, write_text_with_parent,
+};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -282,22 +284,7 @@ fn encode_managed_asset_manifest(manifest: &ManagedAssetManifest) -> Result<Stri
 /// deployment shape (immutable global root, sandboxed runner), not a
 /// reason to refuse a later read-only command.
 pub(crate) fn managed_manifest_write_is_skippable(error: &io::Error) -> bool {
-    match error.kind() {
-        io::ErrorKind::PermissionDenied | io::ErrorKind::ReadOnlyFilesystem => true,
-        _ => error
-            .raw_os_error()
-            .is_some_and(is_readonly_or_access_errno),
-    }
-}
-
-#[cfg(unix)]
-fn is_readonly_or_access_errno(code: i32) -> bool {
-    code == libc::EROFS || code == libc::EACCES
-}
-
-#[cfg(not(unix))]
-fn is_readonly_or_access_errno(_code: i32) -> bool {
-    false
+    is_readonly_or_access_error(error)
 }
 
 fn managed_asset_manifest_io_error(

--- a/crates/orbit-store/src/driver/file/friction_store/mod.rs
+++ b/crates/orbit-store/src/driver/file/friction_store/mod.rs
@@ -247,7 +247,7 @@ pub fn ensure_default_tag_taxonomy(frictions_root: &Path) -> Result<PathBuf, Orb
         for (tag, description) in DEFAULT_FRICTION_TAGS {
             body.push_str(&format!("{tag}: \"{description}\"\n"));
         }
-        atomic_write_text(&path, &body).map_err(|error| OrbitError::Io(error.to_string()))?;
+        atomic_write_text(&path, &body).map_err(|error| OrbitError::from_write_io(&path, error))?;
     }
     Ok(path)
 }
@@ -315,7 +315,7 @@ pub(crate) fn write_record_at(path: &Path, record: &FrictionRecord) -> Result<()
         OrbitError::Store(format!("serialize friction frontmatter: {error}"))
     })?;
     let content = format!("---\n{}---\n{}\n", yaml, record.body.trim_end());
-    atomic_write_text(path, &content).map_err(|error| OrbitError::Io(error.to_string()))?;
+    atomic_write_text(path, &content).map_err(|error| OrbitError::from_write_io(path, error))?;
     Ok(())
 }
 

--- a/crates/orbit-store/src/driver/file/task_bundle/bundle_io/mod.rs
+++ b/crates/orbit-store/src/driver/file/task_bundle/bundle_io/mod.rs
@@ -82,7 +82,7 @@ where
         }
         read_bundle_for_id(&staging_dir, &bundle.envelope.id)?;
         sync_staged_bundle_dirs(&staging_dir)?;
-        publish(&staging_dir, bundle_dir).map_err(OrbitError::from)
+        publish(&staging_dir, bundle_dir).map_err(|err| OrbitError::from_write_io(bundle_dir, err))
     })();
 
     if let Err(error) = &result {
@@ -98,23 +98,18 @@ fn write_bundle_contents(bundle_dir: &Path, bundle: &TaskBundleV2) -> Result<(),
         &bundle.envelope,
         |err| OrbitError::Store(err.to_string()),
     )?;
-    atomic_write_text(
-        &bundle_dir.join(TASK_DESCRIPTION_FILE_NAME),
-        &bundle.description,
-    )
-    .map_err(|err| OrbitError::Io(err.to_string()))?;
-    atomic_write_text(
-        &bundle_dir.join(TASK_ACCEPTANCE_FILE_NAME),
-        &bundle.acceptance,
-    )
-    .map_err(|err| OrbitError::Io(err.to_string()))?;
-    atomic_write_text(&bundle_dir.join(TASK_PLAN_FILE_NAME), &bundle.plan)
-        .map_err(|err| OrbitError::Io(err.to_string()))?;
-    atomic_write_text(
-        &bundle_dir.join(TASK_EXECUTION_SUMMARY_FILE_NAME),
-        &bundle.execution_summary,
-    )
-    .map_err(|err| OrbitError::Io(err.to_string()))?;
+    let description_path = bundle_dir.join(TASK_DESCRIPTION_FILE_NAME);
+    atomic_write_text(&description_path, &bundle.description)
+        .map_err(|err| OrbitError::from_write_io(&description_path, err))?;
+    let acceptance_path = bundle_dir.join(TASK_ACCEPTANCE_FILE_NAME);
+    atomic_write_text(&acceptance_path, &bundle.acceptance)
+        .map_err(|err| OrbitError::from_write_io(&acceptance_path, err))?;
+    let plan_path = bundle_dir.join(TASK_PLAN_FILE_NAME);
+    atomic_write_text(&plan_path, &bundle.plan)
+        .map_err(|err| OrbitError::from_write_io(&plan_path, err))?;
+    let execution_summary_path = bundle_dir.join(TASK_EXECUTION_SUMMARY_FILE_NAME);
+    atomic_write_text(&execution_summary_path, &bundle.execution_summary)
+        .map_err(|err| OrbitError::from_write_io(&execution_summary_path, err))?;
 
     write_jsonl_file(&bundle_dir.join(TASK_EVENTS_FILE_NAME), &bundle.events)?;
     write_jsonl_file(&bundle_dir.join(TASK_COMMENTS_FILE_NAME), &bundle.comments)?;
@@ -138,7 +133,7 @@ fn create_staging_dir(bundle_dir: &Path) -> Result<PathBuf, OrbitError> {
             bundle_dir.display()
         ))
     })?;
-    fs::create_dir_all(parent).map_err(OrbitError::from)?;
+    fs::create_dir_all(parent).map_err(|error| OrbitError::from_write_io(parent, error))?;
     let bundle_name = bundle_dir
         .file_name()
         .and_then(|name| name.to_str())
@@ -156,7 +151,7 @@ fn create_staging_dir(bundle_dir: &Path) -> Result<PathBuf, OrbitError> {
         match fs::create_dir(&candidate) {
             Ok(()) => return Ok(candidate),
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-            Err(error) => return Err(OrbitError::from(error)),
+            Err(error) => return Err(OrbitError::from_write_io(&candidate, error)),
         }
     }
     Err(OrbitError::Store(format!(
@@ -168,9 +163,10 @@ fn create_staging_dir(bundle_dir: &Path) -> Result<PathBuf, OrbitError> {
 fn sync_staged_bundle_dirs(staging_dir: &Path) -> Result<(), OrbitError> {
     let artifact_dir = staging_dir.join(TASK_ARTIFACTS_DIR_NAME);
     let artifact_files_dir = artifact_dir.join(TASK_ARTIFACT_FILES_DIR_NAME);
-    sync_parent_dir(&artifact_files_dir).map_err(OrbitError::from)?;
-    sync_parent_dir(&artifact_dir).map_err(OrbitError::from)?;
-    sync_parent_dir(staging_dir).map_err(OrbitError::from)
+    sync_parent_dir(&artifact_files_dir)
+        .map_err(|err| OrbitError::from_write_io(&artifact_files_dir, err))?;
+    sync_parent_dir(&artifact_dir).map_err(|err| OrbitError::from_write_io(&artifact_dir, err))?;
+    sync_parent_dir(staging_dir).map_err(|err| OrbitError::from_write_io(staging_dir, err))
 }
 
 fn publish_staged_bundle(staging_dir: &Path, bundle_dir: &Path) -> std::io::Result<()> {
@@ -259,13 +255,12 @@ fn validate_bundle_consistency(bundle: &TaskBundleV2) -> Result<(), OrbitError> 
 }
 
 fn ensure_bundle_dirs(bundle_dir: &Path) -> Result<(), OrbitError> {
-    fs::create_dir_all(bundle_dir).map_err(|err| OrbitError::Io(err.to_string()))?;
-    fs::create_dir_all(
-        bundle_dir
-            .join(TASK_ARTIFACTS_DIR_NAME)
-            .join(TASK_ARTIFACT_FILES_DIR_NAME),
-    )
-    .map_err(|err| OrbitError::Io(err.to_string()))?;
+    fs::create_dir_all(bundle_dir).map_err(|err| OrbitError::from_write_io(bundle_dir, err))?;
+    let artifact_files_dir = bundle_dir
+        .join(TASK_ARTIFACTS_DIR_NAME)
+        .join(TASK_ARTIFACT_FILES_DIR_NAME);
+    fs::create_dir_all(&artifact_files_dir)
+        .map_err(|err| OrbitError::from_write_io(&artifact_files_dir, err))?;
     Ok(())
 }
 
@@ -331,7 +326,7 @@ where
         );
         content.push('\n');
     }
-    atomic_write_text(path, &content).map_err(|err| OrbitError::Io(err.to_string()))
+    atomic_write_text(path, &content).map_err(|err| OrbitError::from_write_io(path, err))
 }
 
 fn read_task_events(path: &Path) -> Result<Vec<TaskEventRowV2>, OrbitError> {
@@ -369,12 +364,15 @@ where
             .create(true)
             .append(true)
             .open(path)
-            .map_err(OrbitError::from)?;
+            .map_err(|err| OrbitError::from_write_io(path, err))?;
         file.write_all(encoded.as_bytes())
-            .map_err(OrbitError::from)?;
-        file.write_all(b"\n").map_err(OrbitError::from)?;
-        file.flush().map_err(OrbitError::from)?;
-        file.sync_all().map_err(OrbitError::from)?;
+            .map_err(|err| OrbitError::from_write_io(path, err))?;
+        file.write_all(b"\n")
+            .map_err(|err| OrbitError::from_write_io(path, err))?;
+        file.flush()
+            .map_err(|err| OrbitError::from_write_io(path, err))?;
+        file.sync_all()
+            .map_err(|err| OrbitError::from_write_io(path, err))?;
         Ok(())
     })
 }
@@ -388,9 +386,12 @@ fn repair_jsonl_tail(path: &Path) -> Result<(), OrbitError> {
     file.read_to_string(&mut raw).map_err(OrbitError::from)?;
     let scan = scan_jsonl_tail(path, &raw)?;
     if scan.truncate_at < raw.len() as u64 {
-        file.set_len(scan.truncate_at).map_err(OrbitError::from)?;
-        file.seek(SeekFrom::End(0)).map_err(OrbitError::from)?;
-        file.sync_all().map_err(OrbitError::from)?;
+        file.set_len(scan.truncate_at)
+            .map_err(|err| OrbitError::from_write_io(path, err))?;
+        file.seek(SeekFrom::End(0))
+            .map_err(|err| OrbitError::from_write_io(path, err))?;
+        file.sync_all()
+            .map_err(|err| OrbitError::from_write_io(path, err))?;
     }
     Ok(())
 }
@@ -507,8 +508,9 @@ pub(crate) fn copy_artifact_blobs(
     }
     let source_artifact_dir = source_bundle_dir.join(TASK_ARTIFACTS_DIR_NAME);
     let dest_artifact_dir = dest_bundle_dir.join(TASK_ARTIFACTS_DIR_NAME);
-    fs::create_dir_all(dest_artifact_dir.join(TASK_ARTIFACT_FILES_DIR_NAME))
-        .map_err(|err| OrbitError::Io(err.to_string()))?;
+    let dest_files_dir = dest_artifact_dir.join(TASK_ARTIFACT_FILES_DIR_NAME);
+    fs::create_dir_all(&dest_files_dir)
+        .map_err(|err| OrbitError::from_write_io(&dest_files_dir, err))?;
     for file in &manifest.files {
         let source = source_artifact_dir.join(&file.blob);
         let bytes = fs::read(&source).map_err(|err| {
@@ -535,7 +537,7 @@ pub(crate) fn copy_artifact_blobs(
             )));
         }
         let dest = dest_artifact_dir.join(&file.blob);
-        atomic_write_bytes(&dest, &bytes).map_err(|err| OrbitError::Io(err.to_string()))?;
+        atomic_write_bytes(&dest, &bytes).map_err(|err| OrbitError::from_write_io(&dest, err))?;
     }
     Ok(())
 }

--- a/crates/orbit-store/src/driver/file/task_bundle/bundle_io/tests/mod.rs
+++ b/crates/orbit-store/src/driver/file/task_bundle/bundle_io/tests/mod.rs
@@ -94,6 +94,48 @@ fn interrupted_bundle_publish_never_exposes_partial_final_directory() {
 }
 
 #[test]
+fn erofs_bundle_publish_names_path_and_hints_sandbox() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = bundle_store(&temp);
+    let bundle = sample_bundle("ORB-00000");
+    let bundle_dir = store.bundle_path("ORB-00000").expect("bundle path");
+
+    let error = write_bundle_atomically(&bundle_dir, &bundle, None, |_staging, _final_path| {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::ReadOnlyFilesystem,
+            "Read-only file system",
+        ))
+    })
+    .expect_err("EROFS publish must fail");
+
+    match error {
+        OrbitError::Io(message) => {
+            assert!(
+                message.contains(&bundle_dir.display().to_string()),
+                "expected path in `{message}`"
+            );
+            assert!(
+                message.contains("is not writable"),
+                "expected writable attribution in `{message}`"
+            );
+            assert!(
+                message.contains("sandbox or environment"),
+                "expected sandbox/environment hint in `{message}`"
+            );
+            assert!(
+                message.contains("not an Orbit store defect"),
+                "expected store-defect negation in `{message}`"
+            );
+        }
+        other => panic!("expected Io, got {other}"),
+    }
+    assert!(
+        !bundle_dir.exists(),
+        "an EROFS writer must not expose the canonical bundle path"
+    );
+}
+
+#[test]
 fn append_jsonl_repairs_corrupt_tail_only() {
     let temp = TempDir::new().expect("tempdir");
     let store = bundle_store(&temp);

--- a/crates/orbit-store/src/fs/yaml.rs
+++ b/crates/orbit-store/src/fs/yaml.rs
@@ -33,5 +33,5 @@ where
     F: FnOnce(serde_yaml::Error) -> OrbitError,
 {
     let yaml = serialize_yaml_with(value, invalid)?;
-    write_atomic(path, &yaml).map_err(Into::into)
+    write_atomic(path, &yaml).map_err(|err| OrbitError::from_write_io(path, err))
 }

--- a/crates/orbit-store/src/repository/task/v2_bundle.rs
+++ b/crates/orbit-store/src/repository/task/v2_bundle.rs
@@ -125,7 +125,8 @@ impl TaskBundleStoreV2 {
         // otherwise left in the page cache. Without fsyncing the parent, a power
         // loss in the creation window can orphan the whole bundle even though
         // every file inside was durably written.
-        if let Err(err) = sync_parent_dir(bundle_dir).map_err(|err| OrbitError::Io(err.to_string()))
+        if let Err(err) =
+            sync_parent_dir(bundle_dir).map_err(|err| OrbitError::from_write_io(bundle_dir, err))
         {
             cleanup_partial_bundle_best_effort(bundle_dir, "bundle dir fsync", &err);
             return Err(err);
@@ -227,7 +228,7 @@ impl TaskBundleStoreV2 {
         content: &str,
     ) -> Result<(), OrbitError> {
         let path = self.bundle_path(task_id)?.join(document.file_name());
-        atomic_write_text(&path, content).map_err(|err| OrbitError::Io(err.to_string()))
+        atomic_write_text(&path, content).map_err(|err| OrbitError::from_write_io(&path, err))
     }
 
     pub(crate) fn rewrite_envelope(


### PR DESCRIPTION
## Task

[ORB-10908](https://orbit-cli.com/tasks/ORB-10908) — No attributable diagnostic when the executor sandbox's read-only Orbit-state mount causes an EROFS write failure

### Description

## Problem
When the outer agent-executor sandbox mounts an Orbit state root (worktree `.orbit`, primary checkout `.orbit`, or `~/.orbit`) read-only, `orbit tool run` writes fail with a bare `{"code":"io_error","error":"io error: Read-only file system (os error 30)"}` -- no indication that this is the outer sandbox's mount policy rather than a malformed-input or store-specific bug. The partition is uneven (e.g. primary checkout's `.orbit/tasks`/`.orbit/frictions` may stay writable while other subtrees don't), making the failure read as arbitrary.

The `io_error` code comes from `OrbitError::Io(_) => "io_error"` in `crates/orbit-mcp/src/error.rs` (`error_code`, around line 91). Raw `OrbitError::Io(...)` values that wrap an EROFS `std::io::Error` are constructed at many store-write boundaries with no shared, attributable message -- e.g. `crates/orbit-store/src/driver/file/task_bundle/bundle_io/mod.rs` (the live `orbit.task.update` bundle-write path) builds `OrbitError::Io(err.to_string())` directly from the raw `io::Error` at several call sites, so the sandbox-mount condition is indistinguishable from any other I/O failure.

Note: the spec that originated this task cited `orbit.adr.add` as a second live example, but the ADR lifecycle tools are currently retired -- `crates/orbit-core/src/adapter/tool_host/dispatch.rs` (lines ~20-27) routes every `OrbitBuiltinAction::Adr*` variant straight to `OrbitError::InvalidInput("ADR lifecycle tools have been retired; edit docs/design/**/4_decisions.md")` before any filesystem write happens. `.orbit/adrs` is therefore not a live write path today; `orbit.task.update` (and other live stores such as the friction store) are the representative examples for this class of failure. Whoever picks this up should re-survey which store-write boundaries construct `OrbitError::Io` from a raw filesystem error and decide the minimal set that needs the new diagnostic wired in.

## Why It Matters
The first EROFS hit reads as a plausible product bug and costs real diagnosis time before an agent realizes it's sandbox-imposed, not orbit-specific. Orbit already has an analogous, better diagnostic for its *own* spawned-sub-agent bwrap sandbox: `linux_bwrap_write_grant_diagnostic` in `crates/orbit-exec/src/linux_sandbox.rs` (around line 190) inspects the resolved fs-profile modify rules and returns a message naming the exact rule that denied the write, or that no rule grants it. This task asks for the equivalent at the store-write layer for the *outer* sandbox's EROFS -- a message that names the read-only path and hints that this is likely a sandbox/environment condition, not a store defect.

A useful existing building block: `crates/orbit-core/src/application/mod.rs` already classifies read-only/permission I/O errors for a different purpose (`managed_manifest_write_is_skippable` / `is_readonly_or_access_errno`, around lines 284-301) -- reuse or generalize that EROFS/EACCES classification rather than re-deriving it.

## Constraints / Notes
- Friction: F2026-08-045 (canonical record for this EROFS class; subsumes F2026-08-040 point 2 [now moot] and F2026-08-079 point 1 [duplicate]).
- The underlying mount partition itself is external Cowork/agent-executor infrastructure and is explicitly OUT of scope -- do not attempt to change what gets mounted read-only. Scope is limited to: (a) a clearer, attributable error when an Orbit store write hits EROFS, mirroring the `linux_bwrap_write_grant_diagnostic` pattern, and (b) correcting any executor-envelope prose that currently gives wrong CLI-vs-MCP write-fallback guidance for this condition, if such prose is found and is in fact wrong -- its location was not confirmed as part of filing this task and needs to be located by whoever picks it up (it did not turn up under `docs/`, `crates/orbit-core/assets/skills/`, or this repo's `CLAUDE.md`; it may live outside this repository in the Cowork/agent-executor system prompt).
- Verified 2026-08-16 with fresh `findmnt`/write-probe evidence reproducing the exact partition described in the friction.

### Acceptance Criteria

- An Orbit store write that fails with EROFS on a read-only-mounted state root now surfaces an error that names the read-only path and hints this is likely a sandbox/environment condition rather than a store defect (mirroring the existing linux_bwrap_write_grant_diagnostic pattern for Orbit's own spawned-sandbox layer).
- A test covers the new error path (e.g. simulating or mocking an EROFS write) confirming the improved message.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Lifted the EROFS/EACCES classifier from orbit-core into `orbit_common::fs::io::is_readonly_or_access_error` so store and core share one classification (ErrorKind plus raw Unix errno).
- Added `OrbitError::from_write_io(path, err)`. Classified write failures become `Io` messages that name the path and say this is likely a sandbox or environment condition, not an Orbit store defect. Other I/O stays a bare `Io(err.to_string())`. MCP still maps this to `io_error`.
- Wired `from_write_io` at live store-write seams: task-bundle create/update (`bundle_io`, `rewrite_document`, `write_yaml_atomic_with`) and friction record writes. ADR tools stay retired and were not wired.
- Did not change `From<io::Error>` globally (shared with reads).
- Tests: stubbed ReadOnlyFilesystem/PermissionDenied/raw EROFS+EACCES vs StorageFull in orbit-common; injected ReadOnlyFilesystem into `write_bundle_atomically` publish in orbit-store.

Assessment: Acceptance criteria are met at the store-write boundary with a single shared helper. Unwired `OrbitError::Io(err.to_string())` read/cleanup sites still emit the old bare message; that is intentional and out of the live-write set.

Strategic decisions:
- Keep `OrbitError::Io` rather than a new variant so MCP error codes stay stable.
- Path-aware helper instead of annotating `From<io::Error>` so ordinary read EACCES is not mislabeled as a sandbox mount.

Deviations from original plan:
- The bundle_io test injects `ErrorKind::ReadOnlyFilesystem` rather than `from_raw_os_error(libc::EROFS)` so it is portable. Raw EROFS/EACCES are covered in the orbit-common unit tests.

Unlisted files added to context_files (needed to compile / host the shared seam / cover the new path):
- `file:crates/orbit-common/src/error.rs` — `from_write_io`
- `file:crates/orbit-common/src/fs/io.rs` — shared classifier
- `file:crates/orbit-common/src/tests/error.rs` — classifier/message tests
- `file:crates/orbit-store/src/repository/task/v2_bundle.rs` — live `task.update` document writes
- `file:crates/orbit-store/src/fs/yaml.rs` — envelope/YAML store writes
- `file:crates/orbit-store/src/driver/file/friction_store/mod.rs` — second live store
- `file:crates/orbit-store/src/driver/file/task_bundle/bundle_io/tests/mod.rs` — injected EROFS publish test
- `file:crates/orbit-core/src/application/tests/managed_asset_manifest.rs` — existing skippable-write tests (no code change)

Executor-envelope prose: searched this repo (`docs/`, skills, `CLAUDE.md`) for CLI-vs-MCP write-fallback guidance about this EROFS condition. None found. The envelope that launched this run tells agents to use `orbit tool run` when MCP is not wired; that is a transport fallback, not a writability fallback, and is not wrong for EROFS (both surfaces hit the same store). No in-repo prose was edited.

Validation:
- `cargo test -p orbit-common --lib` (190 passed, including 4 new `from_write_io` tests)
- `cargo test -p orbit-store --lib bundle_io` (includes `erofs_bundle_publish_names_path_and_hints_sandbox`)
- `cargo test -p orbit-core --lib managed_asset_manifest` (6 passed)
- `cargo clippy -p orbit-common -p orbit-store --all-targets -- -D warnings`
- `cargo clippy -p orbit-core --lib -- -D warnings`
- `make ci-fast`

Friction checkpoint: no new record. F2026-08-045 already names this class; this task is the fix.

Recommended follow-ups: none required. Remaining bare `OrbitError::Io(err.to_string())` sites are reads/cleanup and can adopt `from_write_io` later if another live write path shows the same unattributable EROFS.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10908-6a825465`
- Behind base: 0
- Ahead of base: 1

*authored by: grok*