### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/auditability/4_decisions.md
+++ b/docs/design/auditability/4_decisions.md
@@ -4,7 +4,7 @@ type: design
 title: "Auditability — Decisions"
 owner: codex
 last_updated: 2026-08-11
-last_validated: 2026-07-27
+last_validated: 2026-08-29
 status: Draft
 feature: auditability
 doc_role: decisions
@@ -427,7 +427,7 @@ Store friction reports under `.orbit/frictions/{yyyy}-{mm}/F{nnn}.md` with YAML 
 
 **Recorded:** 2026-08-09 19:30:11.118493Z · [ORB-10680]
 **Supersedes:** [Friction reports are append-only records, not lifecycle tasks](#friction-reports-are-append-only-records-not-lifecycle-tasks)
-**Paths:** `crates/orbit-store/src/file/friction_store/**`, `crates/orbit-store/src/sqlite/**`, `crates/orbit-core/src/runtime/orbit_tool_host/**`, `crates/orbit-dashboard/src/api/frictions.rs`, `docs/design/auditability/**`, `docs/design/mcp-bridge/**`
+**Paths:** `crates/orbit-store/src/driver/file/friction_store/**`, `crates/orbit-store/src/driver/sqlite/**`, `crates/orbit-core/src/adapter/tool_host/**`, `crates/orbit-web/src/api/frictions.rs`, `docs/design/auditability/**`, `docs/design/mcp-bridge/**`
 
 ### Context
 [Friction reports are append-only records, not lifecycle tasks](#friction-reports-are-append-only-records-not-lifecycle-tasks) correctly separated friction reports from planned task work, but coupled that semantic decision to Markdown files under `.orbit/frictions/`. File backing was reasonable while records were low-volume, Git-visible, and directly inspectable. Frictions are now hub-only coordination state, authors and operators mutate them through Orbit surfaces, and every filtered list or stats request parses and materializes the complete retained file corpus. The real alternatives are to retain per-record Markdown for direct inspection or preserve the artifact semantics while moving live persistence to indexed SQLite.
@@ -494,11 +494,11 @@ Ship-path PR transitions carry attribution on each automation update. The Review
 ## Derive invocation cost at query time from a versioned price table
 
 **Recorded:** 2026-07-20 04:06:48.987384Z · [ORB-10338]
-**Paths:** `crates/orbit-common/src/types/pricing.rs`, `crates/orbit-common/assets/model_prices.yaml`, `crates/orbit-store/src/sqlite/invocation_store/**`
+**Paths:** `crates/orbit-common/src/model/pricing.rs`, `crates/orbit-common/assets/model_prices.yaml`, `crates/orbit-store/src/driver/sqlite/invocation_store/**`
 
 **Context.** The invocation store already retains exact per-invocation token splits, but had no notion of USD cost — cost existed only as a provider-reported total buried in the worker's unparsed per-run JSON, never joined to a model or token split. [ORB-10338] adds cost. Two real alternatives existed: (a) compute cost once at ingest time and store it as a frozen column, or (b) keep rows token-only and derive cost from a versioned price table looked up by exact model string and the invocation's timestamp on every read/aggregate.
 
-**Decision.** Cost is derived at query time, not stored. `orbit_common::types::pricing` ships a versioned price table as an in-repo YAML asset (`crates/orbit-common/assets/model_prices.yaml`), keyed by exact model string plus an `effective_from`/`effective_until` date range, parsed once behind a `OnceLock` cache. `InvocationRecord` gains `derived_cost_usd` (computed at read time from the row's token splits, model, and timestamp against the price table) alongside a new `provider_cost_usd` column that persists the provider's own reported total verbatim for monthly manual reconciliation. Adding or correcting a price row is a YAML edit, not a Rust code change.
+**Decision.** Cost is derived at query time, not stored. `orbit_common::model::pricing` ships a versioned price table as an in-repo YAML asset (`crates/orbit-common/assets/model_prices.yaml`), keyed by exact model string plus an `effective_from`/`effective_until` date range, parsed once behind a `OnceLock` cache. `InvocationRecord` gains `derived_cost_usd` (computed at read time from the row's token splits, model, and timestamp against the price table) alongside a new `provider_cost_usd` column that persists the provider's own reported total verbatim for monthly manual reconciliation. Adding or correcting a price row is a YAML edit, not a Rust code change.
 
 **Consequences.**
 - Historical invocation rows re-price automatically when a price row is corrected or backfilled — no migration/backfill script needed to fix a wrong rate.
@@ -534,7 +534,7 @@ The full reasoning is preserved in [Workflow alone creates shipment commits whil
 ## Provider subprocess liveness is a separate audit event probed at read time
 
 **Recorded:** 2026-07-27 02:57:13.483354Z · [ORB-10496]
-**Paths:** `crates/orbit-engine/src/activity_job/cli_runner/**`, `crates/orbit-core/src/runtime/run_audit.rs`, `crates/orbit-common/src/utility/process_identity.rs`, `crates/orbit-dashboard/src/api/runs.rs`
+**Paths:** `crates/orbit-engine/src/activity_job/cli_runner/**`, `crates/orbit-core/src/runtime/run_audit.rs`, `crates/orbit-common/src/process/identity.rs`, `crates/orbit-web/src/api/runs.rs`
 
 ### Context
 
@@ -552,7 +552,7 @@ Extending the existing `cli.invocation.started` event was not an option: it is e
 
 Emit one new `cli.invocation.process` v2 audit event (`provider`, `pid`, `pid_start_time`) immediately after spawn and before the supervision loop, ordered strictly between `cli.invocation.started` and `cli.invocation.finished`. The envelope writer persists synchronously, so the row is readable while the invocation is still running.
 
-Liveness is computed at read time, not stored. `orbit_common::utility::process_identity::probe_process_liveness` answers `alive` / `exited` / `unknown` from `kill(pid, 0)` plus the Linux zombie check, using the recorded `pid_start_time` token to reject a recycled PID. `OrbitRuntime::collect_run_provider_processes` pairs each process event with the `cli.invocation.finished` event that closes it within the same step and probes only the still-open ones. `GET /api/runs/:id` (bridge `workflow_run_status`) and `orbit run show` project the result.
+Liveness is computed at read time, not stored. `orbit_common::process::identity::probe_process_liveness` answers `alive` / `exited` / `unknown` from `kill(pid, 0)` plus the Linux zombie check, using the recorded `pid_start_time` token to reject a recycled PID. `OrbitRuntime::collect_run_provider_processes` pairs each process event with the `cli.invocation.finished` event that closes it within the same step and probes only the still-open ones. `GET /api/runs/:id` (bridge `workflow_run_status`) and `orbit run show` project the result.
 
 ### Consequences
 
@@ -566,7 +566,7 @@ Liveness is computed at read time, not stored. `orbit_common::utility::process_i
 ## Friction records carry an author-settable title; derivation is a structural fallback
 
 **Recorded:** 2026-08-02 23:41:57.916629Z · [ORB-10590], [ORB-10598]
-**Paths:** `crates/orbit-common/src/friction/**`, `crates/orbit-store/src/file/friction_store/**`
+**Paths:** `crates/orbit-common/src/governance/friction/**`, `crates/orbit-store/src/driver/file/friction_store/**`
 
 ### Context
 
@@ -599,7 +599,7 @@ The result is clamped to `FRICTION_TITLE_MAX_CHARS` (120) at a word boundary. An
 
 - Every friction lands with a handle that names its subject: an author's own title, or the first prose statement of the body, never a bare section label and never an unreadable paragraph.
 - The existing corpus self-heals on read for the section-label and overlong cases. A record whose body genuinely never states its subject still needs a human title; `update --title` is the supported way to give it one.
-- Title validation lives in one place (`orbit_common::friction::title`) and both tool-host implementations — the checkout-backed host and the checkoutless hub coordination executor — call it, so the two write paths cannot drift on what a legal title is.
+- Title validation lives in one place (`orbit_common::governance::friction::title`) and both tool-host implementations — the checkout-backed host and the checkoutless hub coordination executor — call it, so the two write paths cannot drift on what a legal title is.
 - Cost: the MCP tool schema for `orbit.friction.add` and `.update` gains a parameter. The addition is additive and optional — every existing call keeps working unchanged — but it is still a tool-surface change, and the snapshot guard treats schema drift as release-visible.
 - Cost: two structural rules are more code than a first-line read, and they can still be wrong. A body whose first section genuinely holds the subject in its second sentence derives a weaker title than a careful author would write. The stored field is the escape hatch, which is why it is the primary mechanism and derivation only the fallback.
 - Cost: the deployed `orbit` binary and the Bridge MCP server must be rebuilt before `--title` is reachable from a live surface; until then existing records cannot be retitled through the tools.
@@ -607,7 +607,7 @@ The result is clamped to `FRICTION_TITLE_MAX_CHARS` (120) at a word boundary. An
 ## Friction records move to SQLite with a legacy-evidence path projection
 
 **Recorded:** 2026-08-09 20:25:57.877485Z · [ORB-10680]
-**Paths:** `crates/orbit-store/src/sqlite/friction_store/**`, `crates/orbit-store/src/file/friction_store/**`
+**Paths:** `crates/orbit-store/src/repository/friction/**`, `crates/orbit-store/src/driver/sqlite/migration/**`, `crates/orbit-store/src/driver/file/friction_store/**`
 
 **Context.** Friction list, filtered-query, and stats operations discovered every Markdown record under a workspace's friction tree, parsed every YAML envelope and body, allocated the complete corpus as `Vec<StoredFrictionRecord>`, and only then filtered, sorted, paginated, or aggregated. Peak memory and parse work therefore grew with total retained friction history even when a caller asked for a 50-row page or a narrow status filter. The file-backed rationale no longer matched the runtime contract: frictions are hub-only coordination state, writes go through Orbit surfaces rather than human file edits, and the canonical hub already copies checkout-local records into a global per-workspace file tree. A public `path` field pointed at the backing Markdown file, so moving persistence could not silently leave it fictitious.
 

--- a/docs/design/auto-tasks/1_overview.md
+++ b/docs/design/auto-tasks/1_overview.md
@@ -2,7 +2,7 @@
 title: Auto-tasks — Overview
 owner: claude
 last_updated: 2026-08-22
-last_validated: 2026-07-27
+last_validated: 2026-08-29
 status: Accepted
 feature: auto-tasks
 doc_role: overview
@@ -69,14 +69,14 @@ becomes just the first definition.
 
 | Concern | File | Task |
 |---|---|---|
-| Definition schema | `crates/orbit-common/src/types/auto_task.rs` | ORB-10149 |
+| Definition schema | `crates/orbit-types/src/workflow/auto_task.rs` | ORB-10149 |
 | Discovery (fail-closed) | `crates/orbit-core/src/auto_tasks/loader.rs` | ORB-10149 |
 | Due-math + catch-up | `crates/orbit-core/src/auto_tasks/schedule.rs` | ORB-10149 |
 | Host-local cursor | `crates/orbit-core/src/auto_tasks/state.rs` | ORB-10149 |
 | Scheduler pass | `crates/orbit-core/src/auto_tasks/scheduler.rs` | ORB-10149 |
 | CRUD (CLI + MCP shared) | `crates/orbit-core/src/auto_tasks/crud.rs` | ORB-10149 |
 | Manual mint (`mint`, CLI + MCP) | `crates/orbit-core/src/auto_tasks/crud.rs` | ORB-10439, ORB-10798 |
-| Deterministic action | `crates/orbit-core/src/runtime/v2_host/dispatch.rs` | ORB-10149 |
+| Deterministic action | `crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs` | ORB-10149 |
 | Seeded assets | `crates/orbit-core/assets/{activities,jobs,routines}/…` | ORB-10149 |
 | Default auto-task catalog | `crates/orbit-core/assets/auto_tasks/…` | ORB-10549, ORB-10550, ORB-10950 |
 

--- a/docs/design/auto-tasks/3_vision.md
+++ b/docs/design/auto-tasks/3_vision.md
@@ -2,7 +2,7 @@
 title: Auto-tasks — Vision
 owner: claude
 last_updated: 2026-07-12
-last_validated: 2026-07-27
+last_validated: 2026-08-29
 status: Accepted
 feature: auto-tasks
 doc_role: vision

--- a/docs/design/auto-tasks/4_decisions.md
+++ b/docs/design/auto-tasks/4_decisions.md
@@ -2,7 +2,7 @@
 title: Auto-tasks — Decisions
 owner: claude
 last_updated: 2026-08-11
-last_validated: 2026-07-27
+last_validated: 2026-08-29
 status: Accepted
 feature: auto-tasks
 doc_role: decisions
@@ -43,7 +43,7 @@ Introduce auto-tasks as git-versioned YAML definitions under `.orbit/auto_tasks/
 ## No-diff-expected tasks bypass repository change gates
 
 **Recorded:** 2026-07-12 03:33:35.554901Z · [ORB-10148]
-**Paths:** `crates/orbit-engine/src/executor/automation/vcs/**`, `crates/orbit-common/src/types/task.rs`, `.orbit/auto_tasks/**`
+**Paths:** `crates/orbit-engine/src/executor/automation/vcs/**`, `crates/orbit-types/src/task/model.rs`, `.orbit/auto_tasks/**`
 
 ### Context
 
@@ -79,7 +79,7 @@ Read and replace tracked auto-task definitions through the runtime local root. K
 ## Run budgets are provider-neutral: wall-clock timeouts, never turn caps
 
 **Recorded:** 2026-07-12 03:33:34.766432Z · [ORB-10146], [ORB-10148]
-**Paths:** `crates/orbit-core/assets/**`, `crates/orbit-common/src/types/auto_task.rs`, `.orbit/auto_tasks/**`
+**Paths:** `crates/orbit-core/assets/**`, `crates/orbit-types/src/workflow/auto_task.rs`, `.orbit/auto_tasks/**`
 
 ### Context
 

--- a/docs/design/executors/4_decisions.md
+++ b/docs/design/executors/4_decisions.md
@@ -2,14 +2,14 @@
 title: Executors — Decisions
 owner: claude
 last_updated: 2026-08-11
-last_validated: 2026-07-27
+last_validated: 2026-08-29
 status: Draft
 feature: executors
 doc_role: decisions
 type: design
 summary: Decision log for executor registration and the (now retired) External Executor Protocol.
 tags: [executors]
-paths: ["crates/orbit-common/src/types/executor_def.rs"]
+paths: ["crates/orbit-types/src/workflow/executor_def.rs"]
 related_features: [executors]
 related_artifacts: [ORB-00384, ORB-00400, ORB-10395]
 ---
@@ -29,7 +29,7 @@ this exception in the same PR.
 ## External Executor Protocol for dynamic out-of-process executor registration (retired)
 
 **Recorded:** 2026-06-14 00:40:41.791069Z · [ORB-00384], [ORB-10395]
-**Paths:** `crates/orbit-common/src/types/executor_def.rs`, `docs/design/executors/**`
+**Paths:** `crates/orbit-types/src/workflow/executor_def.rs`, `docs/design/executors/**`
 
 > **RETIRED 2026-07-26 — [ORB-10395].** The External Executor Protocol is not a supported Orbit surface. Retiring the v1 executor stack removed everything this decision stood up: `ExternalExecutor`, the shared `direct_agent` subprocess transport, `ActivityExecutorRegistry`, the `ActivityExecutor` trait, the v1 `ExecutionContext`, the `external.example.yaml` template, and the conformance fixture. v2 dispatch (`orbit-engine::activity_job`) is the only execution path and consults no executor registry, so an `executor_type: external` def is now inert — it deserializes and stores, but nothing spawns it. `ExecutorType::External` survives in the wire enum only so pre-existing defs keep parsing; dropping the variant is a separate release decision, tracked alongside the same call for `ExecutorType::AgentCli`. The Consequences below are history, not live obligations — in particular the wire protocol is **no longer** a backward-compatibility obligation. Any future out-of-process extension point must be decided afresh against the v2 dispatch path.
 


### PR DESCRIPTION
## Task

[ORB-11045](https://orbit-cli.com/tasks/ORB-11045) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Batch selection: the six oldest active design docs after excluding copy templates (all six had last_validated: 2026-07-27) were docs/design/auditability/3_vision.md, docs/design/auditability/4_decisions.md, docs/design/auto-tasks/1_overview.md, docs/design/auto-tasks/3_vision.md, docs/design/auto-tasks/4_decisions.md, and docs/design/executors/4_decisions.md. docs/design/executors/specs/external-executor-protocol.md was the next stable-path tie and was not included. The four docs/design/_templates files were excluded as copy templates, consistent with the prior rotation.
- docs/design/auditability/3_vision.md was inspected but left byte-for-byte unchanged and unstamped: its central comparisons to Temporal/Airflow, OpenTelemetry, SLSA/in-toto/Sigstore/Rekor, and generic security-audit systems are not verifiable from this repository.
- docs/design/auditability/4_decisions.md was verified and stamped 2026-08-29. Updated stale ownership paths/modules for friction storage and tool hosting, invocation pricing, provider-process identity/API, and friction-title validation. Verification used source-symbol searches for V2AuditEnvelope, LoopAuditEvent, InvocationTrace, audit stores, process liveness, self-reported attribution, and friction title handling; existence checks covered every corrected path.
- docs/design/auto-tasks/1_overview.md was verified and stamped 2026-08-29. Corrected the definition-schema path to crates/orbit-types/src/workflow/auto_task.rs and deterministic-action path to crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs. Verified with source reads, path checks, auto-task CLI help, and current seeded activity/job/routine assets.
- docs/design/auto-tasks/3_vision.md was verified and stamped 2026-08-29 with no prose changes. Current internal routine/scheduler/task-flow claims were checked against the auto-task implementation and docs/design/routines; the Temporal/Cadence analogy was not repository-verifiable and was left unchanged.
- docs/design/auto-tasks/4_decisions.md was verified and stamped 2026-08-29. Corrected stale Paths entries from orbit-common task/auto-task locations to orbit-types task/model and workflow/auto_task. Verified scheduler, cursor, dedupe, manual-mint, no-diff gate, and provider-neutral budget claims with source reads and targeted rg checks.
- docs/design/executors/4_decisions.md was verified and stamped 2026-08-29. Corrected the frontmatter and decision Paths entry to crates/orbit-types/src/workflow/executor_def.rs. Verified ExecutorType::External persistence and v2 CLI dispatch behavior in orbit-types, orbit-core, orbit-store tests, and the retired protocol document; historical retired-protocol claims were preserved.
- No frontmatter migration was needed: every selected doc already had schema-compatible type and summary. No new sections, documents, metadata fields, sidecars, or protected/generated files were added or modified.

Validation:
- make ci-fast passed.
- git diff --check passed.
- Markdown relative-link checks passed.
- Final diff contains only the five verified/stamped docs; protected-path scan found no violations.

Assessment: Success. The bounded rotation was followed, unverifiable claims were not rewritten or falsely stamped, and changes are limited to evidence-backed path/module corrections plus earned validation dates.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11045-6a93137f`
- Behind base: 0
- Ahead of base: 1