### PR TITLE
Add Cursor Agent CLI as a first-class Orbit workflow executor

### DIFF
--- a/crates/orbit-agent/src/agent/agent.rs
+++ b/crates/orbit-agent/src/agent/agent.rs
@@ -17,6 +17,7 @@ pub enum ProviderOptions {
     Gemini,
     Grok,
     Copilot,
+    Cursor,
     Ollama,
     Mock,
 }

--- a/crates/orbit-agent/src/lib.rs
+++ b/crates/orbit-agent/src/lib.rs
@@ -10,8 +10,9 @@
 )]
 //! Agent provider abstraction for Orbit. Two transport families coexist:
 //!
-//! - **CLI transports** — drive `claude`, `codex`, `gemini`, `grok`, `ollama`, or
-//!   `mock` as subprocesses through [`AgentRuntime`]. Each runtime builds an
+//! - **CLI transports** — drive `claude`, `codex`, `gemini`, `grok`, `copilot`,
+//!   `cursor-agent`, `ollama`, or `mock` as subprocesses through
+//!   [`AgentRuntime`]. Each runtime builds an
 //!   [`AgentInvocationSpec`] (program, args, stdin envelope) that the engine
 //!   executes through `orbit-exec`; responses are parsed via
 //!   [`parse_and_validate_response`].

--- a/crates/orbit-agent/src/providers/cursor/cursor_cli.rs
+++ b/crates/orbit-agent/src/providers/cursor/cursor_cli.rs
@@ -1,0 +1,35 @@
+use crate::providers::common::render_prompt_with_embedded_envelope;
+
+/// Per-request command construction for Cursor Agent CLI.
+///
+/// The shipped executor owns the static headless flags; this transport adds
+/// only the model chosen by Orbit's crew resolution. [ORB-10945]
+pub(crate) struct CursorCliTransport {
+    model: Option<String>,
+}
+
+impl CursorCliTransport {
+    pub(crate) fn new(model: Option<String>) -> Self {
+        Self { model }
+    }
+
+    pub(crate) fn args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+        if let Some(model) = &self.model {
+            args.push("--model".to_string());
+            args.push(model.clone());
+        }
+        args
+    }
+
+    /// Cursor accepts a prompt from piped stdin in print mode. Keeping the
+    /// execution envelope off argv prevents task context from entering process
+    /// listings, audit argv, or spawn diagnostics.
+    pub(crate) fn stdin(&self, envelope_json: &[u8]) -> Vec<u8> {
+        render_prompt_with_embedded_envelope(envelope_json)
+    }
+
+    pub(crate) fn model_name(&self) -> Option<&str> {
+        self.model.as_deref()
+    }
+}

--- a/crates/orbit-agent/src/providers/cursor/cursor_output.rs
+++ b/crates/orbit-agent/src/providers/cursor/cursor_output.rs
@@ -1,0 +1,28 @@
+//! Cursor's `--print --output-format json` stdout adapter. [ORB-10945]
+//!
+//! A successful CLI invocation emits one JSON object with terminal evidence:
+//! `type=result`, `subtype=success`, `is_error=false`, and a model-authored
+//! `result` string. Failures exit non-zero and need not emit JSON. Orbit must
+//! validate the outer frame before searching the inner text for its response
+//! envelope; otherwise a malformed or partial provider response could be
+//! mistaken for successful completion.
+
+/// Return the model-authored response only when Cursor emitted its complete,
+/// documented success wrapper. Any malformed, failed, or partial shape
+/// normalizes to empty bytes and therefore cannot satisfy Orbit's completion
+/// contract.
+pub(crate) fn normalize_cursor_stdout(stdout: &[u8]) -> Vec<u8> {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(stdout) else {
+        return Vec::new();
+    };
+    let is_success = value.get("type").and_then(serde_json::Value::as_str) == Some("result")
+        && value.get("subtype").and_then(serde_json::Value::as_str) == Some("success")
+        && value.get("is_error").and_then(serde_json::Value::as_bool) == Some(false);
+    if !is_success {
+        return Vec::new();
+    }
+    value
+        .get("result")
+        .and_then(serde_json::Value::as_str)
+        .map_or_else(Vec::new, |result| result.as_bytes().to_vec())
+}

--- a/crates/orbit-agent/src/providers/cursor/cursor_runtime.rs
+++ b/crates/orbit-agent/src/providers/cursor/cursor_runtime.rs
@@ -1,0 +1,98 @@
+use std::collections::HashMap;
+
+use orbit_common::OrbitError;
+use orbit_types::telemetry::InvocationTrace;
+
+use crate::agent::{AgentConfig, ProviderOptions};
+use crate::providers::cursor::cursor_cli::CursorCliTransport;
+use crate::runtime::{AgentRuntime, AgentRuntimeFactory};
+use crate::types::{AgentInvocationSpec, AgentRequest};
+
+const RUNTIME_KEY: &str = "cursor-agent";
+
+/// Non-secret process context required by the local Cursor CLI.
+///
+/// `CURSOR_API_KEY` is intentionally absent. Credentials cross the cleared
+/// child environment only when an operator explicitly names them in
+/// `[execution.env].pass`; otherwise Cursor uses the login state under
+/// `$HOME/.cursor`. [ORB-10945]
+const REQUIRED_ENV_VARS: &[&str] = &["HOME", "PATH"];
+
+pub(crate) struct CursorRuntime {
+    command: String,
+    cli: CursorCliTransport,
+    runtime_key: &'static str,
+    required_env_vars: &'static [&'static str],
+}
+
+pub(crate) struct CursorFactory;
+
+impl CursorRuntime {
+    pub(crate) fn new(
+        command: String,
+        model: Option<String>,
+        runtime_key: &'static str,
+        required_env_vars: &'static [&'static str],
+    ) -> Self {
+        Self {
+            command,
+            cli: CursorCliTransport::new(model),
+            runtime_key,
+            required_env_vars,
+        }
+    }
+}
+
+impl AgentRuntimeFactory for CursorFactory {
+    fn key(&self) -> &'static str {
+        RUNTIME_KEY
+    }
+
+    fn required_env_vars(&self) -> &'static [&'static str] {
+        REQUIRED_ENV_VARS
+    }
+
+    fn options_from_config(
+        &self,
+        _config: &HashMap<String, String>,
+    ) -> Result<ProviderOptions, OrbitError> {
+        Ok(ProviderOptions::Cursor)
+    }
+
+    fn build(&self, cfg: &AgentConfig) -> Result<Box<dyn AgentRuntime>, OrbitError> {
+        match &cfg.provider_options {
+            ProviderOptions::Cursor => Ok(Box::new(CursorRuntime::new(
+                cfg.command.clone(),
+                cfg.model.clone(),
+                self.key(),
+                self.required_env_vars(),
+            ))),
+            _ => Err(OrbitError::InvalidInput(format!(
+                "provider options '{}' cannot build cursor runtime",
+                cfg.provider_key
+            ))),
+        }
+    }
+}
+
+impl AgentRuntime for CursorRuntime {
+    fn invoke(
+        &self,
+        req: AgentRequest,
+    ) -> Result<(AgentInvocationSpec, InvocationTrace), OrbitError> {
+        Ok((
+            crate::providers::build_invocation_spec(
+                self.runtime_key,
+                self.required_env_vars,
+                self.command.clone(),
+                self.cli.args(),
+                self.cli.stdin(&req.envelope_json),
+            ),
+            InvocationTrace::default(),
+        ))
+    }
+
+    fn model_name(&self) -> Option<&str> {
+        self.cli.model_name()
+    }
+}

--- a/crates/orbit-agent/src/providers/cursor/mod.rs
+++ b/crates/orbit-agent/src/providers/cursor/mod.rs
@@ -1,0 +1,9 @@
+mod cursor_cli;
+mod cursor_output;
+mod cursor_runtime;
+
+pub(crate) use cursor_output::normalize_cursor_stdout;
+pub(crate) use cursor_runtime::CursorFactory;
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-agent/src/providers/cursor/tests/cursor_cli.rs
+++ b/crates/orbit-agent/src/providers/cursor/tests/cursor_cli.rs
@@ -1,0 +1,64 @@
+#![allow(missing_docs)]
+
+use super::super::cursor_cli::CursorCliTransport;
+use super::super::cursor_runtime::CursorRuntime;
+use crate::runtime::AgentRuntime;
+use crate::types::{AgentOperation, AgentRequest};
+
+#[test]
+fn args_pass_explicit_model_with_long_flag() {
+    let transport = CursorCliTransport::new(Some("gpt-5".to_string()));
+
+    assert_eq!(transport.args(), vec!["--model", "gpt-5"]);
+}
+
+#[test]
+fn args_are_empty_without_a_model() {
+    assert!(CursorCliTransport::new(None).args().is_empty());
+}
+
+#[test]
+fn prompt_travels_on_stdin_and_never_through_argv() {
+    let envelope = br#"{"schemaVersion":1,"input":{"secret_path":"/srv/tenant-42"}}"#;
+    let transport = CursorCliTransport::new(Some("gpt-5".to_string()));
+
+    let stdin = String::from_utf8(transport.stdin(envelope)).expect("utf8 stdin");
+    assert!(stdin.contains("/srv/tenant-42"));
+    assert!(stdin.contains("Execution envelope:"));
+
+    let argv = transport.args().join(" ");
+    assert!(!argv.contains("/srv/tenant-42"));
+    assert!(!argv.contains("schemaVersion"));
+}
+
+#[test]
+fn model_name_reports_the_selected_model() {
+    assert_eq!(
+        CursorCliTransport::new(Some("gpt-5".to_string())).model_name(),
+        Some("gpt-5")
+    );
+    assert_eq!(CursorCliTransport::new(None).model_name(), None);
+}
+
+#[test]
+fn runtime_requires_state_context_but_never_implicitly_forwards_api_key() {
+    let runtime = CursorRuntime::new(
+        "cursor-agent".to_string(),
+        Some("gpt-5".to_string()),
+        "cursor-agent",
+        &["HOME", "PATH"],
+    );
+    let (invocation, _) = runtime
+        .invoke(AgentRequest {
+            operation: AgentOperation::Activity {
+                activity_id: "cursor-auth-env".to_string(),
+            },
+            envelope_json: br#"{"schemaVersion":1,"input":{}}"#.to_vec(),
+            verbose: false,
+        })
+        .expect("render invocation");
+
+    assert_eq!(invocation.required_env_vars, &["HOME", "PATH"]);
+    assert!(!invocation.required_env_vars.contains(&"CURSOR_API_KEY"));
+    assert!(!invocation.args.iter().any(|arg| arg == "--api-key"));
+}

--- a/crates/orbit-agent/src/providers/cursor/tests/cursor_output.rs
+++ b/crates/orbit-agent/src/providers/cursor/tests/cursor_output.rs
@@ -1,0 +1,115 @@
+#![allow(missing_docs)]
+
+use orbit_types::tool::ExecutionResult;
+
+use crate::providers::normalize_cli_stdout;
+use crate::types::{AgentResponseStatus, parse_and_validate_response};
+
+const ORBIT_SUCCESS: &str =
+    r#"{"schemaVersion":1,"status":"success","result":{"edited":true},"error":null}"#;
+
+/// Captured from Cursor Agent CLI 2026.08.11-e8db854 before authentication on
+/// a fresh host state. Like documented auth/API failures, the CLI exits 1,
+/// writes the error to stderr, and emits no JSON success object on stdout.
+const REAL_STATE_FAILURE_STDERR: &str =
+    "Error: ENOENT: no such file or directory, mkdir '/home/example/.cursor/projects/tmp'\n";
+
+fn cursor_result(result: serde_json::Value) -> String {
+    serde_json::json!({
+        "type": "result",
+        "subtype": "success",
+        "is_error": false,
+        "duration_ms": 1234,
+        "duration_api_ms": 987,
+        "result": result,
+        "session_id": "2fa6a0fb-7cf5-4f7e-9d41-e91f6f6b3333",
+        "request_id": "req-123",
+    })
+    .to_string()
+}
+
+fn exec_result(stdout: &str, stderr: &str, exit_code: i32) -> ExecutionResult {
+    ExecutionResult {
+        success: exit_code == 0,
+        stdout: String::from_utf8(normalize_cli_stdout("cursor", stdout.as_bytes()).into_owned())
+            .expect("utf8 normalized stdout"),
+        stderr: stderr.to_string(),
+        exit_code: Some(exit_code),
+        duration_ms: 1_200,
+        output: None,
+    }
+}
+
+#[test]
+fn documented_success_wrapper_yields_the_embedded_orbit_envelope() {
+    let stdout = cursor_result(serde_json::Value::String(ORBIT_SUCCESS.to_string()));
+
+    let (envelope, status, _) =
+        parse_and_validate_response(&exec_result(&stdout, "", 0)).expect("parse success envelope");
+
+    assert_eq!(status, AgentResponseStatus::Success);
+    assert_eq!(envelope.status, "success");
+}
+
+#[test]
+fn failure_wrapper_never_normalizes_to_success() {
+    let stdout = serde_json::json!({
+        "type": "result",
+        "subtype": "error",
+        "is_error": true,
+        "result": ORBIT_SUCCESS,
+    })
+    .to_string();
+
+    let normalized = normalize_cli_stdout("cursor", stdout.as_bytes());
+    assert!(normalized.is_empty());
+    if let Ok((_, status, _)) =
+        parse_and_validate_response(&exec_result(&stdout, "provider failed", 1))
+    {
+        assert_ne!(status, AgentResponseStatus::Success);
+    }
+}
+
+#[test]
+fn captured_real_nonzero_failure_has_no_completion_evidence() {
+    let execution = exec_result("", REAL_STATE_FAILURE_STDERR, 1);
+    assert!(execution.stdout.is_empty());
+    if let Ok((_, status, _)) = parse_and_validate_response(&execution) {
+        assert_ne!(status, AgentResponseStatus::Success);
+    }
+}
+
+#[test]
+fn missing_terminal_evidence_never_normalizes_to_success() {
+    for stdout in [
+        serde_json::json!({"type":"result","subtype":"success","result":ORBIT_SUCCESS}).to_string(),
+        serde_json::json!({"type":"assistant","result":ORBIT_SUCCESS}).to_string(),
+        serde_json::json!({"type":"result","subtype":"success","is_error":false}).to_string(),
+    ] {
+        assert!(normalize_cli_stdout("cursor", stdout.as_bytes()).is_empty());
+    }
+}
+
+#[test]
+fn malformed_output_yields_no_completion_evidence() {
+    for stdout in ["not json", "{\"type\":\"result\"", ""] {
+        assert!(normalize_cli_stdout("cursor", stdout.as_bytes()).is_empty());
+    }
+}
+
+#[test]
+fn non_string_result_is_rejected() {
+    let stdout = cursor_result(serde_json::json!({"schemaVersion":1,"status":"success"}));
+    assert!(normalize_cli_stdout("cursor", stdout.as_bytes()).is_empty());
+}
+
+#[test]
+fn other_providers_are_returned_borrowed_and_unchanged() {
+    let stdout = br#"{"schemaVersion":1,"status":"success","result":{},"error":null}"#;
+
+    for provider in ["claude", "codex", "gemini", "grok", "ollama"] {
+        let out = normalize_cli_stdout(provider, stdout);
+        assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
+        assert_eq!(out.as_ref(), stdout);
+    }
+}

--- a/crates/orbit-agent/src/providers/cursor/tests/mod.rs
+++ b/crates/orbit-agent/src/providers/cursor/tests/mod.rs
@@ -1,0 +1,2 @@
+mod cursor_cli;
+mod cursor_output;

--- a/crates/orbit-agent/src/providers/mod.rs
+++ b/crates/orbit-agent/src/providers/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! Two families live here:
 //!
-//! - **CLI transports** (`claude`, `codex`, `copilot`, `gemini`, `grok`, `ollama`,
-//!   `mock_agent`):
+//! - **CLI transports** (`claude`, `codex`, `copilot`, `cursor-agent`, `gemini`,
+//!   `grok`, `ollama`, `mock_agent`):
 //!   translate an [`AgentRequest`] into a CLI command invocation and stdin
 //!   envelope that the engine runs via `orbit-exec`.
 //! - **HTTP transports** (`anthropic`, `openai_compat`, `gemini_http`): implement the sibling
@@ -19,6 +19,7 @@ pub(crate) mod claude;
 pub(crate) mod codex;
 mod common;
 pub(crate) mod copilot;
+pub(crate) mod cursor;
 pub(crate) mod gemini;
 pub mod gemini_http;
 pub(crate) mod grok;
@@ -57,7 +58,9 @@ pub(crate) fn build_invocation_spec(
 /// Orbit's own prompt back as a `user.message` frame, so its stream is
 /// reduced to model-authored frames first — see the `copilot::copilot_stream`
 /// module docs for why that reduction is a correctness requirement rather
-/// than tidying. [ORB-10946]
+/// than tidying. `cursor` wraps the assistant response in a terminal JSON
+/// result object; its adapter validates that wrapper and exposes only the
+/// model-authored `result` string. [ORB-10946] [ORB-10945]
 ///
 /// `provider` is the resolved canonical provider id. An unrecognized id is
 /// not an error here: normalization is a per-provider accommodation, and the
@@ -65,6 +68,7 @@ pub(crate) fn build_invocation_spec(
 pub fn normalize_cli_stdout<'a>(provider: &str, stdout: &'a [u8]) -> Cow<'a, [u8]> {
     match provider {
         "copilot" => Cow::Owned(copilot::normalize_copilot_stdout(stdout)),
+        "cursor" => Cow::Owned(cursor::normalize_cursor_stdout(stdout)),
         _ => Cow::Borrowed(stdout),
     }
 }

--- a/crates/orbit-agent/src/runtime/backend.rs
+++ b/crates/orbit-agent/src/runtime/backend.rs
@@ -56,6 +56,7 @@ impl Default for ProviderRegistry {
         let _ = registry.register(Arc::new(crate::providers::gemini::GeminiFactory));
         let _ = registry.register(Arc::new(crate::providers::grok::GrokFactory));
         let _ = registry.register(Arc::new(crate::providers::copilot::CopilotFactory));
+        let _ = registry.register(Arc::new(crate::providers::cursor::CursorFactory));
         let _ = registry.register(Arc::new(crate::providers::ollama::OllamaFactory));
         registry
     }

--- a/crates/orbit-cli/src/command/init/agent_detect.rs
+++ b/crates/orbit-cli/src/command/init/agent_detect.rs
@@ -80,6 +80,10 @@ pub struct DetectedAgents {
     /// command *suggester*, not an agent, and Orbit never dispatches to it.
     /// [ORB-10946]
     pub copilot_cli: bool,
+    /// Cursor's supported local headless agent binary. The Cursor editor/plugin
+    /// control surface is separate and is not evidence that this executable is
+    /// installed. [ORB-10945]
+    pub cursor_cli: bool,
     pub ollama_cli: bool,
 }
 
@@ -92,6 +96,7 @@ pub fn detect(probe: &dyn AgentEnvProbe) -> DetectedAgents {
         gemini_cli: probe.binary_on_path("gemini"),
         grok_cli: probe.binary_on_path("grok"),
         copilot_cli: probe.binary_on_path("copilot"),
+        cursor_cli: probe.binary_on_path("cursor-agent"),
         ollama_cli: probe.binary_on_path("ollama"),
     }
 }
@@ -118,6 +123,9 @@ pub fn available_crew_families(detected: &DetectedAgents) -> Vec<&'static str> {
     if detected.copilot_cli {
         families.push("copilot");
     }
+    if detected.cursor_cli {
+        families.push("cursor");
+    }
     families
 }
 
@@ -134,9 +142,9 @@ pub fn default_model_for(provider: &str) -> Option<&'static str> {
 /// Pick a default provider for the role given a detection snapshot.
 ///
 /// Preference order: first detected CLI in [claude, codex, gemini, grok,
-/// copilot, ollama], else `claude` as a last resort. `copilot` sits after the
-/// four original families so installing it never changes an existing host's
-/// default provider. [ORB-10946]
+/// copilot, cursor, ollama], else `claude` as a last resort. New families are
+/// appended after the original four so installing them never changes an
+/// existing host's default provider. [ORB-10946] [ORB-10945]
 pub fn default_provider(detected: &DetectedAgents) -> &'static str {
     if detected.claude_cli {
         return "claude";
@@ -152,6 +160,9 @@ pub fn default_provider(detected: &DetectedAgents) -> &'static str {
     }
     if detected.copilot_cli {
         return "copilot";
+    }
+    if detected.cursor_cli {
+        return "cursor";
     }
     if detected.ollama_cli {
         return "ollama";

--- a/crates/orbit-cli/src/command/init/agent_prompt.rs
+++ b/crates/orbit-cli/src/command/init/agent_prompt.rs
@@ -115,11 +115,11 @@ pub(crate) fn collect_system_crew_setting(
 
 /// Cheap-tier system options in the same preference order as
 /// `orbit-config::default_system_crew`: Codex Luna, Claude Sonnet, Grok,
-/// Gemini Flash, Copilot Haiku.
+/// Gemini Flash, Copilot Haiku, Cursor.
 fn system_crew_options(detected: &DetectedAgents) -> Vec<CrewSeed> {
     use orbit_common::model_defaults::{
-        CLAUDE_DEFAULT_WEAK, CODEX_LUNA_MODEL, COPILOT_CREW_MODEL, GEMINI_CREW_MODEL,
-        GROK_DEFAULT_MODEL,
+        CLAUDE_DEFAULT_WEAK, CODEX_LUNA_MODEL, COPILOT_CREW_MODEL, CURSOR_CREW_MODEL,
+        GEMINI_CREW_MODEL, GROK_DEFAULT_MODEL,
     };
     let mut options = Vec::new();
     for (enabled, provider, model) in [
@@ -128,6 +128,7 @@ fn system_crew_options(detected: &DetectedAgents) -> Vec<CrewSeed> {
         (detected.grok_cli, "grok", GROK_DEFAULT_MODEL),
         (detected.gemini_cli, "gemini", GEMINI_CREW_MODEL),
         (detected.copilot_cli, "copilot", COPILOT_CREW_MODEL),
+        (detected.cursor_cli, "cursor", CURSOR_CREW_MODEL),
     ] {
         if enabled {
             options.push(CrewSeed {
@@ -162,6 +163,7 @@ fn system_crew_label(option: &CrewSeed) -> &'static str {
         Some("grok") => "Grok",
         Some("gemini") => "Gemini",
         Some("copilot") => "Copilot",
+        Some("cursor") => "Cursor",
         _ => "Agent",
     }
 }
@@ -238,6 +240,7 @@ fn agent_options(detected: &DetectedAgents) -> Vec<AgentOption> {
         (detected.gemini_cli, "Gemini CLI", "gemini"),
         (detected.grok_cli, "Grok CLI", "grok"),
         (detected.copilot_cli, "Copilot CLI", "copilot"),
+        (detected.cursor_cli, "Cursor Agent CLI", "cursor"),
         (detected.ollama_cli, "Ollama CLI", "ollama"),
     ] {
         if enabled {
@@ -281,6 +284,7 @@ fn detection_lines(detected: &DetectedAgents) -> String {
         ("Codex CLI", detected.codex_cli),
         ("Gemini CLI", detected.gemini_cli),
         ("Grok CLI", detected.grok_cli),
+        ("Cursor Agent CLI", detected.cursor_cli),
         ("Ollama CLI", detected.ollama_cli),
     ]
     .into_iter()
@@ -316,6 +320,7 @@ fn agent_display_name(config: &CrewSeed) -> String {
         "gemini" => "Gemini CLI".to_string(),
         "grok" => "Grok CLI".to_string(),
         "copilot" => "Copilot CLI".to_string(),
+        "cursor" => "Cursor Agent CLI".to_string(),
         "ollama" => "Ollama CLI".to_string(),
         provider => format!("{provider} (CLI)"),
     }

--- a/crates/orbit-cli/src/command/init/tests/agent_detect.rs
+++ b/crates/orbit-cli/src/command/init/tests/agent_detect.rs
@@ -44,6 +44,7 @@ fn seeded_crew_availability_requires_a_detected_cli() {
         ("gemini", "gemini"),
         ("grok", "grok"),
         ("copilot", "copilot"),
+        ("cursor-agent", "cursor"),
     ] {
         let detected = detect(&MockAgentEnvProbe::new().with_binary(binary));
         assert_eq!(available_crew_families(&detected), vec![family]);
@@ -59,6 +60,7 @@ fn default_provider_prefers_cli_in_documented_order() {
         gemini_cli: true,
         grok_cli: true,
         copilot_cli: true,
+        cursor_cli: true,
         ollama_cli: true,
     };
     assert_eq!(default_provider(&detected), "claude");
@@ -100,6 +102,14 @@ fn default_provider_prefers_cli_in_documented_order() {
     };
     assert_eq!(default_provider(&detected), "copilot");
 
+    // cursor wins over ollama when the earlier agent families are absent.
+    let detected = DetectedAgents {
+        cursor_cli: true,
+        ollama_cli: true,
+        ..DetectedAgents::default()
+    };
+    assert_eq!(default_provider(&detected), "cursor");
+
     // ollama wins when nothing else
     let detected = DetectedAgents {
         ollama_cli: true,
@@ -116,14 +126,15 @@ fn default_provider_last_resort_is_claude() {
 #[test]
 fn model_registry_returns_expected_defaults() {
     use orbit_common::model_defaults::{
-        CLAUDE_DEFAULT_STRONG, CODEX_DEFAULT_MODEL, COPILOT_DEFAULT_MODEL, GEMINI_DEFAULT_MODEL,
-        GROK_DEFAULT_MODEL,
+        CLAUDE_DEFAULT_STRONG, CODEX_DEFAULT_MODEL, COPILOT_DEFAULT_MODEL, CURSOR_DEFAULT_MODEL,
+        GEMINI_DEFAULT_MODEL, GROK_DEFAULT_MODEL,
     };
     assert_eq!(default_model_for("claude"), Some(CLAUDE_DEFAULT_STRONG));
     assert_eq!(default_model_for("codex"), Some(CODEX_DEFAULT_MODEL));
     assert_eq!(default_model_for("gemini"), Some(GEMINI_DEFAULT_MODEL));
     assert_eq!(default_model_for("grok"), Some(GROK_DEFAULT_MODEL));
     assert_eq!(default_model_for("copilot"), Some(COPILOT_DEFAULT_MODEL));
+    assert_eq!(default_model_for("cursor"), Some(CURSOR_DEFAULT_MODEL));
     assert_eq!(default_model_for("ollama"), None);
     assert_eq!(default_model_for("unknown"), None);
 }

--- a/crates/orbit-common/src/model_defaults.rs
+++ b/crates/orbit-common/src/model_defaults.rs
@@ -84,6 +84,18 @@ pub const COPILOT_DEFAULT_MODEL: &str = "claude-sonnet-4.5";
 /// Cheap-tier Copilot model used for the bounded system crew.
 pub const COPILOT_CREW_MODEL: &str = "claude-haiku-4.5";
 
+/// Default model for the Cursor execution lane.
+///
+/// Cursor routes to multiple model vendors, but the persisted provider remains
+/// `cursor`. Orbit passes this documented current CLI model id explicitly so a
+/// run never depends on an interactive session's ambient model selection.
+/// [ORB-10945]
+pub const CURSOR_DEFAULT_MODEL: &str = "gpt-5";
+
+/// Model used for Cursor's bounded system crew. Cursor does not publish a
+/// stable cheap-tier alias, so the known-good default is reused.
+pub const CURSOR_CREW_MODEL: &str = CURSOR_DEFAULT_MODEL;
+
 /// Cheap Claude model used by the orbit-agent HTTP examples.
 ///
 /// Version pinned like [`ANTHROPIC_HTTP_DEFAULT_MODEL`] because the examples
@@ -94,7 +106,7 @@ pub const ANTHROPIC_EXAMPLE_MODEL: &str = "claude-haiku-4-5-20251001";
 ///
 /// Mirrors the historical `agent_detect::default_model_for` map; `claude` now
 /// resolves to the unversioned [`CLAUDE_DEFAULT_STRONG`] alias. codex/gemini/
-/// grok/copilot use their provider-specific defaults.
+/// grok/copilot/cursor use their provider-specific defaults.
 pub fn default_model_for_provider(provider: &str) -> Option<&'static str> {
     match provider {
         "claude" => Some(CLAUDE_DEFAULT_STRONG),
@@ -102,6 +114,7 @@ pub fn default_model_for_provider(provider: &str) -> Option<&'static str> {
         "gemini" => Some(GEMINI_DEFAULT_MODEL),
         "grok" => Some(GROK_DEFAULT_MODEL),
         "copilot" => Some(COPILOT_DEFAULT_MODEL),
+        "cursor" => Some(CURSOR_DEFAULT_MODEL),
         _ => None,
     }
 }

--- a/crates/orbit-config/src/resolved.rs
+++ b/crates/orbit-config/src/resolved.rs
@@ -15,8 +15,8 @@ use std::path::Path;
 use orbit_common::OrbitError;
 use orbit_common::model_defaults::{
     CLAUDE_DEFAULT_STRONG, CLAUDE_DEFAULT_WEAK, CLAUDE_FABLE_MODEL, CODEX_LUNA_MODEL,
-    CODEX_SOL_MODEL, CODEX_TERRA_MODEL, COPILOT_DEFAULT_MODEL, GEMINI_CREW_MODEL,
-    GROK_DEFAULT_MODEL,
+    CODEX_SOL_MODEL, CODEX_TERRA_MODEL, COPILOT_DEFAULT_MODEL, CURSOR_DEFAULT_MODEL,
+    GEMINI_CREW_MODEL, GROK_DEFAULT_MODEL,
 };
 use orbit_common::security::child_env::{allowlisted_child_env, inherited_child_env};
 use orbit_common::security::redaction::redact_home_dir;
@@ -210,6 +210,7 @@ pub(crate) fn default_crews() -> BTreeMap<String, Crew> {
         ("gemini", GEMINI_CREW_MODEL, "gemini"),
         ("grok", GROK_DEFAULT_MODEL, "grok"),
         ("copilot", COPILOT_DEFAULT_MODEL, "copilot"),
+        ("cursor", CURSOR_DEFAULT_MODEL, "cursor"),
         // [ORB-10877] Shipped job steps name `system` directly, so the
         // built-in set used by a config with no `[crews]` table must define it
         // or those pipelines fail validation. `orbit init` overwrites this with

--- a/crates/orbit-config/src/seed.rs
+++ b/crates/orbit-config/src/seed.rs
@@ -20,10 +20,9 @@ pub(crate) const DEFAULT_CONFIG_TEMPLATE: &str = include_str!("../assets/default
 
 /// Crew families Orbit ships crews for, in the order a seeded config prefers
 /// them. `ollama` is deliberately absent: Orbit ships no `ollama` crew.
-/// [ORB-10946] `copilot` is appended last so adding it cannot move the
-/// default crew on any host that already had one of the four families
-/// installed.
-const CREW_FAMILY_PREFERENCE: &[&str] = &["claude", "codex", "gemini", "grok", "copilot"];
+/// Copilot and Cursor are appended after the original four families so adding
+/// either cannot move an existing host's default crew. [ORB-10946] [ORB-10945]
+const CREW_FAMILY_PREFERENCE: &[&str] = &["claude", "codex", "gemini", "grok", "copilot", "cursor"];
 
 /// Explicit, host-independent inputs for rendering a fresh `config.toml`.
 ///
@@ -158,6 +157,7 @@ fn default_crew_name(seed: &ConfigSeed) -> Option<&'static str> {
             "gemini" => "gemini",
             "grok" => "grok",
             "copilot" => "copilot",
+            "cursor" => "cursor",
             _ => unreachable!("available crew families are fixed"),
         })
 }
@@ -264,8 +264,8 @@ fn default_qa_crew(seed: &ConfigSeed) -> Option<CrewSeed> {
 /// special-case a family.
 fn default_system_crew(seed: &ConfigSeed) -> Option<CrewSeed> {
     use orbit_common::model_defaults::{
-        CLAUDE_DEFAULT_WEAK, CODEX_LUNA_MODEL, COPILOT_CREW_MODEL, GEMINI_CREW_MODEL,
-        GROK_DEFAULT_MODEL,
+        CLAUDE_DEFAULT_WEAK, CODEX_LUNA_MODEL, COPILOT_CREW_MODEL, CURSOR_CREW_MODEL,
+        GEMINI_CREW_MODEL, GROK_DEFAULT_MODEL,
     };
     let (provider, model) = if seed.has_family("codex") {
         ("codex", CODEX_LUNA_MODEL)
@@ -277,6 +277,8 @@ fn default_system_crew(seed: &ConfigSeed) -> Option<CrewSeed> {
         ("gemini", GEMINI_CREW_MODEL)
     } else if seed.has_family("copilot") {
         ("copilot", COPILOT_CREW_MODEL)
+    } else if seed.has_family("cursor") {
+        ("cursor", CURSOR_CREW_MODEL)
     } else {
         return None;
     };

--- a/crates/orbit-config/src/tests/resolved.rs
+++ b/crates/orbit-config/src/tests/resolved.rs
@@ -30,15 +30,14 @@ fn built_in_crews_use_standard_model_specific_names() {
     // lane. [ORB-10877] It is built in because shipped job steps name it
     // directly, so a config with no `[crews]` table must still resolve it.
     //
-    // `copilot` is the second exception: it names the *provider* lane, because
-    // Copilot's model is supplied by another vendor and naming the crew after
-    // that model would hide which execution lane the run actually uses.
-    // [ORB-10946]
+    // `copilot` and `cursor` are provider-lane exceptions: each can route to
+    // models supplied by several vendors, so the crew names retain the
+    // execution provider identity. [ORB-10946] [ORB-10945]
     assert_eq!(
         crews.keys().map(String::as_str).collect::<Vec<_>>(),
         vec![
-            "copilot", "fable", "gemini", "grok", "luna", "opus", "sol", "sonnet", "system",
-            "terra"
+            "copilot", "cursor", "fable", "gemini", "grok", "luna", "opus", "sol", "sonnet",
+            "system", "terra"
         ]
     );
     for (name, provider, model) in [
@@ -51,6 +50,7 @@ fn built_in_crews_use_standard_model_specific_names() {
         ("gemini", "gemini", "gemini-3.7-flash"),
         ("grok", "grok", "grok-4.6"),
         ("copilot", "copilot", "claude-sonnet-4.5"),
+        ("cursor", "cursor", "gpt-5"),
         ("system", "claude", "sonnet"),
     ] {
         let assignment = &crews.get(name).expect("built-in crew").assignment;
@@ -63,6 +63,7 @@ fn built_in_crews_use_standard_model_specific_names() {
     // vendor supplying its model, nor to GitHub. [ORB-10946]
     assert!(!crews.contains_key("github"));
     assert!(!crews.contains_key("claude-sonnet-4.5"));
+    assert!(!crews.contains_key("anysphere"));
 
     let config = ResolvedConfig::built_in(PersistenceConfig::default_for_data_root(Path::new(
         ".orbit",

--- a/crates/orbit-config/src/tests/seed.rs
+++ b/crates/orbit-config/src/tests/seed.rs
@@ -109,6 +109,17 @@ fn grok_only_seeds_grok_and_a_system_crew() {
     assert_default_crew(&parsed, Some("grok"));
 }
 
+#[test]
+fn cursor_only_seeds_cursor_and_a_system_crew() {
+    let contents = seed_contents(&seed_for(&["cursor"]));
+    let parsed = parsed_config(&contents);
+
+    assert_eq!(crew_names(&parsed), vec!["cursor", "system"]);
+    assert_crew(&parsed, "cursor", "cursor", "gpt-5");
+    assert_crew(&parsed, "system", "cursor", "gpt-5");
+    assert_default_crew(&parsed, Some("cursor"));
+}
+
 /// Orbit ships no `ollama` crew, so a host whose only agent CLI is ollama
 /// seeds an explicitly empty registry rather than a dangling default.
 #[test]

--- a/crates/orbit-core/assets/executors/cursor.yaml
+++ b/crates/orbit-core/assets/executors/cursor.yaml
@@ -1,0 +1,25 @@
+schemaVersion: 2
+kind: Executor
+metadata:
+  name: cursor
+spec:
+  executor_type: direct_agent
+  command: cursor-agent
+  # Cursor accepts the prompt from piped stdin. Keeping it out of argv avoids
+  # exposing the Orbit execution envelope in process listings and audit argv.
+  args:
+    # Explicit headless mode. `--output-format` is valid only with print mode.
+    - --print
+    # Apply file edits and commands without an interactive approval prompt.
+    # Orbit's enclosing OS sandbox remains the filesystem/network boundary.
+    - --force
+    # One terminal JSON object whose `result` field carries the assistant text.
+    - --output-format
+    - json
+  stdout_format: envelope
+  sandbox: macos-sandbox-exec
+  model_pair_override:
+    strong: gpt-5
+    weak: gpt-5
+  model_flag: "--model"
+  env: {}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
@@ -328,6 +328,7 @@ fn append_linux_provider_state_roots(
     // `ensure_owned_directory` below, so an unconditional entry would mkdir a
     // `~/.copilot` on hosts that have never installed the CLI.
     directories.extend(linux_copilot_state_roots(provider, home.as_deref()));
+    directories.extend(linux_cursor_state_roots_with(provider, home.as_deref()));
     for directory in directories {
         ensure_owned_directory(&directory)?;
         let canonical = directory.canonicalize().map_err(|error| {
@@ -339,6 +340,20 @@ fn append_linux_provider_state_roots(
         append_unique_modify_root(resolved, canonical.display().to_string());
     }
     Ok(())
+}
+
+/// Writable state root for an active Cursor executor on Linux. The CLI stores
+/// logged-in authentication, settings, permissions, and sessions under
+/// `$HOME/.cursor`; no other provider receives this grant. [ORB-10945]
+#[cfg(target_os = "linux")]
+pub(super) fn linux_cursor_state_roots_with(provider: &str, home: Option<&Path>) -> Vec<PathBuf> {
+    if orbit_types::workflow::Provider::parse(provider).ok()
+        != Some(orbit_types::workflow::Provider::Cursor)
+    {
+        return Vec::new();
+    }
+    home.map(|home| vec![home.join(".cursor")])
+        .unwrap_or_default()
 }
 
 /// Process-env wrapper around [`linux_copilot_state_roots_with`].

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
@@ -698,7 +698,15 @@ mod copilot_state_roots {
 
     #[test]
     fn other_providers_get_nothing() {
-        for provider in ["claude", "codex", "gemini", "grok", "ollama", "local-shell"] {
+        for provider in [
+            "claude",
+            "codex",
+            "gemini",
+            "grok",
+            "cursor",
+            "ollama",
+            "local-shell",
+        ] {
             assert!(
                 linux_copilot_state_roots_with(provider, Some(Path::new("/home/test")), None, None)
                     .is_empty(),
@@ -718,5 +726,39 @@ mod copilot_state_roots {
             )
             .is_empty()
         );
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod cursor_state_roots {
+    use std::path::{Path, PathBuf};
+
+    use crate::adapter::engine_host::v2_host::sandbox::linux_cursor_state_roots_with;
+
+    #[test]
+    fn active_cursor_gets_only_its_home_state_root() {
+        assert_eq!(
+            linux_cursor_state_roots_with("cursor", Some(Path::new("/home/test"))),
+            vec![PathBuf::from("/home/test/.cursor")]
+        );
+        assert!(linux_cursor_state_roots_with("cursor", None).is_empty());
+    }
+
+    #[test]
+    fn other_and_unknown_providers_get_nothing() {
+        for provider in [
+            "claude",
+            "codex",
+            "gemini",
+            "grok",
+            "copilot",
+            "ollama",
+            "not-a-provider",
+        ] {
+            assert!(
+                linux_cursor_state_roots_with(provider, Some(Path::new("/home/test"))).is_empty(),
+                "{provider} must not inherit Cursor state roots",
+            );
+        }
     }
 }

--- a/crates/orbit-core/src/application/executor.rs
+++ b/crates/orbit-core/src/application/executor.rs
@@ -12,6 +12,7 @@ pub(crate) const DEFAULT_EXECUTOR_FILES: &[(&str, &str)] = &[
         "copilot",
         include_str!("../../assets/executors/copilot.yaml"),
     ),
+    ("cursor", include_str!("../../assets/executors/cursor.yaml")),
     (
         "local-shell",
         include_str!("../../assets/executors/local-shell.yaml"),

--- a/crates/orbit-core/src/application/tests/executor.rs
+++ b/crates/orbit-core/src/application/tests/executor.rs
@@ -16,7 +16,7 @@ const LINUX: &str = "linux";
 
 /// Shipped executors that opt into Orbit's sandbox wrapper. `local-shell` is
 /// deliberately excluded — it stays unsandboxed on every platform.
-const SANDBOXED_SHIPPED: &[&str] = &["claude", "codex", "gemini", "grok"];
+const SANDBOXED_SHIPPED: &[&str] = &["claude", "codex", "gemini", "grok", "copilot", "cursor"];
 
 fn base_def(name: &str, executor_type: ExecutorType) -> ExecutorDef {
     let now = Utc::now();

--- a/crates/orbit-core/tests/cursor_fake_agent.rs
+++ b/crates/orbit-core/tests/cursor_fake_agent.rs
@@ -1,0 +1,274 @@
+#![allow(missing_docs)]
+#![allow(clippy::expect_used)]
+// [ORB-10945] Deterministic end-to-end coverage for the Cursor executor. The
+// fake binary exercises Orbit's real runtime, runner, envelope adapter, and
+// shipped executor asset without network access or credentials.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use orbit_core::OrbitRuntime;
+use orbit_engine::{DispatchOutcome, V2AuditWriter, V2DispatchInput, dispatch_v2_activity};
+use orbit_types::resource::{EXECUTOR_RESOURCE_SCHEMA_VERSION, ExecutorResource};
+use orbit_types::workflow::ExecutorDef;
+use orbit_types::workflow::activity_job::{ActivityV2Spec, AgentLoopSpec, OnDenial, Provider};
+
+const PROMPT_SECRET: &str = "cursor-tenant-42-authorization-bearer-zzz";
+const SUCCESS_ENVELOPE: &str =
+    r#"{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"edited\":true},\"error\":null}"#;
+
+fn fake_cursor_agent(dir: &Path, body: &str, argv_path: &Path, stdin_path: &Path) -> PathBuf {
+    let program = dir.join("cursor-agent");
+    let script = format!(
+        r#"#!/bin/sh
+: > '{argv}'
+for arg in "$@"; do printf '%s\n' "$arg" >> '{argv}'; done
+cat > '{stdin}'
+{body}
+"#,
+        argv = argv_path.display(),
+        stdin = stdin_path.display(),
+    );
+    std::fs::write(&program, script).expect("write fake cursor-agent");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&program, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake cursor-agent");
+    }
+    program
+}
+
+struct Harness {
+    _dir: tempfile::TempDir,
+    argv_path: PathBuf,
+    stdin_path: PathBuf,
+    edit_path: PathBuf,
+    runtime: OrbitRuntime,
+}
+
+impl Harness {
+    fn new(body: &str) -> Self {
+        let dir = tempfile::tempdir().expect("harness tempdir");
+        let argv_path = dir.path().join("argv.txt");
+        let stdin_path = dir.path().join("stdin.txt");
+        let edit_path = dir.path().join("workspace/edited.txt");
+        std::fs::create_dir_all(edit_path.parent().expect("workspace parent"))
+            .expect("create fake workspace");
+        let body = body.replace("{EDIT_PATH}", &edit_path.display().to_string());
+        let program = fake_cursor_agent(dir.path(), &body, &argv_path, &stdin_path);
+
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        seed_cursor_executor(&runtime, &program, false);
+        Self {
+            _dir: dir,
+            argv_path,
+            stdin_path,
+            edit_path,
+            runtime,
+        }
+    }
+
+    fn argv(&self) -> Vec<String> {
+        std::fs::read_to_string(&self.argv_path)
+            .expect("fake agent recorded argv")
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn stdin(&self) -> String {
+        std::fs::read_to_string(&self.stdin_path).expect("fake agent recorded stdin")
+    }
+}
+
+fn cursor_resource() -> ExecutorResource {
+    serde_yaml::from_str(include_str!("../assets/executors/cursor.yaml"))
+        .expect("parse embedded Cursor executor")
+}
+
+fn seed_cursor_executor(runtime: &OrbitRuntime, program: &Path, keep_sandbox: bool) {
+    let resource = cursor_resource();
+    assert_eq!(resource.schema_version, EXECUTOR_RESOURCE_SCHEMA_VERSION);
+    assert_eq!(resource.metadata.name, "cursor");
+    let mut def = ExecutorDef::from_resource_spec(
+        resource.metadata.name.clone(),
+        resource.spec.clone(),
+        resource.spec.created_at,
+        resource.spec.updated_at,
+    );
+    def.command = Some(program.to_string_lossy().into_owned());
+    if !keep_sandbox {
+        // Sandbox compilation has deterministic focused coverage. Keeping the
+        // wrapper here would make transport cases depend on host bwrap/SBPL.
+        def.sandbox = None;
+    }
+    runtime
+        .upsert_executor_def(&def)
+        .expect("seed Cursor executor");
+}
+
+fn spec(timeout_seconds: u64) -> AgentLoopSpec {
+    AgentLoopSpec {
+        instruction: "Return the requested Orbit response envelope.".to_string(),
+        tools: Vec::new(),
+        on_denial: OnDenial::Terminate,
+        model: Some("gpt-5".to_string()),
+        max_iterations: 1,
+        backend: None,
+        provider: Provider::Cursor,
+        wall_clock_timeout_seconds: timeout_seconds,
+        require_response_envelope: true,
+        require_completion_envelope: true,
+        proc_allowed_programs: None,
+    }
+}
+
+fn try_dispatch(harness: &Harness, spec: AgentLoopSpec) -> Result<DispatchOutcome, String> {
+    let audit_dir = tempfile::tempdir().expect("audit tempdir");
+    let audit = V2AuditWriter::with_disk_sinks(
+        audit_dir.path(),
+        Arc::new(orbit_store::Store::open_in_memory().expect("audit store")),
+        "ws_test",
+        "cursor-fake",
+        "cursor:gpt-5".to_string(),
+        None,
+    )
+    .expect("build audit writer");
+
+    dispatch_v2_activity(V2DispatchInput {
+        activity_name: "cursor_fake_agent",
+        spec: &ActivityV2Spec::AgentLoop(spec),
+        fs_profile: None,
+        input: serde_json::json!({
+            "prompt": format!("Edit the checkout. Credential: {PROMPT_SECRET}"),
+        }),
+        audit,
+        run_id: "cursor-fake",
+        host: Some(&harness.runtime),
+    })
+    .map_err(|error| error.to_string())
+}
+
+fn dispatch(harness: &Harness, spec: AgentLoopSpec) -> DispatchOutcome {
+    try_dispatch(harness, spec).expect("dispatch Cursor CLI backend")
+}
+
+fn success_body() -> String {
+    format!(
+        r#"printf '%s\n' '{{"type":"result","subtype":"success","is_error":false,"duration_ms":1234,"duration_api_ms":987,"result":"{SUCCESS_ENVELOPE}","session_id":"s1","request_id":"r1"}}'
+exit 0"#
+    )
+}
+
+#[test]
+fn command_construction_matches_the_shipped_headless_contract() {
+    let harness = Harness::new(&success_body());
+    let outcome = dispatch(&harness, spec(60));
+    assert!(outcome.success, "dispatch failed: {:?}", outcome.message);
+
+    let argv = harness.argv();
+    assert!(argv.windows(1).any(|args| args == ["--print"]));
+    assert!(argv.windows(1).any(|args| args == ["--force"]));
+    assert!(
+        argv.windows(2)
+            .any(|args| args == ["--output-format", "json"])
+    );
+    assert!(argv.windows(2).any(|args| args == ["--model", "gpt-5"]));
+    assert!(
+        !argv.iter().any(|arg| arg.contains(PROMPT_SECRET)),
+        "prompt must not enter argv",
+    );
+}
+
+#[test]
+fn prompt_is_delivered_on_stdin_and_model_identity_stays_cursor() {
+    let harness = Harness::new(&success_body());
+    let outcome = dispatch(&harness, spec(60));
+    assert!(outcome.success, "dispatch failed: {:?}", outcome.message);
+    assert!(harness.stdin().contains(PROMPT_SECRET));
+    assert!(harness.stdin().contains("Execution envelope:"));
+
+    let invocation = outcome.invocation.expect("invocation trace");
+    assert_eq!(invocation.provider, "cursor");
+    assert_eq!(invocation.model.as_deref(), Some("gpt-5"));
+    let rendered = serde_json::to_string(&outcome.output).expect("serialize output");
+    assert!(!rendered.contains(PROMPT_SECRET));
+}
+
+#[test]
+fn successful_run_persists_worktree_edit_and_projects_result() {
+    let body = format!(
+        "printf 'edited by cursor\\n' > '{{EDIT_PATH}}'\n{}",
+        success_body()
+    );
+    let harness = Harness::new(&body);
+    let outcome = dispatch(&harness, spec(60));
+
+    assert!(outcome.success, "dispatch failed: {:?}", outcome.message);
+    assert_eq!(outcome.output["edited"], serde_json::Value::Bool(true));
+    assert_eq!(
+        std::fs::read_to_string(&harness.edit_path).expect("agent edit persists"),
+        "edited by cursor\n"
+    );
+}
+
+#[test]
+fn non_zero_exit_fails_even_with_success_json() {
+    let body = success_body().replace("exit 0", "exit 9");
+    let outcome = dispatch(&Harness::new(&body), spec(60));
+    assert!(!outcome.success);
+}
+
+#[test]
+fn malformed_or_incomplete_output_never_succeeds() {
+    for body in [
+        "printf '%s\\n' 'not json'\nexit 0",
+        "printf '%s\\n' '{\"type\":\"result\",\"subtype\":\"success\"}'\nexit 0",
+        "printf '%s\\n' '{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":42}'\nexit 0",
+    ] {
+        let outcome = dispatch(&Harness::new(body), spec(60));
+        assert!(!outcome.success, "invalid Cursor output must fail: {body}");
+    }
+}
+
+#[test]
+fn wall_clock_timeout_cancels_the_agent_and_fails_the_step() {
+    let outcome = dispatch(&Harness::new("sleep 30\nexit 0"), spec(1));
+    assert!(!outcome.success);
+    let message = outcome.message.unwrap_or_default();
+    assert!(message.contains("timeout") || message.contains("wall-clock"));
+}
+
+#[test]
+fn shipped_executor_is_sandboxed_and_missing_binary_is_stable() {
+    let resource = cursor_resource();
+    assert!(
+        resource.spec.sandbox.is_some(),
+        "Cursor asset must opt into the OS sandbox"
+    );
+    assert_eq!(resource.spec.command.as_deref(), Some("cursor-agent"));
+
+    let dir = tempfile::tempdir().expect("missing-binary tempdir");
+    let argv = dir.path().join("argv.txt");
+    let stdin = dir.path().join("stdin.txt");
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    let missing = dir.path().join("missing/cursor-agent");
+    seed_cursor_executor(&runtime, &missing, false);
+    let harness = Harness {
+        _dir: dir,
+        argv_path: argv,
+        stdin_path: stdin,
+        edit_path: PathBuf::new(),
+        runtime,
+    };
+    let error = try_dispatch(&harness, spec(60)).expect_err("missing binary must fail");
+    assert!(
+        error.contains("cursor-agent"),
+        "stable diagnostic names binary: {error}"
+    );
+    assert!(
+        error.contains("failed to spawn"),
+        "stable diagnostic names spawn failure: {error}"
+    );
+}

--- a/crates/orbit-exec/src/macos_sandbox/compile.rs
+++ b/crates/orbit-exec/src/macos_sandbox/compile.rs
@@ -161,6 +161,17 @@ pub(super) fn compile_macos_sandbox_profile_with_env(
             ));
         }
     }
+    // Cursor's logged-in CLI state and permissions live in `$HOME/.cursor`.
+    // Grant the directory only to the active Cursor executor; API-key auth is
+    // an explicit environment opt-in and needs no additional path. [ORB-10945]
+    if Provider::parse(provider).ok() == Some(Provider::Cursor)
+        && let Some(state_dir) = super::provider_dirs::cursor_state_dir(home)
+    {
+        out.push_str(&format!(
+            "(allow file-write* (subpath \"{}\"))\n",
+            super::sbpl_filter::sbpl_escape(&state_dir.display().to_string())
+        ));
+    }
     super::provider_dirs::emit_claude_home_json_allows(home, claude_config_dir, &mut out);
     super::provider_dirs::emit_grok_state_file_allows(home, grok_home, &mut out);
 

--- a/crates/orbit-exec/src/macos_sandbox/provider_dirs.rs
+++ b/crates/orbit-exec/src/macos_sandbox/provider_dirs.rs
@@ -127,6 +127,14 @@ pub(crate) fn copilot_cache_dir(
         .or_else(|| non_empty_env_path(home).map(|path| path.join(".cache").join("copilot")))
 }
 
+/// Cursor CLI stores login credentials, CLI configuration, permissions, and
+/// session state under `$HOME/.cursor`. The caller gates this directory on an
+/// active Cursor executor so other providers do not receive Cursor-specific
+/// write access. [ORB-10945]
+pub(crate) fn cursor_state_dir(home: Option<&OsStr>) -> Option<PathBuf> {
+    non_empty_env_path(home).map(|path| path.join(".cursor"))
+}
+
 pub(super) fn non_empty_env_path(value: Option<&OsStr>) -> Option<PathBuf> {
     let value = value?;
     if value.to_string_lossy().is_empty() {

--- a/crates/orbit-exec/src/macos_sandbox/tests/provider_dirs.rs
+++ b/crates/orbit-exec/src/macos_sandbox/tests/provider_dirs.rs
@@ -636,7 +636,7 @@ fn compile_grants_copilot_dirs_only_to_an_active_copilot_executor() {
     );
 
     // No other provider inherits Copilot-specific write access.
-    for provider in ["claude", "codex", "gemini", "grok"] {
+    for provider in ["claude", "codex", "gemini", "grok", "cursor"] {
         let other = compile_with_env(
             &resolved,
             provider,
@@ -652,6 +652,47 @@ fn compile_grants_copilot_dirs_only_to_an_active_copilot_executor() {
         assert!(
             !other.contains("/Users/test/.cache/copilot"),
             "{provider} must not inherit the copilot extraction cache",
+        );
+    }
+}
+
+#[test]
+fn cursor_state_dir_defaults_under_home() {
+    assert_eq!(
+        cursor_state_dir(Some(OsStr::new("/Users/test"))),
+        Some(PathBuf::from("/Users/test/.cursor"))
+    );
+    assert_eq!(cursor_state_dir(None), None);
+}
+
+#[test]
+fn compile_grants_cursor_state_only_to_an_active_cursor_executor() {
+    let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
+    let cursor_profile = compile_with_env(
+        &resolved,
+        "cursor",
+        EnvOverrides {
+            home: Some("/Users/test"),
+            ..Default::default()
+        },
+    );
+    assert!(
+        cursor_profile.contains("(allow file-write* (subpath \"/Users/test/.cursor\"))"),
+        "active Cursor must be granted its state directory",
+    );
+
+    for provider in ["claude", "codex", "gemini", "grok", "copilot"] {
+        let other = compile_with_env(
+            &resolved,
+            provider,
+            EnvOverrides {
+                home: Some("/Users/test"),
+                ..Default::default()
+            },
+        );
+        assert!(
+            !other.contains("/Users/test/.cursor"),
+            "{provider} must not inherit Cursor state write access",
         );
     }
 }

--- a/crates/orbit-types/src/workflow/activity_job/activity_v2.rs
+++ b/crates/orbit-types/src/workflow/activity_job/activity_v2.rs
@@ -182,6 +182,7 @@ pub enum Provider {
     Ollama,
     #[serde(rename = "openai_compat", alias = "openai-compat")]
     OpenaiCompat,
+    Cursor,
 }
 
 /// One accepted non-canonical spelling for a [`Provider`]. Alias normalization
@@ -222,7 +223,7 @@ impl std::error::Error for ProviderParseError {}
 impl Provider {
     /// Every canonical provider, in declaration order. Adding a variant here is
     /// a compile-time forcing function for the match arms below.
-    pub const ALL: [Provider; 7] = [
+    pub const ALL: [Provider; 8] = [
         Provider::Claude,
         Provider::Codex,
         Provider::Gemini,
@@ -230,6 +231,7 @@ impl Provider {
         Provider::Copilot,
         Provider::Ollama,
         Provider::OpenaiCompat,
+        Provider::Cursor,
     ];
 
     /// Accepted non-canonical spellings, normalized by [`Provider::parse`] /
@@ -241,11 +243,9 @@ impl Provider {
     /// This table is **closed** — an unlisted string is `provider.unknown`,
     /// never guessed. New aliases require a contract bump.
     ///
-    /// [ORB-10946] `copilot` deliberately has **no** alias row. `github` is not
-    /// an accepted spelling for it, and the vendor that supplies a Copilot
-    /// session's underlying model (OpenAI, Anthropic, Google, …) must never
-    /// resolve to `copilot` — nor `copilot` to them. Copilot is its own
-    /// execution lane, and its identity is independent of the model it runs.
+    /// `copilot` and `cursor` deliberately have **no** alias rows. Neither the
+    /// platform name nor a selected underlying model vendor may resolve to a
+    /// different execution lane. [ORB-10946] [ORB-10945]
     pub const ALIASES: &'static [ProviderAlias] = &[
         ProviderAlias {
             alias: "anthropic",
@@ -281,7 +281,7 @@ impl Provider {
 
     /// Human-readable canonical id list used in diagnostics.
     pub const CANONICAL_LIST: &'static str =
-        "claude, codex, gemini, grok, copilot, ollama, openai_compat";
+        "claude, codex, gemini, grok, copilot, ollama, openai_compat, cursor";
 
     pub fn as_str(self) -> &'static str {
         match self {
@@ -292,6 +292,7 @@ impl Provider {
             Provider::Copilot => "copilot",
             Provider::Ollama => "ollama",
             Provider::OpenaiCompat => "openai_compat",
+            Provider::Cursor => "cursor",
         }
     }
 
@@ -351,8 +352,9 @@ impl Provider {
     }
 
     /// Whether the model-neutral Worker leaf executor can execute this
-    /// provider. Worker only wires the CLI agent families; `copilot`, `ollama`
-    /// and `openai_compat` are Orbit-canonical capabilities Worker does not run.
+    /// provider. Worker only wires the four shared CLI agent families;
+    /// `copilot`, `cursor`, `ollama`, and `openai_compat` are Orbit-canonical
+    /// capabilities Worker does not run.
     /// Preserving this distinction is an explicit ORB-10091 constraint — Orbit
     /// keeps the wider set even though Worker cannot execute all of it.
     ///

--- a/crates/orbit-types/src/workflow/activity_job/tests/activity_v2.rs
+++ b/crates/orbit-types/src/workflow/activity_job/tests/activity_v2.rs
@@ -80,11 +80,12 @@ fn provider_capability_predicates_match_contract() {
     // the only variants allowed to exist without a row are the ones named here.
     // An accidental new variant still fails this test.
     //
-    // [ORB-10946] `copilot` is such an identity. Adding it upstream is a
+    // Copilot and Cursor are such identities. Adding either upstream is a
     // cross-system change (Worker and Bridge resolve against the same rows);
-    // until that lands, Orbit can dispatch Copilot while Worker correctly
-    // refuses it — which is what `is_worker_executable() == false` encodes.
-    const ORBIT_ONLY_PROVIDERS: &[&str] = &["copilot"];
+    // until that lands, Orbit can dispatch them while Worker correctly refuses
+    // them — which is what `is_worker_executable() == false` encodes.
+    // [ORB-10946] [ORB-10945]
+    const ORBIT_ONLY_PROVIDERS: &[&str] = &["copilot", "cursor"];
 
     for name in &known {
         assert!(
@@ -121,8 +122,8 @@ fn provider_capability_predicates_match_contract() {
         );
     }
 
-    // The Orbit-only identities, asserted directly since no contract row
-    // covers them yet. [ORB-10946]
+    // Orbit-only identities are asserted directly since no shared contract row
+    // covers them yet. [ORB-10946] [ORB-10945]
     let copilot = Provider::parse("copilot").expect("copilot is canonical");
     assert_eq!(copilot.as_str(), "copilot");
     assert_eq!(copilot.to_string(), "copilot");
@@ -147,6 +148,28 @@ fn provider_capability_predicates_match_contract() {
         assert_ne!(
             resolved.provider, copilot,
             "vendor alias '{vendor_alias}' must not resolve to copilot",
+        );
+    }
+
+    let cursor = Provider::parse("cursor").expect("cursor is canonical");
+    assert_eq!(cursor.as_str(), "cursor");
+    assert_eq!(cursor.to_string(), "cursor");
+    assert!(cursor.has_cli_runtime(), "Orbit ships a Cursor CLI runtime");
+    assert!(
+        !cursor.is_worker_executable(),
+        "Worker has no Cursor lane, so it must refuse rather than fall back",
+    );
+    for spelling in ["cursor-agent", "cursor_cli", "anysphere"] {
+        assert!(
+            Provider::parse(spelling).is_err(),
+            "'{spelling}' must not alias the Cursor provider",
+        );
+    }
+    for vendor_alias in ["anthropic", "openai", "google", "xai"] {
+        let resolved = Provider::resolve_name(vendor_alias).expect("vendor alias resolves");
+        assert_ne!(
+            resolved.provider, cursor,
+            "vendor alias '{vendor_alias}' must not resolve to Cursor",
         );
     }
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -55,7 +55,7 @@ system_crew = "system"      # crew for recovery paths with no job step to name o
 - **`default_crew`** — name of the crew under `[crews.<name>]` used for any task whose own `crew` field is unset. Must match a defined crew or config load fails. See [Per-task crew override](#per-task-crew-override) for how individual tasks select a different crew.
 - **`system_crew`** — name of the crew for system activities that are synthesized at runtime and so have no job step to name a crew on, principally `step_failure_recovery`. Defaults to `system`. Shipped pipelines such as `task_pilot_pipeline` and `task_triage_pipeline` do **not** read this key: their steps name `crew: system` directly, so the definition states which crew does the work. Either way the crew is resolved at dispatch through an explicit crew input, so system work never inherits a failed task's crew or the workspace default. A missing or unusable crew leaves the original failed step failed and emits a diagnostic naming `workflow.system_crew` and the configured crew.
 
-  **The `system` crew.** Interactive `orbit init` (or `--force` on a fresh rewrite) asks which detected cheap-tier family should back `[crews.system]`: Codex Luna (`gpt-5.6-luna`), Claude Sonnet, Gemini Flash (`gemini-3.7-flash`), or Grok (`grok-4.6`). It does not offer Sol, Opus, Terra, or a free-form custom provider, and it never prompts for a QA crew. `workflow.system_crew` stays `system`; only the assignment behind that name is chosen. A host with exactly one of those families auto-accepts it; a host with none omits `[crews.system]` rather than inventing a provider. `--non-interactive` never prompts and still auto-seeds `[crews.system]` from the preference order: Codex Luna, then Claude Sonnet, then Grok, then Gemini Flash — a preference list, not a strict price sort: Flash undercuts Sonnet and Grok per token but sits last because observed runs have failed outright on quota. To change what runs system work after init, edit `[crews.system]`. Configs written before this crew existed have no such table, so the name is resolved first onto the crew `system_crew` names when that crew exists. For Orbit's default or legacy lane names (`system` and `qa`), a missing crew falls back to an existing `qa` crew and then to the already-validated workspace default; the latter keeps old Gemini- and Grok-only configs working even though they never seeded `qa`. Unknown custom names are not substituted. A host that points `system_crew` at a defined cheap crew therefore keeps running system work there rather than being silently relocated. An explicit `[crews.system]` always wins. `[crews.qa]` remains a loadable compatibility lane: existing configs that define it keep working, and new inits may still silently auto-seed it (Terra if Codex is present, otherwise Sonnet if Claude is present) so leftover `crew: qa` bindings do not fail. That seed is not operator-chosen.
+  **The `system` crew.** Interactive `orbit init` (or `--force` on a fresh rewrite) asks which detected bounded family should back `[crews.system]`: Codex Luna (`gpt-5.6-luna`), Claude Sonnet, Gemini Flash (`gemini-3.7-flash`), Grok (`grok-4.6`), Copilot Haiku, or Cursor (`gpt-5`; Cursor has no stable cheap-tier alias). It does not offer Sol, Opus, Terra, or a free-form custom provider, and it never prompts for a QA crew. `workflow.system_crew` stays `system`; only the assignment behind that name is chosen. A host with exactly one of those families auto-accepts it; a host with none omits `[crews.system]` rather than inventing a provider. `--non-interactive` never prompts and still auto-seeds `[crews.system]` from the preference order: Codex Luna, then Claude Sonnet, then Grok, then Gemini Flash, then Copilot, then Cursor. Appending the newer lanes preserves every existing family's selection. To change what runs system work after init, edit `[crews.system]`. Configs written before this crew existed have no such table, so the name is resolved first onto the crew `system_crew` names when that crew exists. For Orbit's default or legacy lane names (`system` and `qa`), a missing crew falls back to an existing `qa` crew and then to the already-validated workspace default; the latter keeps old Gemini- and Grok-only configs working even though they never seeded `qa`. Unknown custom names are not substituted. A host that points `system_crew` at a defined cheap crew therefore keeps running system work there rather than being silently relocated. An explicit `[crews.system]` always wins. `[crews.qa]` remains a loadable compatibility lane: existing configs that define it keep working, and new inits may still silently auto-seed it (Terra if Codex is present, otherwise Sonnet if Claude is present) so leftover `crew: qa` bindings do not fail. That seed is not operator-chosen.
 
 ---
 
@@ -66,7 +66,7 @@ A **crew** is one provider-model assignment. Activities do not carry a model-sel
 | Field | Purpose | Values |
 |---|---|---|
 | `model` | Model identifier passed to the provider CLI | Provider-specific (e.g. `opus`, `sonnet`, `gpt-5.6-sol`, `gemini-3.7-flash`, `grok-4.6`) |
-| `provider` | Agent family | `claude`, `codex`, `gemini`, `grok`, `copilot` (the CLI-executable families; see [Provider identity and resolution](#provider-identity-and-resolution) for the full canonical set) |
+| `provider` | Agent family | `claude`, `codex`, `gemini`, `grok`, `copilot`, `cursor` (the CLI-executable crew families; see [Provider identity and resolution](#provider-identity-and-resolution) for the full canonical set) |
 | `description` | Optional human-facing crew summary | Any non-empty string after trimming |
 | `tags` | Optional discovery labels | Array of strings; normalized, sorted, and deduplicated |
 
@@ -90,7 +90,7 @@ provider = "grok"
 
 The current Grok Build CLI lists `grok-4.6` as its default from `grok models`, so Orbit uses that live menu id. The older `grok-build` string is not retained as a default or alias.
 
-Fresh `orbit init` configuration advertises only detected provider CLIs. Claude seeds `opus`, `sonnet`, and `fable`; Codex seeds `sol`, `terra`, and `luna`; Gemini seeds `gemini`; Grok seeds `grok`; and Copilot seeds `copilot`. Copilot is last in every preference order, so installing the `copilot` CLI never changes the default crew, default provider, or system crew on a host that already has one of the other four families. Interactive init still asks for the default crew (`[crews.custom]`) and, separately, for the cheap-tier system crew written as `[crews.system]`; it does not ask for QA. `--non-interactive` auto-seeds `[crews.system]` from the preference order above whenever a supported family is detected. When Codex or Claude is available, the legacy `qa` crew is still silently auto-seeded on Terra or Sonnet respectively as a compatibility lane. If no supported provider CLI is detected, init leaves both the crew registry and `workflow.default_crew` unset instead of writing an unusable provider.
+Fresh `orbit init` configuration advertises only detected provider CLIs. Claude seeds `opus`, `sonnet`, and `fable`; Codex seeds `sol`, `terra`, and `luna`; Gemini seeds `gemini`; Grok seeds `grok`; Copilot seeds `copilot`; and an installed `cursor-agent` seeds `cursor`. Copilot and Cursor are appended after the original four families, so installing either never changes the default crew, default provider, or system crew on a host that already has an earlier family. Interactive init still asks for the default crew (`[crews.custom]`) and, separately, for the system crew written as `[crews.system]`; it does not ask for QA. `--non-interactive` auto-seeds `[crews.system]` from the preference order above whenever a supported family is detected. When Codex or Claude is available, the legacy `qa` crew is still silently auto-seeded on Terra or Sonnet respectively as a compatibility lane. If no supported provider CLI is detected, init leaves both the crew registry and `workflow.default_crew` unset instead of writing an unusable provider.
 
 You can define any number of crews. Set the workspace-wide fallback with `workflow.default_crew`; assign a specific crew to individual tasks via the [per-task crew override](#per-task-crew-override). Crews are validated at load time: each crew must have non-empty `model` and `provider`; `workflow.default_crew` must name a defined crew.
 
@@ -134,6 +134,7 @@ Every `provider` string Orbit reads — in `[crews.<name>]`, in an activity's in
 | `copilot` | — | yes | no | **no** |
 | `ollama` | — | **unsupported at the Orbit CLI entry point** | no | **no** |
 | `openai_compat` | `openai-compat` | **no** (HTTP-only) | no | **no** |
+| `cursor` | — | yes (`cursor-agent`) | no | **no** |
 
 - **Parsing is case- and whitespace-insensitive.** `Claude`, `  claude `, and `CLAUDE` all resolve to `claude`. `openai-compat` normalizes to `openai_compat`.
 - **Deprecated aliases resolve *and* warn.** The legacy vendor names normalize to their canonical id and log an `orbit.config.crew` deprecation warning (`{alias, canonical}`) — they never fail, but update the config:
@@ -145,12 +146,13 @@ Every `provider` string Orbit reads — in `[crews.<name>]`, in an activity's in
   | `google` | `gemini` |
   | `xai` | `grok` |
 
-  `copilot` has **no** alias. `github` is not an accepted spelling for it, and
-  the vendor that supplies a Copilot session's underlying model never resolves
-  to `copilot` (nor `copilot` to that vendor) — see
-  [GitHub Copilot CLI](#github-copilot-cli).
+  `copilot` and `cursor` have **no** aliases. `github`, `cursor-agent`, and
+  `anysphere` are not provider spellings, and the vendor that supplies a
+  session's underlying model never changes its execution-lane identity. See
+  [GitHub Copilot CLI](#github-copilot-cli) and
+  [Cursor Agent CLI](#cursor-agent-cli).
 
-- **Canonical ≠ Worker-executable.** Orbit's canonical set is deliberately wider than what the model-neutral Worker leaf executor can run: `copilot`, `ollama`, and `openai_compat` are first-class Orbit providers but Worker does not execute them. This distinction is preserved on purpose — do not narrow the canonical set to Worker's subset. For `copilot` this is a *stable diagnostic*, not a fallback: a Worker-routed step naming `copilot` is refused by identity rather than silently re-pointed at another family.
+- **Canonical ≠ Worker-executable.** Orbit's canonical set is deliberately wider than what the model-neutral Worker leaf executor can run: `copilot`, `cursor`, `ollama`, and `openai_compat` are first-class Orbit providers but Worker does not execute them. This distinction is preserved on purpose — do not narrow the canonical set to Worker's subset. For `copilot` and `cursor` this is a *stable diagnostic*, not a fallback: a Worker-routed step naming either lane is refused by identity rather than silently re-pointed at another family.
 - **Known ≠ executable at this entry point.** The shared contract recognizes `ollama`, but the Orbit CLI capability set is the canonical cross-repo four; explicitly selecting `ollama` fails as `provider.unsupported` rather than falling back.
 - **`openai_compat` has no CLI runtime.** Every crew dispatches through the CLI agent path, so selecting it fails structurally (see below) rather than falling back.
 
@@ -182,7 +184,7 @@ Explicit selections that are unsupported or unavailable **fail with a stable dia
 
 - `provider openai_compat is unsupported by the Orbit CLI entry point (HTTP-only)` — a CLI-executable dispatch selected an HTTP-only provider.
 - `provider ollama is unsupported by the Orbit CLI entry point` — a known provider is outside this entry point's capability set.
-- `unknown provider '<x>'; expected one of claude, codex, gemini, grok, copilot, ollama, openai_compat — no CLI runtime registered` — the provider string did not resolve to a canonical id.
+- `unknown provider '<x>'; expected one of claude, codex, gemini, grok, copilot, ollama, openai_compat, cursor — no CLI runtime registered` — the provider string did not resolve to a canonical id.
 
 An **unrecognized `[crews.<name>].provider` value** is the one non-fatal case: it is logged (`orbit.config.crew` warn) and that field falls back to the activity's inline `provider`, because a config typo should not coerce dispatch onto a wrong runtime — the inline value is the known-good identity, not a default guess.
 
@@ -304,6 +306,90 @@ Copilot's stdout is JSONL agent events (`--output-format json`). Orbit reads
 completion evidence only from model-authored frames; a run that emits no
 assistant message has not completed its contract, and Orbit fails the step
 rather than inferring success from the session control plane.
+
+---
+
+## Cursor Agent CLI
+
+Cursor's plugin integration and Cursor worker execution are separate surfaces.
+The plugin installed by ORB-10943 lets a user operate Orbit from Cursor through
+the Orbit skill and MCP server. It does **not** execute workflow work. The
+`cursor` provider described here launches the local `cursor-agent` binary as an
+Orbit-supervised worker; Cursor cloud agents and marketplace publication are
+not used.
+
+### Installation and detection
+
+Install and verify the supported local CLI using Cursor's documented command:
+
+```sh
+curl https://cursor.com/install -fsS | bash
+cursor-agent --version
+```
+
+Ensure the installed directory (normally `$HOME/.local/bin`) is on `PATH`
+before running `orbit init`. Fresh init detects `cursor-agent`, adds a
+`[crews.cursor]` assignment, and can choose it only after every previously
+supported family in the preference order. Selecting `cursor` when its binary
+is unavailable fails with a permanent diagnostic naming `cursor-agent`; Orbit
+never falls back to Codex or another model vendor.
+
+### Authentication and credential handling
+
+Cursor supports two local CLI authentication paths:
+
+1. Run `cursor-agent login` once and verify it with `cursor-agent status`. The
+   login state is stored under `$HOME/.cursor`.
+2. Generate a Cursor user API key and explicitly pass `CURSOR_API_KEY` to the
+   agent subprocess:
+
+   ```toml
+   [execution.env]
+   pass = ["CURSOR_API_KEY"]
+   ```
+
+Orbit deliberately does not add `CURSOR_API_KEY` to the provider's required
+environment and never places a key in argv. Credential values therefore do
+not enter task artifacts, audit argv, transcripts, or spawn errors; the
+operator must opt in through the same child-environment policy used by other
+secrets. Login itself is an unsandboxed setup action, not part of a workflow
+turn.
+
+### Model selection
+
+Every Cursor invocation receives `--model <id>` from its crew assignment. The
+shipped crew uses the model id shown by the current CLI help, `gpt-5`:
+
+```toml
+[crews.cursor]
+model = "gpt-5"
+provider = "cursor"
+```
+
+Use `cursor-agent models` (or `cursor-agent --list-models` on versions that
+advertise that flag) to inspect the ids available to the logged-in account.
+Choosing an Anthropic, OpenAI, Google, or Cursor model never changes the
+provider identity: the run remains a `cursor` run with Cursor authentication,
+state, audit attribution, and sandbox policy.
+
+### Headless execution, output, and sandbox
+
+The shipped direct-agent executor uses `--print --force --output-format json`.
+Print mode is non-interactive, `--force` lets the agent apply edits and commands
+without blocking for approval, and the enclosing Orbit macOS/Linux sandbox
+remains authoritative. The flag cannot grant a path the OS sandbox denied.
+
+The Orbit prompt travels on standard input, never as a positional argument.
+On success, Cursor emits one JSON object with `type: "result"`,
+`subtype: "success"`, `is_error: false`, and the assistant response in its
+`result` string. Orbit validates that terminal wrapper before reading the inner
+response envelope. A non-zero exit, malformed object, missing field, non-string
+result, or absent Orbit completion envelope fails closed.
+
+Only an active Cursor executor receives write access to `$HOME/.cursor` for
+login state, CLI settings, permissions, and sessions. Other providers do not
+inherit that write grant. The worktree and all other paths remain governed by
+the activity filesystem profile.
 
 ---
 

--- a/docs/design/agent-families/2_design.md
+++ b/docs/design/agent-families/2_design.md
@@ -28,11 +28,11 @@ Workspace config defines one concrete assignment under each `[crews.<name>]`: fl
 
 `crates/orbit-config/src/raw.rs` owns the TOML shape, and `crates/orbit-config/src/resolved.rs` materializes it into `Crew` values from `orbit-common`. Runtime loading rejects incomplete crews, retired `planner`/`implementer`/`reviewer` role sub-tables with guidance to write flat `model`, `provider`, and `backend` fields, and `[workflow].default_crew` values that do not name a defined crew.
 
-The built-in runtime registry uses model-specific standard crews: Claude provides `opus`, `sonnet`, and `fable`; Codex provides `sol`, `terra`, and `luna`; Gemini provides `gemini`; Grok provides `grok`; and Copilot provides `copilot`. Fresh `orbit init` config filters that registry by detected provider CLIs, always writes `backend = "cli"`, and chooses the first emitted standard crew as `[workflow].default_crew` (`opus`, `sol`, `gemini`, `grok`, or `copilot`).
+The built-in runtime registry uses model-specific standard crews: Claude provides `opus`, `sonnet`, and `fable`; Codex provides `sol`, `terra`, and `luna`; Gemini provides `gemini`; Grok provides `grok`; Copilot provides `copilot`; and Cursor provides `cursor`. Fresh `orbit init` config filters that registry by detected provider CLIs and chooses the first emitted standard crew as `[workflow].default_crew` (`opus`, `sol`, `gemini`, `grok`, `copilot`, or `cursor`).
 
 It adds `qa` on Terra when Codex is available, otherwise on Sonnet when Claude is available. With no supported provider CLI, initialization emits neither crews nor a dangling default.
 
-`copilot` is the one crew named for its *provider* rather than its model: Copilot's model is supplied by another vendor, so naming the crew after the model would hide which execution lane the run actually uses. It is last in every preference order, so adding it cannot move an existing host's defaults. See [CONFIG.md § GitHub Copilot CLI](../../CONFIG.md#github-copilot-cli) for installation, organization-policy prerequisites, authentication, and model selection. [ORB-10946]
+`copilot` and `cursor` are crews named for their *provider* rather than their model: both lanes can select models supplied by other vendors, so model-named crews would hide which execution lane actually runs. They are appended after the original four families (`copilot`, then `cursor`) so adding them cannot move an existing host's defaults. See [CONFIG.md § GitHub Copilot CLI](../../CONFIG.md#github-copilot-cli) and [§ Cursor Agent CLI](../../CONFIG.md#cursor-agent-cli) for installation, authentication, model selection, and runtime boundaries. [ORB-10946] [ORB-10945]
 
 ## 3. Task and Tool Surface
 
@@ -64,6 +64,7 @@ An activity-specific crew is carried in rendered input rather than persisted as 
 
 - ORB-00042: Onboard Grok (xAI) as a first-class supported agent family.
 - ORB-10946: Add the standalone GitHub Copilot CLI as a first-class workflow executor.
+- ORB-10945: Add Cursor Agent CLI as a first-class Orbit workflow executor.
 - ORB-00058: Introduce per-task crew override for agent model selection.
 - ORB-10315: Seed model-specific crews only for providers available during initialization.
 - ORB-10620: Reject retired crew role sub-tables during config load.


### PR DESCRIPTION
## Task

[ORB-10945](https://orbit-cli.com/tasks/ORB-10945) — Add Cursor Agent CLI as a first-class Orbit workflow executor

### Description

## Problem

ORB-10943 packages Orbit's skill and MCP server for use inside Cursor, but Orbit's execution plane still cannot select or launch Cursor as a worker. The canonical provider set, bundled executors, agent-runtime adapters, crew resolution, and provider-specific sandbox state omit Cursor even though Cursor ships a non-interactive `cursor-agent` CLI suitable for automated coding work.

## Why It Matters

A Cursor user can currently operate Orbit but cannot ask `orbit.workflow.ship` to execute a task with a Cursor agent. That makes the plugin a control-surface integration rather than complete Cursor onboarding and prevents Orbit from evaluating or routing work to an installed Cursor subscription.

## Constraints / Notes

- Add Cursor as its own canonical provider identity; do not alias it to Codex or attribute its work to the underlying model vendor.
- Use the supported local `cursor-agent` headless contract. Cursor cloud agents and marketplace publication are out of scope.
- Orbit's activity sandbox remains the security boundary. Provider approval flags must not broaden the enclosing filesystem or network policy.
- Verify the installed/current CLI help and capture representative success and failure fixtures before fixing argv or output assumptions.
- Preserve the existing completion-envelope, audit, supervision, and fail-closed provider-resolution contracts.

### Acceptance Criteria

- Cursor is a canonical provider accepted by the shared provider parser, capability checks, crew/runtime resolution, and supported-provider diagnostics without changing the behavior or ordering of existing providers.
- Orbit ships a platform-aware direct-agent executor for cursor-agent that runs non-interactively with file modifications enabled, requests machine-readable output, accepts an explicit model selection, and reports a stable unavailable-binary diagnostic.
- A Cursor runtime adapter normalizes representative real CLI success, failure, and malformed-output fixtures into Orbit's response/envelope contract and never treats missing required completion evidence as success.
- Authentication and state handling support the documented Cursor API-key and logged-in CLI paths without persisting credentials in tasks, audit output, transcripts, or error messages.
- macOS and Linux sandbox policy grants only the Cursor state access required by an active Cursor executor; non-Cursor providers do not inherit Cursor-specific write access.
- Fresh-init detection and crew configuration can expose an installed Cursor executor while preserving existing provider-family defaults and never silently falling back to another provider when Cursor is unavailable.
- Deterministic fake-CLI tests cover argv, prompt transport, model propagation, successful worktree edits, non-zero exit, malformed output, timeout/cancellation, and sandbox confinement.
- Current configuration and execution documentation explains Cursor provider setup, authentication, model selection, and the distinction between the Cursor plugin control surface and Cursor worker execution.
- Focused provider/executor tests, make ci-fast, and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Implemented:
- Added Cursor as a canonical Orbit provider without aliases, appended it after the existing provider families, registered its runtime and built-in crew, and preserved fail-closed selection (including no silent provider fallback). Cursor remains an Orbit-only direct executor until the separate shared Worker/Bridge contract supports it.
- Added a bundled platform-aware `cursor-agent` direct executor using `--print --force --output-format json`, stdin prompt transport, and explicit `--model gpt-5` propagation. Missing binaries retain the stable spawn diagnostic naming `cursor-agent`.
- Added a Cursor runtime adapter that accepts only the documented terminal success wrapper (`type=result`, `subtype=success`, `is_error=false`, string `result`) before handing the inner response to Orbit's completion-envelope parser. Failure, malformed, partial, and non-string outputs fail closed.
- Added authentication/state handling for logged-in CLI state under `$HOME/.cursor` and operator-opt-in `CURSOR_API_KEY` forwarding through `[execution.env].pass`. Credentials are never placed in argv or implicitly forwarded.
- Added active-provider-only Cursor state write grants for macOS and Linux; non-Cursor providers do not receive the Cursor-specific grant.
- Added fresh-init CLI detection, crew/default resolution, platform executor seeding, configuration docs, and the Cursor plugin-control-surface versus worker-execution distinction.
- Added deterministic unit and fake-CLI coverage for parser/capabilities, argv and stdin, model propagation, persisted worktree edits, real-shape success/failure fixtures, non-zero exit, malformed/incomplete output, timeout/cancellation, sandbox confinement, and unavailable binary behavior.

CLI evidence:
- Downloaded the official current Cursor CLI package into a temporary directory solely for inspection. Version `2026.08.11-e8db854` help confirmed `--print`, `--force`, `--output-format json`, `--model`, login/status/model commands, and the backward-compatible `cursor-agent` executable name.
- Captured a representative real unauthenticated/API-key failure: exit 1, empty stdout, stderr diagnostic. The sanitized shape is covered by the adapter tests. No authenticated live success was run because no Cursor credentials were available; the success fixture follows Cursor's documented JSON result schema.

Validation:
- `cargo test -p orbit-agent --lib providers::cursor` (12 passed)
- `cargo test -p orbit-config --lib` (80 passed)
- `cargo test -p orbit-cli --bin orbit agent_detect` (6 passed)
- `cargo test -p orbit-core --test cursor_fake_agent` (7 passed)
- `cargo test -p orbit-core application::tests::executor` (13 passed)
- Additional focused provider, init prompt, macOS provider-directory, Linux sandbox, and executor tests passed.
- `make ci-fast` passed.
- `make ci-lint` passed.
- `git diff --check` passed.

Friction checkpoint:
- Filed F2026-08-104 for the recurring managed-worktree issue where `orbit tool run` cannot access the store because it resolves a read-only linked-worktree path; MCP task tools remained usable.

No commit was created, per project policy.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10945-6a8919fe`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*