### PR TITLE
Local federated routes discard the caller's audit context

### DIFF
--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -1883,6 +1883,60 @@ fn federated_mcp_serve_lists_and_routes_local_workspaces_without_destinations() 
     );
 }
 
+/// ORB-11048: in-process federation must preserve the outer MCP call's audit
+/// evidence while retaining the accepting server's trusted session fields.
+#[test]
+fn direct_and_federated_local_calls_record_equivalent_audit_contexts() {
+    let workspace = McpWorkspace::init();
+    let (machine_id, host_id) = host_identity(&workspace.home);
+
+    let mut direct = workspace.serve();
+    direct.call_tool_ok("orbit_crew_list", json!({}));
+    drop(direct);
+
+    let mut federated = federated_client(&workspace);
+    let listed = federated.call_tool_ok("orbit_workspace_list", json!({}));
+    let selector = listed["workspaces"][0]["selector"]
+        .as_str()
+        .expect("local selector");
+    federated.call_tool_ok("orbit_crew_list", json!({ "workspace": selector }));
+    drop(federated);
+
+    let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args(["audit", "list", "--tool", "orbit.crew.list", "--json"])
+        .output()
+        .expect("query direct and federated audit rows");
+    assert!(
+        output.status.success(),
+        "audit list failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let rows: Value = serde_json::from_slice(&output.stdout).expect("parse audit rows");
+    let rows = rows.as_array().expect("audit row array");
+    assert_eq!(rows.len(), 2, "one direct and one federated call: {rows:?}");
+
+    let direct_row = rows
+        .iter()
+        .find(|row| row["self_reported_actor"] == "orbit-mcp-roundtrip-test")
+        .expect("direct audit row preserves initialize actor");
+    let federated_row = rows
+        .iter()
+        .find(|row| row["self_reported_actor"] == "federated-roundtrip")
+        .expect("federated audit row preserves initialize actor");
+    let direct_trace = direct_row["trace_id"].as_str().expect("direct trace");
+    let federated_trace = federated_row["trace_id"].as_str().expect("federated trace");
+    assert_ne!(direct_trace, federated_trace);
+
+    for row in [direct_row, federated_row] {
+        assert_eq!(row["caller_machine_id"], machine_id);
+        assert_eq!(row["caller_host_id"], host_id);
+        assert_eq!(row["process_machine_id"], machine_id);
+        assert_eq!(row["process_host_id"], host_id);
+        assert_eq!(row["transport"], "local");
+        assert_eq!(row["effective_capabilities"], json!(["agent"]));
+    }
+}
+
 /// ORB-11044: an explicit destination naming the local machine is one local route.
 #[test]
 fn federated_mcp_serve_collapses_an_explicit_local_destination_row() {

--- a/crates/orbit-mcp/src/federated/host.rs
+++ b/crates/orbit-mcp/src/federated/host.rs
@@ -183,7 +183,11 @@ impl FederatedMcpHost {
         // reaches the destination, so its failure is the destination's answer
         // (`RemoteTool`) or a post-dispatch ambiguity (`OutcomeUnknown`) —
         // never a delivery miss the caller should retry [ORB-11023].
-        session.call_tool(name, destination_arguments(input, parsed.workspace_id()))
+        session.call_tool(
+            name,
+            destination_arguments(input, parsed.workspace_id()),
+            session_context,
+        )
     }
 }
 

--- a/crates/orbit-mcp/src/federated/probe.rs
+++ b/crates/orbit-mcp/src/federated/probe.rs
@@ -82,7 +82,12 @@ pub trait DestinationProbe: Send + Sync {
 pub trait RoutedSession: Send {
     fn snapshot(&mut self) -> Result<DestinationSnapshot, OrbitError>;
     fn advertised_tools(&mut self) -> Result<Vec<String>, OrbitError>;
-    fn call_tool(&mut self, name: &str, arguments: Value) -> Result<Value, OrbitError>;
+    fn call_tool(
+        &mut self,
+        name: &str,
+        arguments: Value,
+        session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError>;
 }
 
 /// The production probe: one short-lived SSH-hosted MCP session per call.
@@ -162,6 +167,8 @@ impl DestinationProbe for InProcessDestinationProbe {
 
 struct InProcessRoutedSession {
     inner: Arc<dyn crate::McpHost>,
+    /// Trusted server-owned fields captured before initialize. Per-call audit
+    /// evidence is overlaid at dispatch and never written back here.
     session_context: ToolSessionContext,
     snapshot: DestinationSnapshot,
 }
@@ -180,9 +187,16 @@ impl RoutedSession for InProcessRoutedSession {
             .collect())
     }
 
-    fn call_tool(&mut self, name: &str, arguments: Value) -> Result<Value, OrbitError> {
-        self.inner
-            .call_tool(name, arguments, self.session_context.clone())
+    fn call_tool(
+        &mut self,
+        name: &str,
+        arguments: Value,
+        call_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
+        let mut destination_context = self.session_context.clone();
+        destination_context.trace_id = call_context.trace_id;
+        destination_context.self_reported_actor = call_context.self_reported_actor;
+        self.inner.call_tool(name, arguments, destination_context)
     }
 }
 
@@ -268,7 +282,12 @@ impl RoutedSession for SshRoutedSession {
         Ok(tools)
     }
 
-    fn call_tool(&mut self, name: &str, arguments: Value) -> Result<Value, OrbitError> {
+    fn call_tool(
+        &mut self,
+        name: &str,
+        arguments: Value,
+        _session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
         // Classification is finished, so the tool's own budget starts here:
         // the SSH setup, handshake, discovery, and `tools/list` round trips
         // that chose this destination must not shorten it.

--- a/crates/orbit-mcp/src/federated/tests/fixtures.rs
+++ b/crates/orbit-mcp/src/federated/tests/fixtures.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 
 use chrono::{TimeZone, Utc};
 use orbit_common::OrbitError;
-use orbit_types::tool::mcp_advertised_tool_name;
+use orbit_types::tool::{ToolSessionContext, mcp_advertised_tool_name};
 use orbit_types::workspace::{Workspace, WorkspaceStatus};
 use serde_json::Value;
 
@@ -225,7 +225,12 @@ impl RoutedSession for ScriptedRoute {
         Ok(self.tools.clone())
     }
 
-    fn call_tool(&mut self, name: &str, arguments: Value) -> Result<Value, OrbitError> {
+    fn call_tool(
+        &mut self,
+        name: &str,
+        arguments: Value,
+        _session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
         self.log.lock().expect("call log").push(RoutedCall {
             machine_id: self.machine_id.clone(),
             tool: name.to_string(),

--- a/crates/orbit-mcp/src/federated/tests/local.rs
+++ b/crates/orbit-mcp/src/federated/tests/local.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use orbit_common::OrbitError;
-use orbit_types::tool::{McpToolDefinition, ToolSessionContext};
+use orbit_types::tool::{McpCapability, McpToolDefinition, ToolSessionContext};
 use serde_json::{Value, json};
 
 use super::super::config::{
@@ -112,6 +112,30 @@ fn local_only_mux() -> FederatedMcpHost {
         vec![local_destination(OWNER_MACHINE, "local-host")],
         Arc::new(probe),
     )
+}
+
+fn recording_local_mux() -> (Arc<FederatedMcpHost>, Arc<RecordingLocalHost>) {
+    let inner = Arc::new(RecordingLocalHost::new(OWNER_MACHINE));
+    let context = ToolSessionContext {
+        caller_machine_id: Some(OWNER_MACHINE.to_string()),
+        caller_host_id: Some("local-host".to_string()),
+        process_machine_id: Some(OWNER_MACHINE.to_string()),
+        process_host_id: Some("local-host".to_string()),
+        transport: Some(orbit_types::tool::McpTransport::Local),
+        effective_capabilities: std::collections::BTreeSet::from([McpCapability::Agent]),
+        ..ToolSessionContext::default()
+    };
+    let host = FederatedMcpHost::new(
+        vec![local_destination(OWNER_MACHINE, "local-host")],
+        Arc::new(CompositeDestinationProbe::new(
+            Arc::new(InProcessDestinationProbe::new(
+                Arc::clone(&inner) as Arc<dyn McpHost>,
+                context,
+            )),
+            Arc::new(PanickingProbe),
+        )),
+    );
+    (Arc::new(host), inner)
 }
 
 #[test]
@@ -222,29 +246,22 @@ fn an_explicit_local_ssh_row_does_not_duplicate_the_local_descriptor() {
 
 #[test]
 fn a_copied_local_selector_is_delivered_in_process_without_ssh() {
-    let inner = Arc::new(RecordingLocalHost::new(OWNER_MACHINE));
-    let context = ToolSessionContext {
-        process_machine_id: Some(OWNER_MACHINE.to_string()),
-        process_host_id: Some("local-host".to_string()),
-        transport: Some(orbit_types::tool::McpTransport::Local),
+    let (host, inner) = recording_local_mux();
+    let call_context = ToolSessionContext {
+        process_machine_id: Some("hm_spoofed".to_string()),
+        process_host_id: Some("spoofed-host".to_string()),
+        transport: Some(orbit_types::tool::McpTransport::SshMcp),
+        trace_id: Some("trace-current-call".to_string()),
+        effective_capabilities: std::collections::BTreeSet::from([McpCapability::Operator]),
+        self_reported_actor: Some("codex".to_string()),
         ..ToolSessionContext::default()
     };
-    let host = FederatedMcpHost::new(
-        vec![local_destination(OWNER_MACHINE, "local-host")],
-        Arc::new(CompositeDestinationProbe::new(
-            Arc::new(InProcessDestinationProbe::new(
-                Arc::clone(&inner) as Arc<dyn McpHost>,
-                context.clone(),
-            )),
-            Arc::new(PanickingProbe),
-        )),
-    );
 
     let result = host
         .call_tool(
             "orbit.crew.list",
             json!({ "workspace": format!("{OWNER_MACHINE}/ws_orbit") }),
-            ToolSessionContext::default(),
+            call_context,
         )
         .expect("local crew.list");
     assert_eq!(result["workspace"], "ws_orbit");
@@ -257,10 +274,74 @@ fn a_copied_local_selector_is_delivered_in_process_without_ssh() {
         calls[0].2.process_machine_id.as_deref(),
         Some(OWNER_MACHINE)
     );
+    assert_eq!(calls[0].2.process_host_id.as_deref(), Some("local-host"));
+    assert_eq!(calls[0].2.caller_machine_id.as_deref(), Some(OWNER_MACHINE));
+    assert_eq!(calls[0].2.caller_host_id.as_deref(), Some("local-host"));
     assert_eq!(
         calls[0].2.transport,
         Some(orbit_types::tool::McpTransport::Local)
     );
+    assert_eq!(
+        calls[0].2.effective_capabilities,
+        std::collections::BTreeSet::from([McpCapability::Agent])
+    );
+    assert_eq!(calls[0].2.trace_id.as_deref(), Some("trace-current-call"));
+    assert_eq!(calls[0].2.self_reported_actor.as_deref(), Some("codex"));
+}
+
+#[test]
+fn concurrent_local_routes_keep_each_calls_audit_evidence_isolated() {
+    let (host, inner) = recording_local_mux();
+
+    std::thread::scope(|scope| {
+        for (trace_id, actor) in [("trace-a", "codex"), ("trace-b", "claude-code")] {
+            let host = Arc::clone(&host);
+            scope.spawn(move || {
+                host.call_tool(
+                    "orbit.crew.list",
+                    json!({ "workspace": format!("{OWNER_MACHINE}/ws_orbit") }),
+                    ToolSessionContext {
+                        trace_id: Some(trace_id.to_string()),
+                        self_reported_actor: Some(actor.to_string()),
+                        ..ToolSessionContext::default()
+                    },
+                )
+                .expect("concurrent local route");
+            });
+        }
+    });
+
+    let calls = inner.calls.lock().expect("call log");
+    assert_eq!(calls.len(), 2);
+    let mut evidence = calls
+        .iter()
+        .map(|(_, _, context)| {
+            (
+                context.trace_id.as_deref().expect("trace").to_string(),
+                context
+                    .self_reported_actor
+                    .as_deref()
+                    .expect("actor")
+                    .to_string(),
+            )
+        })
+        .collect::<Vec<_>>();
+    evidence.sort();
+    assert_eq!(
+        evidence,
+        [
+            ("trace-a".to_string(), "codex".to_string()),
+            ("trace-b".to_string(), "claude-code".to_string())
+        ]
+    );
+    for (_, _, context) in calls.iter() {
+        assert_eq!(context.process_machine_id.as_deref(), Some(OWNER_MACHINE));
+        assert_eq!(context.process_host_id.as_deref(), Some("local-host"));
+        assert_eq!(
+            context.effective_capabilities,
+            std::collections::BTreeSet::from([McpCapability::Agent])
+        );
+    }
 }
 
 #[test]

--- a/crates/orbit-mcp/src/federated/tests/probe.rs
+++ b/crates/orbit-mcp/src/federated/tests/probe.rs
@@ -9,6 +9,7 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use orbit_common::OrbitError;
+use orbit_types::tool::ToolSessionContext;
 use serde_json::json;
 
 use super::super::probe::{DestinationSession, RoutedSession, SshRoutedSession};
@@ -92,7 +93,11 @@ fn routed_delivery_does_not_inherit_an_exhausted_probe_budget() {
     let mut routed = SshRoutedSession::new(stalled_session(Duration::ZERO), delivery);
     let started = Instant::now();
     let error = routed
-        .call_tool("orbit.command.exec", json!({ "command": "make ci-lint" }))
+        .call_tool(
+            "orbit.command.exec",
+            json!({ "command": "make ci-lint" }),
+            ToolSessionContext::default(),
+        )
         .expect_err("the destination never answers the dispatched call");
     let waited = started.elapsed();
 


### PR DESCRIPTION
## Task

[ORB-11048](https://orbit-cli.com/tasks/ORB-11048) — Local federated routes discard the caller's audit context

### Description

## Confirmed finding

The outer MCP adapter adopts the client's self-reported actor and mints a unique trace for every call (`crates/orbit-mcp/src/adapter/dispatch.rs:102-120`, `:130-136`). `FederatedMcpHost::route_workspace_call` receives that current per-call `ToolSessionContext` at `crates/orbit-mcp/src/federated/host.rs:118-123`, but uses it only to extract the selector and then invokes `session.call_tool` without forwarding the context (`host.rs:124-143`, `:175-186`).

For an implicit local destination, `InProcessDestinationProbe` instead captures one startup-time context in the server constructor and clones that static value for every routed call (`crates/orbit-mcp/src/federated/probe.rs:129-139`, `:153-185`). That capture occurs before MCP initialize and before `context_for_tool_call` stamps a trace, so it cannot contain either the client's current `self_reported_actor` or the per-call `trace_id`.

The local Core audit boundary persists exactly those two fields from the context it receives (`crates/orbit-core/src/adapter/command/dispatch.rs:430-446`). Consequently a local selector routed through federated mode produces an audit row with a null trace and no client claim, unlike the same call through the direct local MCP surface. The ORB-11044 test `a_copied_local_selector_is_delivered_in_process_without_ssh` verifies only process machine and transport; it never checks trace or actor propagation (`crates/orbit-mcp/src/federated/tests/local.rs:207-253`).

## Impact

Local federated calls lose request correlation and the untrusted-but-forensically-useful caller attribution that direct MCP calls retain. This violates ORB-11044's explicit requirement that local delivery observe the same authority and audit behavior as the local MCP surface, and weakens incident reconstruction for local federated mutations.

### Acceptance Criteria

- A locally routed federated call reaches the ServerMcpHost with the current outer call's unique trace_id and self_reported_actor while retaining server-owned machine, host, transport, and effective-capability fields.
- Concurrent local federated calls cannot share or overwrite trace IDs or initialize-owned caller claims.
- A round-trip or boundary test compares direct-local and federated-local audit rows and asserts non-null distinct traces plus preservation of self_reported_actor.
- Remote routing behavior and fail-closed selector/error precedence remain unchanged; affected MCP tests and make ci-fast pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Routed the current outer ToolSessionContext through the federated routed-session dispatch boundary.
- For in-process destinations, overlaid only trace_id and self_reported_actor onto the immutable server-owned context, preserving caller/process machine and host identities, local transport, and effective capabilities. SSH sessions intentionally ignore the added local-only context so remote wire behavior is unchanged.
- Added unit coverage for per-call propagation, resistance to spoofed server-owned fields, and concurrent trace/actor isolation.
- Added a production MCP round-trip audit comparison proving direct-local and federated-local calls record distinct non-null traces, preserve their initialize actors, and retain equivalent trusted identity/transport/capability fields.
- Expanded context_files before editing fixtures.rs and probe.rs for the routed-session signature update, and mcp_roundtrip.rs for the directly affected production audit boundary.
Assessment: The fix is narrowly owned at the routed-session boundary, keeps one dispatch path, avoids shared mutable per-call state, and leaves selector/error precedence and remote delivery semantics unchanged.
Validation:
- cargo test -p orbit-mcp federated::tests (62 passed)
- cargo test -p orbit-cli --test mcp_roundtrip direct_and_federated_local_calls_record_equivalent_audit_contexts -- --nocapture (1 passed)
- make ci-fast (passed)
- make ci-lint (passed)
- git diff --check (passed)
Deviations from original plan:
- Added the production orbit-cli round-trip test because the recording-host unit test cannot prove persisted audit-row equivalence.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11048-6a9317a9`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*