### PR TITLE
Make orbit.task.show global-by-default across tool run and MCP

### DIFF
--- a/crates/orbit-cli/src/command/mcp/server.rs
+++ b/crates/orbit-cli/src/command/mcp/server.rs
@@ -169,10 +169,12 @@ impl ServerMcpHost {
     /// Which registered workspace this call lands in.
     ///
     /// `orbit.task.show` follows the globally unique task ID unless the call
-    /// itself passes `workspace` [ORB-10797]: the session's announced workspace
-    /// is ambient, like cwd, and is the right default for authoring but the
-    /// wrong one for addressing an ID. An explicit per-call `workspace` stays a
-    /// filter on every tool, so a task owned elsewhere is not found there.
+    /// itself passes `workspace` [ORB-10797] [ORB-10961]: the session's
+    /// announced workspace is ambient, like cwd, and is the right default for
+    /// authoring but the wrong one for addressing an ID. Linked-worktree
+    /// runtime identities are also ambient and must not become a filter. An
+    /// explicit per-call `workspace` stays a filter on every tool, so a task
+    /// owned elsewhere is not found there.
     fn workspace_selection(
         &self,
         name: &str,
@@ -293,14 +295,15 @@ fn execute_core_tool(
     input: Value,
     context: ToolSessionContext,
 ) -> Result<Value, OrbitError> {
-    runtime
+    let output = runtime
         .execute_tool_command_dispatch_with_session_context(
             name,
-            input,
+            input.clone(),
             None,
             None,
             ToolEntryPoint::Mcp,
             context,
-        )
-        .map(|outcome| outcome.value)
+        )?
+        .value;
+    crate::command::task::show::attach_bound_workspace_identity(name, &input, runtime, output)
 }

--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -33,12 +33,13 @@ pub enum RuntimeNeed {
     Required,
     Forbidden,
     /// Bind the workspace that owns this task ID rather than the one the cwd
-    /// or `--workspace` walk would pick [ORB-10797].
+    /// or `--workspace` walk would pick [ORB-10797] [ORB-10961].
     ///
-    /// Task IDs are a machine-global primary key, so `task show` is the one
-    /// verb whose target is addressable without knowing its workspace. A
-    /// `--workspace` selector still wins and still filters: the bootstrap
-    /// binds that workspace, and a task owned elsewhere is simply not found.
+    /// Task IDs are a machine-global primary key, so `task show` — including
+    /// `orbit tool run orbit.task.show` — is the one verb whose target is
+    /// addressable without knowing its workspace. A `--workspace` selector
+    /// still wins and still filters: the bootstrap binds that workspace, and a
+    /// task owned elsewhere is simply not found.
     TaskOwner {
         task_id: String,
     },
@@ -709,8 +710,15 @@ impl Commands {
                             ("doctor", None, None, None, "admin".to_string(), None)
                         }
                     };
+                let runtime_need = match &command.command {
+                    ToolSubcommand::Run(args) => match args.task_show_id() {
+                        Some(task_id) => RuntimeNeed::TaskOwner { task_id },
+                        None => RuntimeNeed::Required,
+                    },
+                    _ => RuntimeNeed::Required,
+                };
                 CommandOperation::new(
-                    RuntimeNeed::Required,
+                    runtime_need,
                     Some(CommandMeta {
                         command: "tool".to_string(),
                         subcommand: Some(subcommand.to_string()),

--- a/crates/orbit-cli/src/command/task/mod.rs
+++ b/crates/orbit-cli/src/command/task/mod.rs
@@ -9,7 +9,7 @@ mod lint;
 mod list;
 pub(crate) mod output;
 mod reindex;
-mod show;
+pub(crate) mod show;
 mod update;
 
 pub use command::{TaskCommand, TaskSubcommand};

--- a/crates/orbit-cli/src/command/task/show.rs
+++ b/crates/orbit-cli/src/command/task/show.rs
@@ -241,6 +241,29 @@ impl Execute for TaskShowArgs {
     }
 }
 
+/// Name the owning workspace on an unprojected `orbit.task.show` result.
+///
+/// Human `orbit task show`, `orbit tool run orbit.task.show`, and MCP
+/// `orbit_task_show` share this so an id-only read reports the logical
+/// registry identity a later write can address [ORB-10797] [ORB-10961].
+pub(crate) fn attach_bound_workspace_identity(
+    tool_name: &str,
+    input: &Value,
+    runtime: &OrbitRuntime,
+    mut output: Value,
+) -> Result<Value, OrbitError> {
+    if tool_name != "orbit.task.show" {
+        return Ok(output);
+    }
+    if input.get("field").is_some() || input.get("fields").is_some() {
+        return Ok(output);
+    }
+    if let Some(owner) = bound_workspace_identity(runtime) {
+        insert_workspace_identity(&mut output, &owner)?;
+    }
+    Ok(output)
+}
+
 /// Name the owning workspace in the machine-readable projection, in the same
 /// `(name, logical id)` shape the human line prints, so a follow-up write can
 /// address it with `--workspace`.

--- a/crates/orbit-cli/src/command/tests/operation.rs
+++ b/crates/orbit-cli/src/command/tests/operation.rs
@@ -63,6 +63,40 @@ fn migrate_only_bootstraps_the_applying_form() {
 }
 
 #[test]
+fn tool_run_task_show_bootstraps_the_task_owner_from_id_only_input() {
+    assert_eq!(
+        operation_for(&[
+            "orbit",
+            "tool",
+            "run",
+            "orbit.task.show",
+            "--input",
+            r#"{"id":"ORB-10961","model":"codex"}"#,
+        ])
+        .runtime_need,
+        RuntimeNeed::TaskOwner {
+            task_id: "ORB-10961".to_string()
+        }
+    );
+    assert_eq!(
+        operation_for(&["orbit", "tool", "run", "orbit.task.show"]).runtime_need,
+        RuntimeNeed::Required
+    );
+    assert_eq!(
+        operation_for(&[
+            "orbit",
+            "tool",
+            "run",
+            "orbit.task.list",
+            "--input",
+            r#"{"id":"ORB-10961"}"#,
+        ])
+        .runtime_need,
+        RuntimeNeed::Required
+    );
+}
+
+#[test]
 fn json_error_preferences_are_derived_from_operations() {
     assert_eq!(
         operation_for(&["orbit", "tool", "run", "orbit.task.show"]).json_error_preference,

--- a/crates/orbit-cli/src/command/tool/run.rs
+++ b/crates/orbit-cli/src/command/tool/run.rs
@@ -51,6 +51,31 @@ pub struct ToolRunArgs {
     pub output: OutputFormat,
 }
 
+impl ToolRunArgs {
+    /// Globally unique task ID from `orbit tool run orbit.task.show` input.
+    ///
+    /// The CLI bootstraps that one tool through the host task registry rather
+    /// than cwd, matching `orbit task show` [ORB-10961]. Other tools keep the
+    /// ordinary workspace runtime.
+    pub(crate) fn task_show_id(&self) -> Option<String> {
+        if self.name != "orbit.task.show" {
+            return None;
+        }
+        let raw = if let Some(path) = &self.input_file {
+            std::fs::read_to_string(path).ok()?
+        } else {
+            self.input.clone()?
+        };
+        let value: Value = serde_json::from_str(&raw).ok()?;
+        value
+            .get("id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .map(ToOwned::to_owned)
+    }
+}
+
 impl Execute for ToolRunArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
         let mut input: Value = if let Some(path) = &self.input_file {
@@ -69,6 +94,9 @@ impl Execute for ToolRunArgs {
 
         // Resolve `workspace` once above local CLI tools, then bind or fail
         // closed. MCP uses its own server-side selector resolution.
+        // `orbit.task.show` is bootstrapped via RuntimeNeed::TaskOwner so an
+        // id-only call is not cwd-bound [ORB-10961]. An explicit `workspace`
+        // in the tool input is still a fail-closed filter through this bind.
         let bound = RegisteredRuntimeFactory::bind_cli_tool_workspace(runtime, &mut input)?;
         let runtime = bound.as_ref().unwrap_or(runtime);
 
@@ -98,6 +126,9 @@ impl Execute for ToolRunArgs {
             self.agent,
             self.model,
             session_context,
+        )?;
+        let output = crate::command::task::show::attach_bound_workspace_identity(
+            &self.name, &input, runtime, output,
         )?;
         let output = shape_tool_output(&self.name, &input, output, self.full, &self.fields);
 
@@ -165,6 +196,7 @@ const MINIMAL_TASK_FIELDS: &[&str] = &[
     "implemented_by",
     "created_at",
     "updated_at",
+    "workspace",
 ];
 
 pub(super) fn shape_tool_output(

--- a/crates/orbit-cli/src/command/tool/tests/run.rs
+++ b/crates/orbit-cli/src/command/tool/tests/run.rs
@@ -1,9 +1,34 @@
 use serde_json::json;
 
 use super::super::run::{
-    LOCAL_MACHINE_ID_FALLBACK, local_machine_identity, local_tool_session_context,
+    LOCAL_MACHINE_ID_FALLBACK, ToolRunArgs, local_machine_identity, local_tool_session_context,
     shape_tool_output,
 };
+
+#[test]
+fn task_show_id_is_read_only_from_orbit_task_show_input() {
+    let show = ToolRunArgs {
+        name: "orbit.task.show".to_string(),
+        input: Some(r#"{"id":" ORB-10961 ","model":"codex"}"#.to_string()),
+        input_file: None,
+        agent: None,
+        model: None,
+        timeout: None,
+        dry_run: false,
+        fields: Vec::new(),
+        full: false,
+        pretty: false,
+        output: super::super::run::OutputFormat::Json,
+    };
+    assert_eq!(show.task_show_id().as_deref(), Some("ORB-10961"));
+
+    let list = ToolRunArgs {
+        name: "orbit.task.list".to_string(),
+        input: Some(r#"{"id":"ORB-10961"}"#.to_string()),
+        ..show
+    };
+    assert_eq!(list.task_show_id(), None);
+}
 
 #[test]
 fn list_output_uses_minimal_task_projection() {

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -1258,6 +1258,256 @@ fn mcp_task_show_follows_the_global_id_and_explicit_workspace_stays_a_filter() {
     );
 }
 
+/// ORB-10961: the ORB-10952 managed-worktree shape.
+///
+/// A linked worktree whose checkout identity (`orbit-5c61b3`) diverged from
+/// the logical registry ID must not turn that runtime identity into an
+/// `orbit.task.show` filter. Id-only tool-run and MCP calls follow the task
+/// ID; other workspace-scoped tools still require a registered selector.
+#[test]
+fn task_show_is_global_by_default_across_tool_run_and_mcp() {
+    let workspace = McpWorkspace::init();
+
+    let registry_path = workspace.home.join(".orbit").join("workspaces.json");
+    let registry = std::fs::read_to_string(&registry_path).expect("read workspace registry");
+    std::fs::write(
+        &registry_path,
+        registry.replace("ws_mcp-roundtrip", "ws_legacy-logical"),
+    )
+    .expect("diverge the logical registry id");
+    let identity_path = workspace.work.join(".orbit").join("config.yaml");
+    let identity = std::fs::read_to_string(&identity_path).expect("read checkout identity");
+    std::fs::write(
+        &identity_path,
+        identity.replace("ws_mcp-roundtrip", "orbit-5c61b3"),
+    )
+    .expect("diverge the runtime partition identity");
+
+    let elsewhere = workspace.home.join("elsewhere");
+    std::fs::create_dir_all(&elsewhere).expect("create the second checkout");
+    let output = Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(&elsewhere)
+        .output()
+        .expect("initialize the second Git checkout");
+    assert!(output.status.success(), "git init failed: {output:?}");
+    let output = McpWorkspace::orbit_command(&elsewhere, &workspace.home)
+        .args(["workspace", "init", "--name", "mcp-elsewhere"])
+        .output()
+        .expect("register the second workspace");
+    assert!(
+        output.status.success(),
+        "second workspace init failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let add_input = json!({
+        "title": "Owned despite runtime identity orbit-5c61b3",
+        "description": "Addressed by ID from a linked worktree and a foreign cwd",
+        "workspace": workspace.work.to_str().expect("utf8 checkout path"),
+        "complexity": "low",
+        "model": "codex",
+    })
+    .to_string();
+    let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args(["tool", "run", "orbit.task.add", "--input", &add_input])
+        .output()
+        .expect("author a task in the diverged workspace");
+    assert!(
+        output.status.success(),
+        "task add failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let created: Value = serde_json::from_slice(&output.stdout).expect("parse created task");
+    let task_id = created["id"].as_str().expect("task id").to_string();
+    let show_input = json!({ "id": task_id, "model": "codex" }).to_string();
+
+    let worktree = add_linked_worktree(&workspace.work);
+    let scratch = workspace.home.join("scratch");
+    std::fs::create_dir_all(&scratch).expect("create a non-workspace directory");
+
+    for cwd in [&worktree, &elsewhere, &scratch] {
+        let output = McpWorkspace::orbit_command(cwd, &workspace.home)
+            .args(["tool", "run", "orbit.task.show", "--input", &show_input])
+            .output()
+            .expect("run id-only task show");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "id-only tool run from {} must follow the task id\nstdout:\n{}\nstderr:\n{stderr}",
+            cwd.display(),
+            String::from_utf8_lossy(&output.stdout)
+        );
+        assert!(
+            !stderr.contains("orbit-5c61b3"),
+            "tool run must not promote the runtime identity into a selector from {}: {stderr}",
+            cwd.display()
+        );
+        let shown: Value = serde_json::from_slice(&output.stdout).expect("parse tool run show");
+        assert_eq!(shown["id"], json!(task_id));
+        assert_eq!(shown["workspace"]["id"], "ws_legacy-logical");
+        assert_eq!(shown["workspace"]["name"], "mcp-roundtrip");
+    }
+
+    let invalid = McpWorkspace::orbit_command(&scratch, &workspace.home)
+        .args([
+            "tool",
+            "run",
+            "orbit.task.show",
+            "--input",
+            &json!({
+                "id": task_id,
+                "workspace": "no-such-workspace",
+                "model": "codex"
+            })
+            .to_string(),
+        ])
+        .output()
+        .expect("run invalid explicit workspace filter");
+    assert!(!invalid.status.success());
+    let invalid_stderr = String::from_utf8_lossy(&invalid.stderr);
+    assert!(
+        invalid_stderr.contains("no-such-workspace"),
+        "an invalid explicit selector must be named: {invalid_stderr}"
+    );
+
+    let runtime_identity = McpWorkspace::orbit_command(&scratch, &workspace.home)
+        .args([
+            "tool",
+            "run",
+            "orbit.task.show",
+            "--input",
+            &json!({
+                "id": task_id,
+                "workspace": "orbit-5c61b3",
+                "model": "codex"
+            })
+            .to_string(),
+        ])
+        .output()
+        .expect("run runtime-identity explicit filter");
+    assert!(!runtime_identity.status.success());
+    let runtime_stderr = String::from_utf8_lossy(&runtime_identity.stderr);
+    assert!(
+        runtime_stderr.contains("orbit-5c61b3"),
+        "an explicit runtime identity remains fail-closed: {runtime_stderr}"
+    );
+
+    let mut client = serve_mcp_from(
+        &worktree,
+        &workspace.home,
+        json!({
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": { "name": "managed-executor", "version": "0" },
+            "_meta": { "orbit": { "workspace": "orbit-5c61b3" } },
+        }),
+    );
+    let listed = client.request("tools/list", Value::Null);
+    let task_show = listed["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .find(|tool| tool["name"] == "orbit_task_show")
+        .expect("orbit_task_show advertised");
+    let description = task_show["description"].as_str().expect("description");
+    assert!(
+        description.contains("globally unique"),
+        "advertised help must say id is globally resolved: {description}"
+    );
+    let workspace_help = task_show["inputSchema"]["properties"]["workspace"]["description"]
+        .as_str()
+        .expect("optional workspace filter advertised");
+    assert!(
+        workspace_help.contains("resolved globally by default"),
+        "generic workspace-selection copy must not replace task.show help: {workspace_help}"
+    );
+    assert!(
+        !workspace_help.contains("_meta.orbit.workspace"),
+        "session-default copy would make clients inject ambient identity: {workspace_help}"
+    );
+
+    let shown = client.call_tool_ok("orbit_task_show", json!({ "id": task_id }));
+    assert_eq!(shown["id"], json!(task_id));
+    assert_eq!(shown["workspace"]["id"], "ws_legacy-logical");
+    assert_eq!(shown["workspace"]["name"], "mcp-roundtrip");
+
+    let listed_err = client.call_tool_err("orbit_task_list", json!({}));
+    assert!(
+        listed_err["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("orbit-5c61b3")),
+        "task list must still fail-closed on the runtime identity: {listed_err}"
+    );
+    drop(client);
+
+    let mut client = serve_mcp_from(
+        &scratch,
+        &workspace.home,
+        json!({
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": { "name": "no-initialize-workspace", "version": "0" },
+        }),
+    );
+    let shown = client.call_tool_ok("orbit_task_show", json!({ "id": task_id }));
+    assert_eq!(shown["id"], json!(task_id));
+    let unscoped = client.call_tool_err("orbit_task_list", json!({}));
+    assert!(unscoped["message"].as_str().is_some_and(|message| {
+        message.contains("requires a workspace selector")
+            && message.contains("MCP initialize metadata")
+    }));
+    drop(client);
+
+    let mut client = serve_mcp_from(
+        &scratch,
+        &workspace.home,
+        json!({
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": { "name": "other-session", "version": "0" },
+            "_meta": {
+                "orbit": { "workspace": elsewhere.to_str().expect("utf8 elsewhere") }
+            },
+        }),
+    );
+    let shown = client.call_tool_ok("orbit_task_show", json!({ "id": task_id }));
+    assert_eq!(
+        shown["id"],
+        json!(task_id),
+        "id-only show must ignore a session bound to another workspace: {shown}"
+    );
+    let missed = client.call_tool_err(
+        "orbit_task_show",
+        json!({
+            "id": task_id,
+            "workspace": elsewhere.to_str().expect("utf8 elsewhere")
+        }),
+    );
+    assert!(
+        missed["message"]
+            .as_str()
+            .is_some_and(|message| message.contains(&task_id)),
+        "an explicit foreign workspace must filter: {missed}"
+    );
+}
+
+fn serve_mcp_from(cwd: &Path, home: &Path, initialize: Value) -> McpClient {
+    let child = McpWorkspace::orbit_command(cwd, home)
+        .args(["mcp", "serve"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn orbit mcp serve");
+    let mut client = McpClient::new(child);
+    client.request("initialize", initialize);
+    client.notify("notifications/initialized");
+    client
+}
+
 /// Commit the checkout and attach a linked worktree, mirroring how the engine
 /// stages a managed run.
 fn add_linked_worktree(work: &Path) -> PathBuf {

--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -665,12 +665,12 @@
   {
     "active": true,
     "builtin": true,
-    "description": "Fetch a single Orbit task as JSON. Use the optional `fields` projection (or single-field alias `field`) to retrieve only specific task fields, such as `field: \"orchestrator\"`. The `crew` field selects execution, while `orchestrator` records orchestration attribution.",
+    "description": "Fetch a single Orbit task as JSON. `id` is a globally unique primary key resolved through the host task registry by default; cwd, MCP initialize metadata, and linked-worktree runtime identities are not used as filters. An optional `workspace` argument is an explicit fail-closed filter only. Use the optional `fields` projection (or single-field alias `field`) to retrieve only specific task fields, such as `field: \"orchestrator\"`. The `crew` field selects execution, while `orchestrator` records orchestration attribution.",
     "enabled": true,
     "name": "orbit.task.show",
     "parameters": [
       {
-        "description": "task ID",
+        "description": "Globally unique task ID. Resolved through the host task registry by default; a workspace argument is not required.",
         "name": "id",
         "param_type": "string",
         "required": true
@@ -709,6 +709,12 @@
         "description": "Optional cap for `related_docs` when `with_context` is true. Defaults to 5.",
         "name": "max_docs",
         "param_type": "integer",
+        "required": false
+      },
+      {
+        "description": "Optional explicit workspace filter. `id` is resolved globally by default; do not pass cwd, MCP session/initialize metadata, or a linked-worktree runtime identity (for example `orbit-5c61b3`). When supplied, a registered workspace name, logical workspace ID (`ws_*`), or absolute local checkout path is fail-closed: a valid workspace that does not own the task returns not-found, and an unknown selector is rejected by name.",
+        "name": "workspace",
+        "param_type": "string",
         "required": false
       }
     ],

--- a/crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
@@ -14,7 +14,7 @@ orbit.task.add	title:string, description:string, complexity:string	Create an Orb
 orbit.task.approve	id:string	Approve an Orbit task and return the updated task JSON
 orbit.task.artifact.put	id:string, source_path:string	Store a source file under a task's artifacts directory
 orbit.task.list	-	List Orbit tasks newest-first (default limit 50), across every lifecycle status unless a filter is supplied. Optional filters: status, parent, type, tag, dependency readiness, path.
-orbit.task.show	id:string	Fetch a single Orbit task as JSON. Use the optional `fields` projection (or single-field alias `field`) to retrieve only specific task fields, such as `field: "orchestrator"`. The `crew` field selects execution, while `orchestrator` records orchestration attribution.
+orbit.task.show	id:string	Fetch a single Orbit task as JSON. `id` is a globally unique primary key resolved through the host task registry by default; cwd, MCP initialize metadata, and linked-worktree runtime identities are not used as filters. An optional `workspace` argument is an explicit fail-closed filter only. Use the optional `fields` projection (or single-field alias `field`) to retrieve only specific task fields, such as `field: "orchestrator"`. The `crew` field selects execution, while `orchestrator` records orchestration attribution.
 orbit.task.start	id:string	Start work on an Orbit task and return the updated task JSON
 orbit.task.update	id:string	Update an Orbit task and return the fresh task JSON
 orbit.workflow.run.list	-	List durable workflow runs newest-first with optional bounded filters.

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -714,7 +714,7 @@
     "name": "orbit_task_list"
   },
   {
-    "description": "Fetch a single Orbit task as JSON. Use the optional `fields` projection (or single-field alias `field`) to retrieve only specific task fields, such as `field: \"orchestrator\"`. The `crew` field selects execution, while `orchestrator` records orchestration attribution.",
+    "description": "Fetch a single Orbit task as JSON. `id` is a globally unique primary key resolved through the host task registry by default; cwd, MCP initialize metadata, and linked-worktree runtime identities are not used as filters. An optional `workspace` argument is an explicit fail-closed filter only. Use the optional `fields` projection (or single-field alias `field`) to retrieve only specific task fields, such as `field: \"orchestrator\"`. The `crew` field selects execution, while `orchestrator` records orchestration attribution.",
     "inputSchema": {
       "additionalProperties": true,
       "properties": {
@@ -741,7 +741,7 @@
           "description": "Optional field projection as a string or array of strings. When set, returns only the requested field(s) as JSON. Valid values: comments, plan, execution_summary, description, acceptance_criteria, dependencies, resolved_dependencies, tags, history, context_files, crew, orchestrator, artifacts. `crew` is execution selection; `orchestrator` is separate orchestration attribution."
         },
         "id": {
-          "description": "task ID",
+          "description": "Globally unique task ID. Resolved through the host task registry by default; a workspace argument is not required.",
           "type": "string"
         },
         "max_docs": {
@@ -763,7 +763,7 @@
           "type": "boolean"
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Optional explicit workspace filter. `id` is resolved globally by default; do not pass cwd, MCP session/initialize metadata, or a linked-worktree runtime identity (for example `orbit-5c61b3`). When supplied, a registered workspace name, logical workspace ID (`ws_*`), or absolute local checkout path is fail-closed: a valid workspace that does not own the task returns not-found, and an unknown selector is rejected by name.",
           "type": "string"
         }
       },

--- a/crates/orbit-cli/tests/tool_list.rs
+++ b/crates/orbit-cli/tests/tool_list.rs
@@ -205,6 +205,14 @@ fn tool_list_json_includes_task_show_context_parameters() {
             && param["param_type"] == "integer"
             && param["required"] == false
     }));
+    assert!(parameters.iter().any(|param| {
+        param["name"] == "workspace"
+            && param["param_type"] == "string"
+            && param["required"] == false
+            && param["description"]
+                .as_str()
+                .is_some_and(|description| description.contains("resolved globally by default"))
+    }));
 }
 
 #[test]

--- a/crates/orbit-cli/tests/workspace_selector.rs
+++ b/crates/orbit-cli/tests/workspace_selector.rs
@@ -270,6 +270,119 @@ fn task_show_follows_the_global_task_id_and_explicit_workspace_stays_a_filter() 
     );
 }
 
+/// `orbit tool run orbit.task.show` is the agent-facing twin of `orbit task show`
+/// and must follow the ID from a foreign checkout and from no workspace at all
+/// [ORB-10961]. An explicit `workspace` in the tool input stays a filter.
+#[test]
+fn tool_run_task_show_follows_the_global_task_id_and_explicit_workspace_stays_a_filter() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let orbit_repo = temp.path().join("orbit");
+    let other_repo = temp.path().join("other");
+    let elsewhere = temp.path().join("elsewhere");
+    fs::create_dir_all(&home).expect("home");
+    fs::create_dir_all(&elsewhere).expect("elsewhere");
+
+    init_git_repo(&orbit_repo);
+    init_git_repo(&other_repo);
+
+    run_orbit(
+        &orbit_repo,
+        &home,
+        &[
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "selector-host",
+            "--task-prefix",
+            "SEL",
+        ],
+    )
+    .success();
+    run_orbit(
+        &orbit_repo,
+        &home,
+        &["workspace", "init", "--name", "orbit"],
+    )
+    .success();
+    run_orbit(
+        &other_repo,
+        &home,
+        &["workspace", "init", "--name", "other"],
+    )
+    .success();
+
+    let created = run_orbit_json(
+        &orbit_repo,
+        &home,
+        &[
+            "task",
+            "add",
+            "--title",
+            "Globally addressable task",
+            "--description",
+            "Reachable by ID from anywhere",
+            "--complexity",
+            "low",
+            "--json",
+        ],
+    );
+    let task_id = created["id"].as_str().expect("created id").to_string();
+    let show_input = format!(r#"{{"id":"{task_id}","model":"codex"}}"#);
+
+    for cwd in [&other_repo, &elsewhere] {
+        let shown = run_orbit_json(
+            cwd,
+            &home,
+            &["tool", "run", "orbit.task.show", "--input", &show_input],
+        );
+        assert_eq!(
+            shown["id"],
+            Value::String(task_id.clone()),
+            "tool run task show from {} must follow the id: {shown}",
+            cwd.display()
+        );
+        assert_eq!(shown["workspace"]["name"], "orbit");
+        assert_eq!(shown["workspace"]["id"], "ws_orbit");
+    }
+
+    let filtered_input = format!(r#"{{"id":"{task_id}","workspace":"other","model":"codex"}}"#);
+    let missed = run_orbit(
+        &elsewhere,
+        &home,
+        &["tool", "run", "orbit.task.show", "--input", &filtered_input],
+    )
+    .failure();
+    let missed_stdout = String::from_utf8_lossy(&missed.get_output().stdout);
+    assert!(
+        !missed_stdout.contains("Globally addressable task"),
+        "a foreign task must not be printed under workspace other: {missed_stdout}"
+    );
+    let missed_stderr = String::from_utf8_lossy(&missed.get_output().stderr);
+    assert!(
+        missed_stderr.contains(&task_id),
+        "the miss must name the task it looked for: {missed_stderr}"
+    );
+
+    let invalid = run_orbit(
+        &elsewhere,
+        &home,
+        &[
+            "tool",
+            "run",
+            "orbit.task.show",
+            "--input",
+            &format!(r#"{{"id":"{task_id}","workspace":"no-such-workspace","model":"codex"}}"#),
+        ],
+    )
+    .failure();
+    let invalid_stderr = String::from_utf8_lossy(&invalid.get_output().stderr);
+    assert!(
+        invalid_stderr.contains("no-such-workspace"),
+        "an invalid explicit selector must be named: {invalid_stderr}"
+    );
+}
+
 fn task_ids(value: &Value) -> Vec<String> {
     let items = value
         .as_array()

--- a/crates/orbit-mcp/src/adapter/schema.rs
+++ b/crates/orbit-mcp/src/adapter/schema.rs
@@ -28,6 +28,13 @@ pub(super) fn ensure_workspace_selector(schema: &mut JsonObject, definition: &Mc
     if definition.scope != McpToolScope::WorkspaceRequired {
         return;
     }
+    // `orbit.task.show` still opens a workspace runtime, but `id` is globally
+    // resolved by default [ORB-10961]. The generic selector text would make
+    // clients inject cwd, initialize metadata, or a linked-worktree runtime
+    // identity. The tool declares its own optional filter instead.
+    if definition.schema.name == "orbit.task.show" {
+        return;
+    }
     let Some(properties) = schema.get_mut("properties").and_then(Value::as_object_mut) else {
         return;
     };

--- a/crates/orbit-mcp/src/adapter/tests/schema.rs
+++ b/crates/orbit-mcp/src/adapter/tests/schema.rs
@@ -165,8 +165,8 @@ fn advertised_properties(definition: &McpToolDefinition) -> serde_json::Map<Stri
 #[test]
 fn workspace_scoped_tool_advertises_the_authoritative_server_selector() {
     let definition = definition_with_scope(
-        "orbit.task.show",
-        vec![param("id")],
+        "orbit.task.list",
+        vec![param("limit")],
         McpToolScope::WorkspaceRequired,
     );
 
@@ -195,6 +195,55 @@ fn workspace_scoped_tool_advertises_the_authoritative_server_selector() {
     assert!(
         description.contains("absolute path registered on that server"),
         "selector must document the server-side path form: {description}"
+    );
+}
+
+#[test]
+fn task_show_skips_generic_workspace_selector_injection() {
+    let definition = definition_with_scope(
+        "orbit.task.show",
+        vec![param("id")],
+        McpToolScope::WorkspaceRequired,
+    );
+
+    let properties = advertised_properties(&definition);
+    assert!(
+        !properties.contains_key("workspace"),
+        "generic workspace-selection machinery must not inject a selector on task.show: {properties:?}"
+    );
+}
+
+#[test]
+fn task_show_own_workspace_param_documents_global_id_resolution() {
+    let declared = ToolParam {
+        name: "workspace".to_string(),
+        description: "Optional explicit workspace filter. `id` is resolved globally by default"
+            .to_string(),
+        param_type: "string".to_string(),
+        required: false,
+    };
+    let definition = definition_with_scope(
+        "orbit.task.show",
+        vec![param("id"), declared],
+        McpToolScope::WorkspaceRequired,
+    );
+
+    let properties = advertised_properties(&definition);
+    let workspace = properties
+        .get("workspace")
+        .and_then(Value::as_object)
+        .expect("task.show declares its own optional workspace filter");
+    let description = workspace
+        .get("description")
+        .and_then(Value::as_str)
+        .expect("filter carries routing guidance");
+    assert!(
+        description.contains("resolved globally by default"),
+        "task.show must document global id resolution: {description}"
+    );
+    assert!(
+        !description.contains("_meta.orbit.workspace"),
+        "generic session-default copy must not replace the task.show filter docs: {description}"
     );
 }
 

--- a/crates/orbit-tools/src/builtin/orbit/task/show.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/show.rs
@@ -8,7 +8,14 @@ pub struct OrbitTaskShowTool;
 
 impl Tool for OrbitTaskShowTool {
     fn schema(&self) -> ToolSchema {
-        let mut parameters = super::super::orbit_id_params("task");
+        let mut parameters = vec![ToolParam {
+            name: "id".to_string(),
+            description: "Globally unique task ID. Resolved through the host task registry by \
+                default; a workspace argument is not required."
+                .to_string(),
+            param_type: "string".to_string(),
+            required: true,
+        }];
         parameters.extend(super::super::identity_params());
         parameters.push(ToolParam {
             name: "fields".to_string(),
@@ -47,12 +54,28 @@ impl Tool for OrbitTaskShowTool {
             param_type: "integer".to_string(),
             required: false,
         });
+        parameters.push(ToolParam {
+            name: "workspace".to_string(),
+            description:
+                "Optional explicit workspace filter. `id` is resolved globally by default; do not \
+                pass cwd, MCP session/initialize metadata, or a linked-worktree runtime identity \
+                (for example `orbit-5c61b3`). When supplied, a registered workspace name, logical \
+                workspace ID (`ws_*`), or absolute local checkout path is fail-closed: a valid \
+                workspace that does not own the task returns not-found, and an unknown selector \
+                is rejected by name."
+                    .to_string(),
+            param_type: "string".to_string(),
+            required: false,
+        });
         ToolSchema {
             name: "orbit.task.show".to_string(),
-            description: "Fetch a single Orbit task as JSON. Use the optional `fields` projection \
-                (or single-field alias `field`) to retrieve only specific task fields, such as \
-                `field: \"orchestrator\"`. The `crew` field selects execution, while \
-                `orchestrator` records orchestration attribution."
+            description: "Fetch a single Orbit task as JSON. `id` is a globally unique primary \
+                key resolved through the host task registry by default; cwd, MCP initialize \
+                metadata, and linked-worktree runtime identities are not used as filters. An \
+                optional `workspace` argument is an explicit fail-closed filter only. Use the \
+                optional `fields` projection (or single-field alias `field`) to retrieve only \
+                specific task fields, such as `field: \"orchestrator\"`. The `crew` field \
+                selects execution, while `orchestrator` records orchestration attribution."
                 .to_string(),
             parameters,
             builtin: true,

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -403,6 +403,34 @@ fn task_show_schema_distinguishes_execution_crew_from_orchestrator() {
     assert!(fields.description.contains("orchestrator"));
     assert!(schema.description.contains("execution"));
     assert!(schema.description.contains("orchestration attribution"));
+    assert!(
+        schema.description.contains("globally unique"),
+        "task show must advertise global id resolution: {}",
+        schema.description
+    );
+    let id = schema
+        .parameters
+        .iter()
+        .find(|param| param.name == "id")
+        .expect("task show id parameter");
+    assert!(
+        id.description.contains("Globally unique"),
+        "id help must not send callers through workspace selection: {}",
+        id.description
+    );
+    let workspace = schema
+        .parameters
+        .iter()
+        .find(|param| param.name == "workspace")
+        .expect("task show optional workspace filter");
+    assert!(!workspace.required);
+    assert!(
+        workspace
+            .description
+            .contains("resolved globally by default"),
+        "workspace help must stay an explicit filter: {}",
+        workspace.description
+    );
 }
 
 #[test]

--- a/docs/design/host-registry/2_design.md
+++ b/docs/design/host-registry/2_design.md
@@ -126,7 +126,7 @@ RegisteredRuntimeFactory also carries replica ownership into Core's coordination
 
 ### CLI
 
-The main CLI opens ordinary runtimes through RegisteredRuntimeFactory using cwd, --root and optional --workspace. `task show` is the one exception: without --workspace it opens the checkout the coordination task registry names as the task ID's owner, so it works from a foreign checkout and from a directory that is no workspace at all, and it reports the owning workspace name and logical ID. With --workspace it is the ordinary registered bootstrap, and the selector filters. Workspace init, role, list, show, remove and teardown call orbit-registry directly for catalog operations. The only active host command is local rename.
+The main CLI opens ordinary runtimes through RegisteredRuntimeFactory using cwd, --root and optional --workspace. `task show` is the one exception, on both the human subcommand and `orbit tool run orbit.task.show`: without `--workspace` or a tool-input `workspace` it opens the checkout the coordination task registry names as the task ID's owner, so it works from a foreign checkout, a linked worktree, and from a directory that is no workspace at all, and it reports the owning workspace name and logical ID. With an explicit workspace selector it is the ordinary registered bootstrap, and the selector filters. Linked-worktree runtime identities are not selectors. Workspace init, role, list, show, remove and teardown call orbit-registry directly for catalog operations. The only active host command is local rename.
 
 There is no active v1 CLI surface for fleet host registration, enumeration or retirement, and no workspace owner-link command.
 
@@ -136,7 +136,7 @@ Orbit Web loads local workspaces from orbit-registry, derives checkout-path heal
 
 ### MCP
 
-orbit-mcp reads orbit-registry identity state to describe the accepting process and exposes machine-local discovery definitions. The CLI MCP server resolves each workspace-scoped call against the accepting machine's registry, composes the runtime, and dispatches through Core.
+orbit-mcp reads orbit-registry identity state to describe the accepting process and exposes machine-local discovery definitions. The CLI MCP server resolves each workspace-scoped call against the accepting machine's registry, composes the runtime, and dispatches through Core. `orbit.task.show` is the exception: an id-only call follows the globally unique task ID through the host task registry. Ambient initialize metadata — including a linked-worktree runtime identity — is not a filter. An explicit per-call `workspace` remains fail-closed.
 
 orbit.workspace.list returns active logical workspaces that have a checkout registered on the accepting machine. This includes locally registered replicas and excludes active checkoutless catalog entries; owner_machine_id is not a discovery filter. Remote MCP uses direct SSH stdio, and the local proxy does not resolve workspaces, inspect checkouts or read the remote registry.
 


### PR DESCRIPTION
## Task

[ORB-10961](https://orbit-cli.com/tasks/ORB-10961) — Make orbit.task.show global-by-default across tool run and MCP

### Description

## Problem

ORB-10797 made human `orbit task show <id>` and id-only MCP `orbit.task.show` resolve the globally unique task ID through the host task registry. Its implementation deliberately left `orbit tool run orbit.task.show` bound to cwd, and the MCP definition remains workspace-scoped enough that managed clients can supply or infer a checkout-local identity.

That split now fails in real managed worktrees. During ORB-10952 / `jrun-20260822-1758-3`, task inspection from:

`~/workspace/constellation/codebases/orbit/.orbit/state/worktrees/orbit-jrun-20260822-1758-3`

failed with:

```
invalid input: unknown workspace selector 'orbit-5c61b3'; pass a registered
workspace name, a logical workspace ID, or an absolute local checkout path
```

`orbit-5c61b3` is the legacy/runtime task-partition identity described in ORB-10797 and ORB-10448, not a registered logical selector. The caller already had the globally unique task ID `ORB-10952`; no workspace selection should have been required.

## Required Behavior

Make `orbit.task.show` global-by-default consistently on both agent-facing invocation surfaces:

- `orbit tool run orbit.task.show`
- MCP `orbit_task_show`

An id-only call must resolve the owning registered checkout through the machine-global task registry regardless of cwd, linked-worktree identity, or ambient MCP session workspace. Workspace routing remains required for other task verbs.

## Constraints / Notes

- Preserve ORB-10797's explicit-filter contract: a workspace selector deliberately supplied by the caller remains a fail-closed filter. A valid but wrong workspace returns task-not-found; an invalid explicit selector names the rejected selector.
- Distinguish a caller-supplied filter from ambient/injected execution context. A linked worktree's runtime identity must not be promoted into an explicit task-show filter.
- Update the advertised MCP/tool schema so clients understand that `id` is sufficient and do not synthesize a workspace argument merely because other task tools require one.
- Do not widen `task.list`, `task.update`, `task.start`, `task.add`, search, friction, or any other workspace-scoped operation.
- Reuse the shared task-owner resolver introduced by ORB-10797; do not add a second registry-join implementation.
- The exact ORB-10952 run evidence above is the regression fixture. Tests must use temp registries/worktrees and must not depend on live `.orbit/state` data.

### Acceptance Criteria

- `orbit tool run orbit.task.show --input '{"id":"<foreign-task-id>","model":"codex"}'` succeeds from an unrelated workspace, a linked worktree, and a non-workspace directory without `workspace` or `--root`, returning the task and its owning logical workspace identity.
- An MCP `orbit_task_show` call containing only `id` succeeds when initialize metadata is absent, names another workspace, or carries a linked-worktree/runtime identity such as `orbit-5c61b3`; ambient session context does not become an explicit filter.
- The ORB-10952 reproduction no longer emits `unknown workspace selector 'orbit-5c61b3'` on either tool-run or MCP.
- A caller-supplied valid workspace remains a strict filter: showing a task owned elsewhere returns task-not-found and does not expose the foreign task.
- A caller-supplied invalid workspace remains fail-closed and names the rejected selector; the fix does not silently discard deliberate filters.
- The advertised schema/help for `orbit.task.show` states that `id` is globally resolved by default and does not cause generic workspace-selection machinery to inject or require a workspace argument.
- No workspace-routing behavior changes for task list/update/start/add, search, friction, or other tools.
- Deterministic integration tests exercise the real `orbit tool run` and MCP transports with a linked worktree and a deliberately divergent logical workspace ID/runtime identity pair.
- Focused CLI, MCP, command-layer tests plus `make ci-fast` and lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Execution summary derived by Orbit for ORB-10961 from the change delivered by run jrun-20260822-1925-3; no execution summary was persisted by the implementing agent.

Changed files (18):
- modified: crates/orbit-cli/src/command/mcp/server.rs
- modified: crates/orbit-cli/src/command/operation.rs
- modified: crates/orbit-cli/src/command/task/mod.rs
- modified: crates/orbit-cli/src/command/task/show.rs
- modified: crates/orbit-cli/src/command/tests/operation.rs
- modified: crates/orbit-cli/src/command/tool/run.rs
- modified: crates/orbit-cli/src/command/tool/tests/run.rs
- modified: crates/orbit-cli/tests/mcp_roundtrip.rs
- modified: crates/orbit-cli/tests/output_goldens/tool_list.json
- modified: crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
- modified: crates/orbit-cli/tests/snapshots/mcp_tools_list.json
- modified: crates/orbit-cli/tests/tool_list.rs
- modified: crates/orbit-cli/tests/workspace_selector.rs
- modified: crates/orbit-mcp/src/adapter/schema.rs
- modified: crates/orbit-mcp/src/adapter/tests/schema.rs
- modified: crates/orbit-tools/src/builtin/orbit/task/show.rs
- modified: crates/orbit-tools/tests/public_tool_surface.rs
- modified: docs/design/host-registry/2_design.md

This restates the worktree change the delivery commit contains and asserts nothing beyond it. Re-check it with `git show --stat` on the delivery commit.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10961-6a89f7bd`
- Behind base: 0
- Ahead of base: 1