### PR TITLE
Replica capability classifier is never enforced at MCP dispatch

### DIFF
--- a/crates/orbit-cli/src/command/mcp/server.rs
+++ b/crates/orbit-cli/src/command/mcp/server.rs
@@ -288,6 +288,23 @@ impl ServerMcpHost {
             object.insert("workspace".to_string(), Value::String(repo_root));
         }
 
+        // Destination catalog-role gate [ORB-11021]: refuse before the tool body
+        // runs. Unclassified and execute-class tools pass and keep their own auth.
+        if let Err(error) = federated::ensure_tool_class_held(
+            name,
+            federated::CapabilityClasses::for_checkout(&selected.workspace, &selected.checkout),
+        ) {
+            return runtime
+                .execute_in_process_tool_dispatch(
+                    name,
+                    input,
+                    ToolEntryPoint::Mcp,
+                    context,
+                    move |_| Err(error),
+                )
+                .map(|outcome| outcome.value);
+        }
+
         if name == "orbit.crew.list" {
             let workspace_id = selected.workspace.id.clone();
             let owner_machine_id = selected.workspace.owner_machine_id.clone();

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -514,7 +514,7 @@ fn mcp_server_advertises_governed_tools_but_denies_an_unprivileged_session() {
 /// real v1 MCP transport, a coordination write is refused with the named
 /// catalog-role code — not `invalid_input`, which would make a refusal
 /// indistinguishable from a malformed call, and not `capability_denied`, which
-/// is the separate operator-versus-agent axis [ORB-11012].
+/// is the separate operator-versus-agent axis [ORB-11012] [ORB-11021].
 #[test]
 fn a_replica_checkout_refuses_a_coordination_write_with_capability_refused() {
     let workspace = McpWorkspace::init_replica_of("hm_remote_owner");
@@ -534,11 +534,11 @@ fn a_replica_checkout_refuses_a_coordination_write_with_capability_refused() {
     assert!(
         refused["message"]
             .as_str()
-            .is_some_and(|message| message.contains("hm_remote_owner")),
-        "the refusal names the declared owner: {refused}"
+            .is_some_and(|message| message.contains("control_plane")),
+        "MCP dispatch must refuse the capability class: {refused}"
     );
 
-    // The same refusal on the CLI, which fails closed on the same gate.
+    // CLI task writes still fail closed on Core's coordination-write guard.
     let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
         .args([
             "task",
@@ -559,6 +559,99 @@ fn a_replica_checkout_refuses_a_coordination_write_with_capability_refused() {
     let payload: Value =
         serde_json::from_slice(&output.stderr).expect("JSON error payload on stderr");
     assert_eq!(payload["code"], "capability_refused", "{payload}");
+    assert!(
+        payload["error"]
+            .as_str()
+            .is_some_and(|message| message.contains("hm_remote_owner")),
+        "the CLI refusal names the declared owner: {payload}"
+    );
+}
+
+/// The destination MCP host must enforce checkout capability classes on the
+/// production dispatch path — including control-plane tools that never pass
+/// through Core's task-write guard [ORB-11021].
+#[test]
+fn a_replica_mcp_session_enforces_checkout_capability_classes() {
+    let workspace = McpWorkspace::init_replica_of("hm_remote_owner");
+    let mut client = workspace.serve();
+
+    for (name, arguments) in [
+        (
+            "orbit_friction_add",
+            json!({
+                "body": "must not fork a replica friction",
+                "model": "codex",
+            }),
+        ),
+        (
+            "orbit_search",
+            json!({
+                "query": "must not search replica coordination",
+                "model": "codex",
+            }),
+        ),
+        ("orbit_auto_task_list", json!({})),
+        ("orbit_friction_list", json!({})),
+    ] {
+        let refused = client.call_tool_err(name, arguments);
+        assert_eq!(refused["code"], "capability_refused", "{name}: {refused}");
+        assert!(
+            refused["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("control_plane")),
+            "{name} must name the refused class: {refused}"
+        );
+    }
+
+    let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args(["friction", "list", "--json"])
+        .output()
+        .expect("list frictions on a replica via CLI");
+    assert!(
+        output.status.success(),
+        "CLI friction list failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let listed: Value = serde_json::from_slice(&output.stdout).expect("friction list JSON");
+    let items = listed.as_array().or_else(|| {
+        listed
+            .get("items")
+            .and_then(Value::as_array)
+            .or_else(|| listed.get("frictions").and_then(Value::as_array))
+    });
+    assert!(
+        items.is_some_and(Vec::is_empty),
+        "refused friction.add must not mutate local coordination state: {listed}"
+    );
+
+    let crews = client.call_tool_ok("orbit_crew_list", json!({}));
+    assert!(
+        crews.get("crews").and_then(Value::as_array).is_some(),
+        "unclassified crew.list must remain permitted: {crews}"
+    );
+
+    let marker = workspace.work.join("replica-command-exec-must-not-run");
+    for (name, arguments) in [
+        ("orbit_workflow_run_list", json!({})),
+        (
+            "orbit_command_exec",
+            json!({
+                "argv": ["touch", marker.to_str().expect("utf8 marker")],
+                "working_directory": workspace.work,
+            }),
+        ),
+    ] {
+        let denied = client.call_tool_err(name, arguments);
+        assert_eq!(
+            denied["code"], "capability_denied",
+            "{name} must pass the catalog-role gate and hit its own auth: {denied}"
+        );
+    }
+    assert!(
+        !marker.exists(),
+        "execute-class command.exec must not run after its independent denial"
+    );
 }
 
 /// The operator MCP surface, over the real transport: a server an operator


### PR DESCRIPTION
## Task

[ORB-11021](https://orbit-cli.com/tasks/ORB-11021) — Replica capability classifier is never enforced at MCP dispatch

### Description

## Problem
ORB-11012 added a complete control-plane/execute classifier and `ensure_tool_class_held`, but the production destination MCP path never calls it. At `crates/orbit-mcp/src/federated/capability.rs:113-126` the gate exists, while all live references found by `rg` are its re-export and unit tests. `ServerMcpHost::call_workspace_tool` resolves the checkout and then dispatches directly to Core at `crates/orbit-cli/src/command/mcp/server.rs:266-314` without checking the selected checkout's capability classes.

The only live replica refusal is the older task-specific Core guard (`crates/orbit-core/src/runtime/mod.rs:187-202`), whose call sites cover task writes and hide task reads. Other names classified as `control_plane`—for example `orbit.friction.add`, `orbit.friction.update`, `orbit.auto_task.list`, and `orbit.search`—do not pass through `ensure_coordination_task_write_permitted` and therefore do not receive the promised `capability_refused` at a replica destination.

## Impact
The classifier is advisory despite the design making destination Core refusal the correctness boundary. A replica can execute control-plane-class calls against its local store or return misleading empty/local results instead of a structured `capability_refused`, so callers cannot distinguish a wrong-host route from a legitimate result. This was introduced by ORB-11012.

## Evidence
At commit `688875301934549c888ba4d5e8d3b00c96fe8e11`, `rg -n 'ensure_tool_class_held|mcp_tool_class\\(' crates --glob '*.rs'` finds no production call to the gate. `cargo test -p orbit-mcp` passes because the capability tests invoke the helper directly rather than traversing `ServerMcpHost` with a replica checkout.

### Acceptance Criteria

- Every workspace-scoped MCP call is checked at the authoritative destination boundary against the selected checkout's capability classes before tool execution.
- A replica call to representative control-plane tools outside the task-write guard (including a read and a write) returns structured `code: capability_refused` and does not mutate local coordination state.
- Execute-class and unclassified tools remain permitted by the catalog-role gate on a replica and continue through their independent authorization/validation paths.
- Tests exercise the production MCP dispatch path rather than calling `ensure_tool_class_held` only as a unit helper.
- `cargo test -p orbit-mcp -p orbit-cli` and `make ci-fast` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Wired `federated::ensure_tool_class_held` into `ServerMcpHost::call_workspace_tool` after checkout resolution and before Core or crew dispatch, so every workspace-scoped MCP call is checked against the selected checkout's capability classes.
- Replica MCP calls to control-plane tools outside the task-write guard (`orbit.friction.add`, `orbit.search`, `orbit.auto_task.list`, `orbit.friction.list`) now return structured `capability_refused` and do not mutate local coordination state.
- Execute-class tools (`orbit.workflow.run.list`, `orbit.command.exec`) still pass the catalog-role gate and continue through independent authorization (`capability_denied` on an agent session). Unclassified `orbit.crew.list` remains permitted.
- Production MCP round-trip tests cover this path rather than calling the helper as a unit.

Assessment: The ORB-11012 classifier is now the destination MCP dispatch gate, not an unused helper. CLI task-write refusal still uses Core's older coordination-write guard; that path is outside this MCP-scoped change.

Validation:
- `cargo test -p orbit-mcp -p orbit-cli` passed
- `make ci-fast` passed

Deviations from original plan:
- Existing replica `orbit.task.add` MCP assertion now checks the classifier `control_plane` message because the new gate refuses before Core. CLI still names the declared owner.

Strategic decisions:
- Enforcement lives in the destination MCP host after checkout resolution, using the existing `CapabilityClasses::for_checkout` + `ensure_tool_class_held` helpers. Refusal is audited through the workspace runtime without executing the tool body.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11021-6a8b97b8`
- Behind base: 0
- Ahead of base: 1