### PR TITLE
Federated serve registration + design docs as implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,49 @@ tool's `workspace` argument or MCP initialize metadata; server process cwd is no
 a fallback. `orbit.workspace.list` is global and reports active workspaces that
 have a checkout registered on that machine.
 
+### Federated MCP
+
+The opt-in federated server presents one MCP namespace over SSH destinations
+listed in the operator's machine-global `~/.orbit/mcp-destinations.toml`:
+
+```toml
+[[destinations]]
+ssh = "orbit-owner"
+machine_id = "hm_alpha"
+
+[[destinations]]
+ssh = "operator@orbit-build"
+machine_id = "hm_beta"
+```
+
+From an Orbit workspace, register that mux with a client (Codex shown here):
+
+```bash
+orbit mcp init --federated --client codex --scope home
+```
+
+This adds one client entry named `orbit-federated` that launches `orbit mcp
+serve --mode federated`. It does not replace the existing v1 `orbit` entry.
+Target another supported client with its `--client` value or use `--auto`.
+Remove only the federated entry later with `orbit mcp remove --federated`
+and the same client/scope selection.
+
+In the federated MCP session, call `orbit_workspace_list`, copy the owner row's
+host-qualified `selector`, then pass it unchanged to one workspace-scoped call:
+
+```text
+orbit_workspace_list({})
+  -> {"workspaces":[{"selector":"hm_alpha/ws_orbit", ...}]}
+
+orbit_task_list({"workspace":"hm_alpha/ws_orbit"})
+```
+
+The mux performs no placement or failover, does not detect two destinations
+that both claim Owner, and is only as available as the selected destination.
+Task reads remain owner-only, so use the owner row's selector for
+`orbit_task_list` and `orbit_task_show`; a replica selector is refused with
+`capability_refused`.
+
 Remote MCP uses one direct, byte-transparent SSH stdio hop:
 
 ```text

--- a/crates/orbit-cli/src/command/mcp/command.rs
+++ b/crates/orbit-cli/src/command/mcp/command.rs
@@ -30,8 +30,10 @@ impl Execute for McpCommand {
 pub enum McpSubcommand {
     /// Initialize MCP client integration for the current workspace
     ///
-    /// Registers agent-only authority — the same as bare `orbit mcp serve`.
-    /// For the operator-authorized bootstrap integration (workflow dispatch,
+    /// By default, registers agent-only authority — the same as bare `orbit
+    /// mcp serve`. `--federated` instead adds a separate client entry for the
+    /// session-unbound mux and preserves the default v1 entry. For the
+    /// operator-authorized bootstrap integration (workflow dispatch,
     /// `orbit.command.exec`), use `orbit workspace init --mcp` instead.
     Init(InitArgs),
     /// Remove MCP client integration for the current workspace
@@ -118,11 +120,12 @@ pub struct ServeArgs {
     ///
     /// Most MCP clients cannot announce `_meta.orbit.workspace` on their
     /// initialize, so without this a workspace-scoped tool must repeat the
-    /// selector on every call. `orbit mcp init` and `orbit workspace init
-    /// --mcp` write this into the integrations they generate. A client that
-    /// does announce a workspace, and any explicit per-call `workspace`,
-    /// still take precedence. The selector is resolved against the accepting
-    /// server's registry per call, never from the server process cwd.
+    /// selector on every call. Local `orbit mcp init` and `orbit workspace
+    /// init --mcp` write this into the integrations they generate; the
+    /// federated init path is session-unbound. A client that does announce a
+    /// workspace, and any explicit per-call `workspace`, still take
+    /// precedence. The selector is resolved against the accepting server's
+    /// registry per call, never from the server process cwd.
     #[arg(long, value_name = "SELECTOR", conflicts_with = "mode")]
     pub workspace: Option<String>,
 }

--- a/crates/orbit-cli/src/command/mcp/setup/args.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/args.rs
@@ -50,13 +50,14 @@ pub(super) enum McpAction<'a> {
     /// call site state both explicitly instead of inheriting a default.
     Init(ServerLaunch<'a>),
     Remove,
+    RemoveFederated,
 }
 
 impl McpAction<'_> {
     pub(super) fn label(self) -> &'static str {
         match self {
             Self::Init(_) => "init",
-            Self::Remove => "remove",
+            Self::Remove | Self::RemoveFederated => "remove",
         }
     }
 }
@@ -177,6 +178,12 @@ pub struct InitArgs {
     /// Scope for written config files (workspace: repo-local, home: user-level).
     #[arg(long, value_enum, default_value_t = ScopeArg::Workspace)]
     pub scope: ScopeArg,
+    /// Register the federated mux as a separate `orbit-federated` MCP server.
+    ///
+    /// The generated entry launches `orbit mcp serve --mode federated` and
+    /// does not replace the existing v1 `orbit` server entry.
+    #[arg(long)]
+    pub federated: bool,
 }
 
 impl InitArgs {
@@ -185,10 +192,13 @@ impl InitArgs {
         // Bare `orbit mcp init` keeps its pre-existing agent-only authority;
         // only the `orbit workspace init --mcp` bootstrap path (below, via
         // `init_auto_for_workspace`) selects operator authority.
-        let workspace_id = registered_workspace_id(&layout.repo_root);
-        let launch = ServerLaunch {
-            operator: false,
-            workspace: workspace_id.as_deref(),
+        let workspace_id = (!self.federated)
+            .then(|| registered_workspace_id(&layout.repo_root))
+            .flatten();
+        let launch = if self.federated {
+            ServerLaunch::Federated
+        } else {
+            ServerLaunch::local(false, workspace_id.as_deref())
         };
         let providers = run_action(
             McpAction::Init(launch),
@@ -211,20 +221,29 @@ pub struct RemoveArgs {
     /// Scope for config files to remove (workspace: repo-local, home: user-level).
     #[arg(long, value_enum, default_value_t = ScopeArg::Workspace)]
     pub scope: ScopeArg,
+    /// Remove the separate `orbit-federated` entry instead of the v1 `orbit`
+    /// entry.
+    #[arg(long)]
+    pub federated: bool,
 }
 
 impl RemoveArgs {
     pub fn execute_without_runtime(self, root_override: Option<&Path>) -> CommandOut {
         let layout = resolve_workspace_layout(root_override)?;
+        let action = if self.federated {
+            McpAction::RemoveFederated
+        } else {
+            McpAction::Remove
+        };
         let providers = run_action(
-            McpAction::Remove,
+            action,
             &layout.repo_root,
             &layout.orbit_root,
             self.providers.resolve_mode()?,
             env_home_dir(),
             self.scope,
         )?;
-        print_action_summary(McpAction::Remove, &providers);
+        print_action_summary(action, &providers);
         Ok(CommandOutput::Silent)
     }
 }
@@ -246,10 +265,7 @@ pub(crate) fn init_auto_for_workspace(
     // The workspace being registered is known here, so the generated server is
     // bound to it directly rather than re-derived from the checkout.
     run_action(
-        McpAction::Init(ServerLaunch {
-            operator: true,
-            workspace: Some(workspace_id),
-        }),
+        McpAction::Init(ServerLaunch::local(true, Some(workspace_id))),
         repo_root,
         orbit_root,
         ProviderSelectionMode::Auto,

--- a/crates/orbit-cli/src/command/mcp/setup/dispatch.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/dispatch.rs
@@ -2,6 +2,8 @@ use std::path::{Path, PathBuf};
 
 use orbit_core::OrbitError;
 
+use crate::command::mcp::ORBIT_MCP_SERVER_ID;
+
 use super::args::{McpAction, McpProvider, ProviderSelectionMode, ScopeArg};
 use super::providers::*;
 
@@ -16,32 +18,35 @@ pub(super) fn run_action(
     let providers = resolve_providers(selection, repo_root, home_dir.as_deref());
     for provider in &providers {
         let target = ConfigTarget::resolve(scope, provider, repo_root, home_dir.as_deref())?;
-        match (action, provider) {
-            (McpAction::Init(launch), McpProvider::Claude) => apply_claude_init(&target, launch)?,
-            (McpAction::Remove, McpProvider::Claude) => apply_claude_remove(&target)?,
-            (McpAction::Init(launch), McpProvider::Codex) => apply_codex_init(&target, launch)?,
-            (McpAction::Remove, McpProvider::Codex) => apply_codex_remove(&target)?,
-            (McpAction::Init(launch), McpProvider::Gemini) => apply_gemini_init(&target, launch)?,
-            (McpAction::Remove, McpProvider::Gemini) => apply_gemini_remove(&target)?,
-            (McpAction::Init(launch), McpProvider::Grok) => apply_grok_init(&target, launch)?,
-            (McpAction::Remove, McpProvider::Grok) => apply_grok_remove(&target)?,
-            (McpAction::Init(launch), McpProvider::Cursor) => {
-                apply_simple_json_init(&target, "mcpServers", launch)?
-            }
-            (McpAction::Remove, McpProvider::Cursor) => {
-                apply_simple_json_remove(&target, "mcpServers")?
-            }
-            (McpAction::Init(launch), McpProvider::Vscode) => {
-                apply_simple_json_init(&target, "servers", launch)?
-            }
-            (McpAction::Remove, McpProvider::Vscode) => {
-                apply_simple_json_remove(&target, "servers")?
-            }
-            (McpAction::Init(launch), McpProvider::Windsurf) => {
-                apply_simple_json_init(&target, "mcpServers", launch)?
-            }
-            (McpAction::Remove, McpProvider::Windsurf) => {
-                apply_simple_json_remove(&target, "mcpServers")?
+        match action {
+            McpAction::Init(launch) => match provider {
+                McpProvider::Claude => apply_claude_init(&target, launch)?,
+                McpProvider::Codex => apply_codex_init(&target, launch)?,
+                McpProvider::Gemini => apply_gemini_init(&target, launch)?,
+                McpProvider::Grok => apply_grok_init(&target, launch)?,
+                McpProvider::Cursor => apply_simple_json_init(&target, "mcpServers", launch)?,
+                McpProvider::Vscode => apply_simple_json_init(&target, "servers", launch)?,
+                McpProvider::Windsurf => apply_simple_json_init(&target, "mcpServers", launch)?,
+            },
+            McpAction::Remove | McpAction::RemoveFederated => {
+                let server_id = if matches!(action, McpAction::RemoveFederated) {
+                    ORBIT_FEDERATED_MCP_SERVER_ID
+                } else {
+                    ORBIT_MCP_SERVER_ID
+                };
+                match provider {
+                    McpProvider::Claude => apply_claude_remove(&target, server_id)?,
+                    McpProvider::Codex => apply_codex_remove(&target, server_id)?,
+                    McpProvider::Gemini => apply_gemini_remove(&target, server_id)?,
+                    McpProvider::Grok => apply_grok_remove(&target, server_id)?,
+                    McpProvider::Cursor => {
+                        apply_simple_json_remove(&target, "mcpServers", server_id)?
+                    }
+                    McpProvider::Vscode => apply_simple_json_remove(&target, "servers", server_id)?,
+                    McpProvider::Windsurf => {
+                        apply_simple_json_remove(&target, "mcpServers", server_id)?
+                    }
+                }
             }
         }
     }

--- a/crates/orbit-cli/src/command/mcp/setup/providers/claude.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/claude.rs
@@ -6,25 +6,23 @@ use crate::command::mcp::{ORBIT_MCP_SERVER_ID, safe_mcp_tool_names};
 
 use super::super::dispatch::ConfigTarget;
 use super::super::format::*;
-use super::common::{ServerLaunch, server_args};
+use super::common::{ServerLaunch, server_args, server_id};
 
 pub(in crate::command::mcp::setup) fn apply_claude_init(
     target: &ConfigTarget,
     launch: ServerLaunch<'_>,
 ) -> Result<(), OrbitError> {
+    let server_id = server_id(launch);
     let mut root = load_json_object(&target.mcp_path)?;
     let mcp_servers = ensure_json_object(&mut root, "mcpServers")?;
-    mcp_servers.insert(
-        ORBIT_MCP_SERVER_ID.to_string(),
-        claude_mcp_server_value(launch),
-    );
+    mcp_servers.insert(server_id.to_string(), claude_mcp_server_value(launch));
     write_json_object(&target.mcp_path, &root)?;
 
     if let Some(settings_path) = &target.settings_path {
         let mut settings = load_json_object(settings_path)?;
         let permissions = ensure_json_object(&mut settings, "permissions")?;
         let allow = ensure_json_string_array(permissions, "allow")?;
-        merge_unique_strings(allow, claude_safe_permissions());
+        merge_unique_strings(allow, claude_safe_permissions(server_id));
         write_json_object(settings_path, &settings)?;
     }
     Ok(())
@@ -32,13 +30,14 @@ pub(in crate::command::mcp::setup) fn apply_claude_init(
 
 pub(in crate::command::mcp::setup) fn apply_claude_remove(
     target: &ConfigTarget,
+    server_id: &str,
 ) -> Result<(), OrbitError> {
     let mut root = load_json_object(&target.mcp_path)?;
     if let Some(mcp_servers) = root
         .get_mut("mcpServers")
         .and_then(JsonValue::as_object_mut)
     {
-        mcp_servers.remove(ORBIT_MCP_SERVER_ID);
+        mcp_servers.remove(server_id);
         if mcp_servers.is_empty() {
             root.remove("mcpServers");
         }
@@ -56,13 +55,15 @@ pub(in crate::command::mcp::setup) fn apply_claude_remove(
                 .get_mut("allow")
                 .and_then(JsonValue::as_array_mut)
             {
-                remove_known_strings(allow, &claude_safe_permissions());
+                remove_known_strings(allow, &claude_safe_permissions(server_id));
                 // Migration cleanup: prior `orbit mcp init --claude` runs wrote
                 // plugin-scoped names (`mcp__plugin_orbit_orbit__*`) that the
                 // current init no longer produces. Strip them here so a single
                 // `orbit mcp remove --claude` after upgrade leaves a clean
                 // settings.json instead of orphaning stale entries.
-                remove_known_strings(allow, &claude_legacy_safe_permissions());
+                if server_id == ORBIT_MCP_SERVER_ID {
+                    remove_known_strings(allow, &claude_legacy_safe_permissions());
+                }
                 if allow.is_empty() {
                     permissions.remove("allow");
                 }
@@ -97,20 +98,26 @@ pub(super) fn claude_mcp_server_value(launch: ServerLaunch<'_>) -> JsonValue {
     ]))
 }
 
-fn claude_safe_permissions() -> Vec<String> {
+fn claude_safe_permissions(server_id: &str) -> Vec<String> {
     safe_mcp_tool_names()
         .into_iter()
-        .map(|name| claude_permission_name(&name))
+        .map(|name| claude_permission_name_for_server(server_id, &name))
         .collect()
 }
 
+#[cfg(test)]
 pub(super) fn claude_permission_name(tool_name: &str) -> String {
+    claude_permission_name_for_server(ORBIT_MCP_SERVER_ID, tool_name)
+}
+
+fn claude_permission_name_for_server(server_id: &str, tool_name: &str) -> String {
     // pub(super) widened so providers/tests/claude.rs can call it
     // (sibling under providers per ORB-00221 layout).
     //
     // Claude derives MCP permission names from the connected server id in
-    // .mcp.json. The CLI registers under ORBIT_MCP_SERVER_ID = "orbit", so
-    // permission entries written here must be shaped `mcp__orbit__<tool>`.
+    // .mcp.json. The v1 server registers as `orbit`, while the opt-in mux uses
+    // `orbit-federated`; permission entries must follow the actual server id
+    // so the two integrations can coexist.
     // The plugin-scoped shape `mcp__plugin_<plugin>_<server>__<tool>` is
     // what Claude synthesized for Orbit's retired extension distribution.
     // That path did not run this code, so the plugin-scoped prefix is
@@ -119,7 +126,7 @@ pub(super) fn claude_permission_name(tool_name: &str) -> String {
     // stale plugin-prefixed entries left by pre-ORB-00286 CLI runs.
     format!(
         "mcp__{}__{}",
-        ORBIT_MCP_SERVER_ID,
+        server_id,
         mcp_advertised_tool_name(tool_name)
     )
 }
@@ -130,7 +137,7 @@ fn claude_legacy_safe_permissions() -> Vec<String> {
     // its *plugin* install path, not for bare `.mcp.json` registrations.
     // Existing users carry these stale entries in their settings.json;
     // `apply_claude_remove` strips them alongside the current
-    // `claude_safe_permissions()` so an upgrade + `orbit mcp remove
+    // `claude_safe_permissions(ORBIT_MCP_SERVER_ID)` so an upgrade + `orbit mcp remove
     // --claude` leaves a clean file. Keep the generator independent from
     // `claude_permission_name` so a future prefix change doesn't break
     // this migration.

--- a/crates/orbit-cli/src/command/mcp/setup/providers/codex.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/codex.rs
@@ -1,11 +1,9 @@
 use orbit_core::OrbitError;
 use toml::{Table as TomlTable, Value as TomlValue};
 
-use crate::command::mcp::ORBIT_MCP_SERVER_ID;
-
 use super::super::dispatch::ConfigTarget;
 use super::super::format::*;
-use super::common::{ServerLaunch, server_args};
+use super::common::{ServerLaunch, server_args, server_id};
 
 pub(in crate::command::mcp::setup) fn apply_codex_init(
     target: &ConfigTarget,
@@ -14,7 +12,7 @@ pub(in crate::command::mcp::setup) fn apply_codex_init(
     let mut root = load_toml_table(&target.mcp_path)?;
     let mcp_servers = ensure_toml_table(&mut root, "mcp_servers")?;
     mcp_servers.insert(
-        ORBIT_MCP_SERVER_ID.to_string(),
+        server_id(launch).to_string(),
         TomlValue::Table(codex_mcp_server_table(launch)),
     );
     write_toml_table(&target.mcp_path, &root)
@@ -22,13 +20,14 @@ pub(in crate::command::mcp::setup) fn apply_codex_init(
 
 pub(in crate::command::mcp::setup) fn apply_codex_remove(
     target: &ConfigTarget,
+    server_id: &str,
 ) -> Result<(), OrbitError> {
     let mut root = load_toml_table(&target.mcp_path)?;
     if let Some(mcp_servers) = root
         .get_mut("mcp_servers")
         .and_then(TomlValue::as_table_mut)
     {
-        mcp_servers.remove(ORBIT_MCP_SERVER_ID);
+        mcp_servers.remove(server_id);
         if mcp_servers.is_empty() {
             root.remove("mcp_servers");
         }

--- a/crates/orbit-cli/src/command/mcp/setup/providers/common.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/common.rs
@@ -1,31 +1,72 @@
+use crate::command::mcp::ORBIT_MCP_SERVER_ID;
+
+pub(in crate::command::mcp::setup) const ORBIT_FEDERATED_MCP_SERVER_ID: &str = "orbit-federated";
+
 /// The launch identity a generated client config is written for.
 ///
-/// Both fields answer "what is this integration for", and both are decided by
-/// the registration path rather than by the client that later connects. Every
-/// caller names them explicitly so no path silently upgrades authority or
-/// silently drops the workspace binding.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(in crate::command::mcp::setup) struct ServerLaunch<'a> {
-    /// `true` produces `mcp serve --operator` (the `orbit workspace init
-    /// --mcp` bootstrap path), `false` produces plain `mcp serve` (bare
-    /// `orbit mcp init`).
-    pub(in crate::command::mcp::setup) operator: bool,
-    /// The workspace this integration was registered for, emitted as
-    /// `--workspace <selector>`. `None` when the checkout is not registered on
-    /// this machine, leaving the generated session unbound and every
-    /// workspace-scoped call responsible for its own selector.
-    pub(in crate::command::mcp::setup) workspace: Option<&'a str>,
+/// Local and federated servers are separate variants because the federated mux
+/// cannot carry local operator authority or a local workspace binding. The
+/// registration path chooses the variant explicitly, so bare `orbit mcp init`
+/// cannot silently convert an existing v1 integration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::command::mcp::setup) enum ServerLaunch<'a> {
+    /// The v1 server, optionally operator-authorized and workspace-bound.
+    Local {
+        operator: bool,
+        workspace: Option<&'a str>,
+    },
+    /// The session-unbound mux over operator-configured destinations.
+    Federated,
+}
+
+impl Default for ServerLaunch<'_> {
+    fn default() -> Self {
+        Self::Local {
+            operator: false,
+            workspace: None,
+        }
+    }
+}
+
+impl<'a> ServerLaunch<'a> {
+    pub(in crate::command::mcp::setup) const fn local(
+        operator: bool,
+        workspace: Option<&'a str>,
+    ) -> Self {
+        Self::Local {
+            operator,
+            workspace,
+        }
+    }
+}
+
+pub(super) fn server_id(launch: ServerLaunch<'_>) -> &'static str {
+    match launch {
+        ServerLaunch::Local { .. } => ORBIT_MCP_SERVER_ID,
+        ServerLaunch::Federated => ORBIT_FEDERATED_MCP_SERVER_ID,
+    }
 }
 
 /// The argv a generated client config launches Orbit's MCP server with.
 pub(super) fn server_args(launch: ServerLaunch<'_>) -> Vec<String> {
     let mut args = vec!["mcp".to_string(), "serve".to_string()];
-    if launch.operator {
-        args.push("--operator".to_string());
-    }
-    if let Some(workspace) = launch.workspace {
-        args.push("--workspace".to_string());
-        args.push(workspace.to_string());
+    match launch {
+        ServerLaunch::Local {
+            operator,
+            workspace,
+        } => {
+            if operator {
+                args.push("--operator".to_string());
+            }
+            if let Some(workspace) = workspace {
+                args.push("--workspace".to_string());
+                args.push(workspace.to_string());
+            }
+        }
+        ServerLaunch::Federated => {
+            args.push("--mode".to_string());
+            args.push("federated".to_string());
+        }
     }
     args
 }

--- a/crates/orbit-cli/src/command/mcp/setup/providers/gemini.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/gemini.rs
@@ -13,6 +13,7 @@ pub(in crate::command::mcp::setup) fn apply_gemini_init(
 
 pub(in crate::command::mcp::setup) fn apply_gemini_remove(
     target: &ConfigTarget,
+    server_id: &str,
 ) -> Result<(), OrbitError> {
-    apply_simple_json_remove(target, "mcpServers")
+    apply_simple_json_remove(target, "mcpServers", server_id)
 }

--- a/crates/orbit-cli/src/command/mcp/setup/providers/grok.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/grok.rs
@@ -1,11 +1,9 @@
 use orbit_core::OrbitError;
 use toml::{Table as TomlTable, Value as TomlValue};
 
-use crate::command::mcp::ORBIT_MCP_SERVER_ID;
-
 use super::super::dispatch::ConfigTarget;
 use super::super::format::*;
-use super::common::{ServerLaunch, server_args};
+use super::common::{ServerLaunch, server_args, server_id};
 
 pub(in crate::command::mcp::setup) fn apply_grok_init(
     target: &ConfigTarget,
@@ -14,7 +12,7 @@ pub(in crate::command::mcp::setup) fn apply_grok_init(
     let mut root = load_toml_table(&target.mcp_path)?;
     let mcp_servers = ensure_toml_table(&mut root, "mcp_servers")?;
     mcp_servers.insert(
-        ORBIT_MCP_SERVER_ID.to_string(),
+        server_id(launch).to_string(),
         TomlValue::Table(grok_mcp_server_table(launch)),
     );
     write_toml_table(&target.mcp_path, &root)
@@ -22,13 +20,14 @@ pub(in crate::command::mcp::setup) fn apply_grok_init(
 
 pub(in crate::command::mcp::setup) fn apply_grok_remove(
     target: &ConfigTarget,
+    server_id: &str,
 ) -> Result<(), OrbitError> {
     let mut root = load_toml_table(&target.mcp_path)?;
     if let Some(mcp_servers) = root
         .get_mut("mcp_servers")
         .and_then(TomlValue::as_table_mut)
     {
-        mcp_servers.remove(ORBIT_MCP_SERVER_ID);
+        mcp_servers.remove(server_id);
         if mcp_servers.is_empty() {
             root.remove("mcp_servers");
         }

--- a/crates/orbit-cli/src/command/mcp/setup/providers/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/mod.rs
@@ -7,7 +7,7 @@ mod simple_json;
 
 pub(super) use self::claude::{apply_claude_init, apply_claude_remove};
 pub(super) use self::codex::{apply_codex_init, apply_codex_remove};
-pub(super) use self::common::ServerLaunch;
+pub(super) use self::common::{ORBIT_FEDERATED_MCP_SERVER_ID, ServerLaunch};
 pub(super) use self::gemini::{apply_gemini_init, apply_gemini_remove};
 pub(super) use self::grok::{apply_grok_init, apply_grok_remove};
 pub(super) use self::simple_json::{apply_simple_json_init, apply_simple_json_remove};

--- a/crates/orbit-cli/src/command/mcp/setup/providers/simple_json.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/simple_json.rs
@@ -1,11 +1,9 @@
 use orbit_core::OrbitError;
 use serde_json::{Map as JsonMap, Value as JsonValue};
 
-use crate::command::mcp::ORBIT_MCP_SERVER_ID;
-
 use super::super::dispatch::ConfigTarget;
 use super::super::format::*;
-use super::common::{ServerLaunch, server_args};
+use super::common::{ServerLaunch, server_args, server_id};
 
 pub(in crate::command::mcp::setup) fn apply_simple_json_init(
     target: &ConfigTarget,
@@ -15,7 +13,7 @@ pub(in crate::command::mcp::setup) fn apply_simple_json_init(
     let mut root = load_json_object(&target.mcp_path)?;
     let servers = ensure_json_object(&mut root, top_level_key)?;
     servers.insert(
-        ORBIT_MCP_SERVER_ID.to_string(),
+        server_id(launch).to_string(),
         simple_mcp_server_value(launch),
     );
     write_json_object(&target.mcp_path, &root)
@@ -24,13 +22,14 @@ pub(in crate::command::mcp::setup) fn apply_simple_json_init(
 pub(in crate::command::mcp::setup) fn apply_simple_json_remove(
     target: &ConfigTarget,
     top_level_key: &str,
+    server_id: &str,
 ) -> Result<(), OrbitError> {
     let mut root = load_json_object(&target.mcp_path)?;
     if let Some(servers) = root
         .get_mut(top_level_key)
         .and_then(JsonValue::as_object_mut)
     {
-        servers.remove(ORBIT_MCP_SERVER_ID);
+        servers.remove(server_id);
         if servers.is_empty() {
             root.remove(top_level_key);
         }

--- a/crates/orbit-cli/src/command/mcp/setup/providers/tests/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/tests/mod.rs
@@ -12,13 +12,7 @@ use super::common::ServerLaunch;
 
 /// The `orbit workspace init --mcp` bootstrap authority, with no workspace
 /// binding, so authority assertions stay independent of the binding ones.
-const OPERATOR_LAUNCH: ServerLaunch<'static> = ServerLaunch {
-    operator: true,
-    workspace: None,
-};
+const OPERATOR_LAUNCH: ServerLaunch<'static> = ServerLaunch::local(true, None);
 
 /// A launch bound to a registered workspace, as a generated config carries it.
-const BOUND_LAUNCH: ServerLaunch<'static> = ServerLaunch {
-    operator: false,
-    workspace: Some("ws_demo"),
-};
+const BOUND_LAUNCH: ServerLaunch<'static> = ServerLaunch::local(false, Some("ws_demo"));

--- a/crates/orbit-cli/src/command/mcp/setup/providers/tests/simple_json.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/tests/simple_json.rs
@@ -31,6 +31,32 @@ fn server_value_builders_emit_mcp_serve_only() {
 }
 
 #[test]
+fn server_value_builders_emit_federated_mode_only_when_requested() {
+    let expected = ["mcp", "serve", "--mode", "federated"];
+
+    for (provider, args) in [
+        (
+            "claude",
+            json_args(&claude_mcp_server_value(ServerLaunch::Federated)),
+        ),
+        (
+            "gemini",
+            json_args(&simple_mcp_server_value(ServerLaunch::Federated)),
+        ),
+        (
+            "codex",
+            toml_args(&codex_mcp_server_table(ServerLaunch::Federated)),
+        ),
+        (
+            "grok",
+            toml_args(&grok_mcp_server_table(ServerLaunch::Federated)),
+        ),
+    ] {
+        assert_eq!(args, expected, "{provider} must launch the federated mux");
+    }
+}
+
+#[test]
 fn server_value_builders_append_operator_flag_when_authorized() {
     let claude = claude_mcp_server_value(OPERATOR_LAUNCH);
     let claude_args = claude["args"].as_array().expect("claude args");
@@ -92,10 +118,7 @@ fn toml_args(server: &toml::value::Table) -> Vec<String> {
 /// Authority and binding are independent: the bootstrap path emits both.
 #[test]
 fn server_value_builders_emit_authority_and_binding_together() {
-    let launch = ServerLaunch {
-        operator: true,
-        workspace: Some("ws_demo"),
-    };
+    let launch = ServerLaunch::local(true, Some("ws_demo"));
     assert_eq!(
         json_args(&claude_mcp_server_value(launch)),
         ["mcp", "serve", "--operator", "--workspace", "ws_demo"]

--- a/crates/orbit-cli/src/command/mcp/setup/tests/args.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/tests/args.rs
@@ -1,4 +1,41 @@
+use clap::Parser;
+
 use super::super::args::{McpProvider, ProviderSelectionArgs, ProviderSelectionMode};
+use crate::command::mcp::McpSubcommand;
+use crate::command::{Cli, Commands};
+
+#[test]
+fn cli_parses_federated_init_as_an_explicit_opt_in() {
+    let cli = Cli::parse_from(["orbit", "mcp", "init", "--federated", "--codex"]);
+    match cli.command {
+        Commands::Mcp(command) => match command.command {
+            McpSubcommand::Init(args) => assert!(args.federated),
+            _ => panic!("expected mcp init"),
+        },
+        _ => panic!("expected top-level mcp command"),
+    }
+
+    let cli = Cli::parse_from(["orbit", "mcp", "init", "--codex"]);
+    match cli.command {
+        Commands::Mcp(command) => match command.command {
+            McpSubcommand::Init(args) => assert!(!args.federated),
+            _ => panic!("expected mcp init"),
+        },
+        _ => panic!("expected top-level mcp command"),
+    }
+}
+
+#[test]
+fn cli_parses_federated_remove_as_an_explicit_opt_in() {
+    let cli = Cli::parse_from(["orbit", "mcp", "remove", "--federated", "--codex"]);
+    match cli.command {
+        Commands::Mcp(command) => match command.command {
+            McpSubcommand::Remove(args) => assert!(args.federated),
+            _ => panic!("expected mcp remove"),
+        },
+        _ => panic!("expected top-level mcp command"),
+    }
+}
 
 #[test]
 fn provider_selection_defaults_to_auto() {

--- a/crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs
@@ -156,6 +156,146 @@ fn home_scope_writes_to_home_paths_and_skips_repo_files() {
 }
 
 #[test]
+fn federated_home_scope_preserves_v1_entries() {
+    let repo = tempdir().expect("repo tempdir");
+    let home = tempdir().expect("home tempdir");
+    let orbit_root = repo.path().join(".orbit");
+    std::fs::create_dir_all(&orbit_root).expect("create orbit root");
+
+    let providers = vec![
+        McpProvider::Claude,
+        McpProvider::Codex,
+        McpProvider::Gemini,
+        McpProvider::Grok,
+    ];
+    run_action(
+        McpAction::Init(ServerLaunch::default()),
+        repo.path(),
+        &orbit_root,
+        ProviderSelectionMode::Explicit(providers.clone()),
+        Some(home.path().to_path_buf()),
+        ScopeArg::Home,
+    )
+    .expect("init v1 home scope");
+    run_action(
+        McpAction::Init(ServerLaunch::Federated),
+        repo.path(),
+        &orbit_root,
+        ProviderSelectionMode::Explicit(providers.clone()),
+        Some(home.path().to_path_buf()),
+        ScopeArg::Home,
+    )
+    .expect("init federated home scope");
+
+    let claude: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(home.path().join(".claude").join(".mcp.json"))
+            .expect("read claude mcp"),
+    )
+    .expect("parse claude mcp");
+    assert_eq!(
+        claude["mcpServers"]["orbit"]["args"],
+        serde_json::json!(["mcp", "serve"])
+    );
+    assert_eq!(
+        claude["mcpServers"]["orbit-federated"]["args"],
+        serde_json::json!(["mcp", "serve", "--mode", "federated"])
+    );
+    let claude_settings: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(home.path().join(".claude").join("settings.json"))
+            .expect("read claude settings"),
+    )
+    .expect("parse claude settings");
+    assert!(
+        claude_settings["permissions"]["allow"]
+            .as_array()
+            .expect("claude allow list")
+            .iter()
+            .any(|permission| permission == "mcp__orbit-federated__orbit_task_show")
+    );
+
+    for (provider, path) in [
+        ("codex", home.path().join(".codex").join("config.toml")),
+        ("grok", home.path().join(".grok").join("config.toml")),
+    ] {
+        let config: toml::Value = toml::from_str(
+            &std::fs::read_to_string(path)
+                .unwrap_or_else(|error| panic!("read {provider}: {error}")),
+        )
+        .unwrap_or_else(|error| panic!("parse {provider}: {error}"));
+        assert_eq!(
+            config["mcp_servers"]["orbit"]["args"]
+                .as_array()
+                .map(Vec::len),
+            Some(2),
+            "{provider} must retain v1"
+        );
+        assert_eq!(
+            config["mcp_servers"]["orbit-federated"]["args"]
+                .as_array()
+                .map(Vec::len),
+            Some(4),
+            "{provider} must add federated"
+        );
+    }
+
+    let gemini: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(home.path().join(".gemini").join("settings.json"))
+            .expect("read gemini settings"),
+    )
+    .expect("parse gemini settings");
+    assert_eq!(
+        gemini["mcpServers"]["orbit"]["args"],
+        serde_json::json!(["mcp", "serve"])
+    );
+    assert_eq!(
+        gemini["mcpServers"]["orbit-federated"]["args"],
+        serde_json::json!(["mcp", "serve", "--mode", "federated"])
+    );
+
+    run_action(
+        McpAction::RemoveFederated,
+        repo.path(),
+        &orbit_root,
+        ProviderSelectionMode::Explicit(providers),
+        Some(home.path().to_path_buf()),
+        ScopeArg::Home,
+    )
+    .expect("remove federated home scope");
+
+    let claude: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(home.path().join(".claude").join(".mcp.json"))
+            .expect("read claude after remove"),
+    )
+    .expect("parse claude after remove");
+    assert!(claude["mcpServers"]["orbit"].is_object());
+    assert!(claude["mcpServers"]["orbit-federated"].is_null());
+
+    let codex: toml::Value = toml::from_str(
+        &std::fs::read_to_string(home.path().join(".codex").join("config.toml"))
+            .expect("read codex after remove"),
+    )
+    .expect("parse codex after remove");
+    assert!(codex["mcp_servers"]["orbit"].is_table());
+    assert!(codex["mcp_servers"].get("orbit-federated").is_none());
+
+    let gemini: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(home.path().join(".gemini").join("settings.json"))
+            .expect("read gemini after remove"),
+    )
+    .expect("parse gemini after remove");
+    assert!(gemini["mcpServers"]["orbit"].is_object());
+    assert!(gemini["mcpServers"]["orbit-federated"].is_null());
+
+    let grok: toml::Value = toml::from_str(
+        &std::fs::read_to_string(home.path().join(".grok").join("config.toml"))
+            .expect("read grok after remove"),
+    )
+    .expect("parse grok after remove");
+    assert!(grok["mcp_servers"]["orbit"].is_table());
+    assert!(grok["mcp_servers"].get("orbit-federated").is_none());
+}
+
+#[test]
 fn home_scope_remove_strips_only_orbit_entries() {
     let repo = tempdir().expect("repo tempdir");
     let home = tempdir().expect("home tempdir");

--- a/docs/design/federated-mcp/1_overview.md
+++ b/docs/design/federated-mcp/1_overview.md
@@ -1,8 +1,8 @@
 ---
 title: Federated MCP — Overview
 owner: grok
-last_updated: 2026-08-23
-last_validated: 2026-08-23
+last_updated: 2026-08-24
+last_validated: 2026-08-24
 status: Draft
 feature: federated-mcp
 doc_role: overview
@@ -11,16 +11,16 @@ summary: Mux that presents one MCP namespace over operator-configured destinatio
 tags: [federated-mcp, mcp, host-registry, multi-host]
 paths: ["crates/orbit-mcp/**", "crates/orbit-registry/**", "crates/orbit-core/**"]
 related_features: [federated-mcp, host-registry, mcp-bridge, remote-access, mcp-session-context]
-related_artifacts: [ORB-11010, ORB-11009, ORB-11008]
+related_artifacts: [ORB-11016, ORB-11017, ORB-11015, ORB-11014, ORB-11013, ORB-11012, ORB-11011, ORB-11010, ORB-11009, ORB-11008]
 ---
 
 # Federated MCP — Overview
 
-Federated MCP is a caller-facing mux: one Orbit MCP namespace in front of operator-configured destinations (MCP or SSH remotes already chosen by the operator). It is not v1 local/remote MCP, not a host-registry evolution, and not a fleet inventory. Direct SSH stdio to one chosen host remains the v1 remote path (`--mode remote`). The mux is `orbit mcp serve --mode federated` ([ORB-11014] list, [ORB-11015] routing). [ORB-11008] recorded the policy; this folder is the implementable contract from [ORB-11009] (PR #1139), with review holes closed in [ORB-11010].
+Federated MCP is a caller-facing mux: one Orbit MCP namespace in front of operator-configured SSH stdio destinations. It is not v1 local/remote MCP, not a host-registry evolution, and not a fleet inventory. Direct SSH stdio to one chosen host remains the v1 remote path (`--mode remote`). The mux is `orbit mcp serve --mode federated` ([ORB-11014] list, [ORB-11015] routing). [ORB-11008] recorded the policy; this folder is the implementable contract from [ORB-11009] (PR #1139), with review holes closed in [ORB-11010].
 
 ## 1. Motivation
 
-A later implementation will otherwise invent a second ownership model, key selectors on renameable `host_id`, or ship a relay that mcp-bridge still forbids. The five-point policy recorded by [ORB-11008] is still right; it was not a routing contract, and it no longer lives as a list in host-registry vision. This feature names the mux, the selector, the capability/authority split, the list schema, and the mcp-bridge exception so implementation cannot guess them.
+The implementation keeps one ownership model, keys selectors on stable `machine_id`, and limits the relay exception to the federated namespace. The five-point policy recorded by [ORB-11008] is still right; it was not a routing contract, and it no longer lives as a list in host-registry vision. This feature names the mux, the selector, the capability/authority split, the list schema, and the mcp-bridge exception that the shipped path follows.
 
 ## 2. Core Concepts
 
@@ -37,7 +37,7 @@ Full definitions live in [references/glossary.md](./references/glossary.md). The
 | Concern | File | Task |
 |---------|------|------|
 | Mux vs fleet registry; selector identity; list schema; fail-closed errors | [specs/federated-workspace-mcp.md](./specs/federated-workspace-mcp.md) | [ORB-11009], [ORB-11010] |
-| Proposed mechanism (not shipped) | [2_design.md](./2_design.md) | [ORB-11009], [ORB-11010] |
+| Shipped mux design | [2_design.md](./2_design.md) | [ORB-11011]–[ORB-11017] |
 | Open questions (auth, expiry, freshness, cloud store) | [3_vision.md](./3_vision.md) | [ORB-11009] |
 | Standing rules and rejected alternatives | [4_decisions.md](./4_decisions.md) | [ORB-11009], [ORB-11010] |
 | Standing constraint (mux is not a fleet registry) | [host-registry/3_vision.md](../host-registry/3_vision.md) (cross-link only; the five-point policy list no longer lives there) | [ORB-11008] |
@@ -50,5 +50,12 @@ Full definitions live in [references/glossary.md](./references/glossary.md). The
 - [ORB-11008] — recorded the federated multi-host MCP policy inside host-registry and remote-access vision
 - [ORB-11009] — turns that policy into this implementable design contract (PR #1139)
 - [ORB-11010] — closes the PR #1139 review contract holes (INDEX row, tool class, advertisement vs catalog role, list shape, error precedence, competing authorities, selector wording)
+- [ORB-11011] — federated MCP implementation epic
+- [ORB-11012] — destination-Core `capability_refused`
+- [ORB-11013] — destination config, selector type, and routing errors
+- [ORB-11014] — federated workspace list
+- [ORB-11015] — fail-closed workspace-scoped routing
+- [ORB-11016] — federated client registration and shipped-design documentation
+- [ORB-11017] — host-qualified federated `workspace` parameter
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/federated-mcp/2_design.md
+++ b/docs/design/federated-mcp/2_design.md
@@ -1,8 +1,8 @@
 ---
 title: Federated MCP — Design
 owner: grok
-last_updated: 2026-08-23
-last_validated: 2026-08-23
+last_updated: 2026-08-24
+last_validated: 2026-08-24
 status: Draft
 feature: federated-mcp
 doc_role: design
@@ -11,7 +11,7 @@ summary: Federated MCP mux, selector, capability split, list schema, and fail-cl
 tags: [federated-mcp, mcp, host-registry, multi-host]
 paths: ["crates/orbit-mcp/**", "crates/orbit-registry/**", "crates/orbit-core/**"]
 related_features: [federated-mcp, host-registry, mcp-bridge, remote-access, mcp-session-context]
-related_artifacts: [ORB-11017, ORB-11015, ORB-11014, ORB-11010, ORB-11009, ORB-11008]
+related_artifacts: [ORB-11016, ORB-11017, ORB-11015, ORB-11014, ORB-11013, ORB-11012, ORB-11011, ORB-11010, ORB-11009, ORB-11008]
 ---
 
 # Federated MCP — Design
@@ -22,14 +22,14 @@ The prescriptive invariants live in [specs/federated-workspace-mcp.md](./specs/f
 
 ## 1. Operator-configured destinations
 
-The gateway is a mux in front of destinations the operator already configured (MCP remotes or SSH stdio targets). It does not:
+The shipped gateway is a mux in front of the SSH stdio destinations the operator configured in `~/.orbit/mcp-destinations.toml`. It does not:
 
 - grow host-registry into a fleet inventory;
 - auto-discover the owner checkout of a repository;
 - place work, elect a leader, or pick a healthy substitute;
 - detect or reject competing control-plane authorities (see §7).
 
-Direct SSH stdio to one chosen host remains the v1 remote path and is unchanged by this proposal. A caller that does not use the federated namespace never hits the mux.
+Direct SSH stdio to one chosen host remains the v1 remote path and is unchanged by the mux. A caller that does not use the federated namespace never hits it.
 
 ## 2. Host-qualified selector
 
@@ -61,7 +61,7 @@ A destination Core that does not hold a class **refuses** tools of that class wi
 
 Tool class is assigned by what the tool does, not by a per-tool registry field:
 
-- task issuance and coordination-store writes (`orbit_task_add`, `orbit.task.update`, `orbit.task.start`, …) → `control_plane`
+- task issuance, coordination-store writes, and task reads (`orbit_task_add`, `orbit.task.update`, `orbit.task.list`, `orbit.task.show`, …) → `control_plane`
 - anything touching runs, logs, or scheduler state → `execute`
 - discovery / list tools (`orbit_workspace_list`, …) → unclassified, not subject to `capability_refused`
 
@@ -124,7 +124,9 @@ v1 local stdio, direct SSH stdio, and `orbit mcp listen` stay as specified in mc
 ## 9. Concerns & Honest Limitations
 
 - v1 `--mode remote` is unchanged. Federated list and routing live only in `--mode federated`.
+- The mux performs no placement and does not detect competing Owner declarations. Those remain operator configuration responsibilities.
 - Availability is bounded by the chosen destination. Callers must handle visible routing failures; there is no transparent substitute result.
+- Task reads remain owner-only because the coordination store is owner-authoritative. Use the owner selector for `orbit.task.list` and `orbit.task.show`; a replica selector receives `capability_refused`.
 - Including unreachable hosts makes the list honest and larger; clients must read reachability rather than treating presence as liveness.
 - Capability advertisement can lag destination Core. The destination refuse is the correctness boundary; the gateway is not a second authorization layer.
 - Transport authentication, selector expiry, health freshness, and cloud coordination-store details are deliberately unresolved. See [3_vision.md](./3_vision.md). Probe cadence stays a vision open question; it does not change live-delivery error precedence.
@@ -134,10 +136,14 @@ v1 local stdio, direct SSH stdio, and `orbit mcp listen` stay as specified in mc
 ## Task References
 
 - [ORB-11008] — recorded the federated multi-host MCP policy
-- [ORB-11009] — specified this proposed mechanism as the implementable contract (PR #1139)
+- [ORB-11009] — specified the implementable mux contract (PR #1139)
 - [ORB-11010] — closed the PR #1139 review contract holes in this folder
+- [ORB-11011] — sequenced the shipped federated MCP mux
+- [ORB-11012] — mapped destination checkout role to `capability_refused`
+- [ORB-11013] — implemented destination config, selectors, and routing errors
 - [ORB-11014] — federated `orbit.workspace.list`
 - [ORB-11015] — fail-closed routing of host-qualified selectors
+- [ORB-11016] — registered the federated serve path and aligned current docs
 - [ORB-11017] — federated workspace param is the host-qualified selector
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/federated-mcp/references/conformance-federated.yaml
+++ b/docs/design/federated-mcp/references/conformance-federated.yaml
@@ -1,0 +1,88 @@
+schema_version: 2
+contract: orbit-mcp-federated
+feature_status: Draft
+last_updated: 2026-08-24
+last_validated: 2026-08-24
+
+source_of_truth:
+  design: docs/design/federated-mcp/2_design.md
+  prescriptive_contract: docs/design/federated-mcp/specs/federated-workspace-mcp.md
+  destinations: crates/orbit-mcp/src/federated/config.rs
+  mux_host: crates/orbit-mcp/src/federated/host.rs::FederatedMcpHost
+  destination_capabilities: crates/orbit-mcp/src/federated/capability.rs
+  serve_entry: crates/orbit-cli/src/command/mcp/command.rs
+  client_registration: crates/orbit-cli/src/command/mcp/setup
+
+launch:
+  destinations_file: ~/.orbit/mcp-destinations.toml
+  argv: orbit mcp serve --mode federated
+  registration:
+    command: orbit mcp init --federated
+    removal: orbit mcp remove --federated
+    server_id: orbit-federated
+    coexistence_rule: preserve the v1 `orbit` client entry
+  discovery: call federated orbit_workspace_list and copy a descriptor's selector
+  workspace_call: pass the copied selector as the workspace argument
+
+federated_namespace_exception:
+  v1_invariant: one direct byte-transparent SSH stdio hop; no Orbit process relays onward
+  exception: the federated mux inspects MCP calls and relays them to the destination encoded in the host-qualified selector
+  scope: orbit mcp serve --mode federated only
+  unchanged_v1_paths:
+    - orbit mcp serve
+    - orbit mcp serve --mode remote <ssh-host>
+    - orbit mcp listen
+  v1_conformance: docs/design/mcp-bridge/references/conformance-v1.yaml
+
+routing:
+  selector_source: copy selector from federated orbit_workspace_list
+  selector_shape: hm_<machine_id>/ws_<workspace_id>
+  delivery: one selected destination; no fallback or failover
+  config_collision: duplicate machine_id fails startup as ambiguous_destination
+  errors:
+    - unknown_selector
+    - unreachable_destination
+    - stale_route
+    - unhealthy_checkout
+    - tool_not_on_this_host
+    - capability_refused
+
+authority:
+  destination_runs_logs_scheduler: execute
+  owner_coordination_store: control_plane
+  task_reads:
+    tools:
+      - orbit.task.list
+      - orbit.task.show
+    rule: owner-only; use the owner descriptor's selector
+    replica_result: capability_refused
+
+honest_limitations:
+  placement: none
+  competing_owner_detection: none
+  availability: bounded by the chosen destination
+  task_reads_on_replicas: refused; the mux does not forward them to the owner
+  replication: none
+  implicit_failover: none
+
+validation:
+  registration_and_coexistence: crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs
+  registration_argv: crates/orbit-cli/src/command/mcp/setup/providers/tests/simple_json.rs
+  config_and_selector: crates/orbit-mcp/src/federated/tests/config.rs
+  aggregate_list: crates/orbit-mcp/src/federated/tests/host.rs
+  fail_closed_routes: crates/orbit-mcp/src/federated/tests/route.rs
+  capability_classes: crates/orbit-mcp/src/federated/tests/capability.rs
+
+task_references:
+  epic: ORB-11011
+  children:
+    - ORB-11012
+    - ORB-11013
+    - ORB-11014
+    - ORB-11015
+    - ORB-11016
+    - ORB-11017
+  contract_history:
+    - ORB-11008
+    - ORB-11009
+    - ORB-11010

--- a/website/src/content/docs/how-to/mcp-integration.md
+++ b/website/src/content/docs/how-to/mcp-integration.md
@@ -24,6 +24,48 @@ orbit mcp init --grok
 
 **Grok Build** uses the native `.grok/config.toml` format (similar to how Claude Code can use a config file). `orbit mcp init --grok` will create or update `.grok/config.toml` in your workspace root (or `~/.grok/config.toml` for global).
 
+## Register the federated mux
+
+Federated MCP presents one namespace over the SSH destinations in the
+machine-global `~/.orbit/mcp-destinations.toml`:
+
+```toml
+[[destinations]]
+ssh = "orbit-owner"
+machine_id = "hm_alpha"
+
+[[destinations]]
+ssh = "operator@orbit-build"
+machine_id = "hm_beta"
+```
+
+Register it with a client (Codex shown here):
+
+```bash
+orbit mcp init --federated --client codex --scope home
+```
+
+This adds a separate `orbit-federated` entry that launches `orbit mcp serve
+--mode federated`; an existing v1 `orbit` entry is left unchanged. Use another
+`--client` value or `--auto` to target a different installed client.
+Remove only that entry later with `orbit mcp remove --federated` and the same
+client/scope selection.
+
+In that federated MCP session, list destinations, copy an owner row's
+host-qualified `selector`, and pass it unchanged to a workspace-scoped call:
+
+```text
+orbit_workspace_list({})
+  -> {"workspaces":[{"selector":"hm_alpha/ws_orbit", ...}]}
+
+orbit_task_list({"workspace":"hm_alpha/ws_orbit"})
+```
+
+There is no placement, implicit failover, or competing-Owner detection;
+availability is the availability of the selected destination. Task reads are
+owner-only, so `orbit_task_list` and `orbit_task_show` must use the owner
+selector. A replica selector returns `capability_refused`.
+
 ## Serve
 
 Start the MCP surface:
@@ -55,4 +97,5 @@ means.
 
 ```bash
 orbit mcp remove --all
+orbit mcp remove --federated --all  # remove only the federated entry
 ```


### PR DESCRIPTION
## Task

[ORB-11016](https://orbit-cli.com/tasks/ORB-11016) — Federated serve registration + design docs as implemented

### Description

## Problem
Even a working mux is unused if `orbit mcp init` still writes a single-host server, and federated `2_design.md` still says "proposed / not implemented."

## Why It Matters
Operators need a documented path from destinations file → federated serve → list → copy selector → one workspace-scoped call, without rewriting existing v1 client configs.

## Constraints / Notes
- Parent epic [ORB-11011]. Depends on [ORB-11017] (federated workspace param). Also requires [ORB-11012] merged so docs can name `capability_refused` as live.
- `orbit mcp init --federated` (or equivalent serve-mode flag) writes **one** MCP server launching `orbit mcp serve --mode federated`. Do not surprise-rewrite existing v1 integrations.
- README and website how-to: destinations file, federated serve, list, copy selector, call.
- mcp-bridge `2_design.md` keeps v1 current behavior. Federated `2_design.md` drops "proposed / not implemented" for the shipped mux. Feature status stays **Draft** until Daniel accepts.
- Add `docs/design/federated-mcp/references/conformance-federated.yaml` for the mux exception (do not weaken `conformance-v1.yaml`).
- Honest limitations: no placement, no competing-Owner detection, availability = chosen destination, replica task reads stay owner-only (use the owner selector for `orbit.task.list`).
- Do not file constellation AGENTS.md cutover in this task (different workspace; later).
- Dedicated worktree from `agent-main`. Crew `grok`. Cite [ORB-11011] and children in Task References / `related_artifacts`.

## Risks
- Silently converting existing `orbit mcp init` registrations to federated.
- Fake-resolving vision questions (auth principal, selector expiry, probe cadence, cloud store) in the now-current design doc.

### Acceptance Criteria

- Documented launch path exists: destinations file → `orbit mcp serve --mode federated` → federated list → copy `selector` → one workspace-scoped call. `orbit mcp init --federated` (or equivalent) writes that launch without rewriting existing v1 client configs.
- Federated `2_design.md` describes the shipped mux (no longer "proposed / not implemented"). mcp-bridge `2_design.md` and `conformance-v1.yaml` still describe v1. Feature status remains Draft.
- `docs/design/federated-mcp/references/conformance-federated.yaml` exists and records the federated-namespace exception. Honest limitations include no placement, no competing-Owner detection, and owner-only task reads.
- `make docs-index` and `make ci-fast` pass. Vision questions in `3_vision.md` remain open.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added explicit `orbit mcp init --federated` registration for every supported client. It creates a separate `orbit-federated` entry with argv `orbit mcp serve --mode federated`, preserving the v1 `orbit` entry and its workspace/authority semantics.
- Added symmetric `orbit mcp remove --federated` cleanup, including Claude permission cleanup, without removing v1 registrations.
- Added focused CLI, argv, coexistence, and removal coverage across Claude, Codex, Gemini, and Grok.
- Documented the destinations file → federated registration/serve → federated list → copied owner selector → workspace-scoped task call path in README and the website how-to.
- Updated the federated overview/design to describe the shipped SSH mux while keeping status Draft, documenting no placement, no competing-Owner detection, selected-destination availability, and owner-only task reads.
- Added `docs/design/federated-mcp/references/conformance-federated.yaml` for the federated-namespace relay exception; mcp-bridge v1 design/conformance and federated `3_vision.md` remain unchanged.
Assessment: The opt-in boundary is explicit and type-separated from local launches, so ordinary init cannot silently convert v1 configuration. Registration and removal preserve both server identities independently.

Validation:
- `cargo test -p orbit-cli command::mcp::setup` — 50 passed.
- `make docs-index` — passed; `docs/INDEX.md` unchanged.
- `make ci-fast` — passed.
- `make ci-lint` — passed with warnings denied.
- Parsed `conformance-federated.yaml` successfully and `git diff --check` passed.

Deviations from original plan:
- Added the symmetric federated removal path because a separate persistent server entry otherwise had no safe CLI cleanup. Added setup dispatch to task context for this tightly coupled behavior.
- Added federated `1_overview.md` to task context because its current-behavior table still said the mux was not shipped.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11016-6a8b8f54`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*