### PR TITLE
Keep task.show readable when its stored crew is unavailable

### DIFF
--- a/crates/orbit-cli/src/command/task/output.rs
+++ b/crates/orbit-cli/src/command/task/output.rs
@@ -3,7 +3,8 @@ use std::fmt::Write as _;
 
 use chrono::{DateTime, Utc};
 use orbit_core::{
-    OrbitError, OrbitRuntime, TaskStatus, resolve_task_dependencies, resolve_task_relations,
+    OrbitError, OrbitRuntime, TaskCrewRead, TaskStatus, resolve_task_dependencies,
+    resolve_task_relations,
 };
 use orbit_types::task::{
     ArtifactManifestFileV2, TaskArtifact, task_show_record_field_json,
@@ -105,18 +106,23 @@ pub(crate) fn task_to_json_with_sidecars(
     // This used to propagate, which was invisible while only `--json` built
     // this projection. Since ORB-10586 every mode does (the payload is the
     // same records in both), so propagating would mean `orbit task show`
-    // refusing to display a task whose crew is undefined here. The reason goes
-    // to stderr rather than being swallowed.
-    match runtime.resolved_crew_projection(task) {
-        Ok(Some(projection)) => {
+    // refusing to display a task whose crew is undefined here. ORB-10968 moved
+    // the rule itself into `OrbitRuntime::task_crew_read` so the tool host and
+    // MCP read the same contract; the reason still goes to stderr here rather
+    // than being swallowed.
+    match runtime.task_crew_read(task) {
+        TaskCrewRead::Resolved(projection) => {
             object.insert("resolved_crew".to_string(), Value::String(projection.name));
             object.insert("crew_model".to_string(), Value::String(projection.model));
         }
-        Ok(None) => {}
-        Err(error) => eprintln!(
-            "warning: crew for task {} could not be resolved: {error}",
-            task.id
-        ),
+        TaskCrewRead::Absent => {}
+        TaskCrewRead::Unresolved { reason } => {
+            object.insert("crew_unresolved".to_string(), Value::String(reason.clone()));
+            eprintln!(
+                "warning: crew for task {} could not be resolved: {reason}",
+                task.id
+            );
+        }
     }
     Ok(value)
 }

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -1684,6 +1684,163 @@ fn task_show_is_global_by_default_across_tool_run_and_mcp() {
     );
 }
 
+/// ORB-10968: a stored crew this host has no `[crews.*]` entry for must not
+/// make the task unreadable.
+///
+/// Crew configuration is host-local, so the same task is routinely served by a
+/// machine that never defined its crew — over SSH-marked MCP most of all. The
+/// read surfaces render the raw `crew` and mark the projection unresolved; only
+/// paths that must actually dispatch (`orbit.task.start`) still fail closed.
+#[test]
+fn task_read_surfaces_tolerate_a_crew_this_host_does_not_define() {
+    let workspace = McpWorkspace::init();
+    let config_path = workspace.home.join(".orbit").join("config.toml");
+    let baseline = std::fs::read_to_string(&config_path).expect("read the seeded config");
+
+    // Author the task while the crew exists, the way its owning machine would.
+    std::fs::write(
+        &config_path,
+        format!("{baseline}\n[crews.remote-only]\nprovider = \"codex\"\nmodel = \"gpt-5.6-sol\"\n"),
+    )
+    .expect("define the authoring host's crew");
+    let add_input = json!({
+        "title": "Authored against a crew only the other host defines",
+        "description": "Read back from a host whose [crews.*] table lacks it",
+        "workspace": workspace.work.to_str().expect("utf8 checkout path"),
+        "complexity": "low",
+        "crew": "remote-only",
+        "model": "codex",
+    })
+    .to_string();
+    let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args(["tool", "run", "orbit.task.add", "--input", &add_input])
+        .output()
+        .expect("author a task naming the remote crew");
+    assert!(
+        output.status.success(),
+        "task add failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let created: Value = serde_json::from_slice(&output.stdout).expect("parse created task");
+    let task_id = created["id"].as_str().expect("task id").to_string();
+
+    // Serve it from a host that never had that crew.
+    std::fs::write(&config_path, &baseline).expect("drop the crew from this host");
+    let show_input = json!({ "id": task_id, "model": "codex" }).to_string();
+
+    // (1) CLI tool-run, from a directory outside any workspace, so the read
+    // also goes through the global id lookup.
+    let scratch = workspace.home.join("scratch");
+    std::fs::create_dir_all(&scratch).expect("create a non-workspace directory");
+    // `--full` because tool-run projects a minimal task shape by default, and
+    // the crew fields are what this asserts.
+    let output = McpWorkspace::orbit_command(&scratch, &workspace.home)
+        .args([
+            "tool",
+            "run",
+            "orbit.task.show",
+            "--full",
+            "--input",
+            &show_input,
+        ])
+        .output()
+        .expect("run id-only task show");
+    assert!(
+        output.status.success(),
+        "tool-run show must stay readable\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_unresolved_crew_projection(
+        &serde_json::from_slice(&output.stdout).expect("parse tool run show"),
+    );
+
+    // (2) A local MCP session bound to the workspace.
+    let mut client = workspace.serve();
+    assert_unresolved_crew_projection(
+        &client.call_tool_ok("orbit_task_show", json!({ "id": task_id })),
+    );
+    let listed = client.call_tool_ok(
+        "orbit_task_list",
+        json!({ "workspace": workspace.work.to_str().expect("utf8 checkout path") }),
+    );
+    assert!(
+        listed["items"]
+            .as_array()
+            .expect("task list items")
+            .iter()
+            .any(|task| task["id"] == json!(task_id)),
+        "listing applies the same tolerant read contract: {listed}"
+    );
+    drop(client);
+
+    // (3) The SSH-marked remote session that first hit this (four failed
+    // `orbit.task.show` calls in one session).
+    let server_scratch = workspace.home.join("server-scratch");
+    std::fs::create_dir_all(&server_scratch).expect("create server launch dir");
+    let child = McpWorkspace::orbit_command(&server_scratch, &workspace.home)
+        .args(["mcp", "serve", "--remote-caller-machine-id", "hm_caller"])
+        .env("SSH_CONNECTION", "192.0.2.8 43100 198.51.100.2 22")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn SSH-marked MCP server");
+    let mut client = McpClient::new(child);
+    client.request(
+        "initialize",
+        json!({
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": { "name": "remote-crew-roundtrip", "version": "0" },
+            "_meta": { "orbit": { "workspace": "ws_mcp-roundtrip" } },
+        }),
+    );
+    client.notify("notifications/initialized");
+    assert_unresolved_crew_projection(
+        &client.call_tool_ok("orbit_task_show", json!({ "id": task_id })),
+    );
+    drop(client);
+
+    // Execution still fails closed: starting the task needs a crew this host
+    // can actually dispatch to.
+    let started = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args(["tool", "run", "orbit.task.start", "--input", &show_input])
+        .output()
+        .expect("run task start");
+    assert!(
+        !started.status.success(),
+        "start must not tolerate the crew"
+    );
+    let stderr = String::from_utf8_lossy(&started.stderr);
+    assert!(
+        stderr.contains("remote-only") && stderr.contains("not defined"),
+        "start must fail with the actionable crew-validation error: {stderr}"
+    );
+}
+
+/// The tolerant read contract: the stored crew stays verbatim, the resolved
+/// projection is withheld rather than guessed, and the reason is reported as a
+/// non-fatal field.
+fn assert_unresolved_crew_projection(shown: &Value) {
+    assert_eq!(
+        shown["crew"],
+        json!("remote-only"),
+        "the raw stored crew stays visible: {shown}"
+    );
+    assert!(
+        shown.get("resolved_crew").is_none() && shown.get("crew_model").is_none(),
+        "an unresolvable crew must not be projected: {shown}"
+    );
+    assert!(
+        shown["crew_unresolved"]
+            .as_str()
+            .is_some_and(|reason| reason.contains("remote-only")),
+        "the unresolved marker must name the crew: {shown}"
+    );
+}
+
 fn serve_mcp_from(cwd: &Path, home: &Path, initialize: Value) -> McpClient {
     let child = McpWorkspace::orbit_command(cwd, home)
         .args(["mcp", "serve"])

--- a/crates/orbit-core/src/adapter/tool_host/json.rs
+++ b/crates/orbit-core/src/adapter/tool_host/json.rs
@@ -8,6 +8,7 @@ use orbit_types::task::{
 use serde_json::{Map, Value, json};
 
 use crate::OrbitRuntime;
+use crate::TaskCrewRead;
 use crate::application::task::TaskLintReport;
 
 pub(super) fn task_to_json(task: &Task, status_by_id: &BTreeMap<String, TaskStatus>) -> Value {
@@ -59,21 +60,30 @@ pub(super) fn serialize_task(runtime: &OrbitRuntime, task: &Task) -> Result<Valu
         "history".to_string(),
         serialize_history(&runtime.get_task_history(&task.id)?)?,
     );
-    insert_resolved_crew(runtime, task, object)?;
+    insert_resolved_crew(runtime, task, object);
     Ok(value)
 }
 
-fn insert_resolved_crew(
-    runtime: &OrbitRuntime,
-    task: &Task,
-    object: &mut Map<String, Value>,
-) -> Result<(), OrbitError> {
-    let Some(projection) = runtime.resolved_crew_projection(task)? else {
-        return Ok(());
-    };
-    object.insert("resolved_crew".to_string(), Value::String(projection.name));
-    object.insert("crew_model".to_string(), Value::String(projection.model));
-    Ok(())
+/// Enrich a task projection with its resolved crew, when this host can resolve
+/// one.
+///
+/// `crew` (the stored value) is part of the record; `resolved_crew` /
+/// `crew_model` only annotate it. A host whose `[crews.*]` table has no entry
+/// for the stored crew — a task authored elsewhere, or a config edited since —
+/// still owes the caller the task, so an unresolvable crew is reported as
+/// `crew_unresolved` rather than failing the whole readout (ORB-10968). The
+/// tolerance lives in `OrbitRuntime::task_crew_read`, shared with the CLI.
+fn insert_resolved_crew(runtime: &OrbitRuntime, task: &Task, object: &mut Map<String, Value>) {
+    match runtime.task_crew_read(task) {
+        TaskCrewRead::Absent => {}
+        TaskCrewRead::Resolved(projection) => {
+            object.insert("resolved_crew".to_string(), Value::String(projection.name));
+            object.insert("crew_model".to_string(), Value::String(projection.model));
+        }
+        TaskCrewRead::Unresolved { reason } => {
+            object.insert("crew_unresolved".to_string(), Value::String(reason));
+        }
+    }
 }
 
 pub(super) fn serialize_task_lint_report(report: &TaskLintReport) -> Result<Value, OrbitError> {

--- a/crates/orbit-core/src/adapter/tool_host/test_support.rs
+++ b/crates/orbit-core/src/adapter/tool_host/test_support.rs
@@ -59,6 +59,33 @@ pub(super) fn create_task(
     status: TaskStatus,
     context_files: &[&str],
 ) -> Task {
+    create_task_with_crew(
+        runtime,
+        workspace_path,
+        title,
+        description,
+        status,
+        context_files,
+        None,
+    )
+}
+
+/// Create a task straight through the record store, keeping `crew` exactly as
+/// given.
+///
+/// `orbit.task.add` validates the crew against this host's `[crews.*]` table,
+/// so it cannot author the case read surfaces must tolerate: a stored crew this
+/// host has no entry for, because the task predates a config edit or was
+/// created on another machine (ORB-10968).
+pub(super) fn create_task_with_crew(
+    runtime: &OrbitRuntime,
+    workspace_path: &Path,
+    title: &str,
+    description: &str,
+    status: TaskStatus,
+    context_files: &[&str],
+    crew: Option<&str>,
+) -> Task {
     runtime
         .stores()
         .task_records()
@@ -88,7 +115,7 @@ pub(super) fn create_task(
             task_type: TaskType::Chore,
             external_refs: Vec::new(),
             source_task_id: None,
-            crew: None,
+            crew: crew.map(ToString::to_string),
             orchestrator: None,
             comments: Vec::new(),
         })

--- a/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
@@ -8,7 +8,7 @@ use orbit_types::tool::ToolSessionContext;
 use serde_json::{Value, json};
 
 use super::super::test_support::{
-    create_task, invalid_input_message, run_tool_as_operator, test_runtime,
+    create_task, create_task_with_crew, invalid_input_message, run_tool_as_operator, test_runtime,
 };
 use crate::adapter::command::ToolEntryPoint;
 
@@ -490,6 +490,88 @@ fn task_add_and_show_tools_roundtrip_crew() {
         .expect("task show tool succeeds");
     assert_eq!(shown.get("crew"), Some(&json!("sol")));
     assert_eq!(shown.get("orchestrator"), Some(&json!("sol")));
+}
+
+/// ORB-10968: crew configuration is host-local, so a stored crew this host has
+/// no `[crews.*]` entry for — a legacy name, or one only the authoring machine
+/// defines — must not make the task unreadable. ORB-10586 established that for
+/// `orbit task show`; the tool-host projection behind CLI tool-run and every
+/// MCP session still propagated the resolution error.
+#[test]
+fn task_read_tools_render_a_task_whose_stored_crew_is_undefined_here() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let task = create_task_with_crew(
+        &runtime,
+        &repo_root,
+        "Legacy crew task",
+        "Authored when `all-grok` was still a defined crew.",
+        TaskStatus::Backlog,
+        &[],
+        Some("all-grok"),
+    );
+
+    let shown = runtime
+        .execute_tool_command(
+            "orbit.task.show",
+            json!({ "id": task.id }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task show tool stays readable with an unresolvable crew");
+    assert_eq!(
+        shown.get("crew"),
+        Some(&json!("all-grok")),
+        "the raw stored crew stays visible: {shown}"
+    );
+    assert!(
+        shown.get("resolved_crew").is_none() && shown.get("crew_model").is_none(),
+        "resolved crew/model must be omitted rather than guessed: {shown}"
+    );
+    let unresolved = shown
+        .get("crew_unresolved")
+        .and_then(Value::as_str)
+        .expect("an unresolvable crew is explicitly marked");
+    assert!(
+        unresolved.contains("all-grok"),
+        "the non-fatal warning names the crew: {unresolved}"
+    );
+
+    // Listing and a field projection apply the same tolerant read contract.
+    let listed = runtime
+        .execute_tool_command(
+            "orbit.task.list",
+            json!({ "workspace": "." }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task list tool stays readable with an unresolvable crew");
+    assert_task_titles(&listed, &["Legacy crew task"]);
+    let fields = runtime
+        .execute_tool_command(
+            "orbit.task.show",
+            json!({ "id": task.id, "fields": ["crew"] }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("field projection stays readable with an unresolvable crew");
+    assert_eq!(fields, json!("all-grok"));
+
+    // Execution still resolves strictly: start must fail with the actionable
+    // crew-validation error rather than inherit a fallback.
+    let started = runtime.execute_tool_command(
+        "orbit.task.start",
+        json!({ "id": task.id }),
+        Some("codex".to_string()),
+        Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+    );
+    let message = match started {
+        Err(error) => error.to_string(),
+        Ok(value) => panic!("expected start to reject an unresolvable crew, got {value}"),
+    };
+    assert!(
+        message.contains("all-grok") && message.contains("not defined"),
+        "starting an unresolvable crew must stay a crew-validation error: {message}"
+    );
 }
 
 /// ORB-10648: `priority` is an advertised and applied update field. The record

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -100,9 +100,9 @@ pub use orbit_store::{
 };
 // Routine fire records surfaced by the dashboard's routine-health JSON API.
 pub use orbit_store::{RoutineFireRecord, RoutineFireState};
-pub use runtime::engine::ResolvedCrewProjection;
 pub use runtime::engine::{
     OrchestratorInvocationMetrics, OrchestratorInvocationMetricsBucket,
     OrchestratorMetricsBucketKind,
 };
+pub use runtime::engine::{ResolvedCrewProjection, TaskCrewRead};
 pub use runtime::{OrbitRuntime, WorkspaceRootHint, WorkspaceRuntimeBinding};

--- a/crates/orbit-core/src/runtime/engine/crew.rs
+++ b/crates/orbit-core/src/runtime/engine/crew.rs
@@ -92,6 +92,24 @@ impl ResolvedCrewProjection {
     }
 }
 
+/// What a *read* surface should render for a task's crew.
+///
+/// Read surfaces must always render the task. Crew configuration is
+/// host-local: a task authored on another machine, or before a `[crews.*]`
+/// table was edited, legitimately names a crew this host cannot resolve. That
+/// is a configuration gap in the reader, not a corrupt task, so it downgrades
+/// to [`TaskCrewRead::Unresolved`] instead of failing the readout (ORB-10968).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskCrewRead {
+    /// Neither the task nor the workspace names a crew; readers omit the fields.
+    Absent,
+    /// The crew resolved to a concrete name/model pair.
+    Resolved(ResolvedCrewProjection),
+    /// A crew is named but this host cannot resolve it. Carries the resolution
+    /// error so readers can surface it as a non-fatal warning.
+    Unresolved { reason: String },
+}
+
 impl OrbitRuntime {
     /// Project the selected runtime's effective crew configuration for clients.
     ///
@@ -235,6 +253,30 @@ impl OrbitRuntime {
         self.resolve_crew_for_task(None, task.crew.as_deref())
             .map(ResolvedCrewProjection::from_crew)
             .map(Some)
+    }
+
+    /// Tolerant counterpart to [`OrbitRuntime::resolved_crew_projection`] for
+    /// read surfaces (`orbit task show`, `orbit.task.*` tool responses).
+    ///
+    /// This is the single owner of the "a task stays readable when its crew is
+    /// unavailable here" rule, so the CLI, the tool host, and MCP cannot drift
+    /// apart on it. Paths that actually need a crew — `start`, dispatch — keep
+    /// resolving strictly and still fail with the crew-validation error.
+    pub fn task_crew_read(&self, task: &Task) -> TaskCrewRead {
+        match self.resolved_crew_projection(task) {
+            Ok(Some(projection)) => TaskCrewRead::Resolved(projection),
+            Ok(None) => TaskCrewRead::Absent,
+            Err(error) => {
+                let reason = error.to_string();
+                tracing::warn!(
+                    task_id = %task.id,
+                    stored_crew = task.crew.as_deref().unwrap_or("<unset>"),
+                    reason = %reason,
+                    "task crew could not be resolved on this host; rendering it unresolved",
+                );
+                TaskCrewRead::Unresolved { reason }
+            }
+        }
     }
 
     pub(crate) fn record_run_crew_from_input(

--- a/crates/orbit-core/src/runtime/engine/mod.rs
+++ b/crates/orbit-core/src/runtime/engine/mod.rs
@@ -10,6 +10,7 @@ mod tests;
 
 pub use crew::{
     ConfiguredCrewProjection, ConfiguredCrewRegistryProjection, ResolvedCrewProjection,
+    TaskCrewRead,
 };
 pub use invocation::{
     OrchestratorInvocationMetrics, OrchestratorInvocationMetricsBucket,

--- a/docs/design/agent-families/2_design.md
+++ b/docs/design/agent-families/2_design.md
@@ -46,7 +46,7 @@ The precedence chain is:
 
 This chain resolves the run crew. At activity dispatch there is one additional, explicit authoring choice: a rendered `crew` input selects a different named crew for that activity. With no such input, the run crew is the fallback. No role-keyed lookup participates in either selection.
 
-`orbit.task.show` surfaces the task field and, when the current registry resolves it, the effective crew name plus one `crew_model` string.
+`orbit.task.show` surfaces the task field and, when the current registry resolves it, the effective crew name plus one `crew_model` string. Crew configuration is host-local, so a read surface never fails on a crew this host cannot resolve: the stored `crew` is returned verbatim, `resolved_crew`/`crew_model` are withheld, and `crew_unresolved` carries the reason as a non-fatal warning [ORB-10968]. Listing and the global id lookup follow the same contract; `orbit.task.start` and dispatch still resolve strictly and fail with the crew-validation error.
 
 ## 4. Run Records
 
@@ -56,7 +56,7 @@ Legacy records without crew fields still deserialize because the run-record fiel
 
 ## 5. Concerns & Honest Limitations
 
-Crew names are workspace-local strings. Renaming or deleting a crew can break a task that still references the old name, though existing run records keep the resolved model strings.
+Crew names are workspace-local strings. Renaming or deleting a crew leaves a task naming the old one unable to *run* here, though it stays readable and existing run records keep the resolved model strings.
 
 An activity-specific crew is carried in rendered input rather than persisted as separate per-step routing metadata. Authors must ensure that input is visible in the job asset when a step intentionally differs from its run.
 


### PR DESCRIPTION
## Task

[ORB-10968](https://orbit-cli.com/tasks/ORB-10968) — Keep task.show readable when its stored crew is unavailable

### Description

## Problem
Four `orbit.task.show` calls in one remote SSH MCP session failed because stored crews `all-grok` or `claude` were not defined in that host's current `[crews.*]` configuration. ORB-10586 previously changed task rendering so a failed crew projection would be omitted with a warning instead of making the entire task unreadable, but the remote MCP read path still rejected these tasks.

## Why It Matters
Crew configuration is host-local and can legitimately differ across machines. Historical task data must remain inspectable for diagnosis, migration, and global task lookup even when its execution crew cannot be resolved locally.

## Constraints / Notes
Treat this as a regression or uncovered path from ORB-10586. Mutation and dispatch may still validate crews strictly; this task concerns read surfaces.

### Acceptance Criteria

- orbit.task.show returns the task on CLI tool-run, local MCP, and remote/SSH MCP when its stored crew is absent from the serving host configuration.
- The raw stored crew value remains visible, while resolved crew/model fields are omitted or explicitly marked unresolved with a non-fatal warning.
- Listing and global task lookup apply the same tolerant read contract.
- Starting, approving, or dispatching the task still fails with an actionable crew-validation error when execution requires an unavailable crew.
- Regression tests cover both an undefined legacy crew and a task created on another host with a valid-but-remote crew.

## Execution Summary

<details>
<summary>Click to expand</summary>

Made every `orbit.task.*` read surface tolerate a stored crew this host cannot resolve, and gave that rule one owner.

Root cause: `serialize_task` (crates/orbit-core/src/adapter/tool_host/json.rs) called `resolved_crew_projection` with `?`. ORB-10586 fixed the CLI renderer (which caught the error and warned on stderr) but the tool-host projection behind CLI tool-run and every MCP session — local and SSH — kept propagating it, so `orbit.task.show` failed outright for tasks whose stored crew (`all-grok`, `claude`) is absent from the serving host's `[crews.*]`.

Change:
- `OrbitRuntime::task_crew_read(&Task) -> TaskCrewRead {Absent | Resolved | Unresolved{reason}}` in crates/orbit-core/src/runtime/engine/crew.rs. Infallible; logs `tracing::warn!` with task id, stored crew, and reason. This is now the single owner of the tolerant read contract, exported from orbit-core.
- json.rs `insert_resolved_crew` no longer returns `Result`: it emits `resolved_crew`/`crew_model` when resolvable, and `crew_unresolved: "<reason>"` otherwise. Raw `crew` is untouched (it comes from `task_to_json`).
- crates/orbit-cli/src/command/task/output.rs switched from its private match to `task_crew_read`, keeps the stderr warning, and now also emits `crew_unresolved` so `orbit task show --json`, tool-run, and MCP agree.
- Listing (`task_to_json`) and the hub/global lookup (`host.rs::task_json`) never resolved a crew, so they were already tolerant; the tests pin that.
- Mutation/dispatch untouched: `orbit.task.add`/`update` still `validate_crew_name`, and `start_task_with_actor_label_override` still calls `resolve_and_log_crew_for_task_start`, so start/dispatch keep failing with `crew '<name>' is not defined in [crews.*]`. Note `approve` never validated a crew itself — its old failure was this rendering bug, not validation.

Tests (both new, both pass):
- crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs::task_read_tools_render_a_task_whose_stored_crew_is_undefined_here — undefined legacy crew `all-grok` stored directly through the record store (add would reject it); asserts show/list/field projections stay readable, `crew_unresolved` names the crew, and `orbit.task.start` still fails with the crew-validation error. Needed a new `create_task_with_crew` helper in tool_host/test_support.rs.
- crates/orbit-cli/tests/mcp_roundtrip.rs::task_read_surfaces_tolerate_a_crew_this_host_does_not_define — task authored while `[crews.remote-only]` exists, then the crew is removed from the host config: CLI tool-run (`--full`, from a non-workspace cwd so it also exercises the global id lookup), a local MCP session, and an SSH-marked MCP server (`--remote-caller-machine-id`) all render it; `orbit_task_list` includes it; `orbit.task.start` fails.

Docs: docs/design/agent-families/2_design.md §3 and §5 updated to state the read contract and that a renamed/deleted crew blocks running, not reading.

Context files beyond the original three were added for: the contract's owner (crew.rs) and its re-exports (engine/mod.rs, lib.rs), the CLI read surface adopting it (task/output.rs), the test helper (test_support.rs), and the design doc that describes this behavior.

Validation: `make ci-fast` and `make ci-lint` both pass. `cargo test -p orbit-cli --no-fail-fast`: all 13 integration targets green (mcp_roundtrip 15/15); `cargo test -p orbit-web -p orbit-cmd`: green. Two pre-existing, environment-caused failure sets are unrelated to this change and fail identically without it: orbit-core `runtime::tests::resolve` (12) and orbit-cli `command::workspace::tests::init` (20). Both assert on workspace resolution from the process cwd, and this run executes inside <repo>/.orbit/state/worktrees/..., so the walk-up finds the parent repo's .orbit/config.yaml ("workspace identity 'orbit-5c61b3' ... conflicts"). Unrestricted CI runs from the repo root and should not see them.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10968-6a8a1bae`
- Behind base: 0
- Ahead of base: 1