### PR TITLE
Fix concurrent task-write failures: unlocked index reads, blocking calls in async handlers, lost-update window

### DIFF
--- a/crates/orbit-common/src/fs/io.rs
+++ b/crates/orbit-common/src/fs/io.rs
@@ -14,6 +14,8 @@
 //! module domain-free preserves the `types::` / `utility::` split inside
 //! `orbit-common`.
 
+use std::cell::RefCell;
+use std::collections::HashSet;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -247,9 +249,47 @@ pub fn write_text_with_parent(path: &Path, content: &str) -> io::Result<()> {
     fs::write(path, content)
 }
 
+thread_local! {
+    /// Lock files this thread currently holds, by lock-file path.
+    ///
+    /// ORB-10988: `flock(2)` is owned by the open file description, not by the
+    /// process or thread, so a nested `with_exclusive_file_lock` on the same
+    /// path opens a *second* descriptor and blocks against the outer one —
+    /// a self-deadlock, not a re-entry. Tracking held paths per thread makes
+    /// the helper re-entrant, which is what lets a caller hold a task lock
+    /// across a read-modify-write whose inner writes lock the same file.
+    static HELD_LOCK_PATHS: RefCell<HashSet<PathBuf>> = RefCell::new(HashSet::new());
+}
+
+/// Removes `path` from this thread's held set on drop, including on unwind.
+struct HeldLockPath(PathBuf);
+
+impl Drop for HeldLockPath {
+    fn drop(&mut self) {
+        HELD_LOCK_PATHS.with(|held| {
+            held.borrow_mut().remove(&self.0);
+        });
+    }
+}
+
+/// Registers `path` as held by this thread, or returns `None` when this thread
+/// already holds it (the caller then runs `op` under the outer lock).
+fn claim_lock_path(path: &Path) -> Option<HeldLockPath> {
+    HELD_LOCK_PATHS.with(|held| {
+        held.borrow_mut()
+            .insert(path.to_path_buf())
+            .then(|| HeldLockPath(path.to_path_buf()))
+    })
+}
+
 /// Run `op` while holding an exclusive advisory flock on a sibling lock
 /// file of `target_path` (`.<filename>.lock`). Creates the parent directory
 /// if missing. The lock is released when this function returns.
+///
+/// The lock is re-entrant per thread: a nested call for the same lock path
+/// runs `op` directly under the outermost acquisition instead of deadlocking
+/// on a second descriptor. Cross-thread and cross-process callers still block
+/// on the flock as before.
 ///
 /// The closure returns `Result<T, E>` where any filesystem error hit while
 /// acquiring the lock is folded into `E` via `From<std::io::Error>` —
@@ -269,9 +309,12 @@ where
             format!("cannot determine parent for '{}'", target_path.display()),
         )
     })?;
-    create_private_dir_all(parent).map_err(|e| classify_lock_io(parent, e))?;
 
-    let lock_path = lock_path_for(target_path)?;
+    let lock_path = resolved_lock_path(target_path)?;
+    let Some(_held) = claim_lock_path(&lock_path) else {
+        return op();
+    };
+    create_private_dir_all(parent).map_err(|e| classify_lock_io(parent, e))?;
     let mut options = OpenOptions::new();
     options.create(true).read(true).write(true).truncate(false);
     apply_private_file_mode(&mut options);
@@ -292,6 +335,26 @@ where
     })?;
 
     op()
+}
+
+/// The lock path to open and to key re-entrancy on, resolved through symlinks
+/// where the parent directory already exists.
+///
+/// Orbit reaches one task bundle by more than one route — the canonical store
+/// path and the checkout projection that links to it — so keying re-entrancy
+/// on the literal path would let a nested call miss its own outer lock and
+/// deadlock on a second descriptor to the same file. Resolving the parent
+/// collapses those routes to one key. An unresolvable parent means the
+/// directory does not exist yet, so nothing can be holding a lock inside it.
+fn resolved_lock_path(target_path: &Path) -> io::Result<PathBuf> {
+    let lock_path = lock_path_for(target_path)?;
+    let Some(file_name) = lock_path.file_name() else {
+        return Ok(lock_path);
+    };
+    match lock_path.parent().map(fs::canonicalize) {
+        Some(Ok(parent)) => Ok(parent.join(file_name)),
+        _ => Ok(lock_path),
+    }
 }
 
 fn lock_path_for(path: &Path) -> io::Result<PathBuf> {

--- a/crates/orbit-common/src/fs/tests/io.rs
+++ b/crates/orbit-common/src/fs/tests/io.rs
@@ -87,3 +87,82 @@ fn exclusive_lock_open_on_readonly_dir_names_path_and_hints_sandbox() {
         other => panic!("expected Io, got {other}"),
     }
 }
+
+/// ORB-10988: nesting the same lock path on one thread must re-enter, not
+/// deadlock. `flock(2)` belongs to the open file description, so the inner
+/// call's fresh descriptor would otherwise block on the outer call's lock
+/// forever. The runtime relies on this to hold a task lock across a
+/// read-modify-write whose inner store writes lock the same file.
+#[test]
+fn exclusive_lock_is_reentrant_within_a_thread() {
+    let temp = TempDir::new().expect("tempdir");
+    let target = temp.path().join("bundle").join("task.yaml");
+
+    let depth = with_exclusive_file_lock::<usize, io::Error, _>(&target, "outer", || {
+        with_exclusive_file_lock::<usize, io::Error, _>(&target, "inner", || {
+            with_exclusive_file_lock::<usize, io::Error, _>(&target, "innermost", || Ok(3))
+        })
+    })
+    .expect("nested locks must re-enter");
+
+    assert_eq!(depth, 3);
+}
+
+/// Re-entry must not leak the held-path bookkeeping: once the outer call
+/// returns — even by unwinding — the next acquisition has to lock for real, or
+/// a later caller would silently run unlocked.
+#[test]
+fn exclusive_lock_releases_reentrancy_bookkeeping_after_a_panic() {
+    let temp = TempDir::new().expect("tempdir");
+    let target = temp.path().join("bundle").join("task.yaml");
+
+    let panicked = std::panic::catch_unwind(|| {
+        let _ = with_exclusive_file_lock::<(), io::Error, _>(&target, "outer", || {
+            panic!("body blew up while holding the lock");
+        });
+    });
+    assert!(panicked.is_err(), "the panic must propagate");
+
+    // A different thread can only take the lock if the first release actually
+    // happened, and this thread can only re-lock if its held set was cleared.
+    let taken = std::thread::scope(|scope| {
+        scope
+            .spawn(|| {
+                with_exclusive_file_lock::<bool, io::Error, _>(&target, "other thread", || Ok(true))
+            })
+            .join()
+            .expect("thread joined")
+    })
+    .expect("lock after panic");
+    assert!(taken);
+    with_exclusive_file_lock::<(), io::Error, _>(&target, "same thread again", || Ok(()))
+        .expect("re-lock on the original thread");
+}
+
+/// Re-entrancy has to survive reaching the same lock file by a second route.
+/// Orbit's checkout projection links a workspace path at the canonical task
+/// bundle, so a nested lock arriving via the link must recognize the outer
+/// lock taken via the canonical path rather than deadlock on it.
+#[cfg(unix)]
+#[test]
+fn exclusive_lock_is_reentrant_across_a_symlinked_route() {
+    let temp = TempDir::new().expect("tempdir");
+    let canonical = temp.path().join("canonical");
+    std::fs::create_dir(&canonical).expect("mkdir");
+    let linked = temp.path().join("projection");
+    std::os::unix::fs::symlink(&canonical, &linked).expect("symlink");
+
+    let reached = with_exclusive_file_lock::<bool, io::Error, _>(
+        &canonical.join("task.yaml"),
+        "canonical route",
+        || {
+            with_exclusive_file_lock::<bool, io::Error, _>(
+                &linked.join("task.yaml"),
+                "projected route",
+                || Ok(true),
+            )
+        },
+    )
+    .expect("the projected route must re-enter the canonical lock");
+    assert!(reached);
+}

--- a/crates/orbit-core/src/application/task/tests/update.rs
+++ b/crates/orbit-core/src/application/task/tests/update.rs
@@ -246,3 +246,98 @@ fn drive_to_done(runtime: &OrbitRuntime, id: &str) -> Task {
         .expect("in-progress -> review with execution summary");
     update_status(runtime, id, TaskStatus::Done).expect("review -> done")
 }
+
+/// ORB-10988 / F2026-07-119: the update path must hold the task lock across
+/// its *whole* read-modify-write, not just around the store write.
+///
+/// The body reads the task, decides from that snapshot whether the mutation is
+/// even legal, and only then writes. When the lock covered the write alone, a
+/// concurrent update could commit a status change inside that gap: the second
+/// writer had already cleared the guard against a status it never saw, and its
+/// write landed on a task that had since become unmodifiable.
+///
+/// The other thread holds the bundle lock directly, so the window is opened
+/// deliberately rather than raced for.
+#[test]
+fn concurrent_update_cannot_write_through_a_status_change_it_never_saw() {
+    use std::sync::mpsc::sync_channel;
+    use std::time::Duration;
+
+    let (root, runtime) = test_runtime();
+    let task = add_proposed_task(&runtime, "Guard under contention");
+    let lock_target = task_bundle_dir(root.path(), &task.id).join("task.yaml");
+
+    let (locked_tx, locked_rx) = sync_channel::<()>(0);
+    let (contender_tx, contender_rx) = sync_channel::<()>(0);
+
+    // `move` on the holder closure captures only the channel endpoints; the
+    // runtime and paths cross as shared references, which are `Copy`.
+    let holder_runtime = &runtime;
+    let holder_lock_target = lock_target.as_path();
+    let holder_id = task.id.clone();
+    let contended = std::thread::scope(|scope| {
+        scope.spawn(move || {
+            orbit_common::fs::io::with_exclusive_file_lock::<(), orbit_common::OrbitError, _>(
+                holder_lock_target,
+                "ORB-10988 regression",
+                || {
+                    locked_tx.send(()).expect("announce the held lock");
+                    contender_rx.recv().expect("await the contending update");
+                    // Long enough that an update which reads before locking has
+                    // certainly taken its stale snapshot by now.
+                    std::thread::sleep(Duration::from_millis(250));
+                    holder_runtime
+                        .archive_task(&holder_id)
+                        .expect("archive under the lock");
+                    Ok(())
+                },
+            )
+            .expect("hold the task lock");
+        });
+
+        locked_rx.recv().expect("await the held lock");
+        contender_tx
+            .send(())
+            .expect("announce the contending update");
+        runtime.update_task(
+            &task.id,
+            TaskUpdateParams {
+                title: Some("renamed by the loser of the race".to_string()),
+                ..Default::default()
+            },
+        )
+    });
+
+    let err = contended.expect_err("an archived task must refuse a rename");
+    assert!(
+        err.to_string().contains("cannot be modified"),
+        "expected the archived-task guard, got: {err}"
+    );
+    let reread = runtime.get_task(&task.id).expect("task still readable");
+    assert_eq!(reread.status, TaskStatus::Archived);
+    assert_eq!(
+        reread.title, "Guard under contention",
+        "the losing writer must not have renamed an archived task"
+    );
+}
+
+/// Locate a task's bundle directory under a test runtime's roots. The store
+/// owns the layout; the test only needs *a* path to contend on.
+fn task_bundle_dir(root: &std::path::Path, id: &str) -> std::path::PathBuf {
+    fn walk(dir: &std::path::Path, id: &str) -> Option<std::path::PathBuf> {
+        for entry in std::fs::read_dir(dir).ok()?.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            if path.file_name().is_some_and(|name| name == id) && path.join("task.yaml").is_file() {
+                return Some(path);
+            }
+            if let Some(found) = walk(&path, id) {
+                return Some(found);
+            }
+        }
+        None
+    }
+    walk(root, id).unwrap_or_else(|| panic!("no bundle directory for {id} under {root:?}"))
+}

--- a/crates/orbit-core/src/application/task/update.rs
+++ b/crates/orbit-core/src/application/task/update.rs
@@ -64,7 +64,49 @@ impl OrbitRuntime {
         )
     }
 
+    /// Apply an update, holding the task's write lock across the whole
+    /// read-modify-write.
+    ///
+    /// ORB-10988: the body below reads the task, derives history entries and
+    /// status-transition validity from that snapshot, and only then writes. The
+    /// store locks each write, but not the read that decided it — so two
+    /// concurrent updates to the same task each validated against the same
+    /// pre-state and the later write silently discarded the earlier one. The
+    /// lock is re-entrant per thread, so the store's own per-write locking
+    /// still holds underneath this one.
     fn update_task_with_status_note_and_identity(
+        &self,
+        id: &str,
+        params: TaskUpdateParams,
+        status_note: Option<String>,
+        agent: Option<String>,
+        model: Option<String>,
+    ) -> Result<Task, OrbitError> {
+        // The lock hook takes `FnMut` because it is a trait object, but the
+        // body must run exactly once and consumes its inputs; `take()` makes
+        // both facts explicit rather than forcing the params to be cloneable.
+        let mut inputs = Some((params, status_note, agent, model));
+        let mut updated: Option<Task> = None;
+        self.stores().tasks().with_task_write_lock(id, &mut || {
+            let (params, status_note, agent, model) = inputs.take().ok_or_else(|| {
+                OrbitError::Execution("task update body was invoked more than once".to_string())
+            })?;
+            updated = Some(self.update_task_locked(id, params, status_note, agent, model)?);
+            Ok(())
+        })?;
+        let updated = updated.ok_or_else(|| {
+            OrbitError::Execution("task update body did not run under the task lock".to_string())
+        })?;
+
+        // Cascading friction/task resolution touches *other* records, so it
+        // stays outside this task's lock.
+        if updated.status == TaskStatus::Done {
+            self.record_resolves_side_effects(&updated)?;
+        }
+        Ok(updated)
+    }
+
+    fn update_task_locked(
         &self,
         id: &str,
         mut params: TaskUpdateParams,
@@ -239,9 +281,6 @@ impl OrbitRuntime {
             };
             Ok((task.clone(), event))
         })?;
-        if updated.status == TaskStatus::Done {
-            self.record_resolves_side_effects(&updated)?;
-        }
 
         Ok(updated)
     }

--- a/crates/orbit-store/src/contracts/traits.rs
+++ b/crates/orbit-store/src/contracts/traits.rs
@@ -76,6 +76,23 @@ pub trait TaskStoreBackend: Send + Sync {
     }
     fn delete_task(&self, id: &str) -> Result<bool, OrbitError>;
 
+    /// Run `op` while holding this task's write lock.
+    ///
+    /// A caller that reads a task, decides something from that snapshot, and
+    /// then writes needs the read and the write to be one critical section;
+    /// locking only the write lets a concurrent update land in between and be
+    /// overwritten (ORB-10988). The lock is re-entrant within a thread, so the
+    /// per-write locking the backend already does still applies underneath.
+    ///
+    /// The default is a no-op passthrough for backends with no per-task lock.
+    fn with_task_write_lock(
+        &self,
+        _id: &str,
+        op: &mut dyn FnMut() -> Result<(), OrbitError>,
+    ) -> Result<(), OrbitError> {
+        op()
+    }
+
     /// Status counts per complexity bucket from the generated task index.
     /// Default is empty; the v2 store answers from SQLite without bundle reads.
     fn task_completion_by_complexity(&self) -> Result<Vec<TaskCompletionByComplexity>, OrbitError> {

--- a/crates/orbit-store/src/driver/file/task_bundle/bundle_io/mod.rs
+++ b/crates/orbit-store/src/driver/file/task_bundle/bundle_io/mod.rs
@@ -191,10 +191,32 @@ pub(crate) fn read_bundle_at(bundle_dir: &Path) -> Result<TaskBundleV2, OrbitErr
     })
 }
 
-fn read_bundle_for_id(
+/// Read only a bundle's envelope.
+///
+/// The envelope carries every field the generated task index projects, so
+/// index validation reads this instead of assembling the whole bundle — one
+/// small YAML file per task rather than the bundle's seven.
+pub(crate) fn read_envelope_at(bundle_dir: &Path) -> Result<TaskEnvelopeV2, OrbitError> {
+    let expected_task_id = task_id_from_bundle_dir(bundle_dir)?;
+    read_envelope_for_id(bundle_dir, &expected_task_id).map_err(|error| match error {
+        OrbitError::NotFound {
+            kind: NotFoundKind::Task,
+            ..
+        }
+        | OrbitError::TaskBundleCorrupt { .. }
+        | OrbitError::Io(_) => error,
+        other => OrbitError::TaskBundleCorrupt {
+            task_id: expected_task_id,
+            path: bundle_dir.to_string_lossy().into_owned(),
+            reason: other.to_string(),
+        },
+    })
+}
+
+fn read_envelope_for_id(
     bundle_dir: &Path,
     expected_task_id: &str,
-) -> Result<TaskBundleV2, OrbitError> {
+) -> Result<TaskEnvelopeV2, OrbitError> {
     let envelope_path = bundle_dir.join(TASK_ENVELOPE_FILE_NAME);
     if !envelope_path.is_file() {
         return Err(OrbitError::not_found(
@@ -212,9 +234,15 @@ fn read_bundle_for_id(
             envelope.id
         )));
     }
+    Ok(envelope)
+}
 
+fn read_bundle_for_id(
+    bundle_dir: &Path,
+    expected_task_id: &str,
+) -> Result<TaskBundleV2, OrbitError> {
     let bundle = TaskBundleV2 {
-        envelope,
+        envelope: read_envelope_for_id(bundle_dir, expected_task_id)?,
         description: read_required_text(&bundle_dir.join(TASK_DESCRIPTION_FILE_NAME))?,
         acceptance: read_required_text(&bundle_dir.join(TASK_ACCEPTANCE_FILE_NAME))?,
         plan: read_required_text(&bundle_dir.join(TASK_PLAN_FILE_NAME))?,

--- a/crates/orbit-store/src/driver/file/task_bundle/mod.rs
+++ b/crates/orbit-store/src/driver/file/task_bundle/mod.rs
@@ -8,8 +8,8 @@ mod migrations;
 mod types;
 
 pub(crate) use bundle_io::{
-    append_jsonl_row, cleanup_partial_bundle_best_effort, read_bundle_at, write_bundle_at,
-    write_bundle_with_artifacts_at,
+    append_jsonl_row, cleanup_partial_bundle_best_effort, read_bundle_at, read_envelope_at,
+    write_bundle_at, write_bundle_with_artifacts_at,
 };
 pub(crate) use lock::{remove_task_bundle_lock_sentinel, task_bundle_lock_sentinel_path};
 pub(crate) use types::{TaskBundleV2, TaskDocumentV2};

--- a/crates/orbit-store/src/repository/file_backends.rs
+++ b/crates/orbit-store/src/repository/file_backends.rs
@@ -70,6 +70,14 @@ impl TaskStoreBackend for TaskV2Store {
         self.delete_task(id)
     }
 
+    fn with_task_write_lock(
+        &self,
+        id: &str,
+        op: &mut dyn FnMut() -> Result<(), OrbitError>,
+    ) -> Result<(), OrbitError> {
+        self.with_task_lock(id, op)
+    }
+
     fn task_completion_by_complexity(
         &self,
     ) -> Result<Vec<crate::contracts::TaskCompletionByComplexity>, OrbitError> {

--- a/crates/orbit-store/src/repository/task/v2/index.rs
+++ b/crates/orbit-store/src/repository/task/v2/index.rs
@@ -49,6 +49,15 @@ impl TaskV2Store {
         self.tasks_from_ids(ids).map(Some)
     }
 
+    /// Decide whether the generated index still matches the bundles on disk.
+    ///
+    /// Two properties matter under concurrency (ORB-10988 / F2026-07-119).
+    /// First, this compares envelopes, not whole bundles: the index only
+    /// projects envelope fields, so assembling every task's seven-file bundle
+    /// on every list was pure cost. Second, a task whose bundle a concurrent
+    /// writer currently holds is *skipped* rather than propagated as an error —
+    /// validating the index for task B must not fail because task A is being
+    /// created or deleted at that instant.
     fn index_is_usable(&self) -> Result<bool, OrbitError> {
         let registered = self.registry.tasks_for_workspace(&self.workspace_id)?;
         let indexed = self
@@ -62,24 +71,32 @@ impl TaskV2Store {
             let Some(indexed_updated_at) = indexed.get(&binding.task_id) else {
                 return self.rebuild_index_best_effort("missing index row");
             };
-            let bundle = self.read_existing_bundle(&binding.task_id)?;
-            if bundle.envelope.updated_at.to_rfc3339() != *indexed_updated_at {
+            let Some(envelope) = self
+                .bundle_store
+                .read_envelope_if_settled(&binding.task_id)?
+            else {
+                continue;
+            };
+            if envelope.updated_at.to_rfc3339() != *indexed_updated_at {
                 return self.rebuild_index_best_effort("stale index row");
             }
         }
         Ok(true)
     }
 
+    /// Rebuild the generated index from the bundles, degrading to `false` (use
+    /// the bundle scan instead) on any failure. Every caller reaches this from
+    /// a *read*, so a rebuild that cannot run must not fail that read.
     fn rebuild_index_best_effort(&self, reason: &str) -> Result<bool, OrbitError> {
-        let bundles = self.bundle_store.list_bundles()?;
-        let envelopes = bundles
-            .into_iter()
-            .map(|bundle| bundle.envelope)
-            .collect::<Vec<_>>();
-        match self
-            .registry
-            .replace_workspace_task_indexes(&self.workspace_id, &envelopes)
-        {
+        let rebuilt = self.bundle_store.list_bundles().and_then(|bundles| {
+            let envelopes = bundles
+                .into_iter()
+                .map(|bundle| bundle.envelope)
+                .collect::<Vec<_>>();
+            self.registry
+                .replace_workspace_task_indexes(&self.workspace_id, &envelopes)
+        });
+        match rebuilt {
             Ok(()) => Ok(true),
             Err(err) => {
                 orbit_common::tracing::warn!(
@@ -94,13 +111,19 @@ impl TaskV2Store {
         }
     }
 
+    /// Materialize indexed ids into tasks, dropping any whose bundle a
+    /// concurrent writer is publishing or removing. An id that disappears
+    /// between the index query and the bundle read is a task that was deleted,
+    /// not a listing failure.
     fn tasks_from_ids(&self, ids: Vec<String>) -> Result<Vec<Task>, OrbitError> {
-        ids.into_iter()
-            .map(|id| {
-                let bundle = self.read_existing_bundle(&id)?;
-                self.task_from_bundle(bundle)
-            })
-            .collect()
+        let mut tasks = Vec::with_capacity(ids.len());
+        for id in ids {
+            let Some(bundle) = self.bundle_store.read_bundle_if_settled(&id)? else {
+                continue;
+            };
+            tasks.push(self.task_from_bundle(bundle)?);
+        }
+        Ok(tasks)
     }
 
     pub(super) fn replace_index_best_effort(&self, envelope: &TaskEnvelopeV2, operation: &str) {
@@ -158,7 +181,7 @@ impl TaskV2Store {
         })
     }
 
-    pub(super) fn with_task_lock<T, F>(&self, id: &str, op: F) -> Result<T, OrbitError>
+    pub(crate) fn with_task_lock<T, F>(&self, id: &str, op: F) -> Result<T, OrbitError>
     where
         F: FnOnce() -> Result<T, OrbitError>,
     {

--- a/crates/orbit-store/src/repository/task/v2/tests/concurrency.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/concurrency.rs
@@ -1,0 +1,224 @@
+//! ORB-10988 / F2026-07-119: a write to one task must never fail a read or a
+//! write of another.
+//!
+//! The registry binding list is a snapshot and a bundle is a directory, so an
+//! unrelated create or delete is observable to a reader as a bundle that is
+//! missing or half there. These tests pin both halves of the rule: transient
+//! states are skipped, genuine corruption still fails fast.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use super::*;
+use crate::driver::file::task_bundle::task_bundle_lock_sentinel_path;
+
+fn create_tasks(store: &TaskV2Store, count: usize) -> Vec<String> {
+    (0..count)
+        .map(|index| {
+            store
+                .create_task(create_params(&format!("Task {index}"), TaskStatus::Backlog))
+                .expect("create task")
+                .id
+        })
+        .collect()
+}
+
+fn document_update(actor: &str, summary: &str) -> TaskDocumentUpdateParams {
+    TaskDocumentUpdateParams {
+        actor: actor.to_string(),
+        execution_summary: Some(summary.to_string()),
+        ..Default::default()
+    }
+}
+
+/// A bundle removed between the registry snapshot and the read — the window
+/// `delete_bundle` opens by unregistering and unlinking as two steps — used to
+/// fail the whole listing. It must now cost only that one task.
+#[test]
+fn listing_survives_a_bundle_removed_under_a_live_registry_binding() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let ids = create_tasks(&store, 3);
+
+    let vanished = store
+        .bundle_store
+        .bundle_path(&ids[1])
+        .expect("bundle path");
+    std::fs::remove_dir_all(&vanished).expect("remove bundle out of band");
+
+    let listed: Vec<String> = store
+        .list_tasks()
+        .expect("an unrelated task's removal must not fail the listing")
+        .into_iter()
+        .map(|task| task.id)
+        .collect();
+    assert_eq!(listed.len(), 2, "listed: {listed:?}");
+    assert!(!listed.contains(&ids[1]), "listed: {listed:?}");
+    assert!(listed.contains(&ids[0]) && listed.contains(&ids[2]));
+
+    assert_eq!(
+        store
+            .bundle_store
+            .list_bundles()
+            .expect("list bundles")
+            .len(),
+        2
+    );
+}
+
+/// An incomplete bundle whose create/delete lock sentinel is present is a
+/// writer's work in progress, not damage: skip it and serve every other task.
+#[test]
+fn listing_skips_an_incomplete_bundle_held_by_the_lock_sentinel() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let ids = create_tasks(&store, 2);
+
+    let in_flight = store
+        .bundle_store
+        .bundle_path(&ids[0])
+        .expect("bundle path");
+    let sentinel = task_bundle_lock_sentinel_path(&in_flight).expect("sentinel path");
+    std::fs::write(&sentinel, b"").expect("hold the sentinel");
+    std::fs::remove_file(in_flight.join("description.md")).expect("truncate publication");
+
+    let listed: Vec<String> = store
+        .list_tasks()
+        .expect("an in-flight bundle must not fail the listing")
+        .into_iter()
+        .map(|task| task.id)
+        .collect();
+    assert_eq!(listed, vec![ids[1].clone()]);
+}
+
+/// The tolerance is narrow on purpose: a bundle that is neither held by a
+/// writer nor gone is damaged, and damage must still surface loudly rather
+/// than quietly shrinking every listing.
+#[test]
+fn listing_still_fails_fast_on_a_settled_corrupt_bundle() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let ids = create_tasks(&store, 2);
+
+    let corrupt = store
+        .bundle_store
+        .bundle_path(&ids[0])
+        .expect("bundle path");
+    std::fs::remove_file(corrupt.join("description.md")).expect("damage bundle");
+
+    let err = store
+        .list_tasks()
+        .expect_err("a settled, damaged bundle must not be silently skipped");
+    assert!(
+        matches!(err, OrbitError::TaskBundleCorrupt { ref task_id, .. } if *task_id == ids[0]),
+        "expected corruption for {}, got {err}",
+        ids[0]
+    );
+}
+
+/// The reported failure shape: parallel writes to *distinct* tasks racing the
+/// index validation and rebuild that every listing performs. Serially these
+/// same calls always succeeded; concurrently they transiently failed.
+#[test]
+fn parallel_updates_to_distinct_tasks_never_fail_a_concurrent_listing() {
+    const TASKS: usize = 8;
+    const ROUNDS: usize = 12;
+
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let ids = create_tasks(&store, TASKS);
+    let listings = AtomicUsize::new(0);
+
+    std::thread::scope(|scope| {
+        for (index, id) in ids.iter().enumerate() {
+            let store = &store;
+            scope.spawn(move || {
+                for round in 0..ROUNDS {
+                    store
+                        .update_task_document(
+                            id,
+                            &document_update("codex:gpt-5.5", &format!("writer {index} @{round}")),
+                        )
+                        .unwrap_or_else(|err| {
+                            panic!("update of {id} failed under concurrency: {err}")
+                        });
+                }
+            });
+        }
+        for _ in 0..4 {
+            let store = &store;
+            let listings = &listings;
+            scope.spawn(move || {
+                for _ in 0..(ROUNDS * TASKS) {
+                    let tasks = store
+                        .list_tasks()
+                        .unwrap_or_else(|err| panic!("listing failed under concurrency: {err}"));
+                    assert_eq!(tasks.len(), TASKS, "no task may drop out of a listing");
+                    listings.fetch_add(1, Ordering::Relaxed);
+                }
+            });
+        }
+    });
+
+    assert!(listings.load(Ordering::Relaxed) > 0);
+    for (index, id) in ids.iter().enumerate() {
+        let task = store.get_task(id).expect("get task").expect("task exists");
+        assert_eq!(
+            task.execution_summary,
+            format!("writer {index} @{}", ROUNDS - 1),
+            "every writer's last write must be durable"
+        );
+    }
+}
+
+/// Same-task concurrency: the per-task lock must serialize whole updates, so
+/// every appended comment survives instead of racing writers overwriting each
+/// other's view of the comment sequence.
+#[test]
+fn parallel_updates_to_one_task_keep_every_appended_comment() {
+    const WRITERS: usize = 6;
+    const COMMENTS_PER_WRITER: usize = 5;
+
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let id = create_tasks(&store, 1).remove(0);
+    let created_comments = store
+        .get_task_comments(&id)
+        .expect("get comments")
+        .expect("task exists")
+        .len();
+
+    std::thread::scope(|scope| {
+        for writer in 0..WRITERS {
+            let store = &store;
+            let id = &id;
+            scope.spawn(move || {
+                for round in 0..COMMENTS_PER_WRITER {
+                    store
+                        .update_task_history(
+                            id,
+                            &TaskHistoryUpdateParams {
+                                actor: "codex:gpt-5.5".to_string(),
+                                append_comments: vec![TaskComment {
+                                    at: Utc::now(),
+                                    by: format!("writer-{writer}"),
+                                    message: format!("writer {writer} comment {round}"),
+                                }],
+                                ..Default::default()
+                            },
+                        )
+                        .unwrap_or_else(|err| panic!("history update failed: {err}"));
+                }
+            });
+        }
+    });
+
+    let comments = store
+        .get_task_comments(&id)
+        .expect("get comments")
+        .expect("task exists");
+    assert_eq!(
+        comments.len(),
+        created_comments + WRITERS * COMMENTS_PER_WRITER,
+        "no concurrent comment may be lost"
+    );
+}

--- a/crates/orbit-store/src/repository/task/v2/tests/mod.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/mod.rs
@@ -124,5 +124,6 @@ pub(super) fn assert_sandbox_write_io(err: &OrbitError, path_substr: &str) {
     }
 }
 
+mod concurrency;
 mod crud;
 mod update;

--- a/crates/orbit-store/src/repository/task/v2_bundle.rs
+++ b/crates/orbit-store/src/repository/task/v2_bundle.rs
@@ -16,7 +16,8 @@ use orbit_types::task::{
 
 pub(crate) use crate::driver::file::task_bundle::{TaskBundleV2, TaskDocumentV2};
 use crate::driver::file::task_bundle::{
-    append_jsonl_row, cleanup_partial_bundle_best_effort, read_bundle_at, write_bundle_at,
+    append_jsonl_row, cleanup_partial_bundle_best_effort, read_bundle_at, read_envelope_at,
+    write_bundle_at,
 };
 use crate::driver::file::task_bundle::{
     remove_task_bundle_lock_sentinel, task_bundle_lock_sentinel_path,
@@ -211,14 +212,44 @@ impl TaskBundleStoreV2 {
 
     /// List bundles registered to this workspace.
     ///
-    /// This is intentionally fail-fast for now: one corrupt registered bundle
-    /// makes the list fail so early wiring does not silently hide store damage.
+    /// Corruption is still fail-fast — one damaged bundle fails the list so
+    /// store damage is never silently hidden. What is *not* fail-fast is a
+    /// bundle caught mid-publication or mid-removal by a concurrent writer
+    /// (ORB-10988 / F2026-07-119): the binding list is a snapshot, so a create
+    /// or delete of one task would otherwise fail every read of every other
+    /// task. Those bundles are skipped, exactly as they would be had the
+    /// snapshot been taken a moment earlier or later.
     pub(crate) fn list_bundles(&self) -> Result<Vec<TaskBundleV2>, OrbitError> {
         let bindings = self.registry.tasks_for_workspace(&self.workspace_id)?;
-        bindings
-            .iter()
-            .map(|binding| read_bundle_at(&binding.canonical_path))
-            .collect()
+        let mut bundles = Vec::with_capacity(bindings.len());
+        for binding in &bindings {
+            if let Some(bundle) = read_bundle_tolerating_in_flight(&binding.canonical_path)? {
+                bundles.push(bundle);
+            }
+        }
+        Ok(bundles)
+    }
+
+    /// Read one registered bundle, skipping it when a concurrent writer has it
+    /// in flight. See [`Self::list_bundles`] for the tolerance rule.
+    pub(crate) fn read_bundle_if_settled(
+        &self,
+        task_id: &str,
+    ) -> Result<Option<TaskBundleV2>, OrbitError> {
+        read_bundle_tolerating_in_flight(&self.bundle_path(task_id)?)
+    }
+
+    /// Read one registered bundle's envelope, skipping it when a concurrent
+    /// writer has it in flight. See [`Self::list_bundles`] for the rule.
+    pub(crate) fn read_envelope_if_settled(
+        &self,
+        task_id: &str,
+    ) -> Result<Option<TaskEnvelopeV2>, OrbitError> {
+        let bundle_dir = self.bundle_path(task_id)?;
+        match read_envelope_at(&bundle_dir) {
+            Ok(envelope) => Ok(Some(envelope)),
+            Err(err) => skip_if_in_flight(&bundle_dir, err),
+        }
     }
 
     pub(crate) fn rewrite_document(
@@ -289,4 +320,42 @@ impl TaskBundleStoreV2 {
             comment,
         )
     }
+}
+
+fn read_bundle_tolerating_in_flight(bundle_dir: &Path) -> Result<Option<TaskBundleV2>, OrbitError> {
+    match read_bundle_at(bundle_dir) {
+        Ok(bundle) => Ok(Some(bundle)),
+        Err(err) => skip_if_in_flight(bundle_dir, err),
+    }
+}
+
+/// Convert a failed bundle read into `Ok(None)` when the bundle is provably
+/// mid-flight rather than damaged, and re-raise it otherwise.
+///
+/// Both discriminators are re-checked *after* the read failed, so a bundle
+/// that read cleanly is never suppressed:
+///
+/// - the create/delete lock sentinel is present, meaning another writer holds
+///   the bundle directory right now (or left the sentinel behind by deleting
+///   the task, in which case there is no bundle to read anyway); or
+/// - the bundle directory is gone, meaning the delete completed between the
+///   registry snapshot and the read.
+fn skip_if_in_flight<T>(bundle_dir: &Path, err: OrbitError) -> Result<Option<T>, OrbitError> {
+    if !bundle_read_failure_is_in_flight(bundle_dir) {
+        return Err(err);
+    }
+    orbit_common::tracing::debug!(
+        target: "orbit.store.task_bundle_v2",
+        bundle_dir = %bundle_dir.display(),
+        error = %err,
+        "skipped a task bundle held by a concurrent writer",
+    );
+    Ok(None)
+}
+
+fn bundle_read_failure_is_in_flight(bundle_dir: &Path) -> bool {
+    if task_bundle_lock_sentinel_path(bundle_dir).is_ok_and(|path| path.exists()) {
+        return true;
+    }
+    !bundle_dir.is_dir()
 }

--- a/crates/orbit-web/src/api/mod.rs
+++ b/crates/orbit-web/src/api/mod.rs
@@ -346,6 +346,28 @@ pub(super) fn server_error(e: orbit_core::OrbitError) -> Response {
         .into_response()
 }
 
+/// Run a blocking runtime call on the blocking pool instead of the async
+/// worker that is serving the request.
+///
+/// Every `OrbitRuntime` task mutation descends into an exclusive `flock` with
+/// no timeout. Calling one straight from a handler parks a tokio worker for
+/// the whole wait, so a burst of concurrent writes parks every worker and the
+/// server stops answering — the `ReadTimeout`-then-`ConnectError` shape of
+/// F2026-07-119. `label` names the operation in the panic-propagation error.
+pub(super) async fn blocking<T, F>(label: &str, op: F) -> Result<T, Response>
+where
+    F: FnOnce() -> Result<T, orbit_core::OrbitError> + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::task::spawn_blocking(op).await {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(e)) => Err(map_runtime_error(e)),
+        Err(join_err) => Err(server_error(orbit_core::OrbitError::Execution(format!(
+            "{label} panicked: {join_err}"
+        )))),
+    }
+}
+
 /// Browser-CSRF mitigation only — NOT an access-control boundary.
 ///
 /// This rejects cross-origin state-changing requests originating from a

--- a/crates/orbit-web/src/api/tasks.rs
+++ b/crates/orbit-web/src/api/tasks.rs
@@ -1,5 +1,7 @@
 //! Task CRUD and lifecycle handlers.
 
+use std::sync::Arc;
+
 use crate::state::Ws;
 use axum::body::Body;
 use axum::extract::{Path, RawQuery};
@@ -18,13 +20,57 @@ use orbit_types::task::validate_relative_artifact_path;
 use serde::{Deserialize, Deserializer};
 use serde_json::{Map, Value, json};
 
-use super::{bad_request, map_runtime_error, non_empty_string, server_error, validate_id};
+use super::{
+    bad_request, blocking, map_runtime_error, non_empty_string, server_error, validate_id,
+};
 use crate::projections::{task_locks_json, task_to_json_with_sidecars};
 
 /// Actor recorded for a dashboard-authored comment when the request supplies no
 /// usable human identity. The dashboard is a human-operated surface, so this is
 /// the floor — never the server process's ambient agent identity.
 const HUMAN_ACTOR_LABEL: &str = "human";
+
+/// Which half of [`task_mutation_response`] failed, so each keeps the status
+/// mapping it had when these handlers were written inline: a refused mutation
+/// is the caller's problem, a failed render is the server's.
+enum TaskMutationFailure {
+    Mutation(orbit_core::OrbitError),
+    Render(orbit_core::OrbitError),
+}
+
+/// Apply a task mutation and render its response payload, both on the blocking
+/// pool rather than on the tokio worker serving the request.
+///
+/// ORB-10988 / F2026-07-119: every mutation here descends into an exclusive,
+/// timeout-free `flock` on the task bundle, and the reads that build the
+/// response body hit the store too. Called inline, a burst of dashboard writes
+/// parks one async worker per request until the whole pool is blocked and the
+/// server stops accepting connections; moved here, the burst queues on the
+/// blocking pool and the async workers keep serving.
+async fn task_mutation_response<F>(
+    runtime: Arc<OrbitRuntime>,
+    label: &'static str,
+    mutate: F,
+) -> Response
+where
+    F: FnOnce(&OrbitRuntime) -> Result<Task, orbit_core::OrbitError> + Send + 'static,
+{
+    let rendered = tokio::task::spawn_blocking(move || {
+        let task = mutate(&runtime).map_err(TaskMutationFailure::Mutation)?;
+        let status_by_id = dashboard_status_index(&runtime).map_err(TaskMutationFailure::Render)?;
+        task_to_json_with_sidecars(&runtime, &task, &status_by_id)
+            .map_err(TaskMutationFailure::Render)
+    })
+    .await;
+    match rendered {
+        Ok(Ok(value)) => Json(value).into_response(),
+        Ok(Err(TaskMutationFailure::Mutation(e))) => map_runtime_error(e),
+        Ok(Err(TaskMutationFailure::Render(e))) => server_error(e),
+        Err(join_err) => server_error(orbit_core::OrbitError::Execution(format!(
+            "{label} panicked: {join_err}"
+        ))),
+    }
+}
 
 struct ArtifactResponsePolicy {
     content_type: &'static str,
@@ -627,16 +673,10 @@ pub(super) async fn create_task_action(
         crew: body.crew,
         orchestrator: body.orchestrator,
     };
-    match runtime.add_task_with_identity(params, None, model) {
-        Ok(task) => match dashboard_status_index(&runtime) {
-            Ok(status_by_id) => match task_to_json_with_sidecars(&runtime, &task, &status_by_id) {
-                Ok(value) => Json(value).into_response(),
-                Err(e) => server_error(e),
-            },
-            Err(e) => server_error(e),
-        },
-        Err(e) => map_runtime_error(e),
-    }
+    task_mutation_response(runtime, "task creation", move |runtime| {
+        runtime.add_task_with_identity(params, None, model)
+    })
+    .await
 }
 
 /// `PATCH /tasks/:id` — apply a partial update to a task.
@@ -686,16 +726,11 @@ pub(super) async fn update_task_action(
         context_files: body.context_files,
         upsert_artifacts: Vec::new(),
     };
-    match runtime.update_task_with_identity(id, params, None, model) {
-        Ok(task) => match dashboard_status_index(&runtime) {
-            Ok(status_by_id) => match task_to_json_with_sidecars(&runtime, &task, &status_by_id) {
-                Ok(value) => Json(value).into_response(),
-                Err(e) => server_error(e),
-            },
-            Err(e) => server_error(e),
-        },
-        Err(e) => map_runtime_error(e),
-    }
+    let id = id.to_string();
+    task_mutation_response(runtime, "task update", move |runtime| {
+        runtime.update_task_with_identity(&id, params, None, model)
+    })
+    .await
 }
 
 /// `POST /tasks/:id/comments` — append a human comment to a task.
@@ -726,16 +761,11 @@ pub(super) async fn add_task_comment_action(
         comment: Some(message),
         ..TaskUpdateParams::default()
     };
-    match runtime.update_task_with_identity(id, params, Some(author), None) {
-        Ok(task) => match dashboard_status_index(&runtime) {
-            Ok(status_by_id) => match task_to_json_with_sidecars(&runtime, &task, &status_by_id) {
-                Ok(value) => Json(value).into_response(),
-                Err(e) => server_error(e),
-            },
-            Err(e) => server_error(e),
-        },
-        Err(e) => map_runtime_error(e),
-    }
+    let id = id.to_string();
+    task_mutation_response(runtime, "task comment", move |runtime| {
+        runtime.update_task_with_identity(&id, params, Some(author), None)
+    })
+    .await
 }
 
 /// Resolve the author label recorded for a dashboard comment.
@@ -772,16 +802,11 @@ pub(super) async fn approve_task_action(
         Err(message) => return bad_request(message),
     };
     let body = body.map(|Json(b)| b).unwrap_or_default();
-    match runtime.approve_task(id, body.note, body.comment) {
-        Ok(task) => match dashboard_status_index(&runtime) {
-            Ok(status_by_id) => match task_to_json_with_sidecars(&runtime, &task, &status_by_id) {
-                Ok(value) => Json(value).into_response(),
-                Err(e) => server_error(e),
-            },
-            Err(e) => server_error(e),
-        },
-        Err(e) => map_runtime_error(e),
-    }
+    let id = id.to_string();
+    task_mutation_response(runtime, "task approval", move |runtime| {
+        runtime.approve_task(&id, body.note, body.comment)
+    })
+    .await
 }
 
 pub(super) async fn reject_task_action(
@@ -793,16 +818,11 @@ pub(super) async fn reject_task_action(
         Ok(id) => id,
         Err(message) => return bad_request(message),
     };
-    match runtime.reject_task(id, body.note, body.comment) {
-        Ok(task) => match dashboard_status_index(&runtime) {
-            Ok(status_by_id) => match task_to_json_with_sidecars(&runtime, &task, &status_by_id) {
-                Ok(value) => Json(value).into_response(),
-                Err(e) => server_error(e),
-            },
-            Err(e) => server_error(e),
-        },
-        Err(e) => map_runtime_error(e),
-    }
+    let id = id.to_string();
+    task_mutation_response(runtime, "task rejection", move |runtime| {
+        runtime.reject_task(&id, body.note, body.comment)
+    })
+    .await
 }
 
 pub(super) async fn archive_task_action(Ws(runtime): Ws, Path(id): Path<String>) -> Response {
@@ -810,9 +830,15 @@ pub(super) async fn archive_task_action(Ws(runtime): Ws, Path(id): Path<String>)
         Ok(id) => id,
         Err(message) => return bad_request(message),
     };
-    match runtime.archive_task(id) {
+    let archived_id = id.to_string();
+    let runtime_clone = runtime.clone();
+    match blocking("task archival", move || {
+        runtime_clone.archive_task(&archived_id)
+    })
+    .await
+    {
         Ok(()) => Json(json!({ "ok": true, "id": id })).into_response(),
-        Err(e) => map_runtime_error(e),
+        Err(response) => response,
     }
 }
 


### PR DESCRIPTION
## Task

[ORB-10988](https://orbit-cli.com/tasks/ORB-10988) — Fix concurrent task-write failures: unlocked index reads, blocking calls in async handlers, lost-update window

### Description

Friction F2026-07-119 reported that a burst of 11 concurrent `orbit_task_update` calls through the web API all transiently failed (`ReadTimeout` then `ConnectError`) while the identical calls run serially succeeded. A 2026-08-22 code review confirmed the hazard is still live and traced three cooperating defects:

## 1. Unlocked, fail-fast shared-index reads (likeliest root cause)

The per-task flock only serializes writes to the *same* task. The shared workspace index is validated on read with no lock at all:

- `index_is_usable()` (`crates/orbit-store/src/repository/task/v2/index.rs:52-69`) loops every registered task calling `read_existing_bundle(&binding.task_id)?` outside any lock; a concurrent writer mid-publication makes the `?` propagate an error for an unrelated task.
- `list_bundles()` (`crates/orbit-store/src/repository/task/v2_bundle.rs:212-221`) is documented as intentionally fail-fast — one in-flight/corrupt bundle fails the whole list — and `rebuild_index_best_effort` (`index.rs:73`) calls it.
- A bundle is a directory of several files written via per-file atomic writes, so multi-file publication is not atomic; readers do not consult the create-time lock sentinel (`crates/orbit-store/src/driver/file/task_bundle/lock.rs`).

Net effect: a write to task A racing a read/update of task B transiently fails the whole operation — exactly the reported "concurrent fails, serial succeeds" symptom. Secondary: `index_is_usable()` is an O(N) full-bundle read on every list.

## 2. Blocking calls on async workers, no concurrency limit

`update_task_action` (`crates/orbit-web/src/api/tasks.rs:648`) calls `runtime.update_task_with_identity(...)` synchronously at `tasks.rs:689` (same pattern at `tasks.rs:729` in `add_task_comment_action`); roughly 42 of 56 async handlers in `crates/orbit-web/src/api/` call the blocking runtime directly — only 5 `spawn_blocking` call sites exist. The call path descends into a timeout-free blocking flock (`crates/orbit-store/src/repository/task/v2/index.rs:161` `with_task_lock` → `crates/orbit-common/src/fs/io.rs:288` `lock_exclusive()`); a sibling path (`crates/orbit-store/src/fs/lock/mod.rs:199-226`) does `std::thread::sleep(50ms)` polling up to 30s then returns `Err`. The server (`crates/orbit-web/src/lib.rs:249`) uses a default multi-thread runtime with no tower concurrency-limit/load-shed layer, so N concurrent writes park N tokio workers on flock.

## 3. Lost-update window in the update path

`crates/orbit-core/src/application/task/update.rs:74` reads the task via `self.get_task(id)?` *before* the store re-reads under lock (`v2/updates.rs:15-16`); history entries and status-transition validation are computed from the stale read, so concurrent same-task updates are a lost-update surface even though the store-level write is correctly locked.

## Suggested fix order (from the review; implementer owns the plan)

(a) make `index_is_usable`/`list_bundles` tolerant of in-flight bundles rather than fail-fast; (b) wrap blocking runtime calls in `spawn_blocking` (or add a shared blocking-call helper) and consider a tower concurrency-limit layer; (c) move the read-modify-write in `update.rs` inside the task lock.

On completion this task resolves friction F2026-07-119.

### Acceptance Criteria

- A regression test reproduces the concurrent-write failure mode (parallel updates to distinct tasks racing an index read/rebuild) and passes after the fix: concurrent writes to distinct tasks no longer fail on transient in-flight bundle state.
- Shared-index validation (`index_is_usable`) and `list_bundles` tolerate an in-flight or partially-published bundle without failing operations on unrelated tasks, with the fail-fast behavior retained only where corruption genuinely requires it.
- No orbit-web async handler invokes the blocking runtime/flock path directly on a tokio worker for task mutation endpoints; blocking work is moved off the async workers (e.g. spawn_blocking) at least for the task write/comment endpoints named in the evidence.
- Concurrent updates to the same task cannot silently lose the earlier write: the read-modify-write in orbit-core's task update path happens under the task lock, with a test demonstrating it.
- Friction F2026-07-119 is linked via a resolves relation and closes when this task reaches done.

## Execution Summary

<details>
<summary>Click to expand</summary>

All three cooperating defects from the 2026-08-22 review are fixed, each with a regression test that fails on the pre-fix code.

## 1. Re-entrant task locking (prerequisite, orbit-common)

`with_exclusive_file_lock` (`crates/orbit-common/src/fs/io.rs`) now tracks the lock paths a thread holds in a thread-local set guarded by an RAII drop, and a nested call for a path this thread already holds runs the closure directly. `flock(2)` is owned by the open file description, so nesting previously opened a second descriptor and self-deadlocked — that had to be fixed before orbit-core could hold the task lock across a read-modify-write whose inner store writes lock the same file.

The re-entrancy key resolves the lock file's parent directory through symlinks (`resolved_lock_path`). This was found the hard way: the first version keyed on the literal path, and the orbit-core regression test hung because Orbit's checkout projection reaches one bundle by two routes. A missed key is a silent deadlock, not a wrong answer, so the resolution is not optional.

## 2. Tolerant shared-index reads (orbit-store)

- `bundle_io` gained `read_envelope_at`, sharing the envelope decode with `read_bundle_at`.
- `TaskBundleStoreV2` gained `read_bundle_if_settled` / `read_envelope_if_settled` and the free `skip_if_in_flight`. A failed read is converted to a skip only when re-checking proves the bundle is in flight: the create/delete lock sentinel is present, or the bundle directory is gone. Anything still unreadable when the bundle is neither held nor gone is genuine damage and still fails fast.
- `list_bundles` skips in-flight bundles instead of failing the whole list; its doc comment now states the narrowed rule rather than the old blanket fail-fast.
- `index_is_usable` reads envelopes rather than whole bundles (was an O(N) seven-file-per-task read on every list) and skips a task whose bundle a concurrent writer holds.
- `rebuild_index_best_effort` no longer propagates a `list_bundles` failure; every caller reaches it from a read, so it degrades to the bundle scan.
- `tasks_from_ids` drops ids whose bundle vanished between the index query and the read.

## 3. Blocking calls off the async workers (orbit-web)

`api/mod.rs` gained a `blocking(label, op)` helper. `api/tasks.rs` gained `task_mutation_response`, which runs the mutation *and* the store reads that build the response body on one `spawn_blocking`, keeping the previous status mapping via a `TaskMutationFailure` split (refused mutation -> `map_runtime_error`, failed render -> `server_error`). All five task mutation endpoints — create, update (`tasks.rs` PATCH), comment, approve, reject — now go through it; archive uses the `blocking` helper. No task write endpoint calls the runtime on a tokio worker any more. No tower concurrency-limit layer was added: the description marked it "consider", and it is speculative once the flock wait is off the async pool.

## 4. Lost-update window (orbit-core)

`TaskStoreBackend` gained `with_task_write_lock(id, &mut dyn FnMut)` (default: unlocked passthrough), implemented by `TaskV2Store` via its existing `with_task_lock` (visibility widened to `pub(crate)`). `update_task_with_status_note_and_identity` now wraps the entire read-validate-write body — extracted to `update_task_locked` — in that lock, so the `get_task` snapshot that history entries and transition validation are computed from cannot go stale before the write. `record_resolves_side_effects` stays outside the lock because it touches other records.

## Tests

- `orbit-common fs::tests::io`: re-entrancy within a thread; bookkeeping released after a panic (verified by a second thread then taking the lock); re-entrancy across a symlinked route.
- `orbit-store repository::task::v2::tests::concurrency` (new sibling file): listing survives a bundle removed under a live registry binding; listing skips an incomplete bundle held by the lock sentinel; listing still fails fast on a settled corrupt bundle; parallel updates to 8 distinct tasks x 12 rounds against 4 concurrent listers never fail a listing and every writer's last write is durable; parallel comment appends to one task lose nothing.
- `orbit-core application::task::tests::update::concurrent_update_cannot_write_through_a_status_change_it_never_saw`: a second thread holds the bundle lock, archives the task inside the window, and the contending rename must be refused.

Pre-fix verification (temporary local reverts, restored): forcing `skip_if_in_flight` to always re-raise fails the two tolerance tests; making `with_task_write_lock` a passthrough fails the orbit-core test with the losing writer renaming an already-archived task.

## Validation

`make ci-fast` and `make ci-lint` both pass. `cargo test` passes for orbit-common (209), orbit-core (773 + integration), orbit-store (325), orbit-web (259), orbit-tools, orbit-mcp, orbit-cmd. No new cross-crate dependency edges.

## Note for the reviewer

The `resolves` relation to F2026-07-119 is recorded on this task, but that friction record no longer exists in the workspace friction store (`orbit friction list` starts at F2026-08-001; only historical agent run memos still reference the id). The relation is therefore durable, but the auto-close on `done` will be a no-op against a missing record.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10988-6a8a7059`
- Behind base: 0
- Ahead of base: 1