### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design-patterns/error_translation.md
+++ b/docs/design-patterns/error_translation.md
@@ -1,7 +1,7 @@
 ---
 type: pattern
 summary: "Crate-Boundary Error Translation"
-last_validated: 2026-07-26
+last_validated: 2026-08-23
 ---
 # Crate-Boundary Error Translation
 
@@ -70,7 +70,7 @@ pub fn dispatch_error_to_orbit(error: DispatchError) -> OrbitError {
 ```
 
 Other live translators in the same shape are `selector_error_to_orbit`
-(`orbit-common::utility::selector`) and `rpc_error_to_orbit`
+(`orbit-common::fs::selector`) and `rpc_error_to_orbit`
 (`orbit-search::rpc`).
 
 Patterns to copy:
@@ -80,4 +80,4 @@ Patterns to copy:
 - **One named match per surfaced variant; everything else passes through.** "`InvalidData` → `InvalidInput`, `Io` → `Io`, default → `Execution`" is the right granularity — name the kinds callers will actually branch on, dump the rest into the generic bucket.
 - **`.map_err(translator)?`, not `.map_err(|e| translator(e))?`.** The translator's signature is `FnOnce(E) -> OrbitError`, so the bare path works as a closure. The shorter form reads better at boundary sites.
 
-Use this shape for every new crate in the workspace per the architecture diagram in `CLAUDE.md`. A new typed error should land in the same PR as its translator. `scripts/check-error-translation.sh` (ORB-10013, wired into `make ci-fast` and CI guardrails) enforces the mechanically checkable core: registered boundary errors must export their translator from the owning crate, translators may not live in caller crates, and no foreign error type may be mapped to `OrbitError` variants at a call site.
+Use this shape for every new crate in the workspace per the architecture diagram in `ARCHITECTURE.md`. A new typed error should land in the same PR as its translator. `scripts/check-error-translation.sh` (ORB-10013, wired into `make ci-fast` and CI guardrails) enforces the mechanically checkable core: registered boundary errors must export their translator from the owning crate, translators may not live in caller crates, and no foreign error type may be mapped to `OrbitError` variants at a call site.

--- a/docs/design-patterns/newtype.md
+++ b/docs/design-patterns/newtype.md
@@ -1,7 +1,7 @@
 ---
 type: pattern
 summary: "Newtype Wrapper"
-last_validated: 2026-07-26
+last_validated: 2026-08-23
 ---
 # Newtype Wrapper
 
@@ -37,4 +37,4 @@ The former `RefName` example was removed with the `orbit-knowledge` crate; no cu
 
 ---
 
-**Related: parsed sum-type form.** `Selector` (`crates/orbit-common/src/utility/selector.rs:16`) applies the same principle to a structured input string: `FromStr` parses `dir:`/`file:`/`symbol:` prefixes into an enum with a typed `SelectorParseError`. The enum variants have `pub` fields (a deliberate ergonomics trade for pattern matching at use sites), so the invariant is enforced by convention — every callsite uses `parse()` — rather than by visibility. Reach for this when the input has multiple legitimate shapes and pattern-matching the parsed result outweighs airtight construction.
+**Related: parsed sum-type form.** `Selector` (`crates/orbit-common/src/fs/selector.rs:40`) applies the same principle to a structured input string: `FromStr` parses `dir:`/`file:`/`symbol:` prefixes into an enum with a typed `SelectorParseError`. The enum variants have `pub` fields (a deliberate ergonomics trade for pattern matching at use sites), so the invariant is enforced by convention — every callsite uses `parse()` — rather than by visibility. Reach for this when the input has multiple legitimate shapes and pattern-matching the parsed result outweighs airtight construction.

--- a/docs/design-patterns/raii_guard.md
+++ b/docs/design-patterns/raii_guard.md
@@ -1,7 +1,7 @@
 ---
 type: pattern
 summary: "RAII Guard Pattern"
-last_validated: 2026-07-26
+last_validated: 2026-08-23
 ---
 # RAII Guard Pattern
 
@@ -60,7 +60,7 @@ Patterns to copy:
 
 ## Reference: `StagedTextFile` — `Drop` as rollback
 
-From `crates/orbit-common/src/utility/fs.rs:112`:
+From `crates/orbit-common/src/fs/io.rs:112`:
 
 ```rust
 pub struct StagedTextFile {
@@ -140,7 +140,7 @@ Patterns to copy:
 
 ## Reference: `FileLockGuard` — resource held until `Drop`
 
-From `crates/orbit-store/src/file_lock/mod.rs`:
+From `crates/orbit-store/src/fs/lock/mod.rs`:
 
 ```rust
 #[must_use = "the advisory lock is released as soon as the guard is dropped"]

--- a/docs/design-patterns/test_layout.md
+++ b/docs/design-patterns/test_layout.md
@@ -1,7 +1,7 @@
 ---
 type: pattern
 summary: "Per-Module Sibling tests/ Directory"
-last_validated: 2026-07-26
+last_validated: 2026-08-23
 ---
 # Per-Module Sibling tests/ Directory
 
@@ -89,7 +89,7 @@ This nests the test module as a *child* of the source module. Children can read 
 
 ## Reference: `orbit-mcp::adapter`
 
-The MCP `adapter` module has children `name_map.rs`, `schema.rs`, `dispatch.rs`, and `structured.rs`. The canonical layout: `adapter/mod.rs` declares each child plus `#[cfg(test)] mod tests;`, and `adapter/tests/` contains one file per source child (`tests/name_map.rs`, `tests/schema.rs`, etc.). MCP proxy/discovery tests live beside their implementations under `orbit-mcp/src/remote/tests/`; Registry's crate-level tests live under `orbit-registry/src/tests/`, while persistence sibling tests live under `orbit-registry/src/persistence/tests/`. Each test file accesses its sibling source through the narrowest deliberate visibility.
+The MCP `adapter` module has children `name_map.rs`, `schema.rs`, `dispatch.rs`, and `structured.rs`. The canonical layout: `adapter/mod.rs` declares each child plus `#[cfg(test)] mod tests;`, and `adapter/tests/` contains one file per source child (`tests/name_map.rs`, `tests/schema.rs`, etc.). MCP proxy/discovery tests live beside their implementations under `orbit-mcp/src/remote/tests/`; Registry's crate-level tests live under `orbit-registry/src/tests/`, including the workspace-registry persistence tests in `tests/workspace_registry.rs`. Each test file accesses its sibling source through the narrowest deliberate visibility.
 
 ## Migration recipe
 

--- a/docs/design/activity-job/1_overview.md
+++ b/docs/design/activity-job/1_overview.md
@@ -4,7 +4,7 @@ type: design
 title: "Activity / Job — Overview"
 owner: codex
 last_updated: 2026-07-20
-last_validated: 2026-07-26
+last_validated: 2026-08-23
 status: Draft
 feature: activity-job
 doc_role: overview
@@ -25,7 +25,7 @@ Orbit needs a runtime layer that humans can inspect and code can execute. Activi
 
 1. **Typed execution.** Agent loops and deterministic actions share one schema family after [T20260418-2010].
 2. **Durable local control flow.** Retry, parallelism, fan-out, and loops survive outside one model turn via `JobV2` DAG constructs from [T20260418-2018].
-3. **Clean runtime boundaries.** orbit-core coordinates runs without naming `orbit-agent` internals through the `V2RuntimeHost` work in [T20260418-2143] and [T20260418-2210].
+3. **Clean runtime boundaries.** orbit-core coordinates runs without naming `orbit-agent` internals through the unified `RuntimeHost` boundary in [T20260418-2143] and [T20260418-2210].
 4. **One canonical schema.** `schemaVersion: 1` assets fail load-time parsing after [T20260419-2156].
 
 ---
@@ -67,7 +67,7 @@ Name resolution arrived in [T20260418-2019]; `run-v2` entrypoints in [T20260418-
 
 ### 2.4 Provider is the only agent runtime choice
 
-For `agent_loop`, the asset declares a **provider** — `claude`, `codex`, `gemini`, `grok`, `ollama`, or `openai_compat` — and Orbit dispatches it through the CLI agent path. A provider without a CLI runtime (`openai_compat`) fails structurally instead of falling back.
+For `agent_loop`, the asset declares a **provider** — `claude`, `codex`, `gemini`, `grok`, `copilot`, `ollama`, `openai_compat`, or `cursor`. Orbit's CLI entry point executes the canonical four (`claude`, `codex`, `gemini`, and `grok`); other provider identities fail structurally instead of falling back.
 
 ### 2.5 Audit, policy, and seeded assets make the runtime inspectable
 
@@ -94,14 +94,14 @@ failures still terminate the parent.
 
 | Concern | Where it lives | Primary task ID |
 |---------|----------------|-----------------|
-| v2 activity type system | `crates/orbit-common/src/types/activity_job/activity_v2.rs` | [T20260418-2010] |
-| v2 job step grammar | `crates/orbit-common/src/types/activity_job/job_v2.rs` | [T20260418-2018] |
-| Job kinds (`workflow`, `subroutine`) | `crates/orbit-common/src/types/activity_job/job_v2.rs` | [T20260419-0339] |
-| Target-ref resolution | `crates/orbit-common/src/types/activity_job/catalog.rs` | [T20260418-2019] |
-| `run-v2` core entrypoints and host boundary | `crates/orbit-cmd/src/activity_v2.rs`, `crates/orbit-core/src/command/job/exec.rs` | [T20260418-2143], [T20260418-2210] |
-| Retired-declaration rejection | `crates/orbit-common/src/types/activity_job/retired.rs` | [ORB-10801] |
+| v2 activity type system | `crates/orbit-types/src/workflow/activity_job/activity_v2.rs` | [T20260418-2010] |
+| v2 job step grammar | `crates/orbit-types/src/workflow/activity_job/job_v2.rs` | [T20260418-2018] |
+| Job kinds (`workflow`, `subroutine`) | `crates/orbit-types/src/workflow/activity_job/job_v2.rs` | [T20260419-0339] |
+| Target-ref resolution | `crates/orbit-engine/src/activity_job/catalog.rs` | [T20260418-2019] |
+| `run-v2` core entrypoints and host boundary | `crates/orbit-cmd/src/activity_v2.rs`, `crates/orbit-core/src/application/job/exec.rs`, `crates/orbit-engine/src/context/hosts.rs`, `crates/orbit-core/src/adapter/engine_host/runtime_host.rs` | [T20260418-2143], [T20260418-2210] |
+| Retired-declaration rejection | `crates/orbit-types/src/workflow/activity_job/retired.rs` | [ORB-10801] |
 | v2 DAG executor | `crates/orbit-engine/src/activity_job/job_executor/` | [T20260418-2018], [T20260509-2] |
-| V2 audit envelope and disk sink | `crates/orbit-common/src/types/activity_job/audit_envelope.rs`, `crates/orbit-engine/src/activity_job/audit_writer.rs` | [T20260419-0002] |
+| V2 audit envelope and disk sink | `crates/orbit-types/src/workflow/activity_job/audit_envelope.rs`, `crates/orbit-engine/src/activity_job/audit_writer.rs` | [T20260419-0002] |
 | CLI agent runtime path | `crates/orbit-engine/src/activity_job/cli_runner/mod.rs` | [T20260419-0104] |
 | `fsProfile` enforcement | `crates/orbit-policy`, `tool_context_for_activity`, CLI describe/get surfaces | [T20260419-0503] |
 | Seeded reference activities and pipeline jobs | `crates/orbit-core/assets/activities/`, `crates/orbit-core/assets/jobs/` | [T20260419-2347], [T20260419-0622-3], [T20260419-0623] |
@@ -114,8 +114,8 @@ failures still terminate the parent.
 - **[T20260418-2010]** — Add the first v2 activity runtime scaffolding.
 - **[T20260418-2018]** — Add `JobV2` DAG constructs (`parallel`, `fan_out`, `loop`, `retry`, `when`).
 - **[T20260418-2019]** — Add v2 activity name resolution and pipeline skeleton assets.
-- **[T20260418-2143]** — Wire `V2RuntimeHost` in orbit-core and add `orbit activity run-v2`.
-- **[T20260418-2210]** — Reshape `V2RuntimeHost` to keep `orbit-agent` types out of orbit-core.
+- **[T20260418-2143]** — Wire the v2 runtime host in orbit-core and add `orbit activity run-v2`.
+- **[T20260418-2210]** — Reshape the v2 runtime host to keep `orbit-agent` types out of orbit-core.
 - **[T20260419-0002]** — Add `workspace_path` provenance to the v2 audit envelope.
 - **[T20260419-0104]** — Add `backend: cli` dispatch for v2 `agent_loop`.
 - **[T20260419-0339]** — Add v2 job kinds to the job catalog.


### PR DESCRIPTION
## Task

[ORB-10991](https://orbit-cli.com/tasks/ORB-10991) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Batch selection was computed with missing `last_validated` first, then oldest valid date, then path. The six selected docs were `docs/runbooks/release.md` (missing date), `docs/design-patterns/error_translation.md`, `docs/design-patterns/newtype.md`, `docs/design-patterns/raii_guard.md`, `docs/design-patterns/test_layout.md`, and `docs/design/activity-job/1_overview.md` (the latter five were dated 2026-07-26). The `_templates` scaffold was excluded because the repository's docs index generator excludes it from the corpus.
- Validated and stamped the four pattern docs and Activity / Job overview with `last_validated: 2026-08-23`.
- Corrected verified drift: moved selector, staged-file, and file-lock references to their current paths; corrected the error-translation architecture reference; corrected the registry test-layout reference; updated Activity / Job type, catalog, host-boundary, retired-declaration, and audit-envelope paths; replaced the retired `V2RuntimeHost` wording with the current `RuntimeHost` boundary; and refreshed the provider capability description.
- `docs/runbooks/release.md` was selected but left completely unchanged: its release-account, published-artifact, key-custody, and remote GitHub/npm claims cannot be verified from this checkout, and the document is too broad to stamp honestly.
- No selected frontmatter-less document required migration; all selected docs already had schema-compatible frontmatter. No new metadata fields, sidecars, documents, or sections were added.
Verification evidence:
- Pattern claims and paths were checked with `test -e`, `rg` symbol/path checks, source reads, current sibling-test listings, and `bash scripts/check-error-translation.sh` (`error translation guard passed`).
- Activity overview claims were checked with `test -e` and `rg` against `orbit-types` activity/job definitions, `orbit-engine` catalog/host code, `orbit-core` runtime adapter and assets, retired-feature validation, and audit-envelope definitions.
- `make ci-fast` passed, including `cargo fmt --check`, docs index verification, all guardrails, and plugin validators; `git diff --check` passed.
- Only five in-scope docs changed. Protected paths `.orbit/adrs/`, `CHANGELOG.md`, `docs/changelogs/`, `docs/design/_archive/`, `.orbit/tasks/`, and `.orbit/graph/` were unchanged.
Unvalidated:
- The selected release doc remains unstamped and unmodified for the external/remote claims above. No claim in it was rewritten on belief.
Assessment: bounded documentation upkeep completed with five earned validation stamps and one explicitly skipped selected doc.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10991-6a8a7774`
- Behind base: 0
- Ahead of base: 1