### PR TITLE
Close federated-mcp contract holes from PR #1139 review

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -52,6 +52,7 @@ a conservative title/status fallback.
 | [Auditability](./design/auditability/1_overview.md) | Auditability is Orbit's answer to the operator question that matters after an agent touches a real repository: what happened, why, and who is accountable? | Draft | codex |
 | [Auto-tasks](./design/auto-tasks/1_overview.md) | Dynamically-defined recurring task templates minted by one generic scheduler routine — periodic work as data, not code. | Accepted | claude |
 | [Executors](./design/executors/4_decisions.md) | Decision log for executor registration and the (now retired) External Executor Protocol. | Draft | claude |
+| [Federated MCP](./design/federated-mcp/1_overview.md) | Proposed mux that presents one MCP namespace over operator-configured destinations, keyed by machine_id, without becoming a fleet registry. | Draft | grok |
 | [Host Registry](./design/host-registry/1_overview.md) | The live host-registry feature is a machine-local identity and workspace catalog. | Accepted | codex |
 | [Orbit MCP](./design/mcp-bridge/1_overview.md) | One authoritative Orbit MCP server, reached by local stdio, a byte-transparent direct SSH stdio proxy, or a loopback-default TCP listener. | Draft | codex |
 | [MCP Session Context](./design/mcp-session-context/1_overview.md) | ToolSessionContext is Orbit's transport-to-Core invocation envelope. | Accepted | codex |

--- a/docs/design/federated-mcp/1_overview.md
+++ b/docs/design/federated-mcp/1_overview.md
@@ -11,24 +11,24 @@ summary: Proposed mux that presents one MCP namespace over operator-configured d
 tags: [federated-mcp, mcp, host-registry, multi-host]
 paths: ["crates/orbit-mcp/**", "crates/orbit-registry/**", "crates/orbit-core/**"]
 related_features: [federated-mcp, host-registry, mcp-bridge, remote-access, mcp-session-context]
-related_artifacts: [ORB-11009, ORB-11008]
+related_artifacts: [ORB-11010, ORB-11009, ORB-11008]
 ---
 
 # Federated MCP — Overview
 
-Federated MCP is a proposed caller-facing mux: one Orbit MCP namespace in front of operator-configured destinations (MCP or SSH remotes already chosen by the operator). It is not current v1 behavior, not a host-registry evolution, and not a fleet inventory. Direct SSH stdio to one chosen host remains the implemented remote path. [ORB-11008] recorded the policy; this folder is the implementable contract from [ORB-11009].
+Federated MCP is a proposed caller-facing mux: one Orbit MCP namespace in front of operator-configured destinations (MCP or SSH remotes already chosen by the operator). It is not current v1 behavior, not a host-registry evolution, and not a fleet inventory. Direct SSH stdio to one chosen host remains the implemented remote path. [ORB-11008] recorded the policy; this folder is the implementable contract from [ORB-11009] (PR #1139), with review holes closed in [ORB-11010].
 
 ## 1. Motivation
 
-A later implementation will otherwise invent a second ownership model, key selectors on renameable `host_id`, or ship a relay that mcp-bridge still forbids. The five-point policy in [ORB-11008] is still right; it was not a routing contract. This feature names the mux, the selector, the capability/authority split, the list schema, and the mcp-bridge exception so implementation cannot guess them.
+A later implementation will otherwise invent a second ownership model, key selectors on renameable `host_id`, or ship a relay that mcp-bridge still forbids. The five-point policy recorded by [ORB-11008] is still right; it was not a routing contract, and it no longer lives as a list in host-registry vision. This feature names the mux, the selector, the capability/authority split, the list schema, and the mcp-bridge exception so implementation cannot guess them.
 
 ## 2. Core Concepts
 
 - **Mux, not registry.** Destinations are operator-configured remotes. The gateway does not discover owners, register a fleet, or reinterpret a selector against its own local catalog.
-- **Host-qualified selector.** Opaque addressing token keyed by stable `machine_id` (`hm_…`), for example `hm_<id>/ws_orbit`. Not a path, URL, authorization credential, or renameable `host_id`.
-- **Capabilities vs authority.** `control_plane` and `execute` map onto existing host-registry owner and replica checkout roles. The destination Core refuses the other class; the gateway does not rewrite or fail over.
-- **Split mutations.** The destination host is authoritative for runs, logs, and scheduler state. The declared control-plane authority is authoritative for task issuance and the coordination store.
-- **Live descriptors, fail closed.** Federated `orbit_workspace_list` is session-unbound and includes unreachable hosts. Unknown, unreachable, unhealthy, ambiguous, and stale routes fail explicitly.
+- **Host-qualified selector.** Structured, caller-uninterpreted addressing token with normative encoding `hm_<id>/ws_*`. Keyed by stable `machine_id`, not renameable `host_id`. Callers copy the list `selector` field; they must not parse or construct the token.
+- **Capabilities vs authority.** `control_plane` and `execute` map onto existing host-registry owner and replica checkout roles. The destination's local catalog role determines class; list advertisement is a hint that may lag. Destination Core refuses the other class; the gateway does not rewrite or fail over.
+- **Split mutations.** The destination host is authoritative for runs, logs, and scheduler state. The declared control-plane authority is authoritative for task issuance and the coordination store. One control-plane per repository is operator configuration, not a mux check.
+- **Live descriptors, fail closed.** Federated `orbit_workspace_list` is a new session-unbound shape (not a v1 extension) and includes unreachable hosts. Routing uses a single error precedence and live delivery.
 
 Full definitions live in [references/glossary.md](./references/glossary.md). The prescriptive contract is [specs/federated-workspace-mcp.md](./specs/federated-workspace-mcp.md).
 
@@ -36,11 +36,11 @@ Full definitions live in [references/glossary.md](./references/glossary.md). The
 
 | Concern | File | Task |
 |---------|------|------|
-| Mux vs fleet registry; selector identity; list schema; fail-closed errors | [specs/federated-workspace-mcp.md](./specs/federated-workspace-mcp.md) | [ORB-11009] |
-| Proposed mechanism (not shipped) | [2_design.md](./2_design.md) | [ORB-11009] |
+| Mux vs fleet registry; selector identity; list schema; fail-closed errors | [specs/federated-workspace-mcp.md](./specs/federated-workspace-mcp.md) | [ORB-11009], [ORB-11010] |
+| Proposed mechanism (not shipped) | [2_design.md](./2_design.md) | [ORB-11009], [ORB-11010] |
 | Open questions (auth, expiry, freshness, cloud store) | [3_vision.md](./3_vision.md) | [ORB-11009] |
-| Standing rules and rejected alternatives | [4_decisions.md](./4_decisions.md) | [ORB-11009] |
-| Prior policy (five-point list) | [host-registry/3_vision.md](../host-registry/3_vision.md) (cross-link only) | [ORB-11008] |
+| Standing rules and rejected alternatives | [4_decisions.md](./4_decisions.md) | [ORB-11009], [ORB-11010] |
+| Standing constraint (mux is not a fleet registry) | [host-registry/3_vision.md](../host-registry/3_vision.md) (cross-link only; the five-point policy list no longer lives there) | [ORB-11008] |
 | v1 no-relay / byte-transparent current behavior | [mcp-bridge/2_design.md](../mcp-bridge/2_design.md) | — |
 | Federated-namespace exception to that v1 rule | [mcp-bridge/3_vision.md](../mcp-bridge/3_vision.md) §5 | [ORB-11009] |
 | Owner vs replica catalog roles | [host-registry/2_design.md](../host-registry/2_design.md) | — |
@@ -48,6 +48,7 @@ Full definitions live in [references/glossary.md](./references/glossary.md). The
 ## Task References
 
 - [ORB-11008] — recorded the federated multi-host MCP policy inside host-registry and remote-access vision
-- [ORB-11009] — turns that policy into this implementable design contract
+- [ORB-11009] — turns that policy into this implementable design contract (PR #1139)
+- [ORB-11010] — closes the PR #1139 review contract holes (INDEX row, tool class, advertisement vs catalog role, list shape, error precedence, competing authorities, selector wording)
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/federated-mcp/2_design.md
+++ b/docs/design/federated-mcp/2_design.md
@@ -11,7 +11,7 @@ summary: Proposed (not shipped) federated MCP mux, selector, capability split, l
 tags: [federated-mcp, mcp, host-registry, multi-host]
 paths: ["crates/orbit-mcp/**", "crates/orbit-registry/**", "crates/orbit-core/**"]
 related_features: [federated-mcp, host-registry, mcp-bridge, remote-access, mcp-session-context]
-related_artifacts: [ORB-11009, ORB-11008]
+related_artifacts: [ORB-11010, ORB-11009, ORB-11008]
 ---
 
 # Federated MCP — Design
@@ -26,17 +26,18 @@ The gateway is a mux in front of destinations the operator already configured (M
 
 - grow host-registry into a fleet inventory;
 - auto-discover the owner checkout of a repository;
-- place work, elect a leader, or pick a healthy substitute.
+- place work, elect a leader, or pick a healthy substitute;
+- detect or reject competing control-plane authorities (see §7).
 
 Direct SSH stdio to one chosen host remains the v1 remote path and is unchanged by this proposal. A caller that does not use the federated namespace never hits the mux.
 
 ## 2. Host-qualified selector
 
-Every workspace-scoped federated call carries an opaque host-qualified selector. The token is addressing data. Callers treat it as opaque. The gateway must not reinterpret it against its own local catalog.
+Every workspace-scoped federated call carries a **structured, caller-uninterpreted** host-qualified selector. Encoding `hm_<id>/ws_*` is normative. The token is addressing data. Callers copy the `selector` field from federated `orbit_workspace_list`; they must not parse it, construct it from `host_id`, or concatenate remembered identifiers. The gateway must not reinterpret it against its own local catalog.
 
 The stable key is `machine_id` (`hm_…`), not renameable `host_id`. Example form: `hm_<id>/ws_orbit`. A display host name such as `orbit-linux/ws_orbit` is not a valid selector.
 
-The destination is ambiguous when two configured destinations share a `machine_id`, or when the token is not uniquely host-qualified (a bare `ws_*` is not enough). Ambiguous tokens fail; they are not disambiguated by local catalog, cwd, or session default.
+A token that is not uniquely host-qualified (a bare `ws_*`) is `unknown_selector`. Duplicate `machine_id` across configured destinations is config-load `ambiguous_destination`, not a per-call routing outcome.
 
 ## 3. Capabilities mapped onto owner and replica
 
@@ -45,16 +46,24 @@ This feature does not invent a second ownership model. Host-registry already dis
 - **owner checkout** — local checkout whose logical `owner_machine_id` equals this machine;
 - **replica checkout** — local checkout that names another machine as the logical owner.
 
-Those roles map onto capability classes:
+**The destination's local catalog role determines capability class.** List advertisement is a hint and may lag destination Core. Destination Core refusal is the correctness boundary; the gateway is not a second authorization layer.
 
-| Catalog role | Capability class | Meaning |
+| Catalog role | Classes held | Meaning |
 |---|---|---|
-| Owner checkout | `control_plane` (and typically also `execute`) | Control-plane authority for that workspace's coordination; the canonical checkout can also run |
+| Owner checkout | `control_plane`. May also hold `execute` when that checkout runs locally; that second class is independent of the owner role and is not a refusal input. | Control-plane authority for that workspace's coordination |
 | Replica checkout | `execute` | Execution binding only |
+
+A workspace with absent `owner_machine_id` cannot advertise `control_plane`.
 
 A destination Core that does not hold a class **refuses** tools of that class with a named error (`capability_refused`). The gateway may advertise the destination's capabilities; it does not enforce by rewriting the destination or failing over to the owner.
 
-If a caller routes `orbit_task_add` to an execution-binding host, that destination refuses. The gateway must not silently send the call to the owner.
+Tool class is assigned by what the tool does, not by a per-tool registry field:
+
+- task issuance and coordination-store writes (`orbit_task_add`, `orbit.task.update`, `orbit.task.start`, …) → `control_plane`
+- anything touching runs, logs, or scheduler state → `execute`
+- discovery / list tools (`orbit_workspace_list`, …) → unclassified, not subject to `capability_refused`
+
+If a caller routes a `control_plane` tool to an execution-binding host, that destination refuses. The gateway must not silently send the call to the owner.
 
 ## 4. Split authority — "mutations" is not one blob
 
@@ -69,47 +78,61 @@ Do not lump those as one "mutations" blob. A replica can accept execute-class wo
 
 ## 5. Federated workspace list
 
-Federated `orbit_workspace_list` is **session-unbound**: it must not require a workspace selector. The result is **additive** on today's v1 list fields (`id`, `name`, `ship_mode`, `owner_machine_id`, `git_remote`, `base_branch`, `status`, timestamps) plus:
+Federated `orbit_workspace_list` is **session-unbound**: it must not require a workspace selector. It is a **new response shape**, not a compatible extension of v1 `orbit.workspace.list`.
 
-- `selector` — opaque host-qualified route token;
+v1 puts `machine_id` on the envelope (`{"machine_id", "workspaces":[…]}`) and filters to Active workspaces that are locally checked out. Federated list puts `machine_id` on **each descriptor** and does **not** inherit that filter. Configured workspaces on unreachable or inactive destinations are included, not omitted.
+
+Each descriptor keeps today's v1 workspace fields (`id`, `name`, `ship_mode`, `owner_machine_id`, `git_remote`, `base_branch`, `status`, timestamps) plus:
+
+- `selector` — structured, caller-uninterpreted host-qualified route token (`hm_<id>/ws_*`);
 - `host` — destination display identity (`host_id`, renameable, display only);
 - `machine_id` — destination stable identity;
 - host-reachability — SSH/MCP reachability of the configured destination;
 - workspace checkout-health — repo-root presence at that destination, the same narrow rule as host-registry;
-- `capabilities` — classes the destination currently advertises for that workspace.
+- `capabilities` — classes the destination currently advertises for that workspace (a hint).
 
 Do not overload one `health` field with both SSH reachability and repo-root presence. A down or unreachable host is **included** with an explicit unreachable/unhealthy projection, not omitted. Omission makes every later call a stale-route surprise.
 
 ## 6. Fail-closed routing
 
-The gateway delivers a workspace-scoped call to the destination encoded in the selector. It fails explicitly for:
+The gateway delivers a workspace-scoped call to the destination encoded in the selector. Routing decides on **live delivery**, not cached list health.
 
-- unknown selector;
-- unreachable destination;
-- unhealthy checkout;
-- ambiguous destination;
-- stale route (destination no longer advertises that workspace).
+Caller-facing precedence when more than one class could apply:
+
+`unknown_selector` → `ambiguous_destination` (config load) → `unreachable_destination` → `stale_route` → `unhealthy_checkout` → `tool_not_on_this_host` → `capability_refused`
+
+- `unknown_selector` — token never valid, including a bare `ws_*`.
+- `ambiguous_destination` — duplicate configured `machine_id`, raised at config load, not per call.
+- `unreachable_destination` — configured destination does not answer. Unreachable wins over capability and stale because those are undecidable without the host.
+- `stale_route` — destination configured; a live probe shows the workspace is absent.
+- `unhealthy_checkout` — destination answers but the checkout is not usable.
+- `tool_not_on_this_host` — destination identified; the tool is not advertised there.
+- `capability_refused` — destination holds the workspace but refuses the tool's class. Unclassified discovery/list tools are not subject to this error.
 
 It must not fall back to a local workspace, another host with a matching `ws_*`, a default workspace, or a cached host-local runtime.
 
-`tool_not_on_this_host` is a distinct error from `unknown_selector`: the destination is identified, but the tool is not advertised there.
+## 7. Operator-configured control-plane uniqueness
 
-## 7. Relationship to v1 MCP
+A single control-plane per repository is an operator configuration responsibility, not a mux invariant. The mux does not check it. The would-be signal is matching `git_remote` across destinations with differing `owner_machine_id`. Independently inited checkouts have different `ws_*`, so the mux cannot observe the collision without fleet discovery. A violation surfaces as two independent control planes, not an error.
+
+## 8. Relationship to v1 MCP
 
 v1 local stdio, direct SSH stdio, and `orbit mcp listen` stay as specified in mcp-bridge. The mux is an explicit exception to v1 "byte-transparent / no Orbit process relays onward", **for the federated namespace only**. Automatic owner discovery, replication, relays-as-product, and fleet placement stay out. See [mcp-bridge 3_vision.md §5](../mcp-bridge/3_vision.md).
 
-## 8. Concerns & Honest Limitations
+## 9. Concerns & Honest Limitations
 
 - This design is not shipped. No runtime, tool schema, or conformance YAML in this change implements it.
 - Availability is bounded by the chosen destination. Callers must handle visible routing failures; there is no transparent substitute result.
 - Including unreachable hosts makes the list honest and larger; clients must read reachability rather than treating presence as liveness.
 - Capability advertisement can lag destination Core. The destination refuse is the correctness boundary; the gateway is not a second authorization layer.
-- Transport authentication, selector expiry, health freshness, and cloud coordination-store details are deliberately unresolved. See [3_vision.md](./3_vision.md).
+- Transport authentication, selector expiry, health freshness, and cloud coordination-store details are deliberately unresolved. See [3_vision.md](./3_vision.md). Probe cadence stays a vision open question; it does not change live-delivery error precedence.
 - Mixed Orbit versions across destinations can advertise different surfaces; `tool_not_on_this_host` and `capability_refused` must remain distinguishable from "the mux is confused."
+- Two destinations that each declare Owner for the same `git_remote` are a configuration mistake the mux will serve as two control planes.
 
 ## Task References
 
 - [ORB-11008] — recorded the federated multi-host MCP policy
-- [ORB-11009] — specified this proposed mechanism as the implementable contract
+- [ORB-11009] — specified this proposed mechanism as the implementable contract (PR #1139)
+- [ORB-11010] — closed the PR #1139 review contract holes in this folder
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/federated-mcp/3_vision.md
+++ b/docs/design/federated-mcp/3_vision.md
@@ -11,7 +11,7 @@ summary: Open questions for the proposed federated MCP mux: transport authentica
 tags: [federated-mcp, mcp, host-registry, multi-host]
 paths: ["crates/orbit-mcp/**", "crates/orbit-registry/**", "crates/orbit-core/**"]
 related_features: [federated-mcp, host-registry, mcp-bridge, remote-access, mcp-session-context]
-related_artifacts: [ORB-11009, ORB-11008]
+related_artifacts: [ORB-11010, ORB-11009, ORB-11008]
 ---
 
 # Federated MCP — Vision
@@ -22,18 +22,18 @@ Forward-looking only. The contract in [specs/federated-workspace-mcp.md](./specs
 
 1. **Transport authentication.** What authenticated principal does a destination Core receive on a mux-forwarded call? Selector possession is not authorization. Existing registry and session fields (`machine_id`, `host_id`, `caller_machine_id`, `caller_ip`, SSH audit labels) must not be promoted into credentials by implication.
 2. **Selector expiry.** Does a host-qualified selector remain valid across destination catalog edits, host re-init, and mux restarts, or does it expire? If it expires, what is the caller-visible error, and how does that differ from `stale_route`?
-3. **Health freshness.** How old may host-reachability and checkout-health be when listed? Is the list a live probe, a cached projection with explicit freshness, or a last-known snapshot for unreachable hosts? The spec requires including unreachable hosts; it does not yet define probe cadence or staleness thresholds.
+3. **Health freshness.** How old may host-reachability and checkout-health be when listed? Is the list a live probe, a cached projection with explicit freshness, or a last-known snapshot for unreachable hosts? The spec requires including unreachable hosts and requires routing to decide on live delivery rather than cached list health; it does not yet define probe cadence or staleness thresholds.
 4. **Cloud coordination-store details.** The declared control-plane authority may later offload the coordination store. What is the persistence contract, how do execution-binding hosts refer to it, and how does destination Core still refuse task issuance locally without implying replication?
 
 ## 2. Prior Work
 
 ### Policy recorded in host-registry / remote-access
 
-[ORB-11008] wrote the five-point federated policy (one namespace, live descriptors, fail-closed routing, destination authority, no replica protocol) into host-registry and remote-access vision. That write-up is superseded as a contract home; those docs now cross-link here.
+[ORB-11008] wrote the federated policy (one namespace, live descriptors, fail-closed routing, destination authority, no replica protocol) into host-registry and remote-access vision. That write-up is superseded as a contract home; those docs now cross-link here as a standing constraint. They no longer hold the five-point policy list.
 
 ### Host-registry catalog roles
 
-Owner vs replica checkouts, `machine_id` vs `host_id`, and checkout-health as repo-root presence are live v1 catalog rules. This feature maps new nouns onto those roles instead of creating a parallel ownership vocabulary. See [host-registry 2_design.md](../host-registry/2_design.md).
+Owner vs replica checkouts, `machine_id` vs `host_id`, and checkout-health as repo-root presence are live v1 catalog rules. This feature maps new nouns onto those roles instead of creating a parallel ownership vocabulary. See [host-registry 2_design.md](../host-registry/2_design.md). A workspace with absent `owner_machine_id` cannot advertise `control_plane`.
 
 ### mcp-bridge v1
 
@@ -66,6 +66,7 @@ Nothing in the mux topology is novel: it is a configured reverse-proxy in front 
 ## Task References
 
 - [ORB-11008] — recorded the federated multi-host MCP policy
-- [ORB-11009] — opened this vision folder as the contract home and left the questions above unresolved
+- [ORB-11009] — opened this vision folder as the contract home and left the questions above unresolved (PR #1139)
+- [ORB-11010] — closed review holes in the spec without resolving these vision questions
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/federated-mcp/4_decisions.md
+++ b/docs/design/federated-mcp/4_decisions.md
@@ -11,7 +11,7 @@ summary: Standing rules for the proposed federated MCP mux: destinations are con
 tags: [federated-mcp, mcp, host-registry, multi-host]
 paths: ["crates/orbit-mcp/**", "crates/orbit-registry/**", "crates/orbit-core/**"]
 related_features: [federated-mcp, host-registry, mcp-bridge, remote-access]
-related_artifacts: [ORB-11009, ORB-11008]
+related_artifacts: [ORB-11010, ORB-11009, ORB-11008]
 ---
 
 # Federated MCP — Decisions
@@ -20,7 +20,7 @@ Record non-obvious decisions here by title. These are Door 2 standing rules for 
 
 ## Federated MCP is a mux of operator-configured destinations
 
-**Recorded:** 2026-08 · [ORB-11009]
+**Recorded:** 2026-08 · [ORB-11009] · [ORB-11010] (PR #1139)
 
 ### Context
 
@@ -35,56 +35,73 @@ Treat the federated surface as a mux in front of destinations the operator alrea
 - Destination membership is an operator configuration problem, not a catalog schema problem.
 - Cost: the mux cannot "just find" an owner or a healthy replica; a missing destination is a configuration gap, not a discovery miss.
 
-## Host-qualified selectors are keyed by machine_id
+## Host-qualified selectors are structured and caller-uninterpreted
 
-**Recorded:** 2026-08 · [ORB-11009]
+**Recorded:** 2026-08 · [ORB-11009] · [ORB-11010] (PR #1139)
 
 ### Context
 
-`host_id` is renameable display. Keying a route on it would invalidate every selector on `orbit host rename` and invite examples such as `orbit-linux/ws_orbit`. The gateway's local catalog is the wrong resolution authority for another machine's workspace.
+`host_id` is renameable display. Keying a route on it would invalidate every selector on `orbit host rename` and invite examples such as `orbit-linux/ws_orbit`. Treating the token as a formless blob hid that the encoding `hm_<id>/ws_*` is normative. The gateway's local catalog is the wrong resolution authority for another machine's workspace.
 
 ### Decision
 
-Key the opaque host-qualified selector on stable `machine_id` (`hm_…`), for example `hm_<id>/ws_orbit`. Callers treat it as opaque. The gateway must not reinterpret it against its own local catalog. Two configured destinations that share a `machine_id`, or a token that is not uniquely host-qualified, are `ambiguous_destination`. Apply this to every new selector encoding, including future transport wrappers.
+Key the host-qualified selector on stable `machine_id` (`hm_…`). Encoding `hm_<id>/ws_*` is normative. Callers treat the token as **structured, caller-uninterpreted**: they must not parse it, must not construct it from `host_id`, and must not concatenate remembered `machine_id` and `id` values. The only caller-facing way to obtain a selector is to copy the `selector` field from federated `orbit_workspace_list`. The gateway must not reinterpret it against its own local catalog. A token that is not uniquely host-qualified (a bare `ws_*`) is `unknown_selector`. Duplicate `machine_id` across destinations is config-load `ambiguous_destination`, not a per-call outcome. Apply this to every new selector encoding, including future transport wrappers.
 
 ### Consequences
 
 - Renames do not rebind routes; callers can persist selectors across display-name changes.
-- Cost: humans cannot mint a selector from a hostname they remember; they must copy `machine_id` from the list (or a configured destination record).
+- Cost: humans cannot mint a selector from a hostname they remember, and they cannot assemble one from listed `machine_id` + `id` either; they must copy the list `selector` field.
 
-## Capability class and mutation authority are split
+## Capability class is assigned by tool behavior, held by catalog role
 
-**Recorded:** 2026-08 · [ORB-11009]
+**Recorded:** 2026-08 · [ORB-11009] · [ORB-11010] (PR #1139)
 
 ### Context
 
-One namespace plus several checkouts of one repository looks like a synchronized task store unless capability and authority are named separately. Lumping "mutations" would send `orbit_task_add` to a replica, or silently fail over to the owner, and invent a second ownership model.
+One namespace plus several checkouts of one repository looks like a synchronized task store unless capability and authority are named separately. Lumping "mutations" would send `orbit_task_add` to a replica, or silently fail over to the owner, and invent a second ownership model. Classifying only `orbit_task_add` would leave every other tool for an implementer to guess. Treating list advertisement as the source of truth is circular because advertisement can lag Core, and `owner_machine_id` is `Option`.
 
 ### Decision
 
-Map capabilities onto existing catalog roles: owner checkout is `control_plane` (and typically `execute`); replica checkout is `execute`. Destination-host Core refuses the other class with `capability_refused` and no implicit failover. Split remaining authority: the destination host owns runs, logs, and scheduler state; the declared control-plane owns task issuance and the coordination store. The gateway may advertise capabilities; it does not rewrite destinations. Apply this to every new federated tool, not only `orbit_task_add`.
+Assign capability class by what the tool does: task issuance and coordination-store writes are `control_plane`; tools that touch runs, logs, or scheduler state are `execute`; discovery and list tools are unclassified and are not subject to `capability_refused`. Do not add a per-tool registry field for this. The destination's **local catalog role** determines which classes that destination holds; list advertisement is a hint that may lag. Destination Core refusal is the correctness boundary. Owner checkout holds `control_plane` and may also hold `execute` when it runs locally — that second class is not a refusal input. Replica checkout holds `execute`. A workspace with absent `owner_machine_id` cannot advertise `control_plane`. Destination-host Core refuses the other class with `capability_refused` and no implicit failover. Split remaining authority: the destination host owns runs, logs, and scheduler state; the declared control-plane owns task issuance and the coordination store. Apply this to every new federated tool, not only `orbit_task_add`.
 
 ### Consequences
 
 - Owner/replica remain the only ownership vocabulary; execute-class work can stay on a replica without cloning the coordination store.
-- Cost: a caller that picks the wrong selector gets a named refusal instead of a successful write on the "right" host; clients must route control-plane tools to a `control_plane` destination themselves.
+- Cost: a caller that picks the wrong selector gets a named refusal instead of a successful write on the "right" host; clients must route control-plane tools to a `control_plane` destination themselves, and they cannot trust a stale list advertisement over the destination refuse.
 
 ## Unreachable destinations stay in the list and routing fails closed
 
-**Recorded:** 2026-08 · [ORB-11009]
+**Recorded:** 2026-08 · [ORB-11009] · [ORB-11010] (PR #1139)
 
 ### Context
 
-Omitting a down host from `orbit_workspace_list` makes every later call a stale-route surprise. Overloading one `health` field hides whether SSH failed or the repo root is gone. Falling back to another host with the same `ws_*` is a replica protocol by another name.
+Omitting a down host from `orbit_workspace_list` makes every later call a stale-route surprise. Calling the federated list "additive" hid that v1 puts `machine_id` on the envelope and filters to Active-and-locally-checked-out workspaces. Overloading one `health` field hides whether SSH failed or the repo root is gone. Falling back to another host with the same `ws_*` is a replica protocol by another name. Overlapping error classes without precedence would let an implementation pick whichever name was convenient.
 
 ### Decision
 
-Federated `orbit_workspace_list` is session-unbound and additive. Host-reachability and checkout-health are separate fields. A down or unreachable host is included with an explicit projection, not omitted. Unknown, unreachable, unhealthy, ambiguous, and stale routes fail explicitly. `tool_not_on_this_host` is distinct from `unknown_selector`. No local fallback, no default workspace, no cached host-local runtime. Apply this to every new federated discovery field and every new routing miss.
+Federated `orbit_workspace_list` is a new session-unbound shape, not a compatible extension of v1: `machine_id` lives on each descriptor, not the envelope, and the v1 Active-and-locally-checked-out filter is not inherited. Configured workspaces on unreachable or inactive destinations are included. Host-reachability and checkout-health are separate fields. Routing decides on live delivery, not cached list health. Caller-facing precedence is `unknown_selector` → `ambiguous_destination` (config) → `unreachable_destination` → `stale_route` → `unhealthy_checkout` → `tool_not_on_this_host` → `capability_refused`. Unreachable wins over capability and stale because those are undecidable without the host. `tool_not_on_this_host` is distinct from `unknown_selector`. No local fallback, no default workspace, no cached host-local runtime. Probe cadence stays a vision open question. Apply this to every new federated discovery field and every new routing miss.
 
 ### Consequences
 
 - Callers can distinguish "host down" from "checkout missing" from "tool not advertised here."
 - Cost: the list is not a set of live, callable workspaces; clients must read reachability and capabilities before routing, and availability is bounded by the chosen destination.
+
+## Single control-plane per repository is operator configuration
+
+**Recorded:** 2026-08 · [ORB-11010] (PR #1139)
+
+### Context
+
+Owner role is machine-local. Two hosts can each declare Owner. Independently inited checkouts have different `ws_*`, so the mux cannot observe the collision without the fleet discovery this design forbids. Listing "competing authorities" as a mux-enforced non-goal would make an implementer invent detection the architecture cannot perform.
+
+### Decision
+
+A single control-plane per repository is an operator configuration responsibility, not a mux invariant. The mux does not detect competing owners and does not raise an error when they exist. The would-be signal is matching `git_remote` across destinations with differing `owner_machine_id`. A violation surfaces as two independent control planes, not an error. Apply this whenever a future change is tempted to compare `git_remote` values inside the gateway or to refuse a second Owner.
+
+### Consequences
+
+- Operators who configure one owner per repository get one control plane; that is a deployment rule, not software.
+- Cost: a misconfigured pair of destinations will accept conflicting task issuance with no mux warning.
 
 ## The mux is a federated-namespace exception to v1 no-relay
 
@@ -106,6 +123,7 @@ Admit the mux as an explicit exception to v1 byte-transparent / no-relay rules *
 ## Task References
 
 - [ORB-11008] — recorded the prior federated MCP policy that these rules implement
-- [ORB-11009] — recorded these standing rules as the contract home
+- [ORB-11009] — recorded these standing rules as the contract home (PR #1139)
+- [ORB-11010] — closed the PR #1139 review holes (selector wording, tool class, error precedence, competing authorities)
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/federated-mcp/references/glossary.md
+++ b/docs/design/federated-mcp/references/glossary.md
@@ -8,7 +8,7 @@ status: Draft
 feature: federated-mcp
 tags: [federated-mcp, glossary]
 related_features: [federated-mcp, host-registry, mcp-bridge]
-related_artifacts: [ORB-11009, ORB-11008]
+related_artifacts: [ORB-11010, ORB-11009, ORB-11008]
 ---
 
 # Glossary: Federated MCP
@@ -17,17 +17,20 @@ Vocabulary for the proposed federated MCP mux. Standard industry terms (proxy, m
 
 | Term | Meaning |
 |------|---------|
-| **Ambiguous destination** | Two configured destinations share a `machine_id`, or the selector is not uniquely host-qualified. Fails as `ambiguous_destination`. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
-| **Capabilities** | Advertised classes for a destination+workspace, at least `control_plane` and `execute`. Mapped onto owner vs replica checkouts. [2_design.md §3](../2_design.md) |
+| **Ambiguous destination** | Duplicate `machine_id` among configured destinations. Raised at **config load** as `ambiguous_destination`, not per call. A token that is not uniquely host-qualified (bare `ws_*`) is `unknown_selector`, not this class. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
+| **Capabilities** | Classes a destination holds for a workspace, at least `control_plane` and `execute`. Determined by the destination's local catalog role. List advertisement is a hint that may lag; Destination Core refusal is the correctness boundary. A workspace with absent `owner_machine_id` cannot advertise `control_plane`. [2_design.md §3](../2_design.md) |
 | **Checkout health** | Repo-root presence at the destination (`active` / `invalid` / `unknown` when the host cannot be probed). Not SSH reachability. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
-| **Control-plane authority** | The declared owner checkout (or a later cloud-offloaded store) that owns task issuance and the coordination store for that workspace. [2_design.md §4](../2_design.md) |
+| **Control-plane authority** | The declared owner checkout (or a later cloud-offloaded store) that owns task issuance and the coordination store for that workspace. One per repository is operator configuration, not a mux invariant. [2_design.md §4](../2_design.md) |
 | **Destination** | An operator-configured MCP or SSH remote the mux may forward to. Not a host-registry fleet member. [2_design.md §1](../2_design.md) |
 | **Execute binding** | A replica checkout: it can run, log, and schedule on that host and must refuse control-plane tools. [2_design.md §3](../2_design.md) |
-| **Fail-closed routing** | Unknown, unreachable, unhealthy, ambiguous, and stale routes fail explicitly; no local fallback, default workspace, or `ws_*` substitution. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
+| **Fail-closed routing** | Live delivery with a single caller-facing precedence: `unknown_selector` → `ambiguous_destination` (config) → `unreachable_destination` → `stale_route` → `unhealthy_checkout` → `tool_not_on_this_host` → `capability_refused`. No local fallback, default workspace, or `ws_*` substitution. Cached list health does not decide the error. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
 | **Federated namespace** | The caller-facing MCP surface that accepts host-qualified selectors and list-without-session. The only place the v1 no-relay rule is excepted. [mcp-bridge 3_vision.md §5](../../mcp-bridge/3_vision.md) |
+| **Federated workspace list** | New session-unbound shape for `orbit_workspace_list`. Puts `machine_id` on each descriptor, not the v1 envelope, and does not inherit the v1 Active-and-locally-checked-out filter. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
 | **Gateway** | The mux process that advertises the federated namespace. It does not own destination state and does not rewrite destinations. [1_overview.md](../1_overview.md) |
 | **Host reachability** | Whether the configured destination answers (reachable / unreachable). Separate from checkout health. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
-| **Host-qualified selector** | Opaque addressing token keyed by `machine_id`, for example `hm_<id>/ws_orbit`. Not `host_id`, not a path, not a credential. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
+| **Host-qualified selector** | Structured, caller-uninterpreted addressing token. Encoding `hm_<id>/ws_*` is normative. Not `host_id`, not a path, not a credential. Callers copy the list `selector` field; they must not parse or construct the token. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
 | **Mux** | A configured forwarder of already-chosen destinations, not a registry and not automatic owner discovery. [2_design.md §1](../2_design.md) |
-| **Stale route** | The encoded destination no longer advertises that workspace. Fails as `stale_route`. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
+| **Stale route** | Destination is configured; a live probe shows the workspace is absent. Fails as `stale_route`. Distinct from `unknown_selector` (selector never valid). [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
+| **Tool class** | Assignment by behavior: coordination-store writes are `control_plane`; runs/logs/scheduler tools are `execute`; discovery/list tools are unclassified and not subject to `capability_refused`. Not a per-tool registry field. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
 | **Tool-not-on-this-host** | The destination is identified but does not advertise the tool. Distinct from `unknown_selector`. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
+| **Unclassified tool** | Discovery/list tool. Not subject to `capability_refused`. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |

--- a/docs/design/federated-mcp/specs/federated-workspace-mcp.md
+++ b/docs/design/federated-mcp/specs/federated-workspace-mcp.md
@@ -8,16 +8,16 @@ status: Draft
 feature: federated-mcp
 tags: [federated-mcp, mcp, spec]
 related_features: [federated-mcp, host-registry, mcp-bridge]
-related_artifacts: [ORB-11009, ORB-11008]
+related_artifacts: [ORB-11010, ORB-11009, ORB-11008]
 ---
 
 # Spec: Federated workspace MCP
 
-The federated MCP surface is a **mux of operator-configured destinations**. It presents one caller-facing MCP namespace, lists every configured destination's workspaces as live descriptors, and routes an opaque host-qualified selector to the encoded destination. It is **not** a host-registry evolution, **not** a fleet inventory, and **not** automatic owner discovery. Direct SSH stdio to one chosen host remains v1. This spec is proposed; it is not implemented.
+The federated MCP surface is a **mux of operator-configured destinations**. It presents one caller-facing MCP namespace, lists every configured destination's workspaces as live descriptors, and routes a structured, caller-uninterpreted host-qualified selector to the encoded destination. It is **not** a host-registry evolution, **not** a fleet inventory, and **not** automatic owner discovery. Direct SSH stdio to one chosen host remains v1. This spec is proposed; it is not implemented.
 
 ## Why This Exists
 
-Without this contract, an implementation will key selectors on renameable `host_id`, invent a second ownership model, lump runs and task issuance as one "mutations" blob, omit down hosts from the list, or violate mcp-bridge's no-relay rule (or ship a mux the corpus still forbids). [ORB-11008] recorded the policy; this spec is the implementable mechanism from [ORB-11009].
+Without this contract, an implementation will key selectors on renameable `host_id`, invent a second ownership model, lump runs and task issuance as one "mutations" blob, omit down hosts from the list, or violate mcp-bridge's no-relay rule (or ship a mux the corpus still forbids). [ORB-11008] recorded the policy; [ORB-11009] (PR #1139) opened this spec; [ORB-11010] closes the contract holes that review named.
 
 ## Mux, not fleet registry
 
@@ -28,24 +28,42 @@ Without this contract, an implementation will key selectors on renameable `host_
 
 ## Selector identity
 
-1. The opaque host-qualified selector is keyed by stable `machine_id` (`hm_…`), not renameable `host_id`.
-2. Example form: `hm_<id>/ws_orbit`. Callers treat the token as opaque. Display names such as `orbit-linux/ws_orbit` are not selectors.
-3. The selector is addressing data, not a path, URL, logical-only workspace ID, or authorization credential. Possession of a selector is not authorization.
-4. Every workspace-scoped federated tool accepts the selector. The gateway routes that call to the encoded destination.
-5. **Ambiguous destination** means either (a) two configured destinations share a `machine_id`, or (b) the token is not uniquely host-qualified. Both fail as `ambiguous_destination`.
+1. The host-qualified selector is **structured, caller-uninterpreted**. Encoding `hm_<id>/ws_*` is normative (example: `hm_<id>/ws_orbit`). The stable key is `machine_id` (`hm_…`), not renameable `host_id`.
+2. Callers must not parse the token and must not construct it from `host_id` or by concatenating remembered identifiers. The only caller-facing way to obtain a selector is to copy the `selector` field from federated `orbit_workspace_list`.
+3. Display names such as `orbit-linux/ws_orbit` are not selectors.
+4. The selector is addressing data, not a path, URL, logical-only workspace ID, or authorization credential. Possession of a selector is not authorization.
+5. Every workspace-scoped federated tool accepts the selector. The gateway routes that call to the encoded destination.
+6. A token that is not uniquely host-qualified (a bare `ws_*`, a display host name, or any other form that does not match the normative encoding) is `unknown_selector`, not `ambiguous_destination`.
+7. Duplicate `machine_id` across configured destinations is a **config-load** `ambiguous_destination`. The mux must not treat that collision as a per-call routing outcome.
+
+## Tool classes
+
+Capability class is assigned by **what the tool does**, not by a per-tool registry field and not by naming `orbit_task_add` alone.
+
+| Class | Rule | Examples (not an exhaustive registry) |
+|---|---|---|
+| `control_plane` | Task issuance and coordination-store writes | `orbit_task_add`, `orbit.task.update`, `orbit.task.start` |
+| `execute` | Anything that touches runs, logs, or scheduler state | job-run inspect/cancel, log read, routine/scheduler mutations |
+| unclassified | Discovery and list tools | `orbit_workspace_list` (federated), other list/discovery tools |
+
+Unclassified tools are **not** subject to `capability_refused`. A destination may still fail them for other routing classes (`unknown_selector`, `unreachable_destination`, `tool_not_on_this_host`, and so on).
 
 ## Capabilities vs checkout roles
 
 Capabilities distinguish at least `control_plane` and `execute`. They map onto existing host-registry catalog roles; do not invent a parallel ownership vocabulary.
 
-| Catalog role (v1) | Advertised capabilities | Destination Core |
+**The destination's local catalog role determines capability class.** Federated-list advertisement is a hint and may lag the destination. Destination Core refusal remains the correctness boundary. The gateway does **not** enforce by rewriting the destination, and "typically also `execute`" is not a refusal input.
+
+| Catalog role (v1) | Classes the destination holds | Destination Core |
 |---|---|---|
-| Owner checkout | `control_plane`; typically also `execute` | Control-plane authority for that workspace's coordination. Refuses `execute`-class tools only when it does not advertise `execute` (for example a future control-plane-only store). |
+| Owner checkout | `control_plane`. May also hold `execute` when that checkout runs locally; that second class is independent of the owner role. | Control-plane authority for that workspace's coordination. Refuses `execute`-class tools only when it does not hold `execute` (for example a future control-plane-only store). |
 | Replica checkout | `execute` | Execution binding. Refuses `control_plane` tools. |
 
+A workspace whose logical record has absent `owner_machine_id` (`Option` on `Workspace` in `crates/orbit-types/src/workspace/registry.rs`) **cannot advertise `control_plane`**. Standalone registries that predate host identity may omit the field; they are not a control-plane authority.
+
 1. Destination-host Core **refuses the other class** with named error `capability_refused`.
-2. The gateway may advertise capabilities. It does **not** enforce by rewriting the destination.
-3. If a caller routes `orbit_task_add` (or any other control-plane tool) to an execution-binding host, the destination refuses with `capability_refused`. The gateway **must not** silently send it to the owner. No implicit failover.
+2. The gateway may advertise capabilities. Advertisement is not authorization and is not a second enforcement layer.
+3. If a caller routes a `control_plane` tool (`orbit_task_add`, `orbit.task.update`, or any other coordination-store write) to an execution-binding host, the destination refuses with `capability_refused`. The gateway **must not** silently send it to the owner. No implicit failover.
 
 ## Split authority ("mutations" is not one blob)
 
@@ -60,39 +78,63 @@ Do not specify a single "mutations" permission that covers both columns. A repli
 
 Federated `orbit_workspace_list` is an aggregate of live descriptors, not an aggregate task or store query.
 
+## Single control-plane per repository is operator configuration
+
+A single control-plane per repository is an **operator configuration responsibility**, not a mux invariant. The mux does **not** detect competing owners and does **not** raise an error when two destinations each declare Owner.
+
+The would-be signal is matching `git_remote` across destinations with differing `owner_machine_id`. Independently inited checkouts also have different `ws_*`, so the mux cannot observe the collision without the fleet discovery this design forbids. A violation surfaces as **two independent control planes**, not as a routing or config error.
+
 ## Federated `orbit_workspace_list`
 
+Federated `orbit_workspace_list` is a **new session-unbound response shape**, not a compatible extension of v1 `orbit.workspace.list`.
+
+v1 (`crates/orbit-mcp/src/remote/discovery.rs`) returns `{"machine_id": "hm_…", "workspaces": […]}` with `machine_id` on the **envelope**, and filters to `Active` workspaces that are locally checked out on the accepting machine.
+
+Federated list does **not** inherit that envelope or that filter:
+
 1. **Session-unbound.** The tool must not require a workspace selector. Session/initialize workspace metadata is not an input and not a filter.
-2. **Additive.** Each descriptor keeps today's v1 workspace fields (`id`, `name`, `ship_mode`, `owner_machine_id`, `git_remote`, `base_branch`, `status`, `created_at`, `updated_at`) and adds:
+2. **`machine_id` on each descriptor**, not on the envelope. Each descriptor keeps today's v1 workspace fields (`id`, `name`, `ship_mode`, `owner_machine_id`, `git_remote`, `base_branch`, `status`, `created_at`, `updated_at`) and adds:
 
    | Field | Meaning |
    |---|---|
-   | `selector` | Opaque host-qualified route token (`hm_<id>/ws_*`) |
+   | `selector` | Structured, caller-uninterpreted host-qualified route token (`hm_<id>/ws_*`). Copy this field; do not parse it. |
    | `host` | Destination display identity (renameable `host_id`; display only) |
    | `machine_id` | Destination stable identity (`hm_…`) |
    | host-reachability | Whether the configured destination answers |
    | checkout-health | Repo-root presence at that destination (`active` / `invalid` / `unknown` if the host cannot be probed) |
-   | `capabilities` | Classes the destination currently advertises for that workspace |
+   | `capabilities` | Classes the destination currently **advertises** for that workspace (a hint; see Capabilities vs checkout roles) |
 
 3. **Do not overload one `health` field** with SSH/MCP reachability and repo-root presence.
-4. **Include unreachable hosts.** A down or unreachable configured destination appears with an explicit unreachable (and, if checkout cannot be probed, unknown/unhealthy) projection. **Do not omit it.** Omission makes every later call a stale-route surprise.
-5. v1 `orbit.workspace.list` on a single accepting machine is unchanged: it remains machine-local and is documented in mcp-bridge / host-registry current-behavior docs.
+4. **Include unreachable and inactive destinations.** Configured workspaces on unreachable or inactive destinations are included, not omitted. A down destination appears with an explicit unreachable (and, if checkout cannot be probed, unknown/unhealthy) projection. Omission makes every later call a stale-route surprise.
+5. v1 `orbit.workspace.list` on a single accepting machine is unchanged: it remains machine-local, envelope-keyed, and Active-and-locally-checked-out, and is documented in mcp-bridge / host-registry current-behavior docs.
 
 ## Fail-closed routing
 
 The gateway delivers a workspace-scoped federated call to the destination encoded in the selector. It does not fall back to a local workspace, another host with a matching `ws_*`, a default workspace, or a cached host-local runtime.
 
+Routing decides on **live delivery**, not cached list health. Probe cadence and list freshness remain a vision open question; they do not change which error a live call returns.
+
 | Class | Error identity | When |
 |---|---|---|
-| unknown | `unknown_selector` | Token does not name a configured destination+workspace |
-| unreachable | `unreachable_destination` | Configured destination does not answer |
+| unknown | `unknown_selector` | Token never valid: it does not uniquely name a configured destination+workspace, including a token that is not uniquely host-qualified (bare `ws_*`) |
+| ambiguous | `ambiguous_destination` | Duplicate `machine_id` among configured destinations, raised at **config load**, not per call |
+| unreachable | `unreachable_destination` | Configured destination does not answer a live delivery attempt |
+| stale-route | `stale_route` | Destination is configured; a live probe shows that workspace is absent |
 | unhealthy | `unhealthy_checkout` | Destination answers but the checkout is not usable (repo-root missing / invalid) |
-| ambiguous | `ambiguous_destination` | Shared `machine_id` among destinations, or token not uniquely host-qualified |
-| stale-route | `stale_route` | Encoded destination no longer advertises that workspace |
 | tool not advertised | `tool_not_on_this_host` | Destination is identified; the tool is not on that host's advertised surface |
 | capability refuse | `capability_refused` | Destination Core holds the workspace but refuses the tool's capability class |
 
+`stale_route` vs `unknown_selector`: destination configured but workspace absent after a live probe → `stale_route`; selector never valid → `unknown_selector`.
+
 `tool_not_on_this_host` is distinct from `unknown_selector`. `capability_refused` is distinct from both: the tool may be advertised elsewhere on that host, but this checkout role will not execute it.
+
+### Caller-facing precedence
+
+When more than one class could apply, return the first that matches:
+
+`unknown_selector` → `ambiguous_destination` (config) → `unreachable_destination` → `stale_route` → `unhealthy_checkout` → `tool_not_on_this_host` → `capability_refused`
+
+Unreachable wins over capability and stale because those are undecidable without the host. Cached list health must not reorder this list.
 
 ## mcp-bridge invariant exception
 
@@ -114,7 +156,7 @@ The following remain out of this surface:
 - task or store replication;
 - synchronization;
 - quorum election;
-- competing authorities;
+- detecting or rejecting competing control-plane authorities (operator configuration; see above);
 - implicit failover;
 - silent merging of host-local state.
 
@@ -122,4 +164,4 @@ A disconnected or failed host therefore removes the affected route from useful s
 
 ## Agent Signature
 
-Specified by grok in [ORB-11009], citing prior policy [ORB-11008].
+Specified by grok in [ORB-11009] (PR #1139), with contract holes closed in [ORB-11010], citing prior policy [ORB-11008].


### PR DESCRIPTION
## Task

[ORB-11010](https://orbit-cli.com/tasks/ORB-11010) — Close federated-mcp contract holes from PR #1139 review

### Description

## Problem
[ORB-11009] landed as merged PR https://github.com/danieljhkim/orbit/pull/1139 (`f6e62ee`) while Daniel's review on that PR was still open. The review is structurally approving but names one CI blocker and six contract holes. Until they are closed, an implementation task will invent the missing rules — the failure [ORB-11009] existed to prevent.

Review: https://github.com/danieljhkim/orbit/pull/1139#pullrequestreview-5003319115

## Why It Matters
`make ci-fast` already fails on `agent-main` (`docs/INDEX.md` stale). The two design holes Daniel flagged as most important — no tool-to-capability-class rule, and competing control-plane authorities as an unenforceable non-goal — leave the spec unimplementable.

## Source comments (address every one)

1. **Blocker — INDEX.md** (review body). `./scripts/generate-doc-indexes.sh --check` fails because the generator skipped the untracked folder in the sandbox, then the commit landed without a Federated MCP row. Regenerated row should be:
   `| [Federated MCP](./design/federated-mcp/1_overview.md) | Proposed mux that presents one MCP namespace over operator-configured destinations, keyed by machine_id, without becoming a fleet registry. | Draft | grok |`
   Re-run `make docs-index` after the files are tracked; do not hand-edit INDEX.md if the generator produces the row.

2. **No rule assigns tools to capability classes** — https://github.com/danieljhkim/orbit/pull/1139#discussion_r3839541701 (`specs/federated-workspace-mcp.md` capabilities section). Only `orbit_task_add` is classified. Encode this rule in the spec (not only vision):
   - task issuance and coordination-store writes → `control_plane`
   - anything touching runs, logs, or scheduler state → `execute`
   - discovery / `orbit_workspace_list` → unclassified (not subject to `capability_refused`)
   Do not invent a per-tool registry field in this task.

3. **Advertisement vs catalog role is circular; `owner_machine_id` is `Option`** — https://github.com/danieljhkim/orbit/pull/1139#discussion_r3839541702. Pick: destination local catalog role determines class; advertisement is a hint that may lag (align with `2_design.md` §8). Drop "typically also `execute`" as a refusal input. A workspace with no `owner_machine_id` (`crates/orbit-types/src/workspace/registry.rs`) cannot advertise `control_plane`.

4. **"Additive" hides a response-shape change and skips the v1 filter** — https://github.com/danieljhkim/orbit/pull/1139#discussion_r3839541704. v1 `orbit.workspace.list` is `{"machine_id", "workspaces":[...]}` with `machine_id` on the envelope (`crates/orbit-mcp/src/remote/discovery.rs`) and filters to Active + locally checked out. Federated list is a new session-unbound shape with `machine_id` on each descriptor, and does **not** inherit that filter: include configured workspaces on unreachable/inactive destinations so omission cannot become a stale-route surprise.

5. **Error classes overlap; no precedence** — https://github.com/danieljhkim/orbit/pull/1139#discussion_r3839541705. Required taxonomy:
   - duplicate configured `machine_id` → config-load `ambiguous_destination` (not per-call)
   - token not uniquely host-qualified (bare `ws_*`) → `unknown_selector` (not `ambiguous_destination`)
   - `stale_route` vs `unknown_selector`: destination configured but workspace absent after a live probe → `stale_route`; selector never valid → `unknown_selector`
   - Precedence when multiple could apply: `unknown_selector` → `ambiguous_destination` (config) → `unreachable_destination` → `stale_route` → `unhealthy_checkout` → `tool_not_on_this_host` → `capability_refused`. Unreachable wins over capability/stale because those are undecidable without the host.
   - Routing uses live delivery, not cached list health. Probe cadence stays a vision open question.

6. **Competing authorities cannot be enforced** — https://github.com/danieljhkim/orbit/pull/1139#discussion_r3839541707. Owner role is machine-local (`crates/orbit-registry/src/workspace_registry/catalog.rs`). Two hosts can each declare Owner; independently inited checkouts have different `ws_*`, so the mux cannot observe the collision without the fleet discovery this design forbids. Spec must say:
   - single control-plane per repository is an **operator configuration responsibility**, not a mux invariant
   - the mux does not check it
   - the would-be signal is matching `git_remote` with differing `owner_machine_id`
   - a violation surfaces as two independent control planes, not an error

7. **Overview row points at deleted content** — https://github.com/danieljhkim/orbit/pull/1139#discussion_r3839541709. Relabel or drop the `host-registry/3_vision.md` "Prior policy (five-point list)" row. That file is now a cross-link and standing constraint, not the five-point list.

8. **"Opaque" vs pinned form** — https://github.com/danieljhkim/orbit/pull/1139#discussion_r3839541710. Replace "opaque" with **structured, caller-uninterpreted** everywhere in this folder (spec, 2_design, 4_decisions, glossary). Encoding `hm_<id>/ws_*` is normative; callers must not parse it or construct it from `host_id`. Humans copy the `selector` field from the list, not `machine_id` concatenated by hand, unless the spec explicitly allows constructing from listed `machine_id` + `id` as an operator convenience (if so, say that once, in 4_decisions).

## Constraints / Notes
- Docs only. No runtime/code changes.
- Keep feature status Draft, owner grok.
- Do not reopen mcp-bridge v1 `2_design.md` current-behavior text.
- Do not re-expand the five-point list into host-registry / remote-access vision.
- Cite this task plus [ORB-11009] and PR #1139 in `related_artifacts` where the folder already cites [ORB-11009].

## Risks
- Inventing a per-tool capability table instead of the class rule above.
- Making competing-authority detection a mux feature (forbidden).
- Claiming `make ci-fast` passed while INDEX is still stale.
- Leaving "opaque" in the glossary after the spec is fixed.

### Acceptance Criteria

- docs/INDEX.md includes a Federated MCP row pointing at design/federated-mcp/1_overview.md; after the new files are tracked, `./scripts/generate-doc-indexes.sh --check` and `make ci-fast` both pass (do not claim pass while the folder is untracked).
- The spec states an explicit tool-class rule: task issuance and coordination-store writes are `control_plane`; tools that touch runs, logs, or scheduler state are `execute`; discovery/list tools are unclassified. `orbit_task_add` is not the only classified example. Unclassified tools are not subject to `capability_refused`.
- The spec states that the destination's local catalog role determines capability class; list advertisement is a hint and may lag. Destination Core refusal remains the correctness boundary. A workspace with absent `owner_machine_id` cannot advertise `control_plane`.
- The spec states the federated `orbit_workspace_list` response is a new session-unbound shape, not a compatible extension of v1: v1 puts `machine_id` on the envelope, federated puts it on each descriptor. Federated list does not inherit the v1 Active-and-locally-checked-out filter; configured workspaces on unreachable or inactive destinations are included, not omitted.
- The spec gives a single caller-facing error precedence. Duplicate `machine_id` across destinations is a config-load `ambiguous_destination`, not a per-call routing outcome. A token that is not uniquely host-qualified (e.g. bare `ws_*`) is `unknown_selector`, not `ambiguous_destination`. Routing decides on live delivery, not cached list health.
- The spec states that a single control-plane per repository is an operator configuration responsibility, not a mux invariant. The mux does not detect competing owners. The would-be signal is matching `git_remote` across destinations with differing `owner_machine_id`; a violation surfaces as two independent control planes, not an error.
- 1_overview.md no longer claims host-registry vision still holds the five-point policy list. Selector wording across spec, 2_design, 4_decisions, and glossary is "structured, caller-uninterpreted": encoding `hm_<id>/ws_*` is normative; callers must not parse or construct it except by copying the list `selector` field.
- make ci-lint passes. No runtime or Cargo changes. Feature stays Draft / owner grok. Cite this task and [ORB-11009] / PR #1139.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Regenerated `docs/INDEX.md` via `make docs-index` after confirming `docs/design/federated-mcp/` is tracked; Federated MCP row matches the review (`Draft` / grok, link to `1_overview.md`).
- Spec now assigns tool class by behavior: coordination-store writes (`orbit_task_add`, `orbit.task.update`, `orbit.task.start`) are `control_plane`; runs/logs/scheduler tools are `execute`; discovery/list tools are unclassified and not subject to `capability_refused`. No per-tool registry field.
- Catalog role is the class source of truth; list advertisement is a lagging hint; Destination Core refusal is the correctness boundary. Dropped "typically also execute" as a refusal input. Absent `owner_machine_id` cannot advertise `control_plane`.
- Federated `orbit_workspace_list` is a new session-unbound shape (not a v1 extension): `machine_id` on each descriptor, not the envelope; does not inherit the v1 Active-and-locally-checked-out filter; unreachable/inactive destinations stay in the list.
- Single caller-facing error precedence: `unknown_selector` → `ambiguous_destination` (config-load only) → `unreachable_destination` → `stale_route` → `unhealthy_checkout` → `tool_not_on_this_host` → `capability_refused`. Bare `ws_*` is `unknown_selector`. Routing uses live delivery, not cached list health.
- Single control-plane per repository is operator configuration, not a mux invariant. Mux does not detect matching `git_remote` with differing `owner_machine_id`; a violation is two independent control planes, not an error.
- Relabeled the host-registry vision row (standing constraint; five-point list no longer lives there). Selector wording is "structured, caller-uninterpreted" with normative `hm_<id>/ws_*`; callers copy the list `selector` field. Folder cites [ORB-11010], [ORB-11009], and PR #1139. PR #1139 is in Task References because `related_artifacts` accepts only PREFIX-NNNNN / friction / ADR ids.
Assessment: Docs-only contract closure of every PR #1139 hole. Feature remains Draft / owner grok. No runtime or Cargo changes.
Strategic decisions:
- Copy-only selectors: 4_decisions explicitly rejects concatenating listed `machine_id` + `id` as an operator convenience.
- Did not invent a per-tool capability table.
Validation: `./scripts/generate-doc-indexes.sh --check` passed after regenerate; `make ci-fast` passed; `make ci-lint` passed (clippy --workspace --all-targets -D warnings). Task remained in-progress through validation.
Unlisted files: none; all edits were already in `context_files`.
Friction: F2026-08-128 (`orbit.task.update` from a jrun worktree is cwd-bound and returns task_not_found unless `workspace: ws_orbit` is passed; `orbit.task.show` is host-registry).
Recommended follow-ups: none from this docs-only close; implementation must not add competing-owner detection or a per-tool class registry.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11010-6a8b5beb`
- Behind base: 0
- Ahead of base: 1