### PR TITLE
Cross-workspace federated search with a workspace scope selector

### DIFF
--- a/crates/orbit-cli/src/command/search.rs
+++ b/crates/orbit-cli/src/command/search.rs
@@ -1,5 +1,7 @@
 use clap::{ArgAction, Args, Subcommand, ValueEnum};
-use orbit_core::{GlobalSearchHit, GlobalSearchKind, GlobalSearchParams, OrbitError, OrbitRuntime};
+use orbit_core::{
+    GlobalSearchHit, GlobalSearchKind, GlobalSearchParams, OrbitError, OrbitRuntime, WorkspaceScope,
+};
 
 use crate::command::{CommandOut, Execute, Payload};
 
@@ -38,6 +40,17 @@ pub struct SearchCommand {
     /// Explicit per-kind status override, e.g. task:open,doc:active,friction:open.
     #[arg(long, value_delimiter = ',', global = true)]
     pub status: Vec<String>,
+    /// Search this registered workspace as well. Repeat or comma-separate to
+    /// federate across several; every hit is labelled with the workspace it
+    /// came from. Accepts a registered name, a `ws_*` ID, or an absolute
+    /// checkout path. Distinct from the top-level `orbit --workspace`, which
+    /// binds the whole invocation to one checkout.
+    #[arg(long = "workspace", action = ArgAction::Append, value_delimiter = ',', value_name = "SELECTOR")]
+    pub workspaces: Vec<String>,
+    /// Search every active workspace registered on this machine. Overrides
+    /// `--workspace`.
+    #[arg(long)]
+    pub all_workspaces: bool,
     /// Output as JSON.
     #[arg(long, global = true)]
     pub json: bool,
@@ -106,6 +119,7 @@ impl Execute for SearchCommand {
             all: self.all,
             status: self.status,
             path: input.path,
+            workspaces: WorkspaceScope::from_inputs(self.workspaces, self.all_workspaces),
         })?;
 
         for note in &response.notes {
@@ -196,20 +210,32 @@ struct SearchInput {
 
 fn search_table(results: &[GlobalSearchHit]) -> crate::output::table::Table {
     use crate::output::table::{Column, Table};
+    // A federated query labels every hit; a single-workspace one labels none,
+    // so the column appears exactly when it carries information [ORB-11027].
+    let federated = results.iter().any(|hit| hit.workspace.is_some());
     // Each hit's kind names its own detail command (`orbit task show`
     // or `orbit docs show`).
-    let mut table = Table::new(vec![
-        Column::new("KIND").fixed(),
-        Column::new("SOURCE").fixed(),
+    let mut columns = vec![Column::new("KIND").fixed(), Column::new("SOURCE").fixed()];
+    if federated {
+        columns.push(Column::new("WORKSPACE").fixed());
+    }
+    columns.extend([
         Column::new("ID/PATH").path(),
         Column::new("TITLE/SUMMARY"),
         Column::new("MATCH").fixed(),
-    ])
-    .empty_message("no results matching the query");
+    ]);
+    let mut table = Table::new(columns).empty_message("no results matching the query");
     for hit in results {
-        table.add_row(vec![
-            hit.kind.clone(),
-            hit.source.clone(),
+        let mut row = vec![hit.kind.clone(), hit.source.clone()];
+        if federated {
+            row.push(
+                hit.workspace
+                    .as_ref()
+                    .map(|workspace| workspace.name.clone())
+                    .unwrap_or_default(),
+            );
+        }
+        row.extend([
             hit.id.clone().or(hit.path.clone()).unwrap_or_default(),
             hit.title
                 .clone()
@@ -217,6 +243,7 @@ fn search_table(results: &[GlobalSearchHit]) -> crate::output::table::Table {
                 .unwrap_or_default(),
             match_text(hit),
         ]);
+        table.add_row(row);
     }
     table
 }

--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -344,6 +344,18 @@
         "required": false
       },
       {
+        "description": "Federated scope: registered workspace names, `ws_*` IDs, or absolute checkout paths to search together. Hits carry workspace attribution. Omit to search only the bound workspace.",
+        "name": "workspaces",
+        "param_type": "string_list",
+        "required": false
+      },
+      {
+        "description": "Search every active workspace registered on the answering machine. Overrides `workspaces`. Not available inside an Orbit-managed run.",
+        "name": "all_workspaces",
+        "param_type": "boolean",
+        "required": false
+      },
+      {
         "description": "Preferred provenance field. Pass the canonical agent family (codex, claude, gemini, or grok); full model strings are accepted and auto-normalized.",
         "name": "model",
         "param_type": "string",

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -264,6 +264,10 @@
           "description": "Include normally-hidden statuses for the queried kind. Task adds done/rejected/archived; friction adds triaged/resolved; doc is a no-op.",
           "type": "boolean"
         },
+        "all_workspaces": {
+          "description": "Search every active workspace registered on the answering machine. Overrides `workspaces`. Not available inside an Orbit-managed run.",
+          "type": "boolean"
+        },
         "hybrid": {
           "description": "Opt into hybrid lexical + cosine ranking for indexed task and doc vectors; frictions remain lexical.",
           "type": "boolean"
@@ -329,6 +333,20 @@
         "workspace": {
           "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
           "type": "string"
+        },
+        "workspaces": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Federated scope: registered workspace names, `ws_*` IDs, or absolute checkout paths to search together. Hits carry workspace attribution. Omit to search only the bound workspace."
         }
       },
       "type": "object"

--- a/crates/orbit-cmd/src/lib.rs
+++ b/crates/orbit-cmd/src/lib.rs
@@ -28,6 +28,7 @@ pub mod migrate;
 pub mod registry_routines;
 pub mod registry_runtime;
 pub mod task_owner;
+pub mod workspace_catalog;
 
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-cmd/src/registry_runtime.rs
+++ b/crates/orbit-cmd/src/registry_runtime.rs
@@ -15,6 +15,8 @@ use serde_json::Value;
 
 use orbit_registry::{HOST_TOML_FILE, load_host_identity, workspace_registry};
 
+use crate::workspace_catalog::attach as attach_workspace_catalog;
+
 /// Registered workspace metadata keeps the logical catalog ID distinct from the
 /// task/runtime ID stored in `.orbit/config.yaml`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -120,8 +122,13 @@ impl RegisteredRuntimeFactory {
             let replica_owner = selection
                 .as_ref()
                 .and_then(|selection| replica_owner_for_checkout(&selection.checkout));
-            return OrbitRuntime::initialize_from_resolved_roots(roots, binding)
-                .map(|runtime| runtime.with_coordination_write_owner(replica_owner));
+            let global_root = roots.global_root.clone();
+            return OrbitRuntime::initialize_from_resolved_roots(roots, binding).map(|runtime| {
+                attach_workspace_catalog(
+                    runtime.with_coordination_write_owner(replica_owner),
+                    &global_root,
+                )
+            });
         };
 
         let global_root = global_root_for(root_override)?;
@@ -168,7 +175,10 @@ impl RegisteredRuntimeFactory {
                 &roots.local_root,
             ),
         }?;
-        Ok(runtime.with_coordination_write_owner(replica_owner))
+        Ok(attach_workspace_catalog(
+            runtime.with_coordination_write_owner(replica_owner),
+            &roots.global_root,
+        ))
     }
 
     pub fn open_registered_checkout(
@@ -179,7 +189,12 @@ impl RegisteredRuntimeFactory {
         sync_task_prefix(global_root)?;
         let binding = workspace_runtime_binding(workspace, checkout)?;
         OrbitRuntime::from_roots_with_binding(global_root, &checkout.orbit_dir, binding).map(
-            |runtime| runtime.with_coordination_write_owner(replica_owner_for_checkout(checkout)),
+            |runtime| {
+                attach_workspace_catalog(
+                    runtime.with_coordination_write_owner(replica_owner_for_checkout(checkout)),
+                    global_root,
+                )
+            },
         )
     }
 
@@ -196,6 +211,7 @@ impl RegisteredRuntimeFactory {
             local_root,
             binding,
         )
+        .map(|runtime| attach_workspace_catalog(runtime, global_root))
     }
 
     /// Bind a CLI `orbit tool run` invocation to the workspace named in `input`.

--- a/crates/orbit-cmd/src/tests/mod.rs
+++ b/crates/orbit-cmd/src/tests/mod.rs
@@ -7,3 +7,4 @@ mod migrate;
 mod registry_routines;
 mod registry_runtime;
 mod task_owner;
+mod workspace_catalog;

--- a/crates/orbit-cmd/src/tests/workspace_catalog.rs
+++ b/crates/orbit-cmd/src/tests/workspace_catalog.rs
@@ -1,0 +1,130 @@
+use std::path::Path;
+
+use chrono::Utc;
+use orbit_core::{WorkspaceCatalog, WorkspaceScope};
+use orbit_registry::workspace_registry::{registry_path_for, save_registry_to};
+use orbit_types::workspace::{Workspace, WorkspaceCheckout, WorkspaceRegistry, WorkspaceStatus};
+
+use crate::workspace_catalog::RegistryWorkspaceCatalog;
+
+fn workspace(id: &str, name: &str, status: WorkspaceStatus) -> Workspace {
+    Workspace {
+        id: id.to_string(),
+        name: name.to_string(),
+        owner_machine_id: Some("hm_owner".to_string()),
+        git_remote: None,
+        ship_mode: Some("pr".to_string()),
+        base_branch: "agent-main".to_string(),
+        status,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+fn checkout(workspace_id: &str, root: &Path, name: &str) -> WorkspaceCheckout {
+    let repo = root.join(name);
+    let orbit_dir = repo.join(".orbit");
+    std::fs::create_dir_all(&orbit_dir).expect("orbit dir");
+    WorkspaceCheckout::owner(workspace_id.to_string(), repo, orbit_dir)
+}
+
+/// A two-workspace registry plus one entry the registry marked invalid.
+fn seeded_catalog() -> (tempfile::TempDir, RegistryWorkspaceCatalog) {
+    let root = tempfile::tempdir().expect("root");
+    let global = root.path().join("global");
+    std::fs::create_dir_all(&global).expect("global root");
+
+    let alpha = workspace("ws_alpha", "alpha", WorkspaceStatus::Active);
+    let beta = workspace("ws_beta", "beta", WorkspaceStatus::Active);
+    let invalid = workspace("ws_invalid", "invalid-ws", WorkspaceStatus::Invalid);
+    let checkouts = vec![
+        checkout(&alpha.id, root.path(), "alpha"),
+        checkout(&beta.id, root.path(), "beta"),
+        checkout(&invalid.id, root.path(), "invalid-ws"),
+    ];
+    save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![alpha, beta, invalid],
+            checkouts,
+            ..Default::default()
+        },
+        &registry_path_for(&global),
+    )
+    .expect("workspace registry");
+
+    let catalog = RegistryWorkspaceCatalog::new(&global);
+    (root, catalog)
+}
+
+#[test]
+fn current_scope_never_asks_the_catalog_for_a_checkout() {
+    let (_root, catalog) = seeded_catalog();
+
+    let targets = catalog
+        .resolve_scope(&WorkspaceScope::Current)
+        .expect("resolve");
+
+    assert!(
+        targets.is_empty(),
+        "Core resolves its own checkout; the catalog must not add one"
+    );
+}
+
+#[test]
+fn all_registered_scope_covers_active_workspaces_only() {
+    let (_root, catalog) = seeded_catalog();
+
+    let names = catalog
+        .resolve_scope(&WorkspaceScope::AllRegistered)
+        .expect("resolve")
+        .into_iter()
+        .map(|target| target.name)
+        .collect::<Vec<_>>();
+
+    assert_eq!(names, vec!["alpha", "beta"]);
+}
+
+#[test]
+fn repeated_selectors_for_one_workspace_are_opened_once() {
+    let (_root, catalog) = seeded_catalog();
+
+    // Name and logical ID name the same checkout; opening it twice would
+    // double-count its hits in the fused list.
+    let targets = catalog
+        .resolve_scope(&WorkspaceScope::Selectors(vec![
+            "alpha".to_string(),
+            "ws_alpha".to_string(),
+            "beta".to_string(),
+        ]))
+        .expect("resolve");
+
+    assert_eq!(
+        targets
+            .iter()
+            .map(|target| target.workspace_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["ws_alpha", "ws_beta"]
+    );
+}
+
+#[test]
+fn an_unknown_selector_fails_closed_by_name() {
+    let (_root, catalog) = seeded_catalog();
+
+    let error = catalog
+        .resolve_scope(&WorkspaceScope::Selectors(vec!["nowhere".to_string()]))
+        .expect_err("an unknown selector must not be silently dropped from the scope");
+
+    assert!(error.to_string().contains("nowhere"));
+}
+
+#[test]
+fn a_non_active_workspace_is_not_selectable_by_name() {
+    let (_root, catalog) = seeded_catalog();
+
+    assert!(
+        catalog
+            .resolve_scope(&WorkspaceScope::Selectors(vec!["invalid-ws".to_string()]))
+            .is_err()
+    );
+}

--- a/crates/orbit-cmd/src/workspace_catalog.rs
+++ b/crates/orbit-cmd/src/workspace_catalog.rs
@@ -1,0 +1,116 @@
+//! Registry-backed resolution for Core's federated-search scope.
+//!
+//! Core owns the fan-out, fusion, and attribution; it deliberately owns no
+//! workspace catalog, because `orbit-registry` sits above it in the crate
+//! graph. This module is the composition point that closes that gap: it turns
+//! a [`WorkspaceScope`] into registered checkouts and opens a runtime for one
+//! [ORB-11027].
+//!
+//! It adds no dependency edge — `orbit-cmd` already joins Core to Registry.
+
+use std::path::{Path, PathBuf};
+
+use orbit_common::OrbitError;
+use orbit_core::{FederatedWorkspaceTarget, OrbitRuntime, WorkspaceCatalog, WorkspaceScope};
+use orbit_registry::workspace_registry;
+use orbit_types::workspace::{Workspace, WorkspaceCheckout, WorkspaceRegistry, WorkspaceStatus};
+
+use crate::registry_runtime::RegisteredRuntimeFactory;
+
+/// Resolves federated scope against this machine's workspace registry.
+#[derive(Debug, Clone)]
+pub struct RegistryWorkspaceCatalog {
+    global_root: PathBuf,
+}
+
+impl RegistryWorkspaceCatalog {
+    pub fn new(global_root: impl Into<PathBuf>) -> Self {
+        Self {
+            global_root: global_root.into(),
+        }
+    }
+
+    fn load_registry(&self) -> Result<WorkspaceRegistry, OrbitError> {
+        workspace_registry::load_registry_from(&workspace_registry::registry_path_for(
+            &self.global_root,
+        ))
+    }
+}
+
+impl WorkspaceCatalog for RegistryWorkspaceCatalog {
+    fn resolve_scope(
+        &self,
+        scope: &WorkspaceScope,
+    ) -> Result<Vec<FederatedWorkspaceTarget>, OrbitError> {
+        let registry = self.load_registry()?;
+        let selected = match scope {
+            // Core never asks a catalog to resolve its own checkout.
+            WorkspaceScope::Current => Vec::new(),
+            WorkspaceScope::AllRegistered => workspace_registry::local_workspaces(&registry)
+                .filter(|(workspace, _)| workspace.status == WorkspaceStatus::Active)
+                .map(|(workspace, checkout)| target_for(workspace, checkout))
+                .collect(),
+            // A selector is resolved through the same fail-closed grammar the
+            // `--workspace` binder uses, so an unknown or ambiguous name is
+            // named rather than quietly dropped from the scope.
+            WorkspaceScope::Selectors(selectors) => selectors
+                .iter()
+                .map(|selector| {
+                    RegisteredRuntimeFactory::resolve_workspace_selector(
+                        &self.global_root,
+                        selector,
+                    )
+                    .map(|selected| target_for(&selected.workspace, &selected.checkout))
+                })
+                .collect::<Result<Vec<_>, OrbitError>>()?,
+        };
+        Ok(dedupe_by_workspace_id(selected))
+    }
+
+    fn open(&self, target: &FederatedWorkspaceTarget) -> Result<OrbitRuntime, OrbitError> {
+        let registry = self.load_registry()?;
+        let (workspace, checkout) = registry
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.id == target.workspace_id)
+            .zip(
+                registry
+                    .checkouts
+                    .iter()
+                    .find(|checkout| checkout.workspace_id == target.workspace_id),
+            )
+            .ok_or_else(|| {
+                OrbitError::WorkspaceError(format!(
+                    "workspace '{}' is no longer registered on this machine",
+                    target.name
+                ))
+            })?;
+        RegisteredRuntimeFactory::open_registered_checkout(&self.global_root, workspace, checkout)
+    }
+}
+
+fn target_for(workspace: &Workspace, checkout: &WorkspaceCheckout) -> FederatedWorkspaceTarget {
+    FederatedWorkspaceTarget {
+        workspace_id: workspace.id.clone(),
+        name: workspace.name.clone(),
+        repo_root: checkout.repo_root.clone(),
+    }
+}
+
+/// Two selectors can name the same workspace (`ws_*`, name, and path all
+/// resolve to one checkout). Opening it twice would double-count its hits in
+/// the fused list, so the first mention wins and order is preserved.
+fn dedupe_by_workspace_id(targets: Vec<FederatedWorkspaceTarget>) -> Vec<FederatedWorkspaceTarget> {
+    let mut seen = std::collections::BTreeSet::new();
+    targets
+        .into_iter()
+        .filter(|target| seen.insert(target.workspace_id.clone()))
+        .collect()
+}
+
+/// Attach registry-backed federated search to a runtime this crate opened.
+pub(crate) fn attach(runtime: OrbitRuntime, global_root: &Path) -> OrbitRuntime {
+    runtime.with_workspace_catalog(std::sync::Arc::new(RegistryWorkspaceCatalog::new(
+        global_root,
+    )))
+}

--- a/crates/orbit-core/src/adapter/tool_host/search_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/search_tools.rs
@@ -7,7 +7,7 @@ use orbit_common::protocol::tool_input::{
 };
 use serde_json::Value;
 
-use crate::{GlobalSearchKind, GlobalSearchParams, OrbitRuntime};
+use crate::{GlobalSearchKind, GlobalSearchParams, OrbitRuntime, WorkspaceScope};
 
 use super::input::optional_bool_alias;
 
@@ -40,6 +40,15 @@ pub(super) fn search(runtime: &OrbitRuntime, input: Value) -> Result<Value, Orbi
         .transpose()?
         .unwrap_or_default();
 
+    // `workspaces` is the federated *scope*; `workspace` stays the reserved
+    // routing selector that binds a call to one registered checkout, so the two
+    // never collide [ORB-11027].
+    let workspaces = WorkspaceScope::from_inputs(
+        optional_csv_or_string_list_alias(&input, &["workspaces", "workspace_scope"])?
+            .unwrap_or_default(),
+        optional_bool_alias(&input, &["all_workspaces", "allWorkspaces"])?.unwrap_or(false),
+    );
+
     let result = runtime.global_search(GlobalSearchParams {
         query: optional_string_alias(&input, &["query"])?,
         hybrid,
@@ -53,6 +62,7 @@ pub(super) fn search(runtime: &OrbitRuntime, input: Value) -> Result<Value, Orbi
         status: optional_csv_or_string_list_alias(&input, &["status", "statuses"])?
             .unwrap_or_default(),
         path: optional_string_alias(&input, &["path"])?,
+        workspaces,
     })?;
     serde_json::to_value(result)
         .map_err(|error| OrbitError::Execution(format!("serialize search result: {error}")))

--- a/crates/orbit-core/src/application/search/convert.rs
+++ b/crates/orbit-core/src/application/search/convert.rs
@@ -14,6 +14,7 @@ pub(super) fn lexical_task_hit(task: &orbit_types::task::Task) -> GlobalSearchHi
         score: None,
         score_breakdown: None,
         matched_by: None,
+        workspace: None,
     }
 }
 
@@ -31,6 +32,7 @@ pub(super) fn semantic_hit_to_global(hit: orbit_search::SemanticHit) -> GlobalSe
         score: Some(hit.score),
         score_breakdown: Some(hit.score_breakdown),
         matched_by: None,
+        workspace: None,
     }
 }
 
@@ -52,5 +54,6 @@ pub(super) fn doc_result_to_global(
         score,
         score_breakdown: None,
         matched_by: Some(result.matched_by),
+        workspace: None,
     }
 }

--- a/crates/orbit-core/src/application/search/federated.rs
+++ b/crates/orbit-core/src/application/search/federated.rs
@@ -1,0 +1,301 @@
+//! Cross-workspace search: fan out over registered checkouts, fuse, attribute.
+//!
+//! Each workspace keeps owning and writing its own `.orbit/state/semantic.db`;
+//! only the *read* federates [ORB-11027]. Core resolves nothing about the
+//! catalog itself — a `WorkspaceCatalog` supplied by the registry-owning layer
+//! answers "which checkouts" and "open this one", and everything below is
+//! fan-out, fusion, attribution, and degradation notes.
+//!
+//! Two rules shape the fusion:
+//!
+//! * **Rank, never raw score.** Per-workspace hits are interleaved by their
+//!   position in their own workspace's ranked list, reusing the same
+//!   round-robin merge that already balances kinds. Lexical BM25 scores,
+//!   blended hybrid scores, and `None` (frictions) are not commensurable
+//!   across workspaces, so nothing compares them, and no single large
+//!   workspace can crowd out the rest.
+//! * **Every hit is attributed.** Friction and job-run IDs are allocated per
+//!   workspace, so a merged list without a workspace field lets a caller route
+//!   a follow-up write to the wrong record (F2026-08-046).
+
+use std::collections::BTreeSet;
+
+use orbit_common::OrbitError;
+
+use crate::OrbitRuntime;
+use crate::runtime::workspace_catalog::{
+    FederatedWorkspaceTarget, WorkspaceCatalog, WorkspaceScope,
+};
+
+use super::merge_round_robin;
+use super::types::{
+    GlobalSearchHit, GlobalSearchMode, GlobalSearchParams, GlobalSearchResponse, HitWorkspace,
+    WorkspaceSearchReport,
+};
+
+/// How many registered checkouts one federated query will open.
+///
+/// A bound exists because each workspace costs a runtime open plus a SQLite
+/// handle. It is never applied silently: exceeding it adds a note naming both
+/// the cap and how many workspaces were dropped.
+pub(super) const MAX_FEDERATED_WORKSPACES: usize = 16;
+
+const NO_MATCHING_WORKSPACE_NOTE: &str = "no registered workspace matched the requested scope";
+
+#[cfg(test)]
+thread_local! {
+    /// Test seam for the managed-run guard. The suite itself may run inside an
+    /// Orbit-managed job, whose environment would otherwise make every
+    /// fan-out test observe the refusal.
+    static MANAGED_RUN_OVERRIDE: std::cell::Cell<Option<bool>> =
+        const { std::cell::Cell::new(None) };
+}
+
+fn in_managed_run() -> bool {
+    #[cfg(test)]
+    if let Some(value) = MANAGED_RUN_OVERRIDE.with(std::cell::Cell::get) {
+        return value;
+    }
+    crate::runtime::run_input::managed_run_context_from_env()
+}
+
+#[cfg(test)]
+pub(super) fn with_managed_run_override<T>(value: bool, f: impl FnOnce() -> T) -> T {
+    MANAGED_RUN_OVERRIDE.with(|cell| cell.set(Some(value)));
+    let out = f();
+    MANAGED_RUN_OVERRIDE.with(|cell| cell.set(None));
+    out
+}
+
+impl OrbitRuntime {
+    pub(super) fn federated_search(
+        &self,
+        params: GlobalSearchParams,
+    ) -> Result<GlobalSearchResponse, OrbitError> {
+        ensure_federated_scope_supported(&params)?;
+        ensure_federated_scope_permitted(in_managed_run())?;
+
+        let catalog = self
+            .workspace_catalog()
+            .ok_or_else(federation_unavailable)?;
+
+        let mut notes = Vec::new();
+        let mut targets = catalog.resolve_scope(&params.workspaces)?;
+        if let Some(note) = apply_workspace_cap(&mut targets) {
+            notes.push(note);
+        }
+        if targets.is_empty() {
+            notes.push(NO_MATCHING_WORKSPACE_NOTE.to_string());
+            return Ok(GlobalSearchResponse {
+                mode: GlobalSearchMode::Lexical,
+                kind: params.kind,
+                results: Vec::new(),
+                notes,
+                workspaces: Vec::new(),
+            });
+        }
+
+        // Resolved once: the query-side model is a host fact, not a
+        // per-workspace one. Only hybrid ranking compares vectors, so a lexical
+        // query never pays for it.
+        let query_model = params
+            .hybrid
+            .then(|| orbit_search::query_model_id(None).ok())
+            .flatten();
+
+        let mut branches = Vec::with_capacity(targets.len());
+        let mut reports = Vec::with_capacity(targets.len());
+        for target in &targets {
+            let (hits, report) = self.query_one_workspace(
+                catalog.as_ref(),
+                target,
+                &params,
+                query_model.as_deref(),
+                &mut notes,
+            );
+            branches.push(hits);
+            reports.push(report);
+        }
+
+        let results = merge_round_robin(branches, params.normalized_limit());
+        Ok(GlobalSearchResponse {
+            mode: response_mode(params.hybrid, &results),
+            kind: params.kind,
+            results,
+            notes,
+            workspaces: reports,
+        })
+    }
+
+    /// One workspace's contribution, with every failure mode folded into a note.
+    ///
+    /// Returns no `Result`: a registered checkout can be stale, moved, or owned
+    /// by another machine, and that must degrade exactly one workspace rather
+    /// than the query.
+    fn query_one_workspace(
+        &self,
+        catalog: &dyn WorkspaceCatalog,
+        target: &FederatedWorkspaceTarget,
+        params: &GlobalSearchParams,
+        query_model: Option<&str>,
+        notes: &mut Vec<String>,
+    ) -> (Vec<GlobalSearchHit>, WorkspaceSearchReport) {
+        let mut report = WorkspaceSearchReport {
+            workspace_id: target.workspace_id.clone(),
+            name: target.name.clone(),
+            hits: 0,
+            note: None,
+        };
+        let mut record_note = |report: &mut WorkspaceSearchReport, note: String| {
+            notes.push(workspace_note(&target.name, &note));
+            report.note = Some(match report.note.take() {
+                Some(existing) => format!("{existing}; {note}"),
+                None => note,
+            });
+        };
+
+        let runtime = match catalog.open(target) {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                record_note(&mut report, format!("skipped: {error}"));
+                return (Vec::new(), report);
+            }
+        };
+        if let Some(note) = query_model.and_then(|model| model_mismatch_note(&runtime, model)) {
+            record_note(&mut report, note);
+        }
+
+        // Scope is reset so the sub-runtime — which carries a catalog of its
+        // own — takes the plain single-workspace path and cannot recurse.
+        let mut scoped = params.clone();
+        scoped.workspaces = WorkspaceScope::Current;
+        match runtime.workspace_search(scoped) {
+            Ok(response) => {
+                for note in response.notes {
+                    notes.push(workspace_note(&target.name, &note));
+                }
+                let hits = response
+                    .results
+                    .into_iter()
+                    .map(|hit| attribute(hit, target))
+                    .collect::<Vec<_>>();
+                report.hits = hits.len();
+                (hits, report)
+            }
+            Err(error) => {
+                record_note(&mut report, format!("skipped: {error}"));
+                (Vec::new(), report)
+            }
+        }
+    }
+}
+
+fn federation_unavailable() -> OrbitError {
+    OrbitError::InvalidInput(
+        "multi-workspace search needs a registry-backed runtime; this runtime is bound to a single checkout"
+            .to_string(),
+    )
+}
+
+/// Modes that only mean something inside one checkout.
+///
+/// Enforced here rather than in each surface: this is the domain rule, and the
+/// CLI, the tool host, and the HTTP adapter all reach it through this call.
+pub(super) fn ensure_federated_scope_supported(
+    params: &GlobalSearchParams,
+) -> Result<(), OrbitError> {
+    if params.semantic.is_some() {
+        return Err(OrbitError::InvalidInput(
+            "`semantic` neighbor lookup is single-workspace; it ranks against one workspace's task vectors"
+                .to_string(),
+        ));
+    }
+    if params.path.is_some() {
+        return Err(OrbitError::InvalidInput(
+            "`path` applicability lookup is single-workspace; a checkout path belongs to one workspace"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// The sandbox posture for a federated read from inside an agent run: denied.
+///
+/// The v2 host allow-lists only the run's own `{workspace}/state/semantic.db*`.
+/// An in-process federated read would hand a run scoped to an unrelated code
+/// workspace a handle on every registered index — including a personal vault —
+/// which turns a filesystem-level guarantee into a query-time filter. Denying
+/// the *scope* rather than widening the allow-list keeps the two consistent.
+/// Human and operator surfaces, which are not inside a managed run, keep it.
+pub(super) fn ensure_federated_scope_permitted(in_managed_run: bool) -> Result<(), OrbitError> {
+    if in_managed_run {
+        return Err(OrbitError::InvalidInput(
+            "multi-workspace search is not available inside an Orbit-managed run; a run may only read its own workspace index"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn apply_workspace_cap(targets: &mut Vec<FederatedWorkspaceTarget>) -> Option<String> {
+    if targets.len() <= MAX_FEDERATED_WORKSPACES {
+        return None;
+    }
+    let dropped = targets.len() - MAX_FEDERATED_WORKSPACES;
+    targets.truncate(MAX_FEDERATED_WORKSPACES);
+    Some(format!(
+        "workspace scope capped at {MAX_FEDERATED_WORKSPACES}; {dropped} further registered workspace(s) were not queried"
+    ))
+}
+
+/// Whether this workspace's vectors can contribute cosine rank at all.
+///
+/// A workspace indexed under a different `model_id` has no rows the query
+/// embedder can score, so its hybrid branch degrades to lexical. Say so by
+/// name instead of emitting a plausible-looking ranking the caller cannot
+/// tell apart from a fused one.
+fn model_mismatch_note(runtime: &OrbitRuntime, query_model: &str) -> Option<String> {
+    let indexed = runtime.stores().semantic_vector.model_ids().ok()?;
+    describe_model_mismatch(&indexed, query_model)
+}
+
+pub(super) fn describe_model_mismatch(
+    indexed: &BTreeSet<String>,
+    query_model: &str,
+) -> Option<String> {
+    if indexed.is_empty() || indexed.contains(query_model) {
+        return None;
+    }
+    let models = indexed.iter().cloned().collect::<Vec<_>>().join(", ");
+    Some(format!(
+        "semantic index uses model(s) {models}, not the query model {query_model}; cosine scores are not fused for this workspace and it contributes lexical hits only"
+    ))
+}
+
+pub(super) fn workspace_note(name: &str, note: &str) -> String {
+    format!("[{name}] {note}")
+}
+
+pub(super) fn attribute(
+    mut hit: GlobalSearchHit,
+    target: &FederatedWorkspaceTarget,
+) -> GlobalSearchHit {
+    hit.workspace = Some(HitWorkspace {
+        workspace_id: target.workspace_id.clone(),
+        name: target.name.clone(),
+        repo_root: target.repo_root.to_string_lossy().into_owned(),
+    });
+    hit
+}
+
+fn response_mode(hybrid: bool, results: &[GlobalSearchHit]) -> GlobalSearchMode {
+    if hybrid
+        && results
+            .iter()
+            .any(|hit| matches!(hit.source.as_str(), "hybrid" | "semantic"))
+    {
+        GlobalSearchMode::Hybrid
+    } else {
+        GlobalSearchMode::Lexical
+    }
+}

--- a/crates/orbit-core/src/application/search/mod.rs
+++ b/crates/orbit-core/src/application/search/mod.rs
@@ -10,6 +10,7 @@ use crate::OrbitRuntime;
 use crate::application::docs::SearchResult;
 
 mod convert;
+mod federated;
 mod filters;
 mod hybrid;
 mod path_match;
@@ -21,6 +22,7 @@ mod tests;
 pub use path_match::task_selectors_contain_path;
 pub use types::{
     GlobalSearchHit, GlobalSearchKind, GlobalSearchMode, GlobalSearchParams, GlobalSearchResponse,
+    HitWorkspace, WorkspaceSearchReport,
 };
 
 use self::convert::{doc_result_to_global, lexical_task_hit, semantic_hit_to_global};
@@ -56,7 +58,23 @@ struct HybridSearchScope<'a> {
 }
 
 impl OrbitRuntime {
+    /// Unified search entry point.
+    ///
+    /// A `Current` scope — the default — runs the single-workspace path
+    /// unchanged. Anything wider fans out through the workspace catalog and
+    /// fuses the per-workspace result sets [ORB-11027].
     pub fn global_search(
+        &self,
+        params: GlobalSearchParams,
+    ) -> Result<GlobalSearchResponse, OrbitError> {
+        if params.workspaces.is_federated() {
+            return self.federated_search(params);
+        }
+        self.workspace_search(params)
+    }
+
+    /// One workspace's answer: this runtime's own checkout, nothing else.
+    pub(super) fn workspace_search(
         &self,
         params: GlobalSearchParams,
     ) -> Result<GlobalSearchResponse, OrbitError> {
@@ -94,6 +112,7 @@ impl OrbitRuntime {
                 kind: params.kind,
                 results,
                 notes,
+                workspaces: Vec::new(),
             });
         }
 
@@ -182,6 +201,7 @@ impl OrbitRuntime {
             kind: params.kind,
             results,
             notes,
+            workspaces: Vec::new(),
         })
     }
 
@@ -302,6 +322,7 @@ impl OrbitRuntime {
                     score: None,
                     score_breakdown: None,
                     matched_by: None,
+                    workspace: None,
                 }
             })
             .collect())
@@ -375,6 +396,7 @@ impl OrbitRuntime {
                     score: None,
                     score_breakdown: None,
                     matched_by: Some(tag_filter.iter().map(|tag| format!("tag:{tag}")).collect()),
+                    workspace: None,
                 });
             }
             out.truncate(limit);
@@ -504,6 +526,7 @@ impl OrbitRuntime {
                         score: None,
                         score_breakdown: None,
                         matched_by: None,
+                        workspace: None,
                     },
                     lexical_score: None,
                     semantic_score: Some(hit.score),
@@ -540,7 +563,10 @@ impl OrbitRuntime {
     }
 }
 
-fn merge_round_robin(branches: Vec<Vec<GlobalSearchHit>>, limit: usize) -> Vec<GlobalSearchHit> {
+pub(super) fn merge_round_robin(
+    branches: Vec<Vec<GlobalSearchHit>>,
+    limit: usize,
+) -> Vec<GlobalSearchHit> {
     let mut queues = branches
         .into_iter()
         .filter(|branch| !branch.is_empty())

--- a/crates/orbit-core/src/application/search/tests/federated.rs
+++ b/crates/orbit-core/src/application/search/tests/federated.rs
@@ -1,0 +1,359 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use orbit_common::OrbitError;
+use orbit_types::task::TaskStatus;
+
+use super::*;
+use crate::application::search::federated::{
+    MAX_FEDERATED_WORKSPACES, apply_workspace_cap, describe_model_mismatch,
+    ensure_federated_scope_permitted, ensure_federated_scope_supported, with_managed_run_override,
+};
+use crate::runtime::workspace_catalog::{
+    FederatedWorkspaceTarget, WorkspaceCatalog, WorkspaceScope,
+};
+
+/// A catalog over runtimes the test already built, so the fan-out is exercised
+/// without a workspace registry on disk.
+struct FakeCatalog {
+    entries: Vec<(FederatedWorkspaceTarget, Option<OrbitRuntime>)>,
+}
+
+impl FakeCatalog {
+    fn new(entries: Vec<(FederatedWorkspaceTarget, Option<OrbitRuntime>)>) -> Arc<Self> {
+        Arc::new(Self { entries })
+    }
+}
+
+impl WorkspaceCatalog for FakeCatalog {
+    fn resolve_scope(
+        &self,
+        _scope: &WorkspaceScope,
+    ) -> Result<Vec<FederatedWorkspaceTarget>, OrbitError> {
+        Ok(self
+            .entries
+            .iter()
+            .map(|(target, _)| target.clone())
+            .collect())
+    }
+
+    fn open(&self, target: &FederatedWorkspaceTarget) -> Result<OrbitRuntime, OrbitError> {
+        self.entries
+            .iter()
+            .find(|(candidate, _)| candidate.workspace_id == target.workspace_id)
+            .and_then(|(_, runtime)| runtime.clone())
+            .ok_or_else(|| {
+                OrbitError::WorkspaceError(format!("checkout for '{}' is gone", target.name))
+            })
+    }
+}
+
+fn target(name: &str) -> FederatedWorkspaceTarget {
+    FederatedWorkspaceTarget {
+        workspace_id: format!("ws_{name}"),
+        name: name.to_string(),
+        repo_root: PathBuf::from(format!("/checkouts/{name}")),
+    }
+}
+
+fn seeded_runtime(query: &str, task_count: usize) -> OrbitRuntime {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    for index in 0..task_count {
+        add_task_with_status(
+            &runtime,
+            &format!("{query} task {index:02}"),
+            TaskStatus::Backlog,
+        );
+    }
+    runtime
+}
+
+fn federated_query(query: &str, limit: usize) -> GlobalSearchParams {
+    GlobalSearchParams {
+        query: Some(query.to_string()),
+        kind: GlobalSearchKind::Task,
+        limit,
+        workspaces: WorkspaceScope::AllRegistered,
+        ..Default::default()
+    }
+}
+
+fn hub(catalog: Arc<FakeCatalog>) -> OrbitRuntime {
+    OrbitRuntime::in_memory()
+        .expect("hub runtime")
+        .with_workspace_catalog(catalog)
+}
+
+#[test]
+fn default_scope_keeps_the_single_workspace_response_shape() {
+    let query = "unfederated";
+    let runtime = seeded_runtime(query, 3);
+
+    let response = runtime
+        .global_search(GlobalSearchParams {
+            query: Some(query.to_string()),
+            kind: GlobalSearchKind::Task,
+            limit: 5,
+            ..Default::default()
+        })
+        .expect("search");
+
+    assert!(!response.results.is_empty());
+    assert!(response.results.iter().all(|hit| hit.workspace.is_none()));
+    assert!(response.workspaces.is_empty());
+
+    // The serialized shape is the compatibility contract for the HTTP adapter
+    // and every MCP caller: neither new field may appear by default.
+    let json = serde_json::to_value(&response).expect("serialize");
+    assert!(json.get("workspaces").is_none());
+    assert!(
+        json["results"]
+            .as_array()
+            .expect("results")
+            .iter()
+            .all(|hit| hit.get("workspace").is_none())
+    );
+}
+
+#[test]
+fn federated_search_fuses_and_attributes_hits_from_every_workspace() {
+    let query = "fusewitness";
+    let catalog = FakeCatalog::new(vec![
+        (target("alpha"), Some(seeded_runtime(query, 4))),
+        (target("beta"), Some(seeded_runtime(query, 4))),
+    ]);
+    let runtime = hub(catalog);
+
+    let response = with_managed_run_override(false, || {
+        runtime
+            .global_search(federated_query(query, 4))
+            .expect("federated search")
+    });
+
+    assert_eq!(response.results.len(), 4);
+    let names = response
+        .results
+        .iter()
+        .map(|hit| {
+            hit.workspace
+                .as_ref()
+                .expect("every federated hit is attributed")
+                .name
+                .clone()
+        })
+        .collect::<Vec<_>>();
+    // Rank interleaving, so both workspaces are represented rather than the
+    // first one filling the budget.
+    assert_eq!(names, vec!["alpha", "beta", "alpha", "beta"]);
+    assert_eq!(
+        response
+            .results
+            .iter()
+            .filter_map(|hit| hit.workspace.as_ref())
+            .map(|workspace| workspace.workspace_id.as_str())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from(["ws_alpha", "ws_beta"])
+    );
+    assert_eq!(
+        response
+            .workspaces
+            .iter()
+            .map(|report| (report.name.as_str(), report.hits))
+            .collect::<Vec<_>>(),
+        vec![("alpha", 4), ("beta", 4)]
+    );
+}
+
+#[test]
+fn a_small_workspace_is_not_crowded_out_by_a_large_one() {
+    let query = "crowding";
+    let catalog = FakeCatalog::new(vec![
+        (target("big"), Some(seeded_runtime(query, 12))),
+        (target("small"), Some(seeded_runtime(query, 1))),
+    ]);
+    let runtime = hub(catalog);
+
+    let response = with_managed_run_override(false, || {
+        runtime
+            .global_search(federated_query(query, 6))
+            .expect("federated search")
+    });
+
+    assert_eq!(response.results.len(), 6);
+    assert!(
+        response
+            .results
+            .iter()
+            .any(|hit| hit.workspace.as_ref().is_some_and(|ws| ws.name == "small")),
+        "the single-hit workspace must survive the budget"
+    );
+}
+
+#[test]
+fn an_unopenable_workspace_degrades_to_a_note_without_failing_the_query() {
+    let query = "degrading";
+    let catalog = FakeCatalog::new(vec![
+        (target("healthy"), Some(seeded_runtime(query, 3))),
+        (target("stale"), None),
+    ]);
+    let runtime = hub(catalog);
+
+    let response = with_managed_run_override(false, || {
+        runtime
+            .global_search(federated_query(query, 5))
+            .expect("a broken checkout must not fail the query")
+    });
+
+    assert!(!response.results.is_empty());
+    assert!(response.results.iter().all(|hit| {
+        hit.workspace
+            .as_ref()
+            .is_some_and(|ws| ws.name == "healthy")
+    }));
+    let stale = response
+        .workspaces
+        .iter()
+        .find(|report| report.name == "stale")
+        .expect("the skipped workspace still reports");
+    assert_eq!(stale.hits, 0);
+    assert!(
+        stale
+            .note
+            .as_deref()
+            .is_some_and(|note| note.contains("skipped"))
+    );
+    assert!(
+        response
+            .notes
+            .iter()
+            .any(|note| note.starts_with("[stale]")),
+        "every note names the workspace it came from: {:?}",
+        response.notes
+    );
+}
+
+#[test]
+fn federated_scope_without_a_catalog_is_refused_by_name() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+
+    let error = with_managed_run_override(false, || {
+        runtime
+            .global_search(federated_query("nocatalog", 5))
+            .expect_err("a catalog-less runtime cannot federate")
+    });
+
+    assert!(error.to_string().contains("registry-backed runtime"));
+}
+
+#[test]
+fn an_empty_scope_returns_no_hits_and_says_so() {
+    let catalog = FakeCatalog::new(Vec::new());
+    let runtime = hub(catalog);
+
+    let response = with_managed_run_override(false, || {
+        runtime
+            .global_search(federated_query("nothing", 5))
+            .expect("empty scope is not an error")
+    });
+
+    assert!(response.results.is_empty());
+    assert!(
+        response
+            .notes
+            .iter()
+            .any(|note| note.contains("no registered workspace"))
+    );
+}
+
+#[test]
+fn workspace_fan_out_cap_is_announced_never_silent() {
+    let mut none = (0..MAX_FEDERATED_WORKSPACES)
+        .map(|index| target(&format!("ws{index:02}")))
+        .collect::<Vec<_>>();
+    assert!(apply_workspace_cap(&mut none).is_none());
+    assert_eq!(none.len(), MAX_FEDERATED_WORKSPACES);
+
+    let mut over = (0..MAX_FEDERATED_WORKSPACES + 3)
+        .map(|index| target(&format!("ws{index:02}")))
+        .collect::<Vec<_>>();
+    let note = apply_workspace_cap(&mut over).expect("truncation must be reported");
+    assert_eq!(over.len(), MAX_FEDERATED_WORKSPACES);
+    assert!(note.contains(&MAX_FEDERATED_WORKSPACES.to_string()));
+    assert!(note.contains('3'));
+}
+
+#[test]
+fn model_mismatch_is_reported_and_a_shared_model_is_not() {
+    let indexed = BTreeSet::from(["minilm-l6".to_string()]);
+    let note = describe_model_mismatch(&indexed, "bge-small").expect("mismatch must be reported");
+    assert!(note.contains("minilm-l6"));
+    assert!(note.contains("bge-small"));
+    assert!(note.contains("cosine"));
+
+    assert!(describe_model_mismatch(&indexed, "minilm-l6").is_none());
+    // An unindexed workspace is not a mismatch — it simply has no vectors, and
+    // the existing hybrid fallback already narrates that.
+    assert!(describe_model_mismatch(&BTreeSet::new(), "bge-small").is_none());
+}
+
+#[test]
+fn federated_scope_is_denied_inside_a_managed_run() {
+    let error = ensure_federated_scope_permitted(true)
+        .expect_err("a managed run may only read its own workspace index");
+    assert!(error.to_string().contains("Orbit-managed run"));
+    assert!(ensure_federated_scope_permitted(false).is_ok());
+}
+
+#[test]
+fn neighbor_and_path_lookups_refuse_a_federated_scope() {
+    let semantic = GlobalSearchParams {
+        semantic: Some("ORB-00001".to_string()),
+        workspaces: WorkspaceScope::AllRegistered,
+        ..Default::default()
+    };
+    assert!(
+        ensure_federated_scope_supported(&semantic)
+            .expect_err("neighbor lookup is single-workspace")
+            .to_string()
+            .contains("`semantic`")
+    );
+
+    let path = GlobalSearchParams {
+        path: Some("src/main.rs".to_string()),
+        workspaces: WorkspaceScope::AllRegistered,
+        ..Default::default()
+    };
+    assert!(
+        ensure_federated_scope_supported(&path)
+            .expect_err("path lookup is single-workspace")
+            .to_string()
+            .contains("`path`")
+    );
+
+    assert!(ensure_federated_scope_supported(&federated_query("plain", 5)).is_ok());
+}
+
+#[test]
+fn workspace_scope_reads_the_two_surface_inputs() {
+    assert_eq!(
+        WorkspaceScope::from_inputs(Vec::new(), false),
+        WorkspaceScope::Current
+    );
+    // A blank selector must not silently federate.
+    assert_eq!(
+        WorkspaceScope::from_inputs(vec!["  ".to_string()], false),
+        WorkspaceScope::Current
+    );
+    assert_eq!(
+        WorkspaceScope::from_inputs(vec![" polaris ".to_string()], false),
+        WorkspaceScope::Selectors(vec!["polaris".to_string()])
+    );
+    // "everything registered" wins over an explicit list.
+    assert_eq!(
+        WorkspaceScope::from_inputs(vec!["polaris".to_string()], true),
+        WorkspaceScope::AllRegistered
+    );
+    assert!(!WorkspaceScope::Current.is_federated());
+    assert!(WorkspaceScope::AllRegistered.is_federated());
+}

--- a/crates/orbit-core/src/application/search/tests/hybrid.rs
+++ b/crates/orbit-core/src/application/search/tests/hybrid.rs
@@ -269,6 +269,7 @@ fn hybrid_handles_single_candidate_side() {
         score: None,
         score_breakdown: None,
         matched_by: None,
+        workspace: None,
     };
     let out = blend_doc_hybrid_candidates(
         vec![DocHybridCandidate {

--- a/crates/orbit-core/src/application/search/tests/mod.rs
+++ b/crates/orbit-core/src/application/search/tests/mod.rs
@@ -7,6 +7,7 @@ use orbit_types::task::{TaskPriority, TaskStatus, TaskType};
 use super::*;
 use crate::OrbitRuntime;
 
+mod federated;
 mod global;
 mod hybrid;
 mod path_match;

--- a/crates/orbit-core/src/application/search/types.rs
+++ b/crates/orbit-core/src/application/search/types.rs
@@ -4,6 +4,8 @@ use serde::Serialize;
 
 use orbit_search::ScoreBreakdown;
 
+use crate::runtime::workspace_catalog::WorkspaceScope;
+
 use super::DEFAULT_LIMIT;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
@@ -83,6 +85,10 @@ pub struct GlobalSearchParams {
     /// Cross-kind applicability filter. Task: selector-mapping against
     /// `context_files`. Doc: out of scope (returns empty).
     pub path: Option<String>,
+    /// Which workspaces this query covers. Defaults to
+    /// [`WorkspaceScope::Current`], the untouched single-workspace path
+    /// [ORB-11027].
+    pub workspaces: WorkspaceScope,
 }
 
 impl GlobalSearchParams {
@@ -101,6 +107,38 @@ pub struct GlobalSearchResponse {
     pub kind: GlobalSearchKind,
     pub results: Vec<GlobalSearchHit>,
     pub notes: Vec<String>,
+    /// Per-workspace outcome of a federated query. Empty — and omitted from
+    /// JSON — for the default single-workspace scope, so an existing caller
+    /// sees the same response shape it always did.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub workspaces: Vec<WorkspaceSearchReport>,
+}
+
+/// What one workspace contributed to a federated query.
+///
+/// A workspace that answered nothing still appears here with `hits: 0` and a
+/// `note`, so "returned no matches" is distinguishable from "was never asked".
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WorkspaceSearchReport {
+    pub workspace_id: String,
+    pub name: String,
+    pub hits: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+/// Which workspace a hit came from.
+///
+/// Load-bearing, not decorative: task IDs are globally unique and resolve
+/// through the host registry, but friction and job-run IDs are allocated per
+/// workspace, so the same ID names a different record in each. F2026-08-046
+/// records a near-miss write to the wrong record from exactly that ambiguity
+/// in a merged result set [ORB-11027].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct HitWorkspace {
+    pub workspace_id: String,
+    pub name: String,
+    pub repo_root: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -127,4 +165,8 @@ pub struct GlobalSearchHit {
     pub score_breakdown: Option<ScoreBreakdown>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub matched_by: Option<Vec<String>>,
+    /// Set only on a federated query. `None` on the single-workspace path
+    /// keeps that response byte-identical to before [ORB-11027].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<HitWorkspace>,
 }

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -68,10 +68,12 @@ pub use orbit_tools::prepare_remote_task_artifact_put;
 pub use application::docs::{DocType, TaskRelatedDoc};
 pub use application::job::{PipelineInvokeResult, PipelineWaitEntry};
 pub use application::search::{
-    GlobalSearchHit, GlobalSearchKind, GlobalSearchParams, task_selectors_contain_path,
+    GlobalSearchHit, GlobalSearchKind, GlobalSearchParams, HitWorkspace, WorkspaceSearchReport,
+    task_selectors_contain_path,
 };
 pub use application::workflow::{ShipMode, build_ship_input, find_workflow, resolved_ship_mode};
 pub use context::ActorIdentity;
+pub use runtime::workspace_catalog::{FederatedWorkspaceTarget, WorkspaceCatalog, WorkspaceScope};
 // Shared domain types (owned by orbit-common) that the CLI and dashboard
 // render or construct.
 pub use auto_tasks::{AutoTaskAddParams, AutoTaskUpdateParams};

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod run_input;
 pub(crate) mod task;
 pub use task::StaleTaskReservation;
 pub(crate) mod tool_exec;
+pub mod workspace_catalog;
 pub mod workspace_claim;
 
 #[cfg(test)]
@@ -69,6 +70,10 @@ pub struct OrbitRuntime {
     /// stays registry-neutral; it only carries the refusal supplied by that
     /// owner so every task-record writer shares one fail-closed gate.
     coordination_write_owner: Option<Arc<str>>,
+    /// Supplied by the same registry-owning composition layer, for reads that
+    /// span more than one workspace. Absent on a standalone runtime, which
+    /// then answers only for its own checkout [ORB-11027].
+    workspace_catalog: Option<Arc<dyn workspace_catalog::WorkspaceCatalog>>,
     pub event_log: event_bus::EventLog,
     /// Outcome of the [ORB-10012] workspace-layout pre-flight that ran when
     /// this runtime opened (empty `applied` when the layout was already
@@ -129,6 +134,7 @@ impl OrbitRuntime {
             context,
             workspace_binding: binding.map(Arc::new),
             coordination_write_owner: None,
+            workspace_catalog: None,
             event_log: event_bus::EventLog::default(),
             layout_report: Arc::new(layout_report),
             _temp_dir: None,
@@ -159,6 +165,7 @@ impl OrbitRuntime {
             context,
             workspace_binding: Some(Arc::new(binding)),
             coordination_write_owner: None,
+            workspace_catalog: None,
             event_log: event_bus::EventLog::default(),
             layout_report: Arc::new(orbit_store::workflow::layout::LayoutUpgradeReport::default()),
             _temp_dir: Some(Arc::new(temp_dir)),
@@ -181,6 +188,23 @@ impl OrbitRuntime {
     pub fn with_coordination_write_owner(mut self, owner_machine_id: Option<String>) -> Self {
         self.coordination_write_owner = owner_machine_id.map(Arc::from);
         self
+    }
+
+    /// Attach the workspace catalog that resolves federated search scope. Like
+    /// the replica owner above, it is supplied by the registry-owning layer and
+    /// never constructed by Core.
+    pub fn with_workspace_catalog(
+        mut self,
+        catalog: Arc<dyn workspace_catalog::WorkspaceCatalog>,
+    ) -> Self {
+        self.workspace_catalog = Some(catalog);
+        self
+    }
+
+    pub(crate) fn workspace_catalog(
+        &self,
+    ) -> Option<&Arc<dyn workspace_catalog::WorkspaceCatalog>> {
+        self.workspace_catalog.as_ref()
     }
 
     /// Refuse control-plane work in a replica checkout.

--- a/crates/orbit-core/src/runtime/workspace_catalog.rs
+++ b/crates/orbit-core/src/runtime/workspace_catalog.rs
@@ -1,0 +1,88 @@
+//! Registry-neutral seam for reads that span more than one workspace.
+//!
+//! Core owns no workspace catalog: `orbit-registry` sits above it in the crate
+//! graph. A federated read therefore needs a higher composition layer to answer
+//! two questions — *which checkouts does this scope cover* and *open a runtime
+//! for one of them* — while Core keeps ownership of fan-out, fusion,
+//! attribution, and degradation notes [ORB-11027].
+//!
+//! The seam mirrors [`super::OrbitRuntime::with_coordination_write_owner`]: a
+//! standalone runtime constructed without a catalog still works, and simply
+//! refuses any scope wider than its own workspace.
+
+use std::path::PathBuf;
+
+use orbit_common::OrbitError;
+
+use super::OrbitRuntime;
+
+/// Which workspaces one search covers.
+///
+/// [`WorkspaceScope::Current`] is the default and is not merely "a scope of
+/// one": it takes the untouched single-workspace path, so an existing caller
+/// observes byte-identical results.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum WorkspaceScope {
+    #[default]
+    Current,
+    /// Explicit selectors — registered name, logical `ws_*` ID, or an absolute
+    /// local checkout path. Resolution belongs to the catalog implementation.
+    Selectors(Vec<String>),
+    /// Every active checkout registered on this machine.
+    AllRegistered,
+}
+
+impl WorkspaceScope {
+    /// Whether this scope needs a catalog to answer.
+    pub fn is_federated(&self) -> bool {
+        !matches!(self, Self::Current)
+    }
+
+    /// Build a scope from the two independent inputs every surface collects:
+    /// a list of selectors and an "everything registered" switch.
+    ///
+    /// Blank selectors are dropped so an empty list is indistinguishable from
+    /// no list at all, which keeps `--workspace ""` from silently federating.
+    pub fn from_inputs(selectors: Vec<String>, all_registered: bool) -> Self {
+        let selectors = selectors
+            .into_iter()
+            .map(|selector| selector.trim().to_string())
+            .filter(|selector| !selector.is_empty())
+            .collect::<Vec<_>>();
+        match (selectors.is_empty(), all_registered) {
+            (_, true) => Self::AllRegistered,
+            (true, false) => Self::Current,
+            (false, false) => Self::Selectors(selectors),
+        }
+    }
+}
+
+/// One local checkout a federated read may open.
+///
+/// Deliberately plain data: no `Workspace`, `WorkspaceCheckout`, or registry
+/// handle crosses into Core.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FederatedWorkspaceTarget {
+    /// Logical `ws_*` catalog ID.
+    pub workspace_id: String,
+    /// Registered workspace name, as `orbit workspace list` shows it.
+    pub name: String,
+    pub repo_root: PathBuf,
+}
+
+/// Resolves a [`WorkspaceScope`] and opens runtimes for what it covers.
+///
+/// Two methods rather than one `Vec<(target, runtime)>` so that a single
+/// unopenable checkout — stale path, another machine's replica, a removed
+/// worktree — degrades to a note on that workspace instead of failing the
+/// whole query.
+pub trait WorkspaceCatalog: Send + Sync {
+    /// Checkouts covered by `scope`, in a stable order.
+    fn resolve_scope(
+        &self,
+        scope: &WorkspaceScope,
+    ) -> Result<Vec<FederatedWorkspaceTarget>, OrbitError>;
+
+    /// Open a runtime bound to one resolved target.
+    fn open(&self, target: &FederatedWorkspaceTarget) -> Result<OrbitRuntime, OrbitError>;
+}

--- a/crates/orbit-search/src/commands/mod.rs
+++ b/crates/orbit-search/src/commands/mod.rs
@@ -54,6 +54,15 @@ pub(crate) fn resolve_query_model(model: Option<&str>) -> Result<ModelSpec, Orbi
     parse_model(active.as_deref())
 }
 
+/// The `model_id` a query-side embedder will report for this host.
+///
+/// The companion stamps `model_id` with the model alias, so the alias is the
+/// same key the `embeddings` rows are written under. A federated read compares
+/// this against each workspace's indexed models [ORB-11027].
+pub fn query_model_id(model: Option<&str>) -> Result<String, OrbitError> {
+    resolve_query_model(model).map(|spec| spec.alias.to_string())
+}
+
 pub(crate) fn active_model(paths: &CompanionPaths) -> Option<String> {
     fs::read_to_string(&paths.active_model_path)
         .ok()

--- a/crates/orbit-search/src/lib.rs
+++ b/crates/orbit-search/src/lib.rs
@@ -44,8 +44,9 @@ pub use commands::{
     SemanticIndexResult, SemanticInstallParams, SemanticInstallResult, SemanticReindexParams,
     SemanticReindexResult, SemanticRelatedParams, SemanticRelatedResult, SemanticSearchParams,
     SemanticSearchResult, SemanticStatsResult, SemanticUninstallParams, SemanticUninstallResult,
-    TaskIndexResult, doc_index, doc_semantic_search, semantic_index, semantic_install,
-    semantic_reindex, semantic_related, semantic_search, semantic_stats, semantic_uninstall,
+    TaskIndexResult, doc_index, doc_semantic_search, query_model_id, semantic_index,
+    semantic_install, semantic_reindex, semantic_related, semantic_search, semantic_stats,
+    semantic_uninstall,
 };
 pub use companion::{
     CompanionPaths, INSTALL_REMEDIATION, locate_companion, platform_companion_filename, platform_id,

--- a/crates/orbit-search/src/vector/store/queries.rs
+++ b/crates/orbit-search/src/vector/store/queries.rs
@@ -1,5 +1,6 @@
 //! Read/cascade operations over the index.
 //!
+//! `model_ids` reports the distinct embedding models present in the index.
 //! `delete_source` cascades both the vector rows and the FTS5 rows for a
 //! given `(source_kind, source_id)`. `stats` aggregates row counts by
 //! `(source_kind, model_id)` and counts orphaned `task` rows whose
@@ -30,6 +31,29 @@ impl VectorStore {
             source_ids.insert(row.map_err(|error| OrbitError::Store(error.to_string()))?);
         }
         Ok(source_ids)
+    }
+
+    /// Distinct embedding `model_id` values present in this index.
+    ///
+    /// Cosine scores are only comparable within one model, so a federated read
+    /// consults this before claiming a workspace's vectors participate in a
+    /// fused ranking [ORB-11027].
+    pub fn model_ids(&self) -> Result<BTreeSet<String>, OrbitError> {
+        let conn = self.connection();
+        let conn = conn
+            .lock()
+            .map_err(|error| OrbitError::Store(format!("mutex poisoned: {error}")))?;
+        let mut stmt = conn
+            .prepare("SELECT DISTINCT model_id FROM embeddings")
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let mut model_ids = BTreeSet::new();
+        for row in rows {
+            model_ids.insert(row.map_err(|error| OrbitError::Store(error.to_string()))?);
+        }
+        Ok(model_ids)
     }
 
     pub fn delete_source(&self, source_kind: &str, source_id: &str) -> Result<(), OrbitError> {

--- a/crates/orbit-tools/src/builtin/orbit/search.rs
+++ b/crates/orbit-tools/src/builtin/orbit/search.rs
@@ -83,6 +83,25 @@ impl Tool for OrbitSearchTool {
                 param_type: "string".to_string(),
                 required: false,
             },
+            ToolParam {
+                // ORB-11027: the federated scope, deliberately not named
+                // `workspace` — that is the reserved routing selector that
+                // binds a call to one registered checkout.
+                name: "workspaces".to_string(),
+                description:
+                    "Federated scope: registered workspace names, `ws_*` IDs, or absolute checkout paths to search together. Hits carry workspace attribution. Omit to search only the bound workspace."
+                        .to_string(),
+                param_type: "string_list".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "all_workspaces".to_string(),
+                description:
+                    "Search every active workspace registered on the answering machine. Overrides `workspaces`. Not available inside an Orbit-managed run."
+                        .to_string(),
+                param_type: "boolean".to_string(),
+                required: false,
+            },
         ];
         parameters.extend(super::model_identity_params());
         ToolSchema {

--- a/crates/orbit-tools/src/builtin/orbit/tests/search.rs
+++ b/crates/orbit-tools/src/builtin/orbit/tests/search.rs
@@ -22,3 +22,20 @@ fn search_schema_uses_hybrid_and_semantic_task_id_params() {
     assert!(!params.iter().any(|(name, _)| *name == "field"));
     assert!(!params.iter().any(|(name, _)| *name == "embedding_model"));
 }
+
+#[test]
+fn search_schema_exposes_federated_scope_without_shadowing_the_routing_selector() {
+    let schema = OrbitSearchTool.schema();
+    let params = schema
+        .parameters
+        .iter()
+        .map(|param| (param.name.as_str(), param.param_type.as_str()))
+        .collect::<Vec<_>>();
+
+    // ORB-11027: the scope is `workspaces`; `workspace` stays reserved for the
+    // MCP routing selector, which `orbit-mcp` injects on every
+    // workspace-scoped tool.
+    assert!(params.contains(&("workspaces", "string_list")));
+    assert!(params.contains(&("all_workspaces", "boolean")));
+    assert!(!params.iter().any(|(name, _)| *name == "workspace"));
+}

--- a/docs/design/orbit-search/1_overview.md
+++ b/docs/design/orbit-search/1_overview.md
@@ -77,6 +77,7 @@ The shipped index covers tasks plus explicitly indexed docs, including ADR desig
 | FTS5 + cosine + RRF hybrid pipeline | [2_design.md §5](./2_design.md), [Hybrid retrieval (FTS5 BM25 + cosine, fused via RRF) from day one](./4_decisions.md#hybrid-retrieval-fts5-bm25-cosine-fused-via-rrf-from-day-one) | [T20260510-10] |
 | `orbit semantic install/uninstall` CLI | [2_design.md §6.1](./2_design.md) | [T20260510-9] |
 | `orbit search` CLI + MCP | [2_design.md §6](./2_design.md) | [T20260510-10] |
+| Cross-workspace federated read + scope selector | [2_design.md §6.4](./2_design.md), [Federate the cross-workspace read; deny it inside a managed run](./4_decisions.md#federate-the-cross-workspace-read-deny-it-inside-a-managed-run) | [ORB-11027] |
 | Index-on-mutation + index command | [2_design.md §7](./2_design.md) | [T20260510-9] |
 | Existing task store API | [crates/orbit-store/src/file/task_store/v2/](../../../crates/orbit-store/src/file/task_store/v2/) | — |
 | Concerns & honest limitations | [2_design.md §8](./2_design.md) | [T20260510-3] |
@@ -90,5 +91,6 @@ The shipped index covers tasks plus explicitly indexed docs, including ADR desig
 - [T20260510-3] — Design semantic search over task artifacts and graph (v2). The task that produced this folder.
 - [T20260510-9] — Phase-1 foundation: `orbit-embed` + `orbit-embed-companion` crates, indexing pipeline, install command.
 - [T20260510-10] — Phase-1 retrieval: hybrid query, CLI search/related, MCP tools.
+- [ORB-11027] — Cross-workspace federated search with a workspace scope selector.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/orbit-search/2_design.md
+++ b/docs/design/orbit-search/2_design.md
@@ -3,7 +3,7 @@ summary: "Semantic Search — Design"
 type: design
 title: "Semantic Search — Design"
 owner: claude
-last_updated: 2026-08-13
+last_updated: 2026-08-24
 last_validated: 2026-08-09
 status: Accepted
 feature: orbit-search
@@ -13,7 +13,7 @@ tags: ["orbit-search"]
 
 # Semantic Search — Design
 
-This document specifies the semantic-search implementation: the `orbit-search` crate and its optional companion binary, the companion-binary inference model, the SQLite vector storage schema, the per-field embedding strategy, the hybrid (BM25 + cosine) retrieval pipeline, the MCP and CLI surface, the index-maintenance lifecycle, and the concerns the design deliberately leaves to follow-ups.
+This document specifies the semantic-search implementation: the `orbit-search` crate and its optional companion binary, the companion-binary inference model, the SQLite vector storage schema, the per-field embedding strategy, the hybrid (BM25 + cosine) retrieval pipeline, the MCP and CLI surface, cross-workspace federated read, the index-maintenance lifecycle, and the concerns the design deliberately leaves to follow-ups.
 
 ---
 
@@ -253,6 +253,7 @@ Either retriever alone has a failure mode the other doesn't. RRF resolves both a
 orbit semantic install   [--model bge-small | minilm-l6 | nomic-v1.5] [--force]
 orbit semantic uninstall [--model MODEL] [--all]
 orbit search <query> [--hybrid] [--kind task|doc|all] [--limit N]
+                     [--workspace SELECTOR]... [--all-workspaces]
 orbit search similar <task-id> [--limit N]
 orbit search path <path> [--kind task|doc|all] [--limit N]
 orbit semantic index     [--force] [--model MODEL] [--kind tasks|docs|all]
@@ -268,9 +269,11 @@ orbit semantic stats
 
 If the companion is not installed, task-hybrid search, `orbit search similar <task-id>`, `orbit semantic index`, and `orbit docs index` exit non-zero with: `"Semantic search not enabled. Run \`orbit semantic install\` to download the inference companion."` Doc-hybrid search is softer: it emits a warning/note and falls back to lexical doc results.
 
+`--workspace` and `--all-workspaces` select the federated scope described in [§6.4](#64-cross-workspace-federated-search). They apply to the free-text form only; `similar` and `path` are single-workspace by construction.
+
 ### 6.2 MCP tools
 
-- `orbit.search` — `(query?, hybrid?, semantic?, kind?, limit?, tag?, all?, status?, path?)` → ranked results with snippets.
+- `orbit.search` — `(query?, hybrid?, semantic?, kind?, limit?, tag?, all?, status?, path?, workspaces?, all_workspaces?)` → ranked results with snippets.
 - `orbit.semantic.install`, `orbit.semantic.uninstall`, `orbit.semantic.stats`, `orbit.semantic.index` — companion lifecycle.
 - `orbit.docs.index` — docs-corpus embedding build and stale-source sweep.
 
@@ -295,6 +298,56 @@ If the companion is not installed, task-hybrid search, `orbit search similar <ta
 ```
 
 The score breakdown is deliberately exposed: agents can use it to decide whether a hit is "lexical exact match" vs. "semantic neighborhood" and adapt downstream behavior.
+
+### 6.4 Cross-workspace federated search
+
+Vectors and FTS rows stay workspace-local ([§3](#3-vector-storage)); only the *read* federates. One query may cover several registered checkouts, and Orbit opens each one's `semantic.db`, runs the ordinary single-workspace query there, and fuses the ranked lists. See [Federate the cross-workspace read; deny it inside a managed run](./4_decisions.md#federate-the-cross-workspace-read-deny-it-inside-a-managed-run) for why the index is not centralized instead.
+
+**Scope selector.** `WorkspaceScope` has three states: `Current` (default), `Selectors([..])`, and `AllRegistered`. `Current` takes the untouched single-workspace path, so an existing caller sees identical results and an identical JSON shape — the two federated fields are `skip_serializing_if` empty/`None`.
+
+**Layering.** `orbit-core` may not depend on `orbit-registry`, so the fan-out splits across two crates:
+
+| Owner | Responsibility |
+|-------|----------------|
+| `orbit-core` (`application/search/federated.rs`) | fan-out, fusion, attribution, notes, caps, the managed-run refusal |
+| `orbit-cmd` (`workspace_catalog.rs`) | `WorkspaceCatalog` impl: selector → registered checkout, and opening a runtime for one |
+
+`OrbitRuntime::with_workspace_catalog` attaches the implementation, mirroring `with_coordination_write_owner`. A runtime built without one still works and refuses any scope wider than its own checkout.
+
+**Fusion is by rank, not by score.** Per-workspace hits are interleaved by their position in their own workspace's ranked list, reusing the round-robin merge that already balances kinds. Lexical BM25 scores, blended hybrid scores, and `None` (frictions) are not commensurable across workspaces, so nothing compares them — and one large workspace cannot consume the whole `limit`.
+
+**Model compatibility.** Cosine scores only compare within one `model_id`. A workspace whose index was built under a different model has no rows the query embedder can score, so it degrades to lexical there; the response says so by name rather than emitting a ranking the caller cannot tell apart from a fused one:
+
+```
+[polaris] semantic index uses model(s) minilm-l6, not the query model bge-small;
+          cosine scores are not fused for this workspace and it contributes
+          lexical hits only
+```
+
+**Attribution is mandatory.** Every federated hit carries `workspace: {workspace_id, name, repo_root}`. Task IDs are globally unique and resolve through the host registry, but friction and job-run IDs are allocated per workspace, so the same ID names a different record in each. F2026-08-046 records a near-miss write to the wrong record from exactly that ambiguity in a merged result set.
+
+**Partial failure is normal.** A registered checkout can be stale, moved, or owned by another machine. Each such workspace contributes zero hits plus a note and appears in the `workspaces` report with `hits: 0`; the query still succeeds. Per-workspace notes are prefixed `[<name>]` so every note is attributed too.
+
+**No silent caps.** At most `MAX_FEDERATED_WORKSPACES` (16) checkouts are opened per query. Exceeding it adds a note naming both the cap and how many workspaces were dropped.
+
+**Sandbox posture.** A federated scope is refused inside an Orbit-managed run. Rationale in the decision record; the guard lives in `global_search` so CLI, MCP, `orbit tool run`, and the HTTP adapter all reach it through one rule.
+
+```jsonc
+{
+  "mode": "lexical",
+  "kind": "all",
+  "results": [
+    { "kind": "friction", "id": "F2026-07-013", "workspace":
+      { "workspace_id": "ws_orbit", "name": "orbit", "repo_root": "/…/orbit" } }
+  ],
+  "notes": ["[almanac] skipped: checkout for 'almanac' is gone"],
+  "workspaces": [
+    { "workspace_id": "ws_orbit", "name": "orbit", "hits": 4 },
+    { "workspace_id": "ws_almanac", "name": "almanac", "hits": 0,
+      "note": "skipped: checkout for 'almanac' is gone" }
+  ]
+}
+```
 
 ---
 

--- a/docs/design/orbit-search/4_decisions.md
+++ b/docs/design/orbit-search/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Semantic Search — Decisions"
 type: design
 title: "Semantic Search — Decisions"
 owner: claude
-last_updated: 2026-08-13
+last_updated: 2026-08-24
 last_validated: 2026-08-09
 status: Accepted
 feature: orbit-search
@@ -403,6 +403,47 @@ Phase 1 ships option C. Two new crates:
 
 ---
 
+## Federate the cross-workspace read; deny it inside a managed run
+
+**Recorded:** 2026-08-24 · [ORB-11027]
+**Paths:** `crates/orbit-core/src/application/search/federated.rs`, `crates/orbit-core/src/runtime/workspace_catalog.rs`, `crates/orbit-cmd/src/workspace_catalog.rs`
+
+### Context
+
+`orbit search` was single-workspace: `GlobalSearchKind` is global across *kinds*, not across workspaces, and vectors plus FTS live in one `<repo>/.orbit/state/semantic.db` per workspace ([Workspace-local semantic DB separate from global audit/tool DB](#workspace-local-semantic-db-separate-from-global-audittool-db)). Answering "have we thought about X before" across polaris, almanac, constellation, and the code workspaces meant running the same query N times by hand and merging by eye.
+
+Three shapes were available:
+
+1. **Centralize the store** — move the index to a host-global `~/.orbit/semantic.db`.
+2. **Federate the read** — keep per-workspace indexes; open the registered checkouts and fuse.
+3. **Leave it to the caller** — keep N calls, document the merge.
+
+Option 1 was assessed and rejected in ORB-11001. It breaks the sandbox boundary: the v2 host allow-lists `{workspace}/state/semantic.db*` per run, so a host-global index would hand every sandboxed agent run — including one scoped to an unrelated code workspace — a handle on a file containing the personal vault, degrading a filesystem-level guarantee into a query-time filter. It also does not replicate: a per-workspace index travels with its checkout, a host-global DB does not. Option 3 is what F2026-08-046 already shows failing — merged cross-workspace results without attribution led to a near-miss write to the wrong friction record, because friction IDs are allocated per workspace and the same ID names a different record in each.
+
+Federating the read raises the same sandbox question in a different place, because the fan-out is in-process rather than through the filesystem allow-list: should a sandboxed agent run be able to ask for a multi-workspace scope at all?
+
+### Decision
+
+Federate the read. Each workspace keeps owning and writing its own `semantic.db`; a `WorkspaceScope` selector (`Current` | `Selectors` | `AllRegistered`) widens only the query.
+
+1. **Layering.** `orbit-core` owns fan-out, fusion, attribution, notes, and caps; it takes a registry-neutral `WorkspaceCatalog` seam supplied by `orbit-cmd`, which already joins Core to Registry. No new crate edge.
+2. **Fuse by rank, never by raw score.** Per-workspace hits interleave by position in their own workspace's ranked list, reusing the round-robin merge that already balances kinds. Lexical, hybrid, and absent scores are not commensurable across workspaces.
+3. **Attribution is part of the hit.** Every federated hit carries `workspace: {workspace_id, name, repo_root}`, so the F2026-08-046 defect does not move in-tree along with the merge logic.
+4. **Model mismatch is a named note.** A workspace indexed under a different `model_id` contributes lexical hits only, and the response says so instead of emitting a ranking the caller cannot tell apart from a fused one.
+5. **Sandbox posture: deny.** A federated scope is refused inside an Orbit-managed run. Denying the *scope* rather than widening the per-run allow-list keeps the in-process read and the filesystem grant consistent: a run may read exactly the index it may write. The traded capability — an agent asking one question of the whole corpus mid-run — stays available to the human and operator surfaces that are not inside a run. The alternative, an enumerated allow-list of "safe" workspaces per run, was rejected as a second authorization system whose default would be wrong the first time a new personal workspace was registered.
+6. **Default is untouched.** `Current` takes the existing single-workspace path; both new response fields are omitted from JSON when empty.
+
+### Consequences
+
+- One `orbit search --all-workspaces` answers across the whole corpus, and each hit names the workspace a follow-up read or write should target.
+- Rank-interleaved fusion means a large workspace cannot consume the budget, and no cosine score is ever compared across a model boundary.
+- A missing, stale, or unreadable index degrades one workspace to zero hits with a note instead of failing the query — the normal case for a machine with several registered checkouts.
+- The `WorkspaceCatalog` seam gives any future cross-workspace read the same registry-neutral shape without pulling Registry under Core.
+- Cost: an agent inside a managed run cannot search other workspaces, so cross-workspace recall stays a human/orchestrator step. If that becomes load-bearing, the follow-up is an explicit per-run scope grant carried in the run's own record — not a widened default.
+- Cost: at most 16 workspaces are opened per query. The cap is announced in the response, so a machine that outgrows it sees the truncation rather than silently narrowed recall.
+- Cost: opening a target goes through the ordinary `RegisteredRuntimeFactory::open_registered_checkout`, which runs the same layout pre-flight any `orbit --workspace X` invocation does. A federated *read* can therefore apply a pending layout upgrade to another checkout. That is the established open path rather than a new one, and the managed-run denial keeps it out of agent runs; a genuinely read-only runtime open would be the fix if it ever matters.
+- Cost: `workspaces` and `all_workspaces` join the `orbit.search` parameter surface and the search response shape that [Expose unified search through a thin HTTP adapter](#expose-unified-search-through-a-thin-http-adapter) made a compatibility contract. `workspaces` is deliberately distinct from the reserved `workspace` routing selector; the two are easy to confuse and are documented against each other in both help texts.
+
 ## Task References
 
 - [T20260510-3] — Design semantic search over task artifacts and graph (v2). The task that produced this folder.
@@ -416,5 +457,6 @@ Phase 1 ships option C. Two new crates:
 - [ORB-00205] — Split `orbit search` into query / similar / path forms and require per-kind `--status` syntax. The task that accepted and implemented [Split orbit search modes and require per-kind statuses](#split-orbit-search-modes-and-require-per-kind-statuses).
 - [ORB-00206] — Add doc-corpus embeddings through `orbit docs index` and `orbit search --kind doc --hybrid`. The task that accepted and implemented [Doc corpus embeddings use `docs index` and opt-in hybrid search](#doc-corpus-embeddings-use-docs-index-and-opt-in-hybrid-search).
 - [ORB-10304] — Expose unified lexical, hybrid, and neighbor search through `GET /api/search`.
+- [ORB-11027] — Cross-workspace federated search with a workspace scope selector. The task that accepted and implemented [Federate the cross-workspace read; deny it inside a managed run](#federate-the-cross-workspace-read-deny-it-inside-a-managed-run).
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-11027](https://orbit-cli.com/tasks/ORB-11027) — Cross-workspace federated search with a workspace scope selector

### Description

## Problem

`orbit search` is single-workspace. `GlobalSearchKind` is "global" across *kinds* (`Task | Doc | Friction | All`), not across workspaces, and vectors plus FTS live in one `<repo>/.orbit/state/semantic.db` per workspace. There is no way to ask one question of the whole corpus.

That is the concrete limit behind ORB-11001 (ws_almanac): personal/agent memory is spread across polaris, almanac, constellation and the code workspaces, and answering "have we thought about X before" means running the same query N times by hand and merging the results in your head.

## Approach: federate the read, do not centralize the store

The considered alternative was moving the index to a single host-global `~/.orbit/semantic.db`. That was assessed and rejected in ORB-11001 for reasons that should be preserved here:

- **Sandbox boundary.** Orbit's v2 host allow-lists `{workspace}/state/semantic.db*` per run (`crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs:233`). A host-global index would hand every sandboxed agent run — including one scoped to an unrelated code workspace — a handle on a file containing the personal vault. A filesystem-level guarantee would degrade into a query-time filter.
- **Portability.** A per-workspace index travels with its checkout across machines; a host-global DB does not replicate.
- **Cost.** At this corpus size (~290 personal docs plus per-repo task/doc corpora) N sqlite opens per query is not a real cost, and RRF fusion over ranked lists already exists in-tree for lexical + cosine — fusing N workspace result sets is the same operation.

So: keep each workspace owning and writing its own `semantic.db`; make the read path open the registered checkouts and fuse.

## Scope selector

Add a way to say which workspaces a query covers, on both the CLI (`--workspace`) and the MCP tool surface. Shape to settle during design: a list of selectors, plus some form of "everything registered on this machine". Registered checkouts come from the workspace registry — the same source `orbit_workspace_list` serves.

Default with no selector stays exactly as today: one workspace, same results, same shape.

## Attribution is a hard requirement, not a nicety

`GlobalSearchHit` has no workspace field today. Friction **F2026-08-046** (ws_orbit) records what happens when merged cross-workspace results lack it: a near-miss silent write to the wrong record, because friction ids are allocated per workspace and `F2026-07-013` names a different record in each workspace that has one. The caller took ids from a merged result set and had no way to tell which workspace each came from.

That friction is currently attributed to bridge's own HTTP-backed merge extension, on the grounds that orbit-core has no cross-workspace merge logic of its own. **This task creates exactly that logic in core.** If hits ship without workspace attribution, the defect moves in-tree and becomes Orbit's. Task ids are globally unique and resolve through the host registry; friction ids and job-run ids are not. Attribution has to cover the kinds where ids do not disambiguate.

Worth reading that friction in full before designing the hit shape, and worth deciding whether it can be closed or re-scoped once this lands.

## Sandbox decision to make explicitly

Federated read from inside a sandboxed agent run needs a deliberate answer, because the current per-run allow-list permits only that run's own workspace index. Options include denying multi-workspace scope inside sandboxed runs entirely, permitting it only for an explicitly enumerated set, or extending the allow-list. Whichever is chosen, write down why — the personal vault being reachable from an unrelated code workspace's run is the thing being traded.

## Other design constraints

- **Model compatibility.** Cosine scores compare only within one `model_id`. Workspaces indexed with different embedding models cannot be fused on cosine; surface that as an explicit note rather than emitting a plausible-looking bad ranking. Lexical fusion has no such constraint.
- **Partial failure is normal.** Not every registered workspace has an index, and some are stale or belong to another machine. A missing or unreadable index degrades to zero hits for that workspace with a note; it must not fail the query.
- **Result budgeting.** `limit` currently round-robins across kinds. Decide how it interacts with a second fan-out dimension so one large workspace cannot crowd out the rest.
- **No silent caps.** If the implementation bounds how many workspaces it will open, say so in the response.

## Related

- ORB-11001 (ws_almanac) — assessment that produced this recommendation; step 2 of its sequence, and load-bearing per its Finding 4 since no docs-config change can span two repos from the umbrella.
- F2026-08-046 (ws_orbit) — the attribution defect this must not reproduce in core.
- ORB-11025 (ws_orbit) — lets an explicitly configured docs root escape the gitignore filter. Independent of this task; the two together cover both "index the right things" and "query them all at once".

### Acceptance Criteria

- A single `orbit search` / `orbit.search` call can query more than one registered workspace and returns hits fused into one ranked list
- Every hit in a multi-workspace result carries explicit workspace attribution, so a caller can route a follow-up read or write to the right workspace without guessing
- Default behavior is unchanged: with no scope selector supplied, exactly one workspace is queried and existing single-workspace callers see identical results
- Cosine scores are only fused across workspaces whose indexes share a `model_id`; a mismatch produces an explicit note in the response rather than a silently mis-ranked list
- The sandbox posture for a federated read from inside an agent run is decided and implemented deliberately — either denied, or permitted via an allow-list change that is written down with its rationale — not left to whatever the current per-workspace rule happens to do
- A workspace whose index is missing, stale, or unreadable degrades that workspace to no hits with a note, and does not fail the whole query

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented cross-workspace federated search. The read federates; each workspace
keeps owning and writing its own `semantic.db`.

## Shape

`orbit-core` may not depend on `orbit-registry`, so the fan-out splits over a
registry-neutral seam:

- **`crates/orbit-core/src/runtime/workspace_catalog.rs`** (new) — `WorkspaceScope`
  (`Current` | `Selectors` | `AllRegistered`), `FederatedWorkspaceTarget` (plain
  data: id, name, repo_root), and the `WorkspaceCatalog` trait
  (`resolve_scope` + `open`). `OrbitRuntime::with_workspace_catalog` attaches an
  impl, mirroring `with_coordination_write_owner`. Two trait methods rather than
  one so a single unopenable checkout degrades that workspace, not the query.
- **`crates/orbit-core/src/application/search/federated.rs`** (new) — fan-out,
  fusion, attribution, notes, cap, and the sandbox refusal.
- **`crates/orbit-cmd/src/workspace_catalog.rs`** (new) — `RegistryWorkspaceCatalog`.
  Attached at every `RegisteredRuntimeFactory` open site, so CLI, `orbit tool run`,
  and the MCP server all get the capability. **No new crate edge**; orbit-cmd
  already joins Core to Registry.

`global_search` now dispatches: `Current` → the untouched `workspace_search`;
anything wider → `federated_search`.

## Acceptance criteria

1. **One call, many workspaces, one ranked list** — `orbit search --workspace a,b`
   / `--all-workspaces`; tool params `workspaces` / `all_workspaces`. Verified live
   against the real machine registry.
2. **Attribution on every hit** — `GlobalSearchHit.workspace = {workspace_id, name,
   repo_root}`. Plus a `workspaces` report so "returned nothing" is distinguishable
   from "was never asked". This is the F2026-08-046 defect not moving in-tree.
3. **Default unchanged** — `Current` takes the old path; both new fields are
   `skip_serializing_if` empty/`None`, asserted on the serialized JSON.
4. **Model compatibility** — new `orbit_search::query_model_id()` and
   `VectorStore::model_ids()`. A workspace indexed under a different `model_id`
   gets a named note and contributes lexical hits only. More fundamentally,
   **fusion is by rank, never raw score**: hits interleave by position in their own
   workspace's list (reusing `merge_round_robin`), so no cosine/BM25 score is ever
   compared across a workspace boundary, and a large workspace cannot eat the budget.
5. **Sandbox posture — decided: deny.** A federated scope is refused inside an
   Orbit-managed run. Rationale (written into `4_decisions.md`): the v2 host
   allow-lists only the run's own `state/semantic.db*`, so an in-process federated
   read would hand a run scoped to an unrelated code workspace a handle on every
   registered index including the personal vault — turning a filesystem guarantee
   into a query-time filter. Denying the *scope* keeps read and write grants
   consistent: a run reads exactly the index it may write. Enforced once in
   `global_search` (the authoritative boundary), so CLI/MCP/tool/HTTP all inherit it.
   Rejected alternative (per-run allow-list) recorded.
6. **Partial failure** — unopenable/stale/unreadable → 0 hits + note, query
   succeeds. Sub-workspace notes are prefixed `[<name>]`. Verified live: 8
   unreadable workspaces degraded to notes while polaris + orbit returned hits.

Also: `MAX_FEDERATED_WORKSPACES = 16`, never silent — truncation adds a note
naming the cap and the number dropped. Neighbor (`semantic`) and `path` lookups
reject a federated scope in core (single-workspace by construction), so the CLI
carries no duplicate client-side rule.

## Files beyond the original context_files, and why

- `crates/orbit-core/src/runtime/{mod.rs,workspace_catalog.rs}` — the seam has to
  live in `runtime`; `application` may import it but not vice versa.
- `crates/orbit-core/src/lib.rs`, `crates/orbit-cmd/src/lib.rs`,
  `crates/orbit-cmd/src/tests/mod.rs`, `.../search/tests/mod.rs` — re-exports and
  module registration required to compile.
- `crates/orbit-search/src/{lib.rs,commands/mod.rs,vector/store/queries.rs}` —
  the model-identity read for criterion 4; no equivalent existed.
- `crates/orbit-core/src/application/search/{convert.rs,tests/hybrid.rs}` — the new
  `GlobalSearchHit` field is required in every existing literal.
- `crates/orbit-cli/tests/snapshots/mcp_tools_list.json`,
  `crates/orbit-cli/tests/output_goldens/tool_list.json` — regenerated for the two
  added params. **Release note: RELEASING.md treats any `tools/list` drift as
  breaking.** The diff is strictly additive (two optional params on `orbit.search`;
  the reserved `workspace` routing selector is untouched) — call it at release.
- `docs/design/orbit-search/{1_overview,2_design,4_decisions}.md` — same-PR doc rule.

## Naming decision

The tool-surface scope is `workspaces`, deliberately **not** `workspace`:
`orbit-mcp/src/adapter/schema.rs` injects `workspace` as the routing selector on
every workspace-scoped tool, and `registry_runtime::bind_cli_tool_workspace`
rebinds on it. Reusing the name would have collided. Documented against each
other in both help texts. The CLI keeps `--workspace` per the task description;
its help contrasts it with the top-level `orbit --workspace` binder.

## Validation

- `make ci-fast` — pass. `make ci-lint` — pass (workspace-wide clippy, `-D warnings`).
- `cargo test -p orbit-core -p orbit-cmd -p orbit-tools -p orbit-search -p orbit-cli
  -p orbit-web` — **1693 passed, 0 failed**.
- 16 new tests: 11 in `application/search/tests/federated.rs` (fusion+attribution,
  small-workspace-not-crowded-out, degradation, no-catalog refusal, empty scope,
  cap note, model mismatch, managed-run denial, neighbor/path rejection, scope
  parsing, default-shape JSON contract), 5 in `orbit-cmd/src/tests/workspace_catalog.rs`
  (active-only, dedupe, fail-closed selector), 1 tool-schema test.
- Live end-to-end verified against the real registry, both the denial inside this
  managed run and the happy path with the run env cleared.

## Follow-ups (not done, deliberately)

- `orbit-web`'s `GET /api/search` compiles unchanged and defaults to `Current`.
  Exposing the scope there would let bridge retire the HTTP-backed merge that
  F2026-08-046 is filed against — but that is bridge's call and orbit-web was not
  in scope.
- F2026-08-046 can now be re-scoped or closed: core owns the merge and attributes it.
- Filed **F2026-08-129**: `cargo test` inside a job run inherits
  `ORBIT_MANAGED_RUN_CONTEXT`, so env-gated guards flip under test. Handled here
  with a `#[cfg(test)]` thread-local override (`in_managed_run` /
  `with_managed_run_override`) rather than env mutation.
- Recorded as a cost in the decision record: opening a target uses the ordinary
  `open_registered_checkout`, which runs the same layout pre-flight any
  `orbit --workspace X` does, so a federated read can apply a pending layout
  upgrade to another checkout. Established path, not a new one; the managed-run
  denial keeps it out of agent runs.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11027-6a8ba31a`
- Behind base: 0
- Ahead of base: 1