### PR TITLE
[BLOCKED] `orbit --root <data-dir> executor list` binds parent of the data dir as a workspace

### DIFF
--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -349,11 +349,25 @@ impl WorkspaceInitArgs {
                 }
             }
         }
+        orbit_core::adapter::HubCoordinationExecutor::register_workspace(global_root, &id, &name)?;
+        // A first checkout for this data dir must land in sqlite before the
+        // JSON catalog is saved. Shared-root follow-on checkouts reuse one
+        // orbit_dir (UNIQUE) and must not steal that row. `--force` rebinds
+        // a leftover synthetic parent(data-dir) mint.
+        if !registered_shared_root {
+            orbit_core::adapter::HubCoordinationExecutor::bind_checkout(
+                global_root,
+                &id,
+                &name,
+                cwd,
+                orbit_dir,
+                self.force,
+            )?;
+        }
         workspace_registry::save_registry_to(&registry, registry_path)?;
         if !reconciling_existing && !registered_shared_root {
             write_workspace_identity(orbit_dir, &id)?;
         }
-        orbit_core::adapter::HubCoordinationExecutor::register_workspace(global_root, &id, &name)?;
 
         Ok(WorkspaceInitResult {
             id,

--- a/crates/orbit-cli/tests/worktree_resolution.rs
+++ b/crates/orbit-cli/tests/worktree_resolution.rs
@@ -452,3 +452,301 @@ fn init_git_repo(main_repo: &Path) {
     run_git(main_repo, &["add", "README.md"]);
     run_git(main_repo, &["commit", "-m", "initial"]);
 }
+
+/// [ORB-10981] `orbit --root <data-dir> executor list` from a cwd that is not
+/// the intended git checkout must not mint a checkout for `parent(data-dir)`.
+#[test]
+fn executor_list_with_explicit_root_does_not_bind_parent_of_data_dir() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let data_dir = temp.path().join("qa-root");
+    let repo = temp.path().join("qa-ws");
+    fs::create_dir_all(&home).expect("create home");
+    fs::create_dir_all(&data_dir).expect("create data dir");
+    fs::create_dir_all(&repo).expect("create repo");
+    init_git_repo(&repo);
+
+    let data_dir_arg = data_dir.to_string_lossy().into_owned();
+    run_orbit_success(
+        &home,
+        &home,
+        &[
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "qa",
+            "--task-prefix",
+            "QAZ",
+            "--root",
+            &data_dir_arg,
+        ],
+        None,
+    );
+    run_orbit_success(
+        &home,
+        &home,
+        &[
+            "--root",
+            &data_dir_arg,
+            "executor",
+            "list",
+            "--format",
+            "json",
+        ],
+        None,
+    );
+
+    let parent = canonicalize_or_original(data_dir.parent().expect("data dir parent"));
+    for (workspace_id, repo_root, orbit_dir) in checkout_bindings(&data_dir) {
+        assert_ne!(
+            canonicalize_or_original(Path::new(&repo_root)),
+            parent,
+            "executor list bound parent(data-dir) as {workspace_id} repo_root={repo_root} orbit_dir={orbit_dir}"
+        );
+    }
+
+    run_orbit_success(
+        &repo,
+        &home,
+        &[
+            "--root",
+            &data_dir_arg,
+            "workspace",
+            "init",
+            "--name",
+            "qa",
+            "--force",
+            "--format",
+            "json",
+        ],
+        None,
+    );
+    assert_workspace_commands_use_named_id(&repo, &home, &data_dir, "ws_qa");
+}
+
+/// [ORB-10981] Clean path: init + workspace init from the git checkout, no
+/// extra command from another cwd first.
+#[test]
+fn clean_root_workspace_init_then_auto_task_list_succeeds() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let data_dir = temp.path().join("qa-root");
+    let repo = temp.path().join("qa-ws");
+    fs::create_dir_all(&home).expect("create home");
+    fs::create_dir_all(&data_dir).expect("create data dir");
+    fs::create_dir_all(&repo).expect("create repo");
+    init_git_repo(&repo);
+
+    let data_dir_arg = data_dir.to_string_lossy().into_owned();
+    run_orbit_success(
+        &repo,
+        &home,
+        &[
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "qa",
+            "--task-prefix",
+            "QAZ",
+            "--root",
+            &data_dir_arg,
+        ],
+        None,
+    );
+    run_orbit_success(
+        &repo,
+        &home,
+        &[
+            "--root",
+            &data_dir_arg,
+            "workspace",
+            "init",
+            "--name",
+            "qa",
+            "--format",
+            "json",
+        ],
+        None,
+    );
+    assert_workspace_commands_use_named_id(&repo, &home, &data_dir, "ws_qa");
+}
+
+/// [ORB-10981] `--force` must rebind a leftover synthetic sqlite checkout so
+/// later commands are not split-brain against `workspaces.json`.
+#[test]
+fn workspace_init_force_rebinds_synthetic_data_dir_checkout() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let data_dir = temp.path().join("qa-root");
+    let repo = temp.path().join("qa-ws");
+    fs::create_dir_all(&home).expect("create home");
+    fs::create_dir_all(&data_dir).expect("create data dir");
+    fs::create_dir_all(&repo).expect("create repo");
+    init_git_repo(&repo);
+
+    let data_dir_arg = data_dir.to_string_lossy().into_owned();
+    run_orbit_success(
+        &home,
+        &home,
+        &[
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "qa",
+            "--task-prefix",
+            "QAZ",
+            "--root",
+            &data_dir_arg,
+        ],
+        None,
+    );
+    run_orbit_success(
+        &home,
+        &home,
+        &[
+            "--root",
+            &data_dir_arg,
+            "executor",
+            "list",
+            "--format",
+            "json",
+        ],
+        None,
+    );
+
+    seed_synthetic_data_dir_checkout(&data_dir);
+    run_orbit_success(
+        &repo,
+        &home,
+        &[
+            "--root",
+            &data_dir_arg,
+            "workspace",
+            "init",
+            "--name",
+            "qa",
+            "--force",
+            "--format",
+            "json",
+        ],
+        None,
+    );
+
+    let repo_canon = canonicalize_or_original(&repo);
+    let data_canon = canonicalize_or_original(&data_dir);
+    let bindings = checkout_bindings(&data_dir);
+    assert!(
+        bindings.iter().any(|(workspace_id, repo_root, orbit_dir)| {
+            workspace_id == "ws_qa"
+                && canonicalize_or_original(Path::new(repo_root)) == repo_canon
+                && canonicalize_or_original(Path::new(orbit_dir)) == data_canon
+        }),
+        "expected ws_qa checkout for the git repo; got {bindings:?}"
+    );
+    assert!(
+        bindings
+            .iter()
+            .all(|(workspace_id, _, orbit_dir)| workspace_id != "tmp-5b7149"
+                || canonicalize_or_original(Path::new(orbit_dir)) != data_canon),
+        "synthetic tmp-* row must not keep the data dir: {bindings:?}"
+    );
+    assert_workspace_commands_use_named_id(&repo, &home, &data_dir, "ws_qa");
+}
+
+fn assert_workspace_commands_use_named_id(repo: &Path, home: &Path, data_dir: &Path, id: &str) {
+    let data_dir_arg = data_dir.to_string_lossy().into_owned();
+    let listed = run_orbit_json(
+        repo,
+        home,
+        &[
+            "--root",
+            &data_dir_arg,
+            "workspace",
+            "list",
+            "--format",
+            "json",
+        ],
+        None,
+    );
+    let workspaces = listed
+        .as_array()
+        .unwrap_or_else(|| panic!("workspace list array: {listed}"));
+    assert!(
+        workspaces
+            .iter()
+            .any(|workspace| workspace["id"].as_str() == Some(id)),
+        "workspace list missing {id}: {listed}"
+    );
+    run_orbit_json(
+        repo,
+        home,
+        &[
+            "--root",
+            &data_dir_arg,
+            "auto-task",
+            "list",
+            "--format",
+            "json",
+        ],
+        None,
+    );
+}
+
+fn checkout_bindings(data_dir: &Path) -> Vec<(String, String, String)> {
+    let db = data_dir.join("tasks").join("index.sqlite");
+    if !db.is_file() {
+        return Vec::new();
+    }
+    let conn = rusqlite::Connection::open(&db).expect("open task registry");
+    let mut stmt = conn
+        .prepare("SELECT workspace_id, repo_root, orbit_dir FROM workspace_checkout_bindings")
+        .expect("prepare checkout query");
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .expect("query checkout bindings");
+    rows.collect::<Result<Vec<_>, _>>()
+        .expect("collect checkout bindings")
+}
+
+fn seed_synthetic_data_dir_checkout(data_dir: &Path) {
+    let db = data_dir.join("tasks").join("index.sqlite");
+    let now = "2026-08-22T00:00:00+00:00";
+    let parent = canonicalize_or_original(data_dir.parent().expect("data dir parent"));
+    let data_canon = canonicalize_or_original(data_dir);
+    let conn = rusqlite::Connection::open(&db).expect("open task registry");
+    conn.execute(
+        "INSERT INTO workspace_bindings (
+            workspace_id, slug, repo_fingerprint, created_at, updated_at
+        ) VALUES (?1, ?2, NULL, ?3, ?3)",
+        rusqlite::params!["tmp-5b7149", "tmp", now],
+    )
+    .expect("insert synthetic workspace");
+    conn.execute(
+        "INSERT INTO workspace_checkout_bindings (
+            workspace_id, repo_root, workspace_path, orbit_dir, created_at, updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?5)",
+        rusqlite::params![
+            "tmp-5b7149",
+            parent.to_string_lossy().as_ref(),
+            parent.to_string_lossy().as_ref(),
+            data_canon.to_string_lossy().as_ref(),
+            now,
+        ],
+    )
+    .expect("insert synthetic checkout");
+    fs::write(
+        data_dir.join("config.yaml"),
+        "schema_version: 1\nworkspace_id: tmp-5b7149\n",
+    )
+    .expect("write synthetic identity");
+}
+
+fn canonicalize_or_original(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}

--- a/crates/orbit-core/src/adapter/tool_host/host.rs
+++ b/crates/orbit-core/src/adapter/tool_host/host.rs
@@ -22,7 +22,7 @@ use orbit_store::friction_store::{
     FrictionAddParams, FrictionUpdateParams, prepare_hub_friction_root, readable_hub_friction_root,
 };
 use orbit_store::maintenance::task_registry::{
-    RegisterWorkspaceParams, TaskRegistryStore, task_registry_path,
+    BindWorkspaceParams, RegisterWorkspaceParams, TaskRegistryStore, task_registry_path,
 };
 use orbit_tools::{
     OrbitBuiltinAction, OrbitTaskScope, OrbitToolHost, ReservationOwnerContext, ToolContext,
@@ -93,6 +93,34 @@ impl HubCoordinationExecutor {
             slug: slug.into(),
             repo_fingerprint: None,
         })?;
+        Ok(())
+    }
+
+    /// Bind this checkout in the task registry. `--force` replaces an
+    /// existing orbit-dir row so a synthetic parent(data-dir) bind cannot
+    /// leave split-brain state after workspace init.
+    pub fn bind_checkout(
+        global_root: &Path,
+        workspace_id: impl Into<String>,
+        slug: impl Into<String>,
+        repo_root: &Path,
+        orbit_dir: &Path,
+        replace_existing: bool,
+    ) -> Result<(), OrbitError> {
+        let registry = TaskRegistryStore::open(&task_registry_path(global_root))?;
+        let params = BindWorkspaceParams {
+            workspace_id: Some(workspace_id.into()),
+            slug: slug.into(),
+            repo_root: repo_root.to_path_buf(),
+            workspace_path: repo_root.to_path_buf(),
+            orbit_dir: orbit_dir.to_path_buf(),
+            repo_fingerprint: None,
+        };
+        if replace_existing {
+            registry.rebind_checkout(params)?;
+        } else {
+            registry.bind_workspace(params)?;
+        }
         Ok(())
     }
 

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -5,14 +5,14 @@ use orbit_policy::PolicyEngine;
 use orbit_search::{EmbedWorker, VectorStore};
 use orbit_store::Store;
 use orbit_store::compose::{
-    WorkspaceTaskBackends, audit_event_store_sqlite, global_executor_def_store,
-    global_policy_def_store, layered_policy_def_store, task_reservation_store_sqlite,
-    tool_store_sqlite, workspace_job_run_store, workspace_policy_def_store,
-    workspace_task_backends,
+    WorkspaceTaskBackends, audit_event_store_sqlite, coordination_task_backends,
+    global_executor_def_store, global_policy_def_store, layered_policy_def_store,
+    task_reservation_store_sqlite, tool_store_sqlite, workspace_job_run_store,
+    workspace_policy_def_store, workspace_task_backends,
 };
 use orbit_store::maintenance::task_registry::{
     BindWorkspaceParams, TaskRegistryStore, WorkspaceConfig, read_workspace_config_optional,
-    task_registry_path, workspace_id_for_orbit_dir, write_workspace_config,
+    task_registry_path, write_workspace_config,
 };
 
 use orbit_common::OrbitError;
@@ -29,6 +29,11 @@ use crate::context::{
 };
 use crate::runtime::WorkspaceRuntimeBinding;
 use crate::skill_catalog::SkillCatalog;
+
+/// Job-run partition used when an explicit `--root` data directory is opened
+/// without a selected checkout. Never written to `config.yaml` and never
+/// inserted as a `workspace_checkout_bindings` row.
+const UNBOUND_DATA_DIR_WORKSPACE_ID: &str = "ws_unbound-data-dir";
 
 /// Runtime builder. Global root provides activities, jobs, executors, policies,
 /// config, global skills, and SQLite. Shared root provides existing workspace
@@ -66,23 +71,31 @@ pub(crate) fn build_context_from_roots(
         &paths,
         binding.map(|binding| binding.workspace_id.as_str()),
     )?;
-    let workspace_id = workspace_id_for_orbit_dir(&paths.orbit_dir)?;
-    let import_report = match orbit_store::workflow::legacy_state::import_legacy_v2_state(
-        &store,
-        &paths.orbit_dir,
-        &workspace_id,
-    ) {
-        Ok(report) => report,
-        Err(error) if error.is_readonly_or_access_failure() => {
-            tracing::warn!(
-                target: "orbit.core.bootstrap",
-                root = %paths.orbit_dir.display(),
-                error = %error,
-                "skipped incidental legacy-state import persistence"
-            );
-            orbit_store::workflow::legacy_state::ImportReport::skipped()
+    let configured = read_workspace_config_optional(&paths.orbit_dir)?;
+    let workspace_id = configured
+        .as_ref()
+        .map(|config| config.workspace_id.clone())
+        .unwrap_or_else(|| UNBOUND_DATA_DIR_WORKSPACE_ID.to_string());
+    let import_report = if configured.is_none() {
+        orbit_store::workflow::legacy_state::ImportReport::skipped()
+    } else {
+        match orbit_store::workflow::legacy_state::import_legacy_v2_state(
+            &store,
+            &paths.orbit_dir,
+            &workspace_id,
+        ) {
+            Ok(report) => report,
+            Err(error) if error.is_readonly_or_access_failure() => {
+                tracing::warn!(
+                    target: "orbit.core.bootstrap",
+                    root = %paths.orbit_dir.display(),
+                    error = %error,
+                    "skipped incidental legacy-state import persistence"
+                );
+                orbit_store::workflow::legacy_state::ImportReport::skipped()
+            }
+            Err(error) => return Err(error),
         }
-        Err(error) => return Err(error),
     };
     if import_report.skipped_records() {
         tracing::warn!(
@@ -192,6 +205,17 @@ fn build_v2_task_backends(
 ) -> Result<WorkspaceTaskBackends, OrbitError> {
     let registry = TaskRegistryStore::open(&task_registry_path(global_root))?;
     let config = read_workspace_config_optional(&paths.orbit_dir)?;
+    // An explicit `--root` data directory is not a checkout. Binding
+    // `parent(data-dir)` as `repo_root` mints a synthetic workspace (e.g.
+    // `tmp-XXXXXX` for `/tmp`) that later `workspace init --force` cannot
+    // reclaim. Skip that mint unless a selected checkout supplied a hint.
+    if workspace_id_hint.is_none() && is_explicit_data_dir(global_root, &paths.orbit_dir) {
+        let workspace_id = config
+            .as_ref()
+            .map(|config| config.workspace_id.clone())
+            .unwrap_or_else(|| UNBOUND_DATA_DIR_WORKSPACE_ID.to_string());
+        return Ok(coordination_task_backends(registry, workspace_id));
+    }
     let workspace_id = if let Some(config) = &config {
         if let Some(hint) = workspace_id_hint
             && config.workspace_id != hint
@@ -250,6 +274,19 @@ fn rebind_candidate_workspace_id(
             "workspace config is missing and multiple task artifact bindings match '{}'; restore .orbit/config.yaml or choose a workspace binding",
             paths.orbit_dir.display()
         ))),
+    }
+}
+
+fn is_explicit_data_dir(global_root: &Path, orbit_dir: &Path) -> bool {
+    if global_root == orbit_dir {
+        return true;
+    }
+    match (
+        std::fs::canonicalize(global_root),
+        std::fs::canonicalize(orbit_dir),
+    ) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
     }
 }
 

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -140,16 +140,24 @@ impl OrbitRuntime {
         runtime_config: &orbit_config::ResolvedConfig,
         temp_dir: builder::TempDir,
     ) -> Result<Self, OrbitError> {
+        // Flattened in-memory roots look like an explicit `--root` data dir.
+        // Supply a checkout binding so task APIs still have a partition;
+        // without it the data-dir skip would refuse to mint parent(tempdir).
+        let binding = WorkspaceRuntimeBinding {
+            workspace_id: "ws_memory".to_string(),
+            repo_root: data_root.to_path_buf(),
+            ship_mode: ShipMode::Local,
+        };
         let context = builder::build_context_from_roots(
             data_root,
             data_root,
             data_root,
-            None,
+            Some(&binding),
             runtime_config,
         )?;
         Ok(Self {
             context,
-            workspace_binding: None,
+            workspace_binding: Some(Arc::new(binding)),
             coordination_write_owner: None,
             event_log: event_bus::EventLog::default(),
             layout_report: Arc::new(orbit_store::workflow::layout::LayoutUpgradeReport::default()),

--- a/crates/orbit-core/src/runtime/tests/builder.rs
+++ b/crates/orbit-core/src/runtime/tests/builder.rs
@@ -2,7 +2,9 @@
 
 use std::path::PathBuf;
 
-use orbit_store::maintenance::task_registry::read_workspace_config_optional;
+use orbit_store::maintenance::task_registry::{
+    TaskRegistryStore, read_workspace_config_optional, task_registry_path,
+};
 
 use crate::OrbitError;
 
@@ -201,5 +203,32 @@ fn v2_task_backend_rebinds_when_workspace_config_is_missing() {
             .expect("read rewritten workspace config")
             .map(|config| config.workspace_id),
         original_config.map(|config| config.workspace_id)
+    );
+}
+
+#[test]
+fn explicit_data_dir_runtime_does_not_bind_parent_as_a_checkout() {
+    let root = tempdir().expect("tempdir");
+    let data_dir = root.path().join("data");
+    std::fs::create_dir_all(&data_dir).expect("create data dir");
+
+    let runtime = OrbitRuntime::from_roots(&data_dir, &data_dir).expect("build data-dir runtime");
+    drop(runtime);
+
+    assert!(
+        read_workspace_config_optional(&data_dir)
+            .expect("read workspace config")
+            .is_none(),
+        "an unbound data-dir open must not write a synthetic workspace identity"
+    );
+    let registry =
+        TaskRegistryStore::open(&task_registry_path(&data_dir)).expect("open task registry");
+    let parent = data_dir.parent().expect("data dir parent");
+    let candidates = registry
+        .find_rebind_candidates(parent, parent, &data_dir)
+        .expect("lookup checkout bindings");
+    assert!(
+        candidates.is_empty(),
+        "executor-list-style data-dir open must not insert a checkout for parent(data-dir); got {candidates:?}"
     );
 }

--- a/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
@@ -221,6 +221,93 @@ impl TaskRegistryStore {
         Ok(binding)
     }
 
+    /// Move `orbit_dir` onto `params.workspace_id`, replacing any checkout
+    /// currently bound to that directory.
+    ///
+    /// `bind_workspace` fails closed when the orbit dir already belongs to a
+    /// different workspace. Workspace `--force` reconciliation uses this to
+    /// finish a split-brain bind: a read-only command that minted a synthetic
+    /// checkout for `parent(data-dir)`, then `workspace init --force` claiming
+    /// the same data dir for a real git checkout.
+    pub fn rebind_checkout(
+        &self,
+        params: BindWorkspaceParams,
+    ) -> Result<WorkspaceCheckoutBinding, OrbitError> {
+        let repo_root = normalize_path(&params.repo_root);
+        let workspace_path = normalize_path(&params.workspace_path);
+        let orbit_dir = normalize_path(&params.orbit_dir);
+        let slug = sanitize_slug(&params.slug);
+        let workspace_id =
+            validate_workspace_id(params.workspace_id.as_deref().ok_or_else(|| {
+                OrbitError::InvalidInput("rebind_checkout requires an explicit workspace id".into())
+            })?)?;
+
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let now = now_string();
+
+        if workspace_by_id(&tx, &workspace_id)?.is_none() {
+            tx.execute(
+                "INSERT INTO workspace_bindings (
+                    workspace_id, slug, repo_fingerprint, created_at, updated_at
+                ) VALUES (?1, ?2, ?3, ?4, ?4)",
+                params![workspace_id, slug, params.repo_fingerprint, now],
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        }
+
+        if let Some(existing) = workspace_by_orbit_dir(&tx, &orbit_dir)?
+            && existing.workspace_id != workspace_id
+        {
+            tx.execute(
+                "DELETE FROM workspace_checkout_bindings WHERE orbit_dir = ?1",
+                [path_to_string(&orbit_dir)],
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        }
+
+        if workspace_checkout_by_id(&tx, &workspace_id)?.is_some() {
+            tx.execute(
+                "UPDATE workspace_checkout_bindings
+                 SET repo_root = ?2, workspace_path = ?3, orbit_dir = ?4, updated_at = ?5
+                 WHERE workspace_id = ?1",
+                params![
+                    workspace_id,
+                    path_to_string(&repo_root),
+                    path_to_string(&workspace_path),
+                    path_to_string(&orbit_dir),
+                    now,
+                ],
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        } else {
+            tx.execute(
+                "INSERT INTO workspace_checkout_bindings (
+                    workspace_id, repo_root, workspace_path, orbit_dir, created_at, updated_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?5)",
+                params![
+                    workspace_id,
+                    path_to_string(&repo_root),
+                    path_to_string(&workspace_path),
+                    path_to_string(&orbit_dir),
+                    now,
+                ],
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        }
+
+        let binding = workspace_checkout_by_id(&tx, &workspace_id)?.ok_or_else(|| {
+            OrbitError::Store("failed to read rebound workspace checkout binding".into())
+        })?;
+        tx.commit().map_err(|e| OrbitError::Store(e.to_string()))?;
+        Ok(binding)
+    }
+
     /// Register a logical workspace in the coordination registry without
     /// inventing a machine-local checkout path.
     pub fn register_workspace(

--- a/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
@@ -1002,6 +1002,54 @@ fn bind_workspace_rejects_explicit_workspace_id_conflict() {
 }
 
 #[test]
+fn rebind_checkout_moves_orbit_dir_onto_the_requested_workspace() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let data_dir = temp.path().join("data");
+    let parent = temp.path().to_path_buf();
+    fs::create_dir_all(&data_dir).expect("create data dir");
+    let synthetic = store
+        .bind_workspace(BindWorkspaceParams {
+            workspace_id: Some("tmp-5b7149".into()),
+            slug: "tmp".into(),
+            repo_root: parent.clone(),
+            workspace_path: parent,
+            orbit_dir: data_dir.clone(),
+            repo_fingerprint: None,
+        })
+        .expect("mint synthetic parent bind");
+
+    let repo_root = temp.path().join("repo");
+    fs::create_dir_all(&repo_root).expect("create repo");
+    let rebound = store
+        .rebind_checkout(BindWorkspaceParams {
+            workspace_id: Some("ws_qa".into()),
+            slug: "qa".into(),
+            repo_root: repo_root.clone(),
+            workspace_path: repo_root.clone(),
+            orbit_dir: data_dir.clone(),
+            repo_fingerprint: None,
+        })
+        .expect("rebind orbit dir");
+
+    assert_eq!(rebound.workspace_id, "ws_qa");
+    assert_eq!(rebound.repo_root, normalize_path(&repo_root));
+    assert_eq!(rebound.orbit_dir, normalize_path(&data_dir));
+    assert!(
+        store
+            .find_workspace_checkout(&synthetic.workspace_id)
+            .expect("lookup synthetic")
+            .is_none(),
+        "the synthetic checkout row must not keep the data dir"
+    );
+    let by_orbit = store
+        .find_rebind_candidates(&repo_root, &repo_root, &data_dir)
+        .expect("lookup rebound orbit dir");
+    assert_eq!(by_orbit.len(), 1);
+    assert_eq!(by_orbit[0].workspace_id, "ws_qa");
+}
+
+#[test]
 fn workspace_config_round_trips_and_validates() {
     let temp = TempDir::new().expect("tempdir");
     let orbit_dir = temp.path().join(".orbit");


### PR DESCRIPTION
## Manual resolution required

Orbit preserved and pushed this task's pre-rebase candidate after the shipment pipeline stopped. This PR is intentionally blocked and must be reconciled manually before merge.

- Task: `ORB-10981`
- Run: `jrun-20260822-2338-6`
- Failed step: `commit`
- Error code: `pipeline_step_failed`
- Original base: `e4d88cd8c9c24a7fbe5380393a9d1fa1b7b41a7d`
- Target base: `f9ca5827238ad436785ee1de1ee5202bbdc78aaf`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
deterministic action `git_commit` failed: task bundle corrupt for ORB-10980 at /home/daniel/.orbit/tasks/workspaces/orbit-5c61b3/ORB-10980: store error: task event log status 'done' does not match envelope status 'review' for ORB-10980
```