### PR TITLE
Read-only SQLite files bypass private-permission repair

### DIFF
--- a/crates/orbit-common/src/storage/sqlite.rs
+++ b/crates/orbit-common/src/storage/sqlite.rs
@@ -35,17 +35,18 @@ pub struct OpenedConnection {
 /// The database is hardened before SQLite can create WAL/SHM sidecars, and
 /// pre-existing sidecars are repaired as part of the same operation. Newly
 /// created parent directories are owner-only as well. An existing read-only
-/// database or database on a read-only filesystem is opened immutable before
-/// any directory creation or permission change is attempted.
+/// database on writable storage has group/other permissions removed before it
+/// is opened immutable. A database on a read-only filesystem is opened
+/// immutable before any directory creation or permission change is attempted.
 pub fn open_private(path: &Path) -> Result<OpenedConnection, OrbitError> {
     match fs::metadata(path) {
-        Ok(metadata) if metadata.permissions().readonly() || filesystem_is_read_only(path)? => {
-            return Ok(OpenedConnection {
-                connection: open_immutable(path)?,
-                read_only: true,
-            });
+        Ok(metadata) => {
+            let filesystem_read_only = filesystem_is_read_only(path)?;
+            if filesystem_read_only || metadata.permissions().readonly() {
+                return open_private_read_only(path, filesystem_read_only);
+            }
+            harden_sqlite_files(path)?;
         }
-        Ok(_) => harden_sqlite_files(path)?,
         Err(error) if error.kind() == io::ErrorKind::NotFound => {}
         Err(error) => return Err(sqlite_path_error("inspect", path, error)),
     }
@@ -74,6 +75,19 @@ pub fn open_private(path: &Path) -> Result<OpenedConnection, OrbitError> {
     Ok(OpenedConnection {
         connection,
         read_only: false,
+    })
+}
+
+pub(super) fn open_private_read_only(
+    path: &Path,
+    filesystem_read_only: bool,
+) -> Result<OpenedConnection, OrbitError> {
+    if !filesystem_read_only {
+        harden_read_only_sqlite_files(path)?;
+    }
+    Ok(OpenedConnection {
+        connection: open_immutable(path)?,
+        read_only: true,
     })
 }
 
@@ -114,6 +128,33 @@ fn harden_existing_file(path: &Path) -> Result<(), OrbitError> {
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(error) => Err(sqlite_path_error("harden", path, error)),
     }
+}
+
+fn harden_read_only_sqlite_files(path: &Path) -> Result<(), OrbitError> {
+    harden_existing_read_only_file(path)?;
+    for sidecar in sqlite_sidecar_paths(path) {
+        harden_existing_read_only_file(&sidecar)?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn harden_existing_read_only_file(path: &Path) -> Result<(), OrbitError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(sqlite_path_error("inspect", path, error)),
+    };
+    let owner_only_mode = metadata.permissions().mode() & 0o700;
+    fs::set_permissions(path, fs::Permissions::from_mode(owner_only_mode))
+        .map_err(|error| sqlite_path_error("harden", path, error))
+}
+
+#[cfg(not(unix))]
+fn harden_existing_read_only_file(_path: &Path) -> Result<(), OrbitError> {
+    Ok(())
 }
 
 fn sqlite_sidecar_paths(path: &Path) -> [PathBuf; 2] {

--- a/crates/orbit-common/src/storage/tests/sqlite.rs
+++ b/crates/orbit-common/src/storage/tests/sqlite.rs
@@ -97,7 +97,56 @@ fn private_open_repairs_existing_database_and_sidecars() {
 
 #[cfg(unix)]
 #[test]
-fn private_open_preserves_an_immutable_database_without_side_effects() {
+fn private_open_repairs_permissive_read_only_database_and_sidecars() {
+    use std::os::unix::fs::PermissionsExt;
+
+    for database_mode in [0o444, 0o440] {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("immutable.db");
+        let connection = Connection::open(&path).expect("open fixture");
+        connection
+            .pragma_update(None, "journal_mode", "WAL")
+            .expect("enable WAL");
+        connection
+            .execute_batch(
+                "CREATE TABLE fixture(value TEXT);\
+                 INSERT INTO fixture VALUES ('kept');\
+                 PRAGMA wal_checkpoint(FULL);",
+            )
+            .expect("write and checkpoint fixture");
+
+        for suffix in ["", "-wal", "-shm"] {
+            let file = std::path::PathBuf::from(format!("{}{suffix}", path.display()));
+            assert!(file.exists(), "fixture file exists: {}", file.display());
+            std::fs::set_permissions(&file, std::fs::Permissions::from_mode(database_mode))
+                .expect("make fixture permissive and read-only");
+        }
+
+        let opened = super::super::sqlite::open_private(&path).expect("open immutable");
+        assert!(opened.read_only);
+        let value = opened
+            .connection
+            .query_row("SELECT value FROM fixture", [], |row| {
+                row.get::<_, String>(0)
+            })
+            .expect("read immutable fixture");
+        assert_eq!(value, "kept");
+
+        for suffix in ["", "-wal", "-shm"] {
+            let file = std::path::PathBuf::from(format!("{}{suffix}", path.display()));
+            let mode = std::fs::metadata(&file)
+                .expect("fixture metadata")
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o400, "owner-read-only mode for {}", file.display());
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn private_read_only_filesystem_path_has_no_side_effects() {
     use std::os::unix::fs::PermissionsExt;
 
     let dir = tempfile::tempdir().expect("tempdir");
@@ -107,16 +156,13 @@ fn private_open_preserves_an_immutable_database_without_side_effects() {
         .execute_batch("CREATE TABLE fixture(value TEXT); INSERT INTO fixture VALUES ('kept');")
         .expect("write fixture");
     drop(connection);
-    for suffix in ["-wal", "-shm"] {
-        let sidecar = std::path::PathBuf::from(format!("{}{suffix}", path.display()));
-        if sidecar.exists() {
-            std::fs::remove_file(sidecar).expect("remove fixture sidecar");
-        }
-    }
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o400))
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o444))
         .expect("make fixture read-only");
 
-    let opened = super::super::sqlite::open_private(&path).expect("open immutable");
+    // A unit-test tempdir cannot become a genuine read-only mount without
+    // privileges. Exercise the branch selected after statvfs reports ST_RDONLY.
+    let opened = super::super::sqlite::open_private_read_only(&path, true)
+        .expect("open from read-only filesystem");
     assert!(opened.read_only);
     let value = opened
         .connection
@@ -131,8 +177,8 @@ fn private_open_preserves_an_immutable_database_without_side_effects() {
             .permissions()
             .mode()
             & 0o777,
-        0o400,
-        "read-only mode must not be repaired"
+        0o444,
+        "read-only filesystem mode must remain unchanged"
     );
     assert!(!std::path::PathBuf::from(format!("{}-wal", path.display())).exists());
     assert!(!std::path::PathBuf::from(format!("{}-shm", path.display())).exists());


### PR DESCRIPTION
## Task

[ORB-11049](https://orbit-cli.com/tasks/ORB-11049) — Read-only SQLite files bypass private-permission repair

### Description

## Confirmed finding

`open_private` returns immediately in immutable mode whenever the database file's owner-write bit is absent (`crates/orbit-common/src/storage/sqlite.rs:40-46`). That branch does not distinguish a truly read-only filesystem from an ordinary file such as mode `0o444` on a writable filesystem, and it performs no permission repair before opening the file.

As a result, a database at `0o444` or `0o440` remains readable by group/other indefinitely even though Unix permits the owner to remove those bits without making the database writable. The only immutable regression test creates mode `0o400` and asserts it remains `0o400` (`crates/orbit-common/src/storage/tests/sqlite.rs:98-136`), so it does not exercise the permissive read-only modes that violate the privacy invariant.

This is live in every shipped opener because Store, TaskRegistryStore, and VectorStore all delegate to `open_private`. ORB-11032 was filed after live databases exposed task state and workspace-claim Bearer [REDACTED_AUTH] through group/other-readable files, and its acceptance criterion required every existing shipped SQLite database to be created or repaired without granting group/other access. A database made owner-read-only for backup/forensics can therefore reintroduce the same exposure.

## Impact

On a shared host with traversable parent directories, another local account can read task/audit data and any claim token persisted in a read-only database. The immutable fallback still needs to avoid writes and forbidden chmod on a read-only filesystem, but file-level read-only status alone should not preserve group/other permissions when a safe owner-only mode repair is possible.

### Acceptance Criteria

- On Unix, opening an existing mode 0o444 or 0o440 Orbit SQLite database on a writable filesystem removes all group/other permissions while preserving immutable/read-only database behavior.
- A database on a genuinely read-only filesystem still opens immutable without attempting forbidden chmod, directory creation, or sidecar creation.
- Tests cover permissive owner-read-only file modes separately from read-only-filesystem behavior and assert no group/other bits on the database or retained sidecars.
- All three shipped SQLite openers retain their existing writable and immutable behavior; focused store/search tests, make ci-fast, and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Changed the shared SQLite opener to distinguish a statvfs-reported read-only filesystem from an owner-read-only file on writable storage. Writable-storage read-only databases and retained WAL/SHM sidecars now lose all group/other permission bits while retaining their owner permission bits, and the database still opens immutable.
- Preserved the genuine read-only-filesystem path as an immediate immutable open with no chmod, directory creation, or SQLite sidecar creation.
- Split Unix regression coverage: modes 0o444 and 0o440 are repaired to owner-read-only for the database and retained sidecars, while the read-only-filesystem branch leaves a permissive mode unchanged and creates no sidecars.
Validation:
- `cargo test -p orbit-common --features sqlite storage::tests::sqlite` (6 passed)
- `cargo test -p orbit-store driver::sqlite` (164 passed, 1 ignored)
- `cargo test -p orbit-search vector::` (22 passed)
- `make ci-fast` (passed)
- `make ci-lint` (passed)
Assessment: The privacy repair remains centralized in `open_private`, so Store, TaskRegistryStore, and VectorStore keep one writable/immutable decision path. The implementation changes only the two scoped files and introduces no dependency or persisted-format changes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11049-6a9317a9`
- Behind base: 0
- Ahead of base: 1