### PR TITLE
[auto-task] Remediate current GitHub Actions failures

### DIFF
--- a/crates/orbit-core/assets/routines/task_pilot.yaml
+++ b/crates/orbit-core/assets/routines/task_pilot.yaml
@@ -22,7 +22,7 @@ enabled: false
 hosts:
   - __ORBIT_HOST_ID__
 trigger:
-  cron: "45 */4 * * *"
+  cron: "*/40 * * * *"
   missed_run: skip
 target: job:task_pilot_pipeline
 policy:

--- a/crates/orbit-core/src/application/routine.rs
+++ b/crates/orbit-core/src/application/routine.rs
@@ -168,8 +168,8 @@ mod tests {
             assert!(!definition.enabled);
         }
 
-        // Cadence: hourly — deliberately sparser than the ~20-minute ship
-        // sweep, and parseable by the scheduler.
+        // Cadence: every 40 minutes — deliberately sparser than the
+        // ~20-minute ship sweep, and parseable by the scheduler.
         let triage = std::fs::read_to_string(routines_dir.join("task_triage.yaml"))
             .expect("read triage routine");
         let triage = parse_routine_yaml(&triage).expect("triage routine parses");
@@ -182,7 +182,7 @@ mod tests {
         let pilot = std::fs::read_to_string(routines_dir.join("task_pilot.yaml"))
             .expect("read task-pilot routine");
         let pilot = parse_routine_yaml(&pilot).expect("task-pilot routine parses");
-        assert_eq!(pilot.trigger.cron, "45 */4 * * *");
+        assert_eq!(pilot.trigger.cron, "*/40 * * * *");
         assert_eq!(
             pilot.trigger.missed_run,
             orbit_types::workflow::MissedRunPolicy::Skip

--- a/crates/orbit-web/src/api/mod.rs
+++ b/crates/orbit-web/src/api/mod.rs
@@ -354,16 +354,16 @@ pub(super) fn server_error(e: orbit_core::OrbitError) -> Response {
 /// the whole wait, so a burst of concurrent writes parks every worker and the
 /// server stops answering — the `ReadTimeout`-then-`ConnectError` shape of
 /// F2026-07-119. `label` names the operation in the panic-propagation error.
-pub(super) async fn blocking<T, F>(label: &str, op: F) -> Result<T, Response>
+pub(super) async fn blocking<T, F>(label: &str, op: F) -> Result<T, Box<Response>>
 where
     F: FnOnce() -> Result<T, orbit_core::OrbitError> + Send + 'static,
     T: Send + 'static,
 {
     match tokio::task::spawn_blocking(op).await {
         Ok(Ok(value)) => Ok(value),
-        Ok(Err(e)) => Err(map_runtime_error(e)),
-        Err(join_err) => Err(server_error(orbit_core::OrbitError::Execution(format!(
-            "{label} panicked: {join_err}"
+        Ok(Err(e)) => Err(Box::new(map_runtime_error(e))),
+        Err(join_err) => Err(Box::new(server_error(orbit_core::OrbitError::Execution(
+            format!("{label} panicked: {join_err}"),
         )))),
     }
 }

--- a/crates/orbit-web/src/api/tasks.rs
+++ b/crates/orbit-web/src/api/tasks.rs
@@ -838,7 +838,7 @@ pub(super) async fn archive_task_action(Ws(runtime): Ws, Path(id): Path<String>)
     .await
     {
         Ok(()) => Json(json!({ "ok": true, "id": id })).into_response(),
-        Err(response) => response,
+        Err(response) => *response,
     }
 }
 


### PR DESCRIPTION
## Task

[ORB-10994](https://orbit-cli.com/tasks/ORB-10994) — [auto-task] Remediate current GitHub Actions failures

### Description

Investigate and remediate current GitHub Actions failures for this
repository. This task may legitimately finish with no diff: if no
current, reproducible, repository-owned failure remains, persist the
evidence described below and report a successful no-current-failure or
transient-only outcome.

## Discovery and duplicate safety

1. Enumerate this repository's workflows and recent runs with GitHub's API
   or `gh`, and enumerate open pull requests with their current head SHAs.
   Cover failures for the current heads of `agent-main`, `main`, and every
   open pull request, including informational jobs such as coverage rather
   than looking only at required checks or the main `ci` job.
2. The PR-only `Create orbit task on CI failure` step in
   `.github/workflows/ci.yml` is an input and coverage signal. Search open
   Orbit tasks for its run URL, PR number, SHA, and failure signature.
   Reference matching tasks in the execution summary; do not create
   another task for the same run or root cause. This remediation task owns
   the repair and must not fan a red-run cluster out into more failure
   tasks.
3. For every candidate run, record the run and job URLs, workflow, event,
   branch or PR, run-attempt number, reported head SHA, and the current
   branch/PR head SHA. Query the failed jobs and steps and inspect the
   exact failed-step logs.
4. Independently verify the commit that Actions actually checked out from
   the checkout step/log (`HEAD is now at`, checkout ref/SHA, or equivalent
   unambiguous evidence). Keep the event's reported head SHA, the current
   ref head, and the tested checkout commit distinct; PR merge SHAs are not
   interchangeable with PR head SHAs.
5. Ignore a failed run as stale when its branch or PR has advanced and the
   failure does not reproduce at the current head, or when a newer
   successful run of the same workflow/check at the relevant current
   commit supersedes it. Cite the advancing or superseding run and SHAs;
   age alone is not evidence that a failure is stale.

## Diagnosis and remediation

Cluster repeated runs by root cause before editing. Use the failing
command, job/step, exact error signature, tested commit, and causal
dependency between failures to distinguish one regression repeated across
push/PR runs from independent failures. Repair each current root cause
once, while retaining a mapping from every affected run/job to that
cluster.

Reproduce every current candidate at the current repository head using
the exact command or the narrowest faithful local equivalent. A
deterministic repository-owned failure is in scope and must be fixed in
this task's worktree. Classify a GitHub service, network, hosted-runner, or
other infrastructure failure as transient only with concrete evidence,
such as a successful retry at the same SHA plus logs showing the
infrastructure fault. Do not call a failure transient merely because it
fails to reproduce once.

Fix the underlying repository-owned cause. Do not disable a workflow,
weaken an assertion or lint level, add a broad allow/ignore rule, mark a
failing gate `continue-on-error`, remove an affected target from coverage,
or otherwise obtain green CI by hiding the failure. Informational checks
remain informational, but they must execute successfully.

## Validation and handoff

For each fixed root cause, rerun the exact command that formerly failed.
Then run the repository pre-handoff gate, `make ci-fast`. After the
candidate commit is published through the repository's normal workflow,
inspect its GitHub Actions runs and require a green rerun for every
affected workflow/check. This includes affected informational jobs even
though they remain non-required. Do not declare a repair validated while
an affected run is missing, queued, in progress, cancelled, or red.

Persist an `execution_summary` that maps every investigated run/job URL,
reported head SHA, actual checkout commit, and current ref head to its
root-cause cluster, disposition (fixed, stale, superseded, or transient),
change, local reproduction, exact formerly failing validation, pre-handoff
result, and green GitHub rerun URL. Also map any matching PR-hook-created
Orbit task. For a successful no-diff pass, list the queries, current heads,
superseding successes or transient evidence, and why no repository-owned
failure remained.

## Historical validation fixture

Use run 30232696219 as the calibration example for the evidence model, not
as proof of a current failure:

- `Check / Clippy / Test` → `Run CI guardrails` reported Clippy's needless
  borrow at
  `crates/orbit-store/src/file/task_store/v2_bundle/bundle_io/mod.rs:172`,
  `sync_parent_dir(&staging_dir)`.
- `Coverage (informational)` reported that
  `command::skill::tests::plugin_skill_symlinks_resolve_to_assets` found
  `plugin/skills/orbit-task/SKILL.md` different from
  `crates/orbit-core/assets/skills/orbit-task/SKILL.md`.
- The run metadata reported head
  `49a2871a480b927bb31dc7a315f5ff5d130d15d0`, while the checkout log showed
  `5cec12c53211fad3f4ca940a0565bef87787958d`. A valid investigation preserves
  that discrepancy, clusters adjacent runs by the two root causes, and
  tests whether either failure still exists at the relevant current head
  before editing.


### Acceptance Criteria

- Current-head failures across agent-main, main, and open pull requests were enumerated for every repository workflow, including informational jobs.
- Every investigated run records its reported SHA, actual checkout commit, current ref head, failed job/step, exact log evidence, and stale or superseding evidence where applicable.
- Repeated red runs are clustered by root cause, and every current repository-owned failure is reproduced and fixed without weakening or bypassing a check.
- Transient-only classifications cite infrastructure evidence and a successful same-SHA retry; a single non-reproduction is not treated as sufficient evidence.
- Each fixed cause passes the exact formerly failing validation and make ci-fast, and every affected required or informational GitHub Actions check executes successfully on the candidate commit.
- The persisted execution_summary maps each run/job URL and SHA to its root cause, disposition, change, validations, green rerun, and any matching PR-hook task.
- A no-current-failure or transient-only investigation is a successful no-diff outcome when its current-head queries and superseding or transient evidence are persisted.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: local remediation complete; no commit or GitHub rerun was created because repository policy forbids committing before human approval. The pipeline must publish this candidate and verify the affected checks on the candidate SHA.

Investigation scope and heads:
- Enumerated .github/workflows/ci.yml, ci-macos.yml, release.yml, smoke-plugin-install.yml, and website.yml; recent workflow runs, jobs/steps/logs, open PR heads, and Orbit tasks. CI includes required Linux/MSRV/Clippy-Test jobs and informational Coverage.
- At investigation time agent-main = fe6971f4eaa13666b7e3245a8f1da5e1fbc99f0f (the worktree checkout and origin/agent-main); main = b9626ded795d40a31c12135f04ea2487cd6e8b82. Open PR heads queried included #1129 = 51d65257f29f7bc4d6e33360a443691b37286562, #1128 = bdc916f5f3e305f5f2bb9023527ca37df06979f6, #1127 = 3175d78ab95819bc66085dc1db928440c2e76e59, and #1126 = 6b8b88e63725cc70b716d9915b2df94156b94423. A later GitHub PR refresh hit a TLS handshake timeout; the successful earlier enumeration and run data were retained.
- The injected historical run 30232696219 remains calibration only: reported 49a2871a480b927bb31dc7a315f5ff5d130d15d0 versus checkout 5cec12c53211fad3f4ca940a0565bef87787958d; neither historical fixture failure was treated as current.

Root-cause cluster C1 — large web error result:
- Current agent-main run https://github.com/danieljhkim/orbit/actions/runs/32618944144, push, attempt 1, reported SHA fe6971f4eaa13666b7e3245a8f1da5e1fbc99f0f, checked out fe6971f4eaa13666b7e3245a8f1da5e1fbc99f0f from agent-main, current ref head fe6971f4eaa13666b7e3245a8f1da5e1fbc99f0f. Failed Check / Clippy / Test job https://github.com/danieljhkim/orbit/actions/runs/32618944144/job/97144014329 at Run CI guardrails: clippy::result-large-err at crates/orbit-web/src/api/mod.rs:357 for Result<T, Response>, with the diagnostic that Response is at least 128 bytes and should be boxed. Coverage also failed in https://github.com/danieljhkim/orbit/actions/runs/32618944144/job/97144014317, but that job exposed cluster C2 below.
- The same C1 failure repeated at agent-main reported/tested SHAs e2c5f643356aa2f5c9551b777856b83991abd683 (run https://github.com/danieljhkim/orbit/actions/runs/32618737776; job https://github.com/danieljhkim/orbit/actions/runs/32618737776/job/97143520439), 8dd4b926509e2eb0f1abe710a49717ebcf505d1e (run https://github.com/danieljhkim/orbit/actions/runs/32618569647; job https://github.com/danieljhkim/orbit/actions/runs/32618569647/job/97143116002), and 1d0b4884d51b2b4a1c7130f0ee60beeaaa45f436 (run https://github.com/danieljhkim/orbit/actions/runs/32618546449; job https://github.com/danieljhkim/orbit/actions/runs/32618546449/job/97143060330). Each older push had advanced current agent-main head fe6971f4 and was stale/superseded by the later red run.
- PR #1129 run https://github.com/danieljhkim/orbit/actions/runs/32618480067, pull_request, attempt 1, reported head and checkout 51d65257f29f7bc4d6e33360a443691b37286562; current PR head at enumeration was the same. Failed CI job https://github.com/danieljhkim/orbit/actions/runs/32618480067/job/97142897599 with the identical C1 diagnostic; Linux and MSRV succeeded. The PR was subsequently superseded by the later agent-main history.
- PR #1127 run https://github.com/danieljhkim/orbit/actions/runs/32618322215, pull_request, reported head and checkout 3175d78ab95819bc66085dc1db928440c2e76e59; current PR head at enumeration was the same. Failed CI job https://github.com/danieljhkim/orbit/actions/runs/32618322215/job/97142510418 with the identical C1 diagnostic; Coverage, Linux, and MSRV succeeded.
- Fix: changed blocking to return Box<Response> and boxed both error paths; adapted its sole caller in crates/orbit-web/src/api/tasks.rs. No lint was weakened.

Root-cause cluster C2 — task-pilot rendered/seeded routine drift:
- On e2c5f643356aa2f5c9551b777856b83991abd683, coverage job https://github.com/danieljhkim/orbit/actions/runs/32618737776/job/97143520591 failed Collect workspace coverage because the dogfood test compared left 45 */4 * * * with workspace right */40 * * * *.
- On current agent-main fe6971f4eaa13666b7e3245a8f1da5e1fbc99f0f, coverage job https://github.com/danieljhkim/orbit/actions/runs/32618944144/job/97144014317 reproduced the same mismatch. The branch checkout was agent-main and the tested commit was fe6971f4eaa13666b7e3245a8f1da5e1fbc99f0f. This is repository-owned, not transient.
- Fix: synchronized crates/orbit-core/assets/routines/task_pilot.yaml to */40 * * * * and updated the directly coupled authoritative routine validation/seed expectation and comment in crates/orbit-core/src/application/routine.rs.

Superseding/green evidence:
- main current b9626ded795d40a31c12135f04ea2487cd6e8b82 was green in CI https://github.com/danieljhkim/orbit/actions/runs/32614200413, macOS https://github.com/danieljhkim/orbit/actions/runs/32614200370, and CodeQL https://github.com/danieljhkim/orbit/actions/runs/32614199695.
- PR #1128 head bdc916f5f3e305f5f2bb9023527ca37df06979f6 was green in CI https://github.com/danieljhkim/orbit/actions/runs/32618468590, Website https://github.com/danieljhkim/orbit/actions/runs/32618468611, and CodeQL https://github.com/danieljhkim/orbit/actions/runs/32618467980.
- PR #1126 head 6b8b88e63725cc70b716d9915b2df94156b94423 was green in CI https://github.com/danieljhkim/orbit/actions/runs/32617124269, Website https://github.com/danieljhkim/orbit/actions/runs/32617124278, and CodeQL https://github.com/danieljhkim/orbit/actions/runs/32617123111.
- Older dependabot PR failures were stale/superseded by branch advancement or newer successful workflow runs; no current failure was retained from them.
- The PR-only Create orbit task on CI failure signal was inspected. Its soft failure reported missing complexity for a task-add attempt, but it did not fail the workflow. Orbit task-list search found no matching open task for the investigated run URLs, PR numbers, SHAs, or signatures; no duplicate task was created.

Validation:
- Exact C1 equivalent passed: cargo clippy -p orbit-web --all-targets -- -D warnings.
- Exact C2 tests passed: cargo test -p orbit-core application::routine::tests::dogfood_task_pilot_routine_matches_the_rendered_default_template -- --exact and cargo test -p orbit-core application::routine::tests -- --nocapture (6 passed).
- ./scripts/ci-guardrails.sh passed formatting, compile, tests, docs, and guardrails after the fixes; its only remaining failure was cargo deny check, blocked by the runner filesystem: failed to obtain advisory database lock at ~/.cargo/advisory-dbs/db.lock because the path is read-only. This is recorded as an environment denial, not a code failure.
- make ci-fast passed fully.
- The exact coverage command could not run locally because cargo-llvm-cov is not installed (cargo llvm-cov: no such command); the narrow equivalent routine tests passed. No GitHub green rerun exists for this uncommitted candidate. After normal publication, rerun CI and Coverage on the candidate commit and require all affected jobs to be green before review.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10994-6a8a7d71`
- Behind base: 0
- Ahead of base: 1