### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/_templates/specs/_mechanism.md
+++ b/docs/design/_templates/specs/_mechanism.md
@@ -1,7 +1,7 @@
 ---
 type: design
 summary: "Spec: <Mechanism>"
-last_validated: 2026-07-27
+last_validated: 2026-08-29
 ---
 
 # Spec: <Mechanism>

--- a/docs/design/activity-job/specs/audit-envelope.md
+++ b/docs/design/activity-job/specs/audit-envelope.md
@@ -2,7 +2,7 @@
 type: design
 summary: "Spec: V2 Audit Envelope"
 tags: ["activity-job"]
-last_validated: 2026-08-01
+last_validated: 2026-08-29
 ---
 
 # Spec: V2 Audit Envelope

--- a/docs/design/agent-families/references/glossary.md
+++ b/docs/design/agent-families/references/glossary.md
@@ -2,7 +2,7 @@
 type: design
 summary: "Agent Families — Glossary"
 tags: ["agent-families"]
-last_validated: 2026-08-01
+last_validated: 2026-08-29
 ---
 
 # Agent Families — Glossary

--- a/docs/design/auditability/3_vision.md
+++ b/docs/design/auditability/3_vision.md
@@ -4,7 +4,7 @@ type: design
 title: "Auditability — Vision"
 owner: codex
 last_updated: 2026-07-18
-last_validated: 2026-07-27
+last_validated: 2026-08-29
 status: Draft
 feature: auditability
 doc_role: vision

--- a/docs/design/auditability/references/glossary.md
+++ b/docs/design/auditability/references/glossary.md
@@ -2,7 +2,7 @@
 type: design
 summary: "Glossary: Auditability"
 tags: ["auditability"]
-last_validated: 2026-08-01
+last_validated: 2026-08-29
 ---
 
 # Glossary: Auditability

--- a/docs/design/executors/specs/external-executor-protocol.md
+++ b/docs/design/executors/specs/external-executor-protocol.md
@@ -2,14 +2,14 @@
 title: External Executor Protocol v1 (Retired)
 owner: claude
 last_updated: 2026-08-09
-last_validated: 2026-07-27
+last_validated: 2026-08-29
 status: Retired
 feature: executors
 type: design
 summary: "RETIRED: External Executor Protocol v1 was never a supported surface; the executor_type external transport was deleted in ORB-10395. Kept as a historical record of the retired wire contract."
 tags: [executors, extensibility, protocol, retired]
 paths:
-  - "crates/orbit-common/src/types/executor_def.rs"
+  - "crates/orbit-types/src/workflow/executor_def.rs"
 related_features: [executors]
 related_artifacts: [ORB-00384, ORB-10395]
 ---


### PR DESCRIPTION
## Task

[ORB-11051](https://orbit-cli.com/tasks/ORB-11051) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Selected exactly the six oldest active in-scope docs by missing/oldest `last_validated`, with stable path tie-break: `docs/design/_templates/specs/_mechanism.md`, `docs/design/auditability/3_vision.md`, `docs/design/executors/specs/external-executor-protocol.md` (all 2026-07-27), then `docs/design/activity-job/specs/audit-envelope.md`, `docs/design/agent-families/references/glossary.md`, and `docs/design/auditability/references/glossary.md` (all 2026-08-01). The design template directory is part of the documented docs corpus; numbered template placeholders were not treated as dates.
- Stamped all six selected, verified docs with `last_validated: 2026-08-29`. None required frontmatter migration: every selected file already had a schema-compatible frontmatter block with allowed `type` and non-empty single-line `summary`.
- `docs/design/_templates/specs/_mechanism.md`: verified the skeleton and its `design` / `Spec: <Mechanism>` metadata against `docs/design/CONVENTIONS.md` §6 and the tolerant frontmatter contract in `crates/orbit-core/src/application/docs/frontmatter.rs`; no prose or structure changed.
- `docs/design/auditability/3_vision.md`: verified current implementation and linked design references with `rg`/source reads covering the v2 envelope, audit rows, loop events, blob storage, invocation traces, and `.orbit/state/audit/`; no prose changed.
- `docs/design/executors/specs/external-executor-protocol.md`: verified the retired protocol against `crates/orbit-types/src/workflow/executor_def.rs`, absence of the deleted v1 executor implementation/assets, and the historical paths in `git show 0ea506ce^`; corrected only its stale frontmatter `paths` entry from the removed `crates/orbit-common/src/types/executor_def.rs` to current `crates/orbit-types/src/workflow/executor_def.rs`, then stamped it. Historical claims were retained as historical claims.
- `docs/design/activity-job/specs/audit-envelope.md`: verified `V2AuditEnvelope`/`V2AuditEventKind`, `V2AuditWriter`, `V2SqliteSink`, SQLite sources, blob layout, runtime readers, and `orbit run events|trace|logs` implementations; no prose changed.
- `docs/design/agent-families/references/glossary.md`: verified `AgentFamily::ALL`, `all_agent_families()`, `AgentModelPair`, model-pair override storage/resolution, and shipped executor YAMLs; no prose changed.
- `docs/design/auditability/references/glossary.md`: verified all terms, linked anchors, audit storage/source rows, blob store, and runtime invocation readers against current source; no prose changed.
- No selected doc or claim required a verification skip. Unselected `docs/design/terminal-interface/3_vision.md` was left unchanged. External prior-art assertions and open questions were left unchanged rather than rewritten from inference.
- No new document, section, metadata field, sidecar, validation marker, protected historical file, generated state, or asset was modified. Final changed paths are exactly the six selected docs.

Validation:
- `make ci-fast`: passed.
- `git diff --check`: passed.
- `scripts/generate-doc-indexes.sh --check`: passed as part of `make ci-fast`.
- Protected-path diff check for `.orbit/adrs/`, `CHANGELOG.md`, `docs/changelogs/`, `docs/design/_archive/`, `.orbit/tasks/`, `.orbit/graph/`, and `.orbit/state/`: empty.

Assessment: The bounded documentation rotation is complete. All six selected docs were code/schema-verified and earned today's validation date; the only content correction was a stale source path in retired executor metadata.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11051-6a931e80`
- Behind base: 0
- Ahead of base: 1