### PR TITLE
Allow Claude Code Keychain OAuth under macOS sandbox-exec

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,6 +73,24 @@ run — a config or hook file dropped in another provider's state directory is
 a cross-session persistence vector, not scoped to the current agent's own
 provider. Tracked in `ORB-10234`.
 
+**The macOS credential denylist has one provider-scoped exception.** Claude
+Code stores its OAuth session in the macOS login Keychain (item
+`Claude Code-credentials`), not in a file under `~/.claude`, so the blanket
+`~/Library/Keychains` deny made every sandboxed Claude run fail with
+`OAuth session expired and could not be refreshed` — a login that is present
+and valid, merely unreadable. When (and only when) the confined CLI is Claude,
+the compiled profile re-allows **reads** of `~/Library/Keychains` after the
+deny. Codex, Gemini, Grok, and any unrecognized provider name keep the full
+deny; `/Library/Keychains` and `/System/Library/Keychains` stay denied for
+every provider; nothing grants keychain *writes*, so a sandboxed run can use a
+refreshed token but cannot persist it — re-authentication remains an
+unsandboxed operation. Reading the keychain file is not the same as reading its
+secrets (items stay encrypted behind their own per-item ACLs), but this does
+widen a Claude agent's reach to the login keychain file itself, which is why it
+is scoped to the one provider that needs it. A failing run says which case it
+hit: Orbit attaches its own attribution to the provider's misleading "expired"
+message.
+
 **Environment forwarding to sandboxed/subprocess agents is name-based, not
 value-shaped.** Orbit filters ambient environment variables passed to
 provider subprocesses by matching variable *names* against a fixed list of

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -27,8 +27,8 @@ use super::envelope::{
     task_id_from_input,
 };
 use super::spawn::{
-    linux_bwrap_failed_write_diagnostic, orbit_tool_env, prepare_sandbox_for_dispatch,
-    resolve_provider_launcher,
+    linux_bwrap_failed_write_diagnostic, macos_keychain_auth_diagnostic, orbit_tool_env,
+    prepare_sandbox_for_dispatch, resolve_provider_launcher,
 };
 use super::supervisor::{
     DEFAULT_WALL_CLOCK_TIMEOUT_SECONDS, SpawnTraceContext, SpawnWithTimeoutRequest,
@@ -414,21 +414,33 @@ pub fn run_cli_backend(
             timeout_seconds
         ))
     } else if !exit_success {
+        let stderr_text = String::from_utf8_lossy(stderr.protocol_bytes());
+        let exit_message = || format!("cli subprocess exited with code {exit_code:?}");
         Some(
             sandbox_write_diagnostic
                 .clone()
+                // A Keychain-backed provider login reads as "expired" whether it
+                // really expired or the sandbox hid the credential. Orbit
+                // compiled the profile, so it is the layer that can say which
+                // one this was — and the provider's own message cannot.
+                // [ORB-10929]
+                .or_else(|| {
+                    macos_keychain_auth_diagnostic(
+                        &provider,
+                        sandbox,
+                        &format!("{stdout_text}\n{stderr_text}"),
+                    )
+                    .map(|diagnostic| format!("{} {diagnostic}", exit_message()))
+                })
                 // [ORB-10746] A bare exit code cannot distinguish "this CLI
                 // has no --json-schema" from "the provider rejected Orbit's
                 // schema" from any other nonzero exit, and the first two are
                 // configuration faults an operator can act on immediately.
                 .or_else(|| {
-                    provider_invocation_diagnostic(
-                        stdout_text.as_ref(),
-                        String::from_utf8_lossy(stderr.protocol_bytes()).as_ref(),
-                    )
-                    .map(|diagnostic| bounded_diagnostic(&diagnostic, &redaction))
+                    provider_invocation_diagnostic(stdout_text.as_ref(), stderr_text.as_ref())
+                        .map(|diagnostic| bounded_diagnostic(&diagnostic, &redaction))
                 })
-                .unwrap_or_else(|| format!("cli subprocess exited with code {:?}", exit_code)),
+                .unwrap_or_else(exit_message),
         )
     } else if (spec.require_completion_envelope || spec.require_response_envelope)
         && matches!(envelope_status.as_deref(), Some("failed") | Some("timeout"))

--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -7,8 +7,9 @@ use orbit_common::OrbitError;
 use orbit_exec::{
     BwrapProbeOutcome, LinuxBwrapSpawnRequest, MacosSandboxSpawnRequest, UnsatisfiedWriteGrant,
     compile_linux_bwrap_argv, compile_macos_sandbox_profile, linux_bwrap_write_grant_diagnostic,
-    prepare_linux_bwrap_write_grants, probe_bwrap, sandbox_exec_available,
-    sandbox_exec_unavailable_message, spawn_under_linux_bwrap, spawn_under_macos_sandbox,
+    prepare_linux_bwrap_write_grants, probe_bwrap, provider_reads_macos_login_keychain,
+    sandbox_exec_available, sandbox_exec_unavailable_message, spawn_under_linux_bwrap,
+    spawn_under_macos_sandbox,
 };
 use orbit_types::policy::ResolvedFsProfile;
 use orbit_types::workflow::ExecutorSandboxKind;
@@ -355,10 +356,11 @@ pub(super) fn spawn_child_with_optional_sandbox(
     env: &[(String, String)],
     cwd: Option<&Path>,
     sandbox: Option<&ResolvedSandbox>,
+    provider: &str,
 ) -> Result<SpawnedChild, SpawnError> {
     match sandbox {
         Some(sb) if sb.kind == ExecutorSandboxKind::MacosSandboxExec => {
-            spawn_macos_sandboxed(program, args, env, cwd, sb)
+            spawn_macos_sandboxed(program, args, env, cwd, sb, provider)
         }
         Some(sb) if sb.kind == ExecutorSandboxKind::LinuxBwrap => {
             spawn_linux_bwrap(program, args, env, cwd, sb)
@@ -542,6 +544,63 @@ fn failed_write_path_candidates(line: &str) -> Vec<String> {
     candidates
 }
 
+/// Text a provider CLI emits when it cannot read its Keychain-backed OAuth
+/// session. The CLI cannot tell "the item is gone" from "the item is
+/// unreadable", so it reports both as an expiry.
+const KEYCHAIN_AUTH_FAILURE_MARKER: &str = "OAuth session expired";
+
+/// Distinguish a sandbox Keychain denial from a genuinely expired provider
+/// login.
+///
+/// A macOS sandbox that hides `$HOME/Library/Keychains` makes a valid login
+/// look expired, and the CLI's own message sends the operator to re-login —
+/// which cannot help. Orbit compiled the profile, so it is the only layer that
+/// knows whether the credential was actually reachable; say so next to the
+/// provider's message instead of leaving the operator to guess.
+pub(super) fn macos_keychain_auth_diagnostic(
+    provider: &str,
+    sandbox: Option<&ResolvedSandbox>,
+    output: &str,
+) -> Option<String> {
+    let home = std::env::var_os("HOME");
+    macos_keychain_auth_diagnostic_with(provider, sandbox, output, home.as_deref())
+}
+
+/// Test-friendly variant: callers pass HOME explicitly instead of reading
+/// process-global state, which the compiler's carve-out also depends on.
+// pub(crate) widened for tests/ layout under ORB-00225; test reaches via exposed surface.
+pub(crate) fn macos_keychain_auth_diagnostic_with(
+    provider: &str,
+    sandbox: Option<&ResolvedSandbox>,
+    output: &str,
+    home: Option<&OsStr>,
+) -> Option<String> {
+    let sandbox = sandbox?;
+    if sandbox.kind != ExecutorSandboxKind::MacosSandboxExec
+        || !provider_reads_macos_login_keychain(provider)
+        || !output.contains(KEYCHAIN_AUTH_FAILURE_MARKER)
+    {
+        return None;
+    }
+    // The compiler emits the re-allow only when it can resolve HOME, so an
+    // Orbit process started without a login environment still produces the
+    // fake-expiry failure. That is a different fix from re-authenticating.
+    if home.is_some_and(|home| !home.is_empty()) {
+        Some(format!(
+            "Orbit's macOS sandbox profile allows `$HOME/Library/Keychains` reads for provider \
+             `{provider}`, so the stored credential was reachable and this is a real login \
+             failure: re-authenticate the provider CLI outside Orbit, then retry."
+        ))
+    } else {
+        Some(format!(
+            "HOME is unset for the Orbit process, so its macOS sandbox profile could not allow \
+             `$HOME/Library/Keychains` reads for provider `{provider}`: the sandbox hid the \
+             stored credential and the login is not necessarily expired. Start Orbit with a \
+             login environment and retry before re-authenticating."
+        ))
+    }
+}
+
 // pub(crate) widened for tests/ layout under ORB-00225; test reaches via exposed surface.
 pub(crate) fn spawn_bare(
     program: &str,
@@ -584,8 +643,17 @@ fn spawn_macos_sandboxed(
     env: &[(String, String)],
     cwd: Option<&Path>,
     sandbox: &ResolvedSandbox,
+    provider: &str,
 ) -> Result<SpawnedChild, SpawnError> {
-    spawn_macos_sandboxed_with(program, args, env, cwd, sandbox, sandbox_exec_available())
+    spawn_macos_sandboxed_with(
+        program,
+        args,
+        env,
+        cwd,
+        sandbox,
+        provider,
+        sandbox_exec_available(),
+    )
 }
 
 /// Test-friendly variant of [`spawn_macos_sandboxed`]: callers pass an
@@ -600,6 +668,7 @@ pub(crate) fn spawn_macos_sandboxed_with(
     env: &[(String, String)],
     cwd: Option<&Path>,
     sandbox: &ResolvedSandbox,
+    provider: &str,
     sandbox_exec_present: bool,
 ) -> Result<SpawnedChild, SpawnError> {
     if !sandbox_exec_present {
@@ -627,7 +696,11 @@ pub(crate) fn spawn_macos_sandboxed_with(
     // A profile that fails to compile is deterministic config — permanent.
     // The sandboxed spawn itself goes through orbit-exec, which erases the
     // io::ErrorKind; classify it transient so retries are preserved.
-    let profile_text = compile_macos_sandbox_profile(&sandbox.fs_profile)
+    //
+    // `provider` reaches the compiler because the credential denylist has one
+    // provider-scoped exception: the confined CLI's own credential store. See
+    // `orbit_exec::provider_reads_macos_login_keychain`. [ORB-10929]
+    let profile_text = compile_macos_sandbox_profile(&sandbox.fs_profile, provider)
         .map_err(|err| SpawnError::permanent(err.to_string()))?;
     let (child, profile_temp) = spawn_under_macos_sandbox(MacosSandboxSpawnRequest {
         profile_text: &profile_text,

--- a/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
@@ -196,12 +196,11 @@ pub(super) fn spawn_with_timeout(
         mut child,
         // The temp profile must outlive the child — drop it after wait.
         _profile_temp,
-    } = spawn_child_with_optional_sandbox(program, args, env, cwd, sandbox).map_err(|err| {
-        SpawnError {
+    } = spawn_child_with_optional_sandbox(program, args, env, cwd, sandbox, trace.provider)
+        .map_err(|err| SpawnError {
             permanent: err.permanent,
             message: format!("spawn {program}: {}", err.message),
-        }
-    })?;
+        })?;
 
     // Report the PID before any blocking work: the whole point is to be
     // observable during a long invocation, and the child is already running.

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
@@ -8,7 +8,8 @@ use tempfile::tempdir;
 
 use super::super::super::dispatcher::ResolvedSandbox;
 use super::super::spawn::{
-    SpawnError, SpawnedChild, linux_bwrap_failed_write_diagnostic, orbit_tool_env_with,
+    SpawnError, SpawnedChild, linux_bwrap_failed_write_diagnostic,
+    macos_keychain_auth_diagnostic_with, orbit_tool_env_with,
     prepare_linux_sandbox_for_dispatch_with_probe, reject_unsatisfiable_managed_grants,
     resolve_provider_launcher_with, spawn_bare, spawn_macos_sandboxed_with,
 };
@@ -214,10 +215,71 @@ fn spawn_bare_does_not_inherit_ambient_sensitive_env() {
     );
 }
 
+/// The failure an operator actually sees when a Keychain-backed login cannot be
+/// read: the provider says "expired", which is indistinguishable from a sandbox
+/// denial unless Orbit attributes it. Both branches must be reachable, because
+/// they call for different fixes.
+#[test]
+fn keychain_auth_diagnostic_separates_a_real_expiry_from_a_sandbox_denial() {
+    let sandbox = sandbox_for_test();
+    let failure = "Failed to authenticate: OAuth session expired and could not be refreshed";
+
+    let with_home = macos_keychain_auth_diagnostic_with(
+        "claude",
+        Some(&sandbox),
+        failure,
+        Some(std::ffi::OsStr::new("/Users/test")),
+    )
+    .expect("claude under sandbox-exec must be attributed");
+    assert!(
+        with_home.contains("real login failure"),
+        "a reachable keychain means re-authentication is the fix: {with_home}"
+    );
+
+    let without_home = macos_keychain_auth_diagnostic_with("claude", Some(&sandbox), failure, None)
+        .expect("a HOME-less compile cannot emit the keychain allow");
+    assert!(
+        without_home.contains("HOME is unset"),
+        "an unemitted keychain allow means re-authentication cannot help: {without_home}"
+    );
+}
+
+#[test]
+fn keychain_auth_diagnostic_stays_silent_outside_its_exact_failure_shape() {
+    let sandbox = sandbox_for_test();
+    let failure = "Failed to authenticate: OAuth session expired and could not be refreshed";
+    let home = std::ffi::OsStr::new("/Users/test");
+
+    // Providers that never read the keychain, unsandboxed runs, and unrelated
+    // failures must not collect a keychain explanation.
+    assert!(
+        macos_keychain_auth_diagnostic_with("codex", Some(&sandbox), failure, Some(home)).is_none()
+    );
+    assert!(macos_keychain_auth_diagnostic_with("claude", None, failure, Some(home)).is_none());
+    assert!(
+        macos_keychain_auth_diagnostic_with(
+            "claude",
+            Some(&linux_sandbox_for_test(false)),
+            failure,
+            Some(home)
+        )
+        .is_none()
+    );
+    assert!(
+        macos_keychain_auth_diagnostic_with(
+            "claude",
+            Some(&sandbox),
+            "error: request timed out",
+            Some(home)
+        )
+        .is_none()
+    );
+}
+
 #[test]
 fn spawn_macos_sandboxed_returns_error_when_sandbox_exec_missing_and_fallback_disabled() {
     let sandbox = sandbox_for_test();
-    let err = spawn_macos_sandboxed_with("/bin/sh", &[], &[], None, &sandbox, false)
+    let err = spawn_macos_sandboxed_with("/bin/sh", &[], &[], None, &sandbox, "claude", false)
         .expect_err("expected fallback-disabled error");
     assert!(
         err.permanent,
@@ -498,6 +560,7 @@ fn spawn_macos_sandboxed_falls_back_to_bare_exec_when_allow_fallback_set() {
         &[],
         None,
         &sandbox,
+        "claude",
         false,
     )
     .expect("fallback should succeed");

--- a/crates/orbit-exec/src/lib.rs
+++ b/crates/orbit-exec/src/lib.rs
@@ -46,8 +46,9 @@ pub use linux_sandbox::{
 };
 pub use macos_sandbox::{
     MacosSandboxSpawnRequest, claude_state_dir_from_env, compile_macos_sandbox_profile,
-    grok_state_dir_from_env, sandbox_exec_available, sandbox_exec_path,
-    sandbox_exec_program_for_audit, sandbox_exec_unavailable_message, spawn_under_macos_sandbox,
+    grok_state_dir_from_env, provider_reads_macos_login_keychain, sandbox_exec_available,
+    sandbox_exec_path, sandbox_exec_program_for_audit, sandbox_exec_unavailable_message,
+    spawn_under_macos_sandbox,
 };
 pub use result::ExecutionResult;
 pub use runner::{EnvironmentMode, ExecRequest, StdinMode, run_process};

--- a/crates/orbit-exec/src/macos_sandbox/compile.rs
+++ b/crates/orbit-exec/src/macos_sandbox/compile.rs
@@ -2,15 +2,24 @@ use std::ffi::OsStr;
 
 use orbit_common::OrbitError;
 use orbit_types::policy::ResolvedFsProfile;
+use orbit_types::workflow::Provider;
 
 /// Compile a [`ResolvedFsProfile`] into SBPL text suitable for
 /// `sandbox-exec -f`.
+///
+/// `provider` is the canonical provider name of the CLI this profile will
+/// confine (`claude`, `codex`, ...). It only selects the credential-store
+/// carve-out described in [`provider_reads_macos_login_keychain`]; every other
+/// clause is provider-independent. An unknown name compiles with the full
+/// default credential denylist, so a typo fails closed.
 ///
 /// The emitted profile:
 /// - denies everything by default;
 /// - allows broad reads (`file-read*`) for agent CLI compatibility, then
 ///   appends default read denies for well-known credential locations so those
-///   paths still lose under SBPL's last-match-wins evaluation;
+///   paths still lose under SBPL's last-match-wins evaluation, and finally
+///   re-allows the confined provider's own credential store if it lives in one
+///   of those locations;
 /// - allows the syscall classes agent CLIs rely on (process, signal, mach,
 ///   ipc, sysctl, iokit) and unrestricted network — agents call out to
 ///   provider APIs;
@@ -26,13 +35,17 @@ use orbit_types::policy::ResolvedFsProfile;
 /// Paths in `rules.modify` are emitted as-is. Callers must resolve
 /// workspace-relative globs to absolute paths before invoking this
 /// function — a relative `subpath` is meaningless to the kernel.
-pub fn compile_macos_sandbox_profile(rules: &ResolvedFsProfile) -> Result<String, OrbitError> {
+pub fn compile_macos_sandbox_profile(
+    rules: &ResolvedFsProfile,
+    provider: &str,
+) -> Result<String, OrbitError> {
     let home = std::env::var_os("HOME");
     let codex_home = std::env::var_os("CODEX_HOME");
     let claude_config_dir = std::env::var_os("CLAUDE_CONFIG_DIR");
     let grok_home = std::env::var_os("GROK_HOME");
     compile_macos_sandbox_profile_with_env(
         rules,
+        provider,
         SandboxCompileEnv {
             home: home.as_deref(),
             codex_home: codex_home.as_deref(),
@@ -55,6 +68,7 @@ pub(super) struct SandboxCompileEnv<'a> {
 
 pub(super) fn compile_macos_sandbox_profile_with_env(
     rules: &ResolvedFsProfile,
+    provider: &str,
     env: SandboxCompileEnv<'_>,
 ) -> Result<String, OrbitError> {
     let SandboxCompileEnv {
@@ -147,9 +161,66 @@ pub(super) fn compile_macos_sandbox_profile_with_env(
         }
     }
     emit_default_credential_read_denies(home, &mut out);
+    emit_provider_credential_read_reallow(provider, home, &mut out);
 
     Ok(out)
 }
+
+/// Whether `provider`'s CLI reads its own credentials from the macOS login
+/// Keychain, and therefore cannot run under the default Keychain read deny.
+///
+/// Only Claude Code does today: it keeps its OAuth session in the login
+/// keychain item `Claude Code-credentials` and leaves
+/// `~/.claude/.credentials.json` as an empty stub. Codex, Gemini, and Grok keep
+/// credentials in plain files under their own state directories, which are
+/// already granted, so they keep the deny. Names that do not resolve to a
+/// canonical [`Provider`] keep the deny too — the carve-out fails closed.
+/// [ORB-10929]
+pub fn provider_reads_macos_login_keychain(provider: &str) -> bool {
+    Provider::parse(provider).ok() == Some(Provider::Claude)
+}
+
+/// Re-allow the confined provider's own credential store after
+/// [`emit_default_credential_read_denies`], so last-match-wins grants it.
+///
+/// Without this, a sandboxed `claude` cannot see its Keychain item and reports
+/// `OAuth session expired and could not be refreshed` — an authentication
+/// failure no re-login can clear, because the credential is present and simply
+/// unreadable. The carve-out is deliberately narrow:
+/// - it applies to one provider, so a Codex or Grok agent still cannot read any
+///   keychain;
+/// - it covers only the *user* keychain directory; `/Library/Keychains` and
+///   `/System/Library/Keychains` stay denied for every provider;
+/// - it grants reads only. Nothing here makes the login keychain writable, so a
+///   sandboxed run can use a refreshed token in memory but cannot persist it
+///   back to the keychain; re-authentication stays an unsandboxed operation.
+///
+/// Reading the keychain file is not the same as reading its secrets: item
+/// contents stay encrypted and gated by their own per-item ACLs, which is why
+/// the grant is scoped to the provider that owns the item it needs.
+///
+/// Precedence: this is the last clause in the profile, so it also outranks an
+/// activity's own negated `read` rules. Nothing an activity declares can *widen*
+/// the grant — it depends only on the confined provider — but an activity cannot
+/// narrow it back either. Move this above the `rules.read` loop if a profile
+/// ever needs to deny a provider its own credential store.
+fn emit_provider_credential_read_reallow(provider: &str, home: Option<&OsStr>, out: &mut String) {
+    if !provider_reads_macos_login_keychain(provider) {
+        return;
+    }
+    let Some(home) = super::provider_dirs::non_empty_env_path(home) else {
+        return;
+    };
+    let keychains = format!("{}/{USER_KEYCHAINS_SUBPATH}", home.display());
+    out.push_str(&format!(
+        "(allow file-read* (subpath \"{}\"))\n",
+        super::sbpl_filter::sbpl_escape(&keychains)
+    ));
+}
+
+/// HOME-relative path of the per-user keychain directory. Shared by the default
+/// deny and the provider re-allow so the two clauses cannot drift.
+const USER_KEYCHAINS_SUBPATH: &str = "Library/Keychains";
 
 fn emit_default_credential_read_denies(home: Option<&OsStr>, out: &mut String) {
     if let Some(home) = super::provider_dirs::non_empty_env_path(home) {
@@ -158,7 +229,7 @@ fn emit_default_credential_read_denies(home: Option<&OsStr>, out: &mut String) {
             ".ssh",
             ".aws",
             ".config/gh",
-            "Library/Keychains",
+            USER_KEYCHAINS_SUBPATH,
             "Library/Application Support/Google/Chrome",
             "Library/Application Support/Chromium",
             "Library/Application Support/BraveSoftware/Brave-Browser",

--- a/crates/orbit-exec/src/macos_sandbox/mod.rs
+++ b/crates/orbit-exec/src/macos_sandbox/mod.rs
@@ -35,7 +35,7 @@ mod test_support;
 #[cfg(test)]
 mod tests;
 
-pub use compile::compile_macos_sandbox_profile;
+pub use compile::{compile_macos_sandbox_profile, provider_reads_macos_login_keychain};
 pub use provider_dirs::{claude_state_dir_from_env, grok_state_dir_from_env};
 pub use spawn::{
     MacosSandboxSpawnRequest, sandbox_exec_available, sandbox_exec_path,

--- a/crates/orbit-exec/src/macos_sandbox/test_support.rs
+++ b/crates/orbit-exec/src/macos_sandbox/test_support.rs
@@ -22,9 +22,19 @@ pub(super) struct EnvOverrides<'a> {
     pub(super) grok_home: Option<&'a str>,
 }
 
-pub(super) fn compile_with_env(resolved: &ResolvedFsProfile, env: EnvOverrides<'_>) -> String {
+/// Provider used by profile tests that are not about the per-provider
+/// credential carve-out. Codex keeps every default credential deny, so a test
+/// asserting the shared clauses sees them unmodified.
+pub(super) const NEUTRAL_PROVIDER: &str = "codex";
+
+pub(super) fn compile_with_env(
+    resolved: &ResolvedFsProfile,
+    provider: &str,
+    env: EnvOverrides<'_>,
+) -> String {
     compile_macos_sandbox_profile_with_env(
         resolved,
+        provider,
         SandboxCompileEnv {
             home: env.home.map(OsStr::new),
             codex_home: env.codex_home.map(OsStr::new),

--- a/crates/orbit-exec/src/macos_sandbox/tests/compile.rs
+++ b/crates/orbit-exec/src/macos_sandbox/tests/compile.rs
@@ -3,7 +3,7 @@ use super::super::test_support::*;
 #[test]
 fn compile_emits_deny_default_and_broad_read_with_modify_subpath() {
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
-    let text = compile_with_env(&resolved, EnvOverrides::default());
+    let text = compile_with_env(&resolved, NEUTRAL_PROVIDER, EnvOverrides::default());
     assert!(text.contains("(deny default)"));
     assert!(text.contains("(allow file-read*)"));
     assert!(
@@ -17,6 +17,7 @@ fn compile_default_profile_denies_well_known_credential_reads() {
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
     let text = compile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         EnvOverrides {
             home: Some("/Users/test"),
             ..Default::default()
@@ -50,6 +51,105 @@ fn compile_default_profile_denies_well_known_credential_reads() {
 }
 
 #[test]
+fn compile_for_claude_reallows_user_keychain_read_after_the_default_deny() {
+    // Claude Code's OAuth session lives in the macOS login keychain item
+    // `Claude Code-credentials`, not in `~/.claude/.credentials.json`. With the
+    // deny unqualified, every sandboxed Claude run on macOS died reporting an
+    // expired OAuth session that no re-login could clear.
+    let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
+    let text = compile_with_env(
+        &resolved,
+        "claude",
+        EnvOverrides {
+            home: Some("/Users/test"),
+            ..Default::default()
+        },
+    );
+
+    let deny = "(deny file-read* (subpath \"/Users/test/Library/Keychains\"))";
+    let allow = "(allow file-read* (subpath \"/Users/test/Library/Keychains\"))";
+    let deny_pos = text.find(deny).expect("default user keychain read deny");
+    let allow_pos = text.find(allow).unwrap_or_else(|| {
+        panic!("missing claude user keychain read re-allow: {text}");
+    });
+    assert!(
+        deny_pos < allow_pos,
+        "the re-allow must follow the deny for SBPL last-match-wins: {text}"
+    );
+
+    // The carve-out is the user's keychain only.
+    for system_keychain in ["/Library/Keychains", "/System/Library/Keychains"] {
+        assert!(
+            !text.contains(&format!(
+                "(allow file-read* (subpath \"{system_keychain}\"))"
+            )),
+            "system keychain {system_keychain} must stay denied even for claude: {text}"
+        );
+    }
+    // Reading the credential never implies writing it.
+    assert!(
+        !text.contains("(allow file-write* (subpath \"/Users/test/Library/Keychains\"))"),
+        "keychain writes must stay denied: {text}"
+    );
+    // Unrelated credential stores keep their denies.
+    for other in [
+        "/Users/test/.ssh",
+        "/Users/test/.aws",
+        "/Users/test/.config/gh",
+    ] {
+        assert!(
+            text.contains(&format!("(deny file-read* (subpath \"{other}\"))")),
+            "missing credential read deny for {other}: {text}"
+        );
+        assert!(
+            !text.contains(&format!("(allow file-read* (subpath \"{other}\"))")),
+            "{other} must not be re-allowed: {text}"
+        );
+    }
+}
+
+#[test]
+fn compile_for_non_claude_providers_keeps_the_user_keychain_denied() {
+    // The keychain grant is per-provider on purpose: it is the confined CLI's
+    // own credential store, not a shared allowance. Codex and Grok authenticate
+    // from files under their own state dirs and must never see the keychain.
+    let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
+    let allow = "(allow file-read* (subpath \"/Users/test/Library/Keychains\"))";
+    for provider in ["codex", "grok", "gemini", "ollama", "not-a-provider", ""] {
+        let text = compile_with_env(
+            &resolved,
+            provider,
+            EnvOverrides {
+                home: Some("/Users/test"),
+                ..Default::default()
+            },
+        );
+        assert!(
+            text.contains("(deny file-read* (subpath \"/Users/test/Library/Keychains\"))"),
+            "provider {provider} must keep the user keychain read deny: {text}"
+        );
+        assert!(
+            !text.contains(allow),
+            "provider {provider} must not receive the keychain read re-allow: {text}"
+        );
+    }
+}
+
+#[test]
+fn compile_for_claude_without_home_emits_no_keychain_reallow() {
+    // Without HOME there is no path to re-allow. The profile must not fall back
+    // to a broader clause; the run fails the same way it did before instead.
+    let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
+    let text = compile_with_env(&resolved, "claude", EnvOverrides::default());
+    assert!(
+        !text
+            .lines()
+            .any(|line| line.starts_with("(allow file-read*") && line.contains("Keychains")),
+        "no keychain read allow may be emitted without HOME: {text}"
+    );
+}
+
+#[test]
 fn compile_grants_write_access_to_global_orbit_log_dir() {
     // The agent CLI inherits the sandbox into `orbit mcp serve` and any
     // other `orbit ...` calls. The JSONL tracing layer resolves its
@@ -59,6 +159,7 @@ fn compile_grants_write_access_to_global_orbit_log_dir() {
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
     let text = compile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         EnvOverrides {
             home: Some("/Users/test"),
             ..Default::default()
@@ -80,6 +181,7 @@ fn compile_with_env_does_not_mutate_process_home() {
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
     let text = compile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         EnvOverrides {
             home: Some("/Users/test"),
             ..Default::default()
@@ -101,6 +203,7 @@ fn compile_allows_macos_sandbox_provenance_syscall() {
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
     let text = compile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         EnvOverrides {
             home: Some("/Users/test"),
             ..Default::default()
@@ -121,6 +224,75 @@ fn compile_allows_macos_sandbox_provenance_syscall() {
 use super::super::compile_macos_sandbox_profile;
 #[cfg(target_os = "macos")]
 use orbit_types::policy::ResolvedFsProfile;
+
+#[cfg(target_os = "macos")]
+#[test]
+fn compiled_profile_lets_only_claude_read_the_user_keychain_directory() {
+    // Kernel-level complement to the profile-text assertions: prove the
+    // last-match-wins ordering actually resolves the way the clauses read. A
+    // synthetic HOME stands in for the real login keychain so the test never
+    // touches the operator's credentials.
+    use std::process::Command;
+
+    if !sandbox_exec_can_apply() {
+        return;
+    }
+
+    let parent = sandbox_test_parent("keychain-read");
+    let _cleanup = ScopeGuard(parent.clone());
+    let synthetic_home = tempfile::Builder::new()
+        .prefix("synthetic-home-")
+        .tempdir_in(&parent)
+        .expect("synthetic home tempdir");
+    let keychains = synthetic_home.path().join("Library/Keychains");
+    std::fs::create_dir_all(&keychains).expect("synthetic keychain dir");
+    let credential = keychains.join("login.keychain-db");
+    std::fs::write(&credential, b"synthetic-credential").expect("write synthetic credential");
+
+    let resolved = ResolvedFsProfile {
+        name: "default".to_string(),
+        read: vec![synthetic_home.path().display().to_string()],
+        modify: vec![],
+    };
+    let home = synthetic_home.path().to_string_lossy().into_owned();
+
+    for (provider, should_read) in [("claude", true), ("codex", false)] {
+        let profile_text = compile_with_env(
+            &resolved,
+            provider,
+            EnvOverrides {
+                home: Some(&home),
+                ..Default::default()
+            },
+        );
+        let mut profile_file = tempfile::Builder::new()
+            .prefix("orbit-sandbox-keychain-")
+            .suffix(".sb")
+            .tempfile()
+            .expect("tempfile");
+        use std::io::Write;
+        profile_file
+            .write_all(profile_text.as_bytes())
+            .expect("write profile");
+        profile_file.flush().expect("flush");
+
+        let status = Command::new(sandbox_exec_path_for_test())
+            .arg("-f")
+            .arg(profile_file.path())
+            .arg("/bin/sh")
+            .arg("-c")
+            .arg(format!("cat {}", shell_escape(&credential)))
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("run sandbox-exec");
+        assert_eq!(
+            status.success(),
+            should_read,
+            "provider {provider} keychain read should_succeed={should_read}; status={status:?}"
+        );
+    }
+}
 
 #[cfg(target_os = "macos")]
 #[test]
@@ -166,6 +338,7 @@ fn compiled_profile_allows_nested_orbit_runtime_writes_without_home_orbit_reallo
     let home_str = home.to_string_lossy().into_owned();
     let profile_text = compile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         EnvOverrides {
             home: Some(&home_str),
             ..Default::default()
@@ -260,7 +433,8 @@ fn compiled_profile_blocks_writes_outside_modify_scope() {
         read: vec![dir.path().display().to_string()],
         modify: vec![allowed.display().to_string()],
     };
-    let profile_text = compile_macos_sandbox_profile(&resolved).expect("compile sbpl");
+    let profile_text =
+        compile_macos_sandbox_profile(&resolved, NEUTRAL_PROVIDER).expect("compile sbpl");
     let mut profile_file = tempfile::Builder::new()
         .prefix("orbit-sandbox-test-")
         .suffix(".sb")
@@ -343,7 +517,8 @@ fn compiled_profile_denies_reads_to_negated_read_path() {
         ],
         modify: vec![],
     };
-    let profile_text = compile_macos_sandbox_profile(&resolved).expect("compile sbpl");
+    let profile_text =
+        compile_macos_sandbox_profile(&resolved, NEUTRAL_PROVIDER).expect("compile sbpl");
     let mut profile_file = tempfile::Builder::new()
         .prefix("orbit-sandbox-test-")
         .suffix(".sb")
@@ -415,7 +590,8 @@ fn compiled_profile_for_realistic_agent_loop_profile_allows_repo_writes_denies_d
             format!("!{}/.env", repo.path().display()),
         ],
     };
-    let profile_text = compile_macos_sandbox_profile(&resolved).expect("compile sbpl");
+    let profile_text =
+        compile_macos_sandbox_profile(&resolved, NEUTRAL_PROVIDER).expect("compile sbpl");
     let mut profile_file = tempfile::Builder::new()
         .prefix("orbit-sandbox-test-")
         .suffix(".sb")
@@ -486,7 +662,8 @@ fn compiled_profile_denies_env_glob_without_blocking_other_writes() {
             format!("!{}/**/*.env", dir.path().display()),
         ],
     };
-    let profile_text = compile_macos_sandbox_profile(&resolved).expect("compile sbpl");
+    let profile_text =
+        compile_macos_sandbox_profile(&resolved, NEUTRAL_PROVIDER).expect("compile sbpl");
     let mut profile_file = tempfile::Builder::new()
         .prefix("orbit-sandbox-test-")
         .suffix(".sb")
@@ -556,7 +733,8 @@ fn compiled_profile_with_mid_path_glob_rule_is_accepted_by_sandbox_exec() {
             "/Users/test/repo/**/*.env".to_string(),
         ],
     };
-    let profile_text = compile_macos_sandbox_profile(&resolved).expect("compile sbpl");
+    let profile_text =
+        compile_macos_sandbox_profile(&resolved, NEUTRAL_PROVIDER).expect("compile sbpl");
     assert!(
         !profile_text.contains("(?i)"),
         "compiled profile must not contain the unsupported (?i) inline flag: {profile_text}"

--- a/crates/orbit-exec/src/macos_sandbox/tests/provider_dirs.rs
+++ b/crates/orbit-exec/src/macos_sandbox/tests/provider_dirs.rs
@@ -12,6 +12,7 @@ fn compile_grants_write_access_to_codex_home_when_set() {
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
     let text = compile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         EnvOverrides {
             home: Some("/Users/test"),
             codex_home: Some("/var/folders/test/codex-home"),
@@ -33,6 +34,7 @@ fn compile_grants_write_access_to_home_codex_when_codex_home_missing() {
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
     let text = compile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         EnvOverrides {
             home: Some("/Users/test"),
             ..Default::default()
@@ -49,6 +51,7 @@ fn compile_grants_write_access_to_claude_config_dir_when_set() {
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
     let text = compile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         EnvOverrides {
             home: Some("/Users/test"),
             claude_config_dir: Some("/var/folders/test/claude-config"),
@@ -70,6 +73,7 @@ fn compile_grants_write_access_to_home_claude_when_claude_config_dir_missing() {
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
     let text = compile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         EnvOverrides {
             home: Some("/Users/test"),
             ..Default::default()
@@ -86,6 +90,7 @@ fn compile_grants_write_access_to_home_claude_json_when_claude_config_dir_missin
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
     let text = compile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         EnvOverrides {
             home: Some("/Users/test"),
             ..Default::default()
@@ -112,6 +117,7 @@ fn compile_does_not_emit_home_claude_json_allow_when_claude_config_dir_set() {
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
     let text = compile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         EnvOverrides {
             home: Some("/Users/test"),
             claude_config_dir: Some("/var/folders/test/claude-config"),
@@ -129,6 +135,7 @@ fn compile_grants_write_access_to_home_gemini() {
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
     let text = compile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         EnvOverrides {
             home: Some("/Users/test"),
             ..Default::default()
@@ -214,6 +221,7 @@ fn compile_grants_write_access_to_grok_home_when_set() {
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
     let text = compile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         EnvOverrides {
             home: Some("/Users/test"),
             grok_home: Some("/var/folders/test/grok-home"),
@@ -235,6 +243,7 @@ fn compile_grants_write_access_to_home_grok_when_grok_home_missing() {
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
     let text = compile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         EnvOverrides {
             home: Some("/Users/test"),
             ..Default::default()
@@ -251,6 +260,7 @@ fn compile_emits_explicit_grok_json_lock_and_tmp_allows() {
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
     let text = compile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         EnvOverrides {
             home: Some("/Users/test"),
             ..Default::default()
@@ -290,6 +300,7 @@ fn compile_emits_all_provider_state_dirs() {
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
     let text = compile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         EnvOverrides {
             home: Some("/Users/test"),
             ..Default::default()
@@ -338,6 +349,7 @@ fn compiled_profile_allows_writes_to_provider_state_dirs() {
     };
     let profile_text = compile_macos_sandbox_profile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         SandboxCompileEnv {
             home: Some(synthetic_home.path().as_os_str()),
             codex_home: None,
@@ -406,6 +418,7 @@ fn compiled_profile_allows_writes_to_grok_json_lock_and_tmp_files() {
     };
     let profile_text = compile_macos_sandbox_profile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         SandboxCompileEnv {
             home: Some(synthetic_home.path().as_os_str()),
             codex_home: None,
@@ -488,6 +501,7 @@ fn compiled_profile_allows_writes_to_claude_home_json_siblings() {
     };
     let profile_text = compile_macos_sandbox_profile_with_env(
         &resolved,
+        NEUTRAL_PROVIDER,
         SandboxCompileEnv {
             home: Some(synthetic_home.path().as_os_str()),
             codex_home: None,

--- a/crates/orbit-exec/src/macos_sandbox/tests/sbpl_filter.rs
+++ b/crates/orbit-exec/src/macos_sandbox/tests/sbpl_filter.rs
@@ -7,7 +7,7 @@ fn compile_strips_glob_suffix_for_subpath_root() {
         &["/Users/test/repo"],
         &["/Users/test/repo/src/**"],
     );
-    let text = compile_with_env(&resolved, EnvOverrides::default());
+    let text = compile_with_env(&resolved, NEUTRAL_PROVIDER, EnvOverrides::default());
     assert!(
         text.contains("(allow file-write* (subpath \"/Users/test/repo/src\"))"),
         "expected glob-stripped subpath: {text}"
@@ -25,7 +25,7 @@ fn compile_uses_regex_for_non_subpath_positive_modify_glob() {
         &["/Users/test/repo"],
         &["/Users/test/.orbit/orbit.db*"],
     );
-    let text = compile_with_env(&resolved, EnvOverrides::default());
+    let text = compile_with_env(&resolved, NEUTRAL_PROVIDER, EnvOverrides::default());
     assert!(
         text.contains(
             "(allow file-write* (regex \"^/[Uu][Ss][Ee][Rr][Ss]/[Tt][Ee][Ss][Tt]/\\\\.[Oo][Rr][Bb][Ii][Tt]/[Oo][Rr][Bb][Ii][Tt]\\\\.[Dd][Bb][^/]*$\"))"
@@ -49,7 +49,7 @@ fn compile_uses_regex_for_non_subpath_positive_modify_glob() {
 fn compile_appends_explicit_deny_for_negated_modify_rule() {
     let mut resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo"]);
     resolved.modify.push("!/Users/test/repo/.env".to_string());
-    let text = compile_with_env(&resolved, EnvOverrides::default());
+    let text = compile_with_env(&resolved, NEUTRAL_PROVIDER, EnvOverrides::default());
     assert!(
         text.contains("(deny file-write* (subpath \"/Users/test/repo/.env\"))"),
         "missing deny clause: {text}"
@@ -75,7 +75,7 @@ fn compile_emits_explicit_read_deny_for_negated_read_rule() {
     // `compile_appends_explicit_deny_for_negated_modify_rule`.
     let mut resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo"]);
     resolved.read.push("!/Users/test/repo/.env".to_string());
-    let text = compile_with_env(&resolved, EnvOverrides::default());
+    let text = compile_with_env(&resolved, NEUTRAL_PROVIDER, EnvOverrides::default());
     assert!(
         text.contains("(deny file-read* (subpath \"/Users/test/repo/.env\"))"),
         "missing deny file-read* clause: {text}"
@@ -97,7 +97,7 @@ fn compile_uses_regex_for_non_subpath_negated_read_glob() {
     // collapsed subpath that would over-match.
     let mut resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo"]);
     resolved.read.push("!/Users/test/repo/**/*.env".to_string());
-    let text = compile_with_env(&resolved, EnvOverrides::default());
+    let text = compile_with_env(&resolved, NEUTRAL_PROVIDER, EnvOverrides::default());
     assert!(
         text.contains("(deny file-read* (regex \"^/[Uu][Ss][Ee][Rr][Ss]/[Tt][Ee][Ss][Tt]/[Rr][Ee][Pp][Oo]/(?:.*/)?[^/]*\\\\.[Ee][Nn][Vv]$\"))"),
         "missing regex read deny: {text}"
@@ -114,7 +114,7 @@ fn compile_uses_regex_for_non_subpath_negated_modify_glob() {
     resolved
         .modify
         .push("!/Users/test/repo/**/*.env".to_string());
-    let text = compile_with_env(&resolved, EnvOverrides::default());
+    let text = compile_with_env(&resolved, NEUTRAL_PROVIDER, EnvOverrides::default());
     assert!(
         text.contains(
             "(deny file-write* (regex \"^/[Uu][Ss][Ee][Rr][Ss]/[Tt][Ee][Ss][Tt]/[Rr][Ee][Pp][Oo]/(?:.*/)?[^/]*\\\\.[Ee][Nn][Vv]$\"))"


### PR DESCRIPTION
## Task

[ORB-10929](https://orbit-cli.com/tasks/ORB-10929) — Allow Claude Code Keychain OAuth under macOS sandbox-exec

### Description

## Problem

Mac job runs that pick a Claude crew (`sonnet`, `opus`, `fable`, `custom`) fail in `implement_one` before any work starts:

```text
Failed to authenticate: OAuth session expired and could not be refreshed
```

Reproduced on native workspace `ws_dsearch`, run `jrun-20260817-0246-3`. Codex (`luna`/`system`) and Grok crews on the same host succeed.

This is not an expired login and not a missing workspace `config.toml`.

Claude Code 2.1.233 stores OAuth in the macOS Keychain item `Claude Code-credentials`. `~/.claude/.credentials.json` is a stub (`accessToken`/`refreshToken` empty, `expiresAt: 0`). Orbit's `macos-sandbox-exec` profile always emits:

```text
(deny file-read* (subpath "$HOME/Library/Keychains"))
```

from `emit_default_credential_read_denies` in `crates/orbit-exec/src/macos_sandbox/compile.rs`. The sandboxed CLI cannot see the Keychain item, so it reports a fake OAuth expiry.

Confirmed on this host:

- Unsandboxed `claude -p --model sonnet` authenticates and returns a result.
- The same prompt under `sandbox-exec` with only the Keychain deny reproduces the exact job-run error.
- `security find-generic-password -s Claude Code-credentials` works unsandboxed and fails under that deny.
- Removing `dsearch/.orbit/config.toml` did not change the Claude argv. Global `~/.orbit/config.toml` already defines `[crews.sonnet]`. The old workspace `backend = "cli"` keys are retired/inert (ORB-10801).

## Why It Matters

Every sandboxed Claude job on macOS is dead on arrival. The error string sends operators to re-login, which cannot fix a Keychain deny.

## Constraints / Notes

- Do not lift the whole Keychain deny for every provider. A blanket allow exposes every login-keychain secret to the agent.
- Prefer a Claude-executor-only carve-out, or pass a Claude OAuth/API credential into the cleared child env so the CLI does not need Keychain.
- Keep denying `~/.ssh`, `~/.aws`, `~/.config/gh`, and browser profile stores.
- `ANTHROPIC_API_KEY` is not on the seeded `execution.env.pass` list and is not how this host authenticates Claude.
- Tests that pin the Keychain deny live in `crates/orbit-exec/src/macos_sandbox/tests/compile.rs`.
- Do not treat restoring a workspace `config.toml` as the fix.

### Acceptance Criteria

- A sandboxed Claude CLI invocation on macOS that can authenticate unsandboxed no longer fails with "OAuth session expired and could not be refreshed" solely because `$HOME/Library/Keychains` is denied.
- Codex and Grok sandbox profiles still deny `$HOME/Library/Keychains` (or an equivalent Keychain read block) unless a documented, tested reason says otherwise.
- A compile/spawn test covers the Claude Keychain path so a future deny regression fails in CI rather than only on a live Mac job run.
- Operator-facing docs or the run error distinguish a sandbox Keychain deny from a genuinely expired `claude` login.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed: sandboxed Claude runs on macOS no longer fail with a fake OAuth expiry.

Root cause confirmed as described: `emit_default_credential_read_denies` emitted `(deny file-read* (subpath "$HOME/Library/Keychains"))` unconditionally, and Claude Code's OAuth session lives in the login-keychain item, not in `~/.claude/.credentials.json`.

Change (Claude-executor-only carve-out, not a blanket allow):
- `compile_macos_sandbox_profile(rules, provider)` now takes the confined provider name. The CLI runner already carries it (`SpawnTraceContext.provider`), so it is threaded through `spawn_child_with_optional_sandbox` -> `spawn_macos_sandboxed` -> `spawn_macos_sandboxed_with` with no new dependency edge (orbit-exec already depends on orbit-types).
- New `emit_provider_credential_read_reallow` appends `(allow file-read* (subpath "$HOME/Library/Keychains"))` as the last clause, only when `provider_reads_macos_login_keychain(provider)` is true. That predicate is `Provider::parse(provider).ok() == Some(Provider::Claude)`, so codex/gemini/grok/ollama and any unknown or empty name fail closed and keep the deny.
- `/Library/Keychains` and `/System/Library/Keychains` stay denied for every provider, `~/.ssh`, `~/.aws`, `~/.config/gh` and the browser stores are untouched, and no keychain *write* is granted.

Operator-facing distinction (AC4), both branches:
- `macos_keychain_auth_diagnostic` in the CLI runner turns an `OAuth session expired` failure under `macos-sandbox-exec` into an Orbit-owned attribution appended to the step message: HOME resolvable => the keychain was reachable, so re-authenticate outside Orbit; HOME unset => the profile could not emit the allow, so the sandbox hid the credential and re-login will not help. It slots into the existing `sandbox_write_diagnostic` -> `provider_invocation_diagnostic` chain.
- SECURITY.md now documents the exception, its scope, and the read-only limit next to the existing macOS seatbelt caveats.

Tests (AC3):
- `crates/orbit-exec/src/macos_sandbox/tests/compile.rs`: `compile_for_claude_reallows_user_keychain_read_after_the_default_deny` (deny precedes allow; system keychains and other credential stores not re-allowed; no write allow), `compile_for_non_claude_providers_keeps_the_user_keychain_denied` (codex/grok/gemini/ollama/unknown/empty), `compile_for_claude_without_home_emits_no_keychain_reallow`. These are plain compile-text tests, so a future deny regression fails on Linux CI, not only on a live Mac job.
- macOS-gated `compiled_profile_lets_only_claude_read_the_user_keychain_directory` proves the last-match-wins ordering at the kernel by reading a synthetic keychain file under a synthetic HOME through real `sandbox-exec` (claude succeeds, codex is denied); it never touches the operator's real keychain.
- `crates/orbit-engine/.../tests/spawn.rs`: two tests pin both diagnostic branches and its silence for non-keychain providers, unsandboxed/bwrap runs, and unrelated failures.

Validation: `make ci-fast` and `make ci-lint` both pass; `cargo test -p orbit-exec -p orbit-engine` is green (374 + 32 + 16 tests). The macOS-gated tests and the live Mac job-run repro could not be executed here (Linux runner) — unrestricted CI / a Mac run arbitrates those.

Known limit, stated deliberately rather than fixed here: the carve-out is read-only, so if Claude refreshes an expired token under sandbox it can use the new token in memory but cannot persist it back to the keychain. If a live Mac run shows a failure at that write, the follow-up is a narrow write allow on the login keychain db, not a broader read grant. Also noted in the code: the re-allow is the profile's last clause, so it outranks an activity's own negated `read` rules; nothing an activity declares can widen it, but an activity cannot narrow it back either.

Scope note: the task shipped with empty `context_files`; the changed files were appended to it (SBPL compiler + its exports/tests, the CLI-runner spawn/supervisor/orchestrator seam that carries the provider and surfaces the diagnostic, and SECURITY.md, which documented the now-qualified denylist).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10929-6a827c3e`
- Behind base: 0
- Ahead of base: 1