### PR TITLE
Dashboard: long expanded task detail is clipped and unscrollable in the Tasks pane

### DIFF
--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -439,6 +439,9 @@
         height: 100%;
         align-items: stretch;
       }
+      .main-col > .tab-pane[data-tab="tasks"] .col-tasks {
+        min-height: 0;
+      }
       .main-col > .tab-pane[data-tab="tasks"] .col-tasks > .panel {
         flex: 1 1 auto;
         display: flex;

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -1120,6 +1120,11 @@ fn dashboard_log_dock_has_two_modes_and_an_always_on_status_bar() {
         css.contains("#tasks-panel > .body") && css.contains("min-height: 240px;"),
         "the task list must keep a guaranteed minimum usable height"
     );
+    assert!(
+        css.contains(".main-col > .tab-pane[data-tab=\"tasks\"] .col-tasks")
+            && css.contains(".col-tasks {\n        min-height: 0;"),
+        "the tasks column must be allowed to shrink so #tasks-body can scroll"
+    );
 }
 
 /// ORB-10972: the top-level nav is a left rail, and the vertical chrome above


### PR DESCRIPTION
## Task

[ORB-10975](https://orbit-cli.com/tasks/ORB-10975) — Dashboard: long expanded task detail is clipped and unscrollable in the Tasks pane

### Description

## Symptom

Expanding a task with a long detail body in the Tasks pane cuts the detail off at the bottom of the window. There is no way to scroll to the rest of it — not the task list, not the pane, not the page.

Introduced by the ORB-10972 shell redesign (PR danieljhkim/orbit#1107), which moved scrolling from the document to the content column. Before that change the document scrolled, so an over-tall detail was always reachable.

## Root cause

`.col-tasks` in [index.html:90](crates/orbit-web/assets/dashboard/index.html) is an inline-styled flex column (`display: flex; flex-direction: column; min-width: 0;`) and is a **grid item** of `main.tasks-layout`. It has no `min-height: 0`, so it keeps the CSS grid automatic minimum size (`min-height: auto`) and sizes to its content instead of to the row.

The consequence is that `#tasks-body`'s `overflow-y: auto` never engages: nothing bounds its height, so it just grows. The overflow instead lands on `main.tasks-layout` / `.tab-pane[data-tab="tasks"]`, and that pane is `overflow: hidden` (dashboard.css:437) — so the excess is clipped with no scroller anywhere in the chain.

### Measured (1280x720, 6 rows + a 1200px expanded detail)

| Element | clientHeight | scrollable | overflow-y |
|---|---|---|---|
| `#tasks-body` | 1420 | **0** | auto |
| `.col-tasks` | 1574 | 0 | visible (`min-height: auto`) |
| `main.tasks-layout` | 638 | 956 | visible |
| `.tab-pane.active` | 638 | **956 clipped** | hidden |

The bottom of the detail sits at y=1038 in a 720px viewport, off-screen and unreachable.

## Fix

Give `.col-tasks` `min-height: 0` so the grid item can shrink to the row and `#tasks-body` becomes the real scroller.

Verified in-browser by setting it live:

- 720px viewport: `#tasks-body` becomes 445px tall with 975px of scroll; pane clipping drops to 0; the detail's bottom becomes reachable.
- 560px viewport: 285px tall, 1135px of scroll, nothing clipped — the ORB-10874 `min-height: 240px` floor on `#tasks-body` is still honored and does not re-introduce overflow.

`#side-dock` already carries an explicit `min-height: 0` and is unaffected (measured 0 clipping in both states).

Prefer moving the declaration into the ORB-10972 block in dashboard.css (near `.main-col > .tab-pane[data-tab="tasks"] .col-tasks > .panel`, dashboard.css:442) rather than extending the inline style, so the layout contract lives in one place.

## Regression guard

The asset-source string tests in `crates/orbit-web/src/tests/dashboard_assets.rs` are the only test surface for the dashboard (no JS runner). Add an assertion that the tasks column declares `min-height: 0`, alongside the existing ORB-10972 layout assertions, so the scroll chain is not silently broken again.

### Acceptance Criteria

- Expanding a task whose detail exceeds the viewport in the Tasks pane leaves the full detail reachable by scrolling; the bottom of the detail can be brought into view.
- `#tasks-body` is the scroller: its scrollHeight exceeds its clientHeight when content overflows, and `.tab-pane[data-tab="tasks"]` clips 0px.
- Holds at both 1280x720 and a short 1280x560 viewport, with the ORB-10874 240px minimum on `#tasks-body` still honored.
- The right dock (`#side-dock`) keeps its full height and its own independent scrolling in both Status and Log modes; the task table does not reflow.
- A test in crates/orbit-web/src/tests/dashboard_assets.rs asserts the tasks column's `min-height: 0`, and `cargo test -p orbit-web` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added min-height: 0 to the Tasks pane grid column in the existing ORB-10972 dashboard CSS layout block, allowing the column to shrink so #tasks-body becomes the bounded vertical scroller.
- Added an asset-source regression assertion in dashboard_assets.rs for the tasks column shrink contract.
Assessment: Small, scoped fix preserves the existing 240px task-body minimum and the independent right-dock layout; no unrelated files changed.
Validation:
- cargo test -p orbit-web (259 passed; doc-tests passed)
- git diff --check
- No commit created; pipeline owns handoff.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10975-6a8a2327`
- Behind base: 0
- Ahead of base: 1