### PR TITLE
Design a federated multi-host workspace MCP surface

### DIFF
--- a/docs/design/host-registry/3_vision.md
+++ b/docs/design/host-registry/3_vision.md
@@ -3,7 +3,7 @@ summary: "Host Registry — Vision"
 type: design
 title: "Host Registry — Vision"
 owner: codex
-last_updated: 2026-08-15
+last_updated: 2026-08-23
 last_validated: 2026-08-15
 status: Accepted
 feature: host-registry
@@ -11,21 +11,72 @@ doc_role: vision
 tags: [host-registry, machine-identity, workspace-catalog]
 paths: ["crates/orbit-common/src/types/host.rs", "crates/orbit-common/src/types/workspace.rs", "crates/orbit-registry/src/host_identity.rs", "crates/orbit-registry/src/workspace_registry/**", "crates/orbit-cmd/src/registry_runtime.rs"]
 related_features: [host-registry, mcp-session-context, remote-access]
-related_artifacts: []
+related_artifacts: [ORB-11008]
 ---
 
 # Host Registry — Vision
 
-Keep the registry small: one durable local machine identity, one validated local workspace catalog, and one shared composition seam for opening Core runtimes.
+Keep the registry small: one durable local machine identity, one validated local
+workspace catalog, and one shared composition seam for opening Core runtimes.
+The federated MCP surface below is a proposed design, not current v1 behavior
+([ORB-11008] documents that proposal).
 
-## Stable direction
+## Current v1 boundary
 
-- Stable IDs remain logical and transport-free.
-- Logical workspace records remain separate from machine-local checkout paths.
-- Registry owns schema and persistence; orbit-cmd owns runtime composition.
-- CLI, Web and MCP reuse those seams rather than implementing their own lookup rules.
-- Malformed or future durable state fails closed without being overwritten.
-- Remote transport reaches the accepting server; it does not make local registry state authoritative for another machine.
+V1 exposes machine-local MCP discovery and resolves every workspace-scoped tool
+on the accepting machine. Direct SSH stdio reaches a chosen remote server, but
+there is no federation gateway, cross-host workspace list, or host-qualified
+workspace selector. The local host registry remains neither a fleet inventory
+nor a routing authority for another machine.
+
+## Proposed federated workspace MCP surface
+
+A future gateway may expose one Orbit MCP namespace to a caller while retaining
+one MCP server and one registry at each destination host. Its one aggregate
+discovery tool, `orbit_workspace_list`, returns every reachable workspace as a
+live descriptor:
+
+| Field | Meaning |
+|---|---|
+| `selector` | An opaque, host-qualified route token, for example `orbit-linux/ws_orbit` |
+| `host` | The destination host's display identity |
+| `machine_id` | The destination host's stable machine identity |
+| `health` | The gateway's current reachability and advertised workspace health projection |
+| `capabilities` | The operations the destination currently advertises for that workspace |
+
+The selector is addressing data, not a path, URL, logical workspace ID, or
+authorization credential. Every workspace-scoped Orbit tool accepts it and the
+gateway routes that call to the encoded destination. Callers choose a workspace
+without first choosing a host, but the gateway must not reinterpret the token
+against its own local catalog.
+
+Routing fails explicitly for an unknown selector, an unreachable or unhealthy
+host, an ambiguous destination, or a stale route whose destination no longer
+advertises that workspace. It must not fall back to a local workspace, another
+host with a matching workspace ID, a default workspace, or a cached host-local
+runtime.
+
+## Authority and repository bindings
+
+Routing changes where a call is delivered; it does not move its authority. The
+destination host remains authoritative for its runs, logs, scheduler state, and
+mutations. `orbit_workspace_list` is an aggregate of live descriptors, not an
+aggregate task or store query.
+
+For one repository, one declared control-plane authority owns the coordination
+store. Additional checkouts on other hosts are execution bindings to that
+authority. They do not become competing task stores merely because the
+federated surface can route to them. The authority rule belongs to the runtime
+and coordination boundary, while the gateway only preserves the selected
+destination.
+
+## Explicit non-goals
+
+This proposal excludes task or store replication, synchronization, quorum
+election, competing authorities, implicit failover, and silent merging of
+host-local state. A disconnected or failed host therefore removes the affected
+route from useful service; another host cannot answer in its place unless a
+separate, explicit authority design says so.
 
 ## Questions that require evidence
 
@@ -45,6 +96,14 @@ Identity-bearing legacy catalogs with no explicit checkout role fail safely but 
 
 If Core later authorizes remote calls, it needs an authenticated principal or grant separate from machine_id, host_id, caller IP and SSH audit labels. Existing registry and session fields must not be promoted into credentials by implication.
 
+### Federated routing contract
+
+The gateway needs a transport-authentication and capability-advertisement
+contract before it can expose live descriptors. That contract must define
+health freshness, selector expiry, error identities, and how a destination
+verifies that the routed selector still names its local workspace without
+turning selector possession into authorization.
+
 ### Checkoutless operations
 
 If a future operation truly needs no checkout, define a narrow server-owned API and persistence contract for it. Do not weaken RegisteredRuntimeFactory or make the SSH proxy perform placement and workspace logic.
@@ -52,3 +111,9 @@ If a future operation truly needs no checkout, define a narrow server-owned API 
 ### Schema evolution
 
 New host or catalog schema versions need explicit forward migration, crash-safe writes, future-version rejection tests and rollback classification.
+
+## Task References
+
+- [ORB-11008] proposes the federated multi-host workspace MCP surface and its authority boundary.
+
+Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/host-registry/4_decisions.md
+++ b/docs/design/host-registry/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Host Registry — Decisions"
 type: design
 title: "Host Registry — Decisions"
 owner: codex
-last_updated: 2026-08-15
+last_updated: 2026-08-23
 last_validated: 2026-08-15
 status: Accepted
 feature: host-registry
@@ -11,12 +11,13 @@ doc_role: decisions
 tags: [host-registry, machine-identity, workspace-catalog, runtime-composition]
 paths: ["crates/orbit-common/src/types/host.rs", "crates/orbit-common/src/types/workspace.rs", "crates/orbit-registry/src/host_identity.rs", "crates/orbit-registry/src/workspace_registry/**", "crates/orbit-cmd/src/registry_runtime.rs", "crates/orbit-cli/src/command/host/**", "crates/orbit-cli/src/command/workspace/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-web/src/**"]
 related_features: [host-registry, mcp-session-context, remote-access]
-related_artifacts: []
+related_artifacts: [ORB-11008]
 ---
 
 # Host Registry — Decisions
 
-These choices describe current code.
+These choices describe current code and a separately marked forward-looking
+federated-routing constraint.
 
 ## Shared primitives, owned persistence, separate composition
 
@@ -97,3 +98,33 @@ These choices describe current code.
 **Decision.** Carry raw MCP over direct SSH stdio. The remote CLI server loads its own registry and uses RegisteredRuntimeFactory for each workspace-scoped call.
 
 **Consequences.** The machine holding the data remains authoritative and the proxy stays checkout-free. Cost: checkoutless or cross-machine routing behavior must be added explicitly on the server if it is ever required.
+
+## Federated routing is not a replica protocol
+
+**Recorded:** 2026-08-23 · [ORB-11008] proposes the federated multi-host workspace MCP surface.
+
+**Context.** A single MCP namespace can make several reachable hosts look like
+one workspace catalog. Without an authority rule, that presentation could be
+mistaken for a synchronized task store or turn multiple checkouts of one
+repository into competing control planes.
+
+**Decision.** A federated gateway may aggregate live workspace descriptors and
+route an opaque host-qualified selector to its destination, but it never owns
+or merges destination state. Every workspace-scoped call is delivered to the
+encoded host, which remains authoritative for its runs, logs, scheduler state,
+and mutations. For one repository, one declared control-plane authority owns
+coordination; other hosts are execution bindings. Unknown, unreachable,
+unhealthy, ambiguous, and stale routes fail explicitly. This rule applies to
+future federation work as well as the first gateway implementation.
+
+**Consequences.** The design permits one caller-facing MCP namespace without
+introducing task/store replication, synchronization, quorum election,
+competing authorities, implicit failover, or silent host-local merges. Cost:
+availability is bounded by the chosen destination, so callers must handle
+visible routing failures instead of receiving a transparent substitute result.
+
+## Task References
+
+- [ORB-11008] proposes the federated multi-host workspace MCP surface and routing boundary.
+
+Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/remote-access/3_vision.md
+++ b/docs/design/remote-access/3_vision.md
@@ -1,7 +1,7 @@
 ---
 title: "Remote Access — Vision"
 owner: codex
-last_updated: 2026-08-15
+last_updated: 2026-08-23
 last_validated: 2026-08-15
 status: Accepted
 feature: remote-access
@@ -11,12 +11,17 @@ summary: "Evolution gates for remote Orbit Web access without weakening the loop
 tags: [remote-access, orbit-web, ssh]
 paths: ["crates/orbit-web/**", "crates/orbit-registry/src/workspace_registry/**", "crates/orbit-cmd/src/registry_runtime.rs"]
 related_features: [remote-access, user-interface, host-registry]
-related_artifacts: []
+related_artifacts: [ORB-11008]
 ---
 
 # Remote Access — Vision
 
 Remote access should stay a thin way to reach a machine's existing Orbit Web state. It should not become an accidental synchronization service or an unauthenticated network daemon.
+
+The federated MCP workspace surface is a proposed companion design, not a
+change to the current Web or direct-SSH MCP behavior ([ORB-11008] documents
+the proposal). It may aggregate live routing descriptors, but it does not make
+Remote Access a replication feature.
 
 ## Evolution gates
 
@@ -30,7 +35,22 @@ Background reconnect, tunnel multiplexing, or several remote machines in one bro
 
 ### Cross-machine state
 
-A multi-machine aggregate or offline view is a data-replication problem, not an extension of DashboardState. It needs an authoritative store, conflict behavior, and write semantics of its own.
+A multi-machine aggregate of live workspace descriptors can be a routing
+feature when every descriptor identifies its destination host and every
+workspace-scoped call is delivered there. It must report unknown, unreachable,
+unhealthy, ambiguous, and stale routes as failures; it cannot fall back to a
+local or matching remote workspace. An offline view, a merged task result, or
+any synchronized state remains a data-replication problem with an authoritative
+store, conflict behavior, and write semantics of its own.
+
+### Federated MCP authority
+
+The proposed gateway may present one namespace and `orbit_workspace_list`, but
+the selected destination host remains authoritative for runs, logs, scheduler
+state, and mutations. For a repository with several checkouts, one declared
+control-plane authority owns coordination and additional hosts are execution
+bindings. The gateway must not introduce competing authorities, quorum
+election, implicit failover, or silent merging of host-local state.
 
 ### Performance
 
@@ -43,3 +63,9 @@ Measure registry parse cost, runtime-cache churn, and aggregate endpoint latency
 - The remote machine is authoritative for reads and writes served through its dashboard.
 - Registry snapshots select workspaces; orbit-cmd constructs registered runtimes; Core executes domain behavior.
 - Failed or stale workspace bindings are visible and isolated rather than silently redirected.
+
+## Task References
+
+- [ORB-11008] proposes federated MCP routing while preserving destination-host authority.
+
+Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-11008](https://orbit-cli.com/tasks/ORB-11008) — Design a federated multi-host workspace MCP surface

### Description

## Problem
Codex currently needs one duplicated Orbit MCP tool namespace per reachable host. Orbit should instead expose one workspace-aware surface that discovers and routes live workspaces across hosts without introducing replicated stores, quorum election, or competing control-plane authorities.

## Why It Matters
A unified surface reduces permanent tool/catalog surface and lets callers select a workspace without first selecting a host. The design must preserve the destination host as the authority for its host-local operational state and prevent a second checkout of the same repository from becoming an accidental competing task store.

## Constraints / Notes
- Document this as a proposed design, clearly separated from current v1 behavior.
- `orbit_workspace_list` returns all reachable workspaces with host, machine_id, health, and capabilities.
- Each result carries an opaque host-qualified selector such as `orbit-linux/ws_orbit`.
- Every workspace-scoped Orbit tool accepts that selector and routes internally.
- The destination host remains authoritative for runs, logs, scheduler state, and mutations.
- Multiple checkouts of one repository have one declared control-plane authority; additional hosts are execution bindings.
- Explicitly reject synchronization, replication, quorum election, implicit failover, and merged host-local stores from this feature.
- Reconcile existing host-registry and remote-access vision language so the corpus does not misclassify live federated routing as data replication.

### Acceptance Criteria

- The Orbit design corpus under docs/design describes one federated MCP namespace and an aggregate orbit_workspace_list result containing host, machine_id, health, capabilities, and an opaque host-qualified workspace selector.
- The design states that every workspace-scoped tool routes the opaque selector to its destination host, and defines unknown, unreachable, unhealthy, ambiguous, and stale-route behavior as explicit failures rather than fallback.
- The design preserves the destination host as authority for runs, logs, scheduler state, and mutations, and distinguishes one declared control-plane authority from additional execution bindings for the same repository.
- The design explicitly excludes task/store replication, synchronization, quorum election, competing authorities, implicit failover, and silent merging of host-local state.
- Current v1 behavior is clearly distinguished from the proposed feature, related host-registry and remote-access documents contain no contradiction, and the relevant task ID is cited per docs/design/CONVENTIONS.md.
- `make docs-index`, `make ci-fast`, and `make ci-lint` pass from the Orbit repository.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Documented the proposed single federated MCP namespace, `orbit_workspace_list` descriptor contract, opaque host-qualified routing, and explicit route failures in the host-registry vision.
- Recorded the standing authority rule: destination hosts own operational state; a repository has one declared control-plane authority and other checkouts are execution bindings.
- Reconciled remote-access vision language so live descriptor aggregation is routing, while synchronization, replication, quorum, failover, and host-local-state merging remain excluded.
- Added [ORB-11008] provenance and Task References to each changed design document.
Assessment: The proposal is explicitly separated from current v1 and gives routing, authority, and non-goal boundaries without changing runtime behavior.
Validation:
- make docs-index
- make ci-fast
- make ci-lint
Friction checkpoint: no qualifying friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11008-6a8b511b`
- Behind base: 0
- Ahead of base: 1