### PR TITLE
Revert required-status-check prescription; document the ship-fast/async-remediation merge model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,11 @@ jobs:
           rustc --version | grep -F "${MSRV}"
           cargo check --workspace --locked
 
-  # [ORB-10010] Coverage visibility — informational, NOT a merge gate. This
-  # job is intentionally excluded from any required-status-check wiring
-  # (agent-main's branch protection requires the primary "Check / Clippy /
-  # Test" status check; this informational job is intentionally excluded from
-  # that gate, see RELEASING.md §10c). Per-crate coverage targets (goals, not
-  # gates) are documented in CONTRIBUTING.md "Testing & Coverage".
+  # [ORB-10010] Coverage visibility — informational, NOT a merge gate. No CI
+  # job gates merges on agent-main; failures are signals consumed by the
+  # qa-sweep and ci-failure-remediation routines. Coverage is doubly
+  # informational, and per-crate coverage targets (goals, not gates) are
+  # documented in CONTRIBUTING.md "Testing & Coverage".
   coverage:
     name: Coverage (informational)
     runs-on: ubuntu-latest

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -229,10 +229,7 @@ git push origin agent-main
 git push origin origin/main:refs/heads/agent-main
 cat <<'EOF' | gh api -X PUT repos/danieljhkim/orbit/branches/agent-main/protection --input -
 {
-  "required_status_checks": {
-    "strict": true,
-    "contexts": ["Check / Clippy / Test"]
-  },
+  "required_status_checks": null,
   "enforce_admins": false,
   "required_pull_request_reviews": null,
   "restrictions": null,
@@ -247,14 +244,10 @@ cat <<'EOF' | gh api -X PUT repos/danieljhkim/orbit/branches/agent-main/protecti
 EOF
 ```
 
-The applied `agent-main` protection must keep `strict: true` and require the
-primary CI check named exactly `Check / Clippy / Test`; coverage and platform
-diagnostic jobs remain informational. Verify the live setting after applying
-it with:
-
-```sh
-gh api repos/danieljhkim/orbit/branches/agent-main/protection/required_status_checks
-```
+Protection on `agent-main` exists only to prevent branch deletion
+(`allow_deletions: false`); merges are never gated on CI. CI failures are
+consumed asynchronously by the `qa-sweep` and `ci-failure-remediation`
+routines, which append remediation tasks to the queue.
 
 If a release ever ships without the back-merge, drift compounds (N commits behind `main` after N skipped releases). Recover by either running the same back-merge above (resolves cleanly regardless of N) or, if `agent-main` has no in-flight work, reset it to `main` directly:
 

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -92,9 +92,11 @@ date has passed or its `revoked_at` field is set.
    - smoke the tagged shell installer on macOS and Ubuntu, including semantic
      companion installation where supported.
 
-   Require every job to pass. Then follow
-   [RELEASING.md §10b](../../RELEASING.md#10b-promote-to-main) to promote
-   `agent-main` to `main`, and
+   Review the result of every job, but treat CI as informational on
+   `agent-main`: no job is a merge gate. Failures are queued for asynchronous
+   remediation by the `qa-sweep` and `ci-failure-remediation` routines. Then
+   follow [RELEASING.md §10b](../../RELEASING.md#10b-promote-to-main) to
+   promote `agent-main` to `main`, and
    [§10c](../../RELEASING.md#10c-post-merge-back-merge-to-agent-main) to
    back-merge in the same session.
 


### PR DESCRIPTION
## Task

[ORB-10996](https://orbit-cli.com/tasks/ORB-10996) — Revert required-status-check prescription; document the ship-fast/async-remediation merge model

### Description

## Why

ORB-10989 (PR #1125) wrote a required-status-check prescription into the repo docs. Daniel has rejected that half of the task (2026-08-22): **it is not how Orbit works**. The operating model for `agent-main` is one-directional, no merge gates: PRs ship fast into `agent-main`; CI is a signal, not a gate; `qa-sweep` and `ci-failure-remediation` routines consume failures and append remediation tasks to the queue. No blockage by design. The live branch protection was deliberately never changed (no required status checks today — verified 2026-08-22); the docs now prescribe a setting that will never be applied.

The version-assertion half of ORB-10989 (smoke-plugin-install.sh tag assertion) is correct and stays untouched.

## Scope

- `RELEASING.md` (~lines 236-263): in the §10c recreate-protection snippet, restore `"required_status_checks": null` and delete the paragraph "The applied `agent-main` protection must keep `strict: true` and require the primary CI check named exactly `Check / Clippy / Test`…" plus its verify command. In its place, state the actual model in 2-3 sentences: protection exists only to block branch deletion (`allow_deletions: false`); merges are never gated on CI; failures are remediated asynchronously by the qa-sweep / ci-failure-remediation routines appending tasks.
- `.github/workflows/ci.yml` (~lines 105-110): reword the coverage-job comment — it currently claims "agent-main's branch protection requires the primary Check / Clippy / Test status check", which is false. Say instead that no CI job is a merge gate on agent-main; coverage is doubly informational.
- Check `docs/runbooks/release.md` for any echo of the same prescription and align it.

## Out of scope

- scripts/smoke-plugin-install.sh and its version assertion (kept; see ORB-10995 for its future as an npm smoke).
- Any change to live GitHub branch-protection settings (already correct as-is).

### Acceptance Criteria

- RELEASING.md §10c snippet applies protection with `required_status_checks: null` and no strict/required-check language remains anywhere in the file.
- RELEASING.md states the async-remediation model: no merge gates on agent-main; CI failures become queued remediation tasks via qa-sweep / ci-failure-remediation.
- ci.yml coverage comment no longer claims a required status check exists.
- `rg -i 'required.status|strict.*true' RELEASING.md docs/runbooks/release.md .github/workflows/ci.yml` shows no surviving prescription of a merge gate.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Restored `"required_status_checks": null` in the RELEASING.md §10c recovery snippet and replaced the strict primary-check prescription with deletion-only protection plus asynchronous qa-sweep / ci-failure-remediation handling.
- Reworded the CI coverage comment to state that no CI job gates merges on agent-main and coverage is doubly informational.
- Updated docs/runbooks/release.md to describe CI review as informational with queued asynchronous remediation.

Validation:
- `make ci-fast` passed.
- `git diff --check` passed.
- The requested search finds only the intentional null `required_status_checks` configuration; no `strict.*true` or non-null status-check prescription remains.

Assessment: Small, scoped documentation-only change; the version-assertion smoke script and live GitHub protection settings were untouched.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10996-6a8a8730`
- Behind base: 0
- Ahead of base: 1