### PR TITLE
[BLOCKED] Release integrity: smoke test must assert installed version matches the tag; require status checks on agent-main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,10 +104,10 @@ jobs:
 
   # [ORB-10010] Coverage visibility — informational, NOT a merge gate. This
   # job is intentionally excluded from any required-status-check wiring
-  # (agent-main's branch protection sets required_status_checks: null, see
-  # RELEASING.md §10c; keep it that way for this job if checks are ever made
-  # required). Per-crate coverage targets (goals, not gates) are documented in
-  # CONTRIBUTING.md "Testing & Coverage".
+  # (agent-main's branch protection requires the primary "Check / Clippy /
+  # Test" status check; this informational job is intentionally excluded from
+  # that gate, see RELEASING.md §10c). Per-crate coverage targets (goals, not
+  # gates) are documented in CONTRIBUTING.md "Testing & Coverage".
   coverage:
     name: Coverage (informational)
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-plugin-install.yml
+++ b/.github/workflows/smoke-plugin-install.yml
@@ -11,6 +11,11 @@ on:
     # release ever leaves the chain in a broken state.
     - cron: "0 12 * * 1"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Published release tag to verify (for example, v0.14.0)"
+        required: false
+        type: string
   push:
     tags:
       - "v*"
@@ -31,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -42,4 +49,6 @@ jobs:
 
       - name: Run plugin install smoke
         shell: bash
+        env:
+          SMOKE_PLUGIN_INSTALL_TAG: ${{ inputs.tag || '' }}
         run: ./scripts/smoke-plugin-install.sh

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -128,6 +128,18 @@ Must finish clean. `cargo update --workspace` should report only Orbit workspace
 
 If this cycle changed any CLI the plugin-install smoke drives (`orbit init`, `workspace init`, `mcp serve`, plugin layout), update [`scripts/smoke-plugin-install.sh`](scripts/smoke-plugin-install.sh) on the **same commit as the tag**. The on-tag workflow checks out that script and then runs `@orbit-tools/cli@latest` from npm — a post-tag script fix cannot green a tag-triggered run. Details and the post-npm triage live in [docs/runbooks/release.md](docs/runbooks/release.md#plugin-install-smoke-two-artifacts).
 
+The tag-triggered plugin-install smoke must be treated as a versioned check: it
+fails when the installed `@orbit-tools/cli` version does not equal the tag
+version. Publish the matching npm package, then re-run the workflow from
+Actions → `smoke-plugin-install` → **Run workflow**, entering the release tag
+(for example, `v0.14.0`) in the `tag` input. Confirm that this post-publish,
+versioned run is green before considering the install chain verified. The
+script's assertion can be checked without network access with:
+
+```sh
+./scripts/smoke-plugin-install.sh --dry-run-version-assertion
+```
+
 ### 6. Create the Orbit task
 
 ```
@@ -223,14 +235,31 @@ git push origin agent-main
 git push origin origin/main:refs/heads/agent-main
 cat <<'EOF' | gh api -X PUT repos/danieljhkim/orbit/branches/agent-main/protection --input -
 {
-  "required_status_checks": null,
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["Check / Clippy / Test"]
+  },
   "enforce_admins": false,
   "required_pull_request_reviews": null,
   "restrictions": null,
+  "required_linear_history": false,
+  "allow_force_pushes": true,
   "allow_deletions": false,
-  "allow_force_pushes": true
+  "block_creations": false,
+  "required_conversation_resolution": false,
+  "lock_branch": false,
+  "allow_fork_syncing": false
 }
 EOF
+```
+
+The applied `agent-main` protection must keep `strict: true` and require the
+primary CI check named exactly `Check / Clippy / Test`; coverage and platform
+diagnostic jobs remain informational. Verify the live setting after applying
+it with:
+
+```sh
+gh api repos/danieljhkim/orbit/branches/agent-main/protection/required_status_checks
 ```
 
 If a release ever ships without the back-merge, drift compounds (N commits behind `main` after N skipped releases). Recover by either running the same back-merge above (resolves cleanly regardless of N) or, if `agent-main` has no in-flight work, reset it to `main` directly:
@@ -259,7 +288,7 @@ Watch the Actions tab after pushing the tag. Real failure modes seen historicall
 - **`cargo build --locked` fails**: `Cargo.lock` was not refreshed after the version bump (step 4) — fix forward in the next patch.
 - **Homebrew tap step**: `secrets.TAP_GITHUB_TOKEN` expired, or the tap repo branch protection rejected the push.
 - **Smoke install** (`release.yml`): a regression in `install.sh` itself, since that smoke pulls it from the tagged ref. Verify locally before tagging if `install.sh` changed in this release.
-- **Plugin-install smoke** (separate workflow, `smoke-plugin-install.yml`): fails on the tag until npm is published (expected). After publish, a red run is either the tagged script speaking an old CLI contract, or a bad published artifact. Triage in [docs/runbooks/release.md](docs/runbooks/release.md#plugin-install-smoke-two-artifacts) — do not cut a patch for a script-only fix, and do not re-dispatch the old tag after the script has moved on.
+- **Plugin-install smoke** (separate workflow, `smoke-plugin-install.yml`): a tag run is expected to fail when npm does not yet contain the tag version. After publishing npm, manually dispatch the workflow with that tag in its `tag` input and require the versioned run to go green. A post-publish red run is either the tagged script speaking an old CLI contract, or a bad published artifact. Triage in [docs/runbooks/release.md](docs/runbooks/release.md#plugin-install-smoke-two-artifacts) — do not cut a patch for a script-only fix, and do not re-dispatch the old tag after the script has moved on.
 
 ## When something goes wrong
 

--- a/scripts/smoke-plugin-install.sh
+++ b/scripts/smoke-plugin-install.sh
@@ -19,6 +19,36 @@
 # Pass: exit 0. Fail: non-zero with the relevant stderr captured.
 # Supported: macOS arm64 / x86_64, Linux x86_64 / arm64. Not Windows.
 set -euo pipefail
+NPM_PKG="@orbit-tools/cli"
+
+assert_version_matches_tag() {
+  local installed_version="$1"
+  local expected_version="$2"
+
+  if [[ "$installed_version" != "$expected_version" ]]; then
+    echo "FAIL: installed $NPM_PKG version '$installed_version' does not match tag version '$expected_version'" >&2
+    return 1
+  fi
+  echo "versioned smoke => $NPM_PKG@$installed_version matches tag"
+}
+
+run_version_assertion_test() {
+  assert_version_matches_tag "0.14.0" "0.14.0"
+  if assert_version_matches_tag "0.13.0" "0.14.0"; then
+    echo "FAIL: version assertion accepted a mismatched version" >&2
+    return 1
+  fi
+  echo "PASS: version assertion rejects a mismatched tag version"
+}
+
+if [[ "${1:-}" == "--dry-run-version-assertion" ]]; then
+  run_version_assertion_test
+  exit 0
+fi
+if [[ "$#" -ne 0 ]]; then
+  echo "usage: $0 [--dry-run-version-assertion]" >&2
+  exit 2
+fi
 
 require_bin() {
   local bin="$1"
@@ -42,10 +72,24 @@ case "$(uname -s)" in
     ;;
 esac
 
-NPM_PKG="@orbit-tools/cli"
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 TMPDIR_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+# A tag-triggered run must prove that npm has the package built from that tag.
+# workflow_dispatch supplies SMOKE_PLUGIN_INSTALL_TAG when a releaser reruns
+# this workflow from the default branch against a published release tag.
+tag_name="${SMOKE_PLUGIN_INSTALL_TAG:-}"
+if [[ -z "$tag_name" && "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+  tag_name="${GITHUB_REF_NAME:-}"
+fi
+if [[ -z "$tag_name" && "${GITHUB_REF:-}" == refs/tags/* ]]; then
+  tag_name="${GITHUB_REF#refs/tags/}"
+fi
+expected_tag_version=""
+if [[ -n "$tag_name" ]]; then
+  expected_tag_version="${tag_name#v}"
+fi
 
 # Cache npx installs inside the temp dir so we exercise a clean download.
 export npm_config_cache="$TMPDIR_ROOT/npm-cache"
@@ -133,6 +177,9 @@ if [[ -z "$binary_version" ]]; then
   exit 1
 fi
 echo "orbit --version => $binary_version"
+if [[ -n "$expected_tag_version" ]]; then
+  assert_version_matches_tag "$binary_version" "$expected_tag_version"
+fi
 
 # Also confirm the npm-registry version, for the smoke report.
 npm_version="$(npm view "$NPM_PKG" version 2>/dev/null || echo '<unknown>')"


### PR DESCRIPTION
## Manual resolution required

Orbit preserved and pushed this task's pre-rebase candidate after the shipment pipeline stopped. This PR is intentionally blocked and must be reconciled manually before merge.

- Task: `ORB-10989`
- Run: `jrun-20260823-0400-6`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `9a0d2c8f9b66f35130c7fc79cbe9cd603ee444e6`
- Target base: `9a0d2c8f9b66f35130c7fc79cbe9cd603ee444e6`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: cli subprocess reported declared envelope status="failed" despite exit 0
```