### PR TITLE
Document that NoSandbox cannot escape an inherited provider sandbox

### DIFF
--- a/crates/orbit-exec/src/lib.rs
+++ b/crates/orbit-exec/src/lib.rs
@@ -14,6 +14,11 @@
 //! controlled environments, optional sandboxing, and configurable timeouts.
 //! Results are captured and returned as [`ExecutionResult`] values.
 //!
+//! Sandbox selection in this crate can add an Orbit-controlled sandbox to a
+//! subprocess; it cannot escape containment already applied to the parent
+//! process. A child launched from a provider sandbox still inherits macOS
+//! Seatbelt restrictions or, on Linux, the Bubblewrap mount namespace.
+//!
 //! # Role
 //! Sits directly above `orbit-types` and is consumed by `orbit-tools`, which
 //! builds the builtin `proc.spawn` tool and other shell-invoking tools on top
@@ -23,7 +28,8 @@
 //! - [`run_process`] — primary entry point for spawning a subprocess
 //! - [`ExecRequest`] — builder-style description of the process to run
 //! - [`ExecutionResult`] — captured stdout/stderr, exit code, and duration
-//! - [`Sandbox`] / [`NoSandbox`] — sandbox strategy trait and no-op default
+//! - [`Sandbox`] / [`NoSandbox`] — sandbox strategy trait and strategy that
+//!   adds no additional Orbit sandbox
 //! - [`EnvironmentMode`], [`StdinMode`] — environment and stdin control
 //!
 //! # Dependency direction

--- a/crates/orbit-exec/src/runner.rs
+++ b/crates/orbit-exec/src/runner.rs
@@ -55,6 +55,14 @@ pub struct ExecRequest {
     pub debug: bool,
 }
 
+/// Run a process after applying the supplied Orbit sandbox strategy.
+///
+/// The strategy can add validation or containment before spawning the child.
+/// Passing [`NoSandbox`](crate::NoSandbox) applies no additional Orbit sandbox,
+/// but does not disable or escape any sandbox already imposed on this process.
+/// In particular, children inherit macOS Seatbelt restrictions and Linux
+/// descendants inherit the Bubblewrap mount namespace of an outer provider
+/// sandbox.
 pub fn run_process(
     req: &ExecRequest,
     sandbox: &dyn Sandbox,

--- a/crates/orbit-exec/src/sandbox.rs
+++ b/crates/orbit-exec/src/sandbox.rs
@@ -6,6 +6,14 @@ pub trait Sandbox {
     fn validate(&self, req: &ExecRequest) -> Result<(), OrbitError>;
 }
 
+/// A sandbox strategy that adds no Orbit-specific validation or containment.
+///
+/// `NoSandbox` controls only the sandbox selection made by
+/// [`run_process`](crate::run_process). It neither disables nor escapes an
+/// outer sandbox already imposed on the parent process. For example, child
+/// processes inherit macOS Seatbelt restrictions and Linux descendants inherit
+/// their Bubblewrap mount namespace. It is therefore not a host-side or
+/// credential boundary.
 #[derive(Debug, Default)]
 pub struct NoSandbox;
 


### PR DESCRIPTION
## Task

[ORB-11084](https://orbit-cli.com/tasks/ORB-11084) — Document that NoSandbox cannot escape an inherited provider sandbox

### Description

## Problem
`orbit_exec::NoSandbox` means only that `run_process` adds no additional sandbox validation. When a builtin tool runs beneath a sandboxed provider CLI, the subprocess still inherits macOS Seatbelt or the Linux mount namespace. The current type has no doc comment and crate docs call it a no-op default, which supported the false premise that builtin GitHub tools execute host-side. F2026-08-135 records about forty minutes spent disproving that premise during ORB-11059.

## Why It Matters
A task can move credential-dependent work into a builtin tool and incorrectly claim the sandbox issue is fixed, even though the same credential read remains denied.

## Constraints / Notes
- This is a documentation/contract clarification, not a request to grant credentials or weaken a sandbox.
- State the platform-specific inheritance accurately: macOS child processes inherit Seatbelt; Linux descendants inherit the Bubblewrap namespace.
- Keep `NoSandbox` as the name unless a rename is independently justified.

### Acceptance Criteria

- NoSandbox and run_process documentation explicitly state that no additional sandbox is applied and that an outer process sandbox remains inherited.
- The orbit-exec crate-level contract distinguishes subprocess sandbox selection from escape or host-side execution, with macOS and Linux inheritance called out.
- Builtin tool documentation no longer describes NoSandbox as a host-side credential boundary, and existing execution behavior is unchanged.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Documented `NoSandbox` as adding no Orbit-specific validation or containment, while preserving any outer provider sandbox.
- Documented `run_process` and the crate contract to distinguish selecting an additional subprocess sandbox from host-side escape, including macOS Seatbelt and Linux Bubblewrap namespace inheritance.
- Added `file:crates/orbit-exec/src/runner.rs` to task context because `run_process` owns the required public contract. Builtin GitHub tool wording was inspected and already described execution on its current lane without treating `NoSandbox` as a host-side credential boundary, so no builtin behavior or wording required a change.

Assessment: Documentation-only clarification; runtime execution behavior is unchanged.

Validation:
- `make ci-fast`
- `cargo test -p orbit-exec` (59 passed)
- `make ci-lint`
- `git diff --check`

Friction checkpoint: no new friction record; the task resolved the known inheritance misunderstanding without surfacing a new recurring failure or gotcha.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11084-6a9371c9`
- Behind base: 0
- Ahead of base: 1