### PR TITLE
Redact command arguments before persisting coordination audit records

### DIFF
--- a/crates/orbit-core/src/adapter/tool_host/tests/command_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/command_tools.rs
@@ -182,3 +182,70 @@ fn audit_record_carries_argv_working_directory_caller_and_workspace() {
     assert_eq!(payload["caller"], json!("claude"));
     assert_eq!(payload["workspace"], json!(repo_root.display().to_string()));
 }
+
+#[test]
+fn secret_argv_reaches_child_but_is_redacted_in_the_audit_record() {
+    let _env = unmanaged_tool_env_guard();
+    let (_root, runtime, repo_root) = test_runtime();
+    let token = acquire_claim(&runtime, "claude");
+    let secret = "sk-abcdefghijklmnopqrstuvwxyz012345";
+
+    let result = run_tool_as_operator(
+        &runtime,
+        "orbit.command.exec",
+        json!({
+            "argv": ["echo", secret],
+            "working_directory": repo_root.display().to_string(),
+            "claim_token": token,
+            "model": "claude",
+        }),
+    )
+    .expect("claim holder executes");
+
+    assert!(
+        result["stdout"]
+            .as_str()
+            .expect("stdout is a string")
+            .contains(secret),
+        "the raw secret must reach the controlled test child unchanged: {result}"
+    );
+
+    let events = runtime
+        .list_audit_events(None, None, None, None, 200)
+        .expect("read audit events");
+    let event = events
+        .iter()
+        .find(|event| event.command == "command.exec")
+        .expect("command execution is audited");
+    let payload: Value = event
+        .arguments_json
+        .as_deref()
+        .and_then(|raw| serde_json::from_str(raw).ok())
+        .expect("audit payload is recorded JSON");
+
+    let argv = payload["argv"]
+        .as_array()
+        .expect("argv is recorded as an array");
+    assert_eq!(argv[0], json!("echo"));
+    assert_ne!(
+        argv[1],
+        json!(secret),
+        "the raw secret must not be persisted in the durable audit record: {payload}"
+    );
+    assert!(
+        argv[1]
+            .as_str()
+            .expect("redacted arg is a string")
+            .contains("REDACTED"),
+        "unexpected redacted argv value: {payload}"
+    );
+
+    let raw_record = event
+        .arguments_json
+        .as_deref()
+        .expect("audit payload is recorded as raw JSON text");
+    assert!(
+        !raw_record.contains(secret),
+        "the raw secret must not appear anywhere in the durable audit record: {raw_record}"
+    );
+}

--- a/crates/orbit-core/src/runtime/command_exec.rs
+++ b/crates/orbit-core/src/runtime/command_exec.rs
@@ -23,7 +23,7 @@ use std::process::Command;
 use std::time::Instant;
 
 use orbit_common::OrbitError;
-use orbit_common::security::redaction::is_sensitive_env_name;
+use orbit_common::security::redaction::{PatternRedactor, is_sensitive_env_name};
 use orbit_types::telemetry::AuditEventStatus;
 use orbit_types::tool::ExecutionResult;
 use serde_json::json;
@@ -90,6 +90,11 @@ impl OrbitRuntime {
         } else {
             AuditEventStatus::Failure
         };
+        let redaction = PatternRedactor::with_argv_secrets();
+        let argv_redacted: Vec<String> = full_argv
+            .iter()
+            .map(|arg| redaction.apply_str(arg))
+            .collect();
         if let Err(audit_error) = record_coordination_audit_event(
             self,
             CoordinationAuditEvent {
@@ -100,7 +105,7 @@ impl OrbitRuntime {
                 task_id: None,
                 status,
                 payload: json!({
-                    "argv": full_argv,
+                    "argv": argv_redacted,
                     "working_directory": params.working_directory,
                     "caller": params.actor,
                     "workspace": self.paths().repo_root.to_string_lossy(),


### PR DESCRIPTION
## Task

[ORB-10918](https://orbit-cli.com/tasks/ORB-10918) — Redact command arguments before persisting coordination audit records

### Description

## Problem
`orbit.command.exec` executes the caller's original argv and also serializes that same unredacted argv into the durable coordination audit payload. Tokens, passwords, connection strings, and credential-bearing URLs supplied as arguments therefore remain in plaintext `arguments_json`.

The provider CLI audit path already uses `PatternRedactor::with_argv_secrets()`, but command execution does not.

## Why It Matters
Audit records are intentionally durable and queryable. Persisting secrets there expands credential exposure and makes later audit export or dashboard access hazardous.

## Constraints / Notes
- Process execution must continue to receive the original argv.
- Only the durable/logged representation should be redacted.
- Reuse the established redaction behavior rather than creating a divergent command-specific heuristic.
- Evidence was confirmed at commit `7255976e512dd78eb3fd325ce96973c577685e78`.

### Acceptance Criteria

- orbit.command.exec executes the original argv unchanged while persisting only a redacted argv representation.
- Known token shapes, credential-bearing URLs, and common secret flags are absent from arguments_json and replaced by the established redaction marker.
- Non-sensitive argv remains useful enough to identify the executed program and operation in audit queries.
- Tests prove the raw secret reaches a controlled test child when required but never appears in the corresponding durable audit record.
- Existing command execution, workspace-claim, and audit tests pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Redacted the durable audit payload for orbit.command.exec while leaving process execution untouched.

Change (crates/orbit-core/src/runtime/command_exec.rs): built `argv_redacted` by running each element of `full_argv` through `PatternRedactor::with_argv_secrets()` (the same redactor orbit-engine's CLI runner orchestrator already uses for provider-CLI audit) and persisted that into the `argv` field of the coordination audit payload. `program`/`args` (used to spawn the actual `Command`) are untouched — only the audit-record copy is redacted, so execution semantics are unchanged.

Tests (crates/orbit-core/src/adapter/tool_host/tests/command_tools.rs): added `secret_argv_reaches_child_but_is_redacted_in_the_audit_record`, which runs `echo` with a bare `sk-...` token as an argv element, asserts the raw secret appears in the tool's own stdout (proving the controlled child still received the real argv), then reads the persisted coordination audit event back and asserts the secret is absent from both the parsed `argv` array and the raw `arguments_json` text, replaced by the existing `[REDACTED_API_KEY]` marker. All prior command_tools tests (including `audit_record_carries_argv_working_directory_caller_and_workspace`, which still asserts non-sensitive argv like `["echo","audited-command"]` passes through unmodified) continue to pass unchanged.

Validation: `cargo fmt -p orbit-core` (clean), `cargo clippy -p orbit-core --all-targets` (clean), `make ci-fast` (clean), `cargo test -p orbit-core --lib` scoped to command_tools/workspace_claim/audit (701 passed, 0 failed). Note: `cargo test -p orbit-core --lib` unscoped shows 12 pre-existing failures in `runtime::tests::resolve` (a shared `ENV_LOCK` mutex gets poisoned by an unrelated HOME/env-mutation test in this sandbox and cascades to every other test using that lock) — confirmed pre-existing and unrelated to this change: the failure reproduces identically with --test-threads=1 and in isolation on just that module, and neither touched file participates in that test module.

No new context_files were needed; the change stayed within the two files already scoped to the task.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10918-6a825eb3`
- Behind base: 0
- Ahead of base: 1