### PR TITLE
Global skills catalog is deleted on every runtime open when the global root doubles as the workspace root

### DIFF
--- a/crates/orbit-core/src/bootstrap/init.rs
+++ b/crates/orbit-core/src/bootstrap/init.rs
@@ -99,7 +99,7 @@ pub(crate) fn ensure_orbit_root_initialized(
             ..Default::default()
         },
     )?;
-    prepare_workspace_root_layout(workspace_root)?;
+    prepare_workspace_root_layout(workspace_root, global_root)?;
     if ResolvedConfig::load(&ConfigRoots::global_only(global_root))?.scoring_enabled {
         seed_scoreboard_templates(workspace_root)?;
     }
@@ -136,10 +136,21 @@ pub fn init_workspace_at_root(
     if options.force {
         remove_path_if_exists(&orbit_root)?;
     }
-    let layout = if options.global_only {
-        prepare_global_root_layout(&orbit_root)?
+    // The workspace branch needs its global root before laying out the
+    // workspace: skill reaping must know which catalog is the live global one.
+    let workspace_global_root = if options.global_only {
+        None
     } else {
-        prepare_workspace_root_layout(&orbit_root)?
+        Some(
+            options
+                .global_root_override
+                .clone()
+                .map_or_else(resolve_global_root, Ok::<PathBuf, OrbitError>)?,
+        )
+    };
+    let layout = match workspace_global_root.as_deref() {
+        None => prepare_global_root_layout(&orbit_root)?,
+        Some(global_root) => prepare_workspace_root_layout(&orbit_root, global_root)?,
     };
     let skills_root = if options.global_only {
         global_skills_dir(&orbit_root)
@@ -187,82 +198,83 @@ pub fn init_workspace_at_root(
         refreshed_default_executors,
         refreshed_default_policies,
         scoring_enabled,
-    ) = if options.global_only {
-        let executor_store = global_executor_def_store(layout.executors_dir.clone());
-        let policy_store = global_policy_def_store(layout.policies_dir.clone());
-        let refreshed_default_executors =
-            seed_default_executors(executor_store.as_ref(), overwrite)?;
-        let refreshed_default_policies = seed_default_policies(policy_store.as_ref(), overwrite)?;
-        let activity_reconciliation = seed_default_activities(&layout.activities_dir, overwrite)?;
-        let job_reconciliation = seed_default_jobs(&layout.jobs_dir, overwrite)?;
-        let mut managed_asset_warnings = std::mem::take(&mut skill_asset_warnings);
-        managed_asset_warnings.extend(activity_reconciliation.warnings);
-        managed_asset_warnings.extend(job_reconciliation.warnings);
-        (
-            activity_reconciliation.refreshed,
-            activity_reconciliation.retired,
-            job_reconciliation.refreshed,
-            job_reconciliation.retired,
-            managed_asset_warnings,
-            refreshed_default_executors,
-            refreshed_default_policies,
-            false,
-        )
-    } else {
-        let global_root = options
-            .global_root_override
-            .clone()
-            .map_or_else(resolve_global_root, Ok::<PathBuf, OrbitError>)?;
-        let global_result = init_workspace_at_root(
-            &global_root,
-            InitOptions {
-                refresh_defaults: options.refresh_defaults,
-                global_only: true,
-                link_global_skills: options.link_global_skills || options.refresh_defaults,
-                config_seed: options.config_seed.clone(),
-                ..Default::default()
-            },
-        )?;
-        refreshed_skill_files = global_result.refreshed_skill_files;
-        created_skills_symlink = global_result.created_skills_symlink;
-        // Routines and auto-tasks are workspace-scoped, so their managed-asset
-        // reconciliation happens here rather than in the global branch; fold
-        // their warnings in alongside the global (skill/activity/job) ones.
-        let mut managed_asset_warnings = global_result.managed_asset_warnings;
-        // Routines are workspace-authored (`.orbit/routines/`, no global
-        // directory), so defaults seed here rather than in the global branch.
-        // Host identity is owned by higher-level composition and injected;
-        // Core never opens host.toml or falls back to an OS hostname.
-        if let Some(host_id) = options.routine_host_id.as_deref() {
-            let reconciliation = seed_default_routines(
-                &orbit_root.join("routines"),
-                host_id,
-                workspace_slug_from_orbit_root(&orbit_root).as_deref(),
-                // Routine definitions become workspace-authored after
-                // seeding. Refresh global defaults without overwriting
-                // cadence, host pins, policy, or enabled choices here;
-                // destructive `force` already recreated the root.
-                options.force,
-            )?;
-            refreshed_default_routines = reconciliation.refreshed;
-            managed_asset_warnings.extend(reconciliation.warnings);
+    ) = match workspace_global_root {
+        None => {
+            let executor_store = global_executor_def_store(layout.executors_dir.clone());
+            let policy_store = global_policy_def_store(layout.policies_dir.clone());
+            let refreshed_default_executors =
+                seed_default_executors(executor_store.as_ref(), overwrite)?;
+            let refreshed_default_policies =
+                seed_default_policies(policy_store.as_ref(), overwrite)?;
+            let activity_reconciliation =
+                seed_default_activities(&layout.activities_dir, overwrite)?;
+            let job_reconciliation = seed_default_jobs(&layout.jobs_dir, overwrite)?;
+            let mut managed_asset_warnings = std::mem::take(&mut skill_asset_warnings);
+            managed_asset_warnings.extend(activity_reconciliation.warnings);
+            managed_asset_warnings.extend(job_reconciliation.warnings);
+            (
+                activity_reconciliation.refreshed,
+                activity_reconciliation.retired,
+                job_reconciliation.refreshed,
+                job_reconciliation.retired,
+                managed_asset_warnings,
+                refreshed_default_executors,
+                refreshed_default_policies,
+                false,
+            )
         }
-        // Auto-task definitions are workspace-authored after seeding. Never
-        // refresh an existing file: `workspace init --force` reconciles
-        // registration and must not overwrite an operator's definition.
-        let auto_task_reconciliation = seed_default_auto_tasks(&orbit_root)?;
-        seeded_default_auto_tasks = auto_task_reconciliation.refreshed;
-        managed_asset_warnings.extend(auto_task_reconciliation.warnings);
-        (
-            global_result.refreshed_default_activities,
-            global_result.retired_default_activities,
-            global_result.refreshed_default_jobs,
-            global_result.retired_default_jobs,
-            managed_asset_warnings,
-            global_result.refreshed_default_executors,
-            global_result.refreshed_default_policies,
-            ResolvedConfig::load(&ConfigRoots::new(&global_root, &orbit_root))?.scoring_enabled,
-        )
+        Some(global_root) => {
+            let global_result = init_workspace_at_root(
+                &global_root,
+                InitOptions {
+                    refresh_defaults: options.refresh_defaults,
+                    global_only: true,
+                    link_global_skills: options.link_global_skills || options.refresh_defaults,
+                    config_seed: options.config_seed.clone(),
+                    ..Default::default()
+                },
+            )?;
+            refreshed_skill_files = global_result.refreshed_skill_files;
+            created_skills_symlink = global_result.created_skills_symlink;
+            // Routines and auto-tasks are workspace-scoped, so their managed-asset
+            // reconciliation happens here rather than in the global branch; fold
+            // their warnings in alongside the global (skill/activity/job) ones.
+            let mut managed_asset_warnings = global_result.managed_asset_warnings;
+            // Routines are workspace-authored (`.orbit/routines/`, no global
+            // directory), so defaults seed here rather than in the global branch.
+            // Host identity is owned by higher-level composition and injected;
+            // Core never opens host.toml or falls back to an OS hostname.
+            if let Some(host_id) = options.routine_host_id.as_deref() {
+                let reconciliation = seed_default_routines(
+                    &orbit_root.join("routines"),
+                    host_id,
+                    workspace_slug_from_orbit_root(&orbit_root).as_deref(),
+                    // Routine definitions become workspace-authored after
+                    // seeding. Refresh global defaults without overwriting
+                    // cadence, host pins, policy, or enabled choices here;
+                    // destructive `force` already recreated the root.
+                    options.force,
+                )?;
+                refreshed_default_routines = reconciliation.refreshed;
+                managed_asset_warnings.extend(reconciliation.warnings);
+            }
+            // Auto-task definitions are workspace-authored after seeding. Never
+            // refresh an existing file: `workspace init --force` reconciles
+            // registration and must not overwrite an operator's definition.
+            let auto_task_reconciliation = seed_default_auto_tasks(&orbit_root)?;
+            seeded_default_auto_tasks = auto_task_reconciliation.refreshed;
+            managed_asset_warnings.extend(auto_task_reconciliation.warnings);
+            (
+                global_result.refreshed_default_activities,
+                global_result.retired_default_activities,
+                global_result.refreshed_default_jobs,
+                global_result.retired_default_jobs,
+                managed_asset_warnings,
+                global_result.refreshed_default_executors,
+                global_result.refreshed_default_policies,
+                ResolvedConfig::load(&ConfigRoots::new(&global_root, &orbit_root))?.scoring_enabled,
+            )
+        }
     };
 
     if scoring_enabled {
@@ -353,11 +365,14 @@ fn seed_scoreboard_templates(orbit_root: &Path) -> Result<(), OrbitError> {
     Ok(())
 }
 
-fn prepare_workspace_root_layout(orbit_root: &Path) -> Result<WorkspacePaths, OrbitError> {
+fn prepare_workspace_root_layout(
+    orbit_root: &Path,
+    global_root: &Path,
+) -> Result<WorkspacePaths, OrbitError> {
     fs::create_dir_all(orbit_root).map_err(|e| OrbitError::Io(e.to_string()))?;
     let layout = orbit_layout_paths(orbit_root);
     ensure_workspace_dirs(&layout)?;
-    remove_workspace_seeded_default_skills(orbit_root, &layout)?;
+    remove_workspace_seeded_default_skills(orbit_root, &layout, global_root)?;
     Ok(layout)
 }
 
@@ -395,12 +410,24 @@ fn ensure_workspace_dirs(paths: &WorkspacePaths) -> Result<(), OrbitError> {
     Ok(())
 }
 
+/// Reap skill trees left behind under a workspace root by older versions that
+/// seeded them there.
+///
+/// `global_root` names the root that owns the live catalog. It is normally a
+/// different path from `orbit_root`, but a `--root` scratch root makes one
+/// directory serve as both, and then `<root>/skills` *is* the global catalog
+/// seeded moments earlier in the same runtime open. Reaping it there deleted
+/// every shipped skill on the first command after init, so the live catalog is
+/// excluded from the candidate list. [ORB-10926]
 fn remove_workspace_seeded_default_skills(
     orbit_root: &Path,
     paths: &WorkspacePaths,
+    global_root: &Path,
 ) -> Result<(), OrbitError> {
-    for skills_dir in [&paths.skills_dir, &orbit_root.join("skills")] {
-        if !skills_dir.exists() {
+    let live_catalog = global_skills_dir(global_root);
+    for skills_dir in [paths.skills_dir.clone(), orbit_root.join("skills")] {
+        let skills_dir = skills_dir.as_path();
+        if !skills_dir.exists() || is_same_dir(skills_dir, &live_catalog) {
             continue;
         }
 
@@ -415,16 +442,28 @@ fn remove_workspace_seeded_default_skills(
             remove_path_if_exists(&skills_dir.join(skill_id))?;
         }
 
-        // Skills are only ever seeded into the *global* root, so a managed
-        // manifest here describes skill trees that were just removed. Drop it
-        // once nothing else remains, otherwise it would keep an otherwise-empty
-        // legacy workspace skills directory alive forever.
+        // Skills are never seeded into a workspace-only skills directory, so a
+        // managed manifest here describes skill trees that were just removed.
+        // Drop it once nothing else remains, otherwise it would keep an
+        // otherwise-empty legacy workspace skills directory alive forever.
         if directory_holds_only(skills_dir, MANAGED_ASSET_MANIFEST_FILE)? {
             remove_path_if_exists(&skills_dir.join(MANAGED_ASSET_MANIFEST_FILE))?;
         }
         remove_empty_dir(skills_dir)?;
     }
     Ok(())
+}
+
+/// Whether two paths name the same existing directory. Falls back to a literal
+/// comparison when either side cannot be canonicalized.
+fn is_same_dir(left: &Path, right: &Path) -> bool {
+    if left == right {
+        return true;
+    }
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
 }
 
 /// Whether `dir` contains exactly one entry, named `file_name`.
@@ -1023,6 +1062,50 @@ mod tests {
                 .exists()
         );
         assert_skill_link_exists(home.path().join(".claude").join("skills").join("orbit"));
+    }
+
+    /// A `--root` scratch root makes one directory serve as both the global and
+    /// the workspace root. Every runtime open seeds the global skill catalog and
+    /// then reaps workspace-seeded leftovers; when the two roots are the same
+    /// path, the reap used to delete the catalog it had just written.
+    /// [ORB-10926]
+    #[test]
+    fn runtime_open_keeps_global_skills_when_root_doubles_as_workspace() {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("scratch-root");
+        let router = global_skills_dir(&root).join("orbit").join("SKILL.md");
+
+        ensure_orbit_root_initialized(&root, &root).expect("first runtime open");
+        assert!(
+            router.exists(),
+            "init must seed the global skill catalog at {}",
+            router.display()
+        );
+
+        // Legacy workspace-seeded skills still live in the resources tree of the
+        // same root, and must still be reaped.
+        let legacy_skills = root.join("resources").join("skills");
+        seed_default_skills(&legacy_skills, &root, true).expect("seed legacy workspace skills");
+        assert!(legacy_skills.join("orbit").join("SKILL.md").exists());
+
+        ensure_orbit_root_initialized(&root, &root).expect("second runtime open");
+
+        assert!(
+            router.exists(),
+            "a runtime open must not delete the global skill catalog it seeded"
+        );
+        assert!(
+            global_skills_dir(&root)
+                .join("orbit")
+                .join("references")
+                .join("run-debugging.md")
+                .exists(),
+            "reference files under the global catalog must survive too"
+        );
+        assert!(
+            !legacy_skills.exists(),
+            "legacy workspace-seeded skills must still be reaped"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Task

[ORB-10926](https://orbit-cli.com/tasks/ORB-10926) — Global skills catalog is deleted on every runtime open when the global root doubles as the workspace root

### Description

## Summary

`ensure_orbit_root_initialized` runs on **every runtime open**. It first seeds the shipped skills into `<global_root>/skills`, then calls `prepare_workspace_root_layout(workspace_root)`, which calls `remove_workspace_seeded_default_skills`. That helper deletes every default skill tree it finds under `<workspace_root>/skills` and then `rmdir`s the directory.

When `global_root == workspace_root` — exactly what a `--root` or `ORBIT_ROOT` override produces, and the documented `/tmp` scratch-root pattern from ORB-10910 — step 2 deletes what step 1 just wrote. The operator loses the entire global skills catalog on the first command after init, and `orbit doctor` still reports `Workspace healthy`.

The helper's own comment (`crates/orbit-core/src/bootstrap/init.rs:418`) states the assumption it violates: "Skills are only ever seeded into the *global* root, so a managed manifest here describes skill trees that were just removed." That is false when the two roots are the same path.

This does not reproduce on the default layout (`~/.orbit` global vs `<repo>/.orbit` workspace) because the two roots differ, which is why it has not been noticed.

## Code path

- `crates/orbit-core/src/bootstrap/init.rs:91` `ensure_orbit_root_initialized` — seeds global skills, then line 102 `prepare_workspace_root_layout(workspace_root)`
- `crates/orbit-core/src/bootstrap/init.rs:360` `prepare_workspace_root_layout` → `remove_workspace_seeded_default_skills`
- `crates/orbit-core/src/bootstrap/init.rs:398-428` `remove_workspace_seeded_default_skills` — iterates `[&paths.skills_dir, &orbit_root.join("skills")]`; `is_default_skill_file_for_root` matches the just-seeded content, so `remove_path_if_exists(&skill_dir)` fires, then the manifest is dropped and `remove_empty_dir` removes the catalog root.

## Reproduction

```
$ orbit init --root /tmp/qa/root9 --host-name qah9 --task-prefix QAR
skills: root=<custom orbit root>/skills, refreshed=20, ...
$ find /tmp/qa/root9/skills -type f | wc -l
21
$ orbit skill list --root /tmp/qa/root9
no file skills installed
$ find /tmp/qa/root9/skills -type f | wc -l
0
$ orbit doctor --root /tmp/qa/root9 | grep -i skill
artifacts-skills	skipped	no skills on disk yet
... Workspace healthy.
```

With `ORBIT_ROOT` set instead of `--root`, even `orbit init` itself ends with zero skill files, because init opens a runtime before returning.

`strace` confirms the deleting process is the reading command, not init:

```
$ strace -f -e trace=unlinkat,unlink,rmdir orbit task list --root /tmp/qa/root8
unlinkat(4, "SKILL.md", 0)                                  = 0
unlinkat(AT_FDCWD, "/tmp/qa/root8/skills/orbit", AT_REMOVEDIR) = 0
unlink("/tmp/qa/root8/skills/.orbit-managed-assets.json")     = 0
rmdir("/tmp/qa/root8/skills")                                = 0
```

## Impact

Any operator or CI runner using a `--root` / `ORBIT_ROOT` scratch root (the pattern ORB-10910 documents) silently loses the `orbit` skill, so agents dispatched against that root have no skill guidance. Doctor reports the workspace healthy, so nothing surfaces the loss. If the skills were symlinked into `~/.claude/skills` / `~/.agents/skills`, this also recreates the dangling-symlink condition fixed by ORB-10869.

## Suggested fix

Skip `remove_workspace_seeded_default_skills` when the workspace root resolves to the same path as the global root (the legacy workspace-seeded layout it cleans up cannot exist there), or scope the cleanup to `paths.skills_dir` only when that differs from `global_skills_dir(global_root)`.

Found during QA sweep of ORB-10924 against `02d67f61`.

### Acceptance Criteria

- After `orbit init --root <dir>`, a subsequent runtime open (`orbit skill list`, `orbit task list`, `orbit doctor`) leaves `<dir>/skills` intact.
- `orbit skill list` reports the seeded skills rather than `no file skills installed` on a `--root` / `ORBIT_ROOT` scratch root.
- A regression test covers `ensure_orbit_root_initialized` when `global_root == workspace_root`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed: a runtime open no longer deletes the global skills catalog when the global root doubles as the workspace root.

Root cause confirmed as reported. `ensure_orbit_root_initialized` seeds the global catalog into `<global_root>/skills`, then `prepare_workspace_root_layout(workspace_root)` -> `remove_workspace_seeded_default_skills` reaped `[paths.skills_dir, <workspace_root>/skills]`. With `--root <dir>` both roots resolve to the same path, so the second candidate WAS the catalog just written.

Change (crates/orbit-core/src/bootstrap/init.rs, single file, no new dependency edges):
- `remove_workspace_seeded_default_skills` now takes the owning `global_root` and skips any candidate that resolves to `global_skills_dir(global_root)`, via a new `is_same_dir` helper (path equality first, then canonicalized comparison, literal fallback when canonicalization fails). Legacy workspace-seeded reaping under `<root>/resources/skills` is unchanged.
- `prepare_workspace_root_layout` takes `global_root`; `ensure_orbit_root_initialized` passes its own `global_root`.
- In `init_workspace_at_root` the workspace branch's global root (`global_root_override` or `resolve_global_root()`) is now resolved once, before layout, and the `global_only` if/else became a `match` on that `Option<PathBuf>` so the invariant is structural rather than an unwrap. The resolution itself is the same expression that already ran later in that branch, only hoisted; the global branch is untouched. Diff is mostly reindentation — review with `git diff -w`.
- Corrected the stale comment that asserted skills are only ever seeded into the global root.

Regression test: `bootstrap::init::tests::runtime_open_keeps_global_skills_when_root_doubles_as_workspace` drives `ensure_orbit_root_initialized(&root, &root)` twice, asserts the seeded `skills/orbit/SKILL.md` and a nested reference file survive the second open, and asserts legacy skills planted at `<root>/resources/skills` are still reaped.

Validation:
- `make ci-fast`: pass. `make ci-lint`: pass. `cargo fmt --check`: pass.
- `cargo test -p orbit-core --lib bootstrap::init`: 10/10 pass.
- Full `cargo test -p orbit-core --lib`: 719 pass; the only failures are the 12-13 in `runtime::tests::resolve`, which reproduce identically with the change reverted (verified against `git show HEAD:` of the file). Pre-existing and already recorded as friction F2026-08-096 (managed-run `ORBIT_ROOT` leaks into those fixtures; the poisoned env mutex inflates the count). No new friction filed.
- End-to-end with a locally built binary, reproducing the report: `orbit init --root <scratch>` -> 21 skill files; after `orbit skill list --root <scratch>` -> still 21 and it lists the `orbit` skill instead of `no file skills installed`; after `orbit task list` -> 21; `orbit doctor --root <scratch>` now reports `artifacts-skills ok, 1 skills loaded` instead of `skipped, no skills on disk yet`. All three acceptance criteria met.

Scope note on the report's `ORBIT_ROOT` claim: with `ORBIT_ROOT` set but no `--root`, the global root still resolves to `$HOME/.orbit` (`resolve_global_root` -> `global_orbit_dir`), so the two roots differ and the catalog was never at risk; verified empirically with a temp `HOME` (init seeds 21 files under `~/.orbit/skills` and they survive). `ORBIT_ROOT` only makes the roots coincide when it points at the global root, which this fix also covers. Doc comments name `--root` rather than `ORBIT_ROOT` for that reason.

No files outside the task's declared `context_files` were changed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10926-6a8276fe`
- Behind base: 0
- Ahead of base: 1