### PR TITLE
Fix Agent Plugin validator test for relative repository paths

### DIFF
--- a/scripts/test-validate-agent-plugin.sh
+++ b/scripts/test-validate-agent-plugin.sh
@@ -46,7 +46,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-repo_root = Path(sys.argv[1])
+repo_root = Path(sys.argv[1]).resolve()
 validator = Path(sys.argv[2])
 base_fixture = Path(sys.argv[3])
 


### PR DESCRIPTION
## Task

[ORB-10949](https://orbit-cli.com/tasks/ORB-10949) — Fix Agent Plugin validator test for relative repository paths

### Description

QA sweep found a false failure in the new Agent Plugin validation test from commit fc258dad ([ORB-10943]).

Observed evidence:

$ scripts/test-validate-agent-plugin.sh .
validate-agent-plugin: plugin manifest is valid (plugin/plugin.json)
test-validate-agent-plugin: failed
- plugin.json embeds a repository- or user-specific absolute path
- mcp.json embeds a repository- or user-specific absolute path

Both manifests are portable: neither contains ~ nor the checkout path. The test's embedded Python receives the caller-provided repo_root without resolving it; with ., str(repo_root) == ., so every JSON string containing a dot (including schema URLs) is misclassified as containing the repository path. The validator itself resolves its root and passes.

Reproduction:

1. From the repository root, run scripts/test-validate-agent-plugin.sh .
2. Observe the two false-positive absolute-path failures above.
3. Run scripts/test-validate-agent-plugin.sh "$(pwd -P)" and observe it succeeds, confirming the defect is relative-path handling in the test harness.

Expected: the script accepts its documented optional repository-root argument in relative or absolute form and reports success for the valid plugin package.

### Acceptance Criteria

- scripts/test-validate-agent-plugin.sh . passes for the valid repository plugin package.
- The test still rejects a genuinely embedded repository or user-specific absolute path.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `scripts/test-validate-agent-plugin.sh` to resolve the optional repository-root argument before checking manifest text, so `.` is compared as its canonical absolute checkout path rather than as a one-character substring.
- Kept the existing repository/home absolute-path detection unchanged; it now correctly rejects genuinely embedded checkout and user-home paths.

Validation:
- `scripts/test-validate-agent-plugin.sh .` passed.
- `scripts/test-validate-agent-plugin.sh "$(pwd -P)"` passed.
- `bash -n scripts/test-validate-agent-plugin.sh` passed.
- Temporary fixtures containing the canonical repository path and `Path.home()` in `plugin.json` were both rejected by the test.

Assessment: Minimal, scoped fix with no API or dependency changes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10949-6a89e10a`
- Behind base: 0
- Ahead of base: 1