### PR TITLE
orbit workspace list unconditionally rewrites the global registry and ignores ORBIT_ROOT, failing with an unattributable EROFS

### DIFF
--- a/crates/orbit-cli/src/command/workspace/list.rs
+++ b/crates/orbit-cli/src/command/workspace/list.rs
@@ -18,10 +18,7 @@ impl Execute for WorkspaceListArgs {
         let global_root = runtime.global_root();
         let registry_path = workspace_registry::registry_path_for(&global_root);
         let mut registry = workspace_registry::load_registry_from(&registry_path)?;
-        workspace_registry::validate_workspaces(&mut registry);
-
-        if !registry.workspaces.is_empty() {
-            // Save back if staleness changed any status
+        if workspace_registry::validate_workspaces(&mut registry) {
             workspace_registry::save_registry_to(&registry, &registry_path)?;
         }
         Ok(Payload::detail(

--- a/crates/orbit-core/src/composition.rs
+++ b/crates/orbit-core/src/composition.rs
@@ -46,7 +46,7 @@ impl OrbitRuntime {
     ) -> Result<OrbitRuntimeRoots, OrbitError> {
         roots_from_resolved(
             resolve_initialize_roots(cwd, root_override)?,
-            root_override.is_some(),
+            has_explicit_root_override(root_override),
         )
     }
 
@@ -57,7 +57,7 @@ impl OrbitRuntime {
     ) -> Result<OrbitRuntimeRoots, OrbitError> {
         roots_from_resolved(
             resolve_initialize_roots_with_hint(cwd, root_override, hint)?,
-            root_override.is_some(),
+            has_explicit_root_override(root_override),
         )
     }
 

--- a/crates/orbit-core/src/runtime/tests/runtime.rs
+++ b/crates/orbit-core/src/runtime/tests/runtime.rs
@@ -23,7 +23,7 @@ fn test_runtime() -> (tempfile::TempDir, OrbitRuntime, PathBuf, PathBuf) {
 }
 
 #[test]
-fn orbit_root_env_selects_workspace_but_not_global_root() {
+fn orbit_root_env_pins_global_registry_root() {
     let home = tempdir().expect("home tempdir");
     let repo = tempdir().expect("repo tempdir");
     let workspace_root = repo.path().join(".orbit");
@@ -38,9 +38,14 @@ fn orbit_root_env_selects_workspace_but_not_global_root() {
     let resolved_roots =
         OrbitRuntime::resolve_roots_for_cwd(repo.path(), None).expect("resolve roots");
 
-    assert_eq!(resolved_roots.global_root, home.path().join(".orbit"));
+    // `ORBIT_ROOT` is documented as equivalent to `--root`: both pin the
+    // global registry root alongside the shared/local roots, so
+    // `ORBIT_ROOT=<dir> orbit workspace list` reads and writes
+    // `<dir>/workspaces.json` rather than `$HOME/.orbit` [ORB-10928].
+    assert_eq!(resolved_roots.global_root, workspace_root);
     assert_eq!(resolved_roots.shared_root, workspace_root);
     assert_eq!(resolved_roots.local_root, workspace_root);
+    assert_ne!(resolved_roots.global_root, home.path().join(".orbit"));
 }
 
 #[test]

--- a/crates/orbit-registry/src/tests/workspace_registry.rs
+++ b/crates/orbit-registry/src/tests/workspace_registry.rs
@@ -13,7 +13,7 @@ use tempfile::tempdir;
 use crate::workspace_registry::{
     assign_checkout_role, find_checkout_by_path, find_workspace, find_workspace_by_path,
     load_registry_from, load_registry_from_with_writer, register_checkout,
-    rename_local_owner_host_id, resolve_logical_workspace, save_registry_to,
+    rename_local_owner_host_id, resolve_logical_workspace, save_registry_to, validate_workspaces,
 };
 
 fn timestamp() -> chrono::DateTime<Utc> {
@@ -779,4 +779,32 @@ fn replica_role_rejects_transport_shaped_owner_before_any_mutation() {
             "rejected owner {rejected:?} changed persisted bytes"
         );
     }
+}
+
+#[test]
+fn validate_workspaces_reports_whether_any_status_changed() {
+    let repo_root = tempdir().expect("repo tempdir");
+    let mut registry = WorkspaceRegistry {
+        workspaces: vec![logical_workspace("ws_orbit", None)],
+        checkouts: vec![WorkspaceCheckout::owner(
+            "ws_orbit".to_string(),
+            repo_root.path().to_path_buf(),
+            repo_root.path().join(".orbit"),
+        )],
+        ..Default::default()
+    };
+
+    // The checkout's repo_root exists and the workspace is already Active, so
+    // nothing should change — callers like `orbit workspace list` rely on
+    // this to skip an unnecessary registry write [ORB-10928].
+    assert!(!validate_workspaces(&mut registry));
+    assert_eq!(registry.workspaces[0].status, WorkspaceStatus::Active);
+
+    drop(repo_root);
+    assert!(validate_workspaces(&mut registry));
+    assert_eq!(registry.workspaces[0].status, WorkspaceStatus::Invalid);
+
+    // Once flagged invalid, re-validating with the same missing root is a
+    // no-op.
+    assert!(!validate_workspaces(&mut registry));
 }

--- a/crates/orbit-registry/src/workspace_registry/catalog.rs
+++ b/crates/orbit-registry/src/workspace_registry/catalog.rs
@@ -340,8 +340,12 @@ pub fn set_path_override(
 /// Validates local checkout paths, marking their logical workspace invalid
 /// when the local repository root no longer exists. Checkoutless logical
 /// workspaces retain their catalog status.
-pub fn validate_workspaces(registry: &mut WorkspaceRegistry) {
+///
+/// Returns `true` when any workspace status changed, so callers that only
+/// read the registry (e.g. `workspace list`) can skip writing it back.
+pub fn validate_workspaces(registry: &mut WorkspaceRegistry) -> bool {
     let now = Utc::now();
+    let mut changed = false;
     for ws in &mut registry.workspaces {
         let Some(checkout) = registry
             .checkouts
@@ -354,12 +358,15 @@ pub fn validate_workspaces(registry: &mut WorkspaceRegistry) {
             if ws.status == WorkspaceStatus::Invalid {
                 ws.status = WorkspaceStatus::Active;
                 ws.updated_at = now;
+                changed = true;
             }
         } else if ws.status == WorkspaceStatus::Active {
             ws.status = WorkspaceStatus::Invalid;
             ws.updated_at = now;
+            changed = true;
         }
     }
+    changed
 }
 
 /// Machine identity facts used while validating a local registry file.

--- a/crates/orbit-registry/src/workspace_registry/io.rs
+++ b/crates/orbit-registry/src/workspace_registry/io.rs
@@ -79,5 +79,5 @@ fn registry_host_context(path: &Path) -> Result<WorkspaceRegistryHostContext, Or
 fn write_registry(registry: &WorkspaceRegistry, path: &Path) -> Result<(), OrbitError> {
     let content = serde_json::to_string_pretty(registry)
         .map_err(|error| OrbitError::WorkspaceError(format!("serialize registry: {error}")))?;
-    atomic_write_text(path, &content).map_err(Into::into)
+    atomic_write_text(path, &content).map_err(|error| OrbitError::from_write_io(path, error))
 }


### PR DESCRIPTION
## Task

[ORB-10928](https://orbit-cli.com/tasks/ORB-10928) — orbit workspace list unconditionally rewrites the global registry and ignores ORBIT_ROOT, failing with an unattributable EROFS

### Description

## Summary

Three defects meet in `orbit workspace list`, a command a user reasonably expects to be read-only.

### 1. It writes unconditionally

`crates/orbit-cli/src/command/workspace/list.rs:23-26`:

```rust
if !registry.workspaces.is_empty() {
    // Save back if staleness changed any status
    workspace_registry::save_registry_to(&registry, &registry_path)?;
}
```

The comment says "save back if staleness changed any status", but the guard is only "the registry is non-empty". `validate_workspaces` returns no change signal, so every `workspace list` rewrites `workspaces.json`. A pure listing therefore cannot run against a read-only global root.

### 2. `ORBIT_ROOT` is not honored for the registry

`resolve_roots` (`crates/orbit-core/src/runtime/resolve.rs:123-144`) documents `--root` and `ORBIT_ROOT` as equivalent escape hatches that both "pin both roots". But `runtime.global_root()`, which `workspace list` uses to locate the registry, comes from `resolve_global_root()` → `orbit_common::fs::path::global_orbit_dir()` → `$HOME/.orbit`, which never consults `ORBIT_ROOT`.

So with `ORBIT_ROOT` set, `workspace list` reads *and rewrites* the operator's real `~/.orbit/workspaces.json` instead of the override root's — while `--root` behaves correctly. On a machine without a read-only `~/.orbit`, this is a silent write to the wrong registry, and the listing shows the wrong workspaces.

### 3. The resulting EROFS is unattributable

The failure surfaces as:

```
error: io error: Read-only file system (os error 30)
```

No path, no operation, nothing pointing at `~/.orbit/workspaces.json` — the exact class of diagnostic ORB-10908 and ORB-10915 (`3f5f0429`) set out to eliminate. The registry write path does not go through the attributing helpers in `crates/orbit-common/src/fs/io.rs`.

## Reproduction

With `~/.orbit` read-only (or any read-only global root):

```
$ orbit workspace list
error: io error: Read-only file system (os error 30)

$ strace -f orbit workspace list 2>&1 | grep EROFS
openat(AT_FDCWD, "~/.orbit/.workspaces.json.<n>.0.tmp",
       O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC, 0600) = -1 EROFS (Read-only file system)
```

The `ORBIT_ROOT` divergence, on a writable host:

```
$ export ORBIT_ROOT=/tmp/qa/rootM        # rootM holds workspace wsM
$ orbit workspace list                    # touches ~/.orbit/workspaces.json
$ orbit workspace list --root /tmp/qa/rootM
NAME  ID      STATUS  SHIP MODE  OWNER                ROLE   ROOT
wsM   ws_wsm  active  pr         hm_94181bf6b1c634f8  owner  /tmp/qa/wsM
```

Other commands (`orbit workspace show`, `orbit task list`, `orbit doctor`) do honor `ORBIT_ROOT`; `workspace show` even prints `current orbit root: /tmp/qa/rootM`. The inconsistency is specific to the registry lookup.

## Impact

- `orbit workspace list` is unusable on a read-only or sandboxed global root, with an error that names nothing.
- Scratch-root workflows (`ORBIT_ROOT=/tmp/...`, per ORB-10910) list the wrong registry and mutate the operator's real one.

Found during QA sweep of ORB-10924 against `02d67f61`.

### Acceptance Criteria

- `orbit workspace list` writes the registry only when `validate_workspaces` actually changed a status, and otherwise performs no write.
- `orbit workspace list` succeeds on a read-only global root.
- `ORBIT_ROOT=<dir> orbit workspace list` reads and writes `<dir>/workspaces.json`, matching `--root <dir>`.
- If a registry write does fail with EROFS, the error names the path and operation, per the ORB-10908 / ORB-10915 attribution work.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed all three defects. Six files changed:

1. **Unconditional write** — `crates/orbit-registry/src/workspace_registry/catalog.rs`:
   `validate_workspaces` now returns `bool` (true iff any workspace status
   actually flipped Active<->Invalid). `crates/orbit-cli/src/command/workspace/list.rs`
   gates `save_registry_to` on that return value instead of the old
   `!registry.workspaces.is_empty()` guard, which was unconditionally true
   whenever any workspace existed. Other callers of `validate_workspaces`
   (registry_routines.rs, run/sweep.rs) still save unconditionally — that's
   their existing intended behavior (routine/sweep write paths, not a
   read-only listing command) and is out of scope here.

2. **ORBIT_ROOT ignored for the registry root** — root cause was one layer
   below the listed context files, in `crates/orbit-core/src/composition.rs`:
   `resolve_roots_for_cwd`/`resolve_roots_for_cwd_with_hint` (used by every
   command that doesn't pass an explicit `--workspace` selector, including
   `workspace list`, `workspace show`, `doctor`, `task list`, etc.) computed
   whether to pin `global_root` to `shared_root` using only
   `root_override.is_some()`, silently ignoring `ORBIT_ROOT`. The sibling
   bootstrap-mode functions in the same file already used a
   `has_explicit_root_override()` helper that correctly checks both `--root`
   and `ORBIT_ROOT` — swapped the two `resolve_roots_for_cwd*` call sites
   onto that same helper. This is a general fix: it corrects `global_root()`
   for every CLI command that reads/writes through it under `ORBIT_ROOT`, not
   just `workspace list`. Updated context_files via `orbit.task.update` to
   include `composition.rs` (and the two touched registry files) since
   resolve.rs itself was already correct — it's `composition.rs` that
   decides whether to honor that resolution for `global_root`.

3. **Unattributed EROFS** — `crates/orbit-registry/src/workspace_registry/io.rs`:
   `write_registry`'s `atomic_write_text(...).map_err(Into::into)` produced a
   bare `OrbitError::Io(err.to_string())` with no path. Switched to
   `OrbitError::from_write_io(path, error)`, the attributed helper already
   established by ORB-10908/ORB-10915 (`crates/orbit-common/src/error.rs`),
   which names the path and adds the "sandbox or environment condition, not
   an Orbit store defect" hint on EROFS/EACCES.

Tests: added `validate_workspaces_reports_whether_any_status_changed` in
`orbit-registry`; updated the existing orbit-core test that had literally
codified the ORBIT_ROOT bug as expected behavior (renamed
`orbit_root_env_selects_workspace_but_not_global_root` ->
`orbit_root_env_pins_global_registry_root`, corrected its assertions).

Validation: `cargo fmt --check` clean; `cargo clippy` on the touched crates
and full-workspace `make ci-lint` both pass with `-D warnings`; `make
ci-fast` passes. Full test suites for orbit-core, orbit-registry, orbit-cmd,
orbit-web pass. orbit-cli's full suite has 20 pre-existing failures in
`command::workspace::tests::init::*` (sandbox/EROFS + real-`.orbit`-identity
conflicts) — confirmed via `git stash`/re-run that these are identical on the
pre-fix tree, unrelated to this change. orbit-core also has 12 pre-existing
flaky failures under `runtime::tests::resolve::*` from an unrelated
uncoordinated-mutex race between two separate env-isolation locks
(`resolve.rs`'s local `ENV_LOCK` vs `orbit_common::test_env::scoped`'s lock);
also confirmed pre-existing via `git stash`, and filed as friction F2026-08-098
rather than fixed here (out of scope).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10928-6a8276fe`
- Behind base: 0
- Ahead of base: 1