### PR TITLE
Route managed CLI agents to the shared Orbit registry instead of a read-only worktree root

### DIFF
--- a/crates/orbit-cmd/src/tests/registry_runtime.rs
+++ b/crates/orbit-cmd/src/tests/registry_runtime.rs
@@ -521,3 +521,241 @@ fn task_ids(value: &Value) -> Vec<String> {
         })
         .collect()
 }
+
+/// [ORB-10980] A managed run executes its CLI agent in a linked worktree that
+/// is not a registered checkout and whose worktree-local `.orbit` is mounted
+/// read-only. The injected `ORBIT_ROOT` therefore has to be the authoritative
+/// registry root: that is what lets `orbit tool run orbit.task.show` find the
+/// injected task's owning checkout, and what a workspace-scoped mutation
+/// rebinds through. These tests pin that contract and the fail-closed
+/// behaviours around it.
+struct ManagedWorktreeFixture {
+    _root: tempfile::TempDir,
+    registry_root: PathBuf,
+    repo_root: PathBuf,
+    worktree_root: PathBuf,
+    task_id: String,
+}
+
+impl ManagedWorktreeFixture {
+    /// Roots as resolved when `ORBIT_ROOT` pins the registry: an explicit root
+    /// collapses global/shared/local onto the same directory.
+    fn pinned_registry_roots(&self) -> OrbitRuntimeRoots {
+        OrbitRuntimeRoots {
+            global_root: self.registry_root.clone(),
+            shared_root: self.registry_root.clone(),
+            local_root: self.registry_root.clone(),
+        }
+    }
+
+    /// Roots as resolved with no root override: the registry stays distinct
+    /// from the checkout's shared `.orbit` and the worktree-local one.
+    fn unpinned_roots(&self) -> OrbitRuntimeRoots {
+        OrbitRuntimeRoots {
+            global_root: self.registry_root.clone(),
+            shared_root: self.repo_root.join(".orbit"),
+            local_root: self.worktree_root.join(".orbit"),
+        }
+    }
+
+    fn task_store_dir(&self) -> PathBuf {
+        let partitions = self.registry_root.join("tasks/workspaces");
+        std::fs::read_dir(&partitions)
+            .expect("task partitions")
+            .filter_map(Result::ok)
+            .map(|entry| entry.path().join(&self.task_id))
+            .find(|candidate| candidate.is_dir())
+            .expect("authoritative task store directory")
+    }
+
+    fn show_runtime(&self) -> OrbitRuntime {
+        crate::task_owner::initialize_for_task_show(Some(&self.registry_root), None, &self.task_id)
+            .expect("task-show runtime from the registry root alone")
+    }
+
+    fn workspace_scoped_runtime(&self) -> OrbitRuntime {
+        RegisteredRuntimeFactory::initialize_with_overrides(
+            Some(&self.registry_root),
+            Some(&self.repo_root.to_string_lossy()),
+        )
+        .expect("workspace-scoped runtime")
+    }
+}
+
+fn run_tool(runtime: &OrbitRuntime, name: &str, input: Value) -> Result<Value, OrbitError> {
+    runtime.execute_tool_command(
+        name,
+        input,
+        Some("codex".to_string()),
+        Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+    )
+}
+
+fn managed_worktree_fixture() -> ManagedWorktreeFixture {
+    let root = tempfile::tempdir().expect("root");
+    let registry_root = root.path().join("registry");
+    std::fs::create_dir_all(&registry_root).expect("registry root");
+    std::fs::write(
+        registry_root.join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_managed\"\nhost_id = \"managed\"\ntask_prefix = \"ORB\"\n",
+    )
+    .expect("host identity");
+
+    let (workspace, checkout) =
+        registered_workspace(root.path(), "ws_managed", "managed", "hm_managed");
+    save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![workspace.clone()],
+            checkouts: vec![checkout.clone()],
+            ..Default::default()
+        },
+        &registry_path_for(&registry_root),
+    )
+    .expect("workspace registry");
+
+    let runtime =
+        RegisteredRuntimeFactory::open_registered_checkout(&registry_root, &workspace, &checkout)
+            .expect("registered runtime");
+    let created = run_tool(
+        &runtime,
+        "orbit.task.add",
+        json!({
+            "title": "Injected managed task",
+            "description": "Seeded into the authoritative registered store.",
+            "complexity": "low",
+            "workspace": checkout.repo_root
+        }),
+    )
+    .expect("seed managed task");
+
+    // The linked worktree is deliberately unregistered and its worktree-local
+    // `.orbit` is read-only, exactly as the managed sandbox mounts it.
+    let worktree_root = checkout
+        .repo_root
+        .join(".orbit/state/worktrees/jrun-managed-fixture");
+    let worktree_state = worktree_root.join(".orbit");
+    std::fs::create_dir_all(&worktree_state).expect("worktree state root");
+    set_readonly(&worktree_state, true);
+
+    ManagedWorktreeFixture {
+        _root: root,
+        registry_root,
+        repo_root: checkout.repo_root,
+        worktree_root,
+        task_id: created["id"].as_str().expect("seeded task id").to_string(),
+    }
+}
+
+fn set_readonly(path: &Path, readonly: bool) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = std::fs::metadata(path)
+        .expect("fixture path metadata")
+        .permissions();
+    permissions.set_mode(if readonly { 0o555 } else { 0o755 });
+    std::fs::set_permissions(path, permissions).expect("fixture permissions");
+}
+
+#[test]
+fn managed_registry_root_serves_task_show_and_workspace_scoped_update() {
+    let fixture = managed_worktree_fixture();
+
+    let shown = run_tool(
+        &fixture.show_runtime(),
+        "orbit.task.show",
+        json!({ "id": fixture.task_id }),
+    )
+    .expect("registry root alone must resolve the injected task");
+    assert_eq!(shown["id"], fixture.task_id);
+
+    run_tool(
+        &fixture.workspace_scoped_runtime(),
+        "orbit.task.update",
+        json!({
+            "id": fixture.task_id,
+            "plan": "Authored through the documented CLI fallback."
+        }),
+    )
+    .expect("workspace-scoped update must reach the registered store");
+
+    let after = run_tool(
+        &fixture.show_runtime(),
+        "orbit.task.show",
+        json!({ "id": fixture.task_id, "field": "plan" }),
+    )
+    .expect("re-read through the registry");
+    assert_eq!(
+        after, "Authored through the documented CLI fallback.",
+        "the update must land in the authoritative registered store: {after}"
+    );
+}
+
+#[test]
+fn managed_worktree_cwd_without_a_selector_fails_closed_under_a_pinned_registry_root() {
+    let fixture = managed_worktree_fixture();
+
+    assert!(
+        select_workspace_for_cwd_and_roots(
+            &fixture.worktree_root,
+            &fixture.pinned_registry_roots()
+        )
+        .expect("selection")
+        .is_none(),
+        "an unregistered worktree cwd must not silently bind a workspace under a pinned root"
+    );
+
+    let unknown = match RegisteredRuntimeFactory::initialize_with_overrides(
+        Some(&fixture.registry_root),
+        Some("no-such-workspace"),
+    ) {
+        Ok(_) => panic!("an invalid selector must fail closed"),
+        Err(error) => error,
+    };
+    unsupported_workspace_message(unknown, "no-such-workspace");
+}
+
+#[test]
+fn read_only_authoritative_store_reports_a_path_attributed_permission_error() {
+    let fixture = managed_worktree_fixture();
+    let store_dir = fixture.task_store_dir();
+    let runtime = fixture.workspace_scoped_runtime();
+    set_readonly(&store_dir, true);
+
+    let error = run_tool(
+        &runtime,
+        "orbit.task.update",
+        json!({
+            "id": fixture.task_id,
+            "plan": "Must not be written to a read-only store."
+        }),
+    )
+    .expect_err("a genuine write against a read-only store must fail");
+    let message = error.to_string();
+    set_readonly(&store_dir, false);
+
+    assert!(
+        message.contains(&store_dir.display().to_string()),
+        "a permission failure must name the path it could not write: {message}"
+    );
+    assert!(
+        message.contains("Permission denied"),
+        "a read-only store must be reported as a permission failure, not a missing task: {message}"
+    );
+}
+
+#[test]
+fn unpinned_root_resolution_still_binds_the_registered_checkout() {
+    let fixture = managed_worktree_fixture();
+    let roots = fixture.unpinned_roots();
+
+    let from_checkout = select_workspace_for_cwd_and_roots(&fixture.repo_root, &roots)
+        .expect("selection from the registered checkout")
+        .expect("registered checkout must bind");
+    assert_eq!(from_checkout.workspace.id, "ws_managed");
+
+    let from_worktree = select_workspace_for_cwd_and_roots(&fixture.worktree_root, &roots)
+        .expect("selection from the linked worktree")
+        .expect("shared-root fallback must bind the registered checkout");
+    assert_eq!(from_worktree.workspace.id, "ws_managed");
+    assert_eq!(from_worktree.checkout.repo_root, fixture.repo_root);
+}

--- a/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
@@ -269,11 +269,11 @@ impl RuntimeHost for OrbitRuntime {
             .agent_subprocess_env(required_env_vars)
     }
 
-    fn orbit_root(&self) -> Option<String> {
+    fn orbit_registry_root(&self) -> Option<String> {
         Some(
             self.context
                 .paths()
-                .orbit_dir
+                .global_dir
                 .to_string_lossy()
                 .into_owned(),
         )

--- a/crates/orbit-core/src/adapter/engine_host/tests/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/tests/runtime_host.rs
@@ -1065,3 +1065,41 @@ fn direct_update_identity_prefers_model_for_authored_roles() {
         .expect("review task with explicit identity");
     assert_eq!(reviewed.implemented_by.as_deref(), Some("gpt-explicit"));
 }
+
+/// [ORB-10980] `ORBIT_ROOT` for a spawned CLI agent must name the authoritative
+/// shared registry root. A managed run's workspace `.orbit` and its
+/// worktree-local `.orbit` are both mounted read-only and neither owns the task
+/// store, so reporting either one strands the documented `orbit tool run`
+/// fallback before the agent can read or update its own task.
+#[test]
+fn orbit_registry_root_reports_the_registry_not_a_workspace_state_root() {
+    let root = tempdir().expect("create tempdir");
+    let registry_root = root.path().join("registry");
+    let repo_root = root.path().join("repo");
+    let workspace_state_root = repo_root.join(".orbit");
+    let worktree_state_root = workspace_state_root
+        .join("state/worktrees/jrun-fixture")
+        .join(".orbit");
+    for directory in [&registry_root, &workspace_state_root, &worktree_state_root] {
+        fs::create_dir_all(directory).expect("state root");
+    }
+
+    let runtime = OrbitRuntime::from_resolved_roots(
+        &registry_root,
+        &workspace_state_root,
+        &worktree_state_root,
+    )
+    .expect("linked-worktree runtime");
+    let reported = RuntimeHost::orbit_registry_root(&runtime).expect("registry root");
+    assert_eq!(Path::new(&reported), registry_root);
+    assert_ne!(
+        Path::new(&reported),
+        workspace_state_root,
+        "the workspace state root is read-only in a managed run and is not the registry"
+    );
+    assert_ne!(
+        Path::new(&reported),
+        worktree_state_root,
+        "the worktree-local state root is read-only in a managed run and is not the registry"
+    );
+}

--- a/crates/orbit-core/src/runtime/tests/resolve.rs
+++ b/crates/orbit-core/src/runtime/tests/resolve.rs
@@ -19,6 +19,9 @@ static ENV_LOCK: Mutex<()> = Mutex::new(());
 #[test]
 fn caller_supplied_workspace_hint_keeps_registry_out_of_core_resolution() {
     let _guard = ENV_LOCK.lock().expect("lock env");
+    // `ORBIT_ROOT` outranks the caller hint, and a managed agent run exports
+    // one, so this case only tests hint precedence with the env root cleared.
+    let _root = EnvVarGuard::remove("ORBIT_ROOT");
     let home = tempdir().expect("home tempdir");
     let cwd = tempdir().expect("cwd tempdir");
     let hinted = tempdir().expect("hinted tempdir");

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -221,13 +221,21 @@ pub fn run_cli_backend(
         orbit_tool_env().map_err(|error| DispatchError::CliInvocationPermanent(error.message))?,
     );
     // Spawned CLI agents resolve the Orbit registry from $HOME unless
-    // ORBIT_ROOT is set. A dispatching run already knows its root; inject it so
-    // a provider whose HOME is a tool-specific directory (e.g. ~/.codex) can
-    // still reach `orbit tool run`. [ORB-10909]
-    if let Some(orbit_root) = host.orbit_root()
+    // ORBIT_ROOT is set. A dispatching run already knows its registry; inject
+    // it so a provider whose HOME is a tool-specific directory (e.g. ~/.codex)
+    // can still reach `orbit tool run`. [ORB-10909]
+    //
+    // The injected value is the authoritative shared registry root, never the
+    // dispatching checkout's workspace `.orbit`. A managed run's workspace
+    // state root is mounted read-only inside the sandbox and does not own the
+    // task store, so pinning a child there breaks the documented CLI fallback
+    // before any task work can start. Workspace routing is unchanged: a
+    // mutation still needs its own workspace selector and fails closed
+    // without a resolvable one. [ORB-10980]
+    if let Some(registry_root) = host.orbit_registry_root()
         && !dispatch_env.iter().any(|(key, _)| key == "ORBIT_ROOT")
     {
-        dispatch_env.push(("ORBIT_ROOT".to_string(), orbit_root));
+        dispatch_env.push(("ORBIT_ROOT".to_string(), registry_root));
     }
     // The child's whole environment is composed here and applied to a cleared
     // one by every launcher, so the `[execution.env]` allowlist governs what an

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/envelope.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/envelope.rs
@@ -52,7 +52,7 @@ fn cli_agent_envelope_carries_input_run_id_and_task_context() {
             "plan": "implement it"
         })),
         workspace_root: None,
-        orbit_root: None,
+        orbit_registry_root: None,
     };
     let mut spec = test_agent_loop_spec(Duration::from_secs(5));
     spec.instruction = "perform the requested task".to_string();

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -3,6 +3,7 @@
 use std::collections::{BTreeSet, HashMap};
 use std::ffi::OsString;
 use std::fs;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
@@ -874,7 +875,7 @@ fn run_cli_backend_returns_error_when_declared_workspace_path_missing() {
             "workspace_path": missing.display().to_string()
         })),
         workspace_root: None,
-        orbit_root: None,
+        orbit_registry_root: None,
     };
     let spec = test_agent_loop_spec(Duration::from_secs(5));
     let input = serde_json::json!({
@@ -934,7 +935,7 @@ fn run_cli_backend_records_resolved_cwd_in_started_event() {
             "workspace_path": workspace_string.clone()
         })),
         workspace_root: None,
-        orbit_root: None,
+        orbit_registry_root: None,
     };
     let spec = test_agent_loop_spec(Duration::from_secs(5));
 
@@ -1004,7 +1005,7 @@ fn linux_bwrap_failed_invocation_names_ungranted_write_path_and_deny() {
             "workspace_path": workspace.display().to_string()
         })),
         workspace_root: None,
-        orbit_root: None,
+        orbit_registry_root: None,
     };
     let spec = test_agent_loop_spec(Duration::from_secs(5));
 
@@ -1114,7 +1115,7 @@ fn linux_bwrap_exit_zero_without_an_envelope_still_names_the_denied_write() {
             "workspace_path": workspace.display().to_string()
         })),
         workspace_root: None,
-        orbit_root: None,
+        orbit_registry_root: None,
     };
     let spec = test_agent_loop_spec(Duration::from_secs(5));
 
@@ -1183,7 +1184,7 @@ fn run_cli_backend_emits_provider_pid_between_the_started_and_finished_events() 
         sandbox: None,
         task_context: None,
         workspace_root: None,
-        orbit_root: None,
+        orbit_registry_root: None,
     };
     let spec = test_agent_loop_spec(Duration::from_secs(5));
 
@@ -2983,7 +2984,7 @@ fn run_cli_backend_passes_provider_config_to_codex_runtime_args() {
         sandbox: None,
         task_context: None,
         workspace_root: None,
-        orbit_root: None,
+        orbit_registry_root: None,
     };
     let spec = test_agent_loop_spec(Duration::from_secs(5));
 
@@ -3056,7 +3057,7 @@ fn run_cli_backend_passes_model_to_grok_and_captures_well_formed_stdout() {
         sandbox: None,
         task_context: None,
         workspace_root: None,
-        orbit_root: None,
+        orbit_registry_root: None,
     };
     let mut spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
     spec.model = Some("grok-build".to_string());
@@ -3133,7 +3134,7 @@ fi
         sandbox: None,
         task_context: None,
         workspace_root: None,
-        orbit_root: None,
+        orbit_registry_root: None,
     };
     let mut spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
     spec.model = Some("grok-build".to_string());
@@ -3187,7 +3188,7 @@ fi
         sandbox: None,
         task_context: None,
         workspace_root: None,
-        orbit_root: None,
+        orbit_registry_root: None,
     };
     let mut spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
     spec.model = Some("grok-build".to_string());
@@ -3242,7 +3243,7 @@ fi
         sandbox: None,
         task_context: None,
         workspace_root: None,
-        orbit_root: None,
+        orbit_registry_root: None,
     };
     let mut spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
     spec.model = Some("grok-build".to_string());
@@ -3302,7 +3303,7 @@ fi
         sandbox: None,
         task_context: None,
         workspace_root: None,
-        orbit_root: Some("/resolved/orbit/root".to_string()),
+        orbit_registry_root: Some("/resolved/orbit/root".to_string()),
     };
     let mut spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
     spec.model = Some("grok-build".to_string());
@@ -3319,6 +3320,104 @@ fi
 
     assert!(outcome.success);
     assert_eq!(outcome.output["provider"], "grok");
+}
+
+/// [ORB-10980] A managed run executes in a linked worktree whose workspace and
+/// worktree-local `.orbit` state roots are mounted read-only. The child must be
+/// pinned to the authoritative registry root the host reports, and the existing
+/// binary/PATH pinning plus managed provenance bindings must survive alongside
+/// it — those are what let the documented `orbit tool run` fallback work at all.
+#[test]
+fn run_cli_backend_injects_registry_root_not_worktree_state_root() {
+    let temp = tempdir().expect("tempdir");
+    let registry_root = temp.path().join("registry");
+    let workspace_state_root = temp.path().join("repo").join(".orbit");
+    let worktree_state_root = temp
+        .path()
+        .join("repo/.orbit/state/worktrees/jrun-fixture")
+        .join(".orbit");
+    for directory in [&registry_root, &workspace_state_root, &worktree_state_root] {
+        std::fs::create_dir_all(directory).expect("state root");
+    }
+    // Both `.orbit` state roots are read-only in a managed run; a child pinned
+    // to either cannot bootstrap, so make that concrete in the fixture.
+    for directory in [&workspace_state_root, &worktree_state_root] {
+        let mut permissions = std::fs::metadata(directory)
+            .expect("state root metadata")
+            .permissions();
+        permissions.set_mode(0o555);
+        std::fs::set_permissions(directory, permissions).expect("read-only state root");
+    }
+
+    let script = temp.path().join("grok");
+    write_executable(
+        &script,
+        &format!(
+            r#"#!/bin/sh
+cat > /dev/null
+fail() {{
+  printf '%s\n' "{{\"schemaVersion\":1,\"status\":\"failed\",\"error\":{{\"code\":\"$1\",\"message\":\"$1\",\"details\":null}}}}"
+  exit 1
+}}
+[ "$ORBIT_ROOT" = "{registry}" ] || fail orbit_root_not_registry
+[ "$ORBIT_ROOT" = "{workspace_state}" ] && fail orbit_root_is_workspace_state_root
+[ "$ORBIT_ROOT" = "{worktree_state}" ] && fail orbit_root_is_worktree_state_root
+[ -n "$ORBIT_BIN" ] || fail orbit_bin_missing
+[ -n "$PATH" ] || fail path_missing
+[ "$ORBIT_RUN_ID" = "job-grok-registry-root" ] || fail run_id_missing
+[ "$ORBIT_MANAGED_RUN_CONTEXT" = "1" ] || fail managed_run_context_missing
+[ "$ORBIT_ACTIVE_TASK_ID" = "ORB-10980" ] || fail active_task_missing
+printf '%s\n' '{{"schemaVersion":1,"status":"success","result":{{"identity":"ok"}},"error":null}}'
+"#,
+            registry = registry_root.display(),
+            workspace_state = workspace_state_root.display(),
+            worktree_state = worktree_state_root.display(),
+        ),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-grok-registry-root",
+        "grok:grok-build",
+        sink_for_writer,
+    ));
+    let host = TestHost {
+        command: script.display().to_string(),
+        executor_args: Vec::new(),
+        provider_config: HashMap::new(),
+        sandbox: None,
+        task_context: None,
+        workspace_root: None,
+        orbit_registry_root: Some(registry_root.display().to_string()),
+    };
+    let mut spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
+    spec.model = Some("grok-build".to_string());
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-grok-registry-root",
+        audit,
+        &serde_json::json!({"prompt": "hi", "task_id": "ORB-10980"}),
+        None,
+    )
+    .expect("run succeeds");
+
+    // Restore write permission so the fixture's temp tree can be reclaimed.
+    for directory in [&workspace_state_root, &worktree_state_root] {
+        let mut permissions = std::fs::metadata(directory)
+            .expect("state root metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(directory, permissions).expect("restore state root");
+    }
+
+    assert!(
+        outcome.success,
+        "managed child rejected its Orbit environment: {:?}",
+        outcome.output
+    );
 }
 
 /// AGENT_MODEL/AGENT_TASK must be omitted (unset), not set to an empty

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_macos.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_macos.rs
@@ -45,7 +45,7 @@ fn run_cli_backend_audit_argv_starts_with_sandbox_exec_for_each_provider() {
             sandbox: Some(sandbox_for_test()),
             task_context: None,
             workspace_root: None,
-            orbit_root: None,
+            orbit_registry_root: None,
         };
         let spec = test_agent_loop_spec_for(provider_name, Duration::from_secs(5));
 
@@ -120,7 +120,7 @@ fn run_cli_backend_pins_codex_sandbox_under_outer_wrapper() {
         sandbox: Some(sandbox_for_test()),
         task_context: None,
         workspace_root: None,
-        orbit_root: None,
+        orbit_registry_root: None,
     };
     let spec = test_agent_loop_spec_for("codex", Duration::from_secs(5));
 
@@ -194,7 +194,7 @@ fn run_cli_backend_drops_gemini_sandbox_flag_under_outer_wrapper() {
         sandbox: Some(sandbox_for_test()),
         task_context: None,
         workspace_root: None,
-        orbit_root: None,
+        orbit_registry_root: None,
     };
     let spec = test_agent_loop_spec_for("gemini", Duration::from_secs(5));
 
@@ -261,7 +261,7 @@ fn run_cli_backend_drops_grok_sandbox_flag_under_outer_wrapper() {
         sandbox: Some(sandbox_for_test()),
         task_context: None,
         workspace_root: None,
-        orbit_root: None,
+        orbit_registry_root: None,
     };
     let spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
 
@@ -328,7 +328,7 @@ fn run_cli_backend_leaves_claude_argv_suffix_unchanged_under_sandbox() {
         sandbox: Some(sandbox_for_test()),
         task_context: None,
         workspace_root: None,
-        orbit_root: None,
+        orbit_registry_root: None,
     };
     let spec = test_agent_loop_spec_for("claude", Duration::from_secs(5));
 

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
@@ -241,7 +241,7 @@ pub(in crate::activity_job::cli_runner) struct TestHost {
     pub(in crate::activity_job::cli_runner) sandbox: Option<ResolvedSandbox>,
     pub(in crate::activity_job::cli_runner) task_context: Option<Value>,
     pub(in crate::activity_job::cli_runner) workspace_root: Option<PathBuf>,
-    pub(in crate::activity_job::cli_runner) orbit_root: Option<String>,
+    pub(in crate::activity_job::cli_runner) orbit_registry_root: Option<String>,
 }
 
 impl TestHost {
@@ -253,7 +253,7 @@ impl TestHost {
             sandbox: None,
             task_context: None,
             workspace_root: None,
-            orbit_root: None,
+            orbit_registry_root: None,
         }
     }
 }
@@ -320,8 +320,8 @@ impl RuntimeHost for TestHost {
         }
     }
 
-    fn orbit_root(&self) -> Option<String> {
-        self.orbit_root.clone()
+    fn orbit_registry_root(&self) -> Option<String> {
+        self.orbit_registry_root.clone()
     }
 }
 

--- a/crates/orbit-engine/src/context/hosts.rs
+++ b/crates/orbit-engine/src/context/hosts.rs
@@ -209,7 +209,15 @@ pub trait RuntimeHost: Send + Sync {
     fn agent_subprocess_environment(&self, required_env_vars: &[&str]) -> Vec<(String, String)> {
         allowlisted_child_env(&[], required_env_vars)
     }
-    fn orbit_root(&self) -> Option<String> {
+    /// The authoritative shared Orbit registry root to hand a spawned CLI
+    /// agent as `ORBIT_ROOT`.
+    ///
+    /// This is the registry that owns the task store, not the dispatching
+    /// checkout's workspace `.orbit`. A managed run executes in a linked
+    /// worktree whose workspace `.orbit` is mounted read-only, so pinning a
+    /// child there makes the documented `orbit tool run` fallback unable to
+    /// bootstrap, read, or update the injected task. [ORB-10980]
+    fn orbit_registry_root(&self) -> Option<String> {
         None
     }
     fn missing_required_environment_vars(&self, _required_env_vars: &[&str]) -> Vec<String> {


### PR DESCRIPTION
## Task

[ORB-10980](https://orbit-cli.com/tasks/ORB-10980) — Route managed CLI agents to the shared Orbit registry instead of a read-only worktree root

### Description

## Problem

F2026-08-105 reproduces in a managed linked worktree: the CLI runner exports `ORBIT_ROOT` from `host.orbit_root()` (`crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs`), which is the worktree-local `.orbit` mount. That mount is read-only and is not the host task registry. Consequently the activity envelope's documented fallback, `orbit tool run ...`, attempts bootstrap/migration writes against the worktree root and cannot read or update the injected task without manually overriding `ORBIT_ROOT` to the shared registry root and supplying the linked-worktree workspace selector.

The same failure was independently recorded by F2026-08-104. Direct MCP calls work, but the documented CLI fallback must remain usable when a granted MCP tool is unavailable.

## Why It Matters

A managed agent should not need machine-specific root-discovery knowledge to use its granted Orbit CLI surface. The current exported root makes normal task inspection and durable updates fail before task work can begin.

## Constraints / Notes

- Preserve the runner's explicit Orbit binary pinning and managed-run provenance environment.
- Do not point a worker at an arbitrary global registry or weaken workspace routing: task mutations must remain scoped to the registered workspace and invalid/missing selectors must fail closed.
- Do not make genuine writes succeed against a read-only worktree-local store; route the managed CLI fallback to the authoritative writable shared root instead.
- Keep non-managed/direct CLI root-resolution semantics unchanged.
- Reproduce with isolated registries and a read-only linked-worktree state mount; tests must not use a developer's live `~/.orbit`.

### Acceptance Criteria

- A managed linked-worktree fixture whose worktree-local `.orbit` state is read-only can run the documented `orbit tool run orbit.task.show` and a workspace-scoped `orbit.task.update` through the injected agent environment, and both address the authoritative registered task store.
- The injected `ORBIT_ROOT` for that fixture is the authoritative shared registry root rather than the read-only worktree-local state root; the existing selected Orbit binary/PATH and managed provenance bindings remain present.
- Explicit invalid or missing workspace selectors for workspace-scoped mutation still fail closed, and a genuine direct mutation against a deliberately read-only authoritative store still returns a path-attributed permission error.
- Non-managed CLI root resolution remains unchanged by focused regression coverage.
- Focused CLI-runner/runtime tests and make ci-fast pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Routed the managed CLI agent's `ORBIT_ROOT` at the authoritative shared Orbit registry root instead of the dispatching checkout's workspace `.orbit`.

## Root cause

`run_cli_backend` injected `ORBIT_ROOT` from `RuntimeHost::orbit_root()`, which returned `paths().orbit_dir` — the workspace `.orbit` of the dispatching checkout, not the registry that owns the task store. Two things then break for a managed linked-worktree run:

- The managed bwrap profile `--ro-bind`s that directory and only re-binds `tasks/`, `frictions/`, `state/{audit,logs,job-runs}` and `state/semantic.db*` writable, so bootstrap/migration writes fail with EROFS. The registry root (`~/.orbit/{tasks,orbit.db*,state/logs}`) is already bound writable by `append_linux_runtime_write_roots`.
- Any explicit root pins `global_root == shared_root`, and `select_workspace_for_cwd_and_roots` (crates/orbit-cmd/src/registry_runtime.rs:528-533) deliberately disables the orbit-dir fallback in that mode. The unregistered linked-worktree cwd then binds no workspace, so `orbit tool run orbit.task.update` failed `task_not_found`.

Reproduced live in this jrun worktree: `orbit tool run orbit.task.show` succeeded (it bootstraps through `RuntimeNeed::TaskOwner`, which resolves the owner from the task registry) while the same `orbit.task.update` returned `task_not_found` until `--workspace <checkout>` was supplied.

## Change

- `crates/orbit-engine/src/context/hosts.rs`: renamed `RuntimeHost::orbit_root()` to `orbit_registry_root()` and documented the contract — the registry that owns the task store, never the dispatching checkout's workspace state root.
- `crates/orbit-core/src/adapter/engine_host/runtime_host.rs`: the `OrbitRuntime` impl now reports `paths().global_dir` instead of `paths().orbit_dir`.
- `crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs`: call site plus a comment recording why the registry root is the injected value and that workspace routing is unchanged.

`ORBIT_BIN`/PATH pinning (`orbit_tool_env`) and the `provenance_env` managed-run bindings are untouched, and the `!dispatch_env.contains("ORBIT_ROOT")` guard still lets an explicit value win. Workspace routing is deliberately not relaxed: a mutation still needs its own resolvable selector.

## Tests

- `orbit-core` `adapter/engine_host/tests/runtime_host.rs`: `orbit_registry_root_reports_the_registry_not_a_workspace_state_root` builds a runtime whose shared/local roots are a repo `.orbit` and a linked-worktree `.orbit`, and asserts the reported root is the registry. This is the test that fails on the old `orbit_dir` behaviour.
- `orbit-engine` `cli_runner/tests/orchestrator.rs`: `run_cli_backend_injects_registry_root_not_worktree_state_root` spawns a child against a fixture with both `.orbit` state roots chmod-0555 and asserts the child sees `ORBIT_ROOT` = registry root (and neither state root) alongside `ORBIT_BIN`, `PATH`, `ORBIT_RUN_ID`, `ORBIT_MANAGED_RUN_CONTEXT` and `ORBIT_ACTIVE_TASK_ID`. The ORB-10909 test is kept.
- `orbit-cmd` `tests/registry_runtime.rs`: a `ManagedWorktreeFixture` (isolated registry root, one registered checkout, an unregistered linked worktree with a read-only worktree-local `.orbit`) drives four cases — task.show resolves from the registry root alone and a workspace-scoped task.update lands in the authoritative store; an unregistered worktree cwd with no selector and an invalid selector both fail closed; a chmod-0555 authoritative task store yields a path-attributed `Permission denied` error; and unpinned (no root override) resolution still binds the registered checkout from both the checkout and the worktree cwd.

## Out-of-scope fix

`crates/orbit-core/src/runtime/tests/resolve.rs` — `caller_supplied_workspace_hint_keeps_registry_out_of_core_resolution` took `ENV_LOCK` without clearing `ORBIT_ROOT`, unlike every sibling. Under any managed agent run it resolved to the live repo root, failed, and poisoned `ENV_LOCK` for 11 other tests in the module. Pre-existing (it fails identically without this change) but it blocked the focused runtime suite, so it now removes the env var like its siblings. One line, no production code.

## Validation

`cargo test -p orbit-engine --lib` (387 passed), `-p orbit-core --lib` (767 passed), `-p orbit-cmd --lib` (58 passed), `cargo test -p orbit-cli --bins` (356 passed), `make ci-fast` and `make ci-lint` all pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10980-6a8a32e6`
- Behind base: 0
- Ahead of base: 1