### PR TITLE
[BLOCKED] orbit init: Copilot CLI missing from "Detected agents" list

### DIFF
--- a/crates/orbit-cli/src/command/init/agent_prompt.rs
+++ b/crates/orbit-cli/src/command/init/agent_prompt.rs
@@ -232,19 +232,60 @@ struct AgentOption {
     model: &'static str,
 }
 
+#[derive(Clone, Copy)]
+struct AgentFamily {
+    label: &'static str,
+    provider: &'static str,
+}
+
+const AGENT_FAMILIES: [AgentFamily; 7] = [
+    AgentFamily {
+        label: "Claude CLI",
+        provider: "claude",
+    },
+    AgentFamily {
+        label: "Codex CLI",
+        provider: "codex",
+    },
+    AgentFamily {
+        label: "Gemini CLI",
+        provider: "gemini",
+    },
+    AgentFamily {
+        label: "Grok CLI",
+        provider: "grok",
+    },
+    AgentFamily {
+        label: "Copilot CLI",
+        provider: "copilot",
+    },
+    AgentFamily {
+        label: "Cursor Agent CLI",
+        provider: "cursor",
+    },
+    AgentFamily {
+        label: "Ollama CLI",
+        provider: "ollama",
+    },
+];
+
+fn agent_families(detected: &DetectedAgents) -> impl Iterator<Item = (AgentFamily, bool)> {
+    AGENT_FAMILIES.into_iter().zip([
+        detected.claude_cli,
+        detected.codex_cli,
+        detected.gemini_cli,
+        detected.grok_cli,
+        detected.copilot_cli,
+        detected.cursor_cli,
+        detected.ollama_cli,
+    ])
+}
+
 fn agent_options(detected: &DetectedAgents) -> Vec<AgentOption> {
     let mut options = Vec::new();
-    for (enabled, label, provider) in [
-        (detected.claude_cli, "Claude CLI", "claude"),
-        (detected.codex_cli, "Codex CLI", "codex"),
-        (detected.gemini_cli, "Gemini CLI", "gemini"),
-        (detected.grok_cli, "Grok CLI", "grok"),
-        (detected.copilot_cli, "Copilot CLI", "copilot"),
-        (detected.cursor_cli, "Cursor Agent CLI", "cursor"),
-        (detected.ollama_cli, "Ollama CLI", "ollama"),
-    ] {
+    for (family, enabled) in agent_families(detected) {
         if enabled {
-            options.push(agent_option(label, provider));
+            options.push(agent_option(family.label, family.provider));
         }
     }
 
@@ -279,21 +320,13 @@ fn intro_text(detected: &DetectedAgents, recommended: &CrewSeed) -> String {
 }
 
 fn detection_lines(detected: &DetectedAgents) -> String {
-    [
-        ("Claude CLI", detected.claude_cli),
-        ("Codex CLI", detected.codex_cli),
-        ("Gemini CLI", detected.gemini_cli),
-        ("Grok CLI", detected.grok_cli),
-        ("Cursor Agent CLI", detected.cursor_cli),
-        ("Ollama CLI", detected.ollama_cli),
-    ]
-    .into_iter()
-    .map(|(label, found)| {
-        let status = if found { "found" } else { "not found" };
-        format!("  {label:<18} {status}")
-    })
-    .collect::<Vec<_>>()
-    .join("\n")
+    agent_families(detected)
+        .map(|(family, found)| {
+            let status = if found { "found" } else { "not found" };
+            format!("  {:<18} {status}", family.label)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn format_agent_options(options: &[AgentOption]) -> String {
@@ -314,15 +347,13 @@ fn format_agent_options(options: &[AgentOption]) -> String {
 }
 
 fn agent_display_name(config: &CrewSeed) -> String {
-    match config.provider.as_deref().unwrap_or("custom") {
-        "claude" => "Claude CLI".to_string(),
-        "codex" => "Codex CLI".to_string(),
-        "gemini" => "Gemini CLI".to_string(),
-        "grok" => "Grok CLI".to_string(),
-        "copilot" => "Copilot CLI".to_string(),
-        "cursor" => "Cursor Agent CLI".to_string(),
-        "ollama" => "Ollama CLI".to_string(),
-        provider => format!("{provider} (CLI)"),
+    let provider = config.provider.as_deref().unwrap_or("custom");
+    match AGENT_FAMILIES
+        .iter()
+        .find(|family| family.provider == provider)
+    {
+        Some(family) => family.label.to_string(),
+        None => format!("{provider} (CLI)"),
     }
 }
 

--- a/crates/orbit-cli/src/command/init/tests/agent_prompt.rs
+++ b/crates/orbit-cli/src/command/init/tests/agent_prompt.rs
@@ -68,6 +68,22 @@ fn custom_provider_reprompts_for_blank_unknown_model() {
 }
 
 #[test]
+fn detected_agents_lists_every_family_when_only_copilot_is_present() {
+    let detected = DetectedAgents {
+        copilot_cli: true,
+        ..DetectedAgents::default()
+    };
+    let mut prompter = CannedPrompter::new([""]);
+
+    let result = collect_crew_setting(&detected, &mut prompter).expect("crew setting");
+
+    assert_eq!(result.provider.as_deref(), Some("copilot"));
+    assert!(prompter.transcript().contains(
+        "Detected agents:\n  Claude CLI         not found\n  Codex CLI          not found\n  Gemini CLI         not found\n  Grok CLI           not found\n  Copilot CLI        found\n  Cursor Agent CLI   not found\n  Ollama CLI         not found"
+    ));
+}
+
+#[test]
 fn system_crew_prompt_offers_only_detected_cheap_tier_options() {
     let detected = DetectedAgents {
         claude_cli: true,


### PR DESCRIPTION
## Manual resolution required

Orbit preserved and pushed this task's pre-rebase candidate after the shipment pipeline stopped. This PR is intentionally blocked and must be reconciled manually before merge.

- Task: `ORB-10953`
- Run: `jrun-20260822-1820`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `ec9069ead37162194b7fa922f613d8b68ccfc5fc`
- Target base: `ec9069ead37162194b7fa922f613d8b68ccfc5fc`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: cli subprocess reported declared envelope status="failed" despite exit 0
```