### PR TITLE
Isolate tool-policy tests from managed-run activity allowlists

### DIFF
--- a/crates/orbit-core/src/adapter/command/dispatch.rs
+++ b/crates/orbit-core/src/adapter/command/dispatch.rs
@@ -2,6 +2,8 @@
 //! trusted MCP envelope boundary.
 
 use std::cell::Cell;
+#[cfg(test)]
+use std::cell::RefCell;
 use std::path::Path;
 use std::time::Instant;
 
@@ -51,6 +53,41 @@ impl ToolEntryPoint {
 
 thread_local! {
     static TOOL_AUDIT_RECORDED: Cell<bool> = const { Cell::new(false) };
+}
+
+#[cfg(test)]
+thread_local! {
+    static TEST_ACTIVITY_TOOLS: RefCell<Option<Vec<String>>> = const { RefCell::new(None) };
+}
+
+/// Restores a test-local activity-tool override when dropped.
+///
+/// The override is thread-local so tests never need to change process-global
+/// environment variables merely to isolate their temporary runtime from a
+/// managed executor's inherited activity allowlist.
+#[cfg(test)]
+pub(crate) struct TestActivityToolsGuard {
+    previous: Option<Vec<String>>,
+}
+
+#[cfg(test)]
+impl Drop for TestActivityToolsGuard {
+    fn drop(&mut self) {
+        TEST_ACTIVITY_TOOLS.with(|tools| {
+            tools.replace(self.previous.take());
+        });
+    }
+}
+
+/// Override the effective managed-agent activity allowlist for this test
+/// thread. Production dispatch always reads the inherited activity envelope.
+#[cfg(test)]
+pub(crate) fn override_activity_tools_for_test(
+    allowed_tools: impl IntoIterator<Item = impl Into<String>>,
+) -> TestActivityToolsGuard {
+    let allowed_tools = allowed_tools.into_iter().map(Into::into).collect();
+    let previous = TEST_ACTIVITY_TOOLS.with(|tools| tools.replace(Some(allowed_tools)));
+    TestActivityToolsGuard { previous }
 }
 
 /// Execute a server-global implementation inside Core's ordinary tool audit
@@ -662,6 +699,11 @@ fn read_proc_allowed_programs_from_env() -> Vec<String> {
 }
 
 fn read_activity_tools_from_env() -> Vec<String> {
+    #[cfg(test)]
+    if let Some(allowed_tools) = TEST_ACTIVITY_TOOLS.with(|tools| tools.borrow().clone()) {
+        return allowed_tools;
+    }
+
     if std::env::var("ORBIT_TASK_ACTOR_KIND").ok().as_deref() != Some("agent") {
         return Vec::new();
     }

--- a/crates/orbit-core/src/adapter/command/mod.rs
+++ b/crates/orbit-core/src/adapter/command/mod.rs
@@ -14,6 +14,8 @@ mod tests;
 
 pub use crate::runtime::tool_exec::DryRunResult;
 
+#[cfg(test)]
+pub(crate) use dispatch::override_activity_tools_for_test;
 pub use dispatch::{
     AuditContext, ToolDispatchOutcome, ToolEntryPoint, audit_role_label,
     audit_role_label_for_entry_point, execute_global_in_process_tool_dispatch,

--- a/crates/orbit-core/src/adapter/command/tests/dispatch.rs
+++ b/crates/orbit-core/src/adapter/command/tests/dispatch.rs
@@ -11,8 +11,9 @@ use serde_json::json;
 use super::support::{clear_identity_env, env_guard, fresh_runtime, set_identity_env};
 use crate::adapter::command::dispatch::{
     ORBIT_MANAGED_RUN_CONTEXT_ENV, ToolEntryPoint, audit_role_label,
-    audit_role_label_for_entry_point, finalize_successful_dispatch, reservation_owner_from_env,
-    resolve_audit_context, take_tool_audit_recorded, trusted_mcp_audit_context,
+    audit_role_label_for_entry_point, finalize_successful_dispatch,
+    override_activity_tools_for_test, reservation_owner_from_env, resolve_audit_context,
+    take_tool_audit_recorded, trusted_mcp_audit_context,
 };
 
 #[test]
@@ -236,6 +237,23 @@ fn cli_entry_point_records_run_subcommand() {
         .expect("list audit events");
     assert_eq!(events.len(), 1);
     assert_eq!(events[0].subcommand.as_deref(), Some("run"));
+}
+
+#[test]
+fn managed_agent_activity_allowlist_denies_an_omitted_tool() {
+    let runtime = crate::OrbitRuntime::in_memory().expect("build in-memory runtime");
+    let _activity_tools = override_activity_tools_for_test(["orbit.search"]);
+
+    let error = runtime
+        .execute_tool_command(
+            "orbit.task.show",
+            json!({ "id": "ORB-00001" }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect_err("an omitted managed-agent tool must remain denied");
+
+    assert!(matches!(error, OrbitError::PolicyDenied(_)), "{error:?}");
 }
 
 #[test]

--- a/crates/orbit-core/src/adapter/tool_host/artifact_redaction.rs
+++ b/crates/orbit-core/src/adapter/tool_host/artifact_redaction.rs
@@ -699,6 +699,7 @@ mod tests {
     use std::fs;
     use std::sync::{Mutex, MutexGuard, OnceLock};
 
+    use crate::adapter::command::override_activity_tools_for_test;
     use crate::adapter::tool_host::test_support::test_runtime;
 
     struct EnvVarGuard {
@@ -941,6 +942,10 @@ mod tests {
     fn dispatch_redacts_session_log_body_and_emits_an_audit_report() {
         let token = "orbit-session-log-secret-value";
         let _env = EnvVarGuard::set("GITHUB_TOKEN", token);
+        let _activity_tools = override_activity_tools_for_test([
+            "orbit.session_log.append",
+            "orbit.session_log.list",
+        ]);
         let (_root, runtime, _repo_root) = test_runtime();
 
         let output = runtime


### PR DESCRIPTION
## Task

[ORB-11083](https://orbit-cli.com/tasks/ORB-11083) — Isolate tool-policy tests from managed-run activity allowlists

### Description

## Problem
A managed executor exports `ORBIT_ACTIVITY_TOOLS`, and `cargo test` passes it into the orbit-core test binary. The artifact-redaction fixture builds its own temporary runtime but tool dispatch still reads the outer activity allowlist. At current HEAD, `cargo test -p orbit-core --lib dispatch_redacts_session_log_body_and_emits_an_audit_report` fails with PolicyDenied for `orbit.session_log.append`; the identical command passes when the managed-run control variables are removed. F2026-08-132 is a duplicate of canonical F2026-08-131.

## Why It Matters
A task sees a deterministic failure in unrelated policy/redaction code and can mistake runner policy for a regression. Human and CI shells cannot reproduce it unless they reconstruct the ambient managed envelope.

## Constraints / Notes
- Fix the test fixture or test-only policy seam; do not weaken production activity allowlist enforcement.
- Avoid process-global unset/set races in parallel tests.
- Preserve the redaction assertions and the session-log tool's normal authorization checks.

### Acceptance Criteria

- The focused artifact-redaction session-log test passes with ORBIT_TASK_ACTOR_KIND=agent and an ambient ORBIT_ACTIVITY_TOOLS list that omits orbit.session_log.append.
- A neighboring production-path regression proves a managed agent tool outside its effective allowlist is still rejected; the fix does not widen fail-closed policy.
- The focused test also passes in a clean environment, and parallel execution does not mutate shared process environment.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a cfg(test), thread-local activity-tool allowlist override with RAII restoration at command dispatch; production dispatch continues to read and enforce the inherited managed-run envelope.
- Scoped the artifact-redaction session-log fixture to its required append/list tools, isolating it from the executor allowlist without changing process environment.
- Added a command-dispatch regression that an omitted effective managed-agent tool is denied through the ordinary dispatch path.
Assessment: The policy remains fail-closed in production and test isolation is per-thread, so parallel tests do not modify shared managed-run variables.
Validation:
- cargo test -p orbit-core --lib dispatch_redacts_session_log_body_and_emits_an_audit_report (managed agent environment): passed
- env -u ORBIT_TASK_ACTOR_KIND -u ORBIT_ACTIVITY_TOOLS cargo test -p orbit-core --lib dispatch_redacts_session_log_body_and_emits_an_audit_report: passed
- cargo test -p orbit-core --lib managed_agent_activity_allowlist_denies_an_omitted_tool: passed
- cargo test -p orbit-core --lib -- --test-threads=16: passed (794 tests)
- make ci-fast: passed
- make ci-lint: passed
Friction checkpoint: no new friction filed; the managed-run allowlist leak was the task premise and the implementation introduced no additional recurring blocker.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11083-6a9371c9`
- Behind base: 0
- Ahead of base: 1