### PR TITLE
MCP callers default deny still serves ordinary agent tools

### DIFF
--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -740,12 +740,64 @@ fn a_remote_session_without_a_caller_label_is_still_resolved_through_the_file() 
         &["--operator"],
         &[("SSH_CONNECTION", "192.0.2.8 43100 198.51.100.2 22")],
     );
-    let denied = client.call_tool_err("orbit_workflow_run_list", json!({}));
+    for (name, arguments) in [
+        ("orbit_task_list", json!({})),
+        (
+            "orbit_task_add",
+            json!({
+                "title": "must not be created",
+                "description": "default deny must block ordinary MCP mutations",
+                "complexity": "low",
+                "model": "codex",
+            }),
+        ),
+        ("orbit_workflow_run_list", json!({})),
+    ] {
+        let denied = client.call_tool_err(name, arguments);
+        assert_eq!(
+            denied["code"], "capability_denied",
+            "an unlabelled remote caller falls to the file default, never to its own argv: {name}: {denied}"
+        );
+    }
+}
 
-    assert_eq!(
-        denied["code"], "capability_denied",
-        "an unlabelled remote caller falls to the file default, never to its own argv: {denied}"
+/// [ORB-11056] A workspace-narrowed row falls back to the file default for a
+/// call outside its allowed workspaces. With `default = "deny"`, both ordinary
+/// reads and mutations must therefore fail before reaching their handlers.
+#[test]
+fn a_remote_caller_outside_its_workspace_narrowing_cannot_use_ordinary_tools() {
+    let workspace = McpWorkspace::init();
+    write_callers(
+        &workspace,
+        r#"
+default = "deny"
+
+[[callers]]
+machine_id = "hm_caller"
+capabilities = ["agent"]
+workspaces = ["ws_somewhere-else"]
+"#,
     );
+
+    let mut client = workspace.serve_with_args_and_env(
+        &["--remote-caller-machine-id", "hm_caller"],
+        &[("SSH_CONNECTION", "192.0.2.8 43100 198.51.100.2 22")],
+    );
+    for (name, arguments) in [
+        ("orbit_task_list", json!({})),
+        (
+            "orbit_task_add",
+            json!({
+                "title": "must not be created",
+                "description": "workspace narrowing must block ordinary MCP mutations",
+                "complexity": "low",
+                "model": "codex",
+            }),
+        ),
+    ] {
+        let denied = client.call_tool_err(name, arguments);
+        assert_eq!(denied["code"], "capability_denied", "{name}: {denied}");
+    }
 }
 
 /// [ORB-11052] The file is a ceiling, not a grant: it can only lower a session
@@ -766,6 +818,18 @@ capabilities = ["agent", "operator"]
         &["--remote-caller-machine-id", "hm_caller"],
         &[("SSH_CONNECTION", "192.0.2.8 43100 198.51.100.2 22")],
     );
+    let listed = client.call_tool_ok("orbit_task_list", json!({}));
+    assert_eq!(listed["items"], json!([]));
+    let created = client.call_tool_ok(
+        "orbit_task_add",
+        json!({
+            "title": "remote agent task",
+            "description": "an agent grant retains ordinary MCP mutations",
+            "complexity": "low",
+            "model": "codex",
+        }),
+    );
+    assert_eq!(created["title"], "remote agent task");
     let denied = client.call_tool_err("orbit_workflow_run_list", json!({}));
 
     assert_eq!(
@@ -792,6 +856,8 @@ capabilities = ["agent", "operator"]
         &["--operator", "--remote-caller-machine-id", "hm_caller"],
         &[("SSH_CONNECTION", "192.0.2.8 43100 198.51.100.2 22")],
     );
+    let tasks = client.call_tool_ok("orbit_task_list", json!({}));
+    assert_eq!(tasks["items"], json!([]));
     let listed = client.call_tool_ok("orbit_workflow_run_list", json!({}));
     assert_eq!(listed["items"], json!([]));
 

--- a/crates/orbit-common/src/governance/authorization.rs
+++ b/crates/orbit-common/src/governance/authorization.rs
@@ -30,10 +30,14 @@
 //! availability, so an unadvertised tool is still reachable through
 //! `orbit tool run`.
 //!
-//! *Permission* is [`GOVERNED_OPERATIONS`], resolved by [`authorize`] at one
-//! chokepoint per surface. This is the only authorization statement Orbit
-//! makes about a tool, and it is surface-independent: the same answer for an
-//! MCP call, a CLI `tool run`, the dashboard, and the deterministic dispatcher.
+//! *Permission* for exceptional operations is [`GOVERNED_OPERATIONS`], resolved
+//! by [`authorize`] at one chokepoint per surface. Remote-originated MCP calls
+//! also have a baseline rule at that chokepoint: a destination-side caller
+//! grant must include [`McpCapability::Agent`] before it can use ordinary,
+//! ungoverned tools. The registry remains the only operation-specific
+//! authorization statement Orbit makes, and its answer is surface-independent:
+//! the same answer for an MCP call, a CLI `tool run`, the dashboard, and the
+//! deterministic dispatcher.
 //!
 //! The two therefore need not agree, and deliberately do not. A tool may be
 //! advertised and governed (the operator MCP surface: a session served by
@@ -97,10 +101,12 @@ pub enum OperationSurface {
 
 /// One operation whose performance requires a capability.
 ///
-/// An operation absent from [`GOVERNED_OPERATIONS`] is ungoverned and executes
-/// as before. Governance is opt-in per operation on purpose: the registry is
-/// meant to name the operations whose accidental invocation actually destroys
-/// something, not to become a second copy of the tool registry.
+/// An operation absent from [`GOVERNED_OPERATIONS`] has no operation-specific
+/// capability check. Governance is opt-in per operation on purpose: the
+/// registry is meant to name the operations whose accidental invocation
+/// actually destroys something, not to become a second copy of the tool
+/// registry. The runtime separately enforces the `agent` baseline for ordinary
+/// tools when a destination-side grant identifies a remote MCP caller.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GovernedOperation {
     /// Canonical tool name, or `"<command> <subcommand>"` for a CLI command.

--- a/crates/orbit-core/src/runtime/authorization.rs
+++ b/crates/orbit-core/src/runtime/authorization.rs
@@ -25,14 +25,14 @@ use orbit_common::governance::authorization::{
 use orbit_common::observability::audit_id::audit_execution_id;
 use orbit_store::contracts::AuditEventInsertParams;
 use orbit_types::telemetry::AuditEventStatus;
-use orbit_types::tool::ToolSessionContext;
+use orbit_types::tool::{McpCapability, ToolSessionContext};
 
 use crate::OrbitRuntime;
 use crate::runtime::tool_exec::CapabilityEnforcement;
 
 impl OrbitRuntime {
-    /// Authorize a governed tool call, or pass an ungoverned one straight
-    /// through.
+    /// Authorize a governed tool call, then require destination-granted remote
+    /// callers to hold `agent` before reaching the ordinary MCP surface.
     ///
     /// Called from `run_tool_with_context_and_role`, which every tool caller
     /// traverses: CLI `tool run`, the CLI's admin `run_tool` bypass, MCP
@@ -44,14 +44,74 @@ impl OrbitRuntime {
         session_context: &ToolSessionContext,
         capability_enforcement: CapabilityEnforcement,
     ) -> Result<(), OrbitError> {
-        let Some(operation) = governed_tool(tool_name) else {
+        if let Some(operation) = governed_tool(tool_name) {
+            let envelope = match capability_enforcement {
+                CapabilityEnforcement::Enforce => CallerEnvelope::from_process_env(session_context),
+                CapabilityEnforcement::McpSessionOnly => {
+                    CallerEnvelope::mcp_session(session_context)
+                }
+            };
+            return self.decide_with_envelope(operation, envelope);
+        }
+        if capability_enforcement != CapabilityEnforcement::McpSessionOnly {
             return Ok(());
+        }
+
+        let caller = CallerCapabilities::resolve(&CallerEnvelope::mcp_session(session_context));
+        if !caller.grants().contains(&McpCapability::Agent)
+            && let Some(grant) = caller.remote_caller_grant()
+        {
+            return self.deny_remote_agent_tool(tool_name, &caller, grant);
+        }
+
+        Ok(())
+    }
+
+    /// Refuse an ordinary tool when the destination resolved a remote caller
+    /// without the baseline capability for the agent MCP surface.
+    ///
+    /// Governed tools never reach this path: their operation-specific checks
+    /// remain authoritative, so an operator-only grant can still perform an
+    /// operator operation without implicitly gaining ordinary agent tools.
+    fn deny_remote_agent_tool(
+        &self,
+        tool_name: &str,
+        caller: &CallerCapabilities,
+        grant: &orbit_types::tool::RemoteCallerGrant,
+    ) -> Result<(), OrbitError> {
+        let granted = caller
+            .grants()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        let granted = if granted.is_empty() {
+            "none".to_string()
+        } else {
+            granted
         };
-        let envelope = match capability_enforcement {
-            CapabilityEnforcement::Enforce => CallerEnvelope::from_process_env(session_context),
-            CapabilityEnforcement::McpSessionOnly => CallerEnvelope::mcp_session(session_context),
-        };
-        self.decide_with_envelope(operation, envelope)
+        let message = format!(
+            "operation '{tool_name}' requires the `agent` capability (ordinary MCP tools are \
+             available only to destination-granted agents); caller '{}' was resolved as \
+             `remote-grant` holding [{granted}] from {}",
+            grant.caller_machine_id, grant.source,
+        );
+
+        tracing::warn!(
+            target: "orbit.authorization",
+            operation = tool_name,
+            provenance = %caller.provenance(),
+            granted,
+            caller_machine_id = grant.caller_machine_id,
+            "ordinary MCP tool denied"
+        );
+        self.record_authorization_event(
+            tool_name,
+            caller,
+            AuditEventStatus::Denied,
+            Some(message.clone()),
+        );
+        Err(OrbitError::CapabilityDenied(message))
     }
 
     /// Authorize a governed CLI command, or pass an ungoverned one through.
@@ -97,7 +157,7 @@ impl OrbitRuntime {
                         "governed operation authorized through the operator override"
                     );
                     self.record_authorization_event(
-                        operation,
+                        operation.id,
                         &caller,
                         AuditEventStatus::Success,
                         Some("authorized through the operator override".to_string()),
@@ -119,7 +179,7 @@ impl OrbitRuntime {
                 );
                 let message = denial.to_string();
                 self.record_authorization_event(
-                    operation,
+                    operation.id,
                     &caller,
                     AuditEventStatus::Denied,
                     Some(message.clone()),
@@ -141,7 +201,7 @@ impl OrbitRuntime {
     /// completed change.)
     fn record_authorization_event(
         &self,
-        operation: &'static GovernedOperation,
+        operation_id: &str,
         caller: &CallerCapabilities,
         status: AuditEventStatus,
         error_message: Option<String>,
@@ -152,7 +212,7 @@ impl OrbitRuntime {
             subcommand: Some(caller.provenance().to_string()),
             tool_name: None,
             target_type: Some("operation".to_string()),
-            target_id: Some(operation.id.to_string()),
+            target_id: Some(operation_id.to_string()),
             role: self.actor_label().to_string(),
             status,
             exit_code: i32::from(status != AuditEventStatus::Success),
@@ -206,7 +266,7 @@ impl OrbitRuntime {
         if let Err(error) = self.record_audit_event(&params) {
             tracing::error!(
                 target: "orbit.authorization",
-                operation = operation.id,
+                operation = operation_id,
                 "failed to persist authorization audit event: {error}"
             );
         }


### PR DESCRIPTION
## Task

[ORB-11056](https://orbit-cli.com/tasks/ORB-11056) — MCP callers default deny still serves ordinary agent tools

### Description

`default = "deny"` (and a narrowed row outside its allowed workspaces) resolves to an empty effective capability set, but that empty set is consulted only for entries in `GOVERNED_OPERATIONS`. In live code, `OrbitRuntime::authorize_tool_operation` returns `Ok(())` immediately for every ungoverned tool at `crates/orbit-core/src/runtime/authorization.rs:47-49`. The MCP registry exposes ordinary read/write tools such as `orbit.task.add`, `orbit.task.list`, `orbit.task.update`, `orbit.search`, and session-log mutation at `crates/orbit-tools/src/builtin/orbit/mod.rs:56-117`; none of those appears in the governed registry at `crates/orbit-common/src/governance/authorization.rs:194-258`. Consequently an unmatched remote caller under `default = "deny"` can still read and mutate task/workspace state; only operator-governed calls are refused. This contradicts the callers-file contract recorded at `docs/design/federated-mcp/specs/caller-authorization.md:113`, which says the empty set also refuses ungoverned tools that require `agent`.

Regression source: ORB-11052 introduced destination-side grants and the `deny` default without adding an agent-capability gate for ordinary MCP tools.

### Acceptance Criteria

- A remote-originated MCP session whose resolved caller grant has no `agent` capability cannot execute ordinary MCP tools, including task reads and mutations.
- `default = "deny"` and workspace narrowing outside the granted workspace are covered by end-to-end MCP tests that attempt at least one ungoverned read and one ungoverned mutation.
- Agent and operator grants continue to serve the existing tool subsets, and governed operator checks remain unchanged.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a destination-side `agent` baseline at the runtime tool chokepoint for ordinary ungoverned tools when an MCP session carries a remote caller grant. Governed tools still take their existing operation-specific path first, preserving operator and runner behavior.
- Recorded denied ordinary-tool authorization decisions against the actual tool name and updated the governance documentation to distinguish the remote MCP baseline from operation-specific governance.
- Added end-to-end MCP regressions proving both task reads and task mutations are denied under `default = "deny"` and outside a workspace-narrowed grant, while remote agent and operator grants retain their existing ordinary/governed subsets.
Assessment: The fix is localized to the shared runtime chokepoint, preserves non-MCP ungoverned behavior, and exercises the production MCP transport. No new dependencies or out-of-scope files were needed.
Validation:
- `cargo test -p orbit-cli --test mcp_roundtrip` (40 passed)
- `cargo test -p orbit-core runtime::tests::authorization` (6 passed)
- `make ci-fast`
- `make ci-lint`
Friction checkpoint: No issue met the filing threshold.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11056-6a93437f`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*