### PR TITLE
proc.spawn program allowlist fails open when a v2 activity omits proc_allowed_programs

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
@@ -507,7 +507,12 @@ impl RuntimeHost for OrbitRuntime {
             .canonicalize()
             .unwrap_or_else(|_| self.paths().repo_root.clone());
 
-        let proc_spawn_activity_scoped = proc_allowed_programs.is_some();
+        // Every context built here belongs to a v2 activity, so `proc.spawn` is
+        // always activity-scoped: a missing `proc_allowed_programs` denies every
+        // program instead of degrading to allow-all. Asset load already refuses
+        // an activity that grants `proc.spawn` without the key ([ORB-10959]);
+        // this keeps the enforcement point fail-closed on its own.
+        let proc_spawn_activity_scoped = true;
         let proc_allowed_programs = proc_allowed_programs
             .map(|programs| programs.to_vec())
             .unwrap_or_default();

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/v2_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/v2_host.rs
@@ -224,16 +224,20 @@ fn persist_invocation_trace_does_not_record_retired_read_token_metrics() {
 fn tool_context_for_activity_passes_proc_allowlist() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
 
-    // No allowlist -> not activity-scoped (legacy unrestricted path).
-    let unscoped = <OrbitRuntime as RuntimeHost>::tool_context_for_activity(
+    // No allowlist -> still activity-scoped, so the empty list denies every
+    // program instead of degrading to allow-all. [ORB-10959]
+    let undeclared = <OrbitRuntime as RuntimeHost>::tool_context_for_activity(
         &runtime,
         Some("run-allowlist-test"),
         None,
         None,
         None,
     );
-    assert!(unscoped.proc_allowed_programs.is_empty());
-    assert!(!unscoped.proc_spawn_activity_scoped);
+    assert!(undeclared.proc_allowed_programs.is_empty());
+    assert!(
+        undeclared.proc_spawn_activity_scoped,
+        "a v2 activity context must never hand proc.spawn an unscoped allow-all"
+    );
 
     // Activity-scoped allowlist propagates verbatim and flips the bool.
     let programs = vec!["git".to_string(), "rg".to_string()];

--- a/crates/orbit-engine/src/activity_job/tests/asset_loader.rs
+++ b/crates/orbit-engine/src/activity_job/tests/asset_loader.rs
@@ -85,3 +85,32 @@ spec:
         "{message}"
     );
 }
+
+/// [ORB-10959] An asset that grants `proc.spawn` while omitting
+/// `proc_allowed_programs` is refused at load. Before this, the omitted key
+/// meant "unconstrained" while an explicit `[]` denied everything — the
+/// safer-looking asset was the more permissive one.
+#[test]
+fn load_activity_asset_rejects_proc_spawn_without_program_allowlist() {
+    let yaml = agent_loop_activity_yaml("unbounded_spawn", "    - proc.spawn\n");
+
+    let err = load_activity_asset(&yaml).expect_err("missing program allowlist should fail");
+    let message = err.to_string();
+
+    assert!(message.contains("proc.spawn"), "{message}");
+    assert!(message.contains("proc_allowed_programs"), "{message}");
+}
+
+/// Writing `proc_allowed_programs: []` is the supported way to grant the tool
+/// and deny every program, so it must still load.
+#[test]
+fn load_activity_asset_accepts_explicit_empty_program_allowlist() {
+    let yaml = format!(
+        "{}\n  proc_allowed_programs: []\n",
+        agent_loop_activity_yaml("deny_all_spawn", "    - proc.spawn\n")
+    );
+
+    let asset = load_activity_asset(&yaml).expect("explicit deny-all should load");
+
+    assert_eq!(asset.name, "deny_all_spawn");
+}

--- a/crates/orbit-engine/src/activity_job/tests/mod.rs
+++ b/crates/orbit-engine/src/activity_job/tests/mod.rs
@@ -1,5 +1,7 @@
 #![allow(missing_docs)]
 
+mod asset_loader;
+mod catalog;
 mod crew;
 mod dispatcher;
 mod workspace;

--- a/crates/orbit-tools/src/lib.rs
+++ b/crates/orbit-tools/src/lib.rs
@@ -201,9 +201,11 @@ pub struct ToolContext {
     /// `proc_spawn_activity_scoped` is `false`, an empty list preserves the
     /// legacy unrestricted behaviour for direct CLI / v1 callers.
     pub proc_allowed_programs: Vec<String>,
-    /// True when `proc.spawn` runs inside an activity-scoped context that
-    /// explicitly opted in to the allowlist. When set, an empty
-    /// `proc_allowed_programs` denies every program (fail-closed).
+    /// True when `proc.spawn` runs inside an activity-scoped context. Every v2
+    /// activity context sets it, so an empty `proc_allowed_programs` denies
+    /// every program (fail-closed) rather than degrading to allow-all when an
+    /// asset omits the key ([ORB-10959]). Only direct CLI / v1 callers leave it
+    /// `false`.
     pub proc_spawn_activity_scoped: bool,
     /// Filesystem policy engine used by Orbit-managed agent runtimes.
     pub policy_engine: Option<Arc<PolicyEngine>>,

--- a/crates/orbit-types/src/workflow/activity_job/activity_v2.rs
+++ b/crates/orbit-types/src/workflow/activity_job/activity_v2.rs
@@ -112,9 +112,13 @@ pub struct AgentLoopSpec {
     #[serde(default = "default_require_completion_envelope")]
     pub require_completion_envelope: bool,
     /// Program allowlist enforced before `proc.spawn` executes a request.
-    /// `None` means `proc.spawn` is not constrained at the activity layer
-    /// (legacy / human-driven paths); an empty `Some(vec![])` denies all
-    /// programs (fail-closed).
+    /// An empty `Some(vec![])` denies every program (fail-closed).
+    ///
+    /// `None` is only legal for an activity that does not grant `proc.spawn`:
+    /// asset load rejects the pairing of a `proc.spawn` grant with a missing
+    /// allowlist, so an author opts into deny-all by writing `[]` rather than
+    /// getting allow-all by forgetting the key. The v2 activity tool context
+    /// treats `None` as deny-all too. [ORB-10959]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub proc_allowed_programs: Option<Vec<String>>,
 }

--- a/crates/orbit-types/src/workflow/activity_job/tests/tool_allowlist.rs
+++ b/crates/orbit-types/src/workflow/activity_job/tests/tool_allowlist.rs
@@ -1,3 +1,6 @@
+use serde_json::Value;
+
+use super::super::activity_v2::{ActivityV2, ActivityV2Spec, AgentLoopSpec, OnDenial, Provider};
 use super::super::tool_allowlist::*;
 
 #[test]
@@ -47,4 +50,115 @@ fn registry_validation_rejects_removed_graph_mcp_names() {
             entry: "orbit.graph.search".to_string()
         }
     );
+}
+
+/// [ORB-10959] Granting `proc.spawn` without declaring the program allowlist
+/// used to mean "unconstrained" — the omitted key was more permissive than an
+/// explicit `[]`. Load-time validation now refuses the pairing.
+#[test]
+fn activity_validation_rejects_proc_spawn_grant_without_program_allowlist() {
+    let activity = agent_loop_activity(vec!["proc.spawn".to_string()], None);
+
+    let err = validate_activity_tool_allowlist(&activity)
+        .expect_err("proc.spawn without an allowlist must fail closed");
+
+    assert_eq!(
+        err,
+        ToolAllowlistError::ProcSpawnWithoutProgramAllowlist {
+            entry: "proc.spawn".to_string()
+        }
+    );
+    let message = err.to_string();
+    assert!(message.contains("proc_allowed_programs: []"), "{message}");
+}
+
+/// A wildcard root that covers `proc.spawn` carries the same requirement, and
+/// the error names the entry that granted it.
+#[test]
+fn activity_validation_rejects_proc_wildcard_without_program_allowlist() {
+    let activity = agent_loop_activity(vec!["proc.*".to_string()], None);
+
+    let err = validate_activity_tool_allowlist(&activity)
+        .expect_err("proc.* without an allowlist must fail closed");
+
+    assert_eq!(
+        err,
+        ToolAllowlistError::ProcSpawnWithoutProgramAllowlist {
+            entry: "proc.*".to_string()
+        }
+    );
+}
+
+/// An explicit empty list is the documented way to deny every program, so it
+/// must keep loading (enforcement stays with the `proc.spawn` tool gate).
+#[test]
+fn activity_validation_accepts_explicit_empty_program_allowlist() {
+    let activity = agent_loop_activity(vec!["proc.spawn".to_string()], Some(Vec::new()));
+
+    validate_activity_tool_allowlist(&activity)
+        .expect("explicit deny-all allowlist is the supported opt-in");
+}
+
+/// A non-empty allowlist keeps permitting exactly the listed programs.
+#[test]
+fn activity_validation_accepts_declared_program_allowlist() {
+    let activity = agent_loop_activity(
+        vec!["proc.spawn".to_string()],
+        Some(vec!["git".to_string(), "rg".to_string()]),
+    );
+
+    validate_activity_tool_allowlist(&activity).expect("declared allowlist loads");
+    validate_activity_tool_allowlist_against_registered_tools(&activity, ["proc.spawn"])
+        .expect("declared allowlist passes registry validation");
+}
+
+/// An activity that never grants `proc.spawn` may still omit the key.
+#[test]
+fn activity_validation_allows_missing_program_allowlist_without_proc_spawn() {
+    let activity = agent_loop_activity(vec!["orbit.task.show".to_string()], None);
+
+    validate_activity_tool_allowlist(&activity)
+        .expect("an activity without proc.spawn needs no program allowlist");
+}
+
+/// The registry-aware entry point enforces the same pairing, so an activity
+/// reaching the catalog cannot skip the check the asset loader applies.
+#[test]
+fn registry_validation_rejects_proc_spawn_grant_without_program_allowlist() {
+    let activity = agent_loop_activity(vec!["proc.spawn".to_string()], None);
+
+    let err = validate_activity_tool_allowlist_against_registered_tools(&activity, ["proc.spawn"])
+        .expect_err("catalog validation must fail closed too");
+
+    assert_eq!(
+        err,
+        ToolAllowlistError::ProcSpawnWithoutProgramAllowlist {
+            entry: "proc.spawn".to_string()
+        }
+    );
+}
+
+fn agent_loop_activity(
+    tools: Vec<String>,
+    proc_allowed_programs: Option<Vec<String>>,
+) -> ActivityV2 {
+    ActivityV2 {
+        description: "test".to_string(),
+        input_schema_json: Value::Null,
+        output_schema_json: Value::Null,
+        fs_profile: None,
+        spec: ActivityV2Spec::AgentLoop(AgentLoopSpec {
+            instruction: "test".to_string(),
+            tools,
+            on_denial: OnDenial::Terminate,
+            model: None,
+            max_iterations: 1,
+            backend: None,
+            provider: Provider::default(),
+            wall_clock_timeout_seconds: 30,
+            require_response_envelope: false,
+            require_completion_envelope: true,
+            proc_allowed_programs,
+        }),
+    }
 }

--- a/crates/orbit-types/src/workflow/activity_job/tool_allowlist.rs
+++ b/crates/orbit-types/src/workflow/activity_job/tool_allowlist.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use thiserror::Error;
 
-use super::activity_v2::{ActivityV2, ActivityV2Spec};
+use super::activity_v2::{ActivityV2, ActivityV2Spec, AgentLoopSpec};
 
 /// Explicit list of permitted wildcard roots (§6 / §12 Q7).
 ///
@@ -37,7 +37,14 @@ pub enum ToolAllowlistError {
     UnknownToolName { entry: String },
     #[error("wildcard allowlist entry `{entry}` did not match any registered tools")]
     WildcardRootMatchesNoTools { entry: String },
+    #[error(
+        "allowlist entry `{entry}` grants `proc.spawn` but the activity omits `proc_allowed_programs`; declare the permitted programs (write `proc_allowed_programs: []` to deny every program)"
+    )]
+    ProcSpawnWithoutProgramAllowlist { entry: String },
 }
+
+/// Tool whose activity-layer program allowlist must be declared explicitly.
+const PROC_SPAWN_TOOL: &str = "proc.spawn";
 
 /// Validate an activity's declared tool allowlist at asset-load time.
 /// Returns Ok(()) when every entry is a concrete tool name or a permitted
@@ -96,10 +103,11 @@ where
 }
 
 pub fn validate_activity_tool_allowlist(activity: &ActivityV2) -> Result<(), ToolAllowlistError> {
-    if let Some(allowlist) = activity_tool_allowlist(activity) {
-        validate_tool_allowlist(allowlist)?;
-    }
-    Ok(())
+    let Some(spec) = agent_loop_spec(activity) else {
+        return Ok(());
+    };
+    validate_tool_allowlist(&spec.tools)?;
+    validate_proc_spawn_program_allowlist(spec)
 }
 
 pub fn validate_activity_tool_allowlist_against_registered_tools<'a, I>(
@@ -109,31 +117,58 @@ pub fn validate_activity_tool_allowlist_against_registered_tools<'a, I>(
 where
     I: IntoIterator<Item = &'a str>,
 {
-    if let Some(allowlist) = activity_tool_allowlist(activity) {
-        validate_tool_allowlist_against_registered_tools(allowlist, registered_tools)?;
+    let Some(spec) = agent_loop_spec(activity) else {
+        return Ok(());
+    };
+    validate_tool_allowlist_against_registered_tools(&spec.tools, registered_tools)?;
+    validate_proc_spawn_program_allowlist(spec)
+}
+
+/// An activity that grants `proc.spawn` must also declare
+/// `proc_allowed_programs`. Omitting the key once meant "unconstrained", which
+/// made the safer-looking asset the more permissive one: an explicit `[]`
+/// denied every program while the absent key allowed all of them. Requiring
+/// the pairing at load time keeps the control fail-closed — deny-all is
+/// something an author opts into by writing `[]`, not something they lose by
+/// forgetting a key. [ORB-10959]
+fn validate_proc_spawn_program_allowlist(spec: &AgentLoopSpec) -> Result<(), ToolAllowlistError> {
+    if spec.proc_allowed_programs.is_some() {
+        return Ok(());
     }
-    Ok(())
+    match proc_spawn_grant(&spec.tools) {
+        Some(entry) => Err(ToolAllowlistError::ProcSpawnWithoutProgramAllowlist {
+            entry: entry.to_string(),
+        }),
+        None => Ok(()),
+    }
+}
+
+/// The allowlist entry that grants `proc.spawn`, named so the load error points
+/// at the concrete name or the wildcard root that covers it.
+fn proc_spawn_grant(allowlist: &[String]) -> Option<&str> {
+    allowlist
+        .iter()
+        .find(|entry| entry_matches(entry, PROC_SPAWN_TOOL))
+        .map(String::as_str)
 }
 
 /// Runtime check: is `tool_name` permitted by `allowlist`?
 /// Empty allowlist means nothing is allowed (explicit policy per §6.1).
 pub fn tool_allowed(tool_name: &str, allowlist: &[String]) -> bool {
-    for entry in allowlist {
-        if entry == tool_name {
-            return true;
-        }
-        if let Some(prefix) = wildcard_prefix(entry)
-            && tool_name.starts_with(prefix)
-        {
-            return true;
-        }
-    }
-    false
+    allowlist
+        .iter()
+        .any(|entry| entry_matches(entry, tool_name))
 }
 
-fn activity_tool_allowlist(activity: &ActivityV2) -> Option<&[String]> {
+/// Does one allowlist entry — a concrete name or a wildcard root — cover
+/// `tool_name`?
+fn entry_matches(entry: &str, tool_name: &str) -> bool {
+    entry == tool_name || wildcard_prefix(entry).is_some_and(|prefix| tool_name.starts_with(prefix))
+}
+
+fn agent_loop_spec(activity: &ActivityV2) -> Option<&AgentLoopSpec> {
     match &activity.spec {
-        ActivityV2Spec::AgentLoop(spec) => Some(&spec.tools),
+        ActivityV2Spec::AgentLoop(spec) => Some(spec),
         ActivityV2Spec::Deterministic(_) => None,
     }
 }

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -304,7 +304,7 @@ asserts 100 collision-free dense IDs per artifact kind ([ORB-10596]).
 5. **macOS provenance syscall allowances are private.** `vnguard` and `Sandbox`/67 mirror current Codex startup needs and may require review after OS changes.
 6. **Pipeline env fallback can leave `fs_profile = None`.** Legacy contexts without `ORBIT_ACTIVITY_FS_PROFILE` still omit a profile name; the retired in-process helper used to treat that as unguarded.
 7. **No in-process `fs.*` enforcement remains.** A revived harness would need to rebuild the retired helper (or move enforcement below the tool layer) rather than rely on leftover builtins.
-8. **Generic exec has no policy hook.** `proc.spawn` program allowlists are activity-layer data, and `run_process + NoSandbox` remains unchanged; the OS wrappers attach only to CLI-agent dispatch.
+8. **Generic exec has no policy hook.** `proc.spawn` program allowlists are activity-layer data, and `run_process + NoSandbox` remains unchanged; the OS wrappers attach only to CLI-agent dispatch. The allowlist is mandatory rather than opt-in: asset load rejects an activity whose `tools` cover `proc.spawn` while `proc_allowed_programs` is absent, and the v2 activity tool context always marks `proc.spawn` activity-scoped, so a missing list denies every program instead of degrading to allow-all ([ORB-10959]).
 9. **Symlink semantics are implicit.** `workspace_relative_path` follows symlinks and rejects out-of-workspace targets, but no spec states that invariant.
 10. **Glob syntax is narrow.** Character classes, brace expansion, and POSIX bracket expressions are unsupported.
 11. **Policy result shapes are parallel.** `PolicyDecision` and `FsPolicyEvaluation` have no bridge for future non-fs evaluators.


### PR DESCRIPTION
## Task

[ORB-10959](https://orbit-cli.com/tasks/ORB-10959) — proc.spawn program allowlist fails open when a v2 activity omits proc_allowed_programs

### Description

## Problem

The `proc.spawn` program allowlist added by ORB-00262 is only enforced when an activity explicitly declares `proc_allowed_programs`. An activity that grants `proc.spawn` in `tools:` but omits that key silently gets **unrestricted** program execution — no denial, no warning, no validation error.

The field defaults to `None`:

```rust
// crates/orbit-types/src/workflow/activity_job/activity_v2.rs:114-119
    /// Program allowlist enforced before `proc.spawn` executes a request.
    /// `None` means `proc.spawn` is not constrained at the activity layer
    /// (legacy / human-driven paths); an empty `Some(vec![])` denies all
    /// programs (fail-closed).
    #[serde(default, skip_serializing_if = "Option::is_none")]
    pub proc_allowed_programs: Option<Vec<String>>,
```

`None` then makes the whole context unscoped:

```rust
// crates/orbit-core/src/adapter/engine_host/runtime_host.rs:510
        let proc_spawn_activity_scoped = proc_allowed_programs.is_some();
```

and the tool gate degrades to allow-all:

```rust
// crates/orbit-tools/src/builtin/proc/spawn.rs:51
        let restricted = ctx.proc_spawn_activity_scoped || !ctx.proc_allowed_programs.is_empty();
        if restricted && !ctx.proc_allowed_programs.iter().any(|p| p == &program) {
```

With `scoped == false` and an empty list, `restricted` is `false` and every program is permitted. Note the asymmetry this creates: `proc_allowed_programs: []` (explicit empty) denies everything, while omitting the key entirely allows everything. The safer-looking omission is the more permissive one.

There is no load-time validation tying the two together. `rg proc_allowed_programs` across `crates/orbit-core/src`, `crates/orbit-engine/src`, and `crates/orbit-types/src` (excluding tests) shows the field is only read and propagated, never validated against whether `proc.spawn` appears in `tools`.

## Current exposure

No shipped or workspace-local activity is currently affected — this is latent, not active. Verified across both asset sets:

```
$ cd crates/orbit-core/assets/activities
$ for f in *.yaml examples/*.yaml; do grep -q 'proc\.spawn' "$f" && { grep -q proc_allowed_programs "$f" && echo "HAS  $f" || echo "MISSING  $f"; }; done
HAS  agent_implement.yaml
HAS  epic_orchestrator.yaml
HAS  step_failure_recovery.yaml
HAS  task_pilot.yaml
HAS  triage_failed_runs.yaml
HAS  examples/agent_apply_fixes.yaml
```

The same check over the workspace-local set (`.orbit/resources/activities/`, 36 files) also returns `HAS` for all five activities that grant `proc.spawn`.

## Reproduction

1. Copy `.orbit/resources/activities/agent_implement.yaml` to a new activity and delete the `proc_allowed_programs:` block, leaving `proc.spawn` in `tools:`.
2. Run the activity and have the agent call `proc.spawn` with a program not in any allowlist (e.g. `curl`, `bash`).
3. The call succeeds. No `orbit.policy.deny` warning is emitted and the run is not terminated.

## Severity

**Medium.** Latent rather than active: exploiting it requires an activity definition that omits the key, and every shipped activity currently declares it. The severity is the loss of a security control's fail-closed property, not a directly reachable escape in the current tree.

## Impact

The allowlist is the control that bounds what a prompt-injected or misbehaving agent can execute on the host. ORB-00262 introduced it against exactly this threat: "model-controlled tool JSON can execute arbitrary local programs outside the activity `fsProfile`/sandbox boundary." Because the constraint is opt-in per activity rather than required, that protection is one forgotten YAML key away from silently disappearing — and the failure is invisible: the activity runs normally, and the only signal that the sandbox boundary is gone is the absence of a denial that was never going to fire. Activity assets are user-editable, so this is reachable without touching Rust code.

## Suggested direction

Reject at asset-load time any activity whose `tools` include `proc.spawn` (or a glob covering it) while `proc_allowed_programs` is `None`, forcing authors to write an explicit `[]` to opt into deny-all. Alternatively, invert the default so `None` means fail-closed for the v2 activity path and keep the unrestricted behavior confined to the legacy direct-CLI context, which is the only caller the current comment claims it exists for.

### Acceptance Criteria

- An activity asset that grants `proc.spawn` while omitting `proc_allowed_programs` is rejected at load time, or is treated as deny-all rather than allow-all.
- Explicitly declaring `proc_allowed_programs: []` still denies every program (existing fail-closed behavior preserved).
- Activities that declare a non-empty allowlist continue to permit exactly the listed programs.
- A test covers the omitted-key case and pins the chosen fail-closed behavior.

## Execution Summary

<details>
<summary>Click to expand</summary>

Closed the proc.spawn allowlist fail-open at two layers.

1. Load-time rejection (primary, the task's suggested direction). `validate_proc_spawn_program_allowlist` in crates/orbit-types/src/workflow/activity_job/tool_allowlist.rs refuses an agent_loop activity whose `tools` cover `proc.spawn` -- by concrete name or by a wildcard root such as `proc.*` -- while `proc_allowed_programs` is None. New `ToolAllowlistError::ProcSpawnWithoutProgramAllowlist { entry }` names the granting entry and tells the author to write `proc_allowed_programs: []` for deny-all. The check runs from BOTH activity entry points -- `validate_activity_tool_allowlist` (asset loader, crates/orbit-engine/src/activity_job/asset_loader.rs) and `validate_activity_tool_allowlist_against_registered_tools` (V2ActivityCatalog::validate_tool_allowlists and orbit-cmd) -- so an activity cannot reach the catalog by skipping asset load. Both entry points were refactored to resolve the AgentLoopSpec once (`agent_loop_spec`) instead of just its `tools` slice.

2. Runtime fail-closed (defense in depth, the task's stated alternative). `RuntimeHost::tool_context_for_activity` in crates/orbit-core/src/adapter/engine_host/runtime_host.rs now sets `proc_spawn_activity_scoped = true` unconditionally. Every context built there belongs to a v2 activity, so a missing list denies all programs at the proc.spawn gate rather than degrading to allow-all. This is a no-op for shipped behavior -- an activity that does not grant proc.spawn is already denied the tool by the tool allowlist -- but it removes the fail-open from the enforcement point itself. Direct-CLI/v1 contexts (dispatch.rs env path) still set the flag false and keep legacy unrestricted semantics.

Also factored the duplicated concrete-name/wildcard match into `entry_matches`, now shared by `tool_allowed` and the new `proc_spawn_grant`.

Tests. crates/orbit-types/src/workflow/activity_job/tests/tool_allowlist.rs gains 6 tests: omitted key rejected (concrete `proc.spawn` and wildcard `proc.*`, error identity asserted); explicit `[]` still loads (deny-all preserved); non-empty allowlist still loads and passes registry validation; an activity without proc.spawn may still omit the key; and the registry-aware entry point enforces the same pairing. crates/orbit-engine/src/activity_job/tests/asset_loader.rs gains 2 YAML-level load tests (reject omitted key, accept explicit `[]`).

Unlisted files touched, and why:
- crates/orbit-core/src/adapter/engine_host/runtime_host.rs -- the enforcement point the task description cites at line 510; needed for the fail-closed default.
- crates/orbit-core/src/adapter/engine_host/v2_host/tests/v2_host.rs -- `tool_context_for_activity_passes_proc_allowlist` asserted `!proc_spawn_activity_scoped` for the None case, i.e. it pinned the old fail-open. Rewritten to pin the new fail-closed behavior.
- crates/orbit-engine/src/activity_job/tests/mod.rs -- PRE-EXISTING GAP FOUND: `tests/asset_loader.rs` and `tests/catalog.rs` were never declared as modules, so 9 existing tests (5 asset_loader, 4 catalog) had never compiled or run. Registering them was required for the new criterion-4 test to actually execute. All 9 pre-existing tests pass unchanged once registered.
- crates/orbit-tools/src/lib.rs -- doc comment on ToolContext::proc_spawn_activity_scoped described the now-changed semantics.

Docs: crates/orbit-types/.../activity_v2.rs field doc rewritten (None is now only legal for an activity that does not grant proc.spawn); docs/design/policy-sandbox/2_design.md constraint 8 updated to state the allowlist is mandatory rather than opt-in.

Validation.
- `make ci-lint` (cargo clippy --workspace --all-targets -D warnings): PASS, exit 0.
- All 11 ci-fast guardrail scripts: PASS.
- `cargo fmt --all -- --check`: my 9 files are clean. One PRE-EXISTING failure remains in crates/orbit-web/src/tests/dashboard_assets.rs, which this task does not touch (unformatted at HEAD 06b92815 "fixme: perf"); left as-is rather than dragging an unrelated file into this diff.
- cargo test: orbit-types PASS, orbit-engine lib 386 PASS (was 377 before the module registration), orbit-engine --test v2_cli_agent PASS, orbit-tools (incl. proc_spawn_lockdown, policy_deny_tracing, public_tool_surface) PASS, orbit-cmd 54 PASS, orbit-core lib 731 PASS.
- orbit-core has 12 PRE-EXISTING failures in `runtime::tests::resolve::*` (workspace-root resolution picking up the real repo `.orbit` instead of the test tempdir -- an artifact of running inside this worktree). Verified unrelated: they reproduce identically with my runtime_host.rs change reverted, and nothing in this diff touches runtime root resolution.

Asset audit: all 6 shipped activities and all 5 workspace-local activities that grant proc.spawn already declare proc_allowed_programs, so no asset needed migrating and no currently-loadable activity breaks.

Compatibility note for release: this is a load-time hard failure for any third-party/user-authored activity asset that grants proc.spawn without the key. That is the intended fail-closed behavior per acceptance criterion 1, and the error message states the one-line fix.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10959-6a8a16ea`
- Behind base: 0
- Ahead of base: 1