### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/user-interface/2_design.md
+++ b/docs/design/user-interface/2_design.md
@@ -4,6 +4,7 @@ type: design
 title: "User Interface — Design"
 owner: gemini
 last_updated: 2026-08-16
+last_validated: 2026-08-17
 status: Draft
 feature: user-interface
 doc_role: design

--- a/docs/design/user-interface/3_vision.md
+++ b/docs/design/user-interface/3_vision.md
@@ -4,6 +4,7 @@ type: design
 title: "User Interface — Vision"
 owner: gemini
 last_updated: 2026-04-30
+last_validated: 2026-08-17
 status: Draft
 feature: user-interface
 doc_role: vision

--- a/docs/design/user-interface/4_decisions.md
+++ b/docs/design/user-interface/4_decisions.md
@@ -4,6 +4,7 @@ type: design
 title: "User Interface — Decisions"
 owner: gemini
 last_updated: 2026-08-11
+last_validated: 2026-08-17
 status: Draft
 feature: user-interface
 doc_role: decisions
@@ -169,7 +170,7 @@ Rejected alternative: workspace-prefixed route paths (`/api/:workspace/tasks`). 
 - Cost: handlers that need a concrete workspace now depend on the `Ws` extractor's selection rules; the aggregate task endpoint reopens each workspace's store per request (no cross-workspace caching of task lists yet).
 
 
-## Top-Level Dashboard Nav Is the Operator's Four Tabs
+## Top-Level Dashboard Nav Is the Operator's Five Tabs
 
 **Recorded:** 2026-07-26 19:14:18.916582Z · [ORB-10444]
 
@@ -177,7 +178,7 @@ Rejected alternative: workspace-prefixed route paths (`/api/:workspace/tasks`). 
 Top-level nav is the dashboard's scarcest surface, and two of its six entries were not earning a slot: a deprecated review-threads tab with no backing view, and Scoreboard, a diagnostics-shaped read-only telemetry view sitting beside the operator workflow tabs.
 
 ### Decision
-The top-level nav is exactly Tasks, Audit, Diagnostics, Knowledge (plus the hash-only run-detail route). The deprecated tab is removed outright rather than hidden. Scoreboard becomes a Diagnostics subtab routed as #diagnostics/scoreboard, with its markup moved verbatim so the /api/scoreboard contract is untouched.
+The top-level nav is exactly Tasks, Audit, Diagnostics, Operations, Knowledge (plus the hash-only run-detail route). The deprecated tab is removed outright rather than hidden. Scoreboard becomes a Diagnostics subtab routed as #diagnostics/scoreboard, with its markup moved verbatim so the /api/scoreboard contract is untouched.
 
 ### Consequences
 - The nav reads as the operator workflow; telemetry lives one level down.

--- a/docs/design/user-interface/specs/theme.md
+++ b/docs/design/user-interface/specs/theme.md
@@ -1,3 +1,10 @@
+---
+type: design
+summary: "Spec: Canon Refined Theme"
+tags: ["user-interface"]
+last_validated: 2026-08-17
+---
+
 # Spec: Canon Refined Theme
 
 This document defines the formal design tokens and visual language for the Orbit User Interface (Canon Refined aesthetic), superseding the deprecated Trading Terminal theme.
@@ -10,42 +17,42 @@ As Orbit matures, the extreme constraints of the "Trading Terminal" aesthetic (p
 
 ### Background & Elevation
 The theme uses a layered dark mode, relying on subtle lightness shifts rather than shadows.
-- `bg`: `#0a0a0a` (Base canvas)
-- `bg-elev`: `#17171a` (Cards, panels, buttons)
-- `bg-sunk`: `#060607` (Deep wells, expanded detail rows)
+- `--bg`: `#000000` (Base canvas)
+- `--bg-elev`: `#0a0a0a` (Cards, panels, buttons)
+- Expanded task details use `#050505`; there is no dedicated `--bg-sunk` token in the live stylesheet.
 
 ### Borders
 Borders delineate structure without heavy contrast.
-- `border`: `#26262b` (Standard dividers)
-- `border-strong`: `#3b3b42` (Active/focused inputs)
+- `--border`: `#333333` (Standard dividers)
+- Focused inputs use the `--accent` border; there is no dedicated `--border-strong` token.
 
 ### Typography
-- **Sans-serif (Primary):** `Inter`, used for prose, titles, and general UI text. Ensures high readability at small sizes.
-- **Monospace (Secondary/Data):** `JetBrains Mono`, strictly reserved for IDs, metrics, timestamps, and code snippets.
-- **Base Size:** `13px` with `1.5` line height.
+- **Sans-serif (Primary):** `Inter` with `Geist Sans` fallback, used for prose, titles, and general UI text.
+- **Monospace (Secondary/Data):** `Geist Mono` with `JetBrains Mono` fallback, used for IDs, metrics, timestamps, and code snippets.
+- **Base Size:** `14px` with `1.5` line height.
 
 ### Semantic Colors
 Colors are muted but distinct, avoiding harsh neon tones while maintaining semantic meaning.
-- **Text:** `--text` (`#ededf0`), `--text-muted` (`#9b9ba3`), `--text-faint` (`#686872`)
+- **Text:** `--fg` (`#dcdcdc`), `--fg-dim` (`#71717a`)
 - **Accent (Blue):** `--accent` (`#6e9fff`)
-- **Success/Done (Green):** `--status-done` (`#4cc38a`)
-- **In-Progress (Teal):** `--status-in-progress` (`#5ec8d4`)
-- **Review (Purple):** `--status-review` (`#c97cf0`)
-- **Warning/Proposed (Amber):** `--status-proposed` (`#f5b14a`)
-- **Error/Blocked (Red):** `--status-blocked` (`#ef6b6b`)
+- **Success/Done (Green):** `--status-done` (`#10b981`)
+- **In-Progress (Teal):** `--status-in-progress` (`#06b6d4`)
+- **Review (Purple):** `--status-review` (`#d946ef`)
+- **Warning/Proposed (Amber):** `--status-proposed` (`#f59e0b`)
+- **Error/Blocked (Red):** `--status-blocked` (`#ef4444`)
 
 ### Structural Rules
-- **Radii:** Standardized on `4px` for small elements (buttons, chips) and `6px` for large containers (panels).
+- **Radii:** The stylesheet uses `2px` for many controls, `4px` for small components, and `6px` for panel-like containers.
 - **Density:** Padding remains tight (e.g., `12px 16px` for headers, `8px` gaps), but text is allowed to breathe more than in the legacy terminal theme.
-- **Animation:** Minimal, purposeful motion. Used primarily for "live" indicators (e.g., a pulsing dot `animation: pulse 2s infinite`).
+- **Animation:** Minimal, purposeful motion. Used primarily for loading indicators (e.g., `pulse-skeleton 1.5s infinite ease-in-out`).
 
 ## Mechanism-specific sections
 
 ### Expandable Rows
-Data tables use expandable rows (`.row.open`). When expanded:
-- The row background shifts to an accent wash (`--accent-low`).
-- The expanded detail view drops into a sunken background (`--bg-sunk`) with a 2-column layout (main content + side metadata).
-- Caret icons rotate `90deg` for clear state indication.
+Data tables use expandable rows (`.row.expanded`). When expanded:
+- The row background shifts to an accent wash (`rgba(110, 159, 255, 0.05)`).
+- The expanded detail view uses `#050505` with a 2-column layout (main content + side metadata).
+- Collapsible field carets rotate `-90deg` for clear state indication.
 
 ## Agent Signature
 gemini

--- a/docs/design/worktree-artifacts/1_overview.md
+++ b/docs/design/worktree-artifacts/1_overview.md
@@ -4,6 +4,7 @@ type: design
 title: "Worktree Artifacts - Overview"
 owner: codex
 last_updated: 2026-08-15
+last_validated: 2026-08-17
 status: Accepted
 feature: worktree-artifacts
 doc_role: overview
@@ -24,7 +25,7 @@ related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10501", "ORB-105
 > into feature decision docs; [ORB-10805] removed the redundant tracked store and
 > its IDs.
 
-Historically, worktree artifacts let decision and learning body files travel with the branch that created them while preserving one shared ID authority for the repository. Tasks, audit, scoreboards, and allocator state stayed in the shared `.orbit/`; the now-retired body files lived in the current worktree's `.orbit/`.
+Historically, worktree artifacts let decision and learning body files travel with the branch that created them while preserving one shared ID authority for the repository. Tasks, audit, scoreboards, and allocator state stayed in the shared `.orbit/`; the now-retired body files lived in the current worktree's `.orbit/`. The ADR/learning stores and `id_allocations` surface described below were retired with the native learning subsystem; current Orbit retains the shared/local runtime-root split but no longer exposes those artifact commands or allocation tables.
 
 ## 1. Motivation
 
@@ -40,16 +41,16 @@ The three-task sequence split this apart:
 
 | Concept | Meaning |
 |---------|---------|
-| Shared root | The main checkout `.orbit/`, used for tasks, audit, scoreboards, semantic.db, and allocation authority. |
-| Local root | The current worktree `.orbit/`, used for ADR and learning body files. |
-| Allocation row | A row in `id_allocations` recording ID, kind, allocation status, recorded worktree, branch, and `body_path`. |
-| Local-readable artifact | An allocation whose recorded body path exists and can be read by the current process. |
-| Remote stub | A list row for an allocation whose body is not locally readable, shown only with `include_remote`. Assumes the body still exists in *some* worktree. |
-| Orphaned allocation | An allocation whose pinned worktree is gone from disk *and* whose body is unreadable everywhere locally — a remote stub that can never resolve again. Detected by the `id-allocations` doctor check and retired by `orbit doctor --fix-orphaned-allocations` [ORB-10501]. |
+| Shared root | The main checkout `.orbit/`, used for tasks, audit, scoreboards, semantic.db, and (historically) allocation authority. |
+| Local root | The current worktree `.orbit/`, used for (historically) ADR and learning body files. |
+| Allocation row | A historical `id_allocations` row recording ID, kind, allocation status, recorded worktree, branch, and `body_path`. |
+| Local-readable artifact | A historical allocation whose recorded body path exists and can be read by the current process. |
+| Remote stub | A historical list row for an allocation whose body is not locally readable, shown only with `include_remote`. |
+| Orphaned allocation | A historical allocation whose pinned worktree is gone from disk and whose body is unreadable everywhere locally; this was detected by the `id-allocations` doctor check and retired by `orbit doctor --fix-orphaned-allocations` [ORB-10501]. |
 
 ## 3. At a Glance
 
-| Concern | File | Task |
+| Historical concern | Historical implementation location | Task |
 |---------|------|------|
 | Root split | `crates/orbit-core/src/runtime/resolve.rs` | [ORB-00199] |
 | Allocator and body metadata | `crates/orbit-store/src/sqlite/id_allocator/` | [ORB-00200], [ORB-00201] |

--- a/docs/design/worktree-artifacts/2_design.md
+++ b/docs/design/worktree-artifacts/2_design.md
@@ -4,6 +4,7 @@ type: design
 title: "Worktree Artifacts - Design"
 owner: codex
 last_updated: 2026-08-15
+last_validated: 2026-08-17
 status: Accepted
 feature: worktree-artifacts
 doc_role: design
@@ -34,7 +35,7 @@ Explicit `--root` and `ORBIT_ROOT` overrides pin both roots to preserve the old 
 
 ## 2. Allocation Metadata
 
-In standalone/worktree mode, `id_allocations` lives in
+In the retired standalone/worktree implementation, `id_allocations` lived in
 `shared_root/.orbit/state/semantic.db`. The allocator serializes ID creation with a
 shared lock, then body writes update the row with:
 
@@ -42,11 +43,11 @@ shared lock, then body writes update the row with:
 - `branch`: best-effort current branch.
 - `body_path`: the body file path relative to `worktree_root`.
 
-Backfilled shared-root artifacts receive `body_path` during allocator initialization so old ADRs and migrated learnings remain readable from any worktree.
+Backfilled shared-root artifacts received `body_path` during allocator initialization so old ADRs and migrated learnings remained readable from any worktree. ORB-10736 removed this allocator and the native learning projections; current store migrations explicitly drop `id_allocations`, while any old `.orbit/learnings/` files remain inert historical data.
 
-This is the only allocator, and every create path uses it. [Workspace-scoped knowledge keys, no global knowledge IDs](../host-registry/4_decisions.md#workspace-scoped-knowledge-keys-no-global-knowledge-ids) keys
-knowledge `(workspace_id, artifact_key)`, so an ID is unique within its workspace
-and makes no claim outside it; [ORB-10725] deleted the hub-global sequence that
+The retired design had one allocator, and every create path used it. [Workspace-scoped knowledge keys, no global knowledge IDs](../host-registry/4_decisions.md#workspace-scoped-knowledge-keys-no-global-knowledge-ids) keyed
+knowledge `(workspace_id, artifact_key)`, so an ID was unique within its workspace
+and made no claim outside it; [ORB-10725] deleted the hub-global sequence that
 §2.1 and §2.2 once described.
 
 ### 2.1 The withdrawn hub-global sequence substrate
@@ -67,21 +68,21 @@ database that recorded it must still find it — but the slot is a no-op, and Re
 feature v3 drops the tables `IF EXISTS` so a database that applied the original v2
 converges on the same shape as a fresh one.
 
-What is left is the shape §2 already described: one workspace-local allocator per
+The retired design left the shape §2 described: one workspace-local allocator per
 workspace, reached only by the owning machine. `orbit.learning.add` and
-`orbit.adr.add` are single owner-local transactions — no reservation, no expiry, no
-orphaned ID, no finalize/pull race — and the [ORB-10364] authoring role gate sits on
-that one surface with nothing at stake on refusal.
+`orbit.adr.add` were single owner-local transactions — no reservation, no expiry,
+no orphaned ID, no finalize/pull race — and the [ORB-10364] authoring role gate
+sat on that one surface with nothing at stake on refusal.
 
 ## 3. Write Path
 
-ADR creation writes `adr.yaml` and `body.md` under `local_root/adrs/proposed/ADR-NNNN/`. Learning creation writes `learning.yaml`, `votes.jsonl`, and `comments.jsonl` under `local_root/learnings/L-NNNN/`.
+In the retired implementation, ADR creation wrote `adr.yaml` and `body.md` under `local_root/adrs/proposed/ADR-NNNN/`. Learning creation wrote `learning.yaml`, `votes.jsonl`, and `comments.jsonl` under `local_root/learnings/L-NNNN/`.
 
 The first write into a linked worktree creates only the subtree needed for the artifact type. It does not scaffold local `state/`, `audit/`, `tasks/`, scoreboards, or registry files.
 
 ## 4. Read Federation
 
-ADR `show` resolves the envelope and body together in the store and carries exactly one of four states through Core, HTTP, and local MCP:
+In the retired implementation, ADR `show` resolved the envelope and body together in the store and carried exactly one of four states through Core, HTTP, and local MCP:
 
 1. `local`: a structurally complete, non-empty bundle exists under the current local root. This wins over any readable sibling allocation, and the read does not rewrite the allocation row.
 2. `federated`: no current-local bundle exists and the allocation resolves to a structurally complete, readable sibling bundle.
@@ -106,17 +107,18 @@ List and search retain their existing defaults. Readable allocation-owned bundle
 
 ## 5. Mutation Boundary
 
-ADR document update, accept, and supersede are local-only. A federated or unavailable allocation-owned artifact fails preflight with `artifact_not_local` (HTTP 409 or the same local MCP code) before any bundle, allocation, lifecycle timestamp, index, or audit mutation. Supersede preflights both operands before its first write. Landing the bundle in the current checkout restores ordinary local mutation semantics; a sibling-owned allocation row remains unchanged.
+In the retired implementation, ADR document update, accept, and supersede were local-only. A federated or unavailable allocation-owned artifact failed preflight with `artifact_not_local` (HTTP 409 or the same local MCP code) before any bundle, allocation, lifecycle timestamp, index, or audit mutation. Supersede preflighted both operands before its first write. Landing the bundle in the current checkout restored ordinary local mutation semantics; a sibling-owned allocation row remained unchanged.
 
-Local-only is a boundary on *where* the write runs, not on which surface may run
-it. `orbit adr add`, `orbit adr update`, and `orbit adr supersede` ([orbit adr owns ADR authoring and lifecycle; reconcile stays the cross-checkout verb](./4_decisions.md#orbit-adr-owns-adr-authoring-and-lifecycle-reconcile-stays-the-cross-checkout-verb),
-[ORB-10668]) delegate to the same `orbit.adr.*` tools and so inherit this
-preflight unchanged; they exist so the checkout that owns a bundle can complete
-the lifecycle from a shell, which is the only place the 409 leaves open.
+In that retired design, local-only was a boundary on *where* the write ran, not
+on which surface could run it. `orbit adr add`, `orbit adr update`, and `orbit adr
+supersede` ([orbit adr owns ADR authoring and lifecycle; reconcile stays the
+cross-checkout verb](./4_decisions.md#orbit-adr-owns-adr-authoring-and-lifecycle-reconcile-stays-the-cross-checkout-verb),
+[ORB-10668]) delegated to the same `orbit.adr.*` tools and inherited this
+preflight unchanged.
 
 ### 5.1 Federated ADR reconciliation
 
-`orbit adr reconcile <id> --source-worktree <path>` localizes an already
+The retired `orbit adr reconcile <id> --source-worktree <path>` command localized an already
 published ADR bundle from an explicitly named registered sibling worktree. It
 does not allocate, reconstruct metadata, change lifecycle state, or repoint the
 allocation row. The store requires both checkouts to appear in the same Git
@@ -124,7 +126,7 @@ worktree registry, reads a complete non-empty bundle whose metadata status
 matches its lifecycle partition, and accepts an existing destination only when
 both files are byte-equivalent.
 
-The source and destination ADR locks cover validation, while the shared
+In the retired design, the source and destination ADR locks covered validation, while the shared
 allocator lock pins the complete allocation snapshot across the final atomic
 rename. A changed source, allocation, incomplete bundle, lifecycle mismatch,
 unregistered checkout, or divergent destination fails before the canonical
@@ -134,7 +136,7 @@ preserves a readable published bundle verbatim.
 
 ## 6. Publication Policy and Duplicate Partitions
 
-Every ADR lifecycle partition — `proposed/`, `accepted/`, `superseded/`,
+In the retired implementation, every ADR lifecycle partition — `proposed/`, `accepted/`, `superseded/`,
 `deleted/` — is tracked by git and travels with the repository [ORB-10669].
 Publishing `proposed/` puts the decision under review in the same PR as the
 change that motivates it, and means an ADR authored inside a managed job
@@ -162,10 +164,10 @@ artifact for an ID is refused, not resolved.
 
 ### 6.1 Managed job-worktree drafts
 
-A managed job-run worktree scaffolds a real `.orbit/adrs/proposed` for its run.
-Drafts written there are now tracked, so the on-box auto-commit sweeps them into
-the run's branch. That is the intended disposition for work that ships: the
-draft rides its PR and merges with the code. For a run that is abandoned or
+In the retired implementation, a managed job-run worktree scaffolded a real `.orbit/adrs/proposed` for its run.
+Drafts written there were tracked, so the on-box auto-commit swept them into
+the run's branch. That was the intended disposition for work that shipped: the
+draft rode its PR and merged with the code. For a run that was abandoned or
 whose PR is rejected, the disposition is that **the draft dies with the branch**
 — no operator cleanup step, no reconciliation. Nothing reaches `agent-main`
 unless the branch merges, and the ID allocation left behind is an ordinary valid
@@ -176,13 +178,13 @@ wants to keep a draft from a discarded branch pulls it over with
 
 ## 7. Indexing Behavior
 
-Learning reindex and docs/ADR search operate on locally readable bodies. Remote-only allocation rows are skipped without error; once the recorded worktree is present and readable again, the same list/reindex path can read and index the body.
+In the retired implementation, learning reindex and docs/ADR search operated on locally readable bodies. Remote-only allocation rows were skipped without error; once the recorded worktree was present and readable again, the same list/reindex path could read and index the body.
 
 ## 8. Concerns & Honest Limitations
 
-Remote stubs are intentionally envelope-poor. They expose allocation metadata, not the artifact title, summary, or body, because those fields live in the unreadable body file. Filters that require body fields can only apply to locally readable artifacts.
+The retired remote stubs were intentionally envelope-poor. They exposed allocation metadata, not the artifact title, summary, or body, because those fields lived in the unreadable body file. Filters that required body fields could only apply to locally readable artifacts.
 
-The `worktree_root` column preserves historical rows from earlier phases, so old shared-root rows may record a `.orbit/` path while new rows record a worktree root. Readers resolve `body_path` relative to the recorded value instead of normalizing that history away.
+The retired `worktree_root` column preserved historical rows from earlier phases, so old shared-root rows could record a `.orbit/` path while new rows recorded a worktree root. Retired readers resolved `body_path` relative to the recorded value instead of normalizing that history away.
 
 ## Task References
 


### PR DESCRIPTION
## Task

[ORB-10911](https://orbit-cli.com/tasks/ORB-10911) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Batch selection:
- Selected exactly the six frontmatter-missing documents before any dated `last_validated` entry, using stable path order: `docs/design/user-interface/2_design.md`, `3_vision.md`, `4_decisions.md`, `specs/theme.md`, then `docs/design/worktree-artifacts/1_overview.md` and `2_design.md`.
- The corpus inventory was produced with `find docs -type f -name '*.md'` excluding `docs/design/_archive/` and `docs/changelogs/`, and frontmatter values were enumerated with `head`/`sed`.

Changes and verification:
- `docs/design/user-interface/2_design.md`: added `last_validated: 2026-08-17`. Verified the current five-tab navigation, run-detail route, diagnostics sub-tabs, task/log behavior, telemetry endpoints, and write actions against `crates/orbit-web/assets/dashboard/index.html`, `router.js`, `log-tail.js`, `tasks.js`, `diagnostics.js`, `audit.js`, and `crates/orbit-web/src/api/` using `rg` and source reads.
- `docs/design/user-interface/3_vision.md`: added the validation stamp. Verified the internal theme reference and confirmed the remaining external-tool comparisons and distinctive-UI statements are explicitly forward-looking vision claims, not current implementation assertions; they were left unchanged.
- `docs/design/user-interface/4_decisions.md`: added the stamp and corrected the stale “Four Tabs” decision to five tabs by checking `index.html` and `router.js`, which define Tasks, Audit, Diagnostics, Operations, Knowledge, plus the hash-only run-detail route.
- `docs/design/user-interface/specs/theme.md`: migrated frontmatter with only schema-compatible inferred metadata (`type: design`, summary `Spec: Canon Refined Theme`, inferred tag `user-interface`) plus the established `last_validated` key. Corrected stale token names/values, typography, base size, radii, animation, and expandable-row selectors against the live `dashboard.css` (`:root`, `.row.expanded`, `.row-detail`, `.field-block.collapsible`).
- `docs/design/worktree-artifacts/1_overview.md`: added the stamp and clarified that ADR/learning stores, `id_allocations`, and their commands are retired while the shared/local runtime-root split remains current. Verified with `crates/orbit-core/src/runtime/resolve.rs`, current CLI module registration, and the native-learning removal migration.
- `docs/design/worktree-artifacts/2_design.md`: added the stamp and marked allocation, ADR/learning write/federation/mutation/reconciliation, and remote-stub descriptions as retired historical behavior. Verified current removal with the absence of ADR/learning command/store modules and `apply_remove_native_learning_subsystem` dropping `id_allocations`; current root behavior was checked in runtime resolution and tests.

Unvalidated material:
- No selected document was left unstamped. The vision document’s aspirational comparison statements were not rewritten because they are not code-verifiable current claims; they remain explicitly framed as vision.

Validation:
- `cargo test -p orbit-core --lib application::docs::tests::frontmatter -- --nocapture`: 3 passed.
- `make ci-fast`: passed, including generated doc-index verification and all guard scripts.
- `git diff --check`: passed.
- Final diff contains exactly the six selected documents; no `.orbit/adrs/`, `CHANGELOG.md`, `docs/changelogs/`, `docs/design/_archive/`, `.orbit/tasks/`, `.orbit/graph/`, or generated-state path changed.

Assessment: bounded documentation upkeep completed with evidence-backed corrections only; no new document, section, metadata system, or prose reflow was introduced.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10911-6a825b31`
- Behind base: 0
- Ahead of base: 1