### PR TITLE
Partition workspace-auto by crew and terminalize claimed worker startup failures

### DIFF
--- a/.orbit/resources/jobs/workspace_auto_pipeline.yaml
+++ b/.orbit/resources/jobs/workspace_auto_pipeline.yaml
@@ -54,20 +54,29 @@ spec:
 
           - id: ship_leaves
             when: "{{ steps.admissible.output.has_leaves }} == true"
-            target: activity:invoke_and_wait
-            default_input:
-              job_name: task_auto_pipeline
-              run_input:
-                task_ids: "{{ steps.admissible.output.loose_task_ids }}"
-                mode: "{{ steps.resolve_ship_input.output.mode }}"
-                base_branch: "{{ steps.resolve_ship_input.output.base_branch }}"
+            fan_out:
+              items: "{{ steps.admissible.output.loose_task_dispatches }}"
+              max_workers: 5
+              worker:
+                id: leaf_invoke
+                target: activity:invoke_and_wait
+                default_input:
+                  job_name: task_auto_pipeline
+                  run_input:
+                    task_ids: "{{ item.task_ids }}"
+                    mode: "{{ steps.resolve_ship_input.output.mode }}"
+                    base_branch: "{{ steps.resolve_ship_input.output.base_branch }}"
+            fan_in:
+              join:
+                mode: all
+              collect: leaf_results
 
           - id: require_leaf_success
             when: "{{ steps.admissible.output.has_leaves }} == true"
             target: activity:pipeline_success_guard
             default_input:
               context: workspace auto leaf ship
-              result: "{{ steps.ship_leaves.output }}"
+              results: "{{ steps.leaf_results.output }}"
 
           # Detached: the next iteration keeps shipping leaves while the epic
           # assembles its branch. `classify_workspace_auto_tasks` re-observes

--- a/crates/orbit-core/assets/jobs/workspace_auto_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/workspace_auto_pipeline.yaml
@@ -54,20 +54,29 @@ spec:
 
           - id: ship_leaves
             when: "{{ steps.admissible.output.has_leaves }} == true"
-            target: activity:invoke_and_wait
-            default_input:
-              job_name: task_auto_pipeline
-              run_input:
-                task_ids: "{{ steps.admissible.output.loose_task_ids }}"
-                mode: "{{ steps.resolve_ship_input.output.mode }}"
-                base_branch: "{{ steps.resolve_ship_input.output.base_branch }}"
+            fan_out:
+              items: "{{ steps.admissible.output.loose_task_dispatches }}"
+              max_workers: 5
+              worker:
+                id: leaf_invoke
+                target: activity:invoke_and_wait
+                default_input:
+                  job_name: task_auto_pipeline
+                  run_input:
+                    task_ids: "{{ item.task_ids }}"
+                    mode: "{{ steps.resolve_ship_input.output.mode }}"
+                    base_branch: "{{ steps.resolve_ship_input.output.base_branch }}"
+            fan_in:
+              join:
+                mode: all
+              collect: leaf_results
 
           - id: require_leaf_success
             when: "{{ steps.admissible.output.has_leaves }} == true"
             target: activity:pipeline_success_guard
             default_input:
               context: workspace auto leaf ship
-              result: "{{ steps.ship_leaves.output }}"
+              results: "{{ steps.leaf_results.output }}"
 
           # Detached: the next iteration keeps shipping leaves while the epic
           # assembles its branch. `classify_workspace_auto_tasks` re-observes

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/pipeline_actions.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/pipeline_actions.rs
@@ -380,6 +380,45 @@ fn a_failed_child_stays_linked_with_its_terminal_status() {
 }
 
 #[test]
+fn mixed_crew_child_failure_closes_dispatch_and_fails_parent_guard_promptly() {
+    let (runtime, parent) = parent_runtime();
+    let concrete_error = "invalid input: task bundle mixes crews terra and sol; split the bundle or assign one crew instead of inheriting workflow.default_crew";
+    let started = std::time::Instant::now();
+
+    let output = invoke_and_wait_with(
+        &runtime,
+        "invoke_and_wait",
+        &ship_leaves_input(&parent),
+        |_| Ok(healthy_invoke_output()),
+        |_| {
+            Ok(json!({
+                "results": [{
+                    "run_id": CHILD_RUN,
+                    "status": "failed",
+                    "finished_at": "2026-08-22T23:00:00Z",
+                    "error": concrete_error,
+                }],
+            }))
+        },
+    )
+    .expect("terminal child failure is returned as data");
+
+    assert!(started.elapsed() < std::time::Duration::from_secs(1));
+    let dispatch = &recorded_dispatches(&runtime, &parent)[0];
+    assert_eq!(dispatch.phase, ChildDispatchPhase::Terminal);
+    assert_eq!(dispatch.child_status.as_deref(), Some("failed"));
+    assert_eq!(dispatch.error.as_deref(), Some(concrete_error));
+
+    let error = pipeline_success_guard(
+        "pipeline_success_guard",
+        &json!({ "context": "workspace auto leaf ship", "results": [output] }),
+    )
+    .expect_err("the parent must fail on the terminal mixed-crew child");
+    let message = action_failure_message(error, "pipeline_success_guard");
+    assert!(message.contains("mixes crews"), "{message}");
+}
+
+#[test]
 fn a_wait_that_errors_leaves_the_child_linked_without_claiming_it_failed() {
     let (runtime, parent) = parent_runtime();
 

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
@@ -294,6 +294,14 @@ fn two_loose_tasks_and_one_epic_root_are_admissible_together() {
     // the same iteration: the drain ships the leaves and starts the epic.
     let first = classify(&runtime);
     assert_eq!(first["loose_task_ids"], json!([loose_one.id, loose_two.id]));
+    assert_eq!(
+        first["loose_task_dispatches"].as_array().map(Vec::len),
+        Some(1)
+    );
+    assert_eq!(
+        first["loose_task_dispatches"][0]["task_ids"],
+        json!([loose_one.id, loose_two.id])
+    );
     assert_eq!(first["has_leaves"], true);
     assert_eq!(first["epic_task_id"], epic.id);
     assert_eq!(first["has_epic"], true);
@@ -314,6 +322,106 @@ fn two_loose_tasks_and_one_epic_root_are_admissible_together() {
     assert_eq!(second["epic_task_id"], epic.id);
     assert_eq!(second["loose_task_ids"], json!([]));
     assert_eq!(second["has_leaves"], false);
+}
+
+#[test]
+fn loose_tasks_are_partitioned_by_effective_crew_in_priority_order() {
+    let root = tempfile::tempdir().expect("create tempdir");
+    let global = root.path().join("home/.orbit");
+    let workspace = root.path().join("repo/.orbit");
+    std::fs::create_dir_all(&global).expect("global orbit dir");
+    std::fs::create_dir_all(&workspace).expect("workspace orbit dir");
+    std::fs::write(
+        workspace.join("config.toml"),
+        r#"
+[workflow]
+default_crew = "sol"
+
+[crews.sol]
+provider = "codex"
+backend = "cli"
+model = "gpt-5.6-sol"
+
+[crews.terra]
+provider = "codex"
+backend = "cli"
+model = "gpt-5.6-terra"
+"#,
+    )
+    .expect("write crew fixture");
+    let runtime = OrbitRuntime::from_roots(&global, &workspace).expect("build runtime");
+
+    let sol_high = runtime
+        .add_task(TaskAddParams {
+            title: "Sol high".to_string(),
+            description: "Crew partition fixture".to_string(),
+            priority: TaskPriority::High,
+            crew: Some("sol".to_string()),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("seed sol task");
+    let terra = runtime
+        .add_task(TaskAddParams {
+            title: "Terra medium".to_string(),
+            description: "Crew partition fixture".to_string(),
+            priority: TaskPriority::Medium,
+            crew: Some("terra".to_string()),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("seed terra task");
+    let sol_low = runtime
+        .add_task(TaskAddParams {
+            title: "Sol low".to_string(),
+            description: "Crew partition fixture".to_string(),
+            priority: TaskPriority::Low,
+            crew: Some("sol".to_string()),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("seed second sol task");
+
+    let output = classify(&runtime);
+    assert_eq!(
+        output["loose_task_ids"],
+        json!([sol_high.id, terra.id, sol_low.id])
+    );
+    assert_eq!(
+        output["loose_task_dispatches"],
+        json!([
+            { "crew": "sol", "task_ids": [sol_high.id, sol_low.id] },
+            { "crew": "terra", "task_ids": [terra.id] },
+        ])
+    );
+    for dispatch in output["loose_task_dispatches"]
+        .as_array()
+        .expect("dispatch partitions")
+    {
+        let input = json!({ "task_ids": dispatch["task_ids"] });
+        let run = runtime
+            .stores()
+            .jobs()
+            .insert_job_run(
+                "task_auto_pipeline",
+                1,
+                Utc::now(),
+                Some(input.clone()),
+                None,
+            )
+            .expect("insert homogeneous child");
+        runtime
+            .record_run_crew_from_input(&run.run_id, &input)
+            .expect("persist homogeneous child crew");
+        assert_eq!(
+            runtime
+                .show_job_run(&run.run_id)
+                .expect("show homogeneous child")
+                .resolved_crew
+                .as_deref(),
+            dispatch["crew"].as_str()
+        );
+    }
 }
 
 /// The `hold` decision this replaces froze every conflict-free chore for as

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs
@@ -41,6 +41,7 @@ pub(super) fn classify_workspace_auto_tasks(
         .and_then(Value::as_array)
         .cloned()
         .unwrap_or_default();
+    let loose_task_dispatches = crew_homogeneous_dispatches(runtime, action, &loose_task_ids)?;
 
     let active_epic = active_epic_run(runtime, action)?;
     let epic_task_id = match &active_epic {
@@ -58,6 +59,7 @@ pub(super) fn classify_workspace_auto_tasks(
     let has_epic = epic_task_id.is_some();
     Ok(json!({
         "loose_task_ids": loose_task_ids,
+        "loose_task_dispatches": loose_task_dispatches,
         "has_leaves": has_leaves,
         "epic_task_id": epic_task_id,
         "has_epic": has_epic,
@@ -65,6 +67,46 @@ pub(super) fn classify_workspace_auto_tasks(
         "active_epic_run_id": active_epic.as_ref().map(|epic| epic.run_id.clone()),
         "active_epic_task_id": active_epic.and_then(|epic| epic.task_id),
     }))
+}
+
+/// Partition the already priority-ordered loose leaves by their effective
+/// crew, preserving both task order within a partition and the first-seen
+/// order of the crews. `task_auto_pipeline` resolves the crew again from the
+/// child input and therefore remains the fail-closed authority; this split
+/// only prevents workspace-auto from constructing a heterogeneous child in
+/// the first place.
+fn crew_homogeneous_dispatches(
+    runtime: &OrbitRuntime,
+    action: &str,
+    task_ids: &[Value],
+) -> Result<Vec<Value>, DispatchError> {
+    let mut partitions: Vec<(String, Vec<String>)> = Vec::new();
+    for task_id in task_ids.iter().filter_map(Value::as_str) {
+        let task = runtime.get_task(task_id).map_err(|err| {
+            action_failed(
+                action,
+                format!("load loose task {task_id} for crew partition: {err}"),
+            )
+        })?;
+        let crew = runtime
+            .resolve_crew_for_task(None, task.crew.as_deref())
+            .map_err(|err| {
+                action_failed(
+                    action,
+                    format!("resolve crew for loose task {task_id}: {err}"),
+                )
+            })?;
+        if let Some((_, ids)) = partitions.iter_mut().find(|(name, _)| name == &crew.name) {
+            ids.push(task_id.to_string());
+        } else {
+            partitions.push((crew.name, vec![task_id.to_string()]));
+        }
+    }
+
+    Ok(partitions
+        .into_iter()
+        .map(|(crew, task_ids)| json!({ "crew": crew, "task_ids": task_ids }))
+        .collect())
 }
 
 /// A live `epic_pipeline` run, if one is already supervising a root.

--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -701,33 +701,39 @@ impl OrbitRuntime {
             .input
             .clone()
             .unwrap_or_else(|| Value::Object(Default::default()));
-        self.record_run_crew_from_input(&run.run_id, &input)?;
+        // Once Start succeeds, every later error belongs to this run. Keep the
+        // whole setup path inside the outcome finalized below so crew
+        // validation, event persistence, and resume-state reads cannot escape
+        // with a durable `running` projection.
+        let outcome = (|| {
+            self.record_run_crew_from_input(&run.run_id, &input)?;
 
-        self.record_event(OrbitEvent::JobRunStarted {
-            job_id: run.job_id.clone(),
-            run_id: run.run_id.clone(),
-            attempt: run.attempt,
-        })?;
+            self.record_event(OrbitEvent::JobRunStarted {
+                job_id: run.job_id.clone(),
+                run_id: run.run_id.clone(),
+                attempt: run.attempt,
+            })?;
 
-        // [ORB-10470] The run's own persisted checkpoints are the resume
-        // cursor. A run seeded by `submit_resume_run` starts at the source's
-        // first non-successful step; a run whose previous worker died after
-        // checkpointing continues from where that worker stopped. Reusing a
-        // checkpoint is therefore idempotent — the successful steps are
-        // skipped, never re-dispatched.
-        let resume = self.read_run_state(&run.run_id)?.filter(|state| {
-            state
-                .step_states
-                .values()
-                .any(|step_state| *step_state == JobRunState::Success)
-        });
-        let outcome = self.run_job_v2_from_yaml_with_run_id_and_resume(
-            yaml_path,
-            input.clone(),
-            Some(run.run_id.clone()),
-            run.retry_source_run_id.clone(),
-            resume.as_ref(),
-        );
+            // [ORB-10470] The run's own persisted checkpoints are the resume
+            // cursor. A run seeded by `submit_resume_run` starts at the
+            // source's first non-successful step; a run whose previous worker
+            // died after checkpointing continues from where that worker
+            // stopped. Reusing a checkpoint is therefore idempotent — the
+            // successful steps are skipped, never re-dispatched.
+            let resume = self.read_run_state(&run.run_id)?.filter(|state| {
+                state
+                    .step_states
+                    .values()
+                    .any(|step_state| *step_state == JobRunState::Success)
+            });
+            self.run_job_v2_from_yaml_with_run_id_and_resume(
+                yaml_path,
+                input.clone(),
+                Some(run.run_id.clone()),
+                run.retry_source_run_id.clone(),
+                resume.as_ref(),
+            )
+        })();
         let finished_at = Utc::now();
         self.finalize_v2_pipeline_run(
             run,
@@ -768,7 +774,9 @@ impl OrbitRuntime {
         message: &str,
         state: JobRunState,
     ) -> Result<(), OrbitError> {
-        let current = self.show_job_run(&run.run_id)?;
+        let current = self
+            .get_job_run_backend(&run.run_id)?
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run.run_id.clone()))?;
         let already_has_error = current
             .steps
             .iter()
@@ -985,9 +993,14 @@ impl OrbitRuntime {
         actor: Option<&str>,
     ) -> Result<(), OrbitError> {
         let child_pid = child.id();
+        let mut claimed = false;
         loop {
-            let run = self.show_job_run(run_id)?;
-            if let Some(owner_pid) = run.pid {
+            let run = self
+                .get_job_run_backend(run_id)?
+                .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string()))?;
+            if let Some(owner_pid) = run.pid
+                && !claimed
+            {
                 let _ = self.record_pipeline_audit(
                     "pipeline.worker.claimed",
                     Some(run_id),
@@ -1003,10 +1016,7 @@ impl OrbitRuntime {
                     }),
                     None,
                 );
-                return Ok(());
-            }
-            if run.state != JobRunState::Pending {
-                return Ok(());
+                claimed = true;
             }
 
             if let Some(status) = child.try_wait().map_err(|error| {
@@ -1020,20 +1030,91 @@ impl OrbitRuntime {
                     .filter(|value| !value.is_empty())
                     .map(|value| format!("; worker output:\n{value}"))
                     .unwrap_or_default();
+                if run.state.is_terminal() {
+                    return Ok(());
+                }
+                let ownership = if run.pid.is_some() {
+                    "after claiming"
+                } else {
+                    "before claiming"
+                };
                 let message = format!(
-                    "pipeline worker for run '{run_id}' exited with status {status} before \
-                     claiming the persisted run from registered workspace '{}'; worker log: \
+                    "pipeline worker for run '{run_id}' exited with status {status} {ownership} \
+                     the persisted run from registered workspace '{}'; worker log: \
                      '{}'{output_detail}; verify workspace registration, worker root discovery, \
                      and action availability",
                     workspace.display(),
                     worker_log.display(),
                 );
-                self.finalize_pipeline_worker_startup_failure(&run, &message, actor)?;
+                self.finalize_pipeline_worker_exit_failure(&run, &message, actor)?;
                 return Ok(());
             }
 
             thread::sleep(Duration::from_millis(25));
         }
+    }
+
+    /// Terminalize a worker process that exited while it still owned a
+    /// non-terminal run. `try_wait` has already reaped the process when this is
+    /// called. Pending exits are interrupted startup; a worker that reached
+    /// running failed its claimed execution.
+    fn finalize_pipeline_worker_exit_failure(
+        &self,
+        run: &JobRun,
+        message: &str,
+        actor: Option<&str>,
+    ) -> Result<(), OrbitError> {
+        let current = self
+            .get_job_run_backend(&run.run_id)?
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run.run_id.clone()))?;
+        let (state, started_at, audit_name) = match current.state {
+            JobRunState::Pending => (
+                JobRunState::Interrupted,
+                current.scheduled_at,
+                "pipeline.worker.startup",
+            ),
+            JobRunState::Running => (
+                JobRunState::Failed,
+                current.started_at.unwrap_or(current.scheduled_at),
+                "pipeline.worker.exit",
+            ),
+            _ => return Ok(()),
+        };
+        let finished_at = Utc::now();
+        self.record_pipeline_diagnostic_step(
+            &current,
+            started_at,
+            finished_at,
+            None,
+            message,
+            state,
+        )?;
+        let changed = self.finalize_job_run_with_reservation_cleanup(
+            &current.run_id,
+            state,
+            finished_at,
+            None,
+            TaskReservationReleaseReason::RunTerminal,
+        )?;
+        if changed {
+            self.record_event(OrbitEvent::JobRunCompleted {
+                job_id: current.job_id.clone(),
+                run_id: current.run_id.clone(),
+                state: state.to_string(),
+            })?;
+        }
+        self.record_pipeline_audit(
+            audit_name,
+            Some(&current.run_id),
+            actor,
+            AuditEventStatus::Failure,
+            json!({
+                "run_id": current.run_id,
+                "workspace": self.paths().repo_root,
+                "worker_log": pipeline_worker_log_path(&self.paths().logs_dir, &current.run_id),
+            }),
+            Some(message.to_string()),
+        )
     }
 
     fn finalize_pipeline_worker_startup_failure(

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -1040,13 +1040,29 @@ fn workspace_auto_pipeline_is_single_flight_and_conditionally_dispatches() {
         ship.when.as_deref(),
         Some("{{ steps.admissible.output.has_leaves }} == true")
     );
-    let JobV2StepBody::TargetRef(ship_target) = &ship.body else {
-        panic!("ship step must invoke and wait");
+    let JobV2StepBody::FanOut { fan_out, fan_in } = &ship.body else {
+        panic!("ship step must fan out crew-homogeneous dispatches");
+    };
+    assert_eq!(
+        fan_out.items,
+        "{{ steps.admissible.output.loose_task_dispatches }}"
+    );
+    assert_eq!(fan_out.max_workers, 5);
+    assert_eq!(fan_in.collect.as_deref(), Some("leaf_results"));
+    let JobV2StepBody::TargetRef(ship_target) = &fan_out.worker.body else {
+        panic!("each leaf partition must invoke and wait");
     };
     assert_eq!(ship_target.target, "activity:invoke_and_wait");
+    let ship_input = ship_target.default_input.as_ref().expect("ship input");
+    assert_eq!(ship_input["job_name"], "task_auto_pipeline");
+    assert_eq!(ship_input["run_input"]["task_ids"], "{{ item.task_ids }}");
+
+    let JobV2StepBody::TargetRef(guard) = &drain.steps[2].body else {
+        panic!("leaf success guard must be an activity reference");
+    };
     assert_eq!(
-        ship_target.default_input.as_ref().expect("ship input")["job_name"],
-        "task_auto_pipeline"
+        guard.default_input.as_ref().expect("guard input")["results"],
+        "{{ steps.leaf_results.output }}"
     );
 
     // The epic must NOT be waited on: blocking on a multi-hour epic would

--- a/crates/orbit-core/src/application/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/application/tests/job_pipeline.rs
@@ -7,8 +7,9 @@ use std::time::{Duration, Instant};
 use chrono::Utc;
 use orbit_common::OrbitError;
 use orbit_store::maintenance::migration::SUPPORTED_SCHEMA_VERSION;
+use orbit_types::task::TaskStatus;
 use orbit_types::telemetry::AuditEventStatus;
-use orbit_types::workflow::JobRunState;
+use orbit_types::workflow::{JobRunStartOutcome, JobRunState};
 use orbit_types::workspace::WorkspacePaths;
 use tempfile::TempDir;
 
@@ -28,6 +29,40 @@ fn test_runtime() -> (TempDir, OrbitRuntime) {
     let workspace_root = root.path().join("repo/.orbit");
     std::fs::create_dir_all(&global_root).expect("create global root");
     std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    let runtime =
+        OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build test runtime");
+    (root, runtime)
+}
+
+fn test_runtime_with_named_crews() -> (TempDir, OrbitRuntime) {
+    let root = TempDir::new().expect("tempdir");
+    let global_root = root.path().join("global");
+    let workspace_root = root.path().join("repo/.orbit");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    std::fs::write(
+        workspace_root.join("config.toml"),
+        r#"
+[workflow]
+default_crew = "primary"
+
+[crews.primary]
+provider = "codex"
+backend = "cli"
+model = "default-model"
+
+[crews.terra]
+provider = "codex"
+backend = "cli"
+model = "terra-model"
+
+[crews.sol]
+provider = "codex"
+backend = "cli"
+model = "sol-model"
+"#,
+    )
+    .expect("write crew config");
     let runtime =
         OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build test runtime");
     (root, runtime)
@@ -258,6 +293,179 @@ fn routine_style_detached_worker_is_claimed_within_ownership_window() {
     );
     let durable_output = wait_for_log_contains(&log_path, "routine worker startup");
     assert!(durable_output.contains("routine worker startup"));
+
+    let terminal = wait_for_worker_terminal(&runtime, &run.run_id);
+    assert_eq!(terminal.state, JobRunState::Interrupted);
+    let message = terminal
+        .steps
+        .last()
+        .and_then(|step| step.error_message.as_deref())
+        .expect("claimed exit diagnostic");
+    assert!(message.contains("after claiming"), "{message}");
+    assert_child_reaped(worker_pid);
+}
+
+#[cfg(unix)]
+#[test]
+fn worker_exit_after_mark_running_is_reaped_and_terminalizes_the_run() {
+    let (_root, runtime) = test_runtime();
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("task_auto_pipeline", 1, Utc::now(), None, None)
+        .expect("insert pending run");
+    let release_path = runtime.paths().logs_dir.join("release-claimed-worker");
+    let mut command = Command::new("sh");
+    command.env("ORBIT_TEST_WORKER_RELEASE", &release_path);
+    command.args([
+        "-c",
+        "while [ ! -f \"$ORBIT_TEST_WORKER_RELEASE\" ]; do sleep 0.01; done; \
+         printf 'post-claim validation exploded\\n' >&2; exit 29",
+    ]);
+    let log_path =
+        configure_pipeline_worker_stdio(&mut command, &runtime.paths().logs_dir, &run.run_id)
+            .expect("configure worker log");
+    let worker_pid = runtime
+        .spawn_pipeline_worker_process(&run.run_id, Some("test"), command, log_path)
+        .expect("spawn claimed worker fixture");
+    runtime
+        .stores()
+        .jobs()
+        .claim_pending_job_run_owner(&run.run_id, worker_pid)
+        .expect("claim run owner");
+    assert_eq!(
+        runtime
+            .stores()
+            .jobs()
+            .mark_job_run_running(&run.run_id, Utc::now(), worker_pid)
+            .expect("mark run running"),
+        JobRunStartOutcome::Started
+    );
+    assert_eq!(
+        runtime
+            .show_job_run(&run.run_id)
+            .expect("show running fixture")
+            .state,
+        JobRunState::Running
+    );
+    std::fs::write(&release_path, "release").expect("release claimed worker");
+
+    let terminal = wait_for_worker_terminal(&runtime, &run.run_id);
+    let message = terminal
+        .steps
+        .last()
+        .and_then(|step| step.error_message.as_deref())
+        .expect("post-claim diagnostic");
+    assert_eq!(terminal.state, JobRunState::Failed, "{message}");
+    assert!(terminal.finished_at.is_some());
+    assert!(message.contains("after claiming"), "{message}");
+    assert!(message.contains("exit status: 29"), "{message}");
+    assert!(
+        message.contains("post-claim validation exploded"),
+        "{message}"
+    );
+    assert_child_reaped(worker_pid);
+}
+
+#[test]
+fn mixed_crew_validation_after_start_terminalizes_without_admitting_tasks() {
+    let (_root, runtime) = test_runtime_with_named_crews();
+    let jobs_dir = runtime.paths().global_dir.join("resources/jobs");
+    std::fs::create_dir_all(&jobs_dir).expect("create jobs dir");
+    std::fs::write(
+        jobs_dir.join("task_auto_pipeline.yaml"),
+        r#"schemaVersion: 2
+kind: Job
+metadata:
+  name: task_auto_pipeline
+spec:
+  state: enabled
+  kind: workflow
+  max_active_runs: 10
+  steps:
+    - id: unreachable
+      spec:
+        type: deterministic
+        action: sleep
+        config: {}
+"#,
+    )
+    .expect("seed task_auto_pipeline definition");
+    let terra = runtime
+        .add_task(TaskAddParams {
+            title: "Terra task".to_string(),
+            description: "Mixed crew fixture".to_string(),
+            crew: Some("terra".to_string()),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("add terra task");
+    let sol = runtime
+        .add_task(TaskAddParams {
+            title: "Sol task".to_string(),
+            description: "Mixed crew fixture".to_string(),
+            crew: Some("sol".to_string()),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("add sol task");
+    let input = serde_json::json!({ "task_ids": [terra.id, sol.id] });
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run(
+            "task_auto_pipeline",
+            1,
+            Utc::now(),
+            Some(input.clone()),
+            None,
+        )
+        .expect("insert mixed-crew run");
+    runtime
+        .seed_v2_pipeline_run(&run, &input, None)
+        .expect("seed pipeline state");
+
+    let error = runtime
+        .execute_pipeline_run_worker(&run.run_id)
+        .expect_err("direct mixed-crew input must fail closed");
+    let message = error.to_string();
+    assert!(message.contains("mixes crews"), "{message}");
+    assert!(message.contains("workflow.default_crew"), "{message}");
+
+    let terminal = runtime.show_job_run(&run.run_id).expect("show failed run");
+    assert_eq!(terminal.state, JobRunState::Failed);
+    assert!(terminal.finished_at.is_some());
+    assert!(terminal.resolved_crew.is_none());
+    let diagnostic = terminal.steps.last().expect("failure diagnostic");
+    assert!(
+        diagnostic
+            .error_message
+            .as_deref()
+            .is_some_and(|value| value.contains("mixes crews"))
+    );
+    for task_id in [&terra.id, &sol.id] {
+        assert_eq!(
+            runtime
+                .get_task(task_id)
+                .expect("task remains readable")
+                .status,
+            TaskStatus::Backlog,
+            "mixed-crew validation must happen before task admission"
+        );
+    }
+
+    let started = Instant::now();
+    let waited = runtime
+        .wait_pipeline_runs(std::slice::from_ref(&run.run_id), 10, 1, Some("test"))
+        .expect("terminal child is immediately observable");
+    assert!(started.elapsed() < Duration::from_secs(1));
+    assert_eq!(waited.results[0].status, "failed");
+    assert!(
+        waited.results[0]
+            .error
+            .as_deref()
+            .is_some_and(|value| value.contains("mixes crews"))
+    );
 }
 
 fn wait_for_worker_ownership_outcome(
@@ -266,7 +474,10 @@ fn wait_for_worker_ownership_outcome(
 ) -> orbit_types::workflow::JobRun {
     let deadline = Instant::now() + Duration::from_secs(2);
     loop {
-        let stored = runtime.show_job_run(run_id).expect("show worker run");
+        let stored = runtime
+            .get_job_run_backend(run_id)
+            .expect("read worker run")
+            .expect("worker run exists");
         if stored.pid.is_some() || stored.state != JobRunState::Pending {
             return stored;
         }
@@ -276,6 +487,38 @@ fn wait_for_worker_ownership_outcome(
         );
         thread::sleep(Duration::from_millis(10));
     }
+}
+
+fn wait_for_worker_terminal(runtime: &OrbitRuntime, run_id: &str) -> orbit_types::workflow::JobRun {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let stored = runtime
+            .get_job_run_backend(run_id)
+            .expect("read worker run")
+            .expect("worker run exists");
+        if stored.state.is_terminal() {
+            return stored;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "worker remained non-terminal beyond ownership window"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[cfg(unix)]
+fn assert_child_reaped(pid: u32) {
+    let mut status = 0;
+    // SAFETY: `waitpid` only inspects the explicitly spawned fixture PID and
+    // writes to the valid local status pointer.
+    let result = unsafe { libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG) };
+    assert_eq!(result, -1, "worker {pid} is still a waitable child");
+    assert_eq!(
+        std::io::Error::last_os_error().raw_os_error(),
+        Some(libc::ECHILD),
+        "worker {pid} must already have been reaped by the observer"
+    );
 }
 
 /// Retry a pipeline audit lookup instead of asserting on a single snapshot:


### PR DESCRIPTION
## Task

[ORB-10979](https://orbit-cli.com/tasks/ORB-10979) — Partition workspace-auto by crew and terminalize claimed worker startup failures

### Description

## Problem

Orbit incident `jrun-20260822-2252` exposed a two-layer failure that turns a concrete, immediate validation error into a hung workspace-auto lane.

`workspace_auto_pipeline` selected eligible loose backlog tasks `ORB-10977` (`crew: sol`) and `ORB-10962` (`crew: terra`) and submitted them together as child `task_auto_pipeline` run `jrun-20260822-2252-2`. The child correctly rejected the heterogeneous bundle with:

`invalid input: task bundle mixes crews terra and sol; split the bundle or assign one crew instead of inheriting workflow.default_crew`

That fail-closed behavior is intentional under ORB-10920. The integration bug is that `workspace_auto_pipeline` forwards all `loose_task_ids` to one child even when their resolved crews differ, rather than partitioning them into homogeneous dispatch units.

The runtime then compounds the dispatch error. `execute_pipeline_run_now` marks the child run running before `record_run_crew_from_input(...)?`. Crew resolution can return an error at that point, before `finalize_v2_pipeline_run` is reached. The detached-worker observer stops monitoring as soon as it sees the claimed PID, so the exited worker is not reaped and the durable child remains non-terminal. In the incident, child PID 1219249 exited status 1 and remained a zombie while parent PID 1219238 slept in `pipeline.wait`; the parent can remain in `ship_leaves` until the one-hour timeout.

## Why It Matters

A normal heterogeneous backlog is enough to block `workspace_auto_pipeline`, whose `max_active_runs: 1` then prevents the workspace logistics lane from making further progress. Operators see a running parent and child even though the actionable error already exists in the child worker log.

## Constraints / Notes

- Preserve ORB-10920's fail-closed rule for a directly submitted mixed-crew task bundle. Never silently choose one crew or fall back to `workflow.default_crew`.
- Partition workspace-auto loose leaves before child submission so each child is crew-homogeneous. Singleton dispatch is acceptable; deterministic grouping by resolved crew is preferable if it preserves existing conflict and ordering guarantees.
- Preserve ORB-10819/ORB-10971's blocking `ship_leaves` contract and durable parent-child linkage.
- Once a worker has claimed or marked a run running, every subsequent setup/validation error must pass through terminal finalization and reservation/task cleanup with the concrete error retained.
- The parent-side worker observer or equivalent ownership mechanism must reap exited children after claim; no zombie may be left solely because ownership was recorded.
- Tests must use isolated stores/fake workers and must not require a live provider login or workspace-local production state.
- Rollback is a revert of the partition/finalization changes; do not weaken mixed-crew validation as a rollback shortcut.

### Acceptance Criteria

- A deterministic workspace_auto_pipeline fixture with two eligible conflict-free loose tasks assigned to terra and sol submits separate crew-homogeneous task_auto_pipeline children (or singleton children), and each child persists the crew selected from its task(s).
- A directly submitted task_auto_pipeline input containing terra and sol tasks still fails closed with the explicit mixed-crew error; neither workspace default nor an arbitrary task crew is selected.
- A deterministic failure injected after mark_job_run_running but before normal v2 execution finalization—covering record_run_crew_from_input's mixed-crew error—terminalizes the child within a bounded interval with finished_at, a diagnostic step containing the concrete error, and no durable running projection.
- The detached worker process is reaped after both pre-claim and post-claim exits; a process-level fixture verifies no zombie child remains.
- When a linked child terminalizes from this validation failure, invoke_and_wait observes the terminal result promptly, closes the parent child-dispatch record, and pipeline_success_guard fails the parent without waiting for the one-hour timeout.
- No task is partially admitted or left in-progress when the heterogeneous bundle is rejected before implementation; the original tasks remain independently dispatchable.
- CLI/MCP/API/dashboard run projections agree on the terminal child status, concrete error, parent-child linkage, and parent ship_leaves outcome.
- Focused workspace-auto, crew-resolution, detached-worker, and parent/child wait tests pass, followed by make ci-fast and lint/format checks.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Partitioned workspace-auto loose leaves into deterministic first-seen crew groups and fan out one blocking task_auto_pipeline child per homogeneous group; the child still resolves and persists its crew from its task IDs.
- Kept direct mixed-crew task_auto_pipeline submissions fail-closed with the existing concrete workflow.default_crew diagnostic, and finalized every post-Start setup/validation error as a failed run with finished_at, a diagnostic step, reservation cleanup, and completion event.
- Kept the detached-worker observer alive after claim, used raw run reads to avoid reconciliation racing process observation, terminalized non-terminal post-claim exits, and reaped Child handles for both pre-claim and post-claim exits.
- Added deterministic workspace-auto grouping/crew persistence, direct mixed-crew lifecycle/admission, parent-child wait/guard, and Unix waitpid reaping coverage; synchronized the embedded and workspace managed job assets.
- Expanded context_files only for tightly coupled classifier, tests, catalog fixture, and managed asset copy required to compile and validate the behavior.
Assessment: The implementation preserves direct mixed-crew refusal and existing blocking child linkage while removing the heterogeneous workspace-auto dispatch and both durable-running/zombie failure modes.
Validation:
- cargo test -p orbit-core workspace_auto --lib (14 passed)
- cargo test -p orbit-core application::tests::job_pipeline --lib (19 passed)
- cargo test -p orbit-core adapter::engine_host::v2_host::tests::pipeline_actions --lib (12 passed)
- cargo test -p orbit-core runtime::engine::tests::crew --lib (14 passed)
- env -u ORBIT_ROOT cargo test -p orbit-core --lib (766 passed)
- make ci-fast (passed)
- make ci-lint (passed)
- git diff --check (passed)
Validation note: an initial full orbit-core run inherited the managed activity's ORBIT_ROOT and failed only the environment-resolution isolation module; the same module and then the full 766-test suite passed with that injected override removed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10979-6a8a2b7b`
- Behind base: 0
- Ahead of base: 1