### PR TITLE
Managed proc.spawn calls always fail the new filesystem-policy gate

### DIFF
--- a/crates/orbit-cli/tests/proc_spawn_managed.rs
+++ b/crates/orbit-cli/tests/proc_spawn_managed.rs
@@ -1,0 +1,199 @@
+#![allow(missing_docs)]
+// Integration fixtures use expect for concise failure diagnostics.
+#![allow(clippy::expect_used)]
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command as StdCommand, Output};
+
+use assert_cmd::Command as AssertCommand;
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+#[test]
+fn managed_cli_proc_spawn_applies_registered_workspace_policy() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&home).expect("create home");
+    fs::create_dir_all(workspace.join("allowed")).expect("create allowed directory");
+    fs::create_dir_all(workspace.join("denied")).expect("create denied directory");
+    fs::write(workspace.join("allowed/visible.txt"), "visible").expect("write allowed fixture");
+    fs::write(workspace.join("denied/private.txt"), "private").expect("write denied fixture");
+    init_git_repo(&workspace);
+    workspace_init(&workspace, &home);
+    fs::write(
+        home.join(".orbit/resources/policies/default.yaml"),
+        r#"schemaVersion: 2
+kind: Policy
+metadata:
+  name: default
+spec:
+  description: Managed proc.spawn integration policy
+  denyRead:
+    - ./denied/**
+  denyModify: []
+  fsProfiles:
+    restricted:
+      read:
+        - ./allowed/**
+      modify: []
+"#,
+    )
+    .expect("write restricted policy");
+
+    let allowed = run_managed_proc_spawn(
+        &workspace,
+        &home,
+        json!({
+            "program": "/bin/cat",
+            "args": ["allowed/visible.txt"],
+            "timeout_ms": 5_000
+        }),
+        Some("restricted"),
+    );
+    assert!(
+        allowed.status.success(),
+        "allowed managed proc.spawn failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&allowed.stdout),
+        String::from_utf8_lossy(&allowed.stderr)
+    );
+    let value: Value = serde_json::from_slice(&allowed.stdout).expect("allowed JSON output");
+    assert_eq!(value["stdout"].as_str(), Some("visible"));
+
+    let denied = run_managed_proc_spawn(
+        &workspace,
+        &home,
+        json!({
+            "program": "/bin/cat",
+            "args": ["denied/private.txt"],
+            "timeout_ms": 5_000
+        }),
+        Some("restricted"),
+    );
+    assert!(
+        !denied.status.success(),
+        "denied path unexpectedly executed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&denied.stdout),
+        String::from_utf8_lossy(&denied.stderr)
+    );
+    let diagnostic = format!(
+        "{}{}",
+        String::from_utf8_lossy(&denied.stdout),
+        String::from_utf8_lossy(&denied.stderr)
+    );
+    assert!(
+        diagnostic.contains("proc.spawn path")
+            && diagnostic.contains("fsProfile 'restricted'")
+            && !diagnostic.contains("missing its resolved filesystem policy"),
+        "expected the resolved profile to deny the path: {diagnostic}"
+    );
+
+    let missing_profile = run_managed_proc_spawn(
+        &workspace,
+        &home,
+        json!({
+            "program": "/bin/cat",
+            "args": ["allowed/visible.txt"],
+            "timeout_ms": 5_000
+        }),
+        None,
+    );
+    assert!(!missing_profile.status.success());
+    let diagnostic = format!(
+        "{}{}",
+        String::from_utf8_lossy(&missing_profile.stdout),
+        String::from_utf8_lossy(&missing_profile.stderr)
+    );
+    assert!(
+        diagnostic.contains("missing its resolved filesystem policy"),
+        "missing managed profile did not fail closed: {diagnostic}"
+    );
+}
+
+fn workspace_init(workspace: &Path, home: &Path) {
+    let output = orbit_command(workspace, home)
+        .args(["workspace", "init"])
+        .output()
+        .expect("run workspace init");
+    assert!(
+        output.status.success(),
+        "workspace init failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn run_managed_proc_spawn(
+    workspace: &Path,
+    home: &Path,
+    input: Value,
+    fs_profile: Option<&str>,
+) -> Output {
+    let mut command = orbit_command(workspace, home);
+    command
+        .env("ORBIT_MANAGED_RUN_CONTEXT", "1")
+        .env("ORBIT_RUN_ID", "jrun-proc-spawn-test")
+        .env("ORBIT_TASK_ACTOR_KIND", "agent")
+        .env("ORBIT_ACTIVITY_TOOLS", "proc.spawn")
+        .env("ORBIT_PROC_ALLOWED_PROGRAMS", "/bin/cat");
+    match fs_profile {
+        Some(profile) => {
+            command.env("ORBIT_ACTIVITY_FS_PROFILE", profile);
+        }
+        None => {
+            command.env_remove("ORBIT_ACTIVITY_FS_PROFILE");
+        }
+    }
+    command
+        .args(["tool", "run", "proc.spawn", "--input", &input.to_string()])
+        .output()
+        .expect("run managed proc.spawn")
+}
+
+fn orbit_command(workspace: &Path, home: &Path) -> AssertCommand {
+    let mut command = cargo_bin_cmd!("orbit");
+    command
+        .current_dir(workspace)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env_remove("ORBIT_ROOT")
+        .env_remove("ORBIT_AGENT_NAME")
+        .env_remove("ORBIT_AGENT_MODEL")
+        .env_remove("ORBIT_RUN_ID")
+        .env_remove("ORBIT_TASK_ID")
+        .env_remove("ORBIT_ACTIVE_TASK_ID")
+        .env_remove("ORBIT_SESSION_ID");
+    command
+}
+
+fn init_git_repo(workspace: &Path) {
+    run_git(workspace, &["init"]);
+    run_git(workspace, &["config", "user.name", "Orbit Test"]);
+    run_git(
+        workspace,
+        &["config", "user.email", "orbit-test@example.com"],
+    );
+    run_git(workspace, &["config", "commit.gpgsign", "false"]);
+    fs::write(workspace.join("README.md"), "# fixture\n").expect("write readme");
+    run_git(workspace, &["add", "README.md"]);
+    run_git(workspace, &["commit", "-m", "initial"]);
+}
+
+fn run_git(workspace: &Path, args: &[&str]) {
+    let output = StdCommand::new("git")
+        .arg("-C")
+        .arg(workspace)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git -C {} {} failed\nstdout:\n{}\nstderr:\n{}",
+        workspace.display(),
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/orbit-core/src/adapter/command/dispatch.rs
+++ b/crates/orbit-core/src/adapter/command/dispatch.rs
@@ -23,7 +23,7 @@ use crate::redact_sensitive_env_text;
 use crate::runtime::run_input::{
     managed_run_context_from_env, managed_run_context_run_id_from_env,
 };
-use crate::runtime::tool_exec::CapabilityEnforcement;
+use crate::runtime::tool_exec::{CapabilityEnforcement, populate_filesystem_policy_context};
 
 #[cfg(test)]
 pub(super) use crate::runtime::run_input::ORBIT_MANAGED_RUN_CONTEXT_ENV;
@@ -228,7 +228,7 @@ impl OrbitRuntime {
                 let cwd = std::env::current_dir()
                     .ok()
                     .map(|path| path.to_string_lossy().into_owned());
-                let tool_context = ToolContext {
+                let mut tool_context = ToolContext {
                     cwd,
                     session_context,
                     allowed_tools,
@@ -241,6 +241,9 @@ impl OrbitRuntime {
                     reservation_owner: reservation_owner_from_env(),
                     ..Default::default()
                 };
+                if proc_spawn_activity_scoped {
+                    populate_filesystem_policy_context(self, None, &mut tool_context)?;
+                }
                 let capability_enforcement = match entry_point {
                     ToolEntryPoint::Cli => CapabilityEnforcement::Enforce,
                     ToolEntryPoint::Mcp => CapabilityEnforcement::McpSessionOnly,

--- a/crates/orbit-core/src/runtime/tool_exec.rs
+++ b/crates/orbit-core/src/runtime/tool_exec.rs
@@ -41,20 +41,7 @@ impl OrbitRuntime {
             None => resolve_task_id_from_context(self, &tool_context)?,
         };
 
-        // Ensure fs tools always have a workspace boundary for sandboxing.
-        if tool_context.workspace_root.is_none() {
-            tool_context.workspace_root = resolve_workspace_root_from_context(
-                self,
-                resolved_task_id.as_deref(),
-                &tool_context,
-            )?;
-        }
-        if tool_context.policy_engine.is_none() {
-            tool_context.policy_engine = Some(Arc::new(self.policy_engine().clone()));
-        }
-        if tool_context.fs_profile.is_none() {
-            tool_context.fs_profile = read_activity_fs_profile_from_env();
-        }
+        populate_filesystem_policy_context(self, resolved_task_id.as_deref(), &mut tool_context)?;
 
         self.check_tool_enabled(name)?;
 
@@ -165,6 +152,32 @@ impl OrbitRuntime {
         }
         Ok(())
     }
+}
+
+/// Fill the trusted runtime-owned pieces of a registered tool's filesystem
+/// policy context without replacing an explicitly supplied activity context.
+///
+/// CLI-backed activities call this before registry dispatch so `proc.spawn`
+/// receives the same canonical checkout and policy engine as in-process
+/// activities. The registry chokepoint calls it again for ordinary filesystem
+/// tools, making the operation idempotent while preserving fail-closed profile
+/// handling when the managed envelope omitted `ORBIT_ACTIVITY_FS_PROFILE`.
+pub(crate) fn populate_filesystem_policy_context(
+    runtime: &OrbitRuntime,
+    task_id: Option<&str>,
+    tool_context: &mut ToolContext,
+) -> Result<(), OrbitError> {
+    if tool_context.workspace_root.is_none() {
+        tool_context.workspace_root =
+            resolve_workspace_root_from_context(runtime, task_id, tool_context)?;
+    }
+    if tool_context.policy_engine.is_none() {
+        tool_context.policy_engine = Some(Arc::new(runtime.policy_engine().clone()));
+    }
+    if tool_context.fs_profile.is_none() {
+        tool_context.fs_profile = read_activity_fs_profile_from_env();
+    }
+    Ok(())
 }
 
 pub(crate) fn resolve_task_id_from_context(

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -9,6 +9,7 @@ use orbit_agent::{
 };
 use orbit_common::process::identity::process_start_identity_token;
 use orbit_common::security::redaction::{PatternRedactor, redact_sensitive_env_text};
+use orbit_types::policy::UNRESTRICTED_FS_PROFILE;
 use orbit_types::workflow::activity_job::{AgentLoopSpec, V2AuditEventKind};
 use serde_json::Value;
 
@@ -227,9 +228,10 @@ pub fn run_cli_backend(
             programs.join(","),
         ));
     }
-    if let Some(profile) = fs_profile {
-        dispatch_env.push(("ORBIT_ACTIVITY_FS_PROFILE".to_string(), profile.to_string()));
-    }
+    dispatch_env.push((
+        "ORBIT_ACTIVITY_FS_PROFILE".to_string(),
+        resolved_activity_fs_profile_name(fs_profile).to_string(),
+    ));
     dispatch_env.extend(
         orbit_tool_env().map_err(|error| DispatchError::CliInvocationPermanent(error.message))?,
     );
@@ -607,6 +609,10 @@ pub fn run_cli_backend(
             trace,
         }),
     })
+}
+
+pub(super) fn resolved_activity_fs_profile_name(fs_profile: Option<&str>) -> &str {
+    fs_profile.unwrap_or(UNRESTRICTED_FS_PROFILE)
 }
 
 /// Append the Orbit-owned write-denial attribution to a step message that was

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -26,11 +26,21 @@ use super::super::super::dispatcher::DispatchError;
 use super::super::super::dispatcher::ResolvedSandbox;
 use super::super::super::sqlite_sink::V2SqliteSink;
 use super::super::super::workspace::{WorktreeBoundaryGuard, validate_declared_worktree_pair};
+use super::super::orchestrator::resolved_activity_fs_profile_name;
 use super::super::run_cli_backend;
 use super::test_support::{
     RecordingSink, TestHost, capture_events, test_agent_loop_spec, test_agent_loop_spec_for,
     write_executable,
 };
+
+#[test]
+fn cli_activity_fs_profile_resolver_preserves_named_profile() {
+    assert_eq!(resolved_activity_fs_profile_name(None), "unrestricted");
+    assert_eq!(
+        resolved_activity_fs_profile_name(Some("implementer")),
+        "implementer"
+    );
+}
 
 #[test]
 fn run_cli_backend_finished_audit_event_keeps_stdout_stderr_blob_refs() {
@@ -3369,7 +3379,7 @@ fail() {{
 [ "$ORBIT_TASK_ACTOR_KIND" = "agent" ] || fail actor_kind_missing
 [ "$ORBIT_ACTIVITY_TOOLS" = "orbit.task.show,proc.spawn" ] || fail activity_tools_missing
 [ "$ORBIT_PROC_ALLOWED_PROGRAMS" = "git,rg" ] || fail proc_programs_missing
-[ "$ORBIT_ACTIVITY_FS_PROFILE" = "implementer" ] || fail fs_profile_missing
+[ "$ORBIT_ACTIVITY_FS_PROFILE" = "unrestricted" ] || fail fs_profile_missing
 [ "$ORBIT_ACTIVE_TASK_ID" = "ORB-10980" ] || fail active_task_missing
 printf '%s\n' '{{"schemaVersion":1,"status":"success","result":{{"identity":"ok"}},"error":null}}'
 "#,
@@ -3406,7 +3416,7 @@ printf '%s\n' '{{"schemaVersion":1,"status":"success","result":{{"identity":"ok"
         "job-grok-registry-root",
         audit,
         &serde_json::json!({"prompt": "hi", "task_id": "ORB-10980"}),
-        Some("implementer"),
+        None,
     )
     .expect("run succeeds");
 


### PR DESCRIPTION
## Task

[ORB-11047](https://orbit-cli.com/tasks/ORB-11047) — Managed proc.spawn calls always fail the new filesystem-policy gate

### Description

## Confirmed finding

A managed CLI/MCP activity exports the selected profile in `ORBIT_ACTIVITY_FS_PROFILE` (`crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs:230-232`), but the registered tool dispatch path never consumes it or reconstructs the filesystem policy. Instead it marks the call activity-scoped while building `ToolContext` with `workspace_root: None` and all remaining policy fields at their defaults (`crates/orbit-core/src/adapter/command/dispatch.rs:225-242`). The new authoritative gate requires `policy_engine`, `fs_profile`, and `workspace_root` for every scoped call and rejects when any is absent (`crates/orbit-tools/src/builtin/proc/spawn.rs:129-141`).

This is not the in-process v2 path, which correctly populates all three fields (`crates/orbit-core/src/adapter/engine_host/runtime_host.rs:521-531`). It affects the CLI-backed agent path that receives the registered `proc.spawn` tool through nested `orbit tool run` or MCP.

## Live reproduction

At `bae42c0c74424b92e3608a4a4a60d5dc504f6376`, inside managed run `jrun-20260829-1714-5` whose activity grants `proc.spawn` and allows `git`:

`orbit tool run proc.spawn --input '{"program":"git","args":["status","--short"],"timeout_ms":5000}'`

returns `{"code":"policy_denied","error":"policy denied: activity-scoped proc.spawn is missing its resolved filesystem policy"}` before spawning the allowed program.

## Impact

Every CLI-backed managed activity that relies on the registered `proc.spawn` surface is denied regardless of its declared program allowlist or fsProfile. Built-in implementation, orchestration, task-pilot, failure-recovery, and triage activities grant this tool, so their documented read-only command path is unusable. This is a regression introduced by ORB-11031.

### Acceptance Criteria

- A managed CLI-backed activity can invoke an allowlisted proc.spawn program when its path arguments are permitted by the resolved activity fsProfile.
- The nested registered-tool dispatch reconstructs or receives the same canonical workspace root, policy engine, and resolved fsProfile as the owning activity; missing or untrusted policy data still fails closed.
- An integration test crosses the CLI/MCP registered-tool boundary under managed-run environment rather than only constructing ToolContext directly, and proves both an allowed path and a denied path.
- Focused proc.spawn and CLI-agent tests, make ci-fast, and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Reused the registered-tool filesystem-policy population seam at managed CLI/MCP dispatch, so scoped proc.spawn calls receive the canonical active checkout, runtime policy engine, and activity fsProfile before entering the registry. Missing profile data remains absent and is rejected by the authoritative proc.spawn gate.
- Made CLI activity orchestration always export the resolved fsProfile, using the same unrestricted default as the in-process activity path when an activity does not name a profile.
- Added a real orbit tool run integration test under a managed-run environment that executes /bin/cat for an allowed path, denies a disallowed path through the resolved restricted profile, and proves a missing managed profile fails closed. Extended CLI-runner coverage to verify the default profile is exported to the child.
Assessment: The change keeps policy ownership in Core, preserves the existing fail-closed proc.spawn boundary, and aligns CLI-backed activity context with the in-process v2 path without adding a dependency edge.
Deviations from original plan:
- Added crates/orbit-core/src/runtime/tool_exec.rs to context to reuse the canonical registry policy-population path instead of duplicating checkout reconstruction in the command adapter. Added the orchestrator test and a focused CLI integration test because they are directly required to prove the transport boundary.
Validation:
- cargo test -p orbit-cli --test proc_spawn_managed (pass)
- cargo test -p orbit-engine run_cli_backend_injects_registry_root_not_worktree_state_root (pass)
- cargo test -p orbit-engine cli_activity_fs_profile_resolver_preserves_named_profile (pass)
- cargo test -p orbit-tools --test proc_spawn_lockdown (pass, 9 tests)
- cargo test -p orbit-core adapter::command::tests::dispatch (pass, 29 tests)
- make ci-fast (pass)
- make ci-lint (pass)

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11047-6a9317a9`
- Behind base: 0
- Ahead of base: 1