### PR TITLE
Ship code-review-sweep as a fourth default auto-task

### DIFF
--- a/crates/orbit-core/assets/auto_tasks/code-review-sweep.yaml
+++ b/crates/orbit-core/assets/auto_tasks/code-review-sweep.yaml
@@ -1,0 +1,76 @@
+schemaVersion: 1
+name: code-review-sweep
+description: Post-merge code review of changes merged since the last completed sweep
+enabled: false
+schedule:
+  cron: 40 */6 * * *
+template:
+  title: Review recently merged changes
+  description: |-
+    Review the code merged into this workspace since the last completed sweep.
+    The durable output is filed Orbit tasks for every confirmed finding plus the
+    recorded review cursor; the execution summary is the audit trail. Narrative-only
+    output does not count as delivery.
+
+    ## Rules and command surfaces
+
+    - Use the registered Orbit tool surface. Find the previous sweep with
+      `orbit tool run orbit.task.list --input '{"status":["done"],"tag":"code-review-sweep","model":"<agent-family>"}'`
+      and read its cursor with
+      `orbit tool run orbit.task.show --input '{"id":"<id>","model":"<agent-family>"}'`.
+      Search existing coverage with
+      `orbit tool run orbit.search --input '{"query":"<distinctive symptom, symbol, or file terms>","kind":"task","all":true,"model":"<agent-family>"}'`
+      and list open review work with
+      `orbit tool run orbit.task.list --input '{"status":["backlog","in-progress","proposed","blocked"],"tag":"code-review","model":"<agent-family>"}'`.
+      File a finding with
+      `orbit tool run orbit.task.add --input '{"title":"<title>","description":"<markdown>","acceptance_criteria":["<observable outcome>"],"tags":["code-review"],"priority":"<low|medium|high|critical>","type":"bug","workspace":"<current workspace path>","model":"<agent-family>"}'`.
+      Do not use direct lifecycle CLI subcommands; they skip agent provenance.
+    - Fail open. A window with no confirmed findings is a successful no-op. Do not
+      invent work to justify the run.
+
+    ## Determine the review window
+
+    Find the most recent done task tagged `code-review-sweep` and read the
+    last-reviewed commit recorded in its execution summary. Review the commits from
+    that point to the current HEAD of the workspace's integration branch. If no
+    prior sweep task exists, record the current HEAD as the baseline and stop — the
+    first run seeds the cursor.
+
+    ## Review the window
+
+    Read the diffs white-box: correctness, concurrency and error handling, and
+    conformance to the repository's documented standards (agent guide, contributing
+    guide, lint configuration). Review the window as a whole — interactions between
+    separately merged changes are findings per-change review cannot see.
+
+    ## File confirmed findings
+
+    Verify every finding against the live code before filing — a diff that looks
+    wrong but is guarded elsewhere is not a finding. Search open Orbit tasks tagged
+    `code-review` before filing; skip duplicates and nitpicks. File each confirmed
+    finding as its own Orbit task with file:line evidence, a severity-appropriate
+    priority, and the `code-review` tag.
+
+    ## Record the cursor
+
+    Always record the reviewed range and the new last-reviewed commit in the
+    persisted execution summary — the next sweep's window starts there.
+  acceptance_criteria:
+  - The review window was derived from the previous sweep's recorded cursor, or the current HEAD was seeded as the baseline on the first run.
+  - Every filed finding was verified against live code, is non-duplicate, and carries file:line evidence with a severity-appropriate priority and the `code-review` tag.
+  - The reviewed range and the new last-reviewed commit are recorded in the persisted execution summary.
+  - A window with no confirmed findings succeeds as a no-op.
+  task_type: chore
+  tags:
+  - code-review-sweep
+  - no-diff-expected
+  priority: medium
+  # The portable system lane is seeded per machine and compatibility-aliased
+  # for configs written before that crew existed.
+  crew: system
+  status: backlog
+dedupe: skip_if_open
+created_by: system
+created_at: 2026-08-23T00:00:00Z
+updated_by: system
+updated_at: 2026-08-23T00:00:00Z

--- a/crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md
@@ -67,9 +67,9 @@ scheduler's cursor untouched — so it is the safe way to test a definition's
 wording before enabling it. Over MCP: `orbit_auto_task_list` and
 `orbit_auto_task_mint`.
 
-## The three seeded definitions
+## The four seeded definitions
 
-`orbit workspace init` seeds all three, disabled:
+`orbit workspace init` seeds all four, disabled:
 
 - **`qa-sweep`** — hourly. Identifies recent changes, exercises them hands-on
   through their real user-facing paths rather than just re-running the test
@@ -81,6 +81,11 @@ wording before enabling it. Over MCP: `orbit_auto_task_list` and
   dependencies, secret handling, and configuration with evidence; files a
   durable Orbit task for each non-duplicate finding with severity and impact; a
   clean review is a successful no-op.
+- **`code-review-sweep`** — every six hours. Reviews the commits merged into the
+  integration branch since the previous sweep's recorded cursor, verifies each
+  candidate finding against the live code, files the non-duplicate ones as tasks
+  tagged `code-review`, and records the new last-reviewed commit in its execution
+  summary — that cursor is the next sweep's window start.
 
 Read them before enabling. They are also the best worked examples of how much
 instruction a minted task's body should carry.

--- a/crates/orbit-core/src/auto_tasks/mod.rs
+++ b/crates/orbit-core/src/auto_tasks/mod.rs
@@ -51,6 +51,10 @@ pub use state::{AutoTaskCursor, AutoTaskCursorState, cursor_state_path, load_cur
 /// explicitly mint one or enable it through the existing auto-task surface.
 pub(crate) const DEFAULT_AUTO_TASK_FILES: &[(&str, &str)] = &[
     (
+        "code-review-sweep",
+        include_str!("../../assets/auto_tasks/code-review-sweep.yaml"),
+    ),
+    (
         "friction-curation",
         include_str!("../../assets/auto_tasks/friction-curation.yaml"),
     ),

--- a/crates/orbit-core/src/auto_tasks/tests/shipped.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/shipped.rs
@@ -22,7 +22,12 @@ fn shipped_defaults_all_parse_and_are_disabled() {
         .iter()
         .map(|(name, _)| *name)
         .collect();
-    for required in ["friction-curation", "qa-sweep", "security-review"] {
+    for required in [
+        "code-review-sweep",
+        "friction-curation",
+        "qa-sweep",
+        "security-review",
+    ] {
         assert!(
             names.contains(&required),
             "missing shipped default {required}"
@@ -256,6 +261,109 @@ fn qa_sweep_default_preserves_hands_on_validation_contract() {
                     && criterion.contains("production impact")
             }),
         "qa-sweep acceptance criteria must require filing breaking tests"
+    );
+}
+
+/// Code review sweep carries its window cursor in execution summaries rather
+/// than in scheduler state, so the template must keep saying so, and it must
+/// stay generic across workspaces.
+#[test]
+fn code_review_sweep_default_is_portable_cursor_driven_and_inert() {
+    let (_, yaml) = DEFAULT_AUTO_TASK_FILES
+        .iter()
+        .find(|(name, _)| *name == "code-review-sweep")
+        .expect("code-review-sweep default");
+    let definition = parse_auto_task_yaml(yaml).expect("parse code-review-sweep");
+
+    assert_eq!(definition.name, "code-review-sweep");
+    assert!(!definition.enabled, "definition must ship disabled");
+    assert_eq!(
+        definition.schedule,
+        AutoTaskSchedule::Cron {
+            cron: "40 */6 * * *".to_string()
+        },
+        "code-review-sweep must use a documented six-hourly schedule"
+    );
+    assert!(matches!(definition.dedupe, DedupePolicy::SkipIfOpen));
+    assert_eq!(definition.template.crew.as_deref(), Some("system"));
+    assert!(
+        yaml.contains("\n  crew: system"),
+        "default must name the portable system crew"
+    );
+    assert_eq!(
+        definition.template.status,
+        orbit_types::task::TaskStatus::Backlog
+    );
+    for required_tag in ["code-review-sweep", "no-diff-expected"] {
+        assert!(
+            definition
+                .template
+                .tags
+                .iter()
+                .any(|tag| tag == required_tag),
+            "missing required tag {required_tag}"
+        );
+    }
+    assert!(
+        !yaml.contains("/home/") && !yaml.contains("/Users/"),
+        "default must not contain a machine-specific path"
+    );
+    // The template ships to every workspace, so it must not name this
+    // repository's branches or files.
+    for repo_specific in ["agent-main", "ORB-", "CLAUDE.md", "make ci"] {
+        assert!(
+            !yaml.contains(repo_specific),
+            "template must stay workspace-generic; found '{repo_specific}'"
+        );
+    }
+
+    let body = definition.template.description.to_lowercase();
+    for required in [
+        "last-reviewed commit",
+        "execution summary",
+        "seeds the cursor",
+        "verify every finding",
+        "skip duplicates",
+        "file:line",
+        "no-op",
+        "orbit tool run orbit.task.add",
+        "orbit tool run orbit.task.list",
+        "orbit tool run orbit.task.show",
+        "orbit tool run orbit.search",
+    ] {
+        assert!(
+            body.contains(required),
+            "template should retain '{required}'"
+        );
+    }
+    assert!(!body.contains("orbit task add"));
+    assert!(!body.contains("orbit task list"));
+    assert!(!body.contains("orbit task show"));
+    assert!(
+        definition
+            .template
+            .acceptance_criteria
+            .iter()
+            .any(|criterion| {
+                let criterion = criterion.to_lowercase();
+                criterion.contains("reviewed range")
+                    && criterion.contains("last-reviewed commit")
+                    && criterion.contains("execution summary")
+            }),
+        "code-review-sweep must require recording the window cursor"
+    );
+    assert!(
+        definition
+            .template
+            .acceptance_criteria
+            .iter()
+            .any(|criterion| {
+                let criterion = criterion.to_lowercase();
+                criterion.contains("verified against live code")
+                    && criterion.contains("non-duplicate")
+                    && criterion.contains("file:line")
+            }),
+        "code-review-sweep must require verified, evidenced, non-duplicate findings"
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-10997](https://orbit-cli.com/tasks/ORB-10997) — Ship code-review-sweep as a fourth default auto-task

### Description

## Why

Complete the shipped sweep triad with an implementation-quality lens: qa-sweep covers behavior, security-review covers security, and this adds post-merge code review. The model matches Orbit's no-merge-gates philosophy: work ships fast into the integration branch, review runs downstream on a schedule, and confirmed findings are queued as tasks — one direction, no blockage.

## What

Add a new shipped default auto-task `code-review-sweep`, generic across workspaces (no Orbit-repo specifics). It must ship **disabled** (test-enforced invariant) with `crew: system` like the other defaults.

Proposed definition (adjust wording to match house style of the existing three):

```yaml
schemaVersion: 1
name: code-review-sweep
description: Post-merge code review of changes merged since the last completed sweep
enabled: false
schedule:
  cron: 40 */6 * * *
template:
  title: Review recently merged changes
  description: |
    Determine the review window: find the most recent done task tagged
    `code-review-sweep` and read the last-reviewed commit recorded in its
    execution summary. Review the commits from that point to the current
    HEAD of the workspace's integration branch. If no prior sweep task
    exists, record the current HEAD as the baseline and stop — the first
    run seeds the cursor.

    Read the diffs white-box: correctness, concurrency and error handling,
    and conformance to the repository's documented standards (agent guide,
    contributing guide, lint configuration). Review the window as a whole —
    interactions between separately merged changes are findings per-change
    review cannot see.

    Verify every finding against the live code before filing — a diff that
    looks wrong but is guarded elsewhere is not a finding. Search open
    Orbit tasks tagged `code-review` before filing; skip duplicates and
    nitpicks. File each confirmed finding as its own Orbit task via the
    Orbit MCP tools or `orbit tool run orbit.task.add`, with file:line
    evidence, severity-appropriate priority, and the `code-review` tag.

    A window with no confirmed findings is a successful no-op. Always
    record the reviewed range and the new last-reviewed commit in your
    execution summary — the next sweep's window starts there. Your
    narrative output is advisory; filed tasks and the recorded cursor are
    the durable side-effect channel.
  acceptance_criteria:
  - The review window was derived from the previous sweep's recorded cursor (or seeded on first run).
  - Every filed finding was verified against live code, is non-duplicate, and carries file:line evidence.
  - The reviewed range and new last-reviewed commit are recorded in the execution summary.
  task_type: chore
  tags:
  - code-review-sweep
  - no-diff-expected
  priority: medium
  crew: system
  status: backlog
dedupe: skip_if_open
```

## Touch points

- New: `crates/orbit-core/assets/auto_tasks/code-review-sweep.yaml`.
- `crates/orbit-core/src/auto_tasks/mod.rs`: add the `include_str!` entry to `DEFAULT_AUTO_TASK_FILES` (keep alphabetical order).
- `crates/orbit-core/src/auto_tasks/tests/shipped.rs`: add `code-review-sweep` to the required-names list in `shipped_defaults_all_parse_and_are_disabled`.
- `crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md`: "The three seeded definitions" section becomes four; add the bullet. Keep `plugin/skills/orbit/references/setup/auto-tasks.md` byte-identical (the trees are validated as a sync pair) — unless ORB-10995 has already deleted the plugin tree, in which case skip it.
- Verified non-issues: `bootstrap/init.rs` and `workspace/tests/init.rs` check qa-sweep representatively (no exhaustive set assertion); orbit-web `qa-sweep` hits are tag-parsing test fixtures only.

## Out of scope

- Enabling the definition anywhere (defaults ship disabled; the orbit workspace can opt in separately via `orbit auto-task toggle`).
- Scheduler or cursor machinery changes — the window cursor is carried in task execution summaries by contract, not new code.

### Acceptance Criteria

- `code-review-sweep` ships as an embedded default: seeded by `orbit workspace init`, disabled, crew `system`, parsing through the standard schema.
- `shipped_defaults_all_parse_and_are_disabled` covers it and the auto-tasks skill reference documents it alongside the existing three.
- The template is workspace-generic: no repo-specific branch names, file names, or conventions.
- The plugin skills copy stays byte-identical to the core assets copy if the plugin tree still exists.
- make ci-fast and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Shipped `code-review-sweep` as the fourth embedded default auto-task.

## Changes

- **New** `crates/orbit-core/assets/auto_tasks/code-review-sweep.yaml` - `enabled: false`, `crew: system`, `dedupe: skip_if_open`, `status: backlog`, cron `40 */6 * * *`, tags `code-review-sweep` + `no-diff-expected`. Body follows the security-review house style: a `## Rules and command surfaces` section naming the exact `orbit tool run orbit.task.list|show|search|add` surfaces, then window derivation from the previous sweep's cursor (first run seeds HEAD and stops), white-box review of the whole window, verify-before-filing plus dedupe against open `code-review` tasks, and mandatory cursor recording.
- `crates/orbit-core/src/auto_tasks/mod.rs` - added the `include_str!` entry to `DEFAULT_AUTO_TASK_FILES`, first in alphabetical order.
- `crates/orbit-core/src/auto_tasks/tests/shipped.rs` - added `code-review-sweep` to the required-names list in `shipped_defaults_all_parse_and_are_disabled`, plus a focused `code_review_sweep_default_is_portable_cursor_driven_and_inert` test matching the per-default pattern used by the other three (schedule, dedupe, crew, status, tags, no machine-specific paths, no repo-specific strings such as `agent-main` / `ORB-` / `CLAUDE.md` / `make ci`, required body phrases, tool-surface-only commands, and the two cursor/evidence acceptance criteria).
- `crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md` - "The three seeded definitions" became "The four seeded definitions" ("seeds all four") with a `code-review-sweep` bullet describing the cursor-carried review window.

## Scope notes

- The plugin skills copy was skipped because ORB-10995 already deleted the entire `plugin/` tree (verified absent in this checkout), so there is no sync pair left to keep byte-identical.
- No unlisted files were changed; every edit lands inside the task's declared `context_files`.
- No scheduler or cursor machinery was touched - the window cursor is carried in task execution summaries by contract, as scoped.
- `bootstrap/init.rs` and `application/artifact_health.rs` consume `DEFAULT_AUTO_TASK_FILES` dynamically (`.len()` / iteration), so the fourth entry required no change there; confirmed by the full lib test run.

## Validation

- `cargo test -p orbit-core --lib` - 772 passed, 0 failed (includes all 39 `auto_tasks::*` tests and the new one).
- `make ci-fast` - exit 0 (fmt-check + guardrails, including `check-embedded-asset-portability.py`).
- `make ci-lint` - exit 0 (workspace-wide all-target clippy, warnings denied).

No blockers. Filed friction F2026-08-124 for the worktree workspace-resolution gotcha described below (a duplicate copy, F2026-08-125, was filed by an accidental re-run and has been resolved against the canonical record).

## Note for the human

From inside the job worktree (`.orbit/state/worktrees/orbit-jrun-*`), plain `orbit tool run orbit.task.update` returns `task_not_found` for this task even though `orbit.task.show` finds it, and `orbit task list --status in-progress` returns nothing - CWD there resolves to an empty workspace scope. The Bridge MCP fallback was also unavailable (`BRIDGE_EDGE_TOKEN` not configured). This summary was persisted with the global selector: `orbit --workspace ws_orbit tool run orbit.task.update`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10997-6a8a8730`
- Behind base: 0
- Ahead of base: 1