### PR TITLE
Turn federated MCP policy into an implementable design contract

### DIFF
--- a/docs/design/CONVENTIONS.md
+++ b/docs/design/CONVENTIONS.md
@@ -1,7 +1,7 @@
 ---
 title: Design Doc Conventions
 owner: daniel
-last_updated: 2026-08-15
+last_updated: 2026-08-23
 last_validated: 2026-08-15
 status: Accepted
 ---
@@ -213,6 +213,7 @@ Retired features stay listed with their `_archive/` path as a historical record.
 | Agent Families | [docs/design/agent-families/](./agent-families/) | grok |
 | Auditability | [docs/design/auditability/](./auditability/) | codex |
 | Executors | [docs/design/executors/](./executors/) | claude |
+| Federated MCP | [docs/design/federated-mcp/](./federated-mcp/) | grok |
 | Global Store Consolidation | [docs/design/_archive/global-store-consolidation/](./_archive/global-store-consolidation/) | codex |
 | Host Registry | [docs/design/host-registry/](./host-registry/) | claude |
 | Knowledge graph | [docs/design/_archive/knowledge-graph/](./_archive/knowledge-graph/) | claude |

--- a/docs/design/federated-mcp/1_overview.md
+++ b/docs/design/federated-mcp/1_overview.md
@@ -1,0 +1,53 @@
+---
+title: Federated MCP — Overview
+owner: grok
+last_updated: 2026-08-23
+last_validated: 2026-08-23
+status: Draft
+feature: federated-mcp
+doc_role: overview
+type: design
+summary: Proposed mux that presents one MCP namespace over operator-configured destinations, keyed by machine_id, without becoming a fleet registry.
+tags: [federated-mcp, mcp, host-registry, multi-host]
+paths: ["crates/orbit-mcp/**", "crates/orbit-registry/**", "crates/orbit-core/**"]
+related_features: [federated-mcp, host-registry, mcp-bridge, remote-access, mcp-session-context]
+related_artifacts: [ORB-11009, ORB-11008]
+---
+
+# Federated MCP — Overview
+
+Federated MCP is a proposed caller-facing mux: one Orbit MCP namespace in front of operator-configured destinations (MCP or SSH remotes already chosen by the operator). It is not current v1 behavior, not a host-registry evolution, and not a fleet inventory. Direct SSH stdio to one chosen host remains the implemented remote path. [ORB-11008] recorded the policy; this folder is the implementable contract from [ORB-11009].
+
+## 1. Motivation
+
+A later implementation will otherwise invent a second ownership model, key selectors on renameable `host_id`, or ship a relay that mcp-bridge still forbids. The five-point policy in [ORB-11008] is still right; it was not a routing contract. This feature names the mux, the selector, the capability/authority split, the list schema, and the mcp-bridge exception so implementation cannot guess them.
+
+## 2. Core Concepts
+
+- **Mux, not registry.** Destinations are operator-configured remotes. The gateway does not discover owners, register a fleet, or reinterpret a selector against its own local catalog.
+- **Host-qualified selector.** Opaque addressing token keyed by stable `machine_id` (`hm_…`), for example `hm_<id>/ws_orbit`. Not a path, URL, authorization credential, or renameable `host_id`.
+- **Capabilities vs authority.** `control_plane` and `execute` map onto existing host-registry owner and replica checkout roles. The destination Core refuses the other class; the gateway does not rewrite or fail over.
+- **Split mutations.** The destination host is authoritative for runs, logs, and scheduler state. The declared control-plane authority is authoritative for task issuance and the coordination store.
+- **Live descriptors, fail closed.** Federated `orbit_workspace_list` is session-unbound and includes unreachable hosts. Unknown, unreachable, unhealthy, ambiguous, and stale routes fail explicitly.
+
+Full definitions live in [references/glossary.md](./references/glossary.md). The prescriptive contract is [specs/federated-workspace-mcp.md](./specs/federated-workspace-mcp.md).
+
+## 3. At a Glance
+
+| Concern | File | Task |
+|---------|------|------|
+| Mux vs fleet registry; selector identity; list schema; fail-closed errors | [specs/federated-workspace-mcp.md](./specs/federated-workspace-mcp.md) | [ORB-11009] |
+| Proposed mechanism (not shipped) | [2_design.md](./2_design.md) | [ORB-11009] |
+| Open questions (auth, expiry, freshness, cloud store) | [3_vision.md](./3_vision.md) | [ORB-11009] |
+| Standing rules and rejected alternatives | [4_decisions.md](./4_decisions.md) | [ORB-11009] |
+| Prior policy (five-point list) | [host-registry/3_vision.md](../host-registry/3_vision.md) (cross-link only) | [ORB-11008] |
+| v1 no-relay / byte-transparent current behavior | [mcp-bridge/2_design.md](../mcp-bridge/2_design.md) | — |
+| Federated-namespace exception to that v1 rule | [mcp-bridge/3_vision.md](../mcp-bridge/3_vision.md) §5 | [ORB-11009] |
+| Owner vs replica catalog roles | [host-registry/2_design.md](../host-registry/2_design.md) | — |
+
+## Task References
+
+- [ORB-11008] — recorded the federated multi-host MCP policy inside host-registry and remote-access vision
+- [ORB-11009] — turns that policy into this implementable design contract
+
+> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/federated-mcp/2_design.md
+++ b/docs/design/federated-mcp/2_design.md
@@ -1,0 +1,115 @@
+---
+title: Federated MCP — Design
+owner: grok
+last_updated: 2026-08-23
+last_validated: 2026-08-23
+status: Draft
+feature: federated-mcp
+doc_role: design
+type: design
+summary: Proposed (not shipped) federated MCP mux, selector, capability split, list schema, and fail-closed routing. V1 current behavior stays in mcp-bridge.
+tags: [federated-mcp, mcp, host-registry, multi-host]
+paths: ["crates/orbit-mcp/**", "crates/orbit-registry/**", "crates/orbit-core/**"]
+related_features: [federated-mcp, host-registry, mcp-bridge, remote-access, mcp-session-context]
+related_artifacts: [ORB-11009, ORB-11008]
+---
+
+# Federated MCP — Design
+
+This document describes the **proposed** federated MCP surface. It is not implemented. Current v1 behavior — one chosen destination, byte-transparent direct SSH stdio, no Orbit process relaying onward — remains [mcp-bridge 2_design.md](../mcp-bridge/2_design.md). Do not read the sections below as live runtime.
+
+The prescriptive invariants live in [specs/federated-workspace-mcp.md](./specs/federated-workspace-mcp.md). This file explains how those pieces fit.
+
+## 1. Operator-configured destinations
+
+The gateway is a mux in front of destinations the operator already configured (MCP remotes or SSH stdio targets). It does not:
+
+- grow host-registry into a fleet inventory;
+- auto-discover the owner checkout of a repository;
+- place work, elect a leader, or pick a healthy substitute.
+
+Direct SSH stdio to one chosen host remains the v1 remote path and is unchanged by this proposal. A caller that does not use the federated namespace never hits the mux.
+
+## 2. Host-qualified selector
+
+Every workspace-scoped federated call carries an opaque host-qualified selector. The token is addressing data. Callers treat it as opaque. The gateway must not reinterpret it against its own local catalog.
+
+The stable key is `machine_id` (`hm_…`), not renameable `host_id`. Example form: `hm_<id>/ws_orbit`. A display host name such as `orbit-linux/ws_orbit` is not a valid selector.
+
+The destination is ambiguous when two configured destinations share a `machine_id`, or when the token is not uniquely host-qualified (a bare `ws_*` is not enough). Ambiguous tokens fail; they are not disambiguated by local catalog, cwd, or session default.
+
+## 3. Capabilities mapped onto owner and replica
+
+This feature does not invent a second ownership model. Host-registry already distinguishes:
+
+- **owner checkout** — local checkout whose logical `owner_machine_id` equals this machine;
+- **replica checkout** — local checkout that names another machine as the logical owner.
+
+Those roles map onto capability classes:
+
+| Catalog role | Capability class | Meaning |
+|---|---|---|
+| Owner checkout | `control_plane` (and typically also `execute`) | Control-plane authority for that workspace's coordination; the canonical checkout can also run |
+| Replica checkout | `execute` | Execution binding only |
+
+A destination Core that does not hold a class **refuses** tools of that class with a named error (`capability_refused`). The gateway may advertise the destination's capabilities; it does not enforce by rewriting the destination or failing over to the owner.
+
+If a caller routes `orbit_task_add` to an execution-binding host, that destination refuses. The gateway must not silently send the call to the owner.
+
+## 4. Split authority — "mutations" is not one blob
+
+Routing changes where a call is delivered; it does not move authority.
+
+- **Destination host** is authoritative for **runs, logs, and scheduler state** on that host.
+- **Declared control-plane authority** is authoritative for **task issuance and the coordination store**. That store may later be cloud-offloaded; that is an open question, not a hidden replica protocol.
+
+Do not lump those as one "mutations" blob. A replica can accept execute-class work against its own run/log/scheduler state and must still refuse control-plane task issuance.
+
+`orbit_workspace_list` (federated) is an aggregate of live descriptors, not an aggregate task or store query.
+
+## 5. Federated workspace list
+
+Federated `orbit_workspace_list` is **session-unbound**: it must not require a workspace selector. The result is **additive** on today's v1 list fields (`id`, `name`, `ship_mode`, `owner_machine_id`, `git_remote`, `base_branch`, `status`, timestamps) plus:
+
+- `selector` — opaque host-qualified route token;
+- `host` — destination display identity (`host_id`, renameable, display only);
+- `machine_id` — destination stable identity;
+- host-reachability — SSH/MCP reachability of the configured destination;
+- workspace checkout-health — repo-root presence at that destination, the same narrow rule as host-registry;
+- `capabilities` — classes the destination currently advertises for that workspace.
+
+Do not overload one `health` field with both SSH reachability and repo-root presence. A down or unreachable host is **included** with an explicit unreachable/unhealthy projection, not omitted. Omission makes every later call a stale-route surprise.
+
+## 6. Fail-closed routing
+
+The gateway delivers a workspace-scoped call to the destination encoded in the selector. It fails explicitly for:
+
+- unknown selector;
+- unreachable destination;
+- unhealthy checkout;
+- ambiguous destination;
+- stale route (destination no longer advertises that workspace).
+
+It must not fall back to a local workspace, another host with a matching `ws_*`, a default workspace, or a cached host-local runtime.
+
+`tool_not_on_this_host` is a distinct error from `unknown_selector`: the destination is identified, but the tool is not advertised there.
+
+## 7. Relationship to v1 MCP
+
+v1 local stdio, direct SSH stdio, and `orbit mcp listen` stay as specified in mcp-bridge. The mux is an explicit exception to v1 "byte-transparent / no Orbit process relays onward", **for the federated namespace only**. Automatic owner discovery, replication, relays-as-product, and fleet placement stay out. See [mcp-bridge 3_vision.md §5](../mcp-bridge/3_vision.md).
+
+## 8. Concerns & Honest Limitations
+
+- This design is not shipped. No runtime, tool schema, or conformance YAML in this change implements it.
+- Availability is bounded by the chosen destination. Callers must handle visible routing failures; there is no transparent substitute result.
+- Including unreachable hosts makes the list honest and larger; clients must read reachability rather than treating presence as liveness.
+- Capability advertisement can lag destination Core. The destination refuse is the correctness boundary; the gateway is not a second authorization layer.
+- Transport authentication, selector expiry, health freshness, and cloud coordination-store details are deliberately unresolved. See [3_vision.md](./3_vision.md).
+- Mixed Orbit versions across destinations can advertise different surfaces; `tool_not_on_this_host` and `capability_refused` must remain distinguishable from "the mux is confused."
+
+## Task References
+
+- [ORB-11008] — recorded the federated multi-host MCP policy
+- [ORB-11009] — specified this proposed mechanism as the implementable contract
+
+> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/federated-mcp/3_vision.md
+++ b/docs/design/federated-mcp/3_vision.md
@@ -1,0 +1,71 @@
+---
+title: Federated MCP — Vision
+owner: grok
+last_updated: 2026-08-23
+last_validated: 2026-08-23
+status: Draft
+feature: federated-mcp
+doc_role: vision
+type: design
+summary: Open questions for the proposed federated MCP mux: transport authentication, selector expiry, health freshness, and cloud coordination-store details.
+tags: [federated-mcp, mcp, host-registry, multi-host]
+paths: ["crates/orbit-mcp/**", "crates/orbit-registry/**", "crates/orbit-core/**"]
+related_features: [federated-mcp, host-registry, mcp-bridge, remote-access, mcp-session-context]
+related_artifacts: [ORB-11009, ORB-11008]
+---
+
+# Federated MCP — Vision
+
+Forward-looking only. The contract in [specs/federated-workspace-mcp.md](./specs/federated-workspace-mcp.md) is proposed and not shipped. These questions must not be fake-resolved in the spec; an implementation task answers them with evidence.
+
+## 1. Open Questions
+
+1. **Transport authentication.** What authenticated principal does a destination Core receive on a mux-forwarded call? Selector possession is not authorization. Existing registry and session fields (`machine_id`, `host_id`, `caller_machine_id`, `caller_ip`, SSH audit labels) must not be promoted into credentials by implication.
+2. **Selector expiry.** Does a host-qualified selector remain valid across destination catalog edits, host re-init, and mux restarts, or does it expire? If it expires, what is the caller-visible error, and how does that differ from `stale_route`?
+3. **Health freshness.** How old may host-reachability and checkout-health be when listed? Is the list a live probe, a cached projection with explicit freshness, or a last-known snapshot for unreachable hosts? The spec requires including unreachable hosts; it does not yet define probe cadence or staleness thresholds.
+4. **Cloud coordination-store details.** The declared control-plane authority may later offload the coordination store. What is the persistence contract, how do execution-binding hosts refer to it, and how does destination Core still refuse task issuance locally without implying replication?
+
+## 2. Prior Work
+
+### Policy recorded in host-registry / remote-access
+
+[ORB-11008] wrote the five-point federated policy (one namespace, live descriptors, fail-closed routing, destination authority, no replica protocol) into host-registry and remote-access vision. That write-up is superseded as a contract home; those docs now cross-link here.
+
+### Host-registry catalog roles
+
+Owner vs replica checkouts, `machine_id` vs `host_id`, and checkout-health as repo-root presence are live v1 catalog rules. This feature maps new nouns onto those roles instead of creating a parallel ownership vocabulary. See [host-registry 2_design.md](../host-registry/2_design.md).
+
+### mcp-bridge v1
+
+v1 is one chosen destination, byte-transparent direct SSH stdio, and no Orbit process relaying onward. Current behavior stays in [mcp-bridge 2_design.md](../mcp-bridge/2_design.md). [mcp-bridge 3_vision.md §5](../mcp-bridge/3_vision.md) now admits this mux as a federated-namespace-only exception and still excludes automatic owner discovery, replication, relays-as-product, and fleet placement.
+
+### Remote access
+
+Web SSH local-forward remains a different surface. Federated MCP must not reuse the Web tunnel, loopback dashboard, or attach/spawn lifecycle. See [remote-access](../remote-access/1_overview.md).
+
+## 3. What May Be Distinctive
+
+Nothing in the mux topology is novel: it is a configured reverse-proxy in front of existing MCP/SSH destinations. What may be distinctive for Orbit is refusing to turn that mux into a fleet product — selectors keyed on stable machine identity, capabilities mapped onto owner/replica, mutations split rather than blobbed, unreachable hosts listed rather than dropped, and no implicit failover to the owner.
+
+## 4. References
+
+**Orbit-internal**
+
+- [2_design.md](./2_design.md)
+- [specs/federated-workspace-mcp.md](./specs/federated-workspace-mcp.md)
+- [host-registry 2_design.md](../host-registry/2_design.md)
+- [mcp-bridge 2_design.md](../mcp-bridge/2_design.md)
+- [mcp-bridge 3_vision.md](../mcp-bridge/3_vision.md)
+- [mcp-session-context 3_vision.md](../mcp-session-context/3_vision.md)
+- [remote-access 3_vision.md](../remote-access/3_vision.md)
+
+**External**
+
+- Model Context Protocol — stdio transport and `tools/call` dispatch (the mux still speaks MCP; it is not a new RPC).
+
+## Task References
+
+- [ORB-11008] — recorded the federated multi-host MCP policy
+- [ORB-11009] — opened this vision folder as the contract home and left the questions above unresolved
+
+> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/federated-mcp/4_decisions.md
+++ b/docs/design/federated-mcp/4_decisions.md
@@ -1,0 +1,111 @@
+---
+title: Federated MCP — Decisions
+owner: grok
+last_updated: 2026-08-23
+last_validated: 2026-08-23
+status: Draft
+feature: federated-mcp
+doc_role: decisions
+type: design
+summary: Standing rules for the proposed federated MCP mux: destinations are configured, selectors use machine_id, authority is split, routing fails closed.
+tags: [federated-mcp, mcp, host-registry, multi-host]
+paths: ["crates/orbit-mcp/**", "crates/orbit-registry/**", "crates/orbit-core/**"]
+related_features: [federated-mcp, host-registry, mcp-bridge, remote-access]
+related_artifacts: [ORB-11009, ORB-11008]
+---
+
+# Federated MCP — Decisions
+
+Record non-obvious decisions here by title. These are Door 2 standing rules for future implementation; no code anchors yet because the surface is not shipped. See [CONVENTIONS.md §4](../CONVENTIONS.md#4-decisions).
+
+## Federated MCP is a mux of operator-configured destinations
+
+**Recorded:** 2026-08 · [ORB-11009]
+
+### Context
+
+A single MCP namespace can look like a fleet catalog. Host-registry already owns machine-local identity and checkout roles. Growing that catalog into routing, or auto-discovering owners, would make the gateway a second inventory and a placement service.
+
+### Decision
+
+Treat the federated surface as a mux in front of destinations the operator already configured. It is not a host-registry evolution, not a new fleet inventory, and not automatic owner discovery. Direct SSH stdio to one chosen host remains v1. Apply this whenever a future change is tempted to register, probe, or place hosts inside the gateway.
+
+### Consequences
+
+- Destination membership is an operator configuration problem, not a catalog schema problem.
+- Cost: the mux cannot "just find" an owner or a healthy replica; a missing destination is a configuration gap, not a discovery miss.
+
+## Host-qualified selectors are keyed by machine_id
+
+**Recorded:** 2026-08 · [ORB-11009]
+
+### Context
+
+`host_id` is renameable display. Keying a route on it would invalidate every selector on `orbit host rename` and invite examples such as `orbit-linux/ws_orbit`. The gateway's local catalog is the wrong resolution authority for another machine's workspace.
+
+### Decision
+
+Key the opaque host-qualified selector on stable `machine_id` (`hm_…`), for example `hm_<id>/ws_orbit`. Callers treat it as opaque. The gateway must not reinterpret it against its own local catalog. Two configured destinations that share a `machine_id`, or a token that is not uniquely host-qualified, are `ambiguous_destination`. Apply this to every new selector encoding, including future transport wrappers.
+
+### Consequences
+
+- Renames do not rebind routes; callers can persist selectors across display-name changes.
+- Cost: humans cannot mint a selector from a hostname they remember; they must copy `machine_id` from the list (or a configured destination record).
+
+## Capability class and mutation authority are split
+
+**Recorded:** 2026-08 · [ORB-11009]
+
+### Context
+
+One namespace plus several checkouts of one repository looks like a synchronized task store unless capability and authority are named separately. Lumping "mutations" would send `orbit_task_add` to a replica, or silently fail over to the owner, and invent a second ownership model.
+
+### Decision
+
+Map capabilities onto existing catalog roles: owner checkout is `control_plane` (and typically `execute`); replica checkout is `execute`. Destination-host Core refuses the other class with `capability_refused` and no implicit failover. Split remaining authority: the destination host owns runs, logs, and scheduler state; the declared control-plane owns task issuance and the coordination store. The gateway may advertise capabilities; it does not rewrite destinations. Apply this to every new federated tool, not only `orbit_task_add`.
+
+### Consequences
+
+- Owner/replica remain the only ownership vocabulary; execute-class work can stay on a replica without cloning the coordination store.
+- Cost: a caller that picks the wrong selector gets a named refusal instead of a successful write on the "right" host; clients must route control-plane tools to a `control_plane` destination themselves.
+
+## Unreachable destinations stay in the list and routing fails closed
+
+**Recorded:** 2026-08 · [ORB-11009]
+
+### Context
+
+Omitting a down host from `orbit_workspace_list` makes every later call a stale-route surprise. Overloading one `health` field hides whether SSH failed or the repo root is gone. Falling back to another host with the same `ws_*` is a replica protocol by another name.
+
+### Decision
+
+Federated `orbit_workspace_list` is session-unbound and additive. Host-reachability and checkout-health are separate fields. A down or unreachable host is included with an explicit projection, not omitted. Unknown, unreachable, unhealthy, ambiguous, and stale routes fail explicitly. `tool_not_on_this_host` is distinct from `unknown_selector`. No local fallback, no default workspace, no cached host-local runtime. Apply this to every new federated discovery field and every new routing miss.
+
+### Consequences
+
+- Callers can distinguish "host down" from "checkout missing" from "tool not advertised here."
+- Cost: the list is not a set of live, callable workspaces; clients must read reachability and capabilities before routing, and availability is bounded by the chosen destination.
+
+## The mux is a federated-namespace exception to v1 no-relay
+
+**Recorded:** 2026-08 · [ORB-11009]
+
+### Context
+
+mcp-bridge v1 forbids an Orbit process relaying a call onward and requires a byte-transparent SSH proxy. A mux necessarily inspects the selector and forwards. Treating that as a general relay product, or leaving vision §5 as "multi-host routing is a separate product," would either block the surface or un-forbid owner discovery, replication, and fleet placement.
+
+### Decision
+
+Admit the mux as an explicit exception to v1 byte-transparent / no-relay rules **for the federated namespace only**. Automatic owner discovery, replication, relays-as-product, and fleet placement stay out. v1 current-behavior docs continue to describe v1. Apply this whenever a later change wants the proxy to inspect, filter, or redirect traffic outside the federated namespace.
+
+### Consequences
+
+- Implementation can build the mux without rewriting mcp-bridge 2_design as if v1 already federated.
+- Cost: two MCP entry shapes must be documented and tested — v1 direct SSH stays policy-free; only the federated namespace may route — and mixed use cannot leak mux policy into the byte-transparent proxy.
+
+## Task References
+
+- [ORB-11008] — recorded the prior federated MCP policy that these rules implement
+- [ORB-11009] — recorded these standing rules as the contract home
+
+> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/federated-mcp/references/glossary.md
+++ b/docs/design/federated-mcp/references/glossary.md
@@ -1,0 +1,33 @@
+---
+type: design
+summary: "Glossary: Federated MCP"
+last_validated: 2026-08-23
+title: Glossary — Federated MCP
+owner: grok
+status: Draft
+feature: federated-mcp
+tags: [federated-mcp, glossary]
+related_features: [federated-mcp, host-registry, mcp-bridge]
+related_artifacts: [ORB-11009, ORB-11008]
+---
+
+# Glossary: Federated MCP
+
+Vocabulary for the proposed federated MCP mux. Standard industry terms (proxy, mux, TTL) are included only when this feature gives them a specific meaning. Host-registry catalog terms (`machine_id`, owner checkout, replica checkout, checkout health) keep their v1 meanings; this table maps them into the federated surface rather than redefining them.
+
+| Term | Meaning |
+|------|---------|
+| **Ambiguous destination** | Two configured destinations share a `machine_id`, or the selector is not uniquely host-qualified. Fails as `ambiguous_destination`. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
+| **Capabilities** | Advertised classes for a destination+workspace, at least `control_plane` and `execute`. Mapped onto owner vs replica checkouts. [2_design.md §3](../2_design.md) |
+| **Checkout health** | Repo-root presence at the destination (`active` / `invalid` / `unknown` when the host cannot be probed). Not SSH reachability. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
+| **Control-plane authority** | The declared owner checkout (or a later cloud-offloaded store) that owns task issuance and the coordination store for that workspace. [2_design.md §4](../2_design.md) |
+| **Destination** | An operator-configured MCP or SSH remote the mux may forward to. Not a host-registry fleet member. [2_design.md §1](../2_design.md) |
+| **Execute binding** | A replica checkout: it can run, log, and schedule on that host and must refuse control-plane tools. [2_design.md §3](../2_design.md) |
+| **Fail-closed routing** | Unknown, unreachable, unhealthy, ambiguous, and stale routes fail explicitly; no local fallback, default workspace, or `ws_*` substitution. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
+| **Federated namespace** | The caller-facing MCP surface that accepts host-qualified selectors and list-without-session. The only place the v1 no-relay rule is excepted. [mcp-bridge 3_vision.md §5](../../mcp-bridge/3_vision.md) |
+| **Gateway** | The mux process that advertises the federated namespace. It does not own destination state and does not rewrite destinations. [1_overview.md](../1_overview.md) |
+| **Host reachability** | Whether the configured destination answers (reachable / unreachable). Separate from checkout health. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
+| **Host-qualified selector** | Opaque addressing token keyed by `machine_id`, for example `hm_<id>/ws_orbit`. Not `host_id`, not a path, not a credential. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
+| **Mux** | A configured forwarder of already-chosen destinations, not a registry and not automatic owner discovery. [2_design.md §1](../2_design.md) |
+| **Stale route** | The encoded destination no longer advertises that workspace. Fails as `stale_route`. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
+| **Tool-not-on-this-host** | The destination is identified but does not advertise the tool. Distinct from `unknown_selector`. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |

--- a/docs/design/federated-mcp/specs/federated-workspace-mcp.md
+++ b/docs/design/federated-mcp/specs/federated-workspace-mcp.md
@@ -1,0 +1,125 @@
+---
+type: design
+summary: "Spec: Federated workspace MCP mux, selector, capabilities, list schema, and fail-closed routing"
+last_validated: 2026-08-23
+title: Spec — Federated workspace MCP
+owner: grok
+status: Draft
+feature: federated-mcp
+tags: [federated-mcp, mcp, spec]
+related_features: [federated-mcp, host-registry, mcp-bridge]
+related_artifacts: [ORB-11009, ORB-11008]
+---
+
+# Spec: Federated workspace MCP
+
+The federated MCP surface is a **mux of operator-configured destinations**. It presents one caller-facing MCP namespace, lists every configured destination's workspaces as live descriptors, and routes an opaque host-qualified selector to the encoded destination. It is **not** a host-registry evolution, **not** a fleet inventory, and **not** automatic owner discovery. Direct SSH stdio to one chosen host remains v1. This spec is proposed; it is not implemented.
+
+## Why This Exists
+
+Without this contract, an implementation will key selectors on renameable `host_id`, invent a second ownership model, lump runs and task issuance as one "mutations" blob, omit down hosts from the list, or violate mcp-bridge's no-relay rule (or ship a mux the corpus still forbids). [ORB-11008] recorded the policy; this spec is the implementable mechanism from [ORB-11009].
+
+## Mux, not fleet registry
+
+1. Destinations are operator-configured MCP or SSH remotes. The gateway does not register, retire, or enumerate a fleet of machines as host-registry records.
+2. The gateway does not auto-discover the owner checkout of a repository and does not perform placement.
+3. The gateway must not reinterpret a selector against its own local catalog.
+4. A caller that chooses one host and speaks v1 MCP (local stdio, direct SSH stdio, or `orbit mcp listen`) never enters this mux.
+
+## Selector identity
+
+1. The opaque host-qualified selector is keyed by stable `machine_id` (`hm_…`), not renameable `host_id`.
+2. Example form: `hm_<id>/ws_orbit`. Callers treat the token as opaque. Display names such as `orbit-linux/ws_orbit` are not selectors.
+3. The selector is addressing data, not a path, URL, logical-only workspace ID, or authorization credential. Possession of a selector is not authorization.
+4. Every workspace-scoped federated tool accepts the selector. The gateway routes that call to the encoded destination.
+5. **Ambiguous destination** means either (a) two configured destinations share a `machine_id`, or (b) the token is not uniquely host-qualified. Both fail as `ambiguous_destination`.
+
+## Capabilities vs checkout roles
+
+Capabilities distinguish at least `control_plane` and `execute`. They map onto existing host-registry catalog roles; do not invent a parallel ownership vocabulary.
+
+| Catalog role (v1) | Advertised capabilities | Destination Core |
+|---|---|---|
+| Owner checkout | `control_plane`; typically also `execute` | Control-plane authority for that workspace's coordination. Refuses `execute`-class tools only when it does not advertise `execute` (for example a future control-plane-only store). |
+| Replica checkout | `execute` | Execution binding. Refuses `control_plane` tools. |
+
+1. Destination-host Core **refuses the other class** with named error `capability_refused`.
+2. The gateway may advertise capabilities. It does **not** enforce by rewriting the destination.
+3. If a caller routes `orbit_task_add` (or any other control-plane tool) to an execution-binding host, the destination refuses with `capability_refused`. The gateway **must not** silently send it to the owner. No implicit failover.
+
+## Split authority ("mutations" is not one blob)
+
+Routing delivers a call; it does not move authority.
+
+| Concern | Authority |
+|---|---|
+| Runs, logs, scheduler state | **Destination host** that received the call |
+| Task issuance and the coordination store | **Declared control-plane authority** for that workspace (the owner checkout today; may later be cloud-offloaded) |
+
+Do not specify a single "mutations" permission that covers both columns. A replica may accept execute-class work against its own runs/logs/scheduler and must still refuse task issuance.
+
+Federated `orbit_workspace_list` is an aggregate of live descriptors, not an aggregate task or store query.
+
+## Federated `orbit_workspace_list`
+
+1. **Session-unbound.** The tool must not require a workspace selector. Session/initialize workspace metadata is not an input and not a filter.
+2. **Additive.** Each descriptor keeps today's v1 workspace fields (`id`, `name`, `ship_mode`, `owner_machine_id`, `git_remote`, `base_branch`, `status`, `created_at`, `updated_at`) and adds:
+
+   | Field | Meaning |
+   |---|---|
+   | `selector` | Opaque host-qualified route token (`hm_<id>/ws_*`) |
+   | `host` | Destination display identity (renameable `host_id`; display only) |
+   | `machine_id` | Destination stable identity (`hm_…`) |
+   | host-reachability | Whether the configured destination answers |
+   | checkout-health | Repo-root presence at that destination (`active` / `invalid` / `unknown` if the host cannot be probed) |
+   | `capabilities` | Classes the destination currently advertises for that workspace |
+
+3. **Do not overload one `health` field** with SSH/MCP reachability and repo-root presence.
+4. **Include unreachable hosts.** A down or unreachable configured destination appears with an explicit unreachable (and, if checkout cannot be probed, unknown/unhealthy) projection. **Do not omit it.** Omission makes every later call a stale-route surprise.
+5. v1 `orbit.workspace.list` on a single accepting machine is unchanged: it remains machine-local and is documented in mcp-bridge / host-registry current-behavior docs.
+
+## Fail-closed routing
+
+The gateway delivers a workspace-scoped federated call to the destination encoded in the selector. It does not fall back to a local workspace, another host with a matching `ws_*`, a default workspace, or a cached host-local runtime.
+
+| Class | Error identity | When |
+|---|---|---|
+| unknown | `unknown_selector` | Token does not name a configured destination+workspace |
+| unreachable | `unreachable_destination` | Configured destination does not answer |
+| unhealthy | `unhealthy_checkout` | Destination answers but the checkout is not usable (repo-root missing / invalid) |
+| ambiguous | `ambiguous_destination` | Shared `machine_id` among destinations, or token not uniquely host-qualified |
+| stale-route | `stale_route` | Encoded destination no longer advertises that workspace |
+| tool not advertised | `tool_not_on_this_host` | Destination is identified; the tool is not on that host's advertised surface |
+| capability refuse | `capability_refused` | Destination Core holds the workspace but refuses the tool's capability class |
+
+`tool_not_on_this_host` is distinct from `unknown_selector`. `capability_refused` is distinct from both: the tool may be advertised elsewhere on that host, but this checkout role will not execute it.
+
+## mcp-bridge invariant exception
+
+The mux replaces v1 "byte-transparent / no Orbit process relays onward" **for the federated namespace only**. v1 current-behavior text in [mcp-bridge 2_design.md](../../mcp-bridge/2_design.md) stays. This spec does not claim the mux is implemented.
+
+Still excluded (not implied by the exception):
+
+- automatic owner discovery;
+- replication of tasks or stores;
+- relays-as-product (a general Orbit relay outside the federated namespace);
+- fleet placement.
+
+See [mcp-bridge 3_vision.md §5](../../mcp-bridge/3_vision.md).
+
+## Non-goals
+
+The following remain out of this surface:
+
+- task or store replication;
+- synchronization;
+- quorum election;
+- competing authorities;
+- implicit failover;
+- silent merging of host-local state.
+
+A disconnected or failed host therefore removes the affected route from useful service. Another host cannot answer in its place unless a separate, explicit authority design — not this mux — says so.
+
+## Agent Signature
+
+Specified by grok in [ORB-11009], citing prior policy [ORB-11008].

--- a/docs/design/host-registry/1_overview.md
+++ b/docs/design/host-registry/1_overview.md
@@ -3,22 +3,22 @@ summary: "Host Registry — Overview"
 type: design
 title: "Host Registry — Overview"
 owner: codex
-last_updated: 2026-08-15
+last_updated: 2026-08-23
 last_validated: 2026-08-15
 status: Accepted
 feature: host-registry
 doc_role: overview
 tags: [host-registry, machine-identity, workspace-catalog]
 paths: ["crates/orbit-common/src/types/host.rs", "crates/orbit-common/src/types/workspace.rs", "crates/orbit-registry/src/host_identity.rs", "crates/orbit-registry/src/workspace_registry/**", "crates/orbit-cmd/src/registry_runtime.rs", "crates/orbit-cli/src/command/init.rs", "crates/orbit-cli/src/command/host/**", "crates/orbit-cli/src/command/workspace/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-web/src/lib.rs", "crates/orbit-web/src/state.rs", "crates/orbit-mcp/src/remote/identity.rs", "crates/orbit-mcp/src/remote/discovery.rs"]
-related_features: [host-registry, mcp-session-context, remote-access]
-related_artifacts: []
+related_features: [host-registry, mcp-session-context, remote-access, federated-mcp]
+related_artifacts: [ORB-11009]
 ---
 
 # Host Registry — Overview
 
 The live host-registry feature is a machine-local identity and workspace catalog. It tells an Orbit process who the accepting machine is, which logical workspaces this installation knows, and which local checkout may be opened for each workspace.
 
-It is not a fleet router. V1 has no host-registration, host-list, host-retirement, workspace-link, presence, placement, lease, or registry-cache workflow.
+It is not a fleet router. V1 has no host-registration, host-list, host-retirement, workspace-link, presence, placement, lease, or registry-cache workflow. A proposed federated MCP mux is specified separately in [federated-mcp](../federated-mcp/1_overview.md); that surface is not this catalog and is not current v1 behavior.
 
 ## Ownership
 

--- a/docs/design/host-registry/3_vision.md
+++ b/docs/design/host-registry/3_vision.md
@@ -10,16 +10,19 @@ feature: host-registry
 doc_role: vision
 tags: [host-registry, machine-identity, workspace-catalog]
 paths: ["crates/orbit-common/src/types/host.rs", "crates/orbit-common/src/types/workspace.rs", "crates/orbit-registry/src/host_identity.rs", "crates/orbit-registry/src/workspace_registry/**", "crates/orbit-cmd/src/registry_runtime.rs"]
-related_features: [host-registry, mcp-session-context, remote-access]
-related_artifacts: [ORB-11008]
+related_features: [host-registry, mcp-session-context, remote-access, federated-mcp]
+related_artifacts: [ORB-11008, ORB-11009]
 ---
 
 # Host Registry — Vision
 
 Keep the registry small: one durable local machine identity, one validated local
 workspace catalog, and one shared composition seam for opening Core runtimes.
-The federated MCP surface below is a proposed design, not current v1 behavior
-([ORB-11008] documents that proposal).
+
+The proposed federated MCP mux is specified in
+[federated-mcp](../federated-mcp/1_overview.md) ([ORB-11009], citing prior
+policy [ORB-11008]). That folder is the contract home. This vision does not
+restate the mux, selector, capability split, or list schema.
 
 ## Current v1 boundary
 
@@ -27,56 +30,9 @@ V1 exposes machine-local MCP discovery and resolves every workspace-scoped tool
 on the accepting machine. Direct SSH stdio reaches a chosen remote server, but
 there is no federation gateway, cross-host workspace list, or host-qualified
 workspace selector. The local host registry remains neither a fleet inventory
-nor a routing authority for another machine.
-
-## Proposed federated workspace MCP surface
-
-A future gateway may expose one Orbit MCP namespace to a caller while retaining
-one MCP server and one registry at each destination host. Its one aggregate
-discovery tool, `orbit_workspace_list`, returns every reachable workspace as a
-live descriptor:
-
-| Field | Meaning |
-|---|---|
-| `selector` | An opaque, host-qualified route token, for example `orbit-linux/ws_orbit` |
-| `host` | The destination host's display identity |
-| `machine_id` | The destination host's stable machine identity |
-| `health` | The gateway's current reachability and advertised workspace health projection |
-| `capabilities` | The operations the destination currently advertises for that workspace |
-
-The selector is addressing data, not a path, URL, logical workspace ID, or
-authorization credential. Every workspace-scoped Orbit tool accepts it and the
-gateway routes that call to the encoded destination. Callers choose a workspace
-without first choosing a host, but the gateway must not reinterpret the token
-against its own local catalog.
-
-Routing fails explicitly for an unknown selector, an unreachable or unhealthy
-host, an ambiguous destination, or a stale route whose destination no longer
-advertises that workspace. It must not fall back to a local workspace, another
-host with a matching workspace ID, a default workspace, or a cached host-local
-runtime.
-
-## Authority and repository bindings
-
-Routing changes where a call is delivered; it does not move its authority. The
-destination host remains authoritative for its runs, logs, scheduler state, and
-mutations. `orbit_workspace_list` is an aggregate of live descriptors, not an
-aggregate task or store query.
-
-For one repository, one declared control-plane authority owns the coordination
-store. Additional checkouts on other hosts are execution bindings to that
-authority. They do not become competing task stores merely because the
-federated surface can route to them. The authority rule belongs to the runtime
-and coordination boundary, while the gateway only preserves the selected
-destination.
-
-## Explicit non-goals
-
-This proposal excludes task or store replication, synchronization, quorum
-election, competing authorities, implicit failover, and silent merging of
-host-local state. A disconnected or failed host therefore removes the affected
-route from useful service; another host cannot answer in its place unless a
-separate, explicit authority design says so.
+nor a routing authority for another machine. Owner and replica checkout roles
+stay the catalog vocabulary a federated surface must map onto; they are not a
+fleet control plane.
 
 ## Questions that require evidence
 
@@ -98,11 +54,10 @@ If Core later authorizes remote calls, it needs an authenticated principal or gr
 
 ### Federated routing contract
 
-The gateway needs a transport-authentication and capability-advertisement
-contract before it can expose live descriptors. That contract must define
-health freshness, selector expiry, error identities, and how a destination
-verifies that the routed selector still names its local workspace without
-turning selector possession into authorization.
+Moved. Open questions (transport authentication, selector expiry, health
+freshness, cloud coordination-store) live in
+[federated-mcp 3_vision.md](../federated-mcp/3_vision.md). The implementable
+contract is [federated-workspace-mcp.md](../federated-mcp/specs/federated-workspace-mcp.md).
 
 ### Checkoutless operations
 
@@ -114,6 +69,7 @@ New host or catalog schema versions need explicit forward migration, crash-safe 
 
 ## Task References
 
-- [ORB-11008] proposes the federated multi-host workspace MCP surface and its authority boundary.
+- [ORB-11008] recorded the federated multi-host MCP policy later specified in federated-mcp
+- [ORB-11009] moved that contract out of this vision and into `docs/design/federated-mcp/`
 
-Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.
+> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/host-registry/4_decisions.md
+++ b/docs/design/host-registry/4_decisions.md
@@ -10,14 +10,15 @@ feature: host-registry
 doc_role: decisions
 tags: [host-registry, machine-identity, workspace-catalog, runtime-composition]
 paths: ["crates/orbit-common/src/types/host.rs", "crates/orbit-common/src/types/workspace.rs", "crates/orbit-registry/src/host_identity.rs", "crates/orbit-registry/src/workspace_registry/**", "crates/orbit-cmd/src/registry_runtime.rs", "crates/orbit-cli/src/command/host/**", "crates/orbit-cli/src/command/workspace/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-web/src/**"]
-related_features: [host-registry, mcp-session-context, remote-access]
-related_artifacts: [ORB-11008]
+related_features: [host-registry, mcp-session-context, remote-access, federated-mcp]
+related_artifacts: [ORB-11008, ORB-11009]
 ---
 
 # Host Registry — Decisions
 
-These choices describe current code and a separately marked forward-looking
-federated-routing constraint.
+These choices describe current code and a standing constraint that federation
+must not become a replica protocol. The federated MCP contract itself lives in
+[federated-mcp](../federated-mcp/1_overview.md).
 
 ## Shared primitives, owned persistence, separate composition
 
@@ -101,30 +102,27 @@ federated-routing constraint.
 
 ## Federated routing is not a replica protocol
 
-**Recorded:** 2026-08-23 · [ORB-11008] proposes the federated multi-host workspace MCP surface.
+**Recorded:** 2026-08-23 · [ORB-11008] proposed the policy; [ORB-11009] moved the contract to federated-mcp.
 
 **Context.** A single MCP namespace can make several reachable hosts look like
 one workspace catalog. Without an authority rule, that presentation could be
 mistaken for a synchronized task store or turn multiple checkouts of one
 repository into competing control planes.
 
-**Decision.** A federated gateway may aggregate live workspace descriptors and
-route an opaque host-qualified selector to its destination, but it never owns
-or merges destination state. Every workspace-scoped call is delivered to the
-encoded host, which remains authoritative for its runs, logs, scheduler state,
-and mutations. For one repository, one declared control-plane authority owns
-coordination; other hosts are execution bindings. Unknown, unreachable,
-unhealthy, ambiguous, and stale routes fail explicitly. This rule applies to
-future federation work as well as the first gateway implementation.
+**Decision.** Host-registry catalog roles stay owner and replica; this registry
+is not a routing authority. A federated MCP namespace must not become a replica
+protocol or merged store. The implementable mux, selector, capability, list, and
+fail-closed contract lives in [federated-mcp](../federated-mcp/specs/federated-workspace-mcp.md).
+This rule continues to apply to future federation work that touches catalog
+roles.
 
-**Consequences.** The design permits one caller-facing MCP namespace without
-introducing task/store replication, synchronization, quorum election,
-competing authorities, implicit failover, or silent host-local merges. Cost:
-availability is bounded by the chosen destination, so callers must handle
-visible routing failures instead of receiving a transparent substitute result.
+**Consequences.** Owner/replica remain the only ownership vocabulary in this
+folder. Cost: readers of this file no longer find the full routing contract
+here and must follow the federated-mcp link.
 
 ## Task References
 
-- [ORB-11008] proposes the federated multi-host workspace MCP surface and routing boundary.
+- [ORB-11008] recorded the federated multi-host MCP policy
+- [ORB-11009] moved the implementable contract to federated-mcp and left this entry as the host-registry standing constraint
 
-Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.
+> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/host-registry/references/glossary.md
+++ b/docs/design/host-registry/references/glossary.md
@@ -3,14 +3,14 @@ summary: "Glossary — Host Registry"
 type: design
 title: "Glossary — Host Registry"
 owner: codex
-last_updated: 2026-08-15
+last_updated: 2026-08-23
 last_validated: 2026-08-15
 status: Accepted
 feature: host-registry
 doc_role: reference
 tags: [host-registry, glossary]
 paths: ["crates/orbit-common/src/types/host.rs", "crates/orbit-common/src/types/workspace.rs", "crates/orbit-registry/src/host_identity.rs", "crates/orbit-registry/src/workspace_registry/**", "crates/orbit-cmd/src/registry_runtime.rs"]
-related_features: [host-registry]
+related_features: [host-registry, federated-mcp]
 related_artifacts: []
 ---
 
@@ -30,7 +30,7 @@ related_artifacts: []
 | Replica checkout | Local checkout that explicitly names another machine as the logical owner |
 | owner_host_ids | Local machine-ID-to-display-name projection for owners referenced by this catalog; not a fleet inventory |
 | Checkout health | active or invalid derived only from whether a bound repo_root exists |
-| Workspace selector | Registered name, logical ID or resolvable local checkout/worktree path used to address a runtime |
+| Workspace selector | Registered name, logical ID or resolvable local checkout/worktree path used to address a runtime. The proposed federated host-qualified selector (`hm_…/ws_*`) is specified in [federated-mcp](../../federated-mcp/specs/federated-workspace-mcp.md), not here. |
 | Runtime workspace ID | Workspace ID read from .orbit/config.yaml when Core's binding is built; it may differ from the logical catalog ID |
 | RegisteredRuntimeFactory | orbit-cmd composition seam that selects registry state and opens a Core runtime |
 | Caller machine label | MCP audit metadata; not host-registry identity or authorization |

--- a/docs/design/mcp-bridge/1_overview.md
+++ b/docs/design/mcp-bridge/1_overview.md
@@ -10,7 +10,7 @@ type: design
 summary: One authoritative Orbit MCP server, reached by local stdio, a byte-transparent direct SSH stdio proxy, or a loopback-default TCP listener.
 tags: [mcp, ssh, remote-access, registry, audit]
 paths: ["crates/orbit-mcp/**", "crates/orbit-registry/**", "crates/orbit-core/**", "crates/orbit-cli/src/command/mcp/**"]
-related_features: [host-registry, mcp-session-context, remote-access]
+related_features: [host-registry, mcp-session-context, remote-access, federated-mcp]
 ---
 
 # Orbit MCP — Overview

--- a/docs/design/mcp-bridge/3_vision.md
+++ b/docs/design/mcp-bridge/3_vision.md
@@ -1,16 +1,17 @@
 ---
 title: Orbit MCP — Vision
 owner: codex
-last_updated: 2026-08-15
+last_updated: 2026-08-23
 last_validated: 2026-08-15
 status: Draft
 feature: mcp-bridge
 doc_role: vision
 type: design
-summary: Evidence-gated extensions beyond the deliberately small direct-SSH MCP v1.
+summary: Evidence-gated extensions beyond the deliberately small direct-SSH MCP v1, including a federated-namespace-only mux exception.
 tags: [mcp, ssh, authorization, audit]
 paths: ["crates/orbit-mcp/**", "crates/orbit-core/**", "crates/orbit-registry/**"]
-related_features: [host-registry, mcp-session-context]
+related_features: [host-registry, mcp-session-context, federated-mcp]
+related_artifacts: [ORB-11009, ORB-11008]
 ---
 
 # Orbit MCP — Vision
@@ -58,10 +59,21 @@ merely to avoid launching SSH.
 
 ## 5. Multi-host routing
 
-The v1 client chooses one destination and that server answers only from its own
-state. Automatic owner discovery, relays, replication, or fleet placement should
-be considered separate products, not incremental proxy features. Each needs a
-measured use case strong enough to justify new authority and failure modes.
+V1 remains one chosen destination answering only from its own state. The
+client-side proxy stays byte-transparent and does not relay a call onward.
+That rule continues to describe **current behavior** in [`2_design.md`](./2_design.md);
+this section does not claim a mux is implemented.
+
+The proposed federated MCP surface is an **explicit exception** to those v1
+no-relay / byte-transparent rules, **for the federated namespace only**. A mux
+in front of operator-configured destinations may inspect a host-qualified
+selector and forward the call to the encoded destination. Direct SSH stdio to
+one chosen host is unchanged.
+
+The exception does **not** admit automatic owner discovery, replication,
+relays-as-product, or fleet placement. Those stay out. The contract is
+[federated-mcp](../federated-mcp/specs/federated-workspace-mcp.md)
+([ORB-11009], citing [ORB-11008]).
 
 ## 6. Evaluation gates
 
@@ -77,3 +89,10 @@ replaces them:
 
 Current behavior is described in [`2_design.md`](./2_design.md). The machine-
 readable contract is [`references/conformance-v1.yaml`](./references/conformance-v1.yaml).
+
+## Task References
+
+- [ORB-11008] recorded federated MCP policy that this vision now excepts from v1 no-relay
+- [ORB-11009] admitted the federated-namespace mux exception in §5 without claiming it is implemented
+
+> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-session-context/3_vision.md
+++ b/docs/design/mcp-session-context/3_vision.md
@@ -3,15 +3,15 @@ summary: "MCP Session Context — Vision"
 type: design
 title: "MCP Session Context — Vision"
 owner: codex
-last_updated: 2026-08-15
+last_updated: 2026-08-23
 last_validated: 2026-08-15
 status: Accepted
 feature: mcp-session-context
 doc_role: vision
 tags: ["mcp-session-context", "mcp", "workspace", "audit"]
 paths: ["crates/orbit-common/src/types/tool.rs", "crates/orbit-mcp/src/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-core/src/command/tool/**"]
-related_features: ["mcp-session-context"]
-related_artifacts: []
+related_features: ["mcp-session-context", "federated-mcp"]
+related_artifacts: [ORB-11009]
 ---
 
 # MCP Session Context — Vision
@@ -39,8 +39,17 @@ Add a field only when all three are true:
 ## Stable principles
 
 - External workspace values address server state; they do not prove identity.
+  Addressing may later become host-qualified (`hm_…/ws_*`) under the proposed
+  federated MCP surface; v1 still resolves a local selector on the accepting
+  machine. See [federated-mcp](../federated-mcp/specs/federated-workspace-mcp.md).
 - The accepting machine describes itself.
 - Caller machine and network labels are useful for audit correlation but remain fallible.
 - The MCP adapter owns call correlation.
 - Every tools/call, including an unknown raw name, crosses one Core audit boundary.
 - Core remains the execution, audit, and future authorization authority.
+
+## Task References
+
+- [ORB-11009] noted that addressing may become host-qualified under federated MCP without changing v1 overview claims
+
+> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/remote-access/3_vision.md
+++ b/docs/design/remote-access/3_vision.md
@@ -10,18 +10,18 @@ type: design
 summary: "Evolution gates for remote Orbit Web access without weakening the loopback and registry boundaries."
 tags: [remote-access, orbit-web, ssh]
 paths: ["crates/orbit-web/**", "crates/orbit-registry/src/workspace_registry/**", "crates/orbit-cmd/src/registry_runtime.rs"]
-related_features: [remote-access, user-interface, host-registry]
-related_artifacts: [ORB-11008]
+related_features: [remote-access, user-interface, host-registry, federated-mcp]
+related_artifacts: [ORB-11008, ORB-11009]
 ---
 
 # Remote Access — Vision
 
 Remote access should stay a thin way to reach a machine's existing Orbit Web state. It should not become an accidental synchronization service or an unauthenticated network daemon.
 
-The federated MCP workspace surface is a proposed companion design, not a
-change to the current Web or direct-SSH MCP behavior ([ORB-11008] documents
-the proposal). It may aggregate live routing descriptors, but it does not make
-Remote Access a replication feature.
+The proposed federated MCP mux is specified in
+[federated-mcp](../federated-mcp/1_overview.md) ([ORB-11009], citing
+[ORB-11008]). It is not a change to current Web or direct-SSH MCP behavior,
+and it does not make Remote Access a replication feature.
 
 ## Evolution gates
 
@@ -35,22 +35,17 @@ Background reconnect, tunnel multiplexing, or several remote machines in one bro
 
 ### Cross-machine state
 
-A multi-machine aggregate of live workspace descriptors can be a routing
-feature when every descriptor identifies its destination host and every
-workspace-scoped call is delivered there. It must report unknown, unreachable,
-unhealthy, ambiguous, and stale routes as failures; it cannot fall back to a
-local or matching remote workspace. An offline view, a merged task result, or
-any synchronized state remains a data-replication problem with an authoritative
-store, conflict behavior, and write semantics of its own.
+An offline view, a merged task result, or any synchronized dashboard state
+remains a data-replication problem with an authoritative store, conflict
+behavior, and write semantics of its own. Live multi-host workspace
+descriptors belong to the federated MCP mux, not to Remote Access; see
+[federated-mcp](../federated-mcp/specs/federated-workspace-mcp.md).
 
 ### Federated MCP authority
 
-The proposed gateway may present one namespace and `orbit_workspace_list`, but
-the selected destination host remains authoritative for runs, logs, scheduler
-state, and mutations. For a repository with several checkouts, one declared
-control-plane authority owns coordination and additional hosts are execution
-bindings. The gateway must not introduce competing authorities, quorum
-election, implicit failover, or silent merging of host-local state.
+Contract home: [federated-mcp](../federated-mcp/1_overview.md). Remote Access
+does not own that mux and must not grow a second copy of its routing or
+authority rules.
 
 ### Performance
 
@@ -66,6 +61,7 @@ Measure registry parse cost, runtime-cache churn, and aggregate endpoint latency
 
 ## Task References
 
-- [ORB-11008] proposes federated MCP routing while preserving destination-host authority.
+- [ORB-11008] recorded federated MCP policy while preserving destination-host authority
+- [ORB-11009] moved the implementable contract to federated-mcp; this vision now cross-links
 
-Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.
+> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-11009](https://orbit-cli.com/tasks/ORB-11009) — Turn federated MCP policy into an implementable design contract

### Description

## Problem
[ORB-11008] recorded the federated multi-host MCP *policy* (one namespace, live descriptors, fail-closed routing, no replica protocol) inside host-registry and remote-access vision. That is not an implementable contract. The five-point policy is still right; the write-up is missing the mechanism, contradicts mcp-bridge, and leaves the control-plane vs execute split unresolved.

## Why It Matters
A later implementation task will otherwise invent a second ownership model, key selectors on renameable `host_id`, and either violate mcp-bridge's "no relay" invariant or ship a mux the corpus still forbids.

## Constraints / Notes
This is proposed design only. Do not change runtime code. Keep current v1 behavior clearly labelled as current. Copy `docs/design/_templates` into a new feature folder `docs/design/federated-mcp/` (lowercase, hyphenated, singular). Owner: `grok`. Status: `Draft`. Cite [ORB-11008] as prior policy and this task as the implementable contract. Follow `docs/design/CONVENTIONS.md` (numbered docs, required sections, glossary, spec, Task References).

Do **not** invent a second ownership model. Map new nouns onto existing host-registry catalog roles: owner checkout = control-plane authority for that workspace's coordination; replica checkout = execution binding. The gateway does not become a fleet inventory; destinations are operator-configured MCP/SSH remotes.

Required contract (must appear in the new spec, not only as vision prose):

1. **Mux, not fleet registry.** The federated surface is a mux in front of already-configured destinations. It is not a host-registry evolution, not a new fleet inventory, and not automatic owner discovery. Direct SSH stdio to one chosen host remains v1.
2. **Selector identity.** The opaque host-qualified selector is keyed by stable `machine_id` (`hm_…`), not renameable `host_id`. Example form: `hm_<id>/ws_orbit`. Callers treat it as opaque. The gateway must not reinterpret it against its own local catalog. Ambiguous destination means two configured destinations share a `machine_id`, or the token is not uniquely host-qualified.
3. **Capabilities vs authority.** `capabilities` distinguish at least `control_plane` and `execute`. Destination-host Core refuses the other class; the gateway may advertise but does not enforce by rewriting destinations. Split "mutations": destination host is authoritative for runs, logs, and scheduler state; the declared control-plane authority is authoritative for task issuance and the coordination store (which may later be cloud-offloaded). Do not lump those as one "mutations" blob. If a caller routes `orbit_task_add` to an execution-binding host, the destination refuses with a named error; the gateway must not silently send it to the owner instead (no implicit failover).
4. **mcp-bridge invariant exception.** Rewrite mcp-bridge vision §5 so this mux is in, while automatic owner discovery, replication, relays-as-product, and fleet placement stay out. State that the mux replaces v1 "byte-transparent / no Orbit process relays onward" *for the federated namespace only*. v1 2_design current-behavior text stays; do not claim the mux is implemented.
5. **List schema and health.** Federated `orbit_workspace_list` is session-unbound (must not require a workspace selector). Result is additive on today's fields (`id`, `name`, `ship_mode`, …) plus `selector`, `host`, `machine_id`, host-reachability, workspace checkout-health, and `capabilities`. Do not overload one `health` field with SSH reachability and repo-root presence. A down/unreachable host is **included** with an explicit unreachable/unhealthy projection, not omitted (omission makes every later call a stale-route surprise). Tool-not-advertised-on-this-host is a distinct error from unknown-selector.
6. **Fail-closed classes stay:** unknown, unreachable, unhealthy, ambiguous, stale-route. No local fallback, no "same `ws_*` on another box", no default workspace, no cached host-local runtime.
7. **Non-goals stay:** no task/store replication, synchronization, quorum election, competing authorities, implicit failover, or silent merging of host-local state.
8. **Corpus placement.** New folder is the home of the contract (overview, design labelled proposed/not shipped, vision open questions, decisions, glossary, `specs/federated-workspace-mcp.md`). Thin host-registry and remote-access vision to short cross-links; do not keep three copies of the five-point list. Add a CONVENTIONS.md ownership-table row for `federated-mcp` / grok. mcp-session-context vision may note that addressing may become host-qualified; do not change its v1 overview claims.

Open questions that belong in vision, not fake-resolved: transport authentication, selector expiry, health freshness, cloud coordination-store details.

## Risks
- Wording that claims current v1 already federates.
- Selector examples that use `orbit-linux/…` (renameable `host_id`).
- Leaving mcp-bridge §5 as "multi-host routing is a separate product".
- Creating new ownership vocabulary that ignores owner/replica.

### Acceptance Criteria

- docs/design/federated-mcp/ exists with numbered docs, glossary, and specs/federated-workspace-mcp.md, copied from docs/design/_templates, status Draft, owner grok, citing this task and [ORB-11008].
- The spec states the gateway is a mux of operator-configured destinations, not a fleet registry, and that selectors are keyed by machine_id (hm_*) not renameable host_id.
- The spec splits capabilities into at least control_plane vs execute, maps them onto existing owner vs replica checkout roles, and states the destination refuses the other class with a named error and no implicit failover to the owner.
- The spec splits authority: destination host for runs/logs/scheduler; declared control-plane for task issuance and the coordination store. "Mutations" is not one blob.
- Federated orbit_workspace_list is specified as session-unbound, additive on current list fields, with separate host-reachability and checkout-health, including unreachable hosts rather than omitting them, and a distinct tool-not-on-this-host error.
- mcp-bridge/3_vision.md §5 admits this mux as an explicit exception to v1 no-relay/byte-transparent rules for the federated namespace only, and still excludes owner discovery, replication, and fleet placement.
- host-registry and remote-access vision/decision prose no longer host the full contract; they cross-link to federated-mcp. CONVENTIONS.md lists the new feature. mcp-bridge 2_design and other v1 current-behavior docs still describe v1 only.
- make docs-index, make ci-fast, and make ci-lint pass from the Orbit repository. No runtime/code changes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Created `docs/design/federated-mcp/` from `_templates` (overview, design labelled proposed/not shipped, vision, decisions, glossary, `specs/federated-workspace-mcp.md`). Owner `grok`, status Draft. Cites [ORB-11009] and [ORB-11008].
- Spec states: mux of operator-configured destinations (not a fleet registry); selectors keyed by `machine_id` (`hm_…/ws_*`); capabilities `control_plane`/`execute` mapped onto owner/replica; destination Core refuses the other class with `capability_refused` and no implicit failover; authority split (destination host: runs/logs/scheduler; control-plane: task issuance and coordination store); federated `orbit_workspace_list` session-unbound, additive, separate host-reachability vs checkout-health, includes unreachable hosts; distinct `tool_not_on_this_host`.
- mcp-bridge vision §5 admits the mux as a federated-namespace-only exception to v1 no-relay/byte-transparent rules; owner discovery, replication, fleet placement stay out. `2_design.md` still describes v1 only.
- Thinned host-registry and remote-access vision/decision prose to cross-links. CONVENTIONS.md ownership row for `federated-mcp` / grok. mcp-session-context vision notes host-qualified addressing may come later.
- Unlisted files touched (and reserved via context_files): `dir:docs/design/federated-mcp` (new contract home), `file:docs/INDEX.md` (intended regenerate; see sandbox note).
Assessment: Contract is implementable without inventing a second ownership model or claiming v1 already federates. Open questions (transport auth, selector expiry, health freshness, cloud store) remain in vision.

Strategic decisions:
- Mapped new nouns onto existing owner/replica roles rather than new vocabulary.
- Named error identities in the spec (`unknown_selector`, `unreachable_destination`, `unhealthy_checkout`, `ambiguous_destination`, `stale_route`, `tool_not_on_this_host`, `capability_refused`).

Design weaknesses / risks:
- Severity: low. `docs/INDEX.md` could not gain a Federated MCP row because `git add` failed (`index.lock`: Read-only file system); `generate-doc-indexes.sh` only lists versioned files. Mitigation: unrestricted CI / commit step should `git add` the new folder and rerun `make docs-index`.
- Severity: low. Capability advertisement vs destination refuse can diverge until an implementation defines advertisement freshness (left in vision).

Validation:
- `make docs-index`: passed (INDEX unchanged; new folder untracked).
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- No runtime/code changes.

Friction checkpoint: none filed. Semantic search had no embeddings (non-blocking skip). Git-index EPERM is a sandbox denial, recorded above.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11009-6a8b559a`
- Behind base: 0
- Ahead of base: 1

*authored by: grok*