### PR TITLE
Stop doctor from recommending orbit init --refresh-defaults

### DIFF
--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -807,8 +807,5 @@ fn stale_shipped_activity_default_names_the_refresh_remediation() {
     assert_eq!(row.status, WorkspaceDoctorStatus::Error, "{row:?}");
     assert!(row.message.contains("stale"), "{}", row.message);
     assert!(row.message.contains("older release"), "{}", row.message);
-    assert_eq!(
-        row.remediation.as_deref(),
-        Some("Run `orbit init --refresh-defaults`.")
-    );
+    assert_eq!(row.remediation.as_deref(), Some("Run `orbit init`."));
 }

--- a/crates/orbit-core/src/application/artifact_health.rs
+++ b/crates/orbit-core/src/application/artifact_health.rs
@@ -113,6 +113,14 @@ impl ArtifactKind {
     }
 }
 
+/// Command that refreshes the catalog containing this artifact kind.
+fn init_command(kind: ArtifactKind) -> &'static str {
+    match kind {
+        ArtifactKind::Skill | ArtifactKind::Job | ArtifactKind::Activity => "orbit init",
+        ArtifactKind::AutoTask | ArtifactKind::Routine => "orbit workspace init",
+    }
+}
+
 /// Why an artifact is not healthy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ArtifactCondition {
@@ -357,35 +365,36 @@ fn diagnose_catalog(runtime: &OrbitRuntime, catalog: &ManagedCatalog) -> Artifac
     }
 
     let manifest_path = catalog.dir.join(MANAGED_ASSET_MANIFEST_FILE);
-    let manifest = match load_managed_asset_manifest(
-        &manifest_path,
-        kind.asset_kind(),
-        kind.layout(),
-    ) {
-        Ok(manifest) => manifest,
-        Err(error) => {
-            // An unreadable manifest costs provenance for the whole kind, so
-            // say so instead of silently reporting every artifact as
-            // user-authored.
-            findings.push(ArtifactFinding {
-                kind,
-                name: MANAGED_ASSET_MANIFEST_FILE.to_string(),
-                path: manifest_path,
-                condition: ArtifactCondition::Faulty,
-                provenance: ArtifactProvenance::OrbitWritten,
-                detail: format!("managed {} manifest is unreadable: {error}", kind.singular()),
-                remediation: format!(
-                    "Repair or move aside the {} manifest, then run `orbit init --refresh-defaults`.",
-                    kind.singular()
-                ),
-            });
-            return ArtifactHealth {
-                kind,
-                scanned: 0,
-                findings,
-            };
-        }
-    };
+    let manifest =
+        match load_managed_asset_manifest(&manifest_path, kind.asset_kind(), kind.layout()) {
+            Ok(manifest) => manifest,
+            Err(error) => {
+                // An unreadable manifest costs provenance for the whole kind, so
+                // say so instead of silently reporting every artifact as
+                // user-authored.
+                findings.push(ArtifactFinding {
+                    kind,
+                    name: MANAGED_ASSET_MANIFEST_FILE.to_string(),
+                    path: manifest_path,
+                    condition: ArtifactCondition::Faulty,
+                    provenance: ArtifactProvenance::OrbitWritten,
+                    detail: format!(
+                        "managed {} manifest is unreadable: {error}",
+                        kind.singular()
+                    ),
+                    remediation: format!(
+                        "Repair or move aside the {} manifest, then run `{}`.",
+                        kind.singular(),
+                        init_command(kind)
+                    ),
+                });
+                return ArtifactHealth {
+                    kind,
+                    scanned: 0,
+                    findings,
+                };
+            }
+        };
     let tracked: BTreeMap<String, String> = manifest
         .as_ref()
         .map(|manifest| manifest.assets.clone())
@@ -448,7 +457,7 @@ fn diagnose_catalog(runtime: &OrbitRuntime, catalog: &ManagedCatalog) -> Artifac
                         "`{name}` is a stale shipped default: an Orbit-written copy of an older \
                          release that has drifted from the content this binary ships"
                     ),
-                    remediation: "Run `orbit init --refresh-defaults`.".to_string(),
+                    remediation: format!("Run `{}`.", init_command(kind)),
                 }),
                 // Edited after Orbit wrote it: intentional local authorship,
                 // not staleness. Refreshing would discard the edit, so this is
@@ -468,8 +477,9 @@ fn diagnose_catalog(runtime: &OrbitRuntime, catalog: &ManagedCatalog) -> Artifac
                         path.display()
                     ),
                     remediation: format!(
-                        "Move or rename `{}`, then run `orbit init --refresh-defaults` to install the bundled default.",
-                        path.display()
+                        "Move or rename `{}`, then run `{}` to install the bundled default.",
+                        path.display(),
+                        init_command(kind)
                     ),
                 }),
                 None => {}
@@ -505,11 +515,12 @@ fn finish_catalog_health(
         } else if let Some(command) = fault.repair_command {
             format!("Run `{command}`.")
         } else if stale_shipped_default {
-            "Run `orbit init --refresh-defaults`.".to_string()
+            format!("Run `{}`.", init_command(kind))
         } else if provenance == ArtifactProvenance::OrbitWritten {
             format!(
-                "A shipped {} default failed to load — reinstall or upgrade orbit, then run `orbit init --refresh-defaults`.",
-                kind.singular()
+                "A shipped {} default failed to load — reinstall or upgrade orbit, then run `{}`.",
+                kind.singular(),
+                init_command(kind)
             )
         } else {
             format!(

--- a/crates/orbit-core/src/application/tests/managed_assets.rs
+++ b/crates/orbit-core/src/application/tests/managed_assets.rs
@@ -760,9 +760,7 @@ mod artifacts {
         assert_eq!(finding.provenance, ArtifactProvenance::OrbitWritten);
         assert!(finding.is_unloadable_shipped_default());
         assert!(
-            finding
-                .remediation
-                .contains("orbit init --refresh-defaults"),
+            finding.remediation.contains("orbit init"),
             "{}",
             finding.remediation
         );
@@ -800,9 +798,7 @@ mod artifacts {
         assert_eq!(finding.condition, ArtifactCondition::Stale);
         assert_eq!(finding.provenance, ArtifactProvenance::OrbitWritten);
         assert!(
-            finding
-                .remediation
-                .contains("orbit init --refresh-defaults"),
+            finding.remediation.contains("orbit workspace init"),
             "{}",
             finding.remediation
         );


### PR DESCRIPTION
## Task

[ORB-10923](https://orbit-cli.com/tasks/ORB-10923) — Stop doctor from recommending orbit init --refresh-defaults

### Description

## Problem
`orbit doctor` tells the operator to run `orbit init --refresh-defaults` for stale, colliding, or unloadable shipped defaults. That flag is not on `orbit init`.

`InitCommand` exposes `--force`, `--non-interactive`, `--host-name`, and `--task-prefix` only. Internally it always sets `refresh_defaults: true` when calling `init_global`, so a plain `orbit init` already rewrites managed defaults (it still will not overwrite an existing `config.toml`). `orbit workspace init --refresh-defaults` exists but is a hidden no-op whose clap help says defaults are always refreshed on init.

The lie is concentrated in `artifact_health.rs` remediations and pinned by `orbit-cmd` doctor tests and `managed_assets` tests. CHANGELOG and a historical design note still mention the same phantom flag; those are not operator-facing doctor output.

## Why It Matters
Doctor's job is to name a command that works. Following the current remediation produces a clap unknown-argument error, so the operator is stuck on a stale or unloadable shipped default.

## Constraints / Notes
- Do not restore `--refresh-defaults` as a public `orbit init` flag. Refresh is already the explicit-init default.
- Pick the command that actually rewrites that artifact class: global catalogs (`skills`, `jobs`, `activities`) via `orbit init`; workspace catalogs (auto-tasks, and routines if they live under the checkout) via `orbit workspace init`.
- Leave historical CHANGELOG wording alone unless a current docs page still recommends the flag to operators.
- `orbit` is PR-gated: implement on a dedicated worktree from `agent-main`.

### Acceptance Criteria

- No doctor remediation, test assertion, or operator-facing string still contains `orbit init --refresh-defaults`.
- `orbit init --help` and `orbit workspace init --help` still do not advertise `--refresh-defaults` as a public flag. Do not reintroduce it.
- Stale or unloadable shipped defaults that live under the global root (`~/.orbit/skills`, `resources/jobs`, `resources/activities`) remediate with `orbit init`.
- Stale or unloadable shipped defaults that live in the workspace checkout (auto-tasks, and routines if they are workspace-local) remediate with `orbit workspace init`.
- Existing doctor and managed-asset tests that pin the remediation string are updated and pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added artifact-kind-aware remediation routing: global skills/jobs/activities recommend `orbit init`; workspace auto-tasks/routines recommend `orbit workspace init`.
- Updated doctor and managed-asset assertions to pin the working commands; public help remains free of `--refresh-defaults`.
Validation:
- `cargo test -p orbit-core application::tests::managed_assets` (16 passed)
- `cargo test -p orbit-cmd tests::doctor` (23 passed)
- `cargo run -p orbit-cli -- init --help` and `cargo run -p orbit-cli -- workspace init --help` verified no `--refresh-defaults` flag.
- `make ci-fast` passed.
- `make ci-lint` passed.
- Repository search found the phantom flag only in the historical CHANGELOG and design decision note, which the task explicitly leaves unchanged.
Assessment: Small, centralized routing change with coverage for global and workspace-local remediation paths; no new dependencies or public flags.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10923-6a82700b`
- Behind base: 0
- Ahead of base: 1