### PR TITLE
[ORB-10972] dashboard: left command rail, two-mode dock, log status bar

### DIFF
--- a/crates/orbit-web/assets/dashboard/app.js
+++ b/crates/orbit-web/assets/dashboard/app.js
@@ -942,9 +942,13 @@ function buildWorkspaceSelector() {
   note.hidden = true;
   note.title = "Reliability ignores the selected workspace";
 
-  const meta = $("meta");
-  meta.insertBefore(select, $("refresh-btn"));
-  meta.insertBefore(note, $("refresh-btn"));
+  // ORB-10972: the selector moved from the header meta cluster into the rail
+  // foot, beside the connection line. Same element, same id, same listeners.
+  const host = $("rail-workspace");
+  if (!host) return;
+  host.innerHTML = "";
+  host.appendChild(select);
+  host.appendChild(note);
 }
 
 // ORB-10874/ORB-10872: workspace + window live in the query string so a
@@ -1186,6 +1190,18 @@ function fetchAndRenderFrictions() {
   });
 }
 
+// ORB-10972: sets a count badge on a rail entry. `alert` renders it in the
+// blocked colour so a failure count is legible from any tab without opening
+// the tab it belongs to. Every value here comes from a fetch the dashboard
+// already makes — this adds no endpoint.
+function setRailCount(id, value, alert = false) {
+  const node = $(id);
+  if (!node) return;
+  const empty = value == null || value === 0;
+  node.textContent = empty ? "" : formatBigInt(value);
+  node.classList.toggle("alert", Boolean(alert) && !empty);
+}
+
 function renderHealthStrip(data) {
   if (!data) return;
   $("tile-events-value").textContent = formatBigInt(data.events);
@@ -1199,6 +1215,12 @@ function renderHealthStrip(data) {
   } else {
     tile.classList.remove("tile-alert");
   }
+  const failed = $("tile-failed");
+  if (failed) failed.classList.toggle("tile-alert", (data.failed_runs || 0) > 0);
+
+  setRailCount("rail-count-audit", data.events);
+  setRailCount("rail-count-diagnostics", data.failed_runs, true);
+  setRailCount("rail-count-diag-errors", data.failed_runs, true);
   renderSparkline(data.sparkline || []);
 }
 

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -5,9 +5,16 @@
         
         --bg: #000000;
         --bg-elev: #0a0a0a;
-        --border: #333333;
+        --bg-rail: #08080a;
+        /* ORB-10972 two-tier border scale. `--border` draws the edge of a
+           panel or control; `--hair` draws every hairline *inside* one (table
+           rows, group splits, log lines). Before this they were the same
+           #333333, which made the grid read as loud as its contents. */
+        --border: #2a2a2e;
+        --hair: #17171a;
         --fg: #dcdcdc;
         --fg-dim: #71717a;
+        --fg-mute: #4b4b52;
         --accent: #6e9fff;
         --accent-hover: #8ab3ff;
         --accent-hi: #a6cdff;
@@ -66,42 +73,200 @@
         height: 100vh;
         overflow-x: hidden;
       }
+
+      /* ORB-10972: the document is a vertical split — the two-column shell
+         above, the always-on log status bar pinned beneath it. */
+      body {
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+      }
       
 
 
       .mono { font-family: var(--font-mono); }
 
-      header {
-        border-bottom: 1px solid var(--border);
-        padding: 14px 24px;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 16px;
-        background: #000000;
-        position: sticky;
-        top: 0;
-        z-index: 100;
+      /* ORB-10972: the app is a two-column shell — a fixed nav rail and a
+         content column that owns its own scrolling. */
+      .shell {
+        display: grid;
+        grid-template-columns: 216px minmax(0, 1fr);
+        flex: 1 1 auto;
+        min-height: 0;
       }
 
-      header .brand {
+      .rail {
+        background: var(--bg-rail);
+        border-right: 1px solid var(--border);
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        overflow-y: auto;
+      }
+
+      .rail-brand { padding: 16px 18px 10px; }
+      .rail-brand svg { height: 22px; width: auto; }
+
+      .rail .tabs {
+        display: flex;
+        flex-direction: column;
+        padding: 4px 10px;
+        gap: 2px;
+      }
+
+      /* The router still appends #tab-indicator / #subtab-indicator to .tabs
+         and #diag-subtabs. In the rail the active entry is marked by its own
+         background, so the sliding underline is suppressed here rather than
+         removed from the router. */
+      .rail .tab-indicator { display: none !important; }
+
+      .rail-group { display: flex; flex-direction: column; gap: 1px; }
+
+      .rail-group-label {
+        font-size: 9.5px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: var(--fg-mute);
+        padding: 12px 8px 5px;
+      }
+
+      .rail .tab {
         display: flex;
         align-items: center;
-        height: 24px;
-      }
-      header .brand svg {
-        height: 22px;
-        width: auto;
-      }
-      
-      header .meta {
-        font-family: var(--font-mono);
-        font-size: 12px;
-        color: var(--fg-dim);
-        display: inline-flex;
-        align-items: center;
         gap: 10px;
+        width: 100%;
+        padding: 7px 8px;
+        border: none;
+        border-radius: 4px;
+        background: transparent;
+        color: var(--fg-dim);
+        font: inherit;
+        font-size: 13px;
+        text-align: left;
+        cursor: pointer;
+        transition: background 0.15s ease, color 0.15s ease;
       }
+
+      .rail .tab:hover { color: var(--fg); background: rgba(255, 255, 255, 0.04); }
+
+      .rail .tab.active {
+        background: rgba(110, 159, 255, 0.12);
+        color: var(--fg);
+      }
+
+      .rail-ico { width: 15px; height: 15px; flex: 0 0 auto; }
+      .rail-label { flex: 1 1 auto; min-width: 0; }
+
+      .rail-count {
+        margin-left: auto;
+        font-family: var(--font-mono);
+        font-size: 10.5px;
+        font-variant-numeric: tabular-nums;
+        color: var(--fg-mute);
+      }
+      .rail .tab.active .rail-count { color: var(--accent-hi); }
+      .rail-count.alert { color: var(--status-blocked); }
+
+      .rail-subtabs {
+        display: flex;
+        flex-direction: column;
+        gap: 1px;
+        padding: 2px 0 2px 0;
+        border-bottom: none;
+        background: transparent;
+      }
+
+      /* Muted while Diagnostics is not the active destination: the remembered
+         subtab stays remembered, but the rail only ever shows one selection. */
+      .rail-subtabs.dimmed .subtab.active {
+        background: transparent;
+        color: var(--fg-mute);
+      }
+
+      .rail-subtabs .subtab {
+        display: flex;
+        align-items: center;
+        padding: 5px 8px 5px 33px;
+        border-radius: 4px;
+        font-size: 12px;
+        color: var(--fg-mute);
+        text-align: left;
+      }
+      .rail-subtabs .subtab .rail-count { font-size: 10.5px; }
+
+      .rail-foot {
+        margin-top: auto;
+        border-top: 1px solid var(--hair);
+        padding: 12px 14px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .rail-workspace { display: flex; flex-direction: column; gap: 6px; }
+      .rail-workspace .workspace-select { max-width: 100%; margin: 0; width: 100%; }
+
+      .rail-conn {
+        display: flex;
+        align-items: center;
+        font-family: var(--font-mono);
+        font-size: 10.5px;
+        color: var(--fg-mute);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .main-col {
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      /* ORB-10972: one 52px bar replaces the old header + tabs + health strip
+         stack (~194px). The four health metrics ride inline in it. */
+      .topbar {
+        flex: 0 0 auto;
+        height: 52px;
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        gap: 18px;
+        padding: 0 20px;
+        background: var(--bg);
+      }
+
+      .topbar .crumb {
+        font-size: 15px;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+        flex: 0 0 auto;
+      }
+
+      .topbar-spacer { flex: 1 1 auto; }
+
+      .kpis { display: flex; align-items: center; gap: 18px; min-width: 0; }
+
+      .kpi {
+        display: flex;
+        align-items: baseline;
+        gap: 7px;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        white-space: nowrap;
+      }
+      .kpi .k { color: var(--fg-mute); letter-spacing: 0.04em; text-transform: uppercase; }
+      .kpi .v { font-size: 14px; color: var(--fg-dim); font-variant-numeric: tabular-nums; }
+      .kpi.tile-alert .k, .kpi.tile-alert .v { color: var(--state-failed); }
+
+      .kpi-spark { width: 64px; height: 20px; flex: 0 0 auto; }
+      .kpi-spark path { fill: none; stroke: var(--accent); stroke-width: 1.2px; }
+      .kpi-spark .baseline { stroke: var(--hair); stroke-width: 1px; }
+
+      .topbar .global-id-wrap { position: relative; display: inline-block; flex: 0 0 auto; }
 
       .refresh-btn {
         min-width: 74px;
@@ -259,10 +424,26 @@
       main {
         display: grid;
         grid-template-columns: minmax(0, 2.5fr) minmax(0, 1fr);
-        gap: 24px;
-        padding: 24px;
+        gap: 20px;
+        padding: 20px;
         max-width: 1800px;
         margin: 0 auto;
+        min-height: 0;
+      }
+
+      /* ORB-10972: the content column scrolls, not the document. The task
+         pane's main fills the column so the dock beside it can be full height. */
+      .main-col > .tab-pane { flex: 1 1 auto; min-height: 0; overflow-y: auto; }
+      .main-col > .tab-pane[data-tab="tasks"] { overflow: hidden; }
+      .main-col > .tab-pane[data-tab="tasks"] > main.tasks-layout {
+        height: 100%;
+        align-items: stretch;
+      }
+      .main-col > .tab-pane[data-tab="tasks"] .col-tasks > .panel {
+        flex: 1 1 auto;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
       }
       
       @media (max-width: 1000px) {
@@ -285,7 +466,7 @@
       
       .panel > header {
         padding: 12px 16px;
-        border-bottom: 1px solid var(--border);
+        border-bottom: 1px solid var(--hair);
         font-family: var(--font-sans);
         font-size: 12px;
         font-weight: 600;
@@ -297,7 +478,7 @@
         align-items: center;
         flex-wrap: wrap;
         gap: 8px;
-        background: #18181b;
+        background: transparent;
       }
       
       .panel > header .count {
@@ -315,7 +496,8 @@
       }
       
       #tasks-panel > .body {
-        max-height: calc(100vh - 240px);
+        max-height: none;
+        flex: 1 1 auto;
         /* ORB-10874: floor so the task inventory stays usable (a few visible
            rows) even on a short viewport or with the log panel expanded — it
            never gets squeezed toward zero by the surrounding chrome. */
@@ -329,7 +511,7 @@
         display: flex;
         gap: 8px;
         padding: 12px 16px;
-        border-bottom: 1px solid var(--border);
+        border-bottom: 1px solid var(--hair);
         flex-wrap: wrap;
         align-items: center;
         background: var(--bg);
@@ -498,7 +680,7 @@
         align-items: center;
         cursor: pointer;
         transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-        border-bottom: 1px solid var(--border);
+        border-bottom: 1px solid var(--hair);
       }
 
       .row:hover { 
@@ -645,8 +827,8 @@
       .task-crew-select:focus-visible,
       .chip:focus-visible,
       .mutation-undo:focus-visible,
-      .log-panel-toggle:focus-visible,
-      .log-resize-handle:focus-visible {
+      .rail .tab:focus-visible,
+      .dock-seg:focus-visible {
         outline: 2px solid var(--accent-hover);
         outline-offset: 2px;
       }
@@ -656,7 +838,7 @@
         font-family: var(--font-mono);
         font-size: 11px;
         color: var(--fg-dim);
-        border-bottom: 1px solid var(--border);
+        border-bottom: 1px solid var(--hair);
         background: var(--bg);
       }
 
@@ -693,7 +875,7 @@
       .row.header {
         cursor: default;
         background: transparent;
-        border-bottom: 1px solid var(--border);
+        border-bottom: 1px solid var(--hair);
         padding: 2px 16px 6px;
         font-size: 10px;
         font-weight: 600;
@@ -704,7 +886,7 @@
       }
       .row.header:hover {
         background: transparent;
-        border-color: var(--border);
+        border-color: var(--hair);
       }
       .row.header .id,
       .row.header .title,
@@ -727,7 +909,7 @@
         display: grid;
         gap: 16px;
         font-size: 13px;
-        border-bottom: 1px solid var(--border);
+        border-bottom: 1px solid var(--hair);
         animation: fadeIn 0.3s ease;
       }
       
@@ -1308,17 +1490,6 @@
         font-family: var(--font-mono);
       }
       
-      .tabs {
-        display: flex;
-        gap: 8px;
-        padding: 0 24px;
-        border-bottom: 1px solid var(--border);
-        background: #000000;
-        position: sticky;
-        top: 61px; /* Just below header */
-        z-index: 90;
-      }
-      
       .tab-indicator {
         position: absolute;
         bottom: -1px;
@@ -1329,25 +1500,6 @@
         pointer-events: none;
       }
       
-      .tab {
-        background: transparent;
-        color: var(--fg-dim);
-        border: none;
-        padding: 12px 16px;
-        cursor: pointer;
-        font: inherit;
-        font-weight: 500;
-        font-size: 13px;
-        border-bottom: 2px solid transparent;
-        margin-bottom: -1px;
-        transition: color 0.2s ease;
-      }
-      
-      .tab:hover { color: var(--fg); }
-      
-      .tab.active {
-        color: var(--fg);
-      }
       
       .tab-pane { display: none; animation: fadeIn 0.3s ease; }
       .tab-pane.active { display: block; position: relative; z-index: 0; }
@@ -2337,7 +2489,7 @@
         display: flex;
         gap: 4px;
         padding: 8px 16px;
-        border-bottom: 1px solid var(--border);
+        border-bottom: 1px solid var(--hair);
         background: #000000;
         position: relative;
       }
@@ -2615,80 +2767,112 @@
       }
 
       /* Health strip — global header tile row */
-      .health-strip {
-        display: grid;
-        grid-template-columns: repeat(4, minmax(0, 1fr));
-        gap: 0;
-        padding: 0;
-        background: #000000;
-        border-bottom: 1px solid var(--border);
-        position: sticky;
-        top: 110px; /* below header (61px) + tabs (49px) */
-        z-index: 89;
+      /* ORB-10972: the dock. Two panes, one column width. `data-mode` on the
+         host swaps which pane is displayed; nothing about the column's own box
+         changes, so the task table beside it never reflows on a mode switch. */
+      #side-dock {
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        background: var(--bg-elev);
+        border: 1px solid var(--border);
+        border-radius: 2px;
+        overflow: hidden;
       }
 
-      .tile {
-        display: grid;
-        grid-template-columns: 1fr auto;
-        grid-template-rows: auto auto;
-        column-gap: 14px;
-        padding: 10px 16px;
-        border-right: 1px solid var(--border);
-        background: var(--bg);
-        position: relative;
+      .dock-head {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 9px 12px;
+        border-bottom: 1px solid var(--hair);
       }
 
-      .tile:last-child { border-right: none; }
+      .dock-seg-group { display: flex; align-items: center; gap: 4px; }
 
-      .tile .label {
-        grid-column: 1 / 2;
-        grid-row: 1 / 2;
-        font-family: var(--font-sans);
-        font-size: 10px;
-        font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: 0.1em;
-        color: var(--fg-dim);
+      .dock-seg {
+        border: none;
+        background: transparent;
+        color: var(--fg-mute);
+        font: inherit;
+        font-size: 12px;
+        padding: 4px 11px;
+        border-radius: 5px;
+        cursor: pointer;
+        transition: background 0.15s ease, color 0.15s ease;
       }
+      .dock-seg:hover { color: var(--fg); }
+      .dock-seg.on { color: var(--fg); background: var(--bg); }
+      .dock-seg:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 
-      .tile .value {
-        grid-column: 1 / 2;
-        grid-row: 2 / 3;
+      .dock-meta {
+        margin-left: auto;
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
         font-family: var(--font-mono);
-        font-size: 22px;
-        font-weight: 500;
-        color: var(--fg);
-        line-height: 1.1;
+        font-size: 10.5px;
+        font-variant-numeric: tabular-nums;
+        color: var(--fg-mute);
       }
 
-      .tile .glyph {
-        grid-column: 2 / 3;
-        grid-row: 1 / 3;
-        align-self: center;
+      .dock-pane { display: none; flex: 1 1 auto; min-height: 0; flex-direction: column; }
+      #side-dock[data-mode="status"] .dock-pane[data-pane="status"] { display: flex; }
+      #side-dock[data-mode="log"] .dock-pane[data-pane="log"] { display: flex; }
+
+      .dock-pane > .panel {
+        border: none;
+        border-radius: 0;
+        background: transparent;
+        flex: 1 1 auto;
+        min-height: 0;
+      }
+      .dock-pane #locks-body { overflow-y: auto; }
+
+      /* ORB-10972: always-on ambient line, present on every tab. Replaces what
+         the collapsed log panel used to do. */
+      .log-statusbar {
+        flex: 0 0 auto;
+        height: 30px;
+        border-top: 1px solid var(--border);
+        background: var(--bg-elev);
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 0 20px;
         font-family: var(--font-mono);
-        font-size: 10px;
+        font-size: 11px;
+        min-width: 0;
+      }
+      /* ORB-10972: the live dot is used in the dock header and the status bar
+         now, so it needs a rule of its own rather than one scoped to the log
+         panel header it used to live in. */
+      .live-dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        flex: 0 0 auto;
+        background: var(--accent);
+        box-shadow: 0 0 0 3px rgba(110, 159, 255, 0.08);
+        animation: livePulse 2.4s ease-in-out infinite;
+      }
+      .log-statusbar .live-dot { flex: 0 0 auto; }
+      .log-statusbar .sb-label,
+      .log-statusbar .sb-t { color: var(--fg-mute); flex: 0 0 auto; font-variant-numeric: tabular-nums; }
+      .log-statusbar .sb-ag { color: var(--fg-dim); flex: 0 0 auto; }
+      .log-statusbar .sb-m {
         color: var(--fg-dim);
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        min-width: 0;
       }
-
-      .tile.tile-alert {
-        background: rgba(239, 68, 68, 0.06);
-      }
-      .tile.tile-alert .label,
-      .tile.tile-alert .glyph { color: var(--state-failed); }
-      .tile.tile-alert .value { color: var(--state-failed); }
-
-      .tile .sparkline {
-        grid-column: 1 / 3;
-        grid-row: 3 / 4;
-        height: 22px;
-        margin-top: 6px;
-        width: 100%;
-        display: block;
-      }
-      .tile .sparkline path { fill: none; stroke: var(--accent); stroke-width: 1.2px; }
-      .tile .sparkline .baseline { stroke: var(--border); stroke-width: 1px; }
+      .log-statusbar .sb-m b { color: var(--fg); font-weight: 500; }
+      .log-statusbar .sb-m[data-level="err"] { color: var(--status-blocked); }
+      .log-statusbar .sb-m[data-level="deny"] { color: var(--status-review); }
+      .log-statusbar .sb-m[data-level="warn"] { color: var(--status-proposed); }
+      .log-statusbar.empty .sb-label { opacity: 0.6; }
 
       /* Policy view (Audit sub-tab) */
       .policy-grid {
@@ -3497,18 +3681,11 @@
         main.tasks-layout {
           grid-template-columns: 1fr !important;
         }
-        .col-log {
-          min-height: auto;
-        }
-        #log-panel {
-          height: var(--log-panel-height, 260px);
-          max-height: var(--log-panel-height, 260px);
-        }
+        .col-log { min-height: 320px; }
       }
       .col-log {
         display: flex;
         flex-direction: column;
-        gap: 8px;
         min-height: 0;
         min-width: 0;
       }
@@ -3520,10 +3697,13 @@
         min-width: 0;
       }
       #locks-panel {
-        flex: 0 0 auto;
+        flex: 1 1 auto;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
       }
       #locks-body {
-        max-height: 180px;
+        max-height: none;
         overflow: auto;
       }
       .locks-empty {
@@ -3587,60 +3767,17 @@
         text-overflow: ellipsis;
         white-space: nowrap;
       }
+      /* ORB-10972: #log-panel is a pane of the dock now — it fills the dock's
+         height rather than negotiating its own. The ORB-10874 collapse toggle
+         and drag handle are gone with the geometry that needed them; the
+         always-on .log-statusbar and the dock's Status mode replaced them. */
       #log-panel {
         position: relative;
-        height: var(--log-panel-height, calc(100dvh - 420px));
-        max-height: var(--log-panel-height, calc(100dvh - 420px));
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        height: 100%;
       }
-      /* ORB-10874: collapsed keeps only the header (with its toggle/filters
-         reachable via the header itself where relevant) so the operator can
-         still see the panel exists and re-expand it, without it occupying
-         the space a mid-height panel would. */
-      #log-panel.collapsed {
-        height: auto;
-        max-height: none;
-        flex: 0 0 auto;
-      }
-      #log-panel.collapsed .log-stream,
-      #log-panel.collapsed .log-foot {
-        display: none;
-      }
-      .log-resize-handle {
-        position: absolute;
-        top: -5px;
-        left: 0;
-        right: 0;
-        height: 10px;
-        cursor: row-resize;
-        z-index: 2;
-        touch-action: none;
-      }
-      .log-resize-handle::after {
-        content: "";
-        display: block;
-        margin: 4px auto 0;
-        width: 36px;
-        height: 3px;
-        border-radius: 2px;
-        background: var(--border);
-      }
-      .log-resize-handle:hover::after { background: var(--fg-dim); }
-      #log-panel.collapsed .log-resize-handle { cursor: default; pointer-events: none; }
-      .log-panel-toggle {
-        font: inherit;
-        font-family: var(--font-mono);
-        font-size: 10px;
-        text-transform: uppercase;
-        letter-spacing: 0.06em;
-        color: var(--fg-dim);
-        background: var(--bg-elev);
-        border: 1px solid var(--border);
-        border-radius: 3px;
-        padding: 2px 8px;
-        cursor: pointer;
-        margin-left: 6px;
-      }
-      .log-panel-toggle:hover { color: var(--fg); border-color: var(--fg-dim); }
       .col-log .panel > header .title {
         display: flex; align-items: center; gap: 10px;
       }
@@ -3669,9 +3806,10 @@
       }
       .log-line {
         display: grid;
-        grid-template-columns: 64px 72px 42px minmax(120px, 1fr);
+        grid-template-columns: 56px 62px minmax(0, 1fr);
         gap: 10px;
-        padding: 0 16px;
+        padding: 0 14px 0 12px;
+        border-left: 2px solid transparent;
         font-size: 11.5px; line-height: 22px;
         color: var(--fg);
         cursor: pointer;
@@ -3679,10 +3817,17 @@
         transition: background 0.15s ease;
       }
       .log-line:hover { background: rgba(255,255,255,0.03); }
-      .log-line.expanded { background: rgba(255,255,255,0.02); border-bottom-color: var(--border); }
+      .log-line.expanded { background: rgba(255,255,255,0.02); border-bottom-color: var(--hair); }
       .log-line .t  { color: var(--fg-dim); font-feature-settings: "tnum"; white-space: nowrap; }
-      .log-line .ag { color: var(--accent-hi); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-      .log-line .lv { font-weight: 500; letter-spacing: 0.04em; white-space: nowrap; }
+      .log-line .ag { color: var(--fg-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      /* The level text is replaced by the row keyline; the element stays for
+         assistive tech and for the title tooltip. */
+      .log-line .lv { position: absolute; width: 1px; height: 1px; overflow: hidden; clip-path: inset(50%); }
+      .log-line.lv-ok   { border-left-color: var(--status-done); }
+      .log-line.lv-info { border-left-color: transparent; }
+      .log-line.lv-warn { border-left-color: var(--status-proposed); }
+      .log-line.lv-err  { border-left-color: var(--status-blocked); }
+      .log-line.lv-deny { border-left-color: var(--status-review); }
       .log-line .lv.ok   { color: var(--status-done); }
       .log-line .lv.info { color: var(--status-in-progress); }
       .log-line .lv.warn { color: var(--status-proposed); }
@@ -3716,6 +3861,18 @@
         height: 18px; background: linear-gradient(var(--bg-elev), transparent);
         pointer-events: none;
       }
+      .log-filters {
+        flex: 0 0 auto;
+        border-top: none !important;
+        border-bottom: 1px solid var(--hair);
+        padding: 7px 12px;
+        gap: 5px;
+        flex-wrap: nowrap;
+        white-space: nowrap;
+        overflow: hidden;
+      }
+      .log-filters .filter-pill { padding: 2px 7px; }
+      .log-filters .seg.right { margin-left: auto; }
       .log-foot {
         border-top: 1px solid var(--border);
         padding: 9px 16px;

--- a/crates/orbit-web/assets/dashboard/index.html
+++ b/crates/orbit-web/assets/dashboard/index.html
@@ -12,58 +12,81 @@
     <script src="/static/purify.min.js"></script>
     <link rel="stylesheet" href="/static/dashboard.css">  </head>
   <body>
-    <header>
-      <div class="brand">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 82 24" role="img" aria-label="Orbit">
+    <div class="shell">
+      <!-- ORB-10972: the top-level nav is a left rail. It keeps the `.tab` /
+           `.subtab` classes and the `#diag-subtabs` id the router selects on,
+           so every prior hash route resolves unchanged — only the nav's
+           position and presentation moved. Diagnostics' subtabs are visible
+           children here instead of a second row hidden inside the tab. -->
+      <nav class="rail" aria-label="Dashboard sections">
+        <div class="rail-brand">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 82 24" role="img" aria-label="Orbit">
           <g fill="none" stroke="#EDEDEF" stroke-linecap="round" stroke-linejoin="round" transform="translate(2 0)">
             <circle cx="12" cy="12" r="8.5" stroke-width="1.6"></circle>
             <circle cx="18.5" cy="6.5" r="2.5" fill="#6E9FFF" stroke="none"></circle>
           </g>
           <path fill="#EDEDEF" transform="translate(0 1)" d="M35.26 17.24c-1.73 0-3.12-.52-4.18-1.56-1.05-1.05-1.58-2.45-1.58-4.2 0-1.72.53-3.1 1.6-4.14 1.07-1.05 2.45-1.58 4.16-1.58s3.09.53 4.14 1.58c1.07 1.04 1.6 2.42 1.6 4.14 0 1.75-.53 3.15-1.58 4.2-1.06 1.04-2.45 1.56-4.16 1.56Zm0-2.46c.86 0 1.55-.3 2.06-.9.52-.61.78-1.41.78-2.4 0-.98-.26-1.76-.78-2.36-.51-.6-1.2-.9-2.06-.9s-1.56.3-2.08.9c-.51.6-.76 1.38-.76 2.36 0 .99.25 1.79.76 2.4.52.6 1.22.9 2.08.9ZM43.65 17V6h2.58l.18 1.48c.32-.54.73-.95 1.24-1.24.52-.29 1.13-.44 1.84-.44.31 0 .59.03.84.08v2.74a5.5 5.5 0 0 0-.96-.08c-.82 0-1.49.23-2 .7-.5.45-.76 1.14-.76 2.06V17h-3Zm14.05.24c-.76 0-1.42-.15-1.98-.46a3.6 3.6 0 0 1-1.32-1.26L54.16 17h-2.54V1.8h3v5.46c.36-.45.8-.81 1.32-1.08a4 4 0 0 1 1.78-.38c1.46 0 2.64.53 3.52 1.58.9 1.04 1.34 2.41 1.34 4.1 0 1.72-.45 3.11-1.36 4.18-.9 1.05-2.07 1.58-3.52 1.58Zm-.68-2.48c.78 0 1.39-.3 1.84-.9.46-.6.7-1.39.7-2.38 0-.98-.24-1.76-.7-2.34-.45-.6-1.06-.9-1.84-.9-.77 0-1.38.3-1.84.9-.45.58-.68 1.36-.68 2.34 0 .99.23 1.78.68 2.38.46.6 1.07.9 1.84.9ZM65.12 17V6h3v11h-3Zm1.5-12.44c-.51 0-.94-.17-1.28-.5-.33-.34-.5-.76-.5-1.26s.17-.91.5-1.24c.34-.34.77-.52 1.28-.52s.93.18 1.26.52c.34.33.52.74.52 1.24s-.18.92-.52 1.26c-.33.33-.75.5-1.26.5ZM76.13 17.2c-1.25 0-2.22-.31-2.9-.94-.68-.64-1.02-1.58-1.02-2.82V8.48H70.3V6h1.92V3.34h3V6h3.02v2.48h-3.02v4.98c0 .45.1.76.3.94.2.17.55.26 1.04.26h1.6V17c-.28.07-.61.12-1 .16-.37.03-.72.04-1.04.04Z"></path>
         </svg>
-      </div>
-      <div class="meta" id="meta">
-        <span id="conn-status" class="status-dot orange"></span>
-        <span id="meta-text">connecting&hellip;</span>
-        <div class="global-id-wrap">
-          <input type="search" id="global-task-id" placeholder="Jump to ORB-NNNNN" autocomplete="off" spellcheck="false" />
-          <span id="global-task-id-error" class="global-id-error"></span>
         </div>
-        <button id="refresh-btn" class="refresh-btn" type="button">Refresh</button>
-      </div>
-    </header>
-    <nav class="tabs" id="tabs">
-      <button class="tab" data-tab="tasks" type="button">Tasks</button>
-      <button class="tab" data-tab="audit" type="button">Audit</button>
-      <button class="tab" data-tab="diagnostics" type="button">Diagnostics</button>
-      <button class="tab" data-tab="operations" type="button">Operations</button>
-      <button class="tab" data-tab="knowledge" type="button">Knowledge</button>
-    </nav>
-    <section class="health-strip" id="health-strip" aria-label="Audit health summary">
-      <div class="tile" id="tile-events">
-        <span class="label">Events 24h</span>
-        <span class="value" id="tile-events-value">-</span>
-        <span class="glyph">EV</span>
-        <svg class="sparkline" id="tile-events-sparkline" viewBox="0 0 100 22" preserveAspectRatio="none" aria-hidden="true"></svg>
-      </div>
-      <div class="tile" id="tile-denials">
-        <span class="label">Denials 24h</span>
-        <span class="value" id="tile-denials-value">-</span>
-        <span class="glyph" id="tile-denials-glyph">DN</span>
-      </div>
-      <div class="tile" id="tile-failed">
-        <span class="label">Failed Runs 24h</span>
-        <span class="value" id="tile-failed-value">-</span>
-        <span class="glyph">FR</span>
-      </div>
-      <div class="tile" id="tile-active">
-        <span class="label">Active Long</span>
-        <span class="value" id="tile-active-value">-</span>
-        <span class="glyph">LR</span>
-      </div>
-    </section>
+
+        <div class="tabs" id="tabs">
+          <div class="rail-group">
+            <div class="rail-group-label">Work</div>
+          <button class="tab" data-tab="tasks" type="button"><svg class="rail-ico" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 5h14M3 10h14M3 15h9"/></svg><span class="rail-label">Tasks</span><span class="rail-count" id="rail-count-tasks"></span></button>
+          </div>
+
+          <div class="rail-group">
+            <div class="rail-group-label">Observe</div>
+          <button class="tab" data-tab="audit" type="button"><svg class="rail-ico" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 3h9l3 3v11H4z"/><path d="M7 9h6M7 12h4"/></svg><span class="rail-label">Audit</span><span class="rail-count" id="rail-count-audit"></span></button>
+          <button class="tab" data-tab="diagnostics" type="button"><svg class="rail-ico" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 12l4-6 3 4 3-6 4 8"/><path d="M2 16h14"/></svg><span class="rail-label">Diagnostics</span><span class="rail-count" id="rail-count-diagnostics"></span></button>
+            <nav class="subtabs rail-subtabs" id="diag-subtabs" aria-label="Diagnostics views">
+              <button class="subtab" data-subtab="runs" type="button">Recent runs<span class="rail-count" id="rail-count-diag-runs"></span></button>
+              <button class="subtab" data-subtab="metrics" type="button">Metrics<span class="rail-count" id="rail-count-diag-metrics"></span></button>
+              <button class="subtab" data-subtab="errors" type="button">Errors<span class="rail-count" id="rail-count-diag-errors"></span></button>
+              <button class="subtab" data-subtab="incidents" type="button">Incidents<span class="rail-count" id="rail-count-diag-incidents"></span></button>
+              <button class="subtab" data-subtab="reliability" type="button">Reliability<span class="rail-count" id="rail-count-diag-reliability"></span></button>
+              <button class="subtab" data-subtab="scoreboard" type="button">Scoreboard<span class="rail-count" id="rail-count-diag-scoreboard"></span></button>
+            </nav>
+          </div>
+
+          <div class="rail-group">
+            <div class="rail-group-label">Manage</div>
+          <button class="tab" data-tab="operations" type="button"><svg class="rail-ico" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="10" cy="10" r="7"/><path d="M10 6v4l3 2"/></svg><span class="rail-label">Operations</span><span class="rail-count" id="rail-count-operations"></span></button>
+          <button class="tab" data-tab="knowledge" type="button"><svg class="rail-ico" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4h5a2 2 0 0 1 2 2v10a2 2 0 0 0-2-2H4z"/><path d="M16 4h-5a2 2 0 0 0-2 2v10a2 2 0 0 1 2-2h5z"/></svg><span class="rail-label">Knowledge</span><span class="rail-count" id="rail-count-knowledge"></span></button>
+          </div>
+        </div>
+
+        <div class="rail-foot">
+          <div class="rail-workspace" id="rail-workspace"></div>
+          <div class="rail-conn">
+            <span id="conn-status" class="status-dot orange"></span>
+            <span id="meta-text">connecting&hellip;</span>
+          </div>
+        </div>
+      </nav>
+
+      <div class="main-col">
+        <header class="topbar">
+          <span class="crumb" id="topbar-crumb">Tasks</span>
+          <!-- ORB-10972: the four health metrics that used to occupy an 88px
+               strip ride inline here. Same data, same ids for the values. -->
+          <div class="kpis" id="health-strip" aria-label="Audit health summary">
+            <span class="kpi" id="tile-events"><span class="k">Events 24h</span><span class="v" id="tile-events-value">-</span></span>
+            <span class="kpi" id="tile-denials"><span class="k">Denials</span><span class="v" id="tile-denials-value">-</span></span>
+            <span class="kpi" id="tile-failed"><span class="k">Failed runs</span><span class="v" id="tile-failed-value">-</span></span>
+            <span class="kpi" id="tile-active"><span class="k">Long</span><span class="v" id="tile-active-value">-</span></span>
+            <svg class="kpi-spark" id="tile-events-sparkline" viewBox="0 0 100 22" preserveAspectRatio="none" aria-hidden="true"></svg>
+          </div>
+          <span class="topbar-spacer"></span>
+          <div class="global-id-wrap">
+            <input type="search" id="global-task-id" placeholder="Jump to ORB-NNNNN" autocomplete="off" spellcheck="false" />
+            <span id="global-task-id-error" class="global-id-error"></span>
+          </div>
+          <button id="refresh-btn" class="refresh-btn" type="button">Refresh</button>
+        </header>
+
     <section class="tab-pane" data-tab="tasks">
-      <main class="tasks-layout" style="grid-template-columns: minmax(0, 2fr) minmax(0, 1.15fr);">
+      <main class="tasks-layout" style="grid-template-columns: minmax(0, 1fr) 336px;">
         <div class="col-tasks" style="display: flex; flex-direction: column; min-width: 0;">
           <section class="panel" id="tasks-panel">
             <header><span>Tasks</span><span class="count" id="tasks-count">-</span></header>
@@ -81,33 +104,41 @@
             </div>
           </section>
         </div>
-        <div class="col-log">
-          <section class="panel" id="locks-panel">
-            <header><span>Locked files</span><span class="count" id="locks-count">0 files / 0 tasks</span></header>
-            <div class="body" id="locks-body"></div>
-          </section>
-          <section class="panel" id="log-panel">
-            <div class="log-resize-handle" id="log-panel-resize" role="separator" aria-orientation="horizontal" aria-label="Resize log panel" tabindex="0" title="Drag or use arrow keys to resize"></div>
-            <header class="head">
-              <div class="title"><span class="live-dot"></span>orbit.log <span style="color: var(--fg-dim); font-family: var(--font-mono); font-weight: 400; letter-spacing: 0; text-transform: none;">— tail -F</span></div>
-              <div class="actions">
-                <span class="count" id="log-count" style="background: var(--bg-elev); padding: 1px 8px; border: 1px solid var(--border); border-radius: 3px; font-family: var(--font-mono); font-size: 11px;">0</span>
-                <span class="count" id="log-buffered-count" style="display: none; cursor: pointer; background: var(--bg-elev); padding: 1px 8px; border: 1px solid var(--border); border-radius: 3px; font-family: var(--font-mono); font-size: 11px; margin-left: 6px;">0 buffered</span>
-                <button type="button" class="log-panel-toggle" id="log-panel-toggle" aria-expanded="true" aria-controls="logInner" title="Collapse or expand the log panel">collapse</button>
+        <!-- ORB-10972: the right column is a two-mode dock. Status keeps the
+             per-task file locks; Log hosts the orbit.log tail at full dock
+             height. The column width is identical in both modes, so switching
+             never reflows the task table beside it. -->
+        <div class="col-log" id="side-dock" data-mode="status">
+          <div class="dock-head">
+            <div class="dock-seg-group" id="dock-mode-toggle" role="tablist" aria-label="Right dock mode">
+              <button type="button" role="tab" class="dock-seg on" data-mode="status" aria-selected="true" tabindex="0">Status</button>
+              <button type="button" role="tab" class="dock-seg" data-mode="log" aria-selected="false" tabindex="-1">Log</button>
+            </div>
+            <span class="dock-meta"><span class="live-dot"></span><span id="log-count">0</span> lines</span>
+          </div>
+
+          <div class="dock-pane" data-pane="status">
+            <section class="panel" id="locks-panel">
+              <header><span>Locked files</span><span class="count" id="locks-count">0 files / 0 tasks</span></header>
+              <div class="body" id="locks-body"></div>
+            </section>
+          </div>
+
+          <div class="dock-pane" data-pane="log">
+            <section class="panel" id="log-panel">
+              <div class="log-foot log-filters">
+                <span class="filter-pill on" data-filter="all">all</span>
+                <span class="filter-pill" data-filter="err">err</span>
+                <span class="filter-pill" data-filter="deny">deny</span>
+                <span class="filter-pill" data-filter="warn">warn</span>
+                <span class="seg right on" id="log-follow-tail" title="Follow the tail"><b>&#8595;</b> follow</span>
+                <span class="count" id="log-buffered-count" style="display: none;">0 buffered</span>
               </div>
-            </header>
-            <div class="log-stream">
-              <div class="inner" id="logInner"></div>
-            </div>
-            <div class="log-foot">
-              <span class="seg"><b>filter</b></span>
-              <span class="filter-pill on" data-filter="all">all</span>
-              <span class="filter-pill" data-filter="err">err</span>
-              <span class="filter-pill" data-filter="deny">deny</span>
-              <span class="filter-pill" data-filter="warn">warn</span>
-              <span class="seg right on" id="log-follow-tail"><b>↓</b> follow tail</span>
-            </div>
-          </section>
+              <div class="log-stream">
+                <div class="inner" id="logInner"></div>
+              </div>
+            </section>
+          </div>
         </div>
       </main>
     </section>
@@ -390,6 +421,18 @@
         </section>
       </main>
     </section>
+      </div>
+    </div>
+    <!-- ORB-10972: always-on ambient line. Present on every tab, including the
+         ones where the dock is not mounted; log-tail.js mirrors each event here
+         as it arrives. This is what replaced the collapsed log panel. -->
+    <div class="log-statusbar empty" id="log-statusbar" role="status" aria-live="off" aria-label="Latest log line">
+      <span class="live-dot"></span>
+      <span class="sb-label">orbit.log</span>
+      <span class="sb-t" id="log-statusbar-time"></span>
+      <span class="sb-ag" id="log-statusbar-source"></span>
+      <span class="sb-m" id="log-statusbar-message"></span>
+    </div>
     <div id="gantt-tooltip" role="tooltip" aria-hidden="true"></div>
     <script type="module" src="/static/app.js"></script>
   </body>

--- a/crates/orbit-web/assets/dashboard/log-tail.js
+++ b/crates/orbit-web/assets/dashboard/log-tail.js
@@ -18,24 +18,23 @@ let logRows = []; // Keep track to enforce max 200 after 250 limit
 let activeLogFilters = new Set(["all"]);
 let logPanelResizeWired = false;
 
-// ORB-10874: the log pane can be collapsed and resized; both are local
-// presentation preferences (not shared/synced state), so they persist to
-// localStorage rather than the URL. `heightPx` is only present once the
-// operator has dragged the handle — until then the panel keeps auto-fitting
-// to the viewport exactly as before.
+// ORB-10972: the log lives in the Tasks tab's right dock, which has two modes
+// — Status (in-flight runs, locked files, sweep clock) and Log (the tail at
+// full dock height). The mode is a local presentation preference, not shared
+// state, so it persists to localStorage rather than the URL. This supersedes
+// ORB-10874's collapse toggle and height-resize handle: a full-height dock has
+// no height to negotiate, and the always-visible bottom status bar took over
+// the job the collapsed panel used to do.
 const LOG_PANEL_PREFS_KEY = "orbit.dashboard.logPanel";
-const LOG_PANEL_MIN_HEIGHT = 160;
+const DOCK_MODES = ["status", "log"];
 
 function loadLogPanelPrefs() {
   try {
     const raw = window.localStorage.getItem(LOG_PANEL_PREFS_KEY);
     const parsed = raw ? JSON.parse(raw) : {};
-    return {
-      collapsed: Boolean(parsed.collapsed),
-      heightPx: Number.isFinite(parsed.heightPx) ? parsed.heightPx : null,
-    };
+    return { dockMode: DOCK_MODES.includes(parsed.dockMode) ? parsed.dockMode : "status" };
   } catch (_) {
-    return { collapsed: false, heightPx: null };
+    return { dockMode: "status" };
   }
 }
 
@@ -49,116 +48,81 @@ function saveLogPanelPrefs(prefs) {
 
 let logPanelPrefs = loadLogPanelPrefs();
 
-function maxLogPanelHeight() {
-  const panel = $("log-panel");
-  if (!panel) return Infinity;
-  const top = panel.getBoundingClientRect().top;
-  return Math.max(LOG_PANEL_MIN_HEIGHT, Math.floor(window.innerHeight - top - 24));
-}
-
+// Kept as the exported name because app.js (refreshDashboard) and router.js
+// (setActiveTab) both call it. The dock is sized by the CSS grid now, so there
+// is no viewport arithmetic left — this only re-asserts the current mode.
 export function fitLogPanelToViewport() {
-  const panel = $("log-panel");
-  if (!panel) return;
-  applyLogPanelCollapsedState();
-  if (logPanelPrefs.collapsed) return;
-  const cap = maxLogPanelHeight();
-  const height = logPanelPrefs.heightPx != null
-    ? Math.min(Math.max(logPanelPrefs.heightPx, LOG_PANEL_MIN_HEIGHT), cap)
-    : cap;
-  panel.style.setProperty("--log-panel-height", `${height}px`);
+  applyDockMode();
 }
 
-function applyLogPanelCollapsedState() {
-  const panel = $("log-panel");
-  const toggle = $("log-panel-toggle");
-  if (!panel) return;
-  panel.classList.toggle("collapsed", logPanelPrefs.collapsed);
-  if (toggle) {
-    toggle.setAttribute("aria-expanded", logPanelPrefs.collapsed ? "false" : "true");
-    toggle.textContent = logPanelPrefs.collapsed ? "expand" : "collapse";
-  }
-  if (logPanelPrefs.collapsed) {
-    panel.style.removeProperty("--log-panel-height");
+function applyDockMode() {
+  const dock = $("side-dock");
+  if (!dock) return;
+  const mode = logPanelPrefs.dockMode;
+  dock.dataset.mode = mode;
+  for (const btn of document.querySelectorAll("#dock-mode-toggle .dock-seg")) {
+    const on = btn.dataset.mode === mode;
+    btn.classList.toggle("on", on);
+    btn.setAttribute("aria-selected", on ? "true" : "false");
+    btn.tabIndex = on ? 0 : -1;
   }
 }
 
-function wireLogPanelToggle() {
-  const toggle = $("log-panel-toggle");
+function setDockMode(mode) {
+  if (!DOCK_MODES.includes(mode)) return;
+  logPanelPrefs = { ...logPanelPrefs, dockMode: mode };
+  saveLogPanelPrefs(logPanelPrefs);
+  applyDockMode();
+}
+
+function wireDockModeToggle() {
+  const toggle = $("dock-mode-toggle");
   if (!toggle) return;
-  toggle.addEventListener("click", () => {
-    logPanelPrefs = { ...logPanelPrefs, collapsed: !logPanelPrefs.collapsed };
-    saveLogPanelPrefs(logPanelPrefs);
-    fitLogPanelToViewport();
+  for (const btn of toggle.querySelectorAll(".dock-seg")) {
+    btn.addEventListener("click", () => setDockMode(btn.dataset.mode));
+  }
+  // Arrow keys move between the two segments, matching the window selectors.
+  toggle.addEventListener("keydown", (event) => {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    event.preventDefault();
+    const idx = DOCK_MODES.indexOf(logPanelPrefs.dockMode);
+    const next = event.key === "ArrowLeft" ? idx - 1 : idx + 1;
+    const mode = DOCK_MODES[(next + DOCK_MODES.length) % DOCK_MODES.length];
+    setDockMode(mode);
+    const btn = toggle.querySelector(`.dock-seg[data-mode="${mode}"]`);
+    if (btn) btn.focus();
   });
 }
 
-// A pointer-driven drag handle on the log panel's top edge. Dragging sets an
-// explicit height (persisted), clamped so the panel can never be resized
-// smaller than LOG_PANEL_MIN_HEIGHT nor larger than the viewport allows —
-// the task list beside/above it keeps its own independent minimum height
-// (dashboard.css), so this clamp only protects the log panel itself.
-function wireLogPanelResizeHandle() {
-  const handle = $("log-panel-resize");
-  const panel = $("log-panel");
-  if (!handle || !panel) return;
-
-  let dragStartY = 0;
-  let dragStartHeight = 0;
-
-  const onPointerMove = (event) => {
-    const delta = event.clientY - dragStartY;
-    const cap = maxLogPanelHeight();
-    const next = Math.min(Math.max(dragStartHeight + delta, LOG_PANEL_MIN_HEIGHT), cap);
-    panel.style.setProperty("--log-panel-height", `${next}px`);
-  };
-
-  const onPointerUp = (event) => {
-    document.removeEventListener("pointermove", onPointerMove);
-    document.removeEventListener("pointerup", onPointerUp);
-    const rect = panel.getBoundingClientRect();
-    logPanelPrefs = { ...logPanelPrefs, heightPx: Math.round(rect.height), collapsed: false };
-    saveLogPanelPrefs(logPanelPrefs);
-    applyLogPanelCollapsedState();
-  };
-
-  handle.addEventListener("pointerdown", (event) => {
-    if (logPanelPrefs.collapsed) return;
-    event.preventDefault();
-    dragStartY = event.clientY;
-    dragStartHeight = panel.getBoundingClientRect().height;
-    document.addEventListener("pointermove", onPointerMove);
-    document.addEventListener("pointerup", onPointerUp);
-  });
-
-  // Keyboard resize (ArrowUp/ArrowDown) for operators who cannot drag.
-  handle.addEventListener("keydown", (event) => {
-    if (logPanelPrefs.collapsed) return;
-    const step = 32;
-    let delta = 0;
-    if (event.key === "ArrowUp") delta = -step;
-    else if (event.key === "ArrowDown") delta = step;
-    else return;
-    event.preventDefault();
-    const cap = maxLogPanelHeight();
-    const current = panel.getBoundingClientRect().height;
-    const next = Math.min(Math.max(current + delta, LOG_PANEL_MIN_HEIGHT), cap);
-    panel.style.setProperty("--log-panel-height", `${next}px`);
-    logPanelPrefs = { ...logPanelPrefs, heightPx: Math.round(next), collapsed: false };
-    saveLogPanelPrefs(logPanelPrefs);
-  });
+// ORB-10972: the bottom status bar carries the newest line on every tab, not
+// just the Tasks tab where the dock is mounted. The SSE connection is opened
+// once at boot and never torn down on a tab change, so mirroring here is
+// enough to keep the bar live everywhere.
+function updateLogStatusBar(ev) {
+  const bar = $("log-statusbar");
+  if (!bar || !ev) return;
+  let timeStr = ev.ts || "";
+  if (timeStr && timeStr.includes("T")) {
+    const d = new Date(timeStr);
+    if (!isNaN(d.getTime())) timeStr = d.toLocaleTimeString("en-US", { hour12: false });
+  }
+  const t = $("log-statusbar-time");
+  const ag = $("log-statusbar-source");
+  const m = $("log-statusbar-message");
+  if (t) t.textContent = timeStr;
+  if (ag) ag.textContent = ev.source || "";
+  if (m) {
+    m.innerHTML = ev.message_html || "";
+    m.dataset.level = getLogClass(ev.level, ev.code);
+  }
+  bar.classList.remove("empty");
 }
 
 function wireLogPanelResize() {
   if (logPanelResizeWired) return;
   logPanelResizeWired = true;
-  const scheduleFit = () => requestAnimationFrame(fitLogPanelToViewport);
-  window.addEventListener("resize", scheduleFit);
-  if (window.visualViewport) {
-    window.visualViewport.addEventListener("resize", scheduleFit);
-  }
-  wireLogPanelToggle();
-  wireLogPanelResizeHandle();
-  applyLogPanelCollapsedState();
+  wireDockModeToggle();
+  applyDockMode();
 }
 
 function getLogClass(level, code) {
@@ -185,7 +149,12 @@ function renderLogEvent(ev, isFresh) {
   const tSpan = el("span", { class: "t", text: timeStr });
   const agSpan = el("span", { class: "ag", text: ev.source || "" });
   const lvClass = getLogClass(ev.level, ev.code);
-  const lvSpan = el("span", { class: `lv ${lvClass}`, text: ev.code || "" });
+  // ORB-10972: the dock is 336px, so the level is carried by a coloured
+  // keyline on the row rather than a 42px text column — that width goes to the
+  // message instead. The class stays on the span for the filter code, which
+  // reads it back out of dataset.
+  row.classList.add(`lv-${lvClass}`);
+  const lvSpan = el("span", { class: `lv ${lvClass}`, title: ev.code || "", text: ev.code || "" });
   const mSpan = el("span", { class: "m" });
   mSpan.innerHTML = ev.message_html || "";
 
@@ -214,6 +183,7 @@ export function initLogTail() {
       logRows.push(row);
     });
     applyLogFilters();
+    if (events.length > 0) updateLogStatusBar(events[events.length - 1]);
     connectLogStream();
   }).catch(console.error);
   
@@ -235,7 +205,7 @@ export function initLogTail() {
     });
   }
 
-  document.querySelectorAll("#log-panel .filter-pill").forEach(pill => {
+  document.querySelectorAll("#side-dock .filter-pill").forEach(pill => {
     pill.addEventListener("click", (e) => {
       const filter = e.currentTarget.dataset.filter;
       if (filter === "all") {
@@ -253,7 +223,7 @@ export function initLogTail() {
         }
       }
       
-      document.querySelectorAll("#log-panel .filter-pill").forEach(p => {
+      document.querySelectorAll("#side-dock .filter-pill").forEach(p => {
         p.classList.toggle("on", activeLogFilters.has(p.dataset.filter));
       });
       applyLogFilters();
@@ -316,6 +286,7 @@ function connectLogStream() {
   logStream.onmessage = (e) => {
     try {
       const ev = JSON.parse(e.data);
+      updateLogStatusBar(ev);
       if (logFollowTail) {
         const inner = $("logInner");
         const row = renderLogEvent(ev, true);

--- a/crates/orbit-web/assets/dashboard/router.js
+++ b/crates/orbit-web/assets/dashboard/router.js
@@ -212,7 +212,21 @@ function setActiveTabImpl(ctx, raw, opts = {}) {
     top = "tasks";
   }
   ctx.setTab(top);
+  // ORB-10972: the topbar breadcrumb names the active destination, since the
+  // rail no longer sits above the content where the tab strip used to.
+  const crumb = $("topbar-crumb");
+  if (crumb) {
+    crumb.textContent = top === "run-detail"
+      ? "Run detail"
+      : top.charAt(0).toUpperCase() + top.slice(1);
+  }
   document.body.classList.toggle("operations-active", top === "operations");
+  // ORB-10972: the Diagnostics subtabs are permanently visible in the rail now,
+  // so the remembered-subtab highlight must be muted while another destination
+  // is active — otherwise the rail shows two things selected at once. The
+  // `.active` class itself is left alone; it is still the remembered choice.
+  const diagSubtabs = $("diag-subtabs");
+  if (diagSubtabs) diagSubtabs.classList.toggle("dimmed", top !== "diagnostics");
   if (top !== "diagnostics") {
     document.body.classList.remove("reliability-active");
     markWorkspaceSelectorScope(false);

--- a/crates/orbit-web/assets/dashboard/tasks.js
+++ b/crates/orbit-web/assets/dashboard/tasks.js
@@ -1214,6 +1214,10 @@ export function renderTasks(tasks, context) {
 
   const filtered = filterTasks(tasks, context);
   $("tasks-count").textContent = formatTaskCount(filtered.length, tasks.length, tasksMeta(context));
+  // ORB-10972: the rail shows the same filtered count the panel header does,
+  // so the Tasks entry reads correctly from any other tab.
+  const railCount = document.getElementById("rail-count-tasks");
+  if (railCount) railCount.textContent = String(filtered.length);
   renderFilterSummary(context);
   if (filtered.length === 0 && frag.children.length === 0) {
     const defaultText = tasks.length === 0 ? "No tasks available." : "No tasks match filter.";

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -1058,37 +1058,158 @@ fn dashboard_workspace_selection_persists_to_the_url() {
     );
 }
 
-/// ORB-10874: the live `orbit.log` panel can now be collapsed and resized,
-/// and the presentation choice is remembered locally (not shared/synced
-/// state, so localStorage rather than the URL). The task list keeps an
-/// explicit minimum height so it can never be squeezed toward zero.
+/// ORB-10972 supersedes ORB-10874's log-panel affordances. The tail moved into
+/// the Tasks tab's right dock, which has two modes (Status / Log) and fills the
+/// column's full height — so there is no panel height to drag and no collapsed
+/// state to toggle. Their job is now split between the dock's mode toggle and
+/// an always-on bottom status bar that carries the newest line on every tab.
+/// What survives from ORB-10874 is the principle: the presentation choice is
+/// local, so it persists to localStorage under the same key, and the task list
+/// keeps an explicit minimum height so it can never be squeezed toward zero.
 #[test]
-fn dashboard_log_panel_is_collapsible_resizable_and_remembers_presentation() {
+fn dashboard_log_dock_has_two_modes_and_an_always_on_status_bar() {
     let log_tail = include_str!("../../assets/dashboard/log-tail.js");
     let index = include_str!("../../assets/dashboard/index.html");
     let css = include_str!("../../assets/dashboard/dashboard.css");
 
     assert!(
         log_tail.contains("orbit.dashboard.logPanel"),
-        "the log panel's collapsed/height preference must persist to localStorage"
+        "the dock's mode preference must persist to localStorage"
     );
     assert!(
-        log_tail.contains("function wireLogPanelToggle(")
-            && log_tail.contains("function wireLogPanelResizeHandle("),
-        "the log panel must offer both a collapse toggle and a resize handle"
+        log_tail.contains(r#"const DOCK_MODES = ["status", "log"];"#)
+            && log_tail.contains("function wireDockModeToggle("),
+        "the dock must offer exactly the Status and Log modes, with a wired toggle"
     );
     assert!(
-        index.contains(r#"id="log-panel-toggle""#) && index.contains(r#"id="log-panel-resize""#),
-        "the toggle and resize handle must exist in the markup"
+        !log_tail.contains("wireLogPanelResizeHandle")
+            && !log_tail.contains("LOG_PANEL_MIN_HEIGHT"),
+        "the superseded height-resize handle must be gone, not left dead"
     );
     assert!(
-        css.contains("#log-panel.collapsed") && css.contains(".log-resize-handle"),
-        "the collapsed state and the resize handle must be styled"
+        index.contains(r#"id="dock-mode-toggle""#) && index.contains(r#"id="side-dock""#),
+        "the dock and its mode toggle must exist in the markup"
     );
+    assert!(
+        index.contains(r#"data-pane="status""#) && index.contains(r#"data-pane="log""#),
+        "the dock must declare both panes"
+    );
+    assert!(
+        css.contains(r#"#side-dock[data-mode="log"] .dock-pane[data-pane="log"]"#),
+        "the visible pane must be driven by the host's data-mode, so the column \
+         width is identical in both modes and the task table never reflows"
+    );
+
+    // The always-on ambient line, present on every tab — including the ones
+    // where the dock is not mounted.
+    assert!(
+        index.contains(r#"id="log-statusbar""#)
+            && index.contains(r#"id="log-statusbar-message""#),
+        "the bottom status bar must exist in the markup"
+    );
+    assert!(
+        log_tail.contains("function updateLogStatusBar(")
+            && log_tail.contains("updateLogStatusBar(ev);"),
+        "each incoming log event must be mirrored into the status bar"
+    );
+    assert!(
+        css.contains(".log-statusbar"),
+        "the status bar must be styled"
+    );
+
     assert!(
         css.contains("#tasks-panel > .body") && css.contains("min-height: 240px;"),
-        "the task list must keep a guaranteed minimum usable height regardless of log panel state"
+        "the task list must keep a guaranteed minimum usable height"
     );
+}
+
+/// ORB-10972: the top-level nav is a left rail, and the vertical chrome above
+/// the task table collapses into one bar. The rail keeps the class and id
+/// contract `router.js` selects on, which is what makes every prior hash route
+/// resolve unchanged.
+#[test]
+fn dashboard_nav_rail_preserves_the_router_selector_contract() {
+    let index = include_str!("../../assets/dashboard/index.html");
+    let css = include_str!("../../assets/dashboard/dashboard.css");
+    let app = include_str!("../../assets/dashboard/app.js");
+
+    assert!(
+        index.contains(r#"<nav class="rail""#) && css.contains(".rail {"),
+        "the nav must render as a rail"
+    );
+    // The router appends #tab-indicator to `.tabs` and #subtab-indicator to
+    // `#diag-subtabs`, and toggles `.active` on `.tab` / `.subtab`. Those hooks
+    // must survive the move or every route breaks at once.
+    assert!(
+        index.contains(r#"<div class="tabs" id="tabs">"#),
+        "the router appends its indicator to .tabs; the container must remain"
+    );
+    assert!(
+        index.contains(r#"id="diag-subtabs""#),
+        "Diagnostics' subtabs keep their id, now as visible rail children"
+    );
+    assert!(
+        css.contains(".rail .tab-indicator { display: none !important; }"),
+        "the sliding underline is suppressed in the rail, not removed from the router"
+    );
+
+    // The four health metrics ride inline in the top bar, keeping their ids.
+    assert!(
+        index.contains(r#"class="topbar""#) && index.contains(r#"class="kpis" id="health-strip""#),
+        "the health metrics must ride inline in the top bar"
+    );
+    for id in [
+        "tile-events-value",
+        "tile-denials-value",
+        "tile-failed-value",
+        "tile-active-value",
+    ] {
+        assert!(index.contains(&format!(r#"id="{id}""#)), "{id} must survive the move");
+    }
+
+    // Rail counts come from data the dashboard already fetches — no new endpoint.
+    assert!(
+        app.contains("function setRailCount("),
+        "rail counts must be set through one helper"
+    );
+    assert!(
+        css.contains(".rail-count.alert"),
+        "a failure count must be distinguishable in the rail"
+    );
+}
+
+/// ORB-10972: a two-tier border scale. `--border` draws panel and control
+/// edges; `--hair` draws hairlines inside them. Before this both were #333333,
+/// which made the panel grid read as loud as its contents.
+#[test]
+fn dashboard_separates_panel_edges_from_internal_hairlines() {
+    let css = include_str!("../../assets/dashboard/dashboard.css");
+
+    assert!(
+        css.contains("--hair: #17171a;") && css.contains("--border: #2a2a2e;"),
+        "both tiers must be defined, and they must differ"
+    );
+    assert!(
+        css.contains("--fg-mute:"),
+        "the tertiary text tier must be defined alongside them"
+    );
+
+    // The hairlines that separate rows within a panel must use the inner tier.
+    for rule in [
+        ".row {",
+        ".row.header {",
+        ".controls {",
+        ".filter-summary {",
+        ".panel > header {",
+    ] {
+        let start = css.find(rule).unwrap_or_else(|| panic!("{rule} must exist"));
+        let block = &css[start..start + 900.min(css.len() - start)];
+        let end = block.find('}').map(|i| &block[..i]).unwrap_or(block);
+        assert!(
+            !end.contains("1px solid var(--border)"),
+            "{rule} draws an internal hairline; it must use --hair, not --border"
+        );
+    }
 }
 
 /// ORB-10874: inline status/crew edits must show a pending state, refuse a


### PR DESCRIPTION
Resolves ORB-10972.

The dashboard's navigation was buried and its vertical budget went to chrome. Five top-level tabs, with Diagnostics hiding six subtabs behind a second row — you could not tell from the Tasks screen that runs had failed under Diagnostics → Errors. Header, tab strip and health strip together cost ~194px before the first task row, and every internal hairline was the same `#333333` as the panel edges, so the grid read as loud as its contents.

## What changed

**Left rail, 216px.** Replaces the tab strip. Three labelled groups (Work / Observe / Manage); Diagnostics' six subtabs are visible children there instead of a hidden second row. Each entry carries a count, drawn in `--status-blocked` when it represents failures. Counts come from fetches the dashboard already makes — no new endpoint.

**52px top bar.** Breadcrumb, the four health metrics inline, the global `ORB-NNNNN` jump, Refresh. Replaces the header + tabs + health strip stack.

**Right dock, 336px, two modes.** Status holds the file locks; Log holds the `orbit.log` tail at full dock height. The column's box is identical in both modes, so switching never reflows the task table. The log line drops its 42px level column for a coloured keyline, returning that width to the message.

**30px status bar** pinned below the shell, carrying the newest line on every tab.

**Two-tier borders.** `--border` (#2a2a2e) for panel and control edges, `--hair` (#17171a) for hairlines inside them.

## Why routing is safe

The rail reuses the exact classes and ids `router.js` selects on — `.tab`, `.subtab`, `.tabs`, `#diag-subtabs` and the rest. The nav's position moved; its contract did not. The sliding indicator is suppressed by CSS rather than removed from the router, so `indicator.style.display = ""` still clears cleanly.

## Supersedes ORB-10874's log-panel affordances

The collapse toggle and drag-resize handle are gone: a full-height dock has no height to negotiate, and the always-on status bar took over the job the collapsed panel did. The `orbit.dashboard.logPanel` localStorage key is retained, now holding the dock mode. Its test was rewritten to assert the new equivalents rather than keep dead affordances.

## Also fixes

A bug the rail exposes: the remembered Diagnostics subtab kept its highlight while another destination was active, so the rail showed two selections at once. Invisible while the subtabs lived inside the pane.

## Validation

- `cargo test -p orbit-web` — 253 passed, 0 failed (rebased onto `agent-main` and re-run).
- All 13 routes walked live at 1440x900: correct pane, rail marking and breadcrumb, zero JS errors.
- Dock mode switch measured: grid `80px 258px 128px 132px`, panel and every cell width byte-identical across status → log → status.
- 1280x800: no horizontal overflow, all columns full width, no rail collapse needed.
- Chrome above the task panel: 72px, down from ~218px. Ten fully-visible task rows against seven.

## Reviewer judgement wanted

1. **Chrome is 72px, not the "under 60px" the task's criterion asked for.** 52px is fixed chrome; the other 20px is the `main` gutter, which existed before too. Hitting 60 means cutting the gutter to 8px — fitting the design to a number estimated before measuring, so it was left for a decision.
2. **The log tail is taller but narrower** — ~30 lines against ~18, but the message cell is ~157px against ~250px in the old wider column. Long messages truncate sooner; click-to-expand is unchanged. Widening the dock would break the no-reflow guarantee.
3. **One of four Status-dock sections is built.** Locked files is wired. In flight, Needs attention and Sweep clock each need a fetch the Tasks tab does not currently make — new per-30s traffic on the primary screen plus aggregate-view guards. Left as a product call rather than added silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
