### PR TITLE
npm pack of @orbit-tools/cli omits LICENSE (symlink points outside the package)

### DIFF
--- a/npm/LICENSE
+++ b/npm/LICENSE
@@ -1,1 +1,23 @@
-../LICENSE.md
+MIT License
+
+Copyright (c) 2026 Orbit contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Prii


### PR DESCRIPTION
## Task

[ORB-11005](https://orbit-cli.com/tasks/ORB-11005) — npm pack of @orbit-tools/cli omits LICENSE (symlink points outside the package)

### Description

## Problem
After ORB-10995 relocated the npm proxy from `plugin/npm/` to `npm/`, `npm pack` of `@orbit-tools/cli` still ships **without a LICENSE file**. `npm/LICENSE` is a symlink to `../LICENSE.md` (outside the package directory). npm 11 silently drops that symlink rather than packing the target contents.

This is on the user-facing publish path that the relocation and the ORB-10989 version-assertion smoke are meant to protect. The next release from this tree would publish a tarball with no LICENSE, even though `package.json` declares `"license": "MIT"` and lists `"LICENSE"` in `files`.

## Why It Matters
npm consumers and registry license scanners expect the LICENSE file named in `files` to be inside the tarball. The field alone is not a substitute. Release-check and `scripts/smoke-npm-install.sh` do not catch the omission.

## Evidence (ORB-11002 QA, 2026-08-23)
Checkout: `fb2dcd9d` (worktree `orbit-jrun-20260823-0603-2`).
Relevant commit: `a894f6f4` [ORB-10995] (`{plugin/npm => npm}/LICENSE` remains mode `120000`).

```
$ ls -l npm/LICENSE
lrwxrwxrwx npm/LICENSE -> ../LICENSE.md

$ npm pack --pack-destination /tmp/pack
npm notice Tarball Contents
  README.md
  bin/orbit.js
  package.json
  release-signing.pub
  scripts/install-binary.js
npm notice total files: 5
```

No `LICENSE` entry. Confirmed with npm 11.16.0 / node 24.18.0.

The pre-move `plugin/npm/LICENSE` was already a symlink (`../../LICENSE.md`), so 0.14.0 may already have shipped this way; the relocated tree preserves the defect for the next tag.

## Reproduction
1. From this checkout: `cd npm && npm pack --pack-destination /tmp/orbit-npm-pack`.
2. `tar -tzf /tmp/orbit-npm-pack/orbit-tools-cli-0.14.0.tgz`.
3. Observe five files and no `package/LICENSE`.

## Expected
The packed tarball contains a regular `package/LICENSE` file whose contents match the repo `LICENSE.md` (MIT). `npm pack` (or `scripts/release-check.sh`) fails if it is missing.

## Actual
`npm pack` succeeds and omits LICENSE because the `files` entry is an out-of-package symlink.

## Suggested fix
Replace `npm/LICENSE` with a regular file (copy of `LICENSE.md`), or add a release-check assertion that `npm pack --dry-run` includes `LICENSE`. Do not leave a symlink that points outside `npm/`.

### Acceptance Criteria

- `cd npm && npm pack --dry-run` (or an equivalent release-check) lists a LICENSE file in the tarball.
- `npm/LICENSE` is a regular file inside the package directory, not a symlink to a path outside `npm/`.
- A packed tarball extracted to a temp dir contains `package/LICENSE` whose contents match the repository MIT license text.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced `npm/LICENSE`'s out-of-package symlink with a regular file containing the repository `LICENSE.md` contents.
- No other repository files changed.
Validation:
- Confirmed `npm/LICENSE` is regular, not a symlink, and byte-identical to `LICENSE.md`.
- `npm pack --dry-run` passed with npm 11.16.0/node 24.18.0 and listed `LICENSE` in the six-file tarball contents.
- Packed to a temporary directory, extracted, and confirmed `package/LICENSE` is regular and byte-identical to `LICENSE.md`.
- `git diff --check` passed.
Assessment: The npm package now includes the required in-package MIT license file and satisfies all acceptance criteria.
Deviations from original plan: npm was not on PATH, so validation used the installed npm binary by absolute path with an isolated temporary cache.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11005-6a8a9021`
- Behind base: 0
- Ahead of base: 1