### PR TITLE
Re-arm the systemd sweep clock on reinstall and verify its next trigger

### DIFF
--- a/crates/orbit-core/assets/clock/orbit-sweep.timer
+++ b/crates/orbit-core/assets/clock/orbit-sweep.timer
@@ -1,14 +1,14 @@
 # Configured timer for `orbit sweep` [ORB-10720].
-# OnStartupSec arms the first sweep in every fresh user-manager session (and
-# fires immediately when a re-install happens after that deadline). Subsequent
-# sweeps are measured from the last service activation. Monotonic timers do not
-# replay missed timer events; each routine's `missed_run` policy decides what a
-# sweep after downtime does with missed cron slots.
+# OnActiveSec arms the first sweep relative to every timer activation, including
+# a late install, reinstall, cadence change, or re-enable. Subsequent sweeps are
+# measured from the last service activation. Monotonic timers do not replay
+# missed timer events; each routine's `missed_run` policy decides what a sweep
+# after downtime does with missed cron slots.
 [Unit]
 Description=Run orbit sweep every {{CADENCE_SECONDS}} seconds
 
 [Timer]
-OnStartupSec={{CADENCE_SECONDS}}s
+OnActiveSec={{CADENCE_SECONDS}}s
 OnUnitActiveSec={{CADENCE_SECONDS}}s
 AccuracySec=5s
 

--- a/crates/orbit-core/src/routines/clock.rs
+++ b/crates/orbit-core/src/routines/clock.rs
@@ -139,7 +139,24 @@ pub(super) fn set_clock_cadence_with(
         }
         Err(error) => {
             save_clock_settings(global_root, previous)?;
-            Err(error)
+            match install_clock_with(global_root, orbit_bin, previous, platform, runner, home) {
+                Ok(rollback) => Err(OrbitError::Execution(format!(
+                    "clock update failed: {error}; restored the previous configured cadence and {} the previous unit{}",
+                    if rollback.activated {
+                        "reactivated"
+                    } else {
+                        "could not reactivate"
+                    },
+                    if rollback.manual_steps.is_empty() {
+                        String::new()
+                    } else {
+                        format!("; recovery: {}", rollback.manual_steps.join("; "))
+                    }
+                ))),
+                Err(rollback_error) => Err(OrbitError::Execution(format!(
+                    "clock update failed: {error}; restored the previous configured cadence but could not restore its native unit: {rollback_error}"
+                ))),
+            }
         }
     }
 }
@@ -249,7 +266,8 @@ pub fn sweep_log_path(global_root: &Path) -> PathBuf {
 pub struct ClockInstallReport {
     /// Unit files written.
     pub files_written: Vec<PathBuf>,
-    /// True when the unit was activated (loaded/enabled) successfully.
+    /// True when the unit was activated successfully. On systemd this also
+    /// means the manager reported it active with a finite future trigger.
     pub activated: bool,
     /// Follow-up commands to run manually when activation failed or was
     /// unavailable (e.g. no user systemd session).
@@ -371,28 +389,23 @@ fn install_systemd(
         program: "systemctl",
         args: vec!["--user".into(), "daemon-reload".into()],
     };
-    let enable = ManagerCommand {
-        program: "systemctl",
-        args: vec![
-            "--user".into(),
-            "enable".into(),
-            format!("{SYSTEMD_UNIT}.timer"),
-        ],
-    };
-    let restart = ManagerCommand {
-        program: "systemctl",
-        args: vec![
-            "--user".into(),
-            "restart".into(),
-            format!("{SYSTEMD_UNIT}.timer"),
-        ],
-    };
+    let enable = systemd_enable_command();
+    let restart = systemd_restart_command();
     let reloaded = runner.run(&reload).unwrap_or(false);
     let enabled = reloaded && runner.run(&enable).unwrap_or(false);
     // `enable --now` is a no-op for an already-active timer, including the
     // broken `active (elapsed)` state this installer must repair. An explicit
     // restart re-arms the rendered timer on both fresh installs and upgrades.
-    let activated = enabled && runner.run(&restart).unwrap_or(false);
+    let restarted = enabled && runner.run(&restart).unwrap_or(false);
+    let activated = if restarted {
+        let details = query_systemd_clock_details(runner)?;
+        if !details.is_schedulable() {
+            return Err(systemd_unschedulable_error("restart completed"));
+        }
+        true
+    } else {
+        false
+    };
 
     let manual_steps = if activated {
         Vec::new()
@@ -425,7 +438,17 @@ fn systemd_enable_command() -> ManagerCommand {
         args: vec![
             "--user".into(),
             "enable".into(),
-            "--now".into(),
+            format!("{SYSTEMD_UNIT}.timer"),
+        ],
+    }
+}
+
+fn systemd_restart_command() -> ManagerCommand {
+    ManagerCommand {
+        program: "systemctl",
+        args: vec![
+            "--user".into(),
+            "restart".into(),
             format!("{SYSTEMD_UNIT}.timer"),
         ],
     }
@@ -526,6 +549,30 @@ pub(super) fn set_clock_enabled_with(
     let current = runner
         .run(&manager_status_command(platform))
         .unwrap_or(false);
+    if platform == ClockPlatform::Systemd && enabled {
+        let enable = systemd_enable_command();
+        if !runner.run(&enable)? {
+            return Err(manager_command_error(&enable));
+        }
+        // Starting an already-active elapsed timer is a no-op. Restarting
+        // makes `enable` a repair operation as well as a paused-clock resume.
+        let restart = systemd_restart_command();
+        if !runner.run(&restart)? {
+            return Err(manager_command_error(&restart));
+        }
+        let details = query_systemd_clock_details(runner)?;
+        if !details.is_schedulable() {
+            return Err(systemd_unschedulable_error("enable completed"));
+        }
+        return Ok(clock_status_from(
+            settings,
+            true,
+            true,
+            platform,
+            None,
+            Some(details),
+        ));
+    }
     if current == enabled {
         return Ok(clock_status_from(
             settings, enabled, enabled, platform, None, None,
@@ -534,11 +581,7 @@ pub(super) fn set_clock_enabled_with(
     let command = manager_set_enabled_command(platform, enabled, home);
     let succeeded = runner.run(&command)?;
     if !succeeded {
-        return Err(OrbitError::Execution(format!(
-            "{} failed; recovery: {}",
-            command.display(),
-            command.display()
-        )));
+        return Err(manager_command_error(&command));
     }
     Ok(clock_status_from(
         settings, enabled, enabled, platform, None, None,
@@ -564,10 +607,9 @@ pub(super) fn clock_status_with(
         .unwrap_or(false);
     let mut manager_details = None;
     let (schedulable, health_issue) = if platform == ClockPlatform::Systemd {
-        match runner.stdout(&systemd_next_trigger_command()) {
-            Ok(Some(output)) => {
-                let details = SystemdClockDetails::parse(&output);
-                let schedulable = enabled && details.next_tick_at.is_some();
+        match query_systemd_clock_details(runner) {
+            Ok(details) => {
+                let schedulable = enabled && details.is_schedulable();
                 manager_details = Some(details);
                 if !enabled {
                     (false, None)
@@ -577,20 +619,20 @@ pub(super) fn clock_status_with(
                     (
                         false,
                         Some(
-                            "systemd timer is enabled but has no future trigger; recovery: `orbit routine init --install-clock`"
+                            "systemd timer is enabled but is not active with a finite future trigger; recovery: `orbit routine clock enable` re-arms the timer and verifies the result"
                                 .to_string(),
                         ),
                     )
                 }
             }
-            Ok(None) | Err(_) if enabled => (
+            Err(_) if enabled => (
                 false,
                 Some(
-                    "systemd timer is enabled but its next trigger could not be verified; recovery: `systemctl --user status orbit-sweep.timer`, then `orbit routine init --install-clock`"
+                    "systemd timer is enabled but its next trigger could not be verified; recovery: inspect `systemctl --user status orbit-sweep.timer`, then run `orbit routine clock enable` to re-arm and verify it"
                         .to_string(),
                 ),
             ),
-            Ok(None) | Err(_) => (false, None),
+            Err(_) => (false, None),
         }
     } else {
         (enabled, None)
@@ -629,6 +671,37 @@ impl SystemdClockDetails {
                 .or_else(|| property("NextElapseUSecMonotonic")),
         }
     }
+
+    fn is_schedulable(&self) -> bool {
+        self.loaded == Some(true) && self.running == Some(true) && self.next_tick_at.is_some()
+    }
+}
+
+fn query_systemd_clock_details(
+    runner: &dyn ClockCommandRunner,
+) -> Result<SystemdClockDetails, OrbitError> {
+    let command = systemd_next_trigger_command();
+    let output = runner.stdout(&command)?.ok_or_else(|| {
+        OrbitError::Execution(format!(
+            "{} failed; inspect `systemctl --user status {SYSTEMD_UNIT}.timer`",
+            command.display()
+        ))
+    })?;
+    Ok(SystemdClockDetails::parse(&output))
+}
+
+fn manager_command_error(command: &ManagerCommand) -> OrbitError {
+    OrbitError::Execution(format!(
+        "{} failed; recovery: {}",
+        command.display(),
+        command.display()
+    ))
+}
+
+fn systemd_unschedulable_error(action: &str) -> OrbitError {
+    OrbitError::Execution(format!(
+        "systemd timer {action}, but the manager did not report it active with a finite future trigger; inspect `systemctl --user status {SYSTEMD_UNIT}.timer` and `journalctl --user -u {SYSTEMD_UNIT}.timer -u {SYSTEMD_UNIT}.service`; after correcting the reported failure, `orbit routine clock enable` re-arms the timer and verifies the result"
+    ))
 }
 
 fn useful_manager_value(raw: &str) -> Option<String> {

--- a/crates/orbit-core/src/routines/tests/clock.rs
+++ b/crates/orbit-core/src/routines/tests/clock.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use tempfile::tempdir;
@@ -69,6 +69,161 @@ impl ClockCommandRunner for MockRunner {
     }
 }
 
+#[derive(Debug)]
+struct FakeSystemdState {
+    now_seconds: u64,
+    enabled: bool,
+    active: bool,
+    last_service_activation: Option<u64>,
+    next_trigger: Option<u64>,
+}
+
+/// A temporal systemd fake: startup-relative deadlines are based on the
+/// already-running manager, timer-relative deadlines are based on every
+/// restart, and service-relative deadlines are recomputed after a sweep.
+struct SystemdManagerFake {
+    home: PathBuf,
+    state: Mutex<FakeSystemdState>,
+    commands: Mutex<Vec<String>>,
+}
+
+impl SystemdManagerFake {
+    fn new(home: &Path, now_seconds: u64) -> Self {
+        Self {
+            home: home.to_path_buf(),
+            state: Mutex::new(FakeSystemdState {
+                now_seconds,
+                enabled: false,
+                active: false,
+                last_service_activation: None,
+                next_trigger: None,
+            }),
+            commands: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn late_elapsed(home: &Path, now_seconds: u64, last_service_activation: u64) -> Self {
+        Self {
+            home: home.to_path_buf(),
+            state: Mutex::new(FakeSystemdState {
+                now_seconds,
+                enabled: true,
+                active: true,
+                last_service_activation: Some(last_service_activation),
+                next_trigger: None,
+            }),
+            commands: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn next_trigger(&self) -> Option<u64> {
+        self.state
+            .lock()
+            .expect("fake systemd state lock")
+            .next_trigger
+    }
+
+    fn set_now(&self, now_seconds: u64) {
+        self.state
+            .lock()
+            .expect("fake systemd state lock")
+            .now_seconds = now_seconds;
+    }
+
+    fn elapse_and_complete_service(&self) {
+        let cadence = self
+            .timer_value("OnUnitActiveSec")
+            .expect("recurring timer directive");
+        let mut state = self.state.lock().expect("fake systemd state lock");
+        let triggered_at = state.next_trigger.expect("timer has a next trigger");
+        state.now_seconds = triggered_at;
+        state.last_service_activation = Some(triggered_at);
+        state.next_trigger = Some(triggered_at + cadence);
+    }
+
+    fn timer_value(&self, directive: &str) -> Option<u64> {
+        let timer = fs::read_to_string(self.home.join(".config/systemd/user/orbit-sweep.timer"))
+            .expect("fake manager reads installed timer");
+        timer.lines().find_map(|line| {
+            line.strip_prefix(&format!("{directive}="))
+                .and_then(|value| value.strip_suffix('s'))
+                .and_then(|value| value.parse().ok())
+        })
+    }
+
+    fn activate_timer(&self) {
+        let on_active = self.timer_value("OnActiveSec");
+        let on_startup = self.timer_value("OnStartupSec");
+        let on_unit_active = self.timer_value("OnUnitActiveSec");
+        let mut state = self.state.lock().expect("fake systemd state lock");
+        let now = state.now_seconds;
+        let activation_deadline = on_active.map(|cadence| now + cadence);
+        // This models the late `active (elapsed)` regression: startup and
+        // previous-service deadlines that elapsed before restart do not
+        // establish a new future trigger.
+        let startup_deadline = on_startup.filter(|deadline| *deadline > now);
+        let recurring_deadline = on_unit_active
+            .zip(state.last_service_activation)
+            .map(|(cadence, activated)| activated + cadence)
+            .filter(|deadline| *deadline > now);
+        state.active = true;
+        state.next_trigger = [activation_deadline, startup_deadline, recurring_deadline]
+            .into_iter()
+            .flatten()
+            .min();
+    }
+}
+
+impl ClockCommandRunner for SystemdManagerFake {
+    fn run(&self, command: &ManagerCommand) -> Result<bool, OrbitError> {
+        let display = command.display();
+        self.commands
+            .lock()
+            .expect("fake command log lock")
+            .push(display.clone());
+        match display.as_str() {
+            "systemctl --user daemon-reload" => Ok(true),
+            "systemctl --user is-enabled orbit-sweep.timer" => {
+                Ok(self.state.lock().expect("fake systemd state lock").enabled)
+            }
+            "systemctl --user enable orbit-sweep.timer" => {
+                self.state.lock().expect("fake systemd state lock").enabled = true;
+                Ok(true)
+            }
+            "systemctl --user restart orbit-sweep.timer" => {
+                self.activate_timer();
+                Ok(true)
+            }
+            "systemctl --user disable --now orbit-sweep.timer" => {
+                let mut state = self.state.lock().expect("fake systemd state lock");
+                state.enabled = false;
+                state.active = false;
+                state.next_trigger = None;
+                Ok(true)
+            }
+            unexpected => panic!("unexpected fake systemd command: {unexpected}"),
+        }
+    }
+
+    fn stdout(&self, command: &ManagerCommand) -> Result<Option<String>, OrbitError> {
+        self.commands
+            .lock()
+            .expect("fake command log lock")
+            .push(command.display());
+        let state = self.state.lock().expect("fake systemd state lock");
+        let next = state
+            .next_trigger
+            .map_or_else(|| "infinity".to_string(), |value| format!("{value}s"));
+        let last = state
+            .last_service_activation
+            .map_or_else(String::new, |value| format!("{value}s"));
+        Ok(Some(format!(
+            "LoadState=loaded\nActiveState={}\nNextElapseUSecRealtime=\nNextElapseUSecMonotonic={next}\nLastTriggerUSec={last}",
+            if state.active { "active" } else { "inactive" }
+        )))
+    }
+}
+
 fn service_path(rendered: &str) -> &str {
     rendered
         .lines()
@@ -125,22 +280,52 @@ fn rendered_systemd_service_discovers_local_provider_launchers() {
 #[test]
 fn systemd_timer_renders_default_and_configured_cadence() {
     let default_timer = render_systemd_timer(ClockSettings::default());
-    assert!(default_timer.contains("OnStartupSec=60s"));
+    assert!(default_timer.contains("OnActiveSec=60s"));
     assert!(default_timer.contains("OnUnitActiveSec=60s"));
+    assert!(!default_timer.contains("OnStartupSec="));
     assert!(!default_timer.contains("Persistent=true"));
 
     let configured_timer = render_systemd_timer(ClockSettings {
         cadence_seconds: 300,
     });
-    assert!(configured_timer.contains("OnStartupSec=300s"));
+    assert!(configured_timer.contains("OnActiveSec=300s"));
     assert!(configured_timer.contains("OnUnitActiveSec=300s"));
 }
 
 #[test]
-fn systemd_install_arms_a_fresh_manager_and_recurs_at_configured_cadence() {
+fn systemd_install_arms_and_recurs_at_default_and_configured_cadence() {
+    for cadence_seconds in [60, 300] {
+        let root = tempdir().expect("create global root");
+        let home = tempdir().expect("create home");
+        let runner = SystemdManagerFake::new(home.path(), 10);
+
+        let report = install_clock_with(
+            root.path(),
+            "/opt/orbit/bin/orbit",
+            ClockSettings { cadence_seconds },
+            ClockPlatform::Systemd,
+            &runner,
+            home.path(),
+        )
+        .expect("install systemd clock");
+
+        assert!(report.activated);
+        assert_eq!(runner.next_trigger(), Some(10 + cadence_seconds));
+        runner.elapse_and_complete_service();
+        assert_eq!(
+            runner.next_trigger(),
+            Some(10 + cadence_seconds * 2),
+            "service activation establishes the recurring deadline"
+        );
+    }
+}
+
+#[test]
+fn late_reinstall_rearms_an_active_elapsed_timer_from_timer_activation() {
     let root = tempdir().expect("create global root");
     let home = tempdir().expect("create home");
-    let runner = MockRunner::new(vec![Ok(true), Ok(true), Ok(true)]);
+    let week = 7 * 24 * 60 * 60;
+    let runner = SystemdManagerFake::late_elapsed(home.path(), week, 60);
 
     let report = install_clock_with(
         root.path(),
@@ -152,21 +337,13 @@ fn systemd_install_arms_a_fresh_manager_and_recurs_at_configured_cadence() {
         &runner,
         home.path(),
     )
-    .expect("install systemd clock");
+    .expect("late reinstall re-arms timer");
 
     assert!(report.activated);
-    assert_eq!(
-        runner.commands(),
-        vec![
-            "systemctl --user daemon-reload",
-            "systemctl --user enable orbit-sweep.timer",
-            "systemctl --user restart orbit-sweep.timer",
-        ]
-    );
-    let timer = fs::read_to_string(home.path().join(".config/systemd/user/orbit-sweep.timer"))
-        .expect("read installed timer");
-    assert!(timer.contains("OnStartupSec=300s"));
-    assert!(timer.contains("OnUnitActiveSec=300s"));
+    let next = runner
+        .next_trigger()
+        .expect("finite trigger after reinstall");
+    assert!((week + 300..=week + 305).contains(&next));
 }
 
 #[test]
@@ -237,7 +414,8 @@ fn enabled_systemd_timer_without_a_future_trigger_is_unhealthy() {
     let runner = MockRunner::with_outputs(
         vec![Ok(true)],
         vec![Ok(Some(
-            "NextElapseUSecRealtime=\nNextElapseUSecMonotonic=0".to_string(),
+            "LoadState=loaded\nActiveState=active\nNextElapseUSecRealtime=\nNextElapseUSecMonotonic=0"
+                .to_string(),
         ))],
     );
 
@@ -248,7 +426,7 @@ fn enabled_systemd_timer_without_a_future_trigger_is_unhealthy() {
     assert!(!status.schedulable);
     assert_eq!(status.effective_cadence_seconds, None);
     assert!(status.health_issue.as_deref().is_some_and(|issue| {
-        issue.contains("no future trigger") && issue.contains("orbit routine init --install-clock")
+        issue.contains("finite future trigger") && issue.contains("orbit routine clock enable")
     }));
     assert_eq!(
         runner.commands(),
@@ -282,54 +460,113 @@ fn disabled_systemd_timer_reports_loaded_state_without_becoming_schedulable() {
 }
 
 #[test]
-fn pause_and_enable_are_idempotent_for_launchd_and_systemd() {
+fn pause_and_enable_are_idempotent_for_launchd() {
     let root = tempdir().expect("create global root");
     let home = tempdir().expect("create home");
-    for (platform, pause, enable) in [
-        (ClockPlatform::Launchd, "launchctl unload", "launchctl load"),
-        (
-            ClockPlatform::Systemd,
-            "systemctl --user disable --now orbit-sweep.timer",
-            "systemctl --user enable --now orbit-sweep.timer",
-        ),
-    ] {
-        let runner = MockRunner::new(vec![
-            Ok(true),
-            Ok(true),
-            Ok(false),
-            Ok(false),
-            Ok(true),
-            Ok(true),
-        ]);
-        assert!(
-            !set_clock_enabled_with(root.path(), false, platform, &runner, home.path())
-                .expect("pause")
-                .enabled
-        );
-        assert!(
-            !set_clock_enabled_with(root.path(), false, platform, &runner, home.path())
-                .expect("repeat pause")
-                .enabled
-        );
-        assert!(
-            set_clock_enabled_with(root.path(), true, platform, &runner, home.path())
-                .expect("enable")
-                .enabled
-        );
-        assert!(
-            set_clock_enabled_with(root.path(), true, platform, &runner, home.path())
-                .expect("repeat enable")
-                .enabled
-        );
-        let commands = runner.commands();
-        assert_eq!(
-            commands.len(),
-            6,
-            "only state-changing calls run manager commands"
-        );
-        assert!(commands[1].starts_with(pause));
-        assert!(commands[4].starts_with(enable));
-    }
+    let runner = MockRunner::new(vec![
+        Ok(true),
+        Ok(true),
+        Ok(false),
+        Ok(false),
+        Ok(true),
+        Ok(true),
+    ]);
+    assert!(
+        !set_clock_enabled_with(
+            root.path(),
+            false,
+            ClockPlatform::Launchd,
+            &runner,
+            home.path()
+        )
+        .expect("pause")
+        .enabled
+    );
+    assert!(
+        !set_clock_enabled_with(
+            root.path(),
+            false,
+            ClockPlatform::Launchd,
+            &runner,
+            home.path()
+        )
+        .expect("repeat pause")
+        .enabled
+    );
+    assert!(
+        set_clock_enabled_with(
+            root.path(),
+            true,
+            ClockPlatform::Launchd,
+            &runner,
+            home.path()
+        )
+        .expect("enable")
+        .enabled
+    );
+    assert!(
+        set_clock_enabled_with(
+            root.path(),
+            true,
+            ClockPlatform::Launchd,
+            &runner,
+            home.path()
+        )
+        .expect("repeat enable")
+        .enabled
+    );
+    assert_eq!(runner.commands().len(), 6);
+}
+
+#[test]
+fn systemd_cadence_change_and_reenable_establish_new_deadlines() {
+    let root = tempdir().expect("create global root");
+    let home = tempdir().expect("create home");
+    let runner = SystemdManagerFake::new(home.path(), 100);
+    install_clock_with(
+        root.path(),
+        "/opt/orbit/bin/orbit",
+        ClockSettings::default(),
+        ClockPlatform::Systemd,
+        &runner,
+        home.path(),
+    )
+    .expect("initial install");
+
+    runner.set_now(1_000);
+    set_clock_cadence_with(
+        root.path(),
+        300,
+        "/opt/orbit/bin/orbit",
+        ClockPlatform::Systemd,
+        &runner,
+        home.path(),
+    )
+    .expect("cadence change re-arms timer");
+    assert!((1_300..=1_305).contains(&runner.next_trigger().expect("cadence deadline")));
+
+    let paused = set_clock_enabled_with(
+        root.path(),
+        false,
+        ClockPlatform::Systemd,
+        &runner,
+        home.path(),
+    )
+    .expect("pause systemd timer");
+    assert!(!paused.enabled);
+    assert!(runner.next_trigger().is_none());
+
+    runner.set_now(2_000);
+    let enabled = set_clock_enabled_with(
+        root.path(),
+        true,
+        ClockPlatform::Systemd,
+        &runner,
+        home.path(),
+    )
+    .expect("re-enable and verify systemd timer");
+    assert!(enabled.schedulable);
+    assert!((2_300..=2_305).contains(&runner.next_trigger().expect("re-enable deadline")));
 }
 
 #[test]
@@ -348,7 +585,7 @@ fn manager_failures_include_exact_recovery_command() {
     assert!(
         error
             .to_string()
-            .contains("systemctl --user enable --now orbit-sweep.timer")
+            .contains("systemctl --user enable orbit-sweep.timer")
     );
     assert!(error.to_string().contains("recovery:"));
 }
@@ -357,14 +594,12 @@ fn manager_failures_include_exact_recovery_command() {
 fn cadence_reload_failure_restores_config_and_reactivates_previous_systemd_unit() {
     let root = tempdir().expect("create global root");
     let home = tempdir().expect("create home");
-    let runner = MockRunner::new(vec![
-        Ok(true),
-        Ok(true),
-        Ok(false),
-        Ok(true),
-        Ok(true),
-        Ok(true),
-    ]);
+    let runner = MockRunner::with_outputs(
+        vec![Ok(true), Ok(true), Ok(false), Ok(true), Ok(true), Ok(true)],
+        vec![Ok(Some(
+            "LoadState=loaded\nActiveState=active\nNextElapseUSecMonotonic=60s".to_string(),
+        ))],
+    );
     let error = set_clock_cadence_with(
         root.path(),
         300,
@@ -397,8 +632,35 @@ fn cadence_reload_failure_restores_config_and_reactivates_previous_systemd_unit(
             "systemctl --user daemon-reload",
             "systemctl --user enable orbit-sweep.timer",
             "systemctl --user restart orbit-sweep.timer",
+            "systemctl --user show orbit-sweep.timer --property=LoadState --property=ActiveState --property=NextElapseUSecRealtime --property=NextElapseUSecMonotonic --property=LastTriggerUSec",
         ]
     );
+}
+
+#[test]
+fn systemd_install_rejects_successful_commands_without_a_finite_trigger() {
+    let root = tempdir().expect("create global root");
+    let home = tempdir().expect("create home");
+    let runner = MockRunner::with_outputs(
+        vec![Ok(true), Ok(true), Ok(true)],
+        vec![Ok(Some(
+            "LoadState=loaded\nActiveState=active\nNextElapseUSecMonotonic=infinity".to_string(),
+        ))],
+    );
+
+    let error = install_clock_with(
+        root.path(),
+        "/opt/orbit/bin/orbit",
+        ClockSettings::default(),
+        ClockPlatform::Systemd,
+        &runner,
+        home.path(),
+    )
+    .expect_err("unschedulable activation is not reported as active");
+
+    assert!(error.to_string().contains("finite future trigger"));
+    assert!(error.to_string().contains("systemctl --user status"));
+    assert!(error.to_string().contains("journalctl --user"));
 }
 
 #[test]

--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -1,8 +1,8 @@
 ---
 title: Routines — Design
 owner: claude
-last_updated: 2026-08-15
-last_validated: 2026-08-16
+last_updated: 2026-08-23
+last_validated: 2026-08-23
 status: Accepted
 feature: routines
 doc_role: design
@@ -11,7 +11,7 @@ summary: Proposed contract for routine definitions, sweep dispatch, host-local s
 tags: [routines, scheduler]
 paths: ["crates/orbit-cli/src/command/routine/**", "crates/orbit-core/src/routines/**", "crates/orbit-cmd/src/registry_routines.rs", "crates/orbit-cmd/src/registry_runtime.rs", "crates/orbit-registry/src/host_identity.rs", "crates/orbit-registry/src/workspace_registry/**", "crates/orbit-store/src/sqlite/routine_store/**"]
 related_features: [routines, activity-job, host-registry]
-related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ORB-10800]
+related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ORB-10800, ORB-10986]
 ---
 
 # Routines — Design
@@ -30,15 +30,17 @@ routine definition. Its durable configuration is `~/.orbit/clock.toml`, defaults
 60-second cadence, and accepts only whole-minute values from 60 through 3600 seconds.
 
 `orbit routine clock status` reports configured cadence, native-manager enabled state,
-and whether an enabled Linux timer has a finite next trigger. An enabled timer with no
-future trigger is `unhealthy`, has no effective cadence, and reports the reinstall command
-that restores the generated unit. `orbit routine clock pause` disables only launchd/systemd
+and whether an enabled Linux timer is active with a finite next trigger. An enabled timer
+without that scheduling state is `unhealthy`, has no effective cadence, and reports
+`orbit routine clock enable`, which restarts the timer and verifies the resulting deadline.
+`orbit routine clock pause` disables only launchd/systemd
 scheduled invocations (surviving logout/reboot through the native per-user manager);
 it preserves routine cursors, fire history, and per-routine pauses, and a deliberate
 `orbit sweep` is still available. `enable` resumes with the configured cadence, while
 `set --cadence-seconds N` atomically rewrites the host setting and reloads the existing
-unit identity. On an activation failure Orbit reports the concrete native recovery
-command rather than claiming the clock is active. launchd and systemd user managers are
+unit identity. Linux installation, cadence changes, and enablement verify an active timer
+with a finite next trigger after native commands complete. A failed verification is an
+actionable error rather than a claim that the clock is active. launchd and systemd user managers are
 the supported platforms; there is no resident Orbit daemon ([Host-local sweep clock configuration](./4_decisions.md#host-local-sweep-clock-configuration)).
 
 The dashboard Operations view projects the same typed status and control functions
@@ -271,10 +273,12 @@ renders and installs the platform unit:
 
 - **macOS** — a launchd agent (`com.orbit.sweep`) with `StartInterval` 60s. launchd also
   fires on wake, which pairs with `missed_run: catch_up_once` for laptop sleep gaps.
-- **Linux** — `orbit-sweep.timer` combines `OnStartupSec=<cadence>` with
-  `OnUnitActiveSec=<cadence>` plus a oneshot service. A fresh user manager therefore arms a
-  finite first sweep; a reinstall after the startup deadline fires immediately; successful
-  service activations schedule subsequent sweeps at the configured cadence. These monotonic
+- **Linux** — `orbit-sweep.timer` combines `OnActiveSec=<cadence>` with
+  `OnUnitActiveSec=<cadence>` plus a oneshot service. Every timer activation (fresh install,
+  late reinstall, cadence change, or re-enable) therefore arms a finite first sweep relative
+  to that activation; successful service activations schedule subsequent sweeps at the
+  configured cadence. `AccuracySec=5s` bounds manager coalescing after each deadline
+  [ORB-10986]. These monotonic
   triggers deliberately do not replay timer events missed while the manager or host was
   down. The first sweep after restart evaluates each routine's cursor, so `catch_up_once`
   collapses missed cron slots to one fire and `skip` waits for the next natural slot.

--- a/docs/design/routines/4_decisions.md
+++ b/docs/design/routines/4_decisions.md
@@ -1,8 +1,8 @@
 ---
 title: Routines — Decisions
 owner: claude
-last_updated: 2026-08-12
-last_validated: 2026-08-16
+last_updated: 2026-08-23
+last_validated: 2026-08-23
 status: Accepted
 feature: routines
 doc_role: decisions
@@ -11,7 +11,7 @@ summary: Decision log for the routines scheduler, including default seeding and 
 tags: [routines, scheduler]
 paths: ["crates/orbit-core/src/routines/**", "crates/orbit-cmd/src/registry_routines.rs", "crates/orbit-cmd/src/registry_runtime.rs", "crates/orbit-registry/src/**"]
 related_features: [routines, activity-job, host-registry]
-related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ORB-10739]
+related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ORB-10739, ORB-10986]
 ---
 
 # Routines — Decisions
@@ -31,12 +31,12 @@ Something must wake the scheduler. Alternatives: a resident `orbit schedulerd` o
 
 ### Decision
 
-launchd (`StartInterval` 60s) and a systemd timer (`OnStartupSec` plus `OnUnitActiveSec`) invoke `orbit sweep`; sweep is stateless-in, durable-out. The systemd timer arms itself in every fresh user-manager session and recurs after service activation. Missed cron-slot semantics belong to each routine's `missed_run` policy. There is no resident Orbit daemon.
+launchd (`StartInterval` 60s) and a systemd timer (`OnActiveSec` plus `OnUnitActiveSec`) invoke `orbit sweep`; sweep is stateless-in, durable-out. The systemd timer arms itself from every timer activation and recurs after service activation. Missed cron-slot semantics belong to each routine's `missed_run` policy. There is no resident Orbit daemon [ORB-10986].
 
 ### Consequences
 
 - No process supervision, crash recovery, or memory-leak surface; a wedged pass affects one minute, not the scheduler.
-- launchd wake behavior and systemd's first sweep after a fresh manager session pair with `missed_run: catch_up_once` to cover laptop sleep and host downtime without replaying every missed clock tick.
+- launchd wake behavior and systemd's first sweep after timer activation pair with `missed_run: catch_up_once` to cover laptop sleep and host downtime without replaying every missed clock tick.
 - Cost: minute granularity is a hard floor and event triggers are structurally impossible in v1; correct behavior depends on two platform-specific unit files that must be kept in parity and tested on both platforms.
 
 ## Routine discovery via the workspace registry and a versioned [routines] role=source config key
@@ -162,8 +162,8 @@ Store the supported whole-minute cadence in host-local `~/.orbit/clock.toml` and
 
 ### Consequences
 - Clock status reports configured and effective cadence, and native-manager failures include recovery commands.
-- On Linux, enabled state is insufficient for health: status reports an effective cadence only when systemd also exposes a finite next trigger, and an elapsed or unscheduled timer reports the clock reinstall recovery command.
-- Linux uses monotonic startup and post-activation triggers. A fresh user-manager session always gains an initial trigger; missed timer ticks are not replayed, leaving catch-up versus skip behavior to each routine's persisted cursor and `missed_run` policy.
+- On Linux, enabled state and successful manager command exits are insufficient for health: installation and controls report success only when systemd exposes an active timer with a finite next trigger. An elapsed or unscheduled timer reports `orbit routine clock enable`, which restarts the timer even when already enabled and verifies the repaired state.
+- Linux uses monotonic timer-activation and service-activation triggers. `OnActiveSec` establishes the first deadline after every install, reinstall, cadence change, and re-enable; `OnUnitActiveSec` establishes recurrence after each sweep service activation. `AccuracySec=5s` bounds coalescing after either deadline. Missed timer ticks are not replayed, leaving catch-up versus skip behavior to each routine's persisted cursor and `missed_run` policy.
 - Cost: the host-local setting intentionally does not travel with a workspace, so operators configure each host separately.
 
 ## Task References

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -4,8 +4,8 @@ summary: Check Orbit workspace, database, dashboard, log-sink, job-run, and rout
 tags: [operations, health, doctor, dashboard, routines]
 paths: ["crates/orbit-cmd/src/doctor.rs", "crates/orbit-core/src/application/job/run/reconcile.rs"]
 related_features: [orbit-core, activity-job, routines]
-related_artifacts: [ORB-10005, ORB-10070, ORB-10473, ORB-10501, ORB-10558]
-last_validated: 2026-08-22
+related_artifacts: [ORB-10005, ORB-10070, ORB-10473, ORB-10501, ORB-10558, ORB-10986]
+last_validated: 2026-08-23
 ---
 
 # Check Orbit Health
@@ -145,11 +145,15 @@ orbit routine list
 orbit sweep --json
 ```
 
-On Linux, a healthy enabled status includes a finite next systemd trigger and an effective
-cadence. `clock: unhealthy` with an inactive effective cadence means the timer is enabled but
-elapsed, unscheduled, or could not be probed; follow the printed diagnostic and reinstall the
-generated units with `orbit routine init --install-clock`. The generated timer schedules its
-first sweep from each systemd user-manager startup and then recurs from service activation.
+On Linux, a healthy enabled status includes an active timer, a finite next systemd trigger,
+and an effective cadence. `clock: unhealthy` with an inactive effective cadence means the
+timer is enabled but elapsed, unscheduled, inactive, or could not be probed. Inspect the
+printed diagnostic, then run `orbit routine clock enable`: it restarts the timer even when it
+is already enabled and returns success only after verifying a finite next trigger. If that
+verification fails, inspect the `systemctl --user status` and `journalctl --user` commands in
+the error before retrying. The generated timer schedules its first sweep from every timer
+activation and then recurs from service activation; installation and cadence changes perform
+the same post-activation verification.
 It does not replay every tick missed during host or manager downtime: on the next sweep,
 routine `missed_run: catch_up_once` fires once for a gap while `skip` waits for the next natural
 cron slot.


### PR DESCRIPTION
## Task

[ORB-10986](https://orbit-cli.com/tasks/ORB-10986) — Re-arm the systemd sweep clock on reinstall and verify its next trigger

### Description

## Problem
On dk-server-1 with Orbit 0.13.0 and systemd 255, `orbit routine clock status` reported an enabled timer with no future trigger and recommended `orbit routine init --install-clock`. Running that recovery path at 2026-08-23 00:05:33 rewrote, daemon-reloaded, enabled, and restarted the units, but the result remained `active (elapsed)` with `NextElapseUSecMonotonic=infinity`; the last actual trigger remained 2026-08-16.

ORB-10822 changed the generated timer to combine `OnStartupSec=<cadence>` with `OnUnitActiveSec=<cadence>` and made the installer explicitly restart the timer. In the observed late-reinstall state, neither source produced a new deadline. The installer nevertheless returned activation success because it treats successful manager command exits as sufficient and does not verify post-install schedulability. The status recovery guidance therefore loops back to a command that does not repair the condition.

The existing deterministic test asserts rendered directives and mocked `daemon-reload` / `enable` / `restart` success, but does not model or verify a finite next trigger after a late reinstall.

## Why It Matters
The host-wide sweep clock drives every enabled routine across registered workspaces. A successful-looking reinstall can leave all routine automation silently inactive, while the only advertised recovery repeats the ineffective operation.

## Constraints / Notes
- Establish the initial Linux deadline relative to an event that occurs on every fresh activation or reinstall. `OnActiveSec=<cadence>` plus the recurring `OnUnitActiveSec=<cadence>` is the leading candidate, but validate the chosen systemd semantics against the observed late-reinstall case.
- Preserve configurable whole-minute cadences and current routine-level missed-run behavior.
- Installation, cadence changes, and clock enablement must distinguish manager command success from an actually schedulable timer.
- Keep macOS launchd behavior unchanged.
- Do not fire a real sweep from ordinary unit tests; use a behaviorally faithful manager fake or a safely isolated Linux integration test.

### Acceptance Criteria

- On Linux, installing or reinstalling the clock after the user manager has been running longer than the configured cadence leaves `orbit-sweep.timer` active with a finite future trigger, without requiring a manual `orbit-sweep.service` start.
- Fresh installation, reinstall of an `active (elapsed)` timer, cadence changes, and re-enabling a paused clock all establish a next trigger no later than the configured cadence plus `AccuracySec`.
- The timer continues recurring at both the default and a configured cadence after service activation, while existing routine `missed_run` semantics remain unchanged.
- The installer does not report `activated: true` solely because systemd commands exited successfully: it verifies post-activation schedulability and returns a truthful actionable error if no finite next trigger exists.
- `orbit routine clock status` never recommends an ineffective self-loop recovery; its unhealthy output names a recovery path that is verified for the reported state.
- Deterministic automated coverage reproduces the late-reinstall `active (elapsed)` condition and fails against the ORB-10822 behavior; coverage validates resulting scheduling state rather than only rendered text and command order.
- Current timer comments, routine design, and health runbook describe the implemented activation, recurrence, and recovery behavior; macOS launchd behavior is unchanged.
- Focused clock tests, `make ci-fast`, and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced Linux timer startup-relative first scheduling with OnActiveSec while retaining OnUnitActiveSec recurrence and AccuracySec=5s.
- Made install, cadence changes, and systemd enable/recovery verify that the timer is loaded, active, and has a finite future trigger; successful manager exits alone can no longer report activation.
- Made `orbit routine clock enable` restart even an already-enabled elapsed timer and verify the result, and changed unhealthy status guidance to that verified recovery path.
- Added a temporal systemd manager fake covering default/configured recurrence, late active-elapsed reinstall, cadence changes, pause/re-enable, and false-positive activation.
- Updated current routine design, decisions, and health runbook for activation-relative deadlines, verification, recovery, and unchanged routine missed-run semantics.
Assessment: The change stays within the clock integration boundary and leaves launchd behavior unchanged. Systemd 255 documentation confirms OnActiveSec is relative to timer-unit activation, OnUnitActiveSec is relative to service activation, and AccuracySec bounds coalescing after each deadline.
Validation:
- `cargo test -p orbit-core routines::tests::clock --no-fail-fast` (14 passed)
- `make ci-fast` (passed)
- `make ci-lint` (passed)
- `git diff --check` (passed)
Friction checkpoint: no qualifying friction; the only tool-routing hiccup was resolved quickly by applying the explicit workspace filter.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10986-6a8a3f0c`
- Behind base: 0
- Ahead of base: 1