### PR TITLE
Package Orbit as a Cursor-compatible Agent Plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ ci-fast:
 	./scripts/check-orphan-modules.sh
 	./scripts/check-embedded-asset-portability.py
 	./scripts/test-validate-codex-plugin.sh
+	./scripts/test-validate-agent-plugin.sh
 
 # Compile-time pre-handoff gate for agents. Keep this invocation aligned with
 # the default workspace clippy pass in scripts/ci-guardrails.sh.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Paste the prompt below into your agent (Claude Code, Codex CLI, or Gemini CLI) *
 
 Faster to get running, and the right choice if you don't need to change how Orbit works: `curl`, Homebrew, or an agent plugin all give you a released, signed build. You give up the ability to reshape Orbit's conventions in place — you can always clone later and keep your `.orbit/` state.
 
-**Prerequisites:** at least one supported agent CLI (Codex, Claude Code, or Gemini CLI), authenticated. For PR-based workflows (i.e., `orbit run ship` in the default `--mode pr`), `gh` installed and authenticated; otherwise use `--mode local`. On Linux, install and verify the [Linux Bubblewrap host prerequisite](#linux-bubblewrap-host-prerequisite) after `orbit init`.
+**Prerequisites:** at least one supported agent CLI (Codex, Claude Code, Cursor, or Gemini CLI), authenticated. For PR-based workflows (i.e., `orbit run ship` in the default `--mode pr`), `gh` installed and authenticated; otherwise use `--mode local`. On Linux, install and verify the [Linux Bubblewrap host prerequisite](#linux-bubblewrap-host-prerequisite) after `orbit init`.
 
 <details>
 <summary><strong>Manual setup commands</strong> — copy these into your terminal (click to expand)</summary>
@@ -107,6 +107,10 @@ curl -sSf https://raw.githubusercontent.com/danieljhkim/orbit/main/install.sh | 
 # or, in Codex CLI:
 #   codex plugin marketplace add danieljhkim/orbit --ref main
 #   codex plugin add orbit@orbit
+# or, in Cursor (local Agent Plugin; marketplace publication is a human follow-up):
+#   mkdir -p ~/.cursor/plugins/local
+#   ln -sfn "$(pwd)/plugin" ~/.cursor/plugins/local/orbit
+#   # then restart Cursor or run Developer: Reload Window
 
 # initialize
 orbit init                                 # global state (~/.orbit)
@@ -208,7 +212,7 @@ After install, task writes are embedded automatically in the background; `orbit 
 
 ## Agent Plugins vs CLI
 
-Orbit ships lightweight Claude Code and Codex plugins. The CLI gives you the full power of Orbit; choose a plugin when you want Orbit's MCP tools and shared skills strapped onto one agent without installing `orbit` on your `$PATH`.
+Orbit ships lightweight Claude Code, Codex, and Cursor (Agent Plugins 1.0) plugins. The CLI gives you the full power of Orbit; choose a plugin when you want Orbit's MCP tools and shared skills strapped onto one agent without installing `orbit` on your `$PATH`.
 
 ```bash
 # Claude Code
@@ -219,23 +223,31 @@ Orbit ships lightweight Claude Code and Codex plugins. The CLI gives you the ful
 codex plugin marketplace add danieljhkim/orbit --ref main
 codex plugin add orbit@orbit
 
+# Cursor (local Agent Plugin)
+mkdir -p ~/.cursor/plugins/local
+ln -sfn "$(pwd)/plugin" ~/.cursor/plugins/local/orbit
+# Restart Cursor or run Developer: Reload Window, then confirm the Orbit
+# skill and MCP server under Customize → Plugins.
+
 # Later, after an Orbit release:
 codex plugin marketplace upgrade orbit
 codex plugin add orbit@orbit
 ```
 
+Cursor loads the same `plugin/skills/orbit` tree and `npx -y @orbit-tools/cli@latest mcp serve` contract through the root Agent Plugins 1.0 manifests (`plugin/plugin.json` and `plugin/mcp.json`). Public Cursor Marketplace submission, account setup, and publication are a human follow-up and are not part of this install path.
+
 <details>
 <summary><strong>Plugin vs. CLI</strong> — (click to expand)</summary>
 
-|   | **Claude Code plugin** | **Codex plugin** | **CLI (curl / brew)** |
-|---|---|---|---|
-| Install | `/plugin install orbit` after `/plugin marketplace add danieljhkim/orbit` | `codex plugin add orbit@orbit` after `codex plugin marketplace add danieljhkim/orbit --ref main` | `curl … \| sh` or `brew install danieljhkim/tap/orbit` |
-| Orbit binary | Lives inside the plugin sandbox (not on `$PATH`) | Lives inside the plugin cache (not on `$PATH`) | Installed on `$PATH` |
-| MCP registration | Automatic in Claude Code | Automatic in Codex | Manual: `orbit workspace init --mcp` per workspace |
-| Shared Orbit skills | Bundled from `plugin/skills/` | Bundled from `plugin/skills/` | Seeded by `orbit workspace init` |
-| Web dashboard (`orbit web serve`) | No | No | Yes |
-| Other agent CLIs | No, scoped to Claude Code | No, scoped to Codex | Yes |
-| Workflows (ship, run show/list/resume) | Yes — same MCP surface | Yes — same MCP surface | Yes — CLI or MCP |
+|   | **Claude Code plugin** | **Codex plugin** | **Cursor Agent Plugin** | **CLI (curl / brew)** |
+|---|---|---|---|---|
+| Install | `/plugin install orbit` after `/plugin marketplace add danieljhkim/orbit` | `codex plugin add orbit@orbit` after `codex plugin marketplace add danieljhkim/orbit --ref main` | Symlink `plugin/` to `~/.cursor/plugins/local/orbit`, then reload Cursor | `curl … \| sh` or `brew install danieljhkim/tap/orbit` |
+| Orbit binary | Lives inside the plugin sandbox (not on `$PATH`) | Lives inside the plugin cache (not on `$PATH`) | Launched via `npx -y @orbit-tools/cli@latest` (not on `$PATH`) | Installed on `$PATH` |
+| MCP registration | Automatic in Claude Code | Automatic in Codex | Automatic in Cursor from `plugin/mcp.json` | Manual: `orbit workspace init --mcp` per workspace |
+| Shared Orbit skills | Bundled from `plugin/skills/` | Bundled from `plugin/skills/` | Bundled from `plugin/skills/` | Seeded by `orbit workspace init` |
+| Web dashboard (`orbit web serve`) | No | No | No | Yes |
+| Other agent CLIs | No, scoped to Claude Code | No, scoped to Codex | No, scoped to Cursor | Yes |
+| Workflows (ship, run show/list/resume) | Yes — same MCP surface | Yes — same MCP surface | Yes — same MCP surface | Yes — CLI or MCP |
 
 </details>
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -105,7 +105,7 @@ Surface the breaking-change candidate list before drafting the final section. Sh
 
 ### 4. Bump versions
 
-Five files change every release:
+Six files change every release:
 
 | File | Field |
 |------|-------|
@@ -113,6 +113,7 @@ Five files change every release:
 | `Cargo.lock` | refresh via `cargo update --workspace` (no third-party drift) |
 | `plugin/.claude-plugin/plugin.json` | `version` |
 | `plugin/.codex-plugin/plugin.json` | `version` |
+| `plugin/plugin.json` | `version` |
 | `plugin/npm/package.json` | `version` |
 
 The other `0.X.Y` matches in the repo (install-script doc comments, the website task pages, the Node engine pin in `website/package-lock.json`) are intentional — leave them.
@@ -139,11 +140,12 @@ context_files:
   - file:Cargo.lock
   - file:plugin/.claude-plugin/plugin.json
   - file:plugin/.codex-plugin/plugin.json
+  - file:plugin/plugin.json
   - file:plugin/npm/package.json
   - file:scripts/smoke-plugin-install.sh
 ```
 
-Acceptance criteria: each of the five version-bearing file bumps reports the new version, the CHANGELOG section is in place with the agreed structure, every confirmed breaking change appears under Breaking Changes, and the plugin-install smoke script still drives this cycle's CLI non-interactively.
+Acceptance criteria: each of the six version-bearing file bumps reports the new version, the CHANGELOG section is in place with the agreed structure, every confirmed breaking change appears under Breaking Changes, and the plugin-install smoke script still drives this cycle's CLI non-interactively.
 
 ### 7. Human approval
 

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -8,13 +8,15 @@ related_features: [orbit-docs-plugin]
 
 # Release Orbit
 
-How to cut an Orbit release such that `/plugin install orbit` and
-`codex plugin add orbit@orbit` work against the new version. The version
-invariant is load-bearing: the npm package, the Claude and Codex plugin
+How to cut an Orbit release such that `/plugin install orbit`,
+`codex plugin add orbit@orbit`, and the Cursor Agent Plugin at
+`~/.cursor/plugins/local/orbit` work against the new version. The version
+invariant is load-bearing: the npm package, the Claude, Codex, and Agent Plugin
 manifests, and the GitHub Release tag must all agree, or the
 `npx -y @orbit-tools/cli@latest mcp serve` indirection in
-[`plugin/.mcp.json`](../../plugin/.mcp.json) and
-[`plugin/.codex-plugin/plugin.json`](../../plugin/.codex-plugin/plugin.json)
+[`plugin/.mcp.json`](../../plugin/.mcp.json),
+[`plugin/.codex-plugin/plugin.json`](../../plugin/.codex-plugin/plugin.json),
+and [`plugin/mcp.json`](../../plugin/mcp.json)
 downloads a binary that does not match the installed plugin manifest.
 
 See also [RELEASING.md](../../RELEASING.md) for the higher-level release runbook and versioning policy.
@@ -78,10 +80,11 @@ Each step names the exact file or command. Do them in order.
    any version fields. This runbook does not restate that policy.
 
 2. **Bump the plugin manifest versions** in
-   [`plugin/.claude-plugin/plugin.json`](../../plugin/.claude-plugin/plugin.json)
+   [`plugin/.claude-plugin/plugin.json`](../../plugin/.claude-plugin/plugin.json),
+   [`plugin/.codex-plugin/plugin.json`](../../plugin/.codex-plugin/plugin.json),
    and
-   [`plugin/.codex-plugin/plugin.json`](../../plugin/.codex-plugin/plugin.json)
-   (`.version`). Both must match step 1.
+   [`plugin/plugin.json`](../../plugin/plugin.json)
+   (`.version`). All three must match step 1.
 
 3. **Run `make release-check`.** Pre-tag, it will exit non-zero because
    `npm view @orbit-tools/cli version` and the latest `gh release list -L 1`
@@ -91,8 +94,8 @@ Each step names the exact file or command. Do them in order.
    in one of the files the check inspects.
 
 4. **Commit the version bumps** and merge to `agent-main`, the development
-   integration branch. One commit, one PR, one bump set — do not let the two
-   plugin manifests or the npm package drift across commits. If this cycle
+   integration branch. One commit, one PR, one bump set — do not let the Claude,
+   Codex, or Agent Plugin manifests or the npm package drift across commits. If this cycle
    changed any CLI the plugin-install smoke drives, land the
    [`scripts/smoke-plugin-install.sh`](../../scripts/smoke-plugin-install.sh)
    update in the same bump (or earlier). This is not the final release
@@ -354,19 +357,30 @@ asserts equality across these sources, when each is reachable:
 - `.version` in [`plugin/npm/package.json`](../../plugin/npm/package.json)
 - `.version` in [`plugin/.claude-plugin/plugin.json`](../../plugin/.claude-plugin/plugin.json)
 - `.version` in [`plugin/.codex-plugin/plugin.json`](../../plugin/.codex-plugin/plugin.json)
+- `.version` in [`plugin/plugin.json`](../../plugin/plugin.json)
 - `npm view @orbit-tools/cli version`
 - `gh release list -L 1` (latest tag, leading `v` stripped)
 
 It also runs
-[`scripts/validate-codex-plugin.sh`](../../scripts/validate-codex-plugin.sh),
-which checks the Codex manifest, repository marketplace entry, shared skill
-paths, and the absence of user-specific absolute paths or
-`CLAUDE_PROJECT_DIR` in Codex MCP configuration.
+[`scripts/validate-codex-plugin.sh`](../../scripts/validate-codex-plugin.sh)
+and
+[`scripts/validate-agent-plugin.sh`](../../scripts/validate-agent-plugin.sh).
+The Codex validator checks the Codex manifest, repository marketplace entry,
+shared skill paths, and the absence of user-specific absolute paths or
+`CLAUDE_PROJECT_DIR` in Codex MCP configuration. The Agent Plugin validator
+checks the official 1.0.0 `plugin.json` / `mcp.json` schemas, the shared
+`plugin/skills/orbit` skill, relative/portable paths, manifest version parity,
+and MCP command parity with Claude and Codex.
 
 Missing `npm` or `gh` is treated as a skip with a stderr note, not a hard
 failure, so the target stays usable on a fresh checkout without credentials.
 Mismatch across any reachable sources exits non-zero — so the pre-tag failure
 described in step 3 is by design.
+
+Cursor's local install path is the repository Agent Plugin at
+`plugin/`, symlinked to `~/.cursor/plugins/local/orbit`. Public Cursor
+Marketplace submission, publisher account setup, and listing review are a
+human follow-up and are not part of the release cut.
 
 ## Out-of-band fixes
 

--- a/plugin/mcp.json
+++ b/plugin/mcp.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "orbit": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@orbit-tools/cli@latest", "mcp", "serve"]
+    }
+  }
+}

--- a/plugin/npm/README.md
+++ b/plugin/npm/README.md
@@ -1,19 +1,19 @@
 # @orbit-tools/cli
 
 npm binary proxy for the [Orbit](https://github.com/danieljhkim/orbit) CLI and
-the supported Orbit plugins for Claude Code and Codex.
+the supported Orbit plugins for Claude Code, Codex, and Cursor.
 
 On install, downloads the matching prebuilt `orbit` binary from
 [GitHub Releases](https://github.com/danieljhkim/orbit/releases), authenticates
 the signed `orbit-checksums.txt` with the package-pinned release trust set,
 verifies the archive SHA-256, and exposes it as the `orbit` command.
 
-The Claude Code and Codex plugin manifests both launch this package as
-`npx -y @orbit-tools/cli@latest mcp serve`. Their plugin managers install the
-appropriate manifests, shared skills, and client-specific integration assets;
-users do not need to copy files from this package or the Orbit repository.
-Installing `@orbit-tools/cli` by itself provides the native CLI proxy, not the
-agent plugin assets.
+The Claude Code, Codex, and Cursor Agent Plugin manifests all launch this
+package as `npx -y @orbit-tools/cli@latest mcp serve`. Their plugin managers
+install the appropriate manifests, shared skills, and client-specific
+integration assets; users do not need to copy files from this package or the
+Orbit repository. Installing `@orbit-tools/cli` by itself provides the native
+CLI proxy, not the agent plugin assets.
 
 ## Usage
 
@@ -22,7 +22,7 @@ agent plugin assets.
 npm install -g @orbit-tools/cli
 orbit --version
 
-# One-shot via npx (used by the Orbit Claude Code and Codex plugins)
+# One-shot via npx (used by the Orbit Claude Code, Codex, and Cursor plugins)
 npx -y @orbit-tools/cli mcp serve
 ```
 

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "orbit",
+  "version": "0.13.0",
+  "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface and shared workflow skills to compatible clients.",
+  "author": {
+    "name": "danieljhkim",
+    "url": "https://github.com/danieljhkim"
+  },
+  "homepage": "https://github.com/danieljhkim/orbit",
+  "repository": "https://github.com/danieljhkim/orbit",
+  "license": "MIT",
+  "keywords": [
+    "orbit",
+    "task-management",
+    "agent-orchestration",
+    "mcp"
+  ]
+}

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -43,3 +43,5 @@ fi
 "$repo_root/scripts/check-changelog-style.sh"
 "$repo_root/scripts/check-error-translation.sh"
 "$repo_root/scripts/check-orphan-modules.sh"
+"$repo_root/scripts/test-validate-codex-plugin.sh"
+"$repo_root/scripts/test-validate-agent-plugin.sh"

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Verify the release-version invariant for the agent plugin install chain.
 #
-# The npm package version, the Claude/Codex plugin manifest versions, and the
-# latest GitHub Release tag must all agree. Drift here means `npx -y
+# The npm package version, the Claude/Codex/Agent Plugin manifest versions, and
+# the latest GitHub Release tag must all agree. Drift here means `npx -y
 # @orbit-tools/cli@latest mcp serve` downloads a binary tagged at a different
 # release than the installed plugin manifest advertises.
 #
@@ -16,6 +16,7 @@ cd "$repo_root"
 NPM_PKG="@orbit-tools/cli"
 CLAUDE_PLUGIN_MANIFEST="plugin/.claude-plugin/plugin.json"
 CODEX_PLUGIN_MANIFEST="plugin/.codex-plugin/plugin.json"
+AGENT_PLUGIN_MANIFEST="plugin/plugin.json"
 NPM_PACKAGE_JSON="plugin/npm/package.json"
 
 require_bin() {
@@ -28,7 +29,7 @@ require_bin() {
 
 require_bin jq
 
-for f in "$CLAUDE_PLUGIN_MANIFEST" "$CODEX_PLUGIN_MANIFEST" "$NPM_PACKAGE_JSON"; do
+for f in "$CLAUDE_PLUGIN_MANIFEST" "$CODEX_PLUGIN_MANIFEST" "$AGENT_PLUGIN_MANIFEST" "$NPM_PACKAGE_JSON"; do
   if [[ ! -f "$f" ]]; then
     echo "release-check: $f not found (run from repo root)" >&2
     exit 2
@@ -41,8 +42,15 @@ if [[ ! -x "scripts/validate-codex-plugin.sh" ]]; then
 fi
 "$repo_root/scripts/validate-codex-plugin.sh" "$repo_root" >/dev/null
 
+if [[ ! -x "scripts/validate-agent-plugin.sh" ]]; then
+  echo "release-check: scripts/validate-agent-plugin.sh is missing or not executable" >&2
+  exit 2
+fi
+"$repo_root/scripts/validate-agent-plugin.sh" "$repo_root" >/dev/null
+
 claude_plugin_version="$(jq -r .version "$CLAUDE_PLUGIN_MANIFEST")"
 codex_plugin_version="$(jq -r .version "$CODEX_PLUGIN_MANIFEST")"
+agent_plugin_version="$(jq -r .version "$AGENT_PLUGIN_MANIFEST")"
 npm_package_version="$(jq -r .version "$NPM_PACKAGE_JSON")"
 
 if [[ -z "$claude_plugin_version" || "$claude_plugin_version" == "null" ]]; then
@@ -51,6 +59,10 @@ if [[ -z "$claude_plugin_version" || "$claude_plugin_version" == "null" ]]; then
 fi
 if [[ -z "$codex_plugin_version" || "$codex_plugin_version" == "null" ]]; then
   echo "release-check: $CODEX_PLUGIN_MANIFEST has no .version field" >&2
+  exit 2
+fi
+if [[ -z "$agent_plugin_version" || "$agent_plugin_version" == "null" ]]; then
+  echo "release-check: $AGENT_PLUGIN_MANIFEST has no .version field" >&2
   exit 2
 fi
 if [[ -z "$npm_package_version" || "$npm_package_version" == "null" ]]; then
@@ -82,6 +94,7 @@ fi
 
 printf '%-32s %s\n' "$CLAUDE_PLUGIN_MANIFEST"    "$claude_plugin_version"
 printf '%-32s %s\n' "$CODEX_PLUGIN_MANIFEST"     "$codex_plugin_version"
+printf '%-32s %s\n' "$AGENT_PLUGIN_MANIFEST"     "$agent_plugin_version"
 printf '%-32s %s\n' "$NPM_PACKAGE_JSON"          "$npm_package_version"
 printf '%-32s %s\n' "npm view $NPM_PKG"          "${npm_registry_version:-<skipped>}"
 printf '%-32s %s\n' "gh release list -L 1"       "${gh_tag_version:-<skipped>}"
@@ -89,6 +102,14 @@ printf '%-32s %s\n' "gh release list -L 1"       "${gh_tag_version:-<skipped>}"
 drift=0
 if [[ "$claude_plugin_version" != "$codex_plugin_version" ]]; then
   echo "DRIFT: $CLAUDE_PLUGIN_MANIFEST ($claude_plugin_version) != $CODEX_PLUGIN_MANIFEST ($codex_plugin_version)" >&2
+  drift=1
+fi
+if [[ "$claude_plugin_version" != "$agent_plugin_version" ]]; then
+  echo "DRIFT: $CLAUDE_PLUGIN_MANIFEST ($claude_plugin_version) != $AGENT_PLUGIN_MANIFEST ($agent_plugin_version)" >&2
+  drift=1
+fi
+if [[ "$codex_plugin_version" != "$agent_plugin_version" ]]; then
+  echo "DRIFT: $CODEX_PLUGIN_MANIFEST ($codex_plugin_version) != $AGENT_PLUGIN_MANIFEST ($agent_plugin_version)" >&2
   drift=1
 fi
 if [[ "$claude_plugin_version" != "$npm_package_version" ]]; then
@@ -99,6 +120,10 @@ if [[ "$codex_plugin_version" != "$npm_package_version" ]]; then
   echo "DRIFT: $CODEX_PLUGIN_MANIFEST ($codex_plugin_version) != $NPM_PACKAGE_JSON ($npm_package_version)" >&2
   drift=1
 fi
+if [[ "$agent_plugin_version" != "$npm_package_version" ]]; then
+  echo "DRIFT: $AGENT_PLUGIN_MANIFEST ($agent_plugin_version) != $NPM_PACKAGE_JSON ($npm_package_version)" >&2
+  drift=1
+fi
 if [[ -n "$npm_registry_version" && "$claude_plugin_version" != "$npm_registry_version" ]]; then
   echo "DRIFT: $CLAUDE_PLUGIN_MANIFEST ($claude_plugin_version) != npm view $NPM_PKG ($npm_registry_version)" >&2
   drift=1
@@ -107,12 +132,20 @@ if [[ -n "$npm_registry_version" && "$codex_plugin_version" != "$npm_registry_ve
   echo "DRIFT: $CODEX_PLUGIN_MANIFEST ($codex_plugin_version) != npm view $NPM_PKG ($npm_registry_version)" >&2
   drift=1
 fi
+if [[ -n "$npm_registry_version" && "$agent_plugin_version" != "$npm_registry_version" ]]; then
+  echo "DRIFT: $AGENT_PLUGIN_MANIFEST ($agent_plugin_version) != npm view $NPM_PKG ($npm_registry_version)" >&2
+  drift=1
+fi
 if [[ -n "$gh_tag_version" && "$claude_plugin_version" != "$gh_tag_version" ]]; then
   echo "DRIFT: $CLAUDE_PLUGIN_MANIFEST ($claude_plugin_version) != latest gh release tag ($gh_tag_version)" >&2
   drift=1
 fi
 if [[ -n "$gh_tag_version" && "$codex_plugin_version" != "$gh_tag_version" ]]; then
   echo "DRIFT: $CODEX_PLUGIN_MANIFEST ($codex_plugin_version) != latest gh release tag ($gh_tag_version)" >&2
+  drift=1
+fi
+if [[ -n "$gh_tag_version" && "$agent_plugin_version" != "$gh_tag_version" ]]; then
+  echo "DRIFT: $AGENT_PLUGIN_MANIFEST ($agent_plugin_version) != latest gh release tag ($gh_tag_version)" >&2
   drift=1
 fi
 

--- a/scripts/test-validate-agent-plugin.sh
+++ b/scripts/test-validate-agent-plugin.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Exercise the repository-owned Agent Plugin validator and the Cursor local
+# plugins-directory discovery shape.
+set -euo pipefail
+
+repo_root="${1:-${ORBIT_REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}}"
+validator="$repo_root/scripts/validate-agent-plugin.sh"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "test-validate-agent-plugin: required binary 'python3' not on PATH" >&2
+  exit 2
+fi
+
+if ! grep -Fqx 'from __future__ import annotations' "$validator"; then
+  echo "test-validate-agent-plugin: validator must defer annotations for Python 3.9" >&2
+  exit 1
+fi
+
+python3 - <<'PY'
+from __future__ import annotations
+
+from typing import Any
+
+
+def accepts_optional_mapping(value: dict[str, Any] | None) -> list[str]:
+    return [] if value is None else list(value)
+
+
+assert accepts_optional_mapping(None) == []
+assert accepts_optional_mapping({"supported": True}) == ["supported"]
+PY
+
+fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/orbit-agent-plugin.XXXXXX")"
+trap 'rm -rf -- "$fixture_root"' EXIT
+
+cp -R "$repo_root/plugin" "$fixture_root/plugin"
+
+"$validator" "$fixture_root"
+
+python3 - "$repo_root" "$validator" "$fixture_root" <<'PY'
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+repo_root = Path(sys.argv[1])
+validator = Path(sys.argv[2])
+base_fixture = Path(sys.argv[3])
+
+errors: list[str] = []
+
+
+def run_validator(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(validator), str(root)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def clone_fixture(name: str) -> Path:
+    dest = base_fixture.parent / name
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(base_fixture, dest, symlinks=True)
+    return dest
+
+
+def expect_failure(root: Path, needle: str, label: str) -> None:
+    result = run_validator(root)
+    if result.returncode == 0:
+        errors.append(f"{label}: expected validator failure")
+        return
+    combined = result.stdout + result.stderr
+    if needle not in combined:
+        errors.append(f"{label}: stderr/stdout missing {needle!r}\n{combined}")
+
+
+# Cursor discovers Agent Plugins from ~/.cursor/plugins/local/<name>.
+home = base_fixture / "fake-home"
+cursor_plugin = home / ".cursor" / "plugins" / "local" / "orbit"
+if cursor_plugin.exists():
+    shutil.rmtree(cursor_plugin)
+shutil.copytree(base_fixture / "plugin", cursor_plugin, symlinks=True)
+
+plugin_manifest = json.loads((cursor_plugin / "plugin.json").read_text(encoding="utf-8"))
+mcp = json.loads((cursor_plugin / "mcp.json").read_text(encoding="utf-8"))
+skill = cursor_plugin / "skills" / "orbit" / "SKILL.md"
+if plugin_manifest.get("name") != "orbit":
+    errors.append("local Cursor plugin manifest name is not orbit")
+if "$schema" not in plugin_manifest:
+    errors.append("local Cursor plugin.json is missing $schema")
+if (cursor_plugin / ".cursor-plugin").exists():
+    errors.append("local Cursor plugin must not grow a .cursor-plugin surface")
+if not skill.is_file():
+    errors.append("local Cursor plugin does not expose plugin/skills/orbit/SKILL.md")
+orbit_mcp = mcp.get("mcpServers", {}).get("orbit", {})
+if orbit_mcp.get("command") != "npx" or orbit_mcp.get("args") != [
+    "-y",
+    "@orbit-tools/cli@latest",
+    "mcp",
+    "serve",
+]:
+    errors.append("local Cursor plugin MCP launch drifted from the portable npx contract")
+
+plugin_blob = (cursor_plugin / "plugin.json").read_text(encoding="utf-8")
+mcp_blob = (cursor_plugin / "mcp.json").read_text(encoding="utf-8")
+for blob, label in ((plugin_blob, "plugin.json"), (mcp_blob, "mcp.json")):
+    if str(repo_root) in blob or str(Path.home()) in blob:
+        errors.append(f"{label} embeds a repository- or user-specific absolute path")
+
+# Negative: missing official schema.
+broken = clone_fixture("missing-schema")
+payload = json.loads((broken / "plugin" / "plugin.json").read_text(encoding="utf-8"))
+del payload["$schema"]
+(broken / "plugin" / "plugin.json").write_text(json.dumps(payload), encoding="utf-8")
+expect_failure(broken, "$schema", "missing $schema")
+
+# Negative: version drift against Claude/Codex/npm.
+broken = clone_fixture("version-drift")
+payload = json.loads((broken / "plugin" / "plugin.json").read_text(encoding="utf-8"))
+payload["version"] = "0.0.0"
+(broken / "plugin" / "plugin.json").write_text(json.dumps(payload), encoding="utf-8")
+expect_failure(broken, "drifted", "version drift")
+
+# Negative: MCP command no longer matches Claude/Codex.
+broken = clone_fixture("mcp-drift")
+payload = json.loads((broken / "plugin" / "mcp.json").read_text(encoding="utf-8"))
+payload["mcpServers"]["orbit"]["command"] = "node"
+(broken / "plugin" / "mcp.json").write_text(json.dumps(payload), encoding="utf-8")
+expect_failure(broken, "MCP launch", "mcp command drift")
+
+# Negative: absolute path in the Agent Plugin MCP config.
+broken = clone_fixture("absolute-path")
+payload = json.loads((broken / "plugin" / "mcp.json").read_text(encoding="utf-8"))
+payload["mcpServers"]["orbit"]["command"] = "/usr/bin/npx"
+(broken / "plugin" / "mcp.json").write_text(json.dumps(payload), encoding="utf-8")
+expect_failure(broken, "absolute filesystem path", "absolute mcp path")
+
+# Negative: missing shared Orbit skill.
+broken = clone_fixture("missing-skill")
+skill_path = broken / "plugin" / "skills" / "orbit" / "SKILL.md"
+skill_path.unlink()
+expect_failure(broken, "SKILL.md", "missing orbit skill")
+
+# Negative: Cursor-specific surface that the task forbids.
+broken = clone_fixture("cursor-plugin-dir")
+(broken / "plugin" / ".cursor-plugin").mkdir()
+(broken / "plugin" / ".cursor-plugin" / "plugin.json").write_text("{}", encoding="utf-8")
+expect_failure(broken, ".cursor-plugin", "unexpected .cursor-plugin surface")
+
+if errors:
+    print("test-validate-agent-plugin: failed", file=sys.stderr)
+    for error in errors:
+        print(f"- {error}", file=sys.stderr)
+    raise SystemExit(1)
+
+print("test-validate-agent-plugin: local Cursor plugin fixture and validator cases passed")
+PY

--- a/scripts/validate-agent-plugin.sh
+++ b/scripts/validate-agent-plugin.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+# Validate the repository-owned Agent Plugins 1.0 package that Cursor loads.
+#
+# This lives in-repo so CI does not depend on a developer Cursor checkout.
+# It checks the official 1.0.0 plugin.json / mcp.json contracts, required
+# skill and MCP components, relative/portable paths, manifest version parity
+# with Claude/Codex/npm, and MCP launch parity with the existing plugin
+# integrations.
+set -euo pipefail
+
+repo_root="${1:-${ORBIT_REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "validate-agent-plugin: required binary 'python3' not on PATH" >&2
+  exit 2
+fi
+
+python3 - "$repo_root" <<'PY'
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+repo = Path(sys.argv[1]).resolve()
+plugin_root = repo / "plugin"
+manifest_path = plugin_root / "plugin.json"
+mcp_path = plugin_root / "mcp.json"
+claude_manifest_path = plugin_root / ".claude-plugin" / "plugin.json"
+codex_manifest_path = plugin_root / ".codex-plugin" / "plugin.json"
+claude_mcp_path = plugin_root / ".mcp.json"
+npm_package_path = plugin_root / "npm" / "package.json"
+
+PLUGIN_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+MCP_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json"
+PLUGIN_NAME_RE = re.compile(
+    r"^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$"
+)
+SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\."
+    r"(0|[1-9]\d*)\."
+    r"(0|[1-9]\d*)"
+    r"(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\."
+    r"(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+EXPECTED_MCP_COMMAND = "npx"
+EXPECTED_MCP_ARGS = ["-y", "@orbit-tools/cli@latest", "mcp", "serve"]
+PLUGIN_MANIFEST_KEYS = {
+    "$schema",
+    "name",
+    "version",
+    "description",
+    "author",
+    "homepage",
+    "repository",
+    "license",
+    "keywords",
+    "extensions",
+}
+MCP_TOP_KEYS = {"$schema", "mcpServers"}
+STDIO_KEYS = {"type", "command", "args", "env", "cwd"}
+
+errors: list[str] = []
+
+
+def load_json(path: Path, label: str) -> dict[str, Any] | None:
+    if not path.is_file():
+        errors.append(f"{label} is missing")
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        errors.append(f"{label} is not valid JSON: {exc}")
+        return None
+    if not isinstance(payload, dict):
+        errors.append(f"{label} must contain a JSON object")
+        return None
+    return payload
+
+
+def require_string(payload: dict[str, Any], key: str, label: str) -> str | None:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{label}.{key} must be a non-empty string")
+        return None
+    return value
+
+
+def reject_todos(value: Any, path: str) -> None:
+    if isinstance(value, str):
+        if "[TODO:" in value:
+            errors.append(f"{path} still contains a [TODO: ...] placeholder")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            reject_todos(item, f"{path}[{index}]")
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            reject_todos(item, f"{path}.{key}")
+
+
+def reject_user_specific_paths(value: Any, path: str) -> None:
+    if isinstance(value, str):
+        if "CLAUDE_PROJECT_DIR" in value:
+            errors.append(f"{path} must not reference CLAUDE_PROJECT_DIR")
+        if str(Path.home()) in value:
+            errors.append(f"{path} must not embed a user-specific absolute home path")
+        if value.startswith("/") or (len(value) >= 3 and value[1] == ":" and value[0].isalpha()):
+            errors.append(f"{path} must not use an absolute filesystem path")
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            reject_user_specific_paths(item, f"{path}[{index}]")
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key in {"$schema", "url", "homepage", "repository"}:
+                continue
+            if isinstance(item, dict) and "url" in item and key != "author":
+                rest = {k: v for k, v in item.items() if k != "url"}
+                reject_user_specific_paths(rest, f"{path}.{key}")
+                continue
+            reject_user_specific_paths(item, f"{path}.{key}")
+
+
+def mcp_launch(payload: dict[str, Any] | None, label: str) -> tuple[str, list[str]] | None:
+    if payload is None:
+        return None
+    servers = payload.get("mcpServers")
+    if not isinstance(servers, dict):
+        errors.append(f"{label}.mcpServers must be an object")
+        return None
+    orbit = servers.get("orbit")
+    if not isinstance(orbit, dict):
+        errors.append(f"{label}.mcpServers.orbit must be an object")
+        return None
+    command = orbit.get("command")
+    args = orbit.get("args")
+    if not isinstance(command, str) or not command.strip():
+        errors.append(f"{label}.mcpServers.orbit.command must be a non-empty string")
+        return None
+    if not isinstance(args, list) or not all(isinstance(arg, str) and arg.strip() for arg in args):
+        errors.append(f"{label}.mcpServers.orbit.args must be an array of non-empty strings")
+        return None
+    return command, args
+
+
+def validate_skill_frontmatter(skill_dir: Path) -> None:
+    skill_path = skill_dir / "SKILL.md"
+    if not skill_path.is_file():
+        errors.append(f"skill {skill_dir.name} is missing SKILL.md")
+        return
+    text = skill_path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        errors.append(f"skill {skill_dir.name} must start with YAML frontmatter")
+        return
+    end = text.find("\n---", 4)
+    if end == -1:
+        errors.append(f"skill {skill_dir.name} frontmatter is not closed")
+        return
+    fields: dict[str, str] = {}
+    for line in text[4:end].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        fields[key.strip()] = value.strip().strip('"').strip("'")
+    for key in ("name", "description"):
+        if not fields.get(key):
+            errors.append(f"skill {skill_dir.name} frontmatter field {key} must be non-empty")
+
+
+def relative_plugin_cwd(raw: Any) -> bool:
+    if not isinstance(raw, str) or not raw:
+        return False
+    if raw.startswith("${PLUGIN_ROOT}") or raw.startswith("${PLUGIN_DATA}"):
+        return True
+    path = PurePosixPath(raw.replace("\\", "/"))
+    return not path.is_absolute() and ".." not in path.parts and raw.startswith("./")
+
+
+manifest = load_json(manifest_path, "plugin/plugin.json")
+mcp = load_json(mcp_path, "plugin/mcp.json")
+claude_manifest = load_json(claude_manifest_path, "plugin/.claude-plugin/plugin.json")
+codex_manifest = load_json(codex_manifest_path, "plugin/.codex-plugin/plugin.json")
+claude_mcp = load_json(claude_mcp_path, "plugin/.mcp.json")
+npm_package = load_json(npm_package_path, "plugin/npm/package.json")
+
+if (plugin_root / ".cursor-plugin").exists():
+    errors.append(
+        "plugin/.cursor-plugin must not exist; Cursor loads the Agent Plugins "
+        "surface from plugin/plugin.json, plugin/mcp.json, and plugin/skills/"
+    )
+
+if manifest is not None:
+    reject_todos(manifest, "plugin/plugin.json")
+    reject_user_specific_paths(manifest, "plugin/plugin.json")
+    for key in sorted(set(manifest) - PLUGIN_MANIFEST_KEYS):
+        errors.append(f"plugin/plugin.json field {key} is not supported by Agent Plugins 1.0")
+    if manifest.get("$schema") != PLUGIN_SCHEMA:
+        errors.append("plugin/plugin.json.$schema must be the Agent Plugins 1.0.0 plugin schema")
+    name = require_string(manifest, "name", "plugin/plugin.json")
+    if name is not None:
+        if name != "orbit":
+            errors.append("plugin/plugin.json.name must be 'orbit'")
+        if len(name) > 64 or PLUGIN_NAME_RE.fullmatch(name) is None:
+            errors.append("plugin/plugin.json.name must match the Agent Plugins 1.0 name pattern")
+    version = require_string(manifest, "version", "plugin/plugin.json")
+    if version is not None and SEMVER_RE.fullmatch(version) is None:
+        errors.append("plugin/plugin.json.version must use strict semver")
+    require_string(manifest, "description", "plugin/plugin.json")
+    require_string(manifest, "license", "plugin/plugin.json")
+    author = manifest.get("author")
+    if not isinstance(author, dict):
+        errors.append("plugin/plugin.json.author must be an object")
+    else:
+        require_string(author, "name", "plugin/plugin.json.author")
+        for extra in sorted(set(author) - {"name", "email", "url"}):
+            errors.append(f"plugin/plugin.json.author field {extra} is not supported")
+    keywords = manifest.get("keywords")
+    if keywords is not None and (
+        not isinstance(keywords, list) or not all(isinstance(item, str) and item.strip() for item in keywords)
+    ):
+        errors.append("plugin/plugin.json.keywords must be an array of non-empty strings")
+
+    versions: list[tuple[str, str]] = []
+    if version is not None:
+        versions.append(("plugin/plugin.json", version))
+    for path, payload, label in (
+        (claude_manifest_path, claude_manifest, "plugin/.claude-plugin/plugin.json"),
+        (codex_manifest_path, codex_manifest, "plugin/.codex-plugin/plugin.json"),
+        (npm_package_path, npm_package, "plugin/npm/package.json"),
+    ):
+        if payload is None:
+            continue
+        other = payload.get("version")
+        if not isinstance(other, str) or not other.strip():
+            errors.append(f"{label}.version must be a non-empty string")
+            continue
+        versions.append((label, other))
+    distinct = {item[1] for item in versions}
+    if len(distinct) > 1:
+        rendered = ", ".join(f"{label}={ver}" for label, ver in versions)
+        errors.append(f"plugin manifest versions drifted: {rendered}")
+
+if mcp is not None:
+    reject_todos(mcp, "plugin/mcp.json")
+    reject_user_specific_paths(mcp, "plugin/mcp.json")
+    for key in sorted(set(mcp) - MCP_TOP_KEYS):
+        errors.append(f"plugin/mcp.json field {key} is not supported by Agent Plugins 1.0")
+    if mcp.get("$schema") != MCP_SCHEMA:
+        errors.append("plugin/mcp.json.$schema must be the Agent Plugins 1.0.0 MCP schema")
+    servers = mcp.get("mcpServers")
+    if not isinstance(servers, dict) or not servers:
+        errors.append("plugin/mcp.json.mcpServers must be a non-empty object")
+    else:
+        if "orbit" not in servers:
+            errors.append("plugin/mcp.json.mcpServers must register the orbit server")
+        for server_name, server in servers.items():
+            if not isinstance(server_name, str) or not server_name.strip():
+                errors.append("plugin/mcp.json.mcpServers keys must be non-empty strings")
+            if not isinstance(server, dict):
+                errors.append(f"plugin/mcp.json.mcpServers.{server_name} must be an object")
+                continue
+            server_type = server.get("type")
+            if server_type != "stdio":
+                errors.append(f"plugin/mcp.json.mcpServers.{server_name}.type must be 'stdio'")
+            for extra in sorted(set(server) - STDIO_KEYS):
+                errors.append(
+                    f"plugin/mcp.json.mcpServers.{server_name} field {extra} is not supported"
+                )
+            cwd = server.get("cwd")
+            if cwd is not None and not relative_plugin_cwd(cwd):
+                errors.append(
+                    f"plugin/mcp.json.mcpServers.{server_name}.cwd must be plugin-relative"
+                )
+            env = server.get("env")
+            if env is not None:
+                if not isinstance(env, dict) or not all(
+                    isinstance(k, str) and isinstance(v, str) for k, v in env.items()
+                ):
+                    errors.append(
+                        f"plugin/mcp.json.mcpServers.{server_name}.env must be a string map"
+                    )
+                else:
+                    for reserved in ("PLUGIN_ROOT", "PLUGIN_DATA"):
+                        if reserved in env:
+                            errors.append(
+                                f"plugin/mcp.json.mcpServers.{server_name}.env must not set {reserved}"
+                            )
+
+agent_launch = mcp_launch(mcp, "plugin/mcp.json")
+claude_launch = mcp_launch(claude_mcp, "plugin/.mcp.json")
+codex_launch = mcp_launch(
+    codex_manifest if isinstance(codex_manifest, dict) else None,
+    "plugin/.codex-plugin/plugin.json",
+)
+expected = (EXPECTED_MCP_COMMAND, EXPECTED_MCP_ARGS)
+for label, launch in (
+    ("plugin/mcp.json", agent_launch),
+    ("plugin/.mcp.json", claude_launch),
+    ("plugin/.codex-plugin/plugin.json", codex_launch),
+):
+    if launch is None:
+        continue
+    if launch != expected:
+        errors.append(
+            f"{label} MCP launch must be {EXPECTED_MCP_COMMAND} {' '.join(EXPECTED_MCP_ARGS)}"
+        )
+
+skills_root = plugin_root / "skills"
+orbit_skill = skills_root / "orbit"
+if not orbit_skill.is_dir():
+    errors.append("plugin/skills/orbit is missing")
+else:
+    validate_skill_frontmatter(orbit_skill)
+if skills_root.is_dir():
+    for skill_dir in sorted(path for path in skills_root.iterdir() if path.is_dir()):
+        validate_skill_frontmatter(skill_dir)
+
+if errors:
+    print("validate-agent-plugin: failed", file=sys.stderr)
+    for error in errors:
+        print(f"- {error}", file=sys.stderr)
+    raise SystemExit(1)
+
+print(f"validate-agent-plugin: plugin manifest is valid ({manifest_path.relative_to(repo)})")
+PY


### PR DESCRIPTION
## Task

[ORB-10943](https://orbit-cli.com/tasks/ORB-10943) — Package Orbit as a Cursor-compatible Agent Plugin

### Description

Orbit ships installable Claude Code and Codex plugin metadata, but Cursor users cannot install the same shared Orbit skill and MCP server as a first-class plugin.

Add a portable Agent Plugin wrapper at the existing `plugin/` root using the open Agent Plugins 1.0 manifest and root MCP configuration supported by Cursor. Reuse the canonical `plugin/skills/orbit` content and existing MCP launch contract; do not fork the skill tree or add Cursor-only rules, agents, commands, or hooks without a demonstrated need. Extend validation, documentation, and release version checks so the Cursor entrypoint cannot drift from the Claude, Codex, and npm packages.

The deliverable is a repository-ready plugin and local Cursor installation path. Submission to Cursor's public marketplace is an external, human-reviewed follow-up and is not part of this task.

### Acceptance Criteria

- The `plugin/` root contains an Agent Plugins 1.0 `plugin.json` using the official schema and metadata/version consistent with the existing Orbit plugin manifests.
- The root `mcp.json` registers the Orbit MCP server with the same portable `npx -y @orbit-tools/cli@latest mcp serve` contract used by the existing plugin integrations.
- Cursor discovers the shared `plugin/skills/orbit` skill through the Agent Plugin without duplicating skill content or adding unnecessary `.cursor-plugin`-specific surface.
- Repository validation checks the Agent Plugin schema contract, required skill and MCP components, relative/portable paths, manifest version parity, and MCP command parity with the existing Codex and Claude configuration.
- The relevant Makefile/CI validation target runs the new plugin checks, while existing Claude and Codex plugin validation continues to pass.
- README installation guidance and the plugin support matrix include Cursor, with a reproducible local-development/smoke-test path using Cursor's local plugins directory.
- Release documentation lists the Cursor/Agent Plugin manifest among versioned plugin artifacts and prevents releases when plugin versions drift.
- A fixture or local smoke test proves the plugin exposes the Orbit skill and MCP registration without repository- or user-specific absolute paths.
- `make ci-fast` and `make ci-lint` pass, together with all focused plugin validation scripts.
- Public Cursor Marketplace submission, account setup, and publication are explicitly excluded and left as a documented human follow-up.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added Agent Plugins 1.0 `plugin/plugin.json` and `plugin/mcp.json` at the existing plugin root, reusing `plugin/skills/orbit` and the portable `npx -y @orbit-tools/cli@latest mcp serve` contract. No `.cursor-plugin/` surface.
- Added `scripts/validate-agent-plugin.sh` (schema, required skill + MCP, relative/portable paths, version parity, MCP command parity vs Claude `.mcp.json` and Codex) and `scripts/test-validate-agent-plugin.sh` (copies the plugin into a fake `~/.cursor/plugins/local/orbit` fixture plus negative cases).
- Wired the new checks into `Makefile` `ci-fast`, `scripts/ci-guardrails.sh` (alongside existing Codex plugin validation), and `scripts/release-check.sh` version lockstep.
- Documented Cursor in README (install path + support matrix), RELEASING.md, `docs/runbooks/release.md`, and `plugin/npm/README.md`. Public Cursor Marketplace submission is an explicit human follow-up.
Assessment: Scoped to the plugin wrapper, validation, and docs. Claude/Codex plugin validation still passes. `make ci-fast` and `make ci-lint` passed.
Strategic decisions:
- Root Agent Plugins manifests instead of `.cursor-plugin/`, matching Cursor's documented Agent Plugins discovery and the task's no-fork constraint.
- MCP command parity is compared as command+args only so Claude `.mcp.json` (no `type`) and the Agent Plugin schema (`type: stdio`) can coexist.
Design weaknesses / risks:
- Severity: low. Cursor local install is a symlink to `plugin/`, which also contains Claude/Codex metadata; extra files are ignored but the directory is not a minimal Agent Plugin-only tree.
- Mitigation: validator forbids `.cursor-plugin/` and asserts the portable skill + MCP files; marketplace publication remains a human follow-up.
Deviations from original plan: none (plan was authored at pickup).
Recommended follow-ups:
- Human: submit the Agent Plugin to the public Cursor Marketplace (account setup, listing, review).
- Friction F2026-08-101: jrun sandboxes make `orbit tool run` fail with EROFS on `$ORBIT_ROOT/skills`; this run used `env -u ORBIT_ROOT` so writes still landed in the durable store.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10943-6a88ff26`
- Behind base: 0
- Ahead of base: 1