### PR TITLE
Allow orbit.task.show to project ordinary top-level task fields

### DIFF
--- a/crates/orbit-cli/src/command/task/output.rs
+++ b/crates/orbit-cli/src/command/task/output.rs
@@ -5,7 +5,10 @@ use chrono::{DateTime, Utc};
 use orbit_core::{
     OrbitError, OrbitRuntime, TaskStatus, resolve_task_dependencies, resolve_task_relations,
 };
-use orbit_types::task::{ArtifactManifestFileV2, TaskArtifact};
+use orbit_types::task::{
+    ArtifactManifestFileV2, TaskArtifact, task_show_record_field_json,
+    unknown_task_show_field_message,
+};
 use serde_json::{Value, json};
 
 use crate::output::color::Domain;
@@ -291,9 +294,8 @@ pub(super) fn task_field_to_json(
         "artifacts" => Ok(task_artifacts_to_json(
             &runtime.get_task_artifacts(&task.id)?,
         )),
-        other => Err(OrbitError::InvalidInput(format!(
-            "unknown field selector `{other}`. Valid values: comments, plan, execution_summary, description, acceptance_criteria, dependencies, resolved_dependencies, tags, history, context_files, crew, orchestrator, artifacts"
-        ))),
+        other => task_show_record_field_json(task, other)
+            .ok_or_else(|| OrbitError::InvalidInput(unknown_task_show_field_message(other))),
     }
 }
 
@@ -461,9 +463,20 @@ pub(super) fn print_single_task_field(
             }
             Ok(())
         }
-        other => Err(OrbitError::InvalidInput(format!(
-            "unknown field selector `{other}`. Valid values: comments, plan, execution_summary, description, acceptance_criteria, dependencies, resolved_dependencies, tags, history, context_files, crew, orchestrator, artifacts"
-        ))),
+        other => match task_show_record_field_json(task, other) {
+            Some(Value::String(text)) => {
+                print!("{text}");
+                Ok(())
+            }
+            Some(Value::Null) => Ok(()),
+            Some(value) => {
+                print!("{value}");
+                Ok(())
+            }
+            None => Err(OrbitError::InvalidInput(unknown_task_show_field_message(
+                other,
+            ))),
+        },
     }
 }
 

--- a/crates/orbit-cli/src/command/task/show.rs
+++ b/crates/orbit-cli/src/command/task/show.rs
@@ -1,6 +1,7 @@
 use clap::Args;
 use orbit_cmd::task_owner::{WorkspaceIdentity, bound_workspace_identity};
 use orbit_core::{OrbitError, OrbitRuntime, TaskRelatedDoc};
+use orbit_types::task::is_task_show_projection_field;
 use serde_json::{Value, json};
 
 use crate::command::{Block, CommandOut, CommandOutput, Execute, Payload};
@@ -17,13 +18,18 @@ pub struct TaskShowArgs {
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
-    /// Print only the specified field projection(s). Valid values: comments, plan,
-    /// execution_summary, description, acceptance_criteria, dependencies,
-    /// resolved_dependencies, tags, history, context_files, crew, orchestrator,
-    /// artifacts.
-    /// Repeat the flag or use a comma-separated value list. Combined with --json,
-    /// a single field returns that field as JSON and multiple fields return a JSON object.
-    #[arg(long = "fields", alias = "field", value_delimiter = ',', num_args = 1..)]
+    #[arg(
+        long = "fields",
+        alias = "field",
+        value_delimiter = ',',
+        num_args = 1..,
+        help = concat!(
+            "Print only the specified field projection(s). Valid values: ",
+            orbit_types::task_show_projection_fields_csv!(),
+            ". Repeat the flag or use a comma-separated value list. Combined with --json, \
+             a single field returns that field as JSON and multiple fields return a JSON object."
+        )
+    )]
     pub fields: Vec<String>,
     /// Include docs matched from task context files and task feature tags
     #[arg(long)]
@@ -326,7 +332,7 @@ fn related_docs_blocks(related_docs: &[TaskRelatedDoc]) -> Vec<Block> {
     ]
 }
 
-fn normalize_task_show_fields(fields: &[String]) -> Result<Vec<String>, OrbitError> {
+pub(crate) fn normalize_task_show_fields(fields: &[String]) -> Result<Vec<String>, OrbitError> {
     let mut normalized = Vec::new();
     for field in fields {
         let trimmed = field.trim();
@@ -335,25 +341,10 @@ fn normalize_task_show_fields(fields: &[String]) -> Result<Vec<String>, OrbitErr
                 "task show field selectors must not be empty".to_string(),
             ));
         }
-        if !matches!(
-            trimmed,
-            "comments"
-                | "plan"
-                | "execution_summary"
-                | "description"
-                | "acceptance_criteria"
-                | "dependencies"
-                | "resolved_dependencies"
-                | "tags"
-                | "history"
-                | "context_files"
-                | "crew"
-                | "orchestrator"
-                | "artifacts"
-        ) {
-            return Err(OrbitError::InvalidInput(format!(
-                "unknown field selector `{trimmed}`. Valid values: comments, plan, execution_summary, description, acceptance_criteria, dependencies, resolved_dependencies, tags, history, context_files, crew, orchestrator, artifacts"
-            )));
+        if !is_task_show_projection_field(trimmed) {
+            return Err(OrbitError::InvalidInput(
+                orbit_types::task::unknown_task_show_field_message(trimmed),
+            ));
         }
         normalized.push(trimmed.to_string());
     }

--- a/crates/orbit-cli/src/command/task/tests/mod.rs
+++ b/crates/orbit-cli/src/command/task/tests/mod.rs
@@ -2,4 +2,5 @@ mod add;
 mod artifact;
 mod command;
 mod output;
+mod show;
 mod update;

--- a/crates/orbit-cli/src/command/task/tests/show.rs
+++ b/crates/orbit-cli/src/command/task/tests/show.rs
@@ -1,0 +1,58 @@
+use clap::{Parser, error::ErrorKind};
+use orbit_types::task::{TASK_SHOW_PROJECTION_FIELDS, TASK_SHOW_PROJECTION_FIELDS_CSV};
+
+use crate::command::Cli;
+use crate::command::task::show::normalize_task_show_fields;
+
+#[test]
+fn normalize_accepts_ordinary_top_level_fields() {
+    let fields = normalize_task_show_fields(&[
+        "status".to_string(),
+        " id ".to_string(),
+        "title".to_string(),
+        "type".to_string(),
+        "priority".to_string(),
+        "complexity".to_string(),
+        "created_at".to_string(),
+        "updated_at".to_string(),
+    ])
+    .expect("ordinary top-level fields are projectable");
+    assert_eq!(
+        fields,
+        vec![
+            "status",
+            "id",
+            "title",
+            "type",
+            "priority",
+            "complexity",
+            "created_at",
+            "updated_at",
+        ]
+    );
+}
+
+#[test]
+fn normalize_rejects_unknown_fields_with_the_shared_vocabulary() {
+    let error = normalize_task_show_fields(&["not_a_field".to_string()])
+        .expect_err("unknown projection must fail");
+    let message = error.to_string();
+    assert!(message.contains("unknown field selector `not_a_field`"),);
+    assert!(message.contains(TASK_SHOW_PROJECTION_FIELDS_CSV));
+}
+
+#[test]
+fn task_show_help_advertises_the_authoritative_field_vocabulary() {
+    let err = match Cli::try_parse_from(["orbit", "task", "show", "--help"]) {
+        Ok(_) => panic!("show help should exit before parsing"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), ErrorKind::DisplayHelp);
+    let help = err.to_string();
+    for field in TASK_SHOW_PROJECTION_FIELDS {
+        assert!(
+            help.contains(field),
+            "task show help must advertise `{field}`:\n{help}"
+        );
+    }
+}

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -851,6 +851,24 @@ fn mcp_serve_round_trips_records_against_a_temp_workspace() {
         ),
         json!({"crew": "sol", "orchestrator": "terra"})
     );
+    assert_eq!(
+        client.call_tool_ok(
+            "orbit_task_show",
+            json!({ "id": task_id, "fields": ["status"] })
+        ),
+        json!({ "value": "proposed" })
+    );
+    assert_eq!(
+        client.call_tool_ok(
+            "orbit_task_show",
+            json!({ "id": task_id, "fields": ["status", "title", "plan"] }),
+        ),
+        json!({
+            "status": "proposed",
+            "title": "MCP round-trip task",
+            "plan": "",
+        })
+    );
 
     let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
         .args(["task", "show", &task_id])
@@ -882,6 +900,40 @@ fn mcp_serve_round_trips_records_against_a_temp_workspace() {
     assert_eq!(
         serde_json::from_slice::<Value>(&output.stdout).expect("orchestrator JSON"),
         json!("terra")
+    );
+
+    let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args(["task", "show", &task_id, "--json", "--fields", "status"])
+        .output()
+        .expect("show status field through the CLI");
+    assert!(
+        output.status.success(),
+        "status field projection failed: {output:?}"
+    );
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).expect("status JSON"),
+        json!("proposed")
+    );
+
+    let tool_run = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args([
+            "tool",
+            "run",
+            "orbit.task.show",
+            "--input",
+            &format!(r#"{{"id":"{task_id}","fields":["status"]}}"#),
+        ])
+        .output()
+        .expect("show status through orbit tool run");
+    assert!(
+        tool_run.status.success(),
+        "tool-run status projection failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&tool_run.stdout),
+        String::from_utf8_lossy(&tool_run.stderr)
+    );
+    assert_eq!(
+        serde_json::from_slice::<Value>(&tool_run.stdout).expect("tool-run status JSON"),
+        json!("proposed")
     );
 
     let listed = client.call_tool_ok("orbit_task_list", json!({}));

--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -688,7 +688,7 @@
         "required": false
       },
       {
-        "description": "Optional field projection as a string or array of strings. When set, returns only the requested field(s) as JSON. Valid values: comments, plan, execution_summary, description, acceptance_criteria, dependencies, resolved_dependencies, tags, history, context_files, crew, orchestrator, artifacts. `crew` is execution selection; `orchestrator` is separate orchestration attribution.",
+        "description": "Optional field projection as a string or array of strings. When set, returns only the requested field(s) as JSON. Valid values: id, title, type, status, priority, complexity, created_at, updated_at, description, acceptance_criteria, dependencies, resolved_dependencies, tags, plan, execution_summary, context_files, crew, orchestrator, comments, history, artifacts. `crew` is execution selection; `orchestrator` is separate orchestration attribution.",
         "name": "fields",
         "param_type": "string_list",
         "required": false

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -738,7 +738,7 @@
               "type": "string"
             }
           ],
-          "description": "Optional field projection as a string or array of strings. When set, returns only the requested field(s) as JSON. Valid values: comments, plan, execution_summary, description, acceptance_criteria, dependencies, resolved_dependencies, tags, history, context_files, crew, orchestrator, artifacts. `crew` is execution selection; `orchestrator` is separate orchestration attribution."
+          "description": "Optional field projection as a string or array of strings. When set, returns only the requested field(s) as JSON. Valid values: id, title, type, status, priority, complexity, created_at, updated_at, description, acceptance_criteria, dependencies, resolved_dependencies, tags, plan, execution_summary, context_files, crew, orchestrator, comments, history, artifacts. `crew` is execution selection; `orchestrator` is separate orchestration attribution."
         },
         "id": {
           "description": "Globally unique task ID. Resolved through the host task registry by default; a workspace argument is not required.",

--- a/crates/orbit-core/src/adapter/tool_host/host.rs
+++ b/crates/orbit-core/src/adapter/tool_host/host.rs
@@ -33,7 +33,7 @@ use orbit_types::record::FrictionStatus;
 use orbit_types::task::{
     Task, TaskComment, TaskPriority, TaskStatus, TaskType, normalize_task_dependencies,
     normalize_task_tags, resolve_task_dependencies, task_dependencies_ready, task_matches_tags,
-    validate_task_dependencies,
+    task_show_record_field_json, unknown_task_show_field_message, validate_task_dependencies,
 };
 use orbit_types::tool::ToolSessionContext;
 use serde_json::{Map, Value, json};
@@ -577,6 +577,9 @@ impl HubCoordinationExecutor {
         };
         let status = self.inner.tasks.task.task_status_index()?;
         let one = |field: &str| -> Result<Value, OrbitError> {
+            if let Some(value) = task_show_record_field_json(&task, field) {
+                return Ok(value);
+            }
             match field {
                 "comments" => serde_json::to_value(
                     self.inner
@@ -617,8 +620,8 @@ impl HubCoordinationExecutor {
                 "context_files" => Ok(json!(task.context_files)),
                 "crew" => Ok(json!(task.crew)),
                 "orchestrator" => Ok(json!(task.orchestrator)),
-                other => Err(OrbitError::InvalidInput(format!(
-                    "unknown field selector `{other}`. Valid values: comments, plan, execution_summary, description, acceptance_criteria, dependencies, resolved_dependencies, tags, history, context_files, crew, orchestrator, artifacts"
+                other => Err(OrbitError::InvalidInput(unknown_task_show_field_message(
+                    other,
                 ))),
             }
         };
@@ -1035,6 +1038,50 @@ mod checkoutless_hub_tests {
             )
             .expect("empty string clears orchestrator");
         assert_eq!(cleared["orchestrator"], Value::Null);
+    }
+
+    #[test]
+    fn task_show_projects_status_and_mixed_fields_without_checkout() {
+        let (_root, executor, context) = executor();
+        let created = executor
+            .execute_tool(
+                "orbit.task.add",
+                json!({
+                    "workspace": "ws_checkoutless",
+                    "title": "Hub status projection",
+                    "description": "Exercise fields:[status] on the hub.",
+                    "complexity": "low",
+                    "model": "codex"
+                }),
+                context.clone(),
+            )
+            .expect("add checkoutless task");
+        let id = created["id"].as_str().expect("task id");
+
+        assert_eq!(
+            executor
+                .execute_tool(
+                    "orbit.task.show",
+                    json!({"id": id, "fields": ["status"]}),
+                    context.clone(),
+                )
+                .expect("fields:[status] must succeed"),
+            json!("proposed")
+        );
+        assert_eq!(
+            executor
+                .execute_tool(
+                    "orbit.task.show",
+                    json!({"id": id, "fields": ["status", "title", "plan"]}),
+                    context,
+                )
+                .expect("mixed projection must succeed"),
+            json!({
+                "status": "proposed",
+                "title": "Hub status projection",
+                "plan": "",
+            })
+        );
     }
 
     /// After ORB-10680 the partition is the `(workspace_id, friction_id)` key

--- a/crates/orbit-core/src/adapter/tool_host/json.rs
+++ b/crates/orbit-core/src/adapter/tool_host/json.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use orbit_common::OrbitError;
 use orbit_types::task::{
     Task, TaskArtifact, TaskComment, TaskHistoryEntry, TaskStatus, resolve_task_dependencies,
-    resolve_task_relations,
+    resolve_task_relations, task_show_record_field_json, unknown_task_show_field_message,
 };
 use serde_json::{Map, Value, json};
 
@@ -144,9 +144,8 @@ fn task_field_to_json(
         "artifacts" => Ok(serialize_task_artifacts(
             &runtime.get_task_artifacts(&task.id)?,
         )),
-        other => Err(OrbitError::InvalidInput(format!(
-            "unknown field selector `{other}`. Valid values: comments, plan, execution_summary, description, acceptance_criteria, dependencies, resolved_dependencies, tags, history, context_files, crew, orchestrator, artifacts"
-        ))),
+        other => task_show_record_field_json(task, other)
+            .ok_or_else(|| OrbitError::InvalidInput(unknown_task_show_field_message(other))),
     }
 }
 

--- a/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
@@ -1927,6 +1927,93 @@ fn task_show_tool_recovers_mcp_encoded_fields_array() {
 }
 
 #[test]
+fn task_show_tool_projects_status_as_a_bare_json_string() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let task = create_task(
+        &runtime,
+        &repo_root,
+        "Show status",
+        "Exercise the observed fields:[status] call.",
+        TaskStatus::Backlog,
+        &[],
+    );
+
+    let output = runtime
+        .execute_tool_command(
+            "orbit.task.show",
+            json!({ "id": task.id, "fields": ["status"] }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("fields:[status] must succeed");
+
+    assert_eq!(output, json!("backlog"));
+}
+
+#[test]
+fn task_show_tool_projects_mixed_top_level_and_sidecar_fields() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let task = create_task(
+        &runtime,
+        &repo_root,
+        "Show mixed fields",
+        "Exercise mixed top-level and sidecar projection.",
+        TaskStatus::InProgress,
+        &["file:src/lib.rs"],
+    );
+
+    let output = runtime
+        .execute_tool_command(
+            "orbit.task.show",
+            json!({
+                "id": task.id,
+                "fields": ["status", "title", "context_files", "plan"],
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("mixed projection must succeed");
+
+    assert_eq!(
+        output,
+        json!({
+            "status": "in-progress",
+            "title": "Show mixed fields",
+            "context_files": ["file:src/lib.rs"],
+            "plan": "",
+        })
+    );
+}
+
+#[test]
+fn task_show_tool_rejects_unknown_projection_with_the_shared_vocabulary() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let task = create_task(
+        &runtime,
+        &repo_root,
+        "Unknown projection",
+        "Exercise unknown field validation.",
+        TaskStatus::Backlog,
+        &[],
+    );
+
+    let message = invalid_input_message(runtime.execute_tool_command(
+        "orbit.task.show",
+        json!({ "id": task.id, "fields": ["not_a_field"] }),
+        Some("codex".to_string()),
+        Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+    ));
+    assert!(
+        message.contains("unknown field selector `not_a_field`"),
+        "{message}"
+    );
+    assert!(
+        message.contains(orbit_types::task::TASK_SHOW_PROJECTION_FIELDS_CSV),
+        "{message}"
+    );
+}
+
+#[test]
 fn task_update_tool_allows_explicit_attribution_updates() {
     let (_root, runtime, repo_root) = test_runtime();
     let task = create_task(

--- a/crates/orbit-tools/src/builtin/orbit/task/show.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/show.rs
@@ -1,4 +1,5 @@
 use orbit_common::OrbitError;
+use orbit_types::task::TASK_SHOW_PROJECTION_FIELDS_CSV;
 use orbit_types::tool::{ToolParam, ToolSchema};
 use serde_json::Value;
 
@@ -23,13 +24,11 @@ impl Tool for OrbitTaskShowTool {
         parameters.extend(super::super::identity_params());
         parameters.push(ToolParam {
             name: "fields".to_string(),
-            description:
+            description: format!(
                 "Optional field projection as a string or array of strings. When set, returns only \
-                the requested field(s) as JSON. Valid values: comments, plan, execution_summary, \
-                description, acceptance_criteria, dependencies, resolved_dependencies, tags, \
-                history, context_files, crew, orchestrator, artifacts. `crew` is execution \
-                selection; `orchestrator` is separate orchestration attribution."
-                    .to_string(),
+                the requested field(s) as JSON. Valid values: {TASK_SHOW_PROJECTION_FIELDS_CSV}. \
+                `crew` is execution selection; `orchestrator` is separate orchestration attribution."
+            ),
             param_type: "string_list".to_string(),
             required: false,
         });

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -401,6 +401,22 @@ fn task_show_schema_distinguishes_execution_crew_from_orchestrator() {
         .expect("task show fields parameter");
     assert!(fields.description.contains("crew"));
     assert!(fields.description.contains("orchestrator"));
+    for field in [
+        "status",
+        "id",
+        "title",
+        "type",
+        "priority",
+        "complexity",
+        "created_at",
+        "updated_at",
+    ] {
+        assert!(
+            fields.description.contains(field),
+            "task show fields schema must advertise `{field}`: {}",
+            fields.description
+        );
+    }
     assert!(schema.description.contains("execution"));
     assert!(schema.description.contains("orchestration attribution"));
     assert!(

--- a/crates/orbit-types/src/task/mod.rs
+++ b/crates/orbit-types/src/task/mod.rs
@@ -4,6 +4,7 @@ mod artifacts;
 mod error;
 mod model;
 mod plan;
+mod show_fields;
 pub use error::TaskError;
 
 #[cfg(test)]
@@ -33,3 +34,7 @@ pub use model::{
     unsatisfiable_task_dependencies, validate_task_dependencies,
 };
 pub use plan::{TaskPlan, TaskPlanCheckpoint, TaskPlanSuccessCriterion};
+pub use show_fields::{
+    TASK_SHOW_PROJECTION_FIELDS, TASK_SHOW_PROJECTION_FIELDS_CSV, is_task_show_projection_field,
+    task_show_record_field_json, unknown_task_show_field_message,
+};

--- a/crates/orbit-types/src/task/show_fields.rs
+++ b/crates/orbit-types/src/task/show_fields.rs
@@ -1,0 +1,75 @@
+//! Canonical `orbit.task.show` field-projection vocabulary.
+//!
+//! CLI help, MCP/tool schema text, validation errors, and JSON projectors
+//! must all draw from this list. Sidecar fields (`comments`, `history`,
+//! `artifacts`) and `resolved_dependencies` still need a runtime fetch;
+//! the Task-local scalars below are projected from the record itself.
+
+use serde_json::{Value, json};
+
+use crate::task::Task;
+
+/// String-literal CSV of [`TASK_SHOW_PROJECTION_FIELDS`], for `concat!` in
+/// clap help and other const contexts.
+#[macro_export]
+macro_rules! task_show_projection_fields_csv {
+    () => {
+        "id, title, type, status, priority, complexity, created_at, updated_at, description, acceptance_criteria, dependencies, resolved_dependencies, tags, plan, execution_summary, context_files, crew, orchestrator, comments, history, artifacts"
+    };
+}
+
+/// Authoritative `orbit.task.show` `--fields` / `fields` / `field` vocabulary.
+pub const TASK_SHOW_PROJECTION_FIELDS: &[&str] = &[
+    "id",
+    "title",
+    "type",
+    "status",
+    "priority",
+    "complexity",
+    "created_at",
+    "updated_at",
+    "description",
+    "acceptance_criteria",
+    "dependencies",
+    "resolved_dependencies",
+    "tags",
+    "plan",
+    "execution_summary",
+    "context_files",
+    "crew",
+    "orchestrator",
+    "comments",
+    "history",
+    "artifacts",
+];
+
+/// Comma-separated form of [`TASK_SHOW_PROJECTION_FIELDS`].
+pub const TASK_SHOW_PROJECTION_FIELDS_CSV: &str = crate::task_show_projection_fields_csv!();
+
+/// Whether `name` is in the canonical show-projection vocabulary.
+pub fn is_task_show_projection_field(name: &str) -> bool {
+    TASK_SHOW_PROJECTION_FIELDS.contains(&name)
+}
+
+/// Actionable error for a name that is not in the vocabulary.
+pub fn unknown_task_show_field_message(name: &str) -> String {
+    format!("unknown field selector `{name}`. Valid values: {TASK_SHOW_PROJECTION_FIELDS_CSV}")
+}
+
+/// JSON for a Task-local (non-sidecar) projection field.
+///
+/// Returns `None` for sidecar names, `resolved_dependencies`, and unknown
+/// names so callers can keep those on their existing fetch paths.
+pub fn task_show_record_field_json(task: &Task, field: &str) -> Option<Value> {
+    match field {
+        "id" => Some(json!(task.id)),
+        "title" => Some(json!(task.title)),
+        "type" => Some(json!(task.task_type.to_string())),
+        "status" => Some(json!(task.status.to_string())),
+        "priority" => Some(json!(task.priority.to_string())),
+        "complexity" => Some(json!(task.complexity.map(|value| value.to_string()))),
+        "created_at" => Some(json!(task.created_at.to_rfc3339())),
+        "updated_at" => Some(json!(task.updated_at.to_rfc3339())),
+        _ => None,
+    }
+}

--- a/crates/orbit-types/src/task/tests/mod.rs
+++ b/crates/orbit-types/src/task/tests/mod.rs
@@ -1,2 +1,3 @@
 mod artifacts;
+mod show_fields;
 mod task;

--- a/crates/orbit-types/src/task/tests/show_fields.rs
+++ b/crates/orbit-types/src/task/tests/show_fields.rs
@@ -1,0 +1,111 @@
+use crate::task::{
+    TASK_SHOW_PROJECTION_FIELDS, TASK_SHOW_PROJECTION_FIELDS_CSV, Task,
+    is_task_show_projection_field, task_show_record_field_json, unknown_task_show_field_message,
+};
+use serde_json::json;
+
+fn fixture_task() -> Task {
+    serde_yaml::from_str::<Task>(
+        r#"id: ORB-10966
+title: Project ordinary fields
+description: Fixture.
+acceptance_criteria: []
+dependencies: []
+plan: ""
+execution_summary: ""
+context_files: []
+status: in-progress
+priority: high
+complexity: medium
+task_type: bug
+created_at: 2026-08-22T19:39:26.449604717+00:00
+updated_at: 2026-08-22T21:36:50.192298986+00:00
+"#,
+    )
+    .expect("fixture task deserializes")
+}
+
+#[test]
+fn projection_csv_matches_the_field_slice() {
+    assert_eq!(
+        TASK_SHOW_PROJECTION_FIELDS.join(", "),
+        TASK_SHOW_PROJECTION_FIELDS_CSV
+    );
+}
+
+#[test]
+fn vocabulary_includes_ordinary_top_level_fields() {
+    for field in [
+        "id",
+        "title",
+        "type",
+        "status",
+        "priority",
+        "complexity",
+        "created_at",
+        "updated_at",
+    ] {
+        assert!(
+            is_task_show_projection_field(field),
+            "{field} must be projectable"
+        );
+    }
+    assert!(!is_task_show_projection_field("not_a_field"));
+}
+
+#[test]
+fn unknown_field_error_lists_the_vocabulary() {
+    let message = unknown_task_show_field_message("not_a_field");
+    assert!(message.contains("unknown field selector `not_a_field`"),);
+    assert!(message.contains(TASK_SHOW_PROJECTION_FIELDS_CSV));
+    assert!(message.contains("status"));
+}
+
+#[test]
+fn record_field_json_uses_canonical_serialized_types() {
+    let task = fixture_task();
+    assert_eq!(
+        task_show_record_field_json(&task, "status"),
+        Some(json!("in-progress"))
+    );
+    assert_eq!(
+        task_show_record_field_json(&task, "id"),
+        Some(json!("ORB-10966"))
+    );
+    assert_eq!(
+        task_show_record_field_json(&task, "title"),
+        Some(json!("Project ordinary fields"))
+    );
+    assert_eq!(
+        task_show_record_field_json(&task, "type"),
+        Some(json!("bug"))
+    );
+    assert_eq!(
+        task_show_record_field_json(&task, "priority"),
+        Some(json!("high"))
+    );
+    assert_eq!(
+        task_show_record_field_json(&task, "complexity"),
+        Some(json!("medium"))
+    );
+    assert_eq!(
+        task_show_record_field_json(&task, "created_at"),
+        Some(json!(task.created_at.to_rfc3339()))
+    );
+    assert_eq!(
+        task_show_record_field_json(&task, "updated_at"),
+        Some(json!(task.updated_at.to_rfc3339()))
+    );
+    assert_eq!(task_show_record_field_json(&task, "comments"), None);
+    assert_eq!(task_show_record_field_json(&task, "not_a_field"), None);
+}
+
+#[test]
+fn unset_complexity_projects_as_json_null() {
+    let mut task = fixture_task();
+    task.complexity = None;
+    assert_eq!(
+        task_show_record_field_json(&task, "complexity"),
+        Some(json!(null))
+    );
+}


### PR DESCRIPTION
## Task

[ORB-10966](https://orbit-cli.com/tasks/ORB-10966) — Allow orbit.task.show to project ordinary top-level task fields

### Description

## Problem
`orbit.task.show` rejected `fields: ["status"]` eight times across four independent CLI and MCP execution contexts in the 2026-08-22 audit window. The projection whitelist exposes sidecars and selected metadata but excludes ordinary top-level task fields such as status, id, title, type, priority, and complexity.

## Why It Matters
Agents naturally use `fields` as a response projection. The current partial whitelist causes repeated schema-discovery failures and retries on the highest-volume failing tool.

## Constraints / Notes
Keep strict validation for genuinely unknown field names. The advertised schema, CLI parser, MCP adapter, and returned JSON must share one authoritative projection vocabulary.

### Acceptance Criteria

- orbit.task.show accepts status, id, title, type, priority, complexity, created_at, and updated_at as field or fields projections on both CLI tool-run and MCP surfaces.
- Multiple projected top-level and sidecar fields return one JSON object containing exactly the requested fields with their canonical serialized types.
- tools/list and CLI help advertise the complete authoritative field vocabulary without a separately maintained divergent allowlist.
- A genuinely unknown projection still returns an actionable validation error listing valid values.
- Regression tests cover the observed fields:[status] call and mixed top-level/sidecar projections.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a single orbit.task.show projection vocabulary in orbit-types (`TASK_SHOW_PROJECTION_FIELDS` / CSV / unknown-field message) covering existing sidecars plus ordinary top-level fields id, title, type, status, priority, complexity, created_at, updated_at.
- CLI help, MCP schema text, clap/tool-host/checkoutless validation, and JSON projectors now consume that list instead of separately maintained allowlists.
- `fields:[status]` returns the canonical status string; mixed top-level/sidecar projections return one object with exactly the requested keys. Unknown names still fail closed listing Valid values.
- Regression coverage in orbit-types, orbit-core tool-host (including checkoutless hub), orbit-cli help/normalize, MCP round-trip + tools/list snapshot, and tool-list golden.
Assessment: Scoped to the observed whitelist gap. MCP still wraps a single scalar as `{value: ...}` (existing structuredContent object rule); tool-host/CLI JSON keep the bare value.
Strategic decisions: Vocabulary lives in orbit-types so orbit-tools (schema) and orbit-core/cli (projectors) share one list without a new crate edge.
Validation: cargo test -p orbit-types show_fields; cargo test -p orbit-core --lib task_show; cargo test -p orbit-cli --bin orbit command::task::tests::show; cargo test -p orbit-cli --test mcp_roundtrip (snapshot + round-trip); cargo test -p orbit-cli --test output_goldens plain_and_json_forms_match_their_goldens; cargo clippy -p orbit-types -p orbit-tools -p orbit-core -p orbit-cli --all-targets -- -D warnings.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10966-6a8a1672`
- Behind base: 0
- Ahead of base: 1