### PR TITLE
Map Grok Build usage-ledger model ids to the requested public model

### DIFF
--- a/crates/orbit-agent/src/types/tests/response.rs
+++ b/crates/orbit-agent/src/types/tests/response.rs
@@ -172,8 +172,10 @@ mod parse {
 
     #[test]
     fn grok_json_wrapper_reports_no_model_or_cost() {
-        // The production Grok fix established this text/stopReason wrapper;
-        // the wrapper carries neither model identity nor a USD total.
+        // Wrappers that still omit provider metadata (older Grok CLI, or a
+        // result with only the text/stopReason envelope) leave both fields
+        // unset. Live `grok` 1.0.5+ results add modelUsage/total_cost_usd and
+        // are covered by grok_json_wrapper_extracts_model_usage_and_cost.
         let stdout = serde_json::json!({
             "text": "{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}",
             "stopReason": "EndTurn"
@@ -184,6 +186,33 @@ mod parse {
             parse_and_validate_response(&exec(&stdout, "", Some(0), true)).expect("Grok parses");
         assert_eq!(trace.provider_model, None);
         assert_eq!(trace.provider_cost_usd, None);
+    }
+
+    #[test]
+    fn grok_json_wrapper_extracts_model_usage_and_cost() {
+        // Captured shape from Grok Build CLI 1.0.5 (`jrun-20260822-1925-3`):
+        // `--model grok-4.6` produces a Claude-style wrapper whose usage
+        // ledger key is `grok-4.6-build` and which reports total_cost_usd.
+        // Extraction keeps the ledger key verbatim; ingest identity maps it
+        // to the requested public menu id.
+        let stdout = serde_json::json!({
+            "text": "{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}",
+            "stopReason": "EndTurn",
+            "total_cost_usd": 0.0123,
+            "modelUsage": {
+                "grok-4.6-build": {
+                    "inputTokens": 100,
+                    "outputTokens": 20,
+                    "costUSD": 0.0123
+                }
+            }
+        })
+        .to_string();
+
+        let (_, _, trace) =
+            parse_and_validate_response(&exec(&stdout, "", Some(0), true)).expect("Grok parses");
+        assert_eq!(trace.provider_model.as_deref(), Some("grok-4.6-build"));
+        assert_eq!(trace.provider_cost_usd, Some(0.0123));
     }
 
     #[test]

--- a/crates/orbit-core/src/runtime/engine/identity.rs
+++ b/crates/orbit-core/src/runtime/engine/identity.rs
@@ -48,22 +48,29 @@ impl OrbitRuntime {
             .filter(|value| !value.is_empty())
             .map(ToOwned::to_owned);
 
-        if let (Some(requested_model), Some(provider_model)) =
-            (requested_model.as_deref(), provider_model.as_deref())
-            && requested_model != provider_model
-        {
-            tracing::warn!(
-                target: "orbit.core.invocation",
-                job_run_id,
-                activity_id,
-                agent_cli,
-                requested_model,
-                provider_model,
-                "provider-reported model differs from requested model",
-            );
-        }
+        let stored_model = match (requested_model.as_deref(), provider_model.as_deref()) {
+            (Some(requested), Some(provider))
+                if grok_build_ledger_aliases_requested(requested, provider) =>
+            {
+                Some(requested.to_string())
+            }
+            (Some(requested), Some(provider)) if requested != provider => {
+                tracing::warn!(
+                    target: "orbit.core.invocation",
+                    job_run_id,
+                    activity_id,
+                    agent_cli,
+                    requested_model = requested,
+                    provider_model = provider,
+                    "provider-reported model differs from requested model",
+                );
+                Some(provider.to_string())
+            }
+            (_, Some(provider)) => Some(provider.to_string()),
+            (_, None) => requested_model,
+        };
 
-        (agent, provider_model.or(requested_model))
+        (agent, stored_model)
     }
 
     pub(crate) fn try_canonical_agent_model_identity(
@@ -93,4 +100,14 @@ impl OrbitRuntime {
             .map(ToOwned::to_owned);
         (agent, model)
     }
+}
+
+/// Grok Build's usage ledger names requested public menu id `grok-X.Y` as
+/// `grok-X.Y-build`. That suffix is a billing label, not a different public
+/// model, so ingest stores the requested id used by the shipped price table.
+fn grok_build_ledger_aliases_requested(requested: &str, provider: &str) -> bool {
+    requested.starts_with("grok-")
+        && provider
+            .strip_suffix("-build")
+            .is_some_and(|public_id| public_id == requested)
 }

--- a/crates/orbit-core/src/runtime/engine/tests/identity.rs
+++ b/crates/orbit-core/src/runtime/engine/tests/identity.rs
@@ -7,11 +7,19 @@
 //! public `RuntimeHost::resolved_agent_model_pair` surface.
 
 use std::collections::HashMap;
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 use chrono::Utc;
+use orbit_common::derive_cost_usd;
 use orbit_engine::RuntimeHost;
+use orbit_store::InvocationQuery;
 use orbit_types::identity::AgentModelPair;
+use orbit_types::telemetry::{InvocationTrace, TokenUsage};
 use orbit_types::workflow::{ExecutorDef, ExecutorType, ModelPairOverride};
+use tracing::field::{Field, Visit};
+use tracing::{Event, Metadata, Subscriber, span};
 
 use crate::OrbitRuntime;
 
@@ -73,5 +81,217 @@ fn resolved_agent_model_pair_is_none_for_an_unregistered_executor() {
     assert_eq!(
         RuntimeHost::resolved_agent_model_pair(&runtime, "not-registered"),
         None
+    );
+}
+
+const GROK_LEDGER_MISMATCH_WARNING: &str = "provider-reported model differs from requested model";
+
+fn seed_running_job_run(runtime: &OrbitRuntime, job_id: &str) -> String {
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run(job_id, 1, Utc::now(), None, None)
+        .expect("insert job run");
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, Utc::now(), std::process::id())
+        .expect("mark run running");
+    run.run_id
+}
+
+fn grok_usage() -> TokenUsage {
+    TokenUsage {
+        input: 1_000,
+        output: 250,
+        ..TokenUsage::default()
+    }
+}
+
+fn capture_invocation_warnings<F, T>(f: F) -> (T, Vec<CapturedWarning>)
+where
+    F: FnOnce() -> T,
+{
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = WarningCaptureSubscriber {
+        events: Arc::clone(&events),
+        next_span_id: AtomicU64::new(1),
+    };
+    let result = tracing::subscriber::with_default(subscriber, f);
+    let events = events.lock().expect("events lock").clone();
+    (result, events)
+}
+
+#[derive(Debug, Clone)]
+struct CapturedWarning {
+    target: String,
+    message: String,
+}
+
+struct WarningCaptureSubscriber {
+    events: Arc<Mutex<Vec<CapturedWarning>>>,
+    next_span_id: AtomicU64,
+}
+
+impl Subscriber for WarningCaptureSubscriber {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        metadata.target() == "orbit.core.invocation"
+    }
+
+    fn new_span(&self, _span: &span::Attributes<'_>) -> span::Id {
+        span::Id::from_u64(self.next_span_id.fetch_add(1, Ordering::Relaxed))
+    }
+
+    fn record(&self, _span: &span::Id, _values: &span::Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        let mut visitor = MessageCapture::default();
+        event.record(&mut visitor);
+        self.events
+            .lock()
+            .expect("events lock")
+            .push(CapturedWarning {
+                target: event.metadata().target().to_string(),
+                message: visitor.message,
+            });
+    }
+
+    fn enter(&self, _span: &span::Id) {}
+
+    fn exit(&self, _span: &span::Id) {}
+}
+
+#[derive(Default)]
+struct MessageCapture {
+    message: String,
+}
+
+impl Visit for MessageCapture {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message = value.to_string();
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if field.name() == "message" && self.message.is_empty() {
+            self.message = format!("{value:?}");
+        }
+    }
+}
+
+fn has_provider_model_mismatch_warning(events: &[CapturedWarning]) -> bool {
+    events.iter().any(|event| {
+        event.target == "orbit.core.invocation"
+            && event.message.contains(GROK_LEDGER_MISMATCH_WARNING)
+    })
+}
+
+#[test]
+fn grok_build_ledger_model_is_stored_as_the_requested_public_id() {
+    // Live Grok Build JSON (`grok` 1.0.5+) carries modelUsage key
+    // `grok-4.6-build` for `--model grok-4.6`. Parser extraction keeps the
+    // ledger key; ingest identity must persist the priced public menu id.
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let run_id = seed_running_job_run(&runtime, "grok_ledger_job");
+    let usage = grok_usage();
+    let trace = InvocationTrace {
+        usage: usage.clone(),
+        provider_model: Some("grok-4.6-build".to_string()),
+        provider_cost_usd: Some(0.0123),
+        ..InvocationTrace::default()
+    };
+
+    let ((), warnings) = capture_invocation_warnings(|| {
+        RuntimeHost::persist_invocation_trace(
+            &runtime,
+            &run_id,
+            "implement_one",
+            "grok",
+            Some("grok-4.6"),
+            &serde_json::json!({ "task_id": "ORB-10970" }),
+            &trace,
+        )
+        .expect("persist grok ledger ingest");
+    });
+
+    assert!(
+        !has_provider_model_mismatch_warning(&warnings),
+        "grok-4.6 vs grok-4.6-build must not warn; captured={warnings:?}"
+    );
+
+    let records = runtime
+        .invocation_records(InvocationQuery {
+            job_run_id: Some(run_id),
+            limit: 1,
+            ..InvocationQuery::default()
+        })
+        .expect("query invocation records");
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].model.as_deref(), Some("grok-4.6"));
+    let derived = records[0].derived_cost_usd.expect("grok-4.6 is priced");
+    let expected =
+        derive_cost_usd("grok-4.6", records[0].ts, &usage).expect("shipped grok-4.6 row");
+    assert!(
+        (derived - expected).abs() < 1e-12,
+        "derived={derived} expected={expected}"
+    );
+    assert_eq!(
+        derive_cost_usd("grok-4.6-build", records[0].ts, &usage),
+        None,
+        "the usage-ledger id itself is not a priced row"
+    );
+}
+
+#[test]
+fn grok_build_ledger_alias_does_not_warn_for_matching_public_id() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    for (requested, provider) in [
+        ("grok-4.6", "grok-4.6-build"),
+        ("grok-4.5", "grok-4.5-build"),
+    ] {
+        let (stored, warnings) = capture_invocation_warnings(|| {
+            runtime
+                .invocation_agent_model_identity(
+                    "grok",
+                    Some(requested),
+                    Some(provider),
+                    "jrun-grok-ledger",
+                    "implement_one",
+                )
+                .1
+        });
+        assert_eq!(
+            stored.as_deref(),
+            Some(requested),
+            "requested={requested} provider={provider}"
+        );
+        assert!(
+            !has_provider_model_mismatch_warning(&warnings),
+            "requested={requested} provider={provider} captured={warnings:?}"
+        );
+    }
+}
+
+#[test]
+fn grok_build_ledger_mismatch_across_public_versions_still_warns() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let (stored, warnings) = capture_invocation_warnings(|| {
+        runtime
+            .invocation_agent_model_identity(
+                "grok",
+                Some("grok-4.6"),
+                Some("grok-4.5-build"),
+                "jrun-grok-drift",
+                "implement_one",
+            )
+            .1
+    });
+    assert_eq!(stored.as_deref(), Some("grok-4.5-build"));
+    assert!(
+        has_provider_model_mismatch_warning(&warnings),
+        "requested grok-4.6 vs ledger grok-4.5-build is real drift; captured={warnings:?}"
     );
 }

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -1103,8 +1103,7 @@ fn dashboard_log_dock_has_two_modes_and_an_always_on_status_bar() {
     // The always-on ambient line, present on every tab — including the ones
     // where the dock is not mounted.
     assert!(
-        index.contains(r#"id="log-statusbar""#)
-            && index.contains(r#"id="log-statusbar-message""#),
+        index.contains(r#"id="log-statusbar""#) && index.contains(r#"id="log-statusbar-message""#),
         "the bottom status bar must exist in the markup"
     );
     assert!(
@@ -1164,7 +1163,10 @@ fn dashboard_nav_rail_preserves_the_router_selector_contract() {
         "tile-failed-value",
         "tile-active-value",
     ] {
-        assert!(index.contains(&format!(r#"id="{id}""#)), "{id} must survive the move");
+        assert!(
+            index.contains(&format!(r#"id="{id}""#)),
+            "{id} must survive the move"
+        );
     }
 
     // Rail counts come from data the dashboard already fetches — no new endpoint.
@@ -1202,7 +1204,9 @@ fn dashboard_separates_panel_edges_from_internal_hairlines() {
         ".filter-summary {",
         ".panel > header {",
     ] {
-        let start = css.find(rule).unwrap_or_else(|| panic!("{rule} must exist"));
+        let start = css
+            .find(rule)
+            .unwrap_or_else(|| panic!("{rule} must exist"));
         let block = &css[start..start + 900.min(css.len() - start)];
         let end = block.find('}').map(|i| &block[..i]).unwrap_or(block);
         assert!(

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -3,8 +3,8 @@ summary: "Auditability — Design"
 type: design
 title: "Auditability — Design"
 owner: codex
-last_updated: 2026-08-15
-last_validated: 2026-08-15
+last_updated: 2026-08-22
+last_validated: 2026-08-22
 status: Draft
 feature: auditability
 doc_role: design
@@ -164,7 +164,7 @@ remain separate from Fast/service-tier and long-context dimensions, which are
 not approximated into the base table. Direct Codex/Claude orchestration-session
 cost is outside the audit scope.
 
-After [ORB-10370], CLI response parsing also fills `InvocationTrace.provider_model` and `provider_cost_usd` directly from provider-owned result metadata. Claude exposes a `modelUsage` map and `total_cost_usd`; when Claude reports its internal helper model beside the requested model, Orbit selects the unique highest-cost map entry and preserves its key verbatim. Gemini exposes an exact model key under `stats.models` but no invocation USD total; Orbit accepts it only when the map has one entry. Codex JSONL and Grok's JSON wrapper do not currently report either value, so they remain `None`. At SQLite ingest, a non-empty provider model wins over the configured request/alias and the configured model remains the fallback. A disagreement emits a retained `WARN` event under `orbit.core.invocation` with job run, activity, CLI, requested model, and provider model fields. This structured mismatch event was chosen instead of a second invocation column: it makes provider routing drift detectable under the default logging filter without migrating or backfilling rows, while `invocations.model` remains the exact model used for pricing and aggregation.
+After [ORB-10370], CLI response parsing also fills `InvocationTrace.provider_model` and `provider_cost_usd` directly from provider-owned result metadata. Claude exposes a `modelUsage` map and `total_cost_usd`; when Claude reports its internal helper model beside the requested model, Orbit selects the unique highest-cost map entry and preserves its key verbatim. Gemini exposes an exact model key under `stats.models` but no invocation USD total; Orbit accepts it only when the map has one entry. Codex JSONL does not currently report either value, so those fields remain `None`. Grok Build CLI JSON (`grok` 1.0.5+) carries the same `modelUsage` / `total_cost_usd` wrapper fields as Claude. The ledger's only key is the requested public menu id with a `-build` suffix (`grok models` lists `grok-4.6` and `grok-4.5`; the usage map key is `grok-4.6-build` / `grok-4.5-build`). Parser extraction keeps that ledger key verbatim. Wrappers that omit both fields still leave `provider_model` and `provider_cost_usd` unset. At SQLite ingest, a non-empty provider model wins over the configured request/alias and the configured model remains the fallback, except Grok Build's `{public-id}-build` ledger name is canonicalized to the requested public menu id so `invocations.model` matches the shipped price row (`grok-4.6`, not `grok-4.6-build`). A disagreement emits a retained `WARN` event under `orbit.core.invocation` with job run, activity, CLI, requested model, and provider model fields. The Grok `{id}` vs `{id}-build` pair is not disagreement; requested `grok-4.6` vs ledger `grok-4.5-build` still warns. [ORB-10970] This structured mismatch event was chosen instead of a second invocation column: it makes provider routing drift detectable under the default logging filter without migrating or backfilling rows, while `invocations.model` remains the exact model used for pricing and aggregation.
 
 The local dashboard exposes two read-only API surfaces for these traces after [T20260508-14]: `GET /api/runs/:id/logs` returns bounded per-step CLI invocation previews, and `GET /api/diagnostics/errors` returns recent process ERROR rows plus structured agent-stderr error rows sorted newest first. Both endpoints use existing dashboard limit conventions and tolerate missing stored event rows, malformed event JSON, and missing blobs by returning empty or partial arrays.
 
@@ -235,6 +235,7 @@ Each record contains timestamp, level, target, and structured fields. After [T20
 - **[ORB-10337]** — Added dashboard HTTP ingestion for worker invocation records without changing the invocation schema.
 - **[ORB-10338]** — Added the versioned model price table and query-time `derived_cost_usd`, plus a persisted `provider_cost_usd` column for reconciliation.
 - **[ORB-10370]** — Parsed provider-reported CLI model/cost metadata, preferred the reported model at ingest, and retained structured mismatch evidence.
+- **[ORB-10970]** — Mapped Grok Build `modelUsage` ledger ids (`grok-X.Y-build`) to the requested public menu id at ingest identity so stored `invocations.model` prices against the shipped `grok-X.Y` row without warning on the ledger suffix.
 - **[ORB-10579]** — Corrected GPT-5.6 price periods and cache-write rates, added gross-input accounting, and retained OpenAI cache buckets for standard short-context estimates.
 - **[ORB-10581]** — Added reconciliation-safe managed invocation accounting by canonical task orchestrator ([Attribute managed execution cost to an explicit task orchestrator](../task-artifacts/4_decisions.md#attribute-managed-execution-cost-to-an-explicit-task-orchestrator)).
 - **[ORB-10582]** — Projected managed-execution orchestration accounting into the separately versioned dashboard scoreboard section without merging it into executor rankings.


### PR DESCRIPTION
## Task

[ORB-10970](https://orbit-cli.com/tasks/ORB-10970) — Map Grok Build usage-ledger model ids to the requested public model

### Description

## Problem
Grok Build CLI (`grok` 1.0.5) now emits Claude-style `modelUsage` and `total_cost_usd` on JSON results. When Orbit requests `--model grok-4.6`, the usage ledger's only key is `grok-4.6-build`.

`invocation_agent_model_identity` compares those strings verbatim, emits `WARN orbit.core.invocation "provider-reported model differs from requested model"`, and stores `invocations.model = grok-4.6-build` because a non-empty provider model wins.

That stored string is not in the shipped price table (`grok-4.6` is). Derived-cost lookup therefore misses Grok 4.6/4.5 managed invocations. On this host every stored Grok row uses the ledger name (42× `grok-4.6-build`, 4× `grok-4.5-build`). Provider `total_cost_usd` still lands, so USD is not lost on current Grok JSON, but identity and derived-price aggregation are.

This is not dispatch of a different public menu id. `grok models` lists only `grok-4.6` (default) and `grok-4.5`. The `-build` suffix is Grok Build's usage-ledger name for the requested model. Genuine drift (requested `grok-4.6`, ledger `grok-4.5-build`) must still warn.

Reproduced on `jrun-20260822-1925-3` / `implement_one` (ORB-10961): argv `--model grok-4.6`; stdout blob `317baf581d42b3b86eff88e53a1d70ac2a6f5cfcc9e51e5196aeaeb1379786ed` has `modelUsage.grok-4.6-build` and `total_cost_usd`; host invocation id 799 stores `model=grok-4.6-build`.

## Why It Matters
- The default WARN filter fires on every Grok `implement_one`.
- `invocations.model` is the exact string used for pricing and agent/model scoreboards; an unpriced ledger id splits Grok traffic off the `grok-4.6` row.
- [ORB-10370] and `docs/design/auditability/2_design.md` still say Grok's JSON wrapper reports neither model nor cost. Live results now carry both.

## Constraints / Notes
- Do not change the Grok crew/default pin. [ORB-10756] already set `GROK_DEFAULT_MODEL` to the live `grok models` id `grok-4.6`. Keep requesting that public id.
- Do not rewrite the historical `grok-build` price row in place ([ORB-10772]).
- Keep the mismatch WARN for real routing drift (different version or family). Claude alias expansion (`sonnet` vs `claude-sonnet-5`) is out of scope.
- Treat `grok-X.Y-build` as the Grok Build ledger name for requested `grok-X.Y` unless xAI publishes `grok-4.6-build` as a public menu/API id. Whether it is a distinct coding checkpoint vs a billing label is not observable from outside.
- Prefer canonicalizing at ingest identity over adding a second priced string, unless a priced alias row is the smaller complete seam. Parser extraction may keep the ledger key verbatim.
- Related done work: [ORB-10370] (provider_model ingest), [ORB-10741]/[ORB-10756] (Grok default pin), [ORB-10772] (grok-4.6 price rows).
- Do not backfill historical invocation rows unless the change includes an explicit, tested compatibility plan.

### Acceptance Criteria

- A unit test that ingest a Grok JSON result with modelUsage key grok-4.6-build and requested model grok-4.6 persists invocations.model as grok-4.6, or another string that derive_cost_usd prices using the shipped grok-4.6 row.
- The grok-4.6 vs grok-4.6-build (and grok-4.5 vs grok-4.5-build) path does not emit the orbit.core.invocation warning "provider-reported model differs from requested model".
- A unit test still treats requested grok-4.6 vs provider grok-4.5-build (or another different public version) as a real mismatch.
- Live-shaped Grok JSON with modelUsage and total_cost_usd extracts provider_model and provider_cost_usd; a wrapper without those fields still leaves both None. Replace or supplement grok_json_wrapper_reports_no_model_or_cost.
- docs/design/auditability/2_design.md no longer claims Grok's JSON wrapper reports neither model nor cost; it documents the modelUsage ledger key and how it maps to the public menu id.
- make ci-fast passes, and the crate tests covering invocation identity plus Grok response parsing pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Canonicalized Grok Build usage-ledger ids at ingest identity: requested `grok-X.Y` vs provider `grok-X.Y-build` stores `grok-X.Y` and does not emit `orbit.core.invocation` mismatch WARN. Cross-version drift (`grok-4.6` vs `grok-4.5-build`) still warns and still prefers the provider string.
- Parser extraction unchanged (keeps ledger key verbatim). Added live-shaped Grok JSON coverage for `modelUsage` + `total_cost_usd`; wrappers without those fields still leave both None.
- Documented the ledger key → public menu id mapping in `docs/design/auditability/2_design.md` (no longer claims Grok reports neither model nor cost).
- rustfmt-only on `crates/orbit-web/src/tests/dashboard_assets.rs` so `make ci-fast` (`cargo fmt --all --check`) could pass; that file was already unformatted on this worktree base (ORB-10972 nav-rail assertions), not part of the identity fix.
Assessment: Small complete seam at identity ingest; no second priced string, no Grok pin change, no historical backfill. Persist test asserts stored model `grok-4.6` is priced by the shipped row and `grok-4.6-build` is not.
Strategic decisions:
- Match rule is `requested.starts_with("grok-") && provider.strip_suffix("-build") == requested`, not a YAML alias row.
Deviations from original plan:
- Added `file:crates/orbit-web/src/tests/dashboard_assets.rs` for fmt-check only. Justification: AC requires `make ci-fast` to pass; the file was pre-existing fmt drift on this base.
Validation:
- `cargo test -p orbit-core --lib runtime::engine::tests::identity` — 6 passed (includes persist, no-warn 4.6/4.5, mismatch 4.6 vs 4.5-build)
- `cargo test -p orbit-agent --lib types::tests::response` — 40 passed (includes grok_json_wrapper_extracts_model_usage_and_cost and grok_json_wrapper_reports_no_model_or_cost)
- `make ci-fast` — passed
Friction: none filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10970-6a8a16eb`
- Behind base: 0
- Ahead of base: 1