### PR TITLE
Map catalog role to capability_refused (destination Core)

### DIFF
--- a/crates/orbit-cli/src/output/json.rs
+++ b/crates/orbit-cli/src/output/json.rs
@@ -69,6 +69,9 @@ fn error_code(error: &OrbitError) -> &str {
             NotFoundKind::Workspace => "workspace_not_found",
         },
         OrbitError::CapabilityDenied(_) => "capability_denied",
+        // Catalog-role refusal, not an operator capability grant: the CLI
+        // surfaces the same stable code MCP does [ORB-11012].
+        OrbitError::CapabilityRefused(_) => "capability_refused",
         OrbitError::CompanionNotInstalled(_) => "companion_not_installed",
         OrbitError::InvalidInput(_) | OrbitError::InvalidInputDiagnostic { .. } => "invalid_input",
         OrbitError::SensitiveInput { .. } => "sensitive_input",

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -68,7 +68,20 @@ impl McpWorkspace {
         Self::init_with_workspace_name("mcp-roundtrip")
     }
 
+    /// A checkout registered as a replica of `owner_machine_id`, the shape a
+    /// `git clone` on a second machine produces.
+    fn init_replica_of(owner_machine_id: &str) -> Self {
+        Self::init_with_workspace_args(
+            "mcp-roundtrip",
+            &["--role", "replica", "--owner", owner_machine_id],
+        )
+    }
+
     fn init_with_workspace_name(workspace_name: &str) -> Self {
+        Self::init_with_workspace_args(workspace_name, &[])
+    }
+
+    fn init_with_workspace_args(workspace_name: &str, extra_workspace_args: &[&str]) -> Self {
         let temp = tempdir().expect("tempdir");
         let home = temp.path().join("home");
         let work = temp.path().join("work");
@@ -108,7 +121,8 @@ impl McpWorkspace {
             String::from_utf8_lossy(&output.stderr)
         );
 
-        let workspace_init_args = vec!["workspace", "init", "--name", workspace_name];
+        let mut workspace_init_args = vec!["workspace", "init", "--name", workspace_name];
+        workspace_init_args.extend_from_slice(extra_workspace_args);
         let output = Self::orbit_command(&work, &home)
             .args(workspace_init_args)
             .output()
@@ -494,6 +508,57 @@ fn mcp_server_advertises_governed_tools_but_denies_an_unprivileged_session() {
     );
     assert_eq!(denied["code"], "capability_denied", "{denied}");
     assert!(!marker.exists(), "denied command reached domain execution");
+}
+
+/// A replica checkout is an execution binding, not the control plane. Over the
+/// real v1 MCP transport, a coordination write is refused with the named
+/// catalog-role code — not `invalid_input`, which would make a refusal
+/// indistinguishable from a malformed call, and not `capability_denied`, which
+/// is the separate operator-versus-agent axis [ORB-11012].
+#[test]
+fn a_replica_checkout_refuses_a_coordination_write_with_capability_refused() {
+    let workspace = McpWorkspace::init_replica_of("hm_remote_owner");
+
+    let mut client = workspace.serve();
+    // A well-formed call, so the refusal is the catalog role and nothing else.
+    let refused = client.call_tool_err(
+        "orbit_task_add",
+        json!({
+            "title": "must not fork",
+            "description": "A replica must not issue its own task ids",
+            "complexity": "low",
+            "model": "codex",
+        }),
+    );
+    assert_eq!(refused["code"], "capability_refused", "{refused}");
+    assert!(
+        refused["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("hm_remote_owner")),
+        "the refusal names the declared owner: {refused}"
+    );
+
+    // The same refusal on the CLI, which fails closed on the same gate.
+    let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args([
+            "task",
+            "add",
+            "--json",
+            "--title",
+            "must not fork",
+            "--description",
+            "A replica must not issue its own task ids",
+            "--complexity",
+            "low",
+            "--model",
+            "codex",
+        ])
+        .output()
+        .expect("run task add on a replica");
+    assert!(!output.status.success(), "CLI replica task add: {output:?}");
+    let payload: Value =
+        serde_json::from_slice(&output.stderr).expect("JSON error payload on stderr");
+    assert_eq!(payload["code"], "capability_refused", "{payload}");
 }
 
 /// The operator MCP surface, over the real transport: a server an operator

--- a/crates/orbit-cmd/src/tests/registry_runtime.rs
+++ b/crates/orbit-cmd/src/tests/registry_runtime.rs
@@ -235,13 +235,34 @@ fn replica_runtime_refuses_task_writes_and_hides_coordination_reads() {
             ..Default::default()
         })
         .expect_err("replica task write must fail closed");
-    assert!(error.to_string().contains("hm_owner"), "{error}");
+    // A catalog-role refusal, not a malformed call: federated routing has to
+    // report `capability_refused` rather than `invalid_input` [ORB-11012].
+    assert!(
+        matches!(&error, OrbitError::CapabilityRefused(message) if message.contains("hm_owner")),
+        "{error}"
+    );
     assert!(
         runtime
             .list_tasks()
             .expect("empty replica task list")
             .is_empty()
     );
+
+    // The gate covers control-plane coordination only. A replica is the
+    // execution binding, so execute-class tools pass it and are judged on
+    // their own terms — here the operator-capability axis, which stays a
+    // distinct `capability_denied` rather than a catalog-role refusal.
+    for (name, input) in [
+        ("orbit.workflow.run.show", json!({"run_id": "jrun-missing"})),
+        ("orbit.command.exec", json!({"command": "true"})),
+    ] {
+        let error = execute_cli_tool(&runtime, name, input)
+            .expect_err("both execute-class tools are operator surfaces");
+        assert!(
+            matches!(&error, OrbitError::CapabilityDenied(message) if message.contains("operator")),
+            "{name} must clear the catalog-role gate: {error}"
+        );
+    }
 }
 
 struct DualWorkspaceFixture {

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -183,12 +183,18 @@ impl OrbitRuntime {
         self
     }
 
+    /// Refuse control-plane work in a replica checkout.
+    ///
+    /// The refusal is a catalog-role capability outcome, not a malformed call:
+    /// federated routing has to tell "this destination will not run that class"
+    /// apart from "that request was invalid", so this reports
+    /// `CapabilityRefused` [ORB-11012].
     pub(crate) fn ensure_coordination_task_write_permitted(&self) -> Result<(), OrbitError> {
         let Some(owner_machine_id) = self.coordination_write_owner.as_deref() else {
             return Ok(());
         };
-        Err(OrbitError::InvalidInput(format!(
-            "coordination writes are refused in this replica checkout; workspace is owned by machine '{owner_machine_id}'"
+        Err(OrbitError::CapabilityRefused(format!(
+            "control_plane coordination writes are refused in this replica checkout; workspace is owned by machine '{owner_machine_id}'"
         )))
     }
 

--- a/crates/orbit-mcp/src/federated.rs
+++ b/crates/orbit-mcp/src/federated.rs
@@ -5,6 +5,8 @@ use std::str::FromStr;
 
 use orbit_common::OrbitError;
 use orbit_types::identity::{validate_machine_id, validate_registry_identifier};
+use orbit_types::tool::mcp_advertised_tool_name;
+use orbit_types::workspace::{Workspace, WorkspaceCheckout, WorkspaceCheckoutRole};
 use serde::Deserialize;
 
 pub const DESTINATIONS_FILE: &str = "mcp-destinations.toml";
@@ -126,6 +128,124 @@ fn validate_destinations(destinations: &DestinationsFile, path: &Path) -> Result
         }
     }
     Ok(())
+}
+
+/// Capability class of an advertised MCP tool.
+///
+/// Assigned by what the tool does, so a new tool inherits its class from its
+/// behavior rather than from a per-tool registry field [ORB-11012].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpToolClass {
+    /// Discovery and list tools. Never subject to `capability_refused`.
+    Unclassified,
+    /// Task issuance and the coordination store, whose authority is the
+    /// declared control-plane owner rather than the destination host.
+    ControlPlane,
+    /// Runs, logs, and scheduler state, which the destination host owns.
+    Execute,
+}
+
+impl McpToolClass {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            McpToolClass::Unclassified => "unclassified",
+            McpToolClass::ControlPlane => "control_plane",
+            McpToolClass::Execute => "execute",
+        }
+    }
+}
+
+/// Classify one advertised MCP tool by behavior.
+///
+/// Accepts either the canonical (`orbit.task.add`) or advertised
+/// (`orbit_task_add`) spelling. Task reads are `control_plane` because the
+/// coordination store is owner-authoritative. A name this host does not
+/// advertise is unclassified here; routing rejects it earlier with
+/// `tool_not_on_this_host`, which precedes `capability_refused`.
+pub fn mcp_tool_class(tool_name: &str) -> McpToolClass {
+    match mcp_advertised_tool_name(tool_name).as_str() {
+        "orbit_task_add"
+        | "orbit_task_update"
+        | "orbit_task_start"
+        | "orbit_task_approve"
+        | "orbit_task_list"
+        | "orbit_task_show"
+        | "orbit_task_artifact_put"
+        | "orbit_friction_add"
+        | "orbit_friction_list"
+        | "orbit_friction_update"
+        | "orbit_auto_task_list"
+        | "orbit_auto_task_mint"
+        | "orbit_search"
+        | "orbit_workflow_ship" => McpToolClass::ControlPlane,
+        "orbit_command_exec"
+        | "orbit_workflow_run_list"
+        | "orbit_workflow_run_show"
+        | "orbit_workflow_run_resume"
+        | "orbit_session_log_append"
+        | "orbit_session_log_list"
+        | "orbit_session_log_resolve" => McpToolClass::Execute,
+        _ => McpToolClass::Unclassified,
+    }
+}
+
+/// Capability classes a destination advertises for one workspace checkout.
+///
+/// Advertisement is a hint that may lag; destination Core refusal stays the
+/// correctness boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CapabilityClasses {
+    control_plane: bool,
+    execute: bool,
+}
+
+impl CapabilityClasses {
+    pub fn new(control_plane: bool, execute: bool) -> Self {
+        Self {
+            control_plane,
+            execute,
+        }
+    }
+
+    /// Advertisement helper: the classes this local checkout holds.
+    ///
+    /// An owner checkout is the workspace's control-plane authority and also
+    /// runs work locally today. A replica is an execution binding only. A
+    /// workspace whose logical record omits `owner_machine_id` predates host
+    /// identity and cannot advertise `control_plane` at all. A missing checkout
+    /// role is the legacy standalone shape that registry validation
+    /// canonicalizes to owner.
+    pub fn for_checkout(workspace: &Workspace, checkout: &WorkspaceCheckout) -> Self {
+        let is_replica = checkout.role == Some(WorkspaceCheckoutRole::Replica);
+        Self {
+            control_plane: !is_replica && workspace.owner_machine_id.is_some(),
+            execute: true,
+        }
+    }
+
+    pub fn holds(self, class: McpToolClass) -> bool {
+        match class {
+            McpToolClass::Unclassified => true,
+            McpToolClass::ControlPlane => self.control_plane,
+            McpToolClass::Execute => self.execute,
+        }
+    }
+}
+
+/// Destination-side gate: refuse a tool whose class this checkout does not hold.
+///
+/// Unclassified discovery tools always pass. The refusal carries the class so a
+/// caller can distinguish it from a malformed call or an operator capability
+/// grant.
+pub fn ensure_tool_class_held(tool_name: &str, held: CapabilityClasses) -> Result<(), OrbitError> {
+    let class = mcp_tool_class(tool_name);
+    if held.holds(class) {
+        return Ok(());
+    }
+    Err(OrbitError::CapabilityRefused(format!(
+        "this checkout does not hold the '{}' capability class required by '{tool_name}'",
+        class.as_str()
+    )))
 }
 
 #[cfg(test)]

--- a/crates/orbit-mcp/src/tests/federated.rs
+++ b/crates/orbit-mcp/src/tests/federated.rs
@@ -107,3 +107,179 @@ ssh = "orbit-a"
     let error = load_destinations(&path).expect_err("machine_id is required");
     assert!(matches!(error, OrbitError::InvalidInput(_)));
 }
+
+/// The behavior rule from the federated spec, locked tool by tool over the
+/// whole advertised surface [ORB-11012].
+const ADVERTISED_TOOL_CLASSES: &[(&str, McpToolClass)] = &[
+    ("orbit.auto_task.list", McpToolClass::ControlPlane),
+    ("orbit.auto_task.mint", McpToolClass::ControlPlane),
+    ("orbit.command.exec", McpToolClass::Execute),
+    ("orbit.crew.list", McpToolClass::Unclassified),
+    ("orbit.friction.add", McpToolClass::ControlPlane),
+    ("orbit.friction.list", McpToolClass::ControlPlane),
+    ("orbit.friction.update", McpToolClass::ControlPlane),
+    ("orbit.search", McpToolClass::ControlPlane),
+    ("orbit.session_log.append", McpToolClass::Execute),
+    ("orbit.session_log.list", McpToolClass::Execute),
+    ("orbit.session_log.resolve", McpToolClass::Execute),
+    ("orbit.task.add", McpToolClass::ControlPlane),
+    ("orbit.task.approve", McpToolClass::ControlPlane),
+    ("orbit.task.artifact.put", McpToolClass::ControlPlane),
+    ("orbit.task.list", McpToolClass::ControlPlane),
+    ("orbit.task.show", McpToolClass::ControlPlane),
+    ("orbit.task.start", McpToolClass::ControlPlane),
+    ("orbit.task.update", McpToolClass::ControlPlane),
+    ("orbit.workflow.run.list", McpToolClass::Execute),
+    ("orbit.workflow.run.resume", McpToolClass::Execute),
+    ("orbit.workflow.run.show", McpToolClass::Execute),
+    ("orbit.workflow.ship", McpToolClass::ControlPlane),
+    ("orbit.workspace.list", McpToolClass::Unclassified),
+];
+
+#[test]
+fn every_advertised_tool_carries_its_locked_capability_class() {
+    for (name, expected) in ADVERTISED_TOOL_CLASSES {
+        assert_eq!(mcp_tool_class(name), *expected, "{name}");
+    }
+}
+
+/// The classifier is a function over the live surface, so a tool added to the
+/// registry without a class assignment fails here instead of silently becoming
+/// unclassified and unrefusable.
+#[test]
+fn the_locked_mapping_covers_exactly_the_advertised_surface() {
+    let advertised = crate::canonical_mcp_tool_definitions()
+        .expect("canonical MCP definitions")
+        .into_iter()
+        .map(|definition| definition.schema.name)
+        .collect::<std::collections::BTreeSet<_>>();
+    let locked = ADVERTISED_TOOL_CLASSES
+        .iter()
+        .map(|(name, _)| (*name).to_string())
+        .collect::<std::collections::BTreeSet<_>>();
+
+    assert_eq!(advertised, locked);
+    assert_eq!(advertised.len(), 23);
+}
+
+#[test]
+fn classification_accepts_the_advertised_spelling() {
+    assert_eq!(mcp_tool_class("orbit_task_add"), McpToolClass::ControlPlane);
+    assert_eq!(
+        mcp_tool_class("orbit_workflow_run_show"),
+        McpToolClass::Execute
+    );
+}
+
+#[test]
+fn a_replica_refuses_control_plane_and_runs_execute_class_tools() {
+    let held = CapabilityClasses::for_checkout(
+        &workspace_record(Some("hm_owner")),
+        &checkout_record(Some(WorkspaceCheckoutRole::Replica)),
+    );
+
+    let refused = ensure_tool_class_held("orbit.task.add", held)
+        .expect_err("a replica is not the control plane");
+    assert!(
+        matches!(&refused, OrbitError::CapabilityRefused(message) if message.contains("control_plane")),
+        "{refused}"
+    );
+
+    for allowed in ["orbit.workflow.run.show", "orbit.command.exec"] {
+        ensure_tool_class_held(allowed, held).expect(allowed);
+    }
+}
+
+#[test]
+fn an_owner_checkout_holds_the_control_plane() {
+    let held = CapabilityClasses::for_checkout(
+        &workspace_record(Some("hm_owner")),
+        &checkout_record(Some(WorkspaceCheckoutRole::Owner)),
+    );
+
+    ensure_tool_class_held("orbit.task.add", held).expect("owner holds control_plane");
+    ensure_tool_class_held("orbit.command.exec", held).expect("owner runs work locally today");
+}
+
+/// A standalone registry predating host identity is not a control-plane
+/// authority, whatever role its checkout claims.
+#[test]
+fn a_workspace_without_an_owner_machine_id_does_not_advertise_control_plane() {
+    for role in [None, Some(WorkspaceCheckoutRole::Owner)] {
+        let held = CapabilityClasses::for_checkout(&workspace_record(None), &checkout_record(role));
+
+        assert!(!held.holds(McpToolClass::ControlPlane), "{role:?}");
+        assert!(held.holds(McpToolClass::Execute), "{role:?}");
+        assert!(
+            ensure_tool_class_held("orbit.task.update", held).is_err(),
+            "{role:?}"
+        );
+    }
+}
+
+/// A legacy checkout with no recorded role is the standalone owner shape that
+/// registry validation canonicalizes to `owner`.
+#[test]
+fn an_absent_checkout_role_is_treated_as_owner() {
+    let held = CapabilityClasses::for_checkout(
+        &workspace_record(Some("hm_owner")),
+        &checkout_record(None),
+    );
+
+    assert!(held.holds(McpToolClass::ControlPlane));
+}
+
+/// No such checkout exists today, but the class is what refuses, not the role,
+/// so a future control-plane-only store refuses execute-class work.
+#[test]
+fn a_control_plane_that_does_not_run_work_refuses_execute_class_tools() {
+    let held = CapabilityClasses::new(true, false);
+
+    let refused =
+        ensure_tool_class_held("orbit.workflow.run.resume", held).expect_err("execute is not held");
+    assert!(
+        matches!(&refused, OrbitError::CapabilityRefused(message) if message.contains("execute")),
+        "{refused}"
+    );
+    ensure_tool_class_held("orbit.task.add", held).expect("control_plane is held");
+}
+
+#[test]
+fn unclassified_discovery_tools_are_never_refused() {
+    for held in [
+        CapabilityClasses::new(false, false),
+        CapabilityClasses::new(true, true),
+    ] {
+        for discovery in ["orbit.workspace.list", "orbit.crew.list"] {
+            ensure_tool_class_held(discovery, held).expect(discovery);
+        }
+    }
+}
+
+fn workspace_record(owner_machine_id: Option<&str>) -> Workspace {
+    let now = chrono::Utc::now();
+    Workspace {
+        id: "ws_orbit".to_string(),
+        name: "orbit".to_string(),
+        owner_machine_id: owner_machine_id.map(str::to_string),
+        git_remote: None,
+        ship_mode: None,
+        base_branch: "main".to_string(),
+        status: orbit_types::workspace::WorkspaceStatus::Active,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+fn checkout_record(role: Option<WorkspaceCheckoutRole>) -> WorkspaceCheckout {
+    WorkspaceCheckout {
+        workspace_id: "ws_orbit".to_string(),
+        repo_root: PathBuf::from("/srv/orbit"),
+        orbit_dir: PathBuf::from("/srv/orbit/.orbit"),
+        role,
+        owner_machine_id: role
+            .filter(|role| *role == WorkspaceCheckoutRole::Replica)
+            .map(|_| "hm_owner".to_string()),
+        path_overrides: Vec::new(),
+    }
+}


### PR DESCRIPTION
## Task

[ORB-11012](https://orbit-cli.com/tasks/ORB-11012) — Map catalog role to capability_refused (destination Core)

### Description

## Problem
Replica checkouts already refuse coordination writes via `OrbitRuntime::ensure_coordination_task_write_permitted` and hide coordination reads, but the MCP code is `invalid_input`. Federated routing cannot distinguish a catalog-role refuse from a malformed call. Execute-class tools are not classified at all.

## Why It Matters
Destination Core refusal is the correctness boundary in the federated spec. The mux must not become a second authorization layer. This child lands the named error and the behavior-rule classifier so routing ([ORB-11011] child) can return `capability_refused`.

## Constraints / Notes
- Parent epic [ORB-11011]. Depends on the foundations child (error identity `capability_refused`). Independent of federated list/routing otherwise; merge before or with routing.
- Map the existing replica guard to `capability_refused`. Do not invent a parallel ownership vocabulary. Do not add a per-tool registry field.
- Classify the current 23-tool MCP surface by the spec behavior rule in one function, with tests locking the mapping:
  - unclassified: `orbit.workspace.list`, `orbit.crew.list` (not subject to `capability_refused`)
  - `control_plane`: `orbit.task.{add,update,start,approve,list,show,artifact.put}`, `orbit.friction.{add,list,update}`, `orbit.auto_task.{list,mint}`, `orbit.search`, `orbit.workflow.ship`
  - `execute`: `orbit.command.exec`, `orbit.workflow.run.{list,show,resume}`, `orbit.session_log.{append,list,resolve}`
- Task reads are `control_plane` because the coordination store is owner-authoritative (replica already hides them). Changing that is a spec change, not a worker guess.
- A workspace with absent `owner_machine_id` cannot advertise `control_plane` (advertisement helper + unit test). Advertisement is a hint; Core refuse is truth.
- Owner without `execute` would refuse execute-class — no such checkout today; still test the branch.
- Unclassified tools never take this path. Do not compare `git_remote` or detect competing Owners.
- CLI replica task-add still fails closed; changelog note if the message/code changes.
- Dedicated worktree from `agent-main`. Crew `grok`.

## Risks
- Reusing `capability_denied` (operator vs agent).
- Refusing execute-class tools on a replica.
- Building a per-tool capability table in the registry.

### Acceptance Criteria

- Replica `orbit.task.add` over v1 MCP returns structured error `code: capability_refused` (not `invalid_input`, not `capability_denied`).
- Replica `orbit.workflow.run.show` and `orbit.command.exec` are not refused by the catalog-role gate.
- A function (not a registry field) assigns the 23 advertised MCP tools to unclassified / control_plane / execute; unit tests lock the mapping in this task's description.
- A workspace with absent `owner_machine_id` does not advertise `control_plane`.
- CLI replica task-add still fails closed; changelog notes the error-code change if the message is no longer `invalid_input`.
- `make ci-fast` passes. v1 byte-transparent SSH proxy is unchanged.

## Execution Summary

<details>
<summary>Click to expand</summary>

Mapped the existing replica catalog-role guard to `capability_refused` and added the behavior-rule tool classifier the federated routing child needs.

## Changes

- `crates/orbit-core/src/runtime/mod.rs` — `ensure_coordination_task_write_permitted` now returns `OrbitError::CapabilityRefused` instead of `InvalidInput`. Same single gate, same call sites (task add/update/transitions); no parallel ownership vocabulary and no new guard. Message now leads with `control_plane` and still names the declared owner machine.
- `crates/orbit-mcp/src/federated.rs` — new `McpToolClass` (`Unclassified` / `ControlPlane` / `Execute`), `mcp_tool_class(tool_name)` (a function over the name, accepting either the canonical `orbit.task.add` or advertised `orbit_task_add` spelling — no per-tool registry field), `CapabilityClasses` with the advertisement helper `for_checkout(workspace, checkout)`, and the destination-side gate `ensure_tool_class_held`.
  - Advertisement rule: replica → execute only; owner (or the legacy absent role, which registry validation canonicalizes to owner) → control_plane **only when the logical workspace record carries `owner_machine_id`**, plus execute. No `git_remote` comparison, no competing-Owner detection.
  - Unclassified discovery tools always pass the gate. An unadvertised name classifies as unclassified; routing rejects it earlier with `tool_not_on_this_host`, which precedes `capability_refused`.
- `crates/orbit-cli/src/output/json.rs` — added `CapabilityRefused => "capability_refused"`. Unlisted context file, added because the CLI now emits the variant and would otherwise have fallen through to the `internal_error` catch-all.

## Tests

- `crates/orbit-mcp/src/tests/federated.rs` (9 new): `ADVERTISED_TOOL_CLASSES` locks all 23 tools to the classes named in the task description, and a companion test asserts that constant equals exactly the live `canonical_mcp_tool_definitions()` surface (count and names) — so a new tool added without a class assignment fails here rather than silently becoming unrefusable. Also covers the advertised spelling, replica refuse-control-plane/allow-execute, owner holds both, absent `owner_machine_id` (with role `None` and `Owner`) never advertises control_plane, the no-such-checkout-today control-plane-without-execute branch, and discovery tools never refused.
- `crates/orbit-cli/tests/mcp_roundtrip.rs` — new end-to-end `a_replica_checkout_refuses_a_coordination_write_with_capability_refused` over the real v1 MCP transport, via a new `McpWorkspace::init_replica_of` fixture (`workspace init --role replica --owner hm_remote_owner`). A well-formed `orbit_task_add` returns structured `code: capability_refused` naming the owner, and the same call on the CLI (`task add --json`) fails closed with the same code.
- `crates/orbit-cmd/src/tests/registry_runtime.rs` — the existing replica test now asserts the `CapabilityRefused` variant, and additionally drives `orbit.workflow.run.show` and `orbit.command.exec` through the replica runtime: both clear the catalog-role gate and are judged on the separate operator axis (`capability_denied`), which is exactly the operator-vs-agent conflation the task flagged as a risk.

## Notes

- No `CHANGELOG.md` entry: the repo convention (CLAUDE.md, RELEASING.md step 2) is that the changelog is compiled at release time from merged work, not accumulated per-PR. The error-code change is recorded by this task ID in the commit message for the release drafter.
- v1 byte-transparent SSH proxy (`crates/orbit-mcp/src/remote/proxy.rs`) untouched. No new cross-crate dependency edge (orbit-mcp already depends on orbit-types).

## Validation

- `make ci-fast` — pass.
- `make ci-lint` — pass (workspace-wide, all targets, warnings denied).
- `cargo test -p orbit-mcp -p orbit-core -p orbit-cmd -p orbit-cli` — pass, including all 19 `mcp_roundtrip` integration tests.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11012-6a8b7ad6`
- Behind base: 0
- Ahead of base: 1