### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/activity-job/references/glossary.md
+++ b/docs/design/activity-job/references/glossary.md
@@ -1,7 +1,7 @@
 ---
 type: design
 summary: "Glossary: Activity / Job"
-last_validated: 2026-07-27
+last_validated: 2026-08-29
 ---
 
 # Glossary: Activity / Job
@@ -15,5 +15,5 @@ This glossary covers Orbit-specific execution-substrate vocabulary used by the A
 | **TargetRef** | Authoring-facing `target: activity:<name>` form in a job step. It is resolved to a concrete `TargetStep` before execution. See [../2_design.md §3](../2_design.md). |
 | **ToolAllowlistHarnessDelegated** | Advisory envelope event emitted on the CLI agent path to say Orbit passed the declared `tools:` list through to the provider harness instead of enforcing it locally. See [../2_design.md §7.2](../2_design.md). |
 | **V2AuditEnvelope** | Structured audit wrapper carrying run/step/activity provenance for the v2 runtime. See [../specs/audit-envelope.md](../specs/audit-envelope.md). |
-| **V2RuntimeHost** | The orbit-core to orbit-engine boundary trait that supplies deterministic actions, provider credentials, CLI command resolution, and `ToolContext`. See [../2_design.md §6](../2_design.md). |
+| **RuntimeHost** | The orbit-core to orbit-engine boundary trait that supplies deterministic actions, provider credentials, CLI command resolution, and `ToolContext`. See [../2_design.md §6](../2_design.md). |
 | **Workspace Path Provenance** | The absolute repo path attached to envelope events so the shared audit trail can be filtered by originating workspace. See [../specs/audit-envelope.md](../specs/audit-envelope.md). |

--- a/docs/design/agent-families/1_overview.md
+++ b/docs/design/agent-families/1_overview.md
@@ -4,7 +4,7 @@ type: design
 title: "Agent Families — Overview"
 owner: grok
 last_updated: 2026-08-09
-last_validated: 2026-07-27
+last_validated: 2026-08-29
 status: Draft
 feature: agent-families
 doc_role: overview
@@ -24,8 +24,8 @@ Family defaults were originally also used to pick activity role models, but that
 ## 2. Core Concepts
 
 - **Agent Family:** A stable identifier such as `claude`, `codex`, `gemini`, or `grok` used for routing, attribution, and legacy model inference.
-- **Model Inference:** `agent_from_model()` and `provider_from_model()` in `crates/orbit-common/src/types/actor.rs`, together with `infer_agent_family_from_model()` in `crates/orbit-common/src/types/agent_pair.rs`, map concrete model strings to families and providers. `infer_agent_family_from_model()` remains for legacy artifact recovery.
-- **Crew:** A named provider-model-backend assignment loaded from `.orbit/config.toml` under `[crews.<name>]`; every activity role resolves to it.
+- **Model Inference:** `agent_from_model()` and `provider_from_model()` in `crates/orbit-types/src/identity/actor.rs`, together with `infer_agent_family_from_model()` in `crates/orbit-types/src/identity/agent_pair.rs`, map concrete model strings to families and providers. `infer_agent_family_from_model()` remains for legacy artifact recovery.
+- **Crew:** A named provider-model assignment loaded from `.orbit/config.toml` under `[crews.<name>]`; every activity dispatch resolves to it.
 - **Default Crew:** `[workflow].default_crew` names the workspace fallback when a task does not specify `crew`.
 - **Executor:** A YAML definition in `crates/orbit-core/assets/executors/<family>.yaml` describing how to invoke an agent CLI.
 - **Sandbox Surface:** Provider-specific state directories and lockfile rules required for safe `macos-sandbox-exec` execution.
@@ -34,13 +34,13 @@ Family defaults were originally also used to pick activity role models, but that
 
 | Concern | File | Task |
 |---------|------|------|
-| Family inference and crew resolver | `crates/orbit-common/src/types/actor.rs`, `crates/orbit-common/src/types/agent_pair.rs` | [ORB-00042], [ORB-00058], [ORB-10130] |
-| Task-level crew field | `crates/orbit-common/src/types/task.rs` | [ORB-00058] |
+| Family inference and crew resolver | `crates/orbit-types/src/identity/actor.rs`, `crates/orbit-types/src/identity/agent_pair.rs` | [ORB-00042], [ORB-00058], [ORB-10130] |
+| Task-level crew field | `crates/orbit-types/src/task/model.rs` | [ORB-00058] |
 | Runtime config loading | `crates/orbit-config/src/resolved.rs` | [ORB-00058] |
 | Default config template | `crates/orbit-config/assets/default-config.toml` | [ORB-00058] |
 | Run-time crew resolution | `crates/orbit-core/src/runtime/engine/crew.rs` | [ORB-00058] |
 | Tool and CLI crew surfaces | `crates/orbit-tools/src/builtin/orbit/task/` | [ORB-00058] |
-| Grok family onboarding | `crates/orbit-common/src/types/actor.rs`, `crates/orbit-common/src/types/agent_pair.rs` | [ORB-00042] |
+| Grok family onboarding | `crates/orbit-types/src/identity/actor.rs`, `crates/orbit-types/src/identity/agent_pair.rs` | [ORB-00042] |
 
 ## Task References
 

--- a/docs/design/agent-families/2_design.md
+++ b/docs/design/agent-families/2_design.md
@@ -4,7 +4,7 @@ type: design
 title: "Agent Families — Design"
 owner: human
 last_updated: 2026-08-09
-last_validated: 2026-07-27
+last_validated: 2026-08-29
 status: Draft
 feature: agent-families
 doc_role: design
@@ -17,16 +17,16 @@ This document describes the current implementation of Orbit agent families and c
 
 ## 1. Family Registry
 
-The family registry spans `crates/orbit-common/src/types/actor.rs` and `crates/orbit-common/src/types/agent_pair.rs`. `all_agent_families()` returns the supported family identifiers; `agent_from_model()` and `provider_from_model()` infer family and provider from model strings in `actor.rs`; and `infer_agent_family_from_model()` in `agent_pair.rs` remains the conservative recovery helper for older persisted artifacts.
+The family registry spans `crates/orbit-types/src/identity/actor.rs` and `crates/orbit-types/src/identity/agent_pair.rs`. `all_agent_families()` returns the supported family identifiers; `agent_from_model()` and `provider_from_model()` infer family and provider from model strings in `actor.rs`; and `infer_agent_family_from_model()` in `agent_pair.rs` remains the conservative recovery helper for older persisted artifacts.
 
 Adding a family is still a cross-cutting change: executor assets, sandbox behavior, provider inference, review automation, and scoreboard code all need review. The fixed registry forces that audit instead of silently accepting unknown families.
 
 
 ## 2. Crew Registry
 
-Workspace config defines one concrete assignment under each `[crews.<name>]`: flat `model`, `provider`, and `backend` fields. A rendered activity input may select a named `crew`; without one, dispatch uses the run's resolved crew. Activity and job schemas reject the retired `role` key.
+Workspace config defines one concrete assignment under each `[crews.<name>]`: flat `model` and `provider` fields. A rendered activity input may select a named `crew`; without one, dispatch uses the run's resolved crew. Activity and job schemas reject the retired `role` key.
 
-`crates/orbit-config/src/raw.rs` owns the TOML shape, and `crates/orbit-config/src/resolved.rs` materializes it into `Crew` values from `orbit-common`. Runtime loading rejects incomplete crews, retired `planner`/`implementer`/`reviewer` role sub-tables with guidance to write flat `model`, `provider`, and `backend` fields, and `[workflow].default_crew` values that do not name a defined crew.
+`crates/orbit-config/src/raw.rs` owns the TOML shape, and `crates/orbit-config/src/resolved.rs` materializes it into `Crew` values from `orbit-types`. Runtime loading rejects incomplete crews, retired `planner`/`implementer`/`reviewer` role sub-tables with guidance to write flat `model` and `provider` fields, and `[workflow].default_crew` values that do not name a defined crew. A retired `backend` key is accepted only as inert `cli` or rejected with migration guidance.
 
 The built-in runtime registry uses model-specific standard crews: Claude provides `opus`, `sonnet`, and `fable`; Codex provides `sol`, `terra`, and `luna`; Gemini provides `gemini`; Grok provides `grok`; Copilot provides `copilot`; and Cursor provides `cursor`. Fresh `orbit init` config filters that registry by detected provider CLIs and chooses the first emitted standard crew as `[workflow].default_crew` (`opus`, `sol`, `gemini`, `grok`, `copilot`, or `cursor`).
 

--- a/docs/design/agent-families/3_vision.md
+++ b/docs/design/agent-families/3_vision.md
@@ -4,7 +4,7 @@ type: design
 title: "Agent Families — Vision"
 owner: human
 last_updated: 2026-08-09
-last_validated: 2026-07-27
+last_validated: 2026-08-29
 status: Draft
 feature: agent-families
 doc_role: vision
@@ -44,7 +44,7 @@ The distinction between family and crew also lets future workflows ask two diffe
 ## 4. References
 
 - Orbit internal: [1_overview.md](./1_overview.md), [2_design.md](./2_design.md), [4_decisions.md](./4_decisions.md)
-- Orbit internal: `crates/orbit-common/src/types/agent_pair.rs`
+- Orbit internal: `crates/orbit-types/src/identity/agent_pair.rs`
 - Orbit internal: `crates/orbit-core/src/runtime/engine/crew.rs`
 
 ## Task References

--- a/docs/design/agent-families/4_decisions.md
+++ b/docs/design/agent-families/4_decisions.md
@@ -4,7 +4,7 @@ type: design
 title: "Agent Families — Decisions"
 owner: grok
 last_updated: 2026-08-11
-last_validated: 2026-07-27
+last_validated: 2026-08-29
 status: Draft
 feature: agent-families
 doc_role: decisions
@@ -115,7 +115,7 @@ Family is identity, model is configuration, and slot is role. Orbit identity sur
 
 AO-002 scope: planning-duel plan quality on the Orbit codebase, single window in May 2026, ad-hoc task selection, model versions not held constant (gemini-2.5-pro on two runs, gemini-3.1-pro-preview on three). The thread is explicitly framed as decision-grade-for-us, not an objective ranking.
 
-**Decision.** Until new evidence warrants otherwise, default the planner role on planning duels and design-shaped plans to **claude** (currently `claude-opus-4-x` per workspace crew config). This applies to both implementation-shaped planning and UX / design-shaped planning. The choice is provisional and bound to AO-002's evidence window; AO-002's open questions (post-rubric run on `gemini-3.1-pro-preview` against an implementation task, plan-depth response to a volume-rubric clause, new model-family releases) are the natural triggers for revisiting.
+**Decision.** Until new evidence warrants otherwise, default the planner role on planning duels and design-shaped plans to **claude** (currently the `opus` crew/model alias in the workspace defaults). This applies to both implementation-shaped planning and UX / design-shaped planning. The choice is provisional and bound to AO-002's evidence window; AO-002's open questions (post-rubric run on `gemini-3.1-pro-preview` against an implementation task, plan-depth response to a volume-rubric clause, new model-family releases) are the natural triggers for revisiting.
 
 **Consequences.**
 
@@ -144,7 +144,7 @@ AO-002 scope: planning-duel plan quality on the Orbit codebase, single window in
 
 **Recorded:** 2026-07-11 19:53:22.638085Z · [ORB-10130]
 **Supersedes:** [Replace \[agent.<role>\] tables with named \[crews.*\] registry](#replace-agentrole-tables-with-named-crews-registry)
-**Paths:** `crates/orbit-common/src/types/agent_pair.rs`, `crates/orbit-config/src/**`, `crates/orbit-core/src/runtime/**`, `crates/orbit-store/src/**`, `crates/orbit-dashboard/src/**`, `docs/CONFIG.md`
+**Paths:** `crates/orbit-types/src/identity/agent_pair.rs`, `crates/orbit-config/src/**`, `crates/orbit-core/src/runtime/**`, `crates/orbit-store/src/**`, `crates/orbit-web/src/**`, `docs/CONFIG.md`
 
 ### Context
 Named crews currently carry separate planner, implementer, and reviewer assignments, but production crews are homogeneous and only the implementer is on the primary ship path. Role labels still matter for prompts and telemetry, while model selection through three independent slots adds configuration and persistence complexity without selecting distinct behavior.
@@ -177,7 +177,7 @@ Agent availability is detected once during init using `DetectedAgents`, rendered
 ## Retire crew role slots and role-based model resolution
 
 **Recorded:** 2026-08-09 06:33:12.872319Z · [ORB-10620], [ORB-10621], [ORB-10622]
-**Paths:** `crates/orbit-common/src/types/agent_pair.rs`, `crates/orbit-common/src/types/activity_job/activity_v2.rs`, `crates/orbit-common/src/types/activity_job/job_v2.rs`, `crates/orbit-config/src/**`, `crates/orbit-core/src/runtime/**`, `crates/orbit-engine/src/activity_job/**`, `crates/orbit-core/assets/activities/**`, `docs/CONFIG.md`
+**Paths:** `crates/orbit-types/src/identity/agent_pair.rs`, `crates/orbit-types/src/workflow/activity_job/activity_v2.rs`, `crates/orbit-types/src/workflow/activity_job/job_v2.rs`, `crates/orbit-config/src/**`, `crates/orbit-core/src/runtime/**`, `crates/orbit-engine/src/activity_job/**`, `crates/orbit-core/assets/activities/**`, `docs/CONFIG.md`
 
 ### Context
 
@@ -187,7 +187,7 @@ This amends two clauses of [Flatten crews to one provider-model assignment](#fla
 
 ### Decision
 
-Crew configuration accepts flat `provider`/`model`/`backend` only; the legacy role sub-tables are rejected at load with rewrite guidance rather than collapsed. `AgentRole` and the role-to-assignment resolution path are removed from config, runtime, and asset schemas. Routing becomes: an activity or step with an explicit `crew` input dispatches on that crew, and one without dispatches on the run's resolved crew — replacing today's inline-baseline fallback, so no activity is left without a crew when its role is removed.
+Crew configuration accepts flat `provider`/`model` only; the retired `backend` key is accepted only as inert `cli` or rejected at load. Legacy role sub-tables are rejected at load with rewrite guidance rather than collapsed. `AgentRole` and the role-to-assignment resolution path are removed from config, runtime, and asset schemas. Routing becomes: an activity or step with an explicit `crew` input dispatches on that crew, and one without dispatches on the run's resolved crew — replacing today's inline-baseline fallback, so no activity is left without a crew when its role is removed.
 
 ### Consequences
 
@@ -195,7 +195,7 @@ Crew configuration accepts flat `provider`/`model`/`backend` only; the legacy ro
 - A heterogeneous legacy crew now fails loudly at load instead of losing its planner and reviewer assignments behind a log line.
 - System activities that need a model distinct from the run's crew must name a configured crew through an input, making that choice visible in config rather than in engine code.
 - Cost: breaking config change. Any workspace carrying the three-role shape fails to load until rewritten, and shipped activity assets carrying `role:` must be reseeded in the same release.
-- Cost: the planning duel still overrides provider and model at dispatch time through its own override path, so a duel activity's asset alone does not tell you which model ran it. That carve-out, inherited from [Flatten crews to one provider-model assignment](#flatten-crews-to-one-provider-model-assignment), is unchanged here.
+- Cost: the planning-duel override carve-out described by the superseded crew decision was removed with the planning-duel path; current activity assets use explicit crew input or the run's resolved crew.
 
 ## Task References
 


### PR DESCRIPTION
## Task

[ORB-11036](https://orbit-cli.com/tasks/ORB-11036) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- The six active Markdown docs selected by missing/oldest `last_validated` and stable path tie-break were `docs/design/activity-job/references/glossary.md`, `docs/design/agent-families/1_overview.md`, `2_design.md`, `3_vision.md`, `4_decisions.md`, and `docs/design/auditability/3_vision.md`. Each selected file had 2026-07-27; the four agent-families paths sort before auditability/3_vision.md. Template files were excluded as copy templates.
- Stamped the first five with 2026-08-29 after verification. Corrected the activity glossary's removed `V2RuntimeHost` name; corrected agent-family identity/task paths from the old orbit-common layout to `orbit-types`; corrected crew documentation for provider-model dispatch and retired backend handling; corrected the stale Claude model alias; corrected retired planning-duel wording; and corrected historical code-anchor paths from orbit-dashboard to orbit-web.
- Verification evidence: `rg --files`, `rg -n`, and source reads of `crates/orbit-types/src/identity/{actor,agent_pair}.rs`, `crates/orbit-types/src/task/model.rs`, `crates/orbit-types/src/workflow/activity_job`, `crates/orbit-config/src/{raw,resolved,seed}.rs`, `crates/orbit-core/src/runtime/engine/crew.rs`, `crates/orbit-core/src/adapter/engine_host/v2_host`, `crates/orbit-engine/src/context/hosts.rs`, `crates/orbit-engine/src/activity_job/{cli_runner/orchestrator.rs,audit_writer.rs}`, `crates/orbit-core/src/application/executor.rs`, `crates/orbit-common/src/model_defaults.rs`, and `crates/orbit-web/src`.
- `docs/design/auditability/3_vision.md` was inspected but left byte-for-byte unchanged and unstamped because its Temporal/Airflow, OpenTelemetry, SLSA/in-toto/Sigstore/Rekor, and generic security-audit comparison claims are not verifiable against this repository. No selected document needed frontmatter migration; all had existing schema-compatible `type` and `summary`.
- No auto-task overview, template, archive, ADR, changelog, or generated state was modified.

Validation:
- `make ci-fast` passed after the final edit.
- `git diff --check` passed.
- Referenced current paths passed explicit `test -e` checks.
- Final diff contains only the five stamped docs.

Assessment: Success. Only evidence-backed documentation corrections and earned validation stamps were made; no new sections, metadata fields, sidecars, or prose reflow were introduced.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11036-6a930d22`
- Behind base: 0
- Ahead of base: 1