### PR TITLE
Make ci-failure-remediation work under a sandboxed execution lane

### DIFF
--- a/crates/orbit-cli/tests/github_capability_preflight.rs
+++ b/crates/orbit-cli/tests/github_capability_preflight.rs
@@ -1,0 +1,123 @@
+#![allow(missing_docs)]
+// Tests use unwrap/expect to keep fixture setup readable.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+//! `github.auth.status` on an execution lane that holds no GitHub credentials.
+//!
+//! This is the lane the shipped `ci-failure-remediation` definition has to
+//! survive: a sandbox that denies reading the GitHub CLI's configuration and
+//! an execution environment that forwards no GitHub token. The preflight must
+//! come back as an ordinary result naming the missing capability — not as a
+//! tool error, and never as something a caller could mistake for a clean CI
+//! pipeline.
+
+use std::path::{Path, PathBuf};
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
+use tempfile::{TempDir, tempdir};
+
+struct Lane {
+    _temp: TempDir,
+    home: PathBuf,
+    work: PathBuf,
+    path: PathBuf,
+}
+
+impl Lane {
+    /// A workspace whose `PATH` holds only what the fixture puts there, so a
+    /// GitHub CLI is present exactly when a test installs one.
+    fn new() -> Self {
+        let temp = tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let work = temp.path().join("work");
+        let path = temp.path().join("bin");
+        for dir in [&home, &work, &path] {
+            std::fs::create_dir_all(dir).expect("create fixture dir");
+        }
+        Self {
+            _temp: temp,
+            home,
+            work,
+            path,
+        }
+    }
+
+    /// Install a stand-in `gh` that behaves like an unauthenticated one: it
+    /// runs, and it reports that it has no usable credentials.
+    fn install_unauthenticated_gh(&self) {
+        let script = "#!/bin/sh\necho 'gh: To get started with GitHub CLI, please run: gh auth login' >&2\nexit 1\n";
+        let gh = self.path.join("gh");
+        std::fs::write(&gh, script).expect("write gh stub");
+        set_executable(&gh);
+    }
+
+    fn preflight(&self) -> Value {
+        let output = cargo_bin_cmd!("orbit")
+            .current_dir(&self.work)
+            .env("HOME", &self.home)
+            .env("USERPROFILE", &self.home)
+            .env("PATH", &self.path)
+            .env_remove("ORBIT_ROOT")
+            .env_remove("GH_TOKEN")
+            .env_remove("GITHUB_TOKEN")
+            .args(["tool", "run", "github.auth.status"])
+            .output()
+            .expect("run github.auth.status");
+
+        assert!(
+            output.status.success(),
+            "a lane without credentials must still complete the preflight: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        serde_json::from_slice(&output.stdout).expect("preflight returns JSON")
+    }
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let mut permissions = std::fs::metadata(path)
+        .expect("stub metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions).expect("mark stub executable");
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) {}
+
+#[test]
+fn a_lane_without_a_github_cli_reports_the_surface_unavailable() {
+    let lane = Lane::new();
+
+    let preflight = lane.preflight();
+
+    assert_eq!(preflight["available"], false);
+    assert_eq!(preflight["authenticated"], false);
+    assert!(
+        preflight["detail"].as_str().is_some_and(|d| !d.is_empty()),
+        "the outcome must carry a reason a summary can quote: {preflight}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn a_lane_with_no_credentials_reports_unauthenticated_rather_than_failing() {
+    let lane = Lane::new();
+    lane.install_unauthenticated_gh();
+
+    let preflight = lane.preflight();
+
+    assert_eq!(
+        preflight["available"], true,
+        "the client is present; only the credential is missing: {preflight}"
+    );
+    assert_eq!(preflight["authenticated"], false);
+    assert!(
+        preflight["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("no usable credentials")),
+        "the outcome must name the missing credential: {preflight}"
+    );
+}

--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -2,6 +2,157 @@
   {
     "active": true,
     "builtin": true,
+    "description": "Preflight the GitHub CLI surface: whether a GitHub CLI is present on this execution lane (`available`) and whether it holds usable credentials there (`authenticated`). Neither absence nor a missing credential is an error — both are reported so a caller can record a capability-unavailable outcome instead of mistaking it for a clean result.",
+    "enabled": true,
+    "name": "github.auth.status",
+    "parameters": [],
+    "status": "active"
+  },
+  {
+    "active": true,
+    "builtin": true,
+    "description": "List pull requests with their current head SHAs. Defaults to open pull requests.",
+    "enabled": true,
+    "name": "github.pr.list",
+    "parameters": [
+      {
+        "description": "Pull-request state filter: open (default), closed, merged, or all",
+        "name": "state",
+        "param_type": "string",
+        "required": false
+      },
+      {
+        "description": "Restrict to pull requests targeting one base branch",
+        "name": "base",
+        "param_type": "string",
+        "required": false
+      },
+      {
+        "description": "Maximum pull requests to return (default 30, capped at 100)",
+        "name": "limit",
+        "param_type": "integer",
+        "required": false
+      },
+      {
+        "description": "Repository in owner/name format (uses current directory if omitted)",
+        "name": "repo",
+        "param_type": "string",
+        "required": false
+      }
+    ],
+    "status": "active"
+  },
+  {
+    "active": true,
+    "builtin": true,
+    "description": "List recent GitHub Actions workflow runs with each run's reported head SHA. Filter by branch, workflow, status/conclusion, and event.",
+    "enabled": true,
+    "name": "github.run.list",
+    "parameters": [
+      {
+        "description": "Restrict to runs for one branch",
+        "name": "branch",
+        "param_type": "string",
+        "required": false
+      },
+      {
+        "description": "Restrict to one workflow by name, file name, or ID",
+        "name": "workflow",
+        "param_type": "string",
+        "required": false
+      },
+      {
+        "description": "Restrict to one run status or conclusion (queued, in_progress, completed, failure, success, cancelled, timed_out, action_required)",
+        "name": "status",
+        "param_type": "string",
+        "required": false
+      },
+      {
+        "description": "Restrict to one triggering event (push, pull_request, schedule)",
+        "name": "event",
+        "param_type": "string",
+        "required": false
+      },
+      {
+        "description": "Maximum runs to return (default 20, capped at 100)",
+        "name": "limit",
+        "param_type": "integer",
+        "required": false
+      },
+      {
+        "description": "Repository in owner/name format (uses current directory if omitted)",
+        "name": "repo",
+        "param_type": "string",
+        "required": false
+      }
+    ],
+    "status": "active"
+  },
+  {
+    "active": true,
+    "builtin": true,
+    "description": "Read a bounded excerpt of one GitHub Actions run's logs — failed steps by default, or the full log — plus the commit the runner actually checked out, parsed from the log's own checkout evidence. Output is capped so a large log cannot exhaust the caller's context; `truncated` reports when it was.",
+    "enabled": true,
+    "name": "github.run.logs",
+    "parameters": [
+      {
+        "description": "Numeric workflow-run ID",
+        "name": "run",
+        "param_type": "string",
+        "required": true
+      },
+      {
+        "description": "Numeric job ID to narrow the log to one job",
+        "name": "job",
+        "param_type": "string",
+        "required": false
+      },
+      {
+        "description": "\"failed\" (default) for failed-step logs, or \"all\" for the full run log — use \"all\" to evidence the checked-out commit, since the checkout step usually succeeds",
+        "name": "scope",
+        "param_type": "string",
+        "required": false
+      },
+      {
+        "description": "Maximum log bytes to return (default 16384, capped at 262144). The excerpt keeps the head and the tail and marks the omitted gap.",
+        "name": "max_bytes",
+        "param_type": "integer",
+        "required": false
+      },
+      {
+        "description": "Repository in owner/name format (uses current directory if omitted)",
+        "name": "repo",
+        "param_type": "string",
+        "required": false
+      }
+    ],
+    "status": "active"
+  },
+  {
+    "active": true,
+    "builtin": true,
+    "description": "Inspect one GitHub Actions workflow run: its reported head SHA, event, branch, and every job with its URL, steps, and conclusions. Unsuccessful jobs and steps are also collected separately.",
+    "enabled": true,
+    "name": "github.run.view",
+    "parameters": [
+      {
+        "description": "Numeric workflow-run ID",
+        "name": "run",
+        "param_type": "string",
+        "required": true
+      },
+      {
+        "description": "Repository in owner/name format (uses current directory if omitted)",
+        "name": "repo",
+        "param_type": "string",
+        "required": false
+      }
+    ],
+    "status": "active"
+  },
+  {
+    "active": true,
+    "builtin": true,
     "description": "List every auto-task definition in this workspace.",
     "enabled": true,
     "name": "orbit.auto_task.list",

--- a/crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
@@ -1,3 +1,8 @@
+github.auth.status	-	Preflight the GitHub CLI surface: whether a GitHub CLI is present on this execution lane (`available`) and whether it holds usable credentials there (`authenticated`). Neither absence nor a missing credential is an error — both are reported so a caller can record a capability-unavailable outcome instead of mistaking it for a clean result.
+github.pr.list	-	List pull requests with their current head SHAs. Defaults to open pull requests.
+github.run.list	-	List recent GitHub Actions workflow runs with each run's reported head SHA. Filter by branch, workflow, status/conclusion, and event.
+github.run.logs	run:string	Read a bounded excerpt of one GitHub Actions run's logs — failed steps by default, or the full log — plus the commit the runner actually checked out, parsed from the log's own checkout evidence. Output is capped so a large log cannot exhaust the caller's context; `truncated` reports when it was.
+github.run.view	run:string	Inspect one GitHub Actions workflow run: its reported head SHA, event, branch, and every job with its URL, steps, and conclusions. Unsuccessful jobs and steps are also collected separately.
 orbit.auto_task.list	-	List every auto-task definition in this workspace.
 orbit.auto_task.mint	name:string	Mint one task now from an auto-task definition. Unconditional: the schedule, dedupe policy, and enabled flag are ignored, and the scheduler's own cursor is left untouched.
 orbit.command.exec	argv:string|string[], working_directory:string	Execute a command as an explicit argv array in an explicit working directory and return its stdout, stderr, and exit status. Requires operator capability and the workspace claim; withheld from managed runs.

--- a/crates/orbit-core/assets/auto_tasks/ci-failure-remediation.yaml
+++ b/crates/orbit-core/assets/auto_tasks/ci-failure-remediation.yaml
@@ -1,6 +1,18 @@
 schemaVersion: 1
 name: ci-failure-remediation
-description: Hourly evidence-first remediation of current GitHub Actions failures (GitHub-Actions-shaped; operators on other CI should adapt before enabling)
+description: |
+  Hourly evidence-first remediation of current GitHub Actions failures
+  (GitHub-Actions-shaped; operators on other CI should adapt before enabling).
+  Execution-lane precondition: the lane that runs the minted task must be able
+  to reach an authenticated GitHub CLI through the read-only `github.*` builtin
+  tools, which is where all of this definition's CI discovery happens. Those
+  tools run the GitHub CLI as a child of whichever process executes the tool,
+  so a lane that both denies reads of the CLI's credential directory and
+  forwards no GitHub token has no way to authenticate. Before enabling, confirm
+  the lane satisfies one of them: an executor whose sandbox permits reading the
+  GitHub CLI configuration, or a forwarded GitHub token in the execution
+  environment. Where neither holds, the definition still runs and reports an
+  explicit capability-unavailable outcome rather than a clean result.
 enabled: false
 schedule:
   cron: 15 * * * *
@@ -13,19 +25,63 @@ template:
     evidence described below and report a successful no-current-failure or
     transient-only outcome.
 
-    This definition is GitHub-Actions-shaped (`gh` or the GitHub API, run
-    URLs, checkout logs). Operators on other CI systems must adapt discovery
-    and rerun steps before enabling it.
+    This definition is GitHub-Actions-shaped (workflow runs, run URLs,
+    checkout logs). Operators on other CI systems must adapt discovery and
+    rerun steps before enabling it.
+
+    ## CI discovery runs through Orbit tools, not the vendor CLI
+
+    Perform every CI query through these read-only builtin tools:
+
+    - `orbit tool run github.auth.status`
+    - `orbit tool run github.run.list` — workflow runs, filtered by `branch`,
+      `workflow`, `status`, `event`, and `limit`.
+    - `orbit tool run github.run.view` — one run's jobs with their URLs,
+      steps, conclusions, event, branch, and reported head SHA.
+    - `orbit tool run github.run.logs` — a bounded log excerpt for one run,
+      failed steps by default, plus the checkout evidence parsed out of the
+      runner's own output. Pass `scope: "all"` when you need that checkout
+      evidence, because the checkout step usually succeeds and is therefore
+      absent from the failed-step log. Raise `max_bytes` only when the
+      returned excerpt reports `truncated: true` and the omitted region is
+      the part you need.
+    - `orbit tool run github.pr.list` — open pull requests with their current
+      head SHAs.
+
+    Do not invoke the GitHub command-line client directly and do not call the
+    GitHub REST or GraphQL API by hand. The tools above bound their output,
+    redact credentials, and keep the reported head SHA and the tested checkout
+    commit in separate fields; an ad-hoc query does none of that.
+
+    ## Capability preflight
+
+    Begin with `orbit tool run github.auth.status`. It answers with
+    `available` (is there a GitHub client on this execution lane at all) and
+    `authenticated` (does it hold usable credentials here).
+
+    If either is false, stop the investigation immediately. Persist an
+    `execution_summary` that records the outcome as
+    `capability_unavailable`, quotes the preflight's `detail`, names which of
+    `available` / `authenticated` was false, and states that no CI evidence
+    was gathered. Finish with no diff.
+
+    That outcome is not a clean bill of health, and you must not describe it
+    as one. Never report "no current failures", "no-current-failure", or a
+    transient-only pass when the preflight failed: those conclusions require
+    queries you were unable to run. The three endings are distinct and must
+    stay distinguishable in the summary — capability unavailable, evidenced
+    no-current-failure, and evidenced transient-only.
 
     ## Discovery and duplicate safety
 
     1. Derive this workspace's integration and release branches from
        workspace configuration and git remotes or defaults; do not assume
        branch names. Enumerate this repository's workflows and recent runs
-       with GitHub's API or `gh`, and enumerate open pull requests with
-       their current head SHAs. Cover failures for those current integration
-       and release heads and every open pull-request head, including
-       informational jobs rather than looking only at required checks.
+       with `github.run.list`, and enumerate open pull requests with their
+       current head SHAs with `github.pr.list`. Cover failures for those
+       current integration and release heads and every open pull-request
+       head, including informational jobs rather than looking only at
+       required checks.
     2. If the repository has a CI-failure task hook that files Orbit tasks
        from red runs, search open tasks for its run URL, pull request, SHA,
        and failure signature. Use `orbit tool run orbit.search` and
@@ -35,15 +91,18 @@ template:
        owns the repair and must not fan a red-run cluster out into more
        failure tasks.
     3. For every candidate run, record the run and job URLs, workflow, event,
-       branch or PR, run-attempt number, reported head SHA, and the current
-       branch/PR head SHA. Query the failed jobs and steps and inspect the
-       exact failed-step logs.
-    4. Independently verify the commit that the runner actually checked out
-       from the checkout step/log (`HEAD is now at`, checkout ref/SHA, or
-       equivalent unambiguous evidence). Keep the event's reported head SHA,
-       the current ref head, and the tested checkout commit distinct;
-       pull-request merge SHAs are not interchangeable with pull-request
-       head SHAs.
+       branch or PR, reported head SHA, and the current branch/PR head SHA.
+       A rerun is evidenced by a later run of the same workflow at the same
+       reported head SHA, which `github.run.list` reports. Read the failed
+       jobs and steps from `github.run.view`, and the exact failed-step logs
+       from `github.run.logs`.
+    4. Independently verify the commit that the runner actually checked out.
+       `github.run.logs` reports it as `checkout_commits`, with the matching
+       log lines in `checkout_evidence` (`HEAD is now at`, the checkout ref
+       or SHA, or equivalent unambiguous evidence). Keep the event's reported
+       head SHA, the current ref head, and the tested checkout commit
+       distinct; pull-request merge SHAs are not interchangeable with
+       pull-request head SHAs.
     5. Ignore a failed run as stale when its branch or PR has advanced and the
        failure does not reproduce at the current head, or when a newer
        successful run of the same workflow/check at the relevant current
@@ -80,20 +139,22 @@ template:
     Then run this repository's own documented pre-handoff gate, whatever that
     repository documents — do not assume a particular build target or vendor
     command. After the candidate commit is published through the repository's
-    normal workflow, inspect its GitHub Actions runs and require a green
-    rerun for every affected workflow/check. This includes affected
-    informational jobs even though they remain non-required. Do not declare a
-    repair validated while an affected run is missing, queued, in progress,
-    cancelled, or red.
+    normal workflow, inspect its GitHub Actions runs with `github.run.list`
+    and `github.run.view` and require a green rerun for every affected
+    workflow/check. This includes affected informational jobs even though they
+    remain non-required. Do not declare a repair validated while an affected
+    run is missing, queued, in progress, cancelled, or red.
 
-    Persist an `execution_summary` that maps every investigated run/job URL,
-    reported head SHA, actual checkout commit, and current ref head to its
-    root-cause cluster, disposition (fixed, stale, superseded, or transient),
-    change, local reproduction, exact formerly failing validation, pre-handoff
-    result, and green GitHub rerun URL. Also map any matching task created by
-    a CI-failure hook. For a successful no-diff pass, list the queries, current
-    heads, superseding successes or transient evidence, and why no
-    repository-owned failure remained.
+    Persist an `execution_summary` that names the outcome
+    (`capability_unavailable`, `no_current_failure`, `transient_only`, or
+    `remediated`) and maps every investigated run/job URL, reported head SHA,
+    actual checkout commit, and current ref head to its root-cause cluster,
+    disposition (fixed, stale, superseded, or transient), change, local
+    reproduction, exact formerly failing validation, pre-handoff result, and
+    green GitHub rerun URL. Also map any matching task created by a
+    CI-failure hook. For a successful no-diff pass, list the tool queries you
+    ran, current heads, superseding successes or transient evidence, and why
+    no repository-owned failure remained.
 
     ## Reported-head SHA versus checkout commit
 
@@ -104,12 +165,14 @@ template:
     and checks whether the failure still exists at the current ref head
     before editing.
   acceptance_criteria:
+  - Every CI query ran through the read-only github.* Orbit tools; the vendor command-line client and the GitHub API were not invoked directly.
+  - The run began with a github.auth.status preflight, and an unavailable or unauthenticated surface was persisted as an explicit capability-unavailable outcome that is never reported as a no-current-failure or transient-only pass.
   - Current-head failures across the workspace's derived integration and release branches and open pull requests were enumerated for every repository workflow, including informational jobs.
   - Every investigated run records its reported SHA, actual checkout commit, current ref head, failed job/step, exact log evidence, and stale or superseding evidence where applicable.
   - Repeated red runs are clustered by root cause, and every current repository-owned failure is reproduced and fixed without weakening or bypassing a check.
   - Transient-only classifications cite infrastructure evidence and a successful same-SHA retry; a single non-reproduction is not treated as sufficient evidence.
   - Each fixed cause passes the exact formerly failing validation and the repository's documented pre-handoff gate, and every affected required or informational GitHub Actions check executes successfully on the candidate commit.
-  - The persisted execution_summary maps each run/job URL and SHA to its root cause, disposition, change, validations, green rerun, and any matching CI-failure-hook task.
+  - The persisted execution_summary names the outcome and maps each run/job URL and SHA to its root cause, disposition, change, validations, green rerun, and any matching CI-failure-hook task.
   - A no-current-failure or transient-only investigation is a successful no-diff outcome when its current-head queries and superseding or transient evidence are persisted.
   task_type: bug
   tags:

--- a/crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md
@@ -91,7 +91,15 @@ wording before enabling it. Over MCP: `orbit_auto_task_list` and
   pull-request heads, clusters by root cause, repairs repository-owned failures
   without weakening a check, and treats a clean current-head pass as a successful
   no-diff outcome. The body is GitHub-Actions-shaped; operators on other CI
-  should adapt it before enabling.
+  should adapt it before enabling. **Execution-lane precondition:** all of its CI
+  discovery goes through the read-only `github.auth.status`, `github.run.list`,
+  `github.run.view`, `github.run.logs`, and `github.pr.list` builtin tools, which
+  run the GitHub CLI as a child of whichever process executes the tool. So the
+  lane that runs the minted task needs one of: an executor whose sandbox permits
+  reading the GitHub CLI's configuration directory, or a GitHub token forwarded
+  through `[execution.env] pass`. Check before enabling — a lane with neither
+  still completes, but every run ends at the preflight with a
+  capability-unavailable summary and no investigation.
 
 Read them before enabling. They are also the best worked examples of how much
 instruction a minted task's body should carry.

--- a/crates/orbit-core/src/auto_tasks/tests/shipped.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/shipped.rs
@@ -536,6 +536,15 @@ fn ci_failure_remediation_default_is_portable_hourly_and_inert() {
                 .contains("github-actions shaped"),
         "description must disclose the GitHub Actions shape to operators on other CI"
     );
+    let description = definition.description.to_lowercase();
+    assert!(
+        description.contains("execution-lane precondition"),
+        "description must state what the execution lane needs before an operator enables it"
+    );
+    assert!(
+        description.contains("github cli") && description.contains("token"),
+        "description must name both ways a lane can satisfy the precondition"
+    );
 
     let body = definition.template.description.to_lowercase();
     for required in [
@@ -555,6 +564,15 @@ fn ci_failure_remediation_default_is_portable_hourly_and_inert() {
         "orbit tool run orbit.search",
         "orbit tool run orbit.task.list",
         "orbit tool run orbit.task.show",
+        // CI discovery is tool-mediated so it stays bounded, redacted, and
+        // usable from an execution lane that holds no GitHub credentials of
+        // its own.
+        "orbit tool run github.auth.status",
+        "orbit tool run github.run.list",
+        "orbit tool run github.run.view",
+        "orbit tool run github.run.logs",
+        "orbit tool run github.pr.list",
+        "capability_unavailable",
     ] {
         assert!(
             body.contains(required),
@@ -563,6 +581,32 @@ fn ci_failure_remediation_default_is_portable_hourly_and_inert() {
     }
     assert!(!body.contains("orbit task list"));
     assert!(!body.contains("orbit task show"));
+
+    // The body must not reach around the tools. A bare vendor-CLI invocation
+    // or a hand-rolled API call skips the output bound and the redaction, and
+    // fails opaquely on a lane with no credentials.
+    for forbidden in [
+        "`gh ",
+        "$(gh ",
+        "gh run ",
+        "gh pr ",
+        "gh auth ",
+        "gh api",
+        "api.github.com",
+        "curl ",
+    ] {
+        assert!(
+            !definition.template.description.contains(forbidden),
+            "template must route CI discovery through the github.* tools; found '{forbidden}'"
+        );
+    }
+
+    // The silent failure this definition exists to avoid: an agent that could
+    // not query CI at all, reporting a clean pipeline.
+    assert!(
+        body.contains("never report \"no current failures\""),
+        "template must forbid reporting a clean result after a failed preflight"
+    );
     assert!(
         definition
             .template
@@ -586,6 +630,18 @@ fn ci_failure_remediation_default_is_portable_hourly_and_inert() {
                 criterion.contains("no-current-failure") && criterion.contains("no-diff")
             }),
         "ci-failure-remediation must treat a successful no-diff outcome as success"
+    );
+    assert!(
+        definition
+            .template
+            .acceptance_criteria
+            .iter()
+            .any(|criterion| {
+                let criterion = criterion.to_lowercase();
+                criterion.contains("github.auth.status")
+                    && criterion.contains("capability-unavailable")
+            }),
+        "ci-failure-remediation must require the preflight and a distinguishable capability-unavailable outcome"
     );
 }
 

--- a/crates/orbit-tools/src/builtin/github/auth.rs
+++ b/crates/orbit-tools/src/builtin/github/auth.rs
@@ -1,4 +1,5 @@
 use orbit_common::OrbitError;
+use orbit_common::security::redaction::redact_all;
 use orbit_exec::ExecRequest;
 use serde_json::{Value, json};
 
@@ -12,19 +13,49 @@ pub(super) fn build_exec_request(_input: &Value) -> Result<ExecRequest, OrbitErr
     ))
 }
 
+/// The preflight answer, in the three shapes a caller has to tell apart.
+///
+/// A caller that cannot reach GitHub must report *that*, not "no failures
+/// found" — so `available` (is there a GitHub CLI at all) and `authenticated`
+/// (does it hold usable credentials here) are separate fields, and neither
+/// failure mode is an error return. An error would be indistinguishable from
+/// the tool itself being broken.
+fn unavailable(detail: String) -> Value {
+    json!({
+        "available": false,
+        "authenticated": false,
+        "stdout": "",
+        "stderr": "",
+        "detail": detail,
+    })
+}
+
 super::gh_tool! {
     pub struct GithubAuthStatusTool;
     name: "github.auth.status";
-    description: "Verify GitHub CLI authentication status";
+    description: "Preflight the GitHub CLI surface: whether a GitHub CLI is present on this execution lane (`available`) and whether it holds usable credentials there (`authenticated`). Neither absence nor a missing credential is an error — both are reported so a caller can record a capability-unavailable outcome instead of mistaking it for a clean result.";
     parameters: [];
-    request: |_ctx, input| {
-        build_exec_request(input)
-    }
-    response: |_ctx, _input, result| {
+    execute: |_ctx, input| {
+        let req = build_exec_request(&input)?;
+        // A missing `gh`, or a sandbox that denies executing it, surfaces here
+        // as a spawn error. That is a capability answer, not a tool fault.
+        let result = match orbit_exec::run_process(&req, &orbit_exec::NoSandbox) {
+            Ok(result) => result,
+            Err(error) => {
+                return Ok(unavailable(redact_all(&error.to_string())));
+            }
+        };
+
         Ok(json!({
+            "available": true,
             "authenticated": result.success,
-            "stdout": result.stdout.as_str(),
-            "stderr": result.stderr.as_str(),
+            "stdout": redact_all(&result.stdout),
+            "stderr": redact_all(&result.stderr),
+            "detail": if result.success {
+                "GitHub CLI is authenticated on this execution lane"
+            } else {
+                "GitHub CLI is present but holds no usable credentials on this execution lane"
+            },
         }))
     }
 }

--- a/crates/orbit-tools/src/builtin/github/mod.rs
+++ b/crates/orbit-tools/src/builtin/github/mod.rs
@@ -1,4 +1,5 @@
 use orbit_common::OrbitError;
+use orbit_common::security::redaction::redact_all;
 use orbit_exec::{EnvironmentMode, ExecRequest, StdinMode};
 use orbit_types::tool::{ToolParam, ToolSchema};
 use serde_json::Value;
@@ -111,9 +112,29 @@ pub mod auth;
 pub mod pr_checkout;
 pub mod pr_checks;
 pub mod pr_close;
+pub mod pr_list;
 pub mod repo;
+pub mod run_list;
+pub mod run_logs;
+pub mod run_view;
 
-pub fn register(_registry: &mut ToolRegistry) {}
+/// The read-only GitHub discovery surface.
+///
+/// These five tools are the only sanctioned way for a task body to enumerate
+/// CI state: `gh` runs here, as a child of whichever process executes the
+/// tool, and its output is redacted and bounded on the way back out. A body
+/// that shells out to `gh` itself gets none of that.
+///
+/// Nothing that mutates GitHub is registered. `pr_checkout`, `pr_checks`,
+/// `pr_close`, and `repo` stay unregistered — the PR pipeline drives those
+/// operations directly from `orbit-engine`.
+pub fn register(registry: &mut ToolRegistry) {
+    registry.register(auth::GithubAuthStatusTool);
+    registry.register(pr_list::GithubPrListTool);
+    registry.register(run_list::GithubRunListTool);
+    registry.register(run_logs::GithubRunLogsTool);
+    registry.register(run_view::GithubRunViewTool);
+}
 
 /// Extract a non-empty `pr` field from the tool input.
 /// Accepts a numeric PR number or a GitHub PR URL (extracts the number from the path).
@@ -137,3 +158,264 @@ pub(super) fn require_pr(input: &Value) -> Result<String, OrbitError> {
         "invalid `pr`: \"{pr}\"; must be a numeric PR number or GitHub PR URL"
     )))
 }
+
+/// Extract a required numeric GitHub identifier (a workflow-run or job ID).
+///
+/// Numeric-only is a hardening rule, not a formatting preference: the value is
+/// appended to a `gh` argv, and a leading `-` would otherwise be parsed as a
+/// flag.
+pub(super) fn require_numeric_id(input: &Value, key: &str) -> Result<String, OrbitError> {
+    let raw = require_str(input, key)?;
+    if raw.chars().all(|c| c.is_ascii_digit()) {
+        return Ok(raw);
+    }
+    Err(OrbitError::InvalidInput(format!(
+        "invalid `{key}`: \"{raw}\"; must be a numeric GitHub identifier"
+    )))
+}
+
+/// Append `--repo <owner/name>` when the caller supplied one.
+pub(super) fn push_repo_flag(args: &mut Vec<String>, input: &Value) -> Result<(), OrbitError> {
+    push_optional_flag(args, input, "repo", "--repo")
+}
+
+/// Append `<flag> <value>` when `key` is present, rejecting a value that would
+/// be read as another `gh` flag.
+pub(super) fn push_optional_flag(
+    args: &mut Vec<String>,
+    input: &Value,
+    key: &str,
+    flag: &str,
+) -> Result<(), OrbitError> {
+    let Some(value) = input.get(key).and_then(Value::as_str) else {
+        return Ok(());
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        return Ok(());
+    }
+    if value.starts_with('-') {
+        return Err(OrbitError::InvalidInput(format!(
+            "invalid `{key}`: \"{value}\"; must not start with `-`"
+        )));
+    }
+    args.push(flag.to_string());
+    args.push(value.to_string());
+    Ok(())
+}
+
+/// Read an optional positive bound, clamped into `[1, max]`.
+pub(super) fn bounded_limit(
+    input: &Value,
+    key: &str,
+    default: u64,
+    max: u64,
+) -> Result<u64, OrbitError> {
+    let Some(value) = input.get(key) else {
+        return Ok(default);
+    };
+    let raw = match value {
+        Value::Number(number) => number.as_u64().ok_or_else(|| {
+            OrbitError::InvalidInput(format!("`{key}` must be a positive integer"))
+        })?,
+        Value::String(text) => text.trim().parse::<u64>().map_err(|error| {
+            OrbitError::InvalidInput(format!("`{key}` must be a positive integer: {error}"))
+        })?,
+        Value::Null => return Ok(default),
+        _ => {
+            return Err(OrbitError::InvalidInput(format!(
+                "`{key}` must be a positive integer"
+            )));
+        }
+    };
+    if raw == 0 {
+        return Err(OrbitError::InvalidInput(format!(
+            "`{key}` must be greater than zero"
+        )));
+    }
+    Ok(raw.min(max))
+}
+
+/// Parse a `gh --json` payload, naming the command in the failure.
+pub(super) fn parse_gh_json(stdout: &str, label: &str) -> Result<Value, OrbitError> {
+    serde_json::from_str(stdout)
+        .map_err(|error| OrbitError::Execution(format!("failed to parse {label} output: {error}")))
+}
+
+/// One log excerpt, already redacted and bounded.
+pub(super) struct BoundedLog {
+    pub(super) text: String,
+    pub(super) truncated: bool,
+    pub(super) total_bytes: usize,
+    pub(super) returned_bytes: usize,
+}
+
+/// Cap a log excerpt at `max_bytes`, keeping the head and the tail.
+///
+/// A failed-step log carries its signal at both ends — the head names the
+/// command and its arguments, the tail carries the assertion or exit status —
+/// so a plain prefix truncation loses the part the reader came for. The gap is
+/// marked inline, and `truncated` lets a caller ask for more rather than
+/// silently reasoning over a partial log.
+pub(super) fn bound_log_text(raw: &str, max_bytes: usize) -> BoundedLog {
+    let redacted = redact_all(raw);
+    let total_bytes = redacted.len();
+    if total_bytes <= max_bytes {
+        return BoundedLog {
+            returned_bytes: total_bytes,
+            text: redacted,
+            truncated: false,
+            total_bytes,
+        };
+    }
+
+    let head_len = floor_char_boundary(&redacted, max_bytes / 2);
+    let tail_start =
+        ceil_char_boundary(&redacted, total_bytes.saturating_sub(max_bytes - head_len));
+    let omitted = tail_start - head_len;
+    let text = format!(
+        "{}\n[... {omitted} bytes omitted by github.run.logs; raise `max_bytes` for more ...]\n{}",
+        &redacted[..head_len],
+        &redacted[tail_start..]
+    );
+    BoundedLog {
+        returned_bytes: head_len + (total_bytes - tail_start),
+        text,
+        truncated: true,
+        total_bytes,
+    }
+}
+
+fn floor_char_boundary(text: &str, mut index: usize) -> usize {
+    if index >= text.len() {
+        return text.len();
+    }
+    while index > 0 && !text.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+fn ceil_char_boundary(text: &str, mut index: usize) -> usize {
+    while index < text.len() && !text.is_char_boundary(index) {
+        index += 1;
+    }
+    index
+}
+
+/// Prose a runner emits around a checkout. Matched case-insensitively.
+const CHECKOUT_MARKERS: &[&str] = &[
+    "head is now at",
+    "-> fetch_head",
+    "git checkout --progress",
+    "checking out the ref",
+    "checkout ref",
+];
+
+const MIN_SHA_LEN: usize = 7;
+const MAX_SHA_LEN: usize = 40;
+
+/// The commit a runner actually checked out, read out of the runner's own log.
+///
+/// A workflow event's reported head SHA is metadata; this is evidence. They
+/// disagree whenever a merge-queue or pull-request merge commit is what got
+/// tested, so the two travel as separate fields and are never merged into one
+/// `sha`.
+pub(super) struct CheckoutEvidence {
+    pub(super) commits: Vec<String>,
+    pub(super) lines: Vec<String>,
+}
+
+/// Split one `gh run view --log` line into its step column and its payload.
+///
+/// The line format is `job<TAB>step<TAB>timestamp payload`. The split matters:
+/// the *step* column names a pinned action (`actions/checkout@<sha>`), and
+/// harvesting that SHA would report the checkout action's own commit as the
+/// commit under test — the exact conflation this scan exists to prevent.
+fn split_log_line(line: &str) -> (&str, &str) {
+    let line = line.trim_start_matches('\u{feff}');
+    let mut columns = line.splitn(3, '\t');
+    let (step, rest) = match (columns.next(), columns.next(), columns.next()) {
+        (Some(_job), Some(step), Some(rest)) => (step, rest),
+        _ => ("", line),
+    };
+    // Drop the leading ISO-8601 runner timestamp when there is one.
+    let payload = match rest.split_once(' ') {
+        Some((first, tail)) if first.contains('T') && first.ends_with('Z') => tail,
+        _ => rest,
+    };
+    (step, payload)
+}
+
+fn is_hex(byte: u8) -> bool {
+    byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)
+}
+
+/// Whether a payload is a bare commit SHA on its own line.
+///
+/// `actions/checkout` prints the resolved commit this way, with no surrounding
+/// prose, which is often the only place a branch-mode checkout records what it
+/// actually landed on.
+fn is_bare_commit_sha(payload: &str) -> bool {
+    let trimmed = payload.trim();
+    trimmed.len() == MAX_SHA_LEN && trimmed.bytes().all(is_hex)
+}
+
+/// Collect every lowercase-hex token of commit-SHA length in `payload`.
+///
+/// A token preceded by `@` is skipped: that is the `owner/action@sha` pin
+/// form, which identifies the action, not the commit under test.
+fn commit_sha_tokens(payload: &str) -> Vec<&str> {
+    let bytes = payload.as_bytes();
+    let mut tokens = Vec::new();
+    let mut index = 0usize;
+    while index < bytes.len() {
+        if !bytes[index].is_ascii_alphanumeric() {
+            index += 1;
+            continue;
+        }
+        let start = index;
+        while index < bytes.len() && bytes[index].is_ascii_alphanumeric() {
+            index += 1;
+        }
+        let token = &payload[start..index];
+        let pinned = start > 0 && bytes[start - 1] == b'@';
+        if !pinned
+            && (MIN_SHA_LEN..=MAX_SHA_LEN).contains(&token.len())
+            && token.bytes().all(is_hex)
+        {
+            tokens.push(token);
+        }
+    }
+    tokens
+}
+
+/// Scan a runner log for checkout evidence, keeping at most `max_lines` lines.
+pub(super) fn scan_checkout_evidence(log: &str, max_lines: usize) -> CheckoutEvidence {
+    let mut commits: Vec<String> = Vec::new();
+    let mut lines = Vec::new();
+    for line in log.lines() {
+        let (step, payload) = split_log_line(line);
+        let lowered = payload.to_ascii_lowercase();
+        let marked = CHECKOUT_MARKERS
+            .iter()
+            .any(|marker| lowered.contains(marker));
+        let in_checkout_step = step.to_ascii_lowercase().contains("checkout");
+        let is_evidence = marked || (in_checkout_step && is_bare_commit_sha(payload));
+        if !is_evidence {
+            continue;
+        }
+        for token in commit_sha_tokens(payload) {
+            if !commits.iter().any(|sha| sha == token) {
+                commits.push(token.to_string());
+            }
+        }
+        if lines.len() < max_lines {
+            lines.push(redact_all(payload.trim()));
+        }
+    }
+    CheckoutEvidence { commits, lines }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-tools/src/builtin/github/pr_list.rs
+++ b/crates/orbit-tools/src/builtin/github/pr_list.rs
@@ -1,0 +1,67 @@
+use orbit_common::OrbitError;
+use orbit_exec::ExecRequest;
+use serde_json::{Value, json};
+
+use crate::{TIMEOUT_DEFAULT_MS, check_exec_result};
+
+/// The `gh pr list --json` fields this tool projects.
+const PR_LIST_FIELDS: &str =
+    "number,title,state,isDraft,headRefName,headRefOid,baseRefName,url,updatedAt";
+
+const DEFAULT_LIMIT: u64 = 30;
+const MAX_LIMIT: u64 = 100;
+
+pub(super) fn build_exec_request(input: &Value) -> Result<ExecRequest, OrbitError> {
+    let mut args = vec!["pr".to_string(), "list".to_string()];
+    super::push_optional_flag(&mut args, input, "state", "--state")?;
+    super::push_optional_flag(&mut args, input, "base", "--base")?;
+    super::push_repo_flag(&mut args, input)?;
+    args.push("--limit".to_string());
+    args.push(super::bounded_limit(input, "limit", DEFAULT_LIMIT, MAX_LIMIT)?.to_string());
+    args.push("--json".to_string());
+    args.push(PR_LIST_FIELDS.to_string());
+
+    Ok(super::gh_exec_request(args, None, TIMEOUT_DEFAULT_MS))
+}
+
+/// Reshape one `gh pr list` entry, keeping the pull request's current head SHA
+/// under a name that cannot be confused with a run's tested commit.
+pub(super) fn project_pull_request(pr: &Value) -> Value {
+    json!({
+        "number": pr["number"],
+        "title": pr["title"],
+        "state": pr["state"],
+        "draft": pr["isDraft"],
+        "head_branch": pr["headRefName"],
+        "reported_head_sha": pr["headRefOid"],
+        "base_branch": pr["baseRefName"],
+        "url": pr["url"],
+        "updated_at": pr["updatedAt"],
+    })
+}
+
+super::gh_tool! {
+    pub struct GithubPrListTool;
+    name: "github.pr.list";
+    description: "List pull requests with their current head SHAs. Defaults to open pull requests.";
+    parameters: [
+        super::tool_param("state", "Pull-request state filter: open (default), closed, merged, or all", "string", false),
+        super::tool_param("base", "Restrict to pull requests targeting one base branch", "string", false),
+        super::tool_param("limit", "Maximum pull requests to return (default 30, capped at 100)", "integer", false),
+        super::tool_param("repo", "Repository in owner/name format (uses current directory if omitted)", "string", false),
+    ];
+    request: |_ctx, input| {
+        build_exec_request(input)
+    }
+    response: |_ctx, _input, result| {
+        check_exec_result(result, "gh pr list")?;
+
+        let entries = super::parse_gh_json(&result.stdout, "gh pr list")?;
+        let pull_requests: Vec<Value> = entries
+            .as_array()
+            .map(|entries| entries.iter().map(project_pull_request).collect())
+            .unwrap_or_default();
+
+        Ok(json!({ "count": pull_requests.len(), "pull_requests": pull_requests }))
+    }
+}

--- a/crates/orbit-tools/src/builtin/github/run_list.rs
+++ b/crates/orbit-tools/src/builtin/github/run_list.rs
@@ -1,0 +1,77 @@
+use orbit_common::OrbitError;
+use orbit_exec::ExecRequest;
+use serde_json::{Value, json};
+
+use crate::{TIMEOUT_DEFAULT_MS, check_exec_result};
+
+/// The `gh run list --json` fields this tool projects.
+const RUN_LIST_FIELDS: &str = "databaseId,number,workflowName,displayTitle,status,conclusion,event,headBranch,headSha,createdAt,startedAt,updatedAt,url";
+
+const DEFAULT_LIMIT: u64 = 20;
+const MAX_LIMIT: u64 = 100;
+
+pub(super) fn build_exec_request(input: &Value) -> Result<ExecRequest, OrbitError> {
+    let mut args = vec!["run".to_string(), "list".to_string()];
+    super::push_optional_flag(&mut args, input, "branch", "--branch")?;
+    super::push_optional_flag(&mut args, input, "workflow", "--workflow")?;
+    super::push_optional_flag(&mut args, input, "status", "--status")?;
+    super::push_optional_flag(&mut args, input, "event", "--event")?;
+    super::push_repo_flag(&mut args, input)?;
+    args.push("--limit".to_string());
+    args.push(super::bounded_limit(input, "limit", DEFAULT_LIMIT, MAX_LIMIT)?.to_string());
+    args.push("--json".to_string());
+    args.push(RUN_LIST_FIELDS.to_string());
+
+    Ok(super::gh_exec_request(args, None, TIMEOUT_DEFAULT_MS))
+}
+
+/// Reshape one `gh run list` entry into the tool's own field names.
+///
+/// `reported_head_sha` is deliberately not called `sha`: it is the SHA the
+/// workflow event carried, which is not necessarily the commit the runner
+/// tested. Read `github.run.logs` for that.
+pub(super) fn project_run(run: &Value) -> Value {
+    json!({
+        "run_id": run["databaseId"],
+        "run_number": run["number"],
+        "workflow": run["workflowName"],
+        "title": run["displayTitle"],
+        "status": run["status"],
+        "conclusion": run["conclusion"],
+        "event": run["event"],
+        "head_branch": run["headBranch"],
+        "reported_head_sha": run["headSha"],
+        "created_at": run["createdAt"],
+        "started_at": run["startedAt"],
+        "updated_at": run["updatedAt"],
+        "url": run["url"],
+    })
+}
+
+super::gh_tool! {
+    pub struct GithubRunListTool;
+    name: "github.run.list";
+    description: "List recent GitHub Actions workflow runs with each run's reported head SHA. Filter by branch, workflow, status/conclusion, and event.";
+    parameters: [
+        super::tool_param("branch", "Restrict to runs for one branch", "string", false),
+        super::tool_param("workflow", "Restrict to one workflow by name, file name, or ID", "string", false),
+        super::tool_param("status", "Restrict to one run status or conclusion (queued, in_progress, completed, failure, success, cancelled, timed_out, action_required)", "string", false),
+        super::tool_param("event", "Restrict to one triggering event (push, pull_request, schedule)", "string", false),
+        super::tool_param("limit", "Maximum runs to return (default 20, capped at 100)", "integer", false),
+        super::tool_param("repo", "Repository in owner/name format (uses current directory if omitted)", "string", false),
+    ];
+    request: |_ctx, input| {
+        build_exec_request(input)
+    }
+    response: |_ctx, _input, result| {
+        check_exec_result(result, "gh run list")?;
+
+        let runs = super::parse_gh_json(&result.stdout, "gh run list")?;
+        let runs: Vec<Value> = runs
+            .as_array()
+            .map(|entries| entries.iter().map(project_run).collect())
+            .unwrap_or_default();
+
+        Ok(json!({ "count": runs.len(), "runs": runs }))
+    }
+}

--- a/crates/orbit-tools/src/builtin/github/run_logs.rs
+++ b/crates/orbit-tools/src/builtin/github/run_logs.rs
@@ -1,0 +1,88 @@
+use orbit_common::OrbitError;
+use orbit_exec::ExecRequest;
+use serde_json::{Value, json};
+
+use crate::{TIMEOUT_LONG_MS, check_exec_result};
+
+/// Default excerpt size. Small enough that a routine failed-step read costs an
+/// executing agent a few thousand tokens rather than its whole context.
+const DEFAULT_MAX_BYTES: u64 = 16_384;
+
+/// Hard ceiling on one call's excerpt, regardless of what the caller asked for.
+/// A single unbounded runner log can run to tens of megabytes; that is more
+/// than any agent context can hold, so the tool refuses to return it.
+const MAX_MAX_BYTES: u64 = 262_144;
+
+/// Cap on returned checkout-evidence lines. Evidence is a handful of lines per
+/// job; a much larger match set means the pattern caught noise, not evidence.
+const MAX_EVIDENCE_LINES: usize = 40;
+
+/// Which slice of a run's logs to read.
+///
+/// `failed` is the working default. `all` exists because the checkout step
+/// normally *succeeds*, so the commit a runner actually tested is absent from
+/// the failed-step log and only `all` can evidence it.
+fn log_scope(input: &Value) -> Result<&'static str, OrbitError> {
+    match input.get("scope").and_then(Value::as_str) {
+        None | Some("failed") => Ok("--log-failed"),
+        Some("all") => Ok("--log"),
+        Some(other) => Err(OrbitError::InvalidInput(format!(
+            "invalid `scope`: \"{other}\"; must be \"failed\" or \"all\""
+        ))),
+    }
+}
+
+pub(super) fn build_exec_request(input: &Value) -> Result<ExecRequest, OrbitError> {
+    let mut args = vec![
+        "run".to_string(),
+        "view".to_string(),
+        super::require_numeric_id(input, "run")?,
+    ];
+    if input.get("job").is_some() {
+        args.push("--job".to_string());
+        args.push(super::require_numeric_id(input, "job")?);
+    }
+    super::push_repo_flag(&mut args, input)?;
+    args.push(log_scope(input)?.to_string());
+
+    Ok(super::gh_exec_request(args, None, TIMEOUT_LONG_MS))
+}
+
+super::gh_tool! {
+    pub struct GithubRunLogsTool;
+    name: "github.run.logs";
+    description: "Read a bounded excerpt of one GitHub Actions run's logs — failed steps by default, or the full log — plus the commit the runner actually checked out, parsed from the log's own checkout evidence. Output is capped so a large log cannot exhaust the caller's context; `truncated` reports when it was.";
+    parameters: [
+        super::tool_param("run", "Numeric workflow-run ID", "string", true),
+        super::tool_param("job", "Numeric job ID to narrow the log to one job", "string", false),
+        super::tool_param("scope", "\"failed\" (default) for failed-step logs, or \"all\" for the full run log — use \"all\" to evidence the checked-out commit, since the checkout step usually succeeds", "string", false),
+        super::tool_param("max_bytes", "Maximum log bytes to return (default 16384, capped at 262144). The excerpt keeps the head and the tail and marks the omitted gap.", "integer", false),
+        super::tool_param("repo", "Repository in owner/name format (uses current directory if omitted)", "string", false),
+    ];
+    request: |_ctx, input| {
+        build_exec_request(input)
+    }
+    response: |_ctx, input, result| {
+        check_exec_result(result, "gh run view --log")?;
+
+        let max_bytes =
+            super::bounded_limit(input, "max_bytes", DEFAULT_MAX_BYTES, MAX_MAX_BYTES)? as usize;
+        let bounded = super::bound_log_text(&result.stdout, max_bytes);
+        // Scan the whole log, not the excerpt: truncation must not be able to
+        // hide the checkout evidence the caller came for.
+        let evidence = super::scan_checkout_evidence(&result.stdout, MAX_EVIDENCE_LINES);
+
+        Ok(json!({
+            "run_id": input.get("run"),
+            "scope": input.get("scope").and_then(Value::as_str).unwrap_or("failed"),
+            "log": bounded.text,
+            "truncated": bounded.truncated,
+            "returned_bytes": bounded.returned_bytes,
+            "total_bytes": bounded.total_bytes,
+            // Distinct from any run's `reported_head_sha`: this is what the
+            // runner checked out, read from the runner's own output.
+            "checkout_commits": evidence.commits,
+            "checkout_evidence": evidence.lines,
+        }))
+    }
+}

--- a/crates/orbit-tools/src/builtin/github/run_view.rs
+++ b/crates/orbit-tools/src/builtin/github/run_view.rs
@@ -1,0 +1,145 @@
+use orbit_common::OrbitError;
+use orbit_exec::ExecRequest;
+use serde_json::{Value, json};
+
+use crate::{TIMEOUT_DEFAULT_MS, check_exec_result};
+
+/// The `gh run view --json` fields this tool projects.
+const RUN_VIEW_FIELDS: &str = "databaseId,number,workflowName,displayTitle,status,conclusion,event,headBranch,headSha,createdAt,startedAt,updatedAt,url,jobs";
+
+pub(super) fn build_exec_request(input: &Value) -> Result<ExecRequest, OrbitError> {
+    let mut args = vec![
+        "run".to_string(),
+        "view".to_string(),
+        super::require_numeric_id(input, "run")?,
+    ];
+    super::push_repo_flag(&mut args, input)?;
+    args.push("--json".to_string());
+    args.push(RUN_VIEW_FIELDS.to_string());
+
+    Ok(super::gh_exec_request(args, None, TIMEOUT_DEFAULT_MS))
+}
+
+fn project_step(step: &Value) -> Value {
+    json!({
+        "number": step["number"],
+        "name": step["name"],
+        "status": step["status"],
+        "conclusion": step["conclusion"],
+    })
+}
+
+/// The web URL for one job.
+///
+/// `gh run view --json jobs` reports job IDs but no job URL, and an
+/// investigation that cannot link a failing job is much harder to review — so
+/// build it from the run URL, which the same payload does carry.
+fn job_url(run_url: &Value, job_id: &Value) -> Value {
+    match (run_url.as_str(), job_id.as_u64()) {
+        (Some(run_url), Some(job_id)) => Value::String(format!("{run_url}/job/{job_id}")),
+        _ => Value::Null,
+    }
+}
+
+fn project_job(job: &Value, run_url: &Value) -> Value {
+    let steps: Vec<Value> = job["steps"]
+        .as_array()
+        .map(|steps| steps.iter().map(project_step).collect())
+        .unwrap_or_default();
+    json!({
+        "job_id": job["databaseId"],
+        "name": job["name"],
+        "status": job["status"],
+        "conclusion": job["conclusion"],
+        "started_at": job["startedAt"],
+        "completed_at": job["completedAt"],
+        "url": job_url(run_url, &job["databaseId"]),
+        "steps": steps,
+    })
+}
+
+/// Whether a job or step landed in a state a remediation task must explain.
+///
+/// `cancelled` and `timed_out` count: a run that never produced a verdict is
+/// not a green run, and treating it as one is how a red pipeline gets reported
+/// as clean.
+fn is_unsuccessful(conclusion: &Value) -> bool {
+    matches!(
+        conclusion.as_str(),
+        Some("failure" | "cancelled" | "timed_out" | "action_required" | "startup_failure")
+    )
+}
+
+pub(super) fn project_run_view(run: &Value) -> Value {
+    let jobs: Vec<Value> = run["jobs"]
+        .as_array()
+        .map(|jobs| {
+            jobs.iter()
+                .map(|job| project_job(job, &run["url"]))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let failed_jobs: Vec<Value> = jobs
+        .iter()
+        .filter(|job| is_unsuccessful(&job["conclusion"]))
+        .map(|job| {
+            let failed_steps: Vec<Value> = job["steps"]
+                .as_array()
+                .map(|steps| {
+                    steps
+                        .iter()
+                        .filter(|step| is_unsuccessful(&step["conclusion"]))
+                        .cloned()
+                        .collect()
+                })
+                .unwrap_or_default();
+            json!({
+                "job_id": job["job_id"],
+                "name": job["name"],
+                "conclusion": job["conclusion"],
+                "url": job["url"],
+                "failed_steps": failed_steps,
+            })
+        })
+        .collect();
+
+    json!({
+        "run_id": run["databaseId"],
+        "run_number": run["number"],
+        "workflow": run["workflowName"],
+        "title": run["displayTitle"],
+        "status": run["status"],
+        "conclusion": run["conclusion"],
+        "event": run["event"],
+        "head_branch": run["headBranch"],
+        // Event metadata, not evidence: `github.run.logs` reports the commit
+        // the runner actually checked out.
+        "reported_head_sha": run["headSha"],
+        "created_at": run["createdAt"],
+        "started_at": run["startedAt"],
+        "updated_at": run["updatedAt"],
+        "url": run["url"],
+        "jobs": jobs,
+        "failed_jobs": failed_jobs,
+    })
+}
+
+super::gh_tool! {
+    pub struct GithubRunViewTool;
+    name: "github.run.view";
+    description: "Inspect one GitHub Actions workflow run: its reported head SHA, event, branch, and every job with its URL, steps, and conclusions. Unsuccessful jobs and steps are also collected separately.";
+    parameters: [
+        super::tool_param("run", "Numeric workflow-run ID", "string", true),
+        super::tool_param("repo", "Repository in owner/name format (uses current directory if omitted)", "string", false),
+    ];
+    request: |_ctx, input| {
+        build_exec_request(input)
+    }
+    response: |_ctx, _input, result| {
+        check_exec_result(result, "gh run view")?;
+
+        let run = super::parse_gh_json(&result.stdout, "gh run view")?;
+        Ok(project_run_view(&run))
+    }
+}

--- a/crates/orbit-tools/src/builtin/github/tests/bounded_logs.rs
+++ b/crates/orbit-tools/src/builtin/github/tests/bounded_logs.rs
@@ -1,0 +1,150 @@
+//! Bounding and redaction of runner-log excerpts, plus the checkout-evidence
+//! scan that keeps the tested commit distinct from a run's reported head SHA.
+
+use crate::builtin::github::{bound_log_text, scan_checkout_evidence};
+
+#[test]
+fn a_short_log_is_returned_whole_and_unmarked() {
+    let bounded = bound_log_text("error: assertion failed\n", 1024);
+
+    assert!(!bounded.truncated);
+    assert_eq!(bounded.text, "error: assertion failed\n");
+    assert_eq!(bounded.total_bytes, bounded.returned_bytes);
+}
+
+#[test]
+fn an_oversized_log_is_capped_while_keeping_both_ends() {
+    let raw = format!("HEAD-MARKER\n{}\nTAIL-MARKER", "x".repeat(200_000));
+
+    let bounded = bound_log_text(&raw, 4_096);
+
+    assert!(bounded.truncated);
+    assert!(
+        bounded.returned_bytes <= 4_096,
+        "excerpt must respect the requested cap: {}",
+        bounded.returned_bytes
+    );
+    assert_eq!(bounded.total_bytes, raw.len());
+    assert!(bounded.text.contains("HEAD-MARKER"));
+    assert!(bounded.text.contains("TAIL-MARKER"));
+    assert!(bounded.text.contains("bytes omitted"));
+}
+
+#[test]
+fn truncation_never_splits_a_multibyte_character() {
+    let raw = "é".repeat(50_000);
+
+    let bounded = bound_log_text(&raw, 1_001);
+
+    assert!(bounded.truncated);
+    // Reaching this point at all means both slices landed on char boundaries;
+    // a mid-character split panics inside `bound_log_text`.
+    assert!(bounded.text.contains('é'));
+}
+
+#[test]
+fn a_credential_in_the_log_is_redacted_before_it_is_returned() {
+    let raw = format!("remote: fatal: bad credentials ghp_{}\n", "a".repeat(36));
+
+    let bounded = bound_log_text(&raw, 4_096);
+
+    assert!(
+        !bounded.text.contains("ghp_"),
+        "token survived redaction: {}",
+        bounded.text
+    );
+    assert!(bounded.text.contains("[REDACTED_SECRET]"));
+}
+
+#[test]
+fn checkout_evidence_reports_the_tested_commit_not_the_event_sha() {
+    let log = "\
+setup\tRun actions/checkout@v4\t2026-01-01T00:00:00.0000000Z Syncing repository
+setup\tRun actions/checkout@v4\t2026-01-01T00:00:01.0000000Z /usr/bin/git checkout --progress --force 1111111111111111111111111111111111111111
+setup\tRun actions/checkout@v4\t2026-01-01T00:00:02.0000000Z HEAD is now at 1111111 chore: something
+build\tRun tests\t2026-01-01T00:00:03.0000000Z error: build failed
+";
+
+    let evidence = scan_checkout_evidence(log, 40);
+
+    assert!(
+        evidence
+            .commits
+            .contains(&"1111111111111111111111111111111111111111".to_string()),
+        "expected the full checked-out SHA: {:?}",
+        evidence.commits
+    );
+    assert_eq!(evidence.lines.len(), 2);
+    assert!(
+        evidence
+            .lines
+            .iter()
+            .any(|line| line.contains("HEAD is now at"))
+    );
+    assert!(
+        evidence.lines.iter().all(|line| !line.contains('\t')),
+        "the job and step columns are stripped: {:?}",
+        evidence.lines
+    );
+}
+
+/// The failure this scan is built to avoid. Every line of a checkout step is
+/// labelled with the *action's* pinned SHA, and reporting that as the commit
+/// under test would be evidence pointing at the wrong repository entirely.
+#[test]
+fn a_pinned_action_sha_is_never_reported_as_the_checked_out_commit() {
+    let pin = "34e114876b0b11c390a56381ad16ebd13914f8d5";
+    let tested = "5dbb8eff6f1ec88a24da618df1962d2c6b82ab6e";
+    let log = format!(
+        "\
+macOS\tRun actions/checkout@{pin}\t2026-01-01T00:00:00.0000000Z ##[group]Checking out the ref
+macOS\tRun actions/checkout@{pin}\t2026-01-01T00:00:01.0000000Z [command]/usr/bin/git checkout --progress --force -B trunk refs/remotes/origin/trunk
+macOS\tRun actions/checkout@{pin}\t2026-01-01T00:00:02.0000000Z {tested}
+"
+    );
+
+    let evidence = scan_checkout_evidence(&log, 40);
+
+    assert!(
+        !evidence.commits.contains(&pin.to_string()),
+        "the action pin leaked into the checkout evidence: {:?}",
+        evidence.commits
+    );
+    assert_eq!(evidence.commits, vec![tested.to_string()]);
+}
+
+/// A bare SHA is evidence only inside a checkout step. The same shape shows up
+/// in ordinary build output, where it means nothing.
+#[test]
+fn a_bare_sha_outside_a_checkout_step_is_not_treated_as_evidence() {
+    let log = "\
+build\tRun tests\t2026-01-01T00:00:00.0000000Z 5dbb8eff6f1ec88a24da618df1962d2c6b82ab6e
+";
+
+    let evidence = scan_checkout_evidence(log, 40);
+
+    assert!(evidence.commits.is_empty(), "{:?}", evidence.commits);
+    assert!(evidence.lines.is_empty());
+}
+
+#[test]
+fn checkout_evidence_lines_are_capped_and_redacted() {
+    let line = format!(
+        "setup\tcheckout\t2026-01-01T00:00:00.0000000Z HEAD is now at 2222222 token ghp_{}\n",
+        "b".repeat(36)
+    );
+    let log = line.repeat(100);
+
+    let evidence = scan_checkout_evidence(&log, 5);
+
+    assert_eq!(evidence.lines.len(), 5);
+    assert!(evidence.lines.iter().all(|line| !line.contains("ghp_")));
+}
+
+#[test]
+fn a_log_without_checkout_evidence_yields_nothing_rather_than_a_guess() {
+    let evidence = scan_checkout_evidence("build\tRun tests\terror: build failed\n", 40);
+
+    assert!(evidence.commits.is_empty());
+    assert!(evidence.lines.is_empty());
+}

--- a/crates/orbit-tools/src/builtin/github/tests/discovery_requests.rs
+++ b/crates/orbit-tools/src/builtin/github/tests/discovery_requests.rs
@@ -1,0 +1,190 @@
+//! Argv construction and response shaping for the read-only CI discovery
+//! tools. These assert the contract a task body depends on without needing a
+//! GitHub CLI on the machine running the tests.
+
+use serde_json::json;
+
+use crate::builtin::github::{pr_list, run_list, run_logs, run_view};
+
+#[test]
+fn run_list_applies_every_filter_and_caps_the_limit() {
+    let req = run_list::build_exec_request(&json!({
+        "branch": "release",
+        "workflow": "ci.yml",
+        "status": "failure",
+        "event": "push",
+        "limit": 5_000,
+        "repo": "owner/name",
+    }))
+    .expect("request");
+
+    assert_eq!(req.program, "gh");
+    assert_eq!(&req.args[..2], &["run".to_string(), "list".to_string()]);
+    for expected in [
+        "--branch",
+        "release",
+        "--workflow",
+        "ci.yml",
+        "--status",
+        "failure",
+        "--event",
+        "push",
+        "--repo",
+        "owner/name",
+    ] {
+        assert!(
+            req.args.iter().any(|arg| arg == expected),
+            "missing {expected} in {:?}",
+            req.args
+        );
+    }
+    let limit = req
+        .args
+        .iter()
+        .position(|arg| arg == "--limit")
+        .map(|index| req.args[index + 1].clone())
+        .expect("limit flag");
+    assert_eq!(
+        limit, "100",
+        "an oversized limit must clamp, not pass through"
+    );
+}
+
+#[test]
+fn run_list_defaults_to_an_unfiltered_bounded_query() {
+    let req = run_list::build_exec_request(&json!({})).expect("request");
+
+    assert!(!req.args.iter().any(|arg| arg == "--branch"));
+    let limit = req
+        .args
+        .iter()
+        .position(|arg| arg == "--limit")
+        .map(|index| req.args[index + 1].clone())
+        .expect("limit flag");
+    assert_eq!(limit, "20");
+}
+
+#[test]
+fn a_filter_value_cannot_smuggle_another_gh_flag() {
+    let error = run_list::build_exec_request(&json!({ "branch": "--repo" }))
+        .expect_err("a flag-shaped filter must be rejected");
+
+    assert!(error.to_string().contains("branch"), "{error}");
+}
+
+#[test]
+fn run_view_requires_a_numeric_run_id() {
+    let error = run_view::build_exec_request(&json!({ "run": "--log" }))
+        .expect_err("a non-numeric run must be rejected");
+
+    assert!(error.to_string().contains("run"), "{error}");
+}
+
+#[test]
+fn run_view_projects_the_reported_head_sha_and_collects_failed_jobs() {
+    let projected = run_view::project_run_view(&json!({
+        "databaseId": 42,
+        "number": 7,
+        "workflowName": "CI",
+        "headSha": "abc123",
+        "event": "pull_request",
+        "url": "https://example.invalid/o/r/actions/runs/42",
+        "jobs": [
+            {
+                "databaseId": 1,
+                "name": "green",
+                "conclusion": "success",
+                "steps": [{"number": 1, "name": "run", "conclusion": "success"}],
+            },
+            {
+                "databaseId": 2,
+                "name": "red",
+                "conclusion": "failure",
+                "steps": [
+                    {"number": 1, "name": "checkout", "conclusion": "success"},
+                    {"number": 2, "name": "test", "conclusion": "failure"},
+                ],
+            },
+        ],
+    }));
+
+    assert_eq!(projected["reported_head_sha"], "abc123");
+    assert!(
+        projected.get("sha").is_none(),
+        "the reported head SHA must not also appear under an ambiguous name"
+    );
+    assert_eq!(projected["jobs"].as_array().expect("jobs").len(), 2);
+    let failed = projected["failed_jobs"].as_array().expect("failed jobs");
+    assert_eq!(failed.len(), 1);
+    assert_eq!(failed[0]["name"], "red");
+    assert_eq!(
+        failed[0]["failed_steps"].as_array().expect("steps").len(),
+        1
+    );
+    assert_eq!(failed[0]["failed_steps"][0]["name"], "test");
+    assert_eq!(
+        failed[0]["url"], "https://example.invalid/o/r/actions/runs/42/job/2",
+        "a failing job must be linkable even though gh reports no job URL"
+    );
+}
+
+#[test]
+fn a_cancelled_job_counts_as_unsuccessful() {
+    let projected = run_view::project_run_view(&json!({
+        "jobs": [{"databaseId": 1, "name": "flaky", "conclusion": "cancelled", "steps": []}],
+    }));
+
+    assert_eq!(projected["failed_jobs"].as_array().expect("jobs").len(), 1);
+}
+
+#[test]
+fn run_logs_defaults_to_failed_steps_and_accepts_the_full_log() {
+    let failed = run_logs::build_exec_request(&json!({ "run": "99" })).expect("request");
+    assert!(failed.args.iter().any(|arg| arg == "--log-failed"));
+    assert!(!failed.args.iter().any(|arg| arg == "--log"));
+
+    let all = run_logs::build_exec_request(&json!({ "run": "99", "scope": "all", "job": "5" }))
+        .expect("request");
+    assert!(all.args.iter().any(|arg| arg == "--log"));
+    assert!(all.args.iter().any(|arg| arg == "--job"));
+    assert!(all.args.iter().any(|arg| arg == "5"));
+}
+
+#[test]
+fn run_logs_rejects_an_unknown_scope() {
+    let error = run_logs::build_exec_request(&json!({ "run": "99", "scope": "everything" }))
+        .expect_err("an unknown scope must be rejected");
+
+    assert!(error.to_string().contains("scope"), "{error}");
+}
+
+#[test]
+fn pr_list_projects_each_head_sha_under_its_own_name() {
+    let projected = pr_list::project_pull_request(&json!({
+        "number": 3,
+        "title": "Fix it",
+        "state": "OPEN",
+        "isDraft": false,
+        "headRefName": "topic",
+        "headRefOid": "deadbee",
+        "baseRefName": "trunk",
+    }));
+
+    assert_eq!(projected["reported_head_sha"], "deadbee");
+    assert_eq!(projected["head_branch"], "topic");
+    assert!(projected.get("sha").is_none());
+}
+
+#[test]
+fn pr_list_defaults_to_a_bounded_open_query() {
+    let req = pr_list::build_exec_request(&json!({})).expect("request");
+
+    assert_eq!(&req.args[..2], &["pr".to_string(), "list".to_string()]);
+    let limit = req
+        .args
+        .iter()
+        .position(|arg| arg == "--limit")
+        .map(|index| req.args[index + 1].clone())
+        .expect("limit flag");
+    assert_eq!(limit, "30");
+}

--- a/crates/orbit-tools/src/builtin/github/tests/mod.rs
+++ b/crates/orbit-tools/src/builtin/github/tests/mod.rs
@@ -1,0 +1,4 @@
+#![allow(missing_docs)]
+
+mod bounded_logs;
+mod discovery_requests;

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -13,7 +13,6 @@ const RETIRED_AGENT_TOOL_NAMES: &[&str] = &[
     "github.pr.comment.reply",
     "github.pr.comments",
     "github.pr.create",
-    "github.pr.list",
     "github.pr.merge",
     "github.pr.review",
     "github.pr.review.comment",
@@ -59,7 +58,6 @@ fn unused_tools_are_not_registered_in_public_surface() {
     for removed in [
         "git.commit",
         "git.stage_paths",
-        "github.auth.status",
         "github.pr.checkout",
         "github.pr.checks",
         "github.pr.close",
@@ -138,6 +136,62 @@ fn retired_agent_tools_are_absent_from_every_registry_surface_and_dispatch() {
             "dispatch error must name retired tool {retired}: {error}"
         );
     }
+}
+
+/// The read-only GitHub discovery surface a CI-remediation body depends on.
+///
+/// `github.pr.list` was retired with the write-side PR tools; it is back
+/// deliberately, as a read-only listing, because a body that cannot enumerate
+/// open pull-request heads cannot tell a current failure from a stale one.
+/// Nothing that mutates GitHub joined it.
+#[test]
+fn read_only_github_ci_discovery_is_registered_and_write_operations_are_not() {
+    let names = registered_tool_names();
+
+    for retained in [
+        "github.auth.status",
+        "github.pr.list",
+        "github.run.list",
+        "github.run.logs",
+        "github.run.view",
+    ] {
+        assert!(
+            names.contains(retained),
+            "CI discovery tool missing from the agent surface: {retained}"
+        );
+    }
+
+    for absent in [
+        "github.pr.checkout",
+        "github.pr.checks",
+        "github.pr.close",
+        "github.repo.view",
+    ] {
+        assert!(
+            !names.contains(absent),
+            "non-discovery github tool must stay unregistered: {absent}"
+        );
+    }
+}
+
+/// A bounded `github.run.logs` is the whole point of routing log reads through
+/// a tool: an unbounded one would hand a multi-megabyte runner log straight to
+/// the executing agent.
+#[test]
+fn run_logs_advertises_its_output_bound() {
+    let mut registry = ToolRegistry::new();
+    registry.register_builtins();
+
+    let schema = registry
+        .get_active_schema("github.run.logs")
+        .expect("github.run.logs schema");
+    assert!(
+        schema
+            .parameters
+            .iter()
+            .any(|param| param.name == "max_bytes" && !param.required),
+        "github.run.logs must expose an optional output bound"
+    );
 }
 
 #[test]

--- a/docs/design/auto-tasks/1_overview.md
+++ b/docs/design/auto-tasks/1_overview.md
@@ -103,7 +103,11 @@ definition of the same name.
   derived integration and release heads plus open pull-request heads, with
   stale-run filtering, root-cause clustering, CI-failure-hook deduplication,
   and evidence-backed no-diff outcomes (ORB-11054). GitHub-Actions-shaped;
-  operators on other CI should adapt before enabling.
+  operators on other CI should adapt before enabling. All CI discovery runs
+  through the read-only `github.*` builtin tools, which bound log output and
+  redact credentials; a `github.auth.status` preflight makes an execution lane
+  that cannot authenticate report a capability-unavailable outcome instead of a
+  clean pipeline (ORB-11059).
 
 ## Workspace-authored definitions in this repo
 
@@ -136,5 +140,8 @@ encode this repository's branches and gates. Re-init preserves them:
 - ORB-11054 — Added the disabled hourly `ci-failure-remediation` default to the
   embedded catalog and split this overview so repo-local workspace-authored
   definitions are no longer listed as if they were embedded defaults.
+- ORB-11059 — Routed the default's CI discovery through the read-only
+  `github.run.*` / `github.pr.list` / `github.auth.status` builtin tools and
+  added the capability-unavailable outcome.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/plugin/skills/orbit/references/setup/auto-tasks.md
+++ b/plugin/skills/orbit/references/setup/auto-tasks.md
@@ -91,7 +91,15 @@ wording before enabling it. Over MCP: `orbit_auto_task_list` and
   pull-request heads, clusters by root cause, repairs repository-owned failures
   without weakening a check, and treats a clean current-head pass as a successful
   no-diff outcome. The body is GitHub-Actions-shaped; operators on other CI
-  should adapt it before enabling.
+  should adapt it before enabling. **Execution-lane precondition:** all of its CI
+  discovery goes through the read-only `github.auth.status`, `github.run.list`,
+  `github.run.view`, `github.run.logs`, and `github.pr.list` builtin tools, which
+  run the GitHub CLI as a child of whichever process executes the tool. So the
+  lane that runs the minted task needs one of: an executor whose sandbox permits
+  reading the GitHub CLI's configuration directory, or a GitHub token forwarded
+  through `[execution.env] pass`. Check before enabling — a lane with neither
+  still completes, but every run ends at the preflight with a
+  capability-unavailable summary and no investigation.
 
 Read them before enabling. They are also the best worked examples of how much
 instruction a minted task's body should carry.


### PR DESCRIPTION
## Task

[ORB-11059](https://orbit-cli.com/tasks/ORB-11059) — Make ci-failure-remediation work under a sandboxed execution lane

### Description

The `ci-failure-remediation` default auto-task shipped by ORB-11054 (PR #1169)
tells the executing agent to enumerate workflow runs and read failed-step logs
"with GitHub's API or `gh`". A sandboxed execution lane cannot do that, so the
definition is only usable in a full-access lane today.

## Why it fails

The blocker is credentials, not network:

- `crates/orbit-exec/src/macos_sandbox/compile.rs` denies reading
  `~/.config/gh` in `emit_default_credential_read_denies`, alongside `.ssh`,
  `.aws`, and the keychains.
- `[execution.env] pass` does not forward `GH_TOKEN` / `GITHUB_TOKEN`; the
  shipped `crates/orbit-config/assets/default-config.toml` documents user vars
  as opt-in.
- Network egress is allowed (`(allow network*)`, host netns retained), so the
  agent reaches GitHub and is rejected as unauthenticated rather than failing
  fast.

This repository's own enabled copy only works because
`[execution.codex] sandbox = "danger-full-access"` in `.orbit/config.toml`.
The definition also assumes `gh` is installed in every workspace's execution
lane, which a portable shipped default should not.

The worst part of the current failure mode is silent: an agent that cannot
query GitHub can conclude "no current failures" and finish as the definition's
sanctioned no-diff success.

## Approach

Route CI discovery through the builtin GitHub tool surface, which already runs
host-side and therefore keeps credentials on the tool-host side of the sandbox
boundary. `crates/orbit-tools/src/builtin/github/` executes `gh` through
`orbit_exec::run_process(&req, &orbit_exec::NoSandbox)` with
`EnvironmentMode::Inherit`; it just has no run-level coverage yet
(`github.auth.status`, `github.pr.checks`, `github.pr.checkout`,
`github.pr.close`, `github.repo.view`).

1. **Extend the tool family** with read-only siblings built from the existing
   `gh_tool!` macro, following `pr_checks.rs` for shape, registration, and
   schema:
   - `github.run.list` — workflow runs filtered by branch, status/conclusion,
     workflow, and limit.
   - `github.run.view` — jobs, steps, conclusions, run attempt, event, and the
     reported head SHA for one run.
   - `github.run.logs` — failed-step logs for one run (`gh run view
     --log-failed` or equivalent), bounded so a large log cannot blow the
     agent's context.
   - `github.pr.list` — open PRs with their current head SHAs.
   Confirm the existing artifact redaction path
   (`crates/orbit-core/src/adapter/tool_host/artifact_redaction.rs`) scrubs
   tokens from the new tools' output the way it does for the current ones.
2. **Rewrite the definition body** in
   `crates/orbit-core/assets/auto_tasks/ci-failure-remediation.yaml` to call
   `orbit tool run github.run.list` and friends instead of raw `gh` or the
   REST API, matching how the other shipped defaults standardize on
   `orbit tool run orbit.*` surfaces. Keep the evidence model unchanged: the
   tools must still expose the reported head SHA and the actual checkout
   commit distinctly, since that separation is the definition's core rule.
3. **Preflight and fail closed on capability, open on findings.** Begin the
   body with `github.auth.status`. If the surface is unavailable or
   unauthenticated, persist that in `execution_summary` and finish as an
   explicit capability-unavailable outcome — never as "no current failures".
   The no-diff success path stays reserved for a real, evidenced no-failure or
   transient-only pass.
4. **Document the precondition** in the definition's `description` field and in
   the seeded-definitions section of
   `crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md` (and
   its `plugin/skills/orbit/` mirror): what the definition needs from the
   execution lane before an operator enables it.

Rejected alternative: having the scheduler collect failure evidence host-side
and embed it into the task at mint time. It requires a new pre-mint
evidence-provider concept and duplicates the PR-only CI-failure task hook in
`.github/workflows/ci.yml`.

### Acceptance Criteria

- Read-only `github.run.list`, `github.run.view`, `github.run.logs`, and `github.pr.list` builtin tools are registered, follow the existing `gh_tool!` pattern, execute host-side through the tool host, and expose the reported head SHA and actual checkout commit as distinct fields.
- `github.run.logs` bounds its output so a large failed-step log cannot exhaust the executing agent's context, and token redaction covers every new tool's output.
- The shipped `ci-failure-remediation.yaml` body performs all CI discovery through `orbit tool run github.*` and contains no raw `gh` invocation or direct REST call.
- The body preflights `github.auth.status` and, when the surface is unavailable or unauthenticated, records a capability-unavailable outcome in `execution_summary` that is distinguishable from an evidenced no-failure or transient-only no-diff pass.
- A sandboxed execution lane with no `~/.config/gh` access and no `GH_TOKEN`/`GITHUB_TOKEN` in `[execution.env] pass` completes a run of the definition without a credential error and without claiming there were no failures.
- The definition's `description` field and the seeded-definitions section of the orbit skill reference (assets copy and plugin mirror) state the execution-lane precondition for enabling it.
- The repository's pre-handoff gate passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Routed the shipped `ci-failure-remediation` default's CI discovery through five read-only builtin GitHub tools and made an unusable GitHub surface an explicit, reportable outcome instead of a silent "no failures".

## Correction to the task's premise (evidence-backed)

The task planned on "the builtin GitHub tool surface already runs host-side and therefore keeps credentials on the tool-host side of the sandbox boundary". That is false, and the implementation does not rely on it. `orbit tool run` and `orbit mcp serve` are ordinary children of the sandboxed provider CLI, so `gh` inherits the sandbox: macOS emits `(allow process*)` (`crates/orbit-exec/src/macos_sandbox/compile.rs:94`, and `:122` states the inheritance outright), Linux uses `bwrap ... -- <provider>` (`crates/orbit-exec/src/linux_sandbox.rs:620`), and `ToolContext.orbit_host` is an in-process `Arc<dyn OrbitToolHost>` (`crates/orbit-tools/src/lib.rs:225`), not IPC. `NoSandbox` means "this tool adds no sandbox", not "this tool escapes one". Filed as friction F2026-08-135, which also notes that the `~/.config/gh` read-deny is macOS-only — the Linux backend never consults `profile.read`.

The tools are still the right change; what they buy is bounded output, credential redaction, a reported-head-SHA/checkout-commit split, and a *structured* capability answer. The sandbox problem is solved by detection, not relocation — which is what AC4/AC5 actually ask for.

## Tool surface (`crates/orbit-tools/src/builtin/github/`)

`github::register` was a no-op since ORB-10738; it now registers five read-only tools built with the existing `gh_tool!` macro:

- `github.run.list` (`run_list.rs`) — runs filtered by branch/workflow/status/event, limit clamped to 100.
- `github.run.view` (`run_view.rs`) — jobs, steps, conclusions, plus a `failed_jobs` projection. `cancelled`/`timed_out`/`action_required`/`startup_failure` count as unsuccessful, so a run that never produced a verdict cannot read as green.
- `github.run.logs` (`run_logs.rs`) — `--log-failed` by default, `scope: "all"` for the full log. Output capped at 16 KiB (ceiling 256 KiB), keeping head **and** tail with the omitted byte count marked inline, and reporting `truncated` / `returned_bytes` / `total_bytes`.
- `github.pr.list` (`pr_list.rs`) — open PRs with head SHAs.
- `github.auth.status` (`auth.rs`) — reworked onto the macro's `execute:` arm so a missing or unspawnable `gh` returns `available: false` instead of an error; `available` and `authenticated` are separate fields with a quotable `detail`.

Distinct-fields rule (AC1): the event's SHA is only ever `reported_head_sha`; the tested commit is only ever `checkout_commits`, parsed from the runner's own log. No `sha` field exists anywhere, and tests assert its absence.

Redaction (AC2): `redact_all` is applied to every log excerpt, evidence line, and auth stdout/stderr inside the tools; `execute_registered_tool` additionally applies `redact_sensitive_env_json` to all registry output. Verified live — a real `gh auth status` token came back as `[REDACTED_SECRET]`.

## Two live-validation corrections

Validating against real GitHub (gh 2.45) caught two defects unit tests alone would have shipped:

1. `attempt` is not a `gh run list`/`run view --json` field — it errored the whole call. Removed rather than faked; the body now derives a rerun from a later run at the same reported head SHA, which `run.list` does report. `gh` also reports no job URL, so `run.view` derives one from the run URL (`<run_url>/job/<job_id>`).
2. The first checkout-evidence scan reported `34e114876b...` — the **pinned `actions/checkout` SHA from the step-name column**, not the tested commit. Exactly the conflation the task exists to prevent. The scan now splits the `job<TAB>step<TAB>timestamp payload` line, matches only in the payload, skips `@`-prefixed tokens, and additionally accepts a bare 40-hex line when the step column names a checkout (how `actions/checkout` records a branch-mode result). Re-verified live: reports `5dbb8eff...`, the actual tested commit, and never the pin. Regression tests cover both shapes. Implemented without `regex` — orbit-tools has no other regex use and the crate denies `expect_used`.

## Definition and docs

`ci-failure-remediation.yaml` names the five tools explicitly, forbids the vendor CLI and hand-rolled REST/GraphQL, and opens with the `github.auth.status` preflight. A false `available`/`authenticated` stops the investigation and persists `capability_unavailable`, quoting the preflight `detail`; the body states in so many words that this must never be reported as "no current failures" and keeps the three endings distinguishable. `description` states the execution-lane precondition and both ways to satisfy it. The seeded-definitions section of `references/setup/auto-tasks.md` carries the same precondition in the assets copy and the plugin mirror; `docs/design/auto-tasks/1_overview.md` was updated in the same pass.

## Registration reversal, stated deliberately

`github.pr.list` was in `RETIRED_AGENT_TOOL_NAMES` and `github.auth.status` in the "removed" set of `public_tool_surface.rs` (ORB-10738). Both are back as read-only tools, which AC1/AC4 require; the test now positively asserts the discovery surface and, in the same test, that `pr.checkout`, `pr.checks`, `pr.close`, and `repo.view` stay unregistered. Nothing that mutates GitHub was registered.

## Validation

- `make ci-fast` — exit 0.
- `make ci-lint` — exit 0.
- `cargo nextest run -p orbit-tools -p orbit-core -p orbit-cli -p orbit-mcp` — 1534 passed, 1 skipped.
- New tests: 19 in `builtin/github/tests/` (bounding, char-boundary safety, redaction, action-pin rejection, argv/flag-injection, projections) and 2 CLI integration tests in `tests/github_capability_preflight.rs` that run the real binary on a lane with an empty `PATH` and with an unauthenticated `gh` stub, both with `GH_TOKEN`/`GITHUB_TOKEN` removed — the AC5 lane, completing with `available`/`authenticated` false and exit 0.
- CLI output goldens regenerated via `ORBIT_UPDATE_OUTPUT_GOLDENS=1`; the diff is exactly the five new tools.
- Live end-to-end against `danieljhkim/orbit` for all five tools.

Test-environment note: `cargo nextest` inside a managed run inherits `ORBIT_ACTIVITY_TOOLS`, which fails unrelated orbit-core dispatch tests with "not in the activity allowlist". Pre-existing and already filed three times (F2026-08-131, F2026-08-132, F2026-08-134), so no fourth record; all runs above used `env -u` to clear the managed-run variables.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11059-6a93437f`
- Behind base: 0
- Ahead of base: 1