### PR TITLE
Create Orbit SQLite state with private file and directory permissions

### DIFF
--- a/crates/orbit-common/src/fs/io.rs
+++ b/crates/orbit-common/src/fs/io.rs
@@ -432,14 +432,14 @@ fn apply_private_file_mode(options: &mut OpenOptions) {
 fn apply_private_file_mode(_options: &mut OpenOptions) {}
 
 #[cfg(unix)]
-fn set_private_file_permissions(path: &Path) -> io::Result<()> {
+pub(crate) fn set_private_file_permissions(path: &Path) -> io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
     fs::set_permissions(path, fs::Permissions::from_mode(PRIVATE_FILE_MODE))
 }
 
 #[cfg(not(unix))]
-fn set_private_file_permissions(_path: &Path) -> io::Result<()> {
+pub(crate) fn set_private_file_permissions(_path: &Path) -> io::Result<()> {
     Ok(())
 }
 

--- a/crates/orbit-common/src/storage/sqlite.rs
+++ b/crates/orbit-common/src/storage/sqlite.rs
@@ -8,7 +8,9 @@
 //! store-specific overrides (e.g. the task registry's `synchronous=FULL`)
 //! on top.
 
-use std::path::Path;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
 
 use rusqlite::{Connection, OpenFlags};
 
@@ -18,6 +20,121 @@ use crate::OrbitError;
 /// milliseconds. Writers under WAL still serialize; this bounds how long a
 /// contending connection spins before surfacing `database is locked`.
 pub const DEFAULT_BUSY_TIMEOUT_MS: u32 = 5_000;
+
+/// A file-backed SQLite connection opened under Orbit's filesystem policy.
+pub struct OpenedConnection {
+    /// The ready-to-use SQLite connection.
+    pub connection: Connection,
+    /// Whether the database was opened in immutable read-only mode.
+    pub read_only: bool,
+}
+
+/// Open an Orbit SQLite database without exposing its persisted state.
+///
+/// Writable databases are created or repaired to owner-only access on Unix.
+/// The database is hardened before SQLite can create WAL/SHM sidecars, and
+/// pre-existing sidecars are repaired as part of the same operation. Newly
+/// created parent directories are owner-only as well. An existing read-only
+/// database or database on a read-only filesystem is opened immutable before
+/// any directory creation or permission change is attempted.
+pub fn open_private(path: &Path) -> Result<OpenedConnection, OrbitError> {
+    match fs::metadata(path) {
+        Ok(metadata) if metadata.permissions().readonly() || filesystem_is_read_only(path)? => {
+            return Ok(OpenedConnection {
+                connection: open_immutable(path)?,
+                read_only: true,
+            });
+        }
+        Ok(_) => harden_sqlite_files(path)?,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(sqlite_path_error("inspect", path, error)),
+    }
+
+    if let Some(parent) = path.parent() {
+        create_private_dir_all(parent)?;
+    }
+    prepare_private_database_file(path)?;
+
+    let connection = Connection::open(path).map_err(|error| {
+        OrbitError::Store(format!(
+            "cannot open SQLite database '{}': {error}",
+            path.display()
+        ))
+    })?;
+    let pragmas = apply_default_pragmas(&connection)?;
+    if pragmas.write_denied || filesystem_is_read_only(path)? {
+        drop(connection);
+        return Ok(OpenedConnection {
+            connection: open_immutable(path)?,
+            read_only: true,
+        });
+    }
+    harden_sqlite_files(path)?;
+
+    Ok(OpenedConnection {
+        connection,
+        read_only: false,
+    })
+}
+
+/// Create a sensitive SQLite-adjacent state directory.
+///
+/// On Unix, directories created by this call are `0o700`; existing ancestors
+/// are deliberately left unchanged.
+pub fn create_private_dir_all(path: &Path) -> Result<(), OrbitError> {
+    crate::fs::io::create_private_dir_all(path)
+        .map_err(|error| sqlite_path_error("create private directory", path, error))
+}
+
+fn prepare_private_database_file(path: &Path) -> Result<(), OrbitError> {
+    match crate::fs::io::create_new_private_file(path) {
+        Ok(file) => {
+            drop(file);
+            Ok(())
+        }
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            crate::fs::io::set_private_file_permissions(path)
+                .map_err(|error| sqlite_path_error("harden", path, error))
+        }
+        Err(error) => Err(sqlite_path_error("create", path, error)),
+    }
+}
+
+fn harden_sqlite_files(path: &Path) -> Result<(), OrbitError> {
+    harden_existing_file(path)?;
+    for sidecar in sqlite_sidecar_paths(path) {
+        harden_existing_file(&sidecar)?;
+    }
+    Ok(())
+}
+
+fn harden_existing_file(path: &Path) -> Result<(), OrbitError> {
+    match crate::fs::io::set_private_file_permissions(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(sqlite_path_error("harden", path, error)),
+    }
+}
+
+fn sqlite_sidecar_paths(path: &Path) -> [PathBuf; 2] {
+    [
+        path_with_suffix(path, "-wal"),
+        path_with_suffix(path, "-shm"),
+    ]
+}
+
+fn path_with_suffix(path: &Path, suffix: &str) -> PathBuf {
+    let mut value = path.as_os_str().to_os_string();
+    value.push(suffix);
+    PathBuf::from(value)
+}
+
+fn sqlite_path_error(action: &str, path: &Path, error: io::Error) -> OrbitError {
+    OrbitError::Store(format!(
+        "failed to {action} SQLite state '{}': {error}",
+        path.display()
+    ))
+}
 
 /// Result of [`apply_default_pragmas`]: what SQLite actually settled on for
 /// the best-effort settings.

--- a/crates/orbit-common/src/storage/tests/sqlite.rs
+++ b/crates/orbit-common/src/storage/tests/sqlite.rs
@@ -59,3 +59,81 @@ fn defaults_are_idempotent() {
 
     assert!(outcome.wal_active());
 }
+
+#[cfg(unix)]
+#[test]
+fn private_open_repairs_existing_database_and_sidecars() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("repair.db");
+    let connection = Connection::open(&path).expect("open fixture");
+    connection
+        .pragma_update(None, "journal_mode", "WAL")
+        .expect("enable WAL");
+    connection
+        .execute_batch("CREATE TABLE fixture(value TEXT); INSERT INTO fixture VALUES ('secret');")
+        .expect("write fixture");
+
+    for suffix in ["", "-wal", "-shm"] {
+        let file = std::path::PathBuf::from(format!("{}{suffix}", path.display()));
+        assert!(file.exists(), "fixture sidecar exists: {}", file.display());
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o666))
+            .expect("make fixture permissive");
+    }
+
+    let opened = super::super::sqlite::open_private(&path).expect("open private");
+    assert!(!opened.read_only);
+    for suffix in ["", "-wal", "-shm"] {
+        let file = std::path::PathBuf::from(format!("{}{suffix}", path.display()));
+        let mode = std::fs::metadata(&file)
+            .expect("file metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "private mode for {}", file.display());
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn private_open_preserves_an_immutable_database_without_side_effects() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("immutable.db");
+    let connection = Connection::open(&path).expect("open fixture");
+    connection
+        .execute_batch("CREATE TABLE fixture(value TEXT); INSERT INTO fixture VALUES ('kept');")
+        .expect("write fixture");
+    drop(connection);
+    for suffix in ["-wal", "-shm"] {
+        let sidecar = std::path::PathBuf::from(format!("{}{suffix}", path.display()));
+        if sidecar.exists() {
+            std::fs::remove_file(sidecar).expect("remove fixture sidecar");
+        }
+    }
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o400))
+        .expect("make fixture read-only");
+
+    let opened = super::super::sqlite::open_private(&path).expect("open immutable");
+    assert!(opened.read_only);
+    let value = opened
+        .connection
+        .query_row("SELECT value FROM fixture", [], |row| {
+            row.get::<_, String>(0)
+        })
+        .expect("read immutable fixture");
+    assert_eq!(value, "kept");
+    assert_eq!(
+        std::fs::metadata(&path)
+            .expect("database metadata")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o400,
+        "read-only mode must not be repaired"
+    );
+    assert!(!std::path::PathBuf::from(format!("{}-wal", path.display())).exists());
+    assert!(!std::path::PathBuf::from(format!("{}-shm", path.display())).exists());
+}

--- a/crates/orbit-search/src/vector/store/mod.rs
+++ b/crates/orbit-search/src/vector/store/mod.rs
@@ -41,15 +41,7 @@ impl VectorStore {
     /// foreign_keys, synchronous=NORMAL) and creating the
     /// embeddings/corpus_fts schema if missing.
     pub fn open(path: &Path) -> Result<Self, OrbitError> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| OrbitError::Store(e.to_string()))?;
-        }
-        let mut conn = Connection::open(path).map_err(|e| OrbitError::Store(e.to_string()))?;
-        let pragmas = orbit_common::storage::sqlite::apply_default_pragmas(&conn)?;
-        if pragmas.write_denied || orbit_common::storage::sqlite::filesystem_is_read_only(path)? {
-            drop(conn);
-            conn = orbit_common::storage::sqlite::open_immutable(path)?;
-        }
+        let conn = orbit_common::storage::sqlite::open_private(path)?.connection;
         if let Err(error) = schema::ensure_vector_schema(&conn) {
             if error.is_readonly_or_access_failure() {
                 tracing::warn!(

--- a/crates/orbit-search/src/vector/store/tests/mod.rs
+++ b/crates/orbit-search/src/vector/store/tests/mod.rs
@@ -37,4 +37,50 @@ mod open_pragmas {
         // synchronous=NORMAL reports as 1.
         assert_eq!(pragma_i64("synchronous"), 1);
     }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_creates_private_vector_state_under_permissive_umask() {
+        use std::os::unix::fs::PermissionsExt;
+
+        const CHILD_MARKER: &str = "ORBIT_TEST_PRIVATE_VECTOR_SQLITE";
+        if std::env::var_os(CHILD_MARKER).is_none() {
+            let status = std::process::Command::new("sh")
+                .args(["-c", "umask 000; exec \"$@\"", "sh"])
+                .arg(std::env::current_exe().expect("current test executable"))
+                .arg("open_creates_private_vector_state_under_permissive_umask")
+                .env(CHILD_MARKER, "1")
+                .status()
+                .expect("run test under permissive umask");
+            assert!(status.success(), "permissive-umask child failed");
+            return;
+        }
+
+        let root = tempfile::tempdir().expect("tempdir");
+        let state_dir = root.path().join("private/state");
+        let path = state_dir.join("semantic.db");
+        let store = VectorStore::open(&path).expect("open store");
+        let connection = store.connection();
+        let conn = connection.lock().expect("lock vector connection");
+        conn.execute_batch("BEGIN IMMEDIATE; COMMIT;")
+            .expect("touch vector WAL");
+
+        for directory in [state_dir.parent().expect("private parent"), &state_dir] {
+            let mode = std::fs::metadata(directory)
+                .expect("directory metadata")
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o700, "private directory {}", directory.display());
+        }
+        for suffix in ["", "-wal", "-shm"] {
+            let file = std::path::PathBuf::from(format!("{}{suffix}", path.display()));
+            let mode = std::fs::metadata(&file)
+                .expect("SQLite file metadata")
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o600, "private SQLite file {}", file.display());
+        }
+    }
 }

--- a/crates/orbit-store/src/driver/sqlite/connection.rs
+++ b/crates/orbit-store/src/driver/sqlite/connection.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use orbit_common::OrbitError;
-use orbit_common::storage::sqlite::apply_default_pragmas;
+use orbit_common::storage::sqlite::{apply_default_pragmas, open_private};
 use rusqlite::{Connection, Transaction, TransactionBehavior};
 
 use crate::driver::sqlite::migration;
@@ -71,18 +71,9 @@ impl Store {
         Ok(())
     }
     pub fn open(path: &Path) -> Result<Self, OrbitError> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| OrbitError::Store(e.to_string()))?;
-        }
-
-        let mut conn = Connection::open(path).map_err(|e| OrbitError::Store(e.to_string()))?;
-        let pragmas = apply_default_pragmas(&conn)?;
-        let read_only =
-            pragmas.write_denied || orbit_common::storage::sqlite::filesystem_is_read_only(path)?;
-        if read_only {
-            drop(conn);
-            conn = orbit_common::storage::sqlite::open_immutable(path)?;
-        }
+        let opened = open_private(path)?;
+        let conn = opened.connection;
+        let read_only = opened.read_only;
 
         if let Err(error) = migration::apply_schema(&conn) {
             if read_only && error.is_readonly_or_access_failure() {

--- a/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -44,16 +43,11 @@ impl TaskRegistryStore {
             .map(Path::to_path_buf)
             .unwrap_or_else(|| PathBuf::from("."));
         let workspaces_dir = normalize_path(&registry_dir.join("workspaces"));
-        fs::create_dir_all(&registry_dir).map_err(|e| OrbitError::Store(e.to_string()))?;
-        fs::create_dir_all(&workspaces_dir).map_err(|e| OrbitError::Store(e.to_string()))?;
-
-        let mut conn = Connection::open(path).map_err(|e| OrbitError::Store(e.to_string()))?;
-        let pragmas = orbit_common::storage::sqlite::apply_default_pragmas(&conn)?;
-        let read_only =
-            pragmas.write_denied || orbit_common::storage::sqlite::filesystem_is_read_only(path)?;
-        if read_only {
-            drop(conn);
-            conn = orbit_common::storage::sqlite::open_immutable(path)?;
+        let opened = orbit_common::storage::sqlite::open_private(path)?;
+        let conn = opened.connection;
+        let read_only = opened.read_only;
+        if !read_only {
+            orbit_common::storage::sqlite::create_private_dir_all(&workspaces_dir)?;
         }
         // The registry is the commit point that makes a created task official, so
         // its writes must be durable against power loss the moment they ack. WAL's

--- a/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
@@ -179,6 +179,91 @@ fn open_creates_registry_parent_and_workspaces_dir() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn open_creates_private_registry_state_under_permissive_umask() {
+    use std::os::unix::fs::PermissionsExt;
+
+    const CHILD_MARKER: &str = "ORBIT_TEST_PRIVATE_REGISTRY_SQLITE";
+    if std::env::var_os(CHILD_MARKER).is_none() {
+        let status = std::process::Command::new("sh")
+            .args(["-c", "umask 000; exec \"$@\"", "sh"])
+            .arg(std::env::current_exe().expect("current test executable"))
+            .arg("open_creates_private_registry_state_under_permissive_umask")
+            .env(CHILD_MARKER, "1")
+            .status()
+            .expect("run test under permissive umask");
+        assert!(status.success(), "permissive-umask child failed");
+        return;
+    }
+
+    let root = tempfile::tempdir().expect("tempdir");
+    let path = root.path().join("private/tasks/index.sqlite");
+    let registry = TaskRegistryStore::open(&path).expect("open registry");
+    let conn = registry.conn.lock().expect("lock registry");
+    conn.execute_batch("BEGIN IMMEDIATE; COMMIT;")
+        .expect("touch registry WAL");
+
+    for directory in [
+        root.path().join("private"),
+        root.path().join("private/tasks"),
+        root.path().join("private/tasks/workspaces"),
+    ] {
+        let mode = fs::metadata(&directory)
+            .expect("directory metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o700, "private directory {}", directory.display());
+    }
+    for suffix in ["", "-wal", "-shm"] {
+        let file = PathBuf::from(format!("{}{suffix}", path.display()));
+        let mode = fs::metadata(&file)
+            .expect("SQLite file metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "private SQLite file {}", file.display());
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn immutable_registry_open_does_not_chmod_or_recreate_adjacent_state() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = tempfile::tempdir().expect("tempdir");
+    let path = root.path().join("tasks/index.sqlite");
+    drop(TaskRegistryStore::open(&path).expect("create registry"));
+    let workspaces = path.parent().expect("registry parent").join("workspaces");
+    fs::remove_dir(&workspaces).expect("remove empty workspace state");
+    for suffix in ["-wal", "-shm"] {
+        let sidecar = PathBuf::from(format!("{}{suffix}", path.display()));
+        if sidecar.exists() {
+            fs::remove_file(sidecar).expect("remove registry sidecar");
+        }
+    }
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o400)).expect("make registry immutable");
+
+    drop(TaskRegistryStore::open(&path).expect("open immutable registry"));
+
+    assert!(
+        !workspaces.exists(),
+        "read-only open must not recreate state"
+    );
+    assert_eq!(
+        fs::metadata(&path)
+            .expect("registry metadata")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o400,
+        "read-only database mode must remain unchanged"
+    );
+    assert!(!PathBuf::from(format!("{}-wal", path.display())).exists());
+    assert!(!PathBuf::from(format!("{}-shm", path.display())).exists());
+}
+
 #[test]
 fn open_migrates_existing_task_index_columns_before_creating_indexes() {
     let temp = TempDir::new().expect("tempdir");

--- a/crates/orbit-store/src/driver/sqlite/task_reservation_store/tests/workspace_claim.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_reservation_store/tests/workspace_claim.rs
@@ -297,3 +297,35 @@ fn claims_are_scoped_per_workspace() {
         "a claim binds one workspace, not the whole host"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn persisted_workspace_claim_is_not_group_or_world_readable() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = tempfile::tempdir().expect("tempdir");
+    let path = root.path().join("state/orbit.db");
+    let store = Store::open(&path).expect("open file-backed store");
+    let granted = store
+        .acquire_workspace_claim(&acquire_params("operator-a"))
+        .expect("persist workspace claim");
+    assert!(
+        granted.claim_token.is_some(),
+        "claim persisted a bearer token"
+    );
+
+    for suffix in ["", "-wal", "-shm"] {
+        let file = std::path::PathBuf::from(format!("{}{suffix}", path.display()));
+        let mode = std::fs::metadata(&file)
+            .expect("SQLite file metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode & 0o077,
+            0,
+            "{} must not grant group/other access (mode {mode:o})",
+            file.display()
+        );
+    }
+}

--- a/crates/orbit-store/src/driver/sqlite/tests/connection.rs
+++ b/crates/orbit-store/src/driver/sqlite/tests/connection.rs
@@ -155,3 +155,55 @@ fn schema_version_matches_binary_after_open() {
         "a freshly-opened store is migrated to the binary's schema version"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn file_store_is_private_under_permissive_umask() {
+    use std::os::unix::fs::PermissionsExt;
+
+    const CHILD_MARKER: &str = "ORBIT_TEST_PRIVATE_MAIN_SQLITE";
+    if std::env::var_os(CHILD_MARKER).is_none() {
+        let status = std::process::Command::new("sh")
+            .args(["-c", "umask 000; exec \"$@\"", "sh"])
+            .arg(std::env::current_exe().expect("current test executable"))
+            .arg("file_store_is_private_under_permissive_umask")
+            .env(CHILD_MARKER, "1")
+            .status()
+            .expect("run test under permissive umask");
+        assert!(status.success(), "permissive-umask child failed");
+        return;
+    }
+
+    let root = tempfile::tempdir().expect("tempdir");
+    let state_dir = root.path().join("private/state");
+    let path = state_dir.join("orbit.db");
+    let store = Store::open(&path).expect("open store");
+    store
+        .with_transaction(|tx| {
+            tx.connection()
+                .execute_batch(
+                    "CREATE TABLE permission_fixture(value TEXT NOT NULL);
+                     INSERT INTO permission_fixture VALUES ('secret');",
+                )
+                .map_err(|error| OrbitError::Store(error.to_string()))
+        })
+        .expect("persist fixture");
+
+    for directory in [state_dir.parent().expect("private parent"), &state_dir] {
+        let mode = std::fs::metadata(directory)
+            .expect("directory metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o700, "private directory {}", directory.display());
+    }
+    for suffix in ["", "-wal", "-shm"] {
+        let file = std::path::PathBuf::from(format!("{}{suffix}", path.display()));
+        let mode = std::fs::metadata(&file)
+            .expect("SQLite file metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "private SQLite file {}", file.display());
+    }
+}


### PR DESCRIPTION
## Task

[ORB-11032](https://orbit-cli.com/tasks/ORB-11032) — Create Orbit SQLite state with private file and directory permissions

### Description

## Problem
Orbit SQLite stores and their containing state directories are created with ordinary `create_dir_all` and `rusqlite::Connection::open`, so their modes inherit the process umask. The live installation reviewed here has globally readable databases and WAL/SHM sidecars even though the main database stores a Bearer [REDACTED_AUTH]

## Reproducible Evidence
Reviewed at commit `a650b7dcc4f9800a3cd6e79ea3aefaa554781748` on Linux.

- `stat -c '%a %n' ~/.orbit ~/.orbit/orbit.db ~/.orbit/orbit.db-wal ~/.orbit/orbit.db-shm` reports the root as `775` and the database files as `644`.
- `find ~/.orbit -maxdepth 2 -type f -printf '%m %p\n'` also reports `tasks/index.sqlite`, `state/semantic.db`, and their WAL/SHM sidecars as `644`.
- `crates/orbit-store/src/driver/sqlite/connection.rs::Store::open`, `crates/orbit-store/src/driver/sqlite/task_registry/store.rs::TaskRegistryStore::open`, and `crates/orbit-search/src/vector/store/mod.rs::VectorStore::open` use `create_dir_all` plus `Connection::open` without applying `0o700` directory or `0o600` file modes.
- `crates/orbit-store/src/driver/sqlite/migration/mod.rs` adds `task_reservations.claim_token` and documents it as a Bearer [REDACTED_AUTH] `crates/orbit-store/src/driver/sqlite/task_reservation_store/workspace_claim.rs` persists and compares that token.
- ORB-00368 hardened audit blobs and JSONL logs with private filesystem helpers, but its scope and acceptance criteria did not cover SQLite databases or sidecars.

## Severity and Impact
**Severity: Medium.** On a shared host whose home path is traversable, another local account can read `orbit.db` and its WAL, recover an active workspace claim Bearer [REDACTED_AUTH], inspect operational/task data, and interfere with reservation-controlled work. Sidecars can expose recently written rows even if only the primary database is later chmodded.

## Constraints / Notes
- Harden both newly created and pre-existing SQLite database files, WAL/SHM sidecars, and sensitive state directories on Unix; do not depend on umask.
- Preserve read-only/immutable database behavior and non-Unix portability.
- Centralize the permission invariant so every shipped Orbit SQLite opener applies it consistently.

### Acceptance Criteria

- On Unix, every shipped Orbit SQLite database containing workspace, task, audit, or credential-bearing state is created or repaired to mode `0o600`, including any WAL and SHM sidecars, and newly created sensitive parent directories are `0o700`.
- Focused Unix-gated tests run under a permissive umask and assert private modes for the main Store, task registry, and vector/search store without reading the developer environment.
- Existing read-only and immutable SQLite open paths continue to work without attempting forbidden chmod or creation operations.
- A test persists a workspace claim and confirms that neither the main database nor its sidecars grant group/other read access; `make ci-fast` and focused store/search tests pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `orbit_common::storage::sqlite::open_private`, the canonical file-backed SQLite opener. On Unix it creates missing state directories as `0o700`, creates or repairs writable databases and existing WAL/SHM sidecars to `0o600`, and opens read-only files/filesystems immutable before attempting chmod or creation.
- Routed the main Store, task registry, and vector/search store through that opener. The task registry now creates its adjacent `workspaces` directory privately only for writable stores.
- Added Unix tests that re-exec under `umask 000` for all three shipped stores and assert private database, WAL/SHM, and newly created directory modes without consulting developer state.
- Added regression coverage for repairing permissive existing SQLite files, immutable opens with no chmod/sidecar effects, immutable task-registry opens with no adjacent-directory recreation, and a persisted workspace claim whose database and sidecars grant no group/other access.

Validation:
- `cargo test -p orbit-common --features sqlite storage::tests::sqlite --no-fail-fast` passed (5 focused tests).
- `cargo test -p orbit-store -p orbit-search --no-fail-fast` passed (orbit-store: 328 passed/4 ignored before the final additional immutable-registry test; orbit-search: 59 unit + 2 integration passed).
- The additional immutable-registry test passed independently.
- `make ci-fast` passed after the final edit.
- `make ci-lint` passed after the final edit.
- `git diff --check` passed.

Assessment: The permission invariant is centralized at the shared SQLite boundary, all production file-backed openers use it, non-Unix behavior remains portable, and immutable/read-only paths avoid permission and creation side effects. No dependency edge or persisted format changed.

Deviation / scope note: Added `file:crates/orbit-common/src/fs/io.rs` to task context because the SQLite helper needed crate-visible reuse of the existing authoritative private-file chmod primitive; the only change there is visibility from module-private to crate-private.

Friction checkpoint: No qualifying friction was encountered.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11032-6a8bc67f`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*