### PR TITLE
[QA] Linked-worktree task creation rejects valid workspace path

### DIFF
--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -216,20 +216,36 @@ fn build_v2_task_backends(
             .unwrap_or_else(|| UNBOUND_DATA_DIR_WORKSPACE_ID.to_string());
         return Ok(coordination_task_backends(registry, workspace_id));
     }
-    let workspace_id = if let Some(config) = &config {
-        if let Some(hint) = workspace_id_hint
-            && config.workspace_id != hint
-        {
-            return Err(OrbitError::WorkspaceError(format!(
-                "workspace binding id '{}' does not match configured workspace id '{}'",
-                hint, config.workspace_id
-            )));
+    let configured_id = config.as_ref().map(|config| config.workspace_id.as_str());
+    if let (Some(hint), Some(configured)) = (workspace_id_hint, configured_id)
+        && configured != hint
+    {
+        return Err(OrbitError::WorkspaceError(format!(
+            "workspace binding id '{hint}' does not match configured workspace id '{configured}'"
+        )));
+    }
+    // A checkout whose `config.yaml` identity drifted from the registry row for
+    // its orbit dir still keeps its task state under the bound id. Adopt that
+    // row instead of asking `bind_workspace` for the drifted id, which fails
+    // closed and takes every command in the checkout down (ORB-10985). The
+    // config write below reconciles the checkout identity back onto it.
+    let workspace_id = match registry.find_checkout_by_orbit_dir(&paths.orbit_dir)? {
+        Some(bound) => {
+            if configured_id.is_some_and(|configured| configured != bound.workspace_id) {
+                tracing::warn!(
+                    target: "orbit.core.bootstrap",
+                    orbit_dir = %paths.orbit_dir.display(),
+                    bound_workspace_id = %bound.workspace_id,
+                    configured_workspace_id = configured_id,
+                    "checkout identity diverged from its task-registry binding; adopting the bound workspace"
+                );
+            }
+            Some(bound.workspace_id)
         }
-        Some(config.workspace_id.clone())
-    } else if let Some(hint) = workspace_id_hint {
-        Some(hint.to_string())
-    } else {
-        rebind_candidate_workspace_id(&registry, paths)?
+        None => match configured_id.or(workspace_id_hint) {
+            Some(id) => Some(id.to_string()),
+            None => rebind_candidate_workspace_id(&registry, paths)?,
+        },
     };
     let binding = registry.bind_workspace(BindWorkspaceParams {
         workspace_id,
@@ -242,14 +258,26 @@ fn build_v2_task_backends(
     if config
         .as_ref()
         .is_none_or(|config| config.workspace_id != binding.workspace_id)
-    {
-        write_workspace_config(
+        && let Err(error) = write_workspace_config(
             &paths.orbit_dir,
             &WorkspaceConfig {
                 schema_version: 1,
                 workspace_id: binding.workspace_id.clone(),
             },
-        )?;
+        )
+    {
+        // Reads must still work from a read-only mount; the identity file is
+        // reconciled the next time the checkout is writable.
+        if error.is_readonly_or_access_failure() {
+            tracing::warn!(
+                target: "orbit.core.bootstrap",
+                orbit_dir = %paths.orbit_dir.display(),
+                error = %error,
+                "skipped incidental workspace-identity reconciliation"
+            );
+        } else {
+            return Err(error);
+        }
     }
 
     Ok(workspace_task_backends(

--- a/crates/orbit-core/src/runtime/tests/builder.rs
+++ b/crates/orbit-core/src/runtime/tests/builder.rs
@@ -206,6 +206,48 @@ fn v2_task_backend_rebinds_when_workspace_config_is_missing() {
     );
 }
 
+/// ORB-10985: a checkout whose `config.yaml` identity drifted away from the
+/// registry row for its orbit dir must still open — the bound partition holds
+/// its task state — and the identity file is reconciled onto that partition.
+#[test]
+fn v2_task_backend_adopts_the_bound_workspace_when_the_checkout_identity_drifts() {
+    let (_root, global_root, workspace_root, runtime) = v2_runtime();
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Drifted identity task".to_string(),
+            description: "Stays reachable after config.yaml is rewritten".to_string(),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("create task");
+    let bound_workspace_id = read_workspace_config_optional(&workspace_root)
+        .expect("read workspace config")
+        .map(|config| config.workspace_id)
+        .expect("workspace id");
+    drop(runtime);
+
+    orbit_store::maintenance::task_registry::write_workspace_config(
+        &workspace_root,
+        &orbit_store::maintenance::task_registry::WorkspaceConfig {
+            schema_version: 1,
+            workspace_id: "orbit-5c61b3".to_string(),
+        },
+    )
+    .expect("diverge the checkout identity");
+
+    let rebuilt = OrbitRuntime::from_roots(&global_root, &workspace_root)
+        .expect("a drifted checkout identity must not refuse the runtime");
+    let fetched = rebuilt.get_task(&task.id).expect("get task after drift");
+    assert_eq!(fetched.title, "Drifted identity task");
+    assert_eq!(
+        read_workspace_config_optional(&workspace_root)
+            .expect("read reconciled workspace config")
+            .map(|config| config.workspace_id),
+        Some(bound_workspace_id),
+        "the checkout identity must be reconciled onto the bound partition"
+    );
+}
+
 #[test]
 fn explicit_data_dir_runtime_does_not_bind_parent_as_a_checkout() {
     let root = tempdir().expect("tempdir");

--- a/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
@@ -1194,6 +1194,23 @@ impl TaskRegistryStore {
         workspace_checkout_by_id(&conn, &workspace_id)
     }
 
+    /// Look up the checkout bound to an orbit dir, if one is bound.
+    ///
+    /// `orbit_dir` is UNIQUE in `workspace_checkout_bindings`, so this answers
+    /// "which partition does task state under this directory already live in?"
+    /// without attempting a bind.
+    pub fn find_checkout_by_orbit_dir(
+        &self,
+        orbit_dir: &Path,
+    ) -> Result<Option<WorkspaceCheckoutBinding>, OrbitError> {
+        let orbit_dir = normalize_path(orbit_dir);
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+        workspace_by_orbit_dir(&conn, &orbit_dir)
+    }
+
     /// Resolve a checkout before a task operation touches checkout-local files.
     pub fn require_workspace_checkout(
         &self,


### PR DESCRIPTION
## Task

[ORB-10985](https://orbit-cli.com/tasks/ORB-10985) — [QA] Linked-worktree task creation rejects valid workspace path

### Description

Recent user-facing regression observed while validating commits c880ab2b (ORB-10961) and f4ca5f03 (ORB-10980).

Evidence: `cargo test -p orbit-cli --test mcp_roundtrip task_show_is_global_by_default_across_tool_run_and_mcp -- --exact --nocapture` fails consistently (exit 101), and `cargo test -p orbit-cli --test mcp_roundtrip managed_mcp_config_routes_a_linked_worktree_by_its_logical_workspace_id -- --exact --nocapture` fails consistently (exit 101). Both tests fail before their task.show assertions when `orbit.task.add` is called:
`{"code":"invalid_input","error":"invalid input: orbit dir /tmp/.tmp.../work/.orbit is already bound to workspace ws_mcp-roundtrip, not orbit-5c61b3"}`.

Reproduction:
1. Run either exact test above from a clean checkout.
2. The fixture initializes a workspace, then changes the JSON logical workspace id to `ws_legacy-logical` and the local runtime identity to the linked-worktree-style id `orbit-5c61b3`.
3. It creates a second checkout and invokes `orbit tool run orbit.task.add` with the first checkout path in the `workspace` input.
4. Task creation is rejected because runtime identity `orbit-5c61b3` is treated as a requested registry binding even though the explicit workspace path identifies the existing logical workspace.

Expected: an explicit registered workspace path should route task creation to that workspace despite a divergent linked-worktree runtime identity; the test should proceed to validate global task.show behavior.
Actual: task creation fails with the binding conflict above.

Affected user paths: managed MCP/CLI task creation from a linked worktree with a divergent runtime identity.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed: runtime open no longer fails when a checkout's `.orbit/config.yaml` identity has drifted from the task-registry row bound to its orbit dir.

Root cause: `build_v2_task_backends` (crates/orbit-core/src/runtime/builder.rs) passed the identity read from `.orbit/config.yaml` to `TaskRegistryStore::bind_workspace` as a hard request. `workspace_checkout_bindings.orbit_dir` is UNIQUE and the bind fails closed when the directory already belongs to another workspace id, so a checkout whose config identity had drifted (the ORB-10952 linked-worktree shape, e.g. `orbit-5c61b3`) could not open a runtime at all: `invalid input: orbit dir '<...>/.orbit' is already bound to workspace 'ws_mcp-roundtrip', not 'orbit-5c61b3'`. That took down every command in the checkout, including `orbit.task.add` with an explicit registered workspace path.

Change:
- crates/orbit-store/src/driver/sqlite/task_registry/store.rs: added `TaskRegistryStore::find_checkout_by_orbit_dir`, a public exact lookup of the checkout bound to an orbit dir (no bind attempt).
- crates/orbit-core/src/runtime/builder.rs: `build_v2_task_backends` now resolves the partition from that existing row when one exists — the bound id is where the checkout's task state lives — and warns (`orbit.core.bootstrap`) when the configured identity disagrees. The pre-existing config write then reconciles `.orbit/config.yaml` onto the bound partition, which keeps `task_owner::resolve_task_owner` able to map the partition back to a local checkout. The explicit binding-vs-config mismatch error (a caller-supplied hint that disagrees with config.yaml) is unchanged and still fails closed.
- Same file: the identity reconciliation write now tolerates read-only/access failures with a warning instead of failing the open, so read-only mounts keep ORB-10963's observational-read guarantee now that drift can trigger that write.
- crates/orbit-core/src/runtime/tests/builder.rs: added `v2_task_backend_adopts_the_bound_workspace_when_the_checkout_identity_drifts` — task created, config.yaml rewritten to `orbit-5c61b3`, runtime reopens, task still readable, identity reconciled to the bound id.

Scope note: `crates/orbit-store/src/driver/sqlite/task_registry/store.rs` was not in context_files; it was needed to expose the orbit-dir lookup the fix reads (smallest compatible change — one new read-only accessor, no behavior change to existing bind paths). No new crate dependency edge (orbit-core already depends on orbit-store), so ARCHITECTURE.md is unchanged. No current doc described the fail-closed behavior, so no doc update was required.

Validation:
- `cargo test -p orbit-cli --test mcp_roundtrip` — 18/18 pass, including the two reported failures (`task_show_is_global_by_default_across_tool_run_and_mcp`, `managed_mcp_config_routes_a_linked_worktree_by_its_logical_workspace_id`), both of which fail on the base commit.
- `cargo test -p orbit-core -p orbit-store -p orbit-cmd` — all pass; `cargo test -p orbit-cli --no-fail-fast` — all integration targets pass.
- `cargo test --workspace --no-fail-fast`, `make ci-fast`, `make ci-lint` — clean apart from two failures that are PRE-EXISTING on the base commit (verified by re-running them with builder.rs reverted to HEAD):
  1. `orbit-cli --bin orbit tests::audit_middleware::audit_guard_event_json_shapes_are_snapshotted` — snapshot expects `workspace_id: null` but the in-memory runtime now reports `ws_memory`; the snapshot was not updated when ORB-10981 gave in-memory runtimes a `ws_memory` binding.
  2. `orbit-web --lib api::tests::tasks::task_locks_endpoint_matches_cli_json_contract` — task-locks endpoint returns an empty array instead of the three `file:` selectors.
  Both are outside this task's scope and left untouched; they need their own tasks.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10985-6a8a3f0c`
- Behind base: 0
- Ahead of base: 1