### PR TITLE
Federated routed calls inherit the 20s discovery probe deadline and misreport timeouts as unreachable

### DIFF
--- a/crates/orbit-cli/src/command/mcp/server.rs
+++ b/crates/orbit-cli/src/command/mcp/server.rs
@@ -50,9 +50,14 @@ pub(super) fn serve_mcp_federated_stdio() -> Result<(), OrbitError> {
     // The mux is a client to each destination, and identifies itself with the
     // same audit label the v1 proxy forwards.
     let identity = orbit_mcp::mcp_server_identity(&global_root, None, McpSessionAuthority::Agent)?;
+    // Two budgets, not one: the probe timeout bounds the round trips that
+    // decide where a call goes, while the routed `tools/call` is stamped
+    // separately at dispatch so a remote run that legitimately takes minutes
+    // is not cut short by the time spent classifying its route [ORB-11023].
     let probe = federated::SshDestinationProbe::new(
         identity.process_machine_id.clone(),
         federated::DEFAULT_PROBE_TIMEOUT,
+        federated::DEFAULT_ROUTED_DELIVERY_TIMEOUT,
     );
     let host: Arc<dyn McpHost> = Arc::new(federated::FederatedMcpHost::new(
         destinations,

--- a/crates/orbit-mcp/src/federated/host.rs
+++ b/crates/orbit-mcp/src/federated/host.rs
@@ -111,6 +111,10 @@ impl FederatedMcpHost {
     /// Classification uses a live session, not the last list. Fail-closed
     /// precedence: unknown selector, then unreachable, stale, unhealthy,
     /// tool-not-on-this-host, then the destination's own refusal.
+    ///
+    /// That precedence covers everything decidable *before* dispatch. The
+    /// delivery itself runs on its own budget and, if its answer is lost, is
+    /// reported as `outcome_unknown` rather than re-entering this ladder.
     fn route_workspace_call(
         &self,
         name: &str,
@@ -175,6 +179,10 @@ impl FederatedMcpHost {
             tool = name,
             "federated mux delivering tool call"
         );
+        // Not wrapped by `delivery_unreachable`: past this point the request
+        // reaches the destination, so its failure is the destination's answer
+        // (`RemoteTool`) or a post-dispatch ambiguity (`OutcomeUnknown`) —
+        // never a delivery miss the caller should retry [ORB-11023].
         session.call_tool(name, destination_arguments(input, parsed.workspace_id()))
     }
 }
@@ -276,6 +284,10 @@ fn tool_on_surface(advertised: &[String], name: &str) -> bool {
 
 /// Connect, snapshot, and tools/list failures are delivery misses: capability
 /// and stale are undecidable without the host.
+///
+/// It covers only the classification phases. The routed `tools/call` is not
+/// re-labelled here, because once that request is written the call may have
+/// run: [`OrbitError::OutcomeUnknown`] is its honest class.
 fn delivery_unreachable(destination: &Destination, error: OrbitError) -> OrbitError {
     match error {
         OrbitError::UnreachableDestination(_) => error,

--- a/crates/orbit-mcp/src/federated/mod.rs
+++ b/crates/orbit-mcp/src/federated/mod.rs
@@ -30,6 +30,6 @@ pub use self::config::{
 pub use self::descriptor::{Capability, CheckoutHealth, Reachability, WorkspaceDescriptor};
 pub use self::host::{FEDERATED_WORKSPACE_LIST_TOOL, FederatedMcpHost};
 pub use self::probe::{
-    DEFAULT_PROBE_TIMEOUT, DestinationProbe, DestinationSnapshot, RoutedSession,
-    SshDestinationProbe,
+    DEFAULT_PROBE_TIMEOUT, DEFAULT_ROUTED_DELIVERY_TIMEOUT, DestinationProbe, DestinationSnapshot,
+    RoutedSession, SshDestinationProbe,
 };

--- a/crates/orbit-mcp/src/federated/probe.rs
+++ b/crates/orbit-mcp/src/federated/probe.rs
@@ -18,13 +18,30 @@ use serde_json::{Value, json};
 
 use super::config::Destination;
 
-/// How long one destination gets to complete the whole probe.
+/// How long one destination gets to answer everything that decides *where* a
+/// call goes.
 ///
-/// The budget covers SSH connection setup, the MCP handshake, and the
-/// discovery call together, because a caller waiting on the list cannot tell
-/// those phases apart and a per-phase budget would multiply the worst case by
-/// the number of phases.
+/// The budget covers SSH connection setup, the MCP handshake, the discovery
+/// call, and — on a routed session — `tools/list`, because a caller waiting on
+/// the list cannot tell those phases apart and a per-phase budget would
+/// multiply the worst case by the number of phases.
+///
+/// It deliberately does not cover the routed `tools/call` itself. That request
+/// is stamped with its own [`DEFAULT_ROUTED_DELIVERY_TIMEOUT`] budget once
+/// classification is done, so the round trips spent choosing a destination
+/// never shorten the tool's execution time [ORB-11023].
 pub const DEFAULT_PROBE_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// How long a routed `tools/call` gets, measured from the moment its request
+/// is written rather than from session start.
+///
+/// The mux advertises the whole canonical tool surface, including long-running
+/// mutating tools (`orbit.command.exec`, `orbit.workflow.ship`), so a delivery
+/// budget sized like a handshake would make those tools unusable over the mux.
+/// This is the ceiling on one remote tool, not on the session: exceeding it is
+/// reported as [`OrbitError::OutcomeUnknown`], because the request was already
+/// on the wire and may have committed.
+pub const DEFAULT_ROUTED_DELIVERY_TIMEOUT: Duration = Duration::from_secs(900);
 
 /// The MCP protocol revision this client negotiates. Pinned to the revision
 /// Orbit's own server answers with, so a probe fails loudly on a real protocol
@@ -70,14 +87,23 @@ pub trait RoutedSession: Send {
 /// The production probe: one short-lived SSH-hosted MCP session per call.
 pub struct SshDestinationProbe {
     caller_machine_id: String,
-    timeout: Duration,
+    probe_timeout: Duration,
+    delivery_timeout: Duration,
 }
 
 impl SshDestinationProbe {
-    pub fn new(caller_machine_id: String, timeout: Duration) -> Self {
+    /// `probe_timeout` bounds the phases that decide the route; a routed
+    /// `tools/call` is re-stamped with `delivery_timeout` at dispatch, so the
+    /// two are independent rather than shares of one session budget.
+    pub fn new(
+        caller_machine_id: String,
+        probe_timeout: Duration,
+        delivery_timeout: Duration,
+    ) -> Self {
         Self {
             caller_machine_id,
-            timeout,
+            probe_timeout,
+            delivery_timeout,
         }
     }
 }
@@ -89,11 +115,10 @@ impl DestinationProbe for SshDestinationProbe {
     }
 
     fn open_route(&self, destination: &Destination) -> Result<Box<dyn RoutedSession>, OrbitError> {
-        Ok(Box::new(SshRoutedSession {
-            session: self.start_session(destination)?,
-            snapshot: None,
-            tools: None,
-        }))
+        Ok(Box::new(SshRoutedSession::new(
+            self.start_session(destination)?,
+            self.delivery_timeout,
+        )))
     }
 }
 
@@ -102,17 +127,32 @@ impl SshDestinationProbe {
         let child = spawn_destination_session(destination, &self.caller_machine_id)?;
         // The session is one process; the guard ends it on every path,
         // including the timeout path where the child is still mid-answer.
-        let mut session = DestinationSession::start(destination.clone(), child, self.timeout)?;
+        let mut session =
+            DestinationSession::start(destination.clone(), child, self.probe_timeout)?;
         session.handshake()?;
         Ok(session)
     }
 }
 
 /// Production routed session: one SSH child, several MCP requests, then drop.
-struct SshRoutedSession {
+pub(super) struct SshRoutedSession {
     session: DestinationSession,
     snapshot: Option<DestinationSnapshot>,
     tools: Option<Vec<String>>,
+    /// The budget the tool call itself gets, stamped at dispatch rather than
+    /// at session start.
+    delivery_timeout: Duration,
+}
+
+impl SshRoutedSession {
+    pub(super) fn new(session: DestinationSession, delivery_timeout: Duration) -> Self {
+        Self {
+            session,
+            snapshot: None,
+            tools: None,
+            delivery_timeout,
+        }
+    }
 }
 
 impl RoutedSession for SshRoutedSession {
@@ -135,6 +175,10 @@ impl RoutedSession for SshRoutedSession {
     }
 
     fn call_tool(&mut self, name: &str, arguments: Value) -> Result<Value, OrbitError> {
+        // Classification is finished, so the tool's own budget starts here:
+        // the SSH setup, handshake, discovery, and `tools/list` round trips
+        // that chose this destination must not shorten it.
+        self.session.restart_budget(self.delivery_timeout);
         self.session.call_tool(name, arguments)
     }
 }
@@ -163,8 +207,42 @@ fn spawn_destination_session(
         .map_err(|error| unreachable(destination, format!("could not start SSH: {error}")))
 }
 
-/// One MCP client session against a destination, bounded by a single deadline.
-struct DestinationSession {
+/// How to name a request whose answer never arrived, once its bytes are on
+/// the wire.
+///
+/// Losing the answer is not the same fact for every request. The phases that
+/// decide a route are read-only and repeatable, so silence there means the
+/// host did not answer. A routed `tools/call` may already have run and
+/// committed on the destination, and killing the SSH child does not undo it,
+/// so silence there is genuine ambiguity: reporting it as a delivery miss
+/// invites the retry that duplicates the write [ORB-11023].
+#[derive(Clone, Copy)]
+enum LostAnswer<'a> {
+    Unreachable,
+    OutcomeUnknown { tool: &'a str },
+}
+
+impl LostAnswer<'_> {
+    fn classify(self, destination: &Destination, request_id: i64, reason: String) -> OrbitError {
+        match self {
+            Self::Unreachable => unreachable(destination, reason),
+            Self::OutcomeUnknown { tool } => OrbitError::OutcomeUnknown {
+                // The destination-facing request identity, which is what an
+                // operator can correlate against that host's audit log.
+                mcp_call_id: format!("{}/{tool}#{request_id}", destination.machine_id),
+                message: format!("{reason}; the destination may have completed the call"),
+            },
+        }
+    }
+}
+
+/// One MCP client session against a destination, bounded by one deadline at a
+/// time.
+///
+/// The deadline is a budget for the request in flight, not for the session:
+/// [`DestinationSession::restart_budget`] re-stamps it when a phase with its
+/// own budget begins.
+pub(super) struct DestinationSession {
     destination: Destination,
     child: Child,
     stdin: std::process::ChildStdin,
@@ -174,7 +252,7 @@ struct DestinationSession {
 }
 
 impl DestinationSession {
-    fn start(
+    pub(super) fn start(
         destination: Destination,
         mut child: Child,
         timeout: Duration,
@@ -209,8 +287,14 @@ impl DestinationSession {
         })
     }
 
-    fn handshake(&mut self) -> Result<(), OrbitError> {
-        let response = self.request(
+    /// Start a fresh budget for the next phase, discarding whatever the
+    /// previous phases left of the old one.
+    pub(super) fn restart_budget(&mut self, timeout: Duration) {
+        self.deadline = Instant::now() + timeout;
+    }
+
+    pub(super) fn handshake(&mut self) -> Result<(), OrbitError> {
+        let response = self.request_probe(
             "initialize",
             json!({
                 "protocolVersion": PROTOCOL_VERSION,
@@ -233,8 +317,8 @@ impl DestinationSession {
 
     /// Call the destination's private federated discovery path and return its
     /// envelope. The public v1 list intentionally filters Invalid workspaces.
-    fn discover_workspaces(&mut self) -> Result<DestinationSnapshot, OrbitError> {
-        let response = self.request(
+    pub(super) fn discover_workspaces(&mut self) -> Result<DestinationSnapshot, OrbitError> {
+        let response = self.request_probe(
             "tools/call",
             json!({
                 "name": crate::FEDERATED_DESTINATION_WORKSPACE_LIST_TOOL,
@@ -251,8 +335,8 @@ impl DestinationSession {
         snapshot_from_discovery_content(&self.destination, content)
     }
 
-    fn list_tools(&mut self) -> Result<Vec<String>, OrbitError> {
-        let response = self.request("tools/list", json!({}))?;
+    pub(super) fn list_tools(&mut self) -> Result<Vec<String>, OrbitError> {
+        let response = self.request_probe("tools/list", json!({}))?;
         let tools = response["result"]["tools"].as_array().ok_or_else(|| {
             unreachable(
                 &self.destination,
@@ -265,13 +349,19 @@ impl DestinationSession {
             .collect())
     }
 
-    fn call_tool(&mut self, name: &str, arguments: Value) -> Result<Value, OrbitError> {
+    /// Deliver one routed tool call.
+    ///
+    /// Unlike every other request here this one can commit work on the
+    /// destination, so a lost answer after the request is written is
+    /// [`LostAnswer::OutcomeUnknown`] rather than an unreachable host.
+    pub(super) fn call_tool(&mut self, name: &str, arguments: Value) -> Result<Value, OrbitError> {
         let response = self.request(
             "tools/call",
             json!({
                 "name": mcp_advertised_tool_name(name),
                 "arguments": arguments,
             }),
+            LostAnswer::OutcomeUnknown { tool: name },
         )?;
         let result = &response["result"];
         let content = &result["structuredContent"];
@@ -286,16 +376,29 @@ impl DestinationSession {
         Ok(content.clone())
     }
 
-    fn request(&mut self, method: &str, params: Value) -> Result<Value, OrbitError> {
+    /// A request whose loss tells the caller nothing was delivered.
+    fn request_probe(&mut self, method: &str, params: Value) -> Result<Value, OrbitError> {
+        self.request(method, params, LostAnswer::Unreachable)
+    }
+
+    fn request(
+        &mut self,
+        method: &str,
+        params: Value,
+        lost: LostAnswer<'_>,
+    ) -> Result<Value, OrbitError> {
         self.next_id += 1;
         let id = self.next_id;
+        // A failed write is pre-dispatch by construction: the destination
+        // never saw the request, so it stays an unreachable host even for a
+        // delivery.
         self.send(&json!({
             "jsonrpc": "2.0",
             "id": id,
             "method": method,
             "params": params,
         }))?;
-        self.await_response(method, id)
+        self.await_response(method, id, lost)
     }
 
     fn notify(&mut self, method: &str) -> Result<(), OrbitError> {
@@ -316,20 +419,27 @@ impl DestinationSession {
     /// Read until the response with this id arrives or the deadline passes.
     /// Matching strictly by id keeps a server-initiated message or an
     /// out-of-order answer from being read as this request's result.
-    fn await_response(&mut self, method: &str, id: i64) -> Result<Value, OrbitError> {
+    fn await_response(
+        &mut self,
+        method: &str,
+        id: i64,
+        lost: LostAnswer<'_>,
+    ) -> Result<Value, OrbitError> {
         loop {
             let remaining = self.deadline.saturating_duration_since(Instant::now());
             let line = match self.lines.recv_timeout(remaining) {
                 Ok(line) => line,
                 Err(RecvTimeoutError::Timeout) => {
-                    return Err(unreachable(
+                    return Err(lost.classify(
                         &self.destination,
+                        id,
                         format!("timed out waiting for '{method}'"),
                     ));
                 }
                 Err(RecvTimeoutError::Disconnected) => {
-                    return Err(unreachable(
+                    return Err(lost.classify(
                         &self.destination,
+                        id,
                         format!("session ended before answering '{method}'"),
                     ));
                 }

--- a/crates/orbit-mcp/src/federated/tests/fixtures.rs
+++ b/crates/orbit-mcp/src/federated/tests/fixtures.rs
@@ -77,7 +77,13 @@ impl CallLog {
 /// `ws_*`.
 #[derive(Debug, Clone)]
 pub(super) enum ScriptedToolResult {
-    RemoteTool { code: String, message: String },
+    RemoteTool {
+        code: String,
+        message: String,
+    },
+    /// The destination took the `tools/call` and then stopped answering: the
+    /// mux wrote the request and never learned whether it ran.
+    PostDispatchTimeout,
 }
 
 /// A probe with one canned outcome per destination `machine_id`.
@@ -230,6 +236,12 @@ impl RoutedSession for ScriptedRoute {
             .or_else(|| self.calls.get(&mcp_advertised_tool_name(name)));
         match scripted {
             None => Ok(arguments),
+            Some(ScriptedToolResult::PostDispatchTimeout) => Err(OrbitError::OutcomeUnknown {
+                mcp_call_id: format!("{}/{name}", self.machine_id),
+                message: "timed out waiting for 'tools/call'; the destination may have completed \
+                          the call"
+                    .to_string(),
+            }),
             Some(ScriptedToolResult::RemoteTool { code, message }) => Err(OrbitError::RemoteTool {
                 code: code.clone(),
                 message: format!("{}: {message}", self.machine_id),

--- a/crates/orbit-mcp/src/federated/tests/mod.rs
+++ b/crates/orbit-mcp/src/federated/tests/mod.rs
@@ -5,4 +5,5 @@ mod config;
 mod descriptor;
 mod fixtures;
 mod host;
+mod probe;
 mod route;

--- a/crates/orbit-mcp/src/federated/tests/probe.rs
+++ b/crates/orbit-mcp/src/federated/tests/probe.rs
@@ -1,0 +1,108 @@
+//! Delivery budget and post-dispatch classification.
+//!
+//! The fake destination here is a child process that holds the pipe open and
+//! never writes a line, so a real [`DestinationSession`] runs its own timeout
+//! path without an SSH host: everything the mux sends is accepted and nothing
+//! is ever answered.
+
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use orbit_common::OrbitError;
+use serde_json::json;
+
+use super::super::probe::{DestinationSession, RoutedSession, SshRoutedSession};
+use super::fixtures::{OWNER_MACHINE, destination};
+
+/// A destination that takes the request and stops there.
+fn stalled_session(budget: Duration) -> DestinationSession {
+    let child = Command::new("sleep")
+        .arg("30")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn a stalled destination");
+    DestinationSession::start(destination("orbit-owner", OWNER_MACHINE), child, budget)
+        .expect("start a session against the stalled destination")
+}
+
+#[test]
+fn a_stall_before_the_tool_call_is_an_unreachable_destination() {
+    let mut session = stalled_session(Duration::from_millis(50));
+
+    for (phase, error) in [
+        ("initialize", session.handshake().err()),
+        ("discovery", session.discover_workspaces().err()),
+        ("tools/list", session.list_tools().err()),
+    ] {
+        let error = error.unwrap_or_else(|| panic!("{phase} cannot complete against a stall"));
+        assert!(
+            matches!(error, OrbitError::UnreachableDestination(_)),
+            "nothing the caller asked for has run yet at {phase}: {error}"
+        );
+    }
+}
+
+#[test]
+fn a_stall_after_the_tool_call_is_dispatched_is_outcome_unknown() {
+    let mut session = stalled_session(Duration::from_millis(50));
+
+    let error = session
+        .call_tool("orbit.task.add", json!({ "title": "remote write" }))
+        .expect_err("the destination never answers the dispatched call");
+
+    match error {
+        OrbitError::OutcomeUnknown {
+            mcp_call_id,
+            message,
+        } => {
+            assert!(
+                mcp_call_id.starts_with(&format!("{OWNER_MACHINE}/orbit.task.add#")),
+                "the ambiguous call names the destination-facing request: {mcp_call_id}"
+            );
+            assert!(
+                message.contains("may have completed"),
+                "the message must not read as a delivery miss: {message}"
+            );
+        }
+        other => panic!(
+            "a written tools/call that timed out may already have committed remotely, so it \
+             cannot be reported as an unreachable destination: {other}"
+        ),
+    }
+}
+
+#[test]
+fn routed_delivery_does_not_inherit_an_exhausted_probe_budget() {
+    let delivery = Duration::from_millis(300);
+
+    // A zero probe budget is the limit case of what SSH setup, the handshake,
+    // discovery, and tools/list leave behind on a slow destination.
+    let mut exhausted = stalled_session(Duration::ZERO);
+    let started = Instant::now();
+    exhausted
+        .list_tools()
+        .expect_err("an exhausted probe budget gives up at once");
+    assert!(
+        started.elapsed() < delivery,
+        "the probe budget really is spent, so the contrast below is meaningful"
+    );
+
+    let mut routed = SshRoutedSession::new(stalled_session(Duration::ZERO), delivery);
+    let started = Instant::now();
+    let error = routed
+        .call_tool("orbit.command.exec", json!({ "command": "make ci-lint" }))
+        .expect_err("the destination never answers the dispatched call");
+    let waited = started.elapsed();
+
+    assert!(
+        waited >= delivery,
+        "the tool call gets its own budget rather than what classification left over: \
+         gave up after {waited:?}"
+    );
+    assert!(
+        matches!(error, OrbitError::OutcomeUnknown { .. }),
+        "{error}"
+    );
+}

--- a/crates/orbit-mcp/src/federated/tests/route.rs
+++ b/crates/orbit-mcp/src/federated/tests/route.rs
@@ -175,6 +175,30 @@ fn replica_task_add_returns_destination_capability_refused() {
 }
 
 #[test]
+fn a_dispatched_call_whose_answer_is_lost_is_outcome_unknown_not_unreachable() {
+    let probe = three_destination_probe().on_call(
+        OWNER_MACHINE,
+        "orbit.task.add",
+        ScriptedToolResult::PostDispatchTimeout,
+    );
+    let log = probe.call_log();
+    let host = FederatedMcpHost::new(destinations(), Arc::new(probe));
+
+    let error = call_err(&host, "orbit.task.add", "hm_owner/ws_orbit");
+    assert!(
+        matches!(error, OrbitError::OutcomeUnknown { .. }),
+        "the mux must not fold a possibly-committed remote write into the delivery-miss class \
+         a caller retries: {error}"
+    );
+    let calls = log.calls();
+    assert_eq!(
+        calls.len(),
+        1,
+        "the call was delivered once and is not retried here: {calls:?}"
+    );
+}
+
+#[test]
 fn a_copied_selector_round_trips_to_the_encoded_host() {
     let (host, log) = routed_mux();
 

--- a/docs/design/federated-mcp/2_design.md
+++ b/docs/design/federated-mcp/2_design.md
@@ -11,7 +11,7 @@ summary: Federated MCP mux, selector, capability split, list schema, and fail-cl
 tags: [federated-mcp, mcp, host-registry, multi-host]
 paths: ["crates/orbit-mcp/**", "crates/orbit-registry/**", "crates/orbit-core/**"]
 related_features: [federated-mcp, host-registry, mcp-bridge, remote-access, mcp-session-context]
-related_artifacts: [ORB-11016, ORB-11017, ORB-11015, ORB-11014, ORB-11013, ORB-11012, ORB-11011, ORB-11010, ORB-11009, ORB-11008]
+related_artifacts: [ORB-11023, ORB-11016, ORB-11017, ORB-11015, ORB-11014, ORB-11013, ORB-11012, ORB-11011, ORB-11010, ORB-11009, ORB-11008]
 ---
 
 # Federated MCP — Design
@@ -112,6 +112,14 @@ Caller-facing precedence when more than one class could apply:
 - `capability_refused` — destination holds the workspace but refuses the tool's class. Unclassified discovery/list tools are not subject to this error.
 
 It must not fall back to a local workspace, another host with a matching `ws_*`, a default workspace, or a cached host-local runtime.
+
+### Delivery budget and post-dispatch ambiguity
+
+The precedence above covers everything decidable **before** the destination sees the call. Two rules cover what happens after [ORB-11023].
+
+**Two budgets, not one.** SSH setup, the MCP handshake, discovery, and `tools/list` share one probe budget, because a caller cannot tell those phases apart. The routed `tools/call` gets its own, larger budget, stamped when its request is written. A single session-wide deadline would spend the tool's execution time on the round trips that merely chose the destination, and would cap every routed tool — including `orbit.command.exec` and `orbit.workflow.ship` — at whatever classification left over.
+
+**A lost answer after dispatch is `outcome_unknown`, not `unreachable_destination`.** Once the request is on the wire the destination may have run and committed it, and killing the SSH child does not undo remote work. `unreachable_destination` means a delivery miss, which invites a retry; retrying a possibly-committed `orbit.task.add` or `orbit.workflow.ship` duplicates it. A loss *before* the request is written — including a failed write — is still `unreachable_destination`, because nothing was delivered. `outcome_unknown` is a post-dispatch outcome and does not enter the precedence ladder.
 
 ## 7. Operator-configured control-plane uniqueness
 

--- a/docs/design/federated-mcp/4_decisions.md
+++ b/docs/design/federated-mcp/4_decisions.md
@@ -1,8 +1,8 @@
 ---
 title: Federated MCP — Decisions
 owner: grok
-last_updated: 2026-08-23
-last_validated: 2026-08-23
+last_updated: 2026-08-24
+last_validated: 2026-08-24
 status: Draft
 feature: federated-mcp
 doc_role: decisions
@@ -11,7 +11,7 @@ summary: Standing rules for the proposed federated MCP mux: destinations are con
 tags: [federated-mcp, mcp, host-registry, multi-host]
 paths: ["crates/orbit-mcp/**", "crates/orbit-registry/**", "crates/orbit-core/**"]
 related_features: [federated-mcp, host-registry, mcp-bridge, remote-access]
-related_artifacts: [ORB-11010, ORB-11009, ORB-11008]
+related_artifacts: [ORB-11023, ORB-11010, ORB-11009, ORB-11008]
 ---
 
 # Federated MCP — Decisions
@@ -85,6 +85,25 @@ Federated `orbit_workspace_list` is a new session-unbound shape, not a compatibl
 
 - Callers can distinguish "host down" from "checkout missing" from "tool not advertised here."
 - Cost: the list is not a set of live, callable workspaces; clients must read reachability and capabilities before routing, and availability is bounded by the chosen destination.
+
+## Routed delivery has its own budget, and a lost answer after dispatch is `outcome_unknown`
+
+**Recorded:** 2026-08 · [ORB-11023]
+
+### Context
+
+Routing reused the discovery probe's single session-wide deadline, stamped once at session start. A routed call spends that budget on four remote round trips — SSH spawn plus `initialize`, discovery, `tools/list`, then `tools/call` — before the tool runs, so any routed tool slower than the residue could not complete over the mux at all. The mux advertises the whole canonical surface, including `orbit.command.exec` and `orbit.workflow.ship`. Worse, exhausting that deadline produced `unreachable_destination` for a destination that was healthy and actively executing, and killing the SSH child does not undo a write the destination already committed.
+
+### Decision
+
+Classification and delivery are budgeted separately. The probe budget bounds SSH setup, the handshake, discovery, and `tools/list`; the routed `tools/call` is stamped with its own, larger budget at the moment its request is written. A lost answer after that write — budget exceeded or session ended — is `OrbitError::OutcomeUnknown` (`outcome_unknown`), carrying the destination-facing request identity. A loss before the write, including a failed write, stays `unreachable_destination`. `outcome_unknown` is a post-dispatch outcome and does not join the fail-closed precedence ladder. Apply this to every new federated request: read-only classification phases are `unreachable`; anything that can commit on the destination is `outcome_unknown` once its bytes are on the wire.
+
+### Consequences
+
+- A caller can distinguish "the host never got it, retry" from "it may have run, reconcile before retrying," so a timed-out `orbit.task.add` is no longer an invitation to create a duplicate.
+- Long-running routed tools become usable over the mux; a slow destination no longer converts into a false unreachable.
+- Cost: both budgets are constants rather than per-destination configuration, so an operator still cannot tune one destination separately. Rejected for now because no second, differing use exists; a `Destination` timeout field can be added when one does.
+- Cost: `outcome_unknown` gives the caller no verdict. That is the honest report — the mux cannot learn one after the transport is gone — but it does move reconciliation to the caller.
 
 ## Single control-plane per repository is operator configuration
 

--- a/docs/design/federated-mcp/references/conformance-federated.yaml
+++ b/docs/design/federated-mcp/references/conformance-federated.yaml
@@ -39,6 +39,9 @@ routing:
   selector_shape: hm_<machine_id>/ws_<workspace_id>
   delivery: one selected destination; no fallback or failover
   config_collision: duplicate machine_id fails startup as ambiguous_destination
+  budgets:
+    probe: bounds ssh setup, handshake, discovery, and tools/list
+    routed_delivery: stamped when the tools/call request is written; independent of the probe budget
   errors:
     - unknown_selector
     - unreachable_destination
@@ -46,6 +49,10 @@ routing:
     - unhealthy_checkout
     - tool_not_on_this_host
     - capability_refused
+  post_dispatch:
+    error: outcome_unknown
+    when: the tools/call request was written and its answer never arrived
+    rule: never unreachable_destination; not part of the precedence ladder
 
 authority:
   destination_runs_logs_scheduler: execute

--- a/docs/design/federated-mcp/references/glossary.md
+++ b/docs/design/federated-mcp/references/glossary.md
@@ -1,14 +1,14 @@
 ---
 type: design
 summary: "Glossary: Federated MCP"
-last_validated: 2026-08-23
+last_validated: 2026-08-24
 title: Glossary — Federated MCP
 owner: grok
 status: Draft
 feature: federated-mcp
 tags: [federated-mcp, glossary]
 related_features: [federated-mcp, host-registry, mcp-bridge]
-related_artifacts: [ORB-11010, ORB-11009, ORB-11008]
+related_artifacts: [ORB-11023, ORB-11010, ORB-11009, ORB-11008]
 ---
 
 # Glossary: Federated MCP
@@ -23,6 +23,7 @@ Vocabulary for the proposed federated MCP mux. Standard industry terms (proxy, m
 | **Control-plane authority** | The declared owner checkout (or a later cloud-offloaded store) that owns task issuance and the coordination store for that workspace. One per repository is operator configuration, not a mux invariant. [2_design.md §4](../2_design.md) |
 | **Destination** | An operator-configured MCP or SSH remote the mux may forward to. Not a host-registry fleet member. [2_design.md §1](../2_design.md) |
 | **Execute binding** | A replica checkout: it can run, log, and schedule on that host and must refuse control-plane tools. [2_design.md §3](../2_design.md) |
+| **Delivery budget** | The budget a routed `tools/call` gets, stamped when its request is written. Separate from the probe budget that bounds SSH setup, the handshake, discovery, and `tools/list`, so classification never spends the tool's execution time. [2_design.md §6](../2_design.md) |
 | **Fail-closed routing** | Live delivery with a single caller-facing precedence: `unknown_selector` → `ambiguous_destination` (config) → `unreachable_destination` → `stale_route` → `unhealthy_checkout` → `tool_not_on_this_host` → `capability_refused`. No local fallback, default workspace, or `ws_*` substitution. Cached list health does not decide the error. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
 | **Federated namespace** | The caller-facing MCP surface that accepts host-qualified selectors and list-without-session. The only place the v1 no-relay rule is excepted. [mcp-bridge 3_vision.md §5](../../mcp-bridge/3_vision.md) |
 | **Federated workspace list** | New session-unbound shape for `orbit_workspace_list`. Puts `machine_id` on each descriptor, not the v1 envelope, and does not inherit the v1 Active-and-locally-checked-out filter. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
@@ -30,6 +31,7 @@ Vocabulary for the proposed federated MCP mux. Standard industry terms (proxy, m
 | **Host reachability** | Whether the configured destination answers (reachable / unreachable). Separate from checkout health. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
 | **Host-qualified selector** | Structured, caller-uninterpreted addressing token. Encoding `hm_<id>/ws_*` is normative. Not `host_id`, not a path, not a credential. Callers copy the list `selector` field; they must not parse or construct the token. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
 | **Mux** | A configured forwarder of already-chosen destinations, not a registry and not automatic owner discovery. [2_design.md §1](../2_design.md) |
+| **Outcome unknown** | A routed `tools/call` whose request was written and whose answer never arrived. Reported as `outcome_unknown`, never `unreachable_destination`: the remote work may have committed, so a retry could duplicate it. Post-dispatch, and therefore outside the fail-closed precedence ladder. [2_design.md §6](../2_design.md) |
 | **Stale route** | Destination is configured; a live probe shows the workspace is absent. Fails as `stale_route`. Distinct from `unknown_selector` (selector never valid). [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
 | **Tool class** | Assignment by behavior: coordination-store writes are `control_plane`; runs/logs/scheduler tools are `execute`; discovery/list tools are unclassified and not subject to `capability_refused`. Not a per-tool registry field. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |
 | **Tool-not-on-this-host** | The destination is identified but does not advertise the tool. Distinct from `unknown_selector`. [specs/federated-workspace-mcp.md](../specs/federated-workspace-mcp.md) |

--- a/docs/design/federated-mcp/specs/federated-workspace-mcp.md
+++ b/docs/design/federated-mcp/specs/federated-workspace-mcp.md
@@ -1,14 +1,14 @@
 ---
 type: design
 summary: "Spec: Federated workspace MCP mux, selector, capabilities, list schema, and fail-closed routing"
-last_validated: 2026-08-23
+last_validated: 2026-08-24
 title: Spec — Federated workspace MCP
 owner: grok
 status: Draft
 feature: federated-mcp
 tags: [federated-mcp, mcp, spec]
 related_features: [federated-mcp, host-registry, mcp-bridge]
-related_artifacts: [ORB-11017, ORB-11015, ORB-11014, ORB-11013, ORB-11010, ORB-11009, ORB-11008]
+related_artifacts: [ORB-11023, ORB-11017, ORB-11015, ORB-11014, ORB-11013, ORB-11010, ORB-11009, ORB-11008]
 ---
 
 # Spec: Federated workspace MCP
@@ -150,7 +150,7 @@ Routing decides on **live delivery**, not cached list health. Probe cadence and 
 |---|---|---|
 | unknown | `unknown_selector` | Token never valid: it does not uniquely name a configured destination+workspace, including a token that is not uniquely host-qualified (bare `ws_*`) |
 | ambiguous | `ambiguous_destination` | Duplicate `machine_id` among configured destinations, raised at **config load**, not per call |
-| unreachable | `unreachable_destination` | Configured destination does not answer a live delivery attempt |
+| unreachable | `unreachable_destination` | Configured destination does not answer, up to and including a `tools/call` request that could not be written |
 | stale-route | `stale_route` | Destination is configured; a live probe shows that workspace is absent |
 | unhealthy | `unhealthy_checkout` | Destination answers but the checkout is not usable (repo-root missing / invalid) |
 | tool not advertised | `tool_not_on_this_host` | Destination is identified; the tool is not on that host's advertised surface |
@@ -167,6 +167,16 @@ When more than one class could apply, return the first that matches:
 `unknown_selector` → `ambiguous_destination` (config) → `unreachable_destination` → `stale_route` → `unhealthy_checkout` → `tool_not_on_this_host` → `capability_refused`
 
 Unreachable wins over capability and stale because those are undecidable without the host. Cached list health must not reorder this list.
+
+### Delivery budget and post-dispatch outcome
+
+Classification and delivery are budgeted separately [ORB-11023]. SSH setup, the handshake, discovery, and `tools/list` share one probe budget; the routed `tools/call` is stamped with its own, larger budget when its request is written. Routed tools include long-running mutating ones, so the time spent choosing a destination must not be deducted from the time the tool gets to run.
+
+Once that request is written the call may already have executed and committed on the destination, and killing the transport does not undo it. A lost answer there is therefore `outcome_unknown`, never `unreachable_destination`: the latter means a delivery miss and invites the retry that would duplicate the write. This is a post-dispatch outcome and does **not** enter the precedence ladder above — everything in that ladder is decided before the destination sees the call.
+
+| Class | Error identity | When |
+|---|---|---|
+| outcome unknown | `outcome_unknown` | The routed `tools/call` request was written and its answer never arrived (budget exceeded, or the session ended mid-call) |
 
 ## mcp-bridge invariant exception
 


### PR DESCRIPTION
## Task

[ORB-11023](https://orbit-cli.com/tasks/ORB-11023) — Federated routed calls inherit the 20s discovery probe deadline and misreport timeouts as unreachable

### Description

## Problem

[ORB-11015] routing reuses `SshDestinationProbe`'s single, session-wide deadline for routed `tools/call` delivery. The deadline is stamped once at session start and never extended:

- `crates/orbit-mcp/src/federated/probe.rs:210` — `deadline: Instant::now() + timeout`, set once in `DestinationSession::start`.
- `crates/orbit-mcp/src/federated/probe.rs:342` — every `await_response` computes `self.deadline.saturating_duration_since(Instant::now())`, so all requests on the session share one budget.
- `crates/orbit-mcp/src/federated/probe.rs:94-111` — `open_route` builds the routed session through the same `start_session` with `self.timeout`.
- `crates/orbit-mcp/src/federated/probe.rs:27` — `DEFAULT_PROBE_TIMEOUT = 20s`, and its doc comment still scopes the budget to "SSH connection setup, the MCP handshake, and the discovery call".
- `crates/orbit-cli/src/command/mcp/server.rs:53-56` — production federated serve passes `DEFAULT_PROBE_TIMEOUT`; `Destination` (`crates/orbit-mcp/src/federated/config.rs:71-74`) has no timeout field, so an operator cannot raise it.

A routed call now spends that one 20s budget on four remote round trips before the tool even runs: SSH spawn + `initialize` (`start_session`), `orbit.workspace.list` discovery (`FederatedMcpHost::route_workspace_call` -> `session.snapshot()`), `tools/list` (`session.advertised_tools()`), and only then `tools/call` (`crates/orbit-mcp/src/federated/host.rs:141-176`).

## Why It Matters

The mux advertises the full canonical 23-tool surface (`crates/orbit-mcp/src/federated/host.rs:180-189`), which includes long-running, mutating tools that [ORB-11011] explicitly routes: `orbit_command_exec`, `orbit_workflow_ship`, `orbit_workflow_run_resume`, `orbit_task_add` (see `crates/orbit-cli/tests/snapshots/mcp_tools_list.json`). ORB-11011 states "`orbit.workflow.ship` is `control_plane` and runs on the selected host". A remote `orbit.command.exec` running anything slower than the residual budget — the repo's own `make ci-lint` is documented as taking several minutes — cannot complete over the mux at all.

Two distinct failures follow:

1. **Systematic false unreachability.** Once the deadline passes, `recv_timeout(Duration::ZERO)` returns `Timeout` and `await_response` produces `unreachable(...)` -> `OrbitError::UnreachableDestination` -> MCP code `unreachable_destination` (`crates/orbit-mcp/src/error.rs:70`). The destination is healthy and actively executing; the caller is told the host could not be reached.
2. **A completed remote write reported as a delivery miss.** `Drop for DestinationSession` (`crates/orbit-mcp/src/federated/probe.rs:383-390`) kills the SSH child on timeout, but killing the transport does not undo work already committed on the destination. A timed-out `orbit.task.add` or `orbit.workflow.ship` may have fully succeeded remotely while the caller sees `unreachable_destination` — an error class whose documented meaning (`crates/orbit-mcp/src/federated/host.rs:270-276`: "delivery misses") invites a retry, which duplicates the task or re-ships.

The codebase already has the correct class for post-dispatch ambiguity: `OrbitError::OutcomeUnknown` (`crates/orbit-common/src/error.rs:159-163`), mapped to `outcome_unknown` at `crates/orbit-mcp/src/error.rs:96`. Routing does not use it.

## Evidence It Is Untested

`ScriptedRoute` in `crates/orbit-mcp/src/federated/tests/fixtures.rs:200-232` answers `snapshot`, `advertised_tools`, and `call_tool` instantly and models no deadline, so none of the 9 routing tests in `crates/orbit-mcp/src/federated/tests/route.rs` can observe budget exhaustion.

## Suggested Direction

Give delivery its own budget rather than the discovery probe's: stamp a fresh deadline for the `tools/call` request (or make the deadline per-request with a separate, larger delivery timeout), and classify a timeout that occurs *after* the `tools/call` request was written as `OutcomeUnknown` rather than `UnreachableDestination`. Update the `DEFAULT_PROBE_TIMEOUT` doc comment, which currently describes only the probe phases.

### Acceptance Criteria

- A routed federated `tools/call` is bounded by a delivery budget that is independent of the SSH-setup, handshake, discovery, and `tools/list` phases, so time spent classifying the route does not consume the tool's execution time.
- A timeout that occurs after the routed `tools/call` request has been written to the destination is reported as `outcome_unknown` (not `unreachable_destination`), so a caller does not retry a possibly-committed mutation.
- A timeout that occurs before the routed `tools/call` is dispatched still classifies as `unreachable_destination`.
- The `DEFAULT_PROBE_TIMEOUT` doc comment describes the phases it actually bounds, and the routed-delivery budget is documented where it is configured.
- A test drives a fake destination that exceeds the budget mid-`tools/call` and asserts the post-dispatch classification, without requiring a live SSH host.

## Execution Summary

<details>
<summary>Click to expand</summary>

Split the federated mux's single session-wide deadline into a probe budget and an independent routed-delivery budget, and gave a post-dispatch loss its own honest error class.

## Code

`crates/orbit-mcp/src/federated/probe.rs`
- `DEFAULT_PROBE_TIMEOUT` (20s) doc comment rewritten to name the phases it actually bounds — SSH setup, handshake, discovery, and (on a routed session) `tools/list` — and to say delivery is stamped separately.
- New `DEFAULT_ROUTED_DELIVERY_TIMEOUT` (900s), documented as the ceiling on one remote tool rather than on the session, sized for the long-running mutating tools the mux advertises.
- `SshDestinationProbe` now carries `probe_timeout` + `delivery_timeout`; `new()` takes both and documents that they are independent rather than shares of one budget.
- `DestinationSession::restart_budget(timeout)` re-stamps the deadline. `SshRoutedSession::call_tool` calls it immediately before dispatch (via a new `SshRoutedSession::new` constructor), so the four classification round trips no longer consume the tool's execution time.
- New `LostAnswer<'a> { Unreachable, OutcomeUnknown { tool } }`, threaded through `request`/`await_response`. `handshake`, `discover_workspaces`, and `list_tools` go through `request_probe` and stay `Unreachable`. Only `DestinationSession::call_tool` passes `OutcomeUnknown`. A timeout *or* a disconnect after the write yields `OrbitError::OutcomeUnknown { mcp_call_id: "<machine_id>/<tool>#<rpc-id>", .. }`; the id is the destination-facing request identity an operator can correlate against that host's audit log. Disconnect is included because the ambiguity is identical — the request was written and the answer was lost.
- A failed `send()` still returns `unreachable(...)`, so a pre-dispatch loss is `unreachable_destination` by construction.
- `DestinationSession` (and `start`/`handshake`/`discover_workspaces`/`list_tools`/`call_tool`/`restart_budget`) plus `SshRoutedSession` widened from private to `pub(super)`, i.e. visible inside `federated` only, so the sibling test module can drive the real session. No public API change beyond the new exported constant.

`crates/orbit-cli/src/command/mcp/server.rs` — federated serve passes both budgets, with a comment at the configuration site explaining why delivery is the larger one.

`crates/orbit-mcp/src/federated/host.rs` — documented that the fail-closed precedence ladder covers only pre-dispatch classification, that `delivery_unreachable` deliberately does not wrap the tool call, and why. No behavior change here: `session.call_tool`'s error was already returned unwrapped, so `OutcomeUnknown` propagates to MCP code `outcome_unknown`.

`crates/orbit-mcp/src/federated/mod.rs` — exports `DEFAULT_ROUTED_DELIVERY_TIMEOUT`.

## Tests

New `crates/orbit-mcp/src/federated/tests/probe.rs` drives a real `DestinationSession` over a child process that holds the pipe open and never answers — a stalled destination with no SSH host involved:
- `a_stall_before_the_tool_call_is_an_unreachable_destination` — `initialize`, discovery, and `tools/list` each stay `UnreachableDestination`.
- `a_stall_after_the_tool_call_is_dispatched_is_outcome_unknown` — asserts the variant, that `mcp_call_id` starts with `hm_owner/orbit.task.add#`, and that the message does not read as a delivery miss.
- `routed_delivery_does_not_inherit_an_exhausted_probe_budget` — an exhausted session gives up immediately, while an `SshRoutedSession` built on the same exhausted session waits the full delivery budget before returning `OutcomeUnknown`.

`tests/fixtures.rs` gains `ScriptedToolResult::PostDispatchTimeout`; `tests/route.rs` gains `a_dispatched_call_whose_answer_is_lost_is_outcome_unknown_not_unreachable`, asserting the mux surfaces the class unchanged and delivers exactly once.

## Docs

`2_design.md` §6 gains "Delivery budget and post-dispatch ambiguity"; `specs/federated-workspace-mcp.md` narrows the `unreachable_destination` row to "up to and including a `tools/call` request that could not be written" and adds a post-dispatch section plus an `outcome_unknown` row outside the precedence ladder; `references/conformance-federated.yaml` gains `routing.budgets` and `routing.post_dispatch`; `references/glossary.md` gains **Delivery budget** and **Outcome unknown**; `4_decisions.md` gains a decision entry recording the rule and the rejected alternative (a per-`Destination` timeout field — no second differing use exists yet).

## Scope

Deliberately did not add a `Destination` timeout field: no acceptance criterion requires operator-tunable budgets and a second concrete use does not exist. Recorded as a rejected alternative in the ADR. Unlisted files touched beyond `context_files`: `crates/orbit-mcp/src/federated/tests/mod.rs` (register the new sibling test module) and `docs/design/federated-mcp/references/conformance-federated.yaml` (its `routing.errors` list is the machine-readable mirror of the spec table this change edits — leaving it would make it stale).

## Validation

- `cargo test -p orbit-mcp` — 117 + 1 + 2 passed, 0 failed (53 federated, including the 4 new tests).
- `make ci-fast` — pass.
- `make ci-lint` — pass (workspace-wide, all targets, warnings denied).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11023-6a8b9d3d`
- Behind base: 0
- Ahead of base: 1

*authored by: claude*