### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -1,7 +1,7 @@
 ---
 type: context
 summary: Lessons Learned While Building Orbit
-last_validated: 2026-07-27
+last_validated: 2026-08-23
 ---
 
 # Lessons Learned While Building Orbit

--- a/docs/design/_templates/references/glossary.md
+++ b/docs/design/_templates/references/glossary.md
@@ -1,7 +1,7 @@
 ---
 type: design
 summary: "Glossary: <Feature>"
-last_validated: 2026-07-27
+last_validated: 2026-08-23
 ---
 
 # Glossary: <Feature>

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -4,7 +4,7 @@ type: design
 title: "Activity / Job — Design"
 owner: codex
 last_updated: 2026-08-15
-last_validated: 2026-07-26
+last_validated: 2026-08-23
 status: Draft
 feature: activity-job
 doc_role: design
@@ -13,7 +13,7 @@ tags: ["activity-job"]
 
 # Activity / Job — Design
 
-This document describes the shipped Activity / Job substrate across `orbit-common`, `orbit-engine`, `orbit-core`, and `orbit-cli`: asset shape, normalization, dispatch boundaries, DAG execution, audit, and retained legacy edges. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for open questions.
+This document describes the shipped Activity / Job substrate across `orbit-types`, `orbit-engine`, `orbit-core`, and `orbit-cli`: asset shape, normalization, dispatch boundaries, DAG execution, audit, and retained legacy edges. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for open questions.
 
 ---
 
@@ -25,7 +25,7 @@ Activity / Job assets are `schemaVersion: 2` YAML envelopes with:
 - `metadata.name`
 - typed `spec`
 
-The loader in `crates/orbit-common/src/types/activity_job/asset_loader.rs` reads the schema header first, then parses the full envelope into `ActivityV2` or `JobV2`; that shape arrived in [T20260418-2010]. `schemaVersion: 1` is retired after [T20260419-2156], and `kind` mismatches are structural errors, so an activity cannot dispatch as a job or vice versa.
+The loader in `crates/orbit-engine/src/activity_job/asset_loader.rs` reads the schema header first, then parses the full envelope into `ActivityV2` or `JobV2`; that shape arrived in [T20260418-2010]. `schemaVersion: 1` is retired after [T20260419-2156], and `kind` mismatches are structural errors, so an activity cannot dispatch as a job or vice versa.
 
 ---
 
@@ -208,7 +208,7 @@ The target-ref pass was added in [T20260418-2019] and `run-v2` entrypoints in [T
 
 The public CLI now executes activity assets through jobs rather than exposing a standalone `orbit activity run` subcommand. `orbit activity` is an inspection/catalog surface; `orbit job run` and workflow aliases under `orbit run` are the public execution surfaces after [T20260426-0047].
 
-Some module comments still describe older phase ordering; the authoritative behavior is the orbit-core call path in `crates/orbit-core/src/command/job/exec.rs`.
+Some module comments still describe older phase ordering; the authoritative behavior is the orbit-core call path in `crates/orbit-core/src/application/job/exec.rs`.
 
 Seeded direct shipment workflows (`task_local_pipeline` and `task_pr_pipeline`) opt into `recovery_activity: step_failure_recovery` on specific steps after [T20260430-14]. Activity routing has one mechanism after [ORB-10622]: a rendered `crew` input selects that crew, and an activity without one uses the run's resolved crew. `step_failure_recovery` opts into `workflow.system_crew`; the executor renders that configured name into its activity input before resolution. Activity and job assets declaring the retired `role` key fail to load with guidance to use `crew`. The recovery agent receives only the executor-provided recovery keys, inspects the failed step, makes bounded repairs when safe, and returns before the executor's single post-recovery attempt. Higher-level orchestration workflows do not enable the hook because replaying child-run dispatch or planning orchestration is not a safe default recovery action.
 
@@ -230,7 +230,7 @@ After [ORB-10363], `JobV2.failure_activity` is a terminal, best-effort hook dist
 
 After [ORB-10385] / [The runtime reports its deterministic-action registry, and job validation gates on it](./4_decisions.md#the-runtime-reports-its-deterministic-action-registry-and-job-validation-gates-on-it), a job's reachable deterministic actions are checked against the executing runtime before its first step runs. `RuntimeHost::has_deterministic_action` reports the shared typed registry; `validate_job_deterministic_actions` walks the job's `recovery_activity`, `failure_activity`, every step's `recovery_activity`, and every resolved deterministic target (recursing through `parallel:`, `fan_out:`, and `loop:`) and fails the run with `DeterministicActionUnavailable` naming both the activity and the action. Because the check runs inside `execute_job_with_resume` ahead of step one, the run never reaches `worktree_setup`, so no task is admitted and no worktree is created. Unknown actions are never skipped, and the default trait implementation reports `true`, so a host that cannot enumerate its registry keeps surfacing the miss at dispatch. The gate does not weaken the failure hook: an action that becomes unavailable after admission still leaves the original failed-step error authoritative.
 
-[ORB-10630] centralizes action names and core-versus-engine ownership in `orbit-common` ([Typed deterministic action declaration spans core and engine](./4_decisions.md#typed-deterministic-action-declaration-spans-core-and-engine), Proposed). The generated typed enums now derive core's advertised capability check and its engine forwarding path, while the engine matches its ownership-specific enum exhaustively. A declared action without its matching core or engine implementation therefore fails compilation rather than becoming runtime registry skew; an implementation cannot name an undeclared typed action. The duplicated dispatch-table assertion and standalone core asset scan were removed because they only compared duplicate lists. Catalog coverage remains: shipped YAML action strings are external inputs and must still be checked against the generated registry.
+[ORB-10630] centralizes action names and core-versus-engine ownership in `orbit-types` ([Typed deterministic action declaration spans core and engine](./4_decisions.md#typed-deterministic-action-declaration-spans-core-and-engine), Proposed). The generated typed enums now derive core's advertised capability check and its engine forwarding path, while the engine matches its ownership-specific enum exhaustively. A declared action without its matching core or engine implementation therefore fails compilation rather than becoming runtime registry skew; an implementation cannot name an undeclared typed action. The duplicated dispatch-table assertion and standalone core asset scan were removed because they only compared duplicate lists. Catalog coverage remains: shipped YAML action strings are external inputs and must still be checked against the generated registry.
 
 The linked-worktree boundary guard now treats a clean same-branch primary fast-forward as concurrent base movement, not provider escape. The assigned checkout retains its own HEAD, so the later `pr_prepare`/`git_rebase` checkpoints reconcile that movement. Primary resets, force-moves, and branch switches surface as `primary_checkout_drift`; inadmissible history or branch movement inside the assigned worktree surfaces as `worktree_content_conflict`. Conflict diagnostics report `run_changed_paths`, `primary_changed_paths`, and their `conflicting_paths` separately instead of presenting the primary's entire moved set as the task's conflict.
 

--- a/docs/design/activity-job/3_vision.md
+++ b/docs/design/activity-job/3_vision.md
@@ -4,7 +4,7 @@ type: design
 title: "Activity / Job — Vision"
 owner: codex
 last_updated: 2026-07-20
-last_validated: 2026-07-26
+last_validated: 2026-08-23
 status: Draft
 feature: activity-job
 doc_role: vision
@@ -109,7 +109,7 @@ None of these are research contributions. Activity / Job earns its keep only if 
 - [4_decisions.md](./4_decisions.md) — ADR log
 - [specs/backend-resolution.md](./specs/backend-resolution.md) — retired agent backend selection and its migration
 - [specs/audit-envelope.md](./specs/audit-envelope.md) — v2 audit event tree and persistence layout
-- [../knowledge-graph/1_overview.md](../_archive/knowledge-graph/1_overview.md) — graph substrate that sits beside this execution substrate
+- [../_archive/knowledge-graph/1_overview.md](../_archive/knowledge-graph/1_overview.md) — graph substrate that sits beside this execution substrate
 
 ### External
 

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -4,7 +4,7 @@ type: design
 title: "Activity / Job — Decisions"
 owner: codex
 last_updated: 2026-08-15
-last_validated: 2026-07-26
+last_validated: 2026-08-23
 status: Draft
 feature: activity-job
 doc_role: decisions
@@ -70,7 +70,7 @@ Folded instances:
 The agent-loop path is where activity/job can most easily leak provider implementation details, mutable sessions, or role configuration across crate boundaries. The split ADRs all defended the same shape: shared types live low, orbit-core hosts primitive services, the engine dispatches concrete activity specs, and provider/backends remain explicit choices.
 
 ### Decision
-Keep activity/job types in `orbit-common`, keep orbit-core free of `orbit-agent` transport types, and route agent dispatch through retained provider CLI runtimes behind a host-resolved executor contract. Scope stateful agent features narrowly: Groundhog is its own activity kind, role config from `[agent.<role>]` overrides inline settings field-by-field, task-aware CLI envelopes carry durable run context, and provider static-arg fixups run before sandbox dispatch.
+Keep activity/job types in `orbit-types`, keep orbit-core free of `orbit-agent` transport types, and route agent dispatch through retained provider CLI runtimes behind a host-resolved executor contract. Activity routing is crew-based; the retired Groundhog, HTTP, and role-based surfaces remain historical. Task-aware CLI envelopes carry durable run context, and provider static-arg fixups run before sandbox dispatch.
 
 Folded instances:
 
@@ -90,9 +90,9 @@ Folded instances:
 ### Consequences
 - Parsing, validation, dispatch, and CLI display share one Rust type family without making orbit-core depend on provider transport objects.
 - Agent dispatch has one path after [ORB-10801]; tool enforcement stays delegated to the provider harness.
-- First-run and per-role agent choices live in user config while YAML stays reusable across workspaces.
+- First-run and named-crew choices live in user config while YAML stays reusable across workspaces.
 - Costs retained from folded entries:
-- Cost: `orbit-common` now owns a wider slice of runtime vocabulary and has to stay disciplined about not accreting behavior.
+- Cost: `orbit-types` owns the shared runtime vocabulary and has to stay disciplined about not accreting behavior.
 - Cost: session reuse becomes a narrowly scoped feature instead of a general-purpose memory layer.
 - Cost: the feature now has materially different semantics between HTTP and CLI, especially around tool enforcement.
 - Cost: ActivityV2 gains another sibling variant and the feature family becomes slightly broader.
@@ -533,7 +533,7 @@ Keep the public job-executor API stable, but organize the implementation as `job
 The v2 job executor sub-modules (`step.rs`, `parallel.rs`, `fan_out.rs`, `loop_block.rs`, `target.rs`, `recovery.rs`) own non-trivial concurrency, ordering, and audit invariants. Without test coverage co-located with each block, regressions to those invariants surface only as production failures or as audit-trace anomalies that are hard to reproduce.
 
 ### Decision
-Every executor-block module under `crates/orbit-engine/src/activity_job/job_executor/` gets a sibling `*_tests.rs` in `tests/` whose test function names name the specific invariant or failure mode each test guards. The current layout is `step_tests.rs`, `parallel_tests.rs`, `fanout_tests.rs`, `loop_tests.rs`, and `pipeline_durability_tests.rs`, alongside the pre-existing `audit_tests.rs`, `recovery_tests.rs`, and `target_tests.rs`. Shared scaffolding (`ScriptedHost`, `Action`, job/step builders) lives in `tests/mod.rs` so block modules stay focused on their own invariants and don't fork the host shape. Sandbox and policy boundary coverage lives next to the implementations they guard: `crates/orbit-exec/src/macos_sandbox.rs#tests` (read-deny enforcement and a realistic agent_loop profile boundary) and `crates/orbit-policy/src/engine.rs#tests` (global denyRead/denyModify last-match-wins, unknown-profile error, matched_rule observability).
+Every executor-block module under `crates/orbit-engine/src/activity_job/job_executor/` gets a sibling test module in `tests/` whose test function names name the specific invariant or failure mode each test guards. The current layout is `step.rs`, `parallel.rs`, `fanout.rs`, `loop.rs`, and `pipeline_durability.rs`, alongside the pre-existing `audit.rs`, `recovery.rs`, and `target.rs`. Shared scaffolding (`ScriptedHost`, `Action`, job/step builders) lives in `tests/mod.rs` so block modules stay focused on their own invariants and don't fork the host shape. Sandbox and policy boundary coverage lives next to the implementations they guard: `crates/orbit-exec/src/macos_sandbox.rs#tests` (read-deny enforcement and a realistic agent_loop profile boundary) and `crates/orbit-policy/src/engine.rs#tests` (global denyRead/denyModify last-match-wins, unknown-profile error, matched_rule observability).
 
 ### Consequences
 - Future refactors of an executor block must keep the matching invariant test alive in the same-named test file or update it to reflect the new contract.
@@ -1094,7 +1094,7 @@ The unattended triage agent (ORB-10129) normally returns advisory dispositions t
 ## CLI response envelopes are optional for artifact-backed activities
 
 **Recorded:** 2026-07-16 02:08:38.533091Z · [ORB-10231]
-**Paths:** `crates/orbit-common/src/types/activity_job/**`, `crates/orbit-engine/src/activity_job/cli_runner/**`, `crates/orbit-core/assets/activities/**`
+**Paths:** `crates/orbit-types/src/workflow/activity_job/**`, `crates/orbit-engine/src/activity_job/cli_runner/**`, `crates/orbit-core/assets/activities/**`
 
 ### Context
 CLI providers can exit successfully after persisting authoritative task, review, and git artifacts while emitting prose or provider wrapper JSON that lacks an Orbit response envelope. Treating every missing or malformed envelope as fatal strands completed work; treating every response as advisory would break activities whose downstream templates consume structured fields.
@@ -1136,7 +1136,7 @@ CLI agent-loop activities treat response envelopes as best-effort by default. Ex
 ## Terminal PR shipment uses a job-level failure handoff
 
 **Recorded:** 2026-07-25 02:34:08.643735Z · [ORB-10363]
-**Paths:** `crates/orbit-common/src/types/activity_job/**`, `crates/orbit-engine/src/activity_job/**`, `crates/orbit-engine/src/executor/automation/vcs/**`, `crates/orbit-core/assets/jobs/task_pr_pipeline.yaml`
+**Paths:** `crates/orbit-types/src/workflow/activity_job/**`, `crates/orbit-engine/src/activity_job/**`, `crates/orbit-engine/src/executor/automation/vcs/**`, `crates/orbit-core/assets/jobs/task_pr_pipeline.yaml`
 
 ### Context
 A task shipment can fail after an agent has produced coherent work but before the normal commit, rebase, push, and PR checkpoints finish. The real alternatives are to overload per-step recovery so it replays or impersonates later checkpoints, or give the workflow one explicit terminal failure hook that preserves the original failure while publishing any recoverable candidate.
@@ -1217,7 +1217,7 @@ Recognition is the entire change: no safety gate moved. Non-terminal run, `--old
 ## Step completion is a separate contract from response content
 
 **Recorded:** 2026-07-26 20:47:48.459433Z · [ORB-10449], [ORB-10454]
-**Paths:** `crates/orbit-common/src/types/activity_job/activity_v2.rs`, `crates/orbit-agent/src/types/response/envelope.rs`, `docs/design/activity-job/*`
+**Paths:** `crates/orbit-types/src/workflow/activity_job/activity_v2.rs`, `crates/orbit-agent/src/types/response/envelope.rs`, `docs/design/activity-job/*`
 
 **Context.** [CLI response envelopes are optional for artifact-backed activities](#cli-response-envelopes-are-optional-for-artifact-backed-activities) made CLI response envelopes best-effort for artifact-backed activities, leaving `require_response_envelope` as the only flag that reads an agent-loop invocation's stdout. That flag answers *"do downstream templates consume the response?"* — but it was silently also the only thing answering *"did the invocation finish at all?"*, and for artifact-backed activities (`require_response_envelope: false`) nobody was asking. Every `backend: cli` invocation is prompted with the response-envelope contract, so a provider that yields mid-turn still exits 0: `implement_one` in `task_pr_pipeline` checkpointed as success on work that stopped halfway, and the failure surfaced several steps later at whatever deterministic gate noticed first, attributed to the wrong step. Two real alternatives were rejected. Flipping `require_response_envelope: true` everywhere conflates the content question with the completion question and forces full content validation — exit alignment, `status: success`, object `result` — onto activities whose responses nothing reads, re-breaking exactly what [CLI response envelopes are optional for artifact-backed activities](#cli-response-envelopes-are-optional-for-artifact-backed-activities) fixed. Classifying the violation as a retryable `DispatchError` so `step_failure_recovery` fires inverts the fix: that hook exists to repair the delivery path for *completed* work, so it would publish a stalled implementer's partial candidate.
 
@@ -1315,7 +1315,7 @@ Providers may edit assigned worktree files but must not create commits or otherw
 ## Ship duplicate-dispatch guard lives in the shared submission path
 
 **Recorded:** 2026-08-01 21:00:01.786577Z · [ORB-10544]
-**Paths:** `crates/orbit-core/src/command/job/pipeline.rs`, `crates/orbit-dashboard/src/api/runs.rs`, `crates/orbit-core/src/runtime/orbit_tool_host/workflow_tools.rs`
+**Paths:** `crates/orbit-core/src/application/job/pipeline.rs`, `crates/orbit-dashboard/src/api/runs.rs`, `crates/orbit-core/src/adapter/tool_host/workflow_tools.rs`
 
 **Context.** [ORB-10444] added a duplicate-dispatch guard for explicitly-selected ship tasks and placed it inside `POST /api/workflows/ship`, whose ADR claimed the server-side check "covers every surface". It did not. [ORB-10540] added the MCP `orbit.workflow.ship` tool as a second front door onto the same `OrbitRuntime::submit_ship_run` service, and that tool bypassed the endpoint-local check entirely: two runs could be dispatched for one task and then contend for the same worktree and task reservation. The asymmetry was visible in the equivalence test itself, which had to call HTTP first because that was the only order in which both surfaces could dispatch the same ids.
 
@@ -1333,7 +1333,7 @@ Rejected alternative: enforce uniqueness at the store layer as a constraint on n
 ## Dispatch admission separates unmet dependencies from unsatisfiable ones
 
 **Recorded:** 2026-08-02 22:25:12.480309Z · [ORB-10593]
-**Paths:** `crates/orbit-common/src/types/task.rs`, `crates/orbit-core/src/runtime/v2_host/dispatch.rs`
+**Paths:** `crates/orbit-types/src/task/model.rs`, `crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs`
 
 ### Context
 
@@ -1345,7 +1345,7 @@ That conflates two different situations. A dependency in `backlog` / `in-progres
 
 Admission classifies every non-satisfying dependency edge as either a wait or a dead end, and refuses dead ends immediately.
 
-`TaskStatus::dependency_dead_end()` returns `Some(DependencyDeadEnd)` for `archived` and `rejected` and `None` for every other status; a dependency ID that resolves to no task is `DependencyDeadEnd::Missing`. `unsatisfiable_task_dependencies()` in `orbit-common` applies this per task, and `reserve_locks` fails the activity before the first poll when the set is non-empty, with a `task.dependencies.unsatisfiable:` message naming each offending task/dependency pair, the dependency's status, and its remedy.
+`TaskStatus::dependency_dead_end()` returns `Some(DependencyDeadEnd)` for `archived` and `rejected` and `None` for every other status; a dependency ID that resolves to no task is `DependencyDeadEnd::Missing`. `unsatisfiable_task_dependencies()` in `orbit-types` applies this per task, and `reserve_locks` fails the activity before the first poll when the set is non-empty, with a `task.dependencies.unsatisfiable:` message naming each offending task/dependency pair, the dependency's status, and its remedy.
 
 What counts as *satisfied* is unchanged: `Done`-only. This decision makes an unsatisfiable edge fail loudly, and deliberately does not widen admission. `Archived` remains a soft-delete that does not satisfy a dependency.
 
@@ -1399,13 +1399,13 @@ Rejected alternatives: probing the base branch's own PR through GitHub (couples 
 ## Typed deterministic action declaration spans core and engine
 
 **Recorded:** 2026-08-09 06:46:48.177638Z · [ORB-10630]
-**Paths:** `crates/orbit-common/src/types/activity_job/mod.rs`, `crates/orbit-core/src/runtime/v2_host/dispatch.rs`, `crates/orbit-engine/src/executor/automation/mod.rs`
+**Paths:** `crates/orbit-types/src/workflow/activity_job/mod.rs`, `crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs`, `crates/orbit-engine/src/executor/automation/mod.rs`
 
 ### Context
 Deterministic action names had independent core advertisement, core forwarding, engine constants, and engine dispatch lists. The resulting skew shipped asset actions that were not invocable.
 
 ### Decision
-Declare action names and their core-or-engine ownership once in `orbit-common`, generating typed core and engine action enums plus parsing and advertised names. Core dispatches exhaustively by the shared type, while engine implementation dispatch exhaustively matches the engine enum.
+Declare action names and their core-or-engine ownership once in `orbit-types`, generating typed core and engine action enums plus parsing and advertised names. Core dispatches exhaustively by the shared type, while engine implementation dispatch exhaustively matches the engine enum.
 
 ### Consequences
 - Adding a declared core or engine action without its respective dispatch arm fails compilation through a non-exhaustive match; implementations cannot name an undeclared typed action.
@@ -1416,7 +1416,7 @@ Declare action names and their core-or-engine ownership once in `orbit-common`, 
 ## Job execution crosses one RuntimeHost boundary
 
 **Recorded:** 2026-08-09 07:21:03.861806Z · [ORB-10633]
-**Paths:** `crates/orbit-engine/src/context/hosts.rs`, `crates/orbit-core/src/runtime/engine/runtime_host.rs`
+**Paths:** `crates/orbit-engine/src/context/hosts.rs`, `crates/orbit-core/src/adapter/engine_host/runtime_host.rs`
 
 ### Context
 The job executor depended on a dispatcher host and a separate deterministic/task/environment/run host family, both implemented by OrbitRuntime. Keeping both families with a documented ownership rule was a real alternative, but it would preserve two call graphs and let capabilities drift between them.
@@ -1432,7 +1432,7 @@ Declare one orbit-engine RuntimeHost capability boundary with one OrbitRuntime i
 ## Track bundled activity and job ownership by content digest before retirement
 
 **Recorded:** 2026-08-09 22:01:13.919070Z · [ORB-10684]
-**Paths:** `crates/orbit-core/src/command/mod.rs`, `crates/orbit-core/src/command/activity.rs`, `crates/orbit-core/src/command/job/catalog.rs`, `crates/orbit-core/src/command/init.rs`
+**Paths:** `crates/orbit-core/src/application/mod.rs`, `crates/orbit-core/src/bootstrap/activity.rs`, `crates/orbit-core/src/application/job/catalog.rs`, `crates/orbit-core/src/bootstrap/init.rs`
 
 ### Context
 Embedded activity and job assets are materialized into the global resource catalog, but an additive refresh cannot distinguish a retired bundled file from an operator-authored file by name alone. Filename-only pruning would deactivate stale shipped subsystems, but it could also destroy legitimate local resources on legacy installations.
@@ -1449,7 +1449,7 @@ Persist a per-resource-kind managed manifest containing the SHA-256 digest last 
 ## All five definition-artifact kinds carry managed provenance, and doctor reports it
 
 **Recorded:** 2026-08 · [ORB-10800]
-**Code anchors:** `crates/orbit-core/src/command/mod.rs::ManagedAssetLayout`, `crates/orbit-core/src/command/skill.rs::seed_default_skills`, `crates/orbit-core/src/command/routine.rs::seed_default_routines`, `crates/orbit-core/src/auto_tasks/mod.rs::seed_default_auto_tasks`, `crates/orbit-core/src/command/artifact_health.rs`
+**Code anchors:** `crates/orbit-core/src/application/mod.rs::ManagedAssetLayout`, `crates/orbit-core/src/application/skill.rs::seed_default_skills`, `crates/orbit-core/src/application/routine.rs::seed_default_routines`, `crates/orbit-core/src/auto_tasks/mod.rs::seed_default_auto_tasks`, `crates/orbit-core/src/application/artifact_health.rs`
 
 ### Context
 

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -4,6 +4,7 @@ summary: Cut and verify an Orbit release across Cargo, GitHub artifacts, Homebre
 tags: [operations, release, npm, signing]
 paths: [".github/workflows/release.yml", ".github/workflows/smoke-npm-install.yml", "npm/**", "scripts/release-check.sh"]
 related_features: [orbit-docs-plugin]
+last_validated: 2026-08-23
 ---
 
 # Release Orbit


### PR DESCRIPTION
## Task

[ORB-11006](https://orbit-cli.com/tasks/ORB-11006) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Batch selection from the pre-edit HEAD inventory was exactly six documents: `docs/runbooks/release.md` (missing `last_validated`), `docs/design/activity-job/2_design.md`, `3_vision.md`, and `4_decisions.md` (oldest dated `2026-07-26`), then `docs/LESSONS.md` and `docs/design/_templates/references/glossary.md` (stable path tie-break at `2026-07-27`).
- `docs/runbooks/release.md`: added `last_validated: 2026-08-23`. Verified the runbook against `scripts/release-check.sh`, `scripts/smoke-npm-install.sh`, `npm/scripts/install-binary.js`, both release workflows, and Cargo/npm version declarations.
- `docs/design/activity-job/2_design.md`: updated stale post-refactor crate/module ownership and code anchors from `orbit-common`/old `orbit-core/src/command` locations to `orbit-types`, `orbit-engine`, and `orbit-core/src/application`; verified with `rg --files` and symbol searches in the loader, executor, application, and typed action sources.
- `docs/design/activity-job/3_vision.md`: fixed the broken relative link to the archived knowledge-graph overview; verified all local Markdown links resolve.
- `docs/design/activity-job/4_decisions.md`: aligned the current rollup with `orbit-types` ownership and crew routing, corrected executor test filenames, and refreshed current decision path/code-anchor references after the crate reorganization; verified against the current type, engine-host, application, bootstrap, and test files.
- `docs/LESSONS.md` and the glossary template: updated `last_validated`; both already had valid existing frontmatter. No new frontmatter schema, document, section, sidecar, or marker system was introduced.
- Every selected document was validated and stamped; none was skipped. Historical retired-subsystem passages remain explicitly historical and were not rewritten as current behavior. No frontmatter migration was needed: all six selected docs already had `type` and `summary` (runbook, design, context, and design/glossary classifications).
- No forbidden or generated paths were modified.

Validation:
- `make ci-fast` passed.
- `git diff --check`, frontmatter uniqueness, local-link resolution, code-anchor existence, and forbidden-path guards passed.

Assessment: bounded documentation upkeep completed with only targeted stale-path, ownership, routing, filename, and broken-link corrections; no prose reflow or unrelated cleanup.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11006-6a8b6815`
- Behind base: 0
- Ahead of base: 1