### PR TITLE
Correct Linux sandbox security posture documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The constraints are the point — they're what keep agent-assisted code shippabl
 
 - **Conflict-aware parallel execution.** For `orbit run ship`, each agent run lands in its own git worktree per task, and the gate pipeline reserves task `context_files` as locks before fanning out, rejecting overlapping reservations up front instead of producing merge conflicts later (see [merge throughput chart](docs/assets/merge-throughput.png)). → [docs/design/activity-job/](docs/design/activity-job/)
 
-- **Sandboxed-by-default execution.** Dispatched agent CLIs run under an OS-level sandbox out of the box — FS access scoped to the worktree, network egress gated by per-activity policy. macOS uses `sandbox-exec`; Linux uses `linux-bwrap` through `/usr/bin/bwrap` after a capability probe. Windows and other unsupported platforms have no shipped OS-level backend, while in-process FS guards still cover HTTP tools. → [docs/design/policy-sandbox](docs/design/policy-sandbox/)
+- **Sandboxed-by-default execution.** Dispatched agent CLIs use a platform-specific OS boundary where supported. macOS uses `sandbox-exec`; Linux uses trusted `/usr/bin/bwrap` after a capability probe to enforce writes from the resolved policy. The Linux boundary leaves host filesystem reads and host network access available, so it does not provide worktree-only reads or policy-gated network egress. Windows and other unsupported platforms have no shipped OS-level backend, while in-process FS guards still cover HTTP tools. → [docs/design/policy-sandbox](docs/design/policy-sandbox/)
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,7 +64,7 @@ surface), enforcement differs sharply by platform:
 | Platform | What actually constrains a `backend: cli` agent's own syscalls |
 | --- | --- |
 | **macOS** | The `orbit-exec` seatbelt (`sandbox-exec`) profile is a **write** boundary, not a meaningful **read** boundary. The compiled profile emits a blanket `(allow file-read*)` for the whole filesystem, minus a small fixed credential denylist (`~/.ssh`, `~/.aws`, `~/.config/gh`, browser keychains/profile stores, system Keychains) — the `fsProfile`'s positive `read` globs are never emitted into the seatbelt at all (only `read` *deny* entries are). Combined with the unrestricted `(allow network*)` the profile also grants (agents need to reach provider APIs), a `backend: cli` agent's read scope is effectively "everything except the denylist," with an open network egress path — an exfiltration exposure. The credential denylist is also known-incomplete: it does not cover `~/.netrc`, `~/.git-credentials`, `~/.gnupg`, `~/.docker/config.json`, `~/.kube/config`, `~/.npmrc`, or cloud-CLI credential caches (e.g. `~/.aws/sso/cache`, `~/.config/gcloud`, `~/.azure`). Treat the macOS seatbelt's read scoping as **advisory, not a security boundary**, for `backend: cli` agents. Tracked in `ORB-10233`. |
-| **Linux** | **No OS-level sandbox exists for `backend: cli` agents at all.** Orbit's policy governs only the built-in tool surface; a CLI agent's own syscalls (arbitrary file reads/writes, network egress, process spawn) are constrained by nothing Orbit provides. On Linux, a `backend: cli` agent has the full filesystem and network access of the user running Orbit. Tracked in `ORB-10236`. |
+| **Linux** | Orbit runs `backend: cli` agents through trusted `/usr/bin/bwrap` after a namespace-and-mount capability probe. Bubblewrap read-only binds the host root and applies ordered writable mounts from the resolved `modify` policy, so writes are confined while host filesystem reads remain available. It uses `--share-net`, so host network access remains available and network egress is not policy-gated by this boundary. If `/usr/bin/bwrap` is absent or the probe fails, dispatch fails closed unless the executor explicitly sets `allow_fallback: true`; that escape hatch runs the agent without Linux write confinement. |
 
 Additionally, on macOS the seatbelt profile allows writes to each supported
 provider's state directory (`~/.claude`, `~/.codex`, `~/.gemini`, `~/.grok`)
@@ -83,12 +83,13 @@ internal service URL with embedded credentials — is forwarded unredacted to
 any spawned agent, including `backend: cli` agents with open network access.
 Tracked in `ORB-10235`.
 
-**Follow-up remediation** (filed from the pre-release security review,
+**Remaining follow-up remediation** (filed from the pre-release security review,
 `SECURITY-REVIEW-2026-07-15.md`, findings H2/M6/M7/M9): `ORB-10233` (macOS
 seatbelt positive read allowlist), `ORB-10234` (scope provider state-dir
-writes to the active provider), `ORB-10235` (env forwarding allowlist instead
-of denylist), `ORB-10236` (Linux provider-native sandbox for `backend: cli`
-agents).
+writes to the active provider), and `ORB-10235` (env forwarding allowlist
+instead of denylist). Linux write confinement is provided by the
+`linux-bwrap` backend described above; read and network isolation remain
+delegated.
 
 **Symlink resolution.** Policy rules are matched against the *real*
 filesystem location, not the requested path. Before matching, the requested

--- a/website/src/content/docs/concepts/policies.md
+++ b/website/src/content/docs/concepts/policies.md
@@ -11,7 +11,7 @@ Policy is a filesystem-scoping surface. It controls what an activity can read or
 
 An activity can select a named profile with `fsProfile`. If it omits the field, Orbit resolves an implicit unrestricted profile before global denies are applied.
 
-> **Platform support.** OS-level enforcement of `fsProfile` for spawned agent CLIs uses macOS `sandbox-exec` and is **macOS only** today. On Linux and Windows the policy still applies as in-process FS guards for Orbit's HTTP-tool builtins, but the spawned agent subprocess runs without OS-level isolation.
+> **Platform support.** Spawned agent CLIs use a platform-specific OS boundary where supported: macOS uses `sandbox-exec`, and Linux uses trusted `/usr/bin/bwrap` after a namespace-and-mount capability probe. The Linux boundary enforces writes from the resolved `fsProfile` while leaving host filesystem reads and host network access available; read rules and network-egress policy remain delegated. Linux dispatch fails closed when `/usr/bin/bwrap` is unavailable or the probe fails, unless the executor explicitly sets `allow_fallback: true`, which runs without Linux write confinement. On Windows and other unsupported platforms, the policy still applies as in-process FS guards for Orbit's HTTP-tool builtins, but no OS-level backend wraps the spawned agent subprocess.
 
 ## Shape
 

--- a/website/src/content/docs/reference/policy-format.md
+++ b/website/src/content/docs/reference/policy-format.md
@@ -54,4 +54,4 @@ spec:
   fsProfile: implementer
 ```
 
-> **Platform support.** OS-level enforcement of the resolved profile for spawned agent CLIs is **macOS only**, via `sandbox-exec`. On Linux and Windows the same policy YAML is parsed and applied to in-process FS-tool calls, but no kernel-level sandbox wraps the agent subprocess.
+> **Platform support.** Spawned agent CLIs use a platform-specific OS boundary where supported: macOS uses `sandbox-exec`, and Linux uses trusted `/usr/bin/bwrap` after a namespace-and-mount capability probe. The Linux boundary enforces writes from the resolved profile while leaving host filesystem reads and host network access available; read rules and network-egress policy remain delegated. Linux dispatch fails closed when `/usr/bin/bwrap` is unavailable or the probe fails, unless the executor explicitly sets `allow_fallback: true`, which runs without Linux write confinement. On Windows and other unsupported platforms, the same policy YAML is applied to in-process FS-tool calls, but no OS-level backend wraps the agent subprocess.


### PR DESCRIPTION
## Task

[ORB-10919](https://orbit-cli.com/tasks/ORB-10919) — Correct Linux sandbox security posture documentation

### Description

## Problem
Orbit now ships Linux Bubblewrap sandbox support, but `SECURITY.md` and public website pages still state that Linux agent subprocesses have no OS-level sandbox. Conversely, the README overstates the implemented boundary by claiming filesystem access is scoped to the worktree and network egress is policy-gated.

The current implementation provides fail-closed Bubblewrap write confinement: it read-only binds the host root, applies ordered writable mounts, uses private namespaces and minimal mounts, and retains the host network namespace with `--share-net`. Read policy and network-egress policy remain delegated.

## Why It Matters
Contradictory security documentation can lead operators to either disable useful protection or rely on read/network isolation that does not exist.

## Constraints / Notes
- Describe the current code and tested runtime behavior precisely.
- Distinguish write confinement from general filesystem-read isolation.
- State the explicit `allow_fallback` escape hatch and fail-closed default.
- Evidence was confirmed at commit `7255976e512dd78eb3fd325ce96973c577685e78`.

### Acceptance Criteria

- SECURITY.md states that Linux uses trusted /usr/bin/bwrap with a capability probe and fails closed unless allow_fallback is explicitly enabled.
- SECURITY.md accurately states that Linux enforces writes while leaving host filesystem reads and host network access available.
- README and website policy/reference pages use the same security-boundary language and do not claim worktree-only reads or policy-gated network egress.
- A repository-wide search finds no remaining public documentation claiming Linux has no OS-level sandbox.
- Documentation checks and relevant link tests pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Corrected SECURITY.md to document trusted /usr/bin/bwrap capability probing, fail-closed Linux dispatch by default, the explicit allow_fallback escape hatch, write confinement, host filesystem reads, and host network access.
- Aligned README.md and the website policy and policy-format pages with the same boundary, removing claims of worktree-only reads, policy-gated network egress, and Linux absence of an OS-level sandbox.
- Removed the completed Linux sandbox item from SECURITY.md's remaining follow-up list; no additional context selectors were needed.
Validation:
- ./scripts/generate-doc-indexes.sh --check — passed.
- website: npm run check — passed with 0 errors, warnings, or hints.
- website: npm run build — passed; 29 pages built.
- git diff --check — passed.
- Repository-wide public Markdown search found no remaining Linux no-sandbox claims.
Assessment: Documentation now matches the shipped Linux Bubblewrap write boundary and its delegated read/network behavior. The initial website check lacked installed npm dependencies; locked dependencies were installed locally with npm ci, after which check and build passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10919-6a826439`
- Behind base: 0
- Ahead of base: 1