### PR TITLE
Make the embedded QA sweep instructions product-agnostic

### DIFF
--- a/crates/orbit-core/assets/auto_tasks/qa-sweep.yaml
+++ b/crates/orbit-core/assets/auto_tasks/qa-sweep.yaml
@@ -12,28 +12,20 @@ template:
     feature paths as a user would; do not treat re-running the existing test
     suite as sufficient validation.
 
-    When those paths include `orbit init` or `orbit workspace init` and you
-    are inside the Cowork/agent-executor sandbox, `/` and `~/.orbit` are
-    mounted read-only. Do not init against the real home Orbit root — that
-    fails with EROFS. Put the Orbit root and any scratch git checkouts
-    under `/tmp` and use:
+    Follow this repository's documented setup and run instructions. When a
+    sandbox or other environment constraint makes the usual local state
+    unwritable, put scratch checkouts, caches, and other ephemeral state in a
+    writable temporary location rather than the machine's real home directory
+    or the product's live data root.
 
-        orbit --root /tmp/<scratch> init --non-interactive --host-name <name> --task-prefix <XXXX>
-        orbit --root /tmp/<scratch> workspace init
-
-    Root `init` hangs on stdin without `--non-interactive`. `workspace init`
-    does not need that flag and does not prompt non-interactively in
-    practice.
-
-    Before filing anything, search open Orbit tasks tagged `qa-sweep`. For each
-    real issue that is not already filed, create an Orbit task yourself through
-    the Orbit MCP tools or the equivalent `orbit tool run orbit.task.add`
-    command. Give it severity-appropriate priority, tag it `qa-sweep`, and put
-    the relevant commits, observed evidence, and exact reproduction steps in
-    its description. Skip duplicates.
+    Before reporting anything, search the workspace's configured task or issue surface
+    for open work covering the same problem. For each real issue that is not already
+    filed, create a durable record on that surface. Give it severity-appropriate
+    priority and put the relevant commits, observed evidence, and exact
+    reproduction steps in its description. Skip duplicates.
 
     A non-duplicate failing test that blocks the repository's
-    standard validation command must be filed as an Orbit task even when
+    standard validation command must be filed as a durable issue even when
     the failure is sandbox-specific, platform-specific, or otherwise
     environment-specific, including test-harness or portability defects.
     Do not leave such a breaking test in narrative-only output. Distinguish
@@ -42,12 +34,12 @@ template:
     defect). Include the failing command, the exact error, relevant
     environment evidence, and a scope assessment.
 
-    Your narrative output is advisory; the tasks you create are the durable
+    Your narrative output is advisory; the issues you file are the durable
     side-effect channel.
   acceptance_criteria:
   - Recent changes were exercised through their real user-facing paths.
-  - Real, non-duplicate issues were filed as Orbit tasks with evidence and reproduction steps.
-  - Non-duplicate failing tests that block the prescribed validation command were filed as Orbit tasks, with validation impact distinguished from production impact.
+  - Real, non-duplicate issues were filed on the workspace's configured task or issue surface with evidence and reproduction steps.
+  - Non-duplicate failing tests that block the prescribed validation command were filed as durable issues, with validation impact distinguished from production impact.
   task_type: chore
   tags:
   - qa-sweep

--- a/crates/orbit-core/src/auto_tasks/tests/shipped.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/shipped.rs
@@ -204,7 +204,13 @@ fn qa_sweep_default_preserves_hands_on_validation_contract() {
 
     assert_eq!(definition.name, "qa-sweep");
     assert!(!definition.enabled);
-    assert!(matches!(definition.schedule, AutoTaskSchedule::Cron { .. }));
+    assert_eq!(
+        definition.schedule,
+        AutoTaskSchedule::Cron {
+            cron: "50 * * * *".to_string()
+        },
+        "qa-sweep must keep its documented hourly schedule"
+    );
     assert!(matches!(definition.dedupe, DedupePolicy::SkipIfOpen));
     // [ORB-10877] Same portable system-lane rule as friction-curation above.
     assert_eq!(definition.template.crew.as_deref(), Some("system"));
@@ -215,6 +221,14 @@ fn qa_sweep_default_preserves_hands_on_validation_contract() {
     assert_eq!(
         definition.template.status,
         orbit_types::task::TaskStatus::Backlog
+    );
+    assert_eq!(
+        definition.template.task_type,
+        orbit_types::task::TaskType::Chore
+    );
+    assert_eq!(
+        definition.template.priority,
+        orbit_types::task::TaskPriority::Medium
     );
     assert!(definition.template.tags.iter().any(|tag| tag == "qa-sweep"));
     assert!(
@@ -229,10 +243,13 @@ fn qa_sweep_default_preserves_hands_on_validation_contract() {
     for required in [
         "validate them hands-on",
         "exercise the affected",
+        "documented setup",
+        "writable temporary",
+        "configured task or issue surface",
         "skip duplicates",
         "failing test",
         "standard validation command",
-        "must be filed as an orbit task",
+        "must be filed as a durable issue",
         "environment-specific",
         "test-harness",
         "portability",
@@ -249,6 +266,36 @@ fn qa_sweep_default_preserves_hands_on_validation_contract() {
             "template should retain '{required}'"
         );
     }
+    let yaml_lower = yaml.to_lowercase();
+    for orbit_specific in [
+        "orbit init",
+        "workspace init",
+        "--root",
+        "~/.orbit",
+        "orbit mcp",
+        "orbit tool run",
+        "filed as an orbit task",
+        "filed as orbit tasks",
+        "tag it `qa-sweep`",
+    ] {
+        assert!(
+            !yaml_lower.contains(orbit_specific),
+            "qa-sweep instructions must stay product-agnostic; found '{orbit_specific}'"
+        );
+    }
+    assert!(
+        definition
+            .template
+            .acceptance_criteria
+            .iter()
+            .any(|criterion| {
+                let criterion = criterion.to_lowercase();
+                criterion.contains("configured task or issue surface")
+                    && criterion.contains("evidence")
+                    && criterion.contains("reproduction")
+            }),
+        "qa-sweep acceptance criteria must require durable reporting on the workspace issue surface"
+    );
     assert!(
         definition
             .template
@@ -260,6 +307,7 @@ fn qa_sweep_default_preserves_hands_on_validation_contract() {
                     && criterion.contains("validation command")
                     && criterion.contains("validation impact")
                     && criterion.contains("production impact")
+                    && !criterion.contains("orbit task")
             }),
         "qa-sweep acceptance criteria must require filing breaking tests"
     );


### PR DESCRIPTION
## Task

[ORB-11062](https://orbit-cli.com/tasks/ORB-11062) — Make the embedded QA sweep instructions product-agnostic

### Description

## Problem
`crates/orbit-core/assets/auto_tasks/qa-sweep.yaml` is an embedded template intended for QA across arbitrary workspaces, but its task description currently assumes the target is Orbit itself. It names `orbit init`, `orbit workspace init`, `--root`, `~/.orbit`, Orbit MCP/CLI task creation, and Orbit-specific task tags.

## Why It Matters
A seeded QA sweep should tell an agent how to validate whichever product owns the workspace. Product-specific setup and reporting instructions can misdirect QA in non-Orbit repositories and make the shared template less portable.

## Constraints / Notes
- Revise the template instructions, not the Orbit auto-task schema or scheduler behavior.
- Preserve the useful generic QA contract: exercise recent changes through real user-facing paths; do not substitute the existing test suite for hands-on validation; search for duplicates before reporting; capture exact commands, errors, environment evidence, reproduction steps, and scope; distinguish validation impact from demonstrated production impact.
- Replace product-specific initialization and sandbox-path advice with generic guidance to follow the target repository's documented setup and use writable temporary locations when sandbox constraints require scratch state.
- Replace Orbit-specific issue-filing mechanics with generic durable-reporting language that uses the workspace's configured task or issue surface.
- Keep the definition disabled-by-default and retain its existing schedule, dedupe, task metadata, and crew behavior unless a directly required wording change demands otherwise.

### Acceptance Criteria

- The task description in `crates/orbit-core/assets/auto_tasks/qa-sweep.yaml` no longer assumes `orbit init`, `orbit workspace init`, `--root`, `~/.orbit`, Orbit MCP/CLI tools, or Orbit-specific reporting tags.
- The revised instructions remain actionable for arbitrary repositories and explicitly preserve hands-on user-path validation, duplicate checking, evidence and reproduction requirements, blocking-test reporting, and the distinction between validation impact and production impact.
- The definition remains disabled by default and its schedule, dedupe mode, task type, priority, crew, status, and generic tags are unchanged unless a test-backed compatibility reason requires a minimal adjustment.
- Focused embedded-asset/auto-task tests and the repository's relevant fast validation pass, and any assertions coupled to the template text are updated.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Rewrote the embedded qa-sweep minted-task body and acceptance criteria so they no longer assume Orbit setup (`orbit init`, `orbit workspace init`, `--root`, `~/.orbit`) or Orbit MCP/CLI filing. Instructions now follow the target repository's documented setup, use a writable temporary location when sandbox state is unwritable, and report through the workspace's configured task or issue surface.
- Preserved the generic QA contract: hands-on user-path validation, duplicate checking, evidence/reproduction, blocking-test filing, and validation-impact vs production-impact.
- Left definition metadata unchanged: disabled, cron `50 * * * *`, `dedupe: skip_if_open`, `task_type: chore`, `priority: medium`, `crew: system`, `status: backlog`, tags `qa-sweep` and `no-diff-expected`.
- Updated `qa_sweep_default_preserves_hands_on_validation_contract` to require the portable wording, pin schedule/type/priority, and reject Orbit-specific setup/reporting strings.
- Added `file:crates/orbit-core/src/auto_tasks/tests/shipped.rs` to context_files because the coupled assertions had to change with the template.
Assessment: Scoped instruction rewrite with test-backed portability checks. No schema/scheduler/docs changes.
Strategic decisions: Generic "configured task or issue surface" rather than naming Orbit tools, so the seeded template stays usable in non-Orbit workspaces.
Validation: `cargo test -p orbit-core qa_sweep` and `shipped_defaults_all_parse` passed; `make ci-fast` passed.
Friction: `orbit.task.update` from this pinned-ORBIT_ROOT worktree returned `task_not_found` until invoked with `orbit --workspace orbit`; filed as F2026-08-137.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11062-6a934b8a`
- Behind base: 0
- Ahead of base: 1