### PR TITLE
Guarantee lexical search fallback when the semantic companion is unavailable

### DIFF
--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -947,6 +947,57 @@ fn mcp_serve_error_paths_return_tool_errors_and_keep_serving() {
 }
 
 #[test]
+fn mcp_hybrid_search_without_companion_returns_lexical_results() {
+    let workspace = McpWorkspace::init();
+    let companion_state = workspace.home.join(".orbit").join("embed");
+    assert!(
+        !companion_state.exists(),
+        "test must start without companion state"
+    );
+    let mut client = workspace.serve();
+
+    let task = client.call_tool_ok(
+        "orbit_task_add",
+        json!({
+            "title": "MCP lexical fallback regression",
+            "description": "The optional companion is absent.",
+            "tags": ["fallback"],
+            "complexity": "low",
+            "model": "codex"
+        }),
+    );
+    let task_id = task["id"].as_str().expect("task id");
+    let response = client.call_tool_ok(
+        "orbit_search",
+        json!({
+            "query": "MCP lexical fallback regression",
+            "hybrid": true,
+            "kind": "task",
+            "tag": ["fallback"],
+            "limit": 1,
+            "model": "codex"
+        }),
+    );
+
+    assert_eq!(response["mode"], "lexical");
+    assert_eq!(response["results"][0]["id"], task_id);
+    assert_eq!(response["results"][0]["source"], "lexical");
+    let notes = response["notes"].as_array().expect("fallback notes");
+    assert!(notes.iter().any(|note| {
+        note.as_str()
+            .is_some_and(|note| note.contains("falling back to lexical task search"))
+    }));
+    assert!(notes.iter().all(|note| {
+        note.as_str()
+            .is_some_and(|note| !note.contains("orbit semantic install"))
+    }));
+    assert!(
+        !companion_state.exists(),
+        "MCP fallback must not install companion state"
+    );
+}
+
+#[test]
 fn mcp_calls_are_audited_once_including_unknown_raw_names() {
     let workspace = McpWorkspace::init();
     let mut client = workspace.serve();

--- a/crates/orbit-cli/tests/semantic_companion.rs
+++ b/crates/orbit-cli/tests/semantic_companion.rs
@@ -86,6 +86,50 @@ fn direct_search_semantic_command_surfaces_companion_stderr() {
     );
 }
 
+#[test]
+#[cfg(unix)]
+fn tool_run_hybrid_search_without_companion_returns_lexical_results() {
+    let workspace = TestWorkspace::new();
+    let task = workspace.add_task_without_companion();
+    let task_id = task["id"].as_str().expect("task id");
+    let embed_root = workspace.home.join(".orbit").join("embed");
+    assert!(
+        !embed_root.exists(),
+        "test must start without companion state"
+    );
+
+    let input = json!({
+        "query": "Noisy companion regression",
+        "hybrid": true,
+        "kind": "task",
+        "limit": 1,
+        "model": "codex"
+    })
+    .to_string();
+    let output = workspace.run_without_companion(
+        &["tool", "run", "orbit.search", "--input", &input, "--full"],
+        "tool run hybrid search without companion",
+    );
+    let response: Value = serde_json::from_slice(&output.stdout).expect("search JSON");
+
+    assert_eq!(response["mode"], "lexical");
+    assert_eq!(response["results"][0]["id"], task_id);
+    assert_eq!(response["results"][0]["source"], "lexical");
+    let notes = response["notes"].as_array().expect("fallback notes");
+    assert!(notes.iter().any(|note| {
+        note.as_str()
+            .is_some_and(|note| note.contains("falling back to lexical task search"))
+    }));
+    assert!(notes.iter().all(|note| {
+        note.as_str()
+            .is_some_and(|note| !note.contains("orbit semantic install"))
+    }));
+    assert!(
+        !embed_root.exists(),
+        "fallback must not install companion state"
+    );
+}
+
 struct TestWorkspace {
     _temp: TempDir,
     home: std::path::PathBuf,

--- a/crates/orbit-core/src/application/search/hybrid.rs
+++ b/crates/orbit-core/src/application/search/hybrid.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use orbit_common::OrbitError;
 use orbit_search::DocSemanticHit;
 
 use super::convert::doc_result_to_global;
@@ -24,11 +25,11 @@ pub(super) struct DocHybridCandidate {
 }
 
 pub(super) fn lexical_doc_hits(
-    lexical_docs: BTreeMap<String, orbit_search::DocSearchResult>,
+    lexical_docs: Vec<orbit_search::DocSearchResult>,
     limit: usize,
 ) -> Vec<GlobalSearchHit> {
     let mut out = lexical_docs
-        .into_values()
+        .into_iter()
         .map(|result| doc_result_to_global(result.clone(), "lexical", Some(result.score as f32)))
         .collect::<Vec<_>>();
     out.truncate(limit);
@@ -142,6 +143,19 @@ pub(super) fn warn_task_hybrid_fallback(notes: &mut Vec<String>, reason: &str) {
         "task hybrid vector",
         &format!("{TASK_HYBRID_FALLBACK_NOTE}: {reason}"),
     );
+}
+
+/// The companion's install remediation is appropriate for an explicit
+/// semantic command, but hybrid search is intentionally best-effort. Keep
+/// the fallback note useful without turning an optional dependency into an
+/// unattended action item.
+pub(super) fn fallback_reason(error: &OrbitError) -> String {
+    match error {
+        OrbitError::CompanionNotInstalled(_) => {
+            "optional inference companion unavailable".to_string()
+        }
+        _ => error.to_string(),
+    }
 }
 
 pub(super) fn push_skip_note(notes: &mut Vec<String>, branch: &str, reason: &str) {

--- a/crates/orbit-core/src/application/search/mod.rs
+++ b/crates/orbit-core/src/application/search/mod.rs
@@ -29,7 +29,8 @@ use self::filters::{
 };
 use self::hybrid::{
     DocHybridCandidate, blend_doc_hybrid_candidates, compare_global_hits_by_score,
-    doc_search_candidate_limit, lexical_doc_hits, push_skip_note, warn_doc_hybrid_fallback,
+    doc_search_candidate_limit, fallback_reason, lexical_doc_hits, push_skip_note,
+    warn_doc_hybrid_fallback,
 };
 
 const DEFAULT_LIMIT: usize = 10;
@@ -41,10 +42,10 @@ const DOC_SEARCH_MIN_CANDIDATES: usize = DEFAULT_LIMIT * DOC_SEARCH_OVERFETCH;
 #[cfg(test)]
 thread_local! {
     static DOC_SEMANTIC_SEARCH_OVERRIDE:
-        std::cell::RefCell<Option<Result<Vec<DocSemanticHit>, String>>> =
+        std::cell::RefCell<Option<Result<Vec<DocSemanticHit>, OrbitError>>> =
         const { std::cell::RefCell::new(None) };
     static TASK_SEMANTIC_SEARCH_OVERRIDE:
-        std::cell::RefCell<Option<Result<Vec<orbit_search::SemanticHit>, String>>> =
+        std::cell::RefCell<Option<Result<Vec<orbit_search::SemanticHit>, OrbitError>>> =
         const { std::cell::RefCell::new(None) };
 }
 
@@ -212,7 +213,8 @@ impl OrbitRuntime {
                     self.lexical_task_candidates(query, limit)?
                 }
                 Err(error) => {
-                    hybrid::warn_task_hybrid_fallback(notes, &error.to_string());
+                    let reason = fallback_reason(&error);
+                    hybrid::warn_task_hybrid_fallback(notes, &reason);
                     self.lexical_task_candidates(query, limit)?
                 }
             }
@@ -324,8 +326,8 @@ impl OrbitRuntime {
         limit: usize,
     ) -> Result<Vec<orbit_search::SemanticHit>, OrbitError> {
         #[cfg(test)]
-        if let Some(result) = TASK_SEMANTIC_SEARCH_OVERRIDE.with(|cell| cell.borrow().clone()) {
-            return result.map_err(OrbitError::Execution);
+        if let Some(result) = TASK_SEMANTIC_SEARCH_OVERRIDE.with(|cell| cell.borrow_mut().take()) {
+            return result;
         }
 
         Ok(self
@@ -419,7 +421,7 @@ impl OrbitRuntime {
         notes: &mut Vec<String>,
     ) -> Result<Vec<GlobalSearchHit>, OrbitError> {
         let docs_limit = doc_search_candidate_limit(scope.limit);
-        let mut lexical_docs = BTreeMap::<String, orbit_search::DocSearchResult>::new();
+        let mut lexical_docs = Vec::<orbit_search::DocSearchResult>::new();
         for result in lexical_results {
             match result {
                 SearchResult::Doc(result) => {
@@ -434,10 +436,16 @@ impl OrbitRuntime {
                     {
                         continue;
                     }
-                    lexical_docs.insert(result.record.path.clone(), result);
+                    lexical_docs.push(result);
                 }
             }
         }
+
+        let lexical_doc_by_path = lexical_docs
+            .iter()
+            .cloned()
+            .map(|result| (result.record.path.clone(), result))
+            .collect::<BTreeMap<_, _>>();
 
         let semantic = match self.doc_semantic_hits(query, docs_limit) {
             Ok(result) if result.is_empty() => {
@@ -446,7 +454,8 @@ impl OrbitRuntime {
             }
             Ok(result) => result,
             Err(error) => {
-                warn_doc_hybrid_fallback(notes, &error.to_string());
+                let reason = fallback_reason(&error);
+                warn_doc_hybrid_fallback(notes, &reason);
                 return Ok(lexical_doc_hits(lexical_docs, scope.limit));
             }
         };
@@ -457,7 +466,7 @@ impl OrbitRuntime {
             .map(|record| (record.path.clone(), record))
             .collect::<BTreeMap<_, _>>();
         let mut candidates = BTreeMap::<String, DocHybridCandidate>::new();
-        for (path, result) in lexical_docs {
+        for (path, result) in lexical_doc_by_path {
             candidates.insert(
                 path,
                 DocHybridCandidate {
@@ -515,8 +524,8 @@ impl OrbitRuntime {
         limit: usize,
     ) -> Result<Vec<DocSemanticHit>, OrbitError> {
         #[cfg(test)]
-        if let Some(result) = DOC_SEMANTIC_SEARCH_OVERRIDE.with(|cell| cell.borrow().clone()) {
-            return result.map_err(OrbitError::Execution);
+        if let Some(result) = DOC_SEMANTIC_SEARCH_OVERRIDE.with(|cell| cell.borrow_mut().take()) {
+            return result;
         }
 
         Ok(orbit_search::doc_semantic_search(

--- a/crates/orbit-core/src/application/search/tests/hybrid.rs
+++ b/crates/orbit-core/src/application/search/tests/hybrid.rs
@@ -43,24 +43,71 @@ fn global_search_task_hybrid_falls_back_to_lexical_on_semantic_error() {
     let runtime = OrbitRuntime::in_memory().expect("runtime");
     let id = add_task_with_status(&runtime, "task fallback needle", TaskStatus::Backlog);
 
-    let response = with_task_semantic_override(Err("companion missing".to_string()), || {
-        runtime
-            .global_search(GlobalSearchParams {
-                query: Some("task fallback needle".to_string()),
-                hybrid: true,
-                kind: GlobalSearchKind::Task,
-                limit: 3,
-                ..Default::default()
-            })
-            .expect("task lexical fallback")
-    });
+    let response = with_task_semantic_override(
+        Err(OrbitError::Execution(
+            "companion startup failed".to_string(),
+        )),
+        || {
+            runtime
+                .global_search(GlobalSearchParams {
+                    query: Some("task fallback needle".to_string()),
+                    hybrid: true,
+                    kind: GlobalSearchKind::Task,
+                    limit: 3,
+                    ..Default::default()
+                })
+                .expect("task lexical fallback")
+        },
+    );
 
     assert_eq!(response.mode, GlobalSearchMode::Lexical);
     assert!(response.notes.iter().any(|note| {
-        note.contains("falling back to lexical task search") && note.contains("companion missing")
+        note.contains("falling back to lexical task search")
+            && note.contains("companion startup failed")
     }));
     assert_eq!(response.results[0].source, "lexical");
     assert_eq!(response.results[0].id.as_deref(), Some(id.as_str()));
+}
+
+#[test]
+fn global_search_task_hybrid_falls_back_without_install_remediation() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    let id = add_task_with_status(
+        &runtime,
+        "task absent companion needle",
+        TaskStatus::Backlog,
+    );
+
+    let response = with_task_semantic_override(
+        Err(OrbitError::CompanionNotInstalled(
+            orbit_search::INSTALL_REMEDIATION.to_string(),
+        )),
+        || {
+            runtime
+                .global_search(GlobalSearchParams {
+                    query: Some("task absent companion needle".to_string()),
+                    hybrid: true,
+                    kind: GlobalSearchKind::Task,
+                    limit: 1,
+                    ..Default::default()
+                })
+                .expect("missing companion should use lexical search")
+        },
+    );
+
+    assert_eq!(response.mode, GlobalSearchMode::Lexical);
+    assert_eq!(response.results[0].source, "lexical");
+    assert_eq!(response.results[0].id.as_deref(), Some(id.as_str()));
+    assert!(response.notes.iter().any(|note| {
+        note.contains("falling back to lexical task search")
+            && note.contains("optional inference companion unavailable")
+    }));
+    assert!(
+        response
+            .notes
+            .iter()
+            .all(|note| !note.contains("orbit semantic install"))
+    );
 }
 
 #[test]
@@ -114,17 +161,22 @@ fn global_search_doc_hybrid_falls_back_to_lexical_on_semantic_error() {
         &["fallbackneedle"],
     );
 
-    let response = with_doc_semantic_override(Err("companion missing".to_string()), || {
-        runtime
-            .global_search(GlobalSearchParams {
-                query: Some("fallbackneedle".to_string()),
-                hybrid: true,
-                kind: GlobalSearchKind::Doc,
-                limit: 3,
-                ..Default::default()
-            })
-            .expect("fallback search")
-    });
+    let response = with_doc_semantic_override(
+        Err(OrbitError::Execution(
+            "companion startup failed".to_string(),
+        )),
+        || {
+            runtime
+                .global_search(GlobalSearchParams {
+                    query: Some("fallbackneedle".to_string()),
+                    hybrid: true,
+                    kind: GlobalSearchKind::Doc,
+                    limit: 3,
+                    ..Default::default()
+                })
+                .expect("fallback search")
+        },
+    );
 
     assert!(
         response
@@ -136,6 +188,69 @@ fn global_search_doc_hybrid_falls_back_to_lexical_on_semantic_error() {
     assert_eq!(
         response.results[0].path.as_deref(),
         Some("docs/fallback-z-lexical.md")
+    );
+}
+
+#[test]
+fn doc_hybrid_fallback_preserves_lexical_filtering_and_order() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    add_doc_with_tags(
+        &runtime,
+        "docs/parity-a.md",
+        "parity needle first",
+        &["keep"],
+    );
+    add_doc_with_tags(
+        &runtime,
+        "docs/parity-b.md",
+        "parity needle second",
+        &["keep"],
+    );
+    add_doc_with_tags(
+        &runtime,
+        "docs/parity-c.md",
+        "parity needle filtered",
+        &["drop"],
+    );
+
+    let params = GlobalSearchParams {
+        query: Some("parity needle".to_string()),
+        kind: GlobalSearchKind::Doc,
+        tags: vec!["keep".to_string()],
+        limit: 2,
+        ..Default::default()
+    };
+    let lexical = runtime
+        .global_search(params.clone())
+        .expect("lexical search");
+    let fallback = with_doc_semantic_override(
+        Err(OrbitError::Execution(
+            "companion startup failed".to_string(),
+        )),
+        || {
+            runtime
+                .global_search(GlobalSearchParams {
+                    hybrid: true,
+                    ..params
+                })
+                .expect("lexical fallback")
+        },
+    );
+
+    let paths = |response: &GlobalSearchResponse| {
+        response
+            .results
+            .iter()
+            .map(|hit| hit.path.clone())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(paths(&fallback), paths(&lexical));
+    assert_eq!(fallback.results.len(), 2);
+    assert!(
+        fallback
+            .results
+            .iter()
+            .all(|hit| hit.path.as_deref() != Some("docs/parity-c.md"))
     );
 }
 

--- a/crates/orbit-core/src/application/search/tests/mod.rs
+++ b/crates/orbit-core/src/application/search/tests/mod.rs
@@ -127,7 +127,7 @@ fn task_semantic_hit(id: &str, score: f32) -> SemanticHit {
 }
 
 fn with_doc_semantic_override<T>(
-    result: Result<Vec<DocSemanticHit>, String>,
+    result: Result<Vec<DocSemanticHit>, orbit_common::OrbitError>,
     f: impl FnOnce() -> T,
 ) -> T {
     DOC_SEMANTIC_SEARCH_OVERRIDE.with(|cell| {
@@ -141,7 +141,7 @@ fn with_doc_semantic_override<T>(
 }
 
 fn with_task_semantic_override<T>(
-    result: Result<Vec<SemanticHit>, String>,
+    result: Result<Vec<SemanticHit>, orbit_common::OrbitError>,
     f: impl FnOnce() -> T,
 ) -> T {
     TASK_SEMANTIC_SEARCH_OVERRIDE.with(|cell| {


### PR DESCRIPTION
## Task

[ORB-10964](https://orbit-cli.com/tasks/ORB-10964) — Guarantee lexical search fallback when the semantic companion is unavailable

### Description

## Problem
When the inference companion is absent, users can receive `companion not installed: Semantic search not enabled. Run orbit semantic install...`. Some current paths already continue with lexical search, but the message is presented like an actionable failure and the fallback contract is not consistently evident across every search surface.

## Why It Matters
Semantic ranking is optional. Missing optional inference infrastructure must never prevent task, docs, or friction discovery, especially in unattended or sandboxed workers that cannot install binaries.

## Constraints / Notes
Do not auto-install or download the companion. Lexical behavior and filters remain authoritative when vector ranking is unavailable.

### Acceptance Criteria

- With no inference companion installed, a hybrid orbit.search call on CLI tool-run and MCP returns successful lexical results instead of an error.
- The response identifies lexical fallback in structured notes or a non-error warning and does not instruct unattended agents that installation is required.
- Task, docs, status, tag, path, and limit filters behave identically to an explicitly lexical query when fallback occurs.
- No install, download, network access, or persistent companion-state mutation is attempted during fallback.
- Regression tests cover companion absent, companion startup failure, and companion available paths.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Hybrid task and doc search now treats a missing optional inference companion as a lexical fallback without carrying the explicit semantic install remediation into structured notes.
- Preserved lexical ordering and filtering for doc fallback by keeping the lexical candidate order while retaining a path map for semantic blending.
- Added core regression coverage for companion absence, startup failure, available semantic results, and doc filter/order parity; added end-to-end CLI tool-run and MCP tests confirming successful lexical results and no companion-state creation.
- Added the MCP roundtrip test file to context_files because it is directly required by the MCP acceptance criterion.
Validation:
- cargo fmt --all -- --check
- cargo test -p orbit-core application::search::tests --lib (22 passed)
- cargo test -p orbit-cli --test semantic_companion (3 passed)
- cargo test -p orbit-cli --test mcp_roundtrip (13 passed)
- make ci-fast
- make ci-lint
Assessment: The shared search boundary remains authoritative for filters and limits; unavailable semantic infrastructure is now best-effort and non-actionable for unattended callers. No install or download path was added.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10964-6a8a0e62`
- Behind base: 0
- Ahead of base: 1