### PR TITLE
ORB-10908 EROFS diagnostic misses the task-lock-file open, the actual first write on a read-only task dir

### DIFF
--- a/crates/orbit-common/src/error.rs
+++ b/crates/orbit-common/src/error.rs
@@ -325,14 +325,10 @@ impl OrbitError {
     /// to `linux_bwrap_write_grant_diagnostic`. Other I/O stays a bare
     /// [`Self::Io`] so read and capacity failures keep their existing text.
     pub fn from_write_io(path: &Path, err: std::io::Error) -> Self {
-        if crate::fs::io::is_readonly_or_access_error(&err) {
-            Self::Io(format!(
-                "`{}` is not writable: {err}; this is likely a sandbox or environment condition, not an Orbit store defect",
-                path.display()
-            ))
-        } else {
-            Self::Io(err.to_string())
-        }
+        Self::Io(
+            crate::fs::io::write_access_error_message(path, &err)
+                .unwrap_or_else(|| err.to_string()),
+        )
     }
 }
 

--- a/crates/orbit-common/src/fs/io.rs
+++ b/crates/orbit-common/src/fs/io.rs
@@ -269,21 +269,27 @@ where
             format!("cannot determine parent for '{}'", target_path.display()),
         )
     })?;
-    create_private_dir_all(parent)?;
+    create_private_dir_all(parent).map_err(|e| classify_lock_io(parent, e))?;
 
     let lock_path = lock_path_for(target_path)?;
     let mut options = OpenOptions::new();
     options.create(true).read(true).write(true).truncate(false);
     apply_private_file_mode(&mut options);
     let lock_file = options.open(&lock_path).map_err(|e| {
-        io::Error::other(format!("open {label} lock '{}': {e}", lock_path.display()))
+        classify_or_wrap_lock_io(&lock_path, e, |e| {
+            format!("open {label} lock '{}': {e}", lock_path.display())
+        })
     })?;
     set_private_file_permissions(&lock_path).map_err(|e| {
-        io::Error::other(format!("chmod {label} lock '{}': {e}", lock_path.display()))
+        classify_or_wrap_lock_io(&lock_path, e, |e| {
+            format!("chmod {label} lock '{}': {e}", lock_path.display())
+        })
     })?;
-    lock_file
-        .lock_exclusive()
-        .map_err(|e| io::Error::other(format!("lock {label} '{}': {e}", lock_path.display())))?;
+    lock_file.lock_exclusive().map_err(|e| {
+        classify_or_wrap_lock_io(&lock_path, e, |e| {
+            format!("lock {label} '{}': {e}", lock_path.display())
+        })
+    })?;
 
     op()
 }
@@ -372,6 +378,38 @@ fn set_private_file_permissions(path: &Path) -> io::Result<()> {
 #[cfg(not(unix))]
 fn set_private_file_permissions(_path: &Path) -> io::Result<()> {
     Ok(())
+}
+
+/// Attributable write-access failure, or `None` when `err` is some other I/O.
+///
+/// Shared by [`crate::OrbitError::from_write_io`] and lock acquisition so
+/// EROFS/EACCES always names `path` and hints at a sandbox/environment
+/// condition instead of a store defect.
+pub(crate) fn write_access_error_message(path: &Path, err: &io::Error) -> Option<String> {
+    is_readonly_or_access_error(err).then(|| {
+        format!(
+            "`{}` is not writable: {err}; this is likely a sandbox or environment condition, not an Orbit store defect",
+            path.display()
+        )
+    })
+}
+
+fn classify_lock_io(path: &Path, err: io::Error) -> io::Error {
+    match write_access_error_message(path, &err) {
+        Some(message) => io::Error::new(err.kind(), message),
+        None => err,
+    }
+}
+
+fn classify_or_wrap_lock_io(
+    path: &Path,
+    err: io::Error,
+    fallback: impl FnOnce(&io::Error) -> String,
+) -> io::Error {
+    match write_access_error_message(path, &err) {
+        Some(message) => io::Error::new(err.kind(), message),
+        None => io::Error::other(fallback(&err)),
+    }
 }
 
 /// True when `error` is a read-only filesystem or access denial.

--- a/crates/orbit-common/src/fs/tests/io.rs
+++ b/crates/orbit-common/src/fs/tests/io.rs
@@ -1,0 +1,89 @@
+use std::io;
+
+use tempfile::TempDir;
+
+use crate::OrbitError;
+use crate::fs::io::with_exclusive_file_lock;
+
+fn assert_sandbox_write_message(message: &str, path: &str) {
+    assert!(
+        message.contains(path),
+        "expected path `{path}` in `{message}`"
+    );
+    assert!(
+        message.contains("is not writable"),
+        "expected writable attribution in `{message}`"
+    );
+    assert!(
+        message.contains("sandbox or environment"),
+        "expected sandbox/environment hint in `{message}`"
+    );
+    assert!(
+        message.contains("not an Orbit store defect"),
+        "expected store-defect negation in `{message}`"
+    );
+}
+
+#[test]
+fn exclusive_lock_runs_op_and_releases() {
+    let temp = TempDir::new().expect("tempdir");
+    let target = temp.path().join("task.yaml");
+    let ran = with_exclusive_file_lock(&target, "task artifact v2", || {
+        assert!(temp.path().join(".task.yaml.lock").exists());
+        Ok::<_, io::Error>(true)
+    })
+    .expect("lock should succeed");
+    assert!(ran);
+}
+
+#[test]
+fn exclusive_lock_non_access_failure_stays_labeled() {
+    let temp = TempDir::new().expect("tempdir");
+    let blocker = temp.path().join("not-a-dir");
+    std::fs::write(&blocker, b"x").expect("write blocker");
+    let target = blocker.join("task.yaml");
+    let err = with_exclusive_file_lock::<(), io::Error, _>(&target, "task artifact v2", || Ok(()))
+        .expect_err("parent file must fail lock acquisition");
+    let message = err.to_string();
+    assert!(
+        !message.contains("sandbox or environment"),
+        "non-access failures must stay unlabeled: {message}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn exclusive_lock_open_on_readonly_dir_names_path_and_hints_sandbox() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = TempDir::new().expect("tempdir");
+    let dir = temp.path().join("bundle");
+    std::fs::create_dir(&dir).expect("mkdir");
+    let target = dir.join("task.yaml");
+    let lock_path = dir.join(".task.yaml.lock");
+
+    let mut perms = std::fs::metadata(&dir).expect("meta").permissions();
+    perms.set_mode(0o555);
+    std::fs::set_permissions(&dir, perms).expect("chmod -w");
+
+    struct Restore<'a>(&'a std::path::Path);
+    impl Drop for Restore<'_> {
+        fn drop(&mut self) {
+            let _ = std::fs::set_permissions(self.0, std::fs::Permissions::from_mode(0o755));
+        }
+    }
+    let _restore = Restore(&dir);
+
+    let err = with_exclusive_file_lock::<(), OrbitError, _>(&target, "task artifact v2", || Ok(()))
+        .expect_err("lock open must fail on a read-only directory");
+    match err {
+        OrbitError::Io(message) => {
+            assert_sandbox_write_message(&message, &lock_path.display().to_string());
+            assert!(
+                !message.contains("open task artifact v2 lock"),
+                "classified access errors must not use the bare lock-open wrap: {message}"
+            );
+        }
+        other => panic!("expected Io, got {other}"),
+    }
+}

--- a/crates/orbit-common/src/fs/tests/mod.rs
+++ b/crates/orbit-common/src/fs/tests/mod.rs
@@ -1,2 +1,3 @@
 mod glob;
+mod io;
 mod selector;

--- a/crates/orbit-store/src/repository/task/v2/tests/crud.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/crud.rs
@@ -194,6 +194,48 @@ fn delete_task_removes_v2_bundle_and_index_rows() {
     assert!(!store.delete_task("ORB-00000").expect("delete missing"));
 }
 
+#[cfg(unix)]
+#[test]
+fn create_task_on_readonly_parent_dir_names_lock_path_and_hints_sandbox() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    store
+        .create_task(create_params("First", TaskStatus::Backlog))
+        .expect("create first");
+    let next_bundle = store
+        .bundle_store
+        .bundle_path("ORB-00001")
+        .expect("next bundle path");
+    let parent = next_bundle.parent().expect("tasks dir").to_path_buf();
+    let lock_path = parent.join(".ORB-00001.lock");
+    let _restore = make_readonly(&parent);
+
+    let err = store
+        .create_task(create_params("Second", TaskStatus::Backlog))
+        .expect_err("create must fail when the tasks dir is read-only");
+    assert_sandbox_write_io(&err, &lock_path.display().to_string());
+}
+
+#[cfg(unix)]
+#[test]
+fn delete_task_on_readonly_bundle_dir_names_path_and_hints_sandbox() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    store
+        .create_task(create_params("Delete me", TaskStatus::Rejected))
+        .expect("create task");
+    let bundle_dir = store
+        .bundle_store
+        .bundle_path("ORB-00000")
+        .expect("bundle path");
+    let _restore = make_readonly(&bundle_dir);
+
+    let err = store
+        .delete_task("ORB-00000")
+        .expect_err("delete must fail on a read-only bundle dir");
+    assert_sandbox_write_io(&err, &bundle_dir.display().to_string());
+}
+
 #[test]
 fn create_task_persists_lineage_relations() {
     let temp = TempDir::new().expect("tempdir");

--- a/crates/orbit-store/src/repository/task/v2/tests/mod.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/mod.rs
@@ -77,5 +77,52 @@ pub(super) fn create_params(title: &str, status: TaskStatus) -> TaskCreateParams
     }
 }
 
+#[cfg(unix)]
+pub(super) struct RestoreWritePerms<'a> {
+    path: &'a std::path::Path,
+}
+
+#[cfg(unix)]
+impl Drop for RestoreWritePerms<'_> {
+    fn drop(&mut self) {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(self.path, std::fs::Permissions::from_mode(0o755));
+    }
+}
+
+#[cfg(unix)]
+pub(super) fn make_readonly(path: &std::path::Path) -> RestoreWritePerms<'_> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut perms = std::fs::metadata(path).expect("meta").permissions();
+    perms.set_mode(0o555);
+    std::fs::set_permissions(path, perms).expect("chmod -w");
+    RestoreWritePerms { path }
+}
+
+pub(super) fn assert_sandbox_write_io(err: &OrbitError, path_substr: &str) {
+    match err {
+        OrbitError::Io(message) => {
+            assert!(
+                message.contains(path_substr),
+                "expected path `{path_substr}` in `{message}`"
+            );
+            assert!(
+                message.contains("is not writable"),
+                "expected writable attribution in `{message}`"
+            );
+            assert!(
+                message.contains("sandbox or environment"),
+                "expected sandbox/environment hint in `{message}`"
+            );
+            assert!(
+                message.contains("not an Orbit store defect"),
+                "expected store-defect negation in `{message}`"
+            );
+        }
+        other => panic!("expected Io, got {other}"),
+    }
+}
+
 mod crud;
 mod update;

--- a/crates/orbit-store/src/repository/task/v2/tests/update.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/update.rs
@@ -276,3 +276,31 @@ fn artifact_update_writes_manifest_and_sorted_text_artifacts() {
         .expect_err("reject unsafe artifact path");
     assert!(err.to_string().contains(".."), "{err}");
 }
+
+#[cfg(unix)]
+#[test]
+fn document_update_on_readonly_bundle_dir_names_lock_path_and_hints_sandbox() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    store
+        .create_task(create_params("Original", TaskStatus::Backlog))
+        .expect("create task");
+    let bundle_dir = store
+        .bundle_store
+        .bundle_path("ORB-00000")
+        .expect("bundle path");
+    let lock_path = bundle_dir.join(".task.yaml.lock");
+    let _restore = make_readonly(&bundle_dir);
+
+    let err = store
+        .update_task_document(
+            "ORB-00000",
+            &TaskDocumentUpdateParams {
+                actor: "codex:gpt-5.5".to_string(),
+                title: Some("Renamed".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect_err("update must fail on a read-only bundle dir");
+    assert_sandbox_write_io(&err, &lock_path.display().to_string());
+}

--- a/crates/orbit-store/src/repository/task/v2_bundle.rs
+++ b/crates/orbit-store/src/repository/task/v2_bundle.rs
@@ -200,7 +200,7 @@ impl TaskBundleStoreV2 {
         let removed_bundle = match fs::remove_dir_all(&bundle_dir) {
             Ok(()) => true,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
-            Err(err) => return Err(OrbitError::Io(err.to_string())),
+            Err(err) => return Err(OrbitError::from_write_io(&bundle_dir, err)),
         };
         let removed_projection = match self.workspace_orbit_dir.as_deref() {
             Some(workspace_orbit_dir) => remove_projection_entry(workspace_orbit_dir, task_id)?,


### PR DESCRIPTION
## Task

[ORB-10915](https://orbit-cli.com/tasks/ORB-10915) — ORB-10908 EROFS diagnostic misses the task-lock-file open, the actual first write on a read-only task dir

### Description

EROFS/EACCES on a task bundle directory still surfaces a generic, unattributed error instead of the new diagnostic added in ORB-10908, because the fix did not cover the task-lock-file open step.

Root cause: with_exclusive_file_lock (crates/orbit-common/src/fs/io.rs:261) opens `<bundle_dir>/.task.yaml.lock` before any content write happens, and on failure wraps the OS error with a bare io::Error::other(...) (lines 278-280). Callers such as TaskRepositoryV2::with_task_lock (crates/orbit-store/src/repository/task/v2/index.rs:160-166) and the v2 delete path (crates/orbit-store/src/repository/task/v2/crud.rs:195) propagate this straight through `E: From<io::Error>`, which for OrbitError is the plain Self::Io(err.to_string()) blanket conversion in crates/orbit-common/src/error.rs. ORB-10908 (commit ebab7616) only routed the content write calls through the new OrbitError::from_write_io (crates/orbit-store/src/fs/yaml.rs, crates/orbit-store/src/repository/task/v2_bundle.rs) -- it never touched with_exclusive_file_lock or its callers. Since lock acquisition is the first filesystem operation for every v2 task write (add/update/delete), a read-only or permission-denied task directory hits the un-diagnosed path before it ever reaches the code ORB-10908 fixed.

Evidence / reproduction (verified hands-on on this host with the built release binary, in a disposable scratch workspace under /tmp, cleaned up afterward):
1. orbit workspace init a scratch workspace; orbit tool run orbit.task.add a task (e.g. ORB-10914).
2. chmod -w <orbit-root>/tasks/workspaces/<ws>/<task-id> to simulate a read-only mount, matching the ORB-10908 scenario.
3. orbit tool run orbit.task.update against that task id returns:
   {"code":"io_error","error":"io error: open task artifact v2 lock '.../.task.yaml.lock': Permission denied (os error 13)"}
   Expected per ORB-10908's intent: a message naming the path and noting it is likely a sandbox or environment condition, not an Orbit store defect (the from_write_io format).

Fix suggestion: route with_exclusive_file_lock's open/chmod/lock failures through the same is_readonly_or_access_error classification used by OrbitError::from_write_io (or have callers translate the returned io::Error via from_write_io using the lock target path) so the attributable diagnostic covers the actual first failure point, not just the later content write.

Commit involved: ebab7616 [ORB-10908].

### Acceptance Criteria

- with_exclusive_file_lock (or its callers) classifies EROFS/EACCES lock-open failures using the same is_readonly_or_access_error logic as OrbitError::from_write_io.
- A read-only task bundle directory produces the attributable diagnostic (path + sandbox/environment hint) on task add/update/delete, not a bare Permission Denied.
- Existing lock-file tests still pass; a new regression test covers the read-only-directory case.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `with_exclusive_file_lock` now classifies create/open/chmod/lock failures with `is_readonly_or_access_error` before wrapping. EROFS/EACCES produce the same path + sandbox/environment diagnostic as `OrbitError::from_write_io`; other I/O keeps the existing labeled wrap.
- Extracted `write_access_error_message` so lock acquisition and `from_write_io` cannot drift.
- `delete_bundle` routes `remove_dir_all` through `from_write_io` so chmod -w on the bundle dir itself is attributed (delete locks a sibling in the parent).
- Regression tests: lock-open on a read-only dir; task add (read-only parent), update (read-only bundle), and delete (read-only bundle).
Assessment: Scoped to the first write-path failure. Existing lock-file tests and `from_write_io` unit tests still pass.
Strategic decisions: Classify inside `with_exclusive_file_lock` rather than only at callers, because the previous `io::Error::other(...)` wrap dropped ErrorKind/errno and made caller-side `from_write_io` impossible.
Validation: `cargo test -p orbit-common --lib -- fs::tests::io error::tests`; `cargo test -p orbit-store --lib -- repository::task::v2::tests fs::lock::tests repository::task::tests::v2_bundle`; `cargo clippy -p orbit-common -p orbit-store --all-targets -- -D warnings`; `make ci-fast`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10915-6a825eb3`
- Behind base: 0
- Ahead of base: 1