### PR TITLE
Add GitHub Copilot CLI as a first-class Orbit workflow executor

### DIFF
--- a/crates/orbit-agent/src/agent/agent.rs
+++ b/crates/orbit-agent/src/agent/agent.rs
@@ -16,6 +16,7 @@ pub enum ProviderOptions {
     },
     Gemini,
     Grok,
+    Copilot,
     Ollama,
     Mock,
 }

--- a/crates/orbit-agent/src/lib.rs
+++ b/crates/orbit-agent/src/lib.rs
@@ -62,6 +62,7 @@ mod types;
 
 pub use agent::{Agent, AgentConfig, ProviderOptions};
 pub use orbit_types::telemetry::{InvocationTrace, TokenUsage, ToolCallTrace};
+pub use providers::normalize_cli_stdout;
 pub use runtime::AgentRuntime;
 pub use types::{AgentInvocationSpec, AgentOperation, AgentRequest, AgentResponseStatus};
 pub use types::{

--- a/crates/orbit-agent/src/providers/copilot/copilot_cli.rs
+++ b/crates/orbit-agent/src/providers/copilot/copilot_cli.rs
@@ -1,0 +1,47 @@
+use crate::providers::common::render_prompt_with_embedded_envelope;
+
+/// Per-request command construction for the standalone GitHub Copilot CLI.
+///
+/// Static flags (`--allow-all-tools`, `--no-ask-user`, `--output-format json`,
+/// …) live in the shipped `copilot` executor definition; this transport only
+/// adds what varies per request. [ORB-10946]
+pub(crate) struct CopilotCliTransport {
+    model: Option<String>,
+}
+
+impl CopilotCliTransport {
+    pub(crate) fn new(model: Option<String>) -> Self {
+        Self { model }
+    }
+
+    /// Explicit model selection only. Copilot would otherwise fall back to
+    /// `COPILOT_MODEL` or its own persisted `/model` choice, which would make
+    /// the model actually used by a run depend on ambient operator state
+    /// rather than on the crew assignment Orbit resolved.
+    pub(crate) fn args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+
+        if let Some(model) = &self.model {
+            args.push("--model".to_string());
+            args.push(model.clone());
+        }
+
+        args
+    }
+
+    /// The prompt travels on **stdin**, never as a `-p <text>` argument.
+    ///
+    /// `copilot` documents both transports — its own no-prompt error reads
+    /// "provide a prompt with -p or via standard in" — and stdin is the one
+    /// that keeps the Orbit execution envelope out of argv. Argv is visible to
+    /// every process on the host, is recorded in Orbit's audit argv, and is
+    /// echoed back in spawn-failure messages; the envelope carries task
+    /// context and instructions, so it must not travel there. [ORB-10946]
+    pub(crate) fn stdin(&self, envelope_json: &[u8]) -> Vec<u8> {
+        render_prompt_with_embedded_envelope(envelope_json)
+    }
+
+    pub(crate) fn model_name(&self) -> Option<&str> {
+        self.model.as_deref()
+    }
+}

--- a/crates/orbit-agent/src/providers/copilot/copilot_runtime.rs
+++ b/crates/orbit-agent/src/providers/copilot/copilot_runtime.rs
@@ -1,0 +1,108 @@
+use std::collections::HashMap;
+
+use orbit_common::OrbitError;
+use orbit_types::telemetry::InvocationTrace;
+
+use crate::agent::{AgentConfig, ProviderOptions};
+use crate::providers::copilot::copilot_cli::CopilotCliTransport;
+use crate::runtime::{AgentRuntime, AgentRuntimeFactory};
+use crate::types::{AgentInvocationSpec, AgentRequest};
+
+const RUNTIME_KEY: &str = "copilot";
+
+/// Non-credential process context the Copilot CLI needs before it can read
+/// Orbit's envelope.
+///
+/// `COPILOT_HOME` is listed alongside `HOME`/`PATH` because the sandbox grants
+/// exactly the directory it names: if the operator sets it but the child never
+/// receives it, the CLI would write state to `$HOME/.copilot` while the
+/// profile granted the override path, and startup would fail on a denial that
+/// points at the wrong directory.
+///
+/// Copilot's credentials are deliberately **absent** here.
+/// `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, and `GITHUB_TOKEN` are credentials, and
+/// `child_env` admits credentials only by operator-named opt-in through
+/// `[execution.env].pass`. Orbit never forwards them on the provider's behalf,
+/// so a Copilot run cannot silently pick up a GitHub token that an unrelated
+/// tool left in the environment. With no token passed, the CLI uses the
+/// credentials `copilot /login` stored under `COPILOT_HOME`. [ORB-10946]
+const REQUIRED_ENV_VARS: &[&str] = &["HOME", "PATH", "COPILOT_HOME"];
+
+pub(crate) struct CopilotRuntime {
+    command: String,
+    cli: CopilotCliTransport,
+    runtime_key: &'static str,
+    required_env_vars: &'static [&'static str],
+}
+
+pub(crate) struct CopilotFactory;
+
+impl CopilotRuntime {
+    pub(crate) fn new(
+        command: String,
+        model: Option<String>,
+        runtime_key: &'static str,
+        required_env_vars: &'static [&'static str],
+    ) -> Self {
+        Self {
+            command,
+            cli: CopilotCliTransport::new(model),
+            runtime_key,
+            required_env_vars,
+        }
+    }
+}
+
+impl AgentRuntimeFactory for CopilotFactory {
+    fn key(&self) -> &'static str {
+        RUNTIME_KEY
+    }
+
+    fn required_env_vars(&self) -> &'static [&'static str] {
+        REQUIRED_ENV_VARS
+    }
+
+    fn options_from_config(
+        &self,
+        _config: &HashMap<String, String>,
+    ) -> Result<ProviderOptions, OrbitError> {
+        Ok(ProviderOptions::Copilot)
+    }
+
+    fn build(&self, cfg: &AgentConfig) -> Result<Box<dyn AgentRuntime>, OrbitError> {
+        match &cfg.provider_options {
+            ProviderOptions::Copilot => Ok(Box::new(CopilotRuntime::new(
+                cfg.command.clone(),
+                cfg.model.clone(),
+                self.key(),
+                self.required_env_vars(),
+            ))),
+            _ => Err(OrbitError::InvalidInput(format!(
+                "provider options '{}' cannot build copilot runtime",
+                cfg.provider_key
+            ))),
+        }
+    }
+}
+
+impl AgentRuntime for CopilotRuntime {
+    fn invoke(
+        &self,
+        req: AgentRequest,
+    ) -> Result<(AgentInvocationSpec, InvocationTrace), OrbitError> {
+        Ok((
+            crate::providers::build_invocation_spec(
+                self.runtime_key,
+                self.required_env_vars,
+                self.command.clone(),
+                self.cli.args(),
+                self.cli.stdin(&req.envelope_json),
+            ),
+            InvocationTrace::default(),
+        ))
+    }
+
+    fn model_name(&self) -> Option<&str> {
+        self.cli.model_name()
+    }
+}

--- a/crates/orbit-agent/src/providers/copilot/copilot_stream.rs
+++ b/crates/orbit-agent/src/providers/copilot/copilot_stream.rs
@@ -1,0 +1,78 @@
+//! Normalizing the Copilot CLI's JSONL agent-event stream into the bytes
+//! Orbit's response/envelope contract is allowed to read. [ORB-10946]
+//!
+//! `copilot --output-format json` documents its stdout as "JSONL, one JSON
+//! object per line". Every line is an agent-event frame:
+//!
+//! ```text
+//! {"type":"session.warning","data":{…},"ephemeral":true,"id":"…","timestamp":"…"}
+//! {"type":"assistant.message","data":{"content":"…"},"id":"…","timestamp":"…"}
+//! ```
+//!
+//! Orbit's envelope finder searches a provider's stdout in reverse for a
+//! recognizable envelope, descending through wrapper objects and JSON-encoded
+//! strings. Handed a raw Copilot stream, that search is unsafe in one specific
+//! way: Copilot echoes the *prompt* back as a `user.message` event, and every
+//! Orbit prompt embeds a literal example envelope in its response contract
+//! (`{"schemaVersion":1,"status":"success|failed|timeout",…}`). A run that
+//! produced no model output at all still carries that echo, so the finder
+//! could read Orbit's own instructions back as if they were the agent's
+//! completion evidence.
+//!
+//! So this module reduces the stream to model-authored frames before any
+//! protocol read. What survives is what Copilot itself produced; what is
+//! dropped is Orbit's own prompt coming back and the session control plane.
+//! When nothing survives — the auth-failure and cancellation shapes — the
+//! result is empty, and an empty stdout carries no envelope, which is exactly
+//! how a missing completion is meant to be reported.
+
+/// Event-type prefixes whose frames are model output.
+///
+/// `assistant.` carries the agent's messages (`assistant.message`), reasoning,
+/// and per-turn token accounting (`assistant.usage`) that Orbit's invocation
+/// trace reads. `error.` carries the provider's own failure frames
+/// (`error.exception`), which must reach the diagnostic path rather than be
+/// silently discarded.
+///
+/// This is a prefix allowlist rather than an exact-type list so a new
+/// `assistant.*` subtype in a later CLI release keeps flowing instead of being
+/// dropped by a stale table — while `user.*` and `session.*`, the two families
+/// that can replay Orbit's own prompt, stay excluded by construction.
+const MODEL_OUTPUT_EVENT_PREFIXES: &[&str] = &["assistant.", "error."];
+
+/// Reduce a Copilot JSONL stream to its model-authored frames.
+///
+/// Returns the retained frames as JSONL. Lines that are not valid JSON, frames
+/// with no `type` string, and frames outside [`MODEL_OUTPUT_EVENT_PREFIXES`]
+/// are dropped: a malformed or truncated stream degrades toward "no completion
+/// evidence", never toward a false one.
+pub(crate) fn normalize_copilot_stdout(stdout: &[u8]) -> Vec<u8> {
+    let text = String::from_utf8_lossy(stdout);
+    let mut out = String::new();
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+            continue;
+        };
+        if !is_model_output_frame(&value) {
+            continue;
+        }
+        out.push_str(trimmed);
+        out.push('\n');
+    }
+    out.into_bytes()
+}
+
+fn is_model_output_frame(value: &serde_json::Value) -> bool {
+    value
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|event_type| {
+            MODEL_OUTPUT_EVENT_PREFIXES
+                .iter()
+                .any(|prefix| event_type.starts_with(prefix))
+        })
+}

--- a/crates/orbit-agent/src/providers/copilot/mod.rs
+++ b/crates/orbit-agent/src/providers/copilot/mod.rs
@@ -1,0 +1,9 @@
+pub(crate) mod copilot_cli;
+mod copilot_runtime;
+mod copilot_stream;
+
+pub(crate) use copilot_runtime::CopilotFactory;
+pub(crate) use copilot_stream::normalize_copilot_stdout;
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-agent/src/providers/copilot/tests/copilot_cli.rs
+++ b/crates/orbit-agent/src/providers/copilot/tests/copilot_cli.rs
@@ -1,0 +1,57 @@
+#![allow(missing_docs)]
+
+use super::super::copilot_cli::CopilotCliTransport;
+
+#[test]
+fn args_pass_explicit_model_with_long_flag() {
+    let transport = CopilotCliTransport::new(Some("claude-sonnet-4.5".to_string()));
+
+    assert_eq!(transport.args(), vec!["--model", "claude-sonnet-4.5"]);
+}
+
+#[test]
+fn args_propagate_a_model_from_any_vendor_verbatim() {
+    // Copilot routes to several vendors. The provider identity stays
+    // `copilot`; the model string is passed through untouched and is never
+    // rewritten toward the vendor that supplies it. [ORB-10946]
+    for model in ["gpt-5.4", "claude-opus-4.5", "gemini-3.7-flash"] {
+        let transport = CopilotCliTransport::new(Some(model.to_string()));
+
+        assert_eq!(transport.args(), vec!["--model", model]);
+    }
+}
+
+#[test]
+fn args_are_empty_without_a_model() {
+    let transport = CopilotCliTransport::new(None);
+
+    assert!(transport.args().is_empty());
+}
+
+#[test]
+fn prompt_travels_on_stdin_and_never_through_argv() {
+    // The security property behind choosing stdin over `-p <text>`: argv is
+    // world-readable through process listings and is recorded in Orbit's
+    // audit argv, so the execution envelope must not appear there.
+    let envelope = br#"{"schemaVersion":1,"input":{"secret_path":"/srv/tenant-42"}}"#;
+    let transport = CopilotCliTransport::new(Some("claude-sonnet-4.5".to_string()));
+
+    let stdin = String::from_utf8(transport.stdin(envelope)).expect("utf8 stdin");
+    assert!(stdin.contains("/srv/tenant-42"));
+    assert!(stdin.contains("Execution envelope:"));
+
+    let argv = transport.args().join(" ");
+    assert!(!argv.contains("/srv/tenant-42"));
+    assert!(!argv.contains("schemaVersion"));
+    assert!(!argv.contains("-p"));
+    assert!(!argv.contains("--prompt"));
+}
+
+#[test]
+fn model_name_reports_the_selected_model() {
+    assert_eq!(
+        CopilotCliTransport::new(Some("gpt-5.4".to_string())).model_name(),
+        Some("gpt-5.4")
+    );
+    assert_eq!(CopilotCliTransport::new(None).model_name(), None);
+}

--- a/crates/orbit-agent/src/providers/copilot/tests/copilot_stream.rs
+++ b/crates/orbit-agent/src/providers/copilot/tests/copilot_stream.rs
@@ -1,0 +1,193 @@
+#![allow(missing_docs)]
+
+//! Fixture shapes here are taken from a real `copilot --output-format json`
+//! run (CLI 1.0.80, npm `@github/copilot`). The auth-failure fixture is a
+//! verbatim capture; the success/cancellation shapes use the same frame
+//! envelope and the event vocabulary the shipped bundle emits. [ORB-10946]
+
+use orbit_types::tool::ExecutionResult;
+
+use crate::providers::normalize_cli_stdout;
+use crate::types::{AgentResponseStatus, parse_and_validate_response};
+
+/// Verbatim stdout from a real Copilot 1.0.80 run whose token lacked Copilot
+/// entitlement: session control-plane events only, the failure itself on
+/// stderr, exit 1. No `assistant.message`, so no completion evidence.
+const REAL_AUTH_FAILURE_STDOUT: &str = concat!(
+    r#"{"type":"session.warning","data":{"message":"Third-party MCP servers are disabled by your organization's Copilot policy. Only built-in servers are available.","warningType":"policy"},"ephemeral":true,"id":"813be348","timestamp":"2026-08-22T02:34:53.964Z"}"#,
+    "\n",
+    r#"{"type":"session.mcp_servers_loaded","data":{"servers":[]},"ephemeral":true,"id":"262f9cf2","timestamp":"2026-08-22T02:34:53.971Z"}"#,
+    "\n",
+    r#"{"type":"session.mcp_server_status_changed","data":{"serverName":"github-mcp-server","status":"connected"},"ephemeral":true,"id":"2a233069","timestamp":"2026-08-22T02:34:54.961Z"}"#,
+    "\n",
+);
+
+const REAL_AUTH_FAILURE_STDERR: &str = "Error: Authentication failed (Request ID: AE1C:B51BD)\n\nYour GitHub token may be invalid, expired, or lacking the required permissions.\n";
+
+fn envelope_line(content: &str) -> String {
+    let frame = serde_json::json!({
+        "type": "assistant.message",
+        "data": {"content": content},
+        "id": "msg-1",
+        "timestamp": "2026-08-22T02:34:59.000Z",
+    });
+    format!("{frame}\n")
+}
+
+fn normalized(stdout: &str) -> String {
+    String::from_utf8(normalize_cli_stdout("copilot", stdout.as_bytes()).into_owned())
+        .expect("utf8 normalized stdout")
+}
+
+fn exec_result(stdout: &str, stderr: &str, exit_code: i32) -> ExecutionResult {
+    ExecutionResult {
+        success: exit_code == 0,
+        stdout: normalized(stdout),
+        stderr: stderr.to_string(),
+        exit_code: Some(exit_code),
+        duration_ms: 1_200,
+        output: None,
+    }
+}
+
+#[test]
+fn success_stream_yields_the_embedded_orbit_envelope() {
+    let stdout = format!(
+        "{}{}{}",
+        r#"{"type":"session.created","data":{"sessionId":"s1"},"ephemeral":true}"#.to_string()
+            + "\n",
+        envelope_line(
+            r#"{"schemaVersion":1,"status":"success","result":{"edited":true},"error":null}"#
+        ),
+        r#"{"type":"session.idle","data":{},"ephemeral":true}"#.to_string() + "\n",
+    );
+
+    let (envelope, status, _) =
+        parse_and_validate_response(&exec_result(&stdout, "", 0)).expect("parse success envelope");
+
+    assert_eq!(status, AgentResponseStatus::Success);
+    assert_eq!(envelope.status, "success");
+}
+
+#[test]
+fn assistant_usage_survives_normalization_for_the_invocation_trace() {
+    // Token accounting rides on `assistant.usage`. Normalization must not cost
+    // Orbit its telemetry, which is why the filter is an `assistant.*` prefix
+    // allowlist rather than "keep only the final message".
+    let stdout = format!(
+        "{}{}",
+        r#"{"type":"assistant.usage","data":{"inputTokens":120,"outputTokens":34}}"#.to_string()
+            + "\n",
+        envelope_line(r#"{"schemaVersion":1,"status":"success","result":{},"error":null}"#),
+    );
+
+    let kept = normalized(&stdout);
+
+    assert!(kept.contains("assistant.usage"));
+    assert!(kept.contains("assistant.message"));
+}
+
+#[test]
+fn prompt_echo_is_never_read_as_completion_evidence() {
+    // The regression this normalization exists for. Orbit's own prompt embeds
+    // the response contract, example envelope included, and Copilot echoes the
+    // prompt back as a `user.message` frame. A run that produced no model
+    // output must not be able to satisfy the completion contract with Orbit's
+    // own instructions.
+    let prompt_echo = serde_json::json!({
+        "type": "user.message",
+        "data": {"content": String::from_utf8(
+            crate::providers::copilot::copilot_cli::CopilotCliTransport::new(None)
+                .stdin(br#"{"schemaVersion":1,"input":{}}"#),
+        ).expect("utf8 prompt")},
+    });
+    let stdout = format!("{prompt_echo}\n");
+
+    let kept = normalized(&stdout);
+    assert!(kept.is_empty(), "prompt echo must not survive: {kept}");
+
+    let parsed = parse_and_validate_response(&exec_result(&stdout, "", 0));
+    assert!(
+        parsed.is_err(),
+        "a prompt echo alone must not parse as a completed envelope"
+    );
+}
+
+#[test]
+fn real_auth_failure_capture_reports_no_completion_evidence() {
+    assert!(normalized(REAL_AUTH_FAILURE_STDOUT).is_empty());
+
+    let result = parse_and_validate_response(&exec_result(
+        REAL_AUTH_FAILURE_STDOUT,
+        REAL_AUTH_FAILURE_STDERR,
+        1,
+    ));
+
+    if let Ok((_, status, _)) = result {
+        assert_ne!(
+            status,
+            AgentResponseStatus::Success,
+            "a failed launch must never normalize to success"
+        );
+    }
+}
+
+#[test]
+fn cancellation_stream_does_not_normalize_to_success() {
+    // A cancelled turn ends on the session control plane with no terminal
+    // assistant message, so it carries no completion evidence either.
+    let stdout = format!(
+        "{}{}",
+        r#"{"type":"assistant.turn_start","data":{},"id":"t1"}"#.to_string() + "\n",
+        r#"{"type":"session.abort","data":{"reason":"cancelled"},"ephemeral":true}"#.to_string()
+            + "\n",
+    );
+
+    let kept = normalized(&stdout);
+    assert!(!kept.contains("session.abort"));
+
+    let result = parse_and_validate_response(&exec_result(&stdout, "", 130));
+    if let Ok((_, status, _)) = result {
+        assert_ne!(status, AgentResponseStatus::Success);
+    }
+}
+
+#[test]
+fn malformed_lines_are_dropped_without_taking_the_envelope_with_them() {
+    // A truncated capture or interleaved non-JSON chatter must not cost the
+    // run its envelope, and must not itself become evidence.
+    let stdout = format!(
+        "{}{}{}",
+        "not json at all\n",
+        envelope_line(
+            r#"{"schemaVersion":1,"status":"success","result":{"ok":true},"error":null}"#
+        ),
+        r#"{"type":"assistant.message","data":{"content":"tru"#.to_string() + "\n",
+    );
+
+    let (_, status, _) =
+        parse_and_validate_response(&exec_result(&stdout, "", 0)).expect("parse envelope");
+
+    assert_eq!(status, AgentResponseStatus::Success);
+}
+
+#[test]
+fn wholly_malformed_stream_yields_nothing() {
+    let stdout = "not json\n{ still not json\n";
+
+    assert!(normalized(stdout).is_empty());
+}
+
+#[test]
+fn other_providers_are_returned_borrowed_and_unchanged() {
+    let stdout = br#"{"schemaVersion":1,"status":"success","result":{},"error":null}"#;
+
+    for provider in ["claude", "codex", "gemini", "grok", "ollama"] {
+        let out = normalize_cli_stdout(provider, stdout);
+        assert!(
+            matches!(out, std::borrow::Cow::Borrowed(_)),
+            "{provider} must not be reshaped"
+        );
+        assert_eq!(out.as_ref(), stdout);
+    }
+}

--- a/crates/orbit-agent/src/providers/copilot/tests/mod.rs
+++ b/crates/orbit-agent/src/providers/copilot/tests/mod.rs
@@ -1,0 +1,2 @@
+mod copilot_cli;
+mod copilot_stream;

--- a/crates/orbit-agent/src/providers/mod.rs
+++ b/crates/orbit-agent/src/providers/mod.rs
@@ -2,7 +2,8 @@
 //!
 //! Two families live here:
 //!
-//! - **CLI transports** (`claude`, `codex`, `gemini`, `grok`, `ollama`, `mock_agent`):
+//! - **CLI transports** (`claude`, `codex`, `copilot`, `gemini`, `grok`, `ollama`,
+//!   `mock_agent`):
 //!   translate an [`AgentRequest`] into a CLI command invocation and stdin
 //!   envelope that the engine runs via `orbit-exec`.
 //! - **HTTP transports** (`anthropic`, `openai_compat`, `gemini_http`): implement the sibling
@@ -17,12 +18,15 @@ pub mod anthropic;
 pub(crate) mod claude;
 pub(crate) mod codex;
 mod common;
+pub(crate) mod copilot;
 pub(crate) mod gemini;
 pub mod gemini_http;
 pub(crate) mod grok;
 pub(crate) mod mock_agent;
 pub(crate) mod ollama;
 pub mod openai_compat;
+
+use std::borrow::Cow;
 
 use crate::types::AgentInvocationSpec;
 
@@ -42,5 +46,25 @@ pub(crate) fn build_invocation_spec(
         stdin,
         stdout_schema_json: None,
         required_env_vars,
+    }
+}
+
+/// Reduce a provider's raw stdout to the bytes Orbit's response/envelope
+/// contract may read.
+///
+/// Most providers emit their Orbit envelope directly and are returned
+/// borrowed and unchanged. `copilot` streams JSONL agent events that replay
+/// Orbit's own prompt back as a `user.message` frame, so its stream is
+/// reduced to model-authored frames first — see the `copilot::copilot_stream`
+/// module docs for why that reduction is a correctness requirement rather
+/// than tidying. [ORB-10946]
+///
+/// `provider` is the resolved canonical provider id. An unrecognized id is
+/// not an error here: normalization is a per-provider accommodation, and the
+/// default of "read stdout as-is" is what every other provider needs.
+pub fn normalize_cli_stdout<'a>(provider: &str, stdout: &'a [u8]) -> Cow<'a, [u8]> {
+    match provider {
+        "copilot" => Cow::Owned(copilot::normalize_copilot_stdout(stdout)),
+        _ => Cow::Borrowed(stdout),
     }
 }

--- a/crates/orbit-agent/src/runtime/backend.rs
+++ b/crates/orbit-agent/src/runtime/backend.rs
@@ -55,6 +55,7 @@ impl Default for ProviderRegistry {
         let _ = registry.register(Arc::new(crate::providers::claude::ClaudeFactory));
         let _ = registry.register(Arc::new(crate::providers::gemini::GeminiFactory));
         let _ = registry.register(Arc::new(crate::providers::grok::GrokFactory));
+        let _ = registry.register(Arc::new(crate::providers::copilot::CopilotFactory));
         let _ = registry.register(Arc::new(crate::providers::ollama::OllamaFactory));
         registry
     }

--- a/crates/orbit-cli/src/command/init/agent_detect.rs
+++ b/crates/orbit-cli/src/command/init/agent_detect.rs
@@ -75,6 +75,11 @@ pub struct DetectedAgents {
     pub codex_cli: bool,
     pub gemini_cli: bool,
     pub grok_cli: bool,
+    /// The standalone `copilot` CLI (npm `@github/copilot`). The retired
+    /// `gh-copilot` gh extension is deliberately not probed: it is a shell
+    /// command *suggester*, not an agent, and Orbit never dispatches to it.
+    /// [ORB-10946]
+    pub copilot_cli: bool,
     pub ollama_cli: bool,
 }
 
@@ -86,6 +91,7 @@ pub fn detect(probe: &dyn AgentEnvProbe) -> DetectedAgents {
         codex_cli: probe.binary_on_path("codex"),
         gemini_cli: probe.binary_on_path("gemini"),
         grok_cli: probe.binary_on_path("grok"),
+        copilot_cli: probe.binary_on_path("copilot"),
         ollama_cli: probe.binary_on_path("ollama"),
     }
 }
@@ -109,6 +115,9 @@ pub fn available_crew_families(detected: &DetectedAgents) -> Vec<&'static str> {
     if detected.grok_cli {
         families.push("grok");
     }
+    if detected.copilot_cli {
+        families.push("copilot");
+    }
     families
 }
 
@@ -125,7 +134,9 @@ pub fn default_model_for(provider: &str) -> Option<&'static str> {
 /// Pick a default provider for the role given a detection snapshot.
 ///
 /// Preference order: first detected CLI in [claude, codex, gemini, grok,
-/// ollama], else `claude` as a last resort.
+/// copilot, ollama], else `claude` as a last resort. `copilot` sits after the
+/// four original families so installing it never changes an existing host's
+/// default provider. [ORB-10946]
 pub fn default_provider(detected: &DetectedAgents) -> &'static str {
     if detected.claude_cli {
         return "claude";
@@ -138,6 +149,9 @@ pub fn default_provider(detected: &DetectedAgents) -> &'static str {
     }
     if detected.grok_cli {
         return "grok";
+    }
+    if detected.copilot_cli {
+        return "copilot";
     }
     if detected.ollama_cli {
         return "ollama";

--- a/crates/orbit-cli/src/command/init/agent_prompt.rs
+++ b/crates/orbit-cli/src/command/init/agent_prompt.rs
@@ -115,10 +115,11 @@ pub(crate) fn collect_system_crew_setting(
 
 /// Cheap-tier system options in the same preference order as
 /// `orbit-config::default_system_crew`: Codex Luna, Claude Sonnet, Grok,
-/// Gemini Flash.
+/// Gemini Flash, Copilot Haiku.
 fn system_crew_options(detected: &DetectedAgents) -> Vec<CrewSeed> {
     use orbit_common::model_defaults::{
-        CLAUDE_DEFAULT_WEAK, CODEX_LUNA_MODEL, GEMINI_CREW_MODEL, GROK_DEFAULT_MODEL,
+        CLAUDE_DEFAULT_WEAK, CODEX_LUNA_MODEL, COPILOT_CREW_MODEL, GEMINI_CREW_MODEL,
+        GROK_DEFAULT_MODEL,
     };
     let mut options = Vec::new();
     for (enabled, provider, model) in [
@@ -126,6 +127,7 @@ fn system_crew_options(detected: &DetectedAgents) -> Vec<CrewSeed> {
         (detected.claude_cli, "claude", CLAUDE_DEFAULT_WEAK),
         (detected.grok_cli, "grok", GROK_DEFAULT_MODEL),
         (detected.gemini_cli, "gemini", GEMINI_CREW_MODEL),
+        (detected.copilot_cli, "copilot", COPILOT_CREW_MODEL),
     ] {
         if enabled {
             options.push(CrewSeed {
@@ -159,6 +161,7 @@ fn system_crew_label(option: &CrewSeed) -> &'static str {
         Some("claude") => "Claude",
         Some("grok") => "Grok",
         Some("gemini") => "Gemini",
+        Some("copilot") => "Copilot",
         _ => "Agent",
     }
 }
@@ -234,6 +237,7 @@ fn agent_options(detected: &DetectedAgents) -> Vec<AgentOption> {
         (detected.codex_cli, "Codex CLI", "codex"),
         (detected.gemini_cli, "Gemini CLI", "gemini"),
         (detected.grok_cli, "Grok CLI", "grok"),
+        (detected.copilot_cli, "Copilot CLI", "copilot"),
         (detected.ollama_cli, "Ollama CLI", "ollama"),
     ] {
         if enabled {
@@ -311,6 +315,7 @@ fn agent_display_name(config: &CrewSeed) -> String {
         "codex" => "Codex CLI".to_string(),
         "gemini" => "Gemini CLI".to_string(),
         "grok" => "Grok CLI".to_string(),
+        "copilot" => "Copilot CLI".to_string(),
         "ollama" => "Ollama CLI".to_string(),
         provider => format!("{provider} (CLI)"),
     }

--- a/crates/orbit-cli/src/command/init/tests/agent_detect.rs
+++ b/crates/orbit-cli/src/command/init/tests/agent_detect.rs
@@ -43,6 +43,7 @@ fn seeded_crew_availability_requires_a_detected_cli() {
         ("codex", "codex"),
         ("gemini", "gemini"),
         ("grok", "grok"),
+        ("copilot", "copilot"),
     ] {
         let detected = detect(&MockAgentEnvProbe::new().with_binary(binary));
         assert_eq!(available_crew_families(&detected), vec![family]);
@@ -57,6 +58,7 @@ fn default_provider_prefers_cli_in_documented_order() {
         codex_cli: true,
         gemini_cli: true,
         grok_cli: true,
+        copilot_cli: true,
         ollama_cli: true,
     };
     assert_eq!(default_provider(&detected), "claude");
@@ -80,13 +82,23 @@ fn default_provider_prefers_cli_in_documented_order() {
     };
     assert_eq!(default_provider(&detected), "gemini");
 
-    // grok wins when claude/codex/gemini absent
+    // grok wins when claude/codex/gemini absent — and an installed copilot
+    // does not displace it. [ORB-10946]
     let detected = DetectedAgents {
         grok_cli: true,
+        copilot_cli: true,
         ollama_cli: true,
         ..DetectedAgents::default()
     };
     assert_eq!(default_provider(&detected), "grok");
+
+    // copilot wins over ollama when it is the only agent CLI present
+    let detected = DetectedAgents {
+        copilot_cli: true,
+        ollama_cli: true,
+        ..DetectedAgents::default()
+    };
+    assert_eq!(default_provider(&detected), "copilot");
 
     // ollama wins when nothing else
     let detected = DetectedAgents {
@@ -104,12 +116,14 @@ fn default_provider_last_resort_is_claude() {
 #[test]
 fn model_registry_returns_expected_defaults() {
     use orbit_common::model_defaults::{
-        CLAUDE_DEFAULT_STRONG, CODEX_DEFAULT_MODEL, GEMINI_DEFAULT_MODEL, GROK_DEFAULT_MODEL,
+        CLAUDE_DEFAULT_STRONG, CODEX_DEFAULT_MODEL, COPILOT_DEFAULT_MODEL, GEMINI_DEFAULT_MODEL,
+        GROK_DEFAULT_MODEL,
     };
     assert_eq!(default_model_for("claude"), Some(CLAUDE_DEFAULT_STRONG));
     assert_eq!(default_model_for("codex"), Some(CODEX_DEFAULT_MODEL));
     assert_eq!(default_model_for("gemini"), Some(GEMINI_DEFAULT_MODEL));
     assert_eq!(default_model_for("grok"), Some(GROK_DEFAULT_MODEL));
+    assert_eq!(default_model_for("copilot"), Some(COPILOT_DEFAULT_MODEL));
     assert_eq!(default_model_for("ollama"), None);
     assert_eq!(default_model_for("unknown"), None);
 }

--- a/crates/orbit-common/src/model_defaults.rs
+++ b/crates/orbit-common/src/model_defaults.rs
@@ -71,6 +71,19 @@ pub const GEMINI_PAIR_WEAK: &str = "gemini-3.7-flash";
 /// Default Grok Build model (the canonical model listed by `grok models`).
 pub const GROK_DEFAULT_MODEL: &str = "grok-4.6";
 
+/// Default model for the GitHub Copilot CLI lane.
+///
+/// Copilot routes to several vendors' models; Orbit pins an explicit id rather
+/// than letting the CLI fall back to `COPILOT_MODEL` or its persisted `/model`
+/// choice, so a run's model comes from the resolved crew and not from ambient
+/// operator state. Both ids below are present in the model catalog shipped
+/// with Copilot CLI 1.0.80. The provider identity stays `copilot` regardless of
+/// which vendor supplies the model. [ORB-10946]
+pub const COPILOT_DEFAULT_MODEL: &str = "claude-sonnet-4.5";
+
+/// Cheap-tier Copilot model used for the bounded system crew.
+pub const COPILOT_CREW_MODEL: &str = "claude-haiku-4.5";
+
 /// Cheap Claude model used by the orbit-agent HTTP examples.
 ///
 /// Version pinned like [`ANTHROPIC_HTTP_DEFAULT_MODEL`] because the examples
@@ -81,13 +94,14 @@ pub const ANTHROPIC_EXAMPLE_MODEL: &str = "claude-haiku-4-5-20251001";
 ///
 /// Mirrors the historical `agent_detect::default_model_for` map; `claude` now
 /// resolves to the unversioned [`CLAUDE_DEFAULT_STRONG`] alias. codex/gemini/
-/// grok use their provider-specific defaults.
+/// grok/copilot use their provider-specific defaults.
 pub fn default_model_for_provider(provider: &str) -> Option<&'static str> {
     match provider {
         "claude" => Some(CLAUDE_DEFAULT_STRONG),
         "codex" => Some(CODEX_DEFAULT_MODEL),
         "gemini" => Some(GEMINI_DEFAULT_MODEL),
         "grok" => Some(GROK_DEFAULT_MODEL),
+        "copilot" => Some(COPILOT_DEFAULT_MODEL),
         _ => None,
     }
 }

--- a/crates/orbit-config/src/resolved.rs
+++ b/crates/orbit-config/src/resolved.rs
@@ -15,7 +15,8 @@ use std::path::Path;
 use orbit_common::OrbitError;
 use orbit_common::model_defaults::{
     CLAUDE_DEFAULT_STRONG, CLAUDE_DEFAULT_WEAK, CLAUDE_FABLE_MODEL, CODEX_LUNA_MODEL,
-    CODEX_SOL_MODEL, CODEX_TERRA_MODEL, GEMINI_CREW_MODEL, GROK_DEFAULT_MODEL,
+    CODEX_SOL_MODEL, CODEX_TERRA_MODEL, COPILOT_DEFAULT_MODEL, GEMINI_CREW_MODEL,
+    GROK_DEFAULT_MODEL,
 };
 use orbit_common::security::child_env::{allowlisted_child_env, inherited_child_env};
 use orbit_common::security::redaction::redact_home_dir;
@@ -208,6 +209,7 @@ pub(crate) fn default_crews() -> BTreeMap<String, Crew> {
         ("luna", CODEX_LUNA_MODEL, "codex"),
         ("gemini", GEMINI_CREW_MODEL, "gemini"),
         ("grok", GROK_DEFAULT_MODEL, "grok"),
+        ("copilot", COPILOT_DEFAULT_MODEL, "copilot"),
         // [ORB-10877] Shipped job steps name `system` directly, so the
         // built-in set used by a config with no `[crews]` table must define it
         // or those pipelines fail validation. `orbit init` overwrites this with

--- a/crates/orbit-config/src/seed.rs
+++ b/crates/orbit-config/src/seed.rs
@@ -20,7 +20,10 @@ pub(crate) const DEFAULT_CONFIG_TEMPLATE: &str = include_str!("../assets/default
 
 /// Crew families Orbit ships crews for, in the order a seeded config prefers
 /// them. `ollama` is deliberately absent: Orbit ships no `ollama` crew.
-const CREW_FAMILY_PREFERENCE: &[&str] = &["claude", "codex", "gemini", "grok"];
+/// [ORB-10946] `copilot` is appended last so adding it cannot move the
+/// default crew on any host that already had one of the four families
+/// installed.
+const CREW_FAMILY_PREFERENCE: &[&str] = &["claude", "codex", "gemini", "grok", "copilot"];
 
 /// Explicit, host-independent inputs for rendering a fresh `config.toml`.
 ///
@@ -154,6 +157,7 @@ fn default_crew_name(seed: &ConfigSeed) -> Option<&'static str> {
             "codex" => "sol",
             "gemini" => "gemini",
             "grok" => "grok",
+            "copilot" => "copilot",
             _ => unreachable!("available crew families are fixed"),
         })
 }
@@ -260,7 +264,8 @@ fn default_qa_crew(seed: &ConfigSeed) -> Option<CrewSeed> {
 /// special-case a family.
 fn default_system_crew(seed: &ConfigSeed) -> Option<CrewSeed> {
     use orbit_common::model_defaults::{
-        CLAUDE_DEFAULT_WEAK, CODEX_LUNA_MODEL, GEMINI_CREW_MODEL, GROK_DEFAULT_MODEL,
+        CLAUDE_DEFAULT_WEAK, CODEX_LUNA_MODEL, COPILOT_CREW_MODEL, GEMINI_CREW_MODEL,
+        GROK_DEFAULT_MODEL,
     };
     let (provider, model) = if seed.has_family("codex") {
         ("codex", CODEX_LUNA_MODEL)
@@ -270,6 +275,8 @@ fn default_system_crew(seed: &ConfigSeed) -> Option<CrewSeed> {
         ("grok", GROK_DEFAULT_MODEL)
     } else if seed.has_family("gemini") {
         ("gemini", GEMINI_CREW_MODEL)
+    } else if seed.has_family("copilot") {
+        ("copilot", COPILOT_CREW_MODEL)
     } else {
         return None;
     };

--- a/crates/orbit-config/src/tests/resolved.rs
+++ b/crates/orbit-config/src/tests/resolved.rs
@@ -29,10 +29,16 @@ fn built_in_crews_use_standard_model_specific_names() {
     // Every built-in is named for its model except `system`, which names a
     // lane. [ORB-10877] It is built in because shipped job steps name it
     // directly, so a config with no `[crews]` table must still resolve it.
+    //
+    // `copilot` is the second exception: it names the *provider* lane, because
+    // Copilot's model is supplied by another vendor and naming the crew after
+    // that model would hide which execution lane the run actually uses.
+    // [ORB-10946]
     assert_eq!(
         crews.keys().map(String::as_str).collect::<Vec<_>>(),
         vec![
-            "fable", "gemini", "grok", "luna", "opus", "sol", "sonnet", "system", "terra"
+            "copilot", "fable", "gemini", "grok", "luna", "opus", "sol", "sonnet", "system",
+            "terra"
         ]
     );
     for (name, provider, model) in [
@@ -44,6 +50,7 @@ fn built_in_crews_use_standard_model_specific_names() {
         ("luna", "codex", "gpt-5.6-luna"),
         ("gemini", "gemini", "gemini-3.7-flash"),
         ("grok", "grok", "grok-4.6"),
+        ("copilot", "copilot", "claude-sonnet-4.5"),
         ("system", "claude", "sonnet"),
     ] {
         let assignment = &crews.get(name).expect("built-in crew").assignment;
@@ -52,6 +59,10 @@ fn built_in_crews_use_standard_model_specific_names() {
     }
     assert!(!crews.contains_key("claude"));
     assert!(!crews.contains_key("codex"));
+    // The Copilot lane keeps its own identity: it is never aliased to the
+    // vendor supplying its model, nor to GitHub. [ORB-10946]
+    assert!(!crews.contains_key("github"));
+    assert!(!crews.contains_key("claude-sonnet-4.5"));
 
     let config = ResolvedConfig::built_in(PersistenceConfig::default_for_data_root(Path::new(
         ".orbit",

--- a/crates/orbit-core/assets/executors/copilot.yaml
+++ b/crates/orbit-core/assets/executors/copilot.yaml
@@ -1,0 +1,37 @@
+schemaVersion: 2
+kind: Executor
+metadata:
+  name: copilot
+spec:
+  executor_type: direct_agent
+  command: copilot
+  # Static flags only. The prompt is NOT passed here: `copilot` reads it from
+  # standard in when `-p` is absent ("provide a prompt with -p or via standard
+  # in" is the CLI's own message), which keeps the Orbit envelope out of argv
+  # and therefore out of process listings and audit records. [ORB-10946]
+  args:
+    # Unattended tool approval. Deliberately NOT `--allow-all` / `--yolo`:
+    # those also imply `--allow-all-paths` and `--allow-all-urls`, which would
+    # widen the filesystem and network reach beyond what Orbit's own activity
+    # sandbox granted. Tool auto-approval is what non-interactive mode needs;
+    # path and URL policy stay with the enclosing sandbox.
+    - --allow-all-tools
+    # No user prompts: disable the ask_user tool so the agent cannot block a
+    # headless run waiting on a human.
+    - --no-ask-user
+    # JSONL agent events, one JSON object per line.
+    - --output-format
+    - json
+    - --silent
+    # A sandboxed run must not rewrite its own binary mid-flight.
+    - --no-auto-update
+    # Keep the session on this host: no remote control, no session export.
+    - --no-remote
+    - --no-remote-export
+  stdout_format: envelope
+  sandbox: macos-sandbox-exec
+  model_pair_override:
+    strong: claude-sonnet-4.5
+    weak: claude-haiku-4.5
+  model_flag: "--model"
+  env: {}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
@@ -87,7 +87,7 @@ pub(crate) fn resolve_executor_sandbox(
                     grants_workspace_modify,
                     &mut resolved,
                 )?;
-                append_linux_provider_state_roots(&mut resolved)?;
+                append_linux_provider_state_roots(provider, &mut resolved)?;
                 let managed_worktree = subprocess_cwd
                     .and_then(|cwd| active_worktree_subpath(runtime, cwd))
                     .is_some();
@@ -303,6 +303,7 @@ fn append_linux_runtime_write_roots(
 
 #[cfg(target_os = "linux")]
 fn append_linux_provider_state_roots(
+    provider: &str,
     resolved: &mut ResolvedFsProfile,
 ) -> Result<(), DispatchError> {
     let home = std::env::var_os("HOME").map(PathBuf::from);
@@ -321,6 +322,12 @@ fn append_linux_provider_state_roots(
         directories.push(home.join(".gemini"));
         directories.push(home.join(".grok"));
     }
+    // [ORB-10946] Copilot's roots are appended only when Copilot is the
+    // provider being dispatched. This mirrors the macOS gate, and it matters
+    // more here than on macOS: every entry in this list is *created* by
+    // `ensure_owned_directory` below, so an unconditional entry would mkdir a
+    // `~/.copilot` on hosts that have never installed the CLI.
+    directories.extend(linux_copilot_state_roots(provider, home.as_deref()));
     for directory in directories {
         ensure_owned_directory(&directory)?;
         let canonical = directory.canonicalize().map_err(|error| {
@@ -332,6 +339,61 @@ fn append_linux_provider_state_roots(
         append_unique_modify_root(resolved, canonical.display().to_string());
     }
     Ok(())
+}
+
+/// Process-env wrapper around [`linux_copilot_state_roots_with`].
+#[cfg(target_os = "linux")]
+fn linux_copilot_state_roots(provider: &str, home: Option<&Path>) -> Vec<PathBuf> {
+    linux_copilot_state_roots_with(
+        provider,
+        home,
+        std::env::var_os("COPILOT_HOME")
+            .map(PathBuf::from)
+            .as_deref(),
+        std::env::var_os("XDG_CACHE_HOME")
+            .map(PathBuf::from)
+            .as_deref(),
+    )
+}
+
+/// Writable roots an active Copilot executor needs on Linux: its
+/// configuration/state directory (`$COPILOT_HOME`, else `$HOME/.copilot`) and
+/// the launcher's bundled-package extraction cache (`$XDG_CACHE_HOME/copilot`,
+/// else `$HOME/.cache/copilot`). Empty for every other provider. [ORB-10946]
+///
+/// The override values are parameters rather than direct env reads so the
+/// gate can be asserted without mutating process state from a test.
+// pub(super) widened for the sibling tests/ layout.
+#[cfg(target_os = "linux")]
+pub(super) fn linux_copilot_state_roots_with(
+    provider: &str,
+    home: Option<&Path>,
+    copilot_home: Option<&Path>,
+    xdg_cache_home: Option<&Path>,
+) -> Vec<PathBuf> {
+    if orbit_types::workflow::Provider::parse(provider).ok()
+        != Some(orbit_types::workflow::Provider::Copilot)
+    {
+        return Vec::new();
+    }
+    let mut roots = Vec::with_capacity(2);
+    match copilot_home {
+        Some(path) => roots.push(path.to_path_buf()),
+        None => {
+            if let Some(home) = home {
+                roots.push(home.join(".copilot"));
+            }
+        }
+    }
+    match xdg_cache_home {
+        Some(path) => roots.push(path.join("copilot")),
+        None => {
+            if let Some(home) = home {
+                roots.push(home.join(".cache").join("copilot"));
+            }
+        }
+    }
+    roots
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
@@ -654,3 +654,69 @@ fn resolve_executor_sandbox_rejects_bare_worktrees_root_cwd() {
         "bare worktrees-root cwd must not re-allow the registry: {modify:?}"
     );
 }
+
+// [ORB-10946] The Linux half of the Copilot state-root gate. Every entry this
+// returns is created by `ensure_owned_directory`, so an ungated entry would
+// mkdir a `~/.copilot` on hosts that never installed the CLI.
+#[cfg(target_os = "linux")]
+mod copilot_state_roots {
+    use std::path::{Path, PathBuf};
+
+    use crate::adapter::engine_host::v2_host::sandbox::linux_copilot_state_roots_with;
+
+    #[test]
+    fn active_copilot_gets_its_state_and_extraction_cache_roots() {
+        let roots =
+            linux_copilot_state_roots_with("copilot", Some(Path::new("/home/test")), None, None);
+
+        assert_eq!(
+            roots,
+            vec![
+                PathBuf::from("/home/test/.copilot"),
+                PathBuf::from("/home/test/.cache/copilot"),
+            ]
+        );
+    }
+
+    #[test]
+    fn overrides_are_honored() {
+        let roots = linux_copilot_state_roots_with(
+            "copilot",
+            Some(Path::new("/home/test")),
+            Some(Path::new("/srv/copilot-home")),
+            Some(Path::new("/srv/cache")),
+        );
+
+        assert_eq!(
+            roots,
+            vec![
+                PathBuf::from("/srv/copilot-home"),
+                PathBuf::from("/srv/cache/copilot"),
+            ]
+        );
+    }
+
+    #[test]
+    fn other_providers_get_nothing() {
+        for provider in ["claude", "codex", "gemini", "grok", "ollama", "local-shell"] {
+            assert!(
+                linux_copilot_state_roots_with(provider, Some(Path::new("/home/test")), None, None)
+                    .is_empty(),
+                "{provider} must not inherit copilot roots",
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_provider_is_not_treated_as_copilot() {
+        assert!(
+            linux_copilot_state_roots_with(
+                "not-a-provider",
+                Some(Path::new("/home/test")),
+                None,
+                None
+            )
+            .is_empty()
+        );
+    }
+}

--- a/crates/orbit-core/src/application/executor.rs
+++ b/crates/orbit-core/src/application/executor.rs
@@ -9,6 +9,10 @@ pub(crate) const DEFAULT_EXECUTOR_FILES: &[(&str, &str)] = &[
     ("gemini", include_str!("../../assets/executors/gemini.yaml")),
     ("grok", include_str!("../../assets/executors/grok.yaml")),
     (
+        "copilot",
+        include_str!("../../assets/executors/copilot.yaml"),
+    ),
+    (
         "local-shell",
         include_str!("../../assets/executors/local-shell.yaml"),
     ),

--- a/crates/orbit-core/tests/copilot_fake_agent.rs
+++ b/crates/orbit-core/tests/copilot_fake_agent.rs
@@ -1,0 +1,349 @@
+#![allow(missing_docs)]
+// [ORB-10946] Deterministic end-to-end coverage for the Copilot executor. A
+// fake agent stands in for the real `copilot` CLI so every case below — argv
+// shape, prompt transport, exit codes, timeouts, malformed output — is exact
+// and needs no network, credentials, or Copilot entitlement.
+#![allow(clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use orbit_core::OrbitRuntime;
+use orbit_engine::{DispatchOutcome, V2AuditWriter, V2DispatchInput, dispatch_v2_activity};
+use orbit_types::resource::{EXECUTOR_RESOURCE_SCHEMA_VERSION, ExecutorResource};
+use orbit_types::workflow::ExecutorDef;
+use orbit_types::workflow::activity_job::{ActivityV2Spec, AgentLoopSpec, OnDenial, Provider};
+
+/// A secret-looking value planted in the activity input. It must reach the
+/// agent on stdin and must never appear in argv.
+const PROMPT_SECRET: &str = "tenant-42-authorization-bearer-zzz";
+
+const SUCCESS_ENVELOPE: &str =
+    r#"{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"edited\":true},\"error\":null}"#;
+
+/// Install a fake `copilot` on disk and return its path.
+///
+/// `body` runs after the harness has recorded argv and stdin, so every
+/// scenario shares one recording contract and differs only in what the agent
+/// then does. The recording paths are baked into the script rather than passed
+/// through the environment, so cases stay independent under a parallel test
+/// runner.
+fn fake_copilot(dir: &Path, body: &str, argv_path: &Path, stdin_path: &Path) -> PathBuf {
+    let program = dir.join("copilot");
+    let script = format!(
+        r#"#!/bin/sh
+: > '{argv}'
+for arg in "$@"; do printf '%s\n' "$arg" >> '{argv}'; done
+cat > '{stdin}'
+{body}
+"#,
+        argv = argv_path.display(),
+        stdin = stdin_path.display(),
+    );
+    std::fs::write(&program, script).expect("write fake copilot");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&program, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake copilot");
+    }
+    program
+}
+
+struct Harness {
+    _dir: tempfile::TempDir,
+    argv_path: PathBuf,
+    stdin_path: PathBuf,
+    edit_path: PathBuf,
+    runtime: OrbitRuntime,
+}
+
+impl Harness {
+    fn new(body: &str) -> Self {
+        let dir = tempfile::tempdir().expect("harness tempdir");
+        let argv_path = dir.path().join("argv.txt");
+        let stdin_path = dir.path().join("stdin.txt");
+        let edit_path = dir.path().join("workspace").join("edited.txt");
+        std::fs::create_dir_all(edit_path.parent().expect("workspace parent"))
+            .expect("create fake workspace");
+        let body = body.replace("{EDIT_PATH}", &edit_path.display().to_string());
+        let program = fake_copilot(dir.path(), &body, &argv_path, &stdin_path);
+
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        seed_copilot_executor(&runtime, &program);
+        Self {
+            _dir: dir,
+            argv_path,
+            stdin_path,
+            edit_path,
+            runtime,
+        }
+    }
+
+    fn argv(&self) -> Vec<String> {
+        std::fs::read_to_string(&self.argv_path)
+            .expect("fake agent must have recorded argv")
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn stdin(&self) -> String {
+        std::fs::read_to_string(&self.stdin_path).expect("fake agent must have recorded stdin")
+    }
+}
+
+/// Seed the *shipped* copilot executor definition, retargeted at the fake
+/// program. Everything else — the static argv, `stdout_format`, the model flag
+/// — is the asset Orbit actually ships, so these tests fail if that asset
+/// drifts.
+fn seed_copilot_executor(runtime: &OrbitRuntime, program: &Path) {
+    let resource: ExecutorResource =
+        serde_yaml::from_str(include_str!("../assets/executors/copilot.yaml"))
+            .expect("parse embedded copilot executor");
+    assert_eq!(resource.schema_version, EXECUTOR_RESOURCE_SCHEMA_VERSION);
+    assert_eq!(resource.metadata.name, "copilot");
+    let mut def = ExecutorDef::from_resource_spec(
+        resource.metadata.name.clone(),
+        resource.spec.clone(),
+        resource.spec.created_at,
+        resource.spec.updated_at,
+    );
+    def.command = Some(program.to_string_lossy().into_owned());
+    // Sandbox confinement is asserted by the profile-compilation unit tests;
+    // dispatching under a real OS sandbox here would make these cases depend
+    // on the host having bwrap/sandbox-exec available.
+    def.sandbox = None;
+    runtime
+        .upsert_executor_def(&def)
+        .expect("seed copilot executor");
+}
+
+fn spec(model: Option<&str>, timeout_seconds: u64) -> AgentLoopSpec {
+    AgentLoopSpec {
+        instruction: "Return the requested Orbit response envelope.".to_string(),
+        tools: Vec::new(),
+        on_denial: OnDenial::Terminate,
+        model: model.map(str::to_string),
+        max_iterations: 1,
+        backend: None,
+        provider: Provider::Copilot,
+        wall_clock_timeout_seconds: timeout_seconds,
+        require_response_envelope: true,
+        require_completion_envelope: true,
+        proc_allowed_programs: None,
+    }
+}
+
+/// Dispatch through the real CLI runner. No `workspace_path`/`repo_root` pair
+/// is declared: worktree pairing has its own coverage, and these cases are
+/// about the Copilot lane, so the fake agent writes to absolute paths instead.
+fn dispatch(harness: &Harness, spec: AgentLoopSpec) -> DispatchOutcome {
+    let audit_dir = tempfile::tempdir().expect("audit tempdir");
+    let audit = V2AuditWriter::with_disk_sinks(
+        audit_dir.path(),
+        Arc::new(orbit_store::Store::open_in_memory().expect("audit store")),
+        "ws_test",
+        "copilot-fake",
+        "copilot:claude-sonnet-4.5".to_string(),
+        None,
+    )
+    .expect("build audit writer");
+
+    dispatch_v2_activity(V2DispatchInput {
+        activity_name: "copilot_fake_agent",
+        spec: &ActivityV2Spec::AgentLoop(spec),
+        fs_profile: None,
+        input: serde_json::json!({
+            "prompt": format!("Edit the checkout. Credential: {PROMPT_SECRET}"),
+        }),
+        audit,
+        run_id: "copilot-fake",
+        host: Some(&harness.runtime),
+    })
+    .expect("dispatch copilot cli backend")
+}
+
+/// Emit a well-formed Copilot JSONL stream carrying the Orbit envelope,
+/// preceded by the session control-plane frames a real run emits.
+fn success_body() -> String {
+    format!(
+        r#"printf '%s\n' '{{"type":"session.created","data":{{"sessionId":"s1"}},"ephemeral":true}}'
+printf '%s\n' '{{"type":"assistant.usage","data":{{"inputTokens":12,"outputTokens":3}}}}'
+printf '%s\n' '{{"type":"assistant.message","data":{{"content":"{SUCCESS_ENVELOPE}"}}}}'
+printf '%s\n' '{{"type":"session.idle","data":{{}},"ephemeral":true}}'
+exit 0"#
+    )
+}
+
+#[test]
+fn command_construction_matches_the_shipped_unattended_contract() {
+    let harness = Harness::new(&success_body());
+    let outcome = dispatch(&harness, spec(Some("claude-sonnet-4.5"), 60));
+    assert!(outcome.success, "dispatch failed: {:?}", outcome.message);
+
+    let argv = harness.argv();
+
+    // Unattended, non-interactive, machine-readable.
+    assert!(argv.contains(&"--allow-all-tools".to_string()));
+    assert!(argv.contains(&"--no-ask-user".to_string()));
+    assert!(argv.contains(&"--output-format".to_string()));
+    assert!(argv.contains(&"json".to_string()));
+    assert!(argv.contains(&"--silent".to_string()));
+    // A sandboxed run must not rewrite its own binary or leave the host.
+    assert!(argv.contains(&"--no-auto-update".to_string()));
+    assert!(argv.contains(&"--no-remote".to_string()));
+    assert!(argv.contains(&"--no-remote-export".to_string()));
+
+    // Permission configuration: tool auto-approval only. The blanket flags
+    // also imply --allow-all-paths/--allow-all-urls, which would widen reach
+    // past what Orbit's activity sandbox granted.
+    for widening in [
+        "--allow-all",
+        "--yolo",
+        "--allow-all-paths",
+        "--allow-all-urls",
+    ] {
+        assert!(
+            !argv.iter().any(|arg| arg == widening),
+            "{widening} must not be passed; it widens beyond the Orbit sandbox",
+        );
+    }
+}
+
+#[test]
+fn explicit_model_is_propagated_and_never_inferred_from_the_vendor() {
+    for model in ["claude-sonnet-4.5", "gpt-5.4", "gemini-3.7-flash"] {
+        let harness = Harness::new(&success_body());
+        let outcome = dispatch(&harness, spec(Some(model), 60));
+        assert!(outcome.success, "dispatch failed: {:?}", outcome.message);
+
+        let argv = harness.argv();
+        let flag = argv
+            .iter()
+            .position(|arg| arg == "--model")
+            .expect("--model must be passed");
+        assert_eq!(argv[flag + 1], model);
+
+        let invocation = outcome.invocation.as_ref().expect("invocation trace");
+        // The provider identity stays `copilot` no matter which vendor
+        // supplies the model.
+        assert_eq!(invocation.provider, "copilot");
+        assert_eq!(invocation.model.as_deref(), Some(model));
+    }
+}
+
+#[test]
+fn prompt_is_delivered_on_stdin_and_the_secret_never_reaches_argv() {
+    let harness = Harness::new(&success_body());
+    let outcome = dispatch(&harness, spec(Some("claude-sonnet-4.5"), 60));
+    assert!(outcome.success, "dispatch failed: {:?}", outcome.message);
+
+    let stdin = harness.stdin();
+    assert!(stdin.contains(PROMPT_SECRET), "prompt must arrive on stdin");
+    assert!(stdin.contains("Execution envelope:"));
+
+    for arg in harness.argv() {
+        assert!(
+            !arg.contains(PROMPT_SECRET),
+            "prompt content leaked into argv: {arg}",
+        );
+    }
+    // The audit-visible preview must not carry it either.
+    let rendered = serde_json::to_string(&outcome.output).expect("serialize outcome output");
+    assert!(
+        !rendered.contains(PROMPT_SECRET),
+        "prompt secret leaked into the dispatch output",
+    );
+}
+
+#[test]
+fn successful_run_persists_agent_edits_and_reports_success() {
+    let body = format!(
+        "printf 'edited by copilot\\n' > '{{EDIT_PATH}}'\n{}",
+        success_body()
+    );
+    let harness = Harness::new(&body);
+    let outcome = dispatch(&harness, spec(Some("claude-sonnet-4.5"), 60));
+
+    assert!(outcome.success, "dispatch failed: {:?}", outcome.message);
+    // The envelope's `result` reaches the workflow output.
+    assert_eq!(outcome.output["edited"], serde_json::Value::Bool(true));
+    assert_eq!(
+        std::fs::read_to_string(&harness.edit_path).expect("agent edit must persist"),
+        "edited by copilot\n"
+    );
+}
+
+#[test]
+fn non_zero_exit_fails_even_with_a_success_envelope_on_stdout() {
+    let body = format!(
+        r#"printf '%s\n' '{{"type":"assistant.message","data":{{"content":"{SUCCESS_ENVELOPE}"}}}}'
+exit 3"#
+    );
+    let harness = Harness::new(&body);
+    let outcome = dispatch(&harness, spec(Some("claude-sonnet-4.5"), 60));
+
+    assert!(
+        !outcome.success,
+        "a non-zero exit must fail the step regardless of stdout",
+    );
+}
+
+#[test]
+fn auth_failure_shape_reports_no_completion_evidence() {
+    // The real capture: session control-plane frames only, error on stderr.
+    let body = r#"printf '%s\n' '{"type":"session.warning","data":{"message":"Third-party MCP servers are disabled by your organization'"'"'s Copilot policy.","warningType":"policy"},"ephemeral":true}'
+printf '%s\n' 'Error: Authentication failed' >&2
+exit 1"#;
+    let harness = Harness::new(body);
+    let outcome = dispatch(&harness, spec(Some("claude-sonnet-4.5"), 60));
+
+    assert!(
+        !outcome.success,
+        "an unauthenticated launch must not succeed"
+    );
+}
+
+#[test]
+fn exit_zero_without_an_assistant_message_is_not_success() {
+    // The property AC4 turns on: a clean exit with no model output carries no
+    // completion evidence, and Orbit must not manufacture one.
+    let body = r#"printf '%s\n' '{"type":"session.created","data":{"sessionId":"s1"},"ephemeral":true}'
+printf '%s\n' '{"type":"session.idle","data":{},"ephemeral":true}'
+exit 0"#;
+    let harness = Harness::new(body);
+    let outcome = dispatch(&harness, spec(Some("claude-sonnet-4.5"), 60));
+
+    assert!(
+        !outcome.success,
+        "missing completion evidence must never read as success",
+    );
+}
+
+#[test]
+fn malformed_stdout_is_not_success() {
+    let body = r#"printf '%s\n' 'this is not JSON'
+printf '%s\n' '{"type":"assistant.message","data":{"content":"{ truncated'
+exit 0"#;
+    let harness = Harness::new(body);
+    let outcome = dispatch(&harness, spec(Some("claude-sonnet-4.5"), 60));
+
+    assert!(
+        !outcome.success,
+        "malformed output must not read as success"
+    );
+}
+
+#[test]
+fn wall_clock_timeout_cancels_the_agent_and_fails_the_step() {
+    let harness = Harness::new("sleep 30\nexit 0");
+    let outcome = dispatch(&harness, spec(Some("claude-sonnet-4.5"), 1));
+
+    assert!(!outcome.success, "a timed-out agent must not succeed");
+    let message = outcome.message.unwrap_or_default();
+    assert!(
+        message.contains("timeout") || message.contains("wall-clock"),
+        "timeout should be named in the failure message, got: {message}",
+    );
+}

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use orbit_agent::{
-    Agent, AgentConfig, AgentOperation, AgentRequest, peek_response_status,
+    Agent, AgentConfig, AgentOperation, AgentRequest, normalize_cli_stdout, peek_response_status,
     provider_invocation_diagnostic, response_envelope_protocol_check,
 };
 use orbit_common::process::identity::process_start_identity_token;
@@ -354,12 +354,26 @@ pub fn run_cli_backend(
     // A truncated capture retains the final complete JSONL events separately
     // from its diagnostic prefix. Protocol parsing must use that tail so a
     // verbose provider's final Orbit envelope remains authoritative.
-    let stdout_text = String::from_utf8_lossy(stdout.protocol_bytes());
+    //
+    // [ORB-10946] Reduce the capture to the bytes this provider's protocol
+    // contract may be read from, once, so every check below agrees on what the
+    // agent actually emitted. For all providers but `copilot` this borrows the
+    // capture unchanged; `copilot` streams JSONL agent events that replay
+    // Orbit's own prompt — example envelope included — back as a `user.message`
+    // frame, which the reverse envelope scan would otherwise be free to read as
+    // completion evidence.
+    let protocol_stdout = normalize_cli_stdout(&provider, stdout.protocol_bytes());
+    let stdout_text = String::from_utf8_lossy(protocol_stdout.as_ref());
     let envelope_status = peek_response_status(stdout_text.as_ref());
-    let stdout_preview = stdout_text_preview(stdout_text.as_ref(), &redaction, stdout.truncated());
+    // The operator-facing preview stays on the *raw* capture: normalization
+    // drops the session control plane, and that is where a provider puts the
+    // policy and authentication failures an operator needs to see.
+    let raw_stdout_text = String::from_utf8_lossy(stdout.protocol_bytes());
+    let stdout_preview =
+        stdout_text_preview(raw_stdout_text.as_ref(), &redaction, stdout.truncated());
     let parsed_result = exit_success.then(|| {
         parse_cli_response_result(
-            stdout.protocol_bytes(),
+            protocol_stdout.as_ref(),
             stderr.protocol_bytes(),
             exit_code,
             duration.as_millis() as u64,
@@ -402,7 +416,7 @@ pub fn run_cli_backend(
         && !completion_status_failure
         && (!spec.require_response_envelope || response_envelope_valid);
     let trace = parse_cli_invocation_trace(
-        stdout.protocol_bytes(),
+        protocol_stdout.as_ref(),
         stderr.protocol_bytes(),
         exit_code,
         duration.as_millis() as u64,

--- a/crates/orbit-exec/src/macos_sandbox/compile.rs
+++ b/crates/orbit-exec/src/macos_sandbox/compile.rs
@@ -44,6 +44,8 @@ pub fn compile_macos_sandbox_profile(
     let codex_home = std::env::var_os("CODEX_HOME");
     let claude_config_dir = std::env::var_os("CLAUDE_CONFIG_DIR");
     let grok_home = std::env::var_os("GROK_HOME");
+    let copilot_home = std::env::var_os("COPILOT_HOME");
+    let xdg_cache_home = std::env::var_os("XDG_CACHE_HOME");
     compile_macos_sandbox_profile_with_env(
         rules,
         provider,
@@ -52,6 +54,8 @@ pub fn compile_macos_sandbox_profile(
             codex_home: codex_home.as_deref(),
             claude_config_dir: claude_config_dir.as_deref(),
             grok_home: grok_home.as_deref(),
+            copilot_home: copilot_home.as_deref(),
+            xdg_cache_home: xdg_cache_home.as_deref(),
         },
     )
 }
@@ -65,6 +69,8 @@ pub(super) struct SandboxCompileEnv<'a> {
     pub(super) codex_home: Option<&'a OsStr>,
     pub(super) claude_config_dir: Option<&'a OsStr>,
     pub(super) grok_home: Option<&'a OsStr>,
+    pub(super) copilot_home: Option<&'a OsStr>,
+    pub(super) xdg_cache_home: Option<&'a OsStr>,
 }
 
 pub(super) fn compile_macos_sandbox_profile_with_env(
@@ -77,6 +83,8 @@ pub(super) fn compile_macos_sandbox_profile_with_env(
         codex_home,
         claude_config_dir,
         grok_home,
+        copilot_home,
+        xdg_cache_home,
     } = env;
     let mut out = String::new();
     out.push_str("(version 1)\n");
@@ -135,6 +143,23 @@ pub(super) fn compile_macos_sandbox_profile_with_env(
             "(allow file-write* (subpath \"{}\"))\n",
             super::sbpl_filter::sbpl_escape(&state_dir.display().to_string())
         ));
+    }
+    // [ORB-10946] Copilot's directories are granted only when Copilot is the
+    // provider actually being confined. The comment above explains why the
+    // four original providers are emitted unconditionally: their entries are
+    // per-tool configuration directories. Copilot's second entry is a
+    // package-*extraction* directory — the launcher unpacks and executes code
+    // from it — so it is not something an unrelated provider should be handed
+    // just because both run under the same profile compiler.
+    if Provider::parse(provider).ok() == Some(Provider::Copilot) {
+        for state_dir in
+            super::provider_dirs::copilot_state_dirs(home, copilot_home, xdg_cache_home)
+        {
+            out.push_str(&format!(
+                "(allow file-write* (subpath \"{}\"))\n",
+                super::sbpl_filter::sbpl_escape(&state_dir.display().to_string())
+            ));
+        }
     }
     super::provider_dirs::emit_claude_home_json_allows(home, claude_config_dir, &mut out);
     super::provider_dirs::emit_grok_state_file_allows(home, grok_home, &mut out);

--- a/crates/orbit-exec/src/macos_sandbox/provider_dirs.rs
+++ b/crates/orbit-exec/src/macos_sandbox/provider_dirs.rs
@@ -75,6 +75,58 @@ pub fn grok_state_dir_from_env() -> Option<PathBuf> {
     grok_state_dir(home.as_deref(), grok_home.as_deref())
 }
 
+/// Writable directories an **active** Copilot executor needs, in the order
+/// they are granted. [ORB-10946]
+///
+/// Unlike [`provider_state_dirs`], this is gated on the active provider by its
+/// caller. Copilot's cache entry is a package-extraction directory, not
+/// per-tool configuration, so granting it to every provider would hand each
+/// one a writable path it has no reason to touch.
+///
+/// 1. `$COPILOT_HOME`, else `$HOME/.copilot` — the CLI's documented
+///    configuration and state directory (credentials from `copilot /login`,
+///    session history, `mcp-config.json`, and `logs/`).
+/// 2. `$XDG_CACHE_HOME/copilot`, else `$HOME/.cache/copilot` — the standalone
+///    CLI ships as a launcher that extracts its bundled package here on first
+///    run. Without this the CLI aborts before it ever reads Orbit's envelope,
+///    with `ENOENT: no such file or directory, mkdir '<...>/.cache/copilot'`.
+pub(crate) fn copilot_state_dirs(
+    home: Option<&OsStr>,
+    copilot_home: Option<&OsStr>,
+    xdg_cache_home: Option<&OsStr>,
+) -> Vec<PathBuf> {
+    let mut dirs = Vec::with_capacity(2);
+    if let Some(dir) = copilot_state_dir(home, copilot_home) {
+        dirs.push(dir);
+    }
+    if let Some(dir) = copilot_cache_dir(home, xdg_cache_home) {
+        dirs.push(dir);
+    }
+    dirs
+}
+
+/// Copilot CLI documents `COPILOT_HOME` as the override for the directory
+/// where configuration and state files are stored; otherwise it uses
+/// `$HOME/.copilot`.
+pub(crate) fn copilot_state_dir(
+    home: Option<&OsStr>,
+    copilot_home: Option<&OsStr>,
+) -> Option<PathBuf> {
+    non_empty_env_path(copilot_home)
+        .or_else(|| non_empty_env_path(home).map(|path| path.join(".copilot")))
+}
+
+/// The Copilot launcher's bundled-package extraction directory. Honors
+/// `XDG_CACHE_HOME` before falling back to `$HOME/.cache`.
+pub(crate) fn copilot_cache_dir(
+    home: Option<&OsStr>,
+    xdg_cache_home: Option<&OsStr>,
+) -> Option<PathBuf> {
+    non_empty_env_path(xdg_cache_home)
+        .map(|path| path.join("copilot"))
+        .or_else(|| non_empty_env_path(home).map(|path| path.join(".cache").join("copilot")))
+}
+
 pub(super) fn non_empty_env_path(value: Option<&OsStr>) -> Option<PathBuf> {
     let value = value?;
     if value.to_string_lossy().is_empty() {

--- a/crates/orbit-exec/src/macos_sandbox/test_support.rs
+++ b/crates/orbit-exec/src/macos_sandbox/test_support.rs
@@ -20,6 +20,8 @@ pub(super) struct EnvOverrides<'a> {
     pub(super) codex_home: Option<&'a str>,
     pub(super) claude_config_dir: Option<&'a str>,
     pub(super) grok_home: Option<&'a str>,
+    pub(super) copilot_home: Option<&'a str>,
+    pub(super) xdg_cache_home: Option<&'a str>,
 }
 
 /// Provider used by profile tests that are not about the per-provider
@@ -40,6 +42,8 @@ pub(super) fn compile_with_env(
             codex_home: env.codex_home.map(OsStr::new),
             claude_config_dir: env.claude_config_dir.map(OsStr::new),
             grok_home: env.grok_home.map(OsStr::new),
+            copilot_home: env.copilot_home.map(OsStr::new),
+            xdg_cache_home: env.xdg_cache_home.map(OsStr::new),
         },
     )
     .expect("compile")

--- a/crates/orbit-exec/src/macos_sandbox/tests/provider_dirs.rs
+++ b/crates/orbit-exec/src/macos_sandbox/tests/provider_dirs.rs
@@ -355,6 +355,8 @@ fn compiled_profile_allows_writes_to_provider_state_dirs() {
             codex_home: None,
             claude_config_dir: None,
             grok_home: None,
+            copilot_home: None,
+            xdg_cache_home: None,
         },
     )
     .expect("compile sbpl");
@@ -424,6 +426,8 @@ fn compiled_profile_allows_writes_to_grok_json_lock_and_tmp_files() {
             codex_home: None,
             claude_config_dir: None,
             grok_home: None,
+            copilot_home: None,
+            xdg_cache_home: None,
         },
     )
     .expect("compile sbpl");
@@ -507,6 +511,8 @@ fn compiled_profile_allows_writes_to_claude_home_json_siblings() {
             codex_home: None,
             claude_config_dir: None,
             grok_home: None,
+            copilot_home: None,
+            xdg_cache_home: None,
         },
     )
     .expect("compile sbpl");
@@ -551,4 +557,144 @@ fn compiled_profile_allows_writes_to_claude_home_json_siblings() {
             "{label} target file was not written: {target:?}"
         );
     }
+}
+
+// [ORB-10946] Copilot's state grants are gated on the *active* provider, so
+// these assert both halves: present for copilot, absent for everyone else.
+
+#[test]
+fn copilot_state_dirs_default_under_home() {
+    let dirs = copilot_state_dirs(Some(OsStr::new("/Users/test")), None, None);
+
+    assert_eq!(
+        dirs,
+        vec![
+            PathBuf::from("/Users/test/.copilot"),
+            PathBuf::from("/Users/test/.cache/copilot"),
+        ]
+    );
+}
+
+#[test]
+fn copilot_state_dirs_honor_copilot_home_and_xdg_cache_home() {
+    let dirs = copilot_state_dirs(
+        Some(OsStr::new("/Users/test")),
+        Some(OsStr::new("/var/folders/test/copilot-home")),
+        Some(OsStr::new("/var/folders/test/cache")),
+    );
+
+    assert_eq!(
+        dirs,
+        vec![
+            PathBuf::from("/var/folders/test/copilot-home"),
+            PathBuf::from("/var/folders/test/cache/copilot"),
+        ]
+    );
+}
+
+#[test]
+fn copilot_state_dirs_ignore_empty_overrides() {
+    let dirs = copilot_state_dirs(
+        Some(OsStr::new("/Users/test")),
+        Some(OsStr::new("")),
+        Some(OsStr::new("")),
+    );
+
+    assert_eq!(
+        dirs,
+        vec![
+            PathBuf::from("/Users/test/.copilot"),
+            PathBuf::from("/Users/test/.cache/copilot"),
+        ]
+    );
+}
+
+#[test]
+fn copilot_state_dirs_are_empty_without_home_or_overrides() {
+    assert!(copilot_state_dirs(None, None, None).is_empty());
+}
+
+#[test]
+fn compile_grants_copilot_dirs_only_to_an_active_copilot_executor() {
+    let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
+
+    let copilot_profile = compile_with_env(
+        &resolved,
+        "copilot",
+        EnvOverrides {
+            home: Some("/Users/test"),
+            ..Default::default()
+        },
+    );
+    assert!(
+        copilot_profile.contains("(allow file-write* (subpath \"/Users/test/.copilot\"))"),
+        "active copilot must be granted its state dir",
+    );
+    assert!(
+        copilot_profile.contains("(allow file-write* (subpath \"/Users/test/.cache/copilot\"))"),
+        "active copilot must be granted its package-extraction cache",
+    );
+
+    // No other provider inherits Copilot-specific write access.
+    for provider in ["claude", "codex", "gemini", "grok"] {
+        let other = compile_with_env(
+            &resolved,
+            provider,
+            EnvOverrides {
+                home: Some("/Users/test"),
+                ..Default::default()
+            },
+        );
+        assert!(
+            !other.contains("/Users/test/.copilot"),
+            "{provider} must not inherit the copilot state dir",
+        );
+        assert!(
+            !other.contains("/Users/test/.cache/copilot"),
+            "{provider} must not inherit the copilot extraction cache",
+        );
+    }
+}
+
+#[test]
+fn compile_uses_the_copilot_home_override_for_the_active_executor() {
+    let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
+
+    let text = compile_with_env(
+        &resolved,
+        "copilot",
+        EnvOverrides {
+            home: Some("/Users/test"),
+            copilot_home: Some("/var/folders/test/copilot-home"),
+            xdg_cache_home: Some("/var/folders/test/cache"),
+            ..Default::default()
+        },
+    );
+
+    assert!(text.contains("(allow file-write* (subpath \"/var/folders/test/copilot-home\"))"));
+    assert!(text.contains("(allow file-write* (subpath \"/var/folders/test/cache/copilot\"))"));
+    // With the override set, the default location is not additionally granted.
+    assert!(!text.contains("\"/Users/test/.copilot\""));
+}
+
+#[test]
+fn copilot_does_not_receive_the_macos_keychain_carve_out() {
+    // Copilot stores its credentials under COPILOT_HOME, not the login
+    // keychain, so it keeps the default credential deny. It also must not be
+    // handed the GitHub CLI's credential store: borrowing another tool's
+    // credentials is exactly what the auth contract forbids.
+    let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
+
+    let text = compile_with_env(
+        &resolved,
+        "copilot",
+        EnvOverrides {
+            home: Some("/Users/test"),
+            ..Default::default()
+        },
+    );
+
+    assert!(!text.contains("(allow file-read* (subpath \"/Users/test/Library/Keychains\"))"));
+    assert!(text.contains("(deny file-read* (subpath \"/Users/test/Library/Keychains\"))"));
+    assert!(text.contains("(deny file-read* (subpath \"/Users/test/.config/gh\"))"));
 }

--- a/crates/orbit-types/src/workflow/activity_job/activity_v2.rs
+++ b/crates/orbit-types/src/workflow/activity_job/activity_v2.rs
@@ -178,6 +178,7 @@ pub enum Provider {
     Codex,
     Gemini,
     Grok,
+    Copilot,
     Ollama,
     #[serde(rename = "openai_compat", alias = "openai-compat")]
     OpenaiCompat,
@@ -221,11 +222,12 @@ impl std::error::Error for ProviderParseError {}
 impl Provider {
     /// Every canonical provider, in declaration order. Adding a variant here is
     /// a compile-time forcing function for the match arms below.
-    pub const ALL: [Provider; 6] = [
+    pub const ALL: [Provider; 7] = [
         Provider::Claude,
         Provider::Codex,
         Provider::Gemini,
         Provider::Grok,
+        Provider::Copilot,
         Provider::Ollama,
         Provider::OpenaiCompat,
     ];
@@ -238,6 +240,12 @@ impl Provider {
     /// canonical `openai_compat` id (it is also a serde alias on the enum).
     /// This table is **closed** — an unlisted string is `provider.unknown`,
     /// never guessed. New aliases require a contract bump.
+    ///
+    /// [ORB-10946] `copilot` deliberately has **no** alias row. `github` is not
+    /// an accepted spelling for it, and the vendor that supplies a Copilot
+    /// session's underlying model (OpenAI, Anthropic, Google, …) must never
+    /// resolve to `copilot` — nor `copilot` to them. Copilot is its own
+    /// execution lane, and its identity is independent of the model it runs.
     pub const ALIASES: &'static [ProviderAlias] = &[
         ProviderAlias {
             alias: "anthropic",
@@ -272,7 +280,8 @@ impl Provider {
     ];
 
     /// Human-readable canonical id list used in diagnostics.
-    pub const CANONICAL_LIST: &'static str = "claude, codex, gemini, grok, ollama, openai_compat";
+    pub const CANONICAL_LIST: &'static str =
+        "claude, codex, gemini, grok, copilot, ollama, openai_compat";
 
     pub fn as_str(self) -> &'static str {
         match self {
@@ -280,6 +289,7 @@ impl Provider {
             Provider::Codex => "codex",
             Provider::Gemini => "gemini",
             Provider::Grok => "grok",
+            Provider::Copilot => "copilot",
             Provider::Ollama => "ollama",
             Provider::OpenaiCompat => "openai_compat",
         }
@@ -341,10 +351,15 @@ impl Provider {
     }
 
     /// Whether the model-neutral Worker leaf executor can execute this
-    /// provider. Worker only wires the CLI agent families; `ollama` and
-    /// `openai_compat` are Orbit-canonical capabilities Worker does not run.
+    /// provider. Worker only wires the CLI agent families; `copilot`, `ollama`
+    /// and `openai_compat` are Orbit-canonical capabilities Worker does not run.
     /// Preserving this distinction is an explicit ORB-10091 constraint — Orbit
     /// keeps the wider set even though Worker cannot execute all of it.
+    ///
+    /// [ORB-10946] `copilot` returning `false` here is the stable
+    /// unavailable diagnostic, not a fallback: a Worker-routed step naming
+    /// `copilot` is refused by identity rather than silently re-pointed at
+    /// another family.
     pub fn is_worker_executable(self) -> bool {
         matches!(
             self,

--- a/crates/orbit-types/src/workflow/activity_job/tests/activity_v2.rs
+++ b/crates/orbit-types/src/workflow/activity_job/tests/activity_v2.rs
@@ -69,14 +69,36 @@ fn provider_capability_predicates_match_contract() {
     let canonical = string_vec(&contract["canonical_providers"]);
     let known = string_vec(&contract["known_providers"]);
 
-    // Every canonical variant maps to exactly one known-provider row; adding a
-    // `Provider` variant without a contract row (or vice-versa) fails here.
     assert_eq!(canonical.len(), 4, "canonical set is exactly four");
-    assert_eq!(
-        Provider::ALL.len(),
-        known.len(),
-        "Provider::ALL must mirror the contract's known_providers",
-    );
+
+    // Identities Orbit has adopted ahead of the shared Constellation contract.
+    //
+    // The fixture is a byte-for-byte vendored copy of a contract Orbit shares
+    // with Worker and Bridge and does not own, and its hash pin exists to force
+    // a *reviewed* upstream bump. So this assertion is directional rather than
+    // an equality: every contract row must still exist in `Provider::ALL`, and
+    // the only variants allowed to exist without a row are the ones named here.
+    // An accidental new variant still fails this test.
+    //
+    // [ORB-10946] `copilot` is such an identity. Adding it upstream is a
+    // cross-system change (Worker and Bridge resolve against the same rows);
+    // until that lands, Orbit can dispatch Copilot while Worker correctly
+    // refuses it — which is what `is_worker_executable() == false` encodes.
+    const ORBIT_ONLY_PROVIDERS: &[&str] = &["copilot"];
+
+    for name in &known {
+        assert!(
+            Provider::ALL.iter().any(|p| p.as_str() == name),
+            "contract row '{name}' must exist in Provider::ALL",
+        );
+    }
+    for provider in Provider::ALL {
+        let name = provider.as_str();
+        assert!(
+            known.iter().any(|row| row == name) || ORBIT_ONLY_PROVIDERS.contains(&name),
+            "Provider::{provider:?} has no contract row and is not a declared Orbit-only identity",
+        );
+    }
 
     for name in &known {
         let provider =
@@ -96,6 +118,35 @@ fn provider_capability_predicates_match_contract() {
             provider.has_cli_runtime(),
             name != "openai_compat",
             "has_cli_runtime for {name}",
+        );
+    }
+
+    // The Orbit-only identities, asserted directly since no contract row
+    // covers them yet. [ORB-10946]
+    let copilot = Provider::parse("copilot").expect("copilot is canonical");
+    assert_eq!(copilot.as_str(), "copilot");
+    assert_eq!(copilot.to_string(), "copilot");
+    assert!(
+        copilot.has_cli_runtime(),
+        "Orbit ships a copilot CLI runtime",
+    );
+    assert!(
+        !copilot.is_worker_executable(),
+        "Worker has no copilot lane, so it must refuse rather than fall back",
+    );
+    // Copilot is never reachable through another vendor's or GitHub's name,
+    // and no alias resolves away from it.
+    for spelling in ["github", "gh-copilot", "github-copilot", "copilot-cli"] {
+        assert!(
+            Provider::parse(spelling).is_err(),
+            "'{spelling}' must not resolve to a provider",
+        );
+    }
+    for vendor_alias in ["anthropic", "openai", "google", "xai"] {
+        let resolved = Provider::resolve_name(vendor_alias).expect("vendor alias resolves");
+        assert_ne!(
+            resolved.provider, copilot,
+            "vendor alias '{vendor_alias}' must not resolve to copilot",
         );
     }
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -66,7 +66,7 @@ A **crew** is one provider-model assignment. Activities do not carry a model-sel
 | Field | Purpose | Values |
 |---|---|---|
 | `model` | Model identifier passed to the provider CLI | Provider-specific (e.g. `opus`, `sonnet`, `gpt-5.6-sol`, `gemini-3.7-flash`, `grok-4.6`) |
-| `provider` | Agent family | `claude`, `codex`, `gemini`, `grok` (the CLI-executable families; see [Provider identity and resolution](#provider-identity-and-resolution) for the full canonical set) |
+| `provider` | Agent family | `claude`, `codex`, `gemini`, `grok`, `copilot` (the CLI-executable families; see [Provider identity and resolution](#provider-identity-and-resolution) for the full canonical set) |
 | `description` | Optional human-facing crew summary | Any non-empty string after trimming |
 | `tags` | Optional discovery labels | Array of strings; normalized, sorted, and deduplicated |
 
@@ -90,7 +90,7 @@ provider = "grok"
 
 The current Grok Build CLI lists `grok-4.6` as its default from `grok models`, so Orbit uses that live menu id. The older `grok-build` string is not retained as a default or alias.
 
-Fresh `orbit init` configuration advertises only detected provider CLIs. Claude seeds `opus`, `sonnet`, and `fable`; Codex seeds `sol`, `terra`, and `luna`; Gemini seeds `gemini`; and Grok seeds `grok`. Interactive init still asks for the default crew (`[crews.custom]`) and, separately, for the cheap-tier system crew written as `[crews.system]`; it does not ask for QA. `--non-interactive` auto-seeds `[crews.system]` from the preference order above whenever a supported family is detected. When Codex or Claude is available, the legacy `qa` crew is still silently auto-seeded on Terra or Sonnet respectively as a compatibility lane. If no supported provider CLI is detected, init leaves both the crew registry and `workflow.default_crew` unset instead of writing an unusable provider.
+Fresh `orbit init` configuration advertises only detected provider CLIs. Claude seeds `opus`, `sonnet`, and `fable`; Codex seeds `sol`, `terra`, and `luna`; Gemini seeds `gemini`; Grok seeds `grok`; and Copilot seeds `copilot`. Copilot is last in every preference order, so installing the `copilot` CLI never changes the default crew, default provider, or system crew on a host that already has one of the other four families. Interactive init still asks for the default crew (`[crews.custom]`) and, separately, for the cheap-tier system crew written as `[crews.system]`; it does not ask for QA. `--non-interactive` auto-seeds `[crews.system]` from the preference order above whenever a supported family is detected. When Codex or Claude is available, the legacy `qa` crew is still silently auto-seeded on Terra or Sonnet respectively as a compatibility lane. If no supported provider CLI is detected, init leaves both the crew registry and `workflow.default_crew` unset instead of writing an unusable provider.
 
 You can define any number of crews. Set the workspace-wide fallback with `workflow.default_crew`; assign a specific crew to individual tasks via the [per-task crew override](#per-task-crew-override). Crews are validated at load time: each crew must have non-empty `model` and `provider`; `workflow.default_crew` must name a defined crew.
 
@@ -131,6 +131,7 @@ Every `provider` string Orbit reads — in `[crews.<name>]`, in an activity's in
 | `codex` | — | yes | no | yes |
 | `gemini` | — | yes | no | yes |
 | `grok` | — | yes | no | yes |
+| `copilot` | — | yes | no | **no** |
 | `ollama` | — | **unsupported at the Orbit CLI entry point** | no | **no** |
 | `openai_compat` | `openai-compat` | **no** (HTTP-only) | no | **no** |
 
@@ -144,7 +145,12 @@ Every `provider` string Orbit reads — in `[crews.<name>]`, in an activity's in
   | `google` | `gemini` |
   | `xai` | `grok` |
 
-- **Canonical ≠ Worker-executable.** Orbit's canonical set is deliberately wider than what the model-neutral Worker leaf executor can run: `ollama` and `openai_compat` are first-class Orbit providers but Worker does not execute them. This distinction is preserved on purpose — do not narrow the canonical set to Worker's subset.
+  `copilot` has **no** alias. `github` is not an accepted spelling for it, and
+  the vendor that supplies a Copilot session's underlying model never resolves
+  to `copilot` (nor `copilot` to that vendor) — see
+  [GitHub Copilot CLI](#github-copilot-cli).
+
+- **Canonical ≠ Worker-executable.** Orbit's canonical set is deliberately wider than what the model-neutral Worker leaf executor can run: `copilot`, `ollama`, and `openai_compat` are first-class Orbit providers but Worker does not execute them. This distinction is preserved on purpose — do not narrow the canonical set to Worker's subset. For `copilot` this is a *stable diagnostic*, not a fallback: a Worker-routed step naming `copilot` is refused by identity rather than silently re-pointed at another family.
 - **Known ≠ executable at this entry point.** The shared contract recognizes `ollama`, but the Orbit CLI capability set is the canonical cross-repo four; explicitly selecting `ollama` fails as `provider.unsupported` rather than falling back.
 - **`openai_compat` has no CLI runtime.** Every crew dispatches through the CLI agent path, so selecting it fails structurally (see below) rather than falling back.
 
@@ -176,9 +182,128 @@ Explicit selections that are unsupported or unavailable **fail with a stable dia
 
 - `provider openai_compat is unsupported by the Orbit CLI entry point (HTTP-only)` — a CLI-executable dispatch selected an HTTP-only provider.
 - `provider ollama is unsupported by the Orbit CLI entry point` — a known provider is outside this entry point's capability set.
-- `unknown provider '<x>'; expected one of claude, codex, gemini, grok, ollama, openai_compat — no CLI runtime registered` — the provider string did not resolve to a canonical id.
+- `unknown provider '<x>'; expected one of claude, codex, gemini, grok, copilot, ollama, openai_compat — no CLI runtime registered` — the provider string did not resolve to a canonical id.
 
 An **unrecognized `[crews.<name>].provider` value** is the one non-fatal case: it is logged (`orbit.config.crew` warn) and that field falls back to the activity's inline `provider`, because a config typo should not coerce dispatch onto a wrong runtime — the inline value is the known-good identity, not a default guess.
+
+---
+
+## GitHub Copilot CLI
+
+Orbit dispatches Copilot through the **standalone `copilot` CLI** (npm package
+`@github/copilot`), which provides a non-interactive programmatic mode.
+
+> **The retired `gh-copilot` extension is not supported.** `gh copilot` was a
+> shell-command *suggester*, not an agent: it could not edit files or run a
+> turn to completion, so it cannot satisfy Orbit's completion-envelope
+> contract. Orbit never probes for it, never dispatches to it, and installing
+> it does not make the `copilot` provider available.
+
+### Installation
+
+```sh
+npm install -g @github/copilot
+copilot --version
+```
+
+`orbit init` detects the `copilot` binary on `PATH` and offers the `copilot`
+crew. Detection is by binary presence only — see
+[Authentication](#authentication) for what a *working* run additionally needs.
+
+### Organization-policy prerequisites
+
+Copilot is organization-governed, and its policy checks happen server-side
+after the CLI starts. Two failures are common and are **not** Orbit
+misconfiguration:
+
+- **No Copilot entitlement.** The CLI exits non-zero with
+  `Error: Authentication failed` and advises checking the token's
+  `Copilot Requests` permission. Orbit reports the step as failed; it never
+  falls back to another provider.
+- **Third-party MCP servers disabled by policy.** The CLI emits a
+  `session.warning` frame with `warningType: "policy"` and continues with
+  built-in servers only.
+
+Both require a change by the GitHub organization administrator, not by Orbit.
+
+### Authentication
+
+Copilot resolves credentials in this documented order:
+
+1. `COPILOT_GITHUB_TOKEN`
+2. `GH_TOKEN`
+3. `GITHUB_TOKEN`
+4. Otherwise, the credentials stored by `copilot` itself via its `/login`
+   command, under `COPILOT_HOME` (default `$HOME/.copilot`).
+
+**Orbit does not forward those token variables on the provider's behalf.**
+Agent subprocesses get an allowlist-composed environment, and credentials are
+admitted only when an operator names them, so an unrelated `GITHUB_TOKEN` left
+in the environment cannot be silently borrowed by a Copilot run. To use
+token-based authentication, add the variable explicitly:
+
+```toml
+[execution.env]
+pass = ["COPILOT_GITHUB_TOKEN"]
+```
+
+Token *values* are never logged, recorded in audit argv, or included in error
+messages. The recommended setup is `copilot` `/login` once on the host, which
+needs no token in the environment at all.
+
+`COPILOT_HOME` is forwarded to the provider subprocess and is also what the
+sandbox grants, so the directory the CLI writes to and the directory Orbit
+allows cannot drift apart.
+
+### Model selection
+
+Orbit always passes `--model` explicitly, from the crew assignment. Without it
+the CLI would fall back to `COPILOT_MODEL` or its own persisted `/model`
+choice, which would make a run's model depend on ambient operator state rather
+than on configuration.
+
+```toml
+[crews.copilot]
+model = "claude-sonnet-4.5"
+provider = "copilot"
+```
+
+Copilot routes to several vendors' models (`claude-*`, `gpt-*`, `gemini-*`).
+**The provider identity stays `copilot` regardless.** A crew running
+`gpt-5.4` through Copilot is a `copilot` run, not a `codex` run: the execution
+lane, its authentication, its policy, and its sandbox grants are Copilot's.
+Run `copilot --model <id>` or the interactive `/model` command to see the ids
+your organization currently allows.
+
+### Sandbox and permissions
+
+Orbit's activity sandbox remains the security boundary. The shipped executor
+passes `--allow-all-tools` so the agent does not block waiting for approval,
+together with `--no-ask-user`. It deliberately does **not** pass `--allow-all`
+or `--yolo`: those also imply `--allow-all-paths` and `--allow-all-urls`, which
+would widen the agent's reach past what the enclosing Orbit sandbox granted.
+
+When a Copilot executor is the active provider, the sandbox additionally grants
+write access to `COPILOT_HOME` (default `$HOME/.copilot`) and to the launcher's
+package-extraction cache (`$XDG_CACHE_HOME/copilot`, default
+`$HOME/.cache/copilot`). Those grants are **gated on Copilot being the provider
+actually running** — other providers do not inherit them.
+
+Copilot is not granted read access to the GitHub CLI's credential store
+(`~/.config/gh`) or to the macOS login keychain; it authenticates from its own
+`COPILOT_HOME` or from an operator-passed token.
+
+### Prompt transport
+
+The Orbit execution envelope is written to the agent's **standard input**, not
+passed as `-p <text>`. Both are supported by the CLI, but argv is visible in
+process listings and is recorded in Orbit's audit argv, so the prompt — which
+carries task context and instructions — must not travel there.
+
+Copilot's stdout is JSONL agent events (`--output-format json`). Orbit reads
+completion evidence only from model-authored frames; a run that emits no
+assistant message has not completed its contract, and Orbit fails the step
+rather than inferring success from the session control plane.
 
 ---
 

--- a/docs/design/agent-families/2_design.md
+++ b/docs/design/agent-families/2_design.md
@@ -28,7 +28,11 @@ Workspace config defines one concrete assignment under each `[crews.<name>]`: fl
 
 `crates/orbit-config/src/raw.rs` owns the TOML shape, and `crates/orbit-config/src/resolved.rs` materializes it into `Crew` values from `orbit-common`. Runtime loading rejects incomplete crews, retired `planner`/`implementer`/`reviewer` role sub-tables with guidance to write flat `model`, `provider`, and `backend` fields, and `[workflow].default_crew` values that do not name a defined crew.
 
-The built-in runtime registry uses model-specific standard crews: Claude provides `opus`, `sonnet`, and `fable`; Codex provides `sol`, `terra`, and `luna`; Gemini provides `gemini`; and Grok provides `grok`. Fresh `orbit init` config filters that registry by detected provider CLIs, always writes `backend = "cli"`, and chooses the first emitted standard crew as `[workflow].default_crew` (`opus`, `sol`, `gemini`, or `grok`). It adds `qa` on Terra when Codex is available, otherwise on Sonnet when Claude is available. With no supported provider CLI, initialization emits neither crews nor a dangling default.
+The built-in runtime registry uses model-specific standard crews: Claude provides `opus`, `sonnet`, and `fable`; Codex provides `sol`, `terra`, and `luna`; Gemini provides `gemini`; Grok provides `grok`; and Copilot provides `copilot`. Fresh `orbit init` config filters that registry by detected provider CLIs, always writes `backend = "cli"`, and chooses the first emitted standard crew as `[workflow].default_crew` (`opus`, `sol`, `gemini`, `grok`, or `copilot`).
+
+It adds `qa` on Terra when Codex is available, otherwise on Sonnet when Claude is available. With no supported provider CLI, initialization emits neither crews nor a dangling default.
+
+`copilot` is the one crew named for its *provider* rather than its model: Copilot's model is supplied by another vendor, so naming the crew after the model would hide which execution lane the run actually uses. It is last in every preference order, so adding it cannot move an existing host's defaults. See [CONFIG.md § GitHub Copilot CLI](../../CONFIG.md#github-copilot-cli) for installation, organization-policy prerequisites, authentication, and model selection. [ORB-10946]
 
 ## 3. Task and Tool Surface
 
@@ -59,6 +63,7 @@ An activity-specific crew is carried in rendered input rather than persisted as 
 ## Task References
 
 - ORB-00042: Onboard Grok (xAI) as a first-class supported agent family.
+- ORB-10946: Add the standalone GitHub Copilot CLI as a first-class workflow executor.
 - ORB-00058: Introduce per-task crew override for agent model selection.
 - ORB-10315: Seed model-specific crews only for providers available during initialization.
 - ORB-10620: Reject retired crew role sub-tables during config load.


### PR DESCRIPTION
## Task

[ORB-10946](https://orbit-cli.com/tasks/ORB-10946) — Add GitHub Copilot CLI as a first-class Orbit workflow executor

### Description

## Problem

Orbit cannot select or launch GitHub Copilot as a workflow worker. The current canonical provider set, bundled executors, runtime adapters, crew resolution, and sandbox state handling omit GitHub's generally available standalone `copilot` agent CLI, even though it provides a programmatic mode for autonomous code changes.

## Why It Matters

Copilot has a large installed base, strong GitHub-native repository and pull-request integration, organization-managed authentication, and access to multiple underlying model families. Supporting it gives Orbit a meaningful additional execution lane for users whose approved agent subscription is GitHub Copilot.

## Constraints / Notes

- Integrate the current standalone `copilot` CLI. Never depend on or advertise the retired `gh-copilot` extension.
- Persist `copilot` as its own provider identity even when its selected model is supplied by OpenAI, Anthropic, Google, or another vendor.
- Start with the supported local programmatic CLI or ACP surface; do not embed the Copilot SDK or use Copilot cloud agents unless evidence shows the local surfaces cannot satisfy Orbit's supervision and completion contracts.
- Orbit's activity sandbox remains the security boundary. Copilot auto-approval must not expand the enclosing filesystem or network grants.
- Verify current CLI help and capture representative success and failure fixtures before fixing prompt transport, output parsing, or model identifiers.
- Preserve Orbit's completion-envelope, audit, redaction, cancellation, and fail-closed provider-resolution contracts.

### Acceptance Criteria

- Copilot is a canonical provider accepted by the shared provider parser, capability checks, crew/runtime resolution, and supported-provider diagnostics without aliasing it to GitHub, Codex, or the selected underlying model vendor.
- Orbit ships a platform-aware direct-agent executor for the standalone copilot command using a documented non-interactive transport, unattended tool approval inside Orbit's sandbox, no-user-prompt behavior, and explicit model selection.
- The implementation chooses and documents the CLI programmatic or ACP transport using captured current-version evidence; prompts and secrets are not exposed through process listings, logs, tasks, audit records, or error messages.
- A Copilot runtime adapter normalizes representative real success, failure, cancellation, and malformed-output fixtures into Orbit's response/envelope contract and never treats missing required completion evidence as success.
- Authentication honors the documented COPILOT_GITHUB_TOKEN, GH_TOKEN, and GITHUB_TOKEN precedence and supports COPILOT_HOME without logging token values or silently borrowing unrelated provider credentials.
- macOS and Linux sandbox policy grants only the Copilot configuration/state access required by an active Copilot executor; other providers do not inherit Copilot-specific write access.
- Fresh-init detection and crew configuration can expose an installed Copilot executor while preserving existing provider-family defaults and returning a stable unavailable or policy-disabled diagnostic instead of falling back.
- Deterministic fake-agent tests cover command construction, prompt transport, explicit model propagation, successful worktree edits, permission configuration, non-zero exit, malformed output, timeout/cancellation, secret redaction, and sandbox confinement.
- Current configuration and execution documentation covers standalone Copilot CLI installation, organization-policy prerequisites, authentication, model selection, and explicitly rejects the retired gh-copilot extension.
- Focused provider/executor tests, make ci-fast, and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Added GitHub Copilot as a first-class Orbit workflow executor via the standalone `copilot`
CLI (npm `@github/copilot`). `make ci-fast` and `make ci-lint` pass; full `cargo test
--workspace` is green (2945 tests / 62 suites, 0 failures).

## Evidence captured before implementing (CLI 1.0.80, probed on this host)

- `--help` / `copilot help environment` captured from the real binary.
- **Prompt transport decided on evidence.** With empty stdin the CLI exits 1 with its own
  message: "No prompt provided. Run in an interactive terminal or provide a prompt with -p
  or via standard in." Piping the prompt (no `-p`) parses and proceeds to auth. Orbit uses
  **stdin**, so the execution envelope never enters argv, process listings, or the audit
  argv. `--acp` was rejected: it is a persistent bidirectional JSON-RPC *server*, while
  Orbit's contract is one-shot spawn + envelope on stdout.
- Auth precedence confirmed verbatim: `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`
  "(in order of precedence)"; `COPILOT_HOME` defaults to `$HOME/.copilot`.
- Startup extracts its bundled package to `$XDG_CACHE_HOME|$HOME/.cache/copilot` — observed
  as a hard ENOENT abort when that path was not writable, so it is a real sandbox
  requirement, not a guess.
- JSONL frame shape and event vocabulary read from the shipped bundle; GitHub's own
  extractor takes the last `assistant.message` with non-empty `data.content`.
- Model ids (`claude-sonnet-4.5`, `claude-haiku-4.5`) verified against the shipped catalog.
- **Real failure fixture captured** (token lacks Copilot entitlement): ephemeral `session.*`
  frames only, no `assistant.message`, exit 1. Reproduced verbatim in tests.

## What changed

- `orbit-types`: `Provider::Copilot` — canonical, **no alias row**. `github` does not
  resolve to it, and no vendor alias resolves to/from it. `is_worker_executable() == false`
  is a stable refusal, not a fallback.
- `orbit-core`: shipped `assets/executors/copilot.yaml` (direct agent, platform-aware
  sandbox marker) + seeding registration.
- `orbit-agent`: `providers/copilot/` (cli transport, runtime, stream normalizer) +
  `ProviderOptions::Copilot` + registry entry + `normalize_cli_stdout`.
- `orbit-engine`: the CLI runner normalizes provider stdout once before every protocol read.
- Sandbox: Copilot's state dir and extraction cache granted on **macOS and Linux**, gated on
  Copilot being the active provider; no other provider inherits them.
- Config/init: copilot detection, crew, and model defaults — appended **last** everywhere,
  so no existing host's default provider, default crew, or system crew moves.
- Docs: new `docs/CONFIG.md` § "GitHub Copilot CLI" (installation, org-policy
  prerequisites, auth, model selection, sandbox, prompt transport) and an explicit rejection
  of the retired `gh-copilot` extension; provider tables and the agent-families design doc
  updated.

## Two decisions worth review

1. **Completion evidence (AC4).** Copilot echoes the prompt back as a `user.message` frame,
   and every Orbit prompt embeds the response contract's own example envelope. The shared
   reverse envelope scan could therefore read Orbit's own instructions back as the agent's
   completion. The normalizer keeps only model-authored frames (`assistant.*` / `error.*`
   prefix allowlist), so a run with no model output normalizes to empty and fails. The
   allowlist is a prefix, not an exact-type list, so `assistant.usage` telemetry survives and
   a future `assistant.*` subtype is not dropped by a stale table.
2. **Credentials are not auto-forwarded (AC5).** `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` /
   `GITHUB_TOKEN` are deliberately **not** in the provider's env extras. `child_env` admits
   credentials only by operator opt-in through `[execution.env].pass`, so a Copilot run
   cannot silently borrow a GitHub token an unrelated tool left in the environment. Default
   auth is `copilot /login` state under `COPILOT_HOME`. Copilot is also not given read access
   to `~/.config/gh` or the macOS login keychain. This is documented.

## Tests (22 new)

13 unit (orbit-agent: argv shape, model propagation across vendors, stdin-not-argv, stream
normalization for success / real auth-failure capture / cancellation / malformed / prompt-echo),
9 deterministic fake-agent integration tests (`crates/orbit-core/tests/copilot_fake_agent.rs`)
driving the real CLI runner against a scripted agent: command construction, permission
configuration, explicit model propagation, agent edits persisting, prompt-secret absent from
argv and output, non-zero exit, exit-0-without-completion, malformed stdout, wall-clock
timeout. Plus 11 sandbox-gating tests (macOS SBPL + Linux bwrap roots).

## Deviations from the plan, and why

- **No worktree-pair declaration in the integration tests.** Declaring `workspace_path` +
  `repo_root` requires the registered primary root to itself be an exact Git checkout root,
  which `OrbitRuntime::in_memory()` does not provide. Worktree pairing has its own coverage
  and is not what this task changes, so the fake agent writes to absolute paths instead. The
  test is named for what it actually asserts.
- **`provider_contract.json` left untouched.** Adding the variant tripped
  `Provider::ALL.len() == known_providers.len()`. That fixture is a byte-for-byte vendored
  copy of the Constellation contract shared with Worker and Bridge, hash-pinned to force a
  reviewed upstream bump. Editing it locally would forge a contract Orbit does not own, so
  the assertion was made directional (contract ⊆ Orbit) with an explicit
  `ORBIT_ONLY_PROVIDERS` allowlist — an accidental variant still fails. **Follow-up owned
  elsewhere:** the upstream contract needs a `copilot` row before Worker/Bridge can resolve
  it. Friction filed.

## Not verified

No live Copilot run. This host's token lacks Copilot entitlement and the organization's
policy disables third-party MCP servers, so the success path is covered by fixtures derived
from the captured frame shape and the shipped bundle's own extraction rule, not by a real
authenticated session. The failure path *is* a verbatim real capture.

Also note: `orbit tool run` was unusable in this run (parent `.orbit` mounted read-only);
task state was persisted through the loopback HTTP API instead. Friction filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10946-6a890a3e`
- Behind base: 0
- Ahead of base: 1