### PR TITLE
Make duplicate job-run Start delivery idempotent

### DIFF
--- a/crates/orbit-cli/src/output/json.rs
+++ b/crates/orbit-cli/src/output/json.rs
@@ -85,6 +85,7 @@ fn error_code(error: &OrbitError) -> &str {
         OrbitError::Store(_) => "store_error",
         OrbitError::TaskStatusTransition(_) => "task_status_transition",
         OrbitError::JobRunStateTransition(_) => "job_run_state_transition",
+        OrbitError::JobRunStartConflict(_) => "job_run_start_conflict",
         OrbitError::WorkspaceError(_) => "workspace_error",
         OrbitError::Io(_) => "io_error",
         OrbitError::AdrInvalidTransition(_) => "adr_invalid_transition",

--- a/crates/orbit-common/src/error.rs
+++ b/crates/orbit-common/src/error.rs
@@ -207,6 +207,14 @@ pub enum OrbitError {
     WorkspaceClaimHeld(Box<WorkspaceClaimHeld>),
     #[error("invalid job run state transition: {0}")]
     JobRunStateTransition(String),
+    /// [ORB-10965] A duplicate `Start` was applied to a job run that a
+    /// *different* process already owns. Distinct from
+    /// [`OrbitError::JobRunStateTransition`] on purpose: at-least-once delivery
+    /// makes this an expected race whose loser must yield to the incumbent,
+    /// not a state-machine violation, so callers can tell the two apart
+    /// without matching on message text.
+    #[error("job run start conflict: {0}")]
+    JobRunStartConflict(String),
     #[error("workspace error: {0}")]
     WorkspaceError(String),
     #[error("io error: {0}")]

--- a/crates/orbit-common/src/security/redaction.rs
+++ b/crates/orbit-common/src/security/redaction.rs
@@ -206,6 +206,9 @@ pub fn redact_sensitive_env_error(error: OrbitError) -> OrbitError {
         OrbitError::JobRunStateTransition(m) => {
             OrbitError::JobRunStateTransition(redact_sensitive_env_text(&m))
         }
+        OrbitError::JobRunStartConflict(m) => {
+            OrbitError::JobRunStartConflict(redact_sensitive_env_text(&m))
+        }
         OrbitError::Io(m) => OrbitError::Io(redact_sensitive_env_text(&m)),
         OrbitError::WorkspaceError(m) => OrbitError::WorkspaceError(redact_sensitive_env_text(&m)),
         OrbitError::Migration(m) => OrbitError::Migration(redact_sensitive_env_text(&m)),
@@ -324,6 +327,7 @@ pub fn redact_all_error(error: OrbitError) -> OrbitError {
             OrbitError::WorkspaceClaimHeld(redact_workspace_claim_held(*claim, redact_all))
         }
         OrbitError::JobRunStateTransition(m) => OrbitError::JobRunStateTransition(redact_all(&m)),
+        OrbitError::JobRunStartConflict(m) => OrbitError::JobRunStartConflict(redact_all(&m)),
         OrbitError::Io(m) => OrbitError::Io(redact_all(&m)),
         OrbitError::WorkspaceError(m) => OrbitError::WorkspaceError(redact_all(&m)),
         OrbitError::Migration(m) => OrbitError::Migration(redact_all(&m)),

--- a/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
@@ -22,7 +22,7 @@ use orbit_types::task::{
     push_external_ref_if_missing,
 };
 use orbit_types::telemetry::InvocationTrace;
-use orbit_types::workflow::{ActivityV2, JobRun, JobRunState};
+use orbit_types::workflow::{ActivityV2, JobRun, JobRunStartOutcome, JobRunState};
 use serde_json::Value;
 
 use crate::OrbitRuntime;
@@ -57,7 +57,7 @@ impl RuntimeHost for OrbitRuntime {
         run_id: &str,
         started_at: DateTime<Utc>,
         pid: u32,
-    ) -> Result<bool, OrbitError> {
+    ) -> Result<JobRunStartOutcome, OrbitError> {
         self.stores()
             .jobs()
             .mark_job_run_running(run_id, started_at, pid)

--- a/crates/orbit-core/src/application/job/exec.rs
+++ b/crates/orbit-core/src/application/job/exec.rs
@@ -16,7 +16,9 @@ use orbit_engine::{
 use orbit_store::contracts::{JobRunStepParams, TaskReservationReleaseReason};
 use orbit_types::record::OrbitEvent;
 use orbit_types::workflow::activity_job::{V2AuditEventKind, validate_job_retired_sessions};
-use orbit_types::workflow::{JobRun, JobRunState, JobTargetType, PipelineState};
+use orbit_types::workflow::{
+    JobRun, JobRunStartOutcome, JobRunState, JobTargetType, PipelineState,
+};
 use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
@@ -139,13 +141,25 @@ impl OrbitRuntime {
         self.seed_v2_pipeline_run(&run, &input, resume)?;
 
         let started_at = chrono::Utc::now();
-        let changed = self.stores().jobs().mark_job_run_running(
+        // [ORB-10965] This run was inserted moments ago by this very process,
+        // so it must win its own Start. Anything else means another owner
+        // reached it first, and running it here would duplicate execution.
+        match self.stores().jobs().mark_job_run_running(
             &run.run_id,
             started_at,
             std::process::id(),
-        )?;
-        if !changed {
-            return Err(OrbitError::not_found(NotFoundKind::JobRun, run.run_id));
+        )? {
+            JobRunStartOutcome::Started => {}
+            JobRunStartOutcome::NotFound => {
+                return Err(OrbitError::not_found(NotFoundKind::JobRun, run.run_id));
+            }
+            JobRunStartOutcome::AlreadyStarted => {
+                return Err(OrbitError::JobRunStartConflict(format!(
+                    "run '{}' was already started by this process; \
+                     refusing to execute it a second time",
+                    run.run_id
+                )));
+            }
         }
         self.record_run_crew_from_input(&run.run_id, &input)?;
         self.record_event(OrbitEvent::JobRunStarted {

--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -15,7 +15,9 @@ use orbit_store::contracts::{
 };
 use orbit_types::record::OrbitEvent;
 use orbit_types::telemetry::AuditEventStatus;
-use orbit_types::workflow::{JobRun, JobRunState, JobScheduleState, JobTargetType};
+use orbit_types::workflow::{
+    JobRun, JobRunStartOutcome, JobRunState, JobScheduleState, JobTargetType,
+};
 use orbit_types::workspace::WorkspacePaths;
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -642,15 +644,58 @@ impl OrbitRuntime {
             .max(PIPELINE_WAIT_MIN_POLL_SECONDS)
     }
 
+    /// [ORB-10965] Record a duplicate Start that was dropped without a second
+    /// execution.
+    ///
+    /// Delivery is at-least-once, so losing the Start race is an expected
+    /// outcome, not a fault: it is logged and audited as its own event and the
+    /// worker returns successfully, leaving the run's real state to the worker
+    /// that does own it.
+    fn record_deduplicated_start(&self, run: &JobRun, reason: &str) -> Result<(), OrbitError> {
+        tracing::info!(
+            target: "orbit.core.job_run",
+            run_id = %run.run_id,
+            job_id = %run.job_id,
+            attempt = run.attempt,
+            reason,
+            "duplicate job run start delivery deduplicated; the incumbent \
+             owner keeps execution authority",
+        );
+        self.record_event(OrbitEvent::JobRunStartDeduplicated {
+            job_id: run.job_id.clone(),
+            run_id: run.run_id.clone(),
+            attempt: run.attempt,
+            reason: reason.to_string(),
+        })
+    }
+
     fn execute_pipeline_run_now(&self, run: &JobRun, yaml_path: &Path) -> Result<(), OrbitError> {
         let started_at = Utc::now();
-        let changed = self.stores().jobs().mark_job_run_running(
+        // [ORB-10965] The state read in `execute_pipeline_run_worker` and this
+        // Start are separate transactions, so a second worker handed the same
+        // queued run can arrive here having also seen `pending`. The store
+        // arbitrates atomically; whoever does not win execution authority
+        // yields here, before any agent work.
+        let outcome = match self.stores().jobs().mark_job_run_running(
             &run.run_id,
             started_at,
             std::process::id(),
-        )?;
-        if !changed {
-            return Ok(());
+        ) {
+            Ok(outcome) => outcome,
+            Err(OrbitError::JobRunStartConflict(diagnostic)) => {
+                return self.record_deduplicated_start(run, &diagnostic);
+            }
+            Err(error) => return Err(error),
+        };
+        match outcome {
+            JobRunStartOutcome::Started => {}
+            JobRunStartOutcome::AlreadyStarted => {
+                return self.record_deduplicated_start(
+                    run,
+                    "this worker process had already started the run",
+                );
+            }
+            JobRunStartOutcome::NotFound => return Ok(()),
         }
         let input = run
             .input

--- a/crates/orbit-engine/src/context/hosts.rs
+++ b/crates/orbit-engine/src/context/hosts.rs
@@ -15,7 +15,7 @@ use orbit_types::task::{
 };
 use orbit_types::telemetry::InvocationTrace;
 use orbit_types::workflow::activity_job::Provider;
-use orbit_types::workflow::{ActivityV2, JobRun, JobRunState, PipelineState};
+use orbit_types::workflow::{ActivityV2, JobRun, JobRunStartOutcome, JobRunState, PipelineState};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::Path;
@@ -94,7 +94,7 @@ pub trait RuntimeHost: Send + Sync {
         run_id: &str,
         started_at: chrono::DateTime<chrono::Utc>,
         pid: u32,
-    ) -> Result<bool, OrbitError> {
+    ) -> Result<JobRunStartOutcome, OrbitError> {
         let _ = (run_id, started_at, pid);
         Err(unsupported_runtime_capability("mark_job_run_running"))
     }

--- a/crates/orbit-mcp/src/error.rs
+++ b/crates/orbit-mcp/src/error.rs
@@ -73,6 +73,10 @@ fn error_code(err: &OrbitError) -> &str {
         OrbitError::TaskStatusTransition(_)
         | OrbitError::JobRunStateTransition(_)
         | OrbitError::AdrInvalidTransition(_) => "invalid_transition",
+        // [ORB-10965] Not "invalid_transition": a duplicate start losing to the
+        // incumbent owner is an expected race, and the caller yields rather
+        // than treating its own request as malformed.
+        OrbitError::JobRunStartConflict(_) => "job_run_start_conflict",
         OrbitError::DependencyNotDelivered { .. } => "dependency_not_delivered",
         OrbitError::ShipRunInFlight { .. } => "ship_run_in_flight",
         OrbitError::WorkspaceClaimHeld(_) => "workspace_claim_held",

--- a/crates/orbit-store/src/contracts/traits.rs
+++ b/crates/orbit-store/src/contracts/traits.rs
@@ -8,7 +8,9 @@ use orbit_types::task::{
 };
 use orbit_types::telemetry::AuditEvent;
 use orbit_types::tool::StoredTool;
-use orbit_types::workflow::{ExecutorDef, JobRun, JobRunState, KnowledgeRunMetrics, PipelineState};
+use orbit_types::workflow::{
+    ExecutorDef, JobRun, JobRunStartOutcome, JobRunState, KnowledgeRunMetrics, PipelineState,
+};
 use serde_json::Value;
 use std::collections::BTreeMap;
 
@@ -324,12 +326,27 @@ pub trait JobRunStoreBackend: Send + Sync {
         input: Option<serde_json::Value>,
         retry_source_run_id: Option<String>,
     ) -> Result<JobRun, OrbitError>;
+    /// [ORB-10965] Apply a `Start` event to a run, atomically and idempotently.
+    ///
+    /// Scheduling is at-least-once, so this is the single point that decides
+    /// which of several competing or repeated deliveries owns execution. The
+    /// read of the current state and the write of the new one happen in one
+    /// immediate transaction, so exactly one caller can observe
+    /// [`JobRunStartOutcome::Started`].
+    ///
+    /// A redelivery from the owner already recorded on the run is a no-op:
+    /// [`JobRunStartOutcome::AlreadyStarted`], with `started_at`, the owner
+    /// identity, and every checkpoint left untouched. A delivery from a
+    /// *different* owner loses to the incumbent and fails with
+    /// [`OrbitError::JobRunStartConflict`]. Genuinely illegal transitions (a
+    /// `Start` from any state other than `pending`, `running`, or terminal)
+    /// still fail with [`OrbitError::JobRunStateTransition`].
     fn mark_job_run_running(
         &self,
         run_id: &str,
         started_at: DateTime<Utc>,
         pid: u32,
-    ) -> Result<bool, OrbitError>;
+    ) -> Result<JobRunStartOutcome, OrbitError>;
     /// [ORB-10070] Record `pid` (+ its start-time identity token) as the owner
     /// of a still-`pending` run so orphan reconciliation can distinguish a
     /// queued run with a live worker from one whose worker died. Returns

--- a/crates/orbit-store/src/driver/sqlite/job_run_store/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/job_run_store/mod.rs
@@ -5,7 +5,8 @@ use orbit_common::process::identity::process_start_identity_token;
 use orbit_common::{NotFoundKind, OrbitError};
 use orbit_types::identity::Crew;
 use orbit_types::workflow::{
-    JobRun, JobRunState, JobRunStep, JobTargetType, KnowledgeRunMetrics, PipelineState, RunEvent,
+    JobRun, JobRunStartOutcome, JobRunState, JobRunStep, JobTargetType, KnowledgeRunMetrics,
+    PipelineState, RunEvent,
 };
 use rusqlite::TransactionBehavior;
 
@@ -135,22 +136,56 @@ impl JobRunStoreBackend for SqliteJobRunStore {
         Ok(run)
     }
 
+    /// [ORB-10965] The single arbiter of job-run start authority.
+    ///
+    /// Deliberately not routed through [`Self::update_run`]: the decision and
+    /// the write must share one immediate transaction, and the duplicate cases
+    /// must write nothing at all rather than rewrite identical values.
     fn mark_job_run_running(
         &self,
         run_id: &str,
         started_at: DateTime<Utc>,
         pid: u32,
-    ) -> Result<bool, OrbitError> {
-        self.update_run(run_id, |run| {
-            run.state = run
-                .state
-                .try_transition(RunEvent::Start)
-                .map_err(OrbitError::JobRunStateTransition)?;
-            run.started_at = Some(started_at);
-            run.pid = Some(pid);
-            run.pid_start_time = process_start_identity_token(pid);
-            Ok(())
-        })
+    ) -> Result<JobRunStartOutcome, OrbitError> {
+        let pid_start_time = process_start_identity_token(pid);
+        self.store
+            .with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+                let Some(mut run) =
+                    get_job_run_for_workspace_conn(&tx.tx, &self.workspace_id, run_id)?
+                else {
+                    return Ok(JobRunStartOutcome::NotFound);
+                };
+
+                // A run that already left `pending` was started by someone.
+                // Duplicate at-least-once delivery from that same owner is a
+                // no-op; anyone else has lost the race to the incumbent.
+                if run.state == JobRunState::Running || run.state.is_terminal() {
+                    if run.is_owned_by(pid, pid_start_time.as_deref()) {
+                        return Ok(JobRunStartOutcome::AlreadyStarted);
+                    }
+                    return Err(OrbitError::JobRunStartConflict(format!(
+                        "run '{}' is already {} under owner pid {} (started at {}); \
+                         the start attempt from pid {} has no execution authority",
+                        run_id,
+                        run.state,
+                        run.pid
+                            .map_or_else(|| "unknown".to_string(), |owner| owner.to_string()),
+                        run.started_at
+                            .map_or_else(|| "unknown".to_string(), |at| at.to_rfc3339()),
+                        pid,
+                    )));
+                }
+
+                run.state = run
+                    .state
+                    .try_transition(RunEvent::Start)
+                    .map_err(OrbitError::JobRunStateTransition)?;
+                run.started_at = Some(started_at);
+                run.pid = Some(pid);
+                run.pid_start_time = pid_start_time;
+                upsert_job_run_for_workspace_conn(&tx.tx, &self.workspace_id, &run, None)?;
+                Ok(JobRunStartOutcome::Started)
+            })
     }
 
     fn claim_pending_job_run_owner(&self, run_id: &str, pid: u32) -> Result<bool, OrbitError> {
@@ -742,6 +777,7 @@ mod tests {
             backend
                 .mark_job_run_running(&run.run_id, scheduled_at, 42)
                 .expect("running")
+                .owns_execution()
         );
         let step_params = JobRunStepParams {
             step_index: 0,
@@ -801,6 +837,7 @@ mod tests {
             backend
                 .mark_job_run_running(&run.run_id, scheduled_at, 4242)
                 .expect("running")
+                .owns_execution()
         );
         assert!(
             !backend
@@ -874,6 +911,7 @@ mod tests {
             backend
                 .mark_job_run_running(&run.run_id, scheduled_at, 42)
                 .expect("running")
+                .owns_execution()
         );
 
         let mut state = PipelineState::new(
@@ -921,6 +959,203 @@ mod tests {
                 .expect("read state after finalize")
                 .is_some()
         );
+    }
+
+    /// [ORB-10965] At-least-once delivery redelivers a Start to the worker
+    /// that already owns the run. That is a no-op, not a state-machine
+    /// violation: no timestamp, owner identity, or checkpoint moves.
+    #[test]
+    fn duplicate_start_from_the_same_owner_is_a_no_op() {
+        let backend = SqliteJobRunStore::new(Store::open_in_memory().expect("store"), "ws_a");
+        let pid = std::process::id();
+        let run = backend
+            .insert_job_run("job-dup", 1, Utc::now(), None, None)
+            .expect("insert");
+
+        let first_started_at = Utc::now();
+        assert_eq!(
+            backend
+                .mark_job_run_running(&run.run_id, first_started_at, pid)
+                .expect("first start"),
+            JobRunStartOutcome::Started
+        );
+        let claimed = backend
+            .get_job_run(&run.run_id)
+            .expect("get")
+            .expect("some");
+
+        let mut state = PipelineState::new(
+            run.run_id.clone(),
+            run.job_id.clone(),
+            serde_json::json!({"seconds": 0}),
+        );
+        state.record_step(0, JobRunState::Success, None, None);
+        backend
+            .write_run_state(&run.run_id, &state)
+            .expect("write checkpoint");
+
+        // The redelivery carries a later timestamp; the incumbent's stays.
+        let outcome = backend
+            .mark_job_run_running(&run.run_id, first_started_at + Duration::from_secs(30), pid)
+            .expect("redelivered start succeeds");
+        assert_eq!(outcome, JobRunStartOutcome::AlreadyStarted);
+        assert!(
+            !outcome.owns_execution(),
+            "a redelivery must not grant a second execution"
+        );
+
+        let after = backend
+            .get_job_run(&run.run_id)
+            .expect("get")
+            .expect("some");
+        assert_eq!(after.state, JobRunState::Running);
+        assert_eq!(after.started_at, claimed.started_at);
+        assert_eq!(after.pid, Some(pid));
+        assert_eq!(after.pid_start_time, claimed.pid_start_time);
+        assert_eq!(
+            backend
+                .read_run_state(&run.run_id)
+                .expect("read checkpoint")
+                .expect("checkpoint survives")
+                .step_states
+                .get(&0),
+            Some(&JobRunState::Success),
+            "checkpoints must survive a deduplicated start"
+        );
+    }
+
+    /// [ORB-10965] A duplicate Start whose owner differs from the incumbent's
+    /// is reported as a conflict naming both, not as a generic transition
+    /// error, so the loser can yield instead of failing the run.
+    #[test]
+    fn duplicate_start_from_a_different_owner_is_a_specific_conflict() {
+        let backend = SqliteJobRunStore::new(Store::open_in_memory().expect("store"), "ws_a");
+        let incumbent = std::process::id();
+        let run = backend
+            .insert_job_run("job-conflict", 1, Utc::now(), None, None)
+            .expect("insert");
+        let started_at = Utc::now();
+        backend
+            .mark_job_run_running(&run.run_id, started_at, incumbent)
+            .expect("incumbent start");
+
+        let challenger = incumbent + 1;
+        let error = backend
+            .mark_job_run_running(&run.run_id, Utc::now(), challenger)
+            .expect_err("a competing owner has no authority");
+        let message = match &error {
+            OrbitError::JobRunStartConflict(message) => message.clone(),
+            other => panic!("expected a start conflict, got {other:?}"),
+        };
+        assert!(message.contains(&incumbent.to_string()), "{message}");
+        assert!(message.contains(&challenger.to_string()), "{message}");
+
+        let after = backend
+            .get_job_run(&run.run_id)
+            .expect("get")
+            .expect("some");
+        assert_eq!(after.state, JobRunState::Running);
+        assert_eq!(after.pid, Some(incumbent));
+
+        // The same rule holds once the run has finished: a late duplicate
+        // cannot reopen a terminal run, and the refusal still names the race.
+        backend
+            .finalize_job_run(&run.run_id, JobRunState::Success, Utc::now(), Some(5))
+            .expect("finalize");
+        assert!(matches!(
+            backend.mark_job_run_running(&run.run_id, Utc::now(), challenger),
+            Err(OrbitError::JobRunStartConflict(_))
+        ));
+        assert_eq!(
+            backend
+                .mark_job_run_running(&run.run_id, Utc::now(), incumbent)
+                .expect("owner redelivery after completion"),
+            JobRunStartOutcome::AlreadyStarted
+        );
+        assert_eq!(
+            backend
+                .get_job_run(&run.run_id)
+                .expect("get")
+                .expect("some")
+                .state,
+            JobRunState::Success,
+            "a duplicate start must not resurrect a finished run"
+        );
+    }
+
+    /// [ORB-10965] Deduplication is scoped to states a Start can legitimately
+    /// race with. A Start from `retrying` is still a genuine state-machine
+    /// violation and keeps rejecting.
+    #[test]
+    fn start_from_an_illegal_state_still_rejects_as_a_transition_error() {
+        let backend = SqliteJobRunStore::new(Store::open_in_memory().expect("store"), "ws_a");
+        let run = backend
+            .insert_job_run("job-illegal", 1, Utc::now(), None, None)
+            .expect("insert");
+        let mut retrying = run.clone();
+        retrying.state = JobRunState::Retrying;
+        backend
+            .store
+            .upsert_job_run_for_workspace("ws_a", &retrying, None)
+            .expect("force retrying state");
+
+        assert!(matches!(
+            backend.mark_job_run_running(&run.run_id, Utc::now(), std::process::id()),
+            Err(OrbitError::JobRunStateTransition(_))
+        ));
+    }
+
+    /// [ORB-10965] The duplicate-delivery race itself: two workers hand the
+    /// same queued run to the store at the same instant. The immediate
+    /// transaction serializes them, so exactly one is granted execution.
+    #[test]
+    fn competing_starts_grant_execution_authority_to_exactly_one_worker() {
+        let temp = TempDir::new().expect("tempdir");
+        let db_path = temp.path().join("orbit.db");
+        let backend_a = SqliteJobRunStore::new(Store::open(&db_path).expect("store a"), "ws_a");
+        let backend_b = SqliteJobRunStore::new(Store::open(&db_path).expect("store b"), "ws_a");
+        let run = backend_a
+            .insert_job_run("job-race", 1, Utc::now(), None, None)
+            .expect("insert");
+        let run_id = run.run_id.clone();
+        let barrier = Arc::new(Barrier::new(2));
+
+        let mut workers = Vec::new();
+        for (backend, pid) in [(backend_a, 100_001_u32), (backend_b, 100_002_u32)] {
+            let run_id = run_id.clone();
+            let barrier = Arc::clone(&barrier);
+            workers.push(thread::spawn(move || {
+                barrier.wait();
+                (pid, backend.mark_job_run_running(&run_id, Utc::now(), pid))
+            }));
+        }
+        let results: Vec<(u32, Result<JobRunStartOutcome, OrbitError>)> = workers
+            .into_iter()
+            .map(|worker| worker.join().expect("worker"))
+            .collect();
+
+        let winners: Vec<u32> = results
+            .iter()
+            .filter(|(_, result)| matches!(result, Ok(outcome) if outcome.owns_execution()))
+            .map(|(pid, _)| *pid)
+            .collect();
+        assert_eq!(
+            winners.len(),
+            1,
+            "exactly one worker may advance: {results:?}"
+        );
+        assert!(
+            results.iter().any(|(pid, result)| *pid != winners[0]
+                && matches!(result, Err(OrbitError::JobRunStartConflict(_)))),
+            "the loser must yield with a start conflict: {results:?}"
+        );
+
+        let stored = SqliteJobRunStore::new(Store::open(&db_path).expect("store c"), "ws_a")
+            .get_job_run(&run_id)
+            .expect("read")
+            .expect("run");
+        assert_eq!(stored.state, JobRunState::Running);
+        assert_eq!(stored.pid, Some(winners[0]));
     }
 
     #[test]

--- a/crates/orbit-types/src/record/event.rs
+++ b/crates/orbit-types/src/record/event.rs
@@ -46,6 +46,16 @@ pub enum OrbitEvent {
         run_id: String,
         state: String,
     },
+    /// [ORB-10965] A duplicate `Start` delivery was recognized and dropped
+    /// without a second execution. At-least-once scheduling makes this an
+    /// expected outcome, so it is recorded as its own event rather than as a
+    /// failed run.
+    JobRunStartDeduplicated {
+        job_id: String,
+        run_id: String,
+        attempt: u32,
+        reason: String,
+    },
     JobProtocolViolation {
         job_id: String,
         run_id: String,

--- a/crates/orbit-types/src/record/tests/event.rs
+++ b/crates/orbit-types/src/record/tests/event.rs
@@ -1,0 +1,35 @@
+//! [ORB-10965] Audit reads events through their serialized tag, so the shape of
+//! the deduplicated-start record is the contract.
+
+use serde_json::json;
+
+use crate::record::OrbitEvent;
+
+#[test]
+fn deduplicated_start_serializes_as_its_own_event_type() {
+    let event = OrbitEvent::JobRunStartDeduplicated {
+        job_id: "job-a".to_string(),
+        run_id: "jrun-a".to_string(),
+        attempt: 2,
+        reason: "another worker owns the run".to_string(),
+    };
+
+    let payload = serde_json::to_value(&event).expect("serialize");
+    assert_eq!(
+        payload,
+        json!({
+            "type": "JobRunStartDeduplicated",
+            "data": {
+                "job_id": "job-a",
+                "run_id": "jrun-a",
+                "attempt": 2,
+                "reason": "another worker owns the run",
+            }
+        }),
+        "a deduplicated start is recorded on its own, never as a run failure"
+    );
+    assert_eq!(
+        serde_json::from_value::<OrbitEvent>(payload).expect("round trip"),
+        event
+    );
+}

--- a/crates/orbit-types/src/record/tests/mod.rs
+++ b/crates/orbit-types/src/record/tests/mod.rs
@@ -1,3 +1,4 @@
 mod adr;
 mod crew_discovery;
+mod event;
 mod friction;

--- a/crates/orbit-types/src/workflow/job.rs
+++ b/crates/orbit-types/src/workflow/job.rs
@@ -102,6 +102,34 @@ pub enum JobRunState {
     Interrupted,
 }
 
+/// [ORB-10965] Outcome of applying a `Start` event to a job run.
+///
+/// Scheduling is at-least-once, so the same queued run can be delivered to two
+/// workers, or redelivered to the worker that already owns it. Start is
+/// therefore idempotent *per owner*: exactly one caller is granted execution
+/// authority, and a duplicate delivery from that same owner is a no-op rather
+/// than a state-machine violation. A duplicate from a *different* owner is a
+/// conflict — the incumbent keeps authority — and is reported separately so
+/// the caller can distinguish it from a genuinely illegal transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JobRunStartOutcome {
+    /// This caller won the transition into `running` and owns execution.
+    Started,
+    /// The run had already been started by an equivalent owner. Nothing was
+    /// written; the first Start still owns execution.
+    AlreadyStarted,
+    /// No run with the requested id exists.
+    NotFound,
+}
+
+impl JobRunStartOutcome {
+    /// True only for the single caller that won the transition. Every other
+    /// outcome — including a same-owner redelivery — must not execute the run.
+    pub fn owns_execution(self) -> bool {
+        matches!(self, Self::Started)
+    }
+}
+
 /// Events that drive job run state transitions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RunEvent {
@@ -459,4 +487,17 @@ pub struct JobRun {
     /// Step execution results; populated in-memory from step files, not stored in jrun.yaml.
     #[serde(skip)]
     pub steps: Vec<JobRunStep>,
+}
+
+impl JobRun {
+    /// [ORB-10965] Whether `pid` — paired with its process start-time identity
+    /// token, so a reused PID is not mistaken for the original — is the owner
+    /// already recorded on this run.
+    ///
+    /// Owner identity is the equivalence key for a duplicate `Start`. The
+    /// `started_at` instant deliberately is not: every redelivery carries a
+    /// fresh timestamp, and the incumbent's value stays authoritative.
+    pub fn is_owned_by(&self, pid: u32, pid_start_time: Option<&str>) -> bool {
+        self.pid == Some(pid) && self.pid_start_time.as_deref() == pid_start_time
+    }
 }

--- a/crates/orbit-types/src/workflow/mod.rs
+++ b/crates/orbit-types/src/workflow/mod.rs
@@ -38,9 +38,10 @@ pub use executor_def::{
     ExecutorDef, ExecutorSandboxKind, ExecutorType, ModelPairOverride, StdoutFormat,
 };
 pub use job::{
-    AgentCommitRequest, AgentResponseEnvelope, AgentRunError, Job, JobRun, JobRunState, JobRunStep,
-    JobScheduleState, JobStep, JobTargetType, KnowledgeRunMetrics, RunEvent, StepCondition,
-    default_job_max_active_runs, default_max_iterations, default_retry_backoff_seconds,
+    AgentCommitRequest, AgentResponseEnvelope, AgentRunError, Job, JobRun, JobRunStartOutcome,
+    JobRunState, JobRunStep, JobScheduleState, JobStep, JobTargetType, KnowledgeRunMetrics,
+    RunEvent, StepCondition, default_job_max_active_runs, default_max_iterations,
+    default_retry_backoff_seconds,
 };
 pub use routine::{
     MissedRunPolicy, OverlapPolicy, ROUTINE_SCHEMA_VERSION, RoutineDefinition, RoutinePolicy,

--- a/crates/orbit-types/src/workflow/tests/job.rs
+++ b/crates/orbit-types/src/workflow/tests/job.rs
@@ -54,3 +54,56 @@ fn interrupted_display_and_parse_round_trip() {
 fn interrupted_is_a_valid_step_state() {
     assert!(JobRunState::Interrupted.validate_step_state().is_ok());
 }
+
+/// [ORB-10965] Only the caller that won the transition may execute the run;
+/// every duplicate delivery, including one from the owner itself, must not.
+#[test]
+fn only_a_won_start_grants_execution_authority() {
+    use crate::workflow::JobRunStartOutcome;
+
+    assert!(JobRunStartOutcome::Started.owns_execution());
+    assert!(!JobRunStartOutcome::AlreadyStarted.owns_execution());
+    assert!(!JobRunStartOutcome::NotFound.owns_execution());
+}
+
+/// [ORB-10965] Owner identity — pid paired with its start-time token — is the
+/// equivalence key for a duplicate Start. A reused pid is not the same owner.
+#[test]
+fn run_owner_equivalence_pairs_pid_with_its_start_time_token() {
+    use chrono::Utc;
+
+    use crate::workflow::JobRun;
+
+    let now = Utc::now();
+    let mut run = JobRun {
+        run_id: "jrun-owner".to_string(),
+        job_id: "job-owner".to_string(),
+        attempt: 1,
+        state: JobRunState::Running,
+        scheduled_at: now,
+        started_at: Some(now),
+        finished_at: None,
+        duration_ms: None,
+        created_at: now,
+        pid: Some(4242),
+        pid_start_time: Some("v1:99".to_string()),
+        input: None,
+        retry_source_run_id: None,
+        knowledge_metrics: None,
+        resolved_crew: None,
+        crew_model: None,
+        steps: Vec::new(),
+    };
+
+    assert!(run.is_owned_by(4242, Some("v1:99")));
+    assert!(
+        !run.is_owned_by(4242, Some("v1:100")),
+        "a reused pid with a different start time is a different process"
+    );
+    assert!(!run.is_owned_by(4243, Some("v1:99")));
+
+    // A host that cannot produce a start-time token still compares by pid.
+    run.pid_start_time = None;
+    assert!(run.is_owned_by(4242, None));
+    assert!(!run.is_owned_by(4242, Some("v1:99")));
+}

--- a/crates/orbit-web/src/api/mod.rs
+++ b/crates/orbit-web/src/api/mod.rs
@@ -264,6 +264,17 @@ pub(super) fn map_runtime_error(e: orbit_core::OrbitError) -> Response {
         error @ orbit_core::OrbitError::WorkspaceClaimHeld(_) => {
             workspace_claim_held_conflict(error)
         }
+        // [ORB-10965] A duplicate run start that lost to the incumbent owner is
+        // a conflict, not a server fault: the request was well-formed and
+        // another worker simply got there first.
+        orbit_core::OrbitError::JobRunStartConflict(message) => (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "error": message,
+                "code": "job_run_start_conflict",
+            })),
+        )
+            .into_response(),
         other => server_error(other),
     }
 }


### PR DESCRIPTION
## Task

[ORB-10965](https://orbit-cli.com/tasks/ORB-10965) — Make duplicate job-run Start delivery idempotent

### Description

## Problem
Two separate runs in the 2026-08-22 audit window emitted `invalid job run state transition: running + Start`. The signature indicates duplicate worker delivery or competing start paths are attempting the same lifecycle transition after the run is already running.

## Why It Matters
At-least-once scheduling and process races must not turn a successfully claimed run into an audit failure or trigger duplicate execution. Start handling needs one atomic, explicitly idempotent contract.

## Constraints / Notes
Do not weaken rejection of genuinely illegal transitions or reset started timestamps, ownership, checkpoints, or reservations. Establish which duplicate has authority when metadata differs.

### Acceptance Criteria

- Reapplying an equivalent Start event to an already-running run succeeds as a no-op and does not change started_at, owner identity, checkpoints, task reservations, or execution count.
- Competing Start attempts are resolved atomically so at most one worker obtains execution authority.
- A non-equivalent duplicate Start with conflicting owner or immutable metadata fails with a specific conflict diagnostic rather than a generic state-transition error.
- Deterministic concurrency tests reproduce duplicate delivery and prove that only one execution path advances.
- Audit output records the deduplicated Start outcome without classifying it as an unexpected failed tool or job-run event.

## Execution Summary

<details>
<summary>Click to expand</summary>

Execution summary derived by Orbit for ORB-10965 from the change delivered by run jrun-20260822-2030-8; no execution summary was persisted by the implementing agent.

Changed files (17):
- modified: crates/orbit-cli/src/output/json.rs
- modified: crates/orbit-common/src/error.rs
- modified: crates/orbit-common/src/security/redaction.rs
- modified: crates/orbit-core/src/adapter/engine_host/runtime_host.rs
- modified: crates/orbit-core/src/application/job/exec.rs
- modified: crates/orbit-core/src/application/job/pipeline.rs
- modified: crates/orbit-engine/src/context/hosts.rs
- modified: crates/orbit-mcp/src/error.rs
- modified: crates/orbit-store/src/contracts/traits.rs
- modified: crates/orbit-store/src/driver/sqlite/job_run_store/mod.rs
- modified: crates/orbit-types/src/record/event.rs
- added: crates/orbit-types/src/record/tests/event.rs
- modified: crates/orbit-types/src/record/tests/mod.rs
- modified: crates/orbit-types/src/workflow/job.rs
- modified: crates/orbit-types/src/workflow/mod.rs
- modified: crates/orbit-types/src/workflow/tests/job.rs
- modified: crates/orbit-web/src/api/mod.rs

This restates the worktree change the delivery commit contains and asserts nothing beyond it. Re-check it with `git show --stat` on the delivery commit.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10965-6a8a06fc`
- Behind base: 0
- Ahead of base: 1