### PR TITLE
Harden the Official MCP Registry install and launch experience

### DIFF
--- a/.github/workflows/smoke-npm-install.yml
+++ b/.github/workflows/smoke-npm-install.yml
@@ -43,6 +43,16 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Validate MCP Registry metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="$(mktemp)"
+          trap 'rm -f "$archive"' EXIT
+          curl -LsSf "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" -o "$archive"
+          tar xzf "$archive" mcp-publisher
+          ./mcp-publisher validate server.json
+
       - name: Run npm install smoke
         shell: bash
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbit-agent"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cli"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cmd"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "chrono",
  "fs2",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-common"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "chrono",
  "fs2",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-config"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "orbit-common",
  "orbit-types",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-core"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "chrono",
  "croner",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-engine"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-exec"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "libc",
  "orbit-common",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-mcp"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-policy"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-registry"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "chrono",
  "hostname",
@@ -2305,7 +2305,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-search"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-store"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-tools"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2369,7 +2369,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-types"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2386,7 +2386,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-web"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 license = "MIT"
 # MSRV [ORB-10010]: edition 2024 requires >= 1.85; the highest `rust-version`

--- a/README.md
+++ b/README.md
@@ -248,8 +248,11 @@ execute on the accepting server through Orbit Core.
 Workspace-scoped tools accept a registered workspace name, logical `ws_*` ID, or
 absolute path registered on the accepting server. The selector may come from the
 tool's `workspace` argument or MCP initialize metadata; server process cwd is not
-a fallback. `orbit.workspace.list` is global and reports active workspaces that
-have a checkout registered on that machine.
+a fallback. An unbound client should first call `orbit_workspace_list`, then
+reuse a returned `ws_*` ID on workspace-scoped calls. If the list is empty, set
+up the machine with `orbit init` and then run `orbit workspace init` from the
+project directory. `orbit.workspace.list` is global and reports active
+workspaces that have a checkout registered on that machine.
 
 ### Federated MCP
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -105,13 +105,14 @@ Surface the breaking-change candidate list before drafting the final section. Sh
 
 ### 4. Bump versions
 
-Three files change every release:
+Four files change every release:
 
 | File | Field |
 |------|-------|
 | `Cargo.toml` | `[workspace.package].version` |
 | `Cargo.lock` | refresh via `cargo update --workspace` (no third-party drift) |
 | `npm/package.json` | `version` |
+| `server.json` | top-level `version` and `packages[0].version` |
 
 The other `0.X.Y` matches in the repo (install-script doc comments, the website task pages, the Node engine pin in `website/package-lock.json`) are intentional — leave them.
 
@@ -123,7 +124,7 @@ make build
 
 Must finish clean. `cargo update --workspace` should report only Orbit workspace members re-locked — investigate any third-party version movement before continuing.
 
-If this cycle changed any CLI the npm-install smoke drives (`orbit init`, `workspace init`, or `mcp serve`), update [`scripts/smoke-npm-install.sh`](scripts/smoke-npm-install.sh) on the **same commit as the tag**. The on-tag workflow checks out that script and then runs `@orbit-tools/cli@latest` from npm — a post-tag script fix cannot green a tag-triggered run. Details and the post-npm triage live in [docs/runbooks/release.md](docs/runbooks/release.md#npm-install-smoke-two-artifacts).
+If this cycle changed any CLI the npm-install smoke drives (`orbit init`, `workspace init`, or `mcp serve`), update [`scripts/smoke-npm-install.sh`](scripts/smoke-npm-install.sh) on the **same commit as the tag**. The on-tag workflow checks out that script and `server.json`, then runs the exact npm package version declared by the metadata — a post-tag script or metadata fix cannot green a tag-triggered run. Details and the post-npm triage live in [docs/runbooks/release.md](docs/runbooks/release.md#npm-install-smoke-two-artifacts).
 
 The tag-triggered npm-install smoke must be treated as a versioned check: it
 fails when the installed `@orbit-tools/cli` version does not equal the tag
@@ -148,10 +149,11 @@ context_files:
   - file:Cargo.toml
   - file:Cargo.lock
   - file:npm/package.json
+  - file:server.json
   - file:scripts/smoke-npm-install.sh
 ```
 
-Acceptance criteria: Cargo and npm report the new version, Cargo.lock is refreshed without third-party drift, the CHANGELOG section is in place with the agreed structure, every confirmed breaking change appears under Breaking Changes, and the npm-install smoke script still drives this cycle's CLI non-interactively.
+Acceptance criteria: Cargo, npm, and `server.json` report the new version, Cargo.lock is refreshed without third-party drift, the CHANGELOG section is in place with the agreed structure, every confirmed breaking change appears under Breaking Changes, and the npm-install smoke script still drives this cycle's CLI non-interactively.
 
 ### 7. Human approval
 

--- a/crates/orbit-cli/src/command/mcp/server.rs
+++ b/crates/orbit-cli/src/command/mcp/server.rs
@@ -176,7 +176,11 @@ impl ServerMcpHost {
 
     fn workspace_required(&self, name: &str) -> OrbitError {
         OrbitError::InvalidInput(format!(
-            "tool '{name}' requires a workspace selector; pass `workspace` in the tool call or MCP initialize metadata"
+            "tool '{name}' requires an explicit workspace selector; first call \
+             `orbit_workspace_list` and reuse a returned `ws_*` ID as `workspace`. \
+             If no workspace is listed, run `orbit init` and then `orbit workspace init` \
+             from the project directory. A selector may also be passed in MCP initialize \
+             metadata; Orbit never infers one from the server process cwd"
         ))
     }
 

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -818,8 +818,11 @@ fn mcp_serve_lists_the_canonical_surface_outside_any_checkout() {
     // is unbound and must stay fail-closed [ORB-10967].
     let unscoped = client.call_tool_err("orbit_task_list", json!({}));
     assert!(unscoped["message"].as_str().is_some_and(|message| {
-        message.contains("requires a workspace selector")
-            && message.contains("MCP initialize metadata")
+        message.contains("requires an explicit workspace selector")
+            && message.contains("orbit_workspace_list")
+            && message.contains("returned `ws_*` ID")
+            && message.contains("orbit workspace init")
+            && message.contains("never infers one from the server process cwd")
     }));
     let description = tool_workspace_description(&listed, "orbit_task_list");
     assert!(
@@ -865,6 +868,79 @@ fn mcp_serve_lists_the_canonical_surface_outside_any_checkout() {
             .is_some_and(|id| id.starts_with("trace-"))
     );
     assert_eq!(audited.3, audited.4);
+}
+
+#[test]
+fn uninitialized_unbound_mcp_launch_gives_setup_guidance_without_operator_authority() {
+    let registry_metadata = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../server.json");
+    let registry: Value = serde_json::from_str(
+        &std::fs::read_to_string(&registry_metadata).expect("read checked-in registry metadata"),
+    )
+    .expect("parse checked-in registry metadata");
+    assert_eq!(registry["name"], "io.github.danieljhkim/orbit");
+    assert_eq!(registry["packages"][0]["identifier"], "@orbit-tools/cli");
+    assert_eq!(
+        registry["packages"][0]["packageArguments"],
+        json!([
+            { "type": "positional", "value": "mcp" },
+            { "type": "positional", "value": "serve" }
+        ])
+    );
+    assert!(
+        !serde_json::to_string(&registry)
+            .expect("serialize registry metadata")
+            .contains("--operator"),
+        "the registry install path must not grant operator authority"
+    );
+
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let scratch = temp.path().join("scratch");
+    std::fs::create_dir_all(&home).expect("create clean home");
+    std::fs::create_dir_all(&scratch).expect("create non-workspace launch dir");
+
+    // This is the registry-launch shape: no workspace binding, no operator
+    // flag, and a cwd that cannot supply an ambient workspace.
+    let child = McpWorkspace::orbit_command(&scratch, &home)
+        .args(["mcp", "serve"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn clean registry-style MCP server");
+    let mut client = McpClient::new(child);
+    let initialized = client.request(
+        "initialize",
+        json!({
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": { "name": "registry-clean-launch", "version": "0" }
+        }),
+    );
+    assert_eq!(initialized["result"]["serverInfo"]["name"], "orbit-mcp");
+    client.notify("notifications/initialized");
+
+    let listed = client.request("tools/list", Value::Null);
+    assert!(
+        listed["result"]["tools"]
+            .as_array()
+            .is_some_and(|tools| tools
+                .iter()
+                .any(|tool| tool["name"] == "orbit_workspace_list")),
+        "the first routing tool must be available from a clean launch: {listed}"
+    );
+
+    let unscoped = client.call_tool_err("orbit_task_list", json!({}));
+    assert!(unscoped["message"].as_str().is_some_and(|message| {
+        message.contains("orbit_workspace_list")
+            && message.contains("returned `ws_*` ID")
+            && message.contains("orbit init")
+            && message.contains("orbit workspace init")
+            && message.contains("never infers one from the server process cwd")
+    }));
+
+    let workspaces = client.call_tool_ok("orbit_workspace_list", json!({}));
+    assert_eq!(workspaces["workspaces"], json!([]));
 }
 
 #[test]
@@ -2170,8 +2246,9 @@ fn task_show_is_global_by_default_across_tool_run_and_mcp() {
     assert_eq!(shown["id"], json!(task_id));
     let unscoped = client.call_tool_err("orbit_task_list", json!({}));
     assert!(unscoped["message"].as_str().is_some_and(|message| {
-        message.contains("requires a workspace selector")
-            && message.contains("MCP initialize metadata")
+        message.contains("requires an explicit workspace selector")
+            && message.contains("orbit_workspace_list")
+            && message.contains("orbit workspace init")
     }));
     drop(client);
 

--- a/crates/orbit-mcp/src/adapter/schema.rs
+++ b/crates/orbit-mcp/src/adapter/schema.rs
@@ -39,7 +39,9 @@ const UNBOUND_SESSION_SELECTOR_DESCRIPTION: &str = "Workspace selector for the a
      workspace ID (`ws_*`), or an absolute path registered on that server. Required in this \
      session, which is bound to no workspace, so a call that omits it is refused. Sessions \
      bound by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at \
-     initialize may omit it; never inferred from the server process cwd.";
+     initialize may omit it; first call `orbit_workspace_list` and reuse a returned `ws_*` ID. \
+     If none is listed, run `orbit init` and then `orbit workspace init` from the project \
+     directory. Never inferred from the server process cwd.";
 
 /// Federated callers copy the list token; they must not mint a v1 local form.
 const FEDERATED_SELECTOR_DESCRIPTION: &str = "Copy the `selector` field from federated `orbit.workspace.list` to address a workspace. \

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -48,7 +48,7 @@ date has passed or its `revoked_at` field is set.
 
 ## Steps to cut a release
 
-1. **Bump Cargo and npm together.**
+1. **Bump Cargo, npm, and MCP Registry metadata together.**
 
    - Update `[workspace.package].version` in
      [`Cargo.toml`](../../Cargo.toml).
@@ -56,6 +56,10 @@ date has passed or its `revoked_at` field is set.
      [`npm/package.json`](../../npm/package.json). The npm postinstall in
      [`npm/scripts/install-binary.js`](../../npm/scripts/install-binary.js)
      derives the GitHub binary tag from this version.
+   - Update the top-level `.version` and `.packages[0].version` in
+     [`server.json`](../../server.json). The registry metadata must reference
+     the npm package version that contains its matching `mcpName` ownership
+     marker; published npm versions are immutable.
    - Run `cargo update --workspace` to refresh `Cargo.lock` without
      third-party dependency drift.
 
@@ -64,8 +68,8 @@ date has passed or its `revoked_at` field is set.
 
 2. **Run `make release-check`.** Before the new npm package and GitHub Release
    exist, this normally reports only local-to-remote drift against the previous
-   version. Any Cargo-to-`npm/package.json` mismatch is a local error and must
-   be fixed before tagging.
+   version. Any Cargo, `npm/package.json`, or `server.json` mismatch is a local
+   error and must be fixed before tagging.
 
 3. **Keep the npm smoke current.** If this release changes any non-interactive
    command driven by
@@ -74,7 +78,8 @@ date has passed or its `revoked_at` field is set.
    update on the same commit as the tag.
 
 4. **Commit and merge the release preparation to `agent-main`.** Keep the
-   Cargo and npm version bumps, lockfile refresh, and any smoke update together.
+   Cargo, npm, and `server.json` version bumps, lockfile refresh, and any smoke
+   update together.
 
 5. **Tag the merge commit.**
 
@@ -129,11 +134,12 @@ date has passed or its `revoked_at` field is set.
 ## Continuous npm-install verification
 
 The `smoke-npm-install.yml` workflow runs on macOS and Ubuntu weekly, on every
-`v*` tag, and by manual dispatch. It executes
-`npx -y @orbit-tools/cli@latest --version`, thereby exercising the npm
-postinstall binary download and checksum/signature verification. It then
-initializes an isolated Orbit home and workspace and drives `orbit mcp serve`
-through JSON-RPC `initialize` and `tools/list`.
+`v*` tag, and by manual dispatch. It resolves the package and exact version from
+the checked-out `server.json`, then executes that version through `npx`, thereby
+exercising the npm postinstall binary download and checksum/signature
+verification. It then initializes an isolated Orbit home and workspace and
+drives the metadata-declared `mcp serve` command through JSON-RPC `initialize`
+and `tools/list`.
 
 The smoke runs against published artifacts, not the local package. Its pass
 criterion is that the installed version matches the requested tag when one is
@@ -148,18 +154,19 @@ The tag assertion can be tested without network access:
 
 ## Npm-install smoke: two artifacts
 
-The workflow checks out `scripts/smoke-npm-install.sh` from the trigger ref,
-while the script installs `@orbit-tools/cli@latest` from npm. Those are
-independently versioned until npm publication completes.
+The workflow checks out `scripts/smoke-npm-install.sh` and `server.json` from the
+trigger ref, while the script installs the exact package version declared by
+that metadata from npm. The checked-out release contract and published package
+are independently available until npm publication completes.
 
-| Trigger | Script comes from | CLI comes from |
+| Trigger | Script and metadata come from | CLI comes from |
 |---|---|---|
-| push of tag `vX.Y.Z` | that tag | npm `@latest` at run time |
-| `workflow_dispatch` | the selected ref | npm `@latest` at run time |
-| weekly cron | the default branch | npm `@latest` at run time |
+| push of tag `vX.Y.Z` | that tag | npm version declared by that tag's `server.json` |
+| `workflow_dispatch` | the selected ref | npm version declared by that ref's `server.json` |
+| weekly cron | the default branch | npm version declared by that branch's `server.json` |
 
-A green versioned smoke needs both a published `@latest` matching the tag and
-a script on the selected ref that speaks the CLI's current non-interactive
+A green versioned smoke needs the metadata-declared npm version to be published
+and a script on the selected ref that speaks the CLI's current non-interactive
 contract.
 
 If the post-publish smoke is red:
@@ -215,10 +222,12 @@ used together.
 
 - `[workspace.package].version` in `Cargo.toml`;
 - `.version` in `npm/package.json`;
+- the server name, package identity, launch arguments, and both version fields
+  in `server.json`;
 - `npm view @orbit-tools/cli version`, when npm is available;
 - the latest `gh release list -L 1` tag, when GitHub CLI access is available.
 
 Missing `npm` or `gh` skips that remote source with a stderr note. Local
-Cargo/npm drift always fails.
+Cargo/npm/registry-metadata drift always fails.
 
 <!-- ORB-10995 -->

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@orbit-tools/cli",
   "version": "0.15.0",
+  "mcpName": "io.github.danieljhkim/orbit",
   "description": "npm proxy for the Orbit CLI. Downloads the matching native binary from GitHub Releases on install and forwards all invocations.",
   "bin": {
     "orbit": "bin/orbit.js"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbit-tools/cli",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "mcpName": "io.github.danieljhkim/orbit",
   "description": "npm proxy for the Orbit CLI. Downloads the matching native binary from GitHub Releases on install and forwards all invocations.",
   "bin": {

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -12,6 +12,7 @@ cd "$repo_root"
 NPM_PKG="@orbit-tools/cli"
 CARGO_TOML="Cargo.toml"
 NPM_PACKAGE_JSON="npm/package.json"
+MCP_SERVER_JSON="server.json"
 
 require_bin() {
   local bin="$1"
@@ -23,7 +24,7 @@ require_bin() {
 
 require_bin jq
 
-for file in "$CARGO_TOML" "$NPM_PACKAGE_JSON"; do
+for file in "$CARGO_TOML" "$NPM_PACKAGE_JSON" "$MCP_SERVER_JSON"; do
   if [[ ! -f "$file" ]]; then
     echo "release-check: $file not found (run from repo root)" >&2
     exit 2
@@ -44,6 +45,11 @@ cargo_package_version="$(
   ' "$CARGO_TOML"
 )"
 npm_package_version="$(jq -r .version "$NPM_PACKAGE_JSON")"
+mcp_name="$(jq -r .mcpName "$NPM_PACKAGE_JSON")"
+server_name="$(jq -r .name "$MCP_SERVER_JSON")"
+server_version="$(jq -r .version "$MCP_SERVER_JSON")"
+server_package="$(jq -r '.packages[0].identifier // empty' "$MCP_SERVER_JSON")"
+server_package_version="$(jq -r '.packages[0].version // empty' "$MCP_SERVER_JSON")"
 
 if [[ -z "$cargo_package_version" ]]; then
   echo "release-check: $CARGO_TOML has no [workspace.package] version" >&2
@@ -52,6 +58,29 @@ fi
 if [[ -z "$npm_package_version" || "$npm_package_version" == "null" ]]; then
   echo "release-check: $NPM_PACKAGE_JSON has no .version field" >&2
   exit 2
+fi
+if [[ "$mcp_name" != "io.github.danieljhkim/orbit" || "$server_name" != "$mcp_name" ]]; then
+  echo "DRIFT: npm mcpName and server.json name must be io.github.danieljhkim/orbit" >&2
+  exit 1
+fi
+if [[ "$server_package" != "$NPM_PKG" || "$server_version" != "$npm_package_version" || "$server_package_version" != "$server_version" ]]; then
+  echo "DRIFT: server.json package identity/version must match npm/package.json" >&2
+  exit 1
+fi
+if ! jq -e '
+  .packages | length == 1
+  and .[0].registryType == "npm"
+  and .[0].transport.type == "stdio"
+  and ([.[0].packageArguments[] | [.type, .value]] == [["positional", "mcp"], ["positional", "serve"]])
+  and ([.. | strings | select(. == "--operator")] | length == 0)
+' "$MCP_SERVER_JSON" >/dev/null; then
+  echo "DRIFT: server.json must retain exactly the non-operator npm stdio launch: mcp serve" >&2
+  exit 1
+fi
+if command -v mcp-publisher >/dev/null 2>&1; then
+  mcp-publisher validate "$MCP_SERVER_JSON"
+else
+  echo "release-check: mcp-publisher not on PATH; structural registry validation completed, publisher validation deferred to release CI" >&2
 fi
 
 npm_registry_version=""
@@ -78,6 +107,7 @@ fi
 
 printf '%-32s %s\n' "$CARGO_TOML [workspace.package]" "$cargo_package_version"
 printf '%-32s %s\n' "$NPM_PACKAGE_JSON" "$npm_package_version"
+printf '%-32s %s\n' "$MCP_SERVER_JSON" "$server_version"
 printf '%-32s %s\n' "npm view $NPM_PKG" "${npm_registry_version:-<skipped>}"
 printf '%-32s %s\n' "gh release list -L 1" "${gh_tag_version:-<skipped>}"
 

--- a/scripts/smoke-npm-install.sh
+++ b/scripts/smoke-npm-install.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # End-to-end smoke for the published npm install chain.
 #
-# Runs against the *published* @orbit-tools/cli@latest from npm (not the
-# local working tree) so it catches version drift between the npm proxy
-# and the GitHub Release binary it fetches.
+# Resolves the checked-in Official MCP Registry metadata, then runs its
+# published npm package (not the local working tree). This catches drift
+# between the registry contract, npm proxy, and GitHub Release binary.
 #
 # Steps:
-#   1. npx -y @orbit-tools/cli@latest --version
+#   1. resolve server.json and launch its versioned npm package
 #        -> exercises postinstall: tarball download + sha256 verification
 #   2. drive `orbit mcp serve` over stdio with a JSON-RPC handshake
 #      (initialize + tools/list) and assert at least one `orbit.*` tool
@@ -57,6 +57,39 @@ require_bin() {
 require_bin node
 require_bin npx
 require_bin npm
+
+REGISTRY_METADATA="server.json"
+NPM_PACKAGE_JSON="npm/package.json"
+if [[ ! -f "$REGISTRY_METADATA" || ! -f "$NPM_PACKAGE_JSON" ]]; then
+  echo "smoke-npm-install: expected $REGISTRY_METADATA and $NPM_PACKAGE_JSON at the repository root" >&2
+  exit 2
+fi
+
+registry_name="$(node -p "JSON.parse(require('fs').readFileSync('$REGISTRY_METADATA', 'utf8')).name")"
+npm_mcp_name="$(node -p "JSON.parse(require('fs').readFileSync('$NPM_PACKAGE_JSON', 'utf8')).mcpName")"
+NPM_PKG="$(node -p "JSON.parse(require('fs').readFileSync('$REGISTRY_METADATA', 'utf8')).packages?.[0]?.identifier ?? ''")"
+npm_package_version="$(node -p "JSON.parse(require('fs').readFileSync('$NPM_PACKAGE_JSON', 'utf8')).version")"
+registry_version="$(node -p "JSON.parse(require('fs').readFileSync('$REGISTRY_METADATA', 'utf8')).version")"
+registry_package_version="$(node -p "JSON.parse(require('fs').readFileSync('$REGISTRY_METADATA', 'utf8')).packages?.[0]?.version ?? ''")"
+
+if [[ "$registry_name" != "io.github.danieljhkim/orbit" || "$npm_mcp_name" != "$registry_name" ]]; then
+  echo "FAIL: registry name and npm mcpName must both be io.github.danieljhkim/orbit" >&2
+  exit 1
+fi
+if [[ -z "$NPM_PKG" || "$registry_version" != "$npm_package_version" || "$registry_package_version" != "$registry_version" ]]; then
+  echo "FAIL: registry package identity or versions do not match npm/package.json" >&2
+  exit 1
+fi
+if ! node -e "const s=require('./$REGISTRY_METADATA'); const p=s.packages?.[0]; process.exit(Number(p?.registryType !== 'npm' || p?.transport?.type !== 'stdio' || JSON.stringify((p?.packageArguments ?? []).map(a => [a.type, a.value])) !== JSON.stringify([['positional', 'mcp'], ['positional', 'serve']]) || JSON.stringify(s).includes('--operator')));"; then
+  echo "FAIL: registry metadata must declare the fixed non-operator npm stdio launch: mcp serve" >&2
+  exit 1
+fi
+
+NPM_SPEC="$NPM_PKG@$registry_package_version"
+PACKAGE_ARGUMENTS=()
+while IFS= read -r argument; do
+  PACKAGE_ARGUMENTS+=("$argument")
+done < <(node -e "for (const argument of require('./$REGISTRY_METADATA').packages[0].packageArguments) console.log(argument.value)")
 
 case "$(uname -s)" in
   Darwin|Linux) ;;
@@ -122,10 +155,10 @@ run_with_timeout() {
   esac
 }
 
-echo "--- step 1: npx -y $NPM_PKG@latest --version ---"
+echo "--- step 1: npx -y $NPM_SPEC --version (from $REGISTRY_METADATA) ---"
 VERSION_OUT="$TMPDIR_ROOT/version.txt"
-if ! npx -y "$NPM_PKG@latest" --version >"$VERSION_OUT" 2>"$TMPDIR_ROOT/version.err"; then
-  echo "FAIL: npx -y $NPM_PKG@latest --version exited non-zero" >&2
+if ! npx -y "$NPM_SPEC" --version >"$VERSION_OUT" 2>"$TMPDIR_ROOT/version.err"; then
+  echo "FAIL: npx -y $NPM_SPEC --version exited non-zero" >&2
   echo "--- stderr ---" >&2
   cat "$TMPDIR_ROOT/version.err" >&2
   exit 1
@@ -152,7 +185,7 @@ echo "--- step 2: orbit init + workspace init ---"
 # matches the documented binary-first installation flow.
 # Fresh-host non-interactive init requires host identity (ORB-10721): a
 # host name plus a 2-5 letter task prefix that is not ORB/ADR/L/F.
-if ! npx -y "$NPM_PKG@latest" init --non-interactive \
+if ! npx -y "$NPM_SPEC" init --non-interactive \
      --host-name smoke-npm-install --task-prefix SMK \
      >"$TMPDIR_ROOT/init.out" 2>"$TMPDIR_ROOT/init.err"; then
   echo "FAIL: orbit init exited non-zero" >&2
@@ -166,7 +199,7 @@ echo "orbit init => OK ($SMOKE_HOME/.orbit)"
 
 WORKSPACE_DIR="$TMPDIR_ROOT/workspace"
 mkdir -p "$WORKSPACE_DIR"
-if ! ( cd "$WORKSPACE_DIR" && npx -y "$NPM_PKG@latest" workspace init ) \
+if ! ( cd "$WORKSPACE_DIR" && npx -y "$NPM_SPEC" workspace init ) \
      >"$TMPDIR_ROOT/ws-init.out" 2>"$TMPDIR_ROOT/ws-init.err"; then
   echo "FAIL: orbit workspace init exited non-zero" >&2
   echo "--- stderr ---" >&2
@@ -175,24 +208,29 @@ if ! ( cd "$WORKSPACE_DIR" && npx -y "$NPM_PKG@latest" workspace init ) \
 fi
 echo "orbit workspace init => OK ($WORKSPACE_DIR/.orbit)"
 
+LAUNCH_DIR="$TMPDIR_ROOT/registry-launch"
+mkdir -p "$LAUNCH_DIR"
+
 echo "--- step 3: MCP handshake over stdio ---"
 RPC_IN="$TMPDIR_ROOT/rpc-in.txt"
 RPC_OUT="$TMPDIR_ROOT/rpc-out.txt"
 RPC_ERR="$TMPDIR_ROOT/rpc-err.txt"
 
-cat >"$RPC_IN" <<'EOF'
+cat >"$RPC_IN" <<EOF
 {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke-npm-install","version":"0.0.1"}}}
 {"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
 {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"orbit_workflow_run_list","arguments":{"workspace":"$WORKSPACE_DIR"}}}
+{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"orbit_task_list","arguments":{}}}
 EOF
 
 # Feed the requests, then keep stdin open briefly so the server has time
-# to flush its responses before EOF closes the channel. `mcp serve` runs
-# from inside the initialized workspace so it can discover `.orbit/`.
+# to flush its responses before EOF closes the channel. The registry launch
+# runs outside any workspace: it must not infer this initialized workspace.
 {
   cat "$RPC_IN"
   sleep 5
-} | ( cd "$WORKSPACE_DIR" && run_with_timeout 120 npx -y "$NPM_PKG@latest" mcp serve ) \
+} | ( cd "$LAUNCH_DIR" && run_with_timeout 120 npx -y "$NPM_SPEC" "${PACKAGE_ARGUMENTS[@]}" ) \
      >"$RPC_OUT" 2>"$RPC_ERR" || rc=$?
 rc="${rc:-0}"
 
@@ -229,6 +267,22 @@ if ! grep -q '"orbit_' "$RPC_OUT"; then
   cat "$RPC_OUT" >&2
   echo "--- stderr ---" >&2
   cat "$RPC_ERR" >&2
+  exit 1
+fi
+
+if ! node -e '
+const fs = require("fs");
+const frames = fs.readFileSync(process.argv[1], "utf8").trim().split(/\n+/).filter(Boolean).map(JSON.parse);
+const byId = Object.fromEntries(frames.filter(frame => frame.id !== undefined).map(frame => [frame.id, frame]));
+const tools = byId[2]?.result?.tools;
+const operatorMessage = byId[3]?.result?.structuredContent?.message ?? "";
+const workspaceMessage = byId[4]?.result?.structuredContent?.message ?? "";
+if (!byId[1]?.result?.serverInfo || !Array.isArray(tools) || !tools.some(tool => tool.name === "orbit_workspace_list")) process.exit(1);
+if (!/operator/i.test(operatorMessage)) process.exit(1);
+if (!workspaceMessage.includes("orbit_workspace_list") || !workspaceMessage.includes("returned `ws_*` ID") || !workspaceMessage.includes("orbit workspace init") || !workspaceMessage.includes("never infers one from the server process cwd")) process.exit(1);
+' "$RPC_OUT"; then
+  echo "FAIL: registry launch did not initialize, list tools, remain agent-only, and fail closed without a workspace" >&2
+  cat "$RPC_OUT" >&2
   exit 1
 fi
 

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/danieljhkim/orbit",
     "source": "github"
   },
-  "version": "0.15.0",
+  "version": "0.15.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@orbit-tools/cli",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.danieljhkim/orbit",
+  "description": "Orbit's local-first task and workflow registry for coding agents.",
+  "repository": {
+    "url": "https://github.com/danieljhkim/orbit",
+    "source": "github"
+  },
+  "version": "0.15.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@orbit-tools/cli",
+      "version": "0.15.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Task

[ORB-11029](https://orbit-cli.com/tasks/ORB-11029) — Harden the Official MCP Registry install and launch experience

### Description

## Problem
Orbit is a good fit for the Official MCP Registry through the existing `@orbit-tools/cli` npm distribution, but the registry install path is not yet a tested product contract. A generated registry launch must not silently acquire operator authority, infer a workspace from cwd or a default, or leave a first-time user with opaque setup failures.

## Why It Matters
The registry entry will become a downstream source of truth for MCP clients. A bad first launch would either weaken Orbit's authority boundary or make the package appear broken before the user has initialized and selected a workspace.

## Scope
- Add the npm and versioned registry metadata needed to describe the stdio launch `npx @orbit-tools/cli mcp serve`, using the canonical server name `io.github.danieljhkim/orbit`.
- Make the unbound, non-operator startup path explicit and fail-closed.
- Make workspace discovery and first-run setup guidance useful from an MCP client.
- Add release validation that exercises the registry metadata through MCP initialization and `tools/list`.

## Constraints / Notes
- The registry launch command must not include or imply `--operator`.
- Do not infer a workspace from cwd and do not fall back to another registered workspace.
- The first routing instruction for an unbound client is `orbit_workspace_list`, followed by an explicit returned `ws_*` ID on workspace-scoped calls.
- Treat actual publication to the external registry as a separately approved release action; this task produces and validates the registry-ready artifact.

### Acceptance Criteria

- `npm/package.json` declares `mcpName` as `io.github.danieljhkim/orbit`, and a versioned `server.json` describes the npm stdio package with fixed package arguments `mcp` and `serve`; `mcp-publisher validate server.json` succeeds.
- An automated clean-environment test resolves the checked-in registry metadata, launches the declared npm command, completes MCP initialization, and receives a valid `tools/list` response.
- The declared launch and its test do not pass `--operator`, and an automated assertion demonstrates that operator-only authority is not granted by the registry install path.
- When launched without a bound workspace, workspace-scoped operations fail closed: no cwd or default-workspace inference occurs, and the response directs the client to call `orbit_workspace_list` and reuse an explicit returned `ws_*` ID.
- When Orbit has not been initialized or has no registered workspace, the MCP response gives actionable first-run guidance including the supported `orbit workspace init` setup path instead of an opaque not-found or empty-state failure.
- The release validation path fails when registry metadata, package identity, fixed launch arguments, non-operator authority, initialization, or `tools/list` behavior regress.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added npm ownership marker and versioned Official MCP Registry `server.json` for `io.github.danieljhkim/orbit`, declaring the fixed stdio launch `@orbit-tools/cli mcp serve` without `--operator`.
- Made unbound workspace failures and their advertised schema direct clients to `orbit_workspace_list`, reuse a returned `ws_*` ID, and initialize with `orbit init` then `orbit workspace init` when no workspace exists; documented the flow.
- Added clean-launch MCP coverage plus registry-contract assertions, and made the published npm smoke resolve `server.json`, run its declared command outside a workspace, verify initialization/tools-list, operator denial, and fail-closed workspace guidance.
- Added release lockstep checks for registry identity/version/arguments and release-CI `mcp-publisher validate server.json`.
Assessment: focused registry contract hardening with no new dependency edges.
Validation:
- `mcp-publisher validate server.json` passed (downloaded official publisher binary).
- `cargo test -p orbit-cli --test mcp_roundtrip` passed (22 tests).
- `make ci-fast` passed.
- `make ci-lint` passed.
- `./scripts/release-check.sh` passed local registry contract checks; remote npm check skipped because `npm` is unavailable in this runner.
- `./scripts/smoke-npm-install.sh --dry-run-version-assertion` passed. The live published-npm smoke was not run because `npm`/`npx` are unavailable in this runner; scheduled/tag CI runs it with Node setup.
Friction checkpoint: no report filed; the missing local npm CLI is an expected runner prerequisite and CI supplies it.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11029-6a8baee8`
- Behind base: 0
- Ahead of base: 1