### PR TITLE
SSH MCP acceptance token is minted by a predictable non-cryptographic PRNG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,6 +2265,7 @@ version = "0.16.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "getrandom 0.3.4",
  "orbit-common",
  "orbit-registry",
  "orbit-tools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ croner = "3"
 fastembed = { version = "5.13.4", default-features = false, features = ["hf-hub-native-tls", "ort-download-binaries-native-tls"] }
 fs2 = "0.4"
 futures-core = "0.3"
+getrandom = "0.3"
 hostname = "0.4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "net", "sync"] }
 jsonschema = { version = "0.18", default-features = false }

--- a/crates/orbit-mcp/Cargo.toml
+++ b/crates/orbit-mcp/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 base64.workspace = true
+getrandom.workspace = true
 orbit-common = { path = "../orbit-common" }
 orbit-types = { path = "../orbit-types" }
 orbit-registry = { path = "../orbit-registry" }
@@ -21,7 +22,6 @@ rmcp = { version = "1.5", default-features = false, features = ["server", "trans
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
-tempfile.workspace = true
 tokio = { workspace = true, features = ["io-std", "net", "rt"] }
 toml.workspace = true
 tracing.workspace = true

--- a/crates/orbit-mcp/src/remote/ssh_auth.rs
+++ b/crates/orbit-mcp/src/remote/ssh_auth.rs
@@ -22,7 +22,9 @@
 use std::path::{Path, PathBuf};
 
 use base64::Engine as _;
-use base64::engine::general_purpose::{STANDARD as BASE64, STANDARD_NO_PAD as BASE64_NO_PAD};
+use base64::engine::general_purpose::{
+    STANDARD as BASE64, STANDARD_NO_PAD as BASE64_NO_PAD, URL_SAFE_NO_PAD as BASE64_URL,
+};
 use orbit_common::OrbitError;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -39,6 +41,16 @@ const SSH_ORIGINAL_COMMAND_ENV: &str = "SSH_ORIGINAL_COMMAND";
 
 /// Destination-local capabilities issued into generated forced commands.
 const SSH_ACCEPTANCE_DIR: &str = "mcp-ssh-acceptance";
+
+/// What every issued capability starts with, so an operator reading their own
+/// `authorized_keys` can tell at a glance which field Orbit minted.
+const ACCEPTANCE_TOKEN_PREFIX: &str = ".orbit-ssh-";
+
+/// Bytes of operating-system entropy behind one acceptance capability.
+///
+/// 256 bits, comfortably past the 128 a bearer capability needs, because the
+/// value is minted once per operator setup and never sits in a hot path.
+const ACCEPTANCE_TOKEN_BYTES: usize = 32;
 
 /// The prefix sshd and `ssh-keygen -l` use for a SHA-256 key fingerprint.
 pub const FINGERPRINT_PREFIX: &str = "SHA256:";
@@ -145,6 +157,33 @@ impl SshPublicKey {
     }
 }
 
+/// Draw one bearer capability from the operating system's CSPRNG.
+///
+/// The entropy source *is* the security property [ORB-11065]: this token is
+/// the only thing standing between a caller who can run an ordinary remote
+/// command on this destination and a forged key-bound identity, so every bit
+/// of it has to be unpredictable to that caller. `getrandom` reads the OS
+/// CSPRNG — `getrandom(2)`, `arc4random_buf`, `BCryptGenRandom` — so no part
+/// of the value is a function of state the caller can observe or approximate,
+/// such as a wall clock, a process or thread id, or a filename counter. A
+/// name generator borrowed from a temporary-file library is not a substitute:
+/// those are seeded for collision avoidance, not for secrecy.
+///
+/// The URL-safe alphabet is chosen over the standard one so the rendered value
+/// is a single unquoted word in the forced command's argv.
+fn mint_acceptance_token() -> Result<String, OrbitError> {
+    let mut entropy = [0u8; ACCEPTANCE_TOKEN_BYTES];
+    getrandom::fill(&mut entropy).map_err(|error| {
+        OrbitError::Io(format!(
+            "failed to draw operating-system entropy for an SSH acceptance token: {error}"
+        ))
+    })?;
+    Ok(format!(
+        "{ACCEPTANCE_TOKEN_PREFIX}{}",
+        BASE64_URL.encode(entropy)
+    ))
+}
+
 /// Issue the destination-only capability embedded in one generated
 /// `authorized_keys` forced command. Only its digest is persisted; the bearer
 /// value exists solely in the line the operator installs.
@@ -154,30 +193,7 @@ pub fn issue_ssh_acceptance(
     key_fingerprint: &str,
 ) -> Result<String, OrbitError> {
     let path = acceptance_record_path(global_root, machine_id);
-    std::fs::create_dir_all(global_root).map_err(|error| {
-        OrbitError::Io(format!(
-            "failed to create Orbit root '{}': {error}",
-            global_root.display()
-        ))
-    })?;
-    let random = tempfile::Builder::new()
-        .prefix(".orbit-ssh-")
-        .rand_bytes(32)
-        .tempfile_in(global_root)
-        .map_err(|error| {
-            OrbitError::Io(format!("failed to generate SSH acceptance token: {error}"))
-        })?;
-    let token = random
-        .path()
-        .file_name()
-        .and_then(|name| name.to_str())
-        .ok_or_else(|| OrbitError::Io("generated SSH acceptance token was not UTF-8".to_string()))?
-        .to_string();
-    random.close().map_err(|error| {
-        OrbitError::Io(format!(
-            "failed to finish SSH acceptance token generation: {error}"
-        ))
-    })?;
+    let token = mint_acceptance_token()?;
 
     let record = SshAcceptanceRecord {
         schema_version: 1,
@@ -211,7 +227,7 @@ pub fn verify_ssh_acceptance(
     let presented = BASE64_NO_PAD.encode(Sha256::digest(token.as_bytes()));
     if record.schema_version != 1
         || record.machine_id != machine_id
-        || presented != record.token_sha256
+        || !digests_match(&presented, &record.token_sha256)
     {
         return Err(unauthorized_acceptance());
     }
@@ -219,6 +235,23 @@ pub fn verify_ssh_acceptance(
         fingerprints: vec![record.key_fingerprint],
         observation: KeyObservation::DestinationCapability,
     })
+}
+
+/// Compare two token digests without leaking how far they agreed.
+///
+/// A digest is not itself the secret, so this is defense in depth rather than
+/// the load-bearing control; it costs one fold over 43 bytes and removes the
+/// one timing signal an attacker holding a candidate token could measure.
+fn digests_match(presented: &str, stored: &str) -> bool {
+    let (presented, stored) = (presented.as_bytes(), stored.as_bytes());
+    if presented.len() != stored.len() {
+        return false;
+    }
+    presented
+        .iter()
+        .zip(stored)
+        .fold(0u8, |difference, (left, right)| difference | (left ^ right))
+        == 0
 }
 
 fn unauthorized_acceptance() -> OrbitError {

--- a/crates/orbit-mcp/src/remote/tests/ssh_auth.rs
+++ b/crates/orbit-mcp/src/remote/tests/ssh_auth.rs
@@ -1,3 +1,5 @@
+use base64::Engine as _;
+
 use super::super::ssh_auth::{
     FORCED_COMMAND_RESTRICTIONS, KeyObservation, ObservedKeys, SshAcceptance,
     auth_info_fingerprints, fingerprint_defect, issue_ssh_acceptance, parse_public_key,
@@ -137,6 +139,63 @@ fn only_a_destination_issued_capability_recovers_the_bound_key() {
         verify_ssh_acceptance(dir.path(), "hm_alpha", "caller-controlled").is_err(),
         "argv alone must not mint a destination capability"
     );
+}
+
+/// [ORB-11065] The capability's whole job is to be unguessable by a caller who
+/// can already run an ordinary remote command on this destination. That caller
+/// knows roughly when `orbit mcp callers authorize` ran and what the process
+/// looked like, so a token derived from a clock- or thread-id-seeded PRNG —
+/// which is what a temporary-file name generator gives you — is enumerable
+/// offline. Nothing here consults a clock, so every token in this sample is
+/// issued from the same logical instant: what distinguishes them can only be
+/// the operating system's CSPRNG.
+#[test]
+fn an_acceptance_token_is_minted_from_operating_system_entropy() {
+    const SAMPLE: usize = 64;
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let tokens: Vec<String> = (0..SAMPLE)
+        .map(|_| {
+            issue_ssh_acceptance(dir.path(), "hm_alpha", KEY_FINGERPRINT).expect("issue token")
+        })
+        .collect();
+
+    let entropy: Vec<Vec<u8>> = tokens
+        .iter()
+        .map(|token| {
+            let body = token
+                .strip_prefix(".orbit-ssh-")
+                .unwrap_or_else(|| panic!("a capability names itself: {token}"));
+            base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .decode(body.as_bytes())
+                .unwrap_or_else(|error| panic!("token body is not base64: {token}: {error}"))
+        })
+        .collect();
+
+    for (token, bytes) in tokens.iter().zip(&entropy) {
+        assert_eq!(
+            bytes.len() * 8,
+            256,
+            "a bearer capability must carry at least 128 bits of entropy: {token}"
+        );
+    }
+    let distinct: std::collections::BTreeSet<&Vec<u8>> = entropy.iter().collect();
+    assert_eq!(
+        distinct.len(),
+        SAMPLE,
+        "tokens issued back to back from one process repeated, so they are not random"
+    );
+    // A counter, a filename sequence, or any value derived from a fixed seed
+    // pins some byte position; a CSPRNG pins none. With 64 draws the odds of a
+    // genuinely random position staying constant are 256^-63.
+    for position in 0..entropy[0].len() {
+        assert!(
+            entropy
+                .iter()
+                .any(|bytes| bytes[position] != entropy[0][position]),
+            "byte {position} never varied across {SAMPLE} tokens, so it is not drawn from entropy"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11065](https://orbit-cli.com/tasks/ORB-11065) — SSH MCP acceptance token is minted by a predictable non-cryptographic PRNG

### Description

## Summary

`issue_ssh_acceptance` mints the destination-side SSH MCP acceptance capability from `tempfile`'s temporary-file *name generator*, which is a non-cryptographic PRNG seeded from a fully predictable value. The token is the only thing standing between a caller who can run an ordinary remote command and a forged key-bound MCP identity, so its unguessability is the security property the whole ORB-11057 fix rests on.

## Evidence

`crates/orbit-mcp/src/remote/ssh_auth.rs:151-176` — the token is the random component of a `tempfile` name:

```rust
let random = tempfile::Builder::new()
    .prefix(".orbit-ssh-")
    .rand_bytes(32)
    .tempfile_in(global_root)
    ...
let token = random.path().file_name()...to_string();
```

The claimed property is stated at `crates/orbit-mcp/src/remote/ssh_auth.rs:83-90` ("An unguessable capability issued by this destination") and at `crates/orbit-mcp/src/remote/ssh_auth.rs:191-193` ("Caller-controlled argv can present a token, but cannot mint one").

The generator chain, in the versions this workspace locks (`Cargo.lock:3402` tempfile 3.25.0, `Cargo.lock:980` fastrand 2.3.0):

1. `tempfile-3.25.0/src/util.rs:47` — `create_helper` builds names with `let mut rng = fastrand::Rng::new();`, then `tmpname(&mut rng, ...)` (`util.rs:7-20`) draws each character with `rng.alphanumeric()`.
2. `fastrand-2.3.0/src/global_rng.rs:25` — `Rng::new()` is `try_with_rng(Rng::fork)`, and `fork` (`src/lib.rs:322`) is `Rng::with_seed(self.gen_u64())` off the thread-local generator.
3. `fastrand-2.3.0/src/global_rng.rs:30-32` — the thread-local is seeded once with `random_seed()`.
4. `fastrand-2.3.0/src/global_rng.rs:193-203` — `random_seed()` is:

```rust
let mut hasher = DefaultHasher::new();
Instant::now().hash(&mut hasher);
thread::current().id().hash(&mut hasher);
Some(hasher.finish())
```

`DefaultHasher::new()` is explicitly *unkeyed* (std documents that instances from `new` are not randomly keyed), so the seed is a deterministic function of a boot-relative monotonic timestamp and a thread id — not of system entropy. The underlying WyRand stream is then fully determined by that seed.

tempfile itself documents the weakness (`tempfile-3.25.0/src/lib.rs:72`: "it may be possible for an attacker to predict the random file names", and `util.rs:50-52`: "fastrand is predictable"). Its only mitigation is to reseed from `getrandom` after **three consecutive filename collisions** (`util.rs:56-62`, guarded by `if i == 3`), which never happens for a fresh 32-character name — so the CSPRNG path is unreachable in practice here.

## Why this is exploitable in the intended threat model

The threat model this token was added for is a caller who can run an ordinary (non-forced) remote command on the destination — that is precisely what `crates/orbit-cli/src/command/mcp/callers.rs:334-338` warns about ("its destination capability would then be readable and replayable by an ordinary remote command"). Such a caller can invoke:

```
orbit mcp serve --accept-ssh <token> --caller <machine-id> --operator
```

`verify_ssh_acceptance` (`crates/orbit-mcp/src/remote/ssh_auth.rs:189-211`) accepts any token whose SHA-256 matches the stored digest for that `machine_id`. Because the token is a deterministic function of a low-entropy, guessable seed (approximate wall-clock moment `orbit mcp callers authorize` was run, plus machine uptime and a near-constant main-thread id), an attacker can enumerate candidate seeds offline, regenerate candidate tokens, and present them. Success yields `RemoteCallerIdentity::key_bound` (`crates/orbit-mcp/src/remote/identity.rs:196-199`) — exactly the forged key-bound identity ORB-11057 set out to prevent — and, via the `--operator` request in the generated line, whatever the matched callers row grants.

This is a weakening of the fix rather than a return to the pre-fix state: the pre-fix bug allowed forging with no secret at all. But the remediation's stated guarantee ("cannot mint one") does not hold as implemented.

## Suggested direction

Mint the token from a cryptographic source rather than from a temp-file name. `getrandom` is already in the dependency graph (`Cargo.lock:1175`, `Cargo.lock:1188`); register it in root `[workspace.dependencies]` and derive the token from, e.g., 32 bytes of `getrandom` output rendered with the `base64` encoder `ssh_auth.rs` already imports. The stored record, digest comparison, and file layout can stay exactly as they are. Consider also making the digest comparison constant-time while in the area, though the predictable-seed issue is the material one.

### Acceptance Criteria

- The SSH MCP acceptance token is generated from a cryptographically secure random source rather than from a tempfile name backed by fastrand.
- The token carries at least 128 bits of entropy drawn from the operating system CSPRNG, and no code path derives it from a time- or thread-id-seeded PRNG.
- A regression test asserts the token generator's source or that two tokens issued in the same process from a fixed logical clock are not reproducible from process-observable state.
- Existing forced-command issue and verify round-trip tests still pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Replaced the predictable acceptance-token source in `crates/orbit-mcp/src/remote/ssh_auth.rs`
with the operating-system CSPRNG.

**What changed**

- `mint_acceptance_token()` (new, `ssh_auth.rs`) draws `ACCEPTANCE_TOKEN_BYTES = 32` bytes
  via `getrandom::fill` and renders them with `URL_SAFE_NO_PAD` base64 behind the existing
  `.orbit-ssh-` prefix. 256 bits of OS entropy, well past the 128 the criteria require.
  URL-safe alphabet so the value stays one unquoted argv word in the forced command; the
  prefix is kept because `crates/orbit-cli/tests/mcp_roundtrip.rs:1051` asserts it and it
  tells an operator which `authorized_keys` field Orbit minted.
- `issue_ssh_acceptance` no longer touches `tempfile::Builder`, so nothing derives the
  token from `fastrand`'s `Instant`/`ThreadId`-seeded WyRand stream. The
  `std::fs::create_dir_all(global_root)` that existed only to host the temp file is gone
  too — `orbit_common::fs::io::atomic_write_text` already creates parent directories.
- `getrandom = "0.3"` registered in root `[workspace.dependencies]`, consumed as
  `getrandom.workspace = true` in `crates/orbit-mcp/Cargo.toml`. `Cargo.lock` gains only
  the direct edge to the already-locked `getrandom 0.3.4`; no version resolution moved.
- `tempfile` removed from `orbit-mcp`'s `[dependencies]` — it had no remaining non-test
  use. It stays in `[dev-dependencies]`, which is what the sibling `src/**/tests/` modules
  consume. `tests/dep_boundary.rs` only inspects `orbit-*` keys, so it is unaffected.
- `digests_match()` (new) compares the stored and presented base64 digests with a
  length check plus an XOR/OR fold, replacing the short-circuiting `!=`. This is the
  "consider also" item in the task: defense in depth, since the digest is not itself the
  secret.

**Regression test**

`an_acceptance_token_is_minted_from_operating_system_entropy` in
`crates/orbit-mcp/src/remote/tests/ssh_auth.rs` issues 64 tokens from one process with no
clock consulted anywhere in the path — a fixed logical instant — and asserts each body
decodes to exactly 32 bytes (256 bits), all 64 are distinct, and no byte position is
constant across the sample. A counter, a filename sequence, or any fixed-seed derivation
pins a position; a CSPRNG pins none (odds of a false failure per position: 256^-63).

**Validation**

- `cargo test -p orbit-mcp` — 163 passed, 0 failed (includes the pre-existing
  `only_a_destination_issued_capability_recovers_the_bound_key` issue/verify round trip
  and `tests/dep_boundary.rs`).
- `cargo test -p orbit-cli --test mcp_roundtrip` — 42 passed, 0 failed, including
  `the_generated_forced_command_obeys_the_matched_rows_operator_ceiling` (executes the real
  emitted argv over MCP stdio) and `caller_controlled_accept_ssh_flags_cannot_select_a_caller_row`.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `make ci-fast` — clean.

**Scope**

No files touched outside the task's `context_files`. `docs/design/federated-mcp/specs/caller-authorization.md`
describes the capability's lifecycle but never its generation mechanism, so no doc update
was due. Message text, record schema (`schema_version = 1`), on-disk layout, digest
encoding, and the `verify_ssh_acceptance` contract are all unchanged, so previously issued
records still verify.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11065-6a935494`
- Behind base: 0
- Ahead of base: 1