### PR TITLE
Let explicitly configured docs roots opt out of the gitignore filter

### DIFF
--- a/crates/orbit-core/src/application/docs/add_root.rs
+++ b/crates/orbit-core/src/application/docs/add_root.rs
@@ -1,10 +1,8 @@
 use std::path::Path;
 
-use serde_json::json;
-
 use orbit_common::OrbitError;
 
-use super::config::parse_docs_roots_from_config_toml;
+use super::config::{DocsRoot, parse_docs_roots_from_config_toml};
 use super::path_util::path_to_slash_string;
 use super::types::DocAddOutcome;
 
@@ -25,15 +23,15 @@ pub(super) fn add_docs_root(
         return Ok(DocAddOutcome {
             path: normalized,
             added: false,
-            roots,
+            roots: roots.into_iter().map(|root| root.path).collect(),
         });
     }
-    roots.push(normalized.clone());
+    roots.push(DocsRoot::new(normalized.clone()));
     write_docs_roots_to_config(config_path, &raw, &roots)?;
     Ok(DocAddOutcome {
         path: normalized,
         added: true,
-        roots,
+        roots: roots.into_iter().map(|root| root.path).collect(),
     })
 }
 
@@ -79,11 +77,11 @@ fn normalize_docs_root_arg(repo_root: &Path, raw: &str) -> Result<String, OrbitE
     Ok(normalized)
 }
 
-fn roots_equal_contains(roots: &[String], candidate: &str) -> bool {
+fn roots_equal_contains(roots: &[DocsRoot], candidate: &str) -> bool {
     let candidate = comparable_root(candidate);
     roots
         .iter()
-        .any(|root| comparable_root(root.as_str()) == candidate)
+        .any(|root| comparable_root(root.path.as_str()) == candidate)
 }
 
 fn comparable_root(raw: &str) -> String {
@@ -93,43 +91,48 @@ fn comparable_root(raw: &str) -> String {
 fn write_docs_roots_to_config(
     config_path: &Path,
     raw: &str,
-    roots: &[String],
+    roots: &[DocsRoot],
 ) -> Result<(), OrbitError> {
-    let rendered = if raw.trim().is_empty() || !raw.contains("[docs]") {
-        let mut out = raw.trim_end().to_string();
-        if !out.is_empty() {
-            out.push_str("\n\n");
-        }
-        out.push_str("[docs]\nroots = ");
-        out.push_str(&json!(roots).to_string());
-        out.push('\n');
-        out
+    let mut value = if raw.trim().is_empty() {
+        toml::Value::Table(Default::default())
     } else {
-        let mut value = raw.parse::<toml::Value>().map_err(|error| {
+        raw.parse::<toml::Value>().map_err(|error| {
             OrbitError::InvalidInput(format!(
                 "invalid config.toml while updating [docs].roots: {error}"
             ))
-        })?;
-        let table = value.as_table_mut().ok_or_else(|| {
-            OrbitError::InvalidInput("config.toml must be a TOML table".to_string())
-        })?;
-        let docs = table
-            .entry("docs".to_string())
-            .or_insert_with(|| toml::Value::Table(Default::default()));
-        let docs_table = docs.as_table_mut().ok_or_else(|| {
-            OrbitError::InvalidInput("[docs] config must be a TOML table".to_string())
-        })?;
-        docs_table.insert(
-            "roots".to_string(),
-            toml::Value::Array(roots.iter().cloned().map(toml::Value::String).collect()),
-        );
-        toml::to_string_pretty(&value)
-            .map_err(|error| OrbitError::Execution(format!("serialize config.toml: {error}")))?
+        })?
     };
+    let table = value
+        .as_table_mut()
+        .ok_or_else(|| OrbitError::InvalidInput("config.toml must be a TOML table".to_string()))?;
+    let docs = table
+        .entry("docs".to_string())
+        .or_insert_with(|| toml::Value::Table(Default::default()));
+    let docs_table = docs.as_table_mut().ok_or_else(|| {
+        OrbitError::InvalidInput("[docs] config must be a TOML table".to_string())
+    })?;
+    docs_table.insert("roots".to_string(), docs_roots_to_toml_value(roots));
+    let rendered = toml::to_string_pretty(&value)
+        .map_err(|error| OrbitError::Execution(format!("serialize config.toml: {error}")))?;
     if let Some(parent) = config_path.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|error| OrbitError::Io(format!("create {}: {error}", parent.display())))?;
     }
     std::fs::write(config_path, rendered)
         .map_err(|error| OrbitError::Io(format!("write {}: {error}", config_path.display())))
+}
+
+fn docs_roots_to_toml_value(roots: &[DocsRoot]) -> toml::Value {
+    toml::Value::Array(roots.iter().map(docs_root_to_toml_value).collect())
+}
+
+fn docs_root_to_toml_value(root: &DocsRoot) -> toml::Value {
+    if root.respect_gitignore {
+        toml::Value::String(root.path.clone())
+    } else {
+        let mut table = toml::value::Table::new();
+        table.insert("path".to_string(), toml::Value::String(root.path.clone()));
+        table.insert("respect_gitignore".to_string(), toml::Value::Boolean(false));
+        toml::Value::Table(table)
+    }
 }

--- a/crates/orbit-core/src/application/docs/config.rs
+++ b/crates/orbit-core/src/application/docs/config.rs
@@ -13,8 +13,75 @@ struct DocsConfigFile {
 
 #[derive(Debug, Deserialize)]
 struct DocsConfigSection {
-    roots: Option<Vec<String>>,
+    roots: Option<Vec<RawDocsRoot>>,
     search: Option<DocsSearchConfigSection>,
+}
+
+/// One `[docs] roots` entry. Either the plain path string (gitignore still
+/// filters candidates under it, today's behavior) or a table naming the path
+/// explicitly as authoritative over gitignore.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum RawDocsRoot {
+    Plain(String),
+    Explicit {
+        path: String,
+        #[serde(default = "default_respect_gitignore")]
+        respect_gitignore: bool,
+    },
+}
+
+fn default_respect_gitignore() -> bool {
+    true
+}
+
+impl From<RawDocsRoot> for DocsRoot {
+    fn from(raw: RawDocsRoot) -> Self {
+        match raw {
+            RawDocsRoot::Plain(path) => DocsRoot {
+                path,
+                respect_gitignore: true,
+            },
+            RawDocsRoot::Explicit {
+                path,
+                respect_gitignore,
+            } => DocsRoot {
+                path,
+                respect_gitignore,
+            },
+        }
+    }
+}
+
+/// A configured `[docs].roots` entry, resolved to whether gitignore still
+/// filters candidates found beneath it. Naming a root explicitly as a table
+/// (`{ path = "...", respect_gitignore = false }`) opts it out of the
+/// gitignore filter; a plain string keeps today's behavior.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocsRoot {
+    pub path: String,
+    pub respect_gitignore: bool,
+}
+
+impl DocsRoot {
+    pub fn new(path: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            respect_gitignore: true,
+        }
+    }
+}
+
+impl From<&str> for DocsRoot {
+    fn from(path: &str) -> Self {
+        DocsRoot::new(path)
+    }
+}
+
+impl From<String> for DocsRoot {
+    fn from(path: String) -> Self {
+        DocsRoot::new(path)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -35,7 +102,7 @@ struct DocsSearchConfigSection {
     semantic_weight: Option<f32>,
 }
 
-pub fn parse_docs_roots_from_config_toml(raw: &str) -> Result<Vec<String>, OrbitError> {
+pub fn parse_docs_roots_from_config_toml(raw: &str) -> Result<Vec<DocsRoot>, OrbitError> {
     if raw.trim().is_empty() {
         return Ok(default_doc_roots());
     }
@@ -45,6 +112,7 @@ pub fn parse_docs_roots_from_config_toml(raw: &str) -> Result<Vec<String>, Orbit
     Ok(parsed
         .docs
         .and_then(|section| section.roots)
+        .map(|roots| roots.into_iter().map(DocsRoot::from).collect())
         .unwrap_or_else(default_doc_roots))
 }
 
@@ -66,7 +134,7 @@ pub fn parse_docs_search_config_from_config_toml(
     Ok(DocsSearchConfig { semantic_weight })
 }
 
-pub(super) fn read_docs_roots_from_config_path(path: &Path) -> Result<Vec<String>, OrbitError> {
+pub(super) fn read_docs_roots_from_config_path(path: &Path) -> Result<Vec<DocsRoot>, OrbitError> {
     if !path.exists() {
         return Ok(default_doc_roots());
     }
@@ -88,7 +156,7 @@ pub(super) fn read_docs_search_config_from_config_path(
 
 pub(super) fn read_task_context_docs_roots_from_config_path(
     path: &Path,
-) -> Result<Vec<String>, OrbitError> {
+) -> Result<Vec<DocsRoot>, OrbitError> {
     if !path.exists() {
         return Ok(default_doc_roots());
     }
@@ -102,7 +170,7 @@ pub(super) fn read_task_context_docs_roots_from_config_path(
 /// (and the read_ wrapper in mod.rs calls it).
 pub(super) fn parse_task_context_docs_roots_from_config_toml(
     raw: &str,
-) -> Result<Vec<String>, OrbitError> {
+) -> Result<Vec<DocsRoot>, OrbitError> {
     if raw.trim().is_empty() {
         return Ok(default_doc_roots());
     }
@@ -110,11 +178,14 @@ pub(super) fn parse_task_context_docs_roots_from_config_toml(
         OrbitError::InvalidInput(format!("invalid docs config in config.toml: {error}"))
     })?;
     Ok(match parsed.docs {
-        Some(section) => section.roots.unwrap_or_default(),
+        Some(section) => section
+            .roots
+            .map(|roots| roots.into_iter().map(DocsRoot::from).collect())
+            .unwrap_or_default(),
         None => default_doc_roots(),
     })
 }
 
-fn default_doc_roots() -> Vec<String> {
-    vec![DEFAULT_DOC_ROOT.to_string()]
+fn default_doc_roots() -> Vec<DocsRoot> {
+    vec![DocsRoot::new(DEFAULT_DOC_ROOT)]
 }

--- a/crates/orbit-core/src/application/docs/mod.rs
+++ b/crates/orbit-core/src/application/docs/mod.rs
@@ -24,7 +24,7 @@ use orbit_types::task::Task;
 
 use crate::OrbitRuntime;
 
-pub use config::DocsSearchConfig;
+pub use config::{DocsRoot, DocsSearchConfig};
 pub use types::{DocAddOutcome, DocMigrationReport, DocRecord, DocShow, DocType, TaskRelatedDoc};
 pub use walk::walk_docs_roots;
 
@@ -41,7 +41,7 @@ use self::search::{doc_embedding_sources, doc_search_source, related_docs_for_co
 // The original impl block (291-408) is preserved verbatim except for path adjustments
 // that are mechanical (use of super:: paths). All bodies delegate to submodules.
 impl OrbitRuntime {
-    pub fn docs_roots(&self) -> Result<Vec<String>, OrbitError> {
+    pub fn docs_roots(&self) -> Result<Vec<DocsRoot>, OrbitError> {
         read_docs_roots_from_config_path(&self.config_path())
     }
 

--- a/crates/orbit-core/src/application/docs/search.rs
+++ b/crates/orbit-core/src/application/docs/search.rs
@@ -6,6 +6,7 @@ use orbit_common::fs::glob::{match_glob, normalize_glob_path};
 use orbit_common::fs::selector::anchor_path;
 use orbit_search::{DocEmbeddingSource, DocSearchSource};
 
+use super::config::DocsRoot;
 use super::frontmatter::parse_doc_tolerant;
 use super::path_util::{path_to_slash_string, repo_relative_path};
 use super::types::{DocRecord, DocShow, TaskRelatedDoc};
@@ -15,7 +16,7 @@ const DEFAULT_RELATED_DOC_LIMIT: usize = 5;
 
 pub(super) fn show_doc(
     repo_root: &Path,
-    roots: &[String],
+    roots: &[DocsRoot],
     requested: &str,
 ) -> Result<DocShow, OrbitError> {
     let requested_path = Path::new(requested.trim());
@@ -59,14 +60,14 @@ fn path_is_or_contains_dot_orbit(repo_root: &Path, path: &Path) -> bool {
 
 pub(super) fn path_is_under_configured_roots(
     repo_root: &Path,
-    roots: &[String],
+    roots: &[DocsRoot],
     path: &Path,
 ) -> Result<bool, OrbitError> {
     let canonical_path = path
         .canonicalize()
         .map_err(|error| OrbitError::Io(format!("canonicalize {}: {error}", path.display())))?;
     for root in roots {
-        for root_path in expand_root(repo_root, root)? {
+        for root_path in expand_root(repo_root, &root.path)? {
             if path_is_or_contains_dot_orbit(repo_root, &root_path) {
                 continue;
             }
@@ -110,7 +111,7 @@ pub(super) fn doc_search_source(record: DocRecord, body: String) -> DocSearchSou
 
 pub(super) fn doc_embedding_sources(
     repo_root: &Path,
-    roots: &[String],
+    roots: &[DocsRoot],
 ) -> Result<Vec<DocEmbeddingSource>, OrbitError> {
     let mut sources = Vec::new();
     for record in walk_docs_roots(repo_root, roots)? {
@@ -134,7 +135,7 @@ struct RelatedDocCandidate {
 
 pub(super) fn related_docs_for_context(
     repo_root: &Path,
-    roots: &[String],
+    roots: &[DocsRoot],
     context_files: &[String],
     related_features: &[String],
     limit: Option<usize>,

--- a/crates/orbit-core/src/application/docs/tests/config.rs
+++ b/crates/orbit-core/src/application/docs/tests/config.rs
@@ -1,21 +1,44 @@
 //! Config parsing (roots + search weights) tests migrated for ORB-00250.
 
 use super::super::config::{
-    parse_docs_roots_from_config_toml, parse_docs_search_config_from_config_toml,
+    DocsRoot, parse_docs_roots_from_config_toml, parse_docs_search_config_from_config_toml,
     parse_task_context_docs_roots_from_config_toml,
 };
+
+fn root_paths(roots: &[DocsRoot]) -> Vec<&str> {
+    roots.iter().map(|root| root.path.as_str()).collect()
+}
 
 #[test]
 fn config_roots_default_and_parse_explicit_values() {
     assert_eq!(
-        parse_docs_roots_from_config_toml("").unwrap(),
+        root_paths(&parse_docs_roots_from_config_toml("").unwrap()),
         vec!["docs/"]
     );
-    assert_eq!(
+    let parsed =
         parse_docs_roots_from_config_toml("[docs]\nroots = [\"docs/\", \"apps/*/docs/\"]\n")
-            .unwrap(),
-        vec!["docs/", "apps/*/docs/"]
-    );
+            .unwrap();
+    assert_eq!(root_paths(&parsed), vec!["docs/", "apps/*/docs/"]);
+    assert!(parsed.iter().all(|root| root.respect_gitignore));
+}
+
+#[test]
+fn config_roots_parse_explicit_override_table_entries() {
+    let parsed = parse_docs_roots_from_config_toml(
+        "[docs]\nroots = [\"docs/\", { path = \"external/docs/\", respect_gitignore = false }]\n",
+    )
+    .unwrap();
+    assert_eq!(root_paths(&parsed), vec!["docs/", "external/docs/"]);
+    assert!(parsed[0].respect_gitignore);
+    assert!(!parsed[1].respect_gitignore);
+}
+
+#[test]
+fn config_roots_table_entry_defaults_to_respecting_gitignore() {
+    let parsed =
+        parse_docs_roots_from_config_toml("[docs]\nroots = [{ path = \"docs/\" }]\n").unwrap();
+    assert_eq!(root_paths(&parsed), vec!["docs/"]);
+    assert!(parsed[0].respect_gitignore);
 }
 
 #[test]
@@ -49,15 +72,19 @@ fn docs_search_config_defaults_and_clamps_semantic_weight() {
 #[test]
 fn task_context_docs_roots_skip_explicit_empty_or_unset_roots() {
     assert_eq!(
-        parse_task_context_docs_roots_from_config_toml("[docs]\n").unwrap(),
-        Vec::<String>::new()
+        parse_task_context_docs_roots_from_config_toml("[docs]\n")
+            .unwrap()
+            .len(),
+        0
     );
     assert_eq!(
-        parse_task_context_docs_roots_from_config_toml("[docs]\nroots = []\n").unwrap(),
-        Vec::<String>::new()
+        parse_task_context_docs_roots_from_config_toml("[docs]\nroots = []\n")
+            .unwrap()
+            .len(),
+        0
     );
     assert_eq!(
-        parse_task_context_docs_roots_from_config_toml("").unwrap(),
+        root_paths(&parse_task_context_docs_roots_from_config_toml("").unwrap()),
         vec!["docs/"]
     );
 }

--- a/crates/orbit-core/src/application/docs/tests/search.rs
+++ b/crates/orbit-core/src/application/docs/tests/search.rs
@@ -4,6 +4,7 @@ use std::fs;
 
 use tempfile::tempdir;
 
+use super::super::config::DocsRoot;
 use super::super::search::related_docs_for_context;
 use super::super::types::DocType;
 
@@ -59,7 +60,7 @@ fn related_docs_match_context_files_against_doc_paths() {
 
     let related = related_docs_for_context(
         root,
-        &["docs/".to_string()],
+        &[DocsRoot::new("docs/")],
         &["file:crates/orbit-cli/src/command/docs.rs".to_string()],
         &[],
         Some(5),
@@ -86,7 +87,7 @@ fn related_docs_match_task_features_against_doc_related_features() {
 
     let related = related_docs_for_context(
         root,
-        &["docs/".to_string()],
+        &[DocsRoot::new("docs/")],
         &[],
         &["Orbit-Docs".to_string()],
         Some(5),

--- a/crates/orbit-core/src/application/docs/tests/walk.rs
+++ b/crates/orbit-core/src/application/docs/tests/walk.rs
@@ -4,9 +4,21 @@ use std::fs;
 
 use tempfile::tempdir;
 
+use super::super::config::DocsRoot;
 use super::super::walk::{
     git_check_ignore_invocations, reset_git_check_ignore_invocations, walk_docs_roots,
 };
+
+fn init_git_repo(root: &std::path::Path) {
+    let status = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .arg("init")
+        .arg("--quiet")
+        .status()
+        .expect("git init");
+    assert!(status.success(), "git init failed");
+}
 
 #[test]
 fn walker_skips_dot_orbit_even_when_root_points_above_it() {
@@ -21,7 +33,7 @@ fn walker_skips_dot_orbit_even_when_root_points_above_it() {
     fs::create_dir_all(root.join(".orbit/adrs/ADR-0001")).expect("adr dir");
     fs::write(root.join(".orbit/adrs/ADR-0001/body.md"), "# ADR\n").expect("write adr");
 
-    let records = walk_docs_roots(root, &[".".to_string()]).expect("walk docs");
+    let records = walk_docs_roots(root, &[DocsRoot::new(".")]).expect("walk docs");
     assert_eq!(
         records
             .iter()
@@ -48,8 +60,87 @@ fn walker_batches_git_ignore_once_per_walk() {
     .expect("write two");
 
     reset_git_check_ignore_invocations();
-    let records = walk_docs_roots(root, &["docs/".to_string()]).expect("walk docs");
+    let records = walk_docs_roots(root, &[DocsRoot::new("docs/")]).expect("walk docs");
 
     assert_eq!(git_check_ignore_invocations(), 1);
     assert_eq!(records.len(), 2);
+}
+
+#[test]
+fn ordinary_root_still_drops_gitignored_files() {
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path();
+    init_git_repo(root);
+    fs::create_dir_all(root.join("docs")).expect("docs dir");
+    fs::write(root.join(".gitignore"), "docs/ignored.md\n").expect("write gitignore");
+    fs::write(
+        root.join("docs/ignored.md"),
+        "---\ntype: context\nsummary: Ignored doc\n---\nbody\n",
+    )
+    .expect("write ignored");
+    fs::write(
+        root.join("docs/kept.md"),
+        "---\ntype: context\nsummary: Kept doc\n---\nbody\n",
+    )
+    .expect("write kept");
+
+    let records = walk_docs_roots(root, &[DocsRoot::new("docs/")]).expect("walk docs");
+    assert_eq!(
+        records
+            .iter()
+            .map(|record| record.path.as_str())
+            .collect::<Vec<_>>(),
+        vec!["docs/kept.md"]
+    );
+}
+
+#[test]
+fn override_root_indexes_gitignored_files() {
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path();
+    init_git_repo(root);
+    fs::create_dir_all(root.join("external/docs")).expect("external docs dir");
+    fs::write(root.join(".gitignore"), "external/\n").expect("write gitignore");
+    fs::write(
+        root.join("external/docs/ignored.md"),
+        "---\ntype: context\nsummary: Externally gitignored doc\n---\nbody\n",
+    )
+    .expect("write ignored");
+
+    let override_root = DocsRoot {
+        path: "external/docs/".to_string(),
+        respect_gitignore: false,
+    };
+    let records = walk_docs_roots(root, &[override_root]).expect("walk docs");
+    assert_eq!(
+        records
+            .iter()
+            .map(|record| record.path.as_str())
+            .collect::<Vec<_>>(),
+        vec!["external/docs/ignored.md"]
+    );
+}
+
+#[test]
+fn override_root_still_excludes_nested_dot_orbit() {
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path();
+    init_git_repo(root);
+    fs::create_dir_all(root.join("external/.orbit/adrs")).expect(".orbit dir");
+    fs::write(root.join(".gitignore"), "external/\n").expect("write gitignore");
+    fs::write(
+        root.join("external/.orbit/adrs/body.md"),
+        "# ADR\n---\ntype: context\nsummary: Should stay excluded\n---\nbody\n",
+    )
+    .expect("write nested dot-orbit doc");
+
+    let override_root = DocsRoot {
+        path: "external/".to_string(),
+        respect_gitignore: false,
+    };
+    let records = walk_docs_roots(root, &[override_root]).expect("walk docs");
+    assert!(
+        records.is_empty(),
+        "expected .orbit exclusion to hold under an override root: {records:?}"
+    );
 }

--- a/crates/orbit-core/src/application/docs/walk.rs
+++ b/crates/orbit-core/src/application/docs/walk.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -6,6 +6,7 @@ use std::process::{Command, Stdio};
 
 use orbit_common::OrbitError;
 
+use super::config::DocsRoot;
 use super::frontmatter::parse_doc_tolerant;
 use super::path_util::{path_to_slash_string, repo_relative_path};
 use super::types::DocRecord;
@@ -36,27 +37,43 @@ pub(super) fn git_check_ignore_invocations() -> usize {
     GIT_CHECK_IGNORE_INVOCATIONS.with(std::cell::Cell::get)
 }
 
-pub fn walk_docs_roots(repo_root: &Path, roots: &[String]) -> Result<Vec<DocRecord>, OrbitError> {
-    let mut candidates = Vec::new();
+pub fn walk_docs_roots(repo_root: &Path, roots: &[DocsRoot]) -> Result<Vec<DocRecord>, OrbitError> {
+    // A path may be reachable from more than one configured root; if any
+    // contributing root names it explicitly (respect_gitignore = false),
+    // that override wins over a root that would still filter it.
+    let mut candidates: HashMap<PathBuf, bool> = HashMap::new();
     for root in roots {
-        for path in expand_root(repo_root, root)? {
+        let mut found = Vec::new();
+        for path in expand_root(repo_root, &root.path)? {
             if path_is_or_contains_dot_orbit(repo_root, &path) {
                 continue;
             }
             if path.is_file() {
-                maybe_push_doc_candidate(repo_root, &path, &mut candidates)?;
+                maybe_push_doc_candidate(repo_root, &path, &mut found)?;
             } else if path.is_dir() {
-                walk_dir(repo_root, &path, &mut candidates)?;
+                walk_dir(repo_root, &path, &mut found)?;
             }
         }
+        for relative in found {
+            candidates
+                .entry(relative)
+                .and_modify(|respect_gitignore| {
+                    *respect_gitignore = *respect_gitignore && root.respect_gitignore;
+                })
+                .or_insert(root.respect_gitignore);
+        }
     }
-    candidates.sort();
-    candidates.dedup();
 
-    let ignored = git_ignored_paths(repo_root, &candidates);
+    let gitignore_checked = candidates
+        .iter()
+        .filter(|(_, respect_gitignore)| **respect_gitignore)
+        .map(|(relative, _)| relative.clone())
+        .collect::<Vec<_>>();
+    let ignored = git_ignored_paths(repo_root, &gitignore_checked);
+
     let mut records = Vec::new();
-    for relative in candidates {
-        if ignored.contains(&relative) {
+    for (relative, respect_gitignore) in candidates {
+        if respect_gitignore && ignored.contains(&relative) {
             continue;
         }
         let path = repo_root.join(&relative);


### PR DESCRIPTION
## Task

[ORB-11025](https://orbit-cli.com/tasks/ORB-11025) — Let explicitly configured docs roots opt out of the gitignore filter

### Description

## Problem

`walk_docs_roots` (`crates/orbit-core/src/application/docs/walk.rs`) collects every `*.md` candidate under the configured `[docs] roots`, then batches all of them through `git -C <repo_root> check-ignore -z --stdin` and drops whatever git reports as ignored. `.gitignore` is therefore the effective filter on the docs corpus; the hardcoded `.git` / `.orbit` / `node_modules` / `target` skip list in `should_skip_dir` is only a recursion optimization.

That makes it impossible to index a directory the repo deliberately gitignores, even when the operator names it explicitly as a docs root.

## Concrete case driving this

The constellation umbrella repo groups independent repositories that are gitignored on purpose: `.gitignore` excludes `codebases/` (line 23) and `knowledgebase/` (line 30). Daniel wants polaris and almanac doc search to live under the **constellation** workspace rather than in each nested repo's own workspace.

Configuring the obvious thing:

```toml
[docs]
roots = [
    "knowledgebase/almanac/15-discussions/",
    "knowledgebase/almanac/20-projects",
    "knowledgebase/almanac/about-me",
    "knowledgebase/polaris/domain",
    "knowledgebase/polaris/runbooks",
]
```

produces an **empty index with no error**. Verified: all 92 md files under those five roots return IGNORED from `git check-ignore` at the constellation root, while the same files return kept inside almanac's and polaris's own repos. The roots resolve, the candidates are collected, and then every one is discarded. The silent-success failure mode is itself part of the problem.

The same mechanism means constellation's previous docs config was structurally unbuildable: five of six roots did not exist and the sixth (`codebases/`) is gitignored, so `ws_constellation` returned zero hits for `kind: doc` and `kind: all` alike.

Fixing this in `.gitignore` is the wrong direction — git does not descend into an excluded directory, so `!` negation cannot rescue files beneath one without un-excluding every parent, and it fights the umbrella design where these are deliberately separate repos.

## Requirement

An operator must be able to mark a docs root as authoritative, so that everything matching under it is indexed regardless of gitignore status. Naming a path in the config is a deliberate act; it should be able to win over an inherited ignore rule.

## Design notes, not prescriptions

`DocsConfigSection.roots` is `Option<Vec<String>>` today (`config.rs`). Back-compatible shapes worth weighing:

- an untagged serde enum so an entry is either a plain string (current semantics) or a table such as `{ path = "...", respect_gitignore = false }`
- a sibling key listing the override roots separately
- a sigil prefix on the string form

Prefer whichever keeps the plain-string form untouched and makes the override visible on the line that declares it. Deciding this is part of the task.

Distinguishing "explicit" from "broad" roots by path depth or specificity is explicitly **not** wanted — it is unpredictable magic. The override should be something the operator states, not something inferred.

## Constraints

- **Do not lift the `.orbit/` exclusion.** It is a named invariant of the docs design; override roots must still route through `path_is_or_contains_dot_orbit`, and `.git` must still never be descended into. An override relaxes gitignore only.
- **Default unchanged.** Roots configured as they are today keep gitignore filtering, so no existing corpus changes shape.
- `git_ignored_paths` already fails open (a failed spawn or non-zero exit yields an empty ignore set). Do not make that behavior noisier as part of this change, but do not deepen the reliance on it either.
- Only `*.md` is ever a candidate; that stays.

## Known consequence, accepted

With this in place a document under a nested repo can be indexed both by the umbrella workspace and by the nested repo's own workspace, producing two index entries for one file in two different `semantic.db` stores. That duplication is accepted here — Daniel's choice is that constellation is the home for polaris/almanac doc search.

## Related

Assessment context in ORB-11001 (ws_almanac), Finding 4 — that task's step 1 originally proposed a "zero-cost" constellation-level root and was corrected once this filter was understood.

### Acceptance Criteria

- A docs root can be configured such that markdown beneath it is indexed even when `git check-ignore` reports those paths ignored, and `orbit docs index` in the constellation checkout indexes the ~92 md files under `knowledgebase/almanac/{15-discussions,20-projects,about-me}` and `knowledgebase/polaris/{domain,runbooks}` that are currently all discarded
- Default behavior is unchanged: a root configured the way roots are configured today still has gitignore applied, proven by a test that a gitignored file under an ordinary root stays out of the index
- The `.orbit/` exclusion invariant still holds for override roots — `path_is_or_contains_dot_orbit` is not bypassed — and `.git` is still never descended into, proven by a test placing a markdown file under a nested `.orbit/` inside an override root
- Existing `[docs] roots = ["a/", "b/"]` plain-string configs continue to parse unchanged (back-compat test)
- `orbit docs list` output for an override root shows the same DocRecord shape as an ordinary root, with repo-relative paths

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- config.rs: `[docs].roots` entries now deserialize via an untagged `RawDocsRoot` enum — a plain string (today's semantics) or a table `{ path = "...", respect_gitignore = false }`. Both forms normalize into a new `DocsRoot { path, respect_gitignore }` (default `respect_gitignore = true`), which is now the return type of `parse_docs_roots_from_config_toml`, `parse_task_context_docs_roots_from_config_toml`, and the `read_*_from_config_path` wrappers.
- walk.rs: `walk_docs_roots` now takes `&[DocsRoot]`. Candidates are collected per root into a map keyed by relative path with a `respect_gitignore` flag (ANDed across roots when the same file is reachable from more than one root, so an override wins if any contributing root names it explicitly). `git_ignored_paths` is only queried for candidates still subject to gitignore; override-root candidates bypass it entirely. `.orbit/` exclusion (`path_is_or_contains_dot_orbit`) and the `.git` skip in `should_skip_dir` are unchanged and still run before the override logic ever sees a path.
- search.rs, add_root.rs, mod.rs: updated to the `&[DocsRoot]` / `Vec<DocsRoot>` signatures throughout the call chain (`docs_roots()`, `show_doc`, `doc_embedding_sources`, `related_docs_for_context`, `path_is_under_configured_roots`, `add_docs_root`). `add_docs_root`'s config round-trip now serializes each `DocsRoot` back as a plain string or an explicit table (via `toml::Value`, replacing the old `serde_json::json!`-based writer) so an operator's override entries survive an `orbit docs add` on the same file instead of being silently flattened back to strings. `DocAddOutcome.roots` stays `Vec<String>` (paths only) — the CLI/tool JSON contract for `docs add` is unchanged.
- Added tests: `config_roots_parse_explicit_override_table_entries`, `config_roots_table_entry_defaults_to_respecting_gitignore` (config.rs); `ordinary_root_still_drops_gitignored_files`, `override_root_indexes_gitignored_files`, `override_root_still_excludes_nested_dot_orbit` (walk.rs) — the last two build a real git repo in a tempdir so `git check-ignore` genuinely reports the fixture as ignored, exercising the override path end to end rather than mocking it.
Validation:
- `cargo test -p orbit-core --lib` — 777 passed (includes the docs module's 21 tests, all new + existing).
- `cargo test -p orbit-cli --test docs` — 11 passed (docs add/list/show/index CLI integration tests untouched in behavior).
- `cargo build --workspace` — clean.
- `make ci-fast` and `make ci-lint` — both pass (fmt-check, guardrails, workspace clippy with warnings denied).
Assessment: Solid — the override is opt-in per root, back-compat is exercised by both the existing plain-string test and new tests, and the `.orbit`/`.git` invariants are proven under an override root specifically (not just inferred from the default-root test still passing). The `orbit docs add` round-trip fix (writer rewrite) was necessary collateral scope: without it, running `docs add` on a config with an existing override entry would have silently discarded that entry's `respect_gitignore = false` — I judged this a correctness bug directly created by this change, not a speculative improvement, so fixed it in the same PR rather than filing a follow-up.
Deviations from original plan: None — no prior plan was recorded; this is the plan as executed.
Recommended follow-ups: Actually configuring `[docs].roots` with the override table syntax in the constellation umbrella checkout's `.orbit/config.toml` (to index the ~92 md files under `knowledgebase/almanac/*` and `knowledgebase/polaris/{domain,runbooks}`) is a separate operational step in that repo, not this one — this task only ships the mechanism and proves it with an equivalent gitignored-nested-repo fixture.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11025-6a8ba31a`
- Behind base: 0
- Ahead of base: 1