### PR TITLE
chore: prepare v0.13.0 release [ORB-10930]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.13.0
+
+### Breaking Changes
+
+- **Store schema 15 → 16**: audit actor identity splits `role` into `actor_kind` plus a normalized actor. Workspaces migrate on open; a newer store still refuses an older binary. ([ORB-10888])
+- **Store schema 16 → 17**: unauthenticated MCP calls persist a self-reported actor. Same migrate-on-open / no-downgrade rule. ([ORB-10890])
+- **Task complexity is required**: CLI `task add`, web `POST /api/tasks`, and `orbit.task.add` reject a missing `complexity` — pass `low`, `medium`, or `hard`. ([ORB-10892])
+
+### Highlights
+
+- **Dashboard delivery controls**: inspect, toggle, and mint auto-tasks; operate routines and the sweep clock; the Tasks view is clearer with safer live-log and inline edits. ([ORB-10876])
+- **Complexity is first-class**: every new task must set it, and the dashboard charts it as a dimension. ([ORB-10892])
+- **Governed MCP tools need an operator**: unauthenticated sessions can no longer invoke those tools. ([ORB-10916])
+- **Claude Keychain OAuth under sandbox**: Claude can read the user Keychain for OAuth; an explicit `denyRead` still wins. ([ORB-10929])
+- **System crew is seeded**: jobs can name a portable `system` crew; `qa` stays for compatibility. ([ORB-10877])
+
 ## 0.12.1
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbit-agent"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cli"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cmd"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-common"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-config"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "orbit-common",
  "orbit-types",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-core"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "croner",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-engine"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-exec"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "libc",
  "orbit-common",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-mcp"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-policy"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-registry"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "hostname",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-search"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-store"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-tools"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-types"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-web"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.12.1"
+version = "0.13.0"
 edition = "2024"
 license = "MIT"
 # MSRV [ORB-10010]: edition 2024 requires >= 1.85; the highest `rust-version`

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface, skills, and orchestration subagents to Claude Code.",
   "author": {
     "name": "danieljhkim",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP task and knowledge surface plus workflow skills to Codex.",
   "author": {
     "name": "danieljhkim",

--- a/plugin/npm/package.json
+++ b/plugin/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbit-tools/cli",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "npm proxy for the Orbit CLI. Downloads the matching native binary from GitHub Releases on install and forwards all invocations.",
   "bin": {
     "orbit": "bin/orbit.js"


### PR DESCRIPTION
## Task
ORB-10930 — Prepare v0.13.0 release

## Execution Summary
Outcome: success
Bumps the five version-bearing files to 0.13.0 and compiles CHANGELOG.md from `v0.12.1..HEAD`. Daniel confirmed the three breaking-change candidates (ORB-10888, ORB-10890, ORB-10892) and authorized commit + tag.

## Validation
- `cargo update --workspace` only relocked Orbit workspace members
- `make build` clean
- `scripts/check-changelog-style.sh` pass
- `make release-check` expected pre-tag drift: local 0.13.0 > npm/gh 0.12.1
- smoke script already passes `--host-name` / `--task-prefix`

## Branch Freshness
Based on `origin/agent-main` at `1c9b5f1f`. Annotated tag `v0.13.0` points at this bump commit (`f9c3088e`) and has been pushed.