### PR TITLE
Ship a generic ci-failure-remediation default auto-task

### DIFF
--- a/crates/orbit-core/assets/auto_tasks/ci-failure-remediation.yaml
+++ b/crates/orbit-core/assets/auto_tasks/ci-failure-remediation.yaml
@@ -1,0 +1,128 @@
+schemaVersion: 1
+name: ci-failure-remediation
+description: Hourly evidence-first remediation of current GitHub Actions failures (GitHub-Actions-shaped; operators on other CI should adapt before enabling)
+enabled: false
+schedule:
+  cron: 15 * * * *
+template:
+  title: Remediate current GitHub Actions failures
+  description: |
+    Investigate and remediate current GitHub Actions failures for this
+    repository. This task may legitimately finish with no diff: if no
+    current, reproducible, repository-owned failure remains, persist the
+    evidence described below and report a successful no-current-failure or
+    transient-only outcome.
+
+    This definition is GitHub-Actions-shaped (`gh` or the GitHub API, run
+    URLs, checkout logs). Operators on other CI systems must adapt discovery
+    and rerun steps before enabling it.
+
+    ## Discovery and duplicate safety
+
+    1. Derive this workspace's integration and release branches from
+       workspace configuration and git remotes or defaults; do not assume
+       branch names. Enumerate this repository's workflows and recent runs
+       with GitHub's API or `gh`, and enumerate open pull requests with
+       their current head SHAs. Cover failures for those current integration
+       and release heads and every open pull-request head, including
+       informational jobs rather than looking only at required checks.
+    2. If the repository has a CI-failure task hook that files Orbit tasks
+       from red runs, search open tasks for its run URL, pull request, SHA,
+       and failure signature. Use `orbit tool run orbit.search` and
+       `orbit tool run orbit.task.list` / `orbit tool run orbit.task.show`.
+       Reference matching tasks in the execution summary; do not create
+       another task for the same run or root cause. This remediation task
+       owns the repair and must not fan a red-run cluster out into more
+       failure tasks.
+    3. For every candidate run, record the run and job URLs, workflow, event,
+       branch or PR, run-attempt number, reported head SHA, and the current
+       branch/PR head SHA. Query the failed jobs and steps and inspect the
+       exact failed-step logs.
+    4. Independently verify the commit that the runner actually checked out
+       from the checkout step/log (`HEAD is now at`, checkout ref/SHA, or
+       equivalent unambiguous evidence). Keep the event's reported head SHA,
+       the current ref head, and the tested checkout commit distinct;
+       pull-request merge SHAs are not interchangeable with pull-request
+       head SHAs.
+    5. Ignore a failed run as stale when its branch or PR has advanced and the
+       failure does not reproduce at the current head, or when a newer
+       successful run of the same workflow/check at the relevant current
+       commit supersedes it. Cite the advancing or superseding run and SHAs;
+       age alone is not evidence that a failure is stale.
+
+    ## Diagnosis and remediation
+
+    Cluster repeated runs by root cause before editing. Use the failing
+    command, job/step, exact error signature, tested commit, and causal
+    dependency between failures to distinguish one regression repeated across
+    push/PR runs from independent failures. Repair each current root cause
+    once, while retaining a mapping from every affected run/job to that
+    cluster.
+
+    Reproduce every current candidate at the current repository head using
+    the exact command or the narrowest faithful local equivalent. A
+    deterministic repository-owned failure is in scope and must be fixed in
+    this task's worktree. Classify a GitHub service, network, hosted-runner, or
+    other infrastructure failure as transient only with concrete evidence,
+    such as a successful retry at the same SHA plus logs showing the
+    infrastructure fault. Do not call a failure transient merely because it
+    fails to reproduce once.
+
+    Fix the underlying repository-owned cause. Do not disable a workflow,
+    weaken an assertion or lint level, add a broad allow/ignore rule, mark a
+    failing gate `continue-on-error`, remove an affected target from coverage,
+    or otherwise obtain green CI by hiding the failure. Informational checks
+    remain informational, but they must execute successfully.
+
+    ## Validation and handoff
+
+    For each fixed root cause, rerun the exact command that formerly failed.
+    Then run this repository's own documented pre-handoff gate, whatever that
+    repository documents — do not assume a particular build target or vendor
+    command. After the candidate commit is published through the repository's
+    normal workflow, inspect its GitHub Actions runs and require a green
+    rerun for every affected workflow/check. This includes affected
+    informational jobs even though they remain non-required. Do not declare a
+    repair validated while an affected run is missing, queued, in progress,
+    cancelled, or red.
+
+    Persist an `execution_summary` that maps every investigated run/job URL,
+    reported head SHA, actual checkout commit, and current ref head to its
+    root-cause cluster, disposition (fixed, stale, superseded, or transient),
+    change, local reproduction, exact formerly failing validation, pre-handoff
+    result, and green GitHub rerun URL. Also map any matching task created by
+    a CI-failure hook. For a successful no-diff pass, list the queries, current
+    heads, superseding successes or transient evidence, and why no
+    repository-owned failure remained.
+
+    ## Reported-head SHA versus checkout commit
+
+    A CI event's reported head SHA is not always the commit the runner tested.
+    Merge-queue or pull-request merge SHAs, a checkout of a different ref, or
+    stale metadata can make the event SHA disagree with the checkout log. A
+    valid investigation records both, clusters by the actual tested commit,
+    and checks whether the failure still exists at the current ref head
+    before editing.
+  acceptance_criteria:
+  - Current-head failures across the workspace's derived integration and release branches and open pull requests were enumerated for every repository workflow, including informational jobs.
+  - Every investigated run records its reported SHA, actual checkout commit, current ref head, failed job/step, exact log evidence, and stale or superseding evidence where applicable.
+  - Repeated red runs are clustered by root cause, and every current repository-owned failure is reproduced and fixed without weakening or bypassing a check.
+  - Transient-only classifications cite infrastructure evidence and a successful same-SHA retry; a single non-reproduction is not treated as sufficient evidence.
+  - Each fixed cause passes the exact formerly failing validation and the repository's documented pre-handoff gate, and every affected required or informational GitHub Actions check executes successfully on the candidate commit.
+  - The persisted execution_summary maps each run/job URL and SHA to its root cause, disposition, change, validations, green rerun, and any matching CI-failure-hook task.
+  - A no-current-failure or transient-only investigation is a successful no-diff outcome when its current-head queries and superseding or transient evidence are persisted.
+  task_type: bug
+  tags:
+  - ci-failure-remediation
+  - github-actions
+  - no-diff-expected
+  priority: high
+  # The portable system lane is seeded per machine and compatibility-aliased
+  # for configs written before that crew existed.
+  crew: system
+  status: backlog
+dedupe: skip_if_open
+created_by: system
+created_at: 2026-08-29T00:00:00Z
+updated_by: system
+updated_at: 2026-08-29T00:00:00Z

--- a/crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md
@@ -67,9 +67,9 @@ scheduler's cursor untouched — so it is the safe way to test a definition's
 wording before enabling it. Over MCP: `orbit_auto_task_list` and
 `orbit_auto_task_mint`.
 
-## The four seeded definitions
+## The five seeded definitions
 
-`orbit workspace init` seeds all four, disabled:
+`orbit workspace init` seeds all five, disabled:
 
 - **`qa-sweep`** — hourly. Identifies recent changes, exercises them hands-on
   through their real user-facing paths rather than just re-running the test
@@ -86,6 +86,12 @@ wording before enabling it. Over MCP: `orbit_auto_task_list` and
   candidate finding against the live code, files the non-duplicate ones as tasks
   tagged `code-review`, and records the new last-reviewed commit in its execution
   summary — that cursor is the next sweep's window start.
+- **`ci-failure-remediation`** — hourly. Investigates current GitHub Actions
+  failures on the workspace's derived integration and release heads plus open
+  pull-request heads, clusters by root cause, repairs repository-owned failures
+  without weakening a check, and treats a clean current-head pass as a successful
+  no-diff outcome. The body is GitHub-Actions-shaped; operators on other CI
+  should adapt it before enabling.
 
 Read them before enabling. They are also the best worked examples of how much
 instruction a minted task's body should carry.

--- a/crates/orbit-core/src/auto_tasks/mod.rs
+++ b/crates/orbit-core/src/auto_tasks/mod.rs
@@ -51,6 +51,10 @@ pub use state::{AutoTaskCursor, AutoTaskCursorState, cursor_state_path, load_cur
 /// explicitly mint one or enable it through the existing auto-task surface.
 pub(crate) const DEFAULT_AUTO_TASK_FILES: &[(&str, &str)] = &[
     (
+        "ci-failure-remediation",
+        include_str!("../../assets/auto_tasks/ci-failure-remediation.yaml"),
+    ),
+    (
         "code-review-sweep",
         include_str!("../../assets/auto_tasks/code-review-sweep.yaml"),
     ),

--- a/crates/orbit-core/src/auto_tasks/tests/shipped.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/shipped.rs
@@ -23,6 +23,7 @@ fn shipped_defaults_all_parse_and_are_disabled() {
         .map(|(name, _)| *name)
         .collect();
     for required in [
+        "ci-failure-remediation",
         "code-review-sweep",
         "friction-curation",
         "qa-sweep",
@@ -456,5 +457,181 @@ fn security_review_default_is_portable_weekly_and_inert() {
             .any(|criterion| criterion.to_lowercase().contains("no findings")
                 && criterion.to_lowercase().contains("no-op")),
         "security-review acceptance criteria must treat a clean review as success"
+    );
+}
+
+/// CI-failure remediation is the portable default. It keeps the evidence
+/// contract while remaining disabled until an operator opts in.
+#[test]
+fn ci_failure_remediation_default_is_portable_hourly_and_inert() {
+    let (_, yaml) = DEFAULT_AUTO_TASK_FILES
+        .iter()
+        .find(|(name, _)| *name == "ci-failure-remediation")
+        .expect("ci-failure-remediation default");
+    let definition = parse_auto_task_yaml(yaml).expect("parse ci-failure-remediation");
+
+    assert_eq!(definition.name, "ci-failure-remediation");
+    assert!(!definition.enabled, "definition must ship disabled");
+    assert_eq!(
+        definition.schedule,
+        AutoTaskSchedule::Cron {
+            cron: "15 * * * *".to_string()
+        },
+        "ci-failure-remediation must use a documented hourly schedule"
+    );
+    assert!(matches!(definition.dedupe, DedupePolicy::SkipIfOpen));
+    assert_eq!(definition.template.crew.as_deref(), Some("system"));
+    assert!(
+        yaml.contains("\n  crew: system"),
+        "default must name the portable system crew"
+    );
+    assert_eq!(
+        definition.template.status,
+        orbit_types::task::TaskStatus::Backlog
+    );
+    assert_eq!(
+        definition.template.task_type,
+        orbit_types::task::TaskType::Bug
+    );
+    for required_tag in ["ci-failure-remediation", "no-diff-expected"] {
+        assert!(
+            definition
+                .template
+                .tags
+                .iter()
+                .any(|tag| tag == required_tag),
+            "missing required tag {required_tag}"
+        );
+    }
+    assert!(
+        !yaml.contains("/home/") && !yaml.contains("/Users/"),
+        "default must not contain a machine-specific path"
+    );
+    // The template ships to every workspace, so it must not name this
+    // repository's branches, gates, workflow steps, files, or run IDs.
+    for repo_specific in [
+        "agent-main",
+        "make ci",
+        "Create orbit task on CI failure",
+        ".github/workflows",
+        "30232696219",
+        "orbit-store",
+        "plugin_skill_symlinks",
+        "ORB-",
+        "CLAUDE.md",
+    ] {
+        assert!(
+            !yaml.contains(repo_specific),
+            "template must stay workspace-generic; found '{repo_specific}'"
+        );
+    }
+    assert!(
+        definition
+            .description
+            .to_lowercase()
+            .contains("github-actions-shaped")
+            || definition
+                .description
+                .to_lowercase()
+                .contains("github-actions shaped"),
+        "description must disclose the GitHub Actions shape to operators on other CI"
+    );
+
+    let body = definition.template.description.to_lowercase();
+    for required in [
+        "current head",
+        "reported head sha",
+        "checkout commit",
+        "stale",
+        "supersedes",
+        "root cause",
+        "weaken",
+        "transient",
+        "green",
+        "rerun",
+        "execution_summary",
+        "no-diff",
+        "pre-handoff",
+        "orbit tool run orbit.search",
+        "orbit tool run orbit.task.list",
+        "orbit tool run orbit.task.show",
+    ] {
+        assert!(
+            body.contains(required),
+            "template should retain '{required}'"
+        );
+    }
+    assert!(!body.contains("orbit task list"));
+    assert!(!body.contains("orbit task show"));
+    assert!(
+        definition
+            .template
+            .acceptance_criteria
+            .iter()
+            .any(|criterion| {
+                let criterion = criterion.to_lowercase();
+                criterion.contains("execution_summary")
+                    && criterion.contains("green rerun")
+                    && criterion.contains("root cause")
+            }),
+        "ci-failure-remediation must require the execution_summary mapping contract"
+    );
+    assert!(
+        definition
+            .template
+            .acceptance_criteria
+            .iter()
+            .any(|criterion| {
+                let criterion = criterion.to_lowercase();
+                criterion.contains("no-current-failure") && criterion.contains("no-diff")
+            }),
+        "ci-failure-remediation must treat a successful no-diff outcome as success"
+    );
+}
+
+/// This repository already has an enabled workspace-authored
+/// `ci-failure-remediation` definition. Seeding the inert default must treat
+/// that file as authored and leave it byte-for-byte, the way workspace init
+/// preserves an operator-authored `security-review`.
+#[test]
+fn seed_does_not_clobber_repository_authored_ci_failure_remediation() {
+    let authored_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(".orbit/auto_tasks/ci-failure-remediation.yaml");
+    let authored = std::fs::read_to_string(&authored_path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", authored_path.display()));
+    let authored_definition =
+        parse_auto_task_yaml(&authored).expect("repository-authored ci-failure-remediation parses");
+    assert!(
+        authored_definition.enabled,
+        "this repository's definition is workspace-authored and enabled"
+    );
+    assert_ne!(
+        authored_definition.template.crew.as_deref(),
+        Some("system"),
+        "this repository's definition must differ from the inert default so preservation is observable"
+    );
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let orbit_dir = temp.path().join(".orbit");
+    let dest = crate::auto_tasks::definition_path(&orbit_dir, "ci-failure-remediation");
+    std::fs::create_dir_all(dest.parent().expect("auto_tasks parent"))
+        .expect("create auto_tasks dir");
+    std::fs::write(&dest, &authored).expect("install repository-authored definition");
+
+    crate::auto_tasks::seed_default_auto_tasks(&orbit_dir)
+        .expect("seed defaults into a workspace that already has the authored file");
+
+    let preserved = std::fs::read_to_string(&dest).expect("read after seed");
+    assert_eq!(
+        preserved, authored,
+        "seed/re-init must treat the repository-authored definition as authored and leave it byte-for-byte"
+    );
+    let preserved_definition =
+        parse_auto_task_yaml(&preserved).expect("preserved definition still parses");
+    assert!(preserved_definition.enabled);
+    assert_eq!(
+        preserved_definition.template.crew.as_deref(),
+        authored_definition.template.crew.as_deref()
     );
 }

--- a/crates/orbit-core/src/bootstrap/init.rs
+++ b/crates/orbit-core/src/bootstrap/init.rs
@@ -891,6 +891,7 @@ mod tests {
         let friction_path = orbit_root.join("auto_tasks/friction-curation.yaml");
         let qa_path = orbit_root.join("auto_tasks/qa-sweep.yaml");
         let security_path = orbit_root.join("auto_tasks/security-review.yaml");
+        let ci_failure_path = orbit_root.join("auto_tasks/ci-failure-remediation.yaml");
         let friction = fs::read_to_string(&friction_path).expect("read seeded friction definition");
         let friction_definition = orbit_common::protocol::yaml::parse_auto_task_yaml(&friction)
             .expect("seeded friction definition parses through loader schema");
@@ -933,6 +934,23 @@ mod tests {
             security_definition.dedupe,
             orbit_types::workflow::DedupePolicy::SkipIfOpen
         ));
+        let ci_failure = fs::read_to_string(&ci_failure_path)
+            .expect("read seeded ci-failure-remediation definition");
+        let ci_failure_definition = orbit_common::protocol::yaml::parse_auto_task_yaml(&ci_failure)
+            .expect("seeded ci-failure-remediation definition parses through loader schema");
+        assert!(!ci_failure_definition.enabled);
+        assert_eq!(
+            ci_failure_definition.template.crew.as_deref(),
+            Some("system")
+        );
+        assert!(
+            ci_failure.contains("\n  crew: system"),
+            "seeded ci-failure-remediation default must name the system crew"
+        );
+        assert!(matches!(
+            ci_failure_definition.dedupe,
+            orbit_types::workflow::DedupePolicy::SkipIfOpen
+        ));
         assert!(!orbit_root.join("state/auto-tasks.json").exists());
         let loaded = crate::auto_tasks::collect_auto_tasks(&orbit_root);
         assert!(
@@ -961,13 +979,22 @@ mod tests {
                 .iter()
                 .any(|loaded| loaded.definition.name == "security-review")
         );
+        assert!(
+            loaded
+                .definitions
+                .iter()
+                .any(|loaded| loaded.definition.name == "ci-failure-remediation")
+        );
 
         let authored_friction = "operator-authored friction definition\n";
         let authored_qa = "operator-authored QA definition\n";
         let authored_security = "operator-authored security-review definition\n";
+        let authored_ci_failure = "operator-authored ci-failure-remediation definition\n";
         fs::write(&friction_path, authored_friction).expect("write friction edit");
         fs::write(&qa_path, authored_qa).expect("write QA edit");
         fs::write(&security_path, authored_security).expect("write security-review edit");
+        fs::write(&ci_failure_path, authored_ci_failure)
+            .expect("write ci-failure-remediation edit");
         let repeated =
             init_workspace_at_root(&orbit_root, options).expect("reinitialize workspace");
         assert_eq!(repeated.seeded_default_auto_tasks, 0);
@@ -982,6 +1009,11 @@ mod tests {
         assert_eq!(
             fs::read_to_string(security_path).expect("read preserved security-review definition"),
             authored_security
+        );
+        assert_eq!(
+            fs::read_to_string(ci_failure_path)
+                .expect("read preserved ci-failure-remediation definition"),
+            authored_ci_failure
         );
     }
 

--- a/docs/design/auto-tasks/1_overview.md
+++ b/docs/design/auto-tasks/1_overview.md
@@ -11,7 +11,7 @@ summary: Dynamically-defined recurring task templates minted by one generic sche
 tags: [auto-tasks]
 paths: ["crates/orbit-core/src/auto_tasks/**"]
 related_features: [auto-tasks]
-related_artifacts: [ORB-10149, ORB-10318, ORB-10348, ORB-10439, ORB-10446, ORB-10514, ORB-10549, ORB-10950]
+related_artifacts: [ORB-10149, ORB-10318, ORB-10348, ORB-10439, ORB-10446, ORB-10514, ORB-10549, ORB-10950, ORB-11054]
 ---
 
 # Auto-tasks — Overview
@@ -78,23 +78,46 @@ becomes just the first definition.
 | Manual mint (`mint`, CLI + MCP) | `crates/orbit-core/src/auto_tasks/crud.rs` | ORB-10439, ORB-10798 |
 | Deterministic action | `crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs` | ORB-10149 |
 | Seeded assets | `crates/orbit-core/assets/{activities,jobs,routines}/…` | ORB-10149 |
-| Default auto-task catalog | `crates/orbit-core/assets/auto_tasks/…` | ORB-10549, ORB-10550, ORB-10950 |
+| Default auto-task catalog | `crates/orbit-core/assets/auto_tasks/…` | ORB-10549, ORB-10550, ORB-10950, ORB-11054 |
 
-## Definitions shipped in this repo
+## Embedded default catalog
 
-- `qa-sweep` — hands-on validation of recent changes (ORB-10148).
+These five YAML files live under `crates/orbit-core/assets/auto_tasks/` and are
+registered in `DEFAULT_AUTO_TASK_FILES`. `orbit workspace init` materializes a
+missing file as `enabled: false`; re-init does not overwrite a workspace-authored
+definition of the same name.
+
+- `qa-sweep` — hands-on validation of recent changes (ORB-10148, embedded by ORB-10550).
 - `friction-curation` — disabled-by-default daily evidence-first pass that deduplicates open
   friction records, re-verifies survivors against current behavior, resolves
   records that no longer reproduce, and files non-duplicate fix tasks for
-  verified-real issues (ORB-10440).
+  verified-real issues (ORB-10440, embedded by ORB-10549).
 - `security-review` — disabled-by-default weekly evidence-backed review of
   applicable application code, dependencies, secret handling, and configuration;
   each actionable finding is filed as a durable Orbit task, and a clean review
   is a successful no-op (ORB-10950).
+- `code-review-sweep` — disabled-by-default six-hourly review of commits merged
+  since the previous sweep's recorded cursor.
 - `ci-failure-remediation` — disabled-by-default hourly investigation and
-  remediation of current-head GitHub Actions failures across integration,
-  release, and open-PR refs, with stale-run filtering, root-cause clustering,
-  PR-hook deduplication, and evidence-backed no-diff outcomes (ORB-10514).
+  remediation of current-head GitHub Actions failures across the workspace's
+  derived integration and release heads plus open pull-request heads, with
+  stale-run filtering, root-cause clustering, CI-failure-hook deduplication,
+  and evidence-backed no-diff outcomes (ORB-11054). GitHub-Actions-shaped;
+  operators on other CI should adapt before enabling.
+
+## Workspace-authored definitions in this repo
+
+Orbit's own checkout also carries extra `.orbit/auto_tasks/` files that are
+**not** embedded defaults. They may be enabled, name a family-specific crew, or
+encode this repository's branches and gates. Re-init preserves them:
+
+- `ci-failure-remediation` — this repository's enabled, Orbit-specific
+  definition (ORB-10514, `crew: luna`). Distinct from the inert portable default
+  of the same name; managed-asset reconciliation treats the local file as
+  authored.
+- `doc-duties`, `model-price-audit`, `release-prep`, and this repository's
+  enabled copies of catalog names such as `code-review-sweep` and
+  `security-review`.
 
 ## Task References
 
@@ -110,5 +133,8 @@ becomes just the first definition.
   friction tool invocations on the registered `orbit tool run` surface.
 - ORB-10950 — Added the disabled weekly `security-review` default to the
   embedded catalog so new workspaces can opt into a recurring security review.
+- ORB-11054 — Added the disabled hourly `ci-failure-remediation` default to the
+  embedded catalog and split this overview so repo-local workspace-authored
+  definitions are no longer listed as if they were embedded defaults.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/plugin/skills/orbit/references/setup/auto-tasks.md
+++ b/plugin/skills/orbit/references/setup/auto-tasks.md
@@ -67,9 +67,9 @@ scheduler's cursor untouched — so it is the safe way to test a definition's
 wording before enabling it. Over MCP: `orbit_auto_task_list` and
 `orbit_auto_task_mint`.
 
-## The four seeded definitions
+## The five seeded definitions
 
-`orbit workspace init` seeds all four, disabled:
+`orbit workspace init` seeds all five, disabled:
 
 - **`qa-sweep`** — hourly. Identifies recent changes, exercises them hands-on
   through their real user-facing paths rather than just re-running the test
@@ -86,6 +86,12 @@ wording before enabling it. Over MCP: `orbit_auto_task_list` and
   candidate finding against the live code, files the non-duplicate ones as tasks
   tagged `code-review`, and records the new last-reviewed commit in its execution
   summary — that cursor is the next sweep's window start.
+- **`ci-failure-remediation`** — hourly. Investigates current GitHub Actions
+  failures on the workspace's derived integration and release heads plus open
+  pull-request heads, clusters by root cause, repairs repository-owned failures
+  without weakening a check, and treats a clean current-head pass as a successful
+  no-diff outcome. The body is GitHub-Actions-shaped; operators on other CI
+  should adapt it before enabling.
 
 Read them before enabling. They are also the best worked examples of how much
 instruction a minted task's body should carry.


### PR DESCRIPTION
## Task

[ORB-11054](https://orbit-cli.com/tasks/ORB-11054) — Ship a generic ci-failure-remediation default auto-task

### Description

Add a portable `ci-failure-remediation` definition to the embedded default
auto-task catalog, so every workspace initialized by `orbit workspace init`
gets a CI-failure remediation option alongside `qa-sweep`,
`friction-curation`, `security-review`, and `code-review-sweep`.

Today this definition exists only as the repo-local, Orbit-specific
`.orbit/auto_tasks/ci-failure-remediation.yaml` (enabled, `crew: luna`). It is
not in `DEFAULT_AUTO_TASK_FILES`
(`crates/orbit-core/src/auto_tasks/mod.rs:52`), so no other workspace gets it.
`docs/design/auto-tasks/1_overview.md` already lists it under "Definitions
shipped in this repo" (ORB-10514), which reads as if it were an embedded
default — that drift should be resolved by this task too.

## Work

1. **New asset** — `crates/orbit-core/assets/auto_tasks/ci-failure-remediation.yaml`,
   derived from the repo-local definition but project-agnostic, matching the
   shape of the other shipped defaults: `enabled: false`, `crew: system`,
   `status: backlog`, `dedupe: skip_if_open`, `task_type: bug`, tags including
   `ci-failure-remediation` and `no-diff-expected`, and an hourly cron.
   Strip every Orbit-specific element from the body:
   - the hardcoded `agent-main` / `main` branch pair — instruct the agent to
     derive the workspace's integration and release branches plus open PR heads
     rather than naming branches;
   - `make ci-fast` — instruct the agent to run the repository's own documented
     pre-handoff gate, whatever it is;
   - the `.github/workflows/ci.yml` "Create orbit task on CI failure" step —
     keep the duplicate-safety rule generic ("if the repository has a CI-failure
     task hook, search open tasks for its run URL / PR / SHA / failure
     signature and reference rather than duplicate");
   - the "Historical validation fixture" section (run 30232696219, the
     `orbit-store` clippy path, the `plugin_skill_symlinks_resolve_to_assets`
     test) — replace with a short generic worked example of the
     reported-head-SHA vs actual-checkout-commit discrepancy, or drop it.
   Keep the substance that makes the definition good: current-head-only scope,
   reported vs checked-out SHA separation, stale/superseded filtering, root-cause
   clustering, the no-weakening-the-check rule, evidence-backed transient
   classification, green rerun before declaring a repair validated, and the
   `execution_summary` mapping contract including the successful no-diff outcome.
   Do not name a specific CI vendor beyond what generic guidance needs; if it
   stays GitHub-Actions-shaped, say so explicitly in the description field so
   operators on other CI know what they are enabling.

2. **Register it** — add the entry to `DEFAULT_AUTO_TASK_FILES` in
   `crates/orbit-core/src/auto_tasks/mod.rs`, keeping the list's existing order
   convention. Seeding already validates that a default parses and ships
   disabled; confirm the new asset satisfies both.

3. **Tests** — extend the required-name list in
   `crates/orbit-core/src/auto_tasks/tests/shipped.rs`
   (`shipped_defaults_all_parse_and_are_disabled`) with
   `ci-failure-remediation`. Add coverage that the embedded default does not
   clobber this repository's own enabled workspace-authored
   `.orbit/auto_tasks/ci-failure-remediation.yaml` on re-init — the
   managed-asset reconciliation must treat the local file as authored, the way
   `bootstrap/init.rs` already asserts for an operator-authored
   `security-review`.

4. **Docs** — update the "The four seeded definitions" section in
   `crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md` (count
   and list), and reconcile `docs/design/auto-tasks/1_overview.md` so the
   shipped-in-this-repo list and the embedded-default catalog are unambiguous,
   with this task's ID recorded in its Task References section.

### Acceptance Criteria

- `crates/orbit-core/assets/auto_tasks/ci-failure-remediation.yaml` exists, parses through `parse_auto_task_yaml`, ships `enabled: false` with `crew: system`, and contains no Orbit-specific branch names, `make` targets, workflow step names, file paths, or run IDs.
- The generic body retains current-head scoping, reported-vs-checked-out SHA separation, stale/superseded filtering, root-cause clustering, the no-weakening-a-check rule, evidence-backed transient classification, a required green rerun, and the `execution_summary` contract including the successful no-diff outcome.
- `ci-failure-remediation` is registered in `DEFAULT_AUTO_TASK_FILES` and is materialized, disabled, into a freshly initialized workspace.
- `shipped_defaults_all_parse_and_are_disabled` requires `ci-failure-remediation`, and a test proves re-init does not overwrite this repository's enabled workspace-authored `.orbit/auto_tasks/ci-failure-remediation.yaml`.
- The seeded-definitions section of `references/setup/auto-tasks.md` documents the new default and its count, and `docs/design/auto-tasks/1_overview.md` no longer conflates repo-local with embedded defaults and cites this task ID.
- The repository's pre-handoff gate passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added portable `crates/orbit-core/assets/auto_tasks/ci-failure-remediation.yaml` (`enabled: false`, `crew: system`, hourly cron, GitHub-Actions-shaped description). Body keeps current-head scope, reported-vs-checkout SHA separation, stale/superseded filtering, root-cause clustering, no-weakening, evidence-backed transients, green rerun, and the execution_summary/no-diff contract; strips Orbit-specific branches, make targets, workflow step names, file paths, and run IDs.
- Registered `ci-failure-remediation` first in `DEFAULT_AUTO_TASK_FILES` (alphabetical).
- Extended shipped tests: required-name list, portable/inert contract, and seed preservation of this repository's enabled workspace-authored YAML.
- Extended `workspace_init_seeds_inert_defaults_without_clobbering_edits` so a fresh init materializes the default disabled and re-init preserves authored bytes.
- Docs: five seeded definitions in setup/auto-tasks.md (assets + plugin mirror); overview splits embedded catalog vs this-repo workspace-authored files and cites ORB-11054.
Assessment: Scoped to the catalog/docs/tests the task named. Extra files were `bootstrap/init.rs` (materialization/preservation test) and the plugin skill mirror (ci-fast drift check).
Strategic decisions: Kept GitHub Actions in the body after disclosing the shape in the YAML description field, rather than inventing a vendor-neutral CI dialect.
Validation: `cargo test -p orbit-core --lib auto_tasks::tests::shipped` (9 passed); `workspace_init_seeds_inert_defaults_without_clobbering_edits`; `make ci-fast`; `make ci-lint`.
Friction checkpoint: `orbit.task.update` from this linked worktree returned `task_not_found` while `orbit.task.show` succeeded; writes needed `orbit --workspace ws_orbit`. Designed routing (show is ID-global, update is workspace-scoped); recorded as friction.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11054-6a933c2e`
- Behind base: 0
- Ahead of base: 1