### PR TITLE
Preserve explicit denyRead over Claude Keychain credential reallow

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -87,9 +87,14 @@ refreshed token but cannot persist it — re-authentication remains an
 unsandboxed operation. Reading the keychain file is not the same as reading its
 secrets (items stay encrypted behind their own per-item ACLs), but this does
 widen a Claude agent's reach to the login keychain file itself, which is why it
-is scoped to the one provider that needs it. A failing run says which case it
-hit: Orbit attaches its own attribution to the provider's misleading "expired"
-message.
+is scoped to the one provider that needs it. The exception is a default, not an
+override: the compiled clause order is default credential denies, then the
+provider carve-out, then the activity's own negated `read` rules, so an
+`fsProfile` that denies `~/Library/Keychains` — or any ancestor of it, such as
+`~/Library` — takes the read back from Claude under SBPL last-match-wins. A
+failing run says which case it hit: Orbit attaches its own attribution to the
+provider's misleading "expired" message, and only recommends re-authenticating
+when the credential really was reachable.
 
 **Environment forwarding to sandboxed/subprocess agents is name-based, not
 value-shaped.** Orbit filters ambient environment variables passed to

--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -5,11 +5,11 @@ use std::process::{Child, Command, Stdio};
 
 use orbit_common::OrbitError;
 use orbit_exec::{
-    BwrapProbeOutcome, LinuxBwrapSpawnRequest, MacosSandboxSpawnRequest, UnsatisfiedWriteGrant,
-    compile_linux_bwrap_argv, compile_macos_sandbox_profile, linux_bwrap_write_grant_diagnostic,
-    prepare_linux_bwrap_write_grants, probe_bwrap, provider_reads_macos_login_keychain,
-    sandbox_exec_available, sandbox_exec_unavailable_message, spawn_under_linux_bwrap,
-    spawn_under_macos_sandbox,
+    BwrapProbeOutcome, LinuxBwrapSpawnRequest, MacosLoginKeychainAccess, MacosSandboxSpawnRequest,
+    UnsatisfiedWriteGrant, compile_linux_bwrap_argv, compile_macos_sandbox_profile,
+    linux_bwrap_write_grant_diagnostic, macos_login_keychain_access,
+    prepare_linux_bwrap_write_grants, probe_bwrap, sandbox_exec_available,
+    sandbox_exec_unavailable_message, spawn_under_linux_bwrap, spawn_under_macos_sandbox,
 };
 use orbit_types::policy::ResolvedFsProfile;
 use orbit_types::workflow::ExecutorSandboxKind;
@@ -557,6 +557,11 @@ const KEYCHAIN_AUTH_FAILURE_MARKER: &str = "OAuth session expired";
 /// which cannot help. Orbit compiled the profile, so it is the only layer that
 /// knows whether the credential was actually reachable; say so next to the
 /// provider's message instead of leaving the operator to guess.
+///
+/// The verdict comes from `orbit_exec::macos_login_keychain_access`, which
+/// reads the same profile the kernel enforced. Only the `Allowed` case may
+/// recommend re-authentication: the other cases are Orbit's own denial, which
+/// no amount of re-logging in outside the sandbox will clear. [ORB-10931]
 pub(super) fn macos_keychain_auth_diagnostic(
     provider: &str,
     sandbox: Option<&ResolvedSandbox>,
@@ -577,27 +582,36 @@ pub(crate) fn macos_keychain_auth_diagnostic_with(
 ) -> Option<String> {
     let sandbox = sandbox?;
     if sandbox.kind != ExecutorSandboxKind::MacosSandboxExec
-        || !provider_reads_macos_login_keychain(provider)
         || !output.contains(KEYCHAIN_AUTH_FAILURE_MARKER)
     {
         return None;
     }
-    // The compiler emits the re-allow only when it can resolve HOME, so an
-    // Orbit process started without a login environment still produces the
-    // fake-expiry failure. That is a different fix from re-authenticating.
-    if home.is_some_and(|home| !home.is_empty()) {
-        Some(format!(
+    match macos_login_keychain_access(provider, home, &sandbox.fs_profile) {
+        // The provider does not keep credentials in the keychain, so this
+        // failure has nothing to do with the sandbox's keychain deny.
+        MacosLoginKeychainAccess::DeniedByDefaultPolicy => None,
+        MacosLoginKeychainAccess::Allowed => Some(format!(
             "Orbit's macOS sandbox profile allows `$HOME/Library/Keychains` reads for provider \
              `{provider}`, so the stored credential was reachable and this is a real login \
              failure: re-authenticate the provider CLI outside Orbit, then retry."
-        ))
-    } else {
-        Some(format!(
+        )),
+        // The compiler emits the re-allow only when it can resolve HOME, so an
+        // Orbit process started without a login environment still produces the
+        // fake-expiry failure. That is a different fix from re-authenticating.
+        MacosLoginKeychainAccess::HomeUnresolved => Some(format!(
             "HOME is unset for the Orbit process, so its macOS sandbox profile could not allow \
              `$HOME/Library/Keychains` reads for provider `{provider}`: the sandbox hid the \
              stored credential and the login is not necessarily expired. Start Orbit with a \
              login environment and retry before re-authenticating."
-        ))
+        )),
+        MacosLoginKeychainAccess::DeniedByActivityRule { rule } => Some(format!(
+            "The activity's fsProfile `{}` denies `$HOME/Library/Keychains` reads via rule \
+             `{rule}`, which outranks the `{provider}` credential carve-out, so Orbit's macOS \
+             sandbox hid the stored credential and the login is not necessarily expired. \
+             Re-authenticating will not help: drop or narrow that denyRead rule, or run this \
+             activity without the macOS sandbox.",
+            sandbox.fs_profile.name
+        )),
     }
 }
 
@@ -699,7 +713,7 @@ pub(crate) fn spawn_macos_sandboxed_with(
     //
     // `provider` reaches the compiler because the credential denylist has one
     // provider-scoped exception: the confined CLI's own credential store. See
-    // `orbit_exec::provider_reads_macos_login_keychain`. [ORB-10929]
+    // `orbit_exec::macos_login_keychain_access`. [ORB-10929]
     let profile_text = compile_macos_sandbox_profile(&sandbox.fs_profile, provider)
         .map_err(|err| SpawnError::permanent(err.to_string()))?;
     let (child, profile_temp) = spawn_under_macos_sandbox(MacosSandboxSpawnRequest {

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
@@ -244,6 +244,39 @@ fn keychain_auth_diagnostic_separates_a_real_expiry_from_a_sandbox_denial() {
     );
 }
 
+/// [ORB-10931] The third case: the operator's own `denyRead` outranks the
+/// provider carve-out, so Orbit — not the provider — hid the credential.
+/// Recommending re-authentication here sends the operator to a fix that cannot
+/// work, so the message must name the rule instead.
+#[test]
+fn keychain_auth_diagnostic_attributes_an_activity_deny_instead_of_a_relogin() {
+    let failure = "Failed to authenticate: OAuth session expired and could not be refreshed";
+    let home = std::ffi::OsStr::new("/Users/test");
+
+    for deny in ["!/Users/test/Library/Keychains", "!/Users/test/Library"] {
+        let mut sandbox = sandbox_for_test();
+        sandbox.fs_profile.name = "hardened".to_string();
+        sandbox.fs_profile.read.push(deny.to_string());
+
+        let diagnostic =
+            macos_keychain_auth_diagnostic_with("claude", Some(&sandbox), failure, Some(home))
+                .expect("an activity keychain deny must be attributed");
+
+        assert!(
+            diagnostic.contains(deny) && diagnostic.contains("hardened"),
+            "diagnostic must name the profile and the exact deny rule: {diagnostic}"
+        );
+        assert!(
+            diagnostic.contains("Re-authenticating will not help"),
+            "an Orbit-authored denial must not send the operator to re-login: {diagnostic}"
+        );
+        assert!(
+            !diagnostic.contains("real login failure"),
+            "a denied keychain must never be reported as reachable: {diagnostic}"
+        );
+    }
+}
+
 #[test]
 fn keychain_auth_diagnostic_stays_silent_outside_its_exact_failure_shape() {
     let sandbox = sandbox_for_test();

--- a/crates/orbit-exec/src/lib.rs
+++ b/crates/orbit-exec/src/lib.rs
@@ -45,10 +45,10 @@ pub use linux_sandbox::{
     probe_bwrap, spawn_under_linux_bwrap,
 };
 pub use macos_sandbox::{
-    MacosSandboxSpawnRequest, claude_state_dir_from_env, compile_macos_sandbox_profile,
-    grok_state_dir_from_env, provider_reads_macos_login_keychain, sandbox_exec_available,
-    sandbox_exec_path, sandbox_exec_program_for_audit, sandbox_exec_unavailable_message,
-    spawn_under_macos_sandbox,
+    MacosLoginKeychainAccess, MacosSandboxSpawnRequest, claude_state_dir_from_env,
+    compile_macos_sandbox_profile, grok_state_dir_from_env, macos_login_keychain_access,
+    sandbox_exec_available, sandbox_exec_path, sandbox_exec_program_for_audit,
+    sandbox_exec_unavailable_message, spawn_under_macos_sandbox,
 };
 pub use result::ExecutionResult;
 pub use runner::{EnvironmentMode, ExecRequest, StdinMode, run_process};

--- a/crates/orbit-exec/src/macos_sandbox/compile.rs
+++ b/crates/orbit-exec/src/macos_sandbox/compile.rs
@@ -9,7 +9,7 @@ use orbit_types::workflow::Provider;
 ///
 /// `provider` is the canonical provider name of the CLI this profile will
 /// confine (`claude`, `codex`, ...). It only selects the credential-store
-/// carve-out described in [`provider_reads_macos_login_keychain`]; every other
+/// carve-out described in [`macos_login_keychain_access`]; every other
 /// clause is provider-independent. An unknown name compiles with the full
 /// default credential denylist, so a typo fails closed.
 ///
@@ -17,9 +17,10 @@ use orbit_types::workflow::Provider;
 /// - denies everything by default;
 /// - allows broad reads (`file-read*`) for agent CLI compatibility, then
 ///   appends default read denies for well-known credential locations so those
-///   paths still lose under SBPL's last-match-wins evaluation, and finally
-///   re-allows the confined provider's own credential store if it lives in one
-///   of those locations;
+///   paths still lose under SBPL's last-match-wins evaluation, then re-allows
+///   the confined provider's own credential store if it lives in one of those
+///   locations, and only then emits the activity's own negated `read` rules —
+///   so a policy-authored `denyRead` outranks the provider carve-out;
 /// - allows the syscall classes agent CLIs rely on (process, signal, mach,
 ///   ipc, sysctl, iokit) and unrestricted network — agents call out to
 ///   provider APIs;
@@ -152,6 +153,14 @@ pub(super) fn compile_macos_sandbox_profile_with_env(
         ));
     }
 
+    // Clause order below is the security contract, not a formatting choice.
+    // SBPL is last-match-wins, so the default credential denies come first, the
+    // confined provider's own credential carve-out re-allows on top of them,
+    // and the activity's negated `read` rules come last — an operator who
+    // writes `denyRead` for a credential path gets that denial even when the
+    // provider would otherwise be granted it. [ORB-10931]
+    emit_default_credential_read_denies(home, &mut out);
+    emit_provider_credential_read_reallow(provider, home, &mut out);
     for rule in &rules.read {
         if let Some(deny_path) = rule.strip_prefix('!') {
             out.push_str(&format!(
@@ -160,8 +169,6 @@ pub(super) fn compile_macos_sandbox_profile_with_env(
             ));
         }
     }
-    emit_default_credential_read_denies(home, &mut out);
-    emit_provider_credential_read_reallow(provider, home, &mut out);
 
     Ok(out)
 }
@@ -176,8 +183,68 @@ pub(super) fn compile_macos_sandbox_profile_with_env(
 /// already granted, so they keep the deny. Names that do not resolve to a
 /// canonical [`Provider`] keep the deny too — the carve-out fails closed.
 /// [ORB-10929]
-pub fn provider_reads_macos_login_keychain(provider: &str) -> bool {
+///
+/// Internal: callers outside this crate want [`macos_login_keychain_access`],
+/// which answers the question the compiled profile actually settles.
+fn provider_reads_macos_login_keychain(provider: &str) -> bool {
     Provider::parse(provider).ok() == Some(Provider::Claude)
+}
+
+/// What the compiled profile decides about `provider` reading the *user* login
+/// keychain directory (`$HOME/Library/Keychains`).
+///
+/// This mirrors the clause order emitted by
+/// [`compile_macos_sandbox_profile`], so a caller can explain a failing run
+/// without re-deriving SBPL semantics. [ORB-10931]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MacosLoginKeychainAccess {
+    /// The profile grants the read: the provider owns credentials there and no
+    /// activity rule takes it back.
+    Allowed,
+    /// The provider keeps the default credential deny — it does not store
+    /// credentials in the keychain, so it never receives the carve-out.
+    DeniedByDefaultPolicy,
+    /// `HOME` did not resolve, so the compiler had no path to re-allow and the
+    /// default deny stands.
+    HomeUnresolved,
+    /// The activity's own negated `read` rule denies the keychain directory.
+    /// It is emitted after the carve-out, so last-match-wins gives it priority.
+    DeniedByActivityRule {
+        /// The rule as authored in the resolved profile, `!`-prefix included.
+        rule: String,
+    },
+}
+
+/// Resolve [`MacosLoginKeychainAccess`] for a profile that would be compiled
+/// with the same `provider`, `home`, and `rules`.
+///
+/// Activity-rule coverage is judged from the longest non-glob prefix of each
+/// negated `read` rule, which bounds what the emitted `(subpath ...)` or
+/// `(regex ...)` deny clause can match. That is exact for the literal and
+/// trailing-`**` rules operators actually write, and conservative for interior
+/// globs: it may report a denial the kernel would only partially apply, but it
+/// never reports a keychain as reachable once a rule has denied it.
+pub fn macos_login_keychain_access(
+    provider: &str,
+    home: Option<&OsStr>,
+    rules: &ResolvedFsProfile,
+) -> MacosLoginKeychainAccess {
+    if !provider_reads_macos_login_keychain(provider) {
+        return MacosLoginKeychainAccess::DeniedByDefaultPolicy;
+    }
+    let Some(home) = super::provider_dirs::non_empty_env_path(home) else {
+        return MacosLoginKeychainAccess::HomeUnresolved;
+    };
+    let keychains = home.join(USER_KEYCHAINS_SUBPATH);
+    for rule in &rules.read {
+        let Some(deny_path) = rule.strip_prefix('!') else {
+            continue;
+        };
+        if super::sbpl_filter::deny_rule_reaches_path(deny_path, &keychains) {
+            return MacosLoginKeychainAccess::DeniedByActivityRule { rule: rule.clone() };
+        }
+    }
+    MacosLoginKeychainAccess::Allowed
 }
 
 /// Re-allow the confined provider's own credential store after
@@ -199,11 +266,13 @@ pub fn provider_reads_macos_login_keychain(provider: &str) -> bool {
 /// contents stay encrypted and gated by their own per-item ACLs, which is why
 /// the grant is scoped to the provider that owns the item it needs.
 ///
-/// Precedence: this is the last clause in the profile, so it also outranks an
-/// activity's own negated `read` rules. Nothing an activity declares can *widen*
-/// the grant — it depends only on the confined provider — but an activity cannot
-/// narrow it back either. Move this above the `rules.read` loop if a profile
-/// ever needs to deny a provider its own credential store.
+/// Precedence: this clause sits between the default credential denies and the
+/// activity's own negated `read` rules. Nothing an activity declares can
+/// *widen* the grant — it depends only on the confined provider — and an
+/// activity that denies the keychain directory (or any ancestor of it) narrows
+/// it back, because its deny is emitted afterwards and last-match-wins.
+/// [`macos_login_keychain_access`] reports which of those cases a given profile
+/// lands in. [ORB-10931]
 fn emit_provider_credential_read_reallow(provider: &str, home: Option<&OsStr>, out: &mut String) {
     if !provider_reads_macos_login_keychain(provider) {
         return;

--- a/crates/orbit-exec/src/macos_sandbox/mod.rs
+++ b/crates/orbit-exec/src/macos_sandbox/mod.rs
@@ -35,7 +35,9 @@ mod test_support;
 #[cfg(test)]
 mod tests;
 
-pub use compile::{compile_macos_sandbox_profile, provider_reads_macos_login_keychain};
+pub use compile::{
+    MacosLoginKeychainAccess, compile_macos_sandbox_profile, macos_login_keychain_access,
+};
 pub use provider_dirs::{claude_state_dir_from_env, grok_state_dir_from_env};
 pub use spawn::{
     MacosSandboxSpawnRequest, sandbox_exec_available, sandbox_exec_path,

--- a/crates/orbit-exec/src/macos_sandbox/sbpl_filter.rs
+++ b/crates/orbit-exec/src/macos_sandbox/sbpl_filter.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 pub(super) fn sbpl_escape(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
 }
@@ -20,6 +22,22 @@ pub(super) fn sbpl_filter_for_allow_rule(rule: &str) -> String {
         let regex = glob_rule_to_regex(rule);
         format!("(regex \"{}\")", sbpl_escape(&regex))
     }
+}
+
+/// Whether the deny clause compiled from `rule` reaches `path` itself — that
+/// is, whether the rule denies `path` or an ancestor directory of it.
+///
+/// Both clause shapes [`sbpl_filter_for_deny_rule`] can emit are bounded above
+/// by the rule's longest non-glob prefix: `(subpath ROOT)` matches exactly
+/// `ROOT` and below, and a `(regex ...)` built from the same rule can only
+/// match paths under that prefix. Comparing against [`subpath_root`] therefore
+/// answers the question for literal and trailing-`**` rules exactly, and
+/// over-approximates for interior globs (`~/Library/*`), where the regex may
+/// only match part of the subtree. Callers use this to decide whether a
+/// credential path was denied, so over-approximating is the safe direction.
+/// [ORB-10931]
+pub(super) fn deny_rule_reaches_path(rule: &str, path: &Path) -> bool {
+    path.starts_with(subpath_root(rule))
 }
 
 fn rule_can_use_subpath(rule: &str) -> bool {

--- a/crates/orbit-exec/src/macos_sandbox/test_support.rs
+++ b/crates/orbit-exec/src/macos_sandbox/test_support.rs
@@ -56,6 +56,37 @@ pub(super) fn sandbox_exec_path_for_test() -> PathBuf {
     super::spawn::sandbox_exec_path().expect("trusted sandbox-exec path")
 }
 
+/// Apply `profile_text` with the trusted `sandbox-exec` and report whether a
+/// child could read `path`. Shared by the keychain ordering tests so each one
+/// asserts on the kernel's verdict rather than on profile text.
+#[cfg(target_os = "macos")]
+pub(super) fn can_read_under_profile(profile_text: &str, path: &Path) -> bool {
+    use std::io::Write;
+
+    let mut profile_file = tempfile::Builder::new()
+        .prefix("orbit-sandbox-keychain-")
+        .suffix(".sb")
+        .tempfile()
+        .expect("tempfile");
+    profile_file
+        .write_all(profile_text.as_bytes())
+        .expect("write profile");
+    profile_file.flush().expect("flush");
+
+    std::process::Command::new(sandbox_exec_path_for_test())
+        .arg("-f")
+        .arg(profile_file.path())
+        .arg("/bin/sh")
+        .arg("-c")
+        .arg(format!("cat {}", shell_escape(path)))
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .expect("run sandbox-exec")
+        .success()
+}
+
 #[cfg(target_os = "macos")]
 pub(super) fn sandbox_exec_can_apply() -> bool {
     if !super::spawn::sandbox_exec_available() {

--- a/crates/orbit-exec/src/macos_sandbox/tests/compile.rs
+++ b/crates/orbit-exec/src/macos_sandbox/tests/compile.rs
@@ -1,3 +1,4 @@
+use super::super::compile::{MacosLoginKeychainAccess, macos_login_keychain_access};
 use super::super::test_support::*;
 
 #[test]
@@ -106,6 +107,100 @@ fn compile_for_claude_reallows_user_keychain_read_after_the_default_deny() {
             "{other} must not be re-allowed: {text}"
         );
     }
+}
+
+/// [ORB-10931] The clause order *is* the policy under SBPL last-match-wins, so
+/// pin all three bands: default credential denies, then the provider carve-out,
+/// then the activity's own negated `read` rules. An operator who denies a
+/// credential path must not be silently overridden by the carve-out.
+#[test]
+fn compile_orders_activity_read_denies_after_the_claude_keychain_reallow() {
+    let allow = "(allow file-read* (subpath \"/Users/test/Library/Keychains\"))";
+    let default_deny = "(deny file-read* (subpath \"/Users/test/Library/Keychains\"))";
+
+    // Both the exact keychain directory and a broader ancestor must win.
+    for activity_deny in [
+        "!/Users/test/Library/Keychains",
+        "!/Users/test/Library",
+        "!/Users/test/Library/**",
+    ] {
+        let resolved = profile(
+            "hardened",
+            &["/Users/test/repo", activity_deny],
+            &["/Users/test/repo/src"],
+        );
+        let text = compile_with_env(
+            &resolved,
+            "claude",
+            EnvOverrides {
+                home: Some("/Users/test"),
+                ..Default::default()
+            },
+        );
+
+        let activity_clause = format!(
+            "(deny file-read* (subpath \"{}\"))",
+            activity_deny
+                .trim_start_matches('!')
+                .trim_end_matches("/**")
+        );
+        let default_deny_pos = text.find(default_deny).expect("default keychain read deny");
+        let allow_pos = text.find(allow).expect("claude keychain read re-allow");
+        let activity_pos = text
+            .rfind(&activity_clause)
+            .unwrap_or_else(|| panic!("missing activity read deny {activity_deny}: {text}"));
+        assert!(
+            default_deny_pos < allow_pos && allow_pos < activity_pos,
+            "order must be default deny -> provider re-allow -> activity deny for \
+             {activity_deny}: {text}"
+        );
+
+        assert_eq!(
+            macos_login_keychain_access(
+                "claude",
+                Some(std::ffi::OsStr::new("/Users/test")),
+                &resolved
+            ),
+            MacosLoginKeychainAccess::DeniedByActivityRule {
+                rule: activity_deny.to_string()
+            },
+            "the reported access must match the compiled clause order"
+        );
+    }
+}
+
+/// The narrowing above must not become the default: with no overlapping
+/// activity deny, Claude keeps the OAuth read that ORB-10929 delivered.
+#[test]
+fn keychain_access_stays_allowed_without_an_overlapping_activity_deny() {
+    let home = std::ffi::OsStr::new("/Users/test");
+    let unrelated = profile(
+        "default",
+        &["/Users/test/repo", "!/Users/test/.ssh", "!/Users/other"],
+        &["/Users/test/repo/src"],
+    );
+    assert_eq!(
+        macos_login_keychain_access("claude", Some(home), &unrelated),
+        MacosLoginKeychainAccess::Allowed
+    );
+    assert_eq!(
+        macos_login_keychain_access("codex", Some(home), &unrelated),
+        MacosLoginKeychainAccess::DeniedByDefaultPolicy
+    );
+    assert_eq!(
+        macos_login_keychain_access("claude", None, &unrelated),
+        MacosLoginKeychainAccess::HomeUnresolved
+    );
+    // A non-negated `read` entry naming the keychain is not a denial.
+    let positive = profile(
+        "default",
+        &["/Users/test/Library/Keychains"],
+        &["/Users/test/repo/src"],
+    );
+    assert_eq!(
+        macos_login_keychain_access("claude", Some(home), &positive),
+        MacosLoginKeychainAccess::Allowed
+    );
 }
 
 #[test]
@@ -232,65 +327,122 @@ fn compiled_profile_lets_only_claude_read_the_user_keychain_directory() {
     // last-match-wins ordering actually resolves the way the clauses read. A
     // synthetic HOME stands in for the real login keychain so the test never
     // touches the operator's credentials.
-    use std::process::Command;
-
     if !sandbox_exec_can_apply() {
         return;
     }
 
-    let parent = sandbox_test_parent("keychain-read");
-    let _cleanup = ScopeGuard(parent.clone());
-    let synthetic_home = tempfile::Builder::new()
-        .prefix("synthetic-home-")
-        .tempdir_in(&parent)
-        .expect("synthetic home tempdir");
-    let keychains = synthetic_home.path().join("Library/Keychains");
-    std::fs::create_dir_all(&keychains).expect("synthetic keychain dir");
-    let credential = keychains.join("login.keychain-db");
-    std::fs::write(&credential, b"synthetic-credential").expect("write synthetic credential");
-
+    let fixture = SyntheticKeychainHome::create("keychain-read");
     let resolved = ResolvedFsProfile {
         name: "default".to_string(),
-        read: vec![synthetic_home.path().display().to_string()],
+        read: vec![fixture.home_text()],
         modify: vec![],
     };
-    let home = synthetic_home.path().to_string_lossy().into_owned();
 
     for (provider, should_read) in [("claude", true), ("codex", false)] {
+        assert_eq!(
+            fixture.credential_readable(&resolved, provider),
+            should_read,
+            "provider {provider} keychain read should_succeed={should_read}"
+        );
+    }
+}
+
+/// [ORB-10931] The kernel-level half of the ordering contract: an activity that
+/// denies the keychain directory — or an ancestor of it — must actually lose
+/// Claude the read, while a profile without such a rule keeps it. Asserted
+/// through `sandbox-exec` because clause ordering is only a claim until the
+/// kernel resolves it.
+#[cfg(target_os = "macos")]
+#[test]
+fn compiled_profile_honors_an_activity_keychain_deny_for_claude() {
+    if !sandbox_exec_can_apply() {
+        return;
+    }
+
+    let fixture = SyntheticKeychainHome::create("keychain-deny");
+    let home_text = fixture.home_text();
+
+    let default_allow = ResolvedFsProfile {
+        name: "default".to_string(),
+        read: vec![home_text.clone()],
+        modify: vec![],
+    };
+    assert!(
+        fixture.credential_readable(&default_allow, "claude"),
+        "without an overlapping deny, claude keeps its OAuth keychain read"
+    );
+
+    for deny in [
+        format!("!{home_text}/Library/Keychains"),
+        format!("!{home_text}/Library"),
+    ] {
+        let hardened = ResolvedFsProfile {
+            name: "hardened".to_string(),
+            read: vec![home_text.clone(), deny.clone()],
+            modify: vec![],
+        };
+        assert!(
+            !fixture.credential_readable(&hardened, "claude"),
+            "activity rule {deny} must deny claude the keychain read"
+        );
+        assert_eq!(
+            macos_login_keychain_access(
+                "claude",
+                Some(std::ffi::OsStr::new(&home_text)),
+                &hardened
+            ),
+            MacosLoginKeychainAccess::DeniedByActivityRule { rule: deny.clone() },
+            "the reported access must match what the kernel enforced for {deny}"
+        );
+    }
+}
+
+/// A disposable `$HOME` holding a stand-in login keychain, so keychain tests
+/// exercise the real clause set without touching operator credentials.
+#[cfg(target_os = "macos")]
+struct SyntheticKeychainHome {
+    // Declaration order is drop order: the tempdir must go before the guard
+    // that removes its parent.
+    home: tempfile::TempDir,
+    _cleanup: ScopeGuard,
+    credential: std::path::PathBuf,
+}
+
+#[cfg(target_os = "macos")]
+impl SyntheticKeychainHome {
+    fn create(label: &str) -> Self {
+        let parent = sandbox_test_parent(label);
+        let cleanup = ScopeGuard(parent.clone());
+        let home = tempfile::Builder::new()
+            .prefix("synthetic-home-")
+            .tempdir_in(&parent)
+            .expect("synthetic home tempdir");
+        let keychains = home.path().join("Library/Keychains");
+        std::fs::create_dir_all(&keychains).expect("synthetic keychain dir");
+        let credential = keychains.join("login.keychain-db");
+        std::fs::write(&credential, b"synthetic-credential").expect("write synthetic credential");
+        Self {
+            home,
+            _cleanup: cleanup,
+            credential,
+        }
+    }
+
+    fn home_text(&self) -> String {
+        self.home.path().to_string_lossy().into_owned()
+    }
+
+    fn credential_readable(&self, resolved: &ResolvedFsProfile, provider: &str) -> bool {
+        let home = self.home_text();
         let profile_text = compile_with_env(
-            &resolved,
+            resolved,
             provider,
             EnvOverrides {
                 home: Some(&home),
                 ..Default::default()
             },
         );
-        let mut profile_file = tempfile::Builder::new()
-            .prefix("orbit-sandbox-keychain-")
-            .suffix(".sb")
-            .tempfile()
-            .expect("tempfile");
-        use std::io::Write;
-        profile_file
-            .write_all(profile_text.as_bytes())
-            .expect("write profile");
-        profile_file.flush().expect("flush");
-
-        let status = Command::new(sandbox_exec_path_for_test())
-            .arg("-f")
-            .arg(profile_file.path())
-            .arg("/bin/sh")
-            .arg("-c")
-            .arg(format!("cat {}", shell_escape(&credential)))
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .expect("run sandbox-exec");
-        assert_eq!(
-            status.success(),
-            should_read,
-            "provider {provider} keychain read should_succeed={should_read}; status={status:?}"
-        );
+        can_read_under_profile(&profile_text, &self.credential)
     }
 }
 


### PR DESCRIPTION
## Task

[ORB-10931](https://orbit-cli.com/tasks/ORB-10931) — Preserve explicit denyRead over Claude Keychain credential reallow

### Description

## Problem

PR #1084 / ORB-10929 appends Claude's `$HOME/Library/Keychains` read re-allow after every activity `rules.read` denial in `crates/orbit-exec/src/macos_sandbox/compile.rs`. macOS SBPL uses last-match-wins semantics, so an explicit `denyRead` for the Keychains directory—or a broader parent such as `$HOME/Library`—is silently overridden for Claude.

The originating task's execution summary explicitly notes this limitation. It breaks the filesystem-profile contract: an activity cannot narrow Claude's read access to a sensitive credential store even when it asks Orbit to do so.

## Why It Matters

A policy-authored credential denial must take precedence over a provider convenience exception. Otherwise operators can believe a sensitive path is blocked while the compiled sandbox grants it.

## Constraints / Notes

- Regression from the Claude Keychain carve-out delivered by ORB-10929 in PR #1084.
- Preserve the default Claude behavior: when no activity rule denies the user Keychain, sandboxed Claude can read it for OAuth.
- Preserve Keychain read denial for non-Claude providers and do not add Keychain write access or system-Keychain access.
- Respect SBPL ordering explicitly. A suitable shape is default credential denies, then the provider-specific exception, then activity-authored denies; an equally safe design may reject an incompatible profile rather than silently widening it.
- Keep the OAuth diagnostic aligned with the effective compiled policy; it must not claim the Keychain was reachable when an activity rule intentionally denied it.

### Acceptance Criteria

- A Claude macOS sandbox profile with `denyRead` covering `$HOME/Library/Keychains` compiles so the explicit activity denial is effective, including when the denial targets a broader ancestor.
- A Claude profile without an overlapping activity denial still permits read access to the user's Keychain for OAuth, while non-Claude providers retain the default user-Keychain denial.
- Regression tests pin SBPL clause ordering and include a macOS-gated sandbox-exec check using a synthetic HOME for both the default-allow and explicit-deny Claude cases.
- No Keychain write permission or `/Library/Keychains` or `/System/Library/Keychains` read permission is introduced.
- OAuth failure diagnostics distinguish an intentionally denied Keychain from a reachable Keychain and do not recommend ineffective re-authentication.

## Execution Summary

<details>
<summary>Click to expand</summary>

Execution summary derived by Orbit for ORB-10931 from the change delivered by run jrun-20260817-0356-3; no execution summary was persisted by the implementing agent.

Changed files (9):
- modified: SECURITY.md
- modified: crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
- modified: crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
- modified: crates/orbit-exec/src/lib.rs
- modified: crates/orbit-exec/src/macos_sandbox/compile.rs
- modified: crates/orbit-exec/src/macos_sandbox/mod.rs
- modified: crates/orbit-exec/src/macos_sandbox/sbpl_filter.rs
- modified: crates/orbit-exec/src/macos_sandbox/test_support.rs
- modified: crates/orbit-exec/src/macos_sandbox/tests/compile.rs

This restates the worktree change the delivery commit contains and asserts nothing beyond it. Re-check it with `git show --stat` on the delivery commit.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10931-6a82868b`
- Behind base: 0
- Ahead of base: 1