### PR TITLE
Prepare v0.16.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.16.0
+
+### Breaking Changes
+
+- **Replica task writes report capability refusal**: `orbit.task.add` on a replica now returns `capability_refused` instead of `invalid_input`; update clients that branch on the old error code. ([ORB-11012])
+- **Replica MCP access is capability-gated**: workspace-scoped control-plane reads and writes now return `capability_refused` on replica checkouts; route those calls to the owner selector. ([ORB-11021])
+
+### Highlights
+
+- **Federated multi-host MCP**: register an opt-in federated server, discover remote workspaces over configured SSH destinations, and route workspace-scoped calls with host-qualified selectors. ([ORB-11016])
+- **Cross-workspace search**: one CLI or MCP search can query multiple registered workspaces, fuse ranked results, and attribute every hit to its source workspace. ([ORB-11027])
+- **Official MCP Registry launch**: versioned registry metadata and the npm proxy now provide a validated, fail-closed path from registry installation to an unbound Orbit MCP server. ([ORB-11029])
+- **Explicit docs-root overrides**: configured docs roots can opt out of gitignore filtering while retaining Orbit's `.git` and `.orbit` exclusions. ([ORB-11025])
+- **Policy-bound process spawning**: activity `proc.spawn` calls now honor the child-environment allowlist and the activity's filesystem sandbox. ([ORB-11031])
+- **Private SQLite state**: Orbit creates and repairs its state databases, WAL files, sidecars, and sensitive directories with private Unix permissions. ([ORB-11032])
+
 ## 0.15.0
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbit-agent"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cli"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cmd"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-common"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-config"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "orbit-common",
  "orbit-types",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-core"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "croner",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-engine"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-exec"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "libc",
  "orbit-common",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-mcp"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-policy"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-registry"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "hostname",
@@ -2305,7 +2305,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-search"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-store"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-tools"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2369,7 +2369,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-types"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2386,7 +2386,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-web"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.1"
+version = "0.16.0"
 edition = "2024"
 license = "MIT"
 # MSRV [ORB-10010]: edition 2024 requires >= 1.85; the highest `rust-version`

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbit-tools/cli",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "mcpName": "io.github.danieljhkim/orbit",
   "description": "npm proxy for the Orbit CLI. Downloads the matching native binary from GitHub Releases on install and forwards all invocations.",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/danieljhkim/orbit",
     "source": "github"
   },
-  "version": "0.15.1",
+  "version": "0.16.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@orbit-tools/cli",
-      "version": "0.15.1",
+      "version": "0.16.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Task

[ORB-11034](https://orbit-cli.com/tasks/ORB-11034) — Prepare v0.16.0 release

### Description

Prepare the next Orbit release from the report-first survey below. Follow the complete checklist in RELEASING.md, including the release checklist and every versioned release file. This handoff stops at the human review boundary until the task is explicitly approved; do not treat the candidate semver or breaking-change list as human confirmation.

Survey evidence:
- Unfinished-work gate queried backlog, in-progress, and review. Sorted open IDs: ORB-11033. It is exempt because it carries the exact provenance tag auto-task:release-prep. Non-exempt blockers: none.
- Latest reachable release tag: v0.15.0 (git tag --merged HEAD --list 'v*' --sort=-version:refname | head -n 1).
- No-merge survey range: v0.15.0..HEAD.
- Surveyed commits, newest first:
  - 61b8aa41d628ccfaf7291bae5dbd7adbaec9557e fix: Make proc.spawn honor the child-environment allowlist and activity… [ORB-11031]
  - fd6a4281bfe821cc1d42946ba1bc6be930840e9e fix: Create Orbit SQLite state with private file and directory permissi… [ORB-11032]
  - 256db7ba18c19c8dae257e418c12717e1519b000 fix: use publishable MCP registry version [ORB-11029]
  - 3afc1700c1889eceddef6a6b288e8b8765ce097e feat: Harden the Official MCP Registry install and launch experience [ORB-11029]
  - b1543ede29bbf9425df7ede93540fc95b5d572bd feat: Cross-workspace federated search with a workspace scope selector [ORB-11027]
  - 2afc4e9b2c49a021289b537690774e438a251b39 feat: Let explicitly configured docs roots opt out of the gitignore filter [ORB-11025]
  - d27acaac44b6cbfb1f5174f88fc8f95c08ccb685 fix: Federated routed calls inherit the 20s discovery probe deadline and misreport timeouts as unreachable [ORB-11023]
  - 3a8768ecc7050c9c666137b0e25937dd75005e91 fix: Federated workspace list drops invalid destination checkouts [ORB-11020]
  - 339dc09cb47b90687dadef56b3f7770693cf6de9 fix: Replica capability classifier is never enforced at MCP dispatch [ORB-11021]
  - 4302b5ce9af49f74ce59b096a83c131632d77b2f auto-commit: 2026-08-24 01:00:20
  - f01bc0c8d8e219fb7fdc1e5cd37d7988d2871c2b feat: Federated serve registration + design docs as implemented [ORB-11016]
  - c9bed8c969b3331d316a019a2c2802648bdc4ea8 feat: Federated workspace param is the host-qualified selector [ORB-11017]
  - 7eb01271154c0242767cb8bca6329cd0f4fec81f feat: Route workspace-scoped federated calls by host-qualified selector [ORB-11015]
  - 83a9b5b38ba5f384797e5f716ab3d1a757a0f57a feat: Federated orbit.workspace.list over configured SSH destinations [ORB-11014]
  - 69677dadf11b7d9f1c1201cd1808882532da4449 feat: Map catalog role to capability_refused (destination Core) [ORB-11012]
  - ad646f9aad3ac0c2c4c84d6264405d9565c79c93 feat: Federated destination config, selector type, and routing errors [ORB-11013]
  - 85349aece66c24d416b97484d6326da8a6f3f310 chore: [auto-task] Doc duties — validate the least-recently-validated docs [ORB-11006]
  - 205c7c73a24438596e96591f4215fb34ba5a04c3 fix: Close federated-mcp contract holes from PR #1139 review [ORB-11010]
  - f6e62eec8174403f9ddf3dde86b376033717ae1c feat: Turn federated MCP policy into an implementable design contract [ORB-11009]
  - b135aab421c0c8ad649289da1874110c02852a3a4 feat: Design a federated multi-host workspace MCP surface [ORB-11008]
- Referenced Orbit task IDs: ORB-11006, ORB-11008, ORB-11009, ORB-11010, ORB-11012, ORB-11013, ORB-11014, ORB-11015, ORB-11016, ORB-11017, ORB-11020, ORB-11021, ORB-11023, ORB-11025, ORB-11027, ORB-11029, ORB-11031, ORB-11032.
- Candidate pre-1.0 semver bump: 0.16.0 (minor), not human-confirmed.
- Breaking-change candidates for human review:
  - ORB-11012 / 69677dad: replica orbit.task.add changes the MCP structured error code from invalid_input to capability_refused, an externally observable MCP error-contract change.
  - ORB-11021 / 339dc09c: replica MCP dispatch newly refuses previously permitted control-plane reads and writes with capability_refused, changing existing workspace-scoped behavior.
- Federated list/selector/error and timeout schema changes in ORB-11013, ORB-11014, ORB-11015, ORB-11017, and ORB-11023 were assessed as new federated-mode behavior; the cited tasks preserve v1 remote behavior and are recorded for human review if compatibility scope differs.

Human-approved executor checklist:
1. Confirm, downgrade, or expand the breaking-change candidates with the human before drafting the final CHANGELOG section.
2. Update Cargo.toml, Cargo.lock, npm/package.json, and server.json to 0.16.0 as required by RELEASING.md; refresh Cargo.lock without third-party drift.
3. Draft the CHANGELOG section with the agreed breaking changes and highlights, run the required validation, then commit/tag/push/promote only after approval and the checklist is satisfied.

### Acceptance Criteria

- Cargo.toml, Cargo.lock, npm/package.json, and server.json report 0.16.0; Cargo.lock is refreshed without third-party dependency drift.
- CHANGELOG.md contains the approved 0.16.0 section with the required breaking-change and highlights structure.
- Every human-confirmed breaking change appears under Breaking Changes, and the final classification is not inferred from this probe.
- The npm-install smoke script remains valid for this release cycle and the required release validation passes.
- Follow RELEASING.md in full; do not commit, tag, push, publish, promote, or merge until this task is explicitly approved.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added the approved 0.16.0 CHANGELOG section with both human-confirmed breaking changes: replica task-add's structured error changes from `invalid_input` to `capability_refused` ([ORB-11012]), and replica MCP dispatch now refuses control-plane reads/writes with `capability_refused` ([ORB-11021]).
- Added six concise user-facing highlights covering federated MCP, cross-workspace search, Official MCP Registry launch, docs-root gitignore overrides, policy-bound proc.spawn, and private SQLite state.
- Bumped `Cargo.toml`, all 16 Orbit workspace entries in `Cargo.lock`, `npm/package.json`, and both `server.json` fields to 0.16.0.
- Refreshed `Cargo.lock` with `cargo update --workspace`; the diff contains only the 16 Orbit workspace package version changes and no third-party drift.
- Left `scripts/smoke-npm-install.sh` unchanged because the current cycle already updated it in [ORB-11029]; its syntax and offline version assertion remain valid.
- No commit, tag, push, publish, promotion, merge, or review transition was performed.

Assessment: The release-preparation diff is complete and remains at the required human review boundary.

Validation:
- `make build` — passed.
- `make ci-fast` — passed, including CHANGELOG style.
- `make ci-lint` — passed with warnings denied.
- `./scripts/smoke-npm-install.sh --dry-run-version-assertion` — passed.
- `bash -n scripts/smoke-npm-install.sh` — passed.
- `scripts/release-check.sh` with remote probes deliberately unavailable — passed; Cargo/npm/server local metadata agree on 0.16.0.
- Normal `make release-check` reached GitHub and reported the expected pre-release drift (local 0.16.0 versus latest published v0.15.0). npm and `mcp-publisher` are not installed in this runner, so published-artifact and publisher validation remain the post-publish/release-CI checks prescribed by the runbook.
- `git diff --check` — passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11034-6a8bd472`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*