### PR TITLE
Restore automatic workspace propagation for orbit.task.update

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,10 +252,11 @@ Cursor loads the same `plugin/skills/orbit` tree and `npx -y @orbit-tools/cli@la
 </details>
 
 > **Cowork users:** Orbit advertises its canonical MCP surface independently of the
-> server's launch directory. Workspace routing comes from MCP initialize/session
-> context or an explicit registered `workspace` on the tool call. Do not add the
-> global `--root` flag to `orbit mcp serve`; the server rejects launch-root routing
-> so a scratchpad cwd cannot silently select the wrong workspace.
+> server's launch directory. Workspace routing comes from the server's
+> `--workspace` binding, MCP initialize/session context, or an explicit registered
+> `workspace` on the tool call — never from cwd. Do not add the global `--root`
+> flag to `orbit mcp serve`; the server rejects launch-root routing so a
+> scratchpad cwd cannot silently select the wrong workspace.
 
 ---
 
@@ -276,7 +277,9 @@ First-time onboarding (`.orbit/` absent) and "what is orbit" tour requests are h
 
 ## Orbit MCP Surface
 
-`orbit workspace init --mcp` registers the Orbit MCP server with the local agent CLI (Claude Code, Codex, Gemini), same as the plugin. The registered server launches as `orbit mcp serve --operator`: it holds **operator authority**, so governed operations — dispatching a workflow (`orbit.workflow.ship`), observing/resuming a run, and `orbit.command.exec` — are authorized through it. Bare `orbit mcp serve` (and every worker/agent-launched MCP session) stays agent-only and is refused those governed tools; `orbit mcp init` also stays agent-only unless you pass `--operator` at the `orbit mcp serve` layer yourself.
+`orbit workspace init --mcp` registers the Orbit MCP server with the local agent CLI (Claude Code, Codex, Gemini), same as the plugin. The registered server launches as `orbit mcp serve --operator --workspace <ws_id>`: it holds **operator authority**, so governed operations — dispatching a workflow (`orbit.workflow.ship`), observing/resuming a run, and `orbit.command.exec` — are authorized through it. Bare `orbit mcp serve` (and every worker/agent-launched MCP session) stays agent-only and is refused those governed tools; `orbit mcp init` also stays agent-only unless you pass `--operator` at the `orbit mcp serve` layer yourself.
+
+`--workspace` is the workspace binding: most MCP clients cannot announce one at initialize, so the generated integration names the workspace it was registered for and workspace-scoped tools route without repeating a selector on every call. An explicit `workspace` on a tool call still overrides it, and a server launched without a binding still refuses a workspace-scoped call that names no workspace.
 
 `tools/list` is the authoritative MCP reference. Orbit composes that surface from
 the explicitly MCP-registered builtins in `orbit-tools` plus the two discovery

--- a/crates/orbit-cli/src/command/mcp/command.rs
+++ b/crates/orbit-cli/src/command/mcp/command.rs
@@ -99,6 +99,19 @@ pub struct ServeArgs {
     /// authority to an agent's server by accident.
     #[arg(long, conflicts_with = "mode")]
     pub operator: bool,
+    /// Bind this server's sessions to a registered workspace: a workspace
+    /// name, a logical workspace ID (`ws_*`), or an absolute registered
+    /// checkout path.
+    ///
+    /// Most MCP clients cannot announce `_meta.orbit.workspace` on their
+    /// initialize, so without this a workspace-scoped tool must repeat the
+    /// selector on every call. `orbit mcp init` and `orbit workspace init
+    /// --mcp` write this into the integrations they generate. A client that
+    /// does announce a workspace, and any explicit per-call `workspace`,
+    /// still take precedence. The selector is resolved against the accepting
+    /// server's registry per call, never from the server process cwd.
+    #[arg(long, value_name = "SELECTOR", conflicts_with = "mode")]
+    pub workspace: Option<String>,
 }
 
 impl ServeArgs {
@@ -129,6 +142,7 @@ impl ServeArgs {
                 } else {
                     McpSessionAuthority::Agent
                 },
+                self.workspace,
             )?,
         }
         Ok(CommandOutput::Silent)

--- a/crates/orbit-cli/src/command/mcp/server.rs
+++ b/crates/orbit-cli/src/command/mcp/server.rs
@@ -27,8 +27,10 @@ const TASK_SHOW_TOOL: &str = "orbit.task.show";
 pub(super) fn serve_mcp_stdio(
     remote_caller_machine_id: Option<String>,
     authority: McpSessionAuthority,
+    bound_workspace: Option<String>,
 ) -> Result<(), OrbitError> {
-    let (host, session_context) = compose_server(remote_caller_machine_id, authority)?;
+    let (host, session_context) =
+        compose_server(remote_caller_machine_id, authority, bound_workspace)?;
     block_on_server(orbit_mcp::serve_stdio_with_context(host, session_context))
 }
 
@@ -43,7 +45,10 @@ pub(super) fn serve_mcp_listener(
     // For the same reason the socket serves agent authority only: it
     // authenticates no client, so every accepted connection would otherwise
     // inherit whatever authority the listening process was started with.
-    let (host, session_context) = compose_server(None, McpSessionAuthority::Agent)?;
+    //
+    // For the same reason it binds no workspace: a socket is shared by
+    // whoever can reach it, so each session names its own workspace.
+    let (host, session_context) = compose_server(None, McpSessionAuthority::Agent, None)?;
     block_on_server(async move {
         let listener = McpListener::bind(addr, exposure, host, session_context).await?;
         tracing::info!(address = %listener.local_addr()?, "orbit mcp listener bound");
@@ -52,15 +57,29 @@ pub(super) fn serve_mcp_listener(
 }
 
 /// Build the one MCP host this process serves, together with the trusted
-/// session envelope derived from the accepting machine's identity and the
-/// authority this process was started with.
+/// session envelope derived from the accepting machine's identity, the
+/// authority this process was started with, and the workspace it was launched
+/// for.
+///
+/// `bound_workspace` is the launching configuration's answer to "which
+/// workspace is this server for" — the same selector a client could announce
+/// at initialize, supplied by whoever wrote the integration because most MCP
+/// clients cannot announce anything. It is still just a selector: it is
+/// resolved against this machine's registry on every call and overridden by an
+/// explicit per-call `workspace`.
 fn compose_server(
     remote_caller_machine_id: Option<String>,
     authority: McpSessionAuthority,
+    bound_workspace: Option<String>,
 ) -> Result<(Arc<dyn McpHost>, ToolSessionContext), OrbitError> {
     let global_root = resolve_global_root()?;
-    let identity =
+    let mut identity =
         orbit_mcp::mcp_server_identity(&global_root, remote_caller_machine_id, authority)?;
+    identity.session_context.workspace = bound_workspace
+        .as_deref()
+        .map(str::trim)
+        .filter(|selector| !selector.is_empty())
+        .map(ToOwned::to_owned);
     let host = Arc::new(ServerMcpHost::new(
         global_root,
         identity.process_machine_id,

--- a/crates/orbit-cli/src/command/mcp/setup/args.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/args.rs
@@ -4,7 +4,8 @@ use clap::{Args, ValueEnum};
 use orbit_core::OrbitError;
 
 use super::dispatch::{print_action_summary, run_action};
-use super::workspace::{env_home_dir, resolve_workspace_layout};
+use super::providers::ServerLaunch;
+use super::workspace::{env_home_dir, registered_workspace_id, resolve_workspace_layout};
 use crate::command::{CommandOut, CommandOutput};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
@@ -42,22 +43,19 @@ impl McpProvider {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(super) enum McpAction {
-    /// `operator` selects the argv authority flag written into the generated
-    /// server entry: `true` emits `mcp serve --operator`, `false` emits plain
-    /// `mcp serve`. Carrying it on the variant (rather than as a separate
-    /// `run_action` parameter) makes every call site name its authority
-    /// explicitly instead of inheriting a default.
-    Init {
-        operator: bool,
-    },
+pub(super) enum McpAction<'a> {
+    /// [`ServerLaunch`] is the argv identity written into the generated server
+    /// entry: its authority flag and its workspace binding. Carrying it on the
+    /// variant (rather than as separate `run_action` parameters) makes every
+    /// call site state both explicitly instead of inheriting a default.
+    Init(ServerLaunch<'a>),
     Remove,
 }
 
-impl McpAction {
+impl McpAction<'_> {
     pub(super) fn label(self) -> &'static str {
         match self {
-            Self::Init { .. } => "init",
+            Self::Init(_) => "init",
             Self::Remove => "remove",
         }
     }
@@ -187,15 +185,20 @@ impl InitArgs {
         // Bare `orbit mcp init` keeps its pre-existing agent-only authority;
         // only the `orbit workspace init --mcp` bootstrap path (below, via
         // `init_auto_for_workspace`) selects operator authority.
+        let workspace_id = registered_workspace_id(&layout.repo_root);
+        let launch = ServerLaunch {
+            operator: false,
+            workspace: workspace_id.as_deref(),
+        };
         let providers = run_action(
-            McpAction::Init { operator: false },
+            McpAction::Init(launch),
             &layout.repo_root,
             &layout.orbit_root,
             self.providers.resolve_mode()?,
             env_home_dir(),
             self.scope,
         )?;
-        print_action_summary(McpAction::Init { operator: false }, &providers);
+        print_action_summary(McpAction::Init(launch), &providers);
         Ok(CommandOutput::Silent)
     }
 }
@@ -229,6 +232,7 @@ impl RemoveArgs {
 pub(crate) fn init_auto_for_workspace(
     repo_root: &Path,
     orbit_root: &Path,
+    workspace_id: &str,
 ) -> Result<Vec<String>, OrbitError> {
     // `orbit workspace init` is a per-workspace setup, so its auto-MCP path
     // writes repo-local files. `orbit mcp init` defaults to workspace scope
@@ -238,8 +242,14 @@ pub(crate) fn init_auto_for_workspace(
     // explicit `--mcp` request from `orbit workspace init` is treated as
     // deliberate operator setup, so the registered server is authorized for
     // governed operations such as `orbit.workflow.ship` and `orbit.command.exec`.
+    //
+    // The workspace being registered is known here, so the generated server is
+    // bound to it directly rather than re-derived from the checkout.
     run_action(
-        McpAction::Init { operator: true },
+        McpAction::Init(ServerLaunch {
+            operator: true,
+            workspace: Some(workspace_id),
+        }),
         repo_root,
         orbit_root,
         ProviderSelectionMode::Auto,

--- a/crates/orbit-cli/src/command/mcp/setup/dispatch.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/dispatch.rs
@@ -6,7 +6,7 @@ use super::args::{McpAction, McpProvider, ProviderSelectionMode, ScopeArg};
 use super::providers::*;
 
 pub(super) fn run_action(
-    action: McpAction,
+    action: McpAction<'_>,
     repo_root: &Path,
     orbit_root: &Path,
     selection: ProviderSelectionMode,
@@ -17,36 +17,28 @@ pub(super) fn run_action(
     for provider in &providers {
         let target = ConfigTarget::resolve(scope, provider, repo_root, home_dir.as_deref())?;
         match (action, provider) {
-            (McpAction::Init { operator }, McpProvider::Claude) => {
-                apply_claude_init(&target, operator)?
-            }
+            (McpAction::Init(launch), McpProvider::Claude) => apply_claude_init(&target, launch)?,
             (McpAction::Remove, McpProvider::Claude) => apply_claude_remove(&target)?,
-            (McpAction::Init { operator }, McpProvider::Codex) => {
-                apply_codex_init(&target, operator)?
-            }
+            (McpAction::Init(launch), McpProvider::Codex) => apply_codex_init(&target, launch)?,
             (McpAction::Remove, McpProvider::Codex) => apply_codex_remove(&target)?,
-            (McpAction::Init { operator }, McpProvider::Gemini) => {
-                apply_gemini_init(&target, operator)?
-            }
+            (McpAction::Init(launch), McpProvider::Gemini) => apply_gemini_init(&target, launch)?,
             (McpAction::Remove, McpProvider::Gemini) => apply_gemini_remove(&target)?,
-            (McpAction::Init { operator }, McpProvider::Grok) => {
-                apply_grok_init(&target, operator)?
-            }
+            (McpAction::Init(launch), McpProvider::Grok) => apply_grok_init(&target, launch)?,
             (McpAction::Remove, McpProvider::Grok) => apply_grok_remove(&target)?,
-            (McpAction::Init { operator }, McpProvider::Cursor) => {
-                apply_simple_json_init(&target, "mcpServers", operator)?
+            (McpAction::Init(launch), McpProvider::Cursor) => {
+                apply_simple_json_init(&target, "mcpServers", launch)?
             }
             (McpAction::Remove, McpProvider::Cursor) => {
                 apply_simple_json_remove(&target, "mcpServers")?
             }
-            (McpAction::Init { operator }, McpProvider::Vscode) => {
-                apply_simple_json_init(&target, "servers", operator)?
+            (McpAction::Init(launch), McpProvider::Vscode) => {
+                apply_simple_json_init(&target, "servers", launch)?
             }
             (McpAction::Remove, McpProvider::Vscode) => {
                 apply_simple_json_remove(&target, "servers")?
             }
-            (McpAction::Init { operator }, McpProvider::Windsurf) => {
-                apply_simple_json_init(&target, "mcpServers", operator)?
+            (McpAction::Init(launch), McpProvider::Windsurf) => {
+                apply_simple_json_init(&target, "mcpServers", launch)?
             }
             (McpAction::Remove, McpProvider::Windsurf) => {
                 apply_simple_json_remove(&target, "mcpServers")?
@@ -265,7 +257,7 @@ pub(super) fn auto_detected_providers(
     providers
 }
 
-pub(super) fn print_action_summary(action: McpAction, providers: &[McpProvider]) {
+pub(super) fn print_action_summary(action: McpAction<'_>, providers: &[McpProvider]) {
     if providers.is_empty() {
         println!("mcp {}: no providers selected", action.label());
         return;

--- a/crates/orbit-cli/src/command/mcp/setup/providers/claude.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/claude.rs
@@ -6,17 +6,17 @@ use crate::command::mcp::{ORBIT_MCP_SERVER_ID, safe_mcp_tool_names};
 
 use super::super::dispatch::ConfigTarget;
 use super::super::format::*;
-use super::common::server_args;
+use super::common::{ServerLaunch, server_args};
 
 pub(in crate::command::mcp::setup) fn apply_claude_init(
     target: &ConfigTarget,
-    operator: bool,
+    launch: ServerLaunch<'_>,
 ) -> Result<(), OrbitError> {
     let mut root = load_json_object(&target.mcp_path)?;
     let mcp_servers = ensure_json_object(&mut root, "mcpServers")?;
     mcp_servers.insert(
         ORBIT_MCP_SERVER_ID.to_string(),
-        claude_mcp_server_value(operator),
+        claude_mcp_server_value(launch),
     );
     write_json_object(&target.mcp_path, &root)?;
 
@@ -79,7 +79,7 @@ pub(in crate::command::mcp::setup) fn apply_claude_remove(
     Ok(())
 }
 
-pub(super) fn claude_mcp_server_value(operator: bool) -> JsonValue {
+pub(super) fn claude_mcp_server_value(launch: ServerLaunch<'_>) -> JsonValue {
     JsonValue::Object(JsonMap::from_iter([
         (
             "command".to_string(),
@@ -88,7 +88,7 @@ pub(super) fn claude_mcp_server_value(operator: bool) -> JsonValue {
         (
             "args".to_string(),
             JsonValue::Array(
-                server_args(operator)
+                server_args(launch)
                     .into_iter()
                     .map(JsonValue::String)
                     .collect(),

--- a/crates/orbit-cli/src/command/mcp/setup/providers/codex.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/codex.rs
@@ -5,17 +5,17 @@ use crate::command::mcp::ORBIT_MCP_SERVER_ID;
 
 use super::super::dispatch::ConfigTarget;
 use super::super::format::*;
-use super::common::server_args;
+use super::common::{ServerLaunch, server_args};
 
 pub(in crate::command::mcp::setup) fn apply_codex_init(
     target: &ConfigTarget,
-    operator: bool,
+    launch: ServerLaunch<'_>,
 ) -> Result<(), OrbitError> {
     let mut root = load_toml_table(&target.mcp_path)?;
     let mcp_servers = ensure_toml_table(&mut root, "mcp_servers")?;
     mcp_servers.insert(
         ORBIT_MCP_SERVER_ID.to_string(),
-        TomlValue::Table(codex_mcp_server_table(operator)),
+        TomlValue::Table(codex_mcp_server_table(launch)),
     );
     write_toml_table(&target.mcp_path, &root)
 }
@@ -36,7 +36,7 @@ pub(in crate::command::mcp::setup) fn apply_codex_remove(
     write_or_remove_toml_table(&target.mcp_path, &root)
 }
 
-pub(super) fn codex_mcp_server_table(operator: bool) -> TomlTable {
+pub(super) fn codex_mcp_server_table(launch: ServerLaunch<'_>) -> TomlTable {
     TomlTable::from_iter([
         (
             "command".to_string(),
@@ -45,7 +45,7 @@ pub(super) fn codex_mcp_server_table(operator: bool) -> TomlTable {
         (
             "args".to_string(),
             TomlValue::Array(
-                server_args(operator)
+                server_args(launch)
                     .into_iter()
                     .map(TomlValue::String)
                     .collect(),

--- a/crates/orbit-cli/src/command/mcp/setup/providers/common.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/common.rs
@@ -1,14 +1,31 @@
-/// The argv a generated client config launches Orbit's MCP server with.
+/// The launch identity a generated client config is written for.
 ///
-/// `operator` is the one authority signal threaded through config generation:
-/// `true` produces `mcp serve --operator` (the `orbit workspace init --mcp`
-/// bootstrap path), `false` produces plain `mcp serve` (bare `orbit mcp
-/// init`). Every caller passes it explicitly so no registration path silently
-/// upgrades.
-pub(super) fn server_args(operator: bool) -> Vec<String> {
+/// Both fields answer "what is this integration for", and both are decided by
+/// the registration path rather than by the client that later connects. Every
+/// caller names them explicitly so no path silently upgrades authority or
+/// silently drops the workspace binding.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(in crate::command::mcp::setup) struct ServerLaunch<'a> {
+    /// `true` produces `mcp serve --operator` (the `orbit workspace init
+    /// --mcp` bootstrap path), `false` produces plain `mcp serve` (bare
+    /// `orbit mcp init`).
+    pub(in crate::command::mcp::setup) operator: bool,
+    /// The workspace this integration was registered for, emitted as
+    /// `--workspace <selector>`. `None` when the checkout is not registered on
+    /// this machine, leaving the generated session unbound and every
+    /// workspace-scoped call responsible for its own selector.
+    pub(in crate::command::mcp::setup) workspace: Option<&'a str>,
+}
+
+/// The argv a generated client config launches Orbit's MCP server with.
+pub(super) fn server_args(launch: ServerLaunch<'_>) -> Vec<String> {
     let mut args = vec!["mcp".to_string(), "serve".to_string()];
-    if operator {
+    if launch.operator {
         args.push("--operator".to_string());
+    }
+    if let Some(workspace) = launch.workspace {
+        args.push("--workspace".to_string());
+        args.push(workspace.to_string());
     }
     args
 }

--- a/crates/orbit-cli/src/command/mcp/setup/providers/gemini.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/gemini.rs
@@ -1,13 +1,14 @@
 use orbit_core::OrbitError;
 
 use super::super::dispatch::ConfigTarget;
+use super::common::ServerLaunch;
 use super::simple_json::{apply_simple_json_init, apply_simple_json_remove};
 
 pub(in crate::command::mcp::setup) fn apply_gemini_init(
     target: &ConfigTarget,
-    operator: bool,
+    launch: ServerLaunch<'_>,
 ) -> Result<(), OrbitError> {
-    apply_simple_json_init(target, "mcpServers", operator)
+    apply_simple_json_init(target, "mcpServers", launch)
 }
 
 pub(in crate::command::mcp::setup) fn apply_gemini_remove(

--- a/crates/orbit-cli/src/command/mcp/setup/providers/grok.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/grok.rs
@@ -5,17 +5,17 @@ use crate::command::mcp::ORBIT_MCP_SERVER_ID;
 
 use super::super::dispatch::ConfigTarget;
 use super::super::format::*;
-use super::common::server_args;
+use super::common::{ServerLaunch, server_args};
 
 pub(in crate::command::mcp::setup) fn apply_grok_init(
     target: &ConfigTarget,
-    operator: bool,
+    launch: ServerLaunch<'_>,
 ) -> Result<(), OrbitError> {
     let mut root = load_toml_table(&target.mcp_path)?;
     let mcp_servers = ensure_toml_table(&mut root, "mcp_servers")?;
     mcp_servers.insert(
         ORBIT_MCP_SERVER_ID.to_string(),
-        TomlValue::Table(grok_mcp_server_table(operator)),
+        TomlValue::Table(grok_mcp_server_table(launch)),
     );
     write_toml_table(&target.mcp_path, &root)
 }
@@ -36,7 +36,7 @@ pub(in crate::command::mcp::setup) fn apply_grok_remove(
     write_or_remove_toml_table(&target.mcp_path, &root)
 }
 
-pub(super) fn grok_mcp_server_table(operator: bool) -> TomlTable {
+pub(super) fn grok_mcp_server_table(launch: ServerLaunch<'_>) -> TomlTable {
     TomlTable::from_iter([
         (
             "command".to_string(),
@@ -45,7 +45,7 @@ pub(super) fn grok_mcp_server_table(operator: bool) -> TomlTable {
         (
             "args".to_string(),
             TomlValue::Array(
-                server_args(operator)
+                server_args(launch)
                     .into_iter()
                     .map(TomlValue::String)
                     .collect(),

--- a/crates/orbit-cli/src/command/mcp/setup/providers/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/mod.rs
@@ -7,6 +7,7 @@ mod simple_json;
 
 pub(super) use self::claude::{apply_claude_init, apply_claude_remove};
 pub(super) use self::codex::{apply_codex_init, apply_codex_remove};
+pub(super) use self::common::ServerLaunch;
 pub(super) use self::gemini::{apply_gemini_init, apply_gemini_remove};
 pub(super) use self::grok::{apply_grok_init, apply_grok_remove};
 pub(super) use self::simple_json::{apply_simple_json_init, apply_simple_json_remove};

--- a/crates/orbit-cli/src/command/mcp/setup/providers/simple_json.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/simple_json.rs
@@ -5,18 +5,18 @@ use crate::command::mcp::ORBIT_MCP_SERVER_ID;
 
 use super::super::dispatch::ConfigTarget;
 use super::super::format::*;
-use super::common::server_args;
+use super::common::{ServerLaunch, server_args};
 
 pub(in crate::command::mcp::setup) fn apply_simple_json_init(
     target: &ConfigTarget,
     top_level_key: &str,
-    operator: bool,
+    launch: ServerLaunch<'_>,
 ) -> Result<(), OrbitError> {
     let mut root = load_json_object(&target.mcp_path)?;
     let servers = ensure_json_object(&mut root, top_level_key)?;
     servers.insert(
         ORBIT_MCP_SERVER_ID.to_string(),
-        simple_mcp_server_value(operator),
+        simple_mcp_server_value(launch),
     );
     write_json_object(&target.mcp_path, &root)
 }
@@ -38,7 +38,7 @@ pub(in crate::command::mcp::setup) fn apply_simple_json_remove(
     write_or_remove_json_object(&target.mcp_path, &root)
 }
 
-pub(super) fn simple_mcp_server_value(operator: bool) -> JsonValue {
+pub(super) fn simple_mcp_server_value(launch: ServerLaunch<'_>) -> JsonValue {
     JsonValue::Object(JsonMap::from_iter([
         (
             "command".to_string(),
@@ -47,7 +47,7 @@ pub(super) fn simple_mcp_server_value(operator: bool) -> JsonValue {
         (
             "args".to_string(),
             JsonValue::Array(
-                server_args(operator)
+                server_args(launch)
                     .into_iter()
                     .map(JsonValue::String)
                     .collect(),

--- a/crates/orbit-cli/src/command/mcp/setup/providers/tests/claude.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/tests/claude.rs
@@ -3,6 +3,8 @@ use tempfile::tempdir;
 use super::super::super::args::{McpAction, McpProvider, ProviderSelectionMode, ScopeArg};
 use super::super::super::dispatch::run_action;
 use super::super::claude::*;
+use super::super::common::ServerLaunch;
+use super::OPERATOR_LAUNCH;
 
 #[test]
 fn claude_workspace_scope_init_and_remove_preserve_unrelated_entries() {
@@ -24,7 +26,7 @@ fn claude_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     let providers = run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Claude]),
@@ -107,7 +109,7 @@ fn claude_operator_init_writes_single_operator_flag_and_refresh_is_idempotent() 
 
     let init = || {
         run_action(
-            McpAction::Init { operator: true },
+            McpAction::Init(OPERATOR_LAUNCH),
             repo.path(),
             &orbit_root,
             ProviderSelectionMode::Explicit(vec![McpProvider::Claude]),

--- a/crates/orbit-cli/src/command/mcp/setup/providers/tests/codex.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/tests/codex.rs
@@ -2,6 +2,8 @@ use tempfile::tempdir;
 
 use super::super::super::args::{McpAction, McpProvider, ProviderSelectionMode, ScopeArg};
 use super::super::super::dispatch::run_action;
+use super::super::common::ServerLaunch;
+use super::OPERATOR_LAUNCH;
 
 #[test]
 fn codex_workspace_scope_init_and_remove_preserve_unrelated_entries() {
@@ -17,7 +19,7 @@ fn codex_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Codex]),
@@ -80,7 +82,7 @@ fn workspace_scope_codex_init_is_idempotent() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Codex]),
@@ -92,7 +94,7 @@ fn workspace_scope_codex_init_is_idempotent() {
         .expect("read first config");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Codex]),
@@ -115,7 +117,7 @@ fn codex_operator_init_writes_single_operator_flag_and_refresh_is_idempotent() {
 
     let init = || {
         run_action(
-            McpAction::Init { operator: true },
+            McpAction::Init(OPERATOR_LAUNCH),
             repo.path(),
             &orbit_root,
             ProviderSelectionMode::Explicit(vec![McpProvider::Codex]),

--- a/crates/orbit-cli/src/command/mcp/setup/providers/tests/gemini.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/tests/gemini.rs
@@ -2,6 +2,8 @@ use tempfile::tempdir;
 
 use super::super::super::args::{McpAction, McpProvider, ProviderSelectionMode, ScopeArg};
 use super::super::super::dispatch::run_action;
+use super::super::common::ServerLaunch;
+use super::OPERATOR_LAUNCH;
 
 #[test]
 fn gemini_workspace_scope_init_and_remove_preserve_unrelated_entries() {
@@ -17,7 +19,7 @@ fn gemini_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Gemini]),
@@ -70,7 +72,7 @@ fn workspace_scope_gemini_init_is_idempotent() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Gemini]),
@@ -82,7 +84,7 @@ fn workspace_scope_gemini_init_is_idempotent() {
         .expect("read first settings");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Gemini]),
@@ -105,7 +107,7 @@ fn gemini_operator_init_writes_single_operator_flag_and_refresh_is_idempotent() 
 
     let init = || {
         run_action(
-            McpAction::Init { operator: true },
+            McpAction::Init(OPERATOR_LAUNCH),
             repo.path(),
             &orbit_root,
             ProviderSelectionMode::Explicit(vec![McpProvider::Gemini]),

--- a/crates/orbit-cli/src/command/mcp/setup/providers/tests/grok.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/tests/grok.rs
@@ -2,6 +2,8 @@ use tempfile::tempdir;
 
 use super::super::super::args::{McpAction, McpProvider, ProviderSelectionMode, ScopeArg};
 use super::super::super::dispatch::run_action;
+use super::super::common::ServerLaunch;
+use super::OPERATOR_LAUNCH;
 
 #[test]
 fn grok_workspace_scope_init_and_remove_preserve_unrelated_entries() {
@@ -17,7 +19,7 @@ fn grok_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Grok]),
@@ -84,7 +86,7 @@ fn workspace_scope_grok_init_is_idempotent() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Grok]),
@@ -96,7 +98,7 @@ fn workspace_scope_grok_init_is_idempotent() {
         .expect("read first config");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Grok]),
@@ -119,7 +121,7 @@ fn grok_operator_init_writes_single_operator_flag_and_refresh_is_idempotent() {
 
     let init = || {
         run_action(
-            McpAction::Init { operator: true },
+            McpAction::Init(OPERATOR_LAUNCH),
             repo.path(),
             &orbit_root,
             ProviderSelectionMode::Explicit(vec![McpProvider::Grok]),

--- a/crates/orbit-cli/src/command/mcp/setup/providers/tests/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/tests/mod.rs
@@ -7,3 +7,18 @@ mod grok;
 mod simple_json;
 
 // Content moved from inline #[cfg(test)] mod tests in providers/*.rs per ORB-00221.
+
+use super::common::ServerLaunch;
+
+/// The `orbit workspace init --mcp` bootstrap authority, with no workspace
+/// binding, so authority assertions stay independent of the binding ones.
+const OPERATOR_LAUNCH: ServerLaunch<'static> = ServerLaunch {
+    operator: true,
+    workspace: None,
+};
+
+/// A launch bound to a registered workspace, as a generated config carries it.
+const BOUND_LAUNCH: ServerLaunch<'static> = ServerLaunch {
+    operator: false,
+    workspace: Some("ws_demo"),
+};

--- a/crates/orbit-cli/src/command/mcp/setup/providers/tests/simple_json.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/tests/simple_json.rs
@@ -5,22 +5,25 @@ use super::super::super::args::{McpAction, McpProvider, ProviderSelectionMode, S
 use super::super::super::dispatch::{auto_detected_providers, run_action, vscode_home_user_dir};
 use super::super::claude::claude_mcp_server_value;
 use super::super::codex::codex_mcp_server_table;
+use super::super::common::ServerLaunch;
+use super::super::grok::grok_mcp_server_table;
 use super::super::simple_json::simple_mcp_server_value;
+use super::{BOUND_LAUNCH, OPERATOR_LAUNCH};
 
 #[test]
 fn server_value_builders_emit_mcp_serve_only() {
-    let claude = claude_mcp_server_value(false);
+    let claude = claude_mcp_server_value(ServerLaunch::default());
     let claude_args = claude["args"].as_array().expect("claude args");
     assert_eq!(claude_args.len(), 2);
     assert_eq!(claude_args[0].as_str(), Some("mcp"));
     assert_eq!(claude_args[1].as_str(), Some("serve"));
 
-    let gemini = simple_mcp_server_value(false);
+    let gemini = simple_mcp_server_value(ServerLaunch::default());
     let gemini_args = gemini["args"].as_array().expect("gemini args");
     assert_eq!(gemini_args.len(), 2);
     assert!(gemini.get("cwd").is_none());
 
-    let codex = codex_mcp_server_table(false);
+    let codex = codex_mcp_server_table(ServerLaunch::default());
     let codex_args = codex["args"].as_array().expect("codex args");
     assert_eq!(codex_args.len(), 2);
     assert!(codex.get("cwd").is_none());
@@ -29,25 +32,74 @@ fn server_value_builders_emit_mcp_serve_only() {
 
 #[test]
 fn server_value_builders_append_operator_flag_when_authorized() {
-    let claude = claude_mcp_server_value(true);
+    let claude = claude_mcp_server_value(OPERATOR_LAUNCH);
     let claude_args = claude["args"].as_array().expect("claude args");
     assert_eq!(claude_args.len(), 3);
     assert_eq!(claude_args[0].as_str(), Some("mcp"));
     assert_eq!(claude_args[1].as_str(), Some("serve"));
     assert_eq!(claude_args[2].as_str(), Some("--operator"));
 
-    let gemini = simple_mcp_server_value(true);
+    let gemini = simple_mcp_server_value(OPERATOR_LAUNCH);
     let gemini_args = gemini["args"].as_array().expect("gemini args");
     assert_eq!(
         gemini_args,
         &vec![json!("mcp"), json!("serve"), json!("--operator")]
     );
 
-    let codex = codex_mcp_server_table(true);
+    let codex = codex_mcp_server_table(OPERATOR_LAUNCH);
     let codex_args = codex["args"].as_array().expect("codex args");
     assert_eq!(codex_args.len(), 3);
     assert_eq!(codex_args[2].as_str(), Some("--operator"));
     assert_eq!(codex["enabled"].as_bool(), Some(true));
+}
+
+/// A generated integration is written for one registered workspace, so its
+/// argv names that workspace. Without it a client that cannot announce
+/// `_meta.orbit.workspace` at initialize would have to repeat the selector on
+/// every workspace-scoped call.
+#[test]
+fn server_value_builders_bind_the_registered_workspace() {
+    let expected = ["mcp", "serve", "--workspace", "ws_demo"];
+
+    for (provider, args) in [
+        ("claude", json_args(&claude_mcp_server_value(BOUND_LAUNCH))),
+        ("gemini", json_args(&simple_mcp_server_value(BOUND_LAUNCH))),
+        ("codex", toml_args(&codex_mcp_server_table(BOUND_LAUNCH))),
+        ("grok", toml_args(&grok_mcp_server_table(BOUND_LAUNCH))),
+    ] {
+        assert_eq!(args, expected, "{provider} must launch bound");
+    }
+}
+
+fn json_args(server: &serde_json::Value) -> Vec<String> {
+    server["args"]
+        .as_array()
+        .expect("json args")
+        .iter()
+        .map(|arg| arg.as_str().expect("string arg").to_string())
+        .collect()
+}
+
+fn toml_args(server: &toml::value::Table) -> Vec<String> {
+    server["args"]
+        .as_array()
+        .expect("toml args")
+        .iter()
+        .map(|arg| arg.as_str().expect("string arg").to_string())
+        .collect()
+}
+
+/// Authority and binding are independent: the bootstrap path emits both.
+#[test]
+fn server_value_builders_emit_authority_and_binding_together() {
+    let launch = ServerLaunch {
+        operator: true,
+        workspace: Some("ws_demo"),
+    };
+    assert_eq!(
+        json_args(&claude_mcp_server_value(launch)),
+        ["mcp", "serve", "--operator", "--workspace", "ws_demo"]
+    );
 }
 
 #[test]
@@ -64,7 +116,7 @@ fn cursor_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Cursor]),
@@ -115,7 +167,7 @@ fn cursor_home_scope_init_writes_resolved_home_path() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Cursor]),
@@ -168,7 +220,7 @@ fn workspace_scope_cursor_init_is_idempotent() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Cursor]),
@@ -180,7 +232,7 @@ fn workspace_scope_cursor_init_is_idempotent() {
         .expect("read first cursor");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Cursor]),
@@ -208,7 +260,7 @@ fn vscode_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Vscode]),
@@ -263,7 +315,7 @@ fn vscode_home_scope_init_writes_resolved_home_path() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Vscode]),
@@ -322,7 +374,7 @@ fn workspace_scope_vscode_init_is_idempotent() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Vscode]),
@@ -334,7 +386,7 @@ fn workspace_scope_vscode_init_is_idempotent() {
         .expect("read first vscode");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Vscode]),
@@ -363,7 +415,7 @@ fn windsurf_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Windsurf]),
@@ -414,7 +466,7 @@ fn windsurf_home_scope_init_writes_resolved_home_path() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Windsurf]),
@@ -468,7 +520,7 @@ fn workspace_scope_windsurf_init_is_idempotent() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Windsurf]),
@@ -484,7 +536,7 @@ fn workspace_scope_windsurf_init_is_idempotent() {
     let first = std::fs::read_to_string(&path).expect("read first windsurf");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Windsurf]),
@@ -527,7 +579,7 @@ fn cursor_operator_init_writes_single_operator_flag_and_refresh_is_idempotent() 
 
     let init = || {
         run_action(
-            McpAction::Init { operator: true },
+            McpAction::Init(OPERATOR_LAUNCH),
             repo.path(),
             &orbit_root,
             ProviderSelectionMode::Explicit(vec![McpProvider::Cursor]),
@@ -553,7 +605,7 @@ fn vscode_operator_init_writes_single_operator_flag_and_refresh_is_idempotent() 
 
     let init = || {
         run_action(
-            McpAction::Init { operator: true },
+            McpAction::Init(OPERATOR_LAUNCH),
             repo.path(),
             &orbit_root,
             ProviderSelectionMode::Explicit(vec![McpProvider::Vscode]),
@@ -583,7 +635,7 @@ fn windsurf_operator_init_writes_single_operator_flag_and_refresh_is_idempotent(
 
     let init = || {
         run_action(
-            McpAction::Init { operator: true },
+            McpAction::Init(OPERATOR_LAUNCH),
             repo.path(),
             &orbit_root,
             ProviderSelectionMode::Explicit(vec![McpProvider::Windsurf]),

--- a/crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs
@@ -2,6 +2,7 @@ use tempfile::tempdir;
 
 use super::super::args::{McpAction, McpProvider, ProviderSelectionMode, ScopeArg};
 use super::super::dispatch::{auto_detected_providers, run_action, vscode_home_user_dir};
+use super::super::providers::ServerLaunch;
 
 #[test]
 fn auto_detects_expected_providers() {
@@ -61,7 +62,7 @@ fn home_scope_writes_to_home_paths_and_skips_repo_files() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![
@@ -181,7 +182,7 @@ fn home_scope_remove_strips_only_orbit_entries() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![
@@ -255,7 +256,7 @@ fn home_scope_without_home_dir_errors() {
     std::fs::create_dir_all(&orbit_root).expect("create orbit root");
 
     let err = run_action(
-        McpAction::Init { operator: false },
+        McpAction::Init(ServerLaunch::default()),
         repo.path(),
         &orbit_root,
         ProviderSelectionMode::Explicit(vec![McpProvider::Claude]),

--- a/crates/orbit-cli/src/command/mcp/setup/workspace.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/workspace.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use orbit_cmd::registry_runtime::RegisteredRuntimeFactory;
 use orbit_core::OrbitError;
 use orbit_registry::workspace_registry;
 
@@ -56,6 +57,26 @@ pub(super) fn resolve_workspace_layout_for_cwd(cwd: &Path) -> Result<WorkspaceLa
     Err(OrbitError::InvalidInput(
         "current directory is not inside an initialized Orbit workspace; run `orbit workspace init` first or pass `--root <path/to/.orbit>`".to_string(),
     ))
+}
+
+/// The logical workspace ID this checkout is registered under on this machine,
+/// or `None` when the machine registry does not know it.
+///
+/// This is what a generated integration binds its MCP server to. The logical
+/// `ws_*` ID is used rather than the checkout path so a linked worktree — whose
+/// own checkout identity may have diverged from the registration — still names
+/// one workspace, and so a config that travels with the repo does not carry an
+/// absolute path from the machine that wrote it.
+///
+/// An unregistered checkout is not an error here: the generated server simply
+/// stays unbound, exactly as it was before a binding existed, and every
+/// workspace-scoped call supplies its own selector.
+pub(super) fn registered_workspace_id(repo_root: &Path) -> Option<String> {
+    let global_root = workspace_registry::global_orbit_dir().ok()?;
+    let selector = repo_root.to_str()?;
+    RegisteredRuntimeFactory::resolve_workspace_selector(&global_root, selector)
+        .ok()
+        .map(|selected| selected.workspace.id)
 }
 
 fn is_global_orbit_dir(candidate: &Path) -> bool {

--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -104,6 +104,7 @@ impl WorkspaceInitArgs {
             let providers = crate::command::mcp::init_auto_for_workspace(
                 &init_result.root,
                 &init_result.orbit_dir,
+                &init_result.id,
             )?;
             if providers.is_empty() {
                 println!("  mcp:       no providers auto-detected");

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -892,45 +892,75 @@ fn workspace_init_seeds_auto_detected_mcp_configs() {
         &std::fs::read_to_string(workspace.path().join(".claude.json")).expect("read claude mcp"),
     )
     .expect("parse claude mcp");
-    assert_operator_argv(&claude_mcp["mcpServers"]["orbit"]["args"]);
+    let workspace_id = registered_workspace_id(home.path());
+    assert_operator_argv(&claude_mcp["mcpServers"]["orbit"]["args"], &workspace_id);
 
     let codex_config = std::fs::read_to_string(workspace.path().join(".codex/config.toml"))
         .expect("read codex config");
     let codex_parsed: toml::Value = toml::from_str(&codex_config).expect("parse codex config");
-    assert_operator_argv_toml(&codex_parsed["mcp_servers"]["orbit"]["args"]);
+    assert_operator_argv_toml(&codex_parsed["mcp_servers"]["orbit"]["args"], &workspace_id);
 
     let gemini_settings: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string(workspace.path().join(".gemini/settings.json"))
             .expect("read gemini settings"),
     )
     .expect("parse gemini settings");
-    assert_operator_argv(&gemini_settings["mcpServers"]["orbit"]["args"]);
+    assert_operator_argv(
+        &gemini_settings["mcpServers"]["orbit"]["args"],
+        &workspace_id,
+    );
 
     let grok_config = std::fs::read_to_string(workspace.path().join(".grok/config.toml"))
         .expect("read grok config");
     let grok_parsed: toml::Value = toml::from_str(&grok_config).expect("parse grok config");
-    assert_operator_argv_toml(&grok_parsed["mcp_servers"]["orbit"]["args"]);
+    assert_operator_argv_toml(&grok_parsed["mcp_servers"]["orbit"]["args"], &workspace_id);
 }
 
-/// Every generated integration's argv must be exactly `mcp serve --operator`.
-fn assert_operator_argv(args: &serde_json::Value) {
-    let args = args.as_array().expect("args array");
+/// Every generated integration's argv must be exactly `mcp serve --operator
+/// --workspace <ws_id>`: the authority this bootstrap path grants, and the
+/// workspace it was generated for, so a client that cannot announce
+/// `_meta.orbit.workspace` at initialize still routes workspace-scoped tools.
+fn assert_operator_argv(args: &serde_json::Value, workspace_id: &str) {
+    let args = args
+        .as_array()
+        .expect("args array")
+        .iter()
+        .map(|arg| arg.as_str().expect("string arg"))
+        .collect::<Vec<_>>();
     assert_eq!(
         args,
-        &vec![
-            serde_json::json!("mcp"),
-            serde_json::json!("serve"),
-            serde_json::json!("--operator"),
-        ]
+        ["mcp", "serve", "--operator", "--workspace", workspace_id]
     );
 }
 
-fn assert_operator_argv_toml(args: &toml::Value) {
-    let args = args.as_array().expect("args array");
-    assert_eq!(args.len(), 3);
-    assert_eq!(args[0].as_str(), Some("mcp"));
-    assert_eq!(args[1].as_str(), Some("serve"));
-    assert_eq!(args[2].as_str(), Some("--operator"));
+fn assert_operator_argv_toml(args: &toml::Value, workspace_id: &str) {
+    let args = args
+        .as_array()
+        .expect("args array")
+        .iter()
+        .map(|arg| arg.as_str().expect("string arg"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        args,
+        ["mcp", "serve", "--operator", "--workspace", workspace_id]
+    );
+}
+
+/// The logical ID `orbit workspace init` just registered, read back from the
+/// machine registry so the expectation is the real binding rather than a
+/// re-derivation of the temp directory's name.
+fn registered_workspace_id(home: &std::path::Path) -> String {
+    let registry: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(home.join(".orbit").join("workspaces.json"))
+            .expect("read workspace registry"),
+    )
+    .expect("parse workspace registry");
+    registry["workspaces"]
+        .as_array()
+        .and_then(|workspaces| workspaces.first())
+        .and_then(|workspace| workspace["id"].as_str())
+        .expect("one registered workspace")
+        .to_string()
 }
 
 #[test]
@@ -963,16 +993,18 @@ fn workspace_reinit_with_force_mcp_refreshes_operator_argv_without_duplicating_i
     let first: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&claude_path).expect("read claude mcp"))
             .expect("parse claude mcp");
-    assert_operator_argv(&first["mcpServers"]["orbit"]["args"]);
+    let workspace_id = registered_workspace_id(home.path());
+    assert_operator_argv(&first["mcpServers"]["orbit"]["args"], &workspace_id);
 
     // Re-running the supported reconciliation path (`--force --mcp`) must
-    // refresh the managed Orbit entry to a single `--operator` argument, not
-    // append a second one, while leaving unrelated config untouched.
+    // refresh the managed Orbit entry to a single `--operator` argument and a
+    // single `--workspace` binding, not append a second one, while leaving
+    // unrelated config untouched.
     init(true);
     let second: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&claude_path).expect("read claude mcp"))
             .expect("parse claude mcp");
-    assert_operator_argv(&second["mcpServers"]["orbit"]["args"]);
+    assert_operator_argv(&second["mcpServers"]["orbit"]["args"], &workspace_id);
 }
 
 #[test]

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -415,6 +415,11 @@ fn mcp_serve_tools_list_matches_production_snapshot() {
 
     // Snapshot guard for the full production agent surface: names AND input
     // schemas. Any diff here is a breaking MCP schema change per RELEASING.md.
+    //
+    // `tools/list` is answered per session, and this fixture announces a
+    // workspace at initialize, so the snapshot records the workspace-bound
+    // selector documentation. The unbound wording is asserted in
+    // `mcp_serve_lists_the_canonical_surface_outside_any_checkout`.
     let snapshot_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(SNAPSHOT_RELATIVE_PATH);
     if std::env::var("ORBIT_MCP_UPDATE_SNAPSHOT").as_deref() == Ok("1") {
         std::fs::create_dir_all(snapshot_path.parent().expect("snapshot dir"))
@@ -568,19 +573,23 @@ fn workspace_init_mcp_config_reaches_a_governed_tool_over_the_real_transport() {
         vec![
             "mcp".to_string(),
             "serve".to_string(),
-            "--operator".to_string()
+            "--operator".to_string(),
+            "--workspace".to_string(),
+            "ws_mcp-roundtrip".to_string(),
         ],
-        "orbit workspace init --mcp must write argv exactly `mcp serve --operator`"
+        "orbit workspace init --mcp must write the authority it grants and the workspace it \
+         registered"
     );
 
     // Re-running the same reconciliation path (`--force --mcp`, as a second
     // `orbit workspace init --mcp` bootstrap would do) must refresh the
-    // managed entry rather than append a second `--operator` argument.
+    // managed entry rather than append a second `--operator` argument or a
+    // second binding.
     reconcile();
     assert_eq!(
         read_generated_args(),
         args,
-        "refreshing the operator-authorized entry must not duplicate --operator"
+        "refreshing the operator-authorized entry must not duplicate its arguments"
     );
 
     // Spawn the exact argv the generated config launches, over the real MCP
@@ -642,12 +651,29 @@ fn mcp_serve_lists_the_canonical_surface_outside_any_checkout() {
             .is_some_and(|message| message.contains("ORB-00001")),
         "an unregistered id must be reported as not found: {missing}"
     );
-    // Every other workspace-scoped tool still requires one.
+    // Every other workspace-scoped tool still requires one. This session was
+    // launched with no `--workspace` and announced none at initialize, so it
+    // is unbound and must stay fail-closed [ORB-10967].
     let unscoped = client.call_tool_err("orbit_task_list", json!({}));
     assert!(unscoped["message"].as_str().is_some_and(|message| {
         message.contains("requires a workspace selector")
             && message.contains("MCP initialize metadata")
     }));
+    let description = tool_workspace_description(&listed, "orbit_task_list");
+    assert!(
+        description.contains("Required in this session"),
+        "an unbound session must advertise the selector as required: {description}"
+    );
+
+    // An explicit valid selector is the one way out, and it works.
+    let scoped = client.call_tool_ok(
+        "orbit_task_list",
+        json!({ "workspace": "ws_mcp-roundtrip", "limit": 1 }),
+    );
+    assert!(
+        scoped.get("items").is_some() || scoped.is_array(),
+        "an explicit selector must route an unbound session: {scoped}"
+    );
     drop(client);
 
     let connection =
@@ -1372,6 +1398,276 @@ fn worktree_backed_activity_routes_task_and_search_by_advertised_workspace_argum
     let shown: Value = serde_json::from_slice(&output.stdout).expect("parse CLI task show");
     assert_eq!(shown["id"], json!(task_id));
     assert_eq!(shown["execution_summary"], "Routed from a linked worktree");
+}
+
+/// ORB-10967: the managed-executor shape, end to end through the real
+/// generated integration.
+///
+/// ORB-10448 made the selector *advertised* so a schema-following caller could
+/// pass it. That is not enough: a general-purpose MCP client cannot announce
+/// `_meta.orbit.workspace` at initialize at all, so a session that carried no
+/// binding refused every workspace-scoped call with "requires a workspace
+/// selector". The generated integration knows its workspace, so it binds the
+/// server to it at launch and a silent client still routes.
+#[test]
+fn managed_mcp_config_updates_a_task_without_a_workspace_argument() {
+    let workspace = McpWorkspace::init();
+    let task_id = author_task(&workspace, "Managed executor routing");
+    let args = generate_managed_mcp_config(&workspace);
+
+    let mut client = spawn_generated_server(&workspace, &workspace.work, &args);
+
+    // The advertised schema must tell this session the truth: it is bound, so
+    // the selector is optional here.
+    let listed = client.request("tools/list", Value::Null);
+    let description = tool_workspace_description(&listed, "orbit_task_update");
+    assert!(
+        description.contains("Optional in this session"),
+        "a launch-bound session must advertise the selector as optional: {description}"
+    );
+
+    let updated = client.call_tool_ok(
+        "orbit_task_update",
+        json!({
+            "id": task_id,
+            "execution_summary": "Routed by the session's launch binding",
+            "model": "codex",
+        }),
+    );
+    assert_eq!(
+        updated["execution_summary"], "Routed by the session's launch binding",
+        "a managed session must update a task without naming a workspace"
+    );
+
+    // An explicit selector still overrides, and still validates: naming a
+    // workspace that does not exist fails closed rather than falling back to
+    // the binding.
+    let explicit = client.call_tool_ok(
+        "orbit_task_update",
+        json!({
+            "id": task_id,
+            "execution_summary": "Routed by an explicit selector",
+            "workspace": workspace.work.to_str().expect("utf8 checkout path"),
+            "model": "codex",
+        }),
+    );
+    assert_eq!(
+        explicit["execution_summary"],
+        "Routed by an explicit selector"
+    );
+    let rejected = client.call_tool_err(
+        "orbit_task_update",
+        json!({ "id": task_id, "workspace": "ws_not_registered", "model": "codex" }),
+    );
+    assert!(
+        rejected["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("ws_not_registered")),
+        "an explicit selector must be validated, not silently replaced: {rejected}"
+    );
+    drop(client);
+
+    // The checkout-local CLI surface observes the same partition MCP wrote to.
+    assert_eq!(
+        cli_task_execution_summary(&workspace, &workspace.work, &task_id),
+        "Routed by an explicit selector"
+    );
+}
+
+/// ORB-10967 / ORB-10961: the same contract from a linked job worktree whose
+/// checkout identity diverged from the logical `ws_*` the registry knows.
+///
+/// The binding is that logical ID, so the ambient runtime identity of the
+/// worktree never becomes the route, and the managed run lands in the one
+/// partition the checkout-local surfaces use.
+#[test]
+fn managed_mcp_config_routes_a_linked_worktree_by_its_logical_workspace_id() {
+    let workspace = McpWorkspace::init();
+
+    // Diverge the logical registry ID from the checkout identity that keys the
+    // coordination task registry, then generate the integration, so the config
+    // is written for the diverged logical ID.
+    let registry_path = workspace.home.join(".orbit").join("workspaces.json");
+    let registry = std::fs::read_to_string(&registry_path).expect("read workspace registry");
+    std::fs::write(
+        &registry_path,
+        registry.replace("ws_mcp-roundtrip", "ws_legacy-logical"),
+    )
+    .expect("write diverged workspace registry");
+    let identity = std::fs::read_to_string(workspace.work.join(".orbit").join("config.yaml"))
+        .expect("read checkout identity");
+    assert!(
+        identity.contains("ws_mcp-roundtrip"),
+        "checkout identity must keep the pre-divergence ID: {identity}"
+    );
+
+    let identity_path = workspace.work.join(".orbit").join("config.yaml");
+    std::fs::write(
+        &identity_path,
+        identity.replace("ws_mcp-roundtrip", "orbit-5c61b3"),
+    )
+    .expect("diverge the runtime partition identity");
+
+    let task_id = author_task(&workspace, "Linked worktree routing");
+    // `orbit mcp init` is the agent-authority generation path; it resolves the
+    // binding from the registry rather than from the checkout's own identity.
+    let args = generate_agent_mcp_config(&workspace);
+    assert_eq!(
+        args,
+        vec![
+            "mcp".to_string(),
+            "serve".to_string(),
+            "--workspace".to_string(),
+            "ws_legacy-logical".to_string(),
+        ],
+        "the generated config must bind the logical registry ID, not the checkout identity"
+    );
+
+    let worktree = add_linked_worktree(&workspace.work);
+    let mut client = spawn_generated_server(&workspace, &worktree, &args);
+
+    let updated = client.call_tool_ok(
+        "orbit_task_update",
+        json!({
+            "id": task_id,
+            "execution_summary": "Routed from a linked worktree",
+            "model": "codex",
+        }),
+    );
+    assert_eq!(
+        updated["execution_summary"],
+        "Routed from a linked worktree"
+    );
+    drop(client);
+
+    // The `orbit tool run` fallback from the worktree observes the same write:
+    // both surfaces address one partition.
+    assert_eq!(
+        cli_task_execution_summary(&workspace, &worktree, &task_id),
+        "Routed from a linked worktree"
+    );
+}
+
+/// Author one task through the checkout-local CLI surface and return its ID.
+fn author_task(workspace: &McpWorkspace, title: &str) -> String {
+    let input = json!({
+        "title": title,
+        "description": "Authored via the CLI fallback",
+        "complexity": "low",
+        "workspace": workspace.work.to_str().expect("utf8 checkout path"),
+        "model": "codex",
+    })
+    .to_string();
+    let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args(["tool", "run", "orbit.task.add", "--input", &input])
+        .output()
+        .expect("author task through the CLI fallback");
+    assert_command_succeeded("orbit.task.add", &output);
+    let created: Value = serde_json::from_slice(&output.stdout).expect("parse created task");
+    created["id"].as_str().expect("task id").to_string()
+}
+
+/// Run the operator-facing bootstrap (`orbit workspace init --mcp`) and return
+/// the exact argv the integration it generated launches Orbit with.
+fn generate_managed_mcp_config(workspace: &McpWorkspace) -> Vec<String> {
+    std::fs::create_dir_all(workspace.work.join(".claude")).expect("create .claude marker");
+    let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args([
+            "workspace",
+            "init",
+            "--name",
+            "mcp-roundtrip",
+            "--force",
+            "--mcp",
+        ])
+        .output()
+        .expect("run workspace init --force --mcp");
+    assert_command_succeeded("workspace init --force --mcp", &output);
+    read_generated_claude_args(workspace)
+}
+
+/// Run the agent-authority registration (`orbit mcp init --claude`) and return
+/// the argv the integration it generated launches Orbit with.
+fn generate_agent_mcp_config(workspace: &McpWorkspace) -> Vec<String> {
+    let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args(["mcp", "init", "--claude"])
+        .output()
+        .expect("run orbit mcp init --claude");
+    assert_command_succeeded("mcp init --claude", &output);
+    read_generated_claude_args(workspace)
+}
+
+fn read_generated_claude_args(workspace: &McpWorkspace) -> Vec<String> {
+    let claude_mcp: Value = serde_json::from_str(
+        &std::fs::read_to_string(workspace.work.join(".claude.json"))
+            .expect("read generated claude mcp config"),
+    )
+    .expect("parse generated claude mcp config");
+    claude_mcp["mcpServers"]["orbit"]["args"]
+        .as_array()
+        .expect("generated args array")
+        .iter()
+        .map(|value| value.as_str().expect("arg is a string").to_string())
+        .collect()
+}
+
+/// Spawn the generated argv from `cwd` and complete the handshake a real
+/// managed client performs: `clientInfo` only, no `_meta.orbit.workspace`.
+fn spawn_generated_server(workspace: &McpWorkspace, cwd: &Path, args: &[String]) -> McpClient {
+    let child = McpWorkspace::orbit_command(cwd, &workspace.home)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn the server launched by the generated config");
+    let mut client = McpClient::new(child);
+    client.request(
+        "initialize",
+        json!({
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": { "name": "managed-executor", "version": "0" },
+        }),
+    );
+    client.notify("notifications/initialized");
+    client
+}
+
+/// Read one task's execution summary back through the CLI surface at `cwd`.
+fn cli_task_execution_summary(workspace: &McpWorkspace, cwd: &Path, task_id: &str) -> String {
+    let output = McpWorkspace::orbit_command(cwd, &workspace.home)
+        .args([
+            "tool",
+            "run",
+            "orbit.task.show",
+            "--input",
+            &format!(r#"{{"id":"{task_id}"}}"#),
+            "--fields",
+            "id,execution_summary",
+        ])
+        .output()
+        .expect("run the CLI fallback");
+    assert_command_succeeded("orbit.task.show", &output);
+    let shown: Value = serde_json::from_slice(&output.stdout).expect("parse CLI task show");
+    assert_eq!(shown["id"], json!(task_id));
+    shown["execution_summary"]
+        .as_str()
+        .expect("execution summary")
+        .to_string()
+}
+
+/// The advertised `workspace` selector documentation for one listed tool.
+fn tool_workspace_description(listed: &Value, tool_name: &str) -> String {
+    listed["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .find(|tool| tool["name"] == json!(tool_name))
+        .expect("tool listed")["inputSchema"]["properties"]["workspace"]["description"]
+        .as_str()
+        .expect("selector carries routing guidance")
+        .to_string()
 }
 
 /// ORB-10797: the constellation-orchestrator shape.

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -5,7 +5,7 @@
       "additionalProperties": true,
       "properties": {
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },
@@ -23,7 +23,7 @@
           "type": "string"
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },
@@ -72,7 +72,7 @@
           "type": "string"
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },
@@ -140,7 +140,7 @@
           "type": "string"
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },
@@ -200,7 +200,7 @@
           "type": "string"
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },
@@ -244,7 +244,7 @@
           "type": "string"
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },
@@ -327,7 +327,7 @@
           "description": "AND-filter by tag. Repeat or pass an array. Applies to task, doc, and friction."
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },
@@ -377,7 +377,7 @@
           "description": "Optional task ids this note refers to."
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },
@@ -407,7 +407,7 @@
           "type": "boolean"
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },
@@ -425,7 +425,7 @@
           "type": "string"
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },
@@ -582,7 +582,7 @@
           "type": "string"
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },
@@ -621,7 +621,7 @@
           "type": "string"
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },
@@ -705,7 +705,7 @@
           "type": "string"
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },
@@ -806,7 +806,7 @@
           "type": "string"
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },
@@ -981,7 +981,7 @@
           "type": "string"
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },
@@ -1014,7 +1014,7 @@
           "type": "string"
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },
@@ -1036,7 +1036,7 @@
           "type": "string"
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },
@@ -1057,7 +1057,7 @@
           "type": "string"
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },
@@ -1110,7 +1110,7 @@
           "description": "Explicit task IDs to ship; at least one is required."
         },
         "workspace": {
-          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the server process cwd.",
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
         }
       },

--- a/crates/orbit-core/assets/skills/orbit/references/setup/first-run.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/first-run.md
@@ -68,11 +68,14 @@ orbit workspace init --mcp
 This registers the checkout, creates `.orbit/`, and seeds the default skills,
 jobs, activities, policies, routines, and auto-task definitions. `--mcp`
 auto-detects installed agent clients and registers Orbit's MCP server with
-them as `orbit mcp serve --operator` — **operator authority**, so the
-registered integration can dispatch workflows (`orbit.workflow.ship`),
-observe/resume runs, and run `orbit.command.exec`. This is the deliberate
-bootstrap path for a human-facing orchestrator; bare `orbit mcp serve` and any
-worker/agent-launched MCP session stay agent-only.
+them as `orbit mcp serve --operator --workspace <ws_id>` — **operator
+authority**, so the registered integration can dispatch workflows
+(`orbit.workflow.ship`), observe/resume runs, and run `orbit.command.exec`.
+This is the deliberate bootstrap path for a human-facing orchestrator; bare
+`orbit mcp serve` and any worker/agent-launched MCP session stay agent-only.
+`--workspace` binds the session to the workspace being registered, so
+workspace-scoped tools route without an explicit selector on every call —
+most MCP clients cannot announce one at initialize.
 
 Two things to know about what it seeded:
 

--- a/crates/orbit-mcp/src/adapter/dispatch.rs
+++ b/crates/orbit-mcp/src/adapter/dispatch.rs
@@ -18,7 +18,7 @@ use serde_json::{Map, Value};
 
 use super::OrbitToolServer;
 use super::name_map::{ToolNameCollision, build_name_map};
-use super::schema::{ensure_workspace_selector, schema_to_tool};
+use super::schema::{WorkspaceBinding, ensure_workspace_selector, schema_to_tool};
 use super::structured::mcp_structured_content;
 use crate::error::tool_error_result;
 
@@ -59,14 +59,54 @@ impl OrbitToolServer {
             &definition.schema.name,
             &definition.schema.parameters,
         );
-        ensure_workspace_selector(&mut schema, definition);
+        ensure_workspace_selector(&mut schema, definition, self.session_workspace_binding());
         Ok(schema)
+    }
+
+    /// Whether this session already carries a workspace selector, and can
+    /// therefore route a workspace-scoped call that omits one.
+    ///
+    /// `tools/list` is answered per session, so the advertised selector
+    /// documents the session the caller is actually in rather than a generic
+    /// "it depends".
+    fn session_workspace_binding(&self) -> WorkspaceBinding {
+        if self.session_context().workspace.is_some() {
+            WorkspaceBinding::Bound
+        } else {
+            WorkspaceBinding::Unbound
+        }
     }
 
     pub(crate) fn replace_session_context(&self, session_context: ToolSessionContext) {
         if let Ok(mut guard) = self.session_context.write() {
             *guard = session_context;
         }
+    }
+
+    /// Fold one client's `initialize` claims into the trusted session envelope.
+    ///
+    /// Initialize controls only the workspace selector and the caller's claim
+    /// about itself. Caller, process, transport, and correlation facts remain
+    /// server-owned.
+    pub(crate) fn adopt_announced_session(&self, announced: ToolSessionContext) {
+        let mut trusted = self.session_context();
+        // A client that announces no workspace falls back to the one this
+        // server was launched for, rather than clearing the selector: most MCP
+        // clients cannot put `_meta.orbit.workspace` on their initialize at
+        // all, so a managed integration would otherwise have to repeat the
+        // selector on every workspace-scoped call. An announced workspace
+        // still wins, and the fallback is the immutable launch value, so a
+        // re-initialize never inherits the previous client's claim.
+        trusted.workspace = announced
+            .workspace
+            .or_else(|| self.launch_workspace.clone());
+        // ORB-10890: recorded as untrusted evidence beside the trusted role,
+        // never merged into it. A re-initialize replaces the claim outright so
+        // one session can never accumulate two identities; `None` here means
+        // this session is anonymous, not that the previous claim still holds.
+        trusted.self_reported_actor = announced.self_reported_actor;
+        trusted.trace_id = None;
+        self.replace_session_context(trusted);
     }
 
     pub(crate) fn session_context(&self) -> ToolSessionContext {
@@ -147,19 +187,7 @@ impl ServerHandler for OrbitToolServer {
         request: InitializeRequestParams,
         context: RequestContext<RoleServer>,
     ) -> impl std::future::Future<Output = Result<InitializeResult, McpError>> + Send + '_ {
-        let announced = session_context_from_initialize(&request, &context.meta);
-        let mut trusted = self.session_context();
-        // Initialize controls only the legacy workspace selector and the
-        // caller's claim about itself. Caller, process, transport, and
-        // correlation facts remain server-owned.
-        trusted.workspace = announced.workspace;
-        // ORB-10890: recorded as untrusted evidence beside the trusted role,
-        // never merged into it. A re-initialize replaces the claim outright so
-        // one session can never accumulate two identities; `None` here means
-        // this session is anonymous, not that the previous claim still holds.
-        trusted.self_reported_actor = announced.self_reported_actor;
-        trusted.trace_id = None;
-        self.replace_session_context(trusted);
+        self.adopt_announced_session(session_context_from_initialize(&request, &context.meta));
         if context.peer.peer_info().is_none() {
             context.peer.set_peer_info(request);
         }

--- a/crates/orbit-mcp/src/adapter/mod.rs
+++ b/crates/orbit-mcp/src/adapter/mod.rs
@@ -26,6 +26,17 @@ use crate::McpHost;
 /// before dispatch.
 pub struct OrbitToolServer {
     host: Arc<dyn McpHost>,
+    /// The workspace this server process was launched for, when the launching
+    /// configuration named one.
+    ///
+    /// A managed integration — what `orbit mcp init` and `orbit workspace init
+    /// --mcp` generate — knows its workspace before any client connects, and
+    /// most MCP clients cannot announce `_meta.orbit.workspace` at initialize
+    /// at all. Keeping the launch binding here, separate from the mutable
+    /// session context, lets `initialize` fall back to it instead of clearing
+    /// the selector, while a re-initialize still resets to the launch value
+    /// rather than inheriting the previous client's claim.
+    launch_workspace: Option<String>,
     session_context: RwLock<ToolSessionContext>,
 }
 
@@ -42,9 +53,19 @@ impl OrbitToolServer {
             trusted_context.origin_session_id = Some(audit_execution_id("mcp-session"));
         }
         trusted_context.trace_id = None;
+        trusted_context.workspace = normalized_selector(trusted_context.workspace.as_deref());
         Self {
             host,
+            launch_workspace: trusted_context.workspace.clone(),
             session_context: RwLock::new(trusted_context),
         }
     }
+}
+
+/// A selector is present only when it names something; blank is absent.
+fn normalized_selector(selector: Option<&str>) -> Option<String> {
+    selector
+        .map(str::trim)
+        .filter(|selector| !selector.is_empty())
+        .map(ToOwned::to_owned)
 }

--- a/crates/orbit-mcp/src/adapter/schema.rs
+++ b/crates/orbit-mcp/src/adapter/schema.rs
@@ -18,13 +18,44 @@ pub(super) fn schema_to_tool(schema: ToolSchema, input_schema: JsonObject) -> To
 /// Canonical name of the authoritative server's workspace selector.
 pub(crate) const WORKSPACE_SELECTOR_PARAM: &str = "workspace";
 
-const WORKSPACE_SELECTOR_DESCRIPTION: &str = "Workspace selector for the authoritative server: a registered workspace name, a logical \
-     workspace ID (`ws_*`), or an absolute path registered on that server. Optional when the \
-     MCP session announced `_meta.orbit.workspace` at initialize; never inferred from the \
-     server process cwd.";
+/// Whether the session being served already carries a workspace selector.
+///
+/// The two states are advertised differently because they place different
+/// obligations on the caller: a bound session may omit the selector, an
+/// unbound one is refused without it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WorkspaceBinding {
+    Bound,
+    Unbound,
+}
+
+const BOUND_SESSION_SELECTOR_DESCRIPTION: &str = "Workspace selector for the authoritative server: a registered workspace name, a logical \
+     workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this \
+     session, which is already bound to a workspace — by `orbit mcp serve --workspace` at \
+     launch or `_meta.orbit.workspace` at initialize. Pass it to address a different \
+     registered workspace; never inferred from the server process cwd.";
+
+const UNBOUND_SESSION_SELECTOR_DESCRIPTION: &str = "Workspace selector for the authoritative server: a registered workspace name, a logical \
+     workspace ID (`ws_*`), or an absolute path registered on that server. Required in this \
+     session, which is bound to no workspace, so a call that omits it is refused. Sessions \
+     bound by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at \
+     initialize may omit it; never inferred from the server process cwd.";
+
+impl WorkspaceBinding {
+    fn selector_description(self) -> &'static str {
+        match self {
+            Self::Bound => BOUND_SESSION_SELECTOR_DESCRIPTION,
+            Self::Unbound => UNBOUND_SESSION_SELECTOR_DESCRIPTION,
+        }
+    }
+}
 
 /// Advertise the workspace selector on every workspace-scoped tool.
-pub(super) fn ensure_workspace_selector(schema: &mut JsonObject, definition: &McpToolDefinition) {
+pub(super) fn ensure_workspace_selector(
+    schema: &mut JsonObject,
+    definition: &McpToolDefinition,
+    binding: WorkspaceBinding,
+) {
     if definition.scope != McpToolScope::WorkspaceRequired {
         return;
     }
@@ -45,7 +76,7 @@ pub(super) fn ensure_workspace_selector(schema: &mut JsonObject, definition: &Mc
         WORKSPACE_SELECTOR_PARAM.to_string(),
         json!({
             "type": "string",
-            "description": WORKSPACE_SELECTOR_DESCRIPTION,
+            "description": binding.selector_description(),
         }),
     );
 }

--- a/crates/orbit-mcp/src/adapter/tests/schema.rs
+++ b/crates/orbit-mcp/src/adapter/tests/schema.rs
@@ -288,6 +288,160 @@ fn tool_declaring_its_own_workspace_param_keeps_that_description() {
     );
 }
 
+/// A server launched for a workspace advertises the selector as optional, and
+/// says why, so an agent in that session does not have to discover a selector
+/// it will never need.
+#[test]
+fn a_launch_bound_session_advertises_the_selector_as_optional() {
+    let definition = definition_with_scope(
+        "orbit.task.update",
+        vec![param("id")],
+        McpToolScope::WorkspaceRequired,
+    );
+
+    let description = selector_description(&definition, Some("ws_orbit"));
+
+    assert!(
+        description.contains("Optional in this session"),
+        "a bound session must advertise the selector as optional: {description}"
+    );
+    assert!(
+        description.contains("orbit mcp serve --workspace"),
+        "the binding's origin must be named: {description}"
+    );
+}
+
+/// An unbound session must not read as if it could omit the selector: it
+/// cannot, and a call that omits one is refused.
+#[test]
+fn an_unbound_session_advertises_the_selector_as_required() {
+    let definition = definition_with_scope(
+        "orbit.task.update",
+        vec![param("id")],
+        McpToolScope::WorkspaceRequired,
+    );
+
+    let description = selector_description(&definition, None);
+
+    assert!(
+        description.contains("Required in this session"),
+        "an unbound session must advertise the selector as required: {description}"
+    );
+    assert!(
+        description.contains("refused"),
+        "the fail-closed consequence must be stated: {description}"
+    );
+}
+
+fn selector_description(definition: &McpToolDefinition, launch_workspace: Option<&str>) -> String {
+    let context = ToolSessionContext {
+        workspace: launch_workspace.map(ToOwned::to_owned),
+        ..ToolSessionContext::default()
+    };
+    let server =
+        OrbitToolServer::new_with_context(Arc::new(SessionContextHost::default()), context);
+    server
+        .input_schema_for(definition)
+        .expect("input schema resolves")["properties"]["workspace"]["description"]
+        .as_str()
+        .expect("selector carries routing guidance")
+        .to_string()
+}
+
+/// The managed-executor shape: the server knows its workspace, the client
+/// cannot say anything about one, and the session must still route.
+#[test]
+fn initialize_without_an_announced_workspace_keeps_the_launch_binding() {
+    let server = launch_bound_server(Some("ws_orbit"));
+
+    server.adopt_announced_session(session_context_from_initialize(
+        &InitializeRequestParams::new(
+            ClientCapabilities::default(),
+            Implementation::new("claude-code", "0"),
+        ),
+        &Meta::new(),
+    ));
+
+    assert_eq!(
+        server.session_context().workspace.as_deref(),
+        Some("ws_orbit")
+    );
+}
+
+#[test]
+fn an_announced_workspace_overrides_the_launch_binding() {
+    let server = launch_bound_server(Some("ws_orbit"));
+
+    server.adopt_announced_session(session_context_from_initialize(
+        &initialize_params_with_meta(json!({ "orbit": { "workspace": "/repo/other" } })),
+        &Meta::new(),
+    ));
+
+    assert_eq!(
+        server.session_context().workspace.as_deref(),
+        Some("/repo/other")
+    );
+}
+
+/// The fallback is the immutable launch value, never the previous client's
+/// claim, so one session cannot inherit a workspace it was never bound to.
+#[test]
+fn re_initialize_falls_back_to_the_launch_binding_not_the_previous_claim() {
+    let server = launch_bound_server(Some("ws_orbit"));
+    server.adopt_announced_session(session_context_from_initialize(
+        &initialize_params_with_meta(json!({ "orbit": { "workspace": "/repo/other" } })),
+        &Meta::new(),
+    ));
+
+    server.adopt_announced_session(session_context_from_initialize(
+        &InitializeRequestParams::new(
+            ClientCapabilities::default(),
+            Implementation::new("claude-code", "0"),
+        ),
+        &Meta::new(),
+    ));
+
+    assert_eq!(
+        server.session_context().workspace.as_deref(),
+        Some("ws_orbit")
+    );
+}
+
+/// A standalone server binds nothing, so a silent client stays unbound and
+/// every workspace-scoped call must name its own workspace.
+#[test]
+fn an_unbound_server_stays_unbound_when_the_client_announces_nothing() {
+    let server = launch_bound_server(None);
+
+    server.adopt_announced_session(session_context_from_initialize(
+        &InitializeRequestParams::new(
+            ClientCapabilities::default(),
+            Implementation::new("claude-code", "0"),
+        ),
+        &Meta::new(),
+    ));
+
+    assert_eq!(server.session_context().workspace, None);
+}
+
+/// A blank binding names nothing, so it must not present as bound.
+#[test]
+fn a_blank_launch_binding_is_no_binding() {
+    let server = launch_bound_server(Some("   "));
+
+    assert_eq!(server.session_context().workspace, None);
+}
+
+fn launch_bound_server(launch_workspace: Option<&str>) -> OrbitToolServer {
+    OrbitToolServer::new_with_context(
+        Arc::new(SessionContextHost::default()),
+        ToolSessionContext {
+            workspace: launch_workspace.map(ToOwned::to_owned),
+            ..ToolSessionContext::default()
+        },
+    )
+}
+
 fn initialize_params_with_meta(meta: Value) -> InitializeRequestParams {
     let mut params = InitializeRequestParams::new(
         ClientCapabilities::default(),

--- a/docs/design/mcp-session-context/2_design.md
+++ b/docs/design/mcp-session-context/2_design.md
@@ -3,8 +3,8 @@ summary: "MCP Session Context — Design"
 type: design
 title: "MCP Session Context — Design"
 owner: codex
-last_updated: 2026-08-15
-last_validated: 2026-08-15
+last_updated: 2026-08-22
+last_validated: 2026-08-22
 status: Accepted
 feature: mcp-session-context
 doc_role: design
@@ -20,7 +20,7 @@ related_artifacts: []
 
 | Field | Source | Meaning |
 |---|---|---|
-| workspace | Tool input or initialize metadata | Untrusted address selector |
+| workspace | Tool input, initialize metadata, or the server's launch binding | Address selector, resolved per call against the accepting server's registry |
 | workspace_id | Authoritative server resolution | Stable logical workspace selected for execution |
 | caller_machine_id | Local identity or SSH proxy argument | Opaque audit correlation label |
 | caller_host_id | Local accepting server | Local display label; unset for a remote caller |
@@ -30,6 +30,8 @@ related_artifacts: []
 | trace_id | MCP adapter | Fresh correlation ID for one tools/call |
 
 Clients cannot populate trusted fields through initialize metadata or tool JSON. Initialize accepts only the workspace selector under _meta.orbit.workspace, plus the compatibility spelling _meta["orbit.workspace"].
+
+A session may also be bound at launch: `orbit mcp serve --workspace <selector>` seeds the trusted envelope's workspace before any client connects. That binding is decided by whoever wrote the launch configuration, not by the connecting client, but it is still only a selector — it is resolved against the registry on every call and overridden by an explicit per-call workspace.
 
 ## 2. Local and SSH sessions
 
@@ -49,7 +51,10 @@ For a workspace-scoped tool, the authoritative server chooses the first non-empt
 
 1. workspace in the tool input;
 2. workspace announced during initialize;
-3. otherwise, a missing-workspace error.
+3. the workspace this server was launched for (`orbit mcp serve --workspace`);
+4. otherwise, a missing-workspace error.
+
+Steps 2 and 3 are one session field, resolved once at initialize: an announced workspace replaces the launch binding for that session, and a client that announces nothing falls back to the binding rather than clearing it. The fallback is the immutable launch value, so a re-initialize never inherits the previous client's claim. Most MCP clients cannot put _meta on their initialize at all, which is why a managed integration — what `orbit mcp init` and `orbit workspace init --mcp` generate — writes the binding into the argv it registers, using the logical `ws_*` ID so a linked worktree whose checkout identity diverged still names one workspace. A server the operator launched with no binding stays unbound, and every workspace-scoped call there must name its own workspace.
 
 Process cwd is not an MCP fallback. The server resolves the selector against its registry, opens the selected local runtime, writes the resolved workspace_id into context, and normalizes an explicit workspace argument to the selected checkout path before Core dispatch.
 
@@ -62,6 +67,8 @@ orbit.task.show is the one exception to the precedence above. Task IDs are a mac
 OrbitToolServer holds one context for its stdio session. Initialize may replace only the workspace selector. For every tools/call, the adapter clones the session context and mints one fresh trace_id without writing it back.
 
 tools/list comes from the authoritative host on every request. Each definition carries a ToolSchema and one McpToolScope: Global or WorkspaceRequired. Scope controls only workspace-selector injection and server dispatch; it is not authorization metadata.
+
+Because tools/list is answered per session, the injected selector documents the session the caller is actually in: optional in a bound session, required in an unbound one. Both spellings describe the same server rule; only the obligation on the caller differs.
 
 ## 5. Core dispatch and audit
 

--- a/docs/design/mcp-session-context/4_decisions.md
+++ b/docs/design/mcp-session-context/4_decisions.md
@@ -3,8 +3,8 @@ summary: "MCP Session Context — Decisions"
 type: design
 title: "MCP Session Context — Decisions"
 owner: codex
-last_updated: 2026-08-15
-last_validated: 2026-08-15
+last_updated: 2026-08-22
+last_validated: 2026-08-22
 status: Accepted
 feature: mcp-session-context
 doc_role: decisions
@@ -22,9 +22,19 @@ These are the current implementation choices for MCP v1.
 
 **Context.** A client must select server-side workspace state, but client input cannot establish a trusted logical identity.
 
-**Decision.** Accept workspace from explicit tool input first and initialize metadata second. Resolve it on the authoritative server, then set workspace_id. Never fall back to the server process cwd.
+**Decision.** Accept workspace from explicit tool input first, initialize metadata second, and the server's launch binding third. Resolve it on the authoritative server, then set workspace_id. Never fall back to the server process cwd.
 
 **Consequences.** Explicit addressing works from any client launch directory. Missing or unknown selectors fail clearly. Cost: every workspace-scoped call pays server-side resolution.
+
+## A managed integration binds its own workspace at launch
+
+**Context.** The MCP protocol gives a client exactly one place to announce a workspace — `_meta` on initialize — and general-purpose clients do not send it. A session that carried no binding therefore refused every workspace-scoped call, and the agent had to discover a selector Orbit already knew.
+
+**Decision.** `orbit mcp serve --workspace <selector>` binds the session before any client connects, and the config generators write it into the argv they register, using the logical `ws_*` ID. The binding is a default, not an authority: it never overrides an explicit per-call workspace or an announced one, and it is resolved against the registry like any other selector. A server launched without it stays fail-closed.
+
+**Alternative rejected.** Falling back to the server process cwd. That is the retired routing model: it makes the answer depend on where the client happened to launch, and a linked worktree would silently address a different partition than its registration. The launch binding is written once, by whoever registered the integration, and names a workspace rather than a directory.
+
+**Consequences.** A managed executor calls `orbit.task.update` with no workspace argument and lands in the workspace it was launched for. `tools/list` documents which of the two situations the caller is in. Cost: a stale binding (a workspace later deregistered or renamed) surfaces as a per-call resolution error naming the selector, rather than at startup.
 
 ## The accepting server owns provenance
 

--- a/plugin/skills/orbit/references/setup/first-run.md
+++ b/plugin/skills/orbit/references/setup/first-run.md
@@ -68,11 +68,14 @@ orbit workspace init --mcp
 This registers the checkout, creates `.orbit/`, and seeds the default skills,
 jobs, activities, policies, routines, and auto-task definitions. `--mcp`
 auto-detects installed agent clients and registers Orbit's MCP server with
-them as `orbit mcp serve --operator` — **operator authority**, so the
-registered integration can dispatch workflows (`orbit.workflow.ship`),
-observe/resume runs, and run `orbit.command.exec`. This is the deliberate
-bootstrap path for a human-facing orchestrator; bare `orbit mcp serve` and any
-worker/agent-launched MCP session stay agent-only.
+them as `orbit mcp serve --operator --workspace <ws_id>` — **operator
+authority**, so the registered integration can dispatch workflows
+(`orbit.workflow.ship`), observe/resume runs, and run `orbit.command.exec`.
+This is the deliberate bootstrap path for a human-facing orchestrator; bare
+`orbit mcp serve` and any worker/agent-launched MCP session stay agent-only.
+`--workspace` binds the session to the workspace being registered, so
+workspace-scoped tools route without an explicit selector on every call —
+most MCP clients cannot announce one at initialize.
 
 Two things to know about what it seeded:
 


### PR DESCRIPTION
## Task

[ORB-10967](https://orbit-cli.com/tasks/ORB-10967) — Restore automatic workspace propagation for orbit.task.update

### Description

## Problem
A current MCP call failed with `invalid input: tool 'orbit.task.update' requires a workspace selector; pass workspace in the tool call or MCP initialize metadata`. ORB-10448 previously established and tested the managed-executor workspace-routing contract, including task update from a linked worktree, but the failure signature has returned.

## Why It Matters
Task updates are correctly workspace-scoped and should remain fail-closed for ambiguous standalone clients. Managed MCP sessions, however, already know the authoritative workspace and must propagate it without requiring an agent to discover or guess a selector.

## Constraints / Notes
Treat this as a regression of ORB-10448. Preserve explicit workspace selection for unbound clients and remote routing; do not make task mutation global-by-default.

### Acceptance Criteria

- A managed MCP executor launched for ws_orbit can call orbit.task.update without a workspace argument, and the broker routes it using trusted session initialization metadata.
- The same regression is covered for a linked job worktree whose checkout identity differs from its logical ws_* identifier.
- An unbound standalone MCP session still receives a fail-closed workspace-required error unless it passes an explicit valid selector.
- tools/list accurately documents whether workspace may come from initialize metadata, and explicit workspace continues to override or validate consistently.
- End-to-end tests exercise the actual managed client initialization path rather than only adapter unit injection.

## Execution Summary

<details>
<summary>Click to expand</summary>

Root cause: nothing bound a managed MCP session to a workspace. Generated client configs launched bare `orbit mcp serve`, and general-purpose MCP clients (Claude Code, Codex, Gemini) cannot put `_meta.orbit.workspace` on their initialize, so `ToolSessionContext.workspace` stayed `None` and every workspace-scoped tool failed closed with "requires a workspace selector". ORB-10448 only made the selector *advertised* so a schema-following caller could pass it; propagation was never automatic. Confirmed against the live box: `~/.claude.json` in polaris and `.mcp.json` in sextant both register argv `["mcp","serve"]`.

Fix, in four parts:

1. Launch binding. `orbit mcp serve --workspace <SELECTOR>` (conflicts with `--mode remote`); `compose_server` seeds the trusted session envelope's `workspace` from it. It stays a selector: resolved per call against the accepting server's registry, so a stale binding fails closed naming it. `orbit mcp listen` binds nothing — a socket is shared, so each session names its own workspace.
2. Survives initialize. `OrbitToolServer` keeps the immutable launch binding beside the mutable session context, and `initialize` now folds announced claims in via `adopt_announced_session`: `announced.workspace.or(launch_binding)` instead of overwriting with `None`. An announced workspace still wins; a re-initialize resets to the launch value rather than inheriting the previous client's claim; a blank binding is no binding.
3. Generated configs carry it. `ServerLaunch { operator, workspace }` replaces the bare `operator` flag through `McpAction::Init` and every provider writer. `orbit mcp init` resolves the checkout's logical `ws_*` ID from the machine registry (`registered_workspace_id`); `orbit workspace init --mcp` passes the ID it just registered. The logical ID, not a path, so a linked worktree whose checkout identity diverged still names one workspace and a repo-local config carries no absolute path. An unregistered checkout emits today's unbound argv unchanged.
4. tools/list documents the session it is answering. `WorkspaceBinding::{Bound,Unbound}` selects one of two selector descriptions: optional in a bound session, required (and "a call that omits it is refused") in an unbound one. Explicit `workspace` remains an override and a filter in both.

Tests. Two new end-to-end tests in `crates/orbit-cli/tests/mcp_roundtrip.rs` drive the *real* managed client path — generate the integration with the production CLI, extract the exact argv it registered, spawn `orbit` with it, and handshake with `clientInfo` only and no `_meta`: `managed_mcp_config_updates_a_task_without_a_workspace_argument` (task.update with no workspace argument succeeds; explicit selector overrides; a bogus selector is still rejected; the checkout-local CLI sees the same partition) and `managed_mcp_config_routes_a_linked_worktree_by_its_logical_workspace_id` (registry logical ID diverged to `ws_legacy-logical` and checkout identity to `orbit-5c61b3`, config generated via `orbit mcp init --claude`, server spawned from the linked worktree). `mcp_serve_lists_the_canonical_surface_outside_any_checkout` now also asserts the unbound session advertises the selector as required and that an explicit valid selector recovers. Six adapter unit tests cover the initialize fallback, the announced override, re-initialize, the unbound case, blank bindings, and both schema variants. The ORB-10960 argv test and the `orbit workspace init --mcp` unit tests now assert the binding alongside the authority flag.

Out-of-scope files touched, all required by the change: `adapter/mod.rs` (holds the launch binding), `mcp/command.rs` (the flag), `mcp/setup/**` (the other half of the propagation path — a server-side binding no generator writes is dead), `workspace/init.rs` + its tests (the `--mcp` call site and its directly affected assertions), the `mcp_tools_list.json` snapshot (regenerated; it records the bound wording because the fixture announces a workspace, noted in the test), and the design/README/skill docs. The skill mirror `crates/orbit-core/assets/skills/.../first-run.md` was re-synced with `plugin/skills/` as the sync guard requires.

Validation: `make ci-fast` and `make ci-lint` both pass. `cargo test` passes for orbit-cli (350 unit + 18 mcp_roundtrip + all integration targets), orbit-mcp (64), orbit-cmd, orbit-tools, orbit-registry, and orbit-core. Note for anyone rerunning locally inside a managed job: orbit-core's `runtime::tests::resolve` suite fails under an inherited `ORBIT_ROOT`; with `env -u ORBIT_ROOT` it is fully green, and that interference is unrelated to this change.

Filed friction F2026-08-115: the CLI-side twin of this gap. A managed run injects `ORBIT_ROOT=<workspace>/.orbit`, but the workspace registry lives in `$HOME/.orbit/workspaces.json`, so `orbit tool run --input '{"workspace":"ws_orbit"}'` reports every registered selector as unknown. MCP is unaffected (`resolve_global_root()` reads HOME only).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10967-6a8a2069`
- Behind base: 0
- Ahead of base: 1