### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/worktree-artifacts/3_vision.md
+++ b/docs/design/worktree-artifacts/3_vision.md
@@ -11,9 +11,15 @@ tags: ["worktree-artifacts"]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-cli/**"]
 related_features: ["worktree-artifacts"]
 related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201"]
+last_validated: 2026-08-22
 ---
 
 # Worktree Artifacts - Vision
+
+> This vision records retired ADR and learning-store behavior. ORB-10726 retired
+> the ADR store and tool surface, and ORB-10736 removed the native learning
+> subsystem; the shared/local runtime-root split remains, while current decisions
+> live in each feature's `4_decisions.md`.
 
 The worktree artifact model should make knowledge artifacts feel like ordinary branch files without weakening Orbit's shared coordination state.
 
@@ -36,7 +42,7 @@ The worktree artifact model should make knowledge artifacts feel like ordinary b
 
 ### Artifact Discipline
 
-The ADR and learning skills already require tool-mediated writes instead of direct YAML edits. [ORB-00201] changes where those tool-mediated writes land, not the authorship rule.
+The historical ADR and learning surfaces required tool-mediated writes instead of direct YAML edits. [ORB-00201] changed where those tool-mediated writes landed, not the authorship rule.
 
 ## 3. What May Be Distinctive
 

--- a/docs/design/worktree-artifacts/4_decisions.md
+++ b/docs/design/worktree-artifacts/4_decisions.md
@@ -11,9 +11,16 @@ tags: ["worktree-artifacts"]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-engine/**", "crates/orbit-cli/**"]
 related_features: ["worktree-artifacts", "host-registry", "mcp-bridge"]
 related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10272", "ORB-10297", "ORB-10330", "ORB-10501", "ORB-10535", "ORB-10545", "ORB-10668", "ORB-10669", "ORB-10725"]
+last_validated: 2026-08-22
 ---
 
 # Worktree Artifacts - Decisions
+
+> Entries about ADR/learning stores, allocation, federation, and publication are
+> retired history. ORB-10726 retired the ADR store and tool surface, and
+> ORB-10736 removed the native learning subsystem; current feature decisions live
+> in each feature's `4_decisions.md`. The stationary-primary and delivery-summary
+> decisions below describe current code paths.
 
 Decision log for worktree artifact storage. Entries are addressed by title; task references retain their implementation provenance.
 

--- a/docs/runbooks/CONVENTIONS.md
+++ b/docs/runbooks/CONVENTIONS.md
@@ -5,6 +5,7 @@ tags: [docs, operations, runbooks]
 paths: ["docs/runbooks/**"]
 related_features: [orbit-docs]
 related_artifacts: []
+last_validated: 2026-08-22
 ---
 
 # Runbook Conventions

--- a/docs/runbooks/audit-trail.md
+++ b/docs/runbooks/audit-trail.md
@@ -2,9 +2,10 @@
 type: runbook
 summary: Query and interpret Orbit invocation, run, step, and activity audit history.
 tags: [operations, audit, observability, debugging]
-paths: ["crates/orbit-core/src/runtime/run_audit.rs", "crates/orbit-common/src/types/audit_event.rs"]
+paths: ["crates/orbit-core/src/runtime/run_audit.rs", "crates/orbit-types/src/telemetry/audit_event.rs"]
 related_features: [auditability, activity-job]
 related_artifacts: [ORB-10014, ORB-10227, ORB-10228]
+last_validated: 2026-08-22
 ---
 
 # Inspect the Audit Trail
@@ -38,7 +39,7 @@ orbit audit list --json --limit 100              # full event objects
 orbit audit show <id>
 orbit audit stats --since 7d
 orbit audit export --output audit.json           # JSON or --format csv
-orbit audit prune --older-than 90d
+orbit audit prune --older-than 90d --confirm
 ```
 
 Per-invocation fields include `id`, `execution_id`, `timestamp`, `command`, `subcommand`,

--- a/docs/runbooks/database-recovery.md
+++ b/docs/runbooks/database-recovery.md
@@ -5,6 +5,7 @@ tags: [operations, sqlite, corruption, recovery]
 paths: ["crates/orbit-store/**", "crates/orbit-cmd/src/doctor.rs"]
 related_features: [orbit-core]
 related_artifacts: [ORB-10014, ORB-10473]
+last_validated: 2026-08-22
 ---
 
 # Recover a Corrupted Database

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -2,9 +2,10 @@
 type: runbook
 summary: Check Orbit workspace, database, dashboard, log-sink, job-run, and routine-clock health.
 tags: [operations, health, doctor, dashboard, routines]
-paths: ["crates/orbit-cmd/src/doctor.rs", "crates/orbit-core/src/command/job/run/reconcile.rs"]
+paths: ["crates/orbit-cmd/src/doctor.rs", "crates/orbit-core/src/application/job/run/reconcile.rs"]
 related_features: [orbit-core, activity-job, routines]
 related_artifacts: [ORB-10005, ORB-10070, ORB-10473, ORB-10501, ORB-10558]
+last_validated: 2026-08-22
 ---
 
 # Check Orbit Health
@@ -14,8 +15,8 @@ database recovery, or upgrade.
 
 ## Run `orbit doctor`
 
-`orbit doctor` performs nine checks in order. Every check degrades to a row rather than
-aborting unless the store itself cannot open.
+`orbit doctor` performs infrastructure checks and one row for each definition-artifact kind.
+Every check degrades to a row rather than aborting unless the store itself cannot open.
 
 | Check | What it verifies |
 |---|---|
@@ -24,11 +25,10 @@ aborting unless the store itself cannot open.
 | `disk-space` | free space on the volume holding `.orbit` (warn below 1 GiB or 5%; fail below 256 MiB or 1%) |
 | `semantic-index` | stale embedding rows; skipped if never indexed |
 | `stale-locks` | `.lock` files under `state/`, `tasks/`, `learnings/`, and `adrs/.locks/` whose recorded holder PID is dead |
-| `job-runs` | orphaned `pending` or `running` runs whose owner process is gone |
+| `job-runs` | orphaned `pending` or `running` runs with no live worker process |
 | `task-reservations` | active reservations whose owner run or terminal task association proves the reservation stale |
 | `task-relations` | unresolved relation/dependency targets that would block a task-index rebuild |
-| `id-allocations` | learning/ADR ids pinned to a worktree that no longer exists, with no readable body |
-| `artifacts-*` | skills, jobs, activities, auto-tasks, and routines on disk: stale, deprecated, or catalog-invalid |
+| `artifacts-*` | skills, jobs, activities, auto-tasks, and routines on disk: stale, deprecated, residual, or catalog-invalid |
 
 Example:
 
@@ -45,7 +45,6 @@ $ orbit doctor
 │ job-runs         ok        no orphaned job runs                                              │
 │ task-reservations ok       no conclusively stale active task reservations                    │
 │ task-relations   ok        no unresolved relation/dependency targets                        │
-│ id-allocations   ok        no learning/ADR allocations pinned to a missing worktree         │
 0 failure(s), 1 warning(s).
 ```
 
@@ -99,15 +98,6 @@ orbit doctor --fix-retired-activity-backends
 The repair deletes only that obsolete `spec.backend` key, leaves unknown backend values and
 unrelated malformed activities untouched (and reports them for a manual edit), and is
 idempotent across every activity catalog directory in the workspace.
-
-An `id-allocations` warning means an id was allocated inside a worktree that has since been
-reaped, before its body was merged: the body is unrecoverable and the row would otherwise stay
-in the legacy allocation ledger forever. Confirm the named
-worktrees really are gone — a volume that is merely unmounted reads the same way — then retire
-the rows with `orbit doctor --fix-orphaned-allocations`. The repair re-verifies every row
-before writing, refuses any that became readable again, and flips the row to `abandoned`
-instead of deleting it, so the retired ids are never reissued ([Detect and retire id allocations pinned to a reaped worktree](../design/worktree-artifacts/4_decisions.md#detect-and-retire-id-allocations-pinned-to-a-reaped-worktree), ORB-10501). Without
-the flag, `orbit doctor` only reports.
 
 Graph is retired under [Retire and delete Orbit's code-graph subsystem](../design/_archive/orbit-graph/4_decisions.md#retire-and-delete-orbits-code-graph-subsystem) and is not inspected by ordinary health checks. To remove
 leftover state explicitly, run `orbit doctor --remove-graph`. This deletes only the current
@@ -170,13 +160,11 @@ fire immediately only when the recorded owner process is conclusively gone; a li
 unprobeable owner remains protected until terminal or until the routine timeout. Use
 `orbit doctor` and the stuck-job-run runbook below when the run itself remains orphaned.
 
-The dashboard also exposes `GET /api/routines`. Auto-task definitions such as
-`qa-sweep` and `artifact-deprecation-review` are ordinary workspace data under
-`.orbit/auto_tasks/`, processed by the generic auto-task scheduler routine.
-`artifact-deprecation-review` is report-only — it mints a task that lists stale
-learning candidates and stale artifact-id comment references via
-`execution_summary` and never mutates learnings, ADRs, tasks, friction
-records, or comments (ORB-10318, ORB-10348).
+The dashboard also exposes `GET /api/routines`. `qa-sweep` and other auto-task
+definitions are ordinary workspace data under `.orbit/auto_tasks/`, processed by the
+generic auto-task scheduler routine. The scheduler mints tasks from every due,
+enabled definition; it does not itself edit docs, ADRs, learnings, friction records,
+or comments.
 
 ## Verification and escalation
 


### PR DESCRIPTION
## Task

[ORB-10951](https://orbit-cli.com/tasks/ORB-10951) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Batch selection: scanned all versioned Markdown under docs/ while excluding docs/design/_archive/ and docs/changelogs/, then sorted missing last_validated first and dated values oldest-first with path tie-break. The six selected docs were docs/design/worktree-artifacts/3_vision.md, docs/design/worktree-artifacts/4_decisions.md, docs/runbooks/CONVENTIONS.md, docs/runbooks/audit-trail.md, docs/runbooks/database-recovery.md, and docs/runbooks/health-checks.md; all six had frontmatter but no last_validated, so no frontmatter migration was needed.
- Stamped all six selected docs with last_validated: 2026-08-22.
- docs/design/worktree-artifacts/3_vision.md: marked the ADR/learning-store material as retired history and corrected the historical tool-mediated-write wording. Verified the retirement against ORB-10726/ORB-10736 commits and current worktree-artifacts design/overview docs.
- docs/design/worktree-artifacts/4_decisions.md: added the same retired-history boundary while preserving the decision record; identified the stationary-primary and delivery-summary entries as current. Verified task references with git log --all --grep and current symbols for primary_dirt_only_delta_is_benign, ensure_durable_execution_summary, and commit_batch_changes.
- docs/runbooks/CONVENTIONS.md: no prose change; verified its locked type/summary contract, runbook layout, and generated-index instructions against docs/design/orbit-docs/4_decisions.md and scripts/generate-doc-indexes.sh.
- docs/runbooks/audit-trail.md: corrected the stale audit event source path to crates/orbit-types/src/telemetry/audit_event.rs and added required --confirm to the destructive prune example. Verified command/subcommand/flag coverage with orbit audit list/export/prune/stats --help and audit store/middleware source.
- docs/runbooks/database-recovery.md: no prose change; verified database paths, quick_check, recovery commands, task reindex, semantic index, and retired graph cleanup against source, current runbooks, and orbit doctor/semantic help.
- docs/runbooks/health-checks.md: corrected the reconcile source path, removed retired id-allocations check/repair claims, corrected job-run wording, expanded artifact-health terminology, and removed the obsolete artifact-deprecation-review auto-task claim. Verified doctor check construction, repair flags, graph cleanup, health endpoints, routine clock, and generic auto-task scheduler against current source/help.
- No selected doc was frontmatter-less, uncertainly classified, or left unvalidated; no individual claims were intentionally left unvalidated. Historical claims were treated as provenance and checked against their task commits where applicable.

Validation:
- make ci-fast passed, including generated docs index check, formatting, guardrails, and plugin validators.
- git diff --check passed; relative-link and fenced-code checks passed; only the six selected docs changed; forbidden paths were unchanged.
- Store-backed orbit docs show/tool-run attempts were denied by the environment with Read-only file system (os error 30); validation used the repository's source, help output, index checker, and read-only file inspection instead.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10951-6a89e14c`
- Behind base: 0
- Ahead of base: 1