### PR TITLE
Add focused agent guides to Orbit's foundational crates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ ci-fast:
 	./scripts/check-changelog-style.sh
 	./scripts/check-error-translation.sh
 	./scripts/check-orphan-modules.sh
+	./scripts/check-crate-agent-guides.sh
 	./scripts/check-embedded-asset-portability.py
 	./scripts/sync-plugin-skills.sh --check
 	./scripts/test-validate-codex-plugin.sh

--- a/crates/orbit-cli/CLAUDE.md
+++ b/crates/orbit-cli/CLAUDE.md
@@ -22,10 +22,10 @@ forces a directory.
 
 ### Reference shapes
 
-- [`hook/`](src/command/hook) — three subcommands, one `.rs` per body, shared
-  enum types in `render.rs`.
-- [`learning/`](src/command/learning) — eight subcommands, one `.rs` per body,
-  shared formatting in `output.rs`.
+- [`skill/`](src/command/skill) — five subcommands, one `.rs` per body, no
+  shared helper file needed.
+- [`audit/`](src/command/audit) — five subcommands, one `.rs` per body, shared
+  helpers in `support.rs`.
 - [`task/`](src/command/task) — large surface with `artifact` nested parent
   and a `tests/` subdir mirroring source files.
 - [`init/`](src/command/init) — no subcommands, but owns the host-facing init

--- a/crates/orbit-cmd/AGENTS.md
+++ b/crates/orbit-cmd/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/orbit-cmd/CLAUDE.md
+++ b/crates/orbit-cmd/CLAUDE.md
@@ -1,0 +1,76 @@
+# orbit-cmd
+
+Project instructions for the shared application-composition crate.
+
+## One job
+
+`orbit-cmd` exists to solve exactly one problem: **`orbit-registry` sits above
+`orbit-core` in the crate graph, so Core cannot see the machine's workspace
+catalog.** Any command group that needs both a Core runtime and Registry state
+lives here, so that neither lower-layer dependency has to be reversed.
+
+Both `orbit-cli` and `orbit-web` consume it. A command group whose logic is
+needed by Core's own runtime internals (tool hosts, engine hosts, bootstrap
+seeding) belongs in `orbit-core::adapter::command`, not here.
+
+## Layout: one flat module per command group
+
+The source tree is deliberately flat — [`doctor.rs`](src/doctor.rs),
+[`migrate.rs`](src/migrate.rs), [`registry_runtime.rs`](src/registry_runtime.rs),
+[`registry_routines.rs`](src/registry_routines.rs),
+[`workspace_catalog.rs`](src/workspace_catalog.rs),
+[`task_owner.rs`](src/task_owner.rs), [`diagnostics.rs`](src/diagnostics.rs),
+[`activity_v2.rs`](src/activity_v2.rs), [`agent_rules.rs`](src/agent_rules.rs).
+Each file owns one group and states, in its module doc, which boundary it
+closes. Give a group a directory only when it genuinely grows sibling modules
+of its own; do not create a grouping directory that mirrors the CLI's `--help`
+sections.
+
+Each module names exactly one composition seam. `workspace_catalog` turns a
+`WorkspaceScope` into registered checkouts for Core's federated search;
+`task_owner` is the single owner of "which registered workspace owns this task
+ID"; `registry_runtime` builds Core's runtime binding from a registered
+checkout. If a new file cannot be described that way in one sentence, it is
+probably two files or belongs in another crate.
+
+## Runtime methods are extension traits
+
+Behavior that would once have been an inherent `impl OrbitRuntime` block is
+exposed as a per-module `*Commands` trait (`DoctorCommands`, `MigrateCommands`,
+`ActivityV2Commands`, `DiagnosticsCommands`), re-exported through
+[`prelude`](src/lib.rs). Add a new group the same way, and add its trait to the
+prelude in the same change.
+
+## Pure consumer of Core's public API
+
+Every module here is a consumer of `orbit_core::OrbitRuntime`'s **public**
+surface. When something you need is not exposed:
+
+1. Add the seam in `orbit-core` deliberately, with the visibility widening
+   justified there.
+2. Then consume it here.
+
+Never reach around Core to re-implement a rule it owns. Validation,
+authorization, audit decisions, and persistence invariants stay in Core and
+`orbit-store`; this crate composes and projects.
+
+Equally, nothing here may become presentation. There is no `clap` and no
+`axum` dependency, and there must not be one — argv parsing and help text stay
+in `orbit-cli`, HTTP handlers in `orbit-web`. Returning a plain result struct
+that both can render is the point.
+
+## Assets
+
+[`assets/agent-rules.md`](assets/agent-rules.md) is the self-contained block
+`orbit workspace init --inject-agent-rules` writes into a workspace's
+`CLAUDE.md` / `AGENTS.md`. Its start/end markers live literally inside the
+asset because injection is re-runnable and must find its own previous output —
+edit the asset, not the marker handling, when the rule text changes.
+
+## Tests
+
+Unit tests live in [`src/tests/`](src/tests) mirroring source filenames
+([`test_layout.md`](../../docs/design-patterns/test_layout.md)). There is no
+crate-root `tests/` directory: end-to-end coverage of these command groups
+belongs to the CLI's integration tests, which exercise the same code through
+the real entry point.

--- a/crates/orbit-cmd/src/lib.rs
+++ b/crates/orbit-cmd/src/lib.rs
@@ -17,8 +17,8 @@
 //! around. Consumed by `orbit-cli` and `orbit-web`.
 //! Command groups that
 //! orbit-core's runtime internals (tool hosts, engine hosts, bootstrap
-//! seeding) invoke remain in `orbit-core::command`; see `ARCHITECTURE.md`
-//! for the boundary.
+//! seeding) invoke remain in `orbit_core::adapter::command`; see
+//! `ARCHITECTURE.md` for the boundary.
 
 pub mod activity_v2;
 pub mod agent_rules;

--- a/crates/orbit-common/AGENTS.md
+++ b/crates/orbit-common/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/orbit-common/CLAUDE.md
+++ b/crates/orbit-common/CLAUDE.md
@@ -1,0 +1,91 @@
+# orbit-common
+
+Project instructions for the shared mechanism crate.
+
+## One job
+
+Mechanisms every layer needs, sitting directly above `orbit-types` and below
+everything else. It owns the workspace-wide `OrbitError` and a small set of
+responsibility-named modules; it owns no feature, no runtime, and no storage
+backend.
+
+The split against its only dependency is sharp: **`orbit-types` says what a
+thing is, `orbit-common` says how to do something with it.** A pure shape with
+no behavior belongs in `orbit-types`. Anything that touches the filesystem, a
+process, an environment variable, a SQLite connection, YAML, or a tracing
+subscriber belongs here — or, if it is specific to one feature, in that
+feature's crate rather than here.
+
+## Modules are named for a responsibility, not a feature
+
+[`error`](src/error.rs), [`fs`](src/fs), [`governance`](src/governance),
+[`migration`](src/migration), [`model`](src/model),
+[`observability`](src/observability), [`process`](src/process),
+[`protocol`](src/protocol), [`security`](src/security),
+[`storage`](src/storage).
+
+Never add a module named after a caller (`core_support`, `cli_helpers`) or a
+vertical feature. If new code does not fit an existing responsibility, that is
+evidence it belongs to the crate that needs it, not evidence for a new bucket
+here. Each top-level module's `mod.rs` is declarations plus
+`#[cfg(test)] mod tests;` only — see [`security/mod.rs`](src/security/mod.rs).
+Behavior lives in the leaf files.
+
+Tests use the sibling `tests/` layout
+([`test_layout.md`](../../docs/design-patterns/test_layout.md)).
+[`tests/task_artifacts_v2.rs`](tests/task_artifacts_v2.rs) at the crate root is
+a Cargo integration test against the public surface — keep unit coverage in the
+sibling directories instead of growing that file.
+
+## Single-owner invariants
+
+Some modules here exist *because* the behavior must have exactly one
+implementation. Do not reimplement these at a call site, and do not add a
+surface-local variant:
+
+- [`security::child_env`](src/security/child_env.rs) is the only builder for an
+  agent-subprocess environment. It is **allowlist**-based on purpose: a
+  denylist admits every credential nobody thought to name. Every subprocess
+  launcher applies it to a *cleared* environment; `orbit-config` only supplies
+  the operator's `[execution.env]` pass list.
+- [`security::redaction`](src/security/redaction.rs) is the only redaction
+  implementation. `scripts/check-artifact-redaction-guardrail.sh` fails the
+  build if a task/friction tool surface or a CLI-runner argv path grows its own
+  `fn redact_*`.
+- [`fs::selector`](src/fs/selector.rs) owns `SelectorParseError` and its
+  `selector_error_to_orbit` translator; per
+  [`error_translation.md`](../../docs/design-patterns/error_translation.md) no
+  caller crate may translate it.
+- [`migration`](src/migration) is the forward-only, read-time YAML migration
+  framework. It deliberately has no rollback and no write-back; one-shot
+  importers belong in `orbit-store::workflow`.
+
+## Operation registries live here, handlers do not
+
+[`governance::operation`](src/governance/operation.rs) is the
+operations-as-data kernel, and [`governance::friction`](src/governance/friction)
+is the first noun declared through it. The kernel lives in this leaf crate
+precisely so every consumer surface (`orbit-tools`, `orbit-cli`, `orbit-web`,
+`orbit-core`) can read the same table without a new dependency edge, which
+means it must stay transport- and runtime-agnostic: **no clap types, no axum
+types, no `OrbitRuntime` handle.**
+
+Handlers need a runtime, so the handler table lives in `orbit-core` and is
+joined to the spec table by the noun's verb enum. Adding a verb here without
+its handler arm is a compile error by construction — that is the design, not a
+gap to paper over with a default arm.
+
+Every string in a registry (tool name, parameter name, CLI flag spelling, help
+text) is shipped contract. Changing one is a consumer-visible break.
+
+## Feature flags
+
+- `sqlite` gates [`storage::sqlite`](src/storage/sqlite.rs) so non-SQLite
+  consumers (`orbit-policy`, `orbit-exec`) do not pull `rusqlite`.
+- `test-util` exposes [`test_env`](src/test_env.rs) and
+  [`test_fixtures`](src/test_fixtures.rs) to sibling crates, which cannot see
+  this crate's `#[cfg(test)]` items. Consume it from `[dev-dependencies]` only;
+  never from a production dependency.
+- `clap` forwards to `orbit-types/clap` and adds nothing of its own.
+
+Keep gated code behind the flag rather than always-compiled with an `#[allow]`.

--- a/crates/orbit-core/AGENTS.md
+++ b/crates/orbit-core/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/orbit-core/CLAUDE.md
+++ b/crates/orbit-core/CLAUDE.md
@@ -1,0 +1,85 @@
+# orbit-core
+
+Project instructions for the runtime composition crate.
+
+## One job
+
+Assemble every lower subsystem into `OrbitRuntime` and own the coordinated
+use cases that need more than one of them. It is the authoritative place for
+domain validation, authorization, auditing, and lifecycle decisions — the layer
+that says *yes or no*, where transports only collect input.
+
+It depends on the kernels below it and on nothing above: never `orbit-cmd`,
+never `orbit-cli`/`orbit-web`, never `orbit-registry` (see
+[orbit-cmd](../orbit-cmd/CLAUDE.md) for where Core and Registry meet), and never
+`orbit-agent` (the engine's `cli_runner` owns that edge).
+
+## The internal graph is enforced
+
+`runtime <- application <- adapter`, with `composition` as the only joiner.
+[`scripts/check-dependency-direction.sh`](../../scripts/check-dependency-direction.sh)
+fails the build on a violation:
+
+- [`runtime/`](src/runtime) — mechanisms: stores, event bus, audit, claims and
+  reservations, tool and process execution, root resolution, the workspace
+  catalog. It may not import `crate::application` or `crate::adapter`, and it
+  may not call `ResolvedConfig::load` or construct `ConfigRoots` — resolved
+  configuration is *handed to it* by composition.
+- [`application/`](src/application) — shared use cases and their DTOs. It may
+  not import `crate::adapter`.
+- [`adapter/`](src/adapter) — protocol translation only:
+  [`tool_host`](src/adapter/tool_host) for Orbit tools,
+  [`engine_host`](src/adapter/engine_host) implementing
+  `orbit_engine::RuntimeHost`, and [`command`](src/adapter/command) for command
+  dispatch. Adapters translate and delegate; a decision made in an adapter is a
+  decision in the wrong place.
+- [`composition.rs`](src/composition.rs) — the only module that loads resolved
+  config and joins bootstrap, runtime construction, and adapter registration.
+- [`bootstrap/`](src/bootstrap) — initialization, managed-asset seeding, policy
+  seeding, forward-only startup migrations. Runs once, at open.
+
+`auto_tasks`, `routines`, and `metrics` are domain kernels layered on the
+runtime: scheduling and derived measurement, each fired through the same v2 job
+machinery rather than through bespoke code paths.
+
+The guardrail also fails if a retired path reappears: `src/command`,
+`src/runtime/orbit_tool_host`, `src/runtime/engine/runtime_host.rs`. Do not
+recreate them; their successors are `orbit-cmd`, `adapter/tool_host`, and
+`adapter/engine_host`.
+
+## Root re-exports are justified, not convenient
+
+Every `pub use` at [`lib.rs`](src/lib.rs) must correspond to a real import in a
+consumer crate (`orbit-cli`, `orbit-web`, `orbit-cmd`). Do not add one to
+shorten a path. Anything else is imported from its owning module
+(`orbit_core::application::…`, `orbit_core::runtime::…`) or, when the type is
+not Core's, from its owning crate (`orbit_common`, `orbit_store`,
+`orbit_engine`). When you remove a consumer, remove the re-export with it.
+
+## Crate-specific invariants
+
+- **Core decides; MCP and the CLI ask.** New authorization, quota, or
+  validation logic belongs here even when the caller is a transport — do not
+  mirror a Core rule as client-side orchestration.
+- **Operation handlers are joined by the verb enum.**
+  [`adapter/tool_host/friction_tools.rs`](src/adapter/tool_host/friction_tools.rs)
+  matches exhaustively on `FrictionVerb`, whose spec table lives in
+  `orbit_common::governance::friction`. The compiler is what proves every
+  declared verb is wired, so a new verb must never get a default arm.
+- **Redaction stays shared.** `scripts/check-artifact-redaction-guardrail.sh`
+  forbids surface-local `fn redact_*` in
+  [`adapter/tool_host`](src/adapter/tool_host) and
+  [`application/task/add.rs`](src/application/task/add.rs).
+- **Two roots, always.** Runtime resolution is a global root (`~/.orbit/`) plus
+  a workspace root (nearest ancestor `.orbit/`). Scope decisions follow the
+  table in [`ARCHITECTURE.md`](../../ARCHITECTURE.md) §Scoping Rules; do not
+  invent a third root or read one root's artifact from the other's path.
+
+## Tests
+
+Sibling `tests/` directories per module
+([`test_layout.md`](../../docs/design-patterns/test_layout.md)). Crate-root
+[`tests/`](tests) is reserved for integration tests that drive a composed
+runtime end-to-end, such as the fake-agent backend smokes. Test a use case at
+its owning boundary — an `application` operation through `application`, not
+through an adapter that happens to call it.

--- a/crates/orbit-engine/AGENTS.md
+++ b/crates/orbit-engine/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/orbit-engine/CLAUDE.md
+++ b/crates/orbit-engine/CLAUDE.md
@@ -1,0 +1,84 @@
+# orbit-engine
+
+Project instructions for the activity/job execution engine.
+
+## One job
+
+Run a v2 activity or job to completion: resolve inputs through templates,
+dispatch to a provider CLI or a deterministic action, record step results and
+audit rows, and handle retry, resume, fan-out, and concurrency. It sits above
+`orbit-agent`, `orbit-exec`, `orbit-store`, and `orbit-tools`, and is consumed
+by `orbit-core`.
+
+It owns *how* work runs. It does not own *what* work exists or who may ask for
+it: catalog placement, workspace resolution, authorization, and task lifecycle
+policy are Core's. The engine must never depend on `orbit-core`, `orbit-cmd`,
+or any transport crate.
+
+## `RuntimeHost` is the capability boundary
+
+[`context::hosts`](src/context/hosts.rs) defines the single trait through which
+job execution reaches anything the engine does not own — task reads and
+updates, event emission, invocation queries, agent dispatch. Core implements it
+in its `adapter/engine_host` module.
+
+When execution needs a new capability, **add a method to `RuntimeHost`** with a
+default that returns the `unsupported ... capability` error, and implement it in
+Core. Do not smuggle the capability in by widening a dependency, threading an
+`OrbitRuntime`-shaped handle through, or reading state directly from
+`orbit-store` where a host method belongs.
+
+The one deliberate exception to "engine stays provider-agnostic" is
+[`activity_job::cli_runner`](src/activity_job/cli_runner), which names
+`orbit_agent::{Agent, AgentConfig}` directly. That edge exists so `orbit-core`
+stays clean of `orbit-agent` types; keep it inside `cli_runner` rather than
+letting agent types spread across the engine.
+
+## Internal layout
+
+- [`activity_job/`](src/activity_job) — the run path: asset loading and
+  catalogs, crew resolution, the dispatcher, `cli_runner` (argv, envelope,
+  spawn, supervisor, orchestrator), `job_executor` (step, target, loop, fan-out,
+  parallel, recovery, templating, validate), and the audit sinks.
+- [`executor/automation/`](src/executor/automation) — the deterministic actions
+  a job step can invoke without an agent. The `vcs` subtree (commit, push, PR,
+  worktree, freshness, handoff) is the largest; it is organized by *operation*,
+  and each new operation gets a file, not another arm in an existing one.
+- [`context/`](src/context) — split by concern (`hosts`, `outcome`, `env`) and
+  re-exported so `crate::context::X` paths stay stable.
+- [`template.rs`](src/template.rs), [`condition.rs`](src/condition.rs) — pure
+  rendering and predicate evaluation, no I/O.
+
+The run path is where "several phases in one function" pressure shows up first.
+The `job_executor` and `cli_runner` splits are the reference for relieving it:
+name the phase, give it a file, keep the top-level flow readable.
+
+## Crate-specific invariants
+
+- **Boundary errors are translated here.** `DispatchError` and `CatalogError`
+  are registered in `scripts/check-error-translation.sh`; their
+  `dispatch_error_to_orbit` / `catalog_error_to_orbit` translators must stay in
+  this crate ([`error_translation.md`](../../docs/design-patterns/error_translation.md)).
+  A caller crate that maps their variants to `OrbitError` fails CI.
+- **Redaction is not local.** `scripts/check-artifact-redaction-guardrail.sh`
+  forbids `fn redact_*` in
+  [`cli_runner/orchestrator.rs`](src/activity_job/cli_runner/orchestrator.rs)
+  and [`cli_runner/argv.rs`](src/activity_job/cli_runner/argv.rs); argv and
+  output redaction flows through `orbit_common::security::redaction`.
+- **Child environments are composed, never inherited.** Spawn paths build the
+  environment with `orbit_common::security::child_env` over a cleared
+  environment, plus the shared provenance variables in
+  [`context/env.rs`](src/context/env.rs).
+- **Resume must stay correct.** Step results are durable; a change to
+  `job_executor` step accounting needs coverage in the resume/recovery tests,
+  not just the happy path.
+
+## Tests
+
+Sibling `tests/` directories for unit coverage
+([`test_layout.md`](../../docs/design-patterns/test_layout.md)); crate-root
+[`tests/`](tests) holds the end-to-end v2 runtime, CLI-agent, and
+name-resolution integration tests; [`examples/`](examples) holds the runnable
+v2 smoke programs. Put a new cross-module behavior in the crate-root
+integration tests only when it genuinely exercises the public surface
+end-to-end.

--- a/crates/orbit-mcp/AGENTS.md
+++ b/crates/orbit-mcp/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/orbit-mcp/CLAUDE.md
+++ b/crates/orbit-mcp/CLAUDE.md
@@ -1,0 +1,68 @@
+# orbit-mcp
+
+Project instructions for the Model Context Protocol crate.
+
+## One job
+
+Speak MCP. This crate owns stdio framing, advertised-name translation,
+structured responses, per-call trace creation, canonical tool discovery, server
+identity presentation, the TCP listener, the direct SSH stdio proxy, and the
+federated mux. It is a protocol crate, not a runtime.
+
+Everything a protocol should not decide stays behind the [`McpHost`](src/lib.rs)
+trait: workspace resolution, domain validation, auditing, and authorization.
+The kernel hands the host a canonicalized call plus one trusted
+`ToolSessionContext` and returns what it gets back. If you find yourself
+writing a rule about *whether* a call is allowed, it belongs in `orbit-core`.
+
+## Dependency boundary is a test
+
+[`tests/dep_boundary.rs`](tests/dep_boundary.rs) asserts the exact set of
+internal dependencies (`orbit-common`, `orbit-registry`, `orbit-tools`,
+`orbit-types`) by parsing this crate's manifest. Adding an edge to a command,
+runtime, or Web crate fails that test on purpose — the fix is a host method,
+not a wider manifest.
+
+`rmcp` appears in this crate and nowhere else in the workspace. Keep it that
+way: translate `rmcp` types at the adapter edge rather than re-exporting them,
+so a protocol-library upgrade stays a change in one crate.
+
+## Internal layout
+
+- [`adapter/`](src/adapter) — the MCP server itself:
+  [`dispatch`](src/adapter/dispatch.rs) routes a call,
+  [`name_map`](src/adapter/name_map.rs) translates canonical Orbit tool names to
+  the advertised character set and detects collisions,
+  [`schema`](src/adapter/schema.rs) composes JSON Schema, and
+  [`structured`](src/adapter/structured.rs) shapes responses.
+- [`remote/`](src/remote) — server identity, canonical discovery, and the
+  byte-transparent SSH proxy for a caller that has already chosen one host.
+- [`federated/`](src/federated) — the mux: `config` (operator destinations),
+  `descriptor` (live workspace descriptors), `probe` (in-process and SSH
+  destinations), `capability`, and `host` (`FederatedMcpHost`).
+- [`listener.rs`](src/listener.rs) — the TCP transport and its exposure gate.
+- [`error.rs`](src/error.rs) — error shaping toward MCP clients.
+
+Tests use sibling `tests/` directories
+([`test_layout.md`](../../docs/design-patterns/test_layout.md)); crate-root
+[`tests/`](tests) holds the dependency-boundary assertion and the wire
+round-trip that drives a real client over an in-memory duplex.
+
+## Crate-specific invariants
+
+- **Advertised names are shipped contract.** Sanitization exists because Cursor
+  accepts `[a-zA-Z0-9_]` and VS Code accepts `[a-z0-9_-]`; the mapping keeps
+  Orbit's names inside that intersection *without renaming any canonical
+  identifier*. A collision after sanitization is a hard error, never a silent
+  rename.
+- **The federated mux is the one place Orbit is also an MCP client.** Remote
+  membership comes only from the operator's destinations file; the accepting
+  machine is an implicit local destination, never an SSH row. It is not a fleet
+  registry and answers are not cached between calls.
+- **Routing is fail-closed.** A federated call carries a host-qualified
+  selector the caller copied from federated `orbit.workspace.list`. A local
+  selector is delivered in-process without SSH; anything else is refused as
+  `unknown_selector` rather than guessed at.
+- **The accepting machine resolves local state.** Whatever the transport —
+  stdio, TCP, SSH proxy, or a routed federated call — the machine that accepts
+  the call resolves its own workspaces and dispatches through Core.

--- a/crates/orbit-store/AGENTS.md
+++ b/crates/orbit-store/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/orbit-store/CLAUDE.md
+++ b/crates/orbit-store/CLAUDE.md
@@ -1,0 +1,81 @@
+# orbit-store
+
+Project instructions for the persistence crate.
+
+## One job
+
+All durable Orbit state that is not a search index: task bundles, the
+coordination task registry, audit and invocation events, job runs, friction,
+routines, reservations and workspace claims, session logs, skills, and
+definition files. It depends only on `orbit-types` and `orbit-common`, and it
+knows nothing about runtimes, commands, or transports.
+
+Not here: domain policy and authorization (`orbit-core`), the semantic vector
+schema (`orbit-search::vector`, which owns its own `rusqlite::Connection`), and
+anything that needs to *decide* rather than persist.
+
+## Internal direction is enforced, not conventional
+
+This is one crate with a directional internal graph — the arrows in
+[`ARCHITECTURE.md`](../../ARCHITECTURE.md) §"orbit-store internal direction" are
+checked by
+[`scripts/check-dependency-direction.sh`](../../scripts/check-dependency-direction.sh)
+on every `make ci-fast`:
+
+| Layer | Owns | May not import |
+|---|---|---|
+| [`contracts`](src/contracts) | every consumer-visible trait, param, filter, and projection | any implementation, and `rusqlite` at all |
+| [`fs`](src/fs) | advisory locking, path safety, atomic writes, YAML | drivers, repositories, workflows |
+| [`driver/file`](src/driver/file) | one persistence technology: files | `driver/sqlite`, `Store`/`StoreTx`, repositories, workflows |
+| [`driver/sqlite`](src/driver/sqlite) | one persistence technology: SQLite | `driver/file`, repositories, workflows |
+| [`repository`](src/repository) | live invariants that *join* drivers | — |
+| [`workflow`](src/workflow) | explicit one-shot import/export/reindex/repair/upgrade | — |
+| [`compose`](src/compose) | construction; returns contract-facing types | — |
+
+The two drivers never call each other. When a live write spans both — a task
+commit is a canonical bundle write *plus* registry allocation/index rows *plus*
+disposable `.orbit/tasks` checkout symlinks — the join belongs in
+[`repository/task`](src/repository/task), never in a driver.
+
+A one-shot data movement is a `workflow`, not a hidden side effect of opening a
+store. `compose::workspace_friction_store` runs the idempotent, transactional
+Markdown import *before* opening the live repository, precisely so construction
+stays honest.
+
+The guardrail also fails if a retired ownership path (`src/backend`, `src/file`,
+`src/sqlite`, `src/state_io`, `src/task_migration`) reappears. Do not recreate
+one.
+
+## Where a change goes
+
+- New consumer-visible capability → a trait/param/projection in `contracts`,
+  one implementation in exactly one driver, a constructor in `compose`.
+- Shared atomic-write / lock / path-safety / YAML mechanics → `fs`, never a
+  backend-shaped utility module next to a driver.
+- Ordinary application code consumes the contract traits. Concrete construction
+  and migration access stay in composition, bootstrap, and maintenance
+  adapters; [`maintenance`](src/lib.rs) is deliberately named as operator-only.
+
+## Migrations are append-only
+
+[`driver/sqlite/migration/ledger.rs`](src/driver/sqlite/migration/ledger.rs)
+holds a stable ordered `MIGRATIONS` registry. **Never renumber or edit an entry
+that has shipped**, including across reverts and history rewrites — append a
+new version instead. Each migration runs in one transaction together with its
+ledger insert, and a database recorded newer than `SUPPORTED_SCHEMA_VERSION` is
+refused rather than downgraded.
+
+Feature crates get namespaced registries via
+[`migration/feature.rs`](src/driver/sqlite/migration/feature.rs): the feature
+owns its callbacks and calls `Store::apply_feature_migrations` before exposing
+its API; its versions are independent of the global schema version. Use that
+seam rather than adding a feature's tables to the global ledger.
+
+## Tests
+
+Sibling `tests/` directories throughout
+([`test_layout.md`](../../docs/design-patterns/test_layout.md)); the direction
+guardrail excludes `**/tests/**`, so a test may legitimately reach across
+layers to build a fixture while production code may not. There is no crate-root
+`tests/` directory — a change that seems to need one is usually a change that
+belongs behind `contracts` and can be tested through `compose`.

--- a/crates/orbit-types/AGENTS.md
+++ b/crates/orbit-types/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/orbit-types/CLAUDE.md
+++ b/crates/orbit-types/CLAUDE.md
@@ -1,0 +1,63 @@
+# orbit-types
+
+Project instructions for the lowest internal contract crate.
+
+## One job
+
+Shared **data contracts**: structs, enums, serde shapes, pure constructors,
+normalization, lifecycle predicates, and narrow domain errors. Nothing else.
+
+`orbit-types` has **zero Orbit dependencies** and is the only crate that may be
+depended on by every other crate. It performs no filesystem, process,
+environment, database, network, logging, or tracing work — if a change here
+needs `std::fs`, `std::process`, `std::env`, `rusqlite`, or `tracing`, the
+behavior belongs one layer up in `orbit-common` and only its *shape* belongs
+here.
+
+## Domain-qualified modules, never a grab-bag
+
+Every item lives under exactly one domain module: [`identity`](src/identity),
+[`policy`](src/policy), [`record`](src/record), [`resource`](src/resource),
+[`task`](src/task), [`telemetry`](src/telemetry), [`tool`](src/tool),
+[`workflow`](src/workflow), [`workspace`](src/workspace).
+
+`OrbitId` is the **only** crate-root primitive. Do not add a second one; pick
+the domain it belongs to instead. A new top-level module means a genuinely new
+domain, not a convenient home for something that did not fit.
+
+Each domain module follows the same shape — see
+[`identity/mod.rs`](src/identity/mod.rs) or [`task/mod.rs`](src/task/mod.rs):
+
+- Submodules are **private** (`mod actor;`), never `pub mod`.
+- `mod.rs` is declarations plus an explicit `pub use` list. The re-export list
+  *is* the module's public surface; adding a type without listing it there
+  keeps it unreachable on purpose.
+- One `error.rs` per domain holding a narrow `thiserror` enum
+  (`TaskError`, `IdentityError`, `RecordError`, …) re-exported from `mod.rs`.
+  Workspace-wide `OrbitError` lives in `orbit-common` and must not appear here.
+- `#[cfg(test)] mod tests;` pointing at a sibling `tests/` directory that
+  mirrors source filenames ([`test_layout.md`](../../docs/design-patterns/test_layout.md)).
+
+Choosing between neighbouring domains is a real decision, not a coin flip:
+`record` holds durable authored artifacts (ADR, friction, event, audit
+record), while `telemetry` holds measurement of runs (invocation traces, audit
+events, token pricing, metrics). Put a new type where its *lifecycle* belongs.
+
+## Serde shapes are persisted contract
+
+Types here are serialized into task bundles, YAML definitions, SQLite columns,
+and the MCP wire. Renaming a field or changing a `#[serde]` attribute is a data
+migration, not a rename — check for a reader in `orbit-store` (bundle/driver
+code and its `migration` ledger) before touching a shape, and keep
+`*_SCHEMA_VERSION` constants and their guards in step.
+
+The crate is tier **stable** in [`ARCHITECTURE.md`](../../ARCHITECTURE.md);
+breaking a public shape needs a deliberate decision, not a drive-by cleanup.
+
+## The `clap` feature is presentation-only
+
+`clap` is an optional dependency used exclusively through
+`#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]` and `value(...)`
+attributes so CLI enums parse from argv without the CLI redefining them. Do not
+grow it into `Args`/`Parser` derives, help text, or any other command surface —
+that is `orbit-cli`'s job. A default build of this crate must not link clap.

--- a/scripts/check-crate-agent-guides.sh
+++ b/scripts/check-crate-agent-guides.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Crate-level agent guides [ORB-11046].
+#
+# A crate guide is one canonical `CLAUDE.md` plus an `AGENTS.md` *relative*
+# symlink to it, so both provider conventions load the same text and the two
+# can never drift. This script keeps that shape honest and keeps the guides
+# from rotting into stale path references:
+#
+#   1. Every crate in REQUIRED_GUIDE_CRATES has a non-empty CLAUDE.md.
+#   2. Every crates/*/AGENTS.md is a symlink whose literal target is exactly
+#      "CLAUDE.md" (relative, sibling) and resolves to a regular file.
+#   3. Every relative Markdown link inside a crate guide resolves on disk.
+#
+# Runs in `make ci-fast` (local) and scripts/ci-guardrails.sh (CI).
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+REQUIRED_GUIDE_CRATES=(
+  orbit-cli
+  orbit-cmd
+  orbit-common
+  orbit-core
+  orbit-engine
+  orbit-mcp
+  orbit-store
+  orbit-types
+)
+
+fail=0
+
+for crate in "${REQUIRED_GUIDE_CRATES[@]}"; do
+  guide="crates/$crate/CLAUDE.md"
+  link="crates/$crate/AGENTS.md"
+
+  if [[ ! -f "$guide" ]]; then
+    echo "crate-agent-guides: missing $guide"
+    fail=1
+    continue
+  fi
+  if [[ ! -s "$guide" ]]; then
+    echo "crate-agent-guides: $guide is empty"
+    fail=1
+  fi
+  if [[ ! -L "$link" ]]; then
+    echo "crate-agent-guides: $link must exist and be a symlink to CLAUDE.md"
+    fail=1
+  fi
+done
+
+# Any AGENTS.md under crates/ — required or not — must be the sibling symlink.
+while IFS= read -r link; do
+  target="$(readlink "$link" 2>/dev/null || true)"
+  if [[ -z "$target" ]]; then
+    echo "crate-agent-guides: $link is a regular file; it must be a symlink to the sibling CLAUDE.md"
+    fail=1
+    continue
+  fi
+  if [[ "$target" != "CLAUDE.md" ]]; then
+    echo "crate-agent-guides: $link points at '$target'; it must point at the sibling 'CLAUDE.md'"
+    fail=1
+    continue
+  fi
+  if [[ ! -f "$link" ]]; then
+    echo "crate-agent-guides: $link does not resolve to a readable file"
+    fail=1
+  fi
+done < <(find crates -mindepth 2 -maxdepth 2 -name AGENTS.md | sort)
+
+# Relative links inside each guide must resolve, so an example module renamed
+# out from under a guide fails here instead of misleading the next agent.
+while IFS= read -r guide; do
+  crate_dir="$(dirname "$guide")"
+  while IFS= read -r target; do
+    [[ -z "$target" ]] && continue
+    case "$target" in
+      \#*|http://*|https://*|mailto:*) continue ;;
+    esac
+    path="${target%%#*}"
+    [[ -z "$path" ]] && continue
+    if [[ ! -e "$crate_dir/$path" ]]; then
+      echo "crate-agent-guides: $guide links to '$target', which does not resolve"
+      fail=1
+    fi
+  done < <(rg -o '\]\(([^)]+)\)' --replace '$1' --no-line-number --no-filename "$guide" || true)
+done < <(find crates -mindepth 2 -maxdepth 2 -name CLAUDE.md | sort)
+
+if [[ "$fail" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "crate agent guide guard passed"

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -43,6 +43,7 @@ fi
 "$repo_root/scripts/check-changelog-style.sh"
 "$repo_root/scripts/check-error-translation.sh"
 "$repo_root/scripts/check-orphan-modules.sh"
+"$repo_root/scripts/check-crate-agent-guides.sh"
 "$repo_root/scripts/sync-plugin-skills.sh" --check
 "$repo_root/scripts/test-validate-codex-plugin.sh"
 "$repo_root/scripts/test-validate-agent-plugin.sh"


### PR DESCRIPTION
## Task

[ORB-11046](https://orbit-cli.com/tasks/ORB-11046) — Add focused agent guides to Orbit's foundational crates

### Description

## Problem
Only `crates/orbit-cli` currently has a crate-level agent guide: a canonical `CLAUDE.md` with `AGENTS.md` linked to it. The other foundational crates rely entirely on repository-wide instructions, so agents working inside them lack concise local guidance about ownership, internal organization, dependency direction, extension points, and test placement.

Create crate-level `CLAUDE.md` and `AGENTS.md` guides under exactly:

- `crates/orbit-core/`
- `crates/orbit-common/`
- `crates/orbit-cmd/`
- `crates/orbit-types/`
- `crates/orbit-store/`
- `crates/orbit-mcp/`
- `crates/orbit-engine/`

## Why It Matters
These crates define Orbit's principal domain, mechanism, composition, persistence, protocol, and execution boundaries. Focused local guides should help changes land at the correct owner, preserve systematic module organization, and prevent duplicated logic or backward dependency edges.

## Constraints / Notes
- Follow the established `crates/orbit-cli` file convention: `CLAUDE.md` is the canonical content and `AGENTS.md` is a relative symlink to it, unless current repository tooling demonstrates a different required mechanism.
- Author every guide from current code, tests, `ARCHITECTURE.md`, and present requirements. Historical ADRs are not authority and must not be used to justify preserving current structure.
- Keep each guide scoped to rules that are genuinely specific to that crate. Do not copy the repository-level guide wholesale.
- Each guide should state the crate's single responsibility, what belongs and does not belong there, important internal layout conventions, dependency-direction constraints, expected test placement, and crate-specific validation or safety invariants.
- Use current source paths as examples only after verifying them. Avoid brittle inventories that will become stale without conveying an organizing rule.
- Do not change application behavior as part of this documentation task.

### Acceptance Criteria

- Each of `orbit-core`, `orbit-common`, `orbit-cmd`, `orbit-types`, `orbit-store`, `orbit-mcp`, and `orbit-engine` contains a non-empty crate-specific `CLAUDE.md` plus an `AGENTS.md` relative symlink resolving to that file.
- Every guide accurately defines the crate's current ownership boundary, exclusions, dependency direction, internal organization rules, extension points, and test-placement expectations using current source and `ARCHITECTURE.md` as evidence.
- The guides add crate-local direction without duplicating or contradicting the repository-level `AGENTS.md`/`CLAUDE.md` rules.
- No guide cites a historical ADR as architectural authority or preserves a structure merely because an ADR described it.
- All referenced relative paths and example modules resolve in the repository at validation time.
- A deterministic check confirms all seven `AGENTS.md` links resolve to their sibling `CLAUDE.md` files, and `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Added crate-level agent guides to the seven foundational crates, plus a guardrail that keeps them honest.

## What landed

Seven new `CLAUDE.md` guides, each with an `AGENTS.md` relative symlink (`AGENTS.md -> CLAUDE.md`), matching the pre-existing `crates/orbit-cli` convention:

- **orbit-types** — zero-Orbit-dep contract crate; domain-qualified modules with private submodules and explicit `pub use` lists; per-domain narrow `error.rs` (never `OrbitError`); `OrbitId` as the sole crate-root primitive; the `record` vs `telemetry` placement test (authored artifact vs run measurement); serde shapes as persisted contract; `clap` feature is `cfg_attr`-only.
- **orbit-common** — responsibility-named modules, never caller- or feature-named; the "types says what, common says how" split; single-owner invariants (`security::child_env` allowlist, `security::redaction`, `fs::selector`'s translator, the forward-only `migration` framework); the operations-as-data kernel staying transport/runtime-agnostic with handlers in Core joined by the verb enum; `sqlite`/`test-util`/`clap` feature rules.
- **orbit-store** — the enforced internal graph as a per-layer table (contracts / fs / driver-file / driver-sqlite / repository / workflow / compose), drivers never calling each other, cross-driver joins belonging to `repository/task`, one-shot movements being `workflow` not hidden construction side effects, retired paths staying deleted, and the append-only migration ledger plus namespaced feature migrations.
- **orbit-engine** — owns *how* work runs, not *what* exists; `RuntimeHost` as the single capability boundary with "add a host method, don't widen a dependency"; the deliberate `cli_runner`→`orbit-agent` edge and why it is contained there; `DispatchError`/`CatalogError` translator locality; redaction and child-env guardrails on the spawn path; resume correctness.
- **orbit-core** — the enforced `runtime <- application <- adapter` graph with `composition` as sole joiner, including the runtime's ban on `ResolvedConfig::load`/`ConfigRoots::`; adapters translate, they do not decide; the ORB-10016 root re-export policy; retired paths; the two-root model.
- **orbit-cmd** — the crate's whole reason for existing (Registry sits above Core, so Core cannot see the workspace catalog); flat one-module-per-command-group layout where each module names one composition seam; `*Commands` extension traits and the prelude; pure consumer of Core's public API; no clap, no axum.
- **orbit-mcp** — protocol only, with everything decidable behind the `McpHost` trait; the dependency boundary that `tests/dep_boundary.rs` asserts; `rmcp` confined to this crate; advertised names as shipped contract with hard-fail collisions; the federated mux as the one place Orbit is also an MCP client, fail-closed routing, and accepting-machine-resolves-local-state.

Each guide states ownership, exclusions, dependency direction, internal layout rules, extension points, crate-specific invariants, and test placement. All paths and example modules were verified against current source, `ARCHITECTURE.md`, and the guardrail scripts. No guide cites a historical ADR as authority.

## Deterministic check

New `scripts/check-crate-agent-guides.sh`, wired into `make ci-fast` and `scripts/ci-guardrails.sh`. It verifies three things:

1. Each required crate has a non-empty `CLAUDE.md`.
2. Every `crates/*/AGENTS.md` is a symlink whose literal target is exactly `CLAUDE.md` and resolves to a readable regular file.
3. Every relative Markdown link inside a crate guide resolves on disk — so a renamed example module fails CI instead of quietly misleading the next agent.

Negative-tested all four failure modes (regular file instead of symlink; symlink pointing at another crate's guide; dangling link; broken in-guide relative link). Each fails with a specific message; the tree was restored clean afterward.

## Two in-scope corrections the check surfaced

- `crates/orbit-cli/CLAUDE.md` cited `src/command/hook` and `src/command/learning` as reference shapes; neither directory exists any more. Replaced with `skill/` (five subcommands, one `.rs` per body) and `audit/` (five subcommands plus shared `support.rs`) — both verified, both conveying the same directory-per-command rule. Nothing else in that guide changed.
- `crates/orbit-cmd/src/lib.rs` had a doc comment pointing at `orbit-core::command`, a path `scripts/check-dependency-direction.sh` explicitly requires to stay deleted. Now points at `orbit_core::adapter::command`. Doc comment only; no behavior change.

## Validation

- `make ci-fast` — pass (exit 0), including the new guardrail.
- `make ci-lint` — pass (exit 0); run because of the one-line doc-comment edit in `orbit-cmd`.
- No sandbox or runner denials.

## Files

New: 7 × `crates/*/CLAUDE.md`, 7 × `crates/*/AGENTS.md` symlinks, `scripts/check-crate-agent-guides.sh`.
Modified: `Makefile` (+1), `scripts/ci-guardrails.sh` (+1), `crates/orbit-cli/CLAUDE.md` (4 lines), `crates/orbit-cmd/src/lib.rs` (2 lines).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11046-6a93137f`
- Behind base: 0
- Ahead of base: 1