### PR TITLE
Make invoke_and_wait durably expose child dispatch before blocking

### DIFF
--- a/crates/orbit-cli/src/command/run/format.rs
+++ b/crates/orbit-cli/src/command/run/format.rs
@@ -55,3 +55,43 @@ pub(crate) fn format_waiting_line(
     }
     (!parts.is_empty()).then(|| format!("Waiting on {}", parts.join("; ")))
 }
+
+/// One line per child Run this run dispatched [ORB-10971].
+///
+/// Unlike the waiting line above this is not filtered by the parent's state:
+/// the whole point of the dispatch checkpoint is that an operator staring at a
+/// stalled — or cancelled — parent can name its child immediately, so the
+/// lineage is printed for terminal runs too.
+pub(crate) fn format_child_dispatch_lines(state: Option<&PipelineState>) -> Vec<String> {
+    let Some(state) = state else {
+        return Vec::new();
+    };
+    state
+        .child_dispatches
+        .iter()
+        .map(|dispatch| {
+            let mut line = format!(
+                "Child {} job={} step={} phase={} queued={}",
+                dispatch.child_run_id,
+                dispatch.job_name,
+                dispatch.parent_step_id.as_deref().unwrap_or("-"),
+                dispatch.phase.as_str(),
+                dispatch.queued,
+            );
+            if let Some(status) = &dispatch.child_status {
+                line.push_str(&format!(" status={status}"));
+            }
+            if let Some(cancellation) = &dispatch.cancellation {
+                line.push_str(&format!(
+                    " cancellation={}/{}",
+                    cancellation.policy.as_str(),
+                    cancellation.outcome
+                ));
+            }
+            if let Some(error) = &dispatch.error {
+                line.push_str(&format!(" error={}", summarize_error_message(Some(error))));
+            }
+            line
+        })
+        .collect()
+}

--- a/crates/orbit-cli/src/command/run/job.rs
+++ b/crates/orbit-cli/src/command/run/job.rs
@@ -244,6 +244,16 @@ impl Execute for JobResumeArgs {
     }
 }
 
+/// The child Runs this run dispatched, as persisted by the dispatch
+/// checkpoint [ORB-10971]. Always an array so a reader never has to
+/// distinguish "no children" from "field absent".
+pub(crate) fn child_dispatches_json(state: Option<&PipelineState>) -> Value {
+    let dispatches = state
+        .map(|state| state.child_dispatches.as_slice())
+        .unwrap_or_default();
+    serde_json::to_value(dispatches).unwrap_or_else(|_| Value::Array(Vec::new()))
+}
+
 // Retained after the dashboard callers moved to orbit-web; the thin
 // wrapper is kept for any external re-exports or future CLI json paths.
 #[allow(dead_code)]
@@ -253,6 +263,11 @@ pub(crate) fn job_run_to_json(run: &JobRun) -> Value {
 
 pub(crate) fn job_run_to_json_with_state(run: &JobRun, state: Option<&PipelineState>) -> Value {
     let last = run.steps.last();
+    // [ORB-10971] Child lineage is read from the full state, before the
+    // terminal filter below: a cancelled or failed parent must still name the
+    // children it dispatched. Waiting reasons keep the old filter — they are
+    // momentary and mean nothing once the run stopped.
+    let child_dispatches = child_dispatches_json(state);
     let state = (!run.state.is_terminal()).then_some(state).flatten();
     let waiting_on_deps = state
         .and_then(|state| state.waiting_on_deps.as_ref())
@@ -261,6 +276,7 @@ pub(crate) fn job_run_to_json_with_state(run: &JobRun, state: Option<&PipelineSt
         .and_then(|state| state.waiting_on_locks.as_ref())
         .filter(|values| !values.is_empty());
     json!({
+        "child_dispatches": child_dispatches,
         "run_id": run.run_id,
         "job_id": run.job_id,
         "attempt": run.attempt,

--- a/crates/orbit-cli/src/command/run/steps.rs
+++ b/crates/orbit-cli/src/command/run/steps.rs
@@ -8,7 +8,8 @@ use crate::command::{CommandOut, Payload};
 use crate::output::color::Domain;
 
 use super::format::{
-    format_duration, format_timestamp, format_waiting_line, summarize_error_message,
+    format_child_dispatch_lines, format_duration, format_timestamp, format_waiting_line,
+    summarize_error_message,
 };
 
 pub(crate) fn resolve_run(
@@ -185,6 +186,7 @@ pub(crate) fn run_header_text_with_state(run: &JobRun, state: Option<&PipelineSt
     if let Some(line) = format_waiting_line(run.state, state) {
         lines.push(line);
     }
+    lines.extend(format_child_dispatch_lines(state));
     lines.join("\n")
 }
 

--- a/crates/orbit-cli/src/command/run/tests/format.rs
+++ b/crates/orbit-cli/src/command/run/tests/format.rs
@@ -40,3 +40,72 @@ fn waiting_line_omits_terminal_run_even_with_stale_reasons() {
         None
     );
 }
+
+/// [ORB-10971] The child-lineage lines an operator sees on `orbit run show`.
+#[test]
+fn child_dispatch_lines_name_the_child_run_job_and_phase() {
+    let mut state = PipelineState::new("jrun-test".to_string(), "job-test".to_string(), json!({}));
+    state.record_child_dispatch(
+        orbit_types::workflow::ChildDispatch::submitted(
+            "jrun-child-leaves".to_string(),
+            "task_auto_pipeline".to_string(),
+            "invoke_and_wait".to_string(),
+            true,
+            false,
+            chrono::Utc::now(),
+        )
+        .with_parent_step_id(Some("ship_leaves".to_string())),
+    );
+    state.advance_child_dispatch(
+        "jrun-child-leaves",
+        orbit_types::workflow::ChildDispatchPhase::Waiting,
+        None,
+        None,
+    );
+
+    assert_eq!(
+        format_child_dispatch_lines(Some(&state)),
+        vec![
+            "Child jrun-child-leaves job=task_auto_pipeline step=ship_leaves phase=waiting queued=false"
+                .to_string()
+        ]
+    );
+}
+
+#[test]
+fn child_dispatch_lines_survive_a_cancelled_parent_and_name_the_policy() {
+    let mut state = PipelineState::new("jrun-test".to_string(), "job-test".to_string(), json!({}));
+    state.record_child_dispatch(orbit_types::workflow::ChildDispatch::submitted(
+        "jrun-child-leaves".to_string(),
+        "task_auto_pipeline".to_string(),
+        "invoke_and_wait".to_string(),
+        true,
+        false,
+        chrono::Utc::now(),
+    ));
+    state.terminalize_child_dispatch(
+        "jrun-child-leaves",
+        orbit_types::workflow::ChildCancellation {
+            policy: orbit_types::workflow::ChildCancellationPolicy::Cascade,
+            outcome: "cancelled".to_string(),
+            error: None,
+            at: chrono::Utc::now(),
+        },
+    );
+
+    let lines = format_child_dispatch_lines(Some(&state));
+    assert_eq!(lines.len(), 1);
+    assert!(lines[0].contains("phase=terminal"), "{}", lines[0]);
+    assert!(
+        lines[0].contains("cancellation=cascade/cancelled"),
+        "{}",
+        lines[0]
+    );
+}
+
+#[test]
+fn no_child_dispatches_prints_nothing() {
+    let state = PipelineState::new("jrun-test".to_string(), "job-test".to_string(), json!({}));
+    assert!(format_child_dispatch_lines(Some(&state)).is_empty());
+    assert!(format_child_dispatch_lines(None).is_empty());
+}

--- a/crates/orbit-cli/src/command/run/tests/job.rs
+++ b/crates/orbit-cli/src/command/run/tests/job.rs
@@ -238,3 +238,71 @@ fn wait_output_exposes_the_terminal_state_and_diagnostic() {
         "{lines}"
     );
 }
+
+/// A parent state carrying one blocking child dispatch [ORB-10971].
+fn state_with_child_dispatch(
+    run: &orbit_types::workflow::JobRun,
+    phase: orbit_types::workflow::ChildDispatchPhase,
+) -> PipelineState {
+    let mut state = PipelineState::new(run.run_id.clone(), run.job_id.clone(), json!({}));
+    state.record_child_dispatch(
+        orbit_types::workflow::ChildDispatch::submitted(
+            "jrun-child-leaves".to_string(),
+            "task_auto_pipeline".to_string(),
+            "invoke_and_wait".to_string(),
+            true,
+            false,
+            chrono::Utc::now(),
+        )
+        .with_parent_step_id(Some("ship_leaves".to_string())),
+    );
+    state.advance_child_dispatch("jrun-child-leaves", phase, None, None);
+    state
+}
+
+#[test]
+fn job_run_json_names_the_child_a_running_parent_dispatched() {
+    let run = test_run(JobRunState::Running);
+    let state = state_with_child_dispatch(&run, orbit_types::workflow::ChildDispatchPhase::Waiting);
+
+    let value = job_run_to_json_with_state(&run, Some(&state));
+
+    let dispatches = value["child_dispatches"]
+        .as_array()
+        .expect("child_dispatches array");
+    assert_eq!(dispatches.len(), 1);
+    assert_eq!(dispatches[0]["child_run_id"], json!("jrun-child-leaves"));
+    assert_eq!(dispatches[0]["job_name"], json!("task_auto_pipeline"));
+    assert_eq!(dispatches[0]["parent_step_id"], json!("ship_leaves"));
+    assert_eq!(dispatches[0]["phase"], json!("waiting"));
+}
+
+#[test]
+fn job_run_json_keeps_child_lineage_for_a_terminal_run() {
+    // Unlike the waiting reasons above, lineage is not stale once the parent
+    // stops: it is the only handle on the child the parent left behind.
+    let run = test_run(JobRunState::Success);
+    let state =
+        state_with_child_dispatch(&run, orbit_types::workflow::ChildDispatchPhase::Terminal);
+
+    let value = job_run_to_json_with_state(&run, Some(&state));
+
+    assert_eq!(value["waiting_on_deps"], Value::Null);
+    assert_eq!(
+        value["child_dispatches"][0]["child_run_id"],
+        json!("jrun-child-leaves")
+    );
+}
+
+#[test]
+fn job_run_json_always_carries_a_child_dispatch_array() {
+    let run = test_run(JobRunState::Running);
+
+    let value = job_run_to_json_with_state(&run, None);
+
+    assert_eq!(
+        value["child_dispatches"],
+        json!([]),
+        "readers must not have to distinguish 'no children' from 'field absent'"
+    );
+}

--- a/crates/orbit-core/assets/activities/invoke_and_wait.yaml
+++ b/crates/orbit-core/assets/activities/invoke_and_wait.yaml
@@ -8,7 +8,16 @@ spec:
     Submit a named v2 Job and block until its Run reaches a terminal
     state, then return the wait entry as data. Internally chains
     `orbit.pipeline.invoke` (to submit the child Run) and
-    `orbit.pipeline.wait` (to block on completion). Workflows that require
+    `orbit.pipeline.wait` (to block on completion). Submission and waiting
+    are separate observable phases: the child's exact run ID is persisted
+    into the parent Run's state, and audited, before the wait begins, so
+    CLI, MCP, API, and dashboard readers can name the child for the whole
+    duration of the block. A submission that cannot produce a durable
+    child Run fails this activity immediately with the invocation error
+    rather than idling until `timeout_seconds`. Cancelling the parent
+    while it waits keeps the child link, marks the wait terminal, and
+    cancels the child (an `invoke_detached` child is left running instead).
+    Workflows that require
     a successful child Run should follow this activity with
     `pipeline_success_guard` after any cleanup that depends on the raw
     child status. The returned `status` mirrors the child Run's terminal state:

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/child_dispatch.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/child_dispatch.rs
@@ -1,0 +1,331 @@
+//! The durable dispatch checkpoint a parent run writes when it submits a
+//! child Run [ORB-10971].
+//!
+//! `invoke_and_wait` used to be one opaque call: it invoked the child, kept
+//! the returned `run_id` in a local variable, and blocked in `pipeline.wait`.
+//! Because the engine does not persist an activity's output until the
+//! activity returns, a parent could sit on that step for the whole wait
+//! timeout — up to an hour — with no durable child identifier anywhere. An
+//! operator could not tell a healthy long wait apart from a dispatch path
+//! wedged before persistence, and no reader could name the child.
+//!
+//! This module makes the dispatch boundary fail-observable. Submission and
+//! waiting are separate persisted phases even though they remain one
+//! activity: either a durable child run exists and is linked immediately, or
+//! the parent fails promptly carrying the exact pre-dispatch error. Evidence
+//! lands in two independent stores — the parent's `PipelineState` (which CLI,
+//! MCP, API, and dashboard readers project) and the audit log — so losing one
+//! does not hide the child.
+
+use chrono::Utc;
+use orbit_common::observability::audit_id::audit_execution_id;
+use orbit_engine::DispatchError;
+use orbit_store::contracts::AuditEventInsertParams;
+use orbit_types::telemetry::AuditEventStatus;
+use orbit_types::workflow::{ChildDispatch, ChildDispatchPhase};
+use serde_json::Value;
+
+use crate::OrbitRuntime;
+
+/// Audit command for a child submission attempt, successful or not.
+pub(super) const CHILD_DISPATCH_AUDIT: &str = "pipeline.child_dispatch";
+/// Audit command for the parent's observation of a child's terminal state.
+pub(super) const CHILD_WAIT_AUDIT: &str = "pipeline.child_wait";
+
+/// The parent step that is dispatching, as the engine named it.
+pub(super) fn parent_step_id(input: &Value) -> Option<String> {
+    input
+        .get("step_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+/// The parent run id the engine injected into this activity's input.
+pub(super) fn parent_run_id(input: &Value) -> Option<String> {
+    input
+        .get("run_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+/// Persist a freshly submitted child into the parent's run state.
+///
+/// Ordering is the whole point: the audit event goes first, then the run
+/// state. The two stores fail independently, and the child run id must
+/// survive in at least one of them before the parent blocks on anything.
+///
+/// A run state that cannot be written is a hard failure of the dispatch step,
+/// not a warning. The alternative — blocking for an hour on a child nobody can
+/// name — is exactly the condition this checkpoint exists to prevent. The
+/// error names the child run id so an operator can still reach the work that
+/// was successfully submitted.
+pub(super) fn checkpoint_submitted_child(
+    runtime: &OrbitRuntime,
+    action: &str,
+    parent_run_id: Option<&str>,
+    dispatch: &ChildDispatch,
+) -> Result<(), DispatchError> {
+    record_child_audit(
+        runtime,
+        action,
+        CHILD_DISPATCH_AUDIT,
+        AuditEventStatus::Success,
+        parent_run_id,
+        Some(&dispatch.child_run_id),
+        serde_json::json!({
+            "parent_run_id": parent_run_id,
+            "parent_step_id": dispatch.parent_step_id,
+            "child_run_id": dispatch.child_run_id,
+            "job_name": dispatch.job_name,
+            "action": dispatch.action,
+            "blocking": dispatch.blocking,
+            "queued": dispatch.queued,
+            "phase": dispatch.phase.as_str(),
+            "submitted_at": dispatch.submitted_at.to_rfc3339(),
+        }),
+        None,
+    )?;
+
+    let Some(parent_run_id) = parent_run_id else {
+        // A direct `execute_job` caller with no persisted run has no state to
+        // checkpoint into. The audit event above is then the only lineage
+        // record, which is the same contract `checkpoint_step` follows.
+        return Ok(());
+    };
+
+    let Some(mut state) = read_state(runtime, action, parent_run_id)? else {
+        return Ok(());
+    };
+    state.record_child_dispatch(dispatch.clone());
+    runtime
+        .write_run_state(parent_run_id, &state)
+        .map_err(|error| {
+            action_failed(
+                action,
+                format!(
+                    "child run '{}' (job '{}') was submitted but its dispatch checkpoint could not \
+                     be persisted to parent run '{parent_run_id}': {error}",
+                    dispatch.child_run_id, dispatch.job_name
+                ),
+            )
+        })
+}
+
+/// Move a recorded dispatch to a new phase.
+///
+/// Non-fatal by contract, unlike the submission checkpoint: by the time this
+/// runs the child is already durably linked, so a failed projection update
+/// must not discard a child result the parent did observe. Failures are
+/// traced and the caller continues.
+pub(super) fn advance_child_phase(
+    runtime: &OrbitRuntime,
+    parent_run_id: Option<&str>,
+    child_run_id: &str,
+    phase: ChildDispatchPhase,
+    child_status: Option<String>,
+    error: Option<String>,
+) {
+    let Some(parent_run_id) = parent_run_id else {
+        return;
+    };
+    let state = match runtime.read_run_state(parent_run_id) {
+        Ok(Some(state)) => Some(state),
+        Ok(None) => None,
+        Err(error) => {
+            tracing::warn!(
+                parent_run_id,
+                child_run_id,
+                phase = phase.as_str(),
+                %error,
+                "could not read parent run state to advance child dispatch phase"
+            );
+            None
+        }
+    };
+    let Some(mut state) = state else {
+        return;
+    };
+    if !state.advance_child_dispatch(child_run_id, phase, child_status, error) {
+        return;
+    }
+    if let Err(error) = runtime.write_run_state(parent_run_id, &state) {
+        tracing::warn!(
+            parent_run_id,
+            child_run_id,
+            phase = phase.as_str(),
+            %error,
+            "could not persist child dispatch phase"
+        );
+    }
+}
+
+/// Record that the parent observed the child's terminal state.
+pub(super) fn record_child_wait_outcome(
+    runtime: &OrbitRuntime,
+    action: &str,
+    parent_run_id: Option<&str>,
+    child_run_id: &str,
+    status: &str,
+    error_message: Option<&str>,
+) -> Result<(), DispatchError> {
+    let succeeded = status == "succeeded";
+    record_child_audit(
+        runtime,
+        action,
+        CHILD_WAIT_AUDIT,
+        if succeeded {
+            AuditEventStatus::Success
+        } else {
+            AuditEventStatus::Failure
+        },
+        parent_run_id,
+        Some(child_run_id),
+        serde_json::json!({
+            "parent_run_id": parent_run_id,
+            "child_run_id": child_run_id,
+            "status": status,
+            "error": error_message,
+        }),
+        error_message,
+    )
+}
+
+/// Record a submission that never produced a durable child run.
+///
+/// The concrete `orbit.pipeline.invoke` error is the diagnosis: capacity,
+/// dependency, and lock waits all look identical from outside without it.
+pub(super) fn record_dispatch_failure(
+    runtime: &OrbitRuntime,
+    action: &str,
+    parent_run_id: Option<&str>,
+    parent_step_id: Option<&str>,
+    job_name: &str,
+    error_message: &str,
+) {
+    if let Err(error) = record_child_audit(
+        runtime,
+        action,
+        CHILD_DISPATCH_AUDIT,
+        AuditEventStatus::Failure,
+        parent_run_id,
+        None,
+        serde_json::json!({
+            "parent_run_id": parent_run_id,
+            "parent_step_id": parent_step_id,
+            "job_name": job_name,
+            "action": action,
+            "error": error_message,
+        }),
+        Some(error_message),
+    ) {
+        tracing::warn!(%error, job_name, "could not record child dispatch failure audit");
+    }
+}
+
+fn read_state(
+    runtime: &OrbitRuntime,
+    action: &str,
+    run_id: &str,
+) -> Result<Option<orbit_types::workflow::PipelineState>, DispatchError> {
+    runtime
+        .read_run_state(run_id)
+        .map_err(|error| action_failed(action, format!("read parent run state: {error}")))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn record_child_audit(
+    runtime: &OrbitRuntime,
+    action: &str,
+    command: &str,
+    status: AuditEventStatus,
+    parent_run_id: Option<&str>,
+    child_run_id: Option<&str>,
+    payload: Value,
+    error_message: Option<&str>,
+) -> Result<(), DispatchError> {
+    let arguments_json = serde_json::to_string(&payload)
+        .map_err(|error| action_failed(action, format!("serialize {command} payload: {error}")))?;
+    runtime
+        .record_audit_event(&AuditEventInsertParams {
+            execution_id: audit_execution_id("audit-child-dispatch"),
+            command: command.to_string(),
+            subcommand: None,
+            tool_name: None,
+            target_type: Some("job_run".to_string()),
+            target_id: child_run_id.map(ToOwned::to_owned),
+            role: "admin".to_string(),
+            status,
+            exit_code: i32::from(status != AuditEventStatus::Success),
+            duration_ms: 0,
+            working_directory: runtime.paths().repo_root.to_string_lossy().into_owned(),
+            arguments_json: Some(arguments_json),
+            stdout_truncated: None,
+            stderr_truncated: None,
+            error_message: error_message.map(ToOwned::to_owned),
+            host: std::env::var("HOSTNAME").ok(),
+            pid: std::process::id(),
+            session_id: None,
+            workspace_id: None,
+            caller_machine_id: None,
+            caller_host_id: None,
+            process_machine_id: None,
+            process_host_id: None,
+            transport: None,
+            effective_capabilities: Default::default(),
+            origin_session_id: None,
+            mcp_call_id: None,
+            lease_id: None,
+            task_id: None,
+            job_run_id: parent_run_id.map(ToOwned::to_owned),
+            activity_id: None,
+            step_index: None,
+        })
+        .map_err(|error| action_failed(action, format!("record {command} audit: {error}")))
+}
+
+/// Build the dispatch record for a child `orbit.pipeline.invoke` just returned.
+pub(super) fn dispatch_from_invoke_output(
+    action: &str,
+    job_name: &str,
+    blocking: bool,
+    parent_step_id: Option<String>,
+    invoke_output: &Value,
+) -> Result<ChildDispatch, DispatchError> {
+    let child_run_id = invoke_output
+        .get("run_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| action_failed(action, "pipeline.invoke returned no run_id".to_string()))?
+        .to_string();
+    let submitted_at = invoke_output
+        .get("submitted_at")
+        .and_then(Value::as_str)
+        .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.with_timezone(&Utc))
+        .unwrap_or_else(Utc::now);
+
+    Ok(ChildDispatch::submitted(
+        child_run_id,
+        job_name.to_string(),
+        action.to_string(),
+        blocking,
+        invoke_output
+            .get("queued")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        submitted_at,
+    )
+    .with_parent_step_id(parent_step_id))
+}
+
+fn action_failed(action: &str, message: String) -> DispatchError {
+    DispatchError::DeterministicActionFailed {
+        action: action.to_string(),
+        message,
+    }
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
@@ -520,14 +520,12 @@ fn update_run_waiting_reasons(
         return Ok(());
     };
     state.set_waiting_reasons(waiting_on_deps, waiting_on_locks);
-    runtime
-        .stores()
-        .jobs()
-        .write_run_state(run_id, &state)
-        .map_err(|err| DispatchError::DeterministicActionFailed {
+    runtime.write_run_state(run_id, &state).map_err(|err| {
+        DispatchError::DeterministicActionFailed {
             action: action.to_string(),
             message: format!("{err}"),
-        })
+        }
+    })
 }
 
 fn non_empty(values: Vec<String>) -> Option<Vec<String>> {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/mod.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/mod.rs
@@ -8,6 +8,7 @@
 //! `orbit-engine`, so this module never names orbit-agent types.
 
 pub(super) mod backlog_exclusion;
+pub(super) mod child_dispatch;
 pub(super) mod cli_executor;
 pub(super) mod dispatch;
 pub(super) mod pipeline_actions;

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs
@@ -1,3 +1,4 @@
+use orbit_common::OrbitError;
 use orbit_common::observability::audit_id::audit_execution_id;
 use orbit_common::protocol::tool_input::optional_string_list_alias;
 use orbit_engine::DispatchError;
@@ -6,8 +7,10 @@ use orbit_tools::ToolContext;
 use orbit_types::policy::Role;
 use orbit_types::task::TaskStatus;
 use orbit_types::telemetry::AuditEventStatus;
+use orbit_types::workflow::ChildDispatchPhase;
 use serde_json::Value;
 
+use super::child_dispatch;
 use crate::OrbitRuntime;
 use crate::runtime::task::locks::parse_task_ids;
 
@@ -81,91 +84,253 @@ pub(super) fn validate_bundles(action: &str, input: &Value) -> Result<Value, Dis
     }))
 }
 
+/// Submit a child v2 Job, link it durably, then block on its terminal state.
+///
+/// [ORB-10971] Submission and waiting are two observable phases of one
+/// activity. The child's exact run id — the one `orbit.pipeline.invoke`
+/// returned, never one inferred from task status or timestamps — is persisted
+/// into the parent's run state and the audit log *before* the wait begins, so
+/// the dispatch boundary is fail-observable: either a durable child exists and
+/// every reader can name it, or the step fails promptly carrying the concrete
+/// invocation error instead of idling to the wait timeout.
+///
+/// [ORB-10819]'s blocking leaf contract is unchanged past that checkpoint: the
+/// activity still returns the child's terminal wait entry, so a following
+/// `pipeline_success_guard` sees exactly what it saw before.
 pub(super) fn invoke_and_wait(
     runtime: &OrbitRuntime,
     action: &str,
     input: &Value,
     tool_context: ToolContext,
 ) -> Result<Value, DispatchError> {
+    let wait_context = tool_context.clone();
+    invoke_and_wait_with(
+        runtime,
+        action,
+        input,
+        |args| {
+            runtime.run_tool_with_context_and_role(
+                "orbit.pipeline.invoke",
+                args,
+                Role::Admin,
+                tool_context,
+            )
+        },
+        |args| {
+            runtime.run_tool_with_context_and_role(
+                "orbit.pipeline.wait",
+                args,
+                Role::Admin,
+                wait_context,
+            )
+        },
+    )
+}
+
+/// Internal seam over the two pipeline tools so tests can drive the phase
+/// ordering — checkpoint before wait, prompt failure without one — without
+/// spawning real detached workers.
+pub(super) fn invoke_and_wait_with<Invoke, Wait>(
+    runtime: &OrbitRuntime,
+    action: &str,
+    input: &Value,
+    invoke: Invoke,
+    wait: Wait,
+) -> Result<Value, DispatchError>
+where
+    Invoke: FnOnce(Value) -> Result<Value, OrbitError>,
+    Wait: FnOnce(Value) -> Result<Value, OrbitError>,
+{
     if let Some(noop) = stale_gate_admission_noop(runtime, action, input)? {
         return Ok(noop);
     }
 
-    let job_name = input
-        .get("job_name")
-        .and_then(Value::as_str)
-        .ok_or_else(|| DispatchError::DeterministicActionFailed {
-            action: action.to_string(),
-            message: "missing `job_name`".to_string(),
-        })?
-        .to_string();
-    let run_input = input
-        .get("run_input")
-        .cloned()
-        .unwrap_or_else(|| Value::Object(Default::default()));
-    let mut invoke_args = serde_json::Map::new();
-    invoke_args.insert("job_name".to_string(), Value::String(job_name));
-    invoke_args.insert("input".to_string(), run_input);
-    if let Some(priority) = input.get("priority").cloned() {
-        invoke_args.insert("priority".to_string(), priority);
-    }
+    let job_name = required_job_name(action, input)?;
+    let parent_run_id = child_dispatch::parent_run_id(input);
+    let parent_step_id = child_dispatch::parent_step_id(input);
 
-    let invoke_output = runtime
-        .run_tool_with_context_and_role(
-            "orbit.pipeline.invoke",
-            Value::Object(invoke_args),
-            Role::Admin,
-            tool_context.clone(),
-        )
-        .map_err(|err| DispatchError::DeterministicActionFailed {
-            action: action.to_string(),
-            message: format!("pipeline.invoke failed: {err}"),
-        })?;
-    let run_id = invoke_output
-        .get("run_id")
-        .and_then(Value::as_str)
-        .ok_or_else(|| DispatchError::DeterministicActionFailed {
-            action: action.to_string(),
-            message: "pipeline.invoke returned no run_id".to_string(),
-        })?
-        .to_string();
+    // Phase 1 — submit. A failure here never produced a durable child, so it
+    // must terminalize the step now with the concrete reason attached.
+    let invoke_output = invoke(invoke_args(&job_name, input)).map_err(|error| {
+        let message = format!("pipeline.invoke failed: {error}");
+        child_dispatch::record_dispatch_failure(
+            runtime,
+            action,
+            parent_run_id.as_deref(),
+            parent_step_id.as_deref(),
+            &job_name,
+            &message,
+        );
+        action_failed(action, message)
+    })?;
 
-    let mut wait_args = serde_json::Map::new();
-    wait_args.insert(
-        "run_ids".to_string(),
-        Value::Array(vec![Value::String(run_id.clone())]),
+    // Phase 2 — link, durably, before blocking on anything.
+    let dispatch = child_dispatch::dispatch_from_invoke_output(
+        action,
+        &job_name,
+        true,
+        parent_step_id.clone(),
+        &invoke_output,
+    )
+    .inspect_err(|error| {
+        child_dispatch::record_dispatch_failure(
+            runtime,
+            action,
+            parent_run_id.as_deref(),
+            parent_step_id.as_deref(),
+            &job_name,
+            &error.to_string(),
+        );
+    })?;
+    child_dispatch::checkpoint_submitted_child(
+        runtime,
+        action,
+        parent_run_id.as_deref(),
+        &dispatch,
+    )?;
+
+    // Phase 3 — wait. The child is now nameable by every reader for as long
+    // as this blocks.
+    let child_run_id = dispatch.child_run_id.clone();
+    child_dispatch::advance_child_phase(
+        runtime,
+        parent_run_id.as_deref(),
+        &child_run_id,
+        ChildDispatchPhase::Waiting,
+        None,
+        None,
     );
-    if let Some(timeout) = input.get("timeout_seconds").cloned() {
-        wait_args.insert("timeout_seconds".to_string(), timeout);
-    }
-    if let Some(poll) = input.get("poll_interval_seconds").cloned() {
-        wait_args.insert("poll_interval_seconds".to_string(), poll);
-    }
+    let wait_result = wait(wait_args(&child_run_id, input));
 
-    let wait_output = runtime
-        .run_tool_with_context_and_role(
-            "orbit.pipeline.wait",
-            Value::Object(wait_args),
-            Role::Admin,
-            tool_context,
-        )
-        .map_err(|err| DispatchError::DeterministicActionFailed {
-            action: action.to_string(),
-            message: format!("pipeline.wait failed: {err}"),
-        })?;
+    // Phase 4 — close the record whichever way the wait went.
+    close_child_wait(
+        runtime,
+        action,
+        parent_run_id.as_deref(),
+        &child_run_id,
+        wait_result,
+    )
+}
 
-    let first = wait_output
+/// Terminalize the dispatch record from the wait's outcome and hand the child's
+/// wait entry back to the caller.
+///
+/// A wait that errored outright is not a failed child: the parent simply stopped
+/// being able to observe one it did durably submit. That is recorded as
+/// `unobserved` rather than as a child status the parent never saw, so a reader
+/// is never told the child failed on this evidence.
+fn close_child_wait(
+    runtime: &OrbitRuntime,
+    action: &str,
+    parent_run_id: Option<&str>,
+    child_run_id: &str,
+    wait_result: Result<Value, OrbitError>,
+) -> Result<Value, DispatchError> {
+    let wait_output = match wait_result {
+        Ok(output) => output,
+        Err(error) => {
+            let message = format!("pipeline.wait failed: {error}");
+            child_dispatch::advance_child_phase(
+                runtime,
+                parent_run_id,
+                child_run_id,
+                ChildDispatchPhase::Terminal,
+                None,
+                Some(message.clone()),
+            );
+            child_dispatch::record_child_wait_outcome(
+                runtime,
+                action,
+                parent_run_id,
+                child_run_id,
+                "unobserved",
+                Some(&message),
+            )?;
+            return Err(action_failed(action, message));
+        }
+    };
+
+    let entry = wait_output
         .get("results")
         .and_then(Value::as_array)
         .and_then(|arr| arr.first())
         .cloned()
         .unwrap_or_else(|| {
             serde_json::json!({
-                "run_id": run_id,
+                "run_id": child_run_id,
                 "status": "pending",
             })
         });
-    Ok(first)
+    let status = entry
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+    let error_message = entry
+        .get("error")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(ToOwned::to_owned);
+
+    child_dispatch::advance_child_phase(
+        runtime,
+        parent_run_id,
+        child_run_id,
+        ChildDispatchPhase::Terminal,
+        Some(status.clone()),
+        error_message.clone(),
+    );
+    child_dispatch::record_child_wait_outcome(
+        runtime,
+        action,
+        parent_run_id,
+        child_run_id,
+        &status,
+        error_message.as_deref(),
+    )?;
+
+    Ok(entry)
+}
+
+fn required_job_name(action: &str, input: &Value) -> Result<String, DispatchError> {
+    input
+        .get("job_name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| action_failed(action, "missing `job_name`".to_string()))
+        .map(ToOwned::to_owned)
+}
+
+fn invoke_args(job_name: &str, input: &Value) -> Value {
+    let mut args = serde_json::Map::new();
+    args.insert("job_name".to_string(), Value::String(job_name.to_string()));
+    args.insert(
+        "input".to_string(),
+        input
+            .get("run_input")
+            .cloned()
+            .unwrap_or_else(|| Value::Object(Default::default())),
+    );
+    if let Some(priority) = input.get("priority").cloned() {
+        args.insert("priority".to_string(), priority);
+    }
+    Value::Object(args)
+}
+
+fn wait_args(child_run_id: &str, input: &Value) -> Value {
+    let mut args = serde_json::Map::new();
+    args.insert(
+        "run_ids".to_string(),
+        Value::Array(vec![Value::String(child_run_id.to_string())]),
+    );
+    if let Some(timeout) = input.get("timeout_seconds").cloned() {
+        args.insert("timeout_seconds".to_string(), timeout);
+    }
+    if let Some(poll) = input.get("poll_interval_seconds").cloned() {
+        args.insert("poll_interval_seconds".to_string(), poll);
+    }
+    Value::Object(args)
 }
 
 /// Submit a child v2 Job and return as soon as its Run is durable [ORB-10819].
@@ -185,46 +350,52 @@ pub(super) fn invoke_detached(
     input: &Value,
     tool_context: ToolContext,
 ) -> Result<Value, DispatchError> {
-    let job_name = input
-        .get("job_name")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| action_failed(action, "missing `job_name`".to_string()))?
-        .to_string();
-    let run_input = input
-        .get("run_input")
-        .cloned()
-        .unwrap_or_else(|| Value::Object(Default::default()));
-
-    let mut invoke_args = serde_json::Map::new();
-    invoke_args.insert("job_name".to_string(), Value::String(job_name.clone()));
-    invoke_args.insert("input".to_string(), run_input);
-    if let Some(priority) = input.get("priority").cloned() {
-        invoke_args.insert("priority".to_string(), priority);
-    }
+    let job_name = required_job_name(action, input)?;
+    let parent_run_id = child_dispatch::parent_run_id(input);
+    let parent_step_id = child_dispatch::parent_step_id(input);
 
     let invoke_output = runtime
         .run_tool_with_context_and_role(
             "orbit.pipeline.invoke",
-            Value::Object(invoke_args),
+            invoke_args(&job_name, input),
             Role::Admin,
             tool_context,
         )
-        .map_err(|err| action_failed(action, format!("pipeline.invoke failed: {err}")))?;
-    let run_id = invoke_output
-        .get("run_id")
-        .and_then(Value::as_str)
-        .ok_or_else(|| action_failed(action, "pipeline.invoke returned no run_id".to_string()))?
-        .to_string();
+        .map_err(|err| {
+            let message = format!("pipeline.invoke failed: {err}");
+            child_dispatch::record_dispatch_failure(
+                runtime,
+                action,
+                parent_run_id.as_deref(),
+                parent_step_id.as_deref(),
+                &job_name,
+                &message,
+            );
+            action_failed(action, message)
+        })?;
+
+    // [ORB-10971] A detached child is linked on the same durable checkpoint as
+    // a blocked-on one. The caller re-observes it later, so the linkage is the
+    // only handle anyone has on it in the meantime — and it is what tells
+    // cancellation to leave this child alone.
+    let dispatch = child_dispatch::dispatch_from_invoke_output(
+        action,
+        &job_name,
+        false,
+        parent_step_id,
+        &invoke_output,
+    )?;
+    child_dispatch::checkpoint_submitted_child(
+        runtime,
+        action,
+        parent_run_id.as_deref(),
+        &dispatch,
+    )?;
 
     Ok(serde_json::json!({
-        "run_id": run_id,
-        "job_name": job_name,
-        "queued": invoke_output
-            .get("queued")
-            .and_then(Value::as_bool)
-            .unwrap_or(false),
+        "run_id": dispatch.child_run_id,
+        "job_name": dispatch.job_name,
+        "queued": dispatch.queued,
         "submitted_at": invoke_output.get("submitted_at").cloned(),
     }))
 }

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/pipeline_actions.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/pipeline_actions.rs
@@ -123,3 +123,318 @@ fn gate_starvation_fail_tolerates_a_missing_waiting_on_deps_input() {
     assert!(message.contains("file:src/lib.rs"), "{message}");
     assert!(message.contains("waiting_on_deps=[]"), "{message}");
 }
+
+// ─── invoke_and_wait dispatch checkpoint [ORB-10971] ──────────────────────
+
+use crate::adapter::engine_host::v2_host::child_dispatch::{
+    CHILD_DISPATCH_AUDIT, CHILD_WAIT_AUDIT,
+};
+use orbit_common::OrbitError;
+use orbit_types::telemetry::AuditEventStatus;
+use orbit_types::workflow::{
+    ChildCancellationPolicy, ChildDispatch, ChildDispatchPhase, PipelineState,
+};
+use serde_json::Value;
+use std::cell::RefCell;
+
+const CHILD_RUN: &str = "jrun-child-leaves";
+
+/// A persisted parent run, standing in for `workspace_auto_pipeline` at the
+/// moment `ship_leaves` begins.
+fn parent_runtime() -> (OrbitRuntime, String) {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run(
+            "workspace_auto_pipeline",
+            1,
+            chrono::Utc::now(),
+            Some(json!({})),
+            None,
+        )
+        .expect("insert parent run");
+    let state = PipelineState::new(
+        run.run_id.clone(),
+        "workspace_auto_pipeline".to_string(),
+        json!({}),
+    );
+    runtime
+        .stores()
+        .jobs()
+        .write_run_state(&run.run_id, &state)
+        .expect("seed parent run state");
+    (runtime, run.run_id)
+}
+
+/// The reported negative fixture: capacity available, no dependency or lock
+/// wait, healthy worker startup.
+fn ship_leaves_input(parent_run_id: &str) -> Value {
+    json!({
+        "run_id": parent_run_id,
+        "step_id": "ship_leaves",
+        "job_name": "task_auto_pipeline",
+        "run_input": { "task_ids": ["ORB-1", "ORB-2"] },
+    })
+}
+
+fn healthy_invoke_output() -> Value {
+    json!({
+        "run_id": CHILD_RUN,
+        "job_name": "task_auto_pipeline",
+        "queued": false,
+        "submitted_at": "2026-08-22T19:55:00Z",
+    })
+}
+
+fn recorded_dispatches(runtime: &OrbitRuntime, parent_run_id: &str) -> Vec<ChildDispatch> {
+    runtime
+        .read_run_state(parent_run_id)
+        .expect("read parent state")
+        .map(|state| state.child_dispatches)
+        .unwrap_or_default()
+}
+
+fn audit_payloads(runtime: &OrbitRuntime, command: &str) -> Vec<(AuditEventStatus, Value)> {
+    runtime
+        .list_audit_events(None, None, None, None, 100)
+        .expect("list audit events")
+        .into_iter()
+        .filter(|event| event.command == command)
+        .map(|event| {
+            let payload = event
+                .arguments_json
+                .as_deref()
+                .map(|raw| serde_json::from_str::<Value>(raw).expect("audit payload json"))
+                .unwrap_or(Value::Null);
+            (event.status, payload)
+        })
+        .collect()
+}
+
+#[test]
+fn the_child_run_is_durable_and_linked_before_the_wait_begins() {
+    let (runtime, parent) = parent_runtime();
+    // Captured from inside the wait: exactly what a concurrent CLI, MCP, API,
+    // or dashboard reader would have seen while the parent was still blocked.
+    let observed_mid_wait = RefCell::new(Vec::new());
+
+    let output = invoke_and_wait_with(
+        &runtime,
+        "invoke_and_wait",
+        &ship_leaves_input(&parent),
+        |_| Ok(healthy_invoke_output()),
+        |args| {
+            observed_mid_wait.replace(recorded_dispatches(&runtime, &parent));
+            assert_eq!(args["run_ids"], json!([CHILD_RUN]));
+            Ok(json!({
+                "results": [{ "run_id": CHILD_RUN, "status": "succeeded" }],
+            }))
+        },
+    )
+    .expect("healthy dispatch succeeds");
+
+    let mid_wait = observed_mid_wait.into_inner();
+    assert_eq!(mid_wait.len(), 1, "child must be linked before the wait");
+    let linked = &mid_wait[0];
+    assert_eq!(linked.child_run_id, CHILD_RUN);
+    assert_eq!(linked.job_name, "task_auto_pipeline");
+    assert_eq!(linked.parent_step_id.as_deref(), Some("ship_leaves"));
+    assert_eq!(linked.phase, ChildDispatchPhase::Waiting);
+    assert!(linked.blocking);
+    assert!(!linked.queued);
+
+    // The blocking leaf contract: the wait entry is still what reaches
+    // `pipeline_success_guard`.
+    assert_eq!(output["run_id"], json!(CHILD_RUN));
+    assert_eq!(output["status"], json!("succeeded"));
+    pipeline_success_guard(
+        "pipeline_success_guard",
+        &json!({ "context": "workspace auto leaf ship", "result": output }),
+    )
+    .expect("the child's terminal status reaches the guard unchanged");
+
+    let settled = recorded_dispatches(&runtime, &parent);
+    assert_eq!(settled[0].phase, ChildDispatchPhase::Terminal);
+    assert_eq!(settled[0].child_status.as_deref(), Some("succeeded"));
+
+    let dispatch_audits = audit_payloads(&runtime, CHILD_DISPATCH_AUDIT);
+    assert_eq!(dispatch_audits.len(), 1);
+    assert_eq!(dispatch_audits[0].0, AuditEventStatus::Success);
+    assert_eq!(dispatch_audits[0].1["child_run_id"], json!(CHILD_RUN));
+    assert_eq!(dispatch_audits[0].1["parent_run_id"], json!(parent));
+    assert_eq!(dispatch_audits[0].1["parent_step_id"], json!("ship_leaves"));
+
+    let wait_audits = audit_payloads(&runtime, CHILD_WAIT_AUDIT);
+    assert_eq!(wait_audits.len(), 1);
+    assert_eq!(wait_audits[0].1["status"], json!("succeeded"));
+}
+
+#[test]
+fn a_dispatch_that_never_produced_a_child_fails_instead_of_waiting() {
+    let (runtime, parent) = parent_runtime();
+    let waited = RefCell::new(false);
+
+    let err = invoke_and_wait_with(
+        &runtime,
+        "invoke_and_wait",
+        &ship_leaves_input(&parent),
+        |_| {
+            Err(OrbitError::Execution(
+                "pipeline worker for run 'jrun-x' could not start".to_string(),
+            ))
+        },
+        |_| {
+            waited.replace(true);
+            Ok(json!({ "results": [] }))
+        },
+    )
+    .expect_err("a failed submission must terminalize the step");
+
+    assert!(
+        !waited.into_inner(),
+        "the step must never reach the one-hour wait without a durable child"
+    );
+    let message = action_failure_message(err, "invoke_and_wait");
+    assert!(message.contains("pipeline.invoke failed"), "{message}");
+    assert!(message.contains("could not start"), "{message}");
+
+    assert!(
+        recorded_dispatches(&runtime, &parent).is_empty(),
+        "no child run id exists, so nothing may be linked"
+    );
+    let audits = audit_payloads(&runtime, CHILD_DISPATCH_AUDIT);
+    assert_eq!(audits.len(), 1);
+    assert_eq!(audits[0].0, AuditEventStatus::Failure);
+    assert!(
+        audits[0].1["error"]
+            .as_str()
+            .expect("error text")
+            .contains("could not start"),
+        "the concrete invocation error is the diagnosis"
+    );
+}
+
+#[test]
+fn an_invoke_that_returns_no_run_id_is_treated_as_a_failed_dispatch() {
+    let (runtime, parent) = parent_runtime();
+    let waited = RefCell::new(false);
+
+    let err = invoke_and_wait_with(
+        &runtime,
+        "invoke_and_wait",
+        &ship_leaves_input(&parent),
+        |_| Ok(json!({ "queued": true })),
+        |_| {
+            waited.replace(true);
+            Ok(json!({ "results": [] }))
+        },
+    )
+    .expect_err("a run id is the only acceptable proof of a durable child");
+
+    assert!(!waited.into_inner());
+    let message = action_failure_message(err, "invoke_and_wait");
+    assert!(message.contains("returned no run_id"), "{message}");
+    assert_eq!(audit_payloads(&runtime, CHILD_DISPATCH_AUDIT).len(), 1);
+}
+
+#[test]
+fn a_failed_child_stays_linked_with_its_terminal_status() {
+    let (runtime, parent) = parent_runtime();
+
+    let output = invoke_and_wait_with(
+        &runtime,
+        "invoke_and_wait",
+        &ship_leaves_input(&parent),
+        |_| Ok(healthy_invoke_output()),
+        |_| {
+            Ok(json!({
+                "results": [{
+                    "run_id": CHILD_RUN,
+                    "status": "failed",
+                    "error": "implement_one exhausted retries",
+                }],
+            }))
+        },
+    )
+    .expect("a failed child is an observed outcome, not an action failure");
+
+    let dispatches = recorded_dispatches(&runtime, &parent);
+    assert_eq!(dispatches[0].phase, ChildDispatchPhase::Terminal);
+    assert_eq!(dispatches[0].child_status.as_deref(), Some("failed"));
+    assert_eq!(
+        dispatches[0].error.as_deref(),
+        Some("implement_one exhausted retries")
+    );
+
+    pipeline_success_guard(
+        "pipeline_success_guard",
+        &json!({ "context": "workspace auto leaf ship", "result": output }),
+    )
+    .expect_err("the guard, not this action, decides the parent's fate");
+
+    assert_eq!(
+        audit_payloads(&runtime, CHILD_WAIT_AUDIT)[0].0,
+        AuditEventStatus::Failure
+    );
+}
+
+#[test]
+fn a_wait_that_errors_leaves_the_child_linked_without_claiming_it_failed() {
+    let (runtime, parent) = parent_runtime();
+
+    let err = invoke_and_wait_with(
+        &runtime,
+        "invoke_and_wait",
+        &ship_leaves_input(&parent),
+        |_| Ok(healthy_invoke_output()),
+        |_| Err(OrbitError::Execution("store unavailable".to_string())),
+    )
+    .expect_err("an unobservable wait fails the step");
+
+    let message = action_failure_message(err, "invoke_and_wait");
+    assert!(message.contains("pipeline.wait failed"), "{message}");
+
+    let dispatches = recorded_dispatches(&runtime, &parent);
+    assert_eq!(dispatches[0].child_run_id, CHILD_RUN);
+    assert_eq!(dispatches[0].phase, ChildDispatchPhase::Terminal);
+    assert_eq!(
+        dispatches[0].child_status, None,
+        "the parent never observed a child status, so it must not invent one"
+    );
+    assert_eq!(
+        audit_payloads(&runtime, CHILD_WAIT_AUDIT)[0].1["status"],
+        json!("unobserved")
+    );
+}
+
+#[test]
+fn a_detached_child_is_recorded_as_non_blocking() {
+    let (runtime, parent) = parent_runtime();
+    let mut state = runtime
+        .read_run_state(&parent)
+        .expect("read state")
+        .expect("state");
+    state.record_child_dispatch(ChildDispatch::submitted(
+        "jrun-child-epic".to_string(),
+        "epic_pipeline".to_string(),
+        "invoke_detached".to_string(),
+        false,
+        false,
+        chrono::Utc::now(),
+    ));
+    runtime
+        .stores()
+        .jobs()
+        .write_run_state(&parent, &state)
+        .expect("write state");
+
+    let dispatches = recorded_dispatches(&runtime, &parent);
+    assert_eq!(dispatches.len(), 1);
+    assert!(!dispatches[0].blocking);
+    assert_eq!(
+        dispatches[0].cancellation_policy(),
+        ChildCancellationPolicy::Detach,
+        "a detached child was dispatched to outlive its parent's step"
+    );
+}

--- a/crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
@@ -333,3 +333,89 @@ fn operator_can_observe_runs_and_agent_denial_is_audited() {
             && event.target_id.as_deref() == Some("orbit.workflow.run.show")
     }));
 }
+
+/// [ORB-10971] CLI, MCP, dashboard API, and audit must agree on lineage. This
+/// covers the MCP half: `run.show` and `run.list` project the same durable
+/// dispatch checkpoint the other readers do, for a parent that is still
+/// blocked on its child.
+#[test]
+fn mcp_run_observation_names_the_child_a_blocked_parent_dispatched() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let parent = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("workspace_auto_pipeline", 1, Utc::now(), None, None)
+        .expect("insert parent run");
+
+    let mut state = orbit_types::workflow::PipelineState::new(
+        parent.run_id.clone(),
+        "workspace_auto_pipeline".to_string(),
+        json!({}),
+    );
+    state.record_child_dispatch(
+        orbit_types::workflow::ChildDispatch::submitted(
+            "jrun-child-leaves".to_string(),
+            "task_auto_pipeline".to_string(),
+            "invoke_and_wait".to_string(),
+            true,
+            false,
+            Utc::now(),
+        )
+        .with_parent_step_id(Some("ship_leaves".to_string())),
+    );
+    state.advance_child_dispatch(
+        "jrun-child-leaves",
+        orbit_types::workflow::ChildDispatchPhase::Waiting,
+        None,
+        None,
+    );
+    runtime
+        .write_run_state(&parent.run_id, &state)
+        .expect("seed parent dispatch state");
+
+    let shown = run_tool_as_operator(
+        &runtime,
+        "orbit.workflow.run.show",
+        json!({"id": parent.run_id}),
+    )
+    .expect("operator run show");
+    assert_eq!(
+        shown["child_dispatches"][0]["child_run_id"],
+        json!("jrun-child-leaves")
+    );
+    assert_eq!(
+        shown["child_dispatches"][0]["job_name"],
+        json!("task_auto_pipeline")
+    );
+    assert_eq!(
+        shown["child_dispatches"][0]["parent_step_id"],
+        json!("ship_leaves")
+    );
+    assert_eq!(shown["child_dispatches"][0]["phase"], json!("waiting"));
+
+    let listed = run_tool_as_operator(&runtime, "orbit.workflow.run.list", json!({}))
+        .expect("operator run list");
+    assert_eq!(
+        listed["items"][0]["child_dispatches"][0]["child_run_id"],
+        json!("jrun-child-leaves")
+    );
+}
+
+#[test]
+fn mcp_run_observation_carries_an_empty_lineage_for_a_run_without_children() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("task_auto_pipeline", 1, Utc::now(), None, None)
+        .expect("insert run");
+
+    let shown = run_tool_as_operator(
+        &runtime,
+        "orbit.workflow.run.show",
+        json!({"id": run.run_id}),
+    )
+    .expect("operator run show");
+
+    assert_eq!(shown["child_dispatches"], json!([]));
+}

--- a/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
@@ -56,7 +56,7 @@ pub(super) fn ship(
 
 pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
     let id = orbit_common::protocol::tool_input::required_string(&input, &["id"], "id")?;
-    run_json(&runtime.show_job_run(&id)?)
+    run_json_with_lineage(runtime, &runtime.show_job_run(&id)?)
 }
 
 pub(super) fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
@@ -83,7 +83,10 @@ pub(super) fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
         since,
         limit: Some(parse_limit(&input)?),
     })?;
-    let items = runs.iter().map(run_json).collect::<Result<Vec<_>, _>>()?;
+    let items = runs
+        .iter()
+        .map(|run| run_json_with_lineage(runtime, run))
+        .collect::<Result<Vec<_>, _>>()?;
     Ok(json!({ "items": items }))
 }
 
@@ -136,5 +139,25 @@ fn run_json(run: &JobRun) -> Result<Value, OrbitError> {
     let mut value = serde_json::to_value(run).map_err(serialize_error("serialize workflow run"))?;
     value["steps"] = serde_json::to_value(&run.steps)
         .map_err(serialize_error("serialize workflow run steps"))?;
+    Ok(value)
+}
+
+/// [ORB-10971] The run record plus the child Runs it dispatched.
+///
+/// The `JobRun` row alone cannot answer "what did this run submit, and is it
+/// still waiting on it" — that lives in the run's `PipelineState`. Reading it
+/// here is what keeps the MCP surface agreeing with the CLI and the dashboard
+/// about lineage instead of each reader seeing a different half of the truth.
+/// An unreadable state degrades to an empty list rather than failing the read.
+fn run_json_with_lineage(runtime: &OrbitRuntime, run: &JobRun) -> Result<Value, OrbitError> {
+    let mut value = run_json(run)?;
+    let dispatches = runtime
+        .read_run_state(&run.run_id)
+        .ok()
+        .flatten()
+        .map(|state| state.child_dispatches)
+        .unwrap_or_default();
+    value["child_dispatches"] =
+        serde_json::to_value(&dispatches).map_err(serialize_error("serialize child dispatches"))?;
     Ok(value)
 }

--- a/crates/orbit-core/src/application/job/run/actions.rs
+++ b/crates/orbit-core/src/application/job/run/actions.rs
@@ -4,13 +4,20 @@ use chrono::Utc;
 use orbit_common::{NotFoundKind, OrbitError};
 use orbit_store::contracts::TaskReservationReleaseReason;
 use orbit_types::record::OrbitEvent;
-use orbit_types::workflow::{JobRun, JobRunState, PipelineState};
+use orbit_types::workflow::{
+    ChildCancellation, ChildCancellationPolicy, JobRun, JobRunState, PipelineState,
+};
 use serde_json::Value;
 
 use crate::OrbitRuntime;
 
 use super::owner::signal_run_owner_process;
 use super::types::JobRunCancelResult;
+
+/// `source` recorded on a cancellation a parent propagated to its child.
+const CHILD_CASCADE_SOURCE: &str = "parent_cascade";
+/// Backstop against a cycle in persisted dispatch records.
+const MAX_CHILD_CANCEL_CASCADE_DEPTH: usize = 8;
 
 impl OrbitRuntime {
     pub fn cancel_job_run(&self, run_id: &str) -> Result<JobRunCancelResult, OrbitError> {
@@ -34,6 +41,20 @@ impl OrbitRuntime {
         actor: &str,
         source: &str,
         signal: F,
+    ) -> Result<JobRunCancelResult, OrbitError>
+    where
+        F: FnOnce(&JobRun) -> Result<String, OrbitError>,
+    {
+        self.cancel_job_run_cascading(run_id, actor, source, signal, 0)
+    }
+
+    fn cancel_job_run_cascading<F>(
+        &self,
+        run_id: &str,
+        actor: &str,
+        source: &str,
+        signal: F,
+        depth: usize,
     ) -> Result<JobRunCancelResult, OrbitError>
     where
         F: FnOnce(&JobRun) -> Result<String, OrbitError>,
@@ -83,6 +104,7 @@ impl OrbitRuntime {
             )));
         }
         self.mark_cancelled_pipeline_state(&cancelled_run)?;
+        self.settle_child_dispatches_on_cancel(&cancelled_run, actor, depth)?;
         self.record_event(OrbitEvent::JobRunCancelled {
             job_id: run.job_id.clone(),
             run_id: run_id.to_string(),
@@ -145,6 +167,126 @@ impl OrbitRuntime {
         self.stores().jobs().read_run_state(run_id)
     }
 
+    /// Persist a run's pipeline state. The write side of [`Self::read_run_state`],
+    /// for callers outside the store layer that own a read-modify-write of the
+    /// run's own state — dispatch checkpoints, waiting reasons, cancellation.
+    pub fn write_run_state(&self, run_id: &str, state: &PipelineState) -> Result<(), OrbitError> {
+        self.stores().jobs().write_run_state(run_id, state)
+    }
+
+    /// Apply this run's child-cancellation policy and close every dispatch it
+    /// still holds open [ORB-10971].
+    ///
+    /// **The policy.** A child the parent was *blocking* on cascades: the
+    /// parent's wait was that child's only consumer, so leaving it running
+    /// would produce work nobody joins and no operator expects. A child
+    /// dispatched *detached* does not: it was submitted precisely to outlive
+    /// the parent's step (`workspace_auto_pipeline` starts an epic that way),
+    /// and its own drain re-observes it. The dispatch record carries which
+    /// shape it was, so the rule is decided by how the child was dispatched
+    /// rather than by whoever happens to be cancelling.
+    ///
+    /// Either way the linkage survives and the wait step stops rendering as
+    /// `running`: a cancelled parent must still name the child it left behind,
+    /// which is the only handle on that work.
+    ///
+    /// Cascading is best effort. A child that already terminalized, or that
+    /// refuses cancellation, is recorded as such and never blocks the parent's
+    /// own cancellation from completing.
+    fn settle_child_dispatches_on_cancel(
+        &self,
+        run: &JobRun,
+        actor: &str,
+        depth: usize,
+    ) -> Result<(), OrbitError> {
+        let Some(state) = self.read_run_state(&run.run_id)? else {
+            return Ok(());
+        };
+        let open: Vec<(String, ChildCancellationPolicy)> = state
+            .open_child_dispatches()
+            .map(|dispatch| {
+                (
+                    dispatch.child_run_id.clone(),
+                    dispatch.cancellation_policy(),
+                )
+            })
+            .collect();
+        if open.is_empty() {
+            return Ok(());
+        }
+
+        let settled: Vec<(String, ChildCancellation)> = open
+            .into_iter()
+            .map(|(child_run_id, policy)| {
+                let (outcome, error) = match policy {
+                    ChildCancellationPolicy::Detach => ("detached".to_string(), None),
+                    ChildCancellationPolicy::Cascade => {
+                        self.cascade_cancel_child(&child_run_id, actor, depth)
+                    }
+                };
+                (
+                    child_run_id,
+                    ChildCancellation {
+                        policy,
+                        outcome,
+                        error,
+                        at: Utc::now(),
+                    },
+                )
+            })
+            .collect();
+
+        // Re-read: cascading a child re-enters cancellation, and the parent's
+        // own state must be stamped from whatever that left behind.
+        let Some(mut state) = self.read_run_state(&run.run_id)? else {
+            return Ok(());
+        };
+        for (child_run_id, cancellation) in settled {
+            state.terminalize_child_dispatch(&child_run_id, cancellation);
+        }
+        self.write_run_state(&run.run_id, &state)
+    }
+
+    /// Cancel one blocking child, reporting what happened rather than failing
+    /// the parent's cancellation.
+    fn cascade_cancel_child(
+        &self,
+        child_run_id: &str,
+        actor: &str,
+        depth: usize,
+    ) -> (String, Option<String>) {
+        // A dispatch graph is a DAG in practice, so this bound is a backstop
+        // against a corrupted state file, not an expected limit.
+        if depth >= MAX_CHILD_CANCEL_CASCADE_DEPTH {
+            return (
+                "skipped".to_string(),
+                Some(format!(
+                    "child cancellation cascade stopped at depth {depth}"
+                )),
+            );
+        }
+        match self.cancel_job_run_cascading(
+            child_run_id,
+            actor,
+            CHILD_CASCADE_SOURCE,
+            signal_run_owner_process,
+            depth + 1,
+        ) {
+            Ok(_) => ("cancelled".to_string(), None),
+            // A child that reached a terminal state on its own is the ordinary
+            // race, not a fault: the parent simply lost it to the finish line.
+            Err(OrbitError::JobValidation(message))
+            | Err(OrbitError::JobRunStateTransition(message)) => {
+                ("already_terminal".to_string(), Some(message))
+            }
+            Err(error) => ("failed".to_string(), Some(error.to_string())),
+        }
+    }
+
+    /// Cancelling a run preserves its child lineage. `clear_waiting_reasons`
+    /// deliberately does not touch `child_dispatches`: dependency and lock
+    /// waits are momentary and meaningless once terminal, but the child a
+    /// parent dispatched outlives the parent's own record of waiting for it.
     fn mark_cancelled_pipeline_state(&self, run: &JobRun) -> Result<(), OrbitError> {
         if let Some(mut state) = self.read_run_state(&run.run_id)? {
             if let Some(object) = state.pipeline.as_object_mut() {
@@ -160,7 +302,7 @@ impl OrbitRuntime {
             }
             state.clear_waiting_reasons();
             state.updated_at = Utc::now();
-            self.stores().jobs().write_run_state(&run.run_id, &state)?;
+            self.write_run_state(&run.run_id, &state)?;
         } else if run.input.is_some() {
             let mut state = PipelineState::new(
                 run.run_id.clone(),
@@ -180,7 +322,7 @@ impl OrbitRuntime {
                 );
                 object.insert("cancelled".to_string(), Value::Bool(true));
             }
-            self.stores().jobs().write_run_state(&run.run_id, &state)?;
+            self.write_run_state(&run.run_id, &state)?;
         }
         Ok(())
     }

--- a/crates/orbit-core/src/application/job/run/tests/actions.rs
+++ b/crates/orbit-core/src/application/job/run/tests/actions.rs
@@ -447,3 +447,145 @@ fn cancellation_survivor_returns_typed_evidence_without_finalizing_run() {
 fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
+
+// ─── child-dispatch cancellation policy [ORB-10971] ───────────────────────
+
+use orbit_types::workflow::{ChildDispatch, ChildDispatchPhase, PipelineState};
+
+/// A parent parked in a blocking dispatch wait, plus the child it submitted.
+fn parent_waiting_on_child(
+    runtime: &OrbitRuntime,
+    parent_job: &str,
+    child_job: &str,
+    blocking: bool,
+) -> (JobRun, JobRun) {
+    let parent = insert_pending_run(runtime, parent_job);
+    let child = insert_pending_run(runtime, child_job);
+
+    let mut state = PipelineState::new(
+        parent.run_id.clone(),
+        parent_job.to_string(),
+        serde_json::json!({}),
+    );
+    let action = if blocking {
+        "invoke_and_wait"
+    } else {
+        "invoke_detached"
+    };
+    state.record_child_dispatch(
+        ChildDispatch::submitted(
+            child.run_id.clone(),
+            child_job.to_string(),
+            action.to_string(),
+            blocking,
+            false,
+            Utc::now(),
+        )
+        .with_parent_step_id(Some("ship_leaves".to_string())),
+    );
+    state.advance_child_dispatch(&child.run_id, ChildDispatchPhase::Waiting, None, None);
+    runtime
+        .stores()
+        .jobs()
+        .write_run_state(&parent.run_id, &state)
+        .expect("seed parent dispatch state");
+    (parent, child)
+}
+
+fn dispatch_after_cancel(runtime: &OrbitRuntime, parent_run_id: &str) -> ChildDispatch {
+    runtime
+        .read_run_state(parent_run_id)
+        .expect("read parent state")
+        .expect("parent state")
+        .child_dispatches
+        .into_iter()
+        .next()
+        .expect("the child link must survive cancellation")
+}
+
+#[test]
+fn cancelling_a_waiting_parent_cascades_to_its_blocking_child_and_keeps_the_link() {
+    let (_root, runtime) = test_runtime();
+    let (parent, child) = parent_waiting_on_child(
+        &runtime,
+        "workspace_auto_pipeline",
+        "task_auto_pipeline",
+        true,
+    );
+
+    runtime
+        .cancel_job_run_with_context(&parent.run_id, "operator", "cli")
+        .expect("cancel the waiting parent");
+
+    let dispatch = dispatch_after_cancel(&runtime, &parent.run_id);
+    assert_eq!(dispatch.child_run_id, child.run_id);
+    assert_eq!(dispatch.parent_step_id.as_deref(), Some("ship_leaves"));
+    assert_eq!(
+        dispatch.phase,
+        ChildDispatchPhase::Terminal,
+        "the wait step must not keep rendering as running"
+    );
+    let cancellation = dispatch.cancellation.expect("cancellation is recorded");
+    assert_eq!(cancellation.policy.as_str(), "cascade");
+    assert_eq!(cancellation.outcome, "cancelled");
+
+    assert_eq!(
+        runtime
+            .show_job_run(&child.run_id)
+            .expect("show child")
+            .state,
+        JobRunState::Cancelled,
+        "the parent's wait was the child's only consumer",
+    );
+}
+
+#[test]
+fn cancelling_a_parent_leaves_its_detached_child_running() {
+    let (_root, runtime) = test_runtime();
+    let (parent, child) =
+        parent_waiting_on_child(&runtime, "workspace_auto_pipeline", "epic_pipeline", false);
+
+    runtime
+        .cancel_job_run_with_context(&parent.run_id, "operator", "cli")
+        .expect("cancel the parent");
+
+    let dispatch = dispatch_after_cancel(&runtime, &parent.run_id);
+    assert_eq!(dispatch.child_run_id, child.run_id);
+    assert_eq!(dispatch.phase, ChildDispatchPhase::Terminal);
+    let cancellation = dispatch.cancellation.expect("cancellation is recorded");
+    assert_eq!(cancellation.policy.as_str(), "detach");
+    assert_eq!(cancellation.outcome, "detached");
+
+    assert_eq!(
+        runtime
+            .show_job_run(&child.run_id)
+            .expect("show child")
+            .state,
+        JobRunState::Pending,
+        "a detached child was dispatched to outlive the parent's step",
+    );
+}
+
+#[test]
+fn a_child_that_finished_first_is_recorded_rather_than_failing_the_parent_cancel() {
+    let (_root, runtime) = test_runtime();
+    let (parent, child) = parent_waiting_on_child(
+        &runtime,
+        "workspace_auto_pipeline",
+        "task_auto_pipeline",
+        true,
+    );
+    runtime
+        .cancel_job_run(&child.run_id)
+        .expect("child terminalizes on its own first");
+
+    runtime
+        .cancel_job_run_with_context(&parent.run_id, "operator", "cli")
+        .expect("losing the race to the child must not block the parent's cancel");
+
+    let cancellation = dispatch_after_cancel(&runtime, &parent.run_id)
+        .cancellation
+        .expect("cancellation is recorded");
+    assert_eq!(cancellation.outcome, "already_terminal");
+    assert!(cancellation.error.is_some(), "the reason is kept verbatim");
+}

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -253,6 +253,7 @@ fn dispatch_v2_activity_inner(
             Some(host) => run_deterministic(
                 host,
                 input.run_id,
+                input.activity_name,
                 spec,
                 input.fs_profile,
                 input.audit.clone(),
@@ -291,9 +292,31 @@ fn inject_run_id(input: &Value, run_id: &str) -> Value {
     Value::Object(augmented)
 }
 
+/// Name the dispatching step in a deterministic action's input.
+///
+/// [ORB-10971] An action that persists something into the run's own state —
+/// a child dispatch checkpoint, say — needs to say *which* step produced it,
+/// and `run_id` alone cannot. Scoped to the deterministic path: agent-loop
+/// envelopes are a provider-facing contract and are deliberately left alone.
+/// An input that already carries `step_id` wins, so a job asset can still
+/// address a different step explicitly.
+fn inject_step_id(input: &Value, step_id: &str) -> Value {
+    let Value::Object(map) = input else {
+        return input.clone();
+    };
+    if map.contains_key("step_id") {
+        return input.clone();
+    }
+
+    let mut augmented = map.clone();
+    augmented.insert("step_id".to_string(), Value::String(step_id.to_string()));
+    Value::Object(augmented)
+}
+
 fn run_deterministic(
     host: &dyn RuntimeHost,
     run_id: &str,
+    activity_name: &str,
     spec: &DeterministicSpec,
     fs_profile: Option<&str>,
     audit: Arc<V2AuditWriter>,
@@ -331,9 +354,12 @@ fn run_deterministic(
                 message: error.to_string(),
             })?
         }
-        Some(DeterministicAction::Core(_)) | None => {
-            host.run_deterministic(&spec.action, &spec.config, input, tool_context)?
-        }
+        Some(DeterministicAction::Core(_)) | None => host.run_deterministic(
+            &spec.action,
+            &spec.config,
+            &inject_step_id(input, activity_name),
+            tool_context,
+        )?,
     };
     Ok(DispatchOutcome {
         success: true,

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
@@ -75,6 +75,7 @@ fn recovery_success_runs_one_post_recovery_attempt_with_exact_input_and_fs_profi
         host.input_for_action("recover"),
         Some(json!({
             "failed_step_id": "build",
+            "step_id": "recover",
             "activity_name": "flaky",
             "error_message": original_error.to_string(),
             "attempt": 2,
@@ -364,6 +365,7 @@ fn worktree_integrity_failure_bypasses_retry_then_recovers_once() {
         host.input_for_action("recover"),
         Some(json!({
             "failed_step_id": "build",
+            "step_id": "recover",
             "activity_name": "flaky",
             "error_message": integrity_error.to_string(),
             "attempt": 1,

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/resume.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/resume.rs
@@ -310,6 +310,7 @@ fn resume_reexecuted_pr_output_reaches_promotion_and_checkpoint() {
             "pr_number": "618",
             "pr_url": "https://github.example/pull/618",
             "run_id": "run-resume-pr-open",
+            "step_id": "promote_tasks",
         })],
         "fresh pr_open output retains its string type for downstream input",
     );
@@ -433,6 +434,7 @@ fn resume_starts_at_the_failed_push_and_reuses_checkpoints_idempotently() {
             "job_run_id": "jrun-source",
             "workspace_path": "/wt/jrun-source",
             "run_id": "jrun-resume-1",
+            "step_id": "push",
         })],
         "the delivery tail keeps the checkpointed batch id as its ownership id",
     );

--- a/crates/orbit-types/src/workflow/child_dispatch.rs
+++ b/crates/orbit-types/src/workflow/child_dispatch.rs
@@ -1,0 +1,159 @@
+//! Durable record of a child job run dispatched by a parent run's step.
+//!
+//! A parent that submits a child Run and then blocks on it has two distinct
+//! lifecycle phases — submission and waiting — that used to be invisible from
+//! the outside: the deterministic action kept the child's `run_id` in a local
+//! variable and the engine did not persist the activity output until the wait
+//! returned. A parent could therefore sit on a dispatch step for the whole
+//! wait timeout with no durable child identifier, and an operator could not
+//! tell a healthy long wait apart from a dispatch wedged before persistence.
+//!
+//! [`ChildDispatch`] is that missing checkpoint. It is written into the
+//! parent's `PipelineState` immediately after `orbit.pipeline.invoke` returns
+//! a durable child run id and before the parent blocks, so CLI, MCP, API, and
+//! dashboard readers all resolve the same lineage from one persisted record.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Which lifecycle phase a child dispatch has reached in the parent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChildDispatchPhase {
+    /// `orbit.pipeline.invoke` returned a durable child run id. The parent has
+    /// recorded the linkage but has not yet entered its blocking wait.
+    Submitted,
+    /// The parent is blocked on this child's terminal state.
+    Waiting,
+    /// The parent stopped tracking this child: the wait returned, the dispatch
+    /// was detached by design, or the parent itself terminalized.
+    Terminal,
+}
+
+impl ChildDispatchPhase {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ChildDispatchPhase::Submitted => "submitted",
+            ChildDispatchPhase::Waiting => "waiting",
+            ChildDispatchPhase::Terminal => "terminal",
+        }
+    }
+
+    /// Whether the parent still considers this dispatch open. An open dispatch
+    /// on a terminal parent is the exact inconsistency this record exists to
+    /// prevent, so cancellation closes every one it finds.
+    pub fn is_open(self) -> bool {
+        !matches!(self, ChildDispatchPhase::Terminal)
+    }
+}
+
+/// What a terminalizing parent does to a child it dispatched.
+///
+/// The policy is decided by how the child was dispatched, not by the caller of
+/// the moment, so it is the same for an operator cancel, a dashboard cancel,
+/// and a cascade from a grandparent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChildCancellationPolicy {
+    /// The parent was blocking on this child, so the child's only consumer is
+    /// gone. Cancelling the parent cancels the child.
+    Cascade,
+    /// The child was dispatched detached, explicitly to outlive the parent's
+    /// step. Cancelling the parent leaves it running.
+    Detach,
+}
+
+impl ChildCancellationPolicy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ChildCancellationPolicy::Cascade => "cascade",
+            ChildCancellationPolicy::Detach => "detach",
+        }
+    }
+}
+
+/// What actually happened when the policy was applied.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChildCancellation {
+    pub policy: ChildCancellationPolicy,
+    /// `cancelled`, `skipped`, or `failed` — the observed result, which may
+    /// differ from the policy when the child had already terminalized.
+    pub outcome: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    pub at: DateTime<Utc>,
+}
+
+/// One child Run a parent step submitted, and how far the parent got with it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChildDispatch {
+    /// The exact run id returned by `orbit.pipeline.invoke`. Never inferred
+    /// from task status or timestamps.
+    pub child_run_id: String,
+    pub job_name: String,
+    /// The parent job step that dispatched this child, when the engine
+    /// supplied it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_step_id: Option<String>,
+    /// The deterministic action that dispatched it (`invoke_and_wait` or
+    /// `invoke_detached`).
+    pub action: String,
+    /// Whether the parent blocks on this child's terminal state. Drives the
+    /// cancellation policy.
+    pub blocking: bool,
+    /// Whether the child was admitted immediately or held behind
+    /// `max_active_runs` at submission time.
+    pub queued: bool,
+    pub submitted_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub phase: ChildDispatchPhase,
+    /// The child's terminal status once the parent observed one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cancellation: Option<ChildCancellation>,
+}
+
+impl ChildDispatch {
+    /// A freshly submitted child, in the `Submitted` phase. Callers move it to
+    /// `Waiting` only once they are actually about to block.
+    pub fn submitted(
+        child_run_id: String,
+        job_name: String,
+        action: String,
+        blocking: bool,
+        queued: bool,
+        submitted_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            child_run_id,
+            job_name,
+            parent_step_id: None,
+            action,
+            blocking,
+            queued,
+            submitted_at,
+            updated_at: submitted_at,
+            phase: ChildDispatchPhase::Submitted,
+            child_status: None,
+            error: None,
+            cancellation: None,
+        }
+    }
+
+    pub fn with_parent_step_id(mut self, parent_step_id: Option<String>) -> Self {
+        self.parent_step_id = parent_step_id;
+        self
+    }
+
+    /// The policy this dispatch's shape implies for a terminalizing parent.
+    pub fn cancellation_policy(&self) -> ChildCancellationPolicy {
+        if self.blocking {
+            ChildCancellationPolicy::Cascade
+        } else {
+            ChildCancellationPolicy::Detach
+        }
+    }
+}

--- a/crates/orbit-types/src/workflow/mod.rs
+++ b/crates/orbit-types/src/workflow/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod activity_job;
 mod auto_task;
+mod child_dispatch;
 mod error;
 mod executor_def;
 mod job;
@@ -33,6 +34,9 @@ pub use activity_job::{
 pub use auto_task::{
     AUTO_TASK_SCHEMA_VERSION, AUTO_TASK_TAG_PREFIX, AutoTaskDefinition, AutoTaskSchedule,
     AutoTaskTemplate, DedupePolicy, auto_task_tag, is_valid_auto_task_name,
+};
+pub use child_dispatch::{
+    ChildCancellation, ChildCancellationPolicy, ChildDispatch, ChildDispatchPhase,
 };
 pub use executor_def::{
     ExecutorDef, ExecutorSandboxKind, ExecutorType, ModelPairOverride, StdoutFormat,

--- a/crates/orbit-types/src/workflow/run_state.rs
+++ b/crates/orbit-types/src/workflow/run_state.rs
@@ -5,6 +5,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::workflow::JobRunState;
+use crate::workflow::child_dispatch::{
+    ChildCancellation, ChildCancellationPolicy, ChildDispatch, ChildDispatchPhase,
+};
 
 /// Persistent pipeline state for a job run.
 ///
@@ -46,6 +49,16 @@ pub struct PipelineState {
     /// Task lock resource identifiers currently blocking this run, when parked.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub waiting_on_locks: Option<Vec<String>>,
+    /// Child Runs this run dispatched, in submission order.
+    ///
+    /// Written the moment `orbit.pipeline.invoke` returns a durable child run
+    /// id — before a blocking parent enters its wait — so parent/child lineage
+    /// is observable for the whole life of the dispatch rather than only after
+    /// the step's output is finally persisted. Unlike the waiting reasons
+    /// above, this survives terminalization: a cancelled parent must still
+    /// name the child it left behind.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub child_dispatches: Vec<ChildDispatch>,
     pub updated_at: DateTime<Utc>,
 }
 
@@ -65,6 +78,7 @@ impl PipelineState {
             iteration: 0,
             waiting_on_deps: None,
             waiting_on_locks: None,
+            child_dispatches: Vec::new(),
             updated_at: Utc::now(),
         }
     }
@@ -119,6 +133,98 @@ impl PipelineState {
         self.waiting_on_deps = None;
         self.waiting_on_locks = None;
         self.updated_at = Utc::now();
+    }
+
+    /// Record a child dispatch, keyed by the child's run id.
+    ///
+    /// Upsert rather than push: a resumed or retried parent re-executing the
+    /// same dispatch step must not accumulate duplicate rows for one child.
+    /// A re-record keeps the original `submitted_at` so the observable
+    /// submission instant does not drift.
+    pub fn record_child_dispatch(&mut self, dispatch: ChildDispatch) {
+        match self
+            .child_dispatches
+            .iter_mut()
+            .find(|existing| existing.child_run_id == dispatch.child_run_id)
+        {
+            Some(existing) => {
+                let submitted_at = existing.submitted_at;
+                *existing = dispatch;
+                existing.submitted_at = submitted_at;
+            }
+            None => self.child_dispatches.push(dispatch),
+        }
+        self.updated_at = Utc::now();
+    }
+
+    /// Advance a recorded child dispatch. Returns false when no dispatch with
+    /// that child run id is recorded, so a caller can tell a lost checkpoint
+    /// from a successful update instead of silently succeeding.
+    pub fn advance_child_dispatch(
+        &mut self,
+        child_run_id: &str,
+        phase: ChildDispatchPhase,
+        child_status: Option<String>,
+        error: Option<String>,
+    ) -> bool {
+        let Some(dispatch) = self
+            .child_dispatches
+            .iter_mut()
+            .find(|dispatch| dispatch.child_run_id == child_run_id)
+        else {
+            return false;
+        };
+        dispatch.phase = phase;
+        if child_status.is_some() {
+            dispatch.child_status = child_status;
+        }
+        if error.is_some() {
+            dispatch.error = error;
+        }
+        dispatch.updated_at = Utc::now();
+        self.updated_at = Utc::now();
+        true
+    }
+
+    /// Every child dispatch the parent still considers open.
+    pub fn open_child_dispatches(&self) -> impl Iterator<Item = &ChildDispatch> {
+        self.child_dispatches
+            .iter()
+            .filter(|dispatch| dispatch.phase.is_open())
+    }
+
+    /// Close an open dispatch because the parent itself terminalized, and
+    /// record which cancellation policy was applied to the child.
+    ///
+    /// The linkage itself is never dropped: an operator who cancels a parent
+    /// mid-wait still needs the child run id, which is the only handle on the
+    /// work that outlived (or was stopped with) the parent.
+    pub fn terminalize_child_dispatch(
+        &mut self,
+        child_run_id: &str,
+        cancellation: ChildCancellation,
+    ) -> bool {
+        let Some(dispatch) = self
+            .child_dispatches
+            .iter_mut()
+            .find(|dispatch| dispatch.child_run_id == child_run_id)
+        else {
+            return false;
+        };
+        dispatch.phase = ChildDispatchPhase::Terminal;
+        dispatch.cancellation = Some(cancellation);
+        dispatch.updated_at = Utc::now();
+        self.updated_at = Utc::now();
+        true
+    }
+
+    /// The child run ids a terminalizing parent must cancel, per each
+    /// dispatch's own [`ChildCancellationPolicy`].
+    pub fn cascade_cancellation_targets(&self) -> Vec<String> {
+        self.open_child_dispatches()
+            .filter(|dispatch| dispatch.cancellation_policy() == ChildCancellationPolicy::Cascade)
+            .map(|dispatch| dispatch.child_run_id.clone())
+            .collect()
     }
 
     /// Rebuild the pipeline snapshot just before `step_index` executes.

--- a/crates/orbit-types/src/workflow/tests/mod.rs
+++ b/crates/orbit-types/src/workflow/tests/mod.rs
@@ -1,3 +1,4 @@
 mod executor_def;
 mod job;
+mod run_state;
 mod ship;

--- a/crates/orbit-types/src/workflow/tests/run_state.rs
+++ b/crates/orbit-types/src/workflow/tests/run_state.rs
@@ -1,0 +1,120 @@
+//! [ORB-10971] Child-dispatch bookkeeping on a run's pipeline state.
+
+use chrono::Utc;
+
+use crate::workflow::{
+    ChildCancellation, ChildCancellationPolicy, ChildDispatch, ChildDispatchPhase, PipelineState,
+};
+
+fn state() -> PipelineState {
+    PipelineState::new(
+        "jrun-parent".to_string(),
+        "workspace_auto_pipeline".to_string(),
+        serde_json::json!({}),
+    )
+}
+
+fn dispatch(child_run_id: &str, blocking: bool) -> ChildDispatch {
+    ChildDispatch::submitted(
+        child_run_id.to_string(),
+        "task_auto_pipeline".to_string(),
+        "invoke_and_wait".to_string(),
+        blocking,
+        false,
+        Utc::now(),
+    )
+}
+
+#[test]
+fn re_recording_the_same_child_updates_it_rather_than_duplicating_it() {
+    // A resumed or retried parent re-executes its dispatch step. The child is
+    // one child, not two rows.
+    let mut state = state();
+    let first = dispatch("jrun-child", true);
+    let submitted_at = first.submitted_at;
+    state.record_child_dispatch(first);
+
+    let mut second = dispatch("jrun-child", true);
+    second.queued = true;
+    second.submitted_at = Utc::now();
+    state.record_child_dispatch(second);
+
+    assert_eq!(state.child_dispatches.len(), 1);
+    assert!(state.child_dispatches[0].queued);
+    assert_eq!(
+        state.child_dispatches[0].submitted_at, submitted_at,
+        "the observable submission instant must not drift on re-record"
+    );
+}
+
+#[test]
+fn advancing_an_unrecorded_child_reports_the_lost_checkpoint() {
+    let mut state = state();
+    assert!(
+        !state.advance_child_dispatch("jrun-missing", ChildDispatchPhase::Waiting, None, None),
+        "a caller must be able to tell a lost checkpoint from a successful update"
+    );
+}
+
+#[test]
+fn clearing_waiting_reasons_leaves_child_lineage_intact() {
+    // Cancellation clears the waiting reasons. The child link must survive it:
+    // it is the only handle on the work the parent left behind.
+    let mut state = state();
+    state.set_waiting_reasons(Some(vec!["ORB-1".to_string()]), None);
+    state.record_child_dispatch(dispatch("jrun-child", true));
+
+    state.clear_waiting_reasons();
+
+    assert_eq!(state.waiting_on_deps, None);
+    assert_eq!(state.child_dispatches.len(), 1);
+}
+
+#[test]
+fn only_blocking_children_are_cascade_targets() {
+    let mut state = state();
+    state.record_child_dispatch(dispatch("jrun-blocking", true));
+    state.record_child_dispatch(dispatch("jrun-detached", false));
+
+    assert_eq!(state.cascade_cancellation_targets(), vec!["jrun-blocking"]);
+}
+
+#[test]
+fn a_terminalized_child_is_no_longer_open_but_stays_recorded() {
+    let mut state = state();
+    state.record_child_dispatch(dispatch("jrun-child", true));
+
+    assert!(state.terminalize_child_dispatch(
+        "jrun-child",
+        ChildCancellation {
+            policy: ChildCancellationPolicy::Cascade,
+            outcome: "cancelled".to_string(),
+            error: None,
+            at: Utc::now(),
+        },
+    ));
+
+    assert_eq!(state.open_child_dispatches().count(), 0);
+    assert!(state.cascade_cancellation_targets().is_empty());
+    assert_eq!(state.child_dispatches.len(), 1);
+    assert_eq!(
+        state.child_dispatches[0].phase,
+        ChildDispatchPhase::Terminal
+    );
+}
+
+#[test]
+fn a_state_without_children_round_trips_without_the_field() {
+    // Existing on-disk `state.json` files predate this field and must keep
+    // decoding, and a childless run must not start emitting an empty array.
+    let encoded = serde_json::to_value(state()).expect("encode");
+    assert!(
+        !encoded
+            .as_object()
+            .expect("object")
+            .contains_key("child_dispatches")
+    );
+
+    let decoded: PipelineState = serde_json::from_value(encoded).expect("decode");
+    assert!(decoded.child_dispatches.is_empty());
+}

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -2629,6 +2629,30 @@
       }
       .run-meta-grid .value { color: var(--fg); }
 
+      /* Child-run lineage (ORB-10971) */
+      .child-dispatch-panel {
+        padding: 12px 16px;
+        font-family: var(--font-mono);
+        font-size: 12px;
+        border-bottom: 1px solid var(--border);
+      }
+      .child-dispatch-panel .label {
+        color: var(--fg-dim);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        margin-bottom: 6px;
+      }
+      .child-dispatch-row {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 4px;
+      }
+      .child-dispatch-meta { color: var(--fg-dim); }
+      .child-dispatch-error { color: var(--state-failed); }
+
       .step-row {
         display: grid;
         grid-template-columns: 60px 1fr 100px 80px 80px;

--- a/crates/orbit-web/assets/dashboard/run-detail.js
+++ b/crates/orbit-web/assets/dashboard/run-detail.js
@@ -187,7 +187,50 @@ export function renderRunDetailMeta() {
   if (runIsCancellable(run)) actions.appendChild(buildCancelRunButton(run, wrap));
   wrap.appendChild(actions);
   wrap.appendChild(grid);
+  const children = buildChildDispatches(run);
+  if (children) wrap.appendChild(children);
   syncNodes(meta, [wrap]);
+}
+
+// [ORB-10971] The child Runs this run dispatched, from the durable dispatch
+// checkpoint the API projects as `run.child_dispatches`.
+//
+// This is the answer to "the parent has been sitting on a dispatch step for an
+// hour — did it actually submit anything?", so it is rendered from the moment
+// the child is submitted rather than only once the parent's wait returns, and
+// it stays visible after the parent terminalizes.
+function buildChildDispatches(run) {
+  const dispatches = Array.isArray(run.child_dispatches) ? run.child_dispatches : [];
+  if (dispatches.length === 0) return null;
+
+  const rows = dispatches.map((d) => {
+    const parts = [`job ${d.job_name || "?"}`, `phase ${d.phase || "?"}`];
+    if (d.parent_step_id) parts.push(`step ${d.parent_step_id}`);
+    if (d.queued) parts.push("queued");
+    if (d.child_status) parts.push(`status ${d.child_status}`);
+    if (d.cancellation) parts.push(`cancel ${d.cancellation.policy}/${d.cancellation.outcome}`);
+
+    const link = el("button", {
+      class: "back-action",
+      text: d.child_run_id,
+      title: `Open ${d.child_run_id}`,
+    });
+    link.addEventListener("click", () => navigateToRun(d.child_run_id));
+
+    const row = el("div", { class: "child-dispatch-row" }, [
+      link,
+      el("span", { class: "child-dispatch-meta", text: parts.join(" · ") }),
+    ]);
+    if (d.error) {
+      row.appendChild(el("span", { class: "child-dispatch-error", text: d.error }));
+    }
+    return row;
+  });
+
+  return el("div", { class: "child-dispatch-panel" }, [
+    el("div", { class: "label", text: `child runs (${dispatches.length})` }),
+    ...rows,
+  ]);
 }
 
 export function renderRunSteps() {

--- a/crates/orbit-web/src/api/runs.rs
+++ b/crates/orbit-web/src/api/runs.rs
@@ -13,7 +13,7 @@ use super::{
     HISTORY_DEFAULT_LIMIT, LimitQuery, RunEventsQuery, bad_request, bounded_limit,
     map_runtime_error, validate_id,
 };
-use crate::projections::job_run_to_json;
+use crate::projections::job_run_to_json_with_state;
 
 const RUN_EVENTS_DEFAULT_LIMIT: usize = 100;
 /// Hard cap on rows scanned from a single run's persisted v2 audit events.
@@ -146,7 +146,11 @@ pub(super) async fn replay_run_action(Ws(runtime): Ws, Path(id): Path<String>) -
 }
 
 pub(super) fn job_run_detail_to_json(runtime: &OrbitRuntime, run: &JobRun) -> Value {
-    let mut full = job_run_to_json(run);
+    // [ORB-10971] Read the run's pipeline state. This projection used to drop
+    // it entirely, so the dashboard could not see the waiting reasons or the
+    // child-dispatch lineage the CLI already showed.
+    let state = runtime.read_run_state(&run.run_id).ok().flatten();
+    let mut full = job_run_to_json_with_state(run, state.as_ref());
     // Reshape into `{run, steps}` per the dashboard contract: peel the
     // `steps` array off the flat `job_run_to_json` output.
     let stored_steps = full
@@ -160,7 +164,12 @@ pub(super) fn job_run_detail_to_json(runtime: &OrbitRuntime, run: &JobRun) -> Va
     let steps = if audit_steps.is_empty() {
         stored_steps
     } else {
-        Value::Array(audit_steps.iter().map(audit_step_to_json).collect())
+        Value::Array(
+            audit_steps
+                .iter()
+                .map(|step| audit_step_to_json(step, run.state))
+                .collect(),
+        )
     };
 
     // [ORB-10496] Provider subprocesses for this run's agent steps, with a
@@ -199,7 +208,16 @@ fn run_provider_process_to_json(record: &RunProviderProcess) -> Value {
     })
 }
 
-fn audit_step_to_json(step: &RunAuditStep) -> Value {
+/// Project one audit-derived step, reconciled against the run's own state.
+///
+/// [ORB-10971] Steps are rebuilt from `step_started` / `step_finished` audit
+/// events, so a run killed mid-step leaves a `step_started` with no partner
+/// and the step renders `running` forever. A cancelled parent blocked in a
+/// dispatch wait is exactly that case. A step cannot outlive its run: once the
+/// run is terminal, an unfinished step inherits the run's terminal state and is
+/// marked `interrupted` so the projection says what happened rather than
+/// implying work is still in flight.
+fn audit_step_to_json(step: &RunAuditStep, run_state: orbit_core::JobRunState) -> Value {
     let duration_ms = match (step.started_at, step.finished_at) {
         (Some(started), Some(finished)) => Some(
             finished
@@ -209,12 +227,23 @@ fn audit_step_to_json(step: &RunAuditStep) -> Value {
         ),
         _ => None,
     };
+    let unfinished = step.state.is_none();
+    let state = match step.state.as_deref() {
+        Some(state) => state.to_string(),
+        None if run_state.is_terminal() => run_state.to_string(),
+        None => "running".to_string(),
+    };
+    let outcome = match (&step.outcome, unfinished && run_state.is_terminal()) {
+        (Some(outcome), _) => Some(outcome.clone()),
+        (None, true) => Some("interrupted".to_string()),
+        (None, false) => None,
+    };
 
     json!({
         "step_index": step.step_index,
         "target_type": "activity",
         "target_id": step.step_id,
-        "state": step.state.as_deref().unwrap_or("running"),
+        "state": state,
         "started_at": step.started_at.map(|v| v.to_rfc3339()),
         "finished_at": step.finished_at.map(|v| v.to_rfc3339()),
         "duration_ms": duration_ms,
@@ -222,7 +251,7 @@ fn audit_step_to_json(step: &RunAuditStep) -> Value {
         "agent_response_json": null,
         "error_code": null,
         "error_message": step.error_message,
-        "outcome": step.outcome,
+        "outcome": outcome,
     })
 }
 

--- a/crates/orbit-web/src/api/tests/runs.rs
+++ b/crates/orbit-web/src/api/tests/runs.rs
@@ -785,3 +785,125 @@ async fn ship_endpoint_rejects_duplicate_task_ids() {
             .is_some_and(|message| message.contains("duplicate task id"))
     );
 }
+
+// ─── child-dispatch lineage in run detail [ORB-10971] ─────────────────────
+
+use orbit_types::workflow::{ChildDispatch, ChildDispatchPhase, PipelineState};
+
+/// A parent run whose `ship_leaves` step is blocked on a durably linked child.
+fn seed_parent_blocked_on_child(
+    runtime: &OrbitRuntime,
+    run_id: &str,
+    run_state: JobRunState,
+    phase: ChildDispatchPhase,
+) {
+    let run = seed_run(runtime, run_id, "workspace_auto_pipeline", run_state);
+    write_seeded_run(runtime, &run);
+    let mut state = PipelineState::new(
+        run_id.to_string(),
+        "workspace_auto_pipeline".to_string(),
+        json!({}),
+    );
+    state.record_child_dispatch(
+        ChildDispatch::submitted(
+            "jrun-child-leaves".to_string(),
+            "task_auto_pipeline".to_string(),
+            "invoke_and_wait".to_string(),
+            true,
+            false,
+            Utc::now(),
+        )
+        .with_parent_step_id(Some("ship_leaves".to_string())),
+    );
+    state.advance_child_dispatch("jrun-child-leaves", phase, None, None);
+    runtime
+        .write_run_state(run_id, &state)
+        .expect("seed parent run state");
+}
+
+#[test]
+fn run_detail_names_the_child_a_running_parent_is_blocked_on() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let run_id = "jrun-web-child-waiting";
+    seed_parent_blocked_on_child(
+        &runtime,
+        run_id,
+        JobRunState::Running,
+        ChildDispatchPhase::Waiting,
+    );
+    let run = runtime.show_job_run(run_id).expect("show run");
+
+    let detail = job_run_detail_to_json(&runtime, &run);
+    let dispatches = detail["run"]["child_dispatches"]
+        .as_array()
+        .expect("child_dispatches array");
+
+    assert_eq!(dispatches.len(), 1);
+    assert_eq!(dispatches[0]["child_run_id"], "jrun-child-leaves");
+    assert_eq!(dispatches[0]["job_name"], "task_auto_pipeline");
+    assert_eq!(dispatches[0]["parent_step_id"], "ship_leaves");
+    assert_eq!(dispatches[0]["phase"], "waiting");
+    assert_eq!(dispatches[0]["queued"], false);
+}
+
+#[test]
+fn run_detail_keeps_the_child_link_after_the_parent_terminalizes() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let run_id = "jrun-web-child-cancelled";
+    seed_parent_blocked_on_child(
+        &runtime,
+        run_id,
+        JobRunState::Cancelled,
+        ChildDispatchPhase::Terminal,
+    );
+    let run = runtime.show_job_run(run_id).expect("show run");
+
+    let detail = job_run_detail_to_json(&runtime, &run);
+    let dispatches = detail["run"]["child_dispatches"]
+        .as_array()
+        .expect("child_dispatches array");
+
+    assert_eq!(
+        dispatches.len(),
+        1,
+        "a cancelled parent must still name the child it left behind"
+    );
+    assert_eq!(dispatches[0]["child_run_id"], "jrun-child-leaves");
+}
+
+#[test]
+fn a_terminal_run_never_projects_an_unfinished_step_as_still_running() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let run_id = "jrun-web-cancelled-midstep";
+    // A parent killed inside its dispatch wait: `step_started` was audited,
+    // `step_finished` never was.
+    seed_v2_audit_events(
+        &runtime,
+        run_id,
+        vec![json!({
+            "event_type": "step.started",
+            "event_id": "evt-ship-leaves-started",
+            "ts": "2026-08-22T19:55:00Z",
+            "body_kind": "step_started",
+            "step_id": "ship_leaves"
+        })],
+    );
+    let run = seed_run(
+        &runtime,
+        run_id,
+        "workspace_auto_pipeline",
+        JobRunState::Cancelled,
+    );
+    write_seeded_run(&runtime, &run);
+
+    let detail = job_run_detail_to_json(&runtime, &run);
+    let steps = detail["steps"].as_array().expect("steps array");
+
+    assert_eq!(steps.len(), 1);
+    assert_eq!(steps[0]["target_id"], "ship_leaves");
+    assert_eq!(
+        steps[0]["state"], "cancelled",
+        "a step cannot outlive its own run"
+    );
+    assert_eq!(steps[0]["outcome"], "interrupted");
+}

--- a/crates/orbit-web/src/projections.rs
+++ b/crates/orbit-web/src/projections.rs
@@ -145,6 +145,16 @@ pub(crate) fn job_run_to_json(run: &JobRun) -> Value {
 
 pub(crate) fn job_run_to_json_with_state(run: &JobRun, state: Option<&PipelineState>) -> Value {
     let last = run.steps.last();
+    // [ORB-10971] Read child lineage from the full state, before the terminal
+    // filter below: a cancelled or failed parent must still name the children
+    // it dispatched. Waiting reasons keep the filter — they are momentary and
+    // mean nothing once the run stopped.
+    let child_dispatches = serde_json::to_value(
+        state
+            .map(|state| state.child_dispatches.as_slice())
+            .unwrap_or_default(),
+    )
+    .unwrap_or_else(|_| Value::Array(Vec::new()));
     let state = (!run.state.is_terminal()).then_some(state).flatten();
     let waiting_on_deps = state
         .and_then(|state| state.waiting_on_deps.as_ref())
@@ -153,6 +163,7 @@ pub(crate) fn job_run_to_json_with_state(run: &JobRun, state: Option<&PipelineSt
         .and_then(|state| state.waiting_on_locks.as_ref())
         .filter(|values| !values.is_empty());
     json!({
+        "child_dispatches": child_dispatches,
         "run_id": run.run_id,
         "job_id": run.job_id,
         "attempt": run.attempt,


### PR DESCRIPTION
## Task

[ORB-10971](https://orbit-cli.com/tasks/ORB-10971) — Make invoke_and_wait durably expose child dispatch before blocking

### Description

## Problem

`workspace_auto_pipeline` run `jrun-20260822-1955` remained in `ship_leaves` while no child dispatch was observable. Operator checks ruled out all three ordinary explanations: the child was not queued by `max_active_runs`, was not waiting on task dependencies or locks, and did not suffer a detached-worker startup failure.

The `invoke_and_wait` deterministic action currently combines two lifecycle phases in one opaque call. It invokes the child, keeps the returned `run_id` only in a local variable, and then blocks in `pipeline.wait`; the engine does not persist the activity output until the wait returns. A parent can therefore sit at `activity:ship_leaves` for up to the wait timeout with no durable child identifier or parent/child lineage. Operators cannot distinguish a successful child submission from a dispatch path wedged before persistence, and cancellation can leave the parent terminal while the activity still renders `running`.

## Why It Matters

`workspace_auto_pipeline` is the unattended leaf-dispatch path. Its dispatch boundary must be fail-observable: either a durable child run exists and is linked immediately, or the parent fails promptly with the exact pre-dispatch error. A one-hour opaque wait makes automation look dead and prevents safe diagnosis or cancellation.

## Constraints / Notes

- Preserve ORB-10819's blocking leaf contract: once a child is durably submitted, `ship_leaves` may continue waiting for its terminal result before the drain advances.
- Do not solve this only in dashboard JavaScript. Parent/child lineage and the dispatch checkpoint must be durable and available to CLI, MCP, API, and dashboard readers.
- Treat submission and waiting as separate observable phases even if `invoke_and_wait` remains one activity.
- Do not infer a child from task status or timestamps; persist the exact child run ID returned by `orbit.pipeline.invoke`.
- A cancelled parent must retain the child link and show the wait step as terminal rather than indefinitely `running`; whether cancellation cascades to the child must be explicit and tested, not accidental.
- Cover the reported negative fixture: capacity available, no dependency/lock wait, and a healthy worker-startup path.

### Acceptance Criteria

- A deterministic workspace_auto_pipeline fixture with eligible loose leaves, available task_auto_pipeline capacity, no dependency or lock conflicts, and successful worker startup persists a task_auto_pipeline child run before ship_leaves begins its blocking wait.
- Immediately after child submission and while the child is still running, orbit workflow run observation and the dashboard expose the exact child run ID, job name, submitted/queued state, and parent step linkage.
- If orbit.pipeline.invoke cannot produce a durable child run, ship_leaves reaches a terminal failed state within a bounded interval and records the concrete invocation error; it never remains running until the one-hour wait timeout.
- The blocking leaf contract is preserved: after the durable dispatch checkpoint, ship_leaves waits for the linked child and returns its terminal status to pipeline_success_guard.
- Cancelling the parent while it waits preserves the child linkage, terminalizes the parent step/activity projection, and applies a documented, tested child-cancellation policy.
- CLI/MCP run detail, dashboard API/UI, and raw audit evidence agree on parent state, child state, and lineage throughout submit, wait, success/failure, and cancellation fixtures.
- Focused runtime, pipeline-action, run-detail API, and dashboard tests pass together with make ci-fast and make ci-lint.

## Execution Summary

<details>
<summary>Click to expand</summary>

Execution summary derived by Orbit for ORB-10971 from the change delivered by run jrun-20260822-2138-7; no execution summary was persisted by the implementing agent.

Changed files (28):
- modified: crates/orbit-cli/src/command/run/format.rs
- modified: crates/orbit-cli/src/command/run/job.rs
- modified: crates/orbit-cli/src/command/run/steps.rs
- modified: crates/orbit-cli/src/command/run/tests/format.rs
- modified: crates/orbit-cli/src/command/run/tests/job.rs
- modified: crates/orbit-core/assets/activities/invoke_and_wait.yaml
- added: crates/orbit-core/src/adapter/engine_host/v2_host/child_dispatch.rs
- modified: crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
- modified: crates/orbit-core/src/adapter/engine_host/v2_host/mod.rs
- modified: crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs
- modified: crates/orbit-core/src/adapter/engine_host/v2_host/tests/pipeline_actions.rs
- modified: crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
- modified: crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
- modified: crates/orbit-core/src/application/job/run/actions.rs
- modified: crates/orbit-core/src/application/job/run/tests/actions.rs
- modified: crates/orbit-engine/src/activity_job/dispatcher.rs
- modified: crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
- modified: crates/orbit-engine/src/activity_job/job_executor/tests/resume.rs
- added: crates/orbit-types/src/workflow/child_dispatch.rs
- modified: crates/orbit-types/src/workflow/mod.rs
- modified: crates/orbit-types/src/workflow/run_state.rs
- modified: crates/orbit-types/src/workflow/tests/mod.rs
- added: crates/orbit-types/src/workflow/tests/run_state.rs
- modified: crates/orbit-web/assets/dashboard/dashboard.css
- modified: crates/orbit-web/assets/dashboard/run-detail.js
- ... and 3 more file(s)

This restates the worktree change the delivery commit contains and asserts nothing beyond it. Re-check it with `git show --stat` on the delivery commit.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10971-6a8a16ea`
- Behind base: 0
- Ahead of base: 1