### PR TITLE
Prepare v0.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.15.0
+
+### Breaking Changes
+
+- **Agent plugin channel retired**: Orbit no longer ships Claude, Codex, or Cursor agent plugins; install and use the standalone Orbit CLI instead. ([ORB-10995])
+
+### Highlights
+
+- **Built-in code-review sweep**: fresh workspaces include a disabled code-review auto-task that teams can enable to schedule recurring reviews. ([ORB-10997])
+- **Reliable concurrent task updates**: task writes now coordinate safely across simultaneous CLI, MCP, and dashboard activity. ([ORB-10988])
+- **Simpler binary-first onboarding**: the Quick Start now leads with installing the standalone CLI and brings your existing repository conventions into Orbit. ([ORB-10992])
+
 ## 0.14.0
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbit-agent"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cmd"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-common"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-config"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "orbit-common",
  "orbit-types",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "croner",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-engine"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-exec"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "libc",
  "orbit-common",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-mcp"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-policy"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-registry"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "hostname",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-search"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-store"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-tools"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-types"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-web"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 license = "MIT"
 # MSRV [ORB-10010]: edition 2024 requires >= 1.85; the highest `rust-version`

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbit-tools/cli",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "npm proxy for the Orbit CLI. Downloads the matching native binary from GitHub Releases on install and forwards all invocations.",
   "bin": {
     "orbit": "bin/orbit.js"


### PR DESCRIPTION
## Task

[ORB-11004](https://orbit-cli.com/tasks/ORB-11004) — Prepare v0.15.0 release

### Description

Prepare the candidate v0.15.0 release as a reviewable PR targeting agent-main.

The report-first survey is complete. Daniel approved the breaking-change classification for ORB-10995 and explicitly requested that this task be carried to PR on 2026-08-23. Implement the approved release-preparation diff according to RELEASING.md:

- Add the consumer-facing 0.15.0 CHANGELOG section. Include ORB-10995 under Breaking Changes and select 3–6 concise user-facing highlights from the surveyed v0.14.0..HEAD range.
- Bump the workspace Cargo version and npm package version to 0.15.0, refreshing Cargo.lock with no third-party dependency drift.
- Keep scripts/smoke-npm-install.sh aligned with the current CLI if the surveyed cycle requires it; otherwise leave it unchanged and validate its version assertion.
- Run the repository-required release and PR validations.
- Commit, push the task branch, and open the task PR against agent-main through the PR pipeline.

This task stops at an open PR. Do not create or push v0.15.0, publish Cargo/npm/GitHub/Homebrew artifacts, promote agent-main to main, merge any PR, or mark the release complete. Those remain later human-controlled steps.

### Acceptance Criteria

- Cargo.toml, Cargo.lock, and npm/package.json report version 0.15.0; Cargo.lock is refreshed without third-party dependency drift.
- CHANGELOG.md contains a new 0.15.0 section with ORB-10995 under Breaking Changes and 3–6 concise, consumer-facing Highlights drawn from the surveyed v0.14.0..HEAD range.
- The npm-install smoke still drives this cycle's CLI non-interactively and its dry-run version assertion passes; make build, make ci-fast, and make ci-lint pass.
- A task-scoped PR is opened against agent-main. Stop before tag creation/push, package or release publication, agent-main-to-main promotion, PR merge, or final release completion.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added v0.15.0 release notes: the approved ORB-10995 breaking change and three consumer-facing highlights from v0.14.0..HEAD.
- Bumped the Cargo workspace and npm package to 0.15.0; cargo update --workspace refreshed only the 16 Orbit workspace package entries in Cargo.lock.
- Reviewed the npm-install smoke contract; its init, workspace init, and MCP serve commands remain aligned, so scripts/smoke-npm-install.sh is unchanged.
Assessment: Release-preparation diff is scoped to the five release files and ready for the task PR pipeline.
Validation:
- ./scripts/smoke-npm-install.sh --dry-run-version-assertion (pass)
- make build (pass)
- make ci-fast (pass)
- make ci-lint (pass)
- git diff --check (pass)
Notes:
- make release-check correctly reports that untagged 0.15.0 differs from the latest GitHub release tag v0.14.0; it is not applicable until release publication.
- No friction report: no qualifying incident, recurrence, or non-obvious gotcha.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11004-6a8a966f`
- Behind base: 0
- Ahead of base: 1