### PR TITLE
[auto-task] Remediate current GitHub Actions failures

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -24,6 +24,10 @@ on:
       - "crates/orbit-policy/**"
       - "crates/orbit-common/src/types/policy_def.rs"
       - "crates/orbit-common/src/utility/glob.rs"
+      # [ORB-11067] Managed-child logging must use the registry root authorized
+      # by the macOS sandbox rather than the provider-specific HOME.
+      - "crates/orbit-common/src/observability/logging.rs"
+      - "crates/orbit-common/src/observability/tests/logging.rs"
       # [ORB-10682] Darwin owner/cancellation liveness uses native libproc
       # state so unreaped zombies do not look like surviving work.
       - "crates/orbit-common/src/utility/process_identity.rs"

--- a/crates/orbit-common/src/observability/logging.rs
+++ b/crates/orbit-common/src/observability/logging.rs
@@ -62,6 +62,10 @@ use crate::security::redaction;
 
 static FILE_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
 
+const ORBIT_MANAGED_RUN_CONTEXT_ENV: &str = "ORBIT_MANAGED_RUN_CONTEXT";
+const ORBIT_RUN_ID_ENV: &str = "ORBIT_RUN_ID";
+const ORBIT_REGISTRY_ROOT_ENV: &str = "ORBIT_REGISTRY_ROOT";
+
 /// Field formatter that redacts string-valued and `Debug`-formatted tracing
 /// event fields before they are written to stderr or the JSONL tracing feed.
 ///
@@ -415,28 +419,62 @@ pub(super) fn env_filter(default_filter: &str) -> EnvFilter {
 }
 
 /// Resolve the canonical path to the global JSONL tracing feed
-/// (`$HOME/.orbit/state/logs/orbit.jsonl`). Returned as `Result` because the
-/// path depends on `HOME` (or `USERPROFILE`); callers that need a fallback
-/// should fall back to a workspace-relative path or fail with a clear error.
+/// (`$HOME/.orbit/state/logs/orbit.jsonl`, or the managed child's registry
+/// root). A managed child uses `ORBIT_REGISTRY_ROOT` only when the complete
+/// managed-run context is present, matching global-root resolution in
+/// `orbit-core`. Returned as `Result` because the path depends on environment
+/// variables; callers that need a fallback should fall back to a
+/// workspace-relative path or fail with a clear error.
 ///
 /// Producers and readers MUST agree on this path — `init_default_subscriber`
 /// writes here, and `orbit log tail` reads here by default.
 pub fn global_jsonl_log_path() -> io::Result<PathBuf> {
-    let home = std::env::var_os("HOME")
-        .or_else(|| std::env::var_os("USERPROFILE"))
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::NotFound,
-                "cannot resolve HOME/USERPROFILE for JSONL tracing log",
-            )
-        })?;
+    let orbit_root = match managed_registry_root()? {
+        Some(root) => root,
+        None => {
+            let home = std::env::var_os("HOME")
+                .or_else(|| std::env::var_os("USERPROFILE"))
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "cannot resolve HOME/USERPROFILE for JSONL tracing log",
+                    )
+                })?;
+            PathBuf::from(home).join(".orbit")
+        }
+    };
 
-    Ok(PathBuf::from(home)
-        .join(".orbit")
-        .join("state")
-        .join("logs")
-        .join("orbit.jsonl"))
+    Ok(orbit_root.join("state").join("logs").join("orbit.jsonl"))
+}
+
+/// Resolve the registry root carried by an Orbit-managed child. The run ID is
+/// part of the trust boundary: an inherited locator without it must not
+/// redirect ordinary commands' logs.
+fn managed_registry_root() -> io::Result<Option<PathBuf>> {
+    let managed = std::env::var(ORBIT_MANAGED_RUN_CONTEXT_ENV)
+        .ok()
+        .is_some_and(|value| matches!(value.trim(), "1" | "true" | "TRUE"));
+    if !managed
+        || std::env::var(ORBIT_RUN_ID_ENV)
+            .ok()
+            .is_none_or(|value| value.trim().is_empty())
+    {
+        return Ok(None);
+    }
+
+    let Some(value) = std::env::var_os(ORBIT_REGISTRY_ROOT_ENV).filter(|value| !value.is_empty())
+    else {
+        return Ok(None);
+    };
+    let root = PathBuf::from(value);
+    if !root.is_absolute() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "ORBIT_REGISTRY_ROOT must be an absolute path inside an Orbit-managed run",
+        ));
+    }
+    Ok(Some(root))
 }
 
 // Visible to sibling-layout logging tests so file-layer behavior can be

--- a/crates/orbit-common/src/observability/tests/logging.rs
+++ b/crates/orbit-common/src/observability/tests/logging.rs
@@ -525,3 +525,59 @@ mod subscriber {
         fs::metadata(path).expect("metadata").permissions().mode() & 0o777
     }
 }
+
+mod path {
+    use std::{ffi::OsString, path::PathBuf};
+
+    use tempfile::tempdir;
+
+    use super::{ENV_LOCK, EnvVarGuard};
+    use crate::observability::logging::global_jsonl_log_path;
+
+    #[test]
+    fn managed_child_logs_use_the_registry_root_with_provider_home() {
+        let _env = ENV_LOCK.lock().expect("lock env");
+        let provider_home = tempdir().expect("provider home");
+        let registry_root = tempdir().expect("registry root");
+        let provider_home_value = provider_home.path().as_os_str().to_owned();
+        let registry_root_value = registry_root.path().as_os_str().to_owned();
+        let _home = EnvVarGuard::set("HOME", provider_home_value);
+        let _managed = EnvVarGuard::set("ORBIT_MANAGED_RUN_CONTEXT", OsString::from("1"));
+        let _run = EnvVarGuard::set("ORBIT_RUN_ID", OsString::from("jrun-logging-path"));
+        let _registry = EnvVarGuard::set("ORBIT_REGISTRY_ROOT", registry_root_value);
+
+        let expected = PathBuf::from(registry_root.path()).join("state/logs/orbit.jsonl");
+        assert_eq!(global_jsonl_log_path().expect("resolve log path"), expected);
+    }
+
+    #[test]
+    fn registry_root_is_ignored_without_managed_run_context() {
+        let _env = ENV_LOCK.lock().expect("lock env");
+        let home = tempdir().expect("home");
+        let registry_root = tempdir().expect("registry root");
+        let _home = EnvVarGuard::set("HOME", home.path().as_os_str().to_owned());
+        let _managed = EnvVarGuard::remove("ORBIT_MANAGED_RUN_CONTEXT");
+        let _run = EnvVarGuard::remove("ORBIT_RUN_ID");
+        let _registry = EnvVarGuard::set(
+            "ORBIT_REGISTRY_ROOT",
+            registry_root.path().as_os_str().to_owned(),
+        );
+
+        let expected = home.path().join(".orbit/state/logs/orbit.jsonl");
+        assert_eq!(global_jsonl_log_path().expect("resolve log path"), expected);
+    }
+
+    #[test]
+    fn managed_registry_root_must_be_absolute() {
+        let _env = ENV_LOCK.lock().expect("lock env");
+        let _managed = EnvVarGuard::set("ORBIT_MANAGED_RUN_CONTEXT", OsString::from("true"));
+        let _run = EnvVarGuard::set("ORBIT_RUN_ID", OsString::from("jrun-logging-path"));
+        let _registry = EnvVarGuard::set(
+            "ORBIT_REGISTRY_ROOT",
+            OsString::from("relative-registry-root"),
+        );
+
+        let error = global_jsonl_log_path().expect_err("relative registry root must be rejected");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    }
+}


### PR DESCRIPTION
## Task

[ORB-11067](https://orbit-cli.com/tasks/ORB-11067) — [auto-task] Remediate current GitHub Actions failures

### Description

Investigate and remediate current GitHub Actions failures for this
repository. This task may legitimately finish with no diff: if no
current, reproducible, repository-owned failure remains, persist the
evidence described below and report a successful no-current-failure or
transient-only outcome.

## Discovery and duplicate safety

1. Enumerate this repository's workflows and recent runs with GitHub's API
   or `gh`, and enumerate open pull requests with their current head SHAs.
   Cover failures for the current heads of `agent-main`, `main`, and every
   open pull request, including informational jobs such as coverage rather
   than looking only at required checks or the main `ci` job.
2. The PR-only `Create orbit task on CI failure` step in
   `.github/workflows/ci.yml` is an input and coverage signal. Search open
   Orbit tasks for its run URL, PR number, SHA, and failure signature.
   Reference matching tasks in the execution summary; do not create
   another task for the same run or root cause. This remediation task owns
   the repair and must not fan a red-run cluster out into more failure
   tasks.
3. For every candidate run, record the run and job URLs, workflow, event,
   branch or PR, run-attempt number, reported head SHA, and the current
   branch/PR head SHA. Query the failed jobs and steps and inspect the
   exact failed-step logs.
4. Independently verify the commit that Actions actually checked out from
   the checkout step/log (`HEAD is now at`, checkout ref/SHA, or equivalent
   unambiguous evidence). Keep the event's reported head SHA, the current
   ref head, and the tested checkout commit distinct; PR merge SHAs are not
   interchangeable with PR head SHAs.
5. Ignore a failed run as stale when its branch or PR has advanced and the
   failure does not reproduce at the current head, or when a newer
   successful run of the same workflow/check at the relevant current
   commit supersedes it. Cite the advancing or superseding run and SHAs;
   age alone is not evidence that a failure is stale.

## Diagnosis and remediation

Cluster repeated runs by root cause before editing. Use the failing
command, job/step, exact error signature, tested commit, and causal
dependency between failures to distinguish one regression repeated across
push/PR runs from independent failures. Repair each current root cause
once, while retaining a mapping from every affected run/job to that
cluster.

Reproduce every current candidate at the current repository head using
the exact command or the narrowest faithful local equivalent. A
deterministic repository-owned failure is in scope and must be fixed in
this task's worktree. Classify a GitHub service, network, hosted-runner, or
other infrastructure failure as transient only with concrete evidence,
such as a successful retry at the same SHA plus logs showing the
infrastructure fault. Do not call a failure transient merely because it
fails to reproduce once.

Fix the underlying repository-owned cause. Do not disable a workflow,
weaken an assertion or lint level, add a broad allow/ignore rule, mark a
failing gate `continue-on-error`, remove an affected target from coverage,
or otherwise obtain green CI by hiding the failure. Informational checks
remain informational, but they must execute successfully.

## Validation and handoff

For each fixed root cause, rerun the exact command that formerly failed.
Then run the repository pre-handoff gate, `make ci-fast`. After the
candidate commit is published through the repository's normal workflow,
inspect its GitHub Actions runs and require a green rerun for every
affected workflow/check. This includes affected informational jobs even
though they remain non-required. Do not declare a repair validated while
an affected run is missing, queued, in progress, cancelled, or red.

Persist an `execution_summary` that maps every investigated run/job URL,
reported head SHA, actual checkout commit, and current ref head to its
root-cause cluster, disposition (fixed, stale, superseded, or transient),
change, local reproduction, exact formerly failing validation, pre-handoff
result, and green GitHub rerun URL. Also map any matching PR-hook-created
Orbit task. For a successful no-diff pass, list the queries, current heads,
superseding successes or transient evidence, and why no repository-owned
failure remained.

## Historical validation fixture

Use run 30232696219 as the calibration example for the evidence model, not
as proof of a current failure:

- `Check / Clippy / Test` → `Run CI guardrails` reported Clippy's needless
  borrow at
  `crates/orbit-store/src/file/task_store/v2_bundle/bundle_io/mod.rs:172`,
  `sync_parent_dir(&staging_dir)`.
- `Coverage (informational)` reported that
  `command::skill::tests::plugin_skill_symlinks_resolve_to_assets` found
  `plugin/skills/orbit-task/SKILL.md` different from
  `crates/orbit-core/assets/skills/orbit-task/SKILL.md`.
- The run metadata reported head
  `49a2871a480b927bb31dc7a315f5ff5d130d15d0`, while the checkout log showed
  `5cec12c53211fad3f4ca940a0565bef87787958d`. A valid investigation preserves
  that discrepancy, clusters adjacent runs by the two root causes, and
  tests whether either failure still exists at the relevant current head
  before editing.


### Acceptance Criteria

- Current-head failures across agent-main, main, and open pull requests were enumerated for every repository workflow, including informational jobs.
- Every investigated run records its reported SHA, actual checkout commit, current ref head, failed job/step, exact log evidence, and stale or superseding evidence where applicable.
- Repeated red runs are clustered by root cause, and every current repository-owned failure is reproduced and fixed without weakening or bypassing a check.
- Transient-only classifications cite infrastructure evidence and a successful same-SHA retry; a single non-reproduction is not treated as sufficient evidence.
- Each fixed cause passes the exact formerly failing validation and make ci-fast, and every affected required or informational GitHub Actions check executes successfully on the candidate commit.
- The persisted execution_summary maps each run/job URL and SHA to its root cause, disposition, change, validations, green rerun, and any matching PR-hook task.
- A no-current-failure or transient-only investigation is a successful no-diff outcome when its current-head queries and superseding or transient evidence are persisted.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Fixed the current repository-owned macOS CI failure by making the early global JSONL logger resolve `ORBIT_REGISTRY_ROOT` when a complete managed-run context (`ORBIT_MANAGED_RUN_CONTEXT` plus nonblank `ORBIT_RUN_ID`) is present. This keeps provider-specific HOME isolated while writing to the same global registry that the runtime and sandbox profile authorize; unmanaged commands retain the HOME/USERPROFILE fallback and relative managed registry roots are rejected.
- Added focused path-resolution tests for managed provider HOME, unmanaged locator isolation, and absolute-path validation in `crates/orbit-common/src/observability/tests/logging.rs`.
- Published through PR #1181 at head `648576446ed6871ebbf3f4e0c8f302dd8f954c17`. Follow-up commit `64857644` extends the macOS Platform PR path filter to the managed logging implementation and focused tests so the platform-only regression cannot bypass candidate validation again.

Workflow and head discovery:
- Enumerated local workflow files: `.github/workflows/ci.yml`, `ci-macos.yml`, `smoke-npm-install.yml`, `release.yml`, and `website.yml`. GitHub's active workflow inventory additionally reported `cargo-deny`, `Dependabot Updates`, `Dependency Graph`, and `CodeQL`.
- Queried current refs: agent-main=`f9a34c6aad5ff871ea79235feeca5a1b5327764c`; main=`f052db3d4246786628157c2bcc9f8bee7e91012c`. Worktree checkout started and remains at f9a34c6aad5ff871ea79235feeca5a1b5327764c.
- Open PR heads: #1180=`c7cc7f5f333c02928214591210a2d7c80b2e4aba` (agent-main), #959=`0f14f3f2ad2c863f902c0add969ff09d10e3f15c`, #958=`a8b09aede0a8b6627ea5d114093c454e39c236bd`, #957=`e860792b47f3774a49f2eb11ba265e81fbcf58c7`, and #956=`9089a85e7d63abf532c72e1890991c4d00c5c50f` (the last four target main).

Root-cause clusters and run/job evidence (all investigated attempts were 1; checkout logs were independently queried and matched the reported SHA unless explicitly noted):
- Cluster M-current, fixed: run https://github.com/danieljhkim/orbit/actions/runs/33279477540, job https://github.com/danieljhkim/orbit/actions/runs/33279477540/job/99172066302, macOS Platform push on agent-main; reported SHA/current ref head/checkout SHA were all f9a34c6aad5ff871ea79235feeca5a1b5327764c. The failed job was macOS Sandbox step 7, Run orbit-core sandbox tests, exact command `cargo test -p orbit-core --locked sandbox`. Exact log evidence: `managed_nested_orbit_dispatches_from_linked_worktree_under_sandbox` failed at sandbox_nested.rs:186 because startup logging attempted `provider-home/.orbit/state/logs` and got Operation not permitted. The sandbox profile authorized the registry root, not provider HOME. The change above fixes the authoritative logging path.
- M-current predecessor, same cause: run https://github.com/danieljhkim/orbit/actions/runs/33279328537, job https://github.com/danieljhkim/orbit/actions/runs/33279328537/job/99171676928, PR #1179 head/report/checkout d4bbfd7ccca690156e0fcac63a4044137f55907c; it failed the same step/test with the same provider-home JSONL log denial. PR #1179 was merged into agent-main, so this evidence is superseded by the f9 current-head run.
- Cluster M-audit, already fixed by related work: runs 33275507342/job/99161388666 at agent-main SHA 942de3bf45a83030c8951bed5dc87f2353fc2c89 and 33275090340/job/99160292339 at SHA 59a9096d957a99d32d940630e73deebdcde6e2df had macOS Sandbox step 7 and the nested test's global audit-store postcondition failure (15 passed/1 failed). Both branch heads advanced to f9; they are stale/superseded, while the later same-workflow agent-main run 33276013807/job/99162759413 at a928b3261e625a842b5292cd3a5ee61d83c5f597 was green.
- Cluster M-compile, already fixed by ORB-10998: runs 33274697068/job/99159261678 (5dbb8eff6f1ec88a24da618df1962d2c6b82ab6e), 33274581116/job/99158955509 (9da8074c5dcf92bbcbb0859384e110ae0a549b27), 33273792223/job/99156867257 (b1fa0156468c88ac3bb00a06e33ec4fc1788271b), and PR #1170 run 33273476004/job/99156028485 (0a72b454c79f77445307f3fcbbfdc2d3a1df5181) failed macOS step 7 with the reported E0308 Option/Result mismatch in sandbox_nested.rs:244. These are superseded by later green Linux/Clippy checks and by the merged ORB-10998 correction.
- Cluster C-coverage, infrastructure/stale: run 33264781326/job/99132805406 at reported/checkout bae42c0c74424b92e3608a4a4a60d5dc504f6376 (agent-main later advanced to f9) failed informational Coverage step 6, Install cargo-llvm-cov; exact evidence was curl HTTP 504 for the pinned v0.8.7 tarball. It is superseded by current-head Coverage success in run 33279477511/job/99172066366.
- Cluster P-old-main-tests, stale/superseded: run 31065514109/job/92502284610 at reported/checkout ffea25be034ea381a736d51031eae598d59448a2, run 30240791266/job/89897364430 at 2116412b32ea33f1c3296d2313419bde2d9ea847, and run 30239671808/job/89894110617 at 3e74f82732e0c74a1ee4c7bbef4f87b726d21462 failed CI step Run CI guardrails on `worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic`; logs included test result FAILED, assertion/diagnostic evidence, and exit 100. Current main is f052db3d4246786628157c2bcc9f8bee7e91012c and current-main CI run 32696216293/jobs 97338658180, 97338658274, 97338658340, 97338658394 is green.
- Cluster P-old-main-smoke, stale/superseded: run 31388779099 jobs 93455249445 and 93455249569 at ffea25be034ea381a736d51031eae598d59448a2, run 30821091932 jobs 91710908142 and 91710908477 at 2116412b32ea33f1c3296d2313419bde2d9ea847, and run 30273121373 jobs 90000363516 and 90000363569 at the same 2116412b32ea... SHA failed smoke step Run plugin install smoke; exact evidence was `npx -y @orbit-tools/cli@latest --version` exiting 1 with empty stderr. Current-main smoke run 32730166733/jobs 97440377948 and 97440378246 passed at f052....
- Cluster P-dependabot, stale branch-only state with existing remediation: PR #959 run https://github.com/danieljhkim/orbit/actions/runs/31583558682, job https://github.com/danieljhkim/orbit/actions/runs/31583558682/job/94072012355, reported/current PR head/checkout 0f14f3f2ad2c863f902c0add969ff09d10e3f15c; and PR #958 run https://github.com/danieljhkim/orbit/actions/runs/31583549786, job https://github.com/danieljhkim/orbit/actions/runs/31583549786/job/94071981962, reported/current PR head/checkout a8b09aede0a8b6627ea5d114093c454e39c236bd. Both failed Check / Clippy / Test step Run CI guardrails with exact cargo-deny evidence `error[yanked]: detected yanked crate`, Cargo.lock:248, `spin 0.9.8`, advisories FAILED. Their MSRV, Linux Sandbox, and Coverage jobs were successful; the branch-only lockfile state is covered by related ORB-10948 and ORB-10982, and current integration/main heads are green, so no duplicate fix or task was created.
- Open PR #957 and #956 current heads had successful CI, informational Coverage, Linux Sandbox, macOS/Website where path-triggered, and neutral CodeQL. Open PR #1180 run 33279759959 completed all checks successfully, including Check/Clippy/Test job 99172812200, informational Coverage job 99172812212, Linux Sandbox job 99172812153, MSRV job 99172812210, and CodeQL 99172865719; it is unrelated to this uncommitted candidate.

Historical calibration:
- Run 30232696219 was treated only as historical. Per the task envelope, its reported SHA was 49a2871a480b927bb31dc7a315f5ff5d130d15d0 while checkout was 5cec12c53211fad3f4ca940a0565bef87787958d; its Clippy needless-borrow and plugin skill mismatch were not reproduced at current heads.

Duplicate safety:
- Queried task inventory and searched for every investigated run ID/URL, PR number, SHA, failure signature, and the PR-only Create orbit task on CI failure signal. No matching open PR-hook-created task was found. Related tasks referenced in the evidence are ORB-11055, ORB-10998, ORB-10948, ORB-10982, ORB-11059, ORB-11061, and ORB-11064; this task did not create a duplicate remediation task.

Validation:
- Exact formerly failing command `cargo test -p orbit-core --locked sandbox` passed locally: 21 selected orbit-core unit tests and the selected integration test passed on Linux; the macOS-only sandbox-exec nested reproduction is compiled out on this host, so the GitHub macOS log remains the remote reproduction evidence.
- The focused managed-path tests passed: 3/3. The complete orbit-common logging test selection passed: 17/17.
- `make ci-fast` passed, including formatting, docs/index and asset guards, installer security, dependency direction, CLI imports, terminal-state, error translation, plugin validation/smoke, and all guardrail scripts.
- `make ci-lint` passed: workspace all-target clippy with warnings denied.
- `git diff --check` passed. No runner denial occurred during the code validations. A separate exploratory `make audit` was skipped by the local environment because cargo-deny could not acquire `~/.cargo/advisory-dbs/db.lock` on a read-only path; this is recorded as an environment denial, not a code failure.
Post-publication validation:
- [macOS Platform run 33280983025](https://github.com/danieljhkim/orbit/actions/runs/33280983025), [macOS Sandbox job 99175994154](https://github.com/danieljhkim/orbit/actions/runs/33280983025/job/99175994154): reported head SHA, current PR head, requested checkout ref, and actual checkout commit all equal `648576446ed6871ebbf3f4e0c8f302dd8f954c17`. The job passed, including the exact formerly failing `cargo test -p orbit-core --locked sandbox` step.
- [CI run 33280983022](https://github.com/danieljhkim/orbit/actions/runs/33280983022): [Check / Clippy / Test](https://github.com/danieljhkim/orbit/actions/runs/33280983022/job/99175993988), [informational Coverage](https://github.com/danieljhkim/orbit/actions/runs/33280983022/job/99175994089), [Linux Sandbox](https://github.com/danieljhkim/orbit/actions/runs/33280983022/job/99175994092), and [MSRV](https://github.com/danieljhkim/orbit/actions/runs/33280983022/job/99175994091) all passed. Checkout logs for all four independently show `HEAD is now at 6485764` and the full checkout ref above.
- [CodeQL run 33280981407](https://github.com/danieljhkim/orbit/actions/runs/33280981407), [Analyze job 99175991441](https://github.com/danieljhkim/orbit/actions/runs/33280981407/job/99175991441), plus the CodeQL check passed on the same candidate.
- Local follow-up validation passed: 17/17 orbit-common logging tests; 16 selected orbit-core sandbox tests plus the selected Cursor integration test; `make ci-fast`; and `git diff --check`.
- A local macOS `make ci-lint` invocation reached pre-existing Linux-only test imports in `crates/orbit-engine/src/activity_job/cli_runner/tests/argv.rs` and failed with four unused-import diagnostics. That file is unchanged from the PR base and from commit `9f5ac5d3`; the exact candidate's canonical Linux Check / Clippy / Test job above passed. This unrelated platform-local lint debt was not folded into ORB-11067.

Assessment: The fix is scoped to authoritative managed-run log-root resolution, has focused behavior tests, and is now protected by a deterministic macOS candidate gate. Every affected required and informational GitHub check is green on the published head.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11067-6a936375`
- Behind base: 0
- Ahead of base: 1
