### PR TITLE
Keep read-only Orbit tool calls free of incidental writes

### DIFF
--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -1508,6 +1508,246 @@ fn serve_mcp_from(cwd: &Path, home: &Path, initialize: Value) -> McpClient {
     client
 }
 
+/// ORB-10963: managed executors may see the primary Orbit state through a
+/// read-only mount while their linked checkout remains writable. Exercise the
+/// production CLI and MCP entry points inside that mount namespace rather than
+/// approximating the boundary with permission bits.
+#[cfg(target_os = "linux")]
+#[test]
+fn readonly_state_mount_keeps_cli_and_mcp_reads_observational() {
+    if !bubblewrap_mount_namespaces_available() {
+        // Some nested container runners deny user/mount namespaces. The
+        // production behavior remains covered by the focused store and
+        // dispatch tests; an unrestricted Linux CI runner executes this path.
+        return;
+    }
+
+    let workspace = McpWorkspace::init();
+    let add_input = json!({
+        "title": "Read-only managed fixture",
+        "description": "State is warmed before it is remounted read-only",
+        "workspace": workspace.work,
+        "complexity": "low",
+        "model": "codex",
+    })
+    .to_string();
+    let created = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args(["tool", "run", "orbit.task.add", "--input", &add_input])
+        .output()
+        .expect("create the fixture task");
+    assert_command_succeeded("fixture task add", &created);
+    let created: Value = serde_json::from_slice(&created.stdout).expect("parse fixture task");
+    let task_id = created["id"].as_str().expect("fixture task id");
+
+    // Materialize every optional cache/import/index before the mount changes.
+    // The assertions below still prove that opening and reading those stores
+    // does not require a new sidecar, access-time, or audit write.
+    let warm_search = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args([
+            "tool",
+            "run",
+            "orbit.search",
+            "--input",
+            &json!({
+                "query": "read-only managed fixture",
+                "workspace": workspace.work,
+                "model": "codex"
+            })
+            .to_string(),
+        ])
+        .output()
+        .expect("warm fixture search state");
+    assert_command_succeeded("fixture search warmup", &warm_search);
+
+    let worktree = add_linked_worktree(&workspace.work);
+    let state_root = workspace.work.join(".orbit");
+
+    let tool_list = readonly_orbit_command(&worktree, &workspace.home, &state_root)
+        .args(["tool", "list", "--json"])
+        .output()
+        .expect("list tools through the read-only mount");
+    assert_command_succeeded("read-only orbit.tool.list", &tool_list);
+
+    for (name, input) in [
+        (
+            "orbit.task.show",
+            json!({ "id": task_id, "model": "codex" }),
+        ),
+        (
+            "orbit.task.list",
+            json!({ "workspace": workspace.work, "model": "codex" }),
+        ),
+        (
+            "orbit.search",
+            json!({
+                "query": "read-only managed fixture",
+                "workspace": workspace.work,
+                "model": "codex"
+            }),
+        ),
+    ] {
+        let output = readonly_orbit_command(&worktree, &workspace.home, &state_root)
+            .args([
+                "tool",
+                "run",
+                name,
+                "--root",
+                state_root.to_str().expect("utf8 Orbit root"),
+                "--input",
+                &input.to_string(),
+            ])
+            .output()
+            .unwrap_or_else(|error| panic!("run {name} through the read-only mount: {error}"));
+        assert_command_succeeded(name, &output);
+    }
+
+    let mutation = readonly_orbit_command(&worktree, &workspace.home, &state_root)
+        .args([
+            "tool",
+            "run",
+            "orbit.task.update",
+            "--root",
+            state_root.to_str().expect("utf8 Orbit root"),
+            "--input",
+            &json!({
+                "id": task_id,
+                "execution_summary": "must not persist",
+                "model": "codex"
+            })
+            .to_string(),
+        ])
+        .output()
+        .expect("attempt task mutation through the read-only mount");
+    assert_readonly_mutation_failed("CLI", &mutation);
+
+    let mut child = readonly_orbit_command(&worktree, &workspace.home, &state_root);
+    child
+        .args([
+            "mcp",
+            "serve",
+            "--root",
+            state_root.to_str().expect("utf8 Orbit root"),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut client = McpClient::new(child.spawn().expect("spawn read-only MCP server"));
+    let initialize = json!({
+        "protocolVersion": "2025-06-18",
+        "capabilities": {},
+        "clientInfo": { "name": "readonly-managed-executor", "version": "0" },
+        "_meta": { "orbit": { "workspace": worktree } },
+    });
+    let initialized = client.request("initialize", initialize);
+    assert_eq!(initialized["result"]["protocolVersion"], "2025-06-18");
+    client.notify("notifications/initialized");
+
+    let listed = client.request("tools/list", Value::Null);
+    assert!(listed["result"]["tools"].is_array(), "{listed}");
+    assert_eq!(
+        client.call_tool_ok("orbit_task_show", json!({ "id": task_id }))["id"],
+        task_id
+    );
+    assert!(client.call_tool_ok("orbit_task_list", json!({}))["items"].is_array());
+    assert_eq!(
+        client.call_tool_ok(
+            "orbit_search",
+            json!({ "query": "read-only managed fixture", "model": "codex" })
+        )["mode"],
+        "lexical"
+    );
+    let mutation = client.call_tool_err(
+        "orbit_task_update",
+        json!({
+            "id": task_id,
+            "execution_summary": "must not persist",
+            "model": "codex"
+        }),
+    );
+    assert_readonly_diagnostic("MCP", mutation["message"].as_str().unwrap_or_default());
+}
+
+#[cfg(target_os = "linux")]
+fn bubblewrap_mount_namespaces_available() -> bool {
+    Command::new("bwrap")
+        .args([
+            "--die-with-parent",
+            "--ro-bind",
+            "/",
+            "/",
+            "--",
+            "/bin/true",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(target_os = "linux")]
+fn readonly_orbit_command(worktree: &Path, home: &Path, state_root: &Path) -> Command {
+    let mut command = Command::new("bwrap");
+    command
+        .args(["--die-with-parent", "--bind", "/", "/"])
+        .arg("--ro-bind")
+        .arg(state_root)
+        .arg(state_root)
+        .arg("--ro-bind")
+        .arg(home.join(".orbit"))
+        .arg(home.join(".orbit"))
+        .arg("--chdir")
+        .arg(worktree)
+        .arg("--setenv")
+        .arg("HOME")
+        .arg(home)
+        .arg("--setenv")
+        .arg("USERPROFILE")
+        .arg(home)
+        .arg("--setenv")
+        .arg("PATH")
+        .arg(stub_first_path(&McpWorkspace::stub_bin_dir(home)))
+        .arg("--setenv")
+        .arg("ORBIT_ROOT")
+        .arg(state_root)
+        .arg("--")
+        .arg(env!("CARGO_BIN_EXE_orbit"));
+    command
+}
+
+#[cfg(target_os = "linux")]
+fn assert_command_succeeded(label: &str, output: &std::process::Output) {
+    assert!(
+        output.status.success(),
+        "{label} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(target_os = "linux")]
+fn assert_readonly_mutation_failed(label: &str, output: &std::process::Output) {
+    assert!(
+        !output.status.success(),
+        "{label} mutation unexpectedly succeeded"
+    );
+    assert_readonly_diagnostic(label, &String::from_utf8_lossy(&output.stderr));
+}
+
+#[cfg(target_os = "linux")]
+fn assert_readonly_diagnostic(label: &str, diagnostic: &str) {
+    assert!(
+        diagnostic.contains(".task.yaml.lock"),
+        "{label} diagnostic must attribute the task path: {diagnostic}"
+    );
+    let normalized = diagnostic.to_ascii_lowercase();
+    assert!(
+        normalized.contains("read-only file system")
+            || normalized.contains("permission denied")
+            || normalized.contains("not writable"),
+        "{label} diagnostic must identify EROFS/EACCES: {diagnostic}"
+    );
+}
+
 /// Commit the checkout and attach a linked worktree, mirroring how the engine
 /// stages a managed run.
 fn add_linked_worktree(work: &Path) -> PathBuf {

--- a/crates/orbit-common/src/error.rs
+++ b/crates/orbit-common/src/error.rs
@@ -338,6 +338,24 @@ impl OrbitError {
                 .unwrap_or_else(|| err.to_string()),
         )
     }
+
+    /// Whether an operation failed because its persistence target is mounted
+    /// read-only or denies writes.
+    ///
+    /// Filesystem and SQLite adapters currently translate their native errors
+    /// at different crate boundaries. Keep the recognition here so passive
+    /// bootstrap, cache, and telemetry callers do not each grow a partial list
+    /// of platform and SQLite spellings.
+    pub fn is_readonly_or_access_failure(&self) -> bool {
+        let message = self.to_string().to_ascii_lowercase();
+        message.contains("read-only file system")
+            || message.contains("readonly filesystem")
+            || message.contains("permission denied")
+            || message.contains("attempt to write a readonly database")
+            || message.contains("database is read-only")
+            || message.contains("database is readonly")
+            || message.contains(" is not writable:")
+    }
 }
 
 impl From<std::io::Error> for OrbitError {

--- a/crates/orbit-common/src/storage/sqlite.rs
+++ b/crates/orbit-common/src/storage/sqlite.rs
@@ -8,7 +8,9 @@
 //! store-specific overrides (e.g. the task registry's `synchronous=FULL`)
 //! on top.
 
-use rusqlite::Connection;
+use std::path::Path;
+
+use rusqlite::{Connection, OpenFlags};
 
 use crate::OrbitError;
 
@@ -25,6 +27,10 @@ pub struct PragmaOutcome {
     /// convention (`wal`, `memory` for in-memory databases, or a fallback
     /// such as `delete` when the filesystem refuses WAL sidecars).
     pub journal_mode: String,
+    /// The connection refused a persistence pragma because its backing store
+    /// is read-only. Callers that need sidecar-free reads should reopen it as
+    /// an immutable SQLite URI.
+    pub write_denied: bool,
 }
 
 impl PragmaOutcome {
@@ -48,20 +54,104 @@ impl PragmaOutcome {
 ///   that need commit-durable acks (e.g. the task registry) override to
 ///   `FULL` after calling this.
 pub fn apply_default_pragmas(conn: &Connection) -> Result<PragmaOutcome, OrbitError> {
-    let journal_mode = request_wal_journal_mode(conn);
+    let (journal_mode, mut write_denied) = request_wal_journal_mode(conn);
     conn.pragma_update(None, "busy_timeout", DEFAULT_BUSY_TIMEOUT_MS)
         .map_err(|e| OrbitError::Store(format!("failed to set busy_timeout: {e}")))?;
     conn.pragma_update(None, "foreign_keys", "ON")
         .map_err(|e| OrbitError::Store(format!("failed to enable foreign keys: {e}")))?;
-    conn.pragma_update(None, "synchronous", "NORMAL")
-        .map_err(|e| OrbitError::Store(format!("failed to set synchronous=NORMAL: {e}")))?;
-    Ok(PragmaOutcome { journal_mode })
+    if let Err(error) = conn.pragma_update(None, "synchronous", "NORMAL") {
+        let mapped = OrbitError::Store(format!("failed to set synchronous=NORMAL: {error}"));
+        if mapped.is_readonly_or_access_failure() {
+            write_denied = true;
+            tracing::warn!(
+                target: "orbit.common.sqlite",
+                error = %error,
+                "could not set synchronous=NORMAL on a read-only database; continuing for reads"
+            );
+        } else {
+            return Err(mapped);
+        }
+    }
+    Ok(PragmaOutcome {
+        journal_mode,
+        write_denied,
+    })
+}
+
+/// Open an existing SQLite database without creating WAL/SHM sidecars.
+///
+/// `immutable=1` is required for a database on a genuinely read-only mount:
+/// SQLite's ordinary read-only mode may still try to create WAL shared-memory
+/// state before the first SELECT.
+pub fn open_immutable(path: &Path) -> Result<Connection, OrbitError> {
+    let mut uri = url::Url::from_file_path(path).map_err(|()| {
+        OrbitError::Store(format!(
+            "cannot represent SQLite path '{}' as a file URI",
+            path.display()
+        ))
+    })?;
+    uri.query_pairs_mut().append_pair("immutable", "1");
+    let conn = Connection::open_with_flags(
+        uri.as_str(),
+        OpenFlags::SQLITE_OPEN_READ_ONLY
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX
+            | OpenFlags::SQLITE_OPEN_URI,
+    )
+    .map_err(|error| {
+        OrbitError::Store(format!(
+            "cannot open SQLite database '{}' for immutable reads: {error}",
+            path.display()
+        ))
+    })?;
+    conn.pragma_update(None, "query_only", "ON")
+        .map_err(|error| OrbitError::Store(format!("failed to set query_only: {error}")))?;
+    conn.pragma_update(None, "busy_timeout", DEFAULT_BUSY_TIMEOUT_MS)
+        .map_err(|error| OrbitError::Store(format!("failed to set busy_timeout: {error}")))?;
+    conn.pragma_update(None, "foreign_keys", "ON")
+        .map_err(|error| OrbitError::Store(format!("failed to enable foreign keys: {error}")))?;
+    Ok(conn)
+}
+
+/// Whether `path` resides on a filesystem mounted read-only.
+///
+/// SQLite can successfully open a database with read-write flags on such a
+/// mount and only discover the restriction at its first real write. Detecting
+/// the mount flag lets read paths select immutable mode before SQLite attempts
+/// WAL/SHM sidecars or a pending schema migration.
+#[cfg(unix)]
+pub fn filesystem_is_read_only(path: &Path) -> Result<bool, OrbitError> {
+    use std::ffi::CString;
+    use std::mem::MaybeUninit;
+    use std::os::unix::ffi::OsStrExt;
+
+    let path_bytes = path.as_os_str().as_bytes();
+    let path = CString::new(path_bytes)
+        .map_err(|_| OrbitError::Store("SQLite path contains an interior NUL byte".to_string()))?;
+    let mut stats = MaybeUninit::<libc::statvfs>::uninit();
+    // SAFETY: `path` is a live NUL-terminated C string and `stats` points to
+    // writable storage for one `statvfs` value. A zero return initializes it.
+    let status = unsafe { libc::statvfs(path.as_ptr(), stats.as_mut_ptr()) };
+    if status != 0 {
+        return Err(OrbitError::Store(format!(
+            "cannot inspect SQLite filesystem for '{}': {}",
+            path.to_string_lossy(),
+            std::io::Error::last_os_error()
+        )));
+    }
+    // SAFETY: `statvfs` returned zero, so it initialized the output value.
+    let stats = unsafe { stats.assume_init() };
+    Ok(stats.f_flag & libc::ST_RDONLY != 0)
+}
+
+#[cfg(not(unix))]
+pub fn filesystem_is_read_only(_path: &Path) -> Result<bool, OrbitError> {
+    Ok(false)
 }
 
 /// Request WAL and report the journal mode SQLite settled on. Never fails:
 /// WAL is a performance/concurrency upgrade, not a correctness requirement,
 /// so refusals degrade to a warning plus the active mode.
-fn request_wal_journal_mode(conn: &Connection) -> String {
+fn request_wal_journal_mode(conn: &Connection) -> (String, bool) {
     match conn.pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get::<_, String>(0)) {
         Ok(mode) => {
             if !mode.eq_ignore_ascii_case("wal") && !mode.eq_ignore_ascii_case("memory") {
@@ -71,7 +161,7 @@ fn request_wal_journal_mode(conn: &Connection) -> String {
                     "requested WAL mode, but SQLite kept the active journal mode",
                 );
             }
-            mode
+            (mode, false)
         }
         Err(error) => {
             tracing::warn!(
@@ -79,8 +169,12 @@ fn request_wal_journal_mode(conn: &Connection) -> String {
                 error = %error,
                 "could not set WAL mode; continuing with the active journal mode",
             );
-            conn.pragma_query_value(None, "journal_mode", |row| row.get::<_, String>(0))
-                .unwrap_or_else(|_| "unknown".to_string())
+            let write_denied = OrbitError::Store(error.to_string()).is_readonly_or_access_failure();
+            (
+                conn.pragma_query_value(None, "journal_mode", |row| row.get::<_, String>(0))
+                    .unwrap_or_else(|_| "unknown".to_string()),
+                write_denied,
+            )
         }
     }
 }

--- a/crates/orbit-core/src/adapter/command/dispatch.rs
+++ b/crates/orbit-core/src/adapter/command/dispatch.rs
@@ -9,7 +9,7 @@ use orbit_common::observability::audit_id::audit_execution_id;
 use orbit_common::{NotFoundKind, OrbitError};
 use orbit_store::Store;
 use orbit_store::contracts::{AuditEventInsertParams, AuditInvocationFields};
-use orbit_tools::{ReservationOwnerContext, ToolContext};
+use orbit_tools::{ReservationOwnerContext, ToolContext, ToolExecutionKind};
 use orbit_types::identity::{
     normalize_agent_family_for_model, normalize_optional_attribution_label,
 };
@@ -73,6 +73,7 @@ where
     execute_tool_dispatch_with_audit_store(
         name,
         input,
+        ToolExecutionKind::Mutating,
         ToolDispatchAuditContext {
             agent_override: None,
             model_override: None,
@@ -290,13 +291,25 @@ impl OrbitRuntime {
     where
         F: FnOnce(Value) -> Result<Value, OrbitError>,
     {
-        execute_tool_dispatch_with_audit_store(name, input, audit, || self.sqlite_store(), dispatch)
+        let execution_kind = self
+            .tool_registry()
+            .execution_kind(name)
+            .unwrap_or(ToolExecutionKind::Mutating);
+        execute_tool_dispatch_with_audit_store(
+            name,
+            input,
+            execution_kind,
+            audit,
+            || self.sqlite_store(),
+            dispatch,
+        )
     }
 }
 
 fn execute_tool_dispatch_with_audit_store<F, S>(
     name: &str,
     input: Value,
+    execution_kind: ToolExecutionKind,
     audit: ToolDispatchAuditContext,
     open_audit_store: S,
     dispatch: F,
@@ -448,7 +461,7 @@ where
     // db, bad perms) yielded a successful, un-audited mutation with no
     // error surfaced. Fail the call instead so a committed change can
     // never surface without its audit row.
-    finalize_successful_dispatch(name, value, audit_write)
+    finalize_successful_dispatch(name, execution_kind, value, audit_write)
 }
 
 /// Fold a successful tool call together with its audit-write outcome into the
@@ -460,12 +473,9 @@ where
 /// for the per-thread dedup signal, which is set as soon as the row persists
 /// regardless of the tool's own outcome.
 ///
-/// No read-only/mutating split exists on the tool schema, so this fails closed
-/// for *every* successful call — strictly safer than the "at least mutating
-/// tools" floor the finding sets, at the cost of also failing a read-only call
-/// when the audit store is unwritable (an already-degraded state).
 pub(super) fn finalize_successful_dispatch(
     tool_name: &str,
+    execution_kind: ToolExecutionKind,
     value: Value,
     audit_write: Result<(), OrbitError>,
 ) -> Result<ToolDispatchOutcome, OrbitError> {
@@ -474,6 +484,16 @@ pub(super) fn finalize_successful_dispatch(
             value,
             audit_recorded: true,
         }),
+        Err(err) if execution_kind == ToolExecutionKind::ReadOnly => {
+            tracing::warn!(
+                tool = tool_name,
+                "read-only tool completed but its audit event could not be persisted: {err}"
+            );
+            Ok(ToolDispatchOutcome {
+                value,
+                audit_recorded: false,
+            })
+        }
         Err(err) => {
             tracing::error!(
                 tool = tool_name,

--- a/crates/orbit-core/src/adapter/command/tests/dispatch.rs
+++ b/crates/orbit-core/src/adapter/command/tests/dispatch.rs
@@ -1,4 +1,5 @@
 use orbit_common::OrbitError;
+use orbit_tools::ToolExecutionKind;
 use orbit_types::telemetry::AuditEventStatus;
 use orbit_types::tool::{McpCapability, McpTransport, ToolSessionContext};
 use std::collections::BTreeSet;
@@ -659,8 +660,13 @@ fn audit_context_returns_none_when_neither_source_supplies_values() {
 
 #[test]
 fn successful_dispatch_returns_value_when_audit_persists() {
-    let outcome = finalize_successful_dispatch("orbit.task.update", json!({"ok": true}), Ok(()))
-        .expect("audit persisted -> success");
+    let outcome = finalize_successful_dispatch(
+        "orbit.task.update",
+        ToolExecutionKind::Mutating,
+        json!({"ok": true}),
+        Ok(()),
+    )
+    .expect("audit persisted -> success");
 
     assert!(outcome.audit_recorded);
     assert_eq!(outcome.value, json!({"ok": true}));
@@ -672,8 +678,12 @@ fn successful_mutation_fails_when_audit_row_cannot_be_persisted() {
     // failed. Finding M1: the call must fail rather than surface a
     // successful, un-audited mutation.
     let audit_write = Err(OrbitError::Store("disk full".to_string()));
-    let result =
-        finalize_successful_dispatch("orbit.task.update", json!({"mutated": true}), audit_write);
+    let result = finalize_successful_dispatch(
+        "orbit.task.update",
+        ToolExecutionKind::Mutating,
+        json!({"mutated": true}),
+        audit_write,
+    );
 
     let err = result.expect_err("un-audited mutation must fail the call");
     let message = err.to_string();
@@ -681,6 +691,23 @@ fn successful_mutation_fails_when_audit_row_cannot_be_persisted() {
         message.contains("orbit.task.update") && message.contains("audit row"),
         "error names the tool and the missing audit row: {message}"
     );
+}
+
+#[test]
+fn successful_read_only_dispatch_survives_unwritable_audit_store() {
+    let value = json!({"items": []});
+    let outcome = finalize_successful_dispatch(
+        "orbit.task.list",
+        ToolExecutionKind::ReadOnly,
+        value.clone(),
+        Err(OrbitError::Store(
+            "attempt to write a readonly database".to_string(),
+        )),
+    )
+    .expect("passive telemetry must not change a read-only tool result");
+
+    assert_eq!(outcome.value, value);
+    assert!(!outcome.audit_recorded);
 }
 
 #[test]

--- a/crates/orbit-core/src/bootstrap/init.rs
+++ b/crates/orbit-core/src/bootstrap/init.rs
@@ -92,18 +92,43 @@ pub(crate) fn ensure_orbit_root_initialized(
     global_root: &Path,
     workspace_root: &Path,
 ) -> Result<(), OrbitError> {
-    init_workspace_at_root(
+    let global_init = init_workspace_at_root(
         global_root,
         InitOptions {
             global_only: true,
             ..Default::default()
         },
-    )?;
-    prepare_workspace_root_layout(workspace_root, global_root)?;
+    );
+    ignore_denied_implicit_bootstrap_write("global defaults", global_root, global_init)?;
+
+    let workspace_layout = prepare_workspace_root_layout(workspace_root, global_root);
+    ignore_denied_implicit_bootstrap_write("workspace layout", workspace_root, workspace_layout)?;
     if ResolvedConfig::load(&ConfigRoots::global_only(global_root))?.scoring_enabled {
-        seed_scoreboard_templates(workspace_root)?;
+        let scoreboard = seed_scoreboard_templates(workspace_root);
+        ignore_denied_implicit_bootstrap_write("scoreboard templates", workspace_root, scoreboard)?;
     }
     Ok(())
+}
+
+fn ignore_denied_implicit_bootstrap_write<T>(
+    component: &str,
+    root: &Path,
+    result: Result<T, OrbitError>,
+) -> Result<Option<T>, OrbitError> {
+    match result {
+        Ok(value) => Ok(Some(value)),
+        Err(error) if error.is_readonly_or_access_failure() => {
+            tracing::warn!(
+                target: "orbit.core.bootstrap",
+                component,
+                root = %root.display(),
+                error = %error,
+                "skipped incidental runtime bootstrap persistence"
+            );
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
 }
 
 /// Initialize the global `~/.orbit/` root. Always targets `~/.orbit/`

--- a/crates/orbit-core/src/composition.rs
+++ b/crates/orbit-core/src/composition.rs
@@ -128,7 +128,19 @@ fn build_runtime(
     local_root: &Path,
     binding: Option<WorkspaceRuntimeBinding>,
 ) -> Result<OrbitRuntime, OrbitError> {
-    let layout_report = orbit_store::workflow::layout::upgrade_workspace_layout(shared_root)?;
+    let layout_report = match orbit_store::workflow::layout::upgrade_workspace_layout(shared_root) {
+        Ok(report) => report,
+        Err(error) if error.is_readonly_or_access_failure() => {
+            tracing::warn!(
+                target: "orbit.core.bootstrap",
+                root = %shared_root.display(),
+                error = %error,
+                "skipped incidental workspace layout persistence"
+            );
+            orbit_store::workflow::layout::LayoutUpgradeReport::default()
+        }
+        Err(error) => return Err(error),
+    };
     let runtime_config = prepare_resolved_config(global_root, shared_root)?;
     let runtime = OrbitRuntime::build_from_resolved_config(
         global_root,
@@ -149,11 +161,33 @@ fn prepare_resolved_config(
     workspace_root: &Path,
 ) -> Result<ResolvedConfig, OrbitError> {
     let resolved = ResolvedConfig::load(&ConfigRoots::new(global_root, workspace_root))?;
-    if let Some(start) = resolved.tasks_id_start {
-        apply_configured_id_start(global_root, start)?;
+    if let Some(start) = resolved.tasks_id_start
+        && let Err(error) = apply_configured_id_start(global_root, start)
+    {
+        if error.is_readonly_or_access_failure() {
+            tracing::warn!(
+                target: "orbit.core.bootstrap",
+                root = %global_root.display(),
+                error = %error,
+                "skipped incidental task allocator bootstrap persistence"
+            );
+        } else {
+            return Err(error);
+        }
     }
     let global_policy_store = global_policy_def_store(resolved.persistence.policy_dir.clone());
-    seed_default_policies(global_policy_store.as_ref(), false)?;
+    if let Err(error) = seed_default_policies(global_policy_store.as_ref(), false) {
+        if error.is_readonly_or_access_failure() {
+            tracing::warn!(
+                target: "orbit.core.bootstrap",
+                root = %global_root.display(),
+                error = %error,
+                "skipped incidental default-policy persistence"
+            );
+        } else {
+            return Err(error);
+        }
+    }
     Ok(resolved)
 }
 

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -67,11 +67,23 @@ pub(crate) fn build_context_from_roots(
         binding.map(|binding| binding.workspace_id.as_str()),
     )?;
     let workspace_id = workspace_id_for_orbit_dir(&paths.orbit_dir)?;
-    let import_report = orbit_store::workflow::legacy_state::import_legacy_v2_state(
+    let import_report = match orbit_store::workflow::legacy_state::import_legacy_v2_state(
         &store,
         &paths.orbit_dir,
         &workspace_id,
-    )?;
+    ) {
+        Ok(report) => report,
+        Err(error) if error.is_readonly_or_access_failure() => {
+            tracing::warn!(
+                target: "orbit.core.bootstrap",
+                root = %paths.orbit_dir.display(),
+                error = %error,
+                "skipped incidental legacy-state import persistence"
+            );
+            orbit_store::workflow::legacy_state::ImportReport::skipped()
+        }
+        Err(error) => return Err(error),
+    };
     if import_report.skipped_records() {
         tracing::warn!(
             workspace_id = %workspace_id,
@@ -102,7 +114,18 @@ pub(crate) fn build_context_from_roots(
 
     let skill_catalog =
         SkillCatalog::layered(persistence.skill_dir.clone(), global_root.join("skills"));
-    skill_catalog.ensure_layout()?;
+    if let Err(error) = skill_catalog.ensure_layout() {
+        if error.is_readonly_or_access_failure() {
+            tracing::warn!(
+                target: "orbit.core.bootstrap",
+                root = %global_root.display(),
+                error = %error,
+                "skipped incidental skill-catalog layout persistence"
+            );
+        } else {
+            return Err(error);
+        }
+    }
 
     let mut registry = ToolRegistry::new();
     registry.register_builtins();

--- a/crates/orbit-search/src/vector/store/mod.rs
+++ b/crates/orbit-search/src/vector/store/mod.rs
@@ -44,9 +44,24 @@ impl VectorStore {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| OrbitError::Store(e.to_string()))?;
         }
-        let conn = Connection::open(path).map_err(|e| OrbitError::Store(e.to_string()))?;
-        orbit_common::storage::sqlite::apply_default_pragmas(&conn)?;
-        schema::ensure_vector_schema(&conn)?;
+        let mut conn = Connection::open(path).map_err(|e| OrbitError::Store(e.to_string()))?;
+        let pragmas = orbit_common::storage::sqlite::apply_default_pragmas(&conn)?;
+        if pragmas.write_denied || orbit_common::storage::sqlite::filesystem_is_read_only(path)? {
+            drop(conn);
+            conn = orbit_common::storage::sqlite::open_immutable(path)?;
+        }
+        if let Err(error) = schema::ensure_vector_schema(&conn) {
+            if error.is_readonly_or_access_failure() {
+                tracing::warn!(
+                    target: "orbit.search.vector",
+                    path = %path.display(),
+                    error = %error,
+                    "skipped incidental semantic-index schema persistence"
+                );
+            } else {
+                return Err(error);
+            }
+        }
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
         })

--- a/crates/orbit-search/src/vector/store/schema.rs
+++ b/crates/orbit-search/src/vector/store/schema.rs
@@ -8,6 +8,12 @@ use orbit_common::OrbitError;
 use rusqlite::Connection;
 
 pub fn ensure_vector_schema(conn: &Connection) -> Result<(), OrbitError> {
+    if table_exists(conn, "embeddings")?
+        && table_exists(conn, "corpus_fts")?
+        && !table_exists(conn, legacy_task_fts_table())?
+    {
+        return Ok(());
+    }
     conn.execute_batch(
         r#"
             CREATE TABLE IF NOT EXISTS embeddings (

--- a/crates/orbit-store/src/compose/mod.rs
+++ b/crates/orbit-store/src/compose/mod.rs
@@ -82,7 +82,19 @@ pub fn workspace_friction_store(
 ) -> Result<Arc<dyn FrictionStoreBackend>, orbit_common::OrbitError> {
     let workspace_id = workspace_id.into();
     let files_root = files_root.into();
-    import_workspace_frictions(&store, &workspace_id, &files_root)?;
+    if let Err(error) = import_workspace_frictions(&store, &workspace_id, &files_root) {
+        if error.is_readonly_or_access_failure() {
+            orbit_common::tracing::warn!(
+                target: "orbit.store.friction",
+                workspace_id,
+                root = %files_root.display(),
+                error = %error,
+                "skipped incidental legacy-friction import persistence"
+            );
+        } else {
+            return Err(error);
+        }
+    }
     Ok(Arc::new(FrictionStore::open(
         store,
         workspace_id,

--- a/crates/orbit-store/src/driver/sqlite/connection.rs
+++ b/crates/orbit-store/src/driver/sqlite/connection.rs
@@ -75,13 +75,30 @@ impl Store {
             std::fs::create_dir_all(parent).map_err(|e| OrbitError::Store(e.to_string()))?;
         }
 
-        let conn = Connection::open(path).map_err(|e| OrbitError::Store(e.to_string()))?;
-        apply_default_pragmas(&conn)?;
+        let mut conn = Connection::open(path).map_err(|e| OrbitError::Store(e.to_string()))?;
+        let pragmas = apply_default_pragmas(&conn)?;
+        let read_only =
+            pragmas.write_denied || orbit_common::storage::sqlite::filesystem_is_read_only(path)?;
+        if read_only {
+            drop(conn);
+            conn = orbit_common::storage::sqlite::open_immutable(path)?;
+        }
 
-        migration::apply_schema(&conn)?;
+        if let Err(error) = migration::apply_schema(&conn) {
+            if read_only && error.is_readonly_or_access_failure() {
+                orbit_common::tracing::warn!(
+                    target: "orbit.store.sqlite",
+                    path = %path.display(),
+                    error = %error,
+                    "skipped schema migration while opening a store for immutable reads"
+                );
+            } else {
+                return Err(error);
+            }
+        }
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
-            readers: Some(Arc::new(ReadPool::new(path.to_path_buf()))),
+            readers: (!read_only).then(|| Arc::new(ReadPool::new(path.to_path_buf()))),
         })
     }
 

--- a/crates/orbit-store/src/driver/sqlite/migration/ledger.rs
+++ b/crates/orbit-store/src/driver/sqlite/migration/ledger.rs
@@ -161,16 +161,21 @@ pub(crate) fn run_migrations(
     migrations: &[Migration],
 ) -> Result<(), OrbitError> {
     validate_registry(migrations)?;
-    ensure_schema_meta_table(conn)?;
-
     let current = current_schema_version(conn)?;
     let supported = migrations.last().map(|m| m.version).unwrap_or(0);
     if current > supported {
         return Err(OrbitError::Migration(format!(
             "store database schema version {current} is newer than the newest version this \
-             orbit binary supports ({supported}); upgrade orbit to open this database"
+            orbit binary supports ({supported}); upgrade orbit to open this database"
         )));
     }
+    // A current store needs no write transaction. Return before the
+    // idempotent CREATE TABLE so read-only mounts remain genuinely readable.
+    if current == supported {
+        return Ok(());
+    }
+
+    ensure_schema_meta_table(conn)?;
 
     for migration in migrations.iter().filter(|m| m.version > current) {
         apply_one(conn, migration)?;

--- a/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
@@ -18,7 +18,8 @@ use super::queries::{
     workspace_checkout_by_paths, write_task_index_rows,
 };
 use super::schema::{
-    apply_schema, assert_registry_user_version, reject_unsupported_registry_schema,
+    apply_schema, assert_registry_user_version, registry_user_version,
+    reject_unsupported_registry_schema,
 };
 use super::util::{
     normalize_path, now_string, parse_relation_type_name, path_to_string, relation_type_name,
@@ -46,8 +47,14 @@ impl TaskRegistryStore {
         fs::create_dir_all(&registry_dir).map_err(|e| OrbitError::Store(e.to_string()))?;
         fs::create_dir_all(&workspaces_dir).map_err(|e| OrbitError::Store(e.to_string()))?;
 
-        let conn = Connection::open(path).map_err(|e| OrbitError::Store(e.to_string()))?;
-        orbit_common::storage::sqlite::apply_default_pragmas(&conn)?;
+        let mut conn = Connection::open(path).map_err(|e| OrbitError::Store(e.to_string()))?;
+        let pragmas = orbit_common::storage::sqlite::apply_default_pragmas(&conn)?;
+        let read_only =
+            pragmas.write_denied || orbit_common::storage::sqlite::filesystem_is_read_only(path)?;
+        if read_only {
+            drop(conn);
+            conn = orbit_common::storage::sqlite::open_immutable(path)?;
+        }
         // The registry is the commit point that makes a created task official, so
         // its writes must be durable against power loss the moment they ack. WAL's
         // synchronous=NORMAL default only fsyncs the WAL at checkpoint, leaving an
@@ -56,10 +63,23 @@ impl TaskRegistryStore {
         // low-write (≈one commit per task create/bind/unregister), so the extra
         // fsync cost is negligible. Scoped to this connection only — the shared
         // Store::open stays at NORMAL for higher-write stores.
-        conn.pragma_update(None, "synchronous", "FULL")
-            .map_err(|e| OrbitError::Store(format!("failed to set synchronous=FULL: {e}")))?;
+        if !read_only && let Err(error) = conn.pragma_update(None, "synchronous", "FULL") {
+            let mapped = OrbitError::Store(format!("failed to set synchronous=FULL: {error}"));
+            if mapped.is_readonly_or_access_failure() {
+                orbit_common::tracing::warn!(
+                    target: "orbit.store.task_registry",
+                    path = %path.display(),
+                    error = %error,
+                    "could not set synchronous=FULL on a read-only task registry; continuing for reads"
+                );
+            } else {
+                return Err(mapped);
+            }
+        }
         reject_unsupported_registry_schema(&conn)?;
-        apply_schema(&conn)?;
+        if registry_user_version(&conn)? < super::REGISTRY_SCHEMA_VERSION {
+            apply_schema(&conn)?;
+        }
         assert_registry_user_version(&conn)?;
 
         Ok(Self {
@@ -81,6 +101,30 @@ impl TaskRegistryStore {
             .as_deref()
             .map(validate_workspace_id)
             .transpose()?;
+
+        // Runtime construction asks for the same binding on every command.
+        // Satisfy that observational fast path without opening a write
+        // transaction; a read-only mount must only fail when a real rebind is
+        // required.
+        {
+            let conn = self
+                .conn
+                .lock()
+                .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+            if let Some(existing) = workspace_by_orbit_dir(&conn, &orbit_dir)? {
+                if let Some(requested) = &requested_workspace_id
+                    && requested != &existing.workspace_id
+                {
+                    return Err(OrbitError::InvalidInput(format!(
+                        "orbit dir '{}' is already bound to workspace '{}', not '{}'",
+                        orbit_dir.display(),
+                        existing.workspace_id,
+                        requested
+                    )));
+                }
+                return Ok(existing);
+            }
+        }
 
         let mut conn = self
             .conn

--- a/crates/orbit-store/src/workflow/friction.rs
+++ b/crates/orbit-store/src/workflow/friction.rs
@@ -59,8 +59,16 @@ pub fn import_workspace_frictions(
     source_root: &Path,
 ) -> Result<FrictionImportReport, OrbitError> {
     let source_key = source_key(source_root);
+    if let Some(report) =
+        store.with_read_connection(|conn| completed_marker(conn, workspace_id, &source_key))?
+    {
+        return Ok(report);
+    }
+
     store.with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
         let conn = tx.connection();
+        // Re-check inside the writer transaction in case another process
+        // completed the import after the observational fast path.
         if let Some(report) = completed_marker(conn, workspace_id, &source_key)? {
             return Ok(report);
         }

--- a/crates/orbit-tools/src/builtin/orbit/search.rs
+++ b/crates/orbit-tools/src/builtin/orbit/search.rs
@@ -2,11 +2,15 @@ use orbit_common::OrbitError;
 use orbit_types::tool::{ToolParam, ToolSchema};
 use serde_json::Value;
 
-use crate::{OrbitBuiltinAction, Tool, ToolContext};
+use crate::{OrbitBuiltinAction, Tool, ToolContext, ToolExecutionKind};
 
 pub struct OrbitSearchTool;
 
 impl Tool for OrbitSearchTool {
+    fn execution_kind(&self) -> ToolExecutionKind {
+        ToolExecutionKind::ReadOnly
+    }
+
     fn schema(&self) -> ToolSchema {
         let mut parameters = vec![
             ToolParam {

--- a/crates/orbit-tools/src/builtin/orbit/task/list.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/list.rs
@@ -2,11 +2,15 @@ use orbit_common::OrbitError;
 use orbit_types::tool::{ToolParam, ToolSchema};
 use serde_json::Value;
 
-use crate::{OrbitBuiltinAction, Tool, ToolContext};
+use crate::{OrbitBuiltinAction, Tool, ToolContext, ToolExecutionKind};
 
 pub struct OrbitTaskListTool;
 
 impl Tool for OrbitTaskListTool {
+    fn execution_kind(&self) -> ToolExecutionKind {
+        ToolExecutionKind::ReadOnly
+    }
+
     fn schema(&self) -> ToolSchema {
         let mut parameters = vec![
             ToolParam {

--- a/crates/orbit-tools/src/builtin/orbit/task/show.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/show.rs
@@ -2,11 +2,15 @@ use orbit_common::OrbitError;
 use orbit_types::tool::{ToolParam, ToolSchema};
 use serde_json::Value;
 
-use crate::{OrbitBuiltinAction, Tool, ToolContext};
+use crate::{OrbitBuiltinAction, Tool, ToolContext, ToolExecutionKind};
 
 pub struct OrbitTaskShowTool;
 
 impl Tool for OrbitTaskShowTool {
+    fn execution_kind(&self) -> ToolExecutionKind {
+        ToolExecutionKind::ReadOnly
+    }
+
     fn schema(&self) -> ToolSchema {
         let mut parameters = vec![ToolParam {
             name: "id".to_string(),

--- a/crates/orbit-tools/src/lib.rs
+++ b/crates/orbit-tools/src/lib.rs
@@ -245,7 +245,20 @@ impl std::fmt::Debug for ToolContext {
 
 pub trait Tool: Send + Sync {
     fn schema(&self) -> ToolSchema;
+    /// Whether a successful invocation can have externally visible side effects.
+    ///
+    /// The conservative default keeps audit persistence fail-closed for every
+    /// tool that has not explicitly proved it is observational only.
+    fn execution_kind(&self) -> ToolExecutionKind {
+        ToolExecutionKind::Mutating
+    }
     fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolExecutionKind {
+    ReadOnly,
+    Mutating,
 }
 
 /// Extract a non-empty string field from a tool input value.

--- a/crates/orbit-tools/src/registry.rs
+++ b/crates/orbit-tools/src/registry.rs
@@ -8,7 +8,7 @@ use orbit_types::tool::{
 };
 use serde_json::Value;
 
-use crate::{Tool, ToolContext};
+use crate::{Tool, ToolContext, ToolExecutionKind};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToolAvailability {
@@ -136,6 +136,12 @@ impl ToolRegistry {
     pub fn is_active(&self, name: &str) -> bool {
         self.availability(name)
             .is_some_and(ToolAvailability::is_active)
+    }
+
+    pub fn execution_kind(&self, name: &str) -> Option<ToolExecutionKind> {
+        self.tools
+            .get(name)
+            .map(|entry| entry.tool.execution_kind())
     }
 
     pub fn unregister(&mut self, name: &str) -> bool {


### PR DESCRIPTION
## Task

[ORB-10963](https://orbit-cli.com/tasks/ORB-10963) — Keep read-only Orbit tool calls free of incidental writes

### Description

## Problem
Three Codex worker runs in the 2026-08-22 audit window failed before useful work because worker bootstrap and diagnostic reads such as `orbit.tool.list`, `orbit.task.show`, and search encountered `Read-only file system (os error 30)`. A later attempted `orbit.task.update` failed in the same environment as expected for a mutation, but the worker could not even complete the reads needed to diagnose and report that boundary. Read-only diagnostic invocations can also attempt to open telemetry state for writing.

Prior work ORB-10908/ORB-10915 improved diagnostics for genuine task-store writes, and ORB-10928 removed one unconditional workspace-list write, but managed worktrees still expose read paths or command bootstrap code that performs incidental writes.

## Why It Matters
A worker must be able to inspect its task and tool contract before deciding whether mutation is needed. Incidental telemetry, cache, index, or lock writes must not turn a safe read into a failed run.

## Constraints / Notes
- Preserve fail-open passive metrics behavior.
- Genuine mutating operations against a read-only store must continue to fail with an attributable error.
- Reproduce the managed worktree/read-only mount shape, not only a chmod approximation.

### Acceptance Criteria

- In a managed-worktree fixture with Orbit state mounted read-only, orbit.tool.list, orbit.task.show, orbit.task.list, and lexical orbit.search complete successfully.
- Incidental telemetry, cache, index, access-time, or bootstrap persistence failures on read-only calls are skipped or reported non-fatally and do not change the tool result.
- A genuine task mutation against the same read-only store still fails with a path-attributed EROFS/EACCES diagnostic.
- Deterministic regression tests cover CLI tool-run and MCP invocation paths without relying on the developer machine's writable Orbit state.
- Focused tests and make ci-fast pass, with unrelated failures identified separately.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented read-only-safe Orbit inspection from bootstrap through dispatch. Read-only filesystems are detected before SQLite sidecar/schema work and opened in immutable query mode; current-schema fast paths avoid no-op writes, and denied layout, policy, allocator, skill catalog, legacy import, friction import, semantic-index, migration, and passive audit persistence now degrade with warnings on observational calls. Added conservative ToolExecutionKind metadata: orbit.task.show, orbit.task.list, and orbit.search are explicitly observational, so audit failure is fail-open only for those tools while mutations remain fail-closed. Added a managed linked-worktree regression covering CLI tool list/tool-run and MCP tools/list/show/list/search under an actual bubblewrap read-only state mount, plus path-attributed task.update EROFS/EACCES assertions. Expanded context only for tightly coupled runtime bootstrap, SQLite/store owners, tool metadata, and directly affected tests required by those paths. Validation passed: cargo fmt check; orbit-core dispatch tests (29); orbit-store SQLite tests (153 passed, 1 ignored benchmark); orbit-search vector-store tests (8); full orbit-cli mcp_roundtrip (13); make ci-fast; make ci-lint. The nested runner denies bubblewrap namespaces with `No permissions to create new namespace`; the mount test probes and skips only for that environment restriction. Independently validated this exact managed checkout, whose primary .orbit mount is read-only: tool list, task.show, task.list, and lexical search all returned rc=0, including a v14 store that could not persist the pending v15 migration. A chmod-isolated mutation returned rc=1 and attributed EACCES to the task `.task.yaml.lock` path. No friction record was warranted.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10963-6a8a06fb`
- Behind base: 0
- Ahead of base: 1