### PR TITLE
Dashboard renders the Diagnostics subtabs twice (duplicate id="diag-subtabs") after the ORB-10972 rail

### DIFF
--- a/crates/orbit-web/assets/dashboard/index.html
+++ b/crates/orbit-web/assets/dashboard/index.html
@@ -212,14 +212,6 @@
               <span id="diag-title">Diagnostics</span>
               <span class="count" id="diag-count">-</span>
             </header>
-            <nav class="subtabs" id="diag-subtabs">
-              <button class="subtab" data-subtab="runs" type="button">Recent Runs</button>
-              <button class="subtab" data-subtab="metrics" type="button">Metrics</button>
-              <button class="subtab" data-subtab="errors" type="button">Errors</button>
-              <button class="subtab" data-subtab="incidents" type="button">Incidents</button>
-              <button class="subtab" data-subtab="reliability" type="button">Reliability</button>
-              <button class="subtab" data-subtab="scoreboard" type="button">Scoreboard</button>
-            </nav>
             <div class="body scoreboard-table-wrap" id="diag-body" style="display: none;">
               <div class="skeleton-state">
                 <div class="skeleton skeleton-row"></div>

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -1143,9 +1143,10 @@ fn dashboard_nav_rail_preserves_the_router_selector_contract() {
         index.contains(r#"<div class="tabs" id="tabs">"#),
         "the router appends its indicator to .tabs; the container must remain"
     );
-    assert!(
-        index.contains(r#"id="diag-subtabs""#),
-        "Diagnostics' subtabs keep their id, now as visible rail children"
+    assert_eq!(
+        index.matches(r#"id="diag-subtabs""#).count(),
+        1,
+        "Diagnostics' subtabs must keep exactly one id, now as visible rail children"
     );
     assert!(
         css.contains(".rail .tab-indicator { display: none !important; }"),


### PR DESCRIPTION
## Task

[ORB-10976](https://orbit-cli.com/tasks/ORB-10976) — Dashboard renders the Diagnostics subtabs twice (duplicate id="diag-subtabs") after the ORB-10972 rail

### Description

## Summary

ORB-10972 moved the dashboard's top-level nav into a left rail; its plan says the Diagnostics subtabs element is "moved not rebuilt". The implementation added the rail copy but left the original nav in place, so the served HTML now contains **two** elements with `id="diag-subtabs"`.

Verified still present at `agent-main` HEAD `edfd96c8`.

## Evidence

`crates/orbit-web/assets/dashboard/index.html` (`grep -c 'id="diag-subtabs"'` → 2):

- line 42 — `<nav class="subtabs rail-subtabs" id="diag-subtabs" aria-label="Diagnostics views">` (new rail nav, always visible)
- line 215 — `<nav class="subtabs" id="diag-subtabs">` (original nav, still nested inside `#diagnostics-panel`, never removed)

Duplicate `id` attributes are invalid HTML, and here they change behavior:

- No CSS hides the inner copy (`.subtabs` is `display: flex`, and `.tab-pane.active` is `display: block`), so selecting the Diagnostics tab renders the six subtab buttons (Recent Runs / Metrics / Errors / Incidents / Reliability / Scoreboard) a second time inside the panel body, in addition to the always-visible rail copy.
- `crates/orbit-web/assets/dashboard/router.js` mixes selector styles on this id. `document.querySelectorAll("#diag-subtabs .subtab")` (router.js:86, router.js:314) matches buttons in **both** nodes, so both sets get click handlers and `.active` toggling. But `const diagSubtabs = $("diag-subtabs")` (router.js:228, `$` = `getElementById`) resolves only the first node in document order (the rail one), so the "dimmed while another tab is active" treatment added by the same commit never applies to the leftover inner nav. `router.js:91` appends the subtab indicator to `querySelector("#diag-subtabs")` — also only the first node.

The test shipped with that change, `dashboard_nav_rail_preserves_the_router_selector_contract` (`crates/orbit-web/src/tests/dashboard_assets.rs:1147`), only asserts `index.contains(r#"id="diag-subtabs""#)` — a substring check that passes whether the id appears once or twice — so `cargo test -p orbit-web` gave false confidence.

## Reproduction

1. `cargo build -p orbit-cli --bin orbit`
2. `./target/debug/orbit web serve --port 7899 --no-open`
3. `curl -s http://127.0.0.1:7899/ | grep -c 'id="diag-subtabs"'` → `2`
4. In a browser, open the dashboard and click the **Diagnostics** top-level tab: the subtab row appears twice — once in the left rail (expected) and again inside the Diagnostics panel body (leftover).

## Suggested fix

Delete the superseded `<nav class="subtabs" id="diag-subtabs">…</nav>` block at `index.html:215-222`. Strengthen `dashboard_nav_rail_preserves_the_router_selector_contract` to assert the occurrence count of `id="diag-subtabs"` is exactly 1.

## Provenance

Found by the QA sweep for ORB-10974 (run `jrun-20260822-2138-10`, crew `sonnet`), which could not file it: every mutating `orbit` call in that jrun sandbox failed closed — the workspace `.orbit` is mounted read-only, so migration v15 (`invocation_audit_context`) is skipped and audit writes fail with `table audit_events has no column named trace_id`; writes also misroute to the worktree-local root and report `task_not_found`. See friction F2026-08-109. The same wall left ORB-10974 without a persisted `execution_summary`, blocking its delivery gate. Filed manually from the run transcript and re-verified against HEAD.

### Acceptance Criteria

- The served dashboard HTML contains exactly one element with id="diag-subtabs"; the Diagnostics tab shows a single subtab row.
- dashboard_assets.rs asserts the occurrence count of id="diag-subtabs" is exactly 1, so a reintroduced duplicate fails without a live browser.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Removed the superseded Diagnostics subtabs nav from crates/orbit-web/assets/dashboard/index.html, leaving the single rail-owned #diag-subtabs element and its six buttons.
- Updated dashboard_nav_rail_preserves_the_router_selector_contract in crates/orbit-web/src/tests/dashboard_assets.rs to assert index.matches(r#"id=\"diag-subtabs\""#).count() == 1.
Validation:
- Served asset occurrence check: id="diag-subtabs" count=1.
- Focused test: cargo test -p orbit-web dashboard_nav_rail_preserves_the_router_selector_contract (1 passed).
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check: passed.
Assessment: Minimal scoped fix; the rail navigation and router selector contract remain intact, while the regression test now fails on any duplicate id.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10976-6a8a21f6`
- Behind base: 0
- Ahead of base: 1