### PR TITLE
task_pr_pipeline ignores task.crew and inherits workflow.default_crew

### DIFF
--- a/crates/orbit-core/src/runtime/engine/crew.rs
+++ b/crates/orbit-core/src/runtime/engine/crew.rs
@@ -3,7 +3,7 @@ use orbit_types::identity::{
     Crew, CrewAssignment, all_agent_families, infer_agent_family_from_model, resolve_crew,
 };
 use orbit_types::record::{CREW_DISCOVERY_SCHEMA_VERSION, CrewDiscoveryEntryV1, CrewDiscoveryV1};
-use orbit_types::task::Task;
+use orbit_types::task::{Task, is_valid_orb_task_id};
 use orbit_types::workflow::activity_job::ProviderSource;
 use serde::Serialize;
 use serde_json::Value;
@@ -197,10 +197,7 @@ impl OrbitRuntime {
             .and_then(Value::as_str)
             .map(str::trim)
             .filter(|value| !value.is_empty());
-        let task_crew = self
-            .task_id_from_run_input(input)?
-            .map(|task| task.crew)
-            .unwrap_or_default();
+        let task_crew = self.task_crew_from_run_input(input)?;
         self.resolve_crew_for_task(cli_override, task_crew.as_deref())
     }
 
@@ -312,26 +309,101 @@ impl OrbitRuntime {
         Ok(crew)
     }
 
+    /// Unanimous `task.crew` across every stored task named by the run/activity
+    /// input. Missing fixture ids are skipped so fake implementer ids do not
+    /// fail resolution. Distinct crews — including a mix of set and unset —
+    /// fail closed instead of inheriting `workflow.default_crew`.
+    fn task_crew_from_run_input(&self, input: &Value) -> Result<Option<String>, OrbitError> {
+        let mut agreed: Option<Option<String>> = None;
+        for task_id in task_ids_for_crew_resolution(input) {
+            if !is_valid_orb_task_id(&task_id) {
+                continue;
+            }
+            let Some(task) = self.stores().tasks().get_task(&task_id)? else {
+                continue;
+            };
+            let crew = normalized_task_crew(task.crew.as_deref());
+            match &agreed {
+                None => agreed = Some(crew),
+                Some(existing) if existing == &crew => {}
+                Some(existing) => {
+                    return Err(OrbitError::InvalidInput(mixed_bundle_crew_error(
+                        existing.as_deref(),
+                        crew.as_deref(),
+                    )));
+                }
+            }
+        }
+        Ok(agreed.flatten())
+    }
+
     fn task_id_from_run_input(&self, input: &Value) -> Result<Option<Task>, OrbitError> {
         if let Some(task_id) = singular_task_id_from_input(input)
-            && task_id.starts_with("ORB-")
+            && is_valid_orb_task_id(task_id)
+            && let Some(task) = self.stores().tasks().get_task(task_id)?
         {
-            return self.get_task(task_id).map(Some);
+            return Ok(Some(task));
         }
 
         for key in ["task_id", "taskId", "id"] {
-            let Some(task_id) = input.get(key).and_then(Value::as_str) else {
+            let Some(task_id) = input.get(key).and_then(Value::as_str).and_then(non_empty) else {
                 continue;
             };
-            let Some(task_id) = non_empty(task_id) else {
-                continue;
-            };
-            if !task_id.starts_with("ORB-") {
-                continue;
+            if is_valid_orb_task_id(task_id)
+                && let Some(task) = self.stores().tasks().get_task(task_id)?
+            {
+                return Ok(Some(task));
             }
-            return self.get_task(task_id).map(Some);
         }
         Ok(None)
+    }
+}
+
+/// Collect `task_id` / `task.id` / `task_ids` entries. Generic `id` is left to
+/// [`OrbitRuntime::task_id_from_run_input`] so a non-task `id` cannot pollute
+/// mixed-crew detection.
+fn task_ids_for_crew_resolution(input: &Value) -> Vec<String> {
+    let mut ids = Vec::new();
+    let mut push = |raw: Option<&str>| {
+        if let Some(id) = raw.and_then(non_empty)
+            && !ids.iter().any(|existing| existing == id)
+        {
+            ids.push(id.to_string());
+        }
+    };
+    push(input.get("task_id").and_then(Value::as_str));
+    push(
+        input
+            .get("task")
+            .and_then(|task| task.get("id"))
+            .and_then(Value::as_str),
+    );
+    if let Some(items) = input.get("task_ids").and_then(Value::as_array) {
+        for item in items {
+            push(item.as_str());
+        }
+    }
+    ids
+}
+
+fn normalized_task_crew(crew: Option<&str>) -> Option<String> {
+    crew.map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn mixed_bundle_crew_error(left: Option<&str>, right: Option<&str>) -> String {
+    format!(
+        "task bundle mixes crews {} and {}; split the bundle or assign one crew instead of inheriting workflow.default_crew",
+        format_bundle_crew(left),
+        format_bundle_crew(right),
+    )
+}
+
+fn format_bundle_crew(crew: Option<&str>) -> String {
+    match crew {
+        Some(name) => format!("`{name}`"),
+        None => "the workspace default (no task.crew)".to_string(),
     }
 }
 

--- a/crates/orbit-core/src/runtime/engine/tests/crew.rs
+++ b/crates/orbit-core/src/runtime/engine/tests/crew.rs
@@ -3,7 +3,9 @@
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use chrono::Utc;
-use orbit_types::workflow::activity_job::ProviderSource;
+use orbit_engine::RuntimeHost;
+use orbit_store::maintenance::task_registry::{TaskRegistryStore, task_registry_path};
+use orbit_types::workflow::activity_job::{Provider, ProviderSource};
 use serde_json::json;
 use tempfile::{TempDir, tempdir};
 
@@ -85,15 +87,27 @@ fn crew_discovery_projects_the_open_runtime_configuration() {
 }
 
 fn add_task_with_crew(runtime: &OrbitRuntime, crew: &str) -> String {
+    add_task(runtime, Some(crew))
+}
+
+fn add_task(runtime: &OrbitRuntime, crew: Option<&str>) -> String {
     runtime
         .add_task(TaskAddParams {
-            title: format!("{crew} task"),
+            title: format!("{} task", crew.unwrap_or("default")),
             description: "Task fixture for crew resolution.".to_string(),
-            crew: Some(crew.to_string()),
+            crew: crew.map(ToOwned::to_owned),
             ..Default::default()
         })
         .expect("add task")
         .id
+}
+
+fn try_set_task_prefix(runtime: &OrbitRuntime, prefix: &str) {
+    let registry = TaskRegistryStore::open(&task_registry_path(&runtime.global_root()))
+        .expect("open task registry");
+    // Prefix is immutable after the first allocation. Tests that already
+    // created a task keep the host prefix; the lookup path is prefix-agnostic.
+    let _ = registry.set_task_prefix(prefix);
 }
 
 #[test]
@@ -148,19 +162,148 @@ fn explicit_crew_override_wins_over_singleton_task_ids_task_crew() {
 }
 
 #[test]
-fn multi_task_ids_without_override_falls_back_to_default_crew() {
+fn custom_prefix_task_ids_resolve_task_crew() {
+    let (_root, runtime) = runtime_with_named_crews();
+    try_set_task_prefix(&runtime, "DAN");
+    let task_id = add_task_with_crew(&runtime, "beta");
+
+    let crew = runtime
+        .resolve_crew_for_run_input(&json!({ "task_ids": [task_id] }))
+        .expect("resolve crew");
+
+    assert_eq!(crew.name, "beta");
+    assert_eq!(crew.assignment.model, "beta-model");
+}
+
+#[test]
+fn missing_task_ids_fall_back_to_default_crew() {
+    let (_root, runtime) = runtime_with_named_crews();
+
+    let crew = runtime
+        .resolve_crew_for_run_input(&json!({
+            "task_ids": ["DAN-10002", "T-crew"]
+        }))
+        .expect("missing fixture ids must not fail crew resolution");
+
+    assert_eq!(crew.name, "primary");
+    assert_eq!(crew.assignment.model, "default-model");
+}
+
+#[test]
+fn multi_task_ids_with_the_same_crew_use_that_crew() {
+    let (_root, runtime) = runtime_with_named_crews();
+    let first = add_task_with_crew(&runtime, "beta");
+    let second = add_task_with_crew(&runtime, "beta");
+
+    let crew = runtime
+        .resolve_crew_for_run_input(&json!({
+            "task_ids": [first, second]
+        }))
+        .expect("unanimous task crew");
+
+    assert_eq!(crew.name, "beta");
+    assert_eq!(crew.assignment.model, "beta-model");
+}
+
+#[test]
+fn multi_task_ids_without_crew_fall_back_to_default_crew() {
+    let (_root, runtime) = runtime_with_named_crews();
+    let first = add_task(&runtime, None);
+    let second = add_task(&runtime, None);
+
+    let crew = runtime
+        .resolve_crew_for_run_input(&json!({
+            "task_ids": [first, second]
+        }))
+        .expect("unset task crews use the workspace default");
+
+    assert_eq!(crew.name, "primary");
+    assert_eq!(crew.assignment.model, "default-model");
+}
+
+#[test]
+fn mixed_task_crews_fail_closed_instead_of_inheriting_default() {
     let (_root, runtime) = runtime_with_named_crews();
     let beta_task_id = add_task_with_crew(&runtime, "beta");
     let gamma_task_id = add_task_with_crew(&runtime, "gamma");
 
-    let crew = runtime
+    let error = runtime
         .resolve_crew_for_run_input(&json!({
             "task_ids": [beta_task_id, gamma_task_id]
         }))
-        .expect("resolve crew");
+        .expect_err("mixed crews must fail closed");
 
-    assert_eq!(crew.name, "primary");
-    assert_eq!(crew.assignment.model, "default-model");
+    let message = error.to_string();
+    assert!(
+        message.contains("mixes crews") && message.contains("workflow.default_crew"),
+        "unexpected mixed-crew error: {message}"
+    );
+}
+
+#[test]
+fn mixed_set_and_unset_task_crews_fail_closed() {
+    let (_root, runtime) = runtime_with_named_crews();
+    let assigned = add_task_with_crew(&runtime, "beta");
+    let unset = add_task(&runtime, None);
+
+    let error = runtime
+        .resolve_crew_for_run_input(&json!({
+            "task_ids": [assigned, unset]
+        }))
+        .expect_err("set vs unset is a mixed bundle");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("mixes crews"),
+        "unexpected mixed-crew error: {message}"
+    );
+}
+
+#[test]
+fn implementer_dispatch_uses_task_crew_not_default_crew() {
+    let (_root, runtime) = runtime_with_named_crews();
+    try_set_task_prefix(&runtime, "DAN");
+    let task_id = add_task_with_crew(&runtime, "beta");
+    let run_input = json!({ "task_ids": [task_id] });
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run(
+            "task_pr_pipeline",
+            1,
+            Utc::now(),
+            Some(run_input.clone()),
+            None,
+        )
+        .expect("insert implement_one parent run");
+
+    let persisted = runtime
+        .record_run_crew_from_input(&run.run_id, &run_input)
+        .expect("persist resolved crew");
+    let stored = runtime.show_job_run(&run.run_id).expect("show child run");
+    assert_eq!(persisted.name, "beta");
+    assert_eq!(stored.resolved_crew.as_deref(), Some("beta"));
+    assert_eq!(stored.crew_model.as_deref(), Some("beta-model"));
+
+    // implement_one has no activity `crew`; dispatch re-resolves from run input.
+    let config = RuntimeHost::agent_crew_config_for_input(&runtime, &run_input)
+        .expect("implementer dispatch")
+        .expect("crew config");
+    assert_eq!(config.model.as_deref(), Some("beta-model"));
+    assert_eq!(config.provider, Some(Provider::Codex));
+    assert_ne!(config.model.as_deref(), Some("default-model"));
+}
+
+#[test]
+fn implementer_dispatch_without_task_crew_uses_default_crew() {
+    let (_root, runtime) = runtime_with_named_crews();
+    let task_id = add_task(&runtime, None);
+    let config =
+        RuntimeHost::agent_crew_config_for_input(&runtime, &json!({ "task_ids": [task_id] }))
+            .expect("implementer dispatch")
+            .expect("crew config");
+    assert_eq!(config.model.as_deref(), Some("default-model"));
+    assert_eq!(config.provider, Some(Provider::Codex));
 }
 
 /// Table-driven proof of the crew-selection precedence (ORB-10091, contract §3)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -192,7 +192,7 @@ An **unrecognized `[crews.<name>].provider` value** is the one non-fatal case: i
 4. `CONSTELLATION_DEFAULT_PROVIDER` if set (environment tier), otherwise
 5. the canonical `claude` system-default crew.
 
-This means you can mix-and-match in a single ship run: route a tricky refactor to `claude` while routing routine cleanups to `codex` — both go through the same `orbit run ship` invocation, each picking its own crew at dispatch time.
+This means you can mix-and-match in a single ship run: route a tricky refactor to `claude` while routing routine cleanups to `codex` — both go through the same `orbit run ship` invocation, each picking its own crew at dispatch time. `orbit run ship` fans singleton child runs, so each task's `crew` is recorded on that child (`orbit run show` → `resolved_crew`) and used by `implement_one`. A single child pipeline whose `task_ids` name more than one distinct crew (or mix set and unset crews) fails closed rather than inheriting `[workflow].default_crew`.
 
 ### Setting `task.crew`
 


### PR DESCRIPTION
## Task

[ORB-10920](https://orbit-cli.com/tasks/ORB-10920) — task_pr_pipeline ignores task.crew and inherits workflow.default_crew

### Description

## Problem
`orbit run auto` / `orbit run ship` / `task_gate_pipeline` → `task_pr_pipeline` do not honor a task's stored `crew` field. `implement_one` (`activity:agent_implement`) inherits the parent run's `resolved_crew`, which is `workflow.default_crew`.

Reproduced on a Mac first-run of dsearch (`ws_dsearch`, 2026-08-17):
- Task DAN-10002 had `crew: luna` (Codex / `gpt-5.6-luna`) persisted in the store.
- `jrun-20260817-0135-4` (`task_pr_pipeline`) still reported `resolved_crew: custom`, `crew_model: opus`, and invoked `/usr/bin/sandbox-exec … claude --model opus`.
- `task_gate_pipeline` `invoke_and_wait` forwards only `task_ids`, `base_branch`, `base_sync`, `landing_branch`, `auto_push`. It does not pass the task crew. `orbit run ship` has no `--crew` flag.
- Docs and `orbit config keys` say the opposite: a task's `crew` selects the executor; `workflow.default_crew` is only for tasks that do not declare one.

Same run then failed in ~800ms with Claude `Failed to authenticate: OAuth session expired and could not be refreshed`. Re-login could not help because Claude was the wrong provider.

## Why It Matters
Operators set `crew` on a task (dashboard or `orbit.task.update`) and the UI/store confirm it. Auto-ship silently runs the default crew instead. On a Mac whose default crew is Claude/opus, that blocks the entire workspace auto/gate/PR chain even when a working Codex/Grok crew is assigned. The workaround (override workspace `workflow.default_crew`) is global to the workspace and hides the real contract.

## Constraints / Notes
- Fix the runtime resolution so `implement_one` (and any other agent step that should execute the task) uses `task.crew` when set, falling back to `workflow.default_crew` only when the task has no crew.
- `invoke_and_wait` children must not pin the parent's default crew over the task's crew. If a bundle contains mixed crews, fail closed or split — do not silently pick the parent default.
- `orbit run show` / the run record's `resolved_crew` and the implementer argv provider/model must match the task crew.
- Tests must be deterministic (fake executors / recorded argv). Do not require a live Claude or Codex login.
- Do not fix this by documenting the default_crew workaround as the intended contract.
- Evidence runs: `jrun-20260817-0135-4`, also `jrun-20260817-0130-4` and `jrun-20260817-0128-4` (same ignore + Claude OAuth). Mac dsearch friction F2026-08-002.
- Rollback: revert the resolution change; existing tasks keep their stored `crew` field.

### Acceptance Criteria

- A task with `crew` set to a non-default crew, shipped via `orbit run ship` / `task_gate_pipeline` / `task_pr_pipeline`, produces an `implement_one` invocation whose `resolved_crew` (and provider/model argv) match that task crew — not `workflow.default_crew`.
- `orbit run show` on that child run reports `resolved_crew` equal to the task's `crew`.
- A task with no `crew` still uses `workflow.default_crew` (existing default behavior preserved).
- A deterministic unit/integration test covers the override: task crew X, default crew Y, assert implementer dispatch uses X. No live provider login.
- Docs/`orbit config keys` remain true without a workspace `default_crew` workaround being required.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `resolve_crew_for_run_input` now loads `task.crew` from every stored `task_id` / `task.id` / `task_ids` entry, regardless of host prefix (the previous `ORB-` filter dropped `DAN-*` and other allocated ids, so `task_pr_pipeline` / `implement_one` inherited `workflow.default_crew`).
- Unanimous task crews win; all-unset still uses `workflow.default_crew`; mixed crews (including set vs unset) fail closed instead of silently taking the workspace default.
- Missing or malformed fixture ids are skipped so fake implementer inputs do not fail resolution.
- Explicit run-input `crew` still outranks task crews. `invoke_and_wait` did not need a pin: children already re-resolve from their own `task_ids`.
- Tests: custom-prefix singleton, unanimous multi, unset default, mixed fail-closed, and implementer dispatch (`agent_crew_config_for_input` + persisted `resolved_crew`) with task crew X vs default Y. No live provider login.
- `docs/CONFIG.md` records mixed-bundle fail-closed; docs still say a task's `crew` selects the executor.
Assessment: scoped to the run-crew seam that both `orbit run show` and `implement_one` already use. `make ci-fast` and `cargo clippy -p orbit-core --lib --tests -- -D warnings` passed. `cargo test -p orbit-core --lib runtime::engine::tests::crew`: 14 passed.
Strategic decisions: fail closed on mixed bundles rather than split inside one child run; `orbit run ship` already fans singleton children, so mixed crews still each get their own `resolved_crew`.
Design weaknesses / risks:
- Severity: low. A hand-invoked `task_pr_pipeline` with mixed `task_ids` now errors at run start. Mitigation: split the bundle or assign one crew.
Recommended follow-ups: none for this bug. Existing dsearch friction F2026-08-002 is the incident this fixes; not re-filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10920-6a826812`
- Behind base: 0
- Ahead of base: 1