### PR TITLE
Federated workspace list drops invalid destination checkouts

### DIFF
--- a/crates/orbit-cli/src/command/mcp/server.rs
+++ b/crates/orbit-cli/src/command/mcp/server.rs
@@ -186,6 +186,16 @@ impl ServerMcpHost {
         )
     }
 
+    fn list_federated_workspaces(&self) -> Result<Value, OrbitError> {
+        let registry_path =
+            orbit_registry::workspace_registry::registry_path_for(&self.global_root);
+        let registry = orbit_registry::workspace_registry::load_registry_from(&registry_path)?;
+        Ok(orbit_mcp::execute_federated_workspace_discovery(
+            &registry,
+            &self.process_machine_id,
+        ))
+    }
+
     fn call_global_tool(
         &self,
         name: &str,
@@ -200,6 +210,9 @@ impl ServerMcpHost {
             context,
             |_| match name {
                 "orbit.workspace.list" => self.list_workspaces(),
+                orbit_mcp::FEDERATED_DESTINATION_WORKSPACE_LIST_TOOL => {
+                    self.list_federated_workspaces()
+                }
                 _ => Err(OrbitError::not_found(NotFoundKind::Tool, name.to_string())),
             },
         )
@@ -343,6 +356,12 @@ impl McpHost for ServerMcpHost {
         input: Value,
         context: ToolSessionContext,
     ) -> Result<Value, OrbitError> {
+        // The mux's destination-side discovery path is intentionally absent
+        // from tools/list. It retains Invalid local checkouts for descriptor
+        // health without changing direct v1 orbit.workspace.list behavior.
+        if name == orbit_mcp::FEDERATED_DESTINATION_WORKSPACE_LIST_TOOL {
+            return self.call_global_tool(name, input, context);
+        }
         let definition = match self.definition(name) {
             Ok(definition) => definition,
             Err(error) => return self.audit_global_failure(name, input, context, error),

--- a/crates/orbit-mcp/src/federated/probe.rs
+++ b/crates/orbit-mcp/src/federated/probe.rs
@@ -31,9 +31,6 @@ pub const DEFAULT_PROBE_TIMEOUT: Duration = Duration::from_secs(20);
 /// change rather than silently degrading.
 const PROTOCOL_VERSION: &str = "2025-06-18";
 
-/// The v1 discovery tool the mux calls on each destination.
-const V1_WORKSPACE_LIST_TOOL: &str = "orbit.workspace.list";
-
 /// What one destination reported for this call.
 #[derive(Debug, Clone)]
 pub struct DestinationSnapshot {
@@ -234,12 +231,13 @@ impl DestinationSession {
         self.notify("notifications/initialized")
     }
 
-    /// Call the destination's v1 discovery tool and return its envelope.
+    /// Call the destination's private federated discovery path and return its
+    /// envelope. The public v1 list intentionally filters Invalid workspaces.
     fn discover_workspaces(&mut self) -> Result<DestinationSnapshot, OrbitError> {
         let response = self.request(
             "tools/call",
             json!({
-                "name": mcp_advertised_tool_name(V1_WORKSPACE_LIST_TOOL),
+                "name": crate::FEDERATED_DESTINATION_WORKSPACE_LIST_TOOL,
                 "arguments": {},
             }),
         )?;
@@ -250,26 +248,7 @@ impl DestinationSession {
             // message here would leave the caller matching on prose.
             return Err(remote_tool_error(&self.destination, content));
         }
-        let machine_id = content["machine_id"]
-            .as_str()
-            .ok_or_else(|| {
-                unreachable(
-                    &self.destination,
-                    "discovery answer carried no machine_id".to_string(),
-                )
-            })?
-            .to_string();
-        let workspaces: Vec<Workspace> = serde_json::from_value(content["workspaces"].clone())
-            .map_err(|error| {
-                unreachable(
-                    &self.destination,
-                    format!("discovery answer was not a workspace list: {error}"),
-                )
-            })?;
-        Ok(DestinationSnapshot {
-            machine_id,
-            workspaces,
-        })
+        snapshot_from_discovery_content(&self.destination, content)
     }
 
     fn list_tools(&mut self) -> Result<Vec<String>, OrbitError> {
@@ -378,6 +357,32 @@ impl DestinationSession {
             }
         }
     }
+}
+
+pub(crate) fn snapshot_from_discovery_content(
+    destination: &Destination,
+    content: &Value,
+) -> Result<DestinationSnapshot, OrbitError> {
+    let machine_id = content["machine_id"]
+        .as_str()
+        .ok_or_else(|| {
+            unreachable(
+                destination,
+                "discovery answer carried no machine_id".to_string(),
+            )
+        })?
+        .to_string();
+    let workspaces: Vec<Workspace> = serde_json::from_value(content["workspaces"].clone())
+        .map_err(|error| {
+            unreachable(
+                destination,
+                format!("discovery answer was not a workspace list: {error}"),
+            )
+        })?;
+    Ok(DestinationSnapshot {
+        machine_id,
+        workspaces,
+    })
 }
 
 impl Drop for DestinationSession {

--- a/crates/orbit-mcp/src/federated/tests/host.rs
+++ b/crates/orbit-mcp/src/federated/tests/host.rs
@@ -1,14 +1,21 @@
 //! The mux against fake destinations: no SSH, no local registry, no cache.
 
 use std::collections::BTreeSet;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use orbit_common::OrbitError;
 use orbit_types::tool::{McpToolScope, ToolSessionContext};
+use orbit_types::workspace::{
+    WorkspaceCheckout, WorkspaceCheckoutRole, WorkspaceRegistry, WorkspaceStatus,
+};
 use serde_json::Value;
 
+use super::super::config::Destination;
 use super::super::host::{FEDERATED_WORKSPACE_LIST_TOOL, FederatedMcpHost};
-use super::super::probe::DestinationSnapshot;
+use super::super::probe::{
+    DestinationProbe, DestinationSnapshot, RoutedSession, snapshot_from_discovery_content,
+};
 use super::fixtures::{OWNER_MACHINE, REPLICA_MACHINE, ScriptedProbe, destination, workspace};
 use crate::McpHost;
 
@@ -60,6 +67,24 @@ fn list(host: &FederatedMcpHost) -> Vec<Value> {
         .as_array()
         .expect("workspace rows")
         .clone()
+}
+
+struct RegistryBackedProbe {
+    registry: WorkspaceRegistry,
+}
+
+impl DestinationProbe for RegistryBackedProbe {
+    fn probe(&self, destination: &Destination) -> Result<DestinationSnapshot, OrbitError> {
+        let content =
+            crate::execute_federated_workspace_discovery(&self.registry, &destination.machine_id);
+        snapshot_from_discovery_content(destination, &content)
+    }
+
+    fn open_route(&self, _destination: &Destination) -> Result<Box<dyn RoutedSession>, OrbitError> {
+        Err(OrbitError::Execution(
+            "registry-backed discovery fixture does not route tools".to_string(),
+        ))
+    }
 }
 
 #[test]
@@ -254,6 +279,72 @@ fn an_inactive_workspace_is_listed_rather_than_filtered_out() {
     assert_eq!(rows[0]["reachability"], "reachable");
     assert_eq!(rows[0]["checkout_health"], "invalid");
     assert_eq!(rows[0]["selector"], format!("{OWNER_MACHINE}/ws_broken"));
+}
+
+#[test]
+fn destination_registry_discovery_preserves_invalid_owner_and_replica_descriptors() {
+    let owner = workspace("ws_owner", Some(OWNER_MACHINE));
+    let replica = workspace("ws_replica", Some(REPLICA_MACHINE));
+    let mut invalid = workspace("ws_invalid", Some(OWNER_MACHINE));
+    invalid.status = WorkspaceStatus::Invalid;
+    let checkout = |workspace_id: &str, role| WorkspaceCheckout {
+        workspace_id: workspace_id.to_string(),
+        repo_root: PathBuf::from(format!("/tmp/{workspace_id}")),
+        orbit_dir: PathBuf::from(format!("/tmp/{workspace_id}/.orbit")),
+        role: Some(role),
+        owner_machine_id: None,
+        path_overrides: Vec::new(),
+    };
+    let registry = WorkspaceRegistry {
+        workspaces: vec![owner, replica, invalid],
+        checkouts: vec![
+            checkout("ws_owner", WorkspaceCheckoutRole::Owner),
+            checkout("ws_replica", WorkspaceCheckoutRole::Replica),
+            checkout("ws_invalid", WorkspaceCheckoutRole::Owner),
+        ],
+        ..WorkspaceRegistry::default()
+    };
+    let host = FederatedMcpHost::new(
+        vec![destination("orbit-owner", OWNER_MACHINE)],
+        Arc::new(RegistryBackedProbe { registry }),
+    );
+
+    let rows = list(&host);
+    assert_eq!(rows.len(), 3);
+    assert_eq!(
+        rows.iter()
+            .map(|row| row["id"].as_str().expect("workspace id"))
+            .collect::<Vec<_>>(),
+        ["ws_owner", "ws_replica", "ws_invalid"],
+    );
+    assert_eq!(
+        rows[0]["capabilities"],
+        serde_json::json!(["control_plane", "execute"])
+    );
+    assert_eq!(rows[1]["capabilities"], serde_json::json!(["execute"]));
+    assert_eq!(rows[2]["reachability"], "reachable");
+    assert_eq!(rows[2]["checkout_health"], "invalid");
+
+    let pinned = BTreeSet::from([
+        "selector",
+        "host",
+        "machine_id",
+        "reachability",
+        "checkout_health",
+        "capabilities",
+    ]);
+    for row in rows {
+        let keys = row
+            .as_object()
+            .expect("descriptor object")
+            .keys()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>();
+        assert!(
+            pinned.is_subset(&keys),
+            "descriptor is missing pinned keys: {row}"
+        );
+    }
 }
 
 #[test]

--- a/crates/orbit-mcp/src/lib.rs
+++ b/crates/orbit-mcp/src/lib.rs
@@ -35,8 +35,10 @@ use serde_json::Value;
 pub use adapter::OrbitToolServer;
 pub use listener::{DEFAULT_MCP_LISTEN_PORT, ListenerExposure, McpListener};
 pub use remote::{
-    McpServerIdentity, McpSessionAuthority, RemoteProxyArgs, canonical_mcp_tool_definitions,
-    execute_discovery_tool, mcp_server_identity, safe_mcp_tool_names, serve_mcp_remote_proxy,
+    FEDERATED_DESTINATION_WORKSPACE_LIST_TOOL, McpServerIdentity, McpSessionAuthority,
+    RemoteProxyArgs, canonical_mcp_tool_definitions, execute_discovery_tool,
+    execute_federated_workspace_discovery, mcp_server_identity, safe_mcp_tool_names,
+    serve_mcp_remote_proxy,
 };
 
 /// Back-end for the complete MCP tool surface.

--- a/crates/orbit-mcp/src/remote/discovery.rs
+++ b/crates/orbit-mcp/src/remote/discovery.rs
@@ -7,8 +7,17 @@ use orbit_types::tool::{
     McpToolDefinition, McpToolDefinitionError, McpToolScope, ToolParam, ToolSchema,
     validate_mcp_tool_definitions,
 };
-use orbit_types::workspace::{WorkspaceRegistry, WorkspaceStatus};
+use orbit_types::workspace::{Workspace, WorkspaceRegistry, WorkspaceStatus};
 use serde_json::{Value, json};
+
+/// Private wire name used by the federated mux to inspect every local checkout.
+///
+/// This is deliberately absent from [`discovery_tool_definitions`]: direct v1
+/// clients continue to see and call only `orbit.workspace.list`, whose Active
+/// filter is part of that surface. The destination server recognizes this
+/// exact private request without adding it to the advertised tool surface.
+pub const FEDERATED_DESTINATION_WORKSPACE_LIST_TOOL: &str =
+    "orbit_federated_destination_workspace_list";
 
 pub(super) fn discovery_tool_definitions() -> Result<Vec<McpToolDefinition>, McpToolDefinitionError>
 {
@@ -62,18 +71,9 @@ pub fn execute_discovery_tool(
 ) -> Result<Value, OrbitError> {
     match name {
         "orbit.workspace.list" => {
-            let local_workspace_ids = registry
-                .checkouts
-                .iter()
-                .map(|checkout| checkout.workspace_id.as_str())
-                .collect::<BTreeSet<_>>();
-            let workspaces = registry
-                .workspaces
-                .iter()
-                .filter(|workspace| {
-                    workspace.status == WorkspaceStatus::Active
-                        && local_workspace_ids.contains(workspace.id.as_str())
-                })
+            let workspaces = locally_bound_workspaces(registry)
+                .into_iter()
+                .filter(|workspace| workspace.status == WorkspaceStatus::Active)
                 .collect::<Vec<_>>();
             Ok(json!({
                 "machine_id": local_machine_id,
@@ -82,4 +82,33 @@ pub fn execute_discovery_tool(
         }
         _ => Err(OrbitError::not_found(NotFoundKind::Tool, name.to_string())),
     }
+}
+
+/// Project every workspace with a checkout registered on this destination.
+///
+/// Unlike the public v1 discovery tool, this internal federated path retains
+/// Invalid rows so the mux can report their checkout health instead of
+/// silently dropping them.
+pub fn execute_federated_workspace_discovery(
+    registry: &WorkspaceRegistry,
+    local_machine_id: &str,
+) -> Value {
+    let workspaces = locally_bound_workspaces(registry);
+    json!({
+        "machine_id": local_machine_id,
+        "workspaces": workspaces,
+    })
+}
+
+fn locally_bound_workspaces(registry: &WorkspaceRegistry) -> Vec<&Workspace> {
+    let local_workspace_ids = registry
+        .checkouts
+        .iter()
+        .map(|checkout| checkout.workspace_id.as_str())
+        .collect::<BTreeSet<_>>();
+    registry
+        .workspaces
+        .iter()
+        .filter(|workspace| local_workspace_ids.contains(workspace.id.as_str()))
+        .collect()
 }

--- a/crates/orbit-mcp/src/remote/mod.rs
+++ b/crates/orbit-mcp/src/remote/mod.rs
@@ -8,7 +8,10 @@ mod surface;
 #[cfg(test)]
 mod tests;
 
-pub use self::discovery::execute_discovery_tool;
+pub use self::discovery::{
+    FEDERATED_DESTINATION_WORKSPACE_LIST_TOOL, execute_discovery_tool,
+    execute_federated_workspace_discovery,
+};
 pub use self::identity::{McpServerIdentity, McpSessionAuthority, mcp_server_identity};
 pub use self::proxy::{RemoteProxyArgs, serve_mcp_remote_proxy};
 // The federated mux reuses the v1 remote argv verbatim rather than restating

--- a/crates/orbit-mcp/src/remote/tests/discovery.rs
+++ b/crates/orbit-mcp/src/remote/tests/discovery.rs
@@ -9,7 +9,9 @@ use orbit_types::workspace::{
 };
 use serde_json::json;
 
-use super::super::discovery::{discovery_tool_definitions, execute_discovery_tool};
+use super::super::discovery::{
+    discovery_tool_definitions, execute_discovery_tool, execute_federated_workspace_discovery,
+};
 use super::super::surface::canonical_mcp_tool_definitions;
 
 #[test]
@@ -118,6 +120,19 @@ fn discovery_projects_active_workspaces_with_a_local_checkout() {
             .map(|workspace| workspace["id"].as_str().expect("workspace id"))
             .collect::<Vec<_>>(),
         ["ws_local", "ws_replica"]
+    );
+
+    let federated = execute_federated_workspace_discovery(&registry, "hm_local");
+    assert_eq!(federated["machine_id"], "hm_local");
+    assert_eq!(
+        federated["workspaces"]
+            .as_array()
+            .expect("federated rows")
+            .iter()
+            .map(|workspace| workspace["id"].as_str().expect("workspace id"))
+            .collect::<Vec<_>>(),
+        ["ws_local", "ws_replica", "ws_invalid"],
+        "the private destination path retains Invalid local checkouts",
     );
     assert!(matches!(
         execute_discovery_tool("orbit.host.future", &registry, "hm_local"),


### PR DESCRIPTION
## Task

[ORB-11020](https://orbit-cli.com/tasks/ORB-11020) — Federated workspace list drops invalid destination checkouts

### Description

## Problem
The production federated probe cannot deliver the unfiltered workspace set that the federated descriptor contract promises. `SshDestinationProbe::discover_workspaces` calls the destination's existing v1 `orbit.workspace.list` at `crates/orbit-mcp/src/federated/probe.rs:173-181`, but that v1 implementation filters every row to `WorkspaceStatus::Active` at `crates/orbit-mcp/src/remote/discovery.rs:68-78`.

As a result, an invalid checkout is removed before `WorkspaceDescriptor::reachable` can map it to `checkout_health=invalid` (`crates/orbit-mcp/src/federated/descriptor.rs:71-89`). The passing `an_inactive_workspace_is_listed_rather_than_filtered_out` test uses `ScriptedProbe` and injects an Invalid workspace directly, so it does not exercise the production SSH/v1 path. The existing v1 discovery test separately proves that `ws_invalid` is excluded.

## Impact
`orbit mcp serve --mode federated` silently omits inactive configured workspaces instead of listing them, contrary to the federated contract. It also cannot derive live invalid checkout health through its production transport; callers may see a reachable workspaceless placeholder rather than the invalid workspace descriptor.

## Evidence
At commit `688875301934549c888ba4d5e8d3b00c96fe8e11`, `cargo test -p orbit-mcp` passes both the fake federated inactive-row test and the v1 filter test, demonstrating that no integration coverage joins the two behaviors. This was introduced by ORB-11014.

## Constraints
Keep v1 `orbit.workspace.list` behavior unchanged for direct callers. Add a destination-side discovery path or equivalent production mechanism that gives the federated mux all locally bound workspaces with validated checkout status, without reading the gateway's own catalog.

### Acceptance Criteria

- A production-path test with a destination registry containing an Invalid locally bound workspace returns that workspace from the federated list with `reachability=reachable` and `checkout_health=invalid`.
- The federated list still includes Active owner and replica checkouts and preserves the pinned descriptor shape.
- Direct v1 `orbit.workspace.list` remains filtered to Active locally bound workspaces.
- `cargo test -p orbit-mcp` and `make ci-fast` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a private, unadvertised destination discovery request that returns every locally bound workspace, including Invalid rows, while keeping direct v1 orbit.workspace.list Active-only.
- Routed the production federated SSH probe through that destination request and reused the production response parser.
- Added registry-backed federated coverage for Active owner, Active replica, and Invalid checkouts, including reachable/invalid health and pinned descriptor keys.
- Added orbit-mcp root/module exports required for the orbit-cli destination server to share the new path; these two tightly coupled files were appended to context_files before editing.
Validation:
- cargo test -p orbit-mcp (passed: 116 tests across unit/integration/doc targets)
- make ci-fast (passed)
- make ci-lint (passed, workspace/all-target clippy with warnings denied)
- git diff --check (passed)
Assessment: The federated mux now gets the unfiltered local checkout set from the destination itself without changing the advertised MCP surface or the v1 list contract.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11020-6a8b9a18`
- Behind base: 0
- Ahead of base: 1