### PR TITLE
Generate operator-authorized MCP config from workspace init --mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Paste the prompt below into your agent (Claude Code, Codex CLI, or Gemini CLI) *
 > 2. Verify the Rust toolchain. Run `cargo --version` and `rustc --version`. Orbit declares `rust-version = "1.89"` (MSRV), so I need Rust **1.89 or newer**. If cargo is missing, or rustc is older than 1.89, **stop and ask me before installing anything** — the canonical path is `rustup` (`curl https://sh.rustup.rs | sh`), but that modifies shell profile, so I want to confirm first. If rustup is already installed but the toolchain is old, suggest `rustup update stable` and confirm before running.
 > 3. Clone `https://github.com/danieljhkim/orbit` into the location from step 1, then run `make install`. This builds with cargo and copies the `orbit` binary to `$INSTALL_BIN_DIR` (default: `~/.cargo/bin`). Confirm the install path with me before running. Verify with `orbit --version`.
 > 4. Run `orbit init` to initialize global state at `~/.orbit`. It selects the host-appropriate sandbox for the shipped executor definitions: `macos-sandbox-exec` on macOS, `linux-bwrap` on Linux, and no OS-level backend on unsupported platforms. On Linux, after `orbit init`, follow the [Linux Bubblewrap host prerequisite](#linux-bubblewrap-host-prerequisite) below and require its capability probe to pass before dispatching agents.
-> 5. From *this* repository (not the Orbit clone), run `orbit workspace init --mcp`. This creates `.orbit/` here and auto-registers Orbit's MCP server with installed agent CLIs (Claude Code, Codex, Gemini).
+> 5. From *this* repository (not the Orbit clone), run `orbit workspace init --mcp`. This creates `.orbit/` here and auto-registers Orbit's MCP server with installed agent CLIs (Claude Code, Codex, Gemini). The registered server is **operator-authorized**: it can dispatch workflows (`orbit.workflow.ship`, run observation/resume) and run `orbit.command.exec`. Tell me before running this if you'd rather it stay agent-only (`orbit mcp init` instead).
 > 6. Ask me whether to enable semantic search (**optional**). `orbit semantic install` downloads a small embedder companion plus the default bge-small model (lives under `~/.orbit/embed/`) and powers `orbit search <query> --hybrid` / `orbit search similar <task-id>` over tasks. It requires macOS arm64 or Linux x86_64/aarch64 with glibc >= 2.38; Intel macOS is unsupported for semantic search. Don't install without my OK. If I accept and tasks already exist in this workspace, also run `orbit semantic index` to backfill the corpus.
 > 7. Read the key documents so you actually understand the model:
 >    - `README.md` — feature surface, install model, plugin vs CLI
@@ -114,7 +114,7 @@ curl -sSf https://raw.githubusercontent.com/danieljhkim/orbit/main/install.sh | 
 
 # initialize
 orbit init                                 # global state (~/.orbit)
-cd <repo> && orbit workspace init --mcp    # workspace state + MCP integration
+cd <repo> && orbit workspace init --mcp    # workspace state + operator-authorized MCP integration
 
 # create, approve, and ship a task
 TASK_ID=$(orbit task add \
@@ -276,19 +276,20 @@ First-time onboarding (`.orbit/` absent) and "what is orbit" tour requests are h
 
 ## Orbit MCP Surface
 
-`orbit workspace init --mcp` registers the Orbit MCP server with the local agent CLI (Claude Code, Codex, Gemini), same as the plugin.
+`orbit workspace init --mcp` registers the Orbit MCP server with the local agent CLI (Claude Code, Codex, Gemini), same as the plugin. The registered server launches as `orbit mcp serve --operator`: it holds **operator authority**, so governed operations — dispatching a workflow (`orbit.workflow.ship`), observing/resuming a run, and `orbit.command.exec` — are authorized through it. Bare `orbit mcp serve` (and every worker/agent-launched MCP session) stays agent-only and is refused those governed tools; `orbit mcp init` also stays agent-only unless you pass `--operator` at the `orbit mcp serve` layer yourself.
 
 `tools/list` is the authoritative MCP reference. Orbit composes that surface from
 the explicitly MCP-registered builtins in `orbit-tools` plus the two discovery
 tools `orbit.workspace.list` and `orbit.crew.list`. `orbit tool list` remains the
 broader registry reference, including tools deliberately kept off MCP.
 
-MCP v1 has no capability-specific advertisement or authorization tier. Local and
-SSH-originated sessions receive the same complete supported surface. Client
-permission profiles may auto-allow some names and prompt for others, but those
-settings are ergonomics, not a server security boundary. Domain validation,
-sandboxing, workspace claims, and other runtime checks still execute on the
-accepting server through Orbit Core.
+Every advertised tool is visible to every session regardless of authority tier;
+authorization is enforced at call time, not by hiding names from `tools/list`.
+Local and SSH-originated sessions receive the same complete supported surface.
+Client permission profiles may auto-allow some names and prompt for others, but
+those settings are ergonomics, not a server security boundary. Domain
+validation, sandboxing, workspace claims, and other runtime checks still
+execute on the accepting server through Orbit Core.
 
 Workspace-scoped tools accept a registered workspace name, logical `ws_*` ID, or
 absolute path registered on the accepting server. The selector may come from the

--- a/crates/orbit-cli/src/command/mcp/command.rs
+++ b/crates/orbit-cli/src/command/mcp/command.rs
@@ -29,6 +29,10 @@ impl Execute for McpCommand {
 #[derive(Subcommand)]
 pub enum McpSubcommand {
     /// Initialize MCP client integration for the current workspace
+    ///
+    /// Registers agent-only authority — the same as bare `orbit mcp serve`.
+    /// For the operator-authorized bootstrap integration (workflow dispatch,
+    /// `orbit.command.exec`), use `orbit workspace init --mcp` instead.
     Init(InitArgs),
     /// Remove MCP client integration for the current workspace
     Remove(RemoveArgs),

--- a/crates/orbit-cli/src/command/mcp/setup/args.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/args.rs
@@ -43,14 +43,21 @@ impl McpProvider {
 
 #[derive(Debug, Clone, Copy)]
 pub(super) enum McpAction {
-    Init,
+    /// `operator` selects the argv authority flag written into the generated
+    /// server entry: `true` emits `mcp serve --operator`, `false` emits plain
+    /// `mcp serve`. Carrying it on the variant (rather than as a separate
+    /// `run_action` parameter) makes every call site name its authority
+    /// explicitly instead of inheriting a default.
+    Init {
+        operator: bool,
+    },
     Remove,
 }
 
 impl McpAction {
     pub(super) fn label(self) -> &'static str {
         match self {
-            Self::Init => "init",
+            Self::Init { .. } => "init",
             Self::Remove => "remove",
         }
     }
@@ -177,15 +184,18 @@ pub struct InitArgs {
 impl InitArgs {
     pub fn execute_without_runtime(self, root_override: Option<&Path>) -> CommandOut {
         let layout = resolve_workspace_layout(root_override)?;
+        // Bare `orbit mcp init` keeps its pre-existing agent-only authority;
+        // only the `orbit workspace init --mcp` bootstrap path (below, via
+        // `init_auto_for_workspace`) selects operator authority.
         let providers = run_action(
-            McpAction::Init,
+            McpAction::Init { operator: false },
             &layout.repo_root,
             &layout.orbit_root,
             self.providers.resolve_mode()?,
             env_home_dir(),
             self.scope,
         )?;
-        print_action_summary(McpAction::Init, &providers);
+        print_action_summary(McpAction::Init { operator: false }, &providers);
         Ok(CommandOutput::Silent)
     }
 }
@@ -223,8 +233,13 @@ pub(crate) fn init_auto_for_workspace(
     // `orbit workspace init` is a per-workspace setup, so its auto-MCP path
     // writes repo-local files. `orbit mcp init` defaults to workspace scope
     // as well; pass `--scope home` for a user-level registration.
+    //
+    // This is the operator-facing orchestrator connection (ORB-10960): the
+    // explicit `--mcp` request from `orbit workspace init` is treated as
+    // deliberate operator setup, so the registered server is authorized for
+    // governed operations such as `orbit.workflow.ship` and `orbit.command.exec`.
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: true },
         repo_root,
         orbit_root,
         ProviderSelectionMode::Auto,

--- a/crates/orbit-cli/src/command/mcp/setup/dispatch.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/dispatch.rs
@@ -17,26 +17,36 @@ pub(super) fn run_action(
     for provider in &providers {
         let target = ConfigTarget::resolve(scope, provider, repo_root, home_dir.as_deref())?;
         match (action, provider) {
-            (McpAction::Init, McpProvider::Claude) => apply_claude_init(&target)?,
+            (McpAction::Init { operator }, McpProvider::Claude) => {
+                apply_claude_init(&target, operator)?
+            }
             (McpAction::Remove, McpProvider::Claude) => apply_claude_remove(&target)?,
-            (McpAction::Init, McpProvider::Codex) => apply_codex_init(&target)?,
+            (McpAction::Init { operator }, McpProvider::Codex) => {
+                apply_codex_init(&target, operator)?
+            }
             (McpAction::Remove, McpProvider::Codex) => apply_codex_remove(&target)?,
-            (McpAction::Init, McpProvider::Gemini) => apply_gemini_init(&target)?,
+            (McpAction::Init { operator }, McpProvider::Gemini) => {
+                apply_gemini_init(&target, operator)?
+            }
             (McpAction::Remove, McpProvider::Gemini) => apply_gemini_remove(&target)?,
-            (McpAction::Init, McpProvider::Grok) => apply_grok_init(&target)?,
+            (McpAction::Init { operator }, McpProvider::Grok) => {
+                apply_grok_init(&target, operator)?
+            }
             (McpAction::Remove, McpProvider::Grok) => apply_grok_remove(&target)?,
-            (McpAction::Init, McpProvider::Cursor) => {
-                apply_simple_json_init(&target, "mcpServers")?
+            (McpAction::Init { operator }, McpProvider::Cursor) => {
+                apply_simple_json_init(&target, "mcpServers", operator)?
             }
             (McpAction::Remove, McpProvider::Cursor) => {
                 apply_simple_json_remove(&target, "mcpServers")?
             }
-            (McpAction::Init, McpProvider::Vscode) => apply_simple_json_init(&target, "servers")?,
+            (McpAction::Init { operator }, McpProvider::Vscode) => {
+                apply_simple_json_init(&target, "servers", operator)?
+            }
             (McpAction::Remove, McpProvider::Vscode) => {
                 apply_simple_json_remove(&target, "servers")?
             }
-            (McpAction::Init, McpProvider::Windsurf) => {
-                apply_simple_json_init(&target, "mcpServers")?
+            (McpAction::Init { operator }, McpProvider::Windsurf) => {
+                apply_simple_json_init(&target, "mcpServers", operator)?
             }
             (McpAction::Remove, McpProvider::Windsurf) => {
                 apply_simple_json_remove(&target, "mcpServers")?

--- a/crates/orbit-cli/src/command/mcp/setup/providers/claude.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/claude.rs
@@ -10,10 +10,14 @@ use super::common::server_args;
 
 pub(in crate::command::mcp::setup) fn apply_claude_init(
     target: &ConfigTarget,
+    operator: bool,
 ) -> Result<(), OrbitError> {
     let mut root = load_json_object(&target.mcp_path)?;
     let mcp_servers = ensure_json_object(&mut root, "mcpServers")?;
-    mcp_servers.insert(ORBIT_MCP_SERVER_ID.to_string(), claude_mcp_server_value());
+    mcp_servers.insert(
+        ORBIT_MCP_SERVER_ID.to_string(),
+        claude_mcp_server_value(operator),
+    );
     write_json_object(&target.mcp_path, &root)?;
 
     if let Some(settings_path) = &target.settings_path {
@@ -75,7 +79,7 @@ pub(in crate::command::mcp::setup) fn apply_claude_remove(
     Ok(())
 }
 
-pub(super) fn claude_mcp_server_value() -> JsonValue {
+pub(super) fn claude_mcp_server_value(operator: bool) -> JsonValue {
     JsonValue::Object(JsonMap::from_iter([
         (
             "command".to_string(),
@@ -83,7 +87,12 @@ pub(super) fn claude_mcp_server_value() -> JsonValue {
         ),
         (
             "args".to_string(),
-            JsonValue::Array(server_args().into_iter().map(JsonValue::String).collect()),
+            JsonValue::Array(
+                server_args(operator)
+                    .into_iter()
+                    .map(JsonValue::String)
+                    .collect(),
+            ),
         ),
     ]))
 }

--- a/crates/orbit-cli/src/command/mcp/setup/providers/codex.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/codex.rs
@@ -9,12 +9,13 @@ use super::common::server_args;
 
 pub(in crate::command::mcp::setup) fn apply_codex_init(
     target: &ConfigTarget,
+    operator: bool,
 ) -> Result<(), OrbitError> {
     let mut root = load_toml_table(&target.mcp_path)?;
     let mcp_servers = ensure_toml_table(&mut root, "mcp_servers")?;
     mcp_servers.insert(
         ORBIT_MCP_SERVER_ID.to_string(),
-        TomlValue::Table(codex_mcp_server_table()),
+        TomlValue::Table(codex_mcp_server_table(operator)),
     );
     write_toml_table(&target.mcp_path, &root)
 }
@@ -35,7 +36,7 @@ pub(in crate::command::mcp::setup) fn apply_codex_remove(
     write_or_remove_toml_table(&target.mcp_path, &root)
 }
 
-pub(super) fn codex_mcp_server_table() -> TomlTable {
+pub(super) fn codex_mcp_server_table(operator: bool) -> TomlTable {
     TomlTable::from_iter([
         (
             "command".to_string(),
@@ -43,7 +44,12 @@ pub(super) fn codex_mcp_server_table() -> TomlTable {
         ),
         (
             "args".to_string(),
-            TomlValue::Array(server_args().into_iter().map(TomlValue::String).collect()),
+            TomlValue::Array(
+                server_args(operator)
+                    .into_iter()
+                    .map(TomlValue::String)
+                    .collect(),
+            ),
         ),
         ("enabled".to_string(), TomlValue::Boolean(true)),
     ])

--- a/crates/orbit-cli/src/command/mcp/setup/providers/common.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/common.rs
@@ -1,3 +1,14 @@
-pub(super) fn server_args() -> Vec<String> {
-    vec!["mcp".to_string(), "serve".to_string()]
+/// The argv a generated client config launches Orbit's MCP server with.
+///
+/// `operator` is the one authority signal threaded through config generation:
+/// `true` produces `mcp serve --operator` (the `orbit workspace init --mcp`
+/// bootstrap path), `false` produces plain `mcp serve` (bare `orbit mcp
+/// init`). Every caller passes it explicitly so no registration path silently
+/// upgrades.
+pub(super) fn server_args(operator: bool) -> Vec<String> {
+    let mut args = vec!["mcp".to_string(), "serve".to_string()];
+    if operator {
+        args.push("--operator".to_string());
+    }
+    args
 }

--- a/crates/orbit-cli/src/command/mcp/setup/providers/gemini.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/gemini.rs
@@ -5,8 +5,9 @@ use super::simple_json::{apply_simple_json_init, apply_simple_json_remove};
 
 pub(in crate::command::mcp::setup) fn apply_gemini_init(
     target: &ConfigTarget,
+    operator: bool,
 ) -> Result<(), OrbitError> {
-    apply_simple_json_init(target, "mcpServers")
+    apply_simple_json_init(target, "mcpServers", operator)
 }
 
 pub(in crate::command::mcp::setup) fn apply_gemini_remove(

--- a/crates/orbit-cli/src/command/mcp/setup/providers/grok.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/grok.rs
@@ -9,12 +9,13 @@ use super::common::server_args;
 
 pub(in crate::command::mcp::setup) fn apply_grok_init(
     target: &ConfigTarget,
+    operator: bool,
 ) -> Result<(), OrbitError> {
     let mut root = load_toml_table(&target.mcp_path)?;
     let mcp_servers = ensure_toml_table(&mut root, "mcp_servers")?;
     mcp_servers.insert(
         ORBIT_MCP_SERVER_ID.to_string(),
-        TomlValue::Table(grok_mcp_server_table()),
+        TomlValue::Table(grok_mcp_server_table(operator)),
     );
     write_toml_table(&target.mcp_path, &root)
 }
@@ -35,7 +36,7 @@ pub(in crate::command::mcp::setup) fn apply_grok_remove(
     write_or_remove_toml_table(&target.mcp_path, &root)
 }
 
-pub(super) fn grok_mcp_server_table() -> TomlTable {
+pub(super) fn grok_mcp_server_table(operator: bool) -> TomlTable {
     TomlTable::from_iter([
         (
             "command".to_string(),
@@ -43,7 +44,12 @@ pub(super) fn grok_mcp_server_table() -> TomlTable {
         ),
         (
             "args".to_string(),
-            TomlValue::Array(server_args().into_iter().map(TomlValue::String).collect()),
+            TomlValue::Array(
+                server_args(operator)
+                    .into_iter()
+                    .map(TomlValue::String)
+                    .collect(),
+            ),
         ),
         ("enabled".to_string(), TomlValue::Boolean(true)),
     ])

--- a/crates/orbit-cli/src/command/mcp/setup/providers/simple_json.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/simple_json.rs
@@ -10,10 +10,14 @@ use super::common::server_args;
 pub(in crate::command::mcp::setup) fn apply_simple_json_init(
     target: &ConfigTarget,
     top_level_key: &str,
+    operator: bool,
 ) -> Result<(), OrbitError> {
     let mut root = load_json_object(&target.mcp_path)?;
     let servers = ensure_json_object(&mut root, top_level_key)?;
-    servers.insert(ORBIT_MCP_SERVER_ID.to_string(), simple_mcp_server_value());
+    servers.insert(
+        ORBIT_MCP_SERVER_ID.to_string(),
+        simple_mcp_server_value(operator),
+    );
     write_json_object(&target.mcp_path, &root)
 }
 
@@ -34,7 +38,7 @@ pub(in crate::command::mcp::setup) fn apply_simple_json_remove(
     write_or_remove_json_object(&target.mcp_path, &root)
 }
 
-pub(super) fn simple_mcp_server_value() -> JsonValue {
+pub(super) fn simple_mcp_server_value(operator: bool) -> JsonValue {
     JsonValue::Object(JsonMap::from_iter([
         (
             "command".to_string(),
@@ -42,7 +46,12 @@ pub(super) fn simple_mcp_server_value() -> JsonValue {
         ),
         (
             "args".to_string(),
-            JsonValue::Array(server_args().into_iter().map(JsonValue::String).collect()),
+            JsonValue::Array(
+                server_args(operator)
+                    .into_iter()
+                    .map(JsonValue::String)
+                    .collect(),
+            ),
         ),
     ]))
 }

--- a/crates/orbit-cli/src/command/mcp/setup/providers/tests/claude.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/tests/claude.rs
@@ -24,7 +24,7 @@ fn claude_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     let providers = run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Claude]),
@@ -95,6 +95,54 @@ fn claude_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     .expect("parse mcp");
     assert!(mcp["mcpServers"]["orbit"].is_null());
     assert!(mcp["mcpServers"]["other"].is_object());
+}
+
+#[test]
+fn claude_operator_init_writes_single_operator_flag_and_refresh_is_idempotent() {
+    let repo = tempdir().expect("repo tempdir");
+    let home = tempdir().expect("home tempdir");
+    std::fs::create_dir_all(repo.path().join(".claude")).expect("create .claude");
+    let orbit_root = repo.path().join(".orbit");
+    std::fs::create_dir_all(&orbit_root).expect("create orbit root");
+
+    let init = || {
+        run_action(
+            McpAction::Init { operator: true },
+            repo.path(),
+            &orbit_root,
+            ProviderSelectionMode::Explicit(vec![McpProvider::Claude]),
+            Some(home.path().to_path_buf()),
+            ScopeArg::Workspace,
+        )
+        .expect("operator init claude")
+    };
+
+    let assert_single_operator_entry = || {
+        let mcp: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(repo.path().join(".claude.json")).expect("read mcp"),
+        )
+        .expect("parse mcp");
+        let args = mcp["mcpServers"]["orbit"]["args"]
+            .as_array()
+            .expect("args array");
+        assert_eq!(
+            args,
+            &vec![
+                serde_json::json!("mcp"),
+                serde_json::json!("serve"),
+                serde_json::json!("--operator"),
+            ]
+        );
+    };
+
+    init();
+    assert_single_operator_entry();
+
+    // Re-running the operator-authorized init (as `orbit workspace init
+    // --force --mcp` does) must replace the entry with a single `--operator`
+    // argument, not duplicate it.
+    init();
+    assert_single_operator_entry();
 }
 
 #[test]

--- a/crates/orbit-cli/src/command/mcp/setup/providers/tests/codex.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/tests/codex.rs
@@ -17,7 +17,7 @@ fn codex_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Codex]),
@@ -80,7 +80,7 @@ fn workspace_scope_codex_init_is_idempotent() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Codex]),
@@ -92,7 +92,7 @@ fn workspace_scope_codex_init_is_idempotent() {
         .expect("read first config");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Codex]),
@@ -104,4 +104,41 @@ fn workspace_scope_codex_init_is_idempotent() {
         .expect("read second config");
 
     assert_eq!(first, second);
+}
+
+#[test]
+fn codex_operator_init_writes_single_operator_flag_and_refresh_is_idempotent() {
+    let repo = tempdir().expect("repo tempdir");
+    let home = tempdir().expect("home tempdir");
+    let orbit_root = repo.path().join(".orbit");
+    std::fs::create_dir_all(&orbit_root).expect("create orbit root");
+
+    let init = || {
+        run_action(
+            McpAction::Init { operator: true },
+            repo.path(),
+            &orbit_root,
+            ProviderSelectionMode::Explicit(vec![McpProvider::Codex]),
+            Some(home.path().to_path_buf()),
+            ScopeArg::Workspace,
+        )
+        .expect("operator init codex")
+    };
+    let assert_single_operator_entry = || {
+        let config = std::fs::read_to_string(repo.path().join(".codex").join("config.toml"))
+            .expect("read config");
+        let parsed: toml::Value = toml::from_str(&config).expect("parse config");
+        let args = parsed["mcp_servers"]["orbit"]["args"]
+            .as_array()
+            .expect("args array");
+        assert_eq!(args.len(), 3);
+        assert_eq!(args[0].as_str(), Some("mcp"));
+        assert_eq!(args[1].as_str(), Some("serve"));
+        assert_eq!(args[2].as_str(), Some("--operator"));
+    };
+
+    init();
+    assert_single_operator_entry();
+    init();
+    assert_single_operator_entry();
 }

--- a/crates/orbit-cli/src/command/mcp/setup/providers/tests/gemini.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/tests/gemini.rs
@@ -17,7 +17,7 @@ fn gemini_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Gemini]),
@@ -70,7 +70,7 @@ fn workspace_scope_gemini_init_is_idempotent() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Gemini]),
@@ -82,7 +82,7 @@ fn workspace_scope_gemini_init_is_idempotent() {
         .expect("read first settings");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Gemini]),
@@ -94,4 +94,47 @@ fn workspace_scope_gemini_init_is_idempotent() {
         .expect("read second settings");
 
     assert_eq!(first, second);
+}
+
+#[test]
+fn gemini_operator_init_writes_single_operator_flag_and_refresh_is_idempotent() {
+    let repo = tempdir().expect("repo tempdir");
+    let home = tempdir().expect("home tempdir");
+    let orbit_root = repo.path().join(".orbit");
+    std::fs::create_dir_all(&orbit_root).expect("create orbit root");
+
+    let init = || {
+        run_action(
+            McpAction::Init { operator: true },
+            repo.path(),
+            &orbit_root,
+            ProviderSelectionMode::Explicit(vec![McpProvider::Gemini]),
+            Some(home.path().to_path_buf()),
+            ScopeArg::Workspace,
+        )
+        .expect("operator init gemini")
+    };
+    let assert_single_operator_entry = || {
+        let settings: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(repo.path().join(".gemini").join("settings.json"))
+                .expect("read settings"),
+        )
+        .expect("parse settings");
+        let args = settings["mcpServers"]["orbit"]["args"]
+            .as_array()
+            .expect("args array");
+        assert_eq!(
+            args,
+            &vec![
+                serde_json::json!("mcp"),
+                serde_json::json!("serve"),
+                serde_json::json!("--operator"),
+            ]
+        );
+    };
+
+    init();
+    assert_single_operator_entry();
+    init();
+    assert_single_operator_entry();
 }

--- a/crates/orbit-cli/src/command/mcp/setup/providers/tests/grok.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/tests/grok.rs
@@ -17,7 +17,7 @@ fn grok_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Grok]),
@@ -84,7 +84,7 @@ fn workspace_scope_grok_init_is_idempotent() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Grok]),
@@ -96,7 +96,7 @@ fn workspace_scope_grok_init_is_idempotent() {
         .expect("read first config");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Grok]),
@@ -108,4 +108,41 @@ fn workspace_scope_grok_init_is_idempotent() {
         .expect("read second config");
 
     assert_eq!(first, second);
+}
+
+#[test]
+fn grok_operator_init_writes_single_operator_flag_and_refresh_is_idempotent() {
+    let repo = tempdir().expect("repo tempdir");
+    let home = tempdir().expect("home tempdir");
+    let orbit_root = repo.path().join(".orbit");
+    std::fs::create_dir_all(&orbit_root).expect("create orbit root");
+
+    let init = || {
+        run_action(
+            McpAction::Init { operator: true },
+            repo.path(),
+            &orbit_root,
+            ProviderSelectionMode::Explicit(vec![McpProvider::Grok]),
+            Some(home.path().to_path_buf()),
+            ScopeArg::Workspace,
+        )
+        .expect("operator init grok")
+    };
+    let assert_single_operator_entry = || {
+        let config = std::fs::read_to_string(repo.path().join(".grok").join("config.toml"))
+            .expect("read config");
+        let parsed: toml::Value = toml::from_str(&config).expect("parse config");
+        let args = parsed["mcp_servers"]["orbit"]["args"]
+            .as_array()
+            .expect("args array");
+        assert_eq!(args.len(), 3);
+        assert_eq!(args[0].as_str(), Some("mcp"));
+        assert_eq!(args[1].as_str(), Some("serve"));
+        assert_eq!(args[2].as_str(), Some("--operator"));
+    };
+
+    init();
+    assert_single_operator_entry();
+    init();
+    assert_single_operator_entry();
 }

--- a/crates/orbit-cli/src/command/mcp/setup/providers/tests/simple_json.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/tests/simple_json.rs
@@ -1,3 +1,4 @@
+use serde_json::json;
 use tempfile::tempdir;
 
 use super::super::super::args::{McpAction, McpProvider, ProviderSelectionMode, ScopeArg};
@@ -8,21 +9,44 @@ use super::super::simple_json::simple_mcp_server_value;
 
 #[test]
 fn server_value_builders_emit_mcp_serve_only() {
-    let claude = claude_mcp_server_value();
+    let claude = claude_mcp_server_value(false);
     let claude_args = claude["args"].as_array().expect("claude args");
     assert_eq!(claude_args.len(), 2);
     assert_eq!(claude_args[0].as_str(), Some("mcp"));
     assert_eq!(claude_args[1].as_str(), Some("serve"));
 
-    let gemini = simple_mcp_server_value();
+    let gemini = simple_mcp_server_value(false);
     let gemini_args = gemini["args"].as_array().expect("gemini args");
     assert_eq!(gemini_args.len(), 2);
     assert!(gemini.get("cwd").is_none());
 
-    let codex = codex_mcp_server_table();
+    let codex = codex_mcp_server_table(false);
     let codex_args = codex["args"].as_array().expect("codex args");
     assert_eq!(codex_args.len(), 2);
     assert!(codex.get("cwd").is_none());
+    assert_eq!(codex["enabled"].as_bool(), Some(true));
+}
+
+#[test]
+fn server_value_builders_append_operator_flag_when_authorized() {
+    let claude = claude_mcp_server_value(true);
+    let claude_args = claude["args"].as_array().expect("claude args");
+    assert_eq!(claude_args.len(), 3);
+    assert_eq!(claude_args[0].as_str(), Some("mcp"));
+    assert_eq!(claude_args[1].as_str(), Some("serve"));
+    assert_eq!(claude_args[2].as_str(), Some("--operator"));
+
+    let gemini = simple_mcp_server_value(true);
+    let gemini_args = gemini["args"].as_array().expect("gemini args");
+    assert_eq!(
+        gemini_args,
+        &vec![json!("mcp"), json!("serve"), json!("--operator")]
+    );
+
+    let codex = codex_mcp_server_table(true);
+    let codex_args = codex["args"].as_array().expect("codex args");
+    assert_eq!(codex_args.len(), 3);
+    assert_eq!(codex_args[2].as_str(), Some("--operator"));
     assert_eq!(codex["enabled"].as_bool(), Some(true));
 }
 
@@ -40,7 +64,7 @@ fn cursor_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Cursor]),
@@ -91,7 +115,7 @@ fn cursor_home_scope_init_writes_resolved_home_path() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Cursor]),
@@ -144,7 +168,7 @@ fn workspace_scope_cursor_init_is_idempotent() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Cursor]),
@@ -156,7 +180,7 @@ fn workspace_scope_cursor_init_is_idempotent() {
         .expect("read first cursor");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Cursor]),
@@ -184,7 +208,7 @@ fn vscode_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Vscode]),
@@ -239,7 +263,7 @@ fn vscode_home_scope_init_writes_resolved_home_path() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Vscode]),
@@ -298,7 +322,7 @@ fn workspace_scope_vscode_init_is_idempotent() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Vscode]),
@@ -310,7 +334,7 @@ fn workspace_scope_vscode_init_is_idempotent() {
         .expect("read first vscode");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Vscode]),
@@ -339,7 +363,7 @@ fn windsurf_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Windsurf]),
@@ -390,7 +414,7 @@ fn windsurf_home_scope_init_writes_resolved_home_path() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Windsurf]),
@@ -444,7 +468,7 @@ fn workspace_scope_windsurf_init_is_idempotent() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Windsurf]),
@@ -460,7 +484,7 @@ fn workspace_scope_windsurf_init_is_idempotent() {
     let first = std::fs::read_to_string(&path).expect("read first windsurf");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Windsurf]),
@@ -471,4 +495,106 @@ fn workspace_scope_windsurf_init_is_idempotent() {
     let second = std::fs::read_to_string(&path).expect("read second windsurf");
 
     assert_eq!(first, second);
+}
+
+/// Shared assertion for the simple-JSON providers (cursor, vscode, windsurf):
+/// the written `orbit` server entry's `args` array is exactly `["mcp",
+/// "serve", "--operator"]` under the given top-level servers key.
+fn assert_single_operator_entry(config_path: &std::path::Path, top_level_key: &str) {
+    let config: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(config_path).expect("read config"))
+            .expect("parse config");
+    let args = config[top_level_key]["orbit"]["args"]
+        .as_array()
+        .expect("args array");
+    assert_eq!(
+        args,
+        &vec![
+            serde_json::json!("mcp"),
+            serde_json::json!("serve"),
+            serde_json::json!("--operator"),
+        ]
+    );
+}
+
+#[test]
+fn cursor_operator_init_writes_single_operator_flag_and_refresh_is_idempotent() {
+    let repo = tempdir().expect("repo tempdir");
+    let home = tempdir().expect("home tempdir");
+    let orbit_root = repo.path().join(".orbit");
+    std::fs::create_dir_all(&orbit_root).expect("create orbit root");
+    let path = repo.path().join(".cursor").join("mcp.json");
+
+    let init = || {
+        run_action(
+            McpAction::Init { operator: true },
+            repo.path(),
+            &orbit_root,
+            ProviderSelectionMode::Explicit(vec![McpProvider::Cursor]),
+            Some(home.path().to_path_buf()),
+            ScopeArg::Workspace,
+        )
+        .expect("operator init cursor")
+    };
+
+    init();
+    assert_single_operator_entry(&path, "mcpServers");
+    init();
+    assert_single_operator_entry(&path, "mcpServers");
+}
+
+#[test]
+fn vscode_operator_init_writes_single_operator_flag_and_refresh_is_idempotent() {
+    let repo = tempdir().expect("repo tempdir");
+    let home = tempdir().expect("home tempdir");
+    let orbit_root = repo.path().join(".orbit");
+    std::fs::create_dir_all(&orbit_root).expect("create orbit root");
+    let path = repo.path().join(".vscode").join("mcp.json");
+
+    let init = || {
+        run_action(
+            McpAction::Init { operator: true },
+            repo.path(),
+            &orbit_root,
+            ProviderSelectionMode::Explicit(vec![McpProvider::Vscode]),
+            Some(home.path().to_path_buf()),
+            ScopeArg::Workspace,
+        )
+        .expect("operator init vscode")
+    };
+
+    init();
+    assert_single_operator_entry(&path, "servers");
+    init();
+    assert_single_operator_entry(&path, "servers");
+}
+
+#[test]
+fn windsurf_operator_init_writes_single_operator_flag_and_refresh_is_idempotent() {
+    let repo = tempdir().expect("repo tempdir");
+    let home = tempdir().expect("home tempdir");
+    let orbit_root = repo.path().join(".orbit");
+    std::fs::create_dir_all(&orbit_root).expect("create orbit root");
+    let path = repo
+        .path()
+        .join(".codeium")
+        .join("windsurf")
+        .join("mcp_config.json");
+
+    let init = || {
+        run_action(
+            McpAction::Init { operator: true },
+            repo.path(),
+            &orbit_root,
+            ProviderSelectionMode::Explicit(vec![McpProvider::Windsurf]),
+            Some(home.path().to_path_buf()),
+            ScopeArg::Workspace,
+        )
+        .expect("operator init windsurf")
+    };
+
+    init();
+    assert_single_operator_entry(&path, "mcpServers");
+    init();
+    assert_single_operator_entry(&path, "mcpServers");
 }

--- a/crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs
@@ -61,7 +61,7 @@ fn home_scope_writes_to_home_paths_and_skips_repo_files() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![
@@ -181,7 +181,7 @@ fn home_scope_remove_strips_only_orbit_entries() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![
@@ -255,7 +255,7 @@ fn home_scope_without_home_dir_errors() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     let err = run_action(
-        McpAction::Init,
+        McpAction::Init { operator: false },
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Claude]),

--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -50,7 +50,11 @@ pub struct WorkspaceInitArgs {
     /// a value below the current position is refused.
     #[arg(long, value_name = "N")]
     pub task_id_start: Option<u32>,
-    /// Set up MCP client integrations for auto-detected providers.
+    /// Set up MCP client integrations for auto-detected providers. The
+    /// registered server is granted OPERATOR authority: governed operations
+    /// such as `orbit.workflow.ship`, workflow run observation/resume, and
+    /// `orbit.command.exec` become reachable through it. Bare `orbit mcp
+    /// serve` and worker/agent MCP startup remain agent-only.
     #[arg(long)]
     pub mcp: bool,
     /// Inject (or refresh) an Orbit workflow-rules block in CLAUDE.md and AGENTS.md at the workspace root.
@@ -104,7 +108,10 @@ impl WorkspaceInitArgs {
             if providers.is_empty() {
                 println!("  mcp:       no providers auto-detected");
             } else {
-                println!("  mcp:       {}", providers.join(", "));
+                println!(
+                    "  mcp:       {} (operator-authorized: orbit.workflow.ship, run observe/resume, orbit.command.exec)",
+                    providers.join(", ")
+                );
             }
         } else {
             println!("  mcp:       skipped (pass --mcp to set up integrations)");

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -884,6 +884,95 @@ fn workspace_init_seeds_auto_detected_mcp_configs() {
             .exists()
     );
     assert!(workspace.path().join(".grok").join("config.toml").exists());
+
+    // `--mcp` from `orbit workspace init` is the operator-facing orchestrator
+    // bootstrap path (ORB-10960): every auto-detected client must launch the
+    // Orbit server with `mcp serve --operator`, exactly.
+    let claude_mcp: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(workspace.path().join(".claude.json")).expect("read claude mcp"),
+    )
+    .expect("parse claude mcp");
+    assert_operator_argv(&claude_mcp["mcpServers"]["orbit"]["args"]);
+
+    let codex_config = std::fs::read_to_string(workspace.path().join(".codex/config.toml"))
+        .expect("read codex config");
+    let codex_parsed: toml::Value = toml::from_str(&codex_config).expect("parse codex config");
+    assert_operator_argv_toml(&codex_parsed["mcp_servers"]["orbit"]["args"]);
+
+    let gemini_settings: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(workspace.path().join(".gemini/settings.json"))
+            .expect("read gemini settings"),
+    )
+    .expect("parse gemini settings");
+    assert_operator_argv(&gemini_settings["mcpServers"]["orbit"]["args"]);
+
+    let grok_config = std::fs::read_to_string(workspace.path().join(".grok/config.toml"))
+        .expect("read grok config");
+    let grok_parsed: toml::Value = toml::from_str(&grok_config).expect("parse grok config");
+    assert_operator_argv_toml(&grok_parsed["mcp_servers"]["orbit"]["args"]);
+}
+
+/// Every generated integration's argv must be exactly `mcp serve --operator`.
+fn assert_operator_argv(args: &serde_json::Value) {
+    let args = args.as_array().expect("args array");
+    assert_eq!(
+        args,
+        &vec![
+            serde_json::json!("mcp"),
+            serde_json::json!("serve"),
+            serde_json::json!("--operator"),
+        ]
+    );
+}
+
+fn assert_operator_argv_toml(args: &toml::Value) {
+    let args = args.as_array().expect("args array");
+    assert_eq!(args.len(), 3);
+    assert_eq!(args[0].as_str(), Some("mcp"));
+    assert_eq!(args[1].as_str(), Some("serve"));
+    assert_eq!(args[2].as_str(), Some("--operator"));
+}
+
+#[test]
+fn workspace_reinit_with_force_mcp_refreshes_operator_argv_without_duplicating_it() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let home = tempdir().expect("home tempdir");
+    std::fs::create_dir_all(workspace.path().join(".claude")).expect("create .claude");
+
+    let _env = EnvGuard::acquire().home(home.path()).cwd(workspace.path());
+
+    let init = |force| {
+        WorkspaceInitArgs {
+            name: None,
+            base_branch: Some("main".to_string()),
+            ship_mode: None,
+            role: None,
+            owner: None,
+            task_id_start: None,
+            mcp: true,
+            inject_agent_rules: false,
+            refresh_defaults: false,
+            force,
+        }
+        .execute_without_runtime(None)
+        .expect("workspace init with --mcp")
+    };
+
+    init(false);
+    let claude_path = workspace.path().join(".claude.json");
+    let first: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&claude_path).expect("read claude mcp"))
+            .expect("parse claude mcp");
+    assert_operator_argv(&first["mcpServers"]["orbit"]["args"]);
+
+    // Re-running the supported reconciliation path (`--force --mcp`) must
+    // refresh the managed Orbit entry to a single `--operator` argument, not
+    // append a second one, while leaving unrelated config untouched.
+    init(true);
+    let second: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&claude_path).expect("read claude mcp"))
+            .expect("parse claude mcp");
+    assert_operator_argv(&second["mcpServers"]["orbit"]["args"]);
 }
 
 #[test]

--- a/crates/orbit-cli/src/tests/env_isolation.rs
+++ b/crates/orbit-cli/src/tests/env_isolation.rs
@@ -47,6 +47,7 @@ fn restore_var(key: &str, previous: Option<OsString>) {
 pub(crate) struct EnvGuard {
     home: Option<Option<OsString>>,
     userprofile: Option<Option<OsString>>,
+    orbit_root: Option<Option<OsString>>,
     cwd: Option<PathBuf>,
     // Declared last so it drops last: the lock is held until every restoration
     // in `Drop` has run.
@@ -65,6 +66,7 @@ impl EnvGuard {
         Self {
             home: None,
             userprofile: None,
+            orbit_root: None,
             cwd: None,
             _lock: lock,
         }
@@ -72,6 +74,13 @@ impl EnvGuard {
 
     /// Point `HOME` and `USERPROFILE` at `home`, capturing the prior values the
     /// first time either is set.
+    ///
+    /// Also clears `ORBIT_ROOT`, capturing its prior value: it is an explicit
+    /// escape hatch that outranks `HOME`/cwd-based root resolution (see
+    /// `orbit-core/src/runtime/resolve.rs`), so a process launched by Orbit's
+    /// own dispatch — which sets `ORBIT_ROOT` in the ambient environment for
+    /// audit bookkeeping — would otherwise resolve these tests' isolated
+    /// fixture root straight through to the real, non-isolated shared root.
     pub(crate) fn home(mut self, home: &Path) -> Self {
         if self.home.is_none() {
             self.home = Some(std::env::var_os("HOME"));
@@ -79,9 +88,13 @@ impl EnvGuard {
         if self.userprofile.is_none() {
             self.userprofile = Some(std::env::var_os("USERPROFILE"));
         }
+        if self.orbit_root.is_none() {
+            self.orbit_root = Some(std::env::var_os("ORBIT_ROOT"));
+        }
         unsafe {
             std::env::set_var("HOME", home);
             std::env::set_var("USERPROFILE", home);
+            std::env::remove_var("ORBIT_ROOT");
         }
         self
     }
@@ -121,6 +134,9 @@ impl Drop for EnvGuard {
         }
         if let Some(previous) = self.home.take() {
             restore_var("HOME", previous);
+        }
+        if let Some(previous) = self.orbit_root.take() {
+            restore_var("ORBIT_ROOT", previous);
         }
     }
 }

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -514,6 +514,93 @@ fn an_operator_served_mcp_session_reaches_a_governed_tool() {
     assert_eq!(listed["items"], json!([]));
 }
 
+/// ORB-10960: `orbit workspace init --mcp` is the operator-facing bootstrap
+/// path. This proves it end to end — configuration output through server
+/// startup — rather than only unit-testing the argv string builder: it runs
+/// the real CLI to generate a Claude Code integration, extracts the exact
+/// argv that integration launches, spawns `orbit` with that argv over the
+/// real MCP stdio transport, and confirms a governed workflow tool is
+/// authorized. Re-running the same reconciliation path must refresh the
+/// entry to a single `--operator` argument rather than duplicating it.
+#[test]
+fn workspace_init_mcp_config_reaches_a_governed_tool_over_the_real_transport() {
+    let workspace = McpWorkspace::init();
+    std::fs::create_dir_all(workspace.work.join(".claude")).expect("create .claude marker");
+
+    let reconcile = || {
+        let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+            .args([
+                "workspace",
+                "init",
+                "--name",
+                "mcp-roundtrip",
+                "--force",
+                "--mcp",
+            ])
+            .output()
+            .expect("run workspace init --force --mcp");
+        assert!(
+            output.status.success(),
+            "workspace init --force --mcp failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+
+    let read_generated_args = || -> Vec<String> {
+        let claude_mcp: Value = serde_json::from_str(
+            &std::fs::read_to_string(workspace.work.join(".claude.json"))
+                .expect("read generated claude mcp config"),
+        )
+        .expect("parse generated claude mcp config");
+        claude_mcp["mcpServers"]["orbit"]["args"]
+            .as_array()
+            .expect("generated args array")
+            .iter()
+            .map(|value| value.as_str().expect("arg is a string").to_string())
+            .collect()
+    };
+
+    reconcile();
+    let args = read_generated_args();
+    assert_eq!(
+        args,
+        vec![
+            "mcp".to_string(),
+            "serve".to_string(),
+            "--operator".to_string()
+        ],
+        "orbit workspace init --mcp must write argv exactly `mcp serve --operator`"
+    );
+
+    // Re-running the same reconciliation path (`--force --mcp`, as a second
+    // `orbit workspace init --mcp` bootstrap would do) must refresh the
+    // managed entry rather than append a second `--operator` argument.
+    reconcile();
+    assert_eq!(
+        read_generated_args(),
+        args,
+        "refreshing the operator-authorized entry must not duplicate --operator"
+    );
+
+    // Spawn the exact argv the generated config launches, over the real MCP
+    // stdio transport, and prove it reaches a governed workflow tool.
+    let mut command = McpWorkspace::orbit_command(&workspace.work, &workspace.home);
+    command
+        .args(&args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let child = command
+        .spawn()
+        .expect("spawn the server launched by the generated config");
+    let mut client = McpClient::new(child);
+    workspace.initialize(&mut client);
+
+    let listed = client.call_tool_ok("orbit_workflow_run_list", json!({}));
+    assert_eq!(listed["items"], json!([]));
+}
+
 #[test]
 fn mcp_serve_lists_the_canonical_surface_outside_any_checkout() {
     let workspace = McpWorkspace::init();

--- a/crates/orbit-core/assets/skills/orbit/references/setup/first-run.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/first-run.md
@@ -67,7 +67,12 @@ orbit workspace init --mcp
 
 This registers the checkout, creates `.orbit/`, and seeds the default skills,
 jobs, activities, policies, routines, and auto-task definitions. `--mcp`
-auto-detects installed agent clients and registers Orbit's MCP server with them.
+auto-detects installed agent clients and registers Orbit's MCP server with
+them as `orbit mcp serve --operator` — **operator authority**, so the
+registered integration can dispatch workflows (`orbit.workflow.ship`),
+observe/resume runs, and run `orbit.command.exec`. This is the deliberate
+bootstrap path for a human-facing orchestrator; bare `orbit mcp serve` and any
+worker/agent-launched MCP session stay agent-only.
 
 Two things to know about what it seeded:
 

--- a/plugin/skills/orbit/references/setup/first-run.md
+++ b/plugin/skills/orbit/references/setup/first-run.md
@@ -67,7 +67,12 @@ orbit workspace init --mcp
 
 This registers the checkout, creates `.orbit/`, and seeds the default skills,
 jobs, activities, policies, routines, and auto-task definitions. `--mcp`
-auto-detects installed agent clients and registers Orbit's MCP server with them.
+auto-detects installed agent clients and registers Orbit's MCP server with
+them as `orbit mcp serve --operator` — **operator authority**, so the
+registered integration can dispatch workflows (`orbit.workflow.ship`),
+observe/resume runs, and run `orbit.command.exec`. This is the deliberate
+bootstrap path for a human-facing orchestrator; bare `orbit mcp serve` and any
+worker/agent-launched MCP session stay agent-only.
 
 Two things to know about what it seeded:
 


### PR DESCRIPTION
## Task

[ORB-10960](https://orbit-cli.com/tasks/ORB-10960) — Generate operator-authorized MCP config from workspace init --mcp

### Description

## Problem

`orbit workspace init --mcp` currently writes client configurations that launch `orbit mcp serve` without `--operator`. Since ORB-10916 and ORB-10927 made MCP authorization fail closed and introduced an explicit operator session grant, the generated integration receives agent authority only. A human-facing Orbit orchestrator configured through the documented bootstrap path therefore cannot invoke governed MCP operations such as `orbit.workflow.ship`, workflow run observation/resume, or `orbit.command.exec`.

## Desired Authority Boundary

Treat the MCP registration explicitly requested by `orbit workspace init --mcp` as the operator-facing orchestrator connection and generate `orbit mcp serve --operator` for every auto-detected supported client.

Do not broaden authority for bare `orbit mcp serve`, MCP servers started inside dispatched worker execution, remote proxy mode, or any other worker/agent path. Those must remain agent-only unless an operator grant is explicitly selected.

## Constraints / Notes

- This is security-sensitive despite the small code change: help text and initialization output must disclose that the generated integration has operator authority, including access to `orbit.command.exec` and workflow dispatch controls.
- Thread authority through the config-generation API explicitly. Do not change the shared `server_args()` helper in a way that silently upgrades unrelated registration callers.
- Preserve all provider-specific config formats and unrelated user-authored configuration.
- Re-running the supported workspace-init reconciliation path must refresh Orbit's existing server entry to include `--operator` without duplicating it.
- Keep `orbit mcp init` at its existing authority unless its contract is deliberately changed and documented as part of this task; it must not be upgraded accidentally as an implementation side effect.
- ORB-10927 is the immediate prerequisite context: it created the reachable operator MCP session grant that this bootstrap path should now select.

### Acceptance Criteria

- A fresh `orbit workspace init --mcp` writes an Orbit server entry whose argv is exactly `mcp serve --operator` for every auto-detected supported client/config format.
- Starting the generated server and exercising the real MCP transport proves that an operator-governed workflow tool is authorized; the test must cover configuration output through server startup rather than only unit-testing a string builder.
- Bare `orbit mcp serve` and worker/agent MCP startup paths still receive agent-only authority and are denied access to governed operator tools.
- `orbit mcp init` retains its pre-task authority behavior unless the implementation intentionally changes that public contract with corresponding help, documentation, and tests.
- Re-running `orbit workspace init --force --mcp` replaces the managed Orbit server entry with one containing a single `--operator` argument while preserving unrelated client configuration.
- CLI help and bootstrap output visibly state that `--mcp` installs an operator-authorized integration and name the consequential workflow/command capabilities.
- Deterministic tests cover Claude, Codex, Gemini, Grok, Cursor, VS Code, and Windsurf config shapes, including refresh/idempotency behavior.
- Focused MCP setup/workspace-init tests, the repository fast CI suite, and lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented: `orbit workspace init --mcp` now writes `orbit mcp serve --operator` argv
for every generated client integration (Claude, Codex, Gemini, Grok, Cursor, VS Code,
Windsurf), while `orbit mcp init` and every worker/agent MCP startup path keep agent-only
authority unchanged.

Design: threaded `operator: bool` explicitly through the config-generation API rather than
changing the shared `server_args()` helper's default. `McpAction::Init { operator: bool }`
(was a unit variant) makes every `run_action` call site name its authority explicitly —
`init_auto_for_workspace` (the `workspace init --mcp` path) passes `true`; `orbit mcp init`
passes `false`, preserving its pre-task contract. `server_args(operator)` appends
`--operator` only when true; all seven provider `apply_*_init`/`*_mcp_server_*` functions
now take and forward `operator`. Insert-based config writes already replace the `orbit`
server entry wholesale, so re-running `--force --mcp` naturally refreshes to a single
`--operator` argument without extra dedup logic.

Disclosure: `--mcp`'s clap help, the `orbit mcp init` long-form help (contrasting the two
paths), the `workspace init --mcp` bootstrap println output, README.md (agent setup prompt,
quick-start, and the "Orbit MCP Surface" section — corrected a stale "no
authorization tier" claim left over from before ORB-10916/10927), and both copies of
`setup/first-run.md` (core assets + plugin) now name the operator authority and the
consequential tools (`orbit.workflow.ship`, run observe/resume, `orbit.command.exec`).

Tests added/changed:
- Provider-level (claude/codex/gemini/grok/cursor/vscode/windsurf): operator=true argv
  assertion + refresh/idempotency (single `--operator`, not duplicated) for each provider;
  extended the shared server-value-builder unit test to cover operator=true too.
- workspace/tests/init.rs: `workspace_init_seeds_auto_detected_mcp_configs` now asserts
  the operator argv for every auto-detected client; added
  `workspace_reinit_with_force_mcp_refreshes_operator_argv_without_duplicating_it`.
- mcp_roundtrip.rs (real transport, AC-required): new
  `workspace_init_mcp_config_reaches_a_governed_tool_over_the_real_transport` runs the real
  `orbit workspace init --force --mcp` CLI, reads the exact generated Claude config argv,
  asserts it, re-runs to prove idempotency, then spawns `orbit` with that *exact* argv over
  real MCP stdio and proves a governed tool (`orbit_workflow_run_list`) is authorized —
  configuration output through server startup, not just a string-builder unit test.
  Pre-existing `mcp_server_advertises_governed_tools_but_denies_an_unprivileged_session` and
  `an_operator_served_mcp_session_reaches_a_governed_tool` already cover bare `mcp serve`
  staying agent-only and `--operator` being denied/authorized correctly (from ORB-10927).

Scope extension (recorded on-task, see comments): fixed
`crates/orbit-cli/src/tests/env_isolation.rs::EnvGuard` to also isolate `ORBIT_ROOT` — it
is an explicit root-resolution escape hatch that Orbit's own dispatch sets in the ambient
environment of every worktree session, so every `EnvGuard`-based `workspace::tests::init`
test (21/25) was resolving against the real, read-only shared checkout instead of its
isolated tempdir fixture, independent of anything in this task's diff. Fixed and verified
(single- and multi-threaded); filed friction F2026-08-114 with the diagnosis. Related,
not-yet-unified prior friction: F2026-08-098 (orbit-core has two uncoordinated env-mutation
locks for the same class of problem).

Validation:
- `cargo test -p orbit-cli --bin orbit` — 345/345 pass.
- `cargo test -p orbit-cli --test mcp_roundtrip` — 15/15 pass, including the new real-
  transport test and the pre-existing operator-authority tests.
- `cargo fmt --check -p orbit-cli` and `cargo clippy -p orbit-cli --all-targets -- -D
  warnings` — clean.
- `make ci-lint` (workspace-wide clippy, `-D warnings`) — clean.
- `make ci-fast` — every guardrail script passes individually; the aggregate target fails
  only on `cargo fmt --all -- --check` against `crates/orbit-web/src/tests/dashboard_assets.rs`,
  which is pre-existing formatting drift at HEAD (commit 2ab900c) in a file this task never
  touches — confirmed via `cargo fmt -p orbit-web -- --check` reproducing the identical diff
  with this task's changes fully backed out of that file (it was never touched). Not fixed
  here as out of scope for ORB-10960.

Not changed, by design: `orbit mcp init`'s public contract (still agent-only, per the task's
explicit constraint), the shared `server_args()` helper's call sites outside MCP setup, and
worker/agent MCP startup authority (`orbit-cli/src/command/mcp/server.rs` already hardcodes
`McpSessionAuthority::Agent` for the TCP listener and leaves stdio authority to the explicit
`--operator` flag from ORB-10927 — unrelated to this task's config-generation change).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10960-6a8a16ea`
- Behind base: 0
- Ahead of base: 1