### PR TITLE
Enforce operator authorization for governed MCP tools

### DIFF
--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -432,7 +432,7 @@ fn mcp_serve_tools_list_matches_production_snapshot() {
 }
 
 #[test]
-fn mcp_server_advertises_and_calls_the_workflow_family() {
+fn mcp_server_advertises_governed_tools_but_denies_an_unprivileged_session() {
     let workspace = McpWorkspace::init();
     let mut client = workspace.serve();
     let response = client.request("tools/list", Value::Null);
@@ -448,12 +448,31 @@ fn mcp_server_advertises_and_calls_the_workflow_family() {
         "orbit_workflow_run_show",
         "orbit_workflow_run_list",
         "orbit_workflow_run_resume",
+        "orbit_command_exec",
     ] {
         assert!(names.contains(expected), "missing {expected}: {names:?}");
     }
 
-    let listed = client.call_tool_ok("orbit_workflow_run_list", json!({}));
-    assert_eq!(listed["items"], json!([]));
+    for (name, arguments) in [
+        ("orbit_workflow_ship", json!({ "task_ids": ["ORB-00001"] })),
+        ("orbit_workflow_run_show", json!({ "id": "jrun-missing" })),
+        ("orbit_workflow_run_list", json!({})),
+        ("orbit_workflow_run_resume", json!({ "id": "jrun-missing" })),
+    ] {
+        let denied = client.call_tool_err(name, arguments);
+        assert_eq!(denied["code"], "capability_denied", "{name}: {denied}");
+    }
+
+    let marker = workspace.work.join("command-exec-must-not-run");
+    let denied = client.call_tool_err(
+        "orbit_command_exec",
+        json!({
+            "argv": ["touch", marker.to_str().expect("utf8 marker")],
+            "working_directory": workspace.work,
+        }),
+    );
+    assert_eq!(denied["code"], "capability_denied", "{denied}");
+    assert!(!marker.exists(), "denied command reached domain execution");
 }
 
 #[test]
@@ -868,8 +887,7 @@ fn mcp_serve_error_paths_return_tool_errors_and_keep_serving() {
         "error should name the missing field: {bad_params}"
     );
 
-    // v1 does not capability-filter governed tools; Core still performs normal
-    // domain validation after dispatch.
+    // Inactive tools remain absent from the advertised MCP registry.
     let unexposed = client.call_tool_err("orbit_task_delete", json!({ "id": "ORB-00000" }));
     assert_eq!(unexposed["code"], "tool_not_found");
 
@@ -909,13 +927,13 @@ fn mcp_calls_are_audited_once_including_unknown_raw_names() {
         "orbit_workflow_ship",
         json!({ "task_ids": ["ORB-00001"], "model": "codex" }),
     );
-    assert_ne!(workflow_failure["code"], "capability_denied");
+    assert_eq!(workflow_failure["code"], "capability_denied");
     drop(client);
 
     for (tool_name, status) in [
         ("orbit.search", "success"),
         ("orbit.task.add", "failure"),
-        ("orbit.workflow.ship", "failure"),
+        ("orbit.workflow.ship", "denied"),
     ] {
         let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
             .args(["audit", "list", "--tool", tool_name, "--json"])

--- a/crates/orbit-core/src/adapter/command/dispatch.rs
+++ b/crates/orbit-core/src/adapter/command/dispatch.rs
@@ -237,7 +237,7 @@ impl OrbitRuntime {
                 };
                 let capability_enforcement = match entry_point {
                     ToolEntryPoint::Cli => CapabilityEnforcement::Enforce,
-                    ToolEntryPoint::Mcp => CapabilityEnforcement::DeferredForMcpV1,
+                    ToolEntryPoint::Mcp => CapabilityEnforcement::McpSessionOnly,
                 };
                 self.run_tool_with_context_and_role_and_capability(
                     name,

--- a/crates/orbit-core/src/adapter/command/tests/dispatch.rs
+++ b/crates/orbit-core/src/adapter/command/tests/dispatch.rs
@@ -78,22 +78,107 @@ fn dispatch_records_failure_audit_when_tool_handler_errors() {
     assert_eq!(row.subcommand.as_deref(), Some("run-mcp"));
 }
 
+fn mcp_context(capabilities: impl IntoIterator<Item = McpCapability>) -> ToolSessionContext {
+    ToolSessionContext {
+        transport: Some(McpTransport::Local),
+        effective_capabilities: capabilities.into_iter().collect(),
+        ..ToolSessionContext::default()
+    }
+}
+
 #[test]
-fn mcp_v1_defers_capability_authorization_inside_core() {
+fn mcp_empty_session_is_denied_before_governed_tool_execution_and_audited() {
+    let _g = env_guard();
+    clear_identity_env();
+    let runtime = fresh_runtime();
+    let result = runtime
+        .execute_tool_command_dispatch_with_session_context(
+            "orbit.workflow.run.list",
+            json!({}),
+            None,
+            None,
+            ToolEntryPoint::Mcp,
+            mcp_context([]),
+        )
+        .expect_err("an empty MCP session must fail closed");
+
+    assert!(matches!(result, OrbitError::CapabilityDenied(_)));
+    let events = runtime
+        .list_audit_events(
+            None,
+            Some("orbit.workflow.run.list".to_string()),
+            None,
+            None,
+            1,
+        )
+        .expect("read denied MCP audit row");
+    let row = &events[0];
+    assert_eq!(row.status, AuditEventStatus::Denied);
+    assert_eq!(row.transport, Some(McpTransport::Local));
+    assert!(row.effective_capabilities.is_empty());
+}
+
+#[test]
+fn mcp_agent_session_is_denied_before_governed_tool_execution() {
+    let _g = env_guard();
+    let runtime = fresh_runtime();
+    let result = runtime
+        .execute_tool_command_dispatch_with_session_context(
+            "orbit.workflow.run.list",
+            json!({}),
+            None,
+            None,
+            ToolEntryPoint::Mcp,
+            mcp_context([McpCapability::Agent]),
+        )
+        .expect_err("an agent MCP session must not reach operator tools");
+
+    assert!(matches!(result, OrbitError::CapabilityDenied(_)));
+    let events = runtime
+        .list_audit_events(
+            None,
+            Some("orbit.workflow.run.list".to_string()),
+            None,
+            None,
+            1,
+        )
+        .expect("read agent MCP audit row");
+    let row = &events[0];
+    assert_eq!(row.status, AuditEventStatus::Denied);
+    assert_eq!(row.transport, Some(McpTransport::Local));
+    assert_eq!(
+        row.effective_capabilities,
+        BTreeSet::from([McpCapability::Agent])
+    );
+}
+
+#[test]
+fn mcp_operator_session_reaches_governed_tool_execution() {
     let _g = env_guard();
     let runtime = fresh_runtime();
     let result = runtime.execute_tool_command_dispatch_with_session_context(
-        "orbit.task.delete",
-        json!({ "id": "ORB-NOT-THERE" }),
+        "orbit.workflow.run.list",
+        json!({}),
         None,
         None,
         ToolEntryPoint::Mcp,
-        ToolSessionContext::default(),
+        mcp_context([McpCapability::Operator]),
     );
 
-    assert!(
-        !matches!(result, Err(OrbitError::CapabilityDenied(_))),
-        "MCP v1 reaches domain validation without a capability decision"
+    assert!(result.is_ok(), "operator session was denied: {result:?}");
+    let events = runtime
+        .list_audit_events(
+            None,
+            Some("orbit.workflow.run.list".to_string()),
+            None,
+            None,
+            1,
+        )
+        .expect("read operator MCP audit row");
+    assert_eq!(events[0].status, AuditEventStatus::Success);
+    assert_eq!(
+        events[0].effective_capabilities,
+        BTreeSet::from([McpCapability::Operator])
     );
 }
 

--- a/crates/orbit-core/src/runtime/authorization.rs
+++ b/crates/orbit-core/src/runtime/authorization.rs
@@ -28,6 +28,7 @@ use orbit_types::telemetry::AuditEventStatus;
 use orbit_types::tool::ToolSessionContext;
 
 use crate::OrbitRuntime;
+use crate::runtime::tool_exec::CapabilityEnforcement;
 
 impl OrbitRuntime {
     /// Authorize a governed tool call, or pass an ungoverned one straight
@@ -41,11 +42,19 @@ impl OrbitRuntime {
         &self,
         tool_name: &str,
         session_context: &ToolSessionContext,
+        capability_enforcement: CapabilityEnforcement,
     ) -> Result<(), OrbitError> {
         let Some(operation) = governed_tool(tool_name) else {
             return Ok(());
         };
-        self.decide(operation, session_context)
+        let envelope = match capability_enforcement {
+            CapabilityEnforcement::Enforce => CallerEnvelope::from_process_env(session_context),
+            CapabilityEnforcement::McpSessionOnly => CallerEnvelope {
+                session_capabilities: session_context.effective_capabilities.clone(),
+                ..CallerEnvelope::default()
+            },
+        };
+        self.decide_with_envelope(operation, envelope)
     }
 
     /// Authorize a governed CLI command, or pass an ungoverned one through.
@@ -70,8 +79,15 @@ impl OrbitRuntime {
         operation: &'static GovernedOperation,
         session_context: &ToolSessionContext,
     ) -> Result<(), OrbitError> {
-        let caller =
-            CallerCapabilities::resolve(&CallerEnvelope::from_process_env(session_context));
+        self.decide_with_envelope(operation, CallerEnvelope::from_process_env(session_context))
+    }
+
+    fn decide_with_envelope(
+        &self,
+        operation: &'static GovernedOperation,
+        envelope: CallerEnvelope,
+    ) -> Result<(), OrbitError> {
+        let caller = CallerCapabilities::resolve(&envelope);
 
         match authorize(operation, &caller) {
             Ok(()) => {

--- a/crates/orbit-core/src/runtime/tool_exec.rs
+++ b/crates/orbit-core/src/runtime/tool_exec.rs
@@ -10,15 +10,16 @@ use serde_json::Value;
 
 use crate::{NotFoundKind, OrbitError, OrbitRuntime};
 
-/// Whether Core applies its capability registry before executing a tool.
+/// Which trusted inputs Core may use when applying its capability registry.
 ///
-/// MCP v1 deliberately defers this one policy while the server-side skeleton
-/// settles. The choice remains inside Core so a later authorization design can
-/// be enforced here without rebuilding transport-specific gates.
+/// Ordinary in-process and CLI calls may resolve capabilities from both their
+/// session context and the process envelope. MCP calls must use only the grants
+/// carried by their trusted session context: an empty or agent-only MCP session
+/// cannot inherit operator authority from the server process that hosts it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CapabilityEnforcement {
     Enforce,
-    DeferredForMcpV1,
+    McpSessionOnly,
 }
 
 impl OrbitRuntime {
@@ -61,9 +62,7 @@ impl OrbitRuntime {
         // workspace reaches the registry through this function, so this is the
         // only place a governed tool operation is authorized — a per-command
         // guard would be reopened by the next entry point that skips it.
-        if capability_enforcement == CapabilityEnforcement::Enforce {
-            self.authorize_tool_operation(name, &tool_context.session_context)?;
-        }
+        self.authorize_tool_operation(name, &tool_context.session_context, capability_enforcement)?;
 
         if !tool_context.allowed_tools.is_empty()
             && !tool_allowed(name, &tool_context.allowed_tools)


### PR DESCRIPTION
## Task

[ORB-10916](https://orbit-cli.com/tasks/ORB-10916) — Enforce operator authorization for governed MCP tools

### Description

## Problem
MCP v1 dispatch selects `CapabilityEnforcement::DeferredForMcpV1`, so the shared authorization chokepoint is skipped. Governed operator-only tools remain advertised over MCP, including `orbit.command.exec` and workflow dispatch/run controls. Existing unit and wire-level tests confirm that an MCP session with no effective capabilities reaches domain execution instead of receiving `capability_denied`.

Because `orbit.command.exec` accepts arbitrary argv and an explicit working directory, this permits a connected MCP client to execute commands with the MCP server process's OS permissions despite the tool schema requiring operator capability.

## Why It Matters
This crosses Orbit's stated MCP capability boundary and can also cross a caller-side sandbox boundary when the MCP server runs in a less-restricted process context.

## Constraints / Notes
- Preserve the authorized operator path and the managed-run self-dispatch guard.
- Authorization must fail closed for empty, unverified, and agent-only sessions.
- If MCP v1 cannot establish a trusted operator grant, governed tools should be withheld or denied rather than dispatched.
- Evidence was confirmed at commit `7255976e512dd78eb3fd325ce96973c577685e78`.

### Acceptance Criteria

- An MCP call to orbit.command.exec, orbit.workflow.ship, or workflow run-control tools with empty or agent-only effective capabilities returns capability_denied before domain execution.
- A trusted MCP session carrying operator capability can still invoke the governed operator surface.
- MCP tools/list and call behavior do not imply access that the session cannot obtain; either governed tools are capability-filtered or calls fail closed consistently.
- Audit records for denied MCP calls retain the observed transport, effective capabilities, and denial outcome without executing the operation.
- Focused unit and wire-level MCP tests cover empty, agent, and operator capability cases and pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced the MCP v1 authorization deferral with session-only capability enforcement at the shared registry chokepoint. Governed MCP calls now fail closed for empty and agent-only grants and cannot inherit operator authority from the hosting process.
- Preserved the ordinary CLI/in-process capability resolution path and verified a trusted MCP session carrying operator capability still reaches the governed workflow surface.
- Added Core coverage for empty, agent, and operator MCP sessions, including denied/success audit status, observed transport, and exact effective capabilities.
- Added production-wire coverage proving advertised workflow controls and orbit.command.exec return capability_denied before execution; the command test verifies no marker file is created. Updated the existing MCP audit assertion to require a denied outcome.
- Expanded task context to the directly coupled authorization implementation and sibling dispatch tests required to implement and verify the fix.
Assessment: The authorization rule remains at the single Core registry boundary, so every registry-backed governed MCP tool shares one fail-closed path while ungoverned MCP behavior is unchanged.
Validation:
- cargo test -p orbit-core adapter::command::tests::dispatch::mcp_ (4 passed)
- cargo test -p orbit-core runtime::tests::authorization (6 passed)
- cargo test -p orbit-cli --test mcp_roundtrip (10 passed)
- make ci-fast (passed)
- make ci-lint (passed)
- git diff --check (passed)
Friction checkpoint: No qualifying friction encountered.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10916-6a825eb3`
- Behind base: 0
- Ahead of base: 1