### PR TITLE
Prepare v0.14.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.14.0
+
+### Breaking Changes
+
+- **Fresh installs no longer seed the legacy `qa` crew**: new `orbit init` workspaces use the supported `system` crew; update prompts that name the seeded `qa` crew. Existing user-authored `qa` configuration remains compatible. ([ORB-10955])
+- **`proc.spawn` activities now require an allowlist**: v2 activities that grant `proc.spawn` must declare `proc_allowed_programs`; add the allowed programs explicitly. ([ORB-10959])
+
+### Highlights
+
+- **Cursor Agent Plugin support**: Orbit now ships as a Cursor-compatible Agent Plugin alongside the Claude and Codex plugin formats. ([ORB-10943])
+- **More managed CLI executors**: GitHub Copilot CLI and Cursor Agent CLI are first-class workflow executors, with improved installed-agent detection. ([ORB-10946])
+- **Operator-authorized MCP setup**: `orbit workspace init --mcp` can generate MCP configuration for a workspace. ([ORB-10960])
+- **Dashboard workspace shell**: the dashboard gains a command rail, two-mode dock, and log status bar for faster operator navigation. ([ORB-10972])
+- **Security-review automation**: fresh workspaces include a disabled security-review auto-task that teams can enable when ready. ([ORB-10950])
+
 ## 0.13.0
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbit-agent"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cli"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cmd"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-common"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-config"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "orbit-common",
  "orbit-types",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "croner",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-engine"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-exec"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "libc",
  "orbit-common",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-mcp"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-policy"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-registry"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "hostname",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-search"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-store"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-tools"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-types"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-web"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 license = "MIT"
 # MSRV [ORB-10010]: edition 2024 requires >= 1.85; the highest `rust-version`

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface, skills, and orchestration subagents to Claude Code.",
   "author": {
     "name": "danieljhkim",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP task and knowledge surface plus workflow skills to Codex.",
   "author": {
     "name": "danieljhkim",

--- a/plugin/npm/package.json
+++ b/plugin/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbit-tools/cli",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "npm proxy for the Orbit CLI. Downloads the matching native binary from GitHub Releases on install and forwards all invocations.",
   "bin": {
     "orbit": "bin/orbit.js"

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "orbit",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface and shared workflow skills to compatible clients.",
   "author": {
     "name": "danieljhkim",


### PR DESCRIPTION
## Task

[ORB-10987](https://orbit-cli.com/tasks/ORB-10987) — Prepare v0.14.0 release

### Description

Prepare the candidate v0.14.0 release after the report-first probe found no unfinished non-exempt tasks and a non-empty commit range after v0.13.0.

Follow RELEASING.md, especially the release checklist. This handoff is intentionally bounded: do not commit, tag, push, publish, promote, merge, bump versions, edit CHANGELOG.md, or record human confirmation that a breaking-change candidate is accepted. The implementing release agent must stop at the human approval boundary and report evidence before any release-state action.

Probe evidence:
- Unfinished-work query: backlog=[], in-progress=[ORB-10984], review=[]; ORB-10984 is exempt solely because it carries the exact provenance tag auto-task:release-prep. Sorted non-exempt blockers: [].
- Latest reachable release tag: v0.13.0 (from git tag --merged HEAD --list 'v*' --sort=-version:refname | head -n 1).
- Survey command: git log v0.13.0..HEAD --pretty='%H%x09%s' --no-merges.
- Surveyed commits, newest first:
- eac2ae0fedcdaa2df466391ca2f80490af59e12c fix: [QA] Linked-worktree task creation rejects valid workspace path [ORB-10985]
- f88dcbe5713e14bb1fae8565b3c49e7e2fd8ea64 fix: Re-arm the systemd sweep clock on reinstall and verify its next trigger [ORB-10986]
- 030285ee7005fe6b932596d514515c75d9af89a1 fix: [auto-task] Remediate current GitHub Actions failures [ORB-10982]
- a702df96a25b10d16583ebd4c77bb518eb09de7e fix: `orbit --root <data-dir> executor list` binds parent of the data directory [ORB-10981]
- f4ca5f03420cb32e1044c3466b19426a937e61a0 fix: Route managed CLI agents to the shared Orbit registry instead of a local registry [ORB-10980]
- 68f2e41ef80c7645edcd535d3021087d5be1da99 fix: Partition workspace-auto by crew and terminalize claimed worker state [ORB-10979]
- 562a05f972de366c672b17533ae0ced95757598f fix: Restore automatic workspace propagation for orbit.task.update [ORB-10967]
- decaa9d7e37d72b6605a5995490f977876bc70c7 fix: Dashboard: long expanded task detail is clipped and unscrollable [ORB-10975]
- 90a7912f266a2da83d6efc6c97f39236e8dc3112 fix: Dashboard renders the Diagnostics subtabs twice (duplicate id="diagnostics") [ORB-10976]
- 321dcfff4b26976ddde6b07e0efaef6b21a32714 fix: Make invoke_and_wait durably expose child dispatch before blocking [ORB-10971]
- d223d32dc81865a63f21de1777f6bf2dccd42e64 fix: Keep task.show readable when its stored crew is unavailable [ORB-10968]
- 9b0c2430fd860d89d7298b94ae72084c503c9761 feat: Generate operator-authorized MCP config from workspace init --mcp [ORB-10960]
- 84007ee11e1ec56c00a8cf67e1994cba09a3204d fix: Allow orbit.task.show to project ordinary top-level task fields [ORB-10966]
- 9ddd408ab7b5aaf03e6eaf07021fa3c1d0a97af2 fix: proc.spawn program allowlist fails open when a v2 activity omits proc_allowed_programs [ORB-10959]
- 5e273ef95808e5b499f497a5fa9fa8f912ce48b0 fix: Map Grok Build usage-ledger model ids to the requested public model [ORB-10970]
- 06b928152ca79fb0fdd3d092ab3cd44e552036bc fixme: perf
- f58e1627534fe7ccf78cf3466a583dd59da6cbea [ORB-10972] dashboard: left command rail, two-mode dock, log status bar
- 82b94836091d8001972577f3172669c1fd27f228 fix: Restore incident-aware failure grouping in dashboard tool metrics [ORB-10969]
- 8898cb11973553fc7e4614ae52aca0e1bff77368 fix: Guarantee lexical search fallback when the semantic companion is unavailable [ORB-10964]
- f710a6072f4947e166d9d4049aaadecd924fbf3c fix: Keep read-only Orbit tool calls free of incidental writes [ORB-10963]
- 9b6065df2a8d22f145091db8f9261285f081aaec fix: Make duplicate job-run Start delivery idempotent [ORB-10965]
- c880ab2b997980d451a72d456d27120f3e1c02b3 fix: Make orbit.task.show global-by-default across tool run and MCP [ORB-10961]
- 0b919deb42bdcae362b603b82d55454ddd98e5e9 fix: Artifact redaction allowlist omits session_log.append and other peer tools [ORB-10958]
- b11685ca5ac2439437c77be38e0b2bb7005a26c1 feat: Stop seeding the legacy QA crew during orbit init [ORB-10955]
- 89fea222d7cf4322f4cec07d31c83e001fc78cfd chore: use specific claude model name for better auditability
- 824b4b9561e6f8395cede1296b56ffe2f9c469ef chore: add security-review auto-task
- fddeb0b372a8a13156614860e9e49df6e1fa753b fix: orbit init: Copilot CLI missing from "Detected agents" list [ORB-10953]
- 1d0d33c7415037cf37a11a4bedb6d1b71231fd40 chore: [auto-task] Doc duties — validate the least-recently-validated docs [ORB-10952]
- cb4d63f12a95169f8abc9e93f84975ee80bfe57a feat: Seed security-review as a disabled default auto-task [ORB-10950]
- 12e65730abdae2a1037aeba7f6099bf8f66f5e64 chore: [auto-task] Doc duties — validate the least-recently-validated docs [ORB-10951]
- 54419d16f79bca6ef667fad0f564af9427f46861 fix: Fix Agent Plugin validator test for relative repository paths [ORB-10949]
- 83f67c25140cae44a23b165664dd363c7c1bb7aa chore: enable auto-docs
- ad4c45cf2a3b585cd186f44af7c424f78db53248 fix: [auto-task] Remediate current GitHub Actions failures [ORB-10948]
- 58fbddb9070a080f83c6b10a84ef7c948e69512e feat: Add Cursor Agent CLI as a first-class Orbit workflow executor [ORB-10945]
- a2b7781b840ff99ce7dc6b3304d96144ecaa570c feat: Add GitHub Copilot CLI as a first-class Orbit workflow executor [ORB-10946]
- a7e1614fb04f8a7e4db8b4720622fdd770d4ea35 fix: Fix Someday task filter chip resetting to the default status set [ORB-10942]
- e91455ce5fb7fd7d6b1bc184b0c8d2f043c411f9 fix: [auto-task] Remediate current GitHub Actions failures [ORB-10944]
- fc258dadfe617958b1d100b261cbb3bf2bcbae68 feat: Package Orbit as a Cursor-compatible Agent Plugin [ORB-10943]
- f91a3775d2897a0cd9124b3c7620457056305c29 auto-commit: 2026-08-20 21:45:22
- Referenced Orbit task IDs: ORB-10942, ORB-10943, ORB-10944, ORB-10945, ORB-10946, ORB-10948, ORB-10949, ORB-10950, ORB-10951, ORB-10952, ORB-10953, ORB-10955, ORB-10958, ORB-10959, ORB-10960, ORB-10961, ORB-10963, ORB-10964, ORB-10965, ORB-10966, ORB-10967, ORB-10968, ORB-10969, ORB-10970, ORB-10971, ORB-10972, ORB-10975, ORB-10976, ORB-10979, ORB-10980, ORB-10981, ORB-10982, ORB-10985, ORB-10986.
- Candidate semver bump under RELEASING.md pre-1.0 policy: 0.13.0 -> 0.14.0 (minor), because breaking-change candidates remain for human review.
- Breaking-change candidates (not human-confirmed):
  - ORB-10955 / b11685ca5ac2439437c77be38e0b2bb7005a26c1: fresh orbit init no longer seeds the legacy QA crew. RELEASING.md classifies seeded asset removal as breaking. Existing user-authored [crews.qa] configs remain load-compatible; the candidate is the removal of the seeded asset from fresh initialization.
  - ORB-10959 / 9ddd408ab7b5aaf03e6eaf07021fa3c1d0a97af2: v2 activities that grant proc.spawn without proc_allowed_programs are now rejected at asset-load/catalog validation and fail closed at runtime. RELEASING.md classifies activity/job load-time validation that rejects previously parseable input as breaking. The task records that all shipped/workspace-local activities already declare the field, but third-party/user-authored previously parseable activities remain a compatibility candidate.
- No other surveyed commit met the explicit RELEASING.md breaking categories on this read-only triage.

Version-bearing handoff selectors (all five): Cargo.toml, Cargo.lock, plugin/.claude-plugin/plugin.json, plugin/.codex-plugin/plugin.json, plugin/npm/package.json. Also update CHANGELOG.md per the release checklist only after human approval.

Acceptance:
- All five version-bearing files agree on the approved version, and the CHANGELOG section follows RELEASING.md.
- Every human-confirmed breaking change is documented under Breaking Changes; this task must not confirm or classify candidates on its own.
- Before the human-approved implementation phase, make no release-state or repository edits and point back to RELEASING.md for the full checklist.

### Acceptance Criteria

- Follow RELEASING.md and its release checklist; preserve the human approval boundary for tag, publish, promotion, and merge.
- Cargo.toml, Cargo.lock, plugin/.claude-plugin/plugin.json, plugin/.codex-plugin/plugin.json, plugin/plugin.json, and plugin/npm/package.json all agree on the approved version 0.14.0.
- Add the approved 0.14.0 CHANGELOG section using the release structure in RELEASING.md.
- Document both human-confirmed breaking changes under Breaking Changes: ORB-10955 (fresh init no longer seeds the legacy QA crew) and ORB-10959 (v2 proc.spawn activities without proc_allowed_programs are rejected/fail closed).
- Run the release-preparation validation required by RELEASING.md, including the repository release check and build; record exact results in execution_summary.
- The PR workflow may create its task commit, push its task branch, and open/update the PR. Do not tag, publish, promote, or merge without a separate explicit human approval.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Prepared the approved v0.14.0 release candidate without committing or performing any release-state action.
- Added the 0.14.0 CHANGELOG section with the human-confirmed breaking changes: fresh init no longer seeds legacy qa (ORB-10955), and v2 proc.spawn activities must declare proc_allowed_programs (ORB-10959).
- Bumped all six lockstep release version sources to 0.14.0: Cargo.toml, Cargo.lock, the Claude/Codex/Agent Plugin manifests, and plugin/npm/package.json. cargo update --workspace refreshed exactly the 16 Orbit workspace lock entries; no third-party dependency versions moved.
- Inspected scripts/smoke-plugin-install.sh. Its init/workspace-init/MCP/plugin flow needs no change: the new --mcp support is optional and does not alter the commands the smoke drives.

Assessment: Candidate is ready for the task PR pipeline. Per the approved plan and release guardrails, no commit, tag, push, publish, promotion, or merge was performed; those remain behind their respective human approvals.

Validation:
- cargo update --workspace: passed; 16 Orbit workspace packages updated 0.13.0 -> 0.14.0.
- make build: passed (cargo build --workspace, 46.20s).
- make ci-fast: passed.
- make ci-lint: passed (cargo clippy --workspace --all-targets -- -D warnings, 31.41s).
- scripts/check-changelog-style.sh, git diff --check, and a six-source version/lock consistency assertion: passed.
- make release-check: expected pre-tag non-zero (exit 2). Local Claude/Codex/Agent Plugin manifests and npm package agree on 0.14.0; gh release remains v0.13.0 as expected before tagging. npm was unavailable on PATH, so the registry portion was skipped. No unexpected local drift was reported.

Strategic decisions:
- Used RELEASING.md's six-file lockstep despite the older task text's inconsistent five-file wording.
- Left scripts/smoke-plugin-install.sh unchanged after inspection because no release-cycle contract it exercises changed.

Friction checkpoint: none filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10987-6a8a5c85`
- Behind base: 0
- Ahead of base: 1